### PR TITLE
feat(rendergraph): add typed RDG compiler

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,9 @@ set(CMAKE_PDB_OUTPUT_DIRECTORY "${BINARY_ROOT_DIR}/bin/$<CONFIG>")
 add_compile_definitions(EDITOR_MODE_ON=1)
 
 option(moer_build_test "build test unit" ON)
+if(moer_build_test)
+    enable_testing()
+endif()
 
 if(${MSVC})
     add_compile_options("/Zc:preprocessor")

--- a/source/runtime/render/renderer/raster/RasterRenderer.cpp
+++ b/source/runtime/render/renderer/raster/RasterRenderer.cpp
@@ -595,32 +595,32 @@ RasterFrameFeedback RasterRenderer::RenderFrame(RasterFramePacket frame_packet) 
             window_framebuffer_view.GetTexture() != nullptr;
 
         struct RasterGraphResources {
-            RenderGraph::ResourceHandle scene;
-            RenderGraph::ResourceHandle shadow_maps;
-            RenderGraph::ResourceHandle probe_volume;
-            RenderGraph::ResourceHandle lighting_data;
-            RenderGraph::ResourceHandle base_color;
-            RenderGraph::ResourceHandle normal;
-            RenderGraph::ResourceHandle metal_rough_ao;
-            RenderGraph::ResourceHandle depth;
-            RenderGraph::ResourceHandle hiz_current;
-            RenderGraph::ResourceHandle hiz_previous;
-            RenderGraph::ResourceHandle shadow_mask;
-            RenderGraph::ResourceHandle lighting_output;
-            RenderGraph::ResourceHandle ao_working_set;
-            RenderGraph::ResourceHandle motion_vectors;
-            RenderGraph::ResourceHandle ao_output;
-            RenderGraph::ResourceHandle denoiser_output;
-            RenderGraph::ResourceHandle ssr_output;
-            RenderGraph::ResourceHandle aa_output;
-            RenderGraph::ResourceHandle bloom_chain;
-            RenderGraph::ResourceHandle tonemapping_state;
-            RenderGraph::ResourceHandle tonemapping_output;
-            RenderGraph::ResourceHandle selected_framebuffer;
-            RenderGraph::ResourceHandle ui_framebuffer;
-            RenderGraph::ResourceHandle window_framebuffer;
-            RenderGraph::ResourceHandle output;
-            RenderGraph::ResourceHandle processing_image;
+            RenderGraph::TokenHandle   scene;
+            RenderGraph::TokenHandle   shadow_maps;
+            RenderGraph::TokenHandle   probe_volume;
+            RenderGraph::BufferHandle  lighting_data;
+            RenderGraph::TextureHandle base_color;
+            RenderGraph::TextureHandle normal;
+            RenderGraph::TextureHandle metal_rough_ao;
+            RenderGraph::TextureHandle depth;
+            RenderGraph::TextureHandle hiz_current;
+            RenderGraph::TextureHandle hiz_previous;
+            RenderGraph::TextureHandle shadow_mask;
+            RenderGraph::TextureHandle lighting_output;
+            RenderGraph::TokenHandle   ao_working_set;
+            RenderGraph::TokenHandle   motion_vectors;
+            RenderGraph::TextureHandle ao_output;
+            RenderGraph::TextureHandle denoiser_output;
+            RenderGraph::TextureHandle ssr_output;
+            RenderGraph::TextureHandle aa_output;
+            RenderGraph::TokenHandle   bloom_chain;
+            RenderGraph::TokenHandle   tonemapping_state;
+            RenderGraph::TextureHandle tonemapping_output;
+            RenderGraph::TextureHandle selected_framebuffer;
+            RenderGraph::TextureHandle ui_framebuffer;
+            RenderGraph::TextureHandle window_framebuffer;
+            RenderGraph::TextureHandle output;
+            RenderGraph::TokenHandle   processing_image;
         } graph_resources{};
 
         auto define_raster_passes = [&](auto&& schedule) {
@@ -628,7 +628,7 @@ RasterFrameFeedback RasterRenderer::RenderFrame(RasterFramePacket frame_packet) 
                 "ShadowDepth",
                 [&](RenderGraph::PassBuilder& builder) {
                     builder.Read(graph_resources.scene)
-                        .Write(graph_resources.shadow_maps, "all-cascades-and-cube-faces")
+                        .Write(graph_resources.shadow_maps)
                         .SideEffect();
                 },
                 [&]() {
@@ -660,7 +660,7 @@ RasterFrameFeedback RasterRenderer::RenderFrame(RasterFramePacket frame_packet) 
                 "Geometry",
                 [&](RenderGraph::PassBuilder& builder) {
                     builder.Read(graph_resources.scene)
-                        .Read(graph_resources.hiz_previous, "all-mips")
+                        .Read(graph_resources.hiz_previous)
                         .Write(graph_resources.base_color)
                         .Write(graph_resources.normal)
                         .Write(graph_resources.metal_rough_ao)
@@ -688,15 +688,15 @@ RasterFrameFeedback RasterRenderer::RenderFrame(RasterFramePacket frame_packet) 
                 "HiZBuild",
                 [&](RenderGraph::PassBuilder& builder) {
                     builder.Read(graph_resources.depth)
-                        .Write(graph_resources.hiz_current, "all-mips");
+                        .Write(graph_resources.hiz_current);
                 },
                 [&]() { hiz_build_pass->Process(raster_context); }
             );
             schedule(
                 "CommitHiZHistory",
                 [&](RenderGraph::PassBuilder& builder) {
-                    builder.Read(graph_resources.hiz_current, "all-mips")
-                        .Write(graph_resources.hiz_previous, "all-mips")
+                    builder.Read(graph_resources.hiz_current)
+                        .Write(graph_resources.hiz_previous)
                         .SideEffect();
                 },
                 [&]() { raster_context.CommitHiZHistory(camera.GetViewProjectionMatrix()); }
@@ -873,7 +873,7 @@ RasterFrameFeedback RasterRenderer::RenderFrame(RasterFramePacket frame_packet) 
                 "Bloom",
                 [&](RenderGraph::PassBuilder& builder) {
                     builder.ReadWrite(graph_resources.processing_image)
-                        .Write(graph_resources.bloom_chain, "all-mips");
+                        .Write(graph_resources.bloom_chain);
                 },
                 [&]() {
                     processing_image = bloom_pass->Process(raster_context, raster_config, processing_image);
@@ -989,31 +989,49 @@ RasterFrameFeedback RasterRenderer::RenderFrame(RasterFramePacket frame_packet) 
 
         if (render_graph_enabled && !render_graph_fallback_latched) {
             RenderGraph graph("RasterFrame");
+            auto import_physical_texture = [&](std::string_view name, Texture* physical_texture) {
+                assert(physical_texture != nullptr);
+                RenderGraph::TextureAspect aspects = RenderGraph::TextureAspect::None;
+                const auto rhi_aspects = physical_texture->GetAspectFlags();
+                if (uint32_t(rhi_aspects & ETextureAspectFlags::COLOR) != 0) {
+                    aspects = aspects | RenderGraph::TextureAspect::Color;
+                }
+                if (uint32_t(rhi_aspects & ETextureAspectFlags::DEPTH_SLICE) != 0) {
+                    aspects = aspects | RenderGraph::TextureAspect::Depth;
+                }
+                if (uint32_t(rhi_aspects & ETextureAspectFlags::STENCIL_SLICE) != 0) {
+                    aspects = aspects | RenderGraph::TextureAspect::Stencil;
+                }
+                assert(aspects != RenderGraph::TextureAspect::None);
+                return graph.ImportTexture(
+                    name,
+                    physical_texture,
+                    RenderGraph::TextureDesc{
+                        .mip_count = physical_texture->GetNumMips(),
+                        .layer_count = physical_texture->GetNumArray(),
+                        .aspects = aspects
+                    }
+                );
+            };
             auto import_texture = [&](std::string_view name, const auto& texture) {
                 // DepthBufferRef wraps a TextureRef while ordinary texture handles point at the
                 // Texture directly. Canonicalize every texture import to the TextureView's physical
                 // Texture so aliases (including the two depth sampler wrappers and the editor view)
                 // resolve to one graph resource.
-                return graph.Import(
-                    name,
-                    RenderGraph::ResourceKind::Texture,
-                    texture->GetView().GetTexture()
-                );
+                return import_physical_texture(name, texture->GetView().GetTexture());
             };
 
-            graph_resources.scene = graph.Import(
-                "scene", RenderGraph::ResourceKind::Token, render_scene.get()
-            );
-            graph_resources.shadow_maps = graph.Import(
-                "shadow_maps", RenderGraph::ResourceKind::Token, &raster_context.csm_data
-            );
-            graph_resources.probe_volume = graph.Import(
-                "probe_volume", RenderGraph::ResourceKind::Token, &raster_context.probe_volume
-            );
-            graph_resources.lighting_data = graph.Import(
+            graph_resources.scene = graph.ImportToken("scene", render_scene.get());
+            graph_resources.shadow_maps =
+                graph.ImportToken("shadow_maps", &raster_context.csm_data);
+            graph_resources.probe_volume =
+                graph.ImportToken("probe_volume", &raster_context.probe_volume);
+            auto* lighting_data_buffer = raster_context.lighting_data_buffer.buf.Get();
+            assert(lighting_data_buffer != nullptr);
+            graph_resources.lighting_data = graph.ImportBuffer(
                 "lighting_data",
-                RenderGraph::ResourceKind::Buffer,
-                raster_context.lighting_data_buffer.buf.Get()
+                lighting_data_buffer,
+                RenderGraph::BufferDesc{.byte_size = lighting_data_buffer->GetByteSize()}
             );
             graph_resources.base_color =
                 import_texture("base_color", raster_context.textures.base_color.tex);
@@ -1033,12 +1051,9 @@ RasterFrameFeedback RasterRenderer::RenderFrame(RasterFramePacket frame_packet) 
                 import_texture("shadow_mask", raster_context.textures.shadow_mask.tex);
             graph_resources.lighting_output =
                 import_texture("lighting_output", raster_context.textures.lighting_output.tex);
-            graph_resources.ao_working_set = graph.Import(
-                "ao_working_set", RenderGraph::ResourceKind::Token, ao_pass.get()
-            );
-            graph_resources.motion_vectors = graph.Import(
-                "motion_vectors", RenderGraph::ResourceKind::Token, rtao_denoiser_pass.get()
-            );
+            graph_resources.ao_working_set = graph.ImportToken("ao_working_set", ao_pass.get());
+            graph_resources.motion_vectors =
+                graph.ImportToken("motion_vectors", rtao_denoiser_pass.get());
             graph_resources.ao_output =
                 import_texture("ao_output", raster_context.textures.ao_output.tex);
             graph_resources.denoiser_output =
@@ -1047,22 +1062,17 @@ RasterFrameFeedback RasterRenderer::RenderFrame(RasterFramePacket frame_packet) 
                 import_texture("ssr_output", raster_context.textures.ssr_output.tex);
             graph_resources.aa_output =
                 import_texture("aa_output", raster_context.textures.aa_output.tex);
-            graph_resources.bloom_chain = graph.Import(
-                "bloom_chain", RenderGraph::ResourceKind::Token, bloom_pass.get()
-            );
-            graph_resources.tonemapping_state = graph.Import(
-                "tonemapping_state", RenderGraph::ResourceKind::Token, tonemapping_pass.get()
-            );
+            graph_resources.bloom_chain = graph.ImportToken("bloom_chain", bloom_pass.get());
+            graph_resources.tonemapping_state =
+                graph.ImportToken("tonemapping_state", tonemapping_pass.get());
             graph_resources.tonemapping_output =
                 import_texture("tonemapping_output", raster_context.textures.tonemapping_output.tex);
             if (frame_packet.ui_composition.enabled) {
-                graph_resources.selected_framebuffer = graph.Import(
-                    "selected_framebuffer",
-                    RenderGraph::ResourceKind::Texture,
-                    selected_framebuffer_view.GetTexture()
+                graph_resources.selected_framebuffer = import_physical_texture(
+                    "selected_framebuffer", selected_framebuffer_view.GetTexture()
                 );
 
-                RenderGraph::ResourceHandle expected_validation_resource;
+                RenderGraph::TextureHandle expected_validation_resource;
                 const auto& validation_name = frame_packet.validation_selected_frame_buffer_name;
                 if (validation_name == "base_color") {
                     expected_validation_resource = graph_resources.base_color;
@@ -1087,17 +1097,13 @@ RasterFrameFeedback RasterRenderer::RenderFrame(RasterFramePacket frame_packet) 
             graph_resources.ui_framebuffer =
                 import_texture("ui_framebuffer", raster_context.textures.ui_frame_buffer.tex);
             if (ui_writes_external_window) {
-                graph_resources.window_framebuffer = graph.Import(
-                    "window_framebuffer",
-                    RenderGraph::ResourceKind::Texture,
-                    window_framebuffer_view.GetTexture()
+                graph_resources.window_framebuffer = import_physical_texture(
+                    "window_framebuffer", window_framebuffer_view.GetTexture()
                 );
             }
             graph_resources.output =
                 import_texture("output", raster_context.textures.output.tex);
-            graph_resources.processing_image = graph.CreateTransient(
-                "processing_image", RenderGraph::ResourceKind::Token
-            );
+            graph_resources.processing_image = graph.CreateTransientToken("processing_image");
 
             if (render_graph_fallback_latched) {
                 execute_linear();

--- a/source/runtime/render/rendergraph/RenderGraph.cpp
+++ b/source/runtime/render/rendergraph/RenderGraph.cpp
@@ -1,5 +1,7 @@
 #include "rendergraph/RenderGraph.h"
 
+#include "rendergraph/RenderGraphCompiler.h"
+
 #include <algorithm>
 #include <atomic>
 #include <cassert>
@@ -11,6 +13,13 @@ namespace Moer::Render {
 namespace {
 
 std::atomic<uint64_t> s_next_graph_id{1};
+
+[[nodiscard]] bool IsValidTextureDesc(const RenderGraph::TextureDesc& desc) {
+    const auto aspect_mask = static_cast<uint8_t>(desc.aspects);
+    const auto known_mask  = static_cast<uint8_t>(RenderGraph::TextureAspect::All);
+    return desc.mip_count != 0 && desc.layer_count != 0 && aspect_mask != 0 &&
+           (aspect_mask & known_mask) == aspect_mask;
+}
 
 const char* ToString(RenderGraph::ResourceKind kind) {
     switch (kind) {
@@ -24,49 +33,175 @@ const char* ToString(RenderGraph::ResourceKind kind) {
     return "unknown";
 }
 
-const char* ToString(uint8_t access_mode) {
-    switch (access_mode) {
-        case 0:
+const char* ToString(RenderGraph::AccessMode mode) {
+    switch (mode) {
+        case RenderGraph::AccessMode::Read:
             return "R";
-        case 1:
+        case RenderGraph::AccessMode::Write:
             return "W";
-        case 2:
+        case RenderGraph::AccessMode::ReadWrite:
             return "RW";
-        default:
-            return "?";
+    }
+    return "?";
+}
+
+const char* ToString(RenderGraph::EdgeReasonKind kind) {
+    switch (kind) {
+        case RenderGraph::EdgeReasonKind::Explicit:
+            return "explicit";
+        case RenderGraph::EdgeReasonKind::ReadAfterWrite:
+            return "RAW";
+        case RenderGraph::EdgeReasonKind::WriteAfterRead:
+            return "WAR";
+        case RenderGraph::EdgeReasonKind::WriteAfterWrite:
+            return "WAW";
+    }
+    return "unknown";
+}
+
+void AppendTextureAspects(std::ostringstream& stream, RenderGraph::TextureAspect aspects) {
+    const auto mask   = static_cast<uint8_t>(aspects);
+    bool       wrote  = false;
+    auto       append = [&](RenderGraph::TextureAspect aspect, const char* name) {
+        if ((mask & static_cast<uint8_t>(aspect)) == 0) {
+            return;
+        }
+        if (wrote) {
+            stream << '|';
+        }
+        stream << name;
+        wrote = true;
+    };
+    append(RenderGraph::TextureAspect::Color, "color");
+    append(RenderGraph::TextureAspect::Depth, "depth");
+    append(RenderGraph::TextureAspect::Stencil, "stencil");
+    if (!wrote) {
+        stream << "none";
     }
 }
 
-void AppendUnique(std::vector<std::string>& values, std::string value) {
-    if (std::find(values.begin(), values.end(), value) == values.end()) {
-        values.emplace_back(std::move(value));
+void AppendCount(std::ostringstream& stream, uint64_t count, uint64_t remaining) {
+    if (count == remaining) {
+        stream << "remaining";
+    } else {
+        stream << count;
+    }
+}
+
+void AppendRange(std::ostringstream& stream, const RenderGraph::ResourceRange& range) {
+    switch (range.kind) {
+        case RenderGraph::ResourceKind::Texture:
+            stream << "texture[aspect=";
+            AppendTextureAspects(stream, range.texture.aspects);
+            stream << " mip=" << range.texture.mip_first << '+';
+            AppendCount(stream, range.texture.mip_count, RenderGraph::RemainingTextureRange);
+            stream << " layer=" << range.texture.layer_first << '+';
+            AppendCount(stream, range.texture.layer_count, RenderGraph::RemainingTextureRange);
+            stream << ']';
+            break;
+        case RenderGraph::ResourceKind::Buffer:
+            stream << "buffer[offset=" << range.buffer.offset << " size=";
+            AppendCount(stream, range.buffer.size, RenderGraph::RemainingBufferRange);
+            stream << ']';
+            break;
+        case RenderGraph::ResourceKind::Token:
+            stream << "token[all]";
+            break;
+    }
+}
+
+void AppendVersion(std::ostringstream& stream, uint32_t version) {
+    if (version == RenderGraph::InvalidVersion) {
+        stream << "none";
+    } else {
+        stream << 'v' << version;
     }
 }
 
 } // namespace
 
 RenderGraph::RenderGraph(std::string_view graph_name) :
-    name(graph_name), graph_id(s_next_graph_id.fetch_add(1, std::memory_order_relaxed)) {
+    name(graph_name),
+    graph_id(s_next_graph_id.fetch_add(1, std::memory_order_relaxed)) {
     assert(graph_id != 0 && "RenderGraph id counter wrapped.");
 }
 
 RenderGraph::~RenderGraph() = default;
 
-RenderGraph::PassBuilder&
-RenderGraph::PassBuilder::Read(ResourceHandle resource, std::string_view range) {
-    graph.AddAccess(pass_index, resource, AccessMode::Read, range);
+RenderGraph::PassBuilder& RenderGraph::PassBuilder::Read(ResourceHandle resource, std::string_view range) {
+    ResourceRange typed_range = ResourceRange::Token();
+    if (graph.IsValidResource(resource)) {
+        typed_range = ResourceRange::Whole(graph.resources[resource.index].kind);
+    }
+    graph.AddAccess(pass_index, resource, AccessMode::Read, typed_range, false, range);
     return *this;
 }
 
-RenderGraph::PassBuilder&
-RenderGraph::PassBuilder::Write(ResourceHandle resource, std::string_view range) {
-    graph.AddAccess(pass_index, resource, AccessMode::Write, range);
+RenderGraph::PassBuilder& RenderGraph::PassBuilder::Write(ResourceHandle resource, std::string_view range) {
+    ResourceRange typed_range = ResourceRange::Token();
+    if (graph.IsValidResource(resource)) {
+        typed_range = ResourceRange::Whole(graph.resources[resource.index].kind);
+    }
+    graph.AddAccess(pass_index, resource, AccessMode::Write, typed_range, false, range);
     return *this;
 }
 
 RenderGraph::PassBuilder&
 RenderGraph::PassBuilder::ReadWrite(ResourceHandle resource, std::string_view range) {
-    graph.AddAccess(pass_index, resource, AccessMode::ReadWrite, range);
+    ResourceRange typed_range = ResourceRange::Token();
+    if (graph.IsValidResource(resource)) {
+        typed_range = ResourceRange::Whole(graph.resources[resource.index].kind);
+    }
+    graph.AddAccess(pass_index, resource, AccessMode::ReadWrite, typed_range, false, range);
+    return *this;
+}
+
+RenderGraph::PassBuilder& RenderGraph::PassBuilder::Read(TextureHandle resource, TextureRange range) {
+    graph.AddAccess(pass_index, resource.Untyped(), AccessMode::Read, ResourceRange::Texture(range), true);
+    return *this;
+}
+
+RenderGraph::PassBuilder& RenderGraph::PassBuilder::Write(TextureHandle resource, TextureRange range) {
+    graph.AddAccess(pass_index, resource.Untyped(), AccessMode::Write, ResourceRange::Texture(range), true);
+    return *this;
+}
+
+RenderGraph::PassBuilder& RenderGraph::PassBuilder::ReadWrite(TextureHandle resource, TextureRange range) {
+    graph.AddAccess(
+        pass_index, resource.Untyped(), AccessMode::ReadWrite, ResourceRange::Texture(range), true
+    );
+    return *this;
+}
+
+RenderGraph::PassBuilder& RenderGraph::PassBuilder::Read(BufferHandle resource, BufferRange range) {
+    graph.AddAccess(pass_index, resource.Untyped(), AccessMode::Read, ResourceRange::Buffer(range), true);
+    return *this;
+}
+
+RenderGraph::PassBuilder& RenderGraph::PassBuilder::Write(BufferHandle resource, BufferRange range) {
+    graph.AddAccess(pass_index, resource.Untyped(), AccessMode::Write, ResourceRange::Buffer(range), true);
+    return *this;
+}
+
+RenderGraph::PassBuilder& RenderGraph::PassBuilder::ReadWrite(BufferHandle resource, BufferRange range) {
+    graph.AddAccess(
+        pass_index, resource.Untyped(), AccessMode::ReadWrite, ResourceRange::Buffer(range), true
+    );
+    return *this;
+}
+
+RenderGraph::PassBuilder& RenderGraph::PassBuilder::Read(TokenHandle resource) {
+    graph.AddAccess(pass_index, resource.Untyped(), AccessMode::Read, ResourceRange::Token(), true);
+    return *this;
+}
+
+RenderGraph::PassBuilder& RenderGraph::PassBuilder::Write(TokenHandle resource) {
+    graph.AddAccess(pass_index, resource.Untyped(), AccessMode::Write, ResourceRange::Token(), true);
+    return *this;
+}
+
+RenderGraph::PassBuilder& RenderGraph::PassBuilder::ReadWrite(TokenHandle resource) {
+    graph.AddAccess(pass_index, resource.Untyped(), AccessMode::ReadWrite, ResourceRange::Token(), true);
     return *this;
 }
 
@@ -82,11 +217,50 @@ RenderGraph::PassBuilder& RenderGraph::PassBuilder::SideEffect() {
 
 RenderGraph::ResourceHandle
 RenderGraph::Import(std::string_view resource_name, ResourceKind kind, const void* physical_identity) {
+    return ImportInternal(resource_name, kind, physical_identity, nullptr, nullptr);
+}
+
+RenderGraph::TextureHandle
+RenderGraph::ImportTexture(std::string_view resource_name, const void* physical_identity, TextureDesc desc) {
+    return TextureHandle{
+        ImportInternal(resource_name, ResourceKind::Texture, physical_identity, &desc, nullptr)
+    };
+}
+
+RenderGraph::BufferHandle
+RenderGraph::ImportBuffer(std::string_view resource_name, const void* physical_identity, BufferDesc desc) {
+    return BufferHandle{ImportInternal(resource_name, ResourceKind::Buffer, physical_identity, nullptr, &desc)
+    };
+}
+
+RenderGraph::TokenHandle
+RenderGraph::ImportToken(std::string_view resource_name, const void* physical_identity) {
+    return TokenHandle{ImportInternal(resource_name, ResourceKind::Token, physical_identity, nullptr, nullptr)
+    };
+}
+
+RenderGraph::ResourceHandle RenderGraph::ImportInternal(
+    std::string_view   resource_name,
+    ResourceKind       kind,
+    const void*        physical_identity,
+    const TextureDesc* texture_desc,
+    const BufferDesc*  buffer_desc
+) {
     if (!InvalidateCompile()) {
         return {};
     }
     if (resource_name.empty()) {
         declaration_errors.emplace_back("resource name cannot be empty");
+        return {};
+    }
+    if (texture_desc != nullptr && !IsValidTextureDesc(*texture_desc)) {
+        declaration_errors.emplace_back("typed texture descriptor is invalid: " + std::string(resource_name));
+        return {};
+    }
+    if (buffer_desc != nullptr && buffer_desc->byte_size == 0) {
+        declaration_errors.emplace_back(
+            "typed buffer descriptor has zero byte size: " + std::string(resource_name)
+        );
         return {};
     }
 
@@ -95,25 +269,50 @@ RenderGraph::Import(std::string_view resource_name, ResourceKind kind, const voi
         if (resource.name == resource_name ||
             std::find(resource.aliases.begin(), resource.aliases.end(), resource_name) !=
                 resource.aliases.end()) {
-            declaration_errors.emplace_back("duplicate resource or alias name: " + std::string(resource_name));
+            declaration_errors.emplace_back(
+                "duplicate resource or alias name: " + std::string(resource_name)
+            );
             return {};
         }
-        if (physical_identity != nullptr && resource.physical_identity == physical_identity) {
-            if (!resource.imported) {
-                declaration_errors.emplace_back(
-                    "physical identity aliases transient resource: " + std::string(resource_name)
-                );
-                return {};
-            }
-            if (resource.kind != kind) {
-                declaration_errors.emplace_back(
-                    "physical identity imported with different resource kinds: " + std::string(resource_name)
-                );
-                return {};
-            }
-            resource.aliases.emplace_back(resource_name);
-            return ResourceHandle{index, graph_id};
+        if (physical_identity == nullptr || resource.physical_identity != physical_identity) {
+            continue;
         }
+        if (!resource.imported) {
+            declaration_errors.emplace_back(
+                "physical identity aliases transient resource: " + std::string(resource_name)
+            );
+            return {};
+        }
+        if (resource.kind != kind) {
+            declaration_errors.emplace_back(
+                "physical identity imported with different resource kinds: " + std::string(resource_name)
+            );
+            return {};
+        }
+        if (texture_desc != nullptr) {
+            if (resource.typed_desc && resource.texture_desc != *texture_desc) {
+                declaration_errors.emplace_back(
+                    "physical texture alias imported with a different descriptor: " +
+                    std::string(resource_name)
+                );
+                return {};
+            }
+            resource.texture_desc = *texture_desc;
+            resource.typed_desc   = true;
+        }
+        if (buffer_desc != nullptr) {
+            if (resource.typed_desc && resource.buffer_desc != *buffer_desc) {
+                declaration_errors.emplace_back(
+                    "physical buffer alias imported with a different descriptor: " +
+                    std::string(resource_name)
+                );
+                return {};
+            }
+            resource.buffer_desc = *buffer_desc;
+            resource.typed_desc  = true;
+        }
+        resource.aliases.emplace_back(resource_name);
+        return ResourceHandle{index, graph_id};
     }
 
     ResourceDeclaration resource{};
@@ -121,19 +320,57 @@ RenderGraph::Import(std::string_view resource_name, ResourceKind kind, const voi
     resource.kind              = kind;
     resource.physical_identity = physical_identity;
     resource.imported          = true;
+    if (texture_desc != nullptr) {
+        resource.texture_desc = *texture_desc;
+        resource.typed_desc   = true;
+    }
+    if (buffer_desc != nullptr) {
+        resource.buffer_desc = *buffer_desc;
+        resource.typed_desc  = true;
+    }
     resources.emplace_back(std::move(resource));
     return ResourceHandle{static_cast<uint32_t>(resources.size() - 1), graph_id};
 }
 
-RenderGraph::ResourceHandle RenderGraph::CreateTransient(
-    std::string_view resource_name,
-    ResourceKind kind
+RenderGraph::ResourceHandle RenderGraph::CreateTransient(std::string_view resource_name, ResourceKind kind) {
+    return CreateTransientInternal(resource_name, kind, nullptr, nullptr);
+}
+
+RenderGraph::TextureHandle
+RenderGraph::CreateTransientTexture(std::string_view resource_name, TextureDesc desc) {
+    return TextureHandle{CreateTransientInternal(resource_name, ResourceKind::Texture, &desc, nullptr)};
+}
+
+RenderGraph::BufferHandle
+RenderGraph::CreateTransientBuffer(std::string_view resource_name, BufferDesc desc) {
+    return BufferHandle{CreateTransientInternal(resource_name, ResourceKind::Buffer, nullptr, &desc)};
+}
+
+RenderGraph::TokenHandle RenderGraph::CreateTransientToken(std::string_view resource_name) {
+    return TokenHandle{CreateTransientInternal(resource_name, ResourceKind::Token, nullptr, nullptr)};
+}
+
+RenderGraph::ResourceHandle RenderGraph::CreateTransientInternal(
+    std::string_view   resource_name,
+    ResourceKind       kind,
+    const TextureDesc* texture_desc,
+    const BufferDesc*  buffer_desc
 ) {
     if (!InvalidateCompile()) {
         return {};
     }
     if (resource_name.empty()) {
         declaration_errors.emplace_back("resource name cannot be empty");
+        return {};
+    }
+    if (texture_desc != nullptr && !IsValidTextureDesc(*texture_desc)) {
+        declaration_errors.emplace_back("typed texture descriptor is invalid: " + std::string(resource_name));
+        return {};
+    }
+    if (buffer_desc != nullptr && buffer_desc->byte_size == 0) {
+        declaration_errors.emplace_back(
+            "typed buffer descriptor has zero byte size: " + std::string(resource_name)
+        );
         return {};
     }
     for (const auto& resource : resources) {
@@ -146,9 +383,17 @@ RenderGraph::ResourceHandle RenderGraph::CreateTransient(
     }
 
     ResourceDeclaration resource{};
-    resource.name      = resource_name;
-    resource.kind      = kind;
-    resource.imported  = false;
+    resource.name     = resource_name;
+    resource.kind     = kind;
+    resource.imported = false;
+    if (texture_desc != nullptr) {
+        resource.texture_desc = *texture_desc;
+        resource.typed_desc   = true;
+    }
+    if (buffer_desc != nullptr) {
+        resource.buffer_desc = *buffer_desc;
+        resource.typed_desc  = true;
+    }
     resources.emplace_back(std::move(resource));
     return ResourceHandle{static_cast<uint32_t>(resources.size() - 1), graph_id};
 }
@@ -164,11 +409,8 @@ void RenderGraph::Export(ResourceHandle resource) {
     resources[resource.index].exported = true;
 }
 
-RenderGraph::PassHandle RenderGraph::AddPass(
-    std::string_view pass_name,
-    const SetupCallback& setup,
-    ExecuteCallback execute
-) {
+RenderGraph::PassHandle
+RenderGraph::AddPass(std::string_view pass_name, const SetupCallback& setup, ExecuteCallback execute) {
     if (!InvalidateCompile()) {
         return {};
     }
@@ -192,7 +434,7 @@ RenderGraph::PassHandle RenderGraph::AddPass(
     pass.execute = std::move(execute);
     passes.emplace_back(std::move(pass));
     const uint32_t pass_index = static_cast<uint32_t>(passes.size() - 1);
-    PassBuilder builder(*this, pass_index);
+    PassBuilder    builder(*this, pass_index);
     if (setup) {
         setup(builder);
     }
@@ -201,174 +443,10 @@ RenderGraph::PassHandle RenderGraph::AddPass(
 
 bool RenderGraph::Compile() {
     if (executed) {
-        return FailCompile("graph has already executed and cannot be compiled again");
+        compile_error = "graph has already executed and cannot be compiled again";
+        return false;
     }
-    compiled = false;
-    compile_error.clear();
-    execution_order.clear();
-    compiled_edges.clear();
-    for (auto& resource : resources) {
-        resource.first_use = PassHandle::InvalidIndex;
-        resource.last_use  = PassHandle::InvalidIndex;
-    }
-
-    if (!declaration_errors.empty()) {
-        return FailCompile(declaration_errors.front());
-    }
-    if (passes.empty()) {
-        return FailCompile("graph contains no passes");
-    }
-
-    auto add_edge = [&](uint32_t src, uint32_t dst, std::string reason) {
-        if (src == dst) {
-            return;
-        }
-        auto edge = std::find_if(compiled_edges.begin(), compiled_edges.end(), [&](const CompiledEdge& item) {
-            return item.src == src && item.dst == dst;
-        });
-        if (edge == compiled_edges.end()) {
-            compiled_edges.push_back(CompiledEdge{src, dst, {std::move(reason)}});
-        } else {
-            AppendUnique(edge->reasons, std::move(reason));
-        }
-    };
-
-    // Phase 8's production policy is intentionally serial. Adjacent edges make
-    // the old declaration order an explicit invariant while the graph still
-    // compiles and reports the underlying resource hazards.
-    for (uint32_t pass_index = 1; pass_index < passes.size(); ++pass_index) {
-        add_edge(pass_index - 1, pass_index, "serial");
-    }
-
-    for (uint32_t pass_index = 0; pass_index < passes.size(); ++pass_index) {
-        for (const PassHandle dependency : passes[pass_index].explicit_dependencies) {
-            if (!IsValidPass(dependency)) {
-                return FailCompile("pass '" + passes[pass_index].name + "' has an invalid explicit dependency");
-            }
-            add_edge(dependency.index, pass_index, "explicit");
-        }
-    }
-
-    struct HazardState {
-        uint32_t              last_writer = PassHandle::InvalidIndex;
-        std::vector<uint32_t> readers;
-        bool                  ever_written = false;
-    };
-    std::vector<HazardState> hazards(resources.size());
-
-    for (uint32_t pass_index = 0; pass_index < passes.size(); ++pass_index) {
-        struct CombinedAccess {
-            bool read = false;
-            bool write = false;
-        };
-        std::vector<CombinedAccess> combined(resources.size());
-        for (const auto& access : passes[pass_index].accesses) {
-            if (!IsValidResource(access.resource)) {
-                return FailCompile("pass '" + passes[pass_index].name + "' references an invalid resource");
-            }
-            auto& item = combined[access.resource.index];
-            item.read |= access.mode == AccessMode::Read || access.mode == AccessMode::ReadWrite;
-            item.write |= access.mode == AccessMode::Write || access.mode == AccessMode::ReadWrite;
-        }
-
-        for (uint32_t resource_index = 0; resource_index < combined.size(); ++resource_index) {
-            const CombinedAccess access = combined[resource_index];
-            if (!access.read && !access.write) {
-                continue;
-            }
-            auto& hazard  = hazards[resource_index];
-            auto& resource = resources[resource_index];
-
-            if (access.read) {
-                if (!resource.imported && hazard.last_writer == PassHandle::InvalidIndex) {
-                    return FailCompile(
-                        "transient resource '" + resource.name + "' is read before its first producer in pass '" +
-                        passes[pass_index].name + "'"
-                    );
-                }
-                if (hazard.last_writer != PassHandle::InvalidIndex) {
-                    add_edge(hazard.last_writer, pass_index, "RAW:" + resource.name);
-                }
-            }
-
-            if (access.write) {
-                if (hazard.last_writer != PassHandle::InvalidIndex) {
-                    add_edge(hazard.last_writer, pass_index, "WAW:" + resource.name);
-                }
-                for (const uint32_t reader : hazard.readers) {
-                    add_edge(reader, pass_index, "WAR:" + resource.name);
-                }
-                hazard.readers.clear();
-                hazard.last_writer = pass_index;
-                hazard.ever_written = true;
-            } else if (access.read &&
-                       std::find(hazard.readers.begin(), hazard.readers.end(), pass_index) == hazard.readers.end()) {
-                hazard.readers.push_back(pass_index);
-            }
-        }
-    }
-
-    for (uint32_t index = 0; index < resources.size(); ++index) {
-        if (!resources[index].imported && !hazards[index].ever_written) {
-            return FailCompile("transient resource has no producer: " + resources[index].name);
-        }
-    }
-
-    std::sort(compiled_edges.begin(), compiled_edges.end(), [](const CompiledEdge& lhs, const CompiledEdge& rhs) {
-        return lhs.src < rhs.src || (lhs.src == rhs.src && lhs.dst < rhs.dst);
-    });
-    for (auto& edge : compiled_edges) {
-        std::sort(edge.reasons.begin(), edge.reasons.end());
-    }
-
-    std::vector<uint32_t> indegree(passes.size(), 0);
-    for (const auto& edge : compiled_edges) {
-        ++indegree[edge.dst];
-    }
-    std::vector<bool> scheduled(passes.size(), false);
-    while (execution_order.size() < passes.size()) {
-        uint32_t next = PassHandle::InvalidIndex;
-        for (uint32_t pass_index = 0; pass_index < passes.size(); ++pass_index) {
-            if (!scheduled[pass_index] && indegree[pass_index] == 0) {
-                next = pass_index;
-                break;
-            }
-        }
-        if (next == PassHandle::InvalidIndex) {
-            return FailCompile("pass dependency cycle detected");
-        }
-        scheduled[next] = true;
-        execution_order.push_back(next);
-        for (const auto& edge : compiled_edges) {
-            if (edge.src == next) {
-                assert(indegree[edge.dst] > 0);
-                --indegree[edge.dst];
-            }
-        }
-    }
-
-    std::vector<uint32_t> execution_position(passes.size(), PassHandle::InvalidIndex);
-    for (uint32_t position = 0; position < execution_order.size(); ++position) {
-        execution_position[execution_order[position]] = position;
-    }
-    for (uint32_t pass_index = 0; pass_index < passes.size(); ++pass_index) {
-        const uint32_t position = execution_position[pass_index];
-        for (const auto& access : passes[pass_index].accesses) {
-            auto& resource = resources[access.resource.index];
-            resource.first_use = std::min(resource.first_use, position);
-            if (resource.last_use == PassHandle::InvalidIndex) {
-                resource.last_use = position;
-            } else {
-                resource.last_use = std::max(resource.last_use, position);
-            }
-        }
-    }
-    // An imported resource may be forwarded unchanged to a consumer outside
-    // the graph. That is a valid import/export boundary even when no graph pass
-    // touches it. Transients are already required to have a producer above.
-
-    compiled = true;
-    return true;
+    return RenderGraphCompiler(*this).Compile();
 }
 
 bool RenderGraph::Execute() {
@@ -382,8 +460,8 @@ bool RenderGraph::Execute() {
     }
     executed = true;
 
-    for (uint32_t position = 0; position < execution_order.size(); ++position) {
-        auto& pass = passes[execution_order[position]];
+    for (const PassHandle pass_handle : compiled_plan.execution_order) {
+        auto& pass = passes[pass_handle.index];
         assert(pass.execute);
         pass.execute();
     }
@@ -392,7 +470,8 @@ bool RenderGraph::Execute() {
 
 std::string RenderGraph::Dump() const {
     std::ostringstream stream;
-    stream << "graph='" << name << "' mode=serial barrier_owner=rhi_command_preprocess compiled="
+    stream << "graph='" << name
+           << "' frontend=typed-rdg mode=serial barrier_owner=rhi_command_preprocess compiled="
            << (compiled ? "true" : "false") << " executed=" << (executed ? "true" : "false")
            << " passes=" << passes.size() << " resources=" << resources.size();
     if (!compile_error.empty()) {
@@ -401,20 +480,32 @@ std::string RenderGraph::Dump() const {
     stream << '\n';
 
     stream << "passes:\n";
-    const bool has_complete_order = execution_order.size() == passes.size();
+    const bool has_execution_order = compiled_plan.execution_order.size() == passes.size();
     for (uint32_t item_index = 0; item_index < passes.size(); ++item_index) {
-        const uint32_t pass_index = has_complete_order ? execution_order[item_index] : item_index;
+        const uint32_t pass_index =
+            has_execution_order ? compiled_plan.execution_order[item_index].index : item_index;
         const auto& pass = passes[pass_index];
         stream << "  [" << item_index << "] " << pass.name << " declared=" << pass_index
-               << " scheduled=" << (has_complete_order ? "true" : "false")
+               << " scheduled=" << (has_execution_order ? "true" : "false")
                << " side_effect=" << (pass.side_effect ? "true" : "false") << " accesses=[";
         for (uint32_t access_index = 0; access_index < pass.accesses.size(); ++access_index) {
             const auto& access = pass.accesses[access_index];
             if (access_index != 0) {
                 stream << ", ";
             }
-            stream << ToString(static_cast<uint8_t>(access.mode)) << ':'
-                   << resources[access.resource.index].name << '(' << access.range << ')';
+            stream << ToString(access.mode) << ':';
+            if (IsValidResource(access.resource)) {
+                stream << resources[access.resource.index].name;
+            } else {
+                stream << "invalid";
+            }
+            stream << '(';
+            if (access.typed) {
+                AppendRange(stream, access.range);
+            } else {
+                stream << "legacy=" << access.legacy_range;
+            }
+            stream << ')';
         }
         stream << "]\n";
     }
@@ -423,8 +514,16 @@ std::string RenderGraph::Dump() const {
     for (uint32_t index = 0; index < resources.size(); ++index) {
         const auto& resource = resources[index];
         stream << "  [" << index << "] " << resource.name << " kind=" << ToString(resource.kind)
-               << " lifetime=" << (resource.imported ? "imported" : "transient")
-               << " first=";
+               << " lifetime=" << (resource.imported ? "imported" : "transient");
+        if (resource.kind == ResourceKind::Texture && resource.typed_desc) {
+            stream << " desc=[mips=" << resource.texture_desc.mip_count
+                   << " layers=" << resource.texture_desc.layer_count << " aspects=";
+            AppendTextureAspects(stream, resource.texture_desc.aspects);
+            stream << ']';
+        } else if (resource.kind == ResourceKind::Buffer && resource.typed_desc) {
+            stream << " desc=[bytes=" << resource.buffer_desc.byte_size << ']';
+        }
+        stream << " first=";
         if (resource.first_use == PassHandle::InvalidIndex) {
             stream << "unused";
         } else {
@@ -436,7 +535,12 @@ std::string RenderGraph::Dump() const {
         } else {
             stream << resource.last_use;
         }
-        stream << " exported=" << (resource.exported ? "true" : "false") << " aliases=[";
+        uint32_t version_count = 0;
+        if (index < compiled_plan.resources.size()) {
+            version_count = compiled_plan.resources[index].version_count;
+        }
+        stream << " versions=" << version_count << " exported=" << (resource.exported ? "true" : "false")
+               << " aliases=[";
         auto aliases = resource.aliases;
         std::sort(aliases.begin(), aliases.end());
         for (uint32_t alias_index = 0; alias_index < aliases.size(); ++alias_index) {
@@ -448,14 +552,49 @@ std::string RenderGraph::Dump() const {
         stream << "]\n";
     }
 
+    stream << "compiled_accesses:\n";
+    for (const auto& access : compiled_plan.accesses) {
+        stream << "  " << passes[access.pass.index].name << ' ' << ToString(access.mode) << ':'
+               << resources[access.resource.index].name << ' ';
+        AppendRange(stream, access.range);
+        stream << " version=";
+        AppendVersion(stream, access.input_version);
+        stream << "->";
+        AppendVersion(stream, access.output_version);
+        stream << '\n';
+    }
+
     stream << "edges:\n";
-    for (const auto& edge : compiled_edges) {
-        stream << "  " << passes[edge.src].name << " -> " << passes[edge.dst].name << " reasons=[";
+    for (const auto& edge : compiled_plan.edges) {
+        stream << "  " << passes[edge.src.index].name << " -> " << passes[edge.dst.index].name
+               << " reasons=[";
         for (uint32_t reason_index = 0; reason_index < edge.reasons.size(); ++reason_index) {
+            const auto& reason = edge.reasons[reason_index];
             if (reason_index != 0) {
                 stream << ", ";
             }
-            stream << edge.reasons[reason_index];
+            stream << ToString(reason.kind);
+            if (reason.resource.IsValid()) {
+                stream << ':' << resources[reason.resource.index].name << '@';
+                AppendRange(stream, reason.range);
+                stream << ' ';
+                AppendVersion(stream, reason.input_version);
+                stream << "->";
+                AppendVersion(stream, reason.output_version);
+            }
+        }
+        stream << "]\n";
+    }
+
+    stream << "dependency_waves:\n";
+    for (uint32_t wave_index = 0; wave_index < compiled_plan.dependency_waves.size(); ++wave_index) {
+        stream << "  [" << wave_index << "] [";
+        const auto& wave = compiled_plan.dependency_waves[wave_index];
+        for (uint32_t pass_index = 0; pass_index < wave.passes.size(); ++pass_index) {
+            if (pass_index != 0) {
+                stream << ", ";
+            }
+            stream << passes[wave.passes[pass_index].index].name;
         }
         stream << "]\n";
     }
@@ -463,10 +602,12 @@ std::string RenderGraph::Dump() const {
 }
 
 void RenderGraph::AddAccess(
-    uint32_t pass_index,
-    ResourceHandle resource,
-    AccessMode mode,
-    std::string_view range
+    uint32_t         pass_index,
+    ResourceHandle   resource,
+    AccessMode       mode,
+    ResourceRange    range,
+    bool             typed,
+    std::string_view legacy_range
 ) {
     if (!InvalidateCompile()) {
         return;
@@ -476,10 +617,20 @@ void RenderGraph::AddAccess(
         return;
     }
     if (!IsValidResource(resource)) {
-        declaration_errors.emplace_back("pass '" + passes[pass_index].name + "' declared an invalid resource");
+        declaration_errors.emplace_back(
+            "pass '" + passes[pass_index].name + "' declared an invalid resource"
+        );
         return;
     }
-    passes[pass_index].accesses.push_back(AccessDeclaration{resource, mode, std::string(range)});
+    if (range.kind != resources[resource.index].kind) {
+        declaration_errors.emplace_back(
+            "pass '" + passes[pass_index].name + "' used a typed handle with the wrong resource kind"
+        );
+        return;
+    }
+    passes[pass_index].accesses.push_back(
+        AccessDeclaration{resource, mode, range, std::string(legacy_range), typed}
+    );
 }
 
 void RenderGraph::AddDependency(uint32_t pass_index, PassHandle dependency) {
@@ -518,8 +669,7 @@ bool RenderGraph::InvalidateCompile() {
     }
     compiled = false;
     compile_error.clear();
-    execution_order.clear();
-    compiled_edges.clear();
+    compiled_plan.Clear();
     for (auto& resource : resources) {
         resource.first_use = PassHandle::InvalidIndex;
         resource.last_use  = PassHandle::InvalidIndex;

--- a/source/runtime/render/rendergraph/RenderGraph.h
+++ b/source/runtime/render/rendergraph/RenderGraph.h
@@ -11,26 +11,136 @@
 
 namespace Moer::Render {
 
+class RenderGraphCompiler;
+
 /**
- * Phase 8 serial RenderGraph.
+ * Serial frontend backed by a typed RDG compiler.
  *
- * The graph owns declaration, dependency validation, stable scheduling and
- * logical transient lifetimes only. It deliberately does not emit resource
- * barriers or mutate RHI tracked state: command reorder / backend preprocess
- * remains the single owner of real barriers.
+ * The compiler owns typed resource declarations, subresource-aware hazards,
+ * logical resource versions, stable dependency analysis and lifetimes. The
+ * existing RHI command preprocess remains the only owner of physical tracked
+ * state and barriers. Execute deliberately stays synchronous and serial until
+ * command recording has an independent ownership contract.
  */
 class RENDER_API RenderGraph {
 public:
+    static constexpr uint32_t RemainingTextureRange = std::numeric_limits<uint32_t>::max();
+    static constexpr uint64_t RemainingBufferRange  = std::numeric_limits<uint64_t>::max();
+    static constexpr uint32_t InvalidVersion        = std::numeric_limits<uint32_t>::max();
+
     enum class ResourceKind : uint8_t {
         Texture,
         Buffer,
         Token,
     };
 
+    enum class TextureAspect : uint8_t {
+        None    = 0,
+        Color   = 1 << 0,
+        Depth   = 1 << 1,
+        Stencil = 1 << 2,
+        All     = (1 << 0) | (1 << 1) | (1 << 2),
+    };
+
+    friend constexpr TextureAspect operator|(TextureAspect lhs, TextureAspect rhs) {
+        return static_cast<TextureAspect>(static_cast<uint8_t>(lhs) | static_cast<uint8_t>(rhs));
+    }
+
+    friend constexpr TextureAspect operator&(TextureAspect lhs, TextureAspect rhs) {
+        return static_cast<TextureAspect>(static_cast<uint8_t>(lhs) & static_cast<uint8_t>(rhs));
+    }
+
+    struct TextureDesc {
+        uint32_t      mip_count   = 1;
+        uint32_t      layer_count = 1;
+        TextureAspect aspects     = TextureAspect::Color;
+
+        friend bool operator==(const TextureDesc&, const TextureDesc&) = default;
+    };
+
+    struct BufferDesc {
+        uint64_t byte_size = 0;
+
+        friend bool operator==(const BufferDesc&, const BufferDesc&) = default;
+    };
+
+    struct TextureRange {
+        TextureAspect aspects     = TextureAspect::All;
+        uint32_t      mip_first   = 0;
+        uint32_t      mip_count   = RemainingTextureRange;
+        uint32_t      layer_first = 0;
+        uint32_t      layer_count = RemainingTextureRange;
+
+        [[nodiscard]] static constexpr TextureRange Whole() {
+            return {};
+        }
+
+        [[nodiscard]] static constexpr TextureRange Mips(uint32_t first, uint32_t count) {
+            TextureRange range{};
+            range.mip_first = first;
+            range.mip_count = count;
+            return range;
+        }
+
+        [[nodiscard]] static constexpr TextureRange Layers(uint32_t first, uint32_t count) {
+            TextureRange range{};
+            range.layer_first = first;
+            range.layer_count = count;
+            return range;
+        }
+
+        friend bool operator==(const TextureRange&, const TextureRange&) = default;
+    };
+
+    struct BufferRange {
+        uint64_t offset = 0;
+        uint64_t size   = RemainingBufferRange;
+
+        [[nodiscard]] static constexpr BufferRange Whole() {
+            return {};
+        }
+
+        friend bool operator==(const BufferRange&, const BufferRange&) = default;
+    };
+
+    struct ResourceRange {
+        ResourceKind kind = ResourceKind::Token;
+        TextureRange texture{};
+        BufferRange  buffer{};
+
+        [[nodiscard]] static constexpr ResourceRange Whole(ResourceKind kind) {
+            ResourceRange result{};
+            result.kind = kind;
+            return result;
+        }
+
+        [[nodiscard]] static constexpr ResourceRange Texture(TextureRange range = TextureRange::Whole()) {
+            ResourceRange result{};
+            result.kind    = ResourceKind::Texture;
+            result.texture = range;
+            return result;
+        }
+
+        [[nodiscard]] static constexpr ResourceRange Buffer(BufferRange range = BufferRange::Whole()) {
+            ResourceRange result{};
+            result.kind   = ResourceKind::Buffer;
+            result.buffer = range;
+            return result;
+        }
+
+        [[nodiscard]] static constexpr ResourceRange Token() {
+            ResourceRange result{};
+            result.kind = ResourceKind::Token;
+            return result;
+        }
+
+        friend bool operator==(const ResourceRange&, const ResourceRange&) = default;
+    };
+
     struct ResourceHandle {
         static constexpr uint32_t InvalidIndex = std::numeric_limits<uint32_t>::max();
 
-        uint32_t index = InvalidIndex;
+        uint32_t index    = InvalidIndex;
         uint64_t owner_id = 0;
 
         [[nodiscard]] bool IsValid() const {
@@ -42,10 +152,55 @@ public:
         }
     };
 
+    struct TextureHandle {
+        ResourceHandle resource{};
+
+        [[nodiscard]] bool IsValid() const {
+            return resource.IsValid();
+        }
+        [[nodiscard]] ResourceHandle Untyped() const {
+            return resource;
+        }
+
+        friend bool operator==(TextureHandle lhs, TextureHandle rhs) {
+            return lhs.resource == rhs.resource;
+        }
+    };
+
+    struct BufferHandle {
+        ResourceHandle resource{};
+
+        [[nodiscard]] bool IsValid() const {
+            return resource.IsValid();
+        }
+        [[nodiscard]] ResourceHandle Untyped() const {
+            return resource;
+        }
+
+        friend bool operator==(BufferHandle lhs, BufferHandle rhs) {
+            return lhs.resource == rhs.resource;
+        }
+    };
+
+    struct TokenHandle {
+        ResourceHandle resource{};
+
+        [[nodiscard]] bool IsValid() const {
+            return resource.IsValid();
+        }
+        [[nodiscard]] ResourceHandle Untyped() const {
+            return resource;
+        }
+
+        friend bool operator==(TokenHandle lhs, TokenHandle rhs) {
+            return lhs.resource == rhs.resource;
+        }
+    };
+
     struct PassHandle {
         static constexpr uint32_t InvalidIndex = std::numeric_limits<uint32_t>::max();
 
-        uint32_t index = InvalidIndex;
+        uint32_t index    = InvalidIndex;
         uint64_t owner_id = 0;
 
         [[nodiscard]] bool IsValid() const {
@@ -57,11 +212,99 @@ public:
         }
     };
 
+    enum class AccessMode : uint8_t {
+        Read,
+        Write,
+        ReadWrite,
+    };
+
+    enum class EdgeReasonKind : uint8_t {
+        Explicit,
+        ReadAfterWrite,
+        WriteAfterRead,
+        WriteAfterWrite,
+    };
+
+    struct CompiledAccess {
+        PassHandle     pass{};
+        ResourceHandle resource{};
+        AccessMode     mode = AccessMode::Read;
+        ResourceRange  range{};
+        uint32_t       input_version  = InvalidVersion;
+        uint32_t       output_version = InvalidVersion;
+    };
+
+    struct CompiledEdgeReason {
+        EdgeReasonKind kind = EdgeReasonKind::Explicit;
+        ResourceHandle resource{};
+        ResourceRange  range{};
+        uint32_t       input_version  = InvalidVersion;
+        uint32_t       output_version = InvalidVersion;
+
+        friend bool operator==(const CompiledEdgeReason&, const CompiledEdgeReason&) = default;
+    };
+
+    struct CompiledEdge {
+        PassHandle                      src{};
+        PassHandle                      dst{};
+        std::vector<CompiledEdgeReason> reasons{};
+    };
+
+    struct CompiledResource {
+        ResourceHandle resource{};
+        uint32_t       first_use     = PassHandle::InvalidIndex;
+        uint32_t       last_use      = PassHandle::InvalidIndex;
+        uint32_t       version_count = 0;
+        bool           imported      = false;
+        bool           exported      = false;
+    };
+
+    struct CompiledWave {
+        std::vector<PassHandle> passes{};
+    };
+
+    struct CompiledPlan {
+        /** Stable topological order of semantic dependencies. */
+        std::vector<PassHandle> topological_order{};
+        /** Current production order. It remains declaration-order and serial. */
+        std::vector<PassHandle> execution_order{};
+        /** RAW/WAR/WAW and explicit dependencies only, without fake serial edges. */
+        std::vector<CompiledEdge> edges{};
+        /** Atomic subresource/range accesses with logical input/output versions. */
+        std::vector<CompiledAccess>   accesses{};
+        std::vector<CompiledResource> resources{};
+        /** Dependency-only waves for diagnostics. They are not yet an execution schedule. */
+        std::vector<CompiledWave> dependency_waves{};
+
+        void Clear() {
+            topological_order.clear();
+            execution_order.clear();
+            edges.clear();
+            accesses.clear();
+            resources.clear();
+            dependency_waves.clear();
+        }
+    };
+
     class RENDER_API PassBuilder {
     public:
+        // Legacy whole-resource declarations remain available for compatibility.
         PassBuilder& Read(ResourceHandle resource, std::string_view range = "all");
         PassBuilder& Write(ResourceHandle resource, std::string_view range = "all");
         PassBuilder& ReadWrite(ResourceHandle resource, std::string_view range = "all");
+
+        PassBuilder& Read(TextureHandle resource, TextureRange range = TextureRange::Whole());
+        PassBuilder& Write(TextureHandle resource, TextureRange range = TextureRange::Whole());
+        PassBuilder& ReadWrite(TextureHandle resource, TextureRange range = TextureRange::Whole());
+
+        PassBuilder& Read(BufferHandle resource, BufferRange range = BufferRange::Whole());
+        PassBuilder& Write(BufferHandle resource, BufferRange range = BufferRange::Whole());
+        PassBuilder& ReadWrite(BufferHandle resource, BufferRange range = BufferRange::Whole());
+
+        PassBuilder& Read(TokenHandle resource);
+        PassBuilder& Write(TokenHandle resource);
+        PassBuilder& ReadWrite(TokenHandle resource);
+
         PassBuilder& DependsOn(PassHandle dependency);
         PassBuilder& SideEffect();
 
@@ -85,38 +328,36 @@ public:
     RenderGraph(RenderGraph&&)                 = delete;
     RenderGraph& operator=(RenderGraph&&)      = delete;
 
-    /**
-     * Imports a resource owned outside the graph. A non-null physical identity
-     * is de-duplicated, so multiple view/sampler names can alias one resource.
-     */
-    ResourceHandle Import(
-        std::string_view name,
-        ResourceKind    kind,
-        const void*     physical_identity = nullptr
-    );
+    /** Legacy import API. Prefer the typed imports below for new code. */
+    ResourceHandle Import(std::string_view name, ResourceKind kind, const void* physical_identity = nullptr);
 
-    /**
-     * Declares a logical transient lifetime. Phase 8 records first/last use
-     * only; physical allocation, release and alias reuse intentionally remain
-     * with the existing typed resource / GPU-completion ownership system.
-     */
-    ResourceHandle CreateTransient(
-        std::string_view name,
-        ResourceKind    kind
-    );
+    TextureHandle ImportTexture(std::string_view name, const void* physical_identity, TextureDesc desc);
+    BufferHandle  ImportBuffer(std::string_view name, const void* physical_identity, BufferDesc desc);
+    TokenHandle   ImportToken(std::string_view name, const void* physical_identity = nullptr);
+
+    /** Legacy transient API. Prefer the typed declarations below for new code. */
+    ResourceHandle CreateTransient(std::string_view name, ResourceKind kind);
+    TextureHandle  CreateTransientTexture(std::string_view name, TextureDesc desc);
+    BufferHandle   CreateTransientBuffer(std::string_view name, BufferDesc desc);
+    TokenHandle    CreateTransientToken(std::string_view name);
 
     void Export(ResourceHandle resource);
+    void Export(TextureHandle resource) {
+        Export(resource.Untyped());
+    }
+    void Export(BufferHandle resource) {
+        Export(resource.Untyped());
+    }
+    void Export(TokenHandle resource) {
+        Export(resource.Untyped());
+    }
 
-    PassHandle AddPass(
-        std::string_view name,
-        const SetupCallback& setup,
-        ExecuteCallback      execute
-    );
+    PassHandle AddPass(std::string_view name, const SetupCallback& setup, ExecuteCallback execute);
 
-    /** Returns false and stores a deterministic diagnostic when the graph is invalid. */
+    /** Compiles declarations without emitting barriers or recording RHI commands. */
     bool Compile();
 
-    /** Executes callbacks serially once in the compiled stable topological order. */
+    /** Executes callbacks synchronously and serially once in declaration order. */
     bool Execute();
 
     [[nodiscard]] bool IsCompiled() const {
@@ -127,48 +368,67 @@ public:
         return compile_error;
     }
 
-    /** Deterministic text dump of passes, accesses, edges and lifetimes. */
+    [[nodiscard]] const CompiledPlan& GetCompiledPlan() const {
+        return compiled_plan;
+    }
+
+    /** Deterministic text dump of passes, typed accesses, edges, versions and lifetimes. */
     [[nodiscard]] std::string Dump() const;
 
 private:
-    enum class AccessMode : uint8_t {
-        Read,
-        Write,
-        ReadWrite,
-    };
+    friend class RenderGraphCompiler;
 
     struct AccessDeclaration {
-        ResourceHandle resource;
+        ResourceHandle resource{};
         AccessMode     mode = AccessMode::Read;
-        std::string    range;
+        ResourceRange  range{};
+        std::string    legacy_range{};
+        bool           typed = false;
     };
 
     struct ResourceDeclaration {
-        std::string                name;
-        std::vector<std::string>   aliases;
-        ResourceKind               kind = ResourceKind::Token;
-        const void*                physical_identity = nullptr;
-        bool                       imported = false;
-        bool                       exported = false;
-        uint32_t                   first_use = PassHandle::InvalidIndex;
-        uint32_t                   last_use = PassHandle::InvalidIndex;
+        std::string              name{};
+        std::vector<std::string> aliases{};
+        ResourceKind             kind              = ResourceKind::Token;
+        const void*              physical_identity = nullptr;
+        TextureDesc              texture_desc{};
+        BufferDesc               buffer_desc{};
+        bool                     typed_desc = false;
+        bool                     imported   = false;
+        bool                     exported   = false;
+        uint32_t                 first_use  = PassHandle::InvalidIndex;
+        uint32_t                 last_use   = PassHandle::InvalidIndex;
     };
 
     struct PassDeclaration {
-        std::string                    name;
-        std::vector<AccessDeclaration> accesses;
-        std::vector<PassHandle>        explicit_dependencies;
-        ExecuteCallback                execute;
+        std::string                    name{};
+        std::vector<AccessDeclaration> accesses{};
+        std::vector<PassHandle>        explicit_dependencies{};
+        ExecuteCallback                execute{};
         bool                           side_effect = false;
     };
 
-    struct CompiledEdge {
-        uint32_t                 src = PassHandle::InvalidIndex;
-        uint32_t                 dst = PassHandle::InvalidIndex;
-        std::vector<std::string> reasons;
-    };
-
-    void AddAccess(uint32_t pass_index, ResourceHandle resource, AccessMode mode, std::string_view range);
+    ResourceHandle ImportInternal(
+        std::string_view   name,
+        ResourceKind       kind,
+        const void*        physical_identity,
+        const TextureDesc* texture_desc,
+        const BufferDesc*  buffer_desc
+    );
+    ResourceHandle CreateTransientInternal(
+        std::string_view   name,
+        ResourceKind       kind,
+        const TextureDesc* texture_desc,
+        const BufferDesc*  buffer_desc
+    );
+    void AddAccess(
+        uint32_t         pass_index,
+        ResourceHandle   resource,
+        AccessMode       mode,
+        ResourceRange    range,
+        bool             typed,
+        std::string_view legacy_range = {}
+    );
     void AddDependency(uint32_t pass_index, PassHandle dependency);
     void MarkSideEffect(uint32_t pass_index);
     bool InvalidateCompile();
@@ -177,13 +437,12 @@ private:
     [[nodiscard]] bool IsValidResource(ResourceHandle resource) const;
     [[nodiscard]] bool IsValidPass(PassHandle pass) const;
 
-    std::string                      name;
-    std::vector<ResourceDeclaration> resources;
-    std::vector<PassDeclaration>     passes;
-    std::vector<uint32_t>            execution_order;
-    std::vector<CompiledEdge>        compiled_edges;
-    std::vector<std::string>         declaration_errors;
-    std::string                      compile_error;
+    std::string                      name{};
+    std::vector<ResourceDeclaration> resources{};
+    std::vector<PassDeclaration>     passes{};
+    CompiledPlan                     compiled_plan{};
+    std::vector<std::string>         declaration_errors{};
+    std::string                      compile_error{};
     uint64_t                         graph_id = 0;
     bool                             compiled = false;
     bool                             executed = false;

--- a/source/runtime/render/rendergraph/RenderGraphCompiler.cpp
+++ b/source/runtime/render/rendergraph/RenderGraphCompiler.cpp
@@ -1,0 +1,614 @@
+#include "rendergraph/RenderGraphCompiler.h"
+
+#include <algorithm>
+#include <array>
+#include <cassert>
+#include <sstream>
+#include <tuple>
+
+namespace Moer::Render {
+
+namespace {
+
+using ResourceKind  = RenderGraph::ResourceKind;
+using TextureAspect = RenderGraph::TextureAspect;
+using ResourceRange = RenderGraph::ResourceRange;
+
+[[nodiscard]] constexpr uint8_t AspectMask(TextureAspect aspect) {
+    return static_cast<uint8_t>(aspect);
+}
+
+[[nodiscard]] bool HasAspect(TextureAspect mask, TextureAspect aspect) {
+    return (AspectMask(mask) & AspectMask(aspect)) != 0;
+}
+
+template<typename T>
+void SortUnique(std::vector<T>& values) {
+    std::sort(values.begin(), values.end());
+    values.erase(std::unique(values.begin(), values.end()), values.end());
+}
+
+[[nodiscard]] auto RangeSortKey(const ResourceRange& range) {
+    return std::tuple{
+        static_cast<uint8_t>(range.kind),
+        AspectMask(range.texture.aspects),
+        range.texture.mip_first,
+        range.texture.mip_count,
+        range.texture.layer_first,
+        range.texture.layer_count,
+        range.buffer.offset,
+        range.buffer.size
+    };
+}
+
+[[nodiscard]] bool
+ReasonLess(const RenderGraph::CompiledEdgeReason& lhs, const RenderGraph::CompiledEdgeReason& rhs) {
+    const auto lhs_key =
+        std::tuple{static_cast<uint8_t>(lhs.kind), lhs.resource.index, lhs.input_version, lhs.output_version};
+    const auto rhs_key =
+        std::tuple{static_cast<uint8_t>(rhs.kind), rhs.resource.index, rhs.input_version, rhs.output_version};
+    if (lhs_key != rhs_key) {
+        return lhs_key < rhs_key;
+    }
+    return RangeSortKey(lhs.range) < RangeSortKey(rhs.range);
+}
+
+[[nodiscard]] RenderGraph::AccessMode ToAccessMode(bool read, bool write) {
+    if (read && write) {
+        return RenderGraph::AccessMode::ReadWrite;
+    }
+    return write ? RenderGraph::AccessMode::Write : RenderGraph::AccessMode::Read;
+}
+
+} // namespace
+
+bool RenderGraphCompiler::Compile() {
+    graph.compiled = false;
+    graph.compile_error.clear();
+    graph.compiled_plan.Clear();
+    for (auto& resource : graph.resources) {
+        resource.first_use = RenderGraph::PassHandle::InvalidIndex;
+        resource.last_use  = RenderGraph::PassHandle::InvalidIndex;
+    }
+
+    if (!graph.declaration_errors.empty()) {
+        return Fail(graph.declaration_errors.front());
+    }
+    if (graph.passes.empty()) {
+        return Fail("graph contains no passes");
+    }
+
+    normalized_accesses.assign(graph.passes.size(), {});
+    resource_cells.assign(graph.resources.size(), {});
+    resource_version_counts.assign(graph.resources.size(), 0);
+    resource_ever_written.assign(graph.resources.size(), false);
+
+    if (!NormalizeDeclarations() || !BuildAtomicCells() || !BuildSemanticDependencies() ||
+        !BuildTopologicalOrder() || !BuildExecutionOrder()) {
+        return false;
+    }
+
+    BuildDependencyWaves();
+    BuildLifetimes();
+    graph.compiled = true;
+    return true;
+}
+
+bool RenderGraphCompiler::NormalizeDeclarations() {
+    for (uint32_t pass_index = 0; pass_index < graph.passes.size(); ++pass_index) {
+        const auto& pass = graph.passes[pass_index];
+        for (const auto& access : pass.accesses) {
+            if (!graph.IsValidResource(access.resource)) {
+                return Fail("pass '" + pass.name + "' references an invalid resource");
+            }
+            const auto&   resource = graph.resources[access.resource.index];
+            ResourceRange normalized{};
+            if (!NormalizeRange(resource, access, normalized)) {
+                return false;
+            }
+            normalized_accesses[pass_index].push_back(
+                NormalizedAccess{access.resource, access.mode, normalized}
+            );
+        }
+    }
+    return true;
+}
+
+bool RenderGraphCompiler::NormalizeRange(
+    const RenderGraph::ResourceDeclaration& resource,
+    const RenderGraph::AccessDeclaration&   access,
+    ResourceRange&                          normalized
+) {
+    if (access.range.kind != resource.kind) {
+        return Fail("resource range kind does not match resource '" + resource.name + "'");
+    }
+
+    normalized = access.range;
+    switch (resource.kind) {
+        case ResourceKind::Texture: {
+            const auto&   desc          = resource.texture_desc;
+            const uint8_t desc_aspects  = AspectMask(desc.aspects);
+            const uint8_t known_aspects = AspectMask(TextureAspect::All);
+            if (desc.mip_count == 0 || desc.layer_count == 0 || desc_aspects == 0 ||
+                (desc_aspects & known_aspects) != desc_aspects) {
+                return Fail("texture resource has an invalid descriptor: " + resource.name);
+            }
+
+            auto& range = normalized.texture;
+            if (range.aspects == TextureAspect::All) {
+                range.aspects = desc.aspects;
+            }
+            const uint8_t requested_aspects = AspectMask(range.aspects);
+            const uint8_t available_aspects = AspectMask(desc.aspects);
+            if (requested_aspects == 0 || (requested_aspects & available_aspects) != requested_aspects) {
+                return Fail("texture range requests unavailable aspects on resource '" + resource.name + "'");
+            }
+            if (range.mip_first >= desc.mip_count) {
+                return Fail("texture range starts beyond the mip count on resource '" + resource.name + "'");
+            }
+            if (range.mip_count == RenderGraph::RemainingTextureRange) {
+                range.mip_count = desc.mip_count - range.mip_first;
+            }
+            if (range.mip_count == 0 || range.mip_count > desc.mip_count - range.mip_first) {
+                return Fail("texture range exceeds the mip count on resource '" + resource.name + "'");
+            }
+            if (range.layer_first >= desc.layer_count) {
+                return Fail(
+                    "texture range starts beyond the layer count on resource '" + resource.name + "'"
+                );
+            }
+            if (range.layer_count == RenderGraph::RemainingTextureRange) {
+                range.layer_count = desc.layer_count - range.layer_first;
+            }
+            if (range.layer_count == 0 || range.layer_count > desc.layer_count - range.layer_first) {
+                return Fail("texture range exceeds the layer count on resource '" + resource.name + "'");
+            }
+            break;
+        }
+        case ResourceKind::Buffer: {
+            auto& range = normalized.buffer;
+            if (resource.buffer_desc.byte_size == 0) {
+                if (range.offset != 0 || range.size != RenderGraph::RemainingBufferRange) {
+                    return Fail("an explicitly ranged buffer requires a known byte size: " + resource.name);
+                }
+                break;
+            }
+            if (range.offset >= resource.buffer_desc.byte_size) {
+                return Fail("buffer range starts beyond the resource size on '" + resource.name + "'");
+            }
+            if (range.size == RenderGraph::RemainingBufferRange) {
+                range.size = resource.buffer_desc.byte_size - range.offset;
+            }
+            if (range.size == 0 || range.size > resource.buffer_desc.byte_size - range.offset) {
+                return Fail("buffer range exceeds the resource size on '" + resource.name + "'");
+            }
+            break;
+        }
+        case ResourceKind::Token:
+            normalized = ResourceRange::Token();
+            break;
+    }
+    return true;
+}
+
+bool RenderGraphCompiler::BuildAtomicCells() {
+    static constexpr std::array<TextureAspect, 3> texture_aspects{
+        TextureAspect::Color, TextureAspect::Depth, TextureAspect::Stencil
+    };
+
+    for (uint32_t resource_index = 0; resource_index < graph.resources.size(); ++resource_index) {
+        const auto& resource = graph.resources[resource_index];
+        auto&       cells    = resource_cells[resource_index];
+
+        if (resource.kind == ResourceKind::Texture) {
+            std::vector<uint32_t> mip_boundaries{0, resource.texture_desc.mip_count};
+            std::vector<uint32_t> layer_boundaries{0, resource.texture_desc.layer_count};
+            for (const auto& accesses : normalized_accesses) {
+                for (const auto& access : accesses) {
+                    if (access.resource.index != resource_index) {
+                        continue;
+                    }
+                    mip_boundaries.push_back(access.range.texture.mip_first);
+                    mip_boundaries.push_back(access.range.texture.mip_first + access.range.texture.mip_count);
+                    layer_boundaries.push_back(access.range.texture.layer_first);
+                    layer_boundaries.push_back(
+                        access.range.texture.layer_first + access.range.texture.layer_count
+                    );
+                }
+            }
+            SortUnique(mip_boundaries);
+            SortUnique(layer_boundaries);
+
+            for (TextureAspect aspect : texture_aspects) {
+                if (!HasAspect(resource.texture_desc.aspects, aspect)) {
+                    continue;
+                }
+                for (uint32_t mip_index = 0; mip_index + 1 < mip_boundaries.size(); ++mip_index) {
+                    for (uint32_t layer_index = 0; layer_index + 1 < layer_boundaries.size(); ++layer_index) {
+                        const uint32_t mip_first   = mip_boundaries[mip_index];
+                        const uint32_t mip_end     = mip_boundaries[mip_index + 1];
+                        const uint32_t layer_first = layer_boundaries[layer_index];
+                        const uint32_t layer_end   = layer_boundaries[layer_index + 1];
+                        if (mip_first == mip_end || layer_first == layer_end) {
+                            continue;
+                        }
+                        AtomicCell cell{};
+                        cell.range       = ResourceRange::Texture(RenderGraph::TextureRange{
+                                  .aspects     = aspect,
+                                  .mip_first   = mip_first,
+                                  .mip_count   = mip_end - mip_first,
+                                  .layer_first = layer_first,
+                                  .layer_count = layer_end - layer_first
+                        });
+                        cell.initialized = resource.imported;
+                        cell.version     = resource.imported ? 0 : RenderGraph::InvalidVersion;
+                        cells.push_back(std::move(cell));
+                    }
+                }
+            }
+        } else if (resource.kind == ResourceKind::Buffer && resource.buffer_desc.byte_size != 0) {
+            std::vector<uint64_t> boundaries{0, resource.buffer_desc.byte_size};
+            for (const auto& accesses : normalized_accesses) {
+                for (const auto& access : accesses) {
+                    if (access.resource.index != resource_index) {
+                        continue;
+                    }
+                    boundaries.push_back(access.range.buffer.offset);
+                    boundaries.push_back(access.range.buffer.offset + access.range.buffer.size);
+                }
+            }
+            SortUnique(boundaries);
+            for (uint32_t index = 0; index + 1 < boundaries.size(); ++index) {
+                if (boundaries[index] == boundaries[index + 1]) {
+                    continue;
+                }
+                AtomicCell cell{};
+                cell.range       = ResourceRange::Buffer(RenderGraph::BufferRange{
+                          .offset = boundaries[index], .size = boundaries[index + 1] - boundaries[index]
+                });
+                cell.initialized = resource.imported;
+                cell.version     = resource.imported ? 0 : RenderGraph::InvalidVersion;
+                cells.push_back(std::move(cell));
+            }
+        } else {
+            AtomicCell cell{};
+            cell.range       = ResourceRange::Whole(resource.kind);
+            cell.initialized = resource.imported;
+            cell.version     = resource.imported ? 0 : RenderGraph::InvalidVersion;
+            cells.push_back(std::move(cell));
+        }
+
+        if (cells.empty()) {
+            return Fail("resource produced no compiler intervals: " + resource.name);
+        }
+    }
+    return true;
+}
+
+bool RenderGraphCompiler::BuildSemanticDependencies() {
+    for (uint32_t pass_index = 0; pass_index < graph.passes.size(); ++pass_index) {
+        const auto& pass = graph.passes[pass_index];
+        for (const auto dependency : pass.explicit_dependencies) {
+            if (!graph.IsValidPass(dependency)) {
+                return Fail("pass '" + pass.name + "' has an invalid explicit dependency");
+            }
+            AddEdge(
+                dependency.index,
+                pass_index,
+                RenderGraph::CompiledEdgeReason{.kind = RenderGraph::EdgeReasonKind::Explicit}
+            );
+        }
+
+        std::vector<std::vector<CellUsage>> usages(graph.resources.size());
+        for (uint32_t resource_index = 0; resource_index < graph.resources.size(); ++resource_index) {
+            usages[resource_index].resize(resource_cells[resource_index].size());
+        }
+
+        for (const auto& access : normalized_accesses[pass_index]) {
+            auto&       resource_usages = usages[access.resource.index];
+            const auto& cells           = resource_cells[access.resource.index];
+            bool        matched         = false;
+            for (uint32_t cell_index = 0; cell_index < cells.size(); ++cell_index) {
+                if (!RangesOverlap(access.range, cells[cell_index].range)) {
+                    continue;
+                }
+                matched     = true;
+                auto& usage = resource_usages[cell_index];
+                usage.read |= access.mode == RenderGraph::AccessMode::Read ||
+                              access.mode == RenderGraph::AccessMode::ReadWrite;
+                usage.write |= access.mode == RenderGraph::AccessMode::Write ||
+                               access.mode == RenderGraph::AccessMode::ReadWrite;
+            }
+            if (!matched) {
+                return Fail("access range did not map to a compiler interval in pass '" + pass.name + "'");
+            }
+        }
+
+        for (uint32_t resource_index = 0; resource_index < graph.resources.size(); ++resource_index) {
+            auto&      resource_usages = usages[resource_index];
+            const bool writes_resource =
+                std::any_of(resource_usages.begin(), resource_usages.end(), [](const CellUsage& usage) {
+                    return usage.write;
+                });
+            const uint32_t output_version =
+                writes_resource ? ++resource_version_counts[resource_index] : RenderGraph::InvalidVersion;
+
+            for (uint32_t cell_index = 0; cell_index < resource_usages.size(); ++cell_index) {
+                const CellUsage usage = resource_usages[cell_index];
+                if (!usage.read && !usage.write) {
+                    continue;
+                }
+
+                auto&          cell            = resource_cells[resource_index][cell_index];
+                const uint32_t input_version   = cell.version;
+                const auto     resource_handle = RenderGraph::ResourceHandle{resource_index, graph.graph_id};
+
+                if (usage.read) {
+                    if (!cell.initialized) {
+                        return Fail(
+                            "transient resource '" + graph.resources[resource_index].name +
+                            "' is read before its first producer in pass '" + pass.name + "'"
+                        );
+                    }
+                    if (cell.last_writer != RenderGraph::PassHandle::InvalidIndex) {
+                        AddEdge(
+                            cell.last_writer,
+                            pass_index,
+                            RenderGraph::CompiledEdgeReason{
+                                .kind           = RenderGraph::EdgeReasonKind::ReadAfterWrite,
+                                .resource       = resource_handle,
+                                .range          = cell.range,
+                                .input_version  = cell.version,
+                                .output_version = cell.version
+                            }
+                        );
+                    }
+                }
+
+                if (usage.write) {
+                    if (cell.last_writer != RenderGraph::PassHandle::InvalidIndex) {
+                        AddEdge(
+                            cell.last_writer,
+                            pass_index,
+                            RenderGraph::CompiledEdgeReason{
+                                .kind           = RenderGraph::EdgeReasonKind::WriteAfterWrite,
+                                .resource       = resource_handle,
+                                .range          = cell.range,
+                                .input_version  = cell.version,
+                                .output_version = output_version
+                            }
+                        );
+                    }
+                    for (const uint32_t reader : cell.readers) {
+                        AddEdge(
+                            reader,
+                            pass_index,
+                            RenderGraph::CompiledEdgeReason{
+                                .kind           = RenderGraph::EdgeReasonKind::WriteAfterRead,
+                                .resource       = resource_handle,
+                                .range          = cell.range,
+                                .input_version  = cell.version,
+                                .output_version = output_version
+                            }
+                        );
+                    }
+                    cell.readers.clear();
+                    cell.last_writer                      = pass_index;
+                    cell.version                          = output_version;
+                    cell.initialized                      = true;
+                    resource_ever_written[resource_index] = true;
+                } else if (std::find(cell.readers.begin(), cell.readers.end(), pass_index) ==
+                           cell.readers.end()) {
+                    cell.readers.push_back(pass_index);
+                }
+
+                graph.compiled_plan.accesses.push_back(RenderGraph::CompiledAccess{
+                    .pass           = RenderGraph::PassHandle{pass_index, graph.graph_id},
+                    .resource       = resource_handle,
+                    .mode           = ToAccessMode(usage.read, usage.write),
+                    .range          = cell.range,
+                    .input_version  = input_version,
+                    .output_version = usage.write ? output_version : input_version
+                });
+            }
+        }
+    }
+
+    for (uint32_t resource_index = 0; resource_index < graph.resources.size(); ++resource_index) {
+        const auto& resource = graph.resources[resource_index];
+        if (!resource.imported && !resource_ever_written[resource_index]) {
+            return Fail("transient resource has no producer: " + resource.name);
+        }
+        if (!resource.imported && resource.exported) {
+            const bool fully_initialized = std::all_of(
+                resource_cells[resource_index].begin(),
+                resource_cells[resource_index].end(),
+                [](const AtomicCell& cell) {
+                    return cell.initialized;
+                }
+            );
+            if (!fully_initialized) {
+                return Fail("exported transient resource has uninitialized subresources: " + resource.name);
+            }
+        }
+    }
+    return true;
+}
+
+void RenderGraphCompiler::AddEdge(uint32_t src, uint32_t dst, RenderGraph::CompiledEdgeReason reason) {
+    if (src == dst || src == RenderGraph::PassHandle::InvalidIndex ||
+        dst == RenderGraph::PassHandle::InvalidIndex) {
+        return;
+    }
+
+    const auto src_handle = RenderGraph::PassHandle{src, graph.graph_id};
+    const auto dst_handle = RenderGraph::PassHandle{dst, graph.graph_id};
+    auto       edge       = std::find_if(
+        graph.compiled_plan.edges.begin(),
+        graph.compiled_plan.edges.end(),
+        [&](const RenderGraph::CompiledEdge& candidate) {
+            return candidate.src == src_handle && candidate.dst == dst_handle;
+        }
+    );
+    if (edge == graph.compiled_plan.edges.end()) {
+        graph.compiled_plan.edges.push_back(
+            RenderGraph::CompiledEdge{src_handle, dst_handle, {std::move(reason)}}
+        );
+        return;
+    }
+    if (std::find(edge->reasons.begin(), edge->reasons.end(), reason) == edge->reasons.end()) {
+        edge->reasons.push_back(std::move(reason));
+    }
+}
+
+bool RenderGraphCompiler::BuildTopologicalOrder() {
+    std::sort(
+        graph.compiled_plan.edges.begin(),
+        graph.compiled_plan.edges.end(),
+        [](const RenderGraph::CompiledEdge& lhs, const RenderGraph::CompiledEdge& rhs) {
+            return lhs.src.index < rhs.src.index ||
+                   (lhs.src.index == rhs.src.index && lhs.dst.index < rhs.dst.index);
+        }
+    );
+    for (auto& edge : graph.compiled_plan.edges) {
+        std::sort(edge.reasons.begin(), edge.reasons.end(), ReasonLess);
+    }
+
+    std::vector<uint32_t> indegree(graph.passes.size(), 0);
+    for (const auto& edge : graph.compiled_plan.edges) {
+        ++indegree[edge.dst.index];
+    }
+
+    std::vector<bool> scheduled(graph.passes.size(), false);
+    while (graph.compiled_plan.topological_order.size() < graph.passes.size()) {
+        uint32_t next = RenderGraph::PassHandle::InvalidIndex;
+        for (uint32_t pass_index = 0; pass_index < graph.passes.size(); ++pass_index) {
+            if (!scheduled[pass_index] && indegree[pass_index] == 0) {
+                next = pass_index;
+                break;
+            }
+        }
+        if (next == RenderGraph::PassHandle::InvalidIndex) {
+            return Fail("pass dependency cycle detected");
+        }
+        scheduled[next] = true;
+        graph.compiled_plan.topological_order.push_back(RenderGraph::PassHandle{next, graph.graph_id});
+        for (const auto& edge : graph.compiled_plan.edges) {
+            if (edge.src.index == next) {
+                assert(indegree[edge.dst.index] > 0);
+                --indegree[edge.dst.index];
+            }
+        }
+    }
+    return true;
+}
+
+bool RenderGraphCompiler::BuildExecutionOrder() {
+    graph.compiled_plan.execution_order.reserve(graph.passes.size());
+    for (uint32_t pass_index = 0; pass_index < graph.passes.size(); ++pass_index) {
+        graph.compiled_plan.execution_order.push_back(RenderGraph::PassHandle{pass_index, graph.graph_id});
+    }
+
+    for (const auto& edge : graph.compiled_plan.edges) {
+        if (edge.src.index >= edge.dst.index) {
+            return Fail("serial declaration order cannot satisfy a compiled dependency");
+        }
+    }
+    return true;
+}
+
+void RenderGraphCompiler::BuildDependencyWaves() {
+    std::vector<uint32_t> indegree(graph.passes.size(), 0);
+    for (const auto& edge : graph.compiled_plan.edges) {
+        ++indegree[edge.dst.index];
+    }
+
+    std::vector<bool> scheduled(graph.passes.size(), false);
+    uint32_t          scheduled_count = 0;
+    while (scheduled_count < graph.passes.size()) {
+        RenderGraph::CompiledWave wave{};
+        for (uint32_t pass_index = 0; pass_index < graph.passes.size(); ++pass_index) {
+            if (!scheduled[pass_index] && indegree[pass_index] == 0) {
+                wave.passes.push_back(RenderGraph::PassHandle{pass_index, graph.graph_id});
+            }
+        }
+        assert(!wave.passes.empty());
+        for (const auto pass : wave.passes) {
+            scheduled[pass.index] = true;
+            ++scheduled_count;
+        }
+        for (const auto pass : wave.passes) {
+            for (const auto& edge : graph.compiled_plan.edges) {
+                if (edge.src == pass && !scheduled[edge.dst.index]) {
+                    assert(indegree[edge.dst.index] > 0);
+                    --indegree[edge.dst.index];
+                }
+            }
+        }
+        graph.compiled_plan.dependency_waves.push_back(std::move(wave));
+    }
+}
+
+void RenderGraphCompiler::BuildLifetimes() {
+    std::vector<uint32_t> execution_position(graph.passes.size(), RenderGraph::PassHandle::InvalidIndex);
+    for (uint32_t position = 0; position < graph.compiled_plan.execution_order.size(); ++position) {
+        execution_position[graph.compiled_plan.execution_order[position].index] = position;
+    }
+
+    for (const auto& access : graph.compiled_plan.accesses) {
+        auto&          resource = graph.resources[access.resource.index];
+        const uint32_t position = execution_position[access.pass.index];
+        resource.first_use      = std::min(resource.first_use, position);
+        resource.last_use       = resource.last_use == RenderGraph::PassHandle::InvalidIndex ?
+                                      position :
+                                      std::max(resource.last_use, position);
+    }
+
+    graph.compiled_plan.resources.reserve(graph.resources.size());
+    for (uint32_t resource_index = 0; resource_index < graph.resources.size(); ++resource_index) {
+        const auto& resource = graph.resources[resource_index];
+        graph.compiled_plan.resources.push_back(RenderGraph::CompiledResource{
+            .resource      = RenderGraph::ResourceHandle{resource_index, graph.graph_id},
+            .first_use     = resource.first_use,
+            .last_use      = resource.last_use,
+            .version_count = resource_version_counts[resource_index],
+            .imported      = resource.imported,
+            .exported      = resource.exported
+        });
+    }
+}
+
+bool RenderGraphCompiler::RangesOverlap(const ResourceRange& lhs, const ResourceRange& rhs) {
+    if (lhs.kind != rhs.kind) {
+        return false;
+    }
+    switch (lhs.kind) {
+        case ResourceKind::Texture: {
+            if ((AspectMask(lhs.texture.aspects) & AspectMask(rhs.texture.aspects)) == 0) {
+                return false;
+            }
+            const uint32_t lhs_mip_end   = lhs.texture.mip_first + lhs.texture.mip_count;
+            const uint32_t rhs_mip_end   = rhs.texture.mip_first + rhs.texture.mip_count;
+            const uint32_t lhs_layer_end = lhs.texture.layer_first + lhs.texture.layer_count;
+            const uint32_t rhs_layer_end = rhs.texture.layer_first + rhs.texture.layer_count;
+            return lhs.texture.mip_first < rhs_mip_end && rhs.texture.mip_first < lhs_mip_end &&
+                   lhs.texture.layer_first < rhs_layer_end && rhs.texture.layer_first < lhs_layer_end;
+        }
+        case ResourceKind::Buffer:
+            if (lhs.buffer.size == RenderGraph::RemainingBufferRange ||
+                rhs.buffer.size == RenderGraph::RemainingBufferRange) {
+                return true;
+            }
+            return lhs.buffer.offset < rhs.buffer.offset + rhs.buffer.size &&
+                   rhs.buffer.offset < lhs.buffer.offset + lhs.buffer.size;
+        case ResourceKind::Token:
+            return true;
+    }
+    return false;
+}
+
+bool RenderGraphCompiler::Fail(std::string message) {
+    return graph.FailCompile(std::move(message));
+}
+
+} // namespace Moer::Render

--- a/source/runtime/render/rendergraph/RenderGraphCompiler.h
+++ b/source/runtime/render/rendergraph/RenderGraphCompiler.h
@@ -1,0 +1,63 @@
+#pragma once
+
+#include "rendergraph/RenderGraph.h"
+
+#include <string>
+#include <vector>
+
+namespace Moer::Render {
+
+/** Internal compiler for RenderGraph declarations. */
+class RenderGraphCompiler {
+public:
+    explicit RenderGraphCompiler(RenderGraph& graph) : graph(graph) {}
+
+    bool Compile();
+
+private:
+    struct NormalizedAccess {
+        RenderGraph::ResourceHandle resource{};
+        RenderGraph::AccessMode     mode = RenderGraph::AccessMode::Read;
+        RenderGraph::ResourceRange  range{};
+    };
+
+    struct AtomicCell {
+        RenderGraph::ResourceRange range{};
+        std::vector<uint32_t>      readers{};
+        uint32_t                   last_writer = RenderGraph::PassHandle::InvalidIndex;
+        uint32_t                   version     = RenderGraph::InvalidVersion;
+        bool                       initialized = false;
+    };
+
+    struct CellUsage {
+        bool read  = false;
+        bool write = false;
+    };
+
+    bool NormalizeDeclarations();
+    bool BuildAtomicCells();
+    bool BuildSemanticDependencies();
+    bool BuildTopologicalOrder();
+    bool BuildExecutionOrder();
+    void BuildDependencyWaves();
+    void BuildLifetimes();
+
+    bool NormalizeRange(
+        const RenderGraph::ResourceDeclaration& resource,
+        const RenderGraph::AccessDeclaration&   access,
+        RenderGraph::ResourceRange&             normalized
+    );
+    void AddEdge(uint32_t src, uint32_t dst, RenderGraph::CompiledEdgeReason reason);
+    bool Fail(std::string message);
+
+    [[nodiscard]] static bool
+    RangesOverlap(const RenderGraph::ResourceRange& lhs, const RenderGraph::ResourceRange& rhs);
+
+    RenderGraph&                               graph;
+    std::vector<std::vector<NormalizedAccess>> normalized_accesses{};
+    std::vector<std::vector<AtomicCell>>       resource_cells{};
+    std::vector<uint32_t>                      resource_version_counts{};
+    std::vector<bool>                          resource_ever_written{};
+};
+
+} // namespace Moer::Render

--- a/source/test/CMakeLists.txt
+++ b/source/test/CMakeLists.txt
@@ -24,6 +24,7 @@ target_link_libraries(${test_target}
     PRIVATE Moer::Render
 )
 set_target_properties(${test_target} PROPERTIES FOLDER ${moer_test_folder})
+add_test(NAME RenderGraphContract COMMAND $<TARGET_FILE:${test_target}>)
 
 set(test_target TestRHICmdReorderer)
 add_executable(${test_target} "RHICmdReordererTest.cpp")

--- a/source/test/RenderGraphTest.cpp
+++ b/source/test/RenderGraphTest.cpp
@@ -1,5 +1,6 @@
 #include "rendergraph/RenderGraph.h"
 
+#include <algorithm>
 #include <cstdlib>
 #include <iostream>
 #include <string>
@@ -32,20 +33,62 @@ private:
     return text.find(fragment) != std::string_view::npos;
 }
 
+[[nodiscard]] bool HasEdgeReason(
+    const RenderGraph::CompiledPlan& plan,
+    RenderGraph::PassHandle          src,
+    RenderGraph::PassHandle          dst,
+    RenderGraph::EdgeReasonKind      kind,
+    RenderGraph::ResourceHandle      resource = {}
+) {
+    for (const auto& edge : plan.edges) {
+        if (edge.src != src || edge.dst != dst) {
+            continue;
+        }
+        for (const auto& reason : edge.reasons) {
+            if (reason.kind == kind && (!resource.IsValid() || reason.resource == resource)) {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
+[[nodiscard]] bool WaveContains(const RenderGraph::CompiledWave& wave, RenderGraph::PassHandle pass) {
+    return std::find(wave.passes.begin(), wave.passes.end(), pass) != wave.passes.end();
+}
+
 void TestStableSerialCallbackOrder(TestSuite& suite) {
     constexpr std::string_view test_name = "stable serial callback order";
     RenderGraph                graph("StableSerial");
     std::vector<int>           callback_order;
 
-    graph.AddPass("First", [](RenderGraph::PassBuilder& builder) { builder.SideEffect(); }, [&] {
-        callback_order.push_back(1);
-    });
-    graph.AddPass("Second", [](RenderGraph::PassBuilder& builder) { builder.SideEffect(); }, [&] {
-        callback_order.push_back(2);
-    });
-    graph.AddPass("Third", [](RenderGraph::PassBuilder& builder) { builder.SideEffect(); }, [&] {
-        callback_order.push_back(3);
-    });
+    graph.AddPass(
+        "First",
+        [](RenderGraph::PassBuilder& builder) {
+            builder.SideEffect();
+        },
+        [&] {
+            callback_order.push_back(1);
+        }
+    );
+    graph.AddPass(
+        "Second",
+        [](RenderGraph::PassBuilder& builder) {
+            builder.SideEffect();
+        },
+        [&] {
+            callback_order.push_back(2);
+        }
+    );
+    graph.AddPass(
+        "Third",
+        [](RenderGraph::PassBuilder& builder) {
+            builder.SideEffect();
+        },
+        [&] {
+            callback_order.push_back(3);
+        }
+    );
 
     const bool compiled = graph.Compile();
     suite.Check(compiled, test_name, graph.GetCompileError());
@@ -63,21 +106,21 @@ void TestImportedAliasIdentityAndDump(TestSuite& suite) {
     RenderGraph                graph("AliasIdentity");
     int                        physical_resource = 0;
 
-    const auto texture = graph.Import(
-        "SceneColor",
-        RenderGraph::ResourceKind::Texture,
-        &physical_resource
+    const auto texture = graph.ImportTexture(
+        "SceneColor", &physical_resource, RenderGraph::TextureDesc{.mip_count = 4, .layer_count = 1}
     );
-    const auto texture_view = graph.Import(
-        "SceneColorView",
-        RenderGraph::ResourceKind::Texture,
-        &physical_resource
+    const auto texture_view = graph.ImportTexture(
+        "SceneColorView", &physical_resource, RenderGraph::TextureDesc{.mip_count = 4, .layer_count = 1}
     );
-    suite.Check(texture == texture_view, test_name, "aliases of one physical identity must return one handle");
+    suite.Check(
+        texture == texture_view, test_name, "aliases of one physical identity must return one handle"
+    );
 
     graph.AddPass(
         "ReadSceneColor",
-        [texture_view](RenderGraph::PassBuilder& builder) { builder.Read(texture_view); },
+        [texture_view](RenderGraph::PassBuilder& builder) {
+            builder.Read(texture_view);
+        },
         [] {}
     );
     const bool compiled = graph.Compile();
@@ -94,21 +137,27 @@ void TestImportedAliasIdentityAndDump(TestSuite& suite) {
 [[nodiscard]] std::string BuildHazardDump(TestSuite& suite, std::string_view test_name) {
     RenderGraph graph("Hazards");
     int         physical_buffer = 0;
-    const auto  shared = graph.Import("Shared", RenderGraph::ResourceKind::Buffer, &physical_buffer);
+    const auto  shared          = graph.Import("Shared", RenderGraph::ResourceKind::Buffer, &physical_buffer);
 
     graph.AddPass(
         "Produce",
-        [shared](RenderGraph::PassBuilder& builder) { builder.Write(shared); },
+        [shared](RenderGraph::PassBuilder& builder) {
+            builder.Write(shared);
+        },
         [] {}
     );
     graph.AddPass(
         "Consume",
-        [shared](RenderGraph::PassBuilder& builder) { builder.Read(shared); },
+        [shared](RenderGraph::PassBuilder& builder) {
+            builder.Read(shared);
+        },
         [] {}
     );
     graph.AddPass(
         "Overwrite",
-        [shared](RenderGraph::PassBuilder& builder) { builder.Write(shared); },
+        [shared](RenderGraph::PassBuilder& builder) {
+            builder.Write(shared);
+        },
         [] {}
     );
 
@@ -118,23 +167,25 @@ void TestImportedAliasIdentityAndDump(TestSuite& suite) {
 }
 
 void TestHazardsAndDeterministicDump(TestSuite& suite) {
-    constexpr std::string_view test_name = "hazards and deterministic dump";
-    const std::string          first_dump = BuildHazardDump(suite, test_name);
+    constexpr std::string_view test_name   = "hazards and deterministic dump";
+    const std::string          first_dump  = BuildHazardDump(suite, test_name);
     const std::string          second_dump = BuildHazardDump(suite, test_name);
 
-    suite.Check(first_dump == second_dump, test_name, "equivalent graph declarations must produce identical dumps");
     suite.Check(
-        Contains(first_dump, "Produce -> Consume reasons=[RAW:Shared, serial]"),
+        first_dump == second_dump, test_name, "equivalent graph declarations must produce identical dumps"
+    );
+    suite.Check(
+        Contains(first_dump, "Produce -> Consume reasons=[RAW:Shared@"),
         test_name,
         "dump must report the RAW dependency"
     );
     suite.Check(
-        Contains(first_dump, "Consume -> Overwrite reasons=[WAR:Shared, serial]"),
+        Contains(first_dump, "Consume -> Overwrite reasons=[WAR:Shared@"),
         test_name,
         "dump must report the WAR dependency"
     );
     suite.Check(
-        Contains(first_dump, "Produce -> Overwrite reasons=[WAW:Shared]"),
+        Contains(first_dump, "Produce -> Overwrite reasons=[WAW:Shared@"),
         test_name,
         "dump must report the WAW dependency"
     );
@@ -143,16 +194,22 @@ void TestHazardsAndDeterministicDump(TestSuite& suite) {
 void TestTransientReadBeforeProducerFailsWithoutCallbacks(TestSuite& suite) {
     constexpr std::string_view test_name = "transient first read rejection";
     RenderGraph                graph("TransientFirstRead");
-    const auto transient = graph.CreateTransient("Scratch", RenderGraph::ResourceKind::Texture);
+    const auto transient      = graph.CreateTransient("Scratch", RenderGraph::ResourceKind::Texture);
     int        callback_count = 0;
 
     graph.AddPass(
         "InvalidRead",
-        [transient](RenderGraph::PassBuilder& builder) { builder.Read(transient); },
-        [&] { ++callback_count; }
+        [transient](RenderGraph::PassBuilder& builder) {
+            builder.Read(transient);
+        },
+        [&] {
+            ++callback_count;
+        }
     );
 
-    suite.Check(!graph.Compile(), test_name, "Compile must reject a transient read before its first producer");
+    suite.Check(
+        !graph.Compile(), test_name, "Compile must reject a transient read before its first producer"
+    );
     suite.Check(
         Contains(graph.GetCompileError(), "read before its first producer"),
         test_name,
@@ -171,28 +228,42 @@ void TestCrossGraphHandlesAreRejected(TestSuite& suite) {
     int         resource_callback_count = 0;
     consumer_graph.AddPass(
         "InvalidResourceUser",
-        [foreign_resource](RenderGraph::PassBuilder& builder) { builder.Read(foreign_resource); },
-        [&] { ++resource_callback_count; }
+        [foreign_resource](RenderGraph::PassBuilder& builder) {
+            builder.Read(foreign_resource);
+        },
+        [&] {
+            ++resource_callback_count;
+        }
     );
-    suite.Check(!consumer_graph.Compile(), resource_test_name, "Compile must reject a foreign resource handle");
+    suite.Check(
+        !consumer_graph.Compile(), resource_test_name, "Compile must reject a foreign resource handle"
+    );
     suite.Check(
         Contains(consumer_graph.GetCompileError(), "invalid resource"),
         resource_test_name,
         "foreign resource rejection must be diagnosed"
     );
-    suite.Check(!consumer_graph.Execute(), resource_test_name, "a graph with a foreign resource must not execute");
-    suite.Check(resource_callback_count == 0, resource_test_name, "foreign resource graph must run zero callbacks");
+    suite.Check(
+        !consumer_graph.Execute(), resource_test_name, "a graph with a foreign resource must not execute"
+    );
+    suite.Check(
+        resource_callback_count == 0, resource_test_name, "foreign resource graph must run zero callbacks"
+    );
 
     constexpr std::string_view pass_test_name = "cross-graph pass handle rejection";
     RenderGraph                pass_owner_graph("PassOwner");
-    const auto foreign_pass = pass_owner_graph.AddPass("ForeignPass", {}, [] {});
+    const auto                 foreign_pass = pass_owner_graph.AddPass("ForeignPass", {}, [] {});
 
     RenderGraph dependent_graph("PassConsumer");
     int         pass_callback_count = 0;
     dependent_graph.AddPass(
         "InvalidDependent",
-        [foreign_pass](RenderGraph::PassBuilder& builder) { builder.DependsOn(foreign_pass); },
-        [&] { ++pass_callback_count; }
+        [foreign_pass](RenderGraph::PassBuilder& builder) {
+            builder.DependsOn(foreign_pass);
+        },
+        [&] {
+            ++pass_callback_count;
+        }
     );
     suite.Check(!dependent_graph.Compile(), pass_test_name, "Compile must reject a foreign pass handle");
     suite.Check(
@@ -201,7 +272,9 @@ void TestCrossGraphHandlesAreRejected(TestSuite& suite) {
         pass_test_name,
         "foreign pass rejection must be diagnosed"
     );
-    suite.Check(!dependent_graph.Execute(), pass_test_name, "a graph with a foreign dependency must not execute");
+    suite.Check(
+        !dependent_graph.Execute(), pass_test_name, "a graph with a foreign dependency must not execute"
+    );
     suite.Check(pass_callback_count == 0, pass_test_name, "foreign pass graph must run zero callbacks");
 }
 
@@ -209,15 +282,23 @@ void TestCompileAndExecuteAreOneShot(TestSuite& suite) {
     constexpr std::string_view test_name = "Compile and Execute one-shot";
     RenderGraph                graph("OneShot");
     int                        callback_count = 0;
-    graph.AddPass("OnlyPass", {}, [&] { ++callback_count; });
+    graph.AddPass("OnlyPass", {}, [&] {
+        ++callback_count;
+    });
 
     suite.Check(graph.Compile(), test_name, graph.GetCompileError());
+    const size_t compiled_pass_count = graph.GetCompiledPlan().execution_order.size();
     suite.Check(graph.Execute(), test_name, graph.GetCompileError());
     suite.Check(callback_count == 1, test_name, "the first Execute must run the callback once");
     suite.Check(!graph.Execute(), test_name, "a second Execute must be rejected");
     suite.Check(callback_count == 1, test_name, "a rejected second Execute must not repeat the callback");
     suite.Check(!graph.Compile(), test_name, "Compile after execution must be rejected");
     suite.Check(callback_count == 1, test_name, "a rejected second Compile must not repeat the callback");
+    suite.Check(
+        graph.IsCompiled() && graph.GetCompiledPlan().execution_order.size() == compiled_pass_count,
+        test_name,
+        "a rejected post-execution Compile must preserve the valid executed plan for diagnostics"
+    );
 }
 
 void TestLifetimeAndExportDump(TestSuite& suite) {
@@ -228,15 +309,25 @@ void TestLifetimeAndExportDump(TestSuite& suite) {
 
     graph.AddPass(
         "CreateIntermediate",
-        [transient](RenderGraph::PassBuilder& builder) { builder.Write(transient); },
+        [transient](RenderGraph::PassBuilder& builder) {
+            builder.Write(transient);
+        },
         [] {}
     );
     graph.AddPass(
         "ReadIntermediate",
-        [transient](RenderGraph::PassBuilder& builder) { builder.Read(transient); },
+        [transient](RenderGraph::PassBuilder& builder) {
+            builder.Read(transient);
+        },
         [] {}
     );
-    graph.AddPass("UnrelatedTail", [](RenderGraph::PassBuilder& builder) { builder.SideEffect(); }, [] {});
+    graph.AddPass(
+        "UnrelatedTail",
+        [](RenderGraph::PassBuilder& builder) {
+            builder.SideEffect();
+        },
+        [] {}
+    );
 
     const bool compiled = graph.Compile();
     suite.Check(compiled, test_name, graph.GetCompileError());
@@ -244,7 +335,7 @@ void TestLifetimeAndExportDump(TestSuite& suite) {
     suite.Check(
         Contains(
             dump,
-            "Intermediate kind=texture lifetime=transient first=0 last=1 exported=true aliases=[]"
+            "Intermediate kind=texture lifetime=transient first=0 last=1 versions=1 exported=true aliases=[]"
         ),
         test_name,
         "dump must report the transient's first use, last use and export state"
@@ -255,15 +346,13 @@ void TestUntouchedImportedResourceCanBeExported(TestSuite& suite) {
     constexpr std::string_view test_name = "untouched imported export boundary";
     RenderGraph                graph("ImportedForwarding");
     int                        physical_output = 0;
-    const auto output = graph.Import(
-        "Output",
-        RenderGraph::ResourceKind::Texture,
-        &physical_output
-    );
+    const auto output = graph.Import("Output", RenderGraph::ResourceKind::Texture, &physical_output);
     graph.Export(output);
     graph.AddPass(
         "ExternalWindowWrite",
-        [](RenderGraph::PassBuilder& builder) { builder.SideEffect(); },
+        [](RenderGraph::PassBuilder& builder) {
+            builder.SideEffect();
+        },
         [] {}
     );
 
@@ -271,9 +360,537 @@ void TestUntouchedImportedResourceCanBeExported(TestSuite& suite) {
     suite.Check(compiled, test_name, graph.GetCompileError());
     const std::string dump = graph.Dump();
     suite.Check(
-        Contains(dump, "Output kind=texture lifetime=imported first=unused last=unused exported=true"),
+        Contains(
+            dump, "Output kind=texture lifetime=imported first=unused last=unused versions=0 exported=true"
+        ),
         test_name,
         "an imported resource must be exportable unchanged without a fake graph access"
+    );
+}
+
+void TestTypedTextureSubresourceHazards(TestSuite& suite) {
+    constexpr std::string_view test_name = "typed texture subresource hazards";
+    RenderGraph                graph("TextureSubresources");
+    int                        physical_texture = 0;
+    const auto                 texture          = graph.ImportTexture(
+        "MipChain", &physical_texture, RenderGraph::TextureDesc{.mip_count = 4, .layer_count = 2}
+    );
+
+    std::vector<int> callback_order;
+    const auto       write_mip0 = graph.AddPass(
+        "WriteMip0",
+        [texture](RenderGraph::PassBuilder& builder) {
+            builder.Write(texture, RenderGraph::TextureRange::Mips(0, 1));
+        },
+        [&] {
+            callback_order.push_back(0);
+        }
+    );
+    const auto write_mip1 = graph.AddPass(
+        "WriteMip1",
+        [texture](RenderGraph::PassBuilder& builder) {
+            builder.Write(texture, RenderGraph::TextureRange::Mips(1, 1));
+        },
+        [&] {
+            callback_order.push_back(1);
+        }
+    );
+    const auto read_mip0 = graph.AddPass(
+        "ReadMip0",
+        [texture](RenderGraph::PassBuilder& builder) {
+            builder.Read(texture, RenderGraph::TextureRange::Mips(0, 1));
+        },
+        [&] {
+            callback_order.push_back(2);
+        }
+    );
+
+    suite.Check(graph.Compile(), test_name, graph.GetCompileError());
+    const auto& plan = graph.GetCompiledPlan();
+    suite.Check(
+        !HasEdgeReason(
+            plan, write_mip0, write_mip1, RenderGraph::EdgeReasonKind::WriteAfterWrite, texture.Untyped()
+        ),
+        test_name,
+        "disjoint mips must not create a WAW dependency"
+    );
+    suite.Check(
+        HasEdgeReason(
+            plan, write_mip0, read_mip0, RenderGraph::EdgeReasonKind::ReadAfterWrite, texture.Untyped()
+        ),
+        test_name,
+        "an overlapping mip read must depend on its writer"
+    );
+    suite.Check(
+        !HasEdgeReason(
+            plan, write_mip1, read_mip0, RenderGraph::EdgeReasonKind::ReadAfterWrite, texture.Untyped()
+        ),
+        test_name,
+        "a read must not depend on a writer of another mip"
+    );
+    suite.Check(
+        plan.dependency_waves.size() == 2 && WaveContains(plan.dependency_waves[0], write_mip0) &&
+            WaveContains(plan.dependency_waves[0], write_mip1) &&
+            WaveContains(plan.dependency_waves[1], read_mip0),
+        test_name,
+        "dependency waves must expose independent mip writers without changing execution policy"
+    );
+    suite.Check(graph.Execute(), test_name, graph.GetCompileError());
+    suite.Check(
+        callback_order == std::vector<int>{0, 1, 2},
+        test_name,
+        "production callbacks must remain serial and declaration ordered"
+    );
+}
+
+void TestTypedTextureLayerAndAspectHazards(TestSuite& suite) {
+    constexpr std::string_view test_name = "typed texture layer and aspect hazards";
+    RenderGraph                graph("TextureLayersAndAspects");
+    int                        physical_texture = 0;
+    const auto                 texture          = graph.ImportTexture(
+        "DepthStencilArray",
+        &physical_texture,
+        RenderGraph::TextureDesc{
+                                     .mip_count   = 1,
+                                     .layer_count = 2,
+                                     .aspects = RenderGraph::TextureAspect::Depth | RenderGraph::TextureAspect::Stencil
+        }
+    );
+
+    auto make_range = [](RenderGraph::TextureAspect aspect, uint32_t layer) {
+        auto range    = RenderGraph::TextureRange::Layers(layer, 1);
+        range.aspects = aspect;
+        return range;
+    };
+    const auto depth_layer0   = make_range(RenderGraph::TextureAspect::Depth, 0);
+    const auto depth_layer1   = make_range(RenderGraph::TextureAspect::Depth, 1);
+    const auto stencil_layer0 = make_range(RenderGraph::TextureAspect::Stencil, 0);
+
+    const auto write_depth_layer0 = graph.AddPass(
+        "WriteDepthLayer0",
+        [texture, depth_layer0](RenderGraph::PassBuilder& builder) {
+            builder.Write(texture, depth_layer0);
+        },
+        [] {}
+    );
+    const auto write_depth_layer1 = graph.AddPass(
+        "WriteDepthLayer1",
+        [texture, depth_layer1](RenderGraph::PassBuilder& builder) {
+            builder.Write(texture, depth_layer1);
+        },
+        [] {}
+    );
+    const auto write_stencil_layer0 = graph.AddPass(
+        "WriteStencilLayer0",
+        [texture, stencil_layer0](RenderGraph::PassBuilder& builder) {
+            builder.Write(texture, stencil_layer0);
+        },
+        [] {}
+    );
+    const auto read_depth_layer0 = graph.AddPass(
+        "ReadDepthLayer0",
+        [texture, depth_layer0](RenderGraph::PassBuilder& builder) {
+            builder.Read(texture, depth_layer0);
+        },
+        [] {}
+    );
+
+    suite.Check(graph.Compile(), test_name, graph.GetCompileError());
+    const auto& plan = graph.GetCompiledPlan();
+    suite.Check(
+        !HasEdgeReason(
+            plan,
+            write_depth_layer0,
+            write_depth_layer1,
+            RenderGraph::EdgeReasonKind::WriteAfterWrite,
+            texture.Untyped()
+        ),
+        test_name,
+        "different array layers must remain independent"
+    );
+    suite.Check(
+        !HasEdgeReason(
+            plan,
+            write_depth_layer0,
+            write_stencil_layer0,
+            RenderGraph::EdgeReasonKind::WriteAfterWrite,
+            texture.Untyped()
+        ),
+        test_name,
+        "depth and stencil aspects must remain independent"
+    );
+    suite.Check(
+        HasEdgeReason(
+            plan,
+            write_depth_layer0,
+            read_depth_layer0,
+            RenderGraph::EdgeReasonKind::ReadAfterWrite,
+            texture.Untyped()
+        ) &&
+            !HasEdgeReason(
+                plan,
+                write_depth_layer1,
+                read_depth_layer0,
+                RenderGraph::EdgeReasonKind::ReadAfterWrite,
+                texture.Untyped()
+            ) &&
+            !HasEdgeReason(
+                plan,
+                write_stencil_layer0,
+                read_depth_layer0,
+                RenderGraph::EdgeReasonKind::ReadAfterWrite,
+                texture.Untyped()
+            ),
+        test_name,
+        "a read must depend only on the writer of its exact layer and aspect"
+    );
+}
+
+void TestTransientTextureInitializationIsPerSubresource(TestSuite& suite) {
+    constexpr std::string_view test_name = "transient texture subresource initialization";
+    RenderGraph                graph("TransientSubresources");
+    const auto                 texture = graph.CreateTransientTexture(
+        "TransientMipChain", RenderGraph::TextureDesc{.mip_count = 2, .layer_count = 1}
+    );
+    int callback_count = 0;
+
+    graph.AddPass(
+        "WriteMip0",
+        [texture](RenderGraph::PassBuilder& builder) {
+            builder.Write(texture, RenderGraph::TextureRange::Mips(0, 1));
+        },
+        [&] {
+            ++callback_count;
+        }
+    );
+    graph.AddPass(
+        "ReadUninitializedMip1",
+        [texture](RenderGraph::PassBuilder& builder) {
+            builder.Read(texture, RenderGraph::TextureRange::Mips(1, 1));
+        },
+        [&] {
+            ++callback_count;
+        }
+    );
+
+    suite.Check(!graph.Compile(), test_name, "reading an unwritten mip must be rejected");
+    suite.Check(
+        Contains(graph.GetCompileError(), "read before its first producer"),
+        test_name,
+        "subresource initialization failure must be diagnosed"
+    );
+    suite.Check(!graph.Execute(), test_name, "a rejected graph must not execute");
+    suite.Check(callback_count == 0, test_name, "a rejected graph must execute zero callbacks");
+}
+
+void TestExportedTransientRequiresWholeResourceInitialization(TestSuite& suite) {
+    constexpr std::string_view test_name = "exported transient whole-resource initialization";
+
+    RenderGraph partial_graph("PartialTransientExport");
+    const auto  partial_texture = partial_graph.CreateTransientTexture(
+        "PartialMipChain", RenderGraph::TextureDesc{.mip_count = 2, .layer_count = 1}
+    );
+    int partial_callback_count = 0;
+    partial_graph.AddPass(
+        "WriteMip0",
+        [partial_texture](RenderGraph::PassBuilder& builder) {
+            builder.Write(partial_texture, RenderGraph::TextureRange::Mips(0, 1));
+        },
+        [&] {
+            ++partial_callback_count;
+        }
+    );
+    partial_graph.Export(partial_texture);
+
+    suite.Check(
+        !partial_graph.Compile(), test_name, "a whole-resource export must reject an uninitialized mip"
+    );
+    suite.Check(
+        Contains(partial_graph.GetCompileError(), "uninitialized subresources"),
+        test_name,
+        "a partial transient export must have a precise diagnostic"
+    );
+    suite.Check(
+        !partial_graph.Execute(), test_name, "a graph with an invalid transient export must not execute"
+    );
+    suite.Check(
+        partial_callback_count == 0, test_name, "an invalid transient export must execute zero callbacks"
+    );
+
+    RenderGraph complete_graph("CompleteTransientExport");
+    const auto  complete_texture = complete_graph.CreateTransientTexture(
+        "CompleteMipChain", RenderGraph::TextureDesc{.mip_count = 2, .layer_count = 1}
+    );
+    complete_graph.AddPass(
+        "WriteWholeTexture",
+        [complete_texture](RenderGraph::PassBuilder& builder) {
+            builder.Write(complete_texture);
+        },
+        [] {}
+    );
+    complete_graph.Export(complete_texture);
+
+    suite.Check(complete_graph.Compile(), test_name, complete_graph.GetCompileError());
+    suite.Check(complete_graph.Execute(), test_name, complete_graph.GetCompileError());
+}
+
+void TestTypedBufferRangeHazards(TestSuite& suite) {
+    constexpr std::string_view test_name = "typed buffer range hazards";
+    RenderGraph                graph("BufferRanges");
+    int                        physical_buffer = 0;
+    const auto                 buffer =
+        graph.ImportBuffer("RangeBuffer", &physical_buffer, RenderGraph::BufferDesc{.byte_size = 256});
+
+    const auto write_head = graph.AddPass(
+        "WriteHead",
+        [buffer](RenderGraph::PassBuilder& builder) {
+            builder.Write(buffer, RenderGraph::BufferRange{.offset = 0, .size = 64});
+        },
+        [] {}
+    );
+    const auto read_adjacent = graph.AddPass(
+        "ReadAdjacent",
+        [buffer](RenderGraph::PassBuilder& builder) {
+            builder.Read(buffer, RenderGraph::BufferRange{.offset = 64, .size = 64});
+        },
+        [] {}
+    );
+    const auto read_overlap = graph.AddPass(
+        "ReadOverlap",
+        [buffer](RenderGraph::PassBuilder& builder) {
+            builder.Read(buffer, RenderGraph::BufferRange{.offset = 32, .size = 32});
+        },
+        [] {}
+    );
+    const auto overwrite_overlap = graph.AddPass(
+        "OverwriteOverlap",
+        [buffer](RenderGraph::PassBuilder& builder) {
+            builder.Write(buffer, RenderGraph::BufferRange{.offset = 32, .size = 16});
+        },
+        [] {}
+    );
+
+    suite.Check(graph.Compile(), test_name, graph.GetCompileError());
+    const auto& plan = graph.GetCompiledPlan();
+    suite.Check(
+        !HasEdgeReason(
+            plan, write_head, read_adjacent, RenderGraph::EdgeReasonKind::ReadAfterWrite, buffer.Untyped()
+        ),
+        test_name,
+        "adjacent non-overlapping byte ranges must not create a dependency"
+    );
+    suite.Check(
+        HasEdgeReason(
+            plan, write_head, read_overlap, RenderGraph::EdgeReasonKind::ReadAfterWrite, buffer.Untyped()
+        ),
+        test_name,
+        "overlapping buffer ranges must create RAW"
+    );
+    suite.Check(
+        HasEdgeReason(
+            plan,
+            read_overlap,
+            overwrite_overlap,
+            RenderGraph::EdgeReasonKind::WriteAfterRead,
+            buffer.Untyped()
+        ),
+        test_name,
+        "an overlapping writer must wait for the active reader"
+    );
+    suite.Check(
+        !HasEdgeReason(
+            plan,
+            read_adjacent,
+            overwrite_overlap,
+            RenderGraph::EdgeReasonKind::WriteAfterRead,
+            buffer.Untyped()
+        ),
+        test_name,
+        "a writer must not wait for a reader of a disjoint range"
+    );
+}
+
+void TestLogicalResourceVersions(TestSuite& suite) {
+    constexpr std::string_view test_name = "logical resource versions";
+    RenderGraph                graph("Versions");
+    const auto buffer = graph.CreateTransientBuffer("Scratch", RenderGraph::BufferDesc{.byte_size = 128});
+
+    const auto produce = graph.AddPass(
+        "Produce",
+        [buffer](RenderGraph::PassBuilder& builder) {
+            builder.Write(buffer);
+        },
+        [] {}
+    );
+    const auto consume = graph.AddPass(
+        "Consume",
+        [buffer](RenderGraph::PassBuilder& builder) {
+            builder.Read(buffer);
+        },
+        [] {}
+    );
+    const auto overwrite = graph.AddPass(
+        "Overwrite",
+        [buffer](RenderGraph::PassBuilder& builder) {
+            builder.Write(buffer);
+        },
+        [] {}
+    );
+
+    suite.Check(graph.Compile(), test_name, graph.GetCompileError());
+    const auto& plan        = graph.GetCompiledPlan();
+    auto        find_access = [&](RenderGraph::PassHandle pass) -> const RenderGraph::CompiledAccess* {
+        const auto found = std::find_if(
+            plan.accesses.begin(),
+            plan.accesses.end(),
+            [&](const RenderGraph::CompiledAccess& access) {
+                return access.pass == pass && access.resource == buffer.Untyped();
+            }
+        );
+        return found == plan.accesses.end() ? nullptr : &*found;
+    };
+    const auto* produce_access   = find_access(produce);
+    const auto* consume_access   = find_access(consume);
+    const auto* overwrite_access = find_access(overwrite);
+    suite.Check(
+        produce_access != nullptr && produce_access->input_version == RenderGraph::InvalidVersion &&
+            produce_access->output_version == 1,
+        test_name,
+        "the first transient write must produce version 1"
+    );
+    suite.Check(
+        consume_access != nullptr && consume_access->input_version == 1 &&
+            consume_access->output_version == 1,
+        test_name,
+        "a read must consume without advancing the version"
+    );
+    suite.Check(
+        overwrite_access != nullptr && overwrite_access->input_version == 1 &&
+            overwrite_access->output_version == 2,
+        test_name,
+        "the next write must advance the resource version"
+    );
+    suite.Check(
+        buffer.Untyped().index < plan.resources.size() &&
+            plan.resources[buffer.Untyped().index].version_count == 2,
+        test_name,
+        "compiled resource metadata must expose the final version count"
+    );
+}
+
+void TestInvalidTypedRangeIsRejected(TestSuite& suite) {
+    constexpr std::string_view test_name = "invalid typed range rejection";
+    RenderGraph                graph("InvalidRange");
+    int                        physical_texture = 0;
+    const auto                 texture          = graph.ImportTexture(
+        "TwoMips", &physical_texture, RenderGraph::TextureDesc{.mip_count = 2, .layer_count = 1}
+    );
+    int callback_count = 0;
+    graph.AddPass(
+        "OutOfBoundsRead",
+        [texture](RenderGraph::PassBuilder& builder) {
+            builder.Read(texture, RenderGraph::TextureRange::Mips(2, 1));
+        },
+        [&] {
+            ++callback_count;
+        }
+    );
+
+    suite.Check(!graph.Compile(), test_name, "out-of-bounds typed ranges must fail compile");
+    suite.Check(
+        Contains(graph.GetCompileError(), "beyond the mip count"),
+        test_name,
+        "invalid range rejection must identify the mip bound"
+    );
+    suite.Check(callback_count == 0, test_name, "compile failure must happen before callbacks");
+}
+
+void TestUnknownTextureAspectIsRejected(TestSuite& suite) {
+    constexpr std::string_view test_name = "unknown texture descriptor aspect";
+    RenderGraph                graph("UnknownTextureAspect");
+    constexpr auto             invalid_aspects = static_cast<RenderGraph::TextureAspect>(
+        static_cast<uint8_t>(RenderGraph::TextureAspect::Color) | uint8_t{0x80}
+    );
+    const auto texture = graph.CreateTransientTexture(
+        "InvalidTexture",
+        RenderGraph::TextureDesc{.mip_count = 1, .layer_count = 1, .aspects = invalid_aspects}
+    );
+
+    suite.Check(!texture.IsValid(), test_name, "an unknown aspect bit must reject the declaration");
+    suite.Check(!graph.Compile(), test_name, "a graph with an unknown texture aspect must not compile");
+    suite.Check(
+        Contains(graph.GetCompileError(), "descriptor is invalid"),
+        test_name,
+        "an unknown texture aspect must have a precise diagnostic"
+    );
+}
+
+void TestTypedAliasDescriptorMismatchIsRejected(TestSuite& suite) {
+    constexpr std::string_view test_name = "typed alias descriptor mismatch";
+    RenderGraph                graph("AliasDescriptorMismatch");
+    int                        physical_texture = 0;
+    const auto                 canonical        = graph.ImportTexture(
+        "Canonical", &physical_texture, RenderGraph::TextureDesc{.mip_count = 2, .layer_count = 1}
+    );
+    const auto invalid_alias = graph.ImportTexture(
+        "InvalidAlias", &physical_texture, RenderGraph::TextureDesc{.mip_count = 3, .layer_count = 1}
+    );
+    graph.AddPass(
+        "ReadCanonical",
+        [canonical](RenderGraph::PassBuilder& builder) {
+            builder.Read(canonical);
+        },
+        [] {}
+    );
+
+    suite.Check(!invalid_alias.IsValid(), test_name, "a mismatched alias import must return invalid");
+    suite.Check(!graph.Compile(), test_name, "a mismatched alias descriptor must reject the graph");
+    suite.Check(
+        Contains(graph.GetCompileError(), "different descriptor"),
+        test_name,
+        "alias descriptor mismatch must be diagnosed"
+    );
+}
+
+void TestMultipleReadersProduceAllWarEdges(TestSuite& suite) {
+    constexpr std::string_view test_name = "multiple reader WAR edges";
+    RenderGraph                graph("ReaderSet");
+    int                        physical_buffer = 0;
+    const auto                 buffer =
+        graph.ImportBuffer("Shared", &physical_buffer, RenderGraph::BufferDesc{.byte_size = 64});
+    const auto reader_a = graph.AddPass(
+        "ReaderA",
+        [buffer](RenderGraph::PassBuilder& builder) {
+            builder.Read(buffer);
+        },
+        [] {}
+    );
+    const auto reader_b = graph.AddPass(
+        "ReaderB",
+        [buffer](RenderGraph::PassBuilder& builder) {
+            builder.Read(buffer);
+        },
+        [] {}
+    );
+    const auto writer = graph.AddPass(
+        "Writer",
+        [buffer](RenderGraph::PassBuilder& builder) {
+            builder.Write(buffer);
+        },
+        [] {}
+    );
+
+    suite.Check(graph.Compile(), test_name, graph.GetCompileError());
+    const auto& plan = graph.GetCompiledPlan();
+    suite.Check(
+        HasEdgeReason(
+            plan, reader_a, writer, RenderGraph::EdgeReasonKind::WriteAfterRead, buffer.Untyped()
+        ) &&
+            HasEdgeReason(
+                plan, reader_b, writer, RenderGraph::EdgeReasonKind::WriteAfterRead, buffer.Untyped()
+            ),
+        test_name,
+        "a writer must depend on every active overlapping reader"
     );
 }
 
@@ -289,6 +906,16 @@ int main() {
     TestCompileAndExecuteAreOneShot(suite);
     TestLifetimeAndExportDump(suite);
     TestUntouchedImportedResourceCanBeExported(suite);
+    TestTypedTextureSubresourceHazards(suite);
+    TestTypedTextureLayerAndAspectHazards(suite);
+    TestTransientTextureInitializationIsPerSubresource(suite);
+    TestExportedTransientRequiresWholeResourceInitialization(suite);
+    TestTypedBufferRangeHazards(suite);
+    TestLogicalResourceVersions(suite);
+    TestInvalidTypedRangeIsRejected(suite);
+    TestUnknownTextureAspectIsRejected(suite);
+    TestTypedAliasDescriptorMismatchIsRejected(suite);
+    TestMultipleReadersProduceAllWarEdges(suite);
 
     if (suite.FailureCount() != 0) {
         std::cerr << "TestRenderGraph: " << suite.FailureCount() << " failure(s)\n";


### PR DESCRIPTION
## Summary

Introduce the first stage of the modern RDG compiler on top of main's serial Raster RenderGraph.

- add graph-owned typed Texture/Buffer/Token handles with cross-graph validation
- add typed texture aspect/mip/layer ranges and buffer byte ranges
- compile finest resource intervals with RAW/WAR/WAW dependencies and complete reader tracking
- emit logical resource versions, stable topological order, diagnostic dependency waves, serial execution order, and lifetimes
- preserve physical-identity alias canonicalization and validate typed alias descriptors
- migrate Raster physical textures/buffers to typed declarations while retaining aggregate Tokens
- keep synchronous declaration-order execution, the existing RHI command preprocess as the sole barrier owner, and the linear fallback

## Why

The parallel RHI branch contains useful modern RDG ideas, but its barrier, persistent-state, resource-pool, queue, descriptor, and async-recording contracts are coupled to that branch. This PR absorbs the compiler foundation independently without changing main's RHI ownership or command-recording model.

## Safety boundary

This stage intentionally does **not** add physical transient allocation/aliasing, pass culling, barrier generation, queue scheduling, or parallel command recording.

## Validation

- independent pre-merge audits: no remaining P0/P1
- Debug: `MoerEditor` and `TestRenderGraph` build successfully
- Debug/Release: `RenderGraphContract` CTest passes (18 focused scenarios)
- threaded runtime lifecycle: Raster reload and Raster → Raytracing → Raster pass with RT/RHI threading enabled, exit 0, no RenderGraph fallback
- `git diff --check` and clang-format checks pass

Base: `main@289fa148`
Head: `2c0c7afa`