### PR TITLE
fix(editor): prevent startup brand text clipping

### DIFF
--- a/source/editor/startup/StartupSplash.cpp
+++ b/source/editor/startup/StartupSplash.cpp
@@ -606,7 +606,7 @@ void DrawSplashContent(HDC dc, const RECT& client, const WindowContext& context)
         L"MoerEngine",
         -1,
         &product_rect,
-        DT_LEFT | DT_VCENTER | DT_SINGLELINE | DT_NOPREFIX
+        DT_LEFT | DT_VCENTER | DT_SINGLELINE | DT_NOPREFIX | DT_NOCLIP
     );
 
     RECT edition_rect{


### PR DESCRIPTION
## 变更

- 为启动加载页的 `MoerEngine` 品牌标题启用无裁剪绘制。

## 原因与影响

26pt Segoe UI 的实际行高大于原绘制矩形，GDI 会裁掉 `g` 的下伸部分。修复后保留现有字号和布局，同时完整显示字形。

## 验证

- `cmake --build build --target MoerEditor --config Debug`
- `python tools/startup/verify_startup_splash.py --exe target/bin/Debug/MoerEditor.exe --workdir target/bin/Debug --outdir target/validation/startup_splash_g_fix`
- 启动页截图人工检查通过
- 自动验证：正常退出、无窗口卡死、无 forbidden 日志