### PR TITLE
feat(render): add hierarchical RenderDoc markers

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -249,3 +249,7 @@ Shaders文件夹架构及相关规范见`/shaders/README.md`。
    * 有没有用什么设计模式？有没有什么容易出错的地方？有没有什么多线程相关内容？
    * etc...
 5. 命名是否存在歧义或者不规范
+
+## 6. RenderDoc GPU Marker
+
+渲染 pass、GPU 计时区间和帧提交标签应遵循统一层级、颜色与命名约定。添加或修改 marker 前请阅读 [RenderDoc GPU Marker 指南](RENDERDOC.md)，尤其注意 timestamp key 的单次提交唯一性和 marker 对 RHI 命令重排边界的影响。

--- a/docs/RENDERDOC.md
+++ b/docs/RENDERDOC.md
@@ -1,0 +1,108 @@
+# RenderDoc GPU Marker 指南
+
+MoerEngine 的 Vulkan 命令流使用统一的 GPU marker 层级。抓取一帧后，RenderDoc 的 Event Browser 应能直接按“帧 → Renderer → RenderGraph/流水线 → Pass → Subpass/计时区间”浏览，而不需要从裸 `vkCmd*` 事件反推渲染阶段。
+
+## 预期层级
+
+Raster 帧的主干结构如下（实际 pass 会随配置变化）：
+
+```text
+Raster Frame <frame_id>
+├─ Raster Renderer
+│  └─ Raster RenderGraph: RasterFrame
+│     ├─ Pass: ShadowDepth
+│     │  └─ Raster ShadowDepthPass
+│     │     ├─ Point Shadow Face +X
+│     │     │  ├─ Raster PointShadow Culling +X
+│     │     │  └─ Raster PointShadow Draw +X
+│     │     ├─ Point Shadow Face -X
+│     │     ├─ Point Shadow Face +Y
+│     │     ├─ Point Shadow Face -Y
+│     │     ├─ Point Shadow Face +Z
+│     │     └─ Point Shadow Face -Z
+│     ├─ Pass: Geometry
+│     │  └─ Raster GeometryPass
+│     ├─ Pass: Lighting
+│     └─ Pass: UiCombine
+│        └─ UI Composition
+└─ Editor UI
+   └─ Main Viewport
+
+Present: <source texture name>
+```
+
+关闭 RenderGraph 时，中间节点会变为 `Raster Linear Pipeline`，pass 层级保持一致。Raytracing 路径使用 `Raytracing Frame <frame_id> → Raytracing Renderer → <stage>` 的对应结构。
+
+Point Cube 的面顺序固定为 `+X, -X, +Y, -Y, +Z, -Z`。每个面的 marker、culling 计时 key 和 draw 计时 key 都彼此独立，也不与 CSM key 复用。
+
+## 抓帧与检查
+
+1. 在根目录 `MoerEngine.toml` 中选择要检查的 renderer。
+2. 用 RenderDoc 以 Vulkan API 启动 `target/bin/Debug/MoerEditor.exe`。
+3. 等待场景和 shader 完成加载，再抓取稳定帧。
+4. 在 Event Browser 中展开帧根节点；搜索 `Pass:`、`Point Shadow Face` 或具体计时 key。
+5. 选择 draw/dispatch 后，通过 Pipeline State、资源和 Shader Debug 查看详细状态。
+
+若 Event Browser 出现 `[RHI Diagnostics] Command Layers`，说明启用了 RHI 命令重排诊断采样；正常抓帧不会显示内部 `Layer N` 节点。
+
+## 编写 marker
+
+高层渲染代码优先使用 RAII guard：
+
+```cpp
+ScopedGpuMarker pass_marker(
+    cmd_list,
+    "Pass: MyPass",
+    GpuMarkerPalette::Pass()
+);
+```
+
+需要 GPU 时间的区间显式选择 timestamp 模式：
+
+```cpp
+ScopedGpuMarker timed_scope(
+    cmd_list,
+    "Raster MyPass",
+    GpuMarkerPalette::Scope(),
+    EGpuMarkerMode::Timestamp
+);
+```
+
+提交级根节点通过 `CmdSubmit` 设置：
+
+```cpp
+queue.Execute(
+    cmd_list.Submit()
+        .DebugLabel("Raster Frame 42", GpuMarkerPalette::Frame())
+        .TickProfiling()
+);
+```
+
+`ScopedGpuMarker` 不可复制、不可移动。它必须比内部 marker 活得更久，并在 `CommandList::Submit()` 之前析构或显式 `Close()`。Debug 构建会检查 scope 欠栈、类型不匹配、未闭合提交等错误；Release 构建会尽量安全收束损坏的 scope 栈。
+
+## 命名与粒度约定
+
+- `Frame`：提交根节点，可包含动态 frame id，不作为 profiler key。
+- `Renderer`：Raster、Raytracing 或 UI 等大阶段。
+- `RenderGraph`：RenderGraph 或线性流水线容器。
+- `Pass`：稳定的渲染 pass 名，统一使用 `Pass: <name>`。
+- `Subpass`：cascade、cube face、denoise stage 等可读子阶段。
+- `Timestamp`：同时产生 GPU timestamp 的稳定 profiling key。
+- `Transfer`：RHI 自动生成的 upload、copy、clear 等原生命令标签。
+
+同一次 `CommandList::Submit()` 中，每个 timestamp key 必须唯一。不要把 frame id、对象地址等动态内容放进 timestamp key；需要区分重复工作时，应使用 `CSM0`、`+X` 等稳定后缀。Debug 构建会对重复 key 断言，Release 构建会把后续重复项降级为纯可视 marker，避免覆盖 profiler 数据。
+
+RHI scope 是命令重排器的独占层边界，能保证 barrier 和命令落在正确 marker 内。代价是过细的 marker 会限制重排空间，因此应在 pass/subpass 级使用；逐 draw/逐 dispatch 的诊断优先依赖自动命令名或临时调试 marker。
+
+## 验证
+
+Marker 机制的回归测试：
+
+```powershell
+cmake --build build --target TestRHICommandMarker TestRHICmdReorderer TestRHIRecordDiagnostics --config Debug -j 30
+target/bin/Debug/TestRHICommandMarker.exe
+target/bin/Debug/TestRHICmdReorderer.exe
+target/bin/Debug/TestRHIRecordDiagnostics.exe
+```
+
+涉及真实层级或颜色的修改仍需至少抓取一帧，在 RenderDoc 中确认结构、六个 point-cube 面和 pass 颜色。

