### PR TITLE
Add parallel command-list recording architecture

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 /build/*
 /target/*
 /.cache/
+/asset/shader_cache/
 /build_vs2022
 /cmake-build-*/
 

--- a/source/runtime/Engine.cpp
+++ b/source/runtime/Engine.cpp
@@ -231,6 +231,61 @@ uint64_t ParseVulkanPresentSubmitFaultTrigger(int argc, const char** argv) {
     return count;
 }
 
+uint64_t ParseParallelRecordWorkerThrowTrigger(int argc, const char** argv) {
+    constexpr std::string_view argument_name = "--parallel-record-fault-inject";
+    constexpr std::string_view prefix        = "--parallel-record-fault-inject=";
+    constexpr std::string_view point_prefix  = "worker-throw@";
+
+    std::optional<std::string_view> specification;
+    for (int index = 1; index < argc; ++index) {
+        const std::string_view argument = argv[index];
+        std::optional<std::string_view> candidate;
+        if (argument == argument_name) {
+            if (index + 1 >= argc) {
+                throw std::invalid_argument(
+                    "--parallel-record-fault-inject requires worker-throw@<positive-count>"
+                );
+            }
+            candidate = std::string_view(argv[++index]);
+        } else if (argument.starts_with(prefix)) {
+            candidate = argument.substr(prefix.size());
+        }
+
+        if (!candidate.has_value()) {
+            continue;
+        }
+        if (specification.has_value()) {
+            throw std::invalid_argument(
+                "--parallel-record-fault-inject may be specified only once"
+            );
+        }
+        specification = *candidate;
+    }
+
+    if (!specification.has_value()) {
+        return 0;
+    }
+    if (!specification->starts_with(point_prefix)) {
+        throw std::invalid_argument(
+            "unsupported parallel-record fault point; expected worker-throw@<positive-count>"
+        );
+    }
+
+    const std::string_view count_text = specification->substr(point_prefix.size());
+    uint64_t               count      = 0;
+    const auto [end, error] = std::from_chars(
+        count_text.data(), count_text.data() + count_text.size(), count
+    );
+    if (count_text.empty() || error != std::errc{} || end != count_text.data() + count_text.size() ||
+        count == 0) {
+        throw std::invalid_argument(
+            "parallel-record worker fault trigger must be a positive integer: "
+            "worker-throw@<positive-count>"
+        );
+    }
+    return count;
+}
+
 bool ParseThreadingRendererSwitchValidation(int argc, const char** argv) {
     constexpr std::string_view argument_name = "--threading-renderer-switch-validation";
     constexpr std::string_view value_prefix  = "--threading-renderer-switch-validation=";
@@ -249,6 +304,31 @@ bool ParseThreadingRendererSwitchValidation(int argc, const char** argv) {
         if (enabled) {
             throw std::invalid_argument(
                 "--threading-renderer-switch-validation may be specified only once"
+            );
+        }
+        enabled = true;
+    }
+    return enabled;
+}
+
+bool ParseThreadingRasterLifecycleValidation(int argc, const char** argv) {
+    constexpr std::string_view argument_name = "--threading-raster-lifecycle-validation";
+    constexpr std::string_view value_prefix  = "--threading-raster-lifecycle-validation=";
+
+    bool enabled = false;
+    for (int index = 1; index < argc; ++index) {
+        const std::string_view argument = argv[index];
+        if (argument.starts_with(value_prefix)) {
+            throw std::invalid_argument(
+                "--threading-raster-lifecycle-validation is a flag and does not accept a value"
+            );
+        }
+        if (argument != argument_name) {
+            continue;
+        }
+        if (enabled) {
+            throw std::invalid_argument(
+                "--threading-raster-lifecycle-validation may be specified only once"
             );
         }
         enabled = true;
@@ -412,11 +492,20 @@ Engine::Engine() {}
 
 void Engine::ValidateCommandLine(int argc, const char** argv) {
     (void)ParseVulkanPresentSubmitFaultTrigger(argc, argv);
+    (void)ParseParallelRecordWorkerThrowTrigger(argc, argv);
     const bool renderer_switch_validation =
         ParseThreadingRendererSwitchValidation(argc, argv);
+    const bool raster_lifecycle_validation =
+        ParseThreadingRasterLifecycleValidation(argc, argv);
     const auto raster_framebuffer_validation =
         ParseThreadingRasterFramebufferValidation(argc, argv);
-    if (!renderer_switch_validation && !raster_framebuffer_validation.has_value()) {
+    if (renderer_switch_validation && raster_lifecycle_validation) {
+        throw std::invalid_argument(
+            "renderer-switch and Raster lifecycle validation modes are mutually exclusive"
+        );
+    }
+    if (!renderer_switch_validation && !raster_lifecycle_validation &&
+        !raster_framebuffer_validation.has_value()) {
         return;
     }
 
@@ -498,11 +587,21 @@ void Engine::Init(
     const auto& config = ConfigManager::GetInstance().GetConfig();
     const uint64_t vulkan_present_submit_fault_trigger =
         ParseVulkanPresentSubmitFaultTrigger(argc, argv);
+    const uint64_t parallel_record_worker_throw_trigger =
+        ParseParallelRecordWorkerThrowTrigger(argc, argv);
     const bool renderer_switch_validation_enabled =
         ParseThreadingRendererSwitchValidation(argc, argv);
+    const bool raster_lifecycle_validation_enabled =
+        ParseThreadingRasterLifecycleValidation(argc, argv);
     const auto raster_framebuffer_validation =
         ParseThreadingRasterFramebufferValidation(argc, argv);
-    if ((renderer_switch_validation_enabled || raster_framebuffer_validation.has_value()) &&
+    if (renderer_switch_validation_enabled && raster_lifecycle_validation_enabled) {
+        throw std::invalid_argument(
+            "renderer-switch and Raster lifecycle validation modes are mutually exclusive"
+        );
+    }
+    if ((renderer_switch_validation_enabled || raster_lifecycle_validation_enabled ||
+         raster_framebuffer_validation.has_value()) &&
         config.engine.render.default_render_method != "Raster") {
         throw std::invalid_argument(
             "threading Raster validation requires "
@@ -518,12 +617,19 @@ void Engine::Init(
     LOG_INFO("[Threading] GameThread id = {}", GetGameThreadId());
     LOG_INFO(
         "[Threading] render_thread={}, rhi_thread={}, rhi_bypass={}, max_frame_lag={}, "
-        "profile_logging={}",
+        "profile_logging={}, parallel_recording={}, parallel_record_workers={}, "
+        "parallel_record_verify={}, parallel_record_profile={}, "
+        "parallel_record_min_work_units_per_job={}",
         config.engine.threading.render_thread,
         config.engine.threading.rhi_thread,
         config.engine.threading.rhi_bypass,
         config.engine.threading.max_frame_lag,
-        config.engine.threading.profile_logging
+        config.engine.threading.profile_logging,
+        config.engine.threading.parallel_recording,
+        config.engine.threading.parallel_record_workers,
+        config.engine.threading.parallel_record_verify,
+        config.engine.threading.parallel_record_profile,
+        config.engine.threading.parallel_record_min_work_units_per_job
     );
 
     if (config.engine.threading.render_thread) {
@@ -575,9 +681,17 @@ void Engine::Init(
                 .rhi_type        = rhi_type,
                 .name            = "MoerEngine",
                 .rhi_api_version = config.engine.rhi.api_version,
-                .rhi_thread      = config.engine.threading.rhi_thread,
-                .rhi_bypass      = config.engine.threading.rhi_bypass,
-                .thread_profile_logging = config.engine.threading.profile_logging,
+                .rhi_thread              = config.engine.threading.rhi_thread,
+                .rhi_bypass              = config.engine.threading.rhi_bypass,
+                .thread_profile_logging  = config.engine.threading.profile_logging,
+                .parallel_recording      = config.engine.threading.parallel_recording,
+                .parallel_record_workers = config.engine.threading.parallel_record_workers,
+                .parallel_record_verify  = config.engine.threading.parallel_record_verify,
+                .parallel_record_profile = config.engine.threading.parallel_record_profile,
+                .parallel_record_min_work_units_per_job =
+                    config.engine.threading.parallel_record_min_work_units_per_job,
+                .parallel_record_worker_throw_trigger =
+                    parallel_record_worker_throw_trigger,
                 .vulkan_present_submit_fault_trigger = vulkan_present_submit_fault_trigger,
             }
         )
@@ -601,6 +715,12 @@ void Engine::Init(
             "[ThreadingValidation][RendererSwitch] Enabled; sequence=Raster reload, "
             "Raster->Raytracing->Raster; "
             "stable_ready_gt_frames=12."
+        );
+    }
+    if (raster_lifecycle_validation_enabled) {
+        m_raster_lifecycle_validation_enabled = true;
+        LOG_INFO(
+            "[ThreadingValidation][RasterLifecycle] Enabled; stable_ready_gt_frames=12."
         );
     }
 
@@ -695,6 +815,15 @@ void Engine::Run(const EngineHooks& hooks) {
                 const bool validation_requested =
                     ConsumeRendererSwitchValidationReloadRequest();
                 return hook_requested || validation_requested;
+            };
+    } else if (m_raster_lifecycle_validation_enabled) {
+        auto on_tick_test = std::move(runtime_hooks.on_tick_test);
+        runtime_hooks.on_tick_test =
+            [this, on_tick_test = std::move(on_tick_test)](Scene& scene) {
+                if (on_tick_test) {
+                    on_tick_test(scene);
+                }
+                TickRasterLifecycleValidation(scene);
             };
     }
 
@@ -938,6 +1067,30 @@ void Engine::TickRendererSwitchValidation(Scene& scene) {
         case ERendererSwitchValidationStage::Failed:
             break;
     }
+}
+
+void Engine::TickRasterLifecycleValidation(Scene& scene) {
+    assert(IsCurrentlyGameThread());
+    constexpr uint k_stable_ready_gt_frames = 12;
+
+    if (!m_raster_lifecycle_validation_enabled) {
+        return;
+    }
+    if (!scene.IsReady()) {
+        m_raster_lifecycle_validation_ready_frames = 0;
+        return;
+    }
+    ++m_raster_lifecycle_validation_ready_frames;
+    if (m_raster_lifecycle_validation_ready_frames < k_stable_ready_gt_frames) {
+        return;
+    }
+
+    m_raster_lifecycle_validation_enabled = false;
+    LOG_INFO(
+        "[ThreadingValidation][RasterLifecycle] Complete: Raster stable for {} ready GT frames.",
+        k_stable_ready_gt_frames
+    );
+    WindowContext::RequestClose(WindowContext::GetMainWindow());
 }
 
 bool Engine::ConsumeRendererSwitchValidationReloadRequest() {

--- a/source/runtime/Engine.h
+++ b/source/runtime/Engine.h
@@ -69,6 +69,7 @@ private:
     void ShutDown3rdParty();
 
     void TickRendererSwitchValidation(Scene& scene);
+    void TickRasterLifecycleValidation(Scene& scene);
     bool ConsumeRendererSwitchValidationReloadRequest();
 
     SharedPtr<EditorConfig>  m_editor_config;
@@ -92,6 +93,8 @@ private:
         ERendererSwitchValidationStage::Disabled;
     uint m_renderer_switch_validation_ready_frames = 0;
     bool m_renderer_switch_validation_reload_requested = false;
+    bool m_raster_lifecycle_validation_enabled = false;
+    uint m_raster_lifecycle_validation_ready_frames = 0;
 };
 
 } // namespace Moer

--- a/source/runtime/core/include/config/GlobalConfig.h
+++ b/source/runtime/core/include/config/GlobalConfig.h
@@ -32,11 +32,16 @@ struct CORE_API GlobalConfig {
 
     struct Engine {
         struct Threading {
-            bool render_thread   = false;
-            bool rhi_thread      = false;
-            bool rhi_bypass      = true;
-            bool profile_logging = false;
-            uint max_frame_lag   = 0;
+            bool render_thread           = false;
+            bool rhi_thread              = false;
+            bool rhi_bypass              = true;
+            bool profile_logging         = false;
+            bool parallel_recording      = false;
+            uint parallel_record_workers = 0;
+            bool parallel_record_verify  = false;
+            bool parallel_record_profile = false;
+            uint parallel_record_min_work_units_per_job = 64;
+            uint max_frame_lag           = 0;
         } threading;
 
         struct RHI {
@@ -53,6 +58,7 @@ struct CORE_API GlobalConfig {
                 bool low_quality_mode;
                 bool render_graph;
                 bool render_graph_debug_dump;
+                bool render_graph_parallel_recording;
             } raster;
 
         } render;

--- a/source/runtime/core/include/taskgraph/TaskGraph.h
+++ b/source/runtime/core/include/taskgraph/TaskGraph.h
@@ -14,6 +14,7 @@ private:
 
 public:
     CORE_API static TaskGraph& GetInterface();
+    CORE_API static bool       IsInitialized() noexcept;
     static void                Init();
     static void                Shutdown();
     TaskGraph();

--- a/source/runtime/core/source/config/GlobalConfig.cpp
+++ b/source/runtime/core/source/config/GlobalConfig.cpp
@@ -38,6 +38,17 @@ GlobalConfig GlobalConfig::LoadConfigFromTomlFile(const std::string_view& toml_p
         toml_config.at_path("engine.threading.rhi_bypass").value_or(true);
     loaded_config.engine.threading.profile_logging =
         toml_config.at_path("engine.threading.profile_logging").value_or(false);
+    loaded_config.engine.threading.parallel_recording =
+        toml_config.at_path("engine.threading.parallel_recording").value_or(false);
+    loaded_config.engine.threading.parallel_record_workers =
+        toml_config.at_path("engine.threading.parallel_record_workers").value_or(uint{0});
+    loaded_config.engine.threading.parallel_record_verify =
+        toml_config.at_path("engine.threading.parallel_record_verify").value_or(false);
+    loaded_config.engine.threading.parallel_record_profile =
+        toml_config.at_path("engine.threading.parallel_record_profile").value_or(false);
+    loaded_config.engine.threading.parallel_record_min_work_units_per_job =
+        toml_config.at_path("engine.threading.parallel_record_min_work_units_per_job")
+            .value_or(uint{64});
     loaded_config.engine.threading.max_frame_lag =
         toml_config.at_path("engine.threading.max_frame_lag").value_or(uint{0});
 
@@ -57,6 +68,8 @@ GlobalConfig GlobalConfig::LoadConfigFromTomlFile(const std::string_view& toml_p
         toml_config.at_path("engine.render.raster.render_graph").value_or(false);
     loaded_config.engine.render.raster.render_graph_debug_dump =
         toml_config.at_path("engine.render.raster.render_graph_debug_dump").value_or(false);
+    loaded_config.engine.render.raster.render_graph_parallel_recording =
+        toml_config.at_path("engine.render.raster.render_graph_parallel_recording").value_or(false);
 
     loaded_config.engine.scene.scene_path =
         toml_config.at_path("engine.scene.scene_path").value_or("./asset/scenes/sponza/Sponza.gltf");

--- a/source/runtime/core/source/taskgraph/TaskGraph.cpp
+++ b/source/runtime/core/source/taskgraph/TaskGraph.cpp
@@ -11,6 +11,10 @@ TaskGraph& TaskGraph::GetInterface() {
     return *instance;
 }
 
+bool TaskGraph::IsInitialized() noexcept {
+    return instance != nullptr;
+}
+
 void TaskGraph::Init() {
     if (instance == nullptr) {
         instance = MoerNew(TaskGraph)();

--- a/source/runtime/render/renderer/Renderer.cpp
+++ b/source/runtime/render/renderer/Renderer.cpp
@@ -7,6 +7,7 @@
 #include "misc/Timer.h"
 #include "renderer/EditorConfig.h"
 #include "rhi/RHI.h"
+#include "rhi/RHIExecutor.h"
 #include "scene/Scene.h"
 #include "shader/ShaderResourceManager.h"
 #include "window/WindowContext.h"
@@ -134,14 +135,18 @@ void Renderer::ReleaseResources() {
     resources_released = true;
 
     timeline->Wait(time);
-    gfx_queue.Sync();
+    RHIExecutor::Get().Sync(ERHISyncDepth::Present);
     swapchain->Sync();
     device.WaitIdle();
 
     render_scene.reset();
     cmd_list.UpdateBindlessArray(bindless_array);
-    gfx_queue.Execute(cmd_list.Submit().DeleteResources());
-    gfx_queue.Sync();
+    RHIExecutor::Get().Submit(
+        EQueueType::Graphics,
+        cmd_list.Submit().DeleteResources(),
+        ERHIExecSubmitFlags::FlushGPU
+    );
+    RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
 
     scene.Reset();
 }
@@ -186,7 +191,7 @@ void Renderer::PrepareRenderFrame(const WindowFrameState& window_frame) {
         return;
     }
 
-    gfx_queue.Sync();
+    RHIExecutor::Get().Sync(ERHISyncDepth::Present);
     swapchain_create_info.size = {resolution.x, resolution.y};
     swapchain->Sync();
     swapchain->Recreate(swapchain_create_info);

--- a/source/runtime/render/renderer/common/RuntimeAssets.cpp
+++ b/source/runtime/render/renderer/common/RuntimeAssets.cpp
@@ -5,6 +5,7 @@
 #include "misc/ScopedLogTimer.h"
 #include "rhi/RHI.h"
 #include "rhi/RHICommand.h"
+#include "rhi/RHIExecutor.h"
 #include "rhi/RHIResource.h"
 #include "taskgraph/GraphTask.h"
 #include "taskgraph/TaskGraph.h"
@@ -61,7 +62,7 @@ void RuntimeAssets::LoadTextures() {
             textures[name] = std::move(texture);
         };
 
-        CommandList cmd_list;
+        CommandList cmd_list(EQueueType::Copy);
         if (std::filesystem::exists(texture_path)) {
             for (const auto& entry : std::filesystem::directory_iterator(texture_path)) {
                 if (entry.path().extension() == ".png") {
@@ -125,15 +126,17 @@ void RuntimeAssets::LoadTextures() {
         }
         cmd_list.ExportResourcesToQueue(EQueueType::Graphics, std::move(exported_textures), {});
 
-        auto sync_time = device.GetCopyQueue().Execute(cmd_list.Submit());
-        device.GetCopyQueue().Sync(sync_time.timeline);
+        RHIExecutor::Get().Submit(
+            EQueueType::Copy,
+            cmd_list.Submit(),
+            ERHIExecSubmitFlags::FlushGPU
+        );
+        RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
     }
 }
 
 void RuntimeAssets::CompleteAndImportResources() {
     using namespace Render;
-    auto& graphics_queue = device.GetCommandQueue(EQueueType::Graphics);
-
     Array<ImportTexture> import_textures;
     import_textures.reserve(textures.size());
     for (const auto& texture_entry : textures) {
@@ -149,8 +152,12 @@ void RuntimeAssets::CompleteAndImportResources() {
     CopyQueue& copy_queue = device.GetCopyQueue();
 
     const auto copy_queue_timeline = copy_queue.GetFenceHandle();
-    graphics_queue.Execute(cmd_list.Submit().Wait(copy_queue_timeline, copy_queue_timeline->GetValue()));
-    graphics_queue.Sync();
+    RHIExecutor::Get().Submit(
+        EQueueType::Graphics,
+        cmd_list.Submit().Wait(copy_queue_timeline, copy_queue_timeline->GetValue()),
+        ERHIExecSubmitFlags::FlushGPU
+    );
+    RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
     is_loaded.store(true, std::memory_order_seq_cst);
 }
 

--- a/source/runtime/render/renderer/common/ui/DearImGuiRenderer.cpp
+++ b/source/runtime/render/renderer/common/ui/DearImGuiRenderer.cpp
@@ -13,6 +13,7 @@
 #include "misc/MMemory.h"
 #include "rhi/RHI.h"
 #include "rhi/RHICommand.h"
+#include "rhi/RHIExecutor.h"
 
 #include "rhi/RHICommon.h"
 #include "rhi/RHIResource.h"
@@ -278,9 +279,12 @@ static uint UploadFontAtlasAndCreatePipelines(
             CommandList cmd_list;
             cmd_list.CopyFrom(std::move(font_pixels), font_texture);
 
-            auto& graphics_queue = device.GetCommandQueue(EQueueType::Graphics);
-            graphics_queue.Execute(std::move(cmd_list.Submit()));
-            graphics_queue.Sync();
+            RHIExecutor::Get().Submit(
+                EQueueType::Graphics,
+                std::move(cmd_list.Submit()),
+                ERHIExecSubmitFlags::FlushGPU
+            );
+            RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
 
             _backend_data->font_texture = font_texture;
             font_texture_handle =
@@ -559,7 +563,6 @@ void ImGuiRenderBackend::PresentWindows(
         (_execution_thread == EUiDrawExecutionThread::Game && IsCurrentlyGameThread()) ||
         (_execution_thread == EUiDrawExecutionThread::Render && IsCurrentlyRenderThread())
     );
-    auto& graphics_queue = device.GetCommandQueue(EQueueType::Graphics);
     for (const auto& viewport : _frame.platform_viewports) {
         if (viewport.swapchain && viewport.framebuffer) {
             const auto framebuffer_view = viewport.framebuffer->GetView();
@@ -574,7 +577,9 @@ void ImGuiRenderBackend::PresentWindows(
                 );
                 continue;
             }
-            graphics_queue.Present(viewport.swapchain, viewport.framebuffer);
+            RHIExecutor::Get().Present(
+                RHIPresentRequest(viewport.swapchain, framebuffer_view), true
+            );
         }
     }
 }
@@ -811,9 +816,8 @@ void CreateOrResizeViewportResources(
         return;
     }
 
-    auto& graphics_queue = _device.GetCommandQueue(EQueueType::Graphics);
     if (has_swapchain || _resources->framebuffer) {
-        graphics_queue.Sync();
+        RHIExecutor::Get().Sync(ERHISyncDepth::Present);
     }
 
     Moer::WindowHandle handle{static_cast<Moer::WindowType*>(_platform_window)};
@@ -858,7 +862,7 @@ void ReleaseViewportResources(
     }
     assert(!IsRenderThreadRunning() || IsCurrentlyRenderThread());
 
-    _device.GetCommandQueue(EQueueType::Graphics).Sync();
+    RHIExecutor::Get().Sync(ERHISyncDepth::Present);
     if (_resources->swapchain) {
         _resources->swapchain->Sync();
     }
@@ -1029,6 +1033,11 @@ void GuiSwapBuffers(ImGuiViewport* _viewport, void*) {
     if (!viewport_data || !viewport_data->render_resources) {
         return;
     }
-    backend_data.render_backend->device.GetCommandQueue(Moer::Render::EQueueType::Graphics)
-        .Present(viewport_data->render_resources->swapchain, viewport_data->render_resources->framebuffer);
+    RHIExecutor::Get().Present(
+        RHIPresentRequest(
+            viewport_data->render_resources->swapchain,
+            viewport_data->render_resources->framebuffer->GetView()
+        ),
+        true
+    );
 }

--- a/source/runtime/render/renderer/raster/CudaVulkanTools.h
+++ b/source/runtime/render/renderer/raster/CudaVulkanTools.h
@@ -13,6 +13,7 @@
 #include "misc/STL.h"
 #include "misc/Traits.h"
 #include "platform/Platform.h"
+#include "rhi/RHIExecutor.h"
 #include "rhi/vulkan/VulkanDevice.h"
 #include "rhi/vulkan/VulkanQueue.h"
 #include <cuda_runtime.h>
@@ -448,8 +449,12 @@ struct CudaSemaphore {
         vk_native_queue(CudaVulkanTools::getVulkanQueue(context.gfx_queue).GetVkNativeQueue()) {
 
         pfn_sync_vk = [&]() {
-            context.gfx_queue.Execute(context.cmd_list.Submit());
-            context.gfx_queue.Sync();
+            RHIExecutor::Get().Submit(
+                EQueueType::Graphics,
+                context.cmd_list.Submit(),
+                ERHIExecSubmitFlags::FlushGPU
+            );
+            RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
         };
 
         LoadVulkanWin32PFN();

--- a/source/runtime/render/renderer/raster/DirectionalShadowMaskPass.cpp
+++ b/source/runtime/render/renderer/raster/DirectionalShadowMaskPass.cpp
@@ -17,18 +17,46 @@ DirectionalShadowMaskPass::DirectionalShadowMaskPass(RasterContext& context) {
                    .Build<DirectionalShadowMaskPassPipeline>(std::move(pso_full_screen_info));
 }
 
-void DirectionalShadowMaskPass::Process(RasterContext& context) {
-    DirectionalShadowMaskPassBindlessParam param;
-    param.normal_hdl = context.textures.normal.hdl;
-    param.depth_hdl  = context.textures.depth_nearest_sampler.hdl;
+DirectionalShadowMaskPass::RecordParameters
+DirectionalShadowMaskPass::Prepare(const RasterContext& context) const {
+    RecordParameters parameters{
+        .normal_handle = context.textures.normal.hdl,
+        .depth_handle  = context.textures.depth_nearest_sampler.hdl,
+        .normal_owner  = context.textures.normal.tex,
+        .depth_owner   = context.textures.depth_nearest_sampler.tex,
+        .lighting_data = context.lighting_data_buffer.buf,
+        .bindless      = context.bdls,
+        .output        = context.textures.shadow_mask.tex,
+        .render_area   = context.textures.shadow_mask.GetRect2D(),
+    };
+    for (size_t index = 0; index < parameters.cascade_shadow_owners.size(); ++index) {
+        parameters.cascade_shadow_owners[index] = context.csm_data.shadow_map_textures[index].tex;
+    }
+    for (size_t index = 0; index < parameters.point_shadow_owners.size(); ++index) {
+        parameters.point_shadow_owners[index] = context.point_shadow_data.shadow_cubes[index].tex;
+    }
+    return parameters;
+}
 
-    context.cmd_list
-        .Gfx(pipeline, context.lighting_data_buffer.buf, context.bdls, param)
+void DirectionalShadowMaskPass::Record(
+    CommandList&            cmd_list,
+    const RecordParameters& parameters
+) {
+    DirectionalShadowMaskPassBindlessParam param;
+    param.normal_hdl = parameters.normal_handle;
+    param.depth_hdl  = parameters.depth_handle;
+
+    cmd_list
+        .Gfx(pipeline, parameters.lighting_data, parameters.bindless, param)
         .Draw(
             "Directional Shadow Mask Pass",
-            context.textures.shadow_mask.GetRect2D(),
+            parameters.render_area,
             std::move(RasterTool::GetFullScreenDrawDatas()),
-            ColorAttachment(context.textures.shadow_mask.tex)
+            ColorAttachment(parameters.output)
         );
+}
+
+void DirectionalShadowMaskPass::Process(RasterContext& context) {
+    Record(context.cmd_list, Prepare(context));
 }
 } // namespace Moer::Render::Raster

--- a/source/runtime/render/renderer/raster/DirectionalShadowMaskPass.h
+++ b/source/runtime/render/renderer/raster/DirectionalShadowMaskPass.h
@@ -19,8 +19,24 @@ public:
 
 class DirectionalShadowMaskPass {
 public:
+    struct RecordParameters {
+        uint             normal_handle{0};
+        uint             depth_handle{0};
+        TextureRef       normal_owner{};
+        DepthBufferRef   depth_owner{};
+        StaticArray<DepthBufferRef, CSM_MAX_CASCADES> cascade_shadow_owners{};
+        StaticArray<TextureRef, RasterContext::PointShadowData::MAX_POINT_SHADOWS>
+            point_shadow_owners{};
+        BufferRef        lighting_data{};
+        BindlessArrayRef bindless{};
+        TextureRef       output{};
+        Rect2D           render_area{};
+    };
+
     DirectionalShadowMaskPass(RasterContext& context);
 
+    [[nodiscard]] RecordParameters Prepare(const RasterContext& context) const;
+    void Record(CommandList& cmd_list, const RecordParameters& parameters);
     void Process(RasterContext& context);
 
 private:

--- a/source/runtime/render/renderer/raster/HiZBuildPass.h
+++ b/source/runtime/render/renderer/raster/HiZBuildPass.h
@@ -21,19 +21,73 @@ public:
 
 class HiZBuildPass {
 public:
+    struct MipDispatch {
+        TextureView source{};
+        TextureView destination{};
+        uint2       source_size{};
+        uint2       destination_size{};
+        bool        is_mip0{false};
+    };
+
+    /**
+     * Immutable, strongly-owned recording input.  RenderGraph workers must not
+     * read RasterContext::textures while CommitHiZHistory may swap the current
+     * and previous images on the render thread.
+     */
+    struct RecordParameters {
+        DepthBufferRef     source_owner{};
+        TextureRef         destination_owner{};
+        Array<MipDispatch> dispatches{};
+
+        [[nodiscard]] bool IsEmpty() const noexcept {
+            return dispatches.empty();
+        }
+    };
+
     HiZBuildPass(RasterContext& context) {
         pipeline = context.manager.Compute<HiZBuildPipeline>(
             "pipelines/raster/culling/HiZBuild.comp.hlsl"
         );
     }
 
-    void Process(RasterContext& context) {
+    [[nodiscard]] RecordParameters Prepare(const RasterContext& context) const {
+        RecordParameters parameters{};
         if (context.textures.hiz_current.tex == nullptr) {
-            return;
+            return parameters;
         }
 
         const uint mip_count = context.textures.hiz_current.tex->GetNumMips();
         if (mip_count == 0) {
+            return parameters;
+        }
+
+        parameters.source_owner      = context.textures.depth_nearest_sampler.tex;
+        parameters.destination_owner = context.textures.hiz_current.tex;
+        parameters.dispatches.reserve(mip_count);
+
+        const uint2 mip0_size = context.textures.hiz_current.GetSize(0);
+        parameters.dispatches.emplace_back(MipDispatch{
+            .source           = parameters.source_owner->GetView(),
+            .destination      = parameters.destination_owner->GetView(0, 1),
+            .source_size      = mip0_size,
+            .destination_size = mip0_size,
+            .is_mip0          = true,
+        });
+
+        for (uint mip = 1; mip < mip_count; ++mip) {
+            parameters.dispatches.emplace_back(MipDispatch{
+                .source = parameters.destination_owner->GetView(static_cast<uint8>(mip - 1), 1),
+                .destination = parameters.destination_owner->GetView(static_cast<uint8>(mip), 1),
+                .source_size = context.textures.hiz_current.GetSize(mip - 1),
+                .destination_size = context.textures.hiz_current.GetSize(mip),
+                .is_mip0 = false,
+            });
+        }
+        return parameters;
+    }
+
+    void Record(CommandList& cmd_list, const RecordParameters& parameters) {
+        if (parameters.IsEmpty()) {
             return;
         }
 
@@ -48,35 +102,28 @@ public:
             param.dst_size = destination_size;
             param.is_mip0  = is_mip0 ? 1u : 0u;
 
-            context.cmd_list.Compute(pipeline, param, source_view, destination_view)
+            cmd_list.Compute(pipeline, param, source_view, destination_view)
                 .Dispatch(
                     uint3((destination_size.x + 7) / 8, (destination_size.y + 7) / 8, 1),
                     "Build Hi-Z"
                 );
         };
 
-        context.cmd_list.PushScopeWithTimeScope("Build Hi-Z");
-
-        {
-            const TextureView source_view      = context.textures.depth_nearest_sampler.tex->GetView();
-            const TextureView destination_view = context.textures.hiz_current.tex->GetView(0, 1);
-            const uint2       mip0_size        = context.textures.hiz_current.GetSize(0);
-
-            dispatch_build(source_view, destination_view, mip0_size, mip0_size, true);
+        cmd_list.PushScopeWithTimeScope("Build Hi-Z");
+        for (const MipDispatch& dispatch : parameters.dispatches) {
+            dispatch_build(
+                dispatch.source,
+                dispatch.destination,
+                dispatch.source_size,
+                dispatch.destination_size,
+                dispatch.is_mip0
+            );
         }
+        cmd_list.PopScopeWithTimeScope();
+    }
 
-        for (uint mip = 1; mip < mip_count; ++mip) {
-            const TextureView source_view =
-                context.textures.hiz_current.tex->GetView(static_cast<uint8>(mip - 1), 1);
-            const TextureView destination_view =
-                context.textures.hiz_current.tex->GetView(static_cast<uint8>(mip), 1);
-            const uint2 source_size      = context.textures.hiz_current.GetSize(mip - 1);
-            const uint2 destination_size = context.textures.hiz_current.GetSize(mip);
-
-            dispatch_build(source_view, destination_view, source_size, destination_size, false);
-        }
-
-        context.cmd_list.PopScopeWithTimeScope();
+    void Process(RasterContext& context) {
+        Record(context.cmd_list, Prepare(context));
     }
 
 private:

--- a/source/runtime/render/renderer/raster/LightingPass.h
+++ b/source/runtime/render/renderer/raster/LightingPass.h
@@ -21,6 +21,26 @@ public:
 
 class LightingPass {
 public:
+    /**
+     * Immutable recording input captured on the render thread. Bindless handles
+     * alone do not own their resources, so every referenced buffer/texture is
+     * retained until the recorded source reaches a terminal submit callback.
+     */
+    struct RecordParameters {
+        MaterialPassBindlessParam pass_param{};
+        BufferRef                 lighting_data{};
+        BufferRef                 light_buffer_owner{};
+        BindlessArrayRef          bindless{};
+        TextureRef                base_color_owner{};
+        TextureRef                normal_owner{};
+        TextureRef                metal_rough_ao_owner{};
+        DepthBufferRef            depth_owner{};
+        TextureRef                cubemap_owner{};
+        TextureRef                shadow_mask_owner{};
+        TextureRef                output{};
+        Rect2D                    render_area{};
+    };
+
     LightingPass(RasterContext& context) {
         GfxPsoCreateInfo pipeline_info(
             RHIRasterizeInfo::Preset(),
@@ -34,8 +54,10 @@ public:
                        .Build<PbrMaterialShadingPipeline>(std::move(pipeline_info));
     }
 
-    void Process(RasterContext& context, const RasterConfig& ui_config) {
-        MaterialPassBindlessParam pass_param{};
+    [[nodiscard]] RecordParameters
+    Prepare(const RasterContext& context, const RasterConfig& ui_config) const {
+        RecordParameters parameters{};
+        auto&            pass_param = parameters.pass_param;
         pass_param.extra_ambient_color     = ui_config.shading_extra_ambient_color;
         pass_param.extra_ambient_intensity = ui_config.shading_extra_ambient_intensity;
         pass_param.enable_extra_ambient    = ui_config.shading_enable_extra_ambient;
@@ -46,17 +68,43 @@ public:
         pass_param.gbuffer_metal_rough_ao = context.textures.metal_rough_ao.hdl;
         pass_param.gbuffer_depth          = context.textures.depth_nearest_sampler.hdl;
 
-        pass_param.light_buf_hdl      = context.GetGpuSceneRes().light_buf.hdl;
+        const auto& gpu_scene_res     = context.GetGpuSceneRes();
+        pass_param.light_buf_hdl      = gpu_scene_res.light_buf.hdl;
         pass_param.cubemap_handle     = context.textures.cubemap_tex.hdl;
         pass_param.shadow_mask_handle = context.textures.shadow_mask.hdl;
 
-        context.cmd_list.Gfx(pipeline, context.lighting_data_buffer.buf, context.bdls, pass_param)
+        parameters.lighting_data        = context.lighting_data_buffer.buf;
+        parameters.light_buffer_owner   = gpu_scene_res.light_buf.buf;
+        parameters.bindless             = context.bdls;
+        parameters.base_color_owner     = context.textures.base_color.tex;
+        parameters.normal_owner         = context.textures.normal.tex;
+        parameters.metal_rough_ao_owner = context.textures.metal_rough_ao.tex;
+        parameters.depth_owner          = context.textures.depth_nearest_sampler.tex;
+        parameters.cubemap_owner        = context.textures.cubemap_tex.tex;
+        parameters.shadow_mask_owner    = context.textures.shadow_mask.tex;
+        parameters.output               = context.textures.lighting_output.tex;
+        parameters.render_area          = context.textures.lighting_output.GetRect2D();
+        return parameters;
+    }
+
+    void Record(CommandList& cmd_list, const RecordParameters& parameters) {
+        cmd_list
+            .Gfx(
+                pipeline,
+                parameters.lighting_data,
+                parameters.bindless,
+                parameters.pass_param
+            )
             .Draw(
                 "Lighting Pass",
-                context.textures.lighting_output.GetRect2D(),
+                parameters.render_area,
                 std::move(RasterTool::GetFullScreenDrawDatas()),
-                ColorAttachment(context.textures.lighting_output.tex)
+                ColorAttachment(parameters.output)
             );
+    }
+
+    void Process(RasterContext& context, const RasterConfig& ui_config) {
+        Record(context.cmd_list, Prepare(context, ui_config));
     }
 
 private:

--- a/source/runtime/render/renderer/raster/RasterRenderer.cpp
+++ b/source/runtime/render/renderer/raster/RasterRenderer.cpp
@@ -27,6 +27,7 @@
 #include "debug/RenderDocApi.h"
 #include "misc/ScopedLogTimer.h"
 #include "rendergraph/RenderGraph.h"
+#include "rhi/RHIExecutor.h"
 #include "scene/testcase/SceneTestCaseDispatcher.h"
 #include "scene/testcase/SceneTestCaseRunner.h"
 #include "window/WindowContext.h"
@@ -61,13 +62,15 @@ RasterRenderer::RasterRenderer(
     Renderer(initial_resolution, config) {
     ScopedLogTimer startup_timer("[Startup][RasterRenderer] RasterRenderer::Constructor() total");
 
-    const auto& graph_config =
-        ConfigManager::GetInstance().GetConfig().engine.render.raster;
+    const auto& engine_config = ConfigManager::GetInstance().GetConfig().engine;
+    const auto& graph_config  = engine_config.render.raster;
     render_graph_enabled    = graph_config.render_graph;
     render_graph_debug_dump = graph_config.render_graph_debug_dump;
+    parallel_recording_enabled = graph_config.render_graph_parallel_recording;
     LOG_INFO(
-        "[RenderGraph] Raster execution mode: {}",
-        render_graph_enabled ? "graph" : "linear"
+        "[RenderGraph] Raster execution mode: {}, upper recording: {}",
+        render_graph_enabled ? "graph" : "linear",
+        parallel_recording_enabled ? "parallel-eligible" : "serial-fallback"
     );
     if (!config->validation_selected_frame_buffer_name.empty()) {
         LOG_INFO(
@@ -85,8 +88,10 @@ RasterRenderer::RasterRenderer(
     raster_context.UploadExternalFrameBuffers();
     raster_context.AllocateFrameBuffers();
 
-    gfx_queue.Execute(cmd_list.Submit());
-    gfx_queue.Sync();
+    RHIExecutor::Get().Submit(
+        EQueueType::Graphics, cmd_list.Submit(), ERHIExecSubmitFlags::FlushGPU
+    );
+    RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
 
     hiz_build_pass               = MakeUnique<HiZBuildPass>(raster_context);
     shadow_depth_pass            = MakeUnique<ShadowDepthPass>(raster_context);
@@ -124,8 +129,10 @@ RasterRenderer::RasterRenderer(
 #endif
 
     cmd_list.UpdateBindlessArray(bindless_array);
-    gfx_queue.Execute(cmd_list.Submit());
-    gfx_queue.Sync();
+    RHIExecutor::Get().Submit(
+        EQueueType::Graphics, cmd_list.Submit(), ERHIExecSubmitFlags::FlushGPU
+    );
+    RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
 
     LOG_INFO(
         "Cooperative Matrix & Vector Extensions is Enabled: {}",
@@ -457,6 +464,7 @@ RasterFrameFeedback RasterRenderer::RenderFrame(RasterFramePacket frame_packet) 
     }
 
     bool              skip_present = false;
+    bool              split_graph_profiling_frame = false;
     PresentReceiptRef main_present_receipt{};
     if (frame_packet.window.state == EWindowState::Hiding) {
         // 窗口最小化后无法 present，此处主动让出线程，避免高频空转。
@@ -506,8 +514,10 @@ RasterFrameFeedback RasterRenderer::RenderFrame(RasterFramePacket frame_packet) 
 
             // 第一个 Raster Pass 执行前，先发布首次场景上传创建的 descriptor。
             cmd_list.UpdateBindlessArray(bindless_array);
-            gfx_queue.Execute(cmd_list.Submit());
-            gfx_queue.Sync();
+            RHIExecutor::Get().Submit(
+                EQueueType::Graphics, cmd_list.Submit(), ERHIExecSubmitFlags::FlushGPU
+            );
+            RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
         }
 
         auto& raster_config = frame_packet.raster_config;
@@ -594,6 +604,15 @@ RasterFrameFeedback RasterRenderer::RenderFrame(RasterFramePacket frame_packet) 
             frame_packet.ui_composition.enabled && frame_packet.ui_composition.separate_window &&
             window_framebuffer_view.GetTexture() != nullptr;
 
+        struct RasterParallelRecordSnapshots {
+            HiZBuildPass::RecordParameters               hiz{};
+            DirectionalShadowMaskPass::RecordParameters directional_shadow{};
+            LightingPass::RecordParameters               lighting{};
+            SkyboxPass::RecordParameters                 skybox{};
+            bool                                         prepared{false};
+        };
+        auto parallel_record_snapshots = MakeShared<RasterParallelRecordSnapshots>();
+
         struct RasterGraphResources {
             RenderGraph::TokenHandle   scene;
             RenderGraph::TokenHandle   shadow_maps;
@@ -603,6 +622,7 @@ RasterFrameFeedback RasterRenderer::RenderFrame(RasterFramePacket frame_packet) 
             RenderGraph::TextureHandle normal;
             RenderGraph::TextureHandle metal_rough_ao;
             RenderGraph::TextureHandle depth;
+            RenderGraph::TextureHandle cubemap;
             RenderGraph::TextureHandle hiz_current;
             RenderGraph::TextureHandle hiz_previous;
             RenderGraph::TextureHandle shadow_mask;
@@ -620,10 +640,62 @@ RasterFrameFeedback RasterRenderer::RenderFrame(RasterFramePacket frame_packet) 
             RenderGraph::TextureHandle ui_framebuffer;
             RenderGraph::TextureHandle window_framebuffer;
             RenderGraph::TextureHandle output;
+            RenderGraph::BufferHandle  scene_lights;
             RenderGraph::TokenHandle   processing_image;
+            RenderGraph::TokenHandle   parallel_record_snapshots;
+            RenderGraph::TokenHandle   hiz_recorded;
         } graph_resources{};
 
-        auto define_raster_passes = [&](auto&& schedule) {
+        auto define_raster_passes = [&](auto&& dispatch) {
+            auto schedule = [&](std::string_view name, auto&& setup, auto&& execute) {
+                dispatch(
+                    name,
+                    std::forward<decltype(setup)>(setup),
+                    RenderGraph::PassExecutionClass::MainThread,
+                    [execute = std::forward<decltype(execute)>(execute)](CommandList&) mutable {
+                        execute();
+                    }
+                );
+            };
+            auto schedule_external = [&](std::string_view name, auto&& setup, auto&& execute) {
+                dispatch(
+                    name,
+                    [setup = std::forward<decltype(setup)>(setup)](
+                        RenderGraph::PassBuilder& builder
+                    ) mutable {
+                        setup(builder);
+                        builder.ExternalControl();
+                    },
+                    RenderGraph::PassExecutionClass::ExternalControl,
+                    [execute = std::forward<decltype(execute)>(execute)](CommandList&) mutable {
+                        execute();
+                    }
+                );
+            };
+            auto schedule_cpu_prepare = [&](std::string_view name, auto&& setup, auto&& execute) {
+                dispatch(
+                    name,
+                    [setup = std::forward<decltype(setup)>(setup)](
+                        RenderGraph::PassBuilder& builder
+                    ) mutable {
+                        setup(builder);
+                        builder.CpuPrepare();
+                    },
+                    RenderGraph::PassExecutionClass::CpuPrepare,
+                    [execute = std::forward<decltype(execute)>(execute)](CommandList&) mutable {
+                        execute();
+                    }
+                );
+            };
+            auto schedule_parallel_record =
+                [&](std::string_view name, auto&& setup, auto&& record) {
+                    dispatch(
+                        name,
+                        std::forward<decltype(setup)>(setup),
+                        RenderGraph::PassExecutionClass::ParallelRecordEligible,
+                        std::forward<decltype(record)>(record)
+                    );
+                };
             schedule(
                 "ShadowDepth",
                 [&](RenderGraph::PassBuilder& builder) {
@@ -684,37 +756,78 @@ RasterFrameFeedback RasterRenderer::RenderFrame(RasterFramePacket frame_packet) 
                     tessellated_surface_pass->Process(raster_context, raster_config, camera);
                 }
             );
-            schedule(
+            schedule_cpu_prepare(
+                "PrepareParallelRecording",
+                [&](RenderGraph::PassBuilder& builder) {
+                    builder.Reference(graph_resources.depth)
+                        .Reference(graph_resources.normal)
+                        .Reference(graph_resources.base_color)
+                        .Reference(graph_resources.metal_rough_ao)
+                        .Reference(graph_resources.cubemap)
+                        .Reference(graph_resources.hiz_current)
+                        .Reference(graph_resources.shadow_mask)
+                        .Reference(graph_resources.lighting_output)
+                        .Reference(graph_resources.lighting_data)
+                        .Reference(graph_resources.shadow_maps)
+                        .Read(graph_resources.scene)
+                        .Write(graph_resources.parallel_record_snapshots)
+                        .SideEffect();
+                    if (graph_resources.scene_lights.IsValid()) {
+                        builder.Reference(graph_resources.scene_lights);
+                    }
+                },
+                [&, parallel_record_snapshots]() {
+                    parallel_record_snapshots->hiz = hiz_build_pass->Prepare(raster_context);
+                    parallel_record_snapshots->directional_shadow =
+                        directional_shadow_mask_pass->Prepare(raster_context);
+                    parallel_record_snapshots->lighting =
+                        lighting_pass->Prepare(raster_context, raster_config);
+                    parallel_record_snapshots->skybox =
+                        skybox_pass->Prepare(raster_context, raster_config, camera);
+                    parallel_record_snapshots->prepared = true;
+                }
+            );
+            schedule_parallel_record(
                 "HiZBuild",
                 [&](RenderGraph::PassBuilder& builder) {
                     builder.Read(graph_resources.depth)
-                        .Write(graph_resources.hiz_current);
+                        .Read(graph_resources.parallel_record_snapshots)
+                        .Write(graph_resources.hiz_current)
+                        .Write(graph_resources.hiz_recorded);
                 },
-                [&]() { hiz_build_pass->Process(raster_context); }
+                [&, parallel_record_snapshots](CommandList& recording_cmd_list) {
+                    assert(parallel_record_snapshots->prepared);
+                    hiz_build_pass->Record(recording_cmd_list, parallel_record_snapshots->hiz);
+                }
             );
-            schedule(
-                "CommitHiZHistory",
-                [&](RenderGraph::PassBuilder& builder) {
-                    builder.Read(graph_resources.hiz_current)
-                        .Write(graph_resources.hiz_previous)
-                        .SideEffect();
-                },
-                [&]() { raster_context.CommitHiZHistory(camera.GetViewProjectionMatrix()); }
-            );
-            schedule(
+            schedule_parallel_record(
                 "DirectionalShadowMask",
                 [&](RenderGraph::PassBuilder& builder) {
                     builder.Read(graph_resources.normal)
                         .Read(graph_resources.depth)
                         .Read(graph_resources.lighting_data)
                         .Read(graph_resources.shadow_maps)
+                        .Read(graph_resources.parallel_record_snapshots)
                         .Write(graph_resources.shadow_mask);
                 },
-                [&]() {
-                    directional_shadow_mask_pass->Process(raster_context);
+                [&, parallel_record_snapshots](CommandList& recording_cmd_list) {
+                    assert(parallel_record_snapshots->prepared);
+                    directional_shadow_mask_pass->Record(
+                        recording_cmd_list, parallel_record_snapshots->directional_shadow
+                    );
                 }
             );
-            schedule(
+            schedule_cpu_prepare(
+                "CommitHiZHistory",
+                [&](RenderGraph::PassBuilder& builder) {
+                    builder.Reference(graph_resources.hiz_current)
+                        .Reference(graph_resources.hiz_previous)
+                        .Read(graph_resources.hiz_recorded)
+                        .SideEffect();
+                },
+                [&]() { raster_context.CommitHiZHistory(camera.GetViewProjectionMatrix()); }
+            );
+            schedule_parallel_record(
                 "Lighting",
                 [&](RenderGraph::PassBuilder& builder) {
                     builder.Read(graph_resources.base_color)
@@ -723,18 +836,33 @@ RasterFrameFeedback RasterRenderer::RenderFrame(RasterFramePacket frame_packet) 
                         .Read(graph_resources.depth)
                         .Read(graph_resources.shadow_mask)
                         .Read(graph_resources.lighting_data)
+                        .Read(graph_resources.cubemap)
                         .Read(graph_resources.probe_volume)
+                        .Read(graph_resources.parallel_record_snapshots)
                         .Write(graph_resources.lighting_output);
+                    if (graph_resources.scene_lights.IsValid()) {
+                        builder.Read(graph_resources.scene_lights);
+                    }
                 },
-                [&]() { lighting_pass->Process(raster_context, raster_config); }
+                [&, parallel_record_snapshots](CommandList& recording_cmd_list) {
+                    assert(parallel_record_snapshots->prepared);
+                    lighting_pass->Record(
+                        recording_cmd_list, parallel_record_snapshots->lighting
+                    );
+                }
             );
-            schedule(
+            schedule_parallel_record(
                 "Skybox",
                 [&](RenderGraph::PassBuilder& builder) {
                     builder.Read(graph_resources.depth)
+                        .Read(graph_resources.cubemap)
+                        .Read(graph_resources.parallel_record_snapshots)
                         .ReadWrite(graph_resources.lighting_output);
                 },
-                [&]() { skybox_pass->Process(raster_context, raster_config, camera); }
+                [&, parallel_record_snapshots](CommandList& recording_cmd_list) {
+                    assert(parallel_record_snapshots->prepared);
+                    skybox_pass->Record(recording_cmd_list, parallel_record_snapshots->skybox);
+                }
             );
 
             if (draw_scene_gizmos && scene_gizmos.show_probe_gi) {
@@ -802,7 +930,7 @@ RasterFrameFeedback RasterRenderer::RenderFrame(RasterFramePacket frame_packet) 
 
 #if WITH_CUDA
             if (raster_config.ai_is_cuda_enabled) {
-                schedule(
+                schedule_external(
                     "TensorRT",
                     [&](RenderGraph::PassBuilder& builder) {
                         builder.Read(graph_resources.ao_working_set)
@@ -847,7 +975,7 @@ RasterFrameFeedback RasterRenderer::RenderFrame(RasterFramePacket frame_packet) 
                         ssr_pass->Process(raster_context, raster_config, camera, processing_image);
                 }
             );
-            schedule(
+            schedule_cpu_prepare(
                 "CooperativeOps",
                 [&](RenderGraph::PassBuilder& builder) {
                     builder.ReadWrite(graph_resources.processing_image).SideEffect();
@@ -977,12 +1105,21 @@ RasterFrameFeedback RasterRenderer::RenderFrame(RasterFramePacket frame_packet) 
             ScopedGpuMarker pipeline_marker(
                 cmd_list, "Raster Linear Pipeline", GpuMarkerPalette::RenderGraph()
             );
-            auto linear_schedule = [&](std::string_view name, auto&&, auto&& execute) {
+            auto linear_schedule =
+                [&](std::string_view                name,
+                    auto&&,
+                    RenderGraph::PassExecutionClass execution_class,
+                    auto&&                          execute) {
+                if (execution_class == RenderGraph::PassExecutionClass::CpuPrepare ||
+                    execution_class == RenderGraph::PassExecutionClass::ExternalControl) {
+                    std::forward<decltype(execute)>(execute)(cmd_list);
+                    return;
+                }
                 const std::string marker_name = std::format("Pass: {}", name);
                 ScopedGpuMarker pass_marker(
                     cmd_list, marker_name, GpuMarkerPalette::Pass()
                 );
-                std::forward<decltype(execute)>(execute)();
+                std::forward<decltype(execute)>(execute)(cmd_list);
             };
             define_raster_passes(linear_schedule);
         };
@@ -1033,6 +1170,14 @@ RasterFrameFeedback RasterRenderer::RenderFrame(RasterFramePacket frame_packet) 
                 lighting_data_buffer,
                 RenderGraph::BufferDesc{.byte_size = lighting_data_buffer->GetByteSize()}
             );
+            const auto& scene_light_buffer = raster_context.GetGpuSceneRes().light_buf.buf;
+            if (scene_light_buffer) {
+                graph_resources.scene_lights = graph.ImportBuffer(
+                    "scene_lights",
+                    scene_light_buffer.Get(),
+                    RenderGraph::BufferDesc{.byte_size = scene_light_buffer->GetByteSize()}
+                );
+            }
             graph_resources.base_color =
                 import_texture("base_color", raster_context.textures.base_color.tex);
             graph_resources.normal = import_texture("normal", raster_context.textures.normal.tex);
@@ -1040,6 +1185,8 @@ RasterFrameFeedback RasterRenderer::RenderFrame(RasterFramePacket frame_packet) 
                 import_texture("metal_rough_ao", raster_context.textures.metal_rough_ao.tex);
             graph_resources.depth =
                 import_texture("depth", raster_context.textures.depth_linear_sampler.tex);
+            graph_resources.cubemap =
+                import_texture("cubemap", raster_context.textures.cubemap_tex.tex);
             const auto depth_nearest_alias =
                 import_texture("depth_nearest_sampler", raster_context.textures.depth_nearest_sampler.tex);
             assert(depth_nearest_alias == graph_resources.depth);
@@ -1104,21 +1251,56 @@ RasterFrameFeedback RasterRenderer::RenderFrame(RasterFramePacket frame_packet) 
             graph_resources.output =
                 import_texture("output", raster_context.textures.output.tex);
             graph_resources.processing_image = graph.CreateTransientToken("processing_image");
+            graph_resources.parallel_record_snapshots =
+                graph.CreateTransientToken("parallel_record_snapshots");
+            graph_resources.hiz_recorded = graph.CreateTransientToken("hiz_recorded");
 
             if (render_graph_fallback_latched) {
                 execute_linear();
             } else {
-                auto graph_schedule = [&](std::string_view name, auto&& setup, auto&& execute) {
+                auto graph_schedule = [&](std::string_view                    name,
+                                          auto&&                              setup,
+                                          RenderGraph::PassExecutionClass     execution_class,
+                                          auto&&                              execute) {
                     const std::string marker_name = std::format("Pass: {}", name);
-                    graph.AddPass(
+                    if (execution_class == RenderGraph::PassExecutionClass::MainThread ||
+                        execution_class == RenderGraph::PassExecutionClass::CpuPrepare ||
+                        execution_class == RenderGraph::PassExecutionClass::ExternalControl) {
+                        graph.AddPass(
+                            name,
+                            std::forward<decltype(setup)>(setup),
+                            [&, marker_name, execution_class,
+                             execute = std::forward<decltype(execute)>(execute)]() mutable {
+                                // CPU-only callbacks record no commands; external-control callbacks own
+                                // their explicit submission scope. Neither may inherit a managed marker.
+                                if (execution_class == RenderGraph::PassExecutionClass::CpuPrepare ||
+                                    execution_class ==
+                                        RenderGraph::PassExecutionClass::ExternalControl) {
+                                    execute(cmd_list);
+                                    return;
+                                }
+                                ScopedGpuMarker pass_marker(
+                                    cmd_list, marker_name, GpuMarkerPalette::Pass()
+                                );
+                                execute(cmd_list);
+                            }
+                        );
+                        return;
+                    }
+
+                    graph.AddRecordPass(
                         name,
                         std::forward<decltype(setup)>(setup),
-                        [&, marker_name, execute = std::forward<decltype(execute)>(execute)]() mutable {
+                        [marker_name,
+                         execute = std::forward<decltype(execute)>(execute)](
+                            CommandList& recording_cmd_list
+                        ) mutable {
                             ScopedGpuMarker pass_marker(
-                                cmd_list, marker_name, GpuMarkerPalette::Pass()
+                                recording_cmd_list, marker_name, GpuMarkerPalette::Pass()
                             );
-                            execute();
-                        }
+                            execute(recording_cmd_list);
+                        },
+                        execution_class
                     );
                 };
                 define_raster_passes(graph_schedule);
@@ -1134,20 +1316,86 @@ RasterFrameFeedback RasterRenderer::RenderFrame(RasterFramePacket frame_packet) 
                             LOG_INFO("[RenderGraph][DebugDump]\n{}", dump);
                         }
                     }
-                    ScopedGpuMarker graph_marker(
-                        cmd_list,
-                        "Raster RenderGraph: RasterFrame",
-                        GpuMarkerPalette::RenderGraph()
-                    );
-                    if (!graph.Execute()) {
-                        graph_marker.Close();
+                    // A long-lived renderer/graph marker cannot cross the per-pass Submit boundaries.
+                    // Every pass still owns its own marker and the immutable source packet carries a
+                    // stable frame/pass debug label.
+                    renderer_marker.Close();
+                    const auto submit_main_thread_pass =
+                        [&](const RenderGraph::ExecutedPassInfo& pass) {
+                            assert(
+                                pass.domain.queue == RenderGraph::QueueRole::Graphics &&
+                                "Raster RDG pass recorded into a Graphics CommandList but declared another queue"
+                            );
+                            if (cmd_list.IsEmpty()) {
+                                return;
+                            }
+                            CmdSubmit pass_submit = cmd_list.Submit();
+                            pass_submit.DebugLabel(
+                                std::format(
+                                    "Raster Frame {}/{}",
+                                    frame_packet.frame_id,
+                                    pass.name
+                                ),
+                                GpuMarkerPalette::Pass()
+                            );
+                            // Preserve the old one-frame timestamp transaction even though RDG
+                            // now seals several source submissions.  The first source resets the
+                            // frame query range and opens Graphics Exec; intermediate sources only
+                            // emit their pass queries; the UI/frame-tail source closes and advances
+                            // the profiler below.  This also survives TensorRT's explicit mid-frame
+                            // Flush/Sync boundary.
+                            pass_submit.SetProfilingPhase(
+                                split_graph_profiling_frame ?
+                                    ERHIProfilingPhase::Continue :
+                                    ERHIProfilingPhase::Begin
+                            );
+                            split_graph_profiling_frame = true;
+                            // Until RDG barrier/ownership metadata is lowered into the runtime
+                            // topology, pass packets remain an explicit ordered-control stream.
+                            // Their command bodies can still use the lower parallel recorder.
+                            pass_submit.SetTranslateExecutionClass(
+                                ERHITranslateExecutionClass::SerialControl
+                            );
+                            RHIExecutor::Get().Submit(
+                                EQueueType::Graphics,
+                                std::move(pass_submit),
+                                ERHIExecSubmitFlags::None
+                            );
+                        };
+                    const auto configure_recording_source =
+                        [&](const RenderGraph::ExecutedPassInfo& pass,
+                            RHIRecordingSource&                  source) {
+                            assert(
+                                pass.domain.queue == RenderGraph::QueueRole::Graphics &&
+                                "Raster RDG record source declared a non-Graphics queue"
+                            );
+                            const auto profiling_phase =
+                                split_graph_profiling_frame ?
+                                    ERHIProfilingPhase::Continue :
+                                    ERHIProfilingPhase::Begin;
+                            split_graph_profiling_frame = true;
+                            const std::string debug_label = std::format(
+                                "Raster Frame {}/{}", frame_packet.frame_id, pass.name
+                            );
+                            source.submit_metadata.debug_label       = debug_label;
+                            source.submit_metadata.debug_label_color = GpuMarkerPalette::Pass();
+                            source.submit_metadata.profiling_phase   = profiling_phase;
+                            // RDG barrier/ownership lowering is still guarded; keep the backend
+                            // translator ordered even though CPU recording overlaps.
+                            source.submit_metadata.translate_execution_class =
+                                ERHITranslateExecutionClass::SerialControl;
+                        };
+                    if (!graph.ExecuteRecording(
+                            submit_main_thread_pass,
+                            configure_recording_source,
+                            parallel_recording_enabled
+                        )) {
                         render_graph_fallback_latched = true;
                         LOG_ERROR(
-                            "[RenderGraph][Fallback] Raster graph execution was rejected before any pass: {}. "
-                            "Using the linear path for this renderer instance.",
+                            "[RenderGraph][Fallback] Raster graph recording failed after execution began: {}. "
+                            "The linear path will be used from the next frame.",
                             graph.GetCompileError()
                         );
-                        execute_linear();
                     }
                 } else {
                     render_graph_fallback_latched = true;
@@ -1185,16 +1433,21 @@ RasterFrameFeedback RasterRenderer::RenderFrame(RasterFramePacket frame_packet) 
     time++;
     // Host 同步的 copy 操作已经完成。此处触发 timeline，向 validation layer 传递执行顺序，
     // 无需再额外等待 copy queue。
-    gfx_queue.Execute(
+    CmdSubmit frame_submit =
         cmd_list.Submit()
             .DebugLabel(
                 std::format("Raster Frame {}", frame_packet.frame_id),
                 GpuMarkerPalette::Frame()
             )
             .Signal(timeline, time)
-            .DeleteResources()
-            .TickProfiling()
-    );
+            .DeleteResources();
+    if (split_graph_profiling_frame) {
+        frame_submit.SetProfilingPhase(ERHIProfilingPhase::End);
+    } else {
+        frame_submit.TickProfiling();
+    }
+
+    std::optional<RHIPresentRequest> present_request{};
 
     if (!skip_present) {
         const auto output_view = default_output_texture->GetView();
@@ -1211,7 +1464,7 @@ RasterFrameFeedback RasterRenderer::RenderFrame(RasterFramePacket frame_packet) 
         if (output_view.extent.x == swapchain->size.x && output_view.extent.y == swapchain->size.y) {
             main_present_receipt =
                 CreateMainPresentReceipt(frame_packet.scene_updates.scene_ready);
-            gfx_queue.Present(swapchain, default_output_texture, main_present_receipt);
+            present_request.emplace(swapchain, output_view, main_present_receipt);
         } else {
             LOG_WARNING(
                 "Skipping stale main-window present: source={}x{}, swapchain={}x{}.",
@@ -1221,6 +1474,16 @@ RasterFrameFeedback RasterRenderer::RenderFrame(RasterFramePacket frame_packet) 
                 swapchain->size.y
             );
         }
+    }
+
+    RHIExecutor::Get().Submit(
+        EQueueType::Graphics,
+        std::move(frame_submit),
+        ERHIExecSubmitFlags::FlushGPU,
+        present_request ? &*present_request : nullptr
+    );
+
+    if (!skip_present) {
         PresentUiDrawFrame(frame_packet.ui_draw_frame, ui_execution_thread);
     }
 

--- a/source/runtime/render/renderer/raster/RasterRenderer.h
+++ b/source/runtime/render/renderer/raster/RasterRenderer.h
@@ -105,6 +105,7 @@ private:
 
     bool                            render_graph_enabled = false;
     bool                            render_graph_debug_dump = false;
+    bool                            parallel_recording_enabled = false;
     bool                            render_graph_fallback_latched = false;
     std::unordered_set<std::string> logged_render_graph_dumps;
 };

--- a/source/runtime/render/renderer/raster/RasterTool.cpp
+++ b/source/runtime/render/renderer/raster/RasterTool.cpp
@@ -6,6 +6,7 @@
 #include "misc/Timer.h"
 #include "rhi/RHI.h"
 #include "rhi/RHICommand.h"
+#include "rhi/RHIExecutor.h"
 #include "scene/Scene.h"
 
 #include <cassert>
@@ -240,12 +241,20 @@ void RasterTool::ExecuteScenePendingCommands(
     CommandQueue&                  gfx_queue
 ) {
     assert(!IsRenderThreadInitialized() || IsCurrentlyRenderThread());
+    (void)gfx_queue;
 
-    auto copy_evt = device.GetCopyQueue().Execute(commands.copy_queue_cmd_list.Submit());
-    device.GetCopyQueue().Sync(copy_evt.timeline);
-
-    gfx_queue.Execute(commands.gfx_queue_cmd_list.Submit().TickProfiling());
-    gfx_queue.Sync();
+    (void)device;
+    Array<RHIBackendSubmissionBatchEntry> submissions{};
+    submissions.emplace_back(EQueueType::Copy, commands.copy_queue_cmd_list.Submit());
+    submissions.emplace_back(
+        EQueueType::Graphics,
+        commands.gfx_queue_cmd_list.Submit().TickProfiling()
+    );
+    RHIExecutor::Get().Submit(
+        std::move(submissions),
+        ERHIExecSubmitFlags::FlushGPU
+    );
+    RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
 }
 
 } // namespace Moer::Render::Raster

--- a/source/runtime/render/renderer/raster/SkyboxPass.cpp
+++ b/source/runtime/render/renderer/raster/SkyboxPass.cpp
@@ -23,8 +23,13 @@ SkyboxPass::SkyboxPass(RasterContext& context) {
                           .Build<SkyboxPipeline>(std::move(pipeline_info));
 }
 
-void SkyboxPass::Process(RasterContext& context, const RasterConfig& ui_config, const Camera& camera) {
-    SkyboxPassBindlessParam skybox_param;
+SkyboxPass::RecordParameters SkyboxPass::Prepare(
+    const RasterContext& context,
+    const RasterConfig&  ui_config,
+    const Camera&        camera
+) const {
+    RecordParameters parameters{};
+    auto&            skybox_param = parameters.pass_param;
     skybox_param.cubemap_handle = context.textures.cubemap_tex.hdl;
     const auto& directional_light = context.GetSceneUpdates().main_directional_light;
     if (directional_light && ui_config.skybox_exposure_correct_enabled) {
@@ -36,22 +41,33 @@ void SkyboxPass::Process(RasterContext& context, const RasterConfig& ui_config, 
     skybox_param.camera_pos = camera.GetPosition();
     skybox_param.clip2world = Transpose(camera.GetViewProjectionMatrixInv());
 
-    DepthAttachment depth_attachment(
-        context.textures.depth_linear_sampler.tex->GetView().GetTexture()
-    );
+    parameters.bindless      = context.bdls;
+    parameters.cubemap_owner = context.textures.cubemap_tex.tex;
+    parameters.depth_owner   = context.textures.depth_linear_sampler.tex;
+    parameters.output        = context.textures.lighting_output.tex;
+    parameters.render_area   = context.textures.lighting_output.GetRect2D();
+    return parameters;
+}
+
+void SkyboxPass::Record(CommandList& cmd_list, const RecordParameters& parameters) {
+    DepthAttachment depth_attachment(parameters.depth_owner->GetView().GetTexture());
     depth_attachment.action = EAttachmentAction::AC_DS_LOAD_STORE;
 
-    context.cmd_list.Gfx(skybox_pipeline, context.bdls, skybox_param)
+    cmd_list.Gfx(skybox_pipeline, parameters.bindless, parameters.pass_param)
         .Draw(
             "Skybox Pass",
-            context.textures.lighting_output.GetRect2D(),
+            parameters.render_area,
             std::move(RasterTool::GetFullScreenDrawDatas()),
             depth_attachment,
             // 保留上一个延迟光照 Pass 写入的结果。
             ColorAttachment{
-                context.textures.lighting_output.tex, EAttachmentAction::AC_LOAD_STORE, float4(0, 0, 0, 0)
+                parameters.output, EAttachmentAction::AC_LOAD_STORE, float4(0, 0, 0, 0)
             }
         );
+}
+
+void SkyboxPass::Process(RasterContext& context, const RasterConfig& ui_config, const Camera& camera) {
+    Record(context.cmd_list, Prepare(context, ui_config, camera));
 }
 
 } // namespace Moer::Render::Raster

--- a/source/runtime/render/renderer/raster/SkyboxPass.h
+++ b/source/runtime/render/renderer/raster/SkyboxPass.h
@@ -19,8 +19,23 @@ public:
 
 class SkyboxPass {
 public:
+    struct RecordParameters {
+        SkyboxPassBindlessParam pass_param{};
+        BindlessArrayRef        bindless{};
+        TextureRef              cubemap_owner{};
+        DepthBufferRef          depth_owner{};
+        TextureRef              output{};
+        Rect2D                  render_area{};
+    };
+
     SkyboxPass(RasterContext& context);
 
+    [[nodiscard]] RecordParameters Prepare(
+        const RasterContext& context,
+        const RasterConfig&  ui_config,
+        const Camera&        camera
+    ) const;
+    void Record(CommandList& cmd_list, const RecordParameters& parameters);
     void Process(RasterContext& context, const RasterConfig& ui_config, const Camera& camera);
 
 private:

--- a/source/runtime/render/renderer/raytracing/RaytracingRenderer.cpp
+++ b/source/runtime/render/renderer/raytracing/RaytracingRenderer.cpp
@@ -7,6 +7,7 @@
 #include "misc/Timer.h"
 #include "rhi/RHI.h"
 #include "rhi/RHICommand.h"
+#include "rhi/RHIExecutor.h"
 #include "rhi/RHIResource.h"
 #include "rhi/plugin/NrdPlugin.h"
 #include "scene/GpuScene.h"
@@ -172,11 +173,20 @@ void ExecuteSceneUpdate(
     RenderDevice&    device,
     CommandQueue&    gfx_queue
 ) {
+    (void)gfx_queue;
+    (void)device;
     auto scene_cmd_list = render_scene.ApplyUpdate(std::move(update));
-    auto copy_event     = device.GetCopyQueue().Execute(scene_cmd_list.copy_queue_cmd_list.Submit());
-    device.GetCopyQueue().Sync(copy_event.timeline);
-    gfx_queue.Execute(scene_cmd_list.gfx_queue_cmd_list.Submit().TickProfiling());
-    gfx_queue.Sync();
+    Array<RHIBackendSubmissionBatchEntry> submissions{};
+    submissions.emplace_back(EQueueType::Copy, scene_cmd_list.copy_queue_cmd_list.Submit());
+    submissions.emplace_back(
+        EQueueType::Graphics,
+        scene_cmd_list.gfx_queue_cmd_list.Submit().TickProfiling()
+    );
+    RHIExecutor::Get().Submit(
+        std::move(submissions),
+        ERHIExecSubmitFlags::FlushGPU
+    );
+    RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
 }
 
 } // namespace
@@ -544,8 +554,10 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
             RefreshSceneRuntimeRefs();
             state.rt_ctx->FillLowDiscrepancySequence(cmd_list);
             cmd_list.UpdateBindlessArray(bindless_array);
-            gfx_queue.Execute(cmd_list.Submit());
-            gfx_queue.Sync();
+            RHIExecutor::Get().Submit(
+                EQueueType::Graphics, cmd_list.Submit(), ERHIExecSubmitFlags::FlushGPU
+            );
+            RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
         }
 
         ScopedGpuMarker renderer_marker(
@@ -848,15 +860,17 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
 
         if (state.b_export) {
             renderer_marker.Close();
-            gfx_queue.Execute(
+            RHIExecutor::Get().Submit(
+                EQueueType::Graphics,
                 cmd_list.Submit()
                     .DebugLabel(
                         std::format("Raytracing Export Frame {}", frame_packet.frame_id),
                         GpuMarkerPalette::Frame()
                     )
-                    .TickProfiling()
+                    .TickProfiling(),
+                ERHIExecSubmitFlags::FlushGPU
             );
-            gfx_queue.Sync();
+            RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
             DumpTextureToFile(
                 ui_config.export_cfg,
                 state.rt_ctx->frame_rt,
@@ -914,7 +928,7 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
     }
 
     time++;
-    gfx_queue.Execute(
+    CmdSubmit frame_submit =
         cmd_list.Submit()
             .DebugLabel(
                 std::format("Raytracing Frame {}", frame_packet.frame_id),
@@ -922,8 +936,8 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
             )
             .Signal(timeline, time)
             .DeleteResources()
-            .TickProfiling()
-    );
+            .TickProfiling();
+    std::optional<RHIPresentRequest> present_request{};
     if (!skip_present) {
         const auto output_view = state.output->GetView();
         if (frame_packet.window.state == EWindowState::SizeChanged) {
@@ -940,7 +954,7 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
             feedback.main_present_receipt = CreateMainPresentReceipt(
                 frame_packet.scene_updates.scene_ready && frame_packet.runtime_assets_ready
             );
-            gfx_queue.Present(swapchain, state.output, feedback.main_present_receipt);
+            present_request.emplace(swapchain, output_view, feedback.main_present_receipt);
         } else {
             LOG_WARNING(
                 "Skipping stale raytracing main-window present: source={}x{}, swapchain={}x{}.",
@@ -950,6 +964,15 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
                 swapchain->size.y
             );
         }
+    }
+
+    RHIExecutor::Get().Submit(
+        EQueueType::Graphics,
+        std::move(frame_submit),
+        ERHIExecSubmitFlags::FlushGPU,
+        present_request ? &*present_request : nullptr
+    );
+    if (!skip_present) {
         PresentUiDrawFrame(frame_packet.ui_draw_frame, ui_execution_thread);
     }
 

--- a/source/runtime/render/renderer/raytracing/RaytracingRendererExport.cpp
+++ b/source/runtime/render/renderer/raytracing/RaytracingRendererExport.cpp
@@ -1,6 +1,7 @@
 #include "RaytracingRenderer.h"
 
 #include "RTResource.h"
+#include "rhi/RHIExecutor.h"
 #include "taskgraph/TaskGraph.h"
 
 #include <stb/stb_image_write.h>
@@ -27,6 +28,7 @@ void RaytracingRenderer::DumpTextureToFile(
     std::filesystem::path& exported_file_path,
     std::string_view       suffix
 ) {
+    (void)gfx_queue;
     CommandList command_list{};
 
     auto dequantize_half = [](short value, bool gamma_correct = true) {
@@ -81,8 +83,12 @@ void RaytracingRenderer::DumpTextureToFile(
         return;
     }
 
-    gfx_queue.Execute(command_list.Submit().TickProfiling());
-    gfx_queue.Sync();
+    RHIExecutor::Get().Submit(
+        EQueueType::Graphics,
+        command_list.Submit().TickProfiling(),
+        ERHIExecSubmitFlags::FlushGPU
+    );
+    RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
 
     if (hdr) {
         assert(

--- a/source/runtime/render/renderer/raytracing/ShaderUtils.cpp
+++ b/source/runtime/render/renderer/raytracing/ShaderUtils.cpp
@@ -84,6 +84,10 @@ void ShaderUtils::GenerateMipPdf(
     const TextureView&     _env_map,
     std::span<TextureView> _integrated_mips
 ) {
+    if (_integrated_mips.empty()) {
+        return;
+    }
+
     PreprocessEnvironmentMapParams param;
     uint                           width  = _env_map.extent.x;
     uint                           height = _env_map.extent.y;
@@ -101,6 +105,10 @@ void ShaderUtils::GenerateMipPdf(
 }
 
 void ShaderUtils::GenerateMips(CommandList& _cmd_list, std::span<TextureView> _mips) {
+    if (_mips.empty()) {
+        return;
+    }
+
     BuildMipsParam param;
 
     uint width  = _mips[0].extent.x;

--- a/source/runtime/render/rendergraph/RenderGraph.cpp
+++ b/source/runtime/render/rendergraph/RenderGraph.cpp
@@ -1,5 +1,6 @@
 #include "rendergraph/RenderGraph.h"
 
+#include "log/LogSystem.h"
 #include "rendergraph/RenderGraphCompiler.h"
 #include "rhi/RHIExecutor.h"
 #include "taskgraph/TaskGraph.h"
@@ -10,6 +11,7 @@
 #include <exception>
 #include <mutex>
 #include <sstream>
+#include <unordered_set>
 #include <utility>
 
 namespace Moer::Render {
@@ -1206,6 +1208,9 @@ bool RenderGraph::ExecuteRecording(
         }
 
         const bool task_graph_available = TaskGraph::IsInitialized();
+        const bool task_graph_dispatch =
+            first_batch.execution == PassExecutionClass::ParallelRecordEligible &&
+            parallel_recording_enabled && task_graph_available;
         if (first_batch.execution == PassExecutionClass::SerialRecord ||
             !parallel_recording_enabled || !task_graph_available) {
             for (auto& job : jobs) {
@@ -1258,6 +1263,35 @@ bool RenderGraph::ExecuteRecording(
             std::lock_guard lock(error->mutex);
             compile_error = error->message.empty() ? "recording batch failed" : error->message;
             return false;
+        }
+        if (task_graph_dispatch && group_end - batch_index > 1) {
+            std::ostringstream pass_list;
+            for (size_t index = batch_index; index < group_end; ++index) {
+                if (index != batch_index) {
+                    pass_list << ',';
+                }
+                const auto pass_handle = compiled_plan.recording_batches[index].passes.front();
+                pass_list << passes[pass_handle.index].name;
+            }
+
+            const std::string pass_names = pass_list.str();
+            const std::string dispatch_key = name + '\n' + pass_names;
+            static std::mutex                      logged_dispatch_mutex;
+            static std::unordered_set<std::string> logged_dispatches;
+            bool                                   first_dispatch = false;
+            {
+                std::lock_guard lock(logged_dispatch_mutex);
+                first_dispatch = logged_dispatches.emplace(dispatch_key).second;
+            }
+            if (first_dispatch) {
+                LOG_INFO(
+                    "[RenderGraph][ParallelRecordDispatch] graph={} passes=[{}] "
+                    "dispatch=task-graph worker_jobs={} completed=true",
+                    name,
+                    pass_names,
+                    group_end - batch_index
+                );
+            }
         }
         pending_gate_guard.Disarm();
         batch_index = group_end;
@@ -1505,7 +1539,9 @@ std::string RenderGraph::Dump() const {
     stream << "queue_batches:\n";
     for (const auto& batch : compiled_plan.queue_batches) {
         stream << "  [" << batch.id << "] " << ToString(batch.queue.role) << " native="
-               << batch.queue.native_queue_id << " family=" << batch.queue.family_id << " passes=[";
+               << batch.queue.native_queue_id << " family=" << batch.queue.family_id
+               << " external_control=" << (batch.external_control ? "true" : "false")
+               << " passes=[";
         for (uint32_t pass_index = 0; pass_index < batch.passes.size(); ++pass_index) {
             if (pass_index != 0) {
                 stream << ',';

--- a/source/runtime/render/rendergraph/RenderGraph.cpp
+++ b/source/runtime/render/rendergraph/RenderGraph.cpp
@@ -1,10 +1,14 @@
 #include "rendergraph/RenderGraph.h"
 
 #include "rendergraph/RenderGraphCompiler.h"
+#include "rhi/RHIExecutor.h"
+#include "taskgraph/TaskGraph.h"
 
 #include <algorithm>
 #include <atomic>
 #include <cassert>
+#include <exception>
+#include <mutex>
 #include <sstream>
 #include <utility>
 
@@ -93,6 +97,22 @@ const char* ToString(RenderGraph::PipelineType pipeline) {
             return "raytracing";
         case RenderGraph::PipelineType::Copy:
             return "copy";
+    }
+    return "unknown";
+}
+
+const char* ToString(RenderGraph::PassExecutionClass execution) {
+    switch (execution) {
+        case RenderGraph::PassExecutionClass::MainThread:
+            return "main-thread";
+        case RenderGraph::PassExecutionClass::CpuPrepare:
+            return "cpu-prepare";
+        case RenderGraph::PassExecutionClass::ExternalControl:
+            return "external-control";
+        case RenderGraph::PassExecutionClass::SerialRecord:
+            return "serial-record";
+        case RenderGraph::PassExecutionClass::ParallelRecordEligible:
+            return "parallel-record";
     }
     return "unknown";
 }
@@ -498,6 +518,11 @@ RenderGraph::PassBuilder& RenderGraph::PassBuilder::ReadWrite(TokenHandle resour
     return *this;
 }
 
+RenderGraph::PassBuilder& RenderGraph::PassBuilder::Reference(ResourceHandle resource) {
+    graph.AddReference(pass_index, resource);
+    return *this;
+}
+
 RenderGraph::PassBuilder& RenderGraph::PassBuilder::DependsOn(PassHandle dependency) {
     graph.AddDependency(pass_index, dependency);
     return *this;
@@ -511,6 +536,45 @@ RenderGraph::PassBuilder& RenderGraph::PassBuilder::SideEffect() {
 RenderGraph::PassBuilder&
 RenderGraph::PassBuilder::ExecuteOn(QueueRole queue, PipelineType pipeline) {
     graph.SetExecutionDomain(pass_index, queue, pipeline);
+    return *this;
+}
+
+[[nodiscard]] EQueueType ToRHIQueue(RenderGraph::QueueRole queue) {
+    switch (queue) {
+        case RenderGraph::QueueRole::Graphics:
+            return EQueueType::Graphics;
+        case RenderGraph::QueueRole::Compute:
+            return EQueueType::Compute;
+        case RenderGraph::QueueRole::Copy:
+            return EQueueType::Copy;
+        case RenderGraph::QueueRole::None:
+            return EQueueType::Ignore;
+    }
+    return EQueueType::Ignore;
+}
+
+RenderGraph::PassBuilder& RenderGraph::PassBuilder::MainThread() {
+    graph.SetPassExecutionClass(pass_index, PassExecutionClass::MainThread, 1);
+    return *this;
+}
+
+RenderGraph::PassBuilder& RenderGraph::PassBuilder::CpuPrepare() {
+    graph.SetPassExecutionClass(pass_index, PassExecutionClass::CpuPrepare, 1);
+    return *this;
+}
+
+RenderGraph::PassBuilder& RenderGraph::PassBuilder::ExternalControl() {
+    graph.SetPassExecutionClass(pass_index, PassExecutionClass::ExternalControl, 1);
+    return *this;
+}
+
+RenderGraph::PassBuilder& RenderGraph::PassBuilder::SerialRecord(uint32_t workload) {
+    graph.SetPassExecutionClass(pass_index, PassExecutionClass::SerialRecord, workload);
+    return *this;
+}
+
+RenderGraph::PassBuilder& RenderGraph::PassBuilder::ParallelRecord(uint32_t workload) {
+    graph.SetPassExecutionClass(pass_index, PassExecutionClass::ParallelRecordEligible, workload);
     return *this;
 }
 
@@ -821,6 +885,45 @@ RenderGraph::AddPass(std::string_view pass_name, const SetupCallback& setup, Exe
     return PassHandle{pass_index, graph_id};
 }
 
+RenderGraph::PassHandle RenderGraph::AddRecordPass(
+    std::string_view     pass_name,
+    const SetupCallback& setup,
+    RecordCallback       record,
+    PassExecutionClass   execution,
+    uint32_t             workload
+) {
+    if (!InvalidateCompile()) {
+        return {};
+    }
+    if (pass_name.empty()) {
+        declaration_errors.emplace_back("pass name cannot be empty");
+        return {};
+    }
+    if (!record) {
+        declaration_errors.emplace_back("pass has no record callback: " + std::string(pass_name));
+        return {};
+    }
+    if (std::any_of(passes.begin(), passes.end(), [&](const PassDeclaration& pass) {
+            return pass.name == pass_name;
+        })) {
+        declaration_errors.emplace_back("duplicate pass name: " + std::string(pass_name));
+        return {};
+    }
+
+    PassDeclaration pass{};
+    pass.name            = pass_name;
+    pass.record          = std::move(record);
+    pass.execution_class = execution;
+    pass.workload        = workload;
+    passes.emplace_back(std::move(pass));
+    const uint32_t pass_index = static_cast<uint32_t>(passes.size() - 1);
+    PassBuilder    builder(*this, pass_index);
+    if (setup) {
+        setup(builder);
+    }
+    return PassHandle{pass_index, graph_id};
+}
+
 bool RenderGraph::Compile() {
     if (executed) {
         compile_error = "graph has already executed and cannot be compiled again";
@@ -830,6 +933,10 @@ bool RenderGraph::Compile() {
 }
 
 bool RenderGraph::Execute() {
+    return Execute({});
+}
+
+bool RenderGraph::Execute(const PassCompletedCallback& after_pass) {
     if (!compiled) {
         compile_error = "Execute called before a successful Compile";
         return false;
@@ -838,12 +945,322 @@ bool RenderGraph::Execute() {
         compile_error = "a per-frame RenderGraph can only be executed once";
         return false;
     }
+    if (std::any_of(compiled_plan.execution_order.begin(),
+                    compiled_plan.execution_order.end(),
+                    [&](PassHandle handle) { return static_cast<bool>(passes[handle.index].record); })) {
+        compile_error = "serial Execute cannot run command-recording passes without owned CommandLists";
+        return false;
+    }
     executed = true;
 
     for (const PassHandle pass_handle : compiled_plan.execution_order) {
         auto& pass = passes[pass_handle.index];
         assert(pass.execute);
         pass.execute();
+        if (after_pass) {
+            after_pass(ExecutedPassInfo{
+                .handle      = pass_handle,
+                .name        = pass.name,
+                .domain      = pass.domain,
+                .side_effect = pass.side_effect,
+                .execution_class = pass.execution_class,
+            });
+        }
+    }
+    return true;
+}
+
+bool RenderGraph::ExecuteRecording(
+    const PassCompletedCallback&        after_main_thread_pass,
+    const RecordingSourceSetupCallback& configure_recording_source,
+    bool                                parallel_recording_enabled,
+    const RecordingBatchPublisher&      publish_recording_batch
+) {
+    if (!compiled) {
+        compile_error = "ExecuteRecording called before a successful Compile";
+        return false;
+    }
+    if (executed) {
+        compile_error = "a per-frame RenderGraph can only be executed once";
+        return false;
+    }
+    executed = true;
+
+    struct RecordingJob {
+        PassHandle          pass{};
+        std::string         pass_name{};
+        RecordCallback      record{};
+        SharedPtr<CommandList> command_list{};
+        RHIRecordingGateRef completion{};
+    };
+    struct RecordingError {
+        std::mutex  mutex{};
+        std::string message{};
+    };
+    struct PendingGateGuard {
+        const Array<RHIRecordingGateRef>* gates{nullptr};
+        bool                              armed{true};
+
+        ~PendingGateGuard() {
+            if (!armed || gates == nullptr) {
+                return;
+            }
+            for (const auto& gate : *gates) {
+                if (gate && gate->Status() == ERHIRecordingStatus::Pending) {
+                    gate->Fail();
+                }
+            }
+        }
+
+        void Disarm() noexcept {
+            armed = false;
+        }
+    };
+
+    auto make_pass_info = [&](PassHandle handle) {
+        const auto& pass = passes[handle.index];
+        return ExecutedPassInfo{
+            .handle          = handle,
+            .name            = pass.name,
+            .domain          = pass.domain,
+            .side_effect     = pass.side_effect,
+            .execution_class = pass.execution_class,
+        };
+    };
+
+    auto store_error = [](const std::shared_ptr<RecordingError>& error, std::string message) {
+        std::lock_guard lock(error->mutex);
+        if (error->message.empty()) {
+            error->message = std::move(message);
+        }
+    };
+
+    auto has_cpu_recording_dependency = [&](PassHandle candidate,
+                                            size_t     group_begin,
+                                            size_t     group_end) {
+        for (const auto& edge : compiled_plan.edges) {
+            if (edge.dst != candidate) {
+                continue;
+            }
+
+            const bool source_is_in_group = std::any_of(
+                compiled_plan.recording_batches.begin() + group_begin,
+                compiled_plan.recording_batches.begin() + group_end,
+                [&](const CompiledRecordingBatch& batch) {
+                    return batch.passes.size() == 1 && batch.passes.front() == edge.src;
+                }
+            );
+            if (!source_is_in_group) {
+                continue;
+            }
+
+            for (const auto& reason : edge.reasons) {
+                if (reason.kind == EdgeReasonKind::Explicit) {
+                    return true;
+                }
+                if (IsValidResource(reason.resource) &&
+                    resources[reason.resource.index].kind == ResourceKind::Token) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    };
+
+    size_t batch_index = 0;
+    while (batch_index < compiled_plan.recording_batches.size()) {
+        const auto& first_batch = compiled_plan.recording_batches[batch_index];
+        if (first_batch.passes.size() != 1) {
+            compile_error = "recording execution currently requires one pass per compiled batch";
+            return false;
+        }
+
+        const PassHandle first_handle = first_batch.passes.front();
+        auto&            first_pass   = passes[first_handle.index];
+        if (first_batch.execution == PassExecutionClass::MainThread ||
+            first_batch.execution == PassExecutionClass::CpuPrepare ||
+            first_batch.execution == PassExecutionClass::ExternalControl) {
+            if (!first_pass.execute || first_pass.record) {
+                compile_error = "compiled caller-thread pass has an invalid callback shape: " +
+                                first_pass.name;
+                return false;
+            }
+            first_pass.execute();
+            if (first_batch.execution == PassExecutionClass::MainThread &&
+                after_main_thread_pass) {
+                after_main_thread_pass(make_pass_info(first_handle));
+            }
+            ++batch_index;
+            continue;
+        }
+
+        size_t group_end = batch_index + 1;
+        if (first_batch.execution == PassExecutionClass::ParallelRecordEligible) {
+            while (group_end < compiled_plan.recording_batches.size()) {
+                const auto& candidate = compiled_plan.recording_batches[group_end];
+                if (candidate.execution != PassExecutionClass::ParallelRecordEligible ||
+                    candidate.queue.role != first_batch.queue.role ||
+                    candidate.queue.native_queue_id != first_batch.queue.native_queue_id ||
+                    candidate.queue.family_id != first_batch.queue.family_id ||
+                    candidate.passes.size() != 1 ||
+                    has_cpu_recording_dependency(
+                        candidate.passes.front(), batch_index, group_end
+                    )) {
+                    break;
+                }
+                ++group_end;
+            }
+        }
+
+        Array<RecordingJob>        jobs{};
+        Array<RHIRecordingSource>  sources{};
+        Array<RHIRecordingGateRef> group_gates{};
+        jobs.reserve(group_end - batch_index);
+        sources.reserve(group_end - batch_index);
+        group_gates.reserve(group_end - batch_index);
+
+        for (size_t index = batch_index; index < group_end; ++index) {
+            const auto& batch = compiled_plan.recording_batches[index];
+            const auto  handle = batch.passes.front();
+            auto&       pass   = passes[handle.index];
+            const auto  queue  = ToRHIQueue(batch.queue.role);
+            if (!pass.record || pass.execute || queue == EQueueType::Ignore) {
+                compile_error = "compiled recording pass has an invalid callback or queue: " +
+                                pass.name;
+                return false;
+            }
+
+            RecordingJob job{
+                .pass         = handle,
+                .pass_name    = pass.name,
+                .record       = pass.record,
+                .command_list = MakeShared<CommandList>(queue),
+                .completion   = RHIRecordingGate::Create(),
+            };
+            RHIRecordingSource source{
+                .command_list = job.command_list,
+                .completion   = job.completion,
+            };
+            if (configure_recording_source) {
+                try {
+                    configure_recording_source(make_pass_info(handle), source);
+                } catch (const std::exception& exception) {
+                    compile_error = "recording source configuration failed for pass '" + pass.name +
+                                    "': " + exception.what();
+                    return false;
+                } catch (...) {
+                    compile_error = "recording source configuration failed for pass '" + pass.name + "'";
+                    return false;
+                }
+                if (source.command_list != job.command_list || source.completion != job.completion) {
+                    compile_error = "recording source configuration changed ownership for pass '" +
+                                    pass.name + "'";
+                    return false;
+                }
+            }
+            group_gates.emplace_back(job.completion);
+            jobs.emplace_back(std::move(job));
+            sources.emplace_back(std::move(source));
+        }
+
+        PendingGateGuard pending_gate_guard{.gates = &group_gates};
+
+        const auto error = std::make_shared<RecordingError>();
+        auto run_job = [error, store_error](RecordingJob job) mutable {
+            try {
+                job.record(*job.command_list);
+                // Keep every immutable capture alive until the submit reaches
+                // a terminal backend/rejection callback, not merely until CPU
+                // recording finishes.
+                job.command_list->AddCallback(
+                    [keepalive = std::move(job.record)]() mutable { keepalive = {}; }
+                );
+                job.completion->Signal();
+            } catch (const std::exception& exception) {
+                store_error(
+                    error,
+                    "record pass '" + job.pass_name + "' failed: " + exception.what()
+                );
+                job.completion->Fail();
+            } catch (...) {
+                store_error(error, "record pass '" + job.pass_name + "' failed");
+                job.completion->Fail();
+            }
+        };
+
+        // Register the unfinished sources before dispatch, matching the
+        // dev_parallel/UE-style producer-consumer handoff. RHI owns stable
+        // source order; worker completion order is irrelevant.
+        try {
+            if (publish_recording_batch) {
+                publish_recording_batch(std::move(sources));
+            } else {
+                RHIExecutor::Get().SubmitRecording(std::move(sources), ERHIExecSubmitFlags::None);
+            }
+        } catch (const std::exception& exception) {
+            compile_error = std::string("failed to publish recording batch: ") + exception.what();
+            return false;
+        } catch (...) {
+            compile_error = "failed to publish recording batch";
+            return false;
+        }
+
+        const bool task_graph_available = TaskGraph::IsInitialized();
+        if (first_batch.execution == PassExecutionClass::SerialRecord ||
+            !parallel_recording_enabled || !task_graph_available) {
+            for (auto& job : jobs) {
+                run_job(std::move(job));
+            }
+        } else {
+            GraphEventArray record_events{};
+            record_events.reserve(jobs.size());
+            size_t dispatched_count = 0;
+            try {
+                for (; dispatched_count < jobs.size(); ++dispatched_count) {
+                    record_events.emplace_back(LambdaTask::Dispatch(
+                        [job = std::move(jobs[dispatched_count]), run_job]() mutable {
+                            run_job(std::move(job));
+                        }
+                    ));
+                }
+            } catch (const std::exception& exception) {
+                store_error(error, std::string("failed to dispatch recording task: ") + exception.what());
+                for (size_t index = dispatched_count; index < jobs.size(); ++index) {
+                    group_gates[index]->Fail();
+                }
+            } catch (...) {
+                store_error(error, "failed to dispatch recording task");
+                for (size_t index = dispatched_count; index < jobs.size(); ++index) {
+                    group_gates[index]->Fail();
+                }
+            }
+            if (!record_events.empty()) {
+                // Do not use TaskGraph::WaitUntilTasksComplete here. On a named Render Thread that
+                // wait is allowed to pump the same named queue, which can execute the next
+                // RenderFrame re-entrantly while this frame still owns mutable renderer state.
+                // The producer gate is the handoff contract: Signal/Fail happens only after the
+                // worker has stopped mutating its CommandList, and its condition variable gives the
+                // caller the required happens-before edge without processing unrelated RT work.
+                // Keep record_events alive until every producer is terminal so the task/event
+                // ownership also remains explicit across the blocking join.
+                for (const auto& gate : group_gates) {
+                    (void)gate->Wait();
+                }
+            }
+        }
+
+        bool group_succeeded = true;
+        for (const auto& gate : group_gates) {
+            group_succeeded =
+                gate->Wait() == ERHIRecordingStatus::Succeeded && group_succeeded;
+        }
+        if (!group_succeeded) {
+            std::lock_guard lock(error->mutex);
+            compile_error = error->message.empty() ? "recording batch failed" : error->message;
+            return false;
+        }
+        pending_gate_guard.Disarm();
+        batch_index = group_end;
     }
     return true;
 }
@@ -879,6 +1296,8 @@ std::string RenderGraph::Dump() const {
                << " scheduled=" << (has_execution_order ? "true" : "false")
                << " queue=" << ToString(pass.domain.queue)
                << " pipeline=" << ToString(pass.domain.pipeline)
+               << " cpu=" << ToString(pass.execution_class)
+               << " workload=" << pass.workload
                << " side_effect=" << (pass.side_effect ? "true" : "false") << " accesses=[";
         for (uint32_t access_index = 0; access_index < pass.accesses.size(); ++access_index) {
             const auto& access = pass.accesses[access_index];
@@ -900,6 +1319,15 @@ std::string RenderGraph::Dump() const {
             stream << " state=";
             AppendState(stream, access.state);
             stream << ')';
+        }
+        stream << "] references=[";
+        for (uint32_t reference_index = 0; reference_index < pass.references.size();
+             ++reference_index) {
+            if (reference_index != 0) {
+                stream << ", ";
+            }
+            const auto reference = pass.references[reference_index];
+            stream << (IsValidResource(reference) ? resources[reference.index].name : "invalid");
         }
         stream << "]\n";
     }
@@ -1160,6 +1588,27 @@ std::string RenderGraph::Dump() const {
         }
         stream << "]\n";
     }
+
+    stream << "recording_batches:\n";
+    for (const auto& batch : compiled_plan.recording_batches) {
+        stream << "  [" << batch.id << "] queue=" << ToString(batch.queue.role)
+               << "/native" << batch.queue.native_queue_id << "/family" << batch.queue.family_id
+               << " cpu=" << ToString(batch.execution) << " workload=" << batch.workload
+               << " wave=";
+        if (batch.dependency_wave == PassHandle::InvalidIndex) {
+            stream << "none";
+        } else {
+            stream << batch.dependency_wave;
+        }
+        stream << " passes=[";
+        for (uint32_t index = 0; index < batch.passes.size(); ++index) {
+            if (index != 0) {
+                stream << ", ";
+            }
+            stream << passes[batch.passes[index].index].name;
+        }
+        stream << "]\n";
+    }
     return stream.str();
 }
 
@@ -1293,6 +1742,48 @@ void RenderGraph::SetExecutionDomain(
         return;
     }
     passes[pass_index].domain = ExecutionDomain{queue, pipeline};
+}
+
+void RenderGraph::AddReference(uint32_t pass_index, ResourceHandle resource) {
+    if (!InvalidateCompile()) {
+        return;
+    }
+    if (pass_index >= passes.size()) {
+        declaration_errors.emplace_back("resource reference has invalid pass index");
+        return;
+    }
+    if (!IsValidResource(resource)) {
+        declaration_errors.emplace_back(
+            "pass '" + passes[pass_index].name + "' references an invalid resource identity"
+        );
+        return;
+    }
+    auto& references = passes[pass_index].references;
+    if (std::find(references.begin(), references.end(), resource) == references.end()) {
+        references.emplace_back(resource);
+    }
+}
+
+void RenderGraph::SetPassExecutionClass(
+    uint32_t           pass_index,
+    PassExecutionClass execution_class,
+    uint32_t           workload
+) {
+    if (!InvalidateCompile()) {
+        return;
+    }
+    if (pass_index >= passes.size()) {
+        declaration_errors.emplace_back("recording-class declaration has invalid pass index");
+        return;
+    }
+    if (workload == 0) {
+        declaration_errors.emplace_back(
+            "pass '" + passes[pass_index].name + "' has zero recording workload"
+        );
+        return;
+    }
+    passes[pass_index].execution_class = execution_class;
+    passes[pass_index].workload        = workload;
 }
 
 bool RenderGraph::InvalidateCompile() {

--- a/source/runtime/render/rendergraph/RenderGraph.h
+++ b/source/runtime/render/rendergraph/RenderGraph.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "RenderAPI.h"
+#include "rhi/RHIExecutor.h"
 
 #include <cstdint>
 #include <functional>
@@ -14,14 +15,14 @@ namespace Moer::Render {
 class RenderGraphCompiler;
 
 /**
- * Serial frontend backed by a typed RDG compiler.
+ * Typed RDG frontend with an opt-in command-recording schedule.
  *
  * The compiler owns typed resource declarations, subresource-aware hazards,
  * logical resource versions, stable dependency analysis and lifetimes. The
  * RDG does not own physical tracked state or emit barriers in this stage; the
- * existing RHI/Vulkan command path remains responsible. Execute deliberately
- * stays synchronous and serial until command recording has an independent
- * ownership contract.
+ * existing RHI/Vulkan command path remains responsible. Legacy callbacks stay
+ * serial. Explicit record callbacks may be assigned independent CommandLists
+ * while preserving stable source order.
  */
 class RENDER_API RenderGraph {
 public:
@@ -296,6 +297,25 @@ public:
         friend bool operator==(const ExecutionDomain&, const ExecutionDomain&) = default;
     };
 
+    /** CPU callback/CommandList ownership; distinct from backend translate policy. */
+    enum class PassExecutionClass : uint8_t {
+        /** Caller-thread callback whose commands are sealed by the graph observer. */
+        MainThread,
+        /**
+         * Caller-thread, CPU-only preparation/history callback. It may order
+         * Token resources or Reference GPU identities, never seals commands,
+         * and is excluded from the prospective GPU queue plan.
+         */
+        CpuPrepare,
+        /**
+         * Caller-thread hard boundary that owns its command/submission scope.
+         * Used for external Vulkan/CUDA synchronization and unmanaged submission.
+         */
+        ExternalControl,
+        SerialRecord,
+        ParallelRecordEligible,
+    };
+
     /** RDG-neutral states; these do not depend on the legacy RHI enum ordinals. */
     enum class TextureState : uint8_t {
         Automatic,
@@ -415,6 +435,20 @@ public:
     };
 
     /**
+     * Stable CPU recording unit. The first implementation deliberately keeps
+     * one pass per batch; coalescing is a later optimization and must not alter
+     * callback ownership or source order.
+     */
+    struct CompiledRecordingBatch {
+        uint32_t                id = 0;
+        QueueBinding            queue{};
+        std::vector<PassHandle> passes{};
+        PassExecutionClass      execution = PassExecutionClass::SerialRecord;
+        uint32_t                workload = 1;
+        uint32_t                dependency_wave = PassHandle::InvalidIndex;
+    };
+
+    /**
      * One canonical synchronization decision for one atomic resource cell. The future backend may
      * lower a queue_ownership record into paired release/acquire barriers; RDG itself does not emit
      * physical barriers in this stage.
@@ -489,22 +523,25 @@ public:
     };
 
     /**
-     * Immutable compiler diagnostics for the current serial executor. This is shadow metadata,
-     * not an executable submission plan: queue_syncs only describe internal pass/batch edges,
-     * while external import/export/present synchronization endpoints are intentionally absent.
+     * Immutable compiler output. recording_batches is an executable CPU
+     * ownership schedule. GPU queue/barrier fields remain shadow metadata:
+     * queue_syncs only describe internal pass/batch edges, while external
+     * import/export/present synchronization endpoints are intentionally absent.
      */
     struct CompiledPlan {
         /** Stable topological order of semantic dependencies. */
         std::vector<PassHandle> topological_order{};
-        /** Current production order. It remains declaration-order and serial. */
+        /** Stable production order. CPU recording policy is described separately below. */
         std::vector<PassHandle> execution_order{};
         /** Minimal hazard, explicit, state, and ownership frontier without fake serial edges. */
         std::vector<CompiledEdge> edges{};
         /** Atomic subresource/range accesses with logical input/output versions. */
         std::vector<CompiledAccess>   accesses{};
         std::vector<CompiledResource> resources{};
-        /** Dependency-only waves for diagnostics. They are not yet an execution schedule. */
+        /** Semantic dependency waves; CPU recording groups apply their own edge taxonomy. */
         std::vector<CompiledWave> dependency_waves{};
+        /** Stable one-pass CPU recording batches with explicit thread-safety classification. */
+        std::vector<CompiledRecordingBatch> recording_batches{};
         /** Canonical state/memory/ownership decisions, prior to backend-specific lowering. */
         std::vector<CompiledBarrier> barriers{};
         /** Prospective multi-queue batches and their GPU wait/signal relationships. */
@@ -527,6 +564,7 @@ public:
             accesses.clear();
             resources.clear();
             dependency_waves.clear();
+            recording_batches.clear();
             barriers.clear();
             queue_batches.clear();
             queue_syncs.clear();
@@ -586,9 +624,32 @@ public:
         PassBuilder& Write(TokenHandle resource);
         PassBuilder& ReadWrite(TokenHandle resource);
 
+        /**
+         * Declares that a CPU callback observes only the resource identity and
+         * extends its logical graph lifetime. Reference does not itself own the
+         * physical object or declare a GPU content access, version, barrier, or
+         * queue dependency; the callback must capture an owning ref and record
+         * passes must still declare their real GPU reads.
+         */
+        PassBuilder& Reference(ResourceHandle resource);
+        PassBuilder& Reference(TextureHandle resource) {
+            return Reference(resource.Untyped());
+        }
+        PassBuilder& Reference(BufferHandle resource) {
+            return Reference(resource.Untyped());
+        }
+        PassBuilder& Reference(TokenHandle resource) {
+            return Reference(resource.Untyped());
+        }
+
         PassBuilder& DependsOn(PassHandle dependency);
         PassBuilder& SideEffect();
         PassBuilder& ExecuteOn(QueueRole queue, PipelineType pipeline);
+        PassBuilder& MainThread();
+        PassBuilder& CpuPrepare();
+        PassBuilder& ExternalControl();
+        PassBuilder& SerialRecord(uint32_t workload = 1);
+        PassBuilder& ParallelRecord(uint32_t workload = 1);
 
     private:
         PassBuilder(RenderGraph& graph, uint32_t pass_index) : graph(graph), pass_index(pass_index) {}
@@ -599,8 +660,22 @@ public:
         friend class RenderGraph;
     };
 
-    using SetupCallback   = std::function<void(PassBuilder&)>;
-    using ExecuteCallback = std::function<void()>;
+    struct ExecutedPassInfo {
+        PassHandle       handle{};
+        std::string_view name{};
+        ExecutionDomain domain{};
+        bool             side_effect{false};
+        PassExecutionClass execution_class = PassExecutionClass::MainThread;
+    };
+
+    using SetupCallback         = std::function<void(PassBuilder&)>;
+    using ExecuteCallback       = std::function<void()>;
+    using RecordCallback        = std::function<void(CommandList&)>;
+    using PassCompletedCallback = std::function<void(const ExecutedPassInfo&)>;
+    /** May attach submit metadata; CommandList and gate ownership are immutable. */
+    using RecordingSourceSetupCallback =
+        std::function<void(const ExecutedPassInfo&, RHIRecordingSource&)>;
+    using RecordingBatchPublisher = std::function<void(Array<RHIRecordingSource>&&)>;
 
     explicit RenderGraph(std::string_view name = "RenderGraph");
     RenderGraph(std::string_view name, QueueTopology topology);
@@ -670,12 +745,42 @@ public:
     );
 
     PassHandle AddPass(std::string_view name, const SetupCallback& setup, ExecuteCallback execute);
+    PassHandle AddRecordPass(
+        std::string_view     name,
+        const SetupCallback& setup,
+        RecordCallback       record,
+        PassExecutionClass   execution = PassExecutionClass::SerialRecord,
+        uint32_t             workload = 1
+    );
 
     /** Compiles declarations without emitting barriers or recording RHI commands. */
     bool Compile();
 
-    /** Executes callbacks synchronously and serially once in declaration order. */
+    /** Executes callbacks synchronously and serially once in compiled order. */
     bool Execute();
+
+    /**
+     * Executes callbacks serially and invokes the observer after each callback
+     * has completely returned. The observer can safely seal the commands just
+     * recorded by that pass without allowing GPU scopes to cross a submission.
+     */
+    bool Execute(const PassCompletedCallback& after_pass);
+
+    /**
+     * Executes legacy callbacks on the caller and explicit record callbacks on
+     * independently owned CommandLists. Contiguous eligible passes on one queue
+     * are dispatched together even when texture/buffer GPU hazards place them
+     * in different dependency waves: those hazards constrain submission, not
+     * immutable CPU command recording. Token hazards and explicit DependsOn
+     * edges remain CPU recording boundaries. Sources are registered with RHI
+     * in compiled order and joined before the next caller-thread pass.
+     */
+    bool ExecuteRecording(
+        const PassCompletedCallback&        after_main_thread_pass,
+        const RecordingSourceSetupCallback& configure_recording_source = {},
+        bool                                parallel_recording_enabled = true,
+        const RecordingBatchPublisher&      publish_recording_batch = {}
+    );
 
     [[nodiscard]] bool IsCompiled() const {
         return compiled;
@@ -737,10 +842,14 @@ private:
     struct PassDeclaration {
         std::string                    name{};
         std::vector<AccessDeclaration> accesses{};
+        std::vector<ResourceHandle>    references{};
         std::vector<PassHandle>        explicit_dependencies{};
         ExecuteCallback                execute{};
+        RecordCallback                 record{};
         ExecutionDomain               domain{};
         bool                           side_effect = false;
+        PassExecutionClass             execution_class = PassExecutionClass::MainThread;
+        uint32_t                       workload = 1;
     };
 
     ResourceHandle ImportInternal(
@@ -776,8 +885,14 @@ private:
     );
     bool MarkExported(ResourceHandle resource, bool whole_resource);
     void AddDependency(uint32_t pass_index, PassHandle dependency);
+    void AddReference(uint32_t pass_index, ResourceHandle resource);
     void MarkSideEffect(uint32_t pass_index);
     void SetExecutionDomain(uint32_t pass_index, QueueRole queue, PipelineType pipeline);
+    void SetPassExecutionClass(
+        uint32_t           pass_index,
+        PassExecutionClass execution_class,
+        uint32_t           workload
+    );
     bool InvalidateCompile();
     bool FailCompile(std::string message);
 

--- a/source/runtime/render/rendergraph/RenderGraph.h
+++ b/source/runtime/render/rendergraph/RenderGraph.h
@@ -512,6 +512,12 @@ public:
         QueueBinding            queue{};
         std::vector<PassHandle> passes{};
         /**
+         * An externally managed submit/synchronization scope. It is always a
+         * standalone batch so managed lowering cannot place commands or
+         * barriers across the external-control boundary.
+         */
+        bool                    external_control = false;
+        /**
          * Correlated split acquire/release placement hints. An index in pre/post never means that the
          * full CompiledBarrier should be emitted again; pass_barriers and prologue/epilogue remain the
          * canonical boundaries. Export transitions are deliberately epilogue-only.

--- a/source/runtime/render/rendergraph/RenderGraphCompiler.cpp
+++ b/source/runtime/render/rendergraph/RenderGraphCompiler.cpp
@@ -1430,13 +1430,28 @@ void RenderGraphCompiler::BuildQueuePlan() {
     std::vector<uint32_t> pass_to_batch(
         graph.passes.size(), RenderGraph::PassHandle::InvalidIndex
     );
+    bool force_new_managed_batch = false;
     for (const auto pass_handle : graph.compiled_plan.execution_order) {
         const auto& pass    = graph.passes[pass_handle.index];
         if (pass.execution_class == RenderGraph::PassExecutionClass::CpuPrepare) {
             continue;
         }
         const auto  binding = graph.queue_topology.Resolve(pass.domain.queue);
-        if (graph.compiled_plan.queue_batches.empty() ||
+        if (pass.execution_class == RenderGraph::PassExecutionClass::ExternalControl) {
+            const uint32_t batch_id =
+                static_cast<uint32_t>(graph.compiled_plan.queue_batches.size());
+            graph.compiled_plan.queue_batches.push_back(RenderGraph::CompiledQueueBatch{
+                .id               = batch_id,
+                .queue            = binding,
+                .passes           = {pass_handle},
+                .external_control = true,
+            });
+            pass_to_batch[pass_handle.index] = batch_id;
+            force_new_managed_batch          = true;
+            continue;
+        }
+        if (graph.compiled_plan.queue_batches.empty() || force_new_managed_batch ||
+            graph.compiled_plan.queue_batches.back().external_control ||
             graph.compiled_plan.queue_batches.back().queue.role != binding.role) {
             const uint32_t batch_id =
                 static_cast<uint32_t>(graph.compiled_plan.queue_batches.size());
@@ -1445,6 +1460,7 @@ void RenderGraphCompiler::BuildQueuePlan() {
                 .queue = binding,
             });
         }
+        force_new_managed_batch = false;
         auto& batch = graph.compiled_plan.queue_batches.back();
         batch.passes.push_back(pass_handle);
         pass_to_batch[pass_handle.index] = batch.id;

--- a/source/runtime/render/rendergraph/RenderGraphCompiler.cpp
+++ b/source/runtime/render/rendergraph/RenderGraphCompiler.cpp
@@ -248,6 +248,7 @@ bool RenderGraphCompiler::Compile() {
     AuditStatePlanCompleteness();
     BuildQueuePlan();
     BuildDependencyWaves();
+    BuildRecordingBatches();
     BuildLifetimes();
     graph.compiled = true;
     return true;
@@ -283,11 +284,47 @@ bool RenderGraphCompiler::NormalizeDeclarations() {
             return false;
         }
         const auto& pass = graph.passes[pass_index];
+        const bool has_execute = static_cast<bool>(pass.execute);
+        const bool has_record  = static_cast<bool>(pass.record);
+        if (has_execute == has_record) {
+            return Fail(
+                "pass '" + pass.name + "' must declare exactly one execute or record callback"
+            );
+        }
+        const bool caller_thread =
+            pass.execution_class == RenderGraph::PassExecutionClass::MainThread ||
+            pass.execution_class == RenderGraph::PassExecutionClass::CpuPrepare ||
+            pass.execution_class == RenderGraph::PassExecutionClass::ExternalControl;
+        if (has_execute && !caller_thread) {
+            return Fail(
+                "main-thread pass '" + pass.name + "' cannot use a command-recording class"
+            );
+        }
+        if (has_record && caller_thread) {
+            return Fail(
+                "record pass '" + pass.name + "' must use SerialRecord or ParallelRecordEligible"
+            );
+        }
+        if (pass.workload == 0) {
+            return Fail("pass '" + pass.name + "' has zero recording workload");
+        }
+        for (const auto reference : pass.references) {
+            if (!graph.IsValidResource(reference)) {
+                return Fail("pass '" + pass.name + "' has an invalid resource identity reference");
+            }
+        }
         for (const auto& access : pass.accesses) {
             if (!graph.IsValidResource(access.resource)) {
                 return Fail("pass '" + pass.name + "' references an invalid resource");
             }
             const auto&   resource = graph.resources[access.resource.index];
+            if (pass.execution_class == RenderGraph::PassExecutionClass::CpuPrepare &&
+                resource.kind != RenderGraph::ResourceKind::Token) {
+                return Fail(
+                    "cpu-prepare pass '" + pass.name +
+                    "' may only access token resources; use Reference for GPU resource identity"
+                );
+            }
             ResourceRange normalized{};
             if (!NormalizeRange(resource, access.range, normalized) ||
                 !ValidateAccessState(
@@ -1395,6 +1432,9 @@ void RenderGraphCompiler::BuildQueuePlan() {
     );
     for (const auto pass_handle : graph.compiled_plan.execution_order) {
         const auto& pass    = graph.passes[pass_handle.index];
+        if (pass.execution_class == RenderGraph::PassExecutionClass::CpuPrepare) {
+            continue;
+        }
         const auto  binding = graph.queue_topology.Resolve(pass.domain.queue);
         if (graph.compiled_plan.queue_batches.empty() ||
             graph.compiled_plan.queue_batches.back().queue.role != binding.role) {
@@ -1468,6 +1508,10 @@ void RenderGraphCompiler::BuildQueuePlan() {
         const auto& edge = graph.compiled_plan.edges[edge_index];
         const uint32_t signal_batch = pass_to_batch[edge.src.index];
         const uint32_t wait_batch   = pass_to_batch[edge.dst.index];
+        if (signal_batch == RenderGraph::PassHandle::InvalidIndex ||
+            wait_batch == RenderGraph::PassHandle::InvalidIndex) {
+            continue;
+        }
         if (signal_batch == wait_batch) {
             continue;
         }
@@ -1597,6 +1641,33 @@ void RenderGraphCompiler::BuildDependencyWaves() {
     }
 }
 
+void RenderGraphCompiler::BuildRecordingBatches() {
+    std::vector<uint32_t> pass_to_wave(
+        graph.passes.size(),
+        RenderGraph::PassHandle::InvalidIndex
+    );
+    for (uint32_t wave_index = 0; wave_index < graph.compiled_plan.dependency_waves.size();
+         ++wave_index) {
+        for (const auto pass : graph.compiled_plan.dependency_waves[wave_index].passes) {
+            pass_to_wave[pass.index] = wave_index;
+        }
+    }
+
+    graph.compiled_plan.recording_batches.reserve(graph.compiled_plan.execution_order.size());
+    for (const auto pass_handle : graph.compiled_plan.execution_order) {
+        const auto& pass = graph.passes[pass_handle.index];
+        const auto  id = static_cast<uint32_t>(graph.compiled_plan.recording_batches.size());
+        graph.compiled_plan.recording_batches.push_back(RenderGraph::CompiledRecordingBatch{
+            .id              = id,
+            .queue           = graph.queue_topology.Resolve(pass.domain.queue),
+            .passes          = {pass_handle},
+            .execution       = pass.execution_class,
+            .workload        = pass.workload,
+            .dependency_wave = pass_to_wave[pass_handle.index],
+        });
+    }
+}
+
 void RenderGraphCompiler::BuildLifetimes() {
     std::vector<uint32_t> execution_position(graph.passes.size(), RenderGraph::PassHandle::InvalidIndex);
     for (uint32_t position = 0; position < graph.compiled_plan.execution_order.size(); ++position) {
@@ -1610,6 +1681,17 @@ void RenderGraphCompiler::BuildLifetimes() {
         resource.last_use       = resource.last_use == RenderGraph::PassHandle::InvalidIndex ?
                                       position :
                                       std::max(resource.last_use, position);
+    }
+
+    for (uint32_t pass_index = 0; pass_index < graph.passes.size(); ++pass_index) {
+        const uint32_t position = execution_position[pass_index];
+        for (const auto reference : graph.passes[pass_index].references) {
+            auto& resource = graph.resources[reference.index];
+            resource.first_use = std::min(resource.first_use, position);
+            resource.last_use  = resource.last_use == RenderGraph::PassHandle::InvalidIndex ?
+                                     position :
+                                     std::max(resource.last_use, position);
+        }
     }
 
     graph.compiled_plan.resources.reserve(graph.resources.size());

--- a/source/runtime/render/rendergraph/RenderGraphCompiler.h
+++ b/source/runtime/render/rendergraph/RenderGraphCompiler.h
@@ -67,6 +67,7 @@ private:
     bool BuildExecutionOrder();
     void BuildQueuePlan();
     void BuildDependencyWaves();
+    void BuildRecordingBatches();
     void BuildLifetimes();
 
     bool NormalizeRange(

--- a/source/runtime/render/rhi/RHI.cpp
+++ b/source/runtime/render/rhi/RHI.cpp
@@ -6,6 +6,7 @@
 #include "log/LogSystem.h"
 #include "rhi/RHICommand.h"
 #include "rhi/RHICommon.h"
+#include "rhi/RHIExecutor.h"
 #include "rhi/RHIResource.h"
 #include "shader/ShaderResourceManager.h"
 #include "vulkan/VulkanDevice.h"
@@ -19,9 +20,17 @@ VulkanRHIConfig ResolveConfigAs(const DeviceInitInfo& _info) {
     assert(_info.rhi_type == ERHIType::Vulkan);
 
     VulkanRHIConfig config;
-    config.rhi_thread             = _info.rhi_thread;
-    config.rhi_bypass             = _info.rhi_bypass;
-    config.thread_profile_logging = _info.thread_profile_logging;
+    config.rhi_thread                   = _info.rhi_thread;
+    config.rhi_bypass                   = _info.rhi_bypass;
+    config.thread_profile_logging       = _info.thread_profile_logging;
+    config.parallel_recording           = _info.parallel_recording;
+    config.parallel_record_workers      = _info.parallel_record_workers;
+    config.parallel_record_verify       = _info.parallel_record_verify;
+    config.parallel_record_profile      = _info.parallel_record_profile;
+    config.parallel_record_min_work_units_per_job =
+        _info.parallel_record_min_work_units_per_job;
+    config.parallel_record_worker_throw_trigger =
+        _info.parallel_record_worker_throw_trigger;
     config.present_submit_fault_trigger = _info.vulkan_present_submit_fault_trigger;
 
     std::string_view api = _info.rhi_api_version;
@@ -71,9 +80,11 @@ void RenderDevice::Init(DeviceInitInfo&& _info) {
             break;
     }
     Get().rhi_type = _info.rhi_type;
+    RHIExecutor::StartUp();
     Get().impl->PostInit();
 }
 void RenderDevice::Dispose() {
+    RHIExecutor::ShutDown();
     Get().impl.reset();
 }
 CommandQueue& RenderDevice::GetCommandQueue(EQueueType _type) {

--- a/source/runtime/render/rhi/RHI.h
+++ b/source/runtime/render/rhi/RHI.h
@@ -37,9 +37,15 @@ struct DeviceInitInfo {
     ERHIType         rhi_type;
     std::string_view name;
     std::string_view rhi_api_version;
-    bool             rhi_thread = false;
-    bool             rhi_bypass = true;
-    bool             thread_profile_logging = false;
+    bool             rhi_thread                          = false;
+    bool             rhi_bypass                          = true;
+    bool             thread_profile_logging              = false;
+    bool             parallel_recording                  = false;
+    uint32_t         parallel_record_workers              = 0;
+    bool             parallel_record_verify              = false;
+    bool             parallel_record_profile             = false;
+    uint32_t         parallel_record_min_work_units_per_job = 64;
+    uint64_t         parallel_record_worker_throw_trigger = 0;
     uint64_t         vulkan_present_submit_fault_trigger = 0;
 };
 namespace Moer::Render {

--- a/source/runtime/render/rhi/RHIBindlessUpdateLifecycle.h
+++ b/source/runtime/render/rhi/RHIBindlessUpdateLifecycle.h
@@ -1,0 +1,97 @@
+#pragma once
+
+#include <cstdint>
+#include <limits>
+
+namespace Moer::Render {
+
+enum class BindlessUpdateSlotState : std::uint8_t {
+    Stale,
+    Original,
+    ClaimedByCommand,
+};
+
+enum class BindlessUpdateFinalizationAction : std::uint8_t {
+    Ignore,
+    Retire,
+    Restore,
+};
+
+// A bindless mutation owns two slots: one entry in the shader-visible handle
+// array and one entry in the typed descriptor array. Treat the pair as one
+// lifecycle unit so an old command can never act on only half of a reused
+// binding.
+constexpr BindlessUpdateSlotState ClassifyBindlessUpdateSlot(
+    std::uint64_t _current_array_generation,
+    std::uint64_t _current_typed_generation,
+    std::uint64_t _array_claim_token,
+    std::uint64_t _typed_claim_token,
+    std::uint64_t _command_array_generation,
+    std::uint64_t _command_typed_generation,
+    std::uint64_t _command_token
+) {
+    if (_command_token == 0) {
+        return BindlessUpdateSlotState::Stale;
+    }
+
+    if (_current_array_generation == _command_array_generation &&
+        _current_typed_generation == _command_typed_generation &&
+        _array_claim_token == 0 && _typed_claim_token == 0) {
+        return BindlessUpdateSlotState::Original;
+    }
+
+    if (_command_array_generation != std::numeric_limits<std::uint64_t>::max() &&
+        _command_typed_generation != std::numeric_limits<std::uint64_t>::max() &&
+        _current_array_generation == _command_array_generation + 1 &&
+        _current_typed_generation == _command_typed_generation + 1 &&
+        _array_claim_token == _command_token && _typed_claim_token == _command_token) {
+        return BindlessUpdateSlotState::ClaimedByCommand;
+    }
+
+    return BindlessUpdateSlotState::Stale;
+}
+
+constexpr BindlessUpdateFinalizationAction GetBindlessUpdateFinalizationAction(
+    BindlessUpdateSlotState _state,
+    bool                    _is_free,
+    bool                    _gpu_update_succeeded
+) {
+    if (_state == BindlessUpdateSlotState::Stale) {
+        return BindlessUpdateFinalizationAction::Ignore;
+    }
+    if (_gpu_update_succeeded) {
+        return _is_free ? BindlessUpdateFinalizationAction::Retire
+                        : BindlessUpdateFinalizationAction::Ignore;
+    }
+    return _is_free ? BindlessUpdateFinalizationAction::Restore
+                    : BindlessUpdateFinalizationAction::Retire;
+}
+
+constexpr bool RollbackBindlessUpdateSlotClaim(
+    std::uint64_t& _current_array_generation,
+    std::uint64_t& _current_typed_generation,
+    std::uint64_t& _array_claim_token,
+    std::uint64_t& _typed_claim_token,
+    std::uint64_t  _command_array_generation,
+    std::uint64_t  _command_typed_generation,
+    std::uint64_t  _command_token
+) {
+    if (ClassifyBindlessUpdateSlot(
+            _current_array_generation,
+            _current_typed_generation,
+            _array_claim_token,
+            _typed_claim_token,
+            _command_array_generation,
+            _command_typed_generation,
+            _command_token
+        ) != BindlessUpdateSlotState::ClaimedByCommand) {
+        return false;
+    }
+    _current_array_generation = _command_array_generation;
+    _current_typed_generation = _command_typed_generation;
+    _array_claim_token         = 0;
+    _typed_claim_token         = 0;
+    return true;
+}
+
+} // namespace Moer::Render

--- a/source/runtime/render/rhi/RHICommand.h
+++ b/source/runtime/render/rhi/RHICommand.h
@@ -10,6 +10,7 @@
 #include "misc/Traits.h"
 #include "rhi/RHICommon.h"
 #include "rhi/RHIResource.h"
+#include "rhi/RHISubmissionTopology.h"
 #include "shader/ShaderPipeline.h"
 #include <array>
 #include <chrono>
@@ -251,17 +252,36 @@ struct DispatchMeshData {
         return DispatchMeshData{IndirectDrawParam{_buffer, _count_buffer, _max_cnt, _stride}};
     }
 };
+
+// A normal TickProfiling submit owns a complete profiler frame.  Upper-level
+// submission runtimes may instead split that frame across several immutable
+// command sources while preserving one query-pool/reset/advance transaction.
+enum class ERHIProfilingPhase : uint8 {
+    Disabled,
+    Complete,
+    Begin,
+    Continue,
+    End,
+};
+
 struct CmdSubmit {
     Array<UniquePtr<Command>>        cmds;
     Array<std::function<void(void)>> callbacks;
     Array<std::function<void(void)>> success_callbacks;
     TCachedArgArray                  cached_args;
+    Array<RHISubmitSegment>          segments;
 
     Array<WaitEvent>   wait_events;
     Array<SignalEvent> signal_events;
     bool               b_sync{false}; //force sync queue timeline
+    // Kept as a compatibility bit for code which treats profiling as a submit
+    // capability.  profiling_phase is authoritative for split frames.
     bool               b_tick_profiling{false};
+    ERHIProfilingPhase profiling_phase{ERHIProfilingPhase::Disabled};
     bool               b_delete_resources{false};
+    ERHITranslateExecutionClass translate_execution_class{
+        ERHITranslateExecutionClass::Parallel
+    };
     std::string        debug_label;
     float4             debug_label_color = GpuMarkerPalette::Frame();
 
@@ -280,6 +300,11 @@ struct CmdSubmit {
         return std::move(*this);
     }
 
+    CmdSubmit&& SetTranslateExecutionClass(ERHITranslateExecutionClass _execution_class) {
+        translate_execution_class = _execution_class;
+        return std::move(*this);
+    }
+
     CmdSubmit&& DeleteResources() {
         b_delete_resources = true;
         return std::move(*this);
@@ -287,7 +312,37 @@ struct CmdSubmit {
 
     CmdSubmit&& TickProfiling() {
         b_tick_profiling = true;
+        profiling_phase  = ERHIProfilingPhase::Complete;
         return std::move(*this);
+    }
+
+    CmdSubmit&& SetProfilingPhase(ERHIProfilingPhase _phase) {
+        profiling_phase  = _phase;
+        b_tick_profiling = _phase != ERHIProfilingPhase::Disabled;
+        return std::move(*this);
+    }
+
+    ERHIProfilingPhase ProfilingPhase() const noexcept {
+        // Preserve Complete semantics for any legacy producer which still
+        // writes the compatibility bit directly.
+        return profiling_phase != ERHIProfilingPhase::Disabled ?
+                   profiling_phase :
+               b_tick_profiling ? ERHIProfilingPhase::Complete :
+                                  ERHIProfilingPhase::Disabled;
+    }
+
+    bool EmitsProfilingQueries() const noexcept {
+        return ProfilingPhase() != ERHIProfilingPhase::Disabled;
+    }
+
+    bool BeginsProfilingFrame() const noexcept {
+        const ERHIProfilingPhase phase = ProfilingPhase();
+        return phase == ERHIProfilingPhase::Complete || phase == ERHIProfilingPhase::Begin;
+    }
+
+    bool EndsProfilingFrame() const noexcept {
+        const ERHIProfilingPhase phase = ProfilingPhase();
+        return phase == ERHIProfilingPhase::Complete || phase == ERHIProfilingPhase::End;
     }
 
     CmdSubmit&& DebugLabel(
@@ -306,9 +361,12 @@ struct CmdSubmit {
         wait_events        = std::move(_other.wait_events);
         signal_events      = std::move(_other.signal_events);
         cached_args        = std::move(_other.cached_args);
+        segments           = std::move(_other.segments);
         b_sync             = _other.b_sync;
         b_tick_profiling   = _other.b_tick_profiling;
+        profiling_phase    = _other.profiling_phase;
         b_delete_resources = _other.b_delete_resources;
+        translate_execution_class = _other.translate_execution_class;
         debug_label        = std::move(_other.debug_label);
         debug_label_color  = _other.debug_label_color;
     }
@@ -320,9 +378,12 @@ struct CmdSubmit {
         wait_events        = std::move(_other.wait_events);
         signal_events      = std::move(_other.signal_events);
         cached_args        = std::move(_other.cached_args);
+        segments           = std::move(_other.segments);
         b_sync             = _other.b_sync;
         b_tick_profiling   = _other.b_tick_profiling;
+        profiling_phase    = _other.profiling_phase;
         b_delete_resources = _other.b_delete_resources;
+        translate_execution_class = _other.translate_execution_class;
         debug_label        = std::move(_other.debug_label);
         debug_label_color  = _other.debug_label_color;
         return *this;
@@ -1008,6 +1069,7 @@ public:
 
 public:
     RENDER_API CommandList();
+    RENDER_API explicit CommandList(EQueueType _queue_type);
     class Impl;
 
     template<is_shader_pipeline TGfxPso, typename... TArgs>
@@ -1269,9 +1331,27 @@ public:
 
     RENDER_API ArrayArgReference RegisterArgs(ArrayArguments&& _args);
 
+    // Terminal rejection-only ownership path. The producer must have stopped
+    // mutating this CommandList before it is called. It destructively drops all
+    // partial GPU commands, cached arguments, success callbacks and unclosed
+    // scopes, returning only ordinary callbacks that must run for CPU/resource
+    // cleanup. Unlike Submit(), this never creates a GPU-submittable payload.
+    RENDER_API Array<std::function<void()>> DrainOrdinaryCallbacksForRejection();
+
     RENDER_API CmdSubmit Submit();
 
     RENDER_API bool IsEmpty() const;
+
+    EQueueType GetQueueType() const noexcept {
+        return queue_type;
+    }
+
+    CommandList& SetTranslateExecutionClass(
+        ERHITranslateExecutionClass _execution_class
+    ) noexcept {
+        translate_execution_class = _execution_class;
+        return *this;
+    }
 
 private:
     friend DrawDispatcher;
@@ -1346,6 +1426,10 @@ private:
     Array<std::function<void()>> callbacks;
     Array<std::function<void()>> success_callbacks;
     TCachedArgArray              cached_args;
+    EQueueType                   queue_type{EQueueType::Graphics};
+    ERHITranslateExecutionClass  translate_execution_class{
+        ERHITranslateExecutionClass::Parallel
+    };
     struct ScopeState {
         std::string name;
         float4      color;

--- a/source/runtime/render/rhi/RHICommandList.cpp
+++ b/source/runtime/render/rhi/RHICommandList.cpp
@@ -30,7 +30,14 @@ void CommandQueue::Test() {
     draw_dispatcher.Draw(Rect2D{}, std::move(draw_data), ColorAttachment{nullptr});
 }
 
-CommandList::CommandList() {}
+CommandList::CommandList() : CommandList(EQueueType::Graphics) {}
+
+CommandList::CommandList(EQueueType _queue_type) : queue_type(_queue_type) {
+    assert(
+        _queue_type == EQueueType::Graphics || _queue_type == EQueueType::Compute ||
+        _queue_type == EQueueType::Copy
+    );
+}
 // void CommandList::ArgSetter::SetBuffer(uint64 _index, BufferView _buffer) {
 //     auto idx          = handle.GetBindingIdx(_index);
 //     temp_args[_index] = _buffer;
@@ -139,11 +146,45 @@ CmdSubmit CommandList::Submit() {
         std::move(success_callbacks),
         std::move(cached_args)
     );
+    const bool has_submit_side_effects =
+        !submit.callbacks.empty() || !submit.success_callbacks.empty() ||
+        !submit.wait_events.empty() || !submit.signal_events.empty() ||
+        submit.b_delete_resources;
+    if (!submit.cmds.empty() || has_submit_side_effects) {
+        submit.segments.emplace_back(RHISubmitSegment{
+            .queue = queue_type,
+            .begin = 0,
+            .end   = submit.cmds.size(),
+        });
+    }
+    submit.translate_execution_class = translate_execution_class;
     commands.clear();
     callbacks.clear();
     success_callbacks.clear();
     timestamp_scope_names.clear();
+    translate_execution_class = ERHITranslateExecutionClass::Parallel;
     return std::move(submit);
+}
+
+Array<std::function<void()>> CommandList::DrainOrdinaryCallbacksForRejection() {
+    Array<std::function<void()>> cleanup_callbacks = std::move(callbacks);
+
+    // This is deliberately not implemented in terms of Submit(). A failed
+    // producer may leave a partially-built barrier or an unmatched marker;
+    // neither is executable, and Submit() correctly asserts on that shape in
+    // Debug builds. Destroying the command payload releases its strong refs
+    // without manufacturing end-marker commands or submission segments.
+    commands.clear();
+    callbacks.clear();
+    success_callbacks.clear();
+    cached_args.clear();
+    current_barriers = nullptr;
+    while (!scope_stack.empty()) {
+        scope_stack.pop();
+    }
+    timestamp_scope_names.clear();
+    translate_execution_class = ERHITranslateExecutionClass::Parallel;
+    return cleanup_callbacks;
 }
 
 bool CommandList::IsEmpty() const {

--- a/source/runtime/render/rhi/RHIExecutor.cpp
+++ b/source/runtime/render/rhi/RHIExecutor.cpp
@@ -109,14 +109,64 @@ void FinalizeCancelledRecordingSources(
     std::string_view             _reason
 ) {
     // A source protected by an incomplete recording gate must remain opaque:
-    // even reading IsEmpty(), let alone calling Submit(), races its producer.
-    // Cancellation therefore only releases the executor's shared ownership. No
-    // submit callback (ordinary or success-only) is visible until the gate has
-    // completed and a CmdSubmit has actually been materialized.
+    // even reading IsEmpty(), let alone draining callbacks, races its producer.
+    // A terminal gate, however, is the ownership handoff point and its ordinary
+    // callbacks still own CPU/resource cleanup even when shutdown cancels the
+    // FIFO before the source can be materialized. Success-only callbacks must
+    // never run because no GPU submission was published.
+    size_t terminal_source_count = 0;
+    size_t opaque_source_count   = 0;
+    size_t cleanup_callback_count = 0;
+    for (RHIRecordingSource& source : _sources) {
+        const bool terminal =
+            source.completion &&
+            source.completion->Status() != ERHIRecordingStatus::Pending;
+        if (!terminal) {
+            ++opaque_source_count;
+            continue;
+        }
+
+        ++terminal_source_count;
+        if (!source.command_list) {
+            continue;
+        }
+        try {
+            auto source_callbacks =
+                source.command_list->DrainOrdinaryCallbacksForRejection();
+            cleanup_callback_count += source_callbacks.size();
+            for (std::function<void()>& callback : source_callbacks) {
+                if (!callback) {
+                    continue;
+                }
+                try {
+                    callback();
+                } catch (const std::exception& exception) {
+                    LOG_ERROR(
+                        "[RHIExecutor] cancelled-recording cleanup callback threw: {}",
+                        exception.what()
+                    );
+                } catch (...) {
+                    LOG_ERROR("[RHIExecutor] cancelled-recording cleanup callback threw");
+                }
+            }
+        } catch (const std::exception& exception) {
+            LOG_ERROR(
+                "[RHIExecutor] failed to drain cancelled recording source cleanup: {}",
+                exception.what()
+            );
+        } catch (...) {
+            LOG_ERROR("[RHIExecutor] failed to drain cancelled recording source cleanup");
+        }
+    }
+
     LOG_WARNING(
-        "[RHIExecutor] rejected {} recording source(s): {}",
+        "[RHIExecutor] rejected {} recording source(s): {}; "
+        "terminal_sources={} opaque_sources={} cleanup_callbacks={}",
         _sources.size(),
-        _reason
+        _reason,
+        terminal_source_count,
+        opaque_source_count,
+        cleanup_callback_count
     );
     _sources.clear();
 }

--- a/source/runtime/render/rhi/RHIExecutor.cpp
+++ b/source/runtime/render/rhi/RHIExecutor.cpp
@@ -1,0 +1,959 @@
+#include "rhi/RHIExecutor.h"
+
+#include "log/LogSystem.h"
+#include "rhi/RHI.h"
+#include "vulkan/VulkanSubmissionExecutor.h"
+
+#include <algorithm>
+#include <exception>
+#include <optional>
+#include <stdexcept>
+#include <string_view>
+#include <utility>
+
+namespace Moer::Render {
+namespace {
+
+template<typename F>
+class ScopeExit {
+public:
+    explicit ScopeExit(F&& _callback) : callback(std::forward<F>(_callback)) {}
+    ~ScopeExit() noexcept {
+        callback();
+    }
+
+    ScopeExit(const ScopeExit&)            = delete;
+    ScopeExit& operator=(const ScopeExit&) = delete;
+
+private:
+    F callback;
+};
+
+GraphEventRef MakeCompletedBackendEvent() {
+    GraphEventRef event = GraphEvent::CreateGraphEvent();
+    event->TryUnlockSubsequents(EThread::UNKNOWN_THREAD);
+    return event;
+}
+
+bool SubmitHasWork(const CmdSubmit& _submit) {
+    return !_submit.cmds.empty() || !_submit.callbacks.empty() ||
+           !_submit.success_callbacks.empty() || !_submit.wait_events.empty() ||
+           !_submit.signal_events.empty() || _submit.b_sync ||
+           _submit.b_tick_profiling || _submit.b_delete_resources;
+}
+
+bool IsSubmissionQueue(EQueueType _queue) {
+    return _queue == EQueueType::Graphics || _queue == EQueueType::Compute ||
+           _queue == EQueueType::Copy;
+}
+
+bool BatchHasWork(const RHIBackendSubmissionBatch& _batch) {
+    return !_batch.submits.empty() || _batch.present.has_value();
+}
+
+void ResolveRejectedPresent(RHIPresentRequest* _present) {
+    if (_present != nullptr && _present->receipt) {
+        _present->receipt->Resolve(false);
+    }
+}
+
+// A frontend rejection can only happen for invalid input or after the executor
+// has stopped accepting work.  Normal completion callbacks still own cleanup
+// responsibilities, while success callbacks must never run for work that did
+// not reach a GPU queue.  Keep this path backend-neutral and, importantly, run
+// user code only after all executor locks have been released.
+void FinalizeRejectedSubmissions(
+    Array<RHIBackendSubmissionBatchEntry>&& _submits,
+    std::string_view                         _reason
+) {
+    size_t callback_count       = 0;
+    size_t success_callback_cnt = 0;
+    size_t signal_count         = 0;
+    for (const RHIBackendSubmissionBatchEntry& entry : _submits) {
+        callback_count += entry.submit.callbacks.size();
+        success_callback_cnt += entry.submit.success_callbacks.size();
+        signal_count += entry.submit.signal_events.size();
+    }
+
+    LOG_ERROR(
+        "[RHIExecutor] rejected {} frontend submit(s): {}; callbacks={} "
+        "success_callbacks_skipped={} signal_events_unpublished={}",
+        _submits.size(),
+        _reason,
+        callback_count,
+        success_callback_cnt,
+        signal_count
+    );
+
+    for (RHIBackendSubmissionBatchEntry& entry : _submits) {
+        for (std::function<void()>& callback : entry.submit.callbacks) {
+            if (!callback) {
+                continue;
+            }
+            try {
+                callback();
+            } catch (const std::exception& exception) {
+                LOG_ERROR(
+                    "[RHIExecutor] rejected-submit completion callback threw: {}",
+                    exception.what()
+                );
+            } catch (...) {
+                LOG_ERROR("[RHIExecutor] rejected-submit completion callback threw");
+            }
+        }
+    }
+}
+
+void FinalizeCancelledRecordingSources(
+    Array<RHIRecordingSource>&& _sources,
+    std::string_view             _reason
+) {
+    // A source protected by an incomplete recording gate must remain opaque:
+    // even reading IsEmpty(), let alone calling Submit(), races its producer.
+    // Cancellation therefore only releases the executor's shared ownership. No
+    // submit callback (ordinary or success-only) is visible until the gate has
+    // completed and a CmdSubmit has actually been materialized.
+    LOG_WARNING(
+        "[RHIExecutor] rejected {} recording source(s): {}",
+        _sources.size(),
+        _reason
+    );
+    _sources.clear();
+}
+
+void FinalizeFailedRecordingSources(
+    Array<RHIRecordingSource>&& _sources,
+    std::string_view             _reason
+) {
+    // Reject is emitted only after every producer gate is terminal. This is
+    // the ownership point at which failed/partial CommandLists are immutable
+    // and may be destructively drained for their ordinary cleanup callbacks.
+    // DrainOrdinaryCallbacksForRejection produces no CmdSubmit, drops success
+    // callbacks, and guarantees that no partial commands reach a backend.
+    const bool all_terminal = std::all_of(
+        _sources.begin(),
+        _sources.end(),
+        [](const RHIRecordingSource& _source) {
+            return _source.completion &&
+                   _source.completion->Status() != ERHIRecordingStatus::Pending;
+        }
+    );
+    if (!all_terminal) {
+        LOG_ERROR(
+            "[RHIExecutor] failed recording group resolved before every producer became terminal"
+        );
+        FinalizeCancelledRecordingSources(
+            std::move(_sources),
+            "failed recording group still has a mutable producer"
+        );
+        return;
+    }
+
+    const size_t source_count = _sources.size();
+    size_t       cleanup_callback_count = 0;
+    for (RHIRecordingSource& source : _sources) {
+        if (!source.command_list) {
+            continue;
+        }
+        try {
+            auto source_callbacks =
+                source.command_list->DrainOrdinaryCallbacksForRejection();
+            cleanup_callback_count += source_callbacks.size();
+            for (std::function<void()>& callback : source_callbacks) {
+                if (!callback) {
+                    continue;
+                }
+                try {
+                    callback();
+                } catch (const std::exception& exception) {
+                    LOG_ERROR(
+                        "[RHIExecutor] rejected-recording cleanup callback threw: {}",
+                        exception.what()
+                    );
+                } catch (...) {
+                    LOG_ERROR("[RHIExecutor] rejected-recording cleanup callback threw");
+                }
+            }
+        } catch (const std::exception& exception) {
+            LOG_ERROR(
+                "[RHIExecutor] failed to drain rejected recording source cleanup: {}",
+                exception.what()
+            );
+        } catch (...) {
+            LOG_ERROR("[RHIExecutor] failed to drain rejected recording source cleanup");
+        }
+    }
+    _sources.clear();
+    LOG_ERROR(
+        "[RHIExecutor] rejected {} completed recording source(s): {}; cleanup_callbacks={}",
+        source_count,
+        _reason,
+        cleanup_callback_count
+    );
+}
+
+struct ReadySubmissionPayload {
+    Array<RHIBackendSubmissionBatchEntry> submits{};
+    ERHIExecSubmitFlags                    flags{ERHIExecSubmitFlags::FlushGPU};
+    std::optional<RHIPresentRequest>       present{};
+};
+
+struct RecordingSubmissionPayload {
+    Array<RHIRecordingSource> sources{};
+    ERHIExecSubmitFlags       flags{ERHIExecSubmitFlags::FlushGPU};
+};
+
+class HandoffSyncCompletion final {
+public:
+    void Signal() noexcept {
+        {
+            std::lock_guard lock(mutex);
+            complete = true;
+        }
+        cv.notify_all();
+    }
+
+    void Wait() noexcept {
+        std::unique_lock lock(mutex);
+        cv.wait(lock, [this] { return complete; });
+    }
+
+private:
+    std::mutex              mutex;
+    std::condition_variable cv;
+    bool                    complete{false};
+};
+
+// D3D12 has not adopted the Vulkan submission runtime yet. Keep its old queue
+// ownership path isolated instead of weakening the Vulkan topology contract.
+class LegacyQueueBackendExecutor final : public RHIBackendExecutor {
+public:
+    void Enqueue(RHIBackendSubmissionBatch&& _batch) override {
+        std::optional<EQueueType> last_queue{};
+        uint64                    ordered_copy_timeline = 0;
+        {
+            std::lock_guard lock(state_mutex);
+            last_queue             = ordered_tail_queue;
+            ordered_copy_timeline = ordered_tail_copy_timeline;
+        }
+
+        for (RHIBackendSubmissionBatchEntry& entry : _batch.submits) {
+            if (!SubmitHasWork(entry.submit)) {
+                continue;
+            }
+            if (last_queue.has_value() && *last_queue != entry.queue) {
+                WaitForQueue(*last_queue, ordered_copy_timeline);
+            }
+            switch (entry.queue) {
+                case EQueueType::Graphics:
+                case EQueueType::Compute:
+                    RenderDevice::Get().GetCommandQueue(entry.queue).Execute(std::move(entry.submit));
+                    ordered_copy_timeline = 0;
+                    break;
+                case EQueueType::Copy: {
+                    const IOWaitEvt completion =
+                        RenderDevice::Get().GetCopyQueue().Execute(std::move(entry.submit));
+                    ordered_copy_timeline = completion.timeline;
+                    std::lock_guard lock(state_mutex);
+                    last_copy_timeline = std::max(last_copy_timeline, completion.timeline);
+                    break;
+                }
+                case EQueueType::Ignore:
+                case EQueueType::Num:
+                default:
+                    LOG_ERROR(
+                        "[RHIExecutor] batch {} rejected invalid queue {}",
+                        _batch.sequence,
+                        static_cast<uint32>(entry.queue)
+                    );
+                    assert(false && "RHI backend batch contains an invalid queue");
+                    continue;
+            }
+            {
+                std::lock_guard lock(state_mutex);
+                used_queues[static_cast<size_t>(entry.queue)] = true;
+            }
+            last_queue = entry.queue;
+        }
+
+        if (_batch.present.has_value()) {
+            if (last_queue.has_value() && *last_queue != EQueueType::Graphics) {
+                WaitForQueue(*last_queue, ordered_copy_timeline);
+            }
+            RHIPresentRequest& present = *_batch.present;
+            RenderDevice::Get().GetCommandQueue(EQueueType::Graphics)
+                .Present(
+                    std::move(present.swapchain),
+                    present.source,
+                    std::move(present.receipt)
+                );
+            last_queue             = EQueueType::Graphics;
+            ordered_copy_timeline = 0;
+            std::lock_guard lock(state_mutex);
+            used_queues[static_cast<size_t>(EQueueType::Graphics)] = true;
+            present_seen = true;
+        }
+
+        {
+            std::lock_guard lock(state_mutex);
+            ordered_tail_queue         = last_queue;
+            ordered_tail_copy_timeline = ordered_copy_timeline;
+        }
+    }
+
+    GraphEventRef Sync(ERHISyncDepth _depth) override {
+        StaticArray<bool, static_cast<size_t>(EQueueType::Num)> queues{};
+        uint64 copy_timeline = 0;
+        {
+            std::lock_guard lock(state_mutex);
+            queues       = used_queues;
+            copy_timeline = last_copy_timeline;
+        }
+
+        if (queues[static_cast<size_t>(EQueueType::Graphics)] ||
+            _depth == ERHISyncDepth::Present) {
+            RenderDevice::Get().GetCommandQueue(EQueueType::Graphics).Sync();
+        }
+        if (queues[static_cast<size_t>(EQueueType::Compute)]) {
+            RenderDevice::Get().GetCommandQueue(EQueueType::Compute).Sync();
+        }
+        if (copy_timeline != 0) {
+            RenderDevice::Get().GetCopyQueue().Sync(copy_timeline);
+        }
+        return MakeCompletedBackendEvent();
+    }
+
+    void Flush(ERHIFlushDepth) override {
+        // Queue::Execute has already crossed into the existing RHI FIFO.
+    }
+
+    void ShutDown() override {
+        GraphEventRef completion = Sync(ERHISyncDepth::Present);
+        if (completion) {
+            completion->Wait(EThread::UNKNOWN_THREAD);
+        }
+    }
+
+private:
+    static void WaitForQueue(EQueueType _queue, uint64 _copy_timeline) {
+        switch (_queue) {
+            case EQueueType::Graphics:
+            case EQueueType::Compute:
+                RenderDevice::Get().GetCommandQueue(_queue).Sync();
+                return;
+            case EQueueType::Copy:
+                if (_copy_timeline != 0) {
+                    RenderDevice::Get().GetCopyQueue().Sync(_copy_timeline);
+                }
+                return;
+            case EQueueType::Ignore:
+            case EQueueType::Num:
+            default:
+                assert(false && "Legacy RHI executor has an invalid ordered tail queue");
+                return;
+        }
+    }
+
+    std::mutex state_mutex;
+    StaticArray<bool, static_cast<size_t>(EQueueType::Num)> used_queues{};
+    uint64                    last_copy_timeline{0};
+    bool                      present_seen{false};
+    std::optional<EQueueType> ordered_tail_queue{};
+    uint64                    ordered_tail_copy_timeline{0};
+};
+
+std::shared_ptr<RHIBackendExecutor> CreateBackendExecutor() {
+    switch (RenderDevice::Get().GetRHIType()) {
+        case ERHIType::Vulkan:
+            return std::make_shared<VulkanSubmissionExecutor>();
+        case ERHIType::D3D12:
+            LOG_WARNING(
+                "[RHIExecutor] D3D12 uses the legacy queue adapter; upper Vulkan topology is unavailable"
+            );
+            return std::make_shared<LegacyQueueBackendExecutor>();
+    }
+    LOG_ERROR("[RHIExecutor] unsupported RHI type");
+    assert(false && "Unsupported RHI type");
+    return {};
+}
+
+RHISubmissionTopologyPlan BuildBatchTopology(const RHIBackendSubmissionBatch& _batch) {
+    Array<RHISourceSubmitDescription> descriptions{};
+    descriptions.reserve(_batch.submits.size());
+    for (const RHIBackendSubmissionBatchEntry& entry : _batch.submits) {
+        descriptions.emplace_back(RHISourceSubmitDescription{
+            .root_queue       = entry.queue,
+            .command_count    = entry.submit.cmds.size(),
+            .segments         = entry.submit.segments,
+            .execution_class = entry.submit.translate_execution_class,
+            .has_side_effects = SubmitHasWork(entry.submit),
+        });
+    }
+    return BuildRHISubmissionTopology(descriptions, _batch.sequence);
+}
+
+} // namespace
+
+RHIExecutor& RHIExecutor::Get() {
+    static RHIExecutor executor;
+    return executor;
+}
+
+void RHIExecutor::StartUp() {
+    RHIExecutor& executor = Get();
+    std::unique_lock submit_lock(executor.submit_mutex);
+    executor.lifecycle_cv.wait(submit_lock, [&executor] {
+        return executor.lifecycle_state != ELifecycleState::Stopping;
+    });
+    if (executor.lifecycle_state == ELifecycleState::Running) {
+        LOG_WARNING("[RHIExecutor] duplicate StartUp ignored");
+        return;
+    }
+    assert(!executor.backend_executor && "RHIExecutor backend survived device shutdown");
+    assert(executor.pending_submits.empty() && !executor.pending_present.has_value());
+    assert(executor.active_sync_calls == 0 && "RHIExecutor sync survived device shutdown");
+    executor.next_batch_sequence = 1;
+    executor.recording_handoff.Start();
+    executor.lifecycle_state     = ELifecycleState::Running;
+}
+
+std::shared_ptr<RHIBackendExecutor> RHIExecutor::GetBackendExecutorLocked() {
+    if (!backend_executor) {
+        backend_executor = CreateBackendExecutor();
+    }
+    return backend_executor;
+}
+
+RHIBackendSubmissionBatch RHIExecutor::TakePendingBatchLocked() {
+    RHIBackendSubmissionBatch batch{};
+    batch.submits  = std::move(pending_submits);
+    batch.present  = std::move(pending_present);
+    pending_submits.clear();
+    pending_present.reset();
+    if (!batch.submits.empty() || batch.present.has_value()) {
+        batch.sequence = next_batch_sequence++;
+    }
+    return batch;
+}
+
+void RHIExecutor::Submit(
+    EQueueType          _queue,
+    CmdSubmit&&         _submit,
+    ERHIExecSubmitFlags _flags,
+    RHIPresentRequest*  _present
+) {
+    Array<RHIBackendSubmissionBatchEntry> submits;
+    submits.emplace_back(_queue, std::move(_submit));
+    Submit(std::move(submits), _flags, _present);
+}
+
+void RHIExecutor::Submit(
+    Array<RHIBackendSubmissionBatchEntry>&& _submits,
+    ERHIExecSubmitFlags                      _flags,
+    RHIPresentRequest*                       _present
+) {
+    const bool present_valid = _present == nullptr ||
+                               (_present->swapchain && _present->source.texture != nullptr);
+    const bool queues_valid = std::all_of(
+        _submits.begin(),
+        _submits.end(),
+        [](const RHIBackendSubmissionBatchEntry& entry) {
+            return IsSubmissionQueue(entry.queue);
+        }
+    );
+    if (!present_valid || !queues_valid) {
+        ResolveRejectedPresent(_present);
+        FinalizeRejectedSubmissions(
+            std::move(_submits),
+            present_valid ? "invalid queue" : "invalid Present request"
+        );
+        return;
+    }
+
+    auto payload     = std::make_shared<ReadySubmissionPayload>();
+    payload->submits = std::move(_submits);
+    payload->flags   = _flags;
+    if (_present != nullptr) {
+        payload->present.emplace(std::move(*_present));
+    }
+
+    recording_handoff.RouteReady(RHIExecutorRecordingHandoffWork{
+        .prerequisites = {},
+        .resolve = [this, payload](ERHIRecordingHandoffResult _result) mutable {
+            RHIPresentRequest* present = payload->present.has_value() ?
+                                             &*payload->present :
+                                             nullptr;
+            if (_result != ERHIRecordingHandoffResult::Consume) {
+                ResolveRejectedPresent(present);
+                FinalizeRejectedSubmissions(
+                    std::move(payload->submits),
+                    "recording handoff is stopped"
+                );
+                return;
+            }
+            SubmitReady(std::move(payload->submits), payload->flags, present);
+        },
+    });
+}
+
+void RHIExecutor::SubmitReady(
+    Array<RHIBackendSubmissionBatchEntry>&& _submits,
+    ERHIExecSubmitFlags                      _flags,
+    RHIPresentRequest*                       _present
+) {
+
+    // A Present is a batch terminator.  Publish it while holding the same
+    // dispatch gate used by Flush/Sync/Shutdown so no later batch can overtake
+    // it.  `_flags` controls the backend flush depth, not whether the sealed
+    // batch becomes visible to the backend FIFO.
+    if (_present != nullptr) {
+        bool reject_before_dispatch = false;
+        {
+            std::lock_guard lock(submit_mutex);
+            reject_before_dispatch = lifecycle_state != ELifecycleState::Running;
+        }
+        if (reject_before_dispatch) {
+            ResolveRejectedPresent(_present);
+            FinalizeRejectedSubmissions(
+                std::move(_submits),
+                "executor is stopping or stopped"
+            );
+            return;
+        }
+
+        RHIBackendSubmissionBatch          batch{};
+        std::shared_ptr<RHIBackendExecutor> backend{};
+        bool                                rejected = false;
+        {
+            std::lock_guard dispatch_lock(dispatch_mutex);
+            {
+                std::lock_guard lock(submit_mutex);
+                rejected = lifecycle_state != ELifecycleState::Running ||
+                           pending_present.has_value();
+                if (!rejected) {
+                    pending_submits.reserve(pending_submits.size() + _submits.size());
+                    for (RHIBackendSubmissionBatchEntry& entry : _submits) {
+                        pending_submits.emplace_back(std::move(entry));
+                    }
+                    pending_present.emplace(std::move(*_present));
+                    batch   = TakePendingBatchLocked();
+                    backend = GetBackendExecutorLocked();
+                }
+            }
+            if (!rejected) {
+                batch.topology = BuildBatchTopology(batch);
+                backend->Enqueue(std::move(batch));
+                if (HasRHIExecSubmitFlag(_flags, ERHIExecSubmitFlags::FlushGPU)) {
+                    backend->Flush(ERHIFlushDepth::SubmitGPU);
+                }
+            }
+        }
+        if (rejected) {
+            ResolveRejectedPresent(_present);
+            FinalizeRejectedSubmissions(
+                std::move(_submits),
+                "executor stopped while publishing Present"
+            );
+        }
+        return;
+    }
+
+    bool rejected = false;
+    {
+        std::lock_guard lock(submit_mutex);
+        rejected = lifecycle_state != ELifecycleState::Running ||
+                   pending_present.has_value();
+        if (!rejected) {
+            pending_submits.reserve(pending_submits.size() + _submits.size());
+            for (RHIBackendSubmissionBatchEntry& entry : _submits) {
+                pending_submits.emplace_back(std::move(entry));
+            }
+        }
+    }
+    if (rejected) {
+        FinalizeRejectedSubmissions(
+            std::move(_submits),
+            "executor is stopping, stopped, or has an unpublished Present"
+        );
+        return;
+    }
+    if (HasRHIExecSubmitFlag(_flags, ERHIExecSubmitFlags::FlushGPU)) {
+        FlushReady(ERHIFlushDepth::SubmitGPU);
+    }
+}
+
+void RHIExecutor::Submit(
+    Array<CommandList>&& _command_lists,
+    ERHIExecSubmitFlags  _flags,
+    RHIPresentRequest*   _present
+) {
+    Array<RHIBackendSubmissionBatchEntry> submits{};
+    submits.reserve(_command_lists.size());
+    for (CommandList& command_list : _command_lists) {
+        if (command_list.IsEmpty()) {
+            continue;
+        }
+        const EQueueType queue = command_list.GetQueueType();
+        submits.emplace_back(queue, command_list.Submit());
+    }
+    Submit(std::move(submits), _flags, _present);
+}
+
+void RHIExecutor::SubmitRecording(
+    SharedPtr<CommandList> _command_list,
+    RHIRecordingGateRef    _completion,
+    ERHIExecSubmitFlags    _flags
+) {
+    Array<SharedPtr<CommandList>> command_lists{};
+    command_lists.emplace_back(std::move(_command_list));
+    SubmitRecording(std::move(command_lists), std::move(_completion), _flags);
+}
+
+void RHIExecutor::SubmitRecording(
+    Array<SharedPtr<CommandList>>&& _command_lists,
+    RHIRecordingGateRef             _batch_completion,
+    ERHIExecSubmitFlags             _flags
+) {
+    Array<RHIRecordingSource> sources{};
+    sources.reserve(_command_lists.size());
+    for (SharedPtr<CommandList>& command_list : _command_lists) {
+        if (!command_list) {
+            continue;
+        }
+        sources.emplace_back(RHIRecordingSource{
+            .command_list = std::move(command_list),
+            .completion   = _batch_completion,
+        });
+    }
+    SubmitRecording(std::move(sources), _flags);
+}
+
+void RHIExecutor::SubmitRecording(
+    Array<RHIRecordingSource>&& _sources,
+    ERHIExecSubmitFlags         _flags
+) {
+    _sources.erase(
+        std::remove_if(
+            _sources.begin(),
+            _sources.end(),
+            [](const RHIRecordingSource& _source) {
+                return !_source.command_list;
+            }
+        ),
+        _sources.end()
+    );
+
+    if (_sources.empty()) {
+        Array<RHIBackendSubmissionBatchEntry> submits{};
+        Submit(std::move(submits), _flags, nullptr);
+        return;
+    }
+
+    const bool sources_valid = std::all_of(
+        _sources.begin(),
+        _sources.end(),
+        [](const RHIRecordingSource& _source) {
+            return _source.completion &&
+                   IsSubmissionQueue(_source.command_list->GetQueueType());
+        }
+    );
+    if (!sources_valid) {
+        FinalizeCancelledRecordingSources(
+            std::move(_sources),
+            "missing completion gate or invalid queue"
+        );
+        return;
+    }
+
+    auto payload     = std::make_shared<RecordingSubmissionPayload>();
+    payload->sources = std::move(_sources);
+    payload->flags   = _flags;
+
+    std::vector<RHIRecordingGateRef> prerequisites{};
+    prerequisites.reserve(payload->sources.size());
+    for (const RHIRecordingSource& source : payload->sources) {
+        prerequisites.emplace_back(source.completion);
+    }
+
+    recording_handoff.EnqueueRecording(RHIExecutorRecordingHandoffWork{
+        .prerequisites = std::move(prerequisites),
+        .resolve = [this, payload](ERHIRecordingHandoffResult _result) mutable {
+            if (_result == ERHIRecordingHandoffResult::Cancel) {
+                FinalizeCancelledRecordingSources(
+                    std::move(payload->sources),
+                    "completion gate cancelled during shutdown"
+                );
+                return;
+            }
+            if (_result == ERHIRecordingHandoffResult::Reject) {
+                FinalizeFailedRecordingSources(
+                    std::move(payload->sources),
+                    "recording completion gate failed"
+                );
+                return;
+            }
+
+            Array<RHIBackendSubmissionBatchEntry> submits{};
+            Array<size_t> materialized_source_indices{};
+            submits.reserve(payload->sources.size());
+            materialized_source_indices.reserve(payload->sources.size());
+            try {
+                // First seal every source. Only after the whole recording
+                // group owns immutable CmdSubmit payloads may metadata be
+                // applied. If a later metadata copy fails, the existing
+                // frontend rejection path can then terminalize callbacks and
+                // rollback payload for the complete materialized group.
+                for (size_t source_index = 0; source_index < payload->sources.size();
+                     ++source_index) {
+                    RHIRecordingSource& source = payload->sources[source_index];
+                    // Queue type is stable for a CommandList, but validate it
+                    // again at the ownership transition before materializing.
+                    const EQueueType queue = source.command_list->GetQueueType();
+                    if (!IsSubmissionQueue(queue)) {
+                        throw std::runtime_error("recorded source changed to an invalid queue");
+                    }
+                    if (source.command_list->IsEmpty()) {
+                        continue;
+                    }
+                    submits.emplace_back(queue, source.command_list->Submit());
+                    materialized_source_indices.emplace_back(source_index);
+                }
+
+                for (size_t submit_index = 0; submit_index < submits.size(); ++submit_index) {
+                    RHIRecordingSource& source =
+                        payload->sources[materialized_source_indices[submit_index]];
+                    auto& submit   = submits[submit_index].submit;
+                    auto& metadata = source.submit_metadata;
+                    if (metadata.debug_label) {
+                        submit.DebugLabel(*metadata.debug_label, metadata.debug_label_color);
+                    }
+                    if (metadata.profiling_phase) {
+                        submit.SetProfilingPhase(*metadata.profiling_phase);
+                    }
+                    if (metadata.translate_execution_class) {
+                        submit.SetTranslateExecutionClass(*metadata.translate_execution_class);
+                    }
+                }
+            } catch (const std::exception& exception) {
+                LOG_ERROR(
+                    "[RHIExecutor] failed to materialize recording sources: {}",
+                    exception.what()
+                );
+                FinalizeRejectedSubmissions(
+                    std::move(submits),
+                    "recording source finalization failed"
+                );
+                return;
+            } catch (...) {
+                LOG_ERROR("[RHIExecutor] failed to materialize recording sources");
+                FinalizeRejectedSubmissions(
+                    std::move(submits),
+                    "recording source finalization failed"
+                );
+                return;
+            }
+
+            payload->sources.clear();
+            SubmitReady(std::move(submits), payload->flags, nullptr);
+        },
+    });
+}
+
+void RHIExecutor::Present(RHIPresentRequest&& _present, bool _flush) {
+    Array<RHIBackendSubmissionBatchEntry> submits{};
+    Submit(
+        std::move(submits),
+        _flush ? ERHIExecSubmitFlags::FlushGPU : ERHIExecSubmitFlags::None,
+        &_present
+    );
+}
+
+void RHIExecutor::Flush(ERHIFlushDepth _depth) {
+    recording_handoff.RouteReady(RHIExecutorRecordingHandoffWork{
+        .prerequisites = {},
+        .resolve = [this, _depth](ERHIRecordingHandoffResult _result) {
+            if (_result == ERHIRecordingHandoffResult::Consume) {
+                FlushReady(_depth);
+            }
+        },
+    });
+}
+
+void RHIExecutor::FlushReady(ERHIFlushDepth _depth) {
+    {
+        std::lock_guard lock(submit_mutex);
+        if (lifecycle_state != ELifecycleState::Running) {
+            return;
+        }
+    }
+
+    std::lock_guard dispatch_lock(dispatch_mutex);
+    RHIBackendSubmissionBatch batch{};
+    std::shared_ptr<RHIBackendExecutor> backend;
+    {
+        std::lock_guard lock(submit_mutex);
+        if (lifecycle_state != ELifecycleState::Running) {
+            return;
+        }
+        batch   = TakePendingBatchLocked();
+        if (BatchHasWork(batch)) {
+            backend = GetBackendExecutorLocked();
+        } else {
+            backend = backend_executor;
+        }
+    }
+    if (BatchHasWork(batch)) {
+        batch.topology = BuildBatchTopology(batch);
+        backend->Enqueue(std::move(batch));
+    }
+    if (backend) {
+        backend->Flush(_depth);
+    }
+}
+
+void RHIExecutor::Sync(ERHISyncDepth _depth) {
+    auto completion = std::make_shared<HandoffSyncCompletion>();
+    recording_handoff.RouteReady(RHIExecutorRecordingHandoffWork{
+        .prerequisites = {},
+        .resolve = [this, _depth, completion](ERHIRecordingHandoffResult _result) {
+            ScopeExit signal_completion([completion] { completion->Signal(); });
+            if (_result == ERHIRecordingHandoffResult::Consume) {
+                SyncReady(_depth);
+            }
+        },
+    });
+    completion->Wait();
+}
+
+void RHIExecutor::SyncReady(ERHISyncDepth _depth) {
+    {
+        std::lock_guard lock(submit_mutex);
+        if (lifecycle_state != ELifecycleState::Running) {
+            return;
+        }
+    }
+
+    std::shared_ptr<RHIBackendExecutor> backend{};
+    bool                                sync_registered = false;
+    auto finish_sync_call = [this, &sync_registered] {
+        if (!sync_registered) {
+            return;
+        }
+        {
+            std::lock_guard lock(submit_mutex);
+            assert(active_sync_calls > 0);
+            --active_sync_calls;
+        }
+        sync_registered = false;
+        lifecycle_cv.notify_all();
+    };
+    ScopeExit finish_sync_guard(std::move(finish_sync_call));
+    {
+        std::lock_guard dispatch_lock(dispatch_mutex);
+        RHIBackendSubmissionBatch batch{};
+        {
+            std::lock_guard lock(submit_mutex);
+            if (lifecycle_state == ELifecycleState::Running) {
+                batch = TakePendingBatchLocked();
+                if (BatchHasWork(batch)) {
+                    backend = GetBackendExecutorLocked();
+                } else {
+                    backend = backend_executor;
+                }
+                if (backend) {
+                    ++active_sync_calls;
+                    sync_registered = true;
+                }
+            }
+        }
+        if (BatchHasWork(batch)) {
+            batch.topology = BuildBatchTopology(batch);
+            backend->Enqueue(std::move(batch));
+        }
+        if (backend) {
+            backend->Flush(ERHIFlushDepth::SubmitGPU);
+        }
+    }
+
+    GraphEventRef completion = backend ? backend->Sync(_depth) : GraphEventRef{};
+    if (completion) {
+        completion->Wait(EThread::UNKNOWN_THREAD);
+    }
+}
+
+void RHIExecutor::ShutDown() {
+    RHIExecutor& executor = Get();
+    uint64       shutdown_to_complete = 0;
+
+    {
+        std::unique_lock lock(executor.submit_mutex);
+        if (executor.lifecycle_state == ELifecycleState::Stopped) {
+            return;
+        }
+        if (executor.lifecycle_state == ELifecycleState::Stopping) {
+            const uint64 shutdown_to_wait = executor.shutdown_generation;
+            executor.lifecycle_cv.wait(lock, [&executor, shutdown_to_wait] {
+                return executor.completed_shutdown_generation >= shutdown_to_wait;
+            });
+            return;
+        }
+        executor.lifecycle_state = ELifecycleState::Stopping;
+        shutdown_to_complete     = ++executor.shutdown_generation;
+    }
+
+    // Stop accepting handoffs before taking the final pending batch. The
+    // worker's stop token interrupts an unfinished recording gate, rejects it
+    // and every later FIFO operation, and joins without depending on producer
+    // progress. Any callback already inside SubmitReady/SyncReady is allowed
+    // to finish before backend ownership is detached below.
+    executor.recording_handoff.ShutDown();
+
+    RHIBackendSubmissionBatch batch{};
+    std::shared_ptr<RHIBackendExecutor> backend;
+    {
+        std::lock_guard dispatch_lock(executor.dispatch_mutex);
+        {
+            std::lock_guard lock(executor.submit_mutex);
+            batch = executor.TakePendingBatchLocked();
+            if (BatchHasWork(batch)) {
+                executor.GetBackendExecutorLocked();
+            }
+            backend = std::move(executor.backend_executor);
+        }
+        if (BatchHasWork(batch) && backend) {
+            batch.topology = BuildBatchTopology(batch);
+            backend->Enqueue(std::move(batch));
+        }
+        if (backend) {
+            backend->Flush(ERHIFlushDepth::SubmitGPU);
+        }
+    }
+
+    auto finish_shutdown = [&executor, shutdown_to_complete] {
+        {
+            std::lock_guard lock(executor.submit_mutex);
+            executor.completed_shutdown_generation = std::max(
+                executor.completed_shutdown_generation,
+                shutdown_to_complete
+            );
+            executor.lifecycle_state = ELifecycleState::Stopped;
+        }
+        executor.lifecycle_cv.notify_all();
+    };
+    ScopeExit finish_shutdown_guard(std::move(finish_shutdown));
+
+    // Backend shutdown may wait for its worker and GPU queues.  The dispatch
+    // gate is deliberately released first; the Stopping state keeps later
+    // publishers out while concurrent Shutdown/Sync callers wait on the CV.
+    {
+        std::unique_lock lock(executor.submit_mutex);
+        executor.lifecycle_cv.wait(lock, [&executor] {
+            return executor.active_sync_calls == 0;
+        });
+    }
+    if (backend) {
+        backend->ShutDown();
+    }
+}
+
+} // namespace Moer::Render

--- a/source/runtime/render/rhi/RHIExecutor.h
+++ b/source/runtime/render/rhi/RHIExecutor.h
@@ -1,0 +1,116 @@
+#pragma once
+
+#include "RenderAPI.h"
+#include "rhi/RHIExecutorBackend.h"
+#include "rhi/RHIExecutorRecordingHandoff.h"
+
+#include <condition_variable>
+#include <memory>
+#include <mutex>
+
+namespace Moer::Render {
+
+struct RHIRecordingSubmitMetadata {
+    std::optional<std::string>                 debug_label{};
+    float4                                     debug_label_color{GpuMarkerPalette::Pass()};
+    std::optional<ERHIProfilingPhase>          profiling_phase{};
+    std::optional<ERHITranslateExecutionClass> translate_execution_class{};
+};
+
+// One independently recorded source. completion must be signalled only after
+// the producer has stopped mutating command_list. submit_metadata is immutable
+// at publication and deliberately contains data rather than an arbitrary
+// handoff-thread callback, so finalization cannot recursively Flush/Sync.
+// The producer owns the only mutable reference until it calls Signal()/Fail().
+// It must not call RHIExecutor::Flush, Sync or ShutDown while recording; those
+// are ordering/lifecycle boundaries owned by the submitting thread.
+struct RHIRecordingSource {
+    SharedPtr<CommandList>       command_list{};
+    RHIRecordingGateRef          completion{};
+    RHIRecordingSubmitMetadata   submit_metadata{};
+};
+
+class RENDER_API RHIExecutor {
+public:
+    static RHIExecutor& Get();
+    static void StartUp();
+
+    void Submit(
+        EQueueType             _queue,
+        CmdSubmit&&            _submit,
+        ERHIExecSubmitFlags    _flags   = ERHIExecSubmitFlags::FlushGPU,
+        RHIPresentRequest*     _present = nullptr
+    );
+    void Submit(
+        Array<RHIBackendSubmissionBatchEntry>&& _submits,
+        ERHIExecSubmitFlags                      _flags   = ERHIExecSubmitFlags::FlushGPU,
+        RHIPresentRequest*                       _present = nullptr
+    );
+    void Submit(
+        Array<CommandList>&&   _command_lists,
+        ERHIExecSubmitFlags    _flags   = ERHIExecSubmitFlags::FlushGPU,
+        RHIPresentRequest*     _present = nullptr
+    );
+
+    // Recording handoff API. Sources remain shared and mutable until their
+    // explicit gates complete; the RHI handoff worker then seals them into
+    // CmdSubmit payloads in input order. A batch may use one common gate or a
+    // distinct gate per source through the RHIRecordingSource overload. If any
+    // producer fails, the whole group waits for all producers, runs ordinary
+    // CommandList cleanup callbacks once, skips success callbacks, and never
+    // reaches a GPU queue. Shutdown cancellation remains non-blocking and does
+    // not inspect CommandLists whose producers may still be active.
+    void SubmitRecording(
+        SharedPtr<CommandList> _command_list,
+        RHIRecordingGateRef    _completion,
+        ERHIExecSubmitFlags    _flags = ERHIExecSubmitFlags::FlushGPU
+    );
+    void SubmitRecording(
+        Array<SharedPtr<CommandList>>&& _command_lists,
+        RHIRecordingGateRef             _batch_completion,
+        ERHIExecSubmitFlags             _flags = ERHIExecSubmitFlags::FlushGPU
+    );
+    void SubmitRecording(
+        Array<RHIRecordingSource>&& _sources,
+        ERHIExecSubmitFlags         _flags = ERHIExecSubmitFlags::FlushGPU
+    );
+    void Present(RHIPresentRequest&& _present, bool _flush = true);
+
+    void Flush(ERHIFlushDepth _depth = ERHIFlushDepth::SubmitGPU);
+    // Blocking lifecycle boundaries must not be called recursively from an
+    // RHI completion callback whose completion they are waiting for.
+    void Sync(ERHISyncDepth _depth = ERHISyncDepth::RHI);
+    static void ShutDown();
+
+private:
+    enum class ELifecycleState : uint8 {
+        Stopped,
+        Running,
+        Stopping,
+    };
+
+    std::shared_ptr<RHIBackendExecutor> GetBackendExecutorLocked();
+    RHIBackendSubmissionBatch          TakePendingBatchLocked();
+    void SubmitReady(
+        Array<RHIBackendSubmissionBatchEntry>&& _submits,
+        ERHIExecSubmitFlags                      _flags,
+        RHIPresentRequest*                       _present
+    );
+    void FlushReady(ERHIFlushDepth _depth);
+    void SyncReady(ERHISyncDepth _depth);
+
+    std::mutex                              submit_mutex;
+    std::condition_variable                 lifecycle_cv;
+    std::mutex                              dispatch_mutex;
+    std::shared_ptr<RHIBackendExecutor>     backend_executor{};
+    Array<RHIBackendSubmissionBatchEntry>   pending_submits{};
+    std::optional<RHIPresentRequest>         pending_present{};
+    uint64                                   next_batch_sequence{1};
+    size_t                                   active_sync_calls{0};
+    uint64                                   shutdown_generation{0};
+    uint64                                   completed_shutdown_generation{0};
+    ELifecycleState                          lifecycle_state{ELifecycleState::Stopped};
+    RHIExecutorRecordingHandoffQueue         recording_handoff{};
+};
+
+} // namespace Moer::Render

--- a/source/runtime/render/rhi/RHIExecutorBackend.h
+++ b/source/runtime/render/rhi/RHIExecutorBackend.h
@@ -1,0 +1,84 @@
+#pragma once
+
+#include "rhi/RHICommand.h"
+#include "taskgraph/GraphTask.h"
+
+#include <optional>
+
+namespace Moer::Render {
+
+enum class ERHIExecSubmitFlags : uint8_t {
+    None     = 0,
+    FlushGPU = 1 << 0,
+};
+
+constexpr bool HasRHIExecSubmitFlag(
+    ERHIExecSubmitFlags _flags,
+    ERHIExecSubmitFlags _flag
+) noexcept {
+    return (static_cast<uint8_t>(_flags) & static_cast<uint8_t>(_flag)) != 0;
+}
+
+enum class ERHIFlushDepth : uint8_t {
+    RHITranslate = 0,
+    SubmitGPU    = 1,
+};
+
+enum class ERHISyncDepth : uint8_t {
+    RHI     = 0,
+    Present = 1,
+};
+
+struct RHIPresentRequest {
+    SwapchainRef      swapchain{};
+    TextureRef        source_texture{};
+    TextureView       source{};
+    PresentReceiptRef receipt{};
+
+    RHIPresentRequest() = default;
+
+    RHIPresentRequest(
+        SwapchainRef      _swapchain,
+        TextureView       _source,
+        PresentReceiptRef _receipt = {}
+    ) :
+        swapchain(std::move(_swapchain)),
+        source_texture(_source.texture),
+        source(_source),
+        receipt(std::move(_receipt)) {}
+};
+
+struct RHIBackendSubmissionBatchEntry {
+    EQueueType queue{EQueueType::Ignore};
+    CmdSubmit  submit;
+
+    RHIBackendSubmissionBatchEntry(EQueueType _queue, CmdSubmit&& _submit) :
+        queue(_queue), submit(std::move(_submit)) {}
+
+    RHIBackendSubmissionBatchEntry(RHIBackendSubmissionBatchEntry&&) noexcept = default;
+    RHIBackendSubmissionBatchEntry& operator=(RHIBackendSubmissionBatchEntry&&) noexcept = default;
+    RHIBackendSubmissionBatchEntry(const RHIBackendSubmissionBatchEntry&) = delete;
+    RHIBackendSubmissionBatchEntry& operator=(const RHIBackendSubmissionBatchEntry&) = delete;
+};
+
+struct RHIBackendSubmissionBatch {
+    uint64                                   sequence{0};
+    Array<RHIBackendSubmissionBatchEntry>    submits{};
+    std::optional<RHIPresentRequest>          present{};
+    RHISubmissionTopologyPlan                 topology{};
+};
+
+class RHIBackendExecutor {
+public:
+    virtual ~RHIBackendExecutor() = default;
+
+    // RHIExecutor serializes Enqueue/Flush publication order. Sync may run
+    // concurrently after its preceding batches have been published, so each
+    // backend must safely linearize Sync against later Enqueue/Flush calls.
+    virtual void          Enqueue(RHIBackendSubmissionBatch&& _batch) = 0;
+    virtual GraphEventRef Sync(ERHISyncDepth _depth = ERHISyncDepth::RHI) = 0;
+    virtual void          Flush(ERHIFlushDepth _depth = ERHIFlushDepth::SubmitGPU) = 0;
+    virtual void          ShutDown() = 0;
+};
+
+} // namespace Moer::Render

--- a/source/runtime/render/rhi/RHIExecutorRecordingHandoff.cpp
+++ b/source/runtime/render/rhi/RHIExecutorRecordingHandoff.cpp
@@ -1,0 +1,241 @@
+#include "rhi/RHIExecutorRecordingHandoff.h"
+
+#include "log/LogSystem.h"
+
+#include <cassert>
+#include <exception>
+#include <utility>
+
+namespace Moer::Render {
+
+std::shared_ptr<RHIRecordingGate> RHIRecordingGate::Create(bool _initially_complete) {
+    // The constructor is deliberately private so a gate always has shared
+    // ownership while it is registered with the handoff worker.
+    return std::shared_ptr<RHIRecordingGate>(new RHIRecordingGate(_initially_complete));
+}
+
+bool RHIRecordingGate::Signal() noexcept {
+    return Complete(ERHIRecordingStatus::Succeeded);
+}
+
+bool RHIRecordingGate::Fail() noexcept {
+    return Complete(ERHIRecordingStatus::Failed);
+}
+
+bool RHIRecordingGate::Complete(ERHIRecordingStatus _status) noexcept {
+    assert(_status != ERHIRecordingStatus::Pending);
+    {
+        std::lock_guard lock(mutex);
+        if (status != ERHIRecordingStatus::Pending) {
+            return false;
+        }
+        status = _status;
+    }
+    cv.notify_all();
+    return true;
+}
+
+bool RHIRecordingGate::IsComplete() const noexcept {
+    return Status() != ERHIRecordingStatus::Pending;
+}
+
+ERHIRecordingStatus RHIRecordingGate::Status() const noexcept {
+    std::lock_guard lock(mutex);
+    return status;
+}
+
+ERHIRecordingStatus RHIRecordingGate::Wait() const noexcept {
+    std::unique_lock lock(mutex);
+    cv.wait(lock, [this] { return status != ERHIRecordingStatus::Pending; });
+    return status;
+}
+
+ERHIRecordingStatus RHIRecordingGate::Wait(std::stop_token _stop_token) const noexcept {
+    std::unique_lock lock(mutex);
+    const bool completed = cv.wait(lock, _stop_token, [this] {
+        return status != ERHIRecordingStatus::Pending;
+    });
+    return completed ? status : ERHIRecordingStatus::Pending;
+}
+
+RHIExecutorRecordingHandoffQueue::~RHIExecutorRecordingHandoffQueue() {
+    ShutDown();
+}
+
+void RHIExecutorRecordingHandoffQueue::Start() {
+    std::lock_guard lock(mutex);
+    if (accepting) {
+        return;
+    }
+    assert(!worker.joinable());
+    assert(pending.empty());
+    assert(inline_dispatches == 0);
+    assert(!worker_busy);
+    accepting = true;
+    worker    = std::jthread([this](std::stop_token _stop_token) { Run(_stop_token); });
+}
+
+void RHIExecutorRecordingHandoffQueue::EnqueueRecording(
+    RHIExecutorRecordingHandoffWork&& _work
+) {
+    bool reject = false;
+    {
+        std::lock_guard lock(mutex);
+        if (!accepting) {
+            reject = true;
+        } else {
+            pending.emplace_back(std::move(_work));
+        }
+    }
+    if (reject) {
+        ResolveNoThrow(_work, ERHIRecordingHandoffResult::Cancel);
+        return;
+    }
+    work_cv.notify_all();
+}
+
+void RHIExecutorRecordingHandoffQueue::RouteReady(
+    RHIExecutorRecordingHandoffWork&& _work
+) {
+    bool run_inline = false;
+    bool reject     = false;
+    {
+        std::lock_guard lock(mutex);
+        if (!accepting) {
+            reject = true;
+        } else if (worker_busy || inline_dispatches != 0 || !pending.empty()) {
+            pending.emplace_back(std::move(_work));
+        } else {
+            // Mark the direct operation active before releasing the lock. A
+            // concurrent recording handoff is then queued behind it and the
+            // worker waits for this count to return to zero.
+            ++inline_dispatches;
+            run_inline = true;
+        }
+    }
+
+    if (reject) {
+        ResolveNoThrow(_work, ERHIRecordingHandoffResult::Cancel);
+        return;
+    }
+    if (!run_inline) {
+        work_cv.notify_all();
+        return;
+    }
+
+    ResolveNoThrow(_work, ERHIRecordingHandoffResult::Consume);
+    {
+        std::lock_guard lock(mutex);
+        assert(inline_dispatches > 0);
+        --inline_dispatches;
+    }
+    idle_cv.notify_all();
+    work_cv.notify_all();
+}
+
+void RHIExecutorRecordingHandoffQueue::ShutDown() {
+    {
+        std::lock_guard lock(mutex);
+        accepting = false;
+    }
+
+    if (worker.joinable()) {
+        worker.request_stop();
+        work_cv.notify_all();
+        worker.join();
+    }
+
+    std::unique_lock lock(mutex);
+    idle_cv.wait(lock, [this] {
+        return inline_dispatches == 0 && !worker_busy && pending.empty();
+    });
+}
+
+bool RHIExecutorRecordingHandoffQueue::IsIdle() const noexcept {
+    std::lock_guard lock(mutex);
+    return pending.empty() && inline_dispatches == 0 && !worker_busy;
+}
+
+void RHIExecutorRecordingHandoffQueue::Run(std::stop_token _stop_token) noexcept {
+    for (;;) {
+        RHIExecutorRecordingHandoffWork work{};
+        {
+            std::unique_lock lock(mutex);
+            work_cv.wait(lock, _stop_token, [this] {
+                return inline_dispatches == 0 && !pending.empty();
+            });
+            if (_stop_token.stop_requested()) {
+                break;
+            }
+            work = std::move(pending.front());
+            pending.pop_front();
+            worker_busy = true;
+        }
+
+        bool ready = true;
+        for (const RHIRecordingGateRef& prerequisite : work.prerequisites) {
+            if (!prerequisite) {
+                ready = false;
+                continue;
+            }
+            const ERHIRecordingStatus status = prerequisite->Wait(_stop_token);
+            if (status != ERHIRecordingStatus::Succeeded) {
+                ready = false;
+            }
+            // A producer failure does not make the remaining CommandLists
+            // safe to inspect. Keep waiting until every gate is terminal. A
+            // lifecycle cancellation is different: stop must remain bounded.
+            if (_stop_token.stop_requested()) {
+                break;
+            }
+        }
+        const bool cancelled = _stop_token.stop_requested();
+
+        ResolveNoThrow(
+            work,
+            cancelled ? ERHIRecordingHandoffResult::Cancel :
+            ready     ? ERHIRecordingHandoffResult::Consume :
+                        ERHIRecordingHandoffResult::Reject
+        );
+
+        {
+            std::lock_guard lock(mutex);
+            worker_busy = false;
+        }
+        idle_cv.notify_all();
+
+        if (cancelled) {
+            break;
+        }
+    }
+
+    std::deque<RHIExecutorRecordingHandoffWork> rejected{};
+    {
+        std::lock_guard lock(mutex);
+        rejected.swap(pending);
+        worker_busy = false;
+    }
+    idle_cv.notify_all();
+
+    for (RHIExecutorRecordingHandoffWork& work : rejected) {
+        ResolveNoThrow(work, ERHIRecordingHandoffResult::Cancel);
+    }
+}
+
+void RHIExecutorRecordingHandoffQueue::ResolveNoThrow(
+    RHIExecutorRecordingHandoffWork& _work,
+    ERHIRecordingHandoffResult       _result
+) noexcept {
+    if (!_work.resolve) {
+        return;
+    }
+    try {
+        _work.resolve(_result);
+    } catch (const std::exception& exception) {
+        LOG_ERROR("[RHIExecutor] recording handoff resolver threw: {}", exception.what());
+    } catch (...) {
+        LOG_ERROR("[RHIExecutor] recording handoff resolver threw");
+    }
+}
+
+} // namespace Moer::Render

--- a/source/runtime/render/rhi/RHIExecutorRecordingHandoff.h
+++ b/source/runtime/render/rhi/RHIExecutorRecordingHandoff.h
@@ -1,0 +1,124 @@
+#pragma once
+
+#include "RenderAPI.h"
+
+#include <condition_variable>
+#include <cstdint>
+#include <deque>
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <stop_token>
+#include <thread>
+#include <vector>
+
+namespace Moer::Render {
+
+enum class ERHIRecordingStatus : uint8_t {
+    Pending,
+    Succeeded,
+    Failed,
+};
+
+// One-shot CPU publication gate used to hand a CommandList to the RHI
+// executor before its producer has finished recording it. Signal() publishes
+// all writes performed by the recorder before the call; the handoff worker
+// acquires them before consuming the CommandList.
+class RENDER_API RHIRecordingGate final {
+public:
+    static std::shared_ptr<RHIRecordingGate> Create(bool _initially_complete = false);
+
+    // Idempotent. Returns true only for the transition to the complete state.
+    bool Signal() noexcept;
+    bool Fail() noexcept;
+    [[nodiscard]] bool IsComplete() const noexcept;
+    [[nodiscard]] ERHIRecordingStatus Status() const noexcept;
+    // Blocking producer-side join used at explicit RDG wave boundaries.
+    // Unlike the worker overload, this wait is not cancellable and always
+    // returns a terminal Succeeded/Failed status.
+    [[nodiscard]] ERHIRecordingStatus Wait() const noexcept;
+
+private:
+    friend class RHIExecutorRecordingHandoffQueue;
+
+    explicit RHIRecordingGate(bool _initially_complete) :
+        status(
+            _initially_complete ? ERHIRecordingStatus::Succeeded :
+                                  ERHIRecordingStatus::Pending
+        ) {}
+    bool Complete(ERHIRecordingStatus _status) noexcept;
+    [[nodiscard]] ERHIRecordingStatus Wait(std::stop_token _stop_token) const noexcept;
+
+    mutable std::mutex              mutex;
+    mutable std::condition_variable_any cv;
+    ERHIRecordingStatus             status{ERHIRecordingStatus::Pending};
+};
+
+using RHIRecordingGateRef = std::shared_ptr<RHIRecordingGate>;
+
+enum class ERHIRecordingHandoffResult : uint8_t {
+    Consume,
+    // Every prerequisite reached a terminal state, but at least one producer
+    // failed. The resolver may safely inspect every protected CommandList for
+    // frontend cleanup, but must never publish its commands to a GPU queue.
+    Reject,
+    // The queue stopped before all prerequisites became terminal. Protected
+    // CommandLists remain opaque because a producer may still be mutating one.
+    Cancel,
+};
+
+// A work item can depend on one gate per source CommandList. The worker waits
+// for the complete set in input order and resolves the item exactly once.
+struct RHIExecutorRecordingHandoffWork {
+    std::vector<RHIRecordingGateRef> prerequisites{};
+    std::function<void(ERHIRecordingHandoffResult)> resolve{};
+};
+
+// Small FIFO used by RHIExecutor to bridge asynchronously recorded sources to
+// the existing backend submission path. Ready operations are routed through
+// the same ordering domain while a recording handoff is active, so Submit,
+// Present, Flush and Sync cannot overtake an unfinished recording source.
+//
+// A normal failed group waits for every source gate to become terminal before
+// resolving Reject, so its resolver can safely drain frontend cleanup. ShutDown
+// never waits for a gate: requesting stop interrupts the current gate wait and
+// resolves that work plus every later FIFO entry as Cancel.
+class RENDER_API RHIExecutorRecordingHandoffQueue final {
+public:
+    RHIExecutorRecordingHandoffQueue() = default;
+    ~RHIExecutorRecordingHandoffQueue();
+
+    RHIExecutorRecordingHandoffQueue(const RHIExecutorRecordingHandoffQueue&) = delete;
+    RHIExecutorRecordingHandoffQueue& operator=(const RHIExecutorRecordingHandoffQueue&) = delete;
+
+    void Start();
+
+    // Establishes the asynchronous FIFO even when all prerequisites are
+    // already complete. Used by SubmitRecording.
+    void EnqueueRecording(RHIExecutorRecordingHandoffWork&& _work);
+
+    // Runs inline when the FIFO is idle, otherwise queues behind the active
+    // recording handoff. This is the ordering path for ordinary RHI controls.
+    void RouteReady(RHIExecutorRecordingHandoffWork&& _work);
+
+    void ShutDown();
+    [[nodiscard]] bool IsIdle() const noexcept;
+
+private:
+    void Run(std::stop_token _stop_token) noexcept;
+    static void ResolveNoThrow(
+        RHIExecutorRecordingHandoffWork& _work,
+        ERHIRecordingHandoffResult       _result
+    ) noexcept;
+
+    mutable std::mutex                        mutex;
+    std::condition_variable_any               work_cv;
+    std::condition_variable                   idle_cv;
+    std::deque<RHIExecutorRecordingHandoffWork> pending{};
+    std::jthread                              worker{};
+    size_t                                    inline_dispatches{0};
+    bool                                      accepting{false};
+    bool                                      worker_busy{false};
+};
+
+} // namespace Moer::Render

--- a/source/runtime/render/rhi/RHIImpl.h
+++ b/source/runtime/render/rhi/RHIImpl.h
@@ -721,6 +721,10 @@ struct UpdateBindlessArrayCmd : public Command {
 private:
     UpdateBindlessArrayCmd() : Command(EType::UpdateBindlessArray) {}
     mutable BindlessArrayRef        array;
+    mutable std::atomic_bool         updates_handed_off{false};
+    std::shared_ptr<std::atomic_bool> updates_finalized{
+        std::make_shared<std::atomic_bool>(false)
+    };
     Array<BindlessArray::UpdateCmd> update_cmds;
     Array<byte>                     array_data;
     Array<std::pair<uint, uint>>    array_indices_dat;
@@ -730,6 +734,18 @@ private:
     Array<std::pair<uint, uint>>    texture_indices_dat;
 
 public:
+    ~UpdateBindlessArrayCmd() override {
+        if (array && !updates_handed_off.load(std::memory_order_acquire)) {
+            try {
+                array->DiscardUpdateCommand(update_cmds);
+            } catch (...) {
+                // Destructors must not turn a dropped command list into a
+                // process termination. Backends keep membership ownership
+                // alive independently, so a failed rollback remains safe.
+            }
+        }
+    }
+
     UpdateBindlessArrayCmd(
         BindlessArrayRef                  _array,
         Array<BindlessArray::UpdateCmd>&& _update_cmds,
@@ -761,6 +777,18 @@ public:
     }
     const auto& UpdateCommands() const {
         return update_cmds;
+    }
+    bool HandOffUpdates() const {
+        bool expected = false;
+        return updates_handed_off.compare_exchange_strong(
+            expected, true, std::memory_order_acq_rel, std::memory_order_acquire
+        );
+    }
+    bool UpdatesHandedOff() const {
+        return updates_handed_off.load(std::memory_order_acquire);
+    }
+    const auto& UpdateFinalizationToken() const {
+        return updates_finalized;
     }
     const auto& ArrayIndicesData() const {
         return array_indices_dat;

--- a/source/runtime/render/rhi/RHIParallelRecord.h
+++ b/source/runtime/render/rhi/RHIParallelRecord.h
@@ -1,0 +1,344 @@
+#ifndef MOER_RENDER_RHI_PARALLEL_RECORD_H
+#define MOER_RENDER_RHI_PARALLEL_RECORD_H
+
+#include "RHIRecordDiagnostics.h"
+
+#include <algorithm>
+#include <cassert>
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+#include <span>
+#include <vector>
+
+namespace Moer::Render {
+
+enum class ParallelRecordFallbackReason : uint8_t {
+    None,
+    WorkerCountTooSmall,
+    NoEligibleLayer,
+    InsufficientWork,
+    InsufficientConcurrency,
+    InvalidWorkDescription,
+    InvalidCommandType,
+    LayerTooLarge,
+};
+
+// Mirrors UE's 64-draw floor, but uses backend-estimated native recording work
+// rather than Moer's high-level command count. A single MultiDraw may therefore
+// qualify while a long list of cheap copies still remains serial.
+inline constexpr uint32_t kDefaultParallelRecordMinWorkUnitsPerJob = 64;
+
+// A borrowed, immutable view of one reorderer layer. Command indices in the
+// generated plan are local to this span, which lets the backend bind the plan
+// to its own immutable command-pointer storage without copying payloads.
+struct ParallelRecordLayerDescription {
+    std::span<const Command::EType> command_types;
+    // Optional for pure contract tests. Runtime descriptions provide one
+    // positive native-recording work estimate per command.
+    std::span<const uint32_t> command_work_units;
+    // Runtime-only constraints (for example, commands that own GPU timestamp
+    // queries) can keep an otherwise whitelisted layer on the coordinator.
+    bool force_serial{false};
+};
+
+// One recorder owns exactly one contiguous command range. Jobs are emitted in
+// deterministic merge/submission order: layer first, then command_begin.
+struct ParallelRecordJobRange {
+    uint32_t layer_index{0};
+    uint32_t command_begin{0};
+    uint32_t command_count{0};
+    uint64_t work_units{0};
+
+    constexpr uint32_t CommandEnd() const {
+        return command_begin + command_count;
+    }
+};
+
+struct ParallelRecordLayerPlan {
+    uint32_t layer_index{0};
+    uint32_t command_count{0};
+    uint32_t first_job{0};
+    uint32_t job_count{0};
+    bool     parallel{false};
+};
+
+struct ParallelRecordPlan {
+    ParallelRecordFallbackReason          fallback_reason{ParallelRecordFallbackReason::NoEligibleLayer};
+    std::vector<ParallelRecordLayerPlan> layers;
+    std::vector<ParallelRecordJobRange>  jobs;
+    uint32_t                             parallel_layer_count{0};
+
+    constexpr bool CanRecordInParallel() const {
+        return fallback_reason == ParallelRecordFallbackReason::None;
+    }
+};
+
+inline ParallelRecordPlan BuildParallelRecordPlan(
+    std::span<const ParallelRecordLayerDescription> _layers,
+    uint32_t                                        _worker_count,
+    uint32_t _min_work_units_per_job = kDefaultParallelRecordMinWorkUnitsPerJob
+) {
+    ParallelRecordPlan plan;
+    if (_worker_count < 2) {
+        plan.fallback_reason = ParallelRecordFallbackReason::WorkerCountTooSmall;
+        return plan;
+    }
+
+    _min_work_units_per_job = std::max(1u, _min_work_units_per_job);
+
+    std::vector<bool>                                layer_is_parallel;
+    std::vector<std::vector<ParallelRecordJobRange>> layer_jobs;
+    std::vector<uint64_t>                            layer_total_work;
+    layer_is_parallel.reserve(_layers.size());
+    layer_jobs.reserve(_layers.size());
+    layer_total_work.reserve(_layers.size());
+    bool saw_insufficient_work        = false;
+    bool saw_insufficient_concurrency = false;
+    for (size_t layer_index = 0; layer_index < _layers.size(); ++layer_index) {
+        const ParallelRecordLayerDescription& layer = _layers[layer_index];
+        if (layer.command_types.size() > std::numeric_limits<uint32_t>::max()) {
+            plan.fallback_reason = ParallelRecordFallbackReason::LayerTooLarge;
+            return plan;
+        }
+        if (!layer.command_work_units.empty() &&
+            layer.command_work_units.size() != layer.command_types.size()) {
+            plan.fallback_reason = ParallelRecordFallbackReason::InvalidWorkDescription;
+            return plan;
+        }
+
+        // Recording independence is weaker than GPU execution independence.
+        // Once the coordinator has resolved every layer's state transitions,
+        // safe bodies from different ordered layers may be translated on
+        // different CPU workers and still be submitted in original layer
+        // order. A singleton layer therefore contributes one recording job.
+        bool eligible = !layer.force_serial && !layer.command_types.empty();
+        for (const Command::EType type : layer.command_types) {
+            if (static_cast<size_t>(type) >= static_cast<size_t>(Command::EType::Count)) {
+                plan.fallback_reason = ParallelRecordFallbackReason::InvalidCommandType;
+                return plan;
+            }
+            eligible &= GetCommandRecordTraits(type).capability ==
+                        RecordCapability::ParallelPrimarySafe;
+        }
+        uint64_t total_work = 0;
+        for (size_t command_index = 0; command_index < layer.command_types.size(); ++command_index) {
+            const uint32_t work = layer.command_work_units.empty() ?
+                                      1u :
+                                      std::max(1u, layer.command_work_units[command_index]);
+            total_work += work;
+        }
+        std::vector<ParallelRecordJobRange> ranges;
+        if (eligible) {
+            if (total_work < _min_work_units_per_job) {
+                eligible = false;
+                saw_insufficient_work = true;
+            } else {
+                std::vector<uint32_t> weights(layer.command_types.size(), 1u);
+                if (!layer.command_work_units.empty()) {
+                    for (size_t command_index = 0; command_index < weights.size(); ++command_index) {
+                        weights[command_index] =
+                            std::max(1u, layer.command_work_units[command_index]);
+                    }
+                }
+
+                // Positive weights make the maximum feasible group count a
+                // greedy property: cutting at the first threshold leaves the
+                // most work for every suffix. We still choose boundaries near
+                // equal-work targets, but only when that suffix can form all
+                // remaining threshold-sized jobs.
+                // Precompute the maximum greedy threshold-group capacity for
+                // every suffix. This keeps candidate validation O(1) instead
+                // of rescanning the suffix for every possible boundary.
+                std::vector<uint64_t> prefix_work(weights.size() + 1, 0);
+                for (size_t index = 0; index < weights.size(); ++index) {
+                    prefix_work[index + 1] = prefix_work[index] + weights[index];
+                }
+                const size_t invalid_end = weights.size() + 1;
+                std::vector<size_t> next_group_end(weights.size(), invalid_end);
+                size_t end = 0;
+                for (size_t begin = 0; begin < weights.size(); ++begin) {
+                    end = std::max(end, begin + 1);
+                    while (end <= weights.size() &&
+                           prefix_work[end] - prefix_work[begin] <
+                               _min_work_units_per_job) {
+                        ++end;
+                    }
+                    if (end <= weights.size()) {
+                        next_group_end[begin] = end;
+                    }
+                }
+                std::vector<uint32_t> suffix_group_capacities(weights.size() + 1, 0);
+                for (size_t begin = weights.size(); begin-- > 0;) {
+                    const size_t next = next_group_end[begin];
+                    if (next <= weights.size()) {
+                        suffix_group_capacities[begin] =
+                            1u + suffix_group_capacities[next];
+                    }
+                }
+                auto suffix_group_capacity = [&](uint32_t _begin) {
+                    return suffix_group_capacities[_begin];
+                };
+                auto try_partition = [&](uint32_t _job_count) {
+                    std::vector<ParallelRecordJobRange> candidate;
+                    candidate.reserve(_job_count);
+                    uint32_t begin = 0;
+                    uint64_t remaining_work = total_work;
+                    for (uint32_t job_index = 0; job_index + 1 < _job_count; ++job_index) {
+                        const uint32_t remaining_jobs = _job_count - job_index;
+                        const uint64_t target_work =
+                            (remaining_work + remaining_jobs - 1) / remaining_jobs;
+                        uint64_t range_work = 0;
+                        uint64_t selected_work = 0;
+                        uint64_t best_distance = std::numeric_limits<uint64_t>::max();
+                        uint32_t selected_end = 0;
+                        const uint32_t last_end = static_cast<uint32_t>(weights.size()) -
+                                                  (remaining_jobs - 1);
+                        for (uint32_t end = begin + 1; end <= last_end; ++end) {
+                            range_work += weights[end - 1];
+                            if (range_work < _min_work_units_per_job) {
+                                continue;
+                            }
+                            const uint64_t suffix_work = remaining_work - range_work;
+                            if (suffix_work <
+                                uint64_t(remaining_jobs - 1) * _min_work_units_per_job) {
+                                continue;
+                            }
+                            if (suffix_group_capacity(end) < remaining_jobs - 1) {
+                                continue;
+                            }
+                            const uint64_t distance = range_work > target_work ?
+                                                          range_work - target_work :
+                                                          target_work - range_work;
+                            if (distance < best_distance) {
+                                best_distance = distance;
+                                selected_end = end;
+                                selected_work = range_work;
+                            }
+                        }
+                        if (selected_end == 0) {
+                            return std::vector<ParallelRecordJobRange>{};
+                        }
+                        candidate.push_back({
+                            .layer_index = static_cast<uint32_t>(layer_index),
+                            .command_begin = begin,
+                            .command_count = selected_end - begin,
+                            .work_units = selected_work,
+                        });
+                        begin = selected_end;
+                        remaining_work -= selected_work;
+                    }
+                    if (remaining_work < _min_work_units_per_job || begin >= weights.size()) {
+                        return std::vector<ParallelRecordJobRange>{};
+                    }
+                    candidate.push_back({
+                        .layer_index = static_cast<uint32_t>(layer_index),
+                        .command_begin = begin,
+                        .command_count = static_cast<uint32_t>(weights.size()) - begin,
+                        .work_units = remaining_work,
+                    });
+                    return candidate;
+                };
+
+                uint32_t desired_jobs = std::min({
+                    _worker_count,
+                    static_cast<uint32_t>(weights.size()),
+                    static_cast<uint32_t>(std::min<uint64_t>(
+                        total_work / _min_work_units_per_job,
+                        std::numeric_limits<uint32_t>::max()
+                    )),
+                });
+                desired_jobs = std::max(1u, desired_jobs);
+                while (desired_jobs != 0 && ranges.empty()) {
+                    ranges = try_partition(desired_jobs--);
+                }
+                assert(!ranges.empty());
+            }
+        }
+        layer_is_parallel.push_back(eligible);
+        layer_jobs.push_back(std::move(ranges));
+        layer_total_work.push_back(total_work);
+    }
+
+    // The executor drains a recording wave before visiting the next non-empty
+    // serial island so translate-time CPU side effects stay ordered. Evaluate
+    // profitability on those same wave boundaries: two eligible singletons
+    // separated by a serial layer cannot overlap and must not be advertised as
+    // effective parallel work. Empty layers do not make the executor flush.
+    size_t   wave_begin     = 0;
+    uint32_t wave_job_count = 0;
+    auto finish_wave = [&](size_t _wave_end) {
+        if (wave_job_count != 0 && wave_job_count < 2) {
+            for (size_t index = wave_begin; index < _wave_end; ++index) {
+                layer_is_parallel[index] = false;
+            }
+            saw_insufficient_concurrency = true;
+        }
+        wave_begin     = _wave_end;
+        wave_job_count = 0;
+    };
+    for (size_t layer_index = 0; layer_index < _layers.size(); ++layer_index) {
+        if (layer_is_parallel[layer_index]) {
+            if (wave_job_count == 0) {
+                wave_begin = layer_index;
+            }
+            wave_job_count += static_cast<uint32_t>(layer_jobs[layer_index].size());
+        } else if (!_layers[layer_index].command_types.empty()) {
+            finish_wave(layer_index);
+            wave_begin = layer_index + 1;
+        }
+    }
+    finish_wave(_layers.size());
+
+    for (const bool parallel : layer_is_parallel) {
+        plan.parallel_layer_count += parallel ? 1u : 0u;
+    }
+    if (plan.parallel_layer_count == 0) {
+        plan.fallback_reason = saw_insufficient_concurrency ?
+                                   ParallelRecordFallbackReason::InsufficientConcurrency :
+                               saw_insufficient_work ?
+                                   ParallelRecordFallbackReason::InsufficientWork :
+                                   ParallelRecordFallbackReason::NoEligibleLayer;
+        return plan;
+    }
+
+    plan.layers.reserve(_layers.size());
+    for (size_t layer_index = 0; layer_index < _layers.size(); ++layer_index) {
+        const uint32_t command_count = static_cast<uint32_t>(_layers[layer_index].command_types.size());
+        const bool     parallel      = layer_is_parallel[layer_index];
+        const uint32_t job_count = parallel ? static_cast<uint32_t>(layer_jobs[layer_index].size())
+                                            : (command_count == 0 ? 0u : 1u);
+
+        ParallelRecordLayerPlan layer_plan{
+            .layer_index   = static_cast<uint32_t>(layer_index),
+            .command_count = command_count,
+            .first_job     = static_cast<uint32_t>(plan.jobs.size()),
+            .job_count     = job_count,
+            .parallel      = parallel,
+        };
+
+        if (parallel) {
+            plan.jobs.insert(
+                plan.jobs.end(),
+                layer_jobs[layer_index].begin(),
+                layer_jobs[layer_index].end()
+            );
+        } else if (command_count != 0) {
+            plan.jobs.push_back({
+                .layer_index   = static_cast<uint32_t>(layer_index),
+                .command_begin = 0,
+                .command_count = command_count,
+                .work_units    = layer_total_work[layer_index],
+            });
+        }
+
+        plan.layers.push_back(layer_plan);
+    }
+
+    plan.fallback_reason = ParallelRecordFallbackReason::None;
+    return plan;
+}
+
+} // namespace Moer::Render
+
+#endif

--- a/source/runtime/render/rhi/RHIRecordDiagnostics.h
+++ b/source/runtime/render/rhi/RHIRecordDiagnostics.h
@@ -18,6 +18,10 @@ namespace Moer::Render {
 
 enum class RecordCapability : uint8_t {
     SerialOnly,
+    // The command body may be recorded on an allocator-local primary after
+    // the coordinator has completed resource-state preprocessing. Descriptor
+    // commands additionally require an immutable binder copy and a disjoint
+    // descriptor range lease.
     ParallelPrimarySafe,
 };
 
@@ -36,6 +40,10 @@ constexpr RecordConstraint operator|(RecordConstraint _lhs, RecordConstraint _rh
     return static_cast<RecordConstraint>(
         static_cast<uint32_t>(_lhs) | static_cast<uint32_t>(_rhs)
     );
+}
+
+constexpr bool HasRecordConstraint(RecordConstraint _value, RecordConstraint _constraint) {
+    return (static_cast<uint32_t>(_value) & static_cast<uint32_t>(_constraint)) != 0;
 }
 
 struct CommandRecordTraits {
@@ -60,23 +68,27 @@ constexpr CommandRecordTraits GetCommandRecordTraits(Command::EType _type) {
                     Constraint::MutatesCommandPayload | Constraint::AllocatorSideEffect |
                         Constraint::QueueOrHostSideEffect};
         case Type::BufferToBuffer:
-            return {"BufferToBuffer", Capability::SerialOnly, false, Constraint::GlobalResourceState};
+            return {"BufferToBuffer", Capability::ParallelPrimarySafe, false,
+                    Constraint::GlobalResourceState};
         case Type::BufferToTexture:
-            return {"BufferToTexture", Capability::SerialOnly, false, Constraint::GlobalResourceState};
+            return {"BufferToTexture", Capability::ParallelPrimarySafe, false,
+                    Constraint::GlobalResourceState};
         case Type::TextureToBuffer:
-            return {"TextureToBuffer", Capability::SerialOnly, false, Constraint::GlobalResourceState};
+            return {"TextureToBuffer", Capability::ParallelPrimarySafe, false,
+                    Constraint::GlobalResourceState};
         case Type::UploadTexture:
             return {"UploadTexture", Capability::SerialOnly, false,
                     Constraint::MutatesCommandPayload | Constraint::AllocatorSideEffect |
                         Constraint::GlobalResourceState};
         case Type::TextureToTexture:
-            return {"TextureToTexture", Capability::SerialOnly, false, Constraint::GlobalResourceState};
+            return {"TextureToTexture", Capability::ParallelPrimarySafe, false,
+                    Constraint::GlobalResourceState};
         case Type::CopyBackTexture:
             return {"CopyBackTexture", Capability::SerialOnly, false,
                     Constraint::MutatesCommandPayload | Constraint::AllocatorSideEffect |
                         Constraint::QueueOrHostSideEffect};
         case Type::ShaderDispatch:
-            return {"ShaderDispatch", Capability::SerialOnly, true,
+            return {"ShaderDispatch", Capability::ParallelPrimarySafe, true,
                     Constraint::SharedDescriptorBinder | Constraint::GlobalResourceState};
         case Type::BuildAccel:
             return {"BuildAccel", Capability::SerialOnly, false,
@@ -96,19 +108,19 @@ constexpr CommandRecordTraits GetCommandRecordTraits(Command::EType _type) {
                     Constraint::MutatesCommandPayload | Constraint::QueueOrHostSideEffect |
                         Constraint::GlobalResourceState};
         case Type::SetDrawState:
-            return {"SetDrawState", Capability::SerialOnly, true,
+            return {"SetDrawState", Capability::ParallelPrimarySafe, true,
                     Constraint::SharedDescriptorBinder | Constraint::GlobalResourceState};
         case Type::SetGeometryPassDrawState:
             return {"SetGeometryPassDrawState", Capability::SerialOnly, false,
                     Constraint::UnsupportedBackendPath};
         case Type::MultiDraw:
-            return {"MultiDraw", Capability::SerialOnly, true,
+            return {"MultiDraw", Capability::ParallelPrimarySafe, true,
                     Constraint::SharedDescriptorBinder | Constraint::GlobalResourceState};
         case Type::UpdateBindlessArray:
             return {"UpdateBindlessArray", Capability::SerialOnly, false,
                     Constraint::QueueOrHostSideEffect | Constraint::GlobalResourceState};
         case Type::ClearResource:
-            return {"ClearResource", Capability::SerialOnly, true,
+            return {"ClearResource", Capability::ParallelPrimarySafe, true,
                     Constraint::GlobalResourceState};
         case Type::Scope:
             return {"Scope", Capability::SerialOnly, false, Constraint::ProfilerOrScope};
@@ -123,6 +135,25 @@ constexpr CommandRecordTraits GetCommandRecordTraits(Command::EType _type) {
 
 constexpr bool IsParallelRecordCandidate(Command::EType _type) {
     return GetCommandRecordTraits(_type).measurement_candidate;
+}
+
+// A failed worker recording may be replayed on a fresh coordinator command
+// buffer only when visiting the command cannot consume payloads, allocate
+// transient resources, register completion callbacks, touch profiler/query
+// state, or perform host/queue side effects. Global resource state is allowed
+// because it is resolved exactly once by the coordinator before workers run;
+// descriptor binding is allowed because every visit uses an immutable binder
+// copy and a submit-local descriptor lease.
+constexpr bool IsParallelRecordReplaySafe(Command::EType _type) {
+    const CommandRecordTraits traits = GetCommandRecordTraits(_type);
+    constexpr RecordConstraint replay_forbidden =
+        RecordConstraint::MutatesCommandPayload |
+        RecordConstraint::AllocatorSideEffect |
+        RecordConstraint::ProfilerOrScope |
+        RecordConstraint::QueueOrHostSideEffect |
+        RecordConstraint::UnsupportedBackendPath;
+    return traits.capability == RecordCapability::ParallelPrimarySafe &&
+           !HasRecordConstraint(traits.constraints, replay_forbidden);
 }
 
 class StableRecordHash {

--- a/source/runtime/render/rhi/RHIResource.cpp
+++ b/source/runtime/render/rhi/RHIResource.cpp
@@ -11,21 +11,21 @@ void RHIResource::Destroy() {
 }
 namespace Moer::Render {
 
-uint2 TextureWithHandle::GetSize(uint mip) {
+uint2 TextureWithHandle::GetSize(uint mip) const {
     return uint2(std::max(1u, tex->GetExtent().x >> mip), std::max(1u, tex->GetExtent().y >> mip));
 }
-uint TextureWithHandle::GetSizeX(uint mip) {
+uint TextureWithHandle::GetSizeX(uint mip) const {
     return std::max(1u, tex->GetExtent().x >> mip);
 }
-uint TextureWithHandle::GetSizeY(uint mip) {
+uint TextureWithHandle::GetSizeY(uint mip) const {
     return std::max(1u, tex->GetExtent().y >> mip);
 }
-Rect2D TextureWithHandle::GetRect2D(uint mip) {
+Rect2D TextureWithHandle::GetRect2D(uint mip) const {
     uint2 size = GetSize(mip);
     return Rect2D(0, 0, size.x, size.y);
 }
 
-uint TextureWithHandle::GetMipHandle(uint mip) {
+uint TextureWithHandle::GetMipHandle(uint mip) const {
     if (mip_handles.size() > mip) {
         return mip_handles[mip];
     }

--- a/source/runtime/render/rhi/RHIResource.h
+++ b/source/runtime/render/rhi/RHIResource.h
@@ -156,11 +156,11 @@ struct TextureWithHandle {
     uint        hdl;         //主Handle
     Array<uint> mip_handles; //每个Mip的Handle
 
-    uint2  GetSize(uint mip = 0);
-    uint   GetSizeX(uint mip = 0);
-    uint   GetSizeY(uint mip = 0);
-    Rect2D GetRect2D(uint mip = 0);
-    uint   GetMipHandle(uint mip);
+    uint2  GetSize(uint mip = 0) const;
+    uint   GetSizeX(uint mip = 0) const;
+    uint   GetSizeY(uint mip = 0) const;
+    Rect2D GetRect2D(uint mip = 0) const;
+    uint   GetMipHandle(uint mip) const;
 };
 
 struct DepthBufferWithHandle {
@@ -801,6 +801,9 @@ public:
         uint8        num_mips;
         uint8        array_layer;
         uint8        array_count;
+        uint64        array_generation;
+        uint64        slot_generation;
+        uint64        command_token;
         bool         free;
     };
 
@@ -809,6 +812,9 @@ public:
         uint         array_idx;
         uint         slot;
         EPixelFormat format;
+        uint64       array_generation;
+        uint64       slot_generation;
+        uint64       command_token;
         bool         free;
     };
 
@@ -834,6 +840,7 @@ protected:
     friend class UpdateBindlessArrayCmd;
 
     virtual UniquePtr<class Command> CreateUpdateCommand() = 0;
+    virtual void DiscardUpdateCommand(const Array<UpdateCmd>&) {}
 };
 
 struct ArrayArgReference {

--- a/source/runtime/render/rhi/RHISubmissionTopology.h
+++ b/source/runtime/render/rhi/RHISubmissionTopology.h
@@ -1,0 +1,329 @@
+#pragma once
+
+#include "rhi/RHICommon.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <limits>
+#include <optional>
+#include <span>
+#include <utility>
+#include <vector>
+
+namespace Moer::Render {
+
+// Translation is parallel by default. SerialControl is an explicit CPU-side
+// scheduling barrier; it does not change the queue on which GPU work executes.
+enum class ERHITranslateExecutionClass : uint8_t {
+    Parallel      = 0,
+    SerialControl = 1,
+};
+
+struct RHISubmitSegment {
+    EQueueType queue{EQueueType::Ignore};
+    size_t     begin{0};
+    size_t     end{0};
+
+    [[nodiscard]] constexpr bool IsEmpty() const noexcept {
+        return begin == end;
+    }
+};
+
+struct SourceSubmitKey {
+    uint64_t op_seq{0};
+    uint32_t submit_idx{0};
+
+    friend constexpr bool operator==(const SourceSubmitKey&, const SourceSubmitKey&) = default;
+
+    friend constexpr bool operator<(const SourceSubmitKey& _lhs, const SourceSubmitKey& _rhs) {
+        return _lhs.op_seq < _rhs.op_seq ||
+               (_lhs.op_seq == _rhs.op_seq && _lhs.submit_idx < _rhs.submit_idx);
+    }
+};
+
+struct SubmissionKey {
+    uint64_t op_seq{0};
+    uint32_t submit_idx{0};
+
+    friend constexpr bool operator==(const SubmissionKey&, const SubmissionKey&) = default;
+
+    friend constexpr bool operator<(const SubmissionKey& _lhs, const SubmissionKey& _rhs) {
+        return _lhs.op_seq < _rhs.op_seq ||
+               (_lhs.op_seq == _rhs.op_seq && _lhs.submit_idx < _rhs.submit_idx);
+    }
+};
+
+struct SourceSubmitKeyHash {
+    size_t operator()(const SourceSubmitKey& _key) const noexcept {
+        size_t hash = std::hash<uint64_t>{}(_key.op_seq);
+        hash ^= std::hash<uint32_t>{}(_key.submit_idx) + 0x9e3779b9u + (hash << 6u) +
+                (hash >> 2u);
+        return hash;
+    }
+};
+
+struct SubmissionKeyHash {
+    size_t operator()(const SubmissionKey& _key) const noexcept {
+        size_t hash = std::hash<uint64_t>{}(_key.op_seq);
+        hash ^= std::hash<uint32_t>{}(_key.submit_idx) + 0x9e3779b9u + (hash << 6u) +
+                (hash >> 2u);
+        return hash;
+    }
+};
+
+// This deliberately contains no RHI resource ownership. It is the immutable
+// description consumed by the CPU topology planner before backend translation.
+struct RHISourceSubmitDescription {
+    EQueueType                       root_queue{EQueueType::Ignore};
+    size_t                           command_count{0};
+    std::span<const RHISubmitSegment> segments{};
+    ERHITranslateExecutionClass      execution_class{
+        ERHITranslateExecutionClass::Parallel
+    };
+    bool has_side_effects{false};
+};
+
+enum class ERHISubmissionTopologyError : uint8_t {
+    None = 0,
+    InvalidRootQueue,
+    InvalidExecutionClass,
+    InvalidSegmentQueue,
+    InvalidSegmentRange,
+    NonContiguousSegmentCoverage,
+    IndexOverflow,
+};
+
+struct RHISubmissionSegmentPlan {
+    SubmissionKey               key{};
+    SourceSubmitKey             source_key{};
+    uint32_t                    source_segment_index{0};
+    RHISubmitSegment            segment{};
+    ERHITranslateExecutionClass execution_class{
+        ERHITranslateExecutionClass::Parallel
+    };
+
+    bool inherit_source_wait_events{false};
+    bool inherit_source_signal_events_and_callbacks{false};
+    bool inherit_source_runtime_payload{false};
+
+    // Logical CPU translation prerequisites, in source order. GPU queue and
+    // resource dependencies are layered on by the backend preprocessor.
+    std::vector<SubmissionKey> dependencies{};
+};
+
+struct RHISourceSubmitPlan {
+    SourceSubmitKey             source_key{};
+    EQueueType                  root_queue{EQueueType::Ignore};
+    size_t                      command_count{0};
+    ERHITranslateExecutionClass execution_class{
+        ERHITranslateExecutionClass::Parallel
+    };
+    bool   has_side_effects{false};
+    size_t segment_plan_begin{0};
+    size_t segment_plan_count{0};
+};
+
+struct RHISubmissionTopologyPlan {
+    static constexpr size_t NoErrorIndex = std::numeric_limits<size_t>::max();
+
+    ERHISubmissionTopologyError error{ERHISubmissionTopologyError::None};
+    size_t error_source_index{NoErrorIndex};
+    size_t error_segment_index{NoErrorIndex};
+
+    std::vector<RHISubmissionSegmentPlan> segments{};
+    std::vector<RHISourceSubmitPlan>      source_plans{};
+
+    [[nodiscard]] constexpr bool IsValid() const noexcept {
+        return error == ERHISubmissionTopologyError::None;
+    }
+};
+
+namespace RHISubmissionTopologyDetail {
+
+[[nodiscard]] inline constexpr bool IsValidQueue(EQueueType _queue) noexcept {
+    return _queue == EQueueType::Graphics || _queue == EQueueType::Compute ||
+           _queue == EQueueType::Copy;
+}
+
+[[nodiscard]] inline constexpr bool
+IsValidExecutionClass(ERHITranslateExecutionClass _execution_class) noexcept {
+    return _execution_class == ERHITranslateExecutionClass::Parallel ||
+           _execution_class == ERHITranslateExecutionClass::SerialControl;
+}
+
+inline void AppendUnique(
+    std::vector<SubmissionKey>& _dependencies,
+    const SubmissionKey&        _key
+) {
+    for (const SubmissionKey& dependency : _dependencies) {
+        if (dependency == _key) {
+            return;
+        }
+    }
+    _dependencies.emplace_back(_key);
+}
+
+[[nodiscard]] inline RHISubmissionTopologyPlan Fail(
+    ERHISubmissionTopologyError _error,
+    size_t                      _source_index,
+    size_t                      _segment_index = RHISubmissionTopologyPlan::NoErrorIndex
+) {
+    RHISubmissionTopologyPlan result{};
+    result.error               = _error;
+    result.error_source_index  = _source_index;
+    result.error_segment_index = _segment_index;
+    return result;
+}
+
+} // namespace RHISubmissionTopologyDetail
+
+// All source descriptions belong to the operation identified by _op_seq_base.
+// Source keys use the input index; translated submission keys use one stable,
+// monotonically increasing index across every retained segment.
+[[nodiscard]] inline RHISubmissionTopologyPlan BuildRHISubmissionTopology(
+    std::span<const RHISourceSubmitDescription> _descriptions,
+    uint64_t                                    _op_seq_base
+) {
+    using namespace RHISubmissionTopologyDetail;
+
+    if (_descriptions.size() > std::numeric_limits<uint32_t>::max()) {
+        return Fail(ERHISubmissionTopologyError::IndexOverflow, 0);
+    }
+
+    RHISubmissionTopologyPlan result{};
+    result.source_plans.reserve(_descriptions.size());
+
+    std::vector<SubmissionKey> parallel_frontier{};
+    std::optional<SubmissionKey> last_serial_control{};
+
+    for (size_t source_index = 0; source_index < _descriptions.size(); ++source_index) {
+        const RHISourceSubmitDescription& description = _descriptions[source_index];
+        if (!IsValidQueue(description.root_queue)) {
+            return Fail(ERHISubmissionTopologyError::InvalidRootQueue, source_index);
+        }
+        if (!IsValidExecutionClass(description.execution_class)) {
+            return Fail(ERHISubmissionTopologyError::InvalidExecutionClass, source_index);
+        }
+
+        const RHISubmitSegment synthesized_segment{
+            .queue = description.root_queue,
+            .begin = 0,
+            .end   = description.command_count,
+        };
+        const std::span<const RHISubmitSegment> source_segments = description.segments.empty()
+            ? std::span<const RHISubmitSegment>(&synthesized_segment, 1)
+            : description.segments;
+
+        if (source_segments.size() > std::numeric_limits<uint32_t>::max()) {
+            return Fail(ERHISubmissionTopologyError::IndexOverflow, source_index);
+        }
+
+        size_t expected_begin = 0;
+        for (size_t segment_index = 0; segment_index < source_segments.size(); ++segment_index) {
+            const RHISubmitSegment& segment = source_segments[segment_index];
+            if (!IsValidQueue(segment.queue)) {
+                return Fail(
+                    ERHISubmissionTopologyError::InvalidSegmentQueue,
+                    source_index,
+                    segment_index
+                );
+            }
+            if (segment.begin > segment.end || segment.end > description.command_count ||
+                (description.command_count != 0 && segment.IsEmpty()) ||
+                (description.command_count == 0 && source_segments.size() != 1)) {
+                return Fail(
+                    ERHISubmissionTopologyError::InvalidSegmentRange,
+                    source_index,
+                    segment_index
+                );
+            }
+            if (segment.begin != expected_begin) {
+                return Fail(
+                    ERHISubmissionTopologyError::NonContiguousSegmentCoverage,
+                    source_index,
+                    segment_index
+                );
+            }
+            expected_begin = segment.end;
+        }
+        if (expected_begin != description.command_count) {
+            return Fail(
+                ERHISubmissionTopologyError::NonContiguousSegmentCoverage,
+                source_index,
+                source_segments.size()
+            );
+        }
+
+        RHISourceSubmitPlan source_plan{
+            .source_key = SourceSubmitKey{
+                _op_seq_base,
+                static_cast<uint32_t>(source_index),
+            },
+            .root_queue       = description.root_queue,
+            .command_count    = description.command_count,
+            .execution_class = description.execution_class,
+            .has_side_effects = description.has_side_effects,
+            .segment_plan_begin = result.segments.size(),
+            .segment_plan_count = 0,
+        };
+
+        const bool retain_empty_submit =
+            description.command_count == 0 && description.has_side_effects;
+        const bool retain_segments = description.command_count != 0 || retain_empty_submit;
+        if (retain_segments) {
+            if (result.segments.size() > std::numeric_limits<uint32_t>::max() -
+                    source_segments.size()) {
+                return Fail(ERHISubmissionTopologyError::IndexOverflow, source_index);
+            }
+
+            for (size_t segment_index = 0; segment_index < source_segments.size(); ++segment_index) {
+                const SubmissionKey key{
+                    _op_seq_base,
+                    static_cast<uint32_t>(result.segments.size()),
+                };
+                RHISubmissionSegmentPlan segment_plan{
+                    .key                  = key,
+                    .source_key           = source_plan.source_key,
+                    .source_segment_index = static_cast<uint32_t>(segment_index),
+                    .segment              = source_segments[segment_index],
+                    .execution_class      = description.execution_class,
+                };
+
+                if (description.execution_class ==
+                    ERHITranslateExecutionClass::SerialControl) {
+                    // Older keys are appended first so dependency order remains
+                    // deterministic and monotonic for an identical input stream.
+                    if (last_serial_control.has_value()) {
+                        AppendUnique(segment_plan.dependencies, *last_serial_control);
+                    }
+                    for (const SubmissionKey& frontier_key : parallel_frontier) {
+                        AppendUnique(segment_plan.dependencies, frontier_key);
+                    }
+                    parallel_frontier.clear();
+                    last_serial_control = key;
+                } else {
+                    if (last_serial_control.has_value()) {
+                        AppendUnique(segment_plan.dependencies, *last_serial_control);
+                    }
+                    parallel_frontier.emplace_back(key);
+                }
+
+                result.segments.emplace_back(std::move(segment_plan));
+            }
+
+            source_plan.segment_plan_count = result.segments.size() - source_plan.segment_plan_begin;
+            RHISubmissionSegmentPlan& first = result.segments[source_plan.segment_plan_begin];
+            RHISubmissionSegmentPlan& last  = result.segments.back();
+            first.inherit_source_wait_events = true;
+            last.inherit_source_signal_events_and_callbacks = true;
+            last.inherit_source_runtime_payload = true;
+        }
+
+        result.source_plans.emplace_back(std::move(source_plan));
+    }
+
+    return result;
+}
+
+} // namespace Moer::Render

--- a/source/runtime/render/rhi/vulkan/VulkanAllocator.cpp
+++ b/source/runtime/render/rhi/vulkan/VulkanAllocator.cpp
@@ -52,7 +52,11 @@ bool VulkanAllocatorBase::ResetCmdList() {
             .queue      = queue,
         }
     );
-    return result == VK_SUCCESS;
+    if (result == VK_SUCCESS) {
+        cmd_list->SetDescriptorPushLease({});
+        return true;
+    }
+    return false;
 }
 
 void VulkanAllocatorBase::CompleteSuccess() {
@@ -65,6 +69,12 @@ void VulkanAllocatorBase::CompleteSuccess() {
 
 bool VulkanAllocatorBase::Reset() {
     return ResetCmdList();
+}
+
+bool VulkanAllocatorBase::ResetAbandoned() {
+    on_complete.clear();
+    tracker.Reset();
+    return Reset();
 }
 
 // VulkanPresentor

--- a/source/runtime/render/rhi/vulkan/VulkanAllocator.h
+++ b/source/runtime/render/rhi/vulkan/VulkanAllocator.h
@@ -59,6 +59,9 @@ public:
 
     virtual void CompleteSuccess();
     virtual bool Reset();
+    // A recorder that was never submitted must not run success callbacks.
+    // It can still reset and return to the pool after all worker jobs joined.
+    bool ResetAbandoned();
 
 protected:
     std::optional<VulkanCmdAllocator> cmd_allocator;

--- a/source/runtime/render/rhi/vulkan/VulkanCommand.h
+++ b/source/runtime/render/rhi/vulkan/VulkanCommand.h
@@ -9,12 +9,14 @@
 #include "VulkanPlatform.h"
 #include "VulkanRHIResource.h"
 #include "VulkanResourceTracker.h"
+#include <memory>
 #include <string_view>
 
 namespace Moer::Render {
 class VulkanDevice;
 class VulkanDescriptorSetAllocator;
 class VulkanRHIGraphicsPipelineState;
+struct VulkanDescriptorPushLeaseState;
 
 struct PushConstantInfo;
 class VulkanCmdList {
@@ -24,12 +26,13 @@ private:
     VkCommandBuffer           command_buffer;
     class VulkanCmdAllocator* allocator;
     VulkanDevice&             device;
+    std::shared_ptr<VulkanDescriptorPushLeaseState> descriptor_push_lease;
 
 public:
     VulkanCmdList(VulkanCmdAllocator* _allocator, VulkanDevice& _device);
     ~VulkanCmdList();
-    void Begin();
-    void End();
+    [[nodiscard]] VkResult Begin();
+    [[nodiscard]] VkResult End();
     void
     CopyBuffer(VulkanBuffer* _src, VulkanBuffer* _dst, uint64 _size, uint64 _src_offset, uint64 _dst_offset);
     void CopyBufferToTexture(
@@ -138,6 +141,9 @@ public:
     void UploadDescriptors(const PipelineHandle& _pso_handle);
     void UploadPushConstants(const PipelineHandle& _pso_handle, std::span<const uint> _data);
     void BindDescriptors(const PipelineHandle& _pso_handle, const ArrayArguments& _args);
+    void SetDescriptorPushLease(std::shared_ptr<VulkanDescriptorPushLeaseState> _lease) {
+        descriptor_push_lease = std::move(_lease);
+    }
 
     //Raytracing
     void BuildAccelerationStructures(

--- a/source/runtime/render/rhi/vulkan/VulkanCommandList.cpp
+++ b/source/runtime/render/rhi/vulkan/VulkanCommandList.cpp
@@ -21,6 +21,8 @@
 #include "vulkan/vulkan_core.h"
 
 #include <cstdint>
+#include <optional>
+#include <stdexcept>
 #include <stdint.h>
 #include <string>
 #include <variant>
@@ -176,17 +178,17 @@ VulkanCmdList::VulkanCmdList(VulkanCmdAllocator* _alloc, VulkanDevice& _device) 
 VulkanCmdList::~VulkanCmdList() {
     vkFreeCommandBuffers(device.GetDevice(), allocator->GetHandle(), 1, &command_buffer);
 }
-void VulkanCmdList::Begin() {
+VkResult VulkanCmdList::Begin() {
     VkCommandBufferBeginInfo begin_info = {
         .sType            = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO,
         .pNext            = nullptr,
         .flags            = 0,
         .pInheritanceInfo = nullptr
     };
-    VK_CHECK_RESULT(vkBeginCommandBuffer(command_buffer, &begin_info));
+    return vkBeginCommandBuffer(command_buffer, &begin_info);
 }
-void VulkanCmdList::End() {
-    VK_CHECK_RESULT(vkEndCommandBuffer(command_buffer));
+VkResult VulkanCmdList::End() {
+    return vkEndCommandBuffer(command_buffer);
 }
 void VulkanCmdList::CopyBuffer(
     VulkanBuffer* _src,
@@ -598,10 +600,30 @@ void VulkanCmdList::BindDescriptors(const PipelineHandle& _pso_handle, const Arr
     auto* vk_pso = reinterpret_cast<VulkanPipelineState*>(_pso_handle.handle);
 
     assert(vk_pso && vk_pso->bind_template != nullptr && "Pipeline state has no bind template!");
-    VulkanPipelineParamBinder& bind_template        = *vk_pso->bind_template;
-    VulkanDescriptorHeap&      descriptor_heap      = device.GetGlobalDescriptorHeap();
-    auto&                      set_binders          = bind_template.set_binders;
-    uint64                     g_global_desc_offset = descriptor_heap.current_offset;
+    // Pipeline metadata remains immutable across graphics/compute queues and
+    // parallel workers. Only the small per-bind address/offset arrays and push
+    // constant pointer are recorder-local; copying the full binder map would
+    // add unnecessary serial-path cost.
+    const VulkanPipelineParamBinder& bind_template = *vk_pso->bind_template;
+    const auto&                      set_binders   = bind_template.set_binders;
+    auto                             desc_buffers  = bind_template.desc_buffers;
+    auto desc_buffer_offsets = bind_template.desc_buffer_offsets;
+    VkPushConstantsInfoKHR push_constants_info = bind_template.push_constants_info;
+    VulkanDescriptorHeap&  descriptor_heap = device.GetGlobalDescriptorHeap();
+
+    uint64 descriptor_bytes = 0;
+    for (const auto& [set, binder] : set_binders) {
+        (void)set;
+        if (const auto* descriptor_set = std::get_if<VulkanDescriptorSetBinder>(&binder)) {
+            descriptor_bytes += descriptor_set->size;
+        }
+    }
+    const std::optional<uint64> descriptor_range =
+        descriptor_heap.ReservePushDescriptorRange(descriptor_push_lease, descriptor_bytes);
+    if (!descriptor_range.has_value()) {
+        throw std::runtime_error("descriptor submission lease exhausted");
+    }
+    uint64 next_descriptor_offset = *descriptor_range;
 
     for (auto& [set, binder] : set_binders) {
         std::visit(
@@ -609,22 +631,24 @@ void VulkanCmdList::BindDescriptors(const PipelineHandle& _pso_handle, const Arr
                 [&](const VulkanBindlessSetArray& _binder) {
                     BindlessArrayRef     array = std::get<BindlessArrayRef>(_args[_binder.param_idx]);
                     VulkanBindlessArray* bindless_array = static_cast<VulkanBindlessArray*>(array.Get());
-                    bind_template.desc_buffers[_binder.desc_idx].address =
+                    desc_buffers[_binder.desc_idx].address =
                         bindless_array->bindless_buffer_descs->DeviceAddress();
                 },
                 [&](const VulkanBindlessSetSampler& _binder) {
                     BindlessArrayRef     array = std::get<BindlessArrayRef>(_args[_binder.param_idx]);
                     VulkanBindlessArray* bindless_array = static_cast<VulkanBindlessArray*>(array.Get());
-                    bind_template.desc_buffers[_binder.desc_idx].address =
+                    desc_buffers[_binder.desc_idx].address =
                         bindless_array->bindless_texture_descs->DeviceAddress();
                 },
                 [&](const VulkanBindlessSetImage& _binder) {
                     BindlessArrayRef     array = std::get<BindlessArrayRef>(_args[_binder.param_idx]);
                     VulkanBindlessArray* bindless_array = static_cast<VulkanBindlessArray*>(array.Get());
-                    bind_template.desc_buffers[_binder.desc_idx].address =
+                    desc_buffers[_binder.desc_idx].address =
                         bindless_array->bindless_texture_descs->DeviceAddress();
                 },
                 [&](const VulkanDescriptorSetBinder& _binder) {
+                    const uint64 descriptor_set_offset = next_descriptor_offset;
+                    next_descriptor_offset += _binder.size;
                     //normal resources
                     for (uint i = 0; i < _binder.writers.size(); ++i) {
                         auto& writer = _binder.writers[i];
@@ -644,10 +668,17 @@ void VulkanCmdList::BindDescriptors(const PipelineHandle& _pso_handle, const Arr
                                 .format;
                         switch (writer.descriptorType) {
                             case VK_DESCRIPTOR_TYPE_SAMPLER: {
+                                if (writer.descriptorCount != 1) {
+                                    throw std::runtime_error(
+                                        "sampler descriptor arrays are not supported by ArrayArguments"
+                                    );
+                                }
                                 uint64 src_handle = descriptor_heap.GetSamplerDescIdx(
                                     std::get<Sampler>(_args[set_info.param_idx])
                                 );
-                                descriptor_heap.PushSamplerDesc(src_handle, _binder.binding_infos[i].offset);
+                                descriptor_heap.WriteSamplerDesc(
+                                    src_handle, descriptor_set_offset + _binder.binding_infos[i].offset
+                                );
                                 break;
                             }
                             case VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE: {
@@ -655,17 +686,33 @@ void VulkanCmdList::BindDescriptors(const PipelineHandle& _pso_handle, const Arr
                                 if (writer.descriptorCount > 1) {
                                     const TextureViewArray& textures =
                                         std::get<TextureViewArray>(_args[set_info.param_idx]);
-                                    uint desc_size = std::min(writer.descriptorCount, uint(textures.size()));
-                                    for (uint j = 0; j < desc_size; ++j) {
-                                        VkImageLayout layout = GetSamplerImageLayout(textures[j]);
-                                        uint64        src_handle =
-                                            descriptor_heap.GetImageDescIdx(&textures[j], layout);
-                                        descriptor_heap.PushImageDesc(
+                                    if (textures.empty()) {
+                                        throw std::runtime_error(
+                                            "sampled-image descriptor array is empty"
+                                        );
+                                    }
+                                    if (textures.size() > writer.descriptorCount) {
+                                        throw std::runtime_error(
+                                            "sampled-image descriptor array exceeds its declared capacity"
+                                        );
+                                    }
+                                    // Shader array declarations encode a maximum capacity. Partial
+                                    // binding is not enabled for these transient descriptor leases,
+                                    // so alias unused slots to the last valid caller-provided view.
+                                    for (uint j = 0; j < writer.descriptorCount; ++j) {
+                                        const TextureView& texture = textures[std::min<size_t>(
+                                            j, textures.size() - 1
+                                        )];
+                                        VkImageLayout layout = GetSamplerImageLayout(texture);
+                                        uint64 src_handle = descriptor_heap.GetImageDescIdx(
+                                            &texture, layout, writer.descriptorType
+                                        );
+                                        descriptor_heap.WriteImageDesc(
                                             src_handle,
-                                            _binder.binding_infos[i].offset +
-                                                j * device.GetOptionalProperties()
-                                                        .descriptor_buffer_properties
-                                                        .sampledImageDescriptorSize
+                                            descriptor_set_offset + _binder.binding_infos[i].offset +
+                                                j * descriptor_heap.GetDescriptorSize(
+                                                        writer.descriptorType
+                                                    )
                                         );
                                     }
                                     break;
@@ -674,81 +721,123 @@ void VulkanCmdList::BindDescriptors(const PipelineHandle& _pso_handle, const Arr
                                     GetSamplerImageLayout(std::get<TextureView>(_args[set_info.param_idx]));
 
                                 uint64 src_handle = descriptor_heap.GetImageDescIdx(
-                                    &std::get<TextureView>(_args[set_info.param_idx]), layout
+                                    &std::get<TextureView>(_args[set_info.param_idx]),
+                                    layout,
+                                    writer.descriptorType
                                 );
-                                descriptor_heap.PushImageDesc(src_handle, _binder.binding_infos[i].offset);
+                                descriptor_heap.WriteImageDesc(
+                                    src_handle, descriptor_set_offset + _binder.binding_infos[i].offset
+                                );
                                 break;
                             }
                             case VK_DESCRIPTOR_TYPE_STORAGE_IMAGE: {
                                 if (writer.descriptorCount > 1) {
                                     const TextureViewArray& textures =
                                         std::get<TextureViewArray>(_args[set_info.param_idx]);
-                                    uint desc_size = std::min(writer.descriptorCount, uint(textures.size()));
-                                    for (uint j = 0; j < desc_size; ++j) {
-                                        uint64 src_handle = descriptor_heap.GetImageDescIdx(
-                                            &textures[j], VK_IMAGE_LAYOUT_GENERAL
+                                    if (textures.empty()) {
+                                        throw std::runtime_error(
+                                            "storage-image descriptor array is empty"
                                         );
-                                        descriptor_heap.PushImageDesc(
+                                    }
+                                    if (textures.size() > writer.descriptorCount) {
+                                        throw std::runtime_error(
+                                            "storage-image descriptor array exceeds its declared capacity"
+                                        );
+                                    }
+                                    // Keep every fixed layout slot initialized while the shader's
+                                    // real element count controls which indices are semantically used.
+                                    for (uint j = 0; j < writer.descriptorCount; ++j) {
+                                        const TextureView& texture = textures[std::min<size_t>(
+                                            j, textures.size() - 1
+                                        )];
+                                        uint64 src_handle = descriptor_heap.GetImageDescIdx(
+                                            &texture,
+                                            VK_IMAGE_LAYOUT_GENERAL,
+                                            writer.descriptorType
+                                        );
+                                        descriptor_heap.WriteImageDesc(
                                             src_handle,
-                                            _binder.binding_infos[i].offset +
-                                                j * device.GetOptionalProperties()
-                                                        .descriptor_buffer_properties
-                                                        .storageImageDescriptorSize
+                                            descriptor_set_offset + _binder.binding_infos[i].offset +
+                                                j * descriptor_heap.GetDescriptorSize(
+                                                        writer.descriptorType
+                                                    )
                                         );
                                     }
                                     break;
                                 }
                                 uint64 src_handle = descriptor_heap.GetImageDescIdx(
-                                    &std::get<TextureView>(_args[set_info.param_idx]), VK_IMAGE_LAYOUT_GENERAL
+                                    &std::get<TextureView>(_args[set_info.param_idx]),
+                                    VK_IMAGE_LAYOUT_GENERAL,
+                                    writer.descriptorType
                                 );
-                                descriptor_heap.PushImageDesc(src_handle, _binder.binding_infos[i].offset);
+                                descriptor_heap.WriteImageDesc(
+                                    src_handle, descriptor_set_offset + _binder.binding_infos[i].offset
+                                );
                                 break;
                             }
-                            case VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER: {
-                                // VulkanBuffer* buffer     = ResourceCast(std::get<BufferView>(_args[set_info.param_idx]).GetBuffer());
-                                uint64 src_handle = descriptor_heap.GetBufferDescIdx(
-                                    std::get<BufferView>(_args[set_info.param_idx]),
-                                    writer.descriptorType,
-                                    format
-                                );
-                                descriptor_heap.PushUniformDesc(src_handle, _binder.binding_infos[i].offset);
-                                break;
-                            }
+                            case VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER:
                             case VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER:
                             case VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER:
                             case VK_DESCRIPTOR_TYPE_STORAGE_BUFFER: {
+                                auto write_buffer_descriptor = [&](
+                                                                   const BufferView& _buffer,
+                                                                   uint64 _dst_offset
+                                                               ) {
+                                    const uint64 src_handle = descriptor_heap.GetBufferDescIdx(
+                                        _buffer, writer.descriptorType, format
+                                    );
+                                    if (writer.descriptorType == VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER) {
+                                        descriptor_heap.WriteUniformDesc(src_handle, _dst_offset);
+                                    } else {
+                                        descriptor_heap.WriteStorageDesc(src_handle, _dst_offset);
+                                    }
+                                };
                                 if (writer.descriptorCount > 1) {
                                     const BufferViewArray& buffers =
                                         std::get<BufferViewArray>(_args[set_info.param_idx]);
-                                    for (uint j = 0; j < writer.descriptorCount; ++j) {
-                                        uint64 src_handle = descriptor_heap.GetBufferDescIdx(
-                                            buffers[j], writer.descriptorType, format
+                                    if (buffers.empty()) {
+                                        throw std::runtime_error(
+                                            "buffer descriptor array is empty"
                                         );
-                                        descriptor_heap.PushStorageDesc(
-                                            src_handle,
-                                            _binder.binding_infos[i].offset +
-                                                j * device.GetOptionalProperties()
-                                                        .descriptor_buffer_properties
-                                                        .storageBufferDescriptorSize
+                                    }
+                                    if (buffers.size() > writer.descriptorCount) {
+                                        throw std::runtime_error(
+                                            "buffer descriptor array exceeds its declared capacity"
+                                        );
+                                    }
+                                    // Match texture-array max-capacity semantics without relying on
+                                    // partially-bound descriptors or stale lease contents.
+                                    for (uint j = 0; j < writer.descriptorCount; ++j) {
+                                        write_buffer_descriptor(
+                                            buffers[std::min<size_t>(j, buffers.size() - 1)],
+                                            descriptor_set_offset + _binder.binding_infos[i].offset +
+                                                j * descriptor_heap.GetDescriptorSize(
+                                                        writer.descriptorType
+                                                    )
                                         );
                                     }
                                     break;
                                 }
-                                // VulkanBuffer* buffer     = ResourceCast(std::get<BufferView>(_args[set_info.param_idx]).GetBuffer());
-                                uint64 src_handle = descriptor_heap.GetBufferDescIdx(
+                                write_buffer_descriptor(
                                     std::get<BufferView>(_args[set_info.param_idx]),
-                                    writer.descriptorType,
-                                    format
+                                    descriptor_set_offset + _binder.binding_infos[i].offset
                                 );
-                                descriptor_heap.PushStorageDesc(src_handle, _binder.binding_infos[i].offset);
                                 break;
                             }
                             case VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_KHR: {
+                                if (writer.descriptorCount != 1) {
+                                    throw std::runtime_error(
+                                        "acceleration-structure descriptor arrays are not supported by "
+                                        "ArrayArguments"
+                                    );
+                                }
                                 VulkanAccelerationStructure* as = ResourceCast(
                                     std::get<RaytracingTlasRef>(_args[set_info.param_idx]).Get()
                                 );
                                 uint64 src_handle = descriptor_heap.GetAccelDescIdx(as);
-                                descriptor_heap.PushAccelDesc(src_handle, _binder.binding_infos[i].offset);
+                                descriptor_heap.WriteAccelDesc(
+                                    src_handle, descriptor_set_offset + _binder.binding_infos[i].offset
+                                );
                                 break;
                             }
                             case VK_DESCRIPTOR_TYPE_MAX_ENUM: {
@@ -756,28 +845,26 @@ void VulkanCmdList::BindDescriptors(const PipelineHandle& _pso_handle, const Arr
                                 break;
                             }
                             default: {
-                                assert(false && "Unsupported descriptor type!");
+                                throw std::runtime_error("unsupported descriptor type");
                             }
                         }
                     }
 
                     //set desc buffer offset
-                    bind_template.desc_buffer_offsets[_binder.offset_idx].offset =
-                        descriptor_heap.current_offset;
-                    descriptor_heap.IncrementOffset(_binder.size);
+                    desc_buffer_offsets[_binder.offset_idx].offset = descriptor_set_offset;
                     // device.vk_cmd_push_descriptor_set(command_buffer, _binder.bind_point, _binder.push_info.layout, _binder.push_info.set, _binder.writers.size(), _binder.writers.data());
                 }
             },
             binder
         );
     }
-    if (!bind_template.desc_buffers.empty()) {
+    if (!desc_buffers.empty()) {
         vkCmdBindDescriptorBuffersEXT(
-            command_buffer, bind_template.desc_buffers.size(), bind_template.desc_buffers.data()
+            command_buffer, desc_buffers.size(), desc_buffers.data()
         );
     }
 
-    for (const auto& desc_info : bind_template.desc_buffer_offsets) {
+    for (const auto& desc_info : desc_buffer_offsets) {
         uint   buffer_idx = desc_info.buf_idx;
         uint64 offset     = desc_info.offset;
         vkCmdSetDescriptorBufferOffsetsEXT(
@@ -785,9 +872,9 @@ void VulkanCmdList::BindDescriptors(const PipelineHandle& _pso_handle, const Arr
         );
     }
 
-    if (bind_template.push_constants_info.size > 0) {
-        bind_template.push_constants_info.pValues = _args.constants.data();
-        const auto& push_info                     = &bind_template.push_constants_info;
+    if (push_constants_info.size > 0) {
+        push_constants_info.pValues = _args.constants.data();
+        const auto& push_info       = &push_constants_info;
         vkCmdPushConstants(
             command_buffer,
             push_info->layout,

--- a/source/runtime/render/rhi/vulkan/VulkanDescriptor.cpp
+++ b/source/runtime/render/rhi/vulkan/VulkanDescriptor.cpp
@@ -13,6 +13,7 @@
 #include "vulkan/vulkan_core.h"
 
 #include <cassert>
+#include <stdexcept>
 
 const float default_pool_size[VK_DESCRIPTOR_TYPE_RANGE_SIZE] = {
     4096, // VK_DESCRIPTOR_TYPE_SAMPLER
@@ -30,6 +31,37 @@ const float default_pool_size[VK_DESCRIPTOR_TYPE_RANGE_SIZE] = {
 namespace Moer::Render {
 
 static constexpr std::string_view s_ring_desc_buffer_name = "VkDescriporHeap::RingDescriptorBuffer";
+static constexpr uint32           s_offline_descriptor_capacity = 10086;
+
+static uint GetBufferDescriptorSize(const VulkanDevice& _device, VkDescriptorType _type) {
+    const auto& properties = _device.GetOptionalProperties().descriptor_buffer_properties;
+    const bool robust_buffer_access =
+        _device.GetCoreFeatures().core_1_0.robustBufferAccess == VK_TRUE;
+    switch (_type) {
+        case VK_DESCRIPTOR_TYPE_STORAGE_BUFFER:
+            return static_cast<uint>(
+                robust_buffer_access ? properties.robustStorageBufferDescriptorSize
+                                     : properties.storageBufferDescriptorSize
+            );
+        case VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER:
+            return static_cast<uint>(
+                robust_buffer_access ? properties.robustUniformBufferDescriptorSize
+                                     : properties.uniformBufferDescriptorSize
+            );
+        case VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER:
+            return static_cast<uint>(
+                robust_buffer_access ? properties.robustStorageTexelBufferDescriptorSize
+                                     : properties.storageTexelBufferDescriptorSize
+            );
+        case VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER:
+            return static_cast<uint>(
+                robust_buffer_access ? properties.robustUniformTexelBufferDescriptorSize
+                                     : properties.uniformTexelBufferDescriptorSize
+            );
+        default:
+            throw std::runtime_error("unsupported buffer descriptor type");
+    }
+}
 
 VulkanDescriptorSetsLayout::VulkanDescriptorSetsLayout(
     VulkanDevice*                                        _device,
@@ -84,48 +116,67 @@ VkImageLayout DecideImageLayout(VkDescriptorType _type) {
 }
 
 VulkanDescriptorHeap::VulkanDescriptorHeap(VulkanDevice& _device) :
+    buffer_offset(0),
+    image_offset(0),
+    accel_offset(0),
     m_device(&_device),
-    storage_desc_stride(
-        _device.GetOptionalProperties().descriptor_buffer_properties.storageBufferDescriptorSize
-    ),
-    uniform_desc_stride(
-        _device.GetOptionalProperties().descriptor_buffer_properties.uniformBufferDescriptorSize
-    ),
+    storage_desc_stride(GetBufferDescriptorSize(_device, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER)),
+    uniform_desc_stride(GetBufferDescriptorSize(_device, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER)),
     storage_texel_desc_stride(
-        _device.GetOptionalProperties().descriptor_buffer_properties.storageTexelBufferDescriptorSize
+        GetBufferDescriptorSize(_device, VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER)
     ),
     uniform_texel_desc_stride(
-        _device.GetOptionalProperties().descriptor_buffer_properties.uniformTexelBufferDescriptorSize
+        GetBufferDescriptorSize(_device, VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER)
     ),
     buffer_desc_stride(
-        std::max(
-            _device.GetOptionalProperties().descriptor_buffer_properties.storageBufferDescriptorSize,
-            _device.GetOptionalProperties().descriptor_buffer_properties.uniformBufferDescriptorSize
-        )
+        std::max({
+            GetBufferDescriptorSize(_device, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER),
+            GetBufferDescriptorSize(_device, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER),
+            GetBufferDescriptorSize(_device, VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER),
+            GetBufferDescriptorSize(_device, VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER),
+        })
     ),
-    image_desc_stride(
+    sampled_image_desc_stride(
         _device.GetOptionalProperties().descriptor_buffer_properties.sampledImageDescriptorSize
     ),
-    texture_desc_offset(
-        _device.GetOptionalProperties().descriptor_buffer_properties.samplerDescriptorSize *
-        VulkanDevice::bindless_sampler_cnt
+    storage_image_desc_stride(
+        _device.GetOptionalProperties().descriptor_buffer_properties.storageImageDescriptorSize
+    ),
+    image_desc_stride(
+        std::max(
+            _device.GetOptionalProperties().descriptor_buffer_properties.sampledImageDescriptorSize,
+            _device.GetOptionalProperties().descriptor_buffer_properties.storageImageDescriptorSize
+        )
+    ),
+    sample_desc_stride(
+        _device.GetOptionalProperties().descriptor_buffer_properties.samplerDescriptorSize
     ),
     accel_desc_stride(
         _device.GetOptionalProperties().descriptor_buffer_properties.accelerationStructureDescriptorSize
     ),
-    image_offset(0),
-    buffer_offset(0) {
+    texture_desc_offset(
+        _device.GetOptionalProperties().descriptor_buffer_properties.samplerDescriptorSize *
+        VulkanDevice::bindless_sampler_cnt
+    ) {
 
-    buffer_desc_data.resize(10086 * buffer_desc_stride);
-    image_desc_data.resize(10086 * image_desc_stride);
-    accel_desc_data.resize(10086 * accel_desc_stride);
+    buffer_desc_data.resize(s_offline_descriptor_capacity * buffer_desc_stride);
+    image_desc_data.resize(
+        texture_desc_offset + s_offline_descriptor_capacity * image_desc_stride
+    );
+    accel_desc_data.resize(s_offline_descriptor_capacity * accel_desc_stride);
+    buffer_desc_types.resize(s_offline_descriptor_capacity, VK_DESCRIPTOR_TYPE_MAX_ENUM);
+    image_desc_types.resize(s_offline_descriptor_capacity, VK_DESCRIPTOR_TYPE_MAX_ENUM);
 
     VkBuffer           desc_buffer            = VK_NULL_HANDLE;
     VmaAllocation      desc_buffer_allocation = VK_NULL_HANDLE;
     VkBufferCreateInfo buffer_ci{VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO};
     // Increase descriptor buffer size to accommodate larger descriptor sets
     // Each frame gets enough space for all possible descriptors
-    buffer_ci.size  = s_queue_max_frame_in_flight * 1024 * 1024; // 1MB per frame
+    // Graphics and compute each retain their own in-flight slice budget. A
+    // shared three-slice pool can deadlock when one queue holds every slice
+    // while waiting on work that the other queue has not yet recorded.
+    constexpr uint32 descriptor_queue_count = 2;
+    buffer_ci.size = descriptor_queue_count * s_queue_max_frame_in_flight * 1024 * 1024;
     buffer_ci.usage = VK_BUFFER_USAGE_RESOURCE_DESCRIPTOR_BUFFER_BIT_EXT |
                       VK_BUFFER_USAGE_SAMPLER_DESCRIPTOR_BUFFER_BIT_EXT |
                       VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT;
@@ -151,23 +202,22 @@ VulkanDescriptorHeap::VulkanDescriptorHeap(VulkanDevice& _device) :
     );
 
     //fill offsets
-    ring_buffer_offsets.resize(m_device->cmd_alloc_limits);
+    ring_buffer_offsets.resize(descriptor_queue_count * m_device->cmd_alloc_limits);
 
     // Use descriptorBufferOffsetAlignment for ring buffer offset alignment
     uint64 alignment =
         m_device->GetOptionalProperties().descriptor_buffer_properties.descriptorBufferOffsetAlignment;
 
     // Calculate per-frame size conservatively to ensure each frame has enough space
-    uint64 per_frame_size = (buffer_ci.size / m_device->cmd_alloc_limits / alignment) * alignment;
+    uint64 per_frame_size = (buffer_ci.size / ring_buffer_offsets.size() / alignment) * alignment;
 
-    for (uint32_t i = 0; i < m_device->cmd_alloc_limits; ++i) {
+    for (uint32_t i = 0; i < ring_buffer_offsets.size(); ++i) {
         ring_buffer_offsets[i] = Moer::AlignUp(per_frame_size * i, alignment);
     }
-    current_offset = 0;
+    active_push_leases.resize(ring_buffer_offsets.size());
     vmaMapMemory(m_device->GetVmaAllocator(), ring_desc_buffer->GetAllocation(), (void**)&map_ptr);
 
     //fill sampler descs in image_data
-    sample_desc_stride = _device.GetOptionalProperties().descriptor_buffer_properties.samplerDescriptorSize;
     for (uint32_t i = 0; i < VulkanDevice::bindless_sampler_cnt; ++i) {
         VkDescriptorImageInfo  sampler_info{.sampler = VK_NULL_HANDLE};
         VkDescriptorGetInfoEXT desc_info{VK_STRUCTURE_TYPE_DESCRIPTOR_GET_INFO_EXT};
@@ -208,12 +258,25 @@ uint VulkanDescriptorHeap::GetBufferDescIdx(
     VkFormat          _format
 ) {
     assert(_in_buffer.GetBuffer() != nullptr && "buffer is nullptr");
-    uint idx = 0;
-
     VulkanBuffer* vk_buffer = ResourceCast(_in_buffer.GetBuffer());
-    auto&         indices   = vk_buffer->GetDescriptorIndices(_type);
+    VkFormat      buffer_format = VulkanEnumTranslator::METoVKFormat(_in_buffer.format);
+    _format = buffer_format == VK_FORMAT_UNDEFINED ? _format : buffer_format;
+    if (_type != VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER &&
+        _type != VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER) {
+        _format = VK_FORMAT_UNDEFINED;
+    }
 
-    auto it = indices.find(_in_buffer.byte_offset);
+    const VkBufferDescKey key{
+        .byte_offset = _in_buffer.byte_offset,
+        .byte_size   = _in_buffer.GetByteSize(),
+        .format      = _format,
+    };
+
+    std::lock_guard<std::mutex> lock(m_mutex);
+    uint          idx     = 0;
+    auto&         indices = vk_buffer->GetDescriptorIndices(_type);
+
+    auto it = indices.find(key);
     if (it != indices.end()) {
         return it->second * buffer_desc_stride;
     } else {
@@ -222,27 +285,21 @@ uint VulkanDescriptorHeap::GetBufferDescIdx(
         buffer_info.range   = _in_buffer.GetByteSize();
         VkDescriptorGetInfoEXT buffer_desc_info{VK_STRUCTURE_TYPE_DESCRIPTOR_GET_INFO_EXT};
         buffer_desc_info.type  = _type;
-        uint     desc_size     = 0;
-        VkFormat buffer_format = VulkanEnumTranslator::METoVKFormat(_in_buffer.format);
-        _format                = buffer_format == VK_FORMAT_UNDEFINED ? _format : buffer_format;
+        const uint desc_size = GetDescriptorSize(_type);
         switch (_type) {
             case VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER:
                 buffer_info.format                        = _format;
                 buffer_desc_info.data.pStorageTexelBuffer = &buffer_info;
-                desc_size                                 = storage_texel_desc_stride;
                 break;
             case VK_DESCRIPTOR_TYPE_STORAGE_BUFFER:
                 buffer_desc_info.data.pStorageBuffer = &buffer_info;
-                desc_size                            = storage_desc_stride;
                 break;
             case VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER:
                 buffer_desc_info.data.pUniformBuffer = &buffer_info;
-                desc_size                            = uniform_desc_stride;
                 break;
             case VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER:
                 buffer_info.format                        = _format;
                 buffer_desc_info.data.pUniformTexelBuffer = &buffer_info;
-                desc_size                                 = uniform_texel_desc_stride;
                 break;
             default:
                 LOG_ERROR(
@@ -251,21 +308,22 @@ uint VulkanDescriptorHeap::GetBufferDescIdx(
                 assert(false && "Unsupported buffer descriptor type");
                 return 0;
         }
-        assert(
-            m_device->GetOptionalProperties().descriptor_buffer_properties.storageBufferDescriptorSize <=
-            sizeof(BufferCpuDescHandle)
-        );
-
-        std::lock_guard<std::mutex> lock(m_mutex);
         if (buffer_free_list.empty()) {
             idx = buffer_offset / buffer_desc_stride;
+            if (idx >= buffer_desc_types.size()) {
+                throw std::runtime_error("offline buffer descriptor cache exhausted");
+            }
             buffer_offset += buffer_desc_stride;
         } else {
             idx = buffer_free_list.back();
             buffer_free_list.pop_back();
+            if (idx >= buffer_desc_types.size()) {
+                throw std::runtime_error("offline buffer descriptor free-list index is invalid");
+            }
         }
 
-        indices[_in_buffer.byte_offset] = idx;
+        indices[key]          = idx;
+        buffer_desc_types[idx] = _type;
 
         vkGetDescriptorEXT(
             m_device->GetDevice(),
@@ -278,38 +336,85 @@ uint VulkanDescriptorHeap::GetBufferDescIdx(
 }
 void VulkanDescriptorHeap::FreeBufferDescIdx(uint _idx) {
     std::lock_guard<std::mutex> lock(m_mutex);
+    assert(_idx < buffer_desc_types.size() && "offline buffer descriptor index is invalid");
+    buffer_desc_types[_idx] = VK_DESCRIPTOR_TYPE_MAX_ENUM;
     buffer_free_list.push_back(_idx);
 }
 
-uint VulkanDescriptorHeap::GetImageDescIdx(const TextureView* _in_image, VkImageLayout _layout) {
+uint VulkanDescriptorHeap::GetImageDescIdx(
+    const TextureView* _in_image,
+    VkImageLayout      _layout,
+    VkDescriptorType   _descriptor_type
+) {
     auto* texture = ResourceCast(_in_image->texture);
     assert(texture != nullptr && "texture is nullptr");
-    VkTextureDescKey key{_layout, _in_image->mip_level, _in_image->num_mips};
-    auto             res = texture->m_descriptor_indices.try_emplace(key, -1);
-    if (!res.second) {
-        return res.first->second * image_desc_stride + texture_desc_offset;
+    if (_descriptor_type == VK_DESCRIPTOR_TYPE_MAX_ENUM) {
+        _descriptor_type = _layout == VK_IMAGE_LAYOUT_GENERAL ?
+                               VK_DESCRIPTOR_TYPE_STORAGE_IMAGE :
+                               VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE;
     }
-    auto& idx = res.first->second;
+    assert(
+        (_descriptor_type == VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE ||
+         _descriptor_type == VK_DESCRIPTOR_TYPE_STORAGE_IMAGE) &&
+        "unsupported image descriptor type"
+    );
+
+    const uint8 array_count = _in_image->num_array == 0 ? 1 : _in_image->num_array;
+    VkTextureDescKey key{
+        _descriptor_type,
+        _layout,
+        _in_image->mip_level,
+        _in_image->num_mips,
+        _in_image->array_layer,
+        array_count,
+    };
+
+    // Image-view creation owns a texture-local mutex. Resolve it before the
+    // descriptor heap lock so texture destruction never observes the reverse
+    // heap->view / view->heap lock order.
+    const VkImageView image_view = texture->GetView(
+        _in_image->mip_level,
+        _in_image->num_mips,
+        _in_image->array_layer,
+        array_count
+    );
+
+    std::lock_guard<std::mutex> lock(m_mutex);
+    const auto cached = texture->m_descriptor_indices.find(key);
+    if (cached != texture->m_descriptor_indices.end()) {
+        return cached->second * image_desc_stride + texture_desc_offset;
+    }
+    uint idx = 0;
     {
         VkDescriptorImageInfo image_info{
-            .imageView = texture->GetView(_in_image->mip_level, _in_image->num_mips), .imageLayout = _layout
+            .imageView = image_view, .imageLayout = _layout
         };
         VkDescriptorGetInfoEXT desc_info{VK_STRUCTURE_TYPE_DESCRIPTOR_GET_INFO_EXT};
-        desc_info.type               = _layout == VK_IMAGE_LAYOUT_GENERAL ? VK_DESCRIPTOR_TYPE_STORAGE_IMAGE :
-                                                                            VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE;
-        desc_info.data.pSampledImage = &image_info;
-        std::lock_guard<std::mutex> lock(m_mutex);
+        desc_info.type = _descriptor_type;
+        if (_descriptor_type == VK_DESCRIPTOR_TYPE_STORAGE_IMAGE) {
+            desc_info.data.pStorageImage = &image_info;
+        } else {
+            desc_info.data.pSampledImage = &image_info;
+        }
         if (image_free_list.empty()) {
             idx = image_offset / image_desc_stride;
+            if (idx >= image_desc_types.size()) {
+                throw std::runtime_error("offline image descriptor cache exhausted");
+            }
             image_offset += image_desc_stride;
         } else {
             idx = image_free_list.back();
             image_free_list.pop_back();
+            if (idx >= image_desc_types.size()) {
+                throw std::runtime_error("offline image descriptor free-list index is invalid");
+            }
         }
+        texture->m_descriptor_indices.emplace(key, idx);
+        image_desc_types[idx] = _descriptor_type;
         vkGetDescriptorEXT(
             m_device->GetDevice(),
             &desc_info,
-            image_desc_stride,
+            GetDescriptorSize(_descriptor_type),
             image_desc_data.data() + idx * image_desc_stride + texture_desc_offset
         );
     }
@@ -317,6 +422,8 @@ uint VulkanDescriptorHeap::GetImageDescIdx(const TextureView* _in_image, VkImage
 }
 void VulkanDescriptorHeap::FreeImageDescIdx(uint _idx) {
     std::lock_guard<std::mutex> lock(m_mutex);
+    assert(_idx < image_desc_types.size() && "offline image descriptor index is invalid");
+    image_desc_types[_idx] = VK_DESCRIPTOR_TYPE_MAX_ENUM;
     image_free_list.push_back(_idx);
 }
 uint VulkanDescriptorHeap::GetSamplerDescIdx(Sampler _sampler) {
@@ -326,6 +433,7 @@ uint VulkanDescriptorHeap::GetSamplerDescIdx(Sampler _sampler) {
 uint VulkanDescriptorHeap::GetAccelDescIdx(VulkanAccelerationStructure* _as) {
     assert(_as != nullptr && "accel struct is nullptr");
     assert(_as->handle != VK_NULL_HANDLE && "accel struct handle is null");
+    std::lock_guard<std::mutex> lock(m_mutex);
     if (_as->m_descriptor_idx >= 0) {
         return _as->m_descriptor_idx * accel_desc_stride;
     }
@@ -338,13 +446,20 @@ uint VulkanDescriptorHeap::GetAccelDescIdx(VulkanAccelerationStructure* _as) {
     desc_info.data.accelerationStructure =
         vkGetAccelerationStructureDeviceAddressKHR(m_device->GetDevice(), &address_info);
     uint                        idx      = 0;
-    std::lock_guard<std::mutex> lock(m_mutex);
     if (accel_free_list.empty()) {
         idx = accel_offset / accel_desc_stride;
+        if (idx >= accel_desc_data.size() / accel_desc_stride) {
+            throw std::runtime_error("offline acceleration-structure descriptor cache exhausted");
+        }
         accel_offset += accel_desc_stride;
     } else {
         idx = accel_free_list.back();
         accel_free_list.pop_back();
+        if (idx >= accel_desc_data.size() / accel_desc_stride) {
+            throw std::runtime_error(
+                "offline acceleration-structure descriptor free-list index is invalid"
+            );
+        }
     }
     _as->m_descriptor_idx = idx;
     vkGetDescriptorEXT(
@@ -360,56 +475,193 @@ uint VulkanDescriptorHeap::FreeAccelDescIdx(uint _idx) {
     return 0;
 }
 
-void VulkanDescriptorHeap::BeginPushDescriptors(uint _frame_idx) {
-    _frame_idx     = _frame_idx % m_device->cmd_alloc_limits;
-    current_offset = ring_buffer_offsets[_frame_idx];
+VulkanDescriptorPushLease VulkanDescriptorHeap::BeginPushDescriptors(EQueueType _queue_type) {
+    assert(
+        (_queue_type == EQueueType::Graphics || _queue_type == EQueueType::Compute) &&
+        "copy queues do not own descriptor push leases"
+    );
+    const uint32 queue_index = _queue_type == EQueueType::Graphics ? 0u : 1u;
+    const uint32 slot_count  = m_device->cmd_alloc_limits;
+    const uint32 first_slot  = queue_index * slot_count;
+    std::unique_lock<std::mutex> lock(push_range_mutex);
+    push_range_cv.wait(lock, [&, this] {
+        return std::any_of(
+            active_push_leases.begin() + first_slot,
+            active_push_leases.begin() + first_slot + slot_count,
+            [](const auto& _lease) { return _lease == nullptr; }
+        );
+    });
+
+    for (uint32 attempt = 0; attempt < slot_count; ++attempt) {
+        const uint32 relative_slot = (next_push_slots[queue_index] + attempt) % slot_count;
+        const uint32 slot = first_slot + relative_slot;
+        if (active_push_leases[slot] != nullptr) {
+            continue;
+        }
+        const uint64 begin = ring_buffer_offsets[slot];
+        const uint64 end = slot + 1 < ring_buffer_offsets.size()
+                               ? ring_buffer_offsets[slot + 1]
+                               : ring_desc_buffer->GetByteSize();
+        auto state = std::make_shared<VulkanDescriptorPushLeaseState>(slot, begin, end);
+        active_push_leases[slot] = state;
+        next_push_slots[queue_index] = (relative_slot + 1) % slot_count;
+        return {std::move(state)};
+    }
+
+    assert(false && "descriptor lease predicate succeeded without a free slot");
+    return {};
 }
-void VulkanDescriptorHeap::EndPushDescriptors(uint _frame_idx) {
-    _frame_idx         = _frame_idx % m_device->cmd_alloc_limits;
-    uint64 base_offset = ring_buffer_offsets[_frame_idx];
+
+void VulkanDescriptorHeap::EndPushDescriptors(const VulkanDescriptorPushLease& _lease) {
+    assert(_lease.IsValid() && "descriptor push lease is invalid");
+    const uint64 byte_size =
+        _lease.state->next.load(std::memory_order_acquire) - _lease.state->begin;
+    if (byte_size == 0) {
+        return;
+    }
     vmaFlushAllocation(
         m_device->GetVmaAllocator(),
         ring_desc_buffer->GetAllocation(),
-        base_offset,
-        current_offset - base_offset
+        _lease.state->begin,
+        byte_size
     );
 }
 
-// void VulkanDescriptorHeap::PushBufferDesc(uint64 _src_offset, uint64 _set_offset) {
-//     std::lock_guard<std::mutex> lock(m_mutex);
-//     memcpy(map_ptr + current_offset + _set_offset, buffer_desc_data.data() + _src_offset, buffer_desc_stride);
-// }
+void VulkanDescriptorHeap::RecyclePushDescriptors(VulkanDescriptorPushLease _lease) {
+    if (!_lease.IsValid()) {
+        return;
+    }
+    {
+        std::lock_guard<std::mutex> lock(push_range_mutex);
+        const uint32 slot = _lease.state->slot;
+        assert(slot < active_push_leases.size() && "descriptor lease slot is invalid");
+        assert(
+            active_push_leases[slot] == _lease.state &&
+            "descriptor lease was recycled twice or after slot reuse"
+        );
+        active_push_leases[slot].reset();
+    }
+    // Graphics and compute wait on disjoint slot partitions but share this
+    // condition variable. notify_one could wake the wrong partition and leave
+    // the queue that actually gained a slot asleep indefinitely.
+    push_range_cv.notify_all();
+}
 
-void VulkanDescriptorHeap::PushUniformDesc(uint64 _src_offset, uint64 _set_offset) {
+std::optional<uint64> VulkanDescriptorHeap::ReservePushDescriptorRange(
+    const std::shared_ptr<VulkanDescriptorPushLeaseState>& _lease,
+    uint64                                                  _size
+) {
+    assert(_lease != nullptr && "descriptor range reservation has no submission lease");
+    if (_lease == nullptr) {
+        return std::nullopt;
+    }
+    uint64 begin = _lease->next.load(std::memory_order_acquire);
+    while (true) {
+        if (begin > _lease->end || _size > _lease->end - begin) {
+            return std::nullopt;
+        }
+        const uint64 end = begin + _size;
+        if (_lease->next.compare_exchange_weak(
+                begin, end, std::memory_order_acq_rel, std::memory_order_acquire
+            )) {
+            return begin;
+        }
+    }
+}
+
+uint64 VulkanDescriptorHeap::CurrentPushDescriptorOffset(
+    const std::shared_ptr<VulkanDescriptorPushLeaseState>& _lease
+) const {
+    assert(_lease != nullptr && "descriptor offset query has no submission lease");
+    return _lease->next.load(std::memory_order_acquire);
+}
+
+void VulkanDescriptorHeap::RewindPushDescriptors(
+    const std::shared_ptr<VulkanDescriptorPushLeaseState>& _lease,
+    uint64                                                  _offset
+) {
+    assert(_lease != nullptr && "descriptor rewind has no submission lease");
+    const uint64 current = _lease->next.load(std::memory_order_acquire);
+    assert(
+        _offset >= _lease->begin && _offset <= current &&
+        "descriptor rewind escaped the submission lease"
+    );
+    _lease->next.store(_offset, std::memory_order_release);
+}
+
+uint VulkanDescriptorHeap::GetDescriptorSize(VkDescriptorType _type) const {
+    switch (_type) {
+        case VK_DESCRIPTOR_TYPE_SAMPLER: return sample_desc_stride;
+        case VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE: return sampled_image_desc_stride;
+        case VK_DESCRIPTOR_TYPE_STORAGE_IMAGE: return storage_image_desc_stride;
+        case VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER: return uniform_texel_desc_stride;
+        case VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER: return storage_texel_desc_stride;
+        case VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER: return uniform_desc_stride;
+        case VK_DESCRIPTOR_TYPE_STORAGE_BUFFER: return storage_desc_stride;
+        case VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_KHR: return accel_desc_stride;
+        default:
+            LOG_ERROR("Unsupported descriptor type: {}", VK_TYPE_TO_STRING(VkDescriptorType, _type));
+            assert(false && "unsupported descriptor type");
+            return 0;
+    }
+}
+
+void VulkanDescriptorHeap::WriteUniformDesc(uint64 _src_offset, uint64 _dst_offset) {
     std::lock_guard<std::mutex> lock(m_mutex);
+    assert(_src_offset % buffer_desc_stride == 0 && "buffer descriptor offset is misaligned");
+    const uint64 idx = _src_offset / buffer_desc_stride;
+    assert(idx < buffer_desc_types.size() && "buffer descriptor offset is invalid");
+    assert(
+        buffer_desc_types[idx] == VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER &&
+        "uniform descriptor writer received a different descriptor type"
+    );
     memcpy(
-        map_ptr + current_offset + _set_offset, buffer_desc_data.data() + _src_offset, uniform_desc_stride
+        map_ptr + _dst_offset,
+        buffer_desc_data.data() + _src_offset,
+        GetDescriptorSize(buffer_desc_types[idx])
     );
 }
 
-void VulkanDescriptorHeap::PushStorageDesc(uint64 _src_offset, uint64 _set_offset) {
+void VulkanDescriptorHeap::WriteStorageDesc(uint64 _src_offset, uint64 _dst_offset) {
     std::lock_guard<std::mutex> lock(m_mutex);
+    assert(_src_offset % buffer_desc_stride == 0 && "buffer descriptor offset is misaligned");
+    const uint64 idx = _src_offset / buffer_desc_stride;
+    assert(idx < buffer_desc_types.size() && "buffer descriptor offset is invalid");
+    const VkDescriptorType descriptor_type = buffer_desc_types[idx];
+    assert(
+        (descriptor_type == VK_DESCRIPTOR_TYPE_STORAGE_BUFFER ||
+         descriptor_type == VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER ||
+         descriptor_type == VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER) &&
+        "storage descriptor writer received a different descriptor type"
+    );
     memcpy(
-        map_ptr + current_offset + _set_offset, buffer_desc_data.data() + _src_offset, storage_desc_stride
+        map_ptr + _dst_offset,
+        buffer_desc_data.data() + _src_offset,
+        GetDescriptorSize(descriptor_type)
     );
 }
 
-void VulkanDescriptorHeap::PushImageDesc(uint64 _src_offset, uint64 _set_offset) {
+void VulkanDescriptorHeap::WriteImageDesc(uint64 _src_offset, uint64 _dst_offset) {
     std::lock_guard<std::mutex> lock(m_mutex);
-    memcpy(map_ptr + current_offset + _set_offset, image_desc_data.data() + _src_offset, image_desc_stride);
+    assert(_src_offset >= texture_desc_offset && "image descriptor offset precedes image cache");
+    const uint64 relative_offset = _src_offset - texture_desc_offset;
+    assert(relative_offset % image_desc_stride == 0 && "image descriptor offset is misaligned");
+    const uint64 idx = relative_offset / image_desc_stride;
+    assert(idx < image_desc_types.size() && "image descriptor offset is invalid");
+    memcpy(
+        map_ptr + _dst_offset,
+        image_desc_data.data() + _src_offset,
+        GetDescriptorSize(image_desc_types[idx])
+    );
 }
 
-void VulkanDescriptorHeap::PushSamplerDesc(uint64 _src_offset, uint64 _set_offset) {
+void VulkanDescriptorHeap::WriteSamplerDesc(uint64 _src_offset, uint64 _dst_offset) {
     std::lock_guard<std::mutex> lock(m_mutex);
-    memcpy(map_ptr + current_offset + _set_offset, image_desc_data.data() + _src_offset, image_desc_stride);
+    memcpy(map_ptr + _dst_offset, image_desc_data.data() + _src_offset, sample_desc_stride);
 }
 
-void VulkanDescriptorHeap::PushAccelDesc(uint64 _src_offset, uint64 _set_offset) {
+void VulkanDescriptorHeap::WriteAccelDesc(uint64 _src_offset, uint64 _dst_offset) {
     std::lock_guard<std::mutex> lock(m_mutex);
-    memcpy(map_ptr + current_offset + _set_offset, accel_desc_data.data() + _src_offset, accel_desc_stride);
-}
-
-void VulkanDescriptorHeap::IncrementOffset(uint64 _size) {
-    current_offset += _size;
+    memcpy(map_ptr + _dst_offset, accel_desc_data.data() + _src_offset, accel_desc_stride);
 }
 } // namespace Moer::Render

--- a/source/runtime/render/rhi/vulkan/VulkanDescriptor.h
+++ b/source/runtime/render/rhi/vulkan/VulkanDescriptor.h
@@ -13,10 +13,33 @@
 #define VK_DESCRIPTOR_TYPE_END_RANGE   (VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT)
 #define VK_DESCRIPTOR_TYPE_RANGE_SIZE  3
 
+#include <atomic>
+#include <condition_variable>
+#include <memory>
+#include <optional>
+
 #include <mutex>
 
 namespace Moer::Render {
 class VulkanDevice;
+
+struct VulkanDescriptorPushLeaseState {
+    VulkanDescriptorPushLeaseState(uint32 _slot, uint64 _begin, uint64 _end) :
+        slot(_slot), begin(_begin), end(_end), next(_begin) {}
+
+    uint32              slot{0};
+    uint64              begin{0};
+    uint64              end{0};
+    std::atomic<uint64> next{0};
+};
+
+struct VulkanDescriptorPushLease {
+    std::shared_ptr<VulkanDescriptorPushLeaseState> state;
+
+    bool IsValid() const {
+        return state != nullptr;
+    }
+};
 struct VulkanShaderResourceState {
     uint         desc_type;
     uint8        resource_type; //SpvReflectResourceType
@@ -98,6 +121,9 @@ public:
     Array<byte> image_desc_data;
     Array<byte> accel_desc_data;
 
+    Array<VkDescriptorType> buffer_desc_types;
+    Array<VkDescriptorType> image_desc_types;
+
     Array<uint> buffer_free_list;
     Array<uint> image_free_list;
     Array<uint> accel_free_list;
@@ -112,7 +138,11 @@ public:
         VkFormat          _format = VK_FORMAT_UNDEFINED
     );
     void FreeBufferDescIdx(uint _idx);
-    uint GetImageDescIdx(const TextureView* _in_image, VkImageLayout _layout);
+    uint GetImageDescIdx(
+        const TextureView* _in_image,
+        VkImageLayout      _layout,
+        VkDescriptorType   _descriptor_type = VK_DESCRIPTOR_TYPE_MAX_ENUM
+    );
     void FreeImageDescIdx(uint _idx);
     uint GetSamplerDescIdx(Sampler _sampler);
     uint GetAccelDescIdx(VulkanAccelerationStructure* _as);
@@ -120,18 +150,32 @@ public:
 
 public:
     uint64 CurrentFrameOffset(uint _frame_idx) const;
-    void   BeginPushDescriptors(uint _frame_idx);
+    VulkanDescriptorPushLease BeginPushDescriptors(EQueueType _queue_type);
+    void EndPushDescriptors(const VulkanDescriptorPushLease& _lease);
+    void RecyclePushDescriptors(VulkanDescriptorPushLease _lease);
 
-    void EndPushDescriptors(uint _frame_idx);
+    // Reserve one immutable descriptor range for a single pipeline bind. The
+    // returned absolute offset stays valid until the owning queue timeline is
+    // retired; concurrent recorders never share a range.
+    std::optional<uint64> ReservePushDescriptorRange(
+        const std::shared_ptr<VulkanDescriptorPushLeaseState>& _lease,
+        uint64                                                  _size
+    );
+    uint64 CurrentPushDescriptorOffset(
+        const std::shared_ptr<VulkanDescriptorPushLeaseState>& _lease
+    ) const;
+    void RewindPushDescriptors(
+        const std::shared_ptr<VulkanDescriptorPushLeaseState>& _lease,
+        uint64                                                  _offset
+    );
 
-    // void PushBufferDesc(uint64 _src_offset, uint64 _set_offset);
-    void PushUniformDesc(uint64 _src_offset, uint64 _set_offset);
-    void PushStorageDesc(uint64 _src_offset, uint64 _set_offset);
-    void PushImageDesc(uint64 _src_offset, uint64 _set_offset);
-    void PushSamplerDesc(uint64 _src_offset, uint64 _set_offset);
-    void PushAccelDesc(uint64 _src_offset, uint64 _set_offset);
+    uint GetDescriptorSize(VkDescriptorType _type) const;
 
-    void IncrementOffset(uint64 _size);
+    void WriteUniformDesc(uint64 _src_offset, uint64 _dst_offset);
+    void WriteStorageDesc(uint64 _src_offset, uint64 _dst_offset);
+    void WriteImageDesc(uint64 _src_offset, uint64 _dst_offset);
+    void WriteSamplerDesc(uint64 _src_offset, uint64 _dst_offset);
+    void WriteAccelDesc(uint64 _src_offset, uint64 _dst_offset);
 
 public:
     VulkanDevice* m_device;
@@ -144,17 +188,22 @@ public:
     uint uniform_texel_desc_stride;
     uint buffer_desc_stride;
 
+    uint sampled_image_desc_stride;
+    uint storage_image_desc_stride;
     uint image_desc_stride;
     uint sample_desc_stride;
     uint accel_desc_stride;
 
     std::mutex m_mutex;
+    mutable std::mutex push_range_mutex;
+    std::condition_variable push_range_cv;
+    Array<std::shared_ptr<VulkanDescriptorPushLeaseState>> active_push_leases;
+    StaticArray<uint32, 2> next_push_slots{};
     uint64     texture_desc_offset;
 
     uint          ring_buffer_cnt;
     uint64        ring_buffer_size;
     Array<uint64> ring_buffer_offsets;
-    uint64        current_offset;
     uint8*        map_ptr;
 };
 

--- a/source/runtime/render/rhi/vulkan/VulkanDevice.cpp
+++ b/source/runtime/render/rhi/vulkan/VulkanDevice.cpp
@@ -56,9 +56,23 @@ namespace Moer::Render {
 namespace VkUtil = Moer::RHI::Vulkan::Util;
 
 VulkanDevice::VulkanDevice(const VulkanRHIConfig&& _config) : RenderDevice::Impl() {
-    rhi_thread_enabled      = _config.rhi_thread && !_config.rhi_bypass;
-    thread_profile_logging = _config.thread_profile_logging;
+    rhi_thread_enabled            = _config.rhi_thread && !_config.rhi_bypass;
+    thread_profile_logging        = _config.thread_profile_logging;
+    parallel_recording            = _config.parallel_recording;
+    parallel_record_workers       = _config.parallel_record_workers;
+    parallel_record_verify        = _config.parallel_record_verify;
+    parallel_record_profile       = _config.parallel_record_profile;
+    parallel_record_min_work_units_per_job =
+        std::max(1u, _config.parallel_record_min_work_units_per_job);
+    parallel_record_worker_throw_trigger =
+        _config.parallel_record_worker_throw_trigger;
     present_submit_fault_trigger = _config.present_submit_fault_trigger;
+    if (parallel_record_worker_throw_trigger != 0) {
+        LOG_INFO(
+            "[ParallelRecord][FaultConfig] point=worker-throw trigger={}",
+            parallel_record_worker_throw_trigger
+        );
+    }
     if (present_submit_fault_trigger != 0) {
         LOG_INFO(
             "[VulkanFault][Config] point=present-submit trigger={} mode=synthetic-device-lost",
@@ -491,7 +505,13 @@ void VulkanDevice::CreateDevice(uint32 _api_version) {
         *this,
         EQueueType::Graphics,
         rhi_thread_enabled,
-        thread_profile_logging
+        thread_profile_logging,
+        parallel_recording,
+        parallel_record_workers,
+        parallel_record_verify,
+        parallel_record_profile,
+        parallel_record_min_work_units_per_job,
+        parallel_record_worker_throw_trigger
     );
     SetResourceName(uint64(m_graphics_queue), VK_OBJECT_TYPE_QUEUE, "GraphicsQueue");
     compute_queue = MakeUnique<VkCommandQueue>(*this, EQueueType::Compute, false);

--- a/source/runtime/render/rhi/vulkan/VulkanDevice.h
+++ b/source/runtime/render/rhi/vulkan/VulkanDevice.h
@@ -62,10 +62,16 @@ struct QueueFamilyIndices {
 };
 
 struct VulkanRHIConfig {
-    uint32 api_version = VK_API_VERSION_1_3;
-    bool   rhi_thread  = false;
-    bool   rhi_bypass  = true;
-    bool   thread_profile_logging = false;
+    uint32 api_version                  = VK_API_VERSION_1_3;
+    bool   rhi_thread                   = false;
+    bool   rhi_bypass                   = true;
+    bool   thread_profile_logging       = false;
+    bool   parallel_recording           = false;
+    uint32 parallel_record_workers      = 0;
+    bool   parallel_record_verify       = false;
+    bool   parallel_record_profile      = false;
+    uint32 parallel_record_min_work_units_per_job = 64;
+    uint64 parallel_record_worker_throw_trigger = 0;
     uint64 present_submit_fault_trigger = 0;
 };
 
@@ -340,8 +346,14 @@ private:
     UniquePtr<VkCommandQueue> gfx_queue{}; // VkCommandQueue是MoerEngine的封装！
     UniquePtr<VkCommandQueue> compute_queue{};
     UniquePtr<VkCopyQueue>    copy_queue{};
-    bool                      rhi_thread_enabled      = false;
-    bool                      thread_profile_logging = false;
+    bool                      rhi_thread_enabled            = false;
+    bool                      thread_profile_logging       = false;
+    bool                      parallel_recording           = false;
+    uint32                    parallel_record_workers      = 0;
+    bool                      parallel_record_verify       = false;
+    bool                      parallel_record_profile      = false;
+    uint32                    parallel_record_min_work_units_per_job = 64;
+    uint64                    parallel_record_worker_throw_trigger = 0;
     uint64                    present_submit_fault_trigger = 0;
     std::atomic<uint64>       present_submit_attempts{0};
 

--- a/source/runtime/render/rhi/vulkan/VulkanParallelRecordWorkEstimator.cpp
+++ b/source/runtime/render/rhi/vulkan/VulkanParallelRecordWorkEstimator.cpp
@@ -1,0 +1,147 @@
+#include "VulkanParallelRecordWorkEstimator.h"
+
+#include "misc/Traits.h"
+#include "rhi/RHIImpl.h"
+
+#include <algorithm>
+#include <limits>
+#include <variant>
+
+namespace Moer::Render::VulkanParallelRecordDetail {
+namespace {
+
+uint64 EstimateShaderArgumentRecordWorkUnits(
+    const PipelineHandle& _pipeline,
+    const ArrayArguments& _arguments
+) {
+    uint64       work_units     = 0;
+    const size_t argument_count = std::min<size_t>(_arguments.args.size(), 64);
+    for (size_t index = 0; index < argument_count; ++index) {
+        if ((_pipeline.valid_bits & (uint64{1} << index)) == 0) {
+            continue;
+        }
+        work_units += std::visit(
+            Overload{
+                [](TInvalidArg) -> uint64 { return 0; },
+                [](const TextureViewArray& _views) -> uint64 {
+                    return std::max<size_t>(1, _views.size());
+                },
+                [](const BufferViewArray& _views) -> uint64 {
+                    return std::max<size_t>(1, _views.size());
+                },
+                [](const auto&) -> uint64 { return 1; },
+            },
+            _arguments.args[index]
+        );
+    }
+    return work_units;
+}
+
+const ArrayArguments* ResolveArguments(
+    const TShaderArgArray& _arguments,
+    const TCachedArgArray& _cached_arguments
+) {
+    if (std::holds_alternative<ArrayArguments>(_arguments)) {
+        return &std::get<ArrayArguments>(_arguments);
+    }
+    if (std::holds_alternative<ArrayArgReference>(_arguments)) {
+        const uint32 index = std::get<ArrayArgReference>(_arguments)();
+        return index < _cached_arguments.size() ? &_cached_arguments[index] : nullptr;
+    }
+    return nullptr;
+}
+
+uint64 EstimateMeshDrawRecordWorkUnits(const MeshDrawData& _draw_data) {
+    uint64 work_units = _draw_data.vtx_views.empty() ? 0u : 1u;
+    work_units += std::holds_alternative<IndexBuffer>(_draw_data.idx_view) ? 1u : 0u;
+    // Direct draws each emit one vkCmdDraw* call. An indirect payload is one
+    // recording operation regardless of its GPU-side draw count.
+    work_units += _draw_data.draw_params.size();
+    work_units += _draw_data.indirect_draw_param.has_value() ? 1u : 0u;
+    return work_units;
+}
+
+} // namespace
+
+uint32 EstimateWorkUnits(
+    const Command& _command, const TCachedArgArray& _cached_arguments
+) {
+    uint64 work_units = 1;
+    switch (_command.Type()) {
+        case Command::EType::SetDrawState: {
+            const auto& draw = static_cast<const SetDrawStateCmd&>(_command);
+            // Label pair, rendering pair, PSO, descriptor bind, viewport and scissor.
+            work_units = 8 + EstimateShaderArgumentRecordWorkUnits(
+                                 draw.Pipeline(), draw.Args()
+                             );
+            work_units += draw.Args().constants.empty() ? 0u : 1u;
+            for (const MeshDrawData& mesh : draw.DrawData()) {
+                work_units += EstimateMeshDrawRecordWorkUnits(mesh);
+            }
+            break;
+        }
+        case Command::EType::MultiDraw: {
+            const auto& draw = static_cast<const MultiDrawCmd&>(_command);
+            // Label pair, rendering pair, viewport and scissor.
+            work_units = 6;
+            for (const DrawBatchElement& element : draw.draw_batch.draw_cmds) {
+                // PSO plus descriptor bind, followed by payload-dependent work.
+                work_units += 2;
+                const ArrayArguments* arguments = ResolveArguments(
+                    element.args, _cached_arguments
+                );
+                if (arguments != nullptr) {
+                    work_units += EstimateShaderArgumentRecordWorkUnits(
+                        element.handle, *arguments
+                    );
+                    work_units += arguments->constants.empty() ? 0u : 1u;
+                }
+                std::visit(
+                    Overload{
+                        [&](const Array<MeshDrawData>& meshes) {
+                            for (const MeshDrawData& mesh : meshes) {
+                                work_units += EstimateMeshDrawRecordWorkUnits(mesh);
+                            }
+                        },
+                        [&](const Array<DispatchMeshData>& dispatches) {
+                            work_units += dispatches.size();
+                        },
+                    },
+                    element.mesh_dispatch_data
+                );
+            }
+            break;
+        }
+        case Command::EType::ShaderDispatch: {
+            const auto& dispatch  = static_cast<const DispatchCmd&>(_command);
+            const auto& arguments = dispatch.Args(_cached_arguments);
+            // Label pair, PSO, descriptor bind and one direct/indirect dispatch.
+            work_units = 5 + EstimateShaderArgumentRecordWorkUnits(
+                                 dispatch.Pipeline(), arguments
+                             );
+            work_units += arguments.constants.empty() ? 0u : 1u;
+            break;
+        }
+        case Command::EType::UploadBuffer:
+        case Command::EType::UploadTexture:
+        case Command::EType::CopyBackBuffer:
+        case Command::EType::CopyBackTexture:
+        case Command::EType::BufferToBuffer:
+        case Command::EType::BufferToTexture:
+        case Command::EType::TextureToBuffer:
+        case Command::EType::TextureToTexture:
+        case Command::EType::ClearResource:
+            // Marker pair plus one copy/clear call. Bytes and extents are GPU work.
+            work_units = 3;
+            break;
+        default:
+            // Serial-only commands never reach a worker, but diagnostics stay total.
+            work_units = 1;
+            break;
+    }
+    return static_cast<uint32>(std::min<uint64>(
+        std::max<uint64>(1, work_units), std::numeric_limits<uint32>::max()
+    ));
+}
+
+} // namespace Moer::Render::VulkanParallelRecordDetail

--- a/source/runtime/render/rhi/vulkan/VulkanParallelRecordWorkEstimator.h
+++ b/source/runtime/render/rhi/vulkan/VulkanParallelRecordWorkEstimator.h
@@ -1,0 +1,18 @@
+#ifndef MOER_RENDER_VULKAN_PARALLEL_RECORD_WORK_ESTIMATOR_H
+#define MOER_RENDER_VULKAN_PARALLEL_RECORD_WORK_ESTIMATOR_H
+
+#include "RenderAPI.h"
+#include "rhi/RHICommand.h"
+
+namespace Moer::Render::VulkanParallelRecordDetail {
+
+// Estimates recorder-side CPU work. GPU payload size (for example copy bytes,
+// dispatch group counts, or indirect draw counts) intentionally does not
+// contribute because it does not emit additional native recording calls.
+RENDER_API uint32 EstimateWorkUnits(
+    const Command& _command, const TCachedArgArray& _cached_arguments
+);
+
+} // namespace Moer::Render::VulkanParallelRecordDetail
+
+#endif // MOER_RENDER_VULKAN_PARALLEL_RECORD_WORK_ESTIMATOR_H

--- a/source/runtime/render/rhi/vulkan/VulkanQueue.cpp
+++ b/source/runtime/render/rhi/vulkan/VulkanQueue.cpp
@@ -5,6 +5,7 @@
 #include "VulkanCommand.h"
 #include "VulkanDescriptor.h"
 #include "VulkanDevice.h"
+#include "VulkanParallelRecordWorkEstimator.h"
 #include "VulkanRHIResource.h"
 #include "VulkanSerialGolden.h"
 #include "rhi/ExternalCpuJoinPool.h"
@@ -25,6 +26,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <exception>
 #include <memory>
 #include <mutex>
 #include <string>
@@ -149,6 +151,69 @@ static void UnlockBindlessArray(uint64 _handle) {
     bdls_array->Unlock();
 }
 
+static void FinalizeBindlessUpdatesOnce(
+    BindlessArrayRef                         _array,
+    const Array<BindlessArray::UpdateCmd>&   _updates,
+    const std::shared_ptr<std::atomic_bool>& _finalized,
+    bool                                     _gpu_update_succeeded
+) {
+    if (!_array || !_finalized || _finalized->exchange(true, std::memory_order_acq_rel)) {
+        return;
+    }
+    try {
+        reinterpret_cast<VulkanBindlessArray*>(_array.Get())
+            ->FinalizeUpdateCommand(_updates, _gpu_update_succeeded);
+    } catch (const std::exception& error) {
+        LOG_ERROR("Failed to finalize bindless update lifecycle: {}", error.what());
+    } catch (...) {
+        LOG_ERROR("Failed to finalize bindless update lifecycle: unknown error");
+    }
+}
+
+static void FinalizeRejectedBindlessUpdates(const CmdSubmit& _submit) {
+    for (const UniquePtr<Command>& command : _submit.cmds) {
+        if (!command || command->Type() != Command::EType::UpdateBindlessArray) {
+            continue;
+        }
+        const auto& update = *static_cast<const UpdateBindlessArrayCmd*>(command.get());
+        if (!update.UpdatesHandedOff()) {
+            continue;
+        }
+        FinalizeBindlessUpdatesOnce(
+            BindlessArrayRef(update.Handle()),
+            update.UpdateCommands(),
+            update.UpdateFinalizationToken(),
+            false
+        );
+    }
+}
+
+static void InvokeCallbacksNoexcept(
+    Array<std::function<void()>>& _callbacks,
+    std::string_view              _context
+) noexcept {
+    for (std::function<void()>& callback : _callbacks) {
+        if (!callback) {
+            continue;
+        }
+        try {
+            callback();
+        } catch (const std::exception& error) {
+            LOG_ERROR("{} callback threw: {}", _context, error.what());
+        } catch (...) {
+            LOG_ERROR("{} callback threw an unknown exception", _context);
+        }
+    }
+}
+
+class StaleBindlessUpdateBatch final : public std::runtime_error {
+public:
+    StaleBindlessUpdateBatch() :
+        std::runtime_error(
+            "stale bindless update batch cannot be submitted with dependent commands"
+        ) {}
+};
+
 #pragma endregion
 
 #pragma region[ preprocessor ]
@@ -191,12 +256,29 @@ struct VkCmdPreprocessor {
         auto* vk_bindless_array = reinterpret_cast<VulkanBindlessArray*>(_bindless_array.Get());
 
         Moer::Array<TextureSubresourceKeyT<VulkanTexture>> to_read_textures;
-        for (const auto& key : tracker.GetWritedStateTextures()) {
-            if (vk_bindless_array->IsTextureViewAllocated(
-                    uint64(key.texture), key.mip_level, key.mip_count, key.array_layer, key.array_count
-                ) &&
-                !writed_texture_resources.contains(key)) {
-                to_read_textures.push_back(key);
+        Moer::Array<VulkanBuffer*> to_read_buffers;
+        {
+            // Allocation/unbind/update can run on a producer thread while the
+            // RHI coordinator preprocesses this packet. Observe both maps from
+            // one stable snapshot; worker recorders never access them.
+            auto bindless_lock = vk_bindless_array->AcquireLock();
+            for (const auto& key : tracker.GetWritedStateTextures()) {
+                if (vk_bindless_array->IsTextureViewAllocated(
+                        uint64(key.texture),
+                        key.mip_level,
+                        key.mip_count,
+                        key.array_layer,
+                        key.array_count
+                    ) &&
+                    !writed_texture_resources.contains(key)) {
+                    to_read_textures.push_back(key);
+                }
+            }
+            for (const auto& buffer : tracker.GetWritedStateBuffers()) {
+                if (vk_bindless_array->IsResourceAllocated(uint64(buffer)) &&
+                    !writed_buffer_resources.contains(uint64(buffer))) {
+                    to_read_buffers.push_back(buffer);
+                }
             }
         }
         if (!to_read_textures.empty()) {
@@ -212,13 +294,6 @@ struct VkCmdPreprocessor {
                     key.array_layer,
                     key.array_count
                 );
-            }
-        }
-        Moer::Array<VulkanBuffer*> to_read_buffers;
-        for (const auto& i : tracker.GetWritedStateBuffers()) {
-            if (vk_bindless_array->IsResourceAllocated(uint64(i)) &&
-                !writed_buffer_resources.contains(uint64(i))) {
-                to_read_buffers.push_back(i);
             }
         }
         if (!to_read_buffers.empty()) {
@@ -2133,6 +2208,36 @@ public:
 
     void Visit(const UpdateBindlessArrayCmd& _cmd) {
         VulkanBindlessArray* bindless_array = reinterpret_cast<VulkanBindlessArray*>(_cmd.Handle());
+        if (!_cmd.HandOffUpdates()) {
+            return;
+        }
+        const bool update_is_current = bindless_array->BeginUpdateCommand(_cmd.UpdateCommands());
+        BindlessArrayRef array_ref(_cmd.Handle());
+        auto             updates   = _cmd.UpdateCommands();
+        auto             finalized = _cmd.UpdateFinalizationToken();
+        // Keep released resources conservatively visible through GPU
+        // completion. This covers prior packets on every queue, prevents
+        // descriptor-slot reuse while old work can still read it, and
+        // gives record rejection a one-shot finalization token.
+        allocator.AddOnComplete(
+            [array_ref = std::move(array_ref),
+             updates = std::move(updates),
+             finalized = std::move(finalized),
+             update_is_current]() mutable {
+                FinalizeBindlessUpdatesOnce(
+                    array_ref, updates, finalized, update_is_current
+                );
+            }
+        );
+        if (!update_is_current) {
+            LOG_WARNING(
+                "Rejecting command submission containing a stale bindless update batch"
+            );
+            // Silently omitting the upload would allow later draw/dispatch
+            // commands in this same CmdSubmit to consume descriptors that were
+            // never published. Let the queue reject the complete transaction.
+            throw StaleBindlessUpdateBatch{};
+        }
         // auto                 texture_slots  = _cmd.StealTextureUpdates();
         // auto                 buffer_slots   = _cmd.StealBufferUpdates();
 
@@ -2348,9 +2453,10 @@ public:
 
             if (b_texture) {
                 arg.component_cnt = texture_indices_dat.size();
-                arg.stride        = m_device->GetOptionalProperties()
-                                        .descriptor_buffer_properties.sampledImageDescriptorSize >>
-                                    2;
+                arg.stride = m_device->GetGlobalDescriptorHeap().GetDescriptorSize(
+                                 VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE
+                             ) >>
+                             2;
 
                 cmd_list.BindDescriptors(
                     shuffle_sd.handle,
@@ -2368,9 +2474,10 @@ public:
 
             if (b_buffer) {
                 arg.component_cnt = buffer_indices_dat.size();
-                arg.stride        = m_device->GetOptionalProperties()
-                                        .descriptor_buffer_properties.storageBufferDescriptorSize >>
-                                    2;
+                arg.stride = m_device->GetGlobalDescriptorHeap().GetDescriptorSize(
+                                 VK_DESCRIPTOR_TYPE_STORAGE_BUFFER
+                             ) >>
+                             2;
 
                 cmd_list.BindDescriptors(
                     shuffle_sd.handle,
@@ -2378,7 +2485,9 @@ public:
                         arg,
                         buffer_indices_buf,
                         buffer_desc_staging,
-                        bindless_array->bindless_buffer_descs->GetView()
+                        bindless_array->bindless_buffer_descs->GetView(
+                            bindless_array->buffers_offset_in_set
+                        )
                     )
                 );
                 cmd_list.Dispatch((buffer_indices_dat.size() + 63) / 64, 1, 1);
@@ -2729,6 +2838,16 @@ VulkanOperationResult VkNativeQueue::Submit(
     const VulkanOperationContext& _context,
     VkFence                       _fence
 ) {
+    VulkanCmdList* command_lists[] = {&_cmdlist};
+    return Submit(std::span<VulkanCmdList* const>(command_lists), _context, _fence);
+}
+
+VulkanOperationResult VkNativeQueue::Submit(
+    std::span<VulkanCmdList* const> _cmdlists,
+    const VulkanOperationContext&   _context,
+    VkFence                         _fence
+) {
+    assert(!_cmdlists.empty() && "ordered command-buffer submit must not be empty");
     if (device.IsFaulted()) {
         wait_infos.clear();
         signal_infos.clear();
@@ -2750,12 +2869,19 @@ VulkanOperationResult VkNativeQueue::Submit(
         return device.InjectPresentSubmitFault(context);
     }
 
-    VkSubmitInfo2   submit_info{};
-    VkCommandBuffer cmd = _cmdlist.GetHandle();
-
-    VkCommandBufferSubmitInfo cmd_info{
-        .sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_SUBMIT_INFO, .pNext = nullptr, .commandBuffer = cmd
-    };
+    VkSubmitInfo2 submit_info{};
+    Array<VkCommandBufferSubmitInfo> cmd_infos;
+    cmd_infos.reserve(_cmdlists.size());
+    for (VulkanCmdList* cmd_list : _cmdlists) {
+        assert(cmd_list != nullptr && "ordered command-buffer submit contains null entry");
+        cmd_infos.push_back(
+            VkCommandBufferSubmitInfo{
+                .sType         = VK_STRUCTURE_TYPE_COMMAND_BUFFER_SUBMIT_INFO,
+                .pNext         = nullptr,
+                .commandBuffer = cmd_list->GetHandle()
+            }
+        );
+    }
     submit_info.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO_2;
 
     submit_info.pNext                    = nullptr;
@@ -2763,8 +2889,8 @@ VulkanOperationResult VkNativeQueue::Submit(
     submit_info.pWaitSemaphoreInfos      = wait_infos.data();
     submit_info.signalSemaphoreInfoCount = signal_infos.size();
     submit_info.pSignalSemaphoreInfos    = signal_infos.data();
-    submit_info.commandBufferInfoCount   = 1;
-    submit_info.pCommandBufferInfos      = &cmd_info;
+    submit_info.commandBufferInfoCount   = static_cast<uint32_t>(cmd_infos.size());
+    submit_info.pCommandBufferInfos      = cmd_infos.data();
 
     if (context.operation == EVulkanFaultOperation::None) {
         context.operation = EVulkanFaultOperation::QueueSubmit;
@@ -3016,6 +3142,59 @@ static double RhiThreadProfileMilliseconds(
     return std::chrono::duration<double, std::milli>(_end - _begin).count();
 }
 
+void VkCommandQueue::BeginSplitProfilingCpuFrame() {
+    ResetSplitProfilingCpuFrame();
+    split_profiling_cpu_frame.active  = true;
+    split_profiling_cpu_frame.started = std::chrono::steady_clock::now();
+}
+
+void VkCommandQueue::AccumulateSplitProfilingCpuFrame(
+    double _reorder_ms,
+    double _preprocess_ms
+) {
+    // Malformed phase sequences must still publish finite CPU diagnostics.
+    // Starting here does not repair the missing GPU Begin query, but avoids an
+    // uninitialized clock if an End packet is used defensively on its own.
+    if (!split_profiling_cpu_frame.active) {
+        split_profiling_cpu_frame.active  = true;
+        split_profiling_cpu_frame.started = std::chrono::steady_clock::now();
+    }
+    split_profiling_cpu_frame.reorder_ms += _reorder_ms;
+    split_profiling_cpu_frame.preprocess_ms += _preprocess_ms;
+}
+
+void VkCommandQueue::EndSplitProfilingCpuFrame() {
+    if (!split_profiling_cpu_frame.active) {
+        split_profiling_cpu_frame.active  = true;
+        split_profiling_cpu_frame.started = std::chrono::steady_clock::now();
+    }
+
+    const double execute_ms = RhiThreadProfileMilliseconds(
+        split_profiling_cpu_frame.started, std::chrono::steady_clock::now()
+    );
+    profiler_storage.RegisterCpuTimestamp("Queue Execution", execute_ms);
+    profiler_storage.RegisterCpuTimestamp(
+        "Command Reorder", split_profiling_cpu_frame.reorder_ms
+    );
+    profiler_storage.RegisterCpuTimestamp(
+        "Command Preprocess", split_profiling_cpu_frame.preprocess_ms
+    );
+    if (execute_ms > 0.0) {
+        profiler_storage.RegisterCpuTimestamp(
+            "Reorder Percentage", split_profiling_cpu_frame.reorder_ms / execute_ms
+        );
+        profiler_storage.RegisterCpuTimestamp(
+            "Preprocess Percentage", split_profiling_cpu_frame.preprocess_ms / execute_ms
+        );
+    }
+    profiler_storage.AdvanceFrame();
+    ResetSplitProfilingCpuFrame();
+}
+
+void VkCommandQueue::ResetSplitProfilingCpuFrame() {
+    split_profiling_cpu_frame = {};
+}
+
 static uint64 CanonicalDigest(const UnorderedSet<uint64>& _digests) {
     Array<uint64> sorted_digests(_digests.begin(), _digests.end());
     std::sort(sorted_digests.begin(), sorted_digests.end());
@@ -3073,15 +3252,54 @@ static void FailSubmissionSignals(
         _queue_timeline->Fail(_result);
     }
     for (const SignalEvent& event : _signal_events) {
-        reinterpret_cast<VulkanFence*>(event.timeline_handle)->Fail(_result);
+        auto* fence = reinterpret_cast<VulkanFence*>(event.timeline_handle);
+        if (fence != nullptr) {
+            fence->Fail(_result);
+        }
     }
+}
+
+static void TerminalizeRejectedSubmit(
+    VulkanDevice&    _device,
+    CmdSubmit&&      _submit,
+    VkResult         _result,
+    std::string_view _context
+) noexcept {
+    if (_result == VK_SUCCESS) {
+        _result = VK_ERROR_UNKNOWN;
+    }
+
+    _device.RecordRejectedSubmit();
+    FailSubmissionSignals(nullptr, _submit.signal_events, _result);
+    FinalizeRejectedBindlessUpdates(_submit);
+
+    // Completion callbacks are the only user code retained on a rejected
+    // packet. Success callbacks are intentionally destroyed without running.
+    // Drop command/cached payload first, matching normal queue retirement and
+    // giving unhanded bindless updates their destructor rollback opportunity.
+    Array<std::function<void()>> callbacks = std::move(_submit.callbacks);
+    _submit.success_callbacks.clear();
+    _submit.cmds.clear();
+    _submit.cached_args.clear();
+    _submit.segments.clear();
+    _submit.wait_events.clear();
+    _submit.signal_events.clear();
+    _submit.debug_label.clear();
+
+    InvokeCallbacksNoexcept(callbacks, _context);
 }
 
 VkCommandQueue::VkCommandQueue(
     VulkanDevice& _device,
     EQueueType    _type,
     bool          _enable_rhi_thread,
-    bool          _thread_profile_logging
+    bool          _thread_profile_logging,
+    bool          _parallel_recording,
+    uint32_t      _parallel_record_workers,
+    bool          _parallel_record_verify,
+    bool          _parallel_record_profile,
+    uint32_t      _parallel_record_min_work_units_per_job,
+    uint64_t      _parallel_record_worker_throw_trigger
 ) :
     CommandQueue(),
     vk_device(_device),
@@ -3092,9 +3310,26 @@ VkCommandQueue::VkCommandQueue(
         s_queue_max_frame_in_flight * s_query_max_storage * 4
     ),
     profiler_storage(timestamp_pool),
-    rhi_thread_enabled(_enable_rhi_thread) {
+    rhi_thread_enabled(_enable_rhi_thread),
+    parallel_record_requested(_parallel_recording),
+    parallel_record_verify(_parallel_record_verify),
+    parallel_record_profile_enabled(_parallel_record_profile),
+    parallel_record_min_work_units_per_job(
+        std::max(1u, _parallel_record_min_work_units_per_job)
+    ),
+    parallel_record_worker_throw_trigger(_parallel_record_worker_throw_trigger) {
     if (_thread_profile_logging) {
         thread_profile = MakeUnique<RhiThreadProfileState>();
+    }
+    if (parallel_record_profile_enabled && _type == EQueueType::Graphics) {
+        parallel_record_profile = MakeUnique<ParallelRecordProfileState>();
+    }
+    if (parallel_record_requested && rhi_thread_enabled && _type == EQueueType::Graphics) {
+        const uint32 hardware_threads = std::max(2u, std::thread::hardware_concurrency());
+        parallel_record_workers = _parallel_record_workers == 0
+                                      ? std::min(4u, hardware_threads)
+                                      : std::clamp(_parallel_record_workers, 2u, hardware_threads);
+        parallel_record_pool = MakeUnique<ExternalCpuJoinPool>(parallel_record_workers);
     }
     timeline = MoerNew(VulkanFence(vk_device));
 
@@ -3111,10 +3346,28 @@ VkCommandQueue::VkCommandQueue(
         _type == EQueueType::Graphics ? "graphics" : "compute",
         rhi_thread_enabled ? "threaded" : "synchronous"
     );
+    if (parallel_record_requested) {
+        LOG_INFO(
+            "[ParallelRecord] queue={} requested=true effective={} workers={} "
+            "min_work_units_per_job={} reason={}",
+            _type == EQueueType::Graphics ? "Graphics" : "Compute",
+            parallel_record_pool != nullptr,
+            parallel_record_workers,
+            parallel_record_min_work_units_per_job,
+            parallel_record_pool ? "none" :
+            _type != EQueueType::Graphics ? "unsupported-queue" : "rhi-thread-disabled-or-bypass"
+        );
+    }
+    if (parallel_record_profile) {
+        LOG_INFO(
+            "[ParallelRecordProfile][Config] queue=Graphics enabled=true window_ms=1000"
+        );
+    }
 }
 
 VkCommandQueue::~VkCommandQueue() {
     Sync();
+    FlushParallelRecordProfile();
 
     if (rhi_thread_enabled) {
         {
@@ -3123,6 +3376,11 @@ VkCommandQueue::~VkCommandQueue() {
         }
         rhi_work_cv.notify_all();
         rhi_thread.join();
+    }
+
+    if (parallel_record_pool) {
+        parallel_record_pool->StopAndDrain();
+        parallel_record_pool.reset();
     }
 
     {
@@ -3152,11 +3410,12 @@ VkCommandQueue::~VkCommandQueue() {
 
 WaitEvent VkCommandQueue::Execute(CmdSubmit&& _submit) {
     if (vk_device.IsFaulted()) {
-        vk_device.RecordRejectedSubmit();
-        FailSubmissionSignals(nullptr, _submit.signal_events, vk_device.GetFirstFaultResult());
-        for (auto& callback : _submit.callbacks) {
-            callback();
-        }
+        TerminalizeRejectedSubmit(
+            vk_device,
+            std::move(_submit),
+            vk_device.GetFirstFaultResult(),
+            "[VulkanQueue] rejected submit"
+        );
         return {uint64(timeline), last_frame.load(std::memory_order_acquire)};
     }
     if (rhi_thread_enabled) {
@@ -3203,11 +3462,1217 @@ WaitEvent VkCommandQueue::Execute(CmdSubmit&& _submit) {
     return {uint64(timeline), current_timeline};
 }
 
-void VkCommandQueue::ExecuteNow(CmdSubmit&& _submit, uint64 _timeline, uint64 _serial) {
+std::optional<VkCommandQueue::CurrentVulkanRecordedSubmit>
+VkCommandQueue::TranslateForRuntime(CmdSubmit&& _submit) {
+    std::unique_lock<std::mutex> execution_lock(exec_mtx);
+    const uint64 current_timeline = last_frame.fetch_add(1, std::memory_order_relaxed) + 1;
+    std::optional<CurrentVulkanRecordedSubmit> recorded{};
+    ExecuteNow(
+        std::move(_submit),
+        current_timeline,
+        current_timeline,
+        &recorded,
+        true
+    );
+    if (recorded) {
+        recorded->runtime_execution_lock.emplace(std::move(execution_lock));
+    }
+    return recorded;
+}
+
+VulkanRuntimeSubmissionResult VkCommandQueue::SubmitRecordedForRuntime(
+    CurrentVulkanRecordedSubmit _recorded
+) {
     assert(
-        !rhi_thread_enabled ||
+        _recorded.runtime_execution_lock.has_value() &&
+        _recorded.runtime_execution_lock->owns_lock() &&
+        "runtime recorded submit must retain queue execution ownership"
+    );
+    const uint64 submitted_timeline = _recorded.timeline;
+    const bool split_profiling_frame =
+        _recorded.submit.EmitsProfilingQueries() &&
+        _recorded.submit.ProfilingPhase() != ERHIProfilingPhase::Complete;
+    const CurrentVulkanSubmitResult submit_result =
+        SubmitRecorded(std::move(_recorded));
+    if (split_profiling_frame && !submit_result.outcome.WasSubmitted()) {
+        ResetSplitProfilingCpuFrame();
+    }
+    VulkanRuntimeSubmissionResult runtime_result{.outcome = submit_result.outcome};
+    if (submit_result.outcome.WasSubmitted()) {
+        runtime_result.completion = WaitEvent{uint64(timeline), submitted_timeline};
+    }
+    return runtime_result;
+}
+
+void VkCommandQueue::RejectForRuntime(CmdSubmit&& _submit, VkResult _result) {
+    ResetSplitProfilingCpuFrame();
+    TerminalizeRejectedSubmit(
+        vk_device,
+        std::move(_submit),
+        _result,
+        "[RHIExecutor][Vulkan] rejected command submit"
+    );
+}
+
+VulkanRuntimeSubmissionResult VkCommandQueue::PresentForRuntime(
+    SwapchainRef _swapchain,
+    TextureView _source,
+    PresentReceiptRef _receipt
+) {
+    assert(_source.texture != nullptr && "Present source texture is null");
+    TextureRef source_texture{_source.texture};
+    if (vk_device.IsFaulted()) {
+        vk_device.RecordRejectedPresent();
+        if (_receipt) {
+            _receipt->Resolve(false);
+        }
+        return {
+            .outcome = {
+                EVulkanOperationStatus::Rejected, vk_device.GetFirstFaultResult()
+            }
+        };
+    }
+
+    std::unique_lock<std::mutex> execution_lock(exec_mtx);
+    const uint64 current_timeline = last_frame.fetch_add(1, std::memory_order_relaxed) + 1;
+    return PresentNow(
+        std::move(_swapchain),
+        std::move(source_texture),
+        _source,
+        std::move(_receipt),
+        current_timeline,
+        current_timeline,
+        true
+    );
+}
+
+VkCommandQueue::CurrentVulkanSubmitResult
+VkCommandQueue::SubmitRecorded(CurrentVulkanRecordedSubmit _recorded) {
+    assert(
+        _recorded.has_commands == !_recorded.ordered_cmd_lists.empty() &&
+        "recorded Vulkan submit command-list ownership mismatch"
+    );
+
+    const auto profile_submit_started = _recorded.profile.enabled ?
+                                            std::chrono::steady_clock::now() :
+                                            std::chrono::steady_clock::time_point{};
+    const auto end_tag = VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT;
+    VulkanOperationResult submit_outcome{};
+    if (!WaitForSubmittedDependencies(vk_device, _recorded.submit.wait_events)) {
+        vk_device.RecordRejectedSubmit();
+        const VkResult rejected_result = GetRejectedSubmitResult(vk_device);
+        submit_outcome = {EVulkanOperationStatus::Rejected, rejected_result};
+        FailSubmissionSignals(timeline, _recorded.submit.signal_events, rejected_result);
+    } else {
+        queue.Signal(timeline, _recorded.timeline, end_tag);
+        for (auto& event : _recorded.submit.wait_events) {
+            queue.Wait(
+                reinterpret_cast<VulkanFence*>(event.timeline_handle),
+                event.value,
+                VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT
+            );
+        }
+        for (auto& event : _recorded.submit.signal_events) {
+            queue.Signal(
+                reinterpret_cast<VulkanFence*>(event.timeline_handle), event.value, end_tag
+            );
+        }
+        submit_outcome = _recorded.has_commands ?
+                             queue.Submit(
+                                 std::span<VulkanCmdList* const>(
+                                     _recorded.ordered_cmd_lists.data(),
+                                     _recorded.ordered_cmd_lists.size()
+                                 ),
+                                 _recorded.context
+                             ) :
+                             queue.SubmitEmpty(_recorded.context);
+        if (submit_outcome.WasSubmitted()) {
+            MarkSubmissionAccepted(
+                timeline, _recorded.timeline, _recorded.submit.signal_events
+            );
+        } else {
+            FailSubmissionSignals(
+                timeline, _recorded.submit.signal_events, submit_outcome.result
+            );
+        }
+    }
+    if (!submit_outcome.WasSubmitted()) {
+        FinalizeRejectedBindlessUpdates(_recorded.submit);
+    }
+
+    const double profile_submit_cpu_ms = _recorded.profile.enabled ?
+                                             RhiThreadProfileMilliseconds(
+                                                 profile_submit_started,
+                                                 std::chrono::steady_clock::now()
+                                             ) :
+                                             0.0;
+    const uint32 ordered_cmd_list_count =
+        static_cast<uint32>(_recorded.ordered_cmd_lists.size());
+
+    {
+        std::unique_lock<std::mutex> lock(event_mutex);
+        event_queue.emplace_back(
+            VulkanSubmissionEvent{
+                submit_outcome, _recorded.context, submit_outcome.WasSubmitted()
+            },
+            _recorded.timeline,
+            false
+        );
+        event_queue.emplace_back(
+            std::move(_recorded.allocators), _recorded.timeline, false
+        );
+        if (_recorded.descriptor_lease.has_value()) {
+            event_queue.emplace_back(
+                std::move(*_recorded.descriptor_lease), _recorded.timeline, false
+            );
+        }
+        for (auto& event : _recorded.submit.signal_events) {
+            event_queue.emplace_back(
+                SignalEvent(event.timeline_handle, event.value), _recorded.timeline, false
+            );
+        }
+        if (!_recorded.submit.callbacks.empty()) {
+            event_queue.emplace_back(
+                VulkanCallbackBatch{std::move(_recorded.submit.callbacks), false},
+                _recorded.timeline,
+                false
+            );
+        }
+        if (!_recorded.submit.success_callbacks.empty()) {
+            event_queue.emplace_back(
+                VulkanCallbackBatch{std::move(_recorded.submit.success_callbacks), true},
+                _recorded.timeline,
+                false
+            );
+        }
+        if (!_recorded.deferred_releases.empty()) {
+            event_queue.emplace_back(
+                VulkanDeferredReleaseBatch{std::move(_recorded.deferred_releases)},
+                _recorded.timeline,
+                false
+            );
+        }
+        EnqueueCompletionMarker(_recorded.timeline);
+    }
+    queue_cv.notify_one();
+
+    if (_recorded.has_commands) {
+        executed_queue.Enqueue(_recorded.timeline);
+    }
+    if (_recorded.profile.enabled) {
+        _recorded.profile.sample.submit_cpu_ms = profile_submit_cpu_ms;
+        _recorded.profile.sample.execute_cpu_wall_ms = RhiThreadProfileMilliseconds(
+            _recorded.profile.execute_started, std::chrono::steady_clock::now()
+        );
+        _recorded.profile.sample.ordered_cb = ordered_cmd_list_count;
+        RecordParallelRecordProfile(_recorded.profile.sample);
+    }
+
+    return {
+        .outcome                = submit_outcome,
+        .ordered_cmd_list_count = ordered_cmd_list_count,
+    };
+}
+
+bool VkCommandQueue::TryExecuteParallel(
+    CmdSubmit&                    _submit,
+    uint64                        _timeline,
+    uint64                        _serial,
+    const VulkanOperationContext& _context,
+    const FunctionTable&           _function_table,
+    const CmdReorderer&            _reorderer,
+    double                         _reorder_time,
+    std::chrono::steady_clock::time_point _profile_started,
+    std::optional<CurrentVulkanRecordedSubmit>* _out_recorded
+) {
+    const ERHIProfilingPhase profiling_phase = _submit.ProfilingPhase();
+    const bool emits_profiling_queries       = _submit.EmitsProfilingQueries();
+    const bool begins_profiling_frame        = _submit.BeginsProfilingFrame();
+    const bool ends_profiling_frame          = _submit.EndsProfilingFrame();
+    const bool complete_profiling_frame =
+        profiling_phase == ERHIProfilingPhase::Complete;
+    auto fallback_name = [](ParallelRecordFallbackReason _reason) -> std::string_view {
+        switch (_reason) {
+            case ParallelRecordFallbackReason::None:
+                return "none";
+            case ParallelRecordFallbackReason::WorkerCountTooSmall:
+                return "worker-count-too-small";
+            case ParallelRecordFallbackReason::NoEligibleLayer:
+                return "no-eligible-layer";
+            case ParallelRecordFallbackReason::InsufficientWork:
+                return "insufficient-work";
+            case ParallelRecordFallbackReason::InsufficientConcurrency:
+                return "insufficient-concurrency";
+            case ParallelRecordFallbackReason::InvalidWorkDescription:
+                return "invalid-work-description";
+            case ParallelRecordFallbackReason::InvalidCommandType:
+                return "invalid-command-type";
+            case ParallelRecordFallbackReason::LayerTooLarge:
+                return "layer-too-large";
+        }
+        return "unknown";
+    };
+    uint64 batch_serial = 0;
+    auto verify_fallback = [&](std::string_view _reason) {
+        if (parallel_record_verify) {
+            LOG_INFO(
+                "[ParallelRecord] batch={} requested=true effective=false reason={} coordinator={}",
+                batch_serial,
+                _reason,
+                Platform::GetCurrentThreadID()
+            );
+        }
+    };
+
+    if (!parallel_record_pool || queue.GetType() != EQueueType::Graphics || !rhi_thread_enabled) {
+        return false;
+    }
+    batch_serial = ++parallel_record_batch_serial;
+    if (thread_profile) {
+        verify_fallback("record-diagnostics-enabled");
+        return false;
+    }
+
+    const auto& cmd_lists = _reorderer.m_cmd_lists;
+    Array<Array<const Command*>> command_layers(cmd_lists.size());
+    Array<Array<Command::EType>> type_layers(cmd_lists.size());
+    Array<Array<uint32_t>>       work_unit_layers(cmd_lists.size());
+    for (size_t layer_index = 0; layer_index < cmd_lists.size(); ++layer_index) {
+        for (const auto* node = cmd_lists[layer_index].head; node != nullptr; node = node->next) {
+            command_layers[layer_index].push_back(node->cmd);
+            type_layers[layer_index].push_back(node->cmd->Type());
+            work_unit_layers[layer_index].push_back(
+                VulkanParallelRecordDetail::EstimateWorkUnits(
+                    *node->cmd, _submit.cached_args
+                )
+            );
+        }
+    }
+
+    // Scope commands own a reorderer layer. Validate that invariant before
+    // any command payload or tracker state is prepared, then virtualize the
+    // scope across independently recorded primaries below.
+    Array<const ScopeCmd*> scope_validation_stack;
+    for (const auto& commands : command_layers) {
+        uint32 scope_count = 0;
+        for (const Command* command : commands) {
+            scope_count += command->Type() == Command::EType::Scope ? 1u : 0u;
+        }
+        if (scope_count != 0 && (scope_count != 1 || commands.size() != 1)) {
+            verify_fallback("mixed-scope-layer");
+            return false;
+        }
+        if (scope_count == 0) {
+            continue;
+        }
+        const auto* scope = static_cast<const ScopeCmd*>(commands.front());
+        if (scope->IsPush()) {
+            scope_validation_stack.push_back(scope);
+        } else {
+            if (scope_validation_stack.empty() ||
+                scope_validation_stack.back()->ScopeName() != scope->ScopeName() ||
+                scope_validation_stack.back()->QueryTimestamp() != scope->QueryTimestamp()) {
+                verify_fallback("unbalanced-scope");
+                return false;
+            }
+            scope_validation_stack.pop_back();
+        }
+    }
+    if (!scope_validation_stack.empty()) {
+        verify_fallback("unbalanced-scope");
+        return false;
+    }
+
+    Array<ParallelRecordLayerDescription> layer_descriptions;
+    layer_descriptions.reserve(type_layers.size());
+    for (size_t layer_index = 0; layer_index < type_layers.size(); ++layer_index) {
+        bool force_serial = false;
+        if (emits_profiling_queries) {
+            for (const Command* command : command_layers[layer_index]) {
+                if (command->Type() == Command::EType::ShaderDispatch &&
+                    static_cast<const DispatchCmd*>(command)->ProfileSectionName() != "Other") {
+                    force_serial = true;
+                    break;
+                }
+            }
+        }
+        layer_descriptions.push_back({
+            .command_types = std::span<const Command::EType>(
+                type_layers[layer_index].data(), type_layers[layer_index].size()
+            ),
+            .command_work_units = std::span<const uint32_t>(
+                work_unit_layers[layer_index].data(), work_unit_layers[layer_index].size()
+            ),
+            .force_serial = force_serial,
+        });
+    }
+    const ParallelRecordPlan plan = BuildParallelRecordPlan(
+        std::span<const ParallelRecordLayerDescription>(
+            layer_descriptions.data(), layer_descriptions.size()
+        ),
+        parallel_record_workers,
+        parallel_record_min_work_units_per_job
+    );
+    if (!plan.CanRecordInParallel()) {
+        if (parallel_record_verify && batch_serial <= 16) {
+            for (size_t layer_index = 0; layer_index < layer_descriptions.size(); ++layer_index) {
+                const ParallelRecordLayerDescription& layer = layer_descriptions[layer_index];
+                if (layer.command_types.empty()) {
+                    continue;
+                }
+                std::string type_names;
+                uint64      layer_work_units = 0;
+                for (const Command::EType type : layer.command_types) {
+                    if (!type_names.empty()) {
+                        type_names += ',';
+                    }
+                    type_names += GetCommandRecordTraits(type).stable_name;
+                }
+                for (const uint32_t work_units : layer.command_work_units) {
+                    layer_work_units += work_units;
+                }
+                LOG_INFO(
+                    "[ParallelRecord] batch={} candidate-layer={} commands={} work_units={} "
+                    "force_serial={} types={}",
+                    batch_serial,
+                    layer_index,
+                    layer.command_types.size(),
+                    layer_work_units,
+                    layer.force_serial,
+                    type_names
+                );
+            }
+        }
+        verify_fallback(fallback_name(plan.fallback_reason));
+        return false;
+    }
+    uint64 parallel_work_units = 0;
+    for (const ParallelRecordLayerPlan& layer_plan : plan.layers) {
+        if (!layer_plan.parallel) {
+            continue;
+        }
+        for (uint32 job_index = 0; job_index < layer_plan.job_count; ++job_index) {
+            parallel_work_units += plan.jobs[layer_plan.first_job + job_index].work_units;
+        }
+    }
+    for (const ParallelRecordLayerPlan& layer_plan : plan.layers) {
+        if (!layer_plan.parallel) {
+            continue;
+        }
+        for (const Command* command : command_layers[layer_plan.layer_index]) {
+            if (!IsParallelRecordReplaySafe(command->Type())) {
+                verify_fallback("replay-unsafe-command");
+                return false;
+            }
+        }
+    }
+
+    struct ParallelChunkRuntime {
+        ParallelRecordJobRange      range;
+        UniquePtr<VulkanAllocator> allocator;
+        uint32                      worker_id{0};
+        VkResult                    native_failure{VK_SUCCESS};
+        bool                        recorded{false};
+    };
+    struct ParallelLayerRuntime {
+        Array<const Command*>          commands;
+        Array<const ScopeCmd*>         scopes;
+        Array<const ScopeCmd*>         scopes_after;
+        UniquePtr<VulkanAllocator>     primary_allocator;
+        Array<ParallelChunkRuntime>    chunks;
+        UniquePtr<VulkanAllocator>     fallback_allocator;
+        bool                           parallel{false};
+        bool                           scope_only{false};
+        bool                           preprocessed{false};
+        bool                           worker_recorded{false};
+    };
+
+    const std::string queue_label = !_submit.debug_label.empty() ?
+                                        _submit.debug_label :
+                                        "Graphics Exec";
+    const float4 queue_label_color = !_submit.debug_label.empty() ?
+                                         _submit.debug_label_color :
+                                         float4{1.0f, 0.0f, 0.0f, 1.0f};
+    Timer execute_timer;
+    bool  profiling_started = false;
+    auto begin_primary = [&] (
+                             VulkanCmdList& _cmd_list,
+                             const Array<const ScopeCmd*>& _scopes,
+                             bool _coordinator
+                         ) -> VkResult {
+        const VkResult begin_result = _cmd_list.Begin();
+        if (begin_result != VK_SUCCESS) {
+            return begin_result;
+        }
+        if (_coordinator && begins_profiling_frame && !profiling_started) {
+            profiler_storage.CollectProfiling(_cmd_list.GetHandle());
+            {
+                std::unique_lock<std::mutex> profiler_lock(profiler_mutex);
+                cached_profiler_entry = profiler_storage.GetProfilerEntry();
+            }
+            profiler_storage.BeginProfilerSession(_cmd_list, "Graphics Exec");
+            if (complete_profiling_frame) {
+                ResetSplitProfilingCpuFrame();
+                execute_timer.Start();
+            } else {
+                BeginSplitProfilingCpuFrame();
+            }
+            profiling_started = true;
+        }
+        _cmd_list.BeginLabel(queue_label, queue_label_color);
+        for (const ScopeCmd* scope : _scopes) {
+            _cmd_list.BeginLabel(scope->ScopeName(), scope->Color());
+        }
+        return VK_SUCCESS;
+    };
+    auto end_primary = [&](VulkanCmdList& _cmd_list, const Array<const ScopeCmd*>& _scopes) -> VkResult {
+        for (auto scope = _scopes.rbegin(); scope != _scopes.rend(); ++scope) {
+            _cmd_list.EndLabel();
+        }
+        _cmd_list.EndLabel();
+        return _cmd_list.End();
+    };
+
+    VulkanDescriptorHeap& descriptor_heap = vk_device.GetGlobalDescriptorHeap();
+    VulkanDescriptorPushLease descriptor_lease =
+        descriptor_heap.BeginPushDescriptors(EQueueType::Graphics);
+
+    auto tracker_owner = GetAllocator();
+    auto& tracker       = tracker_owner->GetTracker();
+    VkCmdPreprocessor preprocessor(
+        vk_device, tracker, *tracker_owner, _function_table, _submit.cached_args
+    );
+
+    Array<ParallelLayerRuntime> runtime_layers(cmd_lists.size());
+    Array<const ScopeCmd*>      active_scopes;
+    double                      preprocess_time = 0.0;
+    auto reject_prepared_recording = [&](std::string_view _reason, VkResult _result) {
+        if (_result == VK_SUCCESS) {
+            _result = VK_ERROR_UNKNOWN;
+        }
+        LOG_ERROR(
+            "[ParallelRecord] prepared batch {} rejected: reason={} VkResult={}",
+            batch_serial,
+            _reason,
+            static_cast<int32_t>(_result)
+        );
+        ResetSplitProfilingCpuFrame();
+        // Once preprocessing/recording has begun, falling back to replaying
+        // the whole packet is unsafe: serial commands may already have moved
+        // payloads or allocated transient resources, and RestoreState may have
+        // published preferred layouts. Treat native record failure as terminal
+        // so no later frame can consume partially prepared CPU-side state.
+        vk_device.TryLatchFirstFault(_context, _result, false, false, true);
+        vk_device.RecordRejectedSubmit();
+        FailSubmissionSignals(timeline, _submit.signal_events, _result);
+        FinalizeRejectedBindlessUpdates(_submit);
+
+        Array<UniquePtr<VulkanAllocator>> abandoned_allocators;
+        auto collect_allocator = [&](UniquePtr<VulkanAllocator>& _allocator) {
+            if (_allocator) {
+                abandoned_allocators.push_back(std::move(_allocator));
+            }
+        };
+        for (ParallelLayerRuntime& runtime : runtime_layers) {
+            collect_allocator(runtime.primary_allocator);
+            collect_allocator(runtime.fallback_allocator);
+            for (ParallelChunkRuntime& chunk : runtime.chunks) {
+                collect_allocator(chunk.allocator);
+            }
+        }
+        collect_allocator(tracker_owner);
+
+        Array<RHIResource*> deferred_releases = TakeDeferredReleases();
+        {
+            std::unique_lock<std::mutex> lock(event_mutex);
+            event_queue.emplace_back(
+                VulkanSubmissionEvent{
+                    {EVulkanOperationStatus::Rejected, _result}, _context, false
+                },
+                _timeline,
+                false
+            );
+            event_queue.emplace_back(
+                VulkanAllocatorBatch{{}, std::move(abandoned_allocators)},
+                _timeline,
+                false
+            );
+            event_queue.emplace_back(std::move(descriptor_lease), _timeline, false);
+            for (auto& event : _submit.signal_events) {
+                event_queue.emplace_back(
+                    SignalEvent(event.timeline_handle, event.value), _timeline, false
+                );
+            }
+            if (!_submit.callbacks.empty()) {
+                event_queue.emplace_back(
+                    VulkanCallbackBatch{std::move(_submit.callbacks), false}, _timeline, false
+                );
+            }
+            if (!_submit.success_callbacks.empty()) {
+                event_queue.emplace_back(
+                    VulkanCallbackBatch{std::move(_submit.success_callbacks), true}, _timeline, false
+                );
+            }
+            if (!deferred_releases.empty()) {
+                event_queue.emplace_back(
+                    VulkanDeferredReleaseBatch{std::move(deferred_releases)}, _timeline, false
+                );
+            }
+            EnqueueCompletionMarker(_timeline);
+        }
+        queue_cv.notify_one();
+        if (parallel_record_verify) {
+            LOG_INFO(
+                "[ParallelRecord] batch={} requested=true effective=false "
+                "outcome=record-rejected reason={} coordinator={} VkResult={}",
+                batch_serial,
+                _reason,
+                Platform::GetCurrentThreadID(),
+                static_cast<int32_t>(_result)
+            );
+        }
+    };
+
+    // Freeze scope state and command ownership before any recorder starts.
+    // Synthetic label reopen/close at command-buffer boundaries never emits
+    // timestamp queries; the real Scope command remains in a serial island.
+    for (size_t layer_index = 0; layer_index < runtime_layers.size(); ++layer_index) {
+        ParallelLayerRuntime& runtime = runtime_layers[layer_index];
+        runtime.commands = std::move(command_layers[layer_index]);
+        runtime.scopes = active_scopes;
+        runtime.scope_only = runtime.commands.size() == 1 &&
+                             runtime.commands.front()->Type() == Command::EType::Scope;
+        runtime.parallel = plan.layers[layer_index].parallel;
+        if (runtime.scope_only) {
+            const auto* scope = static_cast<const ScopeCmd*>(runtime.commands.front());
+            if (scope->IsPush()) {
+                active_scopes.push_back(scope);
+            } else {
+                active_scopes.pop_back();
+            }
+        }
+        runtime.scopes_after = active_scopes;
+    }
+    assert(active_scopes.empty() && "validated scope stack changed during parallel prepare");
+
+    auto record_layer_prefix = [&](size_t _layer_index, VulkanCmdList& _cmd_list) {
+        ParallelLayerRuntime& runtime = runtime_layers[_layer_index];
+        assert(!runtime.preprocessed && "parallel layer prefix was recorded twice");
+        const auto preprocess_begin = std::chrono::steady_clock::now();
+        for (const Command* command : runtime.commands) {
+            preprocessor.VisitCmd(command);
+        }
+        tracker.ResolveBarriers();
+        tracker.DispatchBarriers(_cmd_list);
+        runtime.preprocessed = true;
+        preprocess_time += std::chrono::duration<double, std::milli>(
+                               std::chrono::steady_clock::now() - preprocess_begin
+                           ).count();
+        _cmd_list.InsertLabel(
+            std::format("[RHI Parallel] Layer {}", _layer_index),
+            {0.15f, 0.25f, 0.55f, 1.0f}
+        );
+    };
+
+    std::atomic<uint32_t> active_jobs{0};
+    std::atomic<uint32_t> max_active_jobs{0};
+    UnorderedSet<uint32>  distinct_workers;
+    uint64                total_job_count = 0;
+    uint32                parallel_wave_count = 0;
+    uint32                serial_island_count = 0;
+    bool                  parallel_recorded = true;
+    double                worker_join_time = 0.0;
+
+    // Preserve translate-time side-effect ordering by draining each contiguous
+    // safe wave before the coordinator visits the next serial island. The GPU
+    // submission remains layer ordered, while commands inside the wave may be
+    // translated concurrently regardless of their eventual execution layer.
+    auto run_parallel_wave = [&](size_t _first_layer, size_t _layer_end) -> bool {
+        Array<ExternalCpuJoinPool::Job> wave_jobs;
+        for (size_t layer_index = _first_layer; layer_index < _layer_end; ++layer_index) {
+            ParallelLayerRuntime& runtime = runtime_layers[layer_index];
+            if (!runtime.parallel) {
+                continue;
+            }
+            for (size_t chunk_index = 0; chunk_index < runtime.chunks.size(); ++chunk_index) {
+                wave_jobs.emplace_back([&, layer_index, chunk_index] {
+                    ParallelLayerRuntime& job_layer = runtime_layers[layer_index];
+                    ParallelChunkRuntime& chunk     = job_layer.chunks[chunk_index];
+                    const uint32 now_active =
+                        active_jobs.fetch_add(1, std::memory_order_acq_rel) + 1;
+                    uint32 observed = max_active_jobs.load(std::memory_order_relaxed);
+                    while (observed < now_active &&
+                           !max_active_jobs.compare_exchange_weak(
+                               observed, now_active, std::memory_order_relaxed
+                           )) {
+                    }
+                    auto finish_active = [&] {
+                        active_jobs.fetch_sub(1, std::memory_order_acq_rel);
+                    };
+
+                    try {
+                        chunk.worker_id = Platform::GetCurrentThreadID();
+                        VulkanCmdList& cmd_list = chunk.allocator->GetCmdList();
+                        cmd_list.SetDescriptorPushLease(descriptor_lease.state);
+                        const VkResult worker_begin =
+                            begin_primary(cmd_list, job_layer.scopes, false);
+                        if (worker_begin != VK_SUCCESS) {
+                            chunk.native_failure = worker_begin;
+                            throw std::runtime_error("parallel command buffer begin failed");
+                        }
+                        bool inject_after_first_command = false;
+                        if (parallel_record_worker_throw_trigger != 0) {
+                            const uint64 attempt = parallel_record_worker_attempts.fetch_add(
+                                1, std::memory_order_acq_rel
+                            ) + 1;
+                            inject_after_first_command =
+                                attempt == parallel_record_worker_throw_trigger;
+                        }
+                        cmd_list.InsertLabel(
+                            std::format(
+                                "[RHI Parallel] Layer {} Commands {}..{}",
+                                layer_index,
+                                chunk.range.command_begin,
+                                chunk.range.CommandEnd()
+                            ),
+                            {0.1f, 0.55f, 0.8f, 1.0f}
+                        );
+                        VkCmdVisitor visitor(
+                            vk_device,
+                            *chunk.allocator,
+                            chunk.allocator->GetTracker(),
+                            cmd_list,
+                            _submit.cached_args,
+                            nullptr,
+                            false
+                        );
+                        for (uint32 command_index = chunk.range.command_begin;
+                             command_index < chunk.range.CommandEnd(); ++command_index) {
+                            visitor.VisitCmd(job_layer.commands[command_index]);
+                            if (inject_after_first_command) {
+                                LOG_INFO(
+                                    "[ParallelRecord][Injection] point=worker-throw "
+                                    "phase=after-first-command trigger={} batch={} layer={} "
+                                    "command={}",
+                                    parallel_record_worker_throw_trigger,
+                                    batch_serial,
+                                    layer_index,
+                                    command_index
+                                );
+                                throw std::runtime_error(
+                                    "injected parallel command recorder worker failure"
+                                );
+                            }
+                        }
+                        const VkResult worker_end =
+                            end_primary(cmd_list, job_layer.scopes_after);
+                        if (worker_end != VK_SUCCESS) {
+                            chunk.native_failure = worker_end;
+                            throw std::runtime_error("parallel command buffer end failed");
+                        }
+                        chunk.recorded = true;
+                    } catch (...) {
+                        finish_active();
+                        throw;
+                    }
+                    finish_active();
+                });
+            }
+        }
+
+        if (wave_jobs.empty()) {
+            return true;
+        }
+        const uint32 wave_index = parallel_wave_count++;
+        total_job_count += wave_jobs.size();
+        const uint64 worker_descriptor_begin =
+            descriptor_heap.CurrentPushDescriptorOffset(descriptor_lease.state);
+        ExternalJoinResult join_result = ExternalJoinResult::Failed;
+        const auto worker_join_started = std::chrono::steady_clock::now();
+        try {
+            join_result = parallel_record_pool->RunAndWait(
+                std::span<const ExternalCpuJoinPool::Job>(wave_jobs.data(), wave_jobs.size())
+            );
+        } catch (...) {
+            join_result = ExternalJoinResult::Failed;
+        }
+        worker_join_time += RhiThreadProfileMilliseconds(
+            worker_join_started, std::chrono::steady_clock::now()
+        );
+
+        bool     wave_recorded = join_result == ExternalJoinResult::Completed;
+        VkResult native_failure = VK_SUCCESS;
+        for (size_t layer_index = _first_layer; layer_index < _layer_end; ++layer_index) {
+            ParallelLayerRuntime& runtime = runtime_layers[layer_index];
+            if (!runtime.parallel) {
+                continue;
+            }
+            for (const ParallelChunkRuntime& chunk : runtime.chunks) {
+                wave_recorded &= chunk.recorded;
+                if (native_failure == VK_SUCCESS && chunk.native_failure != VK_SUCCESS) {
+                    native_failure = chunk.native_failure;
+                }
+                if (chunk.worker_id != 0) {
+                    distinct_workers.insert(chunk.worker_id);
+                }
+            }
+        }
+        if (parallel_record_verify) {
+            LOG_INFO(
+                "[ParallelRecord][Wave] batch={} wave={} layers={}..{} jobs={} "
+                "join_completed={} worker_recorded={}",
+                batch_serial,
+                wave_index,
+                _first_layer,
+                _layer_end,
+                wave_jobs.size(),
+                join_result == ExternalJoinResult::Completed,
+                wave_recorded
+            );
+        }
+        // Native command-buffer failures are device/driver failures, not a
+        // replayable translation exception. Match coordinator Begin/End by
+        // latching the original VkResult and rejecting the prepared packet.
+        if (native_failure != VK_SUCCESS) {
+            reject_prepared_recording("worker-native-record-failed", native_failure);
+            return false;
+        }
+        for (size_t layer_index = _first_layer; layer_index < _layer_end; ++layer_index) {
+            if (runtime_layers[layer_index].parallel) {
+                runtime_layers[layer_index].worker_recorded = wave_recorded;
+            }
+        }
+        if (wave_recorded) {
+            return true;
+        }
+
+        parallel_recorded = false;
+        // The join contract drains all accepted jobs. No worker can still be
+        // writing when the submit-local descriptor cursor is rewound.
+        descriptor_heap.RewindPushDescriptors(
+            descriptor_lease.state, worker_descriptor_begin
+        );
+        for (size_t layer_index = _first_layer; layer_index < _layer_end; ++layer_index) {
+            ParallelLayerRuntime& runtime = runtime_layers[layer_index];
+            if (!runtime.parallel) {
+                continue;
+            }
+            runtime.worker_recorded = false;
+            runtime.fallback_allocator = GetAllocator();
+            VulkanCmdList& fallback_cmd = runtime.fallback_allocator->GetCmdList();
+            fallback_cmd.SetDescriptorPushLease(descriptor_lease.state);
+            const VkResult fallback_begin =
+                begin_primary(fallback_cmd, runtime.scopes, true);
+            if (fallback_begin != VK_SUCCESS) {
+                reject_prepared_recording("fallback-begin-failed", fallback_begin);
+                return false;
+            }
+            fallback_cmd.InsertLabel(
+                "[RHI Parallel] Coordinator Fallback", {0.75f, 0.25f, 0.1f, 1.0f}
+            );
+            VkCmdVisitor visitor(
+                vk_device,
+                *runtime.fallback_allocator,
+                runtime.fallback_allocator->GetTracker(),
+                fallback_cmd,
+                _submit.cached_args,
+                nullptr,
+                false
+            );
+            try {
+                for (const Command* command : runtime.commands) {
+                    visitor.VisitCmd(command);
+                }
+            } catch (const StaleBindlessUpdateBatch& error) {
+                LOG_WARNING(
+                    "[ParallelRecord] fallback rejected stale bindless batch: layer={} error={}",
+                    layer_index,
+                    error.what()
+                );
+                reject_prepared_recording(
+                    "stale-bindless-update", VK_ERROR_VALIDATION_FAILED_EXT
+                );
+                return false;
+            } catch (const std::exception& error) {
+                LOG_ERROR(
+                    "[ParallelRecord] fallback record failed: layer={} error={}",
+                    layer_index,
+                    error.what()
+                );
+                reject_prepared_recording(
+                    "fallback-record-failed", VK_ERROR_OUT_OF_POOL_MEMORY
+                );
+                return false;
+            } catch (...) {
+                reject_prepared_recording(
+                    "fallback-record-failed", VK_ERROR_OUT_OF_POOL_MEMORY
+                );
+                return false;
+            }
+            const VkResult fallback_end = end_primary(fallback_cmd, runtime.scopes_after);
+            if (fallback_end != VK_SUCCESS) {
+                reject_prepared_recording("fallback-end-failed", fallback_end);
+                return false;
+            }
+        }
+        return true;
+    };
+
+    // Consecutive coordinator-only layers share one primary. When a serial
+    // island is immediately followed by a parallel layer, its final commands
+    // also carry that layer's barrier prefix. This preserves GPU ordering while
+    // avoiding one primary allocator/CB for every reorderer layer.
+    constexpr size_t no_pending_wave = std::numeric_limits<size_t>::max();
+    size_t pending_wave_begin = no_pending_wave;
+    size_t pending_wave_end   = no_pending_wave;
+    auto flush_parallel_wave = [&]() -> bool {
+        if (pending_wave_begin == no_pending_wave) {
+            return true;
+        }
+        const size_t wave_begin = pending_wave_begin;
+        const size_t wave_end   = pending_wave_end;
+        pending_wave_begin = no_pending_wave;
+        pending_wave_end   = no_pending_wave;
+        return run_parallel_wave(wave_begin, wave_end);
+    };
+
+    for (size_t layer_index = 0; layer_index < runtime_layers.size();) {
+        while (layer_index < runtime_layers.size() &&
+               runtime_layers[layer_index].commands.empty()) {
+            ++layer_index;
+        }
+        if (layer_index == runtime_layers.size()) {
+            break;
+        }
+
+        ParallelLayerRuntime& first_runtime = runtime_layers[layer_index];
+        if (first_runtime.parallel) {
+            if (!first_runtime.preprocessed) {
+                first_runtime.primary_allocator = GetAllocator();
+                VulkanCmdList& primary_cmd = first_runtime.primary_allocator->GetCmdList();
+                primary_cmd.SetDescriptorPushLease(descriptor_lease.state);
+                const VkResult primary_begin =
+                    begin_primary(primary_cmd, first_runtime.scopes, true);
+                if (primary_begin != VK_SUCCESS) {
+                    reject_prepared_recording("coordinator-begin-failed", primary_begin);
+                    return true;
+                }
+                try {
+                    record_layer_prefix(layer_index, primary_cmd);
+                } catch (const std::exception& error) {
+                    LOG_ERROR(
+                        "[ParallelRecord] coordinator prefix failed: layer={} error={}",
+                        layer_index,
+                        error.what()
+                    );
+                    reject_prepared_recording(
+                        "coordinator-prefix-failed", VK_ERROR_OUT_OF_POOL_MEMORY
+                    );
+                    return true;
+                } catch (...) {
+                    reject_prepared_recording(
+                        "coordinator-prefix-failed", VK_ERROR_OUT_OF_POOL_MEMORY
+                    );
+                    return true;
+                }
+                const VkResult primary_end = end_primary(primary_cmd, first_runtime.scopes_after);
+                if (primary_end != VK_SUCCESS) {
+                    reject_prepared_recording("coordinator-end-failed", primary_end);
+                    return true;
+                }
+            }
+
+            const ParallelRecordLayerPlan& layer_plan = plan.layers[layer_index];
+            first_runtime.chunks.reserve(layer_plan.job_count);
+            for (uint32 job_index = 0; job_index < layer_plan.job_count; ++job_index) {
+                first_runtime.chunks.push_back({
+                    .range     = plan.jobs[layer_plan.first_job + job_index],
+                    .allocator = GetAllocator(),
+                });
+            }
+            if (pending_wave_begin == no_pending_wave) {
+                pending_wave_begin = layer_index;
+            }
+            pending_wave_end = layer_index + 1;
+            ++layer_index;
+            continue;
+        }
+
+        // No serial visitor may overtake the body translation of an earlier
+        // safe layer. This is the CPU-side counterpart of ordered GPU submit.
+        if (!flush_parallel_wave()) {
+            return true;
+        }
+
+        const uint32 island_index = serial_island_count++;
+        if (parallel_record_verify) {
+            LOG_INFO(
+                "[ParallelRecord][Island] batch={} island={} first_layer={} "
+                "joined_waves={}",
+                batch_serial,
+                island_index,
+                layer_index,
+                parallel_wave_count
+            );
+        }
+
+        first_runtime.primary_allocator = GetAllocator();
+        VulkanCmdList& island_cmd = first_runtime.primary_allocator->GetCmdList();
+        island_cmd.SetDescriptorPushLease(descriptor_lease.state);
+        const VkResult island_begin = begin_primary(island_cmd, first_runtime.scopes, true);
+        if (island_begin != VK_SUCCESS) {
+            reject_prepared_recording("coordinator-begin-failed", island_begin);
+            return true;
+        }
+
+        const Array<const ScopeCmd*>* island_exit_scopes = &first_runtime.scopes;
+        try {
+            while (layer_index < runtime_layers.size() &&
+                   !runtime_layers[layer_index].parallel) {
+                ParallelLayerRuntime& runtime = runtime_layers[layer_index];
+                if (runtime.commands.empty()) {
+                    ++layer_index;
+                    continue;
+                }
+                record_layer_prefix(layer_index, island_cmd);
+                VkCmdVisitor visitor(
+                    vk_device,
+                    *first_runtime.primary_allocator,
+                    tracker,
+                    island_cmd,
+                    _submit.cached_args,
+                    emits_profiling_queries ? &profiler_storage : nullptr,
+                    emits_profiling_queries
+                );
+                for (const Command* command : runtime.commands) {
+                    visitor.VisitCmd(command);
+                }
+                island_exit_scopes = &runtime.scopes_after;
+                ++layer_index;
+            }
+
+            // The serial island executes immediately before the next parallel
+            // body, so its primary can own that body's state-transition prefix.
+            if (layer_index < runtime_layers.size() &&
+                runtime_layers[layer_index].parallel &&
+                !runtime_layers[layer_index].commands.empty()) {
+                record_layer_prefix(layer_index, island_cmd);
+                island_exit_scopes = &runtime_layers[layer_index].scopes;
+            }
+        } catch (const StaleBindlessUpdateBatch& error) {
+            LOG_WARNING(
+                "[ParallelRecord] coordinator rejected stale bindless batch: layer={} error={}",
+                layer_index,
+                error.what()
+            );
+            reject_prepared_recording(
+                "stale-bindless-update", VK_ERROR_VALIDATION_FAILED_EXT
+            );
+            return true;
+        } catch (const std::exception& error) {
+            LOG_ERROR(
+                "[ParallelRecord] coordinator island record failed: layer={} error={}",
+                layer_index,
+                error.what()
+            );
+            reject_prepared_recording(
+                "coordinator-record-failed", VK_ERROR_OUT_OF_POOL_MEMORY
+            );
+            return true;
+        } catch (...) {
+            reject_prepared_recording(
+                "coordinator-record-failed", VK_ERROR_OUT_OF_POOL_MEMORY
+            );
+            return true;
+        }
+
+        const VkResult island_end = end_primary(island_cmd, *island_exit_scopes);
+        if (island_end != VK_SUCCESS) {
+            reject_prepared_recording("coordinator-end-failed", island_end);
+            return true;
+        }
+    }
+
+    if (!flush_parallel_wave()) {
+        return true;
+    }
+
+    tracker.RestoreState();
+    VulkanCmdList& epilogue_cmd = tracker_owner->GetCmdList();
+    epilogue_cmd.SetDescriptorPushLease(descriptor_lease.state);
+    const VkResult epilogue_begin = begin_primary(epilogue_cmd, active_scopes, true);
+    if (epilogue_begin != VK_SUCCESS) {
+        reject_prepared_recording("epilogue-begin-failed", epilogue_begin);
+        return true;
+    }
+    epilogue_cmd.InsertLabel("[RHI Parallel] Restore State", {0.15f, 0.25f, 0.55f, 1.0f});
+    tracker.DispatchBarriers(epilogue_cmd);
+    if (ends_profiling_frame) {
+        profiler_storage.EndProfilerSession(epilogue_cmd, "Graphics Exec");
+    }
+    const VkResult epilogue_end = end_primary(epilogue_cmd, active_scopes);
+    if (epilogue_end != VK_SUCCESS) {
+        reject_prepared_recording("epilogue-end-failed", epilogue_end);
+        return true;
+    }
+    tracker.Reset();
+    descriptor_heap.EndPushDescriptors(descriptor_lease);
+    const uint64 descriptor_bytes =
+        descriptor_heap.CurrentPushDescriptorOffset(descriptor_lease.state) -
+        descriptor_lease.state->begin;
+
+    Array<VulkanCmdList*> ordered_cmd_lists;
+    Array<UniquePtr<VulkanAllocator>> submitted_allocators;
+    Array<UniquePtr<VulkanAllocator>> abandoned_allocators;
+    ordered_cmd_lists.reserve(plan.layers.size() + total_job_count + 1);
+    submitted_allocators.reserve(plan.layers.size() + total_job_count + 1);
+    for (ParallelLayerRuntime& runtime : runtime_layers) {
+        if (runtime.primary_allocator) {
+            ordered_cmd_lists.push_back(&runtime.primary_allocator->GetCmdList());
+            submitted_allocators.push_back(std::move(runtime.primary_allocator));
+        }
+        if (!runtime.parallel) {
+            continue;
+        }
+        if (runtime.worker_recorded) {
+            for (ParallelChunkRuntime& chunk : runtime.chunks) {
+                ordered_cmd_lists.push_back(&chunk.allocator->GetCmdList());
+                submitted_allocators.push_back(std::move(chunk.allocator));
+            }
+        } else {
+            ordered_cmd_lists.push_back(&runtime.fallback_allocator->GetCmdList());
+            submitted_allocators.push_back(std::move(runtime.fallback_allocator));
+            // Keep every abandoned recorder pool alive and retire/reset it as
+            // part of the same timeline transaction, but never submit its CB.
+            for (ParallelChunkRuntime& chunk : runtime.chunks) {
+                abandoned_allocators.push_back(std::move(chunk.allocator));
+            }
+        }
+    }
+    ordered_cmd_lists.push_back(&tracker_owner->GetCmdList());
+    submitted_allocators.push_back(std::move(tracker_owner));
+
+    Array<RHIResource*> deferred_releases = TakeDeferredReleases();
+    const double profile_record_wall_ms = parallel_record_profile ?
+                                              RhiThreadProfileMilliseconds(
+                                                  _profile_started,
+                                                  std::chrono::steady_clock::now()
+                                              ) :
+                                              0.0;
+    CurrentVulkanRecordedSubmit recorded_submit{
+        std::move(_submit), _context, _timeline
+    };
+    recorded_submit.has_commands      = true;
+    recorded_submit.ordered_cmd_lists = std::move(ordered_cmd_lists);
+    recorded_submit.allocators = VulkanAllocatorBatch{
+        std::move(submitted_allocators), std::move(abandoned_allocators)
+    };
+    recorded_submit.descriptor_lease.emplace(std::move(descriptor_lease));
+    recorded_submit.deferred_releases = std::move(deferred_releases);
+    if (parallel_record_profile) {
+        recorded_submit.profile.enabled         = true;
+        recorded_submit.profile.execute_started = _profile_started;
+        recorded_submit.profile.sample = {
+            .requested       = true,
+            .planned         = true,
+            .effective       = parallel_recorded,
+            .worker_fallback = !parallel_recorded,
+            .record_wall_ms  = profile_record_wall_ms,
+            .reorder_ms      = _reorder_time,
+            .preprocess_ms   = preprocess_time,
+            .worker_join_ms  = worker_join_time,
+            .layers          = static_cast<uint32>(runtime_layers.size()),
+            .jobs            = static_cast<uint32>(total_job_count),
+            .work_units      = parallel_work_units,
+            .max_active      = max_active_jobs.load(std::memory_order_relaxed),
+        };
+    }
+    const uint32 recorded_cmd_list_count =
+        static_cast<uint32>(recorded_submit.ordered_cmd_lists.size());
+    CurrentVulkanSubmitResult submit_result{};
+    if (_out_recorded != nullptr) {
+        _out_recorded->emplace(std::move(recorded_submit));
+    } else {
+        submit_result = SubmitRecorded(std::move(recorded_submit));
+    }
+
+    QueryFrameDiagnostics query_diagnostics{};
+    if (complete_profiling_frame) {
+        execute_timer.Stop();
+        query_diagnostics = profiler_storage.GetCurrentFrameQueryDiagnostics();
+        const double execute_time = execute_timer.ElapsedMilliseconds();
+        profiler_storage.RegisterCpuTimestamp("Queue Execution", execute_time);
+        profiler_storage.RegisterCpuTimestamp("Command Reorder", _reorder_time);
+        profiler_storage.RegisterCpuTimestamp("Command Preprocess", preprocess_time);
+        if (execute_time > 0.0) {
+            profiler_storage.RegisterCpuTimestamp("Reorder Percentage", _reorder_time / execute_time);
+            profiler_storage.RegisterCpuTimestamp(
+                "Preprocess Percentage", preprocess_time / execute_time
+            );
+        }
+        profiler_storage.AdvanceFrame();
+    } else if (emits_profiling_queries) {
+        const bool submission_accepted =
+            _out_recorded != nullptr || submit_result.outcome.WasSubmitted();
+        if (!submission_accepted) {
+            ResetSplitProfilingCpuFrame();
+        } else {
+            AccumulateSplitProfilingCpuFrame(_reorder_time, preprocess_time);
+            if (ends_profiling_frame) {
+                query_diagnostics = profiler_storage.GetCurrentFrameQueryDiagnostics();
+                EndSplitProfilingCpuFrame();
+            }
+        }
+    }
+
+    if (parallel_record_verify) {
+        LOG_INFO(
+            "[ParallelRecord] batch={} requested=true effective={} outcome={} layers={} jobs={} "
+            "work_units={} ordered_cb={} waves={} islands={} workers={} distinct_workers={} max_active={} "
+            "coordinator={} submit_status={} "
+            "descriptor_bytes={} query_digest={:016x} queries={}",
+            batch_serial,
+            parallel_recorded,
+            parallel_recorded ? "parallel" : "serial-fallback-worker-failure",
+            plan.parallel_layer_count,
+            total_job_count,
+            parallel_work_units,
+            _out_recorded != nullptr ? recorded_cmd_list_count :
+                                       submit_result.ordered_cmd_list_count,
+            parallel_wave_count,
+            serial_island_count,
+            parallel_record_workers,
+            distinct_workers.size(),
+            max_active_jobs.load(std::memory_order_relaxed),
+            Platform::GetCurrentThreadID(),
+            _out_recorded != nullptr ? std::numeric_limits<uint32>::max() :
+                                       static_cast<uint32>(submit_result.outcome.status),
+            descriptor_bytes,
+            query_diagnostics.digest,
+            query_diagnostics.used_query_count
+        );
+    }
+    return true;
+}
+
+void VkCommandQueue::ExecuteNow(
+    CmdSubmit&& _submit,
+    uint64 _timeline,
+    uint64 _serial,
+    std::optional<CurrentVulkanRecordedSubmit>* _out_recorded,
+    bool _runtime_owner
+) {
+    assert(
+        _runtime_owner || !rhi_thread_enabled ||
         rhi_thread_id.load(std::memory_order_acquire) == Platform::GetCurrentThreadID()
     );
+
+    const ERHIProfilingPhase profiling_phase = _submit.ProfilingPhase();
+    const bool emits_profiling_queries       = _submit.EmitsProfilingQueries();
+    const bool begins_profiling_frame        = _submit.BeginsProfilingFrame();
+    const bool ends_profiling_frame          = _submit.EndsProfilingFrame();
+    const bool complete_profiling_frame =
+        profiling_phase == ERHIProfilingPhase::Complete;
 
     const VulkanOperationContext context{
         .operation   = EVulkanFaultOperation::QueueSubmit,
@@ -3217,6 +4682,7 @@ void VkCommandQueue::ExecuteNow(CmdSubmit&& _submit, uint64 _timeline, uint64 _s
         .work_serial = _serial,
     };
     if (vk_device.IsFaulted()) {
+        ResetSplitProfilingCpuFrame();
         vk_device.RecordRejectedSubmit();
         const VkResult rejected_result = vk_device.GetFirstFaultResult();
         FailSubmissionSignals(timeline, _submit.signal_events, rejected_result);
@@ -3244,6 +4710,42 @@ void VkCommandQueue::ExecuteNow(CmdSubmit&& _submit, uint64 _timeline, uint64 _s
         return;
     }
 
+    const auto parallel_profile_started = parallel_record_profile ?
+                                               std::chrono::steady_clock::now() :
+                                               std::chrono::steady_clock::time_point{};
+    Timer reorder_timer{};
+    FunctionTable function_table{
+        .is_resource_write       = &IsBufferTextureWrite,
+        .is_resource_read        = &IsBufferTextureRead,
+        .is_texture_sampled      = &IsTextureSampled,
+        .is_resource_in_bindless = &IsResourceInBindlessArray,
+        .lock_bdls_array         = &LockBindlessArray,
+        .unlock_bdls_array       = &UnlockBindlessArray
+    };
+    CmdReorderer reorderer{function_table, _submit.cached_args};
+    // Prepare the dependency layers exactly once. A profitability fallback
+    // reuses this immutable reorder result on the serial recorder.
+    reorder_timer.Start();
+    for (const auto& cmd : _submit.cmds) {
+        reorderer.AcceptCmd(cmd.get());
+    }
+    reorder_timer.Stop();
+    const double reorder_time = reorder_timer.ElapsedMilliseconds();
+
+    if (TryExecuteParallel(
+            _submit,
+            _timeline,
+            _serial,
+            context,
+            function_table,
+            reorderer,
+            reorder_time,
+            parallel_profile_started,
+            _out_recorded
+        )) {
+        return;
+    }
+
     UniquePtr<RhiRecordExecuteSample> record_sample;
     UniquePtr<VulkanSerialGoldenTrace> serial_golden;
     UnorderedMap<const Command*, uint32_t> original_ordinals;
@@ -3259,25 +4761,7 @@ void VkCommandQueue::ExecuteNow(CmdSubmit&& _submit, uint64 _timeline, uint64 _s
         }
     }
 
-    Timer         timer{};
-    Timer         reorder_timer{};
-    FunctionTable function_table{
-        .is_resource_write       = &IsBufferTextureWrite,
-        .is_resource_read        = &IsBufferTextureRead,
-        .is_texture_sampled      = &IsTextureSampled,
-        .is_resource_in_bindless = &IsResourceInBindlessArray,
-        .lock_bdls_array         = &LockBindlessArray,
-        .unlock_bdls_array       = &UnlockBindlessArray
-    };
-
-    CmdReorderer reorderer{function_table, _submit.cached_args};
-    //reorder commands base on resource read/write and manual scope
-    reorder_timer.Start();
-    for (const auto& cmd : _submit.cmds) {
-        reorderer.AcceptCmd(cmd.get());
-    }
-    reorder_timer.Stop();
-    double reorder_time = reorder_timer.ElapsedMilliseconds();
+    Timer timer{};
 
     //Get Allocators for buffer, texture and commandlist
     auto  allocator_ptr = std::move(GetAllocator());
@@ -3294,7 +4778,7 @@ void VkCommandQueue::ExecuteNow(CmdSubmit&& _submit, uint64 _timeline, uint64 _s
         vk_allocator.GetCmdList(),
         _submit.cached_args,
         &profiler_storage,
-        _submit.b_tick_profiling
+        emits_profiling_queries
     );
 
     //Visitor for barrier generation
@@ -3303,7 +4787,7 @@ void VkCommandQueue::ExecuteNow(CmdSubmit&& _submit, uint64 _timeline, uint64 _s
     // LOG_INFO("Reorderer time {}", timer.ElapsedMilliseconds());
     const auto& cmd_lists = reorderer.m_cmd_lists;
     bool        has_cmd   = !reorderer.m_cmd_lists.empty();
-    uint64      descriptor_frame = 0;
+    std::optional<VulkanDescriptorPushLease> descriptor_lease;
     uint64      descriptor_begin_offset = 0;
 
     if (record_sample) {
@@ -3359,9 +4843,82 @@ void VkCommandQueue::ExecuteNow(CmdSubmit&& _submit, uint64 _timeline, uint64 _s
 
     //Set Descriptor buffer ringbuffer offset and start debug region
     double preprocess_time = 0.0;
+    struct SerialNativeRecordFailure {
+        std::string_view reason;
+        VkResult        result{VK_ERROR_UNKNOWN};
+    };
+    auto reject_serial_recording = [&](std::string_view _reason, VkResult _result) {
+        if (_result == VK_SUCCESS) {
+            _result = VK_ERROR_UNKNOWN;
+        }
+        LOG_ERROR(
+            "[SerialRecord] batch {} rejected: reason={} VkResult={}",
+            _serial,
+            _reason,
+            static_cast<int32_t>(_result)
+        );
+        ResetSplitProfilingCpuFrame();
+        // Recording may already have executed CPU-side preprocessing or
+        // transient allocation. Replaying the packet is therefore unsafe.
+        vk_device.TryLatchFirstFault(context, _result, false, false, true);
+        vk_device.RecordRejectedSubmit();
+        FailSubmissionSignals(timeline, _submit.signal_events, _result);
+        FinalizeRejectedBindlessUpdates(_submit);
+
+        Array<UniquePtr<VulkanAllocator>> abandoned_allocators;
+        if (allocator_ptr) {
+            abandoned_allocators.push_back(std::move(allocator_ptr));
+        }
+        Array<RHIResource*> deferred_releases = TakeDeferredReleases();
+        {
+            std::unique_lock<std::mutex> lock(event_mutex);
+            event_queue.emplace_back(
+                VulkanSubmissionEvent{
+                    {EVulkanOperationStatus::Rejected, _result}, context, false
+                },
+                _timeline,
+                false
+            );
+            event_queue.emplace_back(
+                VulkanAllocatorBatch{{}, std::move(abandoned_allocators)},
+                _timeline,
+                false
+            );
+            if (descriptor_lease.has_value()) {
+                event_queue.emplace_back(std::move(*descriptor_lease), _timeline, false);
+            }
+            for (auto& event : _submit.signal_events) {
+                event_queue.emplace_back(
+                    SignalEvent(event.timeline_handle, event.value), _timeline, false
+                );
+            }
+            if (!_submit.callbacks.empty()) {
+                event_queue.emplace_back(
+                    VulkanCallbackBatch{std::move(_submit.callbacks), false}, _timeline, false
+                );
+            }
+            if (!_submit.success_callbacks.empty()) {
+                event_queue.emplace_back(
+                    VulkanCallbackBatch{std::move(_submit.success_callbacks), true}, _timeline, false
+                );
+            }
+            if (!deferred_releases.empty()) {
+                event_queue.emplace_back(
+                    VulkanDeferredReleaseBatch{std::move(deferred_releases)}, _timeline, false
+                );
+            }
+            EnqueueCompletionMarker(_timeline);
+        }
+        queue_cv.notify_one();
+    };
+
+    auto record_serial_commands = [&] {
     if (has_cmd) {
-        vk_allocator.GetCmdList().Begin();
-        if (_submit.b_tick_profiling) {
+        const VkResult begin_result = vk_allocator.GetCmdList().Begin();
+        if (begin_result != VK_SUCCESS) {
+            throw SerialNativeRecordFailure{"command-buffer-begin-failed", begin_result};
+        }
+        if (begins_profiling_frame) {
             if (serial_golden) {
                 serial_golden->SetCurrentCommand(std::numeric_limits<uint32_t>::max());
             }
@@ -3385,16 +4942,24 @@ void VkCommandQueue::ExecuteNow(CmdSubmit&& _submit, uint64 _timeline, uint64 _s
                     ProfilerStorage::kBeginTimestampStage
                 );
             }
-            timer.Start();
+            if (complete_profiling_frame) {
+                ResetSplitProfilingCpuFrame();
+                timer.Start();
+            } else {
+                BeginSplitProfilingCpuFrame();
+            }
         }
 
         if (queue.GetType() != EQueueType::Copy) {
             // Present work advances the queue timeline without consuming descriptor storage.
             // Keep ring reuse aligned with the execute-only in-flight limit.
-            descriptor_frame = descriptor_submission++;
-            vk_device.GetGlobalDescriptorHeap().BeginPushDescriptors(descriptor_frame);
+            descriptor_lease.emplace(
+                vk_device.GetGlobalDescriptorHeap().BeginPushDescriptors(queue.GetType())
+            );
+            vk_allocator.GetCmdList().SetDescriptorPushLease(descriptor_lease->state);
             if (record_sample) {
-                descriptor_begin_offset = vk_device.GetGlobalDescriptorHeap().current_offset;
+                descriptor_begin_offset = vk_device.GetGlobalDescriptorHeap()
+                                              .CurrentPushDescriptorOffset(descriptor_lease->state);
             }
         }
 
@@ -3450,12 +5015,16 @@ void VkCommandQueue::ExecuteNow(CmdSubmit&& _submit, uint64 _timeline, uint64 _s
             for (const auto* cmdnode = cmd_list.head; cmdnode != nullptr; cmdnode = cmdnode->next) {
                 const auto* cmd = cmdnode->cmd;
                 const uint64 descriptor_before =
-                    vk_device.GetGlobalDescriptorHeap().current_offset;
+                    vk_device.GetGlobalDescriptorHeap().CurrentPushDescriptorOffset(
+                        descriptor_lease->state
+                    );
                 const auto  command_started = std::chrono::steady_clock::now();
                 visitor.VisitCmd(cmd);
                 const auto command_finished = std::chrono::steady_clock::now();
                 const uint64 descriptor_after =
-                    vk_device.GetGlobalDescriptorHeap().current_offset;
+                    vk_device.GetGlobalDescriptorHeap().CurrentPushDescriptorOffset(
+                        descriptor_lease->state
+                    );
                 assert(deferred_index < deferred_diagnostics.size());
                 deferred_diagnostics[deferred_index++] = {
                     .cmd              = cmd,
@@ -3488,7 +5057,7 @@ void VkCommandQueue::ExecuteNow(CmdSubmit&& _submit, uint64 _timeline, uint64 _s
                     diagnostics.descriptor_begin,
                     diagnostics.descriptor_bytes
                 );
-                if (_submit.b_tick_profiling && cmd->Type() == Command::EType::Scope) {
+                if (emits_profiling_queries && cmd->Type() == Command::EType::Scope) {
                     const auto& scope = *static_cast<const ScopeCmd*>(cmd);
                     if (scope.QueryTimestamp()) {
                         serial_golden->RecordQueryEvent(
@@ -3498,7 +5067,7 @@ void VkCommandQueue::ExecuteNow(CmdSubmit&& _submit, uint64 _timeline, uint64 _s
                                            : ProfilerStorage::kEndTimestampStage
                         );
                     }
-                } else if (_submit.b_tick_profiling && cmd->Type() == Command::EType::ShaderDispatch) {
+                } else if (emits_profiling_queries && cmd->Type() == Command::EType::ShaderDispatch) {
                     const auto& dispatch = *static_cast<const DispatchCmd*>(cmd);
                     if (dispatch.ProfileSectionName() != "Other") {
                         serial_golden->RecordQueryEvent(
@@ -3550,7 +5119,7 @@ void VkCommandQueue::ExecuteNow(CmdSubmit&& _submit, uint64 _timeline, uint64 _s
             record_pending_barriers(std::numeric_limits<uint64>::max());
         }
         tracker.DispatchBarriers(vk_allocator.GetCmdList());
-        if (_submit.b_tick_profiling) {
+        if (ends_profiling_frame) {
             profiler_storage.EndProfilerSession(vk_allocator.GetCmdList(), "Graphics Exec");
             if (serial_golden) {
                 serial_golden->SetCurrentCommand(std::numeric_limits<uint32_t>::max());
@@ -3562,15 +5131,20 @@ void VkCommandQueue::ExecuteNow(CmdSubmit&& _submit, uint64 _timeline, uint64 _s
             }
         }
         vk_allocator.GetCmdList().EndLabel();
-        vk_allocator.GetCmdList().End();
+        const VkResult end_result = vk_allocator.GetCmdList().End();
+        if (end_result != VK_SUCCESS) {
+            throw SerialNativeRecordFailure{"command-buffer-end-failed", end_result};
+        }
         if (queue.GetType() != EQueueType::Copy) {
             if (record_sample) {
                 record_sample->descriptor_bytes =
-                    vk_device.GetGlobalDescriptorHeap().current_offset - descriptor_begin_offset;
+                    vk_device.GetGlobalDescriptorHeap().CurrentPushDescriptorOffset(
+                        descriptor_lease->state
+                    ) - descriptor_begin_offset;
             }
-            vk_device.GetGlobalDescriptorHeap().EndPushDescriptors(descriptor_frame);
+            vk_device.GetGlobalDescriptorHeap().EndPushDescriptors(*descriptor_lease);
         }
-        if (record_sample && _submit.b_tick_profiling) {
+        if (record_sample && ends_profiling_frame) {
             const QueryFrameDiagnostics query_diagnostics =
                 profiler_storage.GetCurrentFrameQueryDiagnostics();
             record_sample->query_digest = query_diagnostics.digest;
@@ -3578,12 +5152,32 @@ void VkCommandQueue::ExecuteNow(CmdSubmit&& _submit, uint64 _timeline, uint64 _s
         }
         tracker.Reset();
     }
+    };
+
+    try {
+        record_serial_commands();
+    } catch (const SerialNativeRecordFailure& failure) {
+        reject_serial_recording(failure.reason, failure.result);
+        return;
+    } catch (const StaleBindlessUpdateBatch& error) {
+        LOG_WARNING("[SerialRecord] rejected stale bindless batch: {}", error.what());
+        reject_serial_recording(
+            "stale-bindless-update", VK_ERROR_VALIDATION_FAILED_EXT
+        );
+        return;
+    } catch (const std::exception& error) {
+        reject_serial_recording(error.what(), VK_ERROR_OUT_OF_POOL_MEMORY);
+        return;
+    } catch (...) {
+        reject_serial_recording("unknown-recording-exception", VK_ERROR_UNKNOWN);
+        return;
+    }
 
     if (record_sample) {
         StableRecordHash descriptor_hash;
         descriptor_hash.Add(record_sample->descriptor_bytes);
         record_sample->descriptor_digest = descriptor_hash.Value();
-        if (!_submit.b_tick_profiling) {
+        if (!emits_profiling_queries) {
             StableRecordHash query_hash;
             query_hash.Add(0);
             record_sample->query_digest = query_hash.Value();
@@ -3607,71 +5201,49 @@ void VkCommandQueue::ExecuteNow(CmdSubmit&& _submit, uint64 _timeline, uint64 _s
         RecordRhiRecordProfile(*record_sample);
     }
 
+    const uint32 serial_layer_count = static_cast<uint32>(cmd_lists.size());
     Array<RHIResource*> deferred_releases = TakeDeferredReleases();
-
-    const auto            end_tag = VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT;
-    VulkanOperationResult submit_outcome{};
-    if (!WaitForSubmittedDependencies(vk_device, _submit.wait_events)) {
-        vk_device.RecordRejectedSubmit();
-        const VkResult rejected_result = GetRejectedSubmitResult(vk_device);
-        submit_outcome = {EVulkanOperationStatus::Rejected, rejected_result};
-        FailSubmissionSignals(timeline, _submit.signal_events, rejected_result);
-    } else {
-        queue.Signal(timeline, _timeline, end_tag);
-        for (auto& evt : _submit.wait_events) {
-            queue.Wait(
-                reinterpret_cast<VulkanFence*>(evt.timeline_handle),
-                evt.value,
-                VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT
-            );
-        }
-        for (auto& evt : _submit.signal_events) {
-            queue.Signal(reinterpret_cast<VulkanFence*>(evt.timeline_handle), evt.value, end_tag);
-        }
-
-        submit_outcome = has_cmd ? queue.Submit(vk_allocator.GetCmdList(), context)
-                                 : queue.SubmitEmpty(context);
-        if (submit_outcome.WasSubmitted()) {
-            MarkSubmissionAccepted(timeline, _timeline, _submit.signal_events);
-        } else {
-            FailSubmissionSignals(timeline, _submit.signal_events, submit_outcome.result);
-        }
-    }
-
-    {
-        std::unique_lock<std::mutex> lock(event_mutex);
-        event_queue.emplace_back(
-            VulkanSubmissionEvent{submit_outcome, context, submit_outcome.WasSubmitted()},
-            _timeline,
-            false
-        );
-        event_queue.emplace_back(std::move(allocator_ptr), _timeline, false);
-        for (auto& evt : _submit.signal_events) {
-            event_queue.emplace_back(SignalEvent(evt.timeline_handle, evt.value), _timeline, false);
-        }
-        if (!_submit.callbacks.empty()) {
-            event_queue.emplace_back(
-                VulkanCallbackBatch{std::move(_submit.callbacks), false}, _timeline, false
-            );
-        }
-        if (!_submit.success_callbacks.empty()) {
-            event_queue.emplace_back(
-                VulkanCallbackBatch{std::move(_submit.success_callbacks), true}, _timeline, false
-            );
-        }
-        if (!deferred_releases.empty()) {
-            event_queue.emplace_back(
-                VulkanDeferredReleaseBatch{std::move(deferred_releases)}, _timeline, false
-            );
-        }
-        EnqueueCompletionMarker(_timeline);
-    }
-    queue_cv.notify_one();
-
+    const double profile_record_wall_ms = parallel_record_profile ?
+                                              RhiThreadProfileMilliseconds(
+                                                  parallel_profile_started,
+                                                  std::chrono::steady_clock::now()
+                                              ) :
+                                              0.0;
+    CurrentVulkanRecordedSubmit recorded_submit{
+        std::move(_submit), context, _timeline
+    };
+    recorded_submit.has_commands = has_cmd;
     if (has_cmd) {
-        executed_queue.Enqueue(_timeline);
+        recorded_submit.ordered_cmd_lists.push_back(&vk_allocator.GetCmdList());
     }
-    if (has_cmd && _submit.b_tick_profiling) {
+    recorded_submit.allocators.submitted.push_back(std::move(allocator_ptr));
+    recorded_submit.descriptor_lease  = std::move(descriptor_lease);
+    recorded_submit.deferred_releases = std::move(deferred_releases);
+    if (parallel_record_profile) {
+        recorded_submit.profile.enabled         = true;
+        recorded_submit.profile.execute_started = parallel_profile_started;
+        recorded_submit.profile.sample = {
+            .requested       = parallel_record_requested,
+            .planned         = false,
+            .effective       = false,
+            .worker_fallback = false,
+            .record_wall_ms  = profile_record_wall_ms,
+            .reorder_ms      = reorder_time,
+            .preprocess_ms   = preprocess_time,
+            .worker_join_ms  = 0.0,
+            .layers          = serial_layer_count,
+            .jobs            = 0,
+            .max_active      = 0,
+        };
+    }
+    CurrentVulkanSubmitResult submit_result{};
+    if (_out_recorded != nullptr) {
+        _out_recorded->emplace(std::move(recorded_submit));
+    } else {
+        submit_result = SubmitRecorded(std::move(recorded_submit));
+    }
+
+    if (has_cmd && complete_profiling_frame) {
         timer.Stop();
         profiler_storage.RegisterCpuTimestamp("Queue Execution", timer.ElapsedMilliseconds());
         profiler_storage.RegisterCpuTimestamp("Command Reorder", reorder_time);
@@ -3683,6 +5255,17 @@ void VkCommandQueue::ExecuteNow(CmdSubmit&& _submit, uint64 _timeline, uint64 _s
             "Preprocess Percentage", preprocess_time / timer.ElapsedMilliseconds()
         );
         profiler_storage.AdvanceFrame();
+    } else if (has_cmd && emits_profiling_queries) {
+        const bool submission_accepted =
+            _out_recorded != nullptr || submit_result.outcome.WasSubmitted();
+        if (!submission_accepted) {
+            ResetSplitProfilingCpuFrame();
+        } else {
+            AccumulateSplitProfilingCpuFrame(reorder_time, preprocess_time);
+            if (ends_profiling_frame) {
+                EndSplitProfilingCpuFrame();
+            }
+        }
     }
 }
 
@@ -3761,16 +5344,17 @@ void VkCommandQueue::Present(
     }
 }
 
-void VkCommandQueue::PresentNow(
+VulkanRuntimeSubmissionResult VkCommandQueue::PresentNow(
     SwapchainRef&& _sc,
     TextureRef&&   _source_texture,
     TextureView    _view,
     PresentReceiptRef _receipt,
     uint64         _timeline,
-    uint64         _serial
+    uint64         _serial,
+    bool           _runtime_owner
 ) {
     assert(
-        !rhi_thread_enabled ||
+        _runtime_owner || !rhi_thread_enabled ||
         rhi_thread_id.load(std::memory_order_acquire) == Platform::GetCurrentThreadID()
     );
 
@@ -3799,7 +5383,9 @@ void VkCommandQueue::PresentNow(
         EnqueueCompletionMarker(_timeline);
         lock.unlock();
         queue_cv.notify_one();
-        return;
+        return {
+            .outcome = {EVulkanOperationStatus::Rejected, rejected_result}
+        };
     }
 
     VkSwapchain* sc = ResourceCast(_sc.Get());
@@ -3826,7 +5412,9 @@ void VkCommandQueue::PresentNow(
         EnqueueCompletionMarker(_timeline);
         lock.unlock();
         queue_cv.notify_one();
-        return;
+        return {
+            .outcome = {EVulkanOperationStatus::Rejected, rejected_result}
+        };
     }
     auto acquire = sc->AquireNextImage(rhi_thread_enabled ? 0 : 50'000'000);
     bool recreate_swapchain =
@@ -3867,7 +5455,7 @@ void VkCommandQueue::PresentNow(
             EnqueueCompletionMarker(_timeline);
         }
         queue_cv.notify_one();
-        return;
+        return {.outcome = acquire.outcome};
     }
 
     //copy
@@ -3875,7 +5463,7 @@ void VkCommandQueue::PresentNow(
     const uint idx       = acquire.image_index;
     auto* swaphchain_tex = ResourceCast(sc->GetSwapchainImage(idx).texture);
     {
-        vk_cmd_list.Begin();
+        VK_CHECK_RESULT(vk_cmd_list.Begin());
         const std::string present_label = std::format("Present: {}", vk_src_tex->GetName());
         vk_cmd_list.BeginLabel(present_label, {0.0f, 0.85f, 0.95f, 1.0f});
         vk_tracker.SetPassType(EPassType::Graphics);
@@ -3898,7 +5486,7 @@ void VkCommandQueue::PresentNow(
         vk_tracker.RestoreState();
         vk_tracker.DispatchBarriers(vk_cmd_list);
         vk_cmd_list.EndLabel();
-        vk_cmd_list.End();
+        VK_CHECK_RESULT(vk_cmd_list.End());
         vk_tracker.Reset();
         // vk_tracker.PropagateState();
     }
@@ -3956,6 +5544,11 @@ void VkCommandQueue::PresentNow(
         presented_queue.Enqueue(_timeline);
     }
     queue_cv.notify_one();
+    VulkanRuntimeSubmissionResult runtime_result{.outcome = final_outcome};
+    if (submit_outcome.WasSubmitted()) {
+        runtime_result.completion = WaitEvent{uint64(timeline), _timeline};
+    }
+    return runtime_result;
 }
 
 void VkCommandQueue::Sync() {
@@ -4270,6 +5863,124 @@ void VkCommandQueue::RecordRhiRecordProfile(const RhiRecordExecuteSample& _sampl
     }
     profile.has_topology         = true;
     profile.last_topology_digest = _sample.topology.topology_digest;
+}
+
+void VkCommandQueue::RecordParallelRecordProfile(
+    const ParallelRecordProfileSample& _sample
+) {
+    if (!parallel_record_profile) {
+        return;
+    }
+    assert(!_sample.planned || _sample.requested);
+    assert(!_sample.effective || _sample.planned);
+    assert(
+        !_sample.worker_fallback ||
+        (_sample.planned && !_sample.effective)
+    );
+
+    ParallelRecordProfileState& profile = *parallel_record_profile;
+    ++profile.samples;
+    profile.requested += _sample.requested ? 1u : 0u;
+    profile.planned += _sample.planned ? 1u : 0u;
+    profile.effective += _sample.effective ? 1u : 0u;
+    profile.worker_fallbacks += _sample.worker_fallback ? 1u : 0u;
+    profile.record_samples_ms.push_back(_sample.record_wall_ms);
+    profile.execute_cpu_samples_ms.push_back(_sample.execute_cpu_wall_ms);
+    profile.reorder_total_ms += _sample.reorder_ms;
+    profile.preprocess_total_ms += _sample.preprocess_ms;
+    profile.worker_join_total_ms += _sample.worker_join_ms;
+    profile.submit_cpu_total_ms += _sample.submit_cpu_ms;
+    profile.layer_total += _sample.layers;
+    profile.job_total += _sample.jobs;
+    profile.work_unit_total += _sample.work_units;
+    profile.ordered_cb_total += _sample.ordered_cb;
+    profile.max_active = std::max(profile.max_active, _sample.max_active);
+
+    const auto now = std::chrono::steady_clock::now();
+    if (RhiThreadProfileMilliseconds(profile.window_start, now) >= 1000.0) {
+        FlushParallelRecordProfile();
+    }
+}
+
+void VkCommandQueue::FlushParallelRecordProfile() {
+    if (!parallel_record_profile || parallel_record_profile->samples == 0) {
+        return;
+    }
+
+    ParallelRecordProfileState& profile = *parallel_record_profile;
+    const auto now = std::chrono::steady_clock::now();
+    const double window_ms = RhiThreadProfileMilliseconds(profile.window_start, now);
+    Array<double> sorted_record = profile.record_samples_ms;
+    Array<double> sorted_execute_cpu = profile.execute_cpu_samples_ms;
+    std::sort(sorted_record.begin(), sorted_record.end());
+    std::sort(sorted_execute_cpu.begin(), sorted_execute_cpu.end());
+    assert(sorted_record.size() == profile.samples);
+    assert(sorted_execute_cpu.size() == profile.samples);
+    auto percentile = [](const Array<double>& _sorted, double _fraction) {
+        const size_t index = static_cast<size_t>(
+            std::ceil(_fraction * static_cast<double>(_sorted.size() - 1))
+        );
+        return _sorted[index];
+    };
+    const double sample_count = static_cast<double>(profile.samples);
+    const bool all_samples_parallel = profile.planned == profile.samples &&
+                                      profile.effective == profile.planned;
+    const std::string_view mode = profile.requested == 0 ? "serial" :
+                                  all_samples_parallel    ? "parallel" :
+                                                            "mixed";
+
+    LOG_INFO(
+        "[ParallelRecordProfile] queue=Graphics mode={} window_ms={:.3f} samples={} "
+        "requested={} planned={} effective={} worker_fallbacks={} record_p50_ms={:.6f} "
+        "record_p95_ms={:.6f} record_p99_ms={:.6f} record_max_ms={:.6f} "
+        "execute_cpu_p50_ms={:.6f} execute_cpu_p95_ms={:.6f} "
+        "execute_cpu_p99_ms={:.6f} execute_cpu_max_ms={:.6f} "
+        "reorder_avg_ms={:.6f} preprocess_avg_ms={:.6f} worker_join_avg_ms={:.6f} "
+        "submit_cpu_avg_ms={:.6f} layers_avg={:.3f} jobs_avg={:.3f} "
+        "work_units_avg={:.3f} ordered_cb_avg={:.3f} max_active={}",
+        mode,
+        window_ms,
+        profile.samples,
+        profile.requested,
+        profile.planned,
+        profile.effective,
+        profile.worker_fallbacks,
+        percentile(sorted_record, 0.50),
+        percentile(sorted_record, 0.95),
+        percentile(sorted_record, 0.99),
+        sorted_record.back(),
+        percentile(sorted_execute_cpu, 0.50),
+        percentile(sorted_execute_cpu, 0.95),
+        percentile(sorted_execute_cpu, 0.99),
+        sorted_execute_cpu.back(),
+        profile.reorder_total_ms / sample_count,
+        profile.preprocess_total_ms / sample_count,
+        profile.worker_join_total_ms / sample_count,
+        profile.submit_cpu_total_ms / sample_count,
+        static_cast<double>(profile.layer_total) / sample_count,
+        static_cast<double>(profile.job_total) / sample_count,
+        static_cast<double>(profile.work_unit_total) / sample_count,
+        static_cast<double>(profile.ordered_cb_total) / sample_count,
+        profile.max_active
+    );
+
+    profile.window_start = now;
+    profile.record_samples_ms.clear();
+    profile.execute_cpu_samples_ms.clear();
+    profile.samples = 0;
+    profile.requested = 0;
+    profile.planned = 0;
+    profile.effective = 0;
+    profile.worker_fallbacks = 0;
+    profile.reorder_total_ms = 0.0;
+    profile.preprocess_total_ms = 0.0;
+    profile.worker_join_total_ms = 0.0;
+    profile.submit_cpu_total_ms = 0.0;
+    profile.layer_total = 0;
+    profile.job_total = 0;
+    profile.work_unit_total = 0;
+    profile.ordered_cb_total = 0;
+    profile.max_active = 0;
 }
 
 void VkCommandQueue::RecordThreadingProfile(
@@ -4593,6 +6304,44 @@ void VkCommandQueue::CompletionThreadMain() {
                     vk_device.RecordSkippedCommandPoolReset();
                     allocator_quarantine.emplace_back(std::move(_allocator));
                 },
+                [this, &batch_gpu_success](VulkanAllocatorBatch& _batch) {
+                    bool recycle_batch = batch_gpu_success && !vk_device.IsFaulted();
+                    if (recycle_batch) {
+                        for (auto& allocator : _batch.submitted) {
+                            allocator->CompleteSuccess();
+                        }
+                        for (auto& allocator : _batch.submitted) {
+                            recycle_batch = allocator->Reset() && recycle_batch;
+                        }
+                    }
+
+                    if (recycle_batch && !vk_device.IsFaulted()) {
+                        for (auto& allocator : _batch.submitted) {
+                            allocators.Push(allocator.release());
+                        }
+                    } else {
+                        for (auto& allocator : _batch.submitted) {
+                            if (allocator) {
+                                vk_device.RecordAllocatorQuarantine();
+                                vk_device.RecordSkippedCommandPoolReset();
+                                allocator_quarantine.emplace_back(std::move(allocator));
+                            }
+                        }
+                    }
+
+                    for (auto& allocator : _batch.abandoned) {
+                        if (!vk_device.IsFaulted() && allocator->ResetAbandoned()) {
+                            allocators.Push(allocator.release());
+                        } else if (allocator) {
+                            vk_device.RecordAllocatorQuarantine();
+                            vk_device.RecordSkippedCommandPoolReset();
+                            allocator_quarantine.emplace_back(std::move(allocator));
+                        }
+                    }
+                },
+                [this](VulkanDescriptorPushLease& _lease) {
+                    vk_device.GetGlobalDescriptorHeap().RecyclePushDescriptors(std::move(_lease));
+                },
                 [this, &batch_gpu_success](UniquePtr<VulkanPresentor>& _presentor) {
                     if (batch_gpu_success && !vk_device.IsFaulted()) {
                         _presentor->CompleteSuccess();
@@ -4607,9 +6356,9 @@ void VkCommandQueue::CompletionThreadMain() {
                 },
                 [&batch_gpu_success](VulkanCallbackBatch& _batch) {
                     if (!_batch.success_only || batch_gpu_success) {
-                        for (auto& func : _batch.callbacks) {
-                            func();
-                        }
+                        InvokeCallbacksNoexcept(
+                            _batch.callbacks, "[VulkanQueue] completion"
+                        );
                     }
                 },
                 [this, &batch_gpu_success, &batch_release_safe](VulkanDeferredReleaseBatch& _batch) {
@@ -4753,17 +6502,33 @@ IOWaitEvt               VkCopyQueue::Execute(IOQueueSubmission&& _submission) {
 
 //TODO:看看barrier
 IOWaitEvt VkCopyQueue::Execute(CmdSubmit&& _evt) {
-    Array<UniquePtr<Command>> cmds = std::move(_evt.cmds);
+    TrackedExecuteResult result = ExecuteTracked(std::move(_evt));
+    return {uint64(timeline.Get()), result.logical_timeline};
+}
 
+VulkanRuntimeSubmissionResult VkCopyQueue::ExecuteForRuntime(CmdSubmit&& _evt) {
+    return ExecuteTracked(std::move(_evt)).runtime;
+}
+
+VkCopyQueue::TrackedExecuteResult VkCopyQueue::ExecuteTracked(CmdSubmit&& _evt) {
     auto current_timeline = last_frame;
     if (device.IsFaulted()) {
-        device.RecordRejectedSubmit();
-        FailSubmissionSignals(nullptr, _evt.signal_events, device.GetFirstFaultResult());
-        for (auto& callback : _evt.callbacks) {
-            callback();
-        }
-        return {uint64(timeline.Get()), current_timeline};
+        TerminalizeRejectedSubmit(
+            device,
+            std::move(_evt),
+            device.GetFirstFaultResult(),
+            "[VulkanCopyQueue] rejected submit"
+        );
+        return {
+            .runtime = {
+                .outcome = {
+                    EVulkanOperationStatus::Rejected, device.GetFirstFaultResult()
+                }
+            },
+            .logical_timeline = current_timeline,
+        };
     }
+    Array<UniquePtr<Command>> cmds = std::move(_evt.cmds);
     const bool has_queue_work =
         !cmds.empty() || !_evt.wait_events.empty() || !_evt.signal_events.empty() ||
         !_evt.callbacks.empty() || !_evt.success_callbacks.empty();
@@ -4793,7 +6558,7 @@ IOWaitEvt VkCopyQueue::Execute(CmdSubmit&& _evt) {
             reorderer.AcceptCmd(cmd.get());
         }
 
-        vk_cmd_list.Begin();
+        VK_CHECK_RESULT(vk_cmd_list.Begin());
         vk_cmd_list.BeginLabel("Copy", {0.0f, 1.0f, 1.0f, 1.0f});
         const auto& cmd_lists = reorderer.m_cmd_lists;
 
@@ -4821,7 +6586,7 @@ IOWaitEvt VkCopyQueue::Execute(CmdSubmit&& _evt) {
         vk_tracker.RestoreState();
         vk_tracker.DispatchBarriers(vk_cmd_list);
         vk_cmd_list.EndLabel();
-        vk_cmd_list.End();
+        VK_CHECK_RESULT(vk_cmd_list.End());
         vk_tracker.Reset();
         //event queue
 
@@ -4887,9 +6652,28 @@ IOWaitEvt VkCopyQueue::Execute(CmdSubmit&& _evt) {
             event_queue.emplace_back(VulkanCompletionMarker{}, current_timeline, true);
             queue_cv.notify_one();
         }
-        return {uint64(timeline.Get()), current_timeline};
+        VulkanRuntimeSubmissionResult runtime_result{.outcome = submit_outcome};
+        if (submit_outcome.WasSubmitted()) {
+            runtime_result.completion = WaitEvent{uint64(timeline.Get()), current_timeline};
+        }
+        return {
+            .runtime          = std::move(runtime_result),
+            .logical_timeline = current_timeline,
+        };
     }
-    return {uint64(timeline.Get()), current_timeline};
+    return {
+        .runtime          = {},
+        .logical_timeline = current_timeline,
+    };
+}
+
+void VkCopyQueue::RejectForRuntime(CmdSubmit&& _submit, VkResult _result) {
+    TerminalizeRejectedSubmit(
+        device,
+        std::move(_submit),
+        _result,
+        "[RHIExecutor][Vulkan] rejected Copy submit"
+    );
 }
 
 void VkCopyQueue::Sync(uint64 _timeline) {
@@ -4952,9 +6736,9 @@ void VkCopyQueue::ExecuteThread() {
                 },
                 [this, &batch_gpu_success](VulkanCallbackBatch& _batch) {
                     if (!_batch.success_only || batch_gpu_success) {
-                        for (auto& callback : _batch.callbacks) {
-                            callback();
-                        }
+                        InvokeCallbacksNoexcept(
+                            _batch.callbacks, "[VulkanCopyQueue] completion"
+                        );
                     }
                 },
                 [](VulkanCompletionMarker&) {},
@@ -5102,7 +6886,7 @@ void VkCopyQueue::RHIThreadLoop() {
         auto& vk_allocator = *allocator;
         auto& vk_cmd_list  = vk_allocator.GetCmdList();
         auto& vk_tracker   = vk_allocator.GetTracker();
-        vk_cmd_list.Begin();
+        VK_CHECK_RESULT(vk_cmd_list.Begin());
         vk_cmd_list.BeginLabel("IO Copy", {0.0f, 1.0f, 1.0f, 1.0f});
 
         VkCmdPreprocessor preprocessor(device, vk_tracker, vk_allocator, {}, {}, EQueueType::Copy);
@@ -5120,7 +6904,7 @@ void VkCopyQueue::RHIThreadLoop() {
         vk_tracker.RestoreState();
         vk_tracker.DispatchBarriers(vk_cmd_list);
         vk_cmd_list.EndLabel();
-        vk_cmd_list.End();
+        VK_CHECK_RESULT(vk_cmd_list.End());
         vk_tracker.Reset();
         //event queue
         auto current_timeline = ++last_frame;

--- a/source/runtime/render/rhi/vulkan/VulkanQueue.h
+++ b/source/runtime/render/rhi/vulkan/VulkanQueue.h
@@ -2,12 +2,15 @@
 #include "PixelFormat.h"
 #include "VulkanAllocator.h"
 #include "VulkanCommand.h"
+#include "VulkanDescriptor.h"
 #include "VulkanFault.h"
 // #include "VulkanDevice.h"
 #include "misc/LockFree.h"
 #include "misc/STL.h"
 #include "rhi/RHICommand.h"
 #include "rhi/RHIIO.h"
+#include "rhi/ExternalCpuJoinPool.h"
+#include "rhi/RHIParallelRecord.h"
 #include "rhi/RHIRecordDiagnostics.h"
 #include "vulkan/vulkan_core.h"
 #include <atomic>
@@ -15,10 +18,14 @@
 #include <condition_variable>
 #include <functional>
 #include <mutex>
+#include <optional>
 #include <string_view>
 #include <thread>
 #include <variant>
 namespace Moer::Render {
+class CmdReorderer;
+struct FunctionTable;
+
 static constexpr uint s_queue_max_frame_in_flight = 3;
 static constexpr uint s_query_max_storage         = 8 * 64;
 class VkNativeQueue {
@@ -30,6 +37,11 @@ public:
         VulkanCmdList&               _cmdlist,
         const VulkanOperationContext& _context,
         VkFence                       _fence = VK_NULL_HANDLE
+    );
+    VulkanOperationResult Submit(
+        std::span<VulkanCmdList* const> _cmdlists,
+        const VulkanOperationContext&   _context,
+        VkFence                         _fence = VK_NULL_HANDLE
     );
     VulkanOperationResult SubmitEmpty(
         const VulkanOperationContext& _context,
@@ -191,9 +203,31 @@ struct VulkanSubmissionEvent {
     bool                   gpu_submitted{false};
 };
 
+// Result returned to the upper submission runtime.  A queue timeline is only
+// publishable as a dependency when vkQueueSubmit/SubmitEmpty actually accepted
+// the work; retry/recreate/rejected paths deliberately carry no completion.
+struct VulkanRuntimeSubmissionResult {
+    VulkanOperationResult   outcome{};
+    std::optional<WaitEvent> completion{};
+
+    [[nodiscard]] bool WasSubmitted() const {
+        return completion.has_value();
+    }
+
+    [[nodiscard]] bool IsHardFailure() const {
+        return outcome.status == EVulkanOperationStatus::Faulted ||
+               outcome.status == EVulkanOperationStatus::Rejected;
+    }
+};
+
 struct VulkanCallbackBatch {
     Array<std::function<void()>> callbacks;
     bool                         success_only{false};
+};
+
+struct VulkanAllocatorBatch {
+    Array<UniquePtr<VulkanAllocator>> submitted;
+    Array<UniquePtr<VulkanAllocator>> abandoned;
 };
 
 struct VulkanDeferredReleaseBatch {
@@ -207,6 +241,8 @@ public:
     using EventType = std::variant<
         VulkanSubmissionEvent,
         UniquePtr<VulkanAllocator>,
+        VulkanAllocatorBatch,
+        VulkanDescriptorPushLease,
         UniquePtr<VulkanPresentor>,
         VulkanCallbackBatch,
         VulkanDeferredReleaseBatch,
@@ -291,7 +327,13 @@ public:
         VulkanDevice& _device,
         EQueueType    _type,
         bool          _enable_rhi_thread = false,
-        bool          _thread_profile_logging = false
+        bool          _thread_profile_logging = false,
+        bool          _parallel_recording = false,
+        uint32_t      _parallel_record_workers = 0,
+        bool          _parallel_record_verify = false,
+        bool          _parallel_record_profile = false,
+        uint32_t      _parallel_record_min_work_units_per_job = 64,
+        uint64_t      _parallel_record_worker_throw_trigger = 0
     );
     ~VkCommandQueue();
     WaitEvent   Execute(CmdSubmit&& _submit) override;
@@ -319,6 +361,8 @@ public:
 #endif
 
 private:
+    friend class VulkanSubmissionExecutor;
+
     enum class ERhiWorkKind : uint8 { Execute, Present };
 
     struct RhiWorkProfileTotals {
@@ -416,14 +460,122 @@ private:
         UnorderedSet<uint64>   observed_golden_manifests;
     };
 
-    void                       ExecuteNow(CmdSubmit&& _submit, uint64 _timeline, uint64 _serial);
-    void PresentNow(
+    struct ParallelRecordProfileSample {
+        bool   requested{false};
+        bool   planned{false};
+        bool   effective{false};
+        bool   worker_fallback{false};
+        double record_wall_ms{0.0};
+        double execute_cpu_wall_ms{0.0};
+        double reorder_ms{0.0};
+        double preprocess_ms{0.0};
+        double worker_join_ms{0.0};
+        double submit_cpu_ms{0.0};
+        uint32 layers{0};
+        uint32 jobs{0};
+        uint64 work_units{0};
+        uint32 ordered_cb{0};
+        uint32 max_active{0};
+    };
+
+    struct ParallelRecordProfileState {
+        ParallelRecordProfileState() : window_start(std::chrono::steady_clock::now()) {}
+
+        std::chrono::steady_clock::time_point window_start;
+        Array<double> record_samples_ms;
+        Array<double> execute_cpu_samples_ms;
+        uint64 samples{0};
+        uint64 requested{0};
+        uint64 planned{0};
+        uint64 effective{0};
+        uint64 worker_fallbacks{0};
+        double reorder_total_ms{0.0};
+        double preprocess_total_ms{0.0};
+        double worker_join_total_ms{0.0};
+        double submit_cpu_total_ms{0.0};
+        uint64 layer_total{0};
+        uint64 job_total{0};
+        uint64 work_unit_total{0};
+        uint64 ordered_cb_total{0};
+        uint32 max_active{0};
+    };
+
+    // Current-backend ownership packet at the translate/submit boundary. The
+    // command buffers remain valid because their allocator owners travel in
+    // the same move-only packet until the completion queue takes ownership.
+    struct CurrentVulkanRecordedSubmitProfile {
+        bool                                  enabled{false};
+        std::chrono::steady_clock::time_point execute_started{};
+        ParallelRecordProfileSample           sample{};
+    };
+
+    struct CurrentVulkanRecordedSubmit {
+        CurrentVulkanRecordedSubmit(
+            CmdSubmit&&                   _submit,
+            const VulkanOperationContext& _context,
+            uint64                        _timeline
+        ) :
+            submit(std::move(_submit)), context(_context), timeline(_timeline) {}
+
+        CurrentVulkanRecordedSubmit(const CurrentVulkanRecordedSubmit&) = delete;
+        CurrentVulkanRecordedSubmit& operator=(const CurrentVulkanRecordedSubmit&) = delete;
+        CurrentVulkanRecordedSubmit(CurrentVulkanRecordedSubmit&&) noexcept = default;
+        CurrentVulkanRecordedSubmit& operator=(CurrentVulkanRecordedSubmit&&) noexcept = default;
+
+        CmdSubmit                               submit;
+        VulkanOperationContext                  context;
+        uint64                                  timeline{0};
+        bool                                    has_commands{false};
+        Array<VulkanCmdList*>                   ordered_cmd_lists;
+        VulkanAllocatorBatch                    allocators;
+        std::optional<VulkanDescriptorPushLease> descriptor_lease;
+        Array<RHIResource*>                     deferred_releases;
+        CurrentVulkanRecordedSubmitProfile      profile;
+        std::optional<std::unique_lock<std::mutex>> runtime_execution_lock{};
+    };
+
+    struct CurrentVulkanSubmitResult {
+        VulkanOperationResult outcome{};
+        uint32                ordered_cmd_list_count{0};
+    };
+
+    void                       ExecuteNow(
+        CmdSubmit&& _submit,
+        uint64 _timeline,
+        uint64 _serial,
+        std::optional<CurrentVulkanRecordedSubmit>* _out_recorded = nullptr,
+        bool _runtime_owner = false
+    );
+    CurrentVulkanSubmitResult SubmitRecorded(CurrentVulkanRecordedSubmit _recorded);
+    std::optional<CurrentVulkanRecordedSubmit> TranslateForRuntime(CmdSubmit&& _submit);
+    VulkanRuntimeSubmissionResult SubmitRecordedForRuntime(
+        CurrentVulkanRecordedSubmit _recorded
+    );
+    void RejectForRuntime(CmdSubmit&& _submit, VkResult _result);
+    VulkanRuntimeSubmissionResult PresentForRuntime(
+        SwapchainRef _swapchain,
+        TextureView _source,
+        PresentReceiptRef _receipt
+    );
+    bool                       TryExecuteParallel(
+        CmdSubmit&                    _submit,
+        uint64                        _timeline,
+        uint64                        _serial,
+        const VulkanOperationContext& _context,
+        const FunctionTable&           _function_table,
+        const CmdReorderer&            _reorderer,
+        double                         _reorder_time,
+        std::chrono::steady_clock::time_point _profile_started,
+        std::optional<CurrentVulkanRecordedSubmit>* _out_recorded = nullptr
+    );
+    VulkanRuntimeSubmissionResult PresentNow(
         SwapchainRef&& _swapchain,
         TextureRef&&   _source_texture,
         TextureView    _source_view,
         PresentReceiptRef _receipt,
         uint64         _timeline,
-        uint64         _serial
+        uint64         _serial,
+        bool           _runtime_owner = false
     );
     void                       RhiThreadMain();
     void                       CompletionThreadMain();
@@ -441,10 +593,20 @@ private:
         double       _work_ms,
         uint32       _enqueue_depth
     );
+    void                       RecordParallelRecordProfile(
+        const ParallelRecordProfileSample& _sample
+    );
+    void                       FlushParallelRecordProfile();
+    void                       BeginSplitProfilingCpuFrame();
+    void                       AccumulateSplitProfilingCpuFrame(
+        double _reorder_ms,
+        double _preprocess_ms
+    );
+    void                       EndSplitProfilingCpuFrame();
+    void                       ResetSplitProfilingCpuFrame();
 
 private:
     std::atomic<uint64>                                last_frame{0};
-    uint64                                             descriptor_submission{0};
     CircularQueue<uint64, s_queue_max_frame_in_flight> executed_queue;
     std::atomic<uint64>                                cpu_settled_frame = 0;
     CircularQueue<uint64, s_queue_max_frame_in_flight> presented_queue;
@@ -458,7 +620,24 @@ private:
     ProfileData                                        cached_profiler_entry;
     std::mutex                                         profiler_mutex;
 
+    struct SplitProfilingCpuFrame {
+        bool                                  active{false};
+        std::chrono::steady_clock::time_point started{};
+        double                                reorder_ms{0.0};
+        double                                preprocess_ms{0.0};
+    } split_profiling_cpu_frame;
+
     bool                    rhi_thread_enabled{false};
+    bool                    parallel_record_requested{false};
+    bool                    parallel_record_verify{false};
+    bool                    parallel_record_profile_enabled{false};
+    uint32                  parallel_record_workers{0};
+    uint32                  parallel_record_min_work_units_per_job{64};
+    UniquePtr<ExternalCpuJoinPool> parallel_record_pool;
+    uint64                  parallel_record_batch_serial{0};
+    uint64                  parallel_record_worker_throw_trigger{0};
+    std::atomic<uint64>     parallel_record_worker_attempts{0};
+    UniquePtr<ParallelRecordProfileState> parallel_record_profile;
     UniquePtr<RhiThreadProfileState> thread_profile;
     bool                    rhi_worker_running{false};
     std::atomic<uint32_t>   rhi_thread_id{0};
@@ -478,6 +657,7 @@ private:
 class VkCopyQueue : public CopyQueue {
 public:
     friend VulkanDevice;
+    friend class VulkanSubmissionExecutor;
     VkCopyQueue(VulkanDevice& _device);
     ~VkCopyQueue();
     using EventType = std::variant<
@@ -507,6 +687,7 @@ public:
 
     IOWaitEvt Execute(IOQueueSubmission&& _submit) override;
     IOWaitEvt Execute(CmdSubmit&& _submit) override;
+    VulkanRuntimeSubmissionResult ExecuteForRuntime(CmdSubmit&& _submit);
     FenceRef  GetFenceHandle() override;
     void      Sync(uint64 _timeline) override;
 
@@ -556,6 +737,14 @@ private:
     void RHIThreadLoop();
 
 private:
+    void RejectForRuntime(CmdSubmit&& _submit, VkResult _result);
+
+    struct TrackedExecuteResult {
+        VulkanRuntimeSubmissionResult runtime{};
+        uint64                        logical_timeline{0};
+    };
+
+    TrackedExecuteResult ExecuteTracked(CmdSubmit&& _submit);
     UniquePtr<VulkanAllocator>                GetAllocator();
     void                                      Complete(uint64 _timeline);
     LockFreeQueueBase<VulkanAllocator, false> allocators;

--- a/source/runtime/render/rhi/vulkan/VulkanRHIResource.cpp
+++ b/source/runtime/render/rhi/vulkan/VulkanRHIResource.cpp
@@ -19,12 +19,16 @@
 #include "misc/MMemory.h"
 #include "misc/STL.h"
 #include "rhi/RHI.h"
+#include "rhi/RHIBindlessUpdateLifecycle.h"
 #include "rhi/RHICommand.h"
+#include "rhi/RHIExecutor.h"
 #include "rhi/RHICommon.h"
 #include "rhi/RHIResource.h"
 #include "rhi/RHIResourceInitilizer.h"
 #include "vulkan/vk_enum_string_helper.h"
 #include "vulkan/vulkan_core.h"
+
+#include <limits>
 
 #if WITH_CUDA
 #include "platform/windows/WindowsSecurityAttributes.h"
@@ -33,6 +37,7 @@
 
 #include <memory>
 #include <mutex>
+#include <stdexcept>
 #include <chrono>
 #include <thread>
 
@@ -47,6 +52,13 @@ static constexpr std::string_view s_tlas_instance_buffer_name   = "VkRaytracing:
 static constexpr std::string_view s_bdls_array_name             = "VkBindless::BindlessArrayBuffer";
 static constexpr std::string_view s_bdls_array_buffer_name      = "VkBindless::BindlessBuffuerBuffer";
 static constexpr std::string_view s_bdls_array_image_name       = "VkBindless::BindlessImageBuffer";
+
+static uint64 GetBindlessTextureDescriptorOffset(const VulkanDevice& _device) {
+    const auto& properties = _device.GetOptionalProperties().descriptor_buffer_properties;
+    const uint64 sampler_bytes =
+        static_cast<uint64>(properties.samplerDescriptorSize) * VulkanDevice::bindless_sampler_cnt;
+    return Moer::AlignUp(sampler_bytes, properties.descriptorBufferOffsetAlignment);
+}
 
 VmaAllocationCreateFlags VulkanMemoryManager::MEGenerateVmaMemoryFlags(EBufferUsageFlags _flags) {
     if ((_flags & EBufferUsageFlags::CPU_VISIBLE) == EBufferUsageFlags::CPU_VISIBLE)
@@ -1503,21 +1515,25 @@ VkAccessFlags2 VulkanEnumTranslator::METoVkAccessFlags2(ERHIAccessFlags _flags) 
                         VK_STRUCTURE_TYPE_DESCRIPTOR_BUFFER_BINDING_INFO_EXT,
                         VK_NULL_HANDLE,
                         0ull,
-                        VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT | VK_BUFFER_USAGE_SAMPLER_DESCRIPTOR_BUFFER_BIT_EXT
+                        VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT |
+                            VK_BUFFER_USAGE_SAMPLER_DESCRIPTOR_BUFFER_BIT_EXT |
+                            VK_BUFFER_USAGE_RESOURCE_DESCRIPTOR_BUFFER_BIT_EXT
                     };
                     desc_buffer_offsets.emplace_back(
                         set,
                         GetPipelineBindPoint(),
                         m_pipeline_layout,
                         sampler_descriptor_buffer_idx,
-                        m_device->GetOptionalProperties().descriptor_buffer_properties.samplerDescriptorSize * 256);
+                        GetBindlessTextureDescriptorOffset(*m_device));
 
                 }else if constexpr(std::is_same_v<T, VulkanBindlessSetSampler>){
                     descriptor_buffers[sampler_descriptor_buffer_idx] = {
                         VK_STRUCTURE_TYPE_DESCRIPTOR_BUFFER_BINDING_INFO_EXT,
                         VK_NULL_HANDLE,
                         0ull,
-                        VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT | VK_BUFFER_USAGE_SAMPLER_DESCRIPTOR_BUFFER_BIT_EXT
+                        VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT |
+                            VK_BUFFER_USAGE_SAMPLER_DESCRIPTOR_BUFFER_BIT_EXT |
+                            VK_BUFFER_USAGE_RESOURCE_DESCRIPTOR_BUFFER_BIT_EXT
                     };
 
                     desc_buffer_offsets.emplace_back(
@@ -1678,6 +1694,7 @@ VkAccessFlags2 VulkanEnumTranslator::METoVkAccessFlags2(ERHIAccessFlags _flags) 
     }
 
     VkImageView VulkanTexture::GetView(uint _mip_level, uint _mip_cnt, uint _base_layer, uint _layer_cnt) {
+        std::lock_guard<std::mutex> lock(m_views_mutex);
         uint64 key = EncodeViewKey(_mip_level, _mip_cnt, _base_layer, _layer_cnt);
         auto it  = m_views.find(key);
         if (it != m_views.end()) { return it->second; }
@@ -1773,7 +1790,7 @@ VkAccessFlags2 VulkanEnumTranslator::METoVkAccessFlags2(ERHIAccessFlags _flags) 
         SetName(_name);      
     }
 
-    UnorderedMap<uint64, uint>& VulkanBuffer::GetDescriptorIndices(VkDescriptorType _type) { 
+    VulkanBufferDescriptorIndices& VulkanBuffer::GetDescriptorIndices(VkDescriptorType _type) {
         switch (_type) {
             case VK_DESCRIPTOR_TYPE_STORAGE_BUFFER: return m_descriptor_indices[0];
             case VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER: return m_descriptor_indices[1];
@@ -1794,9 +1811,76 @@ VkAccessFlags2 VulkanEnumTranslator::METoVkAccessFlags2(ERHIAccessFlags _flags) 
     texture_slot_offset(1),
     buffer_slot_offset(1),
     slot_offset(1),
+    array_slot_generations(_max_size, 0),
+    texture_slot_generations(_max_size, 0),
+    buffer_slot_generations(_max_size, 0),
+    array_slot_claim_tokens(_max_size, 0),
+    texture_slot_claim_tokens(_max_size, 0),
+    buffer_slot_claim_tokens(_max_size, 0),
     handles(_max_size),
     texture_view_infos(_max_size),
-    texture_offset_in_buffer(_device->GetOptionalProperties().descriptor_buffer_properties.samplerDescriptorSize * 256) {
+    texture_offset_in_buffer(GetBindlessTextureDescriptorOffset(*_device)) {
+        const uint storage_buffer_descriptor_size =
+            g_heap.GetDescriptorSize(VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
+        const uint sampled_image_descriptor_size =
+            g_heap.GetDescriptorSize(VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE);
+
+        const VkDescriptorBindingFlags flags[2] = {
+            0,
+            VK_DESCRIPTOR_BINDING_VARIABLE_DESCRIPTOR_COUNT_BIT |
+                VK_DESCRIPTOR_BINDING_PARTIALLY_BOUND_BIT |
+                VK_DESCRIPTOR_BINDING_UPDATE_UNUSED_WHILE_PENDING_BIT
+        };
+        VkDescriptorSetLayoutBindingFlagsCreateInfoEXT binding_flags{};
+        binding_flags.sType         =
+            VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_BINDING_FLAGS_CREATE_INFO_EXT;
+        binding_flags.bindingCount  = 2;
+        binding_flags.pBindingFlags = flags;
+
+        std::array<VkDescriptorSetLayoutBinding, 2> buffer_bindings{};
+        VkDescriptorSetLayoutBinding& array_binding = buffer_bindings[0];
+        array_binding.descriptorType  = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
+        array_binding.binding         = 0;
+        array_binding.descriptorCount = 1;
+        array_binding.stageFlags      = VK_SHADER_STAGE_ALL;
+
+        VkDescriptorSetLayoutBinding& buffer_binding = buffer_bindings[1];
+        buffer_binding.descriptorType  = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
+        buffer_binding.binding         = 1;
+        buffer_binding.descriptorCount = _max_size;
+        buffer_binding.stageFlags      = VK_SHADER_STAGE_ALL;
+
+        VkDescriptorSetLayoutCreateInfo buffer_desc_info{
+            VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO
+        };
+        buffer_desc_info.bindingCount = static_cast<uint32>(buffer_bindings.size());
+        buffer_desc_info.pBindings    = buffer_bindings.data();
+        buffer_desc_info.flags = VK_DESCRIPTOR_SET_LAYOUT_CREATE_DESCRIPTOR_BUFFER_BIT_EXT;
+        buffer_desc_info.pNext = &binding_flags;
+
+        VkDescriptorSetLayout buffer_desc_layout = VK_NULL_HANDLE;
+        VK_CHECK_RESULT(vkCreateDescriptorSetLayout(
+            m_device->GetDevice(), &buffer_desc_info, VK_NULL_HANDLE, &buffer_desc_layout
+        ));
+        VkDeviceSize bindless_buffer_descriptor_bytes = 0;
+        vkGetDescriptorSetLayoutSizeEXT(
+            m_device->GetDevice(), buffer_desc_layout, &bindless_buffer_descriptor_bytes
+        );
+        vkGetDescriptorSetLayoutBindingOffsetEXT(
+            m_device->GetDevice(), buffer_desc_layout, 1, &buffers_offset_in_set
+        );
+        vkDestroyDescriptorSetLayout(m_device->GetDevice(), buffer_desc_layout, VK_NULL_HANDLE);
+
+        const uint64 required_buffer_descriptor_bytes =
+            buffers_offset_in_set +
+            static_cast<uint64>(_max_size) * storage_buffer_descriptor_size;
+        if (bindless_buffer_descriptor_bytes < required_buffer_descriptor_bytes) {
+            throw std::runtime_error("bindless buffer descriptor layout is smaller than its bindings");
+        }
+        const uint64 bindless_texture_descriptor_bytes =
+            texture_offset_in_buffer +
+            static_cast<uint64>(_max_size) * sampled_image_descriptor_size;
+
         BufferInfo buffer_info(
             uint64(_max_size),
             uint(sizeof(uint)),
@@ -1825,28 +1909,31 @@ VkAccessFlags2 VulkanEnumTranslator::METoVkAccessFlags2(ERHIAccessFlags _flags) 
         bindless_array_buffer = MoerNew(VulkanBuffer)(s_bdls_array_name,buffer_info, *m_device, current_handle, alloc, false, true);
         
         buffer_ci.usage = VK_BUFFER_USAGE_RESOURCE_DESCRIPTOR_BUFFER_BIT_EXT | VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT | VK_BUFFER_USAGE_STORAGE_BUFFER_BIT;
-        buffer_ci.size  = _max_size * m_device->GetOptionalProperties().descriptor_buffer_properties.storageBufferDescriptorSize;
+        buffer_ci.size  = bindless_buffer_descriptor_bytes;
         current_handle   = VK_NULL_HANDLE;
         alloc           = VK_NULL_HANDLE;
 
         VK_CHECK_RESULT(vmaCreateBuffer(m_device->GetVmaAllocator(), &buffer_ci, &alloc_ci, &current_handle, &alloc, nullptr));
-        buffer_info.size = _max_size;
-        buffer_info.stride = m_device->GetOptionalProperties().descriptor_buffer_properties.storageBufferDescriptorSize;
+        buffer_info.size   = bindless_buffer_descriptor_bytes;
+        buffer_info.stride = 1;
 
         bindless_buffer_descs = MoerNew(VulkanBuffer)(s_bdls_array_buffer_name, buffer_info, *m_device, current_handle, alloc, false, true);
 
-        buffer_ci.usage = VK_BUFFER_USAGE_SAMPLER_DESCRIPTOR_BUFFER_BIT_EXT | VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT | VK_BUFFER_USAGE_STORAGE_BUFFER_BIT;
-        buffer_ci.size  = _max_size * m_device->GetOptionalProperties().descriptor_buffer_properties.sampledImageDescriptorSize;
+        buffer_ci.usage = VK_BUFFER_USAGE_SAMPLER_DESCRIPTOR_BUFFER_BIT_EXT |
+                          VK_BUFFER_USAGE_RESOURCE_DESCRIPTOR_BUFFER_BIT_EXT |
+                          VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT |
+                          VK_BUFFER_USAGE_TRANSFER_DST_BIT |
+                          VK_BUFFER_USAGE_STORAGE_BUFFER_BIT;
+        buffer_ci.size  = bindless_texture_descriptor_bytes;
         current_handle   = VK_NULL_HANDLE;
         alloc           = VK_NULL_HANDLE;
         VK_CHECK_RESULT(vmaCreateBuffer(m_device->GetVmaAllocator(), &buffer_ci, &alloc_ci, &current_handle, &alloc, nullptr));
 
-        buffer_info.size = _max_size;
-        buffer_info.stride = m_device->GetOptionalProperties().descriptor_buffer_properties.sampledImageDescriptorSize;
+        buffer_info.size   = bindless_texture_descriptor_bytes;
+        buffer_info.stride = 1;
         bindless_texture_descs = MoerNew(VulkanBuffer)(s_bdls_array_image_name, buffer_info, *m_device, current_handle, alloc, false, true);
 
         CommandList cmd_list{};
-        auto& gfx_queue = m_device->GetCommandQueue(EQueueType::Graphics);
         //fill sampler data to descriptor buffer
         {
             uint sampler_stride = m_device->GetOptionalProperties().descriptor_buffer_properties.samplerDescriptorSize;
@@ -1867,45 +1954,11 @@ VkAccessFlags2 VulkanEnumTranslator::METoVkAccessFlags2(ERHIAccessFlags _flags) 
             // vmaUnmapMemory(m_device->GetVmaAllocator(), bindless_texture_descs->GetAllocation());
             // vmaFlushAllocation(m_device->GetVmaAllocator(), bindless_texture_descs->GetAllocation(), 0, VulkanDevice::bindless_sampler_cnt * sampler_stride);
             cmd_list.CopyFrom(std::span<byte>(data_array.data(), data_array.size()), bindless_texture_descs->GetView(0, data_array.size()));
-            gfx_queue.Execute(cmd_list.Submit());
-            gfx_queue.Sync();
+            RHIExecutor::Get().Submit(
+                EQueueType::Graphics, cmd_list.Submit(), ERHIExecSubmitFlags::FlushGPU
+            );
+            RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
         }
-
-
-        const VkDescriptorBindingFlags flags[2] = {0,
-            VK_DESCRIPTOR_BINDING_VARIABLE_DESCRIPTOR_COUNT_BIT |
-            VK_DESCRIPTOR_BINDING_PARTIALLY_BOUND_BIT |
-            VK_DESCRIPTOR_BINDING_UPDATE_UNUSED_WHILE_PENDING_BIT };
-
-        VkDescriptorSetLayoutBindingFlagsCreateInfoEXT binding_flags{};
-        binding_flags.sType          = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_BINDING_FLAGS_CREATE_INFO_EXT;
-        binding_flags.bindingCount   = 2;
-        binding_flags.pBindingFlags  = flags;
-
-        std::array<VkDescriptorSetLayoutBinding, 2> buffer_bindings;
-
-        VkDescriptorSetLayoutBinding& array_binding = buffer_bindings[0];
-        array_binding.descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
-        array_binding.binding = 0;
-        array_binding.descriptorCount = 1;
-        array_binding.stageFlags = VK_SHADER_STAGE_ALL;
-
-        VkDescriptorSetLayoutBinding& buffer_binding = buffer_bindings[1];
-        buffer_binding.descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
-        buffer_binding.binding = 1;
-        buffer_binding.descriptorCount = _max_size;
-        buffer_binding.stageFlags = VK_SHADER_STAGE_ALL;
-
-        VkDescriptorSetLayoutCreateInfo buffer_desc_info{VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO};
-        buffer_desc_info.bindingCount = 2;
-        buffer_desc_info.pBindings = buffer_bindings.data();
-        buffer_desc_info.flags = VK_DESCRIPTOR_SET_LAYOUT_CREATE_DESCRIPTOR_BUFFER_BIT_EXT;
-        buffer_desc_info.pNext = &binding_flags;
-
-        VkDescriptorSetLayout buffer_desc_layout = VK_NULL_HANDLE;
-        VK_CHECK_RESULT(vkCreateDescriptorSetLayout(m_device->GetDevice(), &buffer_desc_info, VK_NULL_HANDLE, &buffer_desc_layout));        uint64 buffers_offset;
-        vkGetDescriptorSetLayoutBindingOffsetEXT(m_device->GetDevice(), buffer_desc_layout, 1, &buffers_offset_in_set);
-
         VkDescriptorGetInfoEXT descriptor_info{VK_STRUCTURE_TYPE_DESCRIPTOR_GET_INFO_EXT};
         VkDescriptorAddressInfoEXT address_info{VK_STRUCTURE_TYPE_DESCRIPTOR_ADDRESS_INFO_EXT};
         address_info.address = bindless_array_buffer->DeviceAddress();
@@ -1913,25 +1966,24 @@ VkAccessFlags2 VulkanEnumTranslator::METoVkAccessFlags2(ERHIAccessFlags _flags) 
         descriptor_info.data.pStorageBuffer = &address_info;
         descriptor_info.type = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
         {
-            Array<byte> buffer_data(m_device->GetOptionalProperties().descriptor_buffer_properties.storageBufferDescriptorSize);
+            Array<byte> buffer_data(storage_buffer_descriptor_size);
 
             // byte* mapped_data;
             // vmaMapMemory(m_device->GetVmaAllocator(), bindless_buffer_descs->GetAllocation(), (void**)&mapped_data);
             vkGetDescriptorEXT(
                 m_device->GetDevice(),
                 &descriptor_info,
-                m_device->GetOptionalProperties().descriptor_buffer_properties.storageBufferDescriptorSize,
+                storage_buffer_descriptor_size,
                 buffer_data.data());
             // std::memcpy(mapped_data, buffer_data.data(), buffer_data.size());
             // vmaUnmapMemory(m_device->GetVmaAllocator(), bindless_buffer_descs->GetAllocation());
             // vmaFlushAllocation(m_device->GetVmaAllocator(), bindless_buffer_descs->GetAllocation(), 0, m_device->GetOptionalProperties().descriptor_buffer_properties.storageBufferDescriptorSize);
             cmd_list.CopyFrom(std::span<byte>(buffer_data.data(), buffer_data.size()), bindless_buffer_descs->GetView(0, buffer_data.size()));
-            gfx_queue.Execute(cmd_list.Submit());
-            gfx_queue.Sync();
+            RHIExecutor::Get().Submit(
+                EQueueType::Graphics, cmd_list.Submit(), ERHIExecSubmitFlags::FlushGPU
+            );
+            RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
         }
-
-        vkDestroyDescriptorSetLayout(m_device->GetDevice(), buffer_desc_layout, VK_NULL_HANDLE);
-
     }
 
     static uint SamplerToIndex(const Sampler& _samp) {
@@ -1947,7 +1999,37 @@ VkAccessFlags2 VulkanEnumTranslator::METoVkAccessFlags2(ERHIAccessFlags _flags) 
         return _a_start < b_end && _b_start < a_end;
     }
 
+    void VulkanBindlessArray::TrackResource(RHIResource* _resource) {
+        const uint64 _handle = uint64(_resource);
+        if (_handle == 0) {
+            throw std::runtime_error("cannot track a null bindless resource");
+        }
+        auto [resource, inserted] = resource_allocation_counts.try_emplace(_handle);
+        if (inserted) {
+            resource->second.resource = CountableRef<RHIResource>(_resource);
+        }
+        if (resource->second.count == std::numeric_limits<uint32>::max()) {
+            throw std::runtime_error("bindless resource reference count overflow");
+        }
+        ++resource->second.count;
+    }
+
+    void VulkanBindlessArray::UntrackResource(uint64 _handle) {
+        const auto resource = resource_allocation_counts.find(_handle);
+        if (resource == resource_allocation_counts.end() || resource->second.count == 0) {
+            throw std::runtime_error("cannot untrack an unknown bindless resource");
+        }
+        if (resource->second.count == 1) {
+            resource_allocation_counts.erase(resource);
+        } else {
+            --resource->second.count;
+        }
+    }
+
     void VulkanBindlessArray::TrackTextureView(uint _array_idx, const TextureView& _view) {
+        if (_array_idx >= texture_view_infos.size()) {
+            throw std::runtime_error("bindless texture view slot is outside capacity");
+        }
         UntrackTextureView(_array_idx);
         auto*  vk_texture  = ResourceCast(_view.texture);
         uint64 texture_ptr = uint64(vk_texture);
@@ -1959,23 +2041,37 @@ VkAccessFlags2 VulkanEnumTranslator::METoVkAccessFlags2(ERHIAccessFlags _flags) 
             vk_texture, _view.mip_level, _view.num_mips, _view.array_layer, _view.num_array
         };
         texture_view_infos[_array_idx] = key;
-        texture_view_map[texture_ptr].insert(key);
+        uint32& ref_count = texture_view_ref_counts[texture_ptr][key];
+        if (ref_count == std::numeric_limits<uint32>::max()) {
+            throw std::runtime_error("bindless texture view reference count overflow");
+        }
+        ++ref_count;
     }
 
     void VulkanBindlessArray::UntrackTextureView(uint _array_idx) {
         if (_array_idx >= texture_view_infos.size()) {
             return;
         }
-        const auto& key = texture_view_infos[_array_idx];
+        const auto key = texture_view_infos[_array_idx];
         if (key.texture == nullptr) {
             return;
         }
         uint64 texture_ptr = uint64(key.texture);
-        if (auto it = texture_view_map.find(texture_ptr); it != texture_view_map.end()) {
-            it->second.erase(key);
-            if (it->second.empty()) {
-                texture_view_map.erase(it);
+        const auto texture = texture_view_ref_counts.find(texture_ptr);
+        if (texture == texture_view_ref_counts.end()) {
+            throw std::runtime_error("cannot untrack an unknown bindless texture");
+        }
+        const auto view = texture->second.find(key);
+        if (view == texture->second.end() || view->second == 0) {
+            throw std::runtime_error("cannot untrack an unknown bindless texture view");
+        }
+        if (view->second == 1) {
+            texture->second.erase(view);
+            if (texture->second.empty()) {
+                texture_view_ref_counts.erase(texture);
             }
+        } else {
+            --view->second;
         }
         texture_view_infos[_array_idx] = {};
     }
@@ -1984,32 +2080,41 @@ VkAccessFlags2 VulkanEnumTranslator::METoVkAccessFlags2(ERHIAccessFlags _flags) 
         std::unique_lock<std::mutex> lk(mtx);
 
         {
-            uint64 texture_handle_stride = m_device->GetOptionalProperties().descriptor_buffer_properties.sampledImageDescriptorSize;
-            uint64 buffer_handle_stride  = m_device->GetOptionalProperties().descriptor_buffer_properties.storageBufferDescriptorSize;
+            VulkanDescriptorHeap& heap = m_device->GetGlobalDescriptorHeap();
+            uint64 texture_handle_stride =
+                heap.GetDescriptorSize(VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE);
+            uint64 buffer_handle_stride =
+                heap.GetDescriptorSize(VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
             uint64 array_handle_stride   = sizeof(uint);
 
             //update all cpu data here instead of during execution
 
             //handle update data first
-            VulkanDescriptorHeap& heap = m_device->GetGlobalDescriptorHeap();
-
             uint array_idx = 0;
             uint texture_cnt = 0;
             uint buffer_cnt = 0;
+            uint64 update_command_token = 0;
+            if (!update_cmds.empty()) {
+                if (next_update_command_token == std::numeric_limits<uint64>::max()) {
+                    throw std::runtime_error("bindless update command token exhausted");
+                }
+                update_command_token = ++next_update_command_token;
+            }
 
-            //lock for resource_allocated_set
-            for(const UpdateCmd& cmd : update_cmds){
+            // Snapshot each pending mutation under one command identity.
+            for(UpdateCmd& cmd : update_cmds){
                 std::visit(
-                    [&](auto&& _cmd){
+                    [&](auto& _cmd){
                         using Tcmd = std::decay_t<decltype(_cmd)>;
                         if constexpr (std::is_same_v<Tcmd, TextureUpdateInfo>){
+                            _cmd.command_token = update_command_token;
                             if(_cmd.free){
                                 auto& handle = handles[_cmd.array_idx];
                                 assert(handle.type == VulkanBindlessArray::Texture && handle.Ptr() && "Invalid texture handle");
-                                free_slots.Push(_cmd.array_idx);
-                                free_texture_slots.Push(_cmd.slot);
-                                resource_allocated_set.erase(handle.Ptr());
-                                UntrackTextureView(_cmd.array_idx);
+                                assert(
+                                    uint64(_cmd.texture.Get()) == handle.Ptr() &&
+                                    "Bindless texture release lost resource ownership"
+                                );
 
                                 handle = Handle(0ull, 0, 0, 0);
     
@@ -2020,12 +2125,14 @@ VkAccessFlags2 VulkanEnumTranslator::METoVkAccessFlags2(ERHIAccessFlags _flags) 
 
                         }
                         else if constexpr (std::is_same_v<Tcmd, BufferUpdateInfo>){
+                            _cmd.command_token = update_command_token;
                             if(_cmd.free){
                                 auto& handle = handles[_cmd.array_idx];
                                 assert(handle.type == VulkanBindlessArray::Buffer && handle.Ptr() && "Invalid buffer handle");
-                                free_slots.Push(_cmd.array_idx);
-                                free_buffer_slots.Push(_cmd.slot);
-                                resource_allocated_set.erase(handle.Ptr());
+                                assert(
+                                    uint64(_cmd.buffer.Get()) == handle.Ptr() &&
+                                    "Bindless buffer release lost resource ownership"
+                                );
 
                                 handle = Handle(0ull, 0, 0, 0);
     
@@ -2050,12 +2157,13 @@ VkAccessFlags2 VulkanEnumTranslator::METoVkAccessFlags2(ERHIAccessFlags _flags) 
             texture_cnt = 0;
             buffer_cnt = 0;
 
-            //buffer desc buffer has array_buffer for offset 0 and allocate from slot 1(0 for invalid handle)
-            //array buffer is in same set with other bindless buffer descs, so we need to offset the slot by array_buffer slot(size of storage buffer handle)
+            // Buffer binding 1 is addressed through a view that starts at the
+            // implementation-provided byte offset. Slots therefore remain
+            // relative to that binding and never truncate byte padding into a
+            // descriptor index.
             //in gpu:
             // bindless_array_buffer: [binding 0, offset 0]
             // bindless_buffer_descs: [binding 1, offset $sizeofhandle)]
-            uint buffer_dst_slot_offset = buffers_offset_in_set / buffer_handle_stride;
             for(const UpdateCmd& cmd : update_cmds){
                 std::visit(
                     [&](auto&& _cmd){
@@ -2102,7 +2210,7 @@ VkAccessFlags2 VulkanEnumTranslator::METoVkAccessFlags2(ERHIAccessFlags _flags) 
                                 memcpy(buffer_dat.data() + buffer_cnt * buffer_handle_stride, &heap.buffer_desc_data[src_idx], buffer_handle_stride);
                                 memcpy(array_dat.data() + array_idx * array_handle_stride, &_cmd.slot, sizeof(uint));
                                 array_indices_dat[array_idx] = {array_idx, _cmd.array_idx};
-                                buffer_indices_dat[buffer_cnt] = {buffer_cnt, _cmd.slot + buffer_dst_slot_offset};
+                                buffer_indices_dat[buffer_cnt] = {buffer_cnt, _cmd.slot};
 
                                 ++array_idx;
                                 ++buffer_cnt;
@@ -2129,16 +2237,43 @@ VkAccessFlags2 VulkanEnumTranslator::METoVkAccessFlags2(ERHIAccessFlags _flags) 
     }
 
     uint VulkanBindlessArray::AllocateTexture(const TextureView& _texture, Sampler _sampler) {
-        uint  slot_idx  = 0;
-        uint array_idx = free_slots.Pop();
-        if (array_idx == 0) {
-            slot_idx = slot_offset++;
-        } else { slot_idx = array_idx; }
-        //allocate texture slot
-        uint  texture_slot     = 0;
-        uint texture_slot_ptr = free_texture_slots.Pop();
-        if (texture_slot_ptr == 0) { texture_slot = texture_slot_offset++; } else { texture_slot = texture_slot_ptr; }
         std::unique_lock<std::mutex> lk(mtx);
+        const uint capacity = static_cast<uint>(handles.size());
+        const uint reused_array_slot = free_slots.Pop();
+        const uint reused_texture_slot = free_texture_slots.Pop();
+        auto rollback_reused_slots = [&] {
+            if (reused_array_slot != 0 && reused_array_slot < capacity) {
+                free_slots.Push(reused_array_slot);
+            }
+            if (reused_texture_slot != 0 && reused_texture_slot < capacity) {
+                free_texture_slots.Push(reused_texture_slot);
+            }
+        };
+        if ((reused_array_slot != 0 && reused_array_slot >= capacity) ||
+            (reused_texture_slot != 0 && reused_texture_slot >= capacity)) {
+            rollback_reused_slots();
+            throw std::runtime_error("bindless texture free-list slot is outside capacity");
+        }
+        if ((reused_array_slot == 0 && slot_offset >= capacity) ||
+            (reused_texture_slot == 0 && texture_slot_offset >= capacity)) {
+            rollback_reused_slots();
+            throw std::runtime_error("bindless texture capacity exhausted");
+        }
+
+        const uint slot_idx =
+            reused_array_slot == 0 ? slot_offset++ : reused_array_slot;
+        const uint texture_slot =
+            reused_texture_slot == 0 ? texture_slot_offset++ : reused_texture_slot;
+        if (array_slot_generations[slot_idx] == std::numeric_limits<uint64>::max() ||
+            texture_slot_generations[texture_slot] == std::numeric_limits<uint64>::max()) {
+            free_slots.Push(slot_idx);
+            free_texture_slots.Push(texture_slot);
+            throw std::runtime_error("bindless texture slot generation exhausted");
+        }
+        const uint64 array_generation = ++array_slot_generations[slot_idx];
+        const uint64 texture_generation = ++texture_slot_generations[texture_slot];
+        array_slot_claim_tokens[slot_idx]       = 0;
+        texture_slot_claim_tokens[texture_slot] = 0;
 
         update_cmds.emplace_back(
             TextureUpdateInfo{
@@ -2151,32 +2286,70 @@ VkAccessFlags2 VulkanEnumTranslator::METoVkAccessFlags2(ERHIAccessFlags _flags) 
                 _texture.num_mips,
                 _texture.array_layer,
                 _texture.num_array,
+                array_generation,
+                texture_generation,
+                0,
                 false
             }
         );
         temp_slot_to_cmd[slot_idx] = update_cmds.size() - 1;
         // textures_allocated.emplace_back(_texture.texture, _sampler, _texture.format, slot_idx, texture_slot, _texture.mip_level, _texture.num_mips);
-        resource_allocated_set.insert(uint64(_texture.texture));
+        TrackResource(_texture.texture);
         TrackTextureView(slot_idx, _texture);
         return slot_idx;
     }
 
     uint VulkanBindlessArray::AllocateBuffer(BufferView _buffer) {
-        uint  slot_idx;
-        uint array_idx = free_slots.Pop();
-        if (array_idx == 0) {
-            slot_idx = slot_offset++;
-        } else { slot_idx = array_idx; }
-
-        //allocate buffer index
-        uint  buffer_slot;
-        uint buffer_slot_ptr = free_buffer_slots.Pop();
-        if (buffer_slot_ptr == 0) { buffer_slot = buffer_slot_offset++; } else { buffer_slot = buffer_slot_ptr; }
         std::unique_lock<std::mutex> lk(mtx);
-        update_cmds.emplace_back(BufferUpdateInfo{_buffer.buffer, slot_idx, buffer_slot,_buffer.format, false});
+        const uint capacity = static_cast<uint>(handles.size());
+        const uint reused_array_slot = free_slots.Pop();
+        const uint reused_buffer_slot = free_buffer_slots.Pop();
+        auto rollback_reused_slots = [&] {
+            if (reused_array_slot != 0 && reused_array_slot < capacity) {
+                free_slots.Push(reused_array_slot);
+            }
+            if (reused_buffer_slot != 0 && reused_buffer_slot < capacity) {
+                free_buffer_slots.Push(reused_buffer_slot);
+            }
+        };
+        if ((reused_array_slot != 0 && reused_array_slot >= capacity) ||
+            (reused_buffer_slot != 0 && reused_buffer_slot >= capacity)) {
+            rollback_reused_slots();
+            throw std::runtime_error("bindless buffer free-list slot is outside capacity");
+        }
+        if ((reused_array_slot == 0 && slot_offset >= capacity) ||
+            (reused_buffer_slot == 0 && buffer_slot_offset >= capacity)) {
+            rollback_reused_slots();
+            throw std::runtime_error("bindless buffer capacity exhausted");
+        }
+
+        const uint slot_idx =
+            reused_array_slot == 0 ? slot_offset++ : reused_array_slot;
+        const uint buffer_slot =
+            reused_buffer_slot == 0 ? buffer_slot_offset++ : reused_buffer_slot;
+        if (array_slot_generations[slot_idx] == std::numeric_limits<uint64>::max() ||
+            buffer_slot_generations[buffer_slot] == std::numeric_limits<uint64>::max()) {
+            free_slots.Push(slot_idx);
+            free_buffer_slots.Push(buffer_slot);
+            throw std::runtime_error("bindless buffer slot generation exhausted");
+        }
+        const uint64 array_generation = ++array_slot_generations[slot_idx];
+        const uint64 buffer_generation = ++buffer_slot_generations[buffer_slot];
+        array_slot_claim_tokens[slot_idx]     = 0;
+        buffer_slot_claim_tokens[buffer_slot] = 0;
+        update_cmds.emplace_back(BufferUpdateInfo{
+            _buffer.buffer,
+            slot_idx,
+            buffer_slot,
+            _buffer.format,
+            array_generation,
+            buffer_generation,
+            0,
+            false
+        });
         temp_slot_to_cmd[slot_idx] = update_cmds.size() - 1;
         // buffers_allocated.emplace_back(_buffer.buffer, slot_idx, buffer_slot);
-        resource_allocated_set.insert(uint64(_buffer.buffer));
+        TrackResource(_buffer.buffer);
         return slot_idx;
     }
     static const Sampler s_spl = {ESamplerFilter::SF_LINEAR, SAM_CLAMP_TO_BORDER};
@@ -2195,8 +2368,28 @@ VkAccessFlags2 VulkanEnumTranslator::METoVkAccessFlags2(ERHIAccessFlags _flags) 
                         }else{
                             //TODO: invalidate update command
                             LOG_WARNING("You are releasing a bindless texture that's pending updating, array index: {}", _array_idx);
-                            resource_allocated_set.erase((uint64)_cmd.texture.Get());
+                            if (array_slot_generations[_cmd.array_idx] != _cmd.array_generation ||
+                                texture_slot_generations[_cmd.slot] != _cmd.slot_generation ||
+                                array_slot_claim_tokens[_cmd.array_idx] != 0 ||
+                                texture_slot_claim_tokens[_cmd.slot] != 0) {
+                                throw std::runtime_error(
+                                    "pending bindless texture cancellation lost slot ownership"
+                                );
+                            }
+                            if (array_slot_generations[_cmd.array_idx] ==
+                                    std::numeric_limits<uint64>::max() ||
+                                texture_slot_generations[_cmd.slot] ==
+                                    std::numeric_limits<uint64>::max()) {
+                                throw std::runtime_error(
+                                    "pending bindless texture cancellation generation exhausted"
+                                );
+                            }
+                            ++array_slot_generations[_cmd.array_idx];
+                            ++texture_slot_generations[_cmd.slot];
+                            UntrackResource((uint64)_cmd.texture.Get());
                             UntrackTextureView(_array_idx);
+                            free_slots.Push(_cmd.array_idx);
+                            free_texture_slots.Push(_cmd.slot);
 
                             update_cmds[iter->second] = InvalidUpdateInfo{_array_idx};
                         }
@@ -2206,8 +2399,27 @@ VkAccessFlags2 VulkanEnumTranslator::METoVkAccessFlags2(ERHIAccessFlags _flags) 
                         return;
                     }else{
                         LOG_WARNING("You are releasing a bindless texture that's pending updating, array index: {}", _array_idx);
-                        resource_allocated_set.erase((uint64)_cmd.buffer.Get());
-                        UntrackTextureView(_array_idx);
+                        if (array_slot_generations[_cmd.array_idx] != _cmd.array_generation ||
+                            buffer_slot_generations[_cmd.slot] != _cmd.slot_generation ||
+                            array_slot_claim_tokens[_cmd.array_idx] != 0 ||
+                            buffer_slot_claim_tokens[_cmd.slot] != 0) {
+                            throw std::runtime_error(
+                                "pending bindless buffer cancellation lost slot ownership"
+                            );
+                        }
+                        if (array_slot_generations[_cmd.array_idx] ==
+                                std::numeric_limits<uint64>::max() ||
+                            buffer_slot_generations[_cmd.slot] ==
+                                std::numeric_limits<uint64>::max()) {
+                            throw std::runtime_error(
+                                "pending bindless buffer cancellation generation exhausted"
+                            );
+                        }
+                        ++array_slot_generations[_cmd.array_idx];
+                        ++buffer_slot_generations[_cmd.slot];
+                        UntrackResource((uint64)_cmd.buffer.Get());
+                        free_slots.Push(_cmd.array_idx);
+                        free_buffer_slots.Push(_cmd.slot);
                         update_cmds[iter->second] = InvalidUpdateInfo{_array_idx};
                     }
                 } else if constexpr (std::is_same_v<TCmd, InvalidUpdateInfo>){
@@ -2218,16 +2430,49 @@ VkAccessFlags2 VulkanEnumTranslator::METoVkAccessFlags2(ERHIAccessFlags _flags) 
             return;
         }
 
-
+        if (_array_idx >= handles.size()) {
+            LOG_WARNING("You are releasing an out-of-range bindless texture, array index: {}", _array_idx);
+            return;
+        }
         const auto& handle = handles[_array_idx];
+        if (handle.Ptr() == 0) {
+            LOG_WARNING("You are releasing an empty bindless texture slot, array index: {}", _array_idx);
+            return;
+        }
         if(handle.type == Texture){
             update_cmds.emplace_back(
-                TextureUpdateInfo{nullptr, s_spl, PF_UNDEFINED, _array_idx, handle.slot, 0, 0, 0, 0, true}
+                TextureUpdateInfo{
+                    TextureRef(reinterpret_cast<VulkanTexture*>(handle.Ptr())),
+                    s_spl,
+                    PF_UNDEFINED,
+                    _array_idx,
+                    handle.slot,
+                    0,
+                    0,
+                    0,
+                    0,
+                    array_slot_generations[_array_idx],
+                    texture_slot_generations[handle.slot],
+                    0,
+                    true
+                }
             );
-            UntrackTextureView(_array_idx);
         }else if (handle.type == Buffer){
-            update_cmds.emplace_back(BufferUpdateInfo{nullptr, _array_idx, handle.slot, PF_UNDEFINED, true});
+            update_cmds.emplace_back(BufferUpdateInfo{
+                BufferRef(reinterpret_cast<VulkanBuffer*>(handle.Ptr())),
+                _array_idx,
+                handle.slot,
+                PF_UNDEFINED,
+                array_slot_generations[_array_idx],
+                buffer_slot_generations[handle.slot],
+                0,
+                true
+            });
+        } else {
+            LOG_WARNING("You are releasing an empty bindless texture slot, array index: {}", _array_idx);
+            return;
         }
+        temp_slot_to_cmd[_array_idx] = update_cmds.size() - 1;
     }
 
     void VulkanBindlessArray::UnbindBuffer(uint _array_idx) {
@@ -2246,7 +2491,28 @@ VkAccessFlags2 VulkanEnumTranslator::METoVkAccessFlags2(ERHIAccessFlags _flags) 
                         }else{
                             LOG_WARNING("You are releasing a bindless buffer that's pending updating, array index: {}", _array_idx);
 
-                            resource_allocated_set.erase((uint64)_cmd.texture.Get());
+                            if (array_slot_generations[_cmd.array_idx] != _cmd.array_generation ||
+                                texture_slot_generations[_cmd.slot] != _cmd.slot_generation ||
+                                array_slot_claim_tokens[_cmd.array_idx] != 0 ||
+                                texture_slot_claim_tokens[_cmd.slot] != 0) {
+                                throw std::runtime_error(
+                                    "pending bindless texture cancellation lost slot ownership"
+                                );
+                            }
+                            if (array_slot_generations[_cmd.array_idx] ==
+                                    std::numeric_limits<uint64>::max() ||
+                                texture_slot_generations[_cmd.slot] ==
+                                    std::numeric_limits<uint64>::max()) {
+                                throw std::runtime_error(
+                                    "pending bindless texture cancellation generation exhausted"
+                                );
+                            }
+                            ++array_slot_generations[_cmd.array_idx];
+                            ++texture_slot_generations[_cmd.slot];
+                            UntrackResource((uint64)_cmd.texture.Get());
+                            UntrackTextureView(_array_idx);
+                            free_slots.Push(_cmd.array_idx);
+                            free_texture_slots.Push(_cmd.slot);
                             update_cmds[iter->second] = InvalidUpdateInfo{_array_idx};
                         }
                     } else if constexpr (std::is_same_v<TCmd, BufferUpdateInfo>){
@@ -2256,7 +2522,27 @@ VkAccessFlags2 VulkanEnumTranslator::METoVkAccessFlags2(ERHIAccessFlags _flags) 
                         }else{
                             LOG_WARNING("You are releasing a bindless buffer that's pending updating, array index: {}", _array_idx);
 
-                            resource_allocated_set.erase((uint64)_cmd.buffer.Get());
+                            if (array_slot_generations[_cmd.array_idx] != _cmd.array_generation ||
+                                buffer_slot_generations[_cmd.slot] != _cmd.slot_generation ||
+                                array_slot_claim_tokens[_cmd.array_idx] != 0 ||
+                                buffer_slot_claim_tokens[_cmd.slot] != 0) {
+                                throw std::runtime_error(
+                                    "pending bindless buffer cancellation lost slot ownership"
+                                );
+                            }
+                            if (array_slot_generations[_cmd.array_idx] ==
+                                    std::numeric_limits<uint64>::max() ||
+                                buffer_slot_generations[_cmd.slot] ==
+                                    std::numeric_limits<uint64>::max()) {
+                                throw std::runtime_error(
+                                    "pending bindless buffer cancellation generation exhausted"
+                                );
+                            }
+                            ++array_slot_generations[_cmd.array_idx];
+                            ++buffer_slot_generations[_cmd.slot];
+                            UntrackResource((uint64)_cmd.buffer.Get());
+                            free_slots.Push(_cmd.array_idx);
+                            free_buffer_slots.Push(_cmd.slot);
                             update_cmds[iter->second] = InvalidUpdateInfo{_array_idx};
                         }
                     } else if constexpr (std::is_same_v<TCmd, InvalidUpdateInfo>){
@@ -2267,21 +2553,55 @@ VkAccessFlags2 VulkanEnumTranslator::METoVkAccessFlags2(ERHIAccessFlags _flags) 
             return;
         }
 
+        if (_array_idx >= handles.size()) {
+            LOG_WARNING("You are releasing an out-of-range bindless buffer, array index: {}", _array_idx);
+            return;
+        }
         const auto& handle = handles[_array_idx];
+        if (handle.Ptr() == 0) {
+            LOG_WARNING("You are releasing an empty bindless buffer slot, array index: {}", _array_idx);
+            return;
+        }
         if(handle.type == Texture){
             // textures_freed.push_back(handle.slot);
             update_cmds.emplace_back(
-                TextureUpdateInfo{nullptr, s_spl, PF_UNDEFINED, _array_idx, handle.slot, 0, 0, 0, 0, true}
+                TextureUpdateInfo{
+                    TextureRef(reinterpret_cast<VulkanTexture*>(handle.Ptr())),
+                    s_spl,
+                    PF_UNDEFINED,
+                    _array_idx,
+                    handle.slot,
+                    0,
+                    0,
+                    0,
+                    0,
+                    array_slot_generations[_array_idx],
+                    texture_slot_generations[handle.slot],
+                    0,
+                    true
+                }
             );
         }else if (handle.type == Buffer){
             // buffers_freed.push_back(handle.slot);
-            update_cmds.emplace_back(BufferUpdateInfo{nullptr, _array_idx, handle.slot, PF_UNDEFINED, true});
+            update_cmds.emplace_back(BufferUpdateInfo{
+                BufferRef(reinterpret_cast<VulkanBuffer*>(handle.Ptr())),
+                _array_idx,
+                handle.slot,
+                PF_UNDEFINED,
+                array_slot_generations[_array_idx],
+                buffer_slot_generations[handle.slot],
+                0,
+                true
+            });
+        } else {
+            LOG_WARNING("You are releasing an empty bindless buffer slot, array index: {}", _array_idx);
+            return;
         }
-        // resource_allocated_set.erase((uint64)(buffers_allocated[handle.slot].buffer.Get()));
+        temp_slot_to_cmd[_array_idx] = update_cmds.size() - 1;
     }
 
     bool VulkanBindlessArray::IsResourceAllocated(uint64 _resource) const {
-        return resource_allocated_set.find(_resource) != resource_allocated_set.end();
+        return resource_allocation_counts.find(_resource) != resource_allocation_counts.end();
     }
 
     bool VulkanBindlessArray::IsTextureViewAllocated(
@@ -2291,8 +2611,8 @@ VkAccessFlags2 VulkanEnumTranslator::METoVkAccessFlags2(ERHIAccessFlags _flags) 
         uint8  _array_layer,
         uint8  _array_count
     ) const {
-        auto it = texture_view_map.find(_texture);
-        if (it == texture_view_map.end()) {
+        auto it = texture_view_ref_counts.find(_texture);
+        if (it == texture_view_ref_counts.end()) {
             return false;
         }
         auto* vk_texture = reinterpret_cast<VulkanTexture*>(_texture);
@@ -2302,7 +2622,8 @@ VkAccessFlags2 VulkanEnumTranslator::METoVkAccessFlags2(ERHIAccessFlags _flags) 
         uint32 array_layer = _array_layer;
         uint32 array_count =
             _array_count == kRemainingSubresource ? (vk_texture->GetNumArray() - array_layer) : _array_count;
-        for (const auto& view : it->second) {
+        for (const auto& [view, ref_count] : it->second) {
+            (void)ref_count;
             if (RangeOverlap(view.mip_level, view.mip_count, mip_level, mip_count) &&
                 RangeOverlap(view.array_layer, view.array_count, array_layer, array_count)) {
                 return true;
@@ -2312,7 +2633,791 @@ VkAccessFlags2 VulkanEnumTranslator::METoVkAccessFlags2(ERHIAccessFlags _flags) 
     }
 
     void VulkanBindlessArray::DeAllocateResource(uint64 _res){
-        resource_allocated_set.erase(_res);
+        std::unique_lock<std::mutex> lk(mtx);
+        UntrackResource(_res);
+    }
+
+    bool VulkanBindlessArray::BeginUpdateCommand(
+        const Array<BindlessArray::UpdateCmd>& _updates
+    ) {
+        std::unique_lock<std::mutex> lk(mtx);
+
+        uint64 command_token = 0;
+        bool   token_valid   = true;
+        for (const BindlessArray::UpdateCmd& update : _updates) {
+            std::visit(
+                [&](const auto& _cmd) {
+                    using TCmd = std::decay_t<decltype(_cmd)>;
+                    if constexpr (
+                        std::is_same_v<TCmd, TextureUpdateInfo> ||
+                        std::is_same_v<TCmd, BufferUpdateInfo>
+                    ) {
+                        if (_cmd.command_token == 0) {
+                            token_valid = false;
+                        } else if (command_token == 0) {
+                            command_token = _cmd.command_token;
+                        } else if (command_token != _cmd.command_token) {
+                            token_valid = false;
+                        }
+                    }
+                },
+                update
+            );
+        }
+        if (!token_valid) {
+            throw std::runtime_error("bindless update command has an invalid lifecycle token");
+        }
+
+        auto generation_matches = [&](const auto& _cmd) {
+            using TCmd = std::decay_t<decltype(_cmd)>;
+            if constexpr (std::is_same_v<TCmd, TextureUpdateInfo>) {
+                return _cmd.texture && _cmd.array_idx != 0 &&
+                       _cmd.array_idx < array_slot_generations.size() && _cmd.slot != 0 &&
+                       _cmd.slot < texture_slot_generations.size() &&
+                       ClassifyBindlessUpdateSlot(
+                           array_slot_generations[_cmd.array_idx],
+                           texture_slot_generations[_cmd.slot],
+                           array_slot_claim_tokens[_cmd.array_idx],
+                           texture_slot_claim_tokens[_cmd.slot],
+                           _cmd.array_generation,
+                           _cmd.slot_generation,
+                           _cmd.command_token
+                       ) == BindlessUpdateSlotState::Original;
+            } else if constexpr (std::is_same_v<TCmd, BufferUpdateInfo>) {
+                return _cmd.buffer && _cmd.array_idx != 0 &&
+                       _cmd.array_idx < array_slot_generations.size() && _cmd.slot != 0 &&
+                       _cmd.slot < buffer_slot_generations.size() &&
+                       ClassifyBindlessUpdateSlot(
+                           array_slot_generations[_cmd.array_idx],
+                           buffer_slot_generations[_cmd.slot],
+                           array_slot_claim_tokens[_cmd.array_idx],
+                           buffer_slot_claim_tokens[_cmd.slot],
+                           _cmd.array_generation,
+                           _cmd.slot_generation,
+                           _cmd.command_token
+                       ) == BindlessUpdateSlotState::Original;
+            } else {
+                return true;
+            }
+        };
+
+        bool all_current = token_valid;
+        for (const BindlessArray::UpdateCmd& update : _updates) {
+            std::visit([&](const auto& _cmd) { all_current &= generation_matches(_cmd); }, update);
+        }
+
+        UnorderedSet<uint> global_claims;
+        UnorderedSet<uint> texture_claims;
+        UnorderedSet<uint> buffer_claims;
+        for (const BindlessArray::UpdateCmd& update : _updates) {
+            std::visit(
+                [&](const auto& _cmd) {
+                    using TCmd = std::decay_t<decltype(_cmd)>;
+                    if constexpr (std::is_same_v<TCmd, TextureUpdateInfo>) {
+                        if (!generation_matches(_cmd) || (!_cmd.free && all_current)) {
+                            return;
+                        }
+                        if (array_slot_generations[_cmd.array_idx] ==
+                                std::numeric_limits<uint64>::max() ||
+                            texture_slot_generations[_cmd.slot] ==
+                                std::numeric_limits<uint64>::max()) {
+                            throw std::runtime_error("bindless texture update generation exhausted");
+                        }
+                        if (array_slot_claim_tokens[_cmd.array_idx] != 0 ||
+                            texture_slot_claim_tokens[_cmd.slot] != 0) {
+                            throw std::runtime_error("bindless texture slot already has a lifecycle claim");
+                        }
+                        if (!global_claims.emplace(_cmd.array_idx).second ||
+                            !texture_claims.emplace(_cmd.slot).second) {
+                            throw std::runtime_error("duplicate bindless texture update generation claim");
+                        }
+                    } else if constexpr (std::is_same_v<TCmd, BufferUpdateInfo>) {
+                        if (!generation_matches(_cmd) || (!_cmd.free && all_current)) {
+                            return;
+                        }
+                        if (array_slot_generations[_cmd.array_idx] ==
+                                std::numeric_limits<uint64>::max() ||
+                            buffer_slot_generations[_cmd.slot] ==
+                                std::numeric_limits<uint64>::max()) {
+                            throw std::runtime_error("bindless buffer update generation exhausted");
+                        }
+                        if (array_slot_claim_tokens[_cmd.array_idx] != 0 ||
+                            buffer_slot_claim_tokens[_cmd.slot] != 0) {
+                            throw std::runtime_error("bindless buffer slot already has a lifecycle claim");
+                        }
+                        if (!global_claims.emplace(_cmd.array_idx).second ||
+                            !buffer_claims.emplace(_cmd.slot).second) {
+                            throw std::runtime_error("duplicate bindless buffer update generation claim");
+                        }
+                    }
+                },
+                update
+            );
+        }
+        for (const uint slot : global_claims) {
+            ++array_slot_generations[slot];
+            array_slot_claim_tokens[slot] = command_token;
+        }
+        for (const uint slot : texture_claims) {
+            ++texture_slot_generations[slot];
+            texture_slot_claim_tokens[slot] = command_token;
+        }
+        for (const uint slot : buffer_claims) {
+            ++buffer_slot_generations[slot];
+            buffer_slot_claim_tokens[slot] = command_token;
+        }
+        return all_current;
+    }
+
+    void VulkanBindlessArray::FinalizeUpdateCommand(
+        const Array<BindlessArray::UpdateCmd>& _updates,
+        bool                                    _gpu_update_succeeded
+    ) {
+        std::unique_lock<std::mutex> lk(mtx);
+
+        uint64 command_token = 0;
+        for (const BindlessArray::UpdateCmd& update : _updates) {
+            std::visit(
+                [&](const auto& _cmd) {
+                    using TCmd = std::decay_t<decltype(_cmd)>;
+                    if constexpr (
+                        std::is_same_v<TCmd, TextureUpdateInfo> ||
+                        std::is_same_v<TCmd, BufferUpdateInfo>
+                    ) {
+                        if (_cmd.command_token == 0) {
+                            throw std::runtime_error(
+                                "bindless update finalization has no lifecycle token"
+                            );
+                        }
+                        if (command_token == 0) {
+                            command_token = _cmd.command_token;
+                        } else if (command_token != _cmd.command_token) {
+                            throw std::runtime_error(
+                                "bindless update finalization mixes lifecycle tokens"
+                            );
+                        }
+                    }
+                },
+                update
+            );
+        }
+        if (command_token == 0) {
+            return;
+        }
+
+        Array<std::pair<const TextureUpdateInfo*, bool>> texture_restores;
+        Array<std::pair<const BufferUpdateInfo*, bool>>  buffer_restores;
+        Array<const TextureUpdateInfo*>                  texture_retirements;
+        Array<const BufferUpdateInfo*>                   buffer_retirements;
+        UnorderedMap<uint64, uint32>    resource_decrements;
+        UnorderedMap<
+            TextureSubresourceKeyT<VulkanTexture>,
+            uint32,
+            TextureSubresourceKeyHashT<VulkanTexture>>
+            view_decrements;
+        UnorderedSet<uint> global_slots;
+        UnorderedSet<uint> texture_slots;
+        UnorderedSet<uint> buffer_slots;
+        UnorderedSet<uint> global_claims;
+        UnorderedSet<uint> texture_claims;
+        UnorderedSet<uint> buffer_claims;
+
+        auto reserve_slot_mutation = [&](const auto& _cmd, bool _texture) {
+            if (!global_slots.emplace(_cmd.array_idx).second) {
+                throw std::runtime_error("duplicate pending bindless global-slot mutation");
+            }
+            if (_texture) {
+                if (!texture_slots.emplace(_cmd.slot).second) {
+                    throw std::runtime_error("duplicate pending bindless texture-slot mutation");
+                }
+            } else if (!buffer_slots.emplace(_cmd.slot).second) {
+                throw std::runtime_error("duplicate pending bindless buffer-slot mutation");
+            }
+        };
+
+        auto reserve_claim = [&](const auto& _cmd, bool _texture) {
+            if (array_slot_generations[_cmd.array_idx] ==
+                std::numeric_limits<uint64>::max()) {
+                throw std::runtime_error("bindless global-slot generation exhausted");
+            }
+            if (!global_claims.emplace(_cmd.array_idx).second) {
+                throw std::runtime_error("duplicate pending bindless global-slot claim");
+            }
+            if (_texture) {
+                if (texture_slot_generations[_cmd.slot] ==
+                    std::numeric_limits<uint64>::max()) {
+                    throw std::runtime_error("bindless texture-slot generation exhausted");
+                }
+                if (!texture_claims.emplace(_cmd.slot).second) {
+                    throw std::runtime_error("duplicate pending bindless texture-slot claim");
+                }
+            } else {
+                if (buffer_slot_generations[_cmd.slot] ==
+                    std::numeric_limits<uint64>::max()) {
+                    throw std::runtime_error("bindless buffer-slot generation exhausted");
+                }
+                if (!buffer_claims.emplace(_cmd.slot).second) {
+                    throw std::runtime_error("duplicate pending bindless buffer-slot claim");
+                }
+            }
+        };
+
+        // Validate the whole retirement transaction before changing membership
+        // or exposing any slot to another producer.
+        for (const BindlessArray::UpdateCmd& update : _updates) {
+            std::visit(
+                [&](const auto& _cmd) {
+                    using TCmd = std::decay_t<decltype(_cmd)>;
+                    if constexpr (std::is_same_v<TCmd, TextureUpdateInfo>) {
+                        if (!_cmd.texture || _cmd.array_idx == 0 ||
+                            _cmd.array_idx >= handles.size() || _cmd.slot == 0 ||
+                            _cmd.slot >= texture_slot_generations.size()) {
+                            throw std::runtime_error("invalid pending bindless texture retirement");
+                        }
+                        const BindlessUpdateSlotState state = ClassifyBindlessUpdateSlot(
+                            array_slot_generations[_cmd.array_idx],
+                            texture_slot_generations[_cmd.slot],
+                            array_slot_claim_tokens[_cmd.array_idx],
+                            texture_slot_claim_tokens[_cmd.slot],
+                            _cmd.array_generation,
+                            _cmd.slot_generation,
+                            _cmd.command_token
+                        );
+                        const BindlessUpdateFinalizationAction action =
+                            GetBindlessUpdateFinalizationAction(
+                                state, _cmd.free, _gpu_update_succeeded
+                            );
+                        if (action == BindlessUpdateFinalizationAction::Ignore) {
+                            return;
+                        }
+
+                        const Handle& handle = handles[_cmd.array_idx];
+                        if (action == BindlessUpdateFinalizationAction::Restore) {
+                            if (handle.Ptr() != 0 &&
+                                (handle.Ptr() != uint64(_cmd.texture.Get()) ||
+                                 handle.slot != _cmd.slot ||
+                                 handle.type != VulkanBindlessArray::Texture)) {
+                                throw std::runtime_error(
+                                    "rejected bindless texture release lost slot ownership"
+                                );
+                            }
+                            const auto allocation = resource_allocation_counts.find(
+                                uint64(_cmd.texture.Get())
+                            );
+                            if (allocation == resource_allocation_counts.end() ||
+                                allocation->second.count == 0) {
+                                throw std::runtime_error(
+                                    "rejected bindless texture release lost resource ownership"
+                                );
+                            }
+                            const auto& key = texture_view_infos[_cmd.array_idx];
+                            if (key.texture != ResourceCast(_cmd.texture.Get())) {
+                                throw std::runtime_error(
+                                    "rejected bindless texture release lost its view"
+                                );
+                            }
+                            const auto texture = texture_view_ref_counts.find(uint64(key.texture));
+                            if (texture == texture_view_ref_counts.end()) {
+                                throw std::runtime_error(
+                                    "rejected bindless texture release has no texture entry"
+                                );
+                            }
+                            const auto view = texture->second.find(key);
+                            if (view == texture->second.end() || view->second == 0) {
+                                throw std::runtime_error(
+                                    "rejected bindless texture release has no view ownership"
+                                );
+                            }
+                            reserve_slot_mutation(_cmd, true);
+                            texture_restores.emplace_back(
+                                &_cmd, state == BindlessUpdateSlotState::ClaimedByCommand
+                            );
+                            return;
+                        }
+                        if (_cmd.free) {
+                            if (handle.Ptr() != 0) {
+                                throw std::runtime_error(
+                                    "pending bindless texture release slot is not empty"
+                                );
+                            }
+                        } else if (
+                            handle.Ptr() != 0 &&
+                            (handle.Ptr() != uint64(_cmd.texture.Get()) ||
+                             handle.slot != _cmd.slot ||
+                             handle.type != VulkanBindlessArray::Texture)
+                        ) {
+                            throw std::runtime_error(
+                                "pending bindless texture cancellation lost slot ownership"
+                            );
+                        }
+                        if (state == BindlessUpdateSlotState::Original) {
+                            reserve_claim(_cmd, true);
+                        }
+                        reserve_slot_mutation(_cmd, true);
+                        ++resource_decrements[uint64(_cmd.texture.Get())];
+                        const auto& key = texture_view_infos[_cmd.array_idx];
+                        if (key.texture != ResourceCast(_cmd.texture.Get())) {
+                            throw std::runtime_error("pending bindless texture release lost its view");
+                        }
+                        ++view_decrements[key];
+                        texture_retirements.push_back(&_cmd);
+                    } else if constexpr (std::is_same_v<TCmd, BufferUpdateInfo>) {
+                        if (!_cmd.buffer || _cmd.array_idx == 0 ||
+                            _cmd.array_idx >= handles.size() || _cmd.slot == 0 ||
+                            _cmd.slot >= buffer_slot_generations.size()) {
+                            throw std::runtime_error("invalid pending bindless buffer retirement");
+                        }
+                        const BindlessUpdateSlotState state = ClassifyBindlessUpdateSlot(
+                            array_slot_generations[_cmd.array_idx],
+                            buffer_slot_generations[_cmd.slot],
+                            array_slot_claim_tokens[_cmd.array_idx],
+                            buffer_slot_claim_tokens[_cmd.slot],
+                            _cmd.array_generation,
+                            _cmd.slot_generation,
+                            _cmd.command_token
+                        );
+                        const BindlessUpdateFinalizationAction action =
+                            GetBindlessUpdateFinalizationAction(
+                                state, _cmd.free, _gpu_update_succeeded
+                            );
+                        if (action == BindlessUpdateFinalizationAction::Ignore) {
+                            return;
+                        }
+
+                        const Handle& handle = handles[_cmd.array_idx];
+                        if (action == BindlessUpdateFinalizationAction::Restore) {
+                            if (handle.Ptr() != 0 &&
+                                (handle.Ptr() != uint64(_cmd.buffer.Get()) ||
+                                 handle.slot != _cmd.slot ||
+                                 handle.type != VulkanBindlessArray::Buffer)) {
+                                throw std::runtime_error(
+                                    "rejected bindless buffer release lost slot ownership"
+                                );
+                            }
+                            const auto allocation = resource_allocation_counts.find(
+                                uint64(_cmd.buffer.Get())
+                            );
+                            if (allocation == resource_allocation_counts.end() ||
+                                allocation->second.count == 0) {
+                                throw std::runtime_error(
+                                    "rejected bindless buffer release lost resource ownership"
+                                );
+                            }
+                            reserve_slot_mutation(_cmd, false);
+                            buffer_restores.emplace_back(
+                                &_cmd, state == BindlessUpdateSlotState::ClaimedByCommand
+                            );
+                            return;
+                        }
+                        if (_cmd.free) {
+                            if (handle.Ptr() != 0) {
+                                throw std::runtime_error(
+                                    "pending bindless buffer release slot is not empty"
+                                );
+                            }
+                        } else if (
+                            handle.Ptr() != 0 &&
+                            (handle.Ptr() != uint64(_cmd.buffer.Get()) ||
+                             handle.slot != _cmd.slot ||
+                             handle.type != VulkanBindlessArray::Buffer)
+                        ) {
+                            throw std::runtime_error(
+                                "pending bindless buffer cancellation lost slot ownership"
+                            );
+                        }
+                        if (state == BindlessUpdateSlotState::Original) {
+                            reserve_claim(_cmd, false);
+                        }
+                        reserve_slot_mutation(_cmd, false);
+                        ++resource_decrements[uint64(_cmd.buffer.Get())];
+                        buffer_retirements.push_back(&_cmd);
+                    }
+                },
+                update
+            );
+        }
+
+        for (const auto& [resource, decrement] : resource_decrements) {
+            const auto allocation = resource_allocation_counts.find(resource);
+            if (allocation == resource_allocation_counts.end() ||
+                allocation->second.count < decrement) {
+                throw std::runtime_error("bindless resource retirement exceeds its reference count");
+            }
+        }
+        for (const auto& [key, decrement] : view_decrements) {
+            const auto texture = texture_view_ref_counts.find(uint64(key.texture));
+            if (texture == texture_view_ref_counts.end()) {
+                throw std::runtime_error("pending bindless texture retirement has no texture entry");
+            }
+            const auto view = texture->second.find(key);
+            if (view == texture->second.end() || view->second < decrement) {
+                throw std::runtime_error("bindless texture retirement exceeds its view reference count");
+            }
+        }
+
+        // Claim every still-current cancellation only after the complete
+        // transaction has validated. A later command then observes a stale
+        // generation and cannot restore or upload this retired binding.
+        for (const uint slot : global_claims) {
+            ++array_slot_generations[slot];
+            array_slot_claim_tokens[slot] = command_token;
+        }
+        for (const uint slot : texture_claims) {
+            ++texture_slot_generations[slot];
+            texture_slot_claim_tokens[slot] = command_token;
+        }
+        for (const uint slot : buffer_claims) {
+            ++buffer_slot_generations[slot];
+            buffer_slot_claim_tokens[slot] = command_token;
+        }
+
+        // A rejected free never reached a GPU ordering point. Roll it back to
+        // an active CPU binding instead of recycling the descriptor while
+        // older submissions may still read it. This command is the only owner
+        // allowed to undo its generation claim.
+        for (const auto& [restore, claimed] : texture_restores) {
+            if (claimed && !RollbackBindlessUpdateSlotClaim(
+                               array_slot_generations[restore->array_idx],
+                               texture_slot_generations[restore->slot],
+                               array_slot_claim_tokens[restore->array_idx],
+                               texture_slot_claim_tokens[restore->slot],
+                               restore->array_generation,
+                               restore->slot_generation,
+                               restore->command_token
+                           )) {
+                throw std::runtime_error(
+                    "rejected bindless texture release lost its lifecycle claim"
+                );
+            }
+            handles[restore->array_idx] = Handle(
+                uint64(restore->texture.Get()),
+                restore->slot,
+                1,
+                VulkanBindlessArray::Texture
+            );
+        }
+        for (const auto& [restore, claimed] : buffer_restores) {
+            if (claimed && !RollbackBindlessUpdateSlotClaim(
+                               array_slot_generations[restore->array_idx],
+                               buffer_slot_generations[restore->slot],
+                               array_slot_claim_tokens[restore->array_idx],
+                               buffer_slot_claim_tokens[restore->slot],
+                               restore->array_generation,
+                               restore->slot_generation,
+                               restore->command_token
+                           )) {
+                throw std::runtime_error(
+                    "rejected bindless buffer release lost its lifecycle claim"
+                );
+            }
+            handles[restore->array_idx] = Handle(
+                uint64(restore->buffer.Get()),
+                restore->slot,
+                0,
+                VulkanBindlessArray::Buffer
+            );
+        }
+
+        for (const TextureUpdateInfo* retirement : texture_retirements) {
+            handles[retirement->array_idx] = Handle{};
+            UntrackResource(uint64(retirement->texture.Get()));
+            UntrackTextureView(retirement->array_idx);
+        }
+        for (const BufferUpdateInfo* retirement : buffer_retirements) {
+            handles[retirement->array_idx] = Handle{};
+            UntrackResource(uint64(retirement->buffer.Get()));
+        }
+        for (const TextureUpdateInfo* retirement : texture_retirements) {
+            free_slots.Push(retirement->array_idx);
+            free_texture_slots.Push(retirement->slot);
+        }
+        for (const BufferUpdateInfo* retirement : buffer_retirements) {
+            free_slots.Push(retirement->array_idx);
+            free_buffer_slots.Push(retirement->slot);
+        }
+    }
+
+    void VulkanBindlessArray::DiscardUpdateCommand(
+        const Array<BindlessArray::UpdateCmd>& _updates
+    ) {
+        std::unique_lock<std::mutex> lk(mtx);
+
+        uint64 command_token = 0;
+        for (const BindlessArray::UpdateCmd& update : _updates) {
+            std::visit(
+                [&](const auto& _cmd) {
+                    using TCmd = std::decay_t<decltype(_cmd)>;
+                    if constexpr (
+                        std::is_same_v<TCmd, TextureUpdateInfo> ||
+                        std::is_same_v<TCmd, BufferUpdateInfo>
+                    ) {
+                        if (_cmd.command_token == 0) {
+                            throw std::runtime_error(
+                                "discarded bindless update has no lifecycle token"
+                            );
+                        }
+                        if (command_token == 0) {
+                            command_token = _cmd.command_token;
+                        } else if (command_token != _cmd.command_token) {
+                            throw std::runtime_error(
+                                "discarded bindless update mixes lifecycle tokens"
+                            );
+                        }
+                    }
+                },
+                update
+            );
+        }
+        if (command_token == 0) {
+            return;
+        }
+
+        Array<const TextureUpdateInfo*> texture_restores;
+        Array<const BufferUpdateInfo*>  buffer_restores;
+        Array<const TextureUpdateInfo*> texture_retirements;
+        Array<const BufferUpdateInfo*>  buffer_retirements;
+        UnorderedMap<uint64, uint32>    resource_decrements;
+        UnorderedMap<
+            TextureSubresourceKeyT<VulkanTexture>,
+            uint32,
+            TextureSubresourceKeyHashT<VulkanTexture>>
+            view_decrements;
+        UnorderedSet<uint> global_slots;
+        UnorderedSet<uint> texture_slots;
+        UnorderedSet<uint> buffer_slots;
+        UnorderedSet<uint> global_claims;
+        UnorderedSet<uint> texture_claims;
+        UnorderedSet<uint> buffer_claims;
+
+        auto reserve_slot = [&](const auto& _cmd, bool _texture) {
+            if (!global_slots.emplace(_cmd.array_idx).second) {
+                throw std::runtime_error("duplicate discarded bindless global-slot mutation");
+            }
+            if (_texture) {
+                if (!texture_slots.emplace(_cmd.slot).second) {
+                    throw std::runtime_error("duplicate discarded bindless texture-slot mutation");
+                }
+            } else if (!buffer_slots.emplace(_cmd.slot).second) {
+                throw std::runtime_error("duplicate discarded bindless buffer-slot mutation");
+            }
+        };
+
+        auto reserve_claim = [&](const auto& _cmd, bool _texture) {
+            if (array_slot_generations[_cmd.array_idx] ==
+                std::numeric_limits<uint64>::max()) {
+                throw std::runtime_error("discarded bindless global-slot generation exhausted");
+            }
+            if (!global_claims.emplace(_cmd.array_idx).second) {
+                throw std::runtime_error("duplicate discarded bindless global-slot claim");
+            }
+            if (_texture) {
+                if (texture_slot_generations[_cmd.slot] ==
+                    std::numeric_limits<uint64>::max()) {
+                    throw std::runtime_error("discarded bindless texture-slot generation exhausted");
+                }
+                if (!texture_claims.emplace(_cmd.slot).second) {
+                    throw std::runtime_error("duplicate discarded bindless texture-slot claim");
+                }
+            } else {
+                if (buffer_slot_generations[_cmd.slot] ==
+                    std::numeric_limits<uint64>::max()) {
+                    throw std::runtime_error("discarded bindless buffer-slot generation exhausted");
+                }
+                if (!buffer_claims.emplace(_cmd.slot).second) {
+                    throw std::runtime_error("duplicate discarded bindless buffer-slot claim");
+                }
+            }
+        };
+
+        for (const BindlessArray::UpdateCmd& update : _updates) {
+            std::visit(
+                [&](const auto& _cmd) {
+                    using TCmd = std::decay_t<decltype(_cmd)>;
+                    if constexpr (std::is_same_v<TCmd, TextureUpdateInfo>) {
+                        if (!_cmd.texture || _cmd.array_idx == 0 ||
+                            _cmd.array_idx >= handles.size() || _cmd.slot == 0 ||
+                            _cmd.slot >= texture_slot_generations.size()) {
+                            throw std::runtime_error("invalid discarded bindless texture update");
+                        }
+                        const BindlessUpdateSlotState state = ClassifyBindlessUpdateSlot(
+                            array_slot_generations[_cmd.array_idx],
+                            texture_slot_generations[_cmd.slot],
+                            array_slot_claim_tokens[_cmd.array_idx],
+                            texture_slot_claim_tokens[_cmd.slot],
+                            _cmd.array_generation,
+                            _cmd.slot_generation,
+                            _cmd.command_token
+                        );
+                        if (state == BindlessUpdateSlotState::Stale) {
+                            return;
+                        }
+
+                        Handle& handle = handles[_cmd.array_idx];
+                        if (_cmd.free) {
+                            if (state != BindlessUpdateSlotState::Original) {
+                                return;
+                            }
+                            if (handle.Ptr() != 0 &&
+                                (handle.Ptr() != uint64(_cmd.texture.Get()) ||
+                                 handle.slot != _cmd.slot ||
+                                 handle.type != VulkanBindlessArray::Texture)) {
+                                throw std::runtime_error(
+                                    "discarded bindless texture release lost slot ownership"
+                                );
+                            }
+                            reserve_slot(_cmd, true);
+                            texture_restores.push_back(&_cmd);
+                            return;
+                        }
+
+                        if (handle.Ptr() != 0 &&
+                            (handle.Ptr() != uint64(_cmd.texture.Get()) ||
+                             handle.slot != _cmd.slot ||
+                             handle.type != VulkanBindlessArray::Texture)) {
+                            throw std::runtime_error(
+                                "discarded bindless texture allocation lost slot ownership"
+                            );
+                        }
+                        reserve_slot(_cmd, true);
+                        if (state == BindlessUpdateSlotState::Original) {
+                            reserve_claim(_cmd, true);
+                        }
+                        ++resource_decrements[uint64(_cmd.texture.Get())];
+                        const auto& key = texture_view_infos[_cmd.array_idx];
+                        if (key.texture != ResourceCast(_cmd.texture.Get())) {
+                            throw std::runtime_error(
+                                "discarded bindless texture allocation lost its view"
+                            );
+                        }
+                        ++view_decrements[key];
+                        texture_retirements.push_back(&_cmd);
+                    } else if constexpr (std::is_same_v<TCmd, BufferUpdateInfo>) {
+                        if (!_cmd.buffer || _cmd.array_idx == 0 ||
+                            _cmd.array_idx >= handles.size() || _cmd.slot == 0 ||
+                            _cmd.slot >= buffer_slot_generations.size()) {
+                            throw std::runtime_error("invalid discarded bindless buffer update");
+                        }
+                        const BindlessUpdateSlotState state = ClassifyBindlessUpdateSlot(
+                            array_slot_generations[_cmd.array_idx],
+                            buffer_slot_generations[_cmd.slot],
+                            array_slot_claim_tokens[_cmd.array_idx],
+                            buffer_slot_claim_tokens[_cmd.slot],
+                            _cmd.array_generation,
+                            _cmd.slot_generation,
+                            _cmd.command_token
+                        );
+                        if (state == BindlessUpdateSlotState::Stale) {
+                            return;
+                        }
+
+                        Handle& handle = handles[_cmd.array_idx];
+                        if (_cmd.free) {
+                            if (state != BindlessUpdateSlotState::Original) {
+                                return;
+                            }
+                            if (handle.Ptr() != 0 &&
+                                (handle.Ptr() != uint64(_cmd.buffer.Get()) ||
+                                 handle.slot != _cmd.slot ||
+                                 handle.type != VulkanBindlessArray::Buffer)) {
+                                throw std::runtime_error(
+                                    "discarded bindless buffer release lost slot ownership"
+                                );
+                            }
+                            reserve_slot(_cmd, false);
+                            buffer_restores.push_back(&_cmd);
+                            return;
+                        }
+
+                        if (handle.Ptr() != 0 &&
+                            (handle.Ptr() != uint64(_cmd.buffer.Get()) ||
+                             handle.slot != _cmd.slot ||
+                             handle.type != VulkanBindlessArray::Buffer)) {
+                            throw std::runtime_error(
+                                "discarded bindless buffer allocation lost slot ownership"
+                            );
+                        }
+                        reserve_slot(_cmd, false);
+                        if (state == BindlessUpdateSlotState::Original) {
+                            reserve_claim(_cmd, false);
+                        }
+                        ++resource_decrements[uint64(_cmd.buffer.Get())];
+                        buffer_retirements.push_back(&_cmd);
+                    }
+                },
+                update
+            );
+        }
+
+        for (const auto& [resource, decrement] : resource_decrements) {
+            const auto allocation = resource_allocation_counts.find(resource);
+            if (allocation == resource_allocation_counts.end() ||
+                allocation->second.count < decrement) {
+                throw std::runtime_error(
+                    "discarded bindless update exceeds its resource reference count"
+                );
+            }
+        }
+        for (const auto& [key, decrement] : view_decrements) {
+            const auto texture = texture_view_ref_counts.find(uint64(key.texture));
+            if (texture == texture_view_ref_counts.end()) {
+                throw std::runtime_error(
+                    "discarded bindless texture update has no texture entry"
+                );
+            }
+            const auto view = texture->second.find(key);
+            if (view == texture->second.end() || view->second < decrement) {
+                throw std::runtime_error(
+                    "discarded bindless texture update exceeds its view reference count"
+                );
+            }
+        }
+
+        for (const uint slot : global_claims) {
+            ++array_slot_generations[slot];
+            array_slot_claim_tokens[slot] = command_token;
+        }
+        for (const uint slot : texture_claims) {
+            ++texture_slot_generations[slot];
+            texture_slot_claim_tokens[slot] = command_token;
+        }
+        for (const uint slot : buffer_claims) {
+            ++buffer_slot_generations[slot];
+            buffer_slot_claim_tokens[slot] = command_token;
+        }
+
+        for (const TextureUpdateInfo* restore : texture_restores) {
+            handles[restore->array_idx] = Handle(
+                uint64(restore->texture.Get()),
+                restore->slot,
+                1,
+                VulkanBindlessArray::Texture
+            );
+        }
+        for (const BufferUpdateInfo* restore : buffer_restores) {
+            handles[restore->array_idx] = Handle(
+                uint64(restore->buffer.Get()),
+                restore->slot,
+                0,
+                VulkanBindlessArray::Buffer
+            );
+        }
+        for (const TextureUpdateInfo* retirement : texture_retirements) {
+            handles[retirement->array_idx] = Handle{};
+            UntrackResource(uint64(retirement->texture.Get()));
+            UntrackTextureView(retirement->array_idx);
+        }
+        for (const BufferUpdateInfo* retirement : buffer_retirements) {
+            handles[retirement->array_idx] = Handle{};
+            UntrackResource(uint64(retirement->buffer.Get()));
+        }
+        for (const TextureUpdateInfo* retirement : texture_retirements) {
+            free_slots.Push(retirement->array_idx);
+            free_texture_slots.Push(retirement->slot);
+        }
+        for (const BufferUpdateInfo* retirement : buffer_retirements) {
+            free_slots.Push(retirement->array_idx);
+            free_buffer_slots.Push(retirement->slot);
+        }
     }
     
     struct CopyPair{
@@ -3038,7 +4143,13 @@ VkAccessFlags2 VulkanEnumTranslator::METoVkAccessFlags2(ERHIAccessFlags _flags) 
 
     VulkanTexture::~VulkanTexture() {
         //destroy image views
-        for (auto& [key, view] : m_views) { vkDestroyImageView(m_device->GetDevice(), view, VK_NULL_HANDLE); }
+        {
+            std::lock_guard<std::mutex> lock(m_views_mutex);
+            for (auto& [key, view] : m_views) {
+                vkDestroyImageView(m_device->GetDevice(), view, VK_NULL_HANDLE);
+            }
+            m_views.clear();
+        }
         if (m_alloc.image != VK_NULL_HANDLE && m_alloc.alloc != VK_NULL_HANDLE) { vmaDestroyImage(m_device->GetVmaAllocator(), m_alloc.image, m_alloc.alloc); }
         //free descriptors
         for (auto& [key, desc] : m_descriptor_indices) { m_device->GetGlobalDescriptorHeap().FreeImageDescIdx(desc); }

--- a/source/runtime/render/rhi/vulkan/VulkanRHIResource.h
+++ b/source/runtime/render/rhi/vulkan/VulkanRHIResource.h
@@ -574,6 +574,30 @@ protected:
 
 #pragma region viewable resources definitions
 
+struct VkBufferDescKey {
+    uint64   byte_offset{0};
+    uint64   byte_size{0};
+    VkFormat format{VK_FORMAT_UNDEFINED};
+
+    bool operator==(const VkBufferDescKey& _other) const {
+        return byte_offset == _other.byte_offset && byte_size == _other.byte_size &&
+               format == _other.format;
+    }
+
+    struct Hasher {
+        size_t operator()(const VkBufferDescKey& _key) const {
+            size_t hash = std::hash<uint64>()(_key.byte_offset);
+            hash ^= std::hash<uint64>()(_key.byte_size) + 0x9e3779b9 + (hash << 6) + (hash >> 2);
+            hash ^= std::hash<uint32>()(uint32(_key.format)) + 0x9e3779b9 + (hash << 6) +
+                    (hash >> 2);
+            return hash;
+        }
+    };
+};
+
+using VulkanBufferDescriptorIndices =
+    UnorderedMap<VkBufferDescKey, uint, VkBufferDescKey::Hasher>;
+
 class VulkanBuffer : public Buffer, VulkanDeviceObject {
 public:
     struct BufferAlloc {
@@ -604,15 +628,13 @@ public:
         return m_alloc.buffer;
     }
 
-    // int                   m_descriptor_idx = -1;
-    // UnorderedMap<uint64, uint> m_descriptor_indices;
-    UnorderedMap<uint64, uint> m_descriptor_indices[4];
+    VulkanBufferDescriptorIndices m_descriptor_indices[4];
 
     VkDescriptorType GetDescriptorType() const {
         return m_descriptor_type;
     }
 
-    UnorderedMap<uint64, uint>& GetDescriptorIndices(VkDescriptorType _type);
+    VulkanBufferDescriptorIndices& GetDescriptorIndices(VkDescriptorType _type);
 
 private:
     friend class TempBufferAllocator;
@@ -622,19 +644,30 @@ private:
 };
 
 struct VkTextureDescKey {
-    VkImageLayout layout;
-    uint8         mip_level;
-    uint8         mip_cnt;
+    VkDescriptorType descriptor_type;
+    VkImageLayout    layout;
+    uint8            mip_level;
+    uint8            mip_cnt;
+    uint8            array_layer;
+    uint8            array_count;
 
     bool operator==(const VkTextureDescKey& _other) const {
-        return layout == _other.layout && mip_level == _other.mip_level && mip_cnt == _other.mip_cnt;
+        return descriptor_type == _other.descriptor_type && layout == _other.layout &&
+               mip_level == _other.mip_level && mip_cnt == _other.mip_cnt &&
+               array_layer == _other.array_layer && array_count == _other.array_count;
     }
 
     struct Hasher {
         size_t operator()(const VkTextureDescKey& _key) const {
-            return std::hash<uint32_t>()(uint32_t(_key.layout)) ^
-                   std::hash<uint32_t>()(uint32_t(_key.mip_level)) ^
-                   std::hash<uint32_t>()(uint32_t(_key.mip_cnt));
+            size_t hash = std::hash<uint32>()(uint32(_key.descriptor_type));
+            hash ^= std::hash<uint32>()(uint32(_key.layout)) + 0x9e3779b9 + (hash << 6) +
+                    (hash >> 2);
+            const uint32 subresources = (uint32(_key.mip_level) << 24) |
+                                        (uint32(_key.mip_cnt) << 16) |
+                                        (uint32(_key.array_layer) << 8) |
+                                        uint32(_key.array_count);
+            hash ^= std::hash<uint32>()(subresources) + 0x9e3779b9 + (hash << 6) + (hash >> 2);
+            return hash;
         }
     };
 };
@@ -688,8 +721,27 @@ public:
         }
     }
 
-    int32 GetDescriptorIndex(uint _mip_level, uint _mip_idx, VkImageLayout _layout) {
-        VkTextureDescKey key = {_layout, uint8(_mip_level), uint8(_mip_idx)};
+    int32 GetDescriptorIndex(
+        uint             _mip_level,
+        uint             _mip_count,
+        VkImageLayout    _layout,
+        VkDescriptorType _descriptor_type = VK_DESCRIPTOR_TYPE_MAX_ENUM,
+        uint             _array_layer     = 0,
+        uint             _array_count     = 1
+    ) {
+        if (_descriptor_type == VK_DESCRIPTOR_TYPE_MAX_ENUM) {
+            _descriptor_type = _layout == VK_IMAGE_LAYOUT_GENERAL ?
+                                   VK_DESCRIPTOR_TYPE_STORAGE_IMAGE :
+                                   VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE;
+        }
+        VkTextureDescKey key = {
+            _descriptor_type,
+            _layout,
+            uint8(_mip_level),
+            uint8(_mip_count),
+            uint8(_array_layer),
+            uint8(_array_count)
+        };
         auto             it  = m_descriptor_indices.find(key);
         if (it != m_descriptor_indices.end()) {
             return it->second;
@@ -705,6 +757,7 @@ private:
         VmaAllocation alloc;
     } m_alloc;
     UnorderedMap<uint64, VkImageView> m_views;
+    mutable std::mutex                m_views_mutex;
     VkImageLayout                     m_preferred_layout = VK_IMAGE_LAYOUT_GENERAL;
 };
 
@@ -755,6 +808,11 @@ public:
         uint8  _array_count
     ) const;
     void DeAllocateResource(uint64 _handle);
+    void FinalizeUpdateCommand(
+        const Array<BindlessArray::UpdateCmd>& _updates,
+        bool                                    _gpu_update_succeeded
+    );
+    bool BeginUpdateCommand(const Array<BindlessArray::UpdateCmd>& _updates);
 
     //call on frame end free
     void OnFree(
@@ -773,6 +831,9 @@ public:
     void Unlock() {
         mtx.unlock();
     }
+    std::unique_lock<std::mutex> AcquireLock() {
+        return std::unique_lock<std::mutex>(mtx);
+    }
 
 public:
     VulkanBuffer* bindless_array_buffer;
@@ -784,11 +845,14 @@ public:
 
 private:
     std::mutex mtx;
+    void       TrackResource(RHIResource* _resource);
+    void       UntrackResource(uint64 _handle);
     void       TrackTextureView(uint _array_idx, const TextureView& _view);
     void       UntrackTextureView(uint _array_idx);
 
 protected:
     UniquePtr<Command>          CreateUpdateCommand() override;
+    void DiscardUpdateCommand(const Array<BindlessArray::UpdateCmd>& _updates) override;
     class VulkanDescriptorHeap& g_heap;
 
     LockFreeQueueBase<uint, true> free_texture_slots;
@@ -797,6 +861,13 @@ protected:
     std::atomic_uint              texture_slot_offset;
     std::atomic_uint              buffer_slot_offset;
     std::atomic_uint              slot_offset;
+    Array<uint64>                 array_slot_generations;
+    Array<uint64>                 texture_slot_generations;
+    Array<uint64>                 buffer_slot_generations;
+    Array<uint64>                 array_slot_claim_tokens;
+    Array<uint64>                 texture_slot_claim_tokens;
+    Array<uint64>                 buffer_slot_claim_tokens;
+    uint64                        next_update_command_token{0};
     //frame resources
     // Array<TextureUpdateInfo>     textures_allocated;
     // Array<BufferUpdateInfo>      buffers_allocated;
@@ -809,9 +880,18 @@ protected:
     Array<byte>                  buffer_dat;
     UnorderedMap<uint, uint>     temp_slot_to_cmd;
 
-    UnorderedSet<uint64>                                                   resource_allocated_set;
-    UnorderedMap<uint64, UnorderedSet<TextureSubresourceKeyT<VulkanTexture>, TextureSubresourceKeyHashT<VulkanTexture>>>
-        texture_view_map;
+    struct ResourceAllocationRecord {
+        CountableRef<RHIResource> resource;
+        uint32                    count{0};
+    };
+    UnorderedMap<uint64, ResourceAllocationRecord> resource_allocation_counts;
+    UnorderedMap<
+        uint64,
+        UnorderedMap<
+            TextureSubresourceKeyT<VulkanTexture>,
+            uint32,
+            TextureSubresourceKeyHashT<VulkanTexture>>>
+        texture_view_ref_counts;
     Array<TextureSubresourceKeyT<VulkanTexture>>                           texture_view_infos;
 };
 

--- a/source/runtime/render/rhi/vulkan/VulkanSubmissionExecutor.cpp
+++ b/source/runtime/render/rhi/vulkan/VulkanSubmissionExecutor.cpp
@@ -1,0 +1,681 @@
+#include "VulkanSubmissionExecutor.h"
+
+#include "log/LogSystem.h"
+#include "platform/Platform.h"
+#include "rhi/RHI.h"
+#include "VulkanDevice.h"
+#include "VulkanQueue.h"
+
+#include <algorithm>
+#include <cassert>
+#include <limits>
+#include <string>
+
+namespace Moer::Render {
+namespace {
+
+GraphEventRef MakeCompletedEvent() {
+    GraphEventRef event = GraphEvent::CreateGraphEvent();
+    event->TryUnlockSubsequents(EThread::UNKNOWN_THREAD);
+    return event;
+}
+
+bool SubmitHasSideEffects(const CmdSubmit& _submit) {
+    return !_submit.callbacks.empty() || !_submit.success_callbacks.empty() ||
+           !_submit.wait_events.empty() || !_submit.signal_events.empty() || _submit.b_sync ||
+           _submit.b_tick_profiling || _submit.b_delete_resources;
+}
+
+bool IsNativeQueue(EQueueType _queue) {
+    return _queue == EQueueType::Graphics || _queue == EQueueType::Compute ||
+           _queue == EQueueType::Copy;
+}
+
+bool IsCopyCommand(Command::EType _type) {
+    switch (_type) {
+        case Command::EType::UploadBuffer:
+        case Command::EType::CopyBackBuffer:
+        case Command::EType::BufferToBuffer:
+        case Command::EType::BufferToTexture:
+        case Command::EType::TextureToBuffer:
+        case Command::EType::UploadTexture:
+        case Command::EType::TextureToTexture:
+        case Command::EType::CopyBackTexture:
+        case Command::EType::QueueTransfer:
+            return true;
+        default:
+            return false;
+    }
+}
+
+struct BatchPreflightResult {
+    bool             valid{true};
+    std::string_view reason{"none"};
+    size_t           source_index{std::numeric_limits<size_t>::max()};
+    size_t           command_index{std::numeric_limits<size_t>::max()};
+};
+
+BatchPreflightResult RejectPreflight(
+    std::string_view _reason,
+    size_t           _source_index = std::numeric_limits<size_t>::max(),
+    size_t           _command_index = std::numeric_limits<size_t>::max()
+) {
+    return {
+        .valid         = false,
+        .reason        = _reason,
+        .source_index  = _source_index,
+        .command_index = _command_index,
+    };
+}
+
+BatchPreflightResult ValidateBatch(const RHIBackendSubmissionBatch& _batch) {
+    const RHISubmissionTopologyPlan& topology = _batch.topology;
+    if (!topology.IsValid()) {
+        return RejectPreflight("invalid topology", topology.error_source_index);
+    }
+    if (topology.source_plans.size() != _batch.submits.size()) {
+        return RejectPreflight("source/topology count mismatch");
+    }
+    if (_batch.present &&
+        (!_batch.present->swapchain || _batch.present->source.texture == nullptr)) {
+        return RejectPreflight("invalid Present request");
+    }
+
+    size_t expected_segment_begin = 0;
+    for (size_t source_index = 0; source_index < _batch.submits.size(); ++source_index) {
+        const RHIBackendSubmissionBatchEntry& entry = _batch.submits[source_index];
+        const CmdSubmit& submit = entry.submit;
+        const RHISourceSubmitPlan& source_plan = topology.source_plans[source_index];
+        const bool submit_has_work = !submit.cmds.empty() || SubmitHasSideEffects(submit);
+
+        if (!IsNativeQueue(entry.queue)) {
+            return RejectPreflight("invalid source queue", source_index);
+        }
+        if (source_plan.source_key.op_seq != _batch.sequence ||
+            source_plan.source_key.submit_idx != source_index ||
+            source_plan.root_queue != entry.queue ||
+            source_plan.command_count != submit.cmds.size() ||
+            source_plan.execution_class != submit.translate_execution_class ||
+            source_plan.has_side_effects != submit_has_work) {
+            return RejectPreflight("source plan does not match payload", source_index);
+        }
+        if (source_plan.segment_plan_begin != expected_segment_begin) {
+            return RejectPreflight("non-contiguous source plans", source_index);
+        }
+        if (source_plan.segment_plan_count > 1) {
+            return RejectPreflight("multi-segment source is not supported", source_index);
+        }
+
+        const size_t expected_segment_count = submit_has_work ? 1u : 0u;
+        if (source_plan.segment_plan_count != expected_segment_count) {
+            return RejectPreflight("source retention does not match payload", source_index);
+        }
+
+        if (source_plan.segment_plan_count == 1) {
+            if (expected_segment_begin >= topology.segments.size()) {
+                return RejectPreflight("source segment is out of range", source_index);
+            }
+            const RHISubmissionSegmentPlan& segment_plan =
+                topology.segments[expected_segment_begin];
+            if (segment_plan.key.op_seq != _batch.sequence ||
+                segment_plan.key.submit_idx != expected_segment_begin ||
+                segment_plan.source_key != source_plan.source_key ||
+                segment_plan.source_segment_index != 0 ||
+                segment_plan.segment.queue != source_plan.root_queue ||
+                segment_plan.segment.begin != 0 ||
+                segment_plan.segment.end != submit.cmds.size() ||
+                segment_plan.execution_class != source_plan.execution_class ||
+                !segment_plan.inherit_source_wait_events ||
+                !segment_plan.inherit_source_signal_events_and_callbacks ||
+                !segment_plan.inherit_source_runtime_payload) {
+                return RejectPreflight("single-segment plan does not match source", source_index);
+            }
+
+            if (!submit.segments.empty()) {
+                if (submit.segments.size() != 1 ||
+                    submit.segments.front().queue != source_plan.root_queue ||
+                    submit.segments.front().begin != 0 ||
+                    submit.segments.front().end != submit.cmds.size()) {
+                    return RejectPreflight(
+                        "source segment does not match root queue", source_index
+                    );
+                }
+            }
+        }
+
+        for (size_t command_index = 0; command_index < submit.cmds.size(); ++command_index) {
+            const UniquePtr<Command>& command = submit.cmds[command_index];
+            if (!command) {
+                return RejectPreflight("null command", source_index, command_index);
+            }
+            if (command->Type() >= Command::EType::Count) {
+                return RejectPreflight("invalid command type", source_index, command_index);
+            }
+            if (entry.queue == EQueueType::Copy && !IsCopyCommand(command->Type())) {
+                return RejectPreflight(
+                    "unsupported command on Copy queue", source_index, command_index
+                );
+            }
+        }
+
+        for (const WaitEvent& wait : submit.wait_events) {
+            if (wait.timeline_handle == 0) {
+                return RejectPreflight("null wait fence", source_index);
+            }
+        }
+        for (const SignalEvent& signal : submit.signal_events) {
+            if (signal.timeline_handle == 0) {
+                return RejectPreflight("null signal fence", source_index);
+            }
+        }
+
+        if (entry.queue == EQueueType::Copy) {
+            if (!submit.cached_args.empty()) {
+                return RejectPreflight("Copy submit contains cached arguments", source_index);
+            }
+            if (submit.b_sync || submit.b_tick_profiling || submit.b_delete_resources) {
+                return RejectPreflight("Copy submit contains unsupported control flags", source_index);
+            }
+            if (!submit.debug_label.empty()) {
+                return RejectPreflight("Copy submit debug labels are not supported", source_index);
+            }
+        }
+
+        expected_segment_begin += source_plan.segment_plan_count;
+    }
+
+    if (expected_segment_begin != topology.segments.size()) {
+        return RejectPreflight("unclaimed topology segments");
+    }
+    return {};
+}
+
+const char* TopologyErrorName(ERHISubmissionTopologyError _error) {
+    switch (_error) {
+        case ERHISubmissionTopologyError::None:
+            return "none";
+        case ERHISubmissionTopologyError::InvalidRootQueue:
+            return "invalid-root-queue";
+        case ERHISubmissionTopologyError::InvalidExecutionClass:
+            return "invalid-execution-class";
+        case ERHISubmissionTopologyError::InvalidSegmentQueue:
+            return "invalid-segment-queue";
+        case ERHISubmissionTopologyError::InvalidSegmentRange:
+            return "invalid-segment-range";
+        case ERHISubmissionTopologyError::NonContiguousSegmentCoverage:
+            return "non-contiguous-segment-coverage";
+        case ERHISubmissionTopologyError::IndexOverflow:
+            return "index-overflow";
+    }
+    return "unknown";
+}
+
+void ResolveRejectedPresent(std::optional<RHIPresentRequest>& _present) {
+    if (_present && _present->receipt) {
+        _present->receipt->Resolve(false);
+    }
+}
+
+// The current producer emits one whole-submit segment. Multi-segment expansion
+// needs the resource-state dependency graph to synthesize cross-queue GPU waits;
+// accepting it before that layer exists would silently weaken ordering.
+Array<RHIBackendSubmissionBatchEntry> TakeSingleSegmentEntries(
+    RHIBackendSubmissionBatch&& _batch
+) {
+    Array<RHIBackendSubmissionBatchEntry> expanded{};
+    expanded.reserve(_batch.submits.size());
+
+    for (size_t source_index = 0; source_index < _batch.submits.size(); ++source_index) {
+        RHIBackendSubmissionBatchEntry& source = _batch.submits[source_index];
+        const RHISourceSubmitPlan& source_plan = _batch.topology.source_plans[source_index];
+        if (source_plan.segment_plan_count == 0) {
+            continue;
+        }
+
+        assert(source_plan.segment_plan_count == 1);
+        const RHISubmissionSegmentPlan& segment_plan =
+            _batch.topology.segments[source_plan.segment_plan_begin];
+        source.submit.segments = {RHISubmitSegment{
+            .queue = segment_plan.segment.queue,
+            .begin = 0,
+            .end   = source.submit.cmds.size(),
+        }};
+        expanded.emplace_back(segment_plan.segment.queue, std::move(source.submit));
+    }
+    return expanded;
+}
+
+} // namespace
+
+VulkanSubmissionExecutor::VulkanSubmissionExecutor() :
+    thread([this] { Run(); }) {
+    LOG_INFO("[RHIExecutor][Vulkan] streaming runtime started window=1");
+}
+
+VulkanSubmissionExecutor::~VulkanSubmissionExecutor() {
+    ShutDown();
+}
+
+void VulkanSubmissionExecutor::Completion::Signal() {
+    {
+        std::lock_guard lock(mutex);
+        done = true;
+    }
+    cv.notify_all();
+}
+
+void VulkanSubmissionExecutor::Completion::Wait() {
+    std::unique_lock lock(mutex);
+    cv.wait(lock, [this] { return done; });
+}
+
+void VulkanSubmissionExecutor::Enqueue(RHIBackendSubmissionBatch&& _batch) {
+    bool rejected = false;
+    {
+        std::lock_guard lock(mutex);
+        if (!accepting) {
+            rejected = true;
+        } else {
+            requests.emplace_back(Request{
+                .kind       = ERequestKind::Submit,
+                .batch      = std::move(_batch),
+            });
+        }
+    }
+    if (rejected) {
+        // User completion callbacks must never run while the backend FIFO lock
+        // is held: they may enqueue more RHI work or acquire unrelated locks.
+        RejectBatch(
+            std::move(_batch),
+            static_cast<int32>(VK_ERROR_UNKNOWN),
+            "submission runtime is stopping or stopped"
+        );
+        return;
+    }
+    cv.notify_one();
+}
+
+GraphEventRef VulkanSubmissionExecutor::Sync(ERHISyncDepth _depth) {
+    auto completion = std::make_shared<Completion>();
+    {
+        std::lock_guard lock(mutex);
+        if (!accepting) {
+            return MakeCompletedEvent();
+        }
+        requests.emplace_back(Request{
+            .kind       = ERequestKind::Sync,
+            .sync_depth = _depth,
+            .completion = completion,
+        });
+    }
+    cv.notify_one();
+    completion->Wait();
+    return MakeCompletedEvent();
+}
+
+void VulkanSubmissionExecutor::Flush(ERHIFlushDepth) {
+    // Enqueue publishes directly to the runtime FIFO and wakes its owner.
+    // SubmitGPU intentionally does not wait; Sync is the explicit host boundary.
+    cv.notify_one();
+}
+
+void VulkanSubmissionExecutor::ShutDown() {
+    std::shared_ptr<Completion> completion{};
+    bool                        join_owner = false;
+    {
+        std::lock_guard lock(mutex);
+        if (stopped) {
+            return;
+        }
+        accepting = false;
+        if (!stop_completion) {
+            stop_completion = std::make_shared<Completion>();
+            requests.emplace_back(Request{
+                .kind       = ERequestKind::Stop,
+                .sync_depth = ERHISyncDepth::Present,
+                .completion = stop_completion,
+            });
+            join_owner = true;
+        }
+        completion = stop_completion;
+    }
+    cv.notify_one();
+    completion->Wait();
+    if (join_owner) {
+        if (thread.joinable()) {
+            thread.join();
+        }
+        {
+            std::lock_guard lock(mutex);
+            stopped = true;
+        }
+        cv.notify_all();
+        return;
+    }
+
+    std::unique_lock lock(mutex);
+    cv.wait(lock, [this] { return stopped; });
+}
+
+void VulkanSubmissionExecutor::Run() {
+    Platform::SetCurrentThreadName("Moer Vulkan Submit");
+    while (true) {
+        Request request{};
+        {
+            std::unique_lock lock(mutex);
+            cv.wait(lock, [this] { return !requests.empty(); });
+            request = std::move(requests.front());
+            requests.pop_front();
+        }
+
+        if (request.kind == ERequestKind::Submit) {
+            ProcessBatch(std::move(request.batch));
+            continue;
+        }
+        ProcessSync(request.sync_depth);
+        CompleteRequest(request.completion);
+        if (request.kind == ERequestKind::Stop) {
+            break;
+        }
+    }
+}
+
+void VulkanSubmissionExecutor::RejectBatch(
+    RHIBackendSubmissionBatch&& _batch,
+    int32                       _result,
+    std::string_view            _reason
+) {
+    LOG_ERROR(
+        "[RHIExecutor][Vulkan] reject batch={} sources={} reason={}",
+        _batch.sequence,
+        _batch.submits.size(),
+        _reason
+    );
+
+    ResolveRejectedPresent(_batch.present);
+    const VkResult result = static_cast<VkResult>(_result);
+    for (RHIBackendSubmissionBatchEntry& entry : _batch.submits) {
+        if (entry.queue == EQueueType::Copy) {
+            auto& queue = static_cast<VkCopyQueue&>(RenderDevice::Get().GetCopyQueue());
+            queue.RejectForRuntime(std::move(entry.submit), result);
+            continue;
+        }
+
+        const EQueueType queue_type =
+            IsNativeQueue(entry.queue) && entry.queue != EQueueType::Copy ?
+                entry.queue :
+                EQueueType::Graphics;
+        auto& queue = static_cast<VkCommandQueue&>(
+            RenderDevice::Get().GetCommandQueue(queue_type)
+        );
+        queue.RejectForRuntime(std::move(entry.submit), result);
+    }
+}
+
+void VulkanSubmissionExecutor::ProcessBatch(RHIBackendSubmissionBatch&& _batch) {
+    if (hard_failed) {
+        RejectBatch(
+            std::move(_batch),
+            hard_failure_result,
+            "submission runtime is latched after a hard failure"
+        );
+        return;
+    }
+
+    const BatchPreflightResult preflight = ValidateBatch(_batch);
+    if (!preflight.valid) {
+        LOG_ERROR(
+            "[RHIExecutor][Topology] batch={} preflight rejected reason={} "
+            "topology_error={} source={} command={}",
+            _batch.sequence,
+            preflight.reason,
+            TopologyErrorName(_batch.topology.error),
+            preflight.source_index,
+            preflight.command_index
+        );
+        hard_failed         = true;
+        hard_failure_result = static_cast<int32>(VK_ERROR_UNKNOWN);
+        RejectBatch(
+            std::move(_batch),
+            static_cast<int32>(VK_ERROR_UNKNOWN),
+            preflight.reason
+        );
+        return;
+    }
+
+    if (!logged_multi_source_topology && _batch.submits.size() > 1) {
+        logged_multi_source_topology = true;
+        LOG_INFO(
+            "[RHIExecutor][Vulkan] upper submission topology active: batch={} "
+            "sources={} segments={} present={}",
+            _batch.sequence,
+            _batch.submits.size(),
+            _batch.topology.segments.size(),
+            _batch.present.has_value()
+        );
+    }
+
+    Array<RHIBackendSubmissionBatchEntry> entries = TakeSingleSegmentEntries(std::move(_batch));
+    auto reject_remaining = [&](size_t _begin, VkResult _result, std::string_view _reason) {
+        if (_result == VK_SUCCESS) {
+            _result = VK_ERROR_UNKNOWN;
+        }
+        hard_failed         = true;
+        hard_failure_result = static_cast<int32>(_result);
+        RHIBackendSubmissionBatch rejected{};
+        rejected.sequence = _batch.sequence;
+        rejected.present  = std::move(_batch.present);
+        rejected.submits.reserve(entries.size() - std::min(_begin, entries.size()));
+        for (size_t index = _begin; index < entries.size(); ++index) {
+            rejected.submits.emplace_back(
+                entries[index].queue, std::move(entries[index].submit)
+            );
+        }
+        RejectBatch(
+            std::move(rejected), static_cast<int32>(_result), _reason
+        );
+    };
+
+    for (size_t entry_index = 0; entry_index < entries.size(); ++entry_index) {
+        RHIBackendSubmissionBatchEntry& entry = entries[entry_index];
+        if (ordered_tail_queue.has_value() && *ordered_tail_queue != entry.queue &&
+            ordered_gpu_tail.has_value()) {
+            // Native queue submit order only applies within one queue. Chain
+            // adjacent cross-queue source submissions through their timeline
+            // semaphores so the stable topology order is also a GPU order.
+            entry.submit.wait_events.emplace_back(*ordered_gpu_tail);
+        }
+        if (entry.queue == EQueueType::Copy) {
+            auto& copy_queue = static_cast<VkCopyQueue&>(RenderDevice::Get().GetCopyQueue());
+            const VulkanRuntimeSubmissionResult submit_result =
+                copy_queue.ExecuteForRuntime(std::move(entry.submit));
+            if (submit_result.WasSubmitted()) {
+                assert(submit_result.completion.has_value());
+                last_copy_timeline = std::max(
+                    last_copy_timeline, submit_result.completion->value
+                );
+                ordered_gpu_tail   = *submit_result.completion;
+                ordered_tail_queue = EQueueType::Copy;
+                used_queues[static_cast<size_t>(EQueueType::Copy)] = true;
+            } else if (submit_result.IsHardFailure()) {
+                LOG_ERROR(
+                    "[RHIExecutor][Vulkan] batch={} Copy submission failed status={} result={}",
+                    _batch.sequence,
+                    static_cast<uint32>(submit_result.outcome.status),
+                    static_cast<int32>(submit_result.outcome.result)
+                );
+                // A failed native Copy submit still publishes a CPU retirement
+                // marker. Preserve its logical timeline so a later Sync drains
+                // callbacks and allocator quarantine before device teardown.
+                last_copy_timeline = std::max(
+                    last_copy_timeline, static_cast<uint64>(copy_queue.last_frame)
+                );
+                used_queues[static_cast<size_t>(EQueueType::Copy)] = true;
+                reject_remaining(
+                    entry_index + 1,
+                    submit_result.outcome.result,
+                    "Copy submission hard failure"
+                );
+                return;
+            }
+        } else {
+            auto& queue = static_cast<VkCommandQueue&>(
+                RenderDevice::Get().GetCommandQueue(entry.queue)
+            );
+            std::optional<VkCommandQueue::CurrentVulkanRecordedSubmit> recorded =
+                queue.TranslateForRuntime(std::move(entry.submit));
+            // Translation reserves a logical queue timeline and always
+            // publishes a CPU completion marker, including rejected paths.
+            used_queues[static_cast<size_t>(entry.queue)] = true;
+            if (!recorded) {
+                LOG_ERROR(
+                    "[RHIExecutor][Vulkan] batch={} source_queue={} translation failed",
+                    _batch.sequence,
+                    static_cast<uint32>(entry.queue)
+                );
+                VulkanDevice& vk_device = queue.vk_device;
+                const VkResult result = vk_device.IsFaulted() ?
+                                            vk_device.GetFirstFaultResult() :
+                                            VK_ERROR_UNKNOWN;
+                reject_remaining(
+                    entry_index + 1, result, "command translation failure"
+                );
+                return;
+            }
+            const VulkanRuntimeSubmissionResult submit_result =
+                queue.SubmitRecordedForRuntime(std::move(*recorded));
+            if (submit_result.WasSubmitted()) {
+                assert(submit_result.completion.has_value());
+                ordered_gpu_tail   = *submit_result.completion;
+                ordered_tail_queue = entry.queue;
+                used_queues[static_cast<size_t>(entry.queue)] = true;
+            } else if (submit_result.IsHardFailure()) {
+                LOG_ERROR(
+                    "[RHIExecutor][Vulkan] batch={} source_queue={} submission failed "
+                    "status={} result={}",
+                    _batch.sequence,
+                    static_cast<uint32>(entry.queue),
+                    static_cast<uint32>(submit_result.outcome.status),
+                    static_cast<int32>(submit_result.outcome.result)
+                );
+                reject_remaining(
+                    entry_index + 1,
+                    submit_result.outcome.result,
+                    "command submission hard failure"
+                );
+                return;
+            }
+        }
+    }
+
+    if (_batch.present) {
+        RHIPresentRequest& present = *_batch.present;
+        auto& graphics_queue = static_cast<VkCommandQueue&>(
+            RenderDevice::Get().GetCommandQueue(EQueueType::Graphics)
+        );
+        if (ordered_tail_queue.has_value() &&
+            *ordered_tail_queue != EQueueType::Graphics && ordered_gpu_tail.has_value()) {
+            CommandList bridge_commands(EQueueType::Graphics);
+            CmdSubmit   bridge = bridge_commands.Submit();
+            bridge.wait_events.emplace_back(*ordered_gpu_tail);
+            std::optional<VkCommandQueue::CurrentVulkanRecordedSubmit> recorded =
+                graphics_queue.TranslateForRuntime(std::move(bridge));
+            used_queues[static_cast<size_t>(EQueueType::Graphics)] = true;
+            if (!recorded) {
+                const VkResult result = graphics_queue.vk_device.IsFaulted() ?
+                                            graphics_queue.vk_device.GetFirstFaultResult() :
+                                            VK_ERROR_UNKNOWN;
+                reject_remaining(
+                    entries.size(), result, "Present bridge translation failure"
+                );
+                return;
+            }
+            const VulkanRuntimeSubmissionResult bridge_result =
+                graphics_queue.SubmitRecordedForRuntime(std::move(*recorded));
+            if (!bridge_result.WasSubmitted()) {
+                LOG_ERROR(
+                    "[RHIExecutor][Vulkan] batch={} Present bridge failed status={} result={}",
+                    _batch.sequence,
+                    static_cast<uint32>(bridge_result.outcome.status),
+                    static_cast<int32>(bridge_result.outcome.result)
+                );
+                reject_remaining(
+                    entries.size(),
+                    bridge_result.outcome.result,
+                    "Present bridge submission failure"
+                );
+                return;
+            }
+            assert(bridge_result.completion.has_value());
+            ordered_gpu_tail   = *bridge_result.completion;
+            ordered_tail_queue = EQueueType::Graphics;
+            used_queues[static_cast<size_t>(EQueueType::Graphics)] = true;
+        }
+        const VulkanRuntimeSubmissionResult present_result = graphics_queue.PresentForRuntime(
+            std::move(present.swapchain),
+            present.source,
+            std::move(present.receipt)
+        );
+        // Retry/Recreate still owns a logical timeline and completion marker;
+        // Sync must drain that CPU-side retirement even though no GPU tail was
+        // produced.
+        used_queues[static_cast<size_t>(EQueueType::Graphics)] = true;
+        if (present_result.WasSubmitted()) {
+            assert(present_result.completion.has_value());
+            ordered_gpu_tail   = *present_result.completion;
+            ordered_tail_queue = EQueueType::Graphics;
+            used_queues[static_cast<size_t>(EQueueType::Graphics)] = true;
+        }
+        if (present_result.IsHardFailure()) {
+            LOG_ERROR(
+                "[RHIExecutor][Vulkan] batch={} Present failed status={} result={}",
+                _batch.sequence,
+                static_cast<uint32>(present_result.outcome.status),
+                static_cast<int32>(present_result.outcome.result)
+            );
+            hard_failed = true;
+            hard_failure_result = static_cast<int32>(
+                present_result.outcome.result == VK_SUCCESS ?
+                    VK_ERROR_UNKNOWN :
+                    present_result.outcome.result
+            );
+        }
+        // Retry/Recreate means no copy submit happened.  Keep the previous
+        // ordered tail (including a cross-queue bridge) as the stream tail.
+    }
+}
+
+void VulkanSubmissionExecutor::ProcessSync(ERHISyncDepth _depth) {
+    LOG_INFO(
+        "[RHIExecutor][Vulkan] sync begin depth={} gfx={} compute={} copy_timeline={}",
+        static_cast<uint32>(_depth),
+        used_queues[static_cast<size_t>(EQueueType::Graphics)],
+        used_queues[static_cast<size_t>(EQueueType::Compute)],
+        last_copy_timeline
+    );
+    if (used_queues[static_cast<size_t>(EQueueType::Graphics)] ||
+        _depth == ERHISyncDepth::Present) {
+        RenderDevice::Get().GetCommandQueue(EQueueType::Graphics).Sync();
+    }
+    if (used_queues[static_cast<size_t>(EQueueType::Compute)]) {
+        RenderDevice::Get().GetCommandQueue(EQueueType::Compute).Sync();
+    }
+    if (last_copy_timeline != 0) {
+        RenderDevice::Get().GetCopyQueue().Sync(last_copy_timeline);
+    }
+    ordered_gpu_tail.reset();
+    ordered_tail_queue.reset();
+    used_queues.fill(false);
+    last_copy_timeline = 0;
+    LOG_INFO("[RHIExecutor][Vulkan] sync complete depth={}", static_cast<uint32>(_depth));
+}
+
+void VulkanSubmissionExecutor::CompleteRequest(
+    const std::shared_ptr<Completion>& _completion
+) {
+    if (_completion) {
+        _completion->Signal();
+    }
+}
+
+} // namespace Moer::Render

--- a/source/runtime/render/rhi/vulkan/VulkanSubmissionExecutor.cpp
+++ b/source/runtime/render/rhi/vulkan/VulkanSubmissionExecutor.cpp
@@ -216,35 +216,6 @@ void ResolveRejectedPresent(std::optional<RHIPresentRequest>& _present) {
     }
 }
 
-// The current producer emits one whole-submit segment. Multi-segment expansion
-// needs the resource-state dependency graph to synthesize cross-queue GPU waits;
-// accepting it before that layer exists would silently weaken ordering.
-Array<RHIBackendSubmissionBatchEntry> TakeSingleSegmentEntries(
-    RHIBackendSubmissionBatch&& _batch
-) {
-    Array<RHIBackendSubmissionBatchEntry> expanded{};
-    expanded.reserve(_batch.submits.size());
-
-    for (size_t source_index = 0; source_index < _batch.submits.size(); ++source_index) {
-        RHIBackendSubmissionBatchEntry& source = _batch.submits[source_index];
-        const RHISourceSubmitPlan& source_plan = _batch.topology.source_plans[source_index];
-        if (source_plan.segment_plan_count == 0) {
-            continue;
-        }
-
-        assert(source_plan.segment_plan_count == 1);
-        const RHISubmissionSegmentPlan& segment_plan =
-            _batch.topology.segments[source_plan.segment_plan_begin];
-        source.submit.segments = {RHISubmitSegment{
-            .queue = segment_plan.segment.queue,
-            .begin = 0,
-            .end   = source.submit.cmds.size(),
-        }};
-        expanded.emplace_back(segment_plan.segment.queue, std::move(source.submit));
-    }
-    return expanded;
-}
-
 } // namespace
 
 VulkanSubmissionExecutor::VulkanSubmissionExecutor() :
@@ -368,36 +339,119 @@ void VulkanSubmissionExecutor::Run() {
             requests.pop_front();
         }
 
-        if (request.kind == ERequestKind::Submit) {
-            ProcessBatch(std::move(request.batch));
-            continue;
-        }
-        ProcessSync(request.sync_depth);
-        CompleteRequest(request.completion);
-        if (request.kind == ERequestKind::Stop) {
+        BatchExceptionState exception_state{};
+        const VulkanSubmissionDetail::WorkerRequestDispatchResult dispatch_result =
+            VulkanSubmissionDetail::DispatchWorkerRequestNoexcept(
+                request.kind,
+                [&] {
+                    if (request.kind == ERequestKind::Submit) {
+                        ProcessBatch(request.batch, exception_state);
+                    } else {
+                        ProcessSync(request.sync_depth);
+                    }
+                },
+                [&] {
+                    hard_failed         = true;
+                    hard_failure_result = static_cast<int32>(VK_ERROR_UNKNOWN);
+                    RejectBatch(
+                        std::move(request.batch),
+                        hard_failure_result,
+                        "unhandled submission request exception",
+                        exception_state.first_unconsumed_source,
+                        &exception_state.first_unconsumed_source
+                    );
+                },
+                [&] { CompleteRequest(request.completion); },
+                [&](VulkanSubmissionDetail::EWorkerRequestFailurePhase _phase,
+                    const std::exception_ptr& _exception) {
+                    hard_failed         = true;
+                    hard_failure_result = static_cast<int32>(VK_ERROR_UNKNOWN);
+                    ReportRequestFailure(request.kind, _phase, _exception);
+                }
+            );
+        if (dispatch_result.stop) {
             break;
         }
+    }
+}
+
+void VulkanSubmissionExecutor::ReportRequestFailure(
+    ERequestKind                                        _kind,
+    VulkanSubmissionDetail::EWorkerRequestFailurePhase _phase,
+    const std::exception_ptr&                           _exception
+) noexcept {
+    const char* kind_name = "Submit";
+    switch (_kind) {
+        case ERequestKind::Submit:
+            break;
+        case ERequestKind::Sync:
+            kind_name = "Sync";
+            break;
+        case ERequestKind::Stop:
+            kind_name = "Stop";
+            break;
+    }
+
+    const char* phase_name = "process";
+    switch (_phase) {
+        case VulkanSubmissionDetail::EWorkerRequestFailurePhase::Process:
+            break;
+        case VulkanSubmissionDetail::EWorkerRequestFailurePhase::Reject:
+            phase_name = "reject";
+            break;
+        case VulkanSubmissionDetail::EWorkerRequestFailurePhase::Complete:
+            phase_name = "complete";
+            break;
+    }
+
+    try {
+        if (_exception) {
+            std::rethrow_exception(_exception);
+        }
+    } catch (const std::exception& error) {
+        try {
+            LOG_ERROR(
+                "[RHIExecutor][Vulkan] request={} phase={} threw: {}",
+                kind_name,
+                phase_name,
+                error.what()
+            );
+        } catch (...) {
+        }
+        return;
+    } catch (...) {
+    }
+
+    try {
+        LOG_ERROR(
+            "[RHIExecutor][Vulkan] request={} phase={} threw an unknown exception",
+            kind_name,
+            phase_name
+        );
+    } catch (...) {
     }
 }
 
 void VulkanSubmissionExecutor::RejectBatch(
     RHIBackendSubmissionBatch&& _batch,
     int32                       _result,
-    std::string_view            _reason
+    std::string_view            _reason,
+    size_t                      _first_source,
+    size_t*                     _next_unconsumed_source
 ) {
-    LOG_ERROR(
-        "[RHIExecutor][Vulkan] reject batch={} sources={} reason={}",
-        _batch.sequence,
-        _batch.submits.size(),
-        _reason
-    );
-
+    const size_t first_source = std::min(_first_source, _batch.submits.size());
     ResolveRejectedPresent(_batch.present);
     const VkResult result = static_cast<VkResult>(_result);
-    for (RHIBackendSubmissionBatchEntry& entry : _batch.submits) {
+    for (size_t source_index = first_source;
+         source_index < _batch.submits.size();
+         ++source_index) {
+        RHIBackendSubmissionBatchEntry& entry = _batch.submits[source_index];
         if (entry.queue == EQueueType::Copy) {
             auto& queue = static_cast<VkCopyQueue&>(RenderDevice::Get().GetCopyQueue());
             queue.RejectForRuntime(std::move(entry.submit), result);
+            if (_next_unconsumed_source != nullptr) {
+                *_next_unconsumed_source = source_index + 1;
+            }
             continue;
         }
 
@@ -409,15 +463,30 @@ void VulkanSubmissionExecutor::RejectBatch(
             RenderDevice::Get().GetCommandQueue(queue_type)
         );
         queue.RejectForRuntime(std::move(entry.submit), result);
+        if (_next_unconsumed_source != nullptr) {
+            *_next_unconsumed_source = source_index + 1;
+        }
     }
+
+    LOG_ERROR(
+        "[RHIExecutor][Vulkan] reject batch={} sources={} reason={}",
+        _batch.sequence,
+        _batch.submits.size() - first_source,
+        _reason
+    );
 }
 
-void VulkanSubmissionExecutor::ProcessBatch(RHIBackendSubmissionBatch&& _batch) {
+void VulkanSubmissionExecutor::ProcessBatch(
+    RHIBackendSubmissionBatch& _batch,
+    BatchExceptionState&       _exception_state
+) {
     if (hard_failed) {
         RejectBatch(
             std::move(_batch),
             hard_failure_result,
-            "submission runtime is latched after a hard failure"
+            "submission runtime is latched after a hard failure",
+            0,
+            &_exception_state.first_unconsumed_source
         );
         return;
     }
@@ -438,7 +507,9 @@ void VulkanSubmissionExecutor::ProcessBatch(RHIBackendSubmissionBatch&& _batch) 
         RejectBatch(
             std::move(_batch),
             static_cast<int32>(VK_ERROR_UNKNOWN),
-            preflight.reason
+            preflight.reason,
+            0,
+            &_exception_state.first_unconsumed_source
         );
         return;
     }
@@ -455,29 +526,47 @@ void VulkanSubmissionExecutor::ProcessBatch(RHIBackendSubmissionBatch&& _batch) 
         );
     }
 
-    Array<RHIBackendSubmissionBatchEntry> entries = TakeSingleSegmentEntries(std::move(_batch));
     auto reject_remaining = [&](size_t _begin, VkResult _result, std::string_view _reason) {
         if (_result == VK_SUCCESS) {
             _result = VK_ERROR_UNKNOWN;
         }
         hard_failed         = true;
         hard_failure_result = static_cast<int32>(_result);
-        RHIBackendSubmissionBatch rejected{};
-        rejected.sequence = _batch.sequence;
-        rejected.present  = std::move(_batch.present);
-        rejected.submits.reserve(entries.size() - std::min(_begin, entries.size()));
-        for (size_t index = _begin; index < entries.size(); ++index) {
-            rejected.submits.emplace_back(
-                entries[index].queue, std::move(entries[index].submit)
-            );
-        }
+        _exception_state.first_unconsumed_source =
+            std::min(_begin, _batch.submits.size());
         RejectBatch(
-            std::move(rejected), static_cast<int32>(_result), _reason
+            std::move(_batch),
+            static_cast<int32>(_result),
+            _reason,
+            _exception_state.first_unconsumed_source,
+            &_exception_state.first_unconsumed_source
         );
+        _exception_state.first_unconsumed_source = _batch.submits.size();
     };
 
-    for (size_t entry_index = 0; entry_index < entries.size(); ++entry_index) {
-        RHIBackendSubmissionBatchEntry& entry = entries[entry_index];
+    // Keep every source in the request-owned batch until its queue call has
+    // returned. If reorder, descriptor-lease, allocator, or native recording
+    // setup throws, Run's request barrier can still terminalize the current
+    // source callbacks/signals and every later source. Moving all sources into
+    // a temporary expansion array here would lose those obligations on unwind.
+    for (size_t source_index = 0; source_index < _batch.submits.size(); ++source_index) {
+        RHIBackendSubmissionBatchEntry& entry = _batch.submits[source_index];
+        const RHISourceSubmitPlan& source_plan =
+            _batch.topology.source_plans[source_index];
+        if (source_plan.segment_plan_count == 0) {
+            _exception_state.first_unconsumed_source = source_index + 1;
+            continue;
+        }
+
+        assert(source_plan.segment_plan_count == 1);
+        const RHISubmissionSegmentPlan& segment_plan =
+            _batch.topology.segments[source_plan.segment_plan_begin];
+        entry.submit.segments = {RHISubmitSegment{
+            .queue = segment_plan.segment.queue,
+            .begin = 0,
+            .end   = entry.submit.cmds.size(),
+        }};
+
         if (ordered_tail_queue.has_value() && *ordered_tail_queue != entry.queue &&
             ordered_gpu_tail.has_value()) {
             // Native queue submit order only applies within one queue. Chain
@@ -489,6 +578,9 @@ void VulkanSubmissionExecutor::ProcessBatch(RHIBackendSubmissionBatch&& _batch) 
             auto& copy_queue = static_cast<VkCopyQueue&>(RenderDevice::Get().GetCopyQueue());
             const VulkanRuntimeSubmissionResult submit_result =
                 copy_queue.ExecuteForRuntime(std::move(entry.submit));
+            // ExecuteForRuntime has now either submitted or terminalized this
+            // source. Never reject it again if later bookkeeping/logging throws.
+            _exception_state.first_unconsumed_source = source_index + 1;
             if (submit_result.WasSubmitted()) {
                 assert(submit_result.completion.has_value());
                 last_copy_timeline = std::max(
@@ -512,7 +604,7 @@ void VulkanSubmissionExecutor::ProcessBatch(RHIBackendSubmissionBatch&& _batch) 
                 );
                 used_queues[static_cast<size_t>(EQueueType::Copy)] = true;
                 reject_remaining(
-                    entry_index + 1,
+                    source_index + 1,
                     submit_result.outcome.result,
                     "Copy submission hard failure"
                 );
@@ -528,6 +620,7 @@ void VulkanSubmissionExecutor::ProcessBatch(RHIBackendSubmissionBatch&& _batch) 
             // publishes a CPU completion marker, including rejected paths.
             used_queues[static_cast<size_t>(entry.queue)] = true;
             if (!recorded) {
+                _exception_state.first_unconsumed_source = source_index + 1;
                 LOG_ERROR(
                     "[RHIExecutor][Vulkan] batch={} source_queue={} translation failed",
                     _batch.sequence,
@@ -538,12 +631,15 @@ void VulkanSubmissionExecutor::ProcessBatch(RHIBackendSubmissionBatch&& _batch) 
                                             vk_device.GetFirstFaultResult() :
                                             VK_ERROR_UNKNOWN;
                 reject_remaining(
-                    entry_index + 1, result, "command translation failure"
+                    source_index + 1, result, "command translation failure"
                 );
                 return;
             }
             const VulkanRuntimeSubmissionResult submit_result =
                 queue.SubmitRecordedForRuntime(std::move(*recorded));
+            // SubmitRecordedForRuntime owns the recorded packet through its
+            // terminal result, including native rejection.
+            _exception_state.first_unconsumed_source = source_index + 1;
             if (submit_result.WasSubmitted()) {
                 assert(submit_result.completion.has_value());
                 ordered_gpu_tail   = *submit_result.completion;
@@ -559,7 +655,7 @@ void VulkanSubmissionExecutor::ProcessBatch(RHIBackendSubmissionBatch&& _batch) 
                     static_cast<int32>(submit_result.outcome.result)
                 );
                 reject_remaining(
-                    entry_index + 1,
+                    source_index + 1,
                     submit_result.outcome.result,
                     "command submission hard failure"
                 );
@@ -586,7 +682,7 @@ void VulkanSubmissionExecutor::ProcessBatch(RHIBackendSubmissionBatch&& _batch) 
                                             graphics_queue.vk_device.GetFirstFaultResult() :
                                             VK_ERROR_UNKNOWN;
                 reject_remaining(
-                    entries.size(), result, "Present bridge translation failure"
+                    _batch.submits.size(), result, "Present bridge translation failure"
                 );
                 return;
             }
@@ -600,7 +696,7 @@ void VulkanSubmissionExecutor::ProcessBatch(RHIBackendSubmissionBatch&& _batch) 
                     static_cast<int32>(bridge_result.outcome.result)
                 );
                 reject_remaining(
-                    entries.size(),
+                    _batch.submits.size(),
                     bridge_result.outcome.result,
                     "Present bridge submission failure"
                 );
@@ -614,8 +710,15 @@ void VulkanSubmissionExecutor::ProcessBatch(RHIBackendSubmissionBatch&& _batch) 
         const VulkanRuntimeSubmissionResult present_result = graphics_queue.PresentForRuntime(
             std::move(present.swapchain),
             present.source,
-            std::move(present.receipt)
+            // Keep the request's receipt reference until PresentForRuntime
+            // returns. If it throws after taking its by-value copy, Run can
+            // still resolve this retained receipt through RejectBatch.
+            present.receipt
         );
+        // PresentForRuntime has now terminalized or retained the copied receipt.
+        // Clear the request copy before any later diagnostic/bookkeeping can
+        // throw, preserving an accepted/retry Present's existing semantics.
+        _batch.present.reset();
         // Retry/Recreate still owns a logical timeline and completion marker;
         // Sync must drain that CPU-side retirement even though no GPU tail was
         // produced.

--- a/source/runtime/render/rhi/vulkan/VulkanSubmissionExecutor.h
+++ b/source/runtime/render/rhi/vulkan/VulkanSubmissionExecutor.h
@@ -1,9 +1,11 @@
 #pragma once
 
 #include "rhi/RHIExecutorBackend.h"
+#include "VulkanSubmissionRequestDispatch.h"
 
 #include <condition_variable>
 #include <deque>
+#include <exception>
 #include <memory>
 #include <mutex>
 #include <string_view>
@@ -34,11 +36,7 @@ private:
         bool                    done{false};
     };
 
-    enum class ERequestKind : uint8_t {
-        Submit,
-        Sync,
-        Stop,
-    };
+    using ERequestKind = VulkanSubmissionDetail::EWorkerRequestKind;
 
     struct Request {
         ERequestKind                kind{ERequestKind::Submit};
@@ -47,15 +45,32 @@ private:
         std::shared_ptr<Completion> completion{};
     };
 
+    struct BatchExceptionState {
+        // Sources below this cursor have already been terminalized by their
+        // native queue. The current source and every later source remain the
+        // rejection responsibility of the request on an unexpected exception.
+        size_t first_unconsumed_source{0};
+    };
+
     void Run();
-    void ProcessBatch(RHIBackendSubmissionBatch&& _batch);
+    void ProcessBatch(
+        RHIBackendSubmissionBatch& _batch,
+        BatchExceptionState&       _exception_state
+    );
     void ProcessSync(ERHISyncDepth _depth);
     void RejectBatch(
         RHIBackendSubmissionBatch&& _batch,
         int32                       _result,
-        std::string_view            _reason
+        std::string_view            _reason,
+        size_t                      _first_source = 0,
+        size_t*                     _next_unconsumed_source = nullptr
     );
     void CompleteRequest(const std::shared_ptr<Completion>& _completion);
+    void ReportRequestFailure(
+        ERequestKind                                  _kind,
+        VulkanSubmissionDetail::EWorkerRequestFailurePhase _phase,
+        const std::exception_ptr&                     _exception
+    ) noexcept;
 
     std::mutex                 mutex{};
     std::condition_variable    cv{};

--- a/source/runtime/render/rhi/vulkan/VulkanSubmissionExecutor.h
+++ b/source/runtime/render/rhi/vulkan/VulkanSubmissionExecutor.h
@@ -1,0 +1,76 @@
+#pragma once
+
+#include "rhi/RHIExecutorBackend.h"
+
+#include <condition_variable>
+#include <deque>
+#include <memory>
+#include <mutex>
+#include <string_view>
+#include <thread>
+
+namespace Moer::Render {
+
+// Owns the upper RHI submission stream for Vulkan. Translation remains
+// streaming (one source submission at a time) so descriptor leases can retire
+// while later work is being prepared; native queue submission order is stable.
+class VulkanSubmissionExecutor final : public RHIBackendExecutor {
+public:
+    VulkanSubmissionExecutor();
+    ~VulkanSubmissionExecutor() override;
+
+    void          Enqueue(RHIBackendSubmissionBatch&& _batch) override;
+    GraphEventRef Sync(ERHISyncDepth _depth = ERHISyncDepth::RHI) override;
+    void          Flush(ERHIFlushDepth _depth = ERHIFlushDepth::SubmitGPU) override;
+    void          ShutDown() override;
+
+private:
+    struct Completion {
+        void Signal();
+        void Wait();
+
+        std::mutex              mutex{};
+        std::condition_variable cv{};
+        bool                    done{false};
+    };
+
+    enum class ERequestKind : uint8_t {
+        Submit,
+        Sync,
+        Stop,
+    };
+
+    struct Request {
+        ERequestKind                kind{ERequestKind::Submit};
+        RHIBackendSubmissionBatch   batch{};
+        ERHISyncDepth               sync_depth{ERHISyncDepth::RHI};
+        std::shared_ptr<Completion> completion{};
+    };
+
+    void Run();
+    void ProcessBatch(RHIBackendSubmissionBatch&& _batch);
+    void ProcessSync(ERHISyncDepth _depth);
+    void RejectBatch(
+        RHIBackendSubmissionBatch&& _batch,
+        int32                       _result,
+        std::string_view            _reason
+    );
+    void CompleteRequest(const std::shared_ptr<Completion>& _completion);
+
+    std::mutex                 mutex{};
+    std::condition_variable    cv{};
+    std::deque<Request>        requests{};
+    std::jthread               thread{};
+    bool                       accepting{true};
+    bool                       stopped{false};
+    bool                       hard_failed{false};
+    bool                       logged_multi_source_topology{false};
+    int32                      hard_failure_result{0};
+    std::shared_ptr<Completion> stop_completion{};
+    StaticArray<bool, static_cast<size_t>(EQueueType::Num)> used_queues{};
+    uint64                     last_copy_timeline{0};
+    std::optional<EQueueType>  ordered_tail_queue{};
+    std::optional<WaitEvent>   ordered_gpu_tail{};
+};
+
+} // namespace Moer::Render

--- a/source/runtime/render/rhi/vulkan/VulkanSubmissionRequestDispatch.h
+++ b/source/runtime/render/rhi/vulkan/VulkanSubmissionRequestDispatch.h
@@ -1,0 +1,89 @@
+#pragma once
+
+#include <cstdint>
+#include <exception>
+#include <utility>
+
+namespace Moer::Render::VulkanSubmissionDetail {
+
+enum class EWorkerRequestKind : uint8_t {
+    Submit,
+    Sync,
+    Stop,
+};
+
+enum class EWorkerRequestFailurePhase : uint8_t {
+    Process,
+    Reject,
+    Complete,
+};
+
+struct WorkerRequestDispatchResult {
+    bool failed{false};
+    bool stop{false};
+};
+
+// The submission thread is a process-lifetime service. No request-owned
+// exception may escape its entry point: Submit must reject the payload still
+// owned by the request, while Sync/Stop must release their waiters. Stop is
+// terminal even when its final Sync fails.
+template <
+    typename ProcessFn,
+    typename RejectFn,
+    typename CompleteFn,
+    typename ReportFailureFn>
+[[nodiscard]] WorkerRequestDispatchResult DispatchWorkerRequestNoexcept(
+    EWorkerRequestKind _kind,
+    ProcessFn&&        _process,
+    RejectFn&&         _reject,
+    CompleteFn&&       _complete,
+    ReportFailureFn&&  _report_failure
+) noexcept {
+    bool failed = false;
+
+    auto report_failure = [&](EWorkerRequestFailurePhase _phase,
+                              std::exception_ptr          _exception) noexcept {
+        try {
+            _report_failure(_phase, _exception);
+        } catch (...) {
+            // Diagnostics are best-effort and must not punch through the
+            // submission-thread exception boundary.
+        }
+    };
+
+    try {
+        _process();
+    } catch (...) {
+        failed = true;
+        const std::exception_ptr process_exception = std::current_exception();
+        report_failure(EWorkerRequestFailurePhase::Process, process_exception);
+
+        if (_kind == EWorkerRequestKind::Submit) {
+            try {
+                _reject();
+            } catch (...) {
+                report_failure(
+                    EWorkerRequestFailurePhase::Reject, std::current_exception()
+                );
+            }
+        }
+    }
+
+    if (_kind != EWorkerRequestKind::Submit) {
+        try {
+            _complete();
+        } catch (...) {
+            failed = true;
+            report_failure(
+                EWorkerRequestFailurePhase::Complete, std::current_exception()
+            );
+        }
+    }
+
+    return {
+        .failed = failed,
+        .stop   = _kind == EWorkerRequestKind::Stop,
+    };
+}
+
+} // namespace Moer::Render::VulkanSubmissionDetail

--- a/source/runtime/render/scene/GpuScene.h
+++ b/source/runtime/render/scene/GpuScene.h
@@ -110,8 +110,8 @@ public:
     };
 
     struct PendingCommandList {
-        CommandList copy_queue_cmd_list;
-        CommandList gfx_queue_cmd_list;
+        CommandList copy_queue_cmd_list{EQueueType::Copy};
+        CommandList gfx_queue_cmd_list{EQueueType::Graphics};
     };
 
     /**

--- a/source/runtime/render/scene/RenderScene.cpp
+++ b/source/runtime/render/scene/RenderScene.cpp
@@ -3,6 +3,7 @@
 #include "RenderThread.h"
 #include "log/LogSystem.h"
 #include "rhi/RHI.h"
+#include "rhi/RHIExecutor.h"
 
 namespace Moer::Render {
 
@@ -26,6 +27,10 @@ GpuScene::PendingCommandList RenderScene::ApplyUpdate(GpuSceneUpdate&& update) {
     );
 
     if (update.full_rebuild) {
+        // Device idle only covers work already submitted to Vulkan. Drain the
+        // upper submission owner first so no queued translation can retain the
+        // scene resources that are about to be replaced.
+        RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
         RenderDevice::Get().WaitIdle();
         m_gpu_scene = MakeUnique<GpuScene>(m_bindless_array);
     }

--- a/source/test/CMakeLists.txt
+++ b/source/test/CMakeLists.txt
@@ -92,6 +92,17 @@ target_link_libraries(${test_target}
 set_target_properties(${test_target} PROPERTIES FOLDER ${moer_test_folder})
 add_test(NAME VulkanParallelRecordWorkEstimatorContract COMMAND $<TARGET_FILE:${test_target}>)
 
+# CPU-only fault-injection contract for the Vulkan submission worker's
+# per-request exception barrier. It verifies Submit rejection ownership and
+# unconditional Sync/Stop completion without requiring a Vulkan device.
+set(test_target TestVulkanSubmissionRequestDispatch)
+add_executable(${test_target} "VulkanSubmissionRequestDispatchTest.cpp")
+target_link_libraries(${test_target}
+    PRIVATE Moer::Render
+)
+set_target_properties(${test_target} PROPERTIES FOLDER ${moer_test_folder})
+add_test(NAME VulkanSubmissionRequestDispatchContract COMMAND $<TARGET_FILE:${test_target}>)
+
 # Vulkan integration seam for ordered multi-primary submission and the
 # recoverable worker-failure path. It is intentionally run explicitly because
 # it requires a Vulkan-capable machine; the CPU-only contracts above remain in

--- a/source/test/CMakeLists.txt
+++ b/source/test/CMakeLists.txt
@@ -32,6 +32,7 @@ target_link_libraries(${test_target}
     PRIVATE Moer::Render
 )
 set_target_properties(${test_target} PROPERTIES FOLDER ${moer_test_folder})
+add_test(NAME RHICmdReordererContract COMMAND $<TARGET_FILE:${test_target}>)
 
 set(test_target TestRHICommandMarker)
 add_executable(${test_target} "RHICommandMarkerTest.cpp")
@@ -39,6 +40,7 @@ target_link_libraries(${test_target}
     PRIVATE Moer::Render
 )
 set_target_properties(${test_target} PROPERTIES FOLDER ${moer_test_folder})
+add_test(NAME RHICommandMarkerContract COMMAND $<TARGET_FILE:${test_target}>)
 
 set(test_target TestExternalCpuJoin)
 add_executable(${test_target} "ExternalCpuJoinTest.cpp")
@@ -46,9 +48,56 @@ target_link_libraries(${test_target}
     PRIVATE Moer::Render
 )
 set_target_properties(${test_target} PROPERTIES FOLDER ${moer_test_folder})
+add_test(NAME ExternalCpuJoinContract COMMAND $<TARGET_FILE:${test_target}>)
 
 set(test_target TestRHIRecordDiagnostics)
 add_executable(${test_target} "RHIRecordDiagnosticsTest.cpp")
+target_link_libraries(${test_target}
+    PRIVATE Moer::Render
+)
+set_target_properties(${test_target} PROPERTIES FOLDER ${moer_test_folder})
+add_test(NAME RHIRecordDiagnosticsContract COMMAND $<TARGET_FILE:${test_target}>)
+
+set(test_target TestRHIParallelRecord)
+add_executable(${test_target} "RHIParallelRecordTest.cpp")
+target_link_libraries(${test_target}
+    PRIVATE Moer::Render
+)
+set_target_properties(${test_target} PROPERTIES FOLDER ${moer_test_folder})
+add_test(NAME RHIParallelRecordContract COMMAND $<TARGET_FILE:${test_target}>)
+
+set(test_target TestRHISubmissionTopology)
+add_executable(${test_target} "RHISubmissionTopologyTest.cpp")
+target_link_libraries(${test_target}
+    PRIVATE Moer::Render
+)
+set_target_properties(${test_target} PROPERTIES FOLDER ${moer_test_folder})
+add_test(NAME RHISubmissionTopologyContract COMMAND $<TARGET_FILE:${test_target}>)
+
+set(test_target TestRHIExecutorRecordingHandoff)
+add_executable(${test_target} "RHIExecutorRecordingHandoffTest.cpp")
+target_link_libraries(${test_target}
+    PRIVATE Moer::Render
+)
+set_target_properties(${test_target} PROPERTIES FOLDER ${moer_test_folder})
+add_test(NAME RHIExecutorRecordingHandoffContract COMMAND $<TARGET_FILE:${test_target}>)
+
+# CPU-only contract for the Vulkan recorder work heuristic. This uses RHI
+# command payloads but does not create a Vulkan instance or device.
+set(test_target TestVulkanParallelRecordWorkEstimator)
+add_executable(${test_target} "VulkanParallelRecordWorkEstimatorTest.cpp")
+target_link_libraries(${test_target}
+    PRIVATE Moer::Render
+)
+set_target_properties(${test_target} PROPERTIES FOLDER ${moer_test_folder})
+add_test(NAME VulkanParallelRecordWorkEstimatorContract COMMAND $<TARGET_FILE:${test_target}>)
+
+# Vulkan integration seam for ordered multi-primary submission and the
+# recoverable worker-failure path. It is intentionally run explicitly because
+# it requires a Vulkan-capable machine; the CPU-only contracts above remain in
+# the default CTest suite.
+set(test_target TestRHIParallelRecordVulkan)
+add_executable(${test_target} "RHIParallelRecordVulkanTest.cpp")
 target_link_libraries(${test_target}
     PRIVATE Moer::Render
 )

--- a/source/test/RHICommandMarkerTest.cpp
+++ b/source/test/RHICommandMarkerTest.cpp
@@ -81,6 +81,41 @@ void MarkerScopesAreBalancedColoredAndImmobile() {
     Expect(ScopeAt(next_submit, 0).QueryTimestamp(), "second submission lost timestamp profiling");
 }
 
+void ProfilingPhasesPreserveOneLogicalFrame() {
+    CommandList complete_list;
+    CmdSubmit complete = complete_list.Submit().TickProfiling();
+    Expect(complete.EmitsProfilingQueries(), "complete profiling phase must emit queries");
+    Expect(
+        complete.BeginsProfilingFrame() && complete.EndsProfilingFrame(),
+        "TickProfiling must remain a complete single-submit frame"
+    );
+
+    CommandList begin_list;
+    CmdSubmit begin = begin_list.Submit().SetProfilingPhase(ERHIProfilingPhase::Begin);
+    Expect(
+        begin.EmitsProfilingQueries() && begin.BeginsProfilingFrame() &&
+            !begin.EndsProfilingFrame(),
+        "split profiling begin phase has incorrect boundaries"
+    );
+
+    CommandList continue_list;
+    CmdSubmit continuation =
+        continue_list.Submit().SetProfilingPhase(ERHIProfilingPhase::Continue);
+    Expect(
+        continuation.EmitsProfilingQueries() && !continuation.BeginsProfilingFrame() &&
+            !continuation.EndsProfilingFrame(),
+        "split profiling continuation must only emit pass queries"
+    );
+
+    CommandList end_list;
+    CmdSubmit end = end_list.Submit().SetProfilingPhase(ERHIProfilingPhase::End);
+    Expect(
+        end.EmitsProfilingQueries() && !end.BeginsProfilingFrame() &&
+            end.EndsProfilingFrame(),
+        "split profiling end phase has incorrect boundaries"
+    );
+}
+
 void PointAndCsmMarkerNamesAreCompleteAndDisjoint() {
     std::set<std::string_view> point_faces;
     std::set<std::string_view> point_culling;
@@ -123,6 +158,7 @@ void PointAndCsmMarkerNamesAreCompleteAndDisjoint() {
 int main() {
     try {
         MarkerScopesAreBalancedColoredAndImmobile();
+        ProfilingPhasesPreserveOneLogicalFrame();
         PointAndCsmMarkerNamesAreCompleteAndDisjoint();
         std::cout << "RHI command marker tests passed\n";
         return 0;

--- a/source/test/RHIExecutorRecordingHandoffTest.cpp
+++ b/source/test/RHIExecutorRecordingHandoffTest.cpp
@@ -328,6 +328,63 @@ bool BlockingWaitReportsTerminalStatus() {
     return okay;
 }
 
+bool ShutdownDrainsTerminalSourceBehindPendingHead() {
+    RHIExecutor::StartUp();
+
+    std::atomic<int> ordinary_callbacks{0};
+    std::atomic<int> success_callbacks{0};
+    auto pending_list  = Moer::MakeShared<CommandList>(EQueueType::Graphics);
+    auto terminal_list = Moer::MakeShared<CommandList>(EQueueType::Graphics);
+    terminal_list->AddCallback([&ordinary_callbacks] {
+        ordinary_callbacks.fetch_add(1);
+    });
+    terminal_list->AddSuccessCallback([&success_callbacks] {
+        success_callbacks.fetch_add(1);
+    });
+
+    auto pending_gate  = RHIRecordingGate::Create();
+    auto terminal_gate = RHIRecordingGate::Create(true);
+    RHIExecutor::Get().SubmitRecording(
+        pending_list,
+        pending_gate,
+        ERHIExecSubmitFlags::None
+    );
+    RHIExecutor::Get().SubmitRecording(
+        terminal_list,
+        terminal_gate,
+        ERHIExecSubmitFlags::None
+    );
+
+    // The pending head keeps the already-complete second source in the handoff
+    // FIFO. Shutdown must remain bounded, leave the first source opaque, and
+    // drain only the terminal source's ordinary cleanup exactly once.
+    RHIExecutor::ShutDown();
+
+    CmdSubmit drained_terminal = terminal_list->Submit();
+    const bool okay =
+        Expect(
+            ordinary_callbacks.load() == 1,
+            "shutdown did not run terminal recording cleanup exactly once"
+        ) &&
+        Expect(
+            success_callbacks.load() == 0,
+            "shutdown ran a success-only callback for an unpublished recording"
+        ) &&
+        Expect(
+            drained_terminal.cmds.empty() && drained_terminal.callbacks.empty() &&
+                drained_terminal.success_callbacks.empty() &&
+                drained_terminal.segments.empty(),
+            "shutdown left a terminal cancelled recording source undrained"
+        ) &&
+        Expect(
+            pending_gate->Status() == ERHIRecordingStatus::Pending,
+            "shutdown changed the producer-owned pending gate"
+        );
+
+    pending_gate->Signal();
+    return okay;
+}
+
 bool ShutdownCancelsAnUnsignalledGate() {
     RHIExecutorRecordingHandoffQueue queue{};
     queue.Start();
@@ -403,6 +460,7 @@ int main() {
         !FailedGateRejectsOnlyItsGroupAndPreservesFifo() ||
         !FailedRecordingDrainsCleanupExactlyOnce() ||
         !BlockingWaitReportsTerminalStatus() ||
+        !ShutdownDrainsTerminalSourceBehindPendingHead() ||
         !ShutdownCancelsAnUnsignalledGate()) {
         return EXIT_FAILURE;
     }

--- a/source/test/RHIExecutorRecordingHandoffTest.cpp
+++ b/source/test/RHIExecutorRecordingHandoffTest.cpp
@@ -1,0 +1,411 @@
+#include "rhi/RHIExecutor.h"
+
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <cstdlib>
+#include <iostream>
+#include <mutex>
+#include <thread>
+#include <vector>
+
+namespace {
+
+using namespace Moer::Render;
+using namespace std::chrono_literals;
+
+struct ResolutionLog {
+    void Push(int _id, ERHIRecordingHandoffResult _result) {
+        {
+            std::lock_guard lock(mutex);
+            entries.emplace_back(_id, _result);
+        }
+        cv.notify_all();
+    }
+
+    bool WaitForSize(size_t _size, std::chrono::milliseconds _timeout = 2s) {
+        std::unique_lock lock(mutex);
+        return cv.wait_for(lock, _timeout, [this, _size] {
+            return entries.size() >= _size;
+        });
+    }
+
+    std::vector<std::pair<int, ERHIRecordingHandoffResult>> Snapshot() const {
+        std::lock_guard lock(mutex);
+        return entries;
+    }
+
+    mutable std::mutex mutex;
+    std::condition_variable cv;
+    std::vector<std::pair<int, ERHIRecordingHandoffResult>> entries{};
+};
+
+bool Expect(bool _condition, const char* _message) {
+    if (_condition) {
+        return true;
+    }
+    std::cerr << "RHIExecutorRecordingHandoffContract: " << _message << '\n';
+    return false;
+}
+
+bool PerSourceGatesPreserveFifo() {
+    RHIExecutorRecordingHandoffQueue queue{};
+    queue.Start();
+
+    ResolutionLog log{};
+    auto first_gate  = RHIRecordingGate::Create();
+    auto second_gate = RHIRecordingGate::Create();
+
+    queue.EnqueueRecording(RHIExecutorRecordingHandoffWork{
+        .prerequisites = {first_gate, second_gate},
+        .resolve = [&log](ERHIRecordingHandoffResult _result) {
+            log.Push(1, _result);
+        },
+    });
+    queue.RouteReady(RHIExecutorRecordingHandoffWork{
+        .prerequisites = {},
+        .resolve = [&log](ERHIRecordingHandoffResult _result) {
+            log.Push(2, _result);
+        },
+    });
+
+    second_gate->Signal();
+    std::this_thread::sleep_for(30ms);
+    if (!Expect(log.Snapshot().empty(), "a later ready gate overtook the FIFO head")) {
+        queue.ShutDown();
+        return false;
+    }
+
+    first_gate->Signal();
+    const bool completed = log.WaitForSize(2);
+    const auto entries   = log.Snapshot();
+    queue.ShutDown();
+
+    return Expect(completed, "completed gates did not release the handoff") &&
+           Expect(entries.size() == 2, "unexpected FIFO result count") &&
+           Expect(entries[0].first == 1 && entries[1].first == 2, "FIFO order changed") &&
+           Expect(
+               entries[0].second == ERHIRecordingHandoffResult::Consume &&
+                   entries[1].second == ERHIRecordingHandoffResult::Consume,
+               "completed work was not consumed"
+           );
+}
+
+bool InlineReadyWorkCannotBeOvertaken() {
+    RHIExecutorRecordingHandoffQueue queue{};
+    queue.Start();
+
+    ResolutionLog log{};
+    std::mutex block_mutex;
+    std::condition_variable block_cv;
+    bool inline_entered = false;
+    bool release_inline = false;
+
+    std::jthread inline_thread([&] {
+        queue.RouteReady(RHIExecutorRecordingHandoffWork{
+            .prerequisites = {},
+            .resolve = [&](ERHIRecordingHandoffResult _result) {
+                {
+                    std::unique_lock lock(block_mutex);
+                    inline_entered = true;
+                    block_cv.notify_all();
+                    block_cv.wait(lock, [&] { return release_inline; });
+                }
+                log.Push(1, _result);
+            },
+        });
+    });
+
+    {
+        std::unique_lock lock(block_mutex);
+        if (!block_cv.wait_for(lock, 2s, [&] { return inline_entered; })) {
+            release_inline = true;
+            block_cv.notify_all();
+            queue.ShutDown();
+            return Expect(false, "inline ready work did not start");
+        }
+    }
+
+    auto completed_gate = RHIRecordingGate::Create(true);
+    queue.EnqueueRecording(RHIExecutorRecordingHandoffWork{
+        .prerequisites = {completed_gate},
+        .resolve = [&log](ERHIRecordingHandoffResult _result) {
+            log.Push(2, _result);
+        },
+    });
+    std::this_thread::sleep_for(30ms);
+    if (!Expect(log.Snapshot().empty(), "recording work overtook active ready work")) {
+        {
+            std::lock_guard lock(block_mutex);
+            release_inline = true;
+        }
+        block_cv.notify_all();
+        queue.ShutDown();
+        return false;
+    }
+
+    {
+        std::lock_guard lock(block_mutex);
+        release_inline = true;
+    }
+    block_cv.notify_all();
+    inline_thread.join();
+
+    const bool completed = log.WaitForSize(2);
+    const auto entries   = log.Snapshot();
+    queue.ShutDown();
+    return Expect(completed, "queued recording work did not run") &&
+           Expect(entries.size() == 2, "unexpected inline-order result count") &&
+           Expect(entries[0].first == 1 && entries[1].first == 2, "inline order changed");
+}
+
+bool FailedGateRejectsOnlyItsGroupAndPreservesFifo() {
+    RHIExecutorRecordingHandoffQueue queue{};
+    queue.Start();
+
+    ResolutionLog log{};
+    auto failed_gate = RHIRecordingGate::Create();
+    auto later_gate  = RHIRecordingGate::Create();
+    queue.EnqueueRecording(RHIExecutorRecordingHandoffWork{
+        .prerequisites = {failed_gate, later_gate},
+        .resolve = [&log](ERHIRecordingHandoffResult _result) {
+            log.Push(1, _result);
+        },
+    });
+    queue.RouteReady(RHIExecutorRecordingHandoffWork{
+        .prerequisites = {},
+        .resolve = [&log](ERHIRecordingHandoffResult _result) {
+            log.Push(2, _result);
+        },
+    });
+
+    failed_gate->Fail();
+    std::this_thread::sleep_for(30ms);
+    if (!Expect(
+            log.Snapshot().empty(),
+            "a failed group resolved before every producer gate became terminal"
+        )) {
+        later_gate->Signal();
+        queue.ShutDown();
+        return false;
+    }
+
+    later_gate->Signal();
+    const bool completed = log.WaitForSize(2);
+    const auto entries   = log.Snapshot();
+
+    bool okay = Expect(completed, "failed gate did not resolve the FIFO") &&
+                Expect(entries.size() == 2, "unexpected failed-gate result count") &&
+                Expect(entries[0].first == 1 && entries[1].first == 2, "failed group reordered FIFO") &&
+                Expect(
+                    entries[0].second == ERHIRecordingHandoffResult::Reject,
+                    "failed recording group was consumed"
+                ) &&
+                Expect(
+                    entries[1].second == ERHIRecordingHandoffResult::Consume,
+                    "ready work after failed group was rejected"
+                ) &&
+                Expect(
+                    failed_gate->Status() == ERHIRecordingStatus::Failed,
+                    "failed gate lost its terminal status"
+                ) &&
+                Expect(!failed_gate->Signal(), "failed gate changed terminal status");
+    queue.ShutDown();
+    return okay;
+}
+
+bool FailedRecordingDrainsCleanupExactlyOnce() {
+    RHIExecutor::StartUp();
+
+    std::atomic<int> ordinary_callbacks{0};
+    std::atomic<int> success_callbacks{0};
+    auto first_list  = Moer::MakeShared<CommandList>(EQueueType::Graphics);
+    auto second_list = Moer::MakeShared<CommandList>(EQueueType::Graphics);
+    first_list->AddCallback([&ordinary_callbacks] { ordinary_callbacks.fetch_add(1); });
+    second_list->AddCallback([&ordinary_callbacks] { ordinary_callbacks.fetch_add(1); });
+    first_list->AddSuccessCallback([&success_callbacks] { success_callbacks.fetch_add(1); });
+    second_list->AddSuccessCallback([&success_callbacks] { success_callbacks.fetch_add(1); });
+    // A producer exception may bypass a manual PopScope. The rejection path
+    // must drain cleanup without calling Submit(), whose Debug contract
+    // intentionally rejects an unmatched scope.
+    first_list->PushScope("Unclosed failed producer scope");
+
+    auto failed_gate = RHIRecordingGate::Create();
+    auto later_gate  = RHIRecordingGate::Create();
+    Moer::Array<RHIRecordingSource> sources{};
+    sources.emplace_back(RHIRecordingSource{
+        .command_list = first_list,
+        .completion   = failed_gate,
+    });
+    sources.emplace_back(RHIRecordingSource{
+        .command_list = second_list,
+        .completion   = later_gate,
+    });
+    RHIExecutor::Get().SubmitRecording(std::move(sources), ERHIExecSubmitFlags::None);
+
+    failed_gate->Fail();
+    std::atomic<bool> sync_returned{false};
+    std::jthread sync_thread([&] {
+        RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
+        sync_returned.store(true, std::memory_order_release);
+    });
+    std::this_thread::sleep_for(30ms);
+    bool okay = Expect(
+                    !sync_returned.load(std::memory_order_acquire),
+                    "failed recording group did not wait for a later producer"
+                ) &&
+                Expect(
+                    ordinary_callbacks.load() == 0 && success_callbacks.load() == 0,
+                    "recording callbacks ran while a producer could still mutate its CommandList"
+                );
+
+    later_gate->Signal();
+    sync_thread.join();
+    okay &= Expect(
+        ordinary_callbacks.load() == 2,
+        "failed recording group did not run every ordinary cleanup callback exactly once"
+    );
+    okay &= Expect(
+        success_callbacks.load() == 0,
+        "failed recording group ran a success-only callback"
+    );
+    CmdSubmit drained_first  = first_list->Submit();
+    CmdSubmit drained_second = second_list->Submit();
+    okay &= Expect(
+        drained_first.cmds.empty() && drained_first.callbacks.empty() &&
+            drained_first.success_callbacks.empty() && drained_first.segments.empty() &&
+            drained_second.cmds.empty() && drained_second.callbacks.empty() &&
+            drained_second.success_callbacks.empty() && drained_second.segments.empty(),
+        "rejection drain left a partial command, callback, scope, or submit segment behind"
+    );
+
+    // A second ordering boundary and shutdown must not replay drained cleanup.
+    RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
+    RHIExecutor::ShutDown();
+    okay &= Expect(
+        ordinary_callbacks.load() == 2 && success_callbacks.load() == 0,
+        "failed recording cleanup was not terminal or ran more than once"
+    );
+    return okay;
+}
+
+bool BlockingWaitReportsTerminalStatus() {
+    auto succeeded_gate = RHIRecordingGate::Create();
+    std::atomic<ERHIRecordingStatus> waited_status{ERHIRecordingStatus::Pending};
+    std::atomic<bool> wait_started{false};
+    std::jthread waiter([&] {
+        wait_started.store(true, std::memory_order_release);
+        waited_status.store(succeeded_gate->Wait(), std::memory_order_release);
+    });
+
+    const auto deadline = std::chrono::steady_clock::now() + 2s;
+    while (!wait_started.load(std::memory_order_acquire) &&
+           std::chrono::steady_clock::now() < deadline) {
+        std::this_thread::yield();
+    }
+    std::this_thread::sleep_for(20ms);
+    bool okay = Expect(
+        waited_status.load(std::memory_order_acquire) == ERHIRecordingStatus::Pending,
+        "blocking Wait returned before a Pending gate completed"
+    );
+    succeeded_gate->Signal();
+    waiter.join();
+    okay &= Expect(
+        waited_status.load(std::memory_order_acquire) == ERHIRecordingStatus::Succeeded,
+        "blocking Wait did not report Succeeded"
+    );
+
+    auto failed_gate = RHIRecordingGate::Create();
+    failed_gate->Fail();
+    const auto failed_begin  = std::chrono::steady_clock::now();
+    const auto failed_status = failed_gate->Wait();
+    const auto failed_elapsed = std::chrono::steady_clock::now() - failed_begin;
+    okay &= Expect(
+        failed_status == ERHIRecordingStatus::Failed,
+        "blocking Wait did not report Failed"
+    );
+    okay &= Expect(failed_elapsed < 100ms, "terminal Failed gate did not return immediately");
+    return okay;
+}
+
+bool ShutdownCancelsAnUnsignalledGate() {
+    RHIExecutorRecordingHandoffQueue queue{};
+    queue.Start();
+
+    ResolutionLog log{};
+    auto never_signalled = RHIRecordingGate::Create();
+    queue.EnqueueRecording(RHIExecutorRecordingHandoffWork{
+        .prerequisites = {never_signalled},
+        .resolve = [&log](ERHIRecordingHandoffResult _result) {
+            log.Push(1, _result);
+        },
+    });
+    queue.RouteReady(RHIExecutorRecordingHandoffWork{
+        .prerequisites = {},
+        .resolve = [&log](ERHIRecordingHandoffResult _result) {
+            log.Push(2, _result);
+        },
+    });
+
+    const auto begin = std::chrono::steady_clock::now();
+    queue.ShutDown();
+    const auto elapsed = std::chrono::steady_clock::now() - begin;
+    const auto entries = log.Snapshot();
+
+    bool okay = Expect(elapsed < 1s, "shutdown waited for an unsignalled gate") &&
+                Expect(entries.size() == 2, "shutdown did not resolve every FIFO entry") &&
+                Expect(entries[0].first == 1 && entries[1].first == 2, "reject order changed") &&
+                Expect(
+                    entries[0].second == ERHIRecordingHandoffResult::Cancel &&
+                        entries[1].second == ERHIRecordingHandoffResult::Cancel,
+                    "shutdown consumed cancelled work"
+                );
+
+    std::atomic<int> stopped_result{-1};
+    queue.RouteReady(RHIExecutorRecordingHandoffWork{
+        .prerequisites = {},
+        .resolve = [&stopped_result](ERHIRecordingHandoffResult _result) {
+            stopped_result.store(
+                _result == ERHIRecordingHandoffResult::Cancel ? 1 : 0,
+                std::memory_order_release
+            );
+        },
+    });
+    okay &= Expect(
+        stopped_result.load(std::memory_order_acquire) == 1,
+        "post-shutdown work was not rejected synchronously"
+    );
+
+    // The queue is restartable across device lifetimes.
+    queue.Start();
+    ResolutionLog restarted{};
+    queue.EnqueueRecording(RHIExecutorRecordingHandoffWork{
+        .prerequisites = {RHIRecordingGate::Create(true)},
+        .resolve = [&restarted](ERHIRecordingHandoffResult _result) {
+            restarted.Push(3, _result);
+        },
+    });
+    okay &= Expect(restarted.WaitForSize(1), "restarted queue did not consume work");
+    const auto restarted_entries = restarted.Snapshot();
+    okay &= Expect(
+        restarted_entries.size() == 1 &&
+            restarted_entries[0].second == ERHIRecordingHandoffResult::Consume,
+        "restarted queue returned the wrong resolution"
+    );
+    queue.ShutDown();
+    return okay;
+}
+
+} // namespace
+
+int main() {
+    if (!PerSourceGatesPreserveFifo() || !InlineReadyWorkCannotBeOvertaken() ||
+        !FailedGateRejectsOnlyItsGroupAndPreservesFifo() ||
+        !FailedRecordingDrainsCleanupExactlyOnce() ||
+        !BlockingWaitReportsTerminalStatus() ||
+        !ShutdownCancelsAnUnsignalledGate()) {
+        return EXIT_FAILURE;
+    }
+    std::cout << "RHIExecutor recording handoff contract passed\n";
+    return EXIT_SUCCESS;
+}

--- a/source/test/RHIParallelRecordTest.cpp
+++ b/source/test/RHIParallelRecordTest.cpp
@@ -1,0 +1,392 @@
+#include "rhi/ExternalCpuJoinPool.h"
+#include "rhi/RHIParallelRecord.h"
+
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <cstdint>
+#include <iostream>
+#include <mutex>
+#include <stdexcept>
+#include <thread>
+#include <utility>
+#include <vector>
+
+using namespace Moer::Render;
+using namespace std::chrono_literals;
+
+namespace {
+
+using Type = Command::EType;
+
+void Expect(bool _condition, const char* _message) {
+    if (!_condition) {
+        throw std::runtime_error(_message);
+    }
+}
+
+ParallelRecordLayerDescription Describe(const std::vector<Type>& _types) {
+    return {.command_types = std::span<const Type>(_types)};
+}
+
+ParallelRecordLayerDescription DescribeWeighted(
+    const std::vector<Type>&     _types,
+    const std::vector<uint32_t>& _work_units
+) {
+    return {
+        .command_types = std::span<const Type>(_types),
+        .command_work_units = std::span<const uint32_t>(_work_units),
+    };
+}
+
+ParallelRecordLayerDescription DescribeForcedSerial(const std::vector<Type>& _types) {
+    return {.command_types = std::span<const Type>(_types), .force_serial = true};
+}
+
+void EligibleLayerUsesStableBalancedPartitions() {
+    const std::vector<Type> types(5, Type::BufferToBuffer);
+    const std::vector<ParallelRecordLayerDescription> layers{Describe(types)};
+
+    const ParallelRecordPlan plan = BuildParallelRecordPlan(layers, 3, 1);
+    Expect(plan.CanRecordInParallel(), "eligible layer did not produce a parallel plan");
+    Expect(plan.parallel_layer_count == 1, "parallel layer count was incorrect");
+    Expect(plan.layers.size() == 1 && plan.layers[0].parallel, "layer was not marked parallel");
+    Expect(plan.jobs.size() == 3, "worker count did not cap partition count");
+    Expect(plan.jobs[0].command_begin == 0 && plan.jobs[0].command_count == 2, "first range was not balanced");
+    Expect(plan.jobs[1].command_begin == 2 && plan.jobs[1].command_count == 2, "second range was not contiguous");
+    Expect(plan.jobs[2].command_begin == 4 && plan.jobs[2].command_count == 1, "third range lost the remainder");
+}
+
+void MixedSerialLayerRemainsOneOrderedJob() {
+    const std::vector<Type> eligible{Type::ClearResource, Type::ClearResource};
+    const std::vector<Type> mixed{Type::BufferToBuffer, Type::Scope, Type::BufferToBuffer};
+    const std::vector<ParallelRecordLayerDescription> layers{Describe(eligible), Describe(mixed)};
+
+    const ParallelRecordPlan plan = BuildParallelRecordPlan(layers, 4, 1);
+    Expect(plan.CanRecordInParallel(), "serial neighbor disabled an eligible layer");
+    Expect(plan.layers.size() == 2, "layer descriptions were not preserved");
+    Expect(plan.layers[0].parallel && plan.layers[0].job_count == 2, "eligible layer was not split");
+    Expect(!plan.layers[1].parallel && plan.layers[1].job_count == 1, "mixed layer was partially split");
+    Expect(plan.jobs.size() == 3, "mixed plan emitted the wrong job count");
+    Expect(plan.jobs[2].layer_index == 1 && plan.jobs[2].command_begin == 0 &&
+               plan.jobs[2].command_count == mixed.size(),
+           "serial layer did not remain a single contiguous job");
+}
+
+void RuntimeConstraintForcesAnOtherwiseEligibleLayerSerial() {
+    const std::vector<Type> forced{Type::ShaderDispatch, Type::ShaderDispatch};
+    const std::vector<Type> eligible{Type::ClearResource, Type::ClearResource};
+    const std::vector<ParallelRecordLayerDescription> layers{
+        DescribeForcedSerial(forced), Describe(eligible)
+    };
+
+    const ParallelRecordPlan plan = BuildParallelRecordPlan(layers, 4, 1);
+    Expect(plan.CanRecordInParallel(), "forced serial neighbor disabled the eligible layer");
+    Expect(!plan.layers[0].parallel && plan.layers[0].job_count == 1,
+           "runtime-constrained layer was split");
+    Expect(plan.layers[1].parallel && plan.layers[1].job_count == 2,
+           "unconstrained eligible layer was not split");
+}
+
+void OrderedSingletonLayersFormAParallelRecordingWave() {
+    const std::vector<Type> first{Type::SetDrawState};
+    const std::vector<Type> second{Type::ClearResource};
+    const std::vector<ParallelRecordLayerDescription> layers{
+        Describe(first), Describe(second)
+    };
+
+    const ParallelRecordPlan plan = BuildParallelRecordPlan(layers, 4, 1);
+    Expect(plan.CanRecordInParallel(), "ordered singleton layers did not form a recording wave");
+    Expect(plan.parallel_layer_count == 2, "singleton wave lost an eligible layer");
+    Expect(plan.jobs.size() == 2, "singleton wave emitted the wrong job count");
+    Expect(plan.jobs[0].layer_index == 0 && plan.jobs[0].command_count == 1,
+           "first singleton job was not stable");
+    Expect(plan.jobs[1].layer_index == 1 && plan.jobs[1].command_count == 1,
+           "second singleton job was not stable");
+
+    const std::vector<ParallelRecordLayerDescription> one_layer{Describe(first)};
+    const ParallelRecordPlan one_job = BuildParallelRecordPlan(one_layer, 4, 1);
+    Expect(one_job.fallback_reason == ParallelRecordFallbackReason::InsufficientConcurrency,
+           "a lone singleton paid parallel dispatch overhead");
+}
+
+void SerialIslandBreaksSingletonRecordingWaves() {
+    const std::vector<Type> first{Type::SetDrawState};
+    const std::vector<Type> serial{Type::Scope};
+    const std::vector<Type> third{Type::ClearResource};
+    const std::vector<ParallelRecordLayerDescription> isolated{
+        Describe(first), Describe(serial), Describe(third)
+    };
+
+    const ParallelRecordPlan no_overlap = BuildParallelRecordPlan(isolated, 4, 1);
+    Expect(no_overlap.fallback_reason == ParallelRecordFallbackReason::InsufficientConcurrency,
+           "serial island let isolated singleton jobs advertise false concurrency");
+
+    const std::vector<Type> wide{Type::BufferToBuffer, Type::BufferToBuffer};
+    const std::vector<ParallelRecordLayerDescription> mixed{
+        Describe(first), Describe(serial), Describe(wide)
+    };
+    const ParallelRecordPlan retained = BuildParallelRecordPlan(mixed, 4, 1);
+    Expect(retained.CanRecordInParallel(), "profitable wave was lost with an isolated neighbor");
+    Expect(!retained.layers[0].parallel && retained.layers[0].job_count == 1,
+           "isolated singleton was not demoted to coordinator recording");
+    Expect(retained.layers[2].parallel && retained.layers[2].job_count == 2,
+           "profitable wave was not retained");
+}
+
+void InvalidInputsFailClosedWithoutPublishingJobs() {
+    const std::vector<Type> eligible{Type::TextureToTexture, Type::TextureToTexture};
+    const std::vector<ParallelRecordLayerDescription> layers{Describe(eligible)};
+
+    const ParallelRecordPlan one_worker = BuildParallelRecordPlan(layers, 1, 1);
+    Expect(one_worker.fallback_reason == ParallelRecordFallbackReason::WorkerCountTooSmall,
+           "one worker reported the wrong fallback");
+    Expect(one_worker.jobs.empty() && one_worker.layers.empty(), "one-worker fallback published work");
+
+    const std::vector<Type> serial{Type::Scope, Type::Custom};
+    const std::vector<ParallelRecordLayerDescription> serial_layers{Describe(serial)};
+    const ParallelRecordPlan no_eligible = BuildParallelRecordPlan(serial_layers, 2, 1);
+    Expect(no_eligible.fallback_reason == ParallelRecordFallbackReason::NoEligibleLayer,
+           "serial-only input reported the wrong fallback");
+    Expect(no_eligible.jobs.empty() && no_eligible.layers.empty(), "serial-only fallback published work");
+
+    const std::vector<Type> invalid{Type::BufferToBuffer, Type::Count};
+    const std::vector<ParallelRecordLayerDescription> invalid_layers{Describe(invalid)};
+    const ParallelRecordPlan invalid_plan = BuildParallelRecordPlan(invalid_layers, 2, 1);
+    Expect(invalid_plan.fallback_reason == ParallelRecordFallbackReason::InvalidCommandType,
+           "Count sentinel reported the wrong fallback");
+    Expect(invalid_plan.jobs.empty() && invalid_plan.layers.empty(), "invalid command published work");
+
+    const std::vector<uint32_t> wrong_work_units{1};
+    const std::vector<ParallelRecordLayerDescription> invalid_work{
+        DescribeWeighted(eligible, wrong_work_units)
+    };
+    const ParallelRecordPlan invalid_work_plan = BuildParallelRecordPlan(invalid_work, 2, 1);
+    Expect(
+        invalid_work_plan.fallback_reason == ParallelRecordFallbackReason::InvalidWorkDescription,
+        "mismatched work-unit descriptions did not fail closed"
+    );
+    Expect(invalid_work_plan.jobs.empty(), "invalid work description published jobs");
+}
+
+void StableMergeOrderReconstructsOriginalLayerOrder() {
+    const std::vector<Type> first(5, Type::ShaderDispatch);
+    const std::vector<Type> serial{Type::Scope};
+    const std::vector<Type> third(4, Type::MultiDraw);
+    const std::vector<ParallelRecordLayerDescription> layers{
+        Describe(first), Describe(serial), Describe(third)
+    };
+
+    const ParallelRecordPlan first_plan  = BuildParallelRecordPlan(layers, 3, 1);
+    const ParallelRecordPlan second_plan = BuildParallelRecordPlan(layers, 3, 1);
+    Expect(first_plan.CanRecordInParallel() && second_plan.CanRecordInParallel(), "stable plan did not build");
+    Expect(first_plan.jobs.size() == second_plan.jobs.size(), "same input produced a different job count");
+
+    std::vector<std::pair<uint32_t, uint32_t>> merged;
+    for (size_t index = 0; index < first_plan.jobs.size(); ++index) {
+        const ParallelRecordJobRange& lhs = first_plan.jobs[index];
+        const ParallelRecordJobRange& rhs = second_plan.jobs[index];
+        Expect(lhs.layer_index == rhs.layer_index && lhs.command_begin == rhs.command_begin &&
+                   lhs.command_count == rhs.command_count,
+               "same input produced unstable ranges");
+        for (uint32_t command_index = lhs.command_begin; command_index < lhs.CommandEnd(); ++command_index) {
+            merged.emplace_back(lhs.layer_index, command_index);
+        }
+    }
+
+    std::vector<std::pair<uint32_t, uint32_t>> expected;
+    for (uint32_t layer_index = 0; layer_index < layers.size(); ++layer_index) {
+        for (uint32_t command_index = 0; command_index < layers[layer_index].command_types.size(); ++command_index) {
+            expected.emplace_back(layer_index, command_index);
+        }
+    }
+    Expect(merged == expected, "ordered job merge changed command order");
+}
+
+void WorkGranularityGateAmortizesWorkerAndPrimaryOverhead() {
+    const std::vector<Type> below_floor(7, Type::BufferToBuffer);
+    const std::vector<ParallelRecordLayerDescription> below_floor_layers{Describe(below_floor)};
+    const ParallelRecordPlan below_floor_plan = BuildParallelRecordPlan(below_floor_layers, 4, 8);
+    Expect(
+        below_floor_plan.fallback_reason == ParallelRecordFallbackReason::InsufficientWork,
+        "sub-threshold layer did not report insufficient work"
+    );
+
+    const std::vector<Type> too_small(15, Type::BufferToBuffer);
+    const std::vector<ParallelRecordLayerDescription> small_layers{Describe(too_small)};
+    const ParallelRecordPlan rejected = BuildParallelRecordPlan(small_layers, 4, 8);
+    Expect(
+        rejected.fallback_reason == ParallelRecordFallbackReason::InsufficientConcurrency,
+        "one amortized job did not report insufficient concurrency"
+    );
+    Expect(rejected.jobs.empty(), "sub-threshold layer published worker jobs");
+
+    const std::vector<Type> enough(16, Type::BufferToBuffer);
+    const std::vector<ParallelRecordLayerDescription> enough_layers{Describe(enough)};
+    const ParallelRecordPlan accepted = BuildParallelRecordPlan(enough_layers, 4, 8);
+    Expect(accepted.CanRecordInParallel(), "two amortized worker jobs were rejected");
+    Expect(accepted.jobs.size() == 2, "minimum work gate emitted the wrong job count");
+    Expect(
+        accepted.jobs[0].command_count == 8 && accepted.jobs[1].command_count == 8,
+        "minimum work gate did not preserve eight commands per worker job"
+    );
+}
+
+void WeightedWorkPreservesHeavyCommandsWithoutInventingConcurrency() {
+    const std::vector<Type> heavy{Type::MultiDraw};
+    const std::vector<uint32_t> heavy_work{96};
+    const std::vector<ParallelRecordLayerDescription> one_heavy{
+        DescribeWeighted(heavy, heavy_work)
+    };
+    const ParallelRecordPlan isolated = BuildParallelRecordPlan(one_heavy, 4, 64);
+    Expect(
+        isolated.fallback_reason == ParallelRecordFallbackReason::InsufficientConcurrency,
+        "an isolated heavy command advertised false parallelism"
+    );
+
+    const std::vector<ParallelRecordLayerDescription> heavy_wave{
+        DescribeWeighted(heavy, heavy_work), DescribeWeighted(heavy, heavy_work)
+    };
+    const ParallelRecordPlan wave = BuildParallelRecordPlan(heavy_wave, 4, 64);
+    Expect(wave.CanRecordInParallel(), "two heavy singleton commands did not form a wave");
+    Expect(wave.jobs.size() == 2, "heavy singleton wave emitted the wrong job count");
+    Expect(
+        wave.jobs[0].command_count == 1 && wave.jobs[0].work_units == 96 &&
+            wave.jobs[1].command_count == 1 && wave.jobs[1].work_units == 96,
+        "heavy singleton work was split or lost"
+    );
+
+    const std::vector<uint32_t> light_work{3};
+    const std::vector<ParallelRecordLayerDescription> light_wave{
+        DescribeWeighted(heavy, light_work), DescribeWeighted(heavy, light_work)
+    };
+    const ParallelRecordPlan light = BuildParallelRecordPlan(light_wave, 4, 64);
+    Expect(
+        light.fallback_reason == ParallelRecordFallbackReason::InsufficientWork,
+        "light singleton commands crossed the production work floor"
+    );
+}
+
+void WeightedPartitionsRemainStableAndThresholdSized() {
+    const std::vector<Type> pair(2, Type::MultiDraw);
+    const std::vector<uint32_t> balanced_work{64, 64};
+    const std::vector<ParallelRecordLayerDescription> balanced_layers{
+        DescribeWeighted(pair, balanced_work)
+    };
+    const ParallelRecordPlan balanced = BuildParallelRecordPlan(balanced_layers, 4, 64);
+    Expect(balanced.CanRecordInParallel(), "two threshold-sized commands were rejected");
+    Expect(balanced.jobs.size() == 2, "balanced weighted input emitted the wrong job count");
+    Expect(
+        balanced.jobs[0].command_begin == 0 && balanced.jobs[0].command_count == 1 &&
+            balanced.jobs[0].work_units == 64 && balanced.jobs[1].command_begin == 1 &&
+            balanced.jobs[1].command_count == 1 && balanced.jobs[1].work_units == 64,
+        "balanced weighted partitions were not stable"
+    );
+
+    const std::vector<Type> uneven_types(3, Type::MultiDraw);
+    const std::vector<uint32_t> uneven_work{100, 1, 27};
+    const std::vector<Type> neighbor_type{Type::MultiDraw};
+    const std::vector<uint32_t> neighbor_work{64};
+    const std::vector<ParallelRecordLayerDescription> uneven_layers{
+        DescribeWeighted(uneven_types, uneven_work),
+        DescribeWeighted(neighbor_type, neighbor_work),
+    };
+    const ParallelRecordPlan uneven = BuildParallelRecordPlan(uneven_layers, 4, 64);
+    Expect(uneven.CanRecordInParallel(), "valid uneven work was rejected");
+    Expect(uneven.layers[0].job_count == 1, "sub-threshold tail formed an invalid job");
+    Expect(
+        uneven.jobs[0].command_begin == 0 && uneven.jobs[0].command_count == 3 &&
+            uneven.jobs[0].work_units == 128,
+        "uneven work was not deterministically coalesced"
+    );
+}
+
+void LargeWeightedLayerKeepsStableLinearSuffixPlanning() {
+    constexpr uint32_t command_count = 8192;
+    const std::vector<Type> types(command_count, Type::BufferToBuffer);
+    const std::vector<uint32_t> work(command_count, 1u);
+    const std::vector<ParallelRecordLayerDescription> layers{
+        DescribeWeighted(types, work)
+    };
+
+    const ParallelRecordPlan plan = BuildParallelRecordPlan(layers, 32, 64);
+    Expect(plan.CanRecordInParallel(), "large weighted layer did not produce a plan");
+    Expect(plan.jobs.size() == 32, "large weighted layer did not use the worker cap");
+    uint32_t next_command = 0;
+    uint64_t total_work = 0;
+    for (const ParallelRecordJobRange& job : plan.jobs) {
+        Expect(job.command_begin == next_command, "large weighted ranges were not contiguous");
+        Expect(job.command_count != 0, "large weighted plan emitted an empty range");
+        Expect(job.work_units >= 64, "large weighted plan emitted a sub-threshold range");
+        next_command = job.CommandEnd();
+        total_work += job.work_units;
+    }
+    Expect(next_command == command_count, "large weighted plan lost commands");
+    Expect(total_work == command_count, "large weighted plan lost work units");
+}
+
+void ExternalJoinUsesRealConcurrentWorkers() {
+    ExternalCpuJoinPool pool(2);
+    std::mutex              mutex;
+    std::condition_variable cv;
+    uint32_t                arrived{0};
+
+    std::vector<ExternalCpuJoinPool::Job> jobs;
+    for (uint32_t index = 0; index < 2; ++index) {
+        jobs.emplace_back([&] {
+            std::unique_lock lock(mutex);
+            ++arrived;
+            cv.notify_all();
+            if (!cv.wait_for(lock, 2s, [&] { return arrived == 2; })) {
+                throw std::runtime_error("jobs did not overlap on distinct workers");
+            }
+        });
+    }
+
+    Expect(pool.RunAndWait(jobs) == ExternalJoinResult::Completed, "concurrent worker join failed");
+    Expect(arrived == 2, "concurrent worker join lost a job");
+}
+
+void WorkerFailureKeepsSubmissionGateClosed() {
+    ExternalCpuJoinPool pool(2);
+    std::atomic<uint32_t> completed_recorders{0};
+    std::atomic<uint32_t> submission_gate{0};
+
+    std::vector<ExternalCpuJoinPool::Job> jobs;
+    jobs.emplace_back([] { throw std::runtime_error("injected recorder failure"); });
+    jobs.emplace_back([&] { completed_recorders.fetch_add(1, std::memory_order_relaxed); });
+
+    const ExternalJoinResult result = pool.RunAndWait(jobs);
+    if (result == ExternalJoinResult::Completed) {
+        submission_gate.store(1, std::memory_order_release);
+    }
+
+    Expect(result == ExternalJoinResult::Failed, "recorder failure did not fail the joined batch");
+    Expect(completed_recorders.load(std::memory_order_acquire) == 1, "failed batch did not drain accepted work");
+    Expect(submission_gate.load(std::memory_order_acquire) == 0, "failed recording opened the submit gate");
+}
+
+} // namespace
+
+int main() {
+    try {
+        EligibleLayerUsesStableBalancedPartitions();
+        MixedSerialLayerRemainsOneOrderedJob();
+        RuntimeConstraintForcesAnOtherwiseEligibleLayerSerial();
+        OrderedSingletonLayersFormAParallelRecordingWave();
+        SerialIslandBreaksSingletonRecordingWaves();
+        InvalidInputsFailClosedWithoutPublishingJobs();
+        StableMergeOrderReconstructsOriginalLayerOrder();
+        WorkGranularityGateAmortizesWorkerAndPrimaryOverhead();
+        WeightedWorkPreservesHeavyCommandsWithoutInventingConcurrency();
+        WeightedPartitionsRemainStableAndThresholdSized();
+        LargeWeightedLayerKeepsStableLinearSuffixPlanning();
+        ExternalJoinUsesRealConcurrentWorkers();
+        WorkerFailureKeepsSubmissionGateClosed();
+        std::cout << "RHI parallel record plan tests passed\n";
+        return 0;
+    } catch (const std::exception& error) {
+        std::cerr << "RHI parallel record plan test failed: " << error.what() << '\n';
+        return 1;
+    }
+}

--- a/source/test/RHIParallelRecordVulkanTest.cpp
+++ b/source/test/RHIParallelRecordVulkanTest.cpp
@@ -1,0 +1,541 @@
+#include "Core.h"
+#include "config/ConfigManager.h"
+#include "log/LogSystem.h"
+#include "rhi/RHI.h"
+#include "rhi/RHICommand.h"
+#include "rhi/RHIExecutor.h"
+#include "taskgraph/TaskSystem.h"
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <exception>
+#include <filesystem>
+#include <iostream>
+#include <mutex>
+#include <span>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <vector>
+
+using namespace Moer;
+using namespace Moer::Render;
+
+namespace {
+
+constexpr size_t kElementCount = 64;
+constexpr uint32 kIterations   = 24;
+constexpr uint32 kHeavyCopiesPerWave = 48;
+constexpr uint32 kHeavyCopyCount = kHeavyCopiesPerWave * 2;
+
+template<size_t N>
+Array<byte> OwnedBytes(const std::array<uint32, N>& _values) {
+    Array<byte> bytes(sizeof(uint32) * N);
+    std::memcpy(bytes.data(), _values.data(), bytes.size());
+    return bytes;
+}
+
+template<size_t N>
+std::span<byte> WritableBytes(std::array<uint32, N>& _values) {
+    return {
+        reinterpret_cast<byte*>(_values.data()),
+        sizeof(uint32) * N,
+    };
+}
+
+bool HasArgument(int _argc, const char** _argv, std::string_view _argument) {
+    for (int index = 1; index < _argc; ++index) {
+        if (std::string_view(_argv[index]) == _argument) {
+            return true;
+        }
+    }
+    return false;
+}
+
+void ValidateArguments(int _argc, const char** _argv) {
+    for (int index = 1; index < _argc; ++index) {
+        const std::string_view argument = _argv[index];
+        if (argument != "--parallel" && argument != "--inject-worker-failure" &&
+            argument != "--production-gate" && argument != "--production-heavy") {
+            throw std::invalid_argument("unsupported argument: " + std::string(argument));
+        }
+    }
+    if (HasArgument(_argc, _argv, "--inject-worker-failure") &&
+        !HasArgument(_argc, _argv, "--parallel")) {
+        throw std::invalid_argument("--inject-worker-failure requires --parallel");
+    }
+    if (HasArgument(_argc, _argv, "--production-gate") &&
+        !HasArgument(_argc, _argv, "--parallel")) {
+        throw std::invalid_argument("--production-gate requires --parallel");
+    }
+    if (HasArgument(_argc, _argv, "--production-heavy") &&
+        !HasArgument(_argc, _argv, "--parallel")) {
+        throw std::invalid_argument("--production-heavy requires --parallel");
+    }
+}
+
+void RunOrderedReadback(
+    bool _parallel,
+    bool _inject_worker_failure,
+    bool _production_gate,
+    bool _production_heavy
+) {
+    auto& device = RenderDevice::Get();
+    const EBufferUsageFlags usage =
+        EBufferUsageFlags::TRANSFER_SRC | EBufferUsageFlags::TRANSFER_DST;
+
+    std::array<BufferRef, 4> sources{
+        device.CreateBuffer<uint32>("parallel_order_src_a", kElementCount, usage),
+        device.CreateBuffer<uint32>("parallel_order_src_b", kElementCount, usage),
+        device.CreateBuffer<uint32>("parallel_order_src_c", kElementCount, usage),
+        device.CreateBuffer<uint32>("parallel_order_src_d", kElementCount, usage),
+    };
+    BufferRef destination =
+        device.CreateBuffer<uint32>("parallel_order_destination", kElementCount, usage);
+    std::array<BufferRef, 4> checkpoints{
+        device.CreateBuffer<uint32>("parallel_order_checkpoint_a", kElementCount, usage),
+        device.CreateBuffer<uint32>("parallel_order_checkpoint_b", kElementCount, usage),
+        device.CreateBuffer<uint32>("parallel_order_checkpoint_c", kElementCount, usage),
+        device.CreateBuffer<uint32>("parallel_order_checkpoint_d", kElementCount, usage),
+    };
+    Array<BufferRef> heavy_checkpoints;
+    if (_production_heavy) {
+        heavy_checkpoints.reserve(kHeavyCopyCount);
+        for (uint32 index = 0; index < kHeavyCopyCount; ++index) {
+            heavy_checkpoints.push_back(device.CreateBuffer<uint32>(
+                "parallel_heavy_checkpoint_" + std::to_string(index), kElementCount, usage
+            ));
+        }
+    }
+
+    for (uint32 iteration = 0; iteration < kIterations; ++iteration) {
+        std::array<std::array<uint32, kElementCount>, 4> values{};
+        for (uint32 source = 0; source < values.size(); ++source) {
+            for (uint32 element = 0; element < kElementCount; ++element) {
+                values[source][element] =
+                    0x10000000u * (source + 1u) + iteration * 4096u + element * 17u + 3u;
+            }
+        }
+        std::array<std::array<uint32, kElementCount>, 4> readbacks{};
+        Array<std::array<uint32, kElementCount>> heavy_readbacks(
+            _production_heavy ? kHeavyCopyCount : 0
+        );
+
+        CommandList commands;
+        for (uint32 source = 0; source < sources.size(); ++source) {
+            commands.CopyFrom(
+                OwnedBytes(values[source]),
+                sources[source]->GetView(),
+                "ParallelOrderUpload"
+            );
+        }
+        if (_production_heavy) {
+            for (uint32 index = 0; index < kHeavyCopiesPerWave; ++index) {
+                commands.CopyFrom(
+                    sources[0]->GetView(),
+                    heavy_checkpoints[index]->GetView(),
+                    "ParallelHeavyWave0"
+                );
+            }
+        }
+
+        // Two dependent safe-copy layers form the first worker wave. Their
+        // completion order is irrelevant; GPU execution must retain A then B.
+        commands.CopyFrom(
+            sources[0]->GetView(), destination->GetView(), "ParallelOrderWave0A"
+        );
+        commands.CopyFrom(
+            destination->GetView(), checkpoints[0]->GetView(), "ParallelOrderCheckpointA"
+        );
+        commands.CopyFrom(
+            sources[1]->GetView(), destination->GetView(), "ParallelOrderWave0B"
+        );
+        commands.CopyFrom(
+            destination->GetView(), checkpoints[1]->GetView(), "ParallelOrderCheckpointB"
+        );
+
+        // A coordinator-only scope is an explicit serial island. The second
+        // worker wave may not start translating before the first wave joins.
+        commands.PushScope("ParallelOrderSerialIsland", {0.8f, 0.3f, 0.1f, 1.0f});
+        if (_production_heavy) {
+            for (uint32 index = kHeavyCopiesPerWave; index < kHeavyCopyCount; ++index) {
+                commands.CopyFrom(
+                    sources[2]->GetView(),
+                    heavy_checkpoints[index]->GetView(),
+                    "ParallelHeavyWave1"
+                );
+            }
+        }
+        commands.CopyFrom(
+            sources[2]->GetView(), destination->GetView(), "ParallelOrderWave1C"
+        );
+        commands.CopyFrom(
+            destination->GetView(), checkpoints[2]->GetView(), "ParallelOrderCheckpointC"
+        );
+        commands.CopyFrom(
+            sources[3]->GetView(), destination->GetView(), "ParallelOrderWave1D"
+        );
+        commands.CopyFrom(
+            destination->GetView(), checkpoints[3]->GetView(), "ParallelOrderCheckpointD"
+        );
+        commands.PopScope();
+
+        for (uint32 checkpoint = 0; checkpoint < checkpoints.size(); ++checkpoint) {
+            commands.CopyFrom(
+                checkpoints[checkpoint]->GetView(),
+                WritableBytes(readbacks[checkpoint]),
+                "ParallelOrderReadback"
+            );
+        }
+        if (_production_heavy) {
+            for (uint32 index = 0; index < kHeavyCopyCount; ++index) {
+                commands.CopyFrom(
+                    heavy_checkpoints[index]->GetView(),
+                    WritableBytes(heavy_readbacks[index]),
+                    "ParallelHeavyReadback"
+                );
+            }
+        }
+
+        RHIExecutor::Get().Submit(
+            EQueueType::Graphics,
+            commands.Submit(),
+            ERHIExecSubmitFlags::FlushGPU
+        );
+        RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
+
+        for (size_t checkpoint = 0; checkpoint < readbacks.size(); ++checkpoint) {
+            if (readbacks[checkpoint] == values[checkpoint]) {
+                continue;
+            }
+            for (size_t index = 0; index < readbacks[checkpoint].size(); ++index) {
+                if (readbacks[checkpoint][index] != values[checkpoint][index]) {
+                    throw std::runtime_error(
+                        "ordered GPU checkpoint mismatch at iteration=" +
+                        std::to_string(iteration) + " checkpoint=" +
+                        std::to_string(checkpoint) + " index=" + std::to_string(index) +
+                        " expected=" + std::to_string(values[checkpoint][index]) +
+                        " actual=" + std::to_string(readbacks[checkpoint][index])
+                    );
+                }
+            }
+            throw std::runtime_error("ordered GPU checkpoint mismatch");
+        }
+        for (size_t checkpoint = 0; checkpoint < heavy_readbacks.size(); ++checkpoint) {
+            const size_t source = checkpoint < kHeavyCopiesPerWave ? 0 : 2;
+            if (heavy_readbacks[checkpoint] != values[source]) {
+                throw std::runtime_error(
+                    "heavy weighted checkpoint mismatch at iteration=" +
+                    std::to_string(iteration) + " checkpoint=" + std::to_string(checkpoint)
+                );
+            }
+        }
+    }
+
+    LOG_INFO(
+        "[TESTCASE][PASS] name=ParallelRecordOrderedReadback mode={} worker_fault={} "
+        "production_gate={} production_heavy={} iterations={}",
+        _parallel ? "parallel" : "serial",
+        _inject_worker_failure,
+        _production_gate,
+        _production_heavy,
+        kIterations
+    );
+}
+
+void RunUpperTopologyBatch() {
+    auto& device = RenderDevice::Get();
+    constexpr size_t element_count = 16;
+    const EBufferUsageFlags usage =
+        EBufferUsageFlags::TRANSFER_SRC | EBufferUsageFlags::TRANSFER_DST;
+    BufferRef source = device.CreateBuffer<uint32>("topology_source", element_count, usage);
+    BufferRef destination =
+        device.CreateBuffer<uint32>("topology_destination", element_count, usage);
+
+    std::array<uint32, element_count> expected{};
+    std::array<uint32, element_count> readback{};
+    for (uint32 index = 0; index < expected.size(); ++index) {
+        expected[index] = 0x71000000u + index * 31u;
+    }
+
+    std::mutex callback_mutex{};
+    std::vector<uint32> callback_order{};
+    auto append_callback = [&](uint32 value) {
+        return [&, value] {
+            std::lock_guard lock(callback_mutex);
+            callback_order.push_back(value);
+        };
+    };
+
+    Array<CommandList> command_lists{};
+    command_lists.emplace_back(EQueueType::Graphics);
+    command_lists.back().CopyFrom(OwnedBytes(expected), source->GetView(), "TopologyUpload");
+    command_lists.back().AddCallback(append_callback(0));
+
+    command_lists.emplace_back(EQueueType::Graphics);
+    command_lists.back().SetTranslateExecutionClass(
+        ERHITranslateExecutionClass::SerialControl
+    );
+    command_lists.back().CopyFrom(
+        source->GetView(), destination->GetView(), "TopologySerialControlCopy"
+    );
+    command_lists.back().AddCallback(append_callback(1));
+
+    command_lists.emplace_back(EQueueType::Graphics);
+    command_lists.back().CopyFrom(
+        destination->GetView(), WritableBytes(readback), "TopologyReadback"
+    );
+    command_lists.back().AddCallback(append_callback(2));
+
+    // Empty command streams with observable completion work remain topology
+    // nodes and must retire after every prior source submission.
+    command_lists.emplace_back(EQueueType::Graphics);
+    command_lists.back().SetTranslateExecutionClass(
+        ERHITranslateExecutionClass::SerialControl
+    );
+    command_lists.back().AddCallback(append_callback(3));
+
+    RHIExecutor::Get().Submit(
+        std::move(command_lists), ERHIExecSubmitFlags::FlushGPU
+    );
+    RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
+
+    if (readback != expected) {
+        throw std::runtime_error("upper topology batch GPU ordering mismatch");
+    }
+    const std::vector<uint32> expected_callbacks{0, 1, 2, 3};
+    if (callback_order != expected_callbacks) {
+        throw std::runtime_error("upper topology batch callback ordering mismatch");
+    }
+    LOG_INFO(
+        "[TESTCASE][PASS] name=UpperSubmissionTopology sources=4 serial_control=2 "
+        "empty_side_effect=1"
+    );
+}
+
+void RunPendingSourceTopologyBatch() {
+    auto& device = RenderDevice::Get();
+    constexpr size_t element_count = 16;
+    const EBufferUsageFlags usage =
+        EBufferUsageFlags::TRANSFER_SRC | EBufferUsageFlags::TRANSFER_DST;
+    BufferRef source =
+        device.CreateBuffer<uint32>("topology_pending_source", element_count, usage);
+    BufferRef destination =
+        device.CreateBuffer<uint32>("topology_pending_destination", element_count, usage);
+
+    std::array<uint32, element_count> expected{};
+    std::array<uint32, element_count> readback{};
+    for (uint32 index = 0; index < expected.size(); ++index) {
+        expected[index] = 0x39000000u + index * 17u;
+    }
+
+    std::mutex          callback_mutex{};
+    std::vector<uint32> callback_order{};
+    auto append_callback = [&](uint32 value) {
+        return [&, value] {
+            std::lock_guard lock(callback_mutex);
+            callback_order.push_back(value);
+        };
+    };
+
+    Array<CommandList> pass_lists{};
+    pass_lists.emplace_back(EQueueType::Graphics);
+    pass_lists.back().CopyFrom(OwnedBytes(expected), source->GetView(), "PendingPassUpload");
+    pass_lists.back().AddCallback(append_callback(0));
+
+    pass_lists.emplace_back(EQueueType::Graphics);
+    pass_lists.back().CopyFrom(
+        source->GetView(), destination->GetView(), "PendingPassCopy"
+    );
+    pass_lists.back().AddCallback(append_callback(1));
+
+    pass_lists.emplace_back(EQueueType::Graphics);
+    pass_lists.back().CopyFrom(
+        destination->GetView(), WritableBytes(readback), "PendingPassReadback"
+    );
+    pass_lists.back().AddCallback(append_callback(2));
+
+    pass_lists.emplace_back(EQueueType::Graphics);
+    pass_lists.back().AddCallback(append_callback(3));
+
+    for (size_t index = 0; index < pass_lists.size(); ++index) {
+        CmdSubmit pass_submit = pass_lists[index]
+                                    .SetTranslateExecutionClass(
+                                        ERHITranslateExecutionClass::SerialControl
+                                    )
+                                    .Submit();
+        RHIExecutor::Get().Submit(
+            EQueueType::Graphics,
+            std::move(pass_submit),
+            index + 1 == pass_lists.size() ? ERHIExecSubmitFlags::FlushGPU :
+                                             ERHIExecSubmitFlags::None
+        );
+    }
+    RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
+
+    if (readback != expected) {
+        throw std::runtime_error("pending-source topology GPU ordering mismatch");
+    }
+    if (callback_order != std::vector<uint32>{0, 1, 2, 3}) {
+        throw std::runtime_error("pending-source topology callback ordering mismatch");
+    }
+    LOG_INFO(
+        "[TESTCASE][PASS] name=PendingSourceSubmissionTopology sources=4 "
+        "publish=final-source"
+    );
+}
+
+void RunCrossQueueTopologyBatch() {
+    auto& device = RenderDevice::Get();
+    constexpr size_t element_count = 32;
+    const EBufferUsageFlags usage =
+        EBufferUsageFlags::TRANSFER_SRC | EBufferUsageFlags::TRANSFER_DST;
+    BufferRef source = device.CreateBuffer<uint32>("topology_cross_source", element_count, usage);
+    BufferRef compute_stage =
+        device.CreateBuffer<uint32>("topology_cross_compute", element_count, usage);
+    BufferRef copy_stage =
+        device.CreateBuffer<uint32>("topology_cross_copy", element_count, usage);
+
+    std::array<uint32, element_count> expected{};
+    std::array<uint32, element_count> readback{};
+    for (uint32 index = 0; index < expected.size(); ++index) {
+        expected[index] = 0x53000000u + index * 43u;
+    }
+
+    Array<CommandList> command_lists{};
+    command_lists.emplace_back(EQueueType::Graphics);
+    command_lists.back().CopyFrom(
+        OwnedBytes(expected), source->GetView(), "TopologyCrossQueueUpload"
+    );
+    command_lists.back().ExportResourcesToQueue(
+        EQueueType::Compute,
+        {},
+        Array<ExportBuffer>{{source->GetView(), EBufferState::TRANSFER}}
+    );
+
+    command_lists.emplace_back(EQueueType::Compute);
+    command_lists.back().ImportResourcesFromQueue(
+        EQueueType::Graphics,
+        {},
+        Array<ImportBuffer>{{source->GetView(), EBufferState::TRANSFER}}
+    );
+    command_lists.back().CopyFrom(
+        source->GetView(), compute_stage->GetView(), "TopologyCrossQueueCompute"
+    );
+    command_lists.back().ExportResourcesToQueue(
+        EQueueType::Copy,
+        {},
+        Array<ExportBuffer>{{compute_stage->GetView(), EBufferState::TRANSFER}}
+    );
+
+    command_lists.emplace_back(EQueueType::Copy);
+    command_lists.back().ImportResourcesFromQueue(
+        EQueueType::Compute,
+        {},
+        Array<ImportBuffer>{{compute_stage->GetView(), EBufferState::TRANSFER}}
+    );
+    command_lists.back().CopyFrom(
+        compute_stage->GetView(), copy_stage->GetView(), "TopologyCrossQueueCopy"
+    );
+    command_lists.back().ExportResourcesToQueue(
+        EQueueType::Graphics,
+        {},
+        Array<ExportBuffer>{{copy_stage->GetView(), EBufferState::TRANSFER}}
+    );
+
+    command_lists.emplace_back(EQueueType::Graphics);
+    command_lists.back().ImportResourcesFromQueue(
+        EQueueType::Copy,
+        {},
+        Array<ImportBuffer>{{copy_stage->GetView(), EBufferState::TRANSFER}}
+    );
+    command_lists.back().CopyFrom(
+        copy_stage->GetView(), WritableBytes(readback), "TopologyCrossQueueReadback"
+    );
+
+    for (CommandList& command_list : command_lists) {
+        const EQueueType queue = command_list.GetQueueType();
+        RHIExecutor::Get().Submit(
+            queue, command_list.Submit(), ERHIExecSubmitFlags::FlushGPU
+        );
+    }
+    RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
+
+    if (readback != expected) {
+        throw std::runtime_error("cross-queue topology GPU ordering mismatch");
+    }
+    LOG_INFO(
+        "[TESTCASE][PASS] name=CrossQueueSubmissionTopology "
+        "batches=4 queues=Graphics,Compute,Copy,Graphics ownership=explicit"
+    );
+}
+
+} // namespace
+
+int main(int argc, const char** argv) {
+    bool task_system_initialized = false;
+    bool render_device_initialized = false;
+    try {
+        ValidateArguments(argc, argv);
+        const bool parallel = HasArgument(argc, argv, "--parallel");
+        const bool inject_worker_failure =
+            HasArgument(argc, argv, "--inject-worker-failure");
+        const bool production_heavy = HasArgument(argc, argv, "--production-heavy");
+        const bool production_gate =
+            HasArgument(argc, argv, "--production-gate") || production_heavy;
+
+        LogSystem::Init();
+        ConfigManager::GetInstance().Init(std::filesystem::current_path());
+        TaskSystem::Init();
+        task_system_initialized = true;
+
+        RenderDevice::Init(DeviceInitInfo{
+            .rhi_type         = ERHIType::Vulkan,
+            .name             = "RHIParallelRecordVulkanTest",
+            .rhi_api_version  = "1.3",
+            .rhi_thread       = true,
+            .rhi_bypass       = false,
+            .parallel_recording = parallel,
+            .parallel_record_workers = 4,
+            .parallel_record_verify = parallel,
+            .parallel_record_min_work_units_per_job = production_gate ? 64u : 1u,
+            .parallel_record_worker_throw_trigger = inject_worker_failure ? 1u : 0u,
+        });
+        render_device_initialized = true;
+
+        RunOrderedReadback(
+            parallel, inject_worker_failure, production_gate, production_heavy
+        );
+        RunUpperTopologyBatch();
+        RunPendingSourceTopologyBatch();
+        RunCrossQueueTopologyBatch();
+
+        RenderDevice::Dispose();
+        render_device_initialized = false;
+        TaskSystem::ShutDown();
+        task_system_initialized = false;
+        return 0;
+    } catch (const std::exception& error) {
+        std::cerr << "[TESTCASE][EXCEPTION] " << error.what() << std::endl;
+        LOG_ERROR("[TESTCASE][FAIL] name=ParallelRecordOrderedReadback error={}", error.what());
+        if (render_device_initialized) {
+            RenderDevice::Dispose();
+        }
+        if (task_system_initialized) {
+            TaskSystem::ShutDown();
+        }
+        return 1;
+    } catch (...) {
+        std::cerr << "[TESTCASE][EXCEPTION] unknown" << std::endl;
+        LOG_ERROR("[TESTCASE][FAIL] name=ParallelRecordOrderedReadback error=unknown");
+        if (render_device_initialized) {
+            RenderDevice::Dispose();
+        }
+        if (task_system_initialized) {
+            TaskSystem::ShutDown();
+        }
+        return 1;
+    }
+}

--- a/source/test/RHIRecordDiagnosticsTest.cpp
+++ b/source/test/RHIRecordDiagnosticsTest.cpp
@@ -1,4 +1,6 @@
 #include "rhi/RHIRecordDiagnostics.h"
+#include "rhi/RHIBindlessUpdateLifecycle.h"
+#include "rhi/RHIImpl.h"
 
 #include <algorithm>
 #include <array>
@@ -47,6 +49,16 @@ void CapabilityTableIsExplicitAndFailClosed() {
         Command::EType::MultiDraw,
         Command::EType::ClearResource,
     };
+    constexpr std::array expected_parallel_safe{
+        Command::EType::BufferToBuffer,
+        Command::EType::BufferToTexture,
+        Command::EType::TextureToBuffer,
+        Command::EType::TextureToTexture,
+        Command::EType::ShaderDispatch,
+        Command::EType::SetDrawState,
+        Command::EType::MultiDraw,
+        Command::EType::ClearResource,
+    };
     uint32_t serial_count    = 0;
     uint32_t candidate_count = 0;
     uint32_t safe_count      = 0;
@@ -76,15 +88,44 @@ void CapabilityTableIsExplicitAndFailClosed() {
             traits.measurement_candidate == expected_candidate,
             "measurement-candidate command set changed unexpectedly"
         );
+        const bool expected_safe =
+            std::find(expected_parallel_safe.begin(), expected_parallel_safe.end(), type) !=
+            expected_parallel_safe.end();
+        Expect(
+            (traits.capability == RecordCapability::ParallelPrimarySafe) == expected_safe,
+            "parallel-primary-safe command set changed unexpectedly"
+        );
     }
 
     Expect(serial_count > 0, "capability table has no serial fallback entries");
     Expect(candidate_count == 4, "unexpected Phase 9.0 candidate command count");
-    Expect(safe_count == 0, "Phase 9.0 must not claim a command is parallel-safe yet");
+    Expect(safe_count == expected_parallel_safe.size(), "unexpected parallel-safe command count");
     Expect(
         GetCommandRecordTraits(Command::EType::Count).capability == RecordCapability::SerialOnly,
         "invalid command type did not fail closed"
     );
+}
+
+void ParallelReplayContractExcludesSideEffects() {
+    constexpr std::array replay_safe{
+        Command::EType::BufferToBuffer,
+        Command::EType::BufferToTexture,
+        Command::EType::TextureToBuffer,
+        Command::EType::TextureToTexture,
+        Command::EType::ShaderDispatch,
+        Command::EType::SetDrawState,
+        Command::EType::MultiDraw,
+        Command::EType::ClearResource,
+    };
+    for (const Command::EType type : replay_safe) {
+        Expect(IsParallelRecordReplaySafe(type), "parallel whitelist is not replay safe");
+    }
+    Expect(!IsParallelRecordReplaySafe(Command::EType::UploadBuffer),
+           "payload-mutating upload was marked replay safe");
+    Expect(!IsParallelRecordReplaySafe(Command::EType::Scope),
+           "profiler scope was marked replay safe");
+    Expect(!IsParallelRecordReplaySafe(Command::EType::Custom),
+           "host callback command was marked replay safe");
 }
 
 void TopologyDigestIsDeterministicAndOrderSensitive() {
@@ -554,11 +595,204 @@ void UnresolvedAndOpaqueObjectsFailClosed() {
     Expect(!summary.complete, "incomplete section produced a complete serial golden");
 }
 
+class MockBindlessArray final : public BindlessArray {
+public:
+    explicit MockBindlessArray(uint32_t* _discard_count) : discard_count(_discard_count) {}
+
+    Moer::uint AllocateTexture(const TextureView&, Sampler) override { return 0; }
+    Moer::uint AllocateBuffer(BufferView) override { return 0; }
+    void UnbindTexture(Moer::uint) override {}
+    void UnbindBuffer(Moer::uint) override {}
+    Moer::uint64 ArrayHandle() const override { return 0; }
+
+protected:
+    Moer::UniquePtr<Command> CreateUpdateCommand() override { return {}; }
+    void DiscardUpdateCommand(const Moer::Array<UpdateCmd>&) override { ++*discard_count; }
+    void Destroy() override { delete this; }
+
+private:
+    uint32_t* discard_count;
+};
+
+std::unique_ptr<UpdateBindlessArrayCmd> MakeEmptyBindlessUpdate(BindlessArrayRef _array) {
+    return std::make_unique<UpdateBindlessArrayCmd>(
+        std::move(_array),
+        Moer::Array<BindlessArray::UpdateCmd>{},
+        Moer::Array<Moer::byte>{},
+        Moer::Array<std::pair<Moer::uint, Moer::uint>>{},
+        Moer::Array<Moer::byte>{},
+        Moer::Array<std::pair<Moer::uint, Moer::uint>>{},
+        Moer::Array<Moer::byte>{},
+        Moer::Array<std::pair<Moer::uint, Moer::uint>>{}
+    );
+}
+
+void BindlessUpdateLifecycleIsOneShotAndDiscardSafe() {
+    uint32_t discard_count = 0;
+    BindlessArrayRef array(new MockBindlessArray(&discard_count));
+
+    {
+        auto dropped = MakeEmptyBindlessUpdate(array);
+    }
+    Expect(discard_count == 1, "dropped bindless update did not roll back once");
+
+    std::shared_ptr<std::atomic_bool> finalization_token;
+    {
+        auto handed_off = MakeEmptyBindlessUpdate(array);
+        Expect(handed_off->HandOffUpdates(), "first bindless handoff was rejected");
+        Expect(!handed_off->HandOffUpdates(), "bindless update allowed a second handoff");
+        finalization_token = handed_off->UpdateFinalizationToken();
+    }
+    Expect(discard_count == 1, "handed-off bindless update was rolled back on destruction");
+    Expect(
+        !finalization_token->exchange(true),
+        "bindless finalization token was consumed before retirement"
+    );
+    Expect(finalization_token->exchange(true), "bindless finalization token was not one-shot");
+}
+
+void BindlessGenerationClaimsRejectStaleAndSplitOwnership() {
+    constexpr uint64_t token = 17;
+    constexpr uint64_t generation = 41;
+    using State = BindlessUpdateSlotState;
+
+    Expect(
+        ClassifyBindlessUpdateSlot(
+            generation, generation, 0, 0, generation, generation, token
+        ) == State::Original,
+        "unclaimed bindless generation was not recognized as current"
+    );
+    Expect(
+        ClassifyBindlessUpdateSlot(
+            generation + 1,
+            generation + 1,
+            token,
+            token,
+            generation,
+            generation,
+            token
+        ) == State::ClaimedByCommand,
+        "matching bindless lifecycle claim was not recognized"
+    );
+    Expect(
+        ClassifyBindlessUpdateSlot(
+            generation + 1,
+            generation + 1,
+            token + 1,
+            token + 1,
+            generation,
+            generation,
+            token
+        ) == State::Stale,
+        "foreign bindless lifecycle claim was accepted"
+    );
+    Expect(
+        ClassifyBindlessUpdateSlot(
+            generation + 1,
+            generation,
+            token,
+            0,
+            generation,
+            generation,
+            token
+        ) == State::Stale,
+        "split global/typed bindless ownership was accepted"
+    );
+    Expect(
+        ClassifyBindlessUpdateSlot(
+            generation + 2,
+            generation + 2,
+            0,
+            0,
+            generation,
+            generation,
+            token
+        ) == State::Stale,
+        "reused bindless generation was accepted by an old command"
+    );
+    Expect(
+        ClassifyBindlessUpdateSlot(
+            generation, generation, 0, 0, generation, generation, 0
+        ) == State::Stale,
+        "tokenless bindless update was accepted"
+    );
+    constexpr uint64_t exhausted = std::numeric_limits<uint64_t>::max();
+    Expect(
+        ClassifyBindlessUpdateSlot(
+            exhausted, exhausted, token, token, exhausted, exhausted, token
+        ) == State::Stale,
+        "exhausted bindless generation wrapped into a valid claim"
+    );
+
+    using Action = BindlessUpdateFinalizationAction;
+    Expect(
+        GetBindlessUpdateFinalizationAction(State::Original, false, true) == Action::Ignore,
+        "successful bindless allocation was retired"
+    );
+    Expect(
+        GetBindlessUpdateFinalizationAction(State::ClaimedByCommand, true, true) ==
+            Action::Retire,
+        "successful bindless free was not retired at GPU completion"
+    );
+    Expect(
+        GetBindlessUpdateFinalizationAction(State::Original, false, false) == Action::Retire,
+        "rejected bindless allocation was not cancelled"
+    );
+    Expect(
+        GetBindlessUpdateFinalizationAction(State::ClaimedByCommand, true, false) ==
+            Action::Restore,
+        "rejected bindless free was retired without GPU ordering"
+    );
+    Expect(
+        GetBindlessUpdateFinalizationAction(State::Stale, true, false) == Action::Ignore,
+        "stale bindless update was allowed to mutate current ownership"
+    );
+
+    uint64_t array_generation = generation + 1;
+    uint64_t typed_generation = generation + 1;
+    uint64_t array_claim      = token;
+    uint64_t typed_claim      = token;
+    Expect(
+        RollbackBindlessUpdateSlotClaim(
+            array_generation,
+            typed_generation,
+            array_claim,
+            typed_claim,
+            generation,
+            generation,
+            token
+        ),
+        "owned bindless lifecycle claim could not be rolled back"
+    );
+    Expect(
+        array_generation == generation && typed_generation == generation &&
+            array_claim == 0 && typed_claim == 0,
+        "bindless lifecycle rollback did not restore the original generation"
+    );
+    array_generation = generation + 1;
+    typed_generation = generation + 1;
+    array_claim      = token + 1;
+    typed_claim      = token + 1;
+    Expect(
+        !RollbackBindlessUpdateSlotClaim(
+            array_generation,
+            typed_generation,
+            array_claim,
+            typed_claim,
+            generation,
+            generation,
+            token
+        ),
+        "foreign bindless lifecycle claim was rolled back"
+    );
+}
+
 } // namespace
 
 int main() {
     try {
         CapabilityTableIsExplicitAndFailClosed();
+        ParallelReplayContractExcludesSideEffects();
         TopologyDigestIsDeterministicAndOrderSensitive();
         PredictionRejectsSingleUnitAndModelsEligibleLayer();
         StableTokensIgnorePointersAndCaptureAliasTopology();
@@ -568,6 +802,8 @@ int main() {
         QueryDigestIgnoresRingPlacementButPreservesEvents();
         CombinedDigestKeepsSectionIdentity();
         UnresolvedAndOpaqueObjectsFailClosed();
+        BindlessUpdateLifecycleIsOneShotAndDiscardSafe();
+        BindlessGenerationClaimsRejectStaleAndSplitOwnership();
         std::cout << "RHI record diagnostic tests passed\n";
         return 0;
     } catch (const std::exception& error) {

--- a/source/test/RHISubmissionTopologyTest.cpp
+++ b/source/test/RHISubmissionTopologyTest.cpp
@@ -1,0 +1,248 @@
+#include "rhi/RHISubmissionTopology.h"
+
+#include <array>
+#include <iostream>
+#include <stdexcept>
+#include <vector>
+
+using namespace Moer::Render;
+
+namespace {
+
+void Expect(bool _condition, const char* _message) {
+    if (!_condition) {
+        throw std::runtime_error(_message);
+    }
+}
+
+RHISourceSubmitDescription Describe(
+    EQueueType                              _root_queue,
+    size_t                                  _command_count,
+    std::span<const RHISubmitSegment>       _segments = {},
+    ERHITranslateExecutionClass             _execution_class =
+        ERHITranslateExecutionClass::Parallel,
+    bool                                    _has_side_effects = false
+) {
+    return {
+        .root_queue      = _root_queue,
+        .command_count   = _command_count,
+        .segments        = _segments,
+        .execution_class = _execution_class,
+        .has_side_effects = _has_side_effects,
+    };
+}
+
+void StableInputOrderAndKeysArePreserved() {
+    constexpr std::array first_segments{
+        RHISubmitSegment{EQueueType::Graphics, 0, 2},
+        RHISubmitSegment{EQueueType::Compute, 2, 4},
+    };
+    const std::array descriptions{
+        Describe(EQueueType::Graphics, 4, first_segments),
+        Describe(EQueueType::Copy, 1),
+    };
+
+    const RHISubmissionTopologyPlan first = BuildRHISubmissionTopology(descriptions, 42);
+    const RHISubmissionTopologyPlan second = BuildRHISubmissionTopology(descriptions, 42);
+    Expect(first.IsValid() && second.IsValid(), "stable topology input failed to build");
+    Expect(first.source_plans.size() == 2 && first.segments.size() == 3,
+           "topology lost a source or segment");
+
+    for (size_t index = 0; index < first.segments.size(); ++index) {
+        const RHISubmissionSegmentPlan& lhs = first.segments[index];
+        const RHISubmissionSegmentPlan& rhs = second.segments[index];
+        Expect(lhs.key == rhs.key && lhs.source_key == rhs.source_key &&
+                   lhs.segment.queue == rhs.segment.queue &&
+                   lhs.segment.begin == rhs.segment.begin && lhs.segment.end == rhs.segment.end,
+               "identical topology input produced unstable output");
+        Expect(lhs.key == SubmissionKey{42, static_cast<uint32_t>(index)},
+               "submission keys were not monotonic and unique");
+        if (index != 0) {
+            Expect(first.segments[index - 1].key < lhs.key,
+                   "submission keys did not increase in source order");
+        }
+    }
+
+    Expect(first.segments[0].source_key == SourceSubmitKey{42, 0} &&
+               first.segments[1].source_key == SourceSubmitKey{42, 0} &&
+               first.segments[2].source_key == SourceSubmitKey{42, 1},
+           "source-submit identity was not preserved through flattening");
+    Expect(first.source_plans[0].segment_plan_begin == 0 &&
+               first.source_plans[0].segment_plan_count == 2 &&
+               first.source_plans[1].segment_plan_begin == 2 &&
+               first.source_plans[1].segment_plan_count == 1,
+           "source plan did not retain its stable flat segment range");
+}
+
+void CoverageAndBoundaryMetadataAreExplicit() {
+    constexpr std::array segments{
+        RHISubmitSegment{EQueueType::Graphics, 0, 2},
+        RHISubmitSegment{EQueueType::Compute, 2, 5},
+    };
+    const std::array descriptions{
+        Describe(EQueueType::Graphics, 5, segments),
+    };
+
+    const RHISubmissionTopologyPlan plan = BuildRHISubmissionTopology(descriptions, 7);
+    Expect(plan.IsValid() && plan.segments.size() == 2, "covered source did not build");
+    const RHISubmissionSegmentPlan& first = plan.segments.front();
+    const RHISubmissionSegmentPlan& last  = plan.segments.back();
+    Expect(first.segment.queue == EQueueType::Graphics && first.segment.begin == 0 &&
+               first.segment.end == 2 && last.segment.queue == EQueueType::Compute &&
+               last.segment.begin == 2 && last.segment.end == 5,
+           "explicit segment coverage changed during planning");
+    Expect(first.inherit_source_wait_events &&
+               !first.inherit_source_signal_events_and_callbacks &&
+               !first.inherit_source_runtime_payload,
+           "source wait metadata was not isolated to the first segment");
+    Expect(!last.inherit_source_wait_events &&
+               last.inherit_source_signal_events_and_callbacks &&
+               last.inherit_source_runtime_payload,
+           "source completion metadata was not isolated to the last segment");
+
+    const std::array synthesized_descriptions{
+        Describe(EQueueType::Copy, 3),
+    };
+    const RHISubmissionTopologyPlan synthesized =
+        BuildRHISubmissionTopology(synthesized_descriptions, 8);
+    Expect(synthesized.IsValid() && synthesized.segments.size() == 1,
+           "missing segment list was not synthesized");
+    Expect(synthesized.segments[0].segment.queue == EQueueType::Copy &&
+               synthesized.segments[0].segment.begin == 0 &&
+               synthesized.segments[0].segment.end == 3,
+           "synthesized segment did not cover the complete source submit");
+    Expect(synthesized.segments[0].inherit_source_wait_events &&
+               synthesized.segments[0].inherit_source_signal_events_and_callbacks &&
+               synthesized.segments[0].inherit_source_runtime_payload,
+           "single segment did not inherit both source boundaries");
+}
+
+void SerialControlCreatesStableFrontierBarriers() {
+    constexpr std::array two_segments{
+        RHISubmitSegment{EQueueType::Graphics, 0, 1},
+        RHISubmitSegment{EQueueType::Compute, 1, 2},
+    };
+    const std::array descriptions{
+        Describe(EQueueType::Graphics, 1),                         // key 0, parallel
+        Describe(EQueueType::Graphics, 2, two_segments),           // keys 1,2, parallel
+        Describe(EQueueType::Graphics, 1, {},
+                 ERHITranslateExecutionClass::SerialControl),      // key 3
+        Describe(EQueueType::Compute, 1),                          // key 4
+        Describe(EQueueType::Copy, 1),                             // key 5
+        Describe(EQueueType::Graphics, 1, {},
+                 ERHITranslateExecutionClass::SerialControl),      // key 6
+        Describe(EQueueType::Graphics, 1),                         // key 7
+    };
+
+    const RHISubmissionTopologyPlan plan = BuildRHISubmissionTopology(descriptions, 11);
+    Expect(plan.IsValid() && plan.segments.size() == 8, "serial-control topology failed");
+    const auto expect_dependencies = [&](size_t _segment, std::initializer_list<uint32_t> _indices) {
+        const std::vector<SubmissionKey>& dependencies = plan.segments[_segment].dependencies;
+        Expect(dependencies.size() == _indices.size(), "dependency count was incorrect");
+        size_t dependency_index = 0;
+        for (uint32_t index : _indices) {
+            Expect(dependencies[dependency_index++] == SubmissionKey{11, index},
+                   "dependency order or identity was incorrect");
+        }
+    };
+
+    expect_dependencies(0, {});
+    expect_dependencies(1, {});
+    expect_dependencies(2, {});
+    expect_dependencies(3, {0, 1, 2});
+    expect_dependencies(4, {3});
+    expect_dependencies(5, {3});
+    // The previous serial control is retained explicitly even though both
+    // frontier entries already depend on it.
+    expect_dependencies(6, {3, 4, 5});
+    expect_dependencies(7, {6});
+}
+
+void InvalidRangesAndQueuesFailClosed() {
+    constexpr std::array gap_segments{
+        RHISubmitSegment{EQueueType::Graphics, 0, 1},
+        RHISubmitSegment{EQueueType::Graphics, 2, 3},
+    };
+    const std::array gap_description{
+        Describe(EQueueType::Graphics, 3, gap_segments),
+    };
+    const RHISubmissionTopologyPlan gap = BuildRHISubmissionTopology(gap_description, 1);
+    Expect(gap.error == ERHISubmissionTopologyError::NonContiguousSegmentCoverage &&
+               gap.error_source_index == 0 && gap.error_segment_index == 1 &&
+               gap.segments.empty() && gap.source_plans.empty(),
+           "segment gap did not fail closed with a precise error");
+
+    constexpr std::array bad_range_segments{
+        RHISubmitSegment{EQueueType::Graphics, 0, 4},
+    };
+    const std::array bad_range_description{
+        Describe(EQueueType::Graphics, 3, bad_range_segments),
+    };
+    const RHISubmissionTopologyPlan bad_range =
+        BuildRHISubmissionTopology(bad_range_description, 1);
+    Expect(bad_range.error == ERHISubmissionTopologyError::InvalidSegmentRange &&
+               bad_range.segments.empty() && bad_range.source_plans.empty(),
+           "out-of-bounds segment did not fail closed");
+
+    constexpr std::array bad_queue_segments{
+        RHISubmitSegment{EQueueType::Ignore, 0, 1},
+    };
+    const std::array bad_queue_description{
+        Describe(EQueueType::Graphics, 1, bad_queue_segments),
+    };
+    const RHISubmissionTopologyPlan bad_queue =
+        BuildRHISubmissionTopology(bad_queue_description, 1);
+    Expect(bad_queue.error == ERHISubmissionTopologyError::InvalidSegmentQueue &&
+               bad_queue.error_segment_index == 0 && bad_queue.segments.empty(),
+           "invalid segment queue did not fail closed");
+
+    const std::array bad_root_description{
+        Describe(EQueueType::Num, 1),
+    };
+    const RHISubmissionTopologyPlan bad_root =
+        BuildRHISubmissionTopology(bad_root_description, 1);
+    Expect(bad_root.error == ERHISubmissionTopologyError::InvalidRootQueue &&
+               bad_root.error_source_index == 0 && bad_root.segments.empty(),
+           "invalid root queue did not fail closed");
+}
+
+void EmptySubmitsRequireSideEffects() {
+    const std::array descriptions{
+        Describe(EQueueType::Graphics, 0),
+        Describe(EQueueType::Compute, 0, {},
+                 ERHITranslateExecutionClass::SerialControl, true),
+    };
+
+    const RHISubmissionTopologyPlan plan = BuildRHISubmissionTopology(descriptions, 19);
+    Expect(plan.IsValid() && plan.source_plans.size() == 2 && plan.segments.size() == 1,
+           "empty source retention was incorrect");
+    Expect(plan.source_plans[0].segment_plan_count == 0,
+           "side-effect-free empty submit produced a segment");
+    Expect(plan.source_plans[1].segment_plan_begin == 0 &&
+               plan.source_plans[1].segment_plan_count == 1,
+           "empty side-effect submit was not retained");
+    const RHISubmissionSegmentPlan& retained = plan.segments[0];
+    Expect(retained.source_key == SourceSubmitKey{19, 1} && retained.segment.IsEmpty(),
+           "retained empty segment lost its source identity or range");
+    Expect(retained.inherit_source_wait_events &&
+               retained.inherit_source_signal_events_and_callbacks &&
+               retained.inherit_source_runtime_payload,
+           "empty side-effect segment lost source boundary metadata");
+}
+
+} // namespace
+
+int main() {
+    try {
+        StableInputOrderAndKeysArePreserved();
+        CoverageAndBoundaryMetadataAreExplicit();
+        SerialControlCreatesStableFrontierBarriers();
+        InvalidRangesAndQueuesFailClosed();
+        EmptySubmitsRequireSideEffects();
+        std::cout << "RHI submission topology contract tests passed\n";
+        return 0;
+    } catch (const std::exception& error) {
+        std::cerr << "RHI submission topology contract test failed: " << error.what() << '\n';
+        return 1;
+    }
+}

--- a/source/test/RenderGraphTest.cpp
+++ b/source/test/RenderGraphTest.cpp
@@ -1,10 +1,18 @@
 #include "rendergraph/RenderGraph.h"
+#include "taskgraph/TaskGraph.h"
+#include "taskgraph/TaskSystem.h"
 
 #include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
 #include <cstdlib>
 #include <iostream>
+#include <mutex>
+#include <stdexcept>
 #include <string>
 #include <string_view>
+#include <thread>
 #include <vector>
 
 namespace {
@@ -143,6 +151,72 @@ void TestStableSerialCallbackOrder(TestSuite& suite) {
         callback_order == std::vector<int>{1, 2, 3},
         test_name,
         "callbacks must execute exactly once in declaration order"
+    );
+}
+
+void TestPassCompletionObserverRunsAfterEachCallback(TestSuite& suite) {
+    constexpr std::string_view test_name = "pass completion observer ordering";
+    RenderGraph                graph("PassCompletionObserver");
+    std::vector<std::string>   events;
+    int                        cpu_value = 0;
+
+    graph.AddPass(
+        "Produce",
+        [](RenderGraph::PassBuilder& builder) {
+            builder.SideEffect();
+        },
+        [&] {
+            cpu_value = 41;
+            events.emplace_back("execute:Produce");
+        }
+    );
+    graph.AddPass(
+        "Consume",
+        [](RenderGraph::PassBuilder& builder) {
+            builder.ExecuteOn(
+                RenderGraph::QueueRole::Compute,
+                RenderGraph::PipelineType::Compute
+            );
+            builder.SideEffect();
+        },
+        [&] {
+            suite.Check(
+                cpu_value == 41,
+                test_name,
+                "later pass callbacks must observe earlier callback CPU state"
+            );
+            events.emplace_back("execute:Consume");
+        }
+    );
+
+    const bool compiled = graph.Compile();
+    suite.Check(compiled, test_name, graph.GetCompileError());
+    const bool executed = compiled && graph.Execute([&](const RenderGraph::ExecutedPassInfo& info) {
+        events.emplace_back(std::string("after:") + std::string(info.name));
+        if (info.name == "Produce") {
+            suite.Check(
+                info.domain.queue == RenderGraph::QueueRole::Graphics && info.side_effect,
+                test_name,
+                "observer must receive the compiled Graphics domain and side-effect bit"
+            );
+        } else if (info.name == "Consume") {
+            suite.Check(
+                info.domain.queue == RenderGraph::QueueRole::Compute && info.side_effect,
+                test_name,
+                "observer must receive the compiled Compute domain and side-effect bit"
+            );
+        }
+    });
+    suite.Check(executed, test_name, graph.GetCompileError());
+    suite.Check(
+        events == std::vector<std::string>{
+                      "execute:Produce",
+                      "after:Produce",
+                      "execute:Consume",
+                      "after:Consume",
+                  },
+        test_name,
+        "observer must run once after each fully returned pass callback"
     );
 }
 
@@ -3400,11 +3474,687 @@ void TestMergedAccessStateDeterminesPlanCompleteness(TestSuite& suite) {
     );
 }
 
+void TestRecordingBatchPlanAndClassification(TestSuite& suite) {
+    constexpr std::string_view test_name = "recording batch plan and classification";
+    RenderGraph                graph("RecordingBatches");
+    const auto                 hiz_token    = graph.CreateTransientToken("HiZ");
+    const auto                 shadow_token = graph.CreateTransientToken("ShadowMask");
+
+    const auto hiz = graph.AddRecordPass(
+        "HiZBuild",
+        [=](RenderGraph::PassBuilder& builder) {
+            builder.Write(hiz_token).SideEffect();
+        },
+        [](Moer::Render::CommandList&) {},
+        RenderGraph::PassExecutionClass::ParallelRecordEligible,
+        8
+    );
+    const auto shadow = graph.AddRecordPass(
+        "DirectionalShadowMask",
+        [=](RenderGraph::PassBuilder& builder) {
+            builder.Write(shadow_token).SideEffect();
+        },
+        [](Moer::Render::CommandList&) {},
+        RenderGraph::PassExecutionClass::ParallelRecordEligible,
+        4
+    );
+    const auto commit = graph.AddPass(
+        "CommitHiZHistory",
+        [=](RenderGraph::PassBuilder& builder) {
+            builder.Read(hiz_token).DependsOn(hiz).SideEffect();
+        },
+        [] {}
+    );
+
+    suite.Check(graph.Compile(), test_name, graph.GetCompileError());
+    const auto& plan = graph.GetCompiledPlan();
+    suite.Check(
+        plan.recording_batches.size() == 3 && plan.recording_batches[0].passes == std::vector{hiz} &&
+            plan.recording_batches[1].passes == std::vector{shadow} &&
+            plan.recording_batches[2].passes == std::vector{commit},
+        test_name,
+        "the compiler must emit one stable CPU ownership batch per pass"
+    );
+    suite.Check(
+        plan.recording_batches.size() == 3 &&
+            plan.recording_batches[0].execution ==
+                RenderGraph::PassExecutionClass::ParallelRecordEligible &&
+            plan.recording_batches[1].execution ==
+                RenderGraph::PassExecutionClass::ParallelRecordEligible &&
+            plan.recording_batches[2].execution == RenderGraph::PassExecutionClass::MainThread &&
+            plan.recording_batches[0].workload == 8 &&
+            plan.recording_batches[1].workload == 4,
+        test_name,
+        "recording class and workload must survive compilation"
+    );
+    suite.Check(
+        plan.recording_batches.size() == 3 &&
+            plan.recording_batches[0].dependency_wave ==
+                plan.recording_batches[1].dependency_wave &&
+            plan.recording_batches[2].dependency_wave >
+                plan.recording_batches[0].dependency_wave,
+        test_name,
+        "independent recording passes must share a wave while their consumer follows"
+    );
+    suite.Check(
+        Contains(graph.Dump(), "recording_batches:\n") &&
+            Contains(graph.Dump(), "cpu=parallel-record workload=8 wave=0"),
+        test_name,
+        "the deterministic dump must expose the executable CPU recording schedule"
+    );
+    suite.Check(
+        !graph.Execute() && Contains(graph.GetCompileError(), "owned CommandLists"),
+        test_name,
+        "legacy serial Execute must reject record callbacks instead of sharing a CommandList"
+    );
+}
+
+void TestRecordingCallbackClassMismatchFails(TestSuite& suite) {
+    constexpr std::string_view test_name = "recording callback class mismatch";
+
+    RenderGraph execute_graph("ExecuteAsRecord");
+    execute_graph.AddPass(
+        "BadExecute",
+        [](RenderGraph::PassBuilder& builder) {
+            builder.SideEffect().ParallelRecord();
+        },
+        [] {}
+    );
+    suite.Check(
+        !execute_graph.Compile() &&
+            Contains(execute_graph.GetCompileError(), "cannot use a command-recording class"),
+        test_name,
+        "an execute callback cannot masquerade as a record callback"
+    );
+
+    RenderGraph record_graph("RecordAsMainThread");
+    record_graph.AddRecordPass(
+        "BadRecord",
+        [](RenderGraph::PassBuilder& builder) {
+            builder.SideEffect();
+        },
+        [](Moer::Render::CommandList&) {},
+        RenderGraph::PassExecutionClass::MainThread
+    );
+    suite.Check(
+        !record_graph.Compile() &&
+            Contains(record_graph.GetCompileError(), "must use SerialRecord"),
+        test_name,
+        "a record callback must own a serial or parallel CommandList"
+    );
+}
+
+void TestExternalControlIsAnUnmanagedJoinBoundary(TestSuite& suite) {
+    constexpr std::string_view test_name = "external control join boundary";
+    RenderGraph                graph("ExternalControlBoundary");
+    const auto                 produced = graph.CreateTransientToken("Produced");
+    const auto                 released = graph.CreateTransientToken("Released");
+    std::vector<std::string>   events{};
+
+    graph.AddRecordPass(
+        "RecordBeforeExternal",
+        [=](RenderGraph::PassBuilder& builder) {
+            builder.Write(produced).SideEffect();
+        },
+        [&](Moer::Render::CommandList&) { events.emplace_back("record"); },
+        RenderGraph::PassExecutionClass::ParallelRecordEligible
+    );
+    const auto external = graph.AddPass(
+        "External",
+        [=](RenderGraph::PassBuilder& builder) {
+            builder.Read(produced).Write(released).SideEffect().ExternalControl();
+        },
+        [&] { events.emplace_back("external"); }
+    );
+    graph.AddPass(
+        "ManagedMain",
+        [=](RenderGraph::PassBuilder& builder) {
+            builder.Read(released).DependsOn(external).SideEffect();
+        },
+        [&] { events.emplace_back("main"); }
+    );
+
+    suite.Check(graph.Compile(), test_name, graph.GetCompileError());
+    const auto& plan = graph.GetCompiledPlan();
+    suite.Check(
+        plan.recording_batches.size() == 3 &&
+            plan.recording_batches[1].execution ==
+                RenderGraph::PassExecutionClass::ExternalControl &&
+            Contains(graph.Dump(), "cpu=external-control"),
+        test_name,
+        "the compiler and dump must retain the explicit external-control policy"
+    );
+
+    size_t published_groups = 0;
+    size_t managed_observers = 0;
+    const bool executed = graph.ExecuteRecording(
+        [&](const RenderGraph::ExecutedPassInfo& pass) {
+            ++managed_observers;
+            events.emplace_back(std::string("observer:") + std::string(pass.name));
+        },
+        {},
+        false,
+        [&](Moer::Array<Moer::Render::RHIRecordingSource>&& sources) {
+            ++published_groups;
+            suite.Check(
+                sources.size() == 1 &&
+                    sources.front().completion->Status() ==
+                        Moer::Render::ERHIRecordingStatus::Pending,
+                test_name,
+                "recording ownership must be published before the producer completes"
+            );
+        }
+    );
+
+    suite.Check(executed, test_name, graph.GetCompileError());
+    suite.Check(
+        events == std::vector<std::string>{"record", "external", "main", "observer:ManagedMain"},
+        test_name,
+        "external control must join prior recording and bypass the managed-command observer"
+    );
+    suite.Check(
+        published_groups == 1 && managed_observers == 1,
+        test_name,
+        "only owned record batches are published and only managed main-thread passes are observed"
+    );
+}
+
+void TestCpuPrepareReferencesIdentityWithoutGpuAccess(TestSuite& suite) {
+    constexpr std::string_view test_name = "cpu prepare identity reference";
+    RenderGraph                graph("CpuPrepareIdentity");
+    int                        physical_texture = 0;
+    const auto texture = graph.ImportTexture(
+        "PreparedTexture",
+        &physical_texture,
+        RenderGraph::TextureDesc{.mip_count = 1, .layer_count = 1}
+    );
+    bool cpu_prepare_ran = false;
+    graph.AddPass(
+        "Prepare",
+        [=](RenderGraph::PassBuilder& builder) {
+            builder.Reference(texture).SideEffect().CpuPrepare();
+        },
+        [&] { cpu_prepare_ran = true; }
+    );
+
+    suite.Check(graph.Compile(), test_name, graph.GetCompileError());
+    const auto& plan = graph.GetCompiledPlan();
+    suite.Check(
+        plan.recording_batches.size() == 1 &&
+            plan.recording_batches.front().execution ==
+                RenderGraph::PassExecutionClass::CpuPrepare &&
+            plan.accesses.empty() && plan.edges.empty() && plan.barriers.empty() &&
+            plan.queue_batches.empty(),
+        test_name,
+        "a CPU identity reference must not synthesize GPU access, version, barrier, or queue metadata"
+    );
+    suite.Check(
+        Contains(graph.Dump(), "cpu=cpu-prepare") &&
+            Contains(graph.Dump(), "references=[PreparedTexture]"),
+        test_name,
+        "the dump must expose CPU-only scheduling and identity retention"
+    );
+
+    size_t observer_calls = 0;
+    size_t published_groups = 0;
+    const bool executed = graph.ExecuteRecording(
+        [&](const RenderGraph::ExecutedPassInfo&) { ++observer_calls; },
+        {},
+        true,
+        [&](Moer::Array<Moer::Render::RHIRecordingSource>&&) { ++published_groups; }
+    );
+    suite.Check(executed && cpu_prepare_ran, test_name, graph.GetCompileError());
+    suite.Check(
+        observer_calls == 0 && published_groups == 0,
+        test_name,
+        "CPU-only callbacks must bypass both managed CommandList sealing and recording publication"
+    );
+}
+
+void TestCpuPrepareRejectsGpuAccess(TestSuite& suite) {
+    constexpr std::string_view test_name = "cpu prepare rejects GPU access";
+    RenderGraph                graph("CpuPrepareGpuAccess");
+    int                        physical_texture = 0;
+    const auto texture = graph.ImportTexture(
+        "GpuTexture",
+        &physical_texture,
+        RenderGraph::TextureDesc{.mip_count = 1, .layer_count = 1}
+    );
+    graph.AddPass(
+        "InvalidPrepare",
+        [=](RenderGraph::PassBuilder& builder) {
+            builder.Read(texture).SideEffect().CpuPrepare();
+        },
+        [] {}
+    );
+
+    suite.Check(
+        !graph.Compile() && Contains(graph.GetCompileError(), "may only access token resources"),
+        test_name,
+        "CPU-only callbacks must use Reference rather than synthesize GPU accesses"
+    );
+}
+
+void TestCpuPrepareIsExcludedFromGpuQueuePlan(TestSuite& suite) {
+    constexpr std::string_view test_name = "cpu prepare is excluded from GPU queue plan";
+    RenderGraph graph("CpuPrepareQueuePlan", RenderGraph::QueueTopology::DedicatedQueues());
+    const auto  token = graph.CreateTransientToken("CpuPreparedToken");
+    const auto  prepare = graph.AddPass(
+        "PrepareOnCpu",
+        [=](RenderGraph::PassBuilder& builder) {
+            builder.ExecuteOn(RenderGraph::QueueRole::Compute, RenderGraph::PipelineType::Compute)
+                .Write(token)
+                .SideEffect()
+                .CpuPrepare();
+        },
+        [] {}
+    );
+    const auto consume = graph.AddPass(
+        "ConsumeOnGpu",
+        [=](RenderGraph::PassBuilder& builder) {
+            builder.ExecuteOn(RenderGraph::QueueRole::Graphics, RenderGraph::PipelineType::Graphics)
+                .Read(token)
+                .SideEffect();
+        },
+        [] {}
+    );
+
+    suite.Check(graph.Compile(), test_name, graph.GetCompileError());
+    const auto& plan = graph.GetCompiledPlan();
+    suite.Check(
+        HasEdgeReason(
+            plan, prepare, consume, RenderGraph::EdgeReasonKind::ReadAfterWrite, token.Untyped()
+        ) &&
+            plan.recording_batches.size() == 2 && plan.queue_batches.size() == 1 &&
+            plan.queue_batches.front().passes == std::vector<RenderGraph::PassHandle>{consume} &&
+            plan.queue_syncs.empty(),
+        test_name,
+        "CPU preparation must order callbacks without requiring a nonexistent GPU signal"
+    );
+}
+
+void TestParallelRecordingFallsBackWithoutTaskGraph(TestSuite& suite) {
+    constexpr std::string_view test_name = "parallel recording without task graph";
+    suite.Check(
+        !TaskGraph::IsInitialized(),
+        test_name,
+        "the isolated fallback test must start without the engine TaskGraph lifecycle"
+    );
+
+    RenderGraph graph("NoTaskGraphFallback");
+    const auto  first_token  = graph.CreateTransientToken("First");
+    const auto  second_token = graph.CreateTransientToken("Second");
+    std::vector<int> events{};
+    const auto caller_thread = std::this_thread::get_id();
+    bool       stayed_on_caller = true;
+
+    auto add_record = [&](std::string_view name, RenderGraph::TokenHandle token, int id) {
+        graph.AddRecordPass(
+            name,
+            [=](RenderGraph::PassBuilder& builder) {
+                builder.Write(token).SideEffect();
+            },
+            [&, id](Moer::Render::CommandList&) {
+                stayed_on_caller = stayed_on_caller &&
+                                   std::this_thread::get_id() == caller_thread;
+                events.emplace_back(id);
+            },
+            RenderGraph::PassExecutionClass::ParallelRecordEligible
+        );
+    };
+    add_record("First", first_token, 1);
+    add_record("Second", second_token, 2);
+
+    suite.Check(graph.Compile(), test_name, graph.GetCompileError());
+    Moer::Array<Moer::Render::RHIRecordingGateRef> published_gates{};
+    const bool executed = graph.ExecuteRecording(
+        {},
+        {},
+        true,
+        [&](Moer::Array<Moer::Render::RHIRecordingSource>&& sources) {
+            for (auto& source : sources) {
+                published_gates.emplace_back(source.completion);
+            }
+        }
+    );
+
+    suite.Check(executed, test_name, graph.GetCompileError());
+    suite.Check(
+        stayed_on_caller && events == std::vector<int>{1, 2},
+        test_name,
+        "parallel-eligible work must use the stable serial path when TaskGraph is unavailable"
+    );
+    suite.Check(
+        published_gates.size() == 2 &&
+            std::all_of(published_gates.begin(), published_gates.end(), [](const auto& gate) {
+                return gate->Status() == Moer::Render::ERHIRecordingStatus::Succeeded;
+            }),
+        test_name,
+        "serial fallback must still complete every already-published ownership gate"
+    );
+}
+
+void TestParallelRecordingDispatchAndJoin(TestSuite& suite) {
+    using namespace std::chrono_literals;
+    constexpr std::string_view test_name = "parallel recording dispatch and join";
+
+    struct Rendezvous {
+        std::atomic<int> inflight{0};
+        std::atomic<int> max_inflight{0};
+        std::atomic<bool> named_task_ran{false};
+        std::mutex              mutex{};
+        std::condition_variable cv{};
+        int                     entered{0};
+        bool                    timed_out{false};
+        std::vector<int>        completion_order{};
+        GraphEventRef           deferred_named_task{};
+    } rendezvous;
+
+    const auto make_record = [&](int id) {
+        return [&, id](Moer::Render::CommandList&) {
+            const int inflight = rendezvous.inflight.fetch_add(1) + 1;
+            int       observed = rendezvous.max_inflight.load();
+            while (observed < inflight &&
+                   !rendezvous.max_inflight.compare_exchange_weak(observed, inflight)) {}
+
+            if (id == 1) {
+                auto deferred_named_task = LambdaTask::Dispatch(
+                    [&] { rendezvous.named_task_ran.store(true); }, EThread::EMainThread
+                );
+                std::lock_guard lock(rendezvous.mutex);
+                rendezvous.deferred_named_task = std::move(deferred_named_task);
+            }
+
+            {
+                std::unique_lock lock(rendezvous.mutex);
+                ++rendezvous.entered;
+                rendezvous.cv.notify_all();
+                if (!rendezvous.cv.wait_for(lock, 2s, [&] { return rendezvous.entered == 2; })) {
+                    rendezvous.timed_out = true;
+                }
+            }
+            if (id == 1) {
+                std::this_thread::sleep_for(30ms);
+            }
+            {
+                std::lock_guard lock(rendezvous.mutex);
+                rendezvous.completion_order.push_back(id);
+            }
+            rendezvous.inflight.fetch_sub(1);
+        };
+    };
+
+    RenderGraph graph("ParallelRecordingDispatch");
+    const auto  gpu_dependency = graph.CreateTransientTexture(
+        "GpuDependency",
+        RenderGraph::TextureDesc{
+            .mip_count   = 1,
+            .layer_count = 1,
+            .aspects     = RenderGraph::TextureAspect::Color,
+        }
+    );
+    const auto  second_token = graph.CreateTransientToken("Second");
+    const auto  first = graph.AddRecordPass(
+        "FirstRecord",
+        [=](RenderGraph::PassBuilder& builder) {
+            builder.Write(gpu_dependency).SideEffect();
+        },
+        make_record(1),
+        RenderGraph::PassExecutionClass::ParallelRecordEligible
+    );
+    const auto second = graph.AddRecordPass(
+        "SecondRecord",
+        [=](RenderGraph::PassBuilder& builder) {
+            builder.Read(gpu_dependency).Write(second_token).SideEffect();
+        },
+        make_record(2),
+        RenderGraph::PassExecutionClass::ParallelRecordEligible
+    );
+    bool joined_before_main = false;
+    graph.AddPass(
+        "JoinBoundary",
+        [=](RenderGraph::PassBuilder& builder) {
+            builder.Read(gpu_dependency)
+                .Read(second_token)
+                .DependsOn(first)
+                .DependsOn(second)
+                .SideEffect();
+        },
+        [&] {
+            joined_before_main = rendezvous.inflight.load() == 0 && rendezvous.entered == 2;
+        }
+    );
+
+    suite.Check(graph.Compile(), test_name, graph.GetCompileError());
+    const auto& recording_plan = graph.GetCompiledPlan().recording_batches;
+    suite.Check(
+        recording_plan.size() == 3 &&
+            recording_plan[1].dependency_wave > recording_plan[0].dependency_wave,
+        test_name,
+        "the fixture must place the two record callbacks in different GPU dependency waves"
+    );
+
+    Moer::Array<Moer::Array<Moer::Render::RHIRecordingSource>> published{};
+    bool published_pending = false;
+    bool distinct_command_lists = false;
+    Moer::TaskSystem::Init();
+    const bool executed = graph.ExecuteRecording(
+        {},
+        {},
+        true,
+        [&](Moer::Array<Moer::Render::RHIRecordingSource>&& sources) {
+            published_pending = sources.size() == 2 &&
+                                sources[0].completion->Status() ==
+                                    Moer::Render::ERHIRecordingStatus::Pending &&
+                                sources[1].completion->Status() ==
+                                    Moer::Render::ERHIRecordingStatus::Pending;
+            distinct_command_lists = sources.size() == 2 &&
+                                     sources[0].command_list != sources[1].command_list;
+            published.emplace_back(std::move(sources));
+        }
+    );
+    const bool avoided_named_thread_reentry = !rendezvous.named_task_ran.load();
+    GraphEventRef deferred_named_task{};
+    {
+        std::lock_guard lock(rendezvous.mutex);
+        deferred_named_task = rendezvous.deferred_named_task;
+    }
+    if (deferred_named_task) {
+        TaskGraph::GetInterface().WaitUntilTaskComplete(
+            deferred_named_task, EThread::EMainThread
+        );
+    }
+    const bool explicitly_drained_named_task = rendezvous.named_task_ran.load();
+    Moer::TaskSystem::ShutDown();
+
+    suite.Check(executed, test_name, graph.GetCompileError());
+    suite.Check(
+        published.size() == 1 && published.front().size() == 2 && published_pending,
+        test_name,
+        "one stable source group must be published before either producer completes"
+    );
+    suite.Check(
+        distinct_command_lists,
+        test_name,
+        "parallel record callbacks must never share a CommandList"
+    );
+    suite.Check(
+        rendezvous.max_inflight.load() >= 2 && !rendezvous.timed_out,
+        test_name,
+        "GPU-dependent callbacks must still overlap immutable CPU recording"
+    );
+    suite.Check(
+        rendezvous.completion_order == std::vector<int>{2, 1},
+        test_name,
+        "the test must exercise completion order different from source order"
+    );
+    suite.Check(
+        joined_before_main,
+        test_name,
+        "a caller-thread pass must not run until the recording wave has joined"
+    );
+    suite.Check(
+        avoided_named_thread_reentry && explicitly_drained_named_task,
+        test_name,
+        "joining recording workers must not pump unrelated named-thread work"
+    );
+    suite.Check(
+        published.size() == 1 &&
+            published.front()[0].completion->Status() ==
+                Moer::Render::ERHIRecordingStatus::Succeeded &&
+            published.front()[1].completion->Status() ==
+                Moer::Render::ERHIRecordingStatus::Succeeded,
+        test_name,
+        "every published source gate must reach a successful terminal state"
+    );
+}
+
+void TestCpuRecordingDependenciesSplitParallelGroups(TestSuite& suite) {
+    constexpr std::string_view test_name = "CPU recording dependencies split parallel groups";
+
+    std::atomic<int>        inflight{0};
+    std::atomic<int>        max_inflight{0};
+    std::mutex              order_mutex{};
+    std::vector<int>        record_order{};
+    std::vector<size_t>     published_group_sizes{};
+
+    const auto make_record = [&](int id) {
+        return [&, id](Moer::Render::CommandList&) {
+            const int active = inflight.fetch_add(1) + 1;
+            int       observed = max_inflight.load();
+            while (observed < active &&
+                   !max_inflight.compare_exchange_weak(observed, active)) {}
+            {
+                std::lock_guard lock(order_mutex);
+                record_order.push_back(id);
+            }
+            inflight.fetch_sub(1);
+        };
+    };
+
+    RenderGraph graph("CpuRecordingDependencies");
+    const auto  cpu_token = graph.CreateTransientToken("CpuToken");
+    const auto  first = graph.AddRecordPass(
+        "TokenProducer",
+        [=](RenderGraph::PassBuilder& builder) {
+            builder.Write(cpu_token).SideEffect();
+        },
+        make_record(1),
+        RenderGraph::PassExecutionClass::ParallelRecordEligible
+    );
+    const auto second = graph.AddRecordPass(
+        "TokenConsumer",
+        [=](RenderGraph::PassBuilder& builder) {
+            builder.Read(cpu_token).SideEffect();
+        },
+        make_record(2),
+        RenderGraph::PassExecutionClass::ParallelRecordEligible
+    );
+    graph.AddRecordPass(
+        "ExplicitConsumer",
+        [=](RenderGraph::PassBuilder& builder) {
+            builder.DependsOn(second).SideEffect();
+        },
+        make_record(3),
+        RenderGraph::PassExecutionClass::ParallelRecordEligible
+    );
+
+    suite.Check(graph.Compile(), test_name, graph.GetCompileError());
+    Moer::TaskSystem::Init();
+    const bool executed = graph.ExecuteRecording(
+        {},
+        {},
+        true,
+        [&](Moer::Array<Moer::Render::RHIRecordingSource>&& sources) {
+            published_group_sizes.push_back(sources.size());
+        }
+    );
+    Moer::TaskSystem::ShutDown();
+
+    suite.Check(executed, test_name, graph.GetCompileError());
+    suite.Check(
+        published_group_sizes == std::vector<size_t>{1, 1, 1},
+        test_name,
+        "token and explicit dependencies must form CPU recording group boundaries"
+    );
+    suite.Check(
+        max_inflight.load() == 1 && record_order == std::vector<int>{1, 2, 3},
+        test_name,
+        "CPU-dependent callbacks must record in dependency order without overlap"
+    );
+    (void)first;
+}
+
+void TestRecordingPublicationFailureTerminatesGates(TestSuite& suite) {
+    constexpr std::string_view test_name = "recording publication failure terminates gates";
+    RenderGraph                graph("PublicationFailure");
+    graph.AddRecordPass(
+        "Record",
+        [](RenderGraph::PassBuilder& builder) {
+            builder.SideEffect();
+        },
+        [](Moer::Render::CommandList&) {},
+        RenderGraph::PassExecutionClass::ParallelRecordEligible
+    );
+    suite.Check(graph.Compile(), test_name, graph.GetCompileError());
+
+    Moer::Array<Moer::Render::RHIRecordingSource> published{};
+    const bool executed = graph.ExecuteRecording(
+        {},
+        {},
+        true,
+        [&](Moer::Array<Moer::Render::RHIRecordingSource>&& sources) {
+            published = std::move(sources);
+            throw std::runtime_error("injected publisher failure");
+        }
+    );
+    suite.Check(
+        !executed && Contains(graph.GetCompileError(), "injected publisher failure"),
+        test_name,
+        "publisher exceptions must become a graph execution failure"
+    );
+    suite.Check(
+        published.size() == 1 &&
+            published.front().completion->Status() == Moer::Render::ERHIRecordingStatus::Failed,
+        test_name,
+        "a published gate must never remain Pending when dispatch is abandoned"
+    );
+
+    RenderGraph ownership_graph("SourceOwnershipMutation");
+    ownership_graph.AddRecordPass(
+        "Record",
+        [](RenderGraph::PassBuilder& builder) {
+            builder.SideEffect();
+        },
+        [](Moer::Render::CommandList&) {},
+        RenderGraph::PassExecutionClass::SerialRecord
+    );
+    suite.Check(ownership_graph.Compile(), test_name, ownership_graph.GetCompileError());
+    bool publisher_called = false;
+    const bool ownership_executed = ownership_graph.ExecuteRecording(
+        {},
+        [](const RenderGraph::ExecutedPassInfo&, Moer::Render::RHIRecordingSource& source) {
+            source.completion = Moer::Render::RHIRecordingGate::Create();
+        },
+        false,
+        [&](Moer::Array<Moer::Render::RHIRecordingSource>&&) {
+            publisher_called = true;
+        }
+    );
+    suite.Check(
+        !ownership_executed && !publisher_called &&
+            Contains(ownership_graph.GetCompileError(), "changed ownership"),
+        test_name,
+        "source setup must not replace the producer CommandList or completion gate"
+    );
+}
+
 } // namespace
 
 int main() {
     TestSuite suite;
     TestStableSerialCallbackOrder(suite);
+    TestPassCompletionObserverRunsAfterEachCallback(suite);
     TestImportedAliasIdentityAndDump(suite);
     TestHazardsAndDeterministicDump(suite);
     TestTransientReadBeforeProducerFailsWithoutCallbacks(suite);
@@ -3451,6 +4201,16 @@ int main() {
     TestUndefinedImportMustBeInitializedBeforeRead(suite);
     TestUnknownExportMakesStatePlanIncomplete(suite);
     TestMergedAccessStateDeterminesPlanCompleteness(suite);
+    TestRecordingBatchPlanAndClassification(suite);
+    TestRecordingCallbackClassMismatchFails(suite);
+    TestExternalControlIsAnUnmanagedJoinBoundary(suite);
+    TestCpuPrepareReferencesIdentityWithoutGpuAccess(suite);
+    TestCpuPrepareRejectsGpuAccess(suite);
+    TestCpuPrepareIsExcludedFromGpuQueuePlan(suite);
+    TestParallelRecordingFallsBackWithoutTaskGraph(suite);
+    TestParallelRecordingDispatchAndJoin(suite);
+    TestCpuRecordingDependenciesSplitParallelGroups(suite);
+    TestRecordingPublicationFailureTerminatesGates(suite);
 
     if (suite.FailureCount() != 0) {
         std::cerr << "TestRenderGraph: " << suite.FailureCount() << " failure(s)\n";

--- a/source/test/RenderGraphTest.cpp
+++ b/source/test/RenderGraphTest.cpp
@@ -3606,7 +3606,7 @@ void TestExternalControlIsAnUnmanagedJoinBoundary(TestSuite& suite) {
         },
         [&] { events.emplace_back("external"); }
     );
-    graph.AddPass(
+    const auto managed = graph.AddPass(
         "ManagedMain",
         [=](RenderGraph::PassBuilder& builder) {
             builder.Read(released).DependsOn(external).SideEffect();
@@ -3623,6 +3623,18 @@ void TestExternalControlIsAnUnmanagedJoinBoundary(TestSuite& suite) {
             Contains(graph.Dump(), "cpu=external-control"),
         test_name,
         "the compiler and dump must retain the explicit external-control policy"
+    );
+    suite.Check(
+        plan.queue_batches.size() == 3 &&
+            plan.queue_batches[0].passes == std::vector{plan.recording_batches[0].passes.front()} &&
+            !plan.queue_batches[0].external_control &&
+            plan.queue_batches[1].passes == std::vector{external} &&
+            plan.queue_batches[1].external_control &&
+            plan.queue_batches[2].passes == std::vector{managed} &&
+            !plan.queue_batches[2].external_control &&
+            Contains(graph.Dump(), "external_control=true passes=[External]"),
+        test_name,
+        "external control must be a standalone queue batch that managed lowering cannot cross"
     );
 
     size_t published_groups = 0;

--- a/source/test/VulkanParallelRecordWorkEstimatorTest.cpp
+++ b/source/test/VulkanParallelRecordWorkEstimatorTest.cpp
@@ -1,0 +1,208 @@
+#include "rhi/RHIImpl.h"
+#include "rhi/vulkan/VulkanParallelRecordWorkEstimator.h"
+
+#include <iostream>
+#include <limits>
+#include <stdexcept>
+#include <string_view>
+#include <utility>
+
+using namespace Moer;
+using namespace Moer::Render;
+
+namespace {
+
+void Expect(bool _condition, const char* _message) {
+    if (!_condition) {
+        throw std::runtime_error(_message);
+    }
+}
+
+class TestBuffer final : public Buffer {
+public:
+    TestBuffer() : Buffer(BufferInfo{64, 4, EBufferUsageFlags::NONE}) {}
+
+    void SetName(const std::string_view _name) override {
+        (void)_name;
+    }
+};
+
+PipelineHandle MakePipeline() {
+    PipelineHandle pipeline;
+    // The fourth argument below is deliberately inactive and must not affect
+    // the estimate.
+    pipeline.valid_bits = (uint64{1} << 0) | (uint64{1} << 1) | (uint64{1} << 2);
+    return pipeline;
+}
+
+ArrayArguments MakeArguments() {
+    ArrayArguments arguments(4, 2, false);
+    arguments[0] = BufferView(nullptr, 0, 1, 4);
+
+    TextureViewArray textures;
+    for (uint32 index = 0; index < 3; ++index) {
+        TextureView texture{};
+        texture.texture   = nullptr;
+        texture.format    = PF_UNDEFINED;
+        texture.num_mips  = 1;
+        texture.num_array = 1;
+        textures.emplace_back(texture);
+    }
+    arguments[1] = std::move(textures);
+    arguments[2] = TInvalidArg{0};
+    arguments[3] = BufferView(nullptr, 0, 128, 4);
+    return arguments;
+}
+
+MeshDrawData MakeMeshDraw(TestBuffer& _buffer) {
+    MeshDrawData mesh;
+    mesh.vtx_views.emplace_back(VertexBuffer{&_buffer, 0});
+    mesh.idx_view = IndexBuffer{BufferView(&_buffer, 0, 4, 4), IET_UINT32};
+    mesh.EmplaceDrawIndexed(0, 3, 0, 0);
+    mesh.EmplaceDrawIndexed(3, 3, 0, 0);
+    mesh.DrawIndirect(BufferView(&_buffer, 16, 4, 4), 4096, 16);
+    return mesh;
+}
+
+void SetDrawStateCountsRecorderOperations() {
+    TestBuffer    buffer;
+    PipelineHandle pipeline = MakePipeline();
+    Array<MeshDrawData> meshes;
+    meshes.emplace_back(MakeMeshDraw(buffer));
+
+    SetDrawStateCmd command(
+        pipeline, MakeArguments(), RenderPassInfo{}, std::move(meshes), "EstimatorSetDraw"
+    );
+    const TCachedArgArray no_cached_arguments;
+
+    // 8 fixed + (one scalar + three array elements) + push constants
+    // + (one vertex bind + one index bind + two direct draws + one indirect draw).
+    Expect(
+        VulkanParallelRecordDetail::EstimateWorkUnits(command, no_cached_arguments) == 18,
+        "SetDrawState work estimate did not match its recorder operation shape"
+    );
+}
+
+void MultiDrawCountsInlineAndCachedArguments() {
+    TestBuffer     buffer;
+    PipelineHandle pipeline = MakePipeline();
+    TCachedArgArray cached_arguments;
+    cached_arguments.emplace_back(MakeArguments());
+
+    DrawBatch batch;
+    DrawBatchElement& inline_element = batch.draw_cmds.emplace_back();
+    inline_element.handle            = pipeline;
+    inline_element.args              = MakeArguments();
+    inline_element.RegisterDrawData(MakeMeshDraw(buffer));
+
+    DrawBatchElement& cached_element = batch.draw_cmds.emplace_back();
+    cached_element.handle            = pipeline;
+    cached_element.args              = ArrayArgReference{0};
+    cached_element.RegisterMeshDispatch(DispatchMeshData::Dispatch(uint3{1, 1, 1}));
+    cached_element.RegisterMeshDispatch(DispatchMeshData::Dispatch(uint3{128, 64, 32}));
+
+    MultiDrawCmd command(std::move(batch), RenderPassInfo{}, "EstimatorMultiDraw");
+
+    // 6 fixed + first element (2 bind + 4 args + 1 constants + 5 mesh)
+    // + second element (2 bind + 4 cached args + 1 constants + 2 mesh dispatches).
+    Expect(
+        VulkanParallelRecordDetail::EstimateWorkUnits(command, cached_arguments) == 27,
+        "MultiDraw work estimate lost inline, cached, draw, or mesh-dispatch work"
+    );
+}
+
+void DispatchCountsConstantsButNotGpuPayloadSize() {
+    TestBuffer     buffer;
+    PipelineHandle pipeline = MakePipeline();
+    TCachedArgArray cached_arguments;
+    cached_arguments.emplace_back(MakeArguments());
+
+    DispatchCmd small(
+        TShaderArgArray{MakeArguments()},
+        pipeline,
+        uint3{1, 1, 1},
+        ProfileSection{"Other"},
+        "EstimatorDispatchSmall"
+    );
+    DispatchCmd large(
+        TShaderArgArray{MakeArguments()},
+        pipeline,
+        uint3{65535, 65535, 65535},
+        ProfileSection{"Other"},
+        "EstimatorDispatchLarge"
+    );
+    DispatchCmd indirect(
+        TShaderArgArray{ArrayArgReference{0}},
+        pipeline,
+        BufferView(&buffer, 0, 4, 4),
+        ProfileSection{"Other"},
+        "EstimatorDispatchIndirect"
+    );
+
+    const uint32 expected = 10; // 5 fixed + 4 arguments + one push-constant record.
+    Expect(
+        VulkanParallelRecordDetail::EstimateWorkUnits(small, cached_arguments) == expected,
+        "Dispatch estimate did not include push constants"
+    );
+    Expect(
+        VulkanParallelRecordDetail::EstimateWorkUnits(large, cached_arguments) == expected,
+        "Dispatch group counts incorrectly changed recorder work"
+    );
+    Expect(
+        VulkanParallelRecordDetail::EstimateWorkUnits(indirect, cached_arguments) == expected,
+        "cached indirect Dispatch did not match direct Dispatch recorder work"
+    );
+}
+
+void CopyWorkIgnoresGpuPayloadVolume() {
+    const TCachedArgArray no_cached_arguments;
+    CopyBufferCmd small(1, 2, 0, 0, 4, "EstimatorCopySmall");
+    CopyBufferCmd large(
+        1,
+        2,
+        0,
+        0,
+        std::numeric_limits<uint64>::max(),
+        "EstimatorCopyLarge"
+    );
+    CopyTextureCmd texture(
+        PF_R8G8B8A8_UNORM,
+        1,
+        2,
+        0,
+        0,
+        uint3{0, 0, 0},
+        uint3{0, 0, 0},
+        uint3{4096, 4096, 64},
+        "EstimatorCopyTexture"
+    );
+
+    Expect(
+        VulkanParallelRecordDetail::EstimateWorkUnits(small, no_cached_arguments) == 3,
+        "small buffer copy did not use the fixed recorder cost"
+    );
+    Expect(
+        VulkanParallelRecordDetail::EstimateWorkUnits(large, no_cached_arguments) == 3,
+        "copy byte count incorrectly changed recorder work"
+    );
+    Expect(
+        VulkanParallelRecordDetail::EstimateWorkUnits(texture, no_cached_arguments) == 3,
+        "copy extent incorrectly changed recorder work"
+    );
+}
+
+} // namespace
+
+int main() {
+    try {
+        SetDrawStateCountsRecorderOperations();
+        MultiDrawCountsInlineAndCachedArguments();
+        DispatchCountsConstantsButNotGpuPayloadSize();
+        CopyWorkIgnoresGpuPayloadVolume();
+        std::cout << "Vulkan parallel-record work estimator tests passed\n";
+        return 0;
+    } catch (const std::exception& error) {
+        std::cerr << "Vulkan parallel-record work estimator test failed: " << error.what() << '\n';
+        return 1;
+    }
+}

--- a/source/test/VulkanSubmissionRequestDispatchTest.cpp
+++ b/source/test/VulkanSubmissionRequestDispatchTest.cpp
@@ -1,0 +1,179 @@
+#include "rhi/vulkan/VulkanSubmissionRequestDispatch.h"
+
+#include <iostream>
+#include <stdexcept>
+#include <vector>
+
+using namespace Moer::Render::VulkanSubmissionDetail;
+
+namespace {
+
+void Expect(bool _condition, const char* _message) {
+    if (!_condition) {
+        throw std::runtime_error(_message);
+    }
+}
+
+void SubmitExceptionRejectsEveryOutstandingObligation() {
+    struct OutstandingObligations {
+        bool callbacks{true};
+        bool signals{true};
+        bool present_receipt{true};
+    } obligations;
+
+    uint32_t process_count  = 0;
+    uint32_t reject_count   = 0;
+    uint32_t complete_count = 0;
+    std::vector<EWorkerRequestFailurePhase> failures;
+
+    const WorkerRequestDispatchResult result = DispatchWorkerRequestNoexcept(
+        EWorkerRequestKind::Submit,
+        [&] {
+            ++process_count;
+            throw std::runtime_error("injected Submit failure");
+        },
+        [&] {
+            ++reject_count;
+            obligations.callbacks       = false;
+            obligations.signals         = false;
+            obligations.present_receipt = false;
+        },
+        [&] { ++complete_count; },
+        [&](EWorkerRequestFailurePhase _phase, const std::exception_ptr&) {
+            failures.push_back(_phase);
+        }
+    );
+
+    Expect(result.failed, "Submit exception was not reported as failed");
+    Expect(!result.stop, "Submit exception incorrectly stopped the worker");
+    Expect(process_count == 1, "Submit process callback did not run exactly once");
+    Expect(reject_count == 1, "Submit rejection callback did not run exactly once");
+    Expect(complete_count == 0, "Submit incorrectly ran a Sync completion callback");
+    Expect(
+        !obligations.callbacks && !obligations.signals && !obligations.present_receipt,
+        "Submit rejection left an outstanding request obligation"
+    );
+    Expect(
+        failures.size() == 1 &&
+            failures.front() == EWorkerRequestFailurePhase::Process,
+        "Submit process failure was not diagnosed"
+    );
+}
+
+void SubmitExceptionPreservesTerminalizedPrefix() {
+    enum class ESourceState : uint8_t {
+        Submitted,
+        Pending,
+        Rejected,
+    };
+
+    std::vector<ESourceState> sources{
+        ESourceState::Submitted,
+        ESourceState::Pending,
+        ESourceState::Pending,
+    };
+    const size_t first_unconsumed_source = 1;
+
+    (void)DispatchWorkerRequestNoexcept(
+        EWorkerRequestKind::Submit,
+        [] { throw std::runtime_error("injected second-source failure"); },
+        [&] {
+            for (size_t source_index = first_unconsumed_source;
+                 source_index < sources.size();
+                 ++source_index) {
+                sources[source_index] = ESourceState::Rejected;
+            }
+        },
+        [] {},
+        [](EWorkerRequestFailurePhase, const std::exception_ptr&) {}
+    );
+
+    Expect(
+        sources[0] == ESourceState::Submitted,
+        "exception cleanup rejected an already terminalized source"
+    );
+    Expect(
+        sources[1] == ESourceState::Rejected &&
+            sources[2] == ESourceState::Rejected,
+        "exception cleanup did not reject the current and later sources"
+    );
+}
+
+void SyncExceptionAlwaysCompletes() {
+    uint32_t complete_count = 0;
+    const WorkerRequestDispatchResult result = DispatchWorkerRequestNoexcept(
+        EWorkerRequestKind::Sync,
+        [] { throw std::runtime_error("injected Sync failure"); },
+        [] { throw std::runtime_error("Sync must not reject a Submit"); },
+        [&] { ++complete_count; },
+        [](EWorkerRequestFailurePhase, const std::exception_ptr&) {}
+    );
+
+    Expect(result.failed, "Sync exception was not reported as failed");
+    Expect(!result.stop, "Sync exception incorrectly stopped the worker");
+    Expect(complete_count == 1, "Sync exception did not release its waiter");
+}
+
+void StopExceptionsAlwaysCompleteAndExit() {
+    uint32_t complete_count = 0;
+    std::vector<EWorkerRequestFailurePhase> failures;
+    const WorkerRequestDispatchResult result = DispatchWorkerRequestNoexcept(
+        EWorkerRequestKind::Stop,
+        [] { throw std::runtime_error("injected Stop Sync failure"); },
+        [] { throw std::runtime_error("Stop must not reject a Submit"); },
+        [&] {
+            ++complete_count;
+            throw std::runtime_error("injected completion failure");
+        },
+        [&](EWorkerRequestFailurePhase _phase, const std::exception_ptr&) {
+            failures.push_back(_phase);
+        }
+    );
+
+    Expect(result.failed, "Stop exceptions were not reported as failed");
+    Expect(result.stop, "Stop exception did not preserve the terminal decision");
+    Expect(complete_count == 1, "Stop did not invoke completion exactly once");
+    Expect(
+        failures.size() == 2 &&
+            failures[0] == EWorkerRequestFailurePhase::Process &&
+            failures[1] == EWorkerRequestFailurePhase::Complete,
+        "Stop did not diagnose both process and completion failures"
+    );
+}
+
+void FailureReportingCannotEscapeOrSkipRejection() {
+    uint32_t reject_count = 0;
+    const WorkerRequestDispatchResult result = DispatchWorkerRequestNoexcept(
+        EWorkerRequestKind::Submit,
+        [] { throw std::runtime_error("injected Submit failure"); },
+        [&] {
+            ++reject_count;
+            throw std::runtime_error("injected rejection failure");
+        },
+        [] {},
+        [](EWorkerRequestFailurePhase, const std::exception_ptr&) {
+            throw std::runtime_error("injected diagnostic failure");
+        }
+    );
+
+    Expect(result.failed, "diagnostic containment lost the request failure");
+    Expect(reject_count == 1, "diagnostic failure skipped Submit rejection");
+}
+
+} // namespace
+
+int main() {
+    try {
+        SubmitExceptionRejectsEveryOutstandingObligation();
+        SubmitExceptionPreservesTerminalizedPrefix();
+        SyncExceptionAlwaysCompletes();
+        StopExceptionsAlwaysCompleteAndExit();
+        FailureReportingCannotEscapeOrSkipRejection();
+        std::cout << "Vulkan submission request dispatch tests passed\n";
+        return 0;
+    } catch (const std::exception& error) {
+        std::cerr << "Vulkan submission request dispatch test failed: "
+                  << error.what() << '\n';
+        return 1;
+    }
+}

--- a/template.MoerEngine.toml
+++ b/template.MoerEngine.toml
@@ -20,6 +20,12 @@ rhi_thread = false
 rhi_bypass = true
 max_frame_lag = 0
 profile_logging = false
+parallel_recording = false
+parallel_record_workers = 0
+parallel_record_verify = false
+parallel_record_profile = false
+# Backend CPU-recording work units per job; this is not a draw-count threshold.
+parallel_record_min_work_units_per_job = 64
 
 [engine.rhi]
 type = "Vulkan"
@@ -37,6 +43,7 @@ default_render_method = "Raster"
 enable_shadow = true
 render_graph = false
 render_graph_debug_dump = false
+render_graph_parallel_recording = false
 
 # 推荐AMD GPU或低配显卡启用本设置
 # 该选项会启用光栅化低质量模式：

--- a/tools/threading/README.md
+++ b/tools/threading/README.md
@@ -70,7 +70,11 @@ covering snapshot ownership across renderer teardown. All four leave the lower
 `engine.threading.parallel_recording` switch off and use the Raster-only exit
 or renderer-switch completion marker, so they validate RDG recording ownership,
 join behavior, and normal shutdown without coupling the result to the separate
-lower parallel translator.
+lower parallel translator. Parallel variants also require the graph dump to
+classify `HiZBuild`, `DirectionalShadowMask`, `Lighting`, and `Skybox` as
+`parallel-record`, and require completed TaskGraph dispatch markers for both
+two-pass production groups. A silent no-TaskGraph serial fallback therefore
+fails the feature gate.
 
 Run the full functional matrix:
 

--- a/tools/threading/README.md
+++ b/tools/threading/README.md
@@ -20,7 +20,7 @@ split into repeatable validation runs.
 Matrix configs set `engine.threading.profile_logging=true`. The regular and
 template configs keep it disabled, so normal editor runs do not emit profiling
 windows. They also set `engine.render.raster.render_graph` and
-`render_graph_debug_dump` explicitly for every scenario. The existing
+`render_graph_debug_dump` plus `render_graph_parallel_recording` explicitly for every scenario. The existing
 functional sets keep the RenderGraph path off; the dedicated `rendergraph` set
 enables both the graph and its one-time debug dump.
 
@@ -44,7 +44,7 @@ Run the three-scenario smoke set:
 python tools/threading/run_matrix.py --set smoke --base-config template.MoerEngine.toml
 ```
 
-Run the self-terminating optional-feature renderer lifecycle check:
+Run the self-terminating optional-feature lifecycle checks:
 
 ```powershell
 python tools/threading/run_matrix.py --set feature --base-config template.MoerEngine.toml
@@ -57,6 +57,20 @@ dedicated RenderGraph validation set so it can gate every optional-feature
 build without coupling feature coverage to RenderGraph coverage. It gates on
 functional lifecycle markers rather than periodic profiling markers, which are
 not guaranteed to be emitted before a fast Release validation run exits.
+
+The Raster recording feature checks form an isolated correctness matrix. Both
+`feature_raster_graph_serial_recording` and
+`feature_raster_graph_parallel_recording` use RT + threaded RHI; only the upper
+`render_graph_parallel_recording` switch differs. The
+`feature_raster_graph_parallel_recording_gt` variant exercises the same upper
+worker handoff without a Render Thread. The
+`feature_raster_graph_parallel_recording_reload_switch` variant keeps upper
+recording enabled while recreating Raster and switching Raster→Raytracing→Raster,
+covering snapshot ownership across renderer teardown. All four leave the lower
+`engine.threading.parallel_recording` switch off and use the Raster-only exit
+or renderer-switch completion marker, so they validate RDG recording ownership,
+join behavior, and normal shutdown without coupling the result to the separate
+lower parallel translator.
 
 Run the full functional matrix:
 
@@ -180,6 +194,10 @@ python tools/threading/run_matrix.py --set full --dry-run --base-config template
 | `ray_rt1_rhi` | Raytracing | n/a | n/a | on | on | off | 1 | yes |
 | `ray_rt1_rhi_fault_present_submit` | Raytracing | n/a | n/a | on | on | off | 1 | no |
 | `feature_renderer_switch` | Raster→Raster→Raytracing→Raster | off | off | on | on | off | 1 | no |
+| `feature_raster_graph_serial_recording` | Raster | on | on | on | on | off | 1 | no |
+| `feature_raster_graph_parallel_recording` | Raster | on | on | on | on | off | 1 | no |
+| `feature_raster_graph_parallel_recording_gt` | Raster | on | on | off | on | off | 0 | no |
+| `feature_raster_graph_parallel_recording_reload_switch` | Raster→Raster→Raytracing→Raster | on | on | on | on | off | 1 | no |
 
 ## Pass Criteria
 
@@ -281,7 +299,98 @@ cannot accidentally consume a stale report from an earlier run.
   one-second settle because its first two real presents already provide the
   frame captured after the third synthetic submit fault.
 - The base TOML is parsed after scenario values are patched, and all five
-  threading values, the renderer, and both Raster RenderGraph values are
+  threading values, the renderer, and all three Raster RenderGraph values are
   checked before launch.
 - `--continue-on-failure` is recommended for a full matrix so one failed
   scenario does not hide the state of later scenarios.
+
+## Parallel Command Recording Experiment
+
+There are two independent switches:
+
+```toml
+[engine.render.raster]
+# Upper topology: RDG batches record independent CommandLists on TaskGraph workers.
+render_graph_parallel_recording = false
+
+[engine.threading]
+# Lower topology: Vulkan translates eligible immutable command bodies in parallel.
+parallel_recording = false
+```
+
+The upper switch currently migrates two audited Raster recording groups:
+`HiZBuild` + `DirectionalShadowMask`, then `Lighting` + `Skybox`. Each pass owns
+an independent CommandList and an immutable, strongly-owned Prepare snapshot.
+The second pair deliberately spans two GPU dependency waves: GPU hazards still
+fix Lighting-before-Skybox submission, but do not serialize their CPU command
+recording. Token hazards and explicit `DependsOn` edges still split CPU record
+groups. `CpuPrepare` is a managed caller-thread join boundary with no command
+submission: it may access logical Tokens or `Reference` GPU identities and is
+excluded from the GPU queue plan. `ExternalControl` is reserved for
+TensorRT/Vulkan-CUDA work that owns its own submit/sync scope. Other mutable
+Raster passes remain explicit caller-thread boundaries until their state is
+similarly split.
+
+The Vulkan Graphics queue can experimentally translate/record safe command
+bodies on worker threads while retaining one coordinator for reorder, resource
+state tracking, barrier generation, and final submission. Worker command
+buffers are joined and assembled in stable layer/job order, then submitted by
+one ordered `vkQueueSubmit2`; parallel CPU recording does not reorder GPU work.
+
+The tracked template keeps the experiment off:
+
+```toml
+[engine.threading]
+parallel_recording = false
+parallel_record_workers = 0
+parallel_record_verify = false
+parallel_record_profile = false
+parallel_record_min_work_units_per_job = 64
+```
+
+`parallel_record_workers = 0` selects an automatic worker count. The minimum is
+a backend recording-work heuristic, not a top-level command count and not a
+draw count. Direct draw calls, mesh dispatches, argument writes, pipeline
+changes, and native copy/clear calls contribute units; GPU byte counts,
+dispatch group counts, and indirect draw counts do not. A wave needs at least
+two qualifying jobs, otherwise it safely uses the serial recorder.
+
+Run the five-mode Vulkan correctness/fallback gate after building the target:
+
+```powershell
+python tools/threading/run_parallel_record_vulkan_test.py `
+  --executable target/bin/Release/TestRHIParallelRecordVulkan.exe `
+  --outdir target/validation/parallel_record/release
+```
+
+The runner checks serial, forced-parallel, injected worker failure, production
+gate rejection, and production-heavy admission. It requires real worker
+overlap, stable `wave -> serial island -> wave` assembly, GPU readback
+correctness, exact failure/fallback counts, and clean Vulkan logs.
+
+For Release A/B, enable `parallel_record_profile` in isolated configs and feed
+at least two independent logs per side to `parallel_record_ab.py`. The parser
+is fail-closed for missing fields, invalid percentiles, impure baselines, and
+inconsistent `mode/requested/planned/effective/worker_fallbacks` counters. Its
+performance gate uses end-to-end `ExecuteNow` CPU percentiles, including the
+cost of assembling and submitting multiple command buffers. Record-only
+percentiles and submit averages remain attribution metrics.
+
+The result classes are:
+
+- `GO`: workers were admitted, at least 95% of planned submissions completed
+  on workers, p50 improved by both 15% and 0.2 ms, and p95/p99 did not regress.
+- `GATED`: the feature was requested but no workload met the profitability
+  floor, and the serial fallback stayed within the non-regression tolerance.
+- `EXPERIMENTAL`: any reliability, improvement, or tail gate was not met.
+
+UE's `r.RHICmdMinDrawsPerParallelCmdList=64` is a renderer-layer draw-task
+threshold. MoerEngine's current default of 64 backend work units only borrows
+the profitability-gate principle and conservative order of magnitude; the
+numbers are not semantically interchangeable. Likewise, `dev_parallel_rhi`
+uses whole-submit/segment translate tasks and stable submit assembly, whereas
+this experiment partitions safe ranges inside the current reordered submit.
+A shared recorder/translate context, fewer platform command buffers, and
+draw-range splitting within one large `MultiDraw` remain follow-up architecture
+work for both lines of evolution rather than existing `dev_parallel_rhi`
+features.

--- a/tools/threading/parallel_record_ab.py
+++ b/tools/threading/parallel_record_ab.py
@@ -1,0 +1,619 @@
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Sequence
+
+
+PROFILE_MARKER = "[ParallelRecordProfile]"
+PROFILE_MODES = ("serial", "parallel", "mixed")
+INTEGER_FIELDS = ("samples", "requested", "planned", "effective", "worker_fallbacks")
+WEIGHTED_FIELDS = (
+    "record_p50_ms",
+    "record_p95_ms",
+    "record_p99_ms",
+    "execute_cpu_p50_ms",
+    "execute_cpu_p95_ms",
+    "execute_cpu_p99_ms",
+    "reorder_avg_ms",
+    "preprocess_avg_ms",
+    "worker_join_avg_ms",
+    "submit_cpu_avg_ms",
+    "jobs_avg",
+    "work_units_avg",
+    "ordered_cb_avg",
+)
+MAX_FIELDS = ("record_max_ms", "execute_cpu_max_ms", "max_active")
+REQUIRED_FIELDS = INTEGER_FIELDS + WEIGHTED_FIELDS + MAX_FIELDS
+KEY_VALUE_RE = re.compile(r"([A-Za-z_][A-Za-z0-9_]*)\s*=\s*([^\s,;\]]+)")
+
+
+class ProfileParseError(ValueError):
+    pass
+
+
+@dataclass(frozen=True)
+class ProfileWindow:
+    source: str
+    line: int
+    mode: str
+    samples: int
+    requested: int
+    planned: int
+    effective: int
+    worker_fallbacks: int
+    record_p50_ms: float
+    record_p95_ms: float
+    record_p99_ms: float
+    record_max_ms: float
+    execute_cpu_p50_ms: float
+    execute_cpu_p95_ms: float
+    execute_cpu_p99_ms: float
+    execute_cpu_max_ms: float
+    reorder_avg_ms: float
+    preprocess_avg_ms: float
+    worker_join_avg_ms: float
+    submit_cpu_avg_ms: float
+    jobs_avg: float
+    work_units_avg: float
+    ordered_cb_avg: float
+    max_active: float
+
+
+def _parse_nonnegative_int(value: str, field: str, location: str) -> int:
+    try:
+        parsed = int(value, 10)
+    except ValueError as error:
+        raise ProfileParseError(
+            f"{location}: {field} must be an integer, got {value!r}"
+        ) from error
+    if parsed < 0:
+        raise ProfileParseError(f"{location}: {field} must be non-negative")
+    return parsed
+
+
+def _parse_nonnegative_float(value: str, field: str, location: str) -> float:
+    try:
+        parsed = float(value)
+    except ValueError as error:
+        raise ProfileParseError(
+            f"{location}: {field} must be numeric, got {value!r}"
+        ) from error
+    if not math.isfinite(parsed) or parsed < 0.0:
+        raise ProfileParseError(f"{location}: {field} must be finite and non-negative")
+    return parsed
+
+
+def parse_profile_line(text: str, source: str, line_number: int) -> ProfileWindow | None:
+    marker_offset = text.find(PROFILE_MARKER)
+    if marker_offset < 0:
+        return None
+
+    payload = text[marker_offset + len(PROFILE_MARKER) :]
+    # Keep structured siblings such as [ParallelRecordProfile][Config] out of
+    # the aggregation stream. Data windows always separate the marker and the
+    # first key with whitespace.
+    if payload and not payload[0].isspace():
+        return None
+    fields: dict[str, str] = {}
+    for match in KEY_VALUE_RE.finditer(payload):
+        key, value = match.groups()
+        if key in fields:
+            raise ProfileParseError(
+                f"{source}:{line_number}: duplicate {key!r} field in profile window"
+            )
+        fields[key] = value
+
+    missing = [field for field in ("mode",) + REQUIRED_FIELDS if field not in fields]
+    if missing:
+        raise ProfileParseError(
+            f"{source}:{line_number}: profile window is missing fields: "
+            + ", ".join(missing)
+        )
+
+    location = f"{source}:{line_number}"
+    mode = fields["mode"]
+    if mode not in PROFILE_MODES:
+        raise ProfileParseError(
+            f"{location}: mode must be one of {', '.join(PROFILE_MODES)}, got {mode!r}"
+        )
+    integers = {
+        field: _parse_nonnegative_int(fields[field], field, location)
+        for field in INTEGER_FIELDS
+    }
+    numbers = {
+        field: _parse_nonnegative_float(fields[field], field, location)
+        for field in WEIGHTED_FIELDS + MAX_FIELDS
+    }
+
+    if integers["samples"] == 0:
+        raise ProfileParseError(f"{location}: samples must be greater than zero")
+    if integers["requested"] > integers["samples"]:
+        raise ProfileParseError(f"{location}: requested cannot exceed samples")
+    if integers["planned"] > integers["requested"]:
+        raise ProfileParseError(f"{location}: planned cannot exceed requested")
+    if integers["effective"] > integers["planned"]:
+        raise ProfileParseError(f"{location}: effective cannot exceed planned")
+    if integers["worker_fallbacks"] > integers["planned"]:
+        raise ProfileParseError(f"{location}: worker_fallbacks cannot exceed planned")
+    if integers["effective"] + integers["worker_fallbacks"] != integers["planned"]:
+        raise ProfileParseError(
+            f"{location}: effective + worker_fallbacks must equal planned"
+        )
+    all_samples_parallel = (
+        integers["requested"] == integers["samples"]
+        and integers["planned"] == integers["samples"]
+        and integers["effective"] == integers["samples"]
+        and integers["worker_fallbacks"] == 0
+    )
+    if mode == "serial" and any(
+        integers[field] != 0
+        for field in ("requested", "planned", "effective", "worker_fallbacks")
+    ):
+        raise ProfileParseError(f"{location}: serial mode has non-serial counters")
+    if mode == "parallel" and not all_samples_parallel:
+        raise ProfileParseError(f"{location}: parallel mode does not cover every sample")
+    if mode == "mixed" and (
+        integers["requested"] != integers["samples"] or all_samples_parallel
+    ):
+        raise ProfileParseError(f"{location}: mixed mode counters are inconsistent")
+    if numbers["record_p50_ms"] > numbers["record_p95_ms"]:
+        raise ProfileParseError(f"{location}: record_p50_ms cannot exceed record_p95_ms")
+    if numbers["record_p95_ms"] > numbers["record_p99_ms"]:
+        raise ProfileParseError(f"{location}: record_p95_ms cannot exceed record_p99_ms")
+    if numbers["record_p99_ms"] > numbers["record_max_ms"]:
+        raise ProfileParseError(f"{location}: record_p99_ms cannot exceed record_max_ms")
+    if numbers["execute_cpu_p50_ms"] > numbers["execute_cpu_p95_ms"]:
+        raise ProfileParseError(
+            f"{location}: execute_cpu_p50_ms cannot exceed execute_cpu_p95_ms"
+        )
+    if numbers["execute_cpu_p95_ms"] > numbers["execute_cpu_p99_ms"]:
+        raise ProfileParseError(
+            f"{location}: execute_cpu_p95_ms cannot exceed execute_cpu_p99_ms"
+        )
+    if numbers["execute_cpu_p99_ms"] > numbers["execute_cpu_max_ms"]:
+        raise ProfileParseError(
+            f"{location}: execute_cpu_p99_ms cannot exceed execute_cpu_max_ms"
+        )
+
+    return ProfileWindow(
+        source=source,
+        line=line_number,
+        mode=mode,
+        **integers,
+        **numbers,
+    )
+
+
+def load_profile_windows(path: Path, skip_windows: int) -> tuple[list[ProfileWindow], int]:
+    if skip_windows < 0:
+        raise ValueError("skip_windows must be non-negative")
+    try:
+        text = path.read_text(encoding="utf-8", errors="replace")
+    except OSError as error:
+        raise ProfileParseError(f"cannot read {path}: {error}") from error
+
+    windows: list[ProfileWindow] = []
+    for line_number, line in enumerate(text.splitlines(), start=1):
+        window = parse_profile_line(line, str(path), line_number)
+        if window is not None:
+            windows.append(window)
+
+    if not windows:
+        raise ProfileParseError(f"{path}: no {PROFILE_MARKER} windows found")
+
+    retained = windows[skip_windows:]
+    if not retained:
+        raise ProfileParseError(
+            f"{path}: skip-windows={skip_windows} removed all {len(windows)} profile windows"
+        )
+    return retained, min(skip_windows, len(windows))
+
+
+def aggregate_group(paths: Sequence[Path], skip_windows: int) -> dict[str, object]:
+    windows: list[ProfileWindow] = []
+    skipped = 0
+    per_log: list[dict[str, object]] = []
+    for path in paths:
+        retained, skipped_count = load_profile_windows(path, skip_windows)
+        windows.extend(retained)
+        skipped += skipped_count
+        per_log.append(
+            {
+                "path": str(path),
+                "windows": len(retained),
+                "skipped_windows": skipped_count,
+                "samples": sum(window.samples for window in retained),
+            }
+        )
+
+    samples = sum(window.samples for window in windows)
+    requested = sum(window.requested for window in windows)
+    planned = sum(window.planned for window in windows)
+    effective = sum(window.effective for window in windows)
+    worker_fallbacks = sum(window.worker_fallbacks for window in windows)
+    result: dict[str, object] = {
+        "logs": len(paths),
+        "windows": len(windows),
+        "skipped_windows": skipped,
+        "samples": samples,
+        "requested": requested,
+        "planned": planned,
+        "effective": effective,
+        "worker_fallbacks": worker_fallbacks,
+        "plan_rate": planned / requested if requested else None,
+        "worker_success_rate": effective / planned if planned else None,
+        "effective_rate": effective / requested if requested else None,
+        "mode_counts": {
+            mode: sum(window.mode == mode for window in windows)
+            for mode in PROFILE_MODES
+            if any(window.mode == mode for window in windows)
+        },
+        "per_log": per_log,
+    }
+    for field in WEIGHTED_FIELDS:
+        result[field] = sum(getattr(window, field) * window.samples for window in windows) / samples
+    for field in MAX_FIELDS:
+        result[field] = max(getattr(window, field) for window in windows)
+    return result
+
+
+def validate_group_purity(group: dict[str, object], expected: str) -> None:
+    samples = int(group["samples"])
+    requested = int(group["requested"])
+    planned = int(group["planned"])
+    effective = int(group["effective"])
+    worker_fallbacks = int(group["worker_fallbacks"])
+    mode_counts = group["mode_counts"]
+    assert isinstance(mode_counts, dict)
+
+    if expected == "serial":
+        if (
+            requested != 0
+            or planned != 0
+            or effective != 0
+            or worker_fallbacks != 0
+            or set(mode_counts) != {"serial"}
+        ):
+            raise ProfileParseError(
+                "serial logs are not a pure serial baseline: expected requested=planned="
+                "effective=worker_fallbacks=0 and mode=serial, got "
+                f"requested={requested}, planned={planned}, effective={effective}, "
+                f"worker_fallbacks={worker_fallbacks}, mode_counts={mode_counts}"
+            )
+        return
+
+    if expected == "parallel":
+        invalid_modes = set(mode_counts) - {"parallel", "mixed"}
+        if requested != samples or invalid_modes:
+            raise ProfileParseError(
+                "parallel logs are not a pure feature-on run: expected every sample "
+                f"requested and modes parallel/mixed, got samples={samples}, "
+                f"requested={requested}, mode_counts={mode_counts}"
+            )
+        return
+
+    raise ValueError(f"unsupported expected group {expected!r}")
+
+
+def _comparison(serial: float, parallel: float) -> dict[str, float | None]:
+    delta = serial - parallel
+    return {
+        "serial": serial,
+        "parallel": parallel,
+        "delta_ms": delta,
+        "improvement_ratio": delta / serial if serial > 0.0 else None,
+    }
+
+
+def make_report(
+    serial: dict[str, object],
+    parallel: dict[str, object],
+    *,
+    serial_logs: Sequence[Path],
+    parallel_logs: Sequence[Path],
+    skip_windows: int,
+) -> dict[str, object]:
+    min_worker_success_rate = 0.95
+    min_p50_improvement_ratio = 0.15
+    min_p50_improvement_ms = 0.2
+    max_tail_regression_ratio = 0.03
+    max_tail_regression_ms = 0.2
+
+    planned = int(parallel["planned"])
+    worker_success_rate = parallel["worker_success_rate"]
+    worker_success_applicable = planned > 0
+    worker_success_pass = (
+        not worker_success_applicable
+        or (
+            worker_success_rate is not None
+            and float(worker_success_rate) >= min_worker_success_rate
+        )
+    )
+
+    # Record-only values remain useful diagnostics, but release gating uses the
+    # end-to-end ExecuteNow CPU wall time so multi-CB submit overhead cannot be
+    # hidden behind faster worker recording.
+    comparisons: dict[str, object] = {
+        field: _comparison(float(serial[field]), float(parallel[field]))
+        for field in ("record_p50_ms", "record_p95_ms", "record_p99_ms")
+    }
+    serial_p50 = float(serial["execute_cpu_p50_ms"])
+    parallel_p50 = float(parallel["execute_cpu_p50_ms"])
+    p50 = _comparison(serial_p50, parallel_p50)
+    comparisons["execute_cpu_p50_ms"] = p50
+    p50_ratio = p50["improvement_ratio"]
+    checks: list[dict[str, object]] = [
+        {
+            "name": "parallel_worker_success_rate",
+            "pass": worker_success_pass,
+            "applicable": worker_success_applicable,
+            "actual": worker_success_rate,
+            "requirement": f">= {min_worker_success_rate:.0%} when planned > 0",
+        },
+    ]
+
+    if planned == 0:
+        p50_regression = parallel_p50 - serial_p50
+        p50_tolerance = max(
+            serial_p50 * max_tail_regression_ratio, max_tail_regression_ms
+        )
+        p50_pass = p50_regression <= p50_tolerance + 1e-12
+        p50.update(
+            {
+                "regression_ms": p50_regression,
+                "allowed_regression_ms": p50_tolerance,
+                "pass": p50_pass,
+            }
+        )
+        checks.append(
+            {
+                "name": "execute_cpu_p50_gated_regression",
+                "pass": p50_pass,
+                "actual_ms": p50_regression,
+                "allowed_ms": p50_tolerance,
+                "requirement": (
+                    "parallel - serial <= "
+                    f"max({max_tail_regression_ratio:.0%} of serial, "
+                    f"{max_tail_regression_ms:.3f} ms)"
+                ),
+            }
+        )
+    else:
+        p50_pass = (
+            p50_ratio is not None
+            and p50_ratio >= min_p50_improvement_ratio
+            and float(p50["delta_ms"]) >= min_p50_improvement_ms
+        )
+        checks.append(
+            {
+                "name": "execute_cpu_p50_improvement",
+                "pass": p50_pass,
+                "actual_ratio": p50_ratio,
+                "actual_ms": p50["delta_ms"],
+                "requirement": (
+                    f">= {min_p50_improvement_ratio:.0%} and "
+                    f">= {min_p50_improvement_ms:.3f} ms"
+                ),
+            }
+        )
+
+    for field in ("execute_cpu_p95_ms", "execute_cpu_p99_ms"):
+        serial_value = float(serial[field])
+        parallel_value = float(parallel[field])
+        comparison = _comparison(serial_value, parallel_value)
+        regression = parallel_value - serial_value
+        tolerance = max(serial_value * max_tail_regression_ratio, max_tail_regression_ms)
+        passed = regression <= tolerance + 1e-12
+        comparison.update(
+            {
+                "regression_ms": regression,
+                "allowed_regression_ms": tolerance,
+                "pass": passed,
+            }
+        )
+        comparisons[field] = comparison
+        checks.append(
+            {
+                "name": f"{field}_regression",
+                "pass": passed,
+                "actual_ms": regression,
+                "allowed_ms": tolerance,
+                "requirement": (
+                    "parallel - serial <= "
+                    f"max({max_tail_regression_ratio:.0%} of serial, "
+                    f"{max_tail_regression_ms:.3f} ms)"
+                ),
+            }
+        )
+
+    all_checks_pass = all(bool(check["pass"]) for check in checks)
+    verdict = ("GATED" if planned == 0 else "GO") if all_checks_pass else "EXPERIMENTAL"
+    return {
+        "schema_version": 2,
+        "verdict": verdict,
+        "inputs": {
+            "serial_logs": [str(path) for path in serial_logs],
+            "parallel_logs": [str(path) for path in parallel_logs],
+            "skip_windows_per_log": skip_windows,
+        },
+        "thresholds": {
+            "min_worker_success_rate": min_worker_success_rate,
+            "min_p50_improvement_ratio": min_p50_improvement_ratio,
+            "min_p50_improvement_ms": min_p50_improvement_ms,
+            "max_tail_regression_ratio": max_tail_regression_ratio,
+            "max_tail_regression_ms": max_tail_regression_ms,
+        },
+        "serial": serial,
+        "parallel": parallel,
+        "comparisons": comparisons,
+        "checks": checks,
+    }
+
+
+def _format_number(value: object, precision: int = 3) -> str:
+    if value is None:
+        return "n/a"
+    return f"{float(value):.{precision}f}"
+
+
+def _format_percent(value: object) -> str:
+    if value is None:
+        return "n/a"
+    return f"{float(value):.2%}"
+
+
+def render_markdown(report: dict[str, object]) -> str:
+    serial = report["serial"]
+    parallel = report["parallel"]
+    assert isinstance(serial, dict)
+    assert isinstance(parallel, dict)
+    lines = [
+        "# Parallel Command Recording A/B Report",
+        "",
+        f"**Verdict: {report['verdict']}**",
+        "",
+        "Percentiles below are sample-weighted means of the emitted aggregation-window percentiles; "
+        "max fields are maxima across retained windows. Release gates use end-to-end ExecuteNow CPU time.",
+        "",
+        "| Group | Logs | Windows | Samples | Requested | Planned | Effective | Plan rate | Worker success |",
+        "|---|---:|---:|---:|---:|---:|---:|---:|---:|",
+        (
+            f"| Serial | {serial['logs']} | {serial['windows']} | {serial['samples']} | "
+            f"{serial['requested']} | {serial['planned']} | {serial['effective']} | "
+            f"{_format_percent(serial['plan_rate'])} | "
+            f"{_format_percent(serial['worker_success_rate'])} |"
+        ),
+        (
+            f"| Parallel | {parallel['logs']} | {parallel['windows']} | {parallel['samples']} | "
+            f"{parallel['requested']} | {parallel['planned']} | {parallel['effective']} | "
+            f"{_format_percent(parallel['plan_rate'])} | "
+            f"{_format_percent(parallel['worker_success_rate'])} |"
+        ),
+        "",
+        "| Metric | Serial | Parallel |",
+        "|---|---:|---:|",
+    ]
+    for field in WEIGHTED_FIELDS + MAX_FIELDS:
+        lines.append(
+            f"| `{field}` | {_format_number(serial[field])} | {_format_number(parallel[field])} |"
+        )
+
+    lines.extend(["", "## Gates", "", "| Check | Result | Actual | Requirement |", "|---|---|---|---|"])
+    checks = report["checks"]
+    assert isinstance(checks, list)
+    for check in checks:
+        assert isinstance(check, dict)
+        if check["name"] == "parallel_worker_success_rate":
+            actual_value = check["actual"]
+            actual = "n/a" if actual_value is None else f"{float(actual_value):.2%}"
+        elif check["name"].endswith("_improvement"):
+            ratio = check["actual_ratio"]
+            ratio_text = "n/a" if ratio is None else f"{float(ratio):.2%}"
+            actual = f"{ratio_text}, {_format_number(check['actual_ms'])} ms"
+        else:
+            actual = f"{_format_number(check['actual_ms'])} ms"
+        applicable = bool(check.get("applicable", True))
+        result = "N/A" if not applicable else ("PASS" if check["pass"] else "FAIL")
+        lines.append(
+            f"| `{check['name']}` | {result} | "
+            f"{actual} | {check['requirement']} |"
+        )
+    return "\n".join(lines) + "\n"
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Compare [ParallelRecordProfile] aggregation windows from serial and parallel runs."
+    )
+    parser.add_argument(
+        "--serial-log",
+        action="append",
+        required=True,
+        type=Path,
+        help="Serial stdout.log; repeat for independent runs.",
+    )
+    parser.add_argument(
+        "--parallel-log",
+        action="append",
+        required=True,
+        type=Path,
+        help="Parallel stdout.log; repeat for independent runs.",
+    )
+    parser.add_argument(
+        "--skip-windows",
+        type=int,
+        default=0,
+        help="Discard this many warm-up windows from the start of each log.",
+    )
+    parser.add_argument(
+        "--min-runs-per-side",
+        type=int,
+        default=2,
+        help="Require this many distinct process logs on both sides (default: 2).",
+    )
+    parser.add_argument(
+        "--outdir",
+        required=True,
+        type=Path,
+        help="Directory receiving report.json and report.md.",
+    )
+    args = parser.parse_args(argv)
+    if args.skip_windows < 0:
+        parser.error("--skip-windows must be non-negative")
+    if args.min_runs_per_side < 1:
+        parser.error("--min-runs-per-side must be positive")
+    return args
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    try:
+        serial_run_count = len({path.resolve() for path in args.serial_log})
+        parallel_run_count = len({path.resolve() for path in args.parallel_log})
+        if serial_run_count < args.min_runs_per_side:
+            raise ProfileParseError(
+                "serial side has "
+                f"{serial_run_count} distinct run(s); require at least "
+                f"{args.min_runs_per_side}"
+            )
+        if parallel_run_count < args.min_runs_per_side:
+            raise ProfileParseError(
+                "parallel side has "
+                f"{parallel_run_count} distinct run(s); require at least "
+                f"{args.min_runs_per_side}"
+            )
+        serial = aggregate_group(args.serial_log, args.skip_windows)
+        parallel = aggregate_group(args.parallel_log, args.skip_windows)
+        validate_group_purity(serial, "serial")
+        validate_group_purity(parallel, "parallel")
+        report = make_report(
+            serial,
+            parallel,
+            serial_logs=args.serial_log,
+            parallel_logs=args.parallel_log,
+            skip_windows=args.skip_windows,
+        )
+        args.outdir.mkdir(parents=True, exist_ok=True)
+        json_path = args.outdir / "report.json"
+        markdown_path = args.outdir / "report.md"
+        json_path.write_text(
+            json.dumps(report, ensure_ascii=False, indent=2) + "\n",
+            encoding="utf-8",
+        )
+        markdown_path.write_text(render_markdown(report), encoding="utf-8")
+    except (OSError, ProfileParseError, ValueError) as error:
+        print(f"parallel_record_ab: error: {error}", file=sys.stderr)
+        return 2
+
+    print(f"{report['verdict']}: {json_path}")
+    return 0 if report["verdict"] == "GO" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/threading/run_matrix.py
+++ b/tools/threading/run_matrix.py
@@ -306,6 +306,23 @@ FEATURE_VALIDATION_SCENARIOS = (
     ),
 )
 
+UPPER_PARALLEL_RECORD_GATES = (
+    r"cpu=parallel-record workload=1 wave=[0-9]+ passes=\[HiZBuild\]",
+    r"cpu=parallel-record workload=1 wave=[0-9]+ passes=\[DirectionalShadowMask\]",
+    r"cpu=parallel-record workload=1 wave=[0-9]+ passes=\[Lighting\]",
+    r"cpu=parallel-record workload=1 wave=[0-9]+ passes=\[Skybox\]",
+    (
+        r"\[RenderGraph\]\[ParallelRecordDispatch\] graph=RasterFrame "
+        r"passes=\[HiZBuild,DirectionalShadowMask\] dispatch=task-graph "
+        r"worker_jobs=2 completed=true"
+    ),
+    (
+        r"\[RenderGraph\]\[ParallelRecordDispatch\] graph=RasterFrame "
+        r"passes=\[Lighting,Skybox\] dispatch=task-graph "
+        r"worker_jobs=2 completed=true"
+    ),
+)
+
 SCENARIOS = {
     scenario.name: scenario
     for scenario in (
@@ -547,6 +564,9 @@ def build_verifier_command(
         command.append("--expect-exit-after-ready")
     for pattern in required_patterns(scenario):
         command.extend(["--require-log-pattern", pattern])
+    if scenario.render_graph_parallel_recording:
+        for pattern in UPPER_PARALLEL_RECORD_GATES:
+            command.extend(["--require-log-min-count", pattern, "1"])
     if scenario.renderer == "Raster":
         raster_mode_marker = (
             "[RenderGraph] Raster execution mode: "

--- a/tools/threading/run_matrix.py
+++ b/tools/threading/run_matrix.py
@@ -22,10 +22,12 @@ class Scenario:
     max_frame_lag: int
     render_graph: bool = False
     render_graph_debug_dump: bool = False
+    render_graph_parallel_recording: bool = False
     window_stress: bool = False
     editor_args: tuple[str, ...] = ()
     fault_validation: bool = False
     renderer_switch_validation: bool = False
+    raster_lifecycle_validation: bool = False
     framebuffer_validation: str | None = None
     expect_exit_after_ready: bool = False
     ready_log_pattern: str | None = None
@@ -239,6 +241,69 @@ FEATURE_VALIDATION_SCENARIOS = (
         ready_log_pattern="[ThreadingValidation][RendererSwitch] Complete:",
         require_profile_logs=False,
     ),
+    Scenario(
+        "feature_raster_graph_serial_recording",
+        "Raster",
+        True,
+        True,
+        False,
+        1,
+        render_graph=True,
+        render_graph_debug_dump=True,
+        editor_args=("--threading-raster-lifecycle-validation", "--no-splash"),
+        raster_lifecycle_validation=True,
+        expect_exit_after_ready=True,
+        ready_log_pattern="[ThreadingValidation][RasterLifecycle] Complete:",
+        require_profile_logs=False,
+    ),
+    Scenario(
+        "feature_raster_graph_parallel_recording",
+        "Raster",
+        True,
+        True,
+        False,
+        1,
+        render_graph=True,
+        render_graph_debug_dump=True,
+        render_graph_parallel_recording=True,
+        editor_args=("--threading-raster-lifecycle-validation", "--no-splash"),
+        raster_lifecycle_validation=True,
+        expect_exit_after_ready=True,
+        ready_log_pattern="[ThreadingValidation][RasterLifecycle] Complete:",
+        require_profile_logs=False,
+    ),
+    Scenario(
+        "feature_raster_graph_parallel_recording_gt",
+        "Raster",
+        False,
+        True,
+        False,
+        0,
+        render_graph=True,
+        render_graph_debug_dump=True,
+        render_graph_parallel_recording=True,
+        editor_args=("--threading-raster-lifecycle-validation", "--no-splash"),
+        raster_lifecycle_validation=True,
+        expect_exit_after_ready=True,
+        ready_log_pattern="[ThreadingValidation][RasterLifecycle] Complete:",
+        require_profile_logs=False,
+    ),
+    Scenario(
+        "feature_raster_graph_parallel_recording_reload_switch",
+        "Raster",
+        True,
+        True,
+        False,
+        1,
+        render_graph=True,
+        render_graph_debug_dump=True,
+        render_graph_parallel_recording=True,
+        editor_args=("--threading-renderer-switch-validation", "--no-splash"),
+        renderer_switch_validation=True,
+        expect_exit_after_ready=True,
+        ready_log_pattern="[ThreadingValidation][RendererSwitch] Complete:",
+        require_profile_logs=False,
+    ),
 )
 
 SCENARIOS = {
@@ -291,6 +356,10 @@ def generate_config(base_text: str, scenario: Scenario) -> str:
             "engine.render.raster",
             "render_graph_debug_dump",
         ): scenario.render_graph_debug_dump,
+        (
+            "engine.render.raster",
+            "render_graph_parallel_recording",
+        ): scenario.render_graph_parallel_recording,
     }
     replaced = {target: 0 for target in replacements}
     current_section = ""
@@ -337,6 +406,9 @@ def generate_config(base_text: str, scenario: Scenario) -> str:
         ("engine.render.raster", "render_graph"): raster["render_graph"],
         ("engine.render.raster", "render_graph_debug_dump"): raster[
             "render_graph_debug_dump"
+        ],
+        ("engine.render.raster", "render_graph_parallel_recording"): raster[
+            "render_graph_parallel_recording"
         ],
     }
     if actual != replacements:
@@ -389,6 +461,14 @@ def required_patterns(scenario: Scenario) -> list[str]:
         )
         if scenario.render_graph:
             patterns.append("[RenderGraph][DebugDump]")
+            patterns.append(
+                "upper recording: "
+                + (
+                    "parallel-eligible"
+                    if scenario.render_graph_parallel_recording
+                    else "serial-fallback"
+                )
+            )
     if scenario.renderer_switch_validation:
         patterns.extend(
             [
@@ -401,6 +481,13 @@ def required_patterns(scenario: Scenario) -> list[str]:
                     "[Threading] Raytracing frames execute on "
                     f"{execution_thread} thread id ="
                 ),
+            ]
+        )
+    if scenario.raster_lifecycle_validation:
+        patterns.extend(
+            [
+                "[ThreadingValidation][RasterLifecycle] Enabled",
+                "[ThreadingValidation][RasterLifecycle] Complete:",
             ]
         )
     if scenario.framebuffer_validation:
@@ -1214,6 +1301,7 @@ def main() -> int:
                 f"rhi={scenario.rhi_thread}, bypass={scenario.rhi_bypass}, "
                 f"lag={scenario.max_frame_lag}, graph={scenario.render_graph}, "
                 f"graph_dump={scenario.render_graph_debug_dump}, "
+                f"graph_parallel_record={scenario.render_graph_parallel_recording}, "
                 f"stress={scenario.window_stress}"
             )
         return 0

--- a/tools/threading/run_parallel_record_vulkan_test.py
+++ b/tools/threading/run_parallel_record_vulkan_test.py
@@ -1,0 +1,205 @@
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Sequence
+
+
+SUMMARY_RE = re.compile(
+    r"\[ParallelRecord\] batch=(?P<batch>\d+).*?effective=(?P<effective>true|false) "
+    r"outcome=(?P<outcome>\S+).*?work_units=(?P<work_units>\d+) "
+    r"ordered_cb=(?P<ordered_cb>\d+) "
+    r"waves=(?P<waves>\d+) islands=(?P<islands>\d+).*?"
+    r"distinct_workers=(?P<workers>\d+) max_active=(?P<max_active>\d+)"
+)
+INJECTION_RE = re.compile(
+    r"\[ParallelRecord\]\[Injection\].*?point=worker-throw "
+    r"phase=after-first-command.*?batch=(?P<batch>\d+)"
+)
+
+
+class VulkanTestError(RuntimeError):
+    pass
+
+
+def _require(condition: bool, message: str) -> None:
+    if not condition:
+        raise VulkanTestError(message)
+
+
+def validate_log(mode: str, text: str) -> None:
+    _require("[TESTCASE][FAIL]" not in text, f"{mode}: test emitted a FAIL marker")
+    _require("VUID-" not in text, f"{mode}: Vulkan validation VUID was emitted")
+    _require("Validation Error" not in text, f"{mode}: Vulkan validation error was emitted")
+    expected_fault = "true" if mode == "fallback" else "false"
+    expected_mode = "serial" if mode == "serial" else "parallel"
+    expected_production_gate = "true" if mode in ("gated", "heavy") else "false"
+    expected_production_heavy = "true" if mode == "heavy" else "false"
+    _require(
+        re.search(
+            rf"\[TESTCASE\]\[PASS\].*mode={expected_mode}.*worker_fault={expected_fault}"
+            rf".*production_gate={expected_production_gate}"
+            rf".*production_heavy={expected_production_heavy}",
+            text,
+        )
+        is not None,
+        f"{mode}: missing matching PASS marker",
+    )
+
+    summaries = [match.groupdict() for match in SUMMARY_RE.finditer(text)]
+    if mode == "serial":
+        _require(not summaries, "serial: parallel backend summary was unexpectedly emitted")
+        _require("[ParallelRecord][Injection]" not in text, "serial: fault injection ran")
+        return
+    if mode == "gated":
+        _require(not summaries, "gated: cheap workload unexpectedly recorded in parallel")
+        _require(
+            "reason=insufficient-work" in text,
+            "gated: production threshold did not report insufficient work",
+        )
+        _require("[ParallelRecord][Wave]" not in text, "gated: worker wave was dispatched")
+        _require("[ParallelRecord][Injection]" not in text, "gated: fault injection ran")
+        return
+
+    _require(summaries, f"{mode}: no parallel backend summary was emitted")
+    _require(
+        any(
+            item["outcome"] == "parallel"
+            and int(item["work_units"]) > 0
+            and int(item["ordered_cb"]) > 1
+            and int(item["waves"]) >= 2
+            and int(item["islands"]) >= 1
+            and int(item["workers"]) >= 2
+            and int(item["max_active"]) >= 2
+            for item in summaries
+        ),
+        f"{mode}: no effective concurrent multi-CB batch with two waves and a serial island",
+    )
+    if mode == "heavy":
+        _require(
+            any(int(item["work_units"]) >= 128 for item in summaries),
+            "heavy: production floor did not admit two threshold-sized jobs",
+        )
+
+    lines = text.splitlines()
+    first_parallel_batch = next(
+        item["batch"] for item in summaries if item["outcome"] == "parallel"
+    )
+    wave_positions = [
+        index
+        for index, line in enumerate(lines)
+        if f"[ParallelRecord][Wave] batch={first_parallel_batch} " in line
+    ]
+    island_positions = [
+        index
+        for index, line in enumerate(lines)
+        if f"[ParallelRecord][Island] batch={first_parallel_batch} " in line
+    ]
+    _require(
+        any(
+            any(wave < island for wave in wave_positions)
+            and any(wave > island for wave in wave_positions)
+            for island in island_positions
+        ),
+        f"{mode}: logs do not prove joined wave -> serial island -> later wave order",
+    )
+
+    injection_batches = [match.group("batch") for match in INJECTION_RE.finditer(text)]
+    fallback_batches = [
+        item["batch"]
+        for item in summaries
+        if item["outcome"] == "serial-fallback-worker-failure"
+    ]
+    if mode in ("parallel", "heavy"):
+        _require(not injection_batches, "parallel: unexpected worker fault injection")
+        _require(not fallback_batches, "parallel: unexpected worker fallback")
+    else:
+        _require(
+            len(injection_batches) == 1,
+            f"fallback: expected one post-command injection, got {len(injection_batches)}",
+        )
+        _require(
+            len(fallback_batches) == 1,
+            f"fallback: expected one fallback batch, got {len(fallback_batches)}",
+        )
+        fault_batch = fallback_batches[0]
+        _require(
+            injection_batches[0] == fault_batch,
+            "fallback: injection and coordinator fallback belong to different batches",
+        )
+        _require(
+            re.search(
+                rf"\[ParallelRecord\]\[Wave\] batch={fault_batch} .*?worker_recorded=false",
+                text,
+            )
+            is not None,
+            "fallback: injected batch has no failed worker wave",
+        )
+
+
+def run_case(executable: Path, outdir: Path, mode: str, timeout: float) -> Path:
+    arguments: list[str] = []
+    if mode != "serial":
+        arguments.append("--parallel")
+    if mode == "fallback":
+        arguments.append("--inject-worker-failure")
+    if mode == "gated":
+        arguments.append("--production-gate")
+    if mode == "heavy":
+        arguments.append("--production-heavy")
+
+    completed = subprocess.run(
+        [str(executable), *arguments],
+        cwd=executable.parent,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        timeout=timeout,
+        check=False,
+    )
+    text = completed.stdout + completed.stderr
+    outdir.mkdir(parents=True, exist_ok=True)
+    log_path = outdir / f"{mode}.log"
+    log_path.write_text(text, encoding="utf-8")
+    _require(completed.returncode == 0, f"{mode}: executable returned {completed.returncode}")
+    validate_log(mode, text)
+    return log_path
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Run and gate the Vulkan parallel-record serial/parallel/fallback matrix."
+    )
+    parser.add_argument("--executable", required=True, type=Path)
+    parser.add_argument("--outdir", required=True, type=Path)
+    parser.add_argument("--timeout", type=float, default=180.0)
+    args = parser.parse_args(argv)
+    if args.timeout <= 0.0:
+        parser.error("--timeout must be positive")
+    return args
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    executable = args.executable.resolve()
+    if not executable.is_file():
+        print(f"parallel Vulkan test: executable not found: {executable}", file=sys.stderr)
+        return 2
+    try:
+        logs = [
+            run_case(executable, args.outdir, mode, args.timeout)
+            for mode in ("serial", "parallel", "fallback", "gated", "heavy")
+        ]
+    except (OSError, subprocess.TimeoutExpired, VulkanTestError) as error:
+        print(f"parallel Vulkan test: FAIL: {error}", file=sys.stderr)
+        return 1
+    print("parallel Vulkan test: PASS: " + ", ".join(str(path) for path in logs))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/threading/runtime_verify.py
+++ b/tools/threading/runtime_verify.py
@@ -543,6 +543,15 @@ def main() -> int:
                 wait_process_alive(process, args.startup_settle_seconds)
 
             if not args.expect_exit_after_ready:
+                # Startup splash and editor share a process. Re-resolve the
+                # largest visible top-level window after the ready/settle gate
+                # so capture and WM_CLOSE target the editor rather than a stale
+                # splash HWND discovered during process launch.
+                refreshed_hwnd = find_main_window(process, 5.0)
+                if refreshed_hwnd:
+                    main_hwnd = refreshed_hwnd
+                    report["main_hwnd"] = int(main_hwnd)
+
                 if args.detach_configs:
                     for start_x_ratio in (0.765, 0.75, 0.78):
                         drag_window_tab(main_hwnd, start_x_ratio, 70, 1900, 300)

--- a/tools/threading/test_parallel_record_ab.py
+++ b/tools/threading/test_parallel_record_ab.py
@@ -1,0 +1,371 @@
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+import parallel_record_ab
+
+
+def profile_line(**overrides: float | int | str) -> str:
+    values: dict[str, float | int | str] = {
+        "mode": "serial",
+        "samples": 100,
+        "requested": 0,
+        "planned": 0,
+        "effective": 0,
+        "worker_fallbacks": 0,
+        "record_p50_ms": 2.0,
+        "record_p95_ms": 3.0,
+        "record_p99_ms": 4.0,
+        "record_max_ms": 5.0,
+        "execute_cpu_p50_ms": 2.1,
+        "execute_cpu_p95_ms": 3.1,
+        "execute_cpu_p99_ms": 4.1,
+        "execute_cpu_max_ms": 5.1,
+        "reorder_avg_ms": 0.1,
+        "preprocess_avg_ms": 0.2,
+        "worker_join_avg_ms": 1.0,
+        "submit_cpu_avg_ms": 0.1,
+        "jobs_avg": 4.0,
+        "work_units_avg": 256.0,
+        "ordered_cb_avg": 4.0,
+        "max_active": 4,
+    }
+    values.update(overrides)
+    if "planned" not in overrides and "effective" in overrides:
+        values["planned"] = values["effective"]
+    if "worker_fallbacks" not in overrides:
+        values["worker_fallbacks"] = int(values["planned"]) - int(values["effective"])
+    fields = " ".join(f"{key}={value}" for key, value in values.items())
+    return f"[2026-07-22 12:00:00] [ParallelRecordProfile] {fields}\n"
+
+
+class ParallelRecordAbTests(unittest.TestCase):
+    def write_log(self, root: Path, name: str, *lines: str) -> Path:
+        path = root / name
+        path.write_text("unrelated log line\n" + "".join(lines), encoding="utf-8")
+        return path
+
+    def test_aggregate_skips_each_log_and_weights_by_samples(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            first = self.write_log(
+                root,
+                "first.log",
+                profile_line(record_p50_ms=9.0, record_p95_ms=9.0, record_p99_ms=9.0, record_max_ms=9.0),
+                profile_line(
+                    mode="mixed", samples=100, requested=100, effective=96, record_p50_ms=2.0
+                ),
+            )
+            second = self.write_log(
+                root,
+                "second.log",
+                profile_line(record_p50_ms=8.0, record_p95_ms=8.0, record_p99_ms=8.0, record_max_ms=8.0),
+                profile_line(
+                    mode="mixed", samples=300, requested=300, effective=294, record_p50_ms=1.0
+                ),
+            )
+            aggregate = parallel_record_ab.aggregate_group([first, second], 1)
+
+            self.assertEqual(aggregate["windows"], 2)
+            self.assertEqual(aggregate["skipped_windows"], 2)
+            self.assertEqual(aggregate["samples"], 400)
+            self.assertEqual(aggregate["requested"], 400)
+            self.assertEqual(aggregate["planned"], 390)
+            self.assertEqual(aggregate["effective"], 390)
+            self.assertAlmostEqual(float(aggregate["plan_rate"]), 0.975)
+            self.assertAlmostEqual(float(aggregate["worker_success_rate"]), 1.0)
+            self.assertAlmostEqual(float(aggregate["effective_rate"]), 0.975)
+            self.assertAlmostEqual(float(aggregate["record_p50_ms"]), 1.25)
+            self.assertEqual(aggregate["record_max_ms"], 5.0)
+
+    def test_go_requires_all_four_gates(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            serial_log = self.write_log(root, "serial.log", profile_line())
+            parallel_log = self.write_log(
+                root,
+                "parallel.log",
+                profile_line(
+                    mode="mixed",
+                    requested=100,
+                    effective=97,
+                    record_p50_ms=1.5,
+                    record_p95_ms=3.1,
+                    record_p99_ms=4.1,
+                    execute_cpu_p50_ms=1.5,
+                    execute_cpu_p95_ms=3.1,
+                    execute_cpu_p99_ms=4.1,
+                ),
+            )
+            serial = parallel_record_ab.aggregate_group([serial_log], 0)
+            parallel = parallel_record_ab.aggregate_group([parallel_log], 0)
+            report = parallel_record_ab.make_report(
+                serial,
+                parallel,
+                serial_logs=[serial_log],
+                parallel_logs=[parallel_log],
+                skip_windows=0,
+            )
+
+            self.assertEqual(report["verdict"], "GO")
+            self.assertTrue(all(check["pass"] for check in report["checks"]))
+
+    def test_experimental_when_absolute_p50_gain_or_tail_gate_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            serial_log = self.write_log(
+                root,
+                "serial.log",
+                profile_line(record_p50_ms=1.0, record_p95_ms=3.0, record_p99_ms=4.0),
+            )
+            parallel_log = self.write_log(
+                root,
+                "parallel.log",
+                profile_line(
+                    mode="parallel",
+                    requested=100,
+                    effective=100,
+                    record_p50_ms=0.84,
+                    record_p95_ms=3.21,
+                    record_p99_ms=4.21,
+                    execute_cpu_p50_ms=1.94,
+                    execute_cpu_p95_ms=3.31,
+                    execute_cpu_p99_ms=4.31,
+                ),
+            )
+            report = parallel_record_ab.make_report(
+                parallel_record_ab.aggregate_group([serial_log], 0),
+                parallel_record_ab.aggregate_group([parallel_log], 0),
+                serial_logs=[serial_log],
+                parallel_logs=[parallel_log],
+                skip_windows=0,
+            )
+
+            self.assertEqual(report["verdict"], "EXPERIMENTAL")
+            failures = {check["name"] for check in report["checks"] if not check["pass"]}
+            self.assertEqual(
+                failures,
+                {
+                    "execute_cpu_p50_improvement",
+                    "execute_cpu_p95_ms_regression",
+                    "execute_cpu_p99_ms_regression",
+                },
+            )
+
+    def test_no_qualifying_work_is_gated_without_worker_failure(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            serial_log = self.write_log(root, "serial.log", profile_line())
+            parallel_log = self.write_log(
+                root,
+                "parallel.log",
+                profile_line(
+                    mode="mixed",
+                    requested=100,
+                    planned=0,
+                    effective=0,
+                    execute_cpu_p50_ms=2.15,
+                    execute_cpu_p95_ms=3.15,
+                    execute_cpu_p99_ms=4.15,
+                ),
+            )
+            report = parallel_record_ab.make_report(
+                parallel_record_ab.aggregate_group([serial_log], 0),
+                parallel_record_ab.aggregate_group([parallel_log], 0),
+                serial_logs=[serial_log],
+                parallel_logs=[parallel_log],
+                skip_windows=0,
+            )
+
+            self.assertEqual(report["verdict"], "GATED")
+            self.assertEqual(report["parallel"]["plan_rate"], 0.0)
+            self.assertIsNone(report["parallel"]["worker_success_rate"])
+            worker_check = report["checks"][0]
+            self.assertFalse(worker_check["applicable"])
+            self.assertTrue(worker_check["pass"])
+
+    def test_execute_cpu_gate_catches_submit_overhead(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            serial_log = self.write_log(root, "serial.log", profile_line())
+            parallel_log = self.write_log(
+                root,
+                "parallel.log",
+                profile_line(
+                    mode="parallel",
+                    requested=100,
+                    effective=100,
+                    record_p50_ms=1.4,
+                    execute_cpu_p50_ms=2.4,
+                    submit_cpu_avg_ms=0.8,
+                ),
+            )
+            report = parallel_record_ab.make_report(
+                parallel_record_ab.aggregate_group([serial_log], 0),
+                parallel_record_ab.aggregate_group([parallel_log], 0),
+                serial_logs=[serial_log],
+                parallel_logs=[parallel_log],
+                skip_windows=0,
+            )
+
+            self.assertEqual(report["verdict"], "EXPERIMENTAL")
+            failures = {check["name"] for check in report["checks"] if not check["pass"]}
+            self.assertIn("execute_cpu_p50_improvement", failures)
+
+    def test_worker_success_is_measured_only_over_planned_submissions(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            log = self.write_log(
+                root,
+                "parallel.log",
+                profile_line(
+                    mode="mixed",
+                    requested=100,
+                    planned=20,
+                    effective=19,
+                    worker_fallbacks=1,
+                ),
+            )
+            aggregate = parallel_record_ab.aggregate_group([log], 0)
+
+            self.assertAlmostEqual(float(aggregate["plan_rate"]), 0.2)
+            self.assertAlmostEqual(float(aggregate["worker_success_rate"]), 0.95)
+
+    def test_malformed_profile_line_is_not_silently_ignored(self) -> None:
+        with self.assertRaisesRegex(parallel_record_ab.ProfileParseError, "missing fields"):
+            parallel_record_ab.parse_profile_line(
+                "[ParallelRecordProfile] samples=10 requested=10 effective=10",
+                "broken.log",
+                7,
+            )
+
+    def test_mode_must_match_window_counters(self) -> None:
+        inconsistent_lines = (
+            profile_line(mode="serial", requested=100, planned=0, effective=0),
+            profile_line(
+                mode="parallel",
+                requested=100,
+                planned=99,
+                effective=99,
+            ),
+            profile_line(
+                mode="mixed",
+                requested=100,
+                planned=100,
+                effective=100,
+            ),
+        )
+
+        for line_number, line in enumerate(inconsistent_lines, start=1):
+            with self.subTest(line_number=line_number):
+                with self.assertRaisesRegex(
+                    parallel_record_ab.ProfileParseError,
+                    "mode|counters",
+                ):
+                    parallel_record_ab.parse_profile_line(
+                        line,
+                        "inconsistent.log",
+                        line_number,
+                    )
+
+    def test_config_sibling_is_ignored(self) -> None:
+        self.assertIsNone(
+            parallel_record_ab.parse_profile_line(
+                "[ParallelRecordProfile][Config] queue=Graphics enabled=true",
+                "profile.log",
+                1,
+            )
+        )
+
+    def test_group_purity_rejects_swapped_inputs(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            feature_on = self.write_log(
+                root,
+                "feature_on.log",
+                profile_line(mode="parallel", requested=100, effective=100),
+            )
+            aggregate = parallel_record_ab.aggregate_group([feature_on], 0)
+            with self.assertRaisesRegex(
+                parallel_record_ab.ProfileParseError, "pure serial baseline"
+            ):
+                parallel_record_ab.validate_group_purity(aggregate, "serial")
+
+    def test_main_writes_json_and_markdown(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            serial_log = self.write_log(root, "serial.log", profile_line())
+            serial_log_2 = self.write_log(root, "serial_2.log", profile_line())
+            parallel_log = self.write_log(
+                root,
+                "parallel.log",
+                profile_line(
+                    mode="parallel",
+                    requested=100,
+                    effective=100,
+                    record_p50_ms=1.5,
+                    execute_cpu_p50_ms=1.5,
+                ),
+            )
+            parallel_log_2 = self.write_log(
+                root,
+                "parallel_2.log",
+                profile_line(
+                    mode="parallel",
+                    requested=100,
+                    effective=100,
+                    record_p50_ms=1.5,
+                    execute_cpu_p50_ms=1.5,
+                ),
+            )
+            outdir = root / "report"
+
+            exit_code = parallel_record_ab.main(
+                [
+                    "--serial-log",
+                    str(serial_log),
+                    "--serial-log",
+                    str(serial_log_2),
+                    "--parallel-log",
+                    str(parallel_log),
+                    "--parallel-log",
+                    str(parallel_log_2),
+                    "--outdir",
+                    str(outdir),
+                ]
+            )
+
+            self.assertEqual(exit_code, 0)
+            report = json.loads((outdir / "report.json").read_text(encoding="utf-8"))
+            self.assertEqual(report["verdict"], "GO")
+            self.assertIn("**Verdict: GO**", (outdir / "report.md").read_text(encoding="utf-8"))
+
+    def test_main_requires_distinct_runs_on_both_sides(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            serial_log = self.write_log(root, "serial.log", profile_line())
+            parallel_log = self.write_log(
+                root,
+                "parallel.log",
+                profile_line(mode="parallel", requested=100, effective=100),
+            )
+
+            exit_code = parallel_record_ab.main(
+                [
+                    "--serial-log",
+                    str(serial_log),
+                    "--parallel-log",
+                    str(parallel_log),
+                    "--outdir",
+                    str(root / "report"),
+                ]
+            )
+
+            self.assertEqual(exit_code, 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/threading/test_run_parallel_record_vulkan_test.py
+++ b/tools/threading/test_run_parallel_record_vulkan_test.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import unittest
+
+import run_parallel_record_vulkan_test as runner
+
+
+def pass_line(
+    mode: str,
+    fault: str,
+    production_gate: str = "false",
+    production_heavy: str = "false",
+) -> str:
+    return (
+        "[TESTCASE][PASS] name=ParallelRecordOrderedReadback "
+        f"mode={mode} worker_fault={fault} production_gate={production_gate} "
+        f"production_heavy={production_heavy} iterations=24\n"
+    )
+
+
+def wave(batch: int, index: int) -> str:
+    return (
+        f"[ParallelRecord][Wave] batch={batch} wave={index} layers=0..2 jobs=2 "
+        "join_completed=true worker_recorded=true\n"
+    )
+
+
+def island(batch: int) -> str:
+    return (
+        f"[ParallelRecord][Island] batch={batch} island=0 first_layer=2 joined_waves=1\n"
+    )
+
+
+def summary(batch: int, outcome: str = "parallel") -> str:
+    effective = "true" if outcome == "parallel" else "false"
+    return (
+        f"[ParallelRecord] batch={batch} requested=true effective={effective} "
+        f"outcome={outcome} layers=4 jobs=4 work_units=256 ordered_cb=10 waves=2 islands=1 "
+        "workers=4 distinct_workers=3 max_active=3 coordinator=9 submit_status=0\n"
+    )
+
+
+class VulkanRunnerTests(unittest.TestCase):
+    def test_serial_accepts_only_pass_marker(self) -> None:
+        runner.validate_log("serial", pass_line("serial", "false"))
+
+    def test_parallel_requires_wave_island_wave_and_concurrency(self) -> None:
+        text = wave(1, 0) + island(1) + wave(1, 1) + summary(1) + pass_line("parallel", "false")
+        runner.validate_log("parallel", text)
+
+    def test_parallel_rejects_missing_second_wave(self) -> None:
+        text = wave(1, 0) + island(1) + summary(1) + pass_line("parallel", "false")
+        with self.assertRaisesRegex(runner.VulkanTestError, "do not prove"):
+            runner.validate_log("parallel", text)
+
+    def test_production_gate_rejects_cheap_copy_workload(self) -> None:
+        text = (
+            "[ParallelRecord] batch=1 requested=true effective=false "
+            "reason=insufficient-work coordinator=9\n"
+            + pass_line("parallel", "false", "true")
+        )
+        runner.validate_log("gated", text)
+
+    def test_production_heavy_requires_real_weighted_parallel_work(self) -> None:
+        text = (
+            wave(1, 0)
+            + island(1)
+            + wave(1, 1)
+            + summary(1)
+            + pass_line("parallel", "false", "true", "true")
+        )
+        runner.validate_log("heavy", text)
+
+    def test_fallback_requires_exactly_one_post_command_injection(self) -> None:
+        text = (
+            "[ParallelRecord][Injection] point=worker-throw phase=after-first-command "
+            "trigger=1 batch=1 layer=0 command=0\n"
+            + wave(1, 0).replace("worker_recorded=true", "worker_recorded=false")
+            + island(1)
+            + wave(1, 1)
+            + summary(1, "serial-fallback-worker-failure")
+            + wave(2, 0)
+            + island(2)
+            + wave(2, 1)
+            + summary(2)
+            + pass_line("parallel", "true")
+        )
+        runner.validate_log("fallback", text)
+
+    def test_validation_vuid_is_fatal(self) -> None:
+        with self.assertRaisesRegex(runner.VulkanTestError, "Vulkan validation VUID"):
+            runner.validate_log("serial", "VUID-vkQueueSubmit-test\n" + pass_line("serial", "false"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Introduce an explicit RHI executor and stable submission-source topology, including unfinished `CommandList` handoff through recording completion gates.
- Add the Vulkan lower-level parallel translate/record path with transactional descriptor leases, ordered serial GPU submission, fallback/rejection handling, and bindless lifetime hardening.
- Add a distinct RenderGraph CPU recording plan and pass taxonomy (`MainThread`, `CpuPrepare`, `ExternalControl`, `SerialRecord`, `ParallelRecordEligible`).
- Migrate two audited Raster production recording groups: `HiZBuild + DirectionalShadowMask` and `Lighting + Skybox`.
- Add focused contracts, a real Vulkan five-mode matrix, runtime lifecycle scenarios, A/B tooling, and feature configuration. Generated shader caches are now ignored.

## Architecture

The upper path follows the useful ownership model from `dev_parallel_rhi` without replacing the modern RDG compiler:

1. RDG compiles stable one-pass recording batches.
2. Each record pass receives an independently owned `CommandList` and completion gate.
3. Unfinished sources are registered with `RHIExecutor` before worker dispatch.
4. Immutable callbacks record on TaskGraph workers.
5. RHI materializes sources in compiled order after their gates become terminal.
6. Vulkan may translate/record safe work in parallel, while GPU submission remains stable and serial.

Texture/buffer GPU hazards may span one CPU recording group because they constrain GPU execution, not immutable command construction. Token hazards and explicit `DependsOn` edges remain CPU recording boundaries. `CpuPrepare` only accesses logical tokens or references GPU identities and is excluded from the prospective GPU queue plan.

## Safety and behavior

- Both upper and lower parallel switches default to off.
- RDG sources remain `SerialControl` at the backend until barrier/multi-queue metadata is actively lowered.
- Record callbacks own immutable, strongly referenced snapshots through terminal GPU/rejection callbacks.
- Worker completion order cannot change source or GPU submission order.
- Failure paths preserve callbacks and deferred releases while suppressing success-only work.
- Fixed-capacity descriptor arrays now treat the declared size as a maximum: empty and oversized arrays are rejected, while unused fixed slots are initialized from the last valid element. This fixes Raytracing environment mip setup exposed by renderer switching without reintroducing partially initialized descriptor leases.

## Validation

- Release build: `MoerEditor`, `TestRenderGraph`, and RHI/Vulkan contract targets passed.
- `ctest --test-dir build -C Release --output-on-failure`: **9/9 passed**.
- Vulkan serial / forced-parallel / injected-fallback / gated / heavy matrix: **all passed**.
- Raster runtime matrix: serial upper recording, RT upper parallel, GT upper parallel, and Raster reload → Raytracing → Raster with upper parallel: **all passed**, with no RenderGraph fallback, VUID, access violation, or abnormal exit.
- Dedicated tests cover pending-source publication, completion-order inversion, Token/explicit recording boundaries, caller-thread joins without named-thread re-entry, queue-plan separation, callback lifetime, and descriptor/bindless rollback.

## Current boundaries

- Mutable AO/history, Geometry/Culling, Shadow/Probe residency, post-process state chains, and UI/swapchain passes remain caller-thread callbacks until they receive equivalent Prepare/Record snapshots.
- `ExternalControl` remains shadow queue metadata; active multi-queue lowering must model it as an external submit/sync endpoint.
- This PR establishes architecture and correctness. It does not claim a default-on performance decision.