### PR TITLE
Add fatal diagnostics and migrate top-level asserts

### DIFF
--- a/source/runtime/Engine.cpp
+++ b/source/runtime/Engine.cpp
@@ -20,7 +20,6 @@
 
 // 3rd party (std)
 #include <algorithm>
-#include <cassert>
 
 // namespace
 using namespace Moer::Render;
@@ -30,7 +29,7 @@ namespace Moer {
 Engine::Engine() {}
 
 Engine::~Engine() {
-    assert(has_shutdown && "Engine::ShutDown() was not called before Engine destruction!");
+    MOER_ASSERT(has_shutdown, "Engine::ShutDown() must be called before Engine destruction");
 }
 
 void Engine::Init(const SharedPtr<EditorConfig>& editor_config, bool fullscreen) {
@@ -188,7 +187,11 @@ void Engine::Run() {
             );
 
         } else {
-            assert(false && "Unknown render method");
+            MOER_ASSERT(
+                false,
+                "Unknown render method: {}",
+                static_cast<uint32_t>(m_editor_config->selected_render_method)
+            );
         }
 
         m_renderer->Run(m_editor_config, hooks);

--- a/source/runtime/core/CMakeLists.txt
+++ b/source/runtime/core/CMakeLists.txt
@@ -44,6 +44,7 @@ target_link_libraries(${target_name}
 
 if(WIN32)
     target_link_libraries(${target_name} PUBLIC ws2_32)
+    target_link_libraries(${target_name} PUBLIC dbghelp)
 endif()
 
 # add_dependencies(${target_name} CopyMimallocDlls )

--- a/source/runtime/core/include/Core.h
+++ b/source/runtime/core/include/Core.h
@@ -2,6 +2,7 @@
 #define MOERENGINE_CORE_H
 #include "API_Macro.h"
 #include "math/Math.h"
+#include "misc/Assert.h"
 #include "misc/Crc32.h"
 #include "misc/EnumBitOperation.h"
 #include "misc/Hash.h"

--- a/source/runtime/core/include/log/LogSystem.h
+++ b/source/runtime/core/include/log/LogSystem.h
@@ -20,6 +20,7 @@
 
 namespace Moer { namespace LogSystem {
 CORE_API void Init();
+CORE_API void Flush();
 
 struct ConsoleLogEntryView {
     uint64_t                  sequence = 0;

--- a/source/runtime/core/include/misc/Assert.h
+++ b/source/runtime/core/include/misc/Assert.h
@@ -1,0 +1,107 @@
+#ifndef MOERENGINE_ASSERT_H
+#define MOERENGINE_ASSERT_H
+
+#include "API_Macro.h"
+
+#include <cstdint>
+#include <format>
+#include <string>
+
+namespace Moer::Diagnostics {
+
+enum class EFailureKind : uint8_t {
+    Assert,
+    Ensure,
+};
+
+struct FailureInfo {
+    EFailureKind kind = EFailureKind::Assert;
+    const char*  expression = nullptr;
+    const char*  file = nullptr;
+    const char*  function = nullptr;
+    uint32_t     line = 0;
+    uint32_t     thread_id = 0;
+    std::string  message;
+};
+
+using CrashFlushHook = void (*)();
+
+CORE_API void SetCrashFlushHook(CrashFlushHook hook);
+CORE_API void SetEnsureFailureEscalation(bool enabled);
+CORE_API bool HasEnsureFailures();
+CORE_API void ResetEnsureFailures();
+
+[[noreturn]] CORE_API void HandleAssertFailure(FailureInfo&& info) noexcept;
+CORE_API bool HandleEnsureFailure(FailureInfo&& info) noexcept;
+
+template<typename... Args>
+[[noreturn]] inline void ReportAssertFailure(
+    const char*               expression,
+    const char*               file,
+    uint32_t                  line,
+    const char*               function,
+    uint32_t                  thread_id,
+    std::format_string<Args...> fmt,
+    Args&&...                 args
+) {
+    FailureInfo info{};
+    info.kind = EFailureKind::Assert;
+    info.expression = expression;
+    info.file = file;
+    info.function = function;
+    info.line = line;
+    info.thread_id = thread_id;
+    info.message = std::format(fmt, std::forward<Args>(args)...);
+    HandleAssertFailure(std::move(info));
+}
+
+template<typename... Args>
+inline bool ReportEnsureFailure(
+    const char*               expression,
+    const char*               file,
+    uint32_t                  line,
+    const char*               function,
+    uint32_t                  thread_id,
+    std::format_string<Args...> fmt,
+    Args&&...                 args
+) {
+    FailureInfo info{};
+    info.kind = EFailureKind::Ensure;
+    info.expression = expression;
+    info.file = file;
+    info.function = function;
+    info.line = line;
+    info.thread_id = thread_id;
+    info.message = std::format(fmt, std::forward<Args>(args)...);
+    return HandleEnsureFailure(std::move(info));
+}
+
+} // namespace Moer::Diagnostics
+
+#define MOER_ASSERT(expr, format_str, ...)                                                          \
+    do {                                                                                            \
+        if (!(expr)) {                                                                              \
+            ::Moer::Diagnostics::ReportAssertFailure(                                               \
+                #expr,                                                                              \
+                __FILE__,                                                                           \
+                static_cast<uint32_t>(__LINE__),                                                    \
+                __func__,                                                                           \
+                ::Platform::GetCurrentThreadID(),                                                   \
+                format_str                                                                          \
+                __VA_OPT__(, ) __VA_ARGS__                                                          \
+            );                                                                                      \
+        }                                                                                           \
+    } while (0)
+
+#define MOER_ENSURE(expr, format_str, ...)                                                          \
+    ((expr) ? true                                                                                  \
+            : ::Moer::Diagnostics::ReportEnsureFailure(                                             \
+                  #expr,                                                                            \
+                  __FILE__,                                                                         \
+                  static_cast<uint32_t>(__LINE__),                                                  \
+                  __func__,                                                                         \
+                  ::Platform::GetCurrentThreadID(),                                                 \
+                  format_str                                                                        \
+                  __VA_OPT__(, ) __VA_ARGS__))
+
+#endif // MOERENGINE_ASSERT_H

--- a/source/runtime/core/include/platform/Platform.h
+++ b/source/runtime/core/include/platform/Platform.h
@@ -3,7 +3,10 @@
 #include "API_Macro.h"
 #include "misc/STL.h"
 #include <cstdint>
+#include <filesystem>
 #include <initializer_list>
+#include <string>
+#include <string_view>
 #include <variant>
 #if defined(WIN32) || defined(_WIN32) || defined(_WIN32_) || defined(WIN64) || defined(_WIN64) || \
     defined(_WIN64_)
@@ -31,6 +34,22 @@ struct PlatformMemoryInfo {
 
     // MB
     uint32_t total_physical_memory_mb = 0;
+};
+
+struct PlatformStackTrace {
+    Moer::Array<uintptr_t> frames;
+};
+
+struct PlatformCrashDumpRequest {
+    std::string failure_kind;
+    std::string message;
+    uint32_t    thread_id = 0;
+};
+
+struct PlatformCrashDumpResult {
+    bool                  written = false;
+    std::filesystem::path path;
+    std::string           error_message;
 };
 
 struct Core {
@@ -90,6 +109,11 @@ public:
     CORE_API static int32_t  GetProcessorCoreCount();
     CORE_API static uint32_t GetCurrentThreadID();
     CORE_API static void     SetEnv(const char* _name, const char* _value);
+
+    CORE_API static PlatformStackTrace     CaptureStackTrace(uint32_t frames_to_skip = 0, uint32_t max_frames = 64);
+    CORE_API static std::string            FormatStackTrace(const PlatformStackTrace& trace);
+    CORE_API static PlatformCrashDumpResult WriteCrashDump(const PlatformCrashDumpRequest& request);
+    [[noreturn]] CORE_API static void      FailFast(std::string_view reason);
 
     CORE_API static const PlatformMemoryInfo& GetMemoryInfo();
 };

--- a/source/runtime/core/source/log/LogSystem.cpp
+++ b/source/runtime/core/source/log/LogSystem.cpp
@@ -56,6 +56,12 @@ void Init() {
 #endif
 }
 
+void Flush() {
+    if (auto* logger = spdlog::default_logger_raw(); logger != nullptr) {
+        logger->flush();
+    }
+}
+
 bool PollConsoleLogs(
     uint64_t&         next_sequence,
     ConsoleLogVisitor visitor,

--- a/source/runtime/core/source/misc/Assert.cpp
+++ b/source/runtime/core/source/misc/Assert.cpp
@@ -1,0 +1,122 @@
+#include "misc/Assert.h"
+
+#include "log/LogSystem.h"
+#include "platform/Platform.h"
+#include "profile/ProfileDump.h"
+
+#include <atomic>
+
+namespace Moer::Diagnostics {
+
+namespace {
+
+std::atomic<CrashFlushHook> g_crash_flush_hook{nullptr};
+std::atomic<bool>           g_ensure_failure_escalation{false};
+std::atomic<bool>           g_has_ensure_failures{false};
+std::atomic<bool>           g_handling_fatal{false};
+
+const char* ToString(EFailureKind kind) {
+    switch (kind) {
+        case EFailureKind::Assert:
+            return "assert";
+        case EFailureKind::Ensure:
+            return "ensure";
+    }
+    return "unknown";
+}
+
+void FlushCrashState() {
+    LogSystem::Flush();
+    if (CrashFlushHook hook = g_crash_flush_hook.load(std::memory_order_acquire); hook != nullptr) {
+        hook();
+    }
+    ProfileDump::FlushThreadLocal();
+    LogSystem::Flush();
+}
+
+} // namespace
+
+void SetCrashFlushHook(CrashFlushHook hook) {
+    g_crash_flush_hook.store(hook, std::memory_order_release);
+}
+
+void SetEnsureFailureEscalation(bool enabled) {
+    g_ensure_failure_escalation.store(enabled, std::memory_order_release);
+}
+
+bool HasEnsureFailures() {
+    return g_has_ensure_failures.load(std::memory_order_acquire);
+}
+
+void ResetEnsureFailures() {
+    g_has_ensure_failures.store(false, std::memory_order_release);
+}
+
+[[noreturn]] void HandleAssertFailure(FailureInfo&& info) noexcept {
+    if (g_handling_fatal.exchange(true, std::memory_order_acq_rel)) {
+        Platform::FailFast("recursive fatal failure");
+    }
+
+    LOG_CRITICAL(
+        "[MOER_ASSERT] expr=`{}` file={} line={} function={} thread={} message={}",
+        info.expression ? info.expression : "",
+        info.file ? info.file : "",
+        info.line,
+        info.function ? info.function : "",
+        info.thread_id,
+        info.message
+    );
+    FlushCrashState();
+
+    const PlatformStackTrace stack = Platform::CaptureStackTrace(2);
+    const std::string        stack_text = Platform::FormatStackTrace(stack);
+    const auto dump = Platform::WriteCrashDump(PlatformCrashDumpRequest{
+        .failure_kind = ToString(info.kind),
+        .message = info.message,
+        .thread_id = info.thread_id,
+    });
+
+    if (dump.written) {
+        LOG_CRITICAL("[MOER_ASSERT] dump={}", dump.path.generic_string());
+    } else if (!dump.error_message.empty()) {
+        LOG_CRITICAL("[MOER_ASSERT] dump_write_failed={}", dump.error_message);
+    }
+
+    if (!stack_text.empty()) {
+        LOG_CRITICAL("[MOER_ASSERT] stack:\n{}", stack_text);
+    }
+    FlushCrashState();
+
+    Platform::FailFast(info.message);
+}
+
+bool HandleEnsureFailure(FailureInfo&& info) noexcept {
+    g_has_ensure_failures.store(true, std::memory_order_release);
+
+    LOG_WARNING(
+        "[MOER_ENSURE] expr=`{}` file={} line={} function={} thread={} message={}",
+        info.expression ? info.expression : "",
+        info.file ? info.file : "",
+        info.line,
+        info.function ? info.function : "",
+        info.thread_id,
+        info.message
+    );
+
+    if (g_ensure_failure_escalation.load(std::memory_order_acquire)) {
+        LOG_ERROR(
+            "[MOER_ENSURE_ESCALATED] expr=`{}` file={} line={} function={} thread={} message={}",
+            info.expression ? info.expression : "",
+            info.file ? info.file : "",
+            info.line,
+            info.function ? info.function : "",
+            info.thread_id,
+            info.message
+        );
+        LogSystem::Flush();
+    }
+
+    return false;
+}
+
+} // namespace Moer::Diagnostics

--- a/source/runtime/core/source/platform/Platform.cpp
+++ b/source/runtime/core/source/platform/Platform.cpp
@@ -160,3 +160,40 @@ uint32_t Platform::GetCurrentThreadID() {
 void Platform::SetEnv(const char* _name, const char* _value) {
     PlatformImplement::GetInstance()->SetEnv(_name, _value);
 }
+
+PlatformStackTrace Platform::CaptureStackTrace(uint32_t frames_to_skip, uint32_t max_frames) {
+#if PLATFORM_WINDOWS
+    return WindowsPlatform::CaptureStackTrace(frames_to_skip + 1, max_frames);
+#else
+    (void)frames_to_skip;
+    (void)max_frames;
+    return PlatformStackTrace{};
+#endif
+}
+
+std::string Platform::FormatStackTrace(const PlatformStackTrace& trace) {
+#if PLATFORM_WINDOWS
+    return WindowsPlatform::FormatStackTrace(trace);
+#else
+    (void)trace;
+    return {};
+#endif
+}
+
+PlatformCrashDumpResult Platform::WriteCrashDump(const PlatformCrashDumpRequest& request) {
+#if PLATFORM_WINDOWS
+    return WindowsPlatform::WriteCrashDump(request);
+#else
+    (void)request;
+    return PlatformCrashDumpResult{};
+#endif
+}
+
+[[noreturn]] void Platform::FailFast(std::string_view reason) {
+#if PLATFORM_WINDOWS
+    WindowsPlatform::FailFast(reason);
+#else
+    (void)reason;
+    std::abort();
+#endif
+}

--- a/source/runtime/core/source/platform/Windows/PlatformWindows.cpp
+++ b/source/runtime/core/source/platform/Windows/PlatformWindows.cpp
@@ -2,8 +2,160 @@
 #include "math/Function.h"
 #include "misc/STL.h"
 
+#include <DbgHelp.h>
+#include <chrono>
+#include <filesystem>
+#include <mutex>
 #include <processthreadsapi.h>
+#include <sstream>
+#include <iomanip>
 #include <winnt.h>
+
+#pragma comment(lib, "Dbghelp.lib")
+
+namespace {
+
+std::mutex& GetSymbolMutex() {
+    static std::mutex mutex;
+    return mutex;
+}
+
+bool EnsureSymbolsInitialized() {
+    static bool initialized = [] {
+        HANDLE process = GetCurrentProcess();
+        SymSetOptions(SYMOPT_LOAD_LINES | SYMOPT_UNDNAME | SYMOPT_DEFERRED_LOADS);
+        return SymInitialize(process, nullptr, TRUE) == TRUE;
+    }();
+    return initialized;
+}
+
+std::filesystem::path MakeCrashDumpPath(uint32_t thread_id) {
+    const auto now = std::chrono::system_clock::now();
+    const auto time = std::chrono::system_clock::to_time_t(now);
+    std::tm    local_time{};
+    localtime_s(&local_time, &time);
+
+    std::ostringstream name;
+    name << "moer_crash_"
+         << std::put_time(&local_time, "%Y%m%d_%H%M%S")
+         << "_pid" << GetCurrentProcessId()
+         << "_tid" << thread_id
+         << ".dump";
+
+    const std::filesystem::path dump_dir = std::filesystem::current_path() / "logs" / "crash";
+    std::filesystem::create_directories(dump_dir);
+    return dump_dir / name.str();
+}
+
+} // namespace
+
+PlatformStackTrace WindowsPlatform::CaptureStackTrace(uint32_t frames_to_skip, uint32_t max_frames) {
+    PlatformStackTrace trace{};
+    trace.frames.resize(max_frames);
+    const USHORT captured = ::CaptureStackBackTrace(
+        static_cast<DWORD>(frames_to_skip + 1),
+        static_cast<DWORD>(max_frames),
+        reinterpret_cast<void**>(trace.frames.data()),
+        nullptr
+    );
+    trace.frames.resize(captured);
+    return trace;
+}
+
+std::string WindowsPlatform::FormatStackTrace(const PlatformStackTrace& trace) {
+    if (trace.frames.empty()) {
+        return {};
+    }
+
+    std::lock_guard lock(GetSymbolMutex());
+    const bool symbols_ready = EnsureSymbolsInitialized();
+    HANDLE     process = GetCurrentProcess();
+
+    std::ostringstream stream;
+    for (size_t index = 0; index < trace.frames.size(); ++index) {
+        const DWORD64 address = static_cast<DWORD64>(trace.frames[index]);
+        stream << '#' << index << ' ';
+
+        if (!symbols_ready) {
+            stream << "0x" << std::hex << address << std::dec << '\n';
+            continue;
+        }
+
+        std::array<char, sizeof(SYMBOL_INFO) + MAX_SYM_NAME> symbol_storage{};
+        auto* symbol = reinterpret_cast<SYMBOL_INFO*>(symbol_storage.data());
+        symbol->SizeOfStruct = sizeof(SYMBOL_INFO);
+        symbol->MaxNameLen = MAX_SYM_NAME;
+
+        DWORD64 displacement = 0;
+        if (::SymFromAddr(process, address, &displacement, symbol) == TRUE) {
+            stream << symbol->Name;
+        } else {
+            stream << "0x" << std::hex << address << std::dec;
+        }
+
+        IMAGEHLP_LINE64 line{};
+        line.SizeOfStruct = sizeof(line);
+        DWORD line_displacement = 0;
+        if (::SymGetLineFromAddr64(process, address, &line_displacement, &line) == TRUE) {
+            stream << " (" << line.FileName << ':' << line.LineNumber << ')';
+        }
+
+        stream << '\n';
+    }
+
+    return stream.str();
+}
+
+PlatformCrashDumpResult WindowsPlatform::WriteCrashDump(const PlatformCrashDumpRequest& request) {
+    PlatformCrashDumpResult result{};
+    const std::filesystem::path dump_path = MakeCrashDumpPath(request.thread_id);
+    HANDLE file = ::CreateFileW(
+        dump_path.wstring().c_str(),
+        GENERIC_WRITE,
+        FILE_SHARE_READ,
+        nullptr,
+        CREATE_ALWAYS,
+        FILE_ATTRIBUTE_NORMAL,
+        nullptr
+    );
+    if (file == INVALID_HANDLE_VALUE) {
+        result.error_message = "CreateFileW failed";
+        return result;
+    }
+
+    MINIDUMP_EXCEPTION_INFORMATION exception_info{};
+    exception_info.ThreadId = request.thread_id;
+    exception_info.ExceptionPointers = nullptr;
+    exception_info.ClientPointers = FALSE;
+
+    const BOOL ok = ::MiniDumpWriteDump(
+        GetCurrentProcess(),
+        GetCurrentProcessId(),
+        file,
+        static_cast<MINIDUMP_TYPE>(MiniDumpWithIndirectlyReferencedMemory | MiniDumpScanMemory),
+        nullptr,
+        nullptr,
+        nullptr
+    );
+    ::CloseHandle(file);
+
+    if (ok != TRUE) {
+        result.error_message = "MiniDumpWriteDump failed";
+        return result;
+    }
+
+    result.written = true;
+    result.path = dump_path;
+    return result;
+}
+
+[[noreturn]] void WindowsPlatform::FailFast(std::string_view reason) {
+    std::wstring wide_reason(reason.begin(), reason.end());
+    ::OutputDebugStringW(wide_reason.c_str());
+    ::RaiseFailFastException(nullptr, nullptr, 0);
+    ::TerminateProcess(GetCurrentProcess(), 3);
+    std::abort();
+}
 
 void WindowsPlatform::SetThreadAffinityMask(void* current_thread_handle, uint64_t mask) {
 

--- a/source/runtime/core/source/platform/Windows/PlatformWindows.h
+++ b/source/runtime/core/source/platform/Windows/PlatformWindows.h
@@ -34,6 +34,11 @@
 
 class WindowsPlatform : public PlatformImplement {
 public:
+    static PlatformStackTrace      CaptureStackTrace(uint32_t frames_to_skip, uint32_t max_frames);
+    static std::string             FormatStackTrace(const PlatformStackTrace& trace);
+    static PlatformCrashDumpResult WriteCrashDump(const PlatformCrashDumpRequest& request);
+    [[noreturn]] static void       FailFast(std::string_view reason);
+
     virtual void SetThreadAffinityMask(void* current_thread_handle, uint64_t mask) override;
     virtual void SetCurrentThreadAffinity(Affinity&& _affinity) override;
     virtual void SetCurrentThreadName(std::string_view _name) override;

--- a/source/runtime/render/RenderThread.cpp
+++ b/source/runtime/render/RenderThread.cpp
@@ -24,7 +24,7 @@ void RenderThreadMain(Event* _is_bound_to_taskgraph_event) {
     if (_is_bound_to_taskgraph_event) {
         _is_bound_to_taskgraph_event->Trigger();
     }
-    assert(IsRenderThreadInitialized() && "render thread not set");
+    MOER_ASSERT(IsRenderThreadInitialized(), "Render thread is not initialized before RenderThreadMain");
     LOG_INFO("[RENDER THREAD] thread id:{} executing", GetRenderThreadId());
     TaskGraph::GetInterface().ProcessThreadUntilReturn(EThread::ERenderThread);
     LOG_INFO("[RENDER THREAD] thread id:{} end", GetRenderThreadId());
@@ -83,9 +83,10 @@ void StopRenderThread() {
     //                                 .ConstructAndDispatchWhenReady(EThread::ERenderThread);
     auto return_event = GraphTask<ReturnGraphTask>::Create(EThread::ERenderThread).Dispatch();
     //not sure, game thread tasks should not be executing, because we are currently on Game Thread
-    assert(
+    MOER_ASSERT(
         !TaskGraph::GetInterface().IsThreadProcessingTask(EThread::EMainThread) &&
-        "On Game Thread while Game Thread Tasks are being executing"
+        !TaskGraph::GetInterface().IsThreadProcessingTask(EThread::EMainThread),
+        "Game thread must not be processing main-thread tasks while stopping the render thread"
     );
     TaskGraph::GetInterface().WaitUntilTaskComplete(return_event, EThread::EMainThread);
 
@@ -101,9 +102,9 @@ void ShutDownRenderThread() {}
 
 void RestartRenderThread() {
     LOG_INFO("Restarting Render Thread.");
-    assert(
-        IsGameThreadInitialized() && IsCurrentlyGameThread() &&
-        "Render Thread Control is only allowed in Game Thread."
+    MOER_ASSERT(
+        IsGameThreadInitialized() && IsCurrentlyGameThread(),
+        "Render thread control is only allowed on the initialized game thread"
     );
 
     bool b_render_thread_not_shut_down = g_render_thread && g_render_thread_runnable;
@@ -112,9 +113,9 @@ void RestartRenderThread() {
 }
 
 void SuspendRenderThread(bool _restart_later) {
-    assert(
-        IsGameThreadInitialized() && IsCurrentlyGameThread() &&
-        "Render Thread Control is only allowed in Game Thread."
+    MOER_ASSERT(
+        IsGameThreadInitialized() && IsCurrentlyGameThread(),
+        "Render thread control is only allowed on the initialized game thread"
     );
     LOG_INFO("Try Suspending Render Thread.");
     if (_restart_later) {
@@ -184,7 +185,7 @@ void RenderThreadFence::BeginFence() {
 }
 
 bool RenderThreadFence::IsFenceComplete() {
-    assert(Moer::IsCurrentlyGameThread());
+    MOER_ASSERT(Moer::IsCurrentlyGameThread(), "RenderThreadFence::IsFenceComplete must run on the game thread");
     if (!complete_event.Get() || complete_event->IsComplete()) {
         complete_event = nullptr;
         return true;
@@ -193,7 +194,7 @@ bool RenderThreadFence::IsFenceComplete() {
 }
 void RenderThreadFence::Wait() {
 
-    assert(Moer::IsCurrentlyGameThread());
+    MOER_ASSERT(Moer::IsCurrentlyGameThread(), "RenderThreadFence::Wait must run on the game thread");
 
     if (!IsFenceComplete()) {
         {

--- a/source/runtime/render/rhi/GPUEventStream.cpp
+++ b/source/runtime/render/rhi/GPUEventStream.cpp
@@ -1,5 +1,6 @@
 #include "GPUEventStream.h"
 #include "log/LogSystem.h"
+#include "misc/Assert.h"
 #include "profile/ProfileDump.h"
 #include "profile/ProfileDumpTemplates.h"
 #include "trace/Trace.h"
@@ -370,10 +371,19 @@ std::string BuildFrameDebugText(const ResolvedGPUFrame& frame) {
     return stream.str();
 }
 
+void FlushGpuEventStreamCrashHook() {
+    GPUEventStream::Get().FlushCrashSafeToProfiler();
+}
+
 } // namespace
 
 GPUEventStream& GPUEventStream::Get() {
     static GPUEventStream instance;
+    static const bool     registered_crash_hook = [] {
+        Moer::Diagnostics::SetCrashFlushHook(&FlushGpuEventStreamCrashHook);
+        return true;
+    }();
+    (void)registered_crash_hook;
     return instance;
 }
 
@@ -460,6 +470,22 @@ void GPUEventStream::FlushToProfiler() {
 
     for (const ResolvedGPUFrame& frame : frames_to_emit) {
         EmitFrameToTrace(frame);
+        EmitFrameToProfileDump(frame);
+    }
+    if (!frames_to_emit.empty()) {
+        Moer::ProfileDump::FlushThreadLocal();
+    }
+}
+
+void GPUEventStream::FlushCrashSafeToProfiler() {
+    Array<ResolvedGPUFrame> frames_to_emit;
+    {
+        std::lock_guard lock(stream_mutex);
+        frames_to_emit = ready_frames;
+        ready_frames.clear();
+    }
+
+    for (const ResolvedGPUFrame& frame : frames_to_emit) {
         EmitFrameToProfileDump(frame);
     }
     if (!frames_to_emit.empty()) {

--- a/source/runtime/render/rhi/GPUEventStream.h
+++ b/source/runtime/render/rhi/GPUEventStream.h
@@ -36,6 +36,7 @@ public:
     void ResolveCompleted(WaitEvent completion);
     void EndFrame();
     void FlushToProfiler();
+    void FlushCrashSafeToProfiler();
     std::string FormatLastResolvedFrame() const;
     void InjectResolvedSubmitForTesting(Array<GPUEvent>&& events, EQueueType queue);
     void ResetForTesting();

--- a/source/runtime/render/rhi/RHI.cpp
+++ b/source/runtime/render/rhi/RHI.cpp
@@ -9,14 +9,13 @@
 #include "rhi/RHIResource.h"
 #include "shader/ShaderResourceManager.h"
 #include "vulkan/VulkanDevice.h"
-#include <cassert>
 
 namespace Moer::Render {
 
 template<>
 VulkanRHIConfig ResolveConfigAs(const DeviceInitInfo& _info) {
     using std::string;
-    assert(_info.rhi_type == ERHIType::Vulkan);
+    MOER_ASSERT(_info.rhi_type == ERHIType::Vulkan, "ResolveConfigAs<VulkanRHIConfig> requires Vulkan");
 
     VulkanRHIConfig config;
 
@@ -33,7 +32,7 @@ VulkanRHIConfig ResolveConfigAs(const DeviceInitInfo& _info) {
         config.api_version = VK_API_VERSION_1_3;
     else {
         LOG_ERROR("Unsupported vulkan api version: {}", api);
-        assert(false);
+        MOER_ASSERT(false, "Unsupported vulkan api version: {}", api);
     }
 
     return config;
@@ -41,7 +40,7 @@ VulkanRHIConfig ResolveConfigAs(const DeviceInitInfo& _info) {
 
 template<>
 D3D12RHIConfig ResolveConfigAs(const DeviceInitInfo& _info) {
-    assert(_info.rhi_type == ERHIType::D3D12);
+    MOER_ASSERT(_info.rhi_type == ERHIType::D3D12, "ResolveConfigAs<D3D12RHIConfig> requires D3D12");
 
     D3D12RHIConfig config;
 
@@ -122,7 +121,7 @@ uint64 GetSizeFromImageFormat(EPixelFormat _format, const uint3 _size) {
 
 uint64 GetByteFromPixelFormat(EPixelFormat format) {
     if (IsPixelFormatBC(format)) {
-        assert(false && "BC format does not have fixed byte per pixel");
+        MOER_ASSERT(false, "BC format does not have fixed byte per pixel");
     }
     switch (format) {
         case PF_R8G8B8A8_SRGB:
@@ -190,14 +189,14 @@ uint64 GetByteFromPixelFormat(EPixelFormat format) {
             return 1;
             break;
         default:
-            assert(false && "not support format");
+            MOER_ASSERT(false, "Unsupported pixel format in GetByteFromPixelFormat: {}", static_cast<uint32_t>(format));
     }
     return 0;
 }
 
 uint64 GetChannelFromPixelFormat(EPixelFormat format) {
     if (IsPixelFormatBC(format)) {
-        assert(false && "BC format has no fixed channel count");
+        MOER_ASSERT(false, "BC format has no fixed channel count");
     }
     switch (format) {
         case PF_R8G8B8A8_SRGB:
@@ -265,7 +264,11 @@ uint64 GetChannelFromPixelFormat(EPixelFormat format) {
             return 1;
             break;
         default:
-            assert(false && "not support format");
+            MOER_ASSERT(
+                false,
+                "Unsupported pixel format in GetChannelFromPixelFormat: {}",
+                static_cast<uint32_t>(format)
+            );
     }
     return 0;
 }
@@ -302,7 +305,7 @@ uint64 GetSizeFromPixelFormat(EPixelFormat format, const uint3 size) {
                 return block_cnt * 16;
                 break;
             default:
-                assert(false && "not support format");
+                MOER_ASSERT(false, "Unsupported BC pixel format in GetSizeFromPixelFormat: {}", static_cast<uint32_t>(format));
         }
     }
     return GetByteFromPixelFormat(format) * size.x * size.y * size.z;

--- a/source/runtime/render/window/glfw/GLFWWindowImpl.cpp
+++ b/source/runtime/render/window/glfw/GLFWWindowImpl.cpp
@@ -1,5 +1,6 @@
 #include "GLFWWindowImpl.h"
 
+#include "Core.h"
 #include "misc/MMemory.h"
 #include "platform/Platform.h"
 #include "rhi/RHI.h"
@@ -47,7 +48,7 @@ void GLFWWindowImpl::Init(const SurfaceInitInfo& info) {
     if (!glfwInit()) {
         //error log and quit
         LOG_ERROR("Window init fail.");
-        assert(0 && "Window init fail.");
+        MOER_ASSERT(false, "GLFW initialization failed");
     }
     glfwWindowHint(GLFW_CLIENT_API, GLFW_NO_API);
     if (info.rhi_type == ERHIType::D3D12) {
@@ -55,7 +56,7 @@ void GLFWWindowImpl::Init(const SurfaceInitInfo& info) {
     } else if (info.rhi_type == ERHIType::Vulkan) {
         InitVulkan();
     } else {
-        assert(0 && "Unknown RHI type, code error.");
+        MOER_ASSERT(false, "Unsupported RHI type in GLFWWindowImpl::Init: {}", static_cast<uint32_t>(info.rhi_type));
     }
 
     int          width   = info.width;

--- a/source/test/RHITest/dxrhitest.cpp
+++ b/source/test/RHITest/dxrhitest.cpp
@@ -99,6 +99,8 @@ int main(int argc, char** argv) {
     std::filesystem::path path = argv[0];
     path.filename().string().find(".exe") != std::string::npos ? path = path.parent_path() : path = path;
     ConfigManager::GetInstance().Init(path);
+    Diagnostics::SetEnsureFailureEscalation(true);
+    Diagnostics::ResetEnsureFailures();
 
     TaskSystem::Init();
     DeviceInitInfo info{.rhi_type = ERHIType::D3D12, .name = "DXRHITest"};
@@ -112,8 +114,7 @@ int main(int argc, char** argv) {
 
     RenderDevice::Init(std::move(info));
 
-    try {
-        capturer->Begin("D:\\codebase\\repos\\MoerEngine\\test.wpix");
+    capturer->Begin("D:\\codebase\\repos\\MoerEngine\\test.wpix");
 
         auto& device = RenderDevice::Get();
 
@@ -221,10 +222,11 @@ int main(int argc, char** argv) {
             LOG_INFO("result={}, expect={}, ok={}", iarr[0], res, iarr[0] == res);
         }
 
-        capturer->End();
+    capturer->End();
 
-    } catch (const std::exception& e) {
-        LOG_ERROR("{}", e.what());
+    if (Diagnostics::HasEnsureFailures()) {
+        LOG_ERROR("DXRHITest observed escalated ensure failures.");
+        return 1;
     }
 
     /*

--- a/source/test/RHITest/rhi_translate_multiqueue_test.cpp
+++ b/source/test/RHITest/rhi_translate_multiqueue_test.cpp
@@ -2273,6 +2273,8 @@ int main(int argc, char** argv) {
     Moer::ConfigManager::GetInstance().Init(path);
     Moer::LogSystem::Init();
     Moer::TaskSystem::Init();
+    Moer::Diagnostics::SetEnsureFailureEscalation(true);
+    Moer::Diagnostics::ResetEnsureFailures();
 
     DeviceInitInfo info{
         .rhi_type = ERHIType::Vulkan,
@@ -2286,186 +2288,180 @@ int main(int argc, char** argv) {
     }
 
     bool window_inited = false;
-    try {
-        RenderDevice::Init(std::move(info));
-        ShaderCompiler::Init();
+    RenderDevice::Init(std::move(info));
+    ShaderCompiler::Init();
 
-        auto shutdown_and_return = [&](int code) {
-            if (window_inited) {
-                WindowContext::ShutDown();
-                window_inited = false;
-            }
-            ShaderManager::ShutDown();
-            ShutdownRHIForTest();
-            Moer::TaskSystem::ShutDown();
-            return code;
-        };
-
-        const int queue_ret = RunNamedTestCase("CommandListQueueBinding", RunCommandListQueueBindingTest);
-        if (queue_ret != 0) {
-            return shutdown_and_return(queue_ret);
+    auto shutdown_and_return = [&](int code) {
+        int exit_code = code;
+        if (exit_code == 0 && Moer::Diagnostics::HasEnsureFailures()) {
+            LOG_ERROR("TestRHITranslate observed escalated ensure failures.");
+            exit_code = 1;
         }
-
-        const int translate_metadata_ret = RunNamedTestCase(
-            "TranslateExecutionMetadataRoundTrip",
-            RunTranslateExecutionClassRoundTripTest
-        );
-        if (translate_metadata_ret != 0) {
-            return shutdown_and_return(translate_metadata_ret);
-        }
-
-        const int translate_lambda_ret =
-            RunNamedTestCase("TranslateLambdaCommand", RunTranslateLambdaCommandTest);
-        if (translate_lambda_ret != 0) {
-            return shutdown_and_return(translate_lambda_ret);
-        }
-
-        const int translate_readback_ret =
-            RunNamedTestCase("MultiQueueReadback", RunRHITranslateMultiQueueReadbackTest);
-        if (translate_readback_ret != 0) {
-            return shutdown_and_return(translate_readback_ret);
-        }
-
-        const int multi_cmd_order_ret =
-            RunNamedTestCase("MultiCommandListSubmitOrdering", RunMultiCommandListSubmitOrderingTest);
-        if (multi_cmd_order_ret != 0) {
-            return shutdown_and_return(multi_cmd_order_ret);
-        }
-
-        const int serial_control_ret = RunNamedTestCase(
-            "SerialControlTranslateOrdering",
-            RunSerialControlTranslateOrderingTest
-        );
-        if (serial_control_ret != 0) {
-            return shutdown_and_return(serial_control_ret);
-        }
-
-        const int descriptor_heap_ret = RunNamedTestCase(
-            "ConcurrentDescriptorRangeAllocation",
-            RunDescriptorHeapConcurrentRangeAllocationTest
-        );
-        if (descriptor_heap_ret != 0) {
-            return shutdown_and_return(descriptor_heap_ret);
-        }
-
-        const int graphics_copyscope_ret =
-            RunNamedTestCase("GraphicsCopyScopeRoundTrip", RunGraphicsCopyScopeRoundTripTest);
-        if (graphics_copyscope_ret != 0) {
-            return shutdown_and_return(graphics_copyscope_ret);
-        }
-
-        const int bindless_readback_ret =
-            RunNamedTestCase("BindlessBufferReadback", RunBindlessBufferReadbackTest);
-        if (bindless_readback_ret != 0) {
-            return shutdown_and_return(bindless_readback_ret);
-        }
-
-        const int bindless_texture_readback_ret =
-            RunNamedTestCase("BindlessTextureReadback", RunBindlessTextureReadbackTest);
-        if (bindless_texture_readback_ret != 0) {
-            return shutdown_and_return(bindless_texture_readback_ret);
-        }
-
-        const int multi_bindless_array_ret =
-            RunNamedTestCase("MultiBindlessArrayReadback", RunMultiBindlessArrayReadbackTest);
-        if (multi_bindless_array_ret != 0) {
-            return shutdown_and_return(multi_bindless_array_ret);
-        }
-
-        const int multi_scope_ret =
-            RunNamedTestCase("MultiCopyScopeOrdering", RunMultiCopyScopeOrderingTest);
-        if (multi_scope_ret != 0) {
-            return shutdown_and_return(multi_scope_ret);
-        }
-
-        const int unknown_first_use_ret =
-            RunNamedTestCase("CopyScopeUnknownFirstUse", RunCopyScopeUnknownFirstUseTest);
-        if (unknown_first_use_ret != 0) {
-            return shutdown_and_return(unknown_first_use_ret);
-        }
-
-        const int gpu_event_stream_ret =
-            RunNamedTestCase("GPUEventStreamHierarchy", RunGpuEventStreamHierarchyTest);
-        if (gpu_event_stream_ret != 0) {
-            return shutdown_and_return(gpu_event_stream_ret);
-        }
-
-        const int gpu_event_cross_submit_ret =
-            RunNamedTestCase("GPUEventStreamCrossSubmitAggregation", RunGpuEventStreamCrossSubmitAggregationTest);
-        if (gpu_event_cross_submit_ret != 0) {
-            return shutdown_and_return(gpu_event_cross_submit_ret);
-        }
-
-        const int gpu_event_boundary_validation_ret =
-            RunNamedTestCase("GPUEventStreamBoundaryValidation", RunGpuEventStreamBoundaryValidationTest);
-        if (gpu_event_boundary_validation_ret != 0) {
-            return shutdown_and_return(gpu_event_boundary_validation_ret);
-        }
-
-        const int profile_dump_cvar_ret =
-            RunNamedTestCase("ProfileDumpStartupReadOnlyCVar", RunProfileDumpStartupReadOnlyCVarTest);
-        if (profile_dump_cvar_ret != 0) {
-            return shutdown_and_return(profile_dump_cvar_ret);
-        }
-
-        const int profile_dump_file_ret =
-            RunNamedTestCase("ProfileDumpFileSinkFlush", RunProfileDumpFileSinkTest);
-        if (profile_dump_file_ret != 0) {
-            return shutdown_and_return(profile_dump_file_ret);
-        }
-
-        const int profile_dump_tcp_ret =
-            RunNamedTestCase("ProfileDumpTcpSinkConsumerParse", RunProfileDumpTcpSinkTest);
-        if (profile_dump_tcp_ret != 0) {
-            return shutdown_and_return(profile_dump_tcp_ret);
-        }
-
-        const int profile_dump_gpu_ret =
-            RunNamedTestCase("ProfileDumpGpuEventIntegration", RunGpuEventStreamProfileDumpTest);
-        if (profile_dump_gpu_ret != 0) {
-            return shutdown_and_return(profile_dump_gpu_ret);
-        }
-
-        const int profile_consumer_file_ret =
-            RunNamedTestCase("ProfileConsumerFileLoadNormalization", RunProfileConsumerFileLoadTest);
-        if (profile_consumer_file_ret != 0) {
-            return shutdown_and_return(profile_consumer_file_ret);
-        }
-
-        const int profile_consumer_stream_ret =
-            RunNamedTestCase("ProfileConsumerStreamNormalization", RunProfileConsumerStreamNormalizationTest);
-        if (profile_consumer_stream_ret != 0) {
-            return shutdown_and_return(profile_consumer_stream_ret);
-        }
-
-#if defined(MOER_TEST_WITH_PROFILE)
-        const int profile_dump_flame_ret =
-            RunNamedTestCase("ProfileDumpFlameProfilerIntegration", RunFlameProfilerProfileDumpTest);
-        if (profile_dump_flame_ret != 0) {
-            return shutdown_and_return(profile_dump_flame_ret);
-        }
-#endif
-
-        WindowContext::Init(SurfaceInitInfo(ERHIType::Vulkan, 640, 360, "TestRHITranslatePresent", false));
-        window_inited = true;
-        const int present_copyscope_ret =
-            RunNamedTestCase("PresentWithCopyScope", RunPresentWithCopyScopeTests);
-        if (present_copyscope_ret != 0) {
-            return shutdown_and_return(present_copyscope_ret);
-        }
-        const int present_ret = RunNamedTestCase("PresentRoundTrip", RunPresentTests);
-        if (present_ret != 0) {
-            return shutdown_and_return(present_ret);
-        }
-        return shutdown_and_return(0);
-    } catch (const std::exception& e) {
-        LOG_ERROR("TestRHITranslate failed: {}", e.what());
         if (window_inited) {
             WindowContext::ShutDown();
+            window_inited = false;
         }
         ShaderManager::ShutDown();
         ShutdownRHIForTest();
         Moer::TaskSystem::ShutDown();
-        return 1;
+        return exit_code;
+    };
+
+    const int queue_ret = RunNamedTestCase("CommandListQueueBinding", RunCommandListQueueBindingTest);
+    if (queue_ret != 0) {
+        return shutdown_and_return(queue_ret);
     }
+
+    const int translate_metadata_ret = RunNamedTestCase(
+        "TranslateExecutionMetadataRoundTrip",
+        RunTranslateExecutionClassRoundTripTest
+    );
+    if (translate_metadata_ret != 0) {
+        return shutdown_and_return(translate_metadata_ret);
+    }
+
+    const int translate_lambda_ret =
+        RunNamedTestCase("TranslateLambdaCommand", RunTranslateLambdaCommandTest);
+    if (translate_lambda_ret != 0) {
+        return shutdown_and_return(translate_lambda_ret);
+    }
+
+    const int translate_readback_ret =
+        RunNamedTestCase("MultiQueueReadback", RunRHITranslateMultiQueueReadbackTest);
+    if (translate_readback_ret != 0) {
+        return shutdown_and_return(translate_readback_ret);
+    }
+
+    const int multi_cmd_order_ret =
+        RunNamedTestCase("MultiCommandListSubmitOrdering", RunMultiCommandListSubmitOrderingTest);
+    if (multi_cmd_order_ret != 0) {
+        return shutdown_and_return(multi_cmd_order_ret);
+    }
+
+    const int serial_control_ret = RunNamedTestCase(
+        "SerialControlTranslateOrdering",
+        RunSerialControlTranslateOrderingTest
+    );
+    if (serial_control_ret != 0) {
+        return shutdown_and_return(serial_control_ret);
+    }
+
+    const int descriptor_heap_ret = RunNamedTestCase(
+        "ConcurrentDescriptorRangeAllocation",
+        RunDescriptorHeapConcurrentRangeAllocationTest
+    );
+    if (descriptor_heap_ret != 0) {
+        return shutdown_and_return(descriptor_heap_ret);
+    }
+
+    const int graphics_copyscope_ret =
+        RunNamedTestCase("GraphicsCopyScopeRoundTrip", RunGraphicsCopyScopeRoundTripTest);
+    if (graphics_copyscope_ret != 0) {
+        return shutdown_and_return(graphics_copyscope_ret);
+    }
+
+    const int bindless_readback_ret =
+        RunNamedTestCase("BindlessBufferReadback", RunBindlessBufferReadbackTest);
+    if (bindless_readback_ret != 0) {
+        return shutdown_and_return(bindless_readback_ret);
+    }
+
+    const int bindless_texture_readback_ret =
+        RunNamedTestCase("BindlessTextureReadback", RunBindlessTextureReadbackTest);
+    if (bindless_texture_readback_ret != 0) {
+        return shutdown_and_return(bindless_texture_readback_ret);
+    }
+
+    const int multi_bindless_array_ret =
+        RunNamedTestCase("MultiBindlessArrayReadback", RunMultiBindlessArrayReadbackTest);
+    if (multi_bindless_array_ret != 0) {
+        return shutdown_and_return(multi_bindless_array_ret);
+    }
+
+    const int multi_scope_ret =
+        RunNamedTestCase("MultiCopyScopeOrdering", RunMultiCopyScopeOrderingTest);
+    if (multi_scope_ret != 0) {
+        return shutdown_and_return(multi_scope_ret);
+    }
+
+    const int unknown_first_use_ret =
+        RunNamedTestCase("CopyScopeUnknownFirstUse", RunCopyScopeUnknownFirstUseTest);
+    if (unknown_first_use_ret != 0) {
+        return shutdown_and_return(unknown_first_use_ret);
+    }
+
+    const int gpu_event_stream_ret =
+        RunNamedTestCase("GPUEventStreamHierarchy", RunGpuEventStreamHierarchyTest);
+    if (gpu_event_stream_ret != 0) {
+        return shutdown_and_return(gpu_event_stream_ret);
+    }
+
+    const int gpu_event_cross_submit_ret =
+        RunNamedTestCase("GPUEventStreamCrossSubmitAggregation", RunGpuEventStreamCrossSubmitAggregationTest);
+    if (gpu_event_cross_submit_ret != 0) {
+        return shutdown_and_return(gpu_event_cross_submit_ret);
+    }
+
+    const int gpu_event_boundary_validation_ret =
+        RunNamedTestCase("GPUEventStreamBoundaryValidation", RunGpuEventStreamBoundaryValidationTest);
+    if (gpu_event_boundary_validation_ret != 0) {
+        return shutdown_and_return(gpu_event_boundary_validation_ret);
+    }
+
+    const int profile_dump_cvar_ret =
+        RunNamedTestCase("ProfileDumpStartupReadOnlyCVar", RunProfileDumpStartupReadOnlyCVarTest);
+    if (profile_dump_cvar_ret != 0) {
+        return shutdown_and_return(profile_dump_cvar_ret);
+    }
+
+    const int profile_dump_file_ret =
+        RunNamedTestCase("ProfileDumpFileSinkFlush", RunProfileDumpFileSinkTest);
+    if (profile_dump_file_ret != 0) {
+        return shutdown_and_return(profile_dump_file_ret);
+    }
+
+    const int profile_dump_tcp_ret =
+        RunNamedTestCase("ProfileDumpTcpSinkConsumerParse", RunProfileDumpTcpSinkTest);
+    if (profile_dump_tcp_ret != 0) {
+        return shutdown_and_return(profile_dump_tcp_ret);
+    }
+
+    const int profile_dump_gpu_ret =
+        RunNamedTestCase("ProfileDumpGpuEventIntegration", RunGpuEventStreamProfileDumpTest);
+    if (profile_dump_gpu_ret != 0) {
+        return shutdown_and_return(profile_dump_gpu_ret);
+    }
+
+    const int profile_consumer_file_ret =
+        RunNamedTestCase("ProfileConsumerFileLoadNormalization", RunProfileConsumerFileLoadTest);
+    if (profile_consumer_file_ret != 0) {
+        return shutdown_and_return(profile_consumer_file_ret);
+    }
+
+    const int profile_consumer_stream_ret =
+        RunNamedTestCase("ProfileConsumerStreamNormalization", RunProfileConsumerStreamNormalizationTest);
+    if (profile_consumer_stream_ret != 0) {
+        return shutdown_and_return(profile_consumer_stream_ret);
+    }
+
+#if defined(MOER_TEST_WITH_PROFILE)
+    const int profile_dump_flame_ret =
+        RunNamedTestCase("ProfileDumpFlameProfilerIntegration", RunProfileDumpFlameProfilerProfileDumpTest);
+    if (profile_dump_flame_ret != 0) {
+        return shutdown_and_return(profile_dump_flame_ret);
+    }
+#endif
+
+    WindowContext::Init(SurfaceInitInfo(ERHIType::Vulkan, 640, 360, "TestRHITranslatePresent", false));
+    window_inited = true;
+    const int present_copyscope_ret =
+        RunNamedTestCase("PresentWithCopyScope", RunPresentWithCopyScopeTests);
+    if (present_copyscope_ret != 0) {
+        return shutdown_and_return(present_copyscope_ret);
+    }
+    const int present_ret = RunNamedTestCase("PresentRoundTrip", RunPresentTests);
+    if (present_ret != 0) {
+        return shutdown_and_return(present_ret);
+    }
+    return shutdown_and_return(0);
 }

--- a/source/test/ShaderDXCTest.cpp
+++ b/source/test/ShaderDXCTest.cpp
@@ -77,46 +77,48 @@ int main(int argc, char** argv) {
         path = path.parent_path();
     }
 
-    try {
-        ConfigManager::GetInstance().Init(path);
-        LogSystem::Init();
-        ShaderCompiler::Init();
+    Diagnostics::SetEnsureFailureEscalation(true);
+    Diagnostics::ResetEnsureFailures();
+    ConfigManager::GetInstance().Init(path);
+    LogSystem::Init();
+    ShaderCompiler::Init();
 
-        constexpr std::array kCases = {
-            ShaderCompileCase{"BindlessBindingsOnly.Vulkan", "tests/BindlessBindingsOnly.comp.hlsl", "main", ST_COMPUTE, SP_VULKAN_SM6},
-            ShaderCompileCase{"BindlessDirectArrayBuffer.Vulkan", "tests/BindlessDirectArrayBuffer.comp.hlsl", "main", ST_COMPUTE, SP_VULKAN_SM6},
-            ShaderCompileCase{"BindlessDirectTexture.Vulkan", "tests/BindlessDirectTexture.comp.hlsl", "main", ST_COMPUTE, SP_VULKAN_SM6},
-            ShaderCompileCase{"BindlessArrayBuffer.Vulkan", "tests/BindlessArrayBuffer.comp.hlsl", "main", ST_COMPUTE, SP_VULKAN_SM6},
-            ShaderCompileCase{"BindlessSampler.Vulkan", "tests/BindlessSampler.comp.hlsl", "main", ST_COMPUTE, SP_VULKAN_SM6},
-            ShaderCompileCase{"BindlessTexture.Vulkan", "tests/BindlessTexture.comp.hlsl", "main", ST_COMPUTE, SP_VULKAN_SM6},
-            ShaderCompileCase{"BindlessMinimal.Vulkan", "tests/BindlessMinimal.comp.hlsl", "main", ST_COMPUTE, SP_VULKAN_SM6},
-            ShaderCompileCase{"RayQueryMinimal.Vulkan", "tests/RayQueryMinimal.comp.hlsl", "main", ST_COMPUTE, SP_VULKAN_SM6},
-            ShaderCompileCase{"RayGenMinimal.Vulkan", "tests/RayGenMinimal.rgen.hlsl", "main", ST_RAY_GEN, SP_VULKAN_SM6},
-            ShaderCompileCase{"BindlessMinimal.DXIL", "tests/BindlessMinimal.comp.hlsl", "main", ST_COMPUTE, SP_WIN_D3D_SM6},
-            ShaderCompileCase{"GuiVert.Vulkan", "features/ui/GuiVert.hlsl", "main", ST_VERTEX, SP_VULKAN_SM6},
-            ShaderCompileCase{"GuiFrag.Vulkan", "features/ui/GuiFrag.hlsl", "main", ST_FRAGMENT, SP_VULKAN_SM6},
-        };
+    constexpr std::array kCases = {
+        ShaderCompileCase{"BindlessBindingsOnly.Vulkan", "tests/BindlessBindingsOnly.comp.hlsl", "main", ST_COMPUTE, SP_VULKAN_SM6},
+        ShaderCompileCase{"BindlessDirectArrayBuffer.Vulkan", "tests/BindlessDirectArrayBuffer.comp.hlsl", "main", ST_COMPUTE, SP_VULKAN_SM6},
+        ShaderCompileCase{"BindlessDirectTexture.Vulkan", "tests/BindlessDirectTexture.comp.hlsl", "main", ST_COMPUTE, SP_VULKAN_SM6},
+        ShaderCompileCase{"BindlessArrayBuffer.Vulkan", "tests/BindlessArrayBuffer.comp.hlsl", "main", ST_COMPUTE, SP_VULKAN_SM6},
+        ShaderCompileCase{"BindlessSampler.Vulkan", "tests/BindlessSampler.comp.hlsl", "main", ST_COMPUTE, SP_VULKAN_SM6},
+        ShaderCompileCase{"BindlessTexture.Vulkan", "tests/BindlessTexture.comp.hlsl", "main", ST_COMPUTE, SP_VULKAN_SM6},
+        ShaderCompileCase{"BindlessMinimal.Vulkan", "tests/BindlessMinimal.comp.hlsl", "main", ST_COMPUTE, SP_VULKAN_SM6},
+        ShaderCompileCase{"RayQueryMinimal.Vulkan", "tests/RayQueryMinimal.comp.hlsl", "main", ST_COMPUTE, SP_VULKAN_SM6},
+        ShaderCompileCase{"RayGenMinimal.Vulkan", "tests/RayGenMinimal.rgen.hlsl", "main", ST_RAY_GEN, SP_VULKAN_SM6},
+        ShaderCompileCase{"BindlessMinimal.DXIL", "tests/BindlessMinimal.comp.hlsl", "main", ST_COMPUTE, SP_WIN_D3D_SM6},
+        ShaderCompileCase{"GuiVert.Vulkan", "features/ui/GuiVert.hlsl", "main", ST_VERTEX, SP_VULKAN_SM6},
+        ShaderCompileCase{"GuiFrag.Vulkan", "features/ui/GuiFrag.hlsl", "main", ST_FRAGMENT, SP_VULKAN_SM6},
+    };
 
-        int failed_cases = 0;
-        for (const auto& test_case : kCases) {
-            failed_cases += CompileCase(
-                test_case.case_name,
-                test_case.relative_path,
-                test_case.entry_point,
-                test_case.shader_type,
-                test_case.shader_platform
-            );
-        }
+    int failed_cases = 0;
+    for (const auto& test_case : kCases) {
+        failed_cases += CompileCase(
+            test_case.case_name,
+            test_case.relative_path,
+            test_case.entry_point,
+            test_case.shader_type,
+            test_case.shader_platform
+        );
+    }
 
-        if (failed_cases != 0) {
-            LOG_ERROR("[ShaderDXCTest] failed_cases={}", failed_cases);
-            return 1;
-        }
-
-        LOG_INFO("[ShaderDXCTest] all cases passed");
-        return 0;
-    } catch (const std::exception& e) {
-        std::cerr << "TestShaderDXC failed: " << e.what() << std::endl;
+    if (failed_cases != 0) {
+        LOG_ERROR("[ShaderDXCTest] failed_cases={}", failed_cases);
         return 1;
     }
+
+    if (Diagnostics::HasEnsureFailures()) {
+        LOG_ERROR("[ShaderDXCTest] observed escalated ensure failures");
+        return 1;
+    }
+
+    LOG_INFO("[ShaderDXCTest] all cases passed");
+    return 0;
 }


### PR DESCRIPTION
## Summary
- add repository-owned fatal diagnostics with `MOER_ASSERT` and `MOER_ENSURE`
- add Windows stack capture, `.dump` writing, fail-fast handling, and crash-safe log/profile flushing
- remove repository-owned try/catch from test entrypoints and make ensure failures visible to tests
- migrate a small set of high-value runtime/editor boundary asserts to the new diagnostics path

## Why
This moves fatal handling under a single repository-owned policy instead of relying on scattered raw `assert(...)` and outer try/catch boundaries. Fatal paths now flush logs/profile state, emit a dump on Windows, and fail fast consistently.

## Validation
- passed `testscripts/windows/test_rhi_translate.ps1`
- earlier branch validation passed `testscripts/windows/test_all.ps1` after temporary validation cleanup
- current rerun of `testscripts/windows/test_all.ps1` hit an existing Editor-side SMAA shader compile failure in `shaders/pipelines/postprocess/aa/SmaaWrapper.hlsl`, outside this diff