--- a/source/runtime/render/renderer/common/UiCombinePass.h
+++ b/source/runtime/render/renderer/common/UiCombinePass.h
@@ -73,6 +73,9 @@ public:
         TextureView  input_ui_texture,
         TextureView  default_output_texture
     ) {
+        ScopedGpuMarker ui_composition_marker(
+            cmd_list, "UI Composition", GpuMarkerPalette::Ui()
+        );
         if (is_separate_window && input_window_frame_buffer.GetTexture()) {
             assert(
                 sample_texture_pipelines.contains(input_window_frame_buffer.format) &&

--- a/source/runtime/render/renderer/common/ui/DearImGuiRenderer.cpp
+++ b/source/runtime/render/renderer/common/ui/DearImGuiRenderer.cpp
@@ -522,9 +522,20 @@ void ImGuiRenderBackend::RenderGUI(
     auto& render_data = *static_cast<ImGuiData*>(backend_data);
 
     _cmd_list.UpdateBindlessArray(bindless_array);
-    RenderGuiDrawPacket(_frame.main_viewport, _main_framebuffer, _cmd_list, render_data, *this);
-    for (auto& viewport : _frame.platform_viewports) {
-        if (viewport.framebuffer) {
+    if (!_frame.main_viewport.commands.empty()) {
+        ScopedGpuMarker viewport_marker(
+            _cmd_list, "Main Viewport", GpuMarkerPalette::Ui()
+        );
+        RenderGuiDrawPacket(_frame.main_viewport, _main_framebuffer, _cmd_list, render_data, *this);
+    }
+    for (size_t viewport_index = 0; viewport_index < _frame.platform_viewports.size(); ++viewport_index) {
+        auto& viewport = _frame.platform_viewports[viewport_index];
+        if (viewport.framebuffer && !viewport.commands.empty()) {
+            ScopedGpuMarker viewport_marker(
+                _cmd_list,
+                std::format("Platform Viewport {}", viewport_index),
+                GpuMarkerPalette::Ui()
+            );
             RenderGuiDrawPacket(viewport, viewport.framebuffer->GetView(), _cmd_list, render_data, *this);
         }
     }

--- a/source/runtime/render/renderer/common/ui/UIRenderer.cpp
+++ b/source/runtime/render/renderer/common/ui/UIRenderer.cpp
@@ -76,6 +76,9 @@ void RenderUiDrawFrame(
     EUiDrawExecutionThread _execution_thread
 ) {
     if (_frame.backend) {
+        ScopedGpuMarker ui_marker(
+            _cmd_list, "Editor UI", GpuMarkerPalette::Ui()
+        );
         _frame.backend->RenderGUI(_cmd_list, _main_framebuffer, _frame, _execution_thread);
     }
 }

--- a/source/runtime/render/renderer/raster/RasterRenderer.cpp
+++ b/source/runtime/render/renderer/raster/RasterRenderer.cpp
@@ -520,6 +520,10 @@ RasterFrameFeedback RasterRenderer::RenderFrame(RasterFramePacket frame_packet) 
             );
         }
 
+        ScopedGpuMarker renderer_marker(
+            cmd_list, "Raster Renderer", GpuMarkerPalette::Renderer()
+        );
+
         const Camera& main_camera = scene_updates.main_camera;
         Camera        camera      = frame_packet.render_camera;
 
@@ -970,11 +974,16 @@ RasterFrameFeedback RasterRenderer::RenderFrame(RasterFramePacket frame_packet) 
         };
 
         auto execute_linear = [&]() {
-            auto linear_schedule = [](
-                                       std::string_view,
-                                       auto&&,
-                                       auto&& execute
-                                   ) { std::forward<decltype(execute)>(execute)(); };
+            ScopedGpuMarker pipeline_marker(
+                cmd_list, "Raster Linear Pipeline", GpuMarkerPalette::RenderGraph()
+            );
+            auto linear_schedule = [&](std::string_view name, auto&&, auto&& execute) {
+                const std::string marker_name = std::format("Pass: {}", name);
+                ScopedGpuMarker pass_marker(
+                    cmd_list, marker_name, GpuMarkerPalette::Pass()
+                );
+                std::forward<decltype(execute)>(execute)();
+            };
             define_raster_passes(linear_schedule);
         };
 
@@ -1094,10 +1103,16 @@ RasterFrameFeedback RasterRenderer::RenderFrame(RasterFramePacket frame_packet) 
                 execute_linear();
             } else {
                 auto graph_schedule = [&](std::string_view name, auto&& setup, auto&& execute) {
+                    const std::string marker_name = std::format("Pass: {}", name);
                     graph.AddPass(
                         name,
                         std::forward<decltype(setup)>(setup),
-                        std::forward<decltype(execute)>(execute)
+                        [&, marker_name, execute = std::forward<decltype(execute)>(execute)]() mutable {
+                            ScopedGpuMarker pass_marker(
+                                cmd_list, marker_name, GpuMarkerPalette::Pass()
+                            );
+                            execute();
+                        }
                     );
                 };
                 define_raster_passes(graph_schedule);
@@ -1113,7 +1128,13 @@ RasterFrameFeedback RasterRenderer::RenderFrame(RasterFramePacket frame_packet) 
                             LOG_INFO("[RenderGraph][DebugDump]\n{}", dump);
                         }
                     }
+                    ScopedGpuMarker graph_marker(
+                        cmd_list,
+                        "Raster RenderGraph: RasterFrame",
+                        GpuMarkerPalette::RenderGraph()
+                    );
                     if (!graph.Execute()) {
+                        graph_marker.Close();
                         render_graph_fallback_latched = true;
                         LOG_ERROR(
                             "[RenderGraph][Fallback] Raster graph execution was rejected before any pass: {}. "
@@ -1158,7 +1179,16 @@ RasterFrameFeedback RasterRenderer::RenderFrame(RasterFramePacket frame_packet) 
     time++;
     // Host 同步的 copy 操作已经完成。此处触发 timeline，向 validation layer 传递执行顺序，
     // 无需再额外等待 copy queue。
-    gfx_queue.Execute(cmd_list.Submit().Signal(timeline, time).DeleteResources().TickProfiling());
+    gfx_queue.Execute(
+        cmd_list.Submit()
+            .DebugLabel(
+                std::format("Raster Frame {}", frame_packet.frame_id),
+                GpuMarkerPalette::Frame()
+            )
+            .Signal(timeline, time)
+            .DeleteResources()
+            .TickProfiling()
+    );
 
     if (!skip_present) {
         const auto output_view = default_output_texture->GetView();

--- a/source/runtime/render/renderer/raster/RasterTool.cpp
+++ b/source/runtime/render/renderer/raster/RasterTool.cpp
@@ -16,19 +16,60 @@
 namespace Moer::Render::Raster {
 
 namespace {
-constexpr StaticArray<std::string_view, CSM_MAX_CASCADES> s_shadow_culling_scope_names = {
+constexpr StaticArray<std::string_view, CSM_MAX_CASCADES> s_csm_shadow_cascade_marker_names = {
+    "CSM Cascade 0",
+    "CSM Cascade 1",
+    "CSM Cascade 2",
+    "CSM Cascade 3"
+};
+
+constexpr StaticArray<std::string_view, CSM_MAX_CASCADES> s_csm_shadow_culling_scope_names = {
     "Raster Shadow Culling CSM0",
     "Raster Shadow Culling CSM1",
     "Raster Shadow Culling CSM2",
     "Raster Shadow Culling CSM3"
 };
 
-constexpr StaticArray<std::string_view, CSM_MAX_CASCADES> s_shadow_draw_scope_names = {
+constexpr StaticArray<std::string_view, CSM_MAX_CASCADES> s_csm_shadow_draw_scope_names = {
     "Raster Shadow Draw CSM0",
     "Raster Shadow Draw CSM1",
     "Raster Shadow Draw CSM2",
     "Raster Shadow Draw CSM3"
 };
+
+constexpr StaticArray<std::string_view, CUBE_FACE_Num> s_point_shadow_face_marker_names = {
+    "Point Shadow Face +X",
+    "Point Shadow Face -X",
+    "Point Shadow Face +Y",
+    "Point Shadow Face -Y",
+    "Point Shadow Face +Z",
+    "Point Shadow Face -Z"
+};
+
+constexpr StaticArray<std::string_view, CUBE_FACE_Num> s_point_shadow_culling_scope_names = {
+    "Raster PointShadow Culling +X",
+    "Raster PointShadow Culling -X",
+    "Raster PointShadow Culling +Y",
+    "Raster PointShadow Culling -Y",
+    "Raster PointShadow Culling +Z",
+    "Raster PointShadow Culling -Z"
+};
+
+constexpr StaticArray<std::string_view, CUBE_FACE_Num> s_point_shadow_draw_scope_names = {
+    "Raster PointShadow Draw +X",
+    "Raster PointShadow Draw -X",
+    "Raster PointShadow Draw +Y",
+    "Raster PointShadow Draw -Y",
+    "Raster PointShadow Draw +Z",
+    "Raster PointShadow Draw -Z"
+};
+
+static_assert(s_csm_shadow_cascade_marker_names.size() == CSM_MAX_CASCADES);
+static_assert(s_csm_shadow_culling_scope_names.size() == CSM_MAX_CASCADES);
+static_assert(s_csm_shadow_draw_scope_names.size() == CSM_MAX_CASCADES);
+static_assert(s_point_shadow_face_marker_names.size() == CUBE_FACE_Num);
+static_assert(s_point_shadow_culling_scope_names.size() == CUBE_FACE_Num);
+static_assert(s_point_shadow_draw_scope_names.size() == CUBE_FACE_Num);
 
 std::string BuildDebugLogSiteKey(std::source_location location) {
     std::ostringstream stream;
@@ -74,16 +115,36 @@ std::string_view RasterTool::GetGeometryDrawProfileScopeName() {
     return "Raster Geometry Draw";
 }
 
-// 返回某个级联阴影视锥剔除 dispatch 使用的 profiling scope 名称。
-std::string_view RasterTool::GetShadowCullingProfileScopeName(uint cascade_index) {
+// 返回某个级联阴影的可视 marker 名称。
+std::string_view RasterTool::GetCsmShadowCascadeMarkerName(uint cascade_index) {
     assert(cascade_index < CSM_MAX_CASCADES);
-    return s_shadow_culling_scope_names[cascade_index];
+    return s_csm_shadow_cascade_marker_names[cascade_index];
 }
 
-// 返回某个级联阴影绘制提交使用的 profiling scope 名称。
-std::string_view RasterTool::GetShadowDrawProfileScopeName(uint cascade_index) {
+// 返回某个级联阴影视锥剔除 dispatch 使用的 profiling scope 名称。
+std::string_view RasterTool::GetCsmShadowCullingProfileScopeName(uint cascade_index) {
     assert(cascade_index < CSM_MAX_CASCADES);
-    return s_shadow_draw_scope_names[cascade_index];
+    return s_csm_shadow_culling_scope_names[cascade_index];
+}
+
+std::string_view RasterTool::GetCsmShadowDrawProfileScopeName(uint cascade_index) {
+    assert(cascade_index < CSM_MAX_CASCADES);
+    return s_csm_shadow_draw_scope_names[cascade_index];
+}
+
+std::string_view RasterTool::GetPointShadowFaceMarkerName(uint face) {
+    assert(face < CUBE_FACE_Num);
+    return s_point_shadow_face_marker_names[face];
+}
+
+std::string_view RasterTool::GetPointShadowCullingProfileScopeName(uint face) {
+    assert(face < CUBE_FACE_Num);
+    return s_point_shadow_culling_scope_names[face];
+}
+
+std::string_view RasterTool::GetPointShadowDrawProfileScopeName(uint face) {
+    assert(face < CUBE_FACE_Num);
+    return s_point_shadow_draw_scope_names[face];
 }
 
 void RasterTool::LogDebugEverySeconds(
@@ -129,21 +190,29 @@ void RasterTool::TickAndLogProfiling(CommandQueue& gfx_queue, const RasterConfig
     stream.setf(std::ios::fixed);
     stream.precision(3);
 
-    const double graphics_exec      = find_gpu_time("Graphics Exec");
-    const double shadow_culling_sum = sum_gpu_times(s_shadow_culling_scope_names);
-    const double shadow_draw_sum    = sum_gpu_times(s_shadow_draw_scope_names);
-    const double geometry_culling   = find_gpu_time(GetGeometryCullingProfileScopeName());
-    const double geometry_draw      = find_gpu_time(GetGeometryDrawProfileScopeName());
+    const double graphics_exec            = find_gpu_time("Graphics Exec");
+    const double csm_shadow_culling_sum   = sum_gpu_times(s_csm_shadow_culling_scope_names);
+    const double csm_shadow_draw_sum      = sum_gpu_times(s_csm_shadow_draw_scope_names);
+    const double point_shadow_culling_sum = sum_gpu_times(s_point_shadow_culling_scope_names);
+    const double point_shadow_draw_sum    = sum_gpu_times(s_point_shadow_draw_scope_names);
+    const double geometry_culling        = find_gpu_time(GetGeometryCullingProfileScopeName());
+    const double geometry_draw           = find_gpu_time(GetGeometryDrawProfileScopeName());
 
     stream << "[RasterProfile] GPU(ms)";
     if (graphics_exec >= 0.0) {
         stream << " GraphicsExec=" << graphics_exec;
     }
-    if (shadow_culling_sum > 0.0) {
-        stream << " ShadowCullSum=" << shadow_culling_sum;
+    if (csm_shadow_culling_sum > 0.0) {
+        stream << " CsmShadowCullSum=" << csm_shadow_culling_sum;
     }
-    if (shadow_draw_sum > 0.0) {
-        stream << " ShadowDrawSum=" << shadow_draw_sum;
+    if (csm_shadow_draw_sum > 0.0) {
+        stream << " CsmShadowDrawSum=" << csm_shadow_draw_sum;
+    }
+    if (point_shadow_culling_sum > 0.0) {
+        stream << " PointShadowCullSum=" << point_shadow_culling_sum;
+    }
+    if (point_shadow_draw_sum > 0.0) {
+        stream << " PointShadowDrawSum=" << point_shadow_draw_sum;
     }
     if (geometry_culling >= 0.0) {
         stream << " GeometryCull=" << geometry_culling;

--- a/source/runtime/render/renderer/raster/RasterTool.h
+++ b/source/runtime/render/renderer/raster/RasterTool.h
@@ -16,7 +16,7 @@ class RenderDevice;
 
 namespace Moer::Render::Raster {
 
-class RasterTool {
+class RENDER_API RasterTool {
 public:
     static Array<SingleDrawParam> GetFullScreenDrawDatas();
 
@@ -28,9 +28,17 @@ public:
 
     static std::string_view GetGeometryDrawProfileScopeName();
 
-    static std::string_view GetShadowCullingProfileScopeName(uint cascade_index);
+    static std::string_view GetCsmShadowCascadeMarkerName(uint cascade_index);
 
-    static std::string_view GetShadowDrawProfileScopeName(uint cascade_index);
+    static std::string_view GetCsmShadowCullingProfileScopeName(uint cascade_index);
+
+    static std::string_view GetCsmShadowDrawProfileScopeName(uint cascade_index);
+
+    static std::string_view GetPointShadowFaceMarkerName(uint face);
+
+    static std::string_view GetPointShadowCullingProfileScopeName(uint face);
+
+    static std::string_view GetPointShadowDrawProfileScopeName(uint face);
 
     static void LogDebugEverySeconds(
         std::string_view      message,

--- a/source/runtime/render/renderer/raster/ShadowDepthPass.cpp
+++ b/source/runtime/render/renderer/raster/ShadowDepthPass.cpp
@@ -819,13 +819,19 @@ void ShadowDepthPass::RenderCSM(RasterContext& context, const RasterConfig& ui_c
         context.lighting_data.scale_data[cascade_index]        = shadow_candidate.scale_data;
         context.csm_data.world2shadow_clip[cascade_index]      = shadow_candidate.world2shadow_clip;
 
+        ScopedGpuMarker cascade_marker(
+            context.cmd_list,
+            RasterTool::GetCsmShadowCascadeMarkerName(cascade_index),
+            GpuMarkerPalette::Subpass()
+        );
+
         m_culling_pass.Process(
             context,
             context.lighting_data.world2shadow_clip[cascade_index],
             context.GetGpuSceneRes(),
             context.gpu_culling_buffers.shadow,
             nullptr,
-            RasterTool::GetShadowCullingProfileScopeName(cascade_index)
+            RasterTool::GetCsmShadowCullingProfileScopeName(cascade_index)
         );
 
         RenderShadow(
@@ -835,7 +841,7 @@ void ShadowDepthPass::RenderCSM(RasterContext& context, const RasterConfig& ui_c
             Rect2D(0, 0, ui_config.shadow_csm_sm_size, ui_config.shadow_csm_sm_size),
             context.csm_data.shadow_map_textures[cascade_index].tex->GetView(),
             std::format("Shadow Depth Pass - {}", cascade_index),
-            cascade_index
+            RasterTool::GetCsmShadowDrawProfileScopeName(cascade_index)
         );
 
         store_shadow_cache_entry(shadow_cache_entry, shadow_candidate, shadow_cache_frame_index);
@@ -921,7 +927,7 @@ void ShadowDepthPass::RenderPointShadows(
         float3 dir;
         float3 up;
     };
-    static const FaceInfo faces[] = {
+    static const FaceInfo faces[CUBE_FACE_Num] = {
         {{1, 0, 0}, {0, -1, 0}},  // +X (Right) - Vulkan Y-down usually implies Up is -Y for horizontal faces
         {{-1, 0, 0}, {0, -1, 0}}, // -X (Left)
         {{0, 1, 0}, {0, 0, 1}},   // +Y (Top)   - Up is +Z
@@ -931,12 +937,18 @@ void ShadowDepthPass::RenderPointShadows(
     };
 
     // 4. 遍历 6 个面进行渲染
-    for (uint face = 0; face < 6; ++face) {
+    for (uint face = 0; face < CUBE_FACE_Num; ++face) {
         float3   light_pos = cube_res.light_pos;
         float4x4 view      = MakeLookatViewMatrixRH(light_pos, light_pos + faces[face].dir, faces[face].up);
         float4x4 view_proj = proj * view;
 
         TextureView face_view = TextureView(cube_res.tex.Get()).Slice(face, 1);
+
+        ScopedGpuMarker face_marker(
+            context.cmd_list,
+            RasterTool::GetPointShadowFaceMarkerName(face),
+            GpuMarkerPalette::Subpass()
+        );
 
         m_culling_pass.Process(
             context,
@@ -944,7 +956,7 @@ void ShadowDepthPass::RenderPointShadows(
             context.GetGpuSceneRes(),
             context.gpu_culling_buffers.shadow,
             nullptr,
-            RasterTool::GetShadowCullingProfileScopeName(face)
+            RasterTool::GetPointShadowCullingProfileScopeName(face)
         );
 
         RenderShadow(
@@ -954,7 +966,7 @@ void ShadowDepthPass::RenderPointShadows(
             Rect2D(0, 0, config.shadow_csm_sm_size, config.shadow_csm_sm_size),
             face_view,
             std::format("PointShadow L{} F{}", light_idx, face),
-            std::nullopt
+            RasterTool::GetPointShadowDrawProfileScopeName(face)
         );
     }
 }
@@ -965,8 +977,8 @@ void ShadowDepthPass::RenderShadow(
     const float4x4&     view_proj,
     const Rect2D&       rect,
     TextureView         depth_view,
-    std::string_view    pass_name,
-    std::optional<uint> csm_profile_layer
+    std::string_view                pass_name,
+    std::optional<std::string_view> profile_scope_name
 ) {
     GeometryPassBindlessParam param;
     param.world2clip = Transpose(view_proj);
@@ -985,10 +997,8 @@ void ShadowDepthPass::RenderShadow(
     param.enable_alpha_test             = config.geometry_enable_alpha_test ? 1 : 0;
     param.alpha_test_blend_pixel_cutoff = config.geometry_alpha_test_blend_pixel_cutoff;
 
-    if (csm_profile_layer.has_value()) {
-        context.cmd_list.PushScopeWithTimeScope(
-            RasterTool::GetShadowDrawProfileScopeName(csm_profile_layer.value())
-        );
+    if (profile_scope_name.has_value()) {
+        context.cmd_list.PushScopeWithTimeScope(profile_scope_name.value());
     }
 
     auto draw = context.cmd_list.Gfx(m_pso, context.bdls, param);
@@ -1006,7 +1016,7 @@ void ShadowDepthPass::RenderShadow(
         DepthAttachment(depth_view.GetTexture())
     );
 
-    if (csm_profile_layer.has_value()) {
+    if (profile_scope_name.has_value()) {
         context.cmd_list.PopScopeWithTimeScope();
     }
 }

--- a/source/runtime/render/renderer/raster/ShadowDepthPass.h
+++ b/source/runtime/render/renderer/raster/ShadowDepthPass.h
@@ -56,7 +56,7 @@ private:
         const Rect2D&       rect,
         TextureView         depth_view,
         std::string_view    pass_name,
-        std::optional<uint> csm_profile_layer = std::nullopt
+        std::optional<std::string_view> profile_scope_name = std::nullopt
     );
 
 private:

--- a/source/runtime/render/renderer/raytracing/RaytracingRenderer.cpp
+++ b/source/runtime/render/renderer/raytracing/RaytracingRenderer.cpp
@@ -548,7 +548,14 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
             gfx_queue.Sync();
         }
 
+        ScopedGpuMarker renderer_marker(
+            cmd_list, "Raytracing Renderer", GpuMarkerPalette::Renderer()
+        );
+
         if (state.b_new_env_map) {
+            ScopedGpuMarker environment_marker(
+                cmd_list, "Pass: Environment Setup", GpuMarkerPalette::Pass()
+            );
             auto src_env_map = runtime_assets.GetDefaultEnvMap();
             state.env_map    = device.CreateTexture(
                 src_env_map->GetName(),
@@ -591,6 +598,9 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
             const bool needs_tlas_build = IsLegacyTlasUpdateEnabled() ||
                                           state.current_tlas_revision != state.rt_instance_revision;
             if (needs_tlas_build) {
+                ScopedGpuMarker tlas_marker(
+                    cmd_list, "Pass: Scene Acceleration Structure", GpuMarkerPalette::Pass()
+                );
                 for (size_t i = 0; i < state.rt_scene->GetInstanceCount(); i++) {
                     auto& instance = state.rt_scene->GetInstance(i);
                     state.rt_scene->MarkModified(instance.instance_id);
@@ -699,9 +709,23 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
         cmd_list.UpdateBindlessArray(bindless_array);
 
         state.rt_ctx->Tick(camera, state.antialias_pass->GetPixelOffset());
-        state.prepare_light_pass->Process(cmd_list, *state.rt_ctx, scene_snapshot);
-        state.g_buffer_pass->Process(cmd_list, *state.rt_ctx);
+        {
+            ScopedGpuMarker pass_marker(
+                cmd_list, "Pass: Prepare Lights", GpuMarkerPalette::Pass()
+            );
+            state.prepare_light_pass->Process(cmd_list, *state.rt_ctx, scene_snapshot);
+        }
+        {
+            ScopedGpuMarker pass_marker(
+                cmd_list, "Pass: GBuffer", GpuMarkerPalette::Pass()
+            );
+            state.g_buffer_pass->Process(cmd_list, *state.rt_ctx);
+        }
+        ScopedGpuMarker lighting_marker(
+            cmd_list, "Pass: Lighting", GpuMarkerPalette::Pass()
+        );
         const auto local_light_sampling = state.lighting_pass->Process(cmd_list, *state.rt_ctx);
+        lighting_marker.Close();
         feedback.configured_local_light_sample_mode = local_light_sampling.configured_mode;
         feedback.effective_local_light_sample_mode  = local_light_sampling.effective_mode;
         feedback.adaptive_local_light_fallback_applied =
@@ -723,6 +747,9 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
             }
 
             if (denoiser != nrd::Denoiser::MAX_NUM) {
+                ScopedGpuMarker denoiser_marker(
+                    cmd_list, "Pass: Radiance Denoising", GpuMarkerPalette::Pass()
+                );
                 state.nrd_interface->Begin();
                 state.nrd_interface->UpdateCommonSettings(
                     state.nrd_time++,
@@ -758,25 +785,50 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
         }
 #endif
 
-        state.composition_pass->Process(cmd_list, *state.rt_ctx);
-        state.antialias_pass->Process(
-            cmd_list,
-            aa_params,
-            state.b_feedback_valid,
-            state.rt_ctx->frame_rt.hdr_color,
-            state.rt_ctx->frame_rt.resolved_color
-        );
-        state.tone_mapping_pass->Process(
-            cmd_list,
-            tone_params,
-            state.rt_ctx->frame_rt.resolved_color,
-            state.rt_ctx->frame_rt.ldr_color
-        );
-        state.visualize_pass->Process(cmd_list, *state.rt_ctx, state.visualize_config, bindless_array);
+        {
+            ScopedGpuMarker pass_marker(
+                cmd_list, "Pass: Composition", GpuMarkerPalette::Pass()
+            );
+            state.composition_pass->Process(cmd_list, *state.rt_ctx);
+        }
+        {
+            ScopedGpuMarker pass_marker(
+                cmd_list, "Pass: Anti Aliasing", GpuMarkerPalette::Pass()
+            );
+            state.antialias_pass->Process(
+                cmd_list,
+                aa_params,
+                state.b_feedback_valid,
+                state.rt_ctx->frame_rt.hdr_color,
+                state.rt_ctx->frame_rt.resolved_color
+            );
+        }
+        {
+            ScopedGpuMarker pass_marker(
+                cmd_list, "Pass: Tone Mapping", GpuMarkerPalette::Pass()
+            );
+            state.tone_mapping_pass->Process(
+                cmd_list,
+                tone_params,
+                state.rt_ctx->frame_rt.resolved_color,
+                state.rt_ctx->frame_rt.ldr_color
+            );
+        }
+        {
+            ScopedGpuMarker pass_marker(
+                cmd_list, "Pass: Visualize", GpuMarkerPalette::Pass()
+            );
+            state.visualize_pass->Process(
+                cmd_list, *state.rt_ctx, state.visualize_config, bindless_array
+            );
+        }
 
         const auto& debug_input = frame_packet.debug_input;
         if (debug_input.show_final_texture &&
             state.material_textures.contains(debug_input.selected_material_texture_name)) {
+            ScopedGpuMarker debug_texture_marker(
+                cmd_list, "Pass: Debug Texture", GpuMarkerPalette::Pass()
+            );
             TextureRef texture = state.material_textures[debug_input.selected_material_texture_name].tex;
             ShowTextureParams show_texture_params{};
             show_texture_params.dst_dim = resolution;
@@ -795,7 +847,15 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
         state.b_feedback_valid = true;
 
         if (state.b_export) {
-            gfx_queue.Execute(cmd_list.Submit().TickProfiling());
+            renderer_marker.Close();
+            gfx_queue.Execute(
+                cmd_list.Submit()
+                    .DebugLabel(
+                        std::format("Raytracing Export Frame {}", frame_packet.frame_id),
+                        GpuMarkerPalette::Frame()
+                    )
+                    .TickProfiling()
+            );
             gfx_queue.Sync();
             DumpTextureToFile(
                 ui_config.export_cfg,
@@ -854,7 +914,16 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
     }
 
     time++;
-    gfx_queue.Execute(cmd_list.Submit().Signal(timeline, time).DeleteResources().TickProfiling());
+    gfx_queue.Execute(
+        cmd_list.Submit()
+            .DebugLabel(
+                std::format("Raytracing Frame {}", frame_packet.frame_id),
+                GpuMarkerPalette::Frame()
+            )
+            .Signal(timeline, time)
+            .DeleteResources()
+            .TickProfiling()
+    );
     if (!skip_present) {
         const auto output_view = state.output->GetView();
         if (frame_packet.window.state == EWindowState::SizeChanged) {

--- a/source/runtime/render/rhi/RHICommand.h
+++ b/source/runtime/render/rhi/RHICommand.h
@@ -20,6 +20,7 @@
 #include <mutex>
 #include <optional>
 #include <span>
+#include <string>
 #include <string_view>
 #include <type_traits>
 #include <utility>
@@ -38,6 +39,40 @@ struct ProfileSection {
     // within one profiled submission because each name owns one query pair.
     std::string_view name;
     explicit ProfileSection(const char* _name) : name(_name) {}
+};
+
+// RenderDoc/PIX marker colors are kept in one palette so frame captures use a
+// stable visual language across renderers and passes.
+namespace GpuMarkerPalette {
+inline float4 Frame() noexcept {
+    return {0.18f, 0.42f, 0.90f, 1.0f};
+}
+inline float4 Renderer() noexcept {
+    return {0.20f, 0.65f, 0.90f, 1.0f};
+}
+inline float4 RenderGraph() noexcept {
+    return {0.58f, 0.36f, 0.88f, 1.0f};
+}
+inline float4 Pass() noexcept {
+    return {0.18f, 0.72f, 0.52f, 1.0f};
+}
+inline float4 Subpass() noexcept {
+    return {0.42f, 0.78f, 0.34f, 1.0f};
+}
+inline float4 Ui() noexcept {
+    return {0.95f, 0.52f, 0.18f, 1.0f};
+}
+inline float4 Transfer() noexcept {
+    return {0.90f, 0.72f, 0.18f, 1.0f};
+}
+inline float4 Scope() noexcept {
+    return {0.35f, 0.75f, 0.45f, 1.0f};
+}
+} // namespace GpuMarkerPalette
+
+enum class EGpuMarkerMode : uint8_t {
+    Label,
+    Timestamp,
 };
 
 struct Command {
@@ -227,6 +262,8 @@ struct CmdSubmit {
     bool               b_sync{false}; //force sync queue timeline
     bool               b_tick_profiling{false};
     bool               b_delete_resources{false};
+    std::string        debug_label;
+    float4             debug_label_color = GpuMarkerPalette::Frame();
 
     CmdSubmit&& Wait(Fence* _fence, uint64 _wait_value) {
         wait_events.emplace_back(uint64(_fence), _wait_value);
@@ -253,6 +290,15 @@ struct CmdSubmit {
         return std::move(*this);
     }
 
+    CmdSubmit&& DebugLabel(
+        std::string_view _label,
+        float4           _color = GpuMarkerPalette::Frame()
+    ) {
+        debug_label       = _label;
+        debug_label_color = _color;
+        return std::move(*this);
+    }
+
     CmdSubmit(CmdSubmit&& _other) noexcept {
         cmds               = std::move(_other.cmds);
         callbacks          = std::move(_other.callbacks);
@@ -263,6 +309,8 @@ struct CmdSubmit {
         b_sync             = _other.b_sync;
         b_tick_profiling   = _other.b_tick_profiling;
         b_delete_resources = _other.b_delete_resources;
+        debug_label        = std::move(_other.debug_label);
+        debug_label_color  = _other.debug_label_color;
     }
 
     CmdSubmit& operator=(CmdSubmit&& _other) noexcept {
@@ -275,6 +323,8 @@ struct CmdSubmit {
         b_sync             = _other.b_sync;
         b_tick_profiling   = _other.b_tick_profiling;
         b_delete_resources = _other.b_delete_resources;
+        debug_label        = std::move(_other.debug_label);
+        debug_label_color  = _other.debug_label_color;
         return *this;
     }
     CmdSubmit(
@@ -1068,10 +1118,16 @@ public:
     RENDER_API void ClearResource(TextureView _texture, float4 _color);
     RENDER_API void ClearResource(TextureView _texture, uint32_t _value);
 
-    RENDER_API void PushScope(std::string_view _name);
+    RENDER_API void PushScope(
+        std::string_view _name,
+        float4           _color = GpuMarkerPalette::Scope()
+    );
     RENDER_API void PopScope();
 
-    RENDER_API void PushScopeWithTimeScope(std::string_view _name);
+    RENDER_API void PushScopeWithTimeScope(
+        std::string_view _name,
+        float4           _color = GpuMarkerPalette::Scope()
+    );
     RENDER_API void PopScopeWithTimeScope();
 
     template<typename T, typename... Args>
@@ -1290,7 +1346,62 @@ private:
     Array<std::function<void()>> callbacks;
     Array<std::function<void()>> success_callbacks;
     TCachedArgArray              cached_args;
-    Stack<std::string>           scope_stack;
+    struct ScopeState {
+        std::string name;
+        float4      color;
+        bool        query_timestamp = false;
+    };
+
+    Stack<ScopeState>            scope_stack;
+    UnorderedSet<std::string>    timestamp_scope_names;
+};
+
+// Non-copyable, non-movable RAII wrapper used by high-level render code. It guarantees that a
+// visual/timestamp scope is closed on every return path and prevents a scope
+// from leaking across CommandList::Submit(). Keeping the guard immobile also
+// prevents a non-top scope from being moved and accidentally popping a nested
+// marker.
+class [[nodiscard]] ScopedGpuMarker {
+public:
+    ScopedGpuMarker(
+        CommandList&  _cmd_list,
+        std::string_view _name,
+        float4        _color = GpuMarkerPalette::Scope(),
+        EGpuMarkerMode _mode = EGpuMarkerMode::Label
+    ) :
+        cmd_list(&_cmd_list),
+        mode(_mode) {
+        if (mode == EGpuMarkerMode::Timestamp) {
+            cmd_list->PushScopeWithTimeScope(_name, _color);
+        } else {
+            cmd_list->PushScope(_name, _color);
+        }
+    }
+
+    ~ScopedGpuMarker() {
+        Close();
+    }
+
+    ScopedGpuMarker(const ScopedGpuMarker&)            = delete;
+    ScopedGpuMarker& operator=(const ScopedGpuMarker&) = delete;
+    ScopedGpuMarker(ScopedGpuMarker&&)                 = delete;
+    ScopedGpuMarker& operator=(ScopedGpuMarker&&)      = delete;
+
+    void Close() noexcept {
+        if (!cmd_list) {
+            return;
+        }
+        if (mode == EGpuMarkerMode::Timestamp) {
+            cmd_list->PopScopeWithTimeScope();
+        } else {
+            cmd_list->PopScope();
+        }
+        cmd_list = nullptr;
+    }
+
+private:
+    CommandList*   cmd_list = nullptr;
+    EGpuMarkerMode mode     = EGpuMarkerMode::Label;
 };
 class QueueCmd {};
 

--- a/source/runtime/render/rhi/RHICommandList.cpp
+++ b/source/runtime/render/rhi/RHICommandList.cpp
@@ -121,6 +121,18 @@ void CommandList::ComputeDispatcher::DispatchIndirect(
 }
 
 CmdSubmit CommandList::Submit() {
+    if (!scope_stack.empty()) {
+        assert(scope_stack.empty() && "CommandList::Submit called with unclosed GPU marker scopes");
+        // Keep release builds/captures structurally valid even if a caller
+        // violates the API contract. Debug builds fail above at the source.
+        while (!scope_stack.empty()) {
+            const ScopeState& scope = scope_stack.top();
+            commands.push_back(
+                MakeUnique<ScopeCmd>(scope.name, false, scope.query_timestamp, scope.color)
+            );
+            scope_stack.pop();
+        }
+    }
     CmdSubmit submit(
         std::move(commands),
         std::move(callbacks),
@@ -130,6 +142,7 @@ CmdSubmit CommandList::Submit() {
     commands.clear();
     callbacks.clear();
     success_callbacks.clear();
+    timestamp_scope_names.clear();
     return std::move(submit);
 }
 
@@ -355,25 +368,54 @@ void CommandList::ClearResource(TextureView _texture, uint _value) {
     commands.emplace_back(MakeUnique<ClearResourceCmd>(_texture, _value));
 }
 
-void CommandList::PushScope(std::string_view _name) {
-    commands.push_back(MakeUnique<ScopeCmd>(_name, true, false));
-    scope_stack.emplace(_name);
+void CommandList::PushScope(std::string_view _name, float4 _color) {
+    assert(!_name.empty() && "GPU marker scope name must not be empty");
+    const std::string scope_name = _name.empty() ? "Unnamed GPU Scope" : std::string(_name);
+    commands.push_back(MakeUnique<ScopeCmd>(scope_name, true, false, _color));
+    scope_stack.emplace(ScopeState{scope_name, _color, false});
 }
 
-void CommandList::PushScopeWithTimeScope(std::string_view _name) {
-    commands.push_back(MakeUnique<ScopeCmd>(_name, true, true));
-    scope_stack.emplace(_name);
+void CommandList::PushScopeWithTimeScope(std::string_view _name, float4 _color) {
+    assert(!_name.empty() && "GPU timestamp scope name must not be empty");
+    const std::string scope_name = _name.empty() ? "Unnamed GPU Timestamp Scope" : std::string(_name);
+    const bool unique_timestamp_name = timestamp_scope_names.emplace(scope_name).second;
+    assert(
+        unique_timestamp_name &&
+        "GPU timestamp scope names must be unique within a CommandList submission"
+    );
+
+    // In release builds, a duplicate remains useful as a visual marker but
+    // deliberately does not allocate/reuse an ambiguous profiler query pair.
+    commands.push_back(MakeUnique<ScopeCmd>(scope_name, true, unique_timestamp_name, _color));
+    scope_stack.emplace(ScopeState{scope_name, _color, unique_timestamp_name});
 }
 
 void CommandList::PopScope() {
-    assert(!scope_stack.empty() && "PopScope called without a matching PushScope");
-    commands.push_back(MakeUnique<ScopeCmd>(scope_stack.top(), false, false));
+    if (scope_stack.empty()) {
+        assert(false && "PopScope called without a matching PushScope");
+        return;
+    }
+    const ScopeState& scope = scope_stack.top();
+    assert(!scope.query_timestamp && "PopScope must match PushScope, not PushScopeWithTimeScope");
+    commands.push_back(
+        MakeUnique<ScopeCmd>(scope.name, false, scope.query_timestamp, scope.color)
+    );
     scope_stack.pop();
 }
 
 void CommandList::PopScopeWithTimeScope() {
-    assert(!scope_stack.empty() && "PopScopeWithTimeScope called without a matching push");
-    commands.push_back(MakeUnique<ScopeCmd>(scope_stack.top(), false, true));
+    if (scope_stack.empty()) {
+        assert(false && "PopScopeWithTimeScope called without a matching push");
+        return;
+    }
+    const ScopeState& scope = scope_stack.top();
+    assert(
+        scope.query_timestamp &&
+        "PopScopeWithTimeScope must match PushScopeWithTimeScope, not PushScope"
+    );
+    commands.push_back(
+        MakeUnique<ScopeCmd>(scope.name, false, scope.query_timestamp, scope.color)
+    );
     scope_stack.pop();
 }
 #pragma region[ raytracing ]

--- a/source/runtime/render/rhi/RHIImpl.h
+++ b/source/runtime/render/rhi/RHIImpl.h
@@ -1543,11 +1543,17 @@ private:
 //command for push/pop debug scope
 struct ScopeCmd : public Command {
 public:
-    ScopeCmd(std::string_view _name, bool _push, bool _query_timestamp) :
+    ScopeCmd(
+        std::string_view _name,
+        bool             _push,
+        bool             _query_timestamp,
+        float4           _color = GpuMarkerPalette::Scope()
+    ) :
         Command(EType::Scope, _name),
         b_push(_push),
         scope_name(_name),
-        b_query_timestamp(_query_timestamp) {}
+        b_query_timestamp(_query_timestamp),
+        color(_color) {}
 
 public:
     EQueueType GetQueueType() const override {
@@ -1565,11 +1571,15 @@ public:
     bool QueryTimestamp() const {
         return b_query_timestamp;
     }
+    const float4& Color() const {
+        return color;
+    }
 
 private:
     bool        b_push            = false;
     bool        b_query_timestamp = false;
     std::string scope_name;
+    float4      color = GpuMarkerPalette::Scope();
 };
 
 struct CustomCmd : public Command {

--- a/source/runtime/render/rhi/vulkan/RHICmdReorderer.h
+++ b/source/runtime/render/rhi/vulkan/RHICmdReorderer.h
@@ -1441,8 +1441,13 @@ public:
     }
 
     void VisitCmd(const ScopeCmd* _cmd) {
+        const uint64 scope_layer = m_cmd_lists.size();
+        AddCmd(_cmd, scope_layer);
+        // A marker owns its layer. Work after a push (and barriers for that
+        // work) must be recorded inside the label; work after a pop must start
+        // outside it. Sharing a layer lets preprocessing barriers escape or
+        // bleed into the adjacent RenderDoc scope.
         layer_offset = m_cmd_lists.size();
-        AddCmd(_cmd, layer_offset);
     }
 
     void VisitCmd(const CustomCmd* _cmd) {

--- a/source/runtime/render/rhi/vulkan/VulkanQueue.cpp
+++ b/source/runtime/render/rhi/vulkan/VulkanQueue.cpp
@@ -1225,6 +1225,27 @@ class VkCmdVisitor : VulkanDeviceObject {
     ProfilerStorage*       profiler = nullptr;
     bool                   query_profiling_enabled = false;
 
+    class ScopedNativeLabel {
+    public:
+        ScopedNativeLabel(
+            VulkanCmdList&   _cmd_list,
+            std::string_view _name,
+            float4           _color
+        ) : cmd_list(_cmd_list) {
+            cmd_list.BeginLabel(_name, _color);
+        }
+
+        ~ScopedNativeLabel() {
+            cmd_list.EndLabel();
+        }
+
+        ScopedNativeLabel(const ScopedNativeLabel&)            = delete;
+        ScopedNativeLabel& operator=(const ScopedNativeLabel&) = delete;
+
+    private:
+        VulkanCmdList& cmd_list;
+    };
+
 public:
     VkCmdVisitor(
         VulkanDevice&          _device,
@@ -1315,6 +1336,7 @@ public:
         }
     };
     void Visit(const UploadBufferCmd& _cmd) {
+        ScopedNativeLabel marker(cmd_list, _cmd.name, GpuMarkerPalette::Transfer());
         auto          tmp_buffer = _cmd.staging_buffer;
         VulkanBuffer* buffer     = reinterpret_cast<VulkanBuffer*>(_cmd.Handle());
         cmd_list.CopyBuffer(
@@ -1327,6 +1349,7 @@ public:
     }
 
     void Visit(const UploadTextureCmd& _cmd) {
+        ScopedNativeLabel marker(cmd_list, _cmd.name, GpuMarkerPalette::Transfer());
         auto           tmp_buffer = _cmd.staging_buffer;
         VulkanTexture* texture    = reinterpret_cast<VulkanTexture*>(_cmd.Handle());
         cmd_list.CopyBufferToTexture(
@@ -1342,6 +1365,7 @@ public:
     }
 
     void Visit(const CopyBufferCmd& _cmd) {
+        ScopedNativeLabel marker(cmd_list, _cmd.name, GpuMarkerPalette::Transfer());
         VulkanBuffer* src_buffer = reinterpret_cast<VulkanBuffer*>(_cmd.SrcHandle());
         VulkanBuffer* dst_buffer = reinterpret_cast<VulkanBuffer*>(_cmd.DstHandle());
 
@@ -1349,6 +1373,7 @@ public:
     }
 
     void Visit(const CopyBackBufferCmd& _cmd) {
+        ScopedNativeLabel marker(cmd_list, _cmd.name, GpuMarkerPalette::Transfer());
         VulkanBuffer* src_buffer = reinterpret_cast<VulkanBuffer*>(_cmd.Handle());
         auto          tmp_buffer = _cmd.staging_buffer;
 
@@ -1371,6 +1396,7 @@ public:
     }
 
     void Visit(const CopyBackTextureCmd& _cmd) {
+        ScopedNativeLabel marker(cmd_list, _cmd.name, GpuMarkerPalette::Transfer());
         VulkanTexture* src_texture = reinterpret_cast<VulkanTexture*>(_cmd.Handle());
         auto           tmp_buffer  = _cmd.staging_buffer;
 
@@ -1394,6 +1420,7 @@ public:
     }
 
     void Visit(const CopyTextureCmd& _cmd) {
+        ScopedNativeLabel marker(cmd_list, _cmd.name, GpuMarkerPalette::Transfer());
         VulkanTexture* src_texture = reinterpret_cast<VulkanTexture*>(_cmd.SrcHandle());
         VulkanTexture* dst_texture = reinterpret_cast<VulkanTexture*>(_cmd.DstHandle());
 
@@ -1409,6 +1436,7 @@ public:
     }
 
     void Visit(const CopyBufferToTextureCmd& _cmd) {
+        ScopedNativeLabel marker(cmd_list, _cmd.name, GpuMarkerPalette::Transfer());
         VulkanBuffer*  src_buffer  = reinterpret_cast<VulkanBuffer*>(_cmd.SrcHandle());
         VulkanTexture* dst_texture = reinterpret_cast<VulkanTexture*>(_cmd.DstHandle());
 
@@ -1425,6 +1453,7 @@ public:
     }
 
     void Visit(const CopyTextureToBufferCmd& _cmd) {
+        ScopedNativeLabel marker(cmd_list, _cmd.name, GpuMarkerPalette::Transfer());
         VulkanTexture* src_texture = reinterpret_cast<VulkanTexture*>(_cmd.SrcHandle());
         VulkanBuffer*  dst_buffer  = reinterpret_cast<VulkanBuffer*>(_cmd.DstHandle());
 
@@ -2065,6 +2094,7 @@ public:
     // }
 
     void Visit(const ClearResourceCmd& _cmd) {
+        ScopedNativeLabel marker(cmd_list, _cmd.name, GpuMarkerPalette::Transfer());
         std::visit(
             Overload{
                 [&](const TextureView& _arg) {
@@ -2367,17 +2397,17 @@ public:
 
     void Visit(const ScopeCmd& _cmd) {
         if (_cmd.IsPush()) {
-            cmd_list.BeginLabel(_cmd.ScopeName(), {0.0f, 1.0f, 0.0f, 1.0f});
+            cmd_list.BeginLabel(_cmd.ScopeName(), _cmd.Color());
             if (_cmd.QueryTimestamp() && query_profiling_enabled) {
                 assert(profiler && "profiler is not set");
                 profiler->BeginProfilerSession(cmd_list, _cmd.ScopeName());
             }
         } else {
-            cmd_list.EndLabel();
             if (_cmd.QueryTimestamp() && query_profiling_enabled) {
                 assert(profiler && "profiler is not set");
                 profiler->EndProfilerSession(cmd_list, _cmd.ScopeName());
             }
+            cmd_list.EndLabel();
         }
     }
 
@@ -2908,10 +2938,20 @@ void ProfilerStorage::CollectProfiling(VkCommandBuffer _cb) {
 
 int ProfilerStorage::GetQueryStorageIndex(std::string_view _name) {
     const std::string name{_name};
-    if (name2sample.find(name) == name2sample.end()) {
-        name2sample[name] = Sample(name2sample.size());
+    if (const auto found = name2sample.find(name); found != name2sample.end()) {
+        return found->second.index;
     }
-    return name2sample[name].index;
+    if (name2sample.size() >= s_query_max_storage) {
+        LOG_ERROR(
+            "GPU profiler query-name capacity ({}) exhausted; skipping timestamp scope '{}'.",
+            s_query_max_storage,
+            name
+        );
+        return -1;
+    }
+    const int index = static_cast<int>(name2sample.size());
+    name2sample.emplace(name, Sample(index));
+    return index;
 }
 
 void ProfilerStorage::BeginProfilerSession(
@@ -2922,7 +2962,11 @@ void ProfilerStorage::BeginProfilerSession(
     if (!active) {
         return;
     }
-    uint idx = GetQueryStorageIndex(_name) * 2 + 0 + cur_frame * s_max_num_profiler_queries_per_frame;
+    const int storage_index = GetQueryStorageIndex(_name);
+    if (storage_index < 0) {
+        return;
+    }
+    uint idx = storage_index * 2 + 0 + cur_frame * s_max_num_profiler_queries_per_frame;
     vkCmdWriteTimestamp(_cmd_list.GetHandle(), _stage, timestamp_pool.GetHandle(), idx);
     SetQueryUsed(idx);
     assert(IsQueryUsed(idx + 1) == false && "Query already used");
@@ -2936,7 +2980,11 @@ void ProfilerStorage::EndProfilerSession(
     if (!active) {
         return;
     }
-    uint idx = GetQueryStorageIndex(_name) * 2 + 1 + cur_frame * s_max_num_profiler_queries_per_frame;
+    const int storage_index = GetQueryStorageIndex(_name);
+    if (storage_index < 0) {
+        return;
+    }
+    uint idx = storage_index * 2 + 1 + cur_frame * s_max_num_profiler_queries_per_frame;
     vkCmdWriteTimestamp(_cmd_list.GetHandle(), _stage, timestamp_pool.GetHandle(), idx);
     SetQueryUsed(idx);
     assert(IsQueryUsed(idx - 1) == true && "Query not used");
@@ -3350,10 +3398,15 @@ void VkCommandQueue::ExecuteNow(CmdSubmit&& _submit, uint64 _timeline, uint64 _s
             }
         }
 
-        std::string_view queue_label = queue.GetType() == EQueueType::Graphics ? "Graphics Exec" :
-                                       queue.GetType() == EQueueType::Compute  ? "Compute Exec" :
-                                                                                 "Copy Exec";
-        vk_allocator.GetCmdList().BeginLabel(queue_label, {1.0f, 0.0f, 0.0f, 1.0f});
+        const std::string_view queue_label = !_submit.debug_label.empty() ?
+                                                 std::string_view(_submit.debug_label) :
+                                             queue.GetType() == EQueueType::Graphics ? "Graphics Exec" :
+                                             queue.GetType() == EQueueType::Compute  ? "Compute Exec" :
+                                                                                       "Copy Exec";
+        const float4 queue_label_color = !_submit.debug_label.empty() ?
+                                             _submit.debug_label_color :
+                                             float4{1.0f, 0.0f, 0.0f, 1.0f};
+        vk_allocator.GetCmdList().BeginLabel(queue_label, queue_label_color);
     }
 
     uint layer = 0;
@@ -3361,11 +3414,13 @@ void VkCommandQueue::ExecuteNow(CmdSubmit&& _submit, uint64 _timeline, uint64 _s
         uint32 raw_layer_index = 0;
         for (const CmdReorderer::LinkedCommandList& cmd_list : cmd_lists) {
             const uint32 current_raw_layer = raw_layer_index++;
-            if (layer == 0) {
-                vk_allocator.GetCmdList().BeginLabel("Begin Layers", {0.0f, 0.0f, 1.0f, 1.0f});
-            }
             if (cmd_list.head == nullptr) {
                 continue;
+            }
+            if (layer == 0) {
+                vk_allocator.GetCmdList().BeginLabel(
+                    "[RHI Diagnostics] Command Layers", {0.15f, 0.25f, 0.55f, 1.0f}
+                );
             }
             reorder_timer.Start();
             for (const auto* cmdnode = cmd_list.head; cmdnode != nullptr; cmdnode = cmdnode->next) {
@@ -3378,7 +3433,7 @@ void VkCommandQueue::ExecuteNow(CmdSubmit&& _submit, uint64 _timeline, uint64 _s
             reorder_timer.Stop();
             preprocess_time += reorder_timer.ElapsedMilliseconds();
             vk_allocator.GetCmdList().InsertLabel(
-                std::format("Layer {}", layer++), {0.0f, 0.0f, 1.0f, 1.0f}
+                std::format("[RHI] Layer {}", layer++), {0.15f, 0.25f, 0.55f, 1.0f}
             );
             RecordLayerTiming& layer_timing = record_sample->layer_timings[current_raw_layer];
             struct DeferredCommandDiagnostics {
@@ -3469,9 +3524,6 @@ void VkCommandQueue::ExecuteNow(CmdSubmit&& _submit, uint64 _timeline, uint64 _s
         // counters, per-command clocks, hashes, allocations, formatting, or output.
         // The pre-existing preprocess timer and debug-label formatting remain unchanged.
         for (const CmdReorderer::LinkedCommandList& cmd_list : cmd_lists) {
-            if (layer == 0) {
-                vk_allocator.GetCmdList().BeginLabel("Begin Layers", {0.0f, 0.0f, 1.0f, 1.0f});
-            }
             if (cmd_list.head == nullptr) {
                 continue;
             }
@@ -3483,15 +3535,12 @@ void VkCommandQueue::ExecuteNow(CmdSubmit&& _submit, uint64 _timeline, uint64 _s
             tracker.DispatchBarriers(vk_allocator.GetCmdList());
             reorder_timer.Stop();
             preprocess_time += reorder_timer.ElapsedMilliseconds();
-            vk_allocator.GetCmdList().InsertLabel(
-                std::format("Layer {}", layer++), {0.0f, 0.0f, 1.0f, 1.0f}
-            );
             for (const auto* cmdnode = cmd_list.head; cmdnode != nullptr; cmdnode = cmdnode->next) {
                 visitor.VisitCmd(cmdnode->cmd);
             }
         }
     }
-    if (layer > 0) {
+    if (record_sample && layer > 0) {
         vk_allocator.GetCmdList().EndLabel();
     }
 
@@ -3827,7 +3876,8 @@ void VkCommandQueue::PresentNow(
     auto* swaphchain_tex = ResourceCast(sc->GetSwapchainImage(idx).texture);
     {
         vk_cmd_list.Begin();
-        vk_cmd_list.BeginLabel("Present", {0.0f, 1.0f, 1.0f, 1.0f});
+        const std::string present_label = std::format("Present: {}", vk_src_tex->GetName());
+        vk_cmd_list.BeginLabel(present_label, {0.0f, 0.85f, 0.95f, 1.0f});
         vk_tracker.SetPassType(EPassType::Graphics);
         vk_tracker.RecordState(vk_src_tex, vk_tracker.ReadTexture(vk_src_tex, ETextureState::TRANSFER));
         vk_tracker.RecordState(
@@ -3837,7 +3887,7 @@ void VkCommandQueue::PresentNow(
         vk_tracker.DispatchBarriers(vk_cmd_list);
         //copy
         //todo: need transaction
-        vk_cmd_list.InsertLabel("Copy Present Image", {0.0f, 0.0f, 0.0f, 1.0f});
+        vk_cmd_list.InsertLabel("Copy Present Image", GpuMarkerPalette::Transfer());
         vk_cmd_list.CopyTexture(vk_src_tex, swaphchain_tex, _view.extent, {0, 0, 0}, {0, 0, 0}, 0, 0);
         vk_tracker.RecordState(
             swaphchain_tex, VK_ACCESS_2_NONE, VK_IMAGE_LAYOUT_PRESENT_SRC_KHR, VK_PIPELINE_STAGE_2_COPY_BIT

--- a/source/runtime/render/rhi/vulkan/VulkanSerialGolden.cpp
+++ b/source/runtime/render/rhi/vulkan/VulkanSerialGolden.cpp
@@ -739,6 +739,10 @@ struct VulkanSerialGoldenTrace::Impl {
                 hash.Add(command.IsPush() ? 1u : 0u);
                 hash.Add(command.QueryTimestamp() ? 1u : 0u);
                 hash.AddString(command.ScopeName());
+                AddFloat(hash, command.Color().x);
+                AddFloat(hash, command.Color().y);
+                AddFloat(hash, command.Color().z);
+                AddFloat(hash, command.Color().w);
                 break;
             }
             case Command::EType::Count:

--- a/source/test/CMakeLists.txt
+++ b/source/test/CMakeLists.txt
@@ -32,6 +32,13 @@ target_link_libraries(${test_target}
 )
 set_target_properties(${test_target} PROPERTIES FOLDER ${moer_test_folder})
 
+set(test_target TestRHICommandMarker)
+add_executable(${test_target} "RHICommandMarkerTest.cpp")
+target_link_libraries(${test_target}
+    PRIVATE Moer::Render
+)
+set_target_properties(${test_target} PROPERTIES FOLDER ${moer_test_folder})
+
 set(test_target TestExternalCpuJoin)
 add_executable(${test_target} "ExternalCpuJoinTest.cpp")
 target_link_libraries(${test_target}

--- a/source/test/RHICmdReordererTest.cpp
+++ b/source/test/RHICmdReordererTest.cpp
@@ -208,6 +208,34 @@ void WriteBarrierWaitsForPriorRead() {
     Expect(FindCommandLayer(reorderer, &write_barrier) == 1, "write barrier missed the prior-read WAR edge");
 }
 
+void ScopeCommandsOwnExclusiveLayers() {
+    TCachedArgArray cached_args;
+    CmdReorderer   reorderer(MakeFunctionTable(), cached_args);
+
+    ScopeCmd renderer_push("Renderer", true, false, GpuMarkerPalette::Renderer());
+    ScopeCmd pass_push("Pass", true, false, GpuMarkerPalette::Pass());
+    std::array<byte, 16> first_data{};
+    UploadBufferCmd first_work(0x6100, 0, first_data.size(), first_data.data());
+    ScopeCmd pass_pop("Pass", false, false, GpuMarkerPalette::Pass());
+    std::array<byte, 16> second_data{};
+    UploadBufferCmd second_work(0x6200, 0, second_data.size(), second_data.data());
+    ScopeCmd renderer_pop("Renderer", false, false, GpuMarkerPalette::Renderer());
+
+    reorderer.AcceptCmd(&renderer_push);
+    reorderer.AcceptCmd(&pass_push);
+    reorderer.AcceptCmd(&first_work);
+    reorderer.AcceptCmd(&pass_pop);
+    reorderer.AcceptCmd(&second_work);
+    reorderer.AcceptCmd(&renderer_pop);
+
+    Expect(FindCommandLayer(reorderer, &renderer_push) == 0, "renderer push did not own layer 0");
+    Expect(FindCommandLayer(reorderer, &pass_push) == 1, "nested pass push shared a marker layer");
+    Expect(FindCommandLayer(reorderer, &first_work) == 2, "pass work escaped before its push marker");
+    Expect(FindCommandLayer(reorderer, &pass_pop) == 3, "pass pop shared its work layer");
+    Expect(FindCommandLayer(reorderer, &second_work) == 4, "following work remained inside prior pass");
+    Expect(FindCommandLayer(reorderer, &renderer_pop) == 5, "renderer pop did not own the final layer");
+}
+
 void CommandResourcePreprocessingIsTaskGraphIndependent() {
     std::exception_ptr worker_error;
     std::jthread worker([&] {
@@ -349,6 +377,7 @@ int main() {
         ReadBarrierParticipatesInFollowingWarDependency();
         MultiResourceBarrierPublishesEveryAccessAtItsFinalLayer();
         WriteBarrierWaitsForPriorRead();
+        ScopeCommandsOwnExclusiveLayers();
         CommandResourcePreprocessingIsTaskGraphIndependent();
         std::cout << "RHI command reorderer tests passed\n";
         return 0;

--- a/source/test/RHICommandMarkerTest.cpp
+++ b/source/test/RHICommandMarkerTest.cpp
@@ -1,0 +1,133 @@
+#include "renderer/raster/RasterTool.h"
+#include "rhi/RHICommand.h"
+#include "rhi/RHIImpl.h"
+
+#include <iostream>
+#include <set>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <type_traits>
+
+using namespace Moer;
+using namespace Moer::Render;
+using namespace Moer::Render::Raster;
+
+namespace {
+
+void Expect(bool condition, std::string_view message) {
+    if (!condition) {
+        throw std::runtime_error(std::string(message));
+    }
+}
+
+const ScopeCmd& ScopeAt(const CmdSubmit& submit, size_t index) {
+    Expect(index < submit.cmds.size(), "scope command index is out of range");
+    Expect(submit.cmds[index]->Type() == Command::EType::Scope, "expected a ScopeCmd");
+    return *static_cast<const ScopeCmd*>(submit.cmds[index].get());
+}
+
+void MarkerScopesAreBalancedColoredAndImmobile() {
+    static_assert(!std::is_copy_constructible_v<ScopedGpuMarker>);
+    static_assert(!std::is_move_constructible_v<ScopedGpuMarker>);
+
+    CommandList cmd_list;
+    {
+        ScopedGpuMarker renderer(cmd_list, "Renderer", GpuMarkerPalette::Renderer());
+        {
+            ScopedGpuMarker timed(
+                cmd_list,
+                "Timed Pass",
+                GpuMarkerPalette::Pass(),
+                EGpuMarkerMode::Timestamp
+            );
+        }
+    }
+
+    CmdSubmit submit = cmd_list.Submit().DebugLabel("Test Frame", GpuMarkerPalette::Frame());
+    Expect(submit.debug_label == "Test Frame", "submission debug label was not retained");
+    Expect(submit.cmds.size() == 4, "RAII markers emitted an unbalanced command pair");
+
+    const ScopeCmd& renderer_push = ScopeAt(submit, 0);
+    const ScopeCmd& timed_push    = ScopeAt(submit, 1);
+    const ScopeCmd& timed_pop     = ScopeAt(submit, 2);
+    const ScopeCmd& renderer_pop  = ScopeAt(submit, 3);
+
+    Expect(renderer_push.IsPush(), "renderer scope did not begin with a push");
+    Expect(renderer_pop.IsPop(), "renderer scope did not end with a pop");
+    Expect(
+        renderer_push.ScopeName() == renderer_pop.ScopeName(),
+        "renderer push/pop names differ"
+    );
+    Expect(!renderer_push.QueryTimestamp(), "visual renderer marker unexpectedly requested timing");
+    Expect(timed_push.QueryTimestamp() && timed_pop.QueryTimestamp(), "timed marker lost its query pair");
+    Expect(timed_push.ScopeName() == timed_pop.ScopeName(), "timed push/pop names differ");
+    Expect(
+        renderer_push.Color().x == GpuMarkerPalette::Renderer().x,
+        "marker category color was not retained"
+    );
+
+    // Timestamp keys are per submission, not per CommandList lifetime.
+    {
+        ScopedGpuMarker timed_again(
+            cmd_list,
+            "Timed Pass",
+            GpuMarkerPalette::Pass(),
+            EGpuMarkerMode::Timestamp
+        );
+    }
+    CmdSubmit next_submit = cmd_list.Submit();
+    Expect(next_submit.cmds.size() == 2, "timestamp key was not reset after Submit");
+    Expect(ScopeAt(next_submit, 0).QueryTimestamp(), "second submission lost timestamp profiling");
+}
+
+void PointAndCsmMarkerNamesAreCompleteAndDisjoint() {
+    std::set<std::string_view> point_faces;
+    std::set<std::string_view> point_culling;
+    std::set<std::string_view> point_draw;
+    for (uint face = 0; face < CUBE_FACE_Num; ++face) {
+        point_faces.emplace(RasterTool::GetPointShadowFaceMarkerName(face));
+        point_culling.emplace(RasterTool::GetPointShadowCullingProfileScopeName(face));
+        point_draw.emplace(RasterTool::GetPointShadowDrawProfileScopeName(face));
+    }
+    Expect(point_faces.size() == CUBE_FACE_Num, "point-shadow face labels are not unique");
+    Expect(point_culling.size() == CUBE_FACE_Num, "point-shadow culling keys are not unique");
+    Expect(point_draw.size() == CUBE_FACE_Num, "point-shadow draw keys are not unique");
+    Expect(
+        RasterTool::GetPointShadowFaceMarkerName(CUBE_FACE_PX).find("+X") != std::string_view::npos,
+        "positive-X cube face label is incorrect"
+    );
+    Expect(
+        RasterTool::GetPointShadowFaceMarkerName(CUBE_FACE_NZ).find("-Z") != std::string_view::npos,
+        "negative-Z cube face label is incorrect"
+    );
+
+    std::set<std::string_view> csm_culling;
+    std::set<std::string_view> csm_draw;
+    for (uint cascade = 0; cascade < CSM_MAX_CASCADES; ++cascade) {
+        csm_culling.emplace(RasterTool::GetCsmShadowCullingProfileScopeName(cascade));
+        csm_draw.emplace(RasterTool::GetCsmShadowDrawProfileScopeName(cascade));
+    }
+    Expect(csm_culling.size() == CSM_MAX_CASCADES, "CSM culling keys are not unique");
+    Expect(csm_draw.size() == CSM_MAX_CASCADES, "CSM draw keys are not unique");
+    for (std::string_view name : csm_culling) {
+        Expect(!point_culling.contains(name), "CSM and point-shadow culling keys overlap");
+    }
+    for (std::string_view name : csm_draw) {
+        Expect(!point_draw.contains(name), "CSM and point-shadow draw keys overlap");
+    }
+}
+
+} // namespace
+
+int main() {
+    try {
+        MarkerScopesAreBalancedColoredAndImmobile();
+        PointAndCsmMarkerNamesAreCompleteAndDisjoint();
+        std::cout << "RHI command marker tests passed\n";
+        return 0;
+    } catch (const std::exception& error) {
+        std::cerr << "RHI command marker test failed: " << error.what() << '\n';
+        return 1;
+    }
+}


### PR DESCRIPTION
## Summary

- fix Point Cube shadow profiling so all six faces use distinct visual markers and culling/draw timestamp keys, separate from CSM
- add colored frame → renderer → graph/pipeline → pass → subpass/UI hierarchy across Raster, Raytracing, UI, transfer, and present command streams
- add RAII marker lifetime checks, per-submission timestamp-key validation, profiler capacity protection, reorder-layer correctness tests, and developer documentation

## Validation

- `cmake --build build --target TestRHICommandMarker TestRHICmdReorderer TestRenderGraph TestRHIRecordDiagnostics MoerEditor --config Debug -j 30`
- `TestRHICommandMarker`, `TestRHICmdReorderer`, `TestRenderGraph`, and `TestRHIRecordDiagnostics` pass
- default Raytracing renderer remained healthy for 45 seconds, reached first present, and logged no validation/assert/fatal errors
- Raster + RenderGraph + Point Cube scenario remained healthy for 60 seconds and created the 4096 cube shadow map
- RenderDoc 1.45 replay of Raster frame 300 found 139 markers, all six Point Cube face/cull/draw paths, zero missing expected paths, zero normal-mode RHI layer-noise markers, and distinct category colors

## Design note

A high-level GPU marker owns an RHI reorder layer so barriers and recorded commands stay inside the correct RenderDoc scope. The documentation therefore limits explicit markers to pass/subpass granularity.