### PR TITLE
feat(raster): add tessellated surface showcase

### DIFF
--- a/shaders/pipelines/raster/deferred/geometry/TessellatedSurface.hlsl
+++ b/shaders/pipelines/raster/deferred/geometry/TessellatedSurface.hlsl
@@ -1,0 +1,301 @@
+#include "core/common/Common.hlsl"
+#include "shared/raster/ShaderParameters.h"
+
+[[vk::binding(0, 0)]] ConstantBuffer<Moer::TessellatedSurfaceData> surface_data;
+
+uint HashCell(int2 cell) {
+    uint hash = asuint(cell.x) * 0x8da6b343u;
+    hash ^= asuint(cell.y) * 0xd8163841u;
+    hash ^= hash >> 16u;
+    hash *= 0x7feb352du;
+    hash ^= hash >> 15u;
+    hash *= 0x846ca68bu;
+    return hash ^ (hash >> 16u);
+}
+
+float2 Gradient2D(int2 cell) {
+    switch (HashCell(cell) & 7u) {
+        case 0u: return float2(1.0, 0.0);
+        case 1u: return float2(-1.0, 0.0);
+        case 2u: return float2(0.0, 1.0);
+        case 3u: return float2(0.0, -1.0);
+        case 4u: return float2(0.70710678, 0.70710678);
+        case 5u: return float2(-0.70710678, 0.70710678);
+        case 6u: return float2(0.70710678, -0.70710678);
+        default: return float2(-0.70710678, -0.70710678);
+    }
+}
+
+float Quintic(float value) {
+    return value * value * value * (value * (value * 6.0 - 15.0) + 10.0);
+}
+
+float Noise2D(float2 position) {
+    int2  cell     = int2(floor(position));
+    float2 local   = position - float2(cell);
+    float2 blended = float2(Quintic(local.x), Quintic(local.y));
+
+    float n00 = dot(Gradient2D(cell + int2(0, 0)), local - float2(0.0, 0.0));
+    float n10 = dot(Gradient2D(cell + int2(1, 0)), local - float2(1.0, 0.0));
+    float n01 = dot(Gradient2D(cell + int2(0, 1)), local - float2(0.0, 1.0));
+    float n11 = dot(Gradient2D(cell + int2(1, 1)), local - float2(1.0, 1.0));
+
+    return lerp(lerp(n00, n10, blended.x), lerp(n01, n11, blended.x), blended.y) * 1.41421356;
+}
+
+float Fbm3(float2 position) {
+    float value     = 0.0;
+    float amplitude = 1.0;
+    float weight    = 0.0;
+
+    [unroll]
+    for (uint octave = 0u; octave < 3u; ++octave) {
+        value += Noise2D(position) * amplitude;
+        weight += amplitude;
+        position = position * 1.93 + float2(17.17, 9.23);
+        amplitude *= 0.48;
+    }
+    return value / weight;
+}
+
+float2 ToWindSpace(float2 world_xz) {
+    float2 wind = normalize(surface_data.wind_and_normal.xy);
+    float2 cross_wind = float2(-wind.y, wind.x);
+    return float2(dot(world_xz, wind), dot(world_xz, cross_wind));
+}
+
+float EvaluateSurfaceHeight(float2 world_xz) {
+    float2 wind_position = ToWindSpace(world_xz);
+    float  macro_noise   = Fbm3(wind_position * surface_data.displacement.z);
+    float  height        = 0.0;
+
+    if (surface_data.grid_and_options.z == 0u) {
+        float warped_phase =
+            wind_position.x * 0.82 + macro_noise * surface_data.wind_and_normal.z;
+        float dune_wave = sin(warped_phase) + 0.25 * sin(2.0 * warped_phase + 0.6);
+        dune_wave /= 1.25;
+
+        float detail_phase =
+            wind_position.x * surface_data.displacement.w +
+            0.45 * sin(wind_position.y * 0.31);
+        float detail_wave = sin(detail_phase) + 0.18 * sin(2.0 * detail_phase + 1.2);
+        detail_wave /= 1.18;
+
+        float shape = 0.42 * macro_noise + 0.58 * dune_wave;
+        height = surface_data.displacement.x * (0.68 + 0.52 * shape) +
+                 surface_data.displacement.y * detail_wave;
+    } else {
+        float smooth_detail = Noise2D(
+            wind_position * surface_data.displacement.w + float2(23.4, 41.7)
+        );
+        height = surface_data.displacement.x * (0.72 + 0.36 * macro_noise) +
+                 surface_data.displacement.y * smooth_detail;
+    }
+
+    float extent = max(surface_data.surface_origin_extent.w, 1e-3);
+    float2 normalized_from_center = abs(
+        (world_xz - surface_data.surface_origin_extent.xz) / extent
+    );
+    float edge_distance = max(normalized_from_center.x, normalized_from_center.y);
+    return height * (1.0 - smoothstep(0.88, 1.0, edge_distance));
+}
+
+struct SurfaceControlPoint {
+    precise float3 world_position : POSITION;
+};
+
+struct SurfacePatchConstants {
+    float edge_tessellation[3] : SV_TessFactor;
+    float inside_tessellation  : SV_InsideTessFactor;
+};
+
+struct SurfaceDomainOutput {
+    float4 position       : SV_POSITION;
+    float3 world_position : TEXCOORD0;
+    float3 world_normal   : NORMAL;
+    nointerpolation float tessellation_factor : TEXCOORD1;
+};
+
+SurfaceControlPoint SurfaceVS(uint vertex_id : SV_VertexID, uint instance_id : SV_InstanceID) {
+    uint grid_x = max(surface_data.grid_and_options.x, 1u);
+    uint grid_z = max(surface_data.grid_and_options.y, 1u);
+
+    uint cell_x = instance_id % grid_x;
+    uint cell_z = instance_id / grid_x;
+
+    float extent = surface_data.surface_origin_extent.w;
+    float2 cell_size = (2.0 * extent) / float2(grid_x, grid_z);
+    float2 minimum_xz = surface_data.surface_origin_extent.xz - extent;
+
+    uint2 corner = uint2(0u, 0u);
+    switch (vertex_id) {
+        case 0u: corner = uint2(0u, 0u); break;
+        case 1u: corner = uint2(1u, 1u); break;
+        case 2u: corner = uint2(1u, 0u); break;
+        case 3u: corner = uint2(0u, 0u); break;
+        case 4u: corner = uint2(0u, 1u); break;
+        default: corner = uint2(1u, 1u); break;
+    }
+
+    float2 world_xz = minimum_xz + (float2(cell_x, cell_z) + float2(corner)) * cell_size;
+
+    SurfaceControlPoint output;
+    output.world_position = float3(
+        world_xz.x,
+        surface_data.surface_origin_extent.y,
+        world_xz.y
+    );
+    return output;
+}
+
+float EdgeTessellationFactor(float3 endpoint_a, float3 endpoint_b) {
+    float3 midpoint = 0.5 * (endpoint_a + endpoint_b);
+    float edge_length = length(endpoint_b - endpoint_a);
+    float maximum_height_delta =
+        abs(surface_data.displacement.x) * 1.25 + abs(surface_data.displacement.y);
+    float maximum_slope =
+        abs(surface_data.displacement.x) * surface_data.displacement.z * 6.0 +
+        abs(surface_data.displacement.y) * surface_data.displacement.w * 2.5;
+    float vertical_span = min(maximum_height_delta, edge_length * maximum_slope);
+    float radius = 0.5 * sqrt(edge_length * edge_length + vertical_span * vertical_span) +
+                   abs(surface_data.displacement.y);
+
+    float distance_to_edge = max(
+        length(midpoint - surface_data.camera_position_tan_half_fov.xyz) - radius,
+        0.1
+    );
+    float tan_half_fov = max(surface_data.camera_position_tan_half_fov.w, 1e-3);
+    float projected_diameter_pixels =
+        radius * surface_data.viewport_tessellation.y / (tan_half_fov * distance_to_edge);
+    float target_pixels = max(surface_data.viewport_tessellation.z, 1.0);
+    float factor = projected_diameter_pixels / target_pixels;
+
+    float minimum_factor = max(surface_data.color_high_min_tessellation.w, 2.0);
+    float maximum_factor = max(surface_data.viewport_tessellation.w, minimum_factor);
+    return clamp(factor, minimum_factor, maximum_factor);
+}
+
+SurfacePatchConstants SurfacePatch(
+    InputPatch<SurfaceControlPoint, 3> patch,
+    uint patch_id : SV_PrimitiveID
+) {
+    SurfacePatchConstants output;
+    output.edge_tessellation[0] = EdgeTessellationFactor(
+        patch[1].world_position,
+        patch[2].world_position
+    );
+    output.edge_tessellation[1] = EdgeTessellationFactor(
+        patch[2].world_position,
+        patch[0].world_position
+    );
+    output.edge_tessellation[2] = EdgeTessellationFactor(
+        patch[0].world_position,
+        patch[1].world_position
+    );
+    output.inside_tessellation = max(
+        output.edge_tessellation[0],
+        max(output.edge_tessellation[1], output.edge_tessellation[2])
+    );
+    return output;
+}
+
+[domain("tri")]
+[partitioning("fractional_even")]
+[outputtopology("triangle_ccw")]
+[outputcontrolpoints(3)]
+[patchconstantfunc("SurfacePatch")]
+[maxtessfactor(64.0)]
+SurfaceControlPoint SurfaceHS(
+    InputPatch<SurfaceControlPoint, 3> patch,
+    uint control_point_id : SV_OutputControlPointID,
+    uint patch_id : SV_PrimitiveID
+) {
+    return patch[control_point_id];
+}
+
+[domain("tri")]
+SurfaceDomainOutput SurfaceDS(
+    SurfacePatchConstants patch_constants,
+    const OutputPatch<SurfaceControlPoint, 3> patch,
+    float3 barycentric : SV_DomainLocation
+) {
+    precise float3 base_position =
+        patch[0].world_position * barycentric.x +
+        patch[1].world_position * barycentric.y +
+        patch[2].world_position * barycentric.z;
+
+    float2 world_xz = base_position.xz;
+    float height = EvaluateSurfaceHeight(world_xz);
+    float epsilon = max(surface_data.wind_and_normal.w, 1e-3);
+    float height_x = EvaluateSurfaceHeight(world_xz + float2(epsilon, 0.0));
+    float height_z = EvaluateSurfaceHeight(world_xz + float2(0.0, epsilon));
+
+    float3 tangent_x = float3(epsilon, height_x - height, 0.0);
+    float3 tangent_z = float3(0.0, height_z - height, epsilon);
+    float3 world_normal = normalize(cross(tangent_z, tangent_x));
+    float3 world_position = float3(world_xz.x, base_position.y + height, world_xz.y);
+
+    SurfaceDomainOutput output;
+    output.position = mul(surface_data.world2clip, float4(world_position, 1.0));
+    output.world_position = world_position;
+    output.world_normal = world_normal;
+    output.tessellation_factor =
+        (patch_constants.edge_tessellation[0] +
+         patch_constants.edge_tessellation[1] +
+         patch_constants.edge_tessellation[2] +
+         patch_constants.inside_tessellation) * 0.25;
+    return output;
+}
+
+struct SurfacePixelOutput {
+    float4 base_color     : SV_TARGET0;
+    float4 normal         : SV_TARGET1;
+    float4 metal_rough_ao : SV_TARGET2;
+};
+
+float3 TessellationHeatmap(float normalized_factor) {
+    float3 cold = float3(0.05, 0.20, 0.95);
+    float3 mid  = float3(0.05, 0.95, 0.35);
+    float3 hot  = float3(0.95, 0.12, 0.03);
+    return normalized_factor < 0.5
+        ? lerp(cold, mid, normalized_factor * 2.0)
+        : lerp(mid, hot, normalized_factor * 2.0 - 1.0);
+}
+
+SurfacePixelOutput SurfacePS(SurfaceDomainOutput input) {
+    float3 normal = normalize(input.world_normal);
+    float amplitude = max(abs(surface_data.displacement.x), 1e-3);
+    float relative_height = saturate(
+        (input.world_position.y - surface_data.surface_origin_extent.y) / (amplitude * 1.25)
+    );
+    float flatness = saturate(normal.y);
+    float color_blend = surface_data.grid_and_options.z == 0u
+        ? saturate(0.25 + 0.60 * relative_height + 0.15 * flatness)
+        : saturate(0.15 + 0.85 * flatness);
+    float3 surface_color = lerp(
+        surface_data.color_low_roughness.xyz,
+        surface_data.color_high_min_tessellation.xyz,
+        color_blend
+    );
+
+    uint debug_mode = surface_data.grid_and_options.w;
+    if (debug_mode == 1u) {
+        float minimum_factor = max(surface_data.color_high_min_tessellation.w, 2.0);
+        float maximum_factor = max(surface_data.viewport_tessellation.w, minimum_factor + 1e-3);
+        float normalized_factor = saturate(
+            (input.tessellation_factor - minimum_factor) /
+            (maximum_factor - minimum_factor)
+        );
+        surface_color = TessellationHeatmap(normalized_factor);
+    } else if (debug_mode == 2u) {
+        surface_color = normal * 0.5 + 0.5;
+    } else if (debug_mode == 3u) {
+        surface_color = relative_height.xxx;
+    }
+
+    SurfacePixelOutput output;
+    output.base_color = float4(surface_color, 0.0);
+    output.normal = float4(Raster::PackNormal(normal), 1.0);
+    output.metal_rough_ao = float4(0.0, surface_data.color_low_roughness.w, 1.0, 0.0);
+    return output;
+}

