### PR TITLE
feat(rendergraph): land active multi-queue RDG runtime

### DIFF
--- a/source/runtime/render/renderer/Renderer.cpp
+++ b/source/runtime/render/renderer/Renderer.cpp
@@ -6,6 +6,7 @@
 #include "config/ConfigManager.h"
 #include "misc/Timer.h"
 #include "renderer/EditorConfig.h"
+#include "rendergraph/RenderGraphResourcePool.h"
 #include "rhi/RHI.h"
 #include "rhi/RHIExecutor.h"
 #include "scene/Scene.h"
@@ -149,6 +150,7 @@ void Renderer::ReleaseResources() {
     RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
 
     scene.Reset();
+    RenderGraphResourcePool::Global().Reset();
 }
 
 Renderer::WindowFrameState Renderer::TickWindowContext(uint2 current_resolution) {
@@ -175,6 +177,7 @@ void Renderer::PrepareRenderFrame(const WindowFrameState& window_frame) {
     if (time >= max_frame_in_flight) {
         timeline->Wait(time - max_frame_in_flight);
     }
+    RenderGraphResourcePool::Global().Tick();
 
     const bool recreate_requested =
         main_swapchain_recreate_requested.exchange(false, std::memory_order_acq_rel);

--- a/source/runtime/render/rendergraph/RenderGraph.cpp
+++ b/source/runtime/render/rendergraph/RenderGraph.cpp
@@ -618,6 +618,38 @@ ToBarrierState(const RenderGraphLowering::Scope& scope, bool texture) {
     BarrierCreateInfo&                             output,
     std::string&                                   error
 ) {
+    auto materialize_transfer = [&]() {
+        if (instruction.instruction_kind !=
+                RenderGraphLowering::InstructionKind::QueueRelease &&
+            instruction.instruction_kind !=
+                RenderGraphLowering::InstructionKind::QueueAcquire) {
+            output.queue_transfer = {};
+            return true;
+        }
+        const auto src_queue = ToRHIQueue(instruction.transfer_source.role);
+        const auto dst_queue =
+            ToRHIQueue(instruction.transfer_destination.role);
+        if ((src_queue != EQueueType::Graphics &&
+             src_queue != EQueueType::Compute &&
+             src_queue != EQueueType::Copy) ||
+            (dst_queue != EQueueType::Graphics &&
+             dst_queue != EQueueType::Compute &&
+             dst_queue != EQueueType::Copy) ||
+            src_queue == dst_queue ||
+            instruction.transfer_source.family_id ==
+                instruction.transfer_destination.family_id) {
+            error =
+                "queue ownership instruction has invalid logical or family endpoints";
+            return false;
+        }
+        output.queue_transfer =
+            instruction.instruction_kind ==
+                    RenderGraphLowering::InstructionKind::QueueRelease ?
+                BarrierQueueTransfer::Release(src_queue, dst_queue) :
+                BarrierQueueTransfer::Acquire(src_queue, dst_queue);
+        return true;
+    };
+
     if (instruction.resource_kind == RenderGraph::ResourceKind::Texture) {
         const auto& binding = instruction.physical.texture;
         const auto& range   = instruction.range.texture;
@@ -652,7 +684,7 @@ ToBarrierState(const RenderGraphLowering::Scope& scope, bool texture) {
             ToBarrierState(instruction.destination, true),
             instruction.texture_aspects
         );
-        return true;
+        return materialize_transfer();
     }
 
     if (instruction.resource_kind == RenderGraph::ResourceKind::Buffer) {
@@ -674,7 +706,7 @@ ToBarrierState(const RenderGraphLowering::Scope& scope, bool texture) {
             ToBarrierState(instruction.source, false),
             ToBarrierState(instruction.destination, false)
         );
-        return true;
+        return materialize_transfer();
     }
 
     error = "token instruction cannot be materialized as an RHI barrier";

--- a/source/runtime/render/rendergraph/RenderGraph.cpp
+++ b/source/runtime/render/rendergraph/RenderGraph.cpp
@@ -72,6 +72,8 @@ const char* ToString(RenderGraph::EdgeReasonKind kind) {
             return "state";
         case RenderGraph::EdgeReasonKind::QueueOwnership:
             return "ownership";
+        case RenderGraph::EdgeReasonKind::TransientAlias:
+            return "transient-alias";
     }
     return "unknown";
 }
@@ -558,13 +560,29 @@ RenderGraph::PassBuilder::ExecuteOn(QueueRole queue, PipelineType pipeline) {
     return EQueueType::Ignore;
 }
 
+[[nodiscard]] RenderGraph::TextureAspect
+RaiseTextureAspects(ETextureAspectFlags aspects) {
+    RenderGraph::TextureAspect result = RenderGraph::TextureAspect::None;
+    const uint32_t mask = static_cast<uint32_t>(aspects);
+    if ((mask & static_cast<uint32_t>(ETextureAspectFlags::COLOR)) != 0) {
+        result = result | RenderGraph::TextureAspect::Color;
+    }
+    if ((mask & static_cast<uint32_t>(ETextureAspectFlags::DEPTH_SLICE)) != 0) {
+        result = result | RenderGraph::TextureAspect::Depth;
+    }
+    if ((mask & static_cast<uint32_t>(ETextureAspectFlags::STENCIL_SLICE)) != 0) {
+        result = result | RenderGraph::TextureAspect::Stencil;
+    }
+    return result;
+}
+
 struct MaterializedPassState {
     std::vector<BarrierCreateInfo>                    before{};
     std::vector<BarrierCreateInfo>                    after{};
     std::vector<RenderGraphLowering::PhysicalBinding> keepalive{};
 
-    [[nodiscard]] bool HasPhysicalState() const {
-        return !before.empty() || !after.empty();
+    [[nodiscard]] bool RequiresCompletionLifetime() const {
+        return !before.empty() || !after.empty() || !keepalive.empty();
     }
 };
 
@@ -850,8 +868,88 @@ RenderGraph::CreateTransientBuffer(std::string_view resource_name, BufferDesc de
     return BufferHandle{CreateTransientInternal(resource_name, ResourceKind::Buffer, nullptr, &desc)};
 }
 
+RenderGraph::TextureHandle RenderGraph::CreateTransientTexture(
+    std::string_view               resource_name,
+    const RGTransientTextureDesc& allocation_desc
+) {
+    if (!allocation_desc.IsValid()) {
+        if (InvalidateCompile()) {
+            declaration_errors.emplace_back(
+                "transient texture allocation descriptor is invalid: " +
+                std::string(resource_name)
+            );
+        }
+        return {};
+    }
+    const TextureDesc logical_desc{
+        .mip_count   = allocation_desc.mip_count,
+        .layer_count = allocation_desc.PhysicalLayerCount(),
+        .aspects     = RaiseTextureAspects(allocation_desc.aspect_flags),
+    };
+    const auto handle =
+        TextureHandle{CreateTransientInternal(
+            resource_name,
+            ResourceKind::Texture,
+            &logical_desc,
+            nullptr
+        )};
+    if (handle.IsValid()) {
+        resources[handle.resource.index].transient_texture_desc =
+            allocation_desc;
+    }
+    return handle;
+}
+
+RenderGraph::BufferHandle RenderGraph::CreateTransientBuffer(
+    std::string_view              resource_name,
+    const RGTransientBufferDesc& allocation_desc
+) {
+    if (!allocation_desc.IsValid()) {
+        if (InvalidateCompile()) {
+            declaration_errors.emplace_back(
+                "transient buffer allocation descriptor is invalid: " +
+                std::string(resource_name)
+            );
+        }
+        return {};
+    }
+    const BufferDesc logical_desc{.byte_size = allocation_desc.ByteSize()};
+    const auto handle =
+        BufferHandle{CreateTransientInternal(
+            resource_name,
+            ResourceKind::Buffer,
+            nullptr,
+            &logical_desc
+        )};
+    if (handle.IsValid()) {
+        resources[handle.resource.index].transient_buffer_desc =
+            allocation_desc;
+    }
+    return handle;
+}
+
 RenderGraph::TokenHandle RenderGraph::CreateTransientToken(std::string_view resource_name) {
     return TokenHandle{CreateTransientInternal(resource_name, ResourceKind::Token, nullptr, nullptr)};
+}
+
+TextureRef RenderGraph::GetPhysicalTexture(TextureHandle resource) const {
+    if (!IsValidResource(resource.Untyped())) {
+        return {};
+    }
+    const auto& declaration = resources[resource.resource.index];
+    return declaration.kind == ResourceKind::Texture ?
+               declaration.physical_texture :
+               TextureRef{};
+}
+
+BufferRef RenderGraph::GetPhysicalBuffer(BufferHandle resource) const {
+    if (!IsValidResource(resource.Untyped())) {
+        return {};
+    }
+    const auto& declaration = resources[resource.resource.index];
+    return declaration.kind == ResourceKind::Buffer ?
+               declaration.physical_buffer :
+               BufferRef{};
 }
 
 RenderGraph::ResourceHandle RenderGraph::CreateTransientInternal(
@@ -1086,6 +1184,20 @@ bool RenderGraph::Execute(const PassCompletedCallback& after_pass) {
         compile_error = "a per-frame RenderGraph can only be executed once";
         return false;
     }
+    const bool has_active_allocation_backed_transient = std::any_of(
+        compiled_plan.resources.begin(),
+        compiled_plan.resources.end(),
+        [](const CompiledResource& resource) {
+            return !resource.imported &&
+                   resource.first_use != PassHandle::InvalidIndex &&
+                   resource.transient_slot != PassHandle::InvalidIndex;
+        }
+    );
+    if (has_active_allocation_backed_transient) {
+        compile_error =
+            "allocation-backed transient resources require active ExecuteRecording";
+        return false;
+    }
     if (std::any_of(compiled_plan.execution_order.begin(),
                     compiled_plan.execution_order.end(),
                     [&](PassHandle handle) { return static_cast<bool>(passes[handle.index].record); })) {
@@ -1127,9 +1239,51 @@ bool RenderGraph::ExecuteRecording(
         return false;
     }
 
+    struct TransientBindingReleaseGuard {
+        RenderGraphTransientAllocator* allocator{nullptr};
+        RenderGraph*                   graph{nullptr};
+        bool                           armed{false};
+
+        ~TransientBindingReleaseGuard() {
+            if (armed && allocator != nullptr && graph != nullptr) {
+                allocator->ReleaseNonExported(*graph);
+            }
+        }
+    };
+
+    const bool has_active_allocation_backed_transient = std::any_of(
+        compiled_plan.resources.begin(),
+        compiled_plan.resources.end(),
+        [](const CompiledResource& resource) {
+            return !resource.imported &&
+                   resource.first_use != PassHandle::InvalidIndex &&
+                   resource.transient_slot != PassHandle::InvalidIndex;
+        }
+    );
+    if (has_active_allocation_backed_transient && !active_recording.enabled) {
+        compile_error =
+            "allocation-backed transient resources require active recording";
+        return false;
+    }
+
     std::vector<MaterializedPassState> active_pass_states(passes.size());
+    TransientBindingReleaseGuard transient_release_guard{};
     bool active_has_physical_main_thread = false;
+    RenderGraphTransientAllocator* active_transient_allocator = nullptr;
     if (active_recording.enabled) {
+        active_transient_allocator =
+            active_recording.transient_allocator != nullptr ?
+                active_recording.transient_allocator :
+                &RenderGraphTransientAllocator::Global();
+        std::string allocation_error{};
+        if (!active_transient_allocator->Prepare(*this, allocation_error)) {
+            compile_error = std::move(allocation_error);
+            return false;
+        }
+        transient_release_guard.allocator = active_transient_allocator;
+        transient_release_guard.graph     = this;
+        transient_release_guard.armed     = true;
+
         RenderGraphLowering::LoweredPlan lowered_plan{};
         std::string                      lowering_error{};
         if (!RenderGraphLowering::Lower(*this, lowered_plan, lowering_error)) {
@@ -1189,7 +1343,7 @@ bool RenderGraph::ExecuteRecording(
 
         for (uint32_t pass_index = 0; pass_index < passes.size(); ++pass_index) {
             const auto& state = active_pass_states[pass_index];
-            if (!state.HasPhysicalState()) {
+            if (!state.RequiresCompletionLifetime()) {
                 continue;
             }
             if (state.keepalive.empty()) {
@@ -1269,7 +1423,7 @@ bool RenderGraph::ExecuteRecording(
                     return batch.execution != PassExecutionClass::MainThread ||
                            batch.passes.size() != 1 ||
                            !active_pass_states[batch.passes.front().index]
-                                .HasPhysicalState();
+                                .RequiresCompletionLifetime();
                 }
             );
             if (has_nonphysical_or_nonmain_batch) {
@@ -1577,7 +1731,8 @@ bool RenderGraph::ExecuteRecording(
             const auto& pass_state = active_pass_states[first_handle.index];
             bool        main_thread_lifetime_attached = false;
             const bool  active_physical_main_thread =
-                active_recording.enabled && pass_state.HasPhysicalState();
+                active_recording.enabled &&
+                pass_state.RequiresCompletionLifetime();
             auto attach_main_thread_lifetime = [&] {
                 if (!active_physical_main_thread ||
                     main_thread_lifetime_attached) {
@@ -2159,10 +2314,13 @@ std::string RenderGraph::Dump() const {
             stream << resource.last_use;
         }
         uint32_t version_count = 0;
+        uint32_t transient_slot = PassHandle::InvalidIndex;
         if (index < compiled_plan.resources.size()) {
-            version_count = compiled_plan.resources[index].version_count;
+            version_count  = compiled_plan.resources[index].version_count;
+            transient_slot = compiled_plan.resources[index].transient_slot;
         }
-        stream << " versions=" << version_count << " exported=" << (resource.exported ? "true" : "false")
+        stream << " versions=" << version_count
+               << " exported=" << (resource.exported ? "true" : "false")
                << " aliases=[";
         auto aliases = resource.aliases;
         std::sort(aliases.begin(), aliases.end());
@@ -2172,7 +2330,13 @@ std::string RenderGraph::Dump() const {
             }
             stream << aliases[alias_index];
         }
-        stream << "] initial_states=" << resource.initial_states.size()
+        stream << "] slot=";
+        if (transient_slot == PassHandle::InvalidIndex) {
+            stream << "none";
+        } else {
+            stream << transient_slot;
+        }
+        stream << " initial_states=" << resource.initial_states.size()
                << " final_states=" << resource.final_states.size() << "\n";
     }
 
@@ -2261,6 +2425,7 @@ std::string RenderGraph::Dump() const {
         append_flag(barrier.import_boundary, "import");
         append_flag(barrier.export_boundary, "export");
         append_flag(barrier.source_state_unknown, "unknown-src");
+        append_flag(barrier.transient_alias, "transient-alias");
         if (!wrote_flag) {
             stream << "none";
         }
@@ -2277,6 +2442,23 @@ std::string RenderGraph::Dump() const {
             stream << ' ' << ToString(source.access) << ')';
         }
         stream << "]\n";
+    }
+
+    stream << "alias_boundaries:\n";
+    for (const auto& alias : compiled_plan.alias_boundaries) {
+        stream << "  slot=" << alias.transient_slot << ' '
+               << resources[alias.predecessor_resource.index].name << " -> "
+               << resources[alias.successor_resource.index].name << " passes="
+               << passes[alias.primary_src_pass.index].name << "->"
+               << passes[alias.dst_pass.index].name
+               << " frontier=[";
+        for (uint32_t index = 0; index < alias.source_frontier.size(); ++index) {
+            if (index != 0) {
+                stream << ',';
+            }
+            stream << passes[alias.source_frontier[index].index].name;
+        }
+        stream << "] barrier=" << alias.barrier_index << '\n';
     }
 
     stream << "barrier_placements:\n  prologue=[";
@@ -2589,11 +2771,23 @@ bool RenderGraph::InvalidateCompile() {
     compiled = false;
     compile_error.clear();
     compiled_plan.Clear();
+    ReleaseNonExportedTransientBindings();
     for (auto& resource : resources) {
         resource.first_use = PassHandle::InvalidIndex;
         resource.last_use  = PassHandle::InvalidIndex;
     }
     return true;
+}
+
+void RenderGraph::ReleaseNonExportedTransientBindings() noexcept {
+    for (auto& resource : resources) {
+        if (resource.imported || resource.exported) {
+            continue;
+        }
+        resource.physical_identity = nullptr;
+        resource.physical_texture  = {};
+        resource.physical_buffer   = {};
+    }
 }
 
 bool RenderGraph::FailCompile(std::string message) {

--- a/source/runtime/render/rendergraph/RenderGraph.cpp
+++ b/source/runtime/render/rendergraph/RenderGraph.cpp
@@ -3,6 +3,7 @@
 #include "log/LogSystem.h"
 #include "rendergraph/RenderGraphCompiler.h"
 #include "rendergraph/RenderGraphLowering.h"
+#include "rhi/RHI.h"
 #include "rhi/RHIExecutor.h"
 #include "rhi/RHIThreadOwnership.h"
 #include "taskgraph/TaskGraph.h"
@@ -259,6 +260,23 @@ void AppendVersion(std::ostringstream& stream, uint32_t version) {
 
 RenderGraph::RenderGraph(std::string_view graph_name) :
     RenderGraph(graph_name, QueueTopology::SingleQueue()) {}
+
+RenderGraph::QueueTopology RenderGraph::QueueTopology::FromRHI() {
+    const RHIQueueTopology topology = RenderDevice::Get().GetQueueTopology();
+    auto convert = [](QueueRole role, const RHIQueueBinding& binding) {
+        return QueueBinding{
+            .role            = role,
+            .native_queue_id = binding.native_queue_id,
+            .family_id       = binding.family_id,
+            .available       = binding.available,
+        };
+    };
+    return QueueTopology{
+        .graphics = convert(QueueRole::Graphics, topology.graphics),
+        .compute  = convert(QueueRole::Compute, topology.compute),
+        .copy     = convert(QueueRole::Copy, topology.copy),
+    };
+}
 
 RenderGraph::RenderGraph(std::string_view graph_name, QueueTopology topology) :
     name(graph_name),
@@ -580,6 +598,9 @@ struct MaterializedPassState {
     std::vector<BarrierCreateInfo>                    before{};
     std::vector<BarrierCreateInfo>                    after{};
     std::vector<RenderGraphLowering::PhysicalBinding> keepalive{};
+    Array<RHIRecordingFencePoint>                     wait_fences{};
+    Array<RHIRecordingFencePoint>                     signal_fences{};
+    uint64                                            async_queue_scope{0};
 
     [[nodiscard]] bool RequiresCompletionLifetime() const {
         return !before.empty() || !after.empty() || !keepalive.empty();
@@ -1269,6 +1290,7 @@ bool RenderGraph::ExecuteRecording(
     std::vector<MaterializedPassState> active_pass_states(passes.size());
     TransientBindingReleaseGuard transient_release_guard{};
     bool active_has_physical_main_thread = false;
+    bool active_async_multiqueue          = false;
     RenderGraphTransientAllocator* active_transient_allocator = nullptr;
     if (active_recording.enabled) {
         active_transient_allocator =
@@ -1289,6 +1311,73 @@ bool RenderGraph::ExecuteRecording(
         if (!RenderGraphLowering::Lower(*this, lowered_plan, lowering_error)) {
             compile_error = std::move(lowering_error);
             return false;
+        }
+        const bool active_uses_non_graphics_queue = std::any_of(
+            compiled_plan.queue_batches.begin(),
+            compiled_plan.queue_batches.end(),
+            [](const CompiledQueueBatch& batch) {
+                return batch.queue.role != QueueRole::Graphics;
+            }
+        );
+        if (active_uses_non_graphics_queue) {
+            if (!RenderDevice::IsInitialized()) {
+                compile_error =
+                    "active non-Graphics queue lowering requires an initialized RHI";
+                return false;
+            }
+            const QueueTopology runtime_topology = QueueTopology::FromRHI();
+            for (const auto& batch : compiled_plan.queue_batches) {
+                if (batch.queue.role == QueueRole::None ||
+                    batch.queue != runtime_topology.Resolve(batch.queue.role)) {
+                    compile_error =
+                        "compiled queue topology does not match the initialized "
+                        "RHI; construct the graph with QueueTopology::FromRHI()";
+                    return false;
+                }
+            }
+        }
+        if (!compiled_plan.queue_batches.empty()) {
+            const uint32_t first_native_queue =
+                compiled_plan.queue_batches.front().queue.native_queue_id;
+            active_async_multiqueue = std::any_of(
+                compiled_plan.queue_batches.begin() + 1,
+                compiled_plan.queue_batches.end(),
+                [&](const CompiledQueueBatch& batch) {
+                    return batch.queue.native_queue_id != first_native_queue;
+                }
+            );
+        }
+        if (active_async_multiqueue &&
+            (configure_recording_source || publish_recording_batch)) {
+            compile_error =
+                "active multi-queue lowering requires the built-in immutable "
+                "RHI graph handoff";
+            return false;
+        }
+        if (active_uses_non_graphics_queue) {
+            const bool has_caller_thread_gpu_pass = std::any_of(
+                compiled_plan.queue_batches.begin(),
+                compiled_plan.queue_batches.end(),
+                [&](const CompiledQueueBatch& batch) {
+                    return std::any_of(
+                        batch.passes.begin(),
+                        batch.passes.end(),
+                        [&](PassHandle pass) {
+                            const auto execution =
+                                passes[pass.index].execution_class;
+                            return execution != PassExecutionClass::SerialRecord &&
+                                   execution !=
+                                       PassExecutionClass::ParallelRecordEligible;
+                        }
+                    );
+                }
+            );
+            if (has_caller_thread_gpu_pass) {
+                compile_error =
+                    "active non-Graphics queue lowering requires every GPU pass "
+                    "to use the managed recording handoff";
+                return false;
+            }
         }
 
         auto append_instruction =
@@ -1339,6 +1428,38 @@ bool RenderGraph::ExecuteRecording(
                     return false;
                 }
             }
+            if (active_async_multiqueue) {
+                materialized.async_queue_scope = graph_id;
+            }
+        }
+
+        try {
+            for (const auto& sync : lowered_plan.queue_syncs) {
+                FenceRef fence = RenderDevice::Get().CreateFence();
+                if (!fence.IsValid()) {
+                    compile_error =
+                        "RHI returned no fence for active multi-queue sync " +
+                        std::to_string(sync.correlation_id);
+                    return false;
+                }
+                active_pass_states[sync.signal_pass.index]
+                    .signal_fences.emplace_back(
+                        RHIRecordingFencePoint{.fence = fence, .value = 1}
+                    );
+                active_pass_states[sync.wait_pass.index]
+                    .wait_fences.emplace_back(
+                        RHIRecordingFencePoint{.fence = std::move(fence), .value = 1}
+                    );
+            }
+        } catch (const std::exception& exception) {
+            compile_error =
+                std::string("failed to create active multi-queue synchronization: ") +
+                exception.what();
+            return false;
+        } catch (...) {
+            compile_error =
+                "failed to create active multi-queue synchronization";
+            return false;
         }
 
         for (uint32_t pass_index = 0; pass_index < passes.size(); ++pass_index) {
@@ -1838,9 +1959,6 @@ bool RenderGraph::ExecuteRecording(
             while (group_end < compiled_plan.recording_batches.size()) {
                 const auto& candidate = compiled_plan.recording_batches[group_end];
                 if (candidate.execution != PassExecutionClass::ParallelRecordEligible ||
-                    candidate.queue.role != first_batch.queue.role ||
-                    candidate.queue.native_queue_id != first_batch.queue.native_queue_id ||
-                    candidate.queue.family_id != first_batch.queue.family_id ||
                     candidate.passes.size() != 1 ||
                     has_cpu_recording_dependency(
                         candidate.passes.front(), batch_index, group_end
@@ -1887,6 +2005,15 @@ bool RenderGraph::ExecuteRecording(
                 .completion   = job.completion,
                 .commit       = active_recording_commit,
             };
+            if (active_recording.enabled) {
+                const auto& pass_state = active_pass_states[handle.index];
+                source.submit_metadata.wait_fences =
+                    pass_state.wait_fences;
+                source.submit_metadata.signal_fences =
+                    pass_state.signal_fences;
+                source.submit_metadata.async_queue_scope =
+                    pass_state.async_queue_scope;
+            }
             if (active_recording.enabled) {
                 try {
                     auto lease =
@@ -2216,8 +2343,8 @@ bool RenderGraph::ExecuteRecording(
 std::string RenderGraph::Dump() const {
     std::ostringstream stream;
     stream << "graph='" << name
-           << "' frontend=typed-rdg mode=serial barrier_owner=existing_rhi_vulkan_path "
-              "sync_plan=shadow external_endpoints=unbound state_plan="
+           << "' frontend=typed-rdg mode=compiled barrier_plan=explicit "
+              "sync_plan=queue-dag external_endpoints=unbound state_plan="
            << (compiled_plan.state_plan_complete ? "complete" : "incomplete") << " compiled="
            << (compiled ? "true" : "false") << " executed=" << (executed ? "true" : "false")
            << " passes=" << passes.size() << " resources=" << resources.size();
@@ -2481,6 +2608,7 @@ std::string RenderGraph::Dump() const {
     for (const auto& batch : compiled_plan.queue_batches) {
         stream << "  [" << batch.id << "] " << ToString(batch.queue.role) << " native="
                << batch.queue.native_queue_id << " family=" << batch.queue.family_id
+               << " available=" << (batch.queue.available ? "true" : "false")
                << " external_control=" << (batch.external_control ? "true" : "false")
                << " passes=[";
         for (uint32_t pass_index = 0; pass_index < batch.passes.size(); ++pass_index) {

--- a/source/runtime/render/rendergraph/RenderGraph.cpp
+++ b/source/runtime/render/rendergraph/RenderGraph.cpp
@@ -2,13 +2,16 @@
 
 #include "log/LogSystem.h"
 #include "rendergraph/RenderGraphCompiler.h"
+#include "rendergraph/RenderGraphLowering.h"
 #include "rhi/RHIExecutor.h"
+#include "rhi/RHIThreadOwnership.h"
 #include "taskgraph/TaskGraph.h"
 
 #include <algorithm>
 #include <atomic>
 #include <cassert>
 #include <exception>
+#include <limits>
 #include <mutex>
 #include <sstream>
 #include <unordered_set>
@@ -555,6 +558,90 @@ RenderGraph::PassBuilder::ExecuteOn(QueueRole queue, PipelineType pipeline) {
     return EQueueType::Ignore;
 }
 
+struct MaterializedPassState {
+    std::vector<BarrierCreateInfo>                    before{};
+    std::vector<BarrierCreateInfo>                    after{};
+    std::vector<RenderGraphLowering::PhysicalBinding> keepalive{};
+
+    [[nodiscard]] bool HasPhysicalState() const {
+        return !before.empty() || !after.empty();
+    }
+};
+
+[[nodiscard]] BarrierState
+ToBarrierState(const RenderGraphLowering::Scope& scope, bool texture) {
+    return texture ? BarrierState::Texture(scope.stages, scope.access, scope.layout) :
+                     BarrierState::Buffer(scope.stages, scope.access);
+}
+
+[[nodiscard]] bool MaterializeInstruction(
+    const RenderGraphLowering::LoweredInstruction& instruction,
+    BarrierCreateInfo&                             output,
+    std::string&                                   error
+) {
+    if (instruction.resource_kind == RenderGraph::ResourceKind::Texture) {
+        const auto& binding = instruction.physical.texture;
+        const auto& range   = instruction.range.texture;
+        if (!binding.IsValid() || instruction.texture_aspects == ETextureAspectFlags::NONE) {
+            error = "texture instruction has no physical binding or aspect";
+            return false;
+        }
+        if (instruction.texture_aspects != binding->GetAspectFlags()) {
+            error =
+                "partial-aspect texture state is not supported by the active "
+                "backend-tracker bridge";
+            return false;
+        }
+        constexpr uint32_t max_view_index = std::numeric_limits<uint8_t>::max();
+        if (range.mip_count == 0 || range.layer_count == 0 ||
+            range.mip_first > max_view_index || range.mip_count > max_view_index ||
+            range.layer_first > max_view_index || range.layer_count > max_view_index ||
+            range.mip_first + range.mip_count > binding->GetNumMips() ||
+            range.layer_first + range.layer_count > binding->GetNumArray()) {
+            error = "texture instruction range cannot be represented by an RHI TextureView";
+            return false;
+        }
+
+        TextureView view(binding);
+        view.mip_level   = static_cast<uint8>(range.mip_first);
+        view.num_mips    = static_cast<uint8>(range.mip_count);
+        view.array_layer = static_cast<uint8>(range.layer_first);
+        view.num_array   = static_cast<uint8>(range.layer_count);
+        output = BarrierCreateInfo::Transition(
+            view,
+            ToBarrierState(instruction.source, true),
+            ToBarrierState(instruction.destination, true),
+            instruction.texture_aspects
+        );
+        return true;
+    }
+
+    if (instruction.resource_kind == RenderGraph::ResourceKind::Buffer) {
+        const auto& binding = instruction.physical.buffer;
+        const auto& range   = instruction.range.buffer;
+        if (!binding.IsValid() || range.size == 0 || range.offset > binding->GetByteSize() ||
+            range.size > binding->GetByteSize() - range.offset) {
+            error = "buffer instruction has no physical binding or has an invalid range";
+            return false;
+        }
+        if (range.offset != 0 || range.size != binding->GetByteSize()) {
+            error =
+                "partial buffer state is not supported by the active "
+                "backend-tracker bridge";
+            return false;
+        }
+        output = BarrierCreateInfo::Transition(
+            BufferView(binding.Get(), range.offset, range.size, 1),
+            ToBarrierState(instruction.source, false),
+            ToBarrierState(instruction.destination, false)
+        );
+        return true;
+    }
+
+    error = "token instruction cannot be materialized as an RHI barrier";
+    return false;
+}
+
 RenderGraph::PassBuilder& RenderGraph::PassBuilder::MainThread() {
     graph.SetPassExecutionClass(pass_index, PassExecutionClass::MainThread, 1);
     return *this;
@@ -592,10 +679,62 @@ RenderGraph::ImportTexture(std::string_view resource_name, const void* physical_
     };
 }
 
+RenderGraph::TextureHandle
+RenderGraph::ImportTexture(std::string_view resource_name, TextureRef texture, TextureDesc desc) {
+    if (!texture.IsValid()) {
+        InvalidateCompile();
+        declaration_errors.emplace_back(
+            "strong texture import requires a valid resource: " + std::string(resource_name)
+        );
+        return {};
+    }
+    const auto handle =
+        ImportInternal(resource_name, ResourceKind::Texture, texture.Get(), &desc, nullptr);
+    if (handle.IsValid()) {
+        auto& resource = resources[handle.index];
+        if (resource.physical_texture.IsValid() &&
+            resource.physical_texture.Get() != texture.Get()) {
+            declaration_errors.emplace_back(
+                "strong texture import conflicts with the canonical physical resource: " +
+                std::string(resource_name)
+            );
+            return {};
+        }
+        resource.physical_texture = std::move(texture);
+    }
+    return TextureHandle{handle};
+}
+
 RenderGraph::BufferHandle
 RenderGraph::ImportBuffer(std::string_view resource_name, const void* physical_identity, BufferDesc desc) {
     return BufferHandle{ImportInternal(resource_name, ResourceKind::Buffer, physical_identity, nullptr, &desc)
     };
+}
+
+RenderGraph::BufferHandle
+RenderGraph::ImportBuffer(std::string_view resource_name, BufferRef buffer, BufferDesc desc) {
+    if (!buffer.IsValid()) {
+        InvalidateCompile();
+        declaration_errors.emplace_back(
+            "strong buffer import requires a valid resource: " + std::string(resource_name)
+        );
+        return {};
+    }
+    const auto handle =
+        ImportInternal(resource_name, ResourceKind::Buffer, buffer.Get(), nullptr, &desc);
+    if (handle.IsValid()) {
+        auto& resource = resources[handle.index];
+        if (resource.physical_buffer.IsValid() &&
+            resource.physical_buffer.Get() != buffer.Get()) {
+            declaration_errors.emplace_back(
+                "strong buffer import conflicts with the canonical physical resource: " +
+                std::string(resource_name)
+            );
+            return {};
+        }
+        resource.physical_buffer = std::move(buffer);
+    }
+    return BufferHandle{handle};
 }
 
 RenderGraph::TokenHandle
@@ -976,7 +1115,8 @@ bool RenderGraph::ExecuteRecording(
     const PassCompletedCallback&        after_main_thread_pass,
     const RecordingSourceSetupCallback& configure_recording_source,
     bool                                parallel_recording_enabled,
-    const RecordingBatchPublisher&      publish_recording_batch
+    const RecordingBatchPublisher&      publish_recording_batch,
+    const ActiveRecordingOptions&       active_recording
 ) {
     if (!compiled) {
         compile_error = "ExecuteRecording called before a successful Compile";
@@ -986,7 +1126,160 @@ bool RenderGraph::ExecuteRecording(
         compile_error = "a per-frame RenderGraph can only be executed once";
         return false;
     }
-    executed = true;
+
+    std::vector<MaterializedPassState> active_pass_states(passes.size());
+    bool active_has_physical_main_thread = false;
+    if (active_recording.enabled) {
+        RenderGraphLowering::LoweredPlan lowered_plan{};
+        std::string                      lowering_error{};
+        if (!RenderGraphLowering::Lower(*this, lowered_plan, lowering_error)) {
+            compile_error = std::move(lowering_error);
+            return false;
+        }
+
+        auto append_instruction =
+            [&](const RenderGraphLowering::LoweredInstruction& instruction,
+                std::vector<BarrierCreateInfo>&                 destination,
+                std::string_view                                placement) {
+                BarrierCreateInfo barrier{};
+                std::string       materialization_error{};
+                if (!MaterializeInstruction(instruction, barrier, materialization_error)) {
+                    compile_error =
+                        "RenderGraph active lowering " + std::string(placement) +
+                        " instruction " + std::to_string(instruction.correlation_id) +
+                        " failed: " + materialization_error;
+                    return false;
+                }
+                destination.emplace_back(std::move(barrier));
+                return true;
+            };
+
+        for (const auto& instruction : lowered_plan.prologue) {
+            if (!IsValidPass(instruction.dst_pass) ||
+                !append_instruction(
+                    instruction,
+                    active_pass_states[instruction.dst_pass.index].before,
+                    "prologue"
+                )) {
+                if (compile_error.empty()) {
+                    compile_error =
+                        "RenderGraph active lowering prologue has no valid destination pass";
+                }
+                return false;
+            }
+        }
+        for (const auto& pass_instructions : lowered_plan.passes) {
+            if (!IsValidPass(pass_instructions.pass)) {
+                compile_error = "RenderGraph active lowering references an invalid pass";
+                return false;
+            }
+            auto& materialized = active_pass_states[pass_instructions.pass.index];
+            materialized.keepalive = pass_instructions.keepalive;
+            for (const auto& instruction : pass_instructions.before) {
+                if (!append_instruction(instruction, materialized.before, "before-pass")) {
+                    return false;
+                }
+            }
+            for (const auto& instruction : pass_instructions.after) {
+                if (!append_instruction(instruction, materialized.after, "after-pass")) {
+                    return false;
+                }
+            }
+        }
+
+        for (uint32_t pass_index = 0; pass_index < passes.size(); ++pass_index) {
+            const auto& state = active_pass_states[pass_index];
+            if (!state.HasPhysicalState()) {
+                continue;
+            }
+            if (state.keepalive.empty()) {
+                compile_error =
+                    "RenderGraph active lowering produced physical commands without keepalive "
+                    "ownership for pass '" +
+                    passes[pass_index].name + "'";
+                return false;
+            }
+            const auto execution = passes[pass_index].execution_class;
+            if (execution == PassExecutionClass::CpuPrepare ||
+                execution == PassExecutionClass::ExternalControl) {
+                compile_error =
+                    "RenderGraph active lowering cannot materialize physical state for pass '" +
+                    passes[pass_index].name + "' on its execution class";
+                return false;
+            }
+            if (execution == PassExecutionClass::MainThread) {
+                active_has_physical_main_thread = true;
+                if (active_recording.main_thread_command_list == nullptr) {
+                    compile_error =
+                        "RenderGraph active lowering requires a caller-owned CommandList for "
+                        "main-thread pass '" +
+                        passes[pass_index].name + "'";
+                    return false;
+                }
+                if (active_recording.main_thread_command_list->GetQueueType() !=
+                    EQueueType::Graphics) {
+                    compile_error =
+                        "RenderGraph active lowering requires a Graphics caller-owned CommandList";
+                    return false;
+                }
+                if (!active_recording.main_thread_command_list->IsEmpty()) {
+                    compile_error =
+                        "RenderGraph active lowering requires an isolated empty caller-owned "
+                        "CommandList";
+                    return false;
+                }
+            }
+        }
+        if (active_has_physical_main_thread && after_main_thread_pass) {
+            compile_error =
+                "RenderGraph active lowering requires caller-owned MainThread "
+                "commands to remain unsealed until ExecuteRecording returns";
+            return false;
+        }
+
+        const bool has_any_managed_record_pass = std::any_of(
+            compiled_plan.recording_batches.begin(),
+            compiled_plan.recording_batches.end(),
+            [](const CompiledRecordingBatch& batch) {
+                return batch.execution == PassExecutionClass::SerialRecord ||
+                       batch.execution ==
+                           PassExecutionClass::ParallelRecordEligible;
+            }
+        );
+        const bool has_any_caller_thread_pass = std::any_of(
+            compiled_plan.recording_batches.begin(),
+            compiled_plan.recording_batches.end(),
+            [](const CompiledRecordingBatch& batch) {
+                return batch.execution == PassExecutionClass::MainThread ||
+                       batch.execution == PassExecutionClass::CpuPrepare ||
+                       batch.execution == PassExecutionClass::ExternalControl;
+            }
+        );
+        if (has_any_caller_thread_pass && has_any_managed_record_pass) {
+            compile_error =
+                "RenderGraph active lowering does not yet support mixing "
+                "caller-thread and managed record passes in one transaction";
+            return false;
+        }
+        if (active_has_physical_main_thread) {
+            const bool has_nonphysical_or_nonmain_batch = std::any_of(
+                compiled_plan.recording_batches.begin(),
+                compiled_plan.recording_batches.end(),
+                [&](const CompiledRecordingBatch& batch) {
+                    return batch.execution != PassExecutionClass::MainThread ||
+                           batch.passes.size() != 1 ||
+                           !active_pass_states[batch.passes.front().index]
+                                .HasPhysicalState();
+                }
+            );
+            if (has_nonphysical_or_nonmain_batch) {
+                compile_error =
+                    "RenderGraph active MainThread lowering currently requires "
+                    "an isolated graph of physical MainThread passes";
+                return false;
+            }
+        }
+    }
 
     struct RecordingJob {
         PassHandle          pass{};
@@ -994,10 +1287,18 @@ bool RenderGraph::ExecuteRecording(
         RecordCallback      record{};
         SharedPtr<CommandList> command_list{};
         RHIRecordingGateRef completion{};
+        std::vector<BarrierCreateInfo>                    before{};
+        std::vector<BarrierCreateInfo>                    after{};
+        std::vector<RenderGraphLowering::PhysicalBinding> keepalive{};
     };
     struct RecordingError {
         std::mutex  mutex{};
         std::string message{};
+    };
+    struct RecordingLifetime {
+        std::vector<RenderGraphLowering::PhysicalBinding> keepalive{};
+        RecordCallback                                    record{};
+        ExecuteCallback                                   execute{};
     };
     struct PendingGateGuard {
         const Array<RHIRecordingGateRef>* gates{nullptr};
@@ -1018,6 +1319,172 @@ bool RenderGraph::ExecuteRecording(
             armed = false;
         }
     };
+    struct ProducerGateGuard {
+        RHIRecordingGateRef gate{};
+        bool                armed{true};
+
+        ~ProducerGateGuard() {
+            if (armed && gate &&
+                gate->Status() == ERHIRecordingStatus::Pending) {
+                gate->Fail();
+            }
+        }
+
+        void Disarm() noexcept {
+            armed = false;
+        }
+    };
+    struct ManagedRecordingOwner {
+        // Members are destroyed in reverse declaration order: release the
+        // lease before dropping the strong CommandList owner.
+        SharedPtr<CommandList>                    command_list{};
+        CommandList::ManagedRecordingLease        lease{};
+    };
+    struct ActiveMainCommandStreamGuard {
+        CommandList* command_list{nullptr};
+        std::optional<CommandList::ManagedRecordingLease> lease{};
+        bool armed{false};
+
+        void Abort() noexcept {
+            if (!armed) {
+                return;
+            }
+            lease.reset();
+            if (command_list != nullptr) {
+                try {
+                    auto cleanup_callbacks =
+                        command_list->DrainOrdinaryCallbacksForRejection();
+                    for (auto& callback : cleanup_callbacks) {
+                        if (!callback) {
+                            continue;
+                        }
+                        try {
+                            callback();
+                        } catch (const std::exception& exception) {
+                            LOG_ERROR(
+                                "[RenderGraph] rejected MainThread cleanup "
+                                "callback threw: {}",
+                                exception.what()
+                            );
+                        } catch (...) {
+                            LOG_ERROR(
+                                "[RenderGraph] rejected MainThread cleanup "
+                                "callback threw"
+                            );
+                        }
+                    }
+                } catch (const std::exception& exception) {
+                    LOG_ERROR(
+                        "[RenderGraph] failed to drain rejected MainThread "
+                        "commands: {}",
+                        exception.what()
+                    );
+                } catch (...) {
+                    LOG_ERROR(
+                        "[RenderGraph] failed to drain rejected MainThread commands"
+                    );
+                }
+            }
+            armed = false;
+        }
+
+        void Commit() noexcept {
+            lease.reset();
+            armed = false;
+        }
+
+        ~ActiveMainCommandStreamGuard() {
+            Abort();
+        }
+    };
+    struct ActiveRecordingTransactionGuard {
+        RHIRecordingGateRef* commit{nullptr};
+        Array<ManagedRecordingOwner>* owners{nullptr};
+        bool armed{false};
+
+        void ReleaseLeases() noexcept {
+            if (owners == nullptr) {
+                return;
+            }
+            for (auto& owner : *owners) {
+                owner.lease.Release();
+            }
+            owners->clear();
+        }
+
+        ~ActiveRecordingTransactionGuard() {
+            if (!armed) {
+                return;
+            }
+            // Release the frontend mutation lock before failing the commit
+            // gate. The RHI handoff may wake immediately and drain rejected
+            // sources on its executor thread.
+            ReleaseLeases();
+            if (commit != nullptr && *commit) {
+                (*commit)->Fail();
+            }
+        }
+
+        bool Commit() noexcept {
+            if (!armed || commit == nullptr || !*commit) {
+                return true;
+            }
+            // A successful commit is the only point at which the RHI worker
+            // may seal graph-managed CommandLists.
+            ReleaseLeases();
+            if (!(*commit)->Signal()) {
+                return false;
+            }
+            armed = false;
+            return true;
+        }
+    };
+
+    RHIRecordingGateRef active_recording_commit{};
+    Array<ManagedRecordingOwner> active_recording_owners{};
+    try {
+        if (active_recording.enabled) {
+            active_recording_commit = RHIRecordingGate::Create();
+        }
+    } catch (const std::exception& exception) {
+        compile_error =
+            std::string("failed to create active recording transaction: ") +
+            exception.what();
+        return false;
+    } catch (...) {
+        compile_error = "failed to create active recording transaction";
+        return false;
+    }
+    ActiveRecordingTransactionGuard active_transaction_guard{
+        .commit = &active_recording_commit,
+        .owners = &active_recording_owners,
+        .armed  = active_recording.enabled,
+    };
+    ActiveMainCommandStreamGuard active_main_stream_guard{
+        .command_list =
+            active_has_physical_main_thread ?
+                active_recording.main_thread_command_list :
+                nullptr,
+    };
+    if (active_has_physical_main_thread) {
+        try {
+            active_main_stream_guard.lease.emplace(
+                active_recording.main_thread_command_list
+                    ->AcquireManagedRecordingLease()
+            );
+            active_main_stream_guard.armed = true;
+        } catch (const std::exception& exception) {
+            compile_error =
+                std::string("failed to acquire active MainThread recording lease: ") +
+                exception.what();
+            return false;
+        } catch (...) {
+            compile_error =
+                "failed to acquire active MainThread recording lease";
+            return false;
+        }
+    }
+    executed = true;
 
     auto make_pass_info = [&](PassHandle handle) {
         const auto& pass = passes[handle.index];
@@ -1036,6 +1503,25 @@ bool RenderGraph::ExecuteRecording(
             error->message = std::move(message);
         }
     };
+    auto attach_recording_lifetime =
+        [](CommandList&                                      command_list,
+           std::vector<RenderGraphLowering::PhysicalBinding> keepalive,
+           RecordCallback                                    record,
+           ExecuteCallback                                   execute = {}) {
+            auto lifetime = std::make_shared<RecordingLifetime>(
+                RecordingLifetime{
+                    .keepalive = std::move(keepalive),
+                    .record    = std::move(record),
+                    .execute   = std::move(execute),
+                }
+            );
+            // Ordinary callbacks run before success callbacks. Holding the
+            // same token in both tails keeps raw command/callback captures
+            // alive through every user callback on success, failure, or
+            // cancellation.
+            command_list.AddCallback([lifetime] {});
+            command_list.AddSuccessCallback([lifetime] {});
+        };
 
     auto has_cpu_recording_dependency = [&](PassHandle candidate,
                                             size_t     group_begin,
@@ -1087,7 +1573,103 @@ bool RenderGraph::ExecuteRecording(
                                 first_pass.name;
                 return false;
             }
-            first_pass.execute();
+
+            const auto& pass_state = active_pass_states[first_handle.index];
+            bool        main_thread_lifetime_attached = false;
+            const bool  active_physical_main_thread =
+                active_recording.enabled && pass_state.HasPhysicalState();
+            auto attach_main_thread_lifetime = [&] {
+                if (!active_physical_main_thread ||
+                    main_thread_lifetime_attached) {
+                    return;
+                }
+                attach_recording_lifetime(
+                    *active_recording.main_thread_command_list,
+                    pass_state.keepalive,
+                    {},
+                    first_pass.execute
+                );
+                main_thread_lifetime_attached = true;
+            };
+            auto reject_main_thread =
+                [&](std::string message) {
+                    if (active_has_physical_main_thread) {
+                        try {
+                            attach_main_thread_lifetime();
+                        } catch (const std::exception& exception) {
+                            message +=
+                                "; failed to retain MainThread recording lifetime: ";
+                            message += exception.what();
+                        } catch (...) {
+                            message +=
+                                "; failed to retain MainThread recording lifetime";
+                        }
+
+                        active_main_stream_guard.Abort();
+                    }
+                    compile_error = std::move(message);
+                    return false;
+                };
+
+            try {
+                if (active_physical_main_thread) {
+                    auto& command_list =
+                        *active_recording.main_thread_command_list;
+                    command_list.SetResourceStateOwnership(
+                        ERHIResourceStateOwnership::Explicit
+                    );
+                    if (!pass_state.before.empty()) {
+                        command_list.Barriers(
+                            std::span<const BarrierCreateInfo>(
+                                pass_state.before.data(),
+                                pass_state.before.size()
+                            )
+                        );
+                    }
+                }
+
+                const uint64 main_thread_seal_generation =
+                    active_physical_main_thread ?
+                        active_recording.main_thread_command_list
+                            ->GetSealGeneration() :
+                        0;
+                first_pass.execute();
+
+                if (active_physical_main_thread &&
+                    active_recording.main_thread_command_list
+                            ->GetSealGeneration() !=
+                        main_thread_seal_generation) {
+                    throw std::logic_error(
+                        "active MainThread callback sealed its managed CommandList"
+                    );
+                }
+                if (active_physical_main_thread &&
+                    !active_recording.main_thread_command_list
+                         ->HasExplicitResourceStateOwnership()) {
+                    throw std::logic_error(
+                        "active MainThread callback changed explicit state ownership"
+                    );
+                }
+                if (active_physical_main_thread && !pass_state.after.empty()) {
+                    active_recording.main_thread_command_list->Barriers(
+                        std::span<const BarrierCreateInfo>(
+                            pass_state.after.data(), pass_state.after.size()
+                        )
+                    );
+                }
+                if (active_physical_main_thread) {
+                    attach_main_thread_lifetime();
+                }
+            } catch (const std::exception& exception) {
+                return reject_main_thread(
+                    "main-thread pass '" + first_pass.name +
+                    "' failed: " + exception.what()
+                );
+            } catch (...) {
+                return reject_main_thread(
+                    "main-thread pass '" + first_pass.name + "' failed"
+                );
+            }
             if (first_batch.execution == PassExecutionClass::MainThread &&
                 after_main_thread_pass) {
                 after_main_thread_pass(make_pass_info(first_handle));
@@ -1139,12 +1721,48 @@ bool RenderGraph::ExecuteRecording(
                 .command_list = MakeShared<CommandList>(queue),
                 .completion   = RHIRecordingGate::Create(),
             };
+            if (active_recording.enabled) {
+                const auto& pass_state = active_pass_states[handle.index];
+                job.before             = pass_state.before;
+                job.after              = pass_state.after;
+                job.keepalive          = pass_state.keepalive;
+            }
             RHIRecordingSource source{
                 .command_list = job.command_list,
                 .completion   = job.completion,
+                .commit       = active_recording_commit,
             };
+            if (active_recording.enabled) {
+                try {
+                    auto lease =
+                        job.command_list->AcquireManagedRecordingLease();
+                    active_recording_owners.emplace_back(
+                        ManagedRecordingOwner{
+                            .command_list = job.command_list,
+                            .lease        = std::move(lease),
+                        }
+                    );
+                } catch (const std::exception& exception) {
+                    compile_error =
+                        "failed to acquire managed recording lease for pass '" +
+                        pass.name + "': " + exception.what();
+                    return false;
+                } catch (...) {
+                    compile_error =
+                        "failed to acquire managed recording lease for pass '" +
+                        pass.name + "'";
+                    return false;
+                }
+            }
             if (configure_recording_source) {
                 try {
+                    // Configuration may run while an earlier transaction
+                    // group is already waiting in the handoff FIFO. Treat it
+                    // as an admission owner so Sync/Flush cannot self-join
+                    // behind the pending graph commit gate.
+                    RHIThreadRoleScope configuration_owner(
+                        ERHIThreadRole::RecordWorker
+                    );
                     configure_recording_source(make_pass_info(handle), source);
                 } catch (const std::exception& exception) {
                     compile_error = "recording source configuration failed for pass '" + pass.name +
@@ -1154,9 +1772,36 @@ bool RenderGraph::ExecuteRecording(
                     compile_error = "recording source configuration failed for pass '" + pass.name + "'";
                     return false;
                 }
-                if (source.command_list != job.command_list || source.completion != job.completion) {
+                if (source.command_list != job.command_list ||
+                    source.completion != job.completion ||
+                    source.commit != active_recording_commit) {
                     compile_error = "recording source configuration changed ownership for pass '" +
                                     pass.name + "'";
+                    return false;
+                }
+                if (job.completion->Status() != ERHIRecordingStatus::Pending) {
+                    compile_error =
+                        "recording source configuration completed the producer gate for pass '" +
+                        pass.name + "'; the gate must remain pending until recording finishes";
+                    return false;
+                }
+                if (active_recording_commit &&
+                    active_recording_commit->Status() !=
+                        ERHIRecordingStatus::Pending) {
+                    compile_error =
+                        "recording source configuration completed the active "
+                        "transaction gate for pass '" +
+                        pass.name + "'";
+                    return false;
+                }
+                if (!source.command_list->IsEmpty() ||
+                    source.command_list->HasExplicitResourceStateOwnership() ||
+                    source.command_list->GetTranslateExecutionClass() !=
+                        ERHITranslateExecutionClass::Parallel) {
+                    compile_error =
+                        "recording source configuration may only change submit metadata "
+                        "for pass '" +
+                        pass.name + "'";
                     return false;
                 }
             }
@@ -1168,32 +1813,122 @@ bool RenderGraph::ExecuteRecording(
         PendingGateGuard pending_gate_guard{.gates = &group_gates};
 
         const auto error = std::make_shared<RecordingError>();
-        auto run_job = [error, store_error](RecordingJob job) mutable {
+        auto run_job =
+            [error, store_error, attach_recording_lifetime](RecordingJob job) mutable {
+            RHIThreadRoleScope record_owner(ERHIThreadRole::RecordWorker);
+            ProducerGateGuard producer_gate_guard{.gate = job.completion};
+            bool lifetime_attached = false;
+            auto attach_lifetime = [&] {
+                if (lifetime_attached) {
+                    return;
+                }
+                attach_recording_lifetime(
+                    *job.command_list,
+                    std::move(job.keepalive),
+                    std::move(job.record)
+                );
+                lifetime_attached = true;
+            };
+            auto fail_job =
+                [&](std::string_view detail, bool has_detail) noexcept {
+                    try {
+                        std::string message =
+                            "record pass '" + job.pass_name + "' failed";
+                        if (has_detail) {
+                            message += ": ";
+                            message += detail;
+                        }
+                        store_error(error, std::move(message));
+                    } catch (...) {
+                    }
+                    try {
+                        attach_lifetime();
+                    } catch (...) {
+                        try {
+                            store_error(
+                                error,
+                                "record pass '" + job.pass_name +
+                                    "' failed while retaining its recording "
+                                    "lifetime"
+                            );
+                        } catch (...) {
+                        }
+                    }
+                    job.completion->Fail();
+                    producer_gate_guard.Disarm();
+                };
             try {
+                const bool owns_explicit_state = !job.keepalive.empty();
+                if (owns_explicit_state || !job.before.empty() || !job.after.empty()) {
+                    job.command_list->SetResourceStateOwnership(
+                        ERHIResourceStateOwnership::Explicit
+                    );
+                }
+                if (!job.before.empty()) {
+                    job.command_list->Barriers(
+                        std::span<const BarrierCreateInfo>(
+                            job.before.data(), job.before.size()
+                        )
+                    );
+                }
+                const uint64 seal_generation =
+                    job.command_list->GetSealGeneration();
                 job.record(*job.command_list);
-                // Keep every immutable capture alive until the submit reaches
-                // a terminal backend/rejection callback, not merely until CPU
-                // recording finishes.
-                job.command_list->AddCallback(
-                    [keepalive = std::move(job.record)]() mutable { keepalive = {}; }
-                );
-                job.completion->Signal();
+                if (job.command_list->GetSealGeneration() != seal_generation) {
+                    throw std::logic_error(
+                        "record callback sealed its managed CommandList"
+                    );
+                }
+                if (owns_explicit_state &&
+                    !job.command_list->HasExplicitResourceStateOwnership()) {
+                    throw std::logic_error(
+                        "record callback changed explicit state ownership"
+                    );
+                }
+                if (job.command_list->GetTranslateExecutionClass() !=
+                    ERHITranslateExecutionClass::Parallel) {
+                    throw std::logic_error(
+                        "record callback changed its managed translation class"
+                    );
+                }
+                if (!job.after.empty()) {
+                    job.command_list->Barriers(
+                        std::span<const BarrierCreateInfo>(
+                            job.after.data(), job.after.size()
+                        )
+                    );
+                }
+                attach_lifetime();
+                if (!job.completion->Signal()) {
+                    throw std::logic_error(
+                        "recording completion gate was completed before its producer"
+                    );
+                }
+                producer_gate_guard.Disarm();
             } catch (const std::exception& exception) {
-                store_error(
-                    error,
-                    "record pass '" + job.pass_name + "' failed: " + exception.what()
-                );
-                job.completion->Fail();
+                fail_job(exception.what(), true);
             } catch (...) {
-                store_error(error, "record pass '" + job.pass_name + "' failed");
-                job.completion->Fail();
+                fail_job({}, false);
             }
         };
 
         // Register the unfinished sources before dispatch, matching the
         // dev_parallel/UE-style producer-consumer handoff. RHI owns stable
         // source order; worker completion order is irrelevant.
+        Array<uint64> publication_generations{};
+        publication_generations.reserve(jobs.size());
+        for (const auto& job : jobs) {
+            publication_generations.emplace_back(
+                job.command_list->GetSealGeneration()
+            );
+        }
         try {
+            // Publication is an admission-only phase. The producers have not
+            // started yet, so a custom publisher must not block on their gates
+            // or on RHI work routed behind this pending handoff.
+            RHIThreadRoleScope publication_owner(
+                ERHIThreadRole::RecordWorker
+            );
             if (publish_recording_batch) {
                 publish_recording_batch(std::move(sources));
             } else {
@@ -1205,6 +1940,24 @@ bool RenderGraph::ExecuteRecording(
         } catch (...) {
             compile_error = "failed to publish recording batch";
             return false;
+        }
+        for (size_t index = 0; index < jobs.size(); ++index) {
+            const auto& job = jobs[index];
+            if (job.completion->Status() != ERHIRecordingStatus::Pending ||
+                job.command_list->GetSealGeneration() !=
+                    publication_generations[index] ||
+                !job.command_list->IsEmpty() ||
+                job.command_list->HasExplicitResourceStateOwnership() ||
+                job.command_list->GetTranslateExecutionClass() !=
+                    ERHITranslateExecutionClass::Parallel ||
+                (active_recording_commit &&
+                 active_recording_commit->Status() !=
+                     ERHIRecordingStatus::Pending)) {
+                compile_error =
+                    "recording batch publisher mutated pending source state for pass '" +
+                    job.pass_name + "'";
+                return false;
+            }
         }
 
         const bool task_graph_available = TaskGraph::IsInitialized();
@@ -1296,6 +2049,12 @@ bool RenderGraph::ExecuteRecording(
         pending_gate_guard.Disarm();
         batch_index = group_end;
     }
+    if (!active_transaction_guard.Commit()) {
+        compile_error =
+            "active recording transaction gate completed before graph commit";
+        return false;
+    }
+    active_main_stream_guard.Commit();
     return true;
 }
 

--- a/source/runtime/render/rendergraph/RenderGraph.h
+++ b/source/runtime/render/rendergraph/RenderGraph.h
@@ -13,16 +13,17 @@
 namespace Moer::Render {
 
 class RenderGraphCompiler;
+class RenderGraphLowering;
 
 /**
  * Typed RDG frontend with an opt-in command-recording schedule.
  *
  * The compiler owns typed resource declarations, subresource-aware hazards,
- * logical resource versions, stable dependency analysis and lifetimes. The
- * RDG does not own physical tracked state or emit barriers in this stage; the
- * existing RHI/Vulkan command path remains responsible. Legacy callbacks stay
- * serial. Explicit record callbacks may be assigned independent CommandLists
- * while preserving stable source order.
+ * logical resource versions, stable dependency analysis and lifetimes. Its
+ * default execution remains backend-tracked for compatibility; the guarded
+ * active path lowers a complete supported state plan into authoritative RHI
+ * barriers. Legacy callbacks stay serial. Explicit record callbacks may be
+ * assigned independent CommandLists while preserving stable source order.
  */
 class RENDER_API RenderGraph {
 public:
@@ -678,10 +679,42 @@ public:
     using ExecuteCallback       = std::function<void()>;
     using RecordCallback        = std::function<void(CommandList&)>;
     using PassCompletedCallback = std::function<void(const ExecutedPassInfo&)>;
-    /** May attach submit metadata; CommandList and gate ownership are immutable. */
+    /**
+     * May attach submit metadata; CommandList, producer gate and transaction
+     * gate ownership are immutable. It must not wait on RHI work.
+     */
     using RecordingSourceSetupCallback =
         std::function<void(const ExecutedPassInfo&, RHIRecordingSource&)>;
+    /**
+     * Admission-only callback invoked before the corresponding producers
+     * start. It may move the immutable pending sources into a nonblocking
+     * handoff, but must not mutate/seal their CommandLists, replace or complete
+     * their producer/transaction gates, wait on those gates, or call blocking
+     * RHI lifecycle operations such as Sync. Producer completion is joined by
+     * ExecuteRecording; active lowering releases every published group through
+     * one graph-wide commit gate only after the whole graph succeeds.
+     */
     using RecordingBatchPublisher = std::function<void(Array<RHIRecordingSource>&&)>;
+
+    /**
+     * Opts ExecuteRecording into the authoritative RDG state path.
+     *
+     * Phase 11 materializes a fully validated Graphics-only lowered plan into
+     * explicit RHI barriers. Main-thread passes record into the caller-owned
+     * list; independently recorded passes continue to own their own lists and
+     * are mutation-sealed until one graph-wide RHI transaction commits. The
+     * current backend-tracker bridge requires full-buffer ranges, all physical
+     * texture aspects, and an initially empty main-thread list. Active lowering
+     * fails closed when caller-thread and managed-record passes are mixed in
+     * one graph. A physical MainThread graph must be isolated from nonphysical
+     * passes and keep its caller-owned list unsealed until ExecuteRecording
+     * returns (therefore no per-pass completion observer). Leaving enabled
+     * false preserves the legacy backend-tracked path.
+     */
+    struct ActiveRecordingOptions {
+        bool         enabled                  = false;
+        CommandList* main_thread_command_list = nullptr;
+    };
 
     explicit RenderGraph(std::string_view name = "RenderGraph");
     RenderGraph(std::string_view name, QueueTopology topology);
@@ -697,6 +730,14 @@ public:
 
     TextureHandle ImportTexture(std::string_view name, const void* physical_identity, TextureDesc desc);
     BufferHandle  ImportBuffer(std::string_view name, const void* physical_identity, BufferDesc desc);
+    /**
+     * Strong physical imports used by active lowering. The graph keeps the
+     * resource alive through compilation, recording and lowered-plan handoff.
+     * The raw-pointer overloads above remain declaration-only compatibility
+     * APIs and are deliberately rejected by active lowering.
+     */
+    TextureHandle ImportTexture(std::string_view name, TextureRef texture, TextureDesc desc);
+    BufferHandle  ImportBuffer(std::string_view name, BufferRef buffer, BufferDesc desc);
     TokenHandle   ImportToken(std::string_view name, const void* physical_identity = nullptr);
 
     /** Legacy transient API. Prefer the typed declarations below for new code. */
@@ -785,7 +826,8 @@ public:
         const PassCompletedCallback&        after_main_thread_pass,
         const RecordingSourceSetupCallback& configure_recording_source = {},
         bool                                parallel_recording_enabled = true,
-        const RecordingBatchPublisher&      publish_recording_batch = {}
+        const RecordingBatchPublisher&      publish_recording_batch = {},
+        const ActiveRecordingOptions&        active_recording = {}
     );
 
     [[nodiscard]] bool IsCompiled() const {
@@ -810,6 +852,7 @@ public:
 
 private:
     friend class RenderGraphCompiler;
+    friend class RenderGraphLowering;
 
     struct AccessDeclaration {
         ResourceHandle resource{};
@@ -833,6 +876,8 @@ private:
         std::vector<std::string> aliases{};
         ResourceKind             kind              = ResourceKind::Token;
         const void*              physical_identity = nullptr;
+        TextureRef               physical_texture{};
+        BufferRef                physical_buffer{};
         TextureDesc              texture_desc{};
         BufferDesc               buffer_desc{};
         bool                     typed_desc = false;

--- a/source/runtime/render/rendergraph/RenderGraph.h
+++ b/source/runtime/render/rendergraph/RenderGraph.h
@@ -1,11 +1,13 @@
 #pragma once
 
 #include "RenderAPI.h"
+#include "rendergraph/RenderGraphResourcePool.h"
 #include "rhi/RHIExecutor.h"
 
 #include <cstdint>
 #include <functional>
 #include <limits>
+#include <optional>
 #include <string>
 #include <string_view>
 #include <vector>
@@ -393,6 +395,13 @@ public:
         /** State/data availability established by a prior pass. */
         StateTransition,
         QueueOwnership,
+        /**
+         * Two non-overlapping logical transient resources reuse one physical
+         * whole-object allocation. This is an execution dependency, not a CPU
+         * recording dependency: immutable command lists may still be recorded
+         * in parallel and are submitted in compiled order.
+         */
+        TransientAlias,
     };
 
     struct CompiledAccess {
@@ -427,6 +436,8 @@ public:
         uint32_t       first_use     = PassHandle::InvalidIndex;
         uint32_t       last_use      = PassHandle::InvalidIndex;
         uint32_t       version_count = 0;
+        /** Compiler-assigned whole-object transient allocation slot. */
+        uint32_t       transient_slot = PassHandle::InvalidIndex;
         bool           imported      = false;
         bool           exported      = false;
     };
@@ -486,8 +497,27 @@ public:
         bool             import_boundary = false;
         bool             export_boundary = false;
         bool             source_state_unknown = false;
+        /** Whole-object transient reuse boundary between two logical resources. */
+        bool             transient_alias = false;
         /** Authoritative synchronization frontier whose scopes must be represented by lowering. */
         std::vector<CompiledBarrierSource> sources{};
+    };
+
+    /**
+     * Compiler-selected reuse of one descriptor-exact physical transient slot.
+     *
+     * This models whole RHI-object reuse. It is intentionally distinct from
+     * placed-resource / shared-heap aliasing.
+     */
+    struct CompiledAliasBoundary {
+        uint32_t       transient_slot = PassHandle::InvalidIndex;
+        ResourceHandle predecessor_resource{};
+        ResourceHandle successor_resource{};
+        /** Latest source for compact diagnostics; source_frontier is authoritative. */
+        PassHandle     primary_src_pass{};
+        std::vector<PassHandle> source_frontier{};
+        PassHandle     dst_pass{};
+        uint32_t       barrier_index = PassHandle::InvalidIndex;
     };
 
     struct CompiledQueueSync {
@@ -551,6 +581,8 @@ public:
         std::vector<CompiledRecordingBatch> recording_batches{};
         /** Canonical state/memory/ownership decisions, prior to backend-specific lowering. */
         std::vector<CompiledBarrier> barriers{};
+        /** Descriptor-exact, non-overlapping whole-object transient reuse boundaries. */
+        std::vector<CompiledAliasBoundary> alias_boundaries{};
         /** Prospective multi-queue batches and their GPU wait/signal relationships. */
         std::vector<CompiledQueueBatch> queue_batches{};
         std::vector<CompiledQueueSync>  queue_syncs{};
@@ -573,6 +605,7 @@ public:
             dependency_waves.clear();
             recording_batches.clear();
             barriers.clear();
+            alias_boundaries.clear();
             queue_batches.clear();
             queue_syncs.clear();
             pass_barriers.clear();
@@ -699,8 +732,9 @@ public:
     /**
      * Opts ExecuteRecording into the authoritative RDG state path.
      *
-     * Phase 11 materializes a fully validated Graphics-only lowered plan into
-     * explicit RHI barriers. Main-thread passes record into the caller-owned
+     * Active lowering materializes a fully validated Graphics-only plan into
+     * explicit RHI barriers and allocates descriptor-backed transients from a
+     * Completion-safe pool. Main-thread passes record into the caller-owned
      * list; independently recorded passes continue to own their own lists and
      * are mutation-sealed until one graph-wide RHI transaction commits. The
      * current backend-tracker bridge requires full-buffer ranges, all physical
@@ -709,11 +743,14 @@ public:
      * one graph. A physical MainThread graph must be isolated from nonphysical
      * passes and keep its caller-owned list unsealed until ExecuteRecording
      * returns (therefore no per-pass completion observer). Leaving enabled
-     * false preserves the legacy backend-tracked path.
+     * false preserves the legacy backend-tracked path and rejects active
+     * allocation-backed transient declarations.
      */
     struct ActiveRecordingOptions {
         bool         enabled                  = false;
         CommandList* main_thread_command_list = nullptr;
+        /** Defaults to the global completion-safe pool/allocator. */
+        RenderGraphTransientAllocator* transient_allocator = nullptr;
     };
 
     explicit RenderGraph(std::string_view name = "RenderGraph");
@@ -744,7 +781,28 @@ public:
     ResourceHandle CreateTransient(std::string_view name, ResourceKind kind);
     TextureHandle  CreateTransientTexture(std::string_view name, TextureDesc desc);
     BufferHandle   CreateTransientBuffer(std::string_view name, BufferDesc desc);
+    /**
+     * Allocation-backed transient declarations. The compiler shape is derived
+     * from the physical descriptor so range validation and pool keys cannot
+     * drift apart.
+     */
+    TextureHandle CreateTransientTexture(
+        std::string_view               name,
+        const RGTransientTextureDesc& allocation_desc
+    );
+    BufferHandle CreateTransientBuffer(
+        std::string_view              name,
+        const RGTransientBufferDesc& allocation_desc
+    );
     TokenHandle    CreateTransientToken(std::string_view name);
+
+    /**
+     * Valid during the declaring pass callback after active allocation.
+     * Retaining a physical ref beyond that callback is an RDG lifetime escape;
+     * declare PassBuilder::Reference wherever the object must remain live.
+     */
+    [[nodiscard]] TextureRef GetPhysicalTexture(TextureHandle resource) const;
+    [[nodiscard]] BufferRef  GetPhysicalBuffer(BufferHandle resource) const;
 
     void Export(ResourceHandle resource);
     void Export(TextureHandle resource) {
@@ -853,6 +911,7 @@ public:
 private:
     friend class RenderGraphCompiler;
     friend class RenderGraphLowering;
+    friend class RenderGraphTransientAllocator;
 
     struct AccessDeclaration {
         ResourceHandle resource{};
@@ -880,6 +939,8 @@ private:
         BufferRef                physical_buffer{};
         TextureDesc              texture_desc{};
         BufferDesc               buffer_desc{};
+        std::optional<RGTransientTextureDesc> transient_texture_desc{};
+        std::optional<RGTransientBufferDesc>  transient_buffer_desc{};
         bool                     typed_desc = false;
         bool                     imported   = false;
         bool                     exported   = false;
@@ -935,6 +996,7 @@ private:
         bool           initial
     );
     bool MarkExported(ResourceHandle resource, bool whole_resource);
+    void ReleaseNonExportedTransientBindings() noexcept;
     void AddDependency(uint32_t pass_index, PassHandle dependency);
     void AddReference(uint32_t pass_index, ResourceHandle resource);
     void MarkSideEffect(uint32_t pass_index);

--- a/source/runtime/render/rendergraph/RenderGraph.h
+++ b/source/runtime/render/rendergraph/RenderGraph.h
@@ -251,13 +251,14 @@ public:
         QueueRole role            = QueueRole::None;
         uint32_t  native_queue_id = 0;
         uint32_t  family_id       = 0;
+        bool      available       = true;
 
         friend bool operator==(const QueueBinding&, const QueueBinding&) = default;
     };
 
     /**
-     * Maps logical roles to actual queues. Tests may provide a fake topology; production currently
-     * uses SingleQueue() until the RHI submission path consumes the compiled plan.
+     * Maps logical roles to actual queues. Tests may provide a fake topology;
+     * active production graphs should snapshot QueueTopology::FromRHI().
      */
     struct QueueTopology {
         QueueBinding graphics{QueueRole::Graphics, 0, 0};
@@ -275,6 +276,9 @@ public:
                 .copy     = QueueBinding{QueueRole::Copy, 2, 2},
             };
         }
+
+        /** Snapshot the initialized RHI's real native queue/family mapping. */
+        [[nodiscard]] RENDER_API static QueueTopology FromRHI();
 
         [[nodiscard]] constexpr QueueBinding Resolve(QueueRole role) const {
             switch (role) {
@@ -560,10 +564,11 @@ public:
     };
 
     /**
-     * Immutable compiler output. recording_batches is an executable CPU
-     * ownership schedule. GPU queue/barrier fields remain shadow metadata:
-     * queue_syncs only describe internal pass/batch edges, while external
-     * import/export/present synchronization endpoints are intentionally absent.
+     * Immutable compiler output. recording_batches is the executable CPU
+     * ownership schedule; barriers, queue_batches, and queue_syncs are the
+     * active Graphics/Compute lowering contract. Queue syncs describe managed
+     * internal pass/batch edges only. External import/export/present
+     * synchronization endpoints remain intentionally absent.
      */
     struct CompiledPlan {
         /** Stable topological order of semantic dependencies. */

--- a/source/runtime/render/rendergraph/RenderGraph.h
+++ b/source/runtime/render/rendergraph/RenderGraph.h
@@ -465,9 +465,9 @@ public:
     };
 
     /**
-     * One canonical synchronization decision for one atomic resource cell. The future backend may
-     * lower a queue_ownership record into paired release/acquire barriers; RDG itself does not emit
-     * physical barriers in this stage.
+     * One canonical synchronization decision for one atomic resource cell.
+     * Lowering materializes queue_ownership as one paired release/acquire;
+     * RDG compilation itself remains backend-neutral.
      */
     struct CompiledBarrierSource {
         PassHandle      pass{};
@@ -566,8 +566,8 @@ public:
     /**
      * Immutable compiler output. recording_batches is the executable CPU
      * ownership schedule; barriers, queue_batches, and queue_syncs are the
-     * active Graphics/Compute lowering contract. Queue syncs describe managed
-     * internal pass/batch edges only. External import/export/present
+     * active Graphics/Compute/Copy lowering contract. Queue syncs describe
+     * managed internal pass/batch edges only. External import/export/present
      * synchronization endpoints remain intentionally absent.
      */
     struct CompiledPlan {

--- a/source/runtime/render/rendergraph/RenderGraphCompiler.cpp
+++ b/source/runtime/render/rendergraph/RenderGraphCompiler.cpp
@@ -167,14 +167,6 @@ ReasonLess(const RenderGraph::CompiledEdgeReason& lhs, const RenderGraph::Compil
     if (previous == next) {
         return true;
     }
-    if (previous.kind == ResourceKind::Texture) {
-        const bool previous_shader_read =
-            previous.texture == RenderGraph::TextureState::ShaderResource ||
-            previous.texture == RenderGraph::TextureState::Sampled;
-        const bool next_shader_read = next.texture == RenderGraph::TextureState::ShaderResource ||
-                                      next.texture == RenderGraph::TextureState::Sampled;
-        return previous_shader_read && next_shader_read;
-    }
     return false;
 }
 
@@ -186,9 +178,6 @@ ReasonLess(const RenderGraph::CompiledEdgeReason& lhs, const RenderGraph::Compil
         return lhs;
     }
     assert(StatesCompatible(lhs, rhs));
-    if (lhs.kind == ResourceKind::Texture) {
-        return RenderGraph::ResourceState::Texture(RenderGraph::TextureState::ShaderResource);
-    }
     return lhs;
 }
 

--- a/source/runtime/render/rendergraph/RenderGraphCompiler.cpp
+++ b/source/runtime/render/rendergraph/RenderGraphCompiler.cpp
@@ -235,10 +235,14 @@ bool RenderGraphCompiler::Compile() {
     }
 
     AuditStatePlanCompleteness();
+    BuildLifetimes();
+    BuildTransientAliasPlan();
+    if (!ValidateTransientAliasPlan()) {
+        return false;
+    }
     BuildQueuePlan();
     BuildDependencyWaves();
     BuildRecordingBatches();
-    BuildLifetimes();
     graph.compiled = true;
     return true;
 }
@@ -1074,7 +1078,28 @@ bool RenderGraphCompiler::BuildSemanticDependencies() {
 
     for (uint32_t resource_index = 0; resource_index < graph.resources.size(); ++resource_index) {
         const auto& resource = graph.resources[resource_index];
-        if (!resource.imported && !resource_ever_written[resource_index]) {
+        const bool has_gpu_access = std::any_of(
+            graph.compiled_plan.accesses.begin(),
+            graph.compiled_plan.accesses.end(),
+            [&](const RenderGraph::CompiledAccess& access) {
+                return access.resource.index == resource_index;
+            }
+        );
+        const bool has_opaque_reference = std::any_of(
+            graph.passes.begin(),
+            graph.passes.end(),
+            [&](const RenderGraph::PassDeclaration& pass) {
+                return std::any_of(
+                    pass.references.begin(),
+                    pass.references.end(),
+                    [&](RenderGraph::ResourceHandle reference) {
+                        return reference.index == resource_index;
+                    }
+                );
+            }
+        );
+        if (!resource.imported && (has_gpu_access || has_opaque_reference) &&
+            !resource_ever_written[resource_index]) {
             return Fail("transient resource has no producer: " + resource.name);
         }
         if (resource.exported) {
@@ -1707,10 +1732,568 @@ void RenderGraphCompiler::BuildLifetimes() {
             .first_use     = resource.first_use,
             .last_use      = resource.last_use,
             .version_count = resource_version_counts[resource_index],
+            .transient_slot = RenderGraph::PassHandle::InvalidIndex,
             .imported      = resource.imported,
             .exported      = resource.exported
         });
     }
+}
+
+void RenderGraphCompiler::BuildTransientAliasPlan() {
+    using CompiledAccess = RenderGraph::CompiledAccess;
+
+    struct Candidate {
+        uint32_t              resource_index = RenderGraph::PassHandle::InvalidIndex;
+        const CompiledAccess* first_access   = nullptr;
+        const CompiledAccess* last_access    = nullptr;
+        bool                  reusable       = false;
+    };
+
+    struct AliasSlot {
+        uint32_t                  id              = RenderGraph::PassHandle::InvalidIndex;
+        uint32_t                  tail_resource   = RenderGraph::PassHandle::InvalidIndex;
+        uint32_t                  available_after = RenderGraph::PassHandle::InvalidIndex;
+    };
+
+    const auto is_whole_range =
+        [](const RenderGraph::ResourceDeclaration& resource,
+           const RenderGraph::ResourceRange&       range) {
+            if (range.kind != resource.kind) {
+                return false;
+            }
+            if (resource.kind == ResourceKind::Texture) {
+                return range.texture.aspects == resource.texture_desc.aspects &&
+                       range.texture.mip_first == 0 &&
+                       range.texture.mip_count == resource.texture_desc.mip_count &&
+                       range.texture.layer_first == 0 &&
+                       range.texture.layer_count == resource.texture_desc.layer_count;
+            }
+            if (resource.kind == ResourceKind::Buffer) {
+                return range.buffer.offset == 0 &&
+                       range.buffer.size == resource.buffer_desc.byte_size;
+            }
+            return false;
+        };
+
+    const auto descriptors_match =
+        [&](uint32_t lhs_index, uint32_t rhs_index) {
+            const auto& lhs = graph.resources[lhs_index];
+            const auto& rhs = graph.resources[rhs_index];
+            if (lhs.kind != rhs.kind) {
+                return false;
+            }
+            if (lhs.kind == ResourceKind::Texture) {
+                return lhs.transient_texture_desc.has_value() &&
+                       rhs.transient_texture_desc.has_value() &&
+                       *lhs.transient_texture_desc == *rhs.transient_texture_desc;
+            }
+            if (lhs.kind == ResourceKind::Buffer) {
+                return lhs.transient_buffer_desc.has_value() &&
+                       rhs.transient_buffer_desc.has_value() &&
+                       *lhs.transient_buffer_desc == *rhs.transient_buffer_desc;
+            }
+            return false;
+        };
+
+    std::vector<uint32_t> execution_position(
+        graph.passes.size(),
+        RenderGraph::PassHandle::InvalidIndex
+    );
+    for (uint32_t position = 0; position < graph.compiled_plan.execution_order.size();
+         ++position) {
+        execution_position[graph.compiled_plan.execution_order[position].index] = position;
+    }
+
+    std::vector<Candidate> candidates{};
+    candidates.reserve(graph.resources.size());
+    for (uint32_t resource_index = 0; resource_index < graph.resources.size();
+         ++resource_index) {
+        auto&       compiled_resource = graph.compiled_plan.resources[resource_index];
+        const auto& resource          = graph.resources[resource_index];
+        const bool  allocation_backed =
+            !resource.imported &&
+            (resource.transient_texture_desc.has_value() ||
+             resource.transient_buffer_desc.has_value());
+        if (!allocation_backed ||
+            compiled_resource.first_use == RenderGraph::PassHandle::InvalidIndex) {
+            continue;
+        }
+
+        Candidate candidate{.resource_index = resource_index};
+        std::vector<const CompiledAccess*> accesses{};
+        for (const auto& access : graph.compiled_plan.accesses) {
+            if (access.resource.index == resource_index) {
+                accesses.push_back(&access);
+            }
+        }
+
+        const bool has_opaque_reference =
+            std::any_of(
+                graph.passes.begin(),
+                graph.passes.end(),
+                [&](const RenderGraph::PassDeclaration& pass) {
+                    return std::any_of(
+                        pass.references.begin(),
+                        pass.references.end(),
+                        [&](RenderGraph::ResourceHandle reference) {
+                            return reference.index == resource_index;
+                        }
+                    );
+                }
+            );
+
+        uint32_t first_access_count = 0;
+        uint32_t last_access_count  = 0;
+        bool     accesses_are_safe  = !accesses.empty();
+        for (const auto* access : accesses) {
+            const uint32_t position = execution_position[access->pass.index];
+            if (position == compiled_resource.first_use) {
+                candidate.first_access = access;
+                ++first_access_count;
+            }
+            if (position == compiled_resource.last_use) {
+                candidate.last_access = access;
+                ++last_access_count;
+            }
+            accesses_are_safe &=
+                position != RenderGraph::PassHandle::InvalidIndex &&
+                access->domain.queue == RenderGraph::QueueRole::Graphics &&
+                !access->state.IsAutomatic() && !access->state.IsUndefined() &&
+                is_whole_range(resource, access->range);
+        }
+
+        candidate.reusable =
+            !resource.exported && !has_opaque_reference && accesses_are_safe &&
+            resource_cells[resource_index].size() == 1 &&
+            first_access_count == 1 && last_access_count == 1 &&
+            candidate.first_access != nullptr && candidate.last_access != nullptr &&
+            candidate.first_access->mode == RenderGraph::AccessMode::Write;
+        candidates.push_back(candidate);
+    }
+
+    std::sort(
+        candidates.begin(),
+        candidates.end(),
+        [&](const Candidate& lhs, const Candidate& rhs) {
+            const auto& lhs_resource =
+                graph.compiled_plan.resources[lhs.resource_index];
+            const auto& rhs_resource =
+                graph.compiled_plan.resources[rhs.resource_index];
+            return lhs_resource.first_use < rhs_resource.first_use ||
+                   (lhs_resource.first_use == rhs_resource.first_use &&
+                    lhs.resource_index < rhs.resource_index);
+        }
+    );
+
+    uint32_t               next_slot = 0;
+    std::vector<AliasSlot> reusable_slots{};
+    for (const auto& candidate : candidates) {
+        auto& compiled_resource =
+            graph.compiled_plan.resources[candidate.resource_index];
+
+        AliasSlot* selected_slot = nullptr;
+        if (candidate.reusable) {
+            for (auto& slot : reusable_slots) {
+                if (slot.available_after >= compiled_resource.first_use ||
+                    !descriptors_match(slot.tail_resource, candidate.resource_index)) {
+                    continue;
+                }
+                if (selected_slot == nullptr ||
+                    slot.available_after > selected_slot->available_after ||
+                    (slot.available_after == selected_slot->available_after &&
+                     slot.id < selected_slot->id)) {
+                    selected_slot = &slot;
+                }
+            }
+        }
+
+        std::vector<RenderGraph::CompiledBarrierSource> alias_sources{};
+        const AtomicCell* predecessor_cell = nullptr;
+        const RenderGraph::CompiledBarrierSource* primary_source = nullptr;
+        if (selected_slot != nullptr &&
+            resource_cells[selected_slot->tail_resource].size() == 1) {
+            predecessor_cell =
+                &resource_cells[selected_slot->tail_resource].front();
+            alias_sources = predecessor_cell->readers;
+            if (predecessor_cell->last_writer_source.pass.IsValid() &&
+                std::find(
+                    alias_sources.begin(),
+                    alias_sources.end(),
+                    predecessor_cell->last_writer_source
+                ) == alias_sources.end()) {
+                alias_sources.push_back(
+                    predecessor_cell->last_writer_source
+                );
+            }
+            std::sort(
+                alias_sources.begin(),
+                alias_sources.end(),
+                [&](const RenderGraph::CompiledBarrierSource& lhs,
+                    const RenderGraph::CompiledBarrierSource& rhs) {
+                    return execution_position[lhs.pass.index] <
+                           execution_position[rhs.pass.index];
+                }
+            );
+            alias_sources.erase(
+                std::unique(alias_sources.begin(), alias_sources.end()),
+                alias_sources.end()
+            );
+            if (!alias_sources.empty()) {
+                primary_source = &alias_sources.back();
+            }
+        }
+
+        RenderGraph::CompiledBarrier* alias_barrier       = nullptr;
+        uint32_t alias_barrier_index =
+            RenderGraph::PassHandle::InvalidIndex;
+        if (selected_slot != nullptr && predecessor_cell != nullptr &&
+            primary_source != nullptr &&
+            execution_position[primary_source->pass.index] <
+                compiled_resource.first_use) {
+            for (uint32_t barrier_index = 0;
+                 barrier_index < graph.compiled_plan.barriers.size();
+                 ++barrier_index) {
+                auto& barrier = graph.compiled_plan.barriers[barrier_index];
+                if (barrier.resource.index == candidate.resource_index &&
+                    barrier.dst_pass == candidate.first_access->pass &&
+                    barrier.range == candidate.first_access->range &&
+                    !barrier.src_pass.IsValid() && barrier.sources.empty() &&
+                    barrier.before_state.IsUndefined() &&
+                    barrier.after_state == candidate.first_access->state &&
+                    barrier.after_access == candidate.first_access->mode &&
+                    !barrier.import_boundary && !barrier.export_boundary) {
+                    alias_barrier       = &barrier;
+                    alias_barrier_index = barrier_index;
+                    break;
+                }
+            }
+        }
+
+        if (selected_slot == nullptr || alias_barrier == nullptr ||
+            predecessor_cell == nullptr || primary_source == nullptr) {
+            compiled_resource.transient_slot = next_slot;
+            if (candidate.reusable) {
+                reusable_slots.push_back(AliasSlot{
+                    .id              = next_slot,
+                    .tail_resource   = candidate.resource_index,
+                    .available_after = compiled_resource.last_use,
+                });
+            }
+            ++next_slot;
+            continue;
+        }
+
+        const auto predecessor_resource = selected_slot->tail_resource;
+        alias_barrier->src_pass       = primary_source->pass;
+        alias_barrier->before_state   = predecessor_cell->state;
+        alias_barrier->before_access  = primary_source->access;
+        alias_barrier->src_domain     = primary_source->domain;
+        alias_barrier->state_transition =
+            !StatesCompatible(predecessor_cell->state, candidate.first_access->state);
+        alias_barrier->memory_dependency         = true;
+        alias_barrier->execution_dependency      = true;
+        alias_barrier->queue_dependency          = false;
+        alias_barrier->queue_ownership           = false;
+        alias_barrier->discard_previous_contents = false;
+        alias_barrier->source_state_unknown      = false;
+        alias_barrier->transient_alias           = true;
+        alias_barrier->sources                    = alias_sources;
+
+        compiled_resource.transient_slot = selected_slot->id;
+        graph.compiled_plan.alias_boundaries.push_back(
+            RenderGraph::CompiledAliasBoundary{
+                .transient_slot       = selected_slot->id,
+                .predecessor_resource = RenderGraph::ResourceHandle{
+                    predecessor_resource, graph.graph_id
+                },
+                .successor_resource = RenderGraph::ResourceHandle{
+                    candidate.resource_index, graph.graph_id
+                },
+                .primary_src_pass = primary_source->pass,
+                .source_frontier = [&] {
+                    std::vector<RenderGraph::PassHandle> result{};
+                    result.reserve(alias_sources.size());
+                    for (const auto& source : alias_sources) {
+                        result.push_back(source.pass);
+                    }
+                    return result;
+                }(),
+                .dst_pass      = candidate.first_access->pass,
+                .barrier_index = alias_barrier_index,
+            }
+        );
+        for (const auto& source : alias_sources) {
+            assert(
+                execution_position[source.pass.index] <
+                compiled_resource.first_use
+            );
+            AddEdge(
+                source.pass.index,
+                candidate.first_access->pass.index,
+                RenderGraph::CompiledEdgeReason{
+                    .kind = RenderGraph::EdgeReasonKind::TransientAlias,
+                    .resource = RenderGraph::ResourceHandle{
+                        candidate.resource_index, graph.graph_id
+                    },
+                    .range          = candidate.first_access->range,
+                    .input_version  = candidate.first_access->input_version,
+                    .output_version = candidate.first_access->output_version,
+                }
+            );
+        }
+
+        selected_slot->tail_resource   = candidate.resource_index;
+        selected_slot->available_after = compiled_resource.last_use;
+    }
+
+    // Alias edges are added after the semantic topological audit. They always
+    // point forward in the immutable execution order, so the existing order
+    // remains valid; restore canonical edge/reason order for all consumers.
+    std::sort(
+        graph.compiled_plan.edges.begin(),
+        graph.compiled_plan.edges.end(),
+        [](const RenderGraph::CompiledEdge& lhs, const RenderGraph::CompiledEdge& rhs) {
+            return lhs.src.index < rhs.src.index ||
+                   (lhs.src.index == rhs.src.index && lhs.dst.index < rhs.dst.index);
+        }
+    );
+    for (auto& edge : graph.compiled_plan.edges) {
+        std::sort(edge.reasons.begin(), edge.reasons.end(), ReasonLess);
+    }
+}
+
+bool RenderGraphCompiler::ValidateTransientAliasPlan() {
+    const auto& plan = graph.compiled_plan;
+    if (plan.resources.size() != graph.resources.size()) {
+        return Fail("transient alias plan has an incomplete resource table");
+    }
+
+    std::vector<uint32_t> execution_position(
+        graph.passes.size(),
+        RenderGraph::PassHandle::InvalidIndex
+    );
+    std::vector<uint32_t> topological_position(
+        graph.passes.size(),
+        RenderGraph::PassHandle::InvalidIndex
+    );
+    for (uint32_t position = 0; position < plan.execution_order.size(); ++position) {
+        execution_position[plan.execution_order[position].index] = position;
+    }
+    for (uint32_t position = 0; position < plan.topological_order.size(); ++position) {
+        topological_position[plan.topological_order[position].index] = position;
+    }
+
+    const auto descriptors_match = [&](uint32_t lhs_index, uint32_t rhs_index) {
+        const auto& lhs = graph.resources[lhs_index];
+        const auto& rhs = graph.resources[rhs_index];
+        if (lhs.kind != rhs.kind) {
+            return false;
+        }
+        if (lhs.kind == ResourceKind::Texture) {
+            return lhs.transient_texture_desc.has_value() &&
+                   rhs.transient_texture_desc.has_value() &&
+                   *lhs.transient_texture_desc == *rhs.transient_texture_desc;
+        }
+        if (lhs.kind == ResourceKind::Buffer) {
+            return lhs.transient_buffer_desc.has_value() &&
+                   rhs.transient_buffer_desc.has_value() &&
+                   *lhs.transient_buffer_desc == *rhs.transient_buffer_desc;
+        }
+        return false;
+    };
+
+    const auto has_alias_edge =
+        [&](RenderGraph::PassHandle source,
+            RenderGraph::PassHandle destination,
+            RenderGraph::ResourceHandle resource,
+            const RenderGraph::ResourceRange& range) {
+            return std::any_of(
+                plan.edges.begin(),
+                plan.edges.end(),
+                [&](const RenderGraph::CompiledEdge& edge) {
+                    return edge.src == source && edge.dst == destination &&
+                           std::any_of(
+                               edge.reasons.begin(),
+                               edge.reasons.end(),
+                               [&](const RenderGraph::CompiledEdgeReason& reason) {
+                                   return reason.kind ==
+                                              RenderGraph::EdgeReasonKind::TransientAlias &&
+                                          reason.resource == resource &&
+                                          reason.range == range;
+                               }
+                           );
+                }
+            );
+        };
+
+    for (const auto& edge : plan.edges) {
+        if (!graph.IsValidPass(edge.src) || !graph.IsValidPass(edge.dst) ||
+            topological_position[edge.src.index] ==
+                RenderGraph::PassHandle::InvalidIndex ||
+            topological_position[edge.dst.index] ==
+                RenderGraph::PassHandle::InvalidIndex ||
+            topological_position[edge.src.index] >=
+                topological_position[edge.dst.index]) {
+            return Fail(
+                "transient alias planning invalidated the compiled topological order"
+            );
+        }
+    }
+
+    std::vector<uint32_t> alias_barrier_owners(plan.barriers.size(), 0);
+    for (const auto& alias : plan.alias_boundaries) {
+        if (!graph.IsValidResource(alias.predecessor_resource) ||
+            !graph.IsValidResource(alias.successor_resource) ||
+            !graph.IsValidPass(alias.primary_src_pass) ||
+            !graph.IsValidPass(alias.dst_pass) ||
+            alias.barrier_index >= plan.barriers.size() ||
+            alias.source_frontier.empty()) {
+            return Fail("transient alias boundary contains an invalid handle or index");
+        }
+
+        const uint32_t predecessor_index = alias.predecessor_resource.index;
+        const uint32_t successor_index   = alias.successor_resource.index;
+        const auto& predecessor = plan.resources[predecessor_index];
+        const auto& successor   = plan.resources[successor_index];
+        const auto& predecessor_declaration = graph.resources[predecessor_index];
+        const auto& successor_declaration   = graph.resources[successor_index];
+        if (predecessor.transient_slot == RenderGraph::PassHandle::InvalidIndex ||
+            predecessor.transient_slot != alias.transient_slot ||
+            successor.transient_slot != alias.transient_slot ||
+            predecessor.first_use == RenderGraph::PassHandle::InvalidIndex ||
+            predecessor.last_use == RenderGraph::PassHandle::InvalidIndex ||
+            successor.first_use == RenderGraph::PassHandle::InvalidIndex ||
+            successor.last_use == RenderGraph::PassHandle::InvalidIndex ||
+            predecessor.last_use >= successor.first_use ||
+            predecessor_declaration.imported ||
+            successor_declaration.imported ||
+            predecessor_declaration.exported ||
+            successor_declaration.exported ||
+            !descriptors_match(predecessor_index, successor_index)) {
+            return Fail("transient alias boundary violates slot or lifetime compatibility");
+        }
+
+        const auto& barrier = plan.barriers[alias.barrier_index];
+        ++alias_barrier_owners[alias.barrier_index];
+        if (!barrier.transient_alias ||
+            barrier.resource != alias.successor_resource ||
+            barrier.src_pass != alias.primary_src_pass ||
+            barrier.dst_pass != alias.dst_pass ||
+            !barrier.memory_dependency || !barrier.execution_dependency ||
+            barrier.queue_dependency || barrier.queue_ownership ||
+            barrier.discard_previous_contents || barrier.import_boundary ||
+            barrier.export_boundary || barrier.source_state_unknown ||
+            barrier.sources.size() != alias.source_frontier.size()) {
+            return Fail("transient alias boundary and barrier metadata disagree");
+        }
+
+        for (uint32_t source_index = 0;
+             source_index < alias.source_frontier.size();
+             ++source_index) {
+            const auto source = alias.source_frontier[source_index];
+            if (!graph.IsValidPass(source) ||
+                barrier.sources[source_index].pass != source ||
+                execution_position[source.index] ==
+                    RenderGraph::PassHandle::InvalidIndex ||
+                execution_position[alias.dst_pass.index] ==
+                    RenderGraph::PassHandle::InvalidIndex ||
+                execution_position[source.index] >=
+                    execution_position[alias.dst_pass.index] ||
+                !has_alias_edge(
+                    source,
+                    alias.dst_pass,
+                    alias.successor_resource,
+                    barrier.range
+                )) {
+                return Fail(
+                    "transient alias source frontier is not fully ordered before its successor"
+                );
+            }
+        }
+        if (alias.source_frontier.back() != alias.primary_src_pass) {
+            return Fail("transient alias primary source is not the latest frontier source");
+        }
+    }
+
+    for (uint32_t barrier_index = 0; barrier_index < plan.barriers.size();
+         ++barrier_index) {
+        const uint32_t owner_count = alias_barrier_owners[barrier_index];
+        if ((plan.barriers[barrier_index].transient_alias && owner_count != 1) ||
+            (!plan.barriers[barrier_index].transient_alias && owner_count != 0)) {
+            return Fail(
+                "transient alias barrier does not have exactly one boundary owner"
+            );
+        }
+    }
+
+    uint32_t max_slot = 0;
+    bool     has_slot = false;
+    for (const auto& resource : plan.resources) {
+        if (resource.transient_slot != RenderGraph::PassHandle::InvalidIndex) {
+            max_slot = std::max(max_slot, resource.transient_slot);
+            has_slot = true;
+        }
+    }
+    for (uint32_t slot = 0; has_slot && slot <= max_slot; ++slot) {
+        std::vector<uint32_t> occupants{};
+        for (uint32_t resource_index = 0; resource_index < plan.resources.size();
+             ++resource_index) {
+            if (plan.resources[resource_index].transient_slot == slot) {
+                occupants.push_back(resource_index);
+            }
+        }
+        if (occupants.empty()) {
+            continue;
+        }
+        std::sort(
+            occupants.begin(),
+            occupants.end(),
+            [&](uint32_t lhs, uint32_t rhs) {
+                const auto& lhs_resource = plan.resources[lhs];
+                const auto& rhs_resource = plan.resources[rhs];
+                return lhs_resource.first_use < rhs_resource.first_use ||
+                       (lhs_resource.first_use == rhs_resource.first_use &&
+                        lhs < rhs);
+            }
+        );
+        for (uint32_t index = 0; index < occupants.size(); ++index) {
+            const auto resource_index = occupants[index];
+            const auto& resource      = plan.resources[resource_index];
+            if (resource.first_use == RenderGraph::PassHandle::InvalidIndex ||
+                resource.last_use == RenderGraph::PassHandle::InvalidIndex ||
+                graph.resources[resource_index].imported) {
+                return Fail("transient slot contains an inactive or imported resource");
+            }
+            if (index == 0) {
+                continue;
+            }
+            const uint32_t predecessor_index = occupants[index - 1];
+            const auto& predecessor = plan.resources[predecessor_index];
+            if (predecessor.last_use >= resource.first_use ||
+                !descriptors_match(predecessor_index, resource_index)) {
+                return Fail(
+                    "transient slot occupants overlap or have incompatible descriptors"
+                );
+            }
+            const bool has_boundary = std::any_of(
+                plan.alias_boundaries.begin(),
+                plan.alias_boundaries.end(),
+                [&](const RenderGraph::CompiledAliasBoundary& alias) {
+                    return alias.transient_slot == slot &&
+                           alias.predecessor_resource.index ==
+                               predecessor_index &&
+                           alias.successor_resource.index == resource_index;
+                }
+            );
+            if (!has_boundary) {
+                return Fail(
+                    "adjacent transient slot occupants lack an alias boundary"
+                );
+            }
+        }
+    }
+
+    return true;
 }
 
 bool RenderGraphCompiler::RangesOverlap(const ResourceRange& lhs, const ResourceRange& rhs) {

--- a/source/runtime/render/rendergraph/RenderGraphCompiler.cpp
+++ b/source/runtime/render/rendergraph/RenderGraphCompiler.cpp
@@ -503,6 +503,11 @@ bool RenderGraphCompiler::ValidateExecutionDomain(uint32_t pass_index) {
     if (queue == RenderGraph::QueueRole::None || domain == RenderGraph::PipelineType::None) {
         return Fail("pass '" + pass.name + "' has an incomplete execution domain");
     }
+    if (!graph.queue_topology.Resolve(queue).available) {
+        return Fail(
+            "pass '" + pass.name + "' targets an unavailable logical queue"
+        );
+    }
     if (queue == RenderGraph::QueueRole::Copy && domain != RenderGraph::PipelineType::Copy) {
         return Fail("copy queue pass '" + pass.name + "' must use the copy pipeline domain");
     }

--- a/source/runtime/render/rendergraph/RenderGraphCompiler.h
+++ b/source/runtime/render/rendergraph/RenderGraphCompiler.h
@@ -69,6 +69,8 @@ private:
     void BuildDependencyWaves();
     void BuildRecordingBatches();
     void BuildLifetimes();
+    void BuildTransientAliasPlan();
+    bool ValidateTransientAliasPlan();
 
     bool NormalizeRange(
         const RenderGraph::ResourceDeclaration& resource,

--- a/source/runtime/render/rendergraph/RenderGraphLowering.cpp
+++ b/source/runtime/render/rendergraph/RenderGraphLowering.cpp
@@ -337,7 +337,8 @@ void AppendInstruction(
            << " discard=" << instruction.discard_previous_contents
            << " import=" << instruction.import_boundary
            << " export=" << instruction.export_boundary
-           << " transient_alias=" << instruction.transient_alias;
+           << " transient_alias=" << instruction.transient_alias
+           << " queue_acquire=" << instruction.queue_acquire;
 }
 
 } // namespace
@@ -345,6 +346,7 @@ void AppendInstruction(
 void RenderGraphLowering::LoweredPlan::Clear() {
     prologue.clear();
     passes.clear();
+    queue_syncs.clear();
 }
 
 const RenderGraphLowering::PassInstructions*
@@ -380,7 +382,15 @@ RenderGraphLowering::LoweredPlan::Keepalive(RenderGraph::PassHandle pass) const 
 
 std::string RenderGraphLowering::LoweredPlan::Dump() const {
     std::ostringstream stream;
-    stream << "lowered prologue=" << prologue.size() << " passes=" << passes.size() << "\n";
+    stream << "lowered prologue=" << prologue.size() << " passes=" << passes.size()
+           << " queue_syncs=" << queue_syncs.size() << "\n";
+    for (const auto& sync : queue_syncs) {
+        stream << "sync=" << sync.correlation_id
+               << " signal_pass=" << sync.signal_pass.index
+               << " wait_pass=" << sync.wait_pass.index
+               << " signal_native=" << sync.signal_queue.native_queue_id
+               << " wait_native=" << sync.wait_queue.native_queue_id << "\n";
+    }
     for (const auto& instruction : prologue) {
         stream << "prologue ";
         AppendInstruction(stream, instruction);
@@ -433,36 +443,270 @@ bool RenderGraphLowering::Lower(
         return fail("compiled resource table is incomplete");
     }
 
-    std::vector<bool> gpu_pass(graph.passes.size(), false);
+    auto supported_queue = [](RenderGraph::QueueRole role) {
+        return role == RenderGraph::QueueRole::Graphics ||
+               role == RenderGraph::QueueRole::Compute;
+    };
+    std::vector<bool>     gpu_pass(graph.passes.size(), false);
+    std::vector<uint32_t> pass_queue_batch(
+        graph.passes.size(), RenderGraph::PassHandle::InvalidIndex
+    );
     for (const auto& pass : graph.passes) {
         if (pass.execution_class == RenderGraph::PassExecutionClass::ExternalControl) {
             return fail("ExternalControl pass is outside the managed lowering domain: '" +
                         pass.name + "'");
         }
     }
-    for (const auto& batch : compiled.queue_batches) {
+    std::vector<bool> execution_member(graph.passes.size(), false);
+    if (compiled.execution_order.size() != graph.passes.size()) {
+        return fail("execution order does not cover every declared pass");
+    }
+    for (const auto pass : compiled.execution_order) {
+        if (!graph.IsValidPass(pass) || execution_member[pass.index]) {
+            return fail("execution order contains an invalid or duplicate pass");
+        }
+        execution_member[pass.index] = true;
+    }
+    if (compiled.recording_batches.size() != compiled.execution_order.size()) {
+        return fail("recording schedule does not cover the execution order");
+    }
+    for (uint32_t batch_index = 0;
+         batch_index < compiled.recording_batches.size();
+         ++batch_index) {
+        const auto& batch = compiled.recording_batches[batch_index];
+        const auto  pass  = compiled.execution_order[batch_index];
+        const auto& declaration = graph.passes[pass.index];
+        if (batch.id != batch_index || batch.passes.size() != 1 ||
+            batch.passes.front() != pass ||
+            batch.queue != graph.queue_topology.Resolve(declaration.domain.queue) ||
+            batch.execution != declaration.execution_class ||
+            batch.workload != declaration.workload) {
+            return fail(
+                "recording schedule disagrees with stable execution order"
+            );
+        }
+    }
+    for (uint32_t batch_index = 0; batch_index < compiled.queue_batches.size();
+         ++batch_index) {
+        const auto& batch = compiled.queue_batches[batch_index];
         if (batch.external_control) {
             return fail("external-control queue batch is outside the managed lowering domain");
         }
-        if (batch.queue.role != RenderGraph::QueueRole::Graphics) {
-            return fail("only the Graphics logical queue is supported");
+        if (batch.id != batch_index || !batch.queue.available ||
+            !supported_queue(batch.queue.role)) {
+            return fail(
+                "queue batch has an unsupported role or unstable identifier"
+            );
+        }
+        if (batch.queue != graph.queue_topology.Resolve(batch.queue.role)) {
+            return fail("queue batch binding disagrees with the graph topology");
+        }
+        if (batch.passes.empty()) {
+            return fail("queue batch contains no GPU pass");
         }
         for (const auto pass : batch.passes) {
-            if (!graph.IsValidPass(pass)) {
-                return fail("queue batch references an invalid pass");
+            if (!graph.IsValidPass(pass) || !execution_member[pass.index]) {
+                return fail("queue batch references a pass outside execution order");
+            }
+            if (gpu_pass[pass.index]) {
+                return fail("GPU pass belongs to more than one queue batch");
             }
             gpu_pass[pass.index] = true;
-            if (graph.passes[pass.index].domain.queue != RenderGraph::QueueRole::Graphics) {
+            pass_queue_batch[pass.index] = batch_index;
+            if (graph.passes[pass.index].domain.queue != batch.queue.role) {
                 return fail("GPU pass '" + graph.passes[pass.index].name +
-                            "' does not use the Graphics logical queue");
+                            "' disagrees with its queue batch role");
             }
         }
     }
-    for (const auto& sync : compiled.queue_syncs) {
-        if (sync.gpu_wait_required ||
-            sync.signal_queue.role != RenderGraph::QueueRole::Graphics ||
-            sync.wait_queue.role != RenderGraph::QueueRole::Graphics) {
-            return fail("cross-queue synchronization is not supported");
+    for (const auto pass : compiled.execution_order) {
+        const bool should_be_gpu =
+            graph.passes[pass.index].execution_class !=
+            RenderGraph::PassExecutionClass::CpuPrepare;
+        if (gpu_pass[pass.index] != should_be_gpu) {
+            return fail(
+                should_be_gpu ?
+                    "execution-order GPU pass has no queue batch" :
+                    "CpuPrepare pass unexpectedly belongs to a queue batch"
+            );
+        }
+    }
+    for (uint32_t batch_index = 0; batch_index < compiled.queue_batches.size();
+         ++batch_index) {
+        const auto& batch = compiled.queue_batches[batch_index];
+        std::vector<bool> seen_signals(compiled.queue_syncs.size(), false);
+        for (const uint32_t sync_index : batch.signal_syncs) {
+            if (sync_index >= compiled.queue_syncs.size() ||
+                seen_signals[sync_index] ||
+                compiled.queue_syncs[sync_index].signal_batch != batch_index) {
+                return fail("queue batch has an invalid or duplicate signal sync");
+            }
+            seen_signals[sync_index] = true;
+        }
+        std::vector<bool> seen_waits(compiled.queue_syncs.size(), false);
+        for (const uint32_t sync_index : batch.wait_syncs) {
+            if (sync_index >= compiled.queue_syncs.size() ||
+                seen_waits[sync_index] ||
+                compiled.queue_syncs[sync_index].wait_batch != batch_index) {
+                return fail("queue batch has an invalid or duplicate wait sync");
+            }
+            seen_waits[sync_index] = true;
+        }
+    }
+    std::vector<QueueSyncInstruction> lowered_queue_syncs{};
+    lowered_queue_syncs.reserve(compiled.queue_syncs.size());
+    for (uint32_t sync_index = 0; sync_index < compiled.queue_syncs.size();
+         ++sync_index) {
+        const auto& sync = compiled.queue_syncs[sync_index];
+        if (sync.id != sync_index ||
+            sync.signal_batch >= compiled.queue_batches.size() ||
+            sync.wait_batch >= compiled.queue_batches.size() ||
+            !graph.IsValidPass(sync.signal_pass) ||
+            !graph.IsValidPass(sync.wait_pass) ||
+            !supported_queue(sync.signal_queue.role) ||
+            !supported_queue(sync.wait_queue.role)) {
+            return fail("queue synchronization record is malformed");
+        }
+        const bool duplicate_pair = std::any_of(
+            compiled.queue_syncs.begin(),
+            compiled.queue_syncs.begin() + sync_index,
+            [&](const RenderGraph::CompiledQueueSync& candidate) {
+                return candidate.signal_batch == sync.signal_batch &&
+                       candidate.wait_batch == sync.wait_batch;
+            }
+        );
+        if (duplicate_pair || sync.signal_batch >= sync.wait_batch) {
+            return fail(
+                duplicate_pair ?
+                    "queue synchronization batch pair is duplicated" :
+                    "queue synchronization is not forward ordered"
+            );
+        }
+        const auto& signal_batch = compiled.queue_batches[sync.signal_batch];
+        const auto& wait_batch   = compiled.queue_batches[sync.wait_batch];
+        if (signal_batch.passes.empty() || wait_batch.passes.empty() ||
+            sync.signal_pass != signal_batch.passes.back() ||
+            sync.wait_pass != wait_batch.passes.front() ||
+            sync.signal_queue != signal_batch.queue ||
+            sync.wait_queue != wait_batch.queue ||
+            pass_queue_batch[sync.signal_pass.index] != sync.signal_batch ||
+            pass_queue_batch[sync.wait_pass.index] != sync.wait_batch) {
+            return fail("queue synchronization endpoints disagree with their batches");
+        }
+        if (std::count(
+                signal_batch.signal_syncs.begin(),
+                signal_batch.signal_syncs.end(),
+                sync_index
+            ) != 1 ||
+            std::count(
+                wait_batch.wait_syncs.begin(),
+                wait_batch.wait_syncs.end(),
+                sync_index
+            ) != 1) {
+            return fail("queue synchronization is not owned by both endpoint batches");
+        }
+        const bool crosses_native =
+            sync.signal_queue.native_queue_id != sync.wait_queue.native_queue_id;
+        if (sync.gpu_wait_required != crosses_native) {
+            return fail("queue synchronization GPU-wait policy disagrees with topology");
+        }
+        if (sync.gpu_wait_required && sync.dependency_edges.empty()) {
+            return fail(
+                "cross-native queue synchronization has no dependency edge"
+            );
+        }
+        std::vector<bool> seen_edges(compiled.edges.size(), false);
+        for (const uint32_t edge_index : sync.dependency_edges) {
+            if (edge_index >= compiled.edges.size() || seen_edges[edge_index]) {
+                return fail(
+                    "queue synchronization has an invalid or duplicate dependency edge"
+                );
+            }
+            seen_edges[edge_index] = true;
+            const auto& edge = compiled.edges[edge_index];
+            if (!graph.IsValidPass(edge.src) || !graph.IsValidPass(edge.dst) ||
+                pass_queue_batch[edge.src.index] != sync.signal_batch ||
+                pass_queue_batch[edge.dst.index] != sync.wait_batch) {
+                return fail(
+                    "queue synchronization dependency edge disagrees with its batches"
+                );
+            }
+        }
+        std::vector<bool> seen_barriers(compiled.barriers.size(), false);
+        for (const uint32_t barrier_index : sync.barriers) {
+            if (barrier_index >= compiled.barriers.size() ||
+                seen_barriers[barrier_index]) {
+                return fail(
+                    "queue synchronization has an invalid or duplicate barrier"
+                );
+            }
+            seen_barriers[barrier_index] = true;
+            const auto& barrier = compiled.barriers[barrier_index];
+            const bool matching_destination =
+                graph.IsValidPass(barrier.dst_pass) &&
+                pass_queue_batch[barrier.dst_pass.index] == sync.wait_batch;
+            const bool matching_source = std::any_of(
+                barrier.sources.begin(),
+                barrier.sources.end(),
+                [&](const RenderGraph::CompiledBarrierSource& source) {
+                    return graph.IsValidPass(source.pass) &&
+                           pass_queue_batch[source.pass.index] ==
+                               sync.signal_batch;
+                }
+            );
+            if (!matching_destination || !matching_source) {
+                return fail(
+                    "queue synchronization barrier disagrees with its batches"
+                );
+            }
+        }
+        if (sync.gpu_wait_required) {
+            lowered_queue_syncs.push_back(QueueSyncInstruction{
+                .correlation_id = sync.id,
+                .signal_pass    = sync.signal_pass,
+                .wait_pass      = sync.wait_pass,
+                .signal_queue   = sync.signal_queue,
+                .wait_queue     = sync.wait_queue,
+            });
+        }
+    }
+    for (uint32_t edge_index = 0; edge_index < compiled.edges.size();
+         ++edge_index) {
+        const auto& edge = compiled.edges[edge_index];
+        if (!graph.IsValidPass(edge.src) || !graph.IsValidPass(edge.dst)) {
+            return fail("compiled dependency edge references an invalid pass");
+        }
+        const uint32_t signal_batch = pass_queue_batch[edge.src.index];
+        const uint32_t wait_batch   = pass_queue_batch[edge.dst.index];
+        if (signal_batch == RenderGraph::PassHandle::InvalidIndex ||
+            wait_batch == RenderGraph::PassHandle::InvalidIndex ||
+            signal_batch == wait_batch) {
+            continue;
+        }
+        const auto& signal_queue = compiled.queue_batches[signal_batch].queue;
+        const auto& wait_queue   = compiled.queue_batches[wait_batch].queue;
+        if (signal_queue.native_queue_id == wait_queue.native_queue_id) {
+            continue;
+        }
+        const auto sync = std::find_if(
+            compiled.queue_syncs.begin(),
+            compiled.queue_syncs.end(),
+            [&](const RenderGraph::CompiledQueueSync& candidate) {
+                return candidate.signal_batch == signal_batch &&
+                       candidate.wait_batch == wait_batch &&
+                       candidate.gpu_wait_required &&
+                       std::find(
+                           candidate.dependency_edges.begin(),
+                           candidate.dependency_edges.end(),
+                           edge_index
+                       ) != candidate.dependency_edges.end();
+            }
+        );
+        if (sync == compiled.queue_syncs.end()) {
+            return fail(
+                "cross-native dependency edge is not correlated with an "
+                "executable GPU sync"
+            );
         }
     }
 
@@ -485,8 +729,8 @@ bool RenderGraphLowering::Lower(
         if (!IsKnownAccess(access.mode)) {
             return fail("physical access uses Unknown access on resource '" + resource.name + "'");
         }
-        if (access.domain.queue != RenderGraph::QueueRole::Graphics) {
-            return fail("physical access does not use the Graphics logical queue on resource '" +
+        if (!supported_queue(access.domain.queue)) {
+            return fail("physical access uses an unsupported logical queue on resource '" +
                         resource.name + "'");
         }
         if (access.state.kind == ResourceKind::Texture &&
@@ -527,8 +771,9 @@ bool RenderGraphLowering::Lower(
             }
             return true;
         }
-        if (state.queue != RenderGraph::QueueRole::Graphics) {
-            error = "only Graphics boundary ownership is supported on resource '" + resource.name + "'";
+        if (!supported_queue(state.queue)) {
+            error = "boundary uses an unsupported queue on resource '" +
+                    resource.name + "'";
             return false;
         }
         return true;
@@ -724,6 +969,7 @@ bool RenderGraphLowering::Lower(
     }
 
     LoweredPlan candidate{};
+    candidate.queue_syncs = lowered_queue_syncs;
     candidate.passes.reserve(compiled.execution_order.size());
     for (const auto pass : compiled.execution_order) {
         if (!graph.IsValidPass(pass)) {
@@ -802,6 +1048,7 @@ bool RenderGraphLowering::Lower(
 
     auto lower_instruction = [&](uint32_t barrier_index, LoweredInstruction& instruction) {
         const auto& barrier = compiled.barriers[barrier_index];
+        bool queue_acquire = false;
         if (!graph.IsValidResource(barrier.resource)) {
             error = "barrier references an invalid resource";
             return false;
@@ -811,9 +1058,57 @@ bool RenderGraphLowering::Lower(
             error = "token barrier cannot be physically lowered";
             return false;
         }
-        if (barrier.queue_dependency || barrier.queue_ownership) {
-            error = "queue dependency or ownership transfer is not supported";
+        if (barrier.queue_ownership) {
+            error =
+                "queue-family ownership requires paired release/acquire lowering";
             return false;
+        }
+        if (barrier.queue_dependency &&
+            (!barrier.src_pass.IsValid() || !barrier.dst_pass.IsValid())) {
+            error =
+                "cross-queue external boundary lacks a managed synchronization endpoint";
+            return false;
+        }
+        if (barrier.queue_dependency) {
+            for (const auto& source : barrier.sources) {
+                if (!graph.IsValidPass(source.pass)) {
+                    error = "queue barrier contains an invalid source pass";
+                    return false;
+                }
+                const uint32_t signal_batch =
+                    pass_queue_batch[source.pass.index];
+                const uint32_t wait_batch =
+                    pass_queue_batch[barrier.dst_pass.index];
+                if (signal_batch == RenderGraph::PassHandle::InvalidIndex ||
+                    wait_batch == RenderGraph::PassHandle::InvalidIndex) {
+                    error = "queue barrier source or destination has no queue batch";
+                    return false;
+                }
+                if (compiled.queue_batches[signal_batch].queue.native_queue_id ==
+                    compiled.queue_batches[wait_batch].queue.native_queue_id) {
+                    continue;
+                }
+                queue_acquire = true;
+                const auto sync = std::find_if(
+                    compiled.queue_syncs.begin(),
+                    compiled.queue_syncs.end(),
+                    [&](const RenderGraph::CompiledQueueSync& candidate) {
+                        return candidate.signal_batch == signal_batch &&
+                               candidate.wait_batch == wait_batch &&
+                               candidate.gpu_wait_required &&
+                               std::find(
+                                   candidate.barriers.begin(),
+                                   candidate.barriers.end(),
+                                   barrier_index
+                               ) != candidate.barriers.end();
+                    }
+                );
+                if (sync == compiled.queue_syncs.end()) {
+                    error =
+                        "queue barrier is not correlated with an executable GPU sync";
+                    return false;
+                }
+            }
         }
         if (barrier.source_state_unknown) {
             error = "barrier source state is unknown";
@@ -835,13 +1130,13 @@ bool RenderGraphLowering::Lower(
         }
         if (barrier.dst_pass.IsValid()) {
             if (!graph.IsValidPass(barrier.dst_pass) ||
-                barrier.dst_domain.queue != RenderGraph::QueueRole::Graphics) {
-                error = "barrier destination is not a valid Graphics pass";
+                !supported_queue(barrier.dst_domain.queue)) {
+                error = "barrier destination is not a supported GPU pass";
                 return false;
             }
         } else if (!barrier.export_boundary ||
-                   barrier.dst_domain.queue != RenderGraph::QueueRole::Graphics) {
-            error = "barrier has no managed Graphics destination";
+                   !supported_queue(barrier.dst_domain.queue)) {
+            error = "barrier has no managed supported destination";
             return false;
         }
 
@@ -870,6 +1165,7 @@ bool RenderGraphLowering::Lower(
             .import_boundary         = barrier.import_boundary,
             .export_boundary         = barrier.export_boundary,
             .transient_alias         = barrier.transient_alias,
+            .queue_acquire           = queue_acquire,
         };
 
         if (resource.kind == ResourceKind::Texture) {
@@ -888,7 +1184,7 @@ bool RenderGraphLowering::Lower(
             bool first_source = true;
             for (const auto& source : barrier.sources) {
                 if (!graph.IsValidPass(source.pass) ||
-                    source.domain.queue != RenderGraph::QueueRole::Graphics ||
+                    !supported_queue(source.domain.queue) ||
                     !IsKnownAccess(source.access) || source.state.IsAutomatic()) {
                     error = "barrier fan-in contains an unsupported source";
                     return false;
@@ -898,6 +1194,23 @@ bool RenderGraphLowering::Lower(
                     return false;
                 }
                 instruction.source_frontier.push_back(source.pass);
+                const uint32_t source_batch =
+                    pass_queue_batch[source.pass.index];
+                const uint32_t destination_batch =
+                    barrier.dst_pass.IsValid() ?
+                        pass_queue_batch[barrier.dst_pass.index] :
+                        RenderGraph::PassHandle::InvalidIndex;
+                const bool contributes_local_scope =
+                    !instruction.queue_acquire ||
+                    (source_batch != RenderGraph::PassHandle::InvalidIndex &&
+                     destination_batch != RenderGraph::PassHandle::InvalidIndex &&
+                     compiled.queue_batches[source_batch]
+                             .queue.native_queue_id ==
+                         compiled.queue_batches[destination_batch]
+                             .queue.native_queue_id);
+                if (!contributes_local_scope) {
+                    continue;
+                }
                 if (first_source) {
                     instruction.source = source_scope;
                     first_source = false;
@@ -940,6 +1253,14 @@ bool RenderGraphLowering::Lower(
                 error
             )) {
             return false;
+        }
+        if (instruction.queue_acquire && barrier.sources.empty()) {
+            // The semaphore wait supplies the cross-queue memory dependency.
+            // This destination-local barrier performs visibility/layout
+            // adoption without pretending its source scope executes on the
+            // consumer queue.
+            instruction.source.stages = ERHIPipelineStageFlags::PS_NONE;
+            instruction.source.access = ERHIAccessFlags::UNDEFINED;
         }
         if (instruction.discard_previous_contents && !barrier.before_state.IsUndefined()) {
             error = "discard flag requires an Undefined source state";

--- a/source/runtime/render/rendergraph/RenderGraphLowering.cpp
+++ b/source/runtime/render/rendergraph/RenderGraphLowering.cpp
@@ -1,0 +1,988 @@
+#include "rendergraph/RenderGraphLowering.h"
+
+#include <algorithm>
+#include <cstdint>
+#include <sstream>
+#include <tuple>
+
+namespace Moer::Render {
+
+namespace {
+
+using AccessMode    = RenderGraph::AccessMode;
+using BufferState   = RenderGraph::BufferState;
+using ExecutionDomain = RenderGraph::ExecutionDomain;
+using PipelineType  = RenderGraph::PipelineType;
+using ResourceKind  = RenderGraph::ResourceKind;
+using ResourceState = RenderGraph::ResourceState;
+using TextureAspect = RenderGraph::TextureAspect;
+using TextureState  = RenderGraph::TextureState;
+
+[[nodiscard]] constexpr bool HasRead(AccessMode access) {
+    return access == AccessMode::Read || access == AccessMode::ReadWrite;
+}
+
+[[nodiscard]] constexpr bool HasWrite(AccessMode access) {
+    return access == AccessMode::Write || access == AccessMode::ReadWrite;
+}
+
+[[nodiscard]] constexpr bool IsKnownAccess(AccessMode access) {
+    return access != AccessMode::Unknown;
+}
+
+template<typename Enum>
+[[nodiscard]] constexpr Enum Or(Enum lhs, Enum rhs) {
+    return static_cast<Enum>(
+        static_cast<uint32_t>(lhs) | static_cast<uint32_t>(rhs)
+    );
+}
+
+[[nodiscard]] bool ShaderStages(
+    PipelineType             pipeline,
+    ERHIPipelineStageFlags& stages,
+    std::string&             error
+) {
+    switch (pipeline) {
+        case PipelineType::None:
+            stages = ERHIPipelineStageFlags::PS_ALL_COMMANDS;
+            return true;
+        case PipelineType::Graphics:
+            stages = ERHIPipelineStageFlags::PS_ALL_GRAPHICS;
+            return true;
+        case PipelineType::Compute:
+            stages = ERHIPipelineStageFlags::PS_COMPUTE_SHADER;
+            return true;
+        case PipelineType::RayTracing:
+            stages = ERHIPipelineStageFlags::PS_RAY_TRACING_SHADER;
+            return true;
+        case PipelineType::Copy:
+            error = "a shader resource cannot use the Copy pipeline domain";
+            return false;
+    }
+    error = "unrecognized pipeline domain";
+    return false;
+}
+
+[[nodiscard]] bool TextureLayoutFor(
+    TextureState    state,
+    ETextureLayout& layout,
+    std::string&    error
+) {
+    switch (state) {
+        case TextureState::Undefined:
+            layout = ETextureLayout::TEXTURE_LAYOUT_UNDEFINED;
+            return true;
+        case TextureState::TransferSource:
+            layout = ETextureLayout::TEXTURE_LAYOUT_TRANSFER_SRC;
+            return true;
+        case TextureState::TransferDestination:
+            layout = ETextureLayout::TEXTURE_LAYOUT_TRANSFER_DST;
+            return true;
+        case TextureState::ShaderResource:
+            layout = ETextureLayout::TEXTURE_LAYOUT_COMMON;
+            return true;
+        case TextureState::Sampled:
+            layout = ETextureLayout::TEXTURE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+            return true;
+        case TextureState::RenderTarget:
+            layout = ETextureLayout::TEXTURE_LAYOUT_COLOR_ATTACHMENT;
+            return true;
+        case TextureState::DepthStencilRead:
+            // The Vulkan command preprocessor records every depth attachment
+            // (including load-only attachments) in ATTACHMENT_OPTIMAL. Keep
+            // the explicit RDG state aligned with that physical body state.
+            // Depth textures consumed by shaders use Sampled instead.
+            layout = ETextureLayout::TEXTURE_LAYOUT_DEPTH_STENCIL_WRITE;
+            return true;
+        case TextureState::DepthStencilWrite:
+            layout = ETextureLayout::TEXTURE_LAYOUT_DEPTH_STENCIL_WRITE;
+            return true;
+        case TextureState::UnorderedAccess:
+            layout = ETextureLayout::TEXTURE_LAYOUT_COMMON;
+            return true;
+        case TextureState::Automatic:
+            error = "Automatic texture state has no physical layout";
+            return false;
+        case TextureState::Present:
+            error = "Present layout requires an external synchronization endpoint";
+            return false;
+    }
+    error = "unrecognized texture state";
+    return false;
+}
+
+[[nodiscard]] bool MapScope(
+    const ResourceState&             state,
+    AccessMode                       access,
+    const ExecutionDomain&           domain,
+    RenderGraphLowering::Scope&      scope,
+    std::string&                     error
+) {
+    if (!IsKnownAccess(access)) {
+        error = "Unknown access cannot be lowered";
+        return false;
+    }
+    if (state.kind == ResourceKind::Token) {
+        error = "token state cannot produce a physical barrier";
+        return false;
+    }
+    if (state.IsAutomatic()) {
+        error = "Automatic state cannot be lowered";
+        return false;
+    }
+
+    scope = {};
+    if (state.kind == ResourceKind::Texture) {
+        scope.has_texture_layout = true;
+        if (!TextureLayoutFor(state.texture, scope.layout, error)) {
+            return false;
+        }
+        switch (state.texture) {
+            case TextureState::Undefined:
+                if (access != AccessMode::None) {
+                    error = "Undefined texture state must use None access";
+                    return false;
+                }
+                scope.stages = ERHIPipelineStageFlags::PS_NONE;
+                scope.access = ERHIAccessFlags::UNDEFINED;
+                return true;
+            case TextureState::TransferSource:
+                scope.stages = ERHIPipelineStageFlags::PS_TRANSFER;
+                scope.access = ERHIAccessFlags::TRANSFER_READ;
+                return true;
+            case TextureState::TransferDestination:
+                scope.stages = ERHIPipelineStageFlags::PS_TRANSFER;
+                scope.access = ERHIAccessFlags::TRANSFER_WRITE;
+                return true;
+            case TextureState::ShaderResource:
+            case TextureState::Sampled:
+                if (!ShaderStages(domain.pipeline, scope.stages, error)) {
+                    return false;
+                }
+                // VkCmdPreprocessor uses a generic shader-read access for both
+                // SRV descriptor forms; their layouts remain distinct.
+                scope.access = ERHIAccessFlags::SHADER_READ;
+                return true;
+            case TextureState::RenderTarget:
+                scope.stages = ERHIPipelineStageFlags::PS_COLOR_ATTACHMENT_OUTPUT;
+                if (HasRead(access)) {
+                    scope.access = Or(scope.access, ERHIAccessFlags::COLOR_ATTACHMENT_READ);
+                }
+                if (HasWrite(access)) {
+                    scope.access = Or(scope.access, ERHIAccessFlags::COLOR_ATTACHMENT_WRITE);
+                }
+                return true;
+            case TextureState::DepthStencilRead:
+            case TextureState::DepthStencilWrite:
+                scope.stages = Or(
+                    ERHIPipelineStageFlags::PS_EARLY_FRAGMENT_TESTS,
+                    ERHIPipelineStageFlags::PS_LATE_FRAGMENT_TESTS
+                );
+                if (HasRead(access)) {
+                    scope.access = Or(scope.access, ERHIAccessFlags::DEPTH_STENCIL_READ);
+                }
+                if (HasWrite(access)) {
+                    scope.access = Or(scope.access, ERHIAccessFlags::DEPTH_STENCIL_WRITE);
+                }
+                return true;
+            case TextureState::UnorderedAccess:
+                if (!ShaderStages(domain.pipeline, scope.stages, error)) {
+                    return false;
+                }
+                if (HasRead(access)) {
+                    scope.access = Or(scope.access, ERHIAccessFlags::SHADER_READ);
+                }
+                if (HasWrite(access)) {
+                    scope.access = Or(scope.access, ERHIAccessFlags::SHADER_WRITE);
+                }
+                return true;
+            case TextureState::Automatic:
+            case TextureState::Present:
+                break;
+        }
+    } else {
+        scope.has_texture_layout = false;
+        switch (state.buffer) {
+            case BufferState::Undefined:
+                if (access != AccessMode::None) {
+                    error = "Undefined buffer state must use None access";
+                    return false;
+                }
+                scope.stages = ERHIPipelineStageFlags::PS_NONE;
+                scope.access = ERHIAccessFlags::UNDEFINED;
+                return true;
+            case BufferState::TransferSource:
+                scope.stages = ERHIPipelineStageFlags::PS_TRANSFER;
+                scope.access = ERHIAccessFlags::TRANSFER_READ;
+                return true;
+            case BufferState::TransferDestination:
+                scope.stages = ERHIPipelineStageFlags::PS_TRANSFER;
+                scope.access = ERHIAccessFlags::TRANSFER_WRITE;
+                return true;
+            case BufferState::VertexBuffer:
+                scope.stages = ERHIPipelineStageFlags::PS_VERTEX_INPUT;
+                scope.access = ERHIAccessFlags::VERTEX_ATTRIBUTE_READ;
+                return true;
+            case BufferState::IndexBuffer:
+                scope.stages = ERHIPipelineStageFlags::PS_VERTEX_INPUT;
+                scope.access = ERHIAccessFlags::INDEX_READ;
+                return true;
+            case BufferState::IndirectArgument:
+                scope.stages = ERHIPipelineStageFlags::PS_DRAW_INDIRECT;
+                scope.access = ERHIAccessFlags::INDIRECT_COMMAND_READ;
+                return true;
+            case BufferState::ShaderResource:
+                if (!ShaderStages(domain.pipeline, scope.stages, error)) {
+                    return false;
+                }
+                // VkCmdPreprocessor records CBV/SRV buffers with the generic
+                // shader-read access bit.
+                scope.access = ERHIAccessFlags::SHADER_READ;
+                return true;
+            case BufferState::UnorderedAccess:
+                if (!ShaderStages(domain.pipeline, scope.stages, error)) {
+                    return false;
+                }
+                if (HasRead(access)) {
+                    scope.access = Or(scope.access, ERHIAccessFlags::SHADER_READ);
+                }
+                if (HasWrite(access)) {
+                    scope.access = Or(scope.access, ERHIAccessFlags::SHADER_WRITE);
+                }
+                return true;
+            case BufferState::AccelerationStructureBuildInput:
+                scope.stages = ERHIPipelineStageFlags::PS_ACCELERATION_STRUCTURE_BUILD;
+                scope.access = ERHIAccessFlags::ACCELERATION_STRUCTURE_READ_BIT;
+                return true;
+            case BufferState::AccelerationStructureRead:
+                if (!ShaderStages(domain.pipeline, scope.stages, error)) {
+                    return false;
+                }
+                scope.access = ERHIAccessFlags::ACCELERATION_STRUCTURE_READ_BIT;
+                return true;
+            case BufferState::AccelerationStructureWrite:
+                scope.stages = ERHIPipelineStageFlags::PS_ACCELERATION_STRUCTURE_BUILD;
+                scope.access = ERHIAccessFlags::ACCELERATION_STRUCTURE_WRITE_BIT;
+                return true;
+            case BufferState::Automatic:
+                break;
+        }
+    }
+    error = "unsupported resource state";
+    return false;
+}
+
+[[nodiscard]] ETextureAspectFlags LowerAspects(TextureAspect aspects) {
+    ETextureAspectFlags result = ETextureAspectFlags::NONE;
+    const auto mask = static_cast<uint8_t>(aspects);
+    if ((mask & static_cast<uint8_t>(TextureAspect::Color)) != 0) {
+        result = Or(result, ETextureAspectFlags::COLOR);
+    }
+    if ((mask & static_cast<uint8_t>(TextureAspect::Depth)) != 0) {
+        result = Or(result, ETextureAspectFlags::DEPTH_SLICE);
+    }
+    if ((mask & static_cast<uint8_t>(TextureAspect::Stencil)) != 0) {
+        result = Or(result, ETextureAspectFlags::STENCIL_SLICE);
+    }
+    return result;
+}
+
+[[nodiscard]] TextureAspect RaiseAspects(ETextureAspectFlags aspects) {
+    TextureAspect result = TextureAspect::None;
+    const auto mask = static_cast<uint32_t>(aspects);
+    if ((mask & static_cast<uint32_t>(ETextureAspectFlags::COLOR)) != 0) {
+        result = static_cast<TextureAspect>(
+            static_cast<uint8_t>(result) | static_cast<uint8_t>(TextureAspect::Color)
+        );
+    }
+    if ((mask & static_cast<uint32_t>(ETextureAspectFlags::DEPTH_SLICE)) != 0) {
+        result = static_cast<TextureAspect>(
+            static_cast<uint8_t>(result) | static_cast<uint8_t>(TextureAspect::Depth)
+        );
+    }
+    if ((mask & static_cast<uint32_t>(ETextureAspectFlags::STENCIL_SLICE)) != 0) {
+        result = static_cast<TextureAspect>(
+            static_cast<uint8_t>(result) | static_cast<uint8_t>(TextureAspect::Stencil)
+        );
+    }
+    return result;
+}
+
+void AppendRange(std::ostringstream& stream, const RenderGraph::ResourceRange& range) {
+    if (range.kind == ResourceKind::Texture) {
+        stream << "aspect=" << static_cast<uint32_t>(range.texture.aspects)
+               << ",mip=" << range.texture.mip_first << "+" << range.texture.mip_count
+               << ",layer=" << range.texture.layer_first << "+" << range.texture.layer_count;
+    } else {
+        stream << "offset=" << range.buffer.offset << ",size=" << range.buffer.size;
+    }
+}
+
+void AppendInstruction(
+    std::ostringstream&                                  stream,
+    const RenderGraphLowering::LoweredInstruction& instruction
+) {
+    stream << "kind=" << static_cast<uint32_t>(instruction.instruction_kind)
+           << " barrier=" << instruction.barrier_index
+           << " access_index=" << instruction.access_index
+           << " correlation=" << instruction.correlation_id
+           << " resource=" << instruction.resource.index << " ";
+    AppendRange(stream, instruction.range);
+    stream << " src_stage=" << static_cast<uint32_t>(instruction.source.stages)
+           << " src_access=" << static_cast<uint32_t>(instruction.source.access)
+           << " src_layout=" << static_cast<uint32_t>(instruction.source.layout)
+           << " dst_stage=" << static_cast<uint32_t>(instruction.destination.stages)
+           << " dst_access=" << static_cast<uint32_t>(instruction.destination.access)
+           << " dst_layout=" << static_cast<uint32_t>(instruction.destination.layout)
+           << " discard=" << instruction.discard_previous_contents
+           << " import=" << instruction.import_boundary
+           << " export=" << instruction.export_boundary;
+}
+
+} // namespace
+
+void RenderGraphLowering::LoweredPlan::Clear() {
+    prologue.clear();
+    passes.clear();
+}
+
+const RenderGraphLowering::PassInstructions*
+RenderGraphLowering::LoweredPlan::FindPass(RenderGraph::PassHandle pass) const {
+    const auto found = std::find_if(
+        passes.begin(),
+        passes.end(),
+        [&](const PassInstructions& candidate) { return candidate.pass == pass; }
+    );
+    return found == passes.end() ? nullptr : &*found;
+}
+
+std::span<const RenderGraphLowering::LoweredInstruction>
+RenderGraphLowering::LoweredPlan::Before(RenderGraph::PassHandle pass) const {
+    const auto* instructions = FindPass(pass);
+    return instructions == nullptr ? std::span<const LoweredInstruction>{} :
+                                     std::span<const LoweredInstruction>{instructions->before};
+}
+
+std::span<const RenderGraphLowering::LoweredInstruction>
+RenderGraphLowering::LoweredPlan::After(RenderGraph::PassHandle pass) const {
+    const auto* instructions = FindPass(pass);
+    return instructions == nullptr ? std::span<const LoweredInstruction>{} :
+                                     std::span<const LoweredInstruction>{instructions->after};
+}
+
+std::span<const RenderGraphLowering::PhysicalBinding>
+RenderGraphLowering::LoweredPlan::Keepalive(RenderGraph::PassHandle pass) const {
+    const auto* instructions = FindPass(pass);
+    return instructions == nullptr ? std::span<const PhysicalBinding>{} :
+                                     std::span<const PhysicalBinding>{instructions->keepalive};
+}
+
+std::string RenderGraphLowering::LoweredPlan::Dump() const {
+    std::ostringstream stream;
+    stream << "lowered prologue=" << prologue.size() << " passes=" << passes.size() << "\n";
+    for (const auto& instruction : prologue) {
+        stream << "prologue ";
+        AppendInstruction(stream, instruction);
+        stream << "\n";
+    }
+    for (const auto& pass : passes) {
+        stream << "pass=" << pass.pass.index << " keepalive=[";
+        for (uint32_t index = 0; index < pass.keepalive.size(); ++index) {
+            if (index != 0) {
+                stream << ",";
+            }
+            stream << pass.keepalive[index].resource.index;
+        }
+        stream << "] before=" << pass.before.size() << " after=" << pass.after.size() << "\n";
+        for (const auto& instruction : pass.before) {
+            stream << "  before ";
+            AppendInstruction(stream, instruction);
+            stream << "\n";
+        }
+        for (const auto& instruction : pass.after) {
+            stream << "  after ";
+            AppendInstruction(stream, instruction);
+            stream << "\n";
+        }
+    }
+    return stream.str();
+}
+
+bool RenderGraphLowering::Lower(
+    const RenderGraph& graph,
+    LoweredPlan&       output,
+    std::string&       error
+) {
+    output.Clear();
+    error.clear();
+    auto fail = [&](std::string message) {
+        output.Clear();
+        error = "RenderGraph lowering: " + std::move(message);
+        return false;
+    };
+
+    if (!graph.compiled) {
+        return fail("graph must be compiled before lowering");
+    }
+    const auto& compiled = graph.compiled_plan;
+    if (!compiled.state_plan_complete) {
+        return fail("compiled state plan is incomplete");
+    }
+
+    std::vector<bool> gpu_pass(graph.passes.size(), false);
+    for (const auto& pass : graph.passes) {
+        if (pass.execution_class == RenderGraph::PassExecutionClass::ExternalControl) {
+            return fail("ExternalControl pass is outside the managed lowering domain: '" +
+                        pass.name + "'");
+        }
+    }
+    for (const auto& batch : compiled.queue_batches) {
+        if (batch.external_control) {
+            return fail("external-control queue batch is outside the managed lowering domain");
+        }
+        if (batch.queue.role != RenderGraph::QueueRole::Graphics) {
+            return fail("only the Graphics logical queue is supported");
+        }
+        for (const auto pass : batch.passes) {
+            if (!graph.IsValidPass(pass)) {
+                return fail("queue batch references an invalid pass");
+            }
+            gpu_pass[pass.index] = true;
+            if (graph.passes[pass.index].domain.queue != RenderGraph::QueueRole::Graphics) {
+                return fail("GPU pass '" + graph.passes[pass.index].name +
+                            "' does not use the Graphics logical queue");
+            }
+        }
+    }
+    for (const auto& sync : compiled.queue_syncs) {
+        if (sync.gpu_wait_required ||
+            sync.signal_queue.role != RenderGraph::QueueRole::Graphics ||
+            sync.wait_queue.role != RenderGraph::QueueRole::Graphics) {
+            return fail("cross-queue synchronization is not supported");
+        }
+    }
+
+    std::vector<bool> resource_has_access(graph.resources.size(), false);
+    for (const auto& access : compiled.accesses) {
+        if (!graph.IsValidResource(access.resource) || !graph.IsValidPass(access.pass)) {
+            return fail("compiled access references an invalid handle");
+        }
+        if (access.resource.index >= graph.resources.size()) {
+            return fail("compiled access resource index is out of range");
+        }
+        const auto& resource = graph.resources[access.resource.index];
+        if (resource.kind == ResourceKind::Token) {
+            continue;
+        }
+        resource_has_access[access.resource.index] = true;
+        if (access.state.IsAutomatic()) {
+            return fail("physical access uses Automatic state on resource '" + resource.name + "'");
+        }
+        if (!IsKnownAccess(access.mode)) {
+            return fail("physical access uses Unknown access on resource '" + resource.name + "'");
+        }
+        if (access.domain.queue != RenderGraph::QueueRole::Graphics) {
+            return fail("physical access does not use the Graphics logical queue on resource '" +
+                        resource.name + "'");
+        }
+        if (access.state.kind == ResourceKind::Texture &&
+            access.state.texture == TextureState::Present) {
+            return fail("Present state requires an external synchronization endpoint on resource '" +
+                        resource.name + "'");
+        }
+    }
+
+    auto validate_boundary = [&](const RenderGraph::ResourceDeclaration& resource,
+                                 const RenderGraph::StateDeclaration&    state,
+                                 bool                                    initial) {
+        if (state.state.IsAutomatic()) {
+            error = "Automatic boundary state on resource '" + resource.name + "'";
+            return false;
+        }
+        if (!IsKnownAccess(state.boundary_access)) {
+            error = "Unknown boundary access on resource '" + resource.name + "'";
+            return false;
+        }
+        if (state.state.kind == ResourceKind::Texture &&
+            state.state.texture == TextureState::Present) {
+            error = "Present boundary requires an external synchronization endpoint on resource '" +
+                    resource.name + "'";
+            return false;
+        }
+        if (!initial && state.state.IsUndefined()) {
+            error = "Undefined state cannot be an export destination on resource '" +
+                    resource.name + "'";
+            return false;
+        }
+        if (initial && state.state.IsUndefined()) {
+            if (state.queue != RenderGraph::QueueRole::None ||
+                state.boundary_access != AccessMode::None) {
+                error = "Undefined import boundary must use queue None and access None on resource '" +
+                        resource.name + "'";
+                return false;
+            }
+            return true;
+        }
+        if (state.queue != RenderGraph::QueueRole::Graphics) {
+            error = "only Graphics boundary ownership is supported on resource '" + resource.name + "'";
+            return false;
+        }
+        return true;
+    };
+
+    for (uint32_t resource_index = 0; resource_index < graph.resources.size(); ++resource_index) {
+        const auto& resource = graph.resources[resource_index];
+        if (resource.kind == ResourceKind::Token) {
+            continue;
+        }
+        if (!resource.imported) {
+            return fail("transient physical resource is not supported: '" + resource.name + "'");
+        }
+        if (!resource.typed_desc) {
+            return fail("physical resource requires a typed descriptor: '" + resource.name + "'");
+        }
+        if (resource.kind == ResourceKind::Texture) {
+            if (!resource.physical_texture.IsValid() ||
+                resource.physical_identity != resource.physical_texture.Get()) {
+                return fail("texture lacks a strong physical binding: '" + resource.name + "'");
+            }
+            const auto actual_aspects = RaiseAspects(resource.physical_texture->GetAspectFlags());
+            if (resource.texture_desc.mip_count != resource.physical_texture->GetNumMips() ||
+                resource.texture_desc.layer_count != resource.physical_texture->GetNumArray() ||
+                resource.texture_desc.aspects != actual_aspects) {
+                return fail("texture descriptor does not match its physical binding: '" +
+                            resource.name + "'");
+            }
+        } else {
+            if (!resource.physical_buffer.IsValid() ||
+                resource.physical_identity != resource.physical_buffer.Get()) {
+                return fail("buffer lacks a strong physical binding: '" + resource.name + "'");
+            }
+            if (resource.buffer_desc.byte_size != resource.physical_buffer->GetByteSize()) {
+                return fail("buffer descriptor does not match its physical binding: '" +
+                            resource.name + "'");
+            }
+        }
+
+        if (!resource_has_access[resource_index]) {
+            continue;
+        }
+        if (resource.initial_states.empty()) {
+            return fail("physical resource lacks an explicit initial state: '" + resource.name + "'");
+        }
+        if (!resource.exported || resource.final_states.empty()) {
+            return fail("physical resource lacks an explicit final state: '" + resource.name + "'");
+        }
+        for (const auto& state : resource.initial_states) {
+            if (!validate_boundary(resource, state, true)) {
+                return fail(std::move(error));
+            }
+        }
+        for (const auto& state : resource.final_states) {
+            if (!validate_boundary(resource, state, false)) {
+                return fail(std::move(error));
+            }
+        }
+    }
+
+    std::vector<bool> prologue(compiled.barriers.size(), false);
+    std::vector<bool> epilogue(compiled.barriers.size(), false);
+    std::vector<uint32_t> before_occurrences(compiled.barriers.size(), 0);
+    for (const uint32_t barrier_index : compiled.prologue_barriers) {
+        if (barrier_index >= compiled.barriers.size() || prologue[barrier_index]) {
+            return fail("prologue contains an invalid or duplicate barrier index");
+        }
+        prologue[barrier_index] = true;
+    }
+    for (const uint32_t barrier_index : compiled.epilogue_barriers) {
+        if (barrier_index >= compiled.barriers.size() || epilogue[barrier_index]) {
+            return fail("epilogue contains an invalid or duplicate barrier index");
+        }
+        epilogue[barrier_index] = true;
+    }
+    for (const auto& pass_barriers : compiled.pass_barriers) {
+        if (!graph.IsValidPass(pass_barriers.pass)) {
+            return fail("pass barrier list references an invalid pass");
+        }
+        for (const uint32_t barrier_index : pass_barriers.before) {
+            if (barrier_index >= compiled.barriers.size()) {
+                return fail("pass barrier list contains an invalid barrier index");
+            }
+            ++before_occurrences[barrier_index];
+        }
+    }
+
+    LoweredPlan candidate{};
+    candidate.passes.reserve(compiled.execution_order.size());
+    for (const auto pass : compiled.execution_order) {
+        if (!graph.IsValidPass(pass)) {
+            return fail("execution order references an invalid pass");
+        }
+        if (gpu_pass[pass.index]) {
+            candidate.passes.push_back(PassInstructions{.pass = pass});
+        }
+    }
+
+    auto find_mutable_pass = [&](RenderGraph::PassHandle pass) -> PassInstructions* {
+        const auto found = std::find_if(
+            candidate.passes.begin(),
+            candidate.passes.end(),
+            [&](const PassInstructions& entry) { return entry.pass == pass; }
+        );
+        return found == candidate.passes.end() ? nullptr : &*found;
+    };
+
+    auto binding_for = [&](RenderGraph::ResourceHandle handle) {
+        const auto& resource = graph.resources[handle.index];
+        PhysicalBinding binding{
+            .resource = handle,
+            .kind     = resource.kind,
+        };
+        if (resource.kind == ResourceKind::Texture) {
+            binding.texture = resource.physical_texture;
+        } else if (resource.kind == ResourceKind::Buffer) {
+            binding.buffer = resource.physical_buffer;
+        }
+        return binding;
+    };
+
+    for (auto& pass_entry : candidate.passes) {
+        std::vector<RenderGraph::ResourceHandle> resources{};
+        for (const auto& access : compiled.accesses) {
+            if (access.pass == pass_entry.pass &&
+                graph.resources[access.resource.index].kind != ResourceKind::Token) {
+                resources.push_back(access.resource);
+            }
+        }
+        for (const auto resource : graph.passes[pass_entry.pass.index].references) {
+            if (graph.resources[resource.index].kind != ResourceKind::Token) {
+                resources.push_back(resource);
+            }
+        }
+        std::sort(
+            resources.begin(),
+            resources.end(),
+            [](RenderGraph::ResourceHandle lhs, RenderGraph::ResourceHandle rhs) {
+                return lhs.index < rhs.index;
+            }
+        );
+        resources.erase(
+            std::unique(
+                resources.begin(),
+                resources.end(),
+                [](RenderGraph::ResourceHandle lhs, RenderGraph::ResourceHandle rhs) {
+                    return lhs.index == rhs.index;
+                }
+            ),
+            resources.end()
+        );
+        for (const auto resource : resources) {
+            pass_entry.keepalive.push_back(binding_for(resource));
+        }
+    }
+
+    std::vector<uint32_t> execution_position(
+        graph.passes.size(),
+        RenderGraph::PassHandle::InvalidIndex
+    );
+    for (uint32_t position = 0; position < compiled.execution_order.size(); ++position) {
+        execution_position[compiled.execution_order[position].index] = position;
+    }
+
+    auto lower_instruction = [&](uint32_t barrier_index, LoweredInstruction& instruction) {
+        const auto& barrier = compiled.barriers[barrier_index];
+        if (!graph.IsValidResource(barrier.resource)) {
+            error = "barrier references an invalid resource";
+            return false;
+        }
+        const auto& resource = graph.resources[barrier.resource.index];
+        if (resource.kind == ResourceKind::Token) {
+            error = "token barrier cannot be physically lowered";
+            return false;
+        }
+        if (barrier.queue_dependency || barrier.queue_ownership) {
+            error = "queue dependency or ownership transfer is not supported";
+            return false;
+        }
+        if (barrier.source_state_unknown) {
+            error = "barrier source state is unknown";
+            return false;
+        }
+        if (barrier.before_state.IsAutomatic() || barrier.after_state.IsAutomatic()) {
+            error = "barrier contains Automatic state";
+            return false;
+        }
+        if (!IsKnownAccess(barrier.before_access) || !IsKnownAccess(barrier.after_access)) {
+            error = "barrier contains Unknown access";
+            return false;
+        }
+        if (barrier.before_state.kind == ResourceKind::Texture &&
+            (barrier.before_state.texture == TextureState::Present ||
+             barrier.after_state.texture == TextureState::Present)) {
+            error = "Present barrier requires an external synchronization endpoint";
+            return false;
+        }
+        if (barrier.dst_pass.IsValid()) {
+            if (!graph.IsValidPass(barrier.dst_pass) ||
+                barrier.dst_domain.queue != RenderGraph::QueueRole::Graphics) {
+                error = "barrier destination is not a valid Graphics pass";
+                return false;
+            }
+        } else if (!barrier.export_boundary ||
+                   barrier.dst_domain.queue != RenderGraph::QueueRole::Graphics) {
+            error = "barrier has no managed Graphics destination";
+            return false;
+        }
+
+        instruction = LoweredInstruction{
+            .instruction_kind        = InstructionKind::Barrier,
+            .correlation_id          = barrier_index,
+            .barrier_index           = barrier_index,
+            .access_index            = InvalidAccessIndex,
+            .resource                = barrier.resource,
+            .resource_kind           = resource.kind,
+            .range                   = barrier.range,
+            .texture_aspects         = resource.kind == ResourceKind::Texture ?
+                                           LowerAspects(barrier.range.texture.aspects) :
+                                           ETextureAspectFlags::NONE,
+            .physical                = binding_for(barrier.resource),
+            .src_pass                = barrier.src_pass,
+            .dst_pass                = barrier.dst_pass,
+            .before_state            = barrier.before_state,
+            .after_state             = barrier.after_state,
+            .before_access           = barrier.before_access,
+            .after_access            = barrier.after_access,
+            .state_transition        = barrier.state_transition,
+            .memory_dependency       = barrier.memory_dependency,
+            .execution_dependency    = barrier.execution_dependency,
+            .discard_previous_contents = barrier.discard_previous_contents,
+            .import_boundary         = barrier.import_boundary,
+            .export_boundary         = barrier.export_boundary,
+        };
+
+        if (resource.kind == ResourceKind::Texture) {
+            if (barrier.range.texture.aspects == TextureAspect::None ||
+                barrier.range.texture.mip_count == RenderGraph::RemainingTextureRange ||
+                barrier.range.texture.layer_count == RenderGraph::RemainingTextureRange) {
+                error = "texture barrier range is not fully normalized";
+                return false;
+            }
+        } else if (barrier.range.buffer.size == RenderGraph::RemainingBufferRange) {
+            error = "buffer barrier range is not fully normalized";
+            return false;
+        }
+
+        if (!barrier.sources.empty()) {
+            bool first_source = true;
+            for (const auto& source : barrier.sources) {
+                if (!graph.IsValidPass(source.pass) ||
+                    source.domain.queue != RenderGraph::QueueRole::Graphics ||
+                    !IsKnownAccess(source.access) || source.state.IsAutomatic()) {
+                    error = "barrier fan-in contains an unsupported source";
+                    return false;
+                }
+                Scope source_scope{};
+                if (!MapScope(source.state, source.access, source.domain, source_scope, error)) {
+                    return false;
+                }
+                instruction.source_frontier.push_back(source.pass);
+                if (first_source) {
+                    instruction.source = source_scope;
+                    first_source = false;
+                } else {
+                    instruction.source.stages =
+                        Or(instruction.source.stages, source_scope.stages);
+                    instruction.source.access =
+                        Or(instruction.source.access, source_scope.access);
+                }
+            }
+            if (resource.kind == ResourceKind::Texture) {
+                if (!TextureLayoutFor(
+                        barrier.before_state.texture,
+                        instruction.source.layout,
+                        error
+                    )) {
+                    return false;
+                }
+            }
+            instruction.source.has_texture_layout = resource.kind == ResourceKind::Texture;
+        } else {
+            if (!MapScope(
+                    barrier.before_state,
+                    barrier.before_access,
+                    barrier.src_domain,
+                    instruction.source,
+                    error
+                )) {
+                return false;
+            }
+            if (barrier.src_pass.IsValid()) {
+                instruction.source_frontier.push_back(barrier.src_pass);
+            }
+        }
+        if (!MapScope(
+                barrier.after_state,
+                barrier.after_access,
+                barrier.dst_domain,
+                instruction.destination,
+                error
+            )) {
+            return false;
+        }
+        if (instruction.discard_previous_contents && !barrier.before_state.IsUndefined()) {
+            error = "discard flag requires an Undefined source state";
+            return false;
+        }
+        return true;
+    };
+
+    for (uint32_t barrier_index = 0; barrier_index < compiled.barriers.size(); ++barrier_index) {
+        const auto& barrier = compiled.barriers[barrier_index];
+        if (prologue[barrier_index] && epilogue[barrier_index]) {
+            return fail("one barrier cannot be both prologue and epilogue");
+        }
+        if (prologue[barrier_index]) {
+            if (!barrier.import_boundary || barrier.src_pass.IsValid() ||
+                !barrier.dst_pass.IsValid() || before_occurrences[barrier_index] != 1) {
+                return fail("prologue barrier has inconsistent placement metadata");
+            }
+        } else if (epilogue[barrier_index]) {
+            if (!barrier.export_boundary || barrier.dst_pass.IsValid() ||
+                before_occurrences[barrier_index] != 0) {
+                return fail("epilogue barrier has inconsistent placement metadata");
+            }
+        } else if (!barrier.dst_pass.IsValid() || before_occurrences[barrier_index] != 1) {
+            return fail("internal barrier does not have exactly one before-pass placement");
+        }
+
+        LoweredInstruction instruction{};
+        if (!lower_instruction(barrier_index, instruction)) {
+            return fail("barrier " + std::to_string(barrier_index) + ": " + std::move(error));
+        }
+        if (prologue[barrier_index]) {
+            candidate.prologue.push_back(std::move(instruction));
+            continue;
+        }
+        if (epilogue[barrier_index]) {
+            RenderGraph::PassHandle latest{};
+            uint32_t latest_position = 0;
+            bool found_source = false;
+            for (const auto source : instruction.source_frontier) {
+                if (!graph.IsValidPass(source) ||
+                    execution_position[source.index] == RenderGraph::PassHandle::InvalidIndex) {
+                    return fail("epilogue barrier source is not in execution order");
+                }
+                if (!found_source || execution_position[source.index] > latest_position) {
+                    latest = source;
+                    latest_position = execution_position[source.index];
+                    found_source = true;
+                }
+            }
+            if (!found_source) {
+                return fail("epilogue barrier has no managed source pass");
+            }
+            auto* pass = find_mutable_pass(latest);
+            if (pass == nullptr) {
+                return fail("epilogue barrier source is not a GPU pass");
+            }
+            pass->after.push_back(std::move(instruction));
+            continue;
+        }
+        auto* pass = find_mutable_pass(barrier.dst_pass);
+        if (pass == nullptr) {
+            return fail("barrier destination is not a GPU pass");
+        }
+        pass->before.push_back(std::move(instruction));
+    }
+
+    auto has_boundary = [&](const RenderGraph::CompiledAccess& access, bool initial) {
+        const auto& indices = initial ? compiled.prologue_barriers :
+                                        compiled.epilogue_barriers;
+        return std::any_of(indices.begin(), indices.end(), [&](uint32_t barrier_index) {
+            const auto& barrier = compiled.barriers[barrier_index];
+            return barrier.resource == access.resource && barrier.range == access.range &&
+                   (initial ? barrier.import_boundary : barrier.export_boundary);
+        });
+    };
+    for (const auto& access : compiled.accesses) {
+        if (graph.resources[access.resource.index].kind == ResourceKind::Token) {
+            continue;
+        }
+        if (!has_boundary(access, true)) {
+            return fail("physical access lacks a matching explicit import boundary on resource '" +
+                        graph.resources[access.resource.index].name + "'");
+        }
+        if (!has_boundary(access, false)) {
+            return fail("physical access lacks a matching explicit export boundary on resource '" +
+                        graph.resources[access.resource.index].name + "'");
+        }
+    }
+
+    for (uint32_t access_index = 0; access_index < compiled.accesses.size(); ++access_index) {
+        const auto& access = compiled.accesses[access_index];
+        const auto& resource = graph.resources[access.resource.index];
+        if (resource.kind == ResourceKind::Token) {
+            continue;
+        }
+        auto* pass = find_mutable_pass(access.pass);
+        if (pass == nullptr) {
+            return fail("physical access belongs to a non-GPU pass");
+        }
+        const bool state_already_adopted = std::any_of(
+            pass->before.begin(),
+            pass->before.end(),
+            [&](const LoweredInstruction& instruction) {
+                return instruction.resource == access.resource &&
+                       instruction.range == access.range &&
+                       instruction.after_state == access.state &&
+                       instruction.after_access == access.mode;
+            }
+        ) || std::any_of(
+            candidate.prologue.begin(),
+            candidate.prologue.end(),
+            [&](const LoweredInstruction& instruction) {
+                return instruction.dst_pass == access.pass &&
+                       instruction.resource == access.resource &&
+                       instruction.range == access.range &&
+                       instruction.after_state == access.state &&
+                       instruction.after_access == access.mode;
+            }
+        );
+        if (state_already_adopted) {
+            continue;
+        }
+
+        Scope seed_scope{};
+        if (!MapScope(access.state, access.mode, access.domain, seed_scope, error)) {
+            return fail("access " + std::to_string(access_index) +
+                        " cannot seed explicit tracked state: " + std::move(error));
+        }
+        pass->before.push_back(LoweredInstruction{
+            .instruction_kind        = InstructionKind::StateSeed,
+            .correlation_id          = access_index,
+            .barrier_index           = InvalidBarrierIndex,
+            .access_index            = access_index,
+            .resource                = access.resource,
+            .resource_kind           = resource.kind,
+            .range                   = access.range,
+            .texture_aspects         = resource.kind == ResourceKind::Texture ?
+                                           LowerAspects(access.range.texture.aspects) :
+                                           ETextureAspectFlags::NONE,
+            .physical                = binding_for(access.resource),
+            .src_pass                = access.pass,
+            .dst_pass                = access.pass,
+            .source                  = seed_scope,
+            .destination             = seed_scope,
+            .before_state            = access.state,
+            .after_state             = access.state,
+            .before_access           = access.mode,
+            .after_access            = access.mode,
+        });
+    }
+
+    output = std::move(candidate);
+    error.clear();
+    return true;
+}
+
+} // namespace Moer::Render

--- a/source/runtime/render/rendergraph/RenderGraphLowering.cpp
+++ b/source/runtime/render/rendergraph/RenderGraphLowering.cpp
@@ -338,7 +338,19 @@ void AppendInstruction(
            << " import=" << instruction.import_boundary
            << " export=" << instruction.export_boundary
            << " transient_alias=" << instruction.transient_alias
-           << " queue_acquire=" << instruction.queue_acquire;
+           << " queue_acquire=" << instruction.queue_acquire
+           << " transfer_src_role="
+           << static_cast<uint32_t>(instruction.transfer_source.role)
+           << " transfer_src_native="
+           << instruction.transfer_source.native_queue_id
+           << " transfer_src_family="
+           << instruction.transfer_source.family_id
+           << " transfer_dst_role="
+           << static_cast<uint32_t>(instruction.transfer_destination.role)
+           << " transfer_dst_native="
+           << instruction.transfer_destination.native_queue_id
+           << " transfer_dst_family="
+           << instruction.transfer_destination.family_id;
 }
 
 } // namespace
@@ -389,7 +401,28 @@ std::string RenderGraphLowering::LoweredPlan::Dump() const {
                << " signal_pass=" << sync.signal_pass.index
                << " wait_pass=" << sync.wait_pass.index
                << " signal_native=" << sync.signal_queue.native_queue_id
-               << " wait_native=" << sync.wait_queue.native_queue_id << "\n";
+               << " wait_native=" << sync.wait_queue.native_queue_id
+               << " signal_batch=" << sync.signal_batch
+               << " wait_batch=" << sync.wait_batch
+               << " synthetic_ownership_join="
+               << sync.synthetic_ownership_join
+               << " ownership_joins=[";
+        for (uint32_t index = 0; index < sync.ownership_join_barriers.size(); ++index) {
+            if (index != 0) {
+                stream << ",";
+            }
+            stream << sync.ownership_join_barriers[index];
+        }
+        stream << "] ownership_transfers=[";
+        for (uint32_t index = 0;
+             index < sync.ownership_transfer_barriers.size();
+             ++index) {
+            if (index != 0) {
+                stream << ",";
+            }
+            stream << sync.ownership_transfer_barriers[index];
+        }
+        stream << "]\n";
     }
     for (const auto& instruction : prologue) {
         stream << "prologue ";
@@ -445,7 +478,8 @@ bool RenderGraphLowering::Lower(
 
     auto supported_queue = [](RenderGraph::QueueRole role) {
         return role == RenderGraph::QueueRole::Graphics ||
-               role == RenderGraph::QueueRole::Compute;
+               role == RenderGraph::QueueRole::Compute ||
+               role == RenderGraph::QueueRole::Copy;
     };
     std::vector<bool>     gpu_pass(graph.passes.size(), false);
     std::vector<uint32_t> pass_queue_batch(
@@ -667,6 +701,8 @@ bool RenderGraphLowering::Lower(
                 .wait_pass      = sync.wait_pass,
                 .signal_queue   = sync.signal_queue,
                 .wait_queue     = sync.wait_queue,
+                .signal_batch   = sync.signal_batch,
+                .wait_batch     = sync.wait_batch,
             });
         }
     }
@@ -1058,15 +1094,20 @@ bool RenderGraphLowering::Lower(
             error = "token barrier cannot be physically lowered";
             return false;
         }
-        if (barrier.queue_ownership) {
-            error =
-                "queue-family ownership requires paired release/acquire lowering";
-            return false;
-        }
         if (barrier.queue_dependency &&
             (!barrier.src_pass.IsValid() || !barrier.dst_pass.IsValid())) {
             error =
                 "cross-queue external boundary lacks a managed synchronization endpoint";
+            return false;
+        }
+        if (barrier.queue_ownership &&
+            (!barrier.queue_dependency || barrier.import_boundary ||
+             barrier.export_boundary || barrier.transient_alias ||
+             barrier.sources.empty() || !barrier.src_pass.IsValid() ||
+             !barrier.dst_pass.IsValid())) {
+            error =
+                "queue-family ownership requires one internal managed source "
+                "frontier and destination";
             return false;
         }
         if (barrier.queue_dependency) {
@@ -1201,7 +1242,7 @@ bool RenderGraphLowering::Lower(
                         pass_queue_batch[barrier.dst_pass.index] :
                         RenderGraph::PassHandle::InvalidIndex;
                 const bool contributes_local_scope =
-                    !instruction.queue_acquire ||
+                    barrier.queue_ownership || !instruction.queue_acquire ||
                     (source_batch != RenderGraph::PassHandle::InvalidIndex &&
                      destination_batch != RenderGraph::PassHandle::InvalidIndex &&
                      compiled.queue_batches[source_batch]
@@ -1269,6 +1310,70 @@ bool RenderGraphLowering::Lower(
         return true;
     };
 
+    uint32_t next_synthetic_sync_id =
+        static_cast<uint32_t>(compiled.queue_syncs.size());
+    auto find_lowered_sync =
+        [&](uint32_t signal_batch,
+            uint32_t wait_batch) -> QueueSyncInstruction* {
+            const auto found = std::find_if(
+                candidate.queue_syncs.begin(),
+                candidate.queue_syncs.end(),
+                [&](const QueueSyncInstruction& sync) {
+                    return sync.signal_batch == signal_batch &&
+                           sync.wait_batch == wait_batch;
+                }
+            );
+            return found == candidate.queue_syncs.end() ? nullptr : &*found;
+        };
+    auto append_unique_barrier =
+        [](std::vector<uint32_t>& barriers, uint32_t barrier_index) {
+            if (std::find(barriers.begin(), barriers.end(), barrier_index) ==
+                barriers.end()) {
+                barriers.push_back(barrier_index);
+            }
+        };
+    auto ensure_ownership_join =
+        [&](uint32_t signal_batch,
+            uint32_t wait_batch,
+            uint32_t barrier_index) {
+            if (signal_batch >= compiled.queue_batches.size() ||
+                wait_batch >= compiled.queue_batches.size() ||
+                signal_batch >= wait_batch) {
+                error =
+                    "ownership fan-in join is not a forward queue-batch edge";
+                return false;
+            }
+            const auto& signal = compiled.queue_batches[signal_batch];
+            const auto& wait   = compiled.queue_batches[wait_batch];
+            if (signal.queue.native_queue_id ==
+                wait.queue.native_queue_id) {
+                error =
+                    "ownership fan-in join redundantly targets one native queue";
+                return false;
+            }
+            if (auto* existing =
+                    find_lowered_sync(signal_batch, wait_batch);
+                existing != nullptr) {
+                append_unique_barrier(
+                    existing->ownership_join_barriers,
+                    barrier_index
+                );
+                return true;
+            }
+            candidate.queue_syncs.push_back(QueueSyncInstruction{
+                .correlation_id = next_synthetic_sync_id++,
+                .signal_pass    = signal.passes.back(),
+                .wait_pass      = wait.passes.front(),
+                .signal_queue   = signal.queue,
+                .wait_queue     = wait.queue,
+                .signal_batch   = signal_batch,
+                .wait_batch     = wait_batch,
+                .synthetic_ownership_join = true,
+                .ownership_join_barriers = {barrier_index},
+            });
+            return true;
+        };
+
     for (uint32_t barrier_index = 0; barrier_index < compiled.barriers.size(); ++barrier_index) {
         const auto& barrier = compiled.barriers[barrier_index];
         if (prologue[barrier_index] && epilogue[barrier_index]) {
@@ -1291,6 +1396,167 @@ bool RenderGraphLowering::Lower(
         LoweredInstruction instruction{};
         if (!lower_instruction(barrier_index, instruction)) {
             return fail("barrier " + std::to_string(barrier_index) + ": " + std::move(error));
+        }
+        if (barrier.queue_ownership) {
+            const uint32_t destination_batch =
+                pass_queue_batch[barrier.dst_pass.index];
+            if (destination_batch == RenderGraph::PassHandle::InvalidIndex ||
+                destination_batch >= compiled.queue_batches.size()) {
+                return fail(
+                    "ownership destination has no managed queue batch"
+                );
+            }
+            const auto& destination_binding =
+                compiled.queue_batches[destination_batch].queue;
+
+            struct SourceNativeTail {
+                uint32_t native_queue_id = 0;
+                uint32_t batch = RenderGraph::PassHandle::InvalidIndex;
+            };
+            std::vector<SourceNativeTail> source_tails{};
+            uint32_t source_family = RenderGraph::PassHandle::InvalidIndex;
+            for (const auto& source : barrier.sources) {
+                if (!graph.IsValidPass(source.pass)) {
+                    return fail(
+                        "ownership source frontier contains an invalid pass"
+                    );
+                }
+                const uint32_t source_batch =
+                    pass_queue_batch[source.pass.index];
+                if (source_batch == RenderGraph::PassHandle::InvalidIndex ||
+                    source_batch >= compiled.queue_batches.size() ||
+                    source_batch >= destination_batch) {
+                    return fail(
+                        "ownership source is not a forward managed queue batch"
+                    );
+                }
+                const auto& source_binding =
+                    compiled.queue_batches[source_batch].queue;
+                if (source_binding.role != source.domain.queue) {
+                    return fail(
+                        "ownership source domain disagrees with its queue batch"
+                    );
+                }
+                if (source_family == RenderGraph::PassHandle::InvalidIndex) {
+                    source_family = source_binding.family_id;
+                } else if (source_family != source_binding.family_id) {
+                    return fail(
+                        "ownership source frontier spans multiple queue families"
+                    );
+                }
+                auto tail = std::find_if(
+                    source_tails.begin(),
+                    source_tails.end(),
+                    [&](const SourceNativeTail& candidate_tail) {
+                        return candidate_tail.native_queue_id ==
+                               source_binding.native_queue_id;
+                    }
+                );
+                if (tail == source_tails.end()) {
+                    source_tails.push_back(SourceNativeTail{
+                        .native_queue_id = source_binding.native_queue_id,
+                        .batch           = source_batch,
+                    });
+                } else {
+                    tail->batch = std::max(tail->batch, source_batch);
+                }
+            }
+            if (source_tails.empty() ||
+                source_family == RenderGraph::PassHandle::InvalidIndex ||
+                source_family == destination_binding.family_id) {
+                return fail(
+                    "ownership transfer does not cross two distinct queue families"
+                );
+            }
+
+            const auto release_tail = std::max_element(
+                source_tails.begin(),
+                source_tails.end(),
+                [](const SourceNativeTail& lhs,
+                   const SourceNativeTail& rhs) {
+                    return lhs.batch < rhs.batch;
+                }
+            );
+            const uint32_t release_batch = release_tail->batch;
+            const auto& release_binding =
+                compiled.queue_batches[release_batch].queue;
+            if (release_binding.family_id != source_family ||
+                release_binding.native_queue_id ==
+                    destination_binding.native_queue_id) {
+                return fail(
+                    "ownership release owner disagrees with the source family "
+                    "or destination native queue"
+                );
+            }
+
+            for (const SourceNativeTail& tail : source_tails) {
+                if (tail.native_queue_id ==
+                    release_binding.native_queue_id) {
+                    continue;
+                }
+                if (!ensure_ownership_join(
+                        tail.batch,
+                        release_batch,
+                        barrier_index
+                    )) {
+                    return fail(
+                        "barrier " + std::to_string(barrier_index) +
+                        ": " + std::move(error)
+                    );
+                }
+            }
+
+            QueueSyncInstruction* transfer_sync =
+                find_lowered_sync(release_batch, destination_batch);
+            if (transfer_sync == nullptr ||
+                transfer_sync->signal_queue != release_binding ||
+                transfer_sync->wait_queue != destination_binding) {
+                return fail(
+                    "ownership release is not correlated with its "
+                    "release-to-acquire GPU sync"
+                );
+            }
+            append_unique_barrier(
+                transfer_sync->ownership_transfer_barriers,
+                barrier_index
+            );
+
+            auto* release_pass = find_mutable_pass(
+                compiled.queue_batches[release_batch].passes.back()
+            );
+            auto* acquire_pass = find_mutable_pass(barrier.dst_pass);
+            if (release_pass == nullptr || acquire_pass == nullptr) {
+                return fail(
+                    "ownership release/acquire endpoint is not a GPU pass"
+                );
+            }
+
+            LoweredInstruction release = instruction;
+            release.instruction_kind = InstructionKind::QueueRelease;
+            release.queue_acquire = false;
+            release.transfer_source = release_binding;
+            release.transfer_destination = destination_binding;
+
+            LoweredInstruction acquire = instruction;
+            acquire.instruction_kind = InstructionKind::QueueAcquire;
+            acquire.queue_acquire = true;
+            acquire.transfer_source = release_binding;
+            acquire.transfer_destination = destination_binding;
+
+            const auto keepalive = std::find_if(
+                release_pass->keepalive.begin(),
+                release_pass->keepalive.end(),
+                [&](const PhysicalBinding& binding) {
+                    return binding.resource == instruction.physical.resource &&
+                           binding.Identity() == instruction.physical.Identity();
+                }
+            );
+            if (keepalive == release_pass->keepalive.end()) {
+                release_pass->keepalive.push_back(instruction.physical);
+            }
+            release_pass->after.push_back(std::move(release));
+            acquire_pass->before.push_back(std::move(acquire));
+            continue;
         }
         if (prologue[barrier_index]) {
             candidate.prologue.push_back(std::move(instruction));
@@ -1417,6 +1683,89 @@ bool RenderGraphLowering::Lower(
             .before_access           = access.mode,
             .after_access            = access.mode,
         });
+    }
+
+    for (uint32_t barrier_index = 0;
+         barrier_index < compiled.barriers.size();
+         ++barrier_index) {
+        if (!compiled.barriers[barrier_index].queue_ownership) {
+            continue;
+        }
+        const LoweredInstruction* release = nullptr;
+        const LoweredInstruction* acquire = nullptr;
+        uint32_t release_count = 0;
+        uint32_t acquire_count = 0;
+        for (const auto& pass : candidate.passes) {
+            for (const auto& instruction : pass.after) {
+                if (instruction.barrier_index == barrier_index &&
+                    instruction.instruction_kind ==
+                        InstructionKind::QueueRelease) {
+                    release = &instruction;
+                    ++release_count;
+                }
+            }
+            for (const auto& instruction : pass.before) {
+                if (instruction.barrier_index == barrier_index &&
+                    instruction.instruction_kind ==
+                        InstructionKind::QueueAcquire) {
+                    acquire = &instruction;
+                    ++acquire_count;
+                }
+            }
+        }
+        if (release_count != 1 || acquire_count != 1 ||
+            release == nullptr || acquire == nullptr) {
+            return fail(
+                "ownership barrier does not have exactly one release/acquire pair"
+            );
+        }
+        const auto same_scope = [](const Scope& lhs, const Scope& rhs) {
+            return lhs.stages == rhs.stages &&
+                   lhs.access == rhs.access &&
+                   lhs.layout == rhs.layout &&
+                   lhs.has_texture_layout == rhs.has_texture_layout;
+        };
+        if (release->correlation_id != acquire->correlation_id ||
+            release->resource != acquire->resource ||
+            release->resource_kind != acquire->resource_kind ||
+            !(release->range == acquire->range) ||
+            release->texture_aspects != acquire->texture_aspects ||
+            release->physical.Identity() != acquire->physical.Identity() ||
+            release->before_state != acquire->before_state ||
+            release->after_state != acquire->after_state ||
+            release->before_access != acquire->before_access ||
+            release->after_access != acquire->after_access ||
+            !same_scope(release->source, acquire->source) ||
+            !same_scope(release->destination, acquire->destination) ||
+            release->transfer_source != acquire->transfer_source ||
+            release->transfer_destination !=
+                acquire->transfer_destination ||
+            release->transfer_source.family_id ==
+                release->transfer_destination.family_id) {
+            return fail(
+                "ownership release/acquire pair lost canonical state, range, "
+                "resource, or endpoints"
+            );
+        }
+        const uint32_t transfer_sync_count = static_cast<uint32_t>(
+            std::count_if(
+                candidate.queue_syncs.begin(),
+                candidate.queue_syncs.end(),
+                [&](const QueueSyncInstruction& sync) {
+                    return std::find(
+                               sync.ownership_transfer_barriers.begin(),
+                               sync.ownership_transfer_barriers.end(),
+                               barrier_index
+                           ) != sync.ownership_transfer_barriers.end();
+                }
+            )
+        );
+        if (transfer_sync_count != 1) {
+            return fail(
+                "ownership release/acquire pair does not own exactly one "
+                "transfer sync"
+            );
+        }
     }
 
     output = std::move(candidate);

--- a/source/runtime/render/rendergraph/RenderGraphLowering.cpp
+++ b/source/runtime/render/rendergraph/RenderGraphLowering.cpp
@@ -336,7 +336,8 @@ void AppendInstruction(
            << " dst_layout=" << static_cast<uint32_t>(instruction.destination.layout)
            << " discard=" << instruction.discard_previous_contents
            << " import=" << instruction.import_boundary
-           << " export=" << instruction.export_boundary;
+           << " export=" << instruction.export_boundary
+           << " transient_alias=" << instruction.transient_alias;
 }
 
 } // namespace
@@ -427,6 +428,9 @@ bool RenderGraphLowering::Lower(
     const auto& compiled = graph.compiled_plan;
     if (!compiled.state_plan_complete) {
         return fail("compiled state plan is incomplete");
+    }
+    if (compiled.resources.size() != graph.resources.size()) {
+        return fail("compiled resource table is incomplete");
     }
 
     std::vector<bool> gpu_pass(graph.passes.size(), false);
@@ -535,11 +539,24 @@ bool RenderGraphLowering::Lower(
         if (resource.kind == ResourceKind::Token) {
             continue;
         }
-        if (!resource.imported) {
-            return fail("transient physical resource is not supported: '" + resource.name + "'");
+        if (!resource_has_access[resource_index] &&
+            resource.first_use == RenderGraph::PassHandle::InvalidIndex) {
+            continue;
         }
         if (!resource.typed_desc) {
             return fail("physical resource requires a typed descriptor: '" + resource.name + "'");
+        }
+        if (!resource.imported) {
+            const bool has_allocation_desc =
+                resource.kind == ResourceKind::Texture ?
+                    resource.transient_texture_desc.has_value() :
+                    resource.transient_buffer_desc.has_value();
+            if (!has_allocation_desc) {
+                return fail(
+                    "transient physical resource lacks an allocation descriptor: '" +
+                    resource.name + "'"
+                );
+            }
         }
         if (resource.kind == ResourceKind::Texture) {
             if (!resource.physical_texture.IsValid() ||
@@ -567,21 +584,115 @@ bool RenderGraphLowering::Lower(
         if (!resource_has_access[resource_index]) {
             continue;
         }
-        if (resource.initial_states.empty()) {
-            return fail("physical resource lacks an explicit initial state: '" + resource.name + "'");
-        }
-        if (!resource.exported || resource.final_states.empty()) {
-            return fail("physical resource lacks an explicit final state: '" + resource.name + "'");
-        }
-        for (const auto& state : resource.initial_states) {
-            if (!validate_boundary(resource, state, true)) {
-                return fail(std::move(error));
+        if (resource.imported) {
+            if (resource.initial_states.empty()) {
+                return fail(
+                    "physical resource lacks an explicit initial state: '" +
+                    resource.name + "'"
+                );
             }
+            if (!resource.exported || resource.final_states.empty()) {
+                return fail(
+                    "physical resource lacks an explicit final state: '" +
+                    resource.name + "'"
+                );
+            }
+            for (const auto& state : resource.initial_states) {
+                if (!validate_boundary(resource, state, true)) {
+                    return fail(std::move(error));
+                }
+            }
+        } else if (!resource.initial_states.empty()) {
+            return fail(
+                "allocation-backed transient resource must begin in its implicit "
+                "Undefined state: '" +
+                resource.name + "'"
+            );
+        }
+        if (resource.exported && resource.final_states.empty()) {
+            return fail(
+                "exported transient resource lacks an explicit final state: '" +
+                resource.name + "'"
+            );
         }
         for (const auto& state : resource.final_states) {
             if (!validate_boundary(resource, state, false)) {
                 return fail(std::move(error));
             }
+        }
+    }
+
+    std::vector<uint32_t> alias_barrier_owners(compiled.barriers.size(), 0);
+    for (const auto& alias : compiled.alias_boundaries) {
+        if (!graph.IsValidResource(alias.predecessor_resource) ||
+            !graph.IsValidResource(alias.successor_resource) ||
+            !graph.IsValidPass(alias.primary_src_pass) ||
+            !graph.IsValidPass(alias.dst_pass) ||
+            alias.source_frontier.empty() ||
+            alias.barrier_index >= compiled.barriers.size()) {
+            return fail("transient alias boundary contains an invalid handle or index");
+        }
+        const auto& predecessor =
+            graph.resources[alias.predecessor_resource.index];
+        const auto& successor =
+            graph.resources[alias.successor_resource.index];
+        const auto& predecessor_plan =
+            compiled.resources[alias.predecessor_resource.index];
+        const auto& successor_plan =
+            compiled.resources[alias.successor_resource.index];
+        if (predecessor.imported || successor.imported ||
+            predecessor.exported || successor.exported ||
+            predecessor.physical_identity == nullptr ||
+            predecessor.physical_identity != successor.physical_identity ||
+            predecessor_plan.transient_slot != alias.transient_slot ||
+            successor_plan.transient_slot != alias.transient_slot ||
+            predecessor_plan.last_use >= successor_plan.first_use) {
+            return fail(
+                "transient alias boundary does not bind one compatible non-overlapping "
+                "physical allocation"
+            );
+        }
+
+        const auto& barrier = compiled.barriers[alias.barrier_index];
+        ++alias_barrier_owners[alias.barrier_index];
+        if (!barrier.transient_alias ||
+            barrier.resource != alias.successor_resource ||
+            barrier.src_pass != alias.primary_src_pass ||
+            barrier.dst_pass != alias.dst_pass ||
+            barrier.sources.size() != alias.source_frontier.size() ||
+            !barrier.memory_dependency || !barrier.execution_dependency ||
+            barrier.queue_dependency || barrier.queue_ownership ||
+            barrier.discard_previous_contents || barrier.import_boundary ||
+            barrier.export_boundary || barrier.source_state_unknown) {
+            return fail("transient alias boundary disagrees with its compiled barrier");
+        }
+        for (uint32_t source_index = 0;
+             source_index < alias.source_frontier.size();
+             ++source_index) {
+            if (barrier.sources[source_index].pass !=
+                alias.source_frontier[source_index]) {
+                return fail(
+                    "transient alias barrier dropped or reordered a source frontier"
+                );
+            }
+        }
+        if (alias.source_frontier.back() != alias.primary_src_pass) {
+            return fail(
+                "transient alias primary source is not its latest frontier source"
+            );
+        }
+    }
+    for (uint32_t barrier_index = 0;
+         barrier_index < compiled.barriers.size();
+         ++barrier_index) {
+        const uint32_t owner_count = alias_barrier_owners[barrier_index];
+        if ((compiled.barriers[barrier_index].transient_alias &&
+             owner_count != 1) ||
+            (!compiled.barriers[barrier_index].transient_alias &&
+             owner_count != 0)) {
+            return fail(
+                "transient alias barrier does not have exactly one boundary owner"
+            );
         }
     }
 
@@ -758,6 +869,7 @@ bool RenderGraphLowering::Lower(
             .discard_previous_contents = barrier.discard_previous_contents,
             .import_boundary         = barrier.import_boundary,
             .export_boundary         = barrier.export_boundary,
+            .transient_alias         = barrier.transient_alias,
         };
 
         if (resource.kind == ResourceKind::Texture) {
@@ -908,13 +1020,19 @@ bool RenderGraphLowering::Lower(
         if (graph.resources[access.resource.index].kind == ResourceKind::Token) {
             continue;
         }
-        if (!has_boundary(access, true)) {
-            return fail("physical access lacks a matching explicit import boundary on resource '" +
-                        graph.resources[access.resource.index].name + "'");
+        const auto& declaration = graph.resources[access.resource.index];
+        if (declaration.imported && !has_boundary(access, true)) {
+            return fail(
+                "physical access lacks a matching explicit import boundary on resource '" +
+                declaration.name + "'"
+            );
         }
-        if (!has_boundary(access, false)) {
-            return fail("physical access lacks a matching explicit export boundary on resource '" +
-                        graph.resources[access.resource.index].name + "'");
+        if ((declaration.imported || declaration.exported) &&
+            !has_boundary(access, false)) {
+            return fail(
+                "physical access lacks a matching explicit export boundary on resource '" +
+                declaration.name + "'"
+            );
         }
     }
 

--- a/source/runtime/render/rendergraph/RenderGraphLowering.h
+++ b/source/runtime/render/rendergraph/RenderGraphLowering.h
@@ -15,10 +15,10 @@ namespace Moer::Render {
  * CPU-only lowering of a complete RenderGraph compiler plan.
  *
  * Active lowering intentionally supports a narrow, auditable subset: strongly
- * bound imported or allocation-backed transient resources, explicit states at
- * every physical access and external boundary, and the Graphics logical queue
- * only. Unsupported plans fail closed before producing any instructions. RHI
- * command materialization is a separate step.
+ * bound imported or allocation-backed transient resources and explicit states
+ * at every physical access and external boundary. Graphics/Compute queue DAGs
+ * are executable; queue-family ownership and unmanaged external endpoints
+ * remain fail-closed until paired lowering is available.
  */
 class RENDER_API RenderGraphLowering {
 public:
@@ -92,6 +92,16 @@ public:
         bool import_boundary           = false;
         bool export_boundary           = false;
         bool transient_alias           = false;
+        /** Destination-side visibility/layout barrier after a GPU queue wait. */
+        bool queue_acquire              = false;
+    };
+
+    struct QueueSyncInstruction {
+        uint32_t                correlation_id = 0;
+        RenderGraph::PassHandle signal_pass{};
+        RenderGraph::PassHandle wait_pass{};
+        RenderGraph::QueueBinding signal_queue{};
+        RenderGraph::QueueBinding wait_queue{};
     };
 
     struct PassInstructions {
@@ -109,6 +119,8 @@ public:
         std::vector<LoweredInstruction> prologue{};
         /** Stable RenderGraph execution order, excluding CPU-only prepare passes. */
         std::vector<PassInstructions> passes{};
+        /** Cross-native-queue synchronization points consumed by RHI metadata. */
+        std::vector<QueueSyncInstruction> queue_syncs{};
 
         void Clear();
 

--- a/source/runtime/render/rendergraph/RenderGraphLowering.h
+++ b/source/runtime/render/rendergraph/RenderGraphLowering.h
@@ -16,9 +16,9 @@ namespace Moer::Render {
  *
  * Active lowering intentionally supports a narrow, auditable subset: strongly
  * bound imported or allocation-backed transient resources and explicit states
- * at every physical access and external boundary. Graphics/Compute queue DAGs
- * are executable; queue-family ownership and unmanaged external endpoints
- * remain fail-closed until paired lowering is available.
+ * at every physical access and external boundary. Graphics/Compute/Copy queue
+ * DAGs and internal exclusive queue-family transfers are executable;
+ * unmanaged external ownership endpoints remain fail-closed.
  */
 class RENDER_API RenderGraphLowering {
 public:
@@ -34,6 +34,10 @@ public:
          * across independently submitted CommandLists.
          */
         StateSeed,
+        /** Source-family half emitted after the designated producer batch. */
+        QueueRelease,
+        /** Destination-family half emitted before the consuming pass. */
+        QueueAcquire,
     };
 
     struct Scope {
@@ -94,6 +98,9 @@ public:
         bool transient_alias           = false;
         /** Destination-side visibility/layout barrier after a GPU queue wait. */
         bool queue_acquire              = false;
+        /** Canonical logical endpoints shared by paired release/acquire halves. */
+        RenderGraph::QueueBinding transfer_source{};
+        RenderGraph::QueueBinding transfer_destination{};
     };
 
     struct QueueSyncInstruction {
@@ -102,6 +109,13 @@ public:
         RenderGraph::PassHandle wait_pass{};
         RenderGraph::QueueBinding signal_queue{};
         RenderGraph::QueueBinding wait_queue{};
+        uint32_t signal_batch = RenderGraph::PassHandle::InvalidIndex;
+        uint32_t wait_batch   = RenderGraph::PassHandle::InvalidIndex;
+        /** Added by lowering to join a fan-in frontier at one release owner. */
+        bool synthetic_ownership_join = false;
+        std::vector<uint32_t> ownership_join_barriers{};
+        /** Ownership transfers whose release->acquire ordering uses this sync. */
+        std::vector<uint32_t> ownership_transfer_barriers{};
     };
 
     struct PassInstructions {

--- a/source/runtime/render/rendergraph/RenderGraphLowering.h
+++ b/source/runtime/render/rendergraph/RenderGraphLowering.h
@@ -14,10 +14,11 @@ namespace Moer::Render {
 /**
  * CPU-only lowering of a complete RenderGraph compiler plan.
  *
- * Phase 11 intentionally supports a narrow, auditable subset: strongly bound
- * imported resources, explicit states at every physical access and boundary,
- * and the Graphics logical queue only. Unsupported plans fail closed before
- * producing any instructions. RHI command materialization is a separate step.
+ * Active lowering intentionally supports a narrow, auditable subset: strongly
+ * bound imported or allocation-backed transient resources, explicit states at
+ * every physical access and external boundary, and the Graphics logical queue
+ * only. Unsupported plans fail closed before producing any instructions. RHI
+ * command materialization is a separate step.
  */
 class RENDER_API RenderGraphLowering {
 public:
@@ -90,6 +91,7 @@ public:
         bool discard_previous_contents = false;
         bool import_boundary           = false;
         bool export_boundary           = false;
+        bool transient_alias           = false;
     };
 
     struct PassInstructions {

--- a/source/runtime/render/rendergraph/RenderGraphLowering.h
+++ b/source/runtime/render/rendergraph/RenderGraphLowering.h
@@ -1,0 +1,134 @@
+#pragma once
+
+#include "RenderAPI.h"
+#include "rendergraph/RenderGraph.h"
+#include "rhi/RHICommon.h"
+
+#include <span>
+#include <string>
+#include <vector>
+#include <limits>
+
+namespace Moer::Render {
+
+/**
+ * CPU-only lowering of a complete RenderGraph compiler plan.
+ *
+ * Phase 11 intentionally supports a narrow, auditable subset: strongly bound
+ * imported resources, explicit states at every physical access and boundary,
+ * and the Graphics logical queue only. Unsupported plans fail closed before
+ * producing any instructions. RHI command materialization is a separate step.
+ */
+class RENDER_API RenderGraphLowering {
+public:
+    static constexpr uint32_t InvalidBarrierIndex = std::numeric_limits<uint32_t>::max();
+    static constexpr uint32_t InvalidAccessIndex  = std::numeric_limits<uint32_t>::max();
+
+    enum class InstructionKind : uint8_t {
+        Barrier,
+        /**
+         * Adopts the explicit input state of a pass whose same-state access did
+         * not require a compiler barrier. Materializers may emit a no-op
+         * explicit barrier; its purpose is persistent tracker state adoption
+         * across independently submitted CommandLists.
+         */
+        StateSeed,
+    };
+
+    struct Scope {
+        ERHIPipelineStageFlags stages = ERHIPipelineStageFlags::PS_NONE;
+        ERHIAccessFlags        access = ERHIAccessFlags::UNDEFINED;
+        ETextureLayout         layout = ETextureLayout::TEXTURE_LAYOUT_UNDEFINED;
+        bool                   has_texture_layout = false;
+    };
+
+    struct PhysicalBinding {
+        RenderGraph::ResourceHandle resource{};
+        RenderGraph::ResourceKind   kind = RenderGraph::ResourceKind::Token;
+        TextureRef                  texture{};
+        BufferRef                   buffer{};
+
+        [[nodiscard]] const void* Identity() const {
+            if (kind == RenderGraph::ResourceKind::Texture) {
+                return texture.Get();
+            }
+            if (kind == RenderGraph::ResourceKind::Buffer) {
+                return buffer.Get();
+            }
+            return nullptr;
+        }
+    };
+
+    struct LoweredInstruction {
+        InstructionKind instruction_kind = InstructionKind::Barrier;
+        /** Index in RenderGraph::CompiledPlan::barriers, or InvalidBarrierIndex for a seed. */
+        uint32_t correlation_id = 0;
+        uint32_t barrier_index  = InvalidBarrierIndex;
+        /** Index in CompiledPlan::accesses for StateSeed, otherwise InvalidAccessIndex. */
+        uint32_t access_index   = InvalidAccessIndex;
+
+        RenderGraph::ResourceHandle resource{};
+        RenderGraph::ResourceKind   resource_kind = RenderGraph::ResourceKind::Token;
+        RenderGraph::ResourceRange  range{};
+        ETextureAspectFlags         texture_aspects = ETextureAspectFlags::NONE;
+        PhysicalBinding             physical{};
+
+        RenderGraph::PassHandle src_pass{};
+        RenderGraph::PassHandle dst_pass{};
+        std::vector<RenderGraph::PassHandle> source_frontier{};
+
+        Scope source{};
+        Scope destination{};
+        RenderGraph::ResourceState before_state{};
+        RenderGraph::ResourceState after_state{};
+        RenderGraph::AccessMode    before_access = RenderGraph::AccessMode::None;
+        RenderGraph::AccessMode    after_access  = RenderGraph::AccessMode::None;
+
+        bool state_transition          = false;
+        bool memory_dependency         = false;
+        bool execution_dependency      = false;
+        bool discard_previous_contents = false;
+        bool import_boundary           = false;
+        bool export_boundary           = false;
+    };
+
+    struct PassInstructions {
+        RenderGraph::PassHandle              pass{};
+        std::vector<PhysicalBinding>         keepalive{};
+        std::vector<LoweredInstruction>      before{};
+        std::vector<LoweredInstruction>      after{};
+    };
+
+    struct RENDER_API LoweredPlan {
+        /**
+         * Import-boundary instructions remain separate. A materializer attaches
+         * each instruction to its dst_pass before recording that pass.
+         */
+        std::vector<LoweredInstruction> prologue{};
+        /** Stable RenderGraph execution order, excluding CPU-only prepare passes. */
+        std::vector<PassInstructions> passes{};
+
+        void Clear();
+
+        [[nodiscard]] const PassInstructions*
+        FindPass(RenderGraph::PassHandle pass) const;
+        [[nodiscard]] std::span<const LoweredInstruction>
+        Before(RenderGraph::PassHandle pass) const;
+        [[nodiscard]] std::span<const LoweredInstruction>
+        After(RenderGraph::PassHandle pass) const;
+        [[nodiscard]] std::span<const PhysicalBinding>
+        Keepalive(RenderGraph::PassHandle pass) const;
+
+        /** Pointer-free deterministic diagnostic representation. */
+        [[nodiscard]] std::string Dump() const;
+    };
+
+    /**
+     * Produces a complete plan or no plan. On failure output is cleared and
+     * error contains the first deterministic unsupported-condition diagnostic.
+     */
+    [[nodiscard]] static bool
+    Lower(const RenderGraph& graph, LoweredPlan& output, std::string& error);
+};
+
+} // namespace Moer::Render

--- a/source/runtime/render/rendergraph/RenderGraphResourcePool.cpp
+++ b/source/runtime/render/rendergraph/RenderGraphResourcePool.cpp
@@ -20,34 +20,38 @@ TextureRef CreateTexture(
     std::string_view               name,
     const RGTransientTextureDesc& desc
 ) {
-    auto& device = RenderDevice::Get();
     switch (desc.dimension) {
         case ETextureDimension::TEX_2D:
         case ETextureDimension::TEX_2D_ARRAY:
         case ETextureDimension::TEX_3D:
-            return device.CreateTexture(
-                name,
-                desc.extent,
-                desc.format,
-                desc.usage,
-                desc.mip_count,
-                desc.array_size
-            );
         case ETextureDimension::TEX_CUBE:
-            return device.CreateCubeMap(
-                name,
-                Extent2D(desc.extent.x, desc.extent.y),
-                desc.format,
-                desc.usage,
-                desc.mip_count
-            );
+            break;
         case ETextureDimension::TEX_CUBE_ARRAY:
         case ETextureDimension::NumBits:
             throw std::invalid_argument(
                 "the current RHI factory cannot allocate transient cube arrays"
             );
     }
-    throw std::invalid_argument("unsupported transient texture dimension");
+
+    const bool depth_or_stencil = HasAny(
+        desc.aspect_flags,
+        ETextureAspectFlags::DEPTH_SLICE |
+            ETextureAspectFlags::STENCIL_SLICE
+    );
+    TextureInfo info{
+        desc.dimension,
+        desc.usage,
+        desc.format,
+        depth_or_stencil ? EClearAttachment::DEPTH_STENCIL :
+                           EClearAttachment::COLOR,
+        desc.extent,
+        static_cast<uint8_t>(desc.mip_count),
+        static_cast<uint8_t>(desc.PhysicalLayerCount()),
+        1
+    };
+    info.aspect_flags = desc.aspect_flags;
+    info.debug_name   = std::string(name);
+    return RenderDevice::Get().CreateTexture(name, info);
 }
 
 BufferRef CreateBuffer(
@@ -140,6 +144,11 @@ bool RGTransientTextureDesc::IsValid() const {
     );
     const bool color = HasAny(aspect_flags, ETextureAspectFlags::COLOR);
     if (depth_or_stencil && color) {
+        return false;
+    }
+    const uint32_t format_aspects =
+        static_cast<uint32_t>(GetPixelFormatAspectFlags(format));
+    if ((aspect_mask & format_aspects) != aspect_mask) {
         return false;
     }
 

--- a/source/runtime/render/rendergraph/RenderGraphResourcePool.cpp
+++ b/source/runtime/render/rendergraph/RenderGraphResourcePool.cpp
@@ -1,0 +1,467 @@
+#include "rendergraph/RenderGraphResourcePool.h"
+
+#include "rendergraph/RenderGraph.h"
+#include "rhi/RHI.h"
+
+#include <algorithm>
+#include <limits>
+#include <stdexcept>
+#include <unordered_map>
+#include <utility>
+
+namespace Moer::Render {
+namespace {
+
+[[nodiscard]] bool HasAny(ETextureAspectFlags value, ETextureAspectFlags flags) {
+    return (static_cast<uint32_t>(value) & static_cast<uint32_t>(flags)) != 0;
+}
+
+TextureRef CreateTexture(
+    std::string_view               name,
+    const RGTransientTextureDesc& desc
+) {
+    auto& device = RenderDevice::Get();
+    switch (desc.dimension) {
+        case ETextureDimension::TEX_2D:
+        case ETextureDimension::TEX_2D_ARRAY:
+        case ETextureDimension::TEX_3D:
+            return device.CreateTexture(
+                name,
+                desc.extent,
+                desc.format,
+                desc.usage,
+                desc.mip_count,
+                desc.array_size
+            );
+        case ETextureDimension::TEX_CUBE:
+            return device.CreateCubeMap(
+                name,
+                Extent2D(desc.extent.x, desc.extent.y),
+                desc.format,
+                desc.usage,
+                desc.mip_count
+            );
+        case ETextureDimension::TEX_CUBE_ARRAY:
+        case ETextureDimension::NumBits:
+            throw std::invalid_argument(
+                "the current RHI factory cannot allocate transient cube arrays"
+            );
+    }
+    throw std::invalid_argument("unsupported transient texture dimension");
+}
+
+BufferRef CreateBuffer(
+    std::string_view              name,
+    const RGTransientBufferDesc& desc
+) {
+    return RenderDevice::Get().CreateBuffer(
+        name,
+        BufferInfo{desc.element_count, desc.stride, desc.usage, desc.format}
+    );
+}
+
+void ValidateTextureResult(
+    const RGTransientTextureDesc& desc,
+    const TextureRef&             resource
+) {
+    if (!resource.IsValid()) {
+        throw std::runtime_error("transient texture factory returned null");
+    }
+    const uint3 extent = resource->GetExtent();
+    if (extent.x != desc.extent.x || extent.y != desc.extent.y ||
+        extent.z != desc.extent.z ||
+        resource->GetDimension() != desc.dimension ||
+        resource->GetFormat() != desc.format ||
+        resource->GetUsage() != desc.usage ||
+        resource->GetNumMips() != desc.mip_count ||
+        resource->GetNumArray() != desc.PhysicalLayerCount() ||
+        resource->GetAspectFlags() != desc.aspect_flags) {
+        throw std::runtime_error(
+            "transient texture factory returned a resource that does not match its descriptor"
+        );
+    }
+}
+
+void ValidateBufferResult(
+    const RGTransientBufferDesc& desc,
+    const BufferRef&             resource
+) {
+    if (!resource.IsValid()) {
+        throw std::runtime_error("transient buffer factory returned null");
+    }
+    if (resource->GetNumElement() != desc.element_count ||
+        resource->GetStride() != desc.stride ||
+        resource->GetByteSize() != desc.ByteSize() ||
+        resource->GetUsage() != desc.usage ||
+        resource->GetFormat() != desc.format) {
+        throw std::runtime_error(
+            "transient buffer factory returned a resource that does not match its descriptor"
+        );
+    }
+}
+
+} // namespace
+
+uint32_t RGTransientTextureDesc::PhysicalLayerCount() const {
+    const uint64_t multiplier =
+        dimension == ETextureDimension::TEX_CUBE ||
+                dimension == ETextureDimension::TEX_CUBE_ARRAY ?
+            6u :
+            1u;
+    const uint64_t layers = multiplier * array_size;
+    return layers > std::numeric_limits<uint32_t>::max() ?
+               0u :
+               static_cast<uint32_t>(layers);
+}
+
+bool RGTransientTextureDesc::IsValid() const {
+    constexpr uint32_t supported_aspects =
+        static_cast<uint32_t>(ETextureAspectFlags::COLOR) |
+        static_cast<uint32_t>(ETextureAspectFlags::DEPTH_SLICE) |
+        static_cast<uint32_t>(ETextureAspectFlags::STENCIL_SLICE);
+    const uint32_t aspect_mask = static_cast<uint32_t>(aspect_flags);
+    const uint32_t physical_layers = PhysicalLayerCount();
+    if (extent.x == 0 || extent.y == 0 || extent.z == 0 ||
+        format == PF_UNDEFINED || usage == ETextureUsageFlags::UNDEFINED ||
+        aspect_flags == ETextureAspectFlags::NONE || mip_count == 0 ||
+        array_size == 0 || physical_layers == 0 ||
+        extent.x > static_cast<uint32_t>(std::numeric_limits<int>::max()) ||
+        extent.y > static_cast<uint32_t>(std::numeric_limits<int>::max()) ||
+        extent.z > std::numeric_limits<uint16_t>::max() ||
+        mip_count > std::numeric_limits<uint8_t>::max() ||
+        physical_layers > std::numeric_limits<uint8_t>::max() ||
+        (aspect_mask & ~supported_aspects) != 0) {
+        return false;
+    }
+
+    const bool depth_or_stencil = HasAny(
+        aspect_flags,
+        ETextureAspectFlags::DEPTH_SLICE | ETextureAspectFlags::STENCIL_SLICE
+    );
+    const bool color = HasAny(aspect_flags, ETextureAspectFlags::COLOR);
+    if (depth_or_stencil && color) {
+        return false;
+    }
+
+    switch (dimension) {
+        case ETextureDimension::TEX_2D:
+            return extent.z == 1 && array_size == 1;
+        case ETextureDimension::TEX_2D_ARRAY:
+            return extent.z == 1 && array_size > 1;
+        case ETextureDimension::TEX_3D:
+            return extent.z > 1 && array_size == 1;
+        case ETextureDimension::TEX_CUBE:
+            return extent.z == 1 && extent.x == extent.y && array_size == 1;
+        case ETextureDimension::TEX_CUBE_ARRAY:
+        case ETextureDimension::NumBits:
+            return false;
+    }
+    return false;
+}
+
+uint64_t RGTransientBufferDesc::ByteSize() const {
+    if (stride != 0 &&
+        element_count > std::numeric_limits<uint64_t>::max() / stride) {
+        return 0;
+    }
+    return static_cast<uint64_t>(element_count) * stride;
+}
+
+bool RGTransientBufferDesc::IsValid() const {
+    return element_count > 0 && stride > 0 &&
+           usage != EBufferUsageFlags::NONE && ByteSize() > 0;
+}
+
+RenderGraphResourcePool::RenderGraphResourcePool(
+    uint32_t       retire_after_idle_frames,
+    TextureFactory texture_factory,
+    BufferFactory  buffer_factory
+) :
+    retire_after_idle_frames(retire_after_idle_frames),
+    texture_factory(
+        texture_factory ? std::move(texture_factory) : TextureFactory{CreateTexture}
+    ),
+    buffer_factory(
+        buffer_factory ? std::move(buffer_factory) : BufferFactory{CreateBuffer}
+    ) {}
+
+RenderGraphResourcePool& RenderGraphResourcePool::Global() {
+    static RenderGraphResourcePool pool{};
+    return pool;
+}
+
+TextureRef RenderGraphResourcePool::AcquireTexture(
+    std::string_view               name,
+    const RGTransientTextureDesc& desc
+) {
+    if (!desc.IsValid()) {
+        throw std::invalid_argument("invalid transient texture descriptor");
+    }
+    std::lock_guard lock(mutex);
+    return AcquireTextureLocked(name, desc);
+}
+
+BufferRef RenderGraphResourcePool::AcquireBuffer(
+    std::string_view              name,
+    const RGTransientBufferDesc& desc
+) {
+    if (!desc.IsValid()) {
+        throw std::invalid_argument("invalid transient buffer descriptor");
+    }
+    std::lock_guard lock(mutex);
+    return AcquireBufferLocked(name, desc);
+}
+
+TextureRef RenderGraphResourcePool::AcquireTextureLocked(
+    std::string_view               name,
+    const RGTransientTextureDesc& desc
+) {
+    for (auto& entry : textures) {
+        if (entry.resource.IsValid() && entry.resource->IsUniquelyReferenced() &&
+            entry.desc == desc) {
+            entry.idle_frames = 0;
+            entry.resource->SetName(name);
+            return entry.resource;
+        }
+    }
+
+    TextureRef resource = texture_factory(name, desc);
+    ValidateTextureResult(desc, resource);
+    textures.push_back(TextureEntry{.desc = desc, .resource = resource});
+    return resource;
+}
+
+BufferRef RenderGraphResourcePool::AcquireBufferLocked(
+    std::string_view              name,
+    const RGTransientBufferDesc& desc
+) {
+    for (auto& entry : buffers) {
+        if (entry.resource.IsValid() && entry.resource->IsUniquelyReferenced() &&
+            entry.desc == desc) {
+            entry.idle_frames = 0;
+            entry.resource->SetName(name);
+            return entry.resource;
+        }
+    }
+
+    BufferRef resource = buffer_factory(name, desc);
+    ValidateBufferResult(desc, resource);
+    buffers.push_back(BufferEntry{.desc = desc, .resource = resource});
+    return resource;
+}
+
+void RenderGraphResourcePool::Tick() {
+    std::lock_guard lock(mutex);
+    std::erase_if(textures, [&](TextureEntry& entry) {
+        if (!entry.resource.IsValid() ||
+            !entry.resource->IsUniquelyReferenced()) {
+            entry.idle_frames = 0;
+            return false;
+        }
+        return ++entry.idle_frames > retire_after_idle_frames;
+    });
+    std::erase_if(buffers, [&](BufferEntry& entry) {
+        if (!entry.resource.IsValid() ||
+            !entry.resource->IsUniquelyReferenced()) {
+            entry.idle_frames = 0;
+            return false;
+        }
+        return ++entry.idle_frames > retire_after_idle_frames;
+    });
+}
+
+void RenderGraphResourcePool::Reset() {
+    std::lock_guard lock(mutex);
+    textures.clear();
+    buffers.clear();
+}
+
+uint32_t RenderGraphResourcePool::TextureCount() const {
+    std::lock_guard lock(mutex);
+    return static_cast<uint32_t>(textures.size());
+}
+
+uint32_t RenderGraphResourcePool::BufferCount() const {
+    std::lock_guard lock(mutex);
+    return static_cast<uint32_t>(buffers.size());
+}
+
+uint32_t RenderGraphResourcePool::AvailableTextureCount() const {
+    std::lock_guard lock(mutex);
+    return static_cast<uint32_t>(std::count_if(
+        textures.begin(),
+        textures.end(),
+        [](const TextureEntry& entry) {
+            return entry.resource.IsValid() &&
+                   entry.resource->IsUniquelyReferenced();
+        }
+    ));
+}
+
+uint32_t RenderGraphResourcePool::AvailableBufferCount() const {
+    std::lock_guard lock(mutex);
+    return static_cast<uint32_t>(std::count_if(
+        buffers.begin(),
+        buffers.end(),
+        [](const BufferEntry& entry) {
+            return entry.resource.IsValid() &&
+                   entry.resource->IsUniquelyReferenced();
+        }
+    ));
+}
+
+RenderGraphTransientAllocator& RenderGraphTransientAllocator::Global() {
+    static RenderGraphTransientAllocator allocator{RenderGraphResourcePool::Global()};
+    return allocator;
+}
+
+bool RenderGraphTransientAllocator::Prepare(
+    RenderGraph& graph,
+    std::string& error
+) {
+    error.clear();
+    if (!graph.compiled) {
+        error = "transient allocation requires a successfully compiled graph";
+        return false;
+    }
+    if (graph.compiled_plan.resources.size() != graph.resources.size()) {
+        error = "compiled transient resource table is incomplete";
+        return false;
+    }
+
+    std::unordered_map<uint32_t, TextureRef> texture_slots{};
+    std::unordered_map<uint32_t, BufferRef>  buffer_slots{};
+    std::unordered_map<uint32_t, RGTransientTextureDesc> texture_slot_descs{};
+    std::unordered_map<uint32_t, RGTransientBufferDesc>  buffer_slot_descs{};
+    std::unordered_map<uint32_t, RenderGraph::ResourceKind> slot_kinds{};
+    std::vector<TextureRef> texture_bindings(graph.resources.size());
+    std::vector<BufferRef>  buffer_bindings(graph.resources.size());
+
+    try {
+        for (const auto& compiled_resource : graph.compiled_plan.resources) {
+            if (!graph.IsValidResource(compiled_resource.resource)) {
+                error = "compiled transient resource references an invalid handle";
+                return false;
+            }
+            auto& resource = graph.resources[compiled_resource.resource.index];
+            if (resource.imported || resource.kind == RenderGraph::ResourceKind::Token ||
+                compiled_resource.first_use == RenderGraph::PassHandle::InvalidIndex) {
+                continue;
+            }
+            if (compiled_resource.transient_slot ==
+                RenderGraph::PassHandle::InvalidIndex) {
+                error =
+                    "active transient resource lacks a physical allocation descriptor: '" +
+                    resource.name + "'";
+                return false;
+            }
+            const auto [kind, inserted_kind] = slot_kinds.emplace(
+                compiled_resource.transient_slot,
+                resource.kind
+            );
+            if (!inserted_kind && kind->second != resource.kind) {
+                error =
+                    "transient slot aliases different resource kinds: '" +
+                    resource.name + "'";
+                return false;
+            }
+
+            if (resource.kind == RenderGraph::ResourceKind::Texture) {
+                if (!resource.transient_texture_desc.has_value()) {
+                    error =
+                        "transient texture lacks a physical allocation descriptor: '" +
+                        resource.name + "'";
+                    return false;
+                }
+                const auto [slot_desc, inserted_desc] =
+                    texture_slot_descs.emplace(
+                        compiled_resource.transient_slot,
+                        *resource.transient_texture_desc
+                    );
+                if (!inserted_desc &&
+                    slot_desc->second != *resource.transient_texture_desc) {
+                    error =
+                        "transient texture slot aliases incompatible descriptors: '" +
+                        resource.name + "'";
+                    return false;
+                }
+                auto& slot = texture_slots[compiled_resource.transient_slot];
+                if (!slot.IsValid()) {
+                    slot = resource.physical_texture.IsValid() ?
+                               resource.physical_texture :
+                               pool.AcquireTexture(
+                                   resource.name,
+                                   *resource.transient_texture_desc
+                               );
+                } else if (resource.physical_texture.IsValid() &&
+                           resource.physical_texture.Get() != slot.Get()) {
+                    error =
+                        "transient texture slot has conflicting physical bindings: '" +
+                        resource.name + "'";
+                    return false;
+                }
+                texture_bindings[compiled_resource.resource.index] = slot;
+            } else {
+                if (!resource.transient_buffer_desc.has_value()) {
+                    error =
+                        "transient buffer lacks a physical allocation descriptor: '" +
+                        resource.name + "'";
+                    return false;
+                }
+                const auto [slot_desc, inserted_desc] =
+                    buffer_slot_descs.emplace(
+                        compiled_resource.transient_slot,
+                        *resource.transient_buffer_desc
+                    );
+                if (!inserted_desc &&
+                    slot_desc->second != *resource.transient_buffer_desc) {
+                    error =
+                        "transient buffer slot aliases incompatible descriptors: '" +
+                        resource.name + "'";
+                    return false;
+                }
+                auto& slot = buffer_slots[compiled_resource.transient_slot];
+                if (!slot.IsValid()) {
+                    slot = resource.physical_buffer.IsValid() ?
+                               resource.physical_buffer :
+                               pool.AcquireBuffer(
+                                   resource.name,
+                                   *resource.transient_buffer_desc
+                               );
+                } else if (resource.physical_buffer.IsValid() &&
+                           resource.physical_buffer.Get() != slot.Get()) {
+                    error =
+                        "transient buffer slot has conflicting physical bindings: '" +
+                        resource.name + "'";
+                    return false;
+                }
+                buffer_bindings[compiled_resource.resource.index] = slot;
+            }
+        }
+    } catch (const std::exception& exception) {
+        error = std::string("transient physical allocation failed: ") +
+                exception.what();
+        return false;
+    } catch (...) {
+        error = "transient physical allocation failed";
+        return false;
+    }
+
+    for (uint32_t index = 0; index < graph.resources.size(); ++index) {
+        auto& resource = graph.resources[index];
+        if (texture_bindings[index].IsValid()) {
+            resource.physical_texture  = std::move(texture_bindings[index]);
+            resource.physical_identity = resource.physical_texture.Get();
+        } else if (buffer_bindings[index].IsValid()) {
+            resource.physical_buffer   = std::move(buffer_bindings[index]);
+            resource.physical_identity = resource.physical_buffer.Get();
+        }
+    }
+    return true;
+}
+
+void RenderGraphTransientAllocator::ReleaseNonExported(RenderGraph& graph) noexcept {
+    graph.ReleaseNonExportedTransientBindings();
+}
+
+} // namespace Moer::Render

--- a/source/runtime/render/rendergraph/RenderGraphResourcePool.h
+++ b/source/runtime/render/rendergraph/RenderGraphResourcePool.h
@@ -1,0 +1,132 @@
+#pragma once
+
+#include "RenderAPI.h"
+#include "rhi/RHICommon.h"
+#include "rhi/RHIResource.h"
+
+#include <cstdint>
+#include <functional>
+#include <mutex>
+#include <string_view>
+#include <vector>
+
+namespace Moer::Render {
+
+class RenderGraph;
+
+/**
+ * Physical allocation description for a transient RDG texture.
+ *
+ * array_size is the number of array elements passed to the RHI factory. Cube
+ * textures therefore expose 6 * array_size physical layers.
+ */
+struct RENDER_API RGTransientTextureDesc {
+    ETextureDimension  dimension    = ETextureDimension::TEX_2D;
+    Extent3D           extent       = Extent3D(1, 1, 1);
+    EPixelFormat       format       = PF_UNDEFINED;
+    ETextureUsageFlags usage        = ETextureUsageFlags::UNDEFINED;
+    ETextureAspectFlags aspect_flags = ETextureAspectFlags::COLOR;
+    uint32_t           mip_count    = 1;
+    uint32_t           array_size   = 1;
+
+    [[nodiscard]] uint32_t PhysicalLayerCount() const;
+    [[nodiscard]] bool     IsValid() const;
+
+    friend bool operator==(const RGTransientTextureDesc&, const RGTransientTextureDesc&) = default;
+};
+
+/** Physical allocation description for a transient RDG buffer. */
+struct RENDER_API RGTransientBufferDesc {
+    uint32_t          element_count = 0;
+    uint32_t          stride        = 0;
+    EBufferUsageFlags usage         = EBufferUsageFlags::NONE;
+    EPixelFormat      format        = PF_UNDEFINED;
+
+    [[nodiscard]] uint64_t ByteSize() const;
+    [[nodiscard]] bool     IsValid() const;
+
+    friend bool operator==(const RGTransientBufferDesc&, const RGTransientBufferDesc&) = default;
+};
+
+/**
+ * Cross-frame physical resource pool.
+ *
+ * The pool owns exactly one reference to every cached resource. A resource is
+ * reusable only when its intrusive reference count is one, so CommandList
+ * completion callbacks naturally keep in-flight allocations unavailable.
+ *
+ * Custom pools and all resources acquired from them must be reset or destroyed
+ * before RenderDevice::Dispose(). The device automatically resets only Global().
+ */
+class RENDER_API RenderGraphResourcePool {
+public:
+    using TextureFactory =
+        std::function<TextureRef(std::string_view, const RGTransientTextureDesc&)>;
+    using BufferFactory =
+        std::function<BufferRef(std::string_view, const RGTransientBufferDesc&)>;
+
+    explicit RenderGraphResourcePool(
+        uint32_t       retire_after_idle_frames = 3,
+        TextureFactory texture_factory          = {},
+        BufferFactory  buffer_factory           = {}
+    );
+
+    static RenderGraphResourcePool& Global();
+
+    TextureRef AcquireTexture(std::string_view name, const RGTransientTextureDesc& desc);
+    BufferRef  AcquireBuffer(std::string_view name, const RGTransientBufferDesc& desc);
+
+    /** Advances idle retirement once. Call at most once per rendered frame. */
+    void Tick();
+    /** Drops the pool's references. In-flight users remain protected by their own refs. */
+    void Reset();
+
+    [[nodiscard]] uint32_t TextureCount() const;
+    [[nodiscard]] uint32_t BufferCount() const;
+    [[nodiscard]] uint32_t AvailableTextureCount() const;
+    [[nodiscard]] uint32_t AvailableBufferCount() const;
+
+private:
+    struct TextureEntry {
+        RGTransientTextureDesc desc{};
+        TextureRef            resource{};
+        uint32_t              idle_frames = 0;
+    };
+
+    struct BufferEntry {
+        RGTransientBufferDesc desc{};
+        BufferRef             resource{};
+        uint32_t              idle_frames = 0;
+    };
+
+    TextureRef AcquireTextureLocked(std::string_view name, const RGTransientTextureDesc& desc);
+    BufferRef  AcquireBufferLocked(std::string_view name, const RGTransientBufferDesc& desc);
+
+    mutable std::mutex       mutex{};
+    std::vector<TextureEntry> textures{};
+    std::vector<BufferEntry>  buffers{};
+    uint32_t                  retire_after_idle_frames = 3;
+    TextureFactory            texture_factory{};
+    BufferFactory             buffer_factory{};
+};
+
+/**
+ * Binds compiled transient allocation slots to pooled physical resources.
+ *
+ * Logical slot coloring belongs to RenderGraphCompiler. This class performs
+ * no scheduling decisions; it only materializes the already validated plan.
+ */
+class RENDER_API RenderGraphTransientAllocator {
+public:
+    explicit RenderGraphTransientAllocator(RenderGraphResourcePool& pool) : pool(pool) {}
+
+    static RenderGraphTransientAllocator& Global();
+
+    [[nodiscard]] bool Prepare(RenderGraph& graph, std::string& error);
+    void               ReleaseNonExported(RenderGraph& graph) noexcept;
+
+private:
+    RenderGraphResourcePool& pool;
+};
+
+} // namespace Moer::Render

--- a/source/runtime/render/rhi/RHI.cpp
+++ b/source/runtime/render/rhi/RHI.cpp
@@ -4,6 +4,7 @@
 #include "RHIImpl.h"
 #include "d3d12/D3D12Device.h"
 #include "log/LogSystem.h"
+#include "rendergraph/RenderGraphResourcePool.h"
 #include "rhi/RHICommand.h"
 #include "rhi/RHICommon.h"
 #include "rhi/RHIExecutor.h"
@@ -85,6 +86,10 @@ void RenderDevice::Init(DeviceInitInfo&& _info) {
 }
 void RenderDevice::Dispose() {
     RHIExecutor::ShutDown();
+    // Pooled RHI objects must die while the backend implementation and its
+    // allocators are still alive. In-flight owners have already drained with
+    // the executor; Reset only releases the pool's final cache references.
+    RenderGraphResourcePool::Global().Reset();
     Get().impl.reset();
 }
 CommandQueue& RenderDevice::GetCommandQueue(EQueueType _type) {

--- a/source/runtime/render/rhi/RHI.cpp
+++ b/source/runtime/render/rhi/RHI.cpp
@@ -68,6 +68,9 @@ RenderDevice& RenderDevice::Get() {
     static RenderDevice device;
     return device;
 }
+bool RenderDevice::IsInitialized() {
+    return Get().impl != nullptr;
+}
 void RenderDevice::Init(DeviceInitInfo&& _info) {
     switch (_info.rhi_type) {
         case ERHIType::Vulkan:

--- a/source/runtime/render/rhi/RHI.h
+++ b/source/runtime/render/rhi/RHI.h
@@ -128,6 +128,9 @@ public:
         return CreateBuffer(_name, _element_cnt, sizeof(TElement), _usage, _format);
     }
 
+    /** Runtime-stride allocation used by resource pools and typed graph allocators. */
+    RENDER_API BufferRef CreateBuffer(std::string_view _name, const BufferInfo& _info);
+
     RENDER_API BufferRef CreateStagingBuffer(uint64_t _byte_size);
 
     RENDER_API TextureRef CreateTexture(

--- a/source/runtime/render/rhi/RHI.h
+++ b/source/runtime/render/rhi/RHI.h
@@ -112,6 +112,7 @@ public:
     RENDER_API static void          Init(DeviceInitInfo&& _info);
     RENDER_API static void          Dispose();
     RENDER_API static RenderDevice& Get();
+    RENDER_API static bool          IsInitialized();
 
 public:
     template<typename TElement>
@@ -200,6 +201,9 @@ public:
     RENDER_API CommandQueue& GetCommandQueue(EQueueType _type);
 
     RENDER_API CopyQueue& GetCopyQueue();
+
+    /** Physical queue/family mapping used by executable render-graph plans. */
+    RENDER_API RHIQueueTopology GetQueueTopology() const;
 
     RENDER_API SwapchainRef CreateSwapchain(const SwapchainCreateInfo& _info);
 

--- a/source/runtime/render/rhi/RHI.h
+++ b/source/runtime/render/rhi/RHI.h
@@ -159,6 +159,9 @@ public:
         uint32_t           _array_size = 1
     );
 
+    RENDER_API TextureRef
+    CreateTexture(std::string_view _name, const TextureInfo& _info);
+
     RENDER_API TextureRef CreateCubeMap(
         std::string_view   _name,
         Extent2D           _size,

--- a/source/runtime/render/rhi/RHICommand.h
+++ b/source/runtime/render/rhi/RHICommand.h
@@ -17,6 +17,7 @@
 #include <condition_variable>
 #include <filesystem>
 #include <functional>
+#include <initializer_list>
 #include <misc/STL.h>
 #include <mutex>
 #include <optional>
@@ -264,6 +265,17 @@ enum class ERHIProfilingPhase : uint8 {
     End,
 };
 
+// Selects the owner of resource-state lifetime across one immutable submit.
+// BackendTracked preserves the legacy behavior: the backend infers command
+// states and restores resources to their preferred state at submit end.
+// Explicit is used by an upper-level compiler (for example RDG): barriers in
+// the command stream are authoritative and the backend must not append a
+// restore-to-preferred-state epilogue.
+enum class ERHIResourceStateOwnership : uint8 {
+    BackendTracked,
+    Explicit,
+};
+
 struct CmdSubmit {
     Array<UniquePtr<Command>>        cmds;
     Array<std::function<void(void)>> callbacks;
@@ -279,6 +291,9 @@ struct CmdSubmit {
     bool               b_tick_profiling{false};
     ERHIProfilingPhase profiling_phase{ERHIProfilingPhase::Disabled};
     bool               b_delete_resources{false};
+    ERHIResourceStateOwnership resource_state_ownership{
+        ERHIResourceStateOwnership::BackendTracked
+    };
     ERHITranslateExecutionClass translate_execution_class{
         ERHITranslateExecutionClass::Parallel
     };
@@ -303,6 +318,15 @@ struct CmdSubmit {
     CmdSubmit&& SetTranslateExecutionClass(ERHITranslateExecutionClass _execution_class) {
         translate_execution_class = _execution_class;
         return std::move(*this);
+    }
+
+    CmdSubmit&& SetResourceStateOwnership(ERHIResourceStateOwnership _ownership) {
+        resource_state_ownership = _ownership;
+        return std::move(*this);
+    }
+
+    bool HasExplicitResourceStateOwnership() const noexcept {
+        return resource_state_ownership == ERHIResourceStateOwnership::Explicit;
     }
 
     CmdSubmit&& DeleteResources() {
@@ -366,6 +390,7 @@ struct CmdSubmit {
         b_tick_profiling   = _other.b_tick_profiling;
         profiling_phase    = _other.profiling_phase;
         b_delete_resources = _other.b_delete_resources;
+        resource_state_ownership = _other.resource_state_ownership;
         translate_execution_class = _other.translate_execution_class;
         debug_label        = std::move(_other.debug_label);
         debug_label_color  = _other.debug_label_color;
@@ -383,6 +408,7 @@ struct CmdSubmit {
         b_tick_profiling   = _other.b_tick_profiling;
         profiling_phase    = _other.profiling_phase;
         b_delete_resources = _other.b_delete_resources;
+        resource_state_ownership = _other.resource_state_ownership;
         translate_execution_class = _other.translate_execution_class;
         debug_label        = std::move(_other.debug_label);
         debug_label_color  = _other.debug_label_color;
@@ -427,6 +453,81 @@ struct ReadBuffer {
 struct WriteBuffer {
     BufferView   buffer;
     EBufferState state;
+};
+
+// Fully specified barrier state used by graph-owned command streams. Texture
+// layouts are explicit instead of being inferred from access bits so present,
+// depth-read and transfer-src/dst transitions remain distinguishable.
+struct BarrierState {
+    ERHIPipelineStageFlags stage{ERHIPipelineStageFlags::PS_NONE};
+    ERHIAccessFlags        access{ERHIAccessFlags::UNDEFINED};
+    ETextureLayout         texture_layout{ETextureLayout::TEXTURE_LAYOUT_UNDEFINED};
+
+    auto operator<=>(const BarrierState&) const = default;
+
+    static BarrierState Buffer(
+        ERHIPipelineStageFlags _stage,
+        ERHIAccessFlags        _access
+    ) {
+        return {.stage = _stage, .access = _access};
+    }
+
+    static BarrierState Texture(
+        ERHIPipelineStageFlags _stage,
+        ERHIAccessFlags        _access,
+        ETextureLayout         _layout
+    ) {
+        return {.stage = _stage, .access = _access, .texture_layout = _layout};
+    }
+};
+
+inline constexpr bool BarrierStateWrites(const BarrierState& _state) {
+    return (_state.access & ERHIAccessFlags::SHADER_WRITE) != ERHIAccessFlags::UNDEFINED ||
+           (_state.access & ERHIAccessFlags::COLOR_ATTACHMENT_WRITE) !=
+               ERHIAccessFlags::UNDEFINED ||
+           (_state.access & ERHIAccessFlags::DEPTH_STENCIL_WRITE) !=
+               ERHIAccessFlags::UNDEFINED ||
+           (_state.access & ERHIAccessFlags::TRANSFER_WRITE) != ERHIAccessFlags::UNDEFINED ||
+           (_state.access & ERHIAccessFlags::MEMORY_WRITE) != ERHIAccessFlags::UNDEFINED ||
+           (_state.access & ERHIAccessFlags::CPU_WRITE_BIT) != ERHIAccessFlags::UNDEFINED ||
+           (_state.access & ERHIAccessFlags::UNORDERED_ACCESS_VIEW) !=
+               ERHIAccessFlags::UNDEFINED;
+}
+
+struct BarrierCreateInfo {
+    std::variant<TextureView, BufferView> resource;
+    BarrierState                          src_state{};
+    BarrierState                          dst_state{};
+    // Required for texture barriers. NONE is intentionally invalid at
+    // materialization time; callers must state whether color, depth, stencil,
+    // or a plane subset is transitioned.
+    ETextureAspectFlags texture_aspects{ETextureAspectFlags::NONE};
+
+    static BarrierCreateInfo Transition(
+        TextureView         _texture,
+        BarrierState        _src_state,
+        BarrierState        _dst_state,
+        ETextureAspectFlags _texture_aspects
+    ) {
+        return {
+            .resource        = _texture,
+            .src_state       = _src_state,
+            .dst_state       = _dst_state,
+            .texture_aspects = _texture_aspects,
+        };
+    }
+
+    static BarrierCreateInfo Transition(
+        BufferView  _buffer,
+        BarrierState _src_state,
+        BarrierState _dst_state
+    ) {
+        return {
+            .resource  = _buffer,
+            .src_state = _src_state,
+            .dst_state = _dst_state,
+        };
+    }
 };
 
 struct DrawBatchElement {
@@ -513,11 +614,39 @@ concept is_arg = std::is_same_v<std::remove_reference_t<TInArg>(), BufferView> |
 class CommandList {
 
 public:
+    // A graph-managed recorder owns this lease while user code is allowed to
+    // append commands. Submit() and rejection draining fail before mutating
+    // the list until the lease is released, so an untrusted record callback
+    // cannot split or publish a partially lowered command stream.
+    class RENDER_API ManagedRecordingLease final {
+    public:
+        ManagedRecordingLease() = default;
+        ~ManagedRecordingLease();
+
+        ManagedRecordingLease(const ManagedRecordingLease&)            = delete;
+        ManagedRecordingLease& operator=(const ManagedRecordingLease&) = delete;
+
+        ManagedRecordingLease(ManagedRecordingLease&& _other) noexcept;
+        ManagedRecordingLease& operator=(ManagedRecordingLease&& _other) noexcept;
+
+        void Release() noexcept;
+        [[nodiscard]] bool IsActive() const noexcept {
+            return command_list != nullptr;
+        }
+
+    private:
+        friend class CommandList;
+        explicit ManagedRecordingLease(CommandList& _command_list) noexcept :
+            command_list(&_command_list) {}
+
+        CommandList* command_list{nullptr};
+    };
+
     CommandList(const CommandList&)            = delete;
     CommandList& operator=(const CommandList&) = delete;
 
-    CommandList(CommandList&&)            = default;
-    CommandList& operator=(CommandList&&) = default;
+    RENDER_API CommandList(CommandList&& _other);
+    RENDER_API CommandList& operator=(CommandList&& _other);
 
 public:
     struct RENDER_API DrawDispatcher {
@@ -1238,6 +1367,39 @@ public:
         EndBarriers();
     }
 
+    // Explicit barrier seam for an upper-level state compiler. Unlike the
+    // legacy overload above, both sides of the dependency and the texture
+    // layout/aspect are carried verbatim to the backend.
+    RENDER_API void Barriers(
+        std::span<const BarrierCreateInfo> _barriers,
+        EQueueType                         _src_queue,
+        EQueueType                         _dst_queue
+    );
+
+    void Barriers(
+        std::initializer_list<BarrierCreateInfo> _barriers,
+        EQueueType                               _src_queue,
+        EQueueType                               _dst_queue
+    ) {
+        Barriers(
+            std::span<const BarrierCreateInfo>(_barriers.begin(), _barriers.size()),
+            _src_queue,
+            _dst_queue
+        );
+    }
+
+    void Barriers(std::span<const BarrierCreateInfo> _barriers) {
+        Barriers(_barriers, queue_type, queue_type);
+    }
+
+    void Barriers(std::initializer_list<BarrierCreateInfo> _barriers) {
+        Barriers(
+            std::span<const BarrierCreateInfo>(_barriers.begin(), _barriers.size()),
+            queue_type,
+            queue_type
+        );
+    }
+
     void TextureBarriers(
         EQueueType            _src_queue,
         EQueueType            _dst_queue,
@@ -1340,7 +1502,15 @@ public:
 
     RENDER_API CmdSubmit Submit();
 
+    // CommandList must remain at a stable address for the lifetime of the
+    // returned lease.
+    RENDER_API ManagedRecordingLease AcquireManagedRecordingLease();
+
     RENDER_API bool IsEmpty() const;
+
+    [[nodiscard]] uint64 GetSealGeneration() const noexcept {
+        return seal_generation;
+    }
 
     EQueueType GetQueueType() const noexcept {
         return queue_type;
@@ -1351,6 +1521,21 @@ public:
     ) noexcept {
         translate_execution_class = _execution_class;
         return *this;
+    }
+
+    CommandList& SetResourceStateOwnership(
+        ERHIResourceStateOwnership _ownership
+    ) noexcept {
+        resource_state_ownership = _ownership;
+        return *this;
+    }
+
+    bool HasExplicitResourceStateOwnership() const noexcept {
+        return resource_state_ownership == ERHIResourceStateOwnership::Explicit;
+    }
+
+    ERHITranslateExecutionClass GetTranslateExecutionClass() const noexcept {
+        return translate_execution_class;
     }
 
 private:
@@ -1430,6 +1615,14 @@ private:
     ERHITranslateExecutionClass  translate_execution_class{
         ERHITranslateExecutionClass::Parallel
     };
+    ERHIResourceStateOwnership   resource_state_ownership{
+        ERHIResourceStateOwnership::BackendTracked
+    };
+    // Monotonic mutation epoch for destructive sealing/draining operations.
+    // Managed recorders snapshot it around user callbacks so a callback cannot
+    // silently split or discard a graph-owned command stream.
+    uint64 seal_generation{0};
+    uint32 managed_recording_lease_count{0};
     struct ScopeState {
         std::string name;
         float4      color;

--- a/source/runtime/render/rhi/RHICommand.h
+++ b/source/runtime/render/rhi/RHICommand.h
@@ -500,6 +500,47 @@ inline constexpr bool BarrierStateWrites(const BarrierState& _state) {
                ERHIAccessFlags::UNDEFINED;
 }
 
+enum class EBarrierQueueTransferPhase : uint8 {
+    None,
+    Release,
+    Acquire,
+};
+
+/**
+ * Logical endpoints for one half of an exclusive queue-family ownership
+ * transfer. Backends resolve the logical queues through their authoritative
+ * topology; family indices are deliberately not cached in the command stream.
+ */
+struct BarrierQueueTransfer {
+    EBarrierQueueTransferPhase phase{EBarrierQueueTransferPhase::None};
+    EQueueType                 src_queue{EQueueType::Ignore};
+    EQueueType                 dst_queue{EQueueType::Ignore};
+
+    [[nodiscard]] static constexpr BarrierQueueTransfer Release(
+        EQueueType _src_queue,
+        EQueueType _dst_queue
+    ) {
+        return {
+            .phase     = EBarrierQueueTransferPhase::Release,
+            .src_queue = _src_queue,
+            .dst_queue = _dst_queue,
+        };
+    }
+
+    [[nodiscard]] static constexpr BarrierQueueTransfer Acquire(
+        EQueueType _src_queue,
+        EQueueType _dst_queue
+    ) {
+        return {
+            .phase     = EBarrierQueueTransferPhase::Acquire,
+            .src_queue = _src_queue,
+            .dst_queue = _dst_queue,
+        };
+    }
+
+    friend bool operator==(const BarrierQueueTransfer&, const BarrierQueueTransfer&) = default;
+};
+
 struct BarrierCreateInfo {
     std::variant<TextureView, BufferView> resource;
     BarrierState                          src_state{};
@@ -508,6 +549,7 @@ struct BarrierCreateInfo {
     // materialization time; callers must state whether color, depth, stencil,
     // or a plane subset is transitioned.
     ETextureAspectFlags texture_aspects{ETextureAspectFlags::NONE};
+    BarrierQueueTransfer queue_transfer{};
 
     static BarrierCreateInfo Transition(
         TextureView         _texture,

--- a/source/runtime/render/rhi/RHICommand.h
+++ b/source/runtime/render/rhi/RHICommand.h
@@ -297,6 +297,10 @@ struct CmdSubmit {
     ERHITranslateExecutionClass translate_execution_class{
         ERHITranslateExecutionClass::Parallel
     };
+    // Non-zero only for a validated upper-level queue DAG. Backends may use
+    // this to relax conservative cross-queue total ordering while retaining
+    // native per-queue submission order.
+    uint64             async_queue_scope{0};
     std::string        debug_label;
     float4             debug_label_color = GpuMarkerPalette::Frame();
 
@@ -392,6 +396,7 @@ struct CmdSubmit {
         b_delete_resources = _other.b_delete_resources;
         resource_state_ownership = _other.resource_state_ownership;
         translate_execution_class = _other.translate_execution_class;
+        async_queue_scope  = _other.async_queue_scope;
         debug_label        = std::move(_other.debug_label);
         debug_label_color  = _other.debug_label_color;
     }
@@ -410,6 +415,7 @@ struct CmdSubmit {
         b_delete_resources = _other.b_delete_resources;
         resource_state_ownership = _other.resource_state_ownership;
         translate_execution_class = _other.translate_execution_class;
+        async_queue_scope  = _other.async_queue_scope;
         debug_label        = std::move(_other.debug_label);
         debug_label_color  = _other.debug_label_color;
         return *this;

--- a/source/runtime/render/rhi/RHICommandList.cpp
+++ b/source/runtime/render/rhi/RHICommandList.cpp
@@ -10,6 +10,7 @@
 #include "rhi/RHIResourceInitilizer.h"
 #include "shader/ShaderPipeline.h"
 #include "shader/ShaderResourceManager.h"
+#include <stdexcept>
 namespace Moer::Render {
 
 void CommandQueue::Test() {
@@ -37,6 +38,78 @@ CommandList::CommandList(EQueueType _queue_type) : queue_type(_queue_type) {
         _queue_type == EQueueType::Graphics || _queue_type == EQueueType::Compute ||
         _queue_type == EQueueType::Copy
     );
+}
+
+CommandList::CommandList(CommandList&& _other) :
+    CommandList(_other.queue_type) {
+    *this = std::move(_other);
+}
+
+CommandList& CommandList::operator=(CommandList&& _other) {
+    if (this == &_other) {
+        return *this;
+    }
+    if (managed_recording_lease_count != 0 ||
+        _other.managed_recording_lease_count != 0) {
+        throw std::logic_error(
+            "CommandList move is forbidden while graph-managed recording is active"
+        );
+    }
+
+    commands                    = std::move(_other.commands);
+    current_barriers            = _other.current_barriers;
+    callbacks                   = std::move(_other.callbacks);
+    success_callbacks           = std::move(_other.success_callbacks);
+    cached_args                 = std::move(_other.cached_args);
+    queue_type                  = _other.queue_type;
+    translate_execution_class   = _other.translate_execution_class;
+    resource_state_ownership    = _other.resource_state_ownership;
+    seal_generation             = _other.seal_generation;
+    scope_stack                 = std::move(_other.scope_stack);
+    timestamp_scope_names       = std::move(_other.timestamp_scope_names);
+
+    _other.current_barriers          = nullptr;
+    _other.translate_execution_class =
+        ERHITranslateExecutionClass::Parallel;
+    _other.resource_state_ownership =
+        ERHIResourceStateOwnership::BackendTracked;
+    _other.seal_generation = 0;
+    return *this;
+}
+
+CommandList::ManagedRecordingLease::~ManagedRecordingLease() {
+    Release();
+}
+
+CommandList::ManagedRecordingLease::ManagedRecordingLease(
+    ManagedRecordingLease&& _other
+) noexcept :
+    command_list(std::exchange(_other.command_list, nullptr)) {}
+
+CommandList::ManagedRecordingLease&
+CommandList::ManagedRecordingLease::operator=(ManagedRecordingLease&& _other) noexcept {
+    if (this != &_other) {
+        Release();
+        command_list = std::exchange(_other.command_list, nullptr);
+    }
+    return *this;
+}
+
+void CommandList::ManagedRecordingLease::Release() noexcept {
+    if (command_list == nullptr) {
+        return;
+    }
+    assert(command_list->managed_recording_lease_count > 0);
+    --command_list->managed_recording_lease_count;
+    command_list = nullptr;
+}
+
+CommandList::ManagedRecordingLease CommandList::AcquireManagedRecordingLease() {
+    if (managed_recording_lease_count != 0) {
+        throw std::logic_error("CommandList already has a managed recording lease");
+    }
+    ++managed_recording_lease_count;
+    return ManagedRecordingLease(*this);
 }
 // void CommandList::ArgSetter::SetBuffer(uint64 _index, BufferView _buffer) {
 //     auto idx          = handle.GetBindingIdx(_index);
@@ -128,6 +201,12 @@ void CommandList::ComputeDispatcher::DispatchIndirect(
 }
 
 CmdSubmit CommandList::Submit() {
+    if (managed_recording_lease_count != 0) {
+        throw std::logic_error(
+            "CommandList::Submit is forbidden while graph-managed recording is active"
+        );
+    }
+    ++seal_generation;
     if (!scope_stack.empty()) {
         assert(scope_stack.empty() && "CommandList::Submit called with unclosed GPU marker scopes");
         // Keep release builds/captures structurally valid even if a caller
@@ -158,15 +237,23 @@ CmdSubmit CommandList::Submit() {
         });
     }
     submit.translate_execution_class = translate_execution_class;
+    submit.resource_state_ownership   = resource_state_ownership;
     commands.clear();
     callbacks.clear();
     success_callbacks.clear();
     timestamp_scope_names.clear();
     translate_execution_class = ERHITranslateExecutionClass::Parallel;
+    resource_state_ownership  = ERHIResourceStateOwnership::BackendTracked;
     return std::move(submit);
 }
 
 Array<std::function<void()>> CommandList::DrainOrdinaryCallbacksForRejection() {
+    if (managed_recording_lease_count != 0) {
+        throw std::logic_error(
+            "CommandList rejection draining is forbidden while graph-managed recording is active"
+        );
+    }
+    ++seal_generation;
     Array<std::function<void()>> cleanup_callbacks = std::move(callbacks);
 
     // This is deliberately not implemented in terms of Submit(). A failed
@@ -184,6 +271,7 @@ Array<std::function<void()>> CommandList::DrainOrdinaryCallbacksForRejection() {
     }
     timestamp_scope_names.clear();
     translate_execution_class = ERHITranslateExecutionClass::Parallel;
+    resource_state_ownership  = ERHIResourceStateOwnership::BackendTracked;
     return cleanup_callbacks;
 }
 
@@ -486,6 +574,37 @@ void CommandList::AddCustomCommand(UniquePtr<Command>&& _cmd, std::string_view _
 }
 
 #pragma endregion
+
+void CommandList::Barriers(
+    std::span<const BarrierCreateInfo> _barriers,
+    EQueueType                         _src_queue,
+    EQueueType                         _dst_queue
+) {
+    if (_barriers.empty()) {
+        throw std::invalid_argument("explicit barrier batch cannot be empty");
+    }
+    if (_src_queue != _dst_queue) {
+        assert(
+            _src_queue == _dst_queue &&
+            "explicit barriers cannot perform queue ownership transfer"
+        );
+        throw std::invalid_argument(
+            "explicit barriers require one queue; use paired queue import/export"
+        );
+    }
+    commands.push_back(
+        MakeUnique<BarrierCmd>(
+            static_cast<uint>(_barriers.size()), _src_queue, _dst_queue
+        )
+    );
+    auto* barrier_cmd = static_cast<BarrierCmd*>(commands.back().get());
+    for (const BarrierCreateInfo& barrier : _barriers) {
+        barrier_cmd->AddExplicitBarrier(barrier);
+    }
+    // Recording an authoritative src/dst dependency opts this submit out of
+    // the backend's legacy restore-to-preferred-state epilogue.
+    resource_state_ownership = ERHIResourceStateOwnership::Explicit;
+}
 
 void CommandList::AddCallback(std::function<void()>&& _callback) {
     callbacks.emplace_back(std::move(_callback));

--- a/source/runtime/render/rhi/RHICommandList.cpp
+++ b/source/runtime/render/rhi/RHICommandList.cpp
@@ -583,24 +583,110 @@ void CommandList::Barriers(
     if (_barriers.empty()) {
         throw std::invalid_argument("explicit barrier batch cannot be empty");
     }
-    if (_src_queue != _dst_queue) {
-        assert(
-            _src_queue == _dst_queue &&
-            "explicit barriers cannot perform queue ownership transfer"
-        );
+    if (_src_queue == EQueueType::Ignore || _src_queue == EQueueType::Num ||
+        _src_queue != _dst_queue || _src_queue != queue_type) {
         throw std::invalid_argument(
-            "explicit barriers require one queue; use paired queue import/export"
+            "explicit barrier command affinity must match its CommandList queue"
         );
     }
-    commands.push_back(
-        MakeUnique<BarrierCmd>(
-            static_cast<uint>(_barriers.size()), _src_queue, _dst_queue
-        )
+
+    const auto is_supported_ownership_queue = [](EQueueType queue) {
+        return queue == EQueueType::Graphics || queue == EQueueType::Compute ||
+               queue == EQueueType::Copy;
+    };
+    for (const BarrierCreateInfo& barrier : _barriers) {
+        const auto& transfer = barrier.queue_transfer;
+        switch (transfer.phase) {
+            case EBarrierQueueTransferPhase::None:
+                if (!((transfer.src_queue == EQueueType::Ignore &&
+                       transfer.dst_queue == EQueueType::Ignore) ||
+                      (transfer.src_queue == queue_type &&
+                       transfer.dst_queue == queue_type))) {
+                    throw std::invalid_argument(
+                        "local explicit barrier endpoints must be ignored or match "
+                        "the CommandList queue"
+                    );
+                }
+                break;
+            case EBarrierQueueTransferPhase::Release:
+            case EBarrierQueueTransferPhase::Acquire:
+                if (!is_supported_ownership_queue(transfer.src_queue) ||
+                    !is_supported_ownership_queue(transfer.dst_queue) ||
+                    transfer.src_queue == transfer.dst_queue) {
+                    throw std::invalid_argument(
+                        "queue ownership barrier requires distinct managed "
+                        "Graphics/Compute/Copy endpoints"
+                    );
+                }
+                if ((transfer.phase == EBarrierQueueTransferPhase::Release &&
+                     queue_type != transfer.src_queue) ||
+                    (transfer.phase == EBarrierQueueTransferPhase::Acquire &&
+                     queue_type != transfer.dst_queue)) {
+                    throw std::invalid_argument(
+                        "queue ownership barrier was recorded on the wrong endpoint"
+                    );
+                }
+                break;
+            default:
+                throw std::invalid_argument(
+                    "explicit barrier carries an unknown queue-transfer phase"
+                );
+        }
+
+        std::visit(
+            [&](const auto& resource) {
+                using TResource = std::decay_t<decltype(resource)>;
+                if constexpr (std::is_same_v<TResource, TextureView>) {
+                    const auto* texture = resource.GetTexture();
+                    const auto aspects =
+                        static_cast<uint32_t>(barrier.texture_aspects);
+                    const auto available_aspects =
+                        texture == nullptr ? 0u :
+                        static_cast<uint32_t>(texture->GetAspectFlags());
+                    if (texture == nullptr || resource.num_mips == 0 ||
+                        resource.num_array == 0 ||
+                        resource.mip_level >= texture->GetNumMips() ||
+                        resource.num_mips >
+                            texture->GetNumMips() - resource.mip_level ||
+                        resource.array_layer >= texture->GetNumArray() ||
+                        resource.num_array >
+                            texture->GetNumArray() - resource.array_layer ||
+                        aspects == 0 || (aspects & ~available_aspects) != 0) {
+                        throw std::invalid_argument(
+                            "explicit texture barrier has an invalid resource, "
+                            "range, or aspect"
+                        );
+                    }
+                } else {
+                    static_assert(std::is_same_v<TResource, BufferView>);
+                    const auto* buffer = resource.GetBuffer();
+                    if (buffer == nullptr || resource.GetByteSize() == 0 ||
+                        resource.GetByteOffset() > buffer->GetByteSize() ||
+                        resource.GetByteSize() >
+                            buffer->GetByteSize() - resource.GetByteOffset() ||
+                        barrier.texture_aspects != ETextureAspectFlags::NONE ||
+                        barrier.src_state.texture_layout !=
+                            ETextureLayout::TEXTURE_LAYOUT_UNDEFINED ||
+                        barrier.dst_state.texture_layout !=
+                            ETextureLayout::TEXTURE_LAYOUT_UNDEFINED) {
+                        throw std::invalid_argument(
+                            "explicit buffer barrier has an invalid resource, "
+                            "range, aspect, or texture layout"
+                        );
+                    }
+                }
+            },
+            barrier.resource
+        );
+    }
+
+    auto barrier_cmd = MakeUnique<BarrierCmd>(
+        static_cast<uint>(_barriers.size()), _src_queue, _dst_queue
     );
-    auto* barrier_cmd = static_cast<BarrierCmd*>(commands.back().get());
     for (const BarrierCreateInfo& barrier : _barriers) {
         barrier_cmd->AddExplicitBarrier(barrier);
     }
+    commands.push_back(std::move(barrier_cmd));
     // Recording an authoritative src/dst dependency opts this submit out of
     // the backend's legacy restore-to-preferred-state epilogue.
     resource_state_ownership = ERHIResourceStateOwnership::Explicit;

--- a/source/runtime/render/rhi/RHICommon.h
+++ b/source/runtime/render/rhi/RHICommon.h
@@ -1006,6 +1006,27 @@ enum class ETextureAspectFlags : uint32_t {
 
 ENUM_BIT_OP_IMPL(ETextureAspectFlags, FLAG)
 
+[[nodiscard]] constexpr ETextureAspectFlags
+GetPixelFormatAspectFlags(EPixelFormat format) noexcept {
+    switch (format) {
+        case PF_D16_UNORM:
+        case PF_X8_D24_UNORM_PACK32:
+        case PF_D32_SFLOAT:
+            return ETextureAspectFlags::DEPTH_SLICE;
+        case PF_S8_UINT:
+            return ETextureAspectFlags::STENCIL_SLICE;
+        case PF_D16_UNORM_S8_UINT:
+        case PF_D24_UNORM_S8_UINT:
+        case PF_D32_SFLOAT_S8_UINT:
+            return ETextureAspectFlags::DEPTH_SLICE |
+                   ETextureAspectFlags::STENCIL_SLICE;
+        case PF_UNDEFINED:
+            return ETextureAspectFlags::NONE;
+        default:
+            return ETextureAspectFlags::COLOR;
+    }
+}
+
 /* various shading rate palette, VSR_{fragment_invocation_count}_{region_size}
  * @fragment_invocation_count means fragment shading invocation per region
  * @region_size means one shading result will be used to color ${regions_size} pixels

--- a/source/runtime/render/rhi/RHICommon.h
+++ b/source/runtime/render/rhi/RHICommon.h
@@ -1257,6 +1257,46 @@ enum class EQueueType : uint8 {
     Num,
     Ignore
 };
+
+/**
+ * Backend-neutral physical queue identity. native_queue_id distinguishes
+ * independently ordered native queues; family_id distinguishes explicit
+ * queue-family ownership domains (Vulkan) and may be shared by otherwise
+ * independent queues.
+ */
+struct RHIQueueBinding {
+    EQueueType queue           = EQueueType::Ignore;
+    uint32_t   native_queue_id = 0;
+    uint32_t   family_id       = 0;
+    /** False when the backend does not expose this logical submission role. */
+    bool       available       = true;
+
+    friend bool operator==(const RHIQueueBinding&, const RHIQueueBinding&) = default;
+};
+
+struct RHIQueueTopology {
+    RHIQueueBinding graphics{EQueueType::Graphics, 0, 0};
+    RHIQueueBinding compute{EQueueType::Compute, 0, 0};
+    RHIQueueBinding copy{EQueueType::Copy, 0, 0};
+
+    [[nodiscard]] constexpr RHIQueueBinding Resolve(EQueueType _queue) const {
+        switch (_queue) {
+            case EQueueType::Graphics:
+                return graphics;
+            case EQueueType::Compute:
+                return compute;
+            case EQueueType::Copy:
+                return copy;
+            case EQueueType::Num:
+            case EQueueType::Ignore:
+                return {};
+        }
+        return {};
+    }
+
+    friend bool operator==(const RHIQueueTopology&, const RHIQueueTopology&) = default;
+};
+
 struct ReflectParamInfo {
     ReflectParamInfo() {
         memset(this, 0, sizeof(ReflectParamInfo));

--- a/source/runtime/render/rhi/RHIExecutor.cpp
+++ b/source/runtime/render/rhi/RHIExecutor.cpp
@@ -19,11 +19,17 @@ bool RejectOwnedThreadBlockingCall(std::string_view _operation) {
     if (IsRHIBlockingCallAllowedOnCurrentThread()) {
         return false;
     }
+    const ERHIThreadRole role = GetCurrentRHIThreadRole();
     LOG_ERROR(
         "[RHIExecutor] rejected blocking {} from {} owner thread to prevent a self-join",
         _operation,
-        RHIThreadRoleName(GetCurrentRHIThreadRole())
+        RHIThreadRoleName(role)
     );
+    if (role == ERHIThreadRole::RecordWorker) {
+        throw std::logic_error(
+            "blocking RHI lifecycle call is forbidden from a record worker"
+        );
+    }
     return true;
 }
 
@@ -221,7 +227,7 @@ void FinalizeCancelledRecordingSources(
     for (RHIRecordingSource& source : _sources) {
         const bool terminal =
             source.completion &&
-            source.completion->Status() != ERHIRecordingStatus::Pending;
+            source.completion.Status() != ERHIRecordingStatus::Pending;
         if (!terminal) {
             ++opaque_source_count;
             continue;
@@ -286,7 +292,7 @@ void FinalizeFailedRecordingSources(
         _sources.end(),
         [](const RHIRecordingSource& _source) {
             return _source.completion &&
-                   _source.completion->Status() != ERHIRecordingStatus::Pending;
+                   _source.completion.Status() != ERHIRecordingStatus::Pending;
         }
     );
     if (!all_terminal) {
@@ -847,9 +853,17 @@ void RHIExecutor::SubmitRecording(
     payload->flags   = _flags;
 
     std::vector<RHIRecordingGateRef> prerequisites{};
-    prerequisites.reserve(payload->sources.size());
+    prerequisites.reserve(payload->sources.size() * 2);
     for (const RHIRecordingSource& source : payload->sources) {
-        prerequisites.emplace_back(source.completion);
+        prerequisites.emplace_back(source.completion.gate);
+        if (source.commit &&
+            std::find(
+                prerequisites.begin(),
+                prerequisites.end(),
+                source.commit.gate
+            ) == prerequisites.end()) {
+            prerequisites.emplace_back(source.commit.gate);
+        }
     }
 
     recording_handoff.EnqueueRecording(RHIExecutorRecordingHandoffWork{

--- a/source/runtime/render/rhi/RHIExecutor.cpp
+++ b/source/runtime/render/rhi/RHIExecutor.cpp
@@ -171,6 +171,28 @@ void FinalizeRejectedSubmissions(
     }
 }
 
+void RejectRecordingSignalMetadata(
+    const Array<RHIRecordingSource>& _sources
+) noexcept {
+    // Metadata is prepared source-by-source and preparation can allocate.
+    // If any step throws, the entire immutable recording transaction is
+    // rejected, including producer values not yet copied into CmdSubmit.
+    // Fence rejection is idempotent, so already-materialized values may be
+    // terminalized again by FinalizeRejectedSubmissions below.
+    for (const RHIRecordingSource& source : _sources) {
+        for (const RHIRecordingFencePoint& point :
+             source.submit_metadata.signal_fences) {
+            if (!point.fence.IsValid() || point.value == 0) {
+                continue;
+            }
+            try {
+                point.fence->Reject(point.value);
+            } catch (...) {
+            }
+        }
+    }
+}
+
 void FinalizeRejectedBackendBatch(
     RHIBackendSubmissionBatch&& _batch,
     std::string_view             _reason
@@ -215,6 +237,7 @@ void FinalizeCancelledRecordingSources(
     Array<RHIRecordingSource>&& _sources,
     std::string_view             _reason
 ) {
+    RejectRecordingSignalMetadata(_sources);
     // A source protected by an incomplete recording gate must remain opaque:
     // even reading IsEmpty(), let alone draining callbacks, races its producer.
     // A terminal gate, however, is the ownership handoff point and its ordinary
@@ -282,6 +305,7 @@ void FinalizeFailedRecordingSources(
     Array<RHIRecordingSource>&& _sources,
     std::string_view             _reason
 ) {
+    RejectRecordingSignalMetadata(_sources);
     // Reject is emitted only after every producer gate is terminal. This is
     // the ownership point at which failed/partial CommandLists are immutable
     // and may be destructively drained for their ordinary cleanup callbacks.
@@ -903,7 +927,10 @@ void RHIExecutor::SubmitRecording(
                     if (!IsSubmissionQueue(queue)) {
                         throw std::runtime_error("recorded source changed to an invalid queue");
                     }
-                    if (source.command_list->IsEmpty()) {
+                    const bool metadata_queue_work =
+                        !source.submit_metadata.wait_fences.empty() ||
+                        !source.submit_metadata.signal_fences.empty();
+                    if (source.command_list->IsEmpty() && !metadata_queue_work) {
                         continue;
                     }
                     submits.emplace_back(queue, source.command_list->Submit());
@@ -924,12 +951,49 @@ void RHIExecutor::SubmitRecording(
                     if (metadata.translate_execution_class) {
                         submit.SetTranslateExecutionClass(*metadata.translate_execution_class);
                     }
+                    submit.async_queue_scope = metadata.async_queue_scope;
+
+                    auto sync_keepalive = std::make_shared<Array<FenceRef>>();
+                    sync_keepalive->reserve(
+                        metadata.wait_fences.size() +
+                        metadata.signal_fences.size()
+                    );
+                    for (const RHIRecordingFencePoint& point :
+                         metadata.wait_fences) {
+                        if (!point.fence.IsValid() || point.value == 0) {
+                            throw std::invalid_argument(
+                                "recording wait fence point is invalid"
+                            );
+                        }
+                        submit.wait_events.emplace_back(
+                            uint64(point.fence.Get()), point.value
+                        );
+                        sync_keepalive->emplace_back(point.fence);
+                    }
+                    for (const RHIRecordingFencePoint& point :
+                         metadata.signal_fences) {
+                        if (!point.fence.IsValid() || point.value == 0) {
+                            throw std::invalid_argument(
+                                "recording signal fence point is invalid"
+                            );
+                        }
+                        submit.signal_events.emplace_back(
+                            uint64(point.fence.Get()), point.value
+                        );
+                        sync_keepalive->emplace_back(point.fence);
+                    }
+                    if (!sync_keepalive->empty()) {
+                        // CmdSubmit callbacks are retained by the native
+                        // completion packet on success and rejection alike.
+                        submit.callbacks.emplace_back([sync_keepalive] {});
+                    }
                 }
             } catch (const std::exception& exception) {
                 LOG_ERROR(
                     "[RHIExecutor] failed to materialize recording sources: {}",
                     exception.what()
                 );
+                RejectRecordingSignalMetadata(payload->sources);
                 FinalizeRejectedSubmissions(
                     std::move(submits),
                     "recording source finalization failed"
@@ -937,6 +1001,7 @@ void RHIExecutor::SubmitRecording(
                 return;
             } catch (...) {
                 LOG_ERROR("[RHIExecutor] failed to materialize recording sources");
+                RejectRecordingSignalMetadata(payload->sources);
                 FinalizeRejectedSubmissions(
                     std::move(submits),
                     "recording source finalization failed"

--- a/source/runtime/render/rhi/RHIExecutor.h
+++ b/source/runtime/render/rhi/RHIExecutor.h
@@ -18,15 +18,19 @@ struct RHIRecordingSubmitMetadata {
 };
 
 // One independently recorded source. completion must be signalled only after
-// the producer has stopped mutating command_list. submit_metadata is immutable
-// at publication and deliberately contains data rather than an arbitrary
-// handoff-thread callback, so finalization cannot recursively Flush/Sync.
-// The producer owns the only mutable reference until it calls Signal()/Fail().
-// It must not call RHIExecutor::Flush, Sync or ShutDown while recording; those
-// are ordering/lifecycle boundaries owned by the submitting thread.
+// the producer has stopped mutating command_list. An optional commit gate adds
+// a graph-wide transaction boundary: the RHI worker may observe completed
+// producers early, but cannot seal any source until the owner commits the
+// complete graph. submit_metadata is immutable at publication and deliberately
+// contains data rather than an arbitrary handoff-thread callback, so
+// finalization cannot recursively Flush/Sync. The producer owns the only
+// mutable reference until it calls Signal()/Fail(). It must not call
+// RHIExecutor::Flush, Sync or ShutDown while recording; those are
+// ordering/lifecycle boundaries owned by the submitting thread.
 struct RHIRecordingSource {
     SharedPtr<CommandList>       command_list{};
-    RHIRecordingGateRef          completion{};
+    RHIRecordingGateView         completion{};
+    RHIRecordingGateView         commit{};
     RHIRecordingSubmitMetadata   submit_metadata{};
 };
 
@@ -53,13 +57,14 @@ public:
     );
 
     // Recording handoff API. Sources remain shared and mutable until their
-    // explicit gates complete; the RHI handoff worker then seals them into
-    // CmdSubmit payloads in input order. A batch may use one common gate or a
-    // distinct gate per source through the RHIRecordingSource overload. If any
-    // producer fails, the whole group waits for all producers, runs ordinary
-    // CommandList cleanup callbacks once, skips success callbacks, and never
-    // reaches a GPU queue. Shutdown cancellation remains non-blocking and does
-    // not inspect CommandLists whose producers may still be active.
+    // explicit gates and any optional commit gate complete; the RHI handoff
+    // worker then seals them into CmdSubmit payloads in input order. A batch
+    // may use one common gate or a distinct gate per source through the
+    // RHIRecordingSource overload. If any producer or transaction fails, the
+    // whole group waits for all prerequisites, runs ordinary CommandList
+    // cleanup callbacks once, skips success callbacks, and never reaches a GPU
+    // queue. Shutdown cancellation remains non-blocking and does not inspect
+    // CommandLists whose producers may still be active.
     void SubmitRecording(
         SharedPtr<CommandList> _command_list,
         RHIRecordingGateRef    _completion,

--- a/source/runtime/render/rhi/RHIExecutor.h
+++ b/source/runtime/render/rhi/RHIExecutor.h
@@ -10,11 +10,23 @@
 
 namespace Moer::Render {
 
+struct RHIRecordingFencePoint {
+    FenceRef fence{};
+    uint64   value{0};
+};
+
 struct RHIRecordingSubmitMetadata {
     std::optional<std::string>                 debug_label{};
     float4                                     debug_label_color{GpuMarkerPalette::Pass()};
     std::optional<ERHIProfilingPhase>          profiling_phase{};
     std::optional<ERHITranslateExecutionClass> translate_execution_class{};
+    Array<RHIRecordingFencePoint>              wait_fences{};
+    Array<RHIRecordingFencePoint>              signal_fences{};
+    /**
+     * Non-zero scopes opt a contiguous graph transaction into dependency-led
+     * cross-native-queue overlap. Zero preserves the legacy total GPU order.
+     */
+    uint64                                     async_queue_scope{0};
 };
 
 // One independently recorded source. completion must be signalled only after

--- a/source/runtime/render/rhi/RHIExecutorRecordingHandoff.h
+++ b/source/runtime/render/rhi/RHIExecutorRecordingHandoff.h
@@ -56,6 +56,38 @@ private:
 
 using RHIRecordingGateRef = std::shared_ptr<RHIRecordingGate>;
 
+// Read-only publication capability. Producers retain RHIRecordingGateRef and
+// therefore the only Signal/Fail authority; setup/publisher extensions and the
+// RHI consumer may observe status but cannot complete a gate early.
+class RENDER_API RHIRecordingGateView final {
+public:
+    RHIRecordingGateView() = default;
+    RHIRecordingGateView(const RHIRecordingGateRef& _gate) : gate(_gate) {}
+
+    [[nodiscard]] explicit operator bool() const noexcept {
+        return static_cast<bool>(gate);
+    }
+
+    [[nodiscard]] bool IsComplete() const noexcept {
+        return gate && gate->IsComplete();
+    }
+
+    [[nodiscard]] ERHIRecordingStatus Status() const noexcept {
+        return gate ? gate->Status() : ERHIRecordingStatus::Pending;
+    }
+
+    friend bool operator==(
+        const RHIRecordingGateView& _lhs,
+        const RHIRecordingGateView& _rhs
+    ) noexcept {
+        return _lhs.gate == _rhs.gate;
+    }
+
+private:
+    friend class RHIExecutor;
+    RHIRecordingGateRef gate{};
+};
+
 enum class ERHIRecordingHandoffResult : uint8_t {
     Consume,
     // Every prerequisite reached a terminal state, but at least one producer

--- a/source/runtime/render/rhi/RHIImpl.cpp
+++ b/source/runtime/render/rhi/RHIImpl.cpp
@@ -60,6 +60,11 @@ TextureRef RenderDevice::CreateTexture(
     return impl->CreateTexture(_name, dim, _size, _format, _usage, _mip_cnt, _array_size);
 }
 
+TextureRef
+RenderDevice::CreateTexture(std::string_view _name, const TextureInfo& _info) {
+    return impl->CreateTexture(_name, _info);
+}
+
 TextureRef RenderDevice::CreateCubeMap(
     std::string_view   _name,
     Extent2D           _size,

--- a/source/runtime/render/rhi/RHIImpl.cpp
+++ b/source/runtime/render/rhi/RHIImpl.cpp
@@ -89,6 +89,10 @@ FenceRef RenderDevice::CreateFence() {
     return impl->CreateFence();
 }
 
+RHIQueueTopology RenderDevice::GetQueueTopology() const {
+    return impl->GetQueueTopology();
+}
+
 SwapchainRef RenderDevice::CreateSwapchain(const SwapchainCreateInfo& _info) {
     return impl->CreateSwapchain(_info);
 }

--- a/source/runtime/render/rhi/RHIImpl.cpp
+++ b/source/runtime/render/rhi/RHIImpl.cpp
@@ -6,6 +6,10 @@
 #include "shader/ShaderResourceManager.h"
 
 #include "rhi/plugin/NrdPlugin.h"
+
+#include <limits>
+#include <stdexcept>
+
 namespace Moer::Render {
 PipelineHandle RenderDevice::CreatePipeline(GfxPsoCreateInfo&& _pso_info, PipelineShaderInfo&& _shaders) {
     return impl->CreatePipeline(std::move(_pso_info), std::move(_shaders));
@@ -97,6 +101,19 @@ BufferRef RenderDevice::CreateBuffer(
     EPixelFormat      _format
 ) {
     return impl->CreateBuffer(_name, _element_cnt, _stride, _usage, _format);
+}
+
+BufferRef RenderDevice::CreateBuffer(std::string_view _name, const BufferInfo& _info) {
+    if (_info.size > std::numeric_limits<uint>::max()) {
+        throw std::out_of_range("buffer element count exceeds the current RHI limit");
+    }
+    return CreateBuffer(
+        _name,
+        static_cast<uint>(_info.size),
+        _info.stride,
+        _info.usage,
+        _info.format
+    );
 }
 
 IOInterfaceRef RenderDevice::CreateIOInterface(CopyQueue& _copy_queue) {

--- a/source/runtime/render/rhi/RHIImpl.h
+++ b/source/runtime/render/rhi/RHIImpl.h
@@ -1776,7 +1776,7 @@ public:
         EPixelFormat      _format
     ) = 0;
 
-    virtual TextureRef CreateTexture(
+    TextureRef CreateTexture(
         std::string_view   _name,
         ETextureDimension  _dimension,
         Extent3D           _size,
@@ -1784,7 +1784,29 @@ public:
         ETextureUsageFlags _usage,
         uint32_t           _mip_cnt    = 1,
         uint               _array_size = 1
-    ) = 0;
+    ) {
+        const bool b_depth =
+            uint(ETextureUsageFlags::DEPTH_STENCIL_ATTACHMENT & _usage) != 0;
+        TextureInfo info{
+            _dimension,
+            _usage,
+            _format,
+            b_depth ? EClearAttachment::DEPTH_STENCIL :
+                      EClearAttachment::COLOR,
+            _size,
+            uint8(_mip_cnt),
+            uint8((_dimension == ETextureDimension::TEX_CUBE ? 6 : 1) * _array_size),
+            1
+        };
+        info.aspect_flags =
+            b_depth ? ETextureAspectFlags::DEPTH_SLICE :
+                      ETextureAspectFlags::COLOR;
+        info.debug_name = std::string(_name);
+        return CreateTexture(_name, info);
+    }
+
+    virtual TextureRef
+    CreateTexture(std::string_view _name, const TextureInfo& _info) = 0;
 
     DepthBufferRef CreateDepthBuffer(
         std::string_view   _name,

--- a/source/runtime/render/rhi/RHIImpl.h
+++ b/source/runtime/render/rhi/RHIImpl.h
@@ -582,8 +582,8 @@ private:
     Array<BufferBarrier>  write_buffers;
     Array<ExplicitTextureBarrier> explicit_textures;
     Array<ExplicitBufferBarrier>  explicit_buffers;
-    EQueueType            src_queue;
-    EQueueType            dst_queue;
+    EQueueType            src_queue{EQueueType::Ignore};
+    EQueueType            dst_queue{EQueueType::Ignore};
     bool                  b_queue_transition = false;
 
 public:
@@ -713,7 +713,7 @@ public:
     }
 
     EQueueType GetQueueType() const override {
-        return EQueueType::Graphics;
+        return src_queue != EQueueType::Ignore ? src_queue : dst_queue;
     }
     const auto& ReadTextures() const {
         return read_textures;
@@ -1813,6 +1813,8 @@ public:
     virtual CommandQueue& GetCommandQueue(EQueueType _type) = 0;
 
     virtual CopyQueue& GetCopyQueue() = 0;
+
+    virtual RHIQueueTopology GetQueueTopology() const = 0;
 
     virtual SwapchainRef CreateSwapchain(const SwapchainCreateInfo& _info) = 0;
 

--- a/source/runtime/render/rhi/RHIImpl.h
+++ b/source/runtime/render/rhi/RHIImpl.h
@@ -559,6 +559,7 @@ struct ExplicitTextureBarrier {
     BarrierState        src_state{};
     BarrierState        dst_state{};
     ETextureAspectFlags texture_aspects{ETextureAspectFlags::NONE};
+    BarrierQueueTransfer queue_transfer{};
     uint8               mip_level{};
     uint8               mip_count{1};
     uint8               array_layer{};
@@ -569,6 +570,7 @@ struct ExplicitBufferBarrier {
     uint64       handle{};
     BarrierState src_state{};
     BarrierState dst_state{};
+    BarrierQueueTransfer queue_transfer{};
     uint64       offset{};
     uint64       byte_size{};
 };
@@ -655,6 +657,7 @@ public:
                         .src_state       = _barrier.src_state,
                         .dst_state       = _barrier.dst_state,
                         .texture_aspects = _barrier.texture_aspects,
+                        .queue_transfer  = _barrier.queue_transfer,
                         .mip_level       = _resource.mip_level,
                         .mip_count       = _resource.num_mips,
                         .array_layer     = _resource.array_layer,
@@ -671,6 +674,7 @@ public:
                         .handle     = reinterpret_cast<uint64>(_resource.GetBuffer()),
                         .src_state  = _barrier.src_state,
                         .dst_state  = _barrier.dst_state,
+                        .queue_transfer = _barrier.queue_transfer,
                         .offset     = _resource.GetByteOffset(),
                         .byte_size  = _resource.GetByteSize(),
                     });

--- a/source/runtime/render/rhi/RHIImpl.h
+++ b/source/runtime/render/rhi/RHIImpl.h
@@ -553,6 +553,26 @@ struct BufferBarrier {
     uint64       offset{};
     uint64       byte_size{};
 };
+
+struct ExplicitTextureBarrier {
+    uint64              handle{};
+    BarrierState        src_state{};
+    BarrierState        dst_state{};
+    ETextureAspectFlags texture_aspects{ETextureAspectFlags::NONE};
+    uint8               mip_level{};
+    uint8               mip_count{1};
+    uint8               array_layer{};
+    uint8               array_count{1};
+};
+
+struct ExplicitBufferBarrier {
+    uint64       handle{};
+    BarrierState src_state{};
+    BarrierState dst_state{};
+    uint64       offset{};
+    uint64       byte_size{};
+};
+
 struct BarrierCmd : public Command {
 private:
     BarrierCmd() : Command(EType::Barrier) {}
@@ -560,6 +580,8 @@ private:
     Array<TextureBarrier> write_textures;
     Array<BufferBarrier>  read_buffers;
     Array<BufferBarrier>  write_buffers;
+    Array<ExplicitTextureBarrier> explicit_textures;
+    Array<ExplicitBufferBarrier>  explicit_buffers;
     EQueueType            src_queue;
     EQueueType            dst_queue;
     bool                  b_queue_transition = false;
@@ -618,6 +640,47 @@ public:
         return *this;
     }
 
+    BarrierCmd& AddExplicitBarrier(const BarrierCreateInfo& _barrier) {
+        std::visit(
+            [this, &_barrier](const auto& _resource) {
+                using TResource = std::decay_t<decltype(_resource)>;
+                if constexpr (std::is_same_v<TResource, TextureView>) {
+                    assert(_resource.GetTexture() != nullptr && "explicit texture barrier requires a texture");
+                    assert(
+                        _barrier.texture_aspects != ETextureAspectFlags::NONE &&
+                        "explicit texture barrier requires a non-empty aspect mask"
+                    );
+                    explicit_textures.emplace_back(ExplicitTextureBarrier{
+                        .handle          = reinterpret_cast<uint64>(_resource.GetTexture()),
+                        .src_state       = _barrier.src_state,
+                        .dst_state       = _barrier.dst_state,
+                        .texture_aspects = _barrier.texture_aspects,
+                        .mip_level       = _resource.mip_level,
+                        .mip_count       = _resource.num_mips,
+                        .array_layer     = _resource.array_layer,
+                        .array_count     = _resource.num_array,
+                    });
+                } else {
+                    static_assert(std::is_same_v<TResource, BufferView>);
+                    assert(_resource.GetBuffer() != nullptr && "explicit buffer barrier requires a buffer");
+                    assert(
+                        _barrier.texture_aspects == ETextureAspectFlags::NONE &&
+                        "buffer barriers cannot carry texture aspects"
+                    );
+                    explicit_buffers.emplace_back(ExplicitBufferBarrier{
+                        .handle     = reinterpret_cast<uint64>(_resource.GetBuffer()),
+                        .src_state  = _barrier.src_state,
+                        .dst_state  = _barrier.dst_state,
+                        .offset     = _resource.GetByteOffset(),
+                        .byte_size  = _resource.GetByteSize(),
+                    });
+                }
+            },
+            _barrier.resource
+        );
+        return *this;
+    }
+
     BarrierCmd(
         uint       _read_tex_cnt,
         uint       _write_tex_cnt,
@@ -636,6 +699,19 @@ public:
         write_buffers.reserve(_write_buf_cnt);
     }
 
+    BarrierCmd(
+        uint       _explicit_barrier_count,
+        EQueueType _src_queue,
+        EQueueType _dst_queue
+    ) :
+        Command(EType::Barrier),
+        src_queue(_src_queue),
+        dst_queue(_dst_queue),
+        b_queue_transition(_src_queue != _dst_queue) {
+        explicit_textures.reserve(_explicit_barrier_count);
+        explicit_buffers.reserve(_explicit_barrier_count);
+    }
+
     EQueueType GetQueueType() const override {
         return EQueueType::Graphics;
     }
@@ -650,6 +726,15 @@ public:
     }
     const auto& WriteBuffers() const {
         return write_buffers;
+    }
+    const auto& ExplicitTextures() const {
+        return explicit_textures;
+    }
+    const auto& ExplicitBuffers() const {
+        return explicit_buffers;
+    }
+    bool HasExplicitBarriers() const {
+        return !explicit_textures.empty() || !explicit_buffers.empty();
     }
     const bool IsQueueTransition() const {
         return b_queue_transition;

--- a/source/runtime/render/rhi/RHIResource.h
+++ b/source/runtime/render/rhi/RHIResource.h
@@ -267,6 +267,16 @@ public:
         return (uint32_t)flags.GetRefCount(std::memory_order_relaxed);
     }
 
+    /**
+     * Acquire-loads the intrusive count before reporting sole ownership.
+     *
+     * This is the synchronization query for pools that reuse a resource after
+     * another thread drops its last external reference with DeRef(release).
+     */
+    [[nodiscard]] bool IsUniquelyReferenced() const {
+        return flags.GetRefCount(std::memory_order_acquire) == 1;
+    }
+
     bool IsValid() const {
         return flags.IsValid(std::memory_order_relaxed);
     }
@@ -484,6 +494,9 @@ public:
     }
     EBufferUsageFlags GetUsage() const {
         return info.usage;
+    }
+    EPixelFormat GetFormat() const {
+        return info.format;
     }
     const std::string_view GetName() const {
         return std::string_view(debug_name.has_value() ? debug_name.value().data() : default_name.data());

--- a/source/runtime/render/rhi/d3d12/D3D12Device.cpp
+++ b/source/runtime/render/rhi/d3d12/D3D12Device.cpp
@@ -1445,7 +1445,11 @@ struct D3D12CommandVisitor {
                 Visit(static_cast<const CopyTextureCmd&>(*_cmd));
                 break;
             case Command::EType::Barrier:
-                break; // no-op
+                FATAL(
+                    "D3D12 copy visitor does not materialize explicit or "
+                    "legacy BarrierCmd"
+                );
+                break;
             case Command::EType::ShaderDispatch:
                 Visit(static_cast<const DispatchCmd&>(*_cmd));
                 break;

--- a/source/runtime/render/rhi/d3d12/D3D12Device.cpp
+++ b/source/runtime/render/rhi/d3d12/D3D12Device.cpp
@@ -526,28 +526,16 @@ PipelineHandle D3D12Device::CreatePipeline(PipelineShaderInfo&& _shaders) {
 }
 
 TextureRef D3D12Device::CreateTexture(
-    std::string_view   _name,
-    ETextureDimension  _dimension,
-    Extent3D           _size,
-    EPixelFormat       _format,
-    ETextureUsageFlags _usage,
-    uint32_t           _mip_cnt,
-    uint               _array_size
+    std::string_view  _name,
+    const TextureInfo& _info
 ) {
-    bool        b_depth = uint(ETextureUsageFlags::DEPTH_STENCIL_ATTACHMENT & _usage) != 0;
-    TextureInfo info{
-        _dimension,
-        _usage,
-        _format,
-        b_depth ? EClearAttachment::DEPTH_STENCIL : EClearAttachment::COLOR,
-        _size,
-        uint8(_mip_cnt),
-        uint8(_dimension == ETextureDimension::TEX_CUBE ? 6 : _array_size),
-        1
-    }; // TODO ? msaa tex
-    info.aspect_flags = b_depth ? ETextureAspectFlags::DEPTH_SLICE : ETextureAspectFlags::COLOR;
-    info.debug_name   = _name;
-    return TextureRef{MoerNew(D3D12Texture)(this, info)};
+    TextureInfo info = _info;
+    if (!info.debug_name.has_value()) {
+        info.debug_name = std::string(_name);
+    }
+    auto* texture = MoerNew(D3D12Texture)(this, info);
+    texture->SetName(info.debug_name.value());
+    return TextureRef{texture};
 }
 
 BufferRef D3D12Device::CreateBuffer(

--- a/source/runtime/render/rhi/d3d12/D3D12Device.cpp
+++ b/source/runtime/render/rhi/d3d12/D3D12Device.cpp
@@ -1160,6 +1160,11 @@ struct D3D12CommandPreprocessVisitor {
     }
 
     void Visit(const BarrierCmd& _cmd) {
+        if (_cmd.HasExplicitBarriers()) {
+            FATAL(
+                "D3D12 does not yet materialize graph-owned explicit BarrierCmd"
+            );
+        }
         // we not ignore _cmd.IsQueueTransition()
         ASSERT(!_cmd.IsQueueTransition());
 

--- a/source/runtime/render/rhi/d3d12/D3D12Device.cpp
+++ b/source/runtime/render/rhi/d3d12/D3D12Device.cpp
@@ -606,6 +606,32 @@ CommandQueue& D3D12Device::GetCommandQueue(EQueueType _type) {
     return queue;
 }
 
+RHIQueueTopology D3D12Device::GetQueueTopology() const {
+    // The current D3D12 backend exposes only its Graphics command queue.
+    // Compute/Copy must remain fail-closed until their native queues and
+    // executor submission paths are implemented.
+    return RHIQueueTopology{
+        .graphics = RHIQueueBinding{
+            .queue = EQueueType::Graphics,
+            .native_queue_id = 0,
+            .family_id = 0,
+            .available = true,
+        },
+        .compute = RHIQueueBinding{
+            .queue = EQueueType::Compute,
+            .native_queue_id = 0,
+            .family_id = 0,
+            .available = false,
+        },
+        .copy = RHIQueueBinding{
+            .queue = EQueueType::Copy,
+            .native_queue_id = 0,
+            .family_id = 0,
+            .available = false,
+        },
+    };
+}
+
 CopyQueue& D3D12Device::GetCopyQueue() {
     // TODO: 在此处插入 return 语句
     struct DummyCopyQueue : CopyQueue {

--- a/source/runtime/render/rhi/d3d12/D3D12Device.h
+++ b/source/runtime/render/rhi/d3d12/D3D12Device.h
@@ -1099,15 +1099,8 @@ public:
     PipelineHandle CreatePipeline(GfxPsoCreateInfo&& _pso_info, PipelineShaderInfo&& _shaders) override;
     PipelineHandle CreatePipeline(PipelineShaderInfo&& _shaders) override;
 
-    TextureRef CreateTexture(
-        std::string_view   _name,
-        ETextureDimension  _dimension,
-        Extent3D           _size,
-        EPixelFormat       _format,
-        ETextureUsageFlags _usage,
-        uint32_t           _mip_cnt,
-        uint               _array_size
-    ) override;
+    TextureRef
+    CreateTexture(std::string_view _name, const TextureInfo& _info) override;
 
     BufferRef CreateBuffer(
         std::string_view  _name,

--- a/source/runtime/render/rhi/d3d12/D3D12Device.h
+++ b/source/runtime/render/rhi/d3d12/D3D12Device.h
@@ -1129,6 +1129,8 @@ public:
 
     CopyQueue& GetCopyQueue() override;
 
+    RHIQueueTopology GetQueueTopology() const override;
+
     SwapchainRef CreateSwapchain(const SwapchainCreateInfo& _info) override;
 
 private:

--- a/source/runtime/render/rhi/vulkan/RHICmdReorderer.h
+++ b/source/runtime/render/rhi/vulkan/RHICmdReorderer.h
@@ -834,6 +834,49 @@ public:
     }
 
     void VisitCmd(const BarrierCmd* _cmd) {
+        if (_cmd->HasExplicitBarriers()) {
+            // A materialized transition is a command-stream boundary, not a
+            // resource access that may share a dependency layer. Give it the
+            // next exclusive layer and advance the global offset so neither
+            // its prefix nor following work can cross the barrier.
+            const int64 layer = std::max<int64>(
+                static_cast<int64>(m_cmd_lists.size()),
+                GetLayerWithOffset(0)
+            );
+            for (const ExplicitBufferBarrier& barrier :
+                 _cmd->ExplicitBuffers()) {
+                auto* range_handle = static_cast<RangeHandle*>(
+                    GetHandle(barrier.handle, ResourceType::Texture_Buffer)
+                );
+                RecordWrite(
+                    range_handle,
+                    Range(barrier.offset, barrier.byte_size),
+                    layer
+                );
+                m_write_resources.emplace(range_handle->handle);
+            }
+            for (const ExplicitTextureBarrier& barrier :
+                 _cmd->ExplicitTextures()) {
+                auto* range_handle = static_cast<RangeHandle*>(
+                    GetHandle(barrier.handle, ResourceType::Texture_Buffer)
+                );
+                RecordWrite(
+                    range_handle,
+                    Range(
+                        barrier.mip_level,
+                        barrier.mip_count,
+                        barrier.array_layer,
+                        barrier.array_count
+                    ),
+                    layer
+                );
+                m_write_resources.emplace(range_handle->handle);
+            }
+            AddCmd(_cmd, layer);
+            layer_offset = static_cast<int64>(m_cmd_lists.size());
+            return;
+        }
+
         int64               layer = 0;
         Array<RangeHandle*> read_resources;
         Array<Range>        read_ranges;

--- a/source/runtime/render/rhi/vulkan/VulkanDevice.cpp
+++ b/source/runtime/render/rhi/vulkan/VulkanDevice.cpp
@@ -34,6 +34,7 @@
 
 #include "VulkanIOService.h"
 #include <algorithm>
+#include <array>
 #include <config.h>
 #include <cstdlib>
 #include <filesystem>
@@ -436,23 +437,37 @@ void VulkanDevice::InitGpu(uint32 _api_version) {
 }
 
 void VulkanDevice::CreateDevice(uint32 _api_version) {
+    const uint32_t graphics_family =
+        m_device_info.queue_family_indices.graphics.value();
+    const uint32_t compute_family =
+        m_device_info.queue_family_indices.compute.value();
+    const bool can_split_same_family_compute =
+        compute_family == graphics_family &&
+        compute_family < m_device_info.queue_family_props.size() &&
+        m_device_info.queue_family_props[compute_family].queueCount >= 2;
+    const uint32_t compute_queue_index =
+        can_split_same_family_compute ? 1u : 0u;
+
     std::set<uint32> unique_family_indices = {
-        m_device_info.queue_family_indices.graphics.value(),
+        graphics_family,
         m_device_info.queue_family_indices.present.value(),
-        m_device_info.queue_family_indices.compute.value(),
+        compute_family,
         m_device_info.queue_family_indices.transfer.value()
     };
 
     // setup queue info
     Moer::Array<VkDeviceQueueCreateInfo> queue_create_infos;
 
-    const float default_queue_priority = 1.0f;
+    const std::array queue_priorities{1.0f, 1.0f};
     for (const auto& queue_family_index : unique_family_indices) {
         VkDeviceQueueCreateInfo queue_create_info{};
         queue_create_info.sType            = VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO;
         queue_create_info.queueFamilyIndex = queue_family_index;
-        queue_create_info.queueCount       = 1;
-        queue_create_info.pQueuePriorities = &default_queue_priority;
+        queue_create_info.queueCount =
+            queue_family_index == compute_family ?
+                compute_queue_index + 1 :
+                1;
+        queue_create_info.pQueuePriorities = queue_priorities.data();
 
         queue_create_infos.push_back(queue_create_info);
     }
@@ -489,10 +504,15 @@ void VulkanDevice::CreateDevice(uint32 _api_version) {
     VK_CHECK_RESULT(vkCreateDevice(m_gpu, &device_create_info, nullptr, &m_device));
     volkLoadDevice(m_device);
 
-    vkGetDeviceQueue(m_device, m_device_info.queue_family_indices.graphics.value(), 0, &m_graphics_queue);
+    vkGetDeviceQueue(m_device, graphics_family, 0, &m_graphics_queue);
 
     vkGetDeviceQueue(m_device, m_device_info.queue_family_indices.present.value(), 0, &m_present_queue);
-    vkGetDeviceQueue(m_device, m_device_info.queue_family_indices.compute.value(), 0, &m_compute_queue);
+    vkGetDeviceQueue(
+        m_device,
+        compute_family,
+        compute_queue_index,
+        &m_compute_queue
+    );
     vkGetDeviceQueue(m_device, m_device_info.queue_family_indices.transfer.value(), 0, &m_transfer_queue);
     vkGetDeviceQueue(m_device, m_device_info.queue_family_indices.raytracing.value(), 0, &m_raytracing_queue);
 
@@ -529,6 +549,13 @@ void VulkanDevice::CreateDevice(uint32 _api_version) {
         LOG_WARNING(
             "compute and gfx share the same VkQueue handle. "
             "Using shared host synchronization for queue operations."
+        );
+    } else if (compute_family == graphics_family) {
+        LOG_INFO(
+            "compute and gfx use distinct VkQueue handles in family {} "
+            "(graphics_index=0 compute_index={}).",
+            graphics_family,
+            compute_queue_index
         );
     }
 }
@@ -2230,6 +2257,36 @@ CommandQueue& VulkanDevice::GetCommandQueue(EQueueType _type) {
             assert(false && "Unknown queue type.");
     }
     return *gfx_queue;
+}
+
+RHIQueueTopology VulkanDevice::GetQueueTopology() const {
+    const uint32_t graphics_native_id = 0;
+    const uint32_t compute_native_id =
+        m_compute_queue == m_graphics_queue ? graphics_native_id : 1u;
+    const uint32_t copy_native_id =
+        m_transfer_queue == m_graphics_queue ?
+            graphics_native_id :
+        m_transfer_queue == m_compute_queue ?
+            compute_native_id :
+            compute_native_id + 1;
+
+    return RHIQueueTopology{
+        .graphics = RHIQueueBinding{
+            EQueueType::Graphics,
+            graphics_native_id,
+            m_device_info.queue_family_indices.graphics.value(),
+        },
+        .compute = RHIQueueBinding{
+            EQueueType::Compute,
+            compute_native_id,
+            m_device_info.queue_family_indices.compute.value(),
+        },
+        .copy = RHIQueueBinding{
+            EQueueType::Copy,
+            copy_native_id,
+            m_device_info.queue_family_indices.transfer.value(),
+        },
+    };
 }
 
 CopyQueue& VulkanDevice::GetCopyQueue() {

--- a/source/runtime/render/rhi/vulkan/VulkanDevice.cpp
+++ b/source/runtime/render/rhi/vulkan/VulkanDevice.cpp
@@ -2294,29 +2294,13 @@ CopyQueue& VulkanDevice::GetCopyQueue() {
 }
 
 TextureRef VulkanDevice::CreateTexture(
-    std::string_view   _name,
-    ETextureDimension  _dimension,
-    Extent3D           _size,
-    EPixelFormat       _format,
-    ETextureUsageFlags _usage,
-    uint32_t           _mip_cnt,
-    uint32_t           _array_size
+    std::string_view  _name,
+    const TextureInfo& _info
 ) {
-
-    bool        b_depth = uint(ETextureUsageFlags::DEPTH_STENCIL_ATTACHMENT & _usage) != 0;
-    TextureInfo info{
-        _dimension,
-        _usage,
-        _format,
-        b_depth ? EClearAttachment::DEPTH_STENCIL : EClearAttachment::COLOR,
-        _size,
-        uint8(_mip_cnt),
-        uint8((_dimension == ETextureDimension::TEX_CUBE ? 6 : 1) * _array_size),
-        1
-    };
-    info.aspect_flags = b_depth ? ETextureAspectFlags::DEPTH_SLICE : ETextureAspectFlags::COLOR;
-    info.debug_name   = _name;
-
+    TextureInfo info = _info;
+    if (!info.debug_name.has_value()) {
+        info.debug_name = std::string(_name);
+    }
     return TextureRef{MoerNew(VulkanTexture)(info, this)};
 }
 

--- a/source/runtime/render/rhi/vulkan/VulkanDevice.h
+++ b/source/runtime/render/rhi/vulkan/VulkanDevice.h
@@ -93,15 +93,8 @@ public:
     PipelineHandle CreatePipeline(GfxPsoCreateInfo&& _pso_info, PipelineShaderInfo&& _shaders) override;
     PipelineHandle CreatePipeline(PipelineShaderInfo&& _shaders) override;
 
-    TextureRef CreateTexture(
-        std::string_view   _name,
-        ETextureDimension  _dimension,
-        Extent3D           _size,
-        EPixelFormat       _format,
-        ETextureUsageFlags _usage,
-        uint32_t           _mip_cnt,
-        uint               _array_size
-    ) override;
+    TextureRef
+    CreateTexture(std::string_view _name, const TextureInfo& _info) override;
 
     BufferRef CreateBuffer(
         std::string_view  _name,

--- a/source/runtime/render/rhi/vulkan/VulkanDevice.h
+++ b/source/runtime/render/rhi/vulkan/VulkanDevice.h
@@ -123,6 +123,8 @@ public:
 
     CopyQueue& GetCopyQueue() override;
 
+    RHIQueueTopology GetQueueTopology() const override;
+
     SwapchainRef CreateSwapchain(const SwapchainCreateInfo& _info) override;
 
     IOInterfaceRef CreateIOInterface(CopyQueue& _copy_queue) override;

--- a/source/runtime/render/rhi/vulkan/VulkanQueue.cpp
+++ b/source/runtime/render/rhi/vulkan/VulkanQueue.cpp
@@ -274,6 +274,21 @@ struct VkCmdPreprocessor {
         m_funcs(_funcs),
         cached_args(_cached_args),
         current_queue(_current_queue) {}
+
+    bool OverlapsCurrentTextureWrite(
+        const TextureSubresourceKeyT<VulkanTexture>& _candidate
+    ) const {
+        return std::any_of(
+            writed_texture_resources.begin(),
+            writed_texture_resources.end(),
+            [&](const TextureSubresourceKeyT<VulkanTexture>& written) {
+                return TextureSubresourceRangesOverlap(
+                    written, _candidate
+                );
+            }
+        );
+    }
+
     void HandleBindless(BindlessArrayRef _bindless_array, VkPipelineStageFlagBits2 _pipeline_stages) {
         EPassType pass_type = EPassType::Graphics;
         if (_pipeline_stages == VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT) {
@@ -301,7 +316,7 @@ struct VkCmdPreprocessor {
                         key.array_layer,
                         key.array_count
                     ) &&
-                    !writed_texture_resources.contains(key)) {
+                    !OverlapsCurrentTextureWrite(key)) {
                     to_read_textures.push_back(key);
                 }
             }
@@ -794,6 +809,101 @@ struct VkCmdPreprocessor {
     }
 
     void Visit(const BarrierCmd* _cmd) {
+        if (_cmd->HasExplicitBarriers()) {
+            if (_cmd->IsQueueTransition()) {
+                LOG_CRITICAL(
+                    "Explicit BarrierCmd cannot perform queue ownership transfer "
+                    "({} -> {}); use paired ExportResourcesToQueue/"
+                    "ImportResourcesFromQueue commands",
+                    static_cast<uint>(_cmd->GetSrcQueue()),
+                    static_cast<uint>(_cmd->GetDstQueue())
+                );
+                throw std::logic_error(
+                    "cross-queue explicit barrier must use paired queue-transfer commands"
+                );
+            }
+            if (_cmd->GetSrcQueue() != current_queue ||
+                _cmd->GetDstQueue() != current_queue) {
+                LOG_CRITICAL(
+                    "Explicit BarrierCmd queue affinity mismatch: command={} "
+                    "current={}",
+                    static_cast<uint>(_cmd->GetSrcQueue()),
+                    static_cast<uint>(current_queue)
+                );
+                throw std::logic_error("explicit barrier recorded on the wrong queue");
+            }
+
+            for (const ExplicitBufferBarrier& barrier : _cmd->ExplicitBuffers()) {
+                if (barrier.src_state.texture_layout !=
+                        ETextureLayout::TEXTURE_LAYOUT_UNDEFINED ||
+                    barrier.dst_state.texture_layout !=
+                        ETextureLayout::TEXTURE_LAYOUT_UNDEFINED) {
+                    throw std::invalid_argument(
+                        "explicit buffer barrier cannot carry a texture layout"
+                    );
+                }
+                tracker.EmitExplicitBarrier(
+                    reinterpret_cast<VulkanBuffer*>(barrier.handle),
+                    barrier.offset,
+                    barrier.byte_size,
+                    VulkanEnumTranslator::METoVkPipelineStageFlags2(
+                        barrier.src_state.stage
+                    ),
+                    VulkanEnumTranslator::METoVkAccessFlags2(
+                        barrier.src_state.access
+                    ),
+                    VulkanEnumTranslator::METoVkPipelineStageFlags2(
+                        barrier.dst_state.stage
+                    ),
+                    VulkanEnumTranslator::METoVkAccessFlags2(
+                        barrier.dst_state.access
+                    )
+                );
+            }
+            for (const ExplicitTextureBarrier& barrier :
+                 _cmd->ExplicitTextures()) {
+                const VkImageLayout src_layout =
+                    VulkanEnumTranslator::METoVKImageLayout(
+                        barrier.src_state.texture_layout
+                    );
+                const VkImageLayout dst_layout =
+                    VulkanEnumTranslator::METoVKImageLayout(
+                        barrier.dst_state.texture_layout
+                    );
+                if (src_layout == VK_IMAGE_LAYOUT_MAX_ENUM ||
+                    dst_layout == VK_IMAGE_LAYOUT_MAX_ENUM) {
+                    throw std::invalid_argument(
+                        "explicit texture barrier carries an unsupported layout"
+                    );
+                }
+                tracker.EmitExplicitBarrier(
+                    reinterpret_cast<VulkanTexture*>(barrier.handle),
+                    VulkanEnumTranslator::METoVKImageAspectFlags(
+                        barrier.texture_aspects
+                    ),
+                    barrier.mip_level,
+                    barrier.mip_count,
+                    barrier.array_layer,
+                    barrier.array_count,
+                    VulkanEnumTranslator::METoVkPipelineStageFlags2(
+                        barrier.src_state.stage
+                    ),
+                    VulkanEnumTranslator::METoVkAccessFlags2(
+                        barrier.src_state.access
+                    ),
+                    src_layout,
+                    VulkanEnumTranslator::METoVkPipelineStageFlags2(
+                        barrier.dst_state.stage
+                    ),
+                    VulkanEnumTranslator::METoVkAccessFlags2(
+                        barrier.dst_state.access
+                    ),
+                    dst_layout
+                );
+            }
+            return;
+        }
+
         if (!_cmd->IsQueueTransition()) {
 
             for (auto& barrier : _cmd->ReadBuffers()) {
@@ -922,19 +1032,44 @@ struct VkCmdPreprocessor {
     }
 
     void Visit(const QueueTransferCmd* _cmd) {
-        // EQueueType current_queue = this->allocator.
-        EQueueType temp_queue = this->current_queue;
-        if (_cmd->IsImport()) {
-            _cmd->dst_queue = temp_queue;
+        const EQueueType src_queue =
+            _cmd->IsImport() ? _cmd->src_queue : current_queue;
+        const EQueueType dst_queue =
+            _cmd->IsImport() ? current_queue : _cmd->dst_queue;
+        if (src_queue == EQueueType::Ignore || dst_queue == EQueueType::Ignore) {
+            throw std::invalid_argument("queue transfer requires two concrete queues");
+        }
+        const uint src_queue_family = device.GetQueueFamilyIndex(src_queue);
+        const uint dst_queue_family = device.GetQueueFamilyIndex(dst_queue);
+        const uint current_queue_family = device.GetQueueFamilyIndex(current_queue);
+        const uint expected_queue_family =
+            _cmd->IsImport() ? dst_queue_family : src_queue_family;
+        if (current_queue_family != expected_queue_family) {
+            LOG_CRITICAL(
+                "QueueTransferCmd affinity mismatch: import={} src={}({}) "
+                "dst={}({}) current={}({})",
+                _cmd->IsImport(),
+                static_cast<uint>(src_queue),
+                src_queue_family,
+                static_cast<uint>(dst_queue),
+                dst_queue_family,
+                static_cast<uint>(current_queue),
+                current_queue_family
+            );
+            throw std::logic_error(
+                "queue transfer barrier recorded by a non-endpoint queue family"
+            );
+        }
 
+        if (_cmd->IsImport()) {
             for (auto& barrier : _cmd->ImportTextures()) {
                 auto* vk_texture = ResourceCast(barrier.texture.GetTexture());
                 auto  access     = tracker.ReadTexture(vk_texture, barrier.state);
                 tracker.QueueTransferAcquireResource(
                     vk_texture,
-                    device.GetQueueFamilyIndex(_cmd->src_queue),
-                    device.GetQueueFamilyIndex(_cmd->dst_queue),
-                    vk_texture->GetQueuePreferredLayout(_cmd->src_queue),
+                    src_queue_family,
+                    dst_queue_family,
+                    vk_texture->GetQueuePreferredLayout(src_queue),
                     std::get<1>(access),
                     VK_ACCESS_2_NONE,
                     VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT
@@ -946,24 +1081,22 @@ struct VkCmdPreprocessor {
                 auto  access    = tracker.ReadBuffer(vk_buffer, barrier.state);
                 tracker.QueueTransferAcquireResource(
                     vk_buffer,
-                    device.GetQueueFamilyIndex(_cmd->src_queue),
-                    device.GetQueueFamilyIndex(_cmd->dst_queue),
+                    src_queue_family,
+                    dst_queue_family,
                     VK_ACCESS_2_NONE,
                     VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT
                 );
             }
 
         } else {
-            _cmd->src_queue = temp_queue;
-
             for (auto& barrier : _cmd->ExportTextures()) {
                 auto* vk_texture = ResourceCast(barrier.texture.GetTexture());
                 auto  access     = tracker.ReadTexture(vk_texture, barrier.state);
                 tracker.QueueTransferReleaseResource(
                     vk_texture,
-                    device.GetQueueFamilyIndex(_cmd->src_queue),
-                    device.GetQueueFamilyIndex(_cmd->dst_queue),
-                    vk_texture->GetQueuePreferredLayout(_cmd->src_queue),
+                    src_queue_family,
+                    dst_queue_family,
+                    vk_texture->GetQueuePreferredLayout(src_queue),
                     std::get<1>(access)
                 );
             }
@@ -973,8 +1106,8 @@ struct VkCmdPreprocessor {
                 auto  access    = tracker.ReadBuffer(vk_buffer, barrier.state);
                 tracker.QueueTransferReleaseResource(
                     vk_buffer,
-                    device.GetQueueFamilyIndex(_cmd->src_queue),
-                    device.GetQueueFamilyIndex(_cmd->dst_queue)
+                    src_queue_family,
+                    dst_queue_family
                 );
             }
         }
@@ -4327,7 +4460,12 @@ bool VkCommandQueue::TryExecuteParallel(
     auto tracker_owner = GetAllocator();
     auto& tracker       = tracker_owner->GetTracker();
     VkCmdPreprocessor preprocessor(
-        vk_device, tracker, *tracker_owner, _function_table, _submit.cached_args
+        vk_device,
+        tracker,
+        *tracker_owner,
+        _function_table,
+        _submit.cached_args,
+        queue.GetType()
     );
 
     Array<ParallelLayerRuntime> runtime_layers(cmd_lists.size());
@@ -4900,7 +5038,9 @@ bool VkCommandQueue::TryExecuteParallel(
         return true;
     }
 
-    tracker.RestoreState();
+    if (!_submit.HasExplicitResourceStateOwnership()) {
+        tracker.RestoreState();
+    }
     VulkanCmdList& epilogue_cmd = tracker_owner->GetCmdList();
     epilogue_cmd.SetDescriptorPushLease(descriptor_lease.state);
     const VkResult epilogue_begin = begin_primary(epilogue_cmd, active_scopes, true);
@@ -5198,7 +5338,14 @@ void VkCommandQueue::ExecuteNow(
     );
 
     //Visitor for barrier generation
-    VkCmdPreprocessor preprocessor(vk_device, tracker, vk_allocator, function_table, _submit.cached_args);
+    VkCmdPreprocessor preprocessor(
+        vk_device,
+        tracker,
+        vk_allocator,
+        function_table,
+        _submit.cached_args,
+        queue.GetType()
+    );
 
     // LOG_INFO("Reorderer time {}", timer.ElapsedMilliseconds());
     const auto& cmd_lists = reorderer.m_cmd_lists;
@@ -5518,7 +5665,9 @@ void VkCommandQueue::ExecuteNow(
     }
 
     if (has_cmd) {
-        tracker.RestoreState();
+        if (!_submit.HasExplicitResourceStateOwnership()) {
+            tracker.RestoreState();
+        }
         if (record_sample) {
             record_pending_barriers(std::numeric_limits<uint64>::max());
         }
@@ -7574,7 +7723,9 @@ VkCopyQueue::TrackedExecuteResult VkCopyQueue::ExecuteTrackedImpl(
         //     visitor.VisitCmd(cmd.get());
         // }
         //copy
-        vk_tracker.RestoreState();
+        if (!_evt.HasExplicitResourceStateOwnership()) {
+            vk_tracker.RestoreState();
+        }
         vk_tracker.DispatchBarriers(vk_cmd_list);
         vk_cmd_list.EndLabel();
         VK_CHECK_RESULT(vk_cmd_list.End());
@@ -8126,7 +8277,9 @@ void VkCopyQueue::RHIThreadLoop() {
         for (const auto& cmd : submission.cmds) {
             visitor.VisitCmd(cmd.get());
         }
-        vk_tracker.RestoreState();
+        if (!submission.HasExplicitResourceStateOwnership()) {
+            vk_tracker.RestoreState();
+        }
         vk_tracker.DispatchBarriers(vk_cmd_list);
         vk_cmd_list.EndLabel();
         VK_CHECK_RESULT(vk_cmd_list.End());

--- a/source/runtime/render/rhi/vulkan/VulkanQueue.cpp
+++ b/source/runtime/render/rhi/vulkan/VulkanQueue.cpp
@@ -810,18 +810,6 @@ struct VkCmdPreprocessor {
 
     void Visit(const BarrierCmd* _cmd) {
         if (_cmd->HasExplicitBarriers()) {
-            if (_cmd->IsQueueTransition()) {
-                LOG_CRITICAL(
-                    "Explicit BarrierCmd cannot perform queue ownership transfer "
-                    "({} -> {}); use paired ExportResourcesToQueue/"
-                    "ImportResourcesFromQueue commands",
-                    static_cast<uint>(_cmd->GetSrcQueue()),
-                    static_cast<uint>(_cmd->GetDstQueue())
-                );
-                throw std::logic_error(
-                    "cross-queue explicit barrier must use paired queue-transfer commands"
-                );
-            }
             if (_cmd->GetSrcQueue() != current_queue ||
                 _cmd->GetDstQueue() != current_queue) {
                 LOG_CRITICAL(
@@ -833,6 +821,56 @@ struct VkCmdPreprocessor {
                 throw std::logic_error("explicit barrier recorded on the wrong queue");
             }
 
+            const auto resolve_transfer =
+                [&](const BarrierQueueTransfer& transfer) {
+                    std::pair<uint32_t, uint32_t> families{
+                        VK_QUEUE_FAMILY_IGNORED,
+                        VK_QUEUE_FAMILY_IGNORED,
+                    };
+                    if (transfer.phase == EBarrierQueueTransferPhase::None) {
+                        return families;
+                    }
+                    if (transfer.phase != EBarrierQueueTransferPhase::Release &&
+                        transfer.phase != EBarrierQueueTransferPhase::Acquire) {
+                        throw std::invalid_argument(
+                            "Vulkan ownership barrier carries an unknown phase"
+                        );
+                    }
+                    if ((transfer.src_queue != EQueueType::Graphics &&
+                         transfer.src_queue != EQueueType::Compute &&
+                         transfer.src_queue != EQueueType::Copy) ||
+                        (transfer.dst_queue != EQueueType::Graphics &&
+                         transfer.dst_queue != EQueueType::Compute &&
+                         transfer.dst_queue != EQueueType::Copy) ||
+                        transfer.src_queue == transfer.dst_queue) {
+                        throw std::invalid_argument(
+                            "Vulkan ownership barrier requires distinct managed "
+                            "Graphics/Compute/Copy endpoints"
+                        );
+                    }
+                    const EQueueType expected_queue =
+                        transfer.phase == EBarrierQueueTransferPhase::Release ?
+                            transfer.src_queue :
+                            transfer.dst_queue;
+                    if (current_queue != expected_queue) {
+                        throw std::logic_error(
+                            "Vulkan ownership barrier recorded on the wrong endpoint"
+                        );
+                    }
+                    families.first =
+                        device.GetQueueFamilyIndex(transfer.src_queue);
+                    families.second =
+                        device.GetQueueFamilyIndex(transfer.dst_queue);
+                    if (families.first == VK_QUEUE_FAMILY_IGNORED ||
+                        families.second == VK_QUEUE_FAMILY_IGNORED ||
+                        families.first == families.second) {
+                        throw std::invalid_argument(
+                            "Vulkan ownership barrier requires two distinct queue families"
+                        );
+                    }
+                    return families;
+                };
+
             for (const ExplicitBufferBarrier& barrier : _cmd->ExplicitBuffers()) {
                 if (barrier.src_state.texture_layout !=
                         ETextureLayout::TEXTURE_LAYOUT_UNDEFINED ||
@@ -842,10 +880,15 @@ struct VkCmdPreprocessor {
                         "explicit buffer barrier cannot carry a texture layout"
                     );
                 }
+                const auto [src_family, dst_family] =
+                    resolve_transfer(barrier.queue_transfer);
                 tracker.EmitExplicitBarrier(
                     reinterpret_cast<VulkanBuffer*>(barrier.handle),
                     barrier.offset,
                     barrier.byte_size,
+                    barrier.queue_transfer.phase,
+                    src_family,
+                    dst_family,
                     VulkanEnumTranslator::METoVkPipelineStageFlags2(
                         barrier.src_state.stage
                     ),
@@ -876,6 +919,8 @@ struct VkCmdPreprocessor {
                         "explicit texture barrier carries an unsupported layout"
                     );
                 }
+                const auto [src_family, dst_family] =
+                    resolve_transfer(barrier.queue_transfer);
                 tracker.EmitExplicitBarrier(
                     reinterpret_cast<VulkanTexture*>(barrier.handle),
                     VulkanEnumTranslator::METoVKImageAspectFlags(
@@ -885,6 +930,9 @@ struct VkCmdPreprocessor {
                     barrier.mip_count,
                     barrier.array_layer,
                     barrier.array_count,
+                    barrier.queue_transfer.phase,
+                    src_family,
+                    dst_family,
                     VulkanEnumTranslator::METoVkPipelineStageFlags2(
                         barrier.src_state.stage
                     ),

--- a/source/runtime/render/rhi/vulkan/VulkanResourceTracker.cpp
+++ b/source/runtime/render/rhi/vulkan/VulkanResourceTracker.cpp
@@ -10,6 +10,7 @@
 #include "rhi/RHICommand.h"
 #include "rhi/RHICommon.h"
 
+#include <stdexcept>
 #include <type_traits>
 
 namespace Moer::Render {
@@ -417,6 +418,15 @@ void VkTracker::RecordState(
     uint32_t                 _src_queue_family,
     uint32_t                 _dst_queue_family
 ) {
+    if (explicit_partial_buffers.contains(_buffer)) {
+        LOG_CRITICAL(
+            "A partial-range explicit buffer barrier cannot be followed by "
+            "backend-inferred state tracking in the same submit"
+        );
+        throw std::logic_error(
+            "mixed explicit partial buffer barrier and inferred buffer state"
+        );
+    }
     MarkWriteable(_buffer, IsWriteState(_access));
     pending_buffers.insert(_buffer);
 
@@ -786,32 +796,85 @@ void VkTracker::RecordState(
     uint32_t                 _src_queue_family,
     uint32_t                 _dst_queue_family
 ) {
+    if (explicit_partial_aspect_textures.contains(_texture)) {
+        LOG_CRITICAL(
+            "A partial-aspect explicit texture barrier cannot be followed by "
+            "backend-inferred state tracking in the same submit"
+        );
+        throw std::logic_error(
+            "mixed explicit partial-aspect barrier and inferred texture state"
+        );
+    }
     uint8 resolved_mip_count =
         _mip_count == kRemainingSubresource ? uint8(_texture->GetNumMips() - _mip_level) : _mip_count;
+    uint8 resolved_array_count =
+        _array_count == kRemainingSubresource ?
+            uint8(_texture->GetNumArray() - _array_layer) :
+            _array_count;
+    bool has_explicit_texture_state = false;
+    for (const auto& explicit_range : explicit_texture_ranges) {
+        if (explicit_range.texture == _texture) {
+            has_explicit_texture_state = true;
+            break;
+        }
+    }
 
     // Decompose multi-mip ranges into per-mip entries to prevent overlapping
     // subresource ranges in barriers (Vulkan requires oldLayout to match the
     // actual current layout; overlapping ranges cause desynchronized tracking).
     // （RecordState的时候，需要把多mip的range分解为单mip的range，否则会把0~5和0~1+2~5识别成完全不同的资源）
-    if (resolved_mip_count > 1) {
+    // Explicit RDG ranges may legally change array shape between passes (for
+    // example layers 0+4 followed by 1+2). Once a texture enters the explicit
+    // state domain, use atomic mip/layer tracker keys without widening the
+    // native barriers or changing legacy-only submits.
+    if (resolved_mip_count > 1 ||
+        (has_explicit_texture_state && resolved_array_count > 1)) {
         for (uint8_t i = 0; i < resolved_mip_count; ++i) {
-            RecordState(
-                _texture,
-                _access,
-                _layout,
-                _stage,
-                _mip_level + i,
-                1,
-                _array_layer,
-                _array_count,
-                _src_queue_family,
-                _dst_queue_family
-            );
+            const uint8 layer_count =
+                has_explicit_texture_state ? resolved_array_count : 1;
+            for (uint8 layer = 0; layer < layer_count; ++layer) {
+                RecordState(
+                    _texture,
+                    _access,
+                    _layout,
+                    _stage,
+                    _mip_level + i,
+                    1,
+                    has_explicit_texture_state ?
+                        static_cast<uint8>(_array_layer + layer) :
+                        _array_layer,
+                    has_explicit_texture_state ? 1 : resolved_array_count,
+                    _src_queue_family,
+                    _dst_queue_family
+                );
+            }
         }
         return;
     }
 
     auto         key = MakeTextureStateKey(_texture, _mip_level, 1, _array_layer, _array_count);
+    for (const auto& explicit_range : explicit_texture_ranges) {
+        if (!TextureSubresourceRangesOverlap(explicit_range, key) ||
+            explicit_range == key) {
+            continue;
+        }
+        LOG_CRITICAL(
+            "An explicit texture range cannot be followed by an overlapping "
+            "backend-inferred range with a different shape: explicit "
+            "mip={}+{} layer={}+{}, inferred mip={}+{} layer={}+{}",
+            explicit_range.mip_level,
+            explicit_range.mip_count,
+            explicit_range.array_layer,
+            explicit_range.array_count,
+            key.mip_level,
+            key.mip_count,
+            key.array_layer,
+            key.array_count
+        );
+        throw std::logic_error(
+            "mixed explicit and inferred texture ranges have incompatible shapes"
+        );
+    }
     TextureState state{
         VK_ACCESS_2_NONE,
         VK_IMAGE_LAYOUT_UNDEFINED,
@@ -861,6 +924,162 @@ void VkTracker::RecordState(
             is_write = is_write || it->second.src_layout != it->second.dst_layout;
     }
     MarkWriteable(key, is_write);
+}
+
+void VkTracker::EmitExplicitBarrier(
+    VulkanBuffer*         _buffer,
+    uint64                _offset,
+    uint64                _byte_size,
+    VkPipelineStageFlags2 _src_stage,
+    VkAccessFlags2        _src_access,
+    VkPipelineStageFlags2 _dst_stage,
+    VkAccessFlags2        _dst_access
+) {
+    if (_buffer == nullptr || _byte_size == 0 ||
+        _offset > _buffer->GetByteSize() ||
+        _byte_size > _buffer->GetByteSize() - _offset) {
+        LOG_CRITICAL(
+            "Invalid explicit buffer barrier range: offset={} size={}",
+            _offset,
+            _byte_size
+        );
+        throw std::out_of_range("invalid explicit buffer barrier range");
+    }
+
+    buffer_barriers.emplace_back(VkBufferMemoryBarrier2{
+        .sType               = VK_STRUCTURE_TYPE_BUFFER_MEMORY_BARRIER_2,
+        .pNext               = nullptr,
+        .srcStageMask        = _src_stage,
+        .srcAccessMask       = _src_access,
+        .dstStageMask        = _dst_stage,
+        .dstAccessMask       = _dst_access,
+        .srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED,
+        .dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED,
+        .buffer              = _buffer->GetHandle(),
+        .offset              = _offset,
+        .size                = _byte_size,
+    });
+
+    if (_offset == 0 && _byte_size == _buffer->GetByteSize()) {
+        buffer_states[_buffer] = BufferState{
+            .src_access      = static_cast<VkAccessFlagBits2>(_dst_access),
+            .src_stage       = static_cast<VkPipelineStageFlagBits2>(_dst_stage),
+            .dst_access      = VK_ACCESS_2_NONE,
+            .dst_stage       = VK_PIPELINE_STAGE_2_NONE,
+            .src_queue_family = VK_QUEUE_FAMILY_IGNORED,
+            .dst_queue_family = VK_QUEUE_FAMILY_IGNORED,
+        };
+        MarkWriteable(_buffer, IsWriteState(_dst_access));
+    } else {
+        explicit_partial_buffers.insert(_buffer);
+    }
+}
+
+void VkTracker::EmitExplicitBarrier(
+    VulkanTexture*        _texture,
+    VkImageAspectFlags    _aspects,
+    uint8                 _mip_level,
+    uint8                 _mip_count,
+    uint8                 _array_layer,
+    uint8                 _array_count,
+    VkPipelineStageFlags2 _src_stage,
+    VkAccessFlags2        _src_access,
+    VkImageLayout         _src_layout,
+    VkPipelineStageFlags2 _dst_stage,
+    VkAccessFlags2        _dst_access,
+    VkImageLayout         _dst_layout
+) {
+    if (_texture == nullptr) {
+        throw std::invalid_argument("explicit texture barrier requires a texture");
+    }
+    ValidateSubresourceRange(
+        _texture, _mip_level, _mip_count, _array_layer, _array_count
+    );
+    const VkImageAspectFlags available_aspects =
+        VulkanEnumTranslator::METoVKImageAspectFlags(_texture->GetAspectFlags());
+    if (_aspects == 0 || (_aspects & ~available_aspects) != 0) {
+        LOG_CRITICAL(
+            "Invalid explicit texture aspect mask: requested={:#x} available={:#x}",
+            static_cast<uint32>(_aspects),
+            static_cast<uint32>(available_aspects)
+        );
+        throw std::invalid_argument("explicit texture barrier aspect is unavailable");
+    }
+
+    const uint8 resolved_mip_count =
+        _mip_count == kRemainingSubresource ?
+            uint8(_texture->GetNumMips() - _mip_level) :
+            _mip_count;
+    const uint8 resolved_array_count =
+        _array_count == kRemainingSubresource ?
+            uint8(_texture->GetNumArray() - _array_layer) :
+            _array_count;
+
+    texture_barriers.emplace_back(VkImageMemoryBarrier2{
+        .sType               = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER_2,
+        .pNext               = nullptr,
+        .srcStageMask        = _src_stage,
+        .srcAccessMask       = _src_access,
+        .dstStageMask        = _dst_stage,
+        .dstAccessMask       = _dst_access,
+        .oldLayout           = _src_layout,
+        .newLayout           = _dst_layout,
+        .srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED,
+        .dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED,
+        .image               = _texture->GetHandle(),
+        .subresourceRange =
+            VkImageSubresourceRange{
+                .aspectMask     = _aspects,
+                .baseMipLevel   = _mip_level,
+                .levelCount     = resolved_mip_count,
+                .baseArrayLayer = _array_layer,
+                .layerCount     = resolved_array_count,
+            },
+    });
+
+    if (_aspects != available_aspects) {
+        // The native barrier above remains exact. The legacy inferred tracker
+        // cannot represent aspect-split state, so reject any later inferred
+        // access instead of silently widening it.
+        explicit_partial_aspect_textures.insert(_texture);
+        return;
+    }
+
+    for (uint8 mip = 0; mip < resolved_mip_count; ++mip) {
+        for (uint8 layer = 0; layer < resolved_array_count; ++layer) {
+            const TextureSubresourceKeyT<VulkanTexture> key = MakeTextureStateKey(
+                _texture,
+                static_cast<uint8>(_mip_level + mip),
+                1,
+                static_cast<uint8>(_array_layer + layer),
+                1
+            );
+            texture_states[key] = TextureState{
+                .src_access       = static_cast<VkAccessFlagBits2>(_dst_access),
+                .src_layout       = _dst_layout,
+                .src_stage        = static_cast<VkPipelineStageFlagBits2>(_dst_stage),
+                .dst_access       = VK_ACCESS_2_NONE,
+                .dst_layout       = VK_IMAGE_LAYOUT_UNDEFINED,
+                .dst_stage        = VK_PIPELINE_STAGE_2_NONE,
+                .src_queue_family = VK_QUEUE_FAMILY_IGNORED,
+                .dst_queue_family = VK_QUEUE_FAMILY_IGNORED,
+            };
+            explicit_texture_ranges.insert(key);
+            MarkWriteable(key, IsWriteState(_dst_layout, _dst_access));
+        }
+    }
+    if (IsWriteState(_dst_layout, _dst_access)) {
+        // Keep the declared aggregate view as a conservative bindless lookup
+        // key while the authoritative state table remains mip/layer atomic.
+        // HandleBindless performs overlap-based current-write exclusion.
+        writed_state_textures.insert(MakeTextureStateKey(
+            _texture,
+            _mip_level,
+            resolved_mip_count,
+            _array_layer,
+            resolved_array_count
+        ));
+    }
 }
 
 void VkTracker::ResolveBarriers() {
@@ -1222,6 +1441,12 @@ void VkTracker::Reset() {
     writed_state_buffers.clear();
     write_blas_states.clear();
     flush_buffer_states.clear();
+    flush_buffer_ranges.clear();
+    pending_buffers.clear();
+    pending_textures.clear();
+    explicit_partial_buffers.clear();
+    explicit_partial_aspect_textures.clear();
+    explicit_texture_ranges.clear();
     exported_buffers.clear();
     exported_textures.clear();
 }

--- a/source/runtime/render/rhi/vulkan/VulkanResourceTracker.cpp
+++ b/source/runtime/render/rhi/vulkan/VulkanResourceTracker.cpp
@@ -418,6 +418,14 @@ void VkTracker::RecordState(
     uint32_t                 _src_queue_family,
     uint32_t                 _dst_queue_family
 ) {
+    for (const auto& released_range : explicit_released_buffer_ranges) {
+        if (released_range.buffer == _buffer) {
+            throw std::logic_error(
+                "a queue-release buffer barrier must be the final overlapping "
+                "access in its submit"
+            );
+        }
+    }
     if (explicit_partial_buffers.contains(_buffer)) {
         LOG_CRITICAL(
             "A partial-range explicit buffer barrier cannot be followed by "
@@ -811,6 +819,30 @@ void VkTracker::RecordState(
         _array_count == kRemainingSubresource ?
             uint8(_texture->GetNumArray() - _array_layer) :
             _array_count;
+    const TextureAspectSubresourceRangeT<VulkanTexture> requested_range{
+        .subresource = MakeTextureStateKey(
+            _texture,
+            _mip_level,
+            resolved_mip_count,
+            _array_layer,
+            resolved_array_count
+        ),
+        .aspects = VulkanEnumTranslator::METoVKImageAspectFlags(
+            _texture->GetAspectFlags()
+        ),
+    };
+    for (const auto& released_range :
+         explicit_released_texture_ranges) {
+        if (TextureAspectSubresourceRangesOverlap(
+                released_range,
+                requested_range
+            )) {
+            throw std::logic_error(
+                "a queue-release texture barrier must be the final overlapping "
+                "access in its submit"
+            );
+        }
+    }
     bool has_explicit_texture_state = false;
     for (const auto& explicit_range : explicit_texture_ranges) {
         if (explicit_range.texture == _texture) {
@@ -930,6 +962,9 @@ void VkTracker::EmitExplicitBarrier(
     VulkanBuffer*         _buffer,
     uint64                _offset,
     uint64                _byte_size,
+    EBarrierQueueTransferPhase _phase,
+    uint32_t              _src_queue_family,
+    uint32_t              _dst_queue_family,
     VkPipelineStageFlags2 _src_stage,
     VkAccessFlags2        _src_access,
     VkPipelineStageFlags2 _dst_stage,
@@ -945,20 +980,75 @@ void VkTracker::EmitExplicitBarrier(
         );
         throw std::out_of_range("invalid explicit buffer barrier range");
     }
+    const BufferByteRangeT<VulkanBuffer> transfer_range{
+        .buffer    = _buffer,
+        .offset    = _offset,
+        .byte_size = _byte_size,
+    };
+    for (const auto& released_range : explicit_released_buffer_ranges) {
+        if (BufferByteRangesOverlap(released_range, transfer_range)) {
+            throw std::logic_error(
+                "a queue-release buffer barrier must be the final overlapping "
+                "access in its submit"
+            );
+        }
+    }
+    if (_phase != EBarrierQueueTransferPhase::None &&
+        _phase != EBarrierQueueTransferPhase::Release &&
+        _phase != EBarrierQueueTransferPhase::Acquire) {
+        throw std::invalid_argument(
+            "explicit buffer barrier carries an unknown transfer phase"
+        );
+    }
+    const bool ownership =
+        _phase != EBarrierQueueTransferPhase::None;
+    if ((ownership &&
+         (_src_queue_family == VK_QUEUE_FAMILY_IGNORED ||
+          _dst_queue_family == VK_QUEUE_FAMILY_IGNORED ||
+          _src_queue_family == _dst_queue_family)) ||
+        (!ownership &&
+         (_src_queue_family != VK_QUEUE_FAMILY_IGNORED ||
+          _dst_queue_family != VK_QUEUE_FAMILY_IGNORED))) {
+        throw std::invalid_argument(
+            "explicit buffer barrier carries an invalid queue-family pair"
+        );
+    }
+
+    const VkPipelineStageFlags2 native_src_stage =
+        _phase == EBarrierQueueTransferPhase::Acquire ?
+            VK_PIPELINE_STAGE_2_NONE :
+            _src_stage;
+    const VkAccessFlags2 native_src_access =
+        _phase == EBarrierQueueTransferPhase::Acquire ?
+            VK_ACCESS_2_NONE :
+            _src_access;
+    const VkPipelineStageFlags2 native_dst_stage =
+        _phase == EBarrierQueueTransferPhase::Release ?
+            VK_PIPELINE_STAGE_2_NONE :
+            _dst_stage;
+    const VkAccessFlags2 native_dst_access =
+        _phase == EBarrierQueueTransferPhase::Release ?
+            VK_ACCESS_2_NONE :
+            _dst_access;
 
     buffer_barriers.emplace_back(VkBufferMemoryBarrier2{
         .sType               = VK_STRUCTURE_TYPE_BUFFER_MEMORY_BARRIER_2,
         .pNext               = nullptr,
-        .srcStageMask        = _src_stage,
-        .srcAccessMask       = _src_access,
-        .dstStageMask        = _dst_stage,
-        .dstAccessMask       = _dst_access,
-        .srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED,
-        .dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED,
+        .srcStageMask        = native_src_stage,
+        .srcAccessMask       = native_src_access,
+        .dstStageMask        = native_dst_stage,
+        .dstAccessMask       = native_dst_access,
+        .srcQueueFamilyIndex = _src_queue_family,
+        .dstQueueFamilyIndex = _dst_queue_family,
         .buffer              = _buffer->GetHandle(),
         .offset              = _offset,
         .size                = _byte_size,
     });
+
+    if (_phase == EBarrierQueueTransferPhase::Release) {
+        explicit_released_buffer_ranges.emplace_back(transfer_range);
+        return;
+    }
 
     if (_offset == 0 && _byte_size == _buffer->GetByteSize()) {
         buffer_states[_buffer] = BufferState{
@@ -982,6 +1072,9 @@ void VkTracker::EmitExplicitBarrier(
     uint8                 _mip_count,
     uint8                 _array_layer,
     uint8                 _array_count,
+    EBarrierQueueTransferPhase _phase,
+    uint32_t              _src_queue_family,
+    uint32_t              _dst_queue_family,
     VkPipelineStageFlags2 _src_stage,
     VkAccessFlags2        _src_access,
     VkImageLayout         _src_layout,
@@ -1005,6 +1098,26 @@ void VkTracker::EmitExplicitBarrier(
         );
         throw std::invalid_argument("explicit texture barrier aspect is unavailable");
     }
+    if (_phase != EBarrierQueueTransferPhase::None &&
+        _phase != EBarrierQueueTransferPhase::Release &&
+        _phase != EBarrierQueueTransferPhase::Acquire) {
+        throw std::invalid_argument(
+            "explicit texture barrier carries an unknown transfer phase"
+        );
+    }
+    const bool ownership =
+        _phase != EBarrierQueueTransferPhase::None;
+    if ((ownership &&
+         (_src_queue_family == VK_QUEUE_FAMILY_IGNORED ||
+          _dst_queue_family == VK_QUEUE_FAMILY_IGNORED ||
+          _src_queue_family == _dst_queue_family)) ||
+        (!ownership &&
+         (_src_queue_family != VK_QUEUE_FAMILY_IGNORED ||
+          _dst_queue_family != VK_QUEUE_FAMILY_IGNORED))) {
+        throw std::invalid_argument(
+            "explicit texture barrier carries an invalid queue-family pair"
+        );
+    }
 
     const uint8 resolved_mip_count =
         _mip_count == kRemainingSubresource ?
@@ -1014,18 +1127,56 @@ void VkTracker::EmitExplicitBarrier(
         _array_count == kRemainingSubresource ?
             uint8(_texture->GetNumArray() - _array_layer) :
             _array_count;
+    const TextureAspectSubresourceRangeT<VulkanTexture> transfer_range{
+        .subresource = MakeTextureStateKey(
+            _texture,
+            _mip_level,
+            resolved_mip_count,
+            _array_layer,
+            resolved_array_count
+        ),
+        .aspects = _aspects,
+    };
+    for (const auto& released_range :
+         explicit_released_texture_ranges) {
+        if (TextureAspectSubresourceRangesOverlap(
+                released_range,
+                transfer_range
+            )) {
+            throw std::logic_error(
+                "a queue-release texture barrier must be the final overlapping "
+                "access in its submit"
+            );
+        }
+    }
+    const VkPipelineStageFlags2 native_src_stage =
+        _phase == EBarrierQueueTransferPhase::Acquire ?
+            VK_PIPELINE_STAGE_2_NONE :
+            _src_stage;
+    const VkAccessFlags2 native_src_access =
+        _phase == EBarrierQueueTransferPhase::Acquire ?
+            VK_ACCESS_2_NONE :
+            _src_access;
+    const VkPipelineStageFlags2 native_dst_stage =
+        _phase == EBarrierQueueTransferPhase::Release ?
+            VK_PIPELINE_STAGE_2_NONE :
+            _dst_stage;
+    const VkAccessFlags2 native_dst_access =
+        _phase == EBarrierQueueTransferPhase::Release ?
+            VK_ACCESS_2_NONE :
+            _dst_access;
 
     texture_barriers.emplace_back(VkImageMemoryBarrier2{
         .sType               = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER_2,
         .pNext               = nullptr,
-        .srcStageMask        = _src_stage,
-        .srcAccessMask       = _src_access,
-        .dstStageMask        = _dst_stage,
-        .dstAccessMask       = _dst_access,
+        .srcStageMask        = native_src_stage,
+        .srcAccessMask       = native_src_access,
+        .dstStageMask        = native_dst_stage,
+        .dstAccessMask       = native_dst_access,
         .oldLayout           = _src_layout,
         .newLayout           = _dst_layout,
-        .srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED,
-        .dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED,
+        .srcQueueFamilyIndex = _src_queue_family,
+        .dstQueueFamilyIndex = _dst_queue_family,
         .image               = _texture->GetHandle(),
         .subresourceRange =
             VkImageSubresourceRange{
@@ -1036,6 +1187,11 @@ void VkTracker::EmitExplicitBarrier(
                 .layerCount     = resolved_array_count,
             },
     });
+
+    if (_phase == EBarrierQueueTransferPhase::Release) {
+        explicit_released_texture_ranges.emplace_back(transfer_range);
+        return;
+    }
 
     if (_aspects != available_aspects) {
         // The native barrier above remains exact. The legacy inferred tracker
@@ -1446,6 +1602,8 @@ void VkTracker::Reset() {
     pending_textures.clear();
     explicit_partial_buffers.clear();
     explicit_partial_aspect_textures.clear();
+    explicit_released_buffer_ranges.clear();
+    explicit_released_texture_ranges.clear();
     explicit_texture_ranges.clear();
     exported_buffers.clear();
     exported_textures.clear();

--- a/source/runtime/render/rhi/vulkan/VulkanResourceTracker.h
+++ b/source/runtime/render/rhi/vulkan/VulkanResourceTracker.h
@@ -49,6 +49,41 @@ template<typename TTexture>
            );
 }
 
+template<typename TBuffer>
+struct BufferByteRangeT {
+    TBuffer* buffer{nullptr};
+    uint64   offset{0};
+    uint64   byte_size{0};
+};
+
+template<typename TBuffer>
+[[nodiscard]] constexpr bool BufferByteRangesOverlap(
+    const BufferByteRangeT<TBuffer>& lhs,
+    const BufferByteRangeT<TBuffer>& rhs
+) {
+    if (lhs.buffer != rhs.buffer || lhs.byte_size == 0 || rhs.byte_size == 0) {
+        return false;
+    }
+    return lhs.offset <= rhs.offset ?
+               lhs.byte_size > rhs.offset - lhs.offset :
+               rhs.byte_size > lhs.offset - rhs.offset;
+}
+
+template<typename TTexture>
+struct TextureAspectSubresourceRangeT {
+    TextureSubresourceKeyT<TTexture> subresource{};
+    VkImageAspectFlags               aspects{0};
+};
+
+template<typename TTexture>
+[[nodiscard]] constexpr bool TextureAspectSubresourceRangesOverlap(
+    const TextureAspectSubresourceRangeT<TTexture>& lhs,
+    const TextureAspectSubresourceRangeT<TTexture>& rhs
+) {
+    return (lhs.aspects & rhs.aspects) != 0 &&
+           TextureSubresourceRangesOverlap(lhs.subresource, rhs.subresource);
+}
+
 class VkTracker {
 private:
     struct BufferRange {
@@ -179,13 +214,17 @@ public:
         uint32_t _dst_queue_family = VK_QUEUE_FAMILY_IGNORED
     );
 
-    // Graph-owned barriers bypass state inference. Both sides of the native
-    // dependency are emitted verbatim, then the local tracker adopts dst so a
-    // following legacy-inferred read observes the already-materialized state.
+    // Graph-owned barriers bypass state inference. Local and acquire barriers
+    // adopt dst so a following inferred access observes the materialized
+    // state. A release only emits its native half: destination state belongs
+    // exclusively to the acquire-side tracker.
     void EmitExplicitBarrier(
         VulkanBuffer*         _buffer,
         uint64                _offset,
         uint64                _byte_size,
+        EBarrierQueueTransferPhase _phase,
+        uint32_t              _src_queue_family,
+        uint32_t              _dst_queue_family,
         VkPipelineStageFlags2 _src_stage,
         VkAccessFlags2        _src_access,
         VkPipelineStageFlags2 _dst_stage,
@@ -198,6 +237,9 @@ public:
         uint8                 _mip_count,
         uint8                 _array_layer,
         uint8                 _array_count,
+        EBarrierQueueTransferPhase _phase,
+        uint32_t              _src_queue_family,
+        uint32_t              _dst_queue_family,
         VkPipelineStageFlags2 _src_stage,
         VkAccessFlags2        _src_access,
         VkImageLayout         _src_layout,
@@ -290,6 +332,9 @@ private:
     UnorderedMap<VulkanBuffer*, BufferRange> flush_buffer_ranges;
     Set<VulkanBuffer*>                       explicit_partial_buffers;
     Set<VulkanTexture*>                      explicit_partial_aspect_textures;
+    Array<BufferByteRangeT<VulkanBuffer>> explicit_released_buffer_ranges;
+    Array<TextureAspectSubresourceRangeT<VulkanTexture>>
+        explicit_released_texture_ranges;
     // Explicit texture state is tracked at atomic mip/layer granularity.
     // Inferred accesses to a texture in this set are decomposed the same way,
     // so legal RDG range-shape changes cannot restart from preferred state.

--- a/source/runtime/render/rhi/vulkan/VulkanResourceTracker.h
+++ b/source/runtime/render/rhi/vulkan/VulkanResourceTracker.h
@@ -17,6 +17,38 @@ struct BarrierSemanticDiagnostics {
     uint32 texture_count{0};
     uint32 memory_count{0};
 };
+
+template<typename TTexture>
+[[nodiscard]] constexpr bool TextureSubresourceRangesOverlap(
+    const TextureSubresourceKeyT<TTexture>& lhs,
+    const TextureSubresourceKeyT<TTexture>& rhs
+) {
+    const auto overlaps = [](uint8 first_a,
+                             uint8 count_a,
+                             uint8 first_b,
+                             uint8 count_b) {
+        const uint16 end_a =
+            static_cast<uint16>(first_a) + static_cast<uint16>(count_a);
+        const uint16 end_b =
+            static_cast<uint16>(first_b) + static_cast<uint16>(count_b);
+        return static_cast<uint16>(first_a) < end_b &&
+               static_cast<uint16>(first_b) < end_a;
+    };
+    return lhs.texture == rhs.texture &&
+           overlaps(
+               lhs.mip_level,
+               lhs.mip_count,
+               rhs.mip_level,
+               rhs.mip_count
+           ) &&
+           overlaps(
+               lhs.array_layer,
+               lhs.array_count,
+               rhs.array_layer,
+               rhs.array_count
+           );
+}
+
 class VkTracker {
 private:
     struct BufferRange {
@@ -147,6 +179,33 @@ public:
         uint32_t _dst_queue_family = VK_QUEUE_FAMILY_IGNORED
     );
 
+    // Graph-owned barriers bypass state inference. Both sides of the native
+    // dependency are emitted verbatim, then the local tracker adopts dst so a
+    // following legacy-inferred read observes the already-materialized state.
+    void EmitExplicitBarrier(
+        VulkanBuffer*         _buffer,
+        uint64                _offset,
+        uint64                _byte_size,
+        VkPipelineStageFlags2 _src_stage,
+        VkAccessFlags2        _src_access,
+        VkPipelineStageFlags2 _dst_stage,
+        VkAccessFlags2        _dst_access
+    );
+    void EmitExplicitBarrier(
+        VulkanTexture*        _texture,
+        VkImageAspectFlags    _aspects,
+        uint8                 _mip_level,
+        uint8                 _mip_count,
+        uint8                 _array_layer,
+        uint8                 _array_count,
+        VkPipelineStageFlags2 _src_stage,
+        VkAccessFlags2        _src_access,
+        VkImageLayout         _src_layout,
+        VkPipelineStageFlags2 _dst_stage,
+        VkAccessFlags2        _dst_access,
+        VkImageLayout         _dst_layout
+    );
+
     void SetPassType(EPassType _type) {
         pass_type = _type;
     }
@@ -229,6 +288,15 @@ private:
 
     UnorderedMap<VulkanBuffer*, BufferState> flush_buffer_states;
     UnorderedMap<VulkanBuffer*, BufferRange> flush_buffer_ranges;
+    Set<VulkanBuffer*>                       explicit_partial_buffers;
+    Set<VulkanTexture*>                      explicit_partial_aspect_textures;
+    // Explicit texture state is tracked at atomic mip/layer granularity.
+    // Inferred accesses to a texture in this set are decomposed the same way,
+    // so legal RDG range-shape changes cannot restart from preferred state.
+    UnorderedSet<
+        TextureSubresourceKeyT<VulkanTexture>,
+        TextureSubresourceKeyHashT<VulkanTexture>>
+        explicit_texture_ranges;
 };
 } // namespace Moer::Render
 #endif

--- a/source/runtime/render/rhi/vulkan/VulkanSerialGolden.cpp
+++ b/source/runtime/render/rhi/vulkan/VulkanSerialGolden.cpp
@@ -567,6 +567,7 @@ struct VulkanSerialGoldenTrace::Impl {
             case Command::EType::Barrier: {
                 const auto& command = *static_cast<const BarrierCmd*>(_command);
                 hash.Add(command.IsQueueTransition() ? 1u : 0u);
+                hash.Add(command.HasExplicitBarriers() ? 1u : 0u);
                 hash.Add(static_cast<uint64_t>(command.GetSrcQueue()));
                 hash.Add(static_cast<uint64_t>(command.GetDstQueue()));
                 auto hash_texture_barriers = [&](const auto& barriers) {
@@ -595,6 +596,53 @@ struct VulkanSerialGoldenTrace::Impl {
                 hash_texture_barriers(command.WriteTextures());
                 hash_buffer_barriers(command.ReadBuffers());
                 hash_buffer_barriers(command.WriteBuffers());
+                hash.Add(command.ExplicitTextures().size());
+                for (const ExplicitTextureBarrier& barrier :
+                     command.ExplicitTextures()) {
+                    resources.push_back(
+                        RegisterTexture(
+                            reinterpret_cast<Texture*>(
+                                uintptr_t(barrier.handle)
+                            )
+                        )
+                    );
+                    hash.Add(static_cast<uint64_t>(barrier.src_state.stage));
+                    hash.Add(static_cast<uint64_t>(barrier.src_state.access));
+                    hash.Add(
+                        static_cast<uint64_t>(
+                            barrier.src_state.texture_layout
+                        )
+                    );
+                    hash.Add(static_cast<uint64_t>(barrier.dst_state.stage));
+                    hash.Add(static_cast<uint64_t>(barrier.dst_state.access));
+                    hash.Add(
+                        static_cast<uint64_t>(
+                            barrier.dst_state.texture_layout
+                        )
+                    );
+                    hash.Add(static_cast<uint64_t>(barrier.texture_aspects));
+                    hash.Add(barrier.mip_level);
+                    hash.Add(barrier.mip_count);
+                    hash.Add(barrier.array_layer);
+                    hash.Add(barrier.array_count);
+                }
+                hash.Add(command.ExplicitBuffers().size());
+                for (const ExplicitBufferBarrier& barrier :
+                     command.ExplicitBuffers()) {
+                    resources.push_back(
+                        RegisterBuffer(
+                            reinterpret_cast<Buffer*>(
+                                uintptr_t(barrier.handle)
+                            )
+                        )
+                    );
+                    hash.Add(static_cast<uint64_t>(barrier.src_state.stage));
+                    hash.Add(static_cast<uint64_t>(barrier.src_state.access));
+                    hash.Add(static_cast<uint64_t>(barrier.dst_state.stage));
+                    hash.Add(static_cast<uint64_t>(barrier.dst_state.access));
+                    hash.Add(barrier.offset);
+                    hash.Add(barrier.byte_size);
+                }
                 break;
             }
             case Command::EType::QueueTransfer: {

--- a/source/runtime/render/rhi/vulkan/VulkanSubmissionExecutor.cpp
+++ b/source/runtime/render/rhi/vulkan/VulkanSubmissionExecutor.cpp
@@ -42,6 +42,7 @@ bool IsCopyCommand(Command::EType _type) {
         case Command::EType::UploadTexture:
         case Command::EType::TextureToTexture:
         case Command::EType::CopyBackTexture:
+        case Command::EType::Barrier:
         case Command::EType::QueueTransfer:
             return true;
         default:

--- a/source/runtime/render/rhi/vulkan/VulkanSubmissionExecutor.cpp
+++ b/source/runtime/render/rhi/vulkan/VulkanSubmissionExecutor.cpp
@@ -725,6 +725,62 @@ void VulkanSubmissionExecutor::ProcessBatch(
             _exception_state.first_unconsumed_source = _batch.submits.size();
         };
 
+    const RHIQueueTopology queue_topology =
+        RenderDevice::Get().GetQueueTopology();
+    auto same_native_queue = [&](EQueueType lhs, EQueueType rhs) {
+        return queue_topology.Resolve(lhs).native_queue_id ==
+               queue_topology.Resolve(rhs).native_queue_id;
+    };
+    auto append_unique_wait = [](CmdSubmit& submit, WaitEvent event) {
+        const bool exists = std::any_of(
+            submit.wait_events.begin(),
+            submit.wait_events.end(),
+            [&](const WaitEvent& candidate) {
+                return candidate.timeline_handle == event.timeline_handle &&
+                       candidate.value == event.value;
+            }
+        );
+        if (!exists) {
+            submit.wait_events.emplace_back(event);
+        }
+    };
+    auto append_frontier_waits =
+        [&](CmdSubmit& submit,
+            EQueueType target_queue,
+            const auto& frontier) {
+            for (size_t index = 0; index < frontier.size(); ++index) {
+                if (!frontier[index].has_value()) {
+                    continue;
+                }
+                const auto source_queue = static_cast<EQueueType>(index);
+                if (same_native_queue(source_queue, target_queue)) {
+                    continue;
+                }
+                append_unique_wait(submit, *frontier[index]);
+            }
+        };
+    auto mark_scope_queue_seen = [&](EQueueType queue) {
+        for (size_t index = 0; index < async_scope_seen_queues.size();
+             ++index) {
+            if (same_native_queue(static_cast<EQueueType>(index), queue)) {
+                async_scope_seen_queues[index] = true;
+            }
+        }
+    };
+    auto update_frontier =
+        [&](EQueueType queue, WaitEvent completion, bool collapse) {
+            if (collapse) {
+                gpu_frontier.fill(std::nullopt);
+            } else {
+                for (size_t index = 0; index < gpu_frontier.size(); ++index) {
+                    if (same_native_queue(static_cast<EQueueType>(index), queue)) {
+                        gpu_frontier[index].reset();
+                    }
+                }
+            }
+            gpu_frontier[static_cast<size_t>(queue)] = completion;
+        };
+
     // Keep every source in the request-owned batch until its queue call has
     // returned. If reorder, descriptor-lease, allocator, or native recording
     // setup throws, Run's request barrier can still terminalize the current
@@ -748,12 +804,38 @@ void VulkanSubmissionExecutor::ProcessBatch(
             .end   = entry.submit.cmds.size(),
         }};
 
-        if (ordered_tail_queue.has_value() && *ordered_tail_queue != entry.queue &&
-            ordered_gpu_tail.has_value()) {
-            // Native queue submit order only applies within one queue. Chain
-            // adjacent cross-queue source submissions through their timeline
-            // semaphores so the stable topology order is also a GPU order.
-            entry.submit.wait_events.emplace_back(*ordered_gpu_tail);
+        const uint64 async_scope = entry.submit.async_queue_scope;
+        if (async_scope == 0) {
+            // Legacy/direct submits retain a conservative total GPU order.
+            active_async_queue_scope = 0;
+            async_scope_entry_frontier.fill(std::nullopt);
+            async_scope_seen_queues.fill(false);
+            append_frontier_waits(entry.submit, entry.queue, gpu_frontier);
+        } else {
+            if (active_async_queue_scope != async_scope) {
+                // A new graph transaction begins after the complete prior
+                // frontier. Each native queue waits that frozen entry
+                // frontier once, while explicit RDG waits order work inside
+                // the scope.
+                active_async_queue_scope    = async_scope;
+                async_scope_entry_frontier  = gpu_frontier;
+                async_scope_seen_queues.fill(false);
+                if (!logged_async_queue_scope) {
+                    LOG_INFO(
+                        "[RHIExecutor][Vulkan][AsyncQueueScope] "
+                        "mode=dependency-led native_submit_owner=serial "
+                        "legacy_boundary=frontier"
+                    );
+                    logged_async_queue_scope = true;
+                }
+            }
+            const size_t queue_index = static_cast<size_t>(entry.queue);
+            if (!async_scope_seen_queues[queue_index]) {
+                append_frontier_waits(
+                    entry.submit, entry.queue, async_scope_entry_frontier
+                );
+                mark_scope_queue_seen(entry.queue);
+            }
         }
         if (entry.queue == EQueueType::Copy) {
             auto& copy_queue = static_cast<VkCopyQueue&>(RenderDevice::Get().GetCopyQueue());
@@ -771,8 +853,11 @@ void VulkanSubmissionExecutor::ProcessBatch(
                 last_copy_timeline = std::max(
                     last_copy_timeline, submit_result.completion->value
                 );
-                ordered_gpu_tail   = *submit_result.completion;
-                ordered_tail_queue = EQueueType::Copy;
+                update_frontier(
+                    EQueueType::Copy,
+                    *submit_result.completion,
+                    async_scope == 0
+                );
                 used_queues[static_cast<size_t>(EQueueType::Copy)] = true;
             } else if (submit_result.IsRecoverableRejection()) {
                 // A failed prerequisite did not reach vkQueueSubmit. Drain the
@@ -854,8 +939,11 @@ void VulkanSubmissionExecutor::ProcessBatch(
             _exception_state.first_unconsumed_source = source_index + 1;
             if (submit_result.WasSubmitted()) {
                 assert(submit_result.completion.has_value());
-                ordered_gpu_tail   = *submit_result.completion;
-                ordered_tail_queue = entry.queue;
+                update_frontier(
+                    entry.queue,
+                    *submit_result.completion,
+                    async_scope == 0
+                );
                 used_queues[static_cast<size_t>(entry.queue)] = true;
             } else if (submit_result.IsRecoverableRejection()) {
                 reject_remaining_recoverable(
@@ -884,15 +972,16 @@ void VulkanSubmissionExecutor::ProcessBatch(
     }
 
     if (_batch.present) {
+        active_async_queue_scope = 0;
+        async_scope_entry_frontier.fill(std::nullopt);
+        async_scope_seen_queues.fill(false);
         RHIPresentRequest& present = *_batch.present;
         auto& graphics_queue = static_cast<VkCommandQueue&>(
             RenderDevice::Get().GetCommandQueue(EQueueType::Graphics)
         );
-        if (ordered_tail_queue.has_value() &&
-            *ordered_tail_queue != EQueueType::Graphics && ordered_gpu_tail.has_value()) {
-            CommandList bridge_commands(EQueueType::Graphics);
-            CmdSubmit   bridge = bridge_commands.Submit();
-            bridge.wait_events.emplace_back(*ordered_gpu_tail);
+        CmdSubmit bridge = CommandList(EQueueType::Graphics).Submit();
+        append_frontier_waits(bridge, EQueueType::Graphics, gpu_frontier);
+        if (!bridge.wait_events.empty()) {
             std::optional<VkCommandQueue::CurrentVulkanRecordedSubmit> recorded =
                 graphics_queue.TranslateForRuntime(std::move(bridge));
             used_queues[static_cast<size_t>(EQueueType::Graphics)] = true;
@@ -950,8 +1039,9 @@ void VulkanSubmissionExecutor::ProcessBatch(
                 return;
             }
             assert(bridge_result.completion.has_value());
-            ordered_gpu_tail   = *bridge_result.completion;
-            ordered_tail_queue = EQueueType::Graphics;
+            update_frontier(
+                EQueueType::Graphics, *bridge_result.completion, true
+            );
             used_queues[static_cast<size_t>(EQueueType::Graphics)] = true;
         }
         const VulkanRuntimeSubmissionResult present_result = ExecuteOnSubmissionThread(
@@ -975,8 +1065,9 @@ void VulkanSubmissionExecutor::ProcessBatch(
         used_queues[static_cast<size_t>(EQueueType::Graphics)] = true;
         if (present_result.WasSubmitted()) {
             assert(present_result.completion.has_value());
-            ordered_gpu_tail   = *present_result.completion;
-            ordered_tail_queue = EQueueType::Graphics;
+            update_frontier(
+                EQueueType::Graphics, *present_result.completion, true
+            );
             used_queues[static_cast<size_t>(EQueueType::Graphics)] = true;
         }
         if (present_result.IsHardFailure()) {
@@ -1014,8 +1105,10 @@ void VulkanSubmissionExecutor::ProcessSync(ERHISyncDepth _depth) {
         RenderDevice::Get().GetCommandQueue(EQueueType::Compute).Sync();
         RenderDevice::Get().GetCopyQueue().Sync(last_copy_timeline);
     });
-    ordered_gpu_tail.reset();
-    ordered_tail_queue.reset();
+    gpu_frontier.fill(std::nullopt);
+    async_scope_entry_frontier.fill(std::nullopt);
+    async_scope_seen_queues.fill(false);
+    active_async_queue_scope = 0;
     used_queues.fill(false);
     last_copy_timeline = 0;
     LOG_INFO("[RHIExecutor][Vulkan] sync complete depth={}", static_cast<uint32>(_depth));

--- a/source/runtime/render/rhi/vulkan/VulkanSubmissionExecutor.h
+++ b/source/runtime/render/rhi/vulkan/VulkanSubmissionExecutor.h
@@ -19,8 +19,9 @@ namespace Moer::Render {
 
 // Owns the upper RHI submission stream for Vulkan. The translate owner prepares
 // one source at a time, then transfers its move-only packet to the sole native
-// Submission owner. The conservative one-packet window preserves the current
-// failure and queue-ordering semantics while making thread ownership explicit.
+// Submission owner. Native queue submission remains single-owner and serial.
+// Validated non-zero async scopes may overlap GPU execution across distinct
+// native queues using explicit graph wait/signal events.
 class VulkanSubmissionExecutor final : public RHIBackendExecutor {
 public:
     VulkanSubmissionExecutor();
@@ -118,12 +119,20 @@ private:
     bool                       claims_owned{false};
     bool                       hard_failed{false};
     bool                       logged_multi_source_topology{false};
+    bool                       logged_async_queue_scope{false};
     int32                      hard_failure_result{0};
     std::shared_ptr<Completion> stop_completion{};
     StaticArray<bool, static_cast<size_t>(EQueueType::Num)> used_queues{};
     uint64                     last_copy_timeline{0};
-    std::optional<EQueueType>  ordered_tail_queue{};
-    std::optional<WaitEvent>   ordered_gpu_tail{};
+    StaticArray<
+        std::optional<WaitEvent>,
+        static_cast<size_t>(EQueueType::Num)> gpu_frontier{};
+    uint64 active_async_queue_scope{0};
+    StaticArray<
+        std::optional<WaitEvent>,
+        static_cast<size_t>(EQueueType::Num)> async_scope_entry_frontier{};
+    StaticArray<bool, static_cast<size_t>(EQueueType::Num)>
+        async_scope_seen_queues{};
 
     std::mutex                 submission_mutex{};
     std::condition_variable    submission_cv{};

--- a/source/test/CMakeLists.txt
+++ b/source/test/CMakeLists.txt
@@ -26,6 +26,22 @@ target_link_libraries(${test_target}
 set_target_properties(${test_target} PROPERTIES FOLDER ${moer_test_folder})
 add_test(NAME RenderGraphContract COMMAND $<TARGET_FILE:${test_target}>)
 
+set(test_target TestRenderGraphLowering)
+add_executable(${test_target} "RenderGraphLoweringTest.cpp")
+target_link_libraries(${test_target}
+    PRIVATE Moer::Render
+)
+set_target_properties(${test_target} PROPERTIES FOLDER ${moer_test_folder})
+add_test(NAME RenderGraphLoweringContract COMMAND $<TARGET_FILE:${test_target}>)
+
+set(test_target TestRenderGraphActiveLowering)
+add_executable(${test_target} "RenderGraphActiveLoweringTest.cpp")
+target_link_libraries(${test_target}
+    PRIVATE Moer::Render
+)
+set_target_properties(${test_target} PROPERTIES FOLDER ${moer_test_folder})
+add_test(NAME RenderGraphActiveLoweringContract COMMAND $<TARGET_FILE:${test_target}>)
+
 set(test_target TestRHICmdReorderer)
 add_executable(${test_target} "RHICmdReordererTest.cpp")
 target_link_libraries(${test_target}
@@ -33,6 +49,14 @@ target_link_libraries(${test_target}
 )
 set_target_properties(${test_target} PROPERTIES FOLDER ${moer_test_folder})
 add_test(NAME RHICmdReordererContract COMMAND $<TARGET_FILE:${test_target}>)
+
+set(test_target TestRHIExplicitBarrier)
+add_executable(${test_target} "RHIExplicitBarrierTest.cpp")
+target_link_libraries(${test_target}
+    PRIVATE Moer::Render
+)
+set_target_properties(${test_target} PROPERTIES FOLDER ${moer_test_folder})
+add_test(NAME RHIExplicitBarrierContract COMMAND $<TARGET_FILE:${test_target}>)
 
 set(test_target TestRHICommandMarker)
 add_executable(${test_target} "RHICommandMarkerTest.cpp")

--- a/source/test/CMakeLists.txt
+++ b/source/test/CMakeLists.txt
@@ -42,6 +42,14 @@ target_link_libraries(${test_target}
 set_target_properties(${test_target} PROPERTIES FOLDER ${moer_test_folder})
 add_test(NAME RenderGraphActiveLoweringContract COMMAND $<TARGET_FILE:${test_target}>)
 
+set(test_target TestRenderGraphResourcePool)
+add_executable(${test_target} "RenderGraphResourcePoolTest.cpp")
+target_link_libraries(${test_target}
+    PRIVATE Moer::Render
+)
+set_target_properties(${test_target} PROPERTIES FOLDER ${moer_test_folder})
+add_test(NAME RenderGraphResourcePoolContract COMMAND $<TARGET_FILE:${test_target}>)
+
 set(test_target TestRHICmdReorderer)
 add_executable(${test_target} "RHICmdReordererTest.cpp")
 target_link_libraries(${test_target}

--- a/source/test/RHIExecutorRecordingHandoffTest.cpp
+++ b/source/test/RHIExecutorRecordingHandoffTest.cpp
@@ -306,6 +306,69 @@ bool FailedRecordingDrainsCleanupExactlyOnce() {
     return okay;
 }
 
+bool FailedCommitRejectsCompletedSources() {
+    RHIExecutor::StartUp();
+
+    std::atomic<int> ordinary_callbacks{0};
+    std::atomic<int> success_callbacks{0};
+    auto command_list = Moer::MakeShared<CommandList>(EQueueType::Graphics);
+    command_list->AddCallback([&ordinary_callbacks] {
+        ordinary_callbacks.fetch_add(1);
+    });
+    command_list->AddSuccessCallback([&success_callbacks] {
+        success_callbacks.fetch_add(1);
+    });
+
+    auto producer_complete = RHIRecordingGate::Create(true);
+    auto graph_commit      = RHIRecordingGate::Create();
+    Moer::Array<RHIRecordingSource> sources{};
+    sources.emplace_back(RHIRecordingSource{
+        .command_list = command_list,
+        .completion   = producer_complete,
+        .commit       = graph_commit,
+    });
+    RHIExecutor::Get().SubmitRecording(
+        std::move(sources),
+        ERHIExecSubmitFlags::None
+    );
+
+    std::atomic<bool> sync_returned{false};
+    std::jthread sync_thread([&] {
+        RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
+        sync_returned.store(true, std::memory_order_release);
+    });
+    std::this_thread::sleep_for(30ms);
+    bool okay = Expect(
+                    !sync_returned.load(std::memory_order_acquire),
+                    "completed producer bypassed its pending graph commit"
+                ) &&
+                Expect(
+                    ordinary_callbacks.load() == 0 &&
+                        success_callbacks.load() == 0,
+                    "callbacks ran before the graph transaction resolved"
+                );
+
+    graph_commit->Fail();
+    sync_thread.join();
+    okay &= Expect(
+        ordinary_callbacks.load() == 1,
+        "failed graph commit did not run ordinary cleanup exactly once"
+    );
+    okay &= Expect(
+        success_callbacks.load() == 0,
+        "failed graph commit ran a success-only callback"
+    );
+
+    CmdSubmit drained = command_list->Submit();
+    okay &= Expect(
+        drained.cmds.empty() && drained.callbacks.empty() &&
+            drained.success_callbacks.empty() && drained.segments.empty(),
+        "failed graph commit left a submittable source behind"
+    );
+    RHIExecutor::ShutDown();
+    return okay;
+}
+
 bool BlockingWaitReportsTerminalStatus() {
     auto succeeded_gate = RHIRecordingGate::Create();
     std::atomic<ERHIRecordingStatus> waited_status{ERHIRecordingStatus::Pending};
@@ -531,6 +594,7 @@ int main() {
         !ReadyWorkUsesStableExecutorOwnerAndCannotBeOvertaken() ||
         !FailedGateRejectsOnlyItsGroupAndPreservesFifo() ||
         !FailedRecordingDrainsCleanupExactlyOnce() ||
+        !FailedCommitRejectsCompletedSources() ||
         !BlockingWaitReportsTerminalStatus() ||
         !ShutdownDrainsTerminalSourceBehindPendingHead() ||
         !ShutdownCancelsAnUnsignalledGate() ||

--- a/source/test/RHIExecutorRecordingHandoffTest.cpp
+++ b/source/test/RHIExecutorRecordingHandoffTest.cpp
@@ -49,6 +49,26 @@ bool Expect(bool _condition, const char* _message) {
     return false;
 }
 
+class RecordingFenceProbe final : public Fence {
+public:
+    uint64_t GetValue() const override {
+        return 0;
+    }
+
+    void Wait(uint64_t) override {}
+
+    void Reject(uint64_t _value) override {
+        rejected_value.store(_value, std::memory_order_release);
+    }
+
+    [[nodiscard]] uint64_t RejectedValue() const {
+        return rejected_value.load(std::memory_order_acquire);
+    }
+
+private:
+    std::atomic<uint64_t> rejected_value{0};
+};
+
 bool PerSourceGatesPreserveFifo() {
     RHIExecutorRecordingHandoffQueue queue{};
     queue.Start();
@@ -369,6 +389,105 @@ bool FailedCommitRejectsCompletedSources() {
     return okay;
 }
 
+bool MetadataFailureRejectsEveryProducerSignal() {
+    RHIExecutor::StartUp();
+
+    auto invalid_source = Moer::MakeShared<CommandList>(EQueueType::Graphics);
+    auto later_source   = Moer::MakeShared<CommandList>(EQueueType::Graphics);
+    FenceRef signal_fence = MoerNew(RecordingFenceProbe)();
+    auto* signal_probe =
+        static_cast<RecordingFenceProbe*>(signal_fence.Get());
+
+    Moer::Array<RHIRecordingSource> sources{};
+    sources.emplace_back(RHIRecordingSource{
+        .command_list = invalid_source,
+        .completion   = RHIRecordingGate::Create(true),
+        .submit_metadata = RHIRecordingSubmitMetadata{
+            .wait_fences = {
+                RHIRecordingFencePoint{.fence = {}, .value = 1},
+            },
+        },
+    });
+    sources.emplace_back(RHIRecordingSource{
+        .command_list = later_source,
+        .completion   = RHIRecordingGate::Create(true),
+        .submit_metadata = RHIRecordingSubmitMetadata{
+            .signal_fences = {
+                RHIRecordingFencePoint{.fence = signal_fence, .value = 7},
+            },
+        },
+    });
+    RHIExecutor::Get().SubmitRecording(
+        std::move(sources),
+        ERHIExecSubmitFlags::None
+    );
+    RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
+    RHIExecutor::ShutDown();
+
+    bool okay = Expect(
+        signal_probe->RejectedValue() == 7,
+        "metadata failure did not reject a later producer signal"
+    );
+
+    RHIExecutor::StartUp();
+    FenceRef failed_gate_fence = MoerNew(RecordingFenceProbe)();
+    auto* failed_gate_probe =
+        static_cast<RecordingFenceProbe*>(failed_gate_fence.Get());
+    auto failed_gate = RHIRecordingGate::Create();
+    Moer::Array<RHIRecordingSource> failed_sources{};
+    failed_sources.emplace_back(RHIRecordingSource{
+        .command_list = Moer::MakeShared<CommandList>(EQueueType::Graphics),
+        .completion   = failed_gate,
+        .submit_metadata = RHIRecordingSubmitMetadata{
+            .signal_fences = {
+                RHIRecordingFencePoint{
+                    .fence = failed_gate_fence,
+                    .value = 11,
+                },
+            },
+        },
+    });
+    RHIExecutor::Get().SubmitRecording(
+        std::move(failed_sources),
+        ERHIExecSubmitFlags::None
+    );
+    failed_gate->Fail();
+    RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
+    RHIExecutor::ShutDown();
+    okay &= Expect(
+        failed_gate_probe->RejectedValue() == 11,
+        "failed recording gate did not reject its producer signal"
+    );
+
+    RHIExecutor::StartUp();
+    FenceRef cancelled_fence = MoerNew(RecordingFenceProbe)();
+    auto* cancelled_probe =
+        static_cast<RecordingFenceProbe*>(cancelled_fence.Get());
+    Moer::Array<RHIRecordingSource> cancelled_sources{};
+    cancelled_sources.emplace_back(RHIRecordingSource{
+        .command_list = Moer::MakeShared<CommandList>(EQueueType::Graphics),
+        .completion   = RHIRecordingGate::Create(),
+        .submit_metadata = RHIRecordingSubmitMetadata{
+            .signal_fences = {
+                RHIRecordingFencePoint{
+                    .fence = cancelled_fence,
+                    .value = 13,
+                },
+            },
+        },
+    });
+    RHIExecutor::Get().SubmitRecording(
+        std::move(cancelled_sources),
+        ERHIExecSubmitFlags::None
+    );
+    RHIExecutor::ShutDown();
+    okay &= Expect(
+        cancelled_probe->RejectedValue() == 13,
+        "shutdown cancellation did not reject its producer signal"
+    );
+    return okay;
+}
+
 bool BlockingWaitReportsTerminalStatus() {
     auto succeeded_gate = RHIRecordingGate::Create();
     std::atomic<ERHIRecordingStatus> waited_status{ERHIRecordingStatus::Pending};
@@ -595,6 +714,7 @@ int main() {
         !FailedGateRejectsOnlyItsGroupAndPreservesFifo() ||
         !FailedRecordingDrainsCleanupExactlyOnce() ||
         !FailedCommitRejectsCompletedSources() ||
+        !MetadataFailureRejectsEveryProducerSignal() ||
         !BlockingWaitReportsTerminalStatus() ||
         !ShutdownDrainsTerminalSourceBehindPendingHead() ||
         !ShutdownCancelsAnUnsignalledGate() ||

--- a/source/test/RHIExplicitBarrierTest.cpp
+++ b/source/test/RHIExplicitBarrierTest.cpp
@@ -1,0 +1,302 @@
+#include "rhi/RHIImpl.h"
+#include "rhi/vulkan/RHICmdReorderer.h"
+#include "rhi/vulkan/VulkanResourceTracker.h"
+
+#include <array>
+#include <iostream>
+#include <stdexcept>
+
+using namespace Moer;
+using namespace Moer::Render;
+
+namespace {
+
+void Expect(bool _condition, const char* _message) {
+    if (!_condition) {
+        throw std::runtime_error(_message);
+    }
+}
+
+bool FalseResourceFlag(uint64) {
+    return false;
+}
+
+bool FalseBindlessMembership(uint64, uint64) {
+    return false;
+}
+
+void NoopBindlessLock(uint64) {}
+
+FunctionTable MakeFunctionTable() {
+    return {
+        .is_resource_write       = &FalseResourceFlag,
+        .is_resource_read        = &FalseResourceFlag,
+        .is_texture_sampled      = &FalseResourceFlag,
+        .is_resource_in_bindless = &FalseBindlessMembership,
+        .lock_bdls_array         = &NoopBindlessLock,
+        .unlock_bdls_array       = &NoopBindlessLock,
+    };
+}
+
+int64 FindCommandLayer(
+    const CmdReorderer& _reorderer,
+    const Command*      _command
+) {
+    for (size_t layer = 0; layer < _reorderer.m_cmd_lists.size(); ++layer) {
+        for (const auto* node = _reorderer.m_cmd_lists[layer].head;
+             node != nullptr;
+             node = node->next) {
+            if (node->cmd == _command) {
+                return static_cast<int64>(layer);
+            }
+        }
+    }
+    return -1;
+}
+
+void ExplicitPayloadAndOwnershipArePreserved() {
+    constexpr uint64 buffer_handle  = 0x1000;
+    constexpr uint64 texture_handle = 0x2000;
+    const BufferView buffer(
+        reinterpret_cast<Buffer*>(buffer_handle),
+        64,
+        32,
+        4
+    );
+    TextureView texture{};
+    texture.texture     = reinterpret_cast<Texture*>(texture_handle);
+    texture.mip_level   = 2;
+    texture.num_mips    = 3;
+    texture.array_layer = 1;
+    texture.num_array   = 2;
+
+    const BarrierState buffer_src = BarrierState::Buffer(
+        ERHIPipelineStageFlags::PS_TRANSFER,
+        ERHIAccessFlags::TRANSFER_WRITE
+    );
+    const BarrierState buffer_dst = BarrierState::Buffer(
+        ERHIPipelineStageFlags::PS_COMPUTE_SHADER,
+        ERHIAccessFlags::SHADER_READ
+    );
+    const BarrierState texture_src = BarrierState::Texture(
+        ERHIPipelineStageFlags::PS_COLOR_ATTACHMENT_OUTPUT,
+        ERHIAccessFlags::COLOR_ATTACHMENT_WRITE,
+        ETextureLayout::TEXTURE_LAYOUT_COLOR_ATTACHMENT
+    );
+    const BarrierState texture_dst = BarrierState::Texture(
+        ERHIPipelineStageFlags::PS_FRAGMENT_SHADER,
+        ERHIAccessFlags::SHADER_SAMPLED_READ,
+        ETextureLayout::TEXTURE_LAYOUT_SHADER_READ_ONLY_OPTIMAL
+    );
+
+    CommandList list(EQueueType::Graphics);
+    list.Barriers({
+        BarrierCreateInfo::Transition(buffer, buffer_src, buffer_dst),
+        BarrierCreateInfo::Transition(
+            texture,
+            texture_src,
+            texture_dst,
+            ETextureAspectFlags::DEPTH_SLICE
+        ),
+    });
+    CmdSubmit submit = list.Submit();
+
+    Expect(
+        submit.HasExplicitResourceStateOwnership(),
+        "explicit barrier did not transfer state ownership to CmdSubmit"
+    );
+    Expect(submit.cmds.size() == 1, "explicit barriers were split into multiple commands");
+    const auto& command = *static_cast<const BarrierCmd*>(submit.cmds.front().get());
+    Expect(command.HasExplicitBarriers(), "BarrierCmd lost explicit payload");
+    Expect(command.ReadBuffers().empty(), "explicit buffer leaked into legacy read payload");
+    Expect(command.WriteTextures().empty(), "explicit texture leaked into legacy write payload");
+    Expect(command.ExplicitBuffers().size() == 1, "explicit buffer count mismatch");
+    Expect(command.ExplicitTextures().size() == 1, "explicit texture count mismatch");
+
+    const ExplicitBufferBarrier& recorded_buffer =
+        command.ExplicitBuffers().front();
+    Expect(recorded_buffer.handle == buffer_handle, "explicit buffer identity changed");
+    Expect(recorded_buffer.offset == 64, "explicit buffer offset changed");
+    Expect(recorded_buffer.byte_size == 128, "explicit buffer size changed");
+    Expect(recorded_buffer.src_state == buffer_src, "explicit buffer src state changed");
+    Expect(recorded_buffer.dst_state == buffer_dst, "explicit buffer dst state changed");
+
+    const ExplicitTextureBarrier& recorded_texture =
+        command.ExplicitTextures().front();
+    Expect(recorded_texture.handle == texture_handle, "explicit texture identity changed");
+    Expect(
+        recorded_texture.texture_aspects == ETextureAspectFlags::DEPTH_SLICE,
+        "explicit texture aspect changed"
+    );
+    Expect(
+        recorded_texture.mip_level == 2 && recorded_texture.mip_count == 3 &&
+            recorded_texture.array_layer == 1 &&
+            recorded_texture.array_count == 2,
+        "explicit texture subresource range changed"
+    );
+    Expect(recorded_texture.src_state == texture_src, "explicit texture src state changed");
+    Expect(recorded_texture.dst_state == texture_dst, "explicit texture dst state changed");
+
+    // Ownership is per immutable submission, not sticky CommandList state.
+    CmdSubmit reused = list.Submit();
+    Expect(
+        !reused.HasExplicitResourceStateOwnership(),
+        "CommandList retained explicit ownership across Submit"
+    );
+}
+
+void LegacyBarrierRemainsCompatible() {
+    constexpr uint64 buffer_handle = 0x3000;
+    CommandList      list(EQueueType::Graphics);
+    list.Barriers(
+        EQueueType::Graphics,
+        EQueueType::Graphics,
+        EPassType::Graphics,
+        ReadBuffer{
+            BufferView(reinterpret_cast<Buffer*>(buffer_handle), 0, 4, 4),
+            EBufferState::SHADER_RESOURCE,
+        }
+    );
+    CmdSubmit submit = list.Submit();
+    Expect(
+        !submit.HasExplicitResourceStateOwnership(),
+        "legacy barrier unexpectedly disabled backend state ownership"
+    );
+    const auto& command = *static_cast<const BarrierCmd*>(submit.cmds.front().get());
+    Expect(!command.HasExplicitBarriers(), "legacy barrier became explicit");
+    Expect(command.ReadBuffers().size() == 1, "legacy barrier payload changed");
+}
+
+void EmptyExplicitBarrierBatchFailsWithoutChangingOwnership() {
+    CommandList list(EQueueType::Graphics);
+    bool        rejected = false;
+    try {
+        list.Barriers(std::span<const BarrierCreateInfo>{});
+    } catch (const std::invalid_argument&) {
+        rejected = true;
+    }
+
+    Expect(rejected, "empty explicit barrier batch was not rejected");
+    CmdSubmit submit = list.Submit();
+    Expect(submit.cmds.empty(), "empty explicit barrier batch recorded a command");
+    Expect(
+        !submit.HasExplicitResourceStateOwnership(),
+        "empty explicit barrier batch changed submit state ownership"
+    );
+}
+
+void ExplicitBarrierOwnsAnExclusiveReorderLayer() {
+    constexpr uint64 buffer_handle = 0x4000;
+    const BufferView view(
+        reinterpret_cast<Buffer*>(buffer_handle),
+        0,
+        4,
+        4
+    );
+
+    BarrierCmd prior_read(
+        0,
+        0,
+        1,
+        0,
+        EQueueType::Graphics,
+        EQueueType::Graphics
+    );
+    prior_read.ReadBuffer(
+        view,
+        EBufferState::SHADER_RESOURCE,
+        EPassType::Graphics
+    );
+
+    BarrierCmd explicit_barrier(
+        1,
+        EQueueType::Graphics,
+        EQueueType::Graphics
+    );
+    explicit_barrier.AddExplicitBarrier(
+        BarrierCreateInfo::Transition(
+            view,
+            BarrierState::Buffer(
+                ERHIPipelineStageFlags::PS_FRAGMENT_SHADER,
+                ERHIAccessFlags::SHADER_READ
+            ),
+            BarrierState::Buffer(
+                ERHIPipelineStageFlags::PS_COMPUTE_SHADER,
+                ERHIAccessFlags::SHADER_READ
+            )
+        )
+    );
+
+    std::array<byte, 16> data{};
+    UploadBufferCmd following_write(
+        buffer_handle,
+        0,
+        data.size(),
+        data.data()
+    );
+
+    TCachedArgArray cached_args;
+    CmdReorderer reorderer(MakeFunctionTable(), cached_args);
+    reorderer.AcceptCmd(&prior_read);
+    reorderer.AcceptCmd(&explicit_barrier);
+    reorderer.AcceptCmd(&following_write);
+
+    Expect(FindCommandLayer(reorderer, &prior_read) == 0, "prior read layer changed");
+    Expect(
+        FindCommandLayer(reorderer, &explicit_barrier) == 1,
+        "explicit barrier did not own the next exclusive layer"
+    );
+    Expect(
+        FindCommandLayer(reorderer, &following_write) == 2,
+        "following work crossed the explicit barrier layer"
+    );
+}
+
+void TextureRangeOverlapMatchesAtomicExplicitTracking() {
+    auto* texture = reinterpret_cast<VulkanTexture*>(0x5000);
+    const TextureSubresourceKeyT<VulkanTexture> whole{
+        texture, 0, 1, 0, 4
+    };
+    const TextureSubresourceKeyT<VulkanTexture> subset{
+        texture, 0, 1, 1, 2
+    };
+    const TextureSubresourceKeyT<VulkanTexture> disjoint_layer{
+        texture, 0, 1, 4, 1
+    };
+    const TextureSubresourceKeyT<VulkanTexture> disjoint_mip{
+        texture, 1, 1, 1, 2
+    };
+    const TextureSubresourceKeyT<VulkanTexture> other_texture{
+        reinterpret_cast<VulkanTexture*>(0x6000), 0, 1, 1, 2
+    };
+
+    Expect(
+        TextureSubresourceRangesOverlap(whole, subset) &&
+            TextureSubresourceRangesOverlap(subset, whole),
+        "texture overlap must be symmetric for aggregate and atomic ranges"
+    );
+    Expect(
+        !TextureSubresourceRangesOverlap(whole, disjoint_layer) &&
+            !TextureSubresourceRangesOverlap(whole, disjoint_mip) &&
+            !TextureSubresourceRangesOverlap(whole, other_texture),
+        "texture overlap accepted a disjoint subresource or identity"
+    );
+}
+
+} // namespace
+
+int main() {
+    try {
+        ExplicitPayloadAndOwnershipArePreserved();
+        LegacyBarrierRemainsCompatible();
+        EmptyExplicitBarrierBatchFailsWithoutChangingOwnership();
+        ExplicitBarrierOwnsAnExclusiveReorderLayer();
+        TextureRangeOverlapMatchesAtomicExplicitTracking();
+    } catch (const std::exception& error) {
+        std::cerr << "RHI explicit barrier contract failed: " << error.what()
+                  << '\n';
+        return 1;
+    }
+    std::cout << "RHI explicit barrier contract passed\n";
+    return 0;
+}

--- a/source/test/RHIExplicitBarrierTest.cpp
+++ b/source/test/RHIExplicitBarrierTest.cpp
@@ -17,6 +17,44 @@ void Expect(bool _condition, const char* _message) {
     }
 }
 
+class TestBuffer final : public Buffer {
+public:
+    explicit TestBuffer(uint64 _byte_size) :
+        Buffer(BufferInfo{
+            _byte_size,
+            1,
+            EBufferUsageFlags::UNORDERED_ACCESS | EBufferUsageFlags::TRANSFER_SRC |
+                EBufferUsageFlags::TRANSFER_DST,
+        }) {}
+
+    void SetName(const std::string_view) override {}
+};
+
+class TestTexture final : public Texture {
+public:
+    TestTexture(uint8 _num_mips, uint16 _num_arrays, ETextureAspectFlags _aspects) :
+        Texture(MakeInfo(_num_mips, _num_arrays, _aspects)) {}
+
+    uint GetMipByteSize(uint) const override {
+        return 4;
+    }
+
+    void SetName(const std::string_view) override {}
+
+private:
+    static TextureInfo MakeInfo(uint8 _num_mips, uint16 _num_arrays, ETextureAspectFlags _aspects) {
+        TextureInfo info{};
+        info.usage = ETextureUsageFlags::SAMPLED | ETextureUsageFlags::UNORDERED_ACCESS |
+                     ETextureUsageFlags::COLOR_ATTACHMENT | ETextureUsageFlags::DEPTH_STENCIL_ATTACHMENT |
+                     ETextureUsageFlags::TRANSFER_SRC | ETextureUsageFlags::TRANSFER_DST;
+        info.extent       = {64, 64};
+        info.num_mips     = _num_mips;
+        info.array_size   = _num_arrays;
+        info.aspect_flags = _aspects;
+        return info;
+    }
+};
+
 bool FalseResourceFlag(uint64) {
     return false;
 }
@@ -54,30 +92,23 @@ int64 FindCommandLayer(
     return -1;
 }
 
-void ExplicitPayloadAndOwnershipArePreserved() {
-    constexpr uint64 buffer_handle  = 0x1000;
-    constexpr uint64 texture_handle = 0x2000;
-    const BufferView buffer(
-        reinterpret_cast<Buffer*>(buffer_handle),
-        64,
-        32,
-        4
-    );
-    TextureView texture{};
-    texture.texture     = reinterpret_cast<Texture*>(texture_handle);
+void LocalExplicitPayloadAndOwnershipArePreserved() {
+    TestBuffer       buffer_resource(256);
+    TestTexture      texture_resource(6, 4, ETextureAspectFlags::DEPTH_SLICE);
+    const uint64     buffer_handle  = reinterpret_cast<uint64>(&buffer_resource);
+    const uint64     texture_handle = reinterpret_cast<uint64>(&texture_resource);
+    const BufferView buffer(&buffer_resource, 64, 32, 4);
+    TextureView      texture{};
+    texture.texture     = &texture_resource;
     texture.mip_level   = 2;
     texture.num_mips    = 3;
     texture.array_layer = 1;
     texture.num_array   = 2;
 
-    const BarrierState buffer_src = BarrierState::Buffer(
-        ERHIPipelineStageFlags::PS_TRANSFER,
-        ERHIAccessFlags::TRANSFER_WRITE
-    );
-    const BarrierState buffer_dst = BarrierState::Buffer(
-        ERHIPipelineStageFlags::PS_COMPUTE_SHADER,
-        ERHIAccessFlags::SHADER_READ
-    );
+    const BarrierState buffer_src =
+        BarrierState::Buffer(ERHIPipelineStageFlags::PS_TRANSFER, ERHIAccessFlags::TRANSFER_WRITE);
+    const BarrierState buffer_dst =
+        BarrierState::Buffer(ERHIPipelineStageFlags::PS_COMPUTE_SHADER, ERHIAccessFlags::SHADER_READ);
     const BarrierState texture_src = BarrierState::Texture(
         ERHIPipelineStageFlags::PS_COLOR_ATTACHMENT_OUTPUT,
         ERHIAccessFlags::COLOR_ATTACHMENT_WRITE,
@@ -92,12 +123,7 @@ void ExplicitPayloadAndOwnershipArePreserved() {
     CommandList list(EQueueType::Graphics);
     list.Barriers({
         BarrierCreateInfo::Transition(buffer, buffer_src, buffer_dst),
-        BarrierCreateInfo::Transition(
-            texture,
-            texture_src,
-            texture_dst,
-            ETextureAspectFlags::DEPTH_SLICE
-        ),
+        BarrierCreateInfo::Transition(texture, texture_src, texture_dst, ETextureAspectFlags::DEPTH_SLICE),
     });
     CmdSubmit submit = list.Submit();
 
@@ -113,16 +139,18 @@ void ExplicitPayloadAndOwnershipArePreserved() {
     Expect(command.ExplicitBuffers().size() == 1, "explicit buffer count mismatch");
     Expect(command.ExplicitTextures().size() == 1, "explicit texture count mismatch");
 
-    const ExplicitBufferBarrier& recorded_buffer =
-        command.ExplicitBuffers().front();
+    const ExplicitBufferBarrier& recorded_buffer = command.ExplicitBuffers().front();
     Expect(recorded_buffer.handle == buffer_handle, "explicit buffer identity changed");
     Expect(recorded_buffer.offset == 64, "explicit buffer offset changed");
     Expect(recorded_buffer.byte_size == 128, "explicit buffer size changed");
     Expect(recorded_buffer.src_state == buffer_src, "explicit buffer src state changed");
     Expect(recorded_buffer.dst_state == buffer_dst, "explicit buffer dst state changed");
+    Expect(
+        recorded_buffer.queue_transfer == BarrierQueueTransfer{},
+        "local explicit buffer acquired queue-transfer metadata"
+    );
 
-    const ExplicitTextureBarrier& recorded_texture =
-        command.ExplicitTextures().front();
+    const ExplicitTextureBarrier& recorded_texture = command.ExplicitTextures().front();
     Expect(recorded_texture.handle == texture_handle, "explicit texture identity changed");
     Expect(
         recorded_texture.texture_aspects == ETextureAspectFlags::DEPTH_SLICE,
@@ -130,18 +158,278 @@ void ExplicitPayloadAndOwnershipArePreserved() {
     );
     Expect(
         recorded_texture.mip_level == 2 && recorded_texture.mip_count == 3 &&
-            recorded_texture.array_layer == 1 &&
-            recorded_texture.array_count == 2,
+            recorded_texture.array_layer == 1 && recorded_texture.array_count == 2,
         "explicit texture subresource range changed"
     );
     Expect(recorded_texture.src_state == texture_src, "explicit texture src state changed");
     Expect(recorded_texture.dst_state == texture_dst, "explicit texture dst state changed");
+    Expect(
+        recorded_texture.queue_transfer == BarrierQueueTransfer{},
+        "local explicit texture acquired queue-transfer metadata"
+    );
 
     // Ownership is per immutable submission, not sticky CommandList state.
     CmdSubmit reused = list.Submit();
     Expect(
-        !reused.HasExplicitResourceStateOwnership(),
-        "CommandList retained explicit ownership across Submit"
+        !reused.HasExplicitResourceStateOwnership(), "CommandList retained explicit ownership across Submit"
+    );
+}
+
+void ExpectQueueTransferPayload(
+    const CmdSubmit&            _submit,
+    EQueueType                  _recording_queue,
+    const BufferView&           _buffer,
+    const TextureView&          _texture,
+    const BarrierState&         _buffer_src,
+    const BarrierState&         _buffer_dst,
+    const BarrierState&         _texture_src,
+    const BarrierState&         _texture_dst,
+    const BarrierQueueTransfer& _transfer
+) {
+    Expect(
+        _submit.HasExplicitResourceStateOwnership(),
+        "queue-transfer barrier did not preserve explicit state ownership"
+    );
+    Expect(_submit.cmds.size() == 1, "queue-transfer barriers were split into multiple commands");
+    const auto& command = *static_cast<const BarrierCmd*>(_submit.cmds.front().get());
+    Expect(command.HasExplicitBarriers(), "queue-transfer payload was lost");
+    Expect(
+        command.GetSrcQueue() == _recording_queue && command.GetDstQueue() == _recording_queue,
+        "BarrierCmd affinity did not remain on the recording endpoint"
+    );
+    Expect(
+        command.ExplicitBuffers().size() == 1 && command.ExplicitTextures().size() == 1,
+        "queue-transfer explicit payload count changed"
+    );
+
+    const ExplicitBufferBarrier& recorded_buffer = command.ExplicitBuffers().front();
+    Expect(
+        recorded_buffer.handle == reinterpret_cast<uint64>(_buffer.GetBuffer()),
+        "queue-transfer buffer identity changed"
+    );
+    Expect(
+        recorded_buffer.offset == _buffer.GetByteOffset() &&
+            recorded_buffer.byte_size == _buffer.GetByteSize(),
+        "queue-transfer buffer range changed"
+    );
+    Expect(
+        recorded_buffer.src_state == _buffer_src && recorded_buffer.dst_state == _buffer_dst,
+        "queue-transfer buffer states changed"
+    );
+    Expect(recorded_buffer.queue_transfer == _transfer, "queue-transfer buffer endpoints or phase changed");
+
+    const ExplicitTextureBarrier& recorded_texture = command.ExplicitTextures().front();
+    Expect(
+        recorded_texture.handle == reinterpret_cast<uint64>(_texture.GetTexture()),
+        "queue-transfer texture identity changed"
+    );
+    Expect(
+        recorded_texture.texture_aspects == ETextureAspectFlags::DEPTH_SLICE,
+        "queue-transfer texture aspect changed"
+    );
+    Expect(
+        recorded_texture.mip_level == _texture.mip_level && recorded_texture.mip_count == _texture.num_mips &&
+            recorded_texture.array_layer == _texture.array_layer &&
+            recorded_texture.array_count == _texture.num_array,
+        "queue-transfer texture range changed"
+    );
+    Expect(
+        recorded_texture.src_state == _texture_src && recorded_texture.dst_state == _texture_dst,
+        "queue-transfer texture states changed"
+    );
+    Expect(recorded_texture.queue_transfer == _transfer, "queue-transfer texture endpoints or phase changed");
+}
+
+void ReleaseAndAcquirePayloadsPreserveEndpointAffinity() {
+    TestBuffer       buffer_resource(256);
+    TestTexture      texture_resource(4, 3, ETextureAspectFlags::DEPTH_SLICE);
+    const BufferView buffer(&buffer_resource, 32, 16, 4);
+    TextureView      texture{};
+    texture.texture     = &texture_resource;
+    texture.mip_level   = 1;
+    texture.num_mips    = 2;
+    texture.array_layer = 1;
+    texture.num_array   = 2;
+
+    const BarrierState buffer_src =
+        BarrierState::Buffer(ERHIPipelineStageFlags::PS_TRANSFER, ERHIAccessFlags::TRANSFER_WRITE);
+    const BarrierState buffer_dst =
+        BarrierState::Buffer(ERHIPipelineStageFlags::PS_COMPUTE_SHADER, ERHIAccessFlags::SHADER_READ);
+    const BarrierState texture_src = BarrierState::Texture(
+        ERHIPipelineStageFlags::PS_COLOR_ATTACHMENT_OUTPUT,
+        ERHIAccessFlags::COLOR_ATTACHMENT_WRITE,
+        ETextureLayout::TEXTURE_LAYOUT_COLOR_ATTACHMENT
+    );
+    const BarrierState texture_dst = BarrierState::Texture(
+        ERHIPipelineStageFlags::PS_COMPUTE_SHADER,
+        ERHIAccessFlags::SHADER_SAMPLED_READ,
+        ETextureLayout::TEXTURE_LAYOUT_SHADER_READ_ONLY_OPTIMAL
+    );
+
+    const auto make_barriers = [&](BarrierQueueTransfer _transfer) {
+        BarrierCreateInfo buffer_barrier  = BarrierCreateInfo::Transition(buffer, buffer_src, buffer_dst);
+        buffer_barrier.queue_transfer     = _transfer;
+        BarrierCreateInfo texture_barrier = BarrierCreateInfo::Transition(
+            texture, texture_src, texture_dst, ETextureAspectFlags::DEPTH_SLICE
+        );
+        texture_barrier.queue_transfer = _transfer;
+        return std::array{
+            std::move(buffer_barrier),
+            std::move(texture_barrier),
+        };
+    };
+
+    const BarrierQueueTransfer release =
+        BarrierQueueTransfer::Release(EQueueType::Graphics, EQueueType::Compute);
+    const auto  release_barriers = make_barriers(release);
+    CommandList release_list(EQueueType::Graphics);
+    release_list.Barriers(release_barriers);
+    const CmdSubmit release_submit = release_list.Submit();
+    ExpectQueueTransferPayload(
+        release_submit,
+        EQueueType::Graphics,
+        buffer,
+        texture,
+        buffer_src,
+        buffer_dst,
+        texture_src,
+        texture_dst,
+        release
+    );
+
+    const BarrierQueueTransfer acquire =
+        BarrierQueueTransfer::Acquire(EQueueType::Graphics, EQueueType::Compute);
+    const auto  acquire_barriers = make_barriers(acquire);
+    CommandList acquire_list(EQueueType::Compute);
+    acquire_list.Barriers(acquire_barriers);
+    const CmdSubmit acquire_submit = acquire_list.Submit();
+    ExpectQueueTransferPayload(
+        acquire_submit,
+        EQueueType::Compute,
+        buffer,
+        texture,
+        buffer_src,
+        buffer_dst,
+        texture_src,
+        texture_dst,
+        acquire
+    );
+
+    const BarrierQueueTransfer copy_release =
+        BarrierQueueTransfer::Release(EQueueType::Graphics, EQueueType::Copy);
+    const auto  copy_release_barriers = make_barriers(copy_release);
+    CommandList copy_release_list(EQueueType::Graphics);
+    copy_release_list.Barriers(copy_release_barriers);
+    const CmdSubmit copy_release_submit = copy_release_list.Submit();
+    ExpectQueueTransferPayload(
+        copy_release_submit,
+        EQueueType::Graphics,
+        buffer,
+        texture,
+        buffer_src,
+        buffer_dst,
+        texture_src,
+        texture_dst,
+        copy_release
+    );
+
+    const BarrierQueueTransfer copy_acquire =
+        BarrierQueueTransfer::Acquire(EQueueType::Graphics, EQueueType::Copy);
+    const auto  copy_acquire_barriers = make_barriers(copy_acquire);
+    CommandList copy_acquire_list(EQueueType::Copy);
+    copy_acquire_list.Barriers(copy_acquire_barriers);
+    const CmdSubmit copy_acquire_submit = copy_acquire_list.Submit();
+    ExpectQueueTransferPayload(
+        copy_acquire_submit,
+        EQueueType::Copy,
+        buffer,
+        texture,
+        buffer_src,
+        buffer_dst,
+        texture_src,
+        texture_dst,
+        copy_acquire
+    );
+}
+
+void ExpectRejectedWithoutMutation(
+    CommandList&                       _list,
+    std::span<const BarrierCreateInfo> _barriers,
+    const char*                        _rejection_message
+) {
+    bool rejected = false;
+    try {
+        _list.Barriers(_barriers);
+    } catch (const std::invalid_argument&) {
+        rejected = true;
+    }
+
+    Expect(rejected, _rejection_message);
+    Expect(
+        !_list.HasExplicitResourceStateOwnership(), "rejected explicit barrier changed CommandList ownership"
+    );
+    CmdSubmit submit = _list.Submit();
+    Expect(submit.cmds.empty(), "rejected explicit barrier recorded a partial command");
+    Expect(
+        !submit.HasExplicitResourceStateOwnership(), "rejected explicit barrier changed CmdSubmit ownership"
+    );
+}
+
+void InvalidQueueTransferEndpointsFailWithoutMutation() {
+    TestBuffer         buffer_resource(64);
+    const BufferView   buffer(&buffer_resource, 0, 16, 4);
+    const BarrierState src =
+        BarrierState::Buffer(ERHIPipelineStageFlags::PS_TRANSFER, ERHIAccessFlags::TRANSFER_WRITE);
+    const BarrierState dst =
+        BarrierState::Buffer(ERHIPipelineStageFlags::PS_COMPUTE_SHADER, ERHIAccessFlags::SHADER_READ);
+
+    BarrierCreateInfo release = BarrierCreateInfo::Transition(buffer, src, dst);
+    release.queue_transfer    = BarrierQueueTransfer::Release(EQueueType::Graphics, EQueueType::Compute);
+    const std::array release_batch{release};
+    CommandList      wrong_release_endpoint(EQueueType::Compute);
+    ExpectRejectedWithoutMutation(
+        wrong_release_endpoint, release_batch, "release barrier was accepted on its destination endpoint"
+    );
+
+    BarrierCreateInfo acquire = BarrierCreateInfo::Transition(buffer, src, dst);
+    acquire.queue_transfer    = BarrierQueueTransfer::Acquire(EQueueType::Graphics, EQueueType::Compute);
+    const std::array acquire_batch{acquire};
+    CommandList      wrong_acquire_endpoint(EQueueType::Graphics);
+    ExpectRejectedWithoutMutation(
+        wrong_acquire_endpoint, acquire_batch, "acquire barrier was accepted on its source endpoint"
+    );
+
+    BarrierCreateInfo same_endpoint = BarrierCreateInfo::Transition(buffer, src, dst);
+    same_endpoint.queue_transfer =
+        BarrierQueueTransfer::Release(EQueueType::Graphics, EQueueType::Graphics);
+    const std::array same_endpoint_batch{same_endpoint};
+    CommandList      same_endpoint_list(EQueueType::Graphics);
+    ExpectRejectedWithoutMutation(
+        same_endpoint_list,
+        same_endpoint_batch,
+        "ownership transfer accepted identical source and destination endpoints"
+    );
+}
+
+void InvalidResourceRangeFailsWithoutMutation() {
+    TestBuffer         buffer_resource(128);
+    const BarrierState src =
+        BarrierState::Buffer(ERHIPipelineStageFlags::PS_TRANSFER, ERHIAccessFlags::TRANSFER_WRITE);
+    const BarrierState dst =
+        BarrierState::Buffer(ERHIPipelineStageFlags::PS_COMPUTE_SHADER, ERHIAccessFlags::SHADER_READ);
+    const BarrierQueueTransfer release =
+        BarrierQueueTransfer::Release(EQueueType::Graphics, EQueueType::Compute);
+
+    BarrierCreateInfo valid = BarrierCreateInfo::Transition(BufferView(&buffer_resource, 0, 16, 4), src, dst);
+    valid.queue_transfer    = release;
+    BarrierCreateInfo out_of_range =
+        BarrierCreateInfo::Transition(BufferView(&buffer_resource, 96, 16, 4), src, dst);
+    out_of_range.queue_transfer = release;
+
+    const std::array barriers{valid, out_of_range};
+    CommandList      list(EQueueType::Graphics);
+    ExpectRejectedWithoutMutation(
+        list, barriers, "out-of-range barrier batch was not rejected transactionally"
     );
 }
 
@@ -283,15 +571,75 @@ void TextureRangeOverlapMatchesAtomicExplicitTracking() {
     );
 }
 
+void ReleaseSentinelOverlapUsesExactBufferAndTextureRanges() {
+    auto* buffer = reinterpret_cast<VulkanBuffer*>(0x7000);
+    const BufferByteRangeT<VulkanBuffer> first_buffer{
+        .buffer = buffer, .offset = 0, .byte_size = 256
+    };
+    const BufferByteRangeT<VulkanBuffer> overlapping_buffer{
+        .buffer = buffer, .offset = 128, .byte_size = 256
+    };
+    const BufferByteRangeT<VulkanBuffer> adjacent_buffer{
+        .buffer = buffer, .offset = 256, .byte_size = 256
+    };
+    const BufferByteRangeT<VulkanBuffer> other_buffer{
+        .buffer = reinterpret_cast<VulkanBuffer*>(0x8000),
+        .offset = 0,
+        .byte_size = 256
+    };
+    Expect(
+        BufferByteRangesOverlap(first_buffer, overlapping_buffer) &&
+            BufferByteRangesOverlap(overlapping_buffer, first_buffer),
+        "buffer release overlap must be symmetric"
+    );
+    Expect(
+        !BufferByteRangesOverlap(first_buffer, adjacent_buffer) &&
+            !BufferByteRangesOverlap(first_buffer, other_buffer),
+        "buffer release overlap accepted an adjacent range or identity"
+    );
+
+    auto* texture = reinterpret_cast<VulkanTexture*>(0x9000);
+    const TextureAspectSubresourceRangeT<VulkanTexture> depth{
+        .subresource = {texture, 0, 1, 0, 1},
+        .aspects = VK_IMAGE_ASPECT_DEPTH_BIT,
+    };
+    const TextureAspectSubresourceRangeT<VulkanTexture> stencil{
+        .subresource = {texture, 0, 1, 0, 1},
+        .aspects = VK_IMAGE_ASPECT_STENCIL_BIT,
+    };
+    const TextureAspectSubresourceRangeT<VulkanTexture> depth_overlap{
+        .subresource = {texture, 0, 1, 0, 1},
+        .aspects = VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT,
+    };
+    const TextureAspectSubresourceRangeT<VulkanTexture> other_mip{
+        .subresource = {texture, 1, 1, 0, 1},
+        .aspects = VK_IMAGE_ASPECT_DEPTH_BIT,
+    };
+    Expect(
+        TextureAspectSubresourceRangesOverlap(depth, depth_overlap) &&
+            TextureAspectSubresourceRangesOverlap(depth_overlap, depth),
+        "texture release overlap must include matching aspects"
+    );
+    Expect(
+        !TextureAspectSubresourceRangesOverlap(depth, stencil) &&
+            !TextureAspectSubresourceRangesOverlap(depth, other_mip),
+        "texture release overlap accepted a disjoint aspect or subresource"
+    );
+}
+
 } // namespace
 
 int main() {
     try {
-        ExplicitPayloadAndOwnershipArePreserved();
+        LocalExplicitPayloadAndOwnershipArePreserved();
+        ReleaseAndAcquirePayloadsPreserveEndpointAffinity();
+        InvalidQueueTransferEndpointsFailWithoutMutation();
+        InvalidResourceRangeFailsWithoutMutation();
         LegacyBarrierRemainsCompatible();
         EmptyExplicitBarrierBatchFailsWithoutChangingOwnership();
         ExplicitBarrierOwnsAnExclusiveReorderLayer();
         TextureRangeOverlapMatchesAtomicExplicitTracking();
+        ReleaseSentinelOverlapUsesExactBufferAndTextureRanges();
     } catch (const std::exception& error) {
         std::cerr << "RHI explicit barrier contract failed: " << error.what()
                   << '\n';

--- a/source/test/RHIParallelRecordVulkanTest.cpp
+++ b/source/test/RHIParallelRecordVulkanTest.cpp
@@ -449,6 +449,341 @@ void RunActiveRdgExplicitBarrierReadback(bool _parallel) {
     );
 }
 
+void RunActiveRdgTransientAliasReadback(bool _parallel) {
+    constexpr uint64_t byte_size = sizeof(uint32) * kElementCount;
+    const RGTransientBufferDesc transient_desc{
+        .element_count = kElementCount,
+        .stride        = sizeof(uint32),
+        .usage         = EBufferUsageFlags::TRANSFER_SRC |
+                         EBufferUsageFlags::TRANSFER_DST,
+    };
+
+    std::array<uint32, kElementCount> first_values{};
+    std::array<uint32, kElementCount> expected{};
+    std::array<uint32, kElementCount> readback{};
+    for (uint32 index = 0; index < expected.size(); ++index) {
+        first_values[index] = 0xA1200000u + index * 19u;
+        expected[index]     = 0xA1300000u + index * 53u + 7u;
+    }
+
+    RenderGraphResourcePool       pool{};
+    RenderGraphTransientAllocator allocator(pool);
+    RenderGraph graph("ActiveRdgTransientAlias");
+    const auto first =
+        graph.CreateTransientBuffer("AliasFirst", transient_desc);
+    const auto second =
+        graph.CreateTransientBuffer("AliasSecond", transient_desc);
+
+    graph.AddRecordPass(
+        "WriteAliasFirst",
+        [=](RenderGraph::PassBuilder& builder) {
+            builder.ExecuteOn(
+                       RenderGraph::QueueRole::Graphics,
+                       RenderGraph::PipelineType::Copy
+                   )
+                .Write(
+                    first,
+                    RenderGraph::BufferState::TransferDestination
+                )
+                .SideEffect();
+        },
+        [&graph, first, first_values](CommandList& commands) {
+            const BufferRef physical = graph.GetPhysicalBuffer(first);
+            if (!physical.IsValid()) {
+                throw std::runtime_error(
+                    "first transient alias has no physical buffer"
+                );
+            }
+            commands.CopyFrom(
+                OwnedBytes(first_values),
+                physical->GetView(),
+                "ActiveRdgAliasFirstUpload"
+            );
+        },
+        RenderGraph::PassExecutionClass::ParallelRecordEligible
+    );
+    graph.AddRecordPass(
+        "WriteAliasSecond",
+        [=](RenderGraph::PassBuilder& builder) {
+            builder.ExecuteOn(
+                       RenderGraph::QueueRole::Graphics,
+                       RenderGraph::PipelineType::Copy
+                   )
+                .Write(
+                    second,
+                    RenderGraph::BufferState::TransferDestination
+                )
+                .SideEffect();
+        },
+        [&graph, second, expected](CommandList& commands) {
+            const BufferRef physical = graph.GetPhysicalBuffer(second);
+            if (!physical.IsValid()) {
+                throw std::runtime_error(
+                    "second transient alias has no physical buffer"
+                );
+            }
+            commands.CopyFrom(
+                OwnedBytes(expected),
+                physical->GetView(),
+                "ActiveRdgAliasSecondUpload"
+            );
+        },
+        RenderGraph::PassExecutionClass::ParallelRecordEligible
+    );
+    graph.AddRecordPass(
+        "ReadAliasSecond",
+        [=](RenderGraph::PassBuilder& builder) {
+            builder.ExecuteOn(
+                       RenderGraph::QueueRole::Graphics,
+                       RenderGraph::PipelineType::Copy
+                   )
+                .Read(
+                    second,
+                    RenderGraph::BufferState::TransferSource
+                )
+                .SideEffect();
+        },
+        [&graph, second, &readback](CommandList& commands) {
+            const BufferRef physical = graph.GetPhysicalBuffer(second);
+            if (!physical.IsValid()) {
+                throw std::runtime_error(
+                    "transient alias readback has no physical buffer"
+                );
+            }
+            commands.CopyFrom(
+                physical->GetView(),
+                WritableBytes(readback),
+                "ActiveRdgAliasReadback"
+            );
+        },
+        RenderGraph::PassExecutionClass::ParallelRecordEligible
+    );
+
+    if (!graph.Compile()) {
+        throw std::runtime_error(
+            "active RDG transient alias compile failed: " +
+            graph.GetCompileError()
+        );
+    }
+    const auto& plan = graph.GetCompiledPlan();
+    if (plan.resources[first.resource.index].transient_slot ==
+            RenderGraph::PassHandle::InvalidIndex ||
+        plan.resources[first.resource.index].transient_slot !=
+            plan.resources[second.resource.index].transient_slot ||
+        plan.alias_boundaries.size() != 1) {
+        throw std::runtime_error(
+            "active RDG transient alias compiler plan did not reuse one slot"
+        );
+    }
+    if (transient_desc.ByteSize() != byte_size) {
+        throw std::runtime_error("transient alias descriptor byte size mismatch");
+    }
+    if (!graph.ExecuteRecording(
+            {},
+            {},
+            _parallel,
+            {},
+            RenderGraph::ActiveRecordingOptions{
+                .enabled             = true,
+                .transient_allocator = &allocator,
+            }
+        )) {
+        throw std::runtime_error(
+            "active RDG transient alias execution failed: " +
+            graph.GetCompileError()
+        );
+    }
+    if (pool.BufferCount() != 1) {
+        throw std::runtime_error(
+            "active RDG transient aliases allocated more than one buffer"
+        );
+    }
+    RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
+
+    if (readback != expected) {
+        throw std::runtime_error(
+            "active RDG transient alias readback mismatch"
+        );
+    }
+    if (pool.AvailableBufferCount() != 1) {
+        throw std::runtime_error(
+            "active RDG transient alias allocation did not retire at Completion"
+        );
+    }
+    LOG_INFO(
+        "[TESTCASE][PASS] name=ActiveRdgTransientAlias mode={} "
+        "passes=3 slots=1 buffers=1 state_owner=rdg readback=verified",
+        _parallel ? "parallel" : "serial"
+    );
+}
+
+void RunActiveRdgTransientTextureAliasReadback(bool _parallel) {
+    constexpr uint32 kWidth      = 4;
+    constexpr uint32 kHeight     = 4;
+    constexpr uint32 kTexelCount = kWidth * kHeight;
+    const RGTransientTextureDesc transient_desc{
+        .dimension    = ETextureDimension::TEX_2D,
+        .extent       = Extent3D(kWidth, kHeight, 1),
+        .format       = PF_R8G8B8A8_UNORM,
+        .usage        = ETextureUsageFlags::TRANSFER_SRC |
+                        ETextureUsageFlags::TRANSFER_DST,
+        .aspect_flags = ETextureAspectFlags::COLOR,
+        .mip_count    = 1,
+        .array_size   = 1,
+    };
+
+    std::array<uint32, kTexelCount> first_values{};
+    std::array<uint32, kTexelCount> expected{};
+    std::array<uint32, kTexelCount> readback{};
+    for (uint32 index = 0; index < kTexelCount; ++index) {
+        first_values[index] = 0xFF102030u + index;
+        expected[index]     = 0xFF405060u + index * 0x00010101u;
+    }
+
+    RenderGraphResourcePool       pool{};
+    RenderGraphTransientAllocator allocator(pool);
+    RenderGraph graph("ActiveRdgTransientTextureAlias");
+    const auto first =
+        graph.CreateTransientTexture("TextureAliasFirst", transient_desc);
+    const auto second =
+        graph.CreateTransientTexture("TextureAliasSecond", transient_desc);
+    graph.AddRecordPass(
+        "WriteTextureAliasFirst",
+        [=](RenderGraph::PassBuilder& builder) {
+            builder.ExecuteOn(
+                       RenderGraph::QueueRole::Graphics,
+                       RenderGraph::PipelineType::Copy
+                   )
+                .Write(
+                    first,
+                    RenderGraph::TextureState::TransferDestination
+                )
+                .SideEffect();
+        },
+        [&graph, first, first_values](CommandList& commands) {
+            const TextureRef physical = graph.GetPhysicalTexture(first);
+            if (!physical.IsValid()) {
+                throw std::runtime_error(
+                    "first transient texture alias has no physical texture"
+                );
+            }
+            commands.CopyFrom(
+                OwnedBytes(first_values),
+                physical->GetView(),
+                "ActiveRdgTextureAliasFirstUpload"
+            );
+        },
+        RenderGraph::PassExecutionClass::ParallelRecordEligible
+    );
+    graph.AddRecordPass(
+        "WriteTextureAliasSecond",
+        [=](RenderGraph::PassBuilder& builder) {
+            builder.ExecuteOn(
+                       RenderGraph::QueueRole::Graphics,
+                       RenderGraph::PipelineType::Copy
+                   )
+                .Write(
+                    second,
+                    RenderGraph::TextureState::TransferDestination
+                )
+                .SideEffect();
+        },
+        [&graph, second, expected](CommandList& commands) {
+            const TextureRef physical = graph.GetPhysicalTexture(second);
+            if (!physical.IsValid()) {
+                throw std::runtime_error(
+                    "second transient texture alias has no physical texture"
+                );
+            }
+            commands.CopyFrom(
+                OwnedBytes(expected),
+                physical->GetView(),
+                "ActiveRdgTextureAliasSecondUpload"
+            );
+        },
+        RenderGraph::PassExecutionClass::ParallelRecordEligible
+    );
+    graph.AddRecordPass(
+        "ReadTextureAliasSecond",
+        [=](RenderGraph::PassBuilder& builder) {
+            builder.ExecuteOn(
+                       RenderGraph::QueueRole::Graphics,
+                       RenderGraph::PipelineType::Copy
+                   )
+                .Read(
+                    second,
+                    RenderGraph::TextureState::TransferSource
+                )
+                .SideEffect();
+        },
+        [&graph, second, &readback](CommandList& commands) {
+            const TextureRef physical = graph.GetPhysicalTexture(second);
+            if (!physical.IsValid()) {
+                throw std::runtime_error(
+                    "transient texture alias readback has no physical texture"
+                );
+            }
+            commands.CopyFrom(
+                physical->GetView(),
+                WritableBytes(readback),
+                "ActiveRdgTextureAliasReadback"
+            );
+        },
+        RenderGraph::PassExecutionClass::ParallelRecordEligible
+    );
+
+    if (!graph.Compile()) {
+        throw std::runtime_error(
+            "active RDG transient texture alias compile failed: " +
+            graph.GetCompileError()
+        );
+    }
+    const auto& plan = graph.GetCompiledPlan();
+    if (plan.resources[first.resource.index].transient_slot !=
+            plan.resources[second.resource.index].transient_slot ||
+        plan.alias_boundaries.size() != 1) {
+        throw std::runtime_error(
+            "active RDG transient texture alias did not reuse one slot"
+        );
+    }
+    if (!graph.ExecuteRecording(
+            {},
+            {},
+            _parallel,
+            {},
+            RenderGraph::ActiveRecordingOptions{
+                .enabled             = true,
+                .transient_allocator = &allocator,
+            }
+        )) {
+        throw std::runtime_error(
+            "active RDG transient texture alias execution failed: " +
+            graph.GetCompileError()
+        );
+    }
+    if (pool.TextureCount() != 1) {
+        throw std::runtime_error(
+            "active RDG transient texture aliases allocated more than one texture"
+        );
+    }
+    RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
+    if (readback != expected) {
+        throw std::runtime_error(
+            "active RDG transient texture alias readback mismatch"
+        );
+    }
+    if (pool.AvailableTextureCount() != 1) {
+        throw std::runtime_error(
+            "active RDG transient texture alias did not retire at Completion"
+        );
+    }
+    LOG_INFO(
+        "[TESTCASE][PASS] name=ActiveRdgTransientTextureAlias mode={} "
+        "passes=3 slots=1 textures=1 state_owner=rdg readback=verified",
+        _parallel ? "parallel" : "serial"
+    );
+}
+
 void RunActiveRdgTextureArraySubrange(bool _parallel) {
     auto& device = RenderDevice::Get();
     constexpr uint32 kLayerCount = 4;
@@ -1488,6 +1823,31 @@ void RunShutdownDependencyCancellation() {
     );
 }
 
+void PrimeGlobalTransientPoolForDispose() {
+    auto& pool = RenderGraphResourcePool::Global();
+    pool.Reset();
+    const RGTransientBufferDesc desc{
+        .element_count = kElementCount,
+        .stride        = sizeof(uint32),
+        .usage         = EBufferUsageFlags::TRANSFER_SRC |
+                         EBufferUsageFlags::TRANSFER_DST,
+    };
+    {
+        BufferRef resource =
+            pool.AcquireBuffer("dispose_transient_pool_probe", desc);
+        if (!resource.IsValid()) {
+            throw std::runtime_error(
+                "global transient pool dispose probe allocation failed"
+            );
+        }
+    }
+    if (pool.BufferCount() != 1 || pool.AvailableBufferCount() != 1) {
+        throw std::runtime_error(
+            "global transient pool dispose probe did not become idle"
+        );
+    }
+}
+
 } // namespace
 
 int main(int argc, const char** argv) {
@@ -1525,6 +1885,8 @@ int main(int argc, const char** argv) {
             parallel, inject_worker_failure, production_gate, production_heavy
         );
         RunActiveRdgExplicitBarrierReadback(parallel);
+        RunActiveRdgTransientAliasReadback(parallel);
+        RunActiveRdgTransientTextureAliasReadback(parallel);
         RunActiveRdgTextureArraySubrange(parallel);
         RunExplicitTextureArrayRangeShapeChange(parallel);
         RunUpperTopologyBatch();
@@ -1533,11 +1895,22 @@ int main(int argc, const char** argv) {
         RunRecoverableCopyDependencyRejection();
         RunCrossQueueTopologyBatch();
         RunRuntimeRejectCompletionOwnership();
+        PrimeGlobalTransientPoolForDispose();
         // This explicitly stops the runtime and must remain the final test
         // before device disposal.
         RunShutdownDependencyCancellation();
 
         RenderDevice::Dispose();
+        if (RenderGraphResourcePool::Global().BufferCount() != 0 ||
+            RenderGraphResourcePool::Global().TextureCount() != 0) {
+            throw std::runtime_error(
+                "RenderDevice::Dispose did not reset the global transient pool"
+            );
+        }
+        LOG_INFO(
+            "[TESTCASE][PASS] name=TransientPoolDeviceDispose "
+            "shutdown_order=executor,pool,backend cached_resources=0"
+        );
         render_device_initialized = false;
         TaskSystem::ShutDown();
         task_system_initialized = false;

--- a/source/test/RHIParallelRecordVulkanTest.cpp
+++ b/source/test/RHIParallelRecordVulkanTest.cpp
@@ -1,6 +1,7 @@
 #include "Core.h"
 #include "config/ConfigManager.h"
 #include "log/LogSystem.h"
+#include "rendergraph/RenderGraph.h"
 #include "rhi/RHI.h"
 #include "rhi/RHICommand.h"
 #include "rhi/RHIExecutor.h"
@@ -296,6 +297,309 @@ void RunOrderedReadback(
         _production_gate,
         _production_heavy,
         kIterations
+    );
+}
+
+void RunActiveRdgExplicitBarrierReadback(bool _parallel) {
+    auto& device = RenderDevice::Get();
+    const EBufferUsageFlags usage =
+        EBufferUsageFlags::TRANSFER_SRC | EBufferUsageFlags::TRANSFER_DST;
+    constexpr uint64_t byte_size = sizeof(uint32) * kElementCount;
+
+    BufferRef source =
+        device.CreateBuffer<uint32>("active_rdg_source", kElementCount, usage);
+    BufferRef destination =
+        device.CreateBuffer<uint32>("active_rdg_destination", kElementCount, usage);
+
+    std::array<uint32, kElementCount> values{};
+    std::array<uint32, kElementCount> readback{};
+    for (uint32 index = 0; index < values.size(); ++index) {
+        values[index] = 0xA1100000u + index * 37u + 11u;
+    }
+
+    RenderGraph graph("ActiveRdgExplicitBarrier");
+    const auto source_handle = graph.ImportBuffer(
+        "Source",
+        source,
+        RenderGraph::BufferDesc{.byte_size = byte_size}
+    );
+    const auto destination_handle = graph.ImportBuffer(
+        "Destination",
+        destination,
+        RenderGraph::BufferDesc{.byte_size = byte_size}
+    );
+    graph.SetInitialState(
+        source_handle,
+        RenderGraph::BufferState::Undefined,
+        RenderGraph::QueueRole::None,
+        RenderGraph::AccessMode::None
+    );
+    graph.SetInitialState(
+        destination_handle,
+        RenderGraph::BufferState::Undefined,
+        RenderGraph::QueueRole::None,
+        RenderGraph::AccessMode::None
+    );
+
+    graph.AddRecordPass(
+        "Upload",
+        [=](RenderGraph::PassBuilder& builder) {
+            builder.ExecuteOn(
+                       RenderGraph::QueueRole::Graphics,
+                       RenderGraph::PipelineType::Copy
+                   )
+                .Write(
+                    source_handle,
+                    RenderGraph::BufferState::TransferDestination
+                )
+                .SideEffect();
+        },
+        [source, values](CommandList& commands) {
+            commands.CopyFrom(
+                OwnedBytes(values), source->GetView(), "ActiveRdgUpload"
+            );
+        },
+        RenderGraph::PassExecutionClass::ParallelRecordEligible
+    );
+    graph.AddRecordPass(
+        "Copy",
+        [=](RenderGraph::PassBuilder& builder) {
+            builder.ExecuteOn(
+                       RenderGraph::QueueRole::Graphics,
+                       RenderGraph::PipelineType::Copy
+                   )
+                .Read(source_handle, RenderGraph::BufferState::TransferSource)
+                .Write(
+                    destination_handle,
+                    RenderGraph::BufferState::TransferDestination
+                )
+                .SideEffect();
+        },
+        [source, destination](CommandList& commands) {
+            commands.CopyFrom(
+                source->GetView(),
+                destination->GetView(),
+                "ActiveRdgBufferCopy"
+            );
+        },
+        RenderGraph::PassExecutionClass::ParallelRecordEligible
+    );
+    graph.AddRecordPass(
+        "Readback",
+        [=](RenderGraph::PassBuilder& builder) {
+            builder.ExecuteOn(
+                       RenderGraph::QueueRole::Graphics,
+                       RenderGraph::PipelineType::Copy
+                   )
+                .Read(
+                    destination_handle,
+                    RenderGraph::BufferState::TransferSource
+                )
+                .SideEffect();
+        },
+        [destination, &readback](CommandList& commands) {
+            commands.CopyFrom(
+                destination->GetView(),
+                WritableBytes(readback),
+                "ActiveRdgReadback"
+            );
+        },
+        RenderGraph::PassExecutionClass::ParallelRecordEligible
+    );
+    graph.Export(
+        source_handle,
+        RenderGraph::BufferState::TransferSource,
+        RenderGraph::QueueRole::Graphics,
+        RenderGraph::AccessMode::Read
+    );
+    graph.Export(
+        destination_handle,
+        RenderGraph::BufferState::TransferSource,
+        RenderGraph::QueueRole::Graphics,
+        RenderGraph::AccessMode::Read
+    );
+
+    if (!graph.Compile()) {
+        throw std::runtime_error(
+            "active RDG compile failed: " + graph.GetCompileError()
+        );
+    }
+    if (!graph.ExecuteRecording(
+            {},
+            {},
+            _parallel,
+            {},
+            RenderGraph::ActiveRecordingOptions{.enabled = true}
+        )) {
+        throw std::runtime_error(
+            "active RDG execution failed: " + graph.GetCompileError()
+        );
+    }
+    RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
+
+    if (readback != values) {
+        throw std::runtime_error(
+            "active RDG explicit barrier readback mismatch"
+        );
+    }
+    LOG_INFO(
+        "[TESTCASE][PASS] name=ActiveRdgExplicitBarrier mode={} "
+        "passes=3 state_owner=rdg readback=verified",
+        _parallel ? "parallel" : "serial"
+    );
+}
+
+void RunActiveRdgTextureArraySubrange(bool _parallel) {
+    auto& device = RenderDevice::Get();
+    constexpr uint32 kLayerCount = 4;
+    constexpr uint32 kFirstLayer = 1;
+    constexpr uint32 kTestLayerCount = 2;
+    TextureRef texture = device.CreateTexture(
+        "active_rdg_array_subrange",
+        Extent3D(8, 8, 1),
+        PF_R8G8B8A8_UNORM,
+        ETextureUsageFlags::TRANSFER_DST | ETextureUsageFlags::TRANSFER_SRC,
+        1,
+        kLayerCount
+    );
+
+    RenderGraph graph("ActiveRdgTextureArraySubrange");
+    const auto texture_handle = graph.ImportTexture(
+        "ArrayTexture",
+        texture,
+        RenderGraph::TextureDesc{
+            .mip_count   = 1,
+            .layer_count = kLayerCount,
+            .aspects     = RenderGraph::TextureAspect::Color,
+        }
+    );
+    auto range =
+        RenderGraph::TextureRange::Layers(kFirstLayer, kTestLayerCount);
+    range.aspects = RenderGraph::TextureAspect::Color;
+    graph.SetInitialState(
+        texture_handle,
+        RenderGraph::TextureState::Undefined,
+        RenderGraph::QueueRole::None,
+        RenderGraph::AccessMode::None,
+        range
+    );
+    graph.AddRecordPass(
+        "ClearArrayLayers",
+        [=](RenderGraph::PassBuilder& builder) {
+            builder.ExecuteOn(
+                       RenderGraph::QueueRole::Graphics,
+                       RenderGraph::PipelineType::Copy
+                   )
+                .Write(
+                    texture_handle,
+                    RenderGraph::TextureState::TransferDestination,
+                    range
+                )
+                .SideEffect();
+        },
+        [texture](CommandList& commands) {
+            commands.ClearResource(
+                texture->GetView().Slice(kFirstLayer, kTestLayerCount),
+                float4{0.125f, 0.25f, 0.5f, 1.0f}
+            );
+        },
+        RenderGraph::PassExecutionClass::ParallelRecordEligible
+    );
+    graph.Export(
+        texture_handle,
+        RenderGraph::TextureState::TransferDestination,
+        RenderGraph::QueueRole::Graphics,
+        RenderGraph::AccessMode::Write,
+        range
+    );
+
+    if (!graph.Compile()) {
+        throw std::runtime_error(
+            "active RDG texture array compile failed: " + graph.GetCompileError()
+        );
+    }
+    if (!graph.ExecuteRecording(
+            {},
+            {},
+            _parallel,
+            {},
+            RenderGraph::ActiveRecordingOptions{.enabled = true}
+        )) {
+        throw std::runtime_error(
+            "active RDG texture array execution failed: " + graph.GetCompileError()
+        );
+    }
+    RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
+
+    LOG_INFO(
+        "[TESTCASE][PASS] name=ActiveRdgTextureArraySubrange mode={} "
+        "layers={}+{} state_owner=rdg",
+        _parallel ? "parallel" : "serial",
+        kFirstLayer,
+        kTestLayerCount
+    );
+}
+
+void RunExplicitTextureArrayRangeShapeChange(bool _parallel) {
+    auto& device = RenderDevice::Get();
+    constexpr uint32 kLayerCount = 4;
+    constexpr uint32 kFirstLayer = 1;
+    constexpr uint32 kSubsetLayerCount = 2;
+    TextureRef texture = device.CreateTexture(
+        "explicit_array_shape_change",
+        Extent3D(8, 8, 1),
+        PF_R8G8B8A8_UNORM,
+        ETextureUsageFlags::TRANSFER_DST,
+        1,
+        kLayerCount
+    );
+    const TextureView whole = texture->GetView().Slice(0, kLayerCount);
+    const TextureView subset =
+        texture->GetView().Slice(kFirstLayer, kSubsetLayerCount);
+    const BarrierState undefined = BarrierState::Texture(
+        ERHIPipelineStageFlags::PS_TOP_OF_PIPE,
+        ERHIAccessFlags::UNDEFINED,
+        ETextureLayout::TEXTURE_LAYOUT_UNDEFINED
+    );
+    const BarrierState transfer_destination = BarrierState::Texture(
+        ERHIPipelineStageFlags::PS_TRANSFER,
+        ERHIAccessFlags::TRANSFER_WRITE,
+        ETextureLayout::TEXTURE_LAYOUT_TRANSFER_DST
+    );
+
+    CommandList commands(EQueueType::Graphics);
+    commands.Barriers({
+        BarrierCreateInfo::Transition(
+            whole,
+            undefined,
+            transfer_destination,
+            ETextureAspectFlags::COLOR
+        ),
+    });
+    commands.ClearResource(whole, float4{0.125f, 0.25f, 0.5f, 1.0f});
+    commands.Barriers({
+        BarrierCreateInfo::Transition(
+            subset,
+            transfer_destination,
+            transfer_destination,
+            ETextureAspectFlags::COLOR
+        ),
+    });
+    commands.ClearResource(subset, float4{0.75f, 0.5f, 0.25f, 1.0f});
+    RHIExecutor::Get().Submit(
+        EQueueType::Graphics,
+        commands.Submit(),
+        ERHIExecSubmitFlags::FlushGPU
+    );
+    RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
+
+    LOG_INFO(
+        "[TESTCASE][PASS] name=ExplicitTextureArrayRangeShapeChange mode={} "
+        "shape=0+{}->{}+{} state_owner=explicit",
+        _parallel ? "parallel" : "serial",
+        kLayerCount,
+        kFirstLayer,
+        kSubsetLayerCount
     );
 }
 
@@ -1220,6 +1524,9 @@ int main(int argc, const char** argv) {
         RunOrderedReadback(
             parallel, inject_worker_failure, production_gate, production_heavy
         );
+        RunActiveRdgExplicitBarrierReadback(parallel);
+        RunActiveRdgTextureArraySubrange(parallel);
+        RunExplicitTextureArrayRangeShapeChange(parallel);
         RunUpperTopologyBatch();
         RunPendingSourceTopologyBatch();
         RunContinuousFrameInFlightRetirement();

--- a/source/test/RHIParallelRecordVulkanTest.cpp
+++ b/source/test/RHIParallelRecordVulkanTest.cpp
@@ -2059,6 +2059,54 @@ void RunActiveRdgTransientTextureAliasReadback(bool _parallel) {
     );
 }
 
+void RunTransientDepthStencilAspectAllocation() {
+    TextureRef legacy = RenderDevice::Get().CreateTexture(
+        "LegacyDepthStencilDefaultAspect",
+        Extent3D(8, 8, 1),
+        PF_D32_SFLOAT_S8_UINT,
+        ETextureUsageFlags::SAMPLED |
+            ETextureUsageFlags::DEPTH_STENCIL_ATTACHMENT
+    );
+    if (!legacy.IsValid() ||
+        legacy->GetAspectFlags() != ETextureAspectFlags::DEPTH_SLICE) {
+        throw std::runtime_error(
+            "legacy depth-stencil texture no longer defaults to a depth-only view"
+        );
+    }
+    legacy = {};
+
+    const RGTransientTextureDesc desc{
+        .dimension = ETextureDimension::TEX_2D,
+        .extent    = Extent3D(8, 8, 1),
+        .format    = PF_D32_SFLOAT_S8_UINT,
+        .usage     = ETextureUsageFlags::DEPTH_STENCIL_ATTACHMENT,
+        .aspect_flags =
+            ETextureAspectFlags::DEPTH_SLICE |
+            ETextureAspectFlags::STENCIL_SLICE,
+        .mip_count  = 1,
+        .array_size = 1,
+    };
+
+    RenderGraphResourcePool pool{};
+    TextureRef texture =
+        pool.AcquireTexture("TransientDepthStencilAspect", desc);
+    if (!texture.IsValid() || texture->GetAspectFlags() != desc.aspect_flags) {
+        throw std::runtime_error(
+            "transient depth-stencil allocation lost a physical aspect"
+        );
+    }
+    texture = {};
+    if (pool.AvailableTextureCount() != 1) {
+        throw std::runtime_error(
+            "transient depth-stencil allocation did not return to the pool"
+        );
+    }
+    LOG_INFO(
+        "[TESTCASE][PASS] name=TransientDepthStencilAspectAllocation "
+        "format=D32S8 transient=depth,stencil legacy=depth factory=default"
+    );
+}
+
 void RunActiveRdgTextureArraySubrange(bool _parallel) {
     auto& device = RenderDevice::Get();
     constexpr uint32 kLayerCount = 4;
@@ -3164,6 +3212,7 @@ int main(int argc, const char** argv) {
         RunActiveRdgGraphicsCopyRoundTrip(parallel);
         RunActiveRdgTransientAliasReadback(parallel);
         RunActiveRdgTransientTextureAliasReadback(parallel);
+        RunTransientDepthStencilAspectAllocation();
         RunActiveRdgTextureArraySubrange(parallel);
         RunExplicitTextureArrayRangeShapeChange(parallel);
         RunUpperTopologyBatch();

--- a/source/test/RHIParallelRecordVulkanTest.cpp
+++ b/source/test/RHIParallelRecordVulkanTest.cpp
@@ -2,6 +2,7 @@
 #include "config/ConfigManager.h"
 #include "log/LogSystem.h"
 #include "rendergraph/RenderGraph.h"
+#include "rendergraph/RenderGraphLowering.h"
 #include "rhi/RHI.h"
 #include "rhi/RHICommand.h"
 #include "rhi/RHIExecutor.h"
@@ -11,6 +12,7 @@
 #include "rhi/vulkan/VulkanRHIResource.h"
 #include "taskgraph/TaskSystem.h"
 
+#include <algorithm>
 #include <atomic>
 #include <array>
 #include <chrono>
@@ -456,6 +458,8 @@ void RunActiveRdgAsyncQueueDag(bool _parallel) {
         topology.graphics.native_queue_id != topology.compute.native_queue_id;
     const bool same_queue_family =
         topology.graphics.family_id == topology.compute.family_id;
+    const bool graphics_compute_available =
+        topology.graphics.available && topology.compute.available;
     if (dedicated_compute) {
         RenderGraph stale_topology_graph("ActiveRdgRejectStaleTopology");
         const auto graphics_done =
@@ -805,17 +809,17 @@ void RunActiveRdgAsyncQueueDag(bool _parallel) {
         );
     }
 
-    if (dedicated_compute && same_queue_family) {
+    if (graphics_compute_available && dedicated_compute) {
         QueueBuffer shared_source{
             .buffer = device.CreateBuffer<uint32>(
-                "active_rdg_same_family_shared_source",
+                "active_rdg_distinct_native_shared_source",
                 kElementCount,
                 usage
             ),
         };
         QueueBuffer shared_destination{
             .buffer = device.CreateBuffer<uint32>(
-                "active_rdg_same_family_shared_destination",
+                "active_rdg_distinct_native_shared_destination",
                 kElementCount,
                 usage
             ),
@@ -827,7 +831,7 @@ void RunActiveRdgAsyncQueueDag(bool _parallel) {
         shared_destination.values = shared_source.values;
 
         RenderGraph physical_graph(
-            "ActiveRdgSameFamilyPhysicalRaw", topology
+            "ActiveRdgDistinctNativePhysicalRaw", topology
         );
         const auto source_handle = physical_graph.ImportBuffer(
             "SharedSource",
@@ -847,7 +851,7 @@ void RunActiveRdgAsyncQueueDag(bool _parallel) {
                 RenderGraph::AccessMode::None
             );
         }
-        physical_graph.AddRecordPass(
+        const auto graphics_write_pass = physical_graph.AddRecordPass(
             "GraphicsWriteShared",
             [=](RenderGraph::PassBuilder& builder) {
                 builder.ExecuteOn(
@@ -864,12 +868,12 @@ void RunActiveRdgAsyncQueueDag(bool _parallel) {
                 commands.CopyFrom(
                     OwnedBytes(shared_source.values),
                     shared_source.buffer->GetView(),
-                    "ActiveRdgSameFamilyGraphicsWrite"
+                    "ActiveRdgDistinctNativeGraphicsWrite"
                 );
             },
             RenderGraph::PassExecutionClass::ParallelRecordEligible
         );
-        physical_graph.AddRecordPass(
+        const auto compute_read_pass = physical_graph.AddRecordPass(
             "ComputeReadShared",
             [=](RenderGraph::PassBuilder& builder) {
                 builder.ExecuteOn(
@@ -890,7 +894,7 @@ void RunActiveRdgAsyncQueueDag(bool _parallel) {
                 commands.CopyFrom(
                     shared_source.buffer->GetView(),
                     shared_destination.buffer->GetView(),
-                    "ActiveRdgSameFamilyComputeRead"
+                    "ActiveRdgDistinctNativeComputeRead"
                 );
             },
             RenderGraph::PassExecutionClass::ParallelRecordEligible
@@ -916,9 +920,115 @@ void RunActiveRdgAsyncQueueDag(bool _parallel) {
                 }
             )) {
             throw std::runtime_error(
-                "same-family physical RAW did not compile with a GPU sync: " +
+                "distinct-native physical RAW did not compile with a GPU sync: " +
                 physical_graph.GetCompileError()
             );
+        }
+        RenderGraphLowering::LoweredPlan lowered{};
+        std::string                     lowering_error{};
+        if (!RenderGraphLowering::Lower(
+                physical_graph, lowered, lowering_error
+            )) {
+            throw std::runtime_error(
+                "distinct-native physical RAW lowering failed: " +
+                lowering_error
+            );
+        }
+
+        const auto is_source_resource =
+            [source = source_handle.Untyped()](
+                const RenderGraphLowering::LoweredInstruction& instruction
+            ) {
+                return instruction.resource == source;
+            };
+        const auto before_compute = lowered.Before(compute_read_pass);
+        const auto after_graphics = lowered.After(graphics_write_pass);
+        if (same_queue_family) {
+            const auto local_acquire = std::find_if(
+                before_compute.begin(),
+                before_compute.end(),
+                [&](const RenderGraphLowering::LoweredInstruction& instruction) {
+                    return is_source_resource(instruction) &&
+                           instruction.instruction_kind ==
+                               RenderGraphLowering::InstructionKind::Barrier &&
+                           instruction.queue_acquire;
+                }
+            );
+            const bool has_ownership_half = std::any_of(
+                    after_graphics.begin(),
+                    after_graphics.end(),
+                    [](const RenderGraphLowering::LoweredInstruction& instruction) {
+                        return instruction.instruction_kind ==
+                               RenderGraphLowering::InstructionKind::QueueRelease;
+                    }
+                ) ||
+                std::any_of(
+                    before_compute.begin(),
+                    before_compute.end(),
+                    [](const RenderGraphLowering::LoweredInstruction& instruction) {
+                        return instruction.instruction_kind ==
+                               RenderGraphLowering::InstructionKind::QueueAcquire;
+                    }
+                );
+            if (local_acquire == before_compute.end() ||
+                has_ownership_half) {
+                throw std::runtime_error(
+                    "same-family physical RAW did not lower to one "
+                    "destination-local acquire"
+                );
+            }
+        } else {
+            const auto release = std::find_if(
+                after_graphics.begin(),
+                after_graphics.end(),
+                [&](const RenderGraphLowering::LoweredInstruction& instruction) {
+                    return is_source_resource(instruction) &&
+                           instruction.instruction_kind ==
+                               RenderGraphLowering::InstructionKind::QueueRelease;
+                }
+            );
+            const auto acquire = std::find_if(
+                before_compute.begin(),
+                before_compute.end(),
+                [&](const RenderGraphLowering::LoweredInstruction& instruction) {
+                    return is_source_resource(instruction) &&
+                           instruction.instruction_kind ==
+                               RenderGraphLowering::InstructionKind::QueueAcquire;
+                }
+            );
+            if (release == after_graphics.end() ||
+                acquire == before_compute.end() ||
+                release->barrier_index ==
+                    RenderGraphLowering::InvalidBarrierIndex ||
+                release->barrier_index != acquire->barrier_index ||
+                release->transfer_source != topology.graphics ||
+                release->transfer_destination != topology.compute ||
+                acquire->transfer_source != topology.graphics ||
+                acquire->transfer_destination != topology.compute) {
+                throw std::runtime_error(
+                    "distinct-family physical RAW did not lower to a matched "
+                    "Graphics-release/Compute-acquire pair"
+                );
+            }
+            const bool transfer_sync_correlated = std::any_of(
+                lowered.queue_syncs.begin(),
+                lowered.queue_syncs.end(),
+                [&](const RenderGraphLowering::QueueSyncInstruction& sync) {
+                    return sync.signal_queue == topology.graphics &&
+                           sync.wait_queue == topology.compute &&
+                           std::find(
+                               sync.ownership_transfer_barriers.begin(),
+                               sync.ownership_transfer_barriers.end(),
+                               release->barrier_index
+                           ) != sync.ownership_transfer_barriers.end();
+                }
+            );
+            if (!transfer_sync_correlated) {
+                throw std::runtime_error(
+                    "distinct-family physical RAW release/acquire pair is not "
+                    "correlated with its GPU queue sync"
+                );
+            }
         }
         if (!physical_graph.ExecuteRecording(
                 {},
@@ -928,7 +1038,7 @@ void RunActiveRdgAsyncQueueDag(bool _parallel) {
                 RenderGraph::ActiveRecordingOptions{.enabled = true}
             )) {
             throw std::runtime_error(
-                "same-family physical RAW active execution failed: " +
+                "distinct-native physical RAW active execution failed: " +
                 physical_graph.GetCompileError()
             );
         }
@@ -936,7 +1046,7 @@ void RunActiveRdgAsyncQueueDag(bool _parallel) {
         physical_readback.CopyFrom(
             shared_destination.buffer->GetView(),
             WritableBytes(shared_destination.readback),
-            "ActiveRdgSameFamilyPhysicalReadback"
+            "ActiveRdgDistinctNativePhysicalReadback"
         );
         RHIExecutor::Get().Submit(
             EQueueType::Compute,
@@ -946,18 +1056,21 @@ void RunActiveRdgAsyncQueueDag(bool _parallel) {
         RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
         if (shared_destination.readback != shared_destination.values) {
             throw std::runtime_error(
-                "same-family physical RAW readback mismatch"
+                "distinct-native physical RAW readback mismatch"
             );
         }
         LOG_INFO(
-            "[TESTCASE][PASS] name=ActiveRdgSameFamilyPhysicalRaw "
-            "producer=Graphics consumer=Compute barrier=acquire readback=verified"
+            "[TESTCASE][PASS] name=ActiveRdgDistinctNativePhysicalRaw "
+            "producer=Graphics consumer=Compute ownership={} readback=verified",
+            same_queue_family ? "local-acquire" : "release-acquire"
         );
     } else {
         LOG_INFO(
-            "[TESTCASE][SKIP] name=ActiveRdgSameFamilyPhysicalRaw "
-            "reason=queue_topology compute_native={} graphics_native={} "
+            "[TESTCASE][SKIP] name=ActiveRdgDistinctNativePhysicalRaw "
+            "reason={} compute_native={} graphics_native={} "
             "compute_family={} graphics_family={}",
+            graphics_compute_available ? "shared_native_queue" :
+                                         "queue_unavailable",
             topology.compute.native_queue_id,
             topology.graphics.native_queue_id,
             topology.compute.family_id,
@@ -1200,6 +1313,414 @@ void RunActiveRdgAsyncQueueDag(bool _parallel) {
         topology.compute.native_queue_id,
         topology.graphics.native_queue_id,
         has_gpu_sync
+    );
+}
+
+void RunActiveRdgGraphicsCopyRoundTrip(bool _parallel) {
+    auto&      device   = RenderDevice::Get();
+    const auto topology = RenderGraph::QueueTopology::FromRHI();
+    if (!topology.copy.available ||
+        topology.graphics.native_queue_id == topology.copy.native_queue_id) {
+        LOG_INFO(
+            "[TESTCASE][SKIP] name=ActiveRdgGraphicsCopyRoundTrip "
+            "reason={} graphics_native={} copy_native={} graphics_family={} "
+            "copy_family={}",
+            topology.copy.available ? "shared_native_queue" :
+                                      "copy_queue_unavailable",
+            topology.graphics.native_queue_id,
+            topology.copy.native_queue_id,
+            topology.graphics.family_id,
+            topology.copy.family_id
+        );
+        return;
+    }
+
+    constexpr uint64_t byte_size = sizeof(uint32) * kElementCount;
+    const EBufferUsageFlags usage =
+        EBufferUsageFlags::TRANSFER_SRC | EBufferUsageFlags::TRANSFER_DST;
+    BufferRef source = device.CreateBuffer<uint32>(
+        "active_rdg_graphics_copy_round_trip_source",
+        kElementCount,
+        usage
+    );
+    BufferRef intermediate = device.CreateBuffer<uint32>(
+        "active_rdg_graphics_copy_round_trip_intermediate",
+        kElementCount,
+        usage
+    );
+    BufferRef destination = device.CreateBuffer<uint32>(
+        "active_rdg_graphics_copy_round_trip_destination",
+        kElementCount,
+        usage
+    );
+    std::array<uint32, kElementCount> expected{};
+    std::array<uint32, kElementCount> readback{};
+    for (uint32 index = 0; index < expected.size(); ++index) {
+        expected[index] = 0xC7400000u + index * 73u + 29u;
+    }
+
+    RenderGraph graph("ActiveRdgGraphicsCopyRoundTrip", topology);
+    const auto source_handle = graph.ImportBuffer(
+        "RoundTripSource",
+        source,
+        RenderGraph::BufferDesc{
+            .byte_size    = byte_size,
+            .sharing_mode =
+                RenderGraph::TextureDesc::SharingMode::Exclusive,
+        }
+    );
+    const auto intermediate_handle = graph.ImportBuffer(
+        "RoundTripIntermediate",
+        intermediate,
+        RenderGraph::BufferDesc{
+            .byte_size    = byte_size,
+            .sharing_mode =
+                RenderGraph::TextureDesc::SharingMode::Exclusive,
+        }
+    );
+    const auto destination_handle = graph.ImportBuffer(
+        "RoundTripDestination",
+        destination,
+        RenderGraph::BufferDesc{
+            .byte_size    = byte_size,
+            .sharing_mode =
+                RenderGraph::TextureDesc::SharingMode::Exclusive,
+        }
+    );
+    for (const auto handle : {
+             source_handle,
+             intermediate_handle,
+             destination_handle,
+         }) {
+        graph.SetInitialState(
+            handle,
+            RenderGraph::BufferState::Undefined,
+            RenderGraph::QueueRole::None,
+            RenderGraph::AccessMode::None
+        );
+    }
+
+    const auto graphics_upload = graph.AddRecordPass(
+        "GraphicsUploadSource",
+        [=](RenderGraph::PassBuilder& builder) {
+            builder.ExecuteOn(
+                       RenderGraph::QueueRole::Graphics,
+                       RenderGraph::PipelineType::Copy
+                   )
+                .Write(
+                    source_handle,
+                    RenderGraph::BufferState::TransferDestination
+                )
+                .SideEffect();
+        },
+        [source, expected](CommandList& commands) {
+            commands.CopyFrom(
+                OwnedBytes(expected),
+                source->GetView(),
+                "ActiveRdgGraphicsCopyRoundTripUpload"
+            );
+        },
+        RenderGraph::PassExecutionClass::ParallelRecordEligible
+    );
+    const auto copy_to_intermediate = graph.AddRecordPass(
+        "CopyToIntermediate",
+        [=](RenderGraph::PassBuilder& builder) {
+            builder.ExecuteOn(
+                       RenderGraph::QueueRole::Copy,
+                       RenderGraph::PipelineType::Copy
+                   )
+                .Read(
+                    source_handle,
+                    RenderGraph::BufferState::TransferSource
+                )
+                .Write(
+                    intermediate_handle,
+                    RenderGraph::BufferState::TransferDestination
+                )
+                .SideEffect();
+        },
+        [source, intermediate](CommandList& commands) {
+            commands.CopyFrom(
+                source->GetView(),
+                intermediate->GetView(),
+                "ActiveRdgGraphicsCopyRoundTripToCopy"
+            );
+        },
+        RenderGraph::PassExecutionClass::ParallelRecordEligible
+    );
+    const auto graphics_copy_to_destination = graph.AddRecordPass(
+        "GraphicsCopyToDestination",
+        [=](RenderGraph::PassBuilder& builder) {
+            builder.ExecuteOn(
+                       RenderGraph::QueueRole::Graphics,
+                       RenderGraph::PipelineType::Copy
+                   )
+                .Read(
+                    intermediate_handle,
+                    RenderGraph::BufferState::TransferSource
+                )
+                .Write(
+                    destination_handle,
+                    RenderGraph::BufferState::TransferDestination
+                )
+                .SideEffect();
+        },
+        [intermediate, destination](CommandList& commands) {
+            commands.CopyFrom(
+                intermediate->GetView(),
+                destination->GetView(),
+                "ActiveRdgGraphicsCopyRoundTripToGraphics"
+            );
+        },
+        RenderGraph::PassExecutionClass::ParallelRecordEligible
+    );
+    graph.AddRecordPass(
+        "GraphicsReadback",
+        [=](RenderGraph::PassBuilder& builder) {
+            builder.ExecuteOn(
+                       RenderGraph::QueueRole::Graphics,
+                       RenderGraph::PipelineType::Copy
+                   )
+                .Read(
+                    destination_handle,
+                    RenderGraph::BufferState::TransferSource
+                )
+                .SideEffect();
+        },
+        [destination, &readback](CommandList& commands) {
+            commands.CopyFrom(
+                destination->GetView(),
+                WritableBytes(readback),
+                "ActiveRdgGraphicsCopyRoundTripReadback"
+            );
+        },
+        RenderGraph::PassExecutionClass::ParallelRecordEligible
+    );
+    graph.Export(
+        source_handle,
+        RenderGraph::BufferState::TransferSource,
+        RenderGraph::QueueRole::Copy,
+        RenderGraph::AccessMode::Read
+    );
+    graph.Export(
+        intermediate_handle,
+        RenderGraph::BufferState::TransferSource,
+        RenderGraph::QueueRole::Graphics,
+        RenderGraph::AccessMode::Read
+    );
+    graph.Export(
+        destination_handle,
+        RenderGraph::BufferState::TransferSource,
+        RenderGraph::QueueRole::Graphics,
+        RenderGraph::AccessMode::Read
+    );
+
+    if (!graph.Compile()) {
+        throw std::runtime_error(
+            "Graphics-Copy round trip compile failed: " +
+            graph.GetCompileError()
+        );
+    }
+    const size_t gpu_sync_count = std::count_if(
+        graph.GetCompiledPlan().queue_syncs.begin(),
+        graph.GetCompiledPlan().queue_syncs.end(),
+        [](const RenderGraph::CompiledQueueSync& sync) {
+            return sync.gpu_wait_required;
+        }
+    );
+    if (gpu_sync_count != 2) {
+        throw std::runtime_error(
+            "Graphics-Copy round trip did not compile exactly two native "
+            "queue synchronization points"
+        );
+    }
+
+    RenderGraphLowering::LoweredPlan lowered{};
+    std::string                     lowering_error{};
+    if (!RenderGraphLowering::Lower(graph, lowered, lowering_error)) {
+        throw std::runtime_error(
+            "Graphics-Copy round trip lowering failed: " + lowering_error
+        );
+    }
+    const bool same_queue_family =
+        topology.graphics.family_id == topology.copy.family_id;
+    const auto validate_boundary =
+        [&](std::string_view             label,
+            RenderGraph::BufferHandle    resource,
+            RenderGraph::PassHandle      producer,
+            RenderGraph::PassHandle      consumer,
+            RenderGraph::QueueBinding    source_queue,
+            RenderGraph::QueueBinding    destination_queue) {
+            const auto after_producer  = lowered.After(producer);
+            const auto before_consumer = lowered.Before(consumer);
+            const auto matches_resource =
+                [resource = resource.Untyped()](
+                    const RenderGraphLowering::LoweredInstruction& instruction
+                ) {
+                    return instruction.resource == resource;
+                };
+            const auto count_kind =
+                [&](auto instructions,
+                    RenderGraphLowering::InstructionKind kind) {
+                    return std::count_if(
+                        instructions.begin(),
+                        instructions.end(),
+                        [&](const RenderGraphLowering::LoweredInstruction&
+                                instruction) {
+                            return matches_resource(instruction) &&
+                                   instruction.instruction_kind == kind;
+                        }
+                    );
+                };
+
+            if (same_queue_family) {
+                const auto local_acquire = std::find_if(
+                    before_consumer.begin(),
+                    before_consumer.end(),
+                    [&](const RenderGraphLowering::LoweredInstruction&
+                            instruction) {
+                        return matches_resource(instruction) &&
+                               instruction.instruction_kind ==
+                                   RenderGraphLowering::InstructionKind::Barrier &&
+                               instruction.queue_acquire;
+                    }
+                );
+                const size_t local_acquire_count = std::count_if(
+                    before_consumer.begin(),
+                    before_consumer.end(),
+                    [&](const RenderGraphLowering::LoweredInstruction&
+                            instruction) {
+                        return matches_resource(instruction) &&
+                               instruction.instruction_kind ==
+                                   RenderGraphLowering::InstructionKind::Barrier &&
+                               instruction.queue_acquire;
+                    }
+                );
+                if (local_acquire_count != 1 ||
+                    count_kind(
+                        after_producer,
+                        RenderGraphLowering::InstructionKind::QueueRelease
+                    ) != 0 ||
+                    count_kind(
+                        before_consumer,
+                        RenderGraphLowering::InstructionKind::QueueAcquire
+                    ) != 0 ||
+                    local_acquire->source.stages !=
+                        ERHIPipelineStageFlags::PS_NONE ||
+                    local_acquire->source.access !=
+                        ERHIAccessFlags::UNDEFINED) {
+                    throw std::runtime_error(
+                        std::string(label) +
+                        " did not lower to a destination-local acquire"
+                    );
+                }
+                return;
+            }
+
+            const auto release = std::find_if(
+                after_producer.begin(),
+                after_producer.end(),
+                [&](const RenderGraphLowering::LoweredInstruction&
+                        instruction) {
+                    return matches_resource(instruction) &&
+                           instruction.instruction_kind ==
+                               RenderGraphLowering::InstructionKind::
+                                   QueueRelease;
+                }
+            );
+            const auto acquire = std::find_if(
+                before_consumer.begin(),
+                before_consumer.end(),
+                [&](const RenderGraphLowering::LoweredInstruction&
+                        instruction) {
+                    return matches_resource(instruction) &&
+                           instruction.instruction_kind ==
+                               RenderGraphLowering::InstructionKind::
+                                   QueueAcquire;
+                }
+            );
+            if (count_kind(
+                    after_producer,
+                    RenderGraphLowering::InstructionKind::QueueRelease
+                ) != 1 ||
+                count_kind(
+                    before_consumer,
+                    RenderGraphLowering::InstructionKind::QueueAcquire
+                ) != 1 ||
+                release == after_producer.end() ||
+                acquire == before_consumer.end() ||
+                release->barrier_index ==
+                    RenderGraphLowering::InvalidBarrierIndex ||
+                release->barrier_index != acquire->barrier_index ||
+                release->transfer_source != source_queue ||
+                release->transfer_destination != destination_queue ||
+                acquire->transfer_source != source_queue ||
+                acquire->transfer_destination != destination_queue) {
+                throw std::runtime_error(
+                    std::string(label) +
+                    " did not lower to one matched release/acquire pair"
+                );
+            }
+            const size_t correlated_sync_count = std::count_if(
+                lowered.queue_syncs.begin(),
+                lowered.queue_syncs.end(),
+                [&](const RenderGraphLowering::QueueSyncInstruction& sync) {
+                    return sync.signal_queue == source_queue &&
+                           sync.wait_queue == destination_queue &&
+                           std::find(
+                               sync.ownership_transfer_barriers.begin(),
+                               sync.ownership_transfer_barriers.end(),
+                               release->barrier_index
+                           ) != sync.ownership_transfer_barriers.end();
+                    }
+            );
+            if (correlated_sync_count != 1) {
+                throw std::runtime_error(
+                    std::string(label) +
+                    " release/acquire pair is not correlated with its GPU sync"
+                );
+            }
+        };
+    validate_boundary(
+        "Graphics-to-Copy source transfer",
+        source_handle,
+        graphics_upload,
+        copy_to_intermediate,
+        topology.graphics,
+        topology.copy
+    );
+    validate_boundary(
+        "Copy-to-Graphics intermediate transfer",
+        intermediate_handle,
+        copy_to_intermediate,
+        graphics_copy_to_destination,
+        topology.copy,
+        topology.graphics
+    );
+
+    if (!graph.ExecuteRecording(
+            {},
+            {},
+            _parallel,
+            {},
+            RenderGraph::ActiveRecordingOptions{.enabled = true}
+        )) {
+        throw std::runtime_error(
+            "Graphics-Copy round trip active execution failed: " +
+            graph.GetCompileError()
+        );
+    }
+    RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
+    if (readback != expected) {
+        throw std::runtime_error(
+            "Graphics-Copy round trip readback mismatch"
+        );
+    }
+    LOG_INFO(
+        "[TESTCASE][PASS] name=ActiveRdgGraphicsCopyRoundTrip mode={} "
+        "ownership={} transfers=2 readback=verified",
+        _parallel ? "parallel" : "serial",
+        same_queue_family ? "local-acquire" : "release-acquire"
     );
 }
 
@@ -2640,6 +3161,7 @@ int main(int argc, const char** argv) {
         );
         RunActiveRdgExplicitBarrierReadback(parallel);
         RunActiveRdgAsyncQueueDag(parallel);
+        RunActiveRdgGraphicsCopyRoundTrip(parallel);
         RunActiveRdgTransientAliasReadback(parallel);
         RunActiveRdgTransientTextureAliasReadback(parallel);
         RunActiveRdgTextureArraySubrange(parallel);

--- a/source/test/RHIParallelRecordVulkanTest.cpp
+++ b/source/test/RHIParallelRecordVulkanTest.cpp
@@ -449,6 +449,760 @@ void RunActiveRdgExplicitBarrierReadback(bool _parallel) {
     );
 }
 
+void RunActiveRdgAsyncQueueDag(bool _parallel) {
+    auto& device = RenderDevice::Get();
+    const auto topology = RenderGraph::QueueTopology::FromRHI();
+    const bool dedicated_compute =
+        topology.graphics.native_queue_id != topology.compute.native_queue_id;
+    const bool same_queue_family =
+        topology.graphics.family_id == topology.compute.family_id;
+    if (dedicated_compute) {
+        RenderGraph stale_topology_graph("ActiveRdgRejectStaleTopology");
+        const auto graphics_done =
+            stale_topology_graph.CreateTransientToken("GraphicsDone");
+        stale_topology_graph.AddRecordPass(
+            "Graphics",
+            [=](RenderGraph::PassBuilder& builder) {
+                builder.ExecuteOn(
+                           RenderGraph::QueueRole::Graphics,
+                           RenderGraph::PipelineType::Copy
+                       )
+                    .Write(graphics_done)
+                    .SideEffect();
+            },
+            [](CommandList&) {},
+            RenderGraph::PassExecutionClass::ParallelRecordEligible
+        );
+        stale_topology_graph.AddRecordPass(
+            "Compute",
+            [=](RenderGraph::PassBuilder& builder) {
+                builder.ExecuteOn(
+                           RenderGraph::QueueRole::Compute,
+                           RenderGraph::PipelineType::Copy
+                       )
+                    .Read(graphics_done)
+                    .SideEffect();
+            },
+            [](CommandList&) {},
+            RenderGraph::PassExecutionClass::ParallelRecordEligible
+        );
+        if (!stale_topology_graph.Compile()) {
+            throw std::runtime_error(
+                "stale-topology rejection graph failed to compile: " +
+                stale_topology_graph.GetCompileError()
+            );
+        }
+        if (stale_topology_graph.ExecuteRecording(
+                {},
+                {},
+                _parallel,
+                {},
+                RenderGraph::ActiveRecordingOptions{.enabled = true}
+            )) {
+            throw std::runtime_error(
+                "active RDG accepted a SingleQueue plan on dedicated queues"
+            );
+        }
+        if (stale_topology_graph.GetCompileError().find(
+                "compiled queue topology does not match"
+            ) == std::string::npos) {
+            throw std::runtime_error(
+                "active RDG stale-topology rejection was not diagnostic"
+            );
+        }
+        LOG_INFO(
+            "[TESTCASE][PASS] name=ActiveRdgRejectStaleTopology "
+            "compiled=single runtime=dedicated execution=rejected"
+        );
+    }
+
+    std::atomic<uint32> caller_callbacks{0};
+    RenderGraph caller_graph(
+        "ActiveRdgRejectCallerThreadMultiQueue", topology
+    );
+    const auto caller_graphics_done =
+        caller_graph.CreateTransientToken("GraphicsDone");
+    caller_graph.AddPass(
+            "Graphics",
+            [=](RenderGraph::PassBuilder& builder) {
+                builder.ExecuteOn(
+                           RenderGraph::QueueRole::Graphics,
+                           RenderGraph::PipelineType::Copy
+                       )
+                    .Write(caller_graphics_done)
+                    .SideEffect();
+            },
+            [&] {
+                caller_callbacks.fetch_add(1, std::memory_order_relaxed);
+            }
+    );
+    caller_graph.AddPass(
+            "Compute",
+            [=](RenderGraph::PassBuilder& builder) {
+                builder.ExecuteOn(
+                           RenderGraph::QueueRole::Compute,
+                           RenderGraph::PipelineType::Copy
+                       )
+                    .Read(caller_graphics_done)
+                    .SideEffect();
+            },
+            [&] {
+                caller_callbacks.fetch_add(1, std::memory_order_relaxed);
+            }
+    );
+    if (!caller_graph.Compile()) {
+        throw std::runtime_error(
+            "caller-thread multi-queue rejection graph failed to compile: " +
+            caller_graph.GetCompileError()
+        );
+    }
+    CommandList caller_commands(EQueueType::Graphics);
+    if (caller_graph.ExecuteRecording(
+            {},
+            {},
+            _parallel,
+            {},
+            RenderGraph::ActiveRecordingOptions{
+                .enabled = true,
+                .main_thread_command_list = &caller_commands,
+            }
+        )) {
+        throw std::runtime_error(
+            "active RDG accepted caller-thread multi-queue endpoints"
+        );
+    }
+    if (caller_callbacks.load(std::memory_order_relaxed) != 0 ||
+        !caller_commands.IsEmpty() ||
+        caller_graph.GetCompileError().find(
+            "managed recording handoff"
+        ) == std::string::npos) {
+        throw std::runtime_error(
+            "caller-thread multi-queue rejection was not immutable and diagnostic"
+        );
+    }
+    LOG_INFO(
+        "[TESTCASE][PASS] name=ActiveRdgRejectCallerThreadMultiQueue "
+        "callbacks=0 command_stream=empty execution=rejected"
+    );
+
+    const EBufferUsageFlags usage =
+        EBufferUsageFlags::TRANSFER_SRC | EBufferUsageFlags::TRANSFER_DST;
+    constexpr uint64_t byte_size = sizeof(uint32) * kElementCount;
+
+    struct QueueBuffer {
+        BufferRef buffer{};
+        std::array<uint32, kElementCount> values{};
+        std::array<uint32, kElementCount> readback{};
+    };
+    QueueBuffer graphics_root{
+        .buffer = device.CreateBuffer<uint32>(
+            "active_rdg_async_graphics_root", kElementCount, usage
+        ),
+    };
+    QueueBuffer compute_independent{
+        .buffer = device.CreateBuffer<uint32>(
+            "active_rdg_async_compute_independent", kElementCount, usage
+        ),
+    };
+    QueueBuffer graphics_independent{
+        .buffer = device.CreateBuffer<uint32>(
+            "active_rdg_async_graphics_independent", kElementCount, usage
+        ),
+    };
+    QueueBuffer compute_dependent{
+        .buffer = device.CreateBuffer<uint32>(
+            "active_rdg_async_compute_dependent", kElementCount, usage
+        ),
+    };
+    std::array<QueueBuffer*, 4> buffers{
+        &graphics_root,
+        &compute_independent,
+        &graphics_independent,
+        &compute_dependent,
+    };
+    for (uint32 buffer_index = 0; buffer_index < buffers.size(); ++buffer_index) {
+        for (uint32 element = 0; element < kElementCount; ++element) {
+            buffers[buffer_index]->values[element] =
+                0xB1000000u + buffer_index * 0x01000000u + element * 41u + 13u;
+        }
+    }
+
+    {
+        std::binary_semaphore graphics_record_started{0};
+        std::binary_semaphore compute_record_started{0};
+        RenderGraph independent_graph(
+            "ActiveRdgIndependentQueueRoots", topology
+        );
+        const auto graphics_handle = independent_graph.ImportBuffer(
+            "GraphicsIndependent",
+            graphics_independent.buffer,
+            RenderGraph::BufferDesc{.byte_size = byte_size}
+        );
+        const auto compute_handle = independent_graph.ImportBuffer(
+            "ComputeIndependent",
+            compute_independent.buffer,
+            RenderGraph::BufferDesc{.byte_size = byte_size}
+        );
+        for (const auto handle : {graphics_handle, compute_handle}) {
+            independent_graph.SetInitialState(
+                handle,
+                RenderGraph::BufferState::Undefined,
+                RenderGraph::QueueRole::None,
+                RenderGraph::AccessMode::None
+            );
+        }
+        independent_graph.AddRecordPass(
+            "GraphicsRoot",
+            [=](RenderGraph::PassBuilder& builder) {
+                builder.ExecuteOn(
+                           RenderGraph::QueueRole::Graphics,
+                           RenderGraph::PipelineType::Copy
+                       )
+                    .Write(
+                        graphics_handle,
+                        RenderGraph::BufferState::TransferDestination
+                    )
+                    .SideEffect();
+            },
+            [
+                &graphics_independent,
+                &graphics_record_started,
+                &compute_record_started,
+                _parallel
+            ](CommandList& commands) {
+                if (_parallel) {
+                    graphics_record_started.release();
+                    if (!compute_record_started.try_acquire_for(
+                            std::chrono::seconds(2)
+                        )) {
+                        throw std::runtime_error(
+                            "Compute queue root did not record concurrently"
+                        );
+                    }
+                }
+                commands.CopyFrom(
+                    OwnedBytes(graphics_independent.values),
+                    graphics_independent.buffer->GetView(),
+                    "ActiveRdgIndependentGraphicsRoot"
+                );
+            },
+            RenderGraph::PassExecutionClass::ParallelRecordEligible
+        );
+        independent_graph.AddRecordPass(
+            "ComputeRoot",
+            [=](RenderGraph::PassBuilder& builder) {
+                builder.ExecuteOn(
+                           RenderGraph::QueueRole::Compute,
+                           RenderGraph::PipelineType::Copy
+                       )
+                    .Write(
+                        compute_handle,
+                        RenderGraph::BufferState::TransferDestination
+                    )
+                    .SideEffect();
+            },
+            [
+                &compute_independent,
+                &graphics_record_started,
+                &compute_record_started,
+                _parallel
+            ](CommandList& commands) {
+                if (_parallel) {
+                    compute_record_started.release();
+                    if (!graphics_record_started.try_acquire_for(
+                            std::chrono::seconds(2)
+                        )) {
+                        throw std::runtime_error(
+                            "Graphics queue root did not record concurrently"
+                        );
+                    }
+                }
+                commands.CopyFrom(
+                    OwnedBytes(compute_independent.values),
+                    compute_independent.buffer->GetView(),
+                    "ActiveRdgIndependentComputeRoot"
+                );
+            },
+            RenderGraph::PassExecutionClass::ParallelRecordEligible
+        );
+        independent_graph.Export(
+            graphics_handle,
+            RenderGraph::BufferState::TransferDestination,
+            RenderGraph::QueueRole::Graphics,
+            RenderGraph::AccessMode::Write
+        );
+        independent_graph.Export(
+            compute_handle,
+            RenderGraph::BufferState::TransferDestination,
+            RenderGraph::QueueRole::Compute,
+            RenderGraph::AccessMode::Write
+        );
+        if (!independent_graph.Compile() ||
+            std::any_of(
+                independent_graph.GetCompiledPlan().queue_syncs.begin(),
+                independent_graph.GetCompiledPlan().queue_syncs.end(),
+                [](const RenderGraph::CompiledQueueSync& sync) {
+                    return sync.gpu_wait_required;
+                }
+            )) {
+            throw std::runtime_error(
+                "independent queue roots did not compile as a zero-edge DAG: " +
+                independent_graph.GetCompileError()
+            );
+        }
+        if (!independent_graph.ExecuteRecording(
+                {},
+                {},
+                _parallel,
+                {},
+                RenderGraph::ActiveRecordingOptions{.enabled = true}
+            )) {
+            throw std::runtime_error(
+                "independent queue roots failed active execution: " +
+                independent_graph.GetCompileError()
+            );
+        }
+
+        CommandList compute_readback(EQueueType::Compute);
+        compute_readback.CopyFrom(
+            compute_independent.buffer->GetView(),
+            WritableBytes(compute_independent.readback),
+            "ActiveRdgIndependentComputeReadback"
+        );
+        RHIExecutor::Get().Submit(
+            EQueueType::Compute,
+            compute_readback.Submit(),
+            ERHIExecSubmitFlags::FlushGPU
+        );
+        CommandList graphics_readback(EQueueType::Graphics);
+        graphics_readback.CopyFrom(
+            graphics_independent.buffer->GetView(),
+            WritableBytes(graphics_independent.readback),
+            "ActiveRdgIndependentGraphicsReadback"
+        );
+        RHIExecutor::Get().Submit(
+            EQueueType::Graphics,
+            graphics_readback.Submit(),
+            ERHIExecSubmitFlags::FlushGPU
+        );
+        RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
+        if (graphics_independent.readback != graphics_independent.values ||
+            compute_independent.readback != compute_independent.values) {
+            throw std::runtime_error(
+                "independent queue root readback mismatch"
+            );
+        }
+        graphics_independent.readback.fill(0);
+        compute_independent.readback.fill(0);
+        LOG_INFO(
+            "[TESTCASE][PASS] name=ActiveRdgIndependentQueueRoots "
+            "logical_syncs={} gpu_syncs=0 distinct_native={} execution={} "
+            "cpu_record_cross_queue={}",
+            independent_graph.GetCompiledPlan().queue_syncs.size(),
+            dedicated_compute,
+            dedicated_compute ? "dependency-led" : "native-serial",
+            _parallel ? "parallel-verified" : "serial"
+        );
+    }
+
+    if (dedicated_compute && same_queue_family) {
+        QueueBuffer shared_source{
+            .buffer = device.CreateBuffer<uint32>(
+                "active_rdg_same_family_shared_source",
+                kElementCount,
+                usage
+            ),
+        };
+        QueueBuffer shared_destination{
+            .buffer = device.CreateBuffer<uint32>(
+                "active_rdg_same_family_shared_destination",
+                kElementCount,
+                usage
+            ),
+        };
+        for (uint32 element = 0; element < kElementCount; ++element) {
+            shared_source.values[element] =
+                0xD3100000u + element * 67u + 19u;
+        }
+        shared_destination.values = shared_source.values;
+
+        RenderGraph physical_graph(
+            "ActiveRdgSameFamilyPhysicalRaw", topology
+        );
+        const auto source_handle = physical_graph.ImportBuffer(
+            "SharedSource",
+            shared_source.buffer,
+            RenderGraph::BufferDesc{.byte_size = byte_size}
+        );
+        const auto destination_handle = physical_graph.ImportBuffer(
+            "SharedDestination",
+            shared_destination.buffer,
+            RenderGraph::BufferDesc{.byte_size = byte_size}
+        );
+        for (const auto handle : {source_handle, destination_handle}) {
+            physical_graph.SetInitialState(
+                handle,
+                RenderGraph::BufferState::Undefined,
+                RenderGraph::QueueRole::None,
+                RenderGraph::AccessMode::None
+            );
+        }
+        physical_graph.AddRecordPass(
+            "GraphicsWriteShared",
+            [=](RenderGraph::PassBuilder& builder) {
+                builder.ExecuteOn(
+                           RenderGraph::QueueRole::Graphics,
+                           RenderGraph::PipelineType::Copy
+                       )
+                    .Write(
+                        source_handle,
+                        RenderGraph::BufferState::TransferDestination
+                    )
+                    .SideEffect();
+            },
+            [&shared_source](CommandList& commands) {
+                commands.CopyFrom(
+                    OwnedBytes(shared_source.values),
+                    shared_source.buffer->GetView(),
+                    "ActiveRdgSameFamilyGraphicsWrite"
+                );
+            },
+            RenderGraph::PassExecutionClass::ParallelRecordEligible
+        );
+        physical_graph.AddRecordPass(
+            "ComputeReadShared",
+            [=](RenderGraph::PassBuilder& builder) {
+                builder.ExecuteOn(
+                           RenderGraph::QueueRole::Compute,
+                           RenderGraph::PipelineType::Copy
+                       )
+                    .Read(
+                        source_handle,
+                        RenderGraph::BufferState::TransferSource
+                    )
+                    .Write(
+                        destination_handle,
+                        RenderGraph::BufferState::TransferDestination
+                    )
+                    .SideEffect();
+            },
+            [&shared_source, &shared_destination](CommandList& commands) {
+                commands.CopyFrom(
+                    shared_source.buffer->GetView(),
+                    shared_destination.buffer->GetView(),
+                    "ActiveRdgSameFamilyComputeRead"
+                );
+            },
+            RenderGraph::PassExecutionClass::ParallelRecordEligible
+        );
+        physical_graph.Export(
+            source_handle,
+            RenderGraph::BufferState::TransferSource,
+            RenderGraph::QueueRole::Compute,
+            RenderGraph::AccessMode::Read
+        );
+        physical_graph.Export(
+            destination_handle,
+            RenderGraph::BufferState::TransferDestination,
+            RenderGraph::QueueRole::Compute,
+            RenderGraph::AccessMode::Write
+        );
+        if (!physical_graph.Compile() ||
+            !std::any_of(
+                physical_graph.GetCompiledPlan().queue_syncs.begin(),
+                physical_graph.GetCompiledPlan().queue_syncs.end(),
+                [](const RenderGraph::CompiledQueueSync& sync) {
+                    return sync.gpu_wait_required;
+                }
+            )) {
+            throw std::runtime_error(
+                "same-family physical RAW did not compile with a GPU sync: " +
+                physical_graph.GetCompileError()
+            );
+        }
+        if (!physical_graph.ExecuteRecording(
+                {},
+                {},
+                _parallel,
+                {},
+                RenderGraph::ActiveRecordingOptions{.enabled = true}
+            )) {
+            throw std::runtime_error(
+                "same-family physical RAW active execution failed: " +
+                physical_graph.GetCompileError()
+            );
+        }
+        CommandList physical_readback(EQueueType::Compute);
+        physical_readback.CopyFrom(
+            shared_destination.buffer->GetView(),
+            WritableBytes(shared_destination.readback),
+            "ActiveRdgSameFamilyPhysicalReadback"
+        );
+        RHIExecutor::Get().Submit(
+            EQueueType::Compute,
+            physical_readback.Submit(),
+            ERHIExecSubmitFlags::FlushGPU
+        );
+        RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
+        if (shared_destination.readback != shared_destination.values) {
+            throw std::runtime_error(
+                "same-family physical RAW readback mismatch"
+            );
+        }
+        LOG_INFO(
+            "[TESTCASE][PASS] name=ActiveRdgSameFamilyPhysicalRaw "
+            "producer=Graphics consumer=Compute barrier=acquire readback=verified"
+        );
+    } else {
+        LOG_INFO(
+            "[TESTCASE][SKIP] name=ActiveRdgSameFamilyPhysicalRaw "
+            "reason=queue_topology compute_native={} graphics_native={} "
+            "compute_family={} graphics_family={}",
+            topology.compute.native_queue_id,
+            topology.graphics.native_queue_id,
+            topology.compute.family_id,
+            topology.graphics.family_id
+        );
+    }
+
+    RenderGraph graph("ActiveRdgAsyncQueueDag", topology);
+    const auto graphics_root_handle = graph.ImportBuffer(
+        "GraphicsRoot",
+        graphics_root.buffer,
+        RenderGraph::BufferDesc{.byte_size = byte_size}
+    );
+    const auto compute_independent_handle = graph.ImportBuffer(
+        "ComputeIndependent",
+        compute_independent.buffer,
+        RenderGraph::BufferDesc{.byte_size = byte_size}
+    );
+    const auto graphics_independent_handle = graph.ImportBuffer(
+        "GraphicsIndependent",
+        graphics_independent.buffer,
+        RenderGraph::BufferDesc{.byte_size = byte_size}
+    );
+    const auto compute_dependent_handle = graph.ImportBuffer(
+        "ComputeDependent",
+        compute_dependent.buffer,
+        RenderGraph::BufferDesc{.byte_size = byte_size}
+    );
+    for (const auto handle : {
+             graphics_root_handle,
+             compute_independent_handle,
+             graphics_independent_handle,
+             compute_dependent_handle,
+         }) {
+        graph.SetInitialState(
+            handle,
+            RenderGraph::BufferState::Undefined,
+            RenderGraph::QueueRole::None,
+            RenderGraph::AccessMode::None
+        );
+    }
+    const auto graphics_root_done =
+        graph.CreateTransientToken("GraphicsRootDone");
+
+    graph.AddRecordPass(
+        "GraphicsRoot",
+        [=](RenderGraph::PassBuilder& builder) {
+            builder.ExecuteOn(
+                       RenderGraph::QueueRole::Graphics,
+                       RenderGraph::PipelineType::Copy
+                   )
+                .Write(
+                    graphics_root_handle,
+                    RenderGraph::BufferState::TransferDestination
+                )
+                .Write(graphics_root_done)
+                .SideEffect();
+        },
+        [&graphics_root](CommandList& commands) {
+            commands.CopyFrom(
+                OwnedBytes(graphics_root.values),
+                graphics_root.buffer->GetView(),
+                "ActiveRdgAsyncGraphicsRoot"
+            );
+        },
+        RenderGraph::PassExecutionClass::ParallelRecordEligible
+    );
+    graph.AddRecordPass(
+        "ComputeIndependent",
+        [=](RenderGraph::PassBuilder& builder) {
+            builder.ExecuteOn(
+                       RenderGraph::QueueRole::Compute,
+                       RenderGraph::PipelineType::Copy
+                   )
+                .Write(
+                    compute_independent_handle,
+                    RenderGraph::BufferState::TransferDestination
+                )
+                .SideEffect();
+        },
+        [&compute_independent](CommandList& commands) {
+            commands.CopyFrom(
+                OwnedBytes(compute_independent.values),
+                compute_independent.buffer->GetView(),
+                "ActiveRdgAsyncComputeIndependent"
+            );
+        },
+        RenderGraph::PassExecutionClass::ParallelRecordEligible
+    );
+    graph.AddRecordPass(
+        "GraphicsIndependent",
+        [=](RenderGraph::PassBuilder& builder) {
+            builder.ExecuteOn(
+                       RenderGraph::QueueRole::Graphics,
+                       RenderGraph::PipelineType::Copy
+                   )
+                .Write(
+                    graphics_independent_handle,
+                    RenderGraph::BufferState::TransferDestination
+                )
+                .SideEffect();
+        },
+        [&graphics_independent](CommandList& commands) {
+            commands.CopyFrom(
+                OwnedBytes(graphics_independent.values),
+                graphics_independent.buffer->GetView(),
+                "ActiveRdgAsyncGraphicsIndependent"
+            );
+        },
+        RenderGraph::PassExecutionClass::ParallelRecordEligible
+    );
+    graph.AddRecordPass(
+        "ComputeDependent",
+        [=](RenderGraph::PassBuilder& builder) {
+            builder.ExecuteOn(
+                       RenderGraph::QueueRole::Compute,
+                       RenderGraph::PipelineType::Copy
+                   )
+                .Read(graphics_root_done)
+                .Write(
+                    compute_dependent_handle,
+                    RenderGraph::BufferState::TransferDestination
+                )
+                .SideEffect();
+        },
+        [&compute_dependent](CommandList& commands) {
+            commands.CopyFrom(
+                OwnedBytes(compute_dependent.values),
+                compute_dependent.buffer->GetView(),
+                "ActiveRdgAsyncComputeDependent"
+            );
+        },
+        RenderGraph::PassExecutionClass::ParallelRecordEligible
+    );
+
+    graph.Export(
+        graphics_root_handle,
+        RenderGraph::BufferState::TransferDestination,
+        RenderGraph::QueueRole::Graphics,
+        RenderGraph::AccessMode::Write
+    );
+    graph.Export(
+        compute_independent_handle,
+        RenderGraph::BufferState::TransferDestination,
+        RenderGraph::QueueRole::Compute,
+        RenderGraph::AccessMode::Write
+    );
+    graph.Export(
+        graphics_independent_handle,
+        RenderGraph::BufferState::TransferDestination,
+        RenderGraph::QueueRole::Graphics,
+        RenderGraph::AccessMode::Write
+    );
+    graph.Export(
+        compute_dependent_handle,
+        RenderGraph::BufferState::TransferDestination,
+        RenderGraph::QueueRole::Compute,
+        RenderGraph::AccessMode::Write
+    );
+
+    if (!graph.Compile()) {
+        throw std::runtime_error(
+            "active RDG async queue compile failed: " +
+            graph.GetCompileError()
+        );
+    }
+    const auto& plan = graph.GetCompiledPlan();
+    const bool has_gpu_sync = std::any_of(
+        plan.queue_syncs.begin(),
+        plan.queue_syncs.end(),
+        [](const RenderGraph::CompiledQueueSync& sync) {
+            return sync.gpu_wait_required;
+        }
+    );
+    if (has_gpu_sync != dedicated_compute) {
+        throw std::runtime_error(
+            "active RDG async queue plan disagrees with runtime topology"
+        );
+    }
+    if (!graph.ExecuteRecording(
+            {},
+            {},
+            _parallel,
+            {},
+            RenderGraph::ActiveRecordingOptions{.enabled = true}
+        )) {
+        throw std::runtime_error(
+            "active RDG async queue execution failed: " +
+            graph.GetCompileError()
+        );
+    }
+
+    CommandList compute_readback(EQueueType::Compute);
+    compute_readback.CopyFrom(
+        compute_independent.buffer->GetView(),
+        WritableBytes(compute_independent.readback),
+        "ActiveRdgAsyncComputeIndependentReadback"
+    );
+    compute_readback.CopyFrom(
+        compute_dependent.buffer->GetView(),
+        WritableBytes(compute_dependent.readback),
+        "ActiveRdgAsyncComputeDependentReadback"
+    );
+    RHIExecutor::Get().Submit(
+        EQueueType::Compute,
+        compute_readback.Submit(),
+        ERHIExecSubmitFlags::FlushGPU
+    );
+
+    CommandList graphics_readback(EQueueType::Graphics);
+    graphics_readback.CopyFrom(
+        graphics_root.buffer->GetView(),
+        WritableBytes(graphics_root.readback),
+        "ActiveRdgAsyncGraphicsRootReadback"
+    );
+    graphics_readback.CopyFrom(
+        graphics_independent.buffer->GetView(),
+        WritableBytes(graphics_independent.readback),
+        "ActiveRdgAsyncGraphicsIndependentReadback"
+    );
+    RHIExecutor::Get().Submit(
+        EQueueType::Graphics,
+        graphics_readback.Submit(),
+        ERHIExecSubmitFlags::FlushGPU
+    );
+    RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
+
+    for (const QueueBuffer* buffer : buffers) {
+        if (buffer->readback != buffer->values) {
+            throw std::runtime_error(
+                "active RDG async queue readback mismatch"
+            );
+        }
+    }
+    LOG_INFO(
+        "[TESTCASE][PASS] name=ActiveRdgAsyncQueueDag mode={} "
+        "compute_native={} graphics_native={} gpu_sync={} "
+        "submission_owner=serial",
+        _parallel ? "parallel" : "serial",
+        topology.compute.native_queue_id,
+        topology.graphics.native_queue_id,
+        has_gpu_sync
+    );
+}
+
 void RunActiveRdgTransientAliasReadback(bool _parallel) {
     constexpr uint64_t byte_size = sizeof(uint32) * kElementCount;
     const RGTransientBufferDesc transient_desc{
@@ -1885,6 +2639,7 @@ int main(int argc, const char** argv) {
             parallel, inject_worker_failure, production_gate, production_heavy
         );
         RunActiveRdgExplicitBarrierReadback(parallel);
+        RunActiveRdgAsyncQueueDag(parallel);
         RunActiveRdgTransientAliasReadback(parallel);
         RunActiveRdgTransientTextureAliasReadback(parallel);
         RunActiveRdgTextureArraySubrange(parallel);

--- a/source/test/RenderGraphActiveLoweringTest.cpp
+++ b/source/test/RenderGraphActiveLoweringTest.cpp
@@ -1,0 +1,1842 @@
+#include "rendergraph/RenderGraph.h"
+#include "rhi/RHIImpl.h"
+#include "rhi/RHIResource.h"
+
+#include <algorithm>
+#include <cstdlib>
+#include <iostream>
+#include <memory>
+#include <string>
+#include <string_view>
+#include <type_traits>
+
+namespace {
+
+using Moer::Render::BarrierCmd;
+using Moer::Render::Buffer;
+using Moer::Render::BufferInfo;
+using Moer::Render::BufferRef;
+using Moer::Render::CmdSubmit;
+using Moer::Render::Command;
+using Moer::Render::CommandList;
+using Moer::Render::EQueueType;
+using Moer::Render::ERHIRecordingStatus;
+using Moer::Render::ERHIResourceStateOwnership;
+using Moer::Render::ERHISyncDepth;
+using Moer::Render::RHIExecutor;
+using Moer::Render::RHIRecordingGate;
+using Moer::Render::RHIRecordingGateView;
+using Moer::Render::RHIRecordingSource;
+using Moer::Render::RenderGraph;
+using Moer::Render::Texture;
+using Moer::Render::TextureInfo;
+using Moer::Render::TextureRef;
+using Moer::MakeUnique;
+
+template<typename T>
+concept WritableRecordingGate = requires(T& gate) {
+    gate.Signal();
+    gate.Fail();
+};
+
+static_assert(!WritableRecordingGate<RHIRecordingGateView>);
+static_assert(
+    !std::is_convertible_v<
+        RHIRecordingGateView,
+        Moer::Render::RHIRecordingGateRef
+    >
+);
+
+class TestSuite {
+public:
+    void Check(bool condition, std::string_view test, std::string_view message) {
+        if (condition) {
+            return;
+        }
+        ++failures;
+        std::cerr << "[FAIL] " << test << ": " << message << "\n";
+    }
+
+    [[nodiscard]] int FailureCount() const {
+        return failures;
+    }
+
+private:
+    int failures = 0;
+};
+
+[[nodiscard]] bool Contains(std::string_view text, std::string_view expected) {
+    return text.find(expected) != std::string_view::npos;
+}
+
+class FakeTexture final : public Texture {
+public:
+    FakeTexture(uint8_t mips, uint16_t layers, ETextureAspectFlags aspects) :
+        Texture(MakeInfo(mips, layers, aspects)) {}
+
+    Moer::uint GetMipByteSize(Moer::uint) const override {
+        return 4;
+    }
+
+    void SetName(std::string_view) override {}
+
+private:
+    static TextureInfo
+    MakeInfo(uint8_t mips, uint16_t layers, ETextureAspectFlags aspects) {
+        TextureInfo info{};
+        info.usage = ETextureUsageFlags::SAMPLED |
+                     ETextureUsageFlags::UNORDERED_ACCESS |
+                     ETextureUsageFlags::COLOR_ATTACHMENT |
+                     ETextureUsageFlags::TRANSFER_SRC |
+                     ETextureUsageFlags::TRANSFER_DST;
+        info.extent       = {64, 64};
+        info.num_mips     = mips;
+        info.array_size   = layers;
+        info.aspect_flags = aspects;
+        return info;
+    }
+};
+
+class FakeBuffer final : public Buffer {
+public:
+    explicit FakeBuffer(uint64_t byte_size) :
+        Buffer(BufferInfo{
+            byte_size,
+            1,
+            EBufferUsageFlags::UNORDERED_ACCESS |
+                EBufferUsageFlags::TRANSFER_SRC |
+                EBufferUsageFlags::TRANSFER_DST
+        }) {}
+
+    void SetName(std::string_view) override {}
+};
+
+class LifetimeProbeBuffer final : public Buffer {
+public:
+    explicit LifetimeProbeBuffer(std::shared_ptr<bool> destroyed) :
+        Buffer(BufferInfo{
+            64,
+            1,
+            EBufferUsageFlags::UNORDERED_ACCESS |
+                EBufferUsageFlags::TRANSFER_SRC |
+                EBufferUsageFlags::TRANSFER_DST
+        }),
+        destroyed(std::move(destroyed)) {}
+
+    ~LifetimeProbeBuffer() override {
+        *destroyed = true;
+    }
+
+    void SetName(std::string_view) override {}
+
+private:
+    std::shared_ptr<bool> destroyed;
+};
+
+class ProbeCommand final : public Command {
+public:
+    explicit ProbeCommand(int marker) : Command(EType::Custom), marker(marker) {}
+
+    EQueueType GetQueueType() const override {
+        return EQueueType::Graphics;
+    }
+
+    [[nodiscard]] int Marker() const {
+        return marker;
+    }
+
+private:
+    int marker;
+};
+
+[[nodiscard]] const BarrierCmd* AsBarrier(const Moer::UniquePtr<Command>& command) {
+    if (!command || command->Type() != Command::EType::Barrier) {
+        return nullptr;
+    }
+    return static_cast<const BarrierCmd*>(command.get());
+}
+
+[[nodiscard]] const ProbeCommand* AsProbe(const Moer::UniquePtr<Command>& command) {
+    if (!command || command->Type() != Command::EType::Custom) {
+        return nullptr;
+    }
+    return static_cast<const ProbeCommand*>(command.get());
+}
+
+void TestRecordPassMaterializesExplicitBeforeBodyAfter(TestSuite& suite) {
+    constexpr std::string_view test_name =
+        "record pass materializes explicit before-body-after";
+
+    BufferRef  buffer  = MoerNew(FakeBuffer)(256);
+    TextureRef texture = MoerNew(FakeTexture)(1, 1, ETextureAspectFlags::COLOR);
+
+    RenderGraph graph("ActiveRecordMaterialization");
+    const auto  data = graph.ImportBuffer(
+        "Data",
+        buffer,
+        RenderGraph::BufferDesc{.byte_size = 256}
+    );
+    const auto color = graph.ImportTexture(
+        "Color",
+        texture,
+        RenderGraph::TextureDesc{
+            .mip_count   = 1,
+            .layer_count = 1,
+            .aspects     = RenderGraph::TextureAspect::Color,
+        }
+    );
+    graph.SetInitialState(
+        data,
+        RenderGraph::BufferState::Undefined,
+        RenderGraph::QueueRole::None,
+        RenderGraph::AccessMode::None
+    );
+    graph.SetInitialState(
+        color,
+        RenderGraph::TextureState::Undefined,
+        RenderGraph::QueueRole::None,
+        RenderGraph::AccessMode::None
+    );
+    graph.AddRecordPass(
+        "WriteBoth",
+        [=](RenderGraph::PassBuilder& builder) {
+            builder.Write(data, RenderGraph::BufferState::UnorderedAccess)
+                .Write(color, RenderGraph::TextureState::RenderTarget)
+                .SideEffect();
+        },
+        [](CommandList& commands) {
+            commands.AddCustomCommand(
+                MakeUnique<ProbeCommand>(101),
+                "ActiveLoweringBody"
+            );
+        },
+        RenderGraph::PassExecutionClass::SerialRecord
+    );
+    graph.Export(
+        data,
+        RenderGraph::BufferState::ShaderResource,
+        RenderGraph::QueueRole::Graphics,
+        RenderGraph::AccessMode::Read
+    );
+    graph.Export(
+        color,
+        RenderGraph::TextureState::ShaderResource,
+        RenderGraph::QueueRole::Graphics,
+        RenderGraph::AccessMode::Read
+    );
+
+    suite.Check(graph.Compile(), test_name, graph.GetCompileError());
+    Moer::Array<RHIRecordingSource> published{};
+    const bool executed = graph.ExecuteRecording(
+        {},
+        {},
+        false,
+        [&](Moer::Array<RHIRecordingSource>&& sources) {
+            for (auto& source : sources) {
+                published.emplace_back(std::move(source));
+            }
+        },
+        RenderGraph::ActiveRecordingOptions{.enabled = true}
+    );
+    suite.Check(executed, test_name, graph.GetCompileError());
+    suite.Check(
+        published.size() == 1 &&
+            published.front().completion.Status() == ERHIRecordingStatus::Succeeded,
+        test_name,
+        "one completed recording source must be published"
+    );
+    if (published.size() != 1) {
+        return;
+    }
+
+    CmdSubmit submit = published.front().command_list->Submit();
+    suite.Check(
+        submit.HasExplicitResourceStateOwnership(),
+        test_name,
+        "the sealed recording submit must preserve Explicit ownership"
+    );
+    suite.Check(
+        submit.cmds.size() == 3,
+        test_name,
+        "the command stream must contain one before barrier, body command, and after barrier"
+    );
+    if (submit.cmds.size() != 3) {
+        return;
+    }
+
+    const auto* before = AsBarrier(submit.cmds[0]);
+    const auto* body   = AsProbe(submit.cmds[1]);
+    const auto* after  = AsBarrier(submit.cmds[2]);
+    suite.Check(
+        before != nullptr && body != nullptr && body->Marker() == 101 && after != nullptr,
+        test_name,
+        "explicit barriers must bracket the record callback command"
+    );
+    if (before == nullptr || after == nullptr) {
+        return;
+    }
+    suite.Check(
+        before->ExplicitBuffers().size() == 1 &&
+            before->ExplicitTextures().size() == 1 &&
+            after->ExplicitBuffers().size() == 1 &&
+            after->ExplicitTextures().size() == 1,
+        test_name,
+        "both strong physical imports must be materialized at graph boundaries"
+    );
+    suite.Check(
+        before->GetSrcQueue() == EQueueType::Graphics &&
+            before->GetDstQueue() == EQueueType::Graphics &&
+            after->GetSrcQueue() == EQueueType::Graphics &&
+            after->GetDstQueue() == EQueueType::Graphics &&
+            !before->IsQueueTransition() && !after->IsQueueTransition(),
+        test_name,
+        "Phase 11 barriers must remain Graphics-local"
+    );
+    if (before->ExplicitBuffers().size() == 1 &&
+        before->ExplicitTextures().size() == 1 &&
+        after->ExplicitBuffers().size() == 1 &&
+        after->ExplicitTextures().size() == 1) {
+        suite.Check(
+            before->ExplicitBuffers().front().handle ==
+                    reinterpret_cast<Moer::uint64>(buffer.Get()) &&
+                before->ExplicitTextures().front().handle ==
+                    reinterpret_cast<Moer::uint64>(texture.Get()) &&
+                after->ExplicitBuffers().front().handle ==
+                    reinterpret_cast<Moer::uint64>(buffer.Get()) &&
+                after->ExplicitTextures().front().handle ==
+                    reinterpret_cast<Moer::uint64>(texture.Get()),
+            test_name,
+            "materialized barriers must retain the exact imported physical identities"
+        );
+    }
+}
+
+void TestSameStateSecondReadMaterializesStateSeed(TestSuite& suite) {
+    constexpr std::string_view test_name =
+        "same-state second read materializes a state seed";
+
+    BufferRef buffer = MoerNew(FakeBuffer)(256);
+    RenderGraph graph("ActiveReadSeed");
+    const auto  data = graph.ImportBuffer(
+        "Data",
+        buffer,
+        RenderGraph::BufferDesc{.byte_size = 256}
+    );
+    graph.SetInitialState(
+        data,
+        RenderGraph::BufferState::ShaderResource,
+        RenderGraph::QueueRole::Graphics,
+        RenderGraph::AccessMode::Read
+    );
+    for (int marker : {1, 2}) {
+        graph.AddRecordPass(
+            marker == 1 ? "FirstRead" : "SecondRead",
+            [=](RenderGraph::PassBuilder& builder) {
+                builder.Read(data, RenderGraph::BufferState::ShaderResource).SideEffect();
+            },
+            [marker](CommandList& commands) {
+                commands.AddCustomCommand(
+                    MakeUnique<ProbeCommand>(marker),
+                    marker == 1 ? "FirstReadBody" : "SecondReadBody"
+                );
+            },
+            RenderGraph::PassExecutionClass::SerialRecord
+        );
+    }
+    graph.Export(
+        data,
+        RenderGraph::BufferState::ShaderResource,
+        RenderGraph::QueueRole::Graphics,
+        RenderGraph::AccessMode::Read
+    );
+
+    suite.Check(graph.Compile(), test_name, graph.GetCompileError());
+    Moer::Array<RHIRecordingSource> published{};
+    const bool executed = graph.ExecuteRecording(
+        {},
+        {},
+        false,
+        [&](Moer::Array<RHIRecordingSource>&& sources) {
+            for (auto& source : sources) {
+                published.emplace_back(std::move(source));
+            }
+        },
+        RenderGraph::ActiveRecordingOptions{.enabled = true}
+    );
+    suite.Check(executed, test_name, graph.GetCompileError());
+    suite.Check(
+        published.size() == 2 &&
+            std::all_of(
+                published.begin(),
+                published.end(),
+                [](const RHIRecordingSource& source) {
+                    return source.completion.Status() ==
+                           ERHIRecordingStatus::Succeeded;
+                }
+            ),
+        test_name,
+        "both independent read sources must complete"
+    );
+    if (published.size() != 2) {
+        return;
+    }
+
+    CmdSubmit second_submit = published[1].command_list->Submit();
+    suite.Check(
+        second_submit.HasExplicitResourceStateOwnership(),
+        test_name,
+        "state-seeded read submit must use Explicit ownership"
+    );
+    const auto body = std::find_if(
+        second_submit.cmds.begin(),
+        second_submit.cmds.end(),
+        [](const auto& command) {
+            const auto* probe = AsProbe(command);
+            return probe != nullptr && probe->Marker() == 2;
+        }
+    );
+    suite.Check(
+        body != second_submit.cmds.end() && body != second_submit.cmds.begin(),
+        test_name,
+        "the second read body must follow a materialized state seed"
+    );
+    if (body == second_submit.cmds.end() || body == second_submit.cmds.begin()) {
+        return;
+    }
+    const auto* seed = AsBarrier(*(body - 1));
+    suite.Check(
+        seed != nullptr && seed->ExplicitBuffers().size() == 1,
+        test_name,
+        "the command immediately before the second read must be an explicit buffer seed"
+    );
+    if (seed != nullptr && seed->ExplicitBuffers().size() == 1) {
+        const auto& explicit_seed = seed->ExplicitBuffers().front();
+        suite.Check(
+            explicit_seed.src_state == explicit_seed.dst_state &&
+                explicit_seed.handle == reinterpret_cast<Moer::uint64>(buffer.Get()) &&
+                explicit_seed.offset == 0 && explicit_seed.byte_size == 256,
+            test_name,
+            "state seed must adopt the same ShaderResource state over the full buffer"
+        );
+    }
+}
+
+void ExpectActiveFailClosed(
+    TestSuite&       suite,
+    RenderGraph&     graph,
+    std::string_view test_name,
+    std::string_view expected_error,
+    int&             record_calls,
+    int&             configure_calls,
+    int&             publish_calls
+) {
+    suite.Check(graph.Compile(), test_name, graph.GetCompileError());
+    const bool executed = graph.ExecuteRecording(
+        {},
+        [&](const RenderGraph::ExecutedPassInfo&, RHIRecordingSource&) {
+            ++configure_calls;
+        },
+        false,
+        [&](Moer::Array<RHIRecordingSource>&&) {
+            ++publish_calls;
+        },
+        RenderGraph::ActiveRecordingOptions{.enabled = true}
+    );
+    suite.Check(!executed, test_name, "active execution unexpectedly succeeded");
+    suite.Check(
+        Contains(graph.GetCompileError(), expected_error),
+        test_name,
+        graph.GetCompileError()
+    );
+    suite.Check(
+        record_calls == 0 && configure_calls == 0 && publish_calls == 0,
+        test_name,
+        "lowering rejection must happen before record, source setup, or publication"
+    );
+}
+
+void TestUnsupportedInputsFailBeforeCallbacksOrPublish(TestSuite& suite) {
+    {
+        constexpr std::string_view test_name =
+            "Automatic access fails before callbacks or publication";
+        BufferRef buffer = MoerNew(FakeBuffer)(64);
+        RenderGraph graph("ActiveAutomaticFailClosed");
+        const auto  data = graph.ImportBuffer(
+            "Data",
+            buffer,
+            RenderGraph::BufferDesc{.byte_size = 64}
+        );
+        graph.SetInitialState(
+            data,
+            RenderGraph::BufferState::ShaderResource,
+            RenderGraph::QueueRole::Graphics,
+            RenderGraph::AccessMode::Read
+        );
+        int record_calls    = 0;
+        int configure_calls = 0;
+        int publish_calls   = 0;
+        graph.AddRecordPass(
+            "AutomaticRead",
+            [=](RenderGraph::PassBuilder& builder) {
+                builder.Read(data).SideEffect();
+            },
+            [&](CommandList&) {
+                ++record_calls;
+            },
+            RenderGraph::PassExecutionClass::SerialRecord
+        );
+        graph.Export(
+            data,
+            RenderGraph::BufferState::ShaderResource,
+            RenderGraph::QueueRole::Graphics,
+            RenderGraph::AccessMode::Read
+        );
+        ExpectActiveFailClosed(
+            suite,
+            graph,
+            test_name,
+            "state plan is incomplete",
+            record_calls,
+            configure_calls,
+            publish_calls
+        );
+    }
+
+    {
+        constexpr std::string_view test_name =
+            "raw physical binding fails before callbacks or publication";
+        BufferRef buffer = MoerNew(FakeBuffer)(64);
+        RenderGraph graph("ActiveRawBindingFailClosed");
+        const auto  data = graph.ImportBuffer(
+            "Data",
+            static_cast<const void*>(buffer.Get()),
+            RenderGraph::BufferDesc{.byte_size = 64}
+        );
+        graph.SetInitialState(
+            data,
+            RenderGraph::BufferState::Undefined,
+            RenderGraph::QueueRole::None,
+            RenderGraph::AccessMode::None
+        );
+        int record_calls    = 0;
+        int configure_calls = 0;
+        int publish_calls   = 0;
+        graph.AddRecordPass(
+            "RawWrite",
+            [=](RenderGraph::PassBuilder& builder) {
+                builder.Write(data, RenderGraph::BufferState::UnorderedAccess)
+                    .SideEffect();
+            },
+            [&](CommandList&) {
+                ++record_calls;
+            },
+            RenderGraph::PassExecutionClass::SerialRecord
+        );
+        graph.Export(
+            data,
+            RenderGraph::BufferState::ShaderResource,
+            RenderGraph::QueueRole::Graphics,
+            RenderGraph::AccessMode::Read
+        );
+        ExpectActiveFailClosed(
+            suite,
+            graph,
+            test_name,
+            "strong physical binding",
+            record_calls,
+            configure_calls,
+            publish_calls
+        );
+    }
+
+    {
+        constexpr std::string_view test_name =
+            "partial buffer bridge fails before callbacks or publication";
+        BufferRef buffer = MoerNew(FakeBuffer)(64);
+        RenderGraph graph("ActivePartialBufferFailClosed");
+        const auto  data = graph.ImportBuffer(
+            "Data",
+            buffer,
+            RenderGraph::BufferDesc{.byte_size = 64}
+        );
+        const RenderGraph::BufferRange range{.offset = 0, .size = 32};
+        graph.SetInitialState(
+            data,
+            RenderGraph::BufferState::Undefined,
+            RenderGraph::QueueRole::None,
+            RenderGraph::AccessMode::None,
+            range
+        );
+        int record_calls    = 0;
+        int configure_calls = 0;
+        int publish_calls   = 0;
+        graph.AddRecordPass(
+            "PartialWrite",
+            [=](RenderGraph::PassBuilder& builder) {
+                builder.Write(
+                           data,
+                           RenderGraph::BufferState::UnorderedAccess,
+                           range
+                       )
+                    .SideEffect();
+            },
+            [&](CommandList&) {
+                ++record_calls;
+            },
+            RenderGraph::PassExecutionClass::SerialRecord
+        );
+        graph.Export(
+            data,
+            RenderGraph::BufferState::ShaderResource,
+            RenderGraph::QueueRole::Graphics,
+            RenderGraph::AccessMode::Read,
+            range
+        );
+        ExpectActiveFailClosed(
+            suite,
+            graph,
+            test_name,
+            "partial buffer state",
+            record_calls,
+            configure_calls,
+            publish_calls
+        );
+    }
+
+    {
+        constexpr std::string_view test_name =
+            "source metadata callback cannot record commands";
+        BufferRef buffer = MoerNew(FakeBuffer)(64);
+        RenderGraph graph("ActiveConfigureMutationFailClosed");
+        const auto  data = graph.ImportBuffer(
+            "Data",
+            buffer,
+            RenderGraph::BufferDesc{.byte_size = 64}
+        );
+        graph.SetInitialState(
+            data,
+            RenderGraph::BufferState::Undefined,
+            RenderGraph::QueueRole::None,
+            RenderGraph::AccessMode::None
+        );
+        int record_calls    = 0;
+        int configure_calls = 0;
+        int publish_calls   = 0;
+        graph.AddRecordPass(
+            "Write",
+            [=](RenderGraph::PassBuilder& builder) {
+                builder.Write(data, RenderGraph::BufferState::UnorderedAccess)
+                    .SideEffect();
+            },
+            [&](CommandList&) {
+                ++record_calls;
+            },
+            RenderGraph::PassExecutionClass::SerialRecord
+        );
+        graph.Export(
+            data,
+            RenderGraph::BufferState::ShaderResource,
+            RenderGraph::QueueRole::Graphics,
+            RenderGraph::AccessMode::Read
+        );
+
+        suite.Check(graph.Compile(), test_name, graph.GetCompileError());
+        const bool executed = graph.ExecuteRecording(
+            {},
+            [&](const RenderGraph::ExecutedPassInfo&, RHIRecordingSource& source) {
+                ++configure_calls;
+                source.command_list->AddCustomCommand(
+                    MakeUnique<ProbeCommand>(404),
+                    "IllegalConfigureCommand"
+                );
+            },
+            false,
+            [&](Moer::Array<RHIRecordingSource>&&) {
+                ++publish_calls;
+            },
+            RenderGraph::ActiveRecordingOptions{.enabled = true}
+        );
+        suite.Check(!executed, test_name, "mutating configuration unexpectedly succeeded");
+        suite.Check(
+            Contains(graph.GetCompileError(), "only change submit metadata"),
+            test_name,
+            graph.GetCompileError()
+        );
+        suite.Check(
+            configure_calls == 1 && record_calls == 0 && publish_calls == 0,
+            test_name,
+            "configuration mutation must fail before recording or publication"
+        );
+    }
+}
+
+void TestRecordingSourceSetupCannotCompleteProducerGate(TestSuite& suite) {
+    for (const bool active : {false, true}) {
+        for (const bool signal : {false, true}) {
+            const std::string test_name =
+                std::string(active ? "active" : "legacy") +
+                " source setup cannot replace producer gate with a " +
+                (signal ? "succeeded" : "failed") + " gate";
+            BufferRef buffer = MoerNew(FakeBuffer)(64);
+            RenderGraph graph("SetupCannotCompleteProducerGate");
+            const auto data = graph.ImportBuffer(
+                "Data",
+                buffer,
+                RenderGraph::BufferDesc{.byte_size = 64}
+            );
+            graph.SetInitialState(
+                data,
+                RenderGraph::BufferState::Undefined,
+                RenderGraph::QueueRole::None,
+                RenderGraph::AccessMode::None
+            );
+            int record_calls    = 0;
+            int configure_calls = 0;
+            int publish_calls   = 0;
+            graph.AddRecordPass(
+                "Write",
+                [=](RenderGraph::PassBuilder& builder) {
+                    builder.Write(data, RenderGraph::BufferState::UnorderedAccess)
+                        .SideEffect();
+                },
+                [&](CommandList&) {
+                    ++record_calls;
+                },
+                RenderGraph::PassExecutionClass::SerialRecord
+            );
+            graph.Export(
+                data,
+                RenderGraph::BufferState::ShaderResource,
+                RenderGraph::QueueRole::Graphics,
+                RenderGraph::AccessMode::Read
+            );
+
+            suite.Check(graph.Compile(), test_name, graph.GetCompileError());
+            const bool executed = graph.ExecuteRecording(
+                {},
+                [&](const RenderGraph::ExecutedPassInfo&, RHIRecordingSource& source) {
+                    ++configure_calls;
+                    auto replacement = RHIRecordingGate::Create();
+                    if (signal) {
+                        (void)replacement->Signal();
+                    } else {
+                        (void)replacement->Fail();
+                    }
+                    source.completion = replacement;
+                },
+                false,
+                [&](Moer::Array<RHIRecordingSource>&&) {
+                    ++publish_calls;
+                },
+                RenderGraph::ActiveRecordingOptions{.enabled = active}
+            );
+            suite.Check(
+                !executed,
+                test_name,
+                "source setup unexpectedly completed producer gate"
+            );
+            suite.Check(
+                Contains(graph.GetCompileError(), "changed ownership"),
+                test_name,
+                graph.GetCompileError()
+            );
+            suite.Check(
+                configure_calls == 1 && record_calls == 0 && publish_calls == 0,
+                test_name,
+                "terminal producer gate must fail before recording or publication"
+            );
+        }
+    }
+}
+
+void TestManagedRecordCallbackCannotSealOrDowngrade(TestSuite& suite) {
+    for (const auto execution :
+         {RenderGraph::PassExecutionClass::SerialRecord,
+          RenderGraph::PassExecutionClass::ParallelRecordEligible}) {
+        for (const bool seal : {false, true}) {
+            const std::string test_name =
+                std::string(
+                    execution == RenderGraph::PassExecutionClass::SerialRecord ?
+                        "serial" :
+                        "parallel-eligible"
+                ) +
+                " managed record callback cannot " +
+                (seal ? "seal" : "downgrade ownership");
+            BufferRef buffer = MoerNew(FakeBuffer)(64);
+            RenderGraph graph("ManagedRecordMutationRejected");
+            const auto data = graph.ImportBuffer(
+                "Data",
+                buffer,
+                RenderGraph::BufferDesc{.byte_size = 64}
+            );
+            graph.SetInitialState(
+                data,
+                RenderGraph::BufferState::Undefined,
+                RenderGraph::QueueRole::None,
+                RenderGraph::AccessMode::None
+            );
+            int record_calls  = 0;
+            int publish_calls = 0;
+            graph.AddRecordPass(
+                "Write",
+                [=](RenderGraph::PassBuilder& builder) {
+                    builder.Write(data, RenderGraph::BufferState::UnorderedAccess)
+                        .SideEffect();
+                },
+                [&](CommandList& commands) {
+                    ++record_calls;
+                    if (seal) {
+                        [[maybe_unused]] CmdSubmit discarded = commands.Submit();
+                    } else {
+                        commands.SetResourceStateOwnership(
+                            ERHIResourceStateOwnership::BackendTracked
+                        );
+                    }
+                },
+                execution
+            );
+            graph.Export(
+                data,
+                RenderGraph::BufferState::ShaderResource,
+                RenderGraph::QueueRole::Graphics,
+                RenderGraph::AccessMode::Read
+            );
+
+            suite.Check(graph.Compile(), test_name, graph.GetCompileError());
+            const bool executed = graph.ExecuteRecording(
+                {},
+                {},
+                true,
+                [&](Moer::Array<RHIRecordingSource>&&) {
+                    ++publish_calls;
+                },
+                RenderGraph::ActiveRecordingOptions{.enabled = true}
+            );
+            suite.Check(!executed, test_name, "managed mutation unexpectedly succeeded");
+            suite.Check(
+                Contains(
+                    graph.GetCompileError(),
+                    seal ? "Submit is forbidden while graph-managed recording is active" :
+                           "changed explicit state ownership"
+                ),
+                test_name,
+                graph.GetCompileError()
+            );
+            suite.Check(
+                record_calls == 1 && publish_calls == 1,
+                test_name,
+                "managed mutation must fail its already-admitted producer"
+            );
+        }
+    }
+}
+
+void TestManagedRecordCallbackCannotMoveCommandList(TestSuite& suite) {
+    for (const auto execution :
+         {RenderGraph::PassExecutionClass::SerialRecord,
+          RenderGraph::PassExecutionClass::ParallelRecordEligible}) {
+        for (const bool move_construct : {false, true}) {
+            const std::string test_name =
+                std::string(
+                    execution == RenderGraph::PassExecutionClass::SerialRecord ?
+                        "serial" :
+                        "parallel-eligible"
+                ) +
+                " managed record callback cannot " +
+                (move_construct ? "move-construct" : "move-assign") +
+                " CommandList";
+            BufferRef buffer = MoerNew(FakeBuffer)(64);
+            RenderGraph graph("ManagedRecordMoveRejected");
+            const auto data = graph.ImportBuffer(
+                "Data",
+                buffer,
+                RenderGraph::BufferDesc{.byte_size = 64}
+            );
+            graph.SetInitialState(
+                data,
+                RenderGraph::BufferState::Undefined,
+                RenderGraph::QueueRole::None,
+                RenderGraph::AccessMode::None
+            );
+            int record_calls  = 0;
+            int publish_calls = 0;
+            graph.AddRecordPass(
+                "Write",
+                [=](RenderGraph::PassBuilder& builder) {
+                    builder.Write(data, RenderGraph::BufferState::UnorderedAccess)
+                        .SideEffect();
+                },
+                [&](CommandList& commands) {
+                    ++record_calls;
+                    if (move_construct) {
+                        [[maybe_unused]] CommandList stolen(
+                            std::move(commands)
+                        );
+                    } else {
+                        commands = CommandList(EQueueType::Graphics);
+                    }
+                },
+                execution
+            );
+            graph.Export(
+                data,
+                RenderGraph::BufferState::ShaderResource,
+                RenderGraph::QueueRole::Graphics,
+                RenderGraph::AccessMode::Read
+            );
+
+            suite.Check(graph.Compile(), test_name, graph.GetCompileError());
+            const bool executed = graph.ExecuteRecording(
+                {},
+                {},
+                true,
+                [&](Moer::Array<RHIRecordingSource>&&) {
+                    ++publish_calls;
+                },
+                RenderGraph::ActiveRecordingOptions{.enabled = true}
+            );
+            suite.Check(!executed, test_name, "managed move unexpectedly succeeded");
+            suite.Check(
+                Contains(
+                    graph.GetCompileError(),
+                    "CommandList move is forbidden while graph-managed recording is active"
+                ),
+                test_name,
+                graph.GetCompileError()
+            );
+            suite.Check(
+                record_calls == 1 && publish_calls == 1,
+                test_name,
+                "managed move must fail its already-admitted producer"
+            );
+        }
+    }
+}
+
+void TestRecordProducerRejectsBlockingSync(TestSuite& suite) {
+    for (const auto execution :
+         {RenderGraph::PassExecutionClass::SerialRecord,
+          RenderGraph::PassExecutionClass::ParallelRecordEligible}) {
+        const std::string test_name =
+            std::string(
+                execution == RenderGraph::PassExecutionClass::SerialRecord ?
+                    "serial" :
+                    "parallel-eligible"
+            ) +
+            " record producer rejects blocking Sync";
+        BufferRef buffer = MoerNew(FakeBuffer)(64);
+        RenderGraph graph("RecordProducerRejectsSync");
+        const auto data = graph.ImportBuffer(
+            "Data",
+            buffer,
+            RenderGraph::BufferDesc{.byte_size = 64}
+        );
+        graph.SetInitialState(
+            data,
+            RenderGraph::BufferState::Undefined,
+            RenderGraph::QueueRole::None,
+            RenderGraph::AccessMode::None
+        );
+        int record_calls  = 0;
+        int publish_calls = 0;
+        graph.AddRecordPass(
+            "Write",
+            [=](RenderGraph::PassBuilder& builder) {
+                builder.Write(data, RenderGraph::BufferState::UnorderedAccess)
+                    .SideEffect();
+            },
+            [&](CommandList&) {
+                ++record_calls;
+                RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
+            },
+            execution
+        );
+        graph.Export(
+            data,
+            RenderGraph::BufferState::ShaderResource,
+            RenderGraph::QueueRole::Graphics,
+            RenderGraph::AccessMode::Read
+        );
+
+        suite.Check(graph.Compile(), test_name, graph.GetCompileError());
+        const bool executed = graph.ExecuteRecording(
+            {},
+            {},
+            true,
+            [&](Moer::Array<RHIRecordingSource>&&) {
+                ++publish_calls;
+            },
+            RenderGraph::ActiveRecordingOptions{.enabled = true}
+        );
+        suite.Check(!executed, test_name, "blocking Sync unexpectedly succeeded");
+        suite.Check(
+            Contains(graph.GetCompileError(), "blocking RHI lifecycle call"),
+            test_name,
+            graph.GetCompileError()
+        );
+        suite.Check(
+            record_calls == 1 && publish_calls == 1,
+            test_name,
+            "blocking call must fail the admitted producer without hanging"
+        );
+    }
+}
+
+void TestRecordingPublisherRejectsBlockingSync(TestSuite& suite) {
+    constexpr std::string_view test_name =
+        "recording publisher rejects blocking Sync";
+    BufferRef buffer = MoerNew(FakeBuffer)(64);
+    RenderGraph graph("PublisherRejectsSync");
+    const auto data = graph.ImportBuffer(
+        "Data",
+        buffer,
+        RenderGraph::BufferDesc{.byte_size = 64}
+    );
+    graph.SetInitialState(
+        data,
+        RenderGraph::BufferState::Undefined,
+        RenderGraph::QueueRole::None,
+        RenderGraph::AccessMode::None
+    );
+    int record_calls  = 0;
+    int publish_calls = 0;
+    graph.AddRecordPass(
+        "Write",
+        [=](RenderGraph::PassBuilder& builder) {
+            builder.Write(data, RenderGraph::BufferState::UnorderedAccess)
+                .SideEffect();
+        },
+        [&](CommandList&) {
+            ++record_calls;
+        },
+        RenderGraph::PassExecutionClass::SerialRecord
+    );
+    graph.Export(
+        data,
+        RenderGraph::BufferState::ShaderResource,
+        RenderGraph::QueueRole::Graphics,
+        RenderGraph::AccessMode::Read
+    );
+
+    suite.Check(graph.Compile(), test_name, graph.GetCompileError());
+    const bool executed = graph.ExecuteRecording(
+        {},
+        {},
+        false,
+        [&](Moer::Array<RHIRecordingSource>&&) {
+            ++publish_calls;
+            RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
+        },
+        RenderGraph::ActiveRecordingOptions{.enabled = true}
+    );
+    suite.Check(!executed, test_name, "blocking publisher unexpectedly succeeded");
+    suite.Check(
+        Contains(graph.GetCompileError(), "blocking RHI lifecycle call"),
+        test_name,
+        graph.GetCompileError()
+    );
+    suite.Check(
+        publish_calls == 1 && record_calls == 0,
+        test_name,
+        "publisher rejection must happen before producer dispatch"
+    );
+}
+
+void TestRecordingConfigurationRejectsBlockingSync(TestSuite& suite) {
+    constexpr std::string_view test_name =
+        "recording source configuration rejects blocking Sync";
+    BufferRef buffer = MoerNew(FakeBuffer)(64);
+    RenderGraph graph("ConfigurationRejectsSync");
+    const auto data = graph.ImportBuffer(
+        "Data",
+        buffer,
+        RenderGraph::BufferDesc{.byte_size = 64}
+    );
+    graph.SetInitialState(
+        data,
+        RenderGraph::BufferState::Undefined,
+        RenderGraph::QueueRole::None,
+        RenderGraph::AccessMode::None
+    );
+    int configure_calls = 0;
+    int record_calls    = 0;
+    int publish_calls   = 0;
+    graph.AddRecordPass(
+        "Write",
+        [=](RenderGraph::PassBuilder& builder) {
+            builder.Write(data, RenderGraph::BufferState::UnorderedAccess)
+                .SideEffect();
+        },
+        [&](CommandList&) {
+            ++record_calls;
+        },
+        RenderGraph::PassExecutionClass::SerialRecord
+    );
+    graph.Export(
+        data,
+        RenderGraph::BufferState::ShaderResource,
+        RenderGraph::QueueRole::Graphics,
+        RenderGraph::AccessMode::Read
+    );
+
+    suite.Check(graph.Compile(), test_name, graph.GetCompileError());
+    const bool executed = graph.ExecuteRecording(
+        {},
+        [&](const RenderGraph::ExecutedPassInfo&, RHIRecordingSource&) {
+            ++configure_calls;
+            RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
+        },
+        false,
+        [&](Moer::Array<RHIRecordingSource>&&) {
+            ++publish_calls;
+        },
+        RenderGraph::ActiveRecordingOptions{.enabled = true}
+    );
+    suite.Check(!executed, test_name, "blocking configuration unexpectedly succeeded");
+    suite.Check(
+        Contains(graph.GetCompileError(), "blocking RHI lifecycle call"),
+        test_name,
+        graph.GetCompileError()
+    );
+    suite.Check(
+        configure_calls == 1 && record_calls == 0 && publish_calls == 0,
+        test_name,
+        "configuration rejection must precede publication and recording"
+    );
+}
+
+void TestRecordingPublisherCannotMutatePendingSource(TestSuite& suite) {
+    constexpr std::string_view mutation_names[] = {
+        "seal CommandList",
+        "record command",
+    };
+    for (int mutation = 0; mutation < 2; ++mutation) {
+        const std::string test_name =
+            "recording publisher cannot " +
+            std::string(mutation_names[mutation]);
+        BufferRef buffer = MoerNew(FakeBuffer)(64);
+        RenderGraph graph("PublisherMutationRejected");
+        const auto data = graph.ImportBuffer(
+            "Data",
+            buffer,
+            RenderGraph::BufferDesc{.byte_size = 64}
+        );
+        graph.SetInitialState(
+            data,
+            RenderGraph::BufferState::Undefined,
+            RenderGraph::QueueRole::None,
+            RenderGraph::AccessMode::None
+        );
+        int record_calls  = 0;
+        int publish_calls = 0;
+        graph.AddRecordPass(
+            "Write",
+            [=](RenderGraph::PassBuilder& builder) {
+                builder.Write(data, RenderGraph::BufferState::UnorderedAccess)
+                    .SideEffect();
+            },
+            [&](CommandList&) {
+                ++record_calls;
+            },
+            RenderGraph::PassExecutionClass::SerialRecord
+        );
+        graph.Export(
+            data,
+            RenderGraph::BufferState::ShaderResource,
+            RenderGraph::QueueRole::Graphics,
+            RenderGraph::AccessMode::Read
+        );
+
+        suite.Check(graph.Compile(), test_name, graph.GetCompileError());
+        const bool executed = graph.ExecuteRecording(
+            {},
+            {},
+            false,
+            [&](Moer::Array<RHIRecordingSource>&& sources) {
+                ++publish_calls;
+                auto& source = sources.front();
+                switch (mutation) {
+                    case 0: {
+                        [[maybe_unused]] CmdSubmit discarded =
+                            source.command_list->Submit();
+                        break;
+                    }
+                    case 1:
+                        source.command_list->AddCustomCommand(
+                            MakeUnique<ProbeCommand>(505),
+                            "IllegalPublisherCommand"
+                        );
+                        break;
+                }
+            },
+            RenderGraph::ActiveRecordingOptions{.enabled = true}
+        );
+        suite.Check(!executed, test_name, "publisher mutation unexpectedly succeeded");
+        suite.Check(
+            Contains(
+                graph.GetCompileError(),
+                mutation == 0 ?
+                    "Submit is forbidden while graph-managed recording is active" :
+                    "publisher mutated pending source"
+            ),
+            test_name,
+            graph.GetCompileError()
+        );
+        suite.Check(
+            publish_calls == 1 && record_calls == 0,
+            test_name,
+            "publisher mutation must fail before producer dispatch"
+        );
+    }
+}
+
+void TestActiveRecordingGroupsCommitAtomically(TestSuite& suite) {
+    constexpr std::string_view test_name =
+        "active recording groups commit atomically";
+    BufferRef buffer = MoerNew(FakeBuffer)(64);
+    RenderGraph graph("ActiveRecordingTransaction");
+    const auto data = graph.ImportBuffer(
+        "Data",
+        buffer,
+        RenderGraph::BufferDesc{.byte_size = 64}
+    );
+    graph.SetInitialState(
+        data,
+        RenderGraph::BufferState::Undefined,
+        RenderGraph::QueueRole::None,
+        RenderGraph::AccessMode::None
+    );
+    int first_record_calls  = 0;
+    int second_record_calls = 0;
+    graph.AddRecordPass(
+        "FirstWrite",
+        [=](RenderGraph::PassBuilder& builder) {
+            builder.Write(data, RenderGraph::BufferState::UnorderedAccess)
+                .SideEffect();
+        },
+        [&](CommandList&) {
+            ++first_record_calls;
+        },
+        RenderGraph::PassExecutionClass::SerialRecord
+    );
+    graph.AddRecordPass(
+        "SecondReadFails",
+        [=](RenderGraph::PassBuilder& builder) {
+            builder.Read(data, RenderGraph::BufferState::ShaderResource)
+                .SideEffect();
+        },
+        [&](CommandList&) {
+            ++second_record_calls;
+            throw std::runtime_error("injected second-group failure");
+        },
+        RenderGraph::PassExecutionClass::SerialRecord
+    );
+    graph.Export(
+        data,
+        RenderGraph::BufferState::ShaderResource,
+        RenderGraph::QueueRole::Graphics,
+        RenderGraph::AccessMode::Read
+    );
+
+    Moer::Array<Moer::Array<RHIRecordingSource>> published_groups{};
+    suite.Check(graph.Compile(), test_name, graph.GetCompileError());
+    const bool executed = graph.ExecuteRecording(
+        {},
+        {},
+        false,
+        [&](Moer::Array<RHIRecordingSource>&& sources) {
+            published_groups.emplace_back(std::move(sources));
+        },
+        RenderGraph::ActiveRecordingOptions{.enabled = true}
+    );
+    suite.Check(!executed, test_name, "failing graph unexpectedly committed");
+    suite.Check(
+        Contains(graph.GetCompileError(), "injected second-group failure"),
+        test_name,
+        graph.GetCompileError()
+    );
+    suite.Check(
+        first_record_calls == 1 && second_record_calls == 1 &&
+            published_groups.size() == 2,
+        test_name,
+        "both recording groups were not admitted and joined"
+    );
+
+    RHIRecordingGateView shared_commit{};
+    for (auto& group : published_groups) {
+        suite.Check(
+            group.size() == 1 && group.front().commit,
+            test_name,
+            "published source is missing its graph commit gate"
+        );
+        if (group.empty() || !group.front().commit) {
+            continue;
+        }
+        if (!shared_commit) {
+            shared_commit = group.front().commit;
+        }
+        suite.Check(
+            group.front().commit == shared_commit &&
+            group.front().commit.Status() ==
+                    ERHIRecordingStatus::Failed,
+            test_name,
+            "recording groups did not share one failed transaction"
+        );
+        auto cleanup =
+            group.front().command_list->DrainOrdinaryCallbacksForRejection();
+        for (auto& callback : cleanup) {
+            if (callback) {
+                callback();
+            }
+        }
+    }
+}
+
+void TestActiveMixedMainThreadAndRecordFailsBeforeCallbacks(TestSuite& suite) {
+    constexpr std::string_view test_name =
+        "active mixed MainThread and record passes fail closed";
+    BufferRef buffer = MoerNew(FakeBuffer)(64);
+    CommandList caller_commands(EQueueType::Graphics);
+    RenderGraph graph("MixedMainAndRecordRejected");
+    const auto data = graph.ImportBuffer(
+        "Data",
+        buffer,
+        RenderGraph::BufferDesc{.byte_size = 64}
+    );
+    const auto token = graph.CreateTransientToken("MainToRecordToken");
+    graph.SetInitialState(
+        data,
+        RenderGraph::BufferState::Undefined,
+        RenderGraph::QueueRole::None,
+        RenderGraph::AccessMode::None
+    );
+    int main_calls    = 0;
+    int record_calls  = 0;
+    int publish_calls = 0;
+    const auto main_pass = graph.AddPass(
+        "MainWrite",
+        [=](RenderGraph::PassBuilder& builder) {
+            builder.Write(data, RenderGraph::BufferState::UnorderedAccess)
+                .Write(token)
+                .SideEffect();
+        },
+        [&] {
+            ++main_calls;
+        }
+    );
+    graph.AddRecordPass(
+        "TokenOnlyRecord",
+        [=](RenderGraph::PassBuilder& builder) {
+            builder.Read(token)
+                .DependsOn(main_pass)
+                .SideEffect();
+        },
+        [&](CommandList&) {
+            ++record_calls;
+        },
+        RenderGraph::PassExecutionClass::SerialRecord
+    );
+    graph.Export(
+        data,
+        RenderGraph::BufferState::ShaderResource,
+        RenderGraph::QueueRole::Graphics,
+        RenderGraph::AccessMode::Read
+    );
+
+    suite.Check(graph.Compile(), test_name, graph.GetCompileError());
+    const bool executed = graph.ExecuteRecording(
+        {},
+        {},
+        false,
+        [&](Moer::Array<RHIRecordingSource>&&) {
+            ++publish_calls;
+        },
+        RenderGraph::ActiveRecordingOptions{
+            .enabled                  = true,
+            .main_thread_command_list = &caller_commands,
+        }
+    );
+    suite.Check(!executed, test_name, "mixed active execution unexpectedly succeeded");
+    suite.Check(
+        Contains(graph.GetCompileError(), "does not yet support mixing"),
+        test_name,
+        graph.GetCompileError()
+    );
+    suite.Check(
+        main_calls == 0 && record_calls == 0 && publish_calls == 0 &&
+            caller_commands.IsEmpty(),
+        test_name,
+        "mixed-path rejection must precede callbacks and materialization"
+    );
+}
+
+void TestActiveMainThreadCallbackCannotSealOrDowngrade(TestSuite& suite) {
+    for (const bool seal : {false, true}) {
+        const std::string test_name =
+            std::string("active MainThread callback cannot ") +
+            (seal ? "seal" : "downgrade ownership");
+        BufferRef buffer = MoerNew(FakeBuffer)(64);
+        CommandList caller_commands(EQueueType::Graphics);
+        RenderGraph graph("MainThreadMutationRejected");
+        const auto data = graph.ImportBuffer(
+            "Data",
+            buffer,
+            RenderGraph::BufferDesc{.byte_size = 64}
+        );
+        graph.SetInitialState(
+            data,
+            RenderGraph::BufferState::Undefined,
+            RenderGraph::QueueRole::None,
+            RenderGraph::AccessMode::None
+        );
+        int execute_calls = 0;
+        graph.AddPass(
+            "MainWrite",
+            [=](RenderGraph::PassBuilder& builder) {
+                builder.Write(data, RenderGraph::BufferState::UnorderedAccess)
+                    .SideEffect();
+            },
+            [&] {
+                ++execute_calls;
+                if (seal) {
+                    [[maybe_unused]] CmdSubmit discarded =
+                        caller_commands.Submit();
+                } else {
+                    caller_commands.SetResourceStateOwnership(
+                        ERHIResourceStateOwnership::BackendTracked
+                    );
+                }
+            }
+        );
+        graph.Export(
+            data,
+            RenderGraph::BufferState::ShaderResource,
+            RenderGraph::QueueRole::Graphics,
+            RenderGraph::AccessMode::Read
+        );
+
+        suite.Check(graph.Compile(), test_name, graph.GetCompileError());
+        const bool executed = graph.ExecuteRecording(
+            {},
+            {},
+            false,
+            {},
+            RenderGraph::ActiveRecordingOptions{
+                .enabled                  = true,
+                .main_thread_command_list = &caller_commands,
+            }
+        );
+        suite.Check(!executed, test_name, "MainThread mutation unexpectedly succeeded");
+        suite.Check(
+            Contains(
+                graph.GetCompileError(),
+                seal ? "Submit is forbidden while graph-managed recording is active" :
+                       "changed explicit state ownership"
+            ),
+            test_name,
+            graph.GetCompileError()
+        );
+        suite.Check(
+            execute_calls == 1,
+            test_name,
+            "MainThread mutation callback was not executed exactly once"
+        );
+        suite.Check(
+            caller_commands.IsEmpty() &&
+                !caller_commands.HasExplicitResourceStateOwnership(),
+            test_name,
+            "rejected MainThread commands remained GPU-submittable"
+        );
+    }
+}
+
+void TestActiveRecordingLifetimeOutlivesUserCallbacks(TestSuite& suite) {
+    constexpr std::string_view test_name =
+        "active recording lifetime outlives ordinary and success callbacks";
+    auto destroyed = std::make_shared<bool>(false);
+    std::vector<int> callback_order{};
+    Moer::Array<RHIRecordingSource> published{};
+
+    {
+        BufferRef buffer = MoerNew(LifetimeProbeBuffer)(destroyed);
+        Buffer* raw_buffer = buffer.Get();
+        RenderGraph graph("RecordingLifetimeTail");
+        const auto data = graph.ImportBuffer(
+            "Data",
+            buffer,
+            RenderGraph::BufferDesc{.byte_size = 64}
+        );
+        graph.SetInitialState(
+            data,
+            RenderGraph::BufferState::Undefined,
+            RenderGraph::QueueRole::None,
+            RenderGraph::AccessMode::None
+        );
+        graph.AddRecordPass(
+            "Write",
+            [=](RenderGraph::PassBuilder& builder) {
+                builder.Write(data, RenderGraph::BufferState::UnorderedAccess)
+                    .SideEffect();
+            },
+            [&](CommandList& commands) {
+                commands.AddCallback([&, raw_buffer, destroyed] {
+                    suite.Check(
+                        !*destroyed && raw_buffer->GetByteSize() == 64,
+                        test_name,
+                        "resource died before an ordinary user callback"
+                    );
+                    callback_order.push_back(1);
+                });
+                commands.AddSuccessCallback([&, raw_buffer, destroyed] {
+                    suite.Check(
+                        !*destroyed && raw_buffer->GetByteSize() == 64,
+                        test_name,
+                        "resource died before a success user callback"
+                    );
+                    callback_order.push_back(2);
+                });
+            },
+            RenderGraph::PassExecutionClass::SerialRecord
+        );
+        graph.Export(
+            data,
+            RenderGraph::BufferState::ShaderResource,
+            RenderGraph::QueueRole::Graphics,
+            RenderGraph::AccessMode::Read
+        );
+
+        suite.Check(graph.Compile(), test_name, graph.GetCompileError());
+        suite.Check(
+            graph.ExecuteRecording(
+                {},
+                {},
+                false,
+                [&](Moer::Array<RHIRecordingSource>&& sources) {
+                    published = std::move(sources);
+                },
+                RenderGraph::ActiveRecordingOptions{.enabled = true}
+            ),
+            test_name,
+            graph.GetCompileError()
+        );
+    }
+
+    suite.Check(
+        !*destroyed && published.size() == 1,
+        test_name,
+        "recording lifetime did not survive graph destruction"
+    );
+    if (published.size() != 1) {
+        return;
+    }
+    CmdSubmit submit = published.front().command_list->Submit();
+    submit.cmds.clear();
+    submit.cached_args.clear();
+    for (auto& callback : submit.callbacks) {
+        callback();
+    }
+    for (auto& callback : submit.success_callbacks) {
+        callback();
+    }
+    suite.Check(
+        !*destroyed && callback_order == std::vector<int>{1, 2},
+        test_name,
+        "lifetime did not cover both callback classes in order"
+    );
+    submit.callbacks.clear();
+    submit.success_callbacks.clear();
+    published.clear();
+    suite.Check(
+        *destroyed,
+        test_name,
+        "recording lifetime was retained after all callback payloads were released"
+    );
+}
+
+void TestActiveMainThreadExceptionIsReportedAndDrained(TestSuite& suite) {
+    constexpr std::string_view test_name =
+        "active MainThread exception is reported and drained";
+    BufferRef buffer = MoerNew(FakeBuffer)(64);
+    CommandList caller_commands(EQueueType::Graphics);
+    RenderGraph graph("MainThreadException");
+    const auto data = graph.ImportBuffer(
+        "Data",
+        buffer,
+        RenderGraph::BufferDesc{.byte_size = 64}
+    );
+    graph.SetInitialState(
+        data,
+        RenderGraph::BufferState::Undefined,
+        RenderGraph::QueueRole::None,
+        RenderGraph::AccessMode::None
+    );
+    graph.AddPass(
+        "ThrowingMain",
+        [=](RenderGraph::PassBuilder& builder) {
+            builder.Write(data, RenderGraph::BufferState::UnorderedAccess)
+                .SideEffect();
+        },
+        [] {
+            throw std::runtime_error("injected main failure");
+        }
+    );
+    graph.Export(
+        data,
+        RenderGraph::BufferState::ShaderResource,
+        RenderGraph::QueueRole::Graphics,
+        RenderGraph::AccessMode::Read
+    );
+
+    suite.Check(graph.Compile(), test_name, graph.GetCompileError());
+    bool escaped = false;
+    bool executed = false;
+    try {
+        executed = graph.ExecuteRecording(
+            {},
+            {},
+            false,
+            {},
+            RenderGraph::ActiveRecordingOptions{
+                .enabled                  = true,
+                .main_thread_command_list = &caller_commands,
+            }
+        );
+    } catch (...) {
+        escaped = true;
+    }
+    suite.Check(
+        !escaped && !executed &&
+            Contains(graph.GetCompileError(), "injected main failure"),
+        test_name,
+        graph.GetCompileError()
+    );
+    suite.Check(
+        caller_commands.IsEmpty() &&
+            !caller_commands.HasExplicitResourceStateOwnership(),
+        test_name,
+        "failed MainThread stream remained GPU-submittable"
+    );
+}
+
+void TestMainThreadPhysicalPassRequiresAndUsesCallerList(TestSuite& suite) {
+    {
+        constexpr std::string_view test_name =
+            "main-thread physical pass requires caller CommandList";
+        BufferRef buffer = MoerNew(FakeBuffer)(64);
+        RenderGraph graph("ActiveMainThreadMissingList");
+        const auto  data = graph.ImportBuffer(
+            "Data",
+            buffer,
+            RenderGraph::BufferDesc{.byte_size = 64}
+        );
+        graph.SetInitialState(
+            data,
+            RenderGraph::BufferState::Undefined,
+            RenderGraph::QueueRole::None,
+            RenderGraph::AccessMode::None
+        );
+        int execute_calls = 0;
+        int observer_calls = 0;
+        graph.AddPass(
+            "MainWrite",
+            [=](RenderGraph::PassBuilder& builder) {
+                builder.Write(data, RenderGraph::BufferState::UnorderedAccess)
+                    .SideEffect();
+            },
+            [&] {
+                ++execute_calls;
+            }
+        );
+        graph.Export(
+            data,
+            RenderGraph::BufferState::ShaderResource,
+            RenderGraph::QueueRole::Graphics,
+            RenderGraph::AccessMode::Read
+        );
+
+        suite.Check(graph.Compile(), test_name, graph.GetCompileError());
+        const bool executed = graph.ExecuteRecording(
+            [&](const RenderGraph::ExecutedPassInfo&) {
+                ++observer_calls;
+            },
+            {},
+            false,
+            {},
+            RenderGraph::ActiveRecordingOptions{.enabled = true}
+        );
+        suite.Check(!executed, test_name, "execution unexpectedly succeeded without a list");
+        suite.Check(
+            Contains(graph.GetCompileError(), "caller-owned CommandList"),
+            test_name,
+            graph.GetCompileError()
+        );
+        suite.Check(
+            execute_calls == 0 && observer_calls == 0,
+            test_name,
+            "missing-list validation must precede the main-thread callback and observer"
+        );
+    }
+
+    {
+        constexpr std::string_view test_name =
+            "active MainThread physical pass defers submission until graph return";
+        BufferRef buffer = MoerNew(FakeBuffer)(64);
+        CommandList caller_commands(EQueueType::Graphics);
+        RenderGraph graph("ActiveMainThreadObserverRejected");
+        const auto data = graph.ImportBuffer(
+            "Data",
+            buffer,
+            RenderGraph::BufferDesc{.byte_size = 64}
+        );
+        graph.SetInitialState(
+            data,
+            RenderGraph::BufferState::Undefined,
+            RenderGraph::QueueRole::None,
+            RenderGraph::AccessMode::None
+        );
+        int execute_calls  = 0;
+        int observer_calls = 0;
+        graph.AddPass(
+            "MainWrite",
+            [=](RenderGraph::PassBuilder& builder) {
+                builder.Write(data, RenderGraph::BufferState::UnorderedAccess)
+                    .SideEffect();
+            },
+            [&] {
+                ++execute_calls;
+            }
+        );
+        graph.Export(
+            data,
+            RenderGraph::BufferState::ShaderResource,
+            RenderGraph::QueueRole::Graphics,
+            RenderGraph::AccessMode::Read
+        );
+
+        suite.Check(graph.Compile(), test_name, graph.GetCompileError());
+        const bool executed = graph.ExecuteRecording(
+            [&](const RenderGraph::ExecutedPassInfo&) {
+                ++observer_calls;
+            },
+            {},
+            false,
+            {},
+            RenderGraph::ActiveRecordingOptions{
+                .enabled                  = true,
+                .main_thread_command_list = &caller_commands,
+            }
+        );
+        suite.Check(!executed, test_name, "per-pass active submission was accepted");
+        suite.Check(
+            Contains(graph.GetCompileError(), "remain unsealed"),
+            test_name,
+            graph.GetCompileError()
+        );
+        suite.Check(
+            execute_calls == 0 && observer_calls == 0 &&
+                caller_commands.IsEmpty(),
+            test_name,
+            "observer restriction must be validated before materialization"
+        );
+    }
+
+    {
+        constexpr std::string_view test_name =
+            "main-thread physical pass materializes into caller CommandList";
+        BufferRef buffer = MoerNew(FakeBuffer)(64);
+        CommandList caller_commands(EQueueType::Graphics);
+        RenderGraph graph("ActiveMainThreadCallerList");
+        const auto  data = graph.ImportBuffer(
+            "Data",
+            buffer,
+            RenderGraph::BufferDesc{.byte_size = 64}
+        );
+        graph.SetInitialState(
+            data,
+            RenderGraph::BufferState::Undefined,
+            RenderGraph::QueueRole::None,
+            RenderGraph::AccessMode::None
+        );
+        graph.AddPass(
+            "MainWrite",
+            [=](RenderGraph::PassBuilder& builder) {
+                builder.Write(data, RenderGraph::BufferState::UnorderedAccess)
+                    .SideEffect();
+            },
+            [&] {
+                caller_commands.AddCustomCommand(
+                    MakeUnique<ProbeCommand>(303),
+                    "MainThreadBody"
+                );
+            }
+        );
+        graph.Export(
+            data,
+            RenderGraph::BufferState::ShaderResource,
+            RenderGraph::QueueRole::Graphics,
+            RenderGraph::AccessMode::Read
+        );
+
+        suite.Check(graph.Compile(), test_name, graph.GetCompileError());
+        const bool executed = graph.ExecuteRecording(
+            {},
+            {},
+            false,
+            {},
+            RenderGraph::ActiveRecordingOptions{
+                .enabled                  = true,
+                .main_thread_command_list = &caller_commands,
+            }
+        );
+        suite.Check(executed, test_name, graph.GetCompileError());
+
+        CmdSubmit submit = caller_commands.Submit();
+        suite.Check(
+            submit.HasExplicitResourceStateOwnership() && submit.cmds.size() == 3,
+            test_name,
+            "caller list must seal an Explicit before-body-after stream"
+        );
+        if (submit.cmds.size() == 3) {
+            const auto* before = AsBarrier(submit.cmds[0]);
+            const auto* body   = AsProbe(submit.cmds[1]);
+            const auto* after  = AsBarrier(submit.cmds[2]);
+            suite.Check(
+                before != nullptr && before->ExplicitBuffers().size() == 1 &&
+                    body != nullptr && body->Marker() == 303 &&
+                    after != nullptr && after->ExplicitBuffers().size() == 1,
+                test_name,
+                "main-thread barriers must be materialized around its callback body"
+            );
+        }
+    }
+}
+
+} // namespace
+
+int main() {
+    TestSuite suite;
+    TestRecordPassMaterializesExplicitBeforeBodyAfter(suite);
+    TestSameStateSecondReadMaterializesStateSeed(suite);
+    TestUnsupportedInputsFailBeforeCallbacksOrPublish(suite);
+    TestRecordingSourceSetupCannotCompleteProducerGate(suite);
+    TestManagedRecordCallbackCannotSealOrDowngrade(suite);
+    TestManagedRecordCallbackCannotMoveCommandList(suite);
+    TestRecordProducerRejectsBlockingSync(suite);
+    TestRecordingPublisherRejectsBlockingSync(suite);
+    TestRecordingConfigurationRejectsBlockingSync(suite);
+    TestRecordingPublisherCannotMutatePendingSource(suite);
+    TestActiveRecordingGroupsCommitAtomically(suite);
+    TestActiveMixedMainThreadAndRecordFailsBeforeCallbacks(suite);
+    TestActiveMainThreadCallbackCannotSealOrDowngrade(suite);
+    TestActiveRecordingLifetimeOutlivesUserCallbacks(suite);
+    TestActiveMainThreadExceptionIsReportedAndDrained(suite);
+    TestMainThreadPhysicalPassRequiresAndUsesCallerList(suite);
+
+    if (suite.FailureCount() != 0) {
+        std::cerr << "TestRenderGraphActiveLowering: " << suite.FailureCount()
+                  << " failure(s)\n";
+        return EXIT_FAILURE;
+    }
+    std::cout << "TestRenderGraphActiveLowering: all checks passed\n";
+    return EXIT_SUCCESS;
+}

--- a/source/test/RenderGraphLoweringTest.cpp
+++ b/source/test/RenderGraphLoweringTest.cpp
@@ -1,0 +1,713 @@
+#include "rendergraph/RenderGraph.h"
+#include "rendergraph/RenderGraphLowering.h"
+#include "rhi/RHIResource.h"
+
+#include <algorithm>
+#include <cstdlib>
+#include <iostream>
+#include <string>
+#include <string_view>
+
+namespace {
+
+using Moer::Render::Buffer;
+using Moer::Render::BufferInfo;
+using Moer::Render::BufferRef;
+using Moer::Render::RenderGraph;
+using Moer::Render::RenderGraphLowering;
+using Moer::Render::Texture;
+using Moer::Render::TextureInfo;
+using Moer::Render::TextureRef;
+
+class TestSuite {
+public:
+    void Check(bool condition, std::string_view test, std::string_view message) {
+        if (condition) {
+            return;
+        }
+        ++failures;
+        std::cerr << "[FAIL] " << test << ": " << message << "\n";
+    }
+
+    [[nodiscard]] int FailureCount() const {
+        return failures;
+    }
+
+private:
+    int failures = 0;
+};
+
+[[nodiscard]] bool Contains(std::string_view text, std::string_view expected) {
+    return text.find(expected) != std::string_view::npos;
+}
+
+class FakeTexture final : public Texture {
+public:
+    FakeTexture(uint8_t mips, uint16_t layers, ETextureAspectFlags aspects) :
+        Texture(MakeInfo(mips, layers, aspects)) {}
+
+    Moer::uint GetMipByteSize(Moer::uint) const override {
+        return 4;
+    }
+
+    void SetName(std::string_view) override {}
+
+private:
+    static TextureInfo
+    MakeInfo(uint8_t mips, uint16_t layers, ETextureAspectFlags aspects) {
+        TextureInfo info{};
+        info.usage = ETextureUsageFlags::SAMPLED |
+                     ETextureUsageFlags::UNORDERED_ACCESS |
+                     ETextureUsageFlags::COLOR_ATTACHMENT |
+                     ETextureUsageFlags::DEPTH_STENCIL_ATTACHMENT |
+                     ETextureUsageFlags::TRANSFER_SRC |
+                     ETextureUsageFlags::TRANSFER_DST;
+        info.extent       = {64, 64};
+        info.num_mips     = mips;
+        info.array_size   = layers;
+        info.aspect_flags = aspects;
+        return info;
+    }
+};
+
+class FakeBuffer final : public Buffer {
+public:
+    explicit FakeBuffer(uint64_t byte_size) :
+        Buffer(BufferInfo{
+            byte_size,
+            1,
+            EBufferUsageFlags::UNORDERED_ACCESS |
+                EBufferUsageFlags::TRANSFER_SRC |
+                EBufferUsageFlags::TRANSFER_DST
+        }) {}
+
+    void SetName(std::string_view) override {}
+};
+
+template<typename Enum>
+[[nodiscard]] bool HasFlag(Enum value, Enum flag) {
+    return (static_cast<uint32_t>(value) & static_cast<uint32_t>(flag)) != 0;
+}
+
+void TestTextureFanInAndDeterminism(TestSuite& suite) {
+    constexpr std::string_view test_name = "texture fan-in and deterministic lowering";
+    TextureRef texture = MoerNew(FakeTexture)(2, 1, ETextureAspectFlags::COLOR);
+
+    RenderGraph graph("TextureFanIn");
+    const auto  color = graph.ImportTexture(
+        "Color",
+        texture,
+        RenderGraph::TextureDesc{
+            .mip_count   = 2,
+            .layer_count = 1,
+            .aspects     = RenderGraph::TextureAspect::Color,
+        }
+    );
+    const auto range = RenderGraph::TextureRange::Mips(0, 1);
+    graph.SetInitialState(
+        color,
+        RenderGraph::TextureState::Undefined,
+        RenderGraph::QueueRole::None,
+        RenderGraph::AccessMode::None,
+        range
+    );
+    const auto writer = graph.AddPass(
+        "Writer",
+        [=](RenderGraph::PassBuilder& builder) {
+            builder.Write(color, RenderGraph::TextureState::RenderTarget, range).SideEffect();
+        },
+        [] {}
+    );
+    const auto graphics_reader = graph.AddPass(
+        "GraphicsReader",
+        [=](RenderGraph::PassBuilder& builder) {
+            builder.Read(color, RenderGraph::TextureState::ShaderResource, range).SideEffect();
+        },
+        [] {}
+    );
+    const auto compute_reader = graph.AddPass(
+        "ComputeReader",
+        [=](RenderGraph::PassBuilder& builder) {
+                builder.ExecuteOn(
+                           RenderGraph::QueueRole::Graphics,
+                           RenderGraph::PipelineType::Compute
+                   )
+                .Read(color, RenderGraph::TextureState::ShaderResource, range)
+                .SideEffect();
+        },
+        [] {}
+    );
+    const auto uav_writer = graph.AddPass(
+        "UavWriter",
+        [=](RenderGraph::PassBuilder& builder) {
+            builder.ExecuteOn(
+                       RenderGraph::QueueRole::Graphics,
+                       RenderGraph::PipelineType::Compute
+                   )
+                .Write(color, RenderGraph::TextureState::UnorderedAccess, range)
+                .SideEffect();
+        },
+        [] {}
+    );
+    graph.Export(
+        color,
+        RenderGraph::TextureState::ShaderResource,
+        RenderGraph::QueueRole::Graphics,
+        RenderGraph::AccessMode::Read,
+        range
+    );
+
+    suite.Check(graph.Compile(), test_name, graph.GetCompileError());
+    RenderGraphLowering::LoweredPlan first{};
+    RenderGraphLowering::LoweredPlan second{};
+    std::string error{};
+    suite.Check(
+        RenderGraphLowering::Lower(graph, first, error),
+        test_name,
+        error
+    );
+    suite.Check(
+        RenderGraphLowering::Lower(graph, second, error),
+        test_name,
+        error
+    );
+    suite.Check(first.Dump() == second.Dump(), test_name, "lowered dumps must be deterministic");
+    suite.Check(
+        first.prologue.size() == 1 &&
+            first.prologue.front().discard_previous_contents &&
+            first.prologue.front().source.layout ==
+                ETextureLayout::TEXTURE_LAYOUT_UNDEFINED &&
+            first.prologue.front().destination.layout ==
+                ETextureLayout::TEXTURE_LAYOUT_COLOR_ATTACHMENT &&
+            first.prologue.front().range.texture.mip_count == 1 &&
+            first.prologue.front().texture_aspects == ETextureAspectFlags::COLOR,
+        test_name,
+        "prologue must retain discard, normalized range, aspect and layouts"
+    );
+
+    const auto before_uav = first.Before(uav_writer);
+    const auto fan_in = std::find_if(
+        before_uav.begin(),
+        before_uav.end(),
+        [](const RenderGraphLowering::LoweredInstruction& instruction) {
+            return instruction.instruction_kind ==
+                       RenderGraphLowering::InstructionKind::Barrier &&
+                   instruction.after_state ==
+                       RenderGraph::ResourceState::Texture(
+                           RenderGraph::TextureState::UnorderedAccess
+                       );
+        }
+    );
+    suite.Check(
+        fan_in != before_uav.end() && fan_in->source_frontier.size() >= 2 &&
+            HasFlag(fan_in->source.stages, ERHIPipelineStageFlags::PS_ALL_GRAPHICS) &&
+            HasFlag(fan_in->source.stages, ERHIPipelineStageFlags::PS_COMPUTE_SHADER) &&
+            fan_in->source.access == ERHIAccessFlags::SHADER_READ &&
+            fan_in->source.layout == ETextureLayout::TEXTURE_LAYOUT_COMMON,
+        test_name,
+        "fan-in source stages and accesses must be ORed across the authoritative frontier"
+    );
+    suite.Check(
+        first.Keepalive(writer).size() == 1 &&
+            first.Keepalive(graphics_reader).size() == 1 &&
+            first.Keepalive(compute_reader).size() == 1 &&
+            first.Keepalive(uav_writer).size() == 1 &&
+            first.Keepalive(compute_reader).front().texture.Get() == texture.Get(),
+        test_name,
+        "every GPU pass must retain its physical resource"
+    );
+    suite.Check(
+        first.After(uav_writer).size() == 1 &&
+            first.After(uav_writer).front().export_boundary,
+        test_name,
+        "epilogue must be attached after its latest source pass"
+    );
+}
+
+void TestShaderResourceAndSampledLayoutsRemainDistinct(TestSuite& suite) {
+    constexpr std::string_view test_name =
+        "shader-resource and sampled layouts remain distinct";
+    TextureRef texture = MoerNew(FakeTexture)(1, 1, ETextureAspectFlags::COLOR);
+
+    RenderGraph graph("DistinctShaderReadLayouts");
+    const auto color = graph.ImportTexture(
+        "Color",
+        texture,
+        RenderGraph::TextureDesc{}
+    );
+    graph.SetInitialState(
+        color,
+        RenderGraph::TextureState::ShaderResource,
+        RenderGraph::QueueRole::Graphics,
+        RenderGraph::AccessMode::Read
+    );
+    graph.AddPass(
+        "StorageRead",
+        [=](RenderGraph::PassBuilder& builder) {
+            builder.Read(color, RenderGraph::TextureState::ShaderResource).SideEffect();
+        },
+        [] {}
+    );
+    const auto sampled_read = graph.AddPass(
+        "SampledRead",
+        [=](RenderGraph::PassBuilder& builder) {
+            builder.Read(color, RenderGraph::TextureState::Sampled).SideEffect();
+        },
+        [] {}
+    );
+    graph.Export(
+        color,
+        RenderGraph::TextureState::Sampled,
+        RenderGraph::QueueRole::Graphics,
+        RenderGraph::AccessMode::Read
+    );
+
+    suite.Check(graph.Compile(), test_name, graph.GetCompileError());
+    RenderGraphLowering::LoweredPlan lowered{};
+    std::string error{};
+    suite.Check(RenderGraphLowering::Lower(graph, lowered, error), test_name, error);
+    const auto before_sampled = lowered.Before(sampled_read);
+    const auto transition = std::find_if(
+        before_sampled.begin(),
+        before_sampled.end(),
+        [](const RenderGraphLowering::LoweredInstruction& instruction) {
+            return instruction.instruction_kind ==
+                       RenderGraphLowering::InstructionKind::Barrier &&
+                   instruction.state_transition;
+        }
+    );
+    suite.Check(
+        transition != before_sampled.end() &&
+            transition->source.layout == ETextureLayout::TEXTURE_LAYOUT_COMMON &&
+            transition->destination.layout ==
+                ETextureLayout::TEXTURE_LAYOUT_SHADER_READ_ONLY_OPTIMAL &&
+            transition->source.access == ERHIAccessFlags::SHADER_READ &&
+            transition->destination.access == ERHIAccessFlags::SHADER_READ,
+        test_name,
+        "the compiler/lowerer must preserve the physical SRV-to-sampled layout transition"
+    );
+}
+
+void TestDepthAttachmentReadUsesBackendAttachmentLayout(TestSuite& suite) {
+    constexpr std::string_view test_name =
+        "depth attachment read uses backend attachment layout";
+    TextureRef texture = MoerNew(FakeTexture)(1, 1, ETextureAspectFlags::DEPTH_SLICE);
+
+    RenderGraph graph("DepthAttachmentReadLayout");
+    const auto depth = graph.ImportTexture(
+        "Depth",
+        texture,
+        RenderGraph::TextureDesc{
+            .mip_count   = 1,
+            .layer_count = 1,
+            .aspects     = RenderGraph::TextureAspect::Depth,
+        }
+    );
+    graph.SetInitialState(
+        depth,
+        RenderGraph::TextureState::Undefined,
+        RenderGraph::QueueRole::None,
+        RenderGraph::AccessMode::None
+    );
+    graph.AddPass(
+        "DepthWrite",
+        [=](RenderGraph::PassBuilder& builder) {
+            builder.Write(depth, RenderGraph::TextureState::DepthStencilWrite).SideEffect();
+        },
+        [] {}
+    );
+    const auto depth_read = graph.AddPass(
+        "DepthRead",
+        [=](RenderGraph::PassBuilder& builder) {
+            builder.Read(depth, RenderGraph::TextureState::DepthStencilRead).SideEffect();
+        },
+        [] {}
+    );
+    graph.Export(
+        depth,
+        RenderGraph::TextureState::DepthStencilRead,
+        RenderGraph::QueueRole::Graphics,
+        RenderGraph::AccessMode::Read
+    );
+
+    suite.Check(graph.Compile(), test_name, graph.GetCompileError());
+    RenderGraphLowering::LoweredPlan lowered{};
+    std::string error{};
+    suite.Check(RenderGraphLowering::Lower(graph, lowered, error), test_name, error);
+
+    const auto before_read = lowered.Before(depth_read);
+    const auto transition = std::find_if(
+        before_read.begin(),
+        before_read.end(),
+        [](const RenderGraphLowering::LoweredInstruction& instruction) {
+            return instruction.instruction_kind ==
+                       RenderGraphLowering::InstructionKind::Barrier &&
+                   instruction.after_state ==
+                       RenderGraph::ResourceState::Texture(
+                           RenderGraph::TextureState::DepthStencilRead
+                       );
+        }
+    );
+    suite.Check(
+        transition != before_read.end() &&
+            transition->destination.layout ==
+                ETextureLayout::TEXTURE_LAYOUT_DEPTH_STENCIL_WRITE &&
+            transition->destination.access == ERHIAccessFlags::DEPTH_STENCIL_READ,
+        test_name,
+        "load-only depth attachments must match the backend attachment layout while retaining read access"
+    );
+}
+
+void TestSameStateReadGetsStateSeed(TestSuite& suite) {
+    constexpr std::string_view test_name = "same-state read receives explicit state seed";
+    BufferRef buffer = MoerNew(FakeBuffer)(256);
+
+    RenderGraph graph("ReadSeed");
+    const auto data = graph.ImportBuffer(
+        "Data",
+        buffer,
+        RenderGraph::BufferDesc{.byte_size = 256}
+    );
+    graph.SetInitialState(
+        data,
+        RenderGraph::BufferState::ShaderResource,
+        RenderGraph::QueueRole::Graphics,
+        RenderGraph::AccessMode::Read
+    );
+    const auto first_read = graph.AddPass(
+        "FirstRead",
+        [=](RenderGraph::PassBuilder& builder) {
+            builder.Read(data, RenderGraph::BufferState::ShaderResource).SideEffect();
+        },
+        [] {}
+    );
+    const auto second_read = graph.AddPass(
+        "SecondRead",
+        [=](RenderGraph::PassBuilder& builder) {
+            builder.Read(data, RenderGraph::BufferState::ShaderResource).SideEffect();
+        },
+        [] {}
+    );
+    graph.Export(
+        data,
+        RenderGraph::BufferState::ShaderResource,
+        RenderGraph::QueueRole::Graphics,
+        RenderGraph::AccessMode::Read
+    );
+
+    suite.Check(graph.Compile(), test_name, graph.GetCompileError());
+    RenderGraphLowering::LoweredPlan lowered{};
+    std::string error{};
+    suite.Check(RenderGraphLowering::Lower(graph, lowered, error), test_name, error);
+
+    suite.Check(
+        lowered.prologue.size() == 1 && lowered.prologue.front().dst_pass == first_read,
+        test_name,
+        "the first access must adopt its explicit import boundary"
+    );
+    const auto before_second = lowered.Before(second_read);
+    const auto seed = std::find_if(
+        before_second.begin(),
+        before_second.end(),
+        [](const RenderGraphLowering::LoweredInstruction& instruction) {
+            return instruction.instruction_kind ==
+                   RenderGraphLowering::InstructionKind::StateSeed;
+        }
+    );
+    suite.Check(
+        seed != before_second.end() &&
+            seed->barrier_index == RenderGraphLowering::InvalidBarrierIndex &&
+            seed->access_index != RenderGraphLowering::InvalidAccessIndex &&
+            seed->range.buffer.offset == 0 &&
+            seed->range.buffer.size == 256 &&
+            seed->source.stages == ERHIPipelineStageFlags::PS_ALL_GRAPHICS &&
+            seed->source.access == ERHIAccessFlags::SHADER_READ &&
+            seed->source.stages == seed->destination.stages &&
+            seed->source.access == seed->destination.access,
+        test_name,
+        "a barrier-free read must seed the independent CommandList tracker"
+    );
+    suite.Check(
+        lowered.Keepalive(second_read).size() == 1 &&
+            lowered.Keepalive(second_read).front().buffer.Get() == buffer.Get(),
+        test_name,
+        "state-seeded pass must retain its buffer even without a compiler barrier"
+    );
+}
+
+void ExpectLowerFailure(
+    TestSuite&       suite,
+    RenderGraph&     graph,
+    std::string_view test_name,
+    std::string_view expected
+) {
+    suite.Check(graph.Compile(), test_name, graph.GetCompileError());
+    RenderGraphLowering::LoweredPlan lowered{};
+    std::string error{};
+    const bool result = RenderGraphLowering::Lower(graph, lowered, error);
+    suite.Check(!result, test_name, "lowering unexpectedly succeeded");
+    suite.Check(Contains(error, expected), test_name, error);
+    suite.Check(
+        lowered.prologue.empty() && lowered.passes.empty(),
+        test_name,
+        "failed lowering must not expose a partial plan"
+    );
+}
+
+void TestFailClosedContracts(TestSuite& suite) {
+    {
+        constexpr std::string_view name = "raw physical binding rejected";
+        TextureRef texture = MoerNew(FakeTexture)(1, 1, ETextureAspectFlags::COLOR);
+        RenderGraph graph(name);
+        const auto handle = graph.ImportTexture(
+            "Raw",
+            static_cast<const void*>(texture.Get()),
+            RenderGraph::TextureDesc{}
+        );
+        graph.SetInitialState(
+            handle,
+            RenderGraph::TextureState::Undefined,
+            RenderGraph::QueueRole::None,
+            RenderGraph::AccessMode::None
+        );
+        graph.AddPass(
+            "Write",
+            [=](RenderGraph::PassBuilder& builder) {
+                builder.Write(handle, RenderGraph::TextureState::RenderTarget).SideEffect();
+            },
+            [] {}
+        );
+        graph.Export(
+            handle,
+            RenderGraph::TextureState::ShaderResource,
+            RenderGraph::QueueRole::Graphics,
+            RenderGraph::AccessMode::Read
+        );
+        ExpectLowerFailure(suite, graph, name, "strong physical binding");
+    }
+    {
+        constexpr std::string_view name = "transient physical resource rejected";
+        RenderGraph graph(name);
+        const auto handle =
+            graph.CreateTransientBuffer("Transient", RenderGraph::BufferDesc{.byte_size = 64});
+        graph.AddPass(
+            "Write",
+            [=](RenderGraph::PassBuilder& builder) {
+                builder.ExecuteOn(
+                           RenderGraph::QueueRole::Graphics,
+                           RenderGraph::PipelineType::Copy
+                       )
+                    .Write(handle, RenderGraph::BufferState::TransferDestination)
+                    .SideEffect();
+            },
+            [] {}
+        );
+        graph.Export(
+            handle,
+            RenderGraph::BufferState::TransferSource,
+            RenderGraph::QueueRole::Graphics,
+            RenderGraph::AccessMode::Read
+        );
+        ExpectLowerFailure(suite, graph, name, "transient physical resource");
+    }
+    {
+        constexpr std::string_view name = "automatic access rejected";
+        BufferRef buffer = MoerNew(FakeBuffer)(64);
+        RenderGraph graph(name);
+        const auto handle =
+            graph.ImportBuffer("Buffer", buffer, RenderGraph::BufferDesc{.byte_size = 64});
+        graph.SetInitialState(
+            handle,
+            RenderGraph::BufferState::ShaderResource,
+            RenderGraph::QueueRole::Graphics,
+            RenderGraph::AccessMode::Read
+        );
+        graph.AddPass(
+            "Read",
+            [=](RenderGraph::PassBuilder& builder) { builder.Read(handle).SideEffect(); },
+            [] {}
+        );
+        graph.Export(
+            handle,
+            RenderGraph::BufferState::ShaderResource,
+            RenderGraph::QueueRole::Graphics,
+            RenderGraph::AccessMode::Read
+        );
+        ExpectLowerFailure(suite, graph, name, "state plan is incomplete");
+    }
+    {
+        constexpr std::string_view name = "unknown boundary access rejected";
+        BufferRef buffer = MoerNew(FakeBuffer)(64);
+        RenderGraph graph(name);
+        const auto handle =
+            graph.ImportBuffer("Buffer", buffer, RenderGraph::BufferDesc{.byte_size = 64});
+        graph.SetInitialState(
+            handle,
+            RenderGraph::BufferState::ShaderResource,
+            RenderGraph::QueueRole::Graphics,
+            RenderGraph::AccessMode::Unknown
+        );
+        graph.AddPass(
+            "Read",
+            [=](RenderGraph::PassBuilder& builder) {
+                builder.Read(handle, RenderGraph::BufferState::ShaderResource).SideEffect();
+            },
+            [] {}
+        );
+        graph.Export(
+            handle,
+            RenderGraph::BufferState::ShaderResource,
+            RenderGraph::QueueRole::Graphics,
+            RenderGraph::AccessMode::Read
+        );
+        ExpectLowerFailure(suite, graph, name, "Unknown boundary access");
+    }
+    {
+        constexpr std::string_view name = "present boundary rejected";
+        TextureRef texture = MoerNew(FakeTexture)(1, 1, ETextureAspectFlags::COLOR);
+        RenderGraph graph(name);
+        const auto handle =
+            graph.ImportTexture("Color", texture, RenderGraph::TextureDesc{});
+        graph.SetInitialState(
+            handle,
+            RenderGraph::TextureState::Undefined,
+            RenderGraph::QueueRole::None,
+            RenderGraph::AccessMode::None
+        );
+        graph.AddPass(
+            "Write",
+            [=](RenderGraph::PassBuilder& builder) {
+                builder.Write(handle, RenderGraph::TextureState::RenderTarget).SideEffect();
+            },
+            [] {}
+        );
+        graph.Export(
+            handle,
+            RenderGraph::TextureState::Present,
+            RenderGraph::QueueRole::Graphics,
+            RenderGraph::AccessMode::Read
+        );
+        ExpectLowerFailure(suite, graph, name, "Present boundary");
+    }
+    {
+        constexpr std::string_view name = "non-graphics logical queue rejected";
+        BufferRef buffer = MoerNew(FakeBuffer)(64);
+        RenderGraph graph(name, RenderGraph::QueueTopology::SingleQueue());
+        const auto handle =
+            graph.ImportBuffer("Buffer", buffer, RenderGraph::BufferDesc{.byte_size = 64});
+        graph.SetInitialState(
+            handle,
+            RenderGraph::BufferState::Undefined,
+            RenderGraph::QueueRole::None,
+            RenderGraph::AccessMode::None
+        );
+        graph.AddPass(
+            "Compute",
+            [=](RenderGraph::PassBuilder& builder) {
+                builder.ExecuteOn(
+                           RenderGraph::QueueRole::Compute,
+                           RenderGraph::PipelineType::Compute
+                       )
+                    .Write(handle, RenderGraph::BufferState::UnorderedAccess)
+                    .SideEffect();
+            },
+            [] {}
+        );
+        graph.Export(
+            handle,
+            RenderGraph::BufferState::ShaderResource,
+            RenderGraph::QueueRole::Compute,
+            RenderGraph::AccessMode::Read
+        );
+        ExpectLowerFailure(suite, graph, name, "Graphics logical queue");
+    }
+    {
+        constexpr std::string_view name = "external control rejected";
+        BufferRef buffer = MoerNew(FakeBuffer)(64);
+        RenderGraph graph(name);
+        const auto handle =
+            graph.ImportBuffer("Buffer", buffer, RenderGraph::BufferDesc{.byte_size = 64});
+        graph.SetInitialState(
+            handle,
+            RenderGraph::BufferState::Undefined,
+            RenderGraph::QueueRole::None,
+            RenderGraph::AccessMode::None
+        );
+        graph.AddPass(
+            "External",
+            [=](RenderGraph::PassBuilder& builder) {
+                builder.Write(handle, RenderGraph::BufferState::UnorderedAccess)
+                    .ExternalControl()
+                    .SideEffect();
+            },
+            [] {}
+        );
+        graph.Export(
+            handle,
+            RenderGraph::BufferState::ShaderResource,
+            RenderGraph::QueueRole::Graphics,
+            RenderGraph::AccessMode::Read
+        );
+        ExpectLowerFailure(suite, graph, name, "ExternalControl");
+    }
+    {
+        constexpr std::string_view name = "incomplete state plan rejected";
+        BufferRef buffer = MoerNew(FakeBuffer)(64);
+        RenderGraph graph(name);
+        const auto handle =
+            graph.ImportBuffer("Buffer", buffer, RenderGraph::BufferDesc{.byte_size = 64});
+        graph.AddPass(
+            "Write",
+            [=](RenderGraph::PassBuilder& builder) {
+                builder.Write(handle, RenderGraph::BufferState::UnorderedAccess).SideEffect();
+            },
+            [] {}
+        );
+        graph.Export(
+            handle,
+            RenderGraph::BufferState::ShaderResource,
+            RenderGraph::QueueRole::Graphics,
+            RenderGraph::AccessMode::Read
+        );
+        ExpectLowerFailure(suite, graph, name, "state plan is incomplete");
+    }
+    {
+        constexpr std::string_view name = "missing final boundary rejected";
+        BufferRef buffer = MoerNew(FakeBuffer)(64);
+        RenderGraph graph(name);
+        const auto handle =
+            graph.ImportBuffer("Buffer", buffer, RenderGraph::BufferDesc{.byte_size = 64});
+        graph.SetInitialState(
+            handle,
+            RenderGraph::BufferState::Undefined,
+            RenderGraph::QueueRole::None,
+            RenderGraph::AccessMode::None
+        );
+        graph.AddPass(
+            "Write",
+            [=](RenderGraph::PassBuilder& builder) {
+                builder.Write(handle, RenderGraph::BufferState::UnorderedAccess).SideEffect();
+            },
+            [] {}
+        );
+        ExpectLowerFailure(suite, graph, name, "explicit final state");
+    }
+}
+
+} // namespace
+
+int main() {
+    TestSuite suite;
+    TestTextureFanInAndDeterminism(suite);
+    TestShaderResourceAndSampledLayoutsRemainDistinct(suite);
+    TestDepthAttachmentReadUsesBackendAttachmentLayout(suite);
+    TestSameStateReadGetsStateSeed(suite);
+    TestFailClosedContracts(suite);
+
+    if (suite.FailureCount() != 0) {
+        std::cerr << "TestRenderGraphLowering: " << suite.FailureCount() << " failure(s)\n";
+        return EXIT_FAILURE;
+    }
+    std::cout << "TestRenderGraphLowering: all checks passed\n";
+    return EXIT_SUCCESS;
+}

--- a/source/test/RenderGraphLoweringTest.cpp
+++ b/source/test/RenderGraphLoweringTest.cpp
@@ -440,6 +440,491 @@ void ExpectLowerFailure(
     RenderGraph&     graph,
     std::string_view test_name,
     std::string_view expected
+);
+
+void TestCrossNativeTokenSynchronization(TestSuite& suite) {
+    constexpr std::string_view test_name =
+        "cross-native token synchronization is lowered";
+    RenderGraph graph("CrossNativeTokenSync", RenderGraph::QueueTopology::DedicatedQueues());
+    const auto token = graph.CreateTransientToken("GraphicsToCompute");
+    const auto producer = graph.AddPass(
+        "GraphicsProducer",
+        [=](RenderGraph::PassBuilder& builder) {
+            builder.ExecuteOn(
+                       RenderGraph::QueueRole::Graphics,
+                       RenderGraph::PipelineType::Graphics
+                   )
+                .Write(token)
+                .SideEffect();
+        },
+        [] {}
+    );
+    const auto consumer = graph.AddPass(
+        "ComputeConsumer",
+        [=](RenderGraph::PassBuilder& builder) {
+            builder.ExecuteOn(
+                       RenderGraph::QueueRole::Compute,
+                       RenderGraph::PipelineType::Compute
+                   )
+                .Read(token)
+                .SideEffect();
+        },
+        [] {}
+    );
+
+    suite.Check(graph.Compile(), test_name, graph.GetCompileError());
+    RenderGraphLowering::LoweredPlan lowered{};
+    std::string error{};
+    suite.Check(RenderGraphLowering::Lower(graph, lowered, error), test_name, error);
+    suite.Check(
+        lowered.queue_syncs.size() == 1 &&
+            lowered.queue_syncs.front().correlation_id == 0 &&
+            lowered.queue_syncs.front().signal_pass == producer &&
+            lowered.queue_syncs.front().wait_pass == consumer &&
+            lowered.queue_syncs.front().signal_queue ==
+                graph.GetQueueTopology().Resolve(RenderGraph::QueueRole::Graphics) &&
+            lowered.queue_syncs.front().wait_queue ==
+                graph.GetQueueTopology().Resolve(RenderGraph::QueueRole::Compute),
+        test_name,
+        "the token hazard must become one Graphics-to-Compute lowered GPU sync"
+    );
+    suite.Check(
+        lowered.prologue.empty() && lowered.Before(consumer).empty(),
+        test_name,
+        "a token-only dependency must not manufacture a physical barrier"
+    );
+}
+
+void TestSameNativeTokenSynchronizationNeedsNoGpuSync(TestSuite& suite) {
+    constexpr std::string_view test_name =
+        "same-native token synchronization needs no lowered GPU sync";
+    RenderGraph graph("SameNativeTokenSync", RenderGraph::QueueTopology::SingleQueue());
+    const auto token = graph.CreateTransientToken("GraphicsToCompute");
+    graph.AddPass(
+        "GraphicsProducer",
+        [=](RenderGraph::PassBuilder& builder) {
+            builder.ExecuteOn(
+                       RenderGraph::QueueRole::Graphics,
+                       RenderGraph::PipelineType::Graphics
+                   )
+                .Write(token)
+                .SideEffect();
+        },
+        [] {}
+    );
+    graph.AddPass(
+        "ComputeConsumer",
+        [=](RenderGraph::PassBuilder& builder) {
+            builder.ExecuteOn(
+                       RenderGraph::QueueRole::Compute,
+                       RenderGraph::PipelineType::Compute
+                   )
+                .Read(token)
+                .SideEffect();
+        },
+        [] {}
+    );
+
+    suite.Check(graph.Compile(), test_name, graph.GetCompileError());
+    suite.Check(
+        graph.GetCompiledPlan().queue_syncs.size() == 1 &&
+            !graph.GetCompiledPlan().queue_syncs.front().gpu_wait_required,
+        test_name,
+        "the compiler must retain the logical queue edge without requesting a GPU wait"
+    );
+    RenderGraphLowering::LoweredPlan lowered{};
+    std::string error{};
+    suite.Check(RenderGraphLowering::Lower(graph, lowered, error), test_name, error);
+    suite.Check(
+        lowered.queue_syncs.empty(),
+        test_name,
+        "logical roles sharing one native queue must rely on native submission order"
+    );
+}
+
+void TestSameNativePhysicalBarrierRetainsSourceScope(TestSuite& suite) {
+    constexpr std::string_view test_name =
+        "same-native physical queue barrier retains source scope";
+    BufferRef buffer = MoerNew(FakeBuffer)(256);
+    RenderGraph graph("SameNativePhysicalBarrier", RenderGraph::QueueTopology::SingleQueue());
+    const auto data = graph.ImportBuffer(
+        "Shared",
+        buffer,
+        RenderGraph::BufferDesc{.byte_size = 256}
+    );
+    graph.SetInitialState(
+        data,
+        RenderGraph::BufferState::Undefined,
+        RenderGraph::QueueRole::None,
+        RenderGraph::AccessMode::None
+    );
+    graph.AddPass(
+        "GraphicsWrite",
+        [=](RenderGraph::PassBuilder& builder) {
+            builder.Write(data, RenderGraph::BufferState::UnorderedAccess).SideEffect();
+        },
+        [] {}
+    );
+    const auto consumer = graph.AddPass(
+        "ComputeRead",
+        [=](RenderGraph::PassBuilder& builder) {
+            builder.ExecuteOn(
+                       RenderGraph::QueueRole::Compute,
+                       RenderGraph::PipelineType::Compute
+                   )
+                .Read(data, RenderGraph::BufferState::ShaderResource)
+                .SideEffect();
+        },
+        [] {}
+    );
+    graph.Export(
+        data,
+        RenderGraph::BufferState::ShaderResource,
+        RenderGraph::QueueRole::Compute,
+        RenderGraph::AccessMode::Read
+    );
+
+    suite.Check(graph.Compile(), test_name, graph.GetCompileError());
+    RenderGraphLowering::LoweredPlan lowered{};
+    std::string error{};
+    suite.Check(RenderGraphLowering::Lower(graph, lowered, error), test_name, error);
+    const auto before_consumer = lowered.Before(consumer);
+    const auto barrier = std::find_if(
+        before_consumer.begin(),
+        before_consumer.end(),
+        [](const RenderGraphLowering::LoweredInstruction& instruction) {
+            return instruction.instruction_kind ==
+                       RenderGraphLowering::InstructionKind::Barrier &&
+                   instruction.after_state ==
+                       RenderGraph::ResourceState::Buffer(
+                           RenderGraph::BufferState::ShaderResource
+                       );
+        }
+    );
+    suite.Check(
+        lowered.queue_syncs.empty() &&
+            barrier != before_consumer.end() &&
+            !barrier->queue_acquire &&
+            barrier->source.stages != ERHIPipelineStageFlags::PS_NONE &&
+            barrier->source.access == ERHIAccessFlags::SHADER_WRITE,
+        test_name,
+        "one native queue needs no GPU wait but must retain its producer scope"
+    );
+}
+
+void TestSameFamilyQueueBarrierLowersToAcquire(TestSuite& suite) {
+    constexpr std::string_view test_name =
+        "same-family queue barrier lowers to destination acquire";
+    const RenderGraph::QueueTopology topology{
+        .graphics = {RenderGraph::QueueRole::Graphics, 0, 0},
+        .compute  = {RenderGraph::QueueRole::Compute, 1, 0},
+        .copy     = {RenderGraph::QueueRole::Copy, 2, 0},
+    };
+    BufferRef buffer = MoerNew(FakeBuffer)(256);
+    RenderGraph graph("SameFamilyQueueAcquire", topology);
+    const auto data = graph.ImportBuffer(
+        "Shared",
+        buffer,
+        RenderGraph::BufferDesc{
+            .byte_size    = 256,
+            .sharing_mode = RenderGraph::TextureDesc::SharingMode::Exclusive,
+        }
+    );
+    graph.SetInitialState(
+        data,
+        RenderGraph::BufferState::Undefined,
+        RenderGraph::QueueRole::None,
+        RenderGraph::AccessMode::None
+    );
+    graph.AddPass(
+        "GraphicsWrite",
+        [=](RenderGraph::PassBuilder& builder) {
+            builder.Write(data, RenderGraph::BufferState::UnorderedAccess).SideEffect();
+        },
+        [] {}
+    );
+    const auto consumer = graph.AddPass(
+        "ComputeRead",
+        [=](RenderGraph::PassBuilder& builder) {
+            builder.ExecuteOn(
+                       RenderGraph::QueueRole::Compute,
+                       RenderGraph::PipelineType::Compute
+                   )
+                .Read(data, RenderGraph::BufferState::ShaderResource)
+                .SideEffect();
+        },
+        [] {}
+    );
+    graph.Export(
+        data,
+        RenderGraph::BufferState::ShaderResource,
+        RenderGraph::QueueRole::Compute,
+        RenderGraph::AccessMode::Read
+    );
+
+    suite.Check(graph.Compile(), test_name, graph.GetCompileError());
+    RenderGraphLowering::LoweredPlan lowered{};
+    std::string error{};
+    suite.Check(RenderGraphLowering::Lower(graph, lowered, error), test_name, error);
+    const auto before_consumer = lowered.Before(consumer);
+    const auto acquire = std::find_if(
+        before_consumer.begin(),
+        before_consumer.end(),
+        [](const RenderGraphLowering::LoweredInstruction& instruction) {
+            return instruction.instruction_kind ==
+                       RenderGraphLowering::InstructionKind::Barrier &&
+                   instruction.queue_acquire;
+        }
+    );
+    suite.Check(
+        lowered.queue_syncs.size() == 1 &&
+            acquire != before_consumer.end() &&
+            acquire->source.stages == ERHIPipelineStageFlags::PS_NONE &&
+            acquire->source.access == ERHIAccessFlags::UNDEFINED &&
+            acquire->destination.stages == ERHIPipelineStageFlags::PS_COMPUTE_SHADER &&
+            acquire->destination.access == ERHIAccessFlags::SHADER_READ,
+        test_name,
+        "the GPU wait must be paired with a destination-local acquire whose source scope is empty"
+    );
+}
+
+void TestMixedQueueFanInRetainsLocalSourceScope(TestSuite& suite) {
+    constexpr std::string_view test_name =
+        "mixed queue fan-in retains the local source scope";
+    const RenderGraph::QueueTopology topology{
+        .graphics = {RenderGraph::QueueRole::Graphics, 0, 0},
+        .compute  = {RenderGraph::QueueRole::Compute, 1, 0},
+        .copy     = {RenderGraph::QueueRole::Copy, 2, 0},
+    };
+    BufferRef buffer = MoerNew(FakeBuffer)(256);
+    RenderGraph graph("MixedQueueFanIn", topology);
+    const auto data = graph.ImportBuffer(
+        "Shared",
+        buffer,
+        RenderGraph::BufferDesc{.byte_size = 256}
+    );
+    graph.SetInitialState(
+        data,
+        RenderGraph::BufferState::Undefined,
+        RenderGraph::QueueRole::None,
+        RenderGraph::AccessMode::None
+    );
+    graph.AddPass(
+        "InitialGraphicsWrite",
+        [=](RenderGraph::PassBuilder& builder) {
+            builder.Write(data, RenderGraph::BufferState::UnorderedAccess).SideEffect();
+        },
+        [] {}
+    );
+    const auto graphics_reader = graph.AddPass(
+        "GraphicsRead",
+        [=](RenderGraph::PassBuilder& builder) {
+            builder.Read(data, RenderGraph::BufferState::ShaderResource).SideEffect();
+        },
+        [] {}
+    );
+    const auto compute_reader = graph.AddPass(
+        "ComputeRead",
+        [=](RenderGraph::PassBuilder& builder) {
+            builder.ExecuteOn(
+                       RenderGraph::QueueRole::Compute,
+                       RenderGraph::PipelineType::Compute
+                   )
+                .Read(data, RenderGraph::BufferState::ShaderResource)
+                .SideEffect();
+        },
+        [] {}
+    );
+    const auto final_writer = graph.AddPass(
+        "FinalGraphicsWrite",
+        [=](RenderGraph::PassBuilder& builder) {
+            builder.Write(data, RenderGraph::BufferState::UnorderedAccess).SideEffect();
+        },
+        [] {}
+    );
+    graph.Export(
+        data,
+        RenderGraph::BufferState::UnorderedAccess,
+        RenderGraph::QueueRole::Graphics,
+        RenderGraph::AccessMode::Write
+    );
+
+    suite.Check(graph.Compile(), test_name, graph.GetCompileError());
+    RenderGraphLowering::LoweredPlan lowered{};
+    std::string error{};
+    suite.Check(RenderGraphLowering::Lower(graph, lowered, error), test_name, error);
+    const auto before_writer = lowered.Before(final_writer);
+    const auto barrier = std::find_if(
+        before_writer.begin(),
+        before_writer.end(),
+        [&](const RenderGraphLowering::LoweredInstruction& instruction) {
+            return instruction.queue_acquire &&
+                   std::find(
+                       instruction.source_frontier.begin(),
+                       instruction.source_frontier.end(),
+                       graphics_reader
+                   ) != instruction.source_frontier.end() &&
+                   std::find(
+                       instruction.source_frontier.begin(),
+                       instruction.source_frontier.end(),
+                       compute_reader
+                   ) != instruction.source_frontier.end();
+        }
+    );
+    suite.Check(
+        barrier != before_writer.end() &&
+            HasFlag(
+                barrier->source.stages,
+                ERHIPipelineStageFlags::PS_ALL_GRAPHICS
+            ) &&
+            !HasFlag(
+                barrier->source.stages,
+                ERHIPipelineStageFlags::PS_COMPUTE_SHADER
+            ) &&
+            barrier->source.access == ERHIAccessFlags::SHADER_READ,
+        test_name,
+        "the semaphore covers the remote source while the barrier retains "
+        "the same-native graphics source"
+    );
+}
+
+void TestCrossFamilyExclusiveOwnershipFailsClosed(TestSuite& suite) {
+    constexpr std::string_view test_name =
+        "cross-family exclusive ownership remains fail-closed";
+    BufferRef buffer = MoerNew(FakeBuffer)(256);
+    RenderGraph graph("CrossFamilyOwnership", RenderGraph::QueueTopology::DedicatedQueues());
+    const auto data = graph.ImportBuffer(
+        "Exclusive",
+        buffer,
+        RenderGraph::BufferDesc{
+            .byte_size    = 256,
+            .sharing_mode = RenderGraph::TextureDesc::SharingMode::Exclusive,
+        }
+    );
+    graph.SetInitialState(
+        data,
+        RenderGraph::BufferState::Undefined,
+        RenderGraph::QueueRole::None,
+        RenderGraph::AccessMode::None
+    );
+    graph.AddPass(
+        "GraphicsWrite",
+        [=](RenderGraph::PassBuilder& builder) {
+            builder.Write(data, RenderGraph::BufferState::UnorderedAccess).SideEffect();
+        },
+        [] {}
+    );
+    graph.AddPass(
+        "ComputeRead",
+        [=](RenderGraph::PassBuilder& builder) {
+            builder.ExecuteOn(
+                       RenderGraph::QueueRole::Compute,
+                       RenderGraph::PipelineType::Compute
+                   )
+                .Read(data, RenderGraph::BufferState::ShaderResource)
+                .SideEffect();
+        },
+        [] {}
+    );
+    graph.Export(
+        data,
+        RenderGraph::BufferState::ShaderResource,
+        RenderGraph::QueueRole::Compute,
+        RenderGraph::AccessMode::Read
+    );
+
+    ExpectLowerFailure(
+        suite,
+        graph,
+        test_name,
+        "queue-family ownership requires paired release/acquire lowering"
+    );
+}
+
+void TestMissingCrossNativeSyncFailsClosed(TestSuite& suite) {
+    constexpr std::string_view test_name =
+        "missing cross-native queue sync fails closed";
+    RenderGraph graph(
+        "MissingCrossNativeSync",
+        RenderGraph::QueueTopology::DedicatedQueues()
+    );
+    const auto token = graph.CreateTransientToken("GraphicsToCompute");
+    graph.AddPass(
+        "Graphics",
+        [=](RenderGraph::PassBuilder& builder) {
+            builder.Write(token).SideEffect();
+        },
+        [] {}
+    );
+    graph.AddPass(
+        "Compute",
+        [=](RenderGraph::PassBuilder& builder) {
+            builder.ExecuteOn(
+                       RenderGraph::QueueRole::Compute,
+                       RenderGraph::PipelineType::Compute
+                   )
+                .Read(token)
+                .SideEffect();
+        },
+        [] {}
+    );
+    suite.Check(graph.Compile(), test_name, graph.GetCompileError());
+    auto& plan = const_cast<RenderGraph::CompiledPlan&>(
+        graph.GetCompiledPlan()
+    );
+    plan.queue_syncs.clear();
+    for (auto& batch : plan.queue_batches) {
+        batch.signal_syncs.clear();
+        batch.wait_syncs.clear();
+    }
+
+    RenderGraphLowering::LoweredPlan lowered{};
+    std::string error{};
+    suite.Check(
+        !RenderGraphLowering::Lower(graph, lowered, error) &&
+            Contains(
+                error,
+                "cross-native dependency edge is not correlated"
+            ) &&
+            lowered.prologue.empty() && lowered.passes.empty() &&
+            lowered.queue_syncs.empty(),
+        test_name,
+        error
+    );
+}
+
+void TestUnavailableQueueFailsAtCompile(TestSuite& suite) {
+    constexpr std::string_view test_name =
+        "unavailable logical queue fails at compile";
+    auto topology = RenderGraph::QueueTopology::SingleQueue();
+    topology.compute.available = false;
+    RenderGraph graph("UnavailableCompute", topology);
+    const auto token = graph.CreateTransientToken("ComputeOnly");
+    graph.AddPass(
+        "Compute",
+        [=](RenderGraph::PassBuilder& builder) {
+            builder.ExecuteOn(
+                       RenderGraph::QueueRole::Compute,
+                       RenderGraph::PipelineType::Compute
+                   )
+                .Write(token)
+                .SideEffect();
+        },
+        [] {}
+    );
+    suite.Check(
+        !graph.Compile() &&
+            Contains(graph.GetCompileError(), "unavailable logical queue"),
+        test_name,
+        graph.GetCompileError()
+    );
+}
+
+void ExpectLowerFailure(
+    TestSuite&       suite,
+    RenderGraph&     graph,
+    std::string_view test_name,
+    std::string_view expected
 ) {
     suite.Check(graph.Compile(), test_name, graph.GetCompileError());
     RenderGraphLowering::LoweredPlan lowered{};
@@ -448,7 +933,8 @@ void ExpectLowerFailure(
     suite.Check(!result, test_name, "lowering unexpectedly succeeded");
     suite.Check(Contains(error, expected), test_name, error);
     suite.Check(
-        lowered.prologue.empty() && lowered.passes.empty(),
+        lowered.prologue.empty() && lowered.passes.empty() &&
+            lowered.queue_syncs.empty(),
         test_name,
         "failed lowering must not expose a partial plan"
     );
@@ -590,38 +1076,6 @@ void TestFailClosedContracts(TestSuite& suite) {
         ExpectLowerFailure(suite, graph, name, "Present boundary");
     }
     {
-        constexpr std::string_view name = "non-graphics logical queue rejected";
-        BufferRef buffer = MoerNew(FakeBuffer)(64);
-        RenderGraph graph(name, RenderGraph::QueueTopology::SingleQueue());
-        const auto handle =
-            graph.ImportBuffer("Buffer", buffer, RenderGraph::BufferDesc{.byte_size = 64});
-        graph.SetInitialState(
-            handle,
-            RenderGraph::BufferState::Undefined,
-            RenderGraph::QueueRole::None,
-            RenderGraph::AccessMode::None
-        );
-        graph.AddPass(
-            "Compute",
-            [=](RenderGraph::PassBuilder& builder) {
-                builder.ExecuteOn(
-                           RenderGraph::QueueRole::Compute,
-                           RenderGraph::PipelineType::Compute
-                       )
-                    .Write(handle, RenderGraph::BufferState::UnorderedAccess)
-                    .SideEffect();
-            },
-            [] {}
-        );
-        graph.Export(
-            handle,
-            RenderGraph::BufferState::ShaderResource,
-            RenderGraph::QueueRole::Compute,
-            RenderGraph::AccessMode::Read
-        );
-        ExpectLowerFailure(suite, graph, name, "Graphics logical queue");
-    }
-    {
         constexpr std::string_view name = "external control rejected";
         BufferRef buffer = MoerNew(FakeBuffer)(64);
         RenderGraph graph(name);
@@ -702,6 +1156,14 @@ int main() {
     TestShaderResourceAndSampledLayoutsRemainDistinct(suite);
     TestDepthAttachmentReadUsesBackendAttachmentLayout(suite);
     TestSameStateReadGetsStateSeed(suite);
+    TestCrossNativeTokenSynchronization(suite);
+    TestSameNativeTokenSynchronizationNeedsNoGpuSync(suite);
+    TestSameNativePhysicalBarrierRetainsSourceScope(suite);
+    TestSameFamilyQueueBarrierLowersToAcquire(suite);
+    TestMixedQueueFanInRetainsLocalSourceScope(suite);
+    TestCrossFamilyExclusiveOwnershipFailsClosed(suite);
+    TestMissingCrossNativeSyncFailsClosed(suite);
+    TestUnavailableQueueFailsAtCompile(suite);
     TestFailClosedContracts(suite);
 
     if (suite.FailureCount() != 0) {

--- a/source/test/RenderGraphLoweringTest.cpp
+++ b/source/test/RenderGraphLoweringTest.cpp
@@ -788,24 +788,185 @@ void TestMixedQueueFanInRetainsLocalSourceScope(TestSuite& suite) {
     );
 }
 
-void TestCrossFamilyExclusiveOwnershipFailsClosed(TestSuite& suite) {
-    constexpr std::string_view test_name =
-        "cross-family exclusive ownership remains fail-closed";
-    BufferRef buffer = MoerNew(FakeBuffer)(256);
-    RenderGraph graph("CrossFamilyOwnership", RenderGraph::QueueTopology::DedicatedQueues());
-    const auto data = graph.ImportBuffer(
+void TestCrossFamilyExclusiveOwnershipLowersPairedTransfer(TestSuite& suite) {
+    constexpr std::string_view test_name = "cross-family exclusive ownership lowers one paired transfer";
+    TextureRef                 texture   = MoerNew(FakeTexture)(2, 2, ETextureAspectFlags::COLOR);
+    RenderGraph                graph("CrossFamilyOwnership", RenderGraph::QueueTopology::DedicatedQueues());
+    const auto                 data = graph.ImportTexture(
         "Exclusive",
-        buffer,
-        RenderGraph::BufferDesc{
-            .byte_size    = 256,
-            .sharing_mode = RenderGraph::TextureDesc::SharingMode::Exclusive,
+        texture,
+        RenderGraph::TextureDesc{
+                            .mip_count    = 2,
+                            .layer_count  = 2,
+                            .aspects      = RenderGraph::TextureAspect::Color,
+                            .sharing_mode = RenderGraph::TextureDesc::SharingMode::Exclusive,
         }
     );
     graph.SetInitialState(
         data,
-        RenderGraph::BufferState::Undefined,
+        RenderGraph::TextureState::Undefined,
         RenderGraph::QueueRole::None,
         RenderGraph::AccessMode::None
+    );
+    const auto producer = graph.AddPass(
+        "GraphicsWrite",
+        [=](RenderGraph::PassBuilder& builder) {
+            builder.Write(data, RenderGraph::TextureState::UnorderedAccess).SideEffect();
+        },
+        [] {}
+    );
+    const auto consumer = graph.AddPass(
+        "ComputeRead",
+        [=](RenderGraph::PassBuilder& builder) {
+            builder.ExecuteOn(RenderGraph::QueueRole::Compute, RenderGraph::PipelineType::Compute)
+                .Read(data, RenderGraph::TextureState::Sampled)
+                .SideEffect();
+        },
+        [] {}
+    );
+    graph.Export(
+        data,
+        RenderGraph::TextureState::Sampled,
+        RenderGraph::QueueRole::Compute,
+        RenderGraph::AccessMode::Read
+    );
+
+    suite.Check(graph.Compile(), test_name, graph.GetCompileError());
+    const auto& compiled          = graph.GetCompiledPlan();
+    const auto  ownership_barrier = std::find_if(
+        compiled.barriers.begin(),
+        compiled.barriers.end(),
+        [&](const RenderGraph::CompiledBarrier& barrier) {
+            return barrier.resource == data.Untyped() && barrier.dst_pass == consumer &&
+                   barrier.queue_ownership;
+        }
+    );
+    suite.Check(
+        ownership_barrier != compiled.barriers.end(),
+        test_name,
+        "compiler did not retain the internal ownership transfer"
+    );
+    if (ownership_barrier == compiled.barriers.end()) {
+        return;
+    }
+    const uint32_t ownership_barrier_index =
+        static_cast<uint32_t>(ownership_barrier - compiled.barriers.begin());
+
+    RenderGraphLowering::LoweredPlan lowered{};
+    std::string                      error{};
+    suite.Check(RenderGraphLowering::Lower(graph, lowered, error), test_name, error);
+
+    const auto after_producer = lowered.After(producer);
+    const auto release        = std::find_if(
+        after_producer.begin(),
+        after_producer.end(),
+        [&](const RenderGraphLowering::LoweredInstruction& instruction) {
+            return instruction.instruction_kind == RenderGraphLowering::InstructionKind::QueueRelease &&
+                   instruction.correlation_id == ownership_barrier_index;
+        }
+    );
+    const auto before_consumer = lowered.Before(consumer);
+    const auto acquire         = std::find_if(
+        before_consumer.begin(),
+        before_consumer.end(),
+        [&](const RenderGraphLowering::LoweredInstruction& instruction) {
+            return instruction.instruction_kind == RenderGraphLowering::InstructionKind::QueueAcquire &&
+                   instruction.correlation_id == ownership_barrier_index;
+        }
+    );
+    uint32_t release_count = 0;
+    uint32_t acquire_count = 0;
+    for (const auto& pass : lowered.passes) {
+        release_count += static_cast<uint32_t>(std::count_if(
+            pass.after.begin(),
+            pass.after.end(),
+            [&](const RenderGraphLowering::LoweredInstruction& instruction) {
+                return instruction.instruction_kind == RenderGraphLowering::InstructionKind::QueueRelease &&
+                       instruction.correlation_id == ownership_barrier_index;
+            }
+        ));
+        acquire_count += static_cast<uint32_t>(std::count_if(
+            pass.before.begin(),
+            pass.before.end(),
+            [&](const RenderGraphLowering::LoweredInstruction& instruction) {
+                return instruction.instruction_kind == RenderGraphLowering::InstructionKind::QueueAcquire &&
+                       instruction.correlation_id == ownership_barrier_index;
+            }
+        ));
+    }
+    suite.Check(
+        release_count == 1 && acquire_count == 1 && release != after_producer.end() &&
+            acquire != before_consumer.end(),
+        test_name,
+        "one ownership barrier must lower to exactly one release and one acquire"
+    );
+    if (release == after_producer.end() || acquire == before_consumer.end()) {
+        return;
+    }
+
+    suite.Check(
+        release->barrier_index == ownership_barrier_index &&
+            acquire->barrier_index == ownership_barrier_index && release->resource == acquire->resource &&
+            release->resource == data.Untyped() && release->range == acquire->range &&
+            release->before_state == acquire->before_state && release->after_state == acquire->after_state &&
+            release->source.layout == acquire->source.layout &&
+            release->destination.layout == acquire->destination.layout &&
+            release->source.layout == ETextureLayout::TEXTURE_LAYOUT_COMMON &&
+            release->destination.layout == ETextureLayout::TEXTURE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
+        test_name,
+        "paired halves must preserve identical correlation, resource, range, state and layout"
+    );
+
+    const auto& topology = graph.GetQueueTopology();
+    suite.Check(
+        release->transfer_source == topology.graphics && acquire->transfer_source == topology.graphics &&
+            release->transfer_destination == topology.compute &&
+            acquire->transfer_destination == topology.compute &&
+            release->transfer_source.family_id != release->transfer_destination.family_id &&
+            !release->queue_acquire && acquire->queue_acquire,
+        test_name,
+        "paired halves must retain the Graphics-to-Compute family transfer"
+    );
+
+    const auto transfer_sync = std::find_if(
+        lowered.queue_syncs.begin(),
+        lowered.queue_syncs.end(),
+        [&](const RenderGraphLowering::QueueSyncInstruction& sync) {
+            return std::find(
+                       sync.ownership_transfer_barriers.begin(),
+                       sync.ownership_transfer_barriers.end(),
+                       ownership_barrier_index
+                   ) != sync.ownership_transfer_barriers.end();
+        }
+    );
+    suite.Check(
+        transfer_sync != lowered.queue_syncs.end() && transfer_sync->signal_pass == producer &&
+            transfer_sync->wait_pass == consumer && transfer_sync->signal_queue == topology.graphics &&
+            transfer_sync->wait_queue == topology.compute,
+        test_name,
+        "release owner must signal the destination acquire through its correlated GPU sync"
+    );
+}
+
+void TestCrossFamilyOwnershipFanInUsesOneReleaseOwner(TestSuite& suite) {
+    constexpr std::string_view       test_name = "cross-family ownership fan-in uses one release owner";
+    const RenderGraph::QueueTopology topology{
+        .graphics = {RenderGraph::QueueRole::Graphics, 0, 0},
+        .compute  = {RenderGraph::QueueRole::Compute, 1, 0},
+        .copy     = {RenderGraph::QueueRole::Copy, 2, 1},
+    };
+    BufferRef   buffer = MoerNew(FakeBuffer)(256);
+    RenderGraph graph("CrossFamilyOwnershipFanIn", topology);
+    const auto  data = graph.ImportBuffer(
+        "Exclusive",
+        buffer,
+        RenderGraph::BufferDesc{
+             .byte_size    = 256,
+             .sharing_mode = RenderGraph::TextureDesc::SharingMode::Exclusive,
+        }
+    );
+    graph.SetInitialState(
+        data, RenderGraph::BufferState::Undefined, RenderGraph::QueueRole::None, RenderGraph::AccessMode::None
     );
     graph.AddPass(
         "GraphicsWrite",
@@ -814,30 +975,165 @@ void TestCrossFamilyExclusiveOwnershipFailsClosed(TestSuite& suite) {
         },
         [] {}
     );
-    graph.AddPass(
+    const auto graphics_reader = graph.AddPass(
+        "GraphicsRead",
+        [=](RenderGraph::PassBuilder& builder) {
+            builder.Read(data, RenderGraph::BufferState::ShaderResource).SideEffect();
+        },
+        [] {}
+    );
+    const auto compute_reader = graph.AddPass(
         "ComputeRead",
         [=](RenderGraph::PassBuilder& builder) {
-            builder.ExecuteOn(
-                       RenderGraph::QueueRole::Compute,
-                       RenderGraph::PipelineType::Compute
-                   )
+            builder.ExecuteOn(RenderGraph::QueueRole::Compute, RenderGraph::PipelineType::Compute)
                 .Read(data, RenderGraph::BufferState::ShaderResource)
+                .SideEffect();
+        },
+        [] {}
+    );
+    const auto copy_writer = graph.AddPass(
+        "CopyWrite",
+        [=](RenderGraph::PassBuilder& builder) {
+            builder.ExecuteOn(RenderGraph::QueueRole::Copy, RenderGraph::PipelineType::Copy)
+                .Write(data, RenderGraph::BufferState::TransferDestination)
                 .SideEffect();
         },
         [] {}
     );
     graph.Export(
         data,
-        RenderGraph::BufferState::ShaderResource,
-        RenderGraph::QueueRole::Compute,
-        RenderGraph::AccessMode::Read
+        RenderGraph::BufferState::TransferDestination,
+        RenderGraph::QueueRole::Copy,
+        RenderGraph::AccessMode::Write
     );
 
-    ExpectLowerFailure(
-        suite,
-        graph,
+    suite.Check(graph.Compile(), test_name, graph.GetCompileError());
+    const auto& compiled          = graph.GetCompiledPlan();
+    const auto  ownership_barrier = std::find_if(
+        compiled.barriers.begin(),
+        compiled.barriers.end(),
+        [&](const RenderGraph::CompiledBarrier& barrier) {
+            return barrier.resource == data.Untyped() && barrier.dst_pass == copy_writer &&
+                   barrier.queue_ownership &&
+                   std::find_if(
+                       barrier.sources.begin(),
+                       barrier.sources.end(),
+                       [&](const RenderGraph::CompiledBarrierSource& source) {
+                           return source.pass == graphics_reader;
+                       }
+                   ) != barrier.sources.end() &&
+                   std::find_if(
+                       barrier.sources.begin(),
+                       barrier.sources.end(),
+                       [&](const RenderGraph::CompiledBarrierSource& source) {
+                           return source.pass == compute_reader;
+                       }
+                   ) != barrier.sources.end();
+        }
+    );
+    suite.Check(
+        ownership_barrier != compiled.barriers.end(),
         test_name,
-        "queue-family ownership requires paired release/acquire lowering"
+        "compiler did not retain both source-family native queue readers"
+    );
+    if (ownership_barrier == compiled.barriers.end()) {
+        return;
+    }
+    const uint32_t ownership_barrier_index =
+        static_cast<uint32_t>(ownership_barrier - compiled.barriers.begin());
+
+    RenderGraphLowering::LoweredPlan lowered{};
+    std::string                      error{};
+    suite.Check(RenderGraphLowering::Lower(graph, lowered, error), test_name, error);
+
+    uint32_t release_count = 0;
+    for (const auto& pass : lowered.passes) {
+        release_count += static_cast<uint32_t>(std::count_if(
+            pass.after.begin(),
+            pass.after.end(),
+            [&](const RenderGraphLowering::LoweredInstruction& instruction) {
+                return instruction.instruction_kind == RenderGraphLowering::InstructionKind::QueueRelease &&
+                       instruction.correlation_id == ownership_barrier_index;
+            }
+        ));
+    }
+    const auto after_compute   = lowered.After(compute_reader);
+    const auto compute_release = std::find_if(
+        after_compute.begin(),
+        after_compute.end(),
+        [&](const RenderGraphLowering::LoweredInstruction& instruction) {
+            return instruction.instruction_kind == RenderGraphLowering::InstructionKind::QueueRelease &&
+                   instruction.correlation_id == ownership_barrier_index;
+        }
+    );
+    const auto after_graphics       = lowered.After(graphics_reader);
+    const bool graphics_has_release = std::any_of(
+        after_graphics.begin(),
+        after_graphics.end(),
+        [&](const RenderGraphLowering::LoweredInstruction& instruction) {
+            return instruction.instruction_kind == RenderGraphLowering::InstructionKind::QueueRelease &&
+                   instruction.correlation_id == ownership_barrier_index;
+        }
+    );
+    suite.Check(
+        release_count == 1 && compute_release != after_compute.end() && !graphics_has_release &&
+            compute_release->transfer_source == topology.compute &&
+            compute_release->transfer_destination == topology.copy,
+        test_name,
+        "the maximum source batch must be the unique Compute release owner"
+    );
+
+    const auto before_copy  = lowered.Before(copy_writer);
+    const auto copy_acquire = std::find_if(
+        before_copy.begin(),
+        before_copy.end(),
+        [&](const RenderGraphLowering::LoweredInstruction& instruction) {
+            return instruction.instruction_kind == RenderGraphLowering::InstructionKind::QueueAcquire &&
+                   instruction.correlation_id == ownership_barrier_index;
+        }
+    );
+    suite.Check(
+        copy_acquire != before_copy.end() && copy_acquire->transfer_source == topology.compute &&
+            copy_acquire->transfer_destination == topology.copy,
+        test_name,
+        "the Copy destination must acquire from the designated Compute release owner"
+    );
+
+    const auto ownership_join = std::find_if(
+        lowered.queue_syncs.begin(),
+        lowered.queue_syncs.end(),
+        [&](const RenderGraphLowering::QueueSyncInstruction& sync) {
+            return sync.signal_queue == topology.graphics && sync.wait_queue == topology.compute &&
+                   std::find(
+                       sync.ownership_join_barriers.begin(),
+                       sync.ownership_join_barriers.end(),
+                       ownership_barrier_index
+                   ) != sync.ownership_join_barriers.end();
+        }
+    );
+    suite.Check(
+        ownership_join != lowered.queue_syncs.end(),
+        test_name,
+        "the other source native queue must join the designated release batch"
+    );
+
+    const auto transfer_sync = std::find_if(
+        lowered.queue_syncs.begin(),
+        lowered.queue_syncs.end(),
+        [&](const RenderGraphLowering::QueueSyncInstruction& sync) {
+            return sync.signal_queue == topology.compute &&
+                   sync.wait_queue == topology.copy &&
+                   std::find(
+                       sync.ownership_transfer_barriers.begin(),
+                       sync.ownership_transfer_barriers.end(),
+                       ownership_barrier_index
+                   ) != sync.ownership_transfer_barriers.end();
+        }
+    );
+    suite.Check(
+        transfer_sync != lowered.queue_syncs.end(),
+        test_name,
+        "the unique release owner must signal the Copy acquire"
     );
 }
 
@@ -1161,7 +1457,8 @@ int main() {
     TestSameNativePhysicalBarrierRetainsSourceScope(suite);
     TestSameFamilyQueueBarrierLowersToAcquire(suite);
     TestMixedQueueFanInRetainsLocalSourceScope(suite);
-    TestCrossFamilyExclusiveOwnershipFailsClosed(suite);
+    TestCrossFamilyExclusiveOwnershipLowersPairedTransfer(suite);
+    TestCrossFamilyOwnershipFanInUsesOneReleaseOwner(suite);
     TestMissingCrossNativeSyncFailsClosed(suite);
     TestUnavailableQueueFailsAtCompile(suite);
     TestFailClosedContracts(suite);

--- a/source/test/RenderGraphResourcePoolTest.cpp
+++ b/source/test/RenderGraphResourcePoolTest.cpp
@@ -138,6 +138,57 @@ void CompleteSources(Moer::Array<RHIRecordingSource>& sources) {
     sources.clear();
 }
 
+void TestTextureAspectDescriptorValidation(TestSuite& suite) {
+    constexpr std::string_view test =
+        "transient texture aspects match the physical format";
+    auto depth_stencil = kTextureDesc;
+    depth_stencil.format = PF_D32_SFLOAT_S8_UINT;
+    depth_stencil.usage  = ETextureUsageFlags::DEPTH_STENCIL_ATTACHMENT;
+    depth_stencil.aspect_flags =
+        ETextureAspectFlags::DEPTH_SLICE |
+        ETextureAspectFlags::STENCIL_SLICE;
+    suite.Check(
+        depth_stencil.IsValid(),
+        test,
+        "a complete depth-stencil descriptor was rejected"
+    );
+
+    auto depth_only_view = depth_stencil;
+    depth_only_view.aspect_flags = ETextureAspectFlags::DEPTH_SLICE;
+    suite.Check(
+        depth_only_view.IsValid(),
+        test,
+        "a depth-only view of a depth-stencil format was rejected"
+    );
+
+    auto stencil = kTextureDesc;
+    stencil.format       = PF_S8_UINT;
+    stencil.usage        = ETextureUsageFlags::DEPTH_STENCIL_ATTACHMENT;
+    stencil.aspect_flags = ETextureAspectFlags::STENCIL_SLICE;
+    suite.Check(
+        stencil.IsValid(),
+        test,
+        "a stencil-only descriptor was rejected"
+    );
+
+    auto stencil_on_depth = depth_stencil;
+    stencil_on_depth.format       = PF_D32_SFLOAT;
+    stencil_on_depth.aspect_flags = ETextureAspectFlags::STENCIL_SLICE;
+    suite.Check(
+        !stencil_on_depth.IsValid(),
+        test,
+        "a stencil aspect was accepted for a depth-only format"
+    );
+
+    auto color_as_depth = kTextureDesc;
+    color_as_depth.aspect_flags = ETextureAspectFlags::DEPTH_SLICE;
+    suite.Check(
+        !color_as_depth.IsValid(),
+        test,
+        "a color format was accepted with a depth aspect"
+    );
+}
+
 void RejectSources(Moer::Array<RHIRecordingSource>& sources) {
     for (auto& source : sources) {
         auto callbacks =
@@ -1218,6 +1269,7 @@ void TestTransientExecutionContractsAndRollback(TestSuite& suite) {
 
 int main() {
     TestSuite suite{};
+    TestTextureAspectDescriptorValidation(suite);
     TestPoolReuseAndIdleRetirement(suite);
     TestActiveTransientLifetimeIsCompletionOwned(suite);
     TestRejectedProducerRetiresThroughOrdinaryCallbacks(suite);

--- a/source/test/RenderGraphResourcePoolTest.cpp
+++ b/source/test/RenderGraphResourcePoolTest.cpp
@@ -1,0 +1,1240 @@
+#include "rendergraph/RenderGraph.h"
+#include "rendergraph/RenderGraphLowering.h"
+#include "rendergraph/RenderGraphResourcePool.h"
+
+#include <algorithm>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+
+namespace {
+
+using namespace Moer::Render;
+
+class TestSuite {
+public:
+    void Check(bool condition, std::string_view test, std::string_view message) {
+        if (condition) {
+            return;
+        }
+        ++failures;
+        std::cerr << "[FAIL] " << test << ": " << message << '\n';
+    }
+
+    [[nodiscard]] int FailureCount() const {
+        return failures;
+    }
+
+private:
+    int failures = 0;
+};
+
+class FakeTexture final : public Texture {
+public:
+    explicit FakeTexture(const RGTransientTextureDesc& desc) :
+        Texture(MakeInfo(desc)) {}
+
+    Moer::uint GetMipByteSize(Moer::uint) const override {
+        return 4;
+    }
+
+    void SetName(std::string_view value) override {
+        name.assign(value);
+    }
+
+private:
+    static TextureInfo MakeInfo(const RGTransientTextureDesc& desc) {
+        TextureInfo info{};
+        info.dimension    = desc.dimension;
+        info.usage        = desc.usage;
+        info.format       = desc.format;
+        info.extent       = {static_cast<int>(desc.extent.x), static_cast<int>(desc.extent.y)};
+        info.depth        = static_cast<uint16_t>(desc.extent.z);
+        info.array_size   = static_cast<uint16_t>(desc.PhysicalLayerCount());
+        info.num_mips     = static_cast<uint8_t>(desc.mip_count);
+        info.aspect_flags = desc.aspect_flags;
+        return info;
+    }
+
+    std::string name{};
+};
+
+class FakeBuffer final : public Buffer {
+public:
+    explicit FakeBuffer(const RGTransientBufferDesc& desc) :
+        Buffer(BufferInfo{
+            desc.element_count,
+            desc.stride,
+            desc.usage,
+            desc.format
+        }) {}
+
+    void SetName(std::string_view value) override {
+        name.assign(value);
+    }
+
+private:
+    std::string name{};
+};
+
+struct FactoryProbe {
+    uint32_t textures = 0;
+    uint32_t buffers  = 0;
+
+    RenderGraphResourcePool MakePool(uint32_t retire_after_idle_frames = 3) {
+        return RenderGraphResourcePool(
+            retire_after_idle_frames,
+            [this](std::string_view, const RGTransientTextureDesc& desc) {
+                ++textures;
+                return TextureRef{MoerNew(FakeTexture)(desc)};
+            },
+            [this](std::string_view, const RGTransientBufferDesc& desc) {
+                ++buffers;
+                return BufferRef{MoerNew(FakeBuffer)(desc)};
+            }
+        );
+    }
+};
+
+const RGTransientBufferDesc kBufferDesc{
+    .element_count = 64,
+    .stride        = 4,
+    .usage         = EBufferUsageFlags::TRANSFER_DST |
+                     EBufferUsageFlags::TRANSFER_SRC,
+};
+
+const RGTransientTextureDesc kTextureDesc{
+    .dimension     = ETextureDimension::TEX_2D,
+    .extent        = Extent3D(16, 16, 1),
+    .format        = PF_R8G8B8A8_UNORM,
+    .usage         = ETextureUsageFlags::TRANSFER_DST |
+                     ETextureUsageFlags::TRANSFER_SRC,
+    .aspect_flags  = ETextureAspectFlags::COLOR,
+    .mip_count     = 1,
+    .array_size    = 1,
+};
+
+void InvokeCallbacks(Moer::Array<std::function<void()>>& callbacks) {
+    for (auto& callback : callbacks) {
+        if (callback) {
+            callback();
+        }
+    }
+    callbacks.clear();
+}
+
+void CompleteSource(RHIRecordingSource& source) {
+    CmdSubmit submit = source.command_list->Submit();
+    InvokeCallbacks(submit.callbacks);
+    InvokeCallbacks(submit.success_callbacks);
+    source.command_list.reset();
+}
+
+void CompleteSources(Moer::Array<RHIRecordingSource>& sources) {
+    for (auto& source : sources) {
+        CompleteSource(source);
+    }
+    sources.clear();
+}
+
+void RejectSources(Moer::Array<RHIRecordingSource>& sources) {
+    for (auto& source : sources) {
+        auto callbacks =
+            source.command_list->DrainOrdinaryCallbacksForRejection();
+        InvokeCallbacks(callbacks);
+        source.command_list.reset();
+    }
+    sources.clear();
+}
+
+void TestPoolReuseAndIdleRetirement(TestSuite& suite) {
+    constexpr std::string_view test = "pool reuse and idle retirement";
+    FactoryProbe probe{};
+    auto         pool = probe.MakePool(1);
+
+    BufferRef first = pool.AcquireBuffer("First", kBufferDesc);
+    Buffer*   first_identity = first.Get();
+    BufferRef concurrent = pool.AcquireBuffer("Concurrent", kBufferDesc);
+    suite.Check(
+        first_identity != concurrent.Get() && probe.buffers == 2,
+        test,
+        "an in-use allocation was reused"
+    );
+
+    first = {};
+    BufferRef reused = pool.AcquireBuffer("Reused", kBufferDesc);
+    suite.Check(
+        reused.Get() == first_identity && probe.buffers == 2,
+        test,
+        "an idle descriptor-exact allocation was not reused"
+    );
+
+    concurrent = {};
+    reused     = {};
+    pool.Tick();
+    suite.Check(pool.BufferCount() == 2, test, "pool retired resources one frame too early");
+    pool.Tick();
+    suite.Check(pool.BufferCount() == 0, test, "pool did not retire idle resources");
+}
+
+void TestActiveTransientLifetimeIsCompletionOwned(TestSuite& suite) {
+    constexpr std::string_view test =
+        "active transient lifetime is completion owned";
+    FactoryProbe probe{};
+    auto         pool = probe.MakePool();
+    RenderGraphTransientAllocator allocator(pool);
+    Buffer* recorded_identity = nullptr;
+    Moer::Array<RHIRecordingSource> published{};
+
+    RenderGraph graph("TransientCompletionOwnership");
+    const auto transient = graph.CreateTransientBuffer("Scratch", kBufferDesc);
+    graph.AddRecordPass(
+        "WriteScratch",
+        [=](RenderGraph::PassBuilder& builder) {
+            builder.Write(
+                transient,
+                RenderGraph::BufferState::TransferDestination
+            ).SideEffect();
+        },
+        [&](CommandList&) {
+            recorded_identity = graph.GetPhysicalBuffer(transient).Get();
+        },
+        RenderGraph::PassExecutionClass::SerialRecord
+    );
+
+    const bool compiled = graph.Compile();
+    suite.Check(compiled, test, graph.GetCompileError());
+    const auto& compiled_resource =
+        graph.GetCompiledPlan().resources[transient.resource.index];
+    suite.Check(
+        compiled_resource.transient_slot !=
+                RenderGraph::PassHandle::InvalidIndex &&
+            compiled_resource.first_use == 0 &&
+            compiled_resource.last_use == 0,
+        test,
+        "compiler did not publish a transient allocation slot/lifetime"
+    );
+
+    const bool executed = graph.ExecuteRecording(
+        {},
+        {},
+        false,
+        [&](Moer::Array<RHIRecordingSource>&& sources) {
+            published = std::move(sources);
+        },
+        RenderGraph::ActiveRecordingOptions{
+            .enabled             = true,
+            .transient_allocator = &allocator,
+        }
+    );
+    suite.Check(executed, test, graph.GetCompileError());
+    suite.Check(
+        recorded_identity != nullptr && published.size() == 1,
+        test,
+        "transient pass did not receive its physical allocation"
+    );
+    suite.Check(
+        !graph.GetPhysicalBuffer(transient).IsValid(),
+        test,
+        "non-exported graph ownership was not released after recording"
+    );
+    suite.Check(
+        pool.BufferCount() == 1 && pool.AvailableBufferCount() == 0,
+        test,
+        "pool exposed an in-flight completion-owned allocation"
+    );
+
+    CompleteSources(published);
+    suite.Check(
+        pool.AvailableBufferCount() == 1,
+        test,
+        "completion callbacks did not return the allocation to the pool"
+    );
+    BufferRef reused = pool.AcquireBuffer("NextFrame", kBufferDesc);
+    suite.Check(
+        reused.Get() == recorded_identity && probe.buffers == 1,
+        test,
+        "the next completed frame did not reuse the physical allocation"
+    );
+}
+
+void TestRejectedProducerRetiresThroughOrdinaryCallbacks(TestSuite& suite) {
+    constexpr std::string_view test =
+        "rejected producer retires through ordinary callbacks";
+    FactoryProbe probe{};
+    auto         pool = probe.MakePool();
+    RenderGraphTransientAllocator allocator(pool);
+    Moer::Array<RHIRecordingSource> published{};
+
+    RenderGraph graph("TransientRejectedProducer");
+    const auto transient = graph.CreateTransientBuffer("Scratch", kBufferDesc);
+    graph.AddRecordPass(
+        "FailScratch",
+        [=](RenderGraph::PassBuilder& builder) {
+            builder.Write(
+                transient,
+                RenderGraph::BufferState::TransferDestination
+            ).SideEffect();
+        },
+        [](CommandList&) {
+            throw std::runtime_error("injected record failure");
+        },
+        RenderGraph::PassExecutionClass::SerialRecord
+    );
+
+    const bool compiled = graph.Compile();
+    suite.Check(compiled, test, graph.GetCompileError());
+    const bool executed = graph.ExecuteRecording(
+        {},
+        {},
+        false,
+        [&](Moer::Array<RHIRecordingSource>&& sources) {
+            published = std::move(sources);
+        },
+        RenderGraph::ActiveRecordingOptions{
+            .enabled             = true,
+            .transient_allocator = &allocator,
+        }
+    );
+    suite.Check(!executed, test, "injected record failure unexpectedly committed");
+    suite.Check(
+        published.size() == 1 && pool.AvailableBufferCount() == 0,
+        test,
+        "failed producer lost completion ownership before rejection cleanup"
+    );
+
+    RejectSources(published);
+    suite.Check(
+        pool.AvailableBufferCount() == 1,
+        test,
+        "ordinary rejection callbacks did not retire the allocation"
+    );
+}
+
+void TestUnusedTransientDoesNotAllocate(TestSuite& suite) {
+    constexpr std::string_view test = "unused transient does not allocate";
+    FactoryProbe probe{};
+    auto         pool = probe.MakePool();
+    RenderGraphTransientAllocator allocator(pool);
+    Moer::Array<RHIRecordingSource> published{};
+
+    RenderGraph graph("UnusedTransient");
+    (void)graph.CreateTransientBuffer("Unused", kBufferDesc);
+    BufferRef imported_physical = MoerNew(FakeBuffer)(kBufferDesc);
+    const auto imported = graph.ImportBuffer(
+        "Imported",
+        imported_physical,
+        RenderGraph::BufferDesc{.byte_size = kBufferDesc.ByteSize()}
+    );
+    graph.SetInitialState(
+        imported,
+        RenderGraph::BufferState::Undefined,
+        RenderGraph::QueueRole::None,
+        RenderGraph::AccessMode::None
+    );
+    graph.AddRecordPass(
+        "SideEffectOnly",
+        [=](RenderGraph::PassBuilder& builder) {
+            builder.Write(
+                imported,
+                RenderGraph::BufferState::TransferDestination
+            ).SideEffect();
+        },
+        [](CommandList&) {},
+        RenderGraph::PassExecutionClass::SerialRecord
+    );
+    graph.Export(
+        imported,
+        RenderGraph::BufferState::TransferSource,
+        RenderGraph::QueueRole::Graphics,
+        RenderGraph::AccessMode::Read
+    );
+
+    const bool compiled = graph.Compile();
+    suite.Check(compiled, test, graph.GetCompileError());
+    const bool executed = graph.ExecuteRecording(
+        {},
+        {},
+        false,
+        [&](Moer::Array<RHIRecordingSource>&& sources) {
+            published = std::move(sources);
+        },
+        RenderGraph::ActiveRecordingOptions{
+            .enabled             = true,
+            .transient_allocator = &allocator,
+        }
+    );
+    suite.Check(executed, test, graph.GetCompileError());
+    suite.Check(
+        probe.buffers == 0 && pool.BufferCount() == 0,
+        test,
+        "unused transient resource was physically allocated"
+    );
+    CompleteSources(published);
+}
+
+void TestNonOverlappingBuffersAliasUntilEveryCompletion(TestSuite& suite) {
+    constexpr std::string_view test =
+        "non-overlapping buffers alias until every completion";
+    FactoryProbe probe{};
+    auto         pool = probe.MakePool();
+    RenderGraphTransientAllocator allocator(pool);
+    Moer::Array<RHIRecordingSource> published{};
+    Buffer* first_identity  = nullptr;
+    Buffer* second_identity = nullptr;
+
+    RenderGraph graph("TransientBufferAlias");
+    const auto first  = graph.CreateTransientBuffer("First", kBufferDesc);
+    const auto second = graph.CreateTransientBuffer("Second", kBufferDesc);
+    const auto first_pass = graph.AddRecordPass(
+        "WriteFirst",
+        [=](RenderGraph::PassBuilder& builder) {
+            builder.Write(
+                first,
+                RenderGraph::BufferState::TransferDestination
+            ).SideEffect();
+        },
+        [&](CommandList&) {
+            first_identity = graph.GetPhysicalBuffer(first).Get();
+        },
+        RenderGraph::PassExecutionClass::ParallelRecordEligible
+    );
+    const auto second_pass = graph.AddRecordPass(
+        "WriteSecond",
+        [=](RenderGraph::PassBuilder& builder) {
+            builder.Write(
+                second,
+                RenderGraph::BufferState::TransferDestination
+            ).SideEffect();
+        },
+        [&](CommandList&) {
+            second_identity = graph.GetPhysicalBuffer(second).Get();
+        },
+        RenderGraph::PassExecutionClass::ParallelRecordEligible
+    );
+
+    const bool compiled = graph.Compile();
+    suite.Check(compiled, test, graph.GetCompileError());
+    if (!compiled) {
+        return;
+    }
+
+    const auto& plan = graph.GetCompiledPlan();
+    const auto first_slot =
+        plan.resources[first.resource.index].transient_slot;
+    const auto second_slot =
+        plan.resources[second.resource.index].transient_slot;
+    suite.Check(
+        first_slot != RenderGraph::PassHandle::InvalidIndex &&
+            first_slot == second_slot && plan.alias_boundaries.size() == 1,
+        test,
+        "compiler did not color non-overlapping descriptor-exact buffers into one slot"
+    );
+
+    if (!plan.alias_boundaries.empty()) {
+        const auto& alias = plan.alias_boundaries.front();
+        suite.Check(
+                alias.predecessor_resource == first.resource &&
+                alias.successor_resource == second.resource &&
+                alias.primary_src_pass == first_pass &&
+                alias.source_frontier ==
+                    std::vector<RenderGraph::PassHandle>{first_pass} &&
+                alias.dst_pass == second_pass &&
+                alias.barrier_index < plan.barriers.size(),
+            test,
+            "compiled alias boundary does not name the expected resources and passes"
+        );
+        if (alias.barrier_index < plan.barriers.size()) {
+            const auto& barrier = plan.barriers[alias.barrier_index];
+            suite.Check(
+                barrier.transient_alias &&
+                    barrier.src_pass == first_pass &&
+                    barrier.dst_pass == second_pass &&
+                    barrier.before_state ==
+                        RenderGraph::ResourceState::Buffer(
+                            RenderGraph::BufferState::TransferDestination
+                        ) &&
+                    barrier.after_state ==
+                        RenderGraph::ResourceState::Buffer(
+                            RenderGraph::BufferState::TransferDestination
+                        ) &&
+                    barrier.memory_dependency &&
+                    barrier.execution_dependency &&
+                    !barrier.discard_previous_contents &&
+                    barrier.sources.size() == 1,
+                test,
+                "alias boundary was not lowered to a predecessor-aware memory barrier"
+            );
+        }
+    }
+
+    const bool has_alias_edge = std::any_of(
+        plan.edges.begin(),
+        plan.edges.end(),
+        [&](const RenderGraph::CompiledEdge& edge) {
+            return edge.src == first_pass && edge.dst == second_pass &&
+                   std::any_of(
+                       edge.reasons.begin(),
+                       edge.reasons.end(),
+                       [](const RenderGraph::CompiledEdgeReason& reason) {
+                           return reason.kind ==
+                                  RenderGraph::EdgeReasonKind::TransientAlias;
+                       }
+                   );
+        }
+    );
+    suite.Check(
+        has_alias_edge,
+        test,
+        "alias reuse did not become a formal compiled dependency"
+    );
+
+    const bool executed = graph.ExecuteRecording(
+        {},
+        {},
+        false,
+        [&](Moer::Array<RHIRecordingSource>&& sources) {
+            published = std::move(sources);
+        },
+        RenderGraph::ActiveRecordingOptions{
+            .enabled             = true,
+            .transient_allocator = &allocator,
+        }
+    );
+    suite.Check(executed, test, graph.GetCompileError());
+    suite.Check(
+        first_identity != nullptr && first_identity == second_identity &&
+            probe.buffers == 1 && published.size() == 2,
+        test,
+        "logical aliases did not receive one physical buffer"
+    );
+    suite.Check(
+        pool.AvailableBufferCount() == 0,
+        test,
+        "aliased allocation became reusable before completion"
+    );
+
+    if (published.size() == 2) {
+        CompleteSource(published[0]);
+        suite.Check(
+            pool.AvailableBufferCount() == 0,
+            test,
+            "first owner completion released an allocation still owned by its alias"
+        );
+        CompleteSource(published[1]);
+        suite.Check(
+            pool.AvailableBufferCount() == 1,
+            test,
+            "allocation did not return after every aliased owner completed"
+        );
+    }
+    published.clear();
+}
+
+void TestUnsafeAliasCasesRemainDistinct(TestSuite& suite) {
+    constexpr std::string_view overlap_test =
+        "overlapping transient lifetimes remain distinct";
+    {
+        FactoryProbe probe{};
+        auto         pool = probe.MakePool();
+        RenderGraphTransientAllocator allocator(pool);
+        RenderGraph graph("OverlappingTransientBuffers");
+        const auto first  = graph.CreateTransientBuffer("First", kBufferDesc);
+        const auto second = graph.CreateTransientBuffer("Second", kBufferDesc);
+        graph.AddRecordPass(
+            "WriteFirst",
+            [=](RenderGraph::PassBuilder& builder) {
+                builder.Write(
+                    first,
+                    RenderGraph::BufferState::TransferDestination
+                ).SideEffect();
+            },
+            [](CommandList&) {}
+        );
+        graph.AddRecordPass(
+            "WriteSecond",
+            [=](RenderGraph::PassBuilder& builder) {
+                builder.Write(
+                    second,
+                    RenderGraph::BufferState::TransferDestination
+                ).SideEffect();
+            },
+            [](CommandList&) {}
+        );
+        graph.AddRecordPass(
+            "ReadFirst",
+            [=](RenderGraph::PassBuilder& builder) {
+                builder.Read(
+                    first,
+                    RenderGraph::BufferState::TransferSource
+                ).SideEffect();
+            },
+            [](CommandList&) {}
+        );
+
+        const bool compiled = graph.Compile();
+        suite.Check(compiled, overlap_test, graph.GetCompileError());
+        if (compiled) {
+            const auto& plan = graph.GetCompiledPlan();
+            suite.Check(
+                plan.resources[first.resource.index].transient_slot !=
+                    plan.resources[second.resource.index].transient_slot &&
+                    plan.alias_boundaries.empty(),
+                overlap_test,
+                "overlapping lifetimes were assigned one physical slot"
+            );
+            std::string error{};
+            suite.Check(
+                allocator.Prepare(graph, error),
+                overlap_test,
+                error
+            );
+            suite.Check(
+                graph.GetPhysicalBuffer(first).Get() !=
+                        graph.GetPhysicalBuffer(second).Get() &&
+                    pool.BufferCount() == 2,
+                overlap_test,
+                "allocator collapsed distinct overlapping slots"
+            );
+            allocator.ReleaseNonExported(graph);
+        }
+    }
+
+    constexpr std::string_view descriptor_test =
+        "incompatible transient descriptors remain distinct";
+    {
+        RenderGraph graph("IncompatibleTransientBuffers");
+        auto larger_desc = kBufferDesc;
+        larger_desc.element_count *= 2;
+        const auto first  = graph.CreateTransientBuffer("First", kBufferDesc);
+        const auto second = graph.CreateTransientBuffer("Second", larger_desc);
+        graph.AddRecordPass(
+            "WriteFirst",
+            [=](RenderGraph::PassBuilder& builder) {
+                builder.Write(
+                    first,
+                    RenderGraph::BufferState::TransferDestination
+                ).SideEffect();
+            },
+            [](CommandList&) {}
+        );
+        graph.AddRecordPass(
+            "WriteSecond",
+            [=](RenderGraph::PassBuilder& builder) {
+                builder.Write(
+                    second,
+                    RenderGraph::BufferState::TransferDestination
+                ).SideEffect();
+            },
+            [](CommandList&) {}
+        );
+
+        const bool compiled = graph.Compile();
+        suite.Check(compiled, descriptor_test, graph.GetCompileError());
+        if (compiled) {
+            const auto& plan = graph.GetCompiledPlan();
+            suite.Check(
+                plan.resources[first.resource.index].transient_slot !=
+                    plan.resources[second.resource.index].transient_slot &&
+                    plan.alias_boundaries.empty(),
+                descriptor_test,
+                "descriptor-incompatible resources shared a transient slot"
+            );
+        }
+    }
+
+    constexpr std::string_view export_test =
+        "exported transient resources do not alias";
+    {
+        RenderGraph graph("ExportedTransientBuffer");
+        const auto exported =
+            graph.CreateTransientBuffer("Exported", kBufferDesc);
+        const auto later = graph.CreateTransientBuffer("Later", kBufferDesc);
+        graph.AddRecordPass(
+            "WriteExported",
+            [=](RenderGraph::PassBuilder& builder) {
+                builder.Write(
+                    exported,
+                    RenderGraph::BufferState::TransferDestination
+                ).SideEffect();
+            },
+            [](CommandList&) {}
+        );
+        graph.AddRecordPass(
+            "WriteLater",
+            [=](RenderGraph::PassBuilder& builder) {
+                builder.Write(
+                    later,
+                    RenderGraph::BufferState::TransferDestination
+                ).SideEffect();
+            },
+            [](CommandList&) {}
+        );
+        graph.Export(
+            exported,
+            RenderGraph::BufferState::TransferSource,
+            RenderGraph::QueueRole::Graphics,
+            RenderGraph::AccessMode::Read
+        );
+
+        const bool compiled = graph.Compile();
+        suite.Check(compiled, export_test, graph.GetCompileError());
+        if (compiled) {
+            const auto& plan = graph.GetCompiledPlan();
+            suite.Check(
+                plan.resources[exported.resource.index].transient_slot !=
+                    plan.resources[later.resource.index].transient_slot &&
+                    plan.alias_boundaries.empty(),
+                export_test,
+                "an exported resource was reused by a later transient"
+            );
+        }
+    }
+
+    constexpr std::string_view reference_test =
+        "opaque transient references disable aliasing";
+    {
+        RenderGraph graph("ReferencedTransientBuffer");
+        const auto referenced =
+            graph.CreateTransientBuffer("Referenced", kBufferDesc);
+        const auto later =
+            graph.CreateTransientBuffer("Later", kBufferDesc);
+        graph.AddRecordPass(
+            "WriteReferenced",
+            [=](RenderGraph::PassBuilder& builder) {
+                builder.Write(
+                    referenced,
+                    RenderGraph::BufferState::TransferDestination
+                ).SideEffect();
+            },
+            [](CommandList&) {}
+        );
+        graph.AddRecordPass(
+            "ReferenceOnly",
+            [=](RenderGraph::PassBuilder& builder) {
+                builder.Reference(referenced).SideEffect();
+            },
+            [](CommandList&) {}
+        );
+        graph.AddRecordPass(
+            "WriteLater",
+            [=](RenderGraph::PassBuilder& builder) {
+                builder.Write(
+                    later,
+                    RenderGraph::BufferState::TransferDestination
+                ).SideEffect();
+            },
+            [](CommandList&) {}
+        );
+
+        const bool compiled = graph.Compile();
+        suite.Check(compiled, reference_test, graph.GetCompileError());
+        if (compiled) {
+            const auto& plan = graph.GetCompiledPlan();
+            suite.Check(
+                plan.resources[referenced.resource.index].transient_slot !=
+                    plan.resources[later.resource.index].transient_slot &&
+                    plan.alias_boundaries.empty(),
+                reference_test,
+                "opaque Reference lifetime was reused by a later transient"
+            );
+        }
+    }
+}
+
+void TestNonOverlappingTexturesAlias(TestSuite& suite) {
+    constexpr std::string_view test =
+        "non-overlapping textures use one descriptor-exact allocation";
+    FactoryProbe probe{};
+    auto         pool = probe.MakePool();
+    RenderGraphTransientAllocator allocator(pool);
+    RenderGraph graph("TransientTextureAlias");
+    const auto first  = graph.CreateTransientTexture("First", kTextureDesc);
+    const auto second = graph.CreateTransientTexture("Second", kTextureDesc);
+    graph.AddRecordPass(
+        "WriteFirst",
+        [=](RenderGraph::PassBuilder& builder) {
+            builder.Write(
+                first,
+                RenderGraph::TextureState::TransferDestination
+            ).SideEffect();
+        },
+        [](CommandList&) {}
+    );
+    graph.AddRecordPass(
+        "WriteSecond",
+        [=](RenderGraph::PassBuilder& builder) {
+            builder.Write(
+                second,
+                RenderGraph::TextureState::TransferDestination
+            ).SideEffect();
+        },
+        [](CommandList&) {}
+    );
+
+    const bool compiled = graph.Compile();
+    suite.Check(compiled, test, graph.GetCompileError());
+    if (!compiled) {
+        return;
+    }
+    const auto& plan = graph.GetCompiledPlan();
+    suite.Check(
+        plan.resources[first.resource.index].transient_slot ==
+                plan.resources[second.resource.index].transient_slot &&
+            plan.alias_boundaries.size() == 1,
+        test,
+        "compiler did not alias compatible whole textures"
+    );
+    std::string error{};
+    suite.Check(allocator.Prepare(graph, error), test, error);
+    suite.Check(
+        graph.GetPhysicalTexture(first).Get() ==
+                graph.GetPhysicalTexture(second).Get() &&
+            probe.textures == 1,
+        test,
+        "allocator did not materialize the texture alias slot once"
+    );
+    allocator.ReleaseNonExported(graph);
+}
+
+void TestAliasBarrierCoversCompleteReaderFrontier(TestSuite& suite) {
+    constexpr std::string_view test =
+        "alias barrier covers complete reader frontier";
+    RenderGraph graph("TransientAliasReaderFrontier");
+    const auto first  = graph.CreateTransientBuffer("First", kBufferDesc);
+    const auto second = graph.CreateTransientBuffer("Second", kBufferDesc);
+    graph.AddRecordPass(
+        "WriteFirst",
+        [=](RenderGraph::PassBuilder& builder) {
+            builder.ExecuteOn(
+                       RenderGraph::QueueRole::Graphics,
+                       RenderGraph::PipelineType::Copy
+                   )
+                .Write(
+                    first,
+                    RenderGraph::BufferState::TransferDestination
+                )
+                .SideEffect();
+        },
+        [](CommandList&) {}
+    );
+    const auto ray_reader = graph.AddRecordPass(
+        "RayReadFirst",
+        [=](RenderGraph::PassBuilder& builder) {
+            builder.ExecuteOn(
+                       RenderGraph::QueueRole::Graphics,
+                       RenderGraph::PipelineType::RayTracing
+                   )
+                .Read(
+                    first,
+                    RenderGraph::BufferState::ShaderResource
+                )
+                .SideEffect();
+        },
+        [](CommandList&) {}
+    );
+    const auto graphics_reader = graph.AddRecordPass(
+        "GraphicsReadFirst",
+        [=](RenderGraph::PassBuilder& builder) {
+            builder.ExecuteOn(
+                       RenderGraph::QueueRole::Graphics,
+                       RenderGraph::PipelineType::Graphics
+                   )
+                .Read(
+                    first,
+                    RenderGraph::BufferState::ShaderResource
+                )
+                .SideEffect();
+        },
+        [](CommandList&) {}
+    );
+    const auto successor = graph.AddRecordPass(
+        "WriteSecond",
+        [=](RenderGraph::PassBuilder& builder) {
+            builder.ExecuteOn(
+                       RenderGraph::QueueRole::Graphics,
+                       RenderGraph::PipelineType::Copy
+                   )
+                .Write(
+                    second,
+                    RenderGraph::BufferState::TransferDestination
+                )
+                .SideEffect();
+        },
+        [](CommandList&) {}
+    );
+
+    const bool compiled = graph.Compile();
+    suite.Check(compiled, test, graph.GetCompileError());
+    if (!compiled) {
+        return;
+    }
+    const auto& plan = graph.GetCompiledPlan();
+    suite.Check(
+        plan.alias_boundaries.size() == 1,
+        test,
+        "reader-frontier graph did not produce an alias boundary"
+    );
+    if (plan.alias_boundaries.empty()) {
+        return;
+    }
+    const auto& alias = plan.alias_boundaries.front();
+    suite.Check(
+        alias.barrier_index < plan.barriers.size(),
+        test,
+        "alias boundary references an invalid barrier"
+    );
+    if (alias.barrier_index >= plan.barriers.size()) {
+        return;
+    }
+
+    const auto& barrier = plan.barriers[alias.barrier_index];
+    const auto has_source = [&](RenderGraph::PassHandle pass) {
+        return std::any_of(
+            barrier.sources.begin(),
+            barrier.sources.end(),
+            [&](const RenderGraph::CompiledBarrierSource& source) {
+                return source.pass == pass;
+            }
+        );
+    };
+    suite.Check(
+        barrier.sources.size() == 2 && has_source(ray_reader) &&
+            has_source(graphics_reader) &&
+            barrier.src_pass == graphics_reader,
+        test,
+        "alias barrier dropped a live reader scope from its source frontier"
+    );
+
+    const auto has_alias_edge = [&](RenderGraph::PassHandle source) {
+        return std::any_of(
+            plan.edges.begin(),
+            plan.edges.end(),
+            [&](const RenderGraph::CompiledEdge& edge) {
+                return edge.src == source && edge.dst == successor &&
+                       std::any_of(
+                           edge.reasons.begin(),
+                           edge.reasons.end(),
+                           [](const RenderGraph::CompiledEdgeReason& reason) {
+                               return reason.kind ==
+                                      RenderGraph::EdgeReasonKind::TransientAlias;
+                           }
+                       );
+            }
+        );
+    };
+    suite.Check(
+        has_alias_edge(ray_reader) && has_alias_edge(graphics_reader),
+        test,
+        "alias dependency edges do not cover every reader frontier source"
+    );
+
+    FactoryProbe probe{};
+    auto         pool = probe.MakePool();
+    RenderGraphTransientAllocator allocator(pool);
+    std::string allocation_error{};
+    suite.Check(
+        allocator.Prepare(graph, allocation_error),
+        test,
+        allocation_error
+    );
+    RenderGraphLowering::LoweredPlan lowered{};
+    std::string lowering_error{};
+    suite.Check(
+        RenderGraphLowering::Lower(graph, lowered, lowering_error),
+        test,
+        lowering_error
+    );
+    const auto before = lowered.Before(successor);
+    const auto lowered_alias = std::find_if(
+        before.begin(),
+        before.end(),
+        [](const RenderGraphLowering::LoweredInstruction& instruction) {
+            return instruction.transient_alias;
+        }
+    );
+    suite.Check(
+        lowered_alias != before.end(),
+        test,
+        "lowering dropped the alias barrier"
+    );
+    if (lowered_alias != before.end()) {
+        const uint32_t stages =
+            static_cast<uint32_t>(lowered_alias->source.stages);
+        const uint32_t ray_stage = static_cast<uint32_t>(
+            ERHIPipelineStageFlags::PS_RAY_TRACING_SHADER
+        );
+        const uint32_t graphics_stage = static_cast<uint32_t>(
+            ERHIPipelineStageFlags::PS_ALL_GRAPHICS
+        );
+        suite.Check(
+            (stages & ray_stage) != 0 &&
+                (stages & graphics_stage) != 0,
+            test,
+            "lowering did not merge every reader pipeline stage"
+        );
+    }
+    allocator.ReleaseNonExported(graph);
+}
+
+void TestAliasChainUsesOneSlot(TestSuite& suite) {
+    constexpr std::string_view test = "three-resource alias chain uses one slot";
+    RenderGraph graph("TransientAliasChain");
+    const auto first  = graph.CreateTransientBuffer("First", kBufferDesc);
+    const auto second = graph.CreateTransientBuffer("Second", kBufferDesc);
+    const auto third  = graph.CreateTransientBuffer("Third", kBufferDesc);
+    const auto add_write = [&](std::string_view name, RenderGraph::BufferHandle buffer) {
+        graph.AddRecordPass(
+            name,
+            [=](RenderGraph::PassBuilder& builder) {
+                builder.Write(
+                    buffer,
+                    RenderGraph::BufferState::TransferDestination
+                ).SideEffect();
+            },
+            [](CommandList&) {}
+        );
+    };
+    add_write("WriteFirst", first);
+    add_write("WriteSecond", second);
+    add_write("WriteThird", third);
+
+    const bool compiled = graph.Compile();
+    suite.Check(compiled, test, graph.GetCompileError());
+    if (!compiled) {
+        return;
+    }
+    const auto& plan = graph.GetCompiledPlan();
+    const uint32_t slot = plan.resources[first.resource.index].transient_slot;
+    suite.Check(
+        slot != RenderGraph::PassHandle::InvalidIndex &&
+            plan.resources[second.resource.index].transient_slot == slot &&
+            plan.resources[third.resource.index].transient_slot == slot &&
+            plan.alias_boundaries.size() == 2,
+        test,
+        "compiler did not build the expected adjacent alias chain"
+    );
+}
+
+void TestMainThreadReferenceRetainsCompletionLifetime(TestSuite& suite) {
+    constexpr std::string_view test =
+        "main-thread reference retains completion lifetime";
+    FactoryProbe probe{};
+    auto         pool = probe.MakePool();
+    RenderGraphTransientAllocator allocator(pool);
+    RenderGraph graph("MainThreadReferenceLifetime");
+    const auto transient =
+        graph.CreateTransientBuffer("Referenced", kBufferDesc);
+    graph.AddPass(
+        "WriteReferenced",
+        [=](RenderGraph::PassBuilder& builder) {
+            builder.Write(
+                transient,
+                RenderGraph::BufferState::TransferDestination
+            ).SideEffect();
+        },
+        [] {}
+    );
+    graph.AddPass(
+        "ReferenceOnly",
+        [=](RenderGraph::PassBuilder& builder) {
+            builder.Reference(transient).SideEffect();
+        },
+        [] {}
+    );
+
+    const bool compiled = graph.Compile();
+    suite.Check(compiled, test, graph.GetCompileError());
+    CommandList main_commands(EQueueType::Graphics);
+    const bool executed = compiled && graph.ExecuteRecording(
+        {},
+        {},
+        false,
+        {},
+        RenderGraph::ActiveRecordingOptions{
+            .enabled                  = true,
+            .main_thread_command_list = &main_commands,
+            .transient_allocator      = &allocator,
+        }
+    );
+    suite.Check(executed, test, graph.GetCompileError());
+    suite.Check(
+        !graph.GetPhysicalBuffer(transient).IsValid() &&
+            pool.BufferCount() == 1 &&
+            pool.AvailableBufferCount() == 0,
+        test,
+        "reference-only MainThread pass did not transfer ownership to Completion"
+    );
+    if (executed) {
+        CmdSubmit submit = main_commands.Submit();
+        InvokeCallbacks(submit.callbacks);
+        suite.Check(
+            pool.AvailableBufferCount() == 0,
+            test,
+            "ordinary callbacks released a reference before the success tail"
+        );
+        InvokeCallbacks(submit.success_callbacks);
+        suite.Check(
+            pool.AvailableBufferCount() == 1,
+            test,
+            "success Completion did not retire the reference-only lifetime"
+        );
+    }
+}
+
+void TestTransientExecutionContractsAndRollback(TestSuite& suite) {
+    constexpr std::string_view reference_producer_test =
+        "referenced transient requires a producer";
+    {
+        RenderGraph graph("UnproducedReferencedTransient");
+        const auto transient =
+            graph.CreateTransientBuffer("Scratch", kBufferDesc);
+        graph.AddRecordPass(
+            "ReferenceOnly",
+            [=](RenderGraph::PassBuilder& builder) {
+                builder.Reference(transient).SideEffect();
+            },
+            [](CommandList&) {}
+        );
+        const bool compiled = graph.Compile();
+        suite.Check(
+            !compiled &&
+                graph.GetCompileError().find("no producer") !=
+                    std::string::npos,
+            reference_producer_test,
+            "opaque Reference accepted an uninitialized transient"
+        );
+    }
+
+    constexpr std::string_view disabled_test =
+        "allocation-backed transient rejects inactive recording";
+    {
+        RenderGraph graph("InactiveTransientRecording");
+        const auto transient =
+            graph.CreateTransientBuffer("Scratch", kBufferDesc);
+        graph.AddRecordPass(
+            "WriteScratch",
+            [=](RenderGraph::PassBuilder& builder) {
+                builder.Write(
+                    transient,
+                    RenderGraph::BufferState::TransferDestination
+                ).SideEffect();
+            },
+            [](CommandList&) {}
+        );
+        const bool compiled = graph.Compile();
+        suite.Check(compiled, disabled_test, graph.GetCompileError());
+        const bool executed = compiled && graph.ExecuteRecording({});
+        suite.Check(
+            !executed &&
+                graph.GetCompileError().find("active recording") !=
+                    std::string::npos &&
+                !graph.GetPhysicalBuffer(transient).IsValid(),
+            disabled_test,
+            "inactive recording exposed an unallocated transient"
+        );
+    }
+
+    constexpr std::string_view serial_test =
+        "allocation-backed transient rejects serial execute";
+    {
+        bool callback_ran = false;
+        RenderGraph graph("SerialTransientExecute");
+        const auto transient =
+            graph.CreateTransientBuffer("Scratch", kBufferDesc);
+        graph.AddPass(
+            "WriteScratch",
+            [=](RenderGraph::PassBuilder& builder) {
+                builder.Write(
+                    transient,
+                    RenderGraph::BufferState::TransferDestination
+                ).SideEffect();
+            },
+            [&] { callback_ran = true; }
+        );
+        const bool compiled = graph.Compile();
+        suite.Check(compiled, serial_test, graph.GetCompileError());
+        const bool executed = compiled && graph.Execute();
+        suite.Check(
+            !executed && !callback_ran &&
+                graph.GetCompileError().find("active ExecuteRecording") !=
+                    std::string::npos,
+            serial_test,
+            "serial Execute ran an allocation-backed transient callback"
+        );
+    }
+
+    constexpr std::string_view rollback_test =
+        "lowering failure rolls back transient bindings";
+    {
+        FactoryProbe probe{};
+        auto         pool = probe.MakePool();
+        RenderGraphTransientAllocator allocator(pool);
+        RenderGraph graph("TransientLoweringRollback");
+        const auto transient =
+            graph.CreateTransientBuffer("ComputeScratch", kBufferDesc);
+        graph.AddRecordPass(
+            "ComputeWrite",
+            [=](RenderGraph::PassBuilder& builder) {
+                builder.ExecuteOn(
+                           RenderGraph::QueueRole::Compute,
+                           RenderGraph::PipelineType::Compute
+                       )
+                    .Write(
+                        transient,
+                        RenderGraph::BufferState::UnorderedAccess
+                    )
+                    .SideEffect();
+            },
+            [](CommandList&) {}
+        );
+        const bool compiled = graph.Compile();
+        suite.Check(compiled, rollback_test, graph.GetCompileError());
+        const bool executed = compiled && graph.ExecuteRecording(
+            {},
+            {},
+            false,
+            {},
+            RenderGraph::ActiveRecordingOptions{
+                .enabled             = true,
+                .transient_allocator = &allocator,
+            }
+        );
+        suite.Check(
+            !executed &&
+                graph.GetCompileError().find("Graphics") !=
+                    std::string::npos &&
+                !graph.GetPhysicalBuffer(transient).IsValid() &&
+                pool.BufferCount() == 1 &&
+                pool.AvailableBufferCount() == 1,
+            rollback_test,
+            "failure after Prepare retained a non-exported physical binding"
+        );
+    }
+}
+
+} // namespace
+
+int main() {
+    TestSuite suite{};
+    TestPoolReuseAndIdleRetirement(suite);
+    TestActiveTransientLifetimeIsCompletionOwned(suite);
+    TestRejectedProducerRetiresThroughOrdinaryCallbacks(suite);
+    TestUnusedTransientDoesNotAllocate(suite);
+    TestNonOverlappingBuffersAliasUntilEveryCompletion(suite);
+    TestUnsafeAliasCasesRemainDistinct(suite);
+    TestNonOverlappingTexturesAlias(suite);
+    TestAliasBarrierCoversCompleteReaderFrontier(suite);
+    TestAliasChainUsesOneSlot(suite);
+    TestMainThreadReferenceRetainsCompletionLifetime(suite);
+    TestTransientExecutionContractsAndRollback(suite);
+
+    if (suite.FailureCount() != 0) {
+        std::cerr << suite.FailureCount()
+                  << " render graph resource pool contract(s) failed\n";
+        return 1;
+    }
+    std::cout << "Render graph resource pool contracts passed\n";
+    return 0;
+}

--- a/source/test/RenderGraphTest.cpp
+++ b/source/test/RenderGraphTest.cpp
@@ -2791,8 +2791,8 @@ void TestStageTwoDumpDeterminism(TestSuite& suite) {
     const std::string second = BuildStageTwoDump(suite, test_name);
     suite.Check(first == second, test_name, "equivalent Stage 2 plans must have byte-identical dumps");
     suite.Check(
-        Contains(first, "barrier_owner=existing_rhi_vulkan_path") &&
-            Contains(first, "sync_plan=shadow external_endpoints=unbound") &&
+        Contains(first, "barrier_plan=explicit") &&
+            Contains(first, "sync_plan=queue-dag external_endpoints=unbound") &&
             Contains(first, "barriers:\n") && Contains(first, "queue_batches:\n") &&
             Contains(first, "queue_syncs:\n") && Contains(first, "pipeline=compute") &&
             Contains(first, "flags=[execution,memory,transition,queue,ownership"),

--- a/source/test/RenderGraphTest.cpp
+++ b/source/test/RenderGraphTest.cpp
@@ -2987,55 +2987,61 @@ void TestUntouchedBoundaryWriteRequiresMemoryDependency(TestSuite& suite) {
     );
 }
 
-[[nodiscard]] std::string BuildCompatibleStateOrderDump(
-    TestSuite& suite,
-    std::string_view test_name,
-    bool reverse
-) {
-    RenderGraph graph("CompatibleStateOrder");
+void TestShaderReadStatesRequireTransition(TestSuite& suite) {
+    constexpr std::string_view test_name =
+        "shader resource and sampled states require a transition";
+    RenderGraph graph("DistinctShaderReadStates");
     int         physical = 0;
-    const auto  texture = graph.ImportTexture("Texture", &physical, RenderGraph::TextureDesc{});
+    const auto  texture =
+        graph.ImportTexture("Texture", &physical, RenderGraph::TextureDesc{});
     graph.SetInitialState(
         texture,
         RenderGraph::TextureState::ShaderResource,
         RenderGraph::QueueRole::Graphics,
         RenderGraph::AccessMode::Read
     );
-    graph.AddPass(
-        "Read",
+    const auto storage_read = graph.AddPass(
+        "StorageRead",
         [=](RenderGraph::PassBuilder& builder) {
-            if (reverse) {
-                builder.Read(texture, RenderGraph::TextureState::Sampled);
-                builder.Read(texture, RenderGraph::TextureState::ShaderResource);
-            } else {
-                builder.Read(texture, RenderGraph::TextureState::ShaderResource);
-                builder.Read(texture, RenderGraph::TextureState::Sampled);
-            }
+            builder.Read(texture, RenderGraph::TextureState::ShaderResource);
         },
         [] {}
     );
+    const auto sampled_read = graph.AddPass(
+        "SampledRead",
+        [=](RenderGraph::PassBuilder& builder) {
+            builder.Read(texture, RenderGraph::TextureState::Sampled);
+        },
+        [] {}
+    );
+    graph.Export(
+        texture,
+        RenderGraph::TextureState::Sampled,
+        RenderGraph::QueueRole::Graphics,
+        RenderGraph::AccessMode::Read
+    );
+
     suite.Check(graph.Compile(), test_name, graph.GetCompileError());
+    const auto& plan = graph.GetCompiledPlan();
+    const auto* barrier =
+        FindBarrier(plan, texture.Untyped(), storage_read, sampled_read);
     suite.Check(
-        !graph.GetCompiledPlan().accesses.empty() &&
-            graph.GetCompiledPlan().accesses.front().state == RenderGraph::ResourceState::Texture(
+        barrier != nullptr && barrier->state_transition &&
+            barrier->before_state == RenderGraph::ResourceState::Texture(
                 RenderGraph::TextureState::ShaderResource
+            ) &&
+            barrier->after_state == RenderGraph::ResourceState::Texture(
+                RenderGraph::TextureState::Sampled
+            ) &&
+            HasEdgeReason(
+                plan,
+                storage_read,
+                sampled_read,
+                RenderGraph::EdgeReasonKind::StateTransition,
+                texture.Untyped()
             ),
         test_name,
-        "compatible shader-read states must canonicalize to one stable state"
-    );
-    const std::string dump = graph.Dump();
-    const auto        compiled_plan_offset = dump.find("compiled_accesses:\n");
-    return compiled_plan_offset == std::string::npos ? dump : dump.substr(compiled_plan_offset);
-}
-
-void TestCompatibleStateCanonicalization(TestSuite& suite) {
-    constexpr std::string_view test_name = "compatible state canonicalization";
-    const auto forward = BuildCompatibleStateOrderDump(suite, test_name, false);
-    const auto reverse = BuildCompatibleStateOrderDump(suite, test_name, true);
-    suite.Check(
-        forward == reverse,
-        test_name,
-        "swapping compatible declarations in one pass must not change the compiled-plan dump"
+        "physically distinct Vulkan shader-read layouts must retain a compiler transition"
     );
 }
 
@@ -3650,7 +3656,7 @@ void TestExternalControlIsAnUnmanagedJoinBoundary(TestSuite& suite) {
             ++published_groups;
             suite.Check(
                 sources.size() == 1 &&
-                    sources.front().completion->Status() ==
+                    sources.front().completion.Status() ==
                         Moer::Render::ERHIRecordingStatus::Pending,
                 test_name,
                 "recording ownership must be published before the producer completes"
@@ -3818,7 +3824,7 @@ void TestParallelRecordingFallsBackWithoutTaskGraph(TestSuite& suite) {
     add_record("Second", second_token, 2);
 
     suite.Check(graph.Compile(), test_name, graph.GetCompileError());
-    Moer::Array<Moer::Render::RHIRecordingGateRef> published_gates{};
+    Moer::Array<Moer::Render::RHIRecordingGateView> published_gates{};
     const bool executed = graph.ExecuteRecording(
         {},
         {},
@@ -3839,7 +3845,7 @@ void TestParallelRecordingFallsBackWithoutTaskGraph(TestSuite& suite) {
     suite.Check(
         published_gates.size() == 2 &&
             std::all_of(published_gates.begin(), published_gates.end(), [](const auto& gate) {
-                return gate->Status() == Moer::Render::ERHIRecordingStatus::Succeeded;
+                return gate.Status() == Moer::Render::ERHIRecordingStatus::Succeeded;
             }),
         test_name,
         "serial fallback must still complete every already-published ownership gate"
@@ -3956,9 +3962,9 @@ void TestParallelRecordingDispatchAndJoin(TestSuite& suite) {
         true,
         [&](Moer::Array<Moer::Render::RHIRecordingSource>&& sources) {
             published_pending = sources.size() == 2 &&
-                                sources[0].completion->Status() ==
+                                sources[0].completion.Status() ==
                                     Moer::Render::ERHIRecordingStatus::Pending &&
-                                sources[1].completion->Status() ==
+                                sources[1].completion.Status() ==
                                     Moer::Render::ERHIRecordingStatus::Pending;
             distinct_command_lists = sources.size() == 2 &&
                                      sources[0].command_list != sources[1].command_list;
@@ -4012,9 +4018,9 @@ void TestParallelRecordingDispatchAndJoin(TestSuite& suite) {
     );
     suite.Check(
         published.size() == 1 &&
-            published.front()[0].completion->Status() ==
+            published.front()[0].completion.Status() ==
                 Moer::Render::ERHIRecordingStatus::Succeeded &&
-            published.front()[1].completion->Status() ==
+            published.front()[1].completion.Status() ==
                 Moer::Render::ERHIRecordingStatus::Succeeded,
         test_name,
         "every published source gate must reach a successful terminal state"
@@ -4127,7 +4133,7 @@ void TestRecordingPublicationFailureTerminatesGates(TestSuite& suite) {
     );
     suite.Check(
         published.size() == 1 &&
-            published.front().completion->Status() == Moer::Render::ERHIRecordingStatus::Failed,
+            published.front().completion.Status() == Moer::Render::ERHIRecordingStatus::Failed,
         test_name,
         "a published gate must never remain Pending when dispatch is abandoned"
     );
@@ -4208,7 +4214,7 @@ int main() {
     TestBarrierSourcesIgnoreUnrelatedLastRead(suite);
     TestFanInBarrierPlacementCoversEverySourceBatch(suite);
     TestUntouchedBoundaryWriteRequiresMemoryDependency(suite);
-    TestCompatibleStateCanonicalization(suite);
+    TestShaderReadStatesRequireTransition(suite);
     TestReadTransitionWaitsForEveryActiveReader(suite);
     TestUndefinedImportMustBeInitializedBeforeRead(suite);
     TestUnknownExportMakesStatePlanIncomplete(suite);


### PR DESCRIPTION
## Summary

This lands the first coherent runtime foundation batch for the modern RDG path:

- materialize compiler-generated resource transitions as active RHI barriers
- allocate and retire transient resources through completion-safe lifetime slots and aliasing
- execute the compiled queue DAG across native Graphics / Compute / Copy queues
- emit precise Vulkan queue-family release/acquire barriers, including fan-in to one release owner

The implementation keeps graph publication transactional: producer/configuration failure rejects unpublished work and prevents a partially recorded graph from becoming partially submitted. D3D12 explicit barriers remain fail-closed rather than silently approximating Vulkan semantics.

## Scope boundaries

This PR intentionally stops at the RDG runtime foundation. It does not include the later Raytracing production-graph migration or the ready-lane / multi-segment submission-pipeline commits; those will follow as separately reviewed batches.

## Validation

- Debug full build passed
- all registered CTest targets passed (16/16 at the tip of this batch)
- Vulkan runner passed serial, parallel, worker-fallback, production-gate, and heavy modes
- Vulkan validation log scan reported no VUID / validation errors
- CPU contracts cover active lowering, transient alias lifetimes, queue DAG synchronization, same-family fan-in, precise ownership barriers, rejection, and completion cleanup

## Known constraints

- Vulkan is the runtime-validated explicit-barrier backend; D3D12 remains fail-closed
- same-family distinct-native-queue ownership is covered by CPU lowering contracts because the validation machine exposes distinct Graphics/Compute queue families
- shared queue timelines are deferred as an object-churn optimization and are not required for this correctness milestone