### PR TITLE
feat(raytracing): migrate frame core to modern RDG recording

### DIFF
--- a/shaders/core/utils/ShowTexture.frag.hlsl
+++ b/shaders/core/utils/ShowTexture.frag.hlsl
@@ -8,52 +8,45 @@
 
 BINDLESS_BINDINGS(1, 2, 3, 4)
 
-static SamplerState g_spl{
-  Filter = MIN_MAG_MIP_LINEAR;
-  AddressU = CLAMP;
-  AddressV = CLAMP;
-  AddressW = CLAMP;
-  ComparisonFunc = NEVER;
-  MipLODBias = 0.0f;
-  MinLOD = 1.0f;
-  MaxLOD = 3000.f;
-};
-
-void GetDimensions(out int2 _dimensions) {
-  if (param.bdls_handle >= 0 && param.use_bindless) {
+void GetDimensions(uint mip_level, out uint2 dimensions) {
+  uint mip_count;
+  if (param.use_bindless != 0) {
     TextureHandle texture = TextureHandle(param.bdls_handle);
     Texture2D texture2d = texture.GetTexture2D();
-    texture2d.GetDimensions(_dimensions.x, _dimensions.y);
+    texture2d.GetDimensions(mip_level, dimensions.x, dimensions.y, mip_count);
   } else {
-    src_tex.GetDimensions(_dimensions.x, _dimensions.y);
+    src_tex.GetDimensions(mip_level, dimensions.x, dimensions.y, mip_count);
   }
+  dimensions = max(dimensions, uint2(1, 1));
 }
 
-float4 SampleTexture(float2 uv, float mip_level) {
-  if (param.bdls_handle >= 0 && param.use_bindless) {
+float4 LoadTexture(int2 coord, uint mip_level) {
+  if (param.use_bindless != 0) {
     TextureHandle texture = TextureHandle(param.bdls_handle);
-    // Texture2D texture2d = texture.GetTexture2D();
-    return texture.SampleLevel(uv, mip_level);
-  } else {
-    int2 dimensions;
-    GetDimensions(dimensions);
-    dimensions >>= int(mip_level);
-    int2 coord = int2(uv * float2(dimensions));
-    if (coord.x < 0 || coord.x >= dimensions.x || coord.y < 0 || coord.y >= dimensions.y) {
-      return float4(0.0f, 0.0f, 0.0f, 1.0f);
-    }
-    return src_tex.Load(int3(int2(coord), int(mip_level)));
-    // return src_tex.SampleLevel(g_spl, uv, mip_level);
+    Texture2D texture2d = texture.GetTexture2D();
+    return texture2d.Load(int3(coord, int(mip_level)));
   }
+  return src_tex.Load(int3(coord, int(mip_level)));
+}
+
+float4 SampleTexture(float2 uv, uint mip_level) {
+  uint2 dimensions;
+  GetDimensions(mip_level, dimensions);
+  int2 coord = int2(uv * float2(dimensions));
+  if (coord.x < 0 || coord.x >= int(dimensions.x) ||
+      coord.y < 0 || coord.y >= int(dimensions.y)) {
+    return float4(0.0f, 0.0f, 0.0f, 1.0f);
+  }
+  return LoadTexture(coord, mip_level);
 }
 
 void main(in float4 pos
           : SV_Position, in float2 uv
           : TEXCOORD0, out float4 target
           : SV_Target) {
-  int2 dimensions;
+  uint2 dimensions;
 
-  GetDimensions(dimensions);
+  GetDimensions(0, dimensions);
   float2 dst_dim = float2(param.dst_dim);
   float2 src_dim = float2(dimensions);
 
@@ -81,6 +74,6 @@ void main(in float4 pos
 
   float2 sample_uv = (pos.xy - rect.xy) / (rect.zw - rect.xy);
 
-  float4 color = SampleTexture(sample_uv, float(param.mip_level));
+  float4 color = SampleTexture(sample_uv, param.mip_level);
   target = color;
 }

--- a/shaders/pipelines/raytracing/passes/CompositionPass.hlsl
+++ b/shaders/pipelines/raytracing/passes/CompositionPass.hlsl
@@ -47,6 +47,10 @@ BINDLESS_BINDINGS(3, 2, 4, 5);
 
 [numthreads(8, 8, 1)] void main(uint2 gtid
                                 : SV_DISPATCHTHREADID) {
+  if (any(gtid >= uint2(params.main_view.rect))) {
+    return;
+  }
+
   float3 composited_color = float3(0, 0, 0);
   float view_z = gbuffer_view_depth[gtid];
 

--- a/shaders/pipelines/raytracing/passes/GBufferRT.hlsl
+++ b/shaders/pipelines/raytracing/passes/GBufferRT.hlsl
@@ -89,6 +89,13 @@ float3 UintHashToColor(uint _idx) {
 #if !USE_RAYQUERY
     uint2 pixel_pos = DispatchRaysIndex().xy;
 #endif
+    uint output_width;
+    uint output_height;
+    gbuffer_view_depth.GetDimensions(output_width, output_height);
+    if (any(pixel_pos >= uint2(output_width, output_height))) {
+        return;
+    }
+
     RayDesc ray = Moer::SetupPrimaryRay(pixel_pos, gbuffer_constants.main_view);
 
     uint instance_mask = Moer::RTVM_ALL;

--- a/shaders/pipelines/raytracing/passes/PostProcessGBuffer.hlsl
+++ b/shaders/pipelines/raytracing/passes/PostProcessGBuffer.hlsl
@@ -41,6 +41,14 @@ float GetModifiedRoughnessFromNormalVariance(float _roughness,
 
 [numthreads(16, 16, 1)] void main(uint2 _pixel_pos
                                   : SV_DISPATCHTHREADID) {
+  uint width;
+  uint height;
+  rw_specular_roughness.GetDimensions(width, height);
+  const uint2 extent = uint2(width, height);
+  if (any(_pixel_pos >= extent)) {
+    return;
+  }
+
   float3 normal = Math::OctToNdirUnorm32(r_normal[_pixel_pos]);
   float4 spec_roughness =
       Moer::Unpack_R8G8B8A8_Gamma_UFLOAT(rw_specular_roughness[_pixel_pos]);
@@ -57,7 +65,8 @@ float GetModifiedRoughnessFromNormalVariance(float _roughness,
     for (int j = -1; j <= 1; j++) {
       if (i == 0 && j == 0)
         continue;
-      uint2 pos = _pixel_pos + uint2(i, j);
+      int2 pos = clamp(int2(_pixel_pos) + int2(i, j), int2(0, 0),
+                       int2(extent) - 1);
 
       float3 p_normal = Math::OctToNdirUnorm32(r_normal[pos]);
       float p_z = r_view_depth[pos];
@@ -85,5 +94,15 @@ float GetModifiedRoughnessFromNormalVariance(float _roughness,
 #if WITH_NRD
   rw_normal_roughness[_pixel_pos] =
       NRD_FrontEnd_PackNormalAndRoughness(normal, roughness, 0u);
+#else
+  // Match the configured NRD RGBA8_UNORM normal and linear roughness
+  // encoding even when the denoiser plugin is disabled. Visualize and other
+  // graph consumers can then rely on this resource being initialized.
+  float max_normal_component =
+      max(abs(normal.x), max(abs(normal.y), abs(normal.z)));
+  float3 encoded_normal =
+      normal / max(max_normal_component, 1e-6f) * 0.5f + 0.5f;
+  rw_normal_roughness[_pixel_pos] =
+      float4(encoded_normal, saturate(roughness));
 #endif
 }

--- a/shaders/pipelines/raytracing/passes/VisualizePass.hlsl
+++ b/shaders/pipelines/raytracing/passes/VisualizePass.hlsl
@@ -1,136 +1,132 @@
-
-#include <core/common/Bindless.hlsl>
 #include <shared/ShaderParameters.h>
 
 #include <pipelines/raytracing/lighting/lib/restir/GridCommon.hlsli>
 #include <core/math/Math.hlsli>
 #include <shared/utils/Packing.h>
 
-BINDLESS_BINDINGS(1, 2, 3, 4);
-
 [[vk::binding(0, 0)]] ConstantBuffer<Moer::VisualizeParams> param;
 [[vk::binding(1, 0)]] Texture2D<float3> direct_lighting : register(t0);
-[[vk::binding(3, 0)]] Texture2D<float4> diffuse_lighting : register(t1);
-[[vk::binding(4, 0)]] Texture2D<float4> specular_lighting : register(t2);
-[[vk::binding(5, 0)]] Texture2D<float> view_depth : register(t3);
-[[vk::binding(6, 0)]] Texture2D<float4> emission : register(t4);
-[[vk::binding(7, 0)]] RWTexture2D<float4> output : register(u0);
+[[vk::binding(2, 0)]] Texture2D<float4> diffuse_lighting : register(t1);
+[[vk::binding(3, 0)]] Texture2D<float4> specular_lighting : register(t2);
+[[vk::binding(4, 0)]] Texture2D<float> view_depth : register(t3);
+[[vk::binding(5, 0)]] Texture2D<float> clip_depth : register(t4);
+[[vk::binding(6, 0)]] Texture2D<float4> emission : register(t5);
+[[vk::binding(7, 0)]] Texture2D<uint> normal : register(t6);
+[[vk::binding(8, 0)]] Texture2D<uint> specular_roughness : register(t7);
+[[vk::binding(9, 0)]] Texture2D<float4> motion : register(t8);
+[[vk::binding(10, 0)]] Texture2D<float4> normal_roughness : register(t9);
+[[vk::binding(11, 0)]] RWTexture2D<float4> output : register(u0);
 
-float3 ViewdepthToWorldPos(Moer::ViewParam _view, int2 _pixel_pos,
-                           float _view_depth) {
-  float2 uv = (float2(_pixel_pos) + 0.5f) * _view.inv_rect;
+static const float s_fp16_max = 65504.0f;
 
-  float4 clip_pos = float4(uv.x * 2.f - 1.f, 1.f - uv.y * 2.f, 0.5f, 1.f);
-  float4 view_pos = mul(_view.clip2view, clip_pos);
-  view_pos.xy /= view_pos.z;
-  view_pos.zw = float2(1.f, 1.f);
-  view_pos.xyz *= -_view_depth;
-  return mul(_view.view2world, view_pos).xyz;
+float3 SafeNormalize(float3 value) {
+  return value * rsqrt(dot(value, value) + 1e-9f);
 }
 
-float2 GetUV(int2 _pixel_pos, Moer::ViewParam _view) {
-  return (float2(_pixel_pos) + 0.5f) * _view.inv_rect;
+bool IsValidViewDepth(float depth) {
+  return depth > 0.0f && depth < s_fp16_max * 0.5f;
 }
 
-float3 GetNormal(Moer::ViewParam _view, int2 _pixel_pos) {
-  float2 v = (float2(_pixel_pos) + 0.5f) * _view.inv_rect;
-
-  TextureHandle tex_handle =
-      (TextureHandle)param.bindless_handles.gbuffer_normal;
-  uint normal = tex_handle.SampleLevel<uint>(v, 0);
-  return Math::OctToNdirUnorm32(normal);
+float3 ClipDepthToWorldPos(Moer::ViewParam view, uint2 pixel_pos,
+                           float depth) {
+  float2 uv = (float2(pixel_pos) + 0.5f) * view.inv_rect;
+  float4 clip_pos =
+      float4(uv.x * 2.0f - 1.0f, 1.0f - uv.y * 2.0f, depth, 1.0f);
+  float4 world_pos = mul(view.clip2world, clip_pos);
+  return world_pos.xyz / world_pos.w;
 }
 
-float GetDepth(Moer::ViewParam _view, int2 _pixel_pos) {
-  float2 uv = GetUV(_pixel_pos, _view);
-  TextureHandle tex_handle =
-      (TextureHandle)param.bindless_handles.gbuffer_depth;
-  return tex_handle.SampleLevel<float>(uv, 0);
+float4 GetWorldPositionColor(float3 world_pos) {
+  return float4(frac(world_pos * 0.025f), 1.0f);
 }
 
-float GetPrevDepth(Moer::ViewParam _view, int2 _pixel_pos) {
-  float2 uv = GetUV(_pixel_pos, _view);
-  TextureHandle tex_handle =
-      (TextureHandle)param.bindless_handles.gbuffer_prev_depth;
-  return tex_handle.SampleLevel<float>(uv, 0);
-}
-
-float3 GetMotion(Moer::ViewParam _view, int2 _pixel_pos) {
-  float2 uv = GetUV(_pixel_pos, _view);
-  TextureHandle tex_handle = (TextureHandle)param.bindless_handles.motion;
-
-  float3 motion = tex_handle.SampleLevel<float3>(uv, 0);
-  float2 cur_pixel_pos = float2(_pixel_pos) + motion.xy;
-  float2 cur_uv = GetUV(int2(cur_pixel_pos + 0.5f), _view);
-
-  TextureHandle prev_normal_handle =
-      (TextureHandle)param.bindless_handles.gbuffer_prev_normal;
-
-  float prev_depth = GetPrevDepth(_view, int2(round(cur_pixel_pos)));
-  float expected_depth_linear = GetDepth(_view, _pixel_pos) + motion.z;
-  float3 prev_normal =
-      Math::OctToNdirUnorm32(prev_normal_handle.SampleLevel<uint>(cur_uv, 0));
-  float3 normal = GetNormal(_view, _pixel_pos);
-
-  {
-    // check normal and depth difference
-    if (!Math::IsValidNeighbor(normal, prev_normal, expected_depth_linear,
-                               prev_depth, 0.4f, 2.f)) {
-
-      return float3(1, 0, 0);
-    }
-    // if(dot(normal, prev_normal) < 0.5f){
-    //   return float3(1, 0, 0);
-    // }
+float4 GetNormalColor(uint2 pixel_pos) {
+  if (!IsValidViewDepth(view_depth.Load(int3(pixel_pos, 0)))) {
+    return float4(0.0f, 0.0f, 0.0f, 1.0f);
   }
-  // printf("prev_albedo handle %d albedo handle %d
-  // \n",param.bindless_handles.gbuffer_prev_diffuse_albedo,
-  // param.bindless_handles.gbuffer_diffuse_albedo);
-  return dot(normal, prev_normal);
+
+  float3 decoded =
+      Math::OctToNdirUnorm32(normal.Load(int3(pixel_pos, 0)));
+  return float4(decoded * 0.5f + 0.5f, 1.0f);
 }
 
-void VisualizeGrid(uint2 _pixel_pos, out float4 _final_color) {
+float4 GetViewDepthColor(uint2 pixel_pos) {
+  float depth = view_depth.Load(int3(pixel_pos, 0));
+  if (!IsValidViewDepth(depth)) {
+    return float4(0.0f, 0.0f, 0.0f, 1.0f);
+  }
 
-  float3 world_pos =
-      ViewdepthToWorldPos(param.main_view, _pixel_pos, view_depth[_pixel_pos]);
-
-  _final_color = float4(direct_lighting[_pixel_pos], 1.f);
-  float3 dbg_color =
-      Moer::Grid::GetVisualizeGridColor(param.grid_params, world_pos);
-  _final_color *= float4(dbg_color, 1.f);
-  _final_color = float4(dbg_color, 1.f);
+  float depth_vis = 1.0f - saturate(log2(depth + 1.0f) / 16.0f);
+  return float4(depth_vis.xxx, 1.0f);
 }
 
-float4 GetMaterialColor(Moer::ViewParam _view, uint2 _pixel_pos) {
-  float2 v = (float2(_pixel_pos) + 0.5f) * _view.inv_rect;
-
-  TextureHandle tex_handle =
-      (TextureHandle)param.bindless_handles.gbuffer_specular_roughness;
-  uint rf0_roughness = tex_handle.SampleLevel<uint>(v, 0);
-  float4 rf0_roughness_f = Moer::Unpack_R8G8B8A8_Gamma_UFLOAT(rf0_roughness);
-
-  return rf0_roughness_f.a;
+float4 GetClipDepthColor(uint2 pixel_pos) {
+  float depth = clip_depth.Load(int3(pixel_pos, 0));
+  return float4(saturate(depth).xxx, 1.0f);
 }
 
-[numthreads(16, 16, 1)] void main(uint2 dtid
-                                  : SV_DISPATCHTHREADID) {
-  uint2 pixel_pos = int2(dtid);
-  uint2 viewport_size = param.output_size;
+float4 GetMotionColor(uint2 pixel_pos) {
+  float3 motion_vector = motion.Load(int3(pixel_pos, 0)).xyz;
+  float2 encoded_xy = saturate(0.5f + motion_vector.xy / 64.0f);
+  float encoded_z = saturate(abs(motion_vector.z) / 64.0f);
+  return float4(encoded_xy, encoded_z, 1.0f);
+}
 
-  if (any(pixel_pos >= viewport_size)) {
+float4 GetMaterialColor(uint2 pixel_pos) {
+  if (!IsValidViewDepth(view_depth.Load(int3(pixel_pos, 0)))) {
+    return float4(0.0f, 0.0f, 0.0f, 1.0f);
+  }
+
+  uint packed = specular_roughness.Load(int3(pixel_pos, 0));
+  float roughness = Moer::Unpack_R8G8B8A8_Gamma_UFLOAT(packed).a;
+  return float4(roughness.xxx, 1.0f);
+}
+
+float4 GetNormalRoughnessColor(uint2 pixel_pos) {
+  if (!IsValidViewDepth(view_depth.Load(int3(pixel_pos, 0)))) {
+    return float4(0.0f, 0.0f, 0.0f, 1.0f);
+  }
+
+  float4 packed = normal_roughness.Load(int3(pixel_pos, 0));
+  float3 decoded = SafeNormalize(packed.xyz * 2.0f - 1.0f);
+  return float4(decoded * 0.5f + 0.5f, 1.0f);
+}
+
+float4 VisualizeGrid(uint2 pixel_pos) {
+  float depth = view_depth.Load(int3(pixel_pos, 0));
+  if (!IsValidViewDepth(depth) ||
+      param.grid_params.common_params.cell_size <= 1e-6f) {
+    return float4(direct_lighting.Load(int3(pixel_pos, 0)), 1.0f);
+  }
+
+  float3 world_pos = ClipDepthToWorldPos(
+      param.main_view,
+      pixel_pos,
+      clip_depth.Load(int3(pixel_pos, 0))
+  );
+  return float4(
+      Moer::Grid::GetVisualizeGridColor(param.grid_params, world_pos),
+      1.0f
+  );
+}
+
+[numthreads(16, 16, 1)]
+void main(uint2 pixel_pos : SV_DISPATCHTHREADID) {
+  if (any(pixel_pos >= param.output_size)) {
     return;
   }
 
-  float4 final_color = 0.0f;
+  float4 final_color;
   switch (param.visualize_mode) {
   case Moer::EFC_SceneColor:
-    final_color = float4(direct_lighting[pixel_pos], 1.f);
+    final_color = float4(direct_lighting[pixel_pos], 1.0f);
     break;
   case Moer::EFC_DI:
     final_color =
         float4(diffuse_lighting[pixel_pos].xyz +
-                   specular_lighting[pixel_pos].xyz + emission[pixel_pos].xyz,
-               1.f);
+                   specular_lighting[pixel_pos].xyz +
+                   emission[pixel_pos].xyz,
+               1.0f);
     break;
   case Moer::EFC_DIFFUSE:
     final_color = diffuse_lighting[pixel_pos];
@@ -142,22 +138,42 @@ float4 GetMaterialColor(Moer::ViewParam _view, uint2 _pixel_pos) {
     final_color = emission[pixel_pos];
     break;
   case Moer::EFC_GRID:
-    VisualizeGrid(pixel_pos, final_color);
+    final_color = VisualizeGrid(pixel_pos);
     break;
   case Moer::EFC_POSITION:
-    final_color = float4(
-        ViewdepthToWorldPos(param.main_view, pixel_pos, view_depth[pixel_pos]),
-        1.f);
+    if (!IsValidViewDepth(view_depth[pixel_pos])) {
+      final_color = float4(0.0f, 0.0f, 0.0f, 1.0f);
+    } else {
+      final_color = GetWorldPositionColor(
+          ClipDepthToWorldPos(
+              param.main_view,
+              pixel_pos,
+              clip_depth[pixel_pos]
+          )
+      );
+    }
     break;
-
   case Moer::EFC_NORMAL:
-    final_color = float4(GetNormal(param.main_view, pixel_pos), 1.f);
+    final_color = GetNormalColor(pixel_pos);
+    break;
+  case Moer::EFC_VIEW_DEPTH:
+    final_color = GetViewDepthColor(pixel_pos);
+    break;
+  case Moer::EFC_DEPTH:
+    final_color = GetClipDepthColor(pixel_pos);
     break;
   case Moer::EFC_MATERIAL:
-    final_color = GetMaterialColor(param.main_view, pixel_pos);
+    final_color = GetMaterialColor(pixel_pos);
     break;
   case Moer::EFC_MOTION:
-    final_color = float4(GetMotion(param.main_view, pixel_pos), 1.f);
+    final_color = GetMotionColor(pixel_pos);
+    break;
+  case Moer::EFC_CUSTOM:
+    final_color = GetNormalRoughnessColor(pixel_pos);
+    break;
+  case Moer::EFC_INSTANCE:
+  default:
+    final_color = float4(direct_lighting[pixel_pos], 1.0f);
     break;
   }
 

--- a/shaders/pipelines/raytracing/postprocess/Exposure.hlsl
+++ b/shaders/pipelines/raytracing/postprocess/Exposure.hlsl
@@ -38,17 +38,20 @@ void main() {
 
       target_exposure = clamp(target_exposure, params.min_adapted_luminance,
                               params.max_adapted_luminance);
+      if (!(target_exposure > 0.0f) || !isfinite(target_exposure)) {
+        target_exposure = params.min_adapted_luminance;
+      }
 
       float old_exposure = asfloat(exposure[0]);
       float diff = old_exposure - target_exposure;
 
       float adaption_speed = (diff < 0) ? params.eye_adaptation_speed_up
                                         : params.eye_adaptation_speed_down;
-      if (adaption_speed > 0.0f) {
+      // Zero is the explicit reset sentinel.  It also keeps an uninitialized
+      // or non-finite history value out of the temporal adaptation path.
+      if (old_exposure > 0.0f && isfinite(old_exposure) &&
+          params.frame_time > 0.0f && adaption_speed > 0.0f) {
         target_exposure += diff * exp2(-params.frame_time * adaption_speed);
-      }
-      if(params.frame_time <= 0.0f) {
-        printf("target exposure is %f, old exposure %f frame time %f\n",target_exposure, old_exposure, params.frame_time);
       }
 
       exposure[0] = asuint(target_exposure);

--- a/shaders/pipelines/raytracing/postprocess/Histogram.hlsl
+++ b/shaders/pipelines/raytracing/postprocess/Histogram.hlsl
@@ -28,6 +28,9 @@ groupshared uint s_histogram[HISTOGRAM_BINS];
   if (valid) {
     float3 color = source_tex[pixel_pos].rgb;
     float luminance = STL::Color::Luminance(color);
+    luminance = (isfinite(luminance) && luminance > 1e-6f)
+                    ? luminance
+                    : 1e-6f;
     float biased_log_lum = log2(luminance) * params.log_luminance_scale +
                            params.log_luminance_bias;
     float histogram_bin = saturate(biased_log_lum) * (HISTOGRAM_BINS - 1);

--- a/shaders/pipelines/raytracing/postprocess/TAAPass.hlsl
+++ b/shaders/pipelines/raytracing/postprocess/TAAPass.hlsl
@@ -105,9 +105,13 @@ float3 BicubicSampleCatmullRom(Texture2D _tex, SamplerState _spl, float2 _pos,
 }
 
 void Preload(uint2 _shared_id, int2 _gid) {
+  const int2 input_min = int2(params.in_view_origin);
+  const int2 input_max =
+      input_min + max(int2(params.in_view_size), int2(1, 1)) - 1;
+  const int2 sample_pos = clamp(_gid, input_min, input_max);
 #if SAMPLE_COUNT == 1
-  float3 color = PQEncode(unfiltered_rt[_gid.xy].rgb);
-  float2 m = motion[_gid.xy].xy;
+  float3 color = PQEncode(unfiltered_rt[sample_pos].rgb);
+  float2 m = motion[sample_pos].xy;
   float motion_length = dot(m, m);
 #else
 
@@ -116,8 +120,8 @@ void Preload(uint2 _shared_id, int2 _gid) {
   float2 m = float2(0);
 
   [unroll] for (uint i = 0; i < SAMPLE_COUNT; i++) {
-    float3 c = PQEncode(unfiltered_rt.Load(int3(_gid.xy, i)).rgb);
-    float2 mo = motion.Load(int3(_gid.xy, i)).xy;
+    float3 c = PQEncode(unfiltered_rt.Load(int3(sample_pos, i)).rgb);
+    float2 mo = motion.Load(int3(sample_pos, i)).xy;
     float ml = dot(mo, mo);
 
     color += c;
@@ -150,7 +154,10 @@ float2 OutputToInput(int2 _pixel_pos_to_origin) {
   new_id.y = int(floor(linear_idx));
   new_id.x = int(floor(frac(linear_idx) * BUFFER_X));
 
-  int2 group_base = int2(OutputToInput(group_id * int2(GROUP_X, GROUP_Y)) - 1);
+  const int2 group_output_origin =
+      int2(group_id) * int2(GROUP_X, GROUP_Y);
+  const int2 group_base =
+      int2(floor(OutputToInput(group_output_origin))) - int2(1, 1);
 
   if (new_id.y < RENAMED_GROUP_Y) {
     Preload(new_id, group_base + new_id);
@@ -162,8 +169,12 @@ float2 OutputToInput(int2 _pixel_pos_to_origin) {
 
   GroupMemoryBarrierWithGroupSync();
 
-  int2 out_pixel_pos = dtid + int2(params.out_view_origin);
-  float2 in_pos = OutputToInput(dtid);
+  if (any(int2(dtid) >= int2(params.out_view_size))) {
+    return;
+  }
+
+  int2 out_pixel_pos = int2(dtid) + int2(params.out_view_origin);
+  float2 in_pos = OutputToInput(int2(dtid));
   int2 in_pos_int = int2(round(in_pos));
   int2 in_pos_shared = in_pos_int - group_base - 1;
 

--- a/shaders/pipelines/raytracing/postprocess/ToneMappingPass.hlsl
+++ b/shaders/pipelines/raytracing/postprocess/ToneMappingPass.hlsl
@@ -17,8 +17,10 @@ float3 ConvertToLDR(float3 hdr_color) {
   }
   float adapted_luminance = asfloat(exposure[0]);
 
-  if (adapted_luminance <= 0.0f) {
-    return params.min_adapted_luminance;
+  if (!(adapted_luminance > 0.0f) || !isfinite(adapted_luminance)) {
+    return float3(params.min_adapted_luminance,
+                  params.min_adapted_luminance,
+                  params.min_adapted_luminance);
   }
   float scaled_luminance =
       src_luminance * params.exposure_scale / adapted_luminance;
@@ -38,9 +40,12 @@ float3 ApplyColorLUT(float3 color) {
   float g = color.g * (size - 1.0f) + 0.5f;
   float b = color.b * (size - 1.0f);
 
-  float2 uv1 = float2((floor(b)) * size + r, g) * params.color_lut_size_inv;
+  float lower_slice = floor(b);
+  float upper_slice = min(lower_slice + 1.0f, size - 1.0f);
+  float2 uv1 =
+      float2(lower_slice * size + r, g) * params.color_lut_size_inv;
   float2 uv2 =
-      float2((ceil(b) + 1.0f) * size + r, g) * params.color_lut_size_inv;
+      float2(upper_slice * size + r, g) * params.color_lut_size_inv;
 
   float3 c1 = color_lut.SampleLevel(color_lut_sampler, uv1, 0).rgb;
   float3 c2 = color_lut.SampleLevel(color_lut_sampler, uv2, 0).rgb;

--- a/source/runtime/core/include/config/GlobalConfig.h
+++ b/source/runtime/core/include/config/GlobalConfig.h
@@ -61,6 +61,12 @@ struct CORE_API GlobalConfig {
                 bool render_graph_parallel_recording;
             } raster;
 
+            struct Raytracing {
+                bool render_graph;
+                bool render_graph_debug_dump;
+                bool render_graph_parallel_recording;
+            } raytracing;
+
         } render;
 
         struct Scene {

--- a/source/runtime/core/source/config/GlobalConfig.cpp
+++ b/source/runtime/core/source/config/GlobalConfig.cpp
@@ -70,6 +70,12 @@ GlobalConfig GlobalConfig::LoadConfigFromTomlFile(const std::string_view& toml_p
         toml_config.at_path("engine.render.raster.render_graph_debug_dump").value_or(false);
     loaded_config.engine.render.raster.render_graph_parallel_recording =
         toml_config.at_path("engine.render.raster.render_graph_parallel_recording").value_or(false);
+    loaded_config.engine.render.raytracing.render_graph =
+        toml_config.at_path("engine.render.raytracing.render_graph").value_or(false);
+    loaded_config.engine.render.raytracing.render_graph_debug_dump =
+        toml_config.at_path("engine.render.raytracing.render_graph_debug_dump").value_or(false);
+    loaded_config.engine.render.raytracing.render_graph_parallel_recording =
+        toml_config.at_path("engine.render.raytracing.render_graph_parallel_recording").value_or(false);
 
     loaded_config.engine.scene.scene_path =
         toml_config.at_path("engine.scene.scene_path").value_or("./asset/scenes/sponza/Sponza.gltf");

--- a/source/runtime/render/renderer/raytracing/AntiAliasPass.cpp
+++ b/source/runtime/render/renderer/raytracing/AntiAliasPass.cpp
@@ -6,70 +6,307 @@
 #include "shaderheaders/shared/postprocess/ShaderParameters.h"
 #include <algorithm>
 #include <cmath>
+#include <cstring>
 #include <random>
 
 namespace Moer::Render::Raytracing {
 
 AntialiasPass::AntialiasPass(RenderDevice& _device, ShaderManager& _manager, CreateInfo _info) :
-    taa_pipeline(_manager.Compute<TAAPipeline>("pipelines/raytracing/postprocess/TAAPass.hlsl")),
     frame_idx(0),
     jitter(float2(0.f)),
     jitter_mode(EJitter::MSAA),
     motion(_info.motion),
     feedback_color_ping(_info.feedback_color_ping),
-    feedback_color_pong(_info.feedback_color_pong) {
-    constant_buffer = _device.CreateBuffer<Moer::byte>(
+    feedback_color_pong(_info.feedback_color_pong),
+    feedback_slot_zero(_info.feedback_color_ping),
+    feedback_slot_one(_info.feedback_color_pong) {
+    auto owner = MakeShared<RecordingOwner>();
+    owner->pipeline =
+        _manager.Compute<TAAPipeline>("pipelines/raytracing/postprocess/TAAPass.hlsl");
+    owner->constants = _device.CreateBuffer<Moer::byte>(
         "PostProcess::TAAConstantBuffer", sizeof(TAAParams), EBufferUsageFlags::CONSTANT_BUFFER
     );
+    recording_owner = std::move(owner);
+}
+
+AntialiasPass::PreparedCommand AntialiasPass::Prepare(
+    Params            params,
+    bool              prev_view_valid,
+    const TextureRef& input,
+    const TextureRef& output
+) const {
+    PreparedCommand command{};
+    command.params.in_view_origin = float2(0.f);
+    command.params.in_view_size =
+        float2(input->GetExtent().x, input->GetExtent().y);
+    command.params.out_view_origin = float2(0.f);
+    command.params.out_view_size =
+        float2(output->GetExtent().x, output->GetExtent().y);
+    command.params.in_pixel_offset      = GetPixelOffset();
+    command.params.out_texture_size_inv = float2(
+        1.f / output->GetExtent().x,
+        1.f / output->GetExtent().y
+    );
+    command.params.input_over_output_size =
+        command.params.in_view_size / command.params.out_view_size;
+    command.params.output_over_input_size =
+        command.params.out_view_size / command.params.in_view_size;
+    command.params.clamping_factor =
+        params.enable_history_clamp ? params.clamping_factor : -1.f;
+    command.params.new_frame_weight =
+        prev_view_valid ? params.new_frame_weight : 1.f;
+    command.params.pqc =
+        std::clamp(params.max_radiance, 1e-4f, 1e8f);
+    command.params.inv_pqc = 1.f / command.params.pqc;
+    command.dispatch_groups = uint3(
+        (output->GetExtent().x + 15) / 16,
+        (output->GetExtent().y + 15) / 16,
+        1
+    );
+    return command;
+}
+
+AntialiasPass::RecordResources AntialiasPass::CaptureResources(
+    TextureRef input,
+    TextureRef output
+) const {
+    return RecordResources{
+        .input          = std::move(input),
+        .output         = std::move(output),
+        .motion         = motion,
+        .feedback_read  = feedback_color_ping,
+        .feedback_write = feedback_color_pong
+    };
+}
+
+void AntialiasPass::RecordConstantsUpload(
+    CommandList&           cmd_list,
+    const RecordingOwner&  owner,
+    const PreparedCommand& command
+) {
+    Array<Moer::byte> upload_data(sizeof(TAAParams));
+    std::memcpy(
+        upload_data.data(),
+        &command.params,
+        sizeof(TAAParams)
+    );
+    cmd_list.CopyFrom(std::move(upload_data), owner.constants->GetView());
+}
+
+void AntialiasPass::RecordTAA(
+    CommandList&           cmd_list,
+    RecordingOwner&        owner,
+    const PreparedCommand& command,
+    const RecordResources& resources
+) {
+    Sampler linear_sampler{ESamplerFilter::SF_LINEAR, ESamplerAddressMode::SAM_CLAMP_TO_EDGE};
+    cmd_list
+        .Compute(
+            owner.pipeline,
+            owner.constants,
+            resources.input,
+            resources.motion,
+            resources.feedback_read,
+            linear_sampler,
+            resources.output,
+            resources.feedback_write
+        )
+        .Dispatch(command.dispatch_groups, "TAAPass");
 }
 
 void AntialiasPass::Process(
-    CommandList& _cmd_list,
-    Params       _param,
-    bool         _prev_view_valid,
-    TextureRef   _input,
-    TextureRef   _output
+    CommandList& cmd_list,
+    Params       params,
+    bool         prev_view_valid,
+    TextureRef   input,
+    TextureRef   output
 ) {
-    TAAParams params{};
-    params.in_view_origin         = float2(0.f);
-    params.in_view_size           = float2(_input->GetExtent().x, _input->GetExtent().y);
-    params.out_view_origin        = float2(0.f);
-    params.out_view_size          = float2(_output->GetExtent().x, _output->GetExtent().y);
-    params.in_pixel_offset        = GetPixelOffset();
-    params.out_texture_size_inv   = float2(1.f / _output->GetExtent().x, 1.f / _output->GetExtent().y);
-    params.input_over_output_size = params.in_view_size / params.out_view_size;
-    params.output_over_input_size = params.out_view_size / params.in_view_size;
-    params.clamping_factor        = _param.enable_history_clamp ? _param.clamping_factor : -1.f;
-    params.new_frame_weight       = _prev_view_valid ? _param.new_frame_weight : 1.f;
-    params.pqc                    = std::clamp(_param.max_radiance, 1e-4f, 1e8f);
-    params.inv_pqc                = 1.f / params.pqc;
+    const PreparedCommand command =
+        Prepare(params, prev_view_valid, input, output);
+    const RecordResources resources =
+        CaptureResources(std::move(input), std::move(output));
+    const auto owner = recording_owner;
 
-    _cmd_list.PushScopeWithTimeScope("AntiAliasPass");
-    Array<Moer::byte> upload_data(sizeof(TAAParams));
-    upload_data.assign((Moer::byte*)&params, (Moer::byte*)&params + sizeof(TAAParams));
-
-    _cmd_list.CopyFrom(std::move(upload_data), constant_buffer->GetView());
-
-    const uint2 grid_size = uint2((_output->GetExtent().x + 15) / 16, (_output->GetExtent().y + 15) / 16);
-
-    Sampler linear_sampler{ESamplerFilter::SF_LINEAR, ESamplerAddressMode::SAM_CLAMP_TO_EDGE};
-    _cmd_list
-        .Compute(
-            taa_pipeline,
-            constant_buffer,
-            _input,
-            motion,
-            feedback_color_ping,
-            linear_sampler,
-            _output,
-            feedback_color_pong
-        )
-        .Dispatch(uint3(grid_size.x, grid_size.y, 1), "TAAPass");
-
-    _cmd_list.PopScopeWithTimeScope();
+    cmd_list.PushScopeWithTimeScope("AntiAliasPass");
+    RecordConstantsUpload(cmd_list, *owner, command);
+    RecordTAA(cmd_list, *owner, command, resources);
+    // Normalize the legacy write side through a sampled-read barrier before
+    // the command-list tracker restores its preferred GENERAL layout. This
+    // gives linear and graph frames the same external SRV/read boundary and
+    // preserves graph -> linear transitions on boundary frames.
+    cmd_list.TextureBarriers(
+        EQueueType::Graphics,
+        EQueueType::Graphics,
+        EPassType::Compute,
+        Array<ReadTexture>{
+            {resources.feedback_write->GetView(), ETextureState::SAMPLE}
+        }
+    );
+    cmd_list.PopScopeWithTimeScope();
 }
 
-void AntialiasPass::AdvanceFrame() {
+bool AntialiasPass::AddPasses(
+    RenderGraph&                 graph,
+    const RTGraphFrameResources& graph_resources,
+    const RTContext&             rt_ctx,
+    Params                       params,
+    bool                         prev_view_valid,
+    TextureRef                   input,
+    TextureRef                   output
+) {
+    const auto owner = recording_owner;
+    if (!owner || !owner->constants || !input || !output || !motion ||
+        !feedback_color_ping || !feedback_color_pong) {
+        return false;
+    }
+    const PreparedCommand command =
+        Prepare(params, prev_view_valid, input, output);
+    const RecordResources resources =
+        CaptureResources(std::move(input), std::move(output));
+    if (!resources.input || !resources.output || !resources.motion ||
+        !resources.feedback_read || !resources.feedback_write ||
+        resources.feedback_read.Get() == resources.feedback_write.Get() ||
+        resources.input.Get() != rt_ctx.frame_rt.hdr_color.Get() ||
+        resources.output.Get() != rt_ctx.frame_rt.resolved_color.Get() ||
+        resources.motion.Get() != rt_ctx.frame_rt.motion.Get()) {
+        return false;
+    }
+
+    const auto feedback_handle =
+        [&](const TextureRef& texture) -> RenderGraph::TextureHandle {
+            if (texture.Get() == rt_ctx.frame_rt.feedback_color_ping.Get()) {
+                return graph_resources.feedback_color_ping;
+            }
+            if (texture.Get() == rt_ctx.frame_rt.feedback_color_pong.Get()) {
+                return graph_resources.feedback_color_pong;
+            }
+            return {};
+        };
+    const auto feedback_read  = feedback_handle(resources.feedback_read);
+    const auto feedback_write = feedback_handle(resources.feedback_write);
+    if (!feedback_read.IsValid() || !feedback_write.IsValid() ||
+        feedback_read == feedback_write) {
+        return false;
+    }
+
+    const auto constants =
+        ImportRTGraphBuffer(graph, "RT.AntiAlias.constants", owner->constants);
+    graph.SetInitialState(
+        constants,
+        RenderGraph::BufferState::ShaderResource,
+        RenderGraph::QueueRole::Graphics,
+        RenderGraph::AccessMode::Read
+    );
+    graph.SetInitialState(
+        graph_resources.resolved_color,
+        RenderGraph::TextureState::ShaderResource,
+        RenderGraph::QueueRole::Graphics,
+        RenderGraph::AccessMode::Read
+    );
+    for (const auto feedback : {feedback_read, feedback_write}) {
+        // UAV-capable legacy textures finish in the tracker's preferred
+        // GENERAL layout. Linear TAA explicitly normalizes its write side to
+        // a read dependency before that restore, and graph TAA exports both
+        // histories to the same SRV/read boundary.
+        graph.SetInitialState(
+            feedback,
+            RenderGraph::TextureState::ShaderResource,
+            RenderGraph::QueueRole::Graphics,
+            RenderGraph::AccessMode::Read
+        );
+    }
+
+    graph.AddRecordPass(
+        "RT.AntiAlias.UploadConstants",
+        [=](RenderGraph::PassBuilder& builder) {
+            builder.ExecuteOn(
+                       RenderGraph::QueueRole::Graphics,
+                       RenderGraph::PipelineType::Copy
+                   )
+                .Write(constants, RenderGraph::BufferState::TransferDestination);
+        },
+        [owner, command](CommandList& cmd_list) {
+            ScopedGpuMarker marker(
+                cmd_list,
+                "Pass: RT AntiAlias Constants Upload",
+                GpuMarkerPalette::Transfer()
+            );
+            RecordConstantsUpload(cmd_list, *owner, command);
+        },
+        RenderGraph::PassExecutionClass::ParallelRecordEligible
+    );
+
+    graph.AddRecordPass(
+        "RT.AntiAlias.Dispatch",
+        [=](RenderGraph::PassBuilder& builder) {
+            builder
+                .ExecuteOn(
+                    RenderGraph::QueueRole::Graphics,
+                    RenderGraph::PipelineType::Compute
+                )
+                .Read(constants, RenderGraph::BufferState::ShaderResource)
+                .Read(
+                    graph_resources.hdr_color,
+                    RenderGraph::TextureState::Sampled
+                )
+                .Read(
+                    graph_resources.motion,
+                    RenderGraph::TextureState::Sampled
+                )
+                .Read(
+                    feedback_read,
+                    RenderGraph::TextureState::Sampled
+                )
+                .Write(
+                    graph_resources.resolved_color,
+                    RenderGraph::TextureState::UnorderedAccess
+                )
+                .Write(
+                    feedback_write,
+                    RenderGraph::TextureState::UnorderedAccess
+                );
+        },
+        [owner, command, resources](CommandList& cmd_list) {
+            ScopedGpuMarker marker(
+                cmd_list,
+                "AntiAliasPass",
+                GpuMarkerPalette::Pass(),
+                EGpuMarkerMode::Timestamp
+            );
+            RecordTAA(cmd_list, *owner, command, resources);
+        },
+        RenderGraph::PassExecutionClass::ParallelRecordEligible
+    );
+
+    graph.Export(
+        graph_resources.resolved_color,
+        RenderGraph::TextureState::ShaderResource,
+        RenderGraph::QueueRole::Graphics,
+        RenderGraph::AccessMode::Read
+    );
+    for (const auto feedback : {feedback_read, feedback_write}) {
+        graph.Export(
+            feedback,
+            RenderGraph::TextureState::ShaderResource,
+            RenderGraph::QueueRole::Graphics,
+            RenderGraph::AccessMode::Read
+        );
+    }
+    graph.Export(
+        constants,
+        RenderGraph::BufferState::ShaderResource,
+        RenderGraph::QueueRole::Graphics,
+        RenderGraph::AccessMode::Read
+    );
+    return true;
+}
+
+void AntialiasPass::CommitAcceptedFrame() {
+    if (feedback_color_pong.Get() == feedback_slot_zero.Get()) {
+        initialized_history_mask |= uint8(0b01);
+    } else if (feedback_color_pong.Get() == feedback_slot_one.Get()) {
+        initialized_history_mask |= uint8(0b10);
+    }
     frame_idx++;
 
     if (jitter_mode == EJitter::R2) {
@@ -81,6 +318,10 @@ void AntialiasPass::AdvanceFrame() {
     }
 
     std::swap(feedback_color_ping, feedback_color_pong);
+}
+
+bool AntialiasPass::IsHistoryReadyForGraph() const {
+    return initialized_history_mask == uint8(0b11);
 }
 
 namespace {

--- a/source/runtime/render/renderer/raytracing/AntiAliasPass.h
+++ b/source/runtime/render/renderer/raytracing/AntiAliasPass.h
@@ -3,11 +3,12 @@
 
 // 提供时序抗锯齿 Pass 和逐帧相机抖动。
 
-#include "RTResource.h"
+#include "RaytracingGraphResources.h"
 #include "RaytracingConfig.h"
 #include "rhi/RHI.h"
 #include "rhi/RHICommand.h"
 #include "rhi/RHIResource.h"
+#include "shaderheaders/shared/postprocess/ShaderParameters.h"
 
 namespace Moer::Render::Raytracing {
 
@@ -40,6 +41,19 @@ public:
         TextureRef feedback_color_pong;
     };
 
+    struct PreparedCommand {
+        TAAParams params{};
+        uint3     dispatch_groups{};
+    };
+
+    struct RecordResources {
+        TextureRef input{};
+        TextureRef output{};
+        TextureRef motion{};
+        TextureRef feedback_read{};
+        TextureRef feedback_write{};
+    };
+
     AntialiasPass(RenderDevice& device, class ShaderManager& manager, CreateInfo info);
 
     void Process(
@@ -49,22 +63,60 @@ public:
         TextureRef   _input,
         TextureRef   _output
     );
-    void   AdvanceFrame();
+    bool AddPasses(
+        RenderGraph&                 graph,
+        const RTGraphFrameResources& graph_resources,
+        const RTContext&             rt_ctx,
+        Params                       params,
+        bool                         prev_view_valid,
+        TextureRef                   input,
+        TextureRef                   output
+    );
+    void   CommitAcceptedFrame();
     void   SetJitter(EJitter _jitter_mode);
     float2 GetPixelOffset() const;
+    bool   IsHistoryReadyForGraph() const;
 
 private:
-    TAAPipeline taa_pipeline;
+    struct RecordingOwner {
+        BufferRef   constants{};
+        TAAPipeline pipeline{};
+    };
+
+    PreparedCommand Prepare(
+        Params            params,
+        bool              prev_view_valid,
+        const TextureRef& input,
+        const TextureRef& output
+    ) const;
+    RecordResources CaptureResources(
+        TextureRef input,
+        TextureRef output
+    ) const;
+    static void RecordConstantsUpload(
+        CommandList&           cmd_list,
+        const RecordingOwner&  owner,
+        const PreparedCommand& command
+    );
+    static void RecordTAA(
+        CommandList&           cmd_list,
+        RecordingOwner&        owner,
+        const PreparedCommand& command,
+        const RecordResources& resources
+    );
 
     uint    frame_idx   = 0;
     float2  jitter      = float2(0.f);
     EJitter jitter_mode = EJitter::MSAA;
 
-    BufferRef constant_buffer;
-
     TextureRef motion;
     TextureRef feedback_color_ping;
     TextureRef feedback_color_pong;
+    TextureRef feedback_slot_zero;
+    TextureRef feedback_slot_one;
+    uint8      initialized_history_mask = 0;
+
+    SharedPtr<RecordingOwner> recording_owner;
 };
 } // namespace Moer::Render::Raytracing
 #endif

--- a/source/runtime/render/renderer/raytracing/CompositionPass.cpp
+++ b/source/runtime/render/renderer/raytracing/CompositionPass.cpp
@@ -24,56 +24,249 @@ CompositionPass::CompositionPass(
     mutation_set.SetMutation<CompositionPassPipeline::WITH_NRD>(with_nrd);
 #pragma pop_macro("WITH_NRD")
 
-    composition_pipeline = manager.Compute<CompositionPassPipeline>(
+    auto owner = MakeShared<RecordingOwner>();
+    owner->pipeline = manager.Compute<CompositionPassPipeline>(
         "pipelines/raytracing/passes/CompositionPass.hlsl", mutation_set
     );
 
-    composition_constants = device.CreateBuffer<Moer::byte>(
+    owner->constants = device.CreateBuffer<Moer::byte>(
         "CompositionPass::constant_buffer", sizeof(CompositingConstants), EBufferUsageFlags::CONSTANT_BUFFER
     );
+    recording_owner = std::move(owner);
+}
+
+CompositionPass::PreparedCommand
+CompositionPass::Prepare(const RTContext& rt_ctx) const {
+    PreparedCommand command{};
+    command.constants.denoiser_mode  = rt_ctx.config.denoiser_mode;
+    command.constants.enable_env_map = rt_ctx.scene_params.enable_env_map ? 1 : 0;
+    command.constants.env_map_handle = rt_ctx.scene_params.env_map_handle;
+    command.constants.env_rotation   = rt_ctx.scene_params.env_map_rotation;
+    command.constants.env_scale      = rt_ctx.scene_params.env_map_scale;
+    command.constants.main_view      = rt_ctx.main_view;
+    command.constants.prev_view      = rt_ctx.prev_view;
+    command.dispatch_groups = uint3(
+        static_cast<uint>(std::ceil(command.constants.main_view.rect.x / 8.0f)),
+        static_cast<uint>(std::ceil(command.constants.main_view.rect.y / 8.0f)),
+        1
+    );
+    return command;
+}
+
+CompositionPass::RecordResources
+CompositionPass::CaptureResources(const RTContext& rt_ctx) const {
+    const bool            current_frame = rt_ctx.b_current_frame;
+    const FrameResources& frame          = rt_ctx.frame_rt;
+    TextureRef denoised_diffuse_lighting  = frame.diffuse_lighting;
+    TextureRef denoised_specular_lighting = frame.specular_lighting;
+#if WITH_NRD
+    if (IsNrdDenoiserActive(rt_ctx.config.denoiser_mode)) {
+        denoised_diffuse_lighting  = frame.denoised_diffuse_lighting;
+        denoised_specular_lighting = frame.denoised_specular_lighting;
+    }
+#endif
+    return RecordResources{
+        .hdr_color          = frame.hdr_color,
+        .motion             = frame.motion,
+        .view_depth         = current_frame ? frame.view_depth : frame.prev_view_depth,
+        .diffuse_albedo     =
+            current_frame ? frame.diffuse_albedo : frame.prev_diffuse_albedo,
+        .specular_roughness =
+            current_frame ? frame.specular_roughness : frame.prev_specular_roughness,
+        .normal = current_frame ? frame.normal : frame.prev_normal,
+        .emission                  = frame.emission,
+        .diffuse_lighting          = frame.diffuse_lighting,
+        .specular_lighting         = frame.specular_lighting,
+        .denoised_diffuse_lighting  = std::move(denoised_diffuse_lighting),
+        .denoised_specular_lighting = std::move(denoised_specular_lighting),
+        .env_map        = rt_ctx.env_map,
+        .bindless_array = bindless_array
+    };
+}
+
+void CompositionPass::RecordConstantsUpload(
+    CommandList&           cmd_list,
+    const RecordingOwner&  owner,
+    const PreparedCommand& command
+) {
+    Array<byte> upload_data(sizeof(CompositingConstants));
+    std::memcpy(
+        upload_data.data(),
+        &command.constants,
+        sizeof(CompositingConstants)
+    );
+    cmd_list.CopyFrom(std::move(upload_data), owner.constants->GetView());
+}
+
+void CompositionPass::RecordComposition(
+    CommandList&           cmd_list,
+    RecordingOwner&        owner,
+    const PreparedCommand& command,
+    const RecordResources& resources
+) {
+    cmd_list
+        .Compute(
+            owner.pipeline,
+            owner.constants,
+            resources.hdr_color,
+            resources.motion,
+            resources.view_depth,
+            resources.diffuse_albedo,
+            resources.specular_roughness,
+            resources.normal,
+            resources.emission,
+            resources.diffuse_lighting,
+            resources.specular_lighting,
+            resources.denoised_diffuse_lighting,
+            resources.denoised_specular_lighting,
+            resources.bindless_array
+        )
+        .Dispatch(command.dispatch_groups, "CompositionPass");
 }
 
 void CompositionPass::Process(CommandList& cmd_list, RTContext& rt_ctx) {
-    constants.denoiser_mode  = rt_ctx.config.denoiser_mode;
-    constants.enable_env_map = rt_ctx.scene_params.enable_env_map ? 1 : 0;
-    constants.env_map_handle = rt_ctx.scene_params.env_map_handle;
-    constants.env_rotation   = rt_ctx.scene_params.env_map_rotation;
-    constants.env_scale      = rt_ctx.scene_params.env_map_scale;
-    constants.main_view      = rt_ctx.main_view;
-    constants.prev_view      = rt_ctx.prev_view;
+    const PreparedCommand command   = Prepare(rt_ctx);
+    const RecordResources resources = CaptureResources(rt_ctx);
+    const auto            owner     = recording_owner;
+    RecordConstantsUpload(cmd_list, *owner, command);
+    RecordComposition(cmd_list, *owner, command, resources);
+}
 
-    upload_data.resize(sizeof(CompositingConstants));
-    std::memcpy(upload_data.data(), &constants, sizeof(CompositingConstants));
-    cmd_list.CopyFrom(std::move(upload_data), composition_constants->GetView());
+bool CompositionPass::AddPasses(
+    RenderGraph&                 graph,
+    const RTGraphFrameResources& graph_resources,
+    const RTContext&             rt_ctx
+) {
+    const PreparedCommand command   = Prepare(rt_ctx);
+    const RecordResources resources = CaptureResources(rt_ctx);
+    const auto            owner     = recording_owner;
+    if (!owner || !owner->constants || !resources.hdr_color ||
+        !resources.motion || !resources.view_depth ||
+        !resources.diffuse_albedo || !resources.specular_roughness ||
+        !resources.normal || !resources.emission ||
+        !resources.diffuse_lighting || !resources.specular_lighting ||
+        !resources.denoised_diffuse_lighting ||
+        !resources.denoised_specular_lighting || !resources.bindless_array ||
+        (command.constants.enable_env_map != 0 &&
+         (!resources.env_map || !graph_resources.env_map.IsValid()))) {
+        return false;
+    }
 
-    const bool            current_frame = rt_ctx.b_current_frame;
-    const FrameResources& frame          = rt_ctx.frame_rt;
-    cmd_list
-        .Compute(
-            composition_pipeline,
-            composition_constants,
-            frame.hdr_color,
-            frame.motion,
-            current_frame ? frame.view_depth : frame.prev_view_depth,
-            current_frame ? frame.diffuse_albedo : frame.prev_diffuse_albedo,
-            current_frame ? frame.specular_roughness : frame.prev_specular_roughness,
-            current_frame ? frame.normal : frame.prev_normal,
-            frame.emission,
-            frame.diffuse_lighting,
-            frame.specular_lighting,
-#if WITH_NRD
-            frame.denoised_diffuse_lighting,
-            frame.denoised_specular_lighting,
-#else
-            frame.diffuse_lighting,
-            frame.specular_lighting,
-#endif
-            bindless_array
-        )
-        .Dispatch(
-            uint3(ceil(constants.main_view.rect.x / 8), ceil(constants.main_view.rect.y / 8), 1),
-            "CompositionPass"
-        );
+    const auto constants = ImportRTGraphBuffer(
+        graph,
+        "RT.Composition.constants",
+        owner->constants
+    );
+    graph.SetInitialState(
+        constants,
+        RenderGraph::BufferState::ShaderResource,
+        RenderGraph::QueueRole::Graphics,
+        RenderGraph::AccessMode::Read
+    );
+    graph.SetInitialState(
+        graph_resources.hdr_color,
+        RenderGraph::TextureState::ShaderResource,
+        RenderGraph::QueueRole::Graphics,
+        RenderGraph::AccessMode::Read
+    );
+
+    graph.AddRecordPass(
+        "RT.Composition.UploadConstants",
+        [=](RenderGraph::PassBuilder& builder) {
+            builder.ExecuteOn(
+                       RenderGraph::QueueRole::Graphics,
+                       RenderGraph::PipelineType::Copy
+                   )
+                .Write(constants, RenderGraph::BufferState::TransferDestination);
+        },
+        [owner, command](CommandList& cmd_list) {
+            ScopedGpuMarker marker(
+                cmd_list,
+                "Pass: RT Composition Constants Upload",
+                GpuMarkerPalette::Transfer()
+            );
+            RecordConstantsUpload(cmd_list, *owner, command);
+        },
+        RenderGraph::PassExecutionClass::ParallelRecordEligible
+    );
+
+    graph.AddRecordPass(
+        "RT.Composition.Dispatch",
+        [=](RenderGraph::PassBuilder& builder) {
+            builder
+                .ExecuteOn(
+                    RenderGraph::QueueRole::Graphics,
+                    RenderGraph::PipelineType::Compute
+                )
+                .Read(constants, RenderGraph::BufferState::ShaderResource)
+                .Write(
+                    graph_resources.hdr_color,
+                    RenderGraph::TextureState::UnorderedAccess
+                )
+                .ReadWrite(
+                    graph_resources.motion,
+                    RenderGraph::TextureState::UnorderedAccess
+                )
+                .Read(
+                    graph_resources.current_view_depth,
+                    RenderGraph::TextureState::Sampled
+                )
+                .Read(
+                    graph_resources.current_diffuse_albedo,
+                    RenderGraph::TextureState::Sampled
+                )
+                .Read(
+                    graph_resources.current_specular_roughness,
+                    RenderGraph::TextureState::Sampled
+                )
+                .Read(
+                    graph_resources.current_normal,
+                    RenderGraph::TextureState::Sampled
+                )
+                .Read(
+                    graph_resources.emission,
+                    RenderGraph::TextureState::Sampled
+                )
+                .Read(
+                    graph_resources.diffuse_lighting,
+                    RenderGraph::TextureState::Sampled
+                )
+                .Read(
+                    graph_resources.specular_lighting,
+                    RenderGraph::TextureState::Sampled
+                );
+            if (graph_resources.env_map.IsValid()) {
+                builder.Read(
+                    graph_resources.env_map,
+                    RenderGraph::TextureState::Sampled
+                );
+            }
+        },
+        [owner, command, resources](CommandList& cmd_list) {
+            ScopedGpuMarker marker(
+                cmd_list,
+                "CompositionPass",
+                GpuMarkerPalette::Pass(),
+                EGpuMarkerMode::Timestamp
+            );
+            RecordComposition(cmd_list, *owner, command, resources);
+        },
+        RenderGraph::PassExecutionClass::ParallelRecordEligible
+    );
+
+    graph.Export(
+        graph_resources.hdr_color,
+        RenderGraph::TextureState::ShaderResource,
+        RenderGraph::QueueRole::Graphics,
+        RenderGraph::AccessMode::Read
+    );
+    graph.Export(
+        constants,
+        RenderGraph::BufferState::ShaderResource,
+        RenderGraph::QueueRole::Graphics,
+        RenderGraph::AccessMode::Read
+    );
+    return true;
 }
 
 } // namespace Moer::Render::Raytracing

--- a/source/runtime/render/renderer/raytracing/CompositionPass.h
+++ b/source/runtime/render/renderer/raytracing/CompositionPass.h
@@ -3,7 +3,7 @@
 
 // 将 GBuffer 数据与直接光照输出合成为 HDR 场景颜色。
 
-#include "RTResource.h"
+#include "RaytracingGraphResources.h"
 #include "shader/ShaderPipeline.h"
 #include "shaderheaders/shared/ShaderParameters.h"
 
@@ -55,21 +55,61 @@ public:
 
 class CompositionPass {
 public:
+    struct PreparedCommand {
+        CompositingConstants constants{};
+        uint3                dispatch_groups{};
+    };
+
+    struct RecordResources {
+        TextureRef       hdr_color{};
+        TextureRef       motion{};
+        TextureRef       view_depth{};
+        TextureRef       diffuse_albedo{};
+        TextureRef       specular_roughness{};
+        TextureRef       normal{};
+        TextureRef       emission{};
+        TextureRef       diffuse_lighting{};
+        TextureRef       specular_lighting{};
+        TextureRef       denoised_diffuse_lighting{};
+        TextureRef       denoised_specular_lighting{};
+        TextureRef       env_map{};
+        BindlessArrayRef bindless_array{};
+    };
+
     CompositionPass(
         class RenderDevice&  device,
         class ShaderManager& manager,
         BindlessArrayRef     bindless_array
     );
     void Process(class CommandList& cmd_list, RTContext& rt_ctx);
+    bool AddPasses(
+        RenderGraph&                 graph,
+        const RTGraphFrameResources& graph_resources,
+        const RTContext&             rt_ctx
+    );
 
 private:
-    BindlessArrayRef bindless_array;
+    struct RecordingOwner {
+        BufferRef               constants{};
+        CompositionPassPipeline pipeline{};
+    };
 
-    BufferRef            composition_constants;
-    CompositingConstants constants{};
-    Array<byte>          upload_data;
+    PreparedCommand Prepare(const RTContext& rt_ctx) const;
+    RecordResources CaptureResources(const RTContext& rt_ctx) const;
+    static void RecordConstantsUpload(
+        CommandList&           cmd_list,
+        const RecordingOwner&  owner,
+        const PreparedCommand& command
+    );
+    static void RecordComposition(
+        CommandList&           cmd_list,
+        RecordingOwner&        owner,
+        const PreparedCommand& command,
+        const RecordResources& resources
+    );
 
-    CompositionPassPipeline composition_pipeline;
+    BindlessArrayRef         bindless_array;
+    SharedPtr<RecordingOwner> recording_owner;
 };
 
 } // namespace Moer::Render::Raytracing

--- a/source/runtime/render/renderer/raytracing/GBufferPass.cpp
+++ b/source/runtime/render/renderer/raytracing/GBufferPass.cpp
@@ -146,7 +146,8 @@ void GBufferPass::RecordLegacyTailBridge(
     CommandList&     cmd_list,
     const RTContext& rt_ctx,
     bool             composition_recorded,
-    bool             antialias_recorded
+    bool             antialias_recorded,
+    bool             tone_mapping_recorded
 ) const {
     // Active RDG sources own explicit GENERAL-layout exports, while the
     // remaining legacy tail starts a fresh backend tracker. Seed every
@@ -172,9 +173,14 @@ void GBufferPass::RecordLegacyTailBridge(
             ReadTexture{frame.hdr_color->GetView(), ETextureState::SAMPLE}
         );
     }
-    if (antialias_recorded) {
+    if (antialias_recorded && !tone_mapping_recorded) {
         sampled_inputs.emplace_back(
             ReadTexture{frame.resolved_color->GetView(), ETextureState::SAMPLE}
+        );
+    }
+    if (tone_mapping_recorded) {
+        sampled_inputs.emplace_back(
+            ReadTexture{frame.ldr_color->GetView(), ETextureState::SAMPLE}
         );
     }
 #if WITH_NRD

--- a/source/runtime/render/renderer/raytracing/GBufferPass.cpp
+++ b/source/runtime/render/renderer/raytracing/GBufferPass.cpp
@@ -145,7 +145,8 @@ void GBufferPass::Process(CommandList& cmd_list, RTContext& rt_ctx) {
 void GBufferPass::RecordLegacyTailBridge(
     CommandList&     cmd_list,
     const RTContext& rt_ctx,
-    bool             composition_recorded
+    bool             composition_recorded,
+    bool             antialias_recorded
 ) const {
     // Active RDG sources own explicit GENERAL-layout exports, while the
     // remaining legacy tail starts a fresh backend tracker. Seed every
@@ -166,9 +167,14 @@ void GBufferPass::RecordLegacyTailBridge(
         {frame.diffuse_lighting->GetView(), ETextureState::SAMPLE},
         {frame.specular_lighting->GetView(), ETextureState::SAMPLE},
     };
-    if (composition_recorded) {
+    if (composition_recorded && !antialias_recorded) {
         sampled_inputs.emplace_back(
             ReadTexture{frame.hdr_color->GetView(), ETextureState::SAMPLE}
+        );
+    }
+    if (antialias_recorded) {
+        sampled_inputs.emplace_back(
+            ReadTexture{frame.resolved_color->GetView(), ETextureState::SAMPLE}
         );
     }
 #if WITH_NRD

--- a/source/runtime/render/renderer/raytracing/GBufferPass.cpp
+++ b/source/runtime/render/renderer/raytracing/GBufferPass.cpp
@@ -144,7 +144,8 @@ void GBufferPass::Process(CommandList& cmd_list, RTContext& rt_ctx) {
 
 void GBufferPass::RecordLegacyTailBridge(
     CommandList&     cmd_list,
-    const RTContext& rt_ctx
+    const RTContext& rt_ctx,
+    bool             composition_recorded
 ) const {
     // Active RDG sources own explicit GENERAL-layout exports, while the
     // remaining legacy tail starts a fresh backend tracker. Seed every
@@ -165,6 +166,11 @@ void GBufferPass::RecordLegacyTailBridge(
         {frame.diffuse_lighting->GetView(), ETextureState::SAMPLE},
         {frame.specular_lighting->GetView(), ETextureState::SAMPLE},
     };
+    if (composition_recorded) {
+        sampled_inputs.emplace_back(
+            ReadTexture{frame.hdr_color->GetView(), ETextureState::SAMPLE}
+        );
+    }
 #if WITH_NRD
     sampled_inputs.emplace_back(
         ReadTexture{

--- a/source/runtime/render/renderer/raytracing/GBufferPass.cpp
+++ b/source/runtime/render/renderer/raytracing/GBufferPass.cpp
@@ -148,8 +148,8 @@ void GBufferPass::RecordLegacyTailBridge(
 ) const {
     // Active RDG sources own explicit GENERAL-layout exports, while the
     // remaining legacy tail starts a fresh backend tracker. Seed every
-    // bindless GBuffer history read explicitly so Lighting cannot observe the
-    // preferred GENERAL layout through a sampled-image descriptor.
+    // sampled legacy-tail input explicitly so NRD/Composition cannot observe
+    // the preferred GENERAL layout through a sampled-image descriptor.
     const FrameResources& frame = rt_ctx.frame_rt;
     Array<ReadTexture> sampled_inputs{
         {frame.view_depth->GetView(), ETextureState::SAMPLE},
@@ -162,6 +162,8 @@ void GBufferPass::RecordLegacyTailBridge(
         {frame.prev_normal->GetView(), ETextureState::SAMPLE},
         {frame.emission->GetView(), ETextureState::SAMPLE},
         {frame.motion->GetView(), ETextureState::SAMPLE},
+        {frame.diffuse_lighting->GetView(), ETextureState::SAMPLE},
+        {frame.specular_lighting->GetView(), ETextureState::SAMPLE},
     };
 #if WITH_NRD
     sampled_inputs.emplace_back(
@@ -171,6 +173,17 @@ void GBufferPass::RecordLegacyTailBridge(
         }
     );
 #endif
+    if (rt_ctx.env_map) {
+        // Lighting and Composition both sample the bindless environment map.
+        // The graph exports it to the preferred GENERAL boundary, so seed the
+        // fresh legacy tracker with the descriptor's sampled layout as well.
+        sampled_inputs.emplace_back(
+            ReadTexture{
+                rt_ctx.env_map->GetView(0, rt_ctx.env_map->GetNumMips()),
+                ETextureState::SAMPLE
+            }
+        );
+    }
     cmd_list.TextureBarriers(
         EQueueType::Graphics,
         EQueueType::Graphics,

--- a/source/runtime/render/renderer/raytracing/GBufferPass.cpp
+++ b/source/runtime/render/renderer/raytracing/GBufferPass.cpp
@@ -35,70 +35,404 @@ GBufferPass::GBufferPass(RenderDevice& device, ShaderManager& manager, BindlessA
     );
 }
 
-void GBufferPass::Process(CommandList& cmd_list, RTContext& rt_ctx) {
-    GBufferPassParams                params{};
+GBufferPass::PreparedCommand GBufferPass::Prepare(const RTContext& rt_ctx) const {
+    PreparedCommand                  command{};
     const RaytracingBindlessHandles& bindless_handles = rt_ctx.GetBindlessHandles();
 
     // 场景间接索引表。
-    params.instance_buf_hdl  = bindless_handles.instance_buf_hdl;
-    params.primitive_buf_hdl = bindless_handles.primitive_buf_hdl;
-    params.material_buf_hdl  = bindless_handles.material_buf_hdl;
+    command.params.instance_buf_hdl  = bindless_handles.instance_buf_hdl;
+    command.params.primitive_buf_hdl = bindless_handles.primitive_buf_hdl;
+    command.params.material_buf_hdl  = bindless_handles.material_buf_hdl;
 
     // 共享几何数据大缓冲区。
-    params.position_buf_hdl       = bindless_handles.position_buf_hdl;
-    params.packed_normal_buf_hdl  = bindless_handles.packed_normal_buf_hdl;
-    params.packed_tangent_buf_hdl = bindless_handles.packed_tangent_buf_hdl;
-    params.texcoord0_buf_hdl      = bindless_handles.texcoord0_buf_hdl;
-    params.index_buf_hdl          = bindless_handles.index_buf_hdl;
+    command.params.position_buf_hdl       = bindless_handles.position_buf_hdl;
+    command.params.packed_normal_buf_hdl  = bindless_handles.packed_normal_buf_hdl;
+    command.params.packed_tangent_buf_hdl = bindless_handles.packed_tangent_buf_hdl;
+    command.params.texcoord0_buf_hdl      = bindless_handles.texcoord0_buf_hdl;
+    command.params.index_buf_hdl          = bindless_handles.index_buf_hdl;
 
     // Raytracing 专用的 mesh 级 BLAS 间接索引。
-    params.rt_instance_buf_hdl        = bindless_handles.rt_instance_buf_hdl;
-    params.rt_primitive_table_buf_hdl = bindless_handles.rt_primitive_table_buf_hdl;
+    command.params.rt_instance_buf_hdl        = bindless_handles.rt_instance_buf_hdl;
+    command.params.rt_primitive_table_buf_hdl = bindless_handles.rt_primitive_table_buf_hdl;
 
-    constants.main_view = rt_ctx.main_view;
-    constants.prev_view = rt_ctx.prev_view;
-    upload_data.resize(sizeof(GBufferConstants));
-    std::memcpy(upload_data.data(), &constants, sizeof(GBufferConstants));
+    command.constants.main_view = rt_ctx.main_view;
+    command.constants.prev_view = rt_ctx.prev_view;
+    command.dispatch_groups     = uint3(
+        std::ceil(command.constants.main_view.rect.x / 16),
+        std::ceil(command.constants.main_view.rect.y / 16),
+        1
+    );
+    return command;
+}
 
+GBufferPass::RecordResources GBufferPass::CaptureResources(const RTContext& rt_ctx) const {
     const FrameResources& frame         = rt_ctx.frame_rt;
     const bool            current_frame = rt_ctx.b_current_frame;
-    cmd_list.PushScopeWithTimeScope("GBufferPass");
-    cmd_list.CopyFrom(std::move(upload_data), gbuffer_constants->GetView());
+    return RecordResources{
+        .view_depth = current_frame ? frame.view_depth : frame.prev_view_depth,
+        .diffuse_albedo =
+            current_frame ? frame.diffuse_albedo : frame.prev_diffuse_albedo,
+        .specular_roughness =
+            current_frame ? frame.specular_roughness : frame.prev_specular_roughness,
+        .normal           = current_frame ? frame.normal : frame.prev_normal,
+        .emission         = frame.emission,
+        .motion           = frame.motion,
+        .clip_depth       = frame.clip_depth,
+        .normal_roughness = frame.normal_roughness,
+        .tlas             = rt_ctx.rt_scene ? rt_ctx.rt_scene->GetTlas() : RaytracingTlasRef{},
+        .bindless_array   = bindless_array
+    };
+}
 
+void GBufferPass::RecordConstantsUpload(
+    CommandList&           cmd_list,
+    const PreparedCommand& command
+) {
+    Array<byte> upload_data(sizeof(GBufferConstants));
+    std::memcpy(upload_data.data(), &command.constants, sizeof(GBufferConstants));
+    cmd_list.CopyFrom(std::move(upload_data), gbuffer_constants->GetView());
+}
+
+void GBufferPass::RecordTraceGBuffer(
+    CommandList&           cmd_list,
+    const PreparedCommand& command,
+    const RecordResources& resources
+) {
     cmd_list
         .Compute(
             gbuffer_pipeline,
-            params,
+            command.params,
             gbuffer_constants,
-            current_frame ? frame.view_depth : frame.prev_view_depth,
-            current_frame ? frame.diffuse_albedo : frame.prev_diffuse_albedo,
-            current_frame ? frame.specular_roughness : frame.prev_specular_roughness,
-            current_frame ? frame.normal : frame.prev_normal,
-            frame.emission,
-            frame.motion,
-            frame.clip_depth,
-            rt_ctx.rt_scene->GetTlas(),
-            bindless_array
+            resources.view_depth,
+            resources.diffuse_albedo,
+            resources.specular_roughness,
+            resources.normal,
+            resources.emission,
+            resources.motion,
+            resources.clip_depth,
+            resources.tlas,
+            resources.bindless_array
         )
-        .Dispatch(
-            uint3(ceil(constants.main_view.rect.x / 16), ceil(constants.main_view.rect.y / 16), 1),
-            "RaytracingGbuffer"
-        );
+        .Dispatch(command.dispatch_groups, "RaytracingGbuffer");
+}
 
+void GBufferPass::RecordPostProcessGBuffer(
+    CommandList&           cmd_list,
+    const PreparedCommand& command,
+    const RecordResources& resources
+) {
     cmd_list
         .Compute(
             gbuffer_postprocess_pipeline,
-            current_frame ? frame.specular_roughness : frame.prev_specular_roughness,
-            frame.normal_roughness,
-            current_frame ? frame.normal : frame.prev_normal,
-            current_frame ? frame.view_depth : frame.prev_view_depth
+            resources.specular_roughness,
+            resources.normal_roughness,
+            resources.normal,
+            resources.view_depth
         )
-        .Dispatch(
-            uint3(ceil(constants.main_view.rect.x / 16), ceil(constants.main_view.rect.y / 16), 1),
-            "PostProcessGBuffer"
-        );
+        .Dispatch(command.dispatch_groups, "PostProcessGBuffer");
+}
 
+void GBufferPass::Process(CommandList& cmd_list, RTContext& rt_ctx) {
+    const PreparedCommand command   = Prepare(rt_ctx);
+    const RecordResources resources = CaptureResources(rt_ctx);
+    cmd_list.PushScopeWithTimeScope("GBufferPass");
+    RecordConstantsUpload(cmd_list, command);
+    RecordTraceGBuffer(cmd_list, command, resources);
+    RecordPostProcessGBuffer(cmd_list, command, resources);
     cmd_list.PopScopeWithTimeScope();
+}
+
+void GBufferPass::RecordLegacyTailBridge(
+    CommandList&     cmd_list,
+    const RTContext& rt_ctx
+) const {
+    // Active RDG sources own explicit GENERAL-layout exports, while the
+    // remaining legacy tail starts a fresh backend tracker. Seed every
+    // bindless GBuffer history read explicitly so Lighting cannot observe the
+    // preferred GENERAL layout through a sampled-image descriptor.
+    const FrameResources& frame = rt_ctx.frame_rt;
+    Array<ReadTexture> sampled_inputs{
+        {frame.view_depth->GetView(), ETextureState::SAMPLE},
+        {frame.diffuse_albedo->GetView(), ETextureState::SAMPLE},
+        {frame.specular_roughness->GetView(), ETextureState::SAMPLE},
+        {frame.normal->GetView(), ETextureState::SAMPLE},
+        {frame.prev_view_depth->GetView(), ETextureState::SAMPLE},
+        {frame.prev_diffuse_albedo->GetView(), ETextureState::SAMPLE},
+        {frame.prev_specular_roughness->GetView(), ETextureState::SAMPLE},
+        {frame.prev_normal->GetView(), ETextureState::SAMPLE},
+        {frame.emission->GetView(), ETextureState::SAMPLE},
+        {frame.motion->GetView(), ETextureState::SAMPLE},
+    };
+#if WITH_NRD
+    sampled_inputs.emplace_back(
+        ReadTexture{
+            frame.normal_roughness->GetView(),
+            ETextureState::SAMPLE
+        }
+    );
+#endif
+    cmd_list.TextureBarriers(
+        EQueueType::Graphics,
+        EQueueType::Graphics,
+        EPassType::Compute,
+        std::move(sampled_inputs)
+    );
+}
+
+bool GBufferPass::AddPasses(
+    RenderGraph&                 graph,
+    const RTGraphFrameResources& graph_resources,
+    const RTContext&             rt_ctx,
+    bool                         tlas_built_this_frame,
+    bool                         normal_roughness_readable
+) {
+    const PreparedCommand command   = Prepare(rt_ctx);
+    const RecordResources resources = CaptureResources(rt_ctx);
+    if (!resources.tlas || resources.tlas->GetUnderlyingBuffer() == nullptr) {
+        return false;
+    }
+
+    const BufferRef tlas_buffer(resources.tlas->GetUnderlyingBuffer());
+    const auto constants =
+        ImportRTGraphBuffer(graph, "RT.GBuffer.constants", gbuffer_constants);
+    const auto tlas =
+        ImportRTGraphBuffer(graph, "RT.GBuffer.tlas", tlas_buffer);
+
+    const auto initial_texture =
+        [&](RenderGraph::TextureHandle texture,
+            RenderGraph::TextureState  texture_state,
+            RenderGraph::AccessMode    access) {
+            graph.SetInitialState(
+                texture,
+                texture_state,
+                RenderGraph::QueueRole::Graphics,
+                access
+            );
+        };
+    initial_texture(
+        graph_resources.current_view_depth,
+        RenderGraph::TextureState::ShaderResource,
+        RenderGraph::AccessMode::Read
+    );
+    initial_texture(
+        graph_resources.current_diffuse_albedo,
+        RenderGraph::TextureState::ShaderResource,
+        RenderGraph::AccessMode::Read
+    );
+    initial_texture(
+        graph_resources.current_specular_roughness,
+        RenderGraph::TextureState::ShaderResource,
+        RenderGraph::AccessMode::Read
+    );
+    initial_texture(
+        graph_resources.current_normal,
+        RenderGraph::TextureState::ShaderResource,
+        RenderGraph::AccessMode::Read
+    );
+    initial_texture(
+        graph_resources.emission,
+        RenderGraph::TextureState::ShaderResource,
+        RenderGraph::AccessMode::Read
+    );
+    initial_texture(
+        graph_resources.motion,
+        RenderGraph::TextureState::ShaderResource,
+        RenderGraph::AccessMode::Read
+    );
+    initial_texture(
+        graph_resources.clip_depth,
+        RenderGraph::TextureState::UnorderedAccess,
+        RenderGraph::AccessMode::Write
+    );
+#if WITH_NRD
+    // The mixed graph/legacy frame tail restores UAV-capable textures to the
+    // Vulkan backend's preferred GENERAL layout. Preserve whether the last
+    // meaningful access was an NRD read or a GBuffer write.
+    initial_texture(
+        graph_resources.normal_roughness,
+        normal_roughness_readable ?
+            RenderGraph::TextureState::ShaderResource :
+            RenderGraph::TextureState::UnorderedAccess,
+        normal_roughness_readable ?
+            RenderGraph::AccessMode::Read :
+            RenderGraph::AccessMode::Write
+    );
+#endif
+    graph.SetInitialState(
+        constants,
+        RenderGraph::BufferState::ShaderResource,
+        RenderGraph::QueueRole::Graphics,
+        RenderGraph::AccessMode::Read
+    );
+    graph.SetInitialState(
+        tlas,
+        tlas_built_this_frame ?
+            RenderGraph::BufferState::AccelerationStructureWrite :
+            RenderGraph::BufferState::AccelerationStructureRead,
+        RenderGraph::QueueRole::Graphics,
+        tlas_built_this_frame ?
+            RenderGraph::AccessMode::Write :
+            RenderGraph::AccessMode::Read
+    );
+
+    graph.AddRecordPass(
+        "RT.GBuffer.UploadConstants",
+        [=](RenderGraph::PassBuilder& builder) {
+            builder.ExecuteOn(
+                       RenderGraph::QueueRole::Graphics,
+                       RenderGraph::PipelineType::Copy
+                   )
+                .Write(constants, RenderGraph::BufferState::TransferDestination);
+        },
+        [this, command](CommandList& cmd_list) {
+            ScopedGpuMarker marker(
+                cmd_list,
+                "Pass: RT GBuffer Constants Upload",
+                GpuMarkerPalette::Transfer()
+            );
+            RecordConstantsUpload(cmd_list, command);
+        },
+        RenderGraph::PassExecutionClass::ParallelRecordEligible
+    );
+
+    graph.AddRecordPass(
+        "RT.GBuffer.Trace",
+        [=](RenderGraph::PassBuilder& builder) {
+            builder.ExecuteOn(
+                       RenderGraph::QueueRole::Graphics,
+                       RenderGraph::PipelineType::Compute
+                   )
+                .Read(constants, RenderGraph::BufferState::ShaderResource)
+                .Read(tlas, RenderGraph::BufferState::AccelerationStructureRead)
+                .Write(
+                    graph_resources.current_view_depth,
+                    RenderGraph::TextureState::UnorderedAccess
+                )
+                .Write(
+                    graph_resources.current_diffuse_albedo,
+                    RenderGraph::TextureState::UnorderedAccess
+                )
+                .Write(
+                    graph_resources.current_specular_roughness,
+                    RenderGraph::TextureState::UnorderedAccess
+                )
+                .Write(
+                    graph_resources.current_normal,
+                    RenderGraph::TextureState::UnorderedAccess
+                )
+                .Write(
+                    graph_resources.emission,
+                    RenderGraph::TextureState::UnorderedAccess
+                )
+                .Write(
+                    graph_resources.motion,
+                    RenderGraph::TextureState::UnorderedAccess
+                )
+                .Write(
+                    graph_resources.clip_depth,
+                    RenderGraph::TextureState::UnorderedAccess
+                );
+        },
+        [this, command, resources](CommandList& cmd_list) {
+            ScopedGpuMarker marker(
+                cmd_list,
+                "GBufferPass",
+                GpuMarkerPalette::Pass(),
+                EGpuMarkerMode::Timestamp
+            );
+            RecordTraceGBuffer(cmd_list, command, resources);
+        },
+        RenderGraph::PassExecutionClass::ParallelRecordEligible
+    );
+
+    graph.AddRecordPass(
+        "RT.GBuffer.PostProcess",
+        [=](RenderGraph::PassBuilder& builder) {
+            builder.ExecuteOn(
+                RenderGraph::QueueRole::Graphics,
+                RenderGraph::PipelineType::Compute
+            );
+            builder
+                .ReadWrite(
+                    graph_resources.current_specular_roughness,
+                    RenderGraph::TextureState::UnorderedAccess
+                )
+                .Read(
+                    graph_resources.current_normal,
+                    RenderGraph::TextureState::Sampled
+                )
+                .Read(
+                    graph_resources.current_view_depth,
+                    RenderGraph::TextureState::Sampled
+                );
+#if WITH_NRD
+            builder.Write(
+                graph_resources.normal_roughness,
+                RenderGraph::TextureState::UnorderedAccess
+            );
+#endif
+        },
+        [this, command, resources](CommandList& cmd_list) {
+            ScopedGpuMarker marker(
+                cmd_list,
+                "Pass: RT GBuffer PostProcess",
+                GpuMarkerPalette::Pass()
+            );
+            RecordPostProcessGBuffer(cmd_list, command, resources);
+        },
+        RenderGraph::PassExecutionClass::ParallelRecordEligible
+    );
+
+    const auto export_texture =
+        [&](RenderGraph::TextureHandle texture,
+            RenderGraph::TextureState  texture_state,
+            RenderGraph::AccessMode    access) {
+            graph.Export(
+                texture,
+                texture_state,
+                RenderGraph::QueueRole::Graphics,
+                access
+            );
+        };
+    for (const auto texture : {
+             graph_resources.current_view_depth,
+             graph_resources.current_diffuse_albedo,
+             graph_resources.current_specular_roughness,
+             graph_resources.current_normal,
+             graph_resources.emission,
+             graph_resources.motion,
+         }) {
+        export_texture(
+            texture,
+            RenderGraph::TextureState::ShaderResource,
+            RenderGraph::AccessMode::Read
+        );
+    }
+    export_texture(
+        graph_resources.clip_depth,
+        RenderGraph::TextureState::UnorderedAccess,
+        RenderGraph::AccessMode::Write
+    );
+#if WITH_NRD
+    export_texture(
+        graph_resources.normal_roughness,
+        RenderGraph::TextureState::ShaderResource,
+        RenderGraph::AccessMode::Read
+    );
+#endif
+    graph.Export(
+        constants,
+        RenderGraph::BufferState::ShaderResource,
+        RenderGraph::QueueRole::Graphics,
+        RenderGraph::AccessMode::Read
+    );
+    graph.Export(
+        tlas,
+        RenderGraph::BufferState::AccelerationStructureRead,
+        RenderGraph::QueueRole::Graphics,
+        RenderGraph::AccessMode::Read
+    );
+    return true;
 }
 
 } // namespace Moer::Render::Raytracing

--- a/source/runtime/render/renderer/raytracing/GBufferPass.cpp
+++ b/source/runtime/render/renderer/raytracing/GBufferPass.cpp
@@ -147,13 +147,31 @@ void GBufferPass::RecordLegacyTailBridge(
     const RTContext& rt_ctx,
     bool             composition_recorded,
     bool             antialias_recorded,
-    bool             tone_mapping_recorded
+    bool             tone_mapping_recorded,
+    bool             visualize_recorded
 ) const {
     // Active RDG sources own explicit GENERAL-layout exports, while the
     // remaining legacy tail starts a fresh backend tracker. Seed every
     // sampled legacy-tail input explicitly so NRD/Composition cannot observe
     // the preferred GENERAL layout through a sampled-image descriptor.
     const FrameResources& frame = rt_ctx.frame_rt;
+    if (visualize_recorded) {
+        // A complete FrameCore graph owns the renderer through Visualize.
+        // The fresh legacy tail only needs the two possible UI inputs. Both
+        // transitions target graphics sampling; its submit epilogue restores
+        // debug_color to the UAV-capable texture's preferred GENERAL layout.
+        cmd_list.TextureBarriers(
+            EQueueType::Graphics,
+            EQueueType::Graphics,
+            EPassType::Graphics,
+            Array<ReadTexture>{
+                {frame.debug_color->GetView(), ETextureState::SAMPLE},
+                {frame.ldr_color->GetView(), ETextureState::SAMPLE},
+            }
+        );
+        return;
+    }
+
     Array<ReadTexture> sampled_inputs{
         {frame.view_depth->GetView(), ETextureState::SAMPLE},
         {frame.diffuse_albedo->GetView(), ETextureState::SAMPLE},
@@ -165,6 +183,8 @@ void GBufferPass::RecordLegacyTailBridge(
         {frame.prev_normal->GetView(), ETextureState::SAMPLE},
         {frame.emission->GetView(), ETextureState::SAMPLE},
         {frame.motion->GetView(), ETextureState::SAMPLE},
+        {frame.clip_depth->GetView(), ETextureState::SAMPLE},
+        {frame.normal_roughness->GetView(), ETextureState::SAMPLE},
         {frame.diffuse_lighting->GetView(), ETextureState::SAMPLE},
         {frame.specular_lighting->GetView(), ETextureState::SAMPLE},
     };
@@ -183,14 +203,6 @@ void GBufferPass::RecordLegacyTailBridge(
             ReadTexture{frame.ldr_color->GetView(), ETextureState::SAMPLE}
         );
     }
-#if WITH_NRD
-    sampled_inputs.emplace_back(
-        ReadTexture{
-            frame.normal_roughness->GetView(),
-            ETextureState::SAMPLE
-        }
-    );
-#endif
     if (rt_ctx.env_map) {
         // Lighting and Composition both sample the bindless environment map.
         // The graph exports it to the preferred GENERAL boundary, so seed the
@@ -272,13 +284,12 @@ bool GBufferPass::AddPasses(
     );
     initial_texture(
         graph_resources.clip_depth,
-        RenderGraph::TextureState::UnorderedAccess,
-        RenderGraph::AccessMode::Write
+        RenderGraph::TextureState::ShaderResource,
+        RenderGraph::AccessMode::Read
     );
-#if WITH_NRD
     // The mixed graph/legacy frame tail restores UAV-capable textures to the
     // Vulkan backend's preferred GENERAL layout. Preserve whether the last
-    // meaningful access was an NRD read or a GBuffer write.
+    // meaningful access was a Visualize/NRD read or a GBuffer write.
     initial_texture(
         graph_resources.normal_roughness,
         normal_roughness_readable ?
@@ -288,7 +299,6 @@ bool GBufferPass::AddPasses(
             RenderGraph::AccessMode::Read :
             RenderGraph::AccessMode::Write
     );
-#endif
     graph.SetInitialState(
         constants,
         RenderGraph::BufferState::ShaderResource,
@@ -395,13 +405,11 @@ bool GBufferPass::AddPasses(
                 .Read(
                     graph_resources.current_view_depth,
                     RenderGraph::TextureState::Sampled
+                )
+                .Write(
+                    graph_resources.normal_roughness,
+                    RenderGraph::TextureState::UnorderedAccess
                 );
-#if WITH_NRD
-            builder.Write(
-                graph_resources.normal_roughness,
-                RenderGraph::TextureState::UnorderedAccess
-            );
-#endif
         },
         [this, command, resources](CommandList& cmd_list) {
             ScopedGpuMarker marker(
@@ -441,16 +449,14 @@ bool GBufferPass::AddPasses(
     }
     export_texture(
         graph_resources.clip_depth,
-        RenderGraph::TextureState::UnorderedAccess,
-        RenderGraph::AccessMode::Write
+        RenderGraph::TextureState::ShaderResource,
+        RenderGraph::AccessMode::Read
     );
-#if WITH_NRD
     export_texture(
         graph_resources.normal_roughness,
         RenderGraph::TextureState::ShaderResource,
         RenderGraph::AccessMode::Read
     );
-#endif
     graph.Export(
         constants,
         RenderGraph::BufferState::ShaderResource,

--- a/source/runtime/render/renderer/raytracing/GBufferPass.h
+++ b/source/runtime/render/renderer/raytracing/GBufferPass.h
@@ -90,7 +90,8 @@ public:
         class CommandList& cmd_list,
         const RTContext&   rt_ctx,
         bool               composition_recorded,
-        bool               antialias_recorded
+        bool               antialias_recorded,
+        bool               tone_mapping_recorded
     ) const;
     bool AddPasses(
         RenderGraph&                 graph,

--- a/source/runtime/render/renderer/raytracing/GBufferPass.h
+++ b/source/runtime/render/renderer/raytracing/GBufferPass.h
@@ -89,7 +89,8 @@ public:
     void RecordLegacyTailBridge(
         class CommandList& cmd_list,
         const RTContext&   rt_ctx,
-        bool               composition_recorded
+        bool               composition_recorded,
+        bool               antialias_recorded
     ) const;
     bool AddPasses(
         RenderGraph&                 graph,

--- a/source/runtime/render/renderer/raytracing/GBufferPass.h
+++ b/source/runtime/render/renderer/raytracing/GBufferPass.h
@@ -91,7 +91,8 @@ public:
         const RTContext&   rt_ctx,
         bool               composition_recorded,
         bool               antialias_recorded,
-        bool               tone_mapping_recorded
+        bool               tone_mapping_recorded,
+        bool               visualize_recorded
     ) const;
     bool AddPasses(
         RenderGraph&                 graph,

--- a/source/runtime/render/renderer/raytracing/GBufferPass.h
+++ b/source/runtime/render/renderer/raytracing/GBufferPass.h
@@ -3,7 +3,7 @@
 
 // 生成 Raytracing GBuffer，并转换为降噪器所需布局。
 
-#include "RTResource.h"
+#include "RaytracingGraphResources.h"
 #include "shader/ShaderPipeline.h"
 #include "shaderheaders/shared/ShaderParameters.h"
 
@@ -65,15 +65,54 @@ public:
 
 class GBufferPass {
 public:
+    struct PreparedCommand {
+        GBufferPassParams params{};
+        GBufferConstants  constants{};
+        uint3             dispatch_groups{};
+    };
+
+    struct RecordResources {
+        TextureRef        view_depth{};
+        TextureRef        diffuse_albedo{};
+        TextureRef        specular_roughness{};
+        TextureRef        normal{};
+        TextureRef        emission{};
+        TextureRef        motion{};
+        TextureRef        clip_depth{};
+        TextureRef        normal_roughness{};
+        RaytracingTlasRef tlas{};
+        BindlessArrayRef  bindless_array{};
+    };
+
     GBufferPass(class RenderDevice& device, class ShaderManager& manager, BindlessArrayRef bindless_array);
     void Process(class CommandList& cmd_list, RTContext& rt_ctx);
+    void RecordLegacyTailBridge(class CommandList& cmd_list, const RTContext& rt_ctx) const;
+    bool AddPasses(
+        RenderGraph&                 graph,
+        const RTGraphFrameResources& graph_resources,
+        const RTContext&             rt_ctx,
+        bool                         tlas_built_this_frame,
+        bool                         normal_roughness_readable
+    );
 
 private:
+    PreparedCommand Prepare(const RTContext& rt_ctx) const;
+    RecordResources CaptureResources(const RTContext& rt_ctx) const;
+    void RecordConstantsUpload(CommandList& cmd_list, const PreparedCommand& command);
+    void RecordTraceGBuffer(
+        CommandList&           cmd_list,
+        const PreparedCommand& command,
+        const RecordResources& resources
+    );
+    void RecordPostProcessGBuffer(
+        CommandList&           cmd_list,
+        const PreparedCommand& command,
+        const RecordResources& resources
+    );
+
     BindlessArrayRef bindless_array;
 
-    BufferRef        gbuffer_constants;
-    GBufferConstants constants{};
-    Array<byte>      upload_data;
+    BufferRef gbuffer_constants;
 
     RaytracingGBufferPipeline  gbuffer_pipeline;
     PostProcessGBufferPipeline gbuffer_postprocess_pipeline;

--- a/source/runtime/render/renderer/raytracing/GBufferPass.h
+++ b/source/runtime/render/renderer/raytracing/GBufferPass.h
@@ -86,7 +86,11 @@ public:
 
     GBufferPass(class RenderDevice& device, class ShaderManager& manager, BindlessArrayRef bindless_array);
     void Process(class CommandList& cmd_list, RTContext& rt_ctx);
-    void RecordLegacyTailBridge(class CommandList& cmd_list, const RTContext& rt_ctx) const;
+    void RecordLegacyTailBridge(
+        class CommandList& cmd_list,
+        const RTContext&   rt_ctx,
+        bool               composition_recorded
+    ) const;
     bool AddPasses(
         RenderGraph&                 graph,
         const RTGraphFrameResources& graph_resources,

--- a/source/runtime/render/renderer/raytracing/LightingPass.cpp
+++ b/source/runtime/render/renderer/raytracing/LightingPass.cpp
@@ -476,14 +476,7 @@ bool LightingPass::AddPasses(
             resources.env_pdf
         );
     }
-    RenderGraph::TextureHandle env_map{};
-    if (resources.env_map) {
-        env_map = ImportRTGraphTexture(
-            graph,
-            "RT.Lighting.env_map",
-            resources.env_map
-        );
-    }
+    const RenderGraph::TextureHandle env_map = graph_resources.env_map;
 
     graph.SetInitialState(
         constants,

--- a/source/runtime/render/renderer/raytracing/LightingPass.cpp
+++ b/source/runtime/render/renderer/raytracing/LightingPass.cpp
@@ -52,161 +52,792 @@ LightingPass::LightingPass(ShaderManager& _manager, BindlessArrayRef bindless_ar
     );
 }
 
-LightingPass::LocalLightSamplingDecision
-LightingPass::Process(CommandList& _cmd_list, RTContext& _rt_ctx) {
-    const DI::ReSTIRDIRuntimeConfig& restir_di_runtime_config = _rt_ctx.is_ctx.GetReSTIRDIRuntimeConfig();
+LightingPass::PreparedCommand LightingPass::Prepare(const RTContext& rt_ctx) const {
+    const DI::ReSTIRDIRuntimeConfig& restir_di_runtime_config =
+        rt_ctx.is_ctx.GetReSTIRDIRuntimeConfig();
+    const ImportanceSamplingContext& is_ctx = rt_ctx.is_ctx;
 
-    const ImportanceSamplingContext& is_ctx = _rt_ctx.is_ctx;
-
-    constants.frame_idx        = _rt_ctx.is_ctx.GetFrameIdx();
-    constants.main_view        = _rt_ctx.main_view;
-    constants.prev_view        = _rt_ctx.prev_view;
+    PreparedCommand command{};
+    auto&           constants = command.constants;
+    constants.frame_idx        = is_ctx.GetFrameIdx();
+    constants.main_view        = rt_ctx.main_view;
+    constants.prev_view        = rt_ctx.prev_view;
     constants.enable_prev_tlas = true;
     constants.local_light_pdf_size =
-        _rt_ctx.local_light_pdf_tex ? _rt_ctx.local_light_pdf_tex->GetExtent().xy : uint2(0);
-    constants.env_pdf_size     = _rt_ctx.env_pdf_tex ? _rt_ctx.env_pdf_tex->GetExtent().xy : uint2(0);
-    constants.bindless_handles = _rt_ctx.GetBindlessHandles();
+        rt_ctx.local_light_pdf_tex ? rt_ctx.local_light_pdf_tex->GetExtent().xy : uint2(0);
+    constants.env_pdf_size =
+        rt_ctx.env_pdf_tex ? rt_ctx.env_pdf_tex->GetExtent().xy : uint2(0);
+    constants.bindless_handles = rt_ctx.GetBindlessHandles();
 
     constants.di_params = restir_di_runtime_config.common_params;
     auto initial_sample_params = is_ctx.GetDIInitialSampleParams();
-    LocalLightSamplingDecision sampling_decision{};
-    sampling_decision.configured_mode  = initial_sample_params.local_light_sample_mode;
-    sampling_decision.local_light_count =
+    command.sampling_decision.configured_mode =
+        initial_sample_params.local_light_sample_mode;
+    command.sampling_decision.local_light_count =
         is_ctx.GetLightBufferParams().local_light_region.light_cnt;
-    sampling_decision.adaptive_fallback_applied =
-        _rt_ctx.config.enable_adaptive_local_light_sampling &&
-        initial_sample_params.local_light_sample_mode == s_di_local_light_sample_mode_grid &&
-        sampling_decision.local_light_count < _rt_ctx.config.grid_min_local_light_count;
-    if (sampling_decision.adaptive_fallback_applied) {
-        initial_sample_params.local_light_sample_mode = s_di_local_light_sample_mode_power_ris;
+    command.sampling_decision.adaptive_fallback_applied =
+        rt_ctx.config.enable_adaptive_local_light_sampling &&
+        initial_sample_params.local_light_sample_mode ==
+            s_di_local_light_sample_mode_grid &&
+        command.sampling_decision.local_light_count <
+            rt_ctx.config.grid_min_local_light_count;
+    if (command.sampling_decision.adaptive_fallback_applied) {
+        initial_sample_params.local_light_sample_mode =
+            s_di_local_light_sample_mode_power_ris;
     }
-    sampling_decision.effective_mode = initial_sample_params.local_light_sample_mode;
-    constants.restir_di_params.initial_sample_params    = initial_sample_params;
-    constants.restir_di_params.temporal_resample_params = is_ctx.GetDITemporalResampleParams();
-    constants.restir_di_params.spatial_resample_params  = is_ctx.GetDISpatialResampleParams();
-    constants.restir_di_params.reservoir_buffer_params  = restir_di_runtime_config.reservoir_buffer_params;
-    constants.restir_di_params.shading_params           = is_ctx.GetDIShadingParams();
-    constants.restir_di_params.buffer_indices           = is_ctx.GetReSTIRDIBufferIndices();
+    command.sampling_decision.effective_mode =
+        initial_sample_params.local_light_sample_mode;
 
-    constants.light_buffer_params           = is_ctx.GetLightBufferParams();
-    constants.local_light_ris_buffer_params = is_ctx.GetLocalLightRISBufferParams();
-    constants.env_light_ris_buffer_params   = is_ctx.GetEnvLightRISBufferParams();
+    constants.restir_di_params.initial_sample_params = initial_sample_params;
+    constants.restir_di_params.temporal_resample_params =
+        is_ctx.GetDITemporalResampleParams();
+    constants.restir_di_params.spatial_resample_params =
+        is_ctx.GetDISpatialResampleParams();
+    constants.restir_di_params.reservoir_buffer_params =
+        restir_di_runtime_config.reservoir_buffer_params;
+    constants.restir_di_params.shading_params = is_ctx.GetDIShadingParams();
+    constants.restir_di_params.buffer_indices =
+        is_ctx.GetReSTIRDIBufferIndices();
 
+    constants.light_buffer_params = is_ctx.GetLightBufferParams();
+    constants.local_light_ris_buffer_params =
+        is_ctx.GetLocalLightRISBufferParams();
+    constants.env_light_ris_buffer_params =
+        is_ctx.GetEnvLightRISBufferParams();
     constants.grid_params             = is_ctx.GetGridParams();
-    constants.scene_params            = _rt_ctx.scene_params;
+    constants.scene_params            = rt_ctx.scene_params;
     constants.enable_accumulation     = 1;
     constants.discount_native_samples = 1;
     constants.visualize_cells         = 0;
+    constants.denoiser_mode           = rt_ctx.config.denoiser_mode;
+    constants.reblur_diff_hit_dist_params =
+        rt_ctx.config.reblur_diffuse_hit_dist_params;
+    constants.reblur_spec_hit_dist_params =
+        rt_ctx.config.reblur_specular_hit_dist_params;
 
-    constants.denoiser_mode               = _rt_ctx.config.denoiser_mode;
-    constants.reblur_diff_hit_dist_params = _rt_ctx.config.reblur_diffuse_hit_dist_params;
-    constants.reblur_spec_hit_dist_params = _rt_ctx.config.reblur_specular_hit_dist_params;
-
-    upload_data.resize(sizeof(ResampleConstants));
-    std::memcpy(upload_data.data(), &constants, sizeof(ResampleConstants));
-    _cmd_list.PushScopeWithTimeScope("LightingPass");
-    _cmd_list.CopyFrom(std::move(upload_data), resample_params->GetView());
-    bool b_current_frame = _rt_ctx.b_current_frame;
-
-#define DI_BINDING_ARGS(ctx)                                                                         \
-    ctx.rt_scene->GetTlas(),                                                                         \
-        ctx.rt_scene->GetPrevTlas() ? ctx.rt_scene->GetPrevTlas() : ctx.rt_scene->GetTlas(),         \
-        resample_params, ctx.light_reservoir_buf, ctx.frame_rt.diffuse_lighting,                     \
-        ctx.frame_rt.specular_lighting, ctx.frame_rt.temporal_sample_pos, ctx.frame_rt.gradients,    \
-        b_current_frame ? ctx.frame_rt.restir_luminance : ctx.frame_rt.prev_luminance,               \
-        ctx.frame_rt.prev_diffuse_lighting, ctx.ris_buf, ctx.ris_light_data_buf,                     \
-        ctx.neighbor_offset_buf, bindless_array
-
-    auto div_ceil = [](uint _a, uint _b) -> uint {
-        return (_a + _b - 1) / _b;
+    const auto div_ceil = [](uint value, uint divisor) -> uint {
+        return (value + divisor - 1) / divisor;
     };
-    const uint local_light_count     = sampling_decision.local_light_count;
-    const bool has_local_candidates = initial_sample_params.num_primary_local_lights > 0;
+    const bool has_local_candidates =
+        initial_sample_params.num_primary_local_lights > 0;
     const bool uses_grid =
-        initial_sample_params.local_light_sample_mode == s_di_local_light_sample_mode_grid;
+        initial_sample_params.local_light_sample_mode ==
+        s_di_local_light_sample_mode_grid;
     const bool needs_power_ris =
-        initial_sample_params.local_light_sample_mode == s_di_local_light_sample_mode_power_ris ||
-        (uses_grid && constants.grid_params.common_params.local_light_sampling_fallback_mode ==
-                          s_di_local_light_sample_mode_power_ris);
-    // 所有通过 DI_BINDINGS 声明的 pipeline 都采用相同参数布局。这里只注册一次，
-    // 避免为每个阶段重复构建等价参数包。
-    ArrayArgReference arg_ref =
-        _cmd_list.RegisterArgs(presample_light_pipeline.SetArgs(DI_BINDING_ARGS(_rt_ctx)));
+        initial_sample_params.local_light_sample_mode ==
+            s_di_local_light_sample_mode_power_ris ||
+        (uses_grid &&
+         constants.grid_params.common_params.local_light_sampling_fallback_mode ==
+             s_di_local_light_sample_mode_power_ris);
+    command.record_presample_light =
+        command.sampling_decision.local_light_count != 0 &&
+        has_local_candidates && needs_power_ris;
+    command.record_presample_env =
+        is_ctx.GetLightBufferParams().env_light.light_cnt != 0;
+    command.record_presample_grid =
+        command.sampling_decision.local_light_count != 0 &&
+        has_local_candidates && uses_grid;
 
-    if (local_light_count && has_local_candidates && needs_power_ris) {
-        uint2 dispatch_size = uint2(
-            div_ceil(is_ctx.GetLocalLightRISBufferParams().tile_size, DI_PRESAMPLE_GRID_SIZE),
-            is_ctx.GetLocalLightRISBufferParams().tile_cnt
-        );
-        _cmd_list.Compute(presample_light_pipeline, arg_ref)
-            .Dispatch(
-                uint3(dispatch_size, 1),
-                "PresampleLight",
-                ProfileSection("ReSTIR DI Presample Local")
-            );
+    command.presample_light_dispatch = uint3(
+        div_ceil(
+            is_ctx.GetLocalLightRISBufferParams().tile_size,
+            DI_PRESAMPLE_GRID_SIZE
+        ),
+        is_ctx.GetLocalLightRISBufferParams().tile_cnt,
+        1
+    );
+    command.presample_env_dispatch = uint3(
+        div_ceil(
+            is_ctx.GetEnvLightRISBufferParams().tile_size,
+            DI_PRESAMPLE_GRID_SIZE
+        ),
+        is_ctx.GetEnvLightRISBufferParams().tile_cnt,
+        1
+    );
+    command.presample_grid_dispatch = uint3(
+        div_ceil(
+            is_ctx.GetGridRuntimeConfig().num_light_slot,
+            DI_PRESAMPLE_GRID_SIZE
+        ),
+        1,
+        1
+    );
+    const uint2 lighting_extent = rt_ctx.frame_rt.diffuse_lighting->GetExtent().xy;
+    command.screen_dispatch     = uint3(
+        div_ceil(lighting_extent.x, DI_SCREEN_TILE_SIZE),
+        div_ceil(lighting_extent.y, DI_SCREEN_TILE_SIZE),
+        1
+    );
+    return command;
+}
+
+LightingPass::RecordResources
+LightingPass::CaptureResources(const RTContext& rt_ctx) const {
+    const bool current_frame = rt_ctx.b_current_frame;
+    RaytracingTlasRef tlas =
+        rt_ctx.rt_scene ? rt_ctx.rt_scene->GetTlas() : RaytracingTlasRef{};
+    RaytracingTlasRef prev_tlas =
+        rt_ctx.rt_scene ? rt_ctx.rt_scene->GetPrevTlas() : RaytracingTlasRef{};
+    if (!prev_tlas) {
+        prev_tlas = tlas;
     }
 
-    if (is_ctx.GetLightBufferParams().env_light.light_cnt) {
-        uint2 dispatch_size = uint2(
-            div_ceil(is_ctx.GetEnvLightRISBufferParams().tile_size, DI_PRESAMPLE_GRID_SIZE),
-            is_ctx.GetEnvLightRISBufferParams().tile_cnt
-        );
-        _cmd_list.Compute(presample_env_map_pipeline, arg_ref)
-            .Dispatch(
-                uint3(dispatch_size, 1),
-                "PresampleEnvMap",
-                ProfileSection("ReSTIR DI Presample Environment")
-            );
+    return RecordResources{
+        .tlas                   = tlas,
+        .prev_tlas              = prev_tlas,
+        .constants_buf          = resample_params,
+        .light_reservoir_buf    = rt_ctx.light_reservoir_buf,
+        .ris_buf                = rt_ctx.ris_buf,
+        .ris_light_data_buf     = rt_ctx.ris_light_data_buf,
+        .neighbor_offset_buf    = rt_ctx.neighbor_offset_buf,
+        .light_mapping_buf      = rt_ctx.light_mapping_buf,
+        .light_data_buf         = rt_ctx.light_data_buf,
+        .primitive_to_light_buf = rt_ctx.primitive_to_light_buf,
+        .diffuse_lighting       = rt_ctx.frame_rt.diffuse_lighting,
+        .specular_lighting      = rt_ctx.frame_rt.specular_lighting,
+        .temporal_sample_pos    = rt_ctx.frame_rt.temporal_sample_pos,
+        .gradients              = rt_ctx.frame_rt.gradients,
+        .restir_luminance =
+            current_frame ? rt_ctx.frame_rt.restir_luminance :
+                            rt_ctx.frame_rt.prev_luminance,
+        .prev_diffuse_lighting = rt_ctx.frame_rt.prev_diffuse_lighting,
+        .local_light_pdf       = rt_ctx.local_light_pdf_tex,
+        .env_pdf               = rt_ctx.env_pdf_tex,
+        .env_map               = rt_ctx.env_map,
+        .bindless_array        = bindless_array
+    };
+}
+
+void LightingPass::RecordConstantsUpload(
+    CommandList&           cmd_list,
+    const PreparedCommand& command,
+    const RecordResources& resources
+) const {
+    Array<byte> upload_data(sizeof(ResampleConstants));
+    std::memcpy(
+        upload_data.data(),
+        &command.constants,
+        sizeof(ResampleConstants)
+    );
+    cmd_list.CopyFrom(
+        std::move(upload_data),
+        resources.constants_buf->GetView()
+    );
+}
+
+void LightingPass::RecordDispatch(
+    CommandList&           cmd_list,
+    const PreparedCommand& command,
+    const RecordResources& resources,
+    ELightingDispatch      dispatch
+) {
+#define DI_BINDING_ARGS(ctx)                                                     \
+    ctx.tlas, ctx.prev_tlas, ctx.constants_buf, ctx.light_reservoir_buf,         \
+        ctx.diffuse_lighting, ctx.specular_lighting, ctx.temporal_sample_pos,    \
+        ctx.gradients, ctx.restir_luminance, ctx.prev_diffuse_lighting,          \
+        ctx.ris_buf, ctx.ris_light_data_buf, ctx.neighbor_offset_buf,            \
+        ctx.bindless_array
+
+    switch (dispatch) {
+        case ELightingDispatch::PresampleLight:
+            cmd_list.Compute(
+                        presample_light_pipeline,
+                        DI_BINDING_ARGS(resources)
+                    )
+                .Dispatch(
+                    command.presample_light_dispatch,
+                    "PresampleLight",
+                    ProfileSection("ReSTIR DI Presample Local")
+                );
+            break;
+        case ELightingDispatch::PresampleEnvMap:
+            cmd_list.Compute(
+                        presample_env_map_pipeline,
+                        DI_BINDING_ARGS(resources)
+                    )
+                .Dispatch(
+                    command.presample_env_dispatch,
+                    "PresampleEnvMap",
+                    ProfileSection("ReSTIR DI Presample Environment")
+                );
+            break;
+        case ELightingDispatch::PresampleLightGrid:
+            cmd_list.Compute(
+                        presample_light_grid_pipeline,
+                        DI_BINDING_ARGS(resources)
+                    )
+                .Dispatch(
+                    command.presample_grid_dispatch,
+                    "PresampleLightGrid",
+                    ProfileSection("ReSTIR DI Presample Grid")
+                );
+            break;
+        case ELightingDispatch::GenerateInitialSample:
+            cmd_list.Compute(
+                        generate_initial_sample_pipeline,
+                        DI_BINDING_ARGS(resources)
+                    )
+                .Dispatch(
+                    command.screen_dispatch,
+                    "GenerateInitialSample",
+                    ProfileSection("ReSTIR DI Initial")
+                );
+            break;
+        case ELightingDispatch::TemporalResample:
+            cmd_list.Compute(
+                        temporal_resample_pipeline,
+                        DI_BINDING_ARGS(resources)
+                    )
+                .Dispatch(
+                    command.screen_dispatch,
+                    "TemporalResample",
+                    ProfileSection("ReSTIR DI Temporal")
+                );
+            break;
+        case ELightingDispatch::SpatialResample:
+            cmd_list.Compute(
+                        spatial_resample_pipeline,
+                        DI_BINDING_ARGS(resources)
+                    )
+                .Dispatch(
+                    command.screen_dispatch,
+                    "SpatialResample",
+                    ProfileSection("ReSTIR DI Spatial")
+                );
+            break;
+        case ELightingDispatch::ShadeSample:
+            cmd_list.Compute(
+                        di_shade_sample_pipeline,
+                        DI_BINDING_ARGS(resources)
+                    )
+                .Dispatch(
+                    command.screen_dispatch,
+                    "ShadeSample",
+                    ProfileSection("ReSTIR DI Shade")
+                );
+            break;
     }
-
-    if (local_light_count && has_local_candidates && uses_grid) {
-        uint2 dispatch_size =
-            uint2(div_ceil(is_ctx.GetGridRuntimeConfig().num_light_slot, DI_PRESAMPLE_GRID_SIZE), 1);
-        _cmd_list.Compute(presample_light_grid_pipeline, arg_ref)
-            .Dispatch(
-                uint3(dispatch_size, 1),
-                "PresampleLightGrid",
-                ProfileSection("ReSTIR DI Presample Grid")
-            );
-    }
-
-    // 初始采样、时序复用、空间复用和着色均以屏幕 tile 为调度粒度。
-    {
-        uint2 dispatch_size = _rt_ctx.frame_rt.diffuse_lighting->GetExtent().xy;
-        dispatch_size.x     = div_ceil(dispatch_size.x, DI_SCREEN_TILE_SIZE);
-        dispatch_size.y     = div_ceil(dispatch_size.y, DI_SCREEN_TILE_SIZE);
-        _cmd_list.Compute(generate_initial_sample_pipeline, arg_ref)
-            .Dispatch(
-                uint3(dispatch_size, 1),
-                "GenerateInitialSample",
-                ProfileSection("ReSTIR DI Initial")
-            );
-
-        _cmd_list.Compute(temporal_resample_pipeline, arg_ref)
-            .Dispatch(
-                uint3(dispatch_size, 1),
-                "TemporalResample",
-                ProfileSection("ReSTIR DI Temporal")
-            );
-
-        _cmd_list.Compute(spatial_resample_pipeline, arg_ref)
-            .Dispatch(
-                uint3(dispatch_size, 1),
-                "SpatialResample",
-                ProfileSection("ReSTIR DI Spatial")
-            );
-
-        _cmd_list.Compute(di_shade_sample_pipeline, arg_ref)
-            .Dispatch(
-                uint3(dispatch_size, 1),
-                "ShadeSample",
-                ProfileSection("ReSTIR DI Shade")
-            );
-    }
-
-    _cmd_list.PopScopeWithTimeScope();
 #undef DI_BINDING_ARGS
-    return sampling_decision;
+}
+
+LightingPass::LocalLightSamplingDecision
+LightingPass::Process(CommandList& cmd_list, RTContext& rt_ctx) {
+    const PreparedCommand command   = Prepare(rt_ctx);
+    const RecordResources resources = CaptureResources(rt_ctx);
+
+    cmd_list.PushScopeWithTimeScope("LightingPass");
+    RecordConstantsUpload(cmd_list, command, resources);
+    if (command.record_presample_light) {
+        RecordDispatch(
+            cmd_list,
+            command,
+            resources,
+            ELightingDispatch::PresampleLight
+        );
+    }
+    if (command.record_presample_env) {
+        RecordDispatch(
+            cmd_list,
+            command,
+            resources,
+            ELightingDispatch::PresampleEnvMap
+        );
+    }
+    if (command.record_presample_grid) {
+        RecordDispatch(
+            cmd_list,
+            command,
+            resources,
+            ELightingDispatch::PresampleLightGrid
+        );
+    }
+    RecordDispatch(
+        cmd_list,
+        command,
+        resources,
+        ELightingDispatch::GenerateInitialSample
+    );
+    RecordDispatch(
+        cmd_list,
+        command,
+        resources,
+        ELightingDispatch::TemporalResample
+    );
+    RecordDispatch(
+        cmd_list,
+        command,
+        resources,
+        ELightingDispatch::SpatialResample
+    );
+    RecordDispatch(
+        cmd_list,
+        command,
+        resources,
+        ELightingDispatch::ShadeSample
+    );
+    cmd_list.PopScopeWithTimeScope();
+    return command.sampling_decision;
+}
+
+bool LightingPass::AddPasses(
+    RenderGraph&                 graph,
+    const RTGraphFrameResources& graph_resources,
+    const RTContext&             rt_ctx,
+    LocalLightSamplingDecision&  sampling_decision
+) {
+    const PreparedCommand command   = Prepare(rt_ctx);
+    const RecordResources resources = CaptureResources(rt_ctx);
+    const auto has_backing_buffer = [](const RaytracingTlasRef& tlas) {
+        return tlas && tlas->GetUnderlyingBuffer() != nullptr;
+    };
+    if (!has_backing_buffer(resources.tlas) ||
+        !has_backing_buffer(resources.prev_tlas) ||
+        !resources.constants_buf || !resources.light_reservoir_buf ||
+        !resources.ris_buf ||
+        !resources.ris_light_data_buf || !resources.neighbor_offset_buf ||
+        !resources.light_mapping_buf || !resources.light_data_buf ||
+        !resources.primitive_to_light_buf || !resources.diffuse_lighting ||
+        !resources.specular_lighting || !resources.temporal_sample_pos ||
+        !resources.gradients || !resources.restir_luminance ||
+        !resources.prev_diffuse_lighting || !resources.bindless_array ||
+        (command.record_presample_light && !resources.local_light_pdf) ||
+        (command.record_presample_env && !resources.env_pdf) ||
+        (command.constants.scene_params.enable_env_map != 0 &&
+         !resources.env_map)) {
+        return false;
+    }
+
+    const auto constants =
+        ImportRTGraphBuffer(
+            graph,
+            "RT.Lighting.constants",
+            resources.constants_buf
+        );
+    const BufferRef tlas_buffer(resources.tlas->GetUnderlyingBuffer());
+    const auto tlas =
+        ImportRTGraphBuffer(graph, "RT.Lighting.tlas", tlas_buffer);
+    RenderGraph::BufferHandle prev_tlas = tlas;
+    if (resources.prev_tlas.Get() != resources.tlas.Get()) {
+        const BufferRef prev_tlas_buffer(
+            resources.prev_tlas->GetUnderlyingBuffer()
+        );
+        prev_tlas = ImportRTGraphBuffer(
+            graph,
+            "RT.Lighting.prev_tlas",
+            prev_tlas_buffer
+        );
+    }
+    const auto light_reservoir = ImportRTGraphBuffer(
+        graph,
+        "RT.Lighting.light_reservoir",
+        resources.light_reservoir_buf
+    );
+    const auto ris =
+        ImportRTGraphBuffer(graph, "RT.Lighting.ris", resources.ris_buf);
+    const auto ris_light_data = ImportRTGraphBuffer(
+        graph,
+        "RT.Lighting.ris_light_data",
+        resources.ris_light_data_buf
+    );
+    const auto neighbor_offset = ImportRTGraphBuffer(
+        graph,
+        "RT.Lighting.neighbor_offset",
+        resources.neighbor_offset_buf
+    );
+    const auto light_mapping = ImportRTGraphBuffer(
+        graph,
+        "RT.Lighting.light_mapping",
+        resources.light_mapping_buf
+    );
+    const auto light_data = ImportRTGraphBuffer(
+        graph,
+        "RT.Lighting.light_data",
+        resources.light_data_buf
+    );
+    const auto primitive_to_light = ImportRTGraphBuffer(
+        graph,
+        "RT.Lighting.primitive_to_light",
+        resources.primitive_to_light_buf
+    );
+
+    RenderGraph::TextureHandle local_light_pdf{};
+    if (resources.local_light_pdf) {
+        local_light_pdf = ImportRTGraphTexture(
+            graph,
+            "RT.Lighting.local_light_pdf",
+            resources.local_light_pdf
+        );
+    }
+    RenderGraph::TextureHandle env_pdf{};
+    if (resources.env_pdf) {
+        env_pdf = ImportRTGraphTexture(
+            graph,
+            "RT.Lighting.env_pdf",
+            resources.env_pdf
+        );
+    }
+    RenderGraph::TextureHandle env_map{};
+    if (resources.env_map) {
+        env_map = ImportRTGraphTexture(
+            graph,
+            "RT.Lighting.env_map",
+            resources.env_map
+        );
+    }
+
+    graph.SetInitialState(
+        constants,
+        RenderGraph::BufferState::ShaderResource,
+        RenderGraph::QueueRole::Graphics,
+        RenderGraph::AccessMode::Read
+    );
+    if (prev_tlas != tlas) {
+        graph.SetInitialState(
+            prev_tlas,
+            RenderGraph::BufferState::AccelerationStructureRead,
+            RenderGraph::QueueRole::Graphics,
+            RenderGraph::AccessMode::Read
+        );
+    }
+    for (const auto texture : {
+             graph_resources.previous_view_depth,
+             graph_resources.previous_diffuse_albedo,
+             graph_resources.previous_specular_roughness,
+             graph_resources.previous_normal,
+             graph_resources.diffuse_lighting,
+             graph_resources.specular_lighting,
+         }) {
+        graph.SetInitialState(
+            texture,
+            RenderGraph::TextureState::ShaderResource,
+            RenderGraph::QueueRole::Graphics,
+            RenderGraph::AccessMode::Read
+        );
+    }
+    for (const auto buffer : {
+             light_reservoir,
+             ris,
+             ris_light_data,
+         }) {
+        graph.SetInitialState(
+            buffer,
+            RenderGraph::BufferState::UnorderedAccess,
+            RenderGraph::QueueRole::Graphics,
+            RenderGraph::AccessMode::ReadWrite
+        );
+    }
+    graph.SetInitialState(
+        neighbor_offset,
+        RenderGraph::BufferState::ShaderResource,
+        RenderGraph::QueueRole::Graphics,
+        RenderGraph::AccessMode::Read
+    );
+    for (const auto buffer : {
+             light_mapping,
+             light_data,
+             primitive_to_light,
+         }) {
+        graph.SetInitialState(
+            buffer,
+            RenderGraph::BufferState::UnorderedAccess,
+            RenderGraph::QueueRole::Graphics,
+            RenderGraph::AccessMode::Write
+        );
+    }
+    if (local_light_pdf.IsValid()) {
+        graph.SetInitialState(
+            local_light_pdf,
+            RenderGraph::TextureState::UnorderedAccess,
+            RenderGraph::QueueRole::Graphics,
+            RenderGraph::AccessMode::Write
+        );
+    }
+    if (env_pdf.IsValid()) {
+        graph.SetInitialState(
+            env_pdf,
+            RenderGraph::TextureState::ShaderResource,
+            RenderGraph::QueueRole::Graphics,
+            RenderGraph::AccessMode::Read
+        );
+    }
+    if (env_map.IsValid()) {
+        graph.SetInitialState(
+            env_map,
+            RenderGraph::TextureState::ShaderResource,
+            RenderGraph::QueueRole::Graphics,
+            RenderGraph::AccessMode::Read
+        );
+    }
+
+    graph.AddRecordPass(
+        "RT.Lighting.UploadConstants",
+        [=](RenderGraph::PassBuilder& builder) {
+            builder.ExecuteOn(
+                       RenderGraph::QueueRole::Graphics,
+                       RenderGraph::PipelineType::Copy
+                   )
+                .Write(constants, RenderGraph::BufferState::TransferDestination);
+        },
+        [this, command, resources](CommandList& cmd_list) {
+            ScopedGpuMarker marker(
+                cmd_list,
+                "Pass: RT Lighting Constants Upload",
+                GpuMarkerPalette::Transfer()
+            );
+            RecordConstantsUpload(cmd_list, command, resources);
+        },
+        RenderGraph::PassExecutionClass::ParallelRecordEligible
+    );
+
+    const auto add_dispatch =
+        [&](std::string_view name, ELightingDispatch dispatch) {
+            graph.AddRecordPass(
+                name,
+                [=](RenderGraph::PassBuilder& builder) {
+                    builder
+                        .ExecuteOn(
+                            RenderGraph::QueueRole::Graphics,
+                            RenderGraph::PipelineType::Compute
+                        )
+                        .Read(
+                            constants,
+                            RenderGraph::BufferState::ShaderResource
+                        )
+                        .Read(
+                            tlas,
+                            RenderGraph::BufferState::AccelerationStructureRead
+                        )
+                        .Read(
+                            prev_tlas,
+                            RenderGraph::BufferState::AccelerationStructureRead
+                        )
+                        .ReadWrite(
+                            light_reservoir,
+                            RenderGraph::BufferState::UnorderedAccess
+                        )
+                        .ReadWrite(
+                            ris,
+                            RenderGraph::BufferState::UnorderedAccess
+                        )
+                        .ReadWrite(
+                            ris_light_data,
+                            RenderGraph::BufferState::UnorderedAccess
+                        )
+                        .Read(
+                            neighbor_offset,
+                            RenderGraph::BufferState::ShaderResource
+                        )
+                        .Read(
+                            light_mapping,
+                            RenderGraph::BufferState::ShaderResource
+                        )
+                        .Read(
+                            light_data,
+                            RenderGraph::BufferState::ShaderResource
+                        )
+                        .Read(
+                            primitive_to_light,
+                            RenderGraph::BufferState::ShaderResource
+                        )
+                        .ReadWrite(
+                            graph_resources.diffuse_lighting,
+                            RenderGraph::TextureState::UnorderedAccess
+                        )
+                        .ReadWrite(
+                            graph_resources.specular_lighting,
+                            RenderGraph::TextureState::UnorderedAccess
+                        )
+                        .Read(
+                            graph_resources.current_view_depth,
+                            RenderGraph::TextureState::Sampled
+                        )
+                        .Read(
+                            graph_resources.current_diffuse_albedo,
+                            RenderGraph::TextureState::Sampled
+                        )
+                        .Read(
+                            graph_resources.current_specular_roughness,
+                            RenderGraph::TextureState::Sampled
+                        )
+                        .Read(
+                            graph_resources.current_normal,
+                            RenderGraph::TextureState::Sampled
+                        )
+                        .Read(
+                            graph_resources.previous_view_depth,
+                            RenderGraph::TextureState::Sampled
+                        )
+                        .Read(
+                            graph_resources.previous_diffuse_albedo,
+                            RenderGraph::TextureState::Sampled
+                        )
+                        .Read(
+                            graph_resources.previous_specular_roughness,
+                            RenderGraph::TextureState::Sampled
+                        )
+                        .Read(
+                            graph_resources.previous_normal,
+                            RenderGraph::TextureState::Sampled
+                        )
+                        .Read(
+                            graph_resources.motion,
+                            RenderGraph::TextureState::Sampled
+                        );
+                    if (local_light_pdf.IsValid()) {
+                        builder.Read(
+                            local_light_pdf,
+                            RenderGraph::TextureState::Sampled
+                        );
+                    }
+                    if (env_pdf.IsValid()) {
+                        builder.Read(
+                            env_pdf,
+                            RenderGraph::TextureState::Sampled
+                        );
+                    }
+                    if (env_map.IsValid()) {
+                        builder.Read(
+                            env_map,
+                            RenderGraph::TextureState::Sampled
+                        );
+                    }
+                },
+                [this, command, resources, dispatch](CommandList& cmd_list) {
+                    RecordDispatch(
+                        cmd_list,
+                        command,
+                        resources,
+                        dispatch
+                    );
+                },
+                RenderGraph::PassExecutionClass::ParallelRecordEligible
+            );
+        };
+
+    if (command.record_presample_light) {
+        add_dispatch(
+            "RT.Lighting.PresampleLight",
+            ELightingDispatch::PresampleLight
+        );
+    }
+    if (command.record_presample_env) {
+        add_dispatch(
+            "RT.Lighting.PresampleEnvMap",
+            ELightingDispatch::PresampleEnvMap
+        );
+    }
+    if (command.record_presample_grid) {
+        add_dispatch(
+            "RT.Lighting.PresampleLightGrid",
+            ELightingDispatch::PresampleLightGrid
+        );
+    }
+    add_dispatch(
+        "RT.Lighting.GenerateInitialSample",
+        ELightingDispatch::GenerateInitialSample
+    );
+    add_dispatch(
+        "RT.Lighting.TemporalResample",
+        ELightingDispatch::TemporalResample
+    );
+    add_dispatch(
+        "RT.Lighting.SpatialResample",
+        ELightingDispatch::SpatialResample
+    );
+    add_dispatch(
+        "RT.Lighting.ShadeSample",
+        ELightingDispatch::ShadeSample
+    );
+
+    const auto export_texture =
+        [&](RenderGraph::TextureHandle texture,
+            RenderGraph::TextureState  state,
+            RenderGraph::AccessMode    access) {
+            graph.Export(
+                texture,
+                state,
+                RenderGraph::QueueRole::Graphics,
+                access
+            );
+        };
+    for (const auto texture : {
+             graph_resources.previous_view_depth,
+             graph_resources.previous_diffuse_albedo,
+             graph_resources.previous_specular_roughness,
+             graph_resources.previous_normal,
+             graph_resources.diffuse_lighting,
+             graph_resources.specular_lighting,
+         }) {
+        export_texture(
+            texture,
+            RenderGraph::TextureState::ShaderResource,
+            RenderGraph::AccessMode::Read
+        );
+    }
+    if (local_light_pdf.IsValid()) {
+        export_texture(
+            local_light_pdf,
+            RenderGraph::TextureState::ShaderResource,
+            RenderGraph::AccessMode::Read
+        );
+    }
+    if (env_pdf.IsValid()) {
+        export_texture(
+            env_pdf,
+            RenderGraph::TextureState::ShaderResource,
+            RenderGraph::AccessMode::Read
+        );
+    }
+    if (env_map.IsValid()) {
+        export_texture(
+            env_map,
+            RenderGraph::TextureState::ShaderResource,
+            RenderGraph::AccessMode::Read
+        );
+    }
+
+    graph.Export(
+        constants,
+        RenderGraph::BufferState::ShaderResource,
+        RenderGraph::QueueRole::Graphics,
+        RenderGraph::AccessMode::Read
+    );
+    if (prev_tlas != tlas) {
+        graph.Export(
+            prev_tlas,
+            RenderGraph::BufferState::AccelerationStructureRead,
+            RenderGraph::QueueRole::Graphics,
+            RenderGraph::AccessMode::Read
+        );
+    }
+    for (const auto buffer : {
+             light_reservoir,
+             ris,
+             ris_light_data,
+         }) {
+        graph.Export(
+            buffer,
+            RenderGraph::BufferState::UnorderedAccess,
+            RenderGraph::QueueRole::Graphics,
+            RenderGraph::AccessMode::ReadWrite
+        );
+    }
+    for (const auto buffer : {
+             neighbor_offset,
+             light_mapping,
+             light_data,
+             primitive_to_light,
+         }) {
+        graph.Export(
+            buffer,
+            RenderGraph::BufferState::ShaderResource,
+            RenderGraph::QueueRole::Graphics,
+            RenderGraph::AccessMode::Read
+        );
+    }
+
+    sampling_decision = command.sampling_decision;
+    return true;
 }
 
 } // namespace Moer::Render::Raytracing

--- a/source/runtime/render/renderer/raytracing/LightingPass.h
+++ b/source/runtime/render/renderer/raytracing/LightingPass.h
@@ -3,7 +3,7 @@
 
 // ReSTIR DI 预采样、时序/空间复用以及最终样本着色。
 
-#include "RTResource.h"
+#include "RaytracingGraphResources.h"
 #include "rhi/RHI.h"
 #include "shader/ShaderPipeline.h"
 
@@ -100,15 +100,80 @@ public:
         uint local_light_count          = 0;
     };
 
+    struct PreparedCommand {
+        ResampleConstants           constants{};
+        LocalLightSamplingDecision sampling_decision{};
+        bool                       record_presample_light = false;
+        bool                       record_presample_env   = false;
+        bool                       record_presample_grid  = false;
+        uint3                      presample_light_dispatch{};
+        uint3                      presample_env_dispatch{};
+        uint3                      presample_grid_dispatch{};
+        uint3                      screen_dispatch{};
+    };
+
+    struct RecordResources {
+        RaytracingTlasRef tlas{};
+        RaytracingTlasRef prev_tlas{};
+
+        BufferRef constants_buf{};
+        BufferRef light_reservoir_buf{};
+        BufferRef ris_buf{};
+        BufferRef ris_light_data_buf{};
+        BufferRef neighbor_offset_buf{};
+        BufferRef light_mapping_buf{};
+        BufferRef light_data_buf{};
+        BufferRef primitive_to_light_buf{};
+
+        TextureRef diffuse_lighting{};
+        TextureRef specular_lighting{};
+        TextureRef temporal_sample_pos{};
+        TextureRef gradients{};
+        TextureRef restir_luminance{};
+        TextureRef prev_diffuse_lighting{};
+        TextureRef local_light_pdf{};
+        TextureRef env_pdf{};
+        TextureRef env_map{};
+
+        BindlessArrayRef bindless_array{};
+    };
+
     LightingPass(class ShaderManager& manager, BindlessArrayRef bindless_array);
 
     LocalLightSamplingDecision Process(CommandList& cmd_list, RTContext& rt_ctx);
+    bool AddPasses(
+        RenderGraph&                 graph,
+        const RTGraphFrameResources& graph_resources,
+        const RTContext&             rt_ctx,
+        LocalLightSamplingDecision&  sampling_decision
+    );
 
 private:
-    BindlessArrayRef bindless_array;
+    enum class ELightingDispatch : uint8_t {
+        PresampleLight,
+        PresampleEnvMap,
+        PresampleLightGrid,
+        GenerateInitialSample,
+        TemporalResample,
+        SpatialResample,
+        ShadeSample
+    };
 
-    ResampleConstants constants;
-    Array<byte>       upload_data;
+    PreparedCommand Prepare(const RTContext& rt_ctx) const;
+    RecordResources CaptureResources(const RTContext& rt_ctx) const;
+    void RecordConstantsUpload(
+        CommandList&           cmd_list,
+        const PreparedCommand& command,
+        const RecordResources& resources
+    ) const;
+    void RecordDispatch(
+        CommandList&           cmd_list,
+        const PreparedCommand& command,
+        const RecordResources& resources,
+        ELightingDispatch      dispatch
+    );
+
+    BindlessArrayRef bindless_array;
 
     PresampleLightPipeline        presample_light_pipeline;
     PresampleEnvMapPipeline       presample_env_map_pipeline;

--- a/source/runtime/render/renderer/raytracing/RTResource.cpp
+++ b/source/runtime/render/renderer/raytracing/RTResource.cpp
@@ -285,7 +285,8 @@ void RTContext::FillLowDiscrepancySequence(CommandList& _cmd_list) {
 
 void RTContext::CreateEnvMapResources(TextureWithHandle _env_tex, CommandList& _cmd_list) {
 
-    uint2         extent = _env_tex.tex->GetExtent().xy;
+    env_map = _env_tex.tex;
+    uint2         extent = env_map->GetExtent().xy;
     RenderDevice& device = RenderDevice::Get();
 
     // env_pdf_tex 需要完整的 mip 链（SamplePdfMip 从最高 mip 向下采样），
@@ -304,7 +305,7 @@ void RTContext::CreateEnvMapResources(TextureWithHandle _env_tex, CommandList& _
     for (int i = 0; i < env_pdf_tex->GetNumMips(); ++i) {
         env_pdf_mips.push_back(env_pdf_tex->GetView(i));
     }
-    sd_utils.GenerateMipPdf(_cmd_list, _env_tex.tex, env_pdf_mips);
+    sd_utils.GenerateMipPdf(_cmd_list, env_map, env_pdf_mips);
 
     AllocateAndFreeBdlsIfNeeded(
         bindless_handles.env_pdf,

--- a/source/runtime/render/renderer/raytracing/RTResource.h
+++ b/source/runtime/render/renderer/raytracing/RTResource.h
@@ -22,6 +22,16 @@
 
 namespace Moer::Render::Raytracing {
 
+inline constexpr bool IsNrdDenoiserActive(uint denoiser_mode) {
+#if WITH_NRD
+    return denoiser_mode == s_denoiser_mode_reblur ||
+           denoiser_mode == s_denoiser_mode_relax;
+#else
+    (void)denoiser_mode;
+    return false;
+#endif
+}
+
 struct FrameResources {
     TextureRef view_depth;
     TextureRef diffuse_albedo;

--- a/source/runtime/render/renderer/raytracing/RaytracingGraphResources.h
+++ b/source/runtime/render/renderer/raytracing/RaytracingGraphResources.h
@@ -27,6 +27,7 @@ struct RTGraphFrameResources {
     RenderGraph::TextureHandle specular_lighting{};
     RenderGraph::TextureHandle hdr_color{};
     RenderGraph::TextureHandle resolved_color{};
+    RenderGraph::TextureHandle ldr_color{};
     RenderGraph::TextureHandle feedback_color_ping{};
     RenderGraph::TextureHandle feedback_color_pong{};
     RenderGraph::TextureHandle env_map{};
@@ -118,6 +119,8 @@ inline RTGraphFrameResources RegisterRTGraphFrameResources(
             ImportRTGraphTexture(graph, "RT.hdr_color", frame.hdr_color),
         .resolved_color =
             ImportRTGraphTexture(graph, "RT.resolved_color", frame.resolved_color),
+        .ldr_color =
+            ImportRTGraphTexture(graph, "RT.ldr_color", frame.ldr_color),
         .feedback_color_ping = ImportRTGraphTexture(
             graph,
             "RT.feedback_color_ping",

--- a/source/runtime/render/renderer/raytracing/RaytracingGraphResources.h
+++ b/source/runtime/render/renderer/raytracing/RaytracingGraphResources.h
@@ -28,6 +28,7 @@ struct RTGraphFrameResources {
     RenderGraph::TextureHandle hdr_color{};
     RenderGraph::TextureHandle resolved_color{};
     RenderGraph::TextureHandle ldr_color{};
+    RenderGraph::TextureHandle debug_color{};
     RenderGraph::TextureHandle feedback_color_ping{};
     RenderGraph::TextureHandle feedback_color_pong{};
     RenderGraph::TextureHandle env_map{};
@@ -121,6 +122,8 @@ inline RTGraphFrameResources RegisterRTGraphFrameResources(
             ImportRTGraphTexture(graph, "RT.resolved_color", frame.resolved_color),
         .ldr_color =
             ImportRTGraphTexture(graph, "RT.ldr_color", frame.ldr_color),
+        .debug_color =
+            ImportRTGraphTexture(graph, "RT.debug_color", frame.debug_color),
         .feedback_color_ping = ImportRTGraphTexture(
             graph,
             "RT.feedback_color_ping",

--- a/source/runtime/render/renderer/raytracing/RaytracingGraphResources.h
+++ b/source/runtime/render/renderer/raytracing/RaytracingGraphResources.h
@@ -25,6 +25,8 @@ struct RTGraphFrameResources {
     RenderGraph::TextureHandle normal_roughness{};
     RenderGraph::TextureHandle diffuse_lighting{};
     RenderGraph::TextureHandle specular_lighting{};
+    RenderGraph::TextureHandle hdr_color{};
+    RenderGraph::TextureHandle env_map{};
 
     RenderGraph::TextureHandle current_view_depth{};
     RenderGraph::TextureHandle current_diffuse_albedo{};
@@ -108,8 +110,13 @@ inline RTGraphFrameResources RegisterRTGraphFrameResources(
         .diffuse_lighting =
             ImportRTGraphTexture(graph, "RT.diffuse_lighting", frame.diffuse_lighting),
         .specular_lighting =
-            ImportRTGraphTexture(graph, "RT.specular_lighting", frame.specular_lighting)
+            ImportRTGraphTexture(graph, "RT.specular_lighting", frame.specular_lighting),
+        .hdr_color = ImportRTGraphTexture(graph, "RT.hdr_color", frame.hdr_color)
     };
+    if (rt_ctx.env_map) {
+        resources.env_map =
+            ImportRTGraphTexture(graph, "RT.env_map", rt_ctx.env_map);
+    }
 
     resources.current_view_depth = resources.current_frame ? resources.view_depth :
                                                              resources.prev_view_depth;

--- a/source/runtime/render/renderer/raytracing/RaytracingGraphResources.h
+++ b/source/runtime/render/renderer/raytracing/RaytracingGraphResources.h
@@ -1,0 +1,128 @@
+#pragma once
+
+#include "RTResource.h"
+#include "rendergraph/RenderGraph.h"
+
+#include <cassert>
+
+namespace Moer::Render::Raytracing {
+
+struct RTGraphFrameResources {
+    bool current_frame{};
+
+    RenderGraph::TextureHandle view_depth{};
+    RenderGraph::TextureHandle diffuse_albedo{};
+    RenderGraph::TextureHandle specular_roughness{};
+    RenderGraph::TextureHandle normal{};
+    RenderGraph::TextureHandle prev_view_depth{};
+    RenderGraph::TextureHandle prev_diffuse_albedo{};
+    RenderGraph::TextureHandle prev_specular_roughness{};
+    RenderGraph::TextureHandle prev_normal{};
+
+    RenderGraph::TextureHandle emission{};
+    RenderGraph::TextureHandle motion{};
+    RenderGraph::TextureHandle clip_depth{};
+    RenderGraph::TextureHandle normal_roughness{};
+
+    RenderGraph::TextureHandle current_view_depth{};
+    RenderGraph::TextureHandle current_diffuse_albedo{};
+    RenderGraph::TextureHandle current_specular_roughness{};
+    RenderGraph::TextureHandle current_normal{};
+    RenderGraph::TextureHandle previous_view_depth{};
+    RenderGraph::TextureHandle previous_diffuse_albedo{};
+    RenderGraph::TextureHandle previous_specular_roughness{};
+    RenderGraph::TextureHandle previous_normal{};
+};
+
+inline RenderGraph::TextureAspect RTGraphTextureAspects(const TextureRef& texture) {
+    assert(texture);
+    RenderGraph::TextureAspect aspects = RenderGraph::TextureAspect::None;
+    const auto rhi_aspects = texture->GetAspectFlags();
+    if (uint32_t(rhi_aspects & ETextureAspectFlags::COLOR) != 0) {
+        aspects = aspects | RenderGraph::TextureAspect::Color;
+    }
+    if (uint32_t(rhi_aspects & ETextureAspectFlags::DEPTH_SLICE) != 0) {
+        aspects = aspects | RenderGraph::TextureAspect::Depth;
+    }
+    if (uint32_t(rhi_aspects & ETextureAspectFlags::STENCIL_SLICE) != 0) {
+        aspects = aspects | RenderGraph::TextureAspect::Stencil;
+    }
+    assert(aspects != RenderGraph::TextureAspect::None);
+    return aspects;
+}
+
+inline RenderGraph::TextureHandle ImportRTGraphTexture(
+    RenderGraph&      graph,
+    std::string_view  name,
+    const TextureRef& texture
+) {
+    assert(texture);
+    return graph.ImportTexture(
+        name,
+        texture,
+        RenderGraph::TextureDesc{
+            .mip_count   = texture->GetNumMips(),
+            .layer_count = texture->GetNumArray(),
+            .aspects     = RTGraphTextureAspects(texture)
+        }
+    );
+}
+
+inline RenderGraph::BufferHandle ImportRTGraphBuffer(
+    RenderGraph&     graph,
+    std::string_view name,
+    const BufferRef& buffer
+) {
+    assert(buffer);
+    return graph.ImportBuffer(
+        name,
+        buffer,
+        RenderGraph::BufferDesc{.byte_size = buffer->GetByteSize()}
+    );
+}
+
+inline RTGraphFrameResources RegisterRTGraphFrameResources(
+    RenderGraph&     graph,
+    const RTContext& rt_ctx
+) {
+    const FrameResources& frame = rt_ctx.frame_rt;
+    RTGraphFrameResources resources{
+        .current_frame      = rt_ctx.b_current_frame,
+        .view_depth         = ImportRTGraphTexture(graph, "RT.view_depth", frame.view_depth),
+        .diffuse_albedo     = ImportRTGraphTexture(graph, "RT.diffuse_albedo", frame.diffuse_albedo),
+        .specular_roughness =
+            ImportRTGraphTexture(graph, "RT.specular_roughness", frame.specular_roughness),
+        .normal                 = ImportRTGraphTexture(graph, "RT.normal", frame.normal),
+        .prev_view_depth        = ImportRTGraphTexture(graph, "RT.prev_view_depth", frame.prev_view_depth),
+        .prev_diffuse_albedo    =
+            ImportRTGraphTexture(graph, "RT.prev_diffuse_albedo", frame.prev_diffuse_albedo),
+        .prev_specular_roughness =
+            ImportRTGraphTexture(graph, "RT.prev_specular_roughness", frame.prev_specular_roughness),
+        .prev_normal      = ImportRTGraphTexture(graph, "RT.prev_normal", frame.prev_normal),
+        .emission         = ImportRTGraphTexture(graph, "RT.emission", frame.emission),
+        .motion           = ImportRTGraphTexture(graph, "RT.motion", frame.motion),
+        .clip_depth       = ImportRTGraphTexture(graph, "RT.clip_depth", frame.clip_depth),
+        .normal_roughness = ImportRTGraphTexture(graph, "RT.normal_roughness", frame.normal_roughness)
+    };
+
+    resources.current_view_depth = resources.current_frame ? resources.view_depth :
+                                                             resources.prev_view_depth;
+    resources.current_diffuse_albedo = resources.current_frame ? resources.diffuse_albedo :
+                                                                resources.prev_diffuse_albedo;
+    resources.current_specular_roughness =
+        resources.current_frame ? resources.specular_roughness :
+                                  resources.prev_specular_roughness;
+    resources.current_normal = resources.current_frame ? resources.normal : resources.prev_normal;
+
+    resources.previous_view_depth = resources.current_frame ? resources.prev_view_depth :
+                                                              resources.view_depth;
+    resources.previous_diffuse_albedo = resources.current_frame ? resources.prev_diffuse_albedo :
+                                                                 resources.diffuse_albedo;
+    resources.previous_specular_roughness =
+        resources.current_frame ? resources.prev_specular_roughness :
+                                  resources.specular_roughness;
+    resources.previous_normal = resources.current_frame ? resources.prev_normal : resources.normal;
+    return resources;
+}
+
+} // namespace Moer::Render::Raytracing

--- a/source/runtime/render/renderer/raytracing/RaytracingGraphResources.h
+++ b/source/runtime/render/renderer/raytracing/RaytracingGraphResources.h
@@ -23,6 +23,8 @@ struct RTGraphFrameResources {
     RenderGraph::TextureHandle motion{};
     RenderGraph::TextureHandle clip_depth{};
     RenderGraph::TextureHandle normal_roughness{};
+    RenderGraph::TextureHandle diffuse_lighting{};
+    RenderGraph::TextureHandle specular_lighting{};
 
     RenderGraph::TextureHandle current_view_depth{};
     RenderGraph::TextureHandle current_diffuse_albedo{};
@@ -102,7 +104,11 @@ inline RTGraphFrameResources RegisterRTGraphFrameResources(
         .emission         = ImportRTGraphTexture(graph, "RT.emission", frame.emission),
         .motion           = ImportRTGraphTexture(graph, "RT.motion", frame.motion),
         .clip_depth       = ImportRTGraphTexture(graph, "RT.clip_depth", frame.clip_depth),
-        .normal_roughness = ImportRTGraphTexture(graph, "RT.normal_roughness", frame.normal_roughness)
+        .normal_roughness = ImportRTGraphTexture(graph, "RT.normal_roughness", frame.normal_roughness),
+        .diffuse_lighting =
+            ImportRTGraphTexture(graph, "RT.diffuse_lighting", frame.diffuse_lighting),
+        .specular_lighting =
+            ImportRTGraphTexture(graph, "RT.specular_lighting", frame.specular_lighting)
     };
 
     resources.current_view_depth = resources.current_frame ? resources.view_depth :

--- a/source/runtime/render/renderer/raytracing/RaytracingGraphResources.h
+++ b/source/runtime/render/renderer/raytracing/RaytracingGraphResources.h
@@ -26,6 +26,9 @@ struct RTGraphFrameResources {
     RenderGraph::TextureHandle diffuse_lighting{};
     RenderGraph::TextureHandle specular_lighting{};
     RenderGraph::TextureHandle hdr_color{};
+    RenderGraph::TextureHandle resolved_color{};
+    RenderGraph::TextureHandle feedback_color_ping{};
+    RenderGraph::TextureHandle feedback_color_pong{};
     RenderGraph::TextureHandle env_map{};
 
     RenderGraph::TextureHandle current_view_depth{};
@@ -111,7 +114,20 @@ inline RTGraphFrameResources RegisterRTGraphFrameResources(
             ImportRTGraphTexture(graph, "RT.diffuse_lighting", frame.diffuse_lighting),
         .specular_lighting =
             ImportRTGraphTexture(graph, "RT.specular_lighting", frame.specular_lighting),
-        .hdr_color = ImportRTGraphTexture(graph, "RT.hdr_color", frame.hdr_color)
+        .hdr_color =
+            ImportRTGraphTexture(graph, "RT.hdr_color", frame.hdr_color),
+        .resolved_color =
+            ImportRTGraphTexture(graph, "RT.resolved_color", frame.resolved_color),
+        .feedback_color_ping = ImportRTGraphTexture(
+            graph,
+            "RT.feedback_color_ping",
+            frame.feedback_color_ping
+        ),
+        .feedback_color_pong = ImportRTGraphTexture(
+            graph,
+            "RT.feedback_color_pong",
+            frame.feedback_color_pong
+        )
     };
     if (rt_ctx.env_map) {
         resources.env_map =

--- a/source/runtime/render/renderer/raytracing/RaytracingRenderer.cpp
+++ b/source/runtime/render/renderer/raytracing/RaytracingRenderer.cpp
@@ -36,6 +36,7 @@
 #include <limits>
 #include <new>
 #include <sstream>
+#include <stdexcept>
 #include <thread>
 
 namespace Moer::Render::Raytracing {
@@ -85,6 +86,14 @@ bool IsLegacyTlasUpdateEnabled() {
 bool IsLightGridForced() {
     static const bool enabled = []() {
         const char* value = std::getenv("MOER_RT_FORCE_LIGHT_GRID");
+        return value && value[0] != '\0' && std::string_view(value) != "0";
+    }();
+    return enabled;
+}
+
+bool IsRenderGraphRecordingFailureInjected() {
+    static const bool enabled = []() {
+        const char* value = std::getenv("MOER_RT_RDG_RECORDING_FAIL");
         return value && value[0] != '\0' && std::string_view(value) != "0";
     }();
     return enabled;
@@ -224,6 +233,7 @@ struct RaytracingRenderer::RuntimeState {
     bool                         render_graph_debug_dump              = false;
     bool                         render_graph_parallel_recording      = false;
     bool                         render_graph_fallback_latched        = false;
+    bool                         render_graph_recording_failure_latched = false;
     uint8                        gbuffer_initialized_history_mask     = 0;
     bool                         normal_roughness_readable            = false;
     std::array<const Buffer*, 3> lighting_working_set{};
@@ -537,6 +547,7 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
     bool graph_tone_mapping_recorded        = false;
     bool graph_visualize_recorded           = false;
     bool graph_show_texture_recorded         = false;
+    bool graph_recording_failed              = state.render_graph_recording_failure_latched;
     bool linear_gbuffer_recorded            = false;
     bool linear_lighting_recorded           = false;
     bool linear_antialias_recorded           = false;
@@ -926,9 +937,35 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
                      selected_debug_texture,
                      state.rt_ctx->frame_rt.ldr_color
                  ));
-            if (!gbuffer_added || !lighting_added || !composition_added ||
-                !antialias_added || !tone_mapping_added || !visualize_added ||
-                !show_texture_added) {
+            const bool graph_passes_added =
+                gbuffer_added && lighting_added && composition_added &&
+                antialias_added && tone_mapping_added && visualize_added &&
+                show_texture_added;
+            if (graph_passes_added && IsRenderGraphRecordingFailureInjected()) {
+                graph.AddRecordPass(
+                    "RT.FaultInjection.RecordingFailure",
+                    [](RenderGraph::PassBuilder& builder) {
+                        builder
+                            .ExecuteOn(
+                                RenderGraph::QueueRole::Graphics,
+                                RenderGraph::PipelineType::Compute
+                            )
+                            .SideEffect();
+                    },
+                    [](CommandList&) {
+                        throw std::runtime_error(
+                            "MOER_RT_RDG_RECORDING_FAIL requested a synthetic "
+                            "managed-record failure"
+                        );
+                    },
+                    RenderGraph::PassExecutionClass::ParallelRecordEligible
+                );
+                LOG_WARNING(
+                    "[RenderGraph][Injection] Raytracing managed-record failure "
+                    "armed by MOER_RT_RDG_RECORDING_FAIL."
+                );
+            }
+            if (!graph_passes_added) {
                 state.render_graph_fallback_latched = true;
                 LOG_ERROR(
                     "[RenderGraph][Fallback] Raytracing primary graph could not "
@@ -952,9 +989,12 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
                     }
                 }
 
-                // The caller-owned prefix and managed graph command lists are
-                // distinct submissions. Close every scope before sealing the
-                // prefix; the frame tail will finish the profiling transaction.
+                // The existing single-queue success path intentionally keeps
+                // Prefix as a normal ordered submit. If managed recording later
+                // fails, no dependent renderer pass is recorded or submitted:
+                // the renderer presents its last accepted output until it is
+                // recreated, so the accepted Prefix has no same-frame legacy
+                // consumer that would require a missing visibility bridge.
                 renderer_marker.Close();
                 if (!cmd_list.IsEmpty()) {
                     CmdSubmit prefix_submit =
@@ -978,6 +1018,8 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
                     );
                 }
 
+                bool graph_recording_profiling_started =
+                    split_graph_profiling_frame;
                 const auto configure_recording_source =
                     [&](const RenderGraph::ExecutedPassInfo& pass,
                         RHIRecordingSource&                  source) {
@@ -989,10 +1031,10 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
                         source.submit_metadata.debug_label_color =
                             GpuMarkerPalette::Pass();
                         source.submit_metadata.profiling_phase =
-                            split_graph_profiling_frame ?
+                            graph_recording_profiling_started ?
                                 ERHIProfilingPhase::Continue :
                                 ERHIProfilingPhase::Begin;
-                        split_graph_profiling_frame = true;
+                        graph_recording_profiling_started = true;
                     };
                 if (graph.ExecuteRecording(
                         {},
@@ -1001,6 +1043,8 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
                         {},
                         RenderGraph::ActiveRecordingOptions{.enabled = true}
                     )) {
+                    split_graph_profiling_frame =
+                        graph_recording_profiling_started;
                     graph_primary_recorded     = true;
                     graph_composition_recorded = composition_in_graph;
                     graph_antialias_recorded   = antialias_in_graph;
@@ -1010,18 +1054,26 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
                     graph_show_texture_recorded =
                         show_texture_in_graph;
                 } else {
+                    // ExecuteRecording joins every producer and fails the
+                    // graph-wide commit gate. Sync only joins the resulting
+                    // rejection cleanup and the already accepted Prefix; it is
+                    // not used as a resource-state substitute.
+                    RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
+                    graph_recording_failed = true;
                     state.render_graph_fallback_latched = true;
+                    state.render_graph_recording_failure_latched = true;
                     LOG_ERROR(
                         "[RenderGraph][Fallback] Raytracing primary graph "
                         "recording failed before transaction commit: {}. "
-                        "Re-recording its managed passes linearly this frame and "
-                        "using the linear path from the next frame.",
+                        "Preserving the last accepted output and disabling "
+                        "managed renderer passes until this renderer instance "
+                        "is recreated.",
                         graph.GetCompileError()
                     );
                 }
             }
         }
-        if (!graph_primary_recorded) {
+        if (!graph_recording_failed && !graph_primary_recorded) {
             ScopedGpuMarker pass_marker(
                 cmd_list, "Pass: GBuffer", GpuMarkerPalette::Pass()
             );
@@ -1035,7 +1087,7 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
             local_light_sampling =
                 state.lighting_pass->Process(cmd_list, *state.rt_ctx);
             linear_lighting_recorded = true;
-        } else {
+        } else if (graph_primary_recorded) {
             state.g_buffer_pass->RecordLegacyTailBridge(
                 cmd_list,
                 *state.rt_ctx,
@@ -1052,7 +1104,7 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
         feedback.local_light_count = local_light_sampling.local_light_count;
 
 #if WITH_NRD
-        {
+        if (!graph_recording_failed) {
             const bool    b_current_frame = state.rt_ctx->b_current_frame;
             const auto&   frame_rt        = state.rt_ctx->frame_rt;
             nrd::Denoiser denoiser        = nrd::Denoiser::MAX_NUM;
@@ -1105,13 +1157,13 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
         }
 #endif
 
-        if (!graph_composition_recorded) {
+        if (!graph_recording_failed && !graph_composition_recorded) {
             ScopedGpuMarker pass_marker(
                 cmd_list, "Pass: Composition", GpuMarkerPalette::Pass()
             );
             state.composition_pass->Process(cmd_list, *state.rt_ctx);
         }
-        if (!graph_antialias_recorded) {
+        if (!graph_recording_failed && !graph_antialias_recorded) {
             ScopedGpuMarker pass_marker(
                 cmd_list, "Pass: Anti Aliasing", GpuMarkerPalette::Pass()
             );
@@ -1124,7 +1176,7 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
             );
             linear_antialias_recorded = true;
         }
-        if (!graph_tone_mapping_recorded) {
+        if (!graph_recording_failed && !graph_tone_mapping_recorded) {
             ScopedGpuMarker pass_marker(
                 cmd_list, "Pass: Tone Mapping", GpuMarkerPalette::Pass()
             );
@@ -1136,7 +1188,7 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
             );
             linear_tone_mapping_recorded = true;
         }
-        if (!graph_visualize_recorded) {
+        if (!graph_recording_failed && !graph_visualize_recorded) {
             ScopedGpuMarker pass_marker(
                 cmd_list, "Pass: Visualize", GpuMarkerPalette::Pass()
             );
@@ -1146,7 +1198,8 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
             linear_visualize_recorded = true;
         }
 
-        if (show_texture_requested && !graph_show_texture_recorded) {
+        if (!graph_recording_failed && show_texture_requested &&
+            !graph_show_texture_recorded) {
             ScopedGpuMarker debug_texture_marker(
                 cmd_list, "Pass: Debug Texture", GpuMarkerPalette::Pass()
             );
@@ -1158,7 +1211,9 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
             );
         }
 
-        state.rt_ctx->AdvanceFrame();
+        if (!graph_recording_failed) {
+            state.rt_ctx->AdvanceFrame();
+        }
 
         if (state.b_export) {
             renderer_marker.Close();
@@ -1527,6 +1582,16 @@ void RaytracingRenderer::RecreateFrameResources(uint2 new_extent) {
         PF_R8G8B8A8_SRGB,
         ETextureUsageFlags::COLOR_ATTACHMENT | ETextureUsageFlags::SAMPLED
     );
+
+    if (state.render_graph_recording_failure_latched) {
+        LOG_WARNING(
+            "[RenderGraph][Fallback] Resized raytracing presentation resources "
+            "to {}x{} while preserving the last accepted RT frame resources.",
+            new_extent.x,
+            new_extent.y
+        );
+        return;
+    }
 
     state.rt_ctx->SetResolution(new_extent);
 

--- a/source/runtime/render/renderer/raytracing/RaytracingRenderer.cpp
+++ b/source/runtime/render/renderer/raytracing/RaytracingRenderer.cpp
@@ -30,6 +30,7 @@
 #include <imgui.h>
 
 #include <algorithm>
+#include <array>
 #include <cstdlib>
 #include <limits>
 #include <new>
@@ -218,13 +219,16 @@ struct RaytracingRenderer::RuntimeState {
     bool b_feedback_valid = false;
     bool b_export         = false;
 
-    bool render_graph_enabled            = false;
-    bool render_graph_debug_dump         = false;
-    bool render_graph_parallel_recording = false;
-    bool render_graph_fallback_latched   = false;
-    uint8 gbuffer_initialized_history_mask = 0;
-    bool  normal_roughness_readable         = false;
-    UnorderedSet<std::string> logged_render_graph_dumps;
+    bool                         render_graph_enabled                 = false;
+    bool                         render_graph_debug_dump              = false;
+    bool                         render_graph_parallel_recording      = false;
+    bool                         render_graph_fallback_latched        = false;
+    uint8                        gbuffer_initialized_history_mask     = 0;
+    bool                         normal_roughness_readable            = false;
+    std::array<const Buffer*, 3> lighting_working_set{};
+    uint                         lighting_reservoir_block_array_pitch = 0;
+    uint8                        lighting_initialized_reservoir_mask  = 0;
+    UnorderedSet<std::string>    logged_render_graph_dumps;
 
     uint64 rt_instance_revision      = 0;
     uint64 current_tlas_revision     = invalid_tlas_revision;
@@ -320,7 +324,7 @@ RaytracingRenderer::RaytracingRenderer(
     runtime_state->render_graph_parallel_recording =
         graph_config.render_graph_parallel_recording;
     LOG_INFO(
-        "[RenderGraph] Raytracing execution mode: {}, GBuffer recording: {}",
+        "[RenderGraph] Raytracing execution mode: {}, pre-denoise recording: {}",
         runtime_state->render_graph_enabled ? "graph-pilot" : "linear",
         runtime_state->render_graph_parallel_recording ? "parallel-eligible" :
                                                          "serial"
@@ -520,12 +524,14 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
     }
 
     PrepareRenderFrame(frame_packet.window);
-    bool skip_present                 = false;
-    bool split_graph_profiling_frame = false;
-    bool graph_gbuffer_recorded       = false;
-    bool linear_gbuffer_recorded      = false;
-    bool nrd_recorded                 = false;
-    uint8 gbuffer_history_bit         = 0;
+    bool skip_present                       = false;
+    bool split_graph_profiling_frame       = false;
+    bool graph_pre_denoise_recorded         = false;
+    bool linear_gbuffer_recorded            = false;
+    bool linear_lighting_recorded           = false;
+    bool nrd_recorded                       = false;
+    uint8 gbuffer_history_bit               = 0;
+    LightingPass::LocalLightSamplingDecision local_light_sampling{};
 
     switch (frame_packet.window.state) {
         case EWindowState::Hiding:
@@ -755,6 +761,30 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
 
         state.rt_ctx->Tick(camera, state.antialias_pass->GetPixelOffset());
         gbuffer_history_bit = state.rt_ctx->b_current_frame ? uint8(1) : uint8(2);
+        const std::array<const Buffer*, 3> lighting_working_set{
+            state.rt_ctx->light_reservoir_buf.Get(),
+            state.rt_ctx->ris_buf.Get(),
+            state.rt_ctx->ris_light_data_buf.Get()
+        };
+        const uint lighting_reservoir_block_array_pitch =
+            state.rt_ctx->is_ctx.GetReSTIRDIRuntimeConfig()
+                .reservoir_buffer_params.block_array_pitch;
+        if (state.lighting_working_set != lighting_working_set ||
+            state.lighting_reservoir_block_array_pitch !=
+                lighting_reservoir_block_array_pitch) {
+            state.lighting_working_set = lighting_working_set;
+            state.lighting_reservoir_block_array_pitch =
+                lighting_reservoir_block_array_pitch;
+            // ReSTIR DI rotates three logical reservoir slices. Track the
+            // slices actually written by accepted linear frames rather than
+            // coupling graph eligibility to an implicit frame countdown.
+            state.lighting_initialized_reservoir_mask = 0;
+            LOG_INFO(
+                "[RenderGraph][Raytracing] Lighting working set changed; "
+                "warming reservoir slices linearly (reservoir block pitch={}).",
+                lighting_reservoir_block_array_pitch
+            );
+        }
         {
             ScopedGpuMarker pass_marker(
                 cmd_list, "Pass: Prepare Lights", GpuMarkerPalette::Pass()
@@ -762,28 +792,38 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
             state.prepare_light_pass->Process(cmd_list, *state.rt_ctx, scene_snapshot);
         }
         if (state.render_graph_enabled && !state.render_graph_fallback_latched &&
-            (state.gbuffer_initialized_history_mask & gbuffer_history_bit) != 0 &&
+            state.gbuffer_initialized_history_mask == uint8(0b11) &&
+            state.lighting_initialized_reservoir_mask == uint8(0b111) &&
             !render_graph_boundary_frame) {
-            RenderGraph graph("Raytracing.GBuffer");
+            RenderGraph graph("Raytracing.PreDenoise");
             const RTGraphFrameResources graph_resources =
                 RegisterRTGraphFrameResources(graph, *state.rt_ctx);
-            if (!state.g_buffer_pass->AddPasses(
+            const bool gbuffer_added = state.g_buffer_pass->AddPasses(
                     graph,
                     graph_resources,
                     *state.rt_ctx,
                     tlas_built_this_frame,
                     state.normal_roughness_readable
-                )) {
+                );
+            const bool lighting_added =
+                gbuffer_added &&
+                state.lighting_pass->AddPasses(
+                    graph,
+                    graph_resources,
+                    *state.rt_ctx,
+                    local_light_sampling
+                );
+            if (!gbuffer_added || !lighting_added) {
                 state.render_graph_fallback_latched = true;
                 LOG_ERROR(
-                    "[RenderGraph][Fallback] Raytracing GBuffer graph could not "
-                    "import the TLAS backing buffer. Using the linear path for "
-                    "this renderer instance."
+                    "[RenderGraph][Fallback] Raytracing pre-denoise graph could "
+                    "not import a required GBuffer/Lighting resource. Using the "
+                    "linear path for this renderer instance."
                 );
             } else if (!graph.Compile()) {
                 state.render_graph_fallback_latched = true;
                 LOG_ERROR(
-                    "[RenderGraph][Fallback] Raytracing GBuffer graph compile "
+                    "[RenderGraph][Fallback] Raytracing pre-denoise graph compile "
                     "failed before execution: {}. Using the linear path for "
                     "this renderer instance.",
                     graph.GetCompileError()
@@ -845,36 +885,39 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
                         {},
                         RenderGraph::ActiveRecordingOptions{.enabled = true}
                     )) {
-                    graph_gbuffer_recorded = true;
+                    graph_pre_denoise_recorded = true;
                 } else {
                     state.render_graph_fallback_latched = true;
                     LOG_ERROR(
-                        "[RenderGraph][Fallback] Raytracing GBuffer graph "
+                        "[RenderGraph][Fallback] Raytracing pre-denoise graph "
                         "recording failed before transaction commit: {}. "
-                        "Re-recording GBuffer linearly this frame and using the "
-                        "linear path from the next frame.",
+                        "Re-recording GBuffer and Lighting linearly this frame "
+                        "and using the linear path from the next frame.",
                         graph.GetCompileError()
                     );
                 }
             }
         }
-        if (!graph_gbuffer_recorded) {
+        if (!graph_pre_denoise_recorded) {
             ScopedGpuMarker pass_marker(
                 cmd_list, "Pass: GBuffer", GpuMarkerPalette::Pass()
             );
             state.g_buffer_pass->Process(cmd_list, *state.rt_ctx);
             linear_gbuffer_recorded = true;
+
+            pass_marker.Close();
+            ScopedGpuMarker lighting_marker(
+                cmd_list, "Pass: Lighting", GpuMarkerPalette::Pass()
+            );
+            local_light_sampling =
+                state.lighting_pass->Process(cmd_list, *state.rt_ctx);
+            linear_lighting_recorded = true;
         } else {
             state.g_buffer_pass->RecordLegacyTailBridge(
                 cmd_list,
                 *state.rt_ctx
             );
         }
-        ScopedGpuMarker lighting_marker(
-            cmd_list, "Pass: Lighting", GpuMarkerPalette::Pass()
-        );
-        const auto local_light_sampling = state.lighting_pass->Process(cmd_list, *state.rt_ctx);
-        lighting_marker.Close();
         feedback.configured_local_light_sample_mode = local_light_sampling.configured_mode;
         feedback.effective_local_light_sample_mode  = local_light_sampling.effective_mode;
         feedback.adaptive_local_light_fallback_applied =
@@ -1114,10 +1157,34 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
         ERHIExecSubmitFlags::FlushGPU,
         present_request ? &*present_request : nullptr
     );
-    if (linear_gbuffer_recorded || graph_gbuffer_recorded) {
+    if (linear_gbuffer_recorded || graph_pre_denoise_recorded) {
         state.gbuffer_initialized_history_mask |= gbuffer_history_bit;
     }
-    if (graph_gbuffer_recorded) {
+    if (linear_lighting_recorded) {
+        const uint8 previous_reservoir_mask =
+            state.lighting_initialized_reservoir_mask;
+        const auto& buffer_indices =
+            state.rt_ctx->is_ctx.GetReSTIRDIBufferIndices();
+        for (const uint reservoir_slice : {
+                 buffer_indices.initial_sample_output_buff_idx,
+                 buffer_indices.temperal_resample_output_buff_idx,
+                 buffer_indices.spatial_resample_output_buff_idx,
+             }) {
+            if (reservoir_slice < 3) {
+                state.lighting_initialized_reservoir_mask |=
+                    uint8(1u << reservoir_slice);
+            }
+        }
+        if (previous_reservoir_mask != uint8(0b111) &&
+            state.lighting_initialized_reservoir_mask == uint8(0b111)) {
+            LOG_INFO(
+                "[RenderGraph][Raytracing] All Lighting reservoir slices have "
+                "accepted linear submissions; active RDG is eligible once "
+                "both GBuffer history pings are initialized."
+            );
+        }
+    }
+    if (graph_pre_denoise_recorded) {
         state.normal_roughness_readable = true;
     } else if (linear_gbuffer_recorded) {
         state.normal_roughness_readable = nrd_recorded;
@@ -1308,9 +1375,12 @@ void RaytracingRenderer::RecreateFrameResources(uint2 new_extent) {
     state.antialias_pass_info.feedback_color_ping = state.rt_ctx->frame_rt.feedback_color_ping;
     state.antialias_pass_info.feedback_color_pong = state.rt_ctx->frame_rt.feedback_color_pong;
     state.antialias_pass   = MakeUnique<AntialiasPass>(device, manager, state.antialias_pass_info);
-    state.b_feedback_valid = false;
-    state.gbuffer_initialized_history_mask = 0;
-    state.normal_roughness_readable         = false;
+    state.b_feedback_valid                       = false;
+    state.gbuffer_initialized_history_mask       = 0;
+    state.normal_roughness_readable              = false;
+    state.lighting_working_set                   = {};
+    state.lighting_reservoir_block_array_pitch = 0;
+    state.lighting_initialized_reservoir_mask    = 0;
 }
 
 } // namespace Moer::Render::Raytracing

--- a/source/runtime/render/renderer/raytracing/RaytracingRenderer.cpp
+++ b/source/runtime/render/renderer/raytracing/RaytracingRenderer.cpp
@@ -530,10 +530,12 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
     bool graph_composition_recorded         = false;
     bool graph_antialias_recorded           = false;
     bool graph_tone_mapping_recorded        = false;
+    bool graph_visualize_recorded           = false;
     bool linear_gbuffer_recorded            = false;
     bool linear_lighting_recorded           = false;
     bool linear_antialias_recorded           = false;
     bool linear_tone_mapping_recorded       = false;
+    bool linear_visualize_recorded          = false;
     bool nrd_recorded                       = false;
     uint8 gbuffer_history_bit               = 0;
     float tone_mapping_elapsed_for_commit   = 0.f;
@@ -865,13 +867,23 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
                      state.rt_ctx->frame_rt.resolved_color,
                      state.rt_ctx->frame_rt.ldr_color
                  ));
+            const bool visualize_in_graph = tone_mapping_in_graph;
+            const bool visualize_added =
+                !visualize_in_graph ||
+                (tone_mapping_added &&
+                 state.visualize_pass->AddPasses(
+                     graph,
+                     graph_resources,
+                     *state.rt_ctx,
+                     state.visualize_config
+                 ));
             if (!gbuffer_added || !lighting_added || !composition_added ||
-                !antialias_added || !tone_mapping_added) {
+                !antialias_added || !tone_mapping_added || !visualize_added) {
                 state.render_graph_fallback_latched = true;
                 LOG_ERROR(
                     "[RenderGraph][Fallback] Raytracing primary graph could not "
                     "import a required GBuffer/Lighting/Composition/AntiAlias/"
-                    "ToneMapping resource. Using the linear path for this "
+                    "ToneMapping/Visualize resource. Using the linear path for this "
                     "renderer instance."
                 );
             } else if (!graph.Compile()) {
@@ -944,6 +956,7 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
                     graph_antialias_recorded   = antialias_in_graph;
                     graph_tone_mapping_recorded =
                         tone_mapping_in_graph;
+                    graph_visualize_recorded = visualize_in_graph;
                 } else {
                     state.render_graph_fallback_latched = true;
                     LOG_ERROR(
@@ -976,7 +989,8 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
                 *state.rt_ctx,
                 graph_composition_recorded,
                 graph_antialias_recorded,
-                graph_tone_mapping_recorded
+                graph_tone_mapping_recorded,
+                graph_visualize_recorded
             );
         }
         feedback.configured_local_light_sample_mode = local_light_sampling.configured_mode;
@@ -1070,13 +1084,14 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
             );
             linear_tone_mapping_recorded = true;
         }
-        {
+        if (!graph_visualize_recorded) {
             ScopedGpuMarker pass_marker(
                 cmd_list, "Pass: Visualize", GpuMarkerPalette::Pass()
             );
             state.visualize_pass->Process(
-                cmd_list, *state.rt_ctx, state.visualize_config, bindless_array
+                cmd_list, *state.rt_ctx, state.visualize_config
             );
+            linear_visualize_recorded = true;
         }
 
         const auto& debug_input = frame_packet.debug_input;
@@ -1257,7 +1272,8 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
     if (graph_primary_recorded) {
         state.normal_roughness_readable = true;
     } else if (linear_gbuffer_recorded) {
-        state.normal_roughness_readable = nrd_recorded;
+        state.normal_roughness_readable =
+            nrd_recorded || linear_visualize_recorded;
     }
     if (!skip_present) {
         PresentUiDrawFrame(frame_packet.ui_draw_frame, ui_execution_thread);

--- a/source/runtime/render/renderer/raytracing/RaytracingRenderer.cpp
+++ b/source/runtime/render/renderer/raytracing/RaytracingRenderer.cpp
@@ -529,11 +529,15 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
     bool graph_primary_recorded             = false;
     bool graph_composition_recorded         = false;
     bool graph_antialias_recorded           = false;
+    bool graph_tone_mapping_recorded        = false;
     bool linear_gbuffer_recorded            = false;
     bool linear_lighting_recorded           = false;
     bool linear_antialias_recorded           = false;
+    bool linear_tone_mapping_recorded       = false;
     bool nrd_recorded                       = false;
     uint8 gbuffer_history_bit               = 0;
+    float tone_mapping_elapsed_for_commit   = 0.f;
+    bool tone_mapping_enabled_for_commit    = false;
     LightingPass::LocalLightSamplingDecision local_light_sampling{};
 
     switch (frame_packet.window.state) {
@@ -736,6 +740,9 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
             tone_params.histogram_high_percentile = tone_cfg.histogram_high_percentile;
             tone_params.white_point               = tone_cfg.white_point;
             tone_params.enable_tone_mapping       = tone_cfg.enable_tone_mapping;
+            tone_mapping_elapsed_for_commit        = camera.GetDeltaTime();
+            tone_mapping_enabled_for_commit =
+                tone_params.enable_tone_mapping;
 
             const auto& aa_cfg             = ui_config.aa_cfg;
             aa_params.clamping_factor      = aa_cfg.clamping_factor;
@@ -846,13 +853,26 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
                      state.rt_ctx->frame_rt.hdr_color,
                      state.rt_ctx->frame_rt.resolved_color
                  ));
+            const bool tone_mapping_in_graph = antialias_in_graph;
+            const bool tone_mapping_added =
+                !tone_mapping_in_graph ||
+                (antialias_added &&
+                 state.tone_mapping_pass->AddPasses(
+                     graph,
+                     graph_resources,
+                     *state.rt_ctx,
+                     tone_params,
+                     state.rt_ctx->frame_rt.resolved_color,
+                     state.rt_ctx->frame_rt.ldr_color
+                 ));
             if (!gbuffer_added || !lighting_added || !composition_added ||
-                !antialias_added) {
+                !antialias_added || !tone_mapping_added) {
                 state.render_graph_fallback_latched = true;
                 LOG_ERROR(
                     "[RenderGraph][Fallback] Raytracing primary graph could not "
-                    "import a required GBuffer/Lighting/Composition/AntiAlias "
-                    "resource. Using the linear path for this renderer instance."
+                    "import a required GBuffer/Lighting/Composition/AntiAlias/"
+                    "ToneMapping resource. Using the linear path for this "
+                    "renderer instance."
                 );
             } else if (!graph.Compile()) {
                 state.render_graph_fallback_latched = true;
@@ -922,6 +942,8 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
                     graph_primary_recorded     = true;
                     graph_composition_recorded = composition_in_graph;
                     graph_antialias_recorded   = antialias_in_graph;
+                    graph_tone_mapping_recorded =
+                        tone_mapping_in_graph;
                 } else {
                     state.render_graph_fallback_latched = true;
                     LOG_ERROR(
@@ -953,7 +975,8 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
                 cmd_list,
                 *state.rt_ctx,
                 graph_composition_recorded,
-                graph_antialias_recorded
+                graph_antialias_recorded,
+                graph_tone_mapping_recorded
             );
         }
         feedback.configured_local_light_sample_mode = local_light_sampling.configured_mode;
@@ -1035,7 +1058,7 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
             );
             linear_antialias_recorded = true;
         }
-        {
+        if (!graph_tone_mapping_recorded) {
             ScopedGpuMarker pass_marker(
                 cmd_list, "Pass: Tone Mapping", GpuMarkerPalette::Pass()
             );
@@ -1045,6 +1068,7 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
                 state.rt_ctx->frame_rt.resolved_color,
                 state.rt_ctx->frame_rt.ldr_color
             );
+            linear_tone_mapping_recorded = true;
         }
         {
             ScopedGpuMarker pass_marker(
@@ -1074,7 +1098,6 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
         }
 
         state.rt_ctx->AdvanceFrame();
-        state.tone_mapping_pass->AdvanceFrame(camera.GetDeltaTime());
 
         if (state.b_export) {
             renderer_marker.Close();
@@ -1197,6 +1220,12 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
     if (linear_antialias_recorded || graph_antialias_recorded) {
         state.antialias_pass->CommitAcceptedFrame();
         state.b_feedback_valid = true;
+    }
+    if (linear_tone_mapping_recorded || graph_tone_mapping_recorded) {
+        state.tone_mapping_pass->CommitAcceptedFrame(
+            tone_mapping_elapsed_for_commit,
+            tone_mapping_enabled_for_commit
+        );
     }
     if (linear_gbuffer_recorded || graph_primary_recorded) {
         state.gbuffer_initialized_history_mask |= gbuffer_history_bit;

--- a/source/runtime/render/renderer/raytracing/RaytracingRenderer.cpp
+++ b/source/runtime/render/renderer/raytracing/RaytracingRenderer.cpp
@@ -23,6 +23,7 @@
 #include "PreprocessLightPass.h"
 #include "RTResource.h"
 #include "ShaderUtils.h"
+#include "ShowTexturePass.h"
 #include "ToneMappingPass.h"
 #include "VisualizePass.h"
 
@@ -244,6 +245,7 @@ struct RaytracingRenderer::RuntimeState {
     UniquePtr<LightingPass>     lighting_pass;
     UniquePtr<CompositionPass>  composition_pass;
     UniquePtr<VisualizePass>    visualize_pass;
+    UniquePtr<ShowTexturePass>  show_texture_pass;
     UniquePtr<RTContext>        rt_ctx;
     UniquePtr<ToneMappingPass>  tone_mapping_pass;
 
@@ -281,6 +283,9 @@ struct RaytracingRenderer::RuntimeState {
             MakeUnique<CompositionPass>(renderer.device, renderer.manager, renderer.bindless_array)
         ),
         visualize_pass(MakeUnique<VisualizePass>(renderer.device, renderer.manager)),
+        show_texture_pass(
+            MakeUnique<ShowTexturePass>(renderer.manager, renderer.bindless_array)
+        ),
         rt_ctx(MakeUnique<RTContext>(shader_utils, importance_sampling_context, renderer.bindless_array)) {
         if (!std::filesystem::exists(exported_file_path)) {
             std::filesystem::create_directory(exported_file_path);
@@ -531,6 +536,7 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
     bool graph_antialias_recorded           = false;
     bool graph_tone_mapping_recorded        = false;
     bool graph_visualize_recorded           = false;
+    bool graph_show_texture_recorded         = false;
     bool linear_gbuffer_recorded            = false;
     bool linear_lighting_recorded           = false;
     bool linear_antialias_recorded           = false;
@@ -541,6 +547,9 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
     float tone_mapping_elapsed_for_commit   = 0.f;
     bool tone_mapping_enabled_for_commit    = false;
     LightingPass::LocalLightSamplingDecision local_light_sampling{};
+    TextureRef selected_debug_texture{};
+    bool       show_texture_requested        = false;
+    ShowTextureParams show_texture_params{};
 
     switch (frame_packet.window.state) {
         case EWindowState::Hiding:
@@ -773,6 +782,25 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
         );
         cmd_list.UpdateBindlessArray(bindless_array);
 
+        const auto& debug_input = frame_packet.debug_input;
+        const auto selected_texture_it =
+            state.material_textures.find(
+                debug_input.selected_material_texture_name
+            );
+        show_texture_requested =
+            debug_input.show_final_texture &&
+            selected_texture_it != state.material_textures.end() &&
+            selected_texture_it->second.tex;
+        if (show_texture_requested) {
+            selected_debug_texture = selected_texture_it->second.tex;
+            show_texture_params.bdls_handle = selected_texture_it->second.hdl;
+            show_texture_params.mip_level = static_cast<uint>(
+                std::max(debug_input.mip_level, 0)
+            );
+            show_texture_params.use_bindless =
+                debug_input.use_bindless ? 1u : 0u;
+        }
+
         state.rt_ctx->Tick(camera, state.antialias_pass->GetPixelOffset());
         gbuffer_history_bit = state.rt_ctx->b_current_frame ? uint8(1) : uint8(2);
         const std::array<const Buffer*, 3> lighting_working_set{
@@ -877,14 +905,36 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
                      *state.rt_ctx,
                      state.visualize_config
                  ));
+            const bool show_texture_in_graph =
+                visualize_in_graph && show_texture_requested;
+            RenderGraph::TextureHandle selected_graph_texture{};
+            if (show_texture_in_graph) {
+                selected_graph_texture = ImportRTGraphTexture(
+                    graph,
+                    "RT.selected_material_texture",
+                    selected_debug_texture
+                );
+            }
+            const bool show_texture_added =
+                !show_texture_in_graph ||
+                (visualize_added &&
+                 state.show_texture_pass->AddPass(
+                     graph,
+                     selected_graph_texture,
+                     graph_resources.ldr_color,
+                     show_texture_params,
+                     selected_debug_texture,
+                     state.rt_ctx->frame_rt.ldr_color
+                 ));
             if (!gbuffer_added || !lighting_added || !composition_added ||
-                !antialias_added || !tone_mapping_added || !visualize_added) {
+                !antialias_added || !tone_mapping_added || !visualize_added ||
+                !show_texture_added) {
                 state.render_graph_fallback_latched = true;
                 LOG_ERROR(
                     "[RenderGraph][Fallback] Raytracing primary graph could not "
                     "import a required GBuffer/Lighting/Composition/AntiAlias/"
-                    "ToneMapping/Visualize resource. Using the linear path for this "
-                    "renderer instance."
+                    "ToneMapping/Visualize/ShowTexture resource. Using the linear "
+                    "path for this renderer instance."
                 );
             } else if (!graph.Compile()) {
                 state.render_graph_fallback_latched = true;
@@ -957,6 +1007,8 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
                     graph_tone_mapping_recorded =
                         tone_mapping_in_graph;
                     graph_visualize_recorded = visualize_in_graph;
+                    graph_show_texture_recorded =
+                        show_texture_in_graph;
                 } else {
                     state.render_graph_fallback_latched = true;
                     LOG_ERROR(
@@ -1094,21 +1146,15 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
             linear_visualize_recorded = true;
         }
 
-        const auto& debug_input = frame_packet.debug_input;
-        if (debug_input.show_final_texture &&
-            state.material_textures.contains(debug_input.selected_material_texture_name)) {
+        if (show_texture_requested && !graph_show_texture_recorded) {
             ScopedGpuMarker debug_texture_marker(
                 cmd_list, "Pass: Debug Texture", GpuMarkerPalette::Pass()
             );
-            TextureRef texture = state.material_textures[debug_input.selected_material_texture_name].tex;
-            ShowTextureParams show_texture_params{};
-            show_texture_params.dst_dim = resolution;
-            show_texture_params.bdls_handle =
-                state.material_textures[debug_input.selected_material_texture_name].hdl;
-            show_texture_params.mip_level    = static_cast<uint>(debug_input.mip_level);
-            show_texture_params.use_bindless = debug_input.use_bindless;
-            state.shader_utils.ShowTexture(
-                cmd_list, bindless_array, show_texture_params, texture, state.rt_ctx->frame_rt.ldr_color
+            state.show_texture_pass->Process(
+                cmd_list,
+                show_texture_params,
+                selected_debug_texture,
+                state.rt_ctx->frame_rt.ldr_color
             );
         }
 
@@ -1388,6 +1434,42 @@ void RaytracingRenderer::RefreshSceneRuntimeRefs() {
     state.rt_scene = gpu_scene_res.rt_scene;
     state.rt_ctx->SetBindlessHandles(gpu_scene_res);
     state.rt_ctx->SetRaytracingScene(state.rt_scene);
+
+    state.material_textures.clear();
+    state.material_textures.reserve(gpu_scene_res.texture_array.size());
+    for (const TextureWithHandle& texture : gpu_scene_res.texture_array) {
+        if (!texture.tex ||
+            texture.tex->GetDimension() != ETextureDimension::TEX_2D ||
+            texture.tex->GetNumArray() != 1 ||
+            texture.tex->GetNumMips() == 0 ||
+            texture.tex->GetExtent().x == 0 ||
+            texture.tex->GetExtent().y == 0) {
+            continue;
+        }
+        std::string base_name(texture.tex->GetName());
+        if (base_name.empty()) {
+            base_name = std::format("Material Texture {}", texture.hdl);
+        }
+        std::string display_name = base_name;
+        if (state.material_textures.contains(display_name)) {
+            display_name =
+                std::format("{} [{}]", base_name, texture.hdl);
+        }
+        uint duplicate_index = 2;
+        while (state.material_textures.contains(display_name)) {
+            display_name = std::format(
+                "{} [{}:{}]",
+                base_name,
+                texture.hdl,
+                duplicate_index++
+            );
+        }
+        state.material_textures.emplace(
+            std::move(display_name),
+            texture
+        );
+    }
+
     if (rt_scene_changed) {
         state.b_feedback_valid = false;
         state.current_tlas_revision  = RuntimeState::invalid_tlas_revision;

--- a/source/runtime/render/renderer/raytracing/RaytracingRenderer.cpp
+++ b/source/runtime/render/renderer/raytracing/RaytracingRenderer.cpp
@@ -324,7 +324,7 @@ RaytracingRenderer::RaytracingRenderer(
     runtime_state->render_graph_parallel_recording =
         graph_config.render_graph_parallel_recording;
     LOG_INFO(
-        "[RenderGraph] Raytracing execution mode: {}, pre-denoise recording: {}",
+        "[RenderGraph] Raytracing execution mode: {}, primary graph recording: {}",
         runtime_state->render_graph_enabled ? "graph-pilot" : "linear",
         runtime_state->render_graph_parallel_recording ? "parallel-eligible" :
                                                          "serial"
@@ -526,7 +526,8 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
     PrepareRenderFrame(frame_packet.window);
     bool skip_present                       = false;
     bool split_graph_profiling_frame       = false;
-    bool graph_pre_denoise_recorded         = false;
+    bool graph_primary_recorded             = false;
+    bool graph_composition_recorded         = false;
     bool linear_gbuffer_recorded            = false;
     bool linear_lighting_recorded           = false;
     bool nrd_recorded                       = false;
@@ -561,6 +562,8 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
             state.first_load || state.b_new_env_map ||
             frame_packet.window.state == EWindowState::SizeChanged ||
             ui_config.export_cfg.b_export;
+        const bool nrd_active_this_frame =
+            IsNrdDenoiserActive(ui_config.denoiser_cfg.denoiser_type);
         const bool scene_tlas_updated =
             ExecuteSceneUpdates(frame_packet.scene_updates);
 
@@ -795,7 +798,11 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
             state.gbuffer_initialized_history_mask == uint8(0b11) &&
             state.lighting_initialized_reservoir_mask == uint8(0b111) &&
             !render_graph_boundary_frame) {
-            RenderGraph graph("Raytracing.PreDenoise");
+            RenderGraph graph(
+                nrd_active_this_frame ?
+                    "Raytracing.PreDenoise" :
+                    "Raytracing.FrameCore"
+            );
             const RTGraphFrameResources graph_resources =
                 RegisterRTGraphFrameResources(graph, *state.rt_ctx);
             const bool gbuffer_added = state.g_buffer_pass->AddPasses(
@@ -813,17 +820,26 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
                     *state.rt_ctx,
                     local_light_sampling
                 );
-            if (!gbuffer_added || !lighting_added) {
+            const bool composition_in_graph = !nrd_active_this_frame;
+            const bool composition_added =
+                !composition_in_graph ||
+                (lighting_added &&
+                 state.composition_pass->AddPasses(
+                     graph,
+                     graph_resources,
+                     *state.rt_ctx
+                 ));
+            if (!gbuffer_added || !lighting_added || !composition_added) {
                 state.render_graph_fallback_latched = true;
                 LOG_ERROR(
-                    "[RenderGraph][Fallback] Raytracing pre-denoise graph could "
-                    "not import a required GBuffer/Lighting resource. Using the "
-                    "linear path for this renderer instance."
+                    "[RenderGraph][Fallback] Raytracing primary graph could not "
+                    "import a required GBuffer/Lighting/Composition resource. "
+                    "Using the linear path for this renderer instance."
                 );
             } else if (!graph.Compile()) {
                 state.render_graph_fallback_latched = true;
                 LOG_ERROR(
-                    "[RenderGraph][Fallback] Raytracing pre-denoise graph compile "
+                    "[RenderGraph][Fallback] Raytracing primary graph compile "
                     "failed before execution: {}. Using the linear path for "
                     "this renderer instance.",
                     graph.GetCompileError()
@@ -885,20 +901,21 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
                         {},
                         RenderGraph::ActiveRecordingOptions{.enabled = true}
                     )) {
-                    graph_pre_denoise_recorded = true;
+                    graph_primary_recorded     = true;
+                    graph_composition_recorded = composition_in_graph;
                 } else {
                     state.render_graph_fallback_latched = true;
                     LOG_ERROR(
-                        "[RenderGraph][Fallback] Raytracing pre-denoise graph "
+                        "[RenderGraph][Fallback] Raytracing primary graph "
                         "recording failed before transaction commit: {}. "
-                        "Re-recording GBuffer and Lighting linearly this frame "
-                        "and using the linear path from the next frame.",
+                        "Re-recording its managed passes linearly this frame and "
+                        "using the linear path from the next frame.",
                         graph.GetCompileError()
                     );
                 }
             }
         }
-        if (!graph_pre_denoise_recorded) {
+        if (!graph_primary_recorded) {
             ScopedGpuMarker pass_marker(
                 cmd_list, "Pass: GBuffer", GpuMarkerPalette::Pass()
             );
@@ -915,7 +932,8 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
         } else {
             state.g_buffer_pass->RecordLegacyTailBridge(
                 cmd_list,
-                *state.rt_ctx
+                *state.rt_ctx,
+                graph_composition_recorded
             );
         }
         feedback.configured_local_light_sample_mode = local_light_sampling.configured_mode;
@@ -978,7 +996,7 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
         }
 #endif
 
-        {
+        if (!graph_composition_recorded) {
             ScopedGpuMarker pass_marker(
                 cmd_list, "Pass: Composition", GpuMarkerPalette::Pass()
             );
@@ -1157,7 +1175,7 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
         ERHIExecSubmitFlags::FlushGPU,
         present_request ? &*present_request : nullptr
     );
-    if (linear_gbuffer_recorded || graph_pre_denoise_recorded) {
+    if (linear_gbuffer_recorded || graph_primary_recorded) {
         state.gbuffer_initialized_history_mask |= gbuffer_history_bit;
     }
     if (linear_lighting_recorded) {
@@ -1184,7 +1202,7 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
             );
         }
     }
-    if (graph_pre_denoise_recorded) {
+    if (graph_primary_recorded) {
         state.normal_roughness_readable = true;
     } else if (linear_gbuffer_recorded) {
         state.normal_roughness_readable = nrd_recorded;

--- a/source/runtime/render/renderer/raytracing/RaytracingRenderer.cpp
+++ b/source/runtime/render/renderer/raytracing/RaytracingRenderer.cpp
@@ -218,6 +218,14 @@ struct RaytracingRenderer::RuntimeState {
     bool b_feedback_valid = false;
     bool b_export         = false;
 
+    bool render_graph_enabled            = false;
+    bool render_graph_debug_dump         = false;
+    bool render_graph_parallel_recording = false;
+    bool render_graph_fallback_latched   = false;
+    uint8 gbuffer_initialized_history_mask = 0;
+    bool  normal_roughness_readable         = false;
+    UnorderedSet<std::string> logged_render_graph_dumps;
+
     uint64 rt_instance_revision      = 0;
     uint64 current_tlas_revision     = invalid_tlas_revision;
     uint64 previous_tlas_revision    = invalid_tlas_revision;
@@ -304,7 +312,20 @@ RaytracingRenderer::RaytracingRenderer(
 ) :
     Renderer(resolution, config),
     runtime_assets(runtime_assets),
-    runtime_state(MakeUnique<RuntimeState>(*this)) {}
+    runtime_state(MakeUnique<RuntimeState>(*this)) {
+    const auto& graph_config =
+        ConfigManager::GetInstance().GetConfig().engine.render.raytracing;
+    runtime_state->render_graph_enabled            = graph_config.render_graph;
+    runtime_state->render_graph_debug_dump         = graph_config.render_graph_debug_dump;
+    runtime_state->render_graph_parallel_recording =
+        graph_config.render_graph_parallel_recording;
+    LOG_INFO(
+        "[RenderGraph] Raytracing execution mode: {}, GBuffer recording: {}",
+        runtime_state->render_graph_enabled ? "graph-pilot" : "linear",
+        runtime_state->render_graph_parallel_recording ? "parallel-eligible" :
+                                                         "serial"
+    );
+}
 
 RaytracingRenderer::~RaytracingRenderer() {
     const char* thread_name = IsCurrentlyRenderThread() ? "Render" : "Game";
@@ -499,7 +520,12 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
     }
 
     PrepareRenderFrame(frame_packet.window);
-    bool skip_present = false;
+    bool skip_present                 = false;
+    bool split_graph_profiling_frame = false;
+    bool graph_gbuffer_recorded       = false;
+    bool linear_gbuffer_recorded      = false;
+    bool nrd_recorded                 = false;
+    uint8 gbuffer_history_bit         = 0;
 
     switch (frame_packet.window.state) {
         case EWindowState::Hiding:
@@ -525,7 +551,12 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
     feedback.export_request_finished = ui_config.export_cfg.b_export;
 
     if (frame_packet.scene_updates.scene_ready && frame_packet.runtime_assets_ready) {
-        ExecuteSceneUpdates(frame_packet.scene_updates);
+        const bool render_graph_boundary_frame =
+            state.first_load || state.b_new_env_map ||
+            frame_packet.window.state == EWindowState::SizeChanged ||
+            ui_config.export_cfg.b_export;
+        const bool scene_tlas_updated =
+            ExecuteSceneUpdates(frame_packet.scene_updates);
 
         if (state.first_load) {
             state.first_load    = false;
@@ -606,6 +637,7 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
         state.rt_ctx->FillLowDiscrepancySequence(cmd_list);
         state.b_export = ui_config.export_cfg.b_export;
 
+        bool tlas_built_this_frame = scene_tlas_updated;
         if (state.rt_scene) {
             const bool needs_tlas_build = IsLegacyTlasUpdateEnabled() ||
                                           state.current_tlas_revision != state.rt_instance_revision;
@@ -622,6 +654,7 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
                 cmd_list.PopScopeWithTimeScope();
                 state.current_tlas_revision = state.rt_instance_revision;
                 ++state.renderer_tlas_build_count;
+                tlas_built_this_frame = true;
             } else {
                 ++state.renderer_tlas_skip_count;
             }
@@ -721,17 +754,121 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
         cmd_list.UpdateBindlessArray(bindless_array);
 
         state.rt_ctx->Tick(camera, state.antialias_pass->GetPixelOffset());
+        gbuffer_history_bit = state.rt_ctx->b_current_frame ? uint8(1) : uint8(2);
         {
             ScopedGpuMarker pass_marker(
                 cmd_list, "Pass: Prepare Lights", GpuMarkerPalette::Pass()
             );
             state.prepare_light_pass->Process(cmd_list, *state.rt_ctx, scene_snapshot);
         }
-        {
+        if (state.render_graph_enabled && !state.render_graph_fallback_latched &&
+            (state.gbuffer_initialized_history_mask & gbuffer_history_bit) != 0 &&
+            !render_graph_boundary_frame) {
+            RenderGraph graph("Raytracing.GBuffer");
+            const RTGraphFrameResources graph_resources =
+                RegisterRTGraphFrameResources(graph, *state.rt_ctx);
+            if (!state.g_buffer_pass->AddPasses(
+                    graph,
+                    graph_resources,
+                    *state.rt_ctx,
+                    tlas_built_this_frame,
+                    state.normal_roughness_readable
+                )) {
+                state.render_graph_fallback_latched = true;
+                LOG_ERROR(
+                    "[RenderGraph][Fallback] Raytracing GBuffer graph could not "
+                    "import the TLAS backing buffer. Using the linear path for "
+                    "this renderer instance."
+                );
+            } else if (!graph.Compile()) {
+                state.render_graph_fallback_latched = true;
+                LOG_ERROR(
+                    "[RenderGraph][Fallback] Raytracing GBuffer graph compile "
+                    "failed before execution: {}. Using the linear path for "
+                    "this renderer instance.",
+                    graph.GetCompileError()
+                );
+            } else {
+                if (state.render_graph_debug_dump) {
+                    std::string dump = graph.Dump();
+                    if (state.logged_render_graph_dumps.emplace(dump).second) {
+                        LOG_INFO("[RenderGraph][Raytracing][DebugDump]\n{}", dump);
+                    }
+                }
+
+                // The caller-owned prefix and managed graph command lists are
+                // distinct submissions. Close every scope before sealing the
+                // prefix; the frame tail will finish the profiling transaction.
+                renderer_marker.Close();
+                if (!cmd_list.IsEmpty()) {
+                    CmdSubmit prefix_submit =
+                        cmd_list.Submit().DebugLabel(
+                            std::format(
+                                "Raytracing Frame {}/Graph Prefix",
+                                frame_packet.frame_id
+                            ),
+                            GpuMarkerPalette::Renderer()
+                        );
+                    prefix_submit.SetProfilingPhase(
+                        split_graph_profiling_frame ?
+                            ERHIProfilingPhase::Continue :
+                            ERHIProfilingPhase::Begin
+                    );
+                    split_graph_profiling_frame = true;
+                    RHIExecutor::Get().Submit(
+                        EQueueType::Graphics,
+                        std::move(prefix_submit),
+                        ERHIExecSubmitFlags::None
+                    );
+                }
+
+                const auto configure_recording_source =
+                    [&](const RenderGraph::ExecutedPassInfo& pass,
+                        RHIRecordingSource&                  source) {
+                        source.submit_metadata.debug_label = std::format(
+                            "Raytracing Frame {}/{}",
+                            frame_packet.frame_id,
+                            pass.name
+                        );
+                        source.submit_metadata.debug_label_color =
+                            GpuMarkerPalette::Pass();
+                        source.submit_metadata.profiling_phase =
+                            split_graph_profiling_frame ?
+                                ERHIProfilingPhase::Continue :
+                                ERHIProfilingPhase::Begin;
+                        split_graph_profiling_frame = true;
+                    };
+                if (graph.ExecuteRecording(
+                        {},
+                        configure_recording_source,
+                        state.render_graph_parallel_recording,
+                        {},
+                        RenderGraph::ActiveRecordingOptions{.enabled = true}
+                    )) {
+                    graph_gbuffer_recorded = true;
+                } else {
+                    state.render_graph_fallback_latched = true;
+                    LOG_ERROR(
+                        "[RenderGraph][Fallback] Raytracing GBuffer graph "
+                        "recording failed before transaction commit: {}. "
+                        "Re-recording GBuffer linearly this frame and using the "
+                        "linear path from the next frame.",
+                        graph.GetCompileError()
+                    );
+                }
+            }
+        }
+        if (!graph_gbuffer_recorded) {
             ScopedGpuMarker pass_marker(
                 cmd_list, "Pass: GBuffer", GpuMarkerPalette::Pass()
             );
             state.g_buffer_pass->Process(cmd_list, *state.rt_ctx);
+            linear_gbuffer_recorded = true;
+        } else {
+            state.g_buffer_pass->RecordLegacyTailBridge(
+                cmd_list,
+                *state.rt_ctx
+            );
         }
         ScopedGpuMarker lighting_marker(
             cmd_list, "Pass: Lighting", GpuMarkerPalette::Pass()
@@ -793,6 +930,7 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
                     Ext::NRDInterface::EResourceSlot::OUT_SPECULAR, frame_rt.denoised_specular_lighting
                 );
                 state.nrd_interface->Denoise(cmd_list, denoiser, "Radiance Denoising");
+                nrd_recorded = true;
             }
         }
 #endif
@@ -935,8 +1073,12 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
                 GpuMarkerPalette::Frame()
             )
             .Signal(timeline, time)
-            .DeleteResources()
-            .TickProfiling();
+            .DeleteResources();
+    if (split_graph_profiling_frame) {
+        frame_submit.SetProfilingPhase(ERHIProfilingPhase::End);
+    } else {
+        frame_submit.TickProfiling();
+    }
     std::optional<RHIPresentRequest> present_request{};
     if (!skip_present) {
         const auto output_view = state.output->GetView();
@@ -972,6 +1114,14 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
         ERHIExecSubmitFlags::FlushGPU,
         present_request ? &*present_request : nullptr
     );
+    if (linear_gbuffer_recorded || graph_gbuffer_recorded) {
+        state.gbuffer_initialized_history_mask |= gbuffer_history_bit;
+    }
+    if (graph_gbuffer_recorded) {
+        state.normal_roughness_readable = true;
+    } else if (linear_gbuffer_recorded) {
+        state.normal_roughness_readable = nrd_recorded;
+    }
     if (!skip_present) {
         PresentUiDrawFrame(frame_packet.ui_draw_frame, ui_execution_thread);
     }
@@ -1092,7 +1242,7 @@ void RaytracingRenderer::RefreshSceneRuntimeRefs() {
     }
 }
 
-void RaytracingRenderer::ExecuteSceneUpdates(SceneUpdateBatch& batch) {
+bool RaytracingRenderer::ExecuteSceneUpdates(SceneUpdateBatch& batch) {
     auto& state = *runtime_state;
     bool  updated = false;
     bool  rt_scene_updated = false;
@@ -1124,6 +1274,7 @@ void RaytracingRenderer::ExecuteSceneUpdates(SceneUpdateBatch& batch) {
     if (rt_scene_updated && state.rt_scene) {
         state.current_tlas_revision = state.rt_instance_revision;
     }
+    return rt_scene_updated;
 }
 
 void RaytracingRenderer::RecreateFrameResources(uint2 new_extent) {
@@ -1158,6 +1309,8 @@ void RaytracingRenderer::RecreateFrameResources(uint2 new_extent) {
     state.antialias_pass_info.feedback_color_pong = state.rt_ctx->frame_rt.feedback_color_pong;
     state.antialias_pass   = MakeUnique<AntialiasPass>(device, manager, state.antialias_pass_info);
     state.b_feedback_valid = false;
+    state.gbuffer_initialized_history_mask = 0;
+    state.normal_roughness_readable         = false;
 }
 
 } // namespace Moer::Render::Raytracing

--- a/source/runtime/render/renderer/raytracing/RaytracingRenderer.cpp
+++ b/source/runtime/render/renderer/raytracing/RaytracingRenderer.cpp
@@ -528,8 +528,10 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
     bool split_graph_profiling_frame       = false;
     bool graph_primary_recorded             = false;
     bool graph_composition_recorded         = false;
+    bool graph_antialias_recorded           = false;
     bool linear_gbuffer_recorded            = false;
     bool linear_lighting_recorded           = false;
+    bool linear_antialias_recorded           = false;
     bool nrd_recorded                       = false;
     uint8 gbuffer_history_bit               = 0;
     LightingPass::LocalLightSamplingDecision local_light_sampling{};
@@ -797,6 +799,8 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
         if (state.render_graph_enabled && !state.render_graph_fallback_latched &&
             state.gbuffer_initialized_history_mask == uint8(0b11) &&
             state.lighting_initialized_reservoir_mask == uint8(0b111) &&
+            (nrd_active_this_frame ||
+             state.antialias_pass->IsHistoryReadyForGraph()) &&
             !render_graph_boundary_frame) {
             RenderGraph graph(
                 nrd_active_this_frame ?
@@ -829,12 +833,26 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
                      graph_resources,
                      *state.rt_ctx
                  ));
-            if (!gbuffer_added || !lighting_added || !composition_added) {
+            const bool antialias_in_graph = composition_in_graph;
+            const bool antialias_added =
+                !antialias_in_graph ||
+                (composition_added &&
+                 state.antialias_pass->AddPasses(
+                     graph,
+                     graph_resources,
+                     *state.rt_ctx,
+                     aa_params,
+                     state.b_feedback_valid,
+                     state.rt_ctx->frame_rt.hdr_color,
+                     state.rt_ctx->frame_rt.resolved_color
+                 ));
+            if (!gbuffer_added || !lighting_added || !composition_added ||
+                !antialias_added) {
                 state.render_graph_fallback_latched = true;
                 LOG_ERROR(
                     "[RenderGraph][Fallback] Raytracing primary graph could not "
-                    "import a required GBuffer/Lighting/Composition resource. "
-                    "Using the linear path for this renderer instance."
+                    "import a required GBuffer/Lighting/Composition/AntiAlias "
+                    "resource. Using the linear path for this renderer instance."
                 );
             } else if (!graph.Compile()) {
                 state.render_graph_fallback_latched = true;
@@ -903,6 +921,7 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
                     )) {
                     graph_primary_recorded     = true;
                     graph_composition_recorded = composition_in_graph;
+                    graph_antialias_recorded   = antialias_in_graph;
                 } else {
                     state.render_graph_fallback_latched = true;
                     LOG_ERROR(
@@ -933,7 +952,8 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
             state.g_buffer_pass->RecordLegacyTailBridge(
                 cmd_list,
                 *state.rt_ctx,
-                graph_composition_recorded
+                graph_composition_recorded,
+                graph_antialias_recorded
             );
         }
         feedback.configured_local_light_sample_mode = local_light_sampling.configured_mode;
@@ -1002,7 +1022,7 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
             );
             state.composition_pass->Process(cmd_list, *state.rt_ctx);
         }
-        {
+        if (!graph_antialias_recorded) {
             ScopedGpuMarker pass_marker(
                 cmd_list, "Pass: Anti Aliasing", GpuMarkerPalette::Pass()
             );
@@ -1013,6 +1033,7 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
                 state.rt_ctx->frame_rt.hdr_color,
                 state.rt_ctx->frame_rt.resolved_color
             );
+            linear_antialias_recorded = true;
         }
         {
             ScopedGpuMarker pass_marker(
@@ -1054,8 +1075,6 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
 
         state.rt_ctx->AdvanceFrame();
         state.tone_mapping_pass->AdvanceFrame(camera.GetDeltaTime());
-        state.antialias_pass->AdvanceFrame();
-        state.b_feedback_valid = true;
 
         if (state.b_export) {
             renderer_marker.Close();
@@ -1175,6 +1194,10 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
         ERHIExecSubmitFlags::FlushGPU,
         present_request ? &*present_request : nullptr
     );
+    if (linear_antialias_recorded || graph_antialias_recorded) {
+        state.antialias_pass->CommitAcceptedFrame();
+        state.b_feedback_valid = true;
+    }
     if (linear_gbuffer_recorded || graph_primary_recorded) {
         state.gbuffer_initialized_history_mask |= gbuffer_history_bit;
     }

--- a/source/runtime/render/renderer/raytracing/RaytracingRenderer.h
+++ b/source/runtime/render/renderer/raytracing/RaytracingRenderer.h
@@ -60,7 +60,7 @@ private:
 
     void EnsureDebugUiRegistered(const EngineHooks& hooks);
     void RefreshSceneRuntimeRefs();
-    void ExecuteSceneUpdates(SceneUpdateBatch& batch);
+    bool ExecuteSceneUpdates(SceneUpdateBatch& batch);
     void RecreateFrameResources(uint2 new_extent);
 
     void DumpTextureToFile(

--- a/source/runtime/render/renderer/raytracing/ShaderUtils.cpp
+++ b/source/runtime/render/renderer/raytracing/ShaderUtils.cpp
@@ -28,14 +28,6 @@ ShaderUtils::ShaderUtils(ShaderManager& manager) {
     ));
     generate_mips_pipeline    = std::move(manager.Compute<GenerateMipsPipeline>("core/utils/BuildMips.hlsl"));
 
-    GfxPsoCreateInfo show_texture_pso_info(
-        RHIRasterizeInfo::Preset(), {}, {RHIColorAttachmentInfo::Preset(PF_R8G8B8A8_UNORM)}
-    );
-    show_texture_pipeline = std::move(manager.Raster()
-                                          .Vertex("core/utils/FullScreenQuad.hlsl")
-                                          .Pixel("core/utils/ShowTexture.frag.hlsl")
-                                          .Build<ShowTexturePipeline>(std::move(show_texture_pso_info)));
-
     copy_texture_pipeline =
         std::move(manager.Compute<CopyTextureComputePipeline>("core/utils/CopyTexture.cs.hlsl"));
 }
@@ -145,24 +137,6 @@ void ShaderUtils::GenerateMips(CommandList& _cmd_list, std::span<TextureView> _m
         width  = std::max(1u, width >> 5);
         height = std::max(1u, height >> 5);
     }
-}
-
-void ShaderUtils::ShowTexture(
-    CommandList&             _cmd_list,
-    BindlessArrayRef         _bdls,
-    const ShowTextureParams& _param,
-    TextureRef               _src_tex,
-    TextureRef               _dst_texture
-) {
-    _cmd_list.Gfx(show_texture_pipeline, _param, _src_tex->GetView(0, _src_tex->GetNumMips()), _bdls)
-        .Draw(
-            "ShowTexture",
-            Rect2D(0, 0, _dst_texture->GetExtent().x, _dst_texture->GetExtent().y),
-            {},
-            3,
-            {SingleDrawParam(3, 1, 0, 0, 0)},
-            ColorAttachment(_dst_texture)
-        );
 }
 
 void ShaderUtils::SampleTextureCS(

--- a/source/runtime/render/renderer/raytracing/ShaderUtils.h
+++ b/source/runtime/render/renderer/raytracing/ShaderUtils.h
@@ -48,16 +48,6 @@ public:
     DEFINE_SHADER_ARGS(mips, param);
 };
 
-struct ShowTexturePipeline : public RasterPipeline {
-public:
-    DEFINE_RASTER_PIPELINE_CLASS(ShowTexturePipeline);
-    DEFINE_SHADER_BINDLESS_ARRAY(bdls);
-    DEFINE_SHADER_TEX(src_tex);
-    DEFINE_SHADER_CONSTANT_STRUCT(ShowTextureParams, param);
-
-    DEFINE_SHADER_ARGS(param, src_tex, bdls);
-};
-
 class CopyTextureComputePipeline : public ComputePipeline {
 public:
     DEFINE_COMPUTE_PIPELINE_CLASS(CopyTextureComputePipeline);
@@ -91,10 +81,6 @@ public:
         return generate_mips_pipeline;
     }
 
-    ShowTexturePipeline& GetShowTexturePipeline() {
-        return show_texture_pipeline;
-    }
-
     void GenerateLowDiscrepancySequence(
         CommandList&                   _cmd_list,
         GenLowDiscrepancySequenceParam _param,
@@ -106,14 +92,6 @@ public:
         std::span<TextureView> _integrated_mips
     );
     void GenerateMips(CommandList& _cmd_list, std::span<TextureView> _mips);
-    void ShowTexture(
-        CommandList&             _cmd_list,
-        BindlessArrayRef         _bdls,
-        const ShowTextureParams& _param,
-        TextureRef               _src_tex,
-        TextureRef               _dst_texture
-    );
-
     void SampleTextureCS(CommandList& cmd_list, TextureView input_texture, TextureView output_texture);
 
     [[deprecated("Output format is provided by the output texture")]] void SampleTextureCS(
@@ -129,7 +107,6 @@ private:
     GenLowDiscrepancyPipeline  gen_low_discrepancy_pipeline;
     GenerateMipPdfPipeline     generate_mip_pdf_pipeline;
     GenerateMipsPipeline       generate_mips_pipeline;
-    ShowTexturePipeline        show_texture_pipeline;
     CopyTextureComputePipeline copy_texture_pipeline;
 };
 } // namespace Moer::Render::Raytracing

--- a/source/runtime/render/renderer/raytracing/ShowTexturePass.cpp
+++ b/source/runtime/render/renderer/raytracing/ShowTexturePass.cpp
@@ -1,0 +1,178 @@
+#include "ShowTexturePass.h"
+
+#include "PixelFormat.h"
+#include "rhi/RHICommand.h"
+#include "rhi/RHIResource.h"
+#include "shader/ShaderResourceManager.h"
+
+#include <algorithm>
+
+namespace Moer::Render::Raytracing {
+
+namespace {
+
+bool CanRecordShowTexture(
+    const TextureRef& source,
+    const TextureRef& target
+) {
+    return source && target && source.Get() != target.Get() &&
+           source->GetDimension() == ETextureDimension::TEX_2D &&
+           source->GetNumArray() == 1 && source->GetNumMips() > 0 &&
+           source->GetExtent().x > 0 && source->GetExtent().y > 0 &&
+           target->GetExtent().x > 0 && target->GetExtent().y > 0;
+}
+
+} // namespace
+
+ShowTexturePass::ShowTexturePass(
+    ShaderManager&    manager,
+    BindlessArrayRef  bindless_array
+) {
+    auto owner = MakeShared<RecordingOwner>();
+    owner->bindless_array = std::move(bindless_array);
+
+    GfxPsoCreateInfo pso_info(
+        RHIRasterizeInfo::Preset(),
+        {},
+        {RHIColorAttachmentInfo::Preset(PF_R8G8B8A8_UNORM)}
+    );
+    owner->pipeline =
+        manager.Raster()
+            .Vertex("core/utils/FullScreenQuad.hlsl")
+            .Pixel("core/utils/ShowTexture.frag.hlsl")
+            .Build<ShowTexturePipeline>(std::move(pso_info));
+    recording_owner = std::move(owner);
+}
+
+ShowTexturePass::PreparedCommand ShowTexturePass::Prepare(
+    ShowTextureParams params,
+    const TextureRef& source,
+    const TextureRef& target
+) {
+    PreparedCommand command{};
+    command.params         = params;
+    command.params.dst_dim = target->GetExtent().xy;
+    command.params.mip_level =
+        std::min(command.params.mip_level, source->GetNumMips() - 1);
+    return command;
+}
+
+ShowTexturePass::RecordResources ShowTexturePass::CaptureResources(
+    const TextureRef& source,
+    const TextureRef& target
+) {
+    return {
+        .source = source,
+        .target = target,
+    };
+}
+
+void ShowTexturePass::Record(
+    CommandList&           cmd_list,
+    RecordingOwner&        owner,
+    const PreparedCommand& command,
+    const RecordResources& resources
+) {
+    cmd_list
+        .Gfx(
+            owner.pipeline,
+            command.params,
+            resources.source->GetView(0, resources.source->GetNumMips()),
+            owner.bindless_array
+        )
+        .Draw(
+            "ShowTexture",
+            Rect2D(
+                0,
+                0,
+                resources.target->GetExtent().x,
+                resources.target->GetExtent().y
+            ),
+            {},
+            3,
+            {SingleDrawParam(3, 1, 0, 0, 0)},
+            ColorAttachment(resources.target)
+        );
+}
+
+void ShowTexturePass::Process(
+    CommandList&      cmd_list,
+    ShowTextureParams params,
+    const TextureRef& source,
+    const TextureRef& target
+) {
+    const auto owner = recording_owner;
+    if (!owner || !owner->bindless_array ||
+        !CanRecordShowTexture(source, target)) {
+        return;
+    }
+    const PreparedCommand command   = Prepare(params, source, target);
+    const RecordResources resources = CaptureResources(source, target);
+    Record(cmd_list, *owner, command, resources);
+}
+
+bool ShowTexturePass::AddPass(
+    RenderGraph&               graph,
+    RenderGraph::TextureHandle source_handle,
+    RenderGraph::TextureHandle target_handle,
+    ShowTextureParams          params,
+    const TextureRef&          source,
+    const TextureRef&          target
+) {
+    const auto owner = recording_owner;
+    if (!owner || !owner->bindless_array ||
+        !CanRecordShowTexture(source, target) ||
+        !source_handle.IsValid() || !target_handle.IsValid()) {
+        return false;
+    }
+
+    const PreparedCommand command   = Prepare(params, source, target);
+    const RecordResources resources = CaptureResources(source, target);
+    constexpr RenderGraph::TextureState source_state =
+        RenderGraph::TextureState::Sampled;
+
+    graph.SetInitialState(
+        source_handle,
+        source_state,
+        RenderGraph::QueueRole::Graphics,
+        RenderGraph::AccessMode::Read
+    );
+    graph.AddRecordPass(
+        "RT.ShowTexture",
+        [=](RenderGraph::PassBuilder& builder) {
+            builder
+                .ExecuteOn(
+                    RenderGraph::QueueRole::Graphics,
+                    RenderGraph::PipelineType::Graphics
+                )
+                .Read(source_handle, RenderGraph::TextureState::Sampled)
+                .Write(target_handle, RenderGraph::TextureState::RenderTarget);
+        },
+        [owner, command, resources](CommandList& cmd_list) {
+            ScopedGpuMarker marker(
+                cmd_list,
+                "ShowTexture",
+                GpuMarkerPalette::Pass(),
+                EGpuMarkerMode::Timestamp
+            );
+            Record(cmd_list, *owner, command, resources);
+        },
+        RenderGraph::PassExecutionClass::ParallelRecordEligible
+    );
+
+    graph.Export(
+        source_handle,
+        source_state,
+        RenderGraph::QueueRole::Graphics,
+        RenderGraph::AccessMode::Read
+    );
+    graph.Export(
+        target_handle,
+        RenderGraph::TextureState::Sampled,
+        RenderGraph::QueueRole::Graphics,
+        RenderGraph::AccessMode::Read
+    );
+    return true;
+}
+
+} // namespace Moer::Render::Raytracing

--- a/source/runtime/render/renderer/raytracing/ShowTexturePass.h
+++ b/source/runtime/render/renderer/raytracing/ShowTexturePass.h
@@ -1,0 +1,79 @@
+#ifndef MOER_RENDER_SHOW_TEXTURE_PASS_H
+#define MOER_RENDER_SHOW_TEXTURE_PASS_H
+
+#include "RaytracingGraphResources.h"
+#include "shader/ShaderPipeline.h"
+#include "shaderheaders/shared/utils/ShaderParameters.h"
+
+namespace Moer::Render {
+class ShaderManager;
+}
+
+namespace Moer::Render::Raytracing {
+
+class ShowTexturePipeline : public RasterPipeline {
+public:
+    DEFINE_RASTER_PIPELINE_CLASS(ShowTexturePipeline);
+    DEFINE_SHADER_BINDLESS_ARRAY(bdls);
+    DEFINE_SHADER_TEX(src_tex);
+    DEFINE_SHADER_CONSTANT_STRUCT(ShowTextureParams, param);
+
+    DEFINE_SHADER_ARGS(param, src_tex, bdls);
+};
+
+class ShowTexturePass {
+public:
+    struct PreparedCommand {
+        ShowTextureParams params{};
+    };
+
+    struct RecordResources {
+        TextureRef source{};
+        TextureRef target{};
+    };
+
+    ShowTexturePass(ShaderManager& manager, BindlessArrayRef bindless_array);
+
+    void Process(
+        CommandList&             cmd_list,
+        ShowTextureParams        params,
+        const TextureRef&        source,
+        const TextureRef&        target
+    );
+    bool AddPass(
+        RenderGraph&               graph,
+        RenderGraph::TextureHandle source_handle,
+        RenderGraph::TextureHandle target_handle,
+        ShowTextureParams          params,
+        const TextureRef&          source,
+        const TextureRef&          target
+    );
+
+private:
+    struct RecordingOwner {
+        BindlessArrayRef    bindless_array{};
+        ShowTexturePipeline pipeline{};
+    };
+
+    static PreparedCommand Prepare(
+        ShowTextureParams   params,
+        const TextureRef&   source,
+        const TextureRef&   target
+    );
+    static RecordResources CaptureResources(
+        const TextureRef& source,
+        const TextureRef& target
+    );
+    static void Record(
+        CommandList&           cmd_list,
+        RecordingOwner&        owner,
+        const PreparedCommand& command,
+        const RecordResources& resources
+    );
+
+    SharedPtr<RecordingOwner> recording_owner;
+};
+
+} // namespace Moer::Render::Raytracing
+
+#endif

--- a/source/runtime/render/renderer/raytracing/ToneMappingPass.cpp
+++ b/source/runtime/render/renderer/raytracing/ToneMappingPass.cpp
@@ -11,6 +11,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <cstring>
 
 namespace Moer::Render::Raytracing {
 
@@ -19,144 +20,624 @@ namespace {
 constexpr float g_min_log_luminance = -10.f;
 constexpr float g_max_log_luminance = 4.f;
 
+float FiniteOr(float value, float fallback) {
+    return std::isfinite(value) ? value : fallback;
+}
+
+RenderGraph::TextureState PreferredReadState(const TextureRef& texture) {
+    const auto usage = texture->GetUsage();
+    const bool supports_uav =
+        (usage & ETextureUsageFlags::UNORDERED_ACCESS) ==
+        ETextureUsageFlags::UNORDERED_ACCESS;
+    return supports_uav ?
+               RenderGraph::TextureState::ShaderResource :
+               RenderGraph::TextureState::Sampled;
+}
+
 } // namespace
 
-ToneMappingPass::ToneMappingPass(RenderDevice& device, ShaderManager& manager, CreateInfo info) :
-    histogram_pipeline{manager.Compute<HistogramPipeline>("pipelines/raytracing/postprocess/Histogram.hlsl")},
-    exposure_pipeline{manager.Compute<ExposurePipeline>("pipelines/raytracing/postprocess/Exposure.hlsl")} {
+ToneMappingPass::ToneMappingPass(
+    RenderDevice&  device,
+    ShaderManager& manager,
+    CreateInfo     info
+) {
+    auto owner = MakeShared<RecordingOwner>();
+    owner->histogram_pipeline =
+        manager.Compute<HistogramPipeline>(
+            "pipelines/raytracing/postprocess/Histogram.hlsl"
+        );
+    owner->exposure_pipeline =
+        manager.Compute<ExposurePipeline>(
+            "pipelines/raytracing/postprocess/Exposure.hlsl"
+        );
 
     VertexStream     stream{};
     GfxPsoCreateInfo pso_info(
-        RHIRasterizeInfo::Preset(), stream, {RHIColorAttachmentInfo::Preset(PF_R8G8B8A8_UNORM)}
+        RHIRasterizeInfo::Preset(),
+        stream,
+        {RHIColorAttachmentInfo::Preset(PF_R8G8B8A8_UNORM)}
     );
+    owner->tone_mapping =
+        manager.Raster()
+            .Vertex("core/utils/FullScreenQuad.hlsl")
+            .Pixel("pipelines/raytracing/postprocess/ToneMappingPass.hlsl")
+            .Build<ToneMappingPassPipeline>(std::move(pso_info));
 
-    tone_mapping_pass_pipeline = manager.Raster()
-                                     .Vertex("core/utils/FullScreenQuad.hlsl")
-                                     .Pixel("pipelines/raytracing/postprocess/ToneMappingPass.hlsl")
-                                     .Build<ToneMappingPassPipeline>(std::move(pso_info));
-
-    tone_mapping_constants = device.CreateBuffer<Moer::byte>(
-        "tone_mapping_constants", sizeof(ToneMappingParams), EBufferUsageFlags::CONSTANT_BUFFER
+    owner->constants = device.CreateBuffer<Moer::byte>(
+        "tone_mapping_constants",
+        sizeof(ToneMappingParams),
+        EBufferUsageFlags::CONSTANT_BUFFER
     );
-    histogram_buffer = device.CreateBuffer<uint>(
+    owner->histogram = device.CreateBuffer<uint>(
         "histogram_buffer",
-        info.histogram_bins,
-        EBufferUsageFlags::UNORDERED_ACCESS | EBufferUsageFlags::TEXTURE_BUFFER
+        std::max(info.histogram_bins, uint(HISTOGRAM_BINS)),
+        EBufferUsageFlags::UNORDERED_ACCESS |
+            EBufferUsageFlags::TEXTURE_BUFFER
     );
-    histogram_buffer->SetName("histogram_buffer");
-    exposure_buffer = device.CreateBuffer<uint>(
-        "exposure_buffer", 1, EBufferUsageFlags::UNORDERED_ACCESS | EBufferUsageFlags::TEXTURE_BUFFER
+    owner->histogram->SetName("histogram_buffer");
+    owner->exposure = device.CreateBuffer<uint>(
+        "exposure_buffer",
+        1,
+        EBufferUsageFlags::UNORDERED_ACCESS |
+            EBufferUsageFlags::TEXTURE_BUFFER
     );
+    recording_owner = std::move(owner);
 
-    if (info.color_lut) {
-        color_lut = info.color_lut;
-        if (color_lut->GetHeight() * color_lut->GetHeight() != color_lut->GetWidth()) {
-            color_lut_size = 0;
+    color_lut = std::move(info.color_lut);
+    if (color_lut) {
+        const uint height = color_lut->GetHeight();
+        if (height > 1 && height * height == color_lut->GetWidth()) {
+            color_lut_size = height;
         }
     }
 }
 
-void ToneMappingPass::Process(
-    CommandList& cmd_list,
-    Params       pass_params,
-    TextureRef   source_texture,
-    TextureRef   target_texture
+ToneMappingPass::PreparedCommand ToneMappingPass::Prepare(
+    Params            params,
+    const TextureRef& source_texture
+) const {
+    PreparedCommand command{};
+    command.params.log_luminance_scale =
+        1.f / (g_max_log_luminance - g_min_log_luminance);
+    command.params.log_luminance_bias =
+        -g_min_log_luminance * command.params.log_luminance_scale;
+    command.params.log_luminance_scale_exposure =
+        g_max_log_luminance - g_min_log_luminance;
+    command.params.log_luminance_bias_exposure = g_min_log_luminance;
+
+    command.params.histogram_low_percentile = std::clamp(
+        FiniteOr(params.histogram_low_percentile, 0.8f),
+        0.f,
+        0.99f
+    );
+    command.params.histogram_high_percentile = std::clamp(
+        FiniteOr(params.histogram_high_percentile, 0.95f),
+        command.params.histogram_low_percentile,
+        1.f
+    );
+    command.params.eye_adaptation_speed_up =
+        std::max(FiniteOr(params.eye_adaptation_speed_up, 1.f), 0.f);
+    command.params.eye_adaptation_speed_down =
+        std::max(FiniteOr(params.eye_adaptation_speed_down, 0.5f), 0.f);
+    command.params.min_adapted_luminance =
+        std::max(FiniteOr(params.min_adapted_luminance, 0.02f), 1e-6f);
+    command.params.max_adapted_luminance = std::max(
+        FiniteOr(params.max_adapted_luminance, 0.5f),
+        command.params.min_adapted_luminance
+    );
+    command.params.frame_time =
+        std::max(FiniteOr(frame_time, 0.f), 0.f);
+    command.params.view_origin = uint2(0, 0);
+    command.params.view_size = uint2(
+        source_texture->GetExtent().x,
+        source_texture->GetExtent().y
+    );
+    command.params.exposure_scale = std::exp2f(
+        std::clamp(FiniteOr(params.exposure_bias, -0.5f), -32.f, 32.f)
+    );
+    const float white_point =
+        std::max(FiniteOr(params.white_point, 3.f), 1e-4f);
+    command.params.white_point_inv_squared =
+        1.f / (white_point * white_point);
+    command.params.source_slice = 0;
+
+    const bool enable_color_lut =
+        params.enable_color_lut && color_lut_size > 1;
+    command.params.color_lut_size =
+        enable_color_lut ?
+            float2(color_lut_size * color_lut_size, color_lut_size) :
+            float2(0.f);
+    command.params.color_lut_size_inv =
+        enable_color_lut ?
+            float2(
+                1.f / (color_lut_size * color_lut_size),
+                1.f / color_lut_size
+            ) :
+            float2(0.f);
+    command.params.frame_idx = frame_idx;
+    command.params.enabled = params.enable_tone_mapping ? 1 : 0;
+
+    command.histogram_dispatch_groups = uint3(
+        (source_texture->GetExtent().x + 15) / 16,
+        (source_texture->GetExtent().y + 15) / 16,
+        1
+    );
+    command.reset_exposure =
+        !initialized ||
+        tone_mapping_enabled != params.enable_tone_mapping;
+    return command;
+}
+
+ToneMappingPass::RecordResources ToneMappingPass::CaptureResources(
+    TextureRef source_texture,
+    TextureRef target_texture
+) const {
+    TextureRef lut = color_lut ? color_lut : source_texture;
+    return RecordResources{
+        .source    = std::move(source_texture),
+        .target    = std::move(target_texture),
+        .color_lut = std::move(lut)
+    };
+}
+
+void ToneMappingPass::RecordConstantsUpload(
+    CommandList&           cmd_list,
+    const RecordingOwner&  owner,
+    const PreparedCommand& command
 ) {
-    const bool enable_color_lut = pass_params.enable_color_lut && color_lut_size > 0;
-
-    cmd_list.PushScopeWithTimeScope("ToneMappingPass");
-    ToneMappingParams params{};
-    params.log_luminance_scale          = 1.f / (g_max_log_luminance - g_min_log_luminance);
-    params.log_luminance_bias           = -g_min_log_luminance * params.log_luminance_scale;
-    params.log_luminance_scale_exposure = g_max_log_luminance - g_min_log_luminance;
-    params.log_luminance_bias_exposure  = g_min_log_luminance;
-    params.histogram_low_percentile =
-        std::min(0.99f, std::max(0.f, pass_params.histogram_low_percentile));
-    params.histogram_high_percentile = std::min(
-        1.f, std::max(pass_params.histogram_high_percentile, pass_params.histogram_low_percentile)
+    Array<byte> upload_data(sizeof(ToneMappingParams));
+    std::memcpy(
+        upload_data.data(),
+        &command.params,
+        sizeof(ToneMappingParams)
     );
-    params.eye_adaptation_speed_up   = pass_params.eye_adaptation_speed_up;
-    params.eye_adaptation_speed_down = pass_params.eye_adaptation_speed_down;
-    params.min_adapted_luminance     = pass_params.min_adapted_luminance;
-    params.max_adapted_luminance     = pass_params.max_adapted_luminance;
-    params.frame_time                = frame_time;
-    params.view_origin               = uint2(0, 0);
-    params.view_size                 = uint2(source_texture->GetExtent().x, source_texture->GetExtent().y);
-    params.exposure_scale            = std::exp2f(pass_params.exposure_bias);
-    params.white_point_inv_squared   = 1.f / (pass_params.white_point * pass_params.white_point);
-    params.source_slice              = 0;
-    params.color_lut_size = enable_color_lut ?
-                                float2(color_lut_size * color_lut_size, color_lut_size) :
-                                float2(0.f);
-    params.color_lut_size_inv = enable_color_lut ?
-                                    float2(
-                                        1.f / (color_lut_size * color_lut_size), 1.f / color_lut_size
-                                    ) :
-                                    float2(0.f);
-    params.frame_idx = frame_idx;
-    params.enabled   = pass_params.enable_tone_mapping ? 1 : 0;
-
-    if (!tone_mapping_enabled != pass_params.enable_tone_mapping) {
-        tone_mapping_enabled = pass_params.enable_tone_mapping;
-        ResetExposure(cmd_list);
-    }
-
-    upload_data.resize(sizeof(ToneMappingParams));
-    upload_data.assign(
-        reinterpret_cast<byte*>(&params), reinterpret_cast<byte*>(&params) + sizeof(ToneMappingParams)
-    );
-    cmd_list.CopyFrom(std::move(upload_data), tone_mapping_constants->GetView());
-
-    ResetHistogram(cmd_list);
-    ComputeHistogram(cmd_list, source_texture);
-    ComputeExposure(cmd_list);
-    Render(cmd_list, source_texture, target_texture);
-    cmd_list.PopScopeWithTimeScope();
+    cmd_list.CopyFrom(std::move(upload_data), owner.constants->GetView());
 }
 
-void ToneMappingPass::Render(CommandList& cmd_list, TextureRef source_texture, TextureRef target_texture) {
-    Array<SingleDrawParam> full_screen_draw_data{SingleDrawParam{3, 1, 0, 0, 0}};
-    Sampler               linear_clamp_sampler{SF_LINEAR, SAM_CLAMP_TO_EDGE};
+void ToneMappingPass::RecordResetHistogram(
+    CommandList&          cmd_list,
+    const RecordingOwner& owner
+) {
+    cmd_list.ClearResource(owner.histogram->GetView(), 0);
+}
+
+void ToneMappingPass::RecordResetExposure(
+    CommandList&          cmd_list,
+    const RecordingOwner& owner
+) {
+    cmd_list.ClearResource(owner.exposure->GetView(), 0);
+}
+
+void ToneMappingPass::RecordHistogram(
+    CommandList&           cmd_list,
+    RecordingOwner&        owner,
+    const PreparedCommand& command,
+    const RecordResources& resources
+) {
     cmd_list
-        .Gfx(
-            tone_mapping_pass_pipeline,
-            tone_mapping_constants,
-            source_texture,
-            exposure_buffer,
-            color_lut,
-            linear_clamp_sampler
+        .Compute(
+            owner.histogram_pipeline,
+            owner.constants,
+            resources.source,
+            owner.histogram
         )
-        .Draw(
-            "ToneMapping",
-            Rect2D(0, 0, target_texture->GetExtent().x, target_texture->GetExtent().y),
-            std::move(full_screen_draw_data),
-            ColorAttachment(target_texture)
-        );
-}
-
-void ToneMappingPass::ResetHistogram(CommandList& cmd_list) {
-    cmd_list.ClearResource(histogram_buffer->GetView(), 0);
-}
-
-void ToneMappingPass::ResetExposure(CommandList& cmd_list) {
-    cmd_list.ClearResource(exposure_buffer->GetView(), 0);
-}
-
-void ToneMappingPass::ComputeHistogram(CommandList& cmd_list, TextureRef source_texture) {
-    cmd_list.Compute(histogram_pipeline, tone_mapping_constants, source_texture, histogram_buffer)
         .Dispatch(
-            uint3((source_texture->GetExtent().x + 15) / 16, (source_texture->GetExtent().y + 15) / 16, 1),
+            command.histogram_dispatch_groups,
             "Calculate Histogram"
         );
 }
 
-void ToneMappingPass::ComputeExposure(CommandList& cmd_list) {
-    cmd_list.Compute(exposure_pipeline, tone_mapping_constants, histogram_buffer, exposure_buffer)
+void ToneMappingPass::RecordExposure(
+    CommandList&    cmd_list,
+    RecordingOwner& owner
+) {
+    cmd_list
+        .Compute(
+            owner.exposure_pipeline,
+            owner.constants,
+            owner.histogram,
+            owner.exposure
+        )
         .Dispatch(uint3(1, 1, 1), "Calculate Exposure");
 }
 
-void ToneMappingPass::AdvanceFrame(float elapsed_time) {
-    frame_time = elapsed_time;
+void ToneMappingPass::RecordRender(
+    CommandList&           cmd_list,
+    RecordingOwner&        owner,
+    const RecordResources& resources
+) {
+    Array<SingleDrawParam> full_screen_draw_data{
+        SingleDrawParam{3, 1, 0, 0, 0}
+    };
+    Sampler linear_clamp_sampler{
+        ESamplerFilter::SF_LINEAR,
+        ESamplerAddressMode::SAM_CLAMP_TO_EDGE
+    };
+    cmd_list
+        .Gfx(
+            owner.tone_mapping,
+            owner.constants,
+            resources.source,
+            owner.exposure,
+            resources.color_lut,
+            linear_clamp_sampler
+        )
+        .Draw(
+            "ToneMapping",
+            Rect2D(
+                0,
+                0,
+                resources.target->GetExtent().x,
+                resources.target->GetExtent().y
+            ),
+            std::move(full_screen_draw_data),
+            ColorAttachment(resources.target)
+        );
+}
+
+void ToneMappingPass::Process(
+    CommandList& cmd_list,
+    Params       params,
+    TextureRef   source_texture,
+    TextureRef   target_texture
+) {
+    const PreparedCommand command =
+        Prepare(params, source_texture);
+    const RecordResources resources =
+        CaptureResources(
+            std::move(source_texture),
+            std::move(target_texture)
+        );
+    const auto owner = recording_owner;
+
+    cmd_list.PushScopeWithTimeScope("ToneMappingPass");
+    RecordConstantsUpload(cmd_list, *owner, command);
+    if (command.reset_exposure) {
+        RecordResetExposure(cmd_list, *owner);
+    }
+    RecordResetHistogram(cmd_list, *owner);
+    RecordHistogram(cmd_list, *owner, command, resources);
+    RecordExposure(cmd_list, *owner);
+    RecordRender(cmd_list, *owner, resources);
+    cmd_list.PopScopeWithTimeScope();
+}
+
+bool ToneMappingPass::AddPasses(
+    RenderGraph&                 graph,
+    const RTGraphFrameResources& graph_resources,
+    const RTContext&             rt_ctx,
+    Params                       params,
+    TextureRef                   source_texture,
+    TextureRef                   target_texture
+) {
+    const auto owner = recording_owner;
+    if (!owner || !owner->constants || !owner->histogram ||
+        !owner->exposure || !source_texture || !target_texture ||
+        source_texture->GetExtent() != target_texture->GetExtent() ||
+        source_texture.Get() != rt_ctx.frame_rt.resolved_color.Get() ||
+        target_texture.Get() != rt_ctx.frame_rt.ldr_color.Get() ||
+        !graph_resources.resolved_color.IsValid() ||
+        !graph_resources.ldr_color.IsValid()) {
+        return false;
+    }
+
+    const PreparedCommand command =
+        Prepare(params, source_texture);
+    const RecordResources resources =
+        CaptureResources(
+            std::move(source_texture),
+            std::move(target_texture)
+        );
+    if (!resources.source || !resources.target || !resources.color_lut) {
+        return false;
+    }
+
+    const auto constants = ImportRTGraphBuffer(
+        graph,
+        "RT.ToneMapping.constants",
+        owner->constants
+    );
+    const auto histogram = ImportRTGraphBuffer(
+        graph,
+        "RT.ToneMapping.histogram",
+        owner->histogram
+    );
+    const auto exposure = ImportRTGraphBuffer(
+        graph,
+        "RT.ToneMapping.exposure",
+        owner->exposure
+    );
+
+    RenderGraph::TextureHandle lut = graph_resources.resolved_color;
+    const bool lut_is_source =
+        resources.color_lut.Get() == resources.source.Get();
+    if (!lut_is_source) {
+        lut = ImportRTGraphTexture(
+            graph,
+            "RT.ToneMapping.color_lut",
+            resources.color_lut
+        );
+    }
+    if (!lut.IsValid()) {
+        return false;
+    }
+
+    const auto initial_buffer =
+        [&](RenderGraph::BufferHandle buffer) {
+            graph.SetInitialState(
+                buffer,
+                initialized ?
+                    RenderGraph::BufferState::ShaderResource :
+                    RenderGraph::BufferState::Undefined,
+                initialized ?
+                    RenderGraph::QueueRole::Graphics :
+                    RenderGraph::QueueRole::None,
+                initialized ?
+                    RenderGraph::AccessMode::Read :
+                    RenderGraph::AccessMode::None
+            );
+        };
+    initial_buffer(constants);
+    initial_buffer(histogram);
+    initial_buffer(exposure);
+
+    graph.SetInitialState(
+        graph_resources.resolved_color,
+        RenderGraph::TextureState::ShaderResource,
+        RenderGraph::QueueRole::Graphics,
+        RenderGraph::AccessMode::Read
+    );
+    graph.SetInitialState(
+        graph_resources.ldr_color,
+        initialized ?
+            RenderGraph::TextureState::Sampled :
+            RenderGraph::TextureState::Undefined,
+        initialized ?
+            RenderGraph::QueueRole::Graphics :
+            RenderGraph::QueueRole::None,
+        initialized ?
+            RenderGraph::AccessMode::Read :
+            RenderGraph::AccessMode::None
+    );
+    if (!lut_is_source) {
+        graph.SetInitialState(
+            lut,
+            PreferredReadState(resources.color_lut),
+            RenderGraph::QueueRole::Graphics,
+            RenderGraph::AccessMode::Read
+        );
+    }
+
+    graph.AddRecordPass(
+        "RT.ToneMapping.UploadConstants",
+        [=](RenderGraph::PassBuilder& builder) {
+            builder
+                .ExecuteOn(
+                    RenderGraph::QueueRole::Graphics,
+                    RenderGraph::PipelineType::Copy
+                )
+                .Write(
+                    constants,
+                    RenderGraph::BufferState::TransferDestination
+                );
+        },
+        [owner, command](CommandList& cmd_list) {
+            ScopedGpuMarker marker(
+                cmd_list,
+                "Pass: RT ToneMapping Constants Upload",
+                GpuMarkerPalette::Transfer()
+            );
+            RecordConstantsUpload(cmd_list, *owner, command);
+        },
+        RenderGraph::PassExecutionClass::ParallelRecordEligible
+    );
+
+    if (command.reset_exposure) {
+        graph.AddRecordPass(
+            "RT.ToneMapping.ResetExposure",
+            [=](RenderGraph::PassBuilder& builder) {
+                builder
+                    .ExecuteOn(
+                        RenderGraph::QueueRole::Graphics,
+                        RenderGraph::PipelineType::Copy
+                    )
+                    .Write(
+                        exposure,
+                        RenderGraph::BufferState::TransferDestination
+                    );
+            },
+            [owner](CommandList& cmd_list) {
+                ScopedGpuMarker marker(
+                    cmd_list,
+                    "Pass: RT ToneMapping Reset Exposure",
+                    GpuMarkerPalette::Transfer()
+                );
+                RecordResetExposure(cmd_list, *owner);
+            },
+            RenderGraph::PassExecutionClass::ParallelRecordEligible
+        );
+    }
+
+    graph.AddRecordPass(
+        "RT.ToneMapping.ResetHistogram",
+        [=](RenderGraph::PassBuilder& builder) {
+            builder
+                .ExecuteOn(
+                    RenderGraph::QueueRole::Graphics,
+                    RenderGraph::PipelineType::Copy
+                )
+                .Write(
+                    histogram,
+                    RenderGraph::BufferState::TransferDestination
+                );
+        },
+        [owner](CommandList& cmd_list) {
+            ScopedGpuMarker marker(
+                cmd_list,
+                "Pass: RT ToneMapping Reset Histogram",
+                GpuMarkerPalette::Transfer()
+            );
+            RecordResetHistogram(cmd_list, *owner);
+        },
+        RenderGraph::PassExecutionClass::ParallelRecordEligible
+    );
+
+    graph.AddRecordPass(
+        "RT.ToneMapping.Histogram",
+        [=](RenderGraph::PassBuilder& builder) {
+            builder
+                .ExecuteOn(
+                    RenderGraph::QueueRole::Graphics,
+                    RenderGraph::PipelineType::Compute
+                )
+                .Read(
+                    constants,
+                    RenderGraph::BufferState::ShaderResource
+                )
+                .Read(
+                    graph_resources.resolved_color,
+                    RenderGraph::TextureState::Sampled
+                )
+                .ReadWrite(
+                    histogram,
+                    RenderGraph::BufferState::UnorderedAccess
+                );
+        },
+        [owner, command, resources](CommandList& cmd_list) {
+            ScopedGpuMarker marker(
+                cmd_list,
+                "Pass: RT ToneMapping Histogram",
+                GpuMarkerPalette::Pass()
+            );
+            RecordHistogram(cmd_list, *owner, command, resources);
+        },
+        RenderGraph::PassExecutionClass::ParallelRecordEligible
+    );
+
+    graph.AddRecordPass(
+        "RT.ToneMapping.Exposure",
+        [=](RenderGraph::PassBuilder& builder) {
+            builder
+                .ExecuteOn(
+                    RenderGraph::QueueRole::Graphics,
+                    RenderGraph::PipelineType::Compute
+                )
+                .Read(
+                    constants,
+                    RenderGraph::BufferState::ShaderResource
+                )
+                .Read(
+                    histogram,
+                    RenderGraph::BufferState::ShaderResource
+                )
+                .ReadWrite(
+                    exposure,
+                    RenderGraph::BufferState::UnorderedAccess
+                );
+        },
+        [owner](CommandList& cmd_list) {
+            ScopedGpuMarker marker(
+                cmd_list,
+                "Pass: RT ToneMapping Exposure",
+                GpuMarkerPalette::Pass()
+            );
+            RecordExposure(cmd_list, *owner);
+        },
+        RenderGraph::PassExecutionClass::ParallelRecordEligible
+    );
+
+    graph.AddRecordPass(
+        "RT.ToneMapping.Render",
+        [=](RenderGraph::PassBuilder& builder) {
+            builder
+                .ExecuteOn(
+                    RenderGraph::QueueRole::Graphics,
+                    RenderGraph::PipelineType::Graphics
+                )
+                .Read(
+                    constants,
+                    RenderGraph::BufferState::ShaderResource
+                )
+                .Read(
+                    graph_resources.resolved_color,
+                    RenderGraph::TextureState::Sampled
+                )
+                .Read(
+                    exposure,
+                    RenderGraph::BufferState::ShaderResource
+                )
+                .Write(
+                    graph_resources.ldr_color,
+                    RenderGraph::TextureState::RenderTarget
+                );
+            if (!lut_is_source) {
+                builder.Read(
+                    lut,
+                    RenderGraph::TextureState::Sampled
+                );
+            }
+        },
+        [owner, resources](CommandList& cmd_list) {
+            ScopedGpuMarker marker(
+                cmd_list,
+                "ToneMappingPass",
+                GpuMarkerPalette::Pass(),
+                EGpuMarkerMode::Timestamp
+            );
+            RecordRender(cmd_list, *owner, resources);
+        },
+        RenderGraph::PassExecutionClass::ParallelRecordEligible
+    );
+
+    graph.Export(
+        graph_resources.resolved_color,
+        RenderGraph::TextureState::ShaderResource,
+        RenderGraph::QueueRole::Graphics,
+        RenderGraph::AccessMode::Read
+    );
+    graph.Export(
+        graph_resources.ldr_color,
+        RenderGraph::TextureState::Sampled,
+        RenderGraph::QueueRole::Graphics,
+        RenderGraph::AccessMode::Read
+    );
+    graph.Export(
+        constants,
+        RenderGraph::BufferState::ShaderResource,
+        RenderGraph::QueueRole::Graphics,
+        RenderGraph::AccessMode::Read
+    );
+    graph.Export(
+        histogram,
+        RenderGraph::BufferState::ShaderResource,
+        RenderGraph::QueueRole::Graphics,
+        RenderGraph::AccessMode::Read
+    );
+    graph.Export(
+        exposure,
+        RenderGraph::BufferState::ShaderResource,
+        RenderGraph::QueueRole::Graphics,
+        RenderGraph::AccessMode::Read
+    );
+    if (!lut_is_source) {
+        graph.Export(
+            lut,
+            PreferredReadState(resources.color_lut),
+            RenderGraph::QueueRole::Graphics,
+            RenderGraph::AccessMode::Read
+        );
+    }
+    return true;
+}
+
+void ToneMappingPass::CommitAcceptedFrame(
+    float elapsed_time,
+    bool  enabled
+) {
+    initialized          = true;
+    tone_mapping_enabled = enabled;
+    frame_time =
+        std::max(FiniteOr(elapsed_time, 0.f), 0.f);
     ++frame_idx;
 }
 

--- a/source/runtime/render/renderer/raytracing/ToneMappingPass.h
+++ b/source/runtime/render/renderer/raytracing/ToneMappingPass.h
@@ -3,6 +3,7 @@
 
 // 计算亮度曝光，并将 HDR 光照映射到显示目标。
 
+#include "RaytracingGraphResources.h"
 #include "rhi/RHIResource.h"
 #include "shader/ShaderPipeline.h"
 #include "shaderheaders/shared/ShaderParameters.h"
@@ -71,6 +72,18 @@ public:
         bool  enable_tone_mapping       = true;
     };
 
+    struct PreparedCommand {
+        ToneMappingParams params{};
+        uint3             histogram_dispatch_groups{};
+        bool              reset_exposure = false;
+    };
+
+    struct RecordResources {
+        TextureRef source{};
+        TextureRef target{};
+        TextureRef color_lut{};
+    };
+
 public:
     ToneMappingPass(RenderDevice& device, ShaderManager& manager, CreateInfo info);
     void Process(
@@ -79,30 +92,71 @@ public:
         TextureRef   source_texture,
         TextureRef   target_texture
     );
-    void AdvanceFrame(float _frame_time);
+    bool AddPasses(
+        RenderGraph&                 graph,
+        const RTGraphFrameResources& graph_resources,
+        const RTContext&             rt_ctx,
+        Params                       params,
+        TextureRef                   source_texture,
+        TextureRef                   target_texture
+    );
+    void CommitAcceptedFrame(float elapsed_time, bool enabled);
 
 private:
-    void ComputeExposure(CommandList& _cmd_list);
-    void ComputeHistogram(CommandList& _cmd_list, TextureRef _src_tex);
-    void ResetHistogram(CommandList& _cmd_list);
-    void ResetExposure(CommandList& _cmd_list);
-    void Render(CommandList& _cmd_list, TextureRef _src_tex, TextureRef _target);
+    struct RecordingOwner {
+        BufferRef               constants{};
+        BufferRef               histogram{};
+        BufferRef               exposure{};
+        ToneMappingPassPipeline tone_mapping{};
+        HistogramPipeline       histogram_pipeline{};
+        ExposurePipeline        exposure_pipeline{};
+    };
+
+    PreparedCommand Prepare(
+        Params            params,
+        const TextureRef& source_texture
+    ) const;
+    RecordResources CaptureResources(
+        TextureRef source_texture,
+        TextureRef target_texture
+    ) const;
+    static void RecordConstantsUpload(
+        CommandList&           cmd_list,
+        const RecordingOwner&  owner,
+        const PreparedCommand& command
+    );
+    static void RecordResetHistogram(
+        CommandList&          cmd_list,
+        const RecordingOwner& owner
+    );
+    static void RecordResetExposure(
+        CommandList&          cmd_list,
+        const RecordingOwner& owner
+    );
+    static void RecordHistogram(
+        CommandList&           cmd_list,
+        RecordingOwner&        owner,
+        const PreparedCommand& command,
+        const RecordResources& resources
+    );
+    static void RecordExposure(
+        CommandList&           cmd_list,
+        RecordingOwner&        owner
+    );
+    static void RecordRender(
+        CommandList&           cmd_list,
+        RecordingOwner&        owner,
+        const RecordResources& resources
+    );
 
     float frame_time     = 0;
     uint  frame_idx      = 0;
     uint  color_lut_size = 0;
 
-    BufferRef   tone_mapping_constants;
-    BufferRef   histogram_buffer;
-    BufferRef   exposure_buffer;
-    TextureRef  color_lut;
-    Array<byte> upload_data;
-    bool        tone_mapping_enabled = false;
-
-    ToneMappingPassPipeline tone_mapping_pass_pipeline;
-    HistogramPipeline       histogram_pipeline;
-    ExposurePipeline        exposure_pipeline;
-
+    TextureRef                 color_lut;
+    bool                       initialized          = false;
+    bool                       tone_mapping_enabled = false;
+    SharedPtr<RecordingOwner> recording_owner;
 };
 } // namespace Moer::Render::Raytracing
 #endif

--- a/source/runtime/render/renderer/raytracing/VisualizePass.cpp
+++ b/source/runtime/render/renderer/raytracing/VisualizePass.cpp
@@ -7,53 +7,291 @@
 #include "rhi/RHIResource.h"
 #include "shader/ShaderResourceManager.h"
 
+#include <cstring>
+
 namespace Moer::Render::Raytracing {
 
 VisualizePass::VisualizePass(RenderDevice& device, ShaderManager& manager) {
-    visualize_pipeline =
+    auto owner = MakeShared<RecordingOwner>();
+    owner->pipeline =
         manager.Compute<VisualizePipeline>("pipelines/raytracing/passes/VisualizePass.hlsl");
-    visualize_params_buffer = device.CreateBuffer<Moer::byte>(
+    owner->constants = device.CreateBuffer<Moer::byte>(
         "Raytracing::VisualizeBuffer", sizeof(VisualizeParams), EBufferUsageFlags::CONSTANT_BUFFER
     );
+    recording_owner = std::move(owner);
+}
+
+VisualizePass::PreparedCommand VisualizePass::Prepare(
+    const RTContext&       rt_ctx,
+    const VisualizeConfig& config
+) const {
+    PreparedCommand command{};
+    command.params.grid_params    = rt_ctx.is_ctx.GetGridParams();
+    command.params.b_split        = config.b_split;
+    command.params.split_ratio    = config.split_ratio;
+    command.params.visualize_mode = config.visualize_mode;
+    command.params.main_view      = rt_ctx.main_view;
+    command.params.output_size =
+        rt_ctx.frame_rt.debug_color->GetExtent().xy;
+    command.dispatch_groups = uint3(
+        (command.params.output_size.x + 15) / 16,
+        (command.params.output_size.y + 15) / 16,
+        1
+    );
+    return command;
+}
+
+VisualizePass::RecordResources VisualizePass::CaptureResources(
+    const RTContext& rt_ctx
+) {
+    const FrameResources& frame = rt_ctx.frame_rt;
+    return RecordResources{
+        .ldr_color         = frame.ldr_color,
+        .diffuse_lighting  = frame.diffuse_lighting,
+        .specular_lighting = frame.specular_lighting,
+        .view_depth =
+            rt_ctx.b_current_frame ? frame.view_depth : frame.prev_view_depth,
+        .clip_depth = frame.clip_depth,
+        .emission   = frame.emission,
+        .normal =
+            rt_ctx.b_current_frame ? frame.normal : frame.prev_normal,
+        .specular_roughness =
+            rt_ctx.b_current_frame ?
+                frame.specular_roughness :
+                frame.prev_specular_roughness,
+        .motion           = frame.motion,
+        .normal_roughness = frame.normal_roughness,
+        .debug_color      = frame.debug_color
+    };
+}
+
+void VisualizePass::RecordConstantsUpload(
+    CommandList&           cmd_list,
+    const RecordingOwner&  owner,
+    const PreparedCommand& command
+) {
+    Array<Moer::byte> upload_data(sizeof(VisualizeParams));
+    std::memcpy(
+        upload_data.data(),
+        &command.params,
+        sizeof(VisualizeParams)
+    );
+    cmd_list.CopyFrom(std::move(upload_data), owner.constants->GetView());
+}
+
+void VisualizePass::RecordVisualize(
+    CommandList&           cmd_list,
+    RecordingOwner&        owner,
+    const PreparedCommand& command,
+    const RecordResources& resources
+) {
+    cmd_list
+        .Compute(
+            owner.pipeline,
+            owner.constants,
+            resources.ldr_color,
+            resources.diffuse_lighting,
+            resources.specular_lighting,
+            resources.view_depth,
+            resources.clip_depth,
+            resources.emission,
+            resources.normal,
+            resources.specular_roughness,
+            resources.motion,
+            resources.normal_roughness,
+            resources.debug_color
+        )
+        .Dispatch(command.dispatch_groups, "Visualize");
 }
 
 void VisualizePass::Process(
     CommandList&           cmd_list,
     RTContext&             rt_ctx,
-    const VisualizeConfig& config,
-    BindlessArrayRef       bindless_array
+    const VisualizeConfig& config
 ) {
-    params.grid_params      = rt_ctx.is_ctx.GetGridParams();
-    params.b_split          = config.b_split;
-    params.split_ratio      = config.split_ratio;
-    params.visualize_mode   = config.visualize_mode;
-    params.main_view        = rt_ctx.main_view;
-    params.bindless_handles = rt_ctx.GetBindlessHandles();
-    params.output_size      = rt_ctx.frame_rt.ldr_color->GetExtent().xy;
+    const PreparedCommand command   = Prepare(rt_ctx, config);
+    const RecordResources resources = CaptureResources(rt_ctx);
+    const auto            owner     = recording_owner;
 
-    cmd_list.CopyFrom(
-        std::span<Moer::byte>((Moer::byte*)&params, sizeof(VisualizeParams)),
-        visualize_params_buffer->GetView()
+    cmd_list.PushScopeWithTimeScope("VisualizePass");
+    RecordConstantsUpload(cmd_list, *owner, command);
+    RecordVisualize(cmd_list, *owner, command, resources);
+    cmd_list.PopScopeWithTimeScope();
+}
+
+bool VisualizePass::AddPasses(
+    RenderGraph&                 graph,
+    const RTGraphFrameResources& graph_resources,
+    const RTContext&             rt_ctx,
+    const VisualizeConfig&       config
+) {
+    const auto owner = recording_owner;
+    if (!owner || !owner->constants || !graph_resources.ldr_color.IsValid() ||
+        !graph_resources.diffuse_lighting.IsValid() ||
+        !graph_resources.specular_lighting.IsValid() ||
+        !graph_resources.current_view_depth.IsValid() ||
+        !graph_resources.clip_depth.IsValid() ||
+        !graph_resources.emission.IsValid() ||
+        !graph_resources.current_normal.IsValid() ||
+        !graph_resources.current_specular_roughness.IsValid() ||
+        !graph_resources.motion.IsValid() ||
+        !graph_resources.normal_roughness.IsValid() ||
+        !graph_resources.debug_color.IsValid()) {
+        return false;
+    }
+
+    const PreparedCommand command   = Prepare(rt_ctx, config);
+    const RecordResources resources = CaptureResources(rt_ctx);
+    if (!resources.debug_color) {
+        return false;
+    }
+    const auto expected_extent = resources.debug_color->GetExtent();
+    for (const auto& texture : {
+             resources.ldr_color,
+             resources.diffuse_lighting,
+             resources.specular_lighting,
+             resources.view_depth,
+             resources.clip_depth,
+             resources.emission,
+             resources.normal,
+             resources.specular_roughness,
+             resources.motion,
+             resources.normal_roughness,
+             resources.debug_color,
+         }) {
+        if (!texture || texture->GetExtent() != expected_extent) {
+            return false;
+        }
+    }
+    if (expected_extent.x == 0 || expected_extent.y == 0 ||
+        resources.ldr_color.Get() != rt_ctx.frame_rt.ldr_color.Get() ||
+        resources.debug_color.Get() != rt_ctx.frame_rt.debug_color.Get()) {
+        return false;
+    }
+
+    const auto constants = ImportRTGraphBuffer(
+        graph,
+        "RT.Visualize.constants",
+        owner->constants
+    );
+    graph.SetInitialState(
+        constants,
+        RenderGraph::BufferState::ShaderResource,
+        RenderGraph::QueueRole::Graphics,
+        RenderGraph::AccessMode::Read
+    );
+    graph.SetInitialState(
+        graph_resources.debug_color,
+        RenderGraph::TextureState::ShaderResource,
+        RenderGraph::QueueRole::Graphics,
+        RenderGraph::AccessMode::Read
     );
 
-    const auto div_ceil = [](uint value, uint divisor) -> uint {
-        return (value + divisor - 1) / divisor;
-    };
-    const FrameResources& frame = rt_ctx.frame_rt;
-    cmd_list
-        .Compute(
-            visualize_pipeline,
-            visualize_params_buffer,
-            frame.ldr_color,
-            frame.diffuse_lighting,
-            frame.specular_lighting,
-            rt_ctx.b_current_frame ? frame.view_depth : frame.prev_view_depth,
-            frame.emission,
-            frame.debug_color,
-            bindless_array
-        )
-        .Dispatch(
-            uint3(div_ceil(params.output_size.x, 16), div_ceil(params.output_size.y, 16), 1), "Visualize"
-        );
+    graph.AddRecordPass(
+        "RT.Visualize.UploadConstants",
+        [=](RenderGraph::PassBuilder& builder) {
+            builder
+                .ExecuteOn(
+                    RenderGraph::QueueRole::Graphics,
+                    RenderGraph::PipelineType::Copy
+                )
+                .Write(
+                    constants,
+                    RenderGraph::BufferState::TransferDestination
+                );
+        },
+        [owner, command](CommandList& cmd_list) {
+            ScopedGpuMarker marker(
+                cmd_list,
+                "Pass: RT Visualize Constants Upload",
+                GpuMarkerPalette::Transfer()
+            );
+            RecordConstantsUpload(cmd_list, *owner, command);
+        },
+        RenderGraph::PassExecutionClass::ParallelRecordEligible
+    );
+
+    graph.AddRecordPass(
+        "RT.Visualize.Dispatch",
+        [=](RenderGraph::PassBuilder& builder) {
+            builder
+                .ExecuteOn(
+                    RenderGraph::QueueRole::Graphics,
+                    RenderGraph::PipelineType::Compute
+                )
+                .Read(
+                    constants,
+                    RenderGraph::BufferState::ShaderResource
+                )
+                .Read(
+                    graph_resources.ldr_color,
+                    RenderGraph::TextureState::Sampled
+                )
+                .Read(
+                    graph_resources.diffuse_lighting,
+                    RenderGraph::TextureState::Sampled
+                )
+                .Read(
+                    graph_resources.specular_lighting,
+                    RenderGraph::TextureState::Sampled
+                )
+                .Read(
+                    graph_resources.current_view_depth,
+                    RenderGraph::TextureState::Sampled
+                )
+                .Read(
+                    graph_resources.clip_depth,
+                    RenderGraph::TextureState::Sampled
+                )
+                .Read(
+                    graph_resources.emission,
+                    RenderGraph::TextureState::Sampled
+                )
+                .Read(
+                    graph_resources.current_normal,
+                    RenderGraph::TextureState::Sampled
+                )
+                .Read(
+                    graph_resources.current_specular_roughness,
+                    RenderGraph::TextureState::Sampled
+                )
+                .Read(
+                    graph_resources.motion,
+                    RenderGraph::TextureState::Sampled
+                )
+                .Read(
+                    graph_resources.normal_roughness,
+                    RenderGraph::TextureState::Sampled
+                )
+                .Write(
+                    graph_resources.debug_color,
+                    RenderGraph::TextureState::UnorderedAccess
+                );
+        },
+        [owner, command, resources](CommandList& cmd_list) {
+            ScopedGpuMarker marker(
+                cmd_list,
+                "VisualizePass",
+                GpuMarkerPalette::Pass(),
+                EGpuMarkerMode::Timestamp
+            );
+            RecordVisualize(cmd_list, *owner, command, resources);
+        },
+        RenderGraph::PassExecutionClass::ParallelRecordEligible
+    );
+
+    graph.Export(
+        graph_resources.debug_color,
+        RenderGraph::TextureState::ShaderResource,
+        RenderGraph::QueueRole::Graphics,
+        RenderGraph::AccessMode::Read
+    );
+    graph.Export(
+        constants,
+        RenderGraph::BufferState::ShaderResource,
+        RenderGraph::QueueRole::Graphics,
+        RenderGraph::AccessMode::Read
+    );
+    return true;
 }
 } // namespace Moer::Render::Raytracing

--- a/source/runtime/render/renderer/raytracing/VisualizePass.h
+++ b/source/runtime/render/renderer/raytracing/VisualizePass.h
@@ -3,7 +3,7 @@
 
 // 选择并显示 Raytracing 中间缓冲区，用于编辑器诊断。
 
-#include "RTResource.h"
+#include "RaytracingGraphResources.h"
 #include "shader/ShaderPipeline.h"
 #include "shaderheaders/shared/ShaderParameters.h"
 
@@ -18,9 +18,13 @@ public:
     DEFINE_SHADER_TEX(diffuse_lighting);
     DEFINE_SHADER_TEX(specular_lighting);
     DEFINE_SHADER_TEX(view_depth);
+    DEFINE_SHADER_TEX(clip_depth);
     DEFINE_SHADER_TEX(emission);
+    DEFINE_SHADER_TEX(normal);
+    DEFINE_SHADER_TEX(specular_roughness);
+    DEFINE_SHADER_TEX(motion);
+    DEFINE_SHADER_TEX(normal_roughness);
     DEFINE_SHADER_TEX(output);
-    DEFINE_SHADER_BINDLESS_ARRAY(bdls);
 
     DEFINE_SHADER_ARGS(
         param,
@@ -28,9 +32,13 @@ public:
         diffuse_lighting,
         specular_lighting,
         view_depth,
+        clip_depth,
         emission,
-        output,
-        bdls
+        normal,
+        specular_roughness,
+        motion,
+        normal_roughness,
+        output
     );
 };
 
@@ -42,18 +50,62 @@ struct VisualizeConfig {
 
 class VisualizePass {
 public:
+    struct PreparedCommand {
+        VisualizeParams params{};
+        uint3           dispatch_groups{};
+    };
+
+    struct RecordResources {
+        TextureRef ldr_color{};
+        TextureRef diffuse_lighting{};
+        TextureRef specular_lighting{};
+        TextureRef view_depth{};
+        TextureRef clip_depth{};
+        TextureRef emission{};
+        TextureRef normal{};
+        TextureRef specular_roughness{};
+        TextureRef motion{};
+        TextureRef normal_roughness{};
+        TextureRef debug_color{};
+    };
+
     VisualizePass(RenderDevice& device, class ShaderManager& manager);
     void Process(
         CommandList&           cmd_list,
         RTContext&             rt_ctx,
-        const VisualizeConfig& config,
-        BindlessArrayRef       bindless_array
+        const VisualizeConfig& config
+    );
+    bool AddPasses(
+        RenderGraph&                 graph,
+        const RTGraphFrameResources& graph_resources,
+        const RTContext&             rt_ctx,
+        const VisualizeConfig&       config
     );
 
 private:
-    VisualizeParams   params;
-    BufferRef         visualize_params_buffer;
-    VisualizePipeline visualize_pipeline;
+    struct RecordingOwner {
+        BufferRef         constants{};
+        VisualizePipeline pipeline{};
+    };
+
+    PreparedCommand Prepare(
+        const RTContext&       rt_ctx,
+        const VisualizeConfig& config
+    ) const;
+    static RecordResources CaptureResources(const RTContext& rt_ctx);
+    static void RecordConstantsUpload(
+        CommandList&           cmd_list,
+        const RecordingOwner&  owner,
+        const PreparedCommand& command
+    );
+    static void RecordVisualize(
+        CommandList&           cmd_list,
+        RecordingOwner&        owner,
+        const PreparedCommand& command,
+        const RecordResources& resources
+    );
+
+    SharedPtr<RecordingOwner> recording_owner;
 };
 
 } // namespace Moer::Render::Raytracing

--- a/source/runtime/render/rhi/RHIResource.h
+++ b/source/runtime/render/rhi/RHIResource.h
@@ -956,6 +956,9 @@ public:
     RaytracingGeometryInfo GetInfo() const {
         return info;
     }
+    virtual Buffer* GetUnderlyingBuffer() const {
+        return nullptr;
+    }
 
 protected:
     RaytracingGeometryInfo info;
@@ -993,6 +996,9 @@ class RaytracingTlas : public RHIResource {
 public:
     RaytracingTlas() : RHIResource(RRT_RAYTRACING_TLAS) {}
     virtual ~RaytracingTlas() = default;
+    virtual Buffer* GetUnderlyingBuffer() const {
+        return nullptr;
+    }
 };
 
 //container for scene TLAS and rt instances

--- a/source/runtime/render/rhi/vulkan/VulkanRHIResource.h
+++ b/source/runtime/render/rhi/vulkan/VulkanRHIResource.h
@@ -908,6 +908,9 @@ struct VulkanAccelerationStructure : public RaytracingTlas {
     VulkanAccelerationStructure(VulkanDevice& _device, VulkanRaytracingScene& _src_scene);
     virtual ~VulkanAccelerationStructure() override;
     void Destroy() override;
+    Buffer* GetUnderlyingBuffer() const override {
+        return underlying_buffer;
+    }
 
     VkAccelerationStructureKHR handle            = VK_NULL_HANDLE;
     VulkanBufferRef            underlying_buffer = nullptr;
@@ -926,7 +929,7 @@ public:
         return acc;
     }
 
-    inline VulkanBuffer* GetUnderlyingBuffer() const {
+    inline VulkanBuffer* GetUnderlyingBuffer() const override {
         return underlying_buffer;
     }
     Array<VkAccelerationStructureGeometryKHR>       build_geometries;

--- a/source/runtime/render/shaderheaders/shared/ShaderParameters.h
+++ b/source/runtime/render/shaderheaders/shared/ShaderParameters.h
@@ -266,9 +266,8 @@ struct CompositingConstants {
 };
 
 struct VisualizeParams {
-    ViewParam                 main_view;
-    RaytracingBindlessHandles bindless_handles;
-    Grid::Params              grid_params;
+    ViewParam    main_view;
+    Grid::Params grid_params;
 
     uint2  output_size;
     float2 resolution_scale;

--- a/source/runtime/render/shaderheaders/shared/utils/ShaderParameters.h
+++ b/source/runtime/render/shaderheaders/shared/utils/ShaderParameters.h
@@ -23,7 +23,7 @@ struct ShowTextureParams {
     uint2 dst_dim;
     uint  bdls_handle;
     uint  mip_level;
-    bool  use_bindless;
+    uint  use_bindless;
 };
 
 #ifdef __cplusplus

--- a/template.MoerEngine.toml
+++ b/template.MoerEngine.toml
@@ -53,6 +53,11 @@ render_graph_parallel_recording = false
 # - 抗锯齿：SMAA_1X => FXAA Simplified
 low_quality_mode = false
 
+[engine.render.raytracing]
+render_graph = false
+render_graph_debug_dump = false
+render_graph_parallel_recording = false
+
 [engine.scene]
 # 注：Toml中使用单引号包裹路径，可以避免反斜杠被识别为转义符
 # 注：scene_path支持绝对路径


### PR DESCRIPTION
## Summary
- migrate the non-NRD raytracing frame core to the modern RenderGraph: GBuffer, Lighting, Composition, TAA, ToneMapping, Visualize, and optional ShowTexture
- freeze immutable prepare/record snapshots and publish independent recording sources for serial or parallel CPU recording while preserving compiler-defined Graphics queue submission order
- preserve explicit import/export states, legacy tail bridges, accepted-submit history commits, resize warm-up, and ShowTexture resource/UI behavior
- harden managed-record failure semantics: reject the graph transaction, preserve the last accepted frame, keep UI/Present alive, and retain RT frame resources across presentation resize
- add `MOER_RT_RDG_RECORDING_FAIL` for deterministic serial/parallel managed-record failure coverage

## Validation
- Debug build: passed (VS17/MSVC fallback; Ninja/Clang unavailable in this environment)
- Release build: passed
- Debug CTest: 16/16 passed
- Release CTest: 16/16 passed
- normal parallel RT graph: 21 passes / 41 resources; resize/restore; non-black; clean shutdown
- parallel managed-record failure: 22 completed sources rejected; last-good frame; clean shutdown
- serial managed-record failure: gate rejected; last-good frame; clean shutdown
- fault -> resize -> restore: 5 non-black captures (0.892-0.900); preserved RT frame resources; clean shutdown
- Vulkan validation: no VUID, actual device lost, fatal error, or assertion

## Architectural boundary
This batch intentionally keeps Environment/TLAS/PrepareLights/UpdateBindless in a caller-owned Prefix, NRD as a hard island, and UI/Present in the tail. The production RT graph currently uses one Graphics native queue. Prefix/NRD/UI graph topology and production RT multi-queue remain follow-up work.