### PR TITLE
feat(editor): add branded startup splash

### DIFF
--- a/source/editor/CMakeLists.txt
+++ b/source/editor/CMakeLists.txt
@@ -32,7 +32,7 @@ target_link_libraries(${editor_library_target}
 
 if(WIN32)
     # StartupSplash is a renderer-independent native Win32/GDI window.
-    target_link_libraries(${editor_library_target} PRIVATE user32 gdi32)
+    target_link_libraries(${editor_library_target} PRIVATE user32 gdi32 msimg32)
     target_compile_definitions(${editor_library_target} PRIVATE WIN32_LEAN_AND_MEAN NOMINMAX)
 endif()
 

--- a/source/editor/CMakeLists.txt
+++ b/source/editor/CMakeLists.txt
@@ -30,6 +30,12 @@ target_link_libraries(${editor_library_target}
     PRIVATE nfd
 )
 
+if(WIN32)
+    # StartupSplash is a renderer-independent native Win32/GDI window.
+    target_link_libraries(${editor_library_target} PRIVATE user32 gdi32)
+    target_compile_definitions(${editor_library_target} PRIVATE WIN32_LEAN_AND_MEAN NOMINMAX)
+endif()
+
 target_include_directories(
   ${editor_library_target}
   PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>

--- a/source/editor/Editor.cpp
+++ b/source/editor/Editor.cpp
@@ -3,6 +3,7 @@
 #include "Engine.h"
 
 #include "EditorUI.h"
+#include "window/WindowContext.h"
 
 using namespace Moer::Render;
 
@@ -10,11 +11,30 @@ namespace Moer {
 
 Editor::Editor() = default;
 
-Editor::~Editor() = default;
+Editor::~Editor() {
+    ShutDown();
+}
 
 void Editor::Init(int argc, const char** argv) {
+    Init(argc, argv, StartupHooks{});
+}
+
+void Editor::Init(int argc, const char** argv, StartupHooks startup_hooks) {
+    m_startup_hooks = std::move(startup_hooks);
+    ReportStartupProgress("Starting MoerEditor", "Initializing the engine core");
     m_engine = MakeUnique<Engine>();
-    m_engine->Init(argc, argv);
+    try {
+        m_engine->Init(
+            argc,
+            argv,
+            m_startup_hooks.main_window_visible,
+            m_startup_hooks.on_progress
+        );
+    } catch (...) {
+        m_engine->ShutDown();
+        m_engine.reset();
+        throw;
+    }
 }
 
 void Editor::Run() {
@@ -23,6 +43,7 @@ void Editor::Run() {
 
 void Editor::Run(const ExtraHooks& extra_hooks) {
     // UI 的生命周期限定在 Engine::Run 内，因为其渲染器资源依赖当前运行的 Engine。
+    ReportStartupProgress("Preparing editor interface", "Building ImGui fonts and GPU resources");
     m_editor_ui = MakeUnique<EditorUI>(
         MakeUnique<Render::UIRenderer>(RenderDevice::Get()),
         m_engine->GetEditorConfig(),
@@ -89,6 +110,26 @@ void Editor::Run(const ExtraHooks& extra_hooks) {
                 [this]() {
                     m_editor_ui->SetShowRenderConfigSubUI(true);
                 },
+            .on_startup_progress =
+                [this](std::string_view title, std::string_view detail) {
+                    ReportStartupProgress(title, detail);
+                },
+            .on_first_main_present =
+                [this]() {
+                    ReportStartupProgress("Opening MoerEditor", "The first rendered frame is ready");
+                    if (!m_startup_hooks.main_window_visible) {
+                        WindowContext::ShowMainWindow();
+                        m_startup_hooks.main_window_visible = true;
+                    }
+                    if (m_startup_hooks.on_first_main_present) {
+                        try {
+                            m_startup_hooks.on_first_main_present();
+                        } catch (...) {
+                            // Startup presentation is auxiliary. A client hook
+                            // must not interrupt the renderer after Present.
+                        }
+                    }
+                },
 
             // Raster
             .on_raster_register_frame_buffer_names =
@@ -101,9 +142,22 @@ void Editor::Run(const ExtraHooks& extra_hooks) {
     m_editor_ui.reset();
 }
 
-void Editor::ShutDown() {
-    m_engine->ShutDown();
-    m_engine.reset();
+void Editor::ReportStartupProgress(std::string_view title, std::string_view detail) const noexcept {
+    try {
+        if (m_startup_hooks.on_progress) {
+            m_startup_hooks.on_progress(title, detail);
+        }
+    } catch (...) {
+        // Optional startup UI must not participate in Editor failure paths.
+    }
+}
+
+void Editor::ShutDown() noexcept {
+    m_editor_ui.reset();
+    if (m_engine) {
+        m_engine->ShutDown();
+        m_engine.reset();
+    }
 }
 
 Engine& Editor::GetEngine() {

--- a/source/editor/Editor.h
+++ b/source/editor/Editor.h
@@ -5,6 +5,7 @@
 #include "misc/STL.h"
 
 #include <functional>
+#include <string_view>
 
 namespace Moer {
 
@@ -14,6 +15,12 @@ class Scene;
 
 class Editor {
 public:
+    struct StartupHooks {
+        bool main_window_visible = true;
+        std::function<void(std::string_view title, std::string_view detail)> on_progress;
+        std::function<void()> on_first_main_present;
+    };
+
     struct ExtraHooks {
         std::function<void(Scene&)> on_tick_test;
     };
@@ -22,16 +29,20 @@ public:
     virtual ~Editor();
 
     void Init(int argc, const char** argv);
+    void Init(int argc, const char** argv, StartupHooks startup_hooks);
     void Run();
     void Run(const ExtraHooks& extra_hooks);
-    void ShutDown();
+    void ShutDown() noexcept;
 
     Engine&       GetEngine();
     const Engine& GetEngine() const;
 
 private:
+    void ReportStartupProgress(std::string_view title, std::string_view detail) const noexcept;
+
     UniquePtr<Engine>   m_engine;
     UniquePtr<EditorUI> m_editor_ui;
+    StartupHooks        m_startup_hooks;
 };
 
 } // namespace Moer

--- a/source/editor/main.cpp
+++ b/source/editor/main.cpp
@@ -2,8 +2,26 @@
 
 #include "Editor.h"
 #include "Engine.h"
+#include "startup/StartupSplash.h"
 
+#include <chrono>
 #include <iostream>
+#include <string_view>
+#include <thread>
+#include <utility>
+
+namespace {
+
+bool HasFlag(int argc, const char** argv, std::string_view flag) {
+    for (int index = 1; index < argc; ++index) {
+        if (std::string_view(argv[index]) == flag) {
+            return true;
+        }
+    }
+    return false;
+}
+
+} // namespace
 
 int main(int argc, const char** argv) {
     std::cout << "Moer Engine Editor Starting..." << std::endl;
@@ -15,13 +33,56 @@ int main(int argc, const char** argv) {
         return 2;
     }
 
+    Moer::StartupSplash splash;
+    const bool splash_started =
+        !HasFlag(argc, argv, "--no-splash") &&
+        splash.Start("Starting MoerEditor", "Preparing engine services");
+
+    Moer::Editor::StartupHooks startup_hooks{};
+    startup_hooks.main_window_visible = !splash_started;
+    if (splash_started) {
+        startup_hooks.on_progress =
+            [&splash](std::string_view title, std::string_view detail) {
+                splash.Update(title, detail);
+            };
+        startup_hooks.on_first_main_present = [&splash]() {
+            splash.Finish();
+        };
+    }
+
     Moer::Editor editor;
+    try {
+        editor.Init(argc, argv, std::move(startup_hooks));
+        editor.Run();
+        editor.ShutDown();
+    } catch (const std::exception& error) {
+        std::cerr << "MoerEditor startup failed: " << error.what() << std::endl;
+        if (splash_started && splash.IsRunning()) {
+            splash.Fail("MoerEditor failed to start", error.what());
+        }
+        editor.ShutDown();
+        if (splash_started && splash.IsRunning()) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(1500));
+        }
+        return 1;
+    } catch (...) {
+        std::cerr << "MoerEditor startup failed with an unknown error." << std::endl;
+        if (splash_started && splash.IsRunning()) {
+            splash.Fail(
+                "MoerEditor failed to start",
+                "An unknown error interrupted engine initialization or the editor loop."
+            );
+        }
+        editor.ShutDown();
+        if (splash_started && splash.IsRunning()) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(1500));
+        }
+        return 1;
+    }
 
-    editor.Init(argc, argv);
-
-    editor.Run();
-
-    editor.ShutDown();
+    if (splash.IsRunning()) {
+        splash.Finish();
+    }
 
     return 0;
 }

--- a/source/editor/startup/StartupSplash.cpp
+++ b/source/editor/startup/StartupSplash.cpp
@@ -1,0 +1,1322 @@
+#include "StartupSplash.h"
+
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <cstdint>
+#include <limits>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <string>
+#include <thread>
+#include <utility>
+
+#if defined(_WIN32)
+
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#include <windows.h>
+
+#include <algorithm>
+#include <cwchar>
+
+namespace Moer {
+namespace {
+
+using Clock = std::chrono::steady_clock;
+
+constexpr wchar_t kWindowClassName[] = L"MoerEngineStartupSplashWindow";
+constexpr wchar_t kWindowTitle[]     = L"MoerEngine Startup";
+
+constexpr UINT kRefreshMessage = WM_APP + 0x51;
+constexpr UINT kFinishMessage  = WM_APP + 0x52;
+constexpr UINT kStopMessage    = WM_APP + 0x53;
+constexpr UINT kKeepOpenMessage = WM_APP + 0x54;
+
+constexpr UINT_PTR kAnimationTimerId = 1;
+constexpr UINT     kAnimationPeriod  = 33;
+
+constexpr int kLogicalWindowWidth  = 680;
+constexpr int kLogicalWindowHeight = 380;
+
+constexpr auto kMinimumVisibleTime = std::chrono::milliseconds(350);
+constexpr auto kHandoffOverlapTime = std::chrono::milliseconds(350);
+
+// The official NJU purple is specified for print as C50 M100 Y0 K40. The
+// darker screen approximation anchors the brand while the brighter tints keep
+// fine geometry readable on the near-black startup surface.
+constexpr COLORREF kBackgroundTop    = RGB(23, 17, 32);
+constexpr COLORREF kBackground       = RGB(14, 11, 21);
+constexpr COLORREF kRaisedBackground = RGB(27, 21, 38);
+constexpr COLORREF kNjuPurple        = RGB(77, 0, 153);
+constexpr COLORREF kAccent           = RGB(139, 92, 246);
+constexpr COLORREF kAccentLight      = RGB(196, 181, 253);
+constexpr COLORREF kAccentDim        = RGB(50, 38, 83);
+constexpr COLORREF kWarmGold         = RGB(214, 183, 106);
+constexpr COLORREF kPrimaryText      = RGB(245, 243, 255);
+constexpr COLORREF kSecondaryText    = RGB(184, 178, 200);
+constexpr COLORREF kMutedText        = RGB(119, 112, 135);
+constexpr COLORREF kFailure          = RGB(240, 106, 123);
+
+int Scale(int value, UINT dpi) noexcept {
+    return MulDiv(value, static_cast<int>(dpi), USER_DEFAULT_SCREEN_DPI);
+}
+
+class ScopedGdiObject final {
+public:
+    explicit ScopedGdiObject(HGDIOBJ object = nullptr) noexcept
+        : m_object(object) {}
+
+    ~ScopedGdiObject() {
+        if (m_object != nullptr) {
+            DeleteObject(m_object);
+        }
+    }
+
+    ScopedGdiObject(const ScopedGdiObject&)            = delete;
+    ScopedGdiObject& operator=(const ScopedGdiObject&) = delete;
+
+    [[nodiscard]] HGDIOBJ Get() const noexcept {
+        return m_object;
+    }
+
+private:
+    HGDIOBJ m_object = nullptr;
+};
+
+std::wstring Utf8ToWide(std::string_view text) {
+    if (text.empty()) {
+        return {};
+    }
+
+    const auto byte_count = static_cast<int>((std::min)(
+        text.size(),
+        static_cast<std::size_t>((std::numeric_limits<int>::max)())
+    ));
+
+    auto convert = [text, byte_count](UINT code_page, DWORD flags) -> std::wstring {
+        const int character_count = MultiByteToWideChar(
+            code_page,
+            flags,
+            text.data(),
+            byte_count,
+            nullptr,
+            0
+        );
+        if (character_count <= 0) {
+            return {};
+        }
+
+        std::wstring result(static_cast<std::size_t>(character_count), L'\0');
+        if (MultiByteToWideChar(
+                code_page,
+                flags,
+                text.data(),
+                byte_count,
+                result.data(),
+                character_count
+            ) <= 0) {
+            return {};
+        }
+        return result;
+    };
+
+    if (auto result = convert(CP_UTF8, MB_ERR_INVALID_CHARS); !result.empty()) {
+        return result;
+    }
+    return convert(CP_ACP, 0);
+}
+
+struct SplashSnapshot {
+    std::wstring title  = L"Starting MoerEditor";
+    std::wstring detail = L"Preparing engine services";
+    bool         failed = false;
+};
+
+class SharedSplashState final {
+public:
+    void Set(std::wstring title, std::wstring detail, bool failed) {
+        std::scoped_lock lock(m_mutex);
+        m_snapshot.title  = std::move(title);
+        m_snapshot.detail = std::move(detail);
+        m_snapshot.failed = failed;
+    }
+
+    [[nodiscard]] SplashSnapshot Read() const noexcept {
+        try {
+            std::scoped_lock lock(m_mutex);
+            return m_snapshot;
+        } catch (...) {
+            return {};
+        }
+    }
+
+private:
+    mutable std::mutex m_mutex;
+    SplashSnapshot     m_snapshot;
+};
+
+HFONT CreateUiFont(int point_size, int weight, UINT dpi) noexcept {
+    return CreateFontW(
+        -MulDiv(point_size, static_cast<int>(dpi), 72),
+        0,
+        0,
+        0,
+        weight,
+        FALSE,
+        FALSE,
+        FALSE,
+        DEFAULT_CHARSET,
+        OUT_DEFAULT_PRECIS,
+        CLIP_DEFAULT_PRECIS,
+        CLEARTYPE_QUALITY,
+        DEFAULT_PITCH | FF_DONTCARE,
+        L"Segoe UI"
+    );
+}
+
+struct WindowContext final {
+    explicit WindowContext(std::shared_ptr<SharedSplashState> shared_state)
+        : state(std::move(shared_state)), started_at(Clock::now()) {}
+
+    ~WindowContext() {
+        ResetFonts();
+    }
+
+    void ResetFonts() noexcept {
+        if (product_font != nullptr) {
+            DeleteObject(product_font);
+            product_font = nullptr;
+        }
+        if (title_font != nullptr) {
+            DeleteObject(title_font);
+            title_font = nullptr;
+        }
+        if (body_font != nullptr) {
+            DeleteObject(body_font);
+            body_font = nullptr;
+        }
+        if (meta_font != nullptr) {
+            DeleteObject(meta_font);
+            meta_font = nullptr;
+        }
+    }
+
+    void RecreateFonts(UINT new_dpi) noexcept {
+        ResetFonts();
+        dpi          = new_dpi == 0 ? USER_DEFAULT_SCREEN_DPI : new_dpi;
+        product_font = CreateUiFont(26, FW_SEMIBOLD, dpi);
+        title_font   = CreateUiFont(15, FW_SEMIBOLD, dpi);
+        body_font    = CreateUiFont(10, FW_NORMAL, dpi);
+        meta_font    = CreateUiFont(8, FW_SEMIBOLD, dpi);
+    }
+
+    std::shared_ptr<SharedSplashState> state;
+    Clock::time_point                   started_at;
+    UINT                                dpi            = USER_DEFAULT_SCREEN_DPI;
+    std::uint32_t                       animation_tick = 0;
+    BYTE                                opacity        = 0;
+    bool                                finish_requested = false;
+    bool                                fading_out       = false;
+    std::optional<Clock::time_point>    finish_requested_at;
+    HFONT                               product_font     = nullptr;
+    HFONT                               title_font       = nullptr;
+    HFONT                               body_font        = nullptr;
+    HFONT                               meta_font        = nullptr;
+};
+
+WindowContext* GetWindowContext(HWND window) noexcept {
+    return reinterpret_cast<WindowContext*>(GetWindowLongPtrW(window, GWLP_USERDATA));
+}
+
+void FillSolidRect(HDC dc, const RECT& rect, COLORREF color) noexcept {
+    ScopedGdiObject brush(CreateSolidBrush(color));
+    FillRect(dc, &rect, static_cast<HBRUSH>(brush.Get()));
+}
+
+void SelectFont(HDC dc, HFONT font) noexcept {
+    SelectObject(dc, font != nullptr ? font : GetStockObject(DEFAULT_GUI_FONT));
+}
+
+COLORREF BlendColor(COLORREF background, COLORREF foreground, int alpha) noexcept {
+    alpha = (std::clamp)(alpha, 0, 255);
+    const auto blend_channel = [alpha](int base, int accent) {
+        return (base * (255 - alpha) + accent * alpha + 127) / 255;
+    };
+    return RGB(
+        blend_channel(GetRValue(background), GetRValue(foreground)),
+        blend_channel(GetGValue(background), GetGValue(foreground)),
+        blend_channel(GetBValue(background), GetBValue(foreground))
+    );
+}
+
+void FillGradientRect(
+    HDC      dc,
+    const RECT& rect,
+    COLORREF first,
+    COLORREF second,
+    bool     horizontal
+) noexcept {
+    TRIVERTEX vertices[2]{};
+    vertices[0].x     = rect.left;
+    vertices[0].y     = rect.top;
+    vertices[0].Red   = static_cast<COLOR16>(GetRValue(first) << 8);
+    vertices[0].Green = static_cast<COLOR16>(GetGValue(first) << 8);
+    vertices[0].Blue  = static_cast<COLOR16>(GetBValue(first) << 8);
+    vertices[0].Alpha = 0xFF00;
+    vertices[1].x     = rect.right;
+    vertices[1].y     = rect.bottom;
+    vertices[1].Red   = static_cast<COLOR16>(GetRValue(second) << 8);
+    vertices[1].Green = static_cast<COLOR16>(GetGValue(second) << 8);
+    vertices[1].Blue  = static_cast<COLOR16>(GetBValue(second) << 8);
+    vertices[1].Alpha = 0xFF00;
+
+    GRADIENT_RECT gradient_rect{0, 1};
+    if (!GradientFill(
+            dc,
+            vertices,
+            2,
+            &gradient_rect,
+            1,
+            horizontal ? GRADIENT_FILL_RECT_H : GRADIENT_FILL_RECT_V
+        )) {
+        FillSolidRect(dc, rect, first);
+    }
+}
+
+void DrawLine(
+    HDC      dc,
+    int      x0,
+    int      y0,
+    int      x1,
+    int      y1,
+    COLORREF color,
+    int      thickness = 1
+) noexcept {
+    ScopedGdiObject pen(CreatePen(PS_SOLID, (std::max)(1, thickness), color));
+    const auto old_pen = SelectObject(dc, pen.Get());
+    MoveToEx(dc, x0, y0, nullptr);
+    LineTo(dc, x1, y1);
+    SelectObject(dc, old_pen);
+}
+
+void DrawRectOutline(HDC dc, const RECT& rect, COLORREF color, int thickness = 1) noexcept {
+    ScopedGdiObject pen(CreatePen(PS_SOLID, (std::max)(1, thickness), color));
+    const auto old_pen   = SelectObject(dc, pen.Get());
+    const auto old_brush = SelectObject(dc, GetStockObject(HOLLOW_BRUSH));
+    Rectangle(dc, rect.left, rect.top, rect.right, rect.bottom);
+    SelectObject(dc, old_brush);
+    SelectObject(dc, old_pen);
+}
+
+void DrawSegmentedViewportFrame(
+    HDC         dc,
+    const RECT& client,
+    UINT        dpi,
+    bool        failed
+) noexcept {
+    const int width     = client.right - client.left;
+    const int height    = client.bottom - client.top;
+    const int thickness = (std::max)(1, Scale(1, dpi));
+    const COLORREF active = failed ? kFailure : kAccent;
+
+    DrawRectOutline(dc, RECT{0, 0, width - 1, height - 1}, BlendColor(kBackground, active, 62), thickness);
+    for (int logical_inset = 2; logical_inset <= 5; ++logical_inset) {
+        const int inset = Scale(logical_inset, dpi);
+        DrawRectOutline(
+            dc,
+            RECT{inset, inset, width - inset, height - inset},
+            BlendColor(kBackground, active, 30 - logical_inset * 4)
+        );
+    }
+
+    const int edge   = Scale(3, dpi);
+    const int corner = Scale(44, dpi);
+    const COLORREF dim_corner = BlendColor(kBackground, active, 110);
+    DrawLine(dc, edge, edge, edge + corner, edge, active, thickness);
+    DrawLine(dc, edge, edge, edge, edge + corner, active, thickness);
+    DrawLine(dc, width - edge, height - edge, width - edge - corner, height - edge, active, thickness);
+    DrawLine(dc, width - edge, height - edge, width - edge, height - edge - corner, active, thickness);
+
+    DrawLine(dc, width - edge, edge, width - edge - corner, edge, dim_corner, thickness);
+    DrawLine(dc, width - edge, edge, width - edge, edge + corner, dim_corner, thickness);
+    DrawLine(dc, edge, height - edge, edge + corner, height - edge, dim_corner, thickness);
+    DrawLine(dc, edge, height - edge, edge, height - edge - corner, dim_corner, thickness);
+
+    const int tick_y = Scale(3, dpi);
+    for (int tick = 0; tick < 3; ++tick) {
+        const int x = width - Scale(118 - tick * 16, dpi);
+        DrawLine(dc, x, tick_y, x + Scale(7, dpi), tick_y, BlendColor(kBackground, active, 90 + tick * 28), thickness);
+    }
+
+    const int sample_size = (std::max)(Scale(4, dpi), 2);
+    RECT sample{
+        Scale(22, dpi),
+        height - Scale(25, dpi),
+        Scale(22, dpi) + sample_size,
+        height - Scale(25, dpi) + sample_size
+    };
+    FillSolidRect(dc, sample, failed ? kFailure : kWarmGold);
+}
+
+void DrawRayField(
+    HDC         dc,
+    const RECT& client,
+    const RECT& mark_rect,
+    UINT        dpi,
+    bool        failed
+) noexcept {
+    const COLORREF active = failed ? kFailure : kAccent;
+    const COLORREF ray = BlendColor(kBackgroundTop, active, failed ? 34 : 20);
+    const int origin_x = mark_rect.right - Scale(4, dpi);
+    const int origin_y = mark_rect.top + (mark_rect.bottom - mark_rect.top) / 2;
+
+    DrawLine(dc, origin_x, origin_y, client.right - Scale(90, dpi), Scale(18, dpi), ray);
+    DrawLine(dc, origin_x, origin_y, client.right - Scale(52, dpi), Scale(66, dpi), ray);
+    DrawLine(dc, origin_x, origin_y, client.right - Scale(112, dpi), Scale(126, dpi), ray);
+    DrawLine(dc, origin_x, origin_y, mark_rect.right + Scale(255, dpi), Scale(128, dpi), ray);
+
+    const int dot_size = (std::max)(Scale(2, dpi), 1);
+    for (int row = 0; row < 3; ++row) {
+        for (int column = 0; column < 4; ++column) {
+            const int x = client.right - Scale(285 - column * 15, dpi);
+            const int y = Scale(42 + row * 15, dpi);
+            RECT dot{x, y, x + dot_size, y + dot_size};
+            FillSolidRect(dc, dot, BlendColor(kRaisedBackground, active, 32 + (row + column) * 10));
+        }
+    }
+}
+
+void DrawRayframeMark(
+    HDC                  dc,
+    const RECT&          bounds,
+    const WindowContext& context,
+    bool                 failed
+) noexcept {
+    const UINT dpi = context.dpi;
+    const COLORREF active = failed ? kFailure : kAccent;
+    const std::uint32_t pulse_phase = context.animation_tick % 120U;
+    const int pulse = static_cast<int>(pulse_phase <= 60U ? pulse_phase : 120U - pulse_phase);
+
+    for (int layer = 0; layer < 4; ++layer) {
+        const int inset = Scale(layer + 1, dpi);
+        DrawRectOutline(
+            dc,
+            RECT{bounds.left + inset, bounds.top + inset, bounds.right - inset, bounds.bottom - inset},
+            BlendColor(kRaisedBackground, active, 18 + pulse / 4 - layer * 3)
+        );
+    }
+
+    const int bracket = Scale(18, dpi);
+    const int thickness = (std::max)(1, Scale(2, dpi));
+    DrawLine(dc, bounds.left, bounds.top, bounds.left + bracket, bounds.top, active, thickness);
+    DrawLine(dc, bounds.left, bounds.top, bounds.left, bounds.top + bracket, active, thickness);
+    DrawLine(dc, bounds.right, bounds.bottom, bounds.right - bracket, bounds.bottom, active, thickness);
+    DrawLine(dc, bounds.right, bounds.bottom, bounds.right, bounds.bottom - bracket, active, thickness);
+    const COLORREF dim = BlendColor(kRaisedBackground, active, 125);
+    DrawLine(dc, bounds.right, bounds.top, bounds.right - bracket, bounds.top, dim, thickness);
+    DrawLine(dc, bounds.right, bounds.top, bounds.right, bounds.top + bracket, dim, thickness);
+    DrawLine(dc, bounds.left, bounds.bottom, bounds.left + bracket, bounds.bottom, dim, thickness);
+    DrawLine(dc, bounds.left, bounds.bottom, bounds.left, bounds.bottom - bracket, dim, thickness);
+
+    const int margin_x = Scale(13, dpi);
+    const int margin_y = Scale(14, dpi);
+    const RECT inner{
+        bounds.left + margin_x,
+        bounds.top + margin_y,
+        bounds.right - margin_x,
+        bounds.bottom - margin_y
+    };
+    const int inner_width  = inner.right - inner.left;
+    const int inner_height = inner.bottom - inner.top;
+    const auto x = [&inner, inner_width](int percent) {
+        return inner.left + MulDiv(percent, inner_width, 100);
+    };
+    const auto y = [&inner, inner_height](int percent) {
+        return inner.top + MulDiv(percent, inner_height, 100);
+    };
+    POINT mark_points[] = {
+        {x(0), y(100)},
+        {x(0), y(0)},
+        {x(19), y(0)},
+        {x(50), y(48)},
+        {x(81), y(0)},
+        {x(100), y(0)},
+        {x(100), y(100)},
+        {x(78), y(100)},
+        {x(78), y(42)},
+        {x(50), y(86)},
+        {x(22), y(42)},
+        {x(22), y(100)}
+    };
+
+    ScopedGdiObject mark_region(CreatePolygonRgn(mark_points, 12, WINDING));
+    if (mark_region.Get() != nullptr) {
+        const int saved_dc = SaveDC(dc);
+        SelectClipRgn(dc, static_cast<HRGN>(mark_region.Get()));
+        FillGradientRect(dc, inner, failed ? kFailure : kNjuPurple, failed ? kFailure : kAccentLight, true);
+        RestoreDC(dc, saved_dc);
+    } else {
+        ScopedGdiObject mark_brush(CreateSolidBrush(active));
+        const auto old_brush = SelectObject(dc, mark_brush.Get());
+        const auto old_pen   = SelectObject(dc, GetStockObject(NULL_PEN));
+        Polygon(dc, mark_points, 12);
+        SelectObject(dc, old_pen);
+        SelectObject(dc, old_brush);
+    }
+
+    ScopedGdiObject outline_pen(CreatePen(PS_SOLID, (std::max)(1, Scale(1, dpi)), BlendColor(active, kAccentLight, 145)));
+    const auto old_pen   = SelectObject(dc, outline_pen.Get());
+    const auto old_brush = SelectObject(dc, GetStockObject(HOLLOW_BRUSH));
+    Polygon(dc, mark_points, 12);
+    SelectObject(dc, old_brush);
+    SelectObject(dc, old_pen);
+
+    const int sample_x    = x(50);
+    const int sample_y    = y(48);
+    const int sample_half = (std::max)(Scale(3, dpi), 2);
+    POINT sample[] = {
+        {sample_x, sample_y - sample_half},
+        {sample_x + sample_half, sample_y},
+        {sample_x, sample_y + sample_half},
+        {sample_x - sample_half, sample_y}
+    };
+    ScopedGdiObject sample_brush(CreateSolidBrush(failed ? kFailure : kWarmGold));
+    const auto old_sample_brush = SelectObject(dc, sample_brush.Get());
+    const auto old_sample_pen   = SelectObject(dc, GetStockObject(NULL_PEN));
+    Polygon(dc, sample, 4);
+    SelectObject(dc, old_sample_pen);
+    SelectObject(dc, old_sample_brush);
+}
+
+void DrawCometProgress(
+    HDC                  dc,
+    const RECT&          track,
+    const WindowContext& context,
+    bool                 failed
+) noexcept {
+    FillSolidRect(dc, track, failed ? BlendColor(kBackground, kFailure, 58) : kAccentDim);
+
+    const int tick_width = (std::max)(Scale(1, context.dpi), 1);
+    for (int x = track.left + Scale(48, context.dpi); x < track.right; x += Scale(48, context.dpi)) {
+        RECT tick{x, track.top, x + tick_width, track.bottom};
+        FillSolidRect(dc, tick, BlendColor(kAccentDim, failed ? kFailure : kAccent, 58));
+    }
+
+    if (failed) {
+        RECT failure_segment{
+            track.left,
+            track.top,
+            track.left + (track.right - track.left) / 5,
+            track.bottom
+        };
+        FillSolidRect(dc, failure_segment, kFailure);
+        return;
+    }
+
+    const int track_width   = track.right - track.left;
+    const int segment_width = (std::max)(Scale(150, context.dpi), track_width / 4);
+    const int travel        = track_width + segment_width;
+    const int phase         = static_cast<int>(context.animation_tick % 110U);
+    const int segment_left  = track.left - segment_width + (travel * phase) / 109;
+    const int saved_dc      = SaveDC(dc);
+    IntersectClipRect(dc, track.left, track.top, track.right, track.bottom);
+
+    constexpr int tail_steps = 6;
+    for (int step = 0; step < tail_steps; ++step) {
+        const int left  = segment_left + (segment_width * step) / tail_steps;
+        const int right = segment_left + (segment_width * (step + 1)) / tail_steps;
+        RECT tail{left, track.top, right, track.bottom};
+        FillSolidRect(dc, tail, BlendColor(kAccentDim, kAccent, 26 + step * 27));
+    }
+
+    const int body_left = segment_left + (segment_width * 2) / 3;
+    RECT body{body_left, track.top, segment_left + segment_width, track.bottom};
+    FillSolidRect(dc, body, kAccent);
+    const int head_width = (std::max)(Scale(7, context.dpi), 2);
+    RECT head{body.right - head_width, track.top, body.right, track.bottom};
+    FillSolidRect(dc, head, kAccentLight);
+    RestoreDC(dc, saved_dc);
+}
+
+void DrawSplashContent(HDC dc, const RECT& client, const WindowContext& context) noexcept {
+    const SplashSnapshot snapshot = context.state->Read();
+    const UINT           dpi      = context.dpi;
+    const int            width    = client.right - client.left;
+    const int            height   = client.bottom - client.top;
+    const COLORREF       active   = snapshot.failed ? kFailure : kAccent;
+
+    FillGradientRect(dc, client, kBackgroundTop, kBackground, false);
+
+    RECT header_panel{0, 0, width, Scale(132, dpi)};
+    FillGradientRect(
+        dc,
+        header_panel,
+        BlendColor(kRaisedBackground, active, snapshot.failed ? 22 : 12),
+        BlendColor(kBackground, active, 5),
+        false
+    );
+
+    RECT mark_rect{
+        Scale(49, dpi),
+        Scale(28, dpi),
+        Scale(117, dpi),
+        Scale(96, dpi)
+    };
+    DrawRayField(dc, client, mark_rect, dpi, snapshot.failed);
+
+    const int separator_y = Scale(128, dpi);
+    DrawLine(
+        dc,
+        Scale(52, dpi),
+        separator_y,
+        width - Scale(52, dpi),
+        separator_y,
+        BlendColor(kBackground, active, 34)
+    );
+    DrawLine(
+        dc,
+        Scale(52, dpi),
+        separator_y,
+        Scale(124, dpi),
+        separator_y,
+        BlendColor(kBackground, active, 178),
+        (std::max)(1, Scale(1, dpi))
+    );
+
+    DrawRayframeMark(dc, mark_rect, context, snapshot.failed);
+
+    SetBkMode(dc, TRANSPARENT);
+
+    RECT product_rect{
+        Scale(137, dpi),
+        Scale(32, dpi),
+        width - Scale(190, dpi),
+        Scale(73, dpi)
+    };
+    SetTextColor(dc, kPrimaryText);
+    SelectFont(dc, context.product_font);
+    DrawTextW(
+        dc,
+        L"MoerEngine",
+        -1,
+        &product_rect,
+        DT_LEFT | DT_VCENTER | DT_SINGLELINE | DT_NOPREFIX
+    );
+
+    RECT edition_rect{
+        Scale(139, dpi),
+        Scale(73, dpi),
+        width - Scale(160, dpi),
+        Scale(101, dpi)
+    };
+    SetTextColor(dc, snapshot.failed ? BlendColor(kMutedText, kFailure, 150) : kAccentLight);
+    SelectFont(dc, context.meta_font);
+    DrawTextW(
+        dc,
+        L"NJU GRAPHICS  /  RESEARCH RENDERER",
+        -1,
+        &edition_rect,
+        DT_LEFT | DT_VCENTER | DT_SINGLELINE | DT_NOPREFIX
+    );
+
+    RECT editor_rect{
+        width - Scale(184, dpi),
+        Scale(35, dpi),
+        width - Scale(52, dpi),
+        Scale(54, dpi)
+    };
+    SetTextColor(dc, kPrimaryText);
+    DrawTextW(
+        dc,
+        L"EDITOR",
+        -1,
+        &editor_rect,
+        DT_RIGHT | DT_VCENTER | DT_SINGLELINE | DT_NOPREFIX
+    );
+
+    RECT boot_rect{
+        width - Scale(184, dpi),
+        Scale(55, dpi),
+        width - Scale(52, dpi),
+        Scale(78, dpi)
+    };
+    SetTextColor(dc, kMutedText);
+    DrawTextW(
+        dc,
+        snapshot.failed ? L"STARTUP FAULT" : L"BOOT SEQUENCE",
+        -1,
+        &boot_rect,
+        DT_RIGHT | DT_VCENTER | DT_SINGLELINE | DT_NOPREFIX
+    );
+
+    const int status_line_x = Scale(52, dpi);
+    DrawLine(
+        dc,
+        status_line_x,
+        Scale(151, dpi),
+        status_line_x,
+        Scale(231, dpi),
+        active,
+        (std::max)(Scale(2, dpi), 2)
+    );
+    const int status_sample_size = (std::max)(Scale(4, dpi), 2);
+    RECT status_sample{
+        status_line_x - status_sample_size / 2,
+        Scale(151, dpi) - status_sample_size / 2,
+        status_line_x + (status_sample_size + 1) / 2,
+        Scale(151, dpi) + (status_sample_size + 1) / 2
+    };
+    FillSolidRect(dc, status_sample, snapshot.failed ? kFailure : kWarmGold);
+
+    RECT stage_label_rect{
+        Scale(69, dpi),
+        Scale(141, dpi),
+        width - Scale(52, dpi),
+        Scale(162, dpi)
+    };
+    SetTextColor(dc, snapshot.failed ? kFailure : kMutedText);
+    SelectFont(dc, context.meta_font);
+    DrawTextW(
+        dc,
+        snapshot.failed ? L"STARTUP STATUS  /  FAILED" : L"CURRENT STAGE",
+        -1,
+        &stage_label_rect,
+        DT_LEFT | DT_VCENTER | DT_SINGLELINE | DT_NOPREFIX
+    );
+
+    RECT title_rect{
+        Scale(69, dpi),
+        Scale(161, dpi),
+        width - Scale(52, dpi),
+        Scale(198, dpi)
+    };
+    SetTextColor(dc, snapshot.failed ? kFailure : kPrimaryText);
+    SelectFont(dc, context.title_font);
+    DrawTextW(
+        dc,
+        snapshot.title.empty() ? L"Starting MoerEditor" : snapshot.title.c_str(),
+        -1,
+        &title_rect,
+        DT_LEFT | DT_VCENTER | DT_SINGLELINE | DT_END_ELLIPSIS | DT_NOPREFIX
+    );
+
+    RECT detail_rect{
+        Scale(69, dpi),
+        Scale(204, dpi),
+        width - Scale(52, dpi),
+        height - Scale(92, dpi)
+    };
+    SetTextColor(dc, kSecondaryText);
+    SelectFont(dc, context.body_font);
+    DrawTextW(
+        dc,
+        snapshot.detail.empty() ? L"Please wait while the editor gets ready." : snapshot.detail.c_str(),
+        -1,
+        &detail_rect,
+        DT_LEFT | DT_TOP | DT_WORDBREAK | DT_END_ELLIPSIS | DT_NOPREFIX
+    );
+
+    const auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+        Clock::now() - context.started_at
+    );
+    const auto minutes = elapsed.count() / 60000;
+    const auto seconds = (elapsed.count() / 1000) % 60;
+    const auto tenths  = (elapsed.count() / 100) % 10;
+    wchar_t elapsed_text[64]{};
+    swprintf_s(
+        elapsed_text,
+        sizeof(elapsed_text) / sizeof(elapsed_text[0]),
+        L"ELAPSED  %02lld:%02lld.%01lld",
+        static_cast<long long>(minutes),
+        static_cast<long long>(seconds),
+        static_cast<long long>(tenths)
+    );
+
+    RECT elapsed_rect{
+        Scale(52, dpi),
+        height - Scale(64, dpi),
+        width / 2,
+        height - Scale(40, dpi)
+    };
+    SetTextColor(dc, snapshot.failed ? kFailure : kMutedText);
+    SelectFont(dc, context.meta_font);
+    DrawTextW(
+        dc,
+        snapshot.failed ? L"STARTUP FAILED" : elapsed_text,
+        -1,
+        &elapsed_rect,
+        DT_LEFT | DT_VCENTER | DT_SINGLELINE | DT_NOPREFIX
+    );
+
+    RECT signature_rect{
+        width / 2,
+        height - Scale(64, dpi),
+        width - Scale(52, dpi),
+        height - Scale(40, dpi)
+    };
+    SetTextColor(
+        dc,
+        snapshot.failed ? BlendColor(kMutedText, kFailure, 150) : BlendColor(kMutedText, kAccent, 86)
+    );
+    DrawTextW(
+        dc,
+        L"RAYFRAME  /  STARTUP",
+        -1,
+        &signature_rect,
+        DT_RIGHT | DT_VCENTER | DT_SINGLELINE | DT_NOPREFIX
+    );
+
+    const int bar_left   = Scale(52, dpi);
+    const int bar_right  = width - Scale(52, dpi);
+    const int bar_top    = height - Scale(27, dpi);
+    const int bar_height = (std::max)(Scale(3, dpi), 2);
+    RECT track{bar_left, bar_top, bar_right, bar_top + bar_height};
+    DrawCometProgress(dc, track, context, snapshot.failed);
+
+    DrawSegmentedViewportFrame(dc, client, dpi, snapshot.failed);
+}
+
+void PaintSplash(HWND window, WindowContext& context) noexcept {
+    PAINTSTRUCT paint{};
+    HDC         window_dc = BeginPaint(window, &paint);
+    if (window_dc == nullptr) {
+        return;
+    }
+
+    RECT client{};
+    GetClientRect(window, &client);
+
+    HDC memory_dc = CreateCompatibleDC(window_dc);
+    if (memory_dc == nullptr) {
+        DrawSplashContent(window_dc, client, context);
+        EndPaint(window, &paint);
+        return;
+    }
+
+    HBITMAP bitmap = CreateCompatibleBitmap(
+        window_dc,
+        (std::max)(1L, client.right - client.left),
+        (std::max)(1L, client.bottom - client.top)
+    );
+    if (bitmap == nullptr) {
+        DeleteDC(memory_dc);
+        DrawSplashContent(window_dc, client, context);
+        EndPaint(window, &paint);
+        return;
+    }
+
+    const auto old_bitmap = SelectObject(memory_dc, bitmap);
+    DrawSplashContent(memory_dc, client, context);
+    BitBlt(
+        window_dc,
+        0,
+        0,
+        client.right - client.left,
+        client.bottom - client.top,
+        memory_dc,
+        0,
+        0,
+        SRCCOPY
+    );
+    SelectObject(memory_dc, old_bitmap);
+    DeleteObject(bitmap);
+    DeleteDC(memory_dc);
+    EndPaint(window, &paint);
+}
+
+RECT CenteredWindowRect(UINT dpi) noexcept;
+void RecenterSplashWindow(HWND window, UINT dpi) noexcept;
+
+LRESULT CALLBACK StartupSplashWindowProc(HWND window, UINT message, WPARAM w_param, LPARAM l_param) noexcept {
+    if (message == WM_NCCREATE) {
+        const auto* create = reinterpret_cast<const CREATESTRUCTW*>(l_param);
+        SetWindowLongPtrW(
+            window,
+            GWLP_USERDATA,
+            reinterpret_cast<LONG_PTR>(create->lpCreateParams)
+        );
+    }
+
+    WindowContext* context = GetWindowContext(window);
+
+    switch (message) {
+        case WM_CREATE:
+            if (context != nullptr) {
+                context->RecreateFonts(GetDpiForWindow(window));
+            }
+            SetTimer(window, kAnimationTimerId, kAnimationPeriod, nullptr);
+            return 0;
+
+        case WM_DPICHANGED: {
+            const UINT new_dpi = HIWORD(w_param);
+            if (context != nullptr) {
+                context->RecreateFonts(new_dpi);
+            }
+            RecenterSplashWindow(window, new_dpi);
+            return 0;
+        }
+
+        case WM_DISPLAYCHANGE:
+        case WM_SETTINGCHANGE:
+            RecenterSplashWindow(window, GetDpiForWindow(window));
+            return 0;
+
+        case WM_TIMER:
+            if (w_param == kAnimationTimerId && context != nullptr) {
+                ++context->animation_tick;
+
+                const auto now = Clock::now();
+                if (context->finish_requested && context->finish_requested_at.has_value() &&
+                    now - context->started_at >= kMinimumVisibleTime &&
+                    now - *context->finish_requested_at >= kHandoffOverlapTime) {
+                    context->fading_out = true;
+                }
+
+                if (context->fading_out) {
+                    if (context->opacity <= 32) {
+                        DestroyWindow(window);
+                        return 0;
+                    }
+                    context->opacity = static_cast<BYTE>(context->opacity - 32);
+                    SetLayeredWindowAttributes(window, 0, context->opacity, LWA_ALPHA);
+                } else if (context->opacity < 255) {
+                    const auto next_opacity = (std::min)(static_cast<int>(context->opacity) + 32, 255);
+                    context->opacity        = static_cast<BYTE>(next_opacity);
+                    SetLayeredWindowAttributes(window, 0, context->opacity, LWA_ALPHA);
+                }
+
+                InvalidateRect(window, nullptr, FALSE);
+            }
+            return 0;
+
+        case kRefreshMessage:
+            InvalidateRect(window, nullptr, FALSE);
+            return 0;
+
+        case kFinishMessage:
+            if (context != nullptr) {
+                context->finish_requested    = true;
+                context->finish_requested_at = Clock::now();
+            }
+            return 0;
+
+        case kKeepOpenMessage:
+            if (context != nullptr) {
+                context->finish_requested = false;
+                context->fading_out       = false;
+                context->finish_requested_at.reset();
+            }
+            InvalidateRect(window, nullptr, FALSE);
+            return 0;
+
+        case kStopMessage:
+            DestroyWindow(window);
+            return 0;
+
+        case WM_NCHITTEST:
+            // Match UE-style splash behavior: the window is a fixed startup
+            // surface, not a draggable borderless application window.
+            return HTCLIENT;
+
+        case WM_SYSCOMMAND: {
+            const WPARAM command = w_param & 0xFFF0U;
+            if (command == SC_MOVE || command == SC_SIZE) {
+                return 0;
+            }
+            break;
+        }
+
+        case WM_ERASEBKGND:
+            return 1;
+
+        case WM_PAINT:
+            if (context != nullptr) {
+                PaintSplash(window, *context);
+                return 0;
+            }
+            break;
+
+        case WM_CLOSE:
+            DestroyWindow(window);
+            return 0;
+
+        case WM_DESTROY:
+            KillTimer(window, kAnimationTimerId);
+            PostQuitMessage(0);
+            return 0;
+
+        case WM_NCDESTROY:
+            SetWindowLongPtrW(window, GWLP_USERDATA, 0);
+            break;
+
+        default:
+            break;
+    }
+
+    return DefWindowProcW(window, message, w_param, l_param);
+}
+
+bool EnsureWindowClassRegistered() noexcept {
+    static std::once_flag register_once;
+    static bool           registered = false;
+
+    std::call_once(register_once, []() {
+        WNDCLASSEXW window_class{};
+        window_class.cbSize        = sizeof(window_class);
+        window_class.style         = CS_HREDRAW | CS_VREDRAW;
+        window_class.lpfnWndProc   = StartupSplashWindowProc;
+        window_class.hInstance     = GetModuleHandleW(nullptr);
+        window_class.hCursor       = LoadCursorW(nullptr, MAKEINTRESOURCEW(32512));
+        window_class.hbrBackground = nullptr;
+        window_class.lpszClassName = kWindowClassName;
+
+        registered = RegisterClassExW(&window_class) != 0 || GetLastError() == ERROR_CLASS_ALREADY_EXISTS;
+    });
+
+    return registered;
+}
+
+UINT GetInitialDpi() noexcept {
+    const UINT dpi = GetDpiForSystem();
+    if (dpi > 0) {
+        return dpi;
+    }
+    return USER_DEFAULT_SCREEN_DPI;
+}
+
+RECT CenteredWindowRect(UINT dpi) noexcept {
+    MONITORINFO monitor_info{};
+    monitor_info.cbSize = sizeof(monitor_info);
+    // MoerEditor currently targets the primary display by default. Keep the
+    // splash anchored to the same display instead of following the cursor.
+    const HMONITOR monitor = MonitorFromPoint(POINT{0, 0}, MONITOR_DEFAULTTOPRIMARY);
+    if (!GetMonitorInfoW(monitor, &monitor_info)) {
+        monitor_info.rcWork = RECT{0, 0, GetSystemMetrics(SM_CXSCREEN), GetSystemMetrics(SM_CYSCREEN)};
+    }
+
+    const int available_width  = monitor_info.rcWork.right - monitor_info.rcWork.left;
+    const int available_height = monitor_info.rcWork.bottom - monitor_info.rcWork.top;
+    const int width            = (std::min)(Scale(kLogicalWindowWidth, dpi), available_width);
+    const int height           = (std::min)(Scale(kLogicalWindowHeight, dpi), available_height);
+    const int left             = monitor_info.rcWork.left + (available_width - width) / 2;
+    const int top              = monitor_info.rcWork.top + (available_height - height) / 2;
+    return RECT{left, top, left + width, top + height};
+}
+
+void RecenterSplashWindow(HWND window, UINT dpi) noexcept {
+    const RECT centered = CenteredWindowRect(dpi == 0 ? USER_DEFAULT_SCREEN_DPI : dpi);
+    SetWindowPos(
+        window,
+        nullptr,
+        centered.left,
+        centered.top,
+        centered.right - centered.left,
+        centered.bottom - centered.top,
+        SWP_NOACTIVATE | SWP_NOZORDER
+    );
+}
+
+class ThreadDpiScope final {
+public:
+    ThreadDpiScope() noexcept
+        : m_previous(SetThreadDpiAwarenessContext(DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2)) {}
+
+    ~ThreadDpiScope() {
+        if (m_previous != nullptr) {
+            SetThreadDpiAwarenessContext(m_previous);
+        }
+    }
+
+private:
+    DPI_AWARENESS_CONTEXT m_previous = nullptr;
+};
+
+} // namespace
+
+class StartupSplash::Impl final {
+public:
+    Impl()
+        : m_state(std::make_shared<SharedSplashState>()) {}
+
+    ~Impl() {
+        StopAndJoin();
+    }
+
+    [[nodiscard]] bool Start(std::string_view title, std::string_view detail) noexcept {
+        std::unique_lock lifecycle_lock(m_lifecycle_mutex);
+
+        m_failed.store(false, std::memory_order_release);
+        m_finish_requested.store(false, std::memory_order_release);
+        SetStatus(title, detail, false);
+        if (m_running.load(std::memory_order_acquire)) {
+            PostToWindow(kKeepOpenMessage);
+            return true;
+        }
+
+        if (m_ui_thread.joinable()) {
+            m_ui_thread.join();
+        }
+
+        m_finish_requested.store(false, std::memory_order_release);
+        m_stop_requested.store(false, std::memory_order_release);
+        m_window.store(nullptr, std::memory_order_release);
+        {
+            std::scoped_lock ready_lock(m_ready_mutex);
+            m_ready        = false;
+            m_window_ready = false;
+        }
+
+        try {
+            m_running.store(true, std::memory_order_release);
+            m_ui_thread = std::thread([this]() noexcept { RunUiThread(); });
+        } catch (...) {
+            m_running.store(false, std::memory_order_release);
+            return false;
+        }
+
+        lifecycle_lock.unlock();
+
+        std::unique_lock ready_lock(m_ready_mutex);
+        if (!m_ready_condition.wait_for(ready_lock, std::chrono::milliseconds(1500), [this]() { return m_ready; })) {
+            // Do not allow a late-created splash to appear after the caller has
+            // already fallen back to a visible main window.
+            m_stop_requested.store(true, std::memory_order_release);
+            PostToWindow(kStopMessage);
+            return false;
+        }
+        return m_window_ready;
+    }
+
+    void Update(std::string_view title, std::string_view detail) noexcept {
+        SetStatus(title, detail, m_failed.load(std::memory_order_acquire));
+        PostToWindow(kRefreshMessage);
+    }
+
+    void Finish() noexcept {
+        m_finish_requested.store(true, std::memory_order_release);
+        PostToWindow(kFinishMessage);
+    }
+
+    void Fail(std::string_view title, std::string_view detail) noexcept {
+        m_failed.store(true, std::memory_order_release);
+        m_finish_requested.store(false, std::memory_order_release);
+        SetStatus(title, detail, true);
+        PostToWindow(kKeepOpenMessage);
+    }
+
+    [[nodiscard]] bool IsRunning() const noexcept {
+        return m_running.load(std::memory_order_acquire);
+    }
+
+private:
+    void SetStatus(std::string_view title, std::string_view detail, bool failed) noexcept {
+        try {
+            m_state->Set(Utf8ToWide(title), Utf8ToWide(detail), failed);
+        } catch (...) {
+            // A splash screen must never turn an allocation or encoding failure
+            // into an editor startup failure. Keep the previous snapshot.
+        }
+    }
+
+    void PostToWindow(UINT message) const noexcept {
+        if (const HWND window = m_window.load(std::memory_order_acquire); window != nullptr) {
+            PostMessageW(window, message, 0, 0);
+        }
+    }
+
+    void SignalReady(bool window_ready) noexcept {
+        {
+            std::scoped_lock lock(m_ready_mutex);
+            m_ready        = true;
+            m_window_ready = window_ready;
+        }
+        m_ready_condition.notify_all();
+    }
+
+    void RunUiThread() noexcept {
+        bool ready_signalled = false;
+        try {
+            ThreadDpiScope dpi_scope;
+            if (!EnsureWindowClassRegistered()) {
+                SignalReady(false);
+                ready_signalled = true;
+                m_running.store(false, std::memory_order_release);
+                return;
+            }
+
+            WindowContext context(m_state);
+            const UINT    dpi         = GetInitialDpi();
+            const RECT    window_rect = CenteredWindowRect(dpi);
+            HWND          window      = CreateWindowExW(
+                WS_EX_TOOLWINDOW | WS_EX_TOPMOST | WS_EX_NOACTIVATE | WS_EX_LAYERED,
+                kWindowClassName,
+                kWindowTitle,
+                WS_POPUP,
+                window_rect.left,
+                window_rect.top,
+                window_rect.right - window_rect.left,
+                window_rect.bottom - window_rect.top,
+                nullptr,
+                nullptr,
+                GetModuleHandleW(nullptr),
+                &context
+            );
+            if (window == nullptr) {
+                SignalReady(false);
+                ready_signalled = true;
+                m_running.store(false, std::memory_order_release);
+                return;
+            }
+
+            // The process may start on a monitor whose effective DPI differs
+            // from the system DPI used for the bootstrap rectangle. Resize and
+            // re-center before the first ShowWindow so logical content is never
+            // clipped on mixed-DPI desktops.
+            RecenterSplashWindow(window, GetDpiForWindow(window));
+
+            m_window.store(window, std::memory_order_release);
+            SignalReady(true);
+            ready_signalled = true;
+
+            // Signal creation before making the native window visible. If Start
+            // timed out, it still owns the readiness mutex while setting the
+            // stop flag; SignalReady then unblocks behind it and this check
+            // prevents a late splash from flashing over the visible main window.
+            if (m_stop_requested.load(std::memory_order_acquire)) {
+                DestroyWindow(window);
+                m_window.store(nullptr, std::memory_order_release);
+                m_running.store(false, std::memory_order_release);
+                return;
+            }
+
+            SetLayeredWindowAttributes(window, 0, 0, LWA_ALPHA);
+            ShowWindow(window, SW_SHOWNOACTIVATE);
+            UpdateWindow(window);
+
+            if (m_finish_requested.load(std::memory_order_acquire)) {
+                context.finish_requested    = true;
+                context.finish_requested_at = Clock::now();
+            }
+
+            MSG message{};
+            while (GetMessageW(&message, nullptr, 0, 0) > 0) {
+                TranslateMessage(&message);
+                DispatchMessageW(&message);
+            }
+
+            m_window.store(nullptr, std::memory_order_release);
+            m_running.store(false, std::memory_order_release);
+        } catch (...) {
+            m_window.store(nullptr, std::memory_order_release);
+            m_running.store(false, std::memory_order_release);
+            if (!ready_signalled) {
+                SignalReady(false);
+            }
+        }
+    }
+
+    void StopAndJoin() noexcept {
+        m_stop_requested.store(true, std::memory_order_release);
+        PostToWindow(kStopMessage);
+
+        std::scoped_lock lifecycle_lock(m_lifecycle_mutex);
+        if (m_ui_thread.joinable()) {
+            m_ui_thread.join();
+        }
+        m_running.store(false, std::memory_order_release);
+    }
+
+    std::shared_ptr<SharedSplashState> m_state;
+    std::thread                        m_ui_thread;
+    mutable std::mutex                 m_lifecycle_mutex;
+    mutable std::mutex                 m_ready_mutex;
+    std::condition_variable            m_ready_condition;
+    bool                               m_ready        = false;
+    bool                               m_window_ready = false;
+    std::atomic<HWND>                  m_window{nullptr};
+    std::atomic<bool>                  m_running{false};
+    std::atomic<bool>                  m_finish_requested{false};
+    std::atomic<bool>                  m_stop_requested{false};
+    std::atomic<bool>                  m_failed{false};
+};
+
+StartupSplash::StartupSplash()
+    : m_impl(std::make_unique<Impl>()) {}
+
+StartupSplash::~StartupSplash() = default;
+
+bool StartupSplash::Start(std::string_view title, std::string_view detail) noexcept {
+    return m_impl->Start(title, detail);
+}
+
+void StartupSplash::Update(std::string_view title, std::string_view detail) noexcept {
+    m_impl->Update(title, detail);
+}
+
+void StartupSplash::Finish() noexcept {
+    m_impl->Finish();
+}
+
+void StartupSplash::Fail(std::string_view title, std::string_view detail) noexcept {
+    m_impl->Fail(title, detail);
+}
+
+bool StartupSplash::IsRunning() const noexcept {
+    return m_impl->IsRunning();
+}
+
+} // namespace Moer
+
+#else
+
+namespace Moer {
+
+class StartupSplash::Impl final {
+public:
+    [[nodiscard]] bool Start(std::string_view, std::string_view) noexcept {
+        return false;
+    }
+
+    void Update(std::string_view, std::string_view) noexcept {}
+    void Finish() noexcept {}
+    void Fail(std::string_view, std::string_view) noexcept {}
+
+    [[nodiscard]] bool IsRunning() const noexcept {
+        return false;
+    }
+};
+
+StartupSplash::StartupSplash()
+    : m_impl(std::make_unique<Impl>()) {}
+
+StartupSplash::~StartupSplash() = default;
+
+bool StartupSplash::Start(std::string_view title, std::string_view detail) noexcept {
+    return m_impl->Start(title, detail);
+}
+
+void StartupSplash::Update(std::string_view title, std::string_view detail) noexcept {
+    m_impl->Update(title, detail);
+}
+
+void StartupSplash::Finish() noexcept {
+    m_impl->Finish();
+}
+
+void StartupSplash::Fail(std::string_view title, std::string_view detail) noexcept {
+    m_impl->Fail(title, detail);
+}
+
+bool StartupSplash::IsRunning() const noexcept {
+    return m_impl->IsRunning();
+}
+
+} // namespace Moer
+
+#endif

--- a/source/editor/startup/StartupSplash.h
+++ b/source/editor/startup/StartupSplash.h
@@ -1,0 +1,46 @@
+#pragma once
+
+#include <memory>
+#include <string_view>
+
+namespace Moer {
+
+// A renderer-independent startup window. On Windows the native window and its
+// message pump live entirely on a dedicated UI thread. Other platforms expose
+// the same API as a safe no-op so startup call sites need no platform guards.
+class StartupSplash final {
+public:
+    StartupSplash();
+    ~StartupSplash();
+
+    StartupSplash(const StartupSplash&)            = delete;
+    StartupSplash& operator=(const StartupSplash&) = delete;
+    StartupSplash(StartupSplash&&)                 = delete;
+    StartupSplash& operator=(StartupSplash&&)      = delete;
+
+    // Starts the native UI thread and waits only until window creation has
+    // succeeded or failed. Calling Start again while running updates the text.
+    [[nodiscard]] bool Start(
+        std::string_view title  = "Starting MoerEditor",
+        std::string_view detail = "Preparing engine services"
+    ) noexcept;
+
+    // Copies the strings before returning; callers may pass temporary data.
+    void Update(std::string_view title, std::string_view detail = {}) noexcept;
+
+    // Begins a short, asynchronous fade-out. Destruction always joins the UI
+    // thread, even when Finish was not called explicitly.
+    void Finish() noexcept;
+
+    // Switches to a persistent error presentation. Call Finish when the error
+    // has been reported through the editor's normal error handling path.
+    void Fail(std::string_view title, std::string_view detail = {}) noexcept;
+
+    [[nodiscard]] bool IsRunning() const noexcept;
+
+private:
+    class Impl;
+    std::unique_ptr<Impl> m_impl;
+};
+
+} // namespace Moer

--- a/source/runtime/Engine.cpp
+++ b/source/runtime/Engine.cpp
@@ -32,6 +32,7 @@
 #include <string>
 #include <string_view>
 #include <type_traits>
+#include <utility>
 
 // namespace
 using namespace Moer::Render;
@@ -442,19 +443,43 @@ void Engine::ValidateCommandLine(int argc, const char** argv) {
 }
 
 Engine::~Engine() {
-    assert(m_has_shutdown && "Engine::ShutDown() was not called before Engine destruction!");
+    ShutDown();
 }
 
-void Engine::Init(int argc, const char** argv) {
+void Engine::Init(
+    int                            argc,
+    const char**                   argv,
+    bool                           main_window_visible,
+    const StartupProgressCallback& on_startup_progress
+) {
     ScopedLogTimer startup_timer("[Startup][Engine] Engine::Init total");
+
+    bool startup_logging_ready = false;
+    const auto report_startup = [&](std::string_view title, std::string_view detail) {
+        try {
+            if (on_startup_progress) {
+                on_startup_progress(title, detail);
+            }
+        } catch (...) {
+            // Startup reporting is optional and must never prevent the editor
+            // from reaching its normal error handling path.
+        }
+        if (startup_logging_ready) {
+            LOG_INFO("[Startup][Progress] {} - {}", title, detail);
+        }
+    };
+
+    report_startup("Starting engine core", "Initializing logging and configuration");
 
     // Init LogSystem
     LogSystem::Init(); // for LOG_DEBUG & LOG_TRACE when debug mode
+    startup_logging_ready = true;
 
     // Init ConfigManager
     std::filesystem::path path = argv[0];
     path = path.filename().string().find(".exe") != std::string::npos ? path.parent_path() : path;
 
+    report_startup("Reading configuration", path.string());
     LOG_INFO("Workspace Path : {}", path.string());
 
     if (ContainsNonAscii(path)) {
@@ -486,7 +511,9 @@ void Engine::Init(int argc, const char** argv) {
     }
 
     // Init TaskSystem
+    report_startup("Starting worker services", "Creating task-graph worker threads");
     TaskSystem::Init();
+    m_task_system_initialized = true;
 
     LOG_INFO("[Threading] GameThread id = {}", GetGameThreadId());
     LOG_INFO(
@@ -500,6 +527,7 @@ void Engine::Init(int argc, const char** argv) {
     );
 
     if (config.engine.threading.render_thread) {
+        report_startup("Starting render thread", "Creating the configured render-thread service");
         m_max_frame_lag = std::min(config.engine.threading.max_frame_lag, uint{1});
         if (config.engine.threading.max_frame_lag > 1) {
             LOG_WARNING(
@@ -533,6 +561,14 @@ void Engine::Init(int argc, const char** argv) {
         return ERHIType::Vulkan;
     }();
 
+    report_startup(
+        "Initializing graphics device",
+        rhi_type == ERHIType::Vulkan ? "Creating the Vulkan device, queues, and descriptors" :
+                                       "Creating the D3D12 device, queues, and descriptors"
+    );
+    // Dispose is safe when initialization leaves a partially constructed
+    // implementation behind, so arm cleanup before entering the backend.
+    m_render_device_initialized = true;
     RenderDevice::Init(
         std::move(
             DeviceInitInfo{
@@ -547,7 +583,9 @@ void Engine::Init(int argc, const char** argv) {
         )
     );
 
+    report_startup("Loading shader cache", "Restoring compiled shaders and pipeline metadata");
     ShaderManager::Get(); // Explicit Init ShaderManager
+    m_shader_manager_initialized = true;
 
     m_editor_config = MakeShared<EditorConfig>();
     m_editor_config->selected_render_method =
@@ -576,19 +614,27 @@ void Engine::Init(int argc, const char** argv) {
         b_fullscreen
     );
 
+    report_startup(
+        "Creating editor window",
+        main_window_visible ? "Preparing the main window" : "Keeping the main window hidden until its first frame"
+    );
     WindowContext::Init(SurfaceInitInfo(
         RenderDevice::Get().GetRHIType(),
         m_editor_config->GetResolution().x,
         m_editor_config->GetResolution().y,
         "MoerEditor",
-        b_fullscreen
+        b_fullscreen,
+        main_window_visible
     ));
+    m_window_context_initialized = true;
 
+    report_startup("Loading editor resources", "Uploading editor textures and environment assets");
     m_runtime_assets =
         MakeUnique<RuntimeAssets>(ConfigManager::GetInstance().GetEditorResourcePath(), RenderDevice::Get());
     m_runtime_assets->WaitUntilReady();
     LOG_INFO("[Threading] RuntimeAssets are immutable-ready before renderer/UI frame overlap begins.");
 
+    report_startup("Starting editor services", "Initializing Python scripting and remote control");
     m_script_host = MakeUnique<scripting::ScriptHost>(scripting::PythonRuntimeConfig::Default());
     m_script_host->Start();
 
@@ -603,10 +649,28 @@ void Engine::Init(int argc, const char** argv) {
     if (remote_enabled_by_config && !m_remote_module->SetEnabled(true)) {
         LOG_WARNING("Remote module failed to start. Continue running without remote access.");
     }
+    report_startup("Engine core ready", "Preparing the editor interface");
 }
 
 void Engine::Run(const EngineHooks& hooks) {
     EngineHooks runtime_hooks = hooks;
+    auto        on_first_main_present = std::move(runtime_hooks.on_first_main_present);
+    runtime_hooks.on_first_main_present =
+        [this, callback = std::move(on_first_main_present)]() mutable {
+            assert(IsCurrentlyGameThread());
+            if (m_first_main_present_notified) {
+                return;
+            }
+            m_first_main_present_notified = true;
+            LOG_INFO("[Startup][Engine] First main-window present submitted on the Game Thread.");
+            if (callback) {
+                try {
+                    callback();
+                } catch (...) {
+                    LOG_WARNING("[Startup][Engine] Ignoring an exception from the first-present hook.");
+                }
+            }
+        };
     const bool thread_profile_logging =
         ConfigManager::GetInstance().GetConfig().engine.threading.profile_logging;
     runtime_hooks.on_tick_scripting = [this](Scene& scene) {
@@ -660,9 +724,24 @@ void Engine::Run(const EngineHooks& hooks) {
 
         const bool use_render_thread = m_render_thread_service != nullptr;
 
+        if (runtime_hooks.on_startup_progress && !m_first_main_present_notified) {
+            runtime_hooks.on_startup_progress(
+                "Loading scene and renderer",
+                selected_render_method == ERenderMethod::Raster ?
+                    "Loading the scene and creating Raster pipelines" :
+                    "Loading the scene and creating Raytracing pipelines"
+            );
+        }
+
         if (use_render_thread) {
             m_render_thread_service->RunAndWait(std::move(create_renderer));
             assert(m_renderer && m_renderer->SupportsSynchronizedRenderThread());
+
+            if (runtime_hooks.on_startup_progress && !m_first_main_present_notified) {
+                runtime_hooks.on_startup_progress(
+                    "Preparing first frame", "Uploading scene data and warming the renderer"
+                );
+            }
 
             if (runtime_hooks.on_show_config_sub_ui) {
                 runtime_hooks.on_show_config_sub_ui();
@@ -702,9 +781,13 @@ void Engine::Run(const EngineHooks& hooks) {
                     [raytracing_renderer](Raytracing::RaytracingFramePacket frame_packet) {
                         return raytracing_renderer->RenderFrame(std::move(frame_packet));
                     },
-                    [this, raytracing_renderer](Raytracing::RaytracingFrameFeedback feedback) {
+                    [this, raytracing_renderer, &runtime_hooks](
+                        Raytracing::RaytracingFrameFeedback feedback
+                    ) {
                         raytracing_renderer->ApplyFrameFeedback(
-                            std::move(feedback), m_editor_config->raytracing_config
+                            std::move(feedback),
+                            m_editor_config->raytracing_config,
+                            runtime_hooks
                         );
                     },
                     [&runtime_hooks]() {
@@ -718,6 +801,11 @@ void Engine::Run(const EngineHooks& hooks) {
             }
         } else {
             create_renderer();
+            if (runtime_hooks.on_startup_progress && !m_first_main_present_notified) {
+                runtime_hooks.on_startup_progress(
+                    "Preparing first frame", "Uploading scene data and warming the renderer"
+                );
+            }
             if (runtime_hooks.on_show_config_sub_ui) {
                 runtime_hooks.on_show_config_sub_ui();
             }
@@ -729,7 +817,8 @@ void Engine::Run(const EngineHooks& hooks) {
                         raytracing_renderer->PrepareFrame(m_editor_config, runtime_hooks);
                     raytracing_renderer->ApplyFrameFeedback(
                         raytracing_renderer->RenderFrame(std::move(frame_packet)),
-                        m_editor_config->raytracing_config
+                        m_editor_config->raytracing_config,
+                        runtime_hooks
                     );
 
                     if (runtime_hooks.should_reload && runtime_hooks.should_reload()) {
@@ -882,33 +971,73 @@ scripting::ScriptExecutionFuture Engine::SubmitScriptExecution(scripting::Script
     return scripting::ScriptExecutionFuture(promise.get_future());
 }
 
-void Engine::ShutDown() {
+void Engine::ShutDown() noexcept {
+    if (m_has_shutdown) {
+        return;
+    }
+    m_has_shutdown = true;
+
+    const auto cleanup = []<typename Action>(Action&& action) noexcept {
+        try {
+            std::forward<Action>(action)();
+        } catch (...) {
+            // Shutdown is also the rollback path for partial startup. Continue
+            // releasing later subsystems even if one cleanup operation fails.
+        }
+    };
+
     if (m_remote_module) {
-        m_remote_module->Stop();
+        cleanup([this]() { m_remote_module->Stop(); });
         m_remote_module.reset();
     }
 
     if (m_script_host) {
-        m_script_host->CancelPendingSceneCommands("Scene became unavailable during engine shutdown.");
-        m_script_host->Stop();
+        cleanup([this]() {
+            m_script_host->CancelPendingSceneCommands(
+                "Scene became unavailable during engine shutdown."
+            );
+            m_script_host->Stop();
+        });
         m_script_host.reset();
     }
 
+    if (m_renderer && m_render_thread_service) {
+        cleanup([this]() {
+            m_render_thread_service->RunAndWait([this]() { m_renderer.reset(); });
+        });
+    }
+    // RunAndWait can itself fail while unwinding a render-thread exception.
+    // Destruction on the Game Thread is the final shutdown fallback.
+    m_renderer.reset();
+
     if (m_render_thread_service) {
-        LOG_INFO("[Threading] Stopping Render Thread service.");
-        m_render_thread_service->Stop();
+        cleanup([this]() {
+            LOG_INFO("[Threading] Stopping Render Thread service.");
+            m_render_thread_service->Stop();
+            LOG_INFO("[Threading] Render Thread service stopped.");
+        });
         m_render_thread_service.reset();
-        LOG_INFO("[Threading] Render Thread service stopped.");
     }
 
     m_runtime_assets.reset(); // 释放RuntimeAssets资源
 
-    WindowContext::ShutDown();
-    ShaderManager::ShutDown();
-    RenderDevice::Dispose();
-    TaskSystem::ShutDown();
-
-    m_has_shutdown = true;
+    if (m_window_context_initialized) {
+        m_window_context_initialized = false;
+        cleanup([]() { WindowContext::ShutDown(); });
+    }
+    if (m_shader_manager_initialized) {
+        m_shader_manager_initialized = false;
+        cleanup([]() { ShaderManager::ShutDown(); });
+    }
+    if (m_render_device_initialized) {
+        m_render_device_initialized = false;
+        cleanup([]() { RenderDevice::Dispose(); });
+    }
+    if (m_task_system_initialized) {
+        m_task_system_initialized = false;
+        cleanup([]() { TaskSystem::ShutDown(); });
+    }
+    m_editor_config.reset();
 }
 
 void Engine::Init3rdParty() {

--- a/source/runtime/Engine.h
+++ b/source/runtime/Engine.h
@@ -5,6 +5,8 @@
 #include "scripting/ScriptExecutionFuture.h"
 #include "scripting/ScriptExecutionRequest.h"
 
+#include <string_view>
+
 namespace Moer::scripting {
 class ScriptHost;
 }
@@ -21,12 +23,20 @@ class RenderThreadService;
 
 class RENDER_API Engine {
 public:
+    using StartupProgressCallback =
+        std::function<void(std::string_view title, std::string_view detail)>;
+
     Engine();
     virtual ~Engine();
 
     static void ValidateCommandLine(int argc, const char** argv);
 
-    void Init(int argc, const char** argv);
+    void Init(
+        int                            argc,
+        const char**                   argv,
+        bool                           main_window_visible = true,
+        const StartupProgressCallback& on_startup_progress = {}
+    );
     void Run(const Render::EngineHooks& hooks);
     void RequestExit();
 
@@ -34,7 +44,7 @@ public:
     remote::RemoteModuleController GetRemoteModuleController() const;
 
     scripting::ScriptExecutionFuture SubmitScriptExecution(scripting::ScriptExecutionRequest request);
-    void                             ShutDown();
+    void                             ShutDown() noexcept;
 
     uint2& GetResolution() {
         return m_editor_config->GetResolution();
@@ -71,6 +81,11 @@ private:
 
     uint m_max_frame_lag = 0;
     bool m_has_shutdown = false;
+    bool m_first_main_present_notified = false;
+    bool m_task_system_initialized     = false;
+    bool m_render_device_initialized   = false;
+    bool m_shader_manager_initialized  = false;
+    bool m_window_context_initialized  = false;
 
     // Validation state is accessed only by Game Thread hooks. Render work is drained before reload.
     ERendererSwitchValidationStage m_renderer_switch_validation_stage =

--- a/source/runtime/render/renderer/Renderer.cpp
+++ b/source/runtime/render/renderer/Renderer.cpp
@@ -61,6 +61,72 @@ Renderer::Renderer(uint2 initial_resolution, const SharedPtr<EditorConfig> confi
 
 Renderer::~Renderer() = default;
 
+PresentReceiptRef Renderer::CreateMainPresentReceipt(bool scene_content_ready) {
+    if (first_main_present_confirmed.load(std::memory_order_acquire)) {
+        return {};
+    }
+
+    constexpr auto scene_ready_grace_period = std::chrono::seconds(3);
+    const auto     now                      = std::chrono::steady_clock::now();
+    if (!scene_content_ready) {
+        if (!first_present_candidate_started_at.has_value()) {
+            first_present_candidate_started_at = now;
+            return {};
+        }
+        if (now - *first_present_candidate_started_at < scene_ready_grace_period) {
+            return {};
+        }
+    }
+
+    if (!first_present_receipt_logged) {
+        first_present_receipt_logged = true;
+        if (scene_content_ready) {
+            LOG_INFO(
+                "[Startup][Renderer] First-present receipt armed: scene_content_ready=true."
+            );
+        } else {
+            LOG_WARNING(
+                "[Startup][Renderer] Scene content was not ready within 3 seconds of the first "
+                "drawable frame; arming a fallback Present receipt so the editor remains usable."
+            );
+        }
+    }
+    return MakeShared<PresentReceipt>();
+}
+
+void Renderer::ApplyMainPresentReceipt(const PresentReceiptRef& receipt, const EngineHooks& hooks) {
+    assert(IsCurrentlyGameThread());
+    if (!receipt || first_main_present_confirmed.load(std::memory_order_acquire)) {
+        return;
+    }
+
+    const PresentReceiptResult result = receipt->WaitForSubmission();
+    if (!result.resolved) {
+        LOG_WARNING(
+            "[Startup][Renderer] Timed out after 10 seconds while waiting for the main-window "
+            "Present receipt; keeping the Splash responsive and retrying on a later frame."
+        );
+        return;
+    }
+    if (result.recreate_swapchain) {
+        main_swapchain_recreate_requested.store(true, std::memory_order_release);
+        LOG_INFO(
+            "[Startup][Renderer] Main swapchain requested recreation before the startup handoff."
+        );
+    }
+    if (!result.submitted) {
+        return;
+    }
+
+    bool expected = false;
+    if (first_main_present_confirmed.compare_exchange_strong(
+            expected, true, std::memory_order_acq_rel, std::memory_order_acquire
+        ) &&
+        hooks.on_first_main_present) {
+        hooks.on_first_main_present();
+    }
+}
+
 void Renderer::ReleaseResources() {
     if (resources_released) {
         return;
@@ -105,7 +171,18 @@ void Renderer::PrepareRenderFrame(const WindowFrameState& window_frame) {
         timeline->Wait(time - max_frame_in_flight);
     }
 
-    if (window_frame.state != EWindowState::SizeChanged) {
+    const bool recreate_requested =
+        main_swapchain_recreate_requested.exchange(false, std::memory_order_acq_rel);
+    if (window_frame.state == EWindowState::Hiding) {
+        if (recreate_requested) {
+            // A zero-extent swapchain cannot be recreated. Preserve the WSI
+            // recovery request until the window has a drawable extent again.
+            main_swapchain_recreate_requested.store(true, std::memory_order_release);
+        }
+        return;
+    }
+
+    if (window_frame.state != EWindowState::SizeChanged && !recreate_requested) {
         return;
     }
 

--- a/source/runtime/render/renderer/Renderer.h
+++ b/source/runtime/render/renderer/Renderer.h
@@ -13,6 +13,9 @@
 #include "common/UIRenderer.h"
 #include "common/UiCombinePass.h"
 
+#include <atomic>
+#include <chrono>
+#include <optional>
 #include <string_view>
 
 namespace Moer::Render {
@@ -44,6 +47,13 @@ struct EngineHooks {
     std::function<void(std::string)> on_unregister_ui_func;
 
     std::function<void()> on_show_config_sub_ui;
+
+    // Reports coarse startup stages without coupling Runtime to an editor UI.
+    std::function<void(std::string_view title, std::string_view detail)> on_startup_progress;
+
+    // Invoked on the Game Thread after the first submitted main-swapchain Present.
+    // Engine gates this hook for its full lifetime, including renderer reloads.
+    std::function<void()> on_first_main_present;
 
     // Raster
     std::function<void(const Array<std::string>&)> on_raster_register_frame_buffer_names;
@@ -88,6 +98,8 @@ public:
 
 protected:
     void               PrepareRenderFrame(const WindowFrameState& window_frame);
+    PresentReceiptRef  CreateMainPresentReceipt(bool scene_content_ready);
+    void ApplyMainPresentReceipt(const PresentReceiptRef& receipt, const EngineHooks& hooks);
     [[nodiscard]] bool IsFramePrepareProfilingEnabled() const {
         return frame_prepare_profile_state != nullptr;
     }
@@ -121,6 +133,10 @@ protected:
     uint64   time;
     bool     first_load;
     bool     resources_released = false;
+    mutable std::atomic<bool> first_main_present_confirmed{false};
+    std::atomic<bool> main_swapchain_recreate_requested{false};
+    std::optional<std::chrono::steady_clock::time_point> first_present_candidate_started_at;
+    bool first_present_receipt_logged = false;
     uint     max_frame_in_flight;
 
     UniquePtr<FramePrepareProfileState> frame_prepare_profile_state;

--- a/source/runtime/render/renderer/raster/RasterFramePacket.h
+++ b/source/runtime/render/renderer/raster/RasterFramePacket.h
@@ -31,6 +31,7 @@ static_assert(!std::is_copy_constructible_v<RasterFramePacket>);
 
 struct RasterFrameFeedback {
     uint64_t                    frame_id = 0;
+    PresentReceiptRef           main_present_receipt{};
     RasterConfig::CullingStats  culling_stats{};
     CooperativeOpsStatus        cooperative_ops_status{};
     Array<std::string>          displayable_frame_buffer_names;

--- a/source/runtime/render/renderer/raster/RasterRenderer.cpp
+++ b/source/runtime/render/renderer/raster/RasterRenderer.cpp
@@ -454,7 +454,8 @@ RasterFrameFeedback RasterRenderer::RenderFrame(RasterFramePacket frame_packet) 
         );
     }
 
-    bool skip_present = false;
+    bool              skip_present = false;
+    PresentReceiptRef main_present_receipt{};
     if (frame_packet.window.state == EWindowState::Hiding) {
         // 窗口最小化后无法 present，此处主动让出线程，避免高频空转。
         std::this_thread::yield();
@@ -1158,7 +1159,9 @@ RasterFrameFeedback RasterRenderer::RenderFrame(RasterFramePacket frame_packet) 
             );
         }
         if (output_view.extent.x == swapchain->size.x && output_view.extent.y == swapchain->size.y) {
-            gfx_queue.Present(swapchain, default_output_texture);
+            main_present_receipt =
+                CreateMainPresentReceipt(frame_packet.scene_updates.scene_ready);
+            gfx_queue.Present(swapchain, default_output_texture, main_present_receipt);
         } else {
             LOG_WARNING(
                 "Skipping stale main-window present: source={}x{}, swapchain={}x{}.",
@@ -1172,7 +1175,8 @@ RasterFrameFeedback RasterRenderer::RenderFrame(RasterFramePacket frame_packet) 
     }
 
     RasterFrameFeedback feedback{};
-    feedback.frame_id               = frame_packet.frame_id;
+    feedback.frame_id              = frame_packet.frame_id;
+    feedback.main_present_receipt  = std::move(main_present_receipt);
     feedback.culling_stats          = frame_packet.raster_config.culling_stats;
     feedback.cooperative_ops_status = frame_packet.raster_config.cooperative_ops_status;
     if (frame_packet.frame_id == 0) {
@@ -1196,7 +1200,8 @@ void RasterRenderer::ApplyFrameFeedback(
     RasterConfig&       target_config,
     const EngineHooks&  hooks
 ) {
-    assert(!IsRenderThreadInitialized() || IsCurrentlyGameThread());
+    assert(IsCurrentlyGameThread());
+    ApplyMainPresentReceipt(feedback.main_present_receipt, hooks);
     target_config.culling_stats          = feedback.culling_stats;
     target_config.cooperative_ops_status = feedback.cooperative_ops_status;
     if (!feedback.displayable_frame_buffer_names.empty() &&

--- a/source/runtime/render/renderer/raytracing/RaytracingFramePacket.h
+++ b/source/runtime/render/renderer/raytracing/RaytracingFramePacket.h
@@ -37,6 +37,7 @@ struct RaytracingFramePacket {
 
 struct RaytracingFrameFeedback {
     uint64 frame_id = 0;
+    PresentReceiptRef main_present_receipt{};
 
     bool  has_grid_cell_size = false;
     float grid_cell_size     = 1.0f;

--- a/source/runtime/render/renderer/raytracing/RaytracingRenderer.cpp
+++ b/source/runtime/render/renderer/raytracing/RaytracingRenderer.cpp
@@ -722,7 +722,10 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
             );
         }
         if (output_view.extent.x == swapchain->size.x && output_view.extent.y == swapchain->size.y) {
-            gfx_queue.Present(swapchain, state.output);
+            feedback.main_present_receipt = CreateMainPresentReceipt(
+                frame_packet.scene_updates.scene_ready && frame_packet.runtime_assets_ready
+            );
+            gfx_queue.Present(swapchain, state.output, feedback.main_present_receipt);
         } else {
             LOG_WARNING(
                 "Skipping stale raytracing main-window present: source={}x{}, swapchain={}x{}.",
@@ -747,7 +750,7 @@ void RaytracingRenderer::ApplyFrameFeedback(
     RaytracingFrameFeedback feedback,
     RaytracingConfig&       target_config
 ) {
-    assert(!IsRenderThreadInitialized() || IsCurrentlyGameThread());
+    assert(IsCurrentlyGameThread());
     if (feedback.has_grid_cell_size) {
         target_config.grid_config.cell_size = feedback.grid_cell_size;
     }
@@ -761,9 +764,19 @@ void RaytracingRenderer::ApplyFrameFeedback(
     debug_ui_material_texture_names = std::move(feedback.material_texture_names);
 }
 
+void RaytracingRenderer::ApplyFrameFeedback(
+    RaytracingFrameFeedback feedback,
+    RaytracingConfig&       target_config,
+    const EngineHooks&      hooks
+) {
+    assert(IsCurrentlyGameThread());
+    ApplyMainPresentReceipt(feedback.main_present_receipt, hooks);
+    ApplyFrameFeedback(std::move(feedback), target_config);
+}
+
 bool RaytracingRenderer::RunSingle(const SharedPtr<EditorConfig> editor_config, const EngineHooks& hooks) {
     ApplyFrameFeedback(
-        RenderFrame(PrepareFrame(editor_config, hooks)), editor_config->raytracing_config
+        RenderFrame(PrepareFrame(editor_config, hooks)), editor_config->raytracing_config, hooks
     );
     return !hooks.should_reload || !hooks.should_reload();
 }

--- a/source/runtime/render/renderer/raytracing/RaytracingRenderer.h
+++ b/source/runtime/render/renderer/raytracing/RaytracingRenderer.h
@@ -32,7 +32,14 @@ public:
 
     RaytracingFramePacket   PrepareFrame(const SharedPtr<EditorConfig> editor_config, const EngineHooks& hooks);
     RaytracingFrameFeedback RenderFrame(RaytracingFramePacket frame_packet);
+    // Retained for source/ABI compatibility with tools that apply feedback
+    // without editor lifecycle hooks.
     void ApplyFrameFeedback(RaytracingFrameFeedback feedback, RaytracingConfig& target_config);
+    void ApplyFrameFeedback(
+        RaytracingFrameFeedback feedback,
+        RaytracingConfig&       target_config,
+        const EngineHooks&      hooks
+    );
     void Shutdown(const EngineHooks& hooks);
 
     bool RunSingle(const SharedPtr<EditorConfig> editor_config, const EngineHooks& hooks);

--- a/source/runtime/render/rhi/RHICommand.h
+++ b/source/runtime/render/rhi/RHICommand.h
@@ -12,9 +12,12 @@
 #include "rhi/RHIResource.h"
 #include "shader/ShaderPipeline.h"
 #include <array>
+#include <chrono>
+#include <condition_variable>
 #include <filesystem>
 #include <functional>
 #include <misc/STL.h>
+#include <mutex>
 #include <optional>
 #include <span>
 #include <string_view>
@@ -1298,6 +1301,48 @@ struct ProfileData {
     Array<ProfileResultEntry> gpu_entries;
     Array<ProfileResultEntry> cpu_entries;
 };
+
+struct PresentReceiptResult {
+    bool resolved              = false;
+    bool submitted            = false;
+    bool recreate_swapchain   = false;
+};
+
+class PresentReceipt {
+public:
+    void Resolve(bool _submitted, bool _recreate_swapchain = false) {
+        {
+            std::unique_lock<std::mutex> lock(mutex);
+            if (resolved) {
+                return;
+            }
+            result.resolved            = true;
+            result.submitted           = _submitted;
+            result.recreate_swapchain  = _recreate_swapchain;
+            resolved                   = true;
+        }
+        cv.notify_all();
+    }
+
+    [[nodiscard]] PresentReceiptResult WaitForSubmission(
+        std::chrono::milliseconds _timeout = std::chrono::seconds(10)
+    ) {
+        std::unique_lock<std::mutex> lock(mutex);
+        if (!cv.wait_for(lock, _timeout, [this]() { return resolved; })) {
+            return {};
+        }
+        return result;
+    }
+
+private:
+    std::mutex               mutex;
+    std::condition_variable  cv;
+    PresentReceiptResult     result{};
+    bool                     resolved{false};
+};
+
+using PresentReceiptRef = SharedPtr<PresentReceipt>;
+
 class RENDER_API CommandQueue {
 public:
     CommandQueue() {};
@@ -1305,7 +1350,11 @@ public:
     void                Test();
     virtual void        Wait(WaitEvent _event)                                = 0;
     virtual WaitEvent   Execute(CmdSubmit&& _submit)                          = 0;
-    virtual void        Present(SwapchainRef _swapchain, TextureView _target) = 0;
+    virtual void Present(
+        SwapchainRef      _swapchain,
+        TextureView       _target,
+        PresentReceiptRef _receipt = {}
+    ) = 0;
     virtual void        Sync()                                                = 0;
     virtual ProfileData GetProfilerEntry()                                    = 0;
 

--- a/source/runtime/render/rhi/d3d12/D3D12Device.cpp
+++ b/source/runtime/render/rhi/d3d12/D3D12Device.cpp
@@ -589,7 +589,13 @@ CommandQueue& D3D12Device::GetCommandQueue(EQueueType _type) {
         virtual WaitEvent Execute(CmdSubmit&& _submit) {
             return {};
         };
-        virtual void        Present(SwapchainRef _swapchain, TextureView _target) {};
+        virtual void Present(
+            SwapchainRef _swapchain, TextureView _target, PresentReceiptRef _receipt = {}
+        ) {
+            if (_receipt) {
+                _receipt->Resolve(false);
+            }
+        };
         virtual void        Sync() {};
         virtual ProfileData GetProfilerEntry() {
             return {};
@@ -1569,7 +1575,14 @@ WaitEvent D3D12GraphicsCommandQueue::Execute(CmdSubmit&& _submit) {
     return WaitEvent(uint64(&queue_fence), next_fence_value);
 }
 
-void D3D12GraphicsCommandQueue::Present(SwapchainRef _swapchain, TextureView _target) {
+void D3D12GraphicsCommandQueue::Present(
+    SwapchainRef      _swapchain,
+    TextureView       _target,
+    PresentReceiptRef _receipt
+) {
+    if (_receipt) {
+        _receipt->Resolve(false);
+    }
     FATAL("not implemented");
 }
 

--- a/source/runtime/render/rhi/d3d12/D3D12Device.h
+++ b/source/runtime/render/rhi/d3d12/D3D12Device.h
@@ -1025,7 +1025,11 @@ public:
     // queue.signal is not exposed, exist in cmdsubmit.signalevent
     void        Wait(WaitEvent _event) override;
     WaitEvent   Execute(CmdSubmit&& _submit) override;
-    void        Present(SwapchainRef _swapchain, TextureView _target) override;
+    void Present(
+        SwapchainRef      _swapchain,
+        TextureView       _target,
+        PresentReceiptRef _receipt = {}
+    ) override;
     void        Sync() override;
     ProfileData GetProfilerEntry() override {
         return {};

--- a/source/runtime/render/rhi/vulkan/VulkanQueue.cpp
+++ b/source/runtime/render/rhi/vulkan/VulkanQueue.cpp
@@ -3595,12 +3595,19 @@ void VkCommandQueue::ExecuteNow(CmdSubmit&& _submit, uint64 _timeline, uint64 _s
     }
 }
 
-void VkCommandQueue::Present(SwapchainRef _sc, TextureView _view) {
+void VkCommandQueue::Present(
+    SwapchainRef      _sc,
+    TextureView       _view,
+    PresentReceiptRef _receipt
+) {
     assert(_view.texture != nullptr && "Present source texture is null");
     TextureRef source_texture{_view.texture};
 
     if (vk_device.IsFaulted()) {
         vk_device.RecordRejectedPresent();
+        if (_receipt) {
+            _receipt->Resolve(false);
+        }
         return;
     }
 
@@ -3621,6 +3628,7 @@ void VkCommandQueue::Present(SwapchainRef _sc, TextureView _view) {
                 std::move(_sc),
                 std::move(source_texture),
                 _view,
+                std::move(_receipt),
                 current_timeline,
                 serial,
                 enqueued_at,
@@ -3640,14 +3648,24 @@ void VkCommandQueue::Present(SwapchainRef _sc, TextureView _view) {
     if (thread_profile) {
         const auto work_started = std::chrono::steady_clock::now();
         PresentNow(
-            std::move(_sc), std::move(source_texture), _view, current_timeline, current_timeline
+            std::move(_sc),
+            std::move(source_texture),
+            _view,
+            std::move(_receipt),
+            current_timeline,
+            current_timeline
         );
         const double work_ms =
             RhiThreadProfileMilliseconds(work_started, std::chrono::steady_clock::now());
         RecordThreadingProfile(ERhiWorkKind::Present, work_ms, 0.0, work_ms, 0);
     } else {
         PresentNow(
-            std::move(_sc), std::move(source_texture), _view, current_timeline, current_timeline
+            std::move(_sc),
+            std::move(source_texture),
+            _view,
+            std::move(_receipt),
+            current_timeline,
+            current_timeline
         );
     }
 }
@@ -3656,6 +3674,7 @@ void VkCommandQueue::PresentNow(
     SwapchainRef&& _sc,
     TextureRef&&   _source_texture,
     TextureView    _view,
+    PresentReceiptRef _receipt,
     uint64         _timeline,
     uint64         _serial
 ) {
@@ -3673,6 +3692,9 @@ void VkCommandQueue::PresentNow(
     };
     if (vk_device.IsFaulted()) {
         vk_device.RecordRejectedPresent();
+        if (_receipt) {
+            _receipt->Resolve(false);
+        }
         const VkResult rejected_result = vk_device.GetFirstFaultResult();
         timeline->Fail(rejected_result);
         std::unique_lock<std::mutex> lock(event_mutex);
@@ -3696,6 +3718,9 @@ void VkCommandQueue::PresentNow(
     auto& vk_tracker   = vk_allocator.GetTracker();
     if (!sc->WaitFrameInFlight()) {
         vk_device.RecordRejectedPresent();
+        if (_receipt) {
+            _receipt->Resolve(false);
+        }
         const VkResult rejected_result = GetRejectedSubmitResult(vk_device);
         timeline->Fail(rejected_result);
         std::unique_lock<std::mutex> lock(event_mutex);
@@ -3713,9 +3738,14 @@ void VkCommandQueue::PresentNow(
         return;
     }
     auto acquire = sc->AquireNextImage(rhi_thread_enabled ? 0 : 50'000'000);
+    bool recreate_swapchain =
+        acquire.outcome.status == EVulkanOperationStatus::Recreate;
 
     Array<std::function<void()>> callbacks;
     if (!acquire.HasImage()) {
+        if (_receipt) {
+            _receipt->Resolve(false, recreate_swapchain);
+        }
         if (acquire.outcome.status == EVulkanOperationStatus::Faulted ||
             acquire.outcome.status == EVulkanOperationStatus::Rejected) {
             timeline->Fail(acquire.outcome.result);
@@ -3795,13 +3825,22 @@ void VkCommandQueue::PresentNow(
     } else {
         timeline->Fail(submit_outcome.result);
     }
-    VulkanOperationResult final_outcome  = submit_outcome;
+    VulkanOperationResult final_outcome = submit_outcome;
+    bool                  present_accepted = false;
     if (submit_outcome.WasSubmitted()) {
         const VulkanOperationResult present_outcome =
             sc->Present(queue.GetHandle(), idx, _timeline, _serial);
+        present_accepted =
+            present_outcome.result == VK_SUCCESS || present_outcome.result == VK_SUBOPTIMAL_KHR;
+        recreate_swapchain =
+            recreate_swapchain ||
+            present_outcome.status == EVulkanOperationStatus::Recreate;
         if (!present_outcome.Succeeded()) {
             final_outcome = present_outcome;
         }
+    }
+    if (_receipt) {
+        _receipt->Resolve(present_accepted, recreate_swapchain);
     }
     {
         std::unique_lock<std::mutex> lock(event_mutex);
@@ -4353,6 +4392,7 @@ void VkCommandQueue::RhiThreadMain() {
                                 std::move(_work.swapchain),
                                 std::move(_work.source_texture),
                                 _work.source_view,
+                                std::move(_work.receipt),
                                 _work.timeline,
                                 _work.serial
                             );

--- a/source/runtime/render/rhi/vulkan/VulkanQueue.h
+++ b/source/runtime/render/rhi/vulkan/VulkanQueue.h
@@ -250,6 +250,7 @@ public:
         SwapchainRef                          swapchain;
         TextureRef                            source_texture;
         TextureView                           source_view;
+        PresentReceiptRef                     receipt;
         uint64                                timeline;
         uint64                                serial;
         std::chrono::steady_clock::time_point enqueued_at;
@@ -260,6 +261,7 @@ public:
             SwapchainRef&&                       _swapchain,
             TextureRef&&                         _source_texture,
             TextureView                          _source_view,
+            PresentReceiptRef                    _receipt,
             uint64                               _timeline,
             uint64                               _serial,
             std::chrono::steady_clock::time_point _enqueued_at,
@@ -268,6 +270,7 @@ public:
             swapchain(std::move(_swapchain)),
             source_texture(std::move(_source_texture)),
             source_view(_source_view),
+            receipt(std::move(_receipt)),
             timeline(_timeline),
             serial(_serial),
             enqueued_at(_enqueued_at),
@@ -285,7 +288,11 @@ public:
     ~VkCommandQueue();
     WaitEvent   Execute(CmdSubmit&& _submit) override;
     void        Wait(WaitEvent _event) override;
-    void        Present(SwapchainRef _viewport, TextureView _view) override;
+    void Present(
+        SwapchainRef      _viewport,
+        TextureView       _view,
+        PresentReceiptRef _receipt = {}
+    ) override;
     void        Sync() override;
     ProfileData GetProfilerEntry() override;
 
@@ -406,6 +413,7 @@ private:
         SwapchainRef&& _swapchain,
         TextureRef&&   _source_texture,
         TextureView    _source_view,
+        PresentReceiptRef _receipt,
         uint64         _timeline,
         uint64         _serial
     );

--- a/source/runtime/render/window/WindowContext.cpp
+++ b/source/runtime/render/window/WindowContext.cpp
@@ -43,6 +43,10 @@ WindowHandle* WindowContext::GetMainWindow() {
     return &WindowImpl::GetInstance().main_window_handle;
 };
 
+void WindowContext::ShowMainWindow() {
+    WindowImpl::GetInstance().ShowMainWindow();
+}
+
 void WindowContext::CreateVulkanSurface(
     void*         instance,
     WindowHandle* window,

--- a/source/runtime/render/window/WindowContext.h
+++ b/source/runtime/render/window/WindowContext.h
@@ -47,13 +47,15 @@ struct RENDER_API SurfaceInitInfo {
         uint32_t           _width,
         uint32_t           _height,
         const std::string& _title,
-        bool               _full_screen
+        bool               _full_screen,
+        bool               _visible = true
     ) :
         rhi_type(_rhi_type),
         width(_width),
         height(_height),
         title(_title),
-        b_fullscreen(_full_screen) {}
+        b_fullscreen(_full_screen),
+        b_visible(_visible) {}
 
     SurfaceInitInfo() : SurfaceInitInfo(ERHIType::Vulkan, 1920, 1080, "untitled", false) {}
 
@@ -63,6 +65,7 @@ struct RENDER_API SurfaceInitInfo {
     std::string title{"MoerEngine"};
     bool        b_fullscreen{false};
     bool        b_vsync{false};
+    bool        b_visible{true};
 };
 //mean to support multi window creation and io-management
 class RENDER_API WindowContext {
@@ -79,6 +82,7 @@ public:
     static void          SetFocusMode(WindowHandle*, bool focused);
     static bool          GetFocusMode(WindowHandle*);
     static WindowHandle* GetMainWindow();
+    static void          ShowMainWindow();
     static void          SetTitle(WindowHandle*, const char* newTitle);
     static void          RequestClose(WindowHandle*);
     static bool          ShouldClose(WindowHandle*);

--- a/source/runtime/render/window/WindowContextImpl.h
+++ b/source/runtime/render/window/WindowContextImpl.h
@@ -22,6 +22,7 @@ public:
     virtual void SetTitle(WindowHandle*, const char* _new_title)                     = 0;
     virtual void RequestClose(WindowHandle*)                                          = 0;
     virtual bool ShouldClose(WindowHandle*) const                                    = 0;
+    virtual void ShowMainWindow()                                                    = 0;
 
     virtual void* GetNativeWindow(WindowHandle*) const = 0;
 

--- a/source/runtime/render/window/glfw/GLFWWindowImpl.cpp
+++ b/source/runtime/render/window/glfw/GLFWWindowImpl.cpp
@@ -1,5 +1,6 @@
 #include "GLFWWindowImpl.h"
 
+#include "Core.h"
 #include "misc/MMemory.h"
 #include "platform/Platform.h"
 #include "rhi/RHI.h"
@@ -57,19 +58,37 @@ void GLFWWindowImpl::Init(const SurfaceInitInfo& info) {
     } else {
         assert(0 && "Unknown RHI type, code error.");
     }
+    glfwWindowHint(GLFW_VISIBLE, info.b_visible ? GLFW_TRUE : GLFW_FALSE);
 
     int          width   = info.width;
     int          height  = info.height;
     GLFWmonitor* monitor = nullptr;
+    m_deferred_fullscreen        = false;
+    m_deferred_fullscreen_width  = 0;
+    m_deferred_fullscreen_height = 0;
     if (info.b_fullscreen) {
         // 全屏模式
-        monitor                 = glfwGetPrimaryMonitor();
-        const GLFWvidmode* mode = glfwGetVideoMode(monitor);
-        width                   = mode->width;
-        height                  = mode->height;
+        GLFWmonitor*       fullscreen_monitor = glfwGetPrimaryMonitor();
+        const GLFWvidmode* mode               = glfwGetVideoMode(fullscreen_monitor);
+        width                                 = mode->width;
+        height                                = mode->height;
+
+        if (info.b_visible) {
+            monitor = fullscreen_monitor;
+        } else {
+            // GLFW_VISIBLE is ignored for full-screen windows. Bootstrap as a
+            // hidden windowed window at the target mode size, then enter full
+            // screen from ShowMainWindow() after the first frame is ready.
+            m_deferred_fullscreen        = true;
+            m_deferred_fullscreen_width  = width;
+            m_deferred_fullscreen_height = height;
+        }
     }
 
     GLFWwindow* window = glfwCreateWindow(width, height, info.title.c_str(), monitor, nullptr);
+    // Window hints persist across creations. Restore the normal default so editor platform
+    // windows are not accidentally created hidden after a hidden main-window bootstrap.
+    glfwWindowHint(GLFW_VISIBLE, GLFW_TRUE);
 
     glfwSetWindowUserPointer(window, this);
 
@@ -339,6 +358,49 @@ void GLFWWindowImpl::RequestClose(WindowHandle* _window) {
 
 bool GLFWWindowImpl::ShouldClose(WindowHandle* _window) const {
     return glfwWindowShouldClose((GLFWwindow*)_window->window);
+}
+void GLFWWindowImpl::ShowMainWindow() {
+    assert(IsCurrentlyGameThread() && "GLFW main-window visibility must be changed on the Game Thread.");
+    auto* window = (GLFWwindow*)main_window_handle.window;
+    if (m_deferred_fullscreen) {
+        GLFWmonitor* monitor = glfwGetPrimaryMonitor();
+        if (monitor != nullptr) {
+            // glfwGetError reports and clears the oldest pending error. Clear
+            // unrelated startup errors so the result below belongs to this
+            // monitor transition.
+            glfwGetError(nullptr);
+            glfwSetWindowMonitor(
+                window,
+                monitor,
+                0,
+                0,
+                m_deferred_fullscreen_width,
+                m_deferred_fullscreen_height,
+                GLFW_DONT_CARE
+            );
+            const char* glfw_error_description = nullptr;
+            const int   glfw_error = glfwGetError(&glfw_error_description);
+            if (glfw_error == GLFW_NO_ERROR) {
+                LOG_INFO(
+                    "[Startup][Window] Entered deferred full-screen mode at {}x{}.",
+                    m_deferred_fullscreen_width,
+                    m_deferred_fullscreen_height
+                );
+            } else {
+                LOG_ERROR(
+                    "[Startup][Window] Failed to enter deferred full-screen mode: error={}, description={}",
+                    glfw_error,
+                    glfw_error_description ? glfw_error_description : "<none>"
+                );
+            }
+        } else {
+            LOG_WARNING(
+                "Unable to enter deferred full-screen mode because no primary monitor is available."
+            );
+        }
+        m_deferred_fullscreen = false;
+    }
+    glfwShowWindow(window);
 }
 void* GLFWWindowImpl::GetNativeWindow(WindowHandle* _window) const {
 #if PLATFORM_WINDOWS

--- a/source/runtime/render/window/glfw/GLFWWindowImpl.h
+++ b/source/runtime/render/window/glfw/GLFWWindowImpl.h
@@ -24,6 +24,7 @@ public:
     virtual void  SetTitle(WindowHandle*, const char* _new_title) override;
     virtual void  RequestClose(WindowHandle*) override;
     virtual bool  ShouldClose(WindowHandle*) const override;
+    virtual void  ShowMainWindow() override;
     virtual void* GetNativeWindow(WindowHandle*) const override;
 
 private:
@@ -52,6 +53,10 @@ private:
 private:
     void InitVulkan();
     void InitD3D12();
+
+    bool m_deferred_fullscreen        = false;
+    int  m_deferred_fullscreen_width  = 0;
+    int  m_deferred_fullscreen_height = 0;
 };
 } // namespace Moer
 #endif

--- a/tools/startup/verify_startup_splash.py
+++ b/tools/startup/verify_startup_splash.py
@@ -1,0 +1,457 @@
+from __future__ import annotations
+
+import argparse
+import ctypes
+import json
+import os
+import re
+import struct
+import subprocess
+import sys
+import time
+from ctypes import wintypes
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT))
+
+from tools.threading.runtime_verify import (  # noqa: E402
+    DEFAULT_FORBIDDEN_PATTERNS,
+    capture_print_window,
+    close_process,
+)
+
+
+SPLASH_CLASS = "MoerEngineStartupSplashWindow"
+SPLASH_TITLE = "MoerEngine Startup"
+MAIN_TITLE = "MoerEditor"
+MONITOR_DEFAULTTOPRIMARY = 1
+WM_NCHITTEST = 0x0084
+HTCLIENT = 1
+FIRST_PRESENT_LOG = "[Startup][Engine] First main-window present submitted on the Game Thread."
+CONTENT_READY_LOG = "[Startup][Renderer] First-present receipt armed: scene_content_ready=true."
+
+
+class MonitorInfo(ctypes.Structure):
+    _fields_ = [
+        ("cbSize", wintypes.DWORD),
+        ("rcMonitor", wintypes.RECT),
+        ("rcWork", wintypes.RECT),
+        ("dwFlags", wintypes.DWORD),
+    ]
+
+
+if os.name == "nt":
+    user32 = ctypes.windll.user32
+    user32.MonitorFromPoint.argtypes = (wintypes.POINT, wintypes.DWORD)
+    user32.MonitorFromPoint.restype = wintypes.HANDLE
+    user32.GetMonitorInfoW.argtypes = (wintypes.HANDLE, ctypes.POINTER(MonitorInfo))
+    user32.GetMonitorInfoW.restype = wintypes.BOOL
+    user32.SendMessageW.argtypes = (
+        wintypes.HWND,
+        wintypes.UINT,
+        wintypes.WPARAM,
+        wintypes.LPARAM,
+    )
+    user32.SendMessageW.restype = ctypes.c_ssize_t
+    try:
+        # DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2. Without this, Win32
+        # virtualizes a 150% splash from 1020x570 to 680x380 and PrintWindow
+        # captures only the upper-left logical area.
+        user32.SetProcessDpiAwarenessContext(ctypes.c_void_p(-4))
+    except (AttributeError, OSError):
+        user32.SetProcessDPIAware()
+else:
+    user32 = None
+
+
+def window_text(hwnd: int) -> str:
+    length = user32.GetWindowTextLengthW(hwnd)
+    buffer = ctypes.create_unicode_buffer(max(1, length + 1))
+    user32.GetWindowTextW(hwnd, buffer, len(buffer))
+    return buffer.value
+
+
+def window_class(hwnd: int) -> str:
+    buffer = ctypes.create_unicode_buffer(256)
+    user32.GetClassNameW(hwnd, buffer, len(buffer))
+    return buffer.value
+
+
+def splash_placement(hwnd: int) -> dict[str, object]:
+    window_rect = wintypes.RECT()
+    if not user32.GetWindowRect(hwnd, ctypes.byref(window_rect)):
+        raise ctypes.WinError()
+
+    monitor = user32.MonitorFromPoint(wintypes.POINT(0, 0), MONITOR_DEFAULTTOPRIMARY)
+    monitor_info = MonitorInfo(cbSize=ctypes.sizeof(MonitorInfo))
+    if not monitor or not user32.GetMonitorInfoW(monitor, ctypes.byref(monitor_info)):
+        raise ctypes.WinError()
+
+    window_center_x = (window_rect.left + window_rect.right) // 2
+    window_center_y = (window_rect.top + window_rect.bottom) // 2
+    work_center_x = (monitor_info.rcWork.left + monitor_info.rcWork.right) // 2
+    work_center_y = (monitor_info.rcWork.top + monitor_info.rcWork.bottom) // 2
+    hit_test_lparam = (window_center_x & 0xFFFF) | ((window_center_y & 0xFFFF) << 16)
+
+    return {
+        "window_rect": [
+            window_rect.left,
+            window_rect.top,
+            window_rect.right,
+            window_rect.bottom,
+        ],
+        "primary_work_area": [
+            monitor_info.rcWork.left,
+            monitor_info.rcWork.top,
+            monitor_info.rcWork.right,
+            monitor_info.rcWork.bottom,
+        ],
+        "center_offset": [window_center_x - work_center_x, window_center_y - work_center_y],
+        "hit_test": int(user32.SendMessageW(hwnd, WM_NCHITTEST, 0, hit_test_lparam)),
+    }
+
+
+def visible_windows(pid: int) -> list[dict[str, object]]:
+    windows: list[dict[str, object]] = []
+    callback_type = ctypes.WINFUNCTYPE(wintypes.BOOL, wintypes.HWND, wintypes.LPARAM)
+
+    def callback(hwnd: int, _: int) -> bool:
+        window_pid = wintypes.DWORD()
+        user32.GetWindowThreadProcessId(hwnd, ctypes.byref(window_pid))
+        if window_pid.value == pid and user32.IsWindowVisible(hwnd):
+            windows.append(
+                {
+                    "hwnd": int(hwnd),
+                    "title": window_text(hwnd),
+                    "class": window_class(hwnd),
+                    "hung": bool(user32.IsHungAppWindow(hwnd)),
+                }
+            )
+        return True
+
+    callback_ref = callback_type(callback)
+    user32.EnumWindows(callback_ref, 0)
+    return windows
+
+
+def find_window(
+    windows: list[dict[str, object]], *, title: str | None = None, class_name: str | None = None
+) -> int:
+    for window in windows:
+        if title is not None and window["title"] != title:
+            continue
+        if class_name is not None and window["class"] != class_name:
+            continue
+        return int(window["hwnd"])
+    return 0
+
+
+def white_ratio(path: Path) -> float:
+    data = path.read_bytes()
+    if len(data) < 54 or data[:2] != b"BM":
+        raise RuntimeError(f"Not a BMP capture: {path}")
+    pixel_offset = struct.unpack_from("<I", data, 10)[0]
+    width = abs(struct.unpack_from("<i", data, 18)[0])
+    height = abs(struct.unpack_from("<i", data, 22)[0])
+    bit_count = struct.unpack_from("<H", data, 28)[0]
+    if bit_count != 32:
+        raise RuntimeError(f"Expected a 32-bit BMP capture, got {bit_count}: {path}")
+
+    pixel_count = width * height
+    stride = max(1, pixel_count // 200_000)
+    white = 0
+    sampled = 0
+    for pixel_index in range(0, pixel_count, stride):
+        offset = pixel_offset + pixel_index * 4
+        blue, green, red = data[offset : offset + 3]
+        white += int(red >= 245 and green >= 245 and blue >= 245)
+        sampled += 1
+    return white / max(sampled, 1)
+
+
+def placeholder_gray_ratio(path: Path) -> float:
+    data = path.read_bytes()
+    if len(data) < 54 or data[:2] != b"BM":
+        raise RuntimeError(f"Not a BMP capture: {path}")
+    pixel_offset = struct.unpack_from("<I", data, 10)[0]
+    width = abs(struct.unpack_from("<i", data, 18)[0])
+    height = abs(struct.unpack_from("<i", data, 22)[0])
+    bit_count = struct.unpack_from("<H", data, 28)[0]
+    if bit_count != 32:
+        raise RuntimeError(f"Expected a 32-bit BMP capture, got {bit_count}: {path}")
+
+    pixel_count = width * height
+    stride = max(1, pixel_count // 200_000)
+    placeholder_gray = 0
+    sampled = 0
+    for pixel_index in range(0, pixel_count, stride):
+        offset = pixel_offset + pixel_index * 4
+        blue, green, red = data[offset : offset + 3]
+        neutral = max(red, green, blue) - min(red, green, blue) <= 4
+        placeholder_gray += int(neutral and 105 <= red <= 165)
+        sampled += 1
+    return placeholder_gray / max(sampled, 1)
+
+
+def scan_forbidden(stdout_path: Path, stderr_path: Path) -> list[str]:
+    matches: list[str] = []
+    patterns = [re.compile(pattern, re.IGNORECASE) for pattern in DEFAULT_FORBIDDEN_PATTERNS]
+    for path in (stdout_path, stderr_path):
+        if not path.exists():
+            continue
+        for line_number, line in enumerate(
+            path.read_text(encoding="utf-8", errors="replace").splitlines(), start=1
+        ):
+            if any(pattern.search(line) for pattern in patterns):
+                matches.append(f"{path.name}:{line_number}: {line}")
+    return matches
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Launch MoerEditor and verify the native startup splash, hidden main window, "
+            "first-present handoff, screenshots, responsiveness, and shutdown logs."
+        )
+    )
+    parser.add_argument("--exe", type=Path, required=True)
+    parser.add_argument("--workdir", type=Path, required=True)
+    parser.add_argument("--outdir", type=Path, required=True)
+    parser.add_argument("--config", type=Path)
+    parser.add_argument("--splash-timeout", type=float, default=8.0)
+    parser.add_argument("--startup-timeout", type=float, default=180.0)
+    parser.add_argument("--handoff-timeout", type=float, default=5.0)
+    parser.add_argument("--close-timeout", type=float, default=45.0)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    if os.name != "nt":
+        print("verify_startup_splash.py currently supports Windows only.", file=sys.stderr)
+        return 2
+
+    exe = args.exe.resolve()
+    workdir = args.workdir.resolve()
+    outdir = args.outdir.resolve()
+    config = args.config.resolve() if args.config else None
+    if not exe.is_file():
+        print(f"MoerEditor executable does not exist: {exe}", file=sys.stderr)
+        return 2
+    if not workdir.is_dir():
+        print(f"Working directory does not exist: {workdir}", file=sys.stderr)
+        return 2
+    if config is not None and not config.is_file():
+        print(f"Config does not exist: {config}", file=sys.stderr)
+        return 2
+
+    outdir.mkdir(parents=True, exist_ok=True)
+    stdout_path = outdir / "stdout.log"
+    stderr_path = outdir / "stderr.log"
+    report_path = outdir / "report.json"
+    command = [str(exe)]
+    if config is not None:
+        command.extend(["--config", str(config)])
+
+    report: dict[str, object] = {
+        "command": command,
+        "workdir": str(workdir),
+        "config": str(config) if config else None,
+        "timeline": [],
+        "captures": [],
+        "failure_reasons": [],
+        "success": False,
+    }
+    failures: list[str] = report["failure_reasons"]
+    started = time.monotonic()
+    process: subprocess.Popen[bytes] | None = None
+    splash_hwnd = 0
+    main_hwnd = 0
+
+    def record(event: str, windows: list[dict[str, object]]) -> None:
+        report["timeline"].append(
+            {
+                "seconds": time.monotonic() - started,
+                "event": event,
+                "windows": windows,
+            }
+        )
+
+    try:
+        with stdout_path.open("wb") as stdout, stderr_path.open("wb") as stderr:
+            process = subprocess.Popen(command, cwd=workdir, stdout=stdout, stderr=stderr)
+            report["pid"] = process.pid
+
+            splash_deadline = time.monotonic() + args.splash_timeout
+            while time.monotonic() < splash_deadline:
+                if process.poll() is not None:
+                    raise RuntimeError(f"MoerEditor exited before showing Splash: {process.returncode}")
+                windows = visible_windows(process.pid)
+                splash_hwnd = find_window(windows, title=SPLASH_TITLE, class_name=SPLASH_CLASS)
+                early_main = find_window(windows, title=MAIN_TITLE)
+                if early_main:
+                    failures.append("The main window became visible before the Splash was observed")
+                if splash_hwnd:
+                    record("splash_visible", windows)
+                    break
+                time.sleep(0.05)
+            if not splash_hwnd:
+                raise RuntimeError("Startup Splash window was not found")
+
+            # The native splash intentionally fades in. Capture after a few
+            # animation ticks so PrintWindow does not sample opacity zero.
+            time.sleep(0.5)
+            splash_capture_path = outdir / "01_splash.bmp"
+            splash_capture = capture_print_window(splash_hwnd, splash_capture_path)
+            splash_capture["white_ratio"] = white_ratio(splash_capture_path)
+            report["captures"].append(splash_capture)
+
+            placement = splash_placement(splash_hwnd)
+            report["splash_placement"] = placement
+            center_offset = placement["center_offset"]
+            if abs(center_offset[0]) > 1 or abs(center_offset[1]) > 1:
+                failures.append(
+                    "Splash is not centered in the primary monitor work area: "
+                    f"offset={center_offset}"
+                )
+            if placement["hit_test"] != HTCLIENT:
+                failures.append(
+                    "Splash client area is draggable: "
+                    f"WM_NCHITTEST returned {placement['hit_test']}"
+                )
+
+            startup_deadline = started + args.startup_timeout
+            hung_samples = 0
+            samples = 0
+            while time.monotonic() < startup_deadline:
+                if process.poll() is not None:
+                    raise RuntimeError(f"MoerEditor exited during startup: {process.returncode}")
+                windows = visible_windows(process.pid)
+                samples += 1
+                if splash_hwnd and user32.IsWindow(splash_hwnd):
+                    hung_samples += int(bool(user32.IsHungAppWindow(splash_hwnd)))
+                main_hwnd = find_window(windows, title=MAIN_TITLE)
+                if main_hwnd:
+                    record("main_window_visible", windows)
+                    break
+                time.sleep(0.1)
+            report["splash_responsiveness_samples"] = samples
+            report["splash_hung_samples"] = hung_samples
+            if hung_samples:
+                failures.append(f"Splash was reported hung in {hung_samples}/{samples} samples")
+            if not main_hwnd:
+                raise RuntimeError("Main window did not become visible before startup timeout")
+
+            # Capture the handoff immediately and during its first half-second.
+            # A delayed-only screenshot can miss a transient blank/white frame
+            # between ShowMainWindow and the first stable compositor update.
+            handoff_started = time.monotonic()
+            for capture_index, target_offset in enumerate((0.0, 0.1, 0.25, 0.5)):
+                remaining = handoff_started + target_offset - time.monotonic()
+                if remaining > 0:
+                    time.sleep(remaining)
+                if process.poll() is not None:
+                    raise RuntimeError(
+                        f"MoerEditor exited during handoff capture: {process.returncode}"
+                    )
+                handoff_capture_path = outdir / f"02_main_handoff_{capture_index:02d}.bmp"
+                handoff_capture = capture_print_window(main_hwnd, handoff_capture_path)
+                handoff_capture["white_ratio"] = white_ratio(handoff_capture_path)
+                handoff_capture["placeholder_gray_ratio"] = placeholder_gray_ratio(
+                    handoff_capture_path
+                )
+                handoff_capture["phase"] = "covered_by_splash"
+                handoff_capture["handoff_offset_seconds"] = time.monotonic() - handoff_started
+                report["captures"].append(handoff_capture)
+
+            handoff_deadline = time.monotonic() + args.handoff_timeout
+            while time.monotonic() < handoff_deadline:
+                windows = visible_windows(process.pid)
+                if not find_window(windows, title=SPLASH_TITLE, class_name=SPLASH_CLASS):
+                    record("splash_closed", windows)
+                    reveal_capture_path = outdir / "02_main_reveal.bmp"
+                    reveal_capture = capture_print_window(main_hwnd, reveal_capture_path)
+                    reveal_capture["white_ratio"] = white_ratio(reveal_capture_path)
+                    reveal_capture["placeholder_gray_ratio"] = placeholder_gray_ratio(
+                        reveal_capture_path
+                    )
+                    reveal_capture["phase"] = "splash_reveal"
+                    report["captures"].append(reveal_capture)
+                    if reveal_capture["placeholder_gray_ratio"] > 0.60:
+                        failures.append(
+                            "The Splash revealed the main window while it still contained the "
+                            "neutral-gray bootstrap frame"
+                        )
+                    break
+                time.sleep(0.05)
+            else:
+                failures.append("Splash remained visible after the main window handoff")
+
+            time.sleep(2.0)
+            main_capture_path = outdir / "03_main_window.bmp"
+            main_capture = capture_print_window(main_hwnd, main_capture_path)
+            main_capture["white_ratio"] = white_ratio(main_capture_path)
+            report["captures"].append(main_capture)
+
+            closed_normally, exit_code = close_process(process, main_hwnd, args.close_timeout)
+            report["closed_normally"] = closed_normally
+            report["exit_code"] = exit_code
+            if not closed_normally:
+                failures.append("MoerEditor did not close normally")
+            if exit_code != 0:
+                failures.append(f"MoerEditor exit code was {exit_code}")
+    except Exception as error:
+        failures.append(str(error))
+    finally:
+        if process is not None and process.poll() is None:
+            _, exit_code = close_process(process, main_hwnd or splash_hwnd, min(args.close_timeout, 15.0))
+            report["exit_code"] = exit_code
+
+    report["duration_seconds"] = time.monotonic() - started
+    forbidden_matches = scan_forbidden(stdout_path, stderr_path)
+    report["forbidden_log_matches"] = forbidden_matches
+    if forbidden_matches:
+        failures.append("Forbidden error/validation patterns were found in startup logs")
+
+    stdout_text = (
+        stdout_path.read_text(encoding="utf-8", errors="replace")
+        if stdout_path.exists()
+        else ""
+    )
+    first_present_log_count = stdout_text.count(FIRST_PRESENT_LOG)
+    report["first_present_log_count"] = first_present_log_count
+    if first_present_log_count != 1:
+        failures.append(
+            "Expected exactly one confirmed first-present log before handoff, "
+            f"observed {first_present_log_count}"
+        )
+    content_ready_log_count = stdout_text.count(CONTENT_READY_LOG)
+    report["content_ready_log_count"] = content_ready_log_count
+    if content_ready_log_count != 1:
+        failures.append(
+            "Expected the normal startup handoff to arm exactly one scene-ready Present receipt, "
+            f"observed {content_ready_log_count}"
+        )
+
+    for capture in report["captures"]:
+        if capture["nonblack_ratio"] < 0.01:
+            failures.append(f"Capture is effectively blank: {capture['path']}")
+        # Handoff samples are taken while the opaque splash still covers the main
+        # window. Raster exposure may legitimately start out almost white there;
+        # only the reveal and stable captures are user-visible quality gates.
+        if (
+            capture.get("phase") != "covered_by_splash"
+            and capture["white_ratio"] > 0.60
+        ):
+            failures.append(f"Capture is predominantly white: {capture['path']}")
+
+    report["success"] = not failures
+    report_path.write_text(json.dumps(report, indent=2), encoding="utf-8")
+    print(json.dumps(report, indent=2))
+    return 0 if report["success"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- add a renderer-independent native startup splash with the NJU-purple Rayframe mark, segmented viewport frame, ray/dot accents, and an indeterminate comet progress indicator
- keep the editor window hidden until the first accepted raster or ray-tracing present, then hand off without exposing a blank main window
- propagate first-present receipts through the renderer/RHI backends and provide failure-state handling
- add an automated startup verifier for window responsiveness, handoff timing, screenshots, and forbidden-log checks
- link the Win32 system libraries required by the procedural GDI drawing path, including `msimg32` for `GradientFill`

## Why

The previous startup experience was visually minimal and could expose an unready editor window. This gives MoerEngine a recognizable NJU Graphics identity while tying the splash lifetime to real rendering readiness.

## Validation

- `cmake --build build --config Debug --target MoerEditor -- /m:30` — passed
- final executable import audit — `MSIMG32.dll -> GradientFill` present
- ray-tracing startup verification — 174 splash response samples, 0 hung; first-present and content-ready markers observed; no forbidden log matches
- raster cold-start verification — 454 splash response samples, 0 hung; normal splash-to-editor handoff; no forbidden log matches
- `git diff --check` / staged diff check — passed

## Scope and limitations

- no external image assets or third-party UI libraries were added; the splash uses the C++ standard library plus Windows SDK `user32`, `gdi32`, and `msimg32`
- visual/runtime verification was performed on Windows at 150% DPI
- the repository's Ninja/Clang path was unavailable on this machine, so the current verification used the supported CMake/MSVC Debug path
- raster content can briefly converge exposure after the handoff; the splash itself does not expose a blank window
- unrelated local ray-tracing, RHI, and NRD work is intentionally excluded from this PR