### PR TITLE
perf(raytracing): prepare ReSTIR DI for GI

### DIFF
--- a/shaders/pipelines/raytracing/restir_di/Shading.hlsl
+++ b/shaders/pipelines/raytracing/restir_di/Shading.hlsl
@@ -31,7 +31,6 @@ main(uint2 dtid
   float3 diffuse = 0.f;
   float3 specular = 0.f;
   float light_dist = 0.f;
-  float2 cur_luminance = 0.f;
 
   float3 debug_color_red = float3(1, 0, 0);
   float3 debug_color_green = float3(0, 1, 0);
@@ -48,8 +47,6 @@ main(uint2 dtid
         res, surface, l_sample, resample_params.enable_prev_tlas,
         true /* visibility reuse */, diffuse, specular, light_dist);
 
-    cur_luminance.x = STL::Color::Luminance(diffuse * surface.diffuse_albedo);
-    cur_luminance.y = STL::Color::Luminance(specular);
     specular /= max(surface.specular_f0, 0.001f);
 
 
@@ -61,8 +58,6 @@ main(uint2 dtid
       b_use_red = true;
     }
   }
-  rw_restir_luminance[pixel_pos] = cur_luminance;
-
   // rw_diffuse_lighting[pixel_pos] = float4(diffuse, light_dist);
   // rw_specular_lighting[pixel_pos] = float4(specular, light_dist);
 

--- a/shaders/pipelines/raytracing/restir_di/TemporalResampling.hlsl
+++ b/shaders/pipelines/raytracing/restir_di/TemporalResampling.hlsl
@@ -77,8 +77,6 @@ main(uint2 dtid
   }
 #endif
 
-  rw_temporal_sample_pos[pixel_pos] = temporal_pixel_pos;
-
   Moer::DI::StoreReservoir(
       res, resample_params.restir_di_params.reservoir_buffer_params, pixel_pos,
       resample_params.restir_di_params.buffer_indices

--- a/source/editor/raytracing_ui/RaytracingUI.cpp
+++ b/source/editor/raytracing_ui/RaytracingUI.cpp
@@ -102,6 +102,18 @@ void RaytracingUI::ShowConfig() {
                         m_config.restir_di_cfg.initial_sample_config.local_light_sample_mode = index;
                     }
                 }
+                ImGui::Checkbox(
+                    "Adaptive Grid Fallback",
+                    &m_config.restir_di_cfg.initial_sample_config.enable_adaptive_local_light_sampling
+                );
+                if (m_config.restir_di_cfg.initial_sample_config.enable_adaptive_local_light_sampling) {
+                    ImGui::SliderInt(
+                        "Grid Min Local Lights",
+                        &m_config.restir_di_cfg.initial_sample_config.grid_min_local_light_count,
+                        1,
+                        1024
+                    );
+                }
                 ImGui::TreePop();
             }
             ImGui::TreePop();

--- a/source/runtime/render/renderer/raytracing/LightingPass.cpp
+++ b/source/runtime/render/renderer/raytracing/LightingPass.cpp
@@ -52,7 +52,8 @@ LightingPass::LightingPass(ShaderManager& _manager, BindlessArrayRef bindless_ar
     );
 }
 
