### PR TITLE
feat(rendergraph): add explicit resource state and multi-queue plan

### DIFF
--- a/source/runtime/render/rendergraph/RenderGraph.cpp
+++ b/source/runtime/render/rendergraph/RenderGraph.cpp
@@ -35,6 +35,10 @@ const char* ToString(RenderGraph::ResourceKind kind) {
 
 const char* ToString(RenderGraph::AccessMode mode) {
     switch (mode) {
+        case RenderGraph::AccessMode::Unknown:
+            return "unknown";
+        case RenderGraph::AccessMode::None:
+            return "none";
         case RenderGraph::AccessMode::Read:
             return "R";
         case RenderGraph::AccessMode::Write:
@@ -55,8 +59,114 @@ const char* ToString(RenderGraph::EdgeReasonKind kind) {
             return "WAR";
         case RenderGraph::EdgeReasonKind::WriteAfterWrite:
             return "WAW";
+        case RenderGraph::EdgeReasonKind::StateTransition:
+            return "state";
+        case RenderGraph::EdgeReasonKind::QueueOwnership:
+            return "ownership";
     }
     return "unknown";
+}
+
+const char* ToString(RenderGraph::QueueRole queue) {
+    switch (queue) {
+        case RenderGraph::QueueRole::None:
+            return "none";
+        case RenderGraph::QueueRole::Graphics:
+            return "graphics";
+        case RenderGraph::QueueRole::Compute:
+            return "compute";
+        case RenderGraph::QueueRole::Copy:
+            return "copy";
+    }
+    return "unknown";
+}
+
+const char* ToString(RenderGraph::PipelineType pipeline) {
+    switch (pipeline) {
+        case RenderGraph::PipelineType::None:
+            return "none";
+        case RenderGraph::PipelineType::Graphics:
+            return "graphics";
+        case RenderGraph::PipelineType::Compute:
+            return "compute";
+        case RenderGraph::PipelineType::RayTracing:
+            return "raytracing";
+        case RenderGraph::PipelineType::Copy:
+            return "copy";
+    }
+    return "unknown";
+}
+
+const char* ToString(RenderGraph::TextureState state) {
+    switch (state) {
+        case RenderGraph::TextureState::Automatic:
+            return "automatic";
+        case RenderGraph::TextureState::Undefined:
+            return "undefined";
+        case RenderGraph::TextureState::TransferSource:
+            return "transfer-src";
+        case RenderGraph::TextureState::TransferDestination:
+            return "transfer-dst";
+        case RenderGraph::TextureState::ShaderResource:
+            return "shader-resource";
+        case RenderGraph::TextureState::Sampled:
+            return "sampled";
+        case RenderGraph::TextureState::RenderTarget:
+            return "render-target";
+        case RenderGraph::TextureState::DepthStencilRead:
+            return "depth-read";
+        case RenderGraph::TextureState::DepthStencilWrite:
+            return "depth-write";
+        case RenderGraph::TextureState::UnorderedAccess:
+            return "unordered-access";
+        case RenderGraph::TextureState::Present:
+            return "present";
+    }
+    return "unknown";
+}
+
+const char* ToString(RenderGraph::BufferState state) {
+    switch (state) {
+        case RenderGraph::BufferState::Automatic:
+            return "automatic";
+        case RenderGraph::BufferState::Undefined:
+            return "undefined";
+        case RenderGraph::BufferState::TransferSource:
+            return "transfer-src";
+        case RenderGraph::BufferState::TransferDestination:
+            return "transfer-dst";
+        case RenderGraph::BufferState::VertexBuffer:
+            return "vertex-buffer";
+        case RenderGraph::BufferState::IndexBuffer:
+            return "index-buffer";
+        case RenderGraph::BufferState::IndirectArgument:
+            return "indirect-argument";
+        case RenderGraph::BufferState::ShaderResource:
+            return "shader-resource";
+        case RenderGraph::BufferState::UnorderedAccess:
+            return "unordered-access";
+        case RenderGraph::BufferState::AccelerationStructureBuildInput:
+            return "as-build-input";
+        case RenderGraph::BufferState::AccelerationStructureRead:
+            return "as-read";
+        case RenderGraph::BufferState::AccelerationStructureWrite:
+            return "as-write";
+    }
+    return "unknown";
+}
+
+void AppendState(std::ostringstream& stream, const RenderGraph::ResourceState& state) {
+    switch (state.kind) {
+        case RenderGraph::ResourceKind::Texture:
+            stream << ToString(state.texture);
+            break;
+        case RenderGraph::ResourceKind::Buffer:
+            stream << ToString(state.buffer);
+            break;
+        case RenderGraph::ResourceKind::Token:
+            stream << "logical";
+            break;
+    }
 }
 
 void AppendTextureAspects(std::ostringstream& stream, RenderGraph::TextureAspect aspects) {
@@ -121,7 +231,11 @@ void AppendVersion(std::ostringstream& stream, uint32_t version) {
 } // namespace
 
 RenderGraph::RenderGraph(std::string_view graph_name) :
+    RenderGraph(graph_name, QueueTopology::SingleQueue()) {}
+
+RenderGraph::RenderGraph(std::string_view graph_name, QueueTopology topology) :
     name(graph_name),
+    queue_topology(topology),
     graph_id(s_next_graph_id.fetch_add(1, std::memory_order_relaxed)) {
     assert(graph_id != 0 && "RenderGraph id counter wrapped.");
 }
@@ -133,7 +247,16 @@ RenderGraph::PassBuilder& RenderGraph::PassBuilder::Read(ResourceHandle resource
     if (graph.IsValidResource(resource)) {
         typed_range = ResourceRange::Whole(graph.resources[resource.index].kind);
     }
-    graph.AddAccess(pass_index, resource, AccessMode::Read, typed_range, false, range);
+    graph.AddAccess(
+        pass_index,
+        resource,
+        AccessMode::Read,
+        typed_range,
+        ResourceState{.kind = typed_range.kind},
+        false,
+        false,
+        range
+    );
     return *this;
 }
 
@@ -142,7 +265,16 @@ RenderGraph::PassBuilder& RenderGraph::PassBuilder::Write(ResourceHandle resourc
     if (graph.IsValidResource(resource)) {
         typed_range = ResourceRange::Whole(graph.resources[resource.index].kind);
     }
-    graph.AddAccess(pass_index, resource, AccessMode::Write, typed_range, false, range);
+    graph.AddAccess(
+        pass_index,
+        resource,
+        AccessMode::Write,
+        typed_range,
+        ResourceState{.kind = typed_range.kind},
+        false,
+        false,
+        range
+    );
     return *this;
 }
 
@@ -152,56 +284,217 @@ RenderGraph::PassBuilder::ReadWrite(ResourceHandle resource, std::string_view ra
     if (graph.IsValidResource(resource)) {
         typed_range = ResourceRange::Whole(graph.resources[resource.index].kind);
     }
-    graph.AddAccess(pass_index, resource, AccessMode::ReadWrite, typed_range, false, range);
+    graph.AddAccess(
+        pass_index,
+        resource,
+        AccessMode::ReadWrite,
+        typed_range,
+        ResourceState{.kind = typed_range.kind},
+        false,
+        false,
+        range
+    );
     return *this;
 }
 
 RenderGraph::PassBuilder& RenderGraph::PassBuilder::Read(TextureHandle resource, TextureRange range) {
-    graph.AddAccess(pass_index, resource.Untyped(), AccessMode::Read, ResourceRange::Texture(range), true);
+    graph.AddAccess(
+        pass_index,
+        resource.Untyped(),
+        AccessMode::Read,
+        ResourceRange::Texture(range),
+        ResourceState::Texture(TextureState::Automatic),
+        true,
+        false
+    );
     return *this;
 }
 
 RenderGraph::PassBuilder& RenderGraph::PassBuilder::Write(TextureHandle resource, TextureRange range) {
-    graph.AddAccess(pass_index, resource.Untyped(), AccessMode::Write, ResourceRange::Texture(range), true);
+    graph.AddAccess(
+        pass_index,
+        resource.Untyped(),
+        AccessMode::Write,
+        ResourceRange::Texture(range),
+        ResourceState::Texture(TextureState::Automatic),
+        true,
+        false
+    );
     return *this;
 }
 
 RenderGraph::PassBuilder& RenderGraph::PassBuilder::ReadWrite(TextureHandle resource, TextureRange range) {
     graph.AddAccess(
-        pass_index, resource.Untyped(), AccessMode::ReadWrite, ResourceRange::Texture(range), true
+        pass_index,
+        resource.Untyped(),
+        AccessMode::ReadWrite,
+        ResourceRange::Texture(range),
+        ResourceState::Texture(TextureState::Automatic),
+        true,
+        false
+    );
+    return *this;
+}
+
+RenderGraph::PassBuilder&
+RenderGraph::PassBuilder::Read(TextureHandle resource, TextureState state, TextureRange range) {
+    graph.AddAccess(
+        pass_index,
+        resource.Untyped(),
+        AccessMode::Read,
+        ResourceRange::Texture(range),
+        ResourceState::Texture(state),
+        true,
+        true
+    );
+    return *this;
+}
+
+RenderGraph::PassBuilder&
+RenderGraph::PassBuilder::Write(TextureHandle resource, TextureState state, TextureRange range) {
+    graph.AddAccess(
+        pass_index,
+        resource.Untyped(),
+        AccessMode::Write,
+        ResourceRange::Texture(range),
+        ResourceState::Texture(state),
+        true,
+        true
+    );
+    return *this;
+}
+
+RenderGraph::PassBuilder&
+RenderGraph::PassBuilder::ReadWrite(TextureHandle resource, TextureState state, TextureRange range) {
+    graph.AddAccess(
+        pass_index,
+        resource.Untyped(),
+        AccessMode::ReadWrite,
+        ResourceRange::Texture(range),
+        ResourceState::Texture(state),
+        true,
+        true
     );
     return *this;
 }
 
 RenderGraph::PassBuilder& RenderGraph::PassBuilder::Read(BufferHandle resource, BufferRange range) {
-    graph.AddAccess(pass_index, resource.Untyped(), AccessMode::Read, ResourceRange::Buffer(range), true);
+    graph.AddAccess(
+        pass_index,
+        resource.Untyped(),
+        AccessMode::Read,
+        ResourceRange::Buffer(range),
+        ResourceState::Buffer(BufferState::Automatic),
+        true,
+        false
+    );
     return *this;
 }
 
 RenderGraph::PassBuilder& RenderGraph::PassBuilder::Write(BufferHandle resource, BufferRange range) {
-    graph.AddAccess(pass_index, resource.Untyped(), AccessMode::Write, ResourceRange::Buffer(range), true);
+    graph.AddAccess(
+        pass_index,
+        resource.Untyped(),
+        AccessMode::Write,
+        ResourceRange::Buffer(range),
+        ResourceState::Buffer(BufferState::Automatic),
+        true,
+        false
+    );
     return *this;
 }
 
 RenderGraph::PassBuilder& RenderGraph::PassBuilder::ReadWrite(BufferHandle resource, BufferRange range) {
     graph.AddAccess(
-        pass_index, resource.Untyped(), AccessMode::ReadWrite, ResourceRange::Buffer(range), true
+        pass_index,
+        resource.Untyped(),
+        AccessMode::ReadWrite,
+        ResourceRange::Buffer(range),
+        ResourceState::Buffer(BufferState::Automatic),
+        true,
+        false
+    );
+    return *this;
+}
+
+RenderGraph::PassBuilder&
+RenderGraph::PassBuilder::Read(BufferHandle resource, BufferState state, BufferRange range) {
+    graph.AddAccess(
+        pass_index,
+        resource.Untyped(),
+        AccessMode::Read,
+        ResourceRange::Buffer(range),
+        ResourceState::Buffer(state),
+        true,
+        true
+    );
+    return *this;
+}
+
+RenderGraph::PassBuilder&
+RenderGraph::PassBuilder::Write(BufferHandle resource, BufferState state, BufferRange range) {
+    graph.AddAccess(
+        pass_index,
+        resource.Untyped(),
+        AccessMode::Write,
+        ResourceRange::Buffer(range),
+        ResourceState::Buffer(state),
+        true,
+        true
+    );
+    return *this;
+}
+
+RenderGraph::PassBuilder&
+RenderGraph::PassBuilder::ReadWrite(BufferHandle resource, BufferState state, BufferRange range) {
+    graph.AddAccess(
+        pass_index,
+        resource.Untyped(),
+        AccessMode::ReadWrite,
+        ResourceRange::Buffer(range),
+        ResourceState::Buffer(state),
+        true,
+        true
     );
     return *this;
 }
 
 RenderGraph::PassBuilder& RenderGraph::PassBuilder::Read(TokenHandle resource) {
-    graph.AddAccess(pass_index, resource.Untyped(), AccessMode::Read, ResourceRange::Token(), true);
+    graph.AddAccess(
+        pass_index,
+        resource.Untyped(),
+        AccessMode::Read,
+        ResourceRange::Token(),
+        ResourceState::Token(),
+        true,
+        false
+    );
     return *this;
 }
 
 RenderGraph::PassBuilder& RenderGraph::PassBuilder::Write(TokenHandle resource) {
-    graph.AddAccess(pass_index, resource.Untyped(), AccessMode::Write, ResourceRange::Token(), true);
+    graph.AddAccess(
+        pass_index,
+        resource.Untyped(),
+        AccessMode::Write,
+        ResourceRange::Token(),
+        ResourceState::Token(),
+        true,
+        false
+    );
     return *this;
 }
 
 RenderGraph::PassBuilder& RenderGraph::PassBuilder::ReadWrite(TokenHandle resource) {
-    graph.AddAccess(pass_index, resource.Untyped(), AccessMode::ReadWrite, ResourceRange::Token(), true);
+    graph.AddAccess(
+        pass_index,
+        resource.Untyped(),
+        AccessMode::ReadWrite,
+        ResourceRange::Token(),
+        ResourceState::Token(),
+        true,
+        false
+    );
     return *this;
 }
 
@@ -212,6 +505,12 @@ RenderGraph::PassBuilder& RenderGraph::PassBuilder::DependsOn(PassHandle depende
 
 RenderGraph::PassBuilder& RenderGraph::PassBuilder::SideEffect() {
     graph.MarkSideEffect(pass_index);
+    return *this;
+}
+
+RenderGraph::PassBuilder&
+RenderGraph::PassBuilder::ExecuteOn(QueueRole queue, PipelineType pipeline) {
+    graph.SetExecutionDomain(pass_index, queue, pipeline);
     return *this;
 }
 
@@ -409,6 +708,76 @@ void RenderGraph::Export(ResourceHandle resource) {
     resources[resource.index].exported = true;
 }
 
+void RenderGraph::SetInitialState(
+    TextureHandle resource,
+    TextureState  state,
+    QueueRole     owner_queue,
+    AccessMode    last_access,
+    TextureRange  range
+) {
+    AddStateDeclaration(
+        resource.Untyped(),
+        ResourceRange::Texture(range),
+        ResourceState::Texture(state),
+        owner_queue,
+        last_access,
+        true
+    );
+}
+
+void RenderGraph::SetInitialState(
+    BufferHandle resource,
+    BufferState  state,
+    QueueRole    owner_queue,
+    AccessMode   last_access,
+    BufferRange  range
+) {
+    AddStateDeclaration(
+        resource.Untyped(),
+        ResourceRange::Buffer(range),
+        ResourceState::Buffer(state),
+        owner_queue,
+        last_access,
+        true
+    );
+}
+
+void RenderGraph::Export(
+    TextureHandle resource,
+    TextureState  final_state,
+    QueueRole     owner_queue,
+    AccessMode    next_access,
+    TextureRange  range
+) {
+    Export(resource.Untyped());
+    AddStateDeclaration(
+        resource.Untyped(),
+        ResourceRange::Texture(range),
+        ResourceState::Texture(final_state),
+        owner_queue,
+        next_access,
+        false
+    );
+}
+
+void RenderGraph::Export(
+    BufferHandle resource,
+    BufferState  final_state,
+    QueueRole    owner_queue,
+    AccessMode   next_access,
+    BufferRange  range
+) {
+    Export(resource.Untyped());
+    AddStateDeclaration(
+        resource.Untyped(),
+        ResourceRange::Buffer(range),
+        ResourceState::Buffer(final_state),
+        owner_queue,
+        next_access,
+        false
+    );
+}
+
 RenderGraph::PassHandle
 RenderGraph::AddPass(std::string_view pass_name, const SetupCallback& setup, ExecuteCallback execute) {
     if (!InvalidateCompile()) {
@@ -471,11 +840,21 @@ bool RenderGraph::Execute() {
 std::string RenderGraph::Dump() const {
     std::ostringstream stream;
     stream << "graph='" << name
-           << "' frontend=typed-rdg mode=serial barrier_owner=rhi_command_preprocess compiled="
+           << "' frontend=typed-rdg mode=serial barrier_owner=existing_rhi_vulkan_path "
+              "sync_plan=shadow external_endpoints=unbound state_plan="
+           << (compiled_plan.state_plan_complete ? "complete" : "incomplete") << " compiled="
            << (compiled ? "true" : "false") << " executed=" << (executed ? "true" : "false")
            << " passes=" << passes.size() << " resources=" << resources.size();
     if (!compile_error.empty()) {
         stream << " error='" << compile_error << "'";
+    }
+    stream << '\n';
+
+    stream << "queue_topology:";
+    for (const QueueRole role : {QueueRole::Graphics, QueueRole::Compute, QueueRole::Copy}) {
+        const auto binding = queue_topology.Resolve(role);
+        stream << ' ' << ToString(role) << "=native" << binding.native_queue_id << "/family"
+               << binding.family_id;
     }
     stream << '\n';
 
@@ -487,6 +866,8 @@ std::string RenderGraph::Dump() const {
         const auto& pass = passes[pass_index];
         stream << "  [" << item_index << "] " << pass.name << " declared=" << pass_index
                << " scheduled=" << (has_execution_order ? "true" : "false")
+               << " queue=" << ToString(pass.domain.queue)
+               << " pipeline=" << ToString(pass.domain.pipeline)
                << " side_effect=" << (pass.side_effect ? "true" : "false") << " accesses=[";
         for (uint32_t access_index = 0; access_index < pass.accesses.size(); ++access_index) {
             const auto& access = pass.accesses[access_index];
@@ -505,6 +886,8 @@ std::string RenderGraph::Dump() const {
             } else {
                 stream << "legacy=" << access.legacy_range;
             }
+            stream << " state=";
+            AppendState(stream, access.state);
             stream << ')';
         }
         stream << "]\n";
@@ -519,9 +902,17 @@ std::string RenderGraph::Dump() const {
             stream << " desc=[mips=" << resource.texture_desc.mip_count
                    << " layers=" << resource.texture_desc.layer_count << " aspects=";
             AppendTextureAspects(stream, resource.texture_desc.aspects);
-            stream << ']';
+            stream << " sharing="
+                   << (resource.texture_desc.sharing_mode == TextureDesc::SharingMode::Exclusive ?
+                           "exclusive" :
+                           "concurrent")
+                   << ']';
         } else if (resource.kind == ResourceKind::Buffer && resource.typed_desc) {
-            stream << " desc=[bytes=" << resource.buffer_desc.byte_size << ']';
+            stream << " desc=[bytes=" << resource.buffer_desc.byte_size << " sharing="
+                   << (resource.buffer_desc.sharing_mode == TextureDesc::SharingMode::Exclusive ?
+                           "exclusive" :
+                           "concurrent")
+                   << ']';
         }
         stream << " first=";
         if (resource.first_use == PassHandle::InvalidIndex) {
@@ -549,7 +940,8 @@ std::string RenderGraph::Dump() const {
             }
             stream << aliases[alias_index];
         }
-        stream << "]\n";
+        stream << "] initial_states=" << resource.initial_states.size()
+               << " final_states=" << resource.final_states.size() << "\n";
     }
 
     stream << "compiled_accesses:\n";
@@ -557,6 +949,9 @@ std::string RenderGraph::Dump() const {
         stream << "  " << passes[access.pass.index].name << ' ' << ToString(access.mode) << ':'
                << resources[access.resource.index].name << ' ';
         AppendRange(stream, access.range);
+        stream << " state=";
+        AppendState(stream, access.state);
+        stream << " domain=" << ToString(access.domain.queue) << '/' << ToString(access.domain.pipeline);
         stream << " version=";
         AppendVersion(stream, access.input_version);
         stream << "->";
@@ -586,6 +981,162 @@ std::string RenderGraph::Dump() const {
         stream << "]\n";
     }
 
+    auto append_pass_endpoint = [&](PassHandle pass, bool import_boundary, bool export_boundary) {
+        if (pass.IsValid() && pass.owner_id == graph_id && pass.index < passes.size()) {
+            stream << passes[pass.index].name;
+        } else if (import_boundary) {
+            stream << "<import>";
+        } else if (export_boundary) {
+            stream << "<export>";
+        } else {
+            stream << "<initial>";
+        }
+    };
+
+    stream << "barriers:\n";
+    for (uint32_t barrier_index = 0; barrier_index < compiled_plan.barriers.size(); ++barrier_index) {
+        const auto& barrier = compiled_plan.barriers[barrier_index];
+        stream << "  [" << barrier_index << "] " << resources[barrier.resource.index].name << '@';
+        AppendRange(stream, barrier.range);
+        stream << ' ';
+        append_pass_endpoint(barrier.src_pass, barrier.import_boundary, false);
+        stream << '(' << ToString(barrier.src_domain.queue) << '/'
+               << ToString(barrier.src_domain.pipeline) << ' ';
+        AppendState(stream, barrier.before_state);
+        stream << ' ' << ToString(barrier.before_access) << ") -> ";
+        append_pass_endpoint(barrier.dst_pass, false, barrier.export_boundary);
+        stream << '(' << ToString(barrier.dst_domain.queue) << '/'
+               << ToString(barrier.dst_domain.pipeline) << ' ';
+        AppendState(stream, barrier.after_state);
+        stream << ' ' << ToString(barrier.after_access) << ") flags=[";
+        bool wrote_flag = false;
+        auto append_flag = [&](bool enabled, const char* flag) {
+            if (!enabled) {
+                return;
+            }
+            if (wrote_flag) {
+                stream << ',';
+            }
+            stream << flag;
+            wrote_flag = true;
+        };
+        append_flag(barrier.execution_dependency, "execution");
+        append_flag(barrier.memory_dependency, "memory");
+        append_flag(barrier.state_transition, "transition");
+        append_flag(barrier.queue_dependency, "queue");
+        append_flag(barrier.queue_ownership, "ownership");
+        append_flag(barrier.discard_previous_contents, "discard");
+        append_flag(barrier.import_boundary, "import");
+        append_flag(barrier.export_boundary, "export");
+        append_flag(barrier.source_state_unknown, "unknown-src");
+        if (!wrote_flag) {
+            stream << "none";
+        }
+        stream << "] sources=[";
+        for (uint32_t source_index = 0; source_index < barrier.sources.size(); ++source_index) {
+            if (source_index != 0) {
+                stream << ',';
+            }
+            const auto& source = barrier.sources[source_index];
+            append_pass_endpoint(source.pass, false, false);
+            stream << '(' << ToString(source.domain.queue) << '/'
+                   << ToString(source.domain.pipeline) << ' ';
+            AppendState(stream, source.state);
+            stream << ' ' << ToString(source.access) << ')';
+        }
+        stream << "]\n";
+    }
+
+    stream << "barrier_placements:\n  prologue=[";
+    for (uint32_t index = 0; index < compiled_plan.prologue_barriers.size(); ++index) {
+        if (index != 0) {
+            stream << ',';
+        }
+        stream << compiled_plan.prologue_barriers[index];
+    }
+    stream << "] epilogue=[";
+    for (uint32_t index = 0; index < compiled_plan.epilogue_barriers.size(); ++index) {
+        if (index != 0) {
+            stream << ',';
+        }
+        stream << compiled_plan.epilogue_barriers[index];
+    }
+    stream << "]\n";
+
+    stream << "queue_batches:\n";
+    for (const auto& batch : compiled_plan.queue_batches) {
+        stream << "  [" << batch.id << "] " << ToString(batch.queue.role) << " native="
+               << batch.queue.native_queue_id << " family=" << batch.queue.family_id << " passes=[";
+        for (uint32_t pass_index = 0; pass_index < batch.passes.size(); ++pass_index) {
+            if (pass_index != 0) {
+                stream << ',';
+            }
+            stream << passes[batch.passes[pass_index].index].name;
+        }
+        stream << "] pre=[";
+        for (uint32_t index = 0; index < batch.pre_barriers.size(); ++index) {
+            if (index != 0) {
+                stream << ',';
+            }
+            stream << batch.pre_barriers[index];
+        }
+        stream << "] post=[";
+        for (uint32_t index = 0; index < batch.post_barriers.size(); ++index) {
+            if (index != 0) {
+                stream << ',';
+            }
+            stream << batch.post_barriers[index];
+        }
+        stream << "] waits=[";
+        for (uint32_t index = 0; index < batch.wait_syncs.size(); ++index) {
+            if (index != 0) {
+                stream << ',';
+            }
+            stream << batch.wait_syncs[index];
+        }
+        stream << "] signals=[";
+        for (uint32_t index = 0; index < batch.signal_syncs.size(); ++index) {
+            if (index != 0) {
+                stream << ',';
+            }
+            stream << batch.signal_syncs[index];
+        }
+        stream << "]\n";
+    }
+
+    stream << "queue_syncs:\n";
+    for (const auto& sync : compiled_plan.queue_syncs) {
+        stream << "  [" << sync.id << "] batch" << sync.signal_batch << " -> batch"
+               << sync.wait_batch << " mode=" << (sync.gpu_wait_required ? "gpu" : "host-fifo")
+               << " edges=[";
+        for (uint32_t index = 0; index < sync.dependency_edges.size(); ++index) {
+            if (index != 0) {
+                stream << ',';
+            }
+            stream << sync.dependency_edges[index];
+        }
+        stream << "] barriers=[";
+        for (uint32_t index = 0; index < sync.barriers.size(); ++index) {
+            if (index != 0) {
+                stream << ',';
+            }
+            stream << sync.barriers[index];
+        }
+        stream << "]\n";
+    }
+
+    stream << "pass_barriers:\n";
+    for (const auto& placement : compiled_plan.pass_barriers) {
+        stream << "  " << passes[placement.pass.index].name << " before=[";
+        for (uint32_t index = 0; index < placement.before.size(); ++index) {
+            if (index != 0) {
+                stream << ',';
+            }
+            stream << placement.before[index];
+        }
+        stream << "]\n";
+    }
+
     stream << "dependency_waves:\n";
     for (uint32_t wave_index = 0; wave_index < compiled_plan.dependency_waves.size(); ++wave_index) {
         stream << "  [" << wave_index << "] [";
@@ -606,7 +1157,9 @@ void RenderGraph::AddAccess(
     ResourceHandle   resource,
     AccessMode       mode,
     ResourceRange    range,
+    ResourceState    state,
     bool             typed,
+    bool             explicit_state,
     std::string_view legacy_range
 ) {
     if (!InvalidateCompile()) {
@@ -628,9 +1181,63 @@ void RenderGraph::AddAccess(
         );
         return;
     }
+    if (state.kind != resources[resource.index].kind) {
+        declaration_errors.emplace_back(
+            "pass '" + passes[pass_index].name + "' used a state with the wrong resource kind"
+        );
+        return;
+    }
+    if (mode == AccessMode::None || mode == AccessMode::Unknown) {
+        declaration_errors.emplace_back(
+            "pass '" + passes[pass_index].name + "' declared an invalid access mode"
+        );
+        return;
+    }
     passes[pass_index].accesses.push_back(
-        AccessDeclaration{resource, mode, range, std::string(legacy_range), typed}
+        AccessDeclaration{
+            resource,
+            mode,
+            range,
+            state,
+            std::string(legacy_range),
+            typed,
+            explicit_state
+        }
     );
+}
+
+void RenderGraph::AddStateDeclaration(
+    ResourceHandle resource,
+    ResourceRange  range,
+    ResourceState  state,
+    QueueRole      queue,
+    AccessMode     boundary_access,
+    bool           initial
+) {
+    if (!InvalidateCompile()) {
+        return;
+    }
+    if (!IsValidResource(resource)) {
+        declaration_errors.emplace_back("state declaration received an invalid resource handle");
+        return;
+    }
+    auto& declaration = resources[resource.index];
+    if (declaration.kind == ResourceKind::Token || range.kind != declaration.kind ||
+        state.kind != declaration.kind) {
+        declaration_errors.emplace_back(
+            "state declaration has the wrong resource kind for '" + declaration.name + "'"
+        );
+        return;
+    }
+    if (initial && !declaration.imported) {
+        declaration_errors.emplace_back(
+            "only imported resources may declare an initial state: " + declaration.name
+        );
+        return;
+    }
+    StateDeclaration state_declaration{range, state, queue, boundary_access};
+    auto&            target = initial ? declaration.initial_states : declaration.final_states;
+    target.push_back(std::move(state_declaration));
 }
 
 void RenderGraph::AddDependency(uint32_t pass_index, PassHandle dependency) {
@@ -660,6 +1267,21 @@ void RenderGraph::MarkSideEffect(uint32_t pass_index) {
         return;
     }
     passes[pass_index].side_effect = true;
+}
+
+void RenderGraph::SetExecutionDomain(
+    uint32_t pass_index,
+    QueueRole queue,
+    PipelineType pipeline
+) {
+    if (!InvalidateCompile()) {
+        return;
+    }
+    if (pass_index >= passes.size()) {
+        declaration_errors.emplace_back("execution-domain declaration has invalid pass index");
+        return;
+    }
+    passes[pass_index].domain = ExecutionDomain{queue, pipeline};
 }
 
 bool RenderGraph::InvalidateCompile() {

--- a/source/runtime/render/rendergraph/RenderGraph.cpp
+++ b/source/runtime/render/rendergraph/RenderGraph.cpp
@@ -698,14 +698,21 @@ RenderGraph::ResourceHandle RenderGraph::CreateTransientInternal(
 }
 
 void RenderGraph::Export(ResourceHandle resource) {
+    MarkExported(resource, true);
+}
+
+bool RenderGraph::MarkExported(ResourceHandle resource, bool whole_resource) {
     if (!InvalidateCompile()) {
-        return;
+        return false;
     }
     if (!IsValidResource(resource)) {
         declaration_errors.emplace_back("Export received an invalid resource handle");
-        return;
+        return false;
     }
-    resources[resource.index].exported = true;
+    auto& declaration                    = resources[resource.index];
+    declaration.exported                = true;
+    declaration.whole_resource_exported |= whole_resource;
+    return true;
 }
 
 void RenderGraph::SetInitialState(
@@ -749,7 +756,9 @@ void RenderGraph::Export(
     AccessMode    next_access,
     TextureRange  range
 ) {
-    Export(resource.Untyped());
+    if (!MarkExported(resource.Untyped(), false)) {
+        return;
+    }
     AddStateDeclaration(
         resource.Untyped(),
         ResourceRange::Texture(range),
@@ -767,7 +776,9 @@ void RenderGraph::Export(
     AccessMode   next_access,
     BufferRange  range
 ) {
-    Export(resource.Untyped());
+    if (!MarkExported(resource.Untyped(), false)) {
+        return;
+    }
     AddStateDeclaration(
         resource.Untyped(),
         ResourceRange::Buffer(range),

--- a/source/runtime/render/rendergraph/RenderGraph.h
+++ b/source/runtime/render/rendergraph/RenderGraph.h
@@ -18,9 +18,10 @@ class RenderGraphCompiler;
  *
  * The compiler owns typed resource declarations, subresource-aware hazards,
  * logical resource versions, stable dependency analysis and lifetimes. The
- * existing RHI command preprocess remains the only owner of physical tracked
- * state and barriers. Execute deliberately stays synchronous and serial until
- * command recording has an independent ownership contract.
+ * RDG does not own physical tracked state or emit barriers in this stage; the
+ * existing RHI/Vulkan command path remains responsible. Execute deliberately
+ * stays synchronous and serial until command recording has an independent
+ * ownership contract.
  */
 class RENDER_API RenderGraph {
 public:
@@ -54,12 +55,17 @@ public:
         uint32_t      mip_count   = 1;
         uint32_t      layer_count = 1;
         TextureAspect aspects     = TextureAspect::Color;
+        enum class SharingMode : uint8_t {
+            Exclusive,
+            Concurrent,
+        } sharing_mode = SharingMode::Exclusive;
 
         friend bool operator==(const TextureDesc&, const TextureDesc&) = default;
     };
 
     struct BufferDesc {
         uint64_t byte_size = 0;
+        TextureDesc::SharingMode sharing_mode = TextureDesc::SharingMode::Exclusive;
 
         friend bool operator==(const BufferDesc&, const BufferDesc&) = default;
     };
@@ -213,9 +219,149 @@ public:
     };
 
     enum class AccessMode : uint8_t {
+        Unknown,
+        None,
         Read,
         Write,
         ReadWrite,
+    };
+
+    /** Logical queue role. It is deliberately separate from a native queue and queue family. */
+    enum class QueueRole : uint8_t {
+        None,
+        Graphics,
+        Compute,
+        Copy,
+    };
+
+    /** Pipeline domain used to derive source/destination stage scopes during future RHI lowering. */
+    enum class PipelineType : uint8_t {
+        None,
+        Graphics,
+        Compute,
+        RayTracing,
+        Copy,
+    };
+
+    struct QueueBinding {
+        QueueRole role            = QueueRole::None;
+        uint32_t  native_queue_id = 0;
+        uint32_t  family_id       = 0;
+
+        friend bool operator==(const QueueBinding&, const QueueBinding&) = default;
+    };
+
+    /**
+     * Maps logical roles to actual queues. Tests may provide a fake topology; production currently
+     * uses SingleQueue() until the RHI submission path consumes the compiled plan.
+     */
+    struct QueueTopology {
+        QueueBinding graphics{QueueRole::Graphics, 0, 0};
+        QueueBinding compute{QueueRole::Compute, 0, 0};
+        QueueBinding copy{QueueRole::Copy, 0, 0};
+
+        [[nodiscard]] static constexpr QueueTopology SingleQueue() {
+            return {};
+        }
+
+        [[nodiscard]] static constexpr QueueTopology DedicatedQueues() {
+            return QueueTopology{
+                .graphics = QueueBinding{QueueRole::Graphics, 0, 0},
+                .compute  = QueueBinding{QueueRole::Compute, 1, 1},
+                .copy     = QueueBinding{QueueRole::Copy, 2, 2},
+            };
+        }
+
+        [[nodiscard]] constexpr QueueBinding Resolve(QueueRole role) const {
+            switch (role) {
+                case QueueRole::Graphics:
+                    return graphics;
+                case QueueRole::Compute:
+                    return compute;
+                case QueueRole::Copy:
+                    return copy;
+                case QueueRole::None:
+                    return {};
+            }
+            return {};
+        }
+
+        friend bool operator==(const QueueTopology&, const QueueTopology&) = default;
+    };
+
+    struct ExecutionDomain {
+        QueueRole    queue    = QueueRole::Graphics;
+        PipelineType pipeline = PipelineType::Graphics;
+
+        friend bool operator==(const ExecutionDomain&, const ExecutionDomain&) = default;
+    };
+
+    /** RDG-neutral states; these do not depend on the legacy RHI enum ordinals. */
+    enum class TextureState : uint8_t {
+        Automatic,
+        Undefined,
+        TransferSource,
+        TransferDestination,
+        ShaderResource,
+        Sampled,
+        RenderTarget,
+        DepthStencilRead,
+        DepthStencilWrite,
+        UnorderedAccess,
+        Present,
+    };
+
+    enum class BufferState : uint8_t {
+        Automatic,
+        Undefined,
+        TransferSource,
+        TransferDestination,
+        VertexBuffer,
+        IndexBuffer,
+        IndirectArgument,
+        ShaderResource,
+        UnorderedAccess,
+        AccelerationStructureBuildInput,
+        AccelerationStructureRead,
+        AccelerationStructureWrite,
+    };
+
+    struct ResourceState {
+        ResourceKind kind = ResourceKind::Token;
+        TextureState texture = TextureState::Automatic;
+        BufferState  buffer  = BufferState::Automatic;
+
+        [[nodiscard]] static constexpr ResourceState Texture(TextureState state) {
+            ResourceState result{};
+            result.kind    = ResourceKind::Texture;
+            result.texture = state;
+            return result;
+        }
+
+        [[nodiscard]] static constexpr ResourceState Buffer(BufferState state) {
+            ResourceState result{};
+            result.kind   = ResourceKind::Buffer;
+            result.buffer = state;
+            return result;
+        }
+
+        [[nodiscard]] static constexpr ResourceState Token() {
+            return {};
+        }
+
+        [[nodiscard]] constexpr bool IsAutomatic() const {
+            return kind == ResourceKind::Texture ? texture == TextureState::Automatic :
+                   kind == ResourceKind::Buffer  ? buffer == BufferState::Automatic :
+                                                   true;
+        }
+
+        [[nodiscard]] constexpr bool IsUndefined() const {
+            return kind == ResourceKind::Texture ? texture == TextureState::Undefined :
+                   kind == ResourceKind::Buffer  ? buffer == BufferState::Undefined :
+                                                   false;
+        }
+
+        friend bool operator==(const ResourceState&, const ResourceState&) = default;
     };
 
     enum class EdgeReasonKind : uint8_t {
@@ -223,6 +369,8 @@ public:
         ReadAfterWrite,
         WriteAfterRead,
         WriteAfterWrite,
+        StateTransition,
+        QueueOwnership,
     };
 
     struct CompiledAccess {
@@ -230,6 +378,8 @@ public:
         ResourceHandle resource{};
         AccessMode     mode = AccessMode::Read;
         ResourceRange  range{};
+        ResourceState  state{};
+        ExecutionDomain domain{};
         uint32_t       input_version  = InvalidVersion;
         uint32_t       output_version = InvalidVersion;
     };
@@ -263,6 +413,85 @@ public:
         std::vector<PassHandle> passes{};
     };
 
+    /**
+     * One canonical synchronization decision for one atomic resource cell. The future backend may
+     * lower a queue_ownership record into paired release/acquire barriers; RDG itself does not emit
+     * physical barriers in this stage.
+     */
+    struct CompiledBarrierSource {
+        PassHandle      pass{};
+        ResourceState   state{};
+        AccessMode      access = AccessMode::None;
+        ExecutionDomain domain{QueueRole::None, PipelineType::None};
+
+        friend bool operator==(const CompiledBarrierSource&, const CompiledBarrierSource&) = default;
+    };
+
+    struct CompiledBarrier {
+        ResourceHandle  resource{};
+        ResourceRange   range{};
+        /** Latest actual predecessor in sources; invalid for an external/undefined boundary. */
+        PassHandle      src_pass{};
+        PassHandle      dst_pass{};
+        /** Current tracked state at the destination boundary, independent of source fan-in. */
+        ResourceState   before_state{};
+        ResourceState   after_state{};
+        /** Representative source scope; sources is authoritative when it is non-empty. */
+        AccessMode      before_access = AccessMode::None;
+        AccessMode      after_access  = AccessMode::None;
+        ExecutionDomain src_domain{QueueRole::None, PipelineType::None};
+        ExecutionDomain dst_domain{QueueRole::None, PipelineType::None};
+        bool             state_transition = false;
+        bool             memory_dependency = false;
+        bool             execution_dependency = false;
+        bool             queue_dependency = false;
+        bool             queue_ownership = false;
+        bool             discard_previous_contents = false;
+        bool             import_boundary = false;
+        bool             export_boundary = false;
+        bool             source_state_unknown = false;
+        /** All RAW/WAR/WAW/state predecessors whose scopes must be represented by lowering. */
+        std::vector<CompiledBarrierSource> sources{};
+    };
+
+    struct CompiledQueueSync {
+        uint32_t     id = 0;
+        PassHandle   signal_pass{};
+        PassHandle   wait_pass{};
+        QueueBinding signal_queue{};
+        QueueBinding wait_queue{};
+        uint32_t     signal_batch = PassHandle::InvalidIndex;
+        uint32_t     wait_batch   = PassHandle::InvalidIndex;
+        bool         gpu_wait_required = false;
+        std::vector<uint32_t> dependency_edges{};
+        std::vector<uint32_t> barriers{};
+    };
+
+    struct CompiledPassBarriers {
+        PassHandle            pass{};
+        std::vector<uint32_t> before{};
+    };
+
+    struct CompiledQueueBatch {
+        uint32_t                id = 0;
+        QueueBinding            queue{};
+        std::vector<PassHandle> passes{};
+        /**
+         * Correlated split acquire/release placement hints. An index in pre/post never means that the
+         * full CompiledBarrier should be emitted again; pass_barriers and prologue/epilogue remain the
+         * canonical boundaries. Export transitions are deliberately epilogue-only.
+         */
+        std::vector<uint32_t>   pre_barriers{};
+        std::vector<uint32_t>   post_barriers{};
+        std::vector<uint32_t>   wait_syncs{};
+        std::vector<uint32_t>   signal_syncs{};
+    };
+
+    /**
+     * Immutable compiler diagnostics for the current serial executor. This is shadow metadata,
+     * not an executable submission plan: queue_syncs only describe internal pass/batch edges,
+     * while external import/export/present synchronization endpoints are intentionally absent.
+     */
     struct CompiledPlan {
         /** Stable topological order of semantic dependencies. */
         std::vector<PassHandle> topological_order{};
@@ -275,6 +504,20 @@ public:
         std::vector<CompiledResource> resources{};
         /** Dependency-only waves for diagnostics. They are not yet an execution schedule. */
         std::vector<CompiledWave> dependency_waves{};
+        /** Canonical state/memory/ownership decisions, prior to backend-specific lowering. */
+        std::vector<CompiledBarrier> barriers{};
+        /** Prospective multi-queue batches and their GPU wait/signal relationships. */
+        std::vector<CompiledQueueBatch> queue_batches{};
+        std::vector<CompiledQueueSync>  queue_syncs{};
+        std::vector<CompiledPassBarriers> pass_barriers{};
+        /** Boundary requirements only; active lowering must bind external synchronization first. */
+        std::vector<uint32_t> prologue_barriers{};
+        std::vector<uint32_t> epilogue_barriers{};
+        /**
+         * False when a participating physical cell has no logical state. True only means the
+         * shadow state model is complete; it does not mean this plan can be lowered or submitted.
+         */
+        bool state_plan_complete = true;
 
         void Clear() {
             topological_order.clear();
@@ -283,6 +526,13 @@ public:
             accesses.clear();
             resources.clear();
             dependency_waves.clear();
+            barriers.clear();
+            queue_batches.clear();
+            queue_syncs.clear();
+            pass_barriers.clear();
+            prologue_barriers.clear();
+            epilogue_barriers.clear();
+            state_plan_complete = true;
         }
     };
 
@@ -296,10 +546,40 @@ public:
         PassBuilder& Read(TextureHandle resource, TextureRange range = TextureRange::Whole());
         PassBuilder& Write(TextureHandle resource, TextureRange range = TextureRange::Whole());
         PassBuilder& ReadWrite(TextureHandle resource, TextureRange range = TextureRange::Whole());
+        PassBuilder& Read(
+            TextureHandle resource,
+            TextureState  state,
+            TextureRange  range = TextureRange::Whole()
+        );
+        PassBuilder& Write(
+            TextureHandle resource,
+            TextureState  state,
+            TextureRange  range = TextureRange::Whole()
+        );
+        PassBuilder& ReadWrite(
+            TextureHandle resource,
+            TextureState  state,
+            TextureRange  range = TextureRange::Whole()
+        );
 
         PassBuilder& Read(BufferHandle resource, BufferRange range = BufferRange::Whole());
         PassBuilder& Write(BufferHandle resource, BufferRange range = BufferRange::Whole());
         PassBuilder& ReadWrite(BufferHandle resource, BufferRange range = BufferRange::Whole());
+        PassBuilder& Read(
+            BufferHandle resource,
+            BufferState  state,
+            BufferRange  range = BufferRange::Whole()
+        );
+        PassBuilder& Write(
+            BufferHandle resource,
+            BufferState  state,
+            BufferRange  range = BufferRange::Whole()
+        );
+        PassBuilder& ReadWrite(
+            BufferHandle resource,
+            BufferState  state,
+            BufferRange  range = BufferRange::Whole()
+        );
 
         PassBuilder& Read(TokenHandle resource);
         PassBuilder& Write(TokenHandle resource);
@@ -307,6 +587,7 @@ public:
 
         PassBuilder& DependsOn(PassHandle dependency);
         PassBuilder& SideEffect();
+        PassBuilder& ExecuteOn(QueueRole queue, PipelineType pipeline);
 
     private:
         PassBuilder(RenderGraph& graph, uint32_t pass_index) : graph(graph), pass_index(pass_index) {}
@@ -321,6 +602,7 @@ public:
     using ExecuteCallback = std::function<void()>;
 
     explicit RenderGraph(std::string_view name = "RenderGraph");
+    RenderGraph(std::string_view name, QueueTopology topology);
     ~RenderGraph();
 
     RenderGraph(const RenderGraph&)            = delete;
@@ -352,6 +634,35 @@ public:
         Export(resource.Untyped());
     }
 
+    void SetInitialState(
+        TextureHandle resource,
+        TextureState  state,
+        QueueRole     owner_queue,
+        AccessMode    last_access = AccessMode::Unknown,
+        TextureRange  range       = TextureRange::Whole()
+    );
+    void SetInitialState(
+        BufferHandle resource,
+        BufferState  state,
+        QueueRole    owner_queue,
+        AccessMode   last_access = AccessMode::Unknown,
+        BufferRange  range       = BufferRange::Whole()
+    );
+    void Export(
+        TextureHandle resource,
+        TextureState  final_state,
+        QueueRole     owner_queue,
+        AccessMode    next_access = AccessMode::Read,
+        TextureRange  range       = TextureRange::Whole()
+    );
+    void Export(
+        BufferHandle resource,
+        BufferState  final_state,
+        QueueRole    owner_queue,
+        AccessMode   next_access = AccessMode::Read,
+        BufferRange  range       = BufferRange::Whole()
+    );
+
     PassHandle AddPass(std::string_view name, const SetupCallback& setup, ExecuteCallback execute);
 
     /** Compiles declarations without emitting barriers or recording RHI commands. */
@@ -368,8 +679,13 @@ public:
         return compile_error;
     }
 
+    /** Returns non-executable shadow compiler metadata; see CompiledPlan's contract. */
     [[nodiscard]] const CompiledPlan& GetCompiledPlan() const {
         return compiled_plan;
+    }
+
+    [[nodiscard]] const QueueTopology& GetQueueTopology() const {
+        return queue_topology;
     }
 
     /** Deterministic text dump of passes, typed accesses, edges, versions and lifetimes. */
@@ -382,8 +698,17 @@ private:
         ResourceHandle resource{};
         AccessMode     mode = AccessMode::Read;
         ResourceRange  range{};
+        ResourceState  state{};
         std::string    legacy_range{};
         bool           typed = false;
+        bool           explicit_state = false;
+    };
+
+    struct StateDeclaration {
+        ResourceRange range{};
+        ResourceState state{};
+        QueueRole     queue       = QueueRole::None;
+        AccessMode    boundary_access = AccessMode::None;
     };
 
     struct ResourceDeclaration {
@@ -396,6 +721,8 @@ private:
         bool                     typed_desc = false;
         bool                     imported   = false;
         bool                     exported   = false;
+        std::vector<StateDeclaration> initial_states{};
+        std::vector<StateDeclaration> final_states{};
         uint32_t                 first_use  = PassHandle::InvalidIndex;
         uint32_t                 last_use   = PassHandle::InvalidIndex;
     };
@@ -405,6 +732,7 @@ private:
         std::vector<AccessDeclaration> accesses{};
         std::vector<PassHandle>        explicit_dependencies{};
         ExecuteCallback                execute{};
+        ExecutionDomain               domain{};
         bool                           side_effect = false;
     };
 
@@ -426,11 +754,22 @@ private:
         ResourceHandle   resource,
         AccessMode       mode,
         ResourceRange    range,
+        ResourceState    state,
         bool             typed,
+        bool             explicit_state,
         std::string_view legacy_range = {}
+    );
+    void AddStateDeclaration(
+        ResourceHandle resource,
+        ResourceRange  range,
+        ResourceState  state,
+        QueueRole      queue,
+        AccessMode     boundary_access,
+        bool           initial
     );
     void AddDependency(uint32_t pass_index, PassHandle dependency);
     void MarkSideEffect(uint32_t pass_index);
+    void SetExecutionDomain(uint32_t pass_index, QueueRole queue, PipelineType pipeline);
     bool InvalidateCompile();
     bool FailCompile(std::string message);
 
@@ -444,6 +783,7 @@ private:
     std::vector<std::string>         declaration_errors{};
     std::string                      compile_error{};
     uint64_t                         graph_id = 0;
+    QueueTopology                    queue_topology{};
     bool                             compiled = false;
     bool                             executed = false;
 };

--- a/source/runtime/render/rendergraph/RenderGraph.h
+++ b/source/runtime/render/rendergraph/RenderGraph.h
@@ -369,7 +369,7 @@ public:
         ReadAfterWrite,
         WriteAfterRead,
         WriteAfterWrite,
-        /** State/data availability established on another native queue. */
+        /** State/data availability established by a prior pass. */
         StateTransition,
         QueueOwnership,
     };

--- a/source/runtime/render/rendergraph/RenderGraph.h
+++ b/source/runtime/render/rendergraph/RenderGraph.h
@@ -369,6 +369,7 @@ public:
         ReadAfterWrite,
         WriteAfterRead,
         WriteAfterWrite,
+        /** State/data availability established on another native queue. */
         StateTransition,
         QueueOwnership,
     };
@@ -450,7 +451,7 @@ public:
         bool             import_boundary = false;
         bool             export_boundary = false;
         bool             source_state_unknown = false;
-        /** All RAW/WAR/WAW/state predecessors whose scopes must be represented by lowering. */
+        /** Authoritative synchronization frontier whose scopes must be represented by lowering. */
         std::vector<CompiledBarrierSource> sources{};
     };
 
@@ -497,7 +498,7 @@ public:
         std::vector<PassHandle> topological_order{};
         /** Current production order. It remains declaration-order and serial. */
         std::vector<PassHandle> execution_order{};
-        /** RAW/WAR/WAW and explicit dependencies only, without fake serial edges. */
+        /** Minimal hazard, explicit, state, and ownership frontier without fake serial edges. */
         std::vector<CompiledEdge> edges{};
         /** Atomic subresource/range accesses with logical input/output versions. */
         std::vector<CompiledAccess>   accesses{};
@@ -721,6 +722,7 @@ private:
         bool                     typed_desc = false;
         bool                     imported   = false;
         bool                     exported   = false;
+        bool                     whole_resource_exported = false;
         std::vector<StateDeclaration> initial_states{};
         std::vector<StateDeclaration> final_states{};
         uint32_t                 first_use  = PassHandle::InvalidIndex;
@@ -767,6 +769,7 @@ private:
         AccessMode     boundary_access,
         bool           initial
     );
+    bool MarkExported(ResourceHandle resource, bool whole_resource);
     void AddDependency(uint32_t pass_index, PassHandle dependency);
     void MarkSideEffect(uint32_t pass_index);
     void SetExecutionDomain(uint32_t pass_index, QueueRole queue, PipelineType pipeline);

--- a/source/runtime/render/rendergraph/RenderGraphCompiler.cpp
+++ b/source/runtime/render/rendergraph/RenderGraphCompiler.cpp
@@ -103,6 +103,27 @@ ReasonLess(const RenderGraph::CompiledEdgeReason& lhs, const RenderGraph::Compil
     return false;
 }
 
+[[nodiscard]] bool TextureStateSupportsAspects(
+    RenderGraph::TextureState state,
+    TextureAspect             aspects
+) {
+    const uint8_t selected = AspectMask(aspects);
+    switch (state) {
+        case RenderGraph::TextureState::RenderTarget:
+        case RenderGraph::TextureState::UnorderedAccess:
+        case RenderGraph::TextureState::Present:
+            return selected == AspectMask(TextureAspect::Color);
+        case RenderGraph::TextureState::DepthStencilRead:
+        case RenderGraph::TextureState::DepthStencilWrite: {
+            const uint8_t depth_stencil = AspectMask(TextureAspect::Depth) |
+                                          AspectMask(TextureAspect::Stencil);
+            return selected != 0 && (selected & depth_stencil) == selected;
+        }
+        default:
+            return true;
+    }
+}
+
 [[nodiscard]] bool BufferStateSupports(
     RenderGraph::BufferState state,
     RenderGraph::AccessMode  mode
@@ -270,7 +291,12 @@ bool RenderGraphCompiler::NormalizeDeclarations() {
             ResourceRange normalized{};
             if (!NormalizeRange(resource, access.range, normalized) ||
                 !ValidateAccessState(
-                    pass_index, resource, access.mode, access.state, access.explicit_state
+                    pass_index,
+                    resource,
+                    normalized,
+                    access.mode,
+                    access.state,
+                    access.explicit_state
                 )) {
                 return false;
             }
@@ -332,6 +358,15 @@ bool RenderGraphCompiler::NormalizeDeclarations() {
                 ResourceRange normalized{};
                 if (!NormalizeRange(resource, declaration.range, normalized)) {
                     return false;
+                }
+                if (resource.kind == ResourceKind::Texture &&
+                    !TextureStateSupportsAspects(
+                        declaration.state.texture, normalized.texture.aspects
+                    )) {
+                    return Fail(
+                        "boundary texture state is incompatible with the selected aspects on resource '" +
+                        resource.name + "'"
+                    );
                 }
                 normalized_states.push_back(
                     NormalizedStateDeclaration{
@@ -455,6 +490,7 @@ bool RenderGraphCompiler::ValidateExecutionDomain(uint32_t pass_index) {
 bool RenderGraphCompiler::ValidateAccessState(
     uint32_t                                pass_index,
     const RenderGraph::ResourceDeclaration& resource,
+    const RenderGraph::ResourceRange&       range,
     RenderGraph::AccessMode                 mode,
     const RenderGraph::ResourceState&       state,
     bool                                    explicit_state
@@ -485,6 +521,11 @@ bool RenderGraphCompiler::ValidateAccessState(
                                       state.texture == RenderGraph::TextureState::DepthStencilWrite;
         if (attachment_state && pass.domain.pipeline != RenderGraph::PipelineType::Graphics) {
             return Fail("attachment state requires the graphics pipeline in pass '" + pass.name + "'");
+        }
+        if (!TextureStateSupportsAspects(state.texture, range.texture.aspects)) {
+            return Fail(
+                "texture state is incompatible with the selected aspects in pass '" + pass.name + "'"
+            );
         }
     } else {
         supported     = BufferStateSupports(state.buffer, mode) &&
@@ -829,22 +870,17 @@ bool RenderGraphCompiler::BuildSemanticDependencies() {
                 if (physical_resource && !state_transition && !queue_ownership &&
                     cell.availability_established_pass != RenderGraph::PassHandle::InvalidIndex &&
                     cell.availability_established_pass != pass_index) {
-                    const auto& established_pass =
-                        graph.passes[cell.availability_established_pass];
-                    if (graph.queue_topology.Resolve(established_pass.domain.queue).native_queue_id !=
-                        graph.queue_topology.Resolve(pass.domain.queue).native_queue_id) {
-                        AddEdge(
-                            cell.availability_established_pass,
-                            pass_index,
-                            RenderGraph::CompiledEdgeReason{
-                                .kind           = RenderGraph::EdgeReasonKind::StateTransition,
-                                .resource       = resource_handle,
-                                .range          = cell.range,
-                                .input_version  = cell.version,
-                                .output_version = cell.version
-                            }
-                        );
-                    }
+                    AddEdge(
+                        cell.availability_established_pass,
+                        pass_index,
+                        RenderGraph::CompiledEdgeReason{
+                            .kind           = RenderGraph::EdgeReasonKind::StateTransition,
+                            .resource       = resource_handle,
+                            .range          = cell.range,
+                            .input_version  = cell.version,
+                            .output_version = cell.version
+                        }
+                    );
                 }
                 if (!state_transition && !queue_ownership &&
                     cell.ownership_established_pass != RenderGraph::PassHandle::InvalidIndex &&
@@ -995,8 +1031,8 @@ bool RenderGraphCompiler::BuildSemanticDependencies() {
                 if (physical_resource &&
                     (usage.write || import_availability || state_transition || queue_ownership)) {
                     // This pass has ordered the complete prior frontier and becomes the source of
-                    // state/data availability for sibling native queues. Automatic accesses still
-                    // inherit this dependency even though they make the logical state unknown.
+                    // state/data availability for later accesses. Automatic accesses still inherit
+                    // this dependency even though they make the logical state unknown.
                     cell.availability_established_pass = pass_index;
                 }
                 if (((usage.write || import_availability) && IsExclusive(resource)) ||

--- a/source/runtime/render/rendergraph/RenderGraphCompiler.cpp
+++ b/source/runtime/render/rendergraph/RenderGraphCompiler.cpp
@@ -60,6 +60,126 @@ ReasonLess(const RenderGraph::CompiledEdgeReason& lhs, const RenderGraph::Compil
     return write ? RenderGraph::AccessMode::Write : RenderGraph::AccessMode::Read;
 }
 
+[[nodiscard]] bool HasRead(RenderGraph::AccessMode mode) {
+    return mode == RenderGraph::AccessMode::Unknown || mode == RenderGraph::AccessMode::Read ||
+           mode == RenderGraph::AccessMode::ReadWrite;
+}
+
+[[nodiscard]] bool HasWrite(RenderGraph::AccessMode mode) {
+    return mode == RenderGraph::AccessMode::Unknown || mode == RenderGraph::AccessMode::Write ||
+           mode == RenderGraph::AccessMode::ReadWrite;
+}
+
+[[nodiscard]] bool TextureStateSupports(
+    RenderGraph::TextureState state,
+    RenderGraph::AccessMode   mode
+) {
+    using State = RenderGraph::TextureState;
+    if (mode == RenderGraph::AccessMode::Unknown) {
+        return true;
+    }
+    if (mode == RenderGraph::AccessMode::None) {
+        return state == State::Undefined || state == State::Automatic;
+    }
+    switch (state) {
+        case State::Automatic:
+            return true;
+        case State::Undefined:
+            return false;
+        case State::TransferSource:
+        case State::ShaderResource:
+        case State::Sampled:
+        case State::DepthStencilRead:
+        case State::Present:
+            return HasRead(mode) && !HasWrite(mode);
+        case State::TransferDestination:
+            return mode == RenderGraph::AccessMode::Write;
+        case State::RenderTarget:
+        case State::DepthStencilWrite:
+            return HasWrite(mode);
+        case State::UnorderedAccess:
+            return HasRead(mode) || HasWrite(mode);
+    }
+    return false;
+}
+
+[[nodiscard]] bool BufferStateSupports(
+    RenderGraph::BufferState state,
+    RenderGraph::AccessMode  mode
+) {
+    using State = RenderGraph::BufferState;
+    if (mode == RenderGraph::AccessMode::Unknown) {
+        return true;
+    }
+    if (mode == RenderGraph::AccessMode::None) {
+        return state == State::Undefined || state == State::Automatic;
+    }
+    switch (state) {
+        case State::Automatic:
+            return true;
+        case State::Undefined:
+            return false;
+        case State::TransferSource:
+        case State::VertexBuffer:
+        case State::IndexBuffer:
+        case State::IndirectArgument:
+        case State::ShaderResource:
+        case State::AccelerationStructureBuildInput:
+        case State::AccelerationStructureRead:
+            return HasRead(mode) && !HasWrite(mode);
+        case State::TransferDestination:
+        case State::AccelerationStructureWrite:
+            return mode == RenderGraph::AccessMode::Write;
+        case State::UnorderedAccess:
+            return HasRead(mode) || HasWrite(mode);
+    }
+    return false;
+}
+
+[[nodiscard]] bool StatesCompatible(
+    const RenderGraph::ResourceState& previous,
+    const RenderGraph::ResourceState& next
+) {
+    if (previous.kind != next.kind || previous.IsAutomatic() || next.IsAutomatic()) {
+        return false;
+    }
+    if (previous == next) {
+        return true;
+    }
+    if (previous.kind == ResourceKind::Texture) {
+        const bool previous_shader_read =
+            previous.texture == RenderGraph::TextureState::ShaderResource ||
+            previous.texture == RenderGraph::TextureState::Sampled;
+        const bool next_shader_read = next.texture == RenderGraph::TextureState::ShaderResource ||
+                                      next.texture == RenderGraph::TextureState::Sampled;
+        return previous_shader_read && next_shader_read;
+    }
+    return false;
+}
+
+[[nodiscard]] RenderGraph::ResourceState CanonicalCompatibleState(
+    const RenderGraph::ResourceState& lhs,
+    const RenderGraph::ResourceState& rhs
+) {
+    if (lhs == rhs) {
+        return lhs;
+    }
+    assert(StatesCompatible(lhs, rhs));
+    if (lhs.kind == ResourceKind::Texture) {
+        return RenderGraph::ResourceState::Texture(RenderGraph::TextureState::ShaderResource);
+    }
+    return lhs;
+}
+
+template<typename ResourceDeclaration>
+[[nodiscard]] bool IsExclusive(const ResourceDeclaration& resource) {
+    return resource.kind == ResourceKind::Texture ?
+               resource.texture_desc.sharing_mode == RenderGraph::TextureDesc::SharingMode::Exclusive :
+           resource.kind == ResourceKind::Buffer ?
+               resource.buffer_desc.sharing_mode == RenderGraph::TextureDesc::SharingMode::Exclusive :
+               false;
+}
+
 } // namespace
 
 bool RenderGraphCompiler::Compile() {
@@ -79,23 +199,55 @@ bool RenderGraphCompiler::Compile() {
     }
 
     normalized_accesses.assign(graph.passes.size(), {});
+    normalized_initial_states.assign(graph.resources.size(), {});
+    normalized_final_states.assign(graph.resources.size(), {});
     resource_cells.assign(graph.resources.size(), {});
     resource_version_counts.assign(graph.resources.size(), 0);
     resource_ever_written.assign(graph.resources.size(), false);
 
-    if (!NormalizeDeclarations() || !BuildAtomicCells() || !BuildSemanticDependencies() ||
-        !BuildTopologicalOrder() || !BuildExecutionOrder()) {
+    if (!ValidateQueueTopology() || !NormalizeDeclarations() || !BuildAtomicCells() ||
+        !BuildSemanticDependencies() || !BuildFinalBarriers() || !BuildTopologicalOrder() ||
+        !BuildExecutionOrder()) {
         return false;
     }
 
+    AuditStatePlanCompleteness();
+    BuildQueuePlan();
     BuildDependencyWaves();
     BuildLifetimes();
     graph.compiled = true;
     return true;
 }
 
+bool RenderGraphCompiler::ValidateQueueTopology() {
+    const std::array expected_roles{
+        RenderGraph::QueueRole::Graphics,
+        RenderGraph::QueueRole::Compute,
+        RenderGraph::QueueRole::Copy,
+    };
+    std::array<RenderGraph::QueueBinding, 3> bindings{};
+    for (uint32_t index = 0; index < expected_roles.size(); ++index) {
+        bindings[index] = graph.queue_topology.Resolve(expected_roles[index]);
+        if (bindings[index].role != expected_roles[index]) {
+            return Fail("queue topology contains a binding with the wrong logical role");
+        }
+    }
+    for (uint32_t lhs = 0; lhs < bindings.size(); ++lhs) {
+        for (uint32_t rhs = lhs + 1; rhs < bindings.size(); ++rhs) {
+            if (bindings[lhs].native_queue_id == bindings[rhs].native_queue_id &&
+                bindings[lhs].family_id != bindings[rhs].family_id) {
+                return Fail("one native queue id cannot belong to multiple queue families");
+            }
+        }
+    }
+    return true;
+}
+
 bool RenderGraphCompiler::NormalizeDeclarations() {
     for (uint32_t pass_index = 0; pass_index < graph.passes.size(); ++pass_index) {
+        if (!ValidateExecutionDomain(pass_index)) {
+            return false;
+        }
         const auto& pass = graph.passes[pass_index];
         for (const auto& access : pass.accesses) {
             if (!graph.IsValidResource(access.resource)) {
@@ -103,12 +255,87 @@ bool RenderGraphCompiler::NormalizeDeclarations() {
             }
             const auto&   resource = graph.resources[access.resource.index];
             ResourceRange normalized{};
-            if (!NormalizeRange(resource, access, normalized)) {
+            if (!NormalizeRange(resource, access.range, normalized) ||
+                !ValidateAccessState(
+                    pass_index, resource, access.mode, access.state, access.explicit_state
+                )) {
                 return false;
             }
             normalized_accesses[pass_index].push_back(
-                NormalizedAccess{access.resource, access.mode, normalized}
+                NormalizedAccess{
+                    access.resource,
+                    access.mode,
+                    normalized,
+                    access.state,
+                    access.explicit_state
+                }
             );
+        }
+    }
+
+    for (uint32_t resource_index = 0; resource_index < graph.resources.size(); ++resource_index) {
+        const auto& resource = graph.resources[resource_index];
+        auto normalize_states = [&](
+                                    const std::vector<RenderGraph::StateDeclaration>& declarations,
+                                    std::vector<NormalizedStateDeclaration>&          normalized_states,
+                                    bool                                              initial
+                                ) -> bool {
+            for (const auto& declaration : declarations) {
+                if (declaration.state.IsAutomatic()) {
+                    return Fail("boundary state cannot be automatic on resource '" + resource.name + "'");
+                }
+                if (declaration.queue == RenderGraph::QueueRole::None &&
+                    !declaration.state.IsUndefined()) {
+                    return Fail("a known boundary state requires an owner queue on resource '" + resource.name + "'");
+                }
+                if (!initial && declaration.state.IsUndefined()) {
+                    return Fail("an exported resource cannot require the undefined state: " + resource.name);
+                }
+                if (initial && !declaration.state.IsUndefined() &&
+                    declaration.boundary_access == RenderGraph::AccessMode::None) {
+                    return Fail("a known imported state must describe its previous access on resource '" +
+                                resource.name + "'");
+                }
+                if (initial && declaration.state.IsUndefined() &&
+                    declaration.boundary_access != RenderGraph::AccessMode::None) {
+                    return Fail("an undefined imported state must have no previous access on resource '" +
+                                resource.name + "'");
+                }
+                if (declaration.boundary_access != RenderGraph::AccessMode::None) {
+                    const bool supported = resource.kind == ResourceKind::Texture ?
+                                               TextureStateSupports(
+                                                   declaration.state.texture,
+                                                   declaration.boundary_access
+                                               ) :
+                                               BufferStateSupports(
+                                                   declaration.state.buffer,
+                                                   declaration.boundary_access
+                                               );
+                    if (!supported) {
+                        return Fail("boundary access is incompatible with the state on resource '" +
+                                    resource.name + "'");
+                    }
+                }
+                ResourceRange normalized{};
+                if (!NormalizeRange(resource, declaration.range, normalized)) {
+                    return false;
+                }
+                normalized_states.push_back(
+                    NormalizedStateDeclaration{
+                        normalized,
+                        declaration.state,
+                        declaration.queue,
+                        declaration.boundary_access
+                    }
+                );
+            }
+            return true;
+        };
+        if (!normalize_states(
+                resource.initial_states, normalized_initial_states[resource_index], true
+            ) ||
+            !normalize_states(resource.final_states, normalized_final_states[resource_index], false)) {
+            return false;
         }
     }
     return true;
@@ -116,14 +343,14 @@ bool RenderGraphCompiler::NormalizeDeclarations() {
 
 bool RenderGraphCompiler::NormalizeRange(
     const RenderGraph::ResourceDeclaration& resource,
-    const RenderGraph::AccessDeclaration&   access,
+    const ResourceRange&                    requested,
     ResourceRange&                          normalized
 ) {
-    if (access.range.kind != resource.kind) {
+    if (requested.kind != resource.kind) {
         return Fail("resource range kind does not match resource '" + resource.name + "'");
     }
 
-    normalized = access.range;
+    normalized = requested;
     switch (resource.kind) {
         case ResourceKind::Texture: {
             const auto&   desc          = resource.texture_desc;
@@ -191,6 +418,84 @@ bool RenderGraphCompiler::NormalizeRange(
     return true;
 }
 
+bool RenderGraphCompiler::ValidateExecutionDomain(uint32_t pass_index) {
+    const auto& pass   = graph.passes[pass_index];
+    const auto  queue  = pass.domain.queue;
+    const auto  domain = pass.domain.pipeline;
+    if (queue == RenderGraph::QueueRole::None || domain == RenderGraph::PipelineType::None) {
+        return Fail("pass '" + pass.name + "' has an incomplete execution domain");
+    }
+    if (queue == RenderGraph::QueueRole::Copy && domain != RenderGraph::PipelineType::Copy) {
+        return Fail("copy queue pass '" + pass.name + "' must use the copy pipeline domain");
+    }
+    if (domain == RenderGraph::PipelineType::Graphics &&
+        queue != RenderGraph::QueueRole::Graphics) {
+        return Fail("graphics pipeline pass '" + pass.name + "' must use the graphics queue");
+    }
+    if (domain == RenderGraph::PipelineType::RayTracing &&
+        queue == RenderGraph::QueueRole::Copy) {
+        return Fail("ray tracing pass '" + pass.name + "' cannot use the copy queue");
+    }
+    return true;
+}
+
+bool RenderGraphCompiler::ValidateAccessState(
+    uint32_t                                pass_index,
+    const RenderGraph::ResourceDeclaration& resource,
+    RenderGraph::AccessMode                 mode,
+    const RenderGraph::ResourceState&       state,
+    bool                                    explicit_state
+) {
+    if (resource.kind == ResourceKind::Token) {
+        return true;
+    }
+    if (!explicit_state || state.IsAutomatic()) {
+        if (explicit_state) {
+            return Fail("pass '" + graph.passes[pass_index].name +
+                        "' explicitly requested the automatic state");
+        }
+        graph.compiled_plan.state_plan_complete = false;
+        return true;
+    }
+
+    const auto& pass = graph.passes[pass_index];
+    bool        supported = false;
+    bool        transfer_state = false;
+    if (resource.kind == ResourceKind::Texture) {
+        supported = TextureStateSupports(state.texture, mode) &&
+                    state.texture != RenderGraph::TextureState::Undefined &&
+                    state.texture != RenderGraph::TextureState::Present;
+        transfer_state = state.texture == RenderGraph::TextureState::TransferSource ||
+                         state.texture == RenderGraph::TextureState::TransferDestination;
+        const bool attachment_state = state.texture == RenderGraph::TextureState::RenderTarget ||
+                                      state.texture == RenderGraph::TextureState::DepthStencilRead ||
+                                      state.texture == RenderGraph::TextureState::DepthStencilWrite;
+        if (attachment_state && pass.domain.pipeline != RenderGraph::PipelineType::Graphics) {
+            return Fail("attachment state requires the graphics pipeline in pass '" + pass.name + "'");
+        }
+    } else {
+        supported     = BufferStateSupports(state.buffer, mode) &&
+                    state.buffer != RenderGraph::BufferState::Undefined;
+        transfer_state = state.buffer == RenderGraph::BufferState::TransferSource ||
+                         state.buffer == RenderGraph::BufferState::TransferDestination;
+        const bool graphics_input = state.buffer == RenderGraph::BufferState::VertexBuffer ||
+                                    state.buffer == RenderGraph::BufferState::IndexBuffer;
+        if (graphics_input && pass.domain.pipeline != RenderGraph::PipelineType::Graphics) {
+            return Fail("vertex/index state requires the graphics pipeline in pass '" + pass.name + "'");
+        }
+    }
+    if (!supported) {
+        return Fail("access mode is incompatible with the explicit resource state in pass '" +
+                    pass.name + "'");
+    }
+    if ((pass.domain.queue == RenderGraph::QueueRole::Copy ||
+         pass.domain.pipeline == RenderGraph::PipelineType::Copy) &&
+        !transfer_state) {
+        return Fail("copy execution domain requires a transfer state in pass '" + pass.name + "'");
+    }
+    return true;
+}
+
 bool RenderGraphCompiler::BuildAtomicCells() {
     static constexpr std::array<TextureAspect, 3> texture_aspects{
         TextureAspect::Color, TextureAspect::Depth, TextureAspect::Stencil
@@ -203,18 +508,25 @@ bool RenderGraphCompiler::BuildAtomicCells() {
         if (resource.kind == ResourceKind::Texture) {
             std::vector<uint32_t> mip_boundaries{0, resource.texture_desc.mip_count};
             std::vector<uint32_t> layer_boundaries{0, resource.texture_desc.layer_count};
+            auto add_texture_boundaries = [&](const ResourceRange& range) {
+                mip_boundaries.push_back(range.texture.mip_first);
+                mip_boundaries.push_back(range.texture.mip_first + range.texture.mip_count);
+                layer_boundaries.push_back(range.texture.layer_first);
+                layer_boundaries.push_back(range.texture.layer_first + range.texture.layer_count);
+            };
             for (const auto& accesses : normalized_accesses) {
                 for (const auto& access : accesses) {
                     if (access.resource.index != resource_index) {
                         continue;
                     }
-                    mip_boundaries.push_back(access.range.texture.mip_first);
-                    mip_boundaries.push_back(access.range.texture.mip_first + access.range.texture.mip_count);
-                    layer_boundaries.push_back(access.range.texture.layer_first);
-                    layer_boundaries.push_back(
-                        access.range.texture.layer_first + access.range.texture.layer_count
-                    );
+                    add_texture_boundaries(access.range);
                 }
+            }
+            for (const auto& state : normalized_initial_states[resource_index]) {
+                add_texture_boundaries(state.range);
+            }
+            for (const auto& state : normalized_final_states[resource_index]) {
+                add_texture_boundaries(state.range);
             }
             SortUnique(mip_boundaries);
             SortUnique(layer_boundaries);
@@ -242,20 +554,34 @@ bool RenderGraphCompiler::BuildAtomicCells() {
                         });
                         cell.initialized = resource.imported;
                         cell.version     = resource.imported ? 0 : RenderGraph::InvalidVersion;
+                        cell.state       = RenderGraph::ResourceState::Texture(
+                            resource.imported ? RenderGraph::TextureState::Automatic :
+                                                RenderGraph::TextureState::Undefined
+                        );
+                        cell.state_known = !resource.imported;
                         cells.push_back(std::move(cell));
                     }
                 }
             }
         } else if (resource.kind == ResourceKind::Buffer && resource.buffer_desc.byte_size != 0) {
             std::vector<uint64_t> boundaries{0, resource.buffer_desc.byte_size};
+            auto add_buffer_boundaries = [&](const ResourceRange& range) {
+                boundaries.push_back(range.buffer.offset);
+                boundaries.push_back(range.buffer.offset + range.buffer.size);
+            };
             for (const auto& accesses : normalized_accesses) {
                 for (const auto& access : accesses) {
                     if (access.resource.index != resource_index) {
                         continue;
                     }
-                    boundaries.push_back(access.range.buffer.offset);
-                    boundaries.push_back(access.range.buffer.offset + access.range.buffer.size);
+                    add_buffer_boundaries(access.range);
                 }
+            }
+            for (const auto& state : normalized_initial_states[resource_index]) {
+                add_buffer_boundaries(state.range);
+            }
+            for (const auto& state : normalized_final_states[resource_index]) {
+                add_buffer_boundaries(state.range);
             }
             SortUnique(boundaries);
             for (uint32_t index = 0; index + 1 < boundaries.size(); ++index) {
@@ -268,6 +594,11 @@ bool RenderGraphCompiler::BuildAtomicCells() {
                 });
                 cell.initialized = resource.imported;
                 cell.version     = resource.imported ? 0 : RenderGraph::InvalidVersion;
+                cell.state       = RenderGraph::ResourceState::Buffer(
+                    resource.imported ? RenderGraph::BufferState::Automatic :
+                                        RenderGraph::BufferState::Undefined
+                );
+                cell.state_known = !resource.imported;
                 cells.push_back(std::move(cell));
             }
         } else {
@@ -275,11 +606,50 @@ bool RenderGraphCompiler::BuildAtomicCells() {
             cell.range       = ResourceRange::Whole(resource.kind);
             cell.initialized = resource.imported;
             cell.version     = resource.imported ? 0 : RenderGraph::InvalidVersion;
+            if (resource.kind == ResourceKind::Buffer) {
+                cell.state = RenderGraph::ResourceState::Buffer(
+                    resource.imported ? RenderGraph::BufferState::Automatic :
+                                        RenderGraph::BufferState::Undefined
+                );
+            } else {
+                cell.state = RenderGraph::ResourceState::Token();
+            }
+            cell.state_known = resource.kind == ResourceKind::Token || !resource.imported;
             cells.push_back(std::move(cell));
         }
 
         if (cells.empty()) {
             return Fail("resource produced no compiler intervals: " + resource.name);
+        }
+
+        for (const auto& initial : normalized_initial_states[resource_index]) {
+            bool matched = false;
+            for (auto& cell : cells) {
+                if (!RangesOverlap(initial.range, cell.range)) {
+                    continue;
+                }
+                matched = true;
+                if (cell.has_explicit_initial_state &&
+                    (cell.state != initial.state || cell.last_domain.queue != initial.queue ||
+                     cell.last_mode != initial.boundary_access)) {
+                    return Fail("overlapping initial states conflict on resource '" + resource.name + "'");
+                }
+                cell.state                       = initial.state;
+                cell.state_known                 = true;
+                cell.initialized                 = !initial.state.IsUndefined();
+                if (!cell.initialized) {
+                    cell.version = RenderGraph::InvalidVersion;
+                }
+                cell.last_domain                 = RenderGraph::ExecutionDomain{
+                    initial.queue, RenderGraph::PipelineType::None
+                };
+                cell.last_mode                    = initial.boundary_access;
+                cell.has_explicit_initial_state  = true;
+            }
+            if (!matched) {
+                return Fail("initial state did not map to a compiler interval on resource '" +
+                            resource.name + "'");
+            }
         }
     }
     return true;
@@ -314,10 +684,11 @@ bool RenderGraphCompiler::BuildSemanticDependencies() {
                 }
                 matched     = true;
                 auto& usage = resource_usages[cell_index];
-                usage.read |= access.mode == RenderGraph::AccessMode::Read ||
-                              access.mode == RenderGraph::AccessMode::ReadWrite;
-                usage.write |= access.mode == RenderGraph::AccessMode::Write ||
-                               access.mode == RenderGraph::AccessMode::ReadWrite;
+                if (!MergeCellState(
+                        pass_index, graph.resources[access.resource.index], usage, access
+                    )) {
+                    return false;
+                }
             }
             if (!matched) {
                 return Fail("access range did not map to a compiler interval in pass '" + pass.name + "'");
@@ -342,6 +713,142 @@ bool RenderGraphCompiler::BuildSemanticDependencies() {
                 auto&          cell            = resource_cells[resource_index][cell_index];
                 const uint32_t input_version   = cell.version;
                 const auto     resource_handle = RenderGraph::ResourceHandle{resource_index, graph.graph_id};
+                const auto&    resource        = graph.resources[resource_index];
+                const auto     access_mode     = ToAccessMode(usage.read, usage.write);
+                const auto     next_state      = usage.explicit_state ?
+                                                    usage.state :
+                                                    RenderGraph::ResourceState{.kind = resource.kind};
+
+                const bool physical_resource = resource.kind != ResourceKind::Token;
+                const bool source_state_unknown = physical_resource && !cell.state_known;
+                const bool state_transition =
+                    physical_resource && usage.explicit_state &&
+                    (source_state_unknown || !StatesCompatible(cell.state, next_state));
+
+                std::vector<RenderGraph::CompiledBarrierSource> barrier_sources{};
+                auto append_source = [&](const RenderGraph::CompiledBarrierSource& source) {
+                    if (!source.pass.IsValid()) {
+                        return;
+                    }
+                    if (std::find(barrier_sources.begin(), barrier_sources.end(), source) ==
+                        barrier_sources.end()) {
+                        barrier_sources.push_back(source);
+                    }
+                };
+                if (usage.read && cell.last_writer != RenderGraph::PassHandle::InvalidIndex) {
+                    append_source(cell.last_writer_source);
+                }
+                if (usage.write) {
+                    if (cell.last_writer != RenderGraph::PassHandle::InvalidIndex) {
+                        append_source(cell.last_writer_source);
+                    }
+                    for (const auto& reader : cell.readers) {
+                        append_source(reader);
+                    }
+                }
+
+                const bool boundary_memory_dependency =
+                    cell.last_access == RenderGraph::PassHandle::InvalidIndex &&
+                    cell.last_mode != RenderGraph::AccessMode::None &&
+                    (HasWrite(cell.last_mode) || usage.write);
+                const bool memory_dependency =
+                    physical_resource && (!barrier_sources.empty() || boundary_memory_dependency);
+
+                bool queue_ownership = false;
+                if (physical_resource && cell.last_domain.queue != RenderGraph::QueueRole::None) {
+                    const auto src_queue = graph.queue_topology.Resolve(cell.last_domain.queue);
+                    const auto dst_queue = graph.queue_topology.Resolve(pass.domain.queue);
+                    queue_ownership = IsExclusive(resource) &&
+                                      src_queue.family_id != dst_queue.family_id;
+                }
+
+                if (state_transition || queue_ownership) {
+                    for (const auto& reader : cell.readers) {
+                        append_source(reader);
+                    }
+                    if (cell.last_access != RenderGraph::PassHandle::InvalidIndex &&
+                        barrier_sources.empty()) {
+                        append_source(RenderGraph::CompiledBarrierSource{
+                            .pass   = RenderGraph::PassHandle{cell.last_access, graph.graph_id},
+                            .state  = cell.state,
+                            .access = cell.last_mode,
+                            .domain = cell.last_domain,
+                        });
+                    }
+                    for (const auto& source : barrier_sources) {
+                        if (state_transition) {
+                            AddEdge(
+                                source.pass.index,
+                                pass_index,
+                                RenderGraph::CompiledEdgeReason{
+                                    .kind           = RenderGraph::EdgeReasonKind::StateTransition,
+                                    .resource       = resource_handle,
+                                    .range          = cell.range,
+                                    .input_version  = cell.version,
+                                    .output_version = cell.version
+                                }
+                            );
+                        }
+                        if (queue_ownership) {
+                            AddEdge(
+                                source.pass.index,
+                                pass_index,
+                                RenderGraph::CompiledEdgeReason{
+                                    .kind           = RenderGraph::EdgeReasonKind::QueueOwnership,
+                                    .resource       = resource_handle,
+                                    .range          = cell.range,
+                                    .input_version  = cell.version,
+                                    .output_version = cell.version
+                                }
+                            );
+                        }
+                    }
+                }
+
+                if (!state_transition && usage.explicit_state &&
+                    cell.state_established_pass != RenderGraph::PassHandle::InvalidIndex &&
+                    cell.state_established_pass != pass_index) {
+                    const auto& established_pass = graph.passes[cell.state_established_pass];
+                    if (graph.queue_topology.Resolve(established_pass.domain.queue).native_queue_id !=
+                        graph.queue_topology.Resolve(pass.domain.queue).native_queue_id) {
+                        AddEdge(
+                            cell.state_established_pass,
+                            pass_index,
+                            RenderGraph::CompiledEdgeReason{
+                                .kind           = RenderGraph::EdgeReasonKind::StateTransition,
+                                .resource       = resource_handle,
+                                .range          = cell.range,
+                                .input_version  = cell.version,
+                                .output_version = cell.version
+                            }
+                        );
+                    }
+                }
+
+                const bool import_boundary = resource.imported &&
+                                             cell.last_access == RenderGraph::PassHandle::InvalidIndex;
+                if (physical_resource &&
+                    (state_transition || memory_dependency || queue_ownership ||
+                     (import_boundary && cell.has_explicit_initial_state))) {
+                    AddBarrier(
+                        resource_index,
+                        cell,
+                        RenderGraph::PassHandle{pass_index, graph.graph_id},
+                        next_state,
+                        pass.domain,
+                        access_mode,
+                        state_transition,
+                        memory_dependency,
+                        queue_ownership,
+                        import_boundary,
+                        false,
+                        source_state_unknown,
+                        std::move(barrier_sources)
+                    );
+                }
+                if (source_state_unknown && usage.explicit_state) {
+                    graph.compiled_plan.state_plan_complete = false;
+                }
 
                 if (usage.read) {
                     if (!cell.initialized) {
@@ -379,9 +886,9 @@ bool RenderGraphCompiler::BuildSemanticDependencies() {
                             }
                         );
                     }
-                    for (const uint32_t reader : cell.readers) {
+                    for (const auto& reader : cell.readers) {
                         AddEdge(
-                            reader,
+                            reader.pass.index,
                             pass_index,
                             RenderGraph::CompiledEdgeReason{
                                 .kind           = RenderGraph::EdgeReasonKind::WriteAfterRead,
@@ -394,22 +901,49 @@ bool RenderGraphCompiler::BuildSemanticDependencies() {
                     }
                     cell.readers.clear();
                     cell.last_writer                      = pass_index;
+                    cell.last_writer_source               = RenderGraph::CompiledBarrierSource{
+                        .pass   = RenderGraph::PassHandle{pass_index, graph.graph_id},
+                        .state  = next_state,
+                        .access = access_mode,
+                        .domain = pass.domain,
+                    };
                     cell.version                          = output_version;
                     cell.initialized                      = true;
                     resource_ever_written[resource_index] = true;
-                } else if (std::find(cell.readers.begin(), cell.readers.end(), pass_index) ==
-                           cell.readers.end()) {
-                    cell.readers.push_back(pass_index);
+                } else {
+                    const auto reader = RenderGraph::CompiledBarrierSource{
+                        .pass   = RenderGraph::PassHandle{pass_index, graph.graph_id},
+                        .state  = next_state,
+                        .access = access_mode,
+                        .domain = pass.domain,
+                    };
+                    if (std::find(cell.readers.begin(), cell.readers.end(), reader) ==
+                        cell.readers.end()) {
+                        cell.readers.push_back(reader);
+                    }
                 }
 
                 graph.compiled_plan.accesses.push_back(RenderGraph::CompiledAccess{
                     .pass           = RenderGraph::PassHandle{pass_index, graph.graph_id},
                     .resource       = resource_handle,
-                    .mode           = ToAccessMode(usage.read, usage.write),
+                    .mode           = access_mode,
                     .range          = cell.range,
+                    .state          = next_state,
+                    .domain         = pass.domain,
                     .input_version  = input_version,
                     .output_version = usage.write ? output_version : input_version
                 });
+
+                cell.last_access = pass_index;
+                cell.last_domain = pass.domain;
+                cell.last_mode   = access_mode;
+                cell.state       = next_state;
+                cell.state_known = usage.explicit_state;
+                if (state_transition) {
+                    cell.state_established_pass = pass_index;
+                } else if (!usage.explicit_state) {
+                    cell.state_established_pass = RenderGraph::PassHandle::InvalidIndex;
+                }
             }
         }
     }
@@ -433,6 +967,207 @@ bool RenderGraphCompiler::BuildSemanticDependencies() {
         }
     }
     return true;
+}
+
+bool RenderGraphCompiler::MergeCellState(
+    uint32_t                                pass_index,
+    const RenderGraph::ResourceDeclaration& resource,
+    CellUsage&                              usage,
+    const NormalizedAccess&                 access
+) {
+    const bool had_access = usage.read || usage.write;
+    usage.read |= HasRead(access.mode);
+    usage.write |= HasWrite(access.mode);
+
+    if (!had_access) {
+        usage.state          = access.state;
+        usage.explicit_state = access.explicit_state;
+    } else if (access.explicit_state) {
+        if (usage.explicit_state) {
+            if (!StatesCompatible(usage.state, access.state)) {
+                return Fail("pass '" + graph.passes[pass_index].name +
+                            "' requests conflicting states for one atomic cell of resource '" +
+                            resource.name + "'");
+            }
+            usage.state = CanonicalCompatibleState(usage.state, access.state);
+        } else {
+            usage.state          = access.state;
+            usage.explicit_state = true;
+        }
+    }
+
+    if (usage.explicit_state) {
+        const auto combined_mode = ToAccessMode(usage.read, usage.write);
+        const bool supported = resource.kind == ResourceKind::Texture ?
+                                   TextureStateSupports(usage.state.texture, combined_mode) :
+                               resource.kind == ResourceKind::Buffer ?
+                                   BufferStateSupports(usage.state.buffer, combined_mode) :
+                                   true;
+        if (!supported) {
+            return Fail("combined accesses in pass '" + graph.passes[pass_index].name +
+                        "' are incompatible with the explicit state of resource '" + resource.name +
+                        "'");
+        }
+    }
+    return true;
+}
+
+void RenderGraphCompiler::AddBarrier(
+    uint32_t                     resource_index,
+    const AtomicCell&            cell,
+    RenderGraph::PassHandle      dst_pass,
+    RenderGraph::ResourceState   next_state,
+    RenderGraph::ExecutionDomain next_domain,
+    RenderGraph::AccessMode      next_mode,
+    bool                         state_transition,
+    bool                         memory_dependency,
+    bool                         queue_ownership,
+    bool                         import_boundary,
+    bool                         export_boundary,
+    bool                         source_state_unknown,
+    std::vector<RenderGraph::CompiledBarrierSource> sources
+) {
+    const auto primary_source = std::max_element(
+        sources.begin(),
+        sources.end(),
+        [](const RenderGraph::CompiledBarrierSource& lhs,
+           const RenderGraph::CompiledBarrierSource& rhs) {
+            return lhs.pass.index < rhs.pass.index;
+        }
+    );
+    const auto src_pass = primary_source == sources.end() ? RenderGraph::PassHandle{} :
+                                                            primary_source->pass;
+    const auto src_domain = primary_source == sources.end() ? cell.last_domain :
+                                                              primary_source->domain;
+    const auto src_access = primary_source == sources.end() ? cell.last_mode :
+                                                              primary_source->access;
+    const bool execution_dependency = dst_pass.IsValid() && !sources.empty();
+    bool       queue_dependency     = false;
+    if (next_domain.queue != RenderGraph::QueueRole::None) {
+        const auto dst_native = graph.queue_topology.Resolve(next_domain.queue).native_queue_id;
+        if (sources.empty()) {
+            queue_dependency = cell.last_domain.queue != RenderGraph::QueueRole::None &&
+                               graph.queue_topology.Resolve(cell.last_domain.queue).native_queue_id !=
+                                   dst_native;
+        } else {
+            for (const auto& source : sources) {
+                if (source.domain.queue != RenderGraph::QueueRole::None &&
+                    graph.queue_topology.Resolve(source.domain.queue).native_queue_id != dst_native) {
+                    queue_dependency = true;
+                    break;
+                }
+            }
+        }
+    }
+    graph.compiled_plan.barriers.push_back(RenderGraph::CompiledBarrier{
+        .resource             = RenderGraph::ResourceHandle{resource_index, graph.graph_id},
+        .range                = cell.range,
+        .src_pass             = src_pass,
+        .dst_pass             = dst_pass,
+        .before_state         = cell.state,
+        .after_state          = next_state,
+        .before_access        = src_access,
+        .after_access         = next_mode,
+        .src_domain           = src_domain,
+        .dst_domain           = next_domain,
+        .state_transition     = state_transition,
+        .memory_dependency    = memory_dependency,
+        .execution_dependency = execution_dependency,
+        .queue_dependency     = queue_dependency,
+        .queue_ownership      = queue_ownership,
+        .discard_previous_contents = cell.state_known && cell.state.IsUndefined(),
+        .import_boundary      = import_boundary,
+        .export_boundary      = export_boundary,
+        .source_state_unknown = source_state_unknown,
+        .sources              = std::move(sources)
+    });
+}
+
+bool RenderGraphCompiler::BuildFinalBarriers() {
+    for (uint32_t resource_index = 0; resource_index < graph.resources.size(); ++resource_index) {
+        const auto& resource = graph.resources[resource_index];
+        const auto& finals   = normalized_final_states[resource_index];
+        if (finals.empty()) {
+            continue;
+        }
+        for (const auto& cell : resource_cells[resource_index]) {
+            const NormalizedStateDeclaration* final = nullptr;
+            for (const auto& candidate : finals) {
+                if (!RangesOverlap(candidate.range, cell.range)) {
+                    continue;
+                }
+                if (final != nullptr &&
+                    (final->state != candidate.state || final->queue != candidate.queue ||
+                     final->boundary_access != candidate.boundary_access)) {
+                    return Fail("overlapping final states conflict on resource '" + resource.name + "'");
+                }
+                final = &candidate;
+            }
+            if (final == nullptr) {
+                continue;
+            }
+
+            const bool source_state_unknown = !cell.state_known;
+            const bool state_transition =
+                source_state_unknown || !StatesCompatible(cell.state, final->state);
+            std::vector<RenderGraph::CompiledBarrierSource> sources = cell.readers;
+            if (cell.last_writer_source.pass.IsValid() &&
+                std::find(sources.begin(), sources.end(), cell.last_writer_source) == sources.end()) {
+                sources.push_back(cell.last_writer_source);
+            }
+            const bool source_write = std::any_of(
+                sources.begin(), sources.end(), [](const RenderGraph::CompiledBarrierSource& source) {
+                    return HasWrite(source.access);
+                }
+            );
+            const bool boundary_source_write = sources.empty() && HasWrite(cell.last_mode);
+            const bool memory_dependency =
+                final->boundary_access != RenderGraph::AccessMode::None &&
+                (source_write || boundary_source_write || HasWrite(final->boundary_access));
+            bool queue_ownership = false;
+            if (cell.last_domain.queue != RenderGraph::QueueRole::None) {
+                const auto src_queue = graph.queue_topology.Resolve(cell.last_domain.queue);
+                const auto dst_queue = graph.queue_topology.Resolve(final->queue);
+                queue_ownership = IsExclusive(resource) && src_queue.family_id != dst_queue.family_id;
+            }
+            AddBarrier(
+                resource_index,
+                cell,
+                RenderGraph::PassHandle{},
+                final->state,
+                RenderGraph::ExecutionDomain{final->queue, RenderGraph::PipelineType::None},
+                final->boundary_access,
+                state_transition,
+                memory_dependency,
+                queue_ownership,
+                false,
+                true,
+                source_state_unknown,
+                std::move(sources)
+            );
+            if (source_state_unknown) {
+                graph.compiled_plan.state_plan_complete = false;
+            }
+        }
+    }
+    return true;
+}
+
+void RenderGraphCompiler::AuditStatePlanCompleteness() {
+    for (uint32_t resource_index = 0; resource_index < graph.resources.size(); ++resource_index) {
+        const auto& resource = graph.resources[resource_index];
+        if (resource.kind == ResourceKind::Token) {
+            continue;
+        }
+        for (const auto& cell : resource_cells[resource_index]) {
+            const bool participates_in_plan =
+                resource.exported || cell.last_access != RenderGraph::PassHandle::InvalidIndex;
+            if (participates_in_plan && !cell.state_known) {
+                graph.compiled_plan.state_plan_complete = false;
+                return;
+            }
+        }
+    }
 }
 
 void RenderGraphCompiler::AddEdge(uint32_t src, uint32_t dst, RenderGraph::CompiledEdgeReason reason) {
@@ -515,6 +1250,182 @@ bool RenderGraphCompiler::BuildExecutionOrder() {
         }
     }
     return true;
+}
+
+void RenderGraphCompiler::BuildQueuePlan() {
+    std::vector<uint32_t> pass_to_batch(
+        graph.passes.size(), RenderGraph::PassHandle::InvalidIndex
+    );
+    for (const auto pass_handle : graph.compiled_plan.execution_order) {
+        const auto& pass    = graph.passes[pass_handle.index];
+        const auto  binding = graph.queue_topology.Resolve(pass.domain.queue);
+        if (graph.compiled_plan.queue_batches.empty() ||
+            graph.compiled_plan.queue_batches.back().queue.role != binding.role) {
+            const uint32_t batch_id =
+                static_cast<uint32_t>(graph.compiled_plan.queue_batches.size());
+            graph.compiled_plan.queue_batches.push_back(RenderGraph::CompiledQueueBatch{
+                .id = batch_id,
+                .queue = binding,
+            });
+        }
+        auto& batch = graph.compiled_plan.queue_batches.back();
+        batch.passes.push_back(pass_handle);
+        pass_to_batch[pass_handle.index] = batch.id;
+    }
+
+    graph.compiled_plan.pass_barriers.reserve(graph.passes.size());
+    for (uint32_t pass_index = 0; pass_index < graph.passes.size(); ++pass_index) {
+        graph.compiled_plan.pass_barriers.push_back(RenderGraph::CompiledPassBarriers{
+            .pass = RenderGraph::PassHandle{pass_index, graph.graph_id},
+        });
+    }
+
+    auto add_batch_dependency = [&](
+                                    uint32_t signal_batch,
+                                    uint32_t wait_batch,
+                                    bool     gpu_wait_required,
+                                    uint32_t edge_index
+                                ) -> RenderGraph::CompiledQueueSync& {
+        auto existing = std::find_if(
+            graph.compiled_plan.queue_syncs.begin(),
+            graph.compiled_plan.queue_syncs.end(),
+            [&](const RenderGraph::CompiledQueueSync& sync) {
+                return sync.signal_batch == signal_batch && sync.wait_batch == wait_batch;
+            }
+        );
+        if (existing != graph.compiled_plan.queue_syncs.end()) {
+            existing->gpu_wait_required |= gpu_wait_required;
+            if (edge_index != RenderGraph::PassHandle::InvalidIndex &&
+                std::find(
+                    existing->dependency_edges.begin(),
+                    existing->dependency_edges.end(),
+                    edge_index
+                ) == existing->dependency_edges.end()) {
+                existing->dependency_edges.push_back(edge_index);
+            }
+            return *existing;
+        }
+
+        auto& producer = graph.compiled_plan.queue_batches[signal_batch];
+        auto& consumer = graph.compiled_plan.queue_batches[wait_batch];
+        const uint32_t sync_id = static_cast<uint32_t>(graph.compiled_plan.queue_syncs.size());
+        graph.compiled_plan.queue_syncs.push_back(RenderGraph::CompiledQueueSync{
+            .id                = sync_id,
+            .signal_pass       = producer.passes.back(),
+            .wait_pass         = consumer.passes.front(),
+            .signal_queue      = producer.queue,
+            .wait_queue        = consumer.queue,
+            .signal_batch      = signal_batch,
+            .wait_batch        = wait_batch,
+            .gpu_wait_required = gpu_wait_required,
+            .dependency_edges  = edge_index == RenderGraph::PassHandle::InvalidIndex ?
+                                     std::vector<uint32_t>{} :
+                                     std::vector<uint32_t>{edge_index},
+        });
+        producer.signal_syncs.push_back(sync_id);
+        consumer.wait_syncs.push_back(sync_id);
+        return graph.compiled_plan.queue_syncs.back();
+    };
+
+    for (uint32_t edge_index = 0; edge_index < graph.compiled_plan.edges.size(); ++edge_index) {
+        const auto& edge = graph.compiled_plan.edges[edge_index];
+        const uint32_t signal_batch = pass_to_batch[edge.src.index];
+        const uint32_t wait_batch   = pass_to_batch[edge.dst.index];
+        if (signal_batch == wait_batch) {
+            continue;
+        }
+        const auto& producer = graph.compiled_plan.queue_batches[signal_batch];
+        const auto& consumer = graph.compiled_plan.queue_batches[wait_batch];
+        add_batch_dependency(
+            signal_batch,
+            wait_batch,
+            producer.queue.native_queue_id != consumer.queue.native_queue_id,
+            edge_index
+        );
+    }
+
+    for (uint32_t wait_batch = 0; wait_batch < graph.compiled_plan.queue_batches.size(); ++wait_batch) {
+        const auto native_queue_id =
+            graph.compiled_plan.queue_batches[wait_batch].queue.native_queue_id;
+        for (uint32_t candidate = wait_batch; candidate > 0; --candidate) {
+            const uint32_t signal_batch = candidate - 1;
+            if (graph.compiled_plan.queue_batches[signal_batch].queue.native_queue_id ==
+                native_queue_id) {
+                add_batch_dependency(
+                    signal_batch,
+                    wait_batch,
+                    false,
+                    RenderGraph::PassHandle::InvalidIndex
+                );
+                break;
+            }
+        }
+    }
+
+    for (uint32_t barrier_index = 0; barrier_index < graph.compiled_plan.barriers.size();
+         ++barrier_index) {
+        const auto& barrier = graph.compiled_plan.barriers[barrier_index];
+        if (barrier.import_boundary && !barrier.src_pass.IsValid()) {
+            graph.compiled_plan.prologue_barriers.push_back(barrier_index);
+        }
+        if (barrier.export_boundary && !barrier.dst_pass.IsValid()) {
+            graph.compiled_plan.epilogue_barriers.push_back(barrier_index);
+        }
+        if (barrier.dst_pass.IsValid()) {
+            const uint32_t dst_batch = pass_to_batch[barrier.dst_pass.index];
+            graph.compiled_plan.pass_barriers[barrier.dst_pass.index].before.push_back(barrier_index);
+            if (!barrier.src_pass.IsValid() || barrier.queue_dependency) {
+                graph.compiled_plan.queue_batches[dst_batch].pre_barriers.push_back(barrier_index);
+            }
+        }
+        auto add_post_barrier = [&](RenderGraph::PassHandle source_pass) {
+            if (!source_pass.IsValid() || !barrier.dst_pass.IsValid()) {
+                return;
+            }
+            const uint32_t src_batch = pass_to_batch[source_pass.index];
+            const uint32_t dst_batch = pass_to_batch[barrier.dst_pass.index];
+            if (graph.compiled_plan.queue_batches[src_batch].queue.native_queue_id ==
+                graph.compiled_plan.queue_batches[dst_batch].queue.native_queue_id) {
+                return;
+            }
+            auto& post = graph.compiled_plan.queue_batches[src_batch].post_barriers;
+            if (std::find(post.begin(), post.end(), barrier_index) == post.end()) {
+                post.push_back(barrier_index);
+            }
+        };
+        for (const auto& source : barrier.sources) {
+            add_post_barrier(source.pass);
+        }
+        if (!barrier.dst_pass.IsValid() || !barrier.queue_dependency) {
+            continue;
+        }
+        const uint32_t dst_batch = pass_to_batch[barrier.dst_pass.index];
+        auto attach_to_sync = [&](RenderGraph::PassHandle source_pass) {
+            if (!source_pass.IsValid()) {
+                return;
+            }
+            const uint32_t src_batch = pass_to_batch[source_pass.index];
+            if (graph.compiled_plan.queue_batches[src_batch].queue.native_queue_id ==
+                graph.compiled_plan.queue_batches[dst_batch].queue.native_queue_id) {
+                return;
+            }
+            auto sync = std::find_if(
+                graph.compiled_plan.queue_syncs.begin(),
+                graph.compiled_plan.queue_syncs.end(),
+                [&](const RenderGraph::CompiledQueueSync& candidate) {
+                    return candidate.signal_batch == src_batch && candidate.wait_batch == dst_batch;
+                }
+            );
+            if (sync != graph.compiled_plan.queue_syncs.end() &&
+                std::find(sync->barriers.begin(), sync->barriers.end(), barrier_index) ==
+                    sync->barriers.end()) {
+                sync->barriers.push_back(barrier_index);
+            }
+        };
+        for (const auto& source : barrier.sources) {
+            attach_to_sync(source.pass);
+        }
+    }
 }
 
 void RenderGraphCompiler::BuildDependencyWaves() {

--- a/source/runtime/render/rendergraph/RenderGraphCompiler.cpp
+++ b/source/runtime/render/rendergraph/RenderGraphCompiler.cpp
@@ -180,6 +180,19 @@ template<typename ResourceDeclaration>
                false;
 }
 
+void RetainCurrentOwnerFamilySources(
+    std::vector<RenderGraph::CompiledBarrierSource>& sources,
+    const RenderGraph::QueueTopology&                topology,
+    RenderGraph::QueueRole                           owner_queue
+) {
+    assert(owner_queue != RenderGraph::QueueRole::None);
+    const uint32_t owner_family = topology.Resolve(owner_queue).family_id;
+    std::erase_if(sources, [&](const RenderGraph::CompiledBarrierSource& source) {
+        return source.domain.queue == RenderGraph::QueueRole::None ||
+               topology.Resolve(source.domain.queue).family_id != owner_family;
+    });
+}
+
 } // namespace
 
 bool RenderGraphCompiler::Compile() {
@@ -766,6 +779,14 @@ bool RenderGraphCompiler::BuildSemanticDependencies() {
                     for (const auto& reader : cell.readers) {
                         append_source(reader);
                     }
+                    if (queue_ownership) {
+                        // Only accesses in the currently owning family can participate in the
+                        // next release. Older-family readers are already ordered through the
+                        // ownership chain and must not receive another release placement.
+                        RetainCurrentOwnerFamilySources(
+                            barrier_sources, graph.queue_topology, cell.last_domain.queue
+                        );
+                    }
                     if (cell.last_access != RenderGraph::PassHandle::InvalidIndex &&
                         barrier_sources.empty()) {
                         append_source(RenderGraph::CompiledBarrierSource{
@@ -805,17 +826,37 @@ bool RenderGraphCompiler::BuildSemanticDependencies() {
                     }
                 }
 
-                if (!state_transition && usage.explicit_state &&
-                    cell.state_established_pass != RenderGraph::PassHandle::InvalidIndex &&
-                    cell.state_established_pass != pass_index) {
-                    const auto& established_pass = graph.passes[cell.state_established_pass];
+                if (physical_resource && !state_transition && !queue_ownership &&
+                    cell.availability_established_pass != RenderGraph::PassHandle::InvalidIndex &&
+                    cell.availability_established_pass != pass_index) {
+                    const auto& established_pass =
+                        graph.passes[cell.availability_established_pass];
                     if (graph.queue_topology.Resolve(established_pass.domain.queue).native_queue_id !=
                         graph.queue_topology.Resolve(pass.domain.queue).native_queue_id) {
                         AddEdge(
-                            cell.state_established_pass,
+                            cell.availability_established_pass,
                             pass_index,
                             RenderGraph::CompiledEdgeReason{
                                 .kind           = RenderGraph::EdgeReasonKind::StateTransition,
+                                .resource       = resource_handle,
+                                .range          = cell.range,
+                                .input_version  = cell.version,
+                                .output_version = cell.version
+                            }
+                        );
+                    }
+                }
+                if (!state_transition && !queue_ownership &&
+                    cell.ownership_established_pass != RenderGraph::PassHandle::InvalidIndex &&
+                    cell.ownership_established_pass != pass_index) {
+                    const auto& established_pass = graph.passes[cell.ownership_established_pass];
+                    if (graph.queue_topology.Resolve(established_pass.domain.queue).native_queue_id !=
+                        graph.queue_topology.Resolve(pass.domain.queue).native_queue_id) {
+                        AddEdge(
+                            cell.ownership_established_pass,
+                            pass_index,
+                            RenderGraph::CompiledEdgeReason{
+                                .kind           = RenderGraph::EdgeReasonKind::QueueOwnership,
                                 .resource       = resource_handle,
                                 .range          = cell.range,
                                 .input_version  = cell.version,
@@ -911,6 +952,17 @@ bool RenderGraphCompiler::BuildSemanticDependencies() {
                     cell.initialized                      = true;
                     resource_ever_written[resource_index] = true;
                 } else {
+                    if (state_transition || queue_ownership) {
+                        // The current read is ordered after the complete old frontier and becomes
+                        // the only reader needed for later state/ownership transitions. Same-state
+                        // concurrent reads keep accumulating above because neither flag is set.
+                        cell.readers.clear();
+                        // The previous writer's visibility and dependency are now carried
+                        // transitively by this read. Preserve the logical version, but drop the
+                        // old writer endpoint so queue planning cannot lower a stale direct sync.
+                        cell.last_writer        = RenderGraph::PassHandle::InvalidIndex;
+                        cell.last_writer_source = {};
+                    }
                     const auto reader = RenderGraph::CompiledBarrierSource{
                         .pass   = RenderGraph::PassHandle{pass_index, graph.graph_id},
                         .state  = next_state,
@@ -939,10 +991,21 @@ bool RenderGraphCompiler::BuildSemanticDependencies() {
                 cell.last_mode   = access_mode;
                 cell.state       = next_state;
                 cell.state_known = usage.explicit_state;
-                if (state_transition) {
-                    cell.state_established_pass = pass_index;
-                } else if (!usage.explicit_state) {
-                    cell.state_established_pass = RenderGraph::PassHandle::InvalidIndex;
+                const bool import_availability = import_boundary && memory_dependency;
+                if (physical_resource &&
+                    (usage.write || import_availability || state_transition || queue_ownership)) {
+                    // This pass has ordered the complete prior frontier and becomes the source of
+                    // state/data availability for sibling native queues. Automatic accesses still
+                    // inherit this dependency even though they make the logical state unknown.
+                    cell.availability_established_pass = pass_index;
+                }
+                if (((usage.write || import_availability) && IsExclusive(resource)) ||
+                    queue_ownership ||
+                    (state_transition && IsExclusive(resource))) {
+                    // Writes and import-memory barriers similarly become the authoritative
+                    // frontier inside the current owner family, so sibling native queues never
+                    // bypass external availability or wait on an older acquire.
+                    cell.ownership_established_pass = pass_index;
                 }
             }
         }
@@ -954,14 +1017,23 @@ bool RenderGraphCompiler::BuildSemanticDependencies() {
             return Fail("transient resource has no producer: " + resource.name);
         }
         if (!resource.imported && resource.exported) {
-            const bool fully_initialized = std::all_of(
+            const auto& final_states = normalized_final_states[resource_index];
+            const bool exported_ranges_initialized = std::all_of(
                 resource_cells[resource_index].begin(),
                 resource_cells[resource_index].end(),
-                [](const AtomicCell& cell) {
-                    return cell.initialized;
+                [&](const AtomicCell& cell) {
+                    const bool exported_cell = resource.whole_resource_exported ||
+                                               std::any_of(
+                                                   final_states.begin(),
+                                                   final_states.end(),
+                                                   [&](const NormalizedStateDeclaration& final) {
+                                                       return RangesOverlap(final.range, cell.range);
+                                                   }
+                                               );
+                    return !exported_cell || cell.initialized;
                 }
             );
-            if (!fully_initialized) {
+            if (!exported_ranges_initialized) {
                 return Fail("exported transient resource has uninitialized subresources: " + resource.name);
             }
         }
@@ -1115,6 +1187,25 @@ bool RenderGraphCompiler::BuildFinalBarriers() {
                 std::find(sources.begin(), sources.end(), cell.last_writer_source) == sources.end()) {
                 sources.push_back(cell.last_writer_source);
             }
+            bool queue_ownership = false;
+            if (cell.last_domain.queue != RenderGraph::QueueRole::None) {
+                const auto src_queue = graph.queue_topology.Resolve(cell.last_domain.queue);
+                const auto dst_queue = graph.queue_topology.Resolve(final->queue);
+                queue_ownership = IsExclusive(resource) && src_queue.family_id != dst_queue.family_id;
+            }
+            if (queue_ownership) {
+                RetainCurrentOwnerFamilySources(
+                    sources, graph.queue_topology, cell.last_domain.queue
+                );
+                if (sources.empty() && cell.last_access != RenderGraph::PassHandle::InvalidIndex) {
+                    sources.push_back(RenderGraph::CompiledBarrierSource{
+                        .pass   = RenderGraph::PassHandle{cell.last_access, graph.graph_id},
+                        .state  = cell.state,
+                        .access = cell.last_mode,
+                        .domain = cell.last_domain,
+                    });
+                }
+            }
             const bool source_write = std::any_of(
                 sources.begin(), sources.end(), [](const RenderGraph::CompiledBarrierSource& source) {
                     return HasWrite(source.access);
@@ -1124,12 +1215,6 @@ bool RenderGraphCompiler::BuildFinalBarriers() {
             const bool memory_dependency =
                 final->boundary_access != RenderGraph::AccessMode::None &&
                 (source_write || boundary_source_write || HasWrite(final->boundary_access));
-            bool queue_ownership = false;
-            if (cell.last_domain.queue != RenderGraph::QueueRole::None) {
-                const auto src_queue = graph.queue_topology.Resolve(cell.last_domain.queue);
-                const auto dst_queue = graph.queue_topology.Resolve(final->queue);
-                queue_ownership = IsExclusive(resource) && src_queue.family_id != dst_queue.family_id;
-            }
             AddBarrier(
                 resource_index,
                 cell,
@@ -1159,9 +1244,18 @@ void RenderGraphCompiler::AuditStatePlanCompleteness() {
         if (resource.kind == ResourceKind::Token) {
             continue;
         }
+        const auto& final_states = normalized_final_states[resource_index];
         for (const auto& cell : resource_cells[resource_index]) {
-            const bool participates_in_plan =
-                resource.exported || cell.last_access != RenderGraph::PassHandle::InvalidIndex;
+            const bool exported_cell = resource.whole_resource_exported ||
+                                       std::any_of(
+                                           final_states.begin(),
+                                           final_states.end(),
+                                           [&](const NormalizedStateDeclaration& final) {
+                                               return RangesOverlap(final.range, cell.range);
+                                           }
+                                       );
+            const bool participates_in_plan = exported_cell ||
+                                              cell.last_access != RenderGraph::PassHandle::InvalidIndex;
             if (participates_in_plan && !cell.state_known) {
                 graph.compiled_plan.state_plan_complete = false;
                 return;

--- a/source/runtime/render/rendergraph/RenderGraphCompiler.cpp
+++ b/source/runtime/render/rendergraph/RenderGraphCompiler.cpp
@@ -1016,25 +1016,33 @@ bool RenderGraphCompiler::BuildSemanticDependencies() {
         if (!resource.imported && !resource_ever_written[resource_index]) {
             return Fail("transient resource has no producer: " + resource.name);
         }
-        if (!resource.imported && resource.exported) {
+        if (resource.exported) {
             const auto& final_states = normalized_final_states[resource_index];
             const bool exported_ranges_initialized = std::all_of(
                 resource_cells[resource_index].begin(),
                 resource_cells[resource_index].end(),
                 [&](const AtomicCell& cell) {
-                    const bool exported_cell = resource.whole_resource_exported ||
-                                               std::any_of(
-                                                   final_states.begin(),
-                                                   final_states.end(),
-                                                   [&](const NormalizedStateDeclaration& final) {
-                                                       return RangesOverlap(final.range, cell.range);
-                                                   }
-                                               );
-                    return !exported_cell || cell.initialized;
+                    bool read_boundary = false;
+                    bool typed_exported_cell = false;
+                    for (const auto& final : final_states) {
+                        if (RangesOverlap(final.range, cell.range)) {
+                            typed_exported_cell = true;
+                            read_boundary |= HasRead(final.boundary_access);
+                        }
+                    }
+                    const bool exported_cell = resource.whole_resource_exported || typed_exported_cell;
+                    const bool contents_required = !resource.imported || read_boundary;
+                    return !exported_cell || !contents_required || cell.initialized;
                 }
             );
             if (!exported_ranges_initialized) {
-                return Fail("exported transient resource has uninitialized subresources: " + resource.name);
+                return Fail(
+                    std::string(
+                        resource.imported ?
+                            "exported imported resource has uninitialized subresources required by a read boundary: " :
+                            "exported transient resource has uninitialized subresources: "
+                    ) + resource.name
+                );
             }
         }
     }

--- a/source/runtime/render/rendergraph/RenderGraphCompiler.h
+++ b/source/runtime/render/rendergraph/RenderGraphCompiler.h
@@ -78,6 +78,7 @@ private:
     bool ValidateAccessState(
         uint32_t                          pass_index,
         const RenderGraph::ResourceDeclaration& resource,
+        const RenderGraph::ResourceRange& range,
         RenderGraph::AccessMode           mode,
         const RenderGraph::ResourceState& state,
         bool                              explicit_state

--- a/source/runtime/render/rendergraph/RenderGraphCompiler.h
+++ b/source/runtime/render/rendergraph/RenderGraphCompiler.h
@@ -36,7 +36,8 @@ private:
         uint32_t                   last_writer = RenderGraph::PassHandle::InvalidIndex;
         RenderGraph::CompiledBarrierSource last_writer_source{};
         uint32_t                   last_access = RenderGraph::PassHandle::InvalidIndex;
-        uint32_t                   state_established_pass = RenderGraph::PassHandle::InvalidIndex;
+        uint32_t                   availability_established_pass = RenderGraph::PassHandle::InvalidIndex;
+        uint32_t                   ownership_established_pass = RenderGraph::PassHandle::InvalidIndex;
         uint32_t                   version     = RenderGraph::InvalidVersion;
         RenderGraph::ResourceState state{};
         RenderGraph::ExecutionDomain last_domain{

--- a/source/runtime/render/rendergraph/RenderGraphCompiler.h
+++ b/source/runtime/render/rendergraph/RenderGraphCompiler.h
@@ -19,33 +19,88 @@ private:
         RenderGraph::ResourceHandle resource{};
         RenderGraph::AccessMode     mode = RenderGraph::AccessMode::Read;
         RenderGraph::ResourceRange  range{};
+        RenderGraph::ResourceState  state{};
+        bool                        explicit_state = false;
+    };
+
+    struct NormalizedStateDeclaration {
+        RenderGraph::ResourceRange range{};
+        RenderGraph::ResourceState state{};
+        RenderGraph::QueueRole     queue = RenderGraph::QueueRole::None;
+        RenderGraph::AccessMode    boundary_access = RenderGraph::AccessMode::None;
     };
 
     struct AtomicCell {
         RenderGraph::ResourceRange range{};
-        std::vector<uint32_t>      readers{};
+        std::vector<RenderGraph::CompiledBarrierSource> readers{};
         uint32_t                   last_writer = RenderGraph::PassHandle::InvalidIndex;
+        RenderGraph::CompiledBarrierSource last_writer_source{};
+        uint32_t                   last_access = RenderGraph::PassHandle::InvalidIndex;
+        uint32_t                   state_established_pass = RenderGraph::PassHandle::InvalidIndex;
         uint32_t                   version     = RenderGraph::InvalidVersion;
+        RenderGraph::ResourceState state{};
+        RenderGraph::ExecutionDomain last_domain{
+            RenderGraph::QueueRole::None,
+            RenderGraph::PipelineType::None
+        };
+        RenderGraph::AccessMode last_mode = RenderGraph::AccessMode::None;
         bool                       initialized = false;
+        bool                       state_known = false;
+        bool                       has_explicit_initial_state = false;
     };
 
     struct CellUsage {
-        bool read  = false;
-        bool write = false;
+        bool                       read  = false;
+        bool                       write = false;
+        bool                       explicit_state = false;
+        RenderGraph::ResourceState state{};
     };
 
+    bool ValidateQueueTopology();
     bool NormalizeDeclarations();
     bool BuildAtomicCells();
     bool BuildSemanticDependencies();
+    bool BuildFinalBarriers();
+    void AuditStatePlanCompleteness();
     bool BuildTopologicalOrder();
     bool BuildExecutionOrder();
+    void BuildQueuePlan();
     void BuildDependencyWaves();
     void BuildLifetimes();
 
     bool NormalizeRange(
         const RenderGraph::ResourceDeclaration& resource,
-        const RenderGraph::AccessDeclaration&   access,
+        const RenderGraph::ResourceRange&       requested,
         RenderGraph::ResourceRange&             normalized
+    );
+    bool ValidateExecutionDomain(uint32_t pass_index);
+    bool ValidateAccessState(
+        uint32_t                          pass_index,
+        const RenderGraph::ResourceDeclaration& resource,
+        RenderGraph::AccessMode           mode,
+        const RenderGraph::ResourceState& state,
+        bool                              explicit_state
+    );
+    bool MergeCellState(
+        uint32_t                          pass_index,
+        const RenderGraph::ResourceDeclaration& resource,
+        CellUsage&                        usage,
+        const NormalizedAccess&           access
+    );
+    void AddBarrier(
+        uint32_t                         resource_index,
+        const AtomicCell&                cell,
+        RenderGraph::PassHandle          dst_pass,
+        RenderGraph::ResourceState       next_state,
+        RenderGraph::ExecutionDomain     next_domain,
+        RenderGraph::AccessMode          next_mode,
+        bool                             state_transition,
+        bool                             memory_dependency,
+        bool                             queue_ownership,
+        bool                             import_boundary,
+        bool                             export_boundary,
+        bool                             source_state_unknown,
+        std::vector<RenderGraph::CompiledBarrierSource> sources
     );
     void AddEdge(uint32_t src, uint32_t dst, RenderGraph::CompiledEdgeReason reason);
     bool Fail(std::string message);
@@ -55,6 +110,8 @@ private:
 
     RenderGraph&                               graph;
     std::vector<std::vector<NormalizedAccess>> normalized_accesses{};
+    std::vector<std::vector<NormalizedStateDeclaration>> normalized_initial_states{};
+    std::vector<std::vector<NormalizedStateDeclaration>> normalized_final_states{};
     std::vector<std::vector<AtomicCell>>       resource_cells{};
     std::vector<uint32_t>                      resource_version_counts{};
     std::vector<bool>                          resource_ever_written{};

--- a/source/test/RenderGraphTest.cpp
+++ b/source/test/RenderGraphTest.cpp
@@ -57,6 +57,51 @@ private:
     return std::find(wave.passes.begin(), wave.passes.end(), pass) != wave.passes.end();
 }
 
+[[nodiscard]] const RenderGraph::CompiledBarrier* FindBarrier(
+    const RenderGraph::CompiledPlan& plan,
+    RenderGraph::ResourceHandle      resource,
+    RenderGraph::PassHandle          src,
+    RenderGraph::PassHandle          dst
+) {
+    const auto found = std::find_if(
+        plan.barriers.begin(),
+        plan.barriers.end(),
+        [&](const RenderGraph::CompiledBarrier& barrier) {
+            return barrier.resource == resource && barrier.src_pass == src && barrier.dst_pass == dst;
+        }
+    );
+    return found == plan.barriers.end() ? nullptr : &*found;
+}
+
+[[nodiscard]] const RenderGraph::CompiledAccess* FindAccess(
+    const RenderGraph::CompiledPlan& plan,
+    RenderGraph::PassHandle          pass,
+    RenderGraph::ResourceHandle      resource
+) {
+    const auto found = std::find_if(
+        plan.accesses.begin(),
+        plan.accesses.end(),
+        [&](const RenderGraph::CompiledAccess& access) {
+            return access.pass == pass && access.resource == resource;
+        }
+    );
+    return found == plan.accesses.end() ? nullptr : &*found;
+}
+
+[[nodiscard]] bool HasBarrierSource(
+    const RenderGraph::CompiledBarrier& barrier,
+    RenderGraph::PassHandle             pass,
+    RenderGraph::AccessMode             access
+) {
+    return std::any_of(
+        barrier.sources.begin(),
+        barrier.sources.end(),
+        [&](const RenderGraph::CompiledBarrierSource& source) {
+            return source.pass == pass && source.access == access;
+        }
+    );
+}
+
 void TestStableSerialCallbackOrder(TestSuite& suite) {
     constexpr std::string_view test_name = "stable serial callback order";
     RenderGraph                graph("StableSerial");
@@ -894,6 +939,1141 @@ void TestMultipleReadersProduceAllWarEdges(TestSuite& suite) {
     );
 }
 
+void TestExplicitStateValidation(TestSuite& suite) {
+    constexpr std::string_view test_name = "explicit state validation";
+
+    struct TextureCase {
+        RenderGraph::AccessMode   access;
+        RenderGraph::TextureState state;
+        RenderGraph::QueueRole    queue;
+        RenderGraph::PipelineType pipeline;
+        bool                      valid;
+    };
+    const std::vector<TextureCase> texture_cases{
+        {RenderGraph::AccessMode::Read,
+         RenderGraph::TextureState::Sampled,
+         RenderGraph::QueueRole::Graphics,
+         RenderGraph::PipelineType::Graphics,
+         true},
+        {RenderGraph::AccessMode::Write,
+         RenderGraph::TextureState::RenderTarget,
+         RenderGraph::QueueRole::Graphics,
+         RenderGraph::PipelineType::Graphics,
+         true},
+        {RenderGraph::AccessMode::ReadWrite,
+         RenderGraph::TextureState::UnorderedAccess,
+         RenderGraph::QueueRole::Compute,
+         RenderGraph::PipelineType::Compute,
+         true},
+        {RenderGraph::AccessMode::Read,
+         RenderGraph::TextureState::TransferSource,
+         RenderGraph::QueueRole::Copy,
+         RenderGraph::PipelineType::Copy,
+         true},
+        {RenderGraph::AccessMode::Write,
+         RenderGraph::TextureState::Sampled,
+         RenderGraph::QueueRole::Graphics,
+         RenderGraph::PipelineType::Graphics,
+         false},
+        {RenderGraph::AccessMode::Read,
+         RenderGraph::TextureState::TransferDestination,
+         RenderGraph::QueueRole::Copy,
+         RenderGraph::PipelineType::Copy,
+         false},
+        {RenderGraph::AccessMode::Read,
+         RenderGraph::TextureState::RenderTarget,
+         RenderGraph::QueueRole::Graphics,
+         RenderGraph::PipelineType::Graphics,
+         false},
+        {RenderGraph::AccessMode::Read,
+         RenderGraph::TextureState::Automatic,
+         RenderGraph::QueueRole::Graphics,
+         RenderGraph::PipelineType::Graphics,
+         false},
+        {RenderGraph::AccessMode::Read,
+         RenderGraph::TextureState::Sampled,
+         RenderGraph::QueueRole::Copy,
+         RenderGraph::PipelineType::Copy,
+         false},
+        {RenderGraph::AccessMode::Write,
+         RenderGraph::TextureState::RenderTarget,
+         RenderGraph::QueueRole::Compute,
+         RenderGraph::PipelineType::Compute,
+         false},
+    };
+
+    for (uint32_t index = 0; index < texture_cases.size(); ++index) {
+        const auto& current = texture_cases[index];
+        RenderGraph graph("TextureStateCase");
+        int         physical = 0;
+        const auto  texture = graph.ImportTexture("Texture", &physical, RenderGraph::TextureDesc{});
+        graph.AddPass(
+            "Access",
+            [=](RenderGraph::PassBuilder& builder) {
+                builder.ExecuteOn(current.queue, current.pipeline);
+                switch (current.access) {
+                    case RenderGraph::AccessMode::Read:
+                        builder.Read(texture, current.state);
+                        break;
+                    case RenderGraph::AccessMode::Write:
+                        builder.Write(texture, current.state);
+                        break;
+                    case RenderGraph::AccessMode::ReadWrite:
+                        builder.ReadWrite(texture, current.state);
+                        break;
+                    default:
+                        break;
+                }
+            },
+            [] {}
+        );
+        suite.Check(
+            graph.Compile() == current.valid,
+            test_name,
+            "texture state/access/domain case " + std::to_string(index) + " had the wrong validity"
+        );
+    }
+
+    struct BufferCase {
+        RenderGraph::AccessMode  access;
+        RenderGraph::BufferState state;
+        RenderGraph::QueueRole   queue;
+        RenderGraph::PipelineType pipeline;
+        bool                     valid;
+    };
+    const std::vector<BufferCase> buffer_cases{
+        {RenderGraph::AccessMode::Read,
+         RenderGraph::BufferState::ShaderResource,
+         RenderGraph::QueueRole::Compute,
+         RenderGraph::PipelineType::Compute,
+         true},
+        {RenderGraph::AccessMode::Write,
+         RenderGraph::BufferState::TransferDestination,
+         RenderGraph::QueueRole::Copy,
+         RenderGraph::PipelineType::Copy,
+         true},
+        {RenderGraph::AccessMode::Read,
+         RenderGraph::BufferState::VertexBuffer,
+         RenderGraph::QueueRole::Graphics,
+         RenderGraph::PipelineType::Graphics,
+         true},
+        {RenderGraph::AccessMode::Write,
+         RenderGraph::BufferState::ShaderResource,
+         RenderGraph::QueueRole::Compute,
+         RenderGraph::PipelineType::Compute,
+         false},
+        {RenderGraph::AccessMode::Read,
+         RenderGraph::BufferState::AccelerationStructureWrite,
+         RenderGraph::QueueRole::Compute,
+         RenderGraph::PipelineType::RayTracing,
+         false},
+        {RenderGraph::AccessMode::Read,
+         RenderGraph::BufferState::VertexBuffer,
+         RenderGraph::QueueRole::Compute,
+         RenderGraph::PipelineType::Compute,
+         false},
+    };
+
+    for (uint32_t index = 0; index < buffer_cases.size(); ++index) {
+        const auto& current = buffer_cases[index];
+        RenderGraph graph("BufferStateCase");
+        int         physical = 0;
+        const auto  buffer = graph.ImportBuffer("Buffer", &physical, RenderGraph::BufferDesc{.byte_size = 64});
+        graph.AddPass(
+            "Access",
+            [=](RenderGraph::PassBuilder& builder) {
+                builder.ExecuteOn(current.queue, current.pipeline);
+                switch (current.access) {
+                    case RenderGraph::AccessMode::Read:
+                        builder.Read(buffer, current.state);
+                        break;
+                    case RenderGraph::AccessMode::Write:
+                        builder.Write(buffer, current.state);
+                        break;
+                    case RenderGraph::AccessMode::ReadWrite:
+                        builder.ReadWrite(buffer, current.state);
+                        break;
+                    default:
+                        break;
+                }
+            },
+            [] {}
+        );
+        suite.Check(
+            graph.Compile() == current.valid,
+            test_name,
+            "buffer state/access/domain case " + std::to_string(index) + " had the wrong validity"
+        );
+    }
+}
+
+void TestSameStateMemoryDependencies(TestSuite& suite) {
+    constexpr std::string_view test_name = "same-state memory dependencies";
+    auto add_compute_access = [](
+                                  RenderGraph&             graph,
+                                  std::string_view         name,
+                                  RenderGraph::BufferHandle buffer,
+                                  RenderGraph::AccessMode  mode
+                              ) {
+        return graph.AddPass(
+            name,
+            [=](RenderGraph::PassBuilder& builder) {
+                builder.ExecuteOn(RenderGraph::QueueRole::Compute, RenderGraph::PipelineType::Compute);
+                if (mode == RenderGraph::AccessMode::Read) {
+                    builder.Read(buffer, RenderGraph::BufferState::UnorderedAccess);
+                } else {
+                    builder.Write(buffer, RenderGraph::BufferState::UnorderedAccess);
+                }
+            },
+            [] {}
+        );
+    };
+
+    for (const auto second_mode : {RenderGraph::AccessMode::Read, RenderGraph::AccessMode::Write}) {
+        RenderGraph graph("UavWriteDependency");
+        int         physical = 0;
+        const auto  buffer = graph.ImportBuffer("Uav", &physical, RenderGraph::BufferDesc{.byte_size = 64});
+        graph.SetInitialState(
+            buffer,
+            RenderGraph::BufferState::UnorderedAccess,
+            RenderGraph::QueueRole::Compute,
+            RenderGraph::AccessMode::Read
+        );
+        const auto first  = add_compute_access(graph, "FirstWrite", buffer, RenderGraph::AccessMode::Write);
+        const auto second = add_compute_access(graph, "SecondAccess", buffer, second_mode);
+        suite.Check(graph.Compile(), test_name, graph.GetCompileError());
+        const auto* barrier = FindBarrier(graph.GetCompiledPlan(), buffer.Untyped(), first, second);
+        suite.Check(
+            barrier != nullptr && barrier->memory_dependency && !barrier->state_transition,
+            test_name,
+            second_mode == RenderGraph::AccessMode::Read ?
+                "same-state UAV W->R must emit only a memory dependency" :
+                "same-state UAV W->W must emit only a memory dependency"
+        );
+    }
+
+    RenderGraph read_graph("UavReadRead");
+    int         physical = 0;
+    const auto  buffer = read_graph.ImportBuffer("Uav", &physical, RenderGraph::BufferDesc{.byte_size = 64});
+    read_graph.SetInitialState(
+        buffer,
+        RenderGraph::BufferState::UnorderedAccess,
+        RenderGraph::QueueRole::Compute,
+        RenderGraph::AccessMode::Read
+    );
+    const auto first  = add_compute_access(read_graph, "FirstRead", buffer, RenderGraph::AccessMode::Read);
+    const auto second = add_compute_access(read_graph, "SecondRead", buffer, RenderGraph::AccessMode::Read);
+    suite.Check(read_graph.Compile(), test_name, read_graph.GetCompileError());
+    suite.Check(
+        FindBarrier(read_graph.GetCompiledPlan(), buffer.Untyped(), first, second) == nullptr,
+        test_name,
+        "same-state R->R must not emit a barrier"
+    );
+}
+
+void TestImportAndExportBoundaries(TestSuite& suite) {
+    constexpr std::string_view test_name = "import and export boundaries";
+
+    RenderGraph known_graph("KnownImport");
+    int         known_physical = 0;
+    const auto  known = known_graph.ImportBuffer(
+        "Known", &known_physical, RenderGraph::BufferDesc{.byte_size = 64}
+    );
+    known_graph.SetInitialState(
+        known,
+        RenderGraph::BufferState::ShaderResource,
+        RenderGraph::QueueRole::Graphics,
+        RenderGraph::AccessMode::Read
+    );
+    const auto known_read = known_graph.AddPass(
+        "Read",
+        [known](RenderGraph::PassBuilder& builder) {
+            builder.Read(known, RenderGraph::BufferState::ShaderResource);
+        },
+        [] {}
+    );
+    suite.Check(known_graph.Compile(), test_name, known_graph.GetCompileError());
+    const auto& known_plan = known_graph.GetCompiledPlan();
+    const auto* known_barrier = FindBarrier(known_plan, known.Untyped(), {}, known_read);
+    suite.Check(
+        known_plan.state_plan_complete && known_plan.prologue_barriers.size() == 1 &&
+            known_barrier != nullptr && known_barrier->import_boundary &&
+            !known_barrier->source_state_unknown && !known_barrier->state_transition,
+        test_name,
+        "a known import must produce a complete, known-source prologue record"
+    );
+
+    RenderGraph unknown_graph("UnknownImport");
+    int         unknown_physical = 0;
+    const auto  unknown = unknown_graph.ImportBuffer(
+        "Unknown", &unknown_physical, RenderGraph::BufferDesc{.byte_size = 64}
+    );
+    const auto unknown_read = unknown_graph.AddPass(
+        "Read",
+        [unknown](RenderGraph::PassBuilder& builder) {
+            builder.Read(unknown, RenderGraph::BufferState::ShaderResource);
+        },
+        [] {}
+    );
+    suite.Check(unknown_graph.Compile(), test_name, unknown_graph.GetCompileError());
+    const auto& unknown_plan = unknown_graph.GetCompiledPlan();
+    const auto* unknown_barrier = FindBarrier(unknown_plan, unknown.Untyped(), {}, unknown_read);
+    suite.Check(
+        !unknown_plan.state_plan_complete && unknown_plan.prologue_barriers.size() == 1 &&
+            unknown_barrier != nullptr && unknown_barrier->import_boundary &&
+            unknown_barrier->source_state_unknown && unknown_barrier->state_transition,
+        test_name,
+        "an unknown import must remain visibly incomplete and transition at its first use"
+    );
+
+    RenderGraph final_graph("FinalState");
+    const auto  output = final_graph.CreateTransientBuffer(
+        "Output", RenderGraph::BufferDesc{.byte_size = 64}
+    );
+    const auto write = final_graph.AddPass(
+        "Write",
+        [output](RenderGraph::PassBuilder& builder) {
+            builder.ExecuteOn(RenderGraph::QueueRole::Compute, RenderGraph::PipelineType::Compute);
+            builder.Write(output, RenderGraph::BufferState::UnorderedAccess);
+        },
+        [] {}
+    );
+    final_graph.Export(
+        output,
+        RenderGraph::BufferState::ShaderResource,
+        RenderGraph::QueueRole::Graphics,
+        RenderGraph::AccessMode::Read
+    );
+    suite.Check(final_graph.Compile(), test_name, final_graph.GetCompileError());
+    const auto& final_plan = final_graph.GetCompiledPlan();
+    const auto* final_barrier = FindBarrier(final_plan, output.Untyped(), write, {});
+    suite.Check(
+        final_plan.epilogue_barriers.size() == 1 && final_barrier != nullptr &&
+            final_barrier->export_boundary && final_barrier->state_transition &&
+            final_barrier->memory_dependency,
+        test_name,
+        "an explicit final state must create a state-and-memory epilogue barrier"
+    );
+
+    RenderGraph untouched_graph("UntouchedExport");
+    int         untouched_physical = 0;
+    const auto  untouched = untouched_graph.ImportBuffer(
+        "Untouched", &untouched_physical, RenderGraph::BufferDesc{.byte_size = 64}
+    );
+    untouched_graph.SetInitialState(
+        untouched,
+        RenderGraph::BufferState::ShaderResource,
+        RenderGraph::QueueRole::Graphics,
+        RenderGraph::AccessMode::Read
+    );
+    untouched_graph.Export(
+        untouched,
+        RenderGraph::BufferState::ShaderResource,
+        RenderGraph::QueueRole::Graphics,
+        RenderGraph::AccessMode::Read
+    );
+    untouched_graph.AddPass(
+        "SideEffect",
+        [](RenderGraph::PassBuilder& builder) {
+            builder.SideEffect();
+        },
+        [] {}
+    );
+    suite.Check(untouched_graph.Compile(), test_name, untouched_graph.GetCompileError());
+    const auto& untouched_plan = untouched_graph.GetCompiledPlan();
+    const auto* untouched_barrier = FindBarrier(untouched_plan, untouched.Untyped(), {}, {});
+    suite.Check(
+        untouched_plan.epilogue_barriers.size() == 1 && untouched_barrier != nullptr &&
+            untouched_barrier->export_boundary && !untouched_barrier->state_transition &&
+            !untouched_barrier->memory_dependency,
+        test_name,
+        "an untouched imported resource must still retain its explicit export boundary"
+    );
+}
+
+void TestQueueTopologySynchronization(TestSuite& suite) {
+    constexpr std::string_view test_name = "queue topology synchronization";
+    auto check_case = [&](RenderGraph::QueueTopology topology,
+                          RenderGraph::TextureDesc::SharingMode sharing,
+                          bool                                  queue_dependency,
+                          bool                                  ownership,
+                          bool                                  gpu_wait,
+                          std::string_view                      expectation) {
+        RenderGraph graph("QueueTopology", topology);
+        const auto  buffer = graph.CreateTransientBuffer(
+            "Shared", RenderGraph::BufferDesc{.byte_size = 64, .sharing_mode = sharing}
+        );
+        const auto producer = graph.AddPass(
+            "Produce",
+            [buffer](RenderGraph::PassBuilder& builder) {
+                builder.ExecuteOn(RenderGraph::QueueRole::Compute, RenderGraph::PipelineType::Compute);
+                builder.Write(buffer, RenderGraph::BufferState::UnorderedAccess);
+            },
+            [] {}
+        );
+        const auto consumer = graph.AddPass(
+            "Consume",
+            [buffer](RenderGraph::PassBuilder& builder) {
+                builder.ExecuteOn(RenderGraph::QueueRole::Graphics, RenderGraph::PipelineType::Graphics);
+                builder.Read(buffer, RenderGraph::BufferState::ShaderResource);
+            },
+            [] {}
+        );
+        suite.Check(graph.Compile(), test_name, graph.GetCompileError());
+        const auto& plan = graph.GetCompiledPlan();
+        const auto* barrier = FindBarrier(plan, buffer.Untyped(), producer, consumer);
+        suite.Check(
+            barrier != nullptr && barrier->queue_dependency == queue_dependency &&
+                barrier->queue_ownership == ownership,
+            test_name,
+            expectation
+        );
+        suite.Check(
+            plan.queue_syncs.size() == 1 && plan.queue_syncs.front().gpu_wait_required == gpu_wait,
+            test_name,
+            "queue synchronization mode must follow native queue identity"
+        );
+    };
+
+    check_case(
+        RenderGraph::QueueTopology::SingleQueue(),
+        RenderGraph::TextureDesc::SharingMode::Exclusive,
+        false,
+        false,
+        false,
+        "logical roles on one native queue must not transfer ownership"
+    );
+    check_case(
+        RenderGraph::QueueTopology{
+            .graphics = {RenderGraph::QueueRole::Graphics, 0, 0},
+            .compute  = {RenderGraph::QueueRole::Compute, 1, 0},
+            .copy     = {RenderGraph::QueueRole::Copy, 2, 0},
+        },
+        RenderGraph::TextureDesc::SharingMode::Exclusive,
+        true,
+        false,
+        true,
+        "different native queues in one family require synchronization but no ownership transfer"
+    );
+    check_case(
+        RenderGraph::QueueTopology::DedicatedQueues(),
+        RenderGraph::TextureDesc::SharingMode::Exclusive,
+        true,
+        true,
+        true,
+        "different families must transfer an exclusive resource"
+    );
+    check_case(
+        RenderGraph::QueueTopology::DedicatedQueues(),
+        RenderGraph::TextureDesc::SharingMode::Concurrent,
+        true,
+        false,
+        true,
+        "different families must not transfer a concurrent resource"
+    );
+}
+
+void TestTokenCrossQueueSyncHasNoOwnership(TestSuite& suite) {
+    constexpr std::string_view test_name = "token cross-queue synchronization";
+    RenderGraph graph("TokenSync", RenderGraph::QueueTopology::DedicatedQueues());
+    const auto  token = graph.CreateTransientToken("Token");
+    const auto  producer = graph.AddPass(
+        "Produce",
+        [token](RenderGraph::PassBuilder& builder) {
+            builder.ExecuteOn(RenderGraph::QueueRole::Compute, RenderGraph::PipelineType::Compute);
+            builder.Write(token);
+        },
+        [] {}
+    );
+    const auto consumer = graph.AddPass(
+        "Consume",
+        [token](RenderGraph::PassBuilder& builder) {
+            builder.ExecuteOn(RenderGraph::QueueRole::Graphics, RenderGraph::PipelineType::Graphics);
+            builder.Read(token);
+        },
+        [] {}
+    );
+    suite.Check(graph.Compile(), test_name, graph.GetCompileError());
+    const auto& plan = graph.GetCompiledPlan();
+    suite.Check(
+        HasEdgeReason(
+            plan, producer, consumer, RenderGraph::EdgeReasonKind::ReadAfterWrite, token.Untyped()
+        ) &&
+            plan.queue_syncs.size() == 1 && plan.queue_syncs.front().gpu_wait_required,
+        test_name,
+        "a token hazard must create cross-native-queue synchronization"
+    );
+    suite.Check(
+        plan.barriers.empty(),
+        test_name,
+        "a logical token must never create resource state or ownership barriers"
+    );
+}
+
+void TestBatchPairSyncDeduplication(TestSuite& suite) {
+    constexpr std::string_view test_name = "batch-pair synchronization deduplication";
+    RenderGraph graph("SyncDedup", RenderGraph::QueueTopology::DedicatedQueues());
+    const auto  first = graph.CreateTransientBuffer("First", RenderGraph::BufferDesc{.byte_size = 64});
+    const auto  second = graph.CreateTransientBuffer("Second", RenderGraph::BufferDesc{.byte_size = 64});
+    graph.AddPass(
+        "ProduceFirst",
+        [first](RenderGraph::PassBuilder& builder) {
+            builder.ExecuteOn(RenderGraph::QueueRole::Compute, RenderGraph::PipelineType::Compute);
+            builder.Write(first, RenderGraph::BufferState::UnorderedAccess);
+        },
+        [] {}
+    );
+    graph.AddPass(
+        "ProduceSecond",
+        [second](RenderGraph::PassBuilder& builder) {
+            builder.ExecuteOn(RenderGraph::QueueRole::Compute, RenderGraph::PipelineType::Compute);
+            builder.Write(second, RenderGraph::BufferState::UnorderedAccess);
+        },
+        [] {}
+    );
+    graph.AddPass(
+        "ConsumeBoth",
+        [first, second](RenderGraph::PassBuilder& builder) {
+            builder.ExecuteOn(RenderGraph::QueueRole::Graphics, RenderGraph::PipelineType::Graphics);
+            builder.Read(first, RenderGraph::BufferState::ShaderResource);
+            builder.Read(second, RenderGraph::BufferState::ShaderResource);
+        },
+        [] {}
+    );
+    suite.Check(graph.Compile(), test_name, graph.GetCompileError());
+    const auto& plan = graph.GetCompiledPlan();
+    suite.Check(
+        plan.queue_batches.size() == 2 && plan.queue_syncs.size() == 1,
+        test_name,
+        "all dependencies between one producer/consumer batch pair must share one sync"
+    );
+    suite.Check(
+        !plan.queue_syncs.empty() && plan.queue_syncs.front().dependency_edges.size() == 2 &&
+            plan.queue_syncs.front().barriers.size() == 2,
+        test_name,
+        "the deduplicated sync must retain both dependency edges and both barriers"
+    );
+}
+
+void TestPipelineDomainsAndBarrierSources(TestSuite& suite) {
+    constexpr std::string_view test_name = "pipeline domains and barrier sources";
+    RenderGraph graph("DomainsAndSources", RenderGraph::QueueTopology::DedicatedQueues());
+    const auto  buffer = graph.CreateTransientBuffer("Shared", RenderGraph::BufferDesc{.byte_size = 64});
+    const auto producer = graph.AddPass(
+        "Producer",
+        [buffer](RenderGraph::PassBuilder& builder) {
+            builder.ExecuteOn(RenderGraph::QueueRole::Compute, RenderGraph::PipelineType::Compute);
+            builder.Write(buffer, RenderGraph::BufferState::UnorderedAccess);
+        },
+        [] {}
+    );
+    const auto reader_a = graph.AddPass(
+        "ReaderA",
+        [buffer](RenderGraph::PassBuilder& builder) {
+            builder.ExecuteOn(RenderGraph::QueueRole::Graphics, RenderGraph::PipelineType::RayTracing);
+            builder.Read(buffer, RenderGraph::BufferState::UnorderedAccess);
+        },
+        [] {}
+    );
+    const auto reader_b = graph.AddPass(
+        "ReaderB",
+        [buffer](RenderGraph::PassBuilder& builder) {
+            builder.ExecuteOn(RenderGraph::QueueRole::Compute, RenderGraph::PipelineType::RayTracing);
+            builder.Read(buffer, RenderGraph::BufferState::UnorderedAccess);
+        },
+        [] {}
+    );
+    const auto writer = graph.AddPass(
+        "Writer",
+        [buffer](RenderGraph::PassBuilder& builder) {
+            builder.ExecuteOn(RenderGraph::QueueRole::Graphics, RenderGraph::PipelineType::RayTracing);
+            builder.Write(buffer, RenderGraph::BufferState::UnorderedAccess);
+        },
+        [] {}
+    );
+    suite.Check(graph.Compile(), test_name, graph.GetCompileError());
+    const auto& plan = graph.GetCompiledPlan();
+    const auto* producer_access = FindAccess(plan, producer, buffer.Untyped());
+    const auto* reader_access   = FindAccess(plan, reader_a, buffer.Untyped());
+    suite.Check(
+        producer_access != nullptr &&
+            producer_access->domain == RenderGraph::ExecutionDomain{
+                RenderGraph::QueueRole::Compute, RenderGraph::PipelineType::Compute
+            } &&
+            reader_access != nullptr &&
+            reader_access->domain == RenderGraph::ExecutionDomain{
+                RenderGraph::QueueRole::Graphics, RenderGraph::PipelineType::RayTracing
+            },
+        test_name,
+        "compiled accesses must retain their declared pipeline domains"
+    );
+
+    const auto reader_a_barrier = std::find_if(
+        plan.barriers.begin(), plan.barriers.end(), [&](const RenderGraph::CompiledBarrier& barrier) {
+            return barrier.resource == buffer.Untyped() && barrier.dst_pass == reader_a;
+        }
+    );
+    suite.Check(
+        reader_a_barrier != plan.barriers.end() && reader_a_barrier->src_domain.pipeline ==
+                                                          RenderGraph::PipelineType::Compute &&
+            reader_a_barrier->dst_domain.pipeline == RenderGraph::PipelineType::RayTracing &&
+            HasBarrierSource(*reader_a_barrier, producer, RenderGraph::AccessMode::Write),
+        test_name,
+        "a fan-out barrier must retain the producer source and both pipeline scopes"
+    );
+
+    const auto fan_in = std::find_if(
+        plan.barriers.begin(), plan.barriers.end(), [&](const RenderGraph::CompiledBarrier& barrier) {
+            return barrier.resource == buffer.Untyped() && barrier.dst_pass == writer;
+        }
+    );
+    suite.Check(
+        fan_in != plan.barriers.end() &&
+            HasBarrierSource(*fan_in, producer, RenderGraph::AccessMode::Write) &&
+            HasBarrierSource(*fan_in, reader_a, RenderGraph::AccessMode::Read) &&
+            HasBarrierSource(*fan_in, reader_b, RenderGraph::AccessMode::Read),
+        test_name,
+        "a fan-in write barrier must retain the writer and every active reader source"
+    );
+}
+
+void TestPartialRangeBarrier(TestSuite& suite) {
+    constexpr std::string_view test_name = "partial-range barrier";
+    RenderGraph graph("PartialBarrier");
+    int         physical = 0;
+    const auto  buffer = graph.ImportBuffer("Buffer", &physical, RenderGraph::BufferDesc{.byte_size = 128});
+    graph.SetInitialState(
+        buffer,
+        RenderGraph::BufferState::ShaderResource,
+        RenderGraph::QueueRole::Graphics,
+        RenderGraph::AccessMode::Read
+    );
+    const auto write = graph.AddPass(
+        "WriteMiddle",
+        [buffer](RenderGraph::PassBuilder& builder) {
+            builder.Write(
+                buffer,
+                RenderGraph::BufferState::UnorderedAccess,
+                RenderGraph::BufferRange{.offset = 32, .size = 32}
+            );
+        },
+        [] {}
+    );
+    suite.Check(graph.Compile(), test_name, graph.GetCompileError());
+    const auto* barrier = FindBarrier(graph.GetCompiledPlan(), buffer.Untyped(), {}, write);
+    suite.Check(
+        barrier != nullptr && barrier->range.kind == RenderGraph::ResourceKind::Buffer &&
+            barrier->range.buffer == RenderGraph::BufferRange{.offset = 32, .size = 32},
+        test_name,
+        "a partial access must emit one barrier for exactly its canonical byte interval"
+    );
+}
+
+void TestMixedQueueExecuteRemainsDeclarationOrder(TestSuite& suite) {
+    constexpr std::string_view test_name = "mixed-queue serial execution order";
+    RenderGraph graph("MixedQueueExecute", RenderGraph::QueueTopology::DedicatedQueues());
+    std::vector<int> callbacks;
+    const auto first = graph.AddPass(
+        "Compute",
+        [](RenderGraph::PassBuilder& builder) {
+            builder.ExecuteOn(RenderGraph::QueueRole::Compute, RenderGraph::PipelineType::Compute)
+                .SideEffect();
+        },
+        [&] {
+            callbacks.push_back(1);
+        }
+    );
+    const auto second = graph.AddPass(
+        "Graphics",
+        [](RenderGraph::PassBuilder& builder) {
+            builder.ExecuteOn(RenderGraph::QueueRole::Graphics, RenderGraph::PipelineType::Graphics)
+                .SideEffect();
+        },
+        [&] {
+            callbacks.push_back(2);
+        }
+    );
+    const auto third = graph.AddPass(
+        "Copy",
+        [](RenderGraph::PassBuilder& builder) {
+            builder.ExecuteOn(RenderGraph::QueueRole::Copy, RenderGraph::PipelineType::Copy).SideEffect();
+        },
+        [&] {
+            callbacks.push_back(3);
+        }
+    );
+    suite.Check(graph.Compile(), test_name, graph.GetCompileError());
+    suite.Check(
+        graph.GetCompiledPlan().execution_order ==
+            std::vector<RenderGraph::PassHandle>{first, second, third},
+        test_name,
+        "mixed logical queues must not change the production execution order"
+    );
+    suite.Check(graph.Execute(), test_name, graph.GetCompileError());
+    suite.Check(
+        callbacks == std::vector<int>{1, 2, 3},
+        test_name,
+        "mixed-queue callbacks must still execute serially in declaration order"
+    );
+}
+
+[[nodiscard]] std::string BuildStageTwoDump(TestSuite& suite, std::string_view test_name) {
+    RenderGraph graph("StageTwoDump", RenderGraph::QueueTopology::DedicatedQueues());
+    const auto  buffer = graph.CreateTransientBuffer(
+        "Output",
+        RenderGraph::BufferDesc{
+            .byte_size = 128,
+            .sharing_mode = RenderGraph::TextureDesc::SharingMode::Exclusive,
+        }
+    );
+    graph.AddPass(
+        "CopyProduce",
+        [buffer](RenderGraph::PassBuilder& builder) {
+            builder.ExecuteOn(RenderGraph::QueueRole::Copy, RenderGraph::PipelineType::Copy);
+            builder.Write(
+                buffer,
+                RenderGraph::BufferState::TransferDestination,
+                RenderGraph::BufferRange{.offset = 0, .size = 64}
+            );
+            builder.Write(
+                buffer,
+                RenderGraph::BufferState::TransferDestination,
+                RenderGraph::BufferRange{.offset = 64, .size = 64}
+            );
+        },
+        [] {}
+    );
+    graph.AddPass(
+        "ComputeConsume",
+        [buffer](RenderGraph::PassBuilder& builder) {
+            builder.ExecuteOn(RenderGraph::QueueRole::Compute, RenderGraph::PipelineType::Compute);
+            builder.Read(buffer, RenderGraph::BufferState::ShaderResource);
+        },
+        [] {}
+    );
+    graph.Export(
+        buffer,
+        RenderGraph::BufferState::ShaderResource,
+        RenderGraph::QueueRole::Graphics,
+        RenderGraph::AccessMode::Read
+    );
+    suite.Check(graph.Compile(), test_name, graph.GetCompileError());
+    return graph.Dump();
+}
+
+void TestStageTwoDumpDeterminism(TestSuite& suite) {
+    constexpr std::string_view test_name = "Stage 2 dump determinism";
+    const std::string first  = BuildStageTwoDump(suite, test_name);
+    const std::string second = BuildStageTwoDump(suite, test_name);
+    suite.Check(first == second, test_name, "equivalent Stage 2 plans must have byte-identical dumps");
+    suite.Check(
+        Contains(first, "barrier_owner=existing_rhi_vulkan_path") &&
+            Contains(first, "sync_plan=shadow external_endpoints=unbound") &&
+            Contains(first, "barriers:\n") && Contains(first, "queue_batches:\n") &&
+            Contains(first, "queue_syncs:\n") && Contains(first, "pipeline=compute") &&
+            Contains(first, "flags=[execution,memory,transition,queue,ownership"),
+        test_name,
+        "the deterministic dump must retain state, domain, queue, and ownership decisions"
+    );
+}
+
+void TestBarrierSourcesIgnoreUnrelatedLastRead(TestSuite& suite) {
+    constexpr std::string_view test_name = "barrier sources ignore unrelated last read";
+    RenderGraph graph(
+        "SourceEndpoint",
+        RenderGraph::QueueTopology{
+            .graphics = {RenderGraph::QueueRole::Graphics, 0, 0},
+            .compute  = {RenderGraph::QueueRole::Compute, 1, 0},
+            .copy     = {RenderGraph::QueueRole::Copy, 2, 0},
+        }
+    );
+    const auto buffer = graph.CreateTransientBuffer(
+        "Concurrent",
+        RenderGraph::BufferDesc{
+            .byte_size    = 64,
+            .sharing_mode = RenderGraph::TextureDesc::SharingMode::Concurrent,
+        }
+    );
+    const auto writer = graph.AddPass(
+        "Writer",
+        [buffer](RenderGraph::PassBuilder& builder) {
+            builder.Write(buffer, RenderGraph::BufferState::UnorderedAccess);
+        },
+        [] {}
+    );
+    const auto compute_read = graph.AddPass(
+        "ComputeRead",
+        [buffer](RenderGraph::PassBuilder& builder) {
+            builder.ExecuteOn(RenderGraph::QueueRole::Compute, RenderGraph::PipelineType::Compute);
+            builder.Read(buffer, RenderGraph::BufferState::UnorderedAccess);
+        },
+        [] {}
+    );
+    const auto graphics_read = graph.AddPass(
+        "GraphicsRead",
+        [buffer](RenderGraph::PassBuilder& builder) {
+            builder.Read(buffer, RenderGraph::BufferState::UnorderedAccess);
+        },
+        [] {}
+    );
+
+    suite.Check(graph.Compile(), test_name, graph.GetCompileError());
+    const auto& plan = graph.GetCompiledPlan();
+    const auto* barrier = FindBarrier(plan, buffer.Untyped(), writer, graphics_read);
+    suite.Check(
+        barrier != nullptr && !barrier->queue_dependency && barrier->src_pass == writer &&
+            HasBarrierSource(*barrier, writer, RenderGraph::AccessMode::Write) &&
+            !HasBarrierSource(*barrier, compute_read, RenderGraph::AccessMode::Read),
+        test_name,
+        "an unrelated R/R endpoint must not replace the actual RAW source or create a queue handoff"
+    );
+    const bool has_orphan_gpu_sync = std::any_of(
+        plan.queue_syncs.begin(),
+        plan.queue_syncs.end(),
+        [](const RenderGraph::CompiledQueueSync& sync) {
+            return sync.signal_batch == 1 && sync.wait_batch == 2 && sync.gpu_wait_required;
+        }
+    );
+    suite.Check(
+        !has_orphan_gpu_sync,
+        test_name,
+        "the unrelated compute read must not produce a GPU wait before the final graphics read"
+    );
+}
+
+void TestFanInBarrierPlacementCoversEverySourceBatch(TestSuite& suite) {
+    constexpr std::string_view test_name = "fan-in barrier placement covers every source batch";
+    RenderGraph graph("FanInPlacement", RenderGraph::QueueTopology::DedicatedQueues());
+    int         physical = 0;
+    const auto  buffer = graph.ImportBuffer(
+        "Concurrent",
+        &physical,
+        RenderGraph::BufferDesc{
+            .byte_size    = 64,
+            .sharing_mode = RenderGraph::TextureDesc::SharingMode::Concurrent,
+        }
+    );
+    graph.SetInitialState(
+        buffer,
+        RenderGraph::BufferState::TransferSource,
+        RenderGraph::QueueRole::Copy,
+        RenderGraph::AccessMode::Read
+    );
+    const auto copy_read = graph.AddPass(
+        "CopyRead",
+        [buffer](RenderGraph::PassBuilder& builder) {
+            builder.ExecuteOn(RenderGraph::QueueRole::Copy, RenderGraph::PipelineType::Copy);
+            builder.Read(buffer, RenderGraph::BufferState::TransferSource);
+        },
+        [] {}
+    );
+    const auto graphics_read = graph.AddPass(
+        "GraphicsRead",
+        [buffer](RenderGraph::PassBuilder& builder) {
+            builder.Read(buffer, RenderGraph::BufferState::TransferSource);
+        },
+        [] {}
+    );
+    const auto compute_write = graph.AddPass(
+        "ComputeWrite",
+        [buffer](RenderGraph::PassBuilder& builder) {
+            builder.ExecuteOn(RenderGraph::QueueRole::Compute, RenderGraph::PipelineType::Compute);
+            builder.Write(buffer, RenderGraph::BufferState::UnorderedAccess);
+        },
+        [] {}
+    );
+
+    suite.Check(graph.Compile(), test_name, graph.GetCompileError());
+    const auto& plan = graph.GetCompiledPlan();
+    const auto barrier_it = std::find_if(
+        plan.barriers.begin(),
+        plan.barriers.end(),
+        [&](const RenderGraph::CompiledBarrier& barrier) {
+            return barrier.resource == buffer.Untyped() && barrier.dst_pass == compute_write &&
+                   HasBarrierSource(barrier, copy_read, RenderGraph::AccessMode::Read) &&
+                   HasBarrierSource(barrier, graphics_read, RenderGraph::AccessMode::Read);
+        }
+    );
+    suite.Check(barrier_it != plan.barriers.end(), test_name, "the fan-in barrier must retain both readers");
+    if (barrier_it == plan.barriers.end()) {
+        return;
+    }
+    const uint32_t barrier_index = static_cast<uint32_t>(barrier_it - plan.barriers.begin());
+    suite.Check(
+        plan.queue_batches.size() == 3 &&
+            std::find(
+                plan.queue_batches[0].post_barriers.begin(),
+                plan.queue_batches[0].post_barriers.end(),
+                barrier_index
+            ) != plan.queue_batches[0].post_barriers.end() &&
+            std::find(
+                plan.queue_batches[1].post_barriers.begin(),
+                plan.queue_batches[1].post_barriers.end(),
+                barrier_index
+            ) != plan.queue_batches[1].post_barriers.end(),
+        test_name,
+        "every cross-native source batch must receive the split-release placement hint"
+    );
+    const uint32_t associated_syncs = static_cast<uint32_t>(std::count_if(
+        plan.queue_syncs.begin(),
+        plan.queue_syncs.end(),
+        [&](const RenderGraph::CompiledQueueSync& sync) {
+            return sync.wait_batch == 2 && sync.gpu_wait_required &&
+                   std::find(sync.barriers.begin(), sync.barriers.end(), barrier_index) !=
+                       sync.barriers.end();
+        }
+    ));
+    suite.Check(
+        associated_syncs == 2,
+        test_name,
+        "the barrier must be associated with both GPU waits feeding the destination batch"
+    );
+}
+
+void TestUntouchedBoundaryWriteRequiresMemoryDependency(TestSuite& suite) {
+    constexpr std::string_view test_name = "untouched boundary write dependency";
+    RenderGraph graph("UntouchedBoundaryWrite");
+    int         physical = 0;
+    const auto  buffer = graph.ImportBuffer("Buffer", &physical, RenderGraph::BufferDesc{.byte_size = 64});
+    graph.SetInitialState(
+        buffer,
+        RenderGraph::BufferState::UnorderedAccess,
+        RenderGraph::QueueRole::Graphics,
+        RenderGraph::AccessMode::Write
+    );
+    graph.Export(
+        buffer,
+        RenderGraph::BufferState::ShaderResource,
+        RenderGraph::QueueRole::Graphics,
+        RenderGraph::AccessMode::Read
+    );
+    graph.AddPass(
+        "SideEffect",
+        [](RenderGraph::PassBuilder& builder) {
+            builder.SideEffect();
+        },
+        [] {}
+    );
+    suite.Check(graph.Compile(), test_name, graph.GetCompileError());
+    const auto* barrier = FindBarrier(graph.GetCompiledPlan(), buffer.Untyped(), {}, {});
+    suite.Check(
+        barrier != nullptr && barrier->memory_dependency && barrier->state_transition,
+        test_name,
+        "an untouched imported write must be made visible to the declared external reader"
+    );
+}
+
+[[nodiscard]] std::string BuildCompatibleStateOrderDump(
+    TestSuite& suite,
+    std::string_view test_name,
+    bool reverse
+) {
+    RenderGraph graph("CompatibleStateOrder");
+    int         physical = 0;
+    const auto  texture = graph.ImportTexture("Texture", &physical, RenderGraph::TextureDesc{});
+    graph.SetInitialState(
+        texture,
+        RenderGraph::TextureState::ShaderResource,
+        RenderGraph::QueueRole::Graphics,
+        RenderGraph::AccessMode::Read
+    );
+    graph.AddPass(
+        "Read",
+        [=](RenderGraph::PassBuilder& builder) {
+            if (reverse) {
+                builder.Read(texture, RenderGraph::TextureState::Sampled);
+                builder.Read(texture, RenderGraph::TextureState::ShaderResource);
+            } else {
+                builder.Read(texture, RenderGraph::TextureState::ShaderResource);
+                builder.Read(texture, RenderGraph::TextureState::Sampled);
+            }
+        },
+        [] {}
+    );
+    suite.Check(graph.Compile(), test_name, graph.GetCompileError());
+    suite.Check(
+        !graph.GetCompiledPlan().accesses.empty() &&
+            graph.GetCompiledPlan().accesses.front().state == RenderGraph::ResourceState::Texture(
+                RenderGraph::TextureState::ShaderResource
+            ),
+        test_name,
+        "compatible shader-read states must canonicalize to one stable state"
+    );
+    const std::string dump = graph.Dump();
+    const auto        compiled_plan_offset = dump.find("compiled_accesses:\n");
+    return compiled_plan_offset == std::string::npos ? dump : dump.substr(compiled_plan_offset);
+}
+
+void TestCompatibleStateCanonicalization(TestSuite& suite) {
+    constexpr std::string_view test_name = "compatible state canonicalization";
+    const auto forward = BuildCompatibleStateOrderDump(suite, test_name, false);
+    const auto reverse = BuildCompatibleStateOrderDump(suite, test_name, true);
+    suite.Check(
+        forward == reverse,
+        test_name,
+        "swapping compatible declarations in one pass must not change the compiled-plan dump"
+    );
+}
+
+void TestReadTransitionWaitsForEveryActiveReader(TestSuite& suite) {
+    constexpr std::string_view test_name = "read transition waits for every active reader";
+    RenderGraph graph("ReadTransitionFanIn", RenderGraph::QueueTopology::DedicatedQueues());
+    int         physical = 0;
+    const auto  buffer = graph.ImportBuffer(
+        "Concurrent",
+        &physical,
+        RenderGraph::BufferDesc{
+            .byte_size    = 64,
+            .sharing_mode = RenderGraph::TextureDesc::SharingMode::Concurrent,
+        }
+    );
+    graph.SetInitialState(
+        buffer,
+        RenderGraph::BufferState::TransferSource,
+        RenderGraph::QueueRole::Copy,
+        RenderGraph::AccessMode::Read
+    );
+    const auto copy_read = graph.AddPass(
+        "CopyRead",
+        [buffer](RenderGraph::PassBuilder& builder) {
+            builder.ExecuteOn(RenderGraph::QueueRole::Copy, RenderGraph::PipelineType::Copy);
+            builder.Read(buffer, RenderGraph::BufferState::TransferSource);
+        },
+        [] {}
+    );
+    const auto graphics_read = graph.AddPass(
+        "GraphicsRead",
+        [buffer](RenderGraph::PassBuilder& builder) {
+            builder.Read(buffer, RenderGraph::BufferState::TransferSource);
+        },
+        [] {}
+    );
+    const auto compute_read = graph.AddPass(
+        "ComputeRead",
+        [buffer](RenderGraph::PassBuilder& builder) {
+            builder.ExecuteOn(RenderGraph::QueueRole::Compute, RenderGraph::PipelineType::Compute);
+            builder.Read(buffer, RenderGraph::BufferState::ShaderResource);
+        },
+        [] {}
+    );
+
+    suite.Check(graph.Compile(), test_name, graph.GetCompileError());
+    const auto& plan = graph.GetCompiledPlan();
+    const auto barrier = std::find_if(
+        plan.barriers.begin(),
+        plan.barriers.end(),
+        [&](const RenderGraph::CompiledBarrier& candidate) {
+            return candidate.resource == buffer.Untyped() && candidate.dst_pass == compute_read &&
+                   candidate.state_transition;
+        }
+    );
+    suite.Check(
+        barrier != plan.barriers.end() &&
+            HasBarrierSource(*barrier, copy_read, RenderGraph::AccessMode::Read) &&
+            HasBarrierSource(*barrier, graphics_read, RenderGraph::AccessMode::Read) &&
+            HasEdgeReason(
+                plan,
+                copy_read,
+                compute_read,
+                RenderGraph::EdgeReasonKind::StateTransition,
+                buffer.Untyped()
+            ) &&
+            HasEdgeReason(
+                plan,
+                graphics_read,
+                compute_read,
+                RenderGraph::EdgeReasonKind::StateTransition,
+                buffer.Untyped()
+            ),
+        test_name,
+        "a read-only state transition must fan in every reader still using the previous state"
+    );
+}
+
+void TestUndefinedImportMustBeInitializedBeforeRead(TestSuite& suite) {
+    constexpr std::string_view test_name = "undefined import initialization";
+    int                        physical = 0;
+
+    RenderGraph read_graph("UndefinedRead");
+    const auto  read_buffer = read_graph.ImportBuffer(
+        "Buffer", &physical, RenderGraph::BufferDesc{.byte_size = 128}
+    );
+    read_graph.SetInitialState(
+        read_buffer,
+        RenderGraph::BufferState::Undefined,
+        RenderGraph::QueueRole::None,
+        RenderGraph::AccessMode::None,
+        RenderGraph::BufferRange{.offset = 0, .size = 64}
+    );
+    read_graph.AddPass(
+        "InvalidRead",
+        [read_buffer](RenderGraph::PassBuilder& builder) {
+            builder.Read(
+                read_buffer,
+                RenderGraph::BufferState::ShaderResource,
+                RenderGraph::BufferRange{.offset = 0, .size = 64}
+            );
+        },
+        [] {}
+    );
+    suite.Check(
+        !read_graph.Compile() && Contains(read_graph.GetCompileError(), "read before its first producer"),
+        test_name,
+        "an explicit Undefined range must reject a read before initialization"
+    );
+
+    RenderGraph write_graph("UndefinedWrite");
+    const auto  write_buffer = write_graph.ImportBuffer(
+        "Buffer", &physical, RenderGraph::BufferDesc{.byte_size = 128}
+    );
+    write_graph.SetInitialState(
+        write_buffer,
+        RenderGraph::BufferState::Undefined,
+        RenderGraph::QueueRole::None,
+        RenderGraph::AccessMode::None,
+        RenderGraph::BufferRange{.offset = 0, .size = 64}
+    );
+    const auto write = write_graph.AddPass(
+        "Initialize",
+        [write_buffer](RenderGraph::PassBuilder& builder) {
+            builder.Write(
+                write_buffer,
+                RenderGraph::BufferState::UnorderedAccess,
+                RenderGraph::BufferRange{.offset = 0, .size = 64}
+            );
+        },
+        [] {}
+    );
+    suite.Check(write_graph.Compile(), test_name, write_graph.GetCompileError());
+    const auto* barrier = FindBarrier(write_graph.GetCompiledPlan(), write_buffer.Untyped(), {}, write);
+    suite.Check(
+        barrier != nullptr && barrier->discard_previous_contents,
+        test_name,
+        "the first write after Undefined must be represented as a discard transition"
+    );
+}
+
+void TestUnknownExportMakesStatePlanIncomplete(TestSuite& suite) {
+    constexpr std::string_view test_name = "unknown exported state plan";
+    RenderGraph graph("UnknownExport");
+    int         physical = 0;
+    const auto  buffer = graph.ImportBuffer("Buffer", &physical, RenderGraph::BufferDesc{.byte_size = 64});
+    graph.Export(buffer);
+    graph.AddPass(
+        "SideEffect",
+        [](RenderGraph::PassBuilder& builder) {
+            builder.SideEffect();
+        },
+        [] {}
+    );
+    suite.Check(graph.Compile(), test_name, graph.GetCompileError());
+    suite.Check(
+        !graph.GetCompiledPlan().state_plan_complete,
+        test_name,
+        "an exported physical cell with no known state must keep the plan visibly incomplete"
+    );
+}
+
 } // namespace
 
 int main() {
@@ -916,6 +2096,23 @@ int main() {
     TestUnknownTextureAspectIsRejected(suite);
     TestTypedAliasDescriptorMismatchIsRejected(suite);
     TestMultipleReadersProduceAllWarEdges(suite);
+    TestExplicitStateValidation(suite);
+    TestSameStateMemoryDependencies(suite);
+    TestImportAndExportBoundaries(suite);
+    TestQueueTopologySynchronization(suite);
+    TestTokenCrossQueueSyncHasNoOwnership(suite);
+    TestBatchPairSyncDeduplication(suite);
+    TestPipelineDomainsAndBarrierSources(suite);
+    TestPartialRangeBarrier(suite);
+    TestMixedQueueExecuteRemainsDeclarationOrder(suite);
+    TestStageTwoDumpDeterminism(suite);
+    TestBarrierSourcesIgnoreUnrelatedLastRead(suite);
+    TestFanInBarrierPlacementCoversEverySourceBatch(suite);
+    TestUntouchedBoundaryWriteRequiresMemoryDependency(suite);
+    TestCompatibleStateCanonicalization(suite);
+    TestReadTransitionWaitsForEveryActiveReader(suite);
+    TestUndefinedImportMustBeInitializedBeforeRead(suite);
+    TestUnknownExportMakesStatePlanIncomplete(suite);
 
     if (suite.FailureCount() != 0) {
         std::cerr << "TestRenderGraph: " << suite.FailureCount() << " failure(s)\n";

--- a/source/test/RenderGraphTest.cpp
+++ b/source/test/RenderGraphTest.cpp
@@ -941,6 +941,212 @@ void TestUnknownTextureAspectIsRejected(TestSuite& suite) {
     );
 }
 
+void TestTextureAttachmentStateMatchesSelectedAspects(TestSuite& suite) {
+    constexpr std::string_view test_name = "texture attachment state aspect validation";
+    auto add_side_effect = [](RenderGraph& graph) {
+        graph.AddPass(
+            "SideEffect",
+            [](RenderGraph::PassBuilder& builder) {
+                builder.SideEffect();
+            },
+            [] {}
+        );
+    };
+
+    RenderGraph color_access_graph("ColorAsDepthAttachment");
+    const auto  color_access = color_access_graph.CreateTransientTexture(
+        "Color", RenderGraph::TextureDesc{.aspects = RenderGraph::TextureAspect::Color}
+    );
+    color_access_graph.AddPass(
+        "InvalidDepthWrite",
+        [color_access](RenderGraph::PassBuilder& builder) {
+            builder.Write(color_access, RenderGraph::TextureState::DepthStencilWrite);
+        },
+        [] {}
+    );
+    suite.Check(
+        !color_access_graph.Compile() &&
+            Contains(color_access_graph.GetCompileError(), "selected aspects"),
+        test_name,
+        "a color pass range must reject depth/stencil attachment states"
+    );
+
+    RenderGraph depth_access_graph("DepthAsColorAttachment");
+    const auto  depth_access = depth_access_graph.CreateTransientTexture(
+        "Depth", RenderGraph::TextureDesc{.aspects = RenderGraph::TextureAspect::Depth}
+    );
+    depth_access_graph.AddPass(
+        "InvalidColorWrite",
+        [depth_access](RenderGraph::PassBuilder& builder) {
+            builder.Write(depth_access, RenderGraph::TextureState::RenderTarget);
+        },
+        [] {}
+    );
+    suite.Check(
+        !depth_access_graph.Compile() &&
+            Contains(depth_access_graph.GetCompileError(), "selected aspects"),
+        test_name,
+        "a depth pass range must reject the color render-target state"
+    );
+
+    RenderGraph depth_storage_graph("DepthAsStorageImage");
+    const auto  depth_storage = depth_storage_graph.CreateTransientTexture(
+        "Depth", RenderGraph::TextureDesc{.aspects = RenderGraph::TextureAspect::Depth}
+    );
+    depth_storage_graph.AddPass(
+        "InvalidStorageAccess",
+        [depth_storage](RenderGraph::PassBuilder& builder) {
+            builder.ReadWrite(depth_storage, RenderGraph::TextureState::UnorderedAccess);
+        },
+        [] {}
+    );
+    suite.Check(
+        !depth_storage_graph.Compile() &&
+            Contains(depth_storage_graph.GetCompileError(), "selected aspects"),
+        test_name,
+        "the portable depth/stencil model must reject unordered-access image states"
+    );
+
+    RenderGraph initial_graph("InvalidInitialAttachmentAspect");
+    int         initial_physical = 0;
+    const auto  initial_texture = initial_graph.ImportTexture(
+        "Color",
+        &initial_physical,
+        RenderGraph::TextureDesc{.aspects = RenderGraph::TextureAspect::Color}
+    );
+    initial_graph.SetInitialState(
+        initial_texture,
+        RenderGraph::TextureState::DepthStencilRead,
+        RenderGraph::QueueRole::Graphics,
+        RenderGraph::AccessMode::Read
+    );
+    add_side_effect(initial_graph);
+    suite.Check(
+        !initial_graph.Compile() && Contains(initial_graph.GetCompileError(), "selected aspects"),
+        test_name,
+        "an imported color range must reject a depth/stencil boundary state"
+    );
+
+    RenderGraph final_graph("InvalidFinalAttachmentAspect");
+    int         final_physical = 0;
+    const auto  final_texture = final_graph.ImportTexture(
+        "Depth",
+        &final_physical,
+        RenderGraph::TextureDesc{.aspects = RenderGraph::TextureAspect::Depth}
+    );
+    final_graph.SetInitialState(
+        final_texture,
+        RenderGraph::TextureState::DepthStencilRead,
+        RenderGraph::QueueRole::Graphics,
+        RenderGraph::AccessMode::Read
+    );
+    final_graph.Export(
+        final_texture,
+        RenderGraph::TextureState::RenderTarget,
+        RenderGraph::QueueRole::Graphics,
+        RenderGraph::AccessMode::Write
+    );
+    add_side_effect(final_graph);
+    suite.Check(
+        !final_graph.Compile() && Contains(final_graph.GetCompileError(), "selected aspects"),
+        test_name,
+        "an exported depth range must reject the color render-target state"
+    );
+
+    RenderGraph present_graph("InvalidPresentAspect");
+    int         present_physical = 0;
+    const auto  present_texture = present_graph.ImportTexture(
+        "Depth",
+        &present_physical,
+        RenderGraph::TextureDesc{.aspects = RenderGraph::TextureAspect::Depth}
+    );
+    present_graph.SetInitialState(
+        present_texture,
+        RenderGraph::TextureState::DepthStencilRead,
+        RenderGraph::QueueRole::Graphics,
+        RenderGraph::AccessMode::Read
+    );
+    present_graph.Export(
+        present_texture,
+        RenderGraph::TextureState::Present,
+        RenderGraph::QueueRole::Graphics,
+        RenderGraph::AccessMode::Read
+    );
+    add_side_effect(present_graph);
+    suite.Check(
+        !present_graph.Compile() && Contains(present_graph.GetCompileError(), "selected aspects"),
+        test_name,
+        "only color aspects may cross a Present boundary"
+    );
+
+    RenderGraph color_present_graph("ValidColorPresent");
+    int         color_present_physical = 0;
+    const auto  color_present_texture = color_present_graph.ImportTexture(
+        "Color",
+        &color_present_physical,
+        RenderGraph::TextureDesc{.aspects = RenderGraph::TextureAspect::Color}
+    );
+    color_present_graph.SetInitialState(
+        color_present_texture,
+        RenderGraph::TextureState::ShaderResource,
+        RenderGraph::QueueRole::Graphics,
+        RenderGraph::AccessMode::Read
+    );
+    color_present_graph.Export(
+        color_present_texture,
+        RenderGraph::TextureState::Present,
+        RenderGraph::QueueRole::Graphics,
+        RenderGraph::AccessMode::Read
+    );
+    add_side_effect(color_present_graph);
+    suite.Check(
+        color_present_graph.Compile(),
+        test_name,
+        "a color texture must remain exportable to Present: " +
+            color_present_graph.GetCompileError()
+    );
+
+    RenderGraph valid_graph("ValidDepthStencilAspects");
+    int         valid_physical = 0;
+    const auto  valid_texture = valid_graph.ImportTexture(
+        "DepthStencil",
+        &valid_physical,
+        RenderGraph::TextureDesc{
+            .aspects = RenderGraph::TextureAspect::Depth | RenderGraph::TextureAspect::Stencil
+        }
+    );
+    valid_graph.SetInitialState(
+        valid_texture,
+        RenderGraph::TextureState::DepthStencilRead,
+        RenderGraph::QueueRole::Graphics,
+        RenderGraph::AccessMode::Read
+    );
+    valid_graph.AddPass(
+        "ReadDepth",
+        [valid_texture](RenderGraph::PassBuilder& builder) {
+            builder.Read(
+                valid_texture,
+                RenderGraph::TextureState::DepthStencilRead,
+                RenderGraph::TextureRange{.aspects = RenderGraph::TextureAspect::Depth}
+            );
+        },
+        [] {}
+    );
+    valid_graph.Export(
+        valid_texture,
+        RenderGraph::TextureState::DepthStencilRead,
+        RenderGraph::QueueRole::Graphics,
+        RenderGraph::AccessMode::Read,
+        RenderGraph::TextureRange{.aspects = RenderGraph::TextureAspect::Stencil}
+    );
+    suite.Check(
+        valid_graph.Compile(),
+        test_name,
+        "depth and stencil subsets must accept depth/stencil attachment states: " +
+            valid_graph.GetCompileError()
+    );
+}
+
 void TestTypedAliasDescriptorMismatchIsRejected(TestSuite& suite) {
     constexpr std::string_view test_name = "typed alias descriptor mismatch";
     RenderGraph                graph("AliasDescriptorMismatch");
@@ -1708,6 +1914,99 @@ void TestAutomaticReadsPreserveAvailabilityFrontier(TestSuite& suite) {
         transition_syncs == 2,
         test_name,
         "each later Compute batch must wait for the retained availability frontier"
+    );
+}
+
+void TestSameNativeReadsDependOnTransitionFrontier(TestSuite& suite) {
+    constexpr std::string_view test_name = "same-native reads depend on transition frontier";
+    RenderGraph graph("SameNativeAvailability", RenderGraph::QueueTopology::SingleQueue());
+    const auto  buffer = graph.CreateTransientBuffer(
+        "Buffer", RenderGraph::BufferDesc{.byte_size = 64}
+    );
+    const auto writer = graph.AddPass(
+        "Write",
+        [buffer](RenderGraph::PassBuilder& builder) {
+            builder.Write(buffer, RenderGraph::BufferState::UnorderedAccess);
+        },
+        [] {}
+    );
+    const auto transition = graph.AddPass(
+        "TransitionRead",
+        [buffer](RenderGraph::PassBuilder& builder) {
+            builder.Read(buffer, RenderGraph::BufferState::ShaderResource);
+        },
+        [] {}
+    );
+    const auto sibling_a = graph.AddPass(
+        "CompatibleReadA",
+        [buffer](RenderGraph::PassBuilder& builder) {
+            builder.Read(buffer, RenderGraph::BufferState::ShaderResource);
+        },
+        [] {}
+    );
+    const auto sibling_b = graph.AddPass(
+        "CompatibleReadB",
+        [buffer](RenderGraph::PassBuilder& builder) {
+            builder.Read(buffer, RenderGraph::BufferState::ShaderResource);
+        },
+        [] {}
+    );
+
+    suite.Check(graph.Compile(), test_name, graph.GetCompileError());
+    const auto& plan = graph.GetCompiledPlan();
+    suite.Check(
+        HasEdgeReason(
+            plan,
+            transition,
+            sibling_a,
+            RenderGraph::EdgeReasonKind::StateTransition,
+            buffer.Untyped()
+        ) &&
+            HasEdgeReason(
+                plan,
+                transition,
+                sibling_b,
+                RenderGraph::EdgeReasonKind::StateTransition,
+                buffer.Untyped()
+            ) &&
+            !HasEdgeReason(
+                plan,
+                writer,
+                sibling_a,
+                RenderGraph::EdgeReasonKind::ReadAfterWrite,
+                buffer.Untyped()
+            ) &&
+            !HasEdgeReason(
+                plan,
+                writer,
+                sibling_b,
+                RenderGraph::EdgeReasonKind::ReadAfterWrite,
+                buffer.Untyped()
+            ) &&
+            !HasEdgeReason(
+                plan,
+                sibling_a,
+                sibling_b,
+                RenderGraph::EdgeReasonKind::StateTransition,
+                buffer.Untyped()
+            ),
+        test_name,
+        "compatible reads must fan out from the transition frontier without restoring a stale writer"
+    );
+    suite.Check(
+        plan.dependency_waves.size() == 3 && WaveContains(plan.dependency_waves[0], writer) &&
+            WaveContains(plan.dependency_waves[1], transition) &&
+            WaveContains(plan.dependency_waves[2], sibling_a) &&
+            WaveContains(plan.dependency_waves[2], sibling_b),
+        test_name,
+        "the writer, transition, and compatible sibling reads must occupy three dependency waves"
+    );
+    suite.Check(
+        FindBarrier(plan, buffer.Untyped(), transition, sibling_a) == nullptr &&
+            FindBarrier(plan, buffer.Untyped(), transition, sibling_b) == nullptr &&
+            plan.queue_syncs.empty(),
+        test_name,
+        "a same-state same-queue availability edge must not create a barrier or queue sync"
     );
 }
 
@@ -3030,6 +3329,7 @@ int main() {
     TestLogicalResourceVersions(suite);
     TestInvalidTypedRangeIsRejected(suite);
     TestUnknownTextureAspectIsRejected(suite);
+    TestTextureAttachmentStateMatchesSelectedAspects(suite);
     TestTypedAliasDescriptorMismatchIsRejected(suite);
     TestMultipleReadersProduceAllWarEdges(suite);
     TestExplicitStateValidation(suite);
@@ -3039,6 +3339,7 @@ int main() {
     TestExclusiveOwnershipUsesCurrentOwnerFamily(suite);
     TestOwnershipWriterChainUsesCurrentFrontier(suite);
     TestAutomaticReadsPreserveAvailabilityFrontier(suite);
+    TestSameNativeReadsDependOnTransitionFrontier(suite);
     TestOwnershipAcquireOrdersSiblingNativeQueue(suite);
     TestImportAvailabilityOrdersSiblingNativeQueue(suite);
     TestOwnershipTransitionCollapsesReaderFrontier(suite);

--- a/source/test/RenderGraphTest.cpp
+++ b/source/test/RenderGraphTest.cpp
@@ -679,6 +679,77 @@ void TestExportedTransientRequiresWholeResourceInitialization(TestSuite& suite) 
     suite.Check(complete_graph.Execute(), test_name, complete_graph.GetCompileError());
 }
 
+void TestTypedPartialExportRequiresOnlyDeclaredRange(TestSuite& suite) {
+    constexpr std::string_view test_name = "typed partial export initialization";
+
+    RenderGraph valid_graph("TypedPartialExport");
+    const auto  valid_texture = valid_graph.CreateTransientTexture(
+        "PartialMipChain", RenderGraph::TextureDesc{.mip_count = 2, .layer_count = 1}
+    );
+    const auto write_mip_zero = valid_graph.AddPass(
+        "WriteMip0",
+        [valid_texture](RenderGraph::PassBuilder& builder) {
+            builder.Write(
+                valid_texture,
+                RenderGraph::TextureState::RenderTarget,
+                RenderGraph::TextureRange::Mips(0, 1)
+            );
+        },
+        [] {}
+    );
+    valid_graph.Export(
+        valid_texture,
+        RenderGraph::TextureState::ShaderResource,
+        RenderGraph::QueueRole::Graphics,
+        RenderGraph::AccessMode::Read,
+        RenderGraph::TextureRange::Mips(0, 1)
+    );
+
+    suite.Check(valid_graph.Compile(), test_name, valid_graph.GetCompileError());
+    const auto& valid_plan = valid_graph.GetCompiledPlan();
+    const auto* final_barrier = FindBarrier(
+        valid_plan, valid_texture.Untyped(), write_mip_zero, {}
+    );
+    suite.Check(
+        final_barrier != nullptr && final_barrier->export_boundary &&
+            final_barrier->range.kind == RenderGraph::ResourceKind::Texture &&
+            final_barrier->range.texture.mip_first == 0 &&
+            final_barrier->range.texture.mip_count == 1 &&
+            valid_plan.state_plan_complete,
+        test_name,
+        "a typed partial export must cover only its initialized declared range"
+    );
+
+    RenderGraph invalid_graph("UninitializedTypedPartialExport");
+    const auto  invalid_texture = invalid_graph.CreateTransientTexture(
+        "PartialMipChain", RenderGraph::TextureDesc{.mip_count = 2, .layer_count = 1}
+    );
+    invalid_graph.AddPass(
+        "WriteMip0",
+        [invalid_texture](RenderGraph::PassBuilder& builder) {
+            builder.Write(
+                invalid_texture,
+                RenderGraph::TextureState::RenderTarget,
+                RenderGraph::TextureRange::Mips(0, 1)
+            );
+        },
+        [] {}
+    );
+    invalid_graph.Export(
+        invalid_texture,
+        RenderGraph::TextureState::ShaderResource,
+        RenderGraph::QueueRole::Graphics,
+        RenderGraph::AccessMode::Read,
+        RenderGraph::TextureRange::Mips(1, 1)
+    );
+    suite.Check(
+        !invalid_graph.Compile() &&
+            Contains(invalid_graph.GetCompileError(), "uninitialized subresources"),
+        test_name,
+        "a typed partial export must still reject an uninitialized declared range"
+    );
+}
+
 void TestTypedBufferRangeHazards(TestSuite& suite) {
     constexpr std::string_view test_name = "typed buffer range hazards";
     RenderGraph                graph("BufferRanges");
@@ -1373,6 +1444,680 @@ void TestQueueTopologySynchronization(TestSuite& suite) {
     );
 }
 
+void TestExclusiveOwnershipUsesCurrentOwnerFamily(TestSuite& suite) {
+    constexpr std::string_view test_name = "exclusive ownership follows current owner family";
+    RenderGraph graph("OwnershipChain", RenderGraph::QueueTopology::DedicatedQueues());
+    int         physical = 0;
+    const auto  buffer = graph.ImportBuffer(
+        "Shared",
+        &physical,
+        RenderGraph::BufferDesc{
+            .byte_size    = 64,
+            .sharing_mode = RenderGraph::TextureDesc::SharingMode::Exclusive,
+        }
+    );
+    graph.SetInitialState(
+        buffer,
+        RenderGraph::BufferState::ShaderResource,
+        RenderGraph::QueueRole::Graphics,
+        RenderGraph::AccessMode::Read
+    );
+    const auto graphics_read = graph.AddPass(
+        "GraphicsRead",
+        [buffer](RenderGraph::PassBuilder& builder) {
+            builder.Read(buffer, RenderGraph::BufferState::ShaderResource);
+        },
+        [] {}
+    );
+    const auto compute_read = graph.AddPass(
+        "ComputeRead",
+        [buffer](RenderGraph::PassBuilder& builder) {
+            builder.ExecuteOn(RenderGraph::QueueRole::Compute, RenderGraph::PipelineType::Compute);
+            builder.Read(buffer, RenderGraph::BufferState::ShaderResource);
+        },
+        [] {}
+    );
+    const auto copy_read = graph.AddPass(
+        "CopyRead",
+        [buffer](RenderGraph::PassBuilder& builder) {
+            builder.ExecuteOn(RenderGraph::QueueRole::Copy, RenderGraph::PipelineType::Copy);
+            builder.Read(buffer, RenderGraph::BufferState::TransferSource);
+        },
+        [] {}
+    );
+    graph.Export(
+        buffer,
+        RenderGraph::BufferState::ShaderResource,
+        RenderGraph::QueueRole::Graphics,
+        RenderGraph::AccessMode::Read
+    );
+
+    suite.Check(graph.Compile(), test_name, graph.GetCompileError());
+    const auto& plan = graph.GetCompiledPlan();
+    const auto* transfer = FindBarrier(plan, buffer.Untyped(), compute_read, copy_read);
+    suite.Check(
+        transfer != nullptr && transfer->queue_ownership && transfer->sources.size() == 1 &&
+            HasBarrierSource(*transfer, compute_read, RenderGraph::AccessMode::Read) &&
+            !HasBarrierSource(*transfer, graphics_read, RenderGraph::AccessMode::Read),
+        test_name,
+        "the second transfer must release only from the currently owning Compute family"
+    );
+    const auto* final_transfer = FindBarrier(plan, buffer.Untyped(), copy_read, {});
+    suite.Check(
+        final_transfer != nullptr && final_transfer->export_boundary &&
+            final_transfer->queue_ownership && final_transfer->sources.size() == 1 &&
+            HasBarrierSource(*final_transfer, copy_read, RenderGraph::AccessMode::Read),
+        test_name,
+        "the export transfer must release only from the final Copy owner"
+    );
+    suite.Check(
+        HasEdgeReason(
+            plan,
+            compute_read,
+            copy_read,
+            RenderGraph::EdgeReasonKind::QueueOwnership,
+            buffer.Untyped()
+        ) &&
+            !HasEdgeReason(
+                plan,
+                graphics_read,
+                copy_read,
+                RenderGraph::EdgeReasonKind::QueueOwnership,
+                buffer.Untyped()
+            ),
+        test_name,
+        "the ownership chain must be Graphics-to-Compute-to-Copy without a stale Graphics-to-Copy edge"
+    );
+    const auto graphics_to_copy = std::find_if(
+        plan.queue_syncs.begin(),
+        plan.queue_syncs.end(),
+        [](const RenderGraph::CompiledQueueSync& sync) {
+            return sync.signal_queue.role == RenderGraph::QueueRole::Graphics &&
+                   sync.wait_queue.role == RenderGraph::QueueRole::Copy;
+        }
+    );
+    suite.Check(
+        plan.queue_syncs.size() == 2 && graphics_to_copy == plan.queue_syncs.end(),
+        test_name,
+        "the second transfer must not create a redundant Graphics-to-Copy queue sync"
+    );
+}
+
+void TestOwnershipWriterChainUsesCurrentFrontier(TestSuite& suite) {
+    constexpr std::string_view test_name = "ownership writer chain uses current frontier";
+    RenderGraph graph("WriterOwnershipChain", RenderGraph::QueueTopology::DedicatedQueues());
+    const auto  buffer = graph.CreateTransientBuffer(
+        "Shared", RenderGraph::BufferDesc{.byte_size = 64}
+    );
+    const auto writer = graph.AddPass(
+        "GraphicsWrite",
+        [buffer](RenderGraph::PassBuilder& builder) {
+            builder.Write(buffer, RenderGraph::BufferState::UnorderedAccess);
+        },
+        [] {}
+    );
+    const auto compute_read = graph.AddPass(
+        "ComputeRead",
+        [buffer](RenderGraph::PassBuilder& builder) {
+            builder.ExecuteOn(RenderGraph::QueueRole::Compute, RenderGraph::PipelineType::Compute);
+            builder.Read(buffer, RenderGraph::BufferState::ShaderResource);
+        },
+        [] {}
+    );
+    const auto copy_read = graph.AddPass(
+        "CopyRead",
+        [buffer](RenderGraph::PassBuilder& builder) {
+            builder.ExecuteOn(RenderGraph::QueueRole::Copy, RenderGraph::PipelineType::Copy);
+            builder.Read(buffer, RenderGraph::BufferState::TransferSource);
+        },
+        [] {}
+    );
+
+    suite.Check(graph.Compile(), test_name, graph.GetCompileError());
+    const auto& plan = graph.GetCompiledPlan();
+    const auto* transfer = FindBarrier(plan, buffer.Untyped(), compute_read, copy_read);
+    suite.Check(
+        transfer != nullptr && transfer->queue_ownership && transfer->sources.size() == 1 &&
+            HasBarrierSource(*transfer, compute_read, RenderGraph::AccessMode::Read) &&
+            !HasBarrierSource(*transfer, writer, RenderGraph::AccessMode::Write),
+        test_name,
+        "the second transfer must use only the read that established the current frontier"
+    );
+    suite.Check(
+        !HasEdgeReason(
+            plan,
+            writer,
+            copy_read,
+            RenderGraph::EdgeReasonKind::ReadAfterWrite,
+            buffer.Untyped()
+        ) &&
+            !HasEdgeReason(
+                plan,
+                writer,
+                copy_read,
+                RenderGraph::EdgeReasonKind::StateTransition,
+                buffer.Untyped()
+            ) &&
+            !HasEdgeReason(
+                plan,
+                writer,
+                copy_read,
+                RenderGraph::EdgeReasonKind::QueueOwnership,
+                buffer.Untyped()
+            ),
+        test_name,
+        "an old writer must not remain a direct dependency after a read transfer"
+    );
+    const auto stale_sync = std::find_if(
+        plan.queue_syncs.begin(),
+        plan.queue_syncs.end(),
+        [&](const RenderGraph::CompiledQueueSync& sync) {
+            return sync.signal_pass == writer && sync.wait_pass == copy_read;
+        }
+    );
+    suite.Check(
+        plan.queue_syncs.size() == 2 && stale_sync == plan.queue_syncs.end(),
+        test_name,
+        "the ownership chain must not lower a stale Graphics-to-Copy GPU wait"
+    );
+}
+
+void TestAutomaticReadsPreserveAvailabilityFrontier(TestSuite& suite) {
+    constexpr std::string_view test_name = "automatic reads preserve availability frontier";
+    RenderGraph graph("AutomaticAvailability", RenderGraph::QueueTopology::DedicatedQueues());
+    const auto  buffer = graph.CreateTransientBuffer(
+        "Concurrent",
+        RenderGraph::BufferDesc{
+            .byte_size    = 64,
+            .sharing_mode = RenderGraph::TextureDesc::SharingMode::Concurrent,
+        }
+    );
+    const auto writer = graph.AddPass(
+        "GraphicsWrite",
+        [buffer](RenderGraph::PassBuilder& builder) {
+            builder.Write(buffer, RenderGraph::BufferState::UnorderedAccess);
+        },
+        [] {}
+    );
+    const auto transition = graph.AddPass(
+        "GraphicsTransition",
+        [buffer](RenderGraph::PassBuilder& builder) {
+            builder.Read(buffer, RenderGraph::BufferState::ShaderResource);
+        },
+        [] {}
+    );
+    const auto automatic_compute_a = graph.AddPass(
+        "ComputeAutomaticA",
+        [buffer](RenderGraph::PassBuilder& builder) {
+            builder.ExecuteOn(RenderGraph::QueueRole::Compute, RenderGraph::PipelineType::Compute);
+            builder.Read(buffer);
+        },
+        [] {}
+    );
+    graph.AddPass(
+        "GraphicsAutomatic",
+        [buffer](RenderGraph::PassBuilder& builder) {
+            builder.Read(buffer);
+        },
+        [] {}
+    );
+    const auto automatic_compute_b = graph.AddPass(
+        "ComputeAutomaticB",
+        [buffer](RenderGraph::PassBuilder& builder) {
+            builder.ExecuteOn(RenderGraph::QueueRole::Compute, RenderGraph::PipelineType::Compute);
+            builder.Read(buffer);
+        },
+        [] {}
+    );
+
+    suite.Check(graph.Compile(), test_name, graph.GetCompileError());
+    const auto& plan = graph.GetCompiledPlan();
+    suite.Check(
+        HasEdgeReason(
+            plan,
+            transition,
+            automatic_compute_a,
+            RenderGraph::EdgeReasonKind::StateTransition,
+            buffer.Untyped()
+        ) &&
+            HasEdgeReason(
+                plan,
+                transition,
+                automatic_compute_b,
+                RenderGraph::EdgeReasonKind::StateTransition,
+                buffer.Untyped()
+            ) &&
+            !HasEdgeReason(
+                plan,
+                writer,
+                automatic_compute_b,
+                RenderGraph::EdgeReasonKind::ReadAfterWrite,
+                buffer.Untyped()
+            ),
+        test_name,
+        "Automatic reads must inherit, preserve, and not bypass the transition availability frontier"
+    );
+    const uint32_t transition_syncs = static_cast<uint32_t>(std::count_if(
+        plan.queue_syncs.begin(),
+        plan.queue_syncs.end(),
+        [&](const RenderGraph::CompiledQueueSync& sync) {
+            return sync.signal_pass == transition && sync.gpu_wait_required;
+        }
+    ));
+    suite.Check(
+        transition_syncs == 2,
+        test_name,
+        "each later Compute batch must wait for the retained availability frontier"
+    );
+}
+
+void TestOwnershipAcquireOrdersSiblingNativeQueue(TestSuite& suite) {
+    constexpr std::string_view test_name = "ownership acquire orders sibling native queue";
+    RenderGraph graph(
+        "OwnershipAcquireFrontier",
+        RenderGraph::QueueTopology{
+            .graphics = {RenderGraph::QueueRole::Graphics, 1, 1},
+            .compute  = {RenderGraph::QueueRole::Compute, 2, 1},
+            .copy     = {RenderGraph::QueueRole::Copy, 0, 0},
+        }
+    );
+    int        physical = 0;
+    const auto buffer = graph.ImportBuffer(
+        "Shared", &physical, RenderGraph::BufferDesc{.byte_size = 64}
+    );
+    graph.SetInitialState(
+        buffer,
+        RenderGraph::BufferState::ShaderResource,
+        RenderGraph::QueueRole::Copy,
+        RenderGraph::AccessMode::Read
+    );
+    const auto acquire = graph.AddPass(
+        "GraphicsAcquire",
+        [buffer](RenderGraph::PassBuilder& builder) {
+            builder.Read(buffer, RenderGraph::BufferState::ShaderResource);
+        },
+        [] {}
+    );
+    const auto sibling_read = graph.AddPass(
+        "ComputeRead",
+        [buffer](RenderGraph::PassBuilder& builder) {
+            builder.ExecuteOn(RenderGraph::QueueRole::Compute, RenderGraph::PipelineType::Compute);
+            builder.Read(buffer, RenderGraph::BufferState::ShaderResource);
+        },
+        [] {}
+    );
+
+    suite.Check(graph.Compile(), test_name, graph.GetCompileError());
+    const auto& plan = graph.GetCompiledPlan();
+    suite.Check(
+        HasEdgeReason(
+            plan,
+            acquire,
+            sibling_read,
+            RenderGraph::EdgeReasonKind::QueueOwnership,
+            buffer.Untyped()
+        ),
+        test_name,
+        "a sibling native queue must wait for the pass that acquired family ownership"
+    );
+    suite.Check(
+        plan.queue_syncs.size() == 1 && plan.queue_syncs.front().gpu_wait_required &&
+            plan.queue_syncs.front().signal_pass == acquire &&
+            plan.queue_syncs.front().wait_pass == sibling_read,
+        test_name,
+        "the ownership acquire frontier must lower to one cross-native GPU wait"
+    );
+}
+
+void TestImportAvailabilityOrdersSiblingNativeQueue(TestSuite& suite) {
+    constexpr std::string_view test_name = "import availability orders sibling native queue";
+    RenderGraph graph(
+        "ImportAvailabilityFrontier",
+        RenderGraph::QueueTopology{
+            .graphics = {RenderGraph::QueueRole::Graphics, 1, 1},
+            .compute  = {RenderGraph::QueueRole::Compute, 2, 1},
+            .copy     = {RenderGraph::QueueRole::Copy, 0, 0},
+        }
+    );
+    int        physical = 0;
+    const auto buffer = graph.ImportBuffer(
+        "Shared", &physical, RenderGraph::BufferDesc{.byte_size = 64}
+    );
+    graph.SetInitialState(
+        buffer,
+        RenderGraph::BufferState::UnorderedAccess,
+        RenderGraph::QueueRole::Graphics,
+        RenderGraph::AccessMode::Write
+    );
+    const auto first_read = graph.AddPass(
+        "GraphicsRead",
+        [buffer](RenderGraph::PassBuilder& builder) {
+            builder.Read(buffer);
+        },
+        [] {}
+    );
+    const auto sibling_read = graph.AddPass(
+        "ComputeRead",
+        [buffer](RenderGraph::PassBuilder& builder) {
+            builder.ExecuteOn(RenderGraph::QueueRole::Compute, RenderGraph::PipelineType::Compute);
+            builder.Read(buffer);
+        },
+        [] {}
+    );
+
+    suite.Check(graph.Compile(), test_name, graph.GetCompileError());
+    const auto& plan = graph.GetCompiledPlan();
+    const auto* boundary = FindBarrier(plan, buffer.Untyped(), {}, first_read);
+    suite.Check(
+        boundary != nullptr && boundary->import_boundary && boundary->memory_dependency &&
+            !boundary->state_transition && !boundary->queue_ownership,
+        test_name,
+        "the first read must acquire the external write through an import memory barrier"
+    );
+    suite.Check(
+        HasEdgeReason(
+            plan,
+            first_read,
+            sibling_read,
+            RenderGraph::EdgeReasonKind::StateTransition,
+            buffer.Untyped()
+        ) &&
+            HasEdgeReason(
+                plan,
+                first_read,
+                sibling_read,
+                RenderGraph::EdgeReasonKind::QueueOwnership,
+                buffer.Untyped()
+            ) &&
+            plan.queue_syncs.size() == 1 && plan.queue_syncs.front().gpu_wait_required &&
+            plan.queue_syncs.front().signal_pass == first_read &&
+            plan.queue_syncs.front().wait_pass == sibling_read,
+        test_name,
+        "an Automatic sibling access must wait for the pass that acquired external availability"
+    );
+}
+
+void TestOwnershipTransitionCollapsesReaderFrontier(TestSuite& suite) {
+    constexpr std::string_view test_name = "ownership transition collapses reader frontier";
+    RenderGraph graph(
+        "OwnershipStateFrontier",
+        RenderGraph::QueueTopology{
+            .graphics = {RenderGraph::QueueRole::Graphics, 1, 1},
+            .compute  = {RenderGraph::QueueRole::Compute, 2, 1},
+            .copy     = {RenderGraph::QueueRole::Copy, 0, 0},
+        }
+    );
+    int        physical = 0;
+    const auto buffer = graph.ImportBuffer(
+        "Shared", &physical, RenderGraph::BufferDesc{.byte_size = 64}
+    );
+    graph.SetInitialState(
+        buffer,
+        RenderGraph::BufferState::TransferSource,
+        RenderGraph::QueueRole::Copy,
+        RenderGraph::AccessMode::Read
+    );
+    const auto old_owner_read = graph.AddPass(
+        "CopyRead",
+        [buffer](RenderGraph::PassBuilder& builder) {
+            builder.ExecuteOn(RenderGraph::QueueRole::Copy, RenderGraph::PipelineType::Copy);
+            builder.Read(buffer, RenderGraph::BufferState::TransferSource);
+        },
+        [] {}
+    );
+    const auto acquire = graph.AddPass(
+        "GraphicsAcquire",
+        [buffer](RenderGraph::PassBuilder& builder) {
+            builder.Read(buffer, RenderGraph::BufferState::ShaderResource);
+        },
+        [] {}
+    );
+    const auto transition = graph.AddPass(
+        "ComputeTransition",
+        [buffer](RenderGraph::PassBuilder& builder) {
+            builder.ExecuteOn(RenderGraph::QueueRole::Compute, RenderGraph::PipelineType::Compute);
+            builder.Read(buffer, RenderGraph::BufferState::UnorderedAccess);
+        },
+        [] {}
+    );
+    const auto sibling_read = graph.AddPass(
+        "GraphicsSiblingRead",
+        [buffer](RenderGraph::PassBuilder& builder) {
+            builder.Read(buffer, RenderGraph::BufferState::UnorderedAccess);
+        },
+        [] {}
+    );
+
+    suite.Check(graph.Compile(), test_name, graph.GetCompileError());
+    const auto& plan = graph.GetCompiledPlan();
+    const auto* barrier = FindBarrier(plan, buffer.Untyped(), acquire, transition);
+    suite.Check(
+        barrier != nullptr && barrier->state_transition && !barrier->queue_ownership &&
+            barrier->sources.size() == 1 &&
+            HasBarrierSource(*barrier, acquire, RenderGraph::AccessMode::Read) &&
+            !HasBarrierSource(*barrier, old_owner_read, RenderGraph::AccessMode::Read),
+        test_name,
+        "a same-family transition must not reuse a reader from the family that lost ownership"
+    );
+    suite.Check(
+        !HasEdgeReason(
+            plan,
+            old_owner_read,
+            transition,
+            RenderGraph::EdgeReasonKind::StateTransition,
+            buffer.Untyped()
+        ),
+        test_name,
+        "the collapsed reader frontier must avoid a stale Copy-to-Compute transition edge"
+    );
+    suite.Check(
+        HasEdgeReason(
+            plan,
+            transition,
+            sibling_read,
+            RenderGraph::EdgeReasonKind::StateTransition,
+            buffer.Untyped()
+        ) &&
+            HasEdgeReason(
+                plan,
+                transition,
+                sibling_read,
+                RenderGraph::EdgeReasonKind::QueueOwnership,
+                buffer.Untyped()
+            ) &&
+            !HasEdgeReason(
+                plan,
+                acquire,
+                sibling_read,
+                RenderGraph::EdgeReasonKind::QueueOwnership,
+                buffer.Untyped()
+            ),
+        test_name,
+        "a state transition must advance both availability anchors past the old acquire pass"
+    );
+}
+
+void TestWriterAdvancesAvailabilityFrontiers(TestSuite& suite) {
+    constexpr std::string_view test_name = "writer advances availability frontiers";
+    RenderGraph graph(
+        "WriterFrontier",
+        RenderGraph::QueueTopology{
+            .graphics = {RenderGraph::QueueRole::Graphics, 1, 1},
+            .compute  = {RenderGraph::QueueRole::Compute, 2, 1},
+            .copy     = {RenderGraph::QueueRole::Copy, 0, 0},
+        }
+    );
+    int        physical = 0;
+    const auto buffer = graph.ImportBuffer(
+        "Shared", &physical, RenderGraph::BufferDesc{.byte_size = 64}
+    );
+    graph.SetInitialState(
+        buffer,
+        RenderGraph::BufferState::ShaderResource,
+        RenderGraph::QueueRole::Graphics,
+        RenderGraph::AccessMode::Read
+    );
+    const auto transition = graph.AddPass(
+        "GraphicsTransition",
+        [buffer](RenderGraph::PassBuilder& builder) {
+            builder.Read(buffer, RenderGraph::BufferState::UnorderedAccess);
+        },
+        [] {}
+    );
+    const auto writer = graph.AddPass(
+        "ComputeWrite",
+        [buffer](RenderGraph::PassBuilder& builder) {
+            builder.ExecuteOn(RenderGraph::QueueRole::Compute, RenderGraph::PipelineType::Compute);
+            builder.Write(buffer, RenderGraph::BufferState::UnorderedAccess);
+        },
+        [] {}
+    );
+    graph.AddPass(
+        "GraphicsRead",
+        [buffer](RenderGraph::PassBuilder& builder) {
+            builder.Read(buffer, RenderGraph::BufferState::UnorderedAccess);
+        },
+        [] {}
+    );
+    const auto sibling_read = graph.AddPass(
+        "ComputeRead",
+        [buffer](RenderGraph::PassBuilder& builder) {
+            builder.ExecuteOn(RenderGraph::QueueRole::Compute, RenderGraph::PipelineType::Compute);
+            builder.Read(buffer, RenderGraph::BufferState::UnorderedAccess);
+        },
+        [] {}
+    );
+
+    suite.Check(graph.Compile(), test_name, graph.GetCompileError());
+    const auto& plan = graph.GetCompiledPlan();
+    suite.Check(
+        HasEdgeReason(
+            plan,
+            writer,
+            sibling_read,
+            RenderGraph::EdgeReasonKind::ReadAfterWrite,
+            buffer.Untyped()
+        ) &&
+            !HasEdgeReason(
+                plan,
+                transition,
+                sibling_read,
+                RenderGraph::EdgeReasonKind::StateTransition,
+                buffer.Untyped()
+            ) &&
+            !HasEdgeReason(
+                plan,
+                transition,
+                sibling_read,
+                RenderGraph::EdgeReasonKind::QueueOwnership,
+                buffer.Untyped()
+            ),
+        test_name,
+        "the writer must replace older state and ownership establishment anchors"
+    );
+    const auto stale_sync = std::find_if(
+        plan.queue_syncs.begin(),
+        plan.queue_syncs.end(),
+        [&](const RenderGraph::CompiledQueueSync& sync) {
+            return sync.signal_pass == transition && sync.wait_pass == sibling_read;
+        }
+    );
+    suite.Check(
+        stale_sync == plan.queue_syncs.end(),
+        test_name,
+        "an older transition must not create a direct GPU sync to a post-write reader"
+    );
+}
+
+void TestOwnershipEpochDoesNotReusePriorFamilySources(TestSuite& suite) {
+    constexpr std::string_view test_name = "ownership epochs do not reuse prior family sources";
+    RenderGraph graph(
+        "OwnershipEpochs",
+        RenderGraph::QueueTopology{
+            .graphics = {RenderGraph::QueueRole::Graphics, 0, 0},
+            .compute  = {RenderGraph::QueueRole::Compute, 1, 1},
+            .copy     = {RenderGraph::QueueRole::Copy, 2, 2},
+        }
+    );
+    int        physical = 0;
+    const auto buffer = graph.ImportBuffer(
+        "Shared", &physical, RenderGraph::BufferDesc{.byte_size = 64}
+    );
+    graph.SetInitialState(
+        buffer,
+        RenderGraph::BufferState::ShaderResource,
+        RenderGraph::QueueRole::Graphics,
+        RenderGraph::AccessMode::Read
+    );
+    const auto graphics_epoch_zero = graph.AddPass(
+        "GraphicsEpochZero",
+        [buffer](RenderGraph::PassBuilder& builder) {
+            builder.Read(buffer, RenderGraph::BufferState::ShaderResource);
+        },
+        [] {}
+    );
+    const auto compute_epoch_zero = graph.AddPass(
+        "ComputeEpochZero",
+        [buffer](RenderGraph::PassBuilder& builder) {
+            builder.ExecuteOn(RenderGraph::QueueRole::Compute, RenderGraph::PipelineType::Compute);
+            builder.Read(buffer, RenderGraph::BufferState::ShaderResource);
+        },
+        [] {}
+    );
+    const auto graphics_epoch_one = graph.AddPass(
+        "GraphicsEpochOne",
+        [buffer](RenderGraph::PassBuilder& builder) {
+            builder.Read(buffer, RenderGraph::BufferState::ShaderResource);
+        },
+        [] {}
+    );
+    const auto compute_epoch_one = graph.AddPass(
+        "ComputeEpochOne",
+        [buffer](RenderGraph::PassBuilder& builder) {
+            builder.ExecuteOn(RenderGraph::QueueRole::Compute, RenderGraph::PipelineType::Compute);
+            builder.Read(buffer, RenderGraph::BufferState::ShaderResource);
+        },
+        [] {}
+    );
+
+    suite.Check(graph.Compile(), test_name, graph.GetCompileError());
+    const auto& plan = graph.GetCompiledPlan();
+    const auto* transfer = FindBarrier(
+        plan, buffer.Untyped(), graphics_epoch_one, compute_epoch_one
+    );
+    suite.Check(
+        transfer != nullptr && transfer->queue_ownership && transfer->sources.size() == 1 &&
+            HasBarrierSource(*transfer, graphics_epoch_one, RenderGraph::AccessMode::Read) &&
+            !HasBarrierSource(*transfer, graphics_epoch_zero, RenderGraph::AccessMode::Read) &&
+            !HasBarrierSource(*transfer, compute_epoch_zero, RenderGraph::AccessMode::Read),
+        test_name,
+        "a repeated family must expose only the source from its current ownership epoch"
+    );
+    suite.Check(
+        !HasEdgeReason(
+            plan,
+            graphics_epoch_zero,
+            compute_epoch_one,
+            RenderGraph::EdgeReasonKind::QueueOwnership,
+            buffer.Untyped()
+        ),
+        test_name,
+        "a prior Graphics ownership epoch must not transfer directly to the later Compute epoch"
+    );
+    const auto stale_sync = std::find_if(
+        plan.queue_syncs.begin(),
+        plan.queue_syncs.end(),
+        [&](const RenderGraph::CompiledQueueSync& sync) {
+            return sync.signal_pass == graphics_epoch_zero && sync.wait_pass == compute_epoch_one;
+        }
+    );
+    suite.Check(
+        stale_sync == plan.queue_syncs.end(),
+        test_name,
+        "a prior ownership epoch must not create a stale cross-family sync"
+    );
+}
+
 void TestTokenCrossQueueSyncHasNoOwnership(TestSuite& suite) {
     constexpr std::string_view test_name = "token cross-queue synchronization";
     RenderGraph graph("TokenSync", RenderGraph::QueueTopology::DedicatedQueues());
@@ -1458,7 +2203,13 @@ void TestBatchPairSyncDeduplication(TestSuite& suite) {
 void TestPipelineDomainsAndBarrierSources(TestSuite& suite) {
     constexpr std::string_view test_name = "pipeline domains and barrier sources";
     RenderGraph graph("DomainsAndSources", RenderGraph::QueueTopology::DedicatedQueues());
-    const auto  buffer = graph.CreateTransientBuffer("Shared", RenderGraph::BufferDesc{.byte_size = 64});
+    const auto buffer = graph.CreateTransientBuffer(
+        "Shared",
+        RenderGraph::BufferDesc{
+            .byte_size    = 64,
+            .sharing_mode = RenderGraph::TextureDesc::SharingMode::Concurrent,
+        }
+    );
     const auto producer = graph.AddPass(
         "Producer",
         [buffer](RenderGraph::PassBuilder& builder) {
@@ -2090,6 +2841,7 @@ int main() {
     TestTypedTextureLayerAndAspectHazards(suite);
     TestTransientTextureInitializationIsPerSubresource(suite);
     TestExportedTransientRequiresWholeResourceInitialization(suite);
+    TestTypedPartialExportRequiresOnlyDeclaredRange(suite);
     TestTypedBufferRangeHazards(suite);
     TestLogicalResourceVersions(suite);
     TestInvalidTypedRangeIsRejected(suite);
@@ -2100,6 +2852,14 @@ int main() {
     TestSameStateMemoryDependencies(suite);
     TestImportAndExportBoundaries(suite);
     TestQueueTopologySynchronization(suite);
+    TestExclusiveOwnershipUsesCurrentOwnerFamily(suite);
+    TestOwnershipWriterChainUsesCurrentFrontier(suite);
+    TestAutomaticReadsPreserveAvailabilityFrontier(suite);
+    TestOwnershipAcquireOrdersSiblingNativeQueue(suite);
+    TestImportAvailabilityOrdersSiblingNativeQueue(suite);
+    TestOwnershipTransitionCollapsesReaderFrontier(suite);
+    TestWriterAdvancesAvailabilityFrontiers(suite);
+    TestOwnershipEpochDoesNotReusePriorFamilySources(suite);
     TestTokenCrossQueueSyncHasNoOwnership(suite);
     TestBatchPairSyncDeduplication(suite);
     TestPipelineDomainsAndBarrierSources(suite);

--- a/source/test/RenderGraphTest.cpp
+++ b/source/test/RenderGraphTest.cpp
@@ -2795,12 +2795,196 @@ void TestUndefinedImportMustBeInitializedBeforeRead(TestSuite& suite) {
         },
         [] {}
     );
+    write_graph.Export(
+        write_buffer,
+        RenderGraph::BufferState::ShaderResource,
+        RenderGraph::QueueRole::Graphics,
+        RenderGraph::AccessMode::Read,
+        RenderGraph::BufferRange{.offset = 0, .size = 64}
+    );
     suite.Check(write_graph.Compile(), test_name, write_graph.GetCompileError());
     const auto* barrier = FindBarrier(write_graph.GetCompiledPlan(), write_buffer.Untyped(), {}, write);
     suite.Check(
         barrier != nullptr && barrier->discard_previous_contents,
         test_name,
         "the first write after Undefined must be represented as a discard transition"
+    );
+    const auto* initialized_export_barrier =
+        FindBarrier(write_graph.GetCompiledPlan(), write_buffer.Untyped(), write, {});
+    suite.Check(
+        initialized_export_barrier != nullptr && initialized_export_barrier->export_boundary &&
+            !initialized_export_barrier->discard_previous_contents &&
+            initialized_export_barrier->after_access == RenderGraph::AccessMode::Read,
+        test_name,
+        "a range initialized in the graph must remain exportable to an external reader"
+    );
+
+    RenderGraph read_export_graph("UndefinedReadExport");
+    const auto  read_export_buffer = read_export_graph.ImportBuffer(
+        "Buffer", &physical, RenderGraph::BufferDesc{.byte_size = 128}
+    );
+    read_export_graph.SetInitialState(
+        read_export_buffer,
+        RenderGraph::BufferState::Undefined,
+        RenderGraph::QueueRole::None,
+        RenderGraph::AccessMode::None,
+        RenderGraph::BufferRange::Whole()
+    );
+    read_export_graph.Export(
+        read_export_buffer,
+        RenderGraph::BufferState::ShaderResource,
+        RenderGraph::QueueRole::Graphics,
+        RenderGraph::AccessMode::Read,
+        RenderGraph::BufferRange{.offset = 0, .size = 64}
+    );
+    read_export_graph.AddPass(
+        "SideEffect",
+        [](RenderGraph::PassBuilder& builder) {
+            builder.SideEffect();
+        },
+        [] {}
+    );
+    suite.Check(
+        !read_export_graph.Compile() &&
+            Contains(read_export_graph.GetCompileError(), "uninitialized subresources"),
+        test_name,
+        "an untouched Undefined import must not be exported to an external reader"
+    );
+
+    RenderGraph write_export_graph("UndefinedWriteExport");
+    const auto  write_export_buffer = write_export_graph.ImportBuffer(
+        "Buffer", &physical, RenderGraph::BufferDesc{.byte_size = 128}
+    );
+    write_export_graph.SetInitialState(
+        write_export_buffer,
+        RenderGraph::BufferState::Undefined,
+        RenderGraph::QueueRole::None,
+        RenderGraph::AccessMode::None,
+        RenderGraph::BufferRange::Whole()
+    );
+    write_export_graph.Export(
+        write_export_buffer,
+        RenderGraph::BufferState::UnorderedAccess,
+        RenderGraph::QueueRole::Compute,
+        RenderGraph::AccessMode::Write,
+        RenderGraph::BufferRange{.offset = 0, .size = 64}
+    );
+    write_export_graph.AddPass(
+        "SideEffect",
+        [](RenderGraph::PassBuilder& builder) {
+            builder.SideEffect();
+        },
+        [] {}
+    );
+    suite.Check(
+        write_export_graph.Compile(),
+        test_name,
+        "an external writer does not require preserved imported contents: " +
+            write_export_graph.GetCompileError()
+    );
+    const auto* write_export_barrier =
+        FindBarrier(write_export_graph.GetCompiledPlan(), write_export_buffer.Untyped(), {}, {});
+    suite.Check(
+        write_export_barrier != nullptr && write_export_barrier->export_boundary &&
+            write_export_barrier->discard_previous_contents &&
+            write_export_barrier->state_transition && write_export_barrier->memory_dependency &&
+            write_export_barrier->after_access == RenderGraph::AccessMode::Write &&
+            write_export_barrier->range.kind == RenderGraph::ResourceKind::Buffer &&
+            write_export_barrier->range.buffer.offset == 0 &&
+            write_export_barrier->range.buffer.size == 64 &&
+            write_export_graph.GetCompiledPlan().state_plan_complete,
+        test_name,
+        "a write-only export of Undefined contents must remain an explicit discard boundary"
+    );
+
+    RenderGraph read_write_export_graph("UndefinedReadWriteExport");
+    const auto  read_write_export_buffer = read_write_export_graph.ImportBuffer(
+        "Buffer", &physical, RenderGraph::BufferDesc{.byte_size = 128}
+    );
+    read_write_export_graph.SetInitialState(
+        read_write_export_buffer,
+        RenderGraph::BufferState::Undefined,
+        RenderGraph::QueueRole::None,
+        RenderGraph::AccessMode::None,
+        RenderGraph::BufferRange{.offset = 0, .size = 64}
+    );
+    read_write_export_graph.Export(
+        read_write_export_buffer,
+        RenderGraph::BufferState::UnorderedAccess,
+        RenderGraph::QueueRole::Compute,
+        RenderGraph::AccessMode::ReadWrite,
+        RenderGraph::BufferRange{.offset = 0, .size = 64}
+    );
+    read_write_export_graph.AddPass(
+        "SideEffect",
+        [](RenderGraph::PassBuilder& builder) {
+            builder.SideEffect();
+        },
+        [] {}
+    );
+    suite.Check(
+        !read_write_export_graph.Compile() &&
+            Contains(read_write_export_graph.GetCompileError(), "uninitialized subresources"),
+        test_name,
+        "a ReadWrite export must preserve the same initialization requirement as a read"
+    );
+
+    RenderGraph disjoint_export_graph("DisjointUndefinedReadExport");
+    const auto  disjoint_export_buffer = disjoint_export_graph.ImportBuffer(
+        "Buffer", &physical, RenderGraph::BufferDesc{.byte_size = 128}
+    );
+    disjoint_export_graph.SetInitialState(
+        disjoint_export_buffer,
+        RenderGraph::BufferState::Undefined,
+        RenderGraph::QueueRole::None,
+        RenderGraph::AccessMode::None,
+        RenderGraph::BufferRange{.offset = 0, .size = 64}
+    );
+    disjoint_export_graph.Export(
+        disjoint_export_buffer,
+        RenderGraph::BufferState::ShaderResource,
+        RenderGraph::QueueRole::Graphics,
+        RenderGraph::AccessMode::Read,
+        RenderGraph::BufferRange{.offset = 64, .size = 64}
+    );
+    disjoint_export_graph.AddPass(
+        "SideEffect",
+        [](RenderGraph::PassBuilder& builder) {
+            builder.SideEffect();
+        },
+        [] {}
+    );
+    suite.Check(
+        disjoint_export_graph.Compile(),
+        test_name,
+        "an Undefined import range must not invalidate a disjoint typed export: " +
+            disjoint_export_graph.GetCompileError()
+    );
+
+    RenderGraph legacy_export_graph("LegacyUndefinedExport");
+    const auto  legacy_export_buffer = legacy_export_graph.ImportBuffer(
+        "Buffer", &physical, RenderGraph::BufferDesc{.byte_size = 128}
+    );
+    legacy_export_graph.SetInitialState(
+        legacy_export_buffer,
+        RenderGraph::BufferState::Undefined,
+        RenderGraph::QueueRole::None,
+        RenderGraph::AccessMode::None,
+        RenderGraph::BufferRange{.offset = 0, .size = 64}
+    );
+    legacy_export_graph.Export(legacy_export_buffer);
+    legacy_export_graph.AddPass(
+        "SideEffect",
+        [](RenderGraph::PassBuilder& builder) {
+            builder.SideEffect();
+        },
+        [] {}
+    );
+    suite.Check(
+        legacy_export_graph.Compile(),
+        test_name,
+        "legacy import export has no external read contract and must remain compatible: " +
+            legacy_export_graph.GetCompileError()
     );
 }
 


### PR DESCRIPTION
## Summary

- add RDG-neutral texture/buffer resource states, access modes, queue roles, pipeline domains, sharing modes, and an injectable queue topology
- compile subresource/byte-range cells into canonical memory/state/ownership barrier decisions with complete fan-in source endpoints
- generate logical queue batches, host-FIFO versus GPU wait/signal relationships, and pass/prologue/epilogue barrier placement metadata
- model explicit import initial states and export final states while keeping unknown and undefined boundaries fail-visible
- add CPU contract coverage for explicit states, partial ranges, queue topology, ownership, boundary transitions, fan-in, and deterministic dumps

## Why

This is the second independently mergeable RDG modernization step after #182. It absorbs the explicit-state and multi-queue planning concepts from `dev_parallel_rhi` without importing that branch's coupled RHI/Vulkan submission and threading contracts.

## Execution boundary

The compiled sync plan is intentionally shadow-only:

- production `RenderGraph::Execute()` remains declaration-order and serial
- RDG does not emit or submit physical barriers in this change
- the existing RHI/Vulkan command path remains responsible for physical synchronization
- external import/export/present synchronization endpoints are not yet bound
- `state_plan_complete` means only that participating logical resource cells have known states; it does not mean the plan is ready for lowering or submission

The dump reports `sync_plan=shadow external_endpoints=unbound` to make this boundary observable.

## Validation

- `cmake --build build_vs2022 --config Debug --target TestRenderGraph MoerEditor -- /m:8`
- `ctest --test-dir build_vs2022 -C Debug -R RenderGraphContract --output-on-failure` — 1/1 passed
- `cmake --build build_vs2022 --config Release --target TestRenderGraph -- /m:8`
- `ctest --test-dir build_vs2022 -C Release -R RenderGraphContract --output-on-failure` — 1/1 passed
- Debug Raster/Sponza runtime observation for more than one minute; scene loaded and rendered continuously with no observed validation error, assertion, or crash
- `git diff --check`
