### PR TITLE
[lab/lab2-dof] 将子模块 url 从 ssh 改为 https

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -17,5 +17,5 @@
 	shallow = true
 [submodule "3rdparty/concurrentqueue"]
 	path = 3rdparty/concurrentqueue
-	url = git@github.com:cameron314/concurrentqueue.git
+	url = https://github.com/cameron314/concurrentqueue.git
 	shallow = true


### PR DESCRIPTION
将 `3rdparty/concurrentqueue` 子模块的 url 从 ssh 改为 https，这样无需配置 github ssh key 也可以正常拉取。