### PR TITLE
feat(rhi): establish executor submission completion ownership

### DIFF
--- a/source/runtime/core/include/taskgraph/TaskGraph.h
+++ b/source/runtime/core/include/taskgraph/TaskGraph.h
@@ -15,8 +15,8 @@ private:
 public:
     CORE_API static TaskGraph& GetInterface();
     CORE_API static bool       IsInitialized() noexcept;
-    static void                Init();
-    static void                Shutdown();
+    CORE_API static void       Init();
+    CORE_API static void       Shutdown();
     TaskGraph();
     ~TaskGraph();
     CORE_API void WaitUntilTasksComplete(const GraphEventArray& task_events, EThread::Type currentThread);

--- a/source/runtime/core/source/taskgraph/TaskGraph.cpp
+++ b/source/runtime/core/source/taskgraph/TaskGraph.cpp
@@ -121,8 +121,11 @@ EThread::Type TaskGraph::GetCurrentThread(bool localQueue) {
             (localQueue ? EThread::LOCAL_QUEUE : EThread::MAIN_QUEUE)
         );
     }
-    assert(false);
-    return EThread::UNKNOWN_THREAD;
+    // Dedicated runtime owners such as the RHI Executor are intentionally not
+    // TaskGraph workers. Treat them as external callers so GraphEvent::Wait()
+    // installs an ordinary completion event instead of indexing a named
+    // worker queue. This matches the dev_parallel_rhi ownership model.
+    return EThread::SetPriority(EThread::UNKNOWN_THREAD, EThread::NORMAL_PRI);
 }
 bool TaskGraph::IsThreadProcessingTask(EThread::Type index) {
     return m_workers[EThread::GetThreadIndex(index)].task_thread->IsProcessingTask(

--- a/source/runtime/core/source/taskgraph/ThreadManager.cpp
+++ b/source/runtime/core/source/taskgraph/ThreadManager.cpp
@@ -115,8 +115,8 @@ const char* ThreadManager::GetRunnableThreadName(uint32_t id) {
 RunnableThread* ThreadManager::GetRunnableThread(uint32_t id) {
     if (id == g_game_thread_id)
         return nullptr;
-    auto* thread = m_threads.at(id);
-    return thread;
+    const auto target = m_threads.find(id);
+    return target == m_threads.end() ? nullptr : target->second;
 }
 
 void RunnableThread::Setup(uint64_t _affinity) {

--- a/source/runtime/render/rhi/RHIExecutor.cpp
+++ b/source/runtime/render/rhi/RHIExecutor.cpp
@@ -2,6 +2,7 @@
 
 #include "log/LogSystem.h"
 #include "rhi/RHI.h"
+#include "rhi/RHIThreadOwnership.h"
 #include "vulkan/VulkanSubmissionExecutor.h"
 
 #include <algorithm>
@@ -13,6 +14,18 @@
 
 namespace Moer::Render {
 namespace {
+
+bool RejectOwnedThreadBlockingCall(std::string_view _operation) {
+    if (IsRHIBlockingCallAllowedOnCurrentThread()) {
+        return false;
+    }
+    LOG_ERROR(
+        "[RHIExecutor] rejected blocking {} from {} owner thread to prevent a self-join",
+        _operation,
+        RHIThreadRoleName(GetCurrentRHIThreadRole())
+    );
+    return true;
+}
 
 template<typename F>
 class ScopeExit {
@@ -51,9 +64,17 @@ bool BatchHasWork(const RHIBackendSubmissionBatch& _batch) {
     return !_batch.submits.empty() || _batch.present.has_value();
 }
 
-void ResolveRejectedPresent(RHIPresentRequest* _present) {
-    if (_present != nullptr && _present->receipt) {
+void ResolveRejectedPresent(RHIPresentRequest* _present) noexcept {
+    if (_present == nullptr || !_present->receipt) {
+        return;
+    }
+    try {
         _present->receipt->Resolve(false);
+    } catch (...) {
+        try {
+            LOG_ERROR("[RHIExecutor] rejected Present receipt resolver threw");
+        } catch (...) {
+        }
     }
 }
 
@@ -65,7 +86,7 @@ void ResolveRejectedPresent(RHIPresentRequest* _present) {
 void FinalizeRejectedSubmissions(
     Array<RHIBackendSubmissionBatchEntry>&& _submits,
     std::string_view                         _reason
-) {
+) noexcept {
     size_t callback_count       = 0;
     size_t success_callback_cnt = 0;
     size_t signal_count         = 0;
@@ -75,15 +96,49 @@ void FinalizeRejectedSubmissions(
         signal_count += entry.submit.signal_events.size();
     }
 
-    LOG_ERROR(
-        "[RHIExecutor] rejected {} frontend submit(s): {}; callbacks={} "
-        "success_callbacks_skipped={} signal_events_unpublished={}",
-        _submits.size(),
-        _reason,
-        callback_count,
-        success_callback_cnt,
-        signal_count
-    );
+    try {
+        LOG_ERROR(
+            "[RHIExecutor] rejected {} frontend submit(s): {}; callbacks={} "
+            "success_callbacks_skipped={} signal_events_rejected={}",
+            _submits.size(),
+            _reason,
+            callback_count,
+            success_callback_cnt,
+            signal_count
+        );
+    } catch (...) {
+    }
+
+    // A rejected producer must publish a terminal failure before ordinary
+    // callbacks run. Otherwise a later submission can wait forever for a
+    // timeline value which this frontend path silently discarded.
+    for (RHIBackendSubmissionBatchEntry& entry : _submits) {
+        for (const SignalEvent& signal : entry.submit.signal_events) {
+            auto* fence = reinterpret_cast<Fence*>(signal.timeline_handle);
+            if (fence == nullptr) {
+                continue;
+            }
+            try {
+                fence->Reject(signal.value);
+            } catch (const std::exception& exception) {
+                try {
+                    LOG_ERROR(
+                        "[RHIExecutor] rejected-submit signal terminalization "
+                        "threw: {}",
+                        exception.what()
+                    );
+                } catch (...) {
+                }
+            } catch (...) {
+                try {
+                    LOG_ERROR(
+                        "[RHIExecutor] rejected-submit signal terminalization threw"
+                    );
+                } catch (...) {
+                }
+            }
+        }
+    }
 
     for (RHIBackendSubmissionBatchEntry& entry : _submits) {
         for (std::function<void()>& callback : entry.submit.callbacks) {
@@ -93,14 +148,60 @@ void FinalizeRejectedSubmissions(
             try {
                 callback();
             } catch (const std::exception& exception) {
-                LOG_ERROR(
-                    "[RHIExecutor] rejected-submit completion callback threw: {}",
-                    exception.what()
-                );
+                try {
+                    LOG_ERROR(
+                        "[RHIExecutor] rejected-submit completion callback threw: {}",
+                        exception.what()
+                    );
+                } catch (...) {
+                }
             } catch (...) {
-                LOG_ERROR("[RHIExecutor] rejected-submit completion callback threw");
+                try {
+                    LOG_ERROR("[RHIExecutor] rejected-submit completion callback threw");
+                } catch (...) {
+                }
             }
         }
+    }
+}
+
+void FinalizeRejectedBackendBatch(
+    RHIBackendSubmissionBatch&& _batch,
+    std::string_view             _reason
+) noexcept {
+    RHIPresentRequest* present =
+        _batch.present.has_value() ? &*_batch.present : nullptr;
+    ResolveRejectedPresent(present);
+    FinalizeRejectedSubmissions(std::move(_batch.submits), _reason);
+}
+
+void ReportBackendCreationFailure(
+    std::string_view          _operation,
+    const std::exception_ptr& _failure
+) noexcept {
+    try {
+        if (_failure) {
+            std::rethrow_exception(_failure);
+        }
+    } catch (const std::exception& exception) {
+        try {
+            LOG_ERROR(
+                "[RHIExecutor] backend creation failed during {}: {}",
+                _operation,
+                exception.what()
+            );
+        } catch (...) {
+        }
+        return;
+    } catch (...) {
+    }
+
+    try {
+        LOG_ERROR(
+            "[RHIExecutor] backend creation failed during {} with an unknown exception",
+            _operation
+        );
+    } catch (...) {
     }
 }
 
@@ -450,6 +551,9 @@ RHIExecutor& RHIExecutor::Get() {
 }
 
 void RHIExecutor::StartUp() {
+    if (RejectOwnedThreadBlockingCall("StartUp")) {
+        return;
+    }
     RHIExecutor& executor = Get();
     std::unique_lock submit_lock(executor.submit_mutex);
     executor.lifecycle_cv.wait(submit_lock, [&executor] {
@@ -469,7 +573,11 @@ void RHIExecutor::StartUp() {
 
 std::shared_ptr<RHIBackendExecutor> RHIExecutor::GetBackendExecutorLocked() {
     if (!backend_executor) {
-        backend_executor = CreateBackendExecutor();
+        std::shared_ptr<RHIBackendExecutor> created = CreateBackendExecutor();
+        if (!created) {
+            throw std::runtime_error("RHI backend factory returned no executor");
+        }
+        backend_executor = std::move(created);
     }
     return backend_executor;
 }
@@ -572,7 +680,9 @@ void RHIExecutor::SubmitReady(
         }
 
         RHIBackendSubmissionBatch          batch{};
+        RHIBackendSubmissionBatch          failed_batch{};
         std::shared_ptr<RHIBackendExecutor> backend{};
+        std::exception_ptr                  backend_creation_failure{};
         bool                                rejected = false;
         {
             std::lock_guard dispatch_lock(dispatch_mutex);
@@ -586,17 +696,34 @@ void RHIExecutor::SubmitReady(
                         pending_submits.emplace_back(std::move(entry));
                     }
                     pending_present.emplace(std::move(*_present));
-                    batch   = TakePendingBatchLocked();
-                    backend = GetBackendExecutorLocked();
+                    try {
+                        // Construct the backend before detaching the accepted
+                        // payload from executor ownership. If construction
+                        // fails, move that payload into an explicit rejection
+                        // batch instead of letting a resolver exception destroy
+                        // callbacks and the Present receipt silently.
+                        backend = GetBackendExecutorLocked();
+                        batch   = TakePendingBatchLocked();
+                    } catch (...) {
+                        backend_creation_failure = std::current_exception();
+                        failed_batch             = TakePendingBatchLocked();
+                    }
                 }
             }
-            if (!rejected) {
+            if (!rejected && !backend_creation_failure) {
                 batch.topology = BuildBatchTopology(batch);
                 backend->Enqueue(std::move(batch));
                 if (HasRHIExecSubmitFlag(_flags, ERHIExecSubmitFlags::FlushGPU)) {
                     backend->Flush(ERHIFlushDepth::SubmitGPU);
                 }
             }
+        }
+        if (backend_creation_failure) {
+            ReportBackendCreationFailure("Present", backend_creation_failure);
+            FinalizeRejectedBackendBatch(
+                std::move(failed_batch), "backend creation failed while publishing Present"
+            );
+            return;
         }
         if (rejected) {
             ResolveRejectedPresent(_present);
@@ -837,31 +964,53 @@ void RHIExecutor::FlushReady(ERHIFlushDepth _depth) {
         }
     }
 
-    std::lock_guard dispatch_lock(dispatch_mutex);
-    RHIBackendSubmissionBatch batch{};
+    RHIBackendSubmissionBatch          batch{};
+    RHIBackendSubmissionBatch          failed_batch{};
     std::shared_ptr<RHIBackendExecutor> backend;
+    std::exception_ptr                  backend_creation_failure{};
     {
-        std::lock_guard lock(submit_mutex);
-        if (lifecycle_state != ELifecycleState::Running) {
-            return;
+        std::lock_guard dispatch_lock(dispatch_mutex);
+        {
+            std::lock_guard lock(submit_mutex);
+            if (lifecycle_state != ELifecycleState::Running) {
+                return;
+            }
+            const bool has_pending_work =
+                !pending_submits.empty() || pending_present.has_value();
+            if (has_pending_work) {
+                try {
+                    backend = GetBackendExecutorLocked();
+                    batch   = TakePendingBatchLocked();
+                } catch (...) {
+                    backend_creation_failure = std::current_exception();
+                    failed_batch             = TakePendingBatchLocked();
+                }
+            } else {
+                backend = backend_executor;
+            }
         }
-        batch   = TakePendingBatchLocked();
-        if (BatchHasWork(batch)) {
-            backend = GetBackendExecutorLocked();
-        } else {
-            backend = backend_executor;
+        if (!backend_creation_failure) {
+            if (BatchHasWork(batch)) {
+                batch.topology = BuildBatchTopology(batch);
+                backend->Enqueue(std::move(batch));
+            }
+            if (backend) {
+                backend->Flush(_depth);
+            }
         }
     }
-    if (BatchHasWork(batch)) {
-        batch.topology = BuildBatchTopology(batch);
-        backend->Enqueue(std::move(batch));
-    }
-    if (backend) {
-        backend->Flush(_depth);
+    if (backend_creation_failure) {
+        ReportBackendCreationFailure("Flush", backend_creation_failure);
+        FinalizeRejectedBackendBatch(
+            std::move(failed_batch), "backend creation failed while flushing"
+        );
     }
 }
 
 void RHIExecutor::Sync(ERHISyncDepth _depth) {
+    if (RejectOwnedThreadBlockingCall("Sync")) {
+        return;
+    }
     auto completion = std::make_shared<HandoffSyncCompletion>();
     recording_handoff.RouteReady(RHIExecutorRecordingHandoffWork{
         .prerequisites = {},
@@ -884,8 +1033,15 @@ void RHIExecutor::SyncReady(ERHISyncDepth _depth) {
     }
 
     std::shared_ptr<RHIBackendExecutor> backend{};
+    RHIBackendSubmissionBatch           failed_batch{};
+    std::exception_ptr                   backend_creation_failure{};
     bool                                sync_registered = false;
-    auto finish_sync_call = [this, &sync_registered] {
+    auto finish_sync_call = [this, &sync_registered, &backend] {
+        // A zero active-sync count is the shutdown handoff point. Release this
+        // call's backend ownership before publishing that point so StartUp can
+        // never race a stale queue-ownership lease, even if SyncReady is later
+        // called from something other than the joined handoff worker.
+        backend.reset();
         if (!sync_registered) {
             return;
         }
@@ -904,9 +1060,16 @@ void RHIExecutor::SyncReady(ERHISyncDepth _depth) {
         {
             std::lock_guard lock(submit_mutex);
             if (lifecycle_state == ELifecycleState::Running) {
-                batch = TakePendingBatchLocked();
-                if (BatchHasWork(batch)) {
-                    backend = GetBackendExecutorLocked();
+                const bool has_pending_work =
+                    !pending_submits.empty() || pending_present.has_value();
+                if (has_pending_work) {
+                    try {
+                        backend = GetBackendExecutorLocked();
+                        batch   = TakePendingBatchLocked();
+                    } catch (...) {
+                        backend_creation_failure = std::current_exception();
+                        failed_batch             = TakePendingBatchLocked();
+                    }
                 } else {
                     backend = backend_executor;
                 }
@@ -916,13 +1079,23 @@ void RHIExecutor::SyncReady(ERHISyncDepth _depth) {
                 }
             }
         }
-        if (BatchHasWork(batch)) {
-            batch.topology = BuildBatchTopology(batch);
-            backend->Enqueue(std::move(batch));
+        if (!backend_creation_failure) {
+            if (BatchHasWork(batch)) {
+                batch.topology = BuildBatchTopology(batch);
+                backend->Enqueue(std::move(batch));
+            }
+            if (backend) {
+                backend->Flush(ERHIFlushDepth::SubmitGPU);
+            }
         }
-        if (backend) {
-            backend->Flush(ERHIFlushDepth::SubmitGPU);
-        }
+    }
+
+    if (backend_creation_failure) {
+        ReportBackendCreationFailure("Sync", backend_creation_failure);
+        FinalizeRejectedBackendBatch(
+            std::move(failed_batch), "backend creation failed while synchronizing"
+        );
+        return;
     }
 
     GraphEventRef completion = backend ? backend->Sync(_depth) : GraphEventRef{};
@@ -932,8 +1105,13 @@ void RHIExecutor::SyncReady(ERHISyncDepth _depth) {
 }
 
 void RHIExecutor::ShutDown() {
+    if (RejectOwnedThreadBlockingCall("ShutDown")) {
+        return;
+    }
     RHIExecutor& executor = Get();
     uint64       shutdown_to_complete = 0;
+    std::shared_ptr<RHIBackendExecutor> backend_to_cancel{};
+    std::shared_ptr<RHIBackendExecutor> backend{};
 
     {
         std::unique_lock lock(executor.submit_mutex);
@@ -949,37 +1127,20 @@ void RHIExecutor::ShutDown() {
         }
         executor.lifecycle_state = ELifecycleState::Stopping;
         shutdown_to_complete     = ++executor.shutdown_generation;
+        backend_to_cancel        = executor.backend_executor;
     }
 
-    // Stop accepting handoffs before taking the final pending batch. The
-    // worker's stop token interrupts an unfinished recording gate, rejects it
-    // and every later FIFO operation, and joins without depending on producer
-    // progress. Any callback already inside SubmitReady/SyncReady is allowed
-    // to finish before backend ownership is detached below.
-    executor.recording_handoff.ShutDown();
-
-    RHIBackendSubmissionBatch batch{};
-    std::shared_ptr<RHIBackendExecutor> backend;
-    {
-        std::lock_guard dispatch_lock(executor.dispatch_mutex);
-        {
-            std::lock_guard lock(executor.submit_mutex);
-            batch = executor.TakePendingBatchLocked();
-            if (BatchHasWork(batch)) {
-                executor.GetBackendExecutorLocked();
-            }
-            backend = std::move(executor.backend_executor);
-        }
-        if (BatchHasWork(batch) && backend) {
-            batch.topology = BuildBatchTopology(batch);
-            backend->Enqueue(std::move(batch));
-        }
-        if (backend) {
-            backend->Flush(ERHIFlushDepth::SubmitGPU);
-        }
-    }
-
-    auto finish_shutdown = [&executor, shutdown_to_complete] {
+    // Install lifecycle completion before any operation that can allocate or
+    // otherwise throw. In particular, lazy backend construction must never
+    // strand concurrent Shutdown/StartUp callers behind a permanent Stopping
+    // state.
+    auto finish_shutdown =
+        [&executor, shutdown_to_complete, &backend, &backend_to_cancel] {
+        // StartUp may begin as soon as Stopped is published. Drop every local
+        // reference to the old backend first so its queue ownership leases are
+        // released before a replacement backend tries to claim them.
+        backend.reset();
+        backend_to_cancel.reset();
         {
             std::lock_guard lock(executor.submit_mutex);
             executor.completed_shutdown_generation = std::max(
@@ -992,9 +1153,67 @@ void RHIExecutor::ShutDown() {
     };
     ScopeExit finish_shutdown_guard(std::move(finish_shutdown));
 
-    // Backend shutdown may wait for its worker and GPU queues.  The dispatch
-    // gate is deliberately released first; the Stopping state keeps later
-    // publishers out while concurrent Shutdown/Sync callers wait on the CV.
+    // Publish backend cancellation before joining the handoff owner. That
+    // owner may currently be inside SyncReady waiting behind a Submission
+    // dependency which can no longer acquire a producer during shutdown.
+    if (backend_to_cancel) {
+        backend_to_cancel->BeginShutdown();
+    }
+
+    // Stop accepting handoffs before taking the final pending batch. The
+    // worker's stop token interrupts an unfinished recording gate, rejects it
+    // and every later FIFO operation, and joins without depending on producer
+    // progress. Any callback already inside SubmitReady/SyncReady is allowed
+    // to finish before backend ownership is detached below.
+    executor.recording_handoff.ShutDown();
+
+    RHIBackendSubmissionBatch           batch{};
+    RHIBackendSubmissionBatch           failed_batch{};
+    std::exception_ptr                   backend_creation_failure{};
+    {
+        std::lock_guard dispatch_lock(executor.dispatch_mutex);
+        {
+            std::lock_guard lock(executor.submit_mutex);
+            const bool has_pending_work =
+                !executor.pending_submits.empty() ||
+                executor.pending_present.has_value();
+            if (has_pending_work) {
+                try {
+                    executor.GetBackendExecutorLocked();
+                    batch = executor.TakePendingBatchLocked();
+                } catch (...) {
+                    backend_creation_failure = std::current_exception();
+                    failed_batch = executor.TakePendingBatchLocked();
+                }
+            }
+            backend = std::move(executor.backend_executor);
+        }
+        if (!backend_creation_failure && BatchHasWork(batch) && backend) {
+            batch.topology = BuildBatchTopology(batch);
+            backend->Enqueue(std::move(batch));
+        }
+        if (!backend_creation_failure && backend) {
+            backend->Flush(ERHIFlushDepth::SubmitGPU);
+        }
+    }
+
+    if (backend_creation_failure) {
+        ReportBackendCreationFailure("ShutDown", backend_creation_failure);
+        FinalizeRejectedBackendBatch(
+            std::move(failed_batch), "backend creation failed during shutdown"
+        );
+    }
+
+    // Cancel backend host waits before waiting for concurrent Sync calls.
+    // Otherwise a Sync already queued behind an unpublished dependency would
+    // wait for backend ShutDown, while ShutDown waited for that same Sync.
+    if (backend) {
+        backend->BeginShutdown();
+    }
+
+    // Backend shutdown may wait for its worker and GPU queues. The dispatch
+    // gate is deliberately released first; Stopping keeps later publishers
+    // out while concurrent Shutdown/Sync callers wait on the CV.
     {
         std::unique_lock lock(executor.submit_mutex);
         executor.lifecycle_cv.wait(lock, [&executor] {

--- a/source/runtime/render/rhi/RHIExecutorBackend.h
+++ b/source/runtime/render/rhi/RHIExecutorBackend.h
@@ -78,6 +78,10 @@ public:
     virtual void          Enqueue(RHIBackendSubmissionBatch&& _batch) = 0;
     virtual GraphEventRef Sync(ERHISyncDepth _depth = ERHISyncDepth::RHI) = 0;
     virtual void          Flush(ERHIFlushDepth _depth = ERHIFlushDepth::SubmitGPU) = 0;
+    // Publish non-blocking cancellation before RHIExecutor waits for
+    // concurrent Sync callers. Backends without cancellable host waits may
+    // keep the default no-op implementation.
+    virtual void          BeginShutdown() noexcept {}
     virtual void          ShutDown() = 0;
 };
 

--- a/source/runtime/render/rhi/RHIExecutorRecordingHandoff.cpp
+++ b/source/runtime/render/rhi/RHIExecutorRecordingHandoff.cpp
@@ -1,6 +1,8 @@
 #include "rhi/RHIExecutorRecordingHandoff.h"
 
 #include "log/LogSystem.h"
+#include "platform/Platform.h"
+#include "rhi/RHIThreadOwnership.h"
 
 #include <cassert>
 #include <exception>
@@ -69,10 +71,13 @@ void RHIExecutorRecordingHandoffQueue::Start() {
     }
     assert(!worker.joinable());
     assert(pending.empty());
-    assert(inline_dispatches == 0);
     assert(!worker_busy);
+    // Publish admission only after the worker has been created successfully.
+    // std::jthread construction can throw (for example when the OS cannot
+    // allocate another thread); in that case the queue must remain stopped so
+    // callers cannot enqueue work that has no owner to drain it.
+    worker = std::jthread([this](std::stop_token _stop_token) { Run(_stop_token); });
     accepting = true;
-    worker    = std::jthread([this](std::stop_token _stop_token) { Run(_stop_token); });
 }
 
 void RHIExecutorRecordingHandoffQueue::EnqueueRecording(
@@ -97,20 +102,13 @@ void RHIExecutorRecordingHandoffQueue::EnqueueRecording(
 void RHIExecutorRecordingHandoffQueue::RouteReady(
     RHIExecutorRecordingHandoffWork&& _work
 ) {
-    bool run_inline = false;
-    bool reject     = false;
+    bool reject = false;
     {
         std::lock_guard lock(mutex);
         if (!accepting) {
             reject = true;
-        } else if (worker_busy || inline_dispatches != 0 || !pending.empty()) {
-            pending.emplace_back(std::move(_work));
         } else {
-            // Mark the direct operation active before releasing the lock. A
-            // concurrent recording handoff is then queued behind it and the
-            // worker waits for this count to return to zero.
-            ++inline_dispatches;
-            run_inline = true;
+            pending.emplace_back(std::move(_work));
         }
     }
 
@@ -118,18 +116,6 @@ void RHIExecutorRecordingHandoffQueue::RouteReady(
         ResolveNoThrow(_work, ERHIRecordingHandoffResult::Cancel);
         return;
     }
-    if (!run_inline) {
-        work_cv.notify_all();
-        return;
-    }
-
-    ResolveNoThrow(_work, ERHIRecordingHandoffResult::Consume);
-    {
-        std::lock_guard lock(mutex);
-        assert(inline_dispatches > 0);
-        --inline_dispatches;
-    }
-    idle_cv.notify_all();
     work_cv.notify_all();
 }
 
@@ -146,25 +132,25 @@ void RHIExecutorRecordingHandoffQueue::ShutDown() {
     }
 
     std::unique_lock lock(mutex);
-    idle_cv.wait(lock, [this] {
-        return inline_dispatches == 0 && !worker_busy && pending.empty();
-    });
+    idle_cv.wait(lock, [this] { return !worker_busy && pending.empty(); });
 }
 
 bool RHIExecutorRecordingHandoffQueue::IsIdle() const noexcept {
     std::lock_guard lock(mutex);
-    return pending.empty() && inline_dispatches == 0 && !worker_busy;
+    return pending.empty() && !worker_busy;
 }
 
 void RHIExecutorRecordingHandoffQueue::Run(std::stop_token _stop_token) noexcept {
+    Platform::SetCurrentThreadName("Moer RHI Executor");
+    RHIThreadRoleScope owner_scope(ERHIThreadRole::Executor);
+
     for (;;) {
         RHIExecutorRecordingHandoffWork work{};
         {
             std::unique_lock lock(mutex);
-            work_cv.wait(lock, _stop_token, [this] {
-                return inline_dispatches == 0 && !pending.empty();
-            });
-            if (_stop_token.stop_requested()) {
+            work_cv.wait(lock, _stop_token, [this] { return !pending.empty(); });
+            if (pending.empty()) {
+                assert(_stop_token.stop_requested());
                 break;
             }
             work = std::move(pending.front());
@@ -173,23 +159,27 @@ void RHIExecutorRecordingHandoffQueue::Run(std::stop_token _stop_token) noexcept
         }
 
         bool ready = true;
+        bool cancelled = false;
         for (const RHIRecordingGateRef& prerequisite : work.prerequisites) {
             if (!prerequisite) {
                 ready = false;
                 continue;
             }
-            const ERHIRecordingStatus status = prerequisite->Wait(_stop_token);
+            ERHIRecordingStatus status = prerequisite->Status();
+            if (status == ERHIRecordingStatus::Pending) {
+                status = prerequisite->Wait(_stop_token);
+            }
             if (status != ERHIRecordingStatus::Succeeded) {
                 ready = false;
             }
             // A producer failure does not make the remaining CommandLists
             // safe to inspect. Keep waiting until every gate is terminal. A
             // lifecycle cancellation is different: stop must remain bounded.
-            if (_stop_token.stop_requested()) {
+            if (status == ERHIRecordingStatus::Pending) {
+                cancelled = true;
                 break;
             }
         }
-        const bool cancelled = _stop_token.stop_requested();
 
         ResolveNoThrow(
             work,
@@ -232,9 +222,18 @@ void RHIExecutorRecordingHandoffQueue::ResolveNoThrow(
     try {
         _work.resolve(_result);
     } catch (const std::exception& exception) {
-        LOG_ERROR("[RHIExecutor] recording handoff resolver threw: {}", exception.what());
+        try {
+            LOG_ERROR(
+                "[RHIExecutor] recording handoff resolver threw: {}",
+                exception.what()
+            );
+        } catch (...) {
+        }
     } catch (...) {
-        LOG_ERROR("[RHIExecutor] recording handoff resolver threw");
+        try {
+            LOG_ERROR("[RHIExecutor] recording handoff resolver threw");
+        } catch (...) {
+        }
     }
 }
 

--- a/source/runtime/render/rhi/RHIExecutorRecordingHandoff.h
+++ b/source/runtime/render/rhi/RHIExecutorRecordingHandoff.h
@@ -97,8 +97,10 @@ public:
     // already complete. Used by SubmitRecording.
     void EnqueueRecording(RHIExecutorRecordingHandoffWork&& _work);
 
-    // Runs inline when the FIFO is idle, otherwise queues behind the active
-    // recording handoff. This is the ordering path for ordinary RHI controls.
+    // Always enters the Executor worker FIFO, including when no recording
+    // prerequisite is active. This gives accepted Submit/Present/Flush/Sync
+    // work one stable thread owner and prevents callback affinity from
+    // depending on whether a recording handoff happened to be pending.
     void RouteReady(RHIExecutorRecordingHandoffWork&& _work);
 
     void ShutDown();
@@ -116,7 +118,6 @@ private:
     std::condition_variable                   idle_cv;
     std::deque<RHIExecutorRecordingHandoffWork> pending{};
     std::jthread                              worker{};
-    size_t                                    inline_dispatches{0};
     bool                                      accepting{false};
     bool                                      worker_busy{false};
 };

--- a/source/runtime/render/rhi/RHIResource.h
+++ b/source/runtime/render/rhi/RHIResource.h
@@ -1013,6 +1013,13 @@ public:
     Fence() : RHIResource(RRT_GPU_FENCE) {}
     virtual uint64_t GetValue() const      = 0;
     virtual void     Wait(uint64_t _value) = 0;
+
+    // Terminalize a timeline value which can no longer be published because
+    // its owning submission was rejected before reaching a GPU queue. This is
+    // deliberately distinct from host-signalling the value: treating rejected
+    // producer work as successfully complete could let dependent GPU work read
+    // resources which were never written.
+    virtual void Reject(uint64_t _value) = 0;
 };
 
 struct BackBufferInfo {

--- a/source/runtime/render/rhi/RHIThreadOwnership.cpp
+++ b/source/runtime/render/rhi/RHIThreadOwnership.cpp
@@ -1,0 +1,77 @@
+#include "rhi/RHIThreadOwnership.h"
+
+#include <utility>
+
+namespace Moer::Render {
+namespace {
+
+thread_local ERHIThreadRole g_rhi_thread_role = ERHIThreadRole::Unknown;
+
+} // namespace
+
+ERHIThreadRole GetCurrentRHIThreadRole() noexcept {
+    return g_rhi_thread_role;
+}
+
+const char* RHIThreadRoleName(ERHIThreadRole _role) noexcept {
+    switch (_role) {
+        case ERHIThreadRole::Unknown:
+            return "Unknown";
+        case ERHIThreadRole::Executor:
+            return "Executor";
+        case ERHIThreadRole::Translate:
+            return "Translate";
+        case ERHIThreadRole::Submission:
+            return "Submission";
+        case ERHIThreadRole::Completion:
+            return "Completion";
+        case ERHIThreadRole::RecordWorker:
+            return "RecordWorker";
+    }
+    return "Invalid";
+}
+
+bool IsRHIBlockingCallAllowedOnCurrentThread() noexcept {
+    return GetCurrentRHIThreadRole() == ERHIThreadRole::Unknown;
+}
+
+RHIThreadRoleScope::RHIThreadRoleScope(ERHIThreadRole _role) noexcept :
+    previous_role(g_rhi_thread_role) {
+    g_rhi_thread_role = _role;
+}
+
+RHIThreadRoleScope::~RHIThreadRoleScope() {
+    g_rhi_thread_role = previous_role;
+}
+
+RHITransferableOwnershipGate::Lease::~Lease() {
+    Release();
+}
+
+RHITransferableOwnershipGate::Lease::Lease(Lease&& _other) noexcept :
+    owner(std::exchange(_other.owner, nullptr)) {}
+
+RHITransferableOwnershipGate::Lease&
+RHITransferableOwnershipGate::Lease::operator=(Lease&& _other) noexcept {
+    if (this == &_other) {
+        return *this;
+    }
+    Release();
+    owner = std::exchange(_other.owner, nullptr);
+    return *this;
+}
+
+void RHITransferableOwnershipGate::Lease::Release() noexcept {
+    if (owner == nullptr) {
+        return;
+    }
+    RHITransferableOwnershipGate* gate = std::exchange(owner, nullptr);
+    gate->permit.release();
+}
+
+RHITransferableOwnershipGate::Lease RHITransferableOwnershipGate::Acquire() {
+    permit.acquire();
+    return Lease(this);
+}
+
+} // namespace Moer::Render

--- a/source/runtime/render/rhi/RHIThreadOwnership.h
+++ b/source/runtime/render/rhi/RHIThreadOwnership.h
@@ -1,0 +1,86 @@
+#pragma once
+
+#include "RenderAPI.h"
+
+#include <cstdint>
+#include <semaphore>
+
+namespace Moer::Render {
+
+// Logical ownership roles for the modern RHI pipeline. These are intentionally
+// independent from task-graph thread indices: a role describes which RHI
+// lifecycle domain the current OS thread owns while executing a scoped body.
+enum class ERHIThreadRole : uint8_t {
+    Unknown,
+    Executor,
+    Translate,
+    Submission,
+    Completion,
+    RecordWorker,
+};
+
+RENDER_API ERHIThreadRole GetCurrentRHIThreadRole() noexcept;
+RENDER_API const char*    RHIThreadRoleName(ERHIThreadRole _role) noexcept;
+
+// Public blocking lifecycle calls may wait for every owned stage downstream.
+// Calling one from any stage owner can therefore form a self-join.
+RENDER_API bool IsRHIBlockingCallAllowedOnCurrentThread() noexcept;
+
+class RENDER_API RHIThreadRoleScope final {
+public:
+    explicit RHIThreadRoleScope(ERHIThreadRole _role) noexcept;
+    ~RHIThreadRoleScope();
+
+    RHIThreadRoleScope(const RHIThreadRoleScope&) = delete;
+    RHIThreadRoleScope& operator=(const RHIThreadRoleScope&) = delete;
+    RHIThreadRoleScope(RHIThreadRoleScope&&) = delete;
+    RHIThreadRoleScope& operator=(RHIThreadRoleScope&&) = delete;
+
+private:
+    ERHIThreadRole previous_role{ERHIThreadRole::Unknown};
+};
+
+// Unlike std::mutex ownership, a semaphore permit may be acquired by the
+// translate owner and released by the submission owner. A recorded packet
+// carries this move-only lease across that boundary and keeps queue-local
+// recording state atomic with its eventual native submit.
+class RENDER_API RHITransferableOwnershipGate final {
+public:
+    class RENDER_API Lease final {
+    public:
+        Lease() noexcept = default;
+        ~Lease();
+
+        Lease(const Lease&) = delete;
+        Lease& operator=(const Lease&) = delete;
+        Lease(Lease&& _other) noexcept;
+        Lease& operator=(Lease&& _other) noexcept;
+
+        [[nodiscard]] bool OwnsGate() const noexcept {
+            return owner != nullptr;
+        }
+
+        void Release() noexcept;
+
+    private:
+        friend class RHITransferableOwnershipGate;
+        explicit Lease(RHITransferableOwnershipGate* _owner) noexcept : owner(_owner) {}
+
+        RHITransferableOwnershipGate* owner{nullptr};
+    };
+
+    RHITransferableOwnershipGate() = default;
+    ~RHITransferableOwnershipGate() = default;
+
+    RHITransferableOwnershipGate(const RHITransferableOwnershipGate&) = delete;
+    RHITransferableOwnershipGate& operator=(const RHITransferableOwnershipGate&) = delete;
+    RHITransferableOwnershipGate(RHITransferableOwnershipGate&&) = delete;
+    RHITransferableOwnershipGate& operator=(RHITransferableOwnershipGate&&) = delete;
+
+    [[nodiscard]] Lease Acquire();
+
+private:
+    std::binary_semaphore permit{1};
+};
+
+} // namespace Moer::Render

--- a/source/runtime/render/rhi/d3d12/D3D12Device.cpp
+++ b/source/runtime/render/rhi/d3d12/D3D12Device.cpp
@@ -1493,7 +1493,7 @@ WaitEvent D3D12GraphicsCommandQueue::Execute(CmdSubmit&& _submit) {
         [](const WaitEvent& _event) {
             const auto* fence =
                 reinterpret_cast<const D3D12Fence*>(_event.timeline_handle);
-            return fence == nullptr || fence->IsRejected();
+            return fence == nullptr || fence->IsRejected(_event.value);
         }
     );
     if (rejected_dependency) {
@@ -1662,9 +1662,17 @@ void D3D12Fence::Wait(uint64_t _value) {
     WaitOnHost(_value);
 }
 
-void D3D12Fence::Reject(uint64_t) {
-    rejected.store(true, std::memory_order_release);
+void D3D12Fence::Reject(uint64_t _value) {
+    {
+        std::lock_guard lock(rejection_mutex);
+        rejected_values.emplace(_value);
+    }
     SetEvent(event);
+}
+
+bool D3D12Fence::IsRejected(uint64 _value) const {
+    std::lock_guard lock(rejection_mutex);
+    return rejected_values.contains(_value);
 }
 
 bool D3D12Fence::IsFenceComplete(uint64 _value) {
@@ -1677,10 +1685,10 @@ bool D3D12Fence::IsFenceComplete(uint64 _value) {
 }
 
 void D3D12Fence::WaitOnHost(uint64 _value) {
-    if (IsFenceComplete(_value) || IsRejected())
+    if (IsFenceComplete(_value) || IsRejected(_value))
         return;
     DX_CHECK_HRESULT(fence->SetEventOnCompletion(_value, event));
-    while (!IsFenceComplete(_value) && !IsRejected()) {
+    while (!IsFenceComplete(_value) && !IsRejected(_value)) {
         WaitForSingleObjectEx(event, 50, FALSE);
     }
     //OnScopeExit([&]() { ResetEvent(event); });// maybe useful

--- a/source/runtime/render/rhi/d3d12/D3D12Device.cpp
+++ b/source/runtime/render/rhi/d3d12/D3D12Device.cpp
@@ -12,6 +12,7 @@
 #include "../vulkan/RHICmdReorderer.h"
 #include <algorithm>
 #include <config.h>
+#include <exception>
 #include <filesystem>
 #include <optional>
 #include <platform/Platform.h>
@@ -1486,6 +1487,46 @@ void D3D12GraphicsCommandQueue::Wait(WaitEvent _event) {
 }
 
 WaitEvent D3D12GraphicsCommandQueue::Execute(CmdSubmit&& _submit) {
+    const bool rejected_dependency = std::any_of(
+        _submit.wait_events.begin(),
+        _submit.wait_events.end(),
+        [](const WaitEvent& _event) {
+            const auto* fence =
+                reinterpret_cast<const D3D12Fence*>(_event.timeline_handle);
+            return fence == nullptr || fence->IsRejected();
+        }
+    );
+    if (rejected_dependency) {
+        // A rejected producer is terminal, but not successfully complete.
+        // Propagate that state instead of inserting a native queue wait which
+        // can never resolve and would wedge every later D3D12 submission.
+        for (const SignalEvent& event : _submit.signal_events) {
+            auto* fence = reinterpret_cast<D3D12Fence*>(event.timeline_handle);
+            if (fence != nullptr) {
+                fence->Reject(event.value);
+            }
+        }
+        for (std::function<void()>& callback : _submit.callbacks) {
+            if (!callback) {
+                continue;
+            }
+            try {
+                callback();
+            } catch (const std::exception& exception) {
+                LOG_ERROR(
+                    "[RHIExecutor][D3D12] rejected-submit callback threw: {}",
+                    exception.what()
+                );
+            } catch (...) {
+                LOG_ERROR("[RHIExecutor][D3D12] rejected-submit callback threw");
+            }
+        }
+        _submit.success_callbacks.clear();
+        return WaitEvent{
+            uint64(&queue_fence),
+            last_submitted_fence_value.load(std::memory_order_acquire)
+        };
+    }
 
     auto allocator = RequestCommandResourceAllocator();
     auto cmd_list  = allocator->GetCommandList();
@@ -1621,6 +1662,11 @@ void D3D12Fence::Wait(uint64_t _value) {
     WaitOnHost(_value);
 }
 
+void D3D12Fence::Reject(uint64_t) {
+    rejected.store(true, std::memory_order_release);
+    SetEvent(event);
+}
+
 bool D3D12Fence::IsFenceComplete(uint64 _value) {
     // ref directx-graphics-samples
     // maybe need a lock..
@@ -1631,10 +1677,12 @@ bool D3D12Fence::IsFenceComplete(uint64 _value) {
 }
 
 void D3D12Fence::WaitOnHost(uint64 _value) {
-    if (IsFenceComplete(_value))
+    if (IsFenceComplete(_value) || IsRejected())
         return;
-    fence->SetEventOnCompletion(_value, event);
-    WaitForSingleObjectEx(event, INFINITE, FALSE);
+    DX_CHECK_HRESULT(fence->SetEventOnCompletion(_value, event));
+    while (!IsFenceComplete(_value) && !IsRejected()) {
+        WaitForSingleObjectEx(event, 50, FALSE);
+    }
     //OnScopeExit([&]() { ResetEvent(event); });// maybe useful
     //ResetEvent(event);
 }

--- a/source/runtime/render/rhi/d3d12/D3D12Device.h
+++ b/source/runtime/render/rhi/d3d12/D3D12Device.h
@@ -594,7 +594,8 @@ private:
     ComPtr<ID3D12Fence> fence;
     HANDLE              event;
     std::atomic<uint64> current_value = 0;
-    std::atomic_bool    rejected{false};
+    mutable std::mutex   rejection_mutex;
+    UnorderedSet<uint64> rejected_values;
 
 public:
     D3D12Fence(D3D12Device* _device);
@@ -609,9 +610,7 @@ public:
     void     Reject(uint64_t _value) override;
 
     bool IsFenceComplete(uint64 _value);
-    bool IsRejected() const noexcept {
-        return rejected.load(std::memory_order_acquire);
-    }
+    bool IsRejected(uint64 _value) const;
     void WaitOnHost(uint64 _value);
     void SignalOnHost(uint64 _value);
 };

--- a/source/runtime/render/rhi/d3d12/D3D12Device.h
+++ b/source/runtime/render/rhi/d3d12/D3D12Device.h
@@ -594,6 +594,7 @@ private:
     ComPtr<ID3D12Fence> fence;
     HANDLE              event;
     std::atomic<uint64> current_value = 0;
+    std::atomic_bool    rejected{false};
 
 public:
     D3D12Fence(D3D12Device* _device);
@@ -605,8 +606,12 @@ public:
     }
     uint64_t GetValue() const override; // by default, get latest value, not cached 'current_value'
     void     Wait(uint64_t _value) override;
+    void     Reject(uint64_t _value) override;
 
     bool IsFenceComplete(uint64 _value);
+    bool IsRejected() const noexcept {
+        return rejected.load(std::memory_order_acquire);
+    }
     void WaitOnHost(uint64 _value);
     void SignalOnHost(uint64 _value);
 };

--- a/source/runtime/render/rhi/vulkan/RHICmdReorderer.h
+++ b/source/runtime/render/rhi/vulkan/RHICmdReorderer.h
@@ -1472,6 +1472,10 @@ public:
         };
         _cmd->IterateArgs(func);
 
+        // A side-effect-only custom dispatch may intentionally expose no
+        // resource usages. Keep it in the isolated custom-command scope
+        // instead of converting the initial -1 layer to UINT64_MAX.
+        m_dispatch_layer = GetLayerWithOffset(m_dispatch_layer);
         for (const auto& write_res : m_arg_write_resources) {
             RecordWrite(std::get<1>(write_res), std::get<0>(write_res), m_dispatch_layer);
         }

--- a/source/runtime/render/rhi/vulkan/VulkanAllocator.cpp
+++ b/source/runtime/render/rhi/vulkan/VulkanAllocator.cpp
@@ -6,6 +6,45 @@
 #include "VulkanResourceTracker.h"
 namespace Moer::Render {
 
+namespace {
+
+bool InvokeAllocatorCompletionCallbacksNoexcept(
+    Array<std::function<void()>>& _callbacks,
+    std::string_view              _owner
+) noexcept {
+    bool succeeded = true;
+    for (auto& callback : _callbacks) {
+        try {
+            if (callback) {
+                callback();
+            }
+        } catch (const std::exception& error) {
+            succeeded = false;
+            try {
+                LOG_ERROR(
+                    "[RHIExecutor][Vulkan] {} completion callback threw: {}",
+                    _owner,
+                    error.what()
+                );
+            } catch (...) {
+            }
+        } catch (...) {
+            succeeded = false;
+            try {
+                LOG_ERROR(
+                    "[RHIExecutor][Vulkan] {} completion callback threw",
+                    _owner
+                );
+            } catch (...) {
+            }
+        }
+    }
+    _callbacks.clear();
+    return succeeded;
+}
+
+} // namespace
+
 // VulkanAllocatorBase
 VulkanAllocatorBase::VulkanAllocatorBase(VulkanDevice* _device, EQueueType _type) :
     VulkanDeviceObject(_device),
@@ -58,12 +97,10 @@ bool VulkanAllocatorBase::ResetCmdList() {
     return false;
 }
 
-void VulkanAllocatorBase::CompleteSuccess() {
-    //execute post complete functions if needed
-    for (auto& func : on_complete) {
-        func();
-    }
-    on_complete.clear();
+bool VulkanAllocatorBase::CompleteSuccess() noexcept {
+    return InvokeAllocatorCompletionCallbacksNoexcept(
+        on_complete, "allocator"
+    );
 }
 
 bool VulkanAllocatorBase::Reset() {
@@ -82,12 +119,10 @@ VulkanPresentor::VulkanPresentor(VulkanDevice* _device, EQueueType _type) :
 
 VulkanPresentor::~VulkanPresentor() {}
 
-void VulkanPresentor::CompleteSuccess() {
-    //execute post complete functions if needed
-    for (auto& func : on_complete) {
-        func();
-    }
-    on_complete.clear();
+bool VulkanPresentor::CompleteSuccess() noexcept {
+    return InvokeAllocatorCompletionCallbacksNoexcept(
+        on_complete, "presentor"
+    );
 }
 
 #pragma region[ Query Pool ]
@@ -185,12 +220,10 @@ void VulkanAllocator::ResetBufferAlloc() {
     shader_buffer_allocator.Reset();
 }
 
-void VulkanAllocator::CompleteSuccess() {
-    //execute post complete functions if needed
-    for (auto& func : on_complete) {
-        func();
-    }
-    on_complete.clear();
+bool VulkanAllocator::CompleteSuccess() noexcept {
+    return InvokeAllocatorCompletionCallbacksNoexcept(
+        on_complete, "allocator"
+    );
 }
 
 bool VulkanAllocator::Reset() {

--- a/source/runtime/render/rhi/vulkan/VulkanAllocator.h
+++ b/source/runtime/render/rhi/vulkan/VulkanAllocator.h
@@ -57,7 +57,10 @@ public:
         on_complete.push_back(std::move(_func));
     }
 
-    virtual void CompleteSuccess();
+    // Completion callbacks are user-extensible and must never escape the
+    // Completion owner. A false result quarantines the allocator instead of
+    // resetting/reusing partially finalized state.
+    virtual bool CompleteSuccess() noexcept;
     virtual bool Reset();
     // A recorder that was never submitted must not run success callbacks.
     // It can still reset and return to the pool after all worker jobs joined.
@@ -101,7 +104,7 @@ public:
     VulkanPresentor(VulkanDevice* _device, EQueueType _queue_type);
     virtual ~VulkanPresentor();
 
-    void CompleteSuccess() override;
+    bool CompleteSuccess() noexcept override;
 };
 
 class VulkanAllocator : public VulkanAllocatorBase {
@@ -118,7 +121,7 @@ public:
 
     void ResetBufferAlloc();
 
-    void CompleteSuccess() override;
+    bool CompleteSuccess() noexcept override;
     bool Reset() override;
     //staging buffer allocate with block strategy
 private:

--- a/source/runtime/render/rhi/vulkan/VulkanQueue.cpp
+++ b/source/runtime/render/rhi/vulkan/VulkanQueue.cpp
@@ -163,9 +163,17 @@ static void FinalizeBindlessUpdatesOnce(
         reinterpret_cast<VulkanBindlessArray*>(_array.Get())
             ->FinalizeUpdateCommand(_updates, _gpu_update_succeeded);
     } catch (const std::exception& error) {
-        LOG_ERROR("Failed to finalize bindless update lifecycle: {}", error.what());
+        try {
+            LOG_ERROR(
+                "Failed to finalize bindless update lifecycle: {}", error.what()
+            );
+        } catch (...) {
+        }
     } catch (...) {
-        LOG_ERROR("Failed to finalize bindless update lifecycle: unknown error");
+        try {
+            LOG_ERROR("Failed to finalize bindless update lifecycle: unknown error");
+        } catch (...) {
+        }
     }
 }
 
@@ -198,9 +206,33 @@ static void InvokeCallbacksNoexcept(
         try {
             callback();
         } catch (const std::exception& error) {
-            LOG_ERROR("{} callback threw: {}", _context, error.what());
+            try {
+                LOG_ERROR("{} callback threw: {}", _context, error.what());
+            } catch (...) {
+            }
         } catch (...) {
-            LOG_ERROR("{} callback threw an unknown exception", _context);
+            try {
+                LOG_ERROR("{} callback threw an unknown exception", _context);
+            } catch (...) {
+            }
+        }
+    }
+}
+
+static void ResolvePresentReceiptNoexcept(
+    const PresentReceiptRef& _receipt,
+    bool                     _submitted,
+    bool                     _recreate_swapchain
+) noexcept {
+    if (!_receipt) {
+        return;
+    }
+    try {
+        _receipt->Resolve(_submitted, _recreate_swapchain);
+    } catch (...) {
+        try {
+            LOG_ERROR("[RHIExecutor][Vulkan] failed to resolve Present receipt");
+        } catch (...) {
         }
     }
 }
@@ -3218,11 +3250,14 @@ static std::string JoinRecordCounts(std::span<const uint32> _counts) {
 }
 
 static bool WaitForSubmittedDependencies(
-    VulkanDevice& _device, const Array<WaitEvent>& _wait_events
+    VulkanDevice&           _device,
+    const Array<WaitEvent>& _wait_events,
+    const std::atomic_bool* _continue_waiting = nullptr
 ) {
     for (const WaitEvent& event : _wait_events) {
         auto* fence = reinterpret_cast<VulkanFence*>(event.timeline_handle);
-        if (fence == nullptr || !fence->WaitSubmitted(event.value)) {
+        if (fence == nullptr ||
+            !fence->WaitSubmitted(event.value, _continue_waiting)) {
             return false;
         }
     }
@@ -3332,35 +3367,63 @@ VkCommandQueue::VkCommandQueue(
     }
     timeline = MoerNew(VulkanFence(vk_device));
 
-    completion_worker_running = true;
-    completion_thread         = std::jthread(&VkCommandQueue::CompletionThreadMain, this);
+    try {
+        completion_worker_running = true;
+        completion_thread =
+            std::jthread(&VkCommandQueue::CompletionThreadMain, this);
 
-    if (rhi_thread_enabled) {
-        rhi_worker_running = true;
-        rhi_thread         = std::jthread(&VkCommandQueue::RhiThreadMain, this);
-    }
+        if (rhi_thread_enabled) {
+            rhi_worker_running = true;
+            rhi_thread = std::jthread(&VkCommandQueue::RhiThreadMain, this);
+        }
 
-    LOG_INFO(
-        "[Threading] Vulkan {} queue RHI mode: {}",
-        _type == EQueueType::Graphics ? "graphics" : "compute",
-        rhi_thread_enabled ? "threaded" : "synchronous"
-    );
-    if (parallel_record_requested) {
         LOG_INFO(
-            "[ParallelRecord] queue={} requested=true effective={} workers={} "
-            "min_work_units_per_job={} reason={}",
-            _type == EQueueType::Graphics ? "Graphics" : "Compute",
-            parallel_record_pool != nullptr,
-            parallel_record_workers,
-            parallel_record_min_work_units_per_job,
-            parallel_record_pool ? "none" :
-            _type != EQueueType::Graphics ? "unsupported-queue" : "rhi-thread-disabled-or-bypass"
+            "[Threading] Vulkan {} queue RHI mode: {}",
+            _type == EQueueType::Graphics ? "graphics" : "compute",
+            rhi_thread_enabled ? "threaded" : "synchronous"
         );
-    }
-    if (parallel_record_profile) {
-        LOG_INFO(
-            "[ParallelRecordProfile][Config] queue=Graphics enabled=true window_ms=1000"
-        );
+        if (parallel_record_requested) {
+            LOG_INFO(
+                "[ParallelRecord] queue={} requested=true effective={} workers={} "
+                "min_work_units_per_job={} reason={}",
+                _type == EQueueType::Graphics ? "Graphics" : "Compute",
+                parallel_record_pool != nullptr,
+                parallel_record_workers,
+                parallel_record_min_work_units_per_job,
+                parallel_record_pool ? "none" :
+                _type != EQueueType::Graphics ? "unsupported-queue" :
+                                                "rhi-thread-disabled-or-bypass"
+            );
+        }
+        if (parallel_record_profile) {
+            LOG_INFO(
+                "[ParallelRecordProfile][Config] queue=Graphics enabled=true window_ms=1000"
+            );
+        }
+    } catch (...) {
+        if (rhi_thread_enabled) {
+            {
+                std::lock_guard lock(rhi_work_mutex);
+                rhi_worker_running = false;
+            }
+            rhi_work_cv.notify_all();
+            if (rhi_thread.joinable()) {
+                rhi_thread.join();
+            }
+        }
+
+        {
+            std::lock_guard lock(event_mutex);
+            completion_worker_running = false;
+        }
+        queue_cv.notify_all();
+        if (completion_thread.joinable()) {
+            completion_thread.join();
+        }
+
+        MoerDelete(timeline);
+        timeline = nullptr;
+        throw;
     }
 }
 
@@ -3407,7 +3470,99 @@ VkCommandQueue::~VkCommandQueue() {
     vk_device.RecordQueueSyncComplete();
 }
 
+bool VkCommandQueue::ClaimRuntimeOwnership() {
+    EExecutionOwnershipMode expected = EExecutionOwnershipMode::Unclaimed;
+    if (execution_ownership_mode.compare_exchange_strong(
+            expected,
+            EExecutionOwnershipMode::Runtime,
+            std::memory_order_acq_rel,
+            std::memory_order_acquire
+        )) {
+        std::lock_guard lock(rhi_work_mutex);
+        if (!rhi_work_queue.empty() || enqueued_rhi_work != completed_rhi_work) {
+            execution_ownership_mode.store(
+                EExecutionOwnershipMode::Unclaimed, std::memory_order_release
+            );
+            LOG_ERROR(
+                "[RHIExecutor][Vulkan] cannot claim Runtime ownership for queue={} "
+                "with legacy work in flight",
+                static_cast<uint32>(queue.GetType())
+            );
+            return false;
+        }
+        try {
+            LOG_INFO(
+                "[RHIExecutor][Vulkan] queue={} ownership=Runtime",
+                static_cast<uint32>(queue.GetType())
+            );
+        } catch (...) {
+        }
+        runtime_dependency_waits_enabled.store(true, std::memory_order_release);
+        return true;
+    }
+    try {
+        LOG_ERROR(
+            "[RHIExecutor][Vulkan] queue={} Runtime ownership claim rejected mode={}",
+            static_cast<uint32>(queue.GetType()),
+            static_cast<uint32>(expected)
+        );
+    } catch (...) {
+    }
+    return false;
+}
+
+void VkCommandQueue::ReleaseRuntimeOwnership() noexcept {
+    CancelRuntimeDependencyWaits();
+    EExecutionOwnershipMode expected = EExecutionOwnershipMode::Runtime;
+    const bool released = execution_ownership_mode.compare_exchange_strong(
+        expected,
+        EExecutionOwnershipMode::Unclaimed,
+        std::memory_order_acq_rel,
+        std::memory_order_acquire
+    );
+    assert(released && "only the owning Vulkan runtime may release a queue claim");
+}
+
+void VkCommandQueue::CancelRuntimeDependencyWaits() noexcept {
+    runtime_dependency_waits_enabled.store(false, std::memory_order_release);
+}
+
+bool VkCommandQueue::ClaimLegacyOwnership(std::string_view _operation) {
+    EExecutionOwnershipMode expected = EExecutionOwnershipMode::Unclaimed;
+    if (execution_ownership_mode.compare_exchange_strong(
+            expected,
+            EExecutionOwnershipMode::Legacy,
+            std::memory_order_acq_rel,
+            std::memory_order_acquire
+        )) {
+        LOG_INFO(
+            "[Threading] Vulkan queue={} ownership=Legacy first_operation={}",
+            static_cast<uint32>(queue.GetType()),
+            _operation
+        );
+        return true;
+    }
+    if (expected == EExecutionOwnershipMode::Legacy) {
+        return true;
+    }
+    LOG_ERROR(
+        "[RHIExecutor][Vulkan] rejected legacy {} on Runtime-owned queue={}",
+        _operation,
+        static_cast<uint32>(queue.GetType())
+    );
+    return false;
+}
+
 WaitEvent VkCommandQueue::Execute(CmdSubmit&& _submit) {
+    if (!ClaimLegacyOwnership("Execute")) {
+        TerminalizeRejectedSubmit(
+            vk_device,
+            std::move(_submit),
+            VK_ERROR_UNKNOWN,
+            "[VulkanQueue] rejected mixed Runtime/Legacy submit"
+        );
+        return {uint64(timeline), last_frame.load(std::memory_order_acquire)};
+    }
     if (vk_device.IsFaulted()) {
         TerminalizeRejectedSubmit(
             vk_device,
@@ -3462,91 +3617,274 @@ WaitEvent VkCommandQueue::Execute(CmdSubmit&& _submit) {
 }
 
 std::optional<VkCommandQueue::CurrentVulkanRecordedSubmit>
-VkCommandQueue::TranslateForRuntime(CmdSubmit&& _submit) {
-    std::unique_lock<std::mutex> execution_lock(exec_mtx);
-    const uint64 current_timeline = last_frame.fetch_add(1, std::memory_order_relaxed) + 1;
-    std::optional<CurrentVulkanRecordedSubmit> recorded{};
-    ExecuteNow(
-        std::move(_submit),
-        current_timeline,
-        current_timeline,
-        &recorded,
-        true
+VkCommandQueue::TranslateForRuntime(CmdSubmit&& _submit) noexcept {
+    assert(
+        execution_ownership_mode.load(std::memory_order_acquire) ==
+            EExecutionOwnershipMode::Runtime &&
+        "runtime translate requires an exclusively claimed queue"
     );
-    if (recorded) {
-        recorded->runtime_execution_lock.emplace(std::move(execution_lock));
+    assert(
+        GetCurrentRHIThreadRole() == ERHIThreadRole::Translate &&
+        "runtime command translation must run on the Translate owner"
+    );
+    auto execution_lease = runtime_execution_gate.Acquire();
+    uint64 current_timeline = 0;
+    bool translation_terminalized = false;
+    std::optional<CurrentVulkanRecordedSubmit> recorded{};
+    try {
+        std::unique_lock<std::mutex> execution_lock(exec_mtx);
+        current_timeline =
+            last_frame.fetch_add(1, std::memory_order_relaxed) + 1;
+        ExecuteNow(
+            std::move(_submit),
+            current_timeline,
+            current_timeline,
+            &recorded,
+            true,
+            &translation_terminalized
+        );
+    } catch (const std::exception& error) {
+        try {
+            LOG_ERROR(
+                "[RHIExecutor][Vulkan] command translation threw: {}",
+                error.what()
+            );
+        } catch (...) {
+        }
+    } catch (...) {
+        try {
+            LOG_ERROR("[RHIExecutor][Vulkan] command translation threw");
+        } catch (...) {
+        }
     }
-    return recorded;
+    if (recorded) {
+        recorded->execution_lease = std::move(execution_lease);
+        return recorded;
+    }
+    if (translation_terminalized) {
+        return std::nullopt;
+    }
+
+    if (current_timeline == 0) {
+        RejectForRuntime(std::move(_submit), VK_ERROR_UNKNOWN);
+        return std::nullopt;
+    }
+
+    // A timeline is reserved before translation begins. Unexpected translate
+    // failures must still publish a matching Completion retirement; otherwise
+    // queue Sync would wait forever on an orphaned last_frame value.
+    CurrentVulkanRecordedSubmit rejected{
+        std::move(_submit),
+        VulkanOperationContext{
+            .operation   = EVulkanFaultOperation::QueueSubmit,
+            .queue_type  = queue.GetType(),
+            .queue       = queue.GetHandle(),
+            .timeline    = current_timeline,
+            .work_serial = current_timeline,
+        },
+        current_timeline
+    };
+    rejected.execution_lease       = std::move(execution_lease);
+    rejected.retirement_outcome    = {
+        EVulkanOperationStatus::Rejected, VK_ERROR_UNKNOWN
+    };
+    rejected.native_submit_resolved = true;
+    vk_device.RecordRejectedSubmit();
+    CommitRuntimeSubmitCompletion(rejected, rejected.retirement_outcome);
+    return std::nullopt;
 }
 
 VulkanRuntimeSubmissionResult VkCommandQueue::SubmitRecordedForRuntime(
     CurrentVulkanRecordedSubmit _recorded
-) {
+) noexcept {
     assert(
-        _recorded.runtime_execution_lock.has_value() &&
-        _recorded.runtime_execution_lock->owns_lock() &&
+        GetCurrentRHIThreadRole() == ERHIThreadRole::Submission &&
+        "runtime native submit must run on the Submission owner"
+    );
+    assert(
+        _recorded.execution_lease.OwnsGate() &&
         "runtime recorded submit must retain queue execution ownership"
     );
     const uint64 submitted_timeline = _recorded.timeline;
     const bool split_profiling_frame =
         _recorded.submit.EmitsProfilingQueries() &&
         _recorded.submit.ProfilingPhase() != ERHIProfilingPhase::Complete;
-    const CurrentVulkanSubmitResult submit_result =
-        SubmitRecorded(std::move(_recorded));
-    if (split_profiling_frame && !submit_result.outcome.WasSubmitted()) {
+
+    try {
+        std::unique_lock<std::mutex> execution_lock(exec_mtx);
+        const CurrentVulkanSubmitResult submit_result =
+            SubmitRecorded(_recorded, &runtime_dependency_waits_enabled);
+        if (split_profiling_frame && !submit_result.outcome.WasSubmitted()) {
+            ResetSplitProfilingCpuFrame();
+        }
+    } catch (const std::exception& error) {
+        try {
+            LOG_ERROR(
+                "[RHIExecutor][Vulkan] recorded submission threw before retirement: {}",
+                error.what()
+            );
+        } catch (...) {
+        }
+    } catch (...) {
+        try {
+            LOG_ERROR(
+                "[RHIExecutor][Vulkan] recorded submission threw before retirement"
+            );
+        } catch (...) {
+        }
+    }
+
+    if (!_recorded.native_submit_resolved) {
+        queue.DiscardPendingSubmitState();
+        vk_device.RecordRejectedSubmit();
+        _recorded.retirement_outcome = {
+            EVulkanOperationStatus::Rejected, VK_ERROR_UNKNOWN
+        };
+        _recorded.native_submit_resolved = true;
+    }
+    if (!_recorded.completion_committed) {
+        CommitRuntimeSubmitCompletion(_recorded, _recorded.retirement_outcome);
+    }
+    if (split_profiling_frame && !_recorded.retirement_outcome.WasSubmitted()) {
         ResetSplitProfilingCpuFrame();
     }
-    VulkanRuntimeSubmissionResult runtime_result{.outcome = submit_result.outcome};
-    if (submit_result.outcome.WasSubmitted()) {
+
+    VulkanRuntimeSubmissionResult runtime_result{
+        .outcome               = _recorded.retirement_outcome,
+        .recoverable_rejection = _recorded.recoverable_rejection,
+    };
+    if (_recorded.retirement_outcome.WasSubmitted()) {
         runtime_result.completion = WaitEvent{uint64(timeline), submitted_timeline};
     }
     return runtime_result;
 }
 
-void VkCommandQueue::RejectForRuntime(CmdSubmit&& _submit, VkResult _result) {
-    ResetSplitProfilingCpuFrame();
-    TerminalizeRejectedSubmit(
-        vk_device,
-        std::move(_submit),
-        _result,
-        "[RHIExecutor][Vulkan] rejected command submit"
+void VkCommandQueue::RejectRecordedForRuntime(
+    CurrentVulkanRecordedSubmit&& _recorded,
+    VkResult                       _result
+) noexcept {
+    assert(
+        _recorded.execution_lease.OwnsGate() &&
+        "a failed Translate -> Submission handoff must retain queue ownership"
     );
+    if (_result == VK_SUCCESS) {
+        _result = VK_ERROR_UNKNOWN;
+    }
+    ResetSplitProfilingCpuFrame();
+    vk_device.RecordRejectedSubmit();
+    _recorded.retirement_outcome = {
+        EVulkanOperationStatus::Rejected, _result
+    };
+    _recorded.native_submit_resolved = true;
+    if (!_recorded.completion_committed) {
+        CommitRuntimeSubmitCompletion(_recorded, _recorded.retirement_outcome);
+    }
+}
+
+void VkCommandQueue::RejectForRuntime(CmdSubmit&& _submit, VkResult _result) noexcept {
+    ResetSplitProfilingCpuFrame();
+    if (_result == VK_SUCCESS) {
+        _result = VK_ERROR_UNKNOWN;
+    }
+    vk_device.RecordRejectedSubmit();
+
+    try {
+        std::unique_lock<std::mutex> lock(event_mutex);
+        const uint64 retirement_serial = retirement_enqueued_serial + 1;
+        event_queue.emplace_back(
+            std::in_place_type<VulkanSubmitCompletionBatch>,
+            0,
+            true,
+            retirement_serial,
+            VulkanOperationResult{EVulkanOperationStatus::Rejected, _result},
+            VulkanOperationContext{
+                .operation  = EVulkanFaultOperation::QueueSubmit,
+                .queue_type = queue.GetType(),
+                .queue      = queue.GetHandle(),
+            },
+            false,
+            false,
+            std::move(_submit),
+            VulkanAllocatorBatch{},
+            std::optional<VulkanDescriptorPushLease>{},
+            Array<RHIResource*>{}
+        );
+        retirement_enqueued_serial = retirement_serial;
+    } catch (...) {
+        // Continuing would destroy callbacks/signals outside Completion and
+        // violate the ownership contract. Allocation failure is therefore
+        // treated as an unrecoverable runtime bookkeeping failure.
+        std::terminate();
+    }
+    queue_cv.notify_one();
 }
 
 VulkanRuntimeSubmissionResult VkCommandQueue::PresentForRuntime(
     SwapchainRef _swapchain,
     TextureView _source,
     PresentReceiptRef _receipt
-) {
+) noexcept {
+    assert(
+        execution_ownership_mode.load(std::memory_order_acquire) ==
+            EExecutionOwnershipMode::Runtime &&
+        "runtime Present requires an exclusively claimed queue"
+    );
+    assert(
+        GetCurrentRHIThreadRole() == ERHIThreadRole::Submission &&
+        "runtime Present must run on the Submission owner"
+    );
     assert(_source.texture != nullptr && "Present source texture is null");
-    TextureRef source_texture{_source.texture};
-    if (vk_device.IsFaulted()) {
+    try {
+        TextureRef source_texture{_source.texture};
+        if (vk_device.IsFaulted()) {
+            vk_device.RecordRejectedPresent();
+            ResolvePresentReceiptNoexcept(_receipt, false, false);
+            return {
+                .outcome = {
+                    EVulkanOperationStatus::Rejected,
+                    vk_device.GetFirstFaultResult()
+                }
+            };
+        }
+
+        auto execution_lease = runtime_execution_gate.Acquire();
+        std::unique_lock<std::mutex> execution_lock(exec_mtx);
+        const uint64 current_timeline =
+            last_frame.fetch_add(1, std::memory_order_relaxed) + 1;
+        return PresentNow(
+            std::move(_swapchain),
+            std::move(source_texture),
+            _source,
+            std::move(_receipt),
+            current_timeline,
+            current_timeline,
+            true
+        );
+    } catch (...) {
         vk_device.RecordRejectedPresent();
-        if (_receipt) {
-            _receipt->Resolve(false);
+        ResolvePresentReceiptNoexcept(_receipt, false, false);
+        try {
+            LOG_ERROR(
+                "[RHIExecutor][Vulkan] Present owner setup threw before timeline reservation"
+            );
+        } catch (...) {
         }
         return {
             .outcome = {
-                EVulkanOperationStatus::Rejected, vk_device.GetFirstFaultResult()
+                EVulkanOperationStatus::Rejected,
+                vk_device.IsFaulted() ?
+                    vk_device.GetFirstFaultResult() :
+                    VK_ERROR_UNKNOWN
             }
         };
     }
-
-    std::unique_lock<std::mutex> execution_lock(exec_mtx);
-    const uint64 current_timeline = last_frame.fetch_add(1, std::memory_order_relaxed) + 1;
-    return PresentNow(
-        std::move(_swapchain),
-        std::move(source_texture),
-        _source,
-        std::move(_receipt),
-        current_timeline,
-        current_timeline,
-        true
-    );
 }
 
 VkCommandQueue::CurrentVulkanSubmitResult
-VkCommandQueue::SubmitRecorded(CurrentVulkanRecordedSubmit _recorded) {
+VkCommandQueue::SubmitRecorded(
+    CurrentVulkanRecordedSubmit& _recorded,
+    const std::atomic_bool*       _continue_waiting
+) {
     assert(
         _recorded.has_commands == !_recorded.ordered_cmd_lists.empty() &&
         "recorded Vulkan submit command-list ownership mismatch"
@@ -3557,11 +3895,15 @@ VkCommandQueue::SubmitRecorded(CurrentVulkanRecordedSubmit _recorded) {
                                             std::chrono::steady_clock::time_point{};
     const auto end_tag = VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT;
     VulkanOperationResult submit_outcome{};
-    if (!WaitForSubmittedDependencies(vk_device, _recorded.submit.wait_events)) {
+    if (!WaitForSubmittedDependencies(
+            vk_device, _recorded.submit.wait_events, _continue_waiting
+        )) {
         vk_device.RecordRejectedSubmit();
         const VkResult rejected_result = GetRejectedSubmitResult(vk_device);
         submit_outcome = {EVulkanOperationStatus::Rejected, rejected_result};
-        FailSubmissionSignals(timeline, _recorded.submit.signal_events, rejected_result);
+        _recorded.recoverable_rejection = !vk_device.IsFaulted();
+        _recorded.native_submit_resolved = true;
+        _recorded.retirement_outcome     = submit_outcome;
     } else {
         queue.Signal(timeline, _recorded.timeline, end_tag);
         for (auto& event : _recorded.submit.wait_events) {
@@ -3585,20 +3927,17 @@ VkCommandQueue::SubmitRecorded(CurrentVulkanRecordedSubmit _recorded) {
                                  _recorded.context
                              ) :
                              queue.SubmitEmpty(_recorded.context);
+        _recorded.native_submit_resolved = true;
+        // Persist the native result before any signal-fence bookkeeping can
+        // throw. Once vkQueueSubmit2 has accepted the packet, every later
+        // exception must still retire it as GPU-submitted.
+        _recorded.retirement_outcome = submit_outcome;
         if (submit_outcome.WasSubmitted()) {
             MarkSubmissionAccepted(
                 timeline, _recorded.timeline, _recorded.submit.signal_events
             );
-        } else {
-            FailSubmissionSignals(
-                timeline, _recorded.submit.signal_events, submit_outcome.result
-            );
         }
     }
-    if (!submit_outcome.WasSubmitted()) {
-        FinalizeRejectedBindlessUpdates(_recorded.submit);
-    }
-
     const double profile_submit_cpu_ms = _recorded.profile.enabled ?
                                              RhiThreadProfileMilliseconds(
                                                  profile_submit_started,
@@ -3608,56 +3947,8 @@ VkCommandQueue::SubmitRecorded(CurrentVulkanRecordedSubmit _recorded) {
     const uint32 ordered_cmd_list_count =
         static_cast<uint32>(_recorded.ordered_cmd_lists.size());
 
-    {
-        std::unique_lock<std::mutex> lock(event_mutex);
-        event_queue.emplace_back(
-            VulkanSubmissionEvent{
-                submit_outcome, _recorded.context, submit_outcome.WasSubmitted()
-            },
-            _recorded.timeline,
-            false
-        );
-        event_queue.emplace_back(
-            std::move(_recorded.allocators), _recorded.timeline, false
-        );
-        if (_recorded.descriptor_lease.has_value()) {
-            event_queue.emplace_back(
-                std::move(*_recorded.descriptor_lease), _recorded.timeline, false
-            );
-        }
-        for (auto& event : _recorded.submit.signal_events) {
-            event_queue.emplace_back(
-                SignalEvent(event.timeline_handle, event.value), _recorded.timeline, false
-            );
-        }
-        if (!_recorded.submit.callbacks.empty()) {
-            event_queue.emplace_back(
-                VulkanCallbackBatch{std::move(_recorded.submit.callbacks), false},
-                _recorded.timeline,
-                false
-            );
-        }
-        if (!_recorded.submit.success_callbacks.empty()) {
-            event_queue.emplace_back(
-                VulkanCallbackBatch{std::move(_recorded.submit.success_callbacks), true},
-                _recorded.timeline,
-                false
-            );
-        }
-        if (!_recorded.deferred_releases.empty()) {
-            event_queue.emplace_back(
-                VulkanDeferredReleaseBatch{std::move(_recorded.deferred_releases)},
-                _recorded.timeline,
-                false
-            );
-        }
-        EnqueueCompletionMarker(_recorded.timeline);
-    }
-    queue_cv.notify_one();
+    CommitRuntimeSubmitCompletion(_recorded, submit_outcome);
 
-    if (_recorded.has_commands) {
-        executed_queue.Enqueue(_recorded.timeline);
-    }
     if (_recorded.profile.enabled) {
         _recorded.profile.sample.submit_cpu_ms = profile_submit_cpu_ms;
         _recorded.profile.sample.execute_cpu_wall_ms = RhiThreadProfileMilliseconds(
@@ -3671,6 +3962,51 @@ VkCommandQueue::SubmitRecorded(CurrentVulkanRecordedSubmit _recorded) {
         .outcome                = submit_outcome,
         .ordered_cmd_list_count = ordered_cmd_list_count,
     };
+}
+
+void VkCommandQueue::CommitRuntimeSubmitCompletion(
+    CurrentVulkanRecordedSubmit& _recorded,
+    const VulkanOperationResult&  _outcome
+) noexcept {
+    assert(!_recorded.completion_committed);
+    try {
+        if (!_outcome.WasSubmitted()) {
+            _recorded.allocators.abandoned.reserve(
+                _recorded.allocators.abandoned.size() +
+                _recorded.allocators.submitted.size()
+            );
+            for (auto& allocator : _recorded.allocators.submitted) {
+                _recorded.allocators.abandoned.emplace_back(
+                    std::move(allocator)
+                );
+            }
+            _recorded.allocators.submitted.clear();
+        }
+
+        std::unique_lock<std::mutex> lock(event_mutex);
+        const uint64 retirement_serial = retirement_enqueued_serial + 1;
+        event_queue.emplace_back(
+            std::in_place_type<VulkanSubmitCompletionBatch>,
+            _recorded.timeline,
+            true,
+            retirement_serial,
+            _outcome,
+            _recorded.context,
+            _outcome.WasSubmitted(),
+            _outcome.WasSubmitted(),
+            std::move(_recorded.submit),
+            std::move(_recorded.allocators),
+            std::move(_recorded.descriptor_lease),
+            std::move(_recorded.deferred_releases)
+        );
+        retirement_enqueued_serial     = retirement_serial;
+        _recorded.completion_committed = true;
+    } catch (...) {
+        // The packet may own command pools already submitted to the GPU. It is
+        // never safe to unwind and destroy it on the Submission owner.
+        std::terminate();
+    }
+    queue_cv.notify_one();
 }
 
 bool VkCommandQueue::TryExecuteParallel(
@@ -3949,12 +4285,15 @@ bool VkCommandQueue::TryExecuteParallel(
         if (_result == VK_SUCCESS) {
             _result = VK_ERROR_UNKNOWN;
         }
-        LOG_ERROR(
-            "[ParallelRecord] prepared batch {} rejected: reason={} VkResult={}",
-            batch_serial,
-            _reason,
-            static_cast<int32_t>(_result)
-        );
+        try {
+            LOG_ERROR(
+                "[ParallelRecord] prepared batch {} rejected: reason={} VkResult={}",
+                batch_serial,
+                _reason,
+                static_cast<int32_t>(_result)
+            );
+        } catch (...) {
+        }
         ResetSplitProfilingCpuFrame();
         // Once preprocessing/recording has begun, falling back to replaying
         // the whole packet is unsafe: serial commands may already have moved
@@ -3963,8 +4302,6 @@ bool VkCommandQueue::TryExecuteParallel(
         // so no later frame can consume partially prepared CPU-side state.
         vk_device.TryLatchFirstFault(_context, _result, false, false, true);
         vk_device.RecordRejectedSubmit();
-        FailSubmissionSignals(timeline, _submit.signal_events, _result);
-        FinalizeRejectedBindlessUpdates(_submit);
 
         Array<UniquePtr<VulkanAllocator>> abandoned_allocators;
         auto collect_allocator = [&](UniquePtr<VulkanAllocator>& _allocator) {
@@ -3982,53 +4319,42 @@ bool VkCommandQueue::TryExecuteParallel(
         collect_allocator(tracker_owner);
 
         Array<RHIResource*> deferred_releases = TakeDeferredReleases();
-        {
+        try {
             std::unique_lock<std::mutex> lock(event_mutex);
+            const uint64 retirement_serial = retirement_enqueued_serial + 1;
             event_queue.emplace_back(
-                VulkanSubmissionEvent{
-                    {EVulkanOperationStatus::Rejected, _result}, _context, false
+                std::in_place_type<VulkanSubmitCompletionBatch>,
+                _timeline,
+                true,
+                retirement_serial,
+                VulkanOperationResult{
+                    EVulkanOperationStatus::Rejected, _result
                 },
-                _timeline,
-                false
-            );
-            event_queue.emplace_back(
+                _context,
+                false,
+                true,
+                std::move(_submit),
                 VulkanAllocatorBatch{{}, std::move(abandoned_allocators)},
-                _timeline,
-                false
+                std::move(descriptor_lease),
+                std::move(deferred_releases)
             );
-            event_queue.emplace_back(std::move(descriptor_lease), _timeline, false);
-            for (auto& event : _submit.signal_events) {
-                event_queue.emplace_back(
-                    SignalEvent(event.timeline_handle, event.value), _timeline, false
-                );
-            }
-            if (!_submit.callbacks.empty()) {
-                event_queue.emplace_back(
-                    VulkanCallbackBatch{std::move(_submit.callbacks), false}, _timeline, false
-                );
-            }
-            if (!_submit.success_callbacks.empty()) {
-                event_queue.emplace_back(
-                    VulkanCallbackBatch{std::move(_submit.success_callbacks), true}, _timeline, false
-                );
-            }
-            if (!deferred_releases.empty()) {
-                event_queue.emplace_back(
-                    VulkanDeferredReleaseBatch{std::move(deferred_releases)}, _timeline, false
-                );
-            }
-            EnqueueCompletionMarker(_timeline);
+            retirement_enqueued_serial = retirement_serial;
+        } catch (...) {
+            std::terminate();
         }
         queue_cv.notify_one();
         if (parallel_record_verify) {
-            LOG_INFO(
-                "[ParallelRecord] batch={} requested=true effective=false "
-                "outcome=record-rejected reason={} coordinator={} VkResult={}",
-                batch_serial,
-                _reason,
-                Platform::GetCurrentThreadID(),
-                static_cast<int32_t>(_result)
-            );
+            try {
+                LOG_INFO(
+                    "[ParallelRecord] batch={} requested=true effective=false "
+                    "outcome=record-rejected reason={} coordinator={} VkResult={}",
+                    batch_serial,
+                    _reason,
+                    Platform::GetCurrentThreadID(),
+                    static_cast<int32_t>(_result)
+                );
+            } catch (...) {
+            }
         }
     };
 
@@ -4095,6 +4421,7 @@ bool VkCommandQueue::TryExecuteParallel(
             }
             for (size_t chunk_index = 0; chunk_index < runtime.chunks.size(); ++chunk_index) {
                 wave_jobs.emplace_back([&, layer_index, chunk_index] {
+                    RHIThreadRoleScope owner_scope(ERHIThreadRole::RecordWorker);
                     ParallelLayerRuntime& job_layer = runtime_layers[layer_index];
                     ParallelChunkRuntime& chunk     = job_layer.chunks[chunk_index];
                     const uint32 now_active =
@@ -4217,17 +4544,20 @@ bool VkCommandQueue::TryExecuteParallel(
             }
         }
         if (parallel_record_verify) {
-            LOG_INFO(
-                "[ParallelRecord][Wave] batch={} wave={} layers={}..{} jobs={} "
-                "join_completed={} worker_recorded={}",
-                batch_serial,
-                wave_index,
-                _first_layer,
-                _layer_end,
-                wave_jobs.size(),
-                join_result == ExternalJoinResult::Completed,
-                wave_recorded
-            );
+            try {
+                LOG_INFO(
+                    "[ParallelRecord][Wave] batch={} wave={} layers={}..{} jobs={} "
+                    "join_completed={} worker_recorded={}",
+                    batch_serial,
+                    wave_index,
+                    _first_layer,
+                    _layer_end,
+                    wave_jobs.size(),
+                    join_result == ExternalJoinResult::Completed,
+                    wave_recorded
+                );
+            } catch (...) {
+            }
         }
         // Native command-buffer failures are device/driver failures, not a
         // replayable translation exception. Match coordinator Begin/End by
@@ -4283,21 +4613,28 @@ bool VkCommandQueue::TryExecuteParallel(
                     visitor.VisitCmd(command);
                 }
             } catch (const StaleBindlessUpdateBatch& error) {
-                LOG_WARNING(
-                    "[ParallelRecord] fallback rejected stale bindless batch: layer={} error={}",
-                    layer_index,
-                    error.what()
-                );
+                try {
+                    LOG_WARNING(
+                        "[ParallelRecord] fallback rejected stale bindless batch: "
+                        "layer={} error={}",
+                        layer_index,
+                        error.what()
+                    );
+                } catch (...) {
+                }
                 reject_prepared_recording(
                     "stale-bindless-update", VK_ERROR_VALIDATION_FAILED_EXT
                 );
                 return false;
             } catch (const std::exception& error) {
-                LOG_ERROR(
-                    "[ParallelRecord] fallback record failed: layer={} error={}",
-                    layer_index,
-                    error.what()
-                );
+                try {
+                    LOG_ERROR(
+                        "[ParallelRecord] fallback record failed: layer={} error={}",
+                        layer_index,
+                        error.what()
+                    );
+                } catch (...) {
+                }
                 reject_prepared_recording(
                     "fallback-record-failed", VK_ERROR_OUT_OF_POOL_MEMORY
                 );
@@ -4359,11 +4696,15 @@ bool VkCommandQueue::TryExecuteParallel(
                 try {
                     record_layer_prefix(layer_index, primary_cmd);
                 } catch (const std::exception& error) {
-                    LOG_ERROR(
-                        "[ParallelRecord] coordinator prefix failed: layer={} error={}",
-                        layer_index,
-                        error.what()
-                    );
+                    try {
+                        LOG_ERROR(
+                            "[ParallelRecord] coordinator prefix failed: layer={} "
+                            "error={}",
+                            layer_index,
+                            error.what()
+                        );
+                    } catch (...) {
+                    }
                     reject_prepared_recording(
                         "coordinator-prefix-failed", VK_ERROR_OUT_OF_POOL_MEMORY
                     );
@@ -4405,14 +4746,17 @@ bool VkCommandQueue::TryExecuteParallel(
 
         const uint32 island_index = serial_island_count++;
         if (parallel_record_verify) {
-            LOG_INFO(
-                "[ParallelRecord][Island] batch={} island={} first_layer={} "
-                "joined_waves={}",
-                batch_serial,
-                island_index,
-                layer_index,
-                parallel_wave_count
-            );
+            try {
+                LOG_INFO(
+                    "[ParallelRecord][Island] batch={} island={} first_layer={} "
+                    "joined_waves={}",
+                    batch_serial,
+                    island_index,
+                    layer_index,
+                    parallel_wave_count
+                );
+            } catch (...) {
+            }
         }
 
         first_runtime.primary_allocator = GetAllocator();
@@ -4459,21 +4803,29 @@ bool VkCommandQueue::TryExecuteParallel(
                 island_exit_scopes = &runtime_layers[layer_index].scopes;
             }
         } catch (const StaleBindlessUpdateBatch& error) {
-            LOG_WARNING(
-                "[ParallelRecord] coordinator rejected stale bindless batch: layer={} error={}",
-                layer_index,
-                error.what()
-            );
+            try {
+                LOG_WARNING(
+                    "[ParallelRecord] coordinator rejected stale bindless batch: "
+                    "layer={} error={}",
+                    layer_index,
+                    error.what()
+                );
+            } catch (...) {
+            }
             reject_prepared_recording(
                 "stale-bindless-update", VK_ERROR_VALIDATION_FAILED_EXT
             );
             return true;
         } catch (const std::exception& error) {
-            LOG_ERROR(
-                "[ParallelRecord] coordinator island record failed: layer={} error={}",
-                layer_index,
-                error.what()
-            );
+            try {
+                LOG_ERROR(
+                    "[ParallelRecord] coordinator island record failed: layer={} "
+                    "error={}",
+                    layer_index,
+                    error.what()
+                );
+            } catch (...) {
+            }
             reject_prepared_recording(
                 "coordinator-record-failed", VK_ERROR_OUT_OF_POOL_MEMORY
             );
@@ -4592,7 +4944,7 @@ bool VkCommandQueue::TryExecuteParallel(
     if (_out_recorded != nullptr) {
         _out_recorded->emplace(std::move(recorded_submit));
     } else {
-        submit_result = SubmitRecorded(std::move(recorded_submit));
+        submit_result = SubmitRecorded(recorded_submit);
     }
 
     QueryFrameDiagnostics query_diagnostics{};
@@ -4625,7 +4977,8 @@ bool VkCommandQueue::TryExecuteParallel(
     }
 
     if (parallel_record_verify) {
-        LOG_INFO(
+        try {
+            LOG_INFO(
             "[ParallelRecord] batch={} requested=true effective={} outcome={} layers={} jobs={} "
             "work_units={} ordered_cb={} waves={} islands={} workers={} distinct_workers={} max_active={} "
             "coordinator={} submit_status={} "
@@ -4649,7 +5002,9 @@ bool VkCommandQueue::TryExecuteParallel(
             descriptor_bytes,
             query_diagnostics.digest,
             query_diagnostics.used_query_count
-        );
+            );
+        } catch (...) {
+        }
     }
     return true;
 }
@@ -4659,7 +5014,8 @@ void VkCommandQueue::ExecuteNow(
     uint64 _timeline,
     uint64 _serial,
     std::optional<CurrentVulkanRecordedSubmit>* _out_recorded,
-    bool _runtime_owner
+    bool _runtime_owner,
+    bool* _out_terminalized
 ) {
     assert(
         _runtime_owner || !rhi_thread_enabled ||
@@ -4684,28 +5040,33 @@ void VkCommandQueue::ExecuteNow(
         ResetSplitProfilingCpuFrame();
         vk_device.RecordRejectedSubmit();
         const VkResult rejected_result = vk_device.GetFirstFaultResult();
-        FailSubmissionSignals(timeline, _submit.signal_events, rejected_result);
-        std::unique_lock<std::mutex> lock(event_mutex);
-        event_queue.emplace_back(
-            VulkanSubmissionEvent{
-                {EVulkanOperationStatus::Rejected, rejected_result}, context
-            },
-            _timeline,
-            false
-        );
-        if (!_submit.callbacks.empty()) {
+        try {
+            std::unique_lock<std::mutex> lock(event_mutex);
+            const uint64 retirement_serial = retirement_enqueued_serial + 1;
             event_queue.emplace_back(
-                VulkanCallbackBatch{std::move(_submit.callbacks), false}, _timeline, false
+                std::in_place_type<VulkanSubmitCompletionBatch>,
+                _timeline,
+                true,
+                retirement_serial,
+                VulkanOperationResult{
+                    EVulkanOperationStatus::Rejected, rejected_result
+                },
+                context,
+                false,
+                true,
+                std::move(_submit),
+                VulkanAllocatorBatch{},
+                std::optional<VulkanDescriptorPushLease>{},
+                Array<RHIResource*>{}
             );
+            retirement_enqueued_serial = retirement_serial;
+        } catch (...) {
+            std::terminate();
         }
-        if (!_submit.success_callbacks.empty()) {
-            event_queue.emplace_back(
-                VulkanCallbackBatch{std::move(_submit.success_callbacks), true}, _timeline, false
-            );
-        }
-        EnqueueCompletionMarker(_timeline);
-        lock.unlock();
         queue_cv.notify_one();
+        if (_out_terminalized != nullptr) {
+            *_out_terminalized = true;
+        }
         return;
     }
 
@@ -4742,6 +5103,10 @@ void VkCommandQueue::ExecuteNow(
             parallel_profile_started,
             _out_recorded
         )) {
+        if (_out_terminalized != nullptr && _out_recorded != nullptr &&
+            !_out_recorded->has_value()) {
+            *_out_terminalized = true;
+        }
         return;
     }
 
@@ -4850,65 +5215,53 @@ void VkCommandQueue::ExecuteNow(
         if (_result == VK_SUCCESS) {
             _result = VK_ERROR_UNKNOWN;
         }
-        LOG_ERROR(
-            "[SerialRecord] batch {} rejected: reason={} VkResult={}",
-            _serial,
-            _reason,
-            static_cast<int32_t>(_result)
-        );
+        try {
+            LOG_ERROR(
+                "[SerialRecord] batch {} rejected: reason={} VkResult={}",
+                _serial,
+                _reason,
+                static_cast<int32_t>(_result)
+            );
+        } catch (...) {
+        }
         ResetSplitProfilingCpuFrame();
         // Recording may already have executed CPU-side preprocessing or
         // transient allocation. Replaying the packet is therefore unsafe.
         vk_device.TryLatchFirstFault(context, _result, false, false, true);
         vk_device.RecordRejectedSubmit();
-        FailSubmissionSignals(timeline, _submit.signal_events, _result);
-        FinalizeRejectedBindlessUpdates(_submit);
 
         Array<UniquePtr<VulkanAllocator>> abandoned_allocators;
         if (allocator_ptr) {
             abandoned_allocators.push_back(std::move(allocator_ptr));
         }
         Array<RHIResource*> deferred_releases = TakeDeferredReleases();
-        {
+        try {
             std::unique_lock<std::mutex> lock(event_mutex);
+            const uint64 retirement_serial = retirement_enqueued_serial + 1;
             event_queue.emplace_back(
-                VulkanSubmissionEvent{
-                    {EVulkanOperationStatus::Rejected, _result}, context, false
+                std::in_place_type<VulkanSubmitCompletionBatch>,
+                _timeline,
+                true,
+                retirement_serial,
+                VulkanOperationResult{
+                    EVulkanOperationStatus::Rejected, _result
                 },
-                _timeline,
-                false
-            );
-            event_queue.emplace_back(
+                context,
+                false,
+                true,
+                std::move(_submit),
                 VulkanAllocatorBatch{{}, std::move(abandoned_allocators)},
-                _timeline,
-                false
+                std::move(descriptor_lease),
+                std::move(deferred_releases)
             );
-            if (descriptor_lease.has_value()) {
-                event_queue.emplace_back(std::move(*descriptor_lease), _timeline, false);
-            }
-            for (auto& event : _submit.signal_events) {
-                event_queue.emplace_back(
-                    SignalEvent(event.timeline_handle, event.value), _timeline, false
-                );
-            }
-            if (!_submit.callbacks.empty()) {
-                event_queue.emplace_back(
-                    VulkanCallbackBatch{std::move(_submit.callbacks), false}, _timeline, false
-                );
-            }
-            if (!_submit.success_callbacks.empty()) {
-                event_queue.emplace_back(
-                    VulkanCallbackBatch{std::move(_submit.success_callbacks), true}, _timeline, false
-                );
-            }
-            if (!deferred_releases.empty()) {
-                event_queue.emplace_back(
-                    VulkanDeferredReleaseBatch{std::move(deferred_releases)}, _timeline, false
-                );
-            }
-            EnqueueCompletionMarker(_timeline);
+            retirement_enqueued_serial = retirement_serial;
+        } catch (...) {
+            std::terminate();
         }
         queue_cv.notify_one();
+        if (_out_terminalized != nullptr) {
+            *_out_terminalized = true;
+        }
     };
 
     auto record_serial_commands = [&] {
@@ -5159,7 +5512,12 @@ void VkCommandQueue::ExecuteNow(
         reject_serial_recording(failure.reason, failure.result);
         return;
     } catch (const StaleBindlessUpdateBatch& error) {
-        LOG_WARNING("[SerialRecord] rejected stale bindless batch: {}", error.what());
+        try {
+            LOG_WARNING(
+                "[SerialRecord] rejected stale bindless batch: {}", error.what()
+            );
+        } catch (...) {
+        }
         reject_serial_recording(
             "stale-bindless-update", VK_ERROR_VALIDATION_FAILED_EXT
         );
@@ -5239,7 +5597,7 @@ void VkCommandQueue::ExecuteNow(
     if (_out_recorded != nullptr) {
         _out_recorded->emplace(std::move(recorded_submit));
     } else {
-        submit_result = SubmitRecorded(std::move(recorded_submit));
+        submit_result = SubmitRecorded(recorded_submit);
     }
 
     if (has_cmd && complete_profiling_frame) {
@@ -5276,6 +5634,12 @@ void VkCommandQueue::Present(
     assert(_view.texture != nullptr && "Present source texture is null");
     TextureRef source_texture{_view.texture};
 
+    if (!ClaimLegacyOwnership("Present")) {
+        if (_receipt) {
+            _receipt->Resolve(false);
+        }
+        return;
+    }
     if (vk_device.IsFaulted()) {
         vk_device.RecordRejectedPresent();
         if (_receipt) {
@@ -5351,7 +5715,7 @@ VulkanRuntimeSubmissionResult VkCommandQueue::PresentNow(
     uint64         _timeline,
     uint64         _serial,
     bool           _runtime_owner
-) {
+) noexcept {
     assert(
         _runtime_owner || !rhi_thread_enabled ||
         rhi_thread_id.load(std::memory_order_acquire) == Platform::GetCurrentThreadID()
@@ -5364,193 +5728,235 @@ VulkanRuntimeSubmissionResult VkCommandQueue::PresentNow(
         .timeline    = _timeline,
         .work_serial = _serial,
     };
-    if (vk_device.IsFaulted()) {
-        vk_device.RecordRejectedPresent();
-        if (_receipt) {
-            _receipt->Resolve(false);
-        }
-        const VkResult rejected_result = vk_device.GetFirstFaultResult();
-        timeline->Fail(rejected_result);
-        std::unique_lock<std::mutex> lock(event_mutex);
-        event_queue.emplace_back(
-            VulkanSubmissionEvent{
-                {EVulkanOperationStatus::Rejected, rejected_result}, context, false
-            },
-            _timeline,
-            false
-        );
-        EnqueueCompletionMarker(_timeline);
-        lock.unlock();
-        queue_cv.notify_one();
-        return {
-            .outcome = {EVulkanOperationStatus::Rejected, rejected_result}
-        };
-    }
 
-    VkSwapchain* sc = ResourceCast(_sc.Get());
-    auto         presentor = std::move(GetPresentor());
-    auto& vk_allocator = *presentor;
-    auto& vk_cmd_list  = vk_allocator.GetCmdList();
-    auto& vk_tracker   = vk_allocator.GetTracker();
-    if (!sc->WaitFrameInFlight()) {
-        vk_device.RecordRejectedPresent();
-        if (_receipt) {
-            _receipt->Resolve(false);
-        }
-        const VkResult rejected_result = GetRejectedSubmitResult(vk_device);
-        timeline->Fail(rejected_result);
-        std::unique_lock<std::mutex> lock(event_mutex);
-        event_queue.emplace_back(
-            VulkanSubmissionEvent{
-                {EVulkanOperationStatus::Rejected, rejected_result}, context, false
-            },
-            _timeline,
-            false
-        );
-        event_queue.emplace_back(std::move(presentor), _timeline, false);
-        EnqueueCompletionMarker(_timeline);
-        lock.unlock();
-        queue_cv.notify_one();
-        return {
-            .outcome = {EVulkanOperationStatus::Rejected, rejected_result}
-        };
-    }
-    auto acquire = sc->AquireNextImage(rhi_thread_enabled ? 0 : 50'000'000);
-    bool recreate_swapchain =
-        acquire.outcome.status == EVulkanOperationStatus::Recreate;
+    VulkanOperationResult final_outcome{
+        EVulkanOperationStatus::Rejected, VK_ERROR_UNKNOWN
+    };
+    bool                            gpu_submitted = false;
+    bool                            present_accepted = false;
+    bool                            recreate_swapchain = false;
+    EVulkanPresentorRetirementState presentor_state =
+        EVulkanPresentorRetirementState::Unused;
+    UniquePtr<VulkanPresentor> presentor{};
+    Array<RHIResource*>        deferred_releases{};
 
-    Array<std::function<void()>> callbacks;
-    if (!acquire.HasImage()) {
-        if (_receipt) {
-            _receipt->Resolve(false, recreate_swapchain);
-        }
-        if (acquire.outcome.status == EVulkanOperationStatus::Faulted ||
-            acquire.outcome.status == EVulkanOperationStatus::Rejected) {
-            timeline->Fail(acquire.outcome.result);
+    try {
+        if (vk_device.IsFaulted()) {
+            vk_device.RecordRejectedPresent();
+            final_outcome = {
+                EVulkanOperationStatus::Rejected,
+                vk_device.GetFirstFaultResult()
+            };
         } else {
-            presentors.Push(presentor.release());
-        }
+            VkSwapchain* sc = ResourceCast(_sc.Get());
+            presentor       = GetPresentor();
+            if (!sc->WaitFrameInFlight()) {
+                vk_device.RecordRejectedPresent();
+                final_outcome = {
+                    EVulkanOperationStatus::Rejected,
+                    GetRejectedSubmitResult(vk_device)
+                };
+            } else {
+                const VkSwapchain::AcquireResult acquire =
+                    sc->AquireNextImage(rhi_thread_enabled ? 0 : 50'000'000);
+                final_outcome      = acquire.outcome;
+                recreate_swapchain =
+                    acquire.outcome.status == EVulkanOperationStatus::Recreate;
 
-        Array<RHIResource*> deferred_releases = TakeDeferredReleases();
-        callbacks.emplace_back(
-            [swapchain = std::move(_sc), source_texture = std::move(_source_texture)]() mutable {}
-        );
-        {
-            std::unique_lock<std::mutex> lock(event_mutex);
-            event_queue.emplace_back(
-                VulkanSubmissionEvent{acquire.outcome, context, false}, _timeline, false
-            );
-            if (presentor) {
-                event_queue.emplace_back(std::move(presentor), _timeline, false);
+                if (acquire.HasImage()) {
+                    presentor_state =
+                        EVulkanPresentorRetirementState::RecordedNotSubmitted;
+                    auto& vk_allocator = *presentor;
+                    auto& vk_cmd_list  = vk_allocator.GetCmdList();
+                    auto& vk_tracker   = vk_allocator.GetTracker();
+                    auto* vk_src_tex   = static_cast<VulkanTexture*>(_view.texture);
+                    const uint idx     = acquire.image_index;
+                    auto* swapchain_tex =
+                        ResourceCast(sc->GetSwapchainImage(idx).texture);
+
+                    VK_CHECK_RESULT(vk_cmd_list.Begin());
+                    const std::string present_label =
+                        std::format("Present: {}", vk_src_tex->GetName());
+                    vk_cmd_list.BeginLabel(
+                        present_label, {0.0f, 0.85f, 0.95f, 1.0f}
+                    );
+                    vk_tracker.SetPassType(EPassType::Graphics);
+                    vk_tracker.RecordState(
+                        vk_src_tex,
+                        vk_tracker.ReadTexture(vk_src_tex, ETextureState::TRANSFER)
+                    );
+                    vk_tracker.RecordState(
+                        swapchain_tex,
+                        vk_tracker.WriteTexture(
+                            swapchain_tex, ETextureState::TRANSFER
+                        )
+                    );
+                    vk_tracker.ResolveBarriers();
+                    vk_tracker.DispatchBarriers(vk_cmd_list);
+                    vk_cmd_list.InsertLabel(
+                        "Copy Present Image", GpuMarkerPalette::Transfer()
+                    );
+                    vk_cmd_list.CopyTexture(
+                        vk_src_tex,
+                        swapchain_tex,
+                        _view.extent,
+                        {0, 0, 0},
+                        {0, 0, 0},
+                        0,
+                        0
+                    );
+                    vk_tracker.RecordState(
+                        swapchain_tex,
+                        VK_ACCESS_2_NONE,
+                        VK_IMAGE_LAYOUT_PRESENT_SRC_KHR,
+                        VK_PIPELINE_STAGE_2_COPY_BIT
+                    );
+                    vk_tracker.ResolveBarriers();
+                    vk_tracker.DispatchBarriers(vk_cmd_list);
+                    vk_tracker.RestoreState();
+                    vk_tracker.DispatchBarriers(vk_cmd_list);
+                    vk_cmd_list.EndLabel();
+                    VK_CHECK_RESULT(vk_cmd_list.End());
+                    vk_tracker.Reset();
+
+                    deferred_releases = TakeDeferredReleases();
+                    queue.Signal(
+                        timeline, _timeline, VK_PIPELINE_STAGE_2_COPY_BIT
+                    );
+                    queue.Wait(
+                        acquire.ready_semaphore,
+                        VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT
+                    );
+                    queue.Signal(
+                        sc->GetRenderFinishedFence(idx),
+                        VK_PIPELINE_STAGE_2_COPY_BIT
+                    );
+                    const VulkanOperationResult submit_outcome =
+                        queue.Submit(vk_allocator.GetCmdList(), context);
+                    final_outcome = submit_outcome;
+                    gpu_submitted = submit_outcome.WasSubmitted();
+                    if (gpu_submitted) {
+                        presentor_state =
+                            EVulkanPresentorRetirementState::Submitted;
+                        timeline->MarkSubmitted(_timeline);
+
+                        const VulkanOperationResult present_outcome =
+                            sc->Present(
+                                queue.GetHandle(), idx, _timeline, _serial
+                            );
+                        present_accepted =
+                            present_outcome.result == VK_SUCCESS ||
+                            present_outcome.result == VK_SUBOPTIMAL_KHR;
+                        recreate_swapchain =
+                            recreate_swapchain ||
+                            present_outcome.status ==
+                                EVulkanOperationStatus::Recreate;
+                        if (!present_outcome.Succeeded()) {
+                            final_outcome = present_outcome;
+                        }
+                    }
+                } else {
+                    deferred_releases = TakeDeferredReleases();
+                }
             }
-            event_queue.emplace_back(
-                VulkanCallbackBatch{std::move(callbacks), false}, _timeline, false
-            );
-            if (!deferred_releases.empty()) {
-                event_queue.emplace_back(
-                    VulkanDeferredReleaseBatch{std::move(deferred_releases)}, _timeline, false
-                );
-            }
-            EnqueueCompletionMarker(_timeline);
         }
-        queue_cv.notify_one();
-        return {.outcome = acquire.outcome};
+    } catch (const std::exception& error) {
+        queue.DiscardPendingSubmitState();
+        vk_device.RecordRejectedPresent();
+        final_outcome = {
+            EVulkanOperationStatus::Rejected, VK_ERROR_UNKNOWN
+        };
+        try {
+            LOG_ERROR(
+                "[RHIExecutor][Vulkan] Present threw before retirement: {}",
+                error.what()
+            );
+        } catch (...) {
+        }
+    } catch (...) {
+        queue.DiscardPendingSubmitState();
+        vk_device.RecordRejectedPresent();
+        final_outcome = {
+            EVulkanOperationStatus::Rejected, VK_ERROR_UNKNOWN
+        };
+        try {
+            LOG_ERROR("[RHIExecutor][Vulkan] Present threw before retirement");
+        } catch (...) {
+        }
     }
 
-    //copy
-    auto* vk_src_tex     = static_cast<VulkanTexture*>(_view.texture);
-    const uint idx       = acquire.image_index;
-    auto* swaphchain_tex = ResourceCast(sc->GetSwapchainImage(idx).texture);
-    {
-        VK_CHECK_RESULT(vk_cmd_list.Begin());
-        const std::string present_label = std::format("Present: {}", vk_src_tex->GetName());
-        vk_cmd_list.BeginLabel(present_label, {0.0f, 0.85f, 0.95f, 1.0f});
-        vk_tracker.SetPassType(EPassType::Graphics);
-        vk_tracker.RecordState(vk_src_tex, vk_tracker.ReadTexture(vk_src_tex, ETextureState::TRANSFER));
-        vk_tracker.RecordState(
-            swaphchain_tex, vk_tracker.WriteTexture(swaphchain_tex, ETextureState::TRANSFER)
-        );
-        vk_tracker.ResolveBarriers();
-        vk_tracker.DispatchBarriers(vk_cmd_list);
-        //copy
-        //todo: need transaction
-        vk_cmd_list.InsertLabel("Copy Present Image", GpuMarkerPalette::Transfer());
-        vk_cmd_list.CopyTexture(vk_src_tex, swaphchain_tex, _view.extent, {0, 0, 0}, {0, 0, 0}, 0, 0);
-        vk_tracker.RecordState(
-            swaphchain_tex, VK_ACCESS_2_NONE, VK_IMAGE_LAYOUT_PRESENT_SRC_KHR, VK_PIPELINE_STAGE_2_COPY_BIT
-        );
-        vk_tracker.ResolveBarriers();
-        vk_tracker.DispatchBarriers(vk_cmd_list);
-
-        vk_tracker.RestoreState();
-        vk_tracker.DispatchBarriers(vk_cmd_list);
-        vk_cmd_list.EndLabel();
-        VK_CHECK_RESULT(vk_cmd_list.End());
-        vk_tracker.Reset();
-        // vk_tracker.PropagateState();
-    }
-
-    Array<RHIResource*> deferred_releases = TakeDeferredReleases();
-    callbacks.emplace_back(
-        [swapchain = std::move(_sc), source_texture = std::move(_source_texture)]() mutable {}
+    CommitPresentCompletion(
+        final_outcome,
+        context,
+        gpu_submitted,
+        presentor_state,
+        std::move(presentor),
+        std::move(_sc),
+        std::move(_source_texture),
+        std::move(deferred_releases),
+        _timeline
     );
 
-    queue.Signal(timeline, _timeline, VK_PIPELINE_STAGE_2_COPY_BIT);
-    queue.Wait(acquire.ready_semaphore, VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT);
-    queue.Signal(sc->GetRenderFinishedFence(idx), VK_PIPELINE_STAGE_2_COPY_BIT);
-    VulkanOperationResult submit_outcome = queue.Submit(vk_allocator.GetCmdList(), context);
-    if (submit_outcome.WasSubmitted()) {
-        timeline->MarkSubmitted(_timeline);
-    } else {
-        timeline->Fail(submit_outcome.result);
-    }
-    VulkanOperationResult final_outcome = submit_outcome;
-    bool                  present_accepted = false;
-    if (submit_outcome.WasSubmitted()) {
-        const VulkanOperationResult present_outcome =
-            sc->Present(queue.GetHandle(), idx, _timeline, _serial);
-        present_accepted =
-            present_outcome.result == VK_SUCCESS || present_outcome.result == VK_SUBOPTIMAL_KHR;
-        recreate_swapchain =
-            recreate_swapchain ||
-            present_outcome.status == EVulkanOperationStatus::Recreate;
-        if (!present_outcome.Succeeded()) {
-            final_outcome = present_outcome;
-        }
-    }
-    if (_receipt) {
-        _receipt->Resolve(present_accepted, recreate_swapchain);
-    }
-    {
-        std::unique_lock<std::mutex> lock(event_mutex);
-        event_queue.emplace_back(
-            VulkanSubmissionEvent{final_outcome, context, submit_outcome.WasSubmitted()},
-            _timeline,
-            false
-        );
-        event_queue.emplace_back(std::move(presentor), _timeline, false);
-        event_queue.emplace_back(
-            VulkanCallbackBatch{std::move(callbacks), false}, _timeline, false
-        );
-        if (!deferred_releases.empty()) {
-            event_queue.emplace_back(
-                VulkanDeferredReleaseBatch{std::move(deferred_releases)}, _timeline, false
-            );
-        }
-        EnqueueCompletionMarker(_timeline);
-    }
-    if (submit_outcome.WasSubmitted()) {
-        presented_queue.Enqueue(_timeline);
-    }
-    queue_cv.notify_one();
+    ResolvePresentReceiptNoexcept(
+        _receipt, present_accepted, recreate_swapchain
+    );
+
     VulkanRuntimeSubmissionResult runtime_result{.outcome = final_outcome};
-    if (submit_outcome.WasSubmitted()) {
+    if (gpu_submitted) {
         runtime_result.completion = WaitEvent{uint64(timeline), _timeline};
     }
     return runtime_result;
 }
 
+void VkCommandQueue::CommitPresentCompletion(
+    const VulkanOperationResult&    _outcome,
+    const VulkanOperationContext&   _context,
+    bool                            _gpu_submitted,
+    EVulkanPresentorRetirementState _presentor_state,
+    UniquePtr<VulkanPresentor>&&    _presentor,
+    SwapchainRef&&                  _swapchain,
+    TextureRef&&                    _source_texture,
+    Array<RHIResource*>&&           _deferred_releases,
+    uint64                          _timeline
+) noexcept {
+    try {
+        std::unique_lock<std::mutex> lock(event_mutex);
+        const uint64 retirement_serial = retirement_enqueued_serial + 1;
+        event_queue.emplace_back(
+            std::in_place_type<VulkanPresentCompletionBatch>,
+            _timeline,
+            true,
+            retirement_serial,
+            _outcome,
+            _context,
+            _gpu_submitted,
+            true,
+            _presentor_state,
+            std::move(_presentor),
+            std::move(_swapchain),
+            std::move(_source_texture),
+            std::move(_deferred_releases)
+        );
+        retirement_enqueued_serial = retirement_serial;
+    } catch (...) {
+        // A submitted presentor must never unwind on the Submission owner.
+        std::terminate();
+    }
+    queue_cv.notify_one();
+}
+
 void VkCommandQueue::Sync() {
+    if (GetCurrentRHIThreadRole() == ERHIThreadRole::Completion) {
+        try {
+            LOG_ERROR(
+                "[RHIExecutor][Vulkan] queue={} Completion owner cannot block "
+                "on a retirement queue",
+                static_cast<uint32>(queue.GetType())
+            );
+        } catch (...) {
+        }
+        return;
+    }
     assert(
         !rhi_thread_enabled ||
         rhi_thread_id.load(std::memory_order_acquire) != Platform::GetCurrentThreadID()
@@ -5570,7 +5976,7 @@ void VkCommandQueue::Sync() {
         target_timeline = last_frame.load(std::memory_order_relaxed);
     }
 
-    Complete(target_timeline);
+    CompleteAll(target_timeline);
 
     if (vk_device.IsFaulted()) {
         return;
@@ -5602,21 +6008,21 @@ ProfileData VkCommandQueue::GetProfilerEntry() {
 }
 
 UniquePtr<VulkanAllocator> VkCommandQueue::GetAllocator() {
-    if (executed_queue.Full()) {
-        Complete(executed_queue.Front());
-    }
+    // Completion publishes only successfully completed and reset allocators
+    // into this pool. Pool membership is therefore the reuse gate; if
+    // Completion is delayed by unrelated CPU callbacks, allocate overflow
+    // storage instead of stalling the Translate owner.
     auto allocator = std::move(UniquePtr<VulkanAllocator>(allocators.Pop()));
     if (allocator) {
-        // allocator->ResetCmdList();
         return std::move(allocator);
     }
     return MakeUnique<VulkanAllocator>(&vk_device, queue.GetType());
 }
 
 UniquePtr<VulkanPresentor> VkCommandQueue::GetPresentor() {
-    if (presented_queue.Full()) {
-        Complete(presented_queue.Front());
-    }
+    // Presentors follow the same completion-owned pool contract as command
+    // allocators. A temporary pool miss is capacity pressure, not a reason for
+    // Submission to wait on arbitrary completion callbacks.
     auto presentor = std::move(UniquePtr<VulkanPresentor>(presentors.Pop()));
     if (presentor) {
         return std::move(presentor);
@@ -5644,7 +6050,11 @@ Array<RHIResource*> VkCommandQueue::TakeDeferredReleases() {
 }
 
 void VkCommandQueue::EnqueueCompletionMarker(uint64 _timeline) {
-    event_queue.emplace_back(VulkanCompletionMarker{}, _timeline, true);
+    const uint64 retirement_serial = retirement_enqueued_serial + 1;
+    event_queue.emplace_back(
+        VulkanCompletionMarker{}, _timeline, true, retirement_serial
+    );
+    retirement_enqueued_serial = retirement_serial;
 }
 
 void VkCommandQueue::EnsureRecordCalibration() {
@@ -6158,6 +6568,7 @@ void VkCommandQueue::RhiThreadMain() {
     Platform::SetCurrentThreadName(
         queue.GetType() == EQueueType::Graphics ? "Moer RHI Thread" : "Moer Compute RHI"
     );
+    RHIThreadRoleScope owner_scope(ERHIThreadRole::Submission);
     rhi_thread_id.store(Platform::GetCurrentThreadID(), std::memory_order_release);
     LOG_INFO(
         "[Threading] RHIThread id = {}, queue = {}",
@@ -6243,6 +6654,7 @@ void VkCommandQueue::CompletionThreadMain() {
     Platform::SetCurrentThreadName(
         queue.GetType() == EQueueType::Graphics ? "Vulkan Gfx Completion" : "Vulkan Compute Completion"
     );
+    RHIThreadRoleScope owner_scope(ERHIThreadRole::Completion);
 
     bool batch_gpu_success = false;
     bool batch_release_safe = false;
@@ -6291,10 +6703,229 @@ void VkCommandQueue::CompletionThreadMain() {
                         timeline->Fail(wait_result);
                     }
                 },
+                [this, event_timeline, &batch_gpu_success, &batch_release_safe](
+                    VulkanSubmitCompletionBatch& _batch
+                ) {
+                    batch_gpu_success = false;
+                    batch_release_safe =
+                        !_batch.gpu_submitted &&
+                        (_batch.outcome.status == EVulkanOperationStatus::Retry ||
+                         _batch.outcome.status == EVulkanOperationStatus::Recreate);
+
+                    VkResult completion_result = _batch.outcome.result;
+                    if (completion_result == VK_SUCCESS && !_batch.gpu_submitted) {
+                        completion_result = VK_ERROR_UNKNOWN;
+                    }
+
+                    if (_batch.gpu_submitted) {
+                        VulkanOperationContext wait_context = _batch.context;
+                        wait_context.operation = EVulkanFaultOperation::TimelineHostWait;
+                        const VkResult wait_result =
+                            timeline->HostWait(event_timeline, wait_context);
+                        if (wait_result == VK_SUCCESS && !vk_device.IsDeviceLost()) {
+                            timeline->Notify(event_timeline);
+                            batch_gpu_success = true;
+                            batch_release_safe = true;
+                            completion_result = VK_SUCCESS;
+                        } else {
+                            completion_result =
+                                wait_result != VK_SUCCESS ?
+                                    wait_result :
+                                vk_device.IsFaulted() ?
+                                    vk_device.GetFirstFaultResult() :
+                                    VK_ERROR_DEVICE_LOST;
+                            if (_batch.owns_queue_timeline) {
+                                timeline->Fail(completion_result);
+                            }
+                        }
+                    } else if (_batch.owns_queue_timeline) {
+                        timeline->Fail(completion_result);
+                    }
+
+                    bool recycle_batch =
+                        batch_gpu_success && !vk_device.IsFaulted();
+                    if (recycle_batch) {
+                        for (auto& allocator : _batch.allocators.submitted) {
+                            recycle_batch =
+                                allocator->CompleteSuccess() && recycle_batch;
+                        }
+                    }
+                    if (recycle_batch) {
+                        for (auto& allocator : _batch.allocators.submitted) {
+                            recycle_batch = allocator->Reset() && recycle_batch;
+                        }
+                    }
+                    if (recycle_batch && !vk_device.IsFaulted()) {
+                        for (auto& allocator : _batch.allocators.submitted) {
+                            allocators.Push(allocator.release());
+                        }
+                    } else {
+                        for (auto& allocator : _batch.allocators.submitted) {
+                            if (!allocator) {
+                                continue;
+                            }
+                            vk_device.RecordAllocatorQuarantine();
+                            vk_device.RecordSkippedCommandPoolReset();
+                            allocator_quarantine.emplace_back(std::move(allocator));
+                        }
+                    }
+                    for (auto& allocator : _batch.allocators.abandoned) {
+                        if (!vk_device.IsFaulted() && allocator->ResetAbandoned()) {
+                            allocators.Push(allocator.release());
+                        } else if (allocator) {
+                            vk_device.RecordAllocatorQuarantine();
+                            vk_device.RecordSkippedCommandPoolReset();
+                            allocator_quarantine.emplace_back(std::move(allocator));
+                        }
+                    }
+
+                    if (_batch.descriptor_lease.has_value()) {
+                        vk_device.GetGlobalDescriptorHeap().RecyclePushDescriptors(
+                            std::move(*_batch.descriptor_lease)
+                        );
+                        _batch.descriptor_lease.reset();
+                    }
+
+                    for (const SignalEvent& event : _batch.submit.signal_events) {
+                        auto* fence =
+                            reinterpret_cast<VulkanFence*>(event.timeline_handle);
+                        if (fence == nullptr) {
+                            continue;
+                        }
+                        if (batch_gpu_success) {
+                            fence->Notify(event.value);
+                        } else {
+                            fence->Fail(completion_result);
+                        }
+                    }
+
+                    if (!_batch.gpu_submitted) {
+                        FinalizeRejectedBindlessUpdates(_batch.submit);
+                    }
+                    Array<std::function<void()>> callbacks =
+                        std::move(_batch.submit.callbacks);
+                    Array<std::function<void()>> success_callbacks =
+                        std::move(_batch.submit.success_callbacks);
+                    _batch.submit.cmds.clear();
+                    _batch.submit.cached_args.clear();
+                    _batch.submit.segments.clear();
+                    _batch.submit.wait_events.clear();
+                    _batch.submit.signal_events.clear();
+                    _batch.submit.debug_label.clear();
+
+                    InvokeCallbacksNoexcept(
+                        callbacks, "[VulkanQueue] runtime completion"
+                    );
+                    if (batch_gpu_success) {
+                        InvokeCallbacksNoexcept(
+                            success_callbacks,
+                            "[VulkanQueue] runtime success completion"
+                        );
+                    }
+
+                    if (batch_gpu_success || batch_release_safe) {
+                        for (auto* resource : _batch.deferred_releases) {
+                            MoerDelete(resource);
+                        }
+                    } else {
+                        for (auto* resource : _batch.deferred_releases) {
+                            vk_device.EnqueueDeferredRelease(resource);
+                        }
+                    }
+                    _batch.deferred_releases.clear();
+                },
+                [this, event_timeline, &batch_gpu_success, &batch_release_safe](
+                    VulkanPresentCompletionBatch& _batch
+                ) {
+                    batch_gpu_success = false;
+                    batch_release_safe =
+                        !_batch.gpu_submitted &&
+                        _batch.presentor_state ==
+                            EVulkanPresentorRetirementState::Unused &&
+                        (_batch.outcome.status == EVulkanOperationStatus::Retry ||
+                         _batch.outcome.status ==
+                             EVulkanOperationStatus::Recreate);
+
+                    VkResult completion_result = _batch.outcome.result;
+                    if (_batch.gpu_submitted) {
+                        VulkanOperationContext wait_context = _batch.context;
+                        wait_context.operation =
+                            EVulkanFaultOperation::TimelineHostWait;
+                        const VkResult wait_result =
+                            timeline->HostWait(event_timeline, wait_context);
+                        if (wait_result == VK_SUCCESS &&
+                            !vk_device.IsDeviceLost()) {
+                            timeline->Notify(event_timeline);
+                            batch_gpu_success = true;
+                            batch_release_safe = true;
+                            completion_result = VK_SUCCESS;
+                        } else {
+                            completion_result =
+                                wait_result != VK_SUCCESS ?
+                                    wait_result :
+                                vk_device.IsFaulted() ?
+                                    vk_device.GetFirstFaultResult() :
+                                    VK_ERROR_DEVICE_LOST;
+                            if (_batch.owns_queue_timeline) {
+                                timeline->Fail(completion_result);
+                            }
+                        }
+                    } else if (
+                        _batch.owns_queue_timeline &&
+                        (_batch.outcome.status ==
+                             EVulkanOperationStatus::Faulted ||
+                         _batch.outcome.status ==
+                             EVulkanOperationStatus::Rejected)
+                    ) {
+                        if (completion_result == VK_SUCCESS) {
+                            completion_result = VK_ERROR_UNKNOWN;
+                        }
+                        timeline->Fail(completion_result);
+                    }
+
+                    if (_batch.presentor) {
+                        bool recycle_presentor = false;
+                        if (_batch.presentor_state ==
+                                EVulkanPresentorRetirementState::Submitted &&
+                            batch_gpu_success && !vk_device.IsFaulted()) {
+                            recycle_presentor =
+                                _batch.presentor->CompleteSuccess() &&
+                                _batch.presentor->Reset();
+                        } else if (
+                            _batch.presentor_state ==
+                                EVulkanPresentorRetirementState::Unused &&
+                            batch_release_safe && !vk_device.IsFaulted()
+                        ) {
+                            // No command buffer was begun, matching the
+                            // previous acquire-retry fast recycle path.
+                            recycle_presentor = true;
+                        }
+
+                        if (recycle_presentor && !vk_device.IsFaulted()) {
+                            presentors.Push(_batch.presentor.release());
+                        } else {
+                            vk_device.RecordAllocatorQuarantine();
+                            vk_device.RecordSkippedCommandPoolReset();
+                            presentor_quarantine.emplace_back(
+                                std::move(_batch.presentor)
+                            );
+                        }
+                    }
+
+                    if (batch_gpu_success || batch_release_safe) {
+                        for (auto* resource : _batch.deferred_releases) {
+                            MoerDelete(resource);
+                        }
+                    } else {
+                        for (auto* resource : _batch.deferred_releases) {
+                            vk_device.EnqueueDeferredRelease(resource);
+                        }
+                    }
+                    _batch.deferred_releases.clear();
+                },
                 [this, &batch_gpu_success](UniquePtr<VulkanAllocator>& _allocator) {
                     if (batch_gpu_success && !vk_device.IsFaulted()) {
-                        _allocator->CompleteSuccess();
-                        if (_allocator->Reset()) {
+                        if (_allocator->CompleteSuccess() && _allocator->Reset()) {
                             allocators.Push(_allocator.release());
                             return;
                         }
@@ -6307,8 +6938,11 @@ void VkCommandQueue::CompletionThreadMain() {
                     bool recycle_batch = batch_gpu_success && !vk_device.IsFaulted();
                     if (recycle_batch) {
                         for (auto& allocator : _batch.submitted) {
-                            allocator->CompleteSuccess();
+                            recycle_batch =
+                                allocator->CompleteSuccess() && recycle_batch;
                         }
+                    }
+                    if (recycle_batch) {
                         for (auto& allocator : _batch.submitted) {
                             recycle_batch = allocator->Reset() && recycle_batch;
                         }
@@ -6343,8 +6977,7 @@ void VkCommandQueue::CompletionThreadMain() {
                 },
                 [this, &batch_gpu_success](UniquePtr<VulkanPresentor>& _presentor) {
                     if (batch_gpu_success && !vk_device.IsFaulted()) {
-                        _presentor->CompleteSuccess();
-                        if (_presentor->Reset()) {
+                        if (_presentor->CompleteSuccess() && _presentor->Reset()) {
                             presentors.Push(_presentor.release());
                             return;
                         }
@@ -6394,19 +7027,28 @@ void VkCommandQueue::CompletionThreadMain() {
                    !cpu_settled_frame.compare_exchange_weak(
                        completed, event_timeline, std::memory_order_release, std::memory_order_relaxed
                    )) {}
+            const uint64 retirement_serial = evt->retirement_serial;
+            uint64 settled_serial =
+                retirement_settled_serial.load(std::memory_order_relaxed);
+            while (settled_serial < retirement_serial &&
+                   !retirement_settled_serial.compare_exchange_weak(
+                       settled_serial,
+                       retirement_serial,
+                       std::memory_order_release,
+                       std::memory_order_relaxed
+                   )) {}
             queue_cv.notify_all();
         }
     }
 }
 
-void VkCommandQueue::Complete(uint64 _timeline) {
-    if (_timeline == 0) {
-        return;
-    }
-
+void VkCommandQueue::CompleteAll(uint64 _timeline) {
     std::unique_lock<std::mutex> lock(event_mutex);
-    queue_cv.wait(lock, [this, _timeline]() {
-        return cpu_settled_frame.load(std::memory_order_acquire) >= _timeline;
+    const uint64 target_retirement_serial = retirement_enqueued_serial;
+    queue_cv.wait(lock, [this, _timeline, target_retirement_serial]() {
+        return cpu_settled_frame.load(std::memory_order_acquire) >= _timeline &&
+               retirement_settled_serial.load(std::memory_order_acquire) >=
+                   target_retirement_serial;
     });
 }
 
@@ -6420,16 +7062,50 @@ VkCopyQueue::VkCopyQueue(VulkanDevice& _device) :
     queue(EQueueType::Copy, _device) {
     timeline = MoerNew(VulkanFence)(_device);
     enabled  = true;
-    thread   = std::jthread([this]() {
-        ExecuteThread();
-    });
+    try {
+        thread = std::jthread([this]() {
+            ExecuteThread();
+        });
+        submission_thread = std::jthread([this]() {
+            SubmissionThreadMain();
+        });
+    } catch (...) {
+        {
+            std::lock_guard lock(submission_mutex);
+            submission_accepting.store(false, std::memory_order_release);
+        }
+        submission_cv.notify_all();
+        if (submission_thread.joinable()) {
+            submission_thread.join();
+        }
+
+        enabled.store(false, std::memory_order_release);
+        queue_cv.notify_all();
+        if (thread.joinable()) {
+            thread.join();
+        }
+        timeline = nullptr;
+        throw;
+    }
 }
 
 VkCopyQueue::~VkCopyQueue() {
-    Complete(last_frame);
-    enabled = false;
+    CancelRuntimeDependencyWaits();
+    {
+        std::lock_guard lock(submission_mutex);
+        submission_accepting.store(false, std::memory_order_release);
+    }
+    submission_cv.notify_all();
+    if (submission_thread.joinable()) {
+        submission_thread.join();
+    }
+
+    CompleteAll(last_frame);
+    enabled.store(false, std::memory_order_release);
     queue_cv.notify_all();
-    thread.join();
+    if (thread.joinable()) {
+        thread.join();
+    }
     //clear allocators
     Array<VulkanAllocator*> allocs;
     allocators.PopAll(allocs);
@@ -6439,6 +7115,14 @@ VkCopyQueue::~VkCopyQueue() {
     allocator_quarantine.clear();
     timeline = nullptr;
     device.RecordQueueSyncComplete();
+}
+
+void VkCopyQueue::EnableRuntimeDependencyWaits() noexcept {
+    dependency_waits_enabled.store(true, std::memory_order_release);
+}
+
+void VkCopyQueue::CancelRuntimeDependencyWaits() noexcept {
+    dependency_waits_enabled.store(false, std::memory_order_release);
 }
 static constexpr uint64 fread_segment_size = 1024 * 64; // 64KB
 IOWaitEvt               VkCopyQueue::Execute(IOQueueSubmission&& _submission) {
@@ -6501,35 +7185,263 @@ IOWaitEvt               VkCopyQueue::Execute(IOQueueSubmission&& _submission) {
 
 //TODO:看看barrier
 IOWaitEvt VkCopyQueue::Execute(CmdSubmit&& _evt) {
-    TrackedExecuteResult result = ExecuteTracked(std::move(_evt));
+    TrackedExecuteResult result = ExecuteOnSubmissionOwner(std::move(_evt));
+    if (!result.runtime.outcome.WasSubmitted()) {
+        return {0, 0};
+    }
     return {uint64(timeline.Get()), result.logical_timeline};
 }
 
-VulkanRuntimeSubmissionResult VkCopyQueue::ExecuteForRuntime(CmdSubmit&& _evt) {
-    return ExecuteTracked(std::move(_evt)).runtime;
+VulkanRuntimeSubmissionResult VkCopyQueue::ExecuteForRuntime(CmdSubmit&& _evt) noexcept {
+    assert(
+        GetCurrentRHIThreadRole() == ERHIThreadRole::Submission &&
+        "runtime Copy submission must originate from a Submission owner"
+    );
+    return ExecuteOnSubmissionOwner(std::move(_evt)).runtime;
 }
 
-VkCopyQueue::TrackedExecuteResult VkCopyQueue::ExecuteTracked(CmdSubmit&& _evt) {
-    auto current_timeline = last_frame;
-    if (device.IsFaulted()) {
-        TerminalizeRejectedSubmit(
-            device,
-            std::move(_evt),
-            device.GetFirstFaultResult(),
-            "[VulkanCopyQueue] rejected submit"
-        );
-        return {
-            .runtime = {
-                .outcome = {
-                    EVulkanOperationStatus::Rejected, device.GetFirstFaultResult()
-                }
+VkCopyQueue::TrackedExecuteResult VkCopyQueue::ExecuteOnSubmissionOwner(
+    CmdSubmit&& _submit
+) noexcept {
+    const auto rejected_result = [this](VkResult _result) {
+        if (_result == VK_SUCCESS) {
+            _result = VK_ERROR_UNKNOWN;
+        }
+        return TrackedExecuteResult{
+            .runtime = VulkanRuntimeSubmissionResult{
+                .outcome = VulkanOperationResult{
+                    EVulkanOperationStatus::Rejected, _result
+                },
             },
-            .logical_timeline = current_timeline,
+            .logical_timeline = 0,
+        };
+    };
+
+    if (submission_thread_id.load(std::memory_order_acquire) ==
+        Platform::GetCurrentThreadID()) {
+        try {
+            LOG_ERROR(
+                "[RHIExecutor][Vulkan] Recursive Copy submission on its owner "
+                "thread was rejected"
+            );
+        } catch (...) {
+        }
+        const VkResult result = GetRejectedSubmitResult(device);
+        RejectForRuntime(std::move(_submit), result);
+        return rejected_result(result);
+    }
+
+    UniquePtr<CopySubmissionRequest> request{};
+    std::future<TrackedExecuteResult> completion{};
+    bool                              queued = false;
+    try {
+        request    = MakeUnique<CopySubmissionRequest>(std::move(_submit));
+        completion = request->completion.get_future();
+        {
+            std::lock_guard lock(submission_mutex);
+            if (submission_accepting.load(std::memory_order_acquire)) {
+                submission_requests.emplace_back(std::move(request));
+                queued = true;
+            }
+        }
+
+        if (!queued) {
+            const VkResult result = GetRejectedSubmitResult(device);
+            RejectForRuntime(std::move(request->submit), result);
+            return rejected_result(result);
+        }
+        submission_cv.notify_one();
+    } catch (...) {
+        const VkResult result = GetRejectedSubmitResult(device);
+        if (!queued) {
+            if (request) {
+                RejectForRuntime(std::move(request->submit), result);
+            } else {
+                RejectForRuntime(std::move(_submit), result);
+            }
+        }
+        try {
+            LOG_ERROR(
+                "[RHIExecutor][Vulkan] Failed to enqueue Copy submission owner work"
+            );
+        } catch (...) {
+        }
+        return rejected_result(result);
+    }
+
+    try {
+        return completion.get();
+    } catch (...) {
+        try {
+            LOG_ERROR(
+                "[RHIExecutor][Vulkan] Copy submission owner failed to publish "
+                "its request result"
+            );
+        } catch (...) {
+        }
+        return rejected_result(GetRejectedSubmitResult(device));
+    }
+}
+
+void VkCopyQueue::SubmissionThreadMain() {
+    Platform::SetCurrentThreadName("Moer Vulkan Copy Submission");
+    RHIThreadRoleScope owner_scope(ERHIThreadRole::Submission);
+    submission_thread_id.store(
+        Platform::GetCurrentThreadID(), std::memory_order_release
+    );
+
+    for (;;) {
+        UniquePtr<CopySubmissionRequest> request{};
+        {
+            std::unique_lock lock(submission_mutex);
+            submission_cv.wait(lock, [this]() {
+                return !submission_accepting.load(std::memory_order_acquire) ||
+                       !submission_requests.empty();
+            });
+            if (submission_requests.empty()) {
+                assert(
+                    !submission_accepting.load(std::memory_order_acquire) &&
+                    "Copy submission owner woke without work"
+                );
+                break;
+            }
+            request = std::move(submission_requests.front());
+            submission_requests.pop_front();
+        }
+
+        TrackedExecuteResult result =
+            ExecuteTracked(std::move(request->submit));
+        try {
+            request->completion.set_value(std::move(result));
+        } catch (...) {
+            try {
+                LOG_ERROR(
+                    "[RHIExecutor][Vulkan] Copy submission owner could not resolve "
+                    "an accepted request"
+                );
+            } catch (...) {
+            }
+        }
+    }
+
+    submission_thread_id.store(0, std::memory_order_release);
+}
+
+VkCopyQueue::TrackedExecuteResult VkCopyQueue::ExecuteTracked(CmdSubmit&& _evt) noexcept {
+    RuntimeExecuteState state{};
+    std::unique_lock<std::mutex> execution_lock(exec_mutex);
+    try {
+        return ExecuteTrackedImpl(_evt, state);
+    } catch (const std::exception& error) {
+        try {
+            LOG_ERROR(
+                "[RHIExecutor][Vulkan] Copy execution threw before retirement: {}",
+                error.what()
+            );
+        } catch (...) {
+        }
+    } catch (...) {
+        try {
+            LOG_ERROR("[RHIExecutor][Vulkan] Copy execution threw before retirement");
+        } catch (...) {
+        }
+    }
+
+    if (state.completion_committed) {
+        VulkanRuntimeSubmissionResult runtime_result{
+            .outcome               = state.outcome,
+            .recoverable_rejection = state.recoverable_rejection,
+        };
+        if (state.outcome.WasSubmitted()) {
+            runtime_result.completion =
+                WaitEvent{uint64(timeline.Get()), state.logical_timeline};
+        }
+        return {
+            .runtime          = std::move(runtime_result),
+            .logical_timeline = state.logical_timeline,
         };
     }
-    Array<UniquePtr<Command>> cmds = std::move(_evt.cmds);
+
+    queue.DiscardPendingSubmitState();
+    if (!state.native_submit_resolved) {
+        state.outcome = {
+            EVulkanOperationStatus::Rejected, VK_ERROR_UNKNOWN
+        };
+        state.native_submit_resolved = true;
+        device.RecordRejectedSubmit();
+    }
+
+    // A recorded allocator which did not reach a native submit must be reset
+    // by Completion as abandoned.  If native submission was accepted it must
+    // remain in the submitted set until the GPU timeline completes.
+    if (!state.outcome.WasSubmitted()) {
+        for (auto& allocator : state.allocators.submitted) {
+            state.allocators.abandoned.emplace_back(std::move(allocator));
+        }
+        state.allocators.submitted.clear();
+    }
+
+    CommitRuntimeSubmitCompletion(
+        std::move(_evt),
+        std::move(state.allocators),
+        state.outcome,
+        state.context,
+        state.logical_timeline,
+        state.timeline_reserved && state.outcome.WasSubmitted()
+    );
+    state.completion_committed = true;
+
+    VulkanRuntimeSubmissionResult runtime_result{
+        .outcome               = state.outcome,
+        .recoverable_rejection = state.recoverable_rejection,
+    };
+    if (state.outcome.WasSubmitted()) {
+        runtime_result.completion =
+            WaitEvent{uint64(timeline.Get()), state.logical_timeline};
+    }
+    return {
+        .runtime          = std::move(runtime_result),
+        .logical_timeline = state.logical_timeline,
+    };
+}
+
+VkCopyQueue::TrackedExecuteResult VkCopyQueue::ExecuteTrackedImpl(
+    CmdSubmit& _evt,
+    RuntimeExecuteState& _state
+) {
+    _state.logical_timeline = last_frame;
+    _state.context = VulkanOperationContext{
+        .operation  = EVulkanFaultOperation::QueueSubmit,
+        .queue_type = EQueueType::Copy,
+        .queue      = queue.GetHandle(),
+    };
+
+    if (device.IsFaulted()) {
+        const VkResult rejected_result = device.GetFirstFaultResult();
+        device.RecordRejectedSubmit();
+        _state.outcome = {
+            EVulkanOperationStatus::Rejected, rejected_result
+        };
+        _state.native_submit_resolved = true;
+        CommitRuntimeSubmitCompletion(
+            std::move(_evt),
+            std::move(_state.allocators),
+            _state.outcome,
+            _state.context,
+            0,
+            false
+        );
+        _state.completion_committed = true;
+        return {
+            .runtime = {
+                .outcome = _state.outcome
+            },
+            .logical_timeline = _state.logical_timeline,
+        };
+    }
+
     const bool has_queue_work =
-        !cmds.empty() || !_evt.wait_events.empty() || !_evt.signal_events.empty() ||
+        !_evt.cmds.empty() || !_evt.wait_events.empty() || !_evt.signal_events.empty() ||
         !_evt.callbacks.empty() || !_evt.success_callbacks.empty();
     if (has_queue_work) {
 
@@ -6541,9 +7453,9 @@ VkCopyQueue::TrackedExecuteResult VkCopyQueue::ExecuteTracked(CmdSubmit&& _evt) 
         };
         CmdReorderer reorderer{function_table, _evt.cached_args};
 
-        std::unique_lock<std::mutex> lk(exec_mutex);
-        auto                         allocator    = GetAllocator();
-        auto&                        vk_allocator = *allocator;
+        _state.allocators.submitted.reserve(1);
+        _state.allocators.submitted.emplace_back(GetAllocator());
+        auto& vk_allocator = *_state.allocators.submitted.front();
         auto&                        vk_cmd_list  = vk_allocator.GetCmdList();
         auto&                        vk_tracker   = vk_allocator.GetTracker();
 
@@ -6552,7 +7464,7 @@ VkCopyQueue::TrackedExecuteResult VkCopyQueue::ExecuteTracked(CmdSubmit&& _evt) 
         );
         VkCmdVisitor visitor(device, vk_allocator, vk_tracker, vk_cmd_list, _evt.cached_args);
 
-        for (const auto& cmd : cmds) {
+        for (const auto& cmd : _evt.cmds) {
             // preprocessor.VisitCmd(cmd.get());
             reorderer.AcceptCmd(cmd.get());
         }
@@ -6587,27 +7499,32 @@ VkCopyQueue::TrackedExecuteResult VkCopyQueue::ExecuteTracked(CmdSubmit&& _evt) 
         vk_cmd_list.EndLabel();
         VK_CHECK_RESULT(vk_cmd_list.End());
         vk_tracker.Reset();
-        //event queue
 
-        auto current_timeline = ++last_frame;
-        const VulkanOperationContext context{
+        _state.logical_timeline = ++last_frame;
+        _state.timeline_reserved = true;
+        _state.context = VulkanOperationContext{
             .operation   = EVulkanFaultOperation::QueueSubmit,
             .queue_type  = EQueueType::Copy,
             .queue       = queue.GetHandle(),
-            .timeline    = current_timeline,
-            .work_serial = current_timeline,
+            .timeline    = _state.logical_timeline,
+            .work_serial = _state.logical_timeline,
         };
-        VulkanOperationResult submit_outcome{};
-        if (!WaitForSubmittedDependencies(device, _evt.wait_events)) {
+        if (!WaitForSubmittedDependencies(
+                device, _evt.wait_events, &dependency_waits_enabled
+            )) {
             device.RecordRejectedSubmit();
             const VkResult rejected_result = GetRejectedSubmitResult(device);
-            submit_outcome = {EVulkanOperationStatus::Rejected, rejected_result};
-            FailSubmissionSignals(timeline.Get(), _evt.signal_events, rejected_result);
+            _state.outcome = {
+                EVulkanOperationStatus::Rejected, rejected_result
+            };
+            _state.recoverable_rejection = !device.IsFaulted();
+            _state.native_submit_resolved = true;
         } else {
-            queue.Signal(timeline, current_timeline, VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT);
-            if (current_timeline > 1) {
-                queue.Wait(timeline, current_timeline - 1, VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT);
-            }
+            queue.Signal(
+                timeline,
+                _state.logical_timeline,
+                VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT
+            );
             for (auto& evt : _evt.wait_events) {
                 queue.Wait(reinterpret_cast<VulkanFence*>(evt.timeline_handle), evt.value);
             }
@@ -6618,65 +7535,117 @@ VkCopyQueue::TrackedExecuteResult VkCopyQueue::ExecuteTracked(CmdSubmit&& _evt) 
                     VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT
                 );
             }
-            submit_outcome = queue.Submit(vk_allocator.GetCmdList(), context);
-            if (submit_outcome.WasSubmitted()) {
-                MarkSubmissionAccepted(timeline.Get(), current_timeline, _evt.signal_events);
-            } else {
-                FailSubmissionSignals(timeline.Get(), _evt.signal_events, submit_outcome.result);
+            _state.outcome =
+                queue.Submit(vk_allocator.GetCmdList(), _state.context);
+            _state.native_submit_resolved = true;
+            if (_state.outcome.WasSubmitted()) {
+                MarkSubmissionAccepted(
+                    timeline.Get(),
+                    _state.logical_timeline,
+                    _evt.signal_events
+                );
             }
         }
-        {
-            std::unique_lock<std::mutex> lock(event_mutex);
-            event_queue.emplace_back(
-                VulkanSubmissionEvent{submit_outcome, context, submit_outcome.WasSubmitted()},
-                current_timeline,
-                false
-            );
-            event_queue.emplace_back(std::move(allocator), current_timeline, false);
-            for (auto& evt : _evt.signal_events) {
-                event_queue.emplace_back(
-                    IOSignalEvt(evt.timeline_handle, evt.value), current_timeline, false
-                );
+
+        if (!_state.outcome.WasSubmitted()) {
+            for (auto& allocator : _state.allocators.submitted) {
+                _state.allocators.abandoned.emplace_back(std::move(allocator));
             }
-            if (!_evt.callbacks.empty()) {
-                event_queue.emplace_back(
-                    VulkanCallbackBatch{std::move(_evt.callbacks), false}, current_timeline, false
-                );
-            }
-            if (!_evt.success_callbacks.empty()) {
-                event_queue.emplace_back(
-                    VulkanCallbackBatch{std::move(_evt.success_callbacks), true}, current_timeline, false
-                );
-            }
-            event_queue.emplace_back(VulkanCompletionMarker{}, current_timeline, true);
-            queue_cv.notify_one();
+            _state.allocators.submitted.clear();
         }
-        VulkanRuntimeSubmissionResult runtime_result{.outcome = submit_outcome};
-        if (submit_outcome.WasSubmitted()) {
-            runtime_result.completion = WaitEvent{uint64(timeline.Get()), current_timeline};
+
+        CommitRuntimeSubmitCompletion(
+            std::move(_evt),
+            std::move(_state.allocators),
+            _state.outcome,
+            _state.context,
+            _state.logical_timeline,
+            _state.outcome.WasSubmitted()
+        );
+        _state.completion_committed = true;
+
+        VulkanRuntimeSubmissionResult runtime_result{
+            .outcome               = _state.outcome,
+            .recoverable_rejection = _state.recoverable_rejection,
+        };
+        if (_state.outcome.WasSubmitted()) {
+            runtime_result.completion =
+                WaitEvent{uint64(timeline.Get()), _state.logical_timeline};
         }
         return {
             .runtime          = std::move(runtime_result),
-            .logical_timeline = current_timeline,
+            .logical_timeline = _state.logical_timeline,
         };
     }
     return {
         .runtime          = {},
-        .logical_timeline = current_timeline,
+        .logical_timeline = _state.logical_timeline,
     };
 }
 
-void VkCopyQueue::RejectForRuntime(CmdSubmit&& _submit, VkResult _result) {
-    TerminalizeRejectedSubmit(
-        device,
+void VkCopyQueue::RejectForRuntime(CmdSubmit&& _submit, VkResult _result) noexcept {
+    if (_result == VK_SUCCESS) {
+        _result = VK_ERROR_UNKNOWN;
+    }
+    device.RecordRejectedSubmit();
+    CommitRuntimeSubmitCompletion(
         std::move(_submit),
-        _result,
-        "[RHIExecutor][Vulkan] rejected Copy submit"
+        VulkanAllocatorBatch{},
+        VulkanOperationResult{EVulkanOperationStatus::Rejected, _result},
+        VulkanOperationContext{
+            .operation  = EVulkanFaultOperation::QueueSubmit,
+            .queue_type = EQueueType::Copy,
+            .queue      = queue.GetHandle(),
+        },
+        0,
+        false
     );
 }
 
+void VkCopyQueue::CommitRuntimeSubmitCompletion(
+    CmdSubmit&&                  _submit,
+    VulkanAllocatorBatch&&       _allocators,
+    const VulkanOperationResult& _outcome,
+    const VulkanOperationContext& _context,
+    uint64                        _logical_timeline,
+    bool                          _owns_queue_timeline
+) noexcept {
+    try {
+        std::unique_lock<std::mutex> lock(event_mutex);
+        const uint64 retirement_serial = retirement_enqueued_serial + 1;
+        event_queue.emplace_back(
+            std::in_place_type<VulkanSubmitCompletionBatch>,
+            _logical_timeline,
+            true,
+            retirement_serial,
+            _outcome,
+            _context,
+            _outcome.WasSubmitted(),
+            _owns_queue_timeline,
+            std::move(_submit),
+            std::move(_allocators),
+            std::optional<VulkanDescriptorPushLease>{},
+            Array<RHIResource*>{}
+        );
+        retirement_enqueued_serial = retirement_serial;
+    } catch (...) {
+        std::terminate();
+    }
+    queue_cv.notify_one();
+}
+
 void VkCopyQueue::Sync(uint64 _timeline) {
-    Complete(_timeline);
+    if (GetCurrentRHIThreadRole() == ERHIThreadRole::Completion) {
+        try {
+            LOG_ERROR(
+                "[RHIExecutor][Vulkan] Copy Completion owner cannot block on "
+                "a retirement queue"
+            );
+        } catch (...) {
+        }
+        return;
+    }
+    CompleteAll(_timeline);
 }
 
 FenceRef VkCopyQueue::GetFenceHandle() {
@@ -6684,6 +7653,8 @@ FenceRef VkCopyQueue::GetFenceHandle() {
 }
 
 void VkCopyQueue::ExecuteThread() {
+    Platform::SetCurrentThreadName("Vulkan Copy Completion");
+    RHIThreadRoleScope owner_scope(ERHIThreadRole::Completion);
     bool batch_gpu_success = false;
     while (true) {
         std::optional<IOEvent> evt;
@@ -6721,10 +7692,132 @@ void VkCopyQueue::ExecuteThread() {
                         timeline->Fail(result);
                     }
                 },
+                [this, event_timeline, &batch_gpu_success](
+                    VulkanSubmitCompletionBatch& _batch
+                ) {
+                    batch_gpu_success = false;
+                    VkResult completion_result = _batch.outcome.result;
+                    if (completion_result == VK_SUCCESS && !_batch.gpu_submitted) {
+                        completion_result = VK_ERROR_UNKNOWN;
+                    }
+
+                    if (_batch.gpu_submitted) {
+                        VulkanOperationContext wait_context = _batch.context;
+                        wait_context.operation = EVulkanFaultOperation::TimelineHostWait;
+                        const VkResult wait_result =
+                            timeline->HostWait(event_timeline, wait_context);
+                        if (wait_result == VK_SUCCESS && !device.IsDeviceLost()) {
+                            timeline->Notify(event_timeline);
+                            batch_gpu_success = true;
+                            completion_result = VK_SUCCESS;
+                        } else {
+                            completion_result =
+                                wait_result != VK_SUCCESS ?
+                                    wait_result :
+                                device.IsFaulted() ?
+                                    device.GetFirstFaultResult() :
+                                    VK_ERROR_DEVICE_LOST;
+                            if (_batch.owns_queue_timeline) {
+                                timeline->Fail(completion_result);
+                            }
+                        }
+                    } else if (_batch.owns_queue_timeline) {
+                        timeline->Fail(completion_result);
+                    }
+
+                    bool recycle_batch =
+                        batch_gpu_success && !device.IsFaulted();
+                    if (recycle_batch) {
+                        for (auto& allocator : _batch.allocators.submitted) {
+                            recycle_batch =
+                                allocator->CompleteSuccess() && recycle_batch;
+                        }
+                    }
+                    if (recycle_batch) {
+                        for (auto& allocator : _batch.allocators.submitted) {
+                            recycle_batch = allocator->Reset() && recycle_batch;
+                        }
+                    }
+                    if (recycle_batch && !device.IsFaulted()) {
+                        for (auto& allocator : _batch.allocators.submitted) {
+                            allocators.Push(allocator.release());
+                        }
+                    } else {
+                        for (auto& allocator : _batch.allocators.submitted) {
+                            if (!allocator) {
+                                continue;
+                            }
+                            device.RecordAllocatorQuarantine();
+                            device.RecordSkippedCommandPoolReset();
+                            allocator_quarantine.emplace_back(std::move(allocator));
+                        }
+                    }
+                    for (auto& allocator : _batch.allocators.abandoned) {
+                        if (!device.IsFaulted() && allocator->ResetAbandoned()) {
+                            allocators.Push(allocator.release());
+                        } else if (allocator) {
+                            device.RecordAllocatorQuarantine();
+                            device.RecordSkippedCommandPoolReset();
+                            allocator_quarantine.emplace_back(std::move(allocator));
+                        }
+                    }
+
+                    if (_batch.descriptor_lease.has_value()) {
+                        device.GetGlobalDescriptorHeap().RecyclePushDescriptors(
+                            std::move(*_batch.descriptor_lease)
+                        );
+                        _batch.descriptor_lease.reset();
+                    }
+
+                    for (const SignalEvent& event : _batch.submit.signal_events) {
+                        auto* fence =
+                            reinterpret_cast<VulkanFence*>(event.timeline_handle);
+                        if (fence == nullptr) {
+                            continue;
+                        }
+                        if (batch_gpu_success) {
+                            fence->Notify(event.value);
+                        } else {
+                            fence->Fail(completion_result);
+                        }
+                    }
+
+                    if (!_batch.gpu_submitted) {
+                        FinalizeRejectedBindlessUpdates(_batch.submit);
+                    }
+                    Array<std::function<void()>> callbacks =
+                        std::move(_batch.submit.callbacks);
+                    Array<std::function<void()>> success_callbacks =
+                        std::move(_batch.submit.success_callbacks);
+                    _batch.submit.cmds.clear();
+                    _batch.submit.cached_args.clear();
+                    _batch.submit.segments.clear();
+                    _batch.submit.wait_events.clear();
+                    _batch.submit.signal_events.clear();
+                    _batch.submit.debug_label.clear();
+
+                    InvokeCallbacksNoexcept(
+                        callbacks, "[VulkanCopyQueue] runtime completion"
+                    );
+                    if (batch_gpu_success) {
+                        InvokeCallbacksNoexcept(
+                            success_callbacks,
+                            "[VulkanCopyQueue] runtime success completion"
+                        );
+                    }
+
+                    for (auto* resource : _batch.deferred_releases) {
+                        if (batch_gpu_success) {
+                            MoerDelete(resource);
+                        } else {
+                            device.EnqueueDeferredRelease(resource);
+                        }
+                    }
+                    _batch.deferred_releases.clear();
+                },
                 [this, &batch_gpu_success](UniquePtr<VulkanAllocator>& _allocator) {
                     if (batch_gpu_success && !device.IsFaulted()) {
-                        _allocator->CompleteSuccess();
-                        if (_allocator->Reset()) {
+                        if (_allocator->CompleteSuccess() && _allocator->Reset()) {
                             allocators.Push(_allocator.release());
                             return;
                         }
@@ -6763,6 +7856,16 @@ void VkCopyQueue::ExecuteThread() {
                    !cpu_settled_frame.compare_exchange_weak(
                        settled,
                        event_timeline,
+                       std::memory_order_release,
+                       std::memory_order_relaxed
+                   )) {}
+            const uint64 retirement_serial = evt->retirement_serial;
+            uint64 settled_serial =
+                retirement_settled_serial.load(std::memory_order_relaxed);
+            while (settled_serial < retirement_serial &&
+                   !retirement_settled_serial.compare_exchange_weak(
+                       settled_serial,
+                       retirement_serial,
                        std::memory_order_release,
                        std::memory_order_relaxed
                    )) {}
@@ -6866,6 +7969,16 @@ void VkCopyQueue::IOThreadLoop() {
 }
 
 void VkCopyQueue::RHIThreadLoop() {
+    try {
+        LOG_ERROR(
+            "[RHIExecutor][Vulkan] Legacy Copy RHIThreadLoop is disabled; "
+            "native Copy submission belongs to Moer Vulkan Copy Submission"
+        );
+    } catch (...) {
+    }
+    assert(false && "legacy Copy RHIThreadLoop bypasses the Submission owner");
+    return;
+
     while (enabled) {
         CommandList cmdlist;
         uint64      timeline;
@@ -6945,7 +8058,14 @@ void VkCopyQueue::RHIThreadLoop() {
                     false
                 );
             }
-            event_queue.emplace_back(VulkanCompletionMarker{}, current_timeline, true);
+            const uint64 retirement_serial = retirement_enqueued_serial + 1;
+            event_queue.emplace_back(
+                VulkanCompletionMarker{},
+                current_timeline,
+                true,
+                retirement_serial
+            );
+            retirement_enqueued_serial = retirement_serial;
             queue_cv.notify_one();
         }
         {
@@ -6956,9 +8076,6 @@ void VkCopyQueue::RHIThreadLoop() {
 }
 
 UniquePtr<VulkanAllocator> VkCopyQueue::GetAllocator() {
-    if (last_frame >= device.cmd_alloc_limits) {
-        Complete(last_frame);
-    }
     auto allocator = std::move(UniquePtr<VulkanAllocator>(allocators.Pop()));
     if (allocator) {
         // allocator->ResetCmdList();
@@ -6967,13 +8084,13 @@ UniquePtr<VulkanAllocator> VkCopyQueue::GetAllocator() {
     return MakeUnique<VulkanAllocator>(&device, EQueueType::Copy);
 }
 
-void VkCopyQueue::Complete(uint64 _timeline) {
-    if (_timeline == 0) {
-        return;
-    }
+void VkCopyQueue::CompleteAll(uint64 _timeline) {
     std::unique_lock<std::mutex> lock(event_mutex);
-    settled_cv.wait(lock, [this, _timeline]() {
-        return cpu_settled_frame.load(std::memory_order_acquire) >= _timeline;
+    const uint64 target_retirement_serial = retirement_enqueued_serial;
+    settled_cv.wait(lock, [this, _timeline, target_retirement_serial]() {
+        return cpu_settled_frame.load(std::memory_order_acquire) >= _timeline &&
+               retirement_settled_serial.load(std::memory_order_acquire) >=
+                   target_retirement_serial;
     });
 }
 #pragma endregion

--- a/source/runtime/render/rhi/vulkan/VulkanQueue.cpp
+++ b/source/runtime/render/rhi/vulkan/VulkanQueue.cpp
@@ -3277,19 +3277,44 @@ static void MarkSubmissionAccepted(
     }
 }
 
-static void FailSubmissionSignals(
-    VulkanFence* _queue_timeline,
-    const Array<SignalEvent>& _signal_events,
-    VkResult _result
+static bool IsRecoverableUnsubmittedSignal(
+    VulkanDevice& _device, const VulkanOperationResult& _outcome
 ) {
-    if (_queue_timeline != nullptr) {
-        _queue_timeline->Fail(_result);
+    return _outcome.status == EVulkanOperationStatus::Rejected &&
+           !_device.IsFaulted() &&
+           _outcome.result != VK_ERROR_DEVICE_LOST;
+}
+
+static void TerminalizeUnsubmittedSignal(
+    VulkanDevice&                _device,
+    VulkanFence*                 _fence,
+    uint64                       _value,
+    const VulkanOperationResult& _outcome
+) {
+    if (_fence == nullptr) {
+        return;
     }
+    if (IsRecoverableUnsubmittedSignal(_device, _outcome)) {
+        _fence->Reject(_value);
+    } else {
+        const VkResult result =
+            _outcome.result != VK_SUCCESS ? _outcome.result : VK_ERROR_UNKNOWN;
+        _fence->Fail(result);
+    }
+}
+
+static void TerminalizeUnsubmittedSignals(
+    VulkanDevice&                _device,
+    const Array<SignalEvent>&    _signal_events,
+    const VulkanOperationResult& _outcome
+) {
     for (const SignalEvent& event : _signal_events) {
-        auto* fence = reinterpret_cast<VulkanFence*>(event.timeline_handle);
-        if (fence != nullptr) {
-            fence->Fail(_result);
-        }
+        TerminalizeUnsubmittedSignal(
+            _device,
+            reinterpret_cast<VulkanFence*>(event.timeline_handle),
+            event.value,
+            _outcome
+        );
     }
 }
 
@@ -3304,7 +3329,11 @@ static void TerminalizeRejectedSubmit(
     }
 
     _device.RecordRejectedSubmit();
-    FailSubmissionSignals(nullptr, _submit.signal_events, _result);
+    TerminalizeUnsubmittedSignals(
+        _device,
+        _submit.signal_events,
+        VulkanOperationResult{EVulkanOperationStatus::Rejected, _result}
+    );
     FinalizeRejectedBindlessUpdates(_submit);
 
     // Completion callbacks are the only user code retained on a rejected
@@ -3789,6 +3818,17 @@ void VkCommandQueue::RejectForRuntime(CmdSubmit&& _submit, VkResult _result) noe
     vk_device.RecordRejectedSubmit();
 
     try {
+        TerminalizeUnsubmittedSignals(
+            vk_device,
+            _submit.signal_events,
+            VulkanOperationResult{
+                EVulkanOperationStatus::Rejected, _result
+            }
+        );
+        // Rejection is now externally observable. Completion must not retain
+        // and dereference the raw fence pointers after a waiter releases its
+        // last FenceRef.
+        _submit.signal_events.clear();
         std::unique_lock<std::mutex> lock(event_mutex);
         const uint64 retirement_serial = retirement_enqueued_serial + 1;
         event_queue.emplace_back(
@@ -3971,6 +4011,18 @@ void VkCommandQueue::CommitRuntimeSubmitCompletion(
     assert(!_recorded.completion_committed);
     try {
         if (!_outcome.WasSubmitted()) {
+            TerminalizeUnsubmittedSignal(
+                vk_device,
+                timeline,
+                _recorded.timeline,
+                _outcome
+            );
+            TerminalizeUnsubmittedSignals(
+                vk_device, _recorded.submit.signal_events, _outcome
+            );
+            // Exact signal rejection is published by Submission. Do not
+            // retain raw external fence pointers in the Completion packet.
+            _recorded.submit.signal_events.clear();
             _recorded.allocators.abandoned.reserve(
                 _recorded.allocators.abandoned.size() +
                 _recorded.allocators.submitted.size()
@@ -5920,6 +5972,13 @@ void VkCommandQueue::CommitPresentCompletion(
     uint64                          _timeline
 ) noexcept {
     try {
+        if (!_gpu_submitted &&
+            (_outcome.status == EVulkanOperationStatus::Rejected ||
+             _outcome.status == EVulkanOperationStatus::Faulted)) {
+            TerminalizeUnsubmittedSignal(
+                vk_device, timeline, _timeline, _outcome
+            );
+        }
         std::unique_lock<std::mutex> lock(event_mutex);
         const uint64 retirement_serial = retirement_enqueued_serial + 1;
         event_queue.emplace_back(
@@ -6685,9 +6744,14 @@ void VkCommandQueue::CompletionThreadMain() {
                         (_submission.outcome.status == EVulkanOperationStatus::Retry ||
                          _submission.outcome.status == EVulkanOperationStatus::Recreate);
                     if (!_submission.gpu_submitted) {
-                        if (_submission.outcome.status == EVulkanOperationStatus::Faulted ||
-                            _submission.outcome.status == EVulkanOperationStatus::Rejected) {
+                        if (_submission.outcome.status ==
+                            EVulkanOperationStatus::Faulted) {
                             timeline->Fail(_submission.outcome.result);
+                        } else if (
+                            _submission.outcome.status ==
+                            EVulkanOperationStatus::Rejected
+                        ) {
+                            timeline->Reject(event_timeline);
                         }
                         return;
                     }
@@ -6716,6 +6780,12 @@ void VkCommandQueue::CompletionThreadMain() {
                     if (completion_result == VK_SUCCESS && !_batch.gpu_submitted) {
                         completion_result = VK_ERROR_UNKNOWN;
                     }
+                    const bool recoverable_rejection =
+                        !_batch.gpu_submitted &&
+                        _batch.outcome.status ==
+                            EVulkanOperationStatus::Rejected &&
+                        !vk_device.IsFaulted() &&
+                        _batch.outcome.result != VK_ERROR_DEVICE_LOST;
 
                     if (_batch.gpu_submitted) {
                         VulkanOperationContext wait_context = _batch.context;
@@ -6739,7 +6809,11 @@ void VkCommandQueue::CompletionThreadMain() {
                             }
                         }
                     } else if (_batch.owns_queue_timeline) {
-                        timeline->Fail(completion_result);
+                        if (recoverable_rejection) {
+                            timeline->Reject(event_timeline);
+                        } else {
+                            timeline->Fail(completion_result);
+                        }
                     }
 
                     bool recycle_batch =
@@ -6794,6 +6868,8 @@ void VkCommandQueue::CompletionThreadMain() {
                         }
                         if (batch_gpu_success) {
                             fence->Notify(event.value);
+                        } else if (recoverable_rejection) {
+                            fence->Reject(event.value);
                         } else {
                             fence->Fail(completion_result);
                         }
@@ -6872,15 +6948,19 @@ void VkCommandQueue::CompletionThreadMain() {
                         }
                     } else if (
                         _batch.owns_queue_timeline &&
-                        (_batch.outcome.status ==
-                             EVulkanOperationStatus::Faulted ||
-                         _batch.outcome.status ==
-                             EVulkanOperationStatus::Rejected)
+                        _batch.outcome.status ==
+                            EVulkanOperationStatus::Faulted
                     ) {
                         if (completion_result == VK_SUCCESS) {
                             completion_result = VK_ERROR_UNKNOWN;
                         }
                         timeline->Fail(completion_result);
+                    } else if (
+                        _batch.owns_queue_timeline &&
+                        _batch.outcome.status ==
+                            EVulkanOperationStatus::Rejected
+                    ) {
+                        timeline->Reject(event_timeline);
                     }
 
                     if (_batch.presentor) {
@@ -7387,7 +7467,7 @@ VkCopyQueue::TrackedExecuteResult VkCopyQueue::ExecuteTracked(CmdSubmit&& _evt) 
         state.outcome,
         state.context,
         state.logical_timeline,
-        state.timeline_reserved && state.outcome.WasSubmitted()
+        state.timeline_reserved
     );
     state.completion_committed = true;
 
@@ -7560,7 +7640,7 @@ VkCopyQueue::TrackedExecuteResult VkCopyQueue::ExecuteTrackedImpl(
             _state.outcome,
             _state.context,
             _state.logical_timeline,
-            _state.outcome.WasSubmitted()
+            _state.timeline_reserved
         );
         _state.completion_committed = true;
 
@@ -7608,9 +7688,25 @@ void VkCopyQueue::CommitRuntimeSubmitCompletion(
     const VulkanOperationResult& _outcome,
     const VulkanOperationContext& _context,
     uint64                        _logical_timeline,
-    bool                          _owns_queue_timeline
+    bool                          _has_queue_timeline_reservation
 ) noexcept {
     try {
+        if (!_outcome.WasSubmitted()) {
+            if (_has_queue_timeline_reservation) {
+                TerminalizeUnsubmittedSignal(
+                    device,
+                    timeline.Get(),
+                    _logical_timeline,
+                    _outcome
+                );
+            }
+            TerminalizeUnsubmittedSignals(
+                device, _submit.signal_events, _outcome
+            );
+            // Exact signal rejection is published by Submission. Do not
+            // retain raw external fence pointers in the Completion packet.
+            _submit.signal_events.clear();
+        }
         std::unique_lock<std::mutex> lock(event_mutex);
         const uint64 retirement_serial = retirement_enqueued_serial + 1;
         event_queue.emplace_back(
@@ -7621,7 +7717,7 @@ void VkCopyQueue::CommitRuntimeSubmitCompletion(
             _outcome,
             _context,
             _outcome.WasSubmitted(),
-            _owns_queue_timeline,
+            _has_queue_timeline_reservation,
             std::move(_submit),
             std::move(_allocators),
             std::optional<VulkanDescriptorPushLease>{},
@@ -7676,9 +7772,14 @@ void VkCopyQueue::ExecuteThread() {
                 [this, event_timeline, &batch_gpu_success](VulkanSubmissionEvent& _submission) {
                     batch_gpu_success = false;
                     if (!_submission.gpu_submitted) {
-                        if (_submission.outcome.status == EVulkanOperationStatus::Faulted ||
-                            _submission.outcome.status == EVulkanOperationStatus::Rejected) {
+                        if (_submission.outcome.status ==
+                            EVulkanOperationStatus::Faulted) {
                             timeline->Fail(_submission.outcome.result);
+                        } else if (
+                            _submission.outcome.status ==
+                            EVulkanOperationStatus::Rejected
+                        ) {
+                            timeline->Reject(event_timeline);
                         }
                         return;
                     }
@@ -7700,6 +7801,12 @@ void VkCopyQueue::ExecuteThread() {
                     if (completion_result == VK_SUCCESS && !_batch.gpu_submitted) {
                         completion_result = VK_ERROR_UNKNOWN;
                     }
+                    const bool recoverable_rejection =
+                        !_batch.gpu_submitted &&
+                        _batch.outcome.status ==
+                            EVulkanOperationStatus::Rejected &&
+                        !device.IsFaulted() &&
+                        _batch.outcome.result != VK_ERROR_DEVICE_LOST;
 
                     if (_batch.gpu_submitted) {
                         VulkanOperationContext wait_context = _batch.context;
@@ -7722,7 +7829,11 @@ void VkCopyQueue::ExecuteThread() {
                             }
                         }
                     } else if (_batch.owns_queue_timeline) {
-                        timeline->Fail(completion_result);
+                        if (recoverable_rejection) {
+                            timeline->Reject(event_timeline);
+                        } else {
+                            timeline->Fail(completion_result);
+                        }
                     }
 
                     bool recycle_batch =
@@ -7777,6 +7888,8 @@ void VkCopyQueue::ExecuteThread() {
                         }
                         if (batch_gpu_success) {
                             fence->Notify(event.value);
+                        } else if (recoverable_rejection) {
+                            fence->Reject(event.value);
                         } else {
                             fence->Fail(completion_result);
                         }

--- a/source/runtime/render/rhi/vulkan/VulkanQueue.h
+++ b/source/runtime/render/rhi/vulkan/VulkanQueue.h
@@ -1010,7 +1010,7 @@ private:
         const VulkanOperationResult& _outcome,
         const VulkanOperationContext& _context,
         uint64                       _logical_timeline,
-        bool                         _owns_queue_timeline
+        bool                         _has_queue_timeline_reservation
     ) noexcept;
     UniquePtr<VulkanAllocator>                GetAllocator();
     void                                      CompleteAll(uint64 _timeline);

--- a/source/runtime/render/rhi/vulkan/VulkanQueue.h
+++ b/source/runtime/render/rhi/vulkan/VulkanQueue.h
@@ -13,10 +13,12 @@
 #include "rhi/ExternalCpuJoinPool.h"
 #include "rhi/RHIParallelRecord.h"
 #include "rhi/RHIRecordDiagnostics.h"
+#include "rhi/RHIThreadOwnership.h"
 #include <atomic>
 #include <chrono>
 #include <condition_variable>
 #include <functional>
+#include <future>
 #include <mutex>
 #include <optional>
 #include <string_view>
@@ -59,6 +61,10 @@ public:
         VkPipelineStageFlags2 _stage = VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT
     );
     void Signal(VkSemaphore _semaphore, VkPipelineStageFlags2 _stage = VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT);
+    void DiscardPendingSubmitState() noexcept {
+        wait_infos.clear();
+        signal_infos.clear();
+    }
     VkQueue GetHandle() const {
         return queue;
     }
@@ -209,6 +215,7 @@ struct VulkanSubmissionEvent {
 struct VulkanRuntimeSubmissionResult {
     VulkanOperationResult   outcome{};
     std::optional<WaitEvent> completion{};
+    bool                     recoverable_rejection{false};
 
     [[nodiscard]] bool WasSubmitted() const {
         return completion.has_value();
@@ -216,7 +223,13 @@ struct VulkanRuntimeSubmissionResult {
 
     [[nodiscard]] bool IsHardFailure() const {
         return outcome.status == EVulkanOperationStatus::Faulted ||
-               outcome.status == EVulkanOperationStatus::Rejected;
+               (outcome.status == EVulkanOperationStatus::Rejected &&
+                !recoverable_rejection);
+    }
+
+    [[nodiscard]] bool IsRecoverableRejection() const {
+        return outcome.status == EVulkanOperationStatus::Rejected &&
+               recoverable_rejection;
     }
 };
 
@@ -234,12 +247,123 @@ struct VulkanDeferredReleaseBatch {
     Array<RHIResource*> resources;
 };
 
+// Runtime-recorded submissions cross the Submission -> Completion boundary as
+// one move-only ownership packet.  Keeping the command payload, allocator
+// retirement, descriptor lease, callbacks, signals, and deferred releases in
+// one variant alternative makes that handoff atomic: no exception can leave a
+// partially published completion sequence behind.
+struct VulkanSubmitCompletionBatch {
+    VulkanSubmitCompletionBatch(
+        VulkanOperationResult                    _outcome,
+        VulkanOperationContext                   _context,
+        bool                                     _gpu_submitted,
+        bool                                     _owns_queue_timeline,
+        CmdSubmit&&                              _submit,
+        VulkanAllocatorBatch&&                   _allocators,
+        std::optional<VulkanDescriptorPushLease>&& _descriptor_lease,
+        Array<RHIResource*>&&                    _deferred_releases
+    ) noexcept :
+        outcome(_outcome),
+        context(_context),
+        gpu_submitted(_gpu_submitted),
+        owns_queue_timeline(_owns_queue_timeline),
+        submit(std::move(_submit)),
+        allocators(std::move(_allocators)),
+        descriptor_lease(std::move(_descriptor_lease)),
+        deferred_releases(std::move(_deferred_releases)) {}
+
+    VulkanSubmitCompletionBatch(
+        VulkanOperationResult      _outcome,
+        VulkanOperationContext     _context,
+        bool                       _gpu_submitted,
+        bool                       _owns_queue_timeline,
+        CmdSubmit&&                _submit,
+        VulkanAllocatorBatch&&     _allocators,
+        VulkanDescriptorPushLease&& _descriptor_lease,
+        Array<RHIResource*>&&      _deferred_releases
+    ) noexcept :
+        outcome(_outcome),
+        context(_context),
+        gpu_submitted(_gpu_submitted),
+        owns_queue_timeline(_owns_queue_timeline),
+        submit(std::move(_submit)),
+        allocators(std::move(_allocators)),
+        descriptor_lease(std::move(_descriptor_lease)),
+        deferred_releases(std::move(_deferred_releases)) {}
+
+    VulkanSubmitCompletionBatch(const VulkanSubmitCompletionBatch&) = delete;
+    VulkanSubmitCompletionBatch& operator=(const VulkanSubmitCompletionBatch&) = delete;
+    VulkanSubmitCompletionBatch(VulkanSubmitCompletionBatch&&) noexcept = default;
+    VulkanSubmitCompletionBatch& operator=(VulkanSubmitCompletionBatch&&) noexcept = default;
+
+    VulkanOperationResult                    outcome;
+    VulkanOperationContext                   context;
+    bool                                     gpu_submitted{false};
+    bool                                     owns_queue_timeline{false};
+    CmdSubmit                                submit;
+    VulkanAllocatorBatch                     allocators;
+    std::optional<VulkanDescriptorPushLease> descriptor_lease;
+    Array<RHIResource*>                      deferred_releases;
+};
+
+enum class EVulkanPresentorRetirementState : uint8_t {
+    Unused,
+    RecordedNotSubmitted,
+    Submitted,
+};
+
+// Present has a different submission contract from CmdSubmit: native copy
+// submission can succeed even when vkQueuePresentKHR asks for swapchain
+// recreation. Keep its presentor and retained resources in one move-only
+// packet so they cross Submission -> Completion atomically.
+struct VulkanPresentCompletionBatch {
+    VulkanPresentCompletionBatch(
+        VulkanOperationResult              _outcome,
+        VulkanOperationContext             _context,
+        bool                               _gpu_submitted,
+        bool                               _owns_queue_timeline,
+        EVulkanPresentorRetirementState    _presentor_state,
+        UniquePtr<VulkanPresentor>&&       _presentor,
+        SwapchainRef&&                     _swapchain,
+        TextureRef&&                       _source_texture,
+        Array<RHIResource*>&&              _deferred_releases
+    ) noexcept :
+        outcome(_outcome),
+        context(_context),
+        gpu_submitted(_gpu_submitted),
+        owns_queue_timeline(_owns_queue_timeline),
+        presentor_state(_presentor_state),
+        presentor(std::move(_presentor)),
+        swapchain(std::move(_swapchain)),
+        source_texture(std::move(_source_texture)),
+        deferred_releases(std::move(_deferred_releases)) {}
+
+    VulkanPresentCompletionBatch(const VulkanPresentCompletionBatch&) = delete;
+    VulkanPresentCompletionBatch& operator=(const VulkanPresentCompletionBatch&) = delete;
+    VulkanPresentCompletionBatch(VulkanPresentCompletionBatch&&) noexcept = default;
+    VulkanPresentCompletionBatch& operator=(VulkanPresentCompletionBatch&&) noexcept = default;
+
+    VulkanOperationResult           outcome;
+    VulkanOperationContext          context;
+    bool                            gpu_submitted{false};
+    bool                            owns_queue_timeline{false};
+    EVulkanPresentorRetirementState presentor_state{
+        EVulkanPresentorRetirementState::Unused
+    };
+    UniquePtr<VulkanPresentor>      presentor;
+    SwapchainRef                    swapchain;
+    TextureRef                      source_texture;
+    Array<RHIResource*>             deferred_releases;
+};
+
 struct VulkanCompletionMarker {};
 
 class VkCommandQueue : public CommandQueue {
 public:
     using EventType = std::variant<
         VulkanSubmissionEvent,
+        VulkanSubmitCompletionBatch,
+        VulkanPresentCompletionBatch,
         UniquePtr<VulkanAllocator>,
         VulkanAllocatorBatch,
         VulkanDescriptorPushLease,
@@ -255,17 +379,47 @@ public:
         EventType event;
         uint64    timeline;
         bool      wake_thread;
+        uint64    retirement_serial;
         template<typename Arg>
             requires std::is_constructible_v<EventType, Arg&&>
         QueueEvent(Arg&& _event, uint64 _timeline, bool _wake_thread) :
             event(std::forward<Arg>(_event)),
             timeline(_timeline),
-            wake_thread(_wake_thread) {}
+            wake_thread(_wake_thread),
+            retirement_serial(0) {}
+
+        template<typename Arg>
+            requires std::is_constructible_v<EventType, Arg&&>
+        QueueEvent(
+            Arg&&  _event,
+            uint64 _timeline,
+            bool   _wake_thread,
+            uint64 _retirement_serial
+        ) :
+            event(std::forward<Arg>(_event)),
+            timeline(_timeline),
+            wake_thread(_wake_thread),
+            retirement_serial(_retirement_serial) {}
+
+        template<typename Event, typename... Args>
+            requires std::is_constructible_v<Event, Args&&...>
+        QueueEvent(
+            std::in_place_type_t<Event>,
+            uint64 _timeline,
+            bool   _wake_thread,
+            uint64 _retirement_serial,
+            Args&&... _args
+        ) noexcept(std::is_nothrow_constructible_v<Event, Args&&...>) :
+            event(std::in_place_type<Event>, std::forward<Args>(_args)...),
+            timeline(_timeline),
+            wake_thread(_wake_thread),
+            retirement_serial(_retirement_serial) {}
 
         QueueEvent(QueueEvent&& _other) noexcept :
             event(std::move(_other.event)),
             timeline(_other.timeline),
-            wake_thread(_other.wake_thread) {}
+            wake_thread(_other.wake_thread),
+            retirement_serial(_other.retirement_serial) {}
     };
 
     struct RhiExecuteWork {
@@ -531,7 +685,13 @@ private:
         std::optional<VulkanDescriptorPushLease> descriptor_lease;
         Array<RHIResource*>                     deferred_releases;
         CurrentVulkanRecordedSubmitProfile      profile;
-        std::optional<std::unique_lock<std::mutex>> runtime_execution_lock{};
+        RHITransferableOwnershipGate::Lease     execution_lease{};
+        VulkanOperationResult                   retirement_outcome{
+            EVulkanOperationStatus::Rejected, VK_ERROR_UNKNOWN
+        };
+        bool                                    recoverable_rejection{false};
+        bool                                    native_submit_resolved{false};
+        bool                                    completion_committed{false};
     };
 
     struct CurrentVulkanSubmitResult {
@@ -544,19 +704,31 @@ private:
         uint64 _timeline,
         uint64 _serial,
         std::optional<CurrentVulkanRecordedSubmit>* _out_recorded = nullptr,
-        bool _runtime_owner = false
+        bool _runtime_owner = false,
+        bool* _out_terminalized = nullptr
     );
-    CurrentVulkanSubmitResult SubmitRecorded(CurrentVulkanRecordedSubmit _recorded);
-    std::optional<CurrentVulkanRecordedSubmit> TranslateForRuntime(CmdSubmit&& _submit);
+    CurrentVulkanSubmitResult SubmitRecorded(
+        CurrentVulkanRecordedSubmit& _recorded,
+        const std::atomic_bool*       _continue_waiting = nullptr
+    );
+    std::optional<CurrentVulkanRecordedSubmit>
+        TranslateForRuntime(CmdSubmit&& _submit) noexcept;
     VulkanRuntimeSubmissionResult SubmitRecordedForRuntime(
         CurrentVulkanRecordedSubmit _recorded
-    );
-    void RejectForRuntime(CmdSubmit&& _submit, VkResult _result);
+    ) noexcept;
+    void RejectRecordedForRuntime(
+        CurrentVulkanRecordedSubmit&& _recorded,
+        VkResult                       _result
+    ) noexcept;
+    void RejectForRuntime(CmdSubmit&& _submit, VkResult _result) noexcept;
+    [[nodiscard]] bool ClaimRuntimeOwnership();
+    void ReleaseRuntimeOwnership() noexcept;
+    void CancelRuntimeDependencyWaits() noexcept;
     VulkanRuntimeSubmissionResult PresentForRuntime(
         SwapchainRef _swapchain,
         TextureView _source,
         PresentReceiptRef _receipt
-    );
+    ) noexcept;
     bool                       TryExecuteParallel(
         CmdSubmit&                    _submit,
         uint64                        _timeline,
@@ -576,14 +748,29 @@ private:
         uint64         _timeline,
         uint64         _serial,
         bool           _runtime_owner = false
-    );
+    ) noexcept;
     void                       RhiThreadMain();
     void                       CompletionThreadMain();
     Array<RHIResource*>        TakeDeferredReleases();
     void                       EnqueueCompletionMarker(uint64 _timeline);
+    void                       CommitRuntimeSubmitCompletion(
+        CurrentVulkanRecordedSubmit& _recorded,
+        const VulkanOperationResult&  _outcome
+    ) noexcept;
+    void                       CommitPresentCompletion(
+        const VulkanOperationResult&       _outcome,
+        const VulkanOperationContext&      _context,
+        bool                               _gpu_submitted,
+        EVulkanPresentorRetirementState    _presentor_state,
+        UniquePtr<VulkanPresentor>&&       _presentor,
+        SwapchainRef&&                     _swapchain,
+        TextureRef&&                       _source_texture,
+        Array<RHIResource*>&&              _deferred_releases,
+        uint64                             _timeline
+    ) noexcept;
     UniquePtr<VulkanAllocator> GetAllocator();
     UniquePtr<VulkanPresentor> GetPresentor();
-    void                       Complete(uint64 _timeline);
+    void                       CompleteAll(uint64 _timeline);
     void                       EnsureRecordCalibration();
     void                       RecordRhiRecordProfile(const RhiRecordExecuteSample& _sample);
     void                       RecordThreadingProfile(
@@ -606,10 +793,17 @@ private:
     void                       ResetSplitProfilingCpuFrame();
 
 private:
+    enum class EExecutionOwnershipMode : uint8_t {
+        Unclaimed,
+        Legacy,
+        Runtime,
+    };
+
+    [[nodiscard]] bool ClaimLegacyOwnership(std::string_view _operation);
     std::atomic<uint64>                                last_frame{0};
-    CircularQueue<uint64, s_queue_max_frame_in_flight> executed_queue;
     std::atomic<uint64>                                cpu_settled_frame = 0;
-    CircularQueue<uint64, s_queue_max_frame_in_flight> presented_queue;
+    uint64                                             retirement_enqueued_serial{0};
+    std::atomic<uint64>                                retirement_settled_serial{0};
     VulkanFence*                                       timeline = nullptr;
     std::mutex                                         event_mutex;
     bool                                               completion_worker_running{false};
@@ -649,6 +843,11 @@ private:
     std::condition_variable rhi_work_done_cv;
 
     std::mutex   exec_mtx;
+    RHITransferableOwnershipGate runtime_execution_gate;
+    std::atomic<EExecutionOwnershipMode> execution_ownership_mode{
+        EExecutionOwnershipMode::Unclaimed
+    };
+    std::atomic_bool runtime_dependency_waits_enabled{true};
     std::jthread completion_thread;
     std::jthread rhi_thread;
     Array<UniquePtr<VulkanAllocator>> allocator_quarantine;
@@ -662,6 +861,7 @@ public:
     ~VkCopyQueue();
     using EventType = std::variant<
         VulkanSubmissionEvent,
+        VulkanSubmitCompletionBatch,
         UniquePtr<VulkanAllocator>,
         UniquePtr<VulkanPresentor>,
         VulkanCallbackBatch,
@@ -672,22 +872,52 @@ public:
         EventType event;
         uint64    timeline;
         bool      wake_thread;
+        uint64    retirement_serial;
         template<typename Arg>
             requires std::is_constructible_v<EventType, Arg&&>
         IOEvent(Arg&& _event, uint64 _timeline, bool _wake_thread) :
             event(std::forward<Arg>(_event)),
             timeline(_timeline),
-            wake_thread(_wake_thread) {}
+            wake_thread(_wake_thread),
+            retirement_serial(0) {}
+
+        template<typename Arg>
+            requires std::is_constructible_v<EventType, Arg&&>
+        IOEvent(
+            Arg&&  _event,
+            uint64 _timeline,
+            bool   _wake_thread,
+            uint64 _retirement_serial
+        ) :
+            event(std::forward<Arg>(_event)),
+            timeline(_timeline),
+            wake_thread(_wake_thread),
+            retirement_serial(_retirement_serial) {}
+
+        template<typename Event, typename... Args>
+            requires std::is_constructible_v<Event, Args&&...>
+        IOEvent(
+            std::in_place_type_t<Event>,
+            uint64 _timeline,
+            bool   _wake_thread,
+            uint64 _retirement_serial,
+            Args&&... _args
+        ) noexcept(std::is_nothrow_constructible_v<Event, Args&&...>) :
+            event(std::in_place_type<Event>, std::forward<Args>(_args)...),
+            timeline(_timeline),
+            wake_thread(_wake_thread),
+            retirement_serial(_retirement_serial) {}
 
         IOEvent(IOEvent&& _other) noexcept :
             event(std::move(_other.event)),
             timeline(_other.timeline),
-            wake_thread(_other.wake_thread) {}
+            wake_thread(_other.wake_thread),
+            retirement_serial(_other.retirement_serial) {}
     };
 
     IOWaitEvt Execute(IOQueueSubmission&& _submit) override;
     IOWaitEvt Execute(CmdSubmit&& _submit) override;
-    VulkanRuntimeSubmissionResult ExecuteForRuntime(CmdSubmit&& _submit);
+    VulkanRuntimeSubmissionResult ExecuteForRuntime(CmdSubmit&& _submit) noexcept;
     FenceRef  GetFenceHandle() override;
     void      Sync(uint64 _timeline) override;
 
@@ -737,16 +967,53 @@ private:
     void RHIThreadLoop();
 
 private:
-    void RejectForRuntime(CmdSubmit&& _submit, VkResult _result);
+    void RejectForRuntime(CmdSubmit&& _submit, VkResult _result) noexcept;
+    void EnableRuntimeDependencyWaits() noexcept;
+    void CancelRuntimeDependencyWaits() noexcept;
 
     struct TrackedExecuteResult {
         VulkanRuntimeSubmissionResult runtime{};
         uint64                        logical_timeline{0};
     };
 
-    TrackedExecuteResult ExecuteTracked(CmdSubmit&& _submit);
+    struct RuntimeExecuteState {
+        uint64                   logical_timeline{0};
+        VulkanOperationContext   context{};
+        VulkanOperationResult    outcome{
+            EVulkanOperationStatus::Rejected, VK_ERROR_UNKNOWN
+        };
+        VulkanAllocatorBatch     allocators{};
+        bool                     timeline_reserved{false};
+        bool                     recoverable_rejection{false};
+        bool                     native_submit_resolved{false};
+        bool                     completion_committed{false};
+    };
+
+    struct CopySubmissionRequest {
+        explicit CopySubmissionRequest(CmdSubmit&& _submit) :
+            submit(std::move(_submit)) {}
+
+        std::promise<TrackedExecuteResult> completion;
+        CmdSubmit                          submit;
+    };
+
+    TrackedExecuteResult ExecuteOnSubmissionOwner(CmdSubmit&& _submit) noexcept;
+    void                 SubmissionThreadMain();
+    TrackedExecuteResult ExecuteTracked(CmdSubmit&& _submit) noexcept;
+    TrackedExecuteResult ExecuteTrackedImpl(
+        CmdSubmit&           _submit,
+        RuntimeExecuteState& _state
+    );
+    void CommitRuntimeSubmitCompletion(
+        CmdSubmit&&                 _submit,
+        VulkanAllocatorBatch&&      _allocators,
+        const VulkanOperationResult& _outcome,
+        const VulkanOperationContext& _context,
+        uint64                       _logical_timeline,
+        bool                         _owns_queue_timeline
+    ) noexcept;
     UniquePtr<VulkanAllocator>                GetAllocator();
-    void                                      Complete(uint64 _timeline);
+    void                                      CompleteAll(uint64 _timeline);
     LockFreeQueueBase<VulkanAllocator, false> allocators;
     DEQueue<IOEvent>                          event_queue;
 
@@ -755,6 +1022,8 @@ private:
 
     uint                    last_frame     = 0;
     std::atomic<uint64>     cpu_settled_frame = 0;
+    uint64                  retirement_enqueued_serial{0};
+    std::atomic<uint64>     retirement_settled_serial{0};
     VulkanFenceRef          timeline       = nullptr;
     std::mutex              event_mutex;
     std::atomic_bool        enabled{false};
@@ -762,6 +1031,14 @@ private:
     std::condition_variable settled_cv;
     VkNativeQueue           queue;
     std::jthread            thread;
+
+    DEQueue<UniquePtr<CopySubmissionRequest>> submission_requests;
+    std::mutex                                  submission_mutex;
+    std::condition_variable                     submission_cv;
+    std::atomic_bool                            submission_accepting{true};
+    std::atomic_bool                            dependency_waits_enabled{true};
+    std::jthread                                submission_thread;
+    std::atomic<uint32>                         submission_thread_id{0};
 
     //tmp
     LockFreeQueueBase<IOCmd> commands;

--- a/source/runtime/render/rhi/vulkan/VulkanRHIResource.cpp
+++ b/source/runtime/render/rhi/vulkan/VulkanRHIResource.cpp
@@ -4024,17 +4024,27 @@ VkAccessFlags2 VulkanEnumTranslator::METoVkAccessFlags2(ERHIAccessFlags _flags) 
 
     void VulkanFence::Wait(uint64_t _value) {
         std::unique_lock<std::mutex> _(cv_m);
-        while (current_value < _value && !failed && !m_device->IsFaulted()) {
+        while (current_value < _value &&
+               !rejected_values.contains(_value) &&
+               !failed &&
+               !m_device->IsFaulted()) {
             cv.wait_for(_, std::chrono::milliseconds(50));
         }
-        if (current_value < _value && !failed && m_device->IsFaulted()) {
+        if (current_value < _value &&
+            !rejected_values.contains(_value) &&
+            !failed &&
+            m_device->IsFaulted()) {
             failed         = true;
             failure_result = m_device->GetFirstFaultResult();
         }
     }
 
-    void VulkanFence::Reject(uint64_t) {
-        Fail(VK_ERROR_UNKNOWN);
+    void VulkanFence::Reject(uint64_t _value) {
+        {
+            std::unique_lock<std::mutex> lock(cv_m);
+            rejected_values.emplace(_value);
+        }
+        cv.notify_all();
     }
 
     void VulkanFence::Notify(uint64_t _value) {
@@ -4061,6 +4071,7 @@ VkAccessFlags2 VulkanEnumTranslator::METoVkAccessFlags2(ERHIAccessFlags _flags) 
         std::unique_lock<std::mutex> lock(cv_m);
         while (
             submitted_value < _value &&
+            !rejected_values.contains(_value) &&
             !failed &&
             !m_device->IsFaulted() &&
             (_continue_waiting == nullptr ||
@@ -4068,15 +4079,29 @@ VkAccessFlags2 VulkanEnumTranslator::METoVkAccessFlags2(ERHIAccessFlags _flags) 
         ) {
             cv.wait_for(lock, std::chrono::milliseconds(50));
         }
-        return submitted_value >= _value && !failed && !m_device->IsFaulted();
+        return submitted_value >= _value &&
+               !rejected_values.contains(_value) &&
+               !failed &&
+               !m_device->IsFaulted();
+    }
+
+    bool VulkanFence::IsRejected(uint64_t _value) const {
+        std::unique_lock<std::mutex> lock(cv_m);
+        return rejected_values.contains(_value);
     }
 
     void VulkanFence::Sync(uint64_t _value) {
         std::unique_lock<std::mutex> _(cv_m);
-        while (current_value < _value && !failed && !m_device->IsFaulted()) {
+        while (current_value < _value &&
+               !rejected_values.contains(_value) &&
+               !failed &&
+               !m_device->IsFaulted()) {
             cv.wait_for(_, std::chrono::milliseconds(50));
         }
-        if (current_value < _value && !failed && m_device->IsFaulted()) {
+        if (current_value < _value &&
+            !rejected_values.contains(_value) &&
+            !failed &&
+            m_device->IsFaulted()) {
             failed         = true;
             failure_result = m_device->GetFirstFaultResult();
         }
@@ -4089,6 +4114,17 @@ VkAccessFlags2 VulkanEnumTranslator::METoVkAccessFlags2(ERHIAccessFlags _flags) 
         info.pSemaphores    = &timeline;
         constexpr uint64_t wait_slice_ns = 50'000'000;
         while (!m_device->IsDeviceLost()) {
+            {
+                std::unique_lock<std::mutex> lock(cv_m);
+                if (rejected_values.contains(_value)) {
+                    return VK_ERROR_UNKNOWN;
+                }
+                if (failed) {
+                    return failure_result != VK_SUCCESS ?
+                               failure_result :
+                               VK_ERROR_UNKNOWN;
+                }
+            }
             const VkResult result = vkWaitSemaphores(m_device->GetDevice(), &info, wait_slice_ns);
             if (result == VK_SUCCESS) {
                 return VK_SUCCESS;

--- a/source/runtime/render/rhi/vulkan/VulkanRHIResource.cpp
+++ b/source/runtime/render/rhi/vulkan/VulkanRHIResource.cpp
@@ -4033,6 +4033,10 @@ VkAccessFlags2 VulkanEnumTranslator::METoVkAccessFlags2(ERHIAccessFlags _flags) 
         }
     }
 
+    void VulkanFence::Reject(uint64_t) {
+        Fail(VK_ERROR_UNKNOWN);
+    }
+
     void VulkanFence::Notify(uint64_t _value) {
         {
             std::unique_lock<std::mutex> _(cv_m);
@@ -4050,9 +4054,18 @@ VkAccessFlags2 VulkanEnumTranslator::METoVkAccessFlags2(ERHIAccessFlags _flags) 
         cv.notify_all();
     }
 
-    bool VulkanFence::WaitSubmitted(uint64_t _value) {
+    bool VulkanFence::WaitSubmitted(
+        uint64_t _value,
+        const std::atomic_bool* _continue_waiting
+    ) {
         std::unique_lock<std::mutex> lock(cv_m);
-        while (submitted_value < _value && !failed && !m_device->IsFaulted()) {
+        while (
+            submitted_value < _value &&
+            !failed &&
+            !m_device->IsFaulted() &&
+            (_continue_waiting == nullptr ||
+             _continue_waiting->load(std::memory_order_acquire))
+        ) {
             cv.wait_for(lock, std::chrono::milliseconds(50));
         }
         return submitted_value >= _value && !failed && !m_device->IsFaulted();

--- a/source/runtime/render/rhi/vulkan/VulkanRHIResource.h
+++ b/source/runtime/render/rhi/vulkan/VulkanRHIResource.h
@@ -1053,7 +1053,8 @@ public:
         uint64_t               _value,
         const std::atomic_bool* _continue_waiting = nullptr
     );
-    VkResult HostWait(
+    RENDER_API bool IsRejected(uint64_t _value) const;
+    RENDER_API VkResult HostWait(
         uint64_t                      _value,
         const VulkanOperationContext& _context = VulkanOperationContext{}
     );
@@ -1074,6 +1075,7 @@ private:
     std::condition_variable cv;
     mutable std::mutex      cv_m;
     uint64                  submitted_value{0};
+    UnorderedSet<uint64>    rejected_values;
     bool                    failed{false};
     VkResult                failure_result{VK_SUCCESS};
 };

--- a/source/runtime/render/rhi/vulkan/VulkanRHIResource.h
+++ b/source/runtime/render/rhi/vulkan/VulkanRHIResource.h
@@ -1043,18 +1043,22 @@ public:
     uint64 GetDeviceValue() const;
 
     void Wait(uint64_t _value) override;
+    void Reject(uint64_t _value) override;
     // can be called on any thread to block current thread
     void Sync(uint64);
     // can be called on any thread to signal fence
     void  Notify(uint64);
     void  MarkSubmitted(uint64_t _value);
-    bool  WaitSubmitted(uint64_t _value);
+    RENDER_API bool WaitSubmitted(
+        uint64_t               _value,
+        const std::atomic_bool* _continue_waiting = nullptr
+    );
     VkResult HostWait(
         uint64_t                      _value,
         const VulkanOperationContext& _context = VulkanOperationContext{}
     );
-    void  Fail(VkResult _result);
-    bool  IsFailed() const;
+    RENDER_API void Fail(VkResult _result);
+    RENDER_API bool IsFailed() const;
     void  SignalHost(uint64_t _value);
     auto& GetFence() {
         return timeline;

--- a/source/runtime/render/rhi/vulkan/VulkanSubmissionExecutor.cpp
+++ b/source/runtime/render/rhi/vulkan/VulkanSubmissionExecutor.cpp
@@ -3,6 +3,7 @@
 #include "log/LogSystem.h"
 #include "platform/Platform.h"
 #include "rhi/RHI.h"
+#include "rhi/RHIThreadOwnership.h"
 #include "VulkanDevice.h"
 #include "VulkanQueue.h"
 
@@ -218,13 +219,79 @@ void ResolveRejectedPresent(std::optional<RHIPresentRequest>& _present) {
 
 } // namespace
 
-VulkanSubmissionExecutor::VulkanSubmissionExecutor() :
-    thread([this] { Run(); }) {
-    LOG_INFO("[RHIExecutor][Vulkan] streaming runtime started window=1");
+VulkanSubmissionExecutor::VulkanSubmissionExecutor() {
+    auto& graphics_queue = static_cast<VkCommandQueue&>(
+        RenderDevice::Get().GetCommandQueue(EQueueType::Graphics)
+    );
+    auto& compute_queue = static_cast<VkCommandQueue&>(
+        RenderDevice::Get().GetCommandQueue(EQueueType::Compute)
+    );
+    auto& copy_queue =
+        static_cast<VkCopyQueue&>(RenderDevice::Get().GetCopyQueue());
+    bool graphics_claimed = false;
+    bool compute_claimed  = false;
+    try {
+        graphics_claimed = graphics_queue.ClaimRuntimeOwnership();
+        if (!graphics_claimed) {
+            throw std::runtime_error(
+                "Vulkan Graphics queue ownership conflicts with legacy execution"
+            );
+        }
+        compute_claimed = compute_queue.ClaimRuntimeOwnership();
+        if (!compute_claimed) {
+            throw std::runtime_error(
+                "Vulkan Compute queue ownership conflicts with legacy execution"
+            );
+        }
+        copy_queue.EnableRuntimeDependencyWaits();
+        claims_owned = true;
+
+        submission_thread = std::jthread([this] { RunSubmission(); });
+        executor_thread   = std::jthread([this] { RunExecutor(); });
+        LOG_INFO(
+            "[RHIExecutor][Vulkan] ownership runtime started "
+            "Executor=1 Translate=1 Submission=1 window=1"
+        );
+    } catch (...) {
+        graphics_queue.CancelRuntimeDependencyWaits();
+        compute_queue.CancelRuntimeDependencyWaits();
+        copy_queue.CancelRuntimeDependencyWaits();
+        if (executor_thread.joinable()) {
+            {
+                std::lock_guard lock(mutex);
+                accepting        = false;
+                constructor_abort = true;
+            }
+            cv.notify_all();
+            executor_thread.join();
+        }
+        if (submission_thread.joinable()) {
+            StopSubmissionThread();
+        }
+        if (compute_claimed) {
+            compute_queue.ReleaseRuntimeOwnership();
+        }
+        if (graphics_claimed) {
+            graphics_queue.ReleaseRuntimeOwnership();
+        }
+        claims_owned = false;
+        throw;
+    }
 }
 
 VulkanSubmissionExecutor::~VulkanSubmissionExecutor() {
     ShutDown();
+    if (claims_owned) {
+        auto& graphics_queue = static_cast<VkCommandQueue&>(
+            RenderDevice::Get().GetCommandQueue(EQueueType::Graphics)
+        );
+        auto& compute_queue = static_cast<VkCommandQueue&>(
+            RenderDevice::Get().GetCommandQueue(EQueueType::Compute)
+        );
+        compute_queue.ReleaseRuntimeOwnership();
+        graphics_queue.ReleaseRuntimeOwnership();
+        claims_owned = false;
+    }
 }
 
 void VulkanSubmissionExecutor::Completion::Signal() {
@@ -290,31 +357,74 @@ void VulkanSubmissionExecutor::Flush(ERHIFlushDepth) {
     cv.notify_one();
 }
 
+void VulkanSubmissionExecutor::BeginShutdown() noexcept {
+    try {
+        auto& graphics_queue = static_cast<VkCommandQueue&>(
+            RenderDevice::Get().GetCommandQueue(EQueueType::Graphics)
+        );
+        auto& compute_queue = static_cast<VkCommandQueue&>(
+            RenderDevice::Get().GetCommandQueue(EQueueType::Compute)
+        );
+        auto& copy_queue =
+            static_cast<VkCopyQueue&>(RenderDevice::Get().GetCopyQueue());
+
+        // A Submission owner can be blocked waiting for a producer timeline
+        // which shutdown has stopped admitting. Publish cancellation without
+        // waiting for the backend FIFO so concurrent Sync calls can drain.
+        graphics_queue.CancelRuntimeDependencyWaits();
+        compute_queue.CancelRuntimeDependencyWaits();
+        copy_queue.CancelRuntimeDependencyWaits();
+    } catch (...) {
+        // RenderDevice queue access is expected to remain valid until backend
+        // destruction. Keep this hook noexcept so lifecycle cleanup can still
+        // advance if that contract is broken by an exceptional teardown.
+    }
+}
+
 void VulkanSubmissionExecutor::ShutDown() {
+    BeginShutdown();
     std::shared_ptr<Completion> completion{};
     bool                        join_owner = false;
+
+    // Allocate the candidate stop completion before mutating shared lifecycle
+    // state. A failed allocation must leave the runtime fully retryable.
     {
         std::lock_guard lock(mutex);
         if (stopped) {
             return;
         }
-        accepting = false;
+        completion = stop_completion;
+    }
+    std::shared_ptr<Completion> candidate{};
+    if (!completion) {
+        candidate = std::make_shared<Completion>();
+    }
+
+    {
+        std::lock_guard lock(mutex);
+        if (stopped) {
+            return;
+        }
         if (!stop_completion) {
-            stop_completion = std::make_shared<Completion>();
-            requests.emplace_back(Request{
+            Request stop_request{
                 .kind       = ERequestKind::Stop,
                 .sync_depth = ERHISyncDepth::Present,
-                .completion = stop_completion,
-            });
+                .completion = candidate,
+            };
+            // deque insertion has the strong exception guarantee. Publish the
+            // shared stop state only after the request is owned by the FIFO.
+            requests.emplace_back(std::move(stop_request));
+            stop_completion = candidate;
             join_owner = true;
         }
+        accepting = false;
         completion = stop_completion;
     }
     cv.notify_one();
     completion->Wait();
     if (join_owner) {
-        if (thread.joinable()) {
-            thread.join();
+        if (executor_thread.joinable()) {
+            executor_thread.join();
         }
         {
             std::lock_guard lock(mutex);
@@ -328,13 +438,19 @@ void VulkanSubmissionExecutor::ShutDown() {
     cv.wait(lock, [this] { return stopped; });
 }
 
-void VulkanSubmissionExecutor::Run() {
-    Platform::SetCurrentThreadName("Moer Vulkan Submit");
+void VulkanSubmissionExecutor::RunExecutor() {
+    Platform::SetCurrentThreadName("Moer Vulkan Translate");
+    RHIThreadRoleScope owner_scope(ERHIThreadRole::Translate);
     while (true) {
         Request request{};
         {
             std::unique_lock lock(mutex);
-            cv.wait(lock, [this] { return !requests.empty(); });
+            cv.wait(lock, [this] {
+                return constructor_abort || !requests.empty();
+            });
+            if (constructor_abort && requests.empty()) {
+                break;
+            }
             request = std::move(requests.front());
             requests.pop_front();
         }
@@ -372,6 +488,55 @@ void VulkanSubmissionExecutor::Run() {
         if (dispatch_result.stop) {
             break;
         }
+    }
+    StopSubmissionThread();
+}
+
+bool VulkanSubmissionExecutor::EnqueueSubmissionWork(SubmissionWork&& _work) {
+    {
+        std::lock_guard lock(submission_mutex);
+        if (!submission_accepting) {
+            return false;
+        }
+        submission_work.emplace_back(std::move(_work));
+    }
+    submission_cv.notify_one();
+    return true;
+}
+
+void VulkanSubmissionExecutor::RunSubmission() {
+    Platform::SetCurrentThreadName("Moer Vulkan Submission");
+    RHIThreadRoleScope owner_scope(ERHIThreadRole::Submission);
+    for (;;) {
+        SubmissionWork work{};
+        {
+            std::unique_lock lock(submission_mutex);
+            submission_cv.wait(lock, [this] {
+                return !submission_accepting || !submission_work.empty();
+            });
+            if (submission_work.empty()) {
+                assert(!submission_accepting);
+                break;
+            }
+            work = std::move(submission_work.front());
+            submission_work.pop_front();
+        }
+        if (work.execute.valid()) {
+            // packaged_task captures exceptions and publishes them to the
+            // waiting Translate owner; none may escape this service thread.
+            work.execute();
+        }
+    }
+}
+
+void VulkanSubmissionExecutor::StopSubmissionThread() {
+    {
+        std::lock_guard lock(submission_mutex);
+        submission_accepting = false;
+    }
+    submission_cv.notify_all();
+    if (submission_thread.joinable()) {
+        submission_thread.join();
     }
 }
 
@@ -543,6 +708,22 @@ void VulkanSubmissionExecutor::ProcessBatch(
         );
         _exception_state.first_unconsumed_source = _batch.submits.size();
     };
+    auto reject_remaining_recoverable =
+        [&](size_t _begin, VkResult _result, std::string_view _reason) {
+            if (_result == VK_SUCCESS) {
+                _result = VK_ERROR_UNKNOWN;
+            }
+            _exception_state.first_unconsumed_source =
+                std::min(_begin, _batch.submits.size());
+            RejectBatch(
+                std::move(_batch),
+                static_cast<int32>(_result),
+                _reason,
+                _exception_state.first_unconsumed_source,
+                &_exception_state.first_unconsumed_source
+            );
+            _exception_state.first_unconsumed_source = _batch.submits.size();
+        };
 
     // Keep every source in the request-owned batch until its queue call has
     // returned. If reorder, descriptor-lease, allocator, or native recording
@@ -577,7 +758,11 @@ void VulkanSubmissionExecutor::ProcessBatch(
         if (entry.queue == EQueueType::Copy) {
             auto& copy_queue = static_cast<VkCopyQueue&>(RenderDevice::Get().GetCopyQueue());
             const VulkanRuntimeSubmissionResult submit_result =
-                copy_queue.ExecuteForRuntime(std::move(entry.submit));
+                ExecuteOnSubmissionThread(
+                    [&copy_queue, submit = &entry.submit]() mutable {
+                        return copy_queue.ExecuteForRuntime(std::move(*submit));
+                    }
+                );
             // ExecuteForRuntime has now either submitted or terminalized this
             // source. Never reject it again if later bookkeeping/logging throws.
             _exception_state.first_unconsumed_source = source_index + 1;
@@ -589,6 +774,18 @@ void VulkanSubmissionExecutor::ProcessBatch(
                 ordered_gpu_tail   = *submit_result.completion;
                 ordered_tail_queue = EQueueType::Copy;
                 used_queues[static_cast<size_t>(EQueueType::Copy)] = true;
+            } else if (submit_result.IsRecoverableRejection()) {
+                // A failed prerequisite did not reach vkQueueSubmit. Drain the
+                // current source on Completion, reject the rest of this
+                // topology batch, and keep the runtime available for a later
+                // independent batch.
+                used_queues[static_cast<size_t>(EQueueType::Copy)] = true;
+                reject_remaining_recoverable(
+                    source_index + 1,
+                    submit_result.outcome.result,
+                    "Copy submission dependency rejection"
+                );
+                return;
             } else if (submit_result.IsHardFailure()) {
                 LOG_ERROR(
                     "[RHIExecutor][Vulkan] batch={} Copy submission failed status={} result={}",
@@ -597,11 +794,8 @@ void VulkanSubmissionExecutor::ProcessBatch(
                     static_cast<int32>(submit_result.outcome.result)
                 );
                 // A failed native Copy submit still publishes a CPU retirement
-                // marker. Preserve its logical timeline so a later Sync drains
-                // callbacks and allocator quarantine before device teardown.
-                last_copy_timeline = std::max(
-                    last_copy_timeline, static_cast<uint64>(copy_queue.last_frame)
-                );
+                // marker. ProcessSync always enters Copy Sync, whose independent
+                // retirement serial drains it without reading Copy-owner state.
                 used_queues[static_cast<size_t>(EQueueType::Copy)] = true;
                 reject_remaining(
                     source_index + 1,
@@ -635,8 +829,26 @@ void VulkanSubmissionExecutor::ProcessBatch(
                 );
                 return;
             }
-            const VulkanRuntimeSubmissionResult submit_result =
-                queue.SubmitRecordedForRuntime(std::move(*recorded));
+            VulkanRuntimeSubmissionResult submit_result{};
+            try {
+                submit_result = ExecuteOnSubmissionThread(
+                    [&queue, packet = &*recorded]() mutable {
+                        return queue.SubmitRecordedForRuntime(std::move(*packet));
+                    }
+                );
+            } catch (...) {
+                ReportRequestFailure(
+                    ERequestKind::Submit,
+                    VulkanSubmissionDetail::EWorkerRequestFailurePhase::Process,
+                    std::current_exception()
+                );
+                queue.RejectRecordedForRuntime(
+                    std::move(*recorded), VK_ERROR_UNKNOWN
+                );
+                submit_result.outcome = {
+                    EVulkanOperationStatus::Rejected, VK_ERROR_UNKNOWN
+                };
+            }
             // SubmitRecordedForRuntime owns the recorded packet through its
             // terminal result, including native rejection.
             _exception_state.first_unconsumed_source = source_index + 1;
@@ -645,6 +857,13 @@ void VulkanSubmissionExecutor::ProcessBatch(
                 ordered_gpu_tail   = *submit_result.completion;
                 ordered_tail_queue = entry.queue;
                 used_queues[static_cast<size_t>(entry.queue)] = true;
+            } else if (submit_result.IsRecoverableRejection()) {
+                reject_remaining_recoverable(
+                    source_index + 1,
+                    submit_result.outcome.result,
+                    "command submission dependency rejection"
+                );
+                return;
             } else if (submit_result.IsHardFailure()) {
                 LOG_ERROR(
                     "[RHIExecutor][Vulkan] batch={} source_queue={} submission failed "
@@ -686,8 +905,28 @@ void VulkanSubmissionExecutor::ProcessBatch(
                 );
                 return;
             }
-            const VulkanRuntimeSubmissionResult bridge_result =
-                graphics_queue.SubmitRecordedForRuntime(std::move(*recorded));
+            VulkanRuntimeSubmissionResult bridge_result{};
+            try {
+                bridge_result = ExecuteOnSubmissionThread(
+                    [&graphics_queue, packet = &*recorded]() mutable {
+                        return graphics_queue.SubmitRecordedForRuntime(
+                            std::move(*packet)
+                        );
+                    }
+                );
+            } catch (...) {
+                ReportRequestFailure(
+                    ERequestKind::Submit,
+                    VulkanSubmissionDetail::EWorkerRequestFailurePhase::Process,
+                    std::current_exception()
+                );
+                graphics_queue.RejectRecordedForRuntime(
+                    std::move(*recorded), VK_ERROR_UNKNOWN
+                );
+                bridge_result.outcome = {
+                    EVulkanOperationStatus::Rejected, VK_ERROR_UNKNOWN
+                };
+            }
             if (!bridge_result.WasSubmitted()) {
                 LOG_ERROR(
                     "[RHIExecutor][Vulkan] batch={} Present bridge failed status={} result={}",
@@ -695,11 +934,19 @@ void VulkanSubmissionExecutor::ProcessBatch(
                     static_cast<uint32>(bridge_result.outcome.status),
                     static_cast<int32>(bridge_result.outcome.result)
                 );
-                reject_remaining(
-                    _batch.submits.size(),
-                    bridge_result.outcome.result,
-                    "Present bridge submission failure"
-                );
+                if (bridge_result.IsRecoverableRejection()) {
+                    reject_remaining_recoverable(
+                        _batch.submits.size(),
+                        bridge_result.outcome.result,
+                        "Present bridge dependency rejection"
+                    );
+                } else {
+                    reject_remaining(
+                        _batch.submits.size(),
+                        bridge_result.outcome.result,
+                        "Present bridge submission failure"
+                    );
+                }
                 return;
             }
             assert(bridge_result.completion.has_value());
@@ -707,13 +954,16 @@ void VulkanSubmissionExecutor::ProcessBatch(
             ordered_tail_queue = EQueueType::Graphics;
             used_queues[static_cast<size_t>(EQueueType::Graphics)] = true;
         }
-        const VulkanRuntimeSubmissionResult present_result = graphics_queue.PresentForRuntime(
-            std::move(present.swapchain),
-            present.source,
-            // Keep the request's receipt reference until PresentForRuntime
-            // returns. If it throws after taking its by-value copy, Run can
-            // still resolve this retained receipt through RejectBatch.
-            present.receipt
+        const VulkanRuntimeSubmissionResult present_result = ExecuteOnSubmissionThread(
+            [&graphics_queue, present = &present]() mutable {
+                return graphics_queue.PresentForRuntime(
+                    std::move(present->swapchain),
+                    present->source,
+                    // Keep the request's receipt copy until the Submission
+                    // owner returns so the exception barrier can resolve it.
+                    present->receipt
+                );
+            }
         );
         // PresentForRuntime has now terminalized or retained the copied receipt.
         // Clear the request copy before any later diagnostic/bookkeeping can
@@ -749,23 +999,21 @@ void VulkanSubmissionExecutor::ProcessBatch(
 }
 
 void VulkanSubmissionExecutor::ProcessSync(ERHISyncDepth _depth) {
-    LOG_INFO(
-        "[RHIExecutor][Vulkan] sync begin depth={} gfx={} compute={} copy_timeline={}",
-        static_cast<uint32>(_depth),
-        used_queues[static_cast<size_t>(EQueueType::Graphics)],
-        used_queues[static_cast<size_t>(EQueueType::Compute)],
-        last_copy_timeline
-    );
-    if (used_queues[static_cast<size_t>(EQueueType::Graphics)] ||
-        _depth == ERHISyncDepth::Present) {
+    ExecuteOnSubmissionThread([this, _depth] {
+        LOG_INFO(
+            "[RHIExecutor][Vulkan] sync begin depth={} gfx={} compute={} copy_timeline={}",
+            static_cast<uint32>(_depth),
+            used_queues[static_cast<size_t>(EQueueType::Graphics)],
+            used_queues[static_cast<size_t>(EQueueType::Compute)],
+            last_copy_timeline
+        );
+        // Runtime-side rejections deliberately own no GPU timeline.  Drain
+        // every Completion queue by its independent CPU retirement serial so
+        // Sync also observes callbacks/fence failure for those packets.
         RenderDevice::Get().GetCommandQueue(EQueueType::Graphics).Sync();
-    }
-    if (used_queues[static_cast<size_t>(EQueueType::Compute)]) {
         RenderDevice::Get().GetCommandQueue(EQueueType::Compute).Sync();
-    }
-    if (last_copy_timeline != 0) {
         RenderDevice::Get().GetCopyQueue().Sync(last_copy_timeline);
-    }
+    });
     ordered_gpu_tail.reset();
     ordered_tail_queue.reset();
     used_queues.fill(false);

--- a/source/runtime/render/rhi/vulkan/VulkanSubmissionExecutor.h
+++ b/source/runtime/render/rhi/vulkan/VulkanSubmissionExecutor.h
@@ -6,16 +6,21 @@
 #include <condition_variable>
 #include <deque>
 #include <exception>
+#include <future>
 #include <memory>
 #include <mutex>
+#include <stdexcept>
 #include <string_view>
 #include <thread>
+#include <type_traits>
+#include <utility>
 
 namespace Moer::Render {
 
-// Owns the upper RHI submission stream for Vulkan. Translation remains
-// streaming (one source submission at a time) so descriptor leases can retire
-// while later work is being prepared; native queue submission order is stable.
+// Owns the upper RHI submission stream for Vulkan. The translate owner prepares
+// one source at a time, then transfers its move-only packet to the sole native
+// Submission owner. The conservative one-packet window preserves the current
+// failure and queue-ordering semantics while making thread ownership explicit.
 class VulkanSubmissionExecutor final : public RHIBackendExecutor {
 public:
     VulkanSubmissionExecutor();
@@ -24,6 +29,7 @@ public:
     void          Enqueue(RHIBackendSubmissionBatch&& _batch) override;
     GraphEventRef Sync(ERHISyncDepth _depth = ERHISyncDepth::RHI) override;
     void          Flush(ERHIFlushDepth _depth = ERHIFlushDepth::SubmitGPU) override;
+    void          BeginShutdown() noexcept override;
     void          ShutDown() override;
 
 private:
@@ -52,7 +58,37 @@ private:
         size_t first_unconsumed_source{0};
     };
 
-    void Run();
+    struct SubmissionWork {
+        std::packaged_task<void()> execute{};
+    };
+
+    void RunExecutor();
+    void RunSubmission();
+    bool EnqueueSubmissionWork(SubmissionWork&& _work);
+    void StopSubmissionThread();
+
+    template<typename Function>
+    auto ExecuteOnSubmissionThread(Function&& _function)
+        -> std::invoke_result_t<Function> {
+        using Result = std::invoke_result_t<Function>;
+
+        std::packaged_task<Result()> typed_task(std::forward<Function>(_function));
+        std::future<Result>          result = typed_task.get_future();
+        SubmissionWork work{
+            .execute = std::packaged_task<void()>(
+                [task = std::move(typed_task)]() mutable { task(); }
+            ),
+        };
+        if (!EnqueueSubmissionWork(std::move(work))) {
+            throw std::runtime_error("Vulkan Submission owner is not accepting work");
+        }
+        if constexpr (std::is_void_v<Result>) {
+            result.get();
+        } else {
+            return result.get();
+        }
+    }
+
     void ProcessBatch(
         RHIBackendSubmissionBatch& _batch,
         BatchExceptionState&       _exception_state
@@ -75,9 +111,11 @@ private:
     std::mutex                 mutex{};
     std::condition_variable    cv{};
     std::deque<Request>        requests{};
-    std::jthread               thread{};
+    std::jthread               executor_thread{};
     bool                       accepting{true};
+    bool                       constructor_abort{false};
     bool                       stopped{false};
+    bool                       claims_owned{false};
     bool                       hard_failed{false};
     bool                       logged_multi_source_topology{false};
     int32                      hard_failure_result{0};
@@ -86,6 +124,12 @@ private:
     uint64                     last_copy_timeline{0};
     std::optional<EQueueType>  ordered_tail_queue{};
     std::optional<WaitEvent>   ordered_gpu_tail{};
+
+    std::mutex                 submission_mutex{};
+    std::condition_variable    submission_cv{};
+    std::deque<SubmissionWork> submission_work{};
+    std::jthread               submission_thread{};
+    bool                       submission_accepting{true};
 };
 
 } // namespace Moer::Render

--- a/source/runtime/render/rhi/vulkan/VulkanSwapChain.cpp
+++ b/source/runtime/render/rhi/vulkan/VulkanSwapChain.cpp
@@ -13,6 +13,7 @@
 #include "rhi/RHICommon.h"
 #include "rhi/RHIResource.h"
 #include "rhi/RHIResourceInitilizer.h"
+#include "rhi/RHIThreadOwnership.h"
 
 #include "VulkanPlatform.h"
 
@@ -598,44 +599,60 @@ void VkSwapchain::EnqueuePresent(uint64 _present_idx) {
     cur_present_cnt.fetch_add(1, std::memory_order_acq_rel);
     auto& thread = present_threads[_present_idx % max_frames_in_flight];
     assert(!thread.joinable() && "Present fence slot must be retired before reuse");
-    thread = std::jthread([this, _present_idx]() {
-        const uint64 frame_index = _present_idx % max_frames_in_flight;
-        while (!device.IsDeviceLost()) {
-            const VulkanOperationContext wait_context{
-                .operation  = EVulkanFaultOperation::PresentFenceWait,
-                .queue_type = EQueueType::Graphics,
-                .queue      = device.GetPresentQueue(),
-                .timeline   = _present_idx,
-            };
-            const VkResult result = vkWaitForFences(
-                device.GetDevice(), 1, &in_flight_fences[frame_index], VK_TRUE, 50'000'000
-            );
-            if (result == VK_TIMEOUT) {
-                continue;
-            }
-            if (result == VK_SUCCESS && !device.IsDeviceLost()) {
-                const VkResult reset_result = device.ResetFence(
-                    in_flight_fences[frame_index],
-                    VulkanOperationContext{
-                        .operation  = EVulkanFaultOperation::PresentFenceReset,
-                        .queue_type = EQueueType::Graphics,
-                        .queue      = device.GetPresentQueue(),
-                        .timeline   = _present_idx,
-                    }
+    try {
+        thread = std::jthread([this, _present_idx]() {
+            RHIThreadRoleScope owner_scope(ERHIThreadRole::Completion);
+            const uint64 frame_index = _present_idx % max_frames_in_flight;
+            while (!device.IsDeviceLost()) {
+                const VulkanOperationContext wait_context{
+                    .operation  = EVulkanFaultOperation::PresentFenceWait,
+                    .queue_type = EQueueType::Graphics,
+                    .queue      = device.GetPresentQueue(),
+                    .timeline   = _present_idx,
+                };
+                const VkResult result = vkWaitForFences(
+                    device.GetDevice(),
+                    1,
+                    &in_flight_fences[frame_index],
+                    VK_TRUE,
+                    50'000'000
                 );
-                if (reset_result != VK_SUCCESS) {
-                    break;
+                if (result == VK_TIMEOUT) {
+                    continue;
                 }
-            } else if (result != VK_SUCCESS) {
-                device.TryLatchFirstFault(wait_context, result);
-                if (result != VK_ERROR_DEVICE_LOST) {
-                    device.EmergencyExitWithoutVulkanCleanup(wait_context, result);
+                if (result == VK_SUCCESS && !device.IsDeviceLost()) {
+                    const VkResult reset_result = device.ResetFence(
+                        in_flight_fences[frame_index],
+                        VulkanOperationContext{
+                            .operation  =
+                                EVulkanFaultOperation::PresentFenceReset,
+                            .queue_type = EQueueType::Graphics,
+                            .queue      = device.GetPresentQueue(),
+                            .timeline   = _present_idx,
+                        }
+                    );
+                    if (reset_result != VK_SUCCESS) {
+                        break;
+                    }
+                } else if (result != VK_SUCCESS) {
+                    device.TryLatchFirstFault(wait_context, result);
+                    if (result != VK_ERROR_DEVICE_LOST) {
+                        device.EmergencyExitWithoutVulkanCleanup(
+                            wait_context, result
+                        );
+                    }
                 }
+                break;
             }
-            break;
-        }
-        OnFinishPresent(_present_idx);
-    });
+            OnFinishPresent(_present_idx);
+        });
+    } catch (...) {
+        // vkQueuePresentKHR has already accepted this frame and incremented
+        // cur_present_cnt. Continuing without a waiter would make Sync hang
+        // forever and allow an in-flight present fence to be reused.
+        cur_present_cnt.fetch_sub(1, std::memory_order_acq_rel);
+        std::terminate();
+    }
 }
 
 void VkSwapchain::Sync() {

--- a/source/test/CMakeLists.txt
+++ b/source/test/CMakeLists.txt
@@ -82,6 +82,16 @@ target_link_libraries(${test_target}
 set_target_properties(${test_target} PROPERTIES FOLDER ${moer_test_folder})
 add_test(NAME RHIExecutorRecordingHandoffContract COMMAND $<TARGET_FILE:${test_target}>)
 
+# CPU-only ownership contract for the Executor -> Translate -> Submission ->
+# Completion pipeline and the move-only queue lease crossing Translate/Submit.
+set(test_target TestRHIThreadOwnership)
+add_executable(${test_target} "RHIThreadOwnershipTest.cpp")
+target_link_libraries(${test_target}
+    PRIVATE Moer::Render
+)
+set_target_properties(${test_target} PROPERTIES FOLDER ${moer_test_folder})
+add_test(NAME RHIThreadOwnershipContract COMMAND $<TARGET_FILE:${test_target}>)
+
 # CPU-only contract for the Vulkan recorder work heuristic. This uses RHI
 # command payloads but does not create a Vulkan instance or device.
 set(test_target TestVulkanParallelRecordWorkEstimator)

--- a/source/test/RHIExecutorRecordingHandoffTest.cpp
+++ b/source/test/RHIExecutorRecordingHandoffTest.cpp
@@ -1,4 +1,5 @@
 #include "rhi/RHIExecutor.h"
+#include "rhi/RHIThreadOwnership.h"
 
 #include <atomic>
 #include <chrono>
@@ -91,45 +92,52 @@ bool PerSourceGatesPreserveFifo() {
            );
 }
 
-bool InlineReadyWorkCannotBeOvertaken() {
+bool ReadyWorkUsesStableExecutorOwnerAndCannotBeOvertaken() {
     RHIExecutorRecordingHandoffQueue queue{};
     queue.Start();
 
     ResolutionLog log{};
     std::mutex block_mutex;
     std::condition_variable block_cv;
-    bool inline_entered = false;
-    bool release_inline = false;
+    bool first_entered = false;
+    bool release_first = false;
+    const std::thread::id caller_thread = std::this_thread::get_id();
+    std::thread::id first_owner{};
+    std::thread::id second_owner{};
+    ERHIThreadRole first_role{ERHIThreadRole::Unknown};
+    ERHIThreadRole second_role{ERHIThreadRole::Unknown};
 
-    std::jthread inline_thread([&] {
-        queue.RouteReady(RHIExecutorRecordingHandoffWork{
-            .prerequisites = {},
-            .resolve = [&](ERHIRecordingHandoffResult _result) {
-                {
-                    std::unique_lock lock(block_mutex);
-                    inline_entered = true;
-                    block_cv.notify_all();
-                    block_cv.wait(lock, [&] { return release_inline; });
-                }
-                log.Push(1, _result);
-            },
-        });
+    queue.RouteReady(RHIExecutorRecordingHandoffWork{
+        .prerequisites = {},
+        .resolve = [&](ERHIRecordingHandoffResult _result) {
+            {
+                std::unique_lock lock(block_mutex);
+                first_owner = std::this_thread::get_id();
+                first_role  = GetCurrentRHIThreadRole();
+                first_entered = true;
+                block_cv.notify_all();
+                block_cv.wait(lock, [&] { return release_first; });
+            }
+            log.Push(1, _result);
+        },
     });
 
     {
         std::unique_lock lock(block_mutex);
-        if (!block_cv.wait_for(lock, 2s, [&] { return inline_entered; })) {
-            release_inline = true;
+        if (!block_cv.wait_for(lock, 2s, [&] { return first_entered; })) {
+            release_first = true;
             block_cv.notify_all();
             queue.ShutDown();
-            return Expect(false, "inline ready work did not start");
+            return Expect(false, "ready work did not start on the Executor worker");
         }
     }
 
     auto completed_gate = RHIRecordingGate::Create(true);
     queue.EnqueueRecording(RHIExecutorRecordingHandoffWork{
         .prerequisites = {completed_gate},
-        .resolve = [&log](ERHIRecordingHandoffResult _result) {
+        .resolve = [&log, &second_owner, &second_role](ERHIRecordingHandoffResult _result) {
+            second_owner = std::this_thread::get_id();
+            second_role  = GetCurrentRHIThreadRole();
             log.Push(2, _result);
         },
     });
@@ -137,7 +145,7 @@ bool InlineReadyWorkCannotBeOvertaken() {
     if (!Expect(log.Snapshot().empty(), "recording work overtook active ready work")) {
         {
             std::lock_guard lock(block_mutex);
-            release_inline = true;
+            release_first = true;
         }
         block_cv.notify_all();
         queue.ShutDown();
@@ -146,17 +154,26 @@ bool InlineReadyWorkCannotBeOvertaken() {
 
     {
         std::lock_guard lock(block_mutex);
-        release_inline = true;
+        release_first = true;
     }
     block_cv.notify_all();
-    inline_thread.join();
 
     const bool completed = log.WaitForSize(2);
     const auto entries   = log.Snapshot();
     queue.ShutDown();
     return Expect(completed, "queued recording work did not run") &&
-           Expect(entries.size() == 2, "unexpected inline-order result count") &&
-           Expect(entries[0].first == 1 && entries[1].first == 2, "inline order changed");
+           Expect(entries.size() == 2, "unexpected ready-work result count") &&
+           Expect(entries[0].first == 1 && entries[1].first == 2, "ready-work order changed") &&
+           Expect(
+               first_owner != caller_thread && second_owner != caller_thread,
+               "accepted ready work ran on the caller thread"
+           ) &&
+           Expect(first_owner == second_owner, "ready work changed Executor owner thread") &&
+           Expect(
+               first_role == ERHIThreadRole::Executor &&
+                   second_role == ERHIThreadRole::Executor,
+               "ready work did not run under the Executor role"
+           );
 }
 
 bool FailedGateRejectsOnlyItsGroupAndPreservesFifo() {
@@ -453,15 +470,71 @@ bool ShutdownCancelsAnUnsignalledGate() {
     return okay;
 }
 
+bool ShutdownDrainsAcceptedReadyWork() {
+    RHIExecutorRecordingHandoffQueue queue{};
+    queue.Start();
+
+    ResolutionLog        log{};
+    std::mutex           mutex;
+    std::condition_variable cv;
+    bool                 first_entered{false};
+    bool                 release_first{false};
+
+    queue.RouteReady(RHIExecutorRecordingHandoffWork{
+        .resolve = [&](ERHIRecordingHandoffResult _result) {
+            {
+                std::unique_lock lock(mutex);
+                first_entered = true;
+                cv.notify_all();
+                cv.wait(lock, [&] { return release_first; });
+            }
+            log.Push(1, _result);
+        },
+    });
+    {
+        std::unique_lock lock(mutex);
+        if (!cv.wait_for(lock, 2s, [&] { return first_entered; })) {
+            release_first = true;
+            cv.notify_all();
+            queue.ShutDown();
+            return Expect(false, "ready shutdown head did not enter the Executor");
+        }
+    }
+    queue.RouteReady(RHIExecutorRecordingHandoffWork{
+        .resolve = [&log](ERHIRecordingHandoffResult _result) {
+            log.Push(2, _result);
+        },
+    });
+
+    std::jthread shutdown_thread([&] { queue.ShutDown(); });
+    {
+        std::lock_guard lock(mutex);
+        release_first = true;
+    }
+    cv.notify_all();
+    shutdown_thread.join();
+
+    const auto entries = log.Snapshot();
+    return Expect(entries.size() == 2, "shutdown dropped accepted ready work") &&
+           Expect(entries[0].first == 1 && entries[1].first == 2, "shutdown reordered ready work") &&
+           Expect(
+               entries[0].second == ERHIRecordingHandoffResult::Consume &&
+                   entries[1].second == ERHIRecordingHandoffResult::Consume,
+               "shutdown cancelled work that was already safe for the Executor to drain"
+           );
+}
+
 } // namespace
 
 int main() {
-    if (!PerSourceGatesPreserveFifo() || !InlineReadyWorkCannotBeOvertaken() ||
+    if (!PerSourceGatesPreserveFifo() ||
+        !ReadyWorkUsesStableExecutorOwnerAndCannotBeOvertaken() ||
         !FailedGateRejectsOnlyItsGroupAndPreservesFifo() ||
         !FailedRecordingDrainsCleanupExactlyOnce() ||
         !BlockingWaitReportsTerminalStatus() ||
         !ShutdownDrainsTerminalSourceBehindPendingHead() ||
-        !ShutdownCancelsAnUnsignalledGate()) {
+        !ShutdownCancelsAnUnsignalledGate() ||
+        !ShutdownDrainsAcceptedReadyWork()) {
         return EXIT_FAILURE;
     }
     std::cout << "RHIExecutor recording handoff contract passed\n";

--- a/source/test/RHIParallelRecordVulkanTest.cpp
+++ b/source/test/RHIParallelRecordVulkanTest.cpp
@@ -4,9 +4,15 @@
 #include "rhi/RHI.h"
 #include "rhi/RHICommand.h"
 #include "rhi/RHIExecutor.h"
+#include "rhi/RHIThreadOwnership.h"
+#include "rhi/vulkan/VulkanCustomCommand.h"
+#include "rhi/vulkan/VulkanQueue.h"
+#include "rhi/vulkan/VulkanRHIResource.h"
 #include "taskgraph/TaskSystem.h"
 
+#include <atomic>
 #include <array>
+#include <chrono>
 #include <cstddef>
 #include <cstdint>
 #include <cstring>
@@ -14,10 +20,12 @@
 #include <filesystem>
 #include <iostream>
 #include <mutex>
+#include <semaphore>
 #include <span>
 #include <stdexcept>
 #include <string>
 #include <string_view>
+#include <thread>
 #include <vector>
 
 using namespace Moer;
@@ -30,17 +38,63 @@ constexpr uint32 kIterations   = 24;
 constexpr uint32 kHeavyCopiesPerWave = 48;
 constexpr uint32 kHeavyCopyCount = kHeavyCopiesPerWave * 2;
 
+class TranslateProbeCommand final : public VkCustomDispatchCmd {
+public:
+    explicit TranslateProbeCommand(std::binary_semaphore* _translated) :
+        translated(_translated) {}
+
+    void Execute(const VkDispatchContext&) const override {
+        translated->release();
+    }
+
+    EQueueType GetQueueType() const override {
+        return EQueueType::Graphics;
+    }
+
+private:
+    std::span<const ResourceUsage> GetResourceUsages() const override {
+        return {};
+    }
+
+    std::binary_semaphore* translated;
+};
+
+class OneShotSemaphoreRelease final {
+public:
+    explicit OneShotSemaphoreRelease(std::binary_semaphore& _semaphore) :
+        semaphore(_semaphore) {}
+
+    ~OneShotSemaphoreRelease() {
+        Release();
+    }
+
+    OneShotSemaphoreRelease(const OneShotSemaphoreRelease&) = delete;
+    OneShotSemaphoreRelease& operator=(const OneShotSemaphoreRelease&) = delete;
+
+    void Release() noexcept {
+        if (!armed) {
+            return;
+        }
+        armed = false;
+        semaphore.release();
+    }
+
+private:
+    std::binary_semaphore& semaphore;
+    bool                   armed{true};
+};
+
 template<size_t N>
-Array<byte> OwnedBytes(const std::array<uint32, N>& _values) {
-    Array<byte> bytes(sizeof(uint32) * N);
+Array<Moer::byte> OwnedBytes(const std::array<uint32, N>& _values) {
+    Array<Moer::byte> bytes(sizeof(uint32) * N);
     std::memcpy(bytes.data(), _values.data(), bytes.size());
     return bytes;
 }
 
 template<size_t N>
-std::span<byte> WritableBytes(std::array<uint32, N>& _values) {
+std::span<Moer::byte> WritableBytes(std::array<uint32, N>& _values) {
     return {
-        reinterpret_cast<byte*>(_values.data()),
+        reinterpret_cast<Moer::byte*>(_values.data()),
         sizeof(uint32) * N,
     };
 }
@@ -387,6 +441,184 @@ void RunPendingSourceTopologyBatch() {
     );
 }
 
+void RunContinuousFrameInFlightRetirement() {
+    using namespace std::chrono_literals;
+
+    auto& device = RenderDevice::Get();
+
+    constexpr uint64 frame_count   = 16;
+    constexpr uint64 max_in_flight = s_queue_max_frame_in_flight;
+    constexpr size_t element_count = 32;
+    const EBufferUsageFlags usage =
+        EBufferUsageFlags::TRANSFER_SRC | EBufferUsageFlags::TRANSFER_DST;
+
+    BufferRef frame_output =
+        device.CreateBuffer<uint32>("continuous_frame_output", element_count, usage);
+    FenceRef frame_fence = device.CreateFence();
+
+    std::array<uint32, element_count> expected{};
+    std::array<uint32, element_count> readback{};
+    std::mutex                        callback_mutex{};
+    std::vector<uint64>               callback_order{};
+    uint64                            submitted_frame = 0;
+    std::binary_semaphore             blocked_callback_entered{0};
+    std::binary_semaphore             release_blocked_callback{0};
+    std::binary_semaphore             fourth_translate_reached{0};
+    OneShotSemaphoreRelease release_guard(release_blocked_callback);
+
+    try {
+        for (uint64 frame = 0; frame < frame_count; ++frame) {
+            // Match Renderer::PrepareRenderFrame(): allow three outstanding
+            // frames and wait only on the shared external completion fence.
+            // Deliberately do not call RHIExecutor::Sync() inside the loop.
+            if (submitted_frame >= max_in_flight) {
+                frame_fence->Wait(submitted_frame - max_in_flight);
+            }
+            if (frame == max_in_flight) {
+                if (!blocked_callback_entered.try_acquire_for(5s)) {
+                    throw std::runtime_error(
+                        "continuous frame-in-flight Completion callback did not block"
+                    );
+                }
+                // Make the capacity condition deterministic: the first three
+                // packets reached native submission while frame 1's ordinary
+                // Completion callback is still blocked.
+                std::atomic_bool continue_waiting_for_submission{true};
+                std::jthread submission_deadline(
+                    [&continue_waiting_for_submission](std::stop_token _stop) {
+                        const auto deadline =
+                            std::chrono::steady_clock::now() + 5s;
+                        while (!_stop.stop_requested() &&
+                               std::chrono::steady_clock::now() < deadline) {
+                            std::this_thread::sleep_for(10ms);
+                        }
+                        if (!_stop.stop_requested()) {
+                            continue_waiting_for_submission.store(
+                                false, std::memory_order_release
+                            );
+                        }
+                    }
+                );
+                const bool submitted = ResourceCast(frame_fence.Get())
+                                           ->WaitSubmitted(
+                                               submitted_frame,
+                                               &continue_waiting_for_submission
+                                           );
+                submission_deadline.request_stop();
+                submission_deadline.join();
+                if (!submitted) {
+                    throw std::runtime_error(
+                        "continuous frame-in-flight packets were not submitted "
+                        "before the deadline"
+                    );
+                }
+            }
+
+            std::array<uint32, element_count> frame_values{};
+            for (uint32 index = 0; index < frame_values.size(); ++index) {
+                frame_values[index] =
+                    0x68000000u + static_cast<uint32>(frame) * 4096u +
+                    index * 23u;
+            }
+            if (frame + 1 == frame_count) {
+                expected = frame_values;
+            }
+
+            CommandList commands(EQueueType::Graphics);
+            if (frame == max_in_flight) {
+                commands.AddCustomCommand(
+                    MakeUnique<TranslateProbeCommand>(&fourth_translate_reached),
+                    "ContinuousFrameTranslateProbe"
+                );
+            }
+            commands.CopyFrom(
+                OwnedBytes(frame_values),
+                frame_output->GetView(),
+                "ContinuousFrameUpload"
+            );
+            if (frame + 1 == frame_count) {
+                commands.CopyFrom(
+                    frame_output->GetView(),
+                    WritableBytes(readback),
+                    "ContinuousFrameReadback"
+                );
+            }
+            commands.AddCallback([&, completed_frame = frame + 1] {
+                {
+                    std::lock_guard lock(callback_mutex);
+                    callback_order.push_back(completed_frame);
+                }
+                if (completed_frame == 1) {
+                    blocked_callback_entered.release();
+                    release_blocked_callback.acquire();
+                }
+            });
+
+            submitted_frame = frame + 1;
+            CmdSubmit submit = commands.Submit();
+            submit.Signal(frame_fence.Get(), submitted_frame);
+            RHIExecutor::Get().Submit(
+                EQueueType::Graphics,
+                std::move(submit),
+                ERHIExecSubmitFlags::FlushGPU
+            );
+            if (frame == max_in_flight) {
+                const bool translated_while_completion_blocked =
+                    fourth_translate_reached.try_acquire_for(5s);
+                release_guard.Release();
+                if (!translated_while_completion_blocked) {
+                    throw std::runtime_error(
+                        "Completion callback blocked allocator pool reuse"
+                    );
+                }
+            }
+        }
+
+        frame_fence->Wait(frame_count);
+        RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
+
+        if (readback != expected) {
+            throw std::runtime_error(
+                "continuous frame-in-flight final GPU readback mismatch"
+            );
+        }
+        if (callback_order.size() != frame_count) {
+            throw std::runtime_error(
+                "continuous frame-in-flight callbacks did not all retire"
+            );
+        }
+        for (uint64 frame = 0; frame < frame_count; ++frame) {
+            if (callback_order[frame] != frame + 1) {
+                throw std::runtime_error(
+                    "continuous frame-in-flight callback ordering mismatch"
+                );
+            }
+        }
+    } catch (...) {
+        const std::exception_ptr failure = std::current_exception();
+        // Keep every callback capture and the external Vulkan fence alive
+        // until all accepted packets have retired. This avoids turning an
+        // assertion failure into use-after-free or semaphore-in-use noise.
+        release_guard.Release();
+        try {
+            RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
+        } catch (...) {
+            // Unwinding would destroy callback captures and the external
+            // Vulkan fence while accepted packets may still reference them.
+            std::terminate();
+        }
+        std::rethrow_exception(failure);
+    }
+
+    LOG_INFO(
+        "[TESTCASE][PASS] name=ContinuousFrameInFlightRetirement "
+        "frames={} max_in_flight={} intermediate_sync=0 shared_fence=1 "
+        "allocator_reuse=completion_pool overflow=true blocked_callback_frame=1",
+        frame_count,
+        max_in_flight
+    );
+}
+
 void RunCrossQueueTopologyBatch() {
     auto& device = RenderDevice::Get();
     constexpr size_t element_count = 32;
@@ -472,6 +704,348 @@ void RunCrossQueueTopologyBatch() {
     );
 }
 
+void RunRecoverableCopyDependencyRejection() {
+    auto& device = RenderDevice::Get();
+
+    FenceRef dependency     = device.CreateFence();
+    FenceRef rejected_done  = device.CreateFence();
+    FenceRef recovered_done = device.CreateFence();
+    ResourceCast(dependency.Get())->Fail(VK_ERROR_UNKNOWN);
+
+    BufferRef destination = device.CreateBuffer<uint32>(
+        "recoverable_copy_destination",
+        4,
+        EBufferUsageFlags::TRANSFER_SRC | EBufferUsageFlags::TRANSFER_DST
+    );
+    const std::array<uint32, 4> expected{17, 29, 43, 71};
+    std::array<uint32, 4>       readback{};
+    std::atomic<uint32>         rejected_callbacks{0};
+    std::atomic<uint32>         recovered_callbacks{0};
+    std::atomic<uint32>         recovered_success_callbacks{0};
+
+    CommandList rejected(EQueueType::Copy);
+    rejected.CopyFrom(
+        OwnedBytes(std::array<uint32, 4>{1, 2, 3, 4}),
+        destination->GetView(),
+        "RecoverableCopyRejected"
+    );
+    rejected.AddCallback([&] {
+        rejected_callbacks.fetch_add(1, std::memory_order_relaxed);
+    });
+    CmdSubmit rejected_submit = rejected.Submit();
+    rejected_submit.Wait(dependency.Get(), 1).Signal(rejected_done.Get(), 1);
+
+    CommandList recovered(EQueueType::Copy);
+    recovered.CopyFrom(
+        OwnedBytes(expected),
+        destination->GetView(),
+        "RecoverableCopyUpload"
+    );
+    recovered.CopyFrom(
+        destination->GetView(),
+        WritableBytes(readback),
+        "RecoverableCopyReadback"
+    );
+    recovered.AddCallback([&] {
+        recovered_callbacks.fetch_add(1, std::memory_order_relaxed);
+    });
+    recovered.AddSuccessCallback([&] {
+        recovered_success_callbacks.fetch_add(1, std::memory_order_relaxed);
+    });
+    CmdSubmit recovered_submit = recovered.Submit();
+    recovered_submit.Signal(recovered_done.Get(), 1);
+
+    RHIExecutor::Get().Submit(
+        EQueueType::Copy,
+        std::move(rejected_submit),
+        ERHIExecSubmitFlags::FlushGPU
+    );
+    RHIExecutor::Get().Submit(
+        EQueueType::Copy,
+        std::move(recovered_submit),
+        ERHIExecSubmitFlags::FlushGPU
+    );
+    RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
+
+    if (!ResourceCast(rejected_done.Get())->IsFailed()) {
+        throw std::runtime_error(
+            "recoverable Copy rejection did not fail its external signal"
+        );
+    }
+    if (ResourceCast(recovered_done.Get())->IsFailed() ||
+        readback != expected) {
+        throw std::runtime_error(
+            "Copy submission after a recoverable rejection did not complete"
+        );
+    }
+    if (rejected_callbacks.load(std::memory_order_acquire) != 1 ||
+        recovered_callbacks.load(std::memory_order_acquire) != 1 ||
+        recovered_success_callbacks.load(std::memory_order_acquire) != 1) {
+        throw std::runtime_error(
+            "recoverable Copy rejection callbacks retired incorrectly"
+        );
+    }
+
+    LOG_INFO(
+        "[TESTCASE][PASS] name=RecoverableCopyDependencyRejection "
+        "rejected=N recovered=N+1 owner=CopySubmission"
+    );
+}
+
+void RunRuntimeRejectCompletionOwnership() {
+    using namespace std::chrono_literals;
+
+    auto&    device        = RenderDevice::Get();
+    FenceRef dependency    = device.CreateFence();
+    FenceRef graphics_done = device.CreateFence();
+    FenceRef copy_done     = device.CreateFence();
+    BufferRef rejected_destination = device.CreateBuffer<uint32>(
+        "runtime_reject_destination",
+        4,
+        EBufferUsageFlags::TRANSFER_SRC | EBufferUsageFlags::TRANSFER_DST
+    );
+    ResourceCast(dependency.Get())->Fail(VK_ERROR_UNKNOWN);
+
+    std::atomic<uint32> ordinary_callbacks{0};
+    std::atomic<uint32> success_callbacks{0};
+    std::atomic<uint32> wrong_owner_callbacks{0};
+    std::atomic<uint32> signals_not_failed_before_callback{0};
+    std::atomic<uint32> completion_sync_guard_returns{0};
+    std::atomic<bool>   sync_started{false};
+    std::atomic<bool>   sync_returned{false};
+    std::atomic<bool>   returned_before_release{false};
+    std::atomic<bool>   helper_timed_out{false};
+    std::binary_semaphore copy_callback_entered{0};
+    std::binary_semaphore release_copy_callback{0};
+    std::binary_semaphore copy_callback_finished{0};
+
+    auto validate_completion_owner = [&] {
+        if (GetCurrentRHIThreadRole() != ERHIThreadRole::Completion) {
+            wrong_owner_callbacks.fetch_add(1, std::memory_order_relaxed);
+        }
+    };
+
+    CommandList graphics(EQueueType::Graphics);
+    graphics.CopyFrom(
+        OwnedBytes(std::array<uint32, 4>{1, 2, 3, 4}),
+        rejected_destination->GetView(),
+        "RuntimeRejectRecordedCopy"
+    );
+    graphics.AddCallback([&] {
+        validate_completion_owner();
+        device.GetCopyQueue().Sync(0);
+        completion_sync_guard_returns.fetch_add(1, std::memory_order_relaxed);
+        if (!ResourceCast(graphics_done.Get())->IsFailed()) {
+            signals_not_failed_before_callback.fetch_add(
+                1, std::memory_order_relaxed
+            );
+        }
+        ordinary_callbacks.fetch_add(1, std::memory_order_relaxed);
+    });
+    graphics.AddSuccessCallback([&] {
+        success_callbacks.fetch_add(1, std::memory_order_relaxed);
+    });
+    CmdSubmit graphics_submit = graphics.Submit();
+    graphics_submit.Wait(dependency.Get(), 1).Signal(graphics_done.Get(), 1);
+
+    CommandList copy(EQueueType::Copy);
+    copy.AddCallback([&] {
+        validate_completion_owner();
+        device.GetCommandQueue(EQueueType::Graphics).Sync();
+        completion_sync_guard_returns.fetch_add(1, std::memory_order_relaxed);
+        if (!ResourceCast(copy_done.Get())->IsFailed()) {
+            signals_not_failed_before_callback.fetch_add(
+                1, std::memory_order_relaxed
+            );
+        }
+        copy_callback_entered.release();
+        release_copy_callback.acquire();
+        ordinary_callbacks.fetch_add(1, std::memory_order_relaxed);
+        copy_callback_finished.release();
+    });
+    copy.AddSuccessCallback([&] {
+        success_callbacks.fetch_add(1, std::memory_order_relaxed);
+    });
+    CmdSubmit copy_submit = copy.Submit();
+    copy_submit.Signal(copy_done.Get(), 1);
+
+    std::jthread callback_gate([&] {
+        if (!copy_callback_entered.try_acquire_for(5s)) {
+            helper_timed_out.store(true, std::memory_order_release);
+            release_copy_callback.release();
+            return;
+        }
+        const auto sync_deadline = std::chrono::steady_clock::now() + 5s;
+        while (!sync_started.load(std::memory_order_acquire) &&
+               std::chrono::steady_clock::now() < sync_deadline) {
+            std::this_thread::yield();
+        }
+        if (!sync_started.load(std::memory_order_acquire)) {
+            helper_timed_out.store(true, std::memory_order_release);
+        }
+        std::this_thread::sleep_for(250ms);
+        returned_before_release.store(
+            sync_returned.load(std::memory_order_acquire),
+            std::memory_order_release
+        );
+        release_copy_callback.release();
+        if (!copy_callback_finished.try_acquire_for(5s)) {
+            helper_timed_out.store(true, std::memory_order_release);
+        }
+    });
+
+    Array<RHIBackendSubmissionBatchEntry> submits{};
+    submits.emplace_back(EQueueType::Graphics, std::move(graphics_submit));
+    submits.emplace_back(EQueueType::Copy, std::move(copy_submit));
+    RHIExecutor::Get().Submit(
+        std::move(submits), ERHIExecSubmitFlags::FlushGPU
+    );
+
+    sync_started.store(true, std::memory_order_release);
+    RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
+    sync_returned.store(true, std::memory_order_release);
+    callback_gate.join();
+
+    if (helper_timed_out.load(std::memory_order_acquire)) {
+        throw std::runtime_error("runtime rejection Completion callback timed out");
+    }
+    if (returned_before_release.load(std::memory_order_acquire)) {
+        throw std::runtime_error(
+            "RHI Sync returned before a rejected Copy packet retired on Completion"
+        );
+    }
+    if (ordinary_callbacks.load(std::memory_order_acquire) != 2 ||
+        success_callbacks.load(std::memory_order_acquire) != 0) {
+        throw std::runtime_error(
+            "runtime rejection callbacks did not retire exactly once"
+        );
+    }
+    if (wrong_owner_callbacks.load(std::memory_order_acquire) != 0) {
+        throw std::runtime_error(
+            "runtime rejection callback ran outside the Completion owner"
+        );
+    }
+    if (completion_sync_guard_returns.load(std::memory_order_acquire) != 2) {
+        throw std::runtime_error(
+            "Completion owner cross-queue Sync did not return without blocking"
+        );
+    }
+    if (signals_not_failed_before_callback.load(std::memory_order_acquire) != 0) {
+        throw std::runtime_error(
+            "runtime rejection callback ran before its signal fence failed"
+        );
+    }
+    if (!ResourceCast(graphics_done.Get())->IsFailed() ||
+        !ResourceCast(copy_done.Get())->IsFailed()) {
+        throw std::runtime_error(
+            "runtime rejection did not fail every external signal fence"
+        );
+    }
+
+    RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
+    if (ordinary_callbacks.load(std::memory_order_acquire) != 2 ||
+        success_callbacks.load(std::memory_order_acquire) != 0) {
+        throw std::runtime_error(
+            "a second Sync replayed runtime rejection callbacks"
+        );
+    }
+    LOG_INFO(
+        "[TESTCASE][PASS] name=RuntimeRejectCompletionOwnership "
+        "sources=2 queues=Graphics,Copy callback_owner=Completion "
+        "cross_queue_sync=guarded sync_retirement=serial"
+    );
+}
+
+void RunShutdownDependencyCancellation() {
+    using namespace std::chrono_literals;
+
+    auto& device = RenderDevice::Get();
+
+    FenceRef graphics_dependency = device.CreateFence();
+    FenceRef copy_dependency     = device.CreateFence();
+    FenceRef graphics_done       = device.CreateFence();
+    FenceRef copy_done           = device.CreateFence();
+    std::atomic<uint32> callbacks{0};
+    std::atomic<uint32> success_callbacks{0};
+    std::atomic<bool>   sync_returned{false};
+    std::binary_semaphore sync_started{0};
+
+    CommandList graphics(EQueueType::Graphics);
+    graphics.AddCallback([&] {
+        callbacks.fetch_add(1, std::memory_order_relaxed);
+    });
+    graphics.AddSuccessCallback([&] {
+        success_callbacks.fetch_add(1, std::memory_order_relaxed);
+    });
+    CmdSubmit graphics_submit = graphics.Submit();
+    graphics_submit.Wait(graphics_dependency.Get(), 1)
+        .Signal(graphics_done.Get(), 1);
+
+    CommandList copy(EQueueType::Copy);
+    copy.AddCallback([&] {
+        callbacks.fetch_add(1, std::memory_order_relaxed);
+    });
+    copy.AddSuccessCallback([&] {
+        success_callbacks.fetch_add(1, std::memory_order_relaxed);
+    });
+    CmdSubmit copy_submit = copy.Submit();
+    copy_submit.Wait(copy_dependency.Get(), 1).Signal(copy_done.Get(), 1);
+
+    RHIExecutor::Get().Submit(
+        EQueueType::Graphics,
+        std::move(graphics_submit),
+        ERHIExecSubmitFlags::FlushGPU
+    );
+    RHIExecutor::Get().Submit(
+        EQueueType::Copy,
+        std::move(copy_submit),
+        ERHIExecSubmitFlags::FlushGPU
+    );
+
+    std::jthread sync_waiter([&] {
+        sync_started.release();
+        RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
+        sync_returned.store(true, std::memory_order_release);
+    });
+    sync_started.acquire();
+    std::this_thread::sleep_for(100ms);
+    if (sync_returned.load(std::memory_order_acquire)) {
+        throw std::runtime_error(
+            "Sync returned before unpublished dependencies were cancelled"
+        );
+    }
+
+    // Both dependency values are intentionally never published. Shutdown must
+    // cancel Submission-owner host waits, terminalize both packets on their
+    // Completion owners, release a concurrent Sync, and join every service
+    // thread without a Shutdown <-> Sync dependency cycle.
+    RHIExecutor::ShutDown();
+    sync_waiter.join();
+
+    if (callbacks.load(std::memory_order_acquire) != 2 ||
+        success_callbacks.load(std::memory_order_acquire) != 0) {
+        throw std::runtime_error(
+            "shutdown dependency cancellation retired callbacks incorrectly"
+        );
+    }
+    if (!ResourceCast(graphics_done.Get())->IsFailed() ||
+        !ResourceCast(copy_done.Get())->IsFailed()) {
+        throw std::runtime_error(
+            "shutdown dependency cancellation did not fail external signals"
+        );
+    }
+    if (!sync_returned.load(std::memory_order_acquire)) {
+        throw std::runtime_error(
+            "shutdown dependency cancellation did not release concurrent Sync"
+        );
+    }
+
+    LOG_INFO(
+        "[TESTCASE][PASS] name=ShutdownDependencyCancellation "
+        "queues=Graphics,Copy dependency=unpublished concurrent_sync=drained"
+    );
+}
+
 } // namespace
 
 int main(int argc, const char** argv) {
@@ -510,7 +1084,13 @@ int main(int argc, const char** argv) {
         );
         RunUpperTopologyBatch();
         RunPendingSourceTopologyBatch();
+        RunContinuousFrameInFlightRetirement();
+        RunRecoverableCopyDependencyRejection();
         RunCrossQueueTopologyBatch();
+        RunRuntimeRejectCompletionOwnership();
+        // This explicitly stops the runtime and must remain the final test
+        // before device disposal.
+        RunShutdownDependencyCancellation();
 
         RenderDevice::Dispose();
         render_device_initialized = false;

--- a/source/test/RHIParallelRecordVulkanTest.cpp
+++ b/source/test/RHIParallelRecordVulkanTest.cpp
@@ -705,12 +705,14 @@ void RunCrossQueueTopologyBatch() {
 }
 
 void RunRecoverableCopyDependencyRejection() {
+    using namespace std::chrono_literals;
+
     auto& device = RenderDevice::Get();
 
-    FenceRef dependency     = device.CreateFence();
-    FenceRef rejected_done  = device.CreateFence();
-    FenceRef recovered_done = device.CreateFence();
-    ResourceCast(dependency.Get())->Fail(VK_ERROR_UNKNOWN);
+    FenceRef dependency      = device.CreateFence();
+    FenceRef shared_done     = device.CreateFence();
+    FenceRef stale_wait_done = device.CreateFence();
+    dependency->Reject(1);
 
     BufferRef destination = device.CreateBuffer<uint32>(
         "recoverable_copy_destination",
@@ -718,10 +720,42 @@ void RunRecoverableCopyDependencyRejection() {
         EBufferUsageFlags::TRANSFER_SRC | EBufferUsageFlags::TRANSFER_DST
     );
     const std::array<uint32, 4> expected{17, 29, 43, 71};
+    const std::array<uint32, 4> stale_values{101, 103, 107, 109};
     std::array<uint32, 4>       readback{};
+    std::atomic<uint32>         blocker_callbacks{0};
+    std::atomic<uint32>         blocker_success_callbacks{0};
     std::atomic<uint32>         rejected_callbacks{0};
+    std::atomic<uint32>         rejected_success_callbacks{0};
     std::atomic<uint32>         recovered_callbacks{0};
     std::atomic<uint32>         recovered_success_callbacks{0};
+    std::atomic<uint32>         stale_wait_callbacks{0};
+    std::atomic<uint32>         stale_wait_success_callbacks{0};
+    std::atomic<uint32>         dependent_callbacks{0};
+    std::atomic<uint32>         dependent_success_callbacks{0};
+    std::binary_semaphore       blocker_entered{0};
+    std::binary_semaphore       release_blocker{0};
+    OneShotSemaphoreRelease     release_guard(release_blocker);
+
+    try {
+        CommandList blocker(EQueueType::Copy);
+        blocker.AddCallback([&] {
+            blocker_callbacks.fetch_add(1, std::memory_order_relaxed);
+            blocker_entered.release();
+            release_blocker.acquire();
+        });
+        blocker.AddSuccessCallback([&] {
+            blocker_success_callbacks.fetch_add(1, std::memory_order_relaxed);
+        });
+        RHIExecutor::Get().Submit(
+            EQueueType::Copy,
+            blocker.Submit(),
+            ERHIExecSubmitFlags::FlushGPU
+        );
+        if (!blocker_entered.try_acquire_for(5s)) {
+            throw std::runtime_error(
+                "recoverable rejection test could not block Copy Completion"
+            );
+        }
 
     CommandList rejected(EQueueType::Copy);
     rejected.CopyFrom(
@@ -732,19 +766,17 @@ void RunRecoverableCopyDependencyRejection() {
     rejected.AddCallback([&] {
         rejected_callbacks.fetch_add(1, std::memory_order_relaxed);
     });
+    rejected.AddSuccessCallback([&] {
+        rejected_success_callbacks.fetch_add(1, std::memory_order_relaxed);
+    });
     CmdSubmit rejected_submit = rejected.Submit();
-    rejected_submit.Wait(dependency.Get(), 1).Signal(rejected_done.Get(), 1);
+    rejected_submit.Wait(dependency.Get(), 1).Signal(shared_done.Get(), 1);
 
     CommandList recovered(EQueueType::Copy);
     recovered.CopyFrom(
         OwnedBytes(expected),
         destination->GetView(),
         "RecoverableCopyUpload"
-    );
-    recovered.CopyFrom(
-        destination->GetView(),
-        WritableBytes(readback),
-        "RecoverableCopyReadback"
     );
     recovered.AddCallback([&] {
         recovered_callbacks.fetch_add(1, std::memory_order_relaxed);
@@ -753,7 +785,39 @@ void RunRecoverableCopyDependencyRejection() {
         recovered_success_callbacks.fetch_add(1, std::memory_order_relaxed);
     });
     CmdSubmit recovered_submit = recovered.Submit();
-    recovered_submit.Signal(recovered_done.Get(), 1);
+    recovered_submit.Signal(shared_done.Get(), 2);
+
+    CommandList stale_wait(EQueueType::Copy);
+    stale_wait.CopyFrom(
+        OwnedBytes(stale_values),
+        destination->GetView(),
+        "RejectedStaleTimelineWait"
+    );
+    stale_wait.AddCallback([&] {
+        stale_wait_callbacks.fetch_add(1, std::memory_order_relaxed);
+    });
+    stale_wait.AddSuccessCallback([&] {
+        stale_wait_success_callbacks.fetch_add(1, std::memory_order_relaxed);
+    });
+    CmdSubmit stale_wait_submit = stale_wait.Submit();
+    stale_wait_submit.Wait(shared_done.Get(), 1).Signal(
+        stale_wait_done.Get(), 1
+    );
+
+    CommandList dependent(EQueueType::Copy);
+    dependent.CopyFrom(
+        destination->GetView(),
+        WritableBytes(readback),
+        "RecoveredTimelineDependencyReadback"
+    );
+    dependent.AddCallback([&] {
+        dependent_callbacks.fetch_add(1, std::memory_order_relaxed);
+    });
+    dependent.AddSuccessCallback([&] {
+        dependent_success_callbacks.fetch_add(1, std::memory_order_relaxed);
+    });
+    CmdSubmit dependent_submit = dependent.Submit();
+    dependent_submit.Wait(shared_done.Get(), 2);
 
     RHIExecutor::Get().Submit(
         EQueueType::Copy,
@@ -765,30 +829,100 @@ void RunRecoverableCopyDependencyRejection() {
         std::move(recovered_submit),
         ERHIExecSubmitFlags::FlushGPU
     );
+    RHIExecutor::Get().Submit(
+        EQueueType::Copy,
+        std::move(stale_wait_submit),
+        ERHIExecSubmitFlags::FlushGPU
+    );
+    RHIExecutor::Get().Submit(
+        EQueueType::Copy,
+        std::move(dependent_submit),
+        ERHIExecSubmitFlags::FlushGPU
+    );
+
+    auto* shared_vk_fence = ResourceCast(shared_done.Get());
+    auto* stale_vk_fence  = ResourceCast(stale_wait_done.Get());
+    std::atomic_bool continue_waiting{true};
+    std::jthread publication_deadline(
+        [&continue_waiting](std::stop_token _stop) {
+            const auto deadline = std::chrono::steady_clock::now() + 5s;
+            while (!_stop.stop_requested() &&
+                   std::chrono::steady_clock::now() < deadline) {
+                std::this_thread::sleep_for(10ms);
+            }
+            if (!_stop.stop_requested()) {
+                continue_waiting.store(false, std::memory_order_release);
+            }
+        }
+    );
+    const bool stale_wait_submitted =
+        stale_vk_fence->WaitSubmitted(1, &continue_waiting);
+    publication_deadline.request_stop();
+    publication_deadline.join();
+    if (stale_wait_submitted || !stale_vk_fence->IsRejected(1)) {
+        throw std::runtime_error(
+            "Submission did not publish a rejected stale-value dependency "
+            "before Completion"
+        );
+    }
+    if (!shared_vk_fence->IsRejected(1) ||
+        !shared_vk_fence->WaitSubmitted(2) ||
+        shared_vk_fence->HostWait(2) != VK_SUCCESS ||
+        shared_vk_fence->HostWait(1) != VK_ERROR_UNKNOWN) {
+        throw std::runtime_error(
+            "reused external fence lost its exact rejection or accepted value"
+        );
+    }
+
+    release_guard.Release();
     RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
 
-    if (!ResourceCast(rejected_done.Get())->IsFailed()) {
+    if (!shared_vk_fence->IsRejected(1) ||
+        shared_vk_fence->IsRejected(2) ||
+        shared_vk_fence->IsFailed() ||
+        !stale_vk_fence->IsRejected(1) ||
+        stale_vk_fence->IsFailed()) {
         throw std::runtime_error(
-            "recoverable Copy rejection did not fail its external signal"
+            "recoverable Copy rejection poisoned the reusable external fence"
         );
     }
-    if (ResourceCast(recovered_done.Get())->IsFailed() ||
+    if (shared_vk_fence->WaitSubmitted(1) ||
+        !shared_vk_fence->WaitSubmitted(2) ||
+        shared_done->GetValue() < 2 ||
         readback != expected) {
         throw std::runtime_error(
-            "Copy submission after a recoverable rejection did not complete"
+            "reused external fence did not recover at its next timeline value"
         );
     }
-    if (rejected_callbacks.load(std::memory_order_acquire) != 1 ||
+    if (blocker_callbacks.load(std::memory_order_acquire) != 1 ||
+        blocker_success_callbacks.load(std::memory_order_acquire) != 1 ||
+        rejected_callbacks.load(std::memory_order_acquire) != 1 ||
+        rejected_success_callbacks.load(std::memory_order_acquire) != 0 ||
         recovered_callbacks.load(std::memory_order_acquire) != 1 ||
-        recovered_success_callbacks.load(std::memory_order_acquire) != 1) {
+        recovered_success_callbacks.load(std::memory_order_acquire) != 1 ||
+        stale_wait_callbacks.load(std::memory_order_acquire) != 1 ||
+        stale_wait_success_callbacks.load(std::memory_order_acquire) != 0 ||
+        dependent_callbacks.load(std::memory_order_acquire) != 1 ||
+        dependent_success_callbacks.load(std::memory_order_acquire) != 1) {
         throw std::runtime_error(
             "recoverable Copy rejection callbacks retired incorrectly"
         );
     }
+    } catch (...) {
+        const std::exception_ptr failure = std::current_exception();
+        release_guard.Release();
+        try {
+            RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
+        } catch (...) {
+            std::terminate();
+        }
+        std::rethrow_exception(failure);
+    }
 
     LOG_INFO(
         "[TESTCASE][PASS] name=RecoverableCopyDependencyRejection "
-        "rejected=N recovered=N+1 owner=CopySubmission"
+        "fence=reused rejected=N recovered=N+1 stale_wait=rejected "
+        "publication=Submission"
     );
 }
 
@@ -835,7 +969,7 @@ void RunRuntimeRejectCompletionOwnership() {
         validate_completion_owner();
         device.GetCopyQueue().Sync(0);
         completion_sync_guard_returns.fetch_add(1, std::memory_order_relaxed);
-        if (!ResourceCast(graphics_done.Get())->IsFailed()) {
+        if (!ResourceCast(graphics_done.Get())->IsRejected(1)) {
             signals_not_failed_before_callback.fetch_add(
                 1, std::memory_order_relaxed
             );
@@ -853,7 +987,7 @@ void RunRuntimeRejectCompletionOwnership() {
         validate_completion_owner();
         device.GetCommandQueue(EQueueType::Graphics).Sync();
         completion_sync_guard_returns.fetch_add(1, std::memory_order_relaxed);
-        if (!ResourceCast(copy_done.Get())->IsFailed()) {
+        if (!ResourceCast(copy_done.Get())->IsRejected(1)) {
             signals_not_failed_before_callback.fetch_add(
                 1, std::memory_order_relaxed
             );
@@ -935,10 +1069,12 @@ void RunRuntimeRejectCompletionOwnership() {
             "runtime rejection callback ran before its signal fence failed"
         );
     }
-    if (!ResourceCast(graphics_done.Get())->IsFailed() ||
-        !ResourceCast(copy_done.Get())->IsFailed()) {
+    if (!ResourceCast(graphics_done.Get())->IsRejected(1) ||
+        !ResourceCast(copy_done.Get())->IsRejected(1) ||
+        ResourceCast(graphics_done.Get())->IsFailed() ||
+        ResourceCast(copy_done.Get())->IsFailed()) {
         throw std::runtime_error(
-            "runtime rejection did not fail every external signal fence"
+            "runtime rejection did not terminalize the exact external signal value"
         );
     }
 
@@ -1028,10 +1164,12 @@ void RunShutdownDependencyCancellation() {
             "shutdown dependency cancellation retired callbacks incorrectly"
         );
     }
-    if (!ResourceCast(graphics_done.Get())->IsFailed() ||
-        !ResourceCast(copy_done.Get())->IsFailed()) {
+    if (!ResourceCast(graphics_done.Get())->IsRejected(1) ||
+        !ResourceCast(copy_done.Get())->IsRejected(1) ||
+        ResourceCast(graphics_done.Get())->IsFailed() ||
+        ResourceCast(copy_done.Get())->IsFailed()) {
         throw std::runtime_error(
-            "shutdown dependency cancellation did not fail external signals"
+            "shutdown dependency cancellation did not reject external signal values"
         );
     }
     if (!sync_returned.load(std::memory_order_acquire)) {

--- a/source/test/RHIThreadOwnershipTest.cpp
+++ b/source/test/RHIThreadOwnershipTest.cpp
@@ -1,0 +1,181 @@
+#include "rhi/RHIThreadOwnership.h"
+#include "taskgraph/GraphTask.h"
+#include "taskgraph/TaskGraph.h"
+
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <cstdlib>
+#include <iostream>
+#include <mutex>
+#include <thread>
+#include <type_traits>
+
+namespace {
+
+using namespace Moer::Render;
+using namespace std::chrono_literals;
+
+bool Expect(bool _condition, const char* _message) {
+    if (_condition) {
+        return true;
+    }
+    std::cerr << "RHIThreadOwnershipContract: " << _message << '\n';
+    return false;
+}
+
+bool RoleScopesNestAndRestore() {
+    bool okay = Expect(
+        GetCurrentRHIThreadRole() == ERHIThreadRole::Unknown,
+        "new threads must begin without an RHI owner role"
+    );
+    okay &= Expect(
+        IsRHIBlockingCallAllowedOnCurrentThread(),
+        "ordinary callers must be allowed to use blocking RHI lifecycle calls"
+    );
+
+    {
+        RHIThreadRoleScope executor_scope(ERHIThreadRole::Executor);
+        okay &= Expect(
+            GetCurrentRHIThreadRole() == ERHIThreadRole::Executor,
+            "executor scope did not publish its role"
+        );
+        okay &= Expect(
+            !IsRHIBlockingCallAllowedOnCurrentThread(),
+            "executor owner was allowed to self-join the RHI pipeline"
+        );
+        {
+            RHIThreadRoleScope submission_scope(ERHIThreadRole::Submission);
+            okay &= Expect(
+                GetCurrentRHIThreadRole() == ERHIThreadRole::Submission,
+                "nested submission scope did not override the role"
+            );
+        }
+        okay &= Expect(
+            GetCurrentRHIThreadRole() == ERHIThreadRole::Executor,
+            "nested scope did not restore the previous role"
+        );
+    }
+
+    return okay &&
+           Expect(
+               GetCurrentRHIThreadRole() == ERHIThreadRole::Unknown,
+               "outer scope did not restore the caller role"
+           );
+}
+
+bool EveryPipelineOwnerRejectsBlockingCalls() {
+    constexpr ERHIThreadRole owner_roles[] = {
+        ERHIThreadRole::Executor,
+        ERHIThreadRole::Translate,
+        ERHIThreadRole::Submission,
+        ERHIThreadRole::Completion,
+        ERHIThreadRole::RecordWorker,
+    };
+    for (ERHIThreadRole role : owner_roles) {
+        RHIThreadRoleScope role_scope(role);
+        if (!Expect(
+                !IsRHIBlockingCallAllowedOnCurrentThread(),
+                "an RHI stage owner was allowed to make a blocking lifecycle call"
+            )) {
+            return false;
+        }
+    }
+    return true;
+}
+
+bool LeaseTransfersAcrossThreadsAndRemainsExclusive() {
+    static_assert(
+        !std::is_copy_constructible_v<RHITransferableOwnershipGate::Lease> &&
+        !std::is_copy_assignable_v<RHITransferableOwnershipGate::Lease>
+    );
+    static_assert(
+        std::is_nothrow_move_constructible_v<RHITransferableOwnershipGate::Lease> &&
+        std::is_nothrow_move_assignable_v<RHITransferableOwnershipGate::Lease>
+    );
+
+    RHITransferableOwnershipGate gate{};
+    auto                         first_lease = gate.Acquire();
+
+    std::mutex              mutex;
+    std::condition_variable cv;
+    bool                    release_first{false};
+    std::atomic<bool>       contender_acquired{false};
+
+    std::jthread release_thread(
+        [lease = std::move(first_lease), &mutex, &cv, &release_first]() mutable {
+            std::unique_lock lock(mutex);
+            cv.wait(lock, [&release_first] { return release_first; });
+            lock.unlock();
+            lease.Release();
+        }
+    );
+    std::jthread contender([&] {
+        auto lease = gate.Acquire();
+        contender_acquired.store(true, std::memory_order_release);
+        cv.notify_all();
+    });
+
+    std::this_thread::sleep_for(30ms);
+    bool okay = Expect(
+        !contender_acquired.load(std::memory_order_acquire),
+        "a second owner entered before the transferred lease was released"
+    );
+    {
+        std::lock_guard lock(mutex);
+        release_first = true;
+    }
+    cv.notify_all();
+
+    {
+        std::unique_lock lock(mutex);
+        okay &= Expect(
+            cv.wait_for(lock, 2s, [&] {
+                return contender_acquired.load(std::memory_order_acquire);
+            }),
+            "cross-thread lease release did not wake the next owner"
+        );
+    }
+    return okay;
+}
+
+bool DedicatedOwnerCanWaitForTaskGraphCompletion() {
+    TaskGraph::Init();
+    GraphEventRef completed = GraphEvent::CreateGraphEvent();
+    completed->TryUnlockSubsequents();
+
+    std::atomic<bool> wait_completed{false};
+    std::exception_ptr wait_exception{};
+    std::jthread waiter([&] {
+        RHIThreadRoleScope executor_scope(ERHIThreadRole::Executor);
+        try {
+            completed->Wait(EThread::UNKNOWN_THREAD);
+            wait_completed.store(true, std::memory_order_release);
+        } catch (...) {
+            wait_exception = std::current_exception();
+        }
+    });
+    waiter.join();
+    TaskGraph::Shutdown();
+
+    return Expect(
+               wait_exception == nullptr,
+               "an unregistered dedicated owner could not wait for a GraphEvent"
+           ) &&
+           Expect(
+               wait_completed.load(std::memory_order_acquire),
+               "external GraphEvent wait did not observe completion"
+           );
+}
+
+} // namespace
+
+int main() {
+    if (!RoleScopesNestAndRestore() || !EveryPipelineOwnerRejectsBlockingCalls() ||
+        !LeaseTransfersAcrossThreadsAndRemainsExclusive() ||
+        !DedicatedOwnerCanWaitForTaskGraphCompletion()) {
+        return EXIT_FAILURE;
+    }
+    std::cout << "RHI thread ownership contract passed\n";
+    return EXIT_SUCCESS;
+}


### PR DESCRIPTION
## Summary

Implements phase 4 of the parallel RHI architecture: explicit Executor, Translate, Submission, and Completion thread ownership, adapted from `dev_parallel_rhi`/UE-style stage boundaries to the current `main` RDG, explicit resource-state/barrier/multi-queue model, and parallel CommandList recording.

## Architecture

- Routes both ready and recording-gated frontend work through one dedicated Executor FIFO.
- Splits Vulkan Translate/record from the sole native Submission owner for Graphics/Compute/Present; Copy has its own Submission owner.
- Transfers recorded submits as move-only packets containing command buffers, allocators, descriptor leases, signals/callbacks, deferred releases, and a transferable queue ownership lease.
- Retires submit/present packets atomically on Completion owners, with completion-owned allocator/presentor pools and overflow allocation on temporary pool pressure.
- Adds explicit thread roles and prevents Completion callbacks from re-entering blocking RHI lifecycle waits.
- Adds dependency rejection, fence terminalization, exception-safe lifecycle boundaries, and a cancellation-first shutdown/drain/join protocol.
- Handles side-effect-only custom dispatches with no resource usages without generating an invalid reorder layer.

Native queue submission remains serialized by design; this PR establishes ownership/lifetime correctness and does not claim a performance improvement.

## Validation

- `cmake --build build-vs --config Debug --target TestRHIParallelRecordVulkan MoerEditor` — PASS
- `ctest --test-dir build-vs -C Debug --output-on-failure` — 12/12 PASS
- `TestRHIParallelRecordVulkan` serial — 8 cases PASS
- `TestRHIParallelRecordVulkan --parallel` — 8 cases PASS
- `TestRHIParallelRecordVulkan --parallel --inject-worker-failure` — 8 cases PASS
- Continuous 16-frame / 3-frame-in-flight regression with shared Fence and no loop-local Sync — PASS, including a blocked frame-1 Completion callback while frame 4 still reaches Translate
- Full Raster editor startup, sustained rendering, standard window close, RHI drain/join, and Vulkan device destruction — PASS; no VUID/error/critical/exception in the final runtime log

The machine does not have `just`; validation used the existing Visual Studio CMake build. A full all-target build also reaches three pre-existing Windows MAX_PATH failures in scripting copy targets; affected RHI/editor targets pass.

## Known pre-existing issue

`CrossQueueSubmissionTopology` still reports `VUID-vkCmdPipelineBarrier2-srcQueueFamilyIndex-10387` from the existing queue-family ownership barrier lowering introduced before this phase. It is unchanged across serial/parallel/fallback modes and is intentionally left for the explicit multi-queue barrier-lowering follow-up.