-void LightingPass::Process(CommandList& _cmd_list, RTContext& _rt_ctx) {
+LightingPass::LocalLightSamplingDecision
+LightingPass::Process(CommandList& _cmd_list, RTContext& _rt_ctx) {
     const DI::ReSTIRDIRuntimeConfig& restir_di_runtime_config = _rt_ctx.is_ctx.GetReSTIRDIRuntimeConfig();
 
     const ImportanceSamplingContext& is_ctx = _rt_ctx.is_ctx;
@@ -66,8 +67,21 @@ void LightingPass::Process(CommandList& _cmd_list, RTContext& _rt_ctx) {
     constants.env_pdf_size     = _rt_ctx.env_pdf_tex ? _rt_ctx.env_pdf_tex->GetExtent().xy : uint2(0);
     constants.bindless_handles = _rt_ctx.GetBindlessHandles();
 
-    constants.di_params                                 = restir_di_runtime_config.common_params;
-    constants.restir_di_params.initial_sample_params    = is_ctx.GetDIInitialSampleParams();
+    constants.di_params = restir_di_runtime_config.common_params;
+    auto initial_sample_params = is_ctx.GetDIInitialSampleParams();
+    LocalLightSamplingDecision sampling_decision{};
+    sampling_decision.configured_mode  = initial_sample_params.local_light_sample_mode;
+    sampling_decision.local_light_count =
+        is_ctx.GetLightBufferParams().local_light_region.light_cnt;
+    sampling_decision.adaptive_fallback_applied =
+        _rt_ctx.config.enable_adaptive_local_light_sampling &&
+        initial_sample_params.local_light_sample_mode == s_di_local_light_sample_mode_grid &&
+        sampling_decision.local_light_count < _rt_ctx.config.grid_min_local_light_count;
+    if (sampling_decision.adaptive_fallback_applied) {
+        initial_sample_params.local_light_sample_mode = s_di_local_light_sample_mode_power_ris;
+    }
+    sampling_decision.effective_mode = initial_sample_params.local_light_sample_mode;
+    constants.restir_di_params.initial_sample_params    = initial_sample_params;
     constants.restir_di_params.temporal_resample_params = is_ctx.GetDITemporalResampleParams();
     constants.restir_di_params.spatial_resample_params  = is_ctx.GetDISpatialResampleParams();
     constants.restir_di_params.reservoir_buffer_params  = restir_di_runtime_config.reservoir_buffer_params;
@@ -94,30 +108,42 @@ void LightingPass::Process(CommandList& _cmd_list, RTContext& _rt_ctx) {
     _cmd_list.CopyFrom(std::move(upload_data), resample_params->GetView());
     bool b_current_frame = _rt_ctx.b_current_frame;
 
-#define DI_BINDING_ARGS(ctx)                                                                              \
-    ctx.rt_scene->GetTlas(),                                                                              \
-        ctx.rt_scene->GetPrevTlas() ? ctx.rt_scene->GetPrevTlas() : ctx.rt_scene->GetTlas(),              \
-        resample_params, ctx.light_reservoir_buf, ctx.frame_rt.diffuse_lighting,                          \
-        ctx.frame_rt.specular_lighting, ctx.frame_rt.temporal_sample_pos, ctx.frame_rt.gradients,         \
-        b_current_frame ? ctx.frame_rt.restir_luminance : ctx.frame_rt.prev_luminance,                    \
-        ctx.frame_rt.prev_diffuse_lighting, ctx.ris_buf, ctx.ris_light_data_buf, ctx.neighbor_offset_buf, \
-        bindless_array
+#define DI_BINDING_ARGS(ctx)                                                                         \
+    ctx.rt_scene->GetTlas(),                                                                         \
+        ctx.rt_scene->GetPrevTlas() ? ctx.rt_scene->GetPrevTlas() : ctx.rt_scene->GetTlas(),         \
+        resample_params, ctx.light_reservoir_buf, ctx.frame_rt.diffuse_lighting,                     \
+        ctx.frame_rt.specular_lighting, ctx.frame_rt.temporal_sample_pos, ctx.frame_rt.gradients,    \
+        b_current_frame ? ctx.frame_rt.restir_luminance : ctx.frame_rt.prev_luminance,               \
+        ctx.frame_rt.prev_diffuse_lighting, ctx.ris_buf, ctx.ris_light_data_buf,                     \
+        ctx.neighbor_offset_buf, bindless_array
 
     auto div_ceil = [](uint _a, uint _b) -> uint {
         return (_a + _b - 1) / _b;
     };
+    const uint local_light_count     = sampling_decision.local_light_count;
+    const bool has_local_candidates = initial_sample_params.num_primary_local_lights > 0;
+    const bool uses_grid =
+        initial_sample_params.local_light_sample_mode == s_di_local_light_sample_mode_grid;
+    const bool needs_power_ris =
+        initial_sample_params.local_light_sample_mode == s_di_local_light_sample_mode_power_ris ||
+        (uses_grid && constants.grid_params.common_params.local_light_sampling_fallback_mode ==
+                          s_di_local_light_sample_mode_power_ris);
     // 所有通过 DI_BINDINGS 声明的 pipeline 都采用相同参数布局。这里只注册一次，
     // 避免为每个阶段重复构建等价参数包。
     ArrayArgReference arg_ref =
         _cmd_list.RegisterArgs(presample_light_pipeline.SetArgs(DI_BINDING_ARGS(_rt_ctx)));
 
-    if (is_ctx.GetLightBufferParams().local_light_region.light_cnt) {
+    if (local_light_count && has_local_candidates && needs_power_ris) {
         uint2 dispatch_size = uint2(
             div_ceil(is_ctx.GetLocalLightRISBufferParams().tile_size, DI_PRESAMPLE_GRID_SIZE),
             is_ctx.GetLocalLightRISBufferParams().tile_cnt
         );
         _cmd_list.Compute(presample_light_pipeline, arg_ref)
-            .Dispatch(uint3(dispatch_size, 1), "PresampleLight");
+            .Dispatch(
+                uint3(dispatch_size, 1),
+                "PresampleLight",
+                ProfileSection("ReSTIR DI Presample Local")
+            );
     }
 
     if (is_ctx.GetLightBufferParams().env_light.light_cnt) {
@@ -126,14 +152,22 @@ void LightingPass::Process(CommandList& _cmd_list, RTContext& _rt_ctx) {
             is_ctx.GetEnvLightRISBufferParams().tile_cnt
         );
         _cmd_list.Compute(presample_env_map_pipeline, arg_ref)
-            .Dispatch(uint3(dispatch_size, 1), "PresampleEnvMap");
+            .Dispatch(
+                uint3(dispatch_size, 1),
+                "PresampleEnvMap",
+                ProfileSection("ReSTIR DI Presample Environment")
+            );
     }
 
-    if (is_ctx.GetLightBufferParams().local_light_region.light_cnt) {
+    if (local_light_count && has_local_candidates && uses_grid) {
         uint2 dispatch_size =
             uint2(div_ceil(is_ctx.GetGridRuntimeConfig().num_light_slot, DI_PRESAMPLE_GRID_SIZE), 1);
         _cmd_list.Compute(presample_light_grid_pipeline, arg_ref)
-            .Dispatch(uint3(dispatch_size, 1), "PresampleLightGrid");
+            .Dispatch(
+                uint3(dispatch_size, 1),
+                "PresampleLightGrid",
+                ProfileSection("ReSTIR DI Presample Grid")
+            );
     }
 
     // 初始采样、时序复用、空间复用和着色均以屏幕 tile 为调度粒度。
@@ -142,19 +176,37 @@ void LightingPass::Process(CommandList& _cmd_list, RTContext& _rt_ctx) {
         dispatch_size.x     = div_ceil(dispatch_size.x, DI_SCREEN_TILE_SIZE);
         dispatch_size.y     = div_ceil(dispatch_size.y, DI_SCREEN_TILE_SIZE);
         _cmd_list.Compute(generate_initial_sample_pipeline, arg_ref)
-            .Dispatch(uint3(dispatch_size, 1), "GenerateInitialSample");
+            .Dispatch(
+                uint3(dispatch_size, 1),
+                "GenerateInitialSample",
+                ProfileSection("ReSTIR DI Initial")
+            );
 
         _cmd_list.Compute(temporal_resample_pipeline, arg_ref)
-            .Dispatch(uint3(dispatch_size, 1), "TemporalResample");
+            .Dispatch(
+                uint3(dispatch_size, 1),
+                "TemporalResample",
+                ProfileSection("ReSTIR DI Temporal")
+            );
 
         _cmd_list.Compute(spatial_resample_pipeline, arg_ref)
-            .Dispatch(uint3(dispatch_size, 1), "SpatialResample");
+            .Dispatch(
+                uint3(dispatch_size, 1),
+                "SpatialResample",
+                ProfileSection("ReSTIR DI Spatial")
+            );
 
-        _cmd_list.Compute(di_shade_sample_pipeline, arg_ref).Dispatch(uint3(dispatch_size, 1), "ShadeSample");
+        _cmd_list.Compute(di_shade_sample_pipeline, arg_ref)
+            .Dispatch(
+                uint3(dispatch_size, 1),
+                "ShadeSample",
+                ProfileSection("ReSTIR DI Shade")
+            );
     }
 
     _cmd_list.PopScopeWithTimeScope();
 #undef DI_BINDING_ARGS
+    return sampling_decision;
 }
 
 } // namespace Moer::Render::Raytracing

--- a/source/runtime/render/renderer/raytracing/LightingPass.h
+++ b/source/runtime/render/renderer/raytracing/LightingPass.h
@@ -93,9 +93,16 @@ public:
 
 class LightingPass {
 public:
+    struct LocalLightSamplingDecision {
+        uint configured_mode           = s_di_local_light_sample_mode_uniform;
+        uint effective_mode            = s_di_local_light_sample_mode_uniform;
+        bool adaptive_fallback_applied = false;
+        uint local_light_count          = 0;
+    };
+
     LightingPass(class ShaderManager& manager, BindlessArrayRef bindless_array);
 
-    void Process(CommandList& cmd_list, RTContext& rt_ctx);
+    LocalLightSamplingDecision Process(CommandList& cmd_list, RTContext& rt_ctx);
 
 private:
     BindlessArrayRef bindless_array;

--- a/source/runtime/render/renderer/raytracing/RTResource.h
+++ b/source/runtime/render/renderer/raytracing/RTResource.h
@@ -68,6 +68,8 @@ struct RTContext {
         float4      reblur_specular_hit_dist_params;
         EFinalColor final_color;
         uint        denoiser_mode;
+        bool        enable_adaptive_local_light_sampling = true;
+        uint        grid_min_local_light_count           = 64;
     };
 
 public:

--- a/source/runtime/render/renderer/raytracing/RaytracingConfig.h
+++ b/source/runtime/render/renderer/raytracing/RaytracingConfig.h
@@ -44,7 +44,9 @@ struct GridConfig {
 };
 
 struct ReSTIRDIInitialSampleConfig {
-    uint local_light_sample_mode = Render::s_di_local_light_sample_mode_grid;
+    uint local_light_sample_mode                = Render::s_di_local_light_sample_mode_grid;
+    bool enable_adaptive_local_light_sampling   = true;
+    int  grid_min_local_light_count             = 64;
 };
 
 struct ReSTIRDITemporalResampleConfig {

--- a/source/runtime/render/renderer/raytracing/RaytracingFramePacket.h
+++ b/source/runtime/render/renderer/raytracing/RaytracingFramePacket.h
@@ -47,6 +47,17 @@ struct RaytracingFrameFeedback {
 
     ProfileData        profiler_data{};
     Array<std::string> material_texture_names;
+
+    uint64 renderer_tlas_build_count = 0;
+    uint64 renderer_tlas_skip_count  = 0;
+    uint64 scene_tlas_update_count   = 0;
+    uint64 rt_instance_revision      = 0;
+    uint64 current_tlas_revision     = 0;
+    uint64 previous_tlas_revision    = 0;
+    uint configured_local_light_sample_mode    = s_di_local_light_sample_mode_uniform;
+    uint effective_local_light_sample_mode     = s_di_local_light_sample_mode_uniform;
+    bool adaptive_local_light_fallback_applied = false;
+    uint local_light_count                     = 0;
 };
 
 } // namespace Moer::Render::Raytracing

--- a/source/runtime/render/renderer/raytracing/RaytracingRenderer.cpp
+++ b/source/runtime/render/renderer/raytracing/RaytracingRenderer.cpp
@@ -29,7 +29,10 @@
 #include <imgui.h>
 
 #include <algorithm>
+#include <cstdlib>
+#include <limits>
 #include <new>
+#include <sstream>
 #include <thread>
 
 namespace Moer::Render::Raytracing {
@@ -51,6 +54,118 @@ bool EqualQuaternion(const Quaternion& lhs, const Quaternion& rhs) {
            lhs.vec.w == rhs.vec.w;
 }
 
+double FindGpuTime(const ProfileData& profile_data, std::string_view name) {
+    for (const auto& entry : profile_data.gpu_entries) {
+        if (entry.name == name) {
+            return entry.time;
+        }
+    }
+    return -1.0;
+}
+
+bool IsProfileLogEnabled() {
+    static const bool enabled = []() {
+        const char* value = std::getenv("MOER_RT_PROFILE_LOG");
+        return value && value[0] != '\0' && std::string_view(value) != "0";
+    }();
+    return enabled;
+}
+
+bool IsLegacyTlasUpdateEnabled() {
+    static const bool enabled = []() {
+        const char* value = std::getenv("MOER_RT_TLAS_EVERY_FRAME");
+        return value && value[0] != '\0' && std::string_view(value) != "0";
+    }();
+    return enabled;
+}
+
+bool IsLightGridForced() {
+    static const bool enabled = []() {
+        const char* value = std::getenv("MOER_RT_FORCE_LIGHT_GRID");
+        return value && value[0] != '\0' && std::string_view(value) != "0";
+    }();
+    return enabled;
+}
+
+std::string_view LocalLightSampleModeName(uint mode) {
+    switch (mode) {
+        case s_di_local_light_sample_mode_uniform:
+            return "Uniform";
+        case s_di_local_light_sample_mode_power_ris:
+            return "PowerRIS";
+        case s_di_local_light_sample_mode_grid:
+            return "Grid";
+        default:
+            return "Unknown";
+    }
+}
+
+void TickAndLogProfiling(const RaytracingFrameFeedback& feedback) {
+    const ProfileData& profile_data = feedback.profiler_data;
+    if (!IsProfileLogEnabled() || profile_data.gpu_entries.empty()) {
+        return;
+    }
+
+    static LoopedTimer timer(1.0, true);
+    if (!timer.Tick()) {
+        return;
+    }
+
+    constexpr std::pair<std::string_view, std::string_view> entries[] = {
+        {"GraphicsExec", "Graphics Exec"},
+        {"PrepareLights", "PrepareLights"},
+        {"GBuffer", "GBufferPass"},
+        {"LightingTotal", "LightingPass"},
+        {"DIPresampleLocal", "ReSTIR DI Presample Local"},
+        {"DIPresampleEnv", "ReSTIR DI Presample Environment"},
+        {"DIPresampleGrid", "ReSTIR DI Presample Grid"},
+        {"DIInitial", "ReSTIR DI Initial"},
+        {"DITemporal", "ReSTIR DI Temporal"},
+        {"DISpatial", "ReSTIR DI Spatial"},
+        {"DIShade", "ReSTIR DI Shade"},
+        {"RendererTLAS", "RTScene RendererTLAS"},
+        {"TLASBuild", "RTScene BuildTLAS"},
+        {"TLASUpdate", "RTScene UpdateTLAS"},
+        {"AntiAlias", "AntiAliasPass"},
+        {"ToneMapping", "ToneMappingPass"},
+    };
+
+    std::ostringstream stream;
+    stream.setf(std::ios::fixed);
+    stream.precision(3);
+    stream << "[RaytracingProfile] GPU(ms)";
+    double di_shader_sum = 0.0;
+    for (const auto& [key, scope_name] : entries) {
+        const double duration = FindGpuTime(profile_data, scope_name);
+        if (duration >= 0.0) {
+            stream << ' ' << key << '=' << duration;
+            if (key.starts_with("DI")) {
+                di_shader_sum += duration;
+            }
+        }
+    }
+    const double lighting_total = FindGpuTime(profile_data, "LightingPass");
+    if (lighting_total >= 0.0) {
+        stream << " DIShaderSum=" << di_shader_sum
+               << " LightingUnattributed=" << lighting_total - di_shader_sum;
+    }
+    stream << " TLASPolicy=" << (IsLegacyTlasUpdateEnabled() ? "LegacyEveryFrame" : "RevisionGated")
+           << " RendererTLASBuilds=" << feedback.renderer_tlas_build_count
+           << " RendererTLASSkips=" << feedback.renderer_tlas_skip_count
+           << " SceneTLASUpdates=" << feedback.scene_tlas_update_count
+           << " RTRevision=" << feedback.rt_instance_revision
+           << " CurrentTLASRevision=" << feedback.current_tlas_revision
+           << " PreviousTLASRevision=" << feedback.previous_tlas_revision
+           << " ConfiguredLocalLightSampling="
+           << LocalLightSampleModeName(feedback.configured_local_light_sample_mode)
+           << " EffectiveLocalLightSampling="
+           << LocalLightSampleModeName(feedback.effective_local_light_sample_mode)
+           << " AdaptiveFallback="
+           << (feedback.adaptive_local_light_fallback_applied ? "Applied" : "NotApplied")
+           << " LocalLights=" << feedback.local_light_count;
+    LOG_INFO("{}", stream.str());
+}
+
 void ExecuteSceneUpdate(
     RenderScene&     render_scene,
     GpuSceneUpdate&& update,
@@ -67,6 +182,8 @@ void ExecuteSceneUpdate(
 } // namespace
 
 struct RaytracingRenderer::RuntimeState {
+    static constexpr uint64 invalid_tlas_revision = std::numeric_limits<uint64>::max();
+
     bool b_new_env_map = false;
 
     TextureRef         env_map{};
@@ -90,6 +207,13 @@ struct RaytracingRenderer::RuntimeState {
 
     bool b_feedback_valid = false;
     bool b_export         = false;
+
+    uint64 rt_instance_revision      = 0;
+    uint64 current_tlas_revision     = invalid_tlas_revision;
+    uint64 previous_tlas_revision    = invalid_tlas_revision;
+    uint64 renderer_tlas_build_count = 0;
+    uint64 renderer_tlas_skip_count  = 0;
+    uint64 scene_tlas_update_count   = 0;
 
     std::filesystem::path exported_file_path;
 
@@ -464,11 +588,21 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
         state.b_export = ui_config.export_cfg.b_export;
 
         if (state.rt_scene) {
-            for (size_t i = 0; i < state.rt_scene->GetInstanceCount(); i++) {
-                auto& instance = state.rt_scene->GetInstance(i);
-                state.rt_scene->MarkModified(instance.instance_id);
+            const bool needs_tlas_build = IsLegacyTlasUpdateEnabled() ||
+                                          state.current_tlas_revision != state.rt_instance_revision;
+            if (needs_tlas_build) {
+                for (size_t i = 0; i < state.rt_scene->GetInstanceCount(); i++) {
+                    auto& instance = state.rt_scene->GetInstance(i);
+                    state.rt_scene->MarkModified(instance.instance_id);
+                }
+                cmd_list.PushScopeWithTimeScope("RTScene RendererTLAS");
+                cmd_list.UpdateRaytracingScene(state.rt_scene);
+                cmd_list.PopScopeWithTimeScope();
+                state.current_tlas_revision = state.rt_instance_revision;
+                ++state.renderer_tlas_build_count;
+            } else {
+                ++state.renderer_tlas_skip_count;
             }
-            cmd_list.UpdateRaytracingScene(state.rt_scene);
         }
 
         ToneMappingPass::Params tone_params{};
@@ -498,6 +632,12 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
 
             di_initial_sample_config.local_light_sample_mode =
                 ui_config.restir_di_cfg.initial_sample_config.local_light_sample_mode;
+            state.rt_ctx->config.enable_adaptive_local_light_sampling =
+                ui_config.restir_di_cfg.initial_sample_config.enable_adaptive_local_light_sampling &&
+                !IsLightGridForced();
+            state.rt_ctx->config.grid_min_local_light_count = static_cast<uint>(std::max(
+                ui_config.restir_di_cfg.initial_sample_config.grid_min_local_light_count, 1
+            ));
             di_initial_sample_config.env_map_is =
                 state.importance_sampling_context.GetLightBufferParams().env_light.light_cnt;
             di_temporal_resampling_config.bias_correction_mode =
@@ -561,7 +701,12 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
         state.rt_ctx->Tick(camera, state.antialias_pass->GetPixelOffset());
         state.prepare_light_pass->Process(cmd_list, *state.rt_ctx, scene_snapshot);
         state.g_buffer_pass->Process(cmd_list, *state.rt_ctx);
-        state.lighting_pass->Process(cmd_list, *state.rt_ctx);
+        const auto local_light_sampling = state.lighting_pass->Process(cmd_list, *state.rt_ctx);
+        feedback.configured_local_light_sample_mode = local_light_sampling.configured_mode;
+        feedback.effective_local_light_sample_mode  = local_light_sampling.effective_mode;
+        feedback.adaptive_local_light_fallback_applied =
+            local_light_sampling.adaptive_fallback_applied;
+        feedback.local_light_count = local_light_sampling.local_light_count;
 
 #if WITH_NRD
         {
@@ -705,6 +850,7 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
 
     if (state.rt_scene) {
         state.rt_scene->AdvanceFrame();
+        std::swap(state.current_tlas_revision, state.previous_tlas_revision);
     }
 
     time++;
@@ -739,6 +885,12 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
     }
 
     feedback.profiler_data = gfx_queue.GetProfilerEntry();
+    feedback.renderer_tlas_build_count = state.renderer_tlas_build_count;
+    feedback.renderer_tlas_skip_count  = state.renderer_tlas_skip_count;
+    feedback.scene_tlas_update_count   = state.scene_tlas_update_count;
+    feedback.rt_instance_revision      = state.rt_instance_revision;
+    feedback.current_tlas_revision     = state.current_tlas_revision;
+    feedback.previous_tlas_revision    = state.previous_tlas_revision;
     feedback.material_texture_names.reserve(state.material_textures.size());
     for (const auto& entry : state.material_textures) {
         feedback.material_texture_names.emplace_back(entry.first);
@@ -751,6 +903,7 @@ void RaytracingRenderer::ApplyFrameFeedback(
     RaytracingConfig&       target_config
 ) {
     assert(IsCurrentlyGameThread());
+    TickAndLogProfiling(feedback);
     if (feedback.has_grid_cell_size) {
         target_config.grid_config.cell_size = feedback.grid_cell_size;
     }
@@ -842,21 +995,42 @@ void RaytracingRenderer::RefreshSceneRuntimeRefs() {
     state.rt_ctx->SetRaytracingScene(state.rt_scene);
     if (rt_scene_changed) {
         state.b_feedback_valid = false;
+        state.current_tlas_revision  = RuntimeState::invalid_tlas_revision;
+        state.previous_tlas_revision = RuntimeState::invalid_tlas_revision;
     }
 }
 
 void RaytracingRenderer::ExecuteSceneUpdates(SceneUpdateBatch& batch) {
-    bool updated = false;
+    auto& state = *runtime_state;
+    bool  updated = false;
+    bool  rt_scene_updated = false;
     if (batch.initial_gpu_update) {
+        const bool has_rt_update = batch.initial_gpu_update->raytracing_update !=
+                                   EGpuSceneRaytracingUpdate::None;
         ExecuteSceneUpdate(*render_scene, std::move(*batch.initial_gpu_update), device, gfx_queue);
-        updated = true;
+        updated          = true;
+        rt_scene_updated = rt_scene_updated || has_rt_update;
+        if (has_rt_update) {
+            ++state.rt_instance_revision;
+            ++state.scene_tlas_update_count;
+        }
     }
     if (batch.update_gpu_update) {
+        const bool has_rt_update = batch.update_gpu_update->raytracing_update !=
+                                   EGpuSceneRaytracingUpdate::None;
         ExecuteSceneUpdate(*render_scene, std::move(*batch.update_gpu_update), device, gfx_queue);
-        updated = true;
+        updated          = true;
+        rt_scene_updated = rt_scene_updated || has_rt_update;
+        if (has_rt_update) {
+            ++state.rt_instance_revision;
+            ++state.scene_tlas_update_count;
+        }
     }
     if (updated) {
         RefreshSceneRuntimeRefs();
+    }
+    if (rt_scene_updated && state.rt_scene) {
+        state.current_tlas_revision = state.rt_instance_revision;
     }
 }
 

--- a/source/runtime/render/rhi/RHICommand.h
+++ b/source/runtime/render/rhi/RHICommand.h
@@ -34,6 +34,8 @@ public:
 namespace Moer::Render {
 
 struct ProfileSection {
+    // Non-"Other" names must be unique across timestamped scopes and dispatches
+    // within one profiled submission because each name owns one query pair.
     std::string_view name;
     explicit ProfileSection(const char* _name) : name(_name) {}
 };

--- a/source/runtime/render/rhi/RHICommandList.cpp
+++ b/source/runtime/render/rhi/RHICommandList.cpp
@@ -107,7 +107,7 @@ void CommandList::ComputeDispatcher::Dispatch(
             _name
         );
     }
-    cmd_list.commands.push_back(MakeUnique<DispatchCmd>(std::move(args), pso.handle, _group_count));
+    cmd_list.commands.push_back(MakeUnique<DispatchCmd>(std::move(args), pso.handle, _group_count, _section));
     cmd_list.commands.back()->name = _name;
 }
 
@@ -116,7 +116,7 @@ void CommandList::ComputeDispatcher::DispatchIndirect(
     std::string_view _name,
     ProfileSection   _section
 ) {
-    cmd_list.commands.push_back(MakeUnique<DispatchCmd>(std::move(args), pso.handle, _indirect));
+    cmd_list.commands.push_back(MakeUnique<DispatchCmd>(std::move(args), pso.handle, _indirect, _section));
     cmd_list.commands.back()->name = _name;
 }
 

--- a/source/runtime/render/rhi/RHIImpl.h
+++ b/source/runtime/render/rhi/RHIImpl.h
@@ -1279,6 +1279,7 @@ private:
     // const PipelineHandle& pipeline;
     PipelineHandle          pipeline{};
     DispatchParam           param;
+    std::string_view        profile_section_name{"Other"};
     // ArrayArguments          args;
     TShaderArgArray args;
     DispatchCmd(ArrayArguments&& _args) : Command(EType::ShaderDispatch), args(std::move(_args)) {}
@@ -1288,21 +1289,25 @@ public:
         TShaderArgArray&& _args,
         PipelineHandle&   _handle,
         uint3             _param,
+        ProfileSection    _profile_section,
         std::string_view  _name = typenames[uint(EType::ShaderDispatch)]
     ) :
         Command(EType::ShaderDispatch, _name),
         param(_param),
         pipeline(_handle),
+        profile_section_name(_profile_section.name),
         args(std::move(_args)) {}
     DispatchCmd(
         TShaderArgArray&& _args,
         PipelineHandle&   _handle,
         BufferView        _indirect,
+        ProfileSection    _profile_section,
         std::string_view  _name = typenames[uint(EType::ShaderDispatch)]
     ) :
         Command(EType::ShaderDispatch, _name),
         pipeline(_handle),
         param(DispatchIndirectParam{_indirect}),
+        profile_section_name(_profile_section.name),
         args(std::move(_args)) {}
 
     EQueueType GetQueueType() const override {
@@ -1320,6 +1325,9 @@ public:
     }
     auto Param() const {
         return param;
+    }
+    std::string_view ProfileSectionName() const {
+        return profile_section_name;
     }
 };
 

--- a/source/runtime/render/rhi/vulkan/VulkanQueue.cpp
+++ b/source/runtime/render/rhi/vulkan/VulkanQueue.cpp
@@ -1223,6 +1223,7 @@ class VkCmdVisitor : VulkanDeviceObject {
     VkTracker&             tracker;
     const TCachedArgArray& cached_args;
     ProfilerStorage*       profiler = nullptr;
+    bool                   query_profiling_enabled = false;
 
 public:
     VkCmdVisitor(
@@ -1231,14 +1232,16 @@ public:
         VkTracker&             _tracker,
         VulkanCmdList&         _cmd_list,
         const TCachedArgArray& _cached_args,
-        ProfilerStorage*       _profiler = nullptr
+        ProfilerStorage*       _profiler = nullptr,
+        bool                   _query_profiling_enabled = false
     ) :
         VulkanDeviceObject(&_device),
         allocator(_allocator),
         tracker(_tracker),
         cmd_list(_cmd_list),
         cached_args(_cached_args),
-        profiler(_profiler) {}
+        profiler(_profiler),
+        query_profiling_enabled(_query_profiling_enabled) {}
 
     void VisitCmd(const Command* _cmd) {
         switch (_cmd->Type()) {
@@ -1440,6 +1443,15 @@ public:
         static float4 dispatch_color = {0.0f, 0.0f, 1.0f, 1.0f};
         cmd_list.BeginLabel(_cmd.name, dispatch_color);
         const auto& param = _cmd.Param();
+        const auto  profile_section_name = _cmd.ProfileSectionName();
+        const bool query_timestamp = query_profiling_enabled && profile_section_name != "Other";
+
+        if (query_timestamp) {
+            assert(profiler && "profiler is not set");
+            profiler->BeginProfilerSession(
+                cmd_list, profile_section_name, VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT
+            );
+        }
 
         const PipelineHandle& pso = _cmd.Pipeline();
         cmd_list.SetPso(_cmd.Pipeline());
@@ -1461,6 +1473,12 @@ public:
             },
             param
         );
+
+        if (query_timestamp) {
+            profiler->EndProfilerSession(
+                cmd_list, profile_section_name, VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT
+            );
+        }
 
         cmd_list.EndLabel();
     }
@@ -2350,13 +2368,13 @@ public:
     void Visit(const ScopeCmd& _cmd) {
         if (_cmd.IsPush()) {
             cmd_list.BeginLabel(_cmd.ScopeName(), {0.0f, 1.0f, 0.0f, 1.0f});
-            if (_cmd.QueryTimestamp()) {
+            if (_cmd.QueryTimestamp() && query_profiling_enabled) {
                 assert(profiler && "profiler is not set");
                 profiler->BeginProfilerSession(cmd_list, _cmd.ScopeName());
             }
         } else {
             cmd_list.EndLabel();
-            if (_cmd.QueryTimestamp()) {
+            if (_cmd.QueryTimestamp() && query_profiling_enabled) {
                 assert(profiler && "profiler is not set");
                 profiler->EndProfilerSession(cmd_list, _cmd.ScopeName());
             }
@@ -2896,26 +2914,30 @@ int ProfilerStorage::GetQueryStorageIndex(std::string_view _name) {
     return name2sample[name].index;
 }
 
-void ProfilerStorage::BeginProfilerSession(VulkanCmdList& _cmd_list, std::string_view _name) {
+void ProfilerStorage::BeginProfilerSession(
+    VulkanCmdList&          _cmd_list,
+    std::string_view        _name,
+    VkPipelineStageFlagBits _stage
+) {
     if (!active) {
         return;
     }
     uint idx = GetQueryStorageIndex(_name) * 2 + 0 + cur_frame * s_max_num_profiler_queries_per_frame;
-    vkCmdWriteTimestamp(
-        _cmd_list.GetHandle(), kBeginTimestampStage, timestamp_pool.GetHandle(), idx
-    );
+    vkCmdWriteTimestamp(_cmd_list.GetHandle(), _stage, timestamp_pool.GetHandle(), idx);
     SetQueryUsed(idx);
     assert(IsQueryUsed(idx + 1) == false && "Query already used");
 }
 
-void ProfilerStorage::EndProfilerSession(VulkanCmdList& _cmd_list, std::string_view _name) {
+void ProfilerStorage::EndProfilerSession(
+    VulkanCmdList&          _cmd_list,
+    std::string_view        _name,
+    VkPipelineStageFlagBits _stage
+) {
     if (!active) {
         return;
     }
     uint idx = GetQueryStorageIndex(_name) * 2 + 1 + cur_frame * s_max_num_profiler_queries_per_frame;
-    vkCmdWriteTimestamp(
-        _cmd_list.GetHandle(), kEndTimestampStage, timestamp_pool.GetHandle(), idx
-    );
+    vkCmdWriteTimestamp(_cmd_list.GetHandle(), _stage, timestamp_pool.GetHandle(), idx);
     SetQueryUsed(idx);
     assert(IsQueryUsed(idx - 1) == true && "Query not used");
 }
@@ -3218,7 +3240,13 @@ void VkCommandQueue::ExecuteNow(CmdSubmit&& _submit, uint64 _timeline, uint64 _s
 
     //Visitor for actual command recording
     VkCmdVisitor visitor(
-        vk_device, vk_allocator, tracker, vk_allocator.GetCmdList(), _submit.cached_args, &profiler_storage
+        vk_device,
+        vk_allocator,
+        tracker,
+        vk_allocator.GetCmdList(),
+        _submit.cached_args,
+        &profiler_storage,
+        _submit.b_tick_profiling
     );
 
     //Visitor for barrier generation
@@ -3405,7 +3433,7 @@ void VkCommandQueue::ExecuteNow(CmdSubmit&& _submit, uint64 _timeline, uint64 _s
                     diagnostics.descriptor_begin,
                     diagnostics.descriptor_bytes
                 );
-                if (cmd->Type() == Command::EType::Scope) {
+                if (_submit.b_tick_profiling && cmd->Type() == Command::EType::Scope) {
                     const auto& scope = *static_cast<const ScopeCmd*>(cmd);
                     if (scope.QueryTimestamp()) {
                         serial_golden->RecordQueryEvent(
@@ -3413,6 +3441,20 @@ void VkCommandQueue::ExecuteNow(CmdSubmit&& _submit, uint64 _timeline, uint64 _s
                             scope.ScopeName(),
                             scope.IsPush() ? ProfilerStorage::kBeginTimestampStage
                                            : ProfilerStorage::kEndTimestampStage
+                        );
+                    }
+                } else if (_submit.b_tick_profiling && cmd->Type() == Command::EType::ShaderDispatch) {
+                    const auto& dispatch = *static_cast<const DispatchCmd*>(cmd);
+                    if (dispatch.ProfileSectionName() != "Other") {
+                        serial_golden->RecordQueryEvent(
+                            SerialQueryEvent::Begin,
+                            dispatch.ProfileSectionName(),
+                            VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT
+                        );
+                        serial_golden->RecordQueryEvent(
+                            SerialQueryEvent::End,
+                            dispatch.ProfileSectionName(),
+                            VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT
                         );
                     }
                 }

--- a/source/runtime/render/rhi/vulkan/VulkanQueue.h
+++ b/source/runtime/render/rhi/vulkan/VulkanQueue.h
@@ -133,8 +133,16 @@ struct ProfilerStorage {
         return data;
     }
 
-    void BeginProfilerSession(VulkanCmdList& _cmd, std::string_view _name);
-    void EndProfilerSession(VulkanCmdList& _cmd, std::string_view _name);
+    void BeginProfilerSession(
+        VulkanCmdList&           _cmd,
+        std::string_view         _name,
+        VkPipelineStageFlagBits  _stage = kBeginTimestampStage
+    );
+    void EndProfilerSession(
+        VulkanCmdList&           _cmd,
+        std::string_view         _name,
+        VkPipelineStageFlagBits  _stage = kEndTimestampStage
+    );
     QueryFrameDiagnostics GetCurrentFrameQueryDiagnostics() const;
 
     bool               active = false;

--- a/tools/raytracing/summarize_profile.py
+++ b/tools/raytracing/summarize_profile.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+"""Summarize MoerEngine [RaytracingProfile] sliding-window logs."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import math
+import re
+import statistics
+from datetime import datetime
+from pathlib import Path
+
+
+PROFILE_MARKER = re.compile(r"\[RaytracingProfile\] GPU\(ms\)\s+(.*)$")
+LOG_TIMESTAMP = re.compile(r"^\[(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}(?:\.\d+)?)\]")
+METADATA_KEYS = {
+    "TLASPolicy",
+    "RendererTLASBuilds",
+    "RendererTLASSkips",
+    "SceneTLASUpdates",
+    "RTRevision",
+    "CurrentTLASRevision",
+    "PreviousTLASRevision",
+    "ConfiguredLocalLightSampling",
+    "EffectiveLocalLightSampling",
+    "AdaptiveFallback",
+    "LocalLightSampling",
+    "LocalLights",
+}
+METADATA_STRING_KEYS = {
+    "TLASPolicy",
+    "ConfiguredLocalLightSampling",
+    "EffectiveLocalLightSampling",
+    "AdaptiveFallback",
+    "LocalLightSampling",
+}
+LEGACY_METADATA_RENAMES = {"LocalLightSampling": "LegacyLocalLightSampling"}
+COUNTER_KEYS = (
+    "RendererTLASBuilds",
+    "RendererTLASSkips",
+    "SceneTLASUpdates",
+)
+
+
+def percentile(sorted_values: list[float], fraction: float) -> float:
+    if not sorted_values:
+        raise ValueError("percentile requires at least one value")
+    rank = (len(sorted_values) - 1) * fraction
+    lower = math.floor(rank)
+    upper = math.ceil(rank)
+    if lower == upper:
+        return sorted_values[lower]
+    weight = rank - lower
+    return sorted_values[lower] * (1.0 - weight) + sorted_values[upper] * weight
+
+
+def summarize_values(values: list[float]) -> dict[str, float | int]:
+    ordered = sorted(values)
+    mean = statistics.fmean(ordered)
+    stddev = statistics.pstdev(ordered)
+    return {
+        "n": len(ordered),
+        "mean": mean,
+        "median": statistics.median(ordered),
+        "p90": percentile(ordered, 0.90),
+        "p95": percentile(ordered, 0.95),
+        "p99": percentile(ordered, 0.99),
+        "min": ordered[0],
+        "max": ordered[-1],
+        "stddev": stddev,
+        "cv": stddev / mean if mean else 0.0,
+    }
+
+
+def parse_log(path: Path, discard_first: int, before: datetime | None) -> dict[str, object]:
+    records: list[tuple[dict[str, float], dict[str, str | int]]] = []
+
+    for line in path.read_text(encoding="utf-8", errors="replace").splitlines():
+        if before:
+            timestamp_match = LOG_TIMESTAMP.match(line)
+            if timestamp_match and datetime.fromisoformat(timestamp_match.group(1)) >= before:
+                continue
+        match = PROFILE_MARKER.search(line)
+        if not match:
+            continue
+
+        timing_window: dict[str, float] = {}
+        metadata: dict[str, str | int] = {}
+        for token in match.group(1).split():
+            if "=" not in token:
+                continue
+            key, value = token.split("=", 1)
+            if key in METADATA_KEYS:
+                output_key = LEGACY_METADATA_RENAMES.get(key, key)
+                if key in METADATA_STRING_KEYS:
+                    metadata[output_key] = value
+                else:
+                    try:
+                        metadata[output_key] = int(value)
+                    except ValueError:
+                        metadata[output_key] = value
+                continue
+            try:
+                timing_window[key] = float(value)
+            except ValueError:
+                continue
+        if timing_window:
+            records.append((timing_window, metadata))
+
+    used_records = records[discard_first:]
+    used_windows = [timings for timings, _ in used_records]
+    timing_names = sorted({name for window in used_windows for name in window})
+    timings: dict[str, dict[str, float | int]] = {}
+    for name in timing_names:
+        values = [window[name] for window in used_windows if name in window]
+        if values:
+            timings[name] = summarize_values(values)
+
+    process_final_metadata = records[-1][1] if records else {}
+    measurement_start_metadata = used_records[0][1] if used_records else {}
+    measurement_end_metadata = used_records[-1][1] if used_records else {}
+    measurement_counter_delta: dict[str, int] = {}
+    for key in COUNTER_KEYS:
+        start_value = measurement_start_metadata.get(key)
+        end_value = measurement_end_metadata.get(key)
+        if isinstance(start_value, int) and isinstance(end_value, int):
+            measurement_counter_delta[key] = end_value - start_value
+
+    return {
+        "source": str(path.resolve()),
+        "discard_first": discard_first,
+        "before": before.isoformat(sep=" ") if before else None,
+        "window_count_total": len(records),
+        "window_count_used": len(used_windows),
+        "process_final_metadata": process_final_metadata,
+        "measurement_metadata": {
+            "start": measurement_start_metadata,
+            "end": measurement_end_metadata,
+            "counter_delta": measurement_counter_delta,
+        },
+        "timings_ms": timings,
+    }
+
+
+def write_csv(path: Path, runs: dict[str, dict[str, object]]) -> None:
+    fields = ["run", "scope", "n", "mean", "median", "p90", "p95", "p99", "min", "max", "stddev", "cv"]
+    with path.open("w", encoding="utf-8", newline="") as stream:
+        writer = csv.DictWriter(stream, fieldnames=fields)
+        writer.writeheader()
+        for run_name, run in runs.items():
+            timings = run["timings_ms"]
+            assert isinstance(timings, dict)
+            for scope, stats in timings.items():
+                assert isinstance(stats, dict)
+                writer.writerow({"run": run_name, "scope": scope, **stats})
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("logs", nargs="+", type=Path)
+    parser.add_argument("--discard-first", type=int, default=5)
+    parser.add_argument("--before", type=datetime.fromisoformat)
+    parser.add_argument("--json", type=Path, dest="json_path")
+    parser.add_argument("--csv", type=Path, dest="csv_path")
+    args = parser.parse_args()
+
+    if args.discard_first < 0:
+        parser.error("--discard-first must be non-negative")
+
+    runs: dict[str, dict[str, object]] = {}
+    for path in args.logs:
+        base_name = path.parent.name if path.stem.lower() in {"stdout", "stderr"} else path.stem
+        run_name = base_name
+        suffix = 2
+        while run_name in runs:
+            run_name = f"{base_name}_{suffix}"
+            suffix += 1
+        runs[run_name] = parse_log(path, args.discard_first, args.before)
+    output = {"profile_semantics": "13-frame sliding GPU timestamp windows", "runs": runs}
+    serialized = json.dumps(output, indent=2, ensure_ascii=False)
+    print(serialized)
+
+    if args.json_path:
+        args.json_path.write_text(serialized + "\n", encoding="utf-8")
+    if args.csv_path:
+        write_csv(args.csv_path, runs)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- choose Power RIS instead of building the fixed local-light Grid when ReSTIR DI is configured for Grid but the scene has fewer than the configurable threshold (64 by default)
- gate the renderer-side ping/pong TLAS refresh by RT-scene revision instead of marking every instance dirty every frame
- remove two dead ReSTIR DI shader stores while keeping the backing resources bound for lifecycle safety
- add per-dispatch compute timestamps, truthful configured/effective sampling telemetry, and a JSON/CSV profile summarizer with warm-up-aware counter deltas

## Performance

Latest `main`, same Debug binary, Vulkan, RTX 5080, Sponza, 1920x1080, NRD off. Two stable runs per mode in opposite order; 47 post-warm-up 1 Hz samples per run. Samples are 13-frame sliding GPU timestamp windows, not raw per-frame tail latency.

| Scope | Forced Grid | Adaptive Power RIS | Delta |
|---|---:|---:|---:|
| Graphics median | 3.896 ms | 3.331 ms | -0.565 ms (-14.5%) |
| Lighting median | 3.299 ms | 2.760 ms | -0.539 ms (-16.3%) |

The Grid pass measured 0.587/0.631 ms in the forced runs and was absent in adaptive runs. All steady-state measurement windows had `RendererTLASBuilds delta=0` and `SceneTLASUpdates delta=0`; process totals still record the initial build/update work separately.

## Validation

- `cmake --build build --config Debug --parallel 30`
- `TestRHICmdReorderer.exe`
- `TestRHIRecordDiagnostics.exe`
- `TestShaderStageSupport.exe`
- `py -m py_compile tools/raytracing/summarize_profile.py`
- `git diff --check origin/main...HEAD`
- six successful ray-tracing runtime verifier runs: 62 profile windows each, two nonblank captures, normal shutdown, no errors/VUID/device-lost/assertions/resource residue
- startup splash verifier: first-present handoff, 117 responsiveness samples, normal shutdown, no forbidden log lines
- two independent read-only code audits after rebasing; no remaining P1/P2 findings

## Notes

- the dead textures/resources are intentionally retained; removing their lifecycle/bindless structure caused an intermittent device loss during an earlier experiment
- `MOER_RT_FORCE_LIGHT_GRID=1` and `MOER_RT_TLAS_EVERY_FRAME=1` remain available for same-binary diagnostics
