### PR TITLE
fix(raytracing): guard invalid bindless texture handles

### DIFF
--- a/shaders/pipelines/raytracing/inline/RaytracingCommon.hlsli
+++ b/shaders/pipelines/raytracing/inline/RaytracingCommon.hlsli
@@ -72,6 +72,10 @@ enum EMaterialAttribute {
     EMA_All = 0x1f
 };
 
+bool IsValidBindlessHandle(uint _handle) {
+    return int(_handle) >= 0;
+}
+
 GeometryRecord GetGeometryRecordFrom(
     Moer::GBufferPassParams
          _param, // push constant（bindless handles：instance_buf, primitive_buf, material_buf, MegaBuffers）
@@ -203,7 +207,7 @@ MaterialSample SampleGeometryMaterial(
     float4 transmission       = 0.f;
 
     // Albedo / BaseColor 纹理
-    bool has_base_color = _attribs & EMA_BaseColor && mat.albedo_map_hdl > 0;
+    bool has_base_color = _attribs & EMA_BaseColor && IsValidBindlessHandle(mat.albedo_map_hdl);
     if (has_base_color) {
         TextureHandle albedo_tex = TextureHandle(mat.albedo_map_hdl);
         if (_mip >= 0.f) {
@@ -214,7 +218,7 @@ MaterialSample SampleGeometryMaterial(
     }
 
     // Emissive 纹理
-    if (_attribs & EMA_Emissive && mat.emissive_map_hdl > 0) {
+    if (_attribs & EMA_Emissive && IsValidBindlessHandle(mat.emissive_map_hdl)) {
         TextureHandle emissive_tex = TextureHandle(mat.emissive_map_hdl);
         if (_mip >= 0.f) {
             emissive *= emissive_tex.SampleLevel<float4>(_geo_record.texcoord, _mip);
@@ -225,7 +229,7 @@ MaterialSample SampleGeometryMaterial(
     }
 
     // Normal 纹理
-    if (_attribs & EMA_Normal && mat.normal_map_hdl > 0) {
+    if (_attribs & EMA_Normal && IsValidBindlessHandle(mat.normal_map_hdl)) {
         TextureHandle normal_tex = TextureHandle(mat.normal_map_hdl);
         if (_mip >= 0.f) {
             normal = normal_tex.SampleLevel<float4>(_geo_record.texcoord, _mip);
@@ -238,7 +242,7 @@ MaterialSample SampleGeometryMaterial(
     }
 
     // MetallicRoughness 纹理
-    if (_attribs & EMA_MetalRough && mat.metallic_roughness_map_hdl > 0) {
+    if (_attribs & EMA_MetalRough && IsValidBindlessHandle(mat.metallic_roughness_map_hdl)) {
         TextureHandle metal_rough_tex = TextureHandle(mat.metallic_roughness_map_hdl);
         if (_mip >= 0.f) {
             metallic_roughness = metal_rough_tex.SampleLevel<float4>(_geo_record.texcoord, _mip);


### PR DESCRIPTION
## 背景

Related to #132。

这个问题是在排查反复切换 Renderer 相关问题时发现的。当前 PR 不声明完全修复 #132 中的 `InvalidImageLayout` / command buffer pending / semaphore pending 等同步问题，只修复 raytracing 材质采样中的一个独立错误。

## 修改内容

CPU 侧使用 `-1` 表示材质没有对应贴图。但 shader 里的材质贴图 handle 是 `uint`，因此 `-1` 会变成 `0xffffffff`。

原来的判断使用 `handle > 0`，会把 `0xffffffff` 当成有效 bindless texture index，导致 raytracing shader 继续采样无效纹理。

本 PR 增加了 `IsValidBindlessHandle()`，按有符号值判断 handle 是否有效，并应用到：

- base color
- emissive
- normal
- metallic roughness

## 验证

- `just build`