### PR TITLE
fix(ImageIO): 修复一处mipmap生成时的内存泄漏

### DIFF
--- a/source/runtime/render/scene/loader/io/ImageIO.cpp
+++ b/source/runtime/render/scene/loader/io/ImageIO.cpp
@@ -262,6 +262,10 @@ static void Generatemipmaps(ImageReadDesc& _desc, bool _is_generate_mipmaps) {
         }
     }
 
+    if (_desc.data && _desc.data_callback) {
+        _desc.data_callback(_desc.data);
+    }
+
     // Update descriptor with generated mipmaps
     _desc.mips          = mip_level;
     _desc.data_size     = mipmaps_size * _desc.layers;


### PR DESCRIPTION
反复加载场景就能触发