--- a/source/editor/raster_ui/RasterUI.cpp
+++ b/source/editor/raster_ui/RasterUI.cpp
@@ -186,6 +186,118 @@ void RasterUI::ShowConfig() {
         ImGui::TreePop();
     }
 
+    // MARK: Hardware Tessellation Showcase
+    if (ImGui::TreeNode(
+            "Tessellated Surface",
+            "Tessellated Surface: [%s]",
+            m_config.tessellated_surface_enabled ? "Enable" : "Disable"
+        )) {
+        ImGui::Checkbox("Enable Surface", &m_config.tessellated_surface_enabled);
+
+        ImGui::BeginDisabled(!m_config.tessellated_surface_enabled);
+
+        static constexpr const char* preset_names[] = {
+            "Sand Dunes",
+            "Snow Field"
+        };
+        ImGui::Combo(
+            "Surface Preset",
+            &m_config.tessellated_surface_preset,
+            preset_names,
+            2
+        );
+
+        static constexpr const char* debug_mode_names[] = {
+            "Material",
+            "Tess Factor Heatmap",
+            "World Normal",
+            "Height"
+        };
+        ImGui::Combo(
+            "Surface Debug",
+            &m_config.tessellated_surface_debug_mode,
+            debug_mode_names,
+            4
+        );
+
+        ImGui::DragFloat3(
+            "Surface Center",
+            reinterpret_cast<float*>(&m_config.tessellated_surface_center),
+            0.05f
+        );
+        ImGui::SliderFloat(
+            "Half Extent (m)",
+            &m_config.tessellated_surface_half_extent,
+            0.5f,
+            40.0f
+        );
+        ImGui::SliderInt(
+            "Base Grid",
+            &m_config.tessellated_surface_grid_resolution,
+            2,
+            64,
+            "%d cells/axis"
+        );
+        ImGui::SliderFloat(
+            "Target Edge (px)",
+            &m_config.tessellated_surface_target_edge_pixels,
+            2.0f,
+            32.0f
+        );
+        ImGui::SliderFloat(
+            "Min Tess Factor",
+            &m_config.tessellated_surface_min_tess_factor,
+            2.0f,
+            m_config.tessellated_surface_max_tess_factor
+        );
+        ImGui::SliderFloat(
+            "Max Tess Factor",
+            &m_config.tessellated_surface_max_tess_factor,
+            m_config.tessellated_surface_min_tess_factor,
+            64.0f
+        );
+        ImGui::SliderFloat(
+            "Height Scale",
+            &m_config.tessellated_surface_height_scale,
+            0.0f,
+            3.0f
+        );
+        ImGui::SliderFloat(
+            "Detail Scale",
+            &m_config.tessellated_surface_detail_scale,
+            0.0f,
+            3.0f
+        );
+        ImGui::SliderFloat(
+            "Wind Angle",
+            &m_config.tessellated_surface_wind_angle_degrees,
+            -180.0f,
+            180.0f,
+            "%.0f deg"
+        );
+
+        if (ImGui::Button("Reset Surface Settings")) {
+            m_config.tessellated_surface_preset             = 0;
+            m_config.tessellated_surface_debug_mode         = 0;
+            m_config.tessellated_surface_grid_resolution    = 16;
+            m_config.tessellated_surface_center             = float3(0.0f, 0.04f, 0.0f);
+            m_config.tessellated_surface_half_extent        = 8.0f;
+            m_config.tessellated_surface_target_edge_pixels = 8.0f;
+            m_config.tessellated_surface_min_tess_factor    = 2.0f;
+            m_config.tessellated_surface_max_tess_factor    = 32.0f;
+            m_config.tessellated_surface_height_scale       = 1.0f;
+            m_config.tessellated_surface_detail_scale       = 1.0f;
+            m_config.tessellated_surface_wind_angle_degrees = 18.0f;
+        }
+
+        ImGui::TextDisabled(
+            "Triangle patches: VS -> HS -> DS -> PS. The showcase receives scene shadows but is not yet a CSM caster."
+        );
+
+        ImGui::EndDisabled();
+        ImGui::TreePop();
+    }
+
     // MARK: Shading
     if (ImGui::TreeNode(
             "Shading", "Shading: [%s]", s_shading_mode_name_map.at(m_config.shading_mode).c_str()

--- a/source/runtime/render/renderer/raster/RasterConfig.h
+++ b/source/runtime/render/renderer/raster/RasterConfig.h
@@ -158,6 +158,21 @@ struct RasterConfig {
     // Debug 可视化模式：0=关闭，1=Cluster ID，2=frac(UV)，3=顶点法线
     int   geometry_debug_visualization           = 0;
 
+    // MARK: Procedural Tessellated Surface
+    // Opt-in showcase for the VS -> HS -> DS -> PS hardware tessellation path.
+    bool   tessellated_surface_enabled             = false;
+    int    tessellated_surface_preset              = 0; // 0=sand dunes, 1=snow field
+    int    tessellated_surface_debug_mode          = 0; // 0=material, 1=tess factor, 2=normal, 3=height
+    int    tessellated_surface_grid_resolution     = 16;
+    float3 tessellated_surface_center              = float3(0.0f, 0.04f, 0.0f);
+    float  tessellated_surface_half_extent         = 8.0f;
+    float  tessellated_surface_target_edge_pixels  = 8.0f;
+    float  tessellated_surface_min_tess_factor     = 2.0f;
+    float  tessellated_surface_max_tess_factor     = 32.0f;
+    float  tessellated_surface_height_scale        = 1.0f;
+    float  tessellated_surface_detail_scale        = 1.0f;
+    float  tessellated_surface_wind_angle_degrees  = 18.0f;
+
     // MARK: Culling Statistics (只读，由GPU更新)
     struct CullingStats {
         uint total_instances_before     = 0;

--- a/source/runtime/render/renderer/raster/RasterRenderer.cpp
+++ b/source/runtime/render/renderer/raster/RasterRenderer.cpp
@@ -10,6 +10,7 @@
 #include "CsmGizmoPass.h"
 #include "DirectionalShadowMaskPass.h"
 #include "GeometryPass.h"
+#include "TessellatedSurfacePass.h"
 #include "HiZBuildPass.h"
 #include "LightingPass.h"
 #include "ProbeGizmoPass.h"
@@ -95,6 +96,7 @@ RasterRenderer::RasterRenderer(
     probe_gizmo_pass             = MakeUnique<ProbeGizmoPass>(raster_context);
     camera_gizmo_pass            = MakeUnique<CameraGizmoPass>(raster_context);
     geometry_pass                = MakeUnique<GeometryPass>(raster_context);
+    tessellated_surface_pass     = MakeUnique<TessellatedSurfacePass>(raster_context);
     lighting_pass                = MakeUnique<LightingPass>(raster_context);
     skybox_pass                  = MakeUnique<SkyboxPass>(raster_context);
     ao_pass                      = MakeUnique<AoPass>(raster_context);
@@ -663,6 +665,18 @@ RasterFrameFeedback RasterRenderer::RenderFrame(RasterFramePacket frame_packet) 
                     cmd_list.PushScopeWithTimeScope(RasterTool::GetGeometryPassProfileScopeName());
                     geometry_pass->Process(raster_context, raster_config, camera);
                     cmd_list.PopScopeWithTimeScope();
+                }
+            );
+            schedule(
+                "TessellatedSurface",
+                [&](RenderGraph::PassBuilder& builder) {
+                    builder.ReadWrite(graph_resources.base_color)
+                        .ReadWrite(graph_resources.normal)
+                        .ReadWrite(graph_resources.metal_rough_ao)
+                        .ReadWrite(graph_resources.depth);
+                },
+                [&]() {
+                    tessellated_surface_pass->Process(raster_context, raster_config, camera);
                 }
             );
             schedule(

--- a/source/runtime/render/renderer/raster/RasterRenderer.h
+++ b/source/runtime/render/renderer/raster/RasterRenderer.h
@@ -14,6 +14,7 @@ class RasterContext;
 class HiZBuildPass;
 class ShadowDepthPass;
 class GeometryPass;
+class TessellatedSurfacePass;
 class CsmGizmoPass;
 class DirectionalShadowMaskPass;
 class ProbeUpdatePass;
@@ -79,6 +80,7 @@ private:
     UniquePtr<ProbeGizmoPass>              probe_gizmo_pass;
     UniquePtr<CameraGizmoPass>             camera_gizmo_pass;
     UniquePtr<GeometryPass>                geometry_pass;
+    UniquePtr<TessellatedSurfacePass>      tessellated_surface_pass;
     UniquePtr<LightingPass>                lighting_pass;
     UniquePtr<SkyboxPass>                  skybox_pass;
     UniquePtr<AoPass>                      ao_pass;

--- a/source/runtime/render/renderer/raster/TessellatedSurfacePass.cpp
+++ b/source/runtime/render/renderer/raster/TessellatedSurfacePass.cpp
@@ -1,0 +1,229 @@
+#include "TessellatedSurfacePass.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstring>
+
+namespace Moer::Render::Raster {
+namespace {
+
+constexpr std::string_view kSurfaceShaderPath =
+    "pipelines/raster/deferred/geometry/TessellatedSurface.hlsl";
+// Matches the tested 16x16 grid at factor 64. Higher grid resolutions automatically receive a
+// lower factor cap so UI combinations cannot grow tessellation work quadratically into a TDR.
+constexpr uint64_t kSurfaceTriangleBudget = 2ull * 16ull * 16ull * 64ull * 64ull;
+
+struct SurfacePreset {
+    float  macro_amplitude;
+    float  detail_amplitude;
+    float  macro_frequency;
+    float  detail_frequency;
+    float  warp_strength;
+    float  normal_epsilon;
+    float4 low_color_roughness;
+    float4 high_color;
+};
+
+SurfacePreset GetPreset(int preset) {
+    if (preset == 1) {
+        return SurfacePreset{
+            .macro_amplitude    = 0.38f,
+            .detail_amplitude   = 0.025f,
+            .macro_frequency    = 0.12f,
+            .detail_frequency   = 0.85f,
+            .warp_strength      = 0.35f,
+            .normal_epsilon     = 0.06f,
+            .low_color_roughness = float4(0.58f, 0.70f, 0.84f, 0.68f),
+            .high_color         = float4(0.98f, 0.99f, 1.0f, 0.0f)
+        };
+    }
+
+    return SurfacePreset{
+        .macro_amplitude    = 0.85f,
+        .detail_amplitude   = 0.06f,
+        .macro_frequency    = 0.09f,
+        .detail_frequency   = 1.20f,
+        .warp_strength      = 1.25f,
+        .normal_epsilon     = 0.08f,
+        .low_color_roughness = float4(0.43f, 0.18f, 0.045f, 0.82f),
+        .high_color         = float4(0.95f, 0.67f, 0.27f, 0.0f)
+    };
+}
+
+} // namespace
+
+TessellatedSurfacePass::TessellatedSurfacePass(RasterContext& context) {
+    if (!context.device.SupportsTessellation()) {
+        LOG_WARNING(
+            "[TessellatedSurface] Device does not support hardware tessellation; the showcase pass is disabled."
+        );
+        return;
+    }
+
+    device_max_tessellation_factor = context.device.GetMaxTessellationFactor();
+    if (device_max_tessellation_factor < 2u) {
+        LOG_WARNING(
+            "[TessellatedSurface] Invalid device tessellation limit {}; the showcase pass is disabled.",
+            device_max_tessellation_factor
+        );
+        return;
+    }
+
+    surface_data_buffer = context.device.CreateBuffer<byte>(
+        "Raster::TessellatedSurfaceData",
+        sizeof(TessellatedSurfaceData),
+        EBufferUsageFlags::UNORDERED_ACCESS | EBufferUsageFlags::CONSTANT_BUFFER
+    );
+
+    GfxPsoCreateInfo pipeline_info(
+        RHIRasterizeInfo::Preset(),
+        {},
+        {
+            RHIColorAttachmentInfo::Preset(PF_R8G8B8A8_UNORM),
+            RHIColorAttachmentInfo::Preset(PF_A2R10G10B10_UNORM_PACK32),
+            RHIColorAttachmentInfo::Preset(PF_R8G8B8A8_UNORM)
+        },
+        RHIDepthStencilStateInfo::Preset<DepthStencil::DEPTH_WRITE_GREATER>(),
+        context.textures.depth_linear_sampler.tex->GetFormat(),
+        EPrimitiveTopology::PATCH_LIST
+    );
+    pipeline_info.patch_control_points = 3;
+
+    pipeline = context.manager.Raster()
+                   .Vertex(kSurfaceShaderPath, "SurfaceVS")
+                   .Hull(kSurfaceShaderPath, "SurfaceHS")
+                   .Domain(kSurfaceShaderPath, "SurfaceDS")
+                   .Pixel(kSurfaceShaderPath, "SurfacePS")
+                   .Build<TessellatedSurfacePipeline>(std::move(pipeline_info));
+
+    supported = pipeline.handle.IsValid();
+    LOG_INFO(
+        "[TessellatedSurface] Hardware tessellation showcase {} (device max factor {}).",
+        supported ? "ready" : "failed to create a pipeline",
+        device_max_tessellation_factor
+    );
+}
+
+void TessellatedSurfacePass::Process(
+    RasterContext&     context,
+    const RasterConfig& config,
+    const Camera&       camera
+) {
+    if (!supported || !config.tessellated_surface_enabled) {
+        return;
+    }
+
+    const uint32_t grid_resolution = static_cast<uint32_t>(
+        std::clamp(config.tessellated_surface_grid_resolution, 1, 64)
+    );
+    const float half_extent = std::max(config.tessellated_surface_half_extent, 0.25f);
+    const uint64_t patch_count = 2ull * grid_resolution * grid_resolution;
+    const float budget_factor_limit = std::max(
+        2.0f,
+        std::floor(std::sqrt(static_cast<float>(kSurfaceTriangleBudget) / patch_count))
+    );
+    const float maximum_tessellation = std::clamp(
+        config.tessellated_surface_max_tess_factor,
+        2.0f,
+        std::min(static_cast<float>(device_max_tessellation_factor), budget_factor_limit)
+    );
+    const float minimum_tessellation = std::clamp(
+        config.tessellated_surface_min_tess_factor,
+        2.0f,
+        maximum_tessellation
+    );
+
+    const int preset_index = std::clamp(config.tessellated_surface_preset, 0, 1);
+    const SurfacePreset preset = GetPreset(preset_index);
+    const float height_scale = std::max(config.tessellated_surface_height_scale, 0.0f);
+    const float detail_scale = std::max(config.tessellated_surface_detail_scale, 0.0f);
+    const float wind_radians =
+        config.tessellated_surface_wind_angle_degrees * 3.14159265358979323846f / 180.0f;
+    const Vector3f camera_position = camera.GetPosition();
+    const uint2 resolution = context.GetResolution();
+
+    TessellatedSurfaceData data{};
+    data.world2clip = Transpose(camera.GetViewProjectionMatrix());
+    data.camera_position_tan_half_fov = float4(
+        camera_position.x,
+        camera_position.y,
+        camera_position.z,
+        camera.GetTanHalfFov()
+    );
+    data.viewport_tessellation = float4(
+        static_cast<float>(resolution.x),
+        static_cast<float>(resolution.y),
+        std::max(config.tessellated_surface_target_edge_pixels, 1.0f),
+        maximum_tessellation
+    );
+    data.surface_origin_extent = float4(
+        config.tessellated_surface_center.x,
+        config.tessellated_surface_center.y,
+        config.tessellated_surface_center.z,
+        half_extent
+    );
+    data.displacement = float4(
+        preset.macro_amplitude * height_scale,
+        preset.detail_amplitude * detail_scale,
+        preset.macro_frequency,
+        preset.detail_frequency
+    );
+    data.wind_and_normal = float4(
+        std::cos(wind_radians),
+        std::sin(wind_radians),
+        preset.warp_strength,
+        preset.normal_epsilon
+    );
+    data.color_low_roughness = preset.low_color_roughness;
+    data.color_high_min_tessellation = float4(
+        preset.high_color.x,
+        preset.high_color.y,
+        preset.high_color.z,
+        minimum_tessellation
+    );
+    data.grid_and_options = uint4(
+        grid_resolution,
+        grid_resolution,
+        static_cast<uint32_t>(preset_index),
+        static_cast<uint32_t>(std::clamp(config.tessellated_surface_debug_mode, 0, 3))
+    );
+
+    Array<byte> upload(sizeof(TessellatedSurfaceData));
+    std::memcpy(upload.data(), &data, sizeof(TessellatedSurfaceData));
+    context.cmd_list.CopyFrom(std::move(upload), surface_data_buffer->GetView());
+
+    DepthAttachment depth_attachment(context.textures.depth_linear_sampler.tex->GetView());
+    depth_attachment.action = EAttachmentAction::AC_DS_LOAD_STORE_DEPTH;
+
+    const auto render_area = context.textures.base_color.GetRect2D();
+    Array<SingleDrawParam> draw_params{
+        SingleDrawParam{6u, grid_resolution * grid_resolution, 0u, 0u, 0u}
+    };
+
+    context.cmd_list.PushScopeWithTimeScope("Tessellated Surface");
+    context.cmd_list.Gfx(pipeline, surface_data_buffer->GetView())
+        .Draw(
+            "Tessellated Surface Pass",
+            render_area,
+            std::move(draw_params),
+            depth_attachment,
+            ColorAttachment{
+                context.textures.base_color.tex,
+                EAttachmentAction::AC_LOAD_STORE,
+                float4(0.0f, 0.0f, 0.0f, 0.0f)
+            },
+            ColorAttachment{
+                context.textures.normal.tex,
+                EAttachmentAction::AC_LOAD_STORE,
+                float4(0.0f, 0.0f, 0.0f, 0.0f)
+            },
+            ColorAttachment{
+                context.textures.metal_rough_ao.tex,
+                EAttachmentAction::AC_LOAD_STORE,
+                float4(0.0f, 0.0f, 0.0f, 0.0f)
+            }
+        );
+    context.cmd_list.PopScopeWithTimeScope();
+}
+
+} // namespace Moer::Render::Raster

--- a/source/runtime/render/renderer/raster/TessellatedSurfacePass.h
+++ b/source/runtime/render/renderer/raster/TessellatedSurfacePass.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include "RasterConfig.h"
+#include "RasterResource.h"
+#include "scene/camera/Camera.h"
+#include "shader/ShaderPipeline.h"
+#include "shaderheaders/shared/raster/tessellated_surface/ShaderParameters.h"
+
+namespace Moer::Render::Raster {
+
+class TessellatedSurfacePipeline : public RasterPipeline {
+public:
+    DEFINE_RASTER_PIPELINE_CLASS(TessellatedSurfacePipeline);
+    DEFINE_SHADER_BUFFER(surface_data);
+    DEFINE_SHADER_ARGS(surface_data);
+};
+
+class TessellatedSurfacePass {
+public:
+    explicit TessellatedSurfacePass(RasterContext& context);
+
+    void Process(RasterContext& context, const RasterConfig& config, const Camera& camera);
+
+    bool IsSupported() const {
+        return supported;
+    }
+
+private:
+    TessellatedSurfacePipeline pipeline;
+    BufferRef                  surface_data_buffer;
+    uint32_t                   device_max_tessellation_factor = 0;
+    bool                       supported                      = false;
+};
+
+} // namespace Moer::Render::Raster

--- a/source/runtime/render/rhi/RHI.h
+++ b/source/runtime/render/rhi/RHI.h
@@ -181,6 +181,9 @@ public:
         return rhi_type;
     }
 
+    RENDER_API bool SupportsTessellation() const;
+    RENDER_API uint32_t GetMaxTessellationFactor() const;
+
     RENDER_API PipelineHandle
     CreatePipeline(GfxPsoCreateInfo&& _pso_info, PipelineShaderInfo&& _shaders); //gfx
     RENDER_API PipelineHandle CreatePipeline(PipelineShaderInfo&& _shaders);     //compute

--- a/source/runtime/render/rhi/RHICommon.h
+++ b/source/runtime/render/rhi/RHICommon.h
@@ -743,6 +743,10 @@ enum EShaderType : uint8_t {
     ST_RAY_CALLABLE,
     ST_RAY_INTERSECTION,
     ST_RAY_ANYHIT,
+    // Keep new shader stages after the existing serialized values. Shader cache entries persist
+    // the numeric EShaderType value, so inserting stages above would reinterpret old cache data.
+    ST_HULL,
+    ST_DOMAIN,
     ST_Num,
     ST_NumBits = 4
 };

--- a/source/runtime/render/rhi/RHIImpl.cpp
+++ b/source/runtime/render/rhi/RHIImpl.cpp
@@ -114,6 +114,14 @@ const EShaderPlatform RenderDevice::GetShaderPlatform() const {
     }
 }
 
+bool RenderDevice::SupportsTessellation() const {
+    return impl && impl->SupportsTessellation();
+}
+
+uint32_t RenderDevice::GetMaxTessellationFactor() const {
+    return impl ? impl->GetMaxTessellationFactor() : 0;
+}
+
 RaytracingGeometryRef RenderDevice::CreateRaytracingGeometry(const RaytracingGeometryInfo& _init) {
     return impl->CreateRaytracingGeometry(_init);
 }

--- a/source/runtime/render/rhi/RHIImpl.h
+++ b/source/runtime/render/rhi/RHIImpl.h
@@ -1701,6 +1701,14 @@ public:
         ; // do nothing by default
     }
 
+    virtual bool SupportsTessellation() const {
+        return false;
+    }
+
+    virtual uint32_t GetMaxTessellationFactor() const {
+        return 0;
+    }
+
     virtual bool IsExtensionCooperativeEnabled() const {
         return false;
     }

--- a/source/runtime/render/rhi/RHIResource.h
+++ b/source/runtime/render/rhi/RHIResource.h
@@ -1107,6 +1107,13 @@ struct ShaderVsPs {
     SingleShaderInfo ps;
 };
 
+struct ShaderVsHsDsPs {
+    SingleShaderInfo vs;
+    SingleShaderInfo hs;
+    SingleShaderInfo ds;
+    SingleShaderInfo ps;
+};
+
 struct ShaderMsPs {
     SingleShaderInfo ms;
     SingleShaderInfo ps;
@@ -1144,7 +1151,7 @@ struct ShaderArgCppInfo {
 };
 
 using ShaderOutputGroup =
-    std::variant<ShaderVsGsPs, ShaderVsPs, ShaderMsPs, ShaderTsMsPs, ShaderCs, ShaderRT>;
+    std::variant<ShaderVsGsPs, ShaderVsPs, ShaderVsHsDsPs, ShaderMsPs, ShaderTsMsPs, ShaderCs, ShaderRT>;
 
 struct PipelineShaderInfo {
     ShaderOutputGroup       shader_group;
@@ -1198,12 +1205,20 @@ struct GfxPsoCreateInfo {
         shading_rate(VSR_1_1x1),
         hash_key(0) {}
 
+    GfxPsoCreateInfo& SetPatchControlPoints(uint32_t control_points) {
+        patch_control_points = control_points;
+        return *this;
+    }
+
     RHIRasterizeInfo         rasterizer_info;
     VertexStream             vertex_stream;
     RHIMultisampleStateInfo  multisample_info;
     RHIDepthStencilStateInfo depth_stencil_info;
 
     EPrimitiveTopology primitive_topology;
+    // Required when primitive_topology is PATCH_LIST. Kept explicit instead of assuming triangle
+    // patches so the RHI contract remains valid for future isoline/quad tessellation passes.
+    uint32_t patch_control_points = 0;
 
     EPixelFormat                  depth_stencil_format;
     Array<RHIColorAttachmentInfo> color_attachments_info;

--- a/source/runtime/render/rhi/vulkan/VulkanDevice.cpp
+++ b/source/runtime/render/rhi/vulkan/VulkanDevice.cpp
@@ -1656,6 +1656,31 @@ static void MergeReflectInfo(
 
 PipelineHandle
 VulkanDevice::CreatePipeline(GfxPsoCreateInfo&& _create_info, PipelineShaderInfo&& _shader_info) {
+    const bool uses_tessellation = std::holds_alternative<ShaderVsHsDsPs>(_shader_info.shader_group);
+    if (uses_tessellation) {
+        const uint32_t patch_control_points = _create_info.patch_control_points;
+        const uint32_t max_patch_size = m_device_info.core_properties.core_1_0.limits.maxTessellationPatchSize;
+        if (!SupportsTessellation()) {
+            LOG_ERROR("Cannot create tessellation pipeline: the Vulkan device does not support tessellation shaders.");
+            return {};
+        }
+        if (_create_info.primitive_topology != EPrimitiveTopology::PATCH_LIST) {
+            LOG_ERROR("Cannot create tessellation pipeline: primitive topology must be PATCH_LIST.");
+            return {};
+        }
+        if (patch_control_points == 0 || patch_control_points > max_patch_size) {
+            LOG_ERROR(
+                "Cannot create tessellation pipeline: patch control point count {} is outside [1, {}].",
+                patch_control_points,
+                max_patch_size
+            );
+            return {};
+        }
+    } else if (_create_info.primitive_topology == EPrimitiveTopology::PATCH_LIST) {
+        LOG_ERROR("Cannot create PATCH_LIST pipeline without Hull and Domain shaders.");
+        return {};
+    }
+
     VulkanPipelineState* vk_pso = MoerNew(VulkanPipelineState)(this, VulkanPipelineState::GFX);
 
     uint32_t attachment_count = _create_info.color_attachment_count;
@@ -1783,6 +1808,17 @@ VulkanDevice::CreatePipeline(GfxPsoCreateInfo&& _create_info, PipelineShaderInfo
                 merge_reflect_info(_shader_info_group.gs, VK_SHADER_STAGE_GEOMETRY_BIT);
                 merge_reflect_info(_shader_info_group.ps, VK_SHADER_STAGE_FRAGMENT_BIT);
             },
+            [&](const ShaderVsHsDsPs& _shader_info_group) {
+                shader_stages.reserve(4);
+                emplace_shader(_shader_info_group.vs, VK_SHADER_STAGE_VERTEX_BIT);
+                emplace_shader(_shader_info_group.hs, VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT);
+                emplace_shader(_shader_info_group.ds, VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT);
+                emplace_shader(_shader_info_group.ps, VK_SHADER_STAGE_FRAGMENT_BIT);
+                merge_reflect_info(_shader_info_group.vs, VK_SHADER_STAGE_VERTEX_BIT);
+                merge_reflect_info(_shader_info_group.hs, VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT);
+                merge_reflect_info(_shader_info_group.ds, VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT);
+                merge_reflect_info(_shader_info_group.ps, VK_SHADER_STAGE_FRAGMENT_BIT);
+            },
             [&](const ShaderMsPs& _shader_info_group) {
                 shader_stages.reserve(2);
                 emplace_shader(_shader_info_group.ms, VK_SHADER_STAGE_MESH_BIT_NV);
@@ -1906,6 +1942,11 @@ VulkanDevice::CreatePipeline(GfxPsoCreateInfo&& _create_info, PipelineShaderInfo
     };
     auto vk_multisample_state = to_multi_sample_state(_create_info.multisample_info);
 
+    VkPipelineTessellationStateCreateInfo tessellation_state{
+        VK_STRUCTURE_TYPE_PIPELINE_TESSELLATION_STATE_CREATE_INFO
+    };
+    tessellation_state.patchControlPoints = _create_info.patch_control_points;
+
     auto to_depth_stencil_state = [](const RHIDepthStencilStateInfo& info) {
         VkPipelineDepthStencilStateCreateInfo state{};
         state.sType = VK_STRUCTURE_TYPE_PIPELINE_DEPTH_STENCIL_STATE_CREATE_INFO;
@@ -2013,7 +2054,7 @@ VulkanDevice::CreatePipeline(GfxPsoCreateInfo&& _create_info, PipelineShaderInfo
     pipeline_create_info.pStages             = shader_stages.data();
     pipeline_create_info.pVertexInputState   = &vertex_input_state;
     pipeline_create_info.pInputAssemblyState = &input_assembly_state;
-    pipeline_create_info.pTessellationState  = nullptr;
+    pipeline_create_info.pTessellationState  = uses_tessellation ? &tessellation_state : nullptr;
     pipeline_create_info.pViewportState      = &viewport_state;
     pipeline_create_info.pRasterizationState = &vk_rasterization_state;
     pipeline_create_info.pMultisampleState   = &vk_multisample_state;

--- a/source/runtime/render/rhi/vulkan/VulkanDevice.h
+++ b/source/runtime/render/rhi/vulkan/VulkanDevice.h
@@ -124,6 +124,16 @@ public:
 
     void FlushDebugMessages() const override;
 
+    bool SupportsTessellation() const override {
+        return m_device_info.core_features.core_1_0.tessellationShader == VK_TRUE;
+    }
+
+    uint32_t GetMaxTessellationFactor() const override {
+        return SupportsTessellation() ?
+                   m_device_info.core_properties.core_1_0.limits.maxTessellationGenerationLevel :
+                   0;
+    }
+
     // Cooperative support related
     bool                            IsExtensionCooperativeEnabled() const override;
     const CooperativeExtensionInfo& GetCooperativeExtensionInfo() const override;

--- a/source/runtime/render/rhi/vulkan/VulkanRHIResource.cpp
+++ b/source/runtime/render/rhi/vulkan/VulkanRHIResource.cpp
@@ -1042,6 +1042,8 @@ VkAccessFlags2 VulkanEnumTranslator::METoVkAccessFlags2(ERHIAccessFlags _flags) 
             case EShaderType::ST_COMPUTE: return VK_SHADER_STAGE_COMPUTE_BIT;
             case EShaderType::ST_MESH: return VK_SHADER_STAGE_MESH_BIT_NV;
             case EShaderType::ST_AMPLIFICATION: return VK_SHADER_STAGE_TASK_BIT_NV;
+            case EShaderType::ST_HULL: return VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT;
+            case EShaderType::ST_DOMAIN: return VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT;
             case EShaderType::ST_RAY_GEN: return VK_SHADER_STAGE_RAYGEN_BIT_KHR;
             case EShaderType::ST_RAY_MISS: return VK_SHADER_STAGE_MISS_BIT_KHR;
             case EShaderType::ST_RAY_CLOSESTHIT: return VK_SHADER_STAGE_CLOSEST_HIT_BIT_KHR;

--- a/source/runtime/render/shader/DXC/DXCUtils.cpp
+++ b/source/runtime/render/shader/DXC/DXCUtils.cpp
@@ -15,6 +15,10 @@ ERHIPipelineStageFlags ToPipelineStageFlag(spv::ExecutionModel _stage) {
             return ERHIPipelineStageFlags::PS_COMPUTE_SHADER;
         case spv::ExecutionModelGeometry:
             return ERHIPipelineStageFlags::PS_GEOMETRY_SHADER;
+        case spv::ExecutionModelTessellationControl:
+            return ERHIPipelineStageFlags::PS_TESSELLATION_CONTROL_SHADER;
+        case spv::ExecutionModelTessellationEvaluation:
+            return ERHIPipelineStageFlags::PS_TESSELLATION_EVALUATION_SHADER;
         case spv::ExecutionModelTaskNV:
             return ERHIPipelineStageFlags::PS_TASK_SHADER;
         case spv::ExecutionModelMeshNV:
@@ -71,6 +75,10 @@ const auto* GetShaderTypeWChar(EShaderType _type) {
             return L"ms";
         case ST_AMPLIFICATION:
             return L"as";
+        case ST_HULL:
+            return L"hs";
+        case ST_DOMAIN:
+            return L"ds";
         case ST_RAY_GEN:
             return L"lib";
         case ST_RAY_MISS:

--- a/source/runtime/render/shader/DXC/DXCUtils.h
+++ b/source/runtime/render/shader/DXC/DXCUtils.h
@@ -8,12 +8,12 @@
 #include "spirv.hpp"
 #include "spirv_cross.hpp"
 
-ERHIPipelineStageFlags ToPipelineStageFlag(spv::ExecutionModel _stage);
+RENDER_API ERHIPipelineStageFlags ToPipelineStageFlag(spv::ExecutionModel _stage);
 
 EShaderParameterType BindingTypeToParameterType(EShaderBindingBaseType _type);
 
 EPixelFormat ToPixelFormat(spv::ImageFormat _format);
-std::wstring GetPlatform(EShaderType _type, EShaderPlatform _platform);
+RENDER_API std::wstring GetPlatform(EShaderType _type, EShaderPlatform _platform);
 
 std::wstring SearchValidShaderPath(const std::string& _relative_shader_path);
 #endif

--- a/source/runtime/render/shader/DXC/DirectXShaderCompiler.cpp
+++ b/source/runtime/render/shader/DXC/DirectXShaderCompiler.cpp
@@ -421,6 +421,8 @@ bool DXCompiler::IsSupportTarget(const ShaderTargetInfo& _target_info) {
 
         case ST_MESH:
         case ST_AMPLIFICATION:
+        case ST_HULL:
+        case ST_DOMAIN:
 
         case ST_RAY_GEN:
         case ST_RAY_MISS:

--- a/source/runtime/render/shader/ShaderManager.cpp
+++ b/source/runtime/render/shader/ShaderManager.cpp
@@ -17,6 +17,9 @@ using std::move;
 
 namespace {
 
+constexpr uint32_t k_shader_cache_magic          = 0x4D534443; // "MSDC"
+constexpr uint32_t k_shader_cache_format_version = 1;
+
 std::string_view GetShaderTypeName(EShaderType shader_type) {
     switch (shader_type) {
         case ST_VERTEX: return "vertex";
@@ -25,6 +28,8 @@ std::string_view GetShaderTypeName(EShaderType shader_type) {
         case ST_COMPUTE: return "compute";
         case ST_MESH: return "mesh";
         case ST_AMPLIFICATION: return "amplification";
+        case ST_HULL: return "hull";
+        case ST_DOMAIN: return "domain";
         case ST_RAY_GEN: return "ray_gen";
         case ST_RAY_MISS: return "ray_miss";
         case ST_RAY_CLOSESTHIT: return "ray_closest_hit";
@@ -153,7 +158,10 @@ void ShaderManager::DumpCache(std::filesystem::path _path) {
 
     std::ofstream fs(file_path, std::ios::binary);
     OutputStream  stream(fs);
-    stream << shader_resources_cache;
+    stream << k_shader_cache_magic << k_shader_cache_format_version << shader_resources_cache;
+    if (!fs.good()) {
+        LOG_WARNING("[Startup][Shader] DumpCache failed to write shader cache: {}", file_path.string());
+    }
 }
 
 void ShaderManager::LoadCache(std::filesystem::path _path) {
@@ -190,6 +198,26 @@ void ShaderManager::LoadCache(std::filesystem::path _path) {
     InputStream          stream(fs);
 
     try {
+        uint32_t cache_magic   = 0;
+        uint32_t cache_version = 0;
+        stream >> cache_magic >> cache_version;
+        if (fs.fail()) {
+            LOG_WARNING(
+                "[Startup][Shader] LoadCache discarded truncated or unversioned shader cache: {}",
+                file_path.string()
+            );
+            return;
+        }
+        if (cache_magic != k_shader_cache_magic || cache_version != k_shader_cache_format_version) {
+            LOG_INFO(
+                "[Startup][Shader] LoadCache discarded incompatible shader cache: path='{}', magic=0x{:08X}, version={}, expected_version={}",
+                file_path.string(),
+                cache_magic,
+                cache_version,
+                k_shader_cache_format_version
+            );
+            return;
+        }
         stream >> loaded_cache;
     } catch (const std::exception& e) {
         LOG_WARNING(
@@ -334,10 +362,22 @@ PipelineHandle RasterPipelineConstructor::CreatePipeline(
         auto& asset = std::get<ShaderAsset>(_asset);
         return asset.path.empty() || asset.entry_name.empty();
     };
-    bool b_vs_ps = is_empty(task_path) && !is_empty(vertex_path) && !is_empty(pixel_path);
-    bool b_gs    = !is_empty(geometry_path);
-    bool b_mesh  = !is_empty(mesh_path) && !is_empty(pixel_path);
-    bool b_task  = !is_empty(task_path);
+    bool b_vs_ps  = is_empty(task_path) && !is_empty(vertex_path) && !is_empty(pixel_path);
+    bool b_gs     = !is_empty(geometry_path);
+    bool b_hull   = !is_empty(hull_path);
+    bool b_domain = !is_empty(domain_path);
+    bool b_mesh   = !is_empty(mesh_path) && !is_empty(pixel_path);
+    bool b_task   = !is_empty(task_path);
+
+    if (b_hull != b_domain) {
+        LOG_ERROR("Raster pipeline tessellation requires both Hull and Domain shaders.");
+        return {};
+    }
+    const bool b_tessellation = b_hull && b_domain;
+    if (b_tessellation && (!b_vs_ps || b_gs || b_mesh || b_task)) {
+        LOG_ERROR("Raster tessellation currently supports only the VS + HS + DS + PS stage chain.");
+        return {};
+    }
 
     auto target_info       = device.GetShaderPlatform();
     auto get_shader_output = [&](const ShaderAssetOrCache& _info, EShaderType _type) -> Shader& {
@@ -367,7 +407,16 @@ PipelineHandle RasterPipelineConstructor::CreatePipeline(
     if (b_vs_ps) {
         auto& vert_output  = get_shader_output(vertex_path, ST_VERTEX);
         auto& pixel_output = get_shader_output(pixel_path, ST_FRAGMENT);
-        if (!b_gs) {
+        if (b_tessellation) {
+            auto& hull_output   = get_shader_output(hull_path, ST_HULL);
+            auto& domain_output = get_shader_output(domain_path, ST_DOMAIN);
+            sd_info.shader_group = ShaderVsHsDsPs{
+                .vs = get_shader_info(ST_VERTEX, vert_output),
+                .hs = get_shader_info(ST_HULL, hull_output),
+                .ds = get_shader_info(ST_DOMAIN, domain_output),
+                .ps = get_shader_info(ST_FRAGMENT, pixel_output)
+            };
+        } else if (!b_gs) {
             sd_info.shader_group = ShaderVsPs{
                 .vs = get_shader_info(ST_VERTEX, vert_output),
                 .ps = get_shader_info(ST_FRAGMENT, pixel_output)

--- a/source/runtime/render/shaderheaders/shared/raster/ShaderParameters.h
+++ b/source/runtime/render/shaderheaders/shared/raster/ShaderParameters.h
@@ -23,6 +23,7 @@
 #include "shaderheaders/shared/raster/geometry_pass/ShaderParameters.h"
 #include "shaderheaders/shared/raster/lighting_pass/ShaderParameters.h"
 #include "shaderheaders/shared/raster/post_process/ShaderParameters.h"
+#include "shaderheaders/shared/raster/tessellated_surface/ShaderParameters.h"
 #include "shaderheaders/shared/scene/SharedSceneStruct.h"
 
 namespace Moer::Render {
@@ -35,6 +36,7 @@ namespace Moer::Render {
 #include "shared/raster/geometry_pass/ShaderParameters.h"
 #include "shared/raster/lighting_pass/ShaderParameters.h"
 #include "shared/raster/post_process/ShaderParameters.h"
+#include "shared/raster/tessellated_surface/ShaderParameters.h"
 #include "shared/scene/SharedSceneStruct.h"
 
 namespace Moer {

--- a/source/runtime/render/shaderheaders/shared/raster/tessellated_surface/ShaderParameters.h
+++ b/source/runtime/render/shaderheaders/shared/raster/tessellated_surface/ShaderParameters.h
@@ -1,0 +1,44 @@
+/**
+ * Shared parameters for the procedural tessellated surface showcase.
+ *
+ * Include shared/raster/ShaderParameters.h instead of including this file directly.
+ */
+#pragma once
+
+#ifdef __cplusplus
+#include "misc/Traits.h"
+namespace Moer::Render {
+#else
+namespace Moer {
+#endif
+
+struct TessellatedSurfaceData {
+    float4x4 world2clip;
+
+    // xyz: camera world position, w: tan(vertical field of view / 2)
+    float4 camera_position_tan_half_fov;
+    // xy: viewport size, z: target edge length in pixels, w: maximum tessellation factor
+    float4 viewport_tessellation;
+    // xyz: surface center, w: half extent of the square surface
+    float4 surface_origin_extent;
+    // x: macro amplitude, y: detail amplitude, z: macro frequency, w: detail frequency
+    float4 displacement;
+    // xy: normalized wind direction in XZ, z: domain-warp strength, w: normal finite-difference step
+    float4 wind_and_normal;
+    // rgb: low/slope color, w: perceptual roughness
+    float4 color_low_roughness;
+    // rgb: high/flat color, w: minimum tessellation factor
+    float4 color_high_min_tessellation;
+    // x: grid X, y: grid Z, z: preset (0 sand, 1 snow), w: debug mode
+    uint4 grid_and_options;
+};
+
+#ifdef __cplusplus
+static_assert(sizeof(TessellatedSurfaceData) == 192, "TessellatedSurfaceData layout must match HLSL");
+#endif
+
+#ifdef __cplusplus
+} // namespace Moer::Render
+#else
+} // namespace Moer
+#endif

--- a/source/test/CMakeLists.txt
+++ b/source/test/CMakeLists.txt
@@ -11,6 +11,13 @@ target_link_libraries(${test_target}
 )
 set_target_properties(${test_target} PROPERTIES FOLDER ${moer_test_folder})
 
+set(test_target TestShaderStageSupport)
+add_executable(${test_target} "ShaderStageSupportTest.cpp")
+target_link_libraries(${test_target}
+    PRIVATE Moer::Render
+)
+set_target_properties(${test_target} PROPERTIES FOLDER ${moer_test_folder})
+
 set(test_target TestRenderGraph)
 add_executable(${test_target} "RenderGraphTest.cpp")
 target_link_libraries(${test_target}

--- a/source/test/ShaderStageSupportTest.cpp
+++ b/source/test/ShaderStageSupportTest.cpp
@@ -26,7 +26,7 @@ int main() {
     assert(std::holds_alternative<Moer::Render::ShaderVsHsDsPs>(shader_group));
 
     Moer::Render::GfxPsoCreateInfo pipeline_info(
-        RHIRasterizeInfo::Preset(),
+        ::RHIRasterizeInfo::Preset(),
         {},
         {}
     );

--- a/source/test/ShaderStageSupportTest.cpp
+++ b/source/test/ShaderStageSupportTest.cpp
@@ -1,0 +1,39 @@
+#include "rhi/RHICommon.h"
+#include "rhi/RHIResource.h"
+#include "shader/DXC/DXCUtils.h"
+
+#include <cassert>
+#include <iostream>
+#include <variant>
+
+int main() {
+    static_assert(ST_HULL > ST_RAY_ANYHIT, "New stages must not renumber serialized shader types.");
+    static_assert(ST_DOMAIN == ST_HULL + 1);
+    static_assert(ST_Num <= (1 << ST_NumBits));
+
+    assert(GetPlatform(ST_HULL, SP_VULKAN_SM6) == L"hs_6_7");
+    assert(GetPlatform(ST_DOMAIN, SP_VULKAN_SM6) == L"ds_6_7");
+    assert(
+        ToPipelineStageFlag(spv::ExecutionModelTessellationControl) ==
+        ERHIPipelineStageFlags::PS_TESSELLATION_CONTROL_SHADER
+    );
+    assert(
+        ToPipelineStageFlag(spv::ExecutionModelTessellationEvaluation) ==
+        ERHIPipelineStageFlags::PS_TESSELLATION_EVALUATION_SHADER
+    );
+
+    Moer::Render::ShaderOutputGroup shader_group = Moer::Render::ShaderVsHsDsPs{};
+    assert(std::holds_alternative<Moer::Render::ShaderVsHsDsPs>(shader_group));
+
+    Moer::Render::GfxPsoCreateInfo pipeline_info(
+        RHIRasterizeInfo::Preset(),
+        {},
+        {}
+    );
+    pipeline_info.primitive_topology = EPrimitiveTopology::PATCH_LIST;
+    pipeline_info.SetPatchControlPoints(3);
+    assert(pipeline_info.patch_control_points == 3);
+
+    std::cout << "TestShaderStageSupport: all checks passed\n";
+    return 0;
+}


### PR DESCRIPTION
## Summary

- add Hull/Domain shader support across DXC, shader grouping, RHI capability queries, and Vulkan tessellation PSO creation
- add an opt-in `TessellatedSurfacePass` between Geometry and HiZ with procedural triangle patches, shared-edge adaptive factors, displacement, finite-difference normals, and existing GBuffer/depth output
- add Sand Dunes and Snow Field presets plus material, tess-factor heatmap, world-normal, and height debug views
- version the shader cache so pre-HS/DS caches are rejected safely
- cap combined grid/tessellation work to about 2.1M generated triangles

## Validation

- `cmake --build build --config Debug --target MoerEditor -j 30`
- `cmake --build build --config Debug --target TestShaderStageSupport -j 30`
- `target/bin/Debug/TestShaderStageSupport.exe`
- compiled `SurfaceVS`, `SurfaceHS`, `SurfaceDS`, and `SurfacePS` with the engine's Vulkan 1.3 DXC flags
- launched the Vulkan Raster editor with validation enabled; the tessellation pipeline reported ready with max factor 64 and no VUID/assert/leak errors
- visually checked sand, snow, tess-factor heatmap, world-normal, height, feature-off restoration, and a factor-64 / 2px stress configuration

## Current scope

This is a bounded opaque showcase surface. It receives deferred lighting and scene shadows, but it is not yet a CSM caster and is not represented in ray-tracing BLAS. Full water optics (transparency, refraction, absorption, foam) are intentionally out of scope.