### PR TITLE
feat(rhi): execute parallel Translate and multi-segment submissions

### DIFF
--- a/source/runtime/core/include/taskgraph/GraphTask.h
+++ b/source/runtime/core/include/taskgraph/GraphTask.h
@@ -30,11 +30,12 @@ public:
     void SetPriority(ThreadPriority priority) {
         m_preferd_thread = EThread::SetPriority(m_preferd_thread, priority << EThread::PRIORITY_SHEFT);
     }
-    void QueueTask(EThread::Type currentThread, bool shouldWakeWorker);
+    void QueueTask(EThread::Type currentThread, bool shouldWakeWorker) noexcept;
 
-    CORE_API void PrerequestsComplete(EThread::Type currentThread, int32_t finishedCount, bool unlock = true);
+    CORE_API void
+    PrerequestsComplete(EThread::Type currentThread, int32_t finishedCount, bool unlock = true) noexcept;
 
-    bool ConditionalQueueTask(EThread::Type currentThread, bool shouldWakeWorker) {
+    bool ConditionalQueueTask(EThread::Type currentThread, bool shouldWakeWorker) noexcept {
         if (m_prerequests_count.fetch_sub(1, std::memory_order_acq_rel) == 1) {
             QueueTask(currentThread, shouldWakeWorker);
             return true;

--- a/source/runtime/core/include/taskgraph/TaskGraph.h
+++ b/source/runtime/core/include/taskgraph/TaskGraph.h
@@ -23,12 +23,16 @@ public:
     CORE_API void WaitUntilTaskComplete(const GraphEventRef& task, EThread::Type currentThread);
     CORE_API void WaitUntilTaskComplete(GraphEventRef&& task, EThread::Type currentThread);
     CORE_API void AttachToNameThread(EThread::Type type);
-    virtual void  QueueTask(
-         BaseGraphTask* task,
-         EThread::Type  prefered_thread,
-         EThread::Type  current_thread = EThread::UNKNOWN_THREAD,
-         bool           wake_worker    = true
-     );
+    // Task allocation and construction happen before this publication
+    // boundary and may fail normally. Once QueueTask is entered, ownership
+    // can become visible to a worker, so no exception may escape back to the
+    // producer. A platform wake failure is therefore process-fatal.
+    virtual void QueueTask(
+        BaseGraphTask* task,
+        EThread::Type  prefered_thread,
+        EThread::Type  current_thread = EThread::UNKNOWN_THREAD,
+        bool           wake_worker    = true
+    ) noexcept;
     virtual void           ReturnThread(EThread::Type index);
     virtual BaseGraphTask* DequeueTask(int32_t threadIndex);
     CORE_API virtual void  ProcessThreadUntilIdle(EThread::Type index);
@@ -53,7 +57,7 @@ private:
     int32_t         GetThreadPriorityFromIndex(int32_t threadIndex) {
         return (threadIndex - m_named_thread_count) / m_worker_per_priority;
     }
-    void         WakeUpWorkerThread(int32_t threadIndex, QueueIndex index);
+    void         WakeUpWorkerThread(int32_t threadIndex, QueueIndex index) noexcept;
     WorkerThread m_workers[INT16_MAX];
     int32_t      m_thread_count;
     int32_t      m_named_thread_count;

--- a/source/runtime/core/source/taskgraph/GraphTask.cpp
+++ b/source/runtime/core/source/taskgraph/GraphTask.cpp
@@ -25,11 +25,15 @@ bool GraphEvent::AddSubsequent(BaseGraphTask* subsequent) {
 bool GraphEvent::IsComplete() const {
     return m_subsequents.IsClosed();
 }
-void BaseGraphTask::QueueTask(EThread::Type currentThread, bool shouldWakeupWorker) {
+void BaseGraphTask::QueueTask(EThread::Type currentThread, bool shouldWakeupWorker) noexcept {
     TaskGraph::GetInterface().QueueTask(this, m_preferd_thread, currentThread, shouldWakeupWorker);
 }
 
-void BaseGraphTask::PrerequestsComplete(EThread::Type currentThread, int32_t finishedCount, bool unlock) {
+void BaseGraphTask::PrerequestsComplete(
+    EThread::Type currentThread,
+    int32_t       finishedCount,
+    bool          unlock
+) noexcept {
     int32_t finished = finishedCount + (unlock ? 1 : 0);
     if (m_prerequests_count.fetch_sub(finished) == finished) {
         QueueTask(currentThread, true);

--- a/source/runtime/core/source/taskgraph/TaskGraph.cpp
+++ b/source/runtime/core/source/taskgraph/TaskGraph.cpp
@@ -34,7 +34,7 @@ TaskThreadBase& TaskGraph::GetThread(ThreadIndex index) {
     return *m_workers[index].task_thread;
 }
 
-void TaskGraph::WakeUpWorkerThread(int32_t threadIndex, QueueIndex index) {
+void TaskGraph::WakeUpWorkerThread(int32_t threadIndex, QueueIndex index) noexcept {
     assert(threadIndex >= 0);
     m_workers[threadIndex].task_thread->Wake(index);
 }
@@ -217,7 +217,7 @@ void TaskGraph::QueueTask(
     EThread::Type  _prefered_thread,
     EThread::Type  _current_thread,
     bool           wake_worker
-) {
+) noexcept {
     if (EThread::GetThreadIndex(_prefered_thread) == EThread::UNKNOWN_THREAD) { //any thread is ok
         ThreadPriority priority                = task->GetPriority();
         int32_t        possible_thread_to_wake = m_task_queue[priority].Push(task, 0);

--- a/source/runtime/render/rhi/RHIExecutor.cpp
+++ b/source/runtime/render/rhi/RHIExecutor.cpp
@@ -689,6 +689,23 @@ void RHIExecutor::SubmitReady(
     ERHIExecSubmitFlags                      _flags,
     RHIPresentRequest*                       _present
 ) {
+    const bool legacy_multi_segment_source =
+        RenderDevice::Get().GetRHIType() != ERHIType::Vulkan &&
+        std::any_of(
+            _submits.begin(),
+            _submits.end(),
+            [](const RHIBackendSubmissionBatchEntry& entry) {
+                return entry.submit.segments.size() > 1;
+            }
+        );
+    if (legacy_multi_segment_source) {
+        ResolveRejectedPresent(_present);
+        FinalizeRejectedSubmissions(
+            std::move(_submits),
+            "legacy backend does not support multi-segment sources"
+        );
+        return;
+    }
 
     // A Present is a batch terminator.  Publish it while holding the same
     // dispatch gate used by Flush/Sync/Shutdown so no later batch can overtake

--- a/source/runtime/render/rhi/RHISubmissionTopology.h
+++ b/source/runtime/render/rhi/RHISubmissionTopology.h
@@ -317,7 +317,20 @@ inline void AppendUnique(
             RHISubmissionSegmentPlan& last  = result.segments.back();
             first.inherit_source_wait_events = true;
             last.inherit_source_signal_events_and_callbacks = true;
-            last.inherit_source_runtime_payload = true;
+            // Copy translation does not own the source-level runtime payload
+            // (profiling/control state and other non-command metadata). Keep
+            // signals/callbacks on the true tail, but route runtime ownership
+            // to the last retained non-Copy segment. A pure Copy source has no
+            // runtime-payload owner.
+            for (size_t segment_plan_index = result.segments.size();
+                 segment_plan_index > source_plan.segment_plan_begin;
+                 --segment_plan_index) {
+                RHISubmissionSegmentPlan& candidate = result.segments[segment_plan_index - 1];
+                if (candidate.segment.queue != EQueueType::Copy) {
+                    candidate.inherit_source_runtime_payload = true;
+                    break;
+                }
+            }
         }
 
         result.source_plans.emplace_back(std::move(source_plan));

--- a/source/runtime/render/rhi/vulkan/VulkanIOService.cpp
+++ b/source/runtime/render/rhi/vulkan/VulkanIOService.cpp
@@ -6,11 +6,13 @@
 #include "misc/LockFree.h"
 #include "misc/STL.h"
 #include "rhi/RHICommand.h"
+#include "rhi/RHIExecutor.h"
 #include "rhi/RHIIO.h"
 #include <atomic>
 #include <memory>
 #include <mutex>
 #include <optional>
+#include <semaphore>
 #include <thread>
 #include <type_traits>
 namespace Moer::Render {
@@ -23,6 +25,60 @@ struct VulkanIOTask {
     Array<IOSignalEvt>    signal_evts;
 };
 
+static void CompleteVulkanIOTaskNoexcept(VulkanIOTask* _task) noexcept {
+    if (!_task || !_task->callback) {
+        return;
+    }
+    try {
+        _task->callback();
+    } catch (...) {
+        try {
+            LOG_ERROR("[VulkanIO] task completion callback threw");
+        } catch (...) {
+        }
+    }
+}
+
+static void RejectVulkanIOTaskSignalsNoexcept(VulkanIOTask* _task) noexcept {
+    if (!_task) {
+        return;
+    }
+    for (const IOSignalEvt& signal : _task->signal_evts) {
+        if (signal.handle == 0) {
+            continue;
+        }
+        try {
+            reinterpret_cast<Fence*>(signal.handle)->Reject(signal.timeline);
+        } catch (...) {
+            try {
+                LOG_ERROR("[VulkanIO] failed to reject unpublished signal timeline={}", signal.timeline);
+            } catch (...) {
+            }
+        }
+    }
+}
+
+struct VulkanIOTaskCompletionState {
+    explicit VulkanIOTaskCompletionState(std::shared_ptr<VulkanIOTask> _task) : task(std::move(_task)) {}
+
+    void Complete() noexcept {
+        if (completed.exchange(true, std::memory_order_acq_rel)) {
+            return;
+        }
+        CompleteVulkanIOTaskNoexcept(task.get());
+        task.reset();
+        done.release();
+    }
+
+    void Wait() noexcept {
+        done.acquire();
+    }
+
+    std::shared_ptr<VulkanIOTask> task{};
+    std::binary_semaphore         done{0};
+    std::atomic_bool              completed{false};
+};
+
 void VulkanCommitSession::Commit() {
     if (signal_events.empty()) {
         CommitWithoutSignal();
@@ -33,7 +89,8 @@ void VulkanCommitSession::Commit() {
 
 bool VulkanCommitSession::IsComplete() const {
     // Check if all tasks are completed
-    return pending_tasks.load(std::memory_order_acquire) == task_count;
+    return task_count != 0 &&
+           pending_tasks.load(std::memory_order_acquire) == task_count;
 }
 
 void VulkanCommitSession::Enqueue(FileHandle _handle, size_t _file_offset, void* _ptr, size_t _len) {
@@ -137,6 +194,7 @@ void VulkanCommitSession::CommitSignaled() {
     tsk->callback     = [this]() {
         ++pending_tasks;
     };
+    task_count++;
     CommitIOTask(tsk);
 }
 
@@ -146,7 +204,7 @@ void VulkanCommitSession::CommitIOTask(VulkanIOTask* _tsk) {
 
 struct VulkanIOTaskThread {
     std::jthread                    thread;
-    bool                            enabled = true;
+    std::atomic_bool                enabled{true};
     LockFreeQueueBase<VulkanIOTask> queue;
     VulkanIOTaskThread() {
         thread = std::jthread([this]() {
@@ -155,125 +213,177 @@ struct VulkanIOTaskThread {
     }
 
     ~VulkanIOTaskThread() {
-        enabled = false;
+        enabled.store(false, std::memory_order_release);
         thread.join();
     }
 
     void InnerWorkLoop() {
-        while (enabled) {
-            VulkanIOTask* task;
-            if (task = queue.Pop(); task) {
-                // Process the submission
-                // ...
-                auto copy_file_to_mem =
-                    [&](const FileDesc& _src, size_t _file_offset, std::span<ubyte> _dst) {
-                        FILE* result_handle = nullptr;
-                        fopen_s(&result_handle, (const char*)_src.handle.file, "r");
-                        if (!result_handle) {
-                            SPDLOG_ERROR("Failed to open file {}", (const char*)_src.handle.file);
-                            assert(false && "Failed to open file");
-                        }
-                        std::fseek(result_handle, _file_offset, SEEK_SET);
-                        std::fread(_dst.data(), sizeof(ubyte), _dst.size_bytes(), result_handle);
-                        std::fclose(result_handle);
-                    };
-                uint64 temp_size = 0;
-                for (auto& cmd : task->file_cmds) {
-                    // Process each command
+        for (;;) {
+            VulkanIOTask* raw_task = nullptr;
+            if (raw_task = queue.Pop(); raw_task) {
+                std::shared_ptr<VulkanIOTask> task{};
+                try {
+                    task = std::shared_ptr<VulkanIOTask>(raw_task, [](VulkanIOTask* _task) {
+                        MoerDelete(_task);
+                    });
+                } catch (...) {
+                    // Control-block allocation can fail before shared ownership
+                    // is established. Retire every externally visible promise
+                    // before releasing the raw task so no waiter is orphaned.
+                    RejectVulkanIOTaskSignalsNoexcept(raw_task);
+                    CompleteVulkanIOTaskNoexcept(raw_task);
+                    MoerDelete(raw_task);
+                    try {
+                        LOG_ERROR("[VulkanIO] failed to take ownership of queued task");
+                    } catch (...) {
+                    }
+                    continue;
+                }
+                std::shared_ptr<VulkanIOTaskCompletionState> completion{};
+                try {
+                    completion = std::make_shared<VulkanIOTaskCompletionState>(task);
+                    // Process the submission
                     // ...
-                    std::visit(
-                        Overload{
-                            [&](RawDataDesc& _dst) {
-                                copy_file_to_mem(std::get<FileDesc>(cmd.src), cmd.file_offset, _dst.data);
-                            },
-                            [&](BufferViewDesc& _dst) {
-                                temp_size += cmd.SizeByte();
-                            },
-                            [&](TextureViewDesc& _dst) {
-                                temp_size += cmd.SizeByte();
+                    auto copy_file_to_mem =
+                        [&](const FileDesc& _src, size_t _file_offset, std::span<ubyte> _dst) {
+                            FILE* result_handle = nullptr;
+                            fopen_s(&result_handle, (const char*)_src.handle.file, "r");
+                            if (!result_handle) {
+                                SPDLOG_ERROR("Failed to open file {}", (const char*)_src.handle.file);
+                                assert(false && "Failed to open file");
                             }
-                        },
-                        cmd.dst
+                            std::fseek(result_handle, _file_offset, SEEK_SET);
+                            std::fread(_dst.data(), sizeof(ubyte), _dst.size_bytes(), result_handle);
+                            std::fclose(result_handle);
+                        };
+                    uint64 temp_size = 0;
+                    for (auto& cmd : task->file_cmds) {
+                        // Process each command
+                        // ...
+                        std::visit(
+                            Overload{
+                                [&](RawDataDesc& _dst) {
+                                    copy_file_to_mem(std::get<FileDesc>(cmd.src), cmd.file_offset, _dst.data);
+                                },
+                                [&](BufferViewDesc& _dst) {
+                                    temp_size += cmd.SizeByte();
+                                },
+                                [&](TextureViewDesc& _dst) {
+                                    temp_size += cmd.SizeByte();
+                                }
+                            },
+                            cmd.dst
+                        );
+                    }
+                    Array<ubyte> temp_buffer;
+                    temp_buffer.resize(temp_size);
+                    temp_size = 0;
+                    CommandList cmd_list{EQueueType::Copy};
+                    for (auto& cmd : task->file_cmds) {
+                        std::visit(
+                            Overload{
+                                [&](RawDataDesc& _dst) {},
+                                [&](BufferViewDesc& _dst) {
+                                    copy_file_to_mem(
+                                        std::get<FileDesc>(cmd.src),
+                                        cmd.file_offset,
+                                        std::span<ubyte>(temp_buffer.data() + temp_size, _dst.size)
+                                    );
+                                    VulkanBuffer* buffer = (VulkanBuffer*)_dst.handle;
+                                    cmd_list.CopyFrom(
+                                        std::span<byte>((byte*)temp_buffer.data() + temp_size, _dst.size),
+                                        buffer->GetView(_dst.offset, _dst.size)
+                                    );
+                                    temp_size += cmd.SizeByte();
+                                },
+                                [&](TextureViewDesc& _dst) {
+                                    copy_file_to_mem(
+                                        std::get<FileDesc>(cmd.src),
+                                        cmd.file_offset,
+                                        std::span<ubyte>(temp_buffer.data() + temp_size, _dst.GetByteSize())
+                                    );
+                                    VulkanTexture* texture = (VulkanTexture*)_dst.handle;
+                                    TextureView view(texture, _dst.pixel_fmt, _dst.mip_offset, _dst.mip_cnt);
+                                    view.offset = _dst.offset;
+                                    view.extent = _dst.size;
+                                    cmd_list.CopyFrom(
+                                        std::span<byte>(
+                                            (byte*)temp_buffer.data() + temp_size, _dst.GetByteSize()
+                                        ),
+                                        view
+                                    );
+                                    temp_size += cmd.SizeByte();
+                                }
+                            },
+                            cmd.dst
+                        );
+                    }
+                    for (auto& cmd : task->mem_cmds) {
+                        std::visit(
+                            Overload{
+                                [&](RawDataDesc& _src) {},
+                                [&](BufferViewDesc& _dst) {
+                                    const RawDataDesc& src    = std::get<RawDataDesc>(cmd.src);
+                                    VulkanBuffer*      buffer = (VulkanBuffer*)_dst.handle;
+                                    cmd_list.CopyFrom(
+                                        std::span<byte>((byte*)src.data.data(), src.data.size_bytes()),
+                                        buffer->GetView(_dst.offset, _dst.size)
+                                    );
+                                },
+                                [&](TextureViewDesc& _dst) {
+                                    const RawDataDesc& src     = std::get<RawDataDesc>(cmd.src);
+                                    VulkanTexture*     texture = (VulkanTexture*)_dst.handle;
+                                    TextureView view(texture, _dst.pixel_fmt, _dst.mip_offset, _dst.mip_cnt);
+                                    view.offset = _dst.offset;
+                                    view.extent = _dst.size;
+                                    cmd_list.CopyFrom(
+                                        std::span<byte>((byte*)src.data.data(), src.data.size_bytes()), view
+                                    );
+                                }
+                            },
+                            cmd.dst
+                        );
+                    }
+
+                    // Copy GPU work shares the same Translate -> Submission ->
+                    // Completion ownership pipeline as renderer work. The IO
+                    // thread remains a file-read/assembly producer only.
+                    CmdSubmit submit = cmd_list.Submit();
+                    for (const IOSignalEvt& signal : task->signal_evts) {
+                        submit.Signal(reinterpret_cast<Fence*>(signal.handle), signal.timeline);
+                    }
+                    submit.callbacks.emplace_back([completion]() {
+                        completion->Complete();
+                    });
+                    RHIExecutor::Get().Submit(
+                        EQueueType::Copy, std::move(submit), ERHIExecSubmitFlags::FlushGPU
                     );
+                } catch (...) {
+                    // No successful publication occurred, so every promised
+                    // timeline must become terminal before the session does.
+                    RejectVulkanIOTaskSignalsNoexcept(task.get());
+                    if (completion) {
+                        completion->Complete();
+                    } else {
+                        CompleteVulkanIOTaskNoexcept(task.get());
+                    }
+                    try {
+                        LOG_ERROR("[VulkanIO] task assembly or publication threw");
+                    } catch (...) {
+                    }
                 }
-                Array<ubyte> temp_buffer;
-                temp_buffer.resize(temp_size);
-                temp_size = 0;
-                CommandList cmd_list{};
-                for (auto& cmd : task->file_cmds) {
-                    std::visit(
-                        Overload{
-                            [&](RawDataDesc& _dst) {},
-                            [&](BufferViewDesc& _dst) {
-                                copy_file_to_mem(
-                                    std::get<FileDesc>(cmd.src),
-                                    cmd.file_offset,
-                                    std::span<ubyte>(temp_buffer.data() + temp_size, _dst.size)
-                                );
-                                VulkanBuffer* buffer = (VulkanBuffer*)_dst.handle;
-                                cmd_list.CopyFrom(
-                                    std::span<byte>((byte*)temp_buffer.data() + temp_size, _dst.size),
-                                    buffer->GetView(_dst.offset, _dst.size)
-                                );
-                                temp_size += cmd.SizeByte();
-                            },
-                            [&](TextureViewDesc& _dst) {
-                                copy_file_to_mem(
-                                    std::get<FileDesc>(cmd.src),
-                                    cmd.file_offset,
-                                    std::span<ubyte>(temp_buffer.data() + temp_size, _dst.GetByteSize())
-                                );
-                                VulkanTexture* texture = (VulkanTexture*)_dst.handle;
-                                TextureView    view(texture, _dst.pixel_fmt, _dst.mip_offset, _dst.mip_cnt);
-                                view.offset = _dst.offset;
-                                view.extent = _dst.size;
-                                cmd_list.CopyFrom(
-                                    std::span<byte>(
-                                        (byte*)temp_buffer.data() + temp_size, _dst.GetByteSize()
-                                    ),
-                                    view
-                                );
-                                temp_size += cmd.SizeByte();
-                            }
-                        },
-                        cmd.dst
-                    );
-                }
-                for (auto& cmd : task->mem_cmds) {
-                    std::visit(
-                        Overload{
-                            [&](RawDataDesc& _src) {},
-                            [&](BufferViewDesc& _dst) {
-                                const RawDataDesc& src    = std::get<RawDataDesc>(cmd.src);
-                                VulkanBuffer*      buffer = (VulkanBuffer*)_dst.handle;
-                                cmd_list.CopyFrom(
-                                    std::span<byte>((byte*)src.data.data(), src.data.size_bytes()),
-                                    buffer->GetView(_dst.offset, _dst.size)
-                                );
-                            },
-                            [&](TextureViewDesc& _dst) {
-                                const RawDataDesc& src     = std::get<RawDataDesc>(cmd.src);
-                                VulkanTexture*     texture = (VulkanTexture*)_dst.handle;
-                                TextureView view(texture, _dst.pixel_fmt, _dst.mip_offset, _dst.mip_cnt);
-                                view.offset = _dst.offset;
-                                view.extent = _dst.size;
-                                cmd_list.CopyFrom(
-                                    std::span<byte>((byte*)src.data.data(), src.data.size_bytes()), view
-                                );
-                            }
-                        },
-                        cmd.dst
-                    );
+                if (completion) {
+                    // Wait only for this Copy packet's ordinary Completion
+                    // callback. This avoids coupling IO latency to unrelated
+                    // Graphics/Compute work while keeping session lifetime
+                    // valid until the task is terminal.
+                    completion->Wait();
                 }
 
-                // Execute the command list
-                auto& copy_queue = task->session->io_interface.GetQueue();
-                auto  evt        = copy_queue.Execute(std::move(cmd_list.Submit()));
-                copy_queue.Sync(evt.timeline);
-                task->callback();
-
-            } else {
+            } else if (enabled.load(std::memory_order_acquire)) {
                 std::this_thread::yield();
+            } else {
+                break;
             }
         }
     }
@@ -283,6 +393,7 @@ static constexpr uint64_t max_chunk_size = 1024 * 1024 * 64; // 64MB
 VulkanIOInterface::VulkanIOInterface(VulkanDevice& _device, VkCopyQueue& _queue) :
     m_device(_device),
     m_queue(_queue) {
+    event   = _device.CreateFence();
     storage = MoerNew(VulkanStorage)(_device, _queue);
 }
 
@@ -607,7 +718,7 @@ uint64 VulkanIOInterface::Execute(IOCommandList&& _cmdlist) {
 }
 
 WaitEvent VulkanIOInterface::GetWaitEvent(uint64 _timeline) {
-    return {uint64(event.Get()), timeline};
+    return {uint64(event.Get()), _timeline};
 }
 
 void VulkanIOInterface::Sync(uint64 _timeline) {
@@ -624,13 +735,27 @@ void VulkanIOInterface::Tick() {
         }
     }
     if (!callbacks.empty()) {
-        if (event->GetValue() >= callbacks.front().timeline) {
-            auto& callback = callbacks.front();
+        auto*        event_fence       = ResourceCast(event.Get());
+        const uint64 callback_timeline = callbacks.front().timeline;
+        const bool   terminal          = event->GetValue() >= callback_timeline ||
+                              event_fence->IsRejected(callback_timeline) || event_fence->IsFailed();
+        if (terminal) {
+            // Remove the terminal batch before invoking user code. A throwing
+            // or re-entrant callback must never replay already attempted
+            // callbacks or retain the batch's file handles indefinitely.
+            VkExecCallback callback = std::move(callbacks.front());
+            callbacks.pop();
             for (auto& cb : callback.callback) {
-                cb();
+                try {
+                    cb();
+                } catch (...) {
+                    try {
+                        LOG_ERROR("[VulkanIO] user completion callback threw");
+                    } catch (...) {
+                    }
+                }
             }
             callback.Clear();
-            callbacks.pop();
         }
     } else {
         //yield if no callback
@@ -686,11 +811,26 @@ VulkanStorage::VulkanStorage(VulkanDevice& _device, VkCopyQueue& _queue) : copy_
     task_thread = MoerNew(VulkanIOTaskThread)();
 }
 
+VulkanStorage::~VulkanStorage() {
+    MoerDelete(task_thread);
+    task_thread = nullptr;
+    MoerDelete(current_session);
+    current_session = nullptr;
+}
+
 VulkanCommitSession* VulkanStorage::GetCurrentSession() {
-    if (current_session && !current_session->IsComplete()) {
-        return current_session;
+    if (current_session) {
+        // A completion can race with the caller staging the next command on
+        // the same session. Never recycle a session that still owns
+        // uncommitted commands, and do not consider a fresh zero-task session
+        // complete.
+        if (!current_session->IsComplete() ||
+            current_session->HasUncommittedWork()) {
+            return current_session;
+        }
+        MoerDelete(current_session);
+        current_session = nullptr;
     }
-    assert(!current_session && "current session not signaled!");
     current_session = MoerNew(VulkanCommitSession)(*this);
     return current_session;
 }

--- a/source/runtime/render/rhi/vulkan/VulkanIOService.h
+++ b/source/runtime/render/rhi/vulkan/VulkanIOService.h
@@ -1,6 +1,7 @@
 #include "VulkanAllocator.h"
 #include "VulkanDevice.h"
 #include "VulkanQueue.h"
+#include "RenderAPI.h"
 #include "misc/STL.h"
 #include "rhi/RHI.h"
 #include "rhi/RHICommand.h"
@@ -47,12 +48,16 @@ private:
     Array<IOSignalEvt> signal_events;
     std::atomic_uint   pending_tasks = 0;
     bool               signaled      = false;
-    uint               task_count    = 1;
+    uint               task_count    = 0;
 
     void CommitWithoutSignal();
     void CommitSignaled();
     void FlushAllCommit();
     void CommitIOTask(class VulkanIOTask*);
+    bool HasUncommittedWork() const {
+        return !file_cmds.empty() || !mem_cmds.empty() ||
+               !signal_events.empty();
+    }
 };
 
 struct VkExecCallback {
@@ -116,11 +121,12 @@ private:
     uint64                timeline = 0;
 };
 
-class VulkanStorage {
+class RENDER_API VulkanStorage {
 public:
     friend VulkanCommitSession;
     friend class VulkanIOTaskThread;
     VulkanStorage(VulkanDevice& _device, VkCopyQueue& _copy_queue);
+    ~VulkanStorage();
     void Enqueue(FileHandle _handle, size_t _file_offset, void* _ptr, size_t _len);
     void Enqueue(FileHandle _handle, size_t _file_offset, void* _buffer_ptr, size_t _offset, size_t _len);
     void Enqueue(
@@ -153,7 +159,7 @@ private:
 
 private:
     VkCopyQueue&               copy_queue;
-    VulkanCommitSession*       current_session;
+    VulkanCommitSession*       current_session{nullptr};
     struct VulkanIOTaskThread* task_thread;
 };
 } // namespace Moer::Render

--- a/source/runtime/render/rhi/vulkan/VulkanQueue.cpp
+++ b/source/runtime/render/rhi/vulkan/VulkanQueue.cpp
@@ -8,6 +8,7 @@
 #include "VulkanParallelRecordWorkEstimator.h"
 #include "VulkanRHIResource.h"
 #include "VulkanSerialGolden.h"
+#include "VulkanSubmissionDiagnostics.h"
 #include "rhi/ExternalCpuJoinPool.h"
 #include "misc/Alignment.h"
 #include "misc/STL.h"
@@ -32,6 +33,167 @@
 #include <thread>
 #include <variant>
 namespace Moer::Render {
+namespace {
+
+std::atomic<const VulkanNativeSubmissionObserver*>
+    g_native_submission_observer{nullptr};
+std::atomic<const VulkanSubmissionDependencyWaitObserver*>
+    g_submission_dependency_wait_observer{nullptr};
+std::atomic<const VulkanBackendSyncWaitObserver*>
+    g_backend_sync_wait_observer{nullptr};
+
+void NotifyNativeSubmission(
+    EQueueType                   _queue,
+    VkQueue                      _native_queue,
+    const VulkanOperationResult& _outcome,
+    bool                         _empty_submit
+) noexcept {
+    const VulkanNativeSubmissionObserver* observer =
+        g_native_submission_observer.load(std::memory_order_acquire);
+    if (observer == nullptr) {
+        return;
+    }
+    observer->callback(
+        observer->context,
+        VulkanNativeSubmissionEvent{
+            .queue               = _queue,
+            .native_queue_handle = reinterpret_cast<uint64>(_native_queue),
+            .thread_id           = Platform::GetCurrentThreadID(),
+            .thread_role         = GetCurrentRHIThreadRole(),
+            .outcome             = _outcome,
+            .empty_submit        = _empty_submit,
+        }
+    );
+}
+
+} // namespace
+
+void NotifyVulkanSubmissionDependencyWaitBlocked(
+    EQueueType _queue,
+    uint32     _dependency_count
+) noexcept {
+    const VulkanSubmissionDependencyWaitObserver* observer =
+        g_submission_dependency_wait_observer.load(
+            std::memory_order_acquire
+        );
+    if (observer == nullptr) {
+        return;
+    }
+    observer->callback(
+        observer->context,
+        VulkanSubmissionDependencyWaitEvent{
+            .queue            = _queue,
+            .thread_id        = Platform::GetCurrentThreadID(),
+            .thread_role      = GetCurrentRHIThreadRole(),
+            .dependency_count = _dependency_count,
+        }
+    );
+}
+
+void NotifyVulkanBackendSyncWait() noexcept {
+    const VulkanBackendSyncWaitObserver* observer =
+        g_backend_sync_wait_observer.load(std::memory_order_acquire);
+    if (observer == nullptr) {
+        return;
+    }
+    observer->callback(
+        observer->context,
+        VulkanBackendSyncWaitEvent{
+            .thread_id   = Platform::GetCurrentThreadID(),
+            .thread_role = GetCurrentRHIThreadRole(),
+        }
+    );
+}
+
+bool TryInstallVulkanNativeSubmissionObserver(
+    const VulkanNativeSubmissionObserver* _observer
+) noexcept {
+    if (_observer == nullptr || _observer->callback == nullptr) {
+        return false;
+    }
+    const VulkanNativeSubmissionObserver* expected = nullptr;
+    return g_native_submission_observer.compare_exchange_strong(
+        expected,
+        _observer,
+        std::memory_order_release,
+        std::memory_order_relaxed
+    );
+}
+
+bool RemoveVulkanNativeSubmissionObserver(
+    const VulkanNativeSubmissionObserver* _observer
+) noexcept {
+    if (_observer == nullptr) {
+        return false;
+    }
+    const VulkanNativeSubmissionObserver* expected = _observer;
+    return g_native_submission_observer.compare_exchange_strong(
+        expected,
+        nullptr,
+        std::memory_order_acq_rel,
+        std::memory_order_acquire
+    );
+}
+
+bool TryInstallVulkanSubmissionDependencyWaitObserver(
+    const VulkanSubmissionDependencyWaitObserver* _observer
+) noexcept {
+    if (_observer == nullptr || _observer->callback == nullptr) {
+        return false;
+    }
+    const VulkanSubmissionDependencyWaitObserver* expected = nullptr;
+    return g_submission_dependency_wait_observer.compare_exchange_strong(
+        expected,
+        _observer,
+        std::memory_order_release,
+        std::memory_order_relaxed
+    );
+}
+
+bool RemoveVulkanSubmissionDependencyWaitObserver(
+    const VulkanSubmissionDependencyWaitObserver* _observer
+) noexcept {
+    if (_observer == nullptr) {
+        return false;
+    }
+    const VulkanSubmissionDependencyWaitObserver* expected = _observer;
+    return g_submission_dependency_wait_observer.compare_exchange_strong(
+        expected,
+        nullptr,
+        std::memory_order_acq_rel,
+        std::memory_order_acquire
+    );
+}
+
+bool TryInstallVulkanBackendSyncWaitObserver(
+    const VulkanBackendSyncWaitObserver* _observer
+) noexcept {
+    if (_observer == nullptr || _observer->callback == nullptr) {
+        return false;
+    }
+    const VulkanBackendSyncWaitObserver* expected = nullptr;
+    return g_backend_sync_wait_observer.compare_exchange_strong(
+        expected,
+        _observer,
+        std::memory_order_release,
+        std::memory_order_relaxed
+    );
+}
+
+bool RemoveVulkanBackendSyncWaitObserver(
+    const VulkanBackendSyncWaitObserver* _observer
+) noexcept {
+    if (_observer == nullptr) {
+        return false;
+    }
+    const VulkanBackendSyncWaitObserver* expected = _observer;
+    return g_backend_sync_wait_observer.compare_exchange_strong(
+        expected,
+        nullptr,
+        std::memory_order_acq_rel,
+        std::memory_order_acquire
+    );
+}
 
 #pragma region[ utils ]
 
@@ -3040,6 +3202,7 @@ VulkanOperationResult VkNativeQueue::SubmitEmpty(
     context.queue      = queue;
     const VulkanOperationResult outcome =
         device.SubmitOnQueue(queue, submit_info, _fence, context);
+    NotifyNativeSubmission(type, queue, outcome, true);
     wait_infos.clear();
     signal_infos.clear();
     return outcome;
@@ -3109,6 +3272,7 @@ VulkanOperationResult VkNativeQueue::Submit(
     }
     const VulkanOperationResult outcome =
         device.SubmitOnQueue(queue, submit_info, _fence, context);
+    NotifyNativeSubmission(type, queue, outcome, false);
     wait_infos.clear();
     signal_infos.clear();
     return outcome;
@@ -3433,12 +3597,18 @@ static std::string JoinRecordCounts(std::span<const uint32> _counts) {
 static bool WaitForSubmittedDependencies(
     VulkanDevice&           _device,
     const Array<WaitEvent>& _wait_events,
+    EQueueType               _queue,
     const std::atomic_bool* _continue_waiting = nullptr
 ) {
     for (const WaitEvent& event : _wait_events) {
         auto* fence = reinterpret_cast<VulkanFence*>(event.timeline_handle);
         if (fence == nullptr ||
-            !fence->WaitSubmitted(event.value, _continue_waiting)) {
+            !fence->WaitSubmitted(
+                event.value,
+                _continue_waiting,
+                _queue,
+                static_cast<uint32>(_wait_events.size())
+            )) {
             return false;
         }
     }
@@ -4117,7 +4287,10 @@ VkCommandQueue::SubmitRecorded(
     const auto end_tag = VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT;
     VulkanOperationResult submit_outcome{};
     if (!WaitForSubmittedDependencies(
-            vk_device, _recorded.submit.wait_events, _continue_waiting
+            vk_device,
+            _recorded.submit.wait_events,
+            queue.GetType(),
+            _continue_waiting
         )) {
         vk_device.RecordRejectedSubmit();
         const VkResult rejected_result = GetRejectedSubmitResult(vk_device);
@@ -7343,19 +7516,7 @@ VkCopyQueue::VkCopyQueue(VulkanDevice& _device) :
         thread = std::jthread([this]() {
             ExecuteThread();
         });
-        submission_thread = std::jthread([this]() {
-            SubmissionThreadMain();
-        });
     } catch (...) {
-        {
-            std::lock_guard lock(submission_mutex);
-            submission_accepting.store(false, std::memory_order_release);
-        }
-        submission_cv.notify_all();
-        if (submission_thread.joinable()) {
-            submission_thread.join();
-        }
-
         enabled.store(false, std::memory_order_release);
         queue_cv.notify_all();
         if (thread.joinable()) {
@@ -7368,16 +7529,7 @@ VkCopyQueue::VkCopyQueue(VulkanDevice& _device) :
 
 VkCopyQueue::~VkCopyQueue() {
     CancelRuntimeDependencyWaits();
-    {
-        std::lock_guard lock(submission_mutex);
-        submission_accepting.store(false, std::memory_order_release);
-    }
-    submission_cv.notify_all();
-    if (submission_thread.joinable()) {
-        submission_thread.join();
-    }
-
-    CompleteAll(last_frame);
+    CompleteAll(last_frame.load(std::memory_order_acquire));
     enabled.store(false, std::memory_order_release);
     queue_cv.notify_all();
     if (thread.joinable()) {
@@ -7400,6 +7552,39 @@ void VkCopyQueue::EnableRuntimeDependencyWaits() noexcept {
 
 void VkCopyQueue::CancelRuntimeDependencyWaits() noexcept {
     dependency_waits_enabled.store(false, std::memory_order_release);
+}
+
+bool VkCopyQueue::ClaimRuntimeOwnership() {
+    EExecutionOwnershipMode expected = EExecutionOwnershipMode::Unclaimed;
+    if (execution_ownership_mode.compare_exchange_strong(
+            expected,
+            EExecutionOwnershipMode::Runtime,
+            std::memory_order_acq_rel,
+            std::memory_order_acquire
+        )) {
+        EnableRuntimeDependencyWaits();
+        return true;
+    }
+    try {
+        LOG_ERROR(
+            "[RHIExecutor][Vulkan] Copy Runtime ownership claim rejected mode={}",
+            static_cast<uint32>(expected)
+        );
+    } catch (...) {
+    }
+    return false;
+}
+
+void VkCopyQueue::ReleaseRuntimeOwnership() noexcept {
+    CancelRuntimeDependencyWaits();
+    EExecutionOwnershipMode expected = EExecutionOwnershipMode::Runtime;
+    const bool released = execution_ownership_mode.compare_exchange_strong(
+        expected,
+        EExecutionOwnershipMode::Unclaimed,
+        std::memory_order_acq_rel,
+        std::memory_order_acquire
+    );
+    assert(released && "only the owning Vulkan runtime may release Copy");
 }
 static constexpr uint64 fread_segment_size = 1024 * 64; // 64KB
 IOWaitEvt               VkCopyQueue::Execute(IOQueueSubmission&& _submission) {
@@ -7462,265 +7647,74 @@ IOWaitEvt               VkCopyQueue::Execute(IOQueueSubmission&& _submission) {
 
 //TODO:看看barrier
 IOWaitEvt VkCopyQueue::Execute(CmdSubmit&& _evt) {
-    TrackedExecuteResult result = ExecuteOnSubmissionOwner(std::move(_evt));
-    if (!result.runtime.outcome.WasSubmitted()) {
-        return {0, 0};
-    }
-    return {uint64(timeline.Get()), result.logical_timeline};
-}
-
-VulkanRuntimeSubmissionResult VkCopyQueue::ExecuteForRuntime(CmdSubmit&& _evt) noexcept {
-    assert(
-        GetCurrentRHIThreadRole() == ERHIThreadRole::Submission &&
-        "runtime Copy submission must originate from a Submission owner"
-    );
-    return ExecuteOnSubmissionOwner(std::move(_evt)).runtime;
-}
-
-VkCopyQueue::TrackedExecuteResult VkCopyQueue::ExecuteOnSubmissionOwner(
-    CmdSubmit&& _submit
-) noexcept {
-    const auto rejected_result = [this](VkResult _result) {
-        if (_result == VK_SUCCESS) {
-            _result = VK_ERROR_UNKNOWN;
-        }
-        return TrackedExecuteResult{
-            .runtime = VulkanRuntimeSubmissionResult{
-                .outcome = VulkanOperationResult{
-                    EVulkanOperationStatus::Rejected, _result
-                },
-            },
-            .logical_timeline = 0,
-        };
-    };
-
-    if (submission_thread_id.load(std::memory_order_acquire) ==
-        Platform::GetCurrentThreadID()) {
-        try {
-            LOG_ERROR(
-                "[RHIExecutor][Vulkan] Recursive Copy submission on its owner "
-                "thread was rejected"
-            );
-        } catch (...) {
-        }
-        const VkResult result = GetRejectedSubmitResult(device);
-        RejectForRuntime(std::move(_submit), result);
-        return rejected_result(result);
-    }
-
-    UniquePtr<CopySubmissionRequest> request{};
-    std::future<TrackedExecuteResult> completion{};
-    bool                              queued = false;
     try {
-        request    = MakeUnique<CopySubmissionRequest>(std::move(_submit));
-        completion = request->completion.get_future();
-        {
-            std::lock_guard lock(submission_mutex);
-            if (submission_accepting.load(std::memory_order_acquire)) {
-                submission_requests.emplace_back(std::move(request));
-                queued = true;
-            }
-        }
-
-        if (!queued) {
-            const VkResult result = GetRejectedSubmitResult(device);
-            RejectForRuntime(std::move(request->submit), result);
-            return rejected_result(result);
-        }
-        submission_cv.notify_one();
-    } catch (...) {
-        const VkResult result = GetRejectedSubmitResult(device);
-        if (!queued) {
-            if (request) {
-                RejectForRuntime(std::move(request->submit), result);
-            } else {
-                RejectForRuntime(std::move(_submit), result);
-            }
-        }
-        try {
-            LOG_ERROR(
-                "[RHIExecutor][Vulkan] Failed to enqueue Copy submission owner work"
-            );
-        } catch (...) {
-        }
-        return rejected_result(result);
-    }
-
-    try {
-        return completion.get();
-    } catch (...) {
-        try {
-            LOG_ERROR(
-                "[RHIExecutor][Vulkan] Copy submission owner failed to publish "
-                "its request result"
-            );
-        } catch (...) {
-        }
-        return rejected_result(GetRejectedSubmitResult(device));
-    }
-}
-
-void VkCopyQueue::SubmissionThreadMain() {
-    Platform::SetCurrentThreadName("Moer Vulkan Copy Submission");
-    RHIThreadRoleScope owner_scope(ERHIThreadRole::Submission);
-    submission_thread_id.store(
-        Platform::GetCurrentThreadID(), std::memory_order_release
-    );
-
-    for (;;) {
-        UniquePtr<CopySubmissionRequest> request{};
-        {
-            std::unique_lock lock(submission_mutex);
-            submission_cv.wait(lock, [this]() {
-                return !submission_accepting.load(std::memory_order_acquire) ||
-                       !submission_requests.empty();
-            });
-            if (submission_requests.empty()) {
-                assert(
-                    !submission_accepting.load(std::memory_order_acquire) &&
-                    "Copy submission owner woke without work"
-                );
-                break;
-            }
-            request = std::move(submission_requests.front());
-            submission_requests.pop_front();
-        }
-
-        TrackedExecuteResult result =
-            ExecuteTracked(std::move(request->submit));
-        try {
-            request->completion.set_value(std::move(result));
-        } catch (...) {
-            try {
-                LOG_ERROR(
-                    "[RHIExecutor][Vulkan] Copy submission owner could not resolve "
-                    "an accepted request"
-                );
-            } catch (...) {
-            }
-        }
-    }
-
-    submission_thread_id.store(0, std::memory_order_release);
-}
-
-VkCopyQueue::TrackedExecuteResult VkCopyQueue::ExecuteTracked(CmdSubmit&& _evt) noexcept {
-    RuntimeExecuteState state{};
-    std::unique_lock<std::mutex> execution_lock(exec_mutex);
-    try {
-        return ExecuteTrackedImpl(_evt, state);
-    } catch (const std::exception& error) {
-        try {
-            LOG_ERROR(
-                "[RHIExecutor][Vulkan] Copy execution threw before retirement: {}",
-                error.what()
-            );
-        } catch (...) {
-        }
-    } catch (...) {
-        try {
-            LOG_ERROR("[RHIExecutor][Vulkan] Copy execution threw before retirement");
-        } catch (...) {
-        }
-    }
-
-    if (state.completion_committed) {
-        VulkanRuntimeSubmissionResult runtime_result{
-            .outcome               = state.outcome,
-            .recoverable_rejection = state.recoverable_rejection,
-        };
-        if (state.outcome.WasSubmitted()) {
-            runtime_result.completion =
-                WaitEvent{uint64(timeline.Get()), state.logical_timeline};
-        }
-        return {
-            .runtime          = std::move(runtime_result),
-            .logical_timeline = state.logical_timeline,
-        };
-    }
-
-    queue.DiscardPendingSubmitState();
-    if (!state.native_submit_resolved) {
-        state.outcome = {
-            EVulkanOperationStatus::Rejected, VK_ERROR_UNKNOWN
-        };
-        state.native_submit_resolved = true;
-        device.RecordRejectedSubmit();
-    }
-
-    // A recorded allocator which did not reach a native submit must be reset
-    // by Completion as abandoned.  If native submission was accepted it must
-    // remain in the submitted set until the GPU timeline completes.
-    if (!state.outcome.WasSubmitted()) {
-        for (auto& allocator : state.allocators.submitted) {
-            state.allocators.abandoned.emplace_back(std::move(allocator));
-        }
-        state.allocators.submitted.clear();
-    }
-
-    CommitRuntimeSubmitCompletion(
-        std::move(_evt),
-        std::move(state.allocators),
-        state.outcome,
-        state.context,
-        state.logical_timeline,
-        state.timeline_reserved
-    );
-    state.completion_committed = true;
-
-    VulkanRuntimeSubmissionResult runtime_result{
-        .outcome               = state.outcome,
-        .recoverable_rejection = state.recoverable_rejection,
-    };
-    if (state.outcome.WasSubmitted()) {
-        runtime_result.completion =
-            WaitEvent{uint64(timeline.Get()), state.logical_timeline};
-    }
-    return {
-        .runtime          = std::move(runtime_result),
-        .logical_timeline = state.logical_timeline,
-    };
-}
-
-VkCopyQueue::TrackedExecuteResult VkCopyQueue::ExecuteTrackedImpl(
-    CmdSubmit& _evt,
-    RuntimeExecuteState& _state
-) {
-    _state.logical_timeline = last_frame;
-    _state.context = VulkanOperationContext{
-        .operation  = EVulkanFaultOperation::QueueSubmit,
-        .queue_type = EQueueType::Copy,
-        .queue      = queue.GetHandle(),
-    };
-
-    if (device.IsFaulted()) {
-        const VkResult rejected_result = device.GetFirstFaultResult();
-        device.RecordRejectedSubmit();
-        _state.outcome = {
-            EVulkanOperationStatus::Rejected, rejected_result
-        };
-        _state.native_submit_resolved = true;
-        CommitRuntimeSubmitCompletion(
-            std::move(_evt),
-            std::move(_state.allocators),
-            _state.outcome,
-            _state.context,
-            0,
-            false
+        LOG_ERROR(
+            "[RHIExecutor][Vulkan] direct Copy Execute is unsupported; "
+            "publish work through RHIExecutor"
         );
-        _state.completion_committed = true;
-        return {
-            .runtime = {
-                .outcome = _state.outcome
-            },
-            .logical_timeline = _state.logical_timeline,
-        };
+    } catch (...) {
     }
+    RejectForRuntime(std::move(_evt), VK_ERROR_UNKNOWN);
+    return {0, 0};
+}
 
-    const bool has_queue_work =
-        !_evt.cmds.empty() || !_evt.wait_events.empty() || !_evt.signal_events.empty() ||
-        !_evt.callbacks.empty() || !_evt.success_callbacks.empty();
-    if (has_queue_work) {
+std::optional<VkCopyQueue::CurrentVulkanCopyRecordedSubmit>
+VkCopyQueue::TranslateForRuntime(CmdSubmit&& _evt) noexcept {
+    assert(
+        execution_ownership_mode.load(std::memory_order_acquire) ==
+            EExecutionOwnershipMode::Runtime &&
+        "runtime Copy translate requires an exclusively claimed queue"
+    );
+    assert(
+        GetCurrentRHIThreadRole() == ERHIThreadRole::Translate &&
+        "runtime Copy translation must run on the Translate owner"
+    );
+
+    auto execution_lease = runtime_execution_gate.Acquire();
+    std::optional<CurrentVulkanCopyRecordedSubmit> recorded{};
+    try {
+        recorded.emplace(std::move(_evt));
+        recorded->execution_lease = std::move(execution_lease);
+
+        const bool has_queue_work =
+            !recorded->submit.cmds.empty() ||
+            !recorded->submit.wait_events.empty() ||
+            !recorded->submit.signal_events.empty() ||
+            !recorded->submit.callbacks.empty() ||
+            !recorded->submit.success_callbacks.empty() ||
+            recorded->submit.b_sync ||
+            recorded->submit.b_tick_profiling ||
+            recorded->submit.b_delete_resources;
+        if (!has_queue_work) {
+            recorded->retirement_outcome     = {};
+            recorded->native_submit_resolved = true;
+            recorded->completion_committed   = true;
+            return recorded;
+        }
+
+        std::unique_lock<std::mutex> execution_lock(exec_mutex);
+        recorded->logical_timeline =
+            last_frame.fetch_add(1, std::memory_order_relaxed) + 1;
+        recorded->context = VulkanOperationContext{
+            .operation   = EVulkanFaultOperation::QueueSubmit,
+            .queue_type  = EQueueType::Copy,
+            .queue       = queue.GetHandle(),
+            .timeline    = recorded->logical_timeline,
+            .work_serial = recorded->logical_timeline,
+        };
+
+        if (device.IsFaulted()) {
+            device.RecordRejectedSubmit();
+            recorded->retirement_outcome = {
+                EVulkanOperationStatus::Rejected,
+                device.GetFirstFaultResult()
+            };
+            recorded->native_submit_resolved = true;
+            CommitRuntimeSubmitCompletion(
+                *recorded, recorded->retirement_outcome
+            );
+            return std::nullopt;
+        }
 
         FunctionTable function_table{
             .is_resource_write       = &IsBufferTextureWrite,
@@ -7728,201 +7722,315 @@ VkCopyQueue::TrackedExecuteResult VkCopyQueue::ExecuteTrackedImpl(
             .is_texture_sampled      = &IsTextureSampled,
             .is_resource_in_bindless = &IsResourceInBindlessArray
         };
-        CmdReorderer reorderer{function_table, _evt.cached_args};
+        CmdReorderer reorderer{
+            function_table, recorded->submit.cached_args
+        };
 
-        _state.allocators.submitted.reserve(1);
-        _state.allocators.submitted.emplace_back(GetAllocator());
-        auto& vk_allocator = *_state.allocators.submitted.front();
-        auto&                        vk_cmd_list  = vk_allocator.GetCmdList();
-        auto&                        vk_tracker   = vk_allocator.GetTracker();
+        recorded->allocators.submitted.reserve(1);
+        recorded->allocators.submitted.emplace_back(GetAllocator());
+        auto& vk_allocator =
+            *recorded->allocators.submitted.front();
+        auto& vk_cmd_list = vk_allocator.GetCmdList();
+        auto& vk_tracker  = vk_allocator.GetTracker();
 
         VkCmdPreprocessor preprocessor(
-            device, vk_tracker, vk_allocator, {}, _evt.cached_args, EQueueType::Copy
+            device,
+            vk_tracker,
+            vk_allocator,
+            {},
+            recorded->submit.cached_args,
+            EQueueType::Copy
         );
-        VkCmdVisitor visitor(device, vk_allocator, vk_tracker, vk_cmd_list, _evt.cached_args);
+        VkCmdVisitor visitor(
+            device,
+            vk_allocator,
+            vk_tracker,
+            vk_cmd_list,
+            recorded->submit.cached_args
+        );
 
-        for (const auto& cmd : _evt.cmds) {
-            // preprocessor.VisitCmd(cmd.get());
+        for (const auto& cmd : recorded->submit.cmds) {
             reorderer.AcceptCmd(cmd.get());
         }
 
         VK_CHECK_RESULT(vk_cmd_list.Begin());
         vk_cmd_list.BeginLabel("Copy", {0.0f, 1.0f, 1.0f, 1.0f});
-        const auto& cmd_lists = reorderer.m_cmd_lists;
-
-        for (const CmdReorderer::LinkedCommandList& cmd_list : cmd_lists) {
+        for (const CmdReorderer::LinkedCommandList& cmd_list :
+             reorderer.m_cmd_lists) {
             if (cmd_list.head == nullptr) {
                 continue;
             }
-            for (const auto* cmdnode = cmd_list.head; cmdnode != nullptr; cmdnode = cmdnode->next) {
-                preprocessor.VisitCmd(cmdnode->cmd);
+            for (const auto* node = cmd_list.head; node != nullptr;
+                 node = node->next) {
+                preprocessor.VisitCmd(node->cmd);
             }
             vk_tracker.ResolveBarriers();
             vk_tracker.DispatchBarriers(vk_cmd_list);
-            for (const auto* cmdnode = cmd_list.head; cmdnode != nullptr; cmdnode = cmdnode->next) {
-                const auto* cmd = cmdnode->cmd;
-                visitor.VisitCmd(cmd);
+            for (const auto* node = cmd_list.head; node != nullptr;
+                 node = node->next) {
+                visitor.VisitCmd(node->cmd);
             }
         }
 
-        // vk_tracker.ResolveBarriers();
-        // vk_tracker.DispatchBarriers(vk_cmd_list);
-        // for (const auto& cmd : cmds) {
-        //     visitor.VisitCmd(cmd.get());
-        // }
-        //copy
-        if (!_evt.HasExplicitResourceStateOwnership()) {
+        if (!recorded->submit.HasExplicitResourceStateOwnership()) {
             vk_tracker.RestoreState();
         }
         vk_tracker.DispatchBarriers(vk_cmd_list);
         vk_cmd_list.EndLabel();
         VK_CHECK_RESULT(vk_cmd_list.End());
         vk_tracker.Reset();
+        return recorded;
+    } catch (const std::exception& error) {
+        try {
+            LOG_ERROR(
+                "[RHIExecutor][Vulkan] Copy translation threw: {}",
+                error.what()
+            );
+        } catch (...) {
+        }
+    } catch (...) {
+        try {
+            LOG_ERROR("[RHIExecutor][Vulkan] Copy translation threw");
+        } catch (...) {
+        }
+    }
 
-        _state.logical_timeline = ++last_frame;
-        _state.timeline_reserved = true;
-        _state.context = VulkanOperationContext{
-            .operation   = EVulkanFaultOperation::QueueSubmit,
-            .queue_type  = EQueueType::Copy,
-            .queue       = queue.GetHandle(),
-            .timeline    = _state.logical_timeline,
-            .work_serial = _state.logical_timeline,
+    if (!recorded) {
+        RejectForRuntime(std::move(_evt), VK_ERROR_UNKNOWN);
+        return std::nullopt;
+    }
+    if (!recorded->native_submit_resolved) {
+        device.RecordRejectedSubmit();
+        recorded->retirement_outcome = {
+            EVulkanOperationStatus::Rejected, VK_ERROR_UNKNOWN
         };
+        recorded->native_submit_resolved = true;
+    }
+    if (!recorded->completion_committed) {
+        CommitRuntimeSubmitCompletion(
+            *recorded, recorded->retirement_outcome
+        );
+    }
+    return std::nullopt;
+}
+
+VulkanRuntimeSubmissionResult VkCopyQueue::SubmitRecordedForRuntime(
+    CurrentVulkanCopyRecordedSubmit _recorded
+) noexcept {
+    assert(
+        execution_ownership_mode.load(std::memory_order_acquire) ==
+            EExecutionOwnershipMode::Runtime &&
+        "runtime Copy submit requires an exclusively claimed queue"
+    );
+    assert(
+        GetCurrentRHIThreadRole() == ERHIThreadRole::Submission &&
+        "runtime Copy submit must run on the Submission owner"
+    );
+    assert(
+        _recorded.execution_lease.OwnsGate() &&
+        "runtime Copy packet must retain queue execution ownership"
+    );
+
+    if (_recorded.logical_timeline == 0) {
+        return {
+            .outcome = _recorded.retirement_outcome,
+        };
+    }
+
+    try {
+        std::unique_lock<std::mutex> execution_lock(exec_mutex);
         if (!WaitForSubmittedDependencies(
-                device, _evt.wait_events, &dependency_waits_enabled
+                device,
+                _recorded.submit.wait_events,
+                EQueueType::Copy,
+                &dependency_waits_enabled
             )) {
             device.RecordRejectedSubmit();
-            const VkResult rejected_result = GetRejectedSubmitResult(device);
-            _state.outcome = {
-                EVulkanOperationStatus::Rejected, rejected_result
+            _recorded.retirement_outcome = {
+                EVulkanOperationStatus::Rejected,
+                GetRejectedSubmitResult(device)
             };
-            _state.recoverable_rejection = !device.IsFaulted();
-            _state.native_submit_resolved = true;
+            _recorded.recoverable_rejection = !device.IsFaulted();
+            _recorded.native_submit_resolved = true;
         } else {
             queue.Signal(
                 timeline,
-                _state.logical_timeline,
+                _recorded.logical_timeline,
                 VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT
             );
-            for (auto& evt : _evt.wait_events) {
-                queue.Wait(reinterpret_cast<VulkanFence*>(evt.timeline_handle), evt.value);
+            for (auto& event : _recorded.submit.wait_events) {
+                queue.Wait(
+                    reinterpret_cast<VulkanFence*>(
+                        event.timeline_handle
+                    ),
+                    event.value
+                );
             }
-            for (auto& evt : _evt.signal_events) {
+            for (auto& event : _recorded.submit.signal_events) {
                 queue.Signal(
-                    reinterpret_cast<VulkanFence*>(evt.timeline_handle),
-                    evt.value,
+                    reinterpret_cast<VulkanFence*>(
+                        event.timeline_handle
+                    ),
+                    event.value,
                     VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT
                 );
             }
-            _state.outcome =
-                queue.Submit(vk_allocator.GetCmdList(), _state.context);
-            _state.native_submit_resolved = true;
-            if (_state.outcome.WasSubmitted()) {
+
+            assert(
+                _recorded.allocators.submitted.size() == 1 &&
+                "Copy Translate must publish exactly one command allocator"
+            );
+            auto& vk_allocator =
+                *_recorded.allocators.submitted.front();
+            _recorded.retirement_outcome =
+                queue.Submit(vk_allocator.GetCmdList(), _recorded.context);
+            _recorded.native_submit_resolved = true;
+            if (_recorded.retirement_outcome.WasSubmitted()) {
                 MarkSubmissionAccepted(
                     timeline.Get(),
-                    _state.logical_timeline,
-                    _evt.signal_events
+                    _recorded.logical_timeline,
+                    _recorded.submit.signal_events
                 );
             }
         }
-
-        if (!_state.outcome.WasSubmitted()) {
-            for (auto& allocator : _state.allocators.submitted) {
-                _state.allocators.abandoned.emplace_back(std::move(allocator));
-            }
-            _state.allocators.submitted.clear();
+    } catch (const std::exception& error) {
+        try {
+            LOG_ERROR(
+                "[RHIExecutor][Vulkan] Copy recorded submit threw before retirement: {}",
+                error.what()
+            );
+        } catch (...) {
         }
-
-        CommitRuntimeSubmitCompletion(
-            std::move(_evt),
-            std::move(_state.allocators),
-            _state.outcome,
-            _state.context,
-            _state.logical_timeline,
-            _state.timeline_reserved
-        );
-        _state.completion_committed = true;
-
-        VulkanRuntimeSubmissionResult runtime_result{
-            .outcome               = _state.outcome,
-            .recoverable_rejection = _state.recoverable_rejection,
-        };
-        if (_state.outcome.WasSubmitted()) {
-            runtime_result.completion =
-                WaitEvent{uint64(timeline.Get()), _state.logical_timeline};
+    } catch (...) {
+        try {
+            LOG_ERROR(
+                "[RHIExecutor][Vulkan] Copy recorded submit threw before retirement"
+            );
+        } catch (...) {
         }
-        return {
-            .runtime          = std::move(runtime_result),
-            .logical_timeline = _state.logical_timeline,
-        };
     }
-    return {
-        .runtime          = {},
-        .logical_timeline = _state.logical_timeline,
+
+    if (!_recorded.native_submit_resolved) {
+        queue.DiscardPendingSubmitState();
+        device.RecordRejectedSubmit();
+        _recorded.retirement_outcome = {
+            EVulkanOperationStatus::Rejected, VK_ERROR_UNKNOWN
+        };
+        _recorded.native_submit_resolved = true;
+    }
+    if (!_recorded.completion_committed) {
+        CommitRuntimeSubmitCompletion(
+            _recorded, _recorded.retirement_outcome
+        );
+    }
+
+    VulkanRuntimeSubmissionResult runtime_result{
+        .outcome               = _recorded.retirement_outcome,
+        .recoverable_rejection = _recorded.recoverable_rejection,
     };
+    if (_recorded.retirement_outcome.WasSubmitted()) {
+        runtime_result.completion =
+            WaitEvent{
+                uint64(timeline.Get()),
+                _recorded.logical_timeline
+            };
+    }
+    return runtime_result;
 }
 
+void VkCopyQueue::RejectRecordedForRuntime(
+    CurrentVulkanCopyRecordedSubmit&& _recorded,
+    VkResult                           _result
+) noexcept {
+    assert(
+        _recorded.execution_lease.OwnsGate() &&
+        "a failed Copy Translate -> Submission handoff must retain ownership"
+    );
+    if (_result == VK_SUCCESS) {
+        _result = VK_ERROR_UNKNOWN;
+    }
+    queue.DiscardPendingSubmitState();
+    device.RecordRejectedSubmit();
+    _recorded.retirement_outcome = {
+        EVulkanOperationStatus::Rejected, _result
+    };
+    _recorded.native_submit_resolved = true;
+    if (!_recorded.completion_committed) {
+        CommitRuntimeSubmitCompletion(
+            _recorded, _recorded.retirement_outcome
+        );
+    }
+}
 void VkCopyQueue::RejectForRuntime(CmdSubmit&& _submit, VkResult _result) noexcept {
     if (_result == VK_SUCCESS) {
         _result = VK_ERROR_UNKNOWN;
     }
     device.RecordRejectedSubmit();
+    CurrentVulkanCopyRecordedSubmit rejected{std::move(_submit)};
+    rejected.context = VulkanOperationContext{
+        .operation  = EVulkanFaultOperation::QueueSubmit,
+        .queue_type = EQueueType::Copy,
+        .queue      = queue.GetHandle(),
+    };
+    rejected.retirement_outcome = {
+        EVulkanOperationStatus::Rejected, _result
+    };
+    rejected.native_submit_resolved = true;
     CommitRuntimeSubmitCompletion(
-        std::move(_submit),
-        VulkanAllocatorBatch{},
-        VulkanOperationResult{EVulkanOperationStatus::Rejected, _result},
-        VulkanOperationContext{
-            .operation  = EVulkanFaultOperation::QueueSubmit,
-            .queue_type = EQueueType::Copy,
-            .queue      = queue.GetHandle(),
-        },
-        0,
-        false
+        rejected, rejected.retirement_outcome
     );
 }
 
 void VkCopyQueue::CommitRuntimeSubmitCompletion(
-    CmdSubmit&&                  _submit,
-    VulkanAllocatorBatch&&       _allocators,
-    const VulkanOperationResult& _outcome,
-    const VulkanOperationContext& _context,
-    uint64                        _logical_timeline,
-    bool                          _has_queue_timeline_reservation
+    CurrentVulkanCopyRecordedSubmit& _recorded,
+    const VulkanOperationResult&      _outcome
 ) noexcept {
+    assert(!_recorded.completion_committed);
     try {
         if (!_outcome.WasSubmitted()) {
-            if (_has_queue_timeline_reservation) {
+            if (_recorded.logical_timeline != 0) {
                 TerminalizeUnsubmittedSignal(
                     device,
                     timeline.Get(),
-                    _logical_timeline,
+                    _recorded.logical_timeline,
                     _outcome
                 );
             }
             TerminalizeUnsubmittedSignals(
-                device, _submit.signal_events, _outcome
+                device, _recorded.submit.signal_events, _outcome
             );
             // Exact signal rejection is published by Submission. Do not
             // retain raw external fence pointers in the Completion packet.
-            _submit.signal_events.clear();
+            _recorded.submit.signal_events.clear();
+            _recorded.allocators.abandoned.reserve(
+                _recorded.allocators.abandoned.size() +
+                _recorded.allocators.submitted.size()
+            );
+            for (auto& allocator : _recorded.allocators.submitted) {
+                _recorded.allocators.abandoned.emplace_back(
+                    std::move(allocator)
+                );
+            }
+            _recorded.allocators.submitted.clear();
         }
         std::unique_lock<std::mutex> lock(event_mutex);
         const uint64 retirement_serial = retirement_enqueued_serial + 1;
         event_queue.emplace_back(
             std::in_place_type<VulkanSubmitCompletionBatch>,
-            _logical_timeline,
+            _recorded.logical_timeline,
             true,
             retirement_serial,
             _outcome,
-            _context,
+            _recorded.context,
             _outcome.WasSubmitted(),
-            _has_queue_timeline_reservation,
-            std::move(_submit),
-            std::move(_allocators),
+            _recorded.logical_timeline != 0,
+            std::move(_recorded.submit),
+            std::move(_recorded.allocators),
             std::optional<VulkanDescriptorPushLease>{},
             Array<RHIResource*>{}
         );
         retirement_enqueued_serial = retirement_serial;
+        _recorded.completion_committed = true;
     } catch (...) {
         std::terminate();
     }
@@ -8284,7 +8392,7 @@ void VkCopyQueue::RHIThreadLoop() {
     try {
         LOG_ERROR(
             "[RHIExecutor][Vulkan] Legacy Copy RHIThreadLoop is disabled; "
-            "native Copy submission belongs to Moer Vulkan Copy Submission"
+            "native Copy submission belongs to Moer Vulkan Submission"
         );
     } catch (...) {
     }

--- a/source/runtime/render/rhi/vulkan/VulkanQueue.h
+++ b/source/runtime/render/rhi/vulkan/VulkanQueue.h
@@ -18,7 +18,6 @@
 #include <chrono>
 #include <condition_variable>
 #include <functional>
-#include <future>
 #include <mutex>
 #include <optional>
 #include <string_view>
@@ -917,7 +916,6 @@ public:
 
     IOWaitEvt Execute(IOQueueSubmission&& _submit) override;
     IOWaitEvt Execute(CmdSubmit&& _submit) override;
-    VulkanRuntimeSubmissionResult ExecuteForRuntime(CmdSubmit&& _submit) noexcept;
     FenceRef  GetFenceHandle() override;
     void      Sync(uint64 _timeline) override;
 
@@ -971,46 +969,50 @@ private:
     void EnableRuntimeDependencyWaits() noexcept;
     void CancelRuntimeDependencyWaits() noexcept;
 
-    struct TrackedExecuteResult {
-        VulkanRuntimeSubmissionResult runtime{};
-        uint64                        logical_timeline{0};
-    };
-
-    struct RuntimeExecuteState {
-        uint64                   logical_timeline{0};
-        VulkanOperationContext   context{};
-        VulkanOperationResult    outcome{
-            EVulkanOperationStatus::Rejected, VK_ERROR_UNKNOWN
-        };
-        VulkanAllocatorBatch     allocators{};
-        bool                     timeline_reserved{false};
-        bool                     recoverable_rejection{false};
-        bool                     native_submit_resolved{false};
-        bool                     completion_committed{false};
-    };
-
-    struct CopySubmissionRequest {
-        explicit CopySubmissionRequest(CmdSubmit&& _submit) :
+    struct CurrentVulkanCopyRecordedSubmit {
+        explicit CurrentVulkanCopyRecordedSubmit(CmdSubmit&& _submit) :
             submit(std::move(_submit)) {}
 
-        std::promise<TrackedExecuteResult> completion;
-        CmdSubmit                          submit;
+        CurrentVulkanCopyRecordedSubmit(
+            const CurrentVulkanCopyRecordedSubmit&
+        ) = delete;
+        CurrentVulkanCopyRecordedSubmit& operator=(
+            const CurrentVulkanCopyRecordedSubmit&
+        ) = delete;
+        CurrentVulkanCopyRecordedSubmit(
+            CurrentVulkanCopyRecordedSubmit&&
+        ) noexcept = default;
+        CurrentVulkanCopyRecordedSubmit& operator=(
+            CurrentVulkanCopyRecordedSubmit&&
+        ) noexcept = default;
+
+        CmdSubmit                           submit;
+        VulkanOperationContext              context{};
+        uint64                              logical_timeline{0};
+        VulkanAllocatorBatch                allocators{};
+        RHITransferableOwnershipGate::Lease execution_lease{};
+        VulkanOperationResult               retirement_outcome{
+            EVulkanOperationStatus::Rejected, VK_ERROR_UNKNOWN
+        };
+        bool recoverable_rejection{false};
+        bool native_submit_resolved{false};
+        bool completion_committed{false};
     };
 
-    TrackedExecuteResult ExecuteOnSubmissionOwner(CmdSubmit&& _submit) noexcept;
-    void                 SubmissionThreadMain();
-    TrackedExecuteResult ExecuteTracked(CmdSubmit&& _submit) noexcept;
-    TrackedExecuteResult ExecuteTrackedImpl(
-        CmdSubmit&           _submit,
-        RuntimeExecuteState& _state
-    );
+    std::optional<CurrentVulkanCopyRecordedSubmit>
+        TranslateForRuntime(CmdSubmit&& _submit) noexcept;
+    VulkanRuntimeSubmissionResult SubmitRecordedForRuntime(
+        CurrentVulkanCopyRecordedSubmit _recorded
+    ) noexcept;
+    void RejectRecordedForRuntime(
+        CurrentVulkanCopyRecordedSubmit&& _recorded,
+        VkResult                           _result
+    ) noexcept;
+    [[nodiscard]] bool ClaimRuntimeOwnership();
+    void ReleaseRuntimeOwnership() noexcept;
     void CommitRuntimeSubmitCompletion(
-        CmdSubmit&&                 _submit,
-        VulkanAllocatorBatch&&      _allocators,
-        const VulkanOperationResult& _outcome,
-        const VulkanOperationContext& _context,
-        uint64                       _logical_timeline,
-        bool                         _has_queue_timeline_reservation
+        CurrentVulkanCopyRecordedSubmit& _recorded,
+        const VulkanOperationResult&      _outcome
     ) noexcept;
     UniquePtr<VulkanAllocator>                GetAllocator();
     void                                      CompleteAll(uint64 _timeline);
@@ -1018,9 +1020,14 @@ private:
     DEQueue<IOEvent>                          event_queue;
 
 private:
+    enum class EExecutionOwnershipMode : uint8_t {
+        Unclaimed,
+        Runtime,
+    };
+
     VulkanDevice& device;
 
-    uint                    last_frame     = 0;
+    std::atomic<uint64>     last_frame{0};
     std::atomic<uint64>     cpu_settled_frame = 0;
     uint64                  retirement_enqueued_serial{0};
     std::atomic<uint64>     retirement_settled_serial{0};
@@ -1032,18 +1039,16 @@ private:
     VkNativeQueue           queue;
     std::jthread            thread;
 
-    DEQueue<UniquePtr<CopySubmissionRequest>> submission_requests;
-    std::mutex                                  submission_mutex;
-    std::condition_variable                     submission_cv;
-    std::atomic_bool                            submission_accepting{true};
-    std::atomic_bool                            dependency_waits_enabled{true};
-    std::jthread                                submission_thread;
-    std::atomic<uint32>                         submission_thread_id{0};
+    std::atomic_bool dependency_waits_enabled{true};
 
     //tmp
     LockFreeQueueBase<IOCmd> commands;
 
     std::mutex                                     exec_mutex;
+    RHITransferableOwnershipGate                   runtime_execution_gate;
+    std::atomic<EExecutionOwnershipMode>           execution_ownership_mode{
+        EExecutionOwnershipMode::Unclaimed
+    };
     Array<VkSemaphore>                             pending_semaphores;
     Queue<std::pair<IOQueueCommandList&&, uint64>> io_thread_cmds;
     std::mutex                                     io_mutex;

--- a/source/runtime/render/rhi/vulkan/VulkanRHIResource.cpp
+++ b/source/runtime/render/rhi/vulkan/VulkanRHIResource.cpp
@@ -25,6 +25,7 @@
 #include "rhi/RHICommon.h"
 #include "rhi/RHIResource.h"
 #include "rhi/RHIResourceInitilizer.h"
+#include "VulkanSubmissionDiagnostics.h"
 #include "vulkan/vk_enum_string_helper.h"
 
 #include <limits>
@@ -4066,9 +4067,12 @@ VkAccessFlags2 VulkanEnumTranslator::METoVkAccessFlags2(ERHIAccessFlags _flags) 
 
     bool VulkanFence::WaitSubmitted(
         uint64_t _value,
-        const std::atomic_bool* _continue_waiting
+        const std::atomic_bool* _continue_waiting,
+        EQueueType              _waiting_queue,
+        uint32                  _dependency_count
     ) {
         std::unique_lock<std::mutex> lock(cv_m);
+        bool notified_blocked_wait = false;
         while (
             submitted_value < _value &&
             !rejected_values.contains(_value) &&
@@ -4077,6 +4081,13 @@ VkAccessFlags2 VulkanEnumTranslator::METoVkAccessFlags2(ERHIAccessFlags _flags) 
             (_continue_waiting == nullptr ||
              _continue_waiting->load(std::memory_order_acquire))
         ) {
+            if (!notified_blocked_wait) {
+                NotifyVulkanSubmissionDependencyWaitBlocked(
+                    _waiting_queue,
+                    _dependency_count
+                );
+                notified_blocked_wait = true;
+            }
             cv.wait_for(lock, std::chrono::milliseconds(50));
         }
         return submitted_value >= _value &&

--- a/source/runtime/render/rhi/vulkan/VulkanRHIResource.h
+++ b/source/runtime/render/rhi/vulkan/VulkanRHIResource.h
@@ -1054,7 +1054,9 @@ public:
     void  MarkSubmitted(uint64_t _value);
     RENDER_API bool WaitSubmitted(
         uint64_t               _value,
-        const std::atomic_bool* _continue_waiting = nullptr
+        const std::atomic_bool* _continue_waiting = nullptr,
+        EQueueType              _waiting_queue = EQueueType::Ignore,
+        uint32                  _dependency_count = 0
     );
     RENDER_API bool IsRejected(uint64_t _value) const;
     RENDER_API VkResult HostWait(

--- a/source/runtime/render/rhi/vulkan/VulkanSubmissionDiagnostics.h
+++ b/source/runtime/render/rhi/vulkan/VulkanSubmissionDiagnostics.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include "RenderAPI.h"
+#include "rhi/RHICommon.h"
+
+namespace Moer::Render {
+
+// A successful source-packet handoff observed on the sole Vulkan Submission
+// owner. This is intentionally below Translate and above native completion, so
+// diagnostics can distinguish source order from worker completion order.
+struct VulkanSourceSubmissionEvent {
+    uint64     batch_sequence{0};
+    uint32     source_index{0};
+    EQueueType queue{EQueueType::Ignore};
+    uint64     async_queue_scope{0};
+};
+
+using VulkanSourceSubmissionCallback = void (*)(void*, const VulkanSourceSubmissionEvent&) noexcept;
+
+struct VulkanSourceSubmissionObserver {
+    void*                          context{nullptr};
+    VulkanSourceSubmissionCallback callback{nullptr};
+};
+
+// Observer storage is caller-owned and must remain immutable while installed.
+// The callback runs on the Submission owner and must be short, non-blocking,
+// noexcept, and must not re-enter RHI. Install before publishing the observed
+// work, quiesce that work, remove the observer, and only then destroy it;
+// removal does not wait for a callback which has already loaded the observer.
+// Runtime cost while disabled is one atomic pointer load per submitted source.
+[[nodiscard]] RENDER_API bool
+TryInstallVulkanSourceSubmissionObserver(const VulkanSourceSubmissionObserver* _observer) noexcept;
+[[nodiscard]] RENDER_API bool
+RemoveVulkanSourceSubmissionObserver(const VulkanSourceSubmissionObserver* _observer) noexcept;
+
+} // namespace Moer::Render

--- a/source/runtime/render/rhi/vulkan/VulkanSubmissionDiagnostics.h
+++ b/source/runtime/render/rhi/vulkan/VulkanSubmissionDiagnostics.h
@@ -12,9 +12,16 @@ namespace Moer::Render {
 // diagnostics can distinguish source order from worker completion order.
 struct VulkanSourceSubmissionEvent {
     uint64     batch_sequence{0};
+    // Stable executable-entry index after backend segment materialization.
     uint32     source_index{0};
+    // Original upper source identity remains stable when one source lowers to
+    // several executable segment packets.
+    uint32     original_source_index{0};
+    uint32     source_segment_index{0};
+    uint32     source_segment_count{1};
     EQueueType queue{EQueueType::Ignore};
     uint64     async_queue_scope{0};
+    bool       cross_native_predecessor_wait{false};
 };
 
 using VulkanSourceSubmissionCallback = void (*)(void*, const VulkanSourceSubmissionEvent&) noexcept;
@@ -23,6 +30,20 @@ struct VulkanSourceSubmissionObserver {
     void*                          context{nullptr};
     VulkanSourceSubmissionCallback callback{nullptr};
 };
+
+// Narrow for-testing seam for the real multi-segment completion aggregate.
+// It deliberately exposes only observable callback ordering/counts, not the
+// backend-private aggregate or its synchronization storage.
+struct VulkanMultiSegmentCompletionProbeResult {
+    bool   suffix_retirement_deferred_callbacks{false};
+    bool   prefix_retirement_completed_callbacks{false};
+    bool   repeated_retirement_suppressed{false};
+    uint32 ordinary_callback_count{0};
+    uint32 success_callback_count{0};
+};
+
+[[nodiscard]] RENDER_API VulkanMultiSegmentCompletionProbeResult
+RunVulkanMultiSegmentCompletionProbeForTesting();
 
 // Observer storage is caller-owned and must remain immutable while installed.
 // The callback runs on the Submission owner and must be short, non-blocking,

--- a/source/runtime/render/rhi/vulkan/VulkanSubmissionDiagnostics.h
+++ b/source/runtime/render/rhi/vulkan/VulkanSubmissionDiagnostics.h
@@ -1,7 +1,9 @@
 #pragma once
 
 #include "RenderAPI.h"
+#include "VulkanFault.h"
 #include "rhi/RHICommon.h"
+#include "rhi/RHIThreadOwnership.h"
 
 namespace Moer::Render {
 
@@ -32,5 +34,97 @@ struct VulkanSourceSubmissionObserver {
 TryInstallVulkanSourceSubmissionObserver(const VulkanSourceSubmissionObserver* _observer) noexcept;
 [[nodiscard]] RENDER_API bool
 RemoveVulkanSourceSubmissionObserver(const VulkanSourceSubmissionObserver* _observer) noexcept;
+
+// A direct observation at the VkNativeQueue -> VulkanDevice submit boundary.
+// Unlike the source-packet observer above, this proves which OS thread and RHI
+// role actually invoked the native queue operation.
+struct VulkanNativeSubmissionEvent {
+    EQueueType              queue{EQueueType::Ignore};
+    uint64                  native_queue_handle{0};
+    uint32                  thread_id{0};
+    ERHIThreadRole          thread_role{ERHIThreadRole::Unknown};
+    VulkanOperationResult   outcome{};
+    bool                    empty_submit{false};
+};
+
+using VulkanNativeSubmissionCallback =
+    void (*)(void*, const VulkanNativeSubmissionEvent&) noexcept;
+
+struct VulkanNativeSubmissionObserver {
+    void*                          context{nullptr};
+    VulkanNativeSubmissionCallback callback{nullptr};
+};
+
+// The callback runs immediately after the native submit call returns. The
+// caller owns observer storage and must keep it immutable until removal.
+[[nodiscard]] RENDER_API bool
+TryInstallVulkanNativeSubmissionObserver(
+    const VulkanNativeSubmissionObserver* _observer
+) noexcept;
+[[nodiscard]] RENDER_API bool
+RemoveVulkanNativeSubmissionObserver(
+    const VulkanNativeSubmissionObserver* _observer
+) noexcept;
+
+struct VulkanSubmissionDependencyWaitEvent {
+    EQueueType     queue{EQueueType::Ignore};
+    uint32         thread_id{0};
+    ERHIThreadRole thread_role{ERHIThreadRole::Unknown};
+    uint32         dependency_count{0};
+};
+
+using VulkanSubmissionDependencyWaitCallback =
+    void (*)(void*, const VulkanSubmissionDependencyWaitEvent&) noexcept;
+
+struct VulkanSubmissionDependencyWaitObserver {
+    void*                                  context{nullptr};
+    VulkanSubmissionDependencyWaitCallback callback{nullptr};
+};
+
+// Test/diagnostic seam on the first unsatisfied WaitSubmitted blocking cycle
+// entered by the sole Submission owner. The callback runs while the fence wait
+// mutex is held and therefore must not block or re-enter RHI. Disabled cost is
+// one atomic pointer load for a dependency that actually blocks.
+[[nodiscard]] RENDER_API bool
+TryInstallVulkanSubmissionDependencyWaitObserver(
+    const VulkanSubmissionDependencyWaitObserver* _observer
+) noexcept;
+[[nodiscard]] RENDER_API bool
+RemoveVulkanSubmissionDependencyWaitObserver(
+    const VulkanSubmissionDependencyWaitObserver* _observer
+) noexcept;
+
+struct VulkanBackendSyncWaitEvent {
+    uint32         thread_id{0};
+    ERHIThreadRole thread_role{ERHIThreadRole::Unknown};
+};
+
+using VulkanBackendSyncWaitCallback =
+    void (*)(void*, const VulkanBackendSyncWaitEvent&) noexcept;
+
+struct VulkanBackendSyncWaitObserver {
+    void*                         context{nullptr};
+    VulkanBackendSyncWaitCallback callback{nullptr};
+};
+
+// Fires after Vulkan's backend Sync request is owned by the runtime FIFO and
+// immediately before its caller waits for completion. At this point the upper
+// RHIExecutor has already registered the active Sync call.
+[[nodiscard]] RENDER_API bool
+TryInstallVulkanBackendSyncWaitObserver(
+    const VulkanBackendSyncWaitObserver* _observer
+) noexcept;
+[[nodiscard]] RENDER_API bool
+RemoveVulkanBackendSyncWaitObserver(
+    const VulkanBackendSyncWaitObserver* _observer
+) noexcept;
+
+// Backend-internal notification points shared across Vulkan translation,
+// resource, and submission implementation units.
+void NotifyVulkanSubmissionDependencyWaitBlocked(
+    EQueueType _queue,
+    uint32     _dependency_count
+) noexcept;
+void NotifyVulkanBackendSyncWait() noexcept;
 
 } // namespace Moer::Render

--- a/source/runtime/render/rhi/vulkan/VulkanSubmissionExecutor.cpp
+++ b/source/runtime/render/rhi/vulkan/VulkanSubmissionExecutor.cpp
@@ -4,16 +4,49 @@
 #include "platform/Platform.h"
 #include "rhi/RHI.h"
 #include "rhi/RHIThreadOwnership.h"
+#include "taskgraph/TaskGraph.h"
 #include "VulkanDevice.h"
 #include "VulkanQueue.h"
+#include "VulkanSubmissionDiagnostics.h"
+#include "VulkanTranslateWaveScheduler.h"
 
 #include <algorithm>
+#include <atomic>
 #include <cassert>
+#include <latch>
 #include <limits>
 #include <string>
 
 namespace Moer::Render {
 namespace {
+
+std::atomic<const VulkanSourceSubmissionObserver*> g_source_submission_observer{nullptr};
+
+void NotifySourceSubmitted(
+    uint64     _batch_sequence,
+    uint32     _source_index,
+    EQueueType _queue,
+    uint64     _async_queue_scope
+) noexcept {
+    assert(
+        GetCurrentRHIThreadRole() == ERHIThreadRole::Submission &&
+        "source submission diagnostics must run on the Submission owner"
+    );
+    const VulkanSourceSubmissionObserver* observer =
+        g_source_submission_observer.load(std::memory_order_acquire);
+    if (observer == nullptr) {
+        return;
+    }
+    observer->callback(
+        observer->context,
+        VulkanSourceSubmissionEvent{
+            .batch_sequence    = _batch_sequence,
+            .source_index      = _source_index,
+            .queue             = _queue,
+            .async_queue_scope = _async_queue_scope,
+        }
+    );
+}
 
 GraphEventRef MakeCompletedEvent() {
     GraphEventRef event = GraphEvent::CreateGraphEvent();
@@ -48,6 +81,12 @@ bool IsCopyCommand(Command::EType _type) {
         default:
             return false;
     }
+}
+
+bool IsParallelTranslateCandidate(const RHIBackendSubmissionBatchEntry& _entry) {
+    return (_entry.queue == EQueueType::Graphics || _entry.queue == EQueueType::Compute) &&
+           _entry.submit.translate_execution_class == ERHITranslateExecutionClass::Parallel &&
+           _entry.submit.HasExplicitResourceStateOwnership() && _entry.submit.async_queue_scope != 0;
 }
 
 struct BatchPreflightResult {
@@ -131,6 +170,13 @@ BatchPreflightResult ValidateBatch(const RHIBackendSubmissionBatch& _batch) {
                 !segment_plan.inherit_source_signal_events_and_callbacks ||
                 !segment_plan.inherit_source_runtime_payload) {
                 return RejectPreflight("single-segment plan does not match source", source_index);
+            }
+            for (const SubmissionKey& dependency : segment_plan.dependencies) {
+                if (dependency.op_seq != _batch.sequence || dependency.submit_idx >= expected_segment_begin) {
+                    return RejectPreflight(
+                        "source segment has an unknown or non-preceding dependency", source_index
+                    );
+                }
             }
 
             if (!submit.segments.empty()) {
@@ -220,6 +266,26 @@ void ResolveRejectedPresent(std::optional<RHIPresentRequest>& _present) {
 
 } // namespace
 
+bool TryInstallVulkanSourceSubmissionObserver(const VulkanSourceSubmissionObserver* _observer) noexcept {
+    if (_observer == nullptr || _observer->callback == nullptr) {
+        return false;
+    }
+    const VulkanSourceSubmissionObserver* expected = nullptr;
+    return g_source_submission_observer.compare_exchange_strong(
+        expected, _observer, std::memory_order_release, std::memory_order_relaxed
+    );
+}
+
+bool RemoveVulkanSourceSubmissionObserver(const VulkanSourceSubmissionObserver* _observer) noexcept {
+    if (_observer == nullptr) {
+        return false;
+    }
+    const VulkanSourceSubmissionObserver* expected = _observer;
+    return g_source_submission_observer.compare_exchange_strong(
+        expected, nullptr, std::memory_order_acq_rel, std::memory_order_acquire
+    );
+}
+
 VulkanSubmissionExecutor::VulkanSubmissionExecutor() {
     auto& graphics_queue = static_cast<VkCommandQueue&>(
         RenderDevice::Get().GetCommandQueue(EQueueType::Graphics)
@@ -251,7 +317,8 @@ VulkanSubmissionExecutor::VulkanSubmissionExecutor() {
         executor_thread   = std::jthread([this] { RunExecutor(); });
         LOG_INFO(
             "[RHIExecutor][Vulkan] ownership runtime started "
-            "Executor=1 Translate=1 Submission=1 window=1"
+            "Executor=1 TranslateCoordinator=1 TranslateWorkers=TaskGraph "
+            "Submission=1 batch_window=1"
         );
     } catch (...) {
         graphics_queue.CancelRuntimeDependencyWaits();
@@ -696,6 +763,14 @@ void VulkanSubmissionExecutor::ProcessBatch(
         if (_result == VK_SUCCESS) {
             _result = VK_ERROR_UNKNOWN;
         }
+        // prepare_source may have admitted a later ready native lane before
+        // the stable submission cursor rejects an earlier source. Preserve
+        // gpu_frontier for successfully submitted work, but force the next
+        // batch (even one reusing the same graph scope id) to freeze a fresh
+        // entry frontier and republish its first-lane waits.
+        active_async_queue_scope = 0;
+        async_scope_entry_frontier.fill(std::nullopt);
+        async_scope_seen_queues.fill(false);
         hard_failed         = true;
         hard_failure_result = static_cast<int32>(_result);
         _exception_state.first_unconsumed_source =
@@ -714,6 +789,9 @@ void VulkanSubmissionExecutor::ProcessBatch(
             if (_result == VK_SUCCESS) {
                 _result = VK_ERROR_UNKNOWN;
             }
+            active_async_queue_scope = 0;
+            async_scope_entry_frontier.fill(std::nullopt);
+            async_scope_seen_queues.fill(false);
             _exception_state.first_unconsumed_source =
                 std::min(_begin, _batch.submits.size());
             RejectBatch(
@@ -781,19 +859,12 @@ void VulkanSubmissionExecutor::ProcessBatch(
             }
             gpu_frontier[static_cast<size_t>(queue)] = completion;
         };
-
-    // Keep every source in the request-owned batch until its queue call has
-    // returned. If reorder, descriptor-lease, allocator, or native recording
-    // setup throws, Run's request barrier can still terminalize the current
-    // source callbacks/signals and every later source. Moving all sources into
-    // a temporary expansion array here would lose those obligations on unwind.
-    for (size_t source_index = 0; source_index < _batch.submits.size(); ++source_index) {
+    auto prepare_source = [&](size_t source_index) {
         RHIBackendSubmissionBatchEntry& entry = _batch.submits[source_index];
         const RHISourceSubmitPlan& source_plan =
             _batch.topology.source_plans[source_index];
         if (source_plan.segment_plan_count == 0) {
-            _exception_state.first_unconsumed_source = source_index + 1;
-            continue;
+            return false;
         }
 
         assert(source_plan.segment_plan_count == 1);
@@ -812,12 +883,13 @@ void VulkanSubmissionExecutor::ProcessBatch(
             async_scope_entry_frontier.fill(std::nullopt);
             async_scope_seen_queues.fill(false);
             append_frontier_waits(entry.submit, entry.queue, gpu_frontier);
-        } else {
+            return true;
+        }
+
             if (active_async_queue_scope != async_scope) {
                 // A new graph transaction begins after the complete prior
-                // frontier. Each native queue waits that frozen entry
-                // frontier once, while explicit RDG waits order work inside
-                // the scope.
+            // frontier. Each native queue waits that frozen entry frontier
+            // once, while explicit RDG waits order work inside the scope.
                 active_async_queue_scope    = async_scope;
                 async_scope_entry_frontier  = gpu_frontier;
                 async_scope_seen_queues.fill(false);
@@ -837,13 +909,443 @@ void VulkanSubmissionExecutor::ProcessBatch(
                 );
                 mark_scope_queue_seen(entry.queue);
             }
+        return true;
+    };
+    auto is_parallel_translate_candidate = [&](size_t source_index) {
+        return source_index < _batch.submits.size() &&
+               _batch.topology.source_plans[source_index].segment_plan_count == 1 &&
+               IsParallelTranslateCandidate(_batch.submits[source_index]);
+    };
+    auto process_parallel_translate_group = [&](size_t group_begin, size_t group_end) {
+        using namespace VulkanTranslateWaveDetail;
+
+        assert(group_begin < group_end);
+        assert(group_end <= _batch.submits.size());
+
+        const size_t                group_size = group_end - group_begin;
+        Array<Array<SubmissionKey>> dependency_storage(group_size);
+        Array<TranslateWaveNode>    schedule_nodes{};
+        schedule_nodes.reserve(group_size);
+
+        const size_t first_segment = _batch.topology.source_plans[group_begin].segment_plan_begin;
+        const size_t last_segment  = _batch.topology.source_plans[group_end - 1].segment_plan_begin;
+        for (size_t local_index = 0; local_index < group_size; ++local_index) {
+            const size_t               source_index = group_begin + local_index;
+            const RHISourceSubmitPlan& source_plan  = _batch.topology.source_plans[source_index];
+            assert(source_plan.segment_plan_count == 1);
+            const RHISubmissionSegmentPlan& segment_plan =
+                _batch.topology.segments[source_plan.segment_plan_begin];
+
+            Array<SubmissionKey>& dependencies = dependency_storage[local_index];
+            dependencies.reserve(segment_plan.dependencies.size());
+            for (const SubmissionKey& dependency : segment_plan.dependencies) {
+                // A dependency outside this contiguous explicit-RDG
+                // group belongs to an already terminalized prefix.
+                if (dependency.submit_idx >= first_segment && dependency.submit_idx <= last_segment) {
+                    dependencies.emplace_back(dependency);
         }
+            }
+
+            schedule_nodes.emplace_back(TranslateWaveNode{
+                .key             = segment_plan.key,
+                .native_queue_id = queue_topology.Resolve(_batch.submits[source_index].queue).native_queue_id,
+                .async_translate = true,
+                .dependencies    = dependencies,
+            });
+        }
+
+        TranslateWaveScheduler scheduler{};
+        if (!scheduler.Build(schedule_nodes)) {
+            const size_t error_node = scheduler.GetErrorNodeIndex();
+            LOG_ERROR(
+                "[RHIExecutor][Vulkan][ParallelTranslate] "
+                "schedule rejected batch={} source={} error={} "
+                "dependency={}",
+                _batch.sequence,
+                error_node == TranslateWaveScheduler::NoIndex ? group_begin : group_begin + error_node,
+                static_cast<uint32>(scheduler.GetBuildError()),
+                scheduler.GetErrorDependencyIndex()
+            );
+            reject_remaining(group_begin, VK_ERROR_UNKNOWN, "parallel Translate schedule rejected");
+            return false;
+        }
+
+        struct TranslateGroupSlot {
+            size_t                                                     source_index{0};
+            SubmissionKey                                              key{};
+            VkCommandQueue*                                            queue{nullptr};
+            EQueueType                                                 queue_type{EQueueType::Ignore};
+            uint64                                                     async_queue_scope{0};
+            bool                                                       prepared{false};
+            bool                                                       attempted{false};
+            bool                                                       terminalized{false};
+            std::optional<VkCommandQueue::CurrentVulkanRecordedSubmit> recorded{};
+        };
+
+        Array<TranslateGroupSlot> slots{};
+        slots.reserve(group_size);
+        for (size_t local_index = 0; local_index < group_size; ++local_index) {
+            const size_t                    source_index = group_begin + local_index;
+            const RHISourceSubmitPlan&      source_plan  = _batch.topology.source_plans[source_index];
+            const RHISubmissionSegmentPlan& segment_plan =
+                _batch.topology.segments[source_plan.segment_plan_begin];
+            auto& queue = static_cast<VkCommandQueue&>(
+                RenderDevice::Get().GetCommandQueue(_batch.submits[source_index].queue)
+            );
+            slots.emplace_back(TranslateGroupSlot{
+                .source_index      = source_index,
+                .key               = segment_plan.key,
+                .queue             = &queue,
+                .queue_type        = _batch.submits[source_index].queue,
+                .async_queue_scope = _batch.submits[source_index].submit.async_queue_scope,
+            });
+        }
+
+        // Group-wide terminalization is deliberately declared after the
+        // slots so its destructor runs first. It closes every translated
+        // packet and every untouched raw source before the outer request
+        // exception barrier can reject the later batch suffix.
+        struct TranslateGroupTerminalizer {
+            RHIBackendSubmissionBatch* batch{nullptr};
+            Array<TranslateGroupSlot>* slots{nullptr};
+            size_t                     group_end{0};
+            size_t*                    first_unconsumed_source{nullptr};
+            bool                       armed{true};
+
+            TranslateGroupTerminalizer(
+                RHIBackendSubmissionBatch* _batch,
+                Array<TranslateGroupSlot>* _slots,
+                size_t                     _group_end,
+                size_t*                    _first_unconsumed_source
+            ) noexcept :
+                batch(_batch),
+                slots(_slots),
+                group_end(_group_end),
+                first_unconsumed_source(_first_unconsumed_source) {}
+
+            TranslateGroupTerminalizer(const TranslateGroupTerminalizer&)            = delete;
+            TranslateGroupTerminalizer& operator=(const TranslateGroupTerminalizer&) = delete;
+
+            ~TranslateGroupTerminalizer() noexcept {
+                TerminalizeAll(VK_ERROR_UNKNOWN);
+            }
+
+            void TerminalizeAll(VkResult result) noexcept {
+                if (!armed) {
+                    return;
+                }
+                if (result == VK_SUCCESS) {
+                    result = VK_ERROR_UNKNOWN;
+                }
+                for (TranslateGroupSlot& slot : *slots) {
+                    if (slot.terminalized) {
+                        continue;
+                    }
+                    RHIBackendSubmissionBatchEntry& entry = batch->submits[slot.source_index];
+                    if (slot.recorded) {
+                        slot.queue->RejectRecordedForRuntime(std::move(*slot.recorded), result);
+                    } else if (!slot.attempted) {
+                        slot.queue->RejectForRuntime(std::move(entry.submit), result);
+                    }
+                    // A null result from an attempted Translate already
+                    // owns a rejected Completion retirement.
+                    slot.terminalized = true;
+                }
+                if (first_unconsumed_source != nullptr) {
+                    *first_unconsumed_source = std::max(*first_unconsumed_source, group_end);
+                }
+                armed = false;
+            }
+
+            void Disarm() noexcept {
+                if (first_unconsumed_source != nullptr) {
+                    *first_unconsumed_source = std::max(*first_unconsumed_source, group_end);
+                }
+                armed = false;
+            }
+        } terminalizer{&_batch, &slots, group_end, &_exception_state.first_unconsumed_source};
+
+        auto slot_for_key = [&](const SubmissionKey& key) -> TranslateGroupSlot& {
+            assert(key.op_seq == _batch.sequence);
+            assert(key.submit_idx >= first_segment);
+            const size_t local_index = key.submit_idx - first_segment;
+            assert(local_index < slots.size());
+            assert(slots[local_index].key == key);
+            return slots[local_index];
+        };
+        auto fail_group = [&](size_t           failure_source,
+                              VkResult         failure_result,
+                              bool             recoverable_failure,
+                              std::string_view failure_reason) {
+            if (failure_result == VK_SUCCESS) {
+                failure_result = VK_ERROR_UNKNOWN;
+            }
+            scheduler.Cancel();
+            terminalizer.TerminalizeAll(failure_result);
+            LOG_ERROR(
+                "[RHIExecutor][Vulkan][ParallelTranslate] "
+                "batch={} failure_source={} reason={} result={} "
+                "recoverable={}",
+                _batch.sequence,
+                failure_source,
+                failure_reason,
+                static_cast<int32>(failure_result),
+                recoverable_failure
+            );
+            if (recoverable_failure) {
+                reject_remaining_recoverable(group_end, failure_result, failure_reason);
+            } else {
+                reject_remaining(group_end, failure_result, failure_reason);
+            }
+            return false;
+        };
+
+        size_t next_release_local = 0;
+        for (;;) {
+            std::vector<SubmissionKey> wave = scheduler.NextWave();
+            if (wave.empty()) {
+                if (scheduler.IsComplete()) {
+                    assert(next_release_local == slots.size());
+                    terminalizer.Disarm();
+                    return true;
+                }
+                return fail_group(
+                    group_begin + next_release_local,
+                    VK_ERROR_UNKNOWN,
+                    false,
+                    "parallel Translate schedule stalled"
+                );
+            }
+
+            Array<TranslateGroupSlot*> wave_slots{};
+            wave_slots.reserve(wave.size());
+            for (const SubmissionKey& key : wave) {
+                TranslateGroupSlot& slot = slot_for_key(key);
+                assert(!slot.prepared);
+                if (!prepare_source(slot.source_index)) {
+                    return fail_group(
+                        slot.source_index,
+                        VK_ERROR_UNKNOWN,
+                        false,
+                        "parallel Translate source lost its segment"
+                    );
+                }
+                slot.prepared = true;
+                wave_slots.emplace_back(&slot);
+            }
+
+            bool dispatch_failed = false;
+            if (wave_slots.size() > 1 && TaskGraph::IsInitialized()) {
+                // LambdaTask::Dispatch can allocate before it queues a
+                // task. Once it reaches TaskGraph::QueueTask, the engine's
+                // lock-free path does not throw. A latch therefore gives
+                // us a non-allocating, noexcept join: on a dispatch
+                // exception, count down the current/unstarted suffix and
+                // still wait for every already-queued worker.
+                std::latch completed(static_cast<std::ptrdiff_t>(wave_slots.size()));
+                size_t     dispatched_count = 0;
+                for (; dispatched_count < wave_slots.size(); ++dispatched_count) {
+                    TranslateGroupSlot* slot = wave_slots[dispatched_count];
+                    try {
+                        RHIBackendSubmissionBatchEntry* entry = &_batch.submits[slot->source_index];
+                        (void)LambdaTask::Dispatch(
+                            [slot, entry, &completed] {
+                                RHIThreadRoleScope translate_worker(ERHIThreadRole::Translate);
+                                slot->attempted = true;
+                                slot->recorded  = slot->queue->TranslateForRuntime(std::move(entry->submit));
+                                completed.count_down();
+                            },
+                            EThread::AnyThread_NormalPri
+                        );
+                    } catch (...) {
+                        dispatch_failed = true;
+                        completed.count_down(static_cast<std::ptrdiff_t>(wave_slots.size() - dispatched_count)
+                        );
+                        break;
+                    }
+                }
+                completed.wait();
+            } else {
+                for (TranslateGroupSlot* slot : wave_slots) {
+                    RHIBackendSubmissionBatchEntry& entry = _batch.submits[slot->source_index];
+                    slot->attempted                       = true;
+                    slot->recorded = slot->queue->TranslateForRuntime(std::move(entry.submit));
+                }
+            }
+
+            std::optional<size_t> translation_failure_source{};
+            VkResult              translation_failure_result = VK_ERROR_UNKNOWN;
+            std::string_view      translation_failure_reason{"parallel Translate task dispatch failure"};
+            for (TranslateGroupSlot* slot : wave_slots) {
+                if (!slot->attempted) {
+                    if (!translation_failure_source) {
+                        translation_failure_source = slot->source_index;
+                        translation_failure_reason = "parallel Translate task dispatch failure";
+                    }
+                    continue;
+                }
+
+                used_queues[static_cast<size_t>(_batch.submits[slot->source_index].queue)] = true;
+                if (!scheduler.MarkTranslated(slot->key) && !translation_failure_source) {
+                    translation_failure_source = slot->source_index;
+                    translation_failure_reason = "parallel Translate scheduler state failure";
+                }
+                if (!slot->recorded) {
+                    // TranslateForRuntime already committed the rejected
+                    // Completion marker for this source.
+                    slot->terminalized = true;
+                    if (!translation_failure_source) {
+                        translation_failure_source = slot->source_index;
+                        translation_failure_result = slot->queue->vk_device.IsFaulted() ?
+                                                         slot->queue->vk_device.GetFirstFaultResult() :
+                                                         VK_ERROR_UNKNOWN;
+                        translation_failure_reason = "parallel command translation failure";
+                    }
+                }
+            }
+
+            if (dispatch_failed || translation_failure_source) {
+                return fail_group(
+                    translation_failure_source.value_or(group_begin + next_release_local),
+                    translation_failure_result,
+                    false,
+                    translation_failure_reason
+                );
+            }
+
+            if (!logged_parallel_translate_wave && wave_slots.size() > 1) {
+                logged_parallel_translate_wave = true;
+                LOG_INFO(
+                    "[RHIExecutor][Vulkan][ParallelTranslate] "
+                    "mode=ready-native-lanes workers=TaskGraph "
+                    "native_lanes={} ordered_submit_owner=serial "
+                    "batch_window=1",
+                    wave_slots.size()
+                );
+            }
+
+            // Translation readiness is a native-lane ready set, while
+            // submission remains a distinct stable cursor. A later
+            // independent lane may already hold a recorded packet here;
+            // it is released only after every earlier source is ready.
+            while (next_release_local < slots.size()) {
+                TranslateGroupSlot& slot  = slots[next_release_local];
+                const auto          state = scheduler.GetState(slot.key);
+                if (!state || *state != ETranslateWaveNodeState::Translated) {
+                    break;
+                }
+                assert(slot.recorded);
+                assert(!slot.terminalized);
+
+                RHIBackendSubmissionBatchEntry& entry = _batch.submits[slot.source_index];
+                VkCommandQueue&                 queue = *slot.queue;
+
+                VulkanRuntimeSubmissionResult submit_result{};
+                try {
+                    submit_result =
+                        ExecuteOnSubmissionThread([&queue,
+                                                   packet         = &*slot.recorded,
+                                                   batch_sequence = _batch.sequence,
+                                                   source_index   = static_cast<uint32>(slot.source_index),
+                                                   queue_type     = slot.queue_type,
+                                                   async_scope    = slot.async_queue_scope]() mutable {
+                            VulkanRuntimeSubmissionResult result =
+                                queue.SubmitRecordedForRuntime(std::move(*packet));
+                            if (result.WasSubmitted()) {
+                                NotifySourceSubmitted(batch_sequence, source_index, queue_type, async_scope);
+                            }
+                            return result;
+                        });
+                } catch (...) {
+                    ReportRequestFailure(
+                        ERequestKind::Submit,
+                        VulkanSubmissionDetail::EWorkerRequestFailurePhase::Process,
+                        std::current_exception()
+                    );
+                    queue.RejectRecordedForRuntime(std::move(*slot.recorded), VK_ERROR_UNKNOWN);
+                    submit_result.outcome = {EVulkanOperationStatus::Rejected, VK_ERROR_UNKNOWN};
+                }
+                slot.terminalized                        = true;
+                _exception_state.first_unconsumed_source = slot.source_index + 1;
+                if (!scheduler.MarkReleased(slot.key)) {
+                    return fail_group(
+                        slot.source_index,
+                        VK_ERROR_UNKNOWN,
+                        false,
+                        "parallel Translate scheduler release failure"
+                    );
+                }
+                ++next_release_local;
+
+                if (submit_result.WasSubmitted()) {
+                    assert(submit_result.completion.has_value());
+                    update_frontier(entry.queue, *submit_result.completion, false);
+                    continue;
+                }
+
+                const VkResult         failure_result      = submit_result.outcome.result == VK_SUCCESS ?
+                                                                 VK_ERROR_UNKNOWN :
+                                                                 submit_result.outcome.result;
+                const bool             recoverable_failure = submit_result.IsRecoverableRejection();
+                const std::string_view failure_reason =
+                    recoverable_failure ? "parallel command submission dependency rejection" :
+                                          "parallel command submission hard failure";
+                return fail_group(slot.source_index, failure_result, recoverable_failure, failure_reason);
+            }
+        }
+    };
+
+    // Keep every source in the request-owned batch until its queue call has
+    // returned. If reorder, descriptor-lease, allocator, or native recording
+    // setup throws, Run's request barrier can still terminalize the current
+    // source callbacks/signals and every later source. Moving all sources into
+    // a temporary expansion array here would lose those obligations on unwind.
+    for (size_t source_index = 0; source_index < _batch.submits.size(); ++source_index) {
+        if (is_parallel_translate_candidate(source_index)) {
+            const uint64 async_scope = _batch.submits[source_index].submit.async_queue_scope;
+            size_t       group_end   = source_index + 1;
+            while (group_end < _batch.submits.size() && is_parallel_translate_candidate(group_end) &&
+                   _batch.submits[group_end].submit.async_queue_scope == async_scope) {
+                ++group_end;
+            }
+            if (group_end - source_index > 1) {
+                if (!process_parallel_translate_group(source_index, group_end)) {
+                    return;
+                }
+                source_index = group_end - 1;
+                continue;
+            }
+        }
+
+        RHIBackendSubmissionBatchEntry& entry = _batch.submits[source_index];
+        if (!prepare_source(source_index)) {
+            _exception_state.first_unconsumed_source = source_index + 1;
+            continue;
+        }
+
+        const uint64 async_scope = entry.submit.async_queue_scope;
         if (entry.queue == EQueueType::Copy) {
             auto& copy_queue = static_cast<VkCopyQueue&>(RenderDevice::Get().GetCopyQueue());
             const VulkanRuntimeSubmissionResult submit_result =
                 ExecuteOnSubmissionThread(
-                    [&copy_queue, submit = &entry.submit]() mutable {
-                        return copy_queue.ExecuteForRuntime(std::move(*submit));
+                    [
+                        &copy_queue,
+                        submit = &entry.submit,
+                        batch_sequence = _batch.sequence,
+                        source_index = static_cast<uint32>(source_index),
+                        async_scope
+                    ]() mutable {
+                        VulkanRuntimeSubmissionResult result =
+                            copy_queue.ExecuteForRuntime(std::move(*submit));
+                        if (result.WasSubmitted()) {
+                            NotifySourceSubmitted(
+                                batch_sequence,
+                                source_index,
+                                EQueueType::Copy,
+                                async_scope
+                            );
+                        }
+                        return result;
                     }
                 );
             // ExecuteForRuntime has now either submitted or terminalized this
@@ -918,8 +1420,25 @@ void VulkanSubmissionExecutor::ProcessBatch(
             VulkanRuntimeSubmissionResult submit_result{};
             try {
                 submit_result = ExecuteOnSubmissionThread(
-                    [&queue, packet = &*recorded]() mutable {
-                        return queue.SubmitRecordedForRuntime(std::move(*packet));
+                    [
+                        &queue,
+                        packet = &*recorded,
+                        batch_sequence = _batch.sequence,
+                        source_index = static_cast<uint32>(source_index),
+                        queue_type = entry.queue,
+                        async_scope
+                    ]() mutable {
+                        VulkanRuntimeSubmissionResult result =
+                            queue.SubmitRecordedForRuntime(std::move(*packet));
+                        if (result.WasSubmitted()) {
+                            NotifySourceSubmitted(
+                                batch_sequence,
+                                source_index,
+                                queue_type,
+                                async_scope
+                            );
+                        }
+                        return result;
                     }
                 );
             } catch (...) {

--- a/source/runtime/render/rhi/vulkan/VulkanSubmissionExecutor.cpp
+++ b/source/runtime/render/rhi/vulkan/VulkanSubmissionExecutor.cpp
@@ -297,6 +297,7 @@ VulkanSubmissionExecutor::VulkanSubmissionExecutor() {
         static_cast<VkCopyQueue&>(RenderDevice::Get().GetCopyQueue());
     bool graphics_claimed = false;
     bool compute_claimed  = false;
+    bool copy_claimed     = false;
     try {
         graphics_claimed = graphics_queue.ClaimRuntimeOwnership();
         if (!graphics_claimed) {
@@ -310,7 +311,12 @@ VulkanSubmissionExecutor::VulkanSubmissionExecutor() {
                 "Vulkan Compute queue ownership conflicts with legacy execution"
             );
         }
-        copy_queue.EnableRuntimeDependencyWaits();
+        copy_claimed = copy_queue.ClaimRuntimeOwnership();
+        if (!copy_claimed) {
+            throw std::runtime_error(
+                "Vulkan Copy queue ownership conflicts with legacy execution"
+            );
+        }
         claims_owned = true;
 
         submission_thread = std::jthread([this] { RunSubmission(); });
@@ -336,6 +342,9 @@ VulkanSubmissionExecutor::VulkanSubmissionExecutor() {
         if (submission_thread.joinable()) {
             StopSubmissionThread();
         }
+        if (copy_claimed) {
+            copy_queue.ReleaseRuntimeOwnership();
+        }
         if (compute_claimed) {
             compute_queue.ReleaseRuntimeOwnership();
         }
@@ -356,6 +365,9 @@ VulkanSubmissionExecutor::~VulkanSubmissionExecutor() {
         auto& compute_queue = static_cast<VkCommandQueue&>(
             RenderDevice::Get().GetCommandQueue(EQueueType::Compute)
         );
+        auto& copy_queue =
+            static_cast<VkCopyQueue&>(RenderDevice::Get().GetCopyQueue());
+        copy_queue.ReleaseRuntimeOwnership();
         compute_queue.ReleaseRuntimeOwnership();
         graphics_queue.ReleaseRuntimeOwnership();
         claims_owned = false;
@@ -415,6 +427,7 @@ GraphEventRef VulkanSubmissionExecutor::Sync(ERHISyncDepth _depth) {
         });
     }
     cv.notify_one();
+    NotifyVulkanBackendSyncWait();
     completion->Wait();
     return MakeCompletedEvent();
 }
@@ -1326,17 +1339,43 @@ void VulkanSubmissionExecutor::ProcessBatch(
         const uint64 async_scope = entry.submit.async_queue_scope;
         if (entry.queue == EQueueType::Copy) {
             auto& copy_queue = static_cast<VkCopyQueue&>(RenderDevice::Get().GetCopyQueue());
-            const VulkanRuntimeSubmissionResult submit_result =
-                ExecuteOnSubmissionThread(
+            std::optional<VkCopyQueue::CurrentVulkanCopyRecordedSubmit>
+                recorded =
+                    copy_queue.TranslateForRuntime(std::move(entry.submit));
+            used_queues[static_cast<size_t>(EQueueType::Copy)] = true;
+            if (!recorded) {
+                _exception_state.first_unconsumed_source =
+                    source_index + 1;
+                const VkResult result = copy_queue.device.IsFaulted() ?
+                                            copy_queue.device.GetFirstFaultResult() :
+                                            VK_ERROR_UNKNOWN;
+                LOG_ERROR(
+                    "[RHIExecutor][Vulkan] batch={} Copy translation failed result={}",
+                    _batch.sequence,
+                    static_cast<int32>(result)
+                );
+                reject_remaining(
+                    source_index + 1,
+                    result,
+                    "Copy translation failure"
+                );
+                return;
+            }
+
+            VulkanRuntimeSubmissionResult submit_result{};
+            try {
+                submit_result = ExecuteOnSubmissionThread(
                     [
                         &copy_queue,
-                        submit = &entry.submit,
+                        packet = &*recorded,
                         batch_sequence = _batch.sequence,
                         source_index = static_cast<uint32>(source_index),
                         async_scope
                     ]() mutable {
                         VulkanRuntimeSubmissionResult result =
-                            copy_queue.ExecuteForRuntime(std::move(*submit));
+                            copy_queue.SubmitRecordedForRuntime(
+                                std::move(*packet)
+                            );
                         if (result.WasSubmitted()) {
                             NotifySourceSubmitted(
                                 batch_sequence,
@@ -1348,7 +1387,21 @@ void VulkanSubmissionExecutor::ProcessBatch(
                         return result;
                     }
                 );
-            // ExecuteForRuntime has now either submitted or terminalized this
+            } catch (...) {
+                ReportRequestFailure(
+                    ERequestKind::Submit,
+                    VulkanSubmissionDetail::EWorkerRequestFailurePhase::Process,
+                    std::current_exception()
+                );
+                copy_queue.RejectRecordedForRuntime(
+                    std::move(*recorded), VK_ERROR_UNKNOWN
+                );
+                submit_result.outcome = {
+                    EVulkanOperationStatus::Rejected,
+                    VK_ERROR_UNKNOWN
+                };
+            }
+            // SubmitRecordedForRuntime has now either submitted or terminalized this
             // source. Never reject it again if later bookkeeping/logging throws.
             _exception_state.first_unconsumed_source = source_index + 1;
             if (submit_result.WasSubmitted()) {
@@ -1361,13 +1414,11 @@ void VulkanSubmissionExecutor::ProcessBatch(
                     *submit_result.completion,
                     async_scope == 0
                 );
-                used_queues[static_cast<size_t>(EQueueType::Copy)] = true;
             } else if (submit_result.IsRecoverableRejection()) {
                 // A failed prerequisite did not reach vkQueueSubmit. Drain the
                 // current source on Completion, reject the rest of this
                 // topology batch, and keep the runtime available for a later
                 // independent batch.
-                used_queues[static_cast<size_t>(EQueueType::Copy)] = true;
                 reject_remaining_recoverable(
                     source_index + 1,
                     submit_result.outcome.result,
@@ -1384,7 +1435,6 @@ void VulkanSubmissionExecutor::ProcessBatch(
                 // A failed native Copy submit still publishes a CPU retirement
                 // marker. ProcessSync always enters Copy Sync, whose independent
                 // retirement serial drains it without reading Copy-owner state.
-                used_queues[static_cast<size_t>(EQueueType::Copy)] = true;
                 reject_remaining(
                     source_index + 1,
                     submit_result.outcome.result,

--- a/source/runtime/render/rhi/vulkan/VulkanSubmissionExecutor.cpp
+++ b/source/runtime/render/rhi/vulkan/VulkanSubmissionExecutor.cpp
@@ -15,6 +15,9 @@
 #include <cassert>
 #include <latch>
 #include <limits>
+#include <memory>
+#include <mutex>
+#include <stdexcept>
 #include <string>
 
 namespace Moer::Render {
@@ -25,8 +28,12 @@ std::atomic<const VulkanSourceSubmissionObserver*> g_source_submission_observer{
 void NotifySourceSubmitted(
     uint64     _batch_sequence,
     uint32     _source_index,
+    uint32     _original_source_index,
+    uint32     _source_segment_index,
+    uint32     _source_segment_count,
     EQueueType _queue,
-    uint64     _async_queue_scope
+    uint64     _async_queue_scope,
+    bool       _cross_native_predecessor_wait
 ) noexcept {
     assert(
         GetCurrentRHIThreadRole() == ERHIThreadRole::Submission &&
@@ -42,8 +49,12 @@ void NotifySourceSubmitted(
         VulkanSourceSubmissionEvent{
             .batch_sequence    = _batch_sequence,
             .source_index      = _source_index,
+            .original_source_index         = _original_source_index,
+            .source_segment_index          = _source_segment_index,
+            .source_segment_count          = _source_segment_count,
             .queue             = _queue,
             .async_queue_scope = _async_queue_scope,
+            .cross_native_predecessor_wait = _cross_native_predecessor_wait,
         }
     );
 }
@@ -89,6 +100,126 @@ bool IsParallelTranslateCandidate(const RHIBackendSubmissionBatchEntry& _entry) 
            _entry.submit.HasExplicitResourceStateOwnership() && _entry.submit.async_queue_scope != 0;
 }
 
+void InvokeSourceCallbacksNoexcept(
+    Array<std::function<void()>>& _callbacks,
+    std::string_view              _context
+) noexcept {
+    for (std::function<void()>& callback : _callbacks) {
+        if (!callback) {
+            continue;
+        }
+        try {
+            callback();
+        } catch (const std::exception& error) {
+            try {
+                LOG_ERROR("{} callback threw: {}", _context, error.what());
+            } catch (...) {
+            }
+        } catch (...) {
+            try {
+                LOG_ERROR("{} callback threw", _context);
+            } catch (...) {
+            }
+        }
+    }
+    _callbacks.clear();
+}
+
+class VulkanMultiSegmentCompletionState final {
+public:
+    explicit VulkanMultiSegmentCompletionState(Array<FenceRef>&& _segment_outcomes) :
+        segment_outcomes(std::move(_segment_outcomes)),
+        retired(segment_outcomes.size(), uint8{0}),
+        remaining(segment_outcomes.size()) {}
+
+    void AdoptSourceCallbacks(
+        Array<std::function<void()>>&& _callbacks,
+        Array<std::function<void()>>&& _success_callbacks
+    ) noexcept {
+        callbacks         = std::move(_callbacks);
+        success_callbacks = std::move(_success_callbacks);
+    }
+
+    const FenceRef& SegmentOutcome(size_t _segment_index) const noexcept {
+        return segment_outcomes[_segment_index];
+    }
+
+    void Retire(size_t _segment_index) noexcept {
+        bool segment_success = false;
+        if (_segment_index < segment_outcomes.size()) {
+            auto* outcome   = ResourceCast(segment_outcomes[_segment_index].Get());
+            segment_success = outcome != nullptr && outcome->GetValue() >= 1 && !outcome->IsRejected(1) &&
+                              !outcome->IsFailed();
+        }
+
+        Array<std::function<void()>> final_callbacks{};
+        Array<std::function<void()>> final_success_callbacks{};
+        bool                         invoke_success = false;
+        {
+            std::lock_guard lock(mutex);
+            if (_segment_index >= retired.size() || retired[_segment_index] != 0) {
+                return;
+            }
+            retired[_segment_index] = 1;
+            all_success             = all_success && segment_success;
+            assert(remaining != 0);
+            --remaining;
+            if (remaining != 0) {
+                return;
+            }
+            invoke_success          = all_success;
+            final_callbacks         = std::move(callbacks);
+            final_success_callbacks = std::move(success_callbacks);
+        }
+
+        InvokeSourceCallbacksNoexcept(final_callbacks, "[RHIExecutor][Vulkan][MultiSegment] ordinary");
+        if (invoke_success) {
+            InvokeSourceCallbacksNoexcept(
+                final_success_callbacks, "[RHIExecutor][Vulkan][MultiSegment] success"
+            );
+        }
+    }
+
+private:
+    Array<FenceRef>              segment_outcomes{};
+    Array<uint8>                 retired{};
+    size_t                       remaining{0};
+    bool                         all_success{true};
+    std::mutex                   mutex{};
+    Array<std::function<void()>> callbacks{};
+    Array<std::function<void()>> success_callbacks{};
+};
+
+struct VulkanExecutableSourceMetadata {
+    uint32 original_source_index{0};
+    uint32 source_segment_index{0};
+    uint32 source_segment_count{1};
+    bool   cross_native_predecessor_wait{false};
+};
+
+struct VulkanSegmentMaterializationResult {
+    bool                                  changed{false};
+    size_t                                original_source_count{0};
+    size_t                                cross_native_wait_count{0};
+    Array<VulkanExecutableSourceMetadata> sources{};
+};
+
+struct VulkanOriginalSourceMaterialization {
+    bool                                               multi_segment{false};
+    size_t                                             executable_begin{0};
+    size_t                                             executable_count{1};
+    std::shared_ptr<VulkanMultiSegmentCompletionState> completion{};
+};
+
+CmdSubmit MakeEmptySubmit() {
+    return CmdSubmit(
+        Array<UniquePtr<Command>>{},
+        Array<std::function<void()>>{},
+        Array<std::function<void()>>{},
+        TCachedArgArray{}
+    );
+}
+
 struct BatchPreflightResult {
     bool             valid{true};
     std::string_view reason{"none"};
@@ -117,8 +248,7 @@ BatchPreflightResult ValidateBatch(const RHIBackendSubmissionBatch& _batch) {
     if (topology.source_plans.size() != _batch.submits.size()) {
         return RejectPreflight("source/topology count mismatch");
     }
-    if (_batch.present &&
-        (!_batch.present->swapchain || _batch.present->source.texture == nullptr)) {
+    if (_batch.present && (!_batch.present->swapchain || _batch.present->source.texture == nullptr)) {
         return RejectPreflight("invalid Present request");
     }
 
@@ -133,8 +263,7 @@ BatchPreflightResult ValidateBatch(const RHIBackendSubmissionBatch& _batch) {
             return RejectPreflight("invalid source queue", source_index);
         }
         if (source_plan.source_key.op_seq != _batch.sequence ||
-            source_plan.source_key.submit_idx != source_index ||
-            source_plan.root_queue != entry.queue ||
+            source_plan.source_key.submit_idx != source_index || source_plan.root_queue != entry.queue ||
             source_plan.command_count != submit.cmds.size() ||
             source_plan.execution_class != submit.translate_execution_class ||
             source_plan.has_side_effects != submit_has_work) {
@@ -143,66 +272,93 @@ BatchPreflightResult ValidateBatch(const RHIBackendSubmissionBatch& _batch) {
         if (source_plan.segment_plan_begin != expected_segment_begin) {
             return RejectPreflight("non-contiguous source plans", source_index);
         }
-        if (source_plan.segment_plan_count > 1) {
-            return RejectPreflight("multi-segment source is not supported", source_index);
-        }
 
-        const size_t expected_segment_count = submit_has_work ? 1u : 0u;
+        const RHISubmitSegment synthesized_segment{
+            .queue = source_plan.root_queue,
+            .begin = 0,
+            .end   = submit.cmds.size(),
+        };
+        const std::span<const RHISubmitSegment> source_segments =
+            submit.segments.empty() ? std::span<const RHISubmitSegment>(&synthesized_segment, 1) :
+                                      std::span<const RHISubmitSegment>(submit.segments);
+        const size_t expected_segment_count = submit_has_work ? source_segments.size() : 0;
         if (source_plan.segment_plan_count != expected_segment_count) {
             return RejectPreflight("source retention does not match payload", source_index);
         }
 
-        if (source_plan.segment_plan_count == 1) {
-            if (expected_segment_begin >= topology.segments.size()) {
+        const bool multi_segment = expected_segment_count > 1;
+        if (multi_segment && (!submit.HasExplicitResourceStateOwnership() || submit.async_queue_scope == 0)) {
+            return RejectPreflight(
+                "multi-segment source requires explicit state and async scope", source_index
+            );
+        }
+        if (multi_segment && (submit.b_sync || submit.b_delete_resources ||
+                              submit.ProfilingPhase() != ERHIProfilingPhase::Disabled)) {
+            return RejectPreflight("multi-segment source contains unsupported control payload", source_index);
+        }
+
+        std::optional<size_t> runtime_payload_segment{};
+        for (size_t segment_index = expected_segment_count; segment_index > 0; --segment_index) {
+            if (source_segments[segment_index - 1].queue != EQueueType::Copy) {
+                runtime_payload_segment = segment_index - 1;
+                break;
+            }
+        }
+        if (!runtime_payload_segment &&
+            (!submit.cached_args.empty() || !submit.debug_label.empty() || submit.b_sync ||
+             submit.b_delete_resources || submit.ProfilingPhase() != ERHIProfilingPhase::Disabled)) {
+            return RejectPreflight("Copy-only source contains unsupported runtime payload", source_index);
+        }
+
+        for (size_t segment_index = 0; segment_index < expected_segment_count; ++segment_index) {
+            const size_t flat_segment_index = expected_segment_begin + segment_index;
+            if (flat_segment_index >= topology.segments.size()) {
                 return RejectPreflight("source segment is out of range", source_index);
             }
-            const RHISubmissionSegmentPlan& segment_plan =
-                topology.segments[expected_segment_begin];
+            const RHISubmitSegment&         descriptor   = source_segments[segment_index];
+            const RHISubmissionSegmentPlan& segment_plan = topology.segments[flat_segment_index];
             if (segment_plan.key.op_seq != _batch.sequence ||
-                segment_plan.key.submit_idx != expected_segment_begin ||
+                segment_plan.key.submit_idx != flat_segment_index ||
                 segment_plan.source_key != source_plan.source_key ||
-                segment_plan.source_segment_index != 0 ||
-                segment_plan.segment.queue != source_plan.root_queue ||
-                segment_plan.segment.begin != 0 ||
-                segment_plan.segment.end != submit.cmds.size() ||
+                segment_plan.source_segment_index != segment_index ||
+                segment_plan.segment.queue != descriptor.queue ||
+                segment_plan.segment.begin != descriptor.begin ||
+                segment_plan.segment.end != descriptor.end ||
                 segment_plan.execution_class != source_plan.execution_class ||
-                !segment_plan.inherit_source_wait_events ||
-                !segment_plan.inherit_source_signal_events_and_callbacks ||
-                !segment_plan.inherit_source_runtime_payload) {
-                return RejectPreflight("single-segment plan does not match source", source_index);
+                segment_plan.inherit_source_wait_events != (segment_index == 0) ||
+                segment_plan.inherit_source_signal_events_and_callbacks !=
+                    (segment_index + 1 == expected_segment_count) ||
+                segment_plan.inherit_source_runtime_payload !=
+                    (runtime_payload_segment.has_value() && *runtime_payload_segment == segment_index)) {
+                return RejectPreflight("segment plan does not match source", source_index);
             }
             for (const SubmissionKey& dependency : segment_plan.dependencies) {
-                if (dependency.op_seq != _batch.sequence || dependency.submit_idx >= expected_segment_begin) {
+                if (dependency.op_seq != _batch.sequence || dependency.submit_idx >= flat_segment_index) {
                     return RejectPreflight(
                         "source segment has an unknown or non-preceding dependency", source_index
                     );
                 }
             }
 
-            if (!submit.segments.empty()) {
-                if (submit.segments.size() != 1 ||
-                    submit.segments.front().queue != source_plan.root_queue ||
-                    submit.segments.front().begin != 0 ||
-                    submit.segments.front().end != submit.cmds.size()) {
+            if (expected_segment_count == 1 &&
+                (descriptor.queue != source_plan.root_queue || descriptor.begin != 0 ||
+                 descriptor.end != submit.cmds.size())) {
+                return RejectPreflight("single segment does not match root queue", source_index);
+            }
+
+            for (size_t command_index = descriptor.begin; command_index < descriptor.end; ++command_index) {
+                const UniquePtr<Command>& command = submit.cmds[command_index];
+                if (!command) {
+                    return RejectPreflight("null command", source_index, command_index);
+                }
+                if (command->Type() >= Command::EType::Count) {
+                    return RejectPreflight("invalid command type", source_index, command_index);
+                }
+                if (descriptor.queue == EQueueType::Copy && !IsCopyCommand(command->Type())) {
                     return RejectPreflight(
-                        "source segment does not match root queue", source_index
+                        "unsupported command on Copy segment", source_index, command_index
                     );
                 }
-            }
-        }
-
-        for (size_t command_index = 0; command_index < submit.cmds.size(); ++command_index) {
-            const UniquePtr<Command>& command = submit.cmds[command_index];
-            if (!command) {
-                return RejectPreflight("null command", source_index, command_index);
-            }
-            if (command->Type() >= Command::EType::Count) {
-                return RejectPreflight("invalid command type", source_index, command_index);
-            }
-            if (entry.queue == EQueueType::Copy && !IsCopyCommand(command->Type())) {
-                return RejectPreflight(
-                    "unsupported command on Copy queue", source_index, command_index
-                );
             }
         }
 
@@ -217,7 +373,7 @@ BatchPreflightResult ValidateBatch(const RHIBackendSubmissionBatch& _batch) {
             }
         }
 
-        if (entry.queue == EQueueType::Copy) {
+        if (expected_segment_count == 1 && source_segments.front().queue == EQueueType::Copy) {
             if (!submit.cached_args.empty()) {
                 return RejectPreflight("Copy submit contains cached arguments", source_index);
             }
@@ -236,6 +392,231 @@ BatchPreflightResult ValidateBatch(const RHIBackendSubmissionBatch& _batch) {
         return RejectPreflight("unclaimed topology segments");
     }
     return {};
+}
+
+VulkanSegmentMaterializationResult
+MaterializeMultiSegmentBatch(RHIBackendSubmissionBatch& _batch, const RHIQueueTopology& _queue_topology) {
+    VulkanSegmentMaterializationResult result{};
+    result.original_source_count = _batch.submits.size();
+
+    size_t executable_source_count = 0;
+    for (const RHISourceSubmitPlan& source_plan : _batch.topology.source_plans) {
+        result.changed              = result.changed || source_plan.segment_plan_count > 1;
+        const size_t retained_count = source_plan.segment_plan_count > 1 ? source_plan.segment_plan_count : 1;
+        if (retained_count > std::numeric_limits<size_t>::max() - executable_source_count) {
+            throw std::runtime_error("multi-segment materialization source count overflow");
+        }
+        executable_source_count += retained_count;
+    }
+
+    if (executable_source_count > std::numeric_limits<uint32>::max()) {
+        throw std::runtime_error("multi-segment materialization exceeds SubmissionKey capacity");
+    }
+
+    result.sources.reserve(executable_source_count);
+    if (!result.changed) {
+        for (size_t source_index = 0; source_index < _batch.submits.size(); ++source_index) {
+            result.sources.emplace_back(VulkanExecutableSourceMetadata{
+                .original_source_index = static_cast<uint32>(source_index),
+                .source_segment_index  = 0,
+                .source_segment_count  = 1,
+            });
+        }
+        return result;
+    }
+
+    Array<VulkanOriginalSourceMaterialization> source_materializations(_batch.submits.size());
+    Array<RHIBackendSubmissionBatchEntry>      executable_sources{};
+    executable_sources.reserve(executable_source_count);
+
+    for (size_t source_index = 0; source_index < _batch.submits.size(); ++source_index) {
+        RHIBackendSubmissionBatchEntry& source_entry  = _batch.submits[source_index];
+        CmdSubmit&                      source_submit = source_entry.submit;
+        const RHISourceSubmitPlan&      source_plan   = _batch.topology.source_plans[source_index];
+
+        VulkanOriginalSourceMaterialization& materialization = source_materializations[source_index];
+        materialization.multi_segment                        = source_plan.segment_plan_count > 1;
+        materialization.executable_begin                     = executable_sources.size();
+        materialization.executable_count = materialization.multi_segment ? source_plan.segment_plan_count : 1;
+
+        if (!materialization.multi_segment) {
+            executable_sources.emplace_back(source_entry.queue, MakeEmptySubmit());
+            result.sources.emplace_back(VulkanExecutableSourceMetadata{
+                .original_source_index = static_cast<uint32>(source_index),
+                .source_segment_index  = 0,
+                .source_segment_count  = 1,
+            });
+            continue;
+        }
+
+        Array<FenceRef> segment_outcomes{};
+        segment_outcomes.reserve(source_plan.segment_plan_count);
+        for (size_t segment_index = 0; segment_index < source_plan.segment_plan_count; ++segment_index) {
+            FenceRef outcome = RenderDevice::Get().CreateFence();
+            if (!outcome.IsValid()) {
+                throw std::runtime_error("multi-segment materialization failed to create completion fence");
+            }
+            segment_outcomes.emplace_back(std::move(outcome));
+        }
+        materialization.completion =
+            std::make_shared<VulkanMultiSegmentCompletionState>(std::move(segment_outcomes));
+
+        for (size_t segment_index = 0; segment_index < source_plan.segment_plan_count; ++segment_index) {
+            const RHISubmissionSegmentPlan& segment_plan =
+                _batch.topology.segments[source_plan.segment_plan_begin + segment_index];
+            const RHISubmitSegment& descriptor    = segment_plan.segment;
+            const size_t            command_count = descriptor.end - descriptor.begin;
+
+            CmdSubmit segment_submit = MakeEmptySubmit();
+            segment_submit.cmds.reserve(command_count);
+            segment_submit.callbacks.reserve(1);
+            segment_submit.signal_events.reserve(
+                1 + (segment_plan.inherit_source_signal_events_and_callbacks ?
+                         source_submit.signal_events.size() :
+                         0)
+            );
+            segment_submit.wait_events.reserve(
+                (segment_plan.inherit_source_wait_events ? source_submit.wait_events.size() : 0) + 1
+            );
+            segment_submit.segments.reserve(1);
+
+            segment_submit.resource_state_ownership  = source_submit.resource_state_ownership;
+            segment_submit.translate_execution_class = source_submit.translate_execution_class;
+            segment_submit.async_queue_scope         = source_submit.async_queue_scope;
+            segment_submit.debug_label_color         = source_submit.debug_label_color;
+
+            if (descriptor.queue != EQueueType::Copy) {
+                segment_submit.cached_args = source_submit.cached_args;
+            }
+            if (segment_plan.inherit_source_runtime_payload) {
+                segment_submit.debug_label = source_submit.debug_label;
+            }
+
+            segment_submit.segments.emplace_back(RHISubmitSegment{
+                .queue = descriptor.queue,
+                .begin = 0,
+                .end   = command_count,
+            });
+
+            const FenceRef& segment_outcome = materialization.completion->SegmentOutcome(segment_index);
+            segment_submit.signal_events.emplace_back(SignalEvent{
+                .timeline_handle = uint64(segment_outcome.Get()),
+                .value           = 1,
+            });
+            segment_submit.callbacks.emplace_back([completion = materialization.completion, segment_index] {
+                completion->Retire(segment_index);
+            });
+
+            bool cross_native_predecessor_wait = false;
+            if (segment_index != 0) {
+                const RHISubmissionSegmentPlan& predecessor_plan =
+                    _batch.topology.segments[source_plan.segment_plan_begin + segment_index - 1];
+                cross_native_predecessor_wait =
+                    _queue_topology.Resolve(predecessor_plan.segment.queue).native_queue_id !=
+                    _queue_topology.Resolve(descriptor.queue).native_queue_id;
+                if (cross_native_predecessor_wait) {
+                    const FenceRef& predecessor_outcome =
+                        materialization.completion->SegmentOutcome(segment_index - 1);
+                    segment_submit.wait_events.emplace_back(WaitEvent{
+                        .timeline_handle = uint64(predecessor_outcome.Get()),
+                        .value           = 1,
+                    });
+                    ++result.cross_native_wait_count;
+                }
+            }
+
+            executable_sources.emplace_back(descriptor.queue, std::move(segment_submit));
+            result.sources.emplace_back(VulkanExecutableSourceMetadata{
+                .original_source_index         = static_cast<uint32>(source_index),
+                .source_segment_index          = static_cast<uint32>(segment_index),
+                .source_segment_count          = static_cast<uint32>(source_plan.segment_plan_count),
+                .cross_native_predecessor_wait = cross_native_predecessor_wait,
+            });
+        }
+    }
+
+    assert(executable_sources.size() == executable_source_count);
+    assert(result.sources.size() == executable_source_count);
+
+    // Build and validate the flattened immutable topology before moving any
+    // command, callback, or external synchronization ownership out of the
+    // original sources. Every operation after this point is pre-reserved and
+    // noexcept for the owned payload types.
+    Array<RHISourceSubmitDescription> descriptions{};
+    descriptions.reserve(executable_source_count);
+    for (size_t source_index = 0; source_index < _batch.submits.size(); ++source_index) {
+        const RHIBackendSubmissionBatchEntry&      source_entry    = _batch.submits[source_index];
+        const VulkanOriginalSourceMaterialization& materialization = source_materializations[source_index];
+        if (!materialization.multi_segment) {
+            descriptions.emplace_back(RHISourceSubmitDescription{
+                .root_queue      = source_entry.queue,
+                .command_count   = source_entry.submit.cmds.size(),
+                .segments        = source_entry.submit.segments,
+                .execution_class = source_entry.submit.translate_execution_class,
+                .has_side_effects =
+                    SubmitHasSideEffects(source_entry.submit) || !source_entry.submit.cmds.empty(),
+            });
+            continue;
+        }
+
+        for (size_t segment_index = 0; segment_index < materialization.executable_count; ++segment_index) {
+            const RHIBackendSubmissionBatchEntry& executable_entry =
+                executable_sources[materialization.executable_begin + segment_index];
+            descriptions.emplace_back(RHISourceSubmitDescription{
+                .root_queue       = executable_entry.queue,
+                .command_count    = executable_entry.submit.segments.front().end,
+                .segments         = executable_entry.submit.segments,
+                .execution_class  = executable_entry.submit.translate_execution_class,
+                .has_side_effects = true,
+            });
+        }
+    }
+
+    RHISubmissionTopologyPlan executable_topology = BuildRHISubmissionTopology(descriptions, _batch.sequence);
+    if (!executable_topology.IsValid() ||
+        executable_topology.source_plans.size() != executable_sources.size()) {
+        throw std::runtime_error("multi-segment materialization produced an invalid executable topology");
+    }
+
+    for (size_t source_index = 0; source_index < _batch.submits.size(); ++source_index) {
+        RHIBackendSubmissionBatchEntry&      source_entry    = _batch.submits[source_index];
+        VulkanOriginalSourceMaterialization& materialization = source_materializations[source_index];
+        if (!materialization.multi_segment) {
+            executable_sources[materialization.executable_begin].submit = std::move(source_entry.submit);
+            continue;
+        }
+
+        materialization.completion->AdoptSourceCallbacks(
+            std::move(source_entry.submit.callbacks), std::move(source_entry.submit.success_callbacks)
+        );
+
+        const RHISourceSubmitPlan& source_plan = _batch.topology.source_plans[source_index];
+        for (size_t segment_index = 0; segment_index < materialization.executable_count; ++segment_index) {
+            const RHISubmitSegment& descriptor =
+                _batch.topology.segments[source_plan.segment_plan_begin + segment_index].segment;
+            CmdSubmit& executable_submit =
+                executable_sources[materialization.executable_begin + segment_index].submit;
+            for (size_t command_index = descriptor.begin; command_index < descriptor.end; ++command_index) {
+                executable_submit.cmds.emplace_back(std::move(source_entry.submit.cmds[command_index]));
+            }
+        }
+
+        CmdSubmit& first_submit = executable_sources[materialization.executable_begin].submit;
+        for (const WaitEvent& wait : source_entry.submit.wait_events) {
+            first_submit.wait_events.emplace_back(wait);
+        }
+
+        CmdSubmit& last_submit =
+            executable_sources[materialization.executable_begin + materialization.executable_count - 1]
+                .submit;
+        for (const SignalEvent& signal : source_entry.submit.signal_events) {
+            last_submit.signal_events.emplace_back(signal);
+        }
+    }
+
+    _batch.submits  = std::move(executable_sources);
+    _batch.topology = std::move(executable_topology);
+    return result;
 }
 
 const char* TopologyErrorName(ERHISubmissionTopologyError _error) {
@@ -265,6 +646,51 @@ void ResolveRejectedPresent(std::optional<RHIPresentRequest>& _present) {
 }
 
 } // namespace
+
+VulkanMultiSegmentCompletionProbeResult RunVulkanMultiSegmentCompletionProbeForTesting() {
+    Array<FenceRef> segment_outcomes{};
+    segment_outcomes.reserve(2);
+    segment_outcomes.emplace_back(RenderDevice::Get().CreateFence());
+    segment_outcomes.emplace_back(RenderDevice::Get().CreateFence());
+    if (!segment_outcomes[0].IsValid() || !segment_outcomes[1].IsValid()) {
+        throw std::runtime_error("multi-segment completion probe failed to create fences");
+    }
+
+    auto   completion = std::make_shared<VulkanMultiSegmentCompletionState>(std::move(segment_outcomes));
+    uint32 ordinary_callback_count = 0;
+    uint32 success_callback_count  = 0;
+    completion->AdoptSourceCallbacks(
+        Array<std::function<void()>>{[&ordinary_callback_count] {
+            ++ordinary_callback_count;
+        }},
+        Array<std::function<void()>>{[&success_callback_count] {
+            ++success_callback_count;
+        }}
+    );
+
+    VulkanMultiSegmentCompletionProbeResult result{};
+    auto*                                   suffix = ResourceCast(completion->SegmentOutcome(1).Get());
+    auto*                                   prefix = ResourceCast(completion->SegmentOutcome(0).Get());
+    if (suffix == nullptr || prefix == nullptr) {
+        throw std::runtime_error("multi-segment completion probe received non-Vulkan fences");
+    }
+
+    suffix->Fail(VK_ERROR_UNKNOWN);
+    completion->Retire(1);
+    result.suffix_retirement_deferred_callbacks = ordinary_callback_count == 0 && success_callback_count == 0;
+
+    prefix->Notify(1);
+    completion->Retire(0);
+    result.prefix_retirement_completed_callbacks =
+        ordinary_callback_count == 1 && success_callback_count == 0;
+
+    completion->Retire(1);
+    completion->Retire(0);
+    result.repeated_retirement_suppressed = ordinary_callback_count == 1 && success_callback_count == 0;
+    result.ordinary_callback_count        = ordinary_callback_count;
+    result.success_callback_count         = success_callback_count;
+    return result;
+}
 
 bool TryInstallVulkanSourceSubmissionObserver(const VulkanSourceSubmissionObserver* _observer) noexcept {
     if (_observer == nullptr || _observer->callback == nullptr) {
@@ -760,6 +1186,46 @@ void VulkanSubmissionExecutor::ProcessBatch(
         return;
     }
 
+    const RHIQueueTopology                   queue_topology = RenderDevice::Get().GetQueueTopology();
+    const VulkanSegmentMaterializationResult materialization =
+        MaterializeMultiSegmentBatch(_batch, queue_topology);
+    if (materialization.changed) {
+        const BatchPreflightResult executable_preflight = ValidateBatch(_batch);
+        if (!executable_preflight.valid) {
+            LOG_ERROR(
+                "[RHIExecutor][Vulkan][MultiSegment] batch={} "
+                "executable preflight rejected reason={} topology_error={} "
+                "source={} command={}",
+                _batch.sequence,
+                executable_preflight.reason,
+                TopologyErrorName(_batch.topology.error),
+                executable_preflight.source_index,
+                executable_preflight.command_index
+            );
+            hard_failed         = true;
+            hard_failure_result = static_cast<int32>(VK_ERROR_UNKNOWN);
+            RejectBatch(
+                std::move(_batch),
+                static_cast<int32>(VK_ERROR_UNKNOWN),
+                executable_preflight.reason,
+                0,
+                &_exception_state.first_unconsumed_source
+            );
+            return;
+        }
+        if (!logged_multi_segment_topology) {
+            logged_multi_segment_topology = true;
+            LOG_INFO(
+                "[RHIExecutor][Vulkan][MultiSegment] "
+                "original_sources={} executable_segments={} "
+                "cross_native_waits={} completion_aggregate=true",
+                materialization.original_source_count,
+                _batch.submits.size(),
+                materialization.cross_native_wait_count
+            );
+        }
+    }
+
     if (!logged_multi_source_topology && _batch.submits.size() > 1) {
         logged_multi_source_topology = true;
         LOG_INFO(
@@ -817,8 +1283,6 @@ void VulkanSubmissionExecutor::ProcessBatch(
             _exception_state.first_unconsumed_source = _batch.submits.size();
         };
 
-    const RHIQueueTopology queue_topology =
-        RenderDevice::Get().GetQueueTopology();
     auto same_native_queue = [&](EQueueType lhs, EQueueType rhs) {
         return queue_topology.Resolve(lhs).native_queue_id ==
                queue_topology.Resolve(rhs).native_queue_id;
@@ -1260,12 +1724,23 @@ void VulkanSubmissionExecutor::ProcessBatch(
                                                    packet         = &*slot.recorded,
                                                    batch_sequence = _batch.sequence,
                                                    source_index   = static_cast<uint32>(slot.source_index),
+                                                   source_metadata =
+                                                       materialization.sources[slot.source_index],
                                                    queue_type     = slot.queue_type,
                                                    async_scope    = slot.async_queue_scope]() mutable {
                             VulkanRuntimeSubmissionResult result =
                                 queue.SubmitRecordedForRuntime(std::move(*packet));
                             if (result.WasSubmitted()) {
-                                NotifySourceSubmitted(batch_sequence, source_index, queue_type, async_scope);
+                                NotifySourceSubmitted(
+                                    batch_sequence,
+                                    source_index,
+                                    source_metadata.original_source_index,
+                                    source_metadata.source_segment_index,
+                                    source_metadata.source_segment_count,
+                                    queue_type,
+                                    async_scope,
+                                    source_metadata.cross_native_predecessor_wait
+                                );
                             }
                             return result;
                         });
@@ -1370,6 +1845,7 @@ void VulkanSubmissionExecutor::ProcessBatch(
                         packet = &*recorded,
                         batch_sequence = _batch.sequence,
                         source_index = static_cast<uint32>(source_index),
+                        source_metadata = materialization.sources[source_index],
                         async_scope
                     ]() mutable {
                         VulkanRuntimeSubmissionResult result =
@@ -1380,8 +1856,12 @@ void VulkanSubmissionExecutor::ProcessBatch(
                             NotifySourceSubmitted(
                                 batch_sequence,
                                 source_index,
+                                source_metadata.original_source_index,
+                                source_metadata.source_segment_index,
+                                source_metadata.source_segment_count,
                                 EQueueType::Copy,
-                                async_scope
+                                async_scope,
+                                source_metadata.cross_native_predecessor_wait
                             );
                         }
                         return result;
@@ -1475,6 +1955,7 @@ void VulkanSubmissionExecutor::ProcessBatch(
                         packet = &*recorded,
                         batch_sequence = _batch.sequence,
                         source_index = static_cast<uint32>(source_index),
+                        source_metadata = materialization.sources[source_index],
                         queue_type = entry.queue,
                         async_scope
                     ]() mutable {
@@ -1484,8 +1965,12 @@ void VulkanSubmissionExecutor::ProcessBatch(
                             NotifySourceSubmitted(
                                 batch_sequence,
                                 source_index,
+                                source_metadata.original_source_index,
+                                source_metadata.source_segment_index,
+                                source_metadata.source_segment_count,
                                 queue_type,
-                                async_scope
+                                async_scope,
+                                source_metadata.cross_native_predecessor_wait
                             );
                         }
                         return result;

--- a/source/runtime/render/rhi/vulkan/VulkanSubmissionExecutor.h
+++ b/source/runtime/render/rhi/vulkan/VulkanSubmissionExecutor.h
@@ -54,9 +54,10 @@ private:
     };
 
     struct BatchExceptionState {
-        // Sources below this cursor have already been terminalized by their
-        // native queue. The current source and every later source remain the
-        // rejection responsibility of the request on an unexpected exception.
+        // Executable entries below this cursor have already been terminalized
+        // by their native queue. A multi-segment upper source may occupy
+        // several entries; its source-level callback lifetime is protected by
+        // a completion aggregate spanning every segment.
         size_t first_unconsumed_source{0};
     };
 
@@ -120,6 +121,7 @@ private:
     bool                       claims_owned{false};
     bool                       hard_failed{false};
     bool                       logged_multi_source_topology{false};
+    bool                       logged_multi_segment_topology{false};
     bool                       logged_async_queue_scope{false};
     bool                                                    logged_parallel_translate_wave{false};
     int32                      hard_failure_result{0};

--- a/source/runtime/render/rhi/vulkan/VulkanSubmissionExecutor.h
+++ b/source/runtime/render/rhi/vulkan/VulkanSubmissionExecutor.h
@@ -17,11 +17,12 @@
 
 namespace Moer::Render {
 
-// Owns the upper RHI submission stream for Vulkan. The translate owner prepares
-// one source at a time, then transfers its move-only packet to the sole native
-// Submission owner. Native queue submission remains single-owner and serial.
-// Validated non-zero async scopes may overlap GPU execution across distinct
-// native queues using explicit graph wait/signal events.
+// Owns the upper RHI submission stream for Vulkan. The Translate coordinator
+// may dispatch one explicit-RDG source per native queue lane to TaskGraph
+// workers, then transfers every move-only packet in stable source order to the
+// sole native Submission owner. Native queue submission remains single-owner
+// and serial. Validated non-zero async scopes may overlap CPU translation and
+// GPU execution across distinct native queues.
 class VulkanSubmissionExecutor final : public RHIBackendExecutor {
 public:
     VulkanSubmissionExecutor();
@@ -120,6 +121,7 @@ private:
     bool                       hard_failed{false};
     bool                       logged_multi_source_topology{false};
     bool                       logged_async_queue_scope{false};
+    bool                                                    logged_parallel_translate_wave{false};
     int32                      hard_failure_result{0};
     std::shared_ptr<Completion> stop_completion{};
     StaticArray<bool, static_cast<size_t>(EQueueType::Num)> used_queues{};

--- a/source/runtime/render/rhi/vulkan/VulkanTranslateWaveScheduler.h
+++ b/source/runtime/render/rhi/vulkan/VulkanTranslateWaveScheduler.h
@@ -1,0 +1,319 @@
+#pragma once
+
+#include "rhi/RHISubmissionTopology.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+#include <optional>
+#include <span>
+#include <vector>
+
+namespace Moer::Render::VulkanTranslateWaveDetail {
+
+// CPU-only input used to schedule Vulkan translation work. native_queue_id is
+// the physical queue identity from RHIQueueTopology, not the logical
+// EQueueType. Dependencies are explicit topology edges and must point to an
+// earlier node in this stable input order.
+struct TranslateWaveNode {
+    SubmissionKey                  key{};
+    uint32_t                       native_queue_id{0};
+    bool                           async_translate{true};
+    std::span<const SubmissionKey> dependencies{};
+};
+
+enum class ETranslateWaveBuildError : uint8_t {
+    None = 0,
+    DuplicateKey,
+    UnknownDependency,
+    FutureDependency,
+};
+
+enum class ETranslateWaveNodeState : uint8_t {
+    Pending = 0,
+    Translating,
+    Translated,
+    Released,
+    Cancelled,
+};
+
+// Builds stable translation waves without owning threads or Vulkan objects.
+//
+// Explicit topology dependencies are satisfied by MarkTranslated, because
+// their CPU prerequisite is complete at that point. Physical-queue ordering is
+// stricter: a node sharing native_queue_id with an earlier node waits for
+// MarkReleased, which represents transfer of that packet lease to Submit or
+// Reject. A non-async node is an exclusive Copy/control boundary; it waits for
+// the complete earlier prefix to be released and blocks the later suffix until
+// it is released.
+//
+// NextWave scans the complete stable input and emits every currently-ready
+// native lane. A blocked same-native node therefore cannot hide a later,
+// independent lane. The caller still owns final ordered release/submission:
+// translated packets may remain held until all earlier stable keys are ready.
+class TranslateWaveScheduler final {
+public:
+    static constexpr size_t NoIndex = std::numeric_limits<size_t>::max();
+
+    [[nodiscard]] bool Build(std::span<const TranslateWaveNode> _input) {
+        Reset();
+
+        nodes.reserve(_input.size());
+        for (size_t input_index = 0; input_index < _input.size(); ++input_index) {
+            const TranslateWaveNode& input = _input[input_index];
+            if (FindNodeIndex(input.key) != NoIndex) {
+                return Fail(ETranslateWaveBuildError::DuplicateKey, input_index, NoIndex);
+            }
+            nodes.emplace_back(InternalNode{
+                .key             = input.key,
+                .native_queue_id = input.native_queue_id,
+                .async_translate = input.async_translate,
+            });
+        }
+
+        size_t last_hard_boundary = NoIndex;
+        for (size_t input_index = 0; input_index < _input.size(); ++input_index) {
+            InternalNode& node = nodes[input_index];
+
+            for (size_t dependency_index = 0; dependency_index < _input[input_index].dependencies.size();
+                 ++dependency_index) {
+                const SubmissionKey dependency_key  = _input[input_index].dependencies[dependency_index];
+                const size_t        dependency_node = FindNodeIndex(dependency_key);
+                if (dependency_node == NoIndex) {
+                    return Fail(ETranslateWaveBuildError::UnknownDependency, input_index, dependency_index);
+                }
+                if (dependency_node >= input_index) {
+                    return Fail(ETranslateWaveBuildError::FutureDependency, input_index, dependency_index);
+                }
+
+                bool duplicate_dependency = false;
+                for (const size_t existing : node.dependencies) {
+                    if (existing == dependency_node) {
+                        duplicate_dependency = true;
+                        break;
+                    }
+                }
+                if (!duplicate_dependency) {
+                    node.dependencies.emplace_back(dependency_node);
+                }
+            }
+
+            for (size_t predecessor = input_index; predecessor > 0; --predecessor) {
+                const size_t candidate = predecessor - 1;
+                if (nodes[candidate].native_queue_id == node.native_queue_id) {
+                    node.same_native_queue_predecessor = candidate;
+                    break;
+                }
+            }
+
+            node.hard_boundary_predecessor = last_hard_boundary;
+            if (!node.async_translate) {
+                last_hard_boundary = input_index;
+            }
+        }
+
+        built = true;
+        return true;
+    }
+
+    [[nodiscard]] std::vector<SubmissionKey> NextWave() {
+        std::vector<SubmissionKey> wave;
+        if (!built || cancelled) {
+            return wave;
+        }
+
+        for (size_t node_index = 0; node_index < nodes.size(); ++node_index) {
+            InternalNode& node = nodes[node_index];
+            if (!IsReady(node_index)) {
+                continue;
+            }
+
+            node.state = ETranslateWaveNodeState::Translating;
+            wave.emplace_back(node.key);
+
+            // Copy/control work is ready only after its full earlier prefix
+            // has released, and it remains an exclusive wave.
+            if (!node.async_translate) {
+                break;
+            }
+        }
+        return wave;
+    }
+
+    [[nodiscard]] bool MarkTranslated(const SubmissionKey& _key) noexcept {
+        InternalNode* node = FindNode(_key);
+        if (node == nullptr || node->state != ETranslateWaveNodeState::Translating) {
+            return false;
+        }
+        node->state = ETranslateWaveNodeState::Translated;
+        return true;
+    }
+
+    [[nodiscard]] bool MarkReleased(const SubmissionKey& _key) noexcept {
+        InternalNode* node = FindNode(_key);
+        if (node == nullptr) {
+            return false;
+        }
+
+        if (node->state == ETranslateWaveNodeState::Translated ||
+            (cancelled && node->state == ETranslateWaveNodeState::Translating)) {
+            node->state = ETranslateWaveNodeState::Released;
+            return true;
+        }
+        return false;
+    }
+
+    // Pending suffix nodes have no packet lease and can be terminalized
+    // immediately. In-flight or translated nodes retain their state so the
+    // owner can still release their packet exactly once.
+    void Cancel() noexcept {
+        if (!built || cancelled) {
+            return;
+        }
+        cancelled = true;
+        for (InternalNode& node : nodes) {
+            if (node.state == ETranslateWaveNodeState::Pending) {
+                node.state = ETranslateWaveNodeState::Cancelled;
+            }
+        }
+    }
+
+    [[nodiscard]] bool IsValid() const noexcept {
+        return built && build_error == ETranslateWaveBuildError::None;
+    }
+
+    [[nodiscard]] bool IsCancelled() const noexcept {
+        return cancelled;
+    }
+
+    [[nodiscard]] bool IsComplete() const noexcept {
+        if (!built) {
+            return false;
+        }
+        for (const InternalNode& node : nodes) {
+            if (node.state != ETranslateWaveNodeState::Released &&
+                node.state != ETranslateWaveNodeState::Cancelled) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    [[nodiscard]] ETranslateWaveBuildError GetBuildError() const noexcept {
+        return build_error;
+    }
+
+    [[nodiscard]] size_t GetErrorNodeIndex() const noexcept {
+        return error_node_index;
+    }
+
+    [[nodiscard]] size_t GetErrorDependencyIndex() const noexcept {
+        return error_dependency_index;
+    }
+
+    [[nodiscard]] std::optional<ETranslateWaveNodeState> GetState(const SubmissionKey& _key) const noexcept {
+        const InternalNode* node = FindNode(_key);
+        if (node == nullptr) {
+            return std::nullopt;
+        }
+        return node->state;
+    }
+
+private:
+    struct InternalNode {
+        SubmissionKey           key{};
+        uint32_t                native_queue_id{0};
+        bool                    async_translate{true};
+        std::vector<size_t>     dependencies{};
+        size_t                  same_native_queue_predecessor{NoIndex};
+        size_t                  hard_boundary_predecessor{NoIndex};
+        ETranslateWaveNodeState state{ETranslateWaveNodeState::Pending};
+    };
+
+    void Reset() noexcept {
+        nodes.clear();
+        build_error            = ETranslateWaveBuildError::None;
+        error_node_index       = NoIndex;
+        error_dependency_index = NoIndex;
+        built                  = false;
+        cancelled              = false;
+    }
+
+    [[nodiscard]] bool
+    Fail(ETranslateWaveBuildError _error, size_t _node_index, size_t _dependency_index) noexcept {
+        nodes.clear();
+        build_error            = _error;
+        error_node_index       = _node_index;
+        error_dependency_index = _dependency_index;
+        built                  = false;
+        cancelled              = false;
+        return false;
+    }
+
+    [[nodiscard]] size_t FindNodeIndex(const SubmissionKey& _key) const noexcept {
+        for (size_t index = 0; index < nodes.size(); ++index) {
+            if (nodes[index].key == _key) {
+                return index;
+            }
+        }
+        return NoIndex;
+    }
+
+    [[nodiscard]] InternalNode* FindNode(const SubmissionKey& _key) noexcept {
+        const size_t index = FindNodeIndex(_key);
+        return index == NoIndex ? nullptr : &nodes[index];
+    }
+
+    [[nodiscard]] const InternalNode* FindNode(const SubmissionKey& _key) const noexcept {
+        const size_t index = FindNodeIndex(_key);
+        return index == NoIndex ? nullptr : &nodes[index];
+    }
+
+    [[nodiscard]] bool IsReady(size_t _node_index) const noexcept {
+        const InternalNode& node = nodes[_node_index];
+        if (node.state != ETranslateWaveNodeState::Pending) {
+            return false;
+        }
+
+        for (const size_t dependency_index : node.dependencies) {
+            const InternalNode& dependency = nodes[dependency_index];
+            if (dependency.async_translate) {
+                if (dependency.state != ETranslateWaveNodeState::Translated &&
+                    dependency.state != ETranslateWaveNodeState::Released) {
+                    return false;
+                }
+            } else if (dependency.state != ETranslateWaveNodeState::Released) {
+                return false;
+            }
+        }
+
+        if (node.same_native_queue_predecessor != NoIndex &&
+            nodes[node.same_native_queue_predecessor].state != ETranslateWaveNodeState::Released) {
+            return false;
+        }
+
+        if (node.hard_boundary_predecessor != NoIndex &&
+            nodes[node.hard_boundary_predecessor].state != ETranslateWaveNodeState::Released) {
+            return false;
+        }
+
+        if (!node.async_translate) {
+            for (size_t prefix_index = 0; prefix_index < _node_index; ++prefix_index) {
+                if (nodes[prefix_index].state != ETranslateWaveNodeState::Released) {
+                    return false;
+                }
+            }
+        }
+
+        return true;
+    }
+
+    std::vector<InternalNode> nodes{};
+    ETranslateWaveBuildError  build_error{ETranslateWaveBuildError::None};
+    size_t                    error_node_index{NoIndex};
+    size_t                    error_dependency_index{NoIndex};
+    bool                      built{false};
+    bool                      cancelled{false};
+};
+
+} // namespace Moer::Render::VulkanTranslateWaveDetail

--- a/source/test/CMakeLists.txt
+++ b/source/test/CMakeLists.txt
@@ -145,6 +145,17 @@ target_link_libraries(${test_target}
 set_target_properties(${test_target} PROPERTIES FOLDER ${moer_test_folder})
 add_test(NAME VulkanSubmissionRequestDispatchContract COMMAND $<TARGET_FILE:${test_target}>)
 
+# CPU-only dependency-wave contract for same-batch Vulkan translation.
+# Explicit topology edges unlock at translated, while native-queue aliases and
+# Copy/control boundaries retain packet ownership until released.
+set(test_target TestVulkanTranslateWaveScheduler)
+add_executable(${test_target} "VulkanTranslateWaveSchedulerTest.cpp")
+target_link_libraries(${test_target}
+    PRIVATE Moer::Render
+)
+set_target_properties(${test_target} PROPERTIES FOLDER ${moer_test_folder})
+add_test(NAME VulkanTranslateWaveSchedulerContract COMMAND $<TARGET_FILE:${test_target}>)
+
 # Compile-time contract for the engine's Volk integration. The source
 # intentionally includes vulkan_core.h before engine Vulkan headers to ensure
 # VK_NO_PROTOTYPES propagates through the same lightweight header interface

--- a/source/test/RHIParallelRecordVulkanTest.cpp
+++ b/source/test/RHIParallelRecordVulkanTest.cpp
@@ -1,6 +1,7 @@
 #include "Core.h"
 #include "config/ConfigManager.h"
 #include "log/LogSystem.h"
+#include "platform/Platform.h"
 #include "rendergraph/RenderGraph.h"
 #include "rendergraph/RenderGraphLowering.h"
 #include "rhi/RHI.h"
@@ -8,6 +9,8 @@
 #include "rhi/RHIExecutor.h"
 #include "rhi/RHIThreadOwnership.h"
 #include "rhi/vulkan/VulkanCustomCommand.h"
+#include "rhi/vulkan/VulkanDevice.h"
+#include "rhi/vulkan/VulkanIOService.h"
 #include "rhi/vulkan/VulkanQueue.h"
 #include "rhi/vulkan/VulkanRHIResource.h"
 #include "rhi/vulkan/VulkanSubmissionDiagnostics.h"
@@ -199,6 +202,192 @@ public:
 private:
     VulkanSourceSubmissionObserver observer{};
     bool                           installed{false};
+};
+
+class NativeSubmissionCapture final {
+public:
+    static void Observe(
+        void*                              _context,
+        const VulkanNativeSubmissionEvent& _event
+    ) noexcept {
+        auto& capture = *static_cast<NativeSubmissionCapture*>(_context);
+        const size_t index =
+            capture.count.fetch_add(1, std::memory_order_acq_rel);
+        if (index >= capture.events.size()) {
+            capture.overflow.store(true, std::memory_order_release);
+            return;
+        }
+        capture.events[index] = _event;
+    }
+
+    [[nodiscard]] size_t Count() const noexcept {
+        return count.load(std::memory_order_acquire);
+    }
+
+    [[nodiscard]] bool Overflowed() const noexcept {
+        return overflow.load(std::memory_order_acquire);
+    }
+
+    [[nodiscard]] const VulkanNativeSubmissionEvent& Event(
+        size_t _index
+    ) const noexcept {
+        return events[_index];
+    }
+
+private:
+    std::array<VulkanNativeSubmissionEvent, 16> events{};
+    std::atomic<size_t>                         count{0};
+    std::atomic<bool>                           overflow{false};
+};
+
+class ScopedNativeSubmissionObserver final {
+public:
+    explicit ScopedNativeSubmissionObserver(
+        NativeSubmissionCapture& _capture
+    ) :
+        observer{
+            .context  = &_capture,
+            .callback = &NativeSubmissionCapture::Observe,
+        } {
+        if (!TryInstallVulkanNativeSubmissionObserver(&observer)) {
+            throw std::runtime_error(
+                "Vulkan native submission observer was already installed"
+            );
+        }
+        installed = true;
+    }
+
+    ~ScopedNativeSubmissionObserver() noexcept {
+        if (installed &&
+            !RemoveVulkanNativeSubmissionObserver(&observer)) {
+            std::terminate();
+        }
+    }
+
+    ScopedNativeSubmissionObserver(
+        const ScopedNativeSubmissionObserver&
+    ) = delete;
+    ScopedNativeSubmissionObserver& operator=(
+        const ScopedNativeSubmissionObserver&
+    ) = delete;
+
+private:
+    VulkanNativeSubmissionObserver observer{};
+    bool                           installed{false};
+};
+
+class CopyDependencyWaitCapture final {
+public:
+    static void Observe(
+        void*                                        _context,
+        const VulkanSubmissionDependencyWaitEvent& _event
+    ) noexcept {
+        auto& capture =
+            *static_cast<CopyDependencyWaitCapture*>(_context);
+        if (_event.queue != EQueueType::Copy) {
+            return;
+        }
+        if (_event.thread_role != ERHIThreadRole::Submission) {
+            capture.wrong_owner.store(true, std::memory_order_release);
+        }
+        if (capture.count.fetch_add(1, std::memory_order_acq_rel) == 0) {
+            capture.entered.release();
+        }
+    }
+
+    std::binary_semaphore entered{0};
+    std::atomic<uint32>   count{0};
+    std::atomic<bool>     wrong_owner{false};
+};
+
+class ScopedDependencyWaitObserver final {
+public:
+    explicit ScopedDependencyWaitObserver(
+        CopyDependencyWaitCapture& _capture
+    ) :
+        observer{
+            .context  = &_capture,
+            .callback = &CopyDependencyWaitCapture::Observe,
+        } {
+        if (!TryInstallVulkanSubmissionDependencyWaitObserver(
+                &observer
+            )) {
+            throw std::runtime_error(
+                "Vulkan dependency-wait observer was already installed"
+            );
+        }
+        installed = true;
+    }
+
+    ~ScopedDependencyWaitObserver() noexcept {
+        if (installed &&
+            !RemoveVulkanSubmissionDependencyWaitObserver(&observer)) {
+            std::terminate();
+        }
+    }
+
+    ScopedDependencyWaitObserver(
+        const ScopedDependencyWaitObserver&
+    ) = delete;
+    ScopedDependencyWaitObserver& operator=(
+        const ScopedDependencyWaitObserver&
+    ) = delete;
+
+private:
+    VulkanSubmissionDependencyWaitObserver observer{};
+    bool                                   installed{false};
+};
+
+class BackendSyncWaitCapture final {
+public:
+    static void Observe(
+        void*                             _context,
+        const VulkanBackendSyncWaitEvent&
+    ) noexcept {
+        auto& capture = *static_cast<BackendSyncWaitCapture*>(_context);
+        if (capture.count.fetch_add(1, std::memory_order_acq_rel) == 0) {
+            capture.entered.release();
+        }
+    }
+
+    std::binary_semaphore entered{0};
+    std::atomic<uint32>   count{0};
+};
+
+class ScopedBackendSyncWaitObserver final {
+public:
+    explicit ScopedBackendSyncWaitObserver(
+        BackendSyncWaitCapture& _capture
+    ) :
+        observer{
+            .context  = &_capture,
+            .callback = &BackendSyncWaitCapture::Observe,
+        } {
+        if (!TryInstallVulkanBackendSyncWaitObserver(&observer)) {
+            throw std::runtime_error(
+                "Vulkan backend Sync-wait observer was already installed"
+            );
+        }
+        installed = true;
+    }
+
+    ~ScopedBackendSyncWaitObserver() noexcept {
+        if (installed &&
+            !RemoveVulkanBackendSyncWaitObserver(&observer)) {
+            std::terminate();
+        }
+    }
+
+    ScopedBackendSyncWaitObserver(
+        const ScopedBackendSyncWaitObserver&
+    ) = delete;
+    ScopedBackendSyncWaitObserver& operator=(
+        const ScopedBackendSyncWaitObserver&
+    ) = delete;
+
+private:
+    VulkanBackendSyncWaitObserver observer{};
+    bool                          installed{false};
 };
 
 template<size_t N>
@@ -1439,14 +1628,11 @@ void RunActiveRdgAsyncQueueDag(bool _parallel) {
 void RunActiveRdgGraphicsCopyRoundTrip(bool _parallel) {
     auto&      device   = RenderDevice::Get();
     const auto topology = RenderGraph::QueueTopology::FromRHI();
-    if (!topology.copy.available ||
-        topology.graphics.native_queue_id == topology.copy.native_queue_id) {
+    if (!topology.copy.available) {
         LOG_INFO(
             "[TESTCASE][SKIP] name=ActiveRdgGraphicsCopyRoundTrip "
-            "reason={} graphics_native={} copy_native={} graphics_family={} "
+            "reason=copy_queue_unavailable graphics_native={} copy_native={} graphics_family={} "
             "copy_family={}",
-            topology.copy.available ? "shared_native_queue" :
-                                      "copy_queue_unavailable",
             topology.graphics.native_queue_id,
             topology.copy.native_queue_id,
             topology.graphics.family_id,
@@ -1648,10 +1834,14 @@ void RunActiveRdgGraphicsCopyRoundTrip(bool _parallel) {
             return sync.gpu_wait_required;
         }
     );
-    if (gpu_sync_count != 2) {
+    const bool native_alias =
+        topology.graphics.native_queue_id ==
+        topology.copy.native_queue_id;
+    const size_t expected_gpu_sync_count = native_alias ? 0 : 2;
+    if (gpu_sync_count != expected_gpu_sync_count) {
         throw std::runtime_error(
-            "Graphics-Copy round trip did not compile exactly two native "
-            "queue synchronization points"
+            "Graphics-Copy round trip GPU synchronization count disagrees "
+            "with native queue aliasing"
         );
     }
 
@@ -1838,9 +2028,14 @@ void RunActiveRdgGraphicsCopyRoundTrip(bool _parallel) {
     }
     LOG_INFO(
         "[TESTCASE][PASS] name=ActiveRdgGraphicsCopyRoundTrip mode={} "
-        "ownership={} transfers=2 readback=verified",
+        "ownership={} transfers=2 gpu_syncs={} graphics_native={} "
+        "copy_native={} native_alias={} readback=verified",
         _parallel ? "parallel" : "serial",
-        same_queue_family ? "local-acquire" : "release-acquire"
+        same_queue_family ? "local-acquire" : "release-acquire",
+        gpu_sync_count,
+        topology.graphics.native_queue_id,
+        topology.copy.native_queue_id,
+        native_alias
     );
 }
 
@@ -2703,6 +2898,7 @@ void RunContinuousFrameInFlightRetirement() {
 
 void RunCrossQueueTopologyBatch() {
     auto& device = RenderDevice::Get();
+    const RHIQueueTopology topology = device.GetQueueTopology();
     constexpr size_t element_count = 32;
     const EBufferUsageFlags usage =
         EBufferUsageFlags::TRANSFER_SRC | EBufferUsageFlags::TRANSFER_DST;
@@ -2714,6 +2910,8 @@ void RunCrossQueueTopologyBatch() {
 
     std::array<uint32, element_count> expected{};
     std::array<uint32, element_count> readback{};
+    std::array<std::atomic<uint32>, 4> ordinary_callbacks{};
+    std::array<std::atomic<uint32>, 4> success_callbacks{};
     for (uint32 index = 0; index < expected.size(); ++index) {
         expected[index] = 0x53000000u + index * 43u;
     }
@@ -2769,6 +2967,22 @@ void RunCrossQueueTopologyBatch() {
         copy_stage->GetView(), WritableBytes(readback), "TopologyCrossQueueReadback"
     );
 
+    for (size_t index = 0; index < command_lists.size(); ++index) {
+        command_lists[index].AddCallback([&, index] {
+            ordinary_callbacks[index].fetch_add(
+                1, std::memory_order_relaxed
+            );
+        });
+        command_lists[index].AddSuccessCallback([&, index] {
+            success_callbacks[index].fetch_add(
+                1, std::memory_order_relaxed
+            );
+        });
+    }
+
+    NativeSubmissionCapture        native_capture{};
+    ScopedNativeSubmissionObserver native_observer(native_capture);
+    const uint32 main_thread_id = Platform::GetCurrentThreadID();
     for (CommandList& command_list : command_lists) {
         const EQueueType queue = command_list.GetQueueType();
         RHIExecutor::Get().Submit(
@@ -2780,9 +2994,69 @@ void RunCrossQueueTopologyBatch() {
     if (readback != expected) {
         throw std::runtime_error("cross-queue topology GPU ordering mismatch");
     }
+    if (native_capture.Overflowed() || native_capture.Count() != 4) {
+        throw std::runtime_error(
+            "cross-queue batch did not issue exactly four native submits"
+        );
+    }
+    constexpr std::array expected_queues{
+        EQueueType::Graphics,
+        EQueueType::Compute,
+        EQueueType::Copy,
+        EQueueType::Graphics,
+    };
+    const uint32 submission_thread_id =
+        native_capture.Event(0).thread_id;
+    for (size_t index = 0; index < expected_queues.size(); ++index) {
+        const VulkanNativeSubmissionEvent& event =
+            native_capture.Event(index);
+        if (event.queue != expected_queues[index] ||
+            event.thread_role != ERHIThreadRole::Submission ||
+            event.thread_id != submission_thread_id ||
+            event.thread_id == main_thread_id ||
+            !event.outcome.WasSubmitted()) {
+            throw std::runtime_error(
+                "Graphics/Compute/Copy native submit escaped the sole "
+                "Submission owner or changed source order"
+            );
+        }
+        if (ordinary_callbacks[index].load(std::memory_order_acquire) != 1 ||
+            success_callbacks[index].load(std::memory_order_acquire) != 1) {
+            throw std::runtime_error(
+                "cross-queue callbacks did not retire exactly once"
+            );
+        }
+    }
+    const bool native_alias =
+        native_capture.Event(0).native_queue_handle ==
+        native_capture.Event(2).native_queue_handle;
+    if (native_alias !=
+        (topology.graphics.native_queue_id ==
+         topology.copy.native_queue_id)) {
+        throw std::runtime_error(
+            "observed Graphics/Copy native queue alias disagrees with topology"
+        );
+    }
+
+    RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
+    if (native_capture.Count() != 4) {
+        throw std::runtime_error(
+            "a second Sync unexpectedly issued another native submit"
+        );
+    }
+    for (size_t index = 0; index < ordinary_callbacks.size(); ++index) {
+        if (ordinary_callbacks[index].load(std::memory_order_acquire) != 1 ||
+            success_callbacks[index].load(std::memory_order_acquire) != 1) {
+            throw std::runtime_error(
+                "a second Sync replayed cross-queue callbacks"
+            );
+        }
+    }
     LOG_INFO(
         "[TESTCASE][PASS] name=CrossQueueSubmissionTopology "
-        "batches=4 queues=Graphics,Compute,Copy,Graphics ownership=explicit"
+        "batches=4 queues=Graphics,Compute,Copy,Graphics ownership=explicit "
+        "native_owner=verified native_alias={} callbacks=exactly_once replay=0",
+        native_alias
     );
 }
 
@@ -3230,6 +3504,8 @@ void RunRecoverableCopyDependencyRejection() {
     std::binary_semaphore       blocker_entered{0};
     std::binary_semaphore       release_blocker{0};
     OneShotSemaphoreRelease     release_guard(release_blocker);
+    NativeSubmissionCapture        native_capture{};
+    ScopedNativeSubmissionObserver native_observer(native_capture);
 
     try {
         CommandList blocker(EQueueType::Copy);
@@ -3403,6 +3679,44 @@ void RunRecoverableCopyDependencyRejection() {
             "recoverable Copy rejection callbacks retired incorrectly"
         );
     }
+    if (native_capture.Overflowed() || native_capture.Count() != 3) {
+        throw std::runtime_error(
+            "rejected Copy packets reached native submit or accepted packets "
+            "were lost"
+        );
+    }
+    const uint32 submission_thread_id =
+        native_capture.Event(0).thread_id;
+    for (size_t index = 0; index < native_capture.Count(); ++index) {
+        const VulkanNativeSubmissionEvent& event =
+            native_capture.Event(index);
+        if (event.queue != EQueueType::Copy ||
+            event.thread_role != ERHIThreadRole::Submission ||
+            event.thread_id != submission_thread_id ||
+            !event.outcome.WasSubmitted()) {
+            throw std::runtime_error(
+                "accepted Copy recovery packets escaped the sole native "
+                "Submission owner"
+            );
+        }
+    }
+
+    RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
+    if (native_capture.Count() != 3 ||
+        blocker_callbacks.load(std::memory_order_acquire) != 1 ||
+        blocker_success_callbacks.load(std::memory_order_acquire) != 1 ||
+        rejected_callbacks.load(std::memory_order_acquire) != 1 ||
+        rejected_success_callbacks.load(std::memory_order_acquire) != 0 ||
+        recovered_callbacks.load(std::memory_order_acquire) != 1 ||
+        recovered_success_callbacks.load(std::memory_order_acquire) != 1 ||
+        stale_wait_callbacks.load(std::memory_order_acquire) != 1 ||
+        stale_wait_success_callbacks.load(std::memory_order_acquire) != 0 ||
+        dependent_callbacks.load(std::memory_order_acquire) != 1 ||
+        dependent_success_callbacks.load(std::memory_order_acquire) != 1) {
+        throw std::runtime_error(
+            "a second Sync replayed recoverable Copy retirement"
+        );
+    }
     } catch (...) {
         const std::exception_ptr failure = std::current_exception();
         release_guard.Release();
@@ -3417,7 +3731,179 @@ void RunRecoverableCopyDependencyRejection() {
     LOG_INFO(
         "[TESTCASE][PASS] name=RecoverableCopyDependencyRejection "
         "fence=reused rejected=N recovered=N+1 stale_wait=rejected "
-        "publication=Submission"
+        "publication=Submission native_rejected=0 native_accepted=3 "
+        "native_owner=verified runtime=recovered replay=0"
+    );
+}
+
+void RunDirectCopyExecuteRejected() {
+    auto& device = RenderDevice::Get();
+    FenceRef done = device.CreateFence();
+    std::atomic<uint32> ordinary_callbacks{0};
+    std::atomic<uint32> success_callbacks{0};
+
+    CommandList direct(EQueueType::Copy);
+    direct.AddCallback([&] {
+        ordinary_callbacks.fetch_add(1, std::memory_order_relaxed);
+    });
+    direct.AddSuccessCallback([&] {
+        success_callbacks.fetch_add(1, std::memory_order_relaxed);
+    });
+    CmdSubmit submit = direct.Submit();
+    submit.Signal(done.Get(), 1);
+
+    NativeSubmissionCapture        native_capture{};
+    ScopedNativeSubmissionObserver native_observer(native_capture);
+    device.GetCopyQueue().Execute(std::move(submit));
+    auto* vk_done = ResourceCast(done.Get());
+    if (!vk_done->IsRejected(1) || vk_done->IsFailed()) {
+        throw std::runtime_error(
+            "direct Copy Execute did not fail closed at the Runtime ownership "
+            "boundary"
+        );
+    }
+
+    RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
+    if (native_capture.Count() != 0 ||
+        ordinary_callbacks.load(std::memory_order_acquire) != 1 ||
+        success_callbacks.load(std::memory_order_acquire) != 0) {
+        throw std::runtime_error(
+            "direct Copy rejection reached native submit or retired callbacks "
+            "incorrectly"
+        );
+    }
+
+    RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
+    if (native_capture.Count() != 0 ||
+        ordinary_callbacks.load(std::memory_order_acquire) != 1 ||
+        success_callbacks.load(std::memory_order_acquire) != 0) {
+        throw std::runtime_error(
+            "direct Copy rejection replayed on a second Sync"
+        );
+    }
+
+    LOG_INFO(
+        "[TESTCASE][PASS] name=DirectCopyExecuteRejected "
+        "runtime_claim=exclusive native_submit=0 callbacks=exactly_once "
+        "signal=rejected replay=0"
+    );
+}
+
+void RunVulkanStorageUnifiedCopySubmission() {
+    auto& device = RenderDevice::Get();
+    auto* vulkan_device =
+        static_cast<VulkanDevice*>(device.GetImpl());
+    auto& copy_queue =
+        static_cast<VkCopyQueue&>(device.GetCopyQueue());
+
+    constexpr size_t element_count = 16;
+    constexpr size_t byte_size = sizeof(uint32) * element_count;
+    std::array<uint32, element_count> first_values{};
+    std::array<uint32, element_count> expected{};
+    std::array<uint32, element_count> readback{};
+    for (uint32 index = 0; index < expected.size(); ++index) {
+        first_values[index] = 0x15A00000u + index * 19u + 3u;
+        expected[index]     = 0x15B00000u + index * 37u + 9u;
+    }
+
+    BufferRef destination = device.CreateBuffer<uint32>(
+        "phase15b_io_copy_destination",
+        element_count,
+        EBufferUsageFlags::TRANSFER_SRC |
+            EBufferUsageFlags::TRANSFER_DST
+    );
+    FenceRef done = device.CreateFence();
+    NativeSubmissionCapture native_capture{};
+    {
+        ScopedNativeSubmissionObserver native_observer(native_capture);
+        VulkanStorage storage(*vulkan_device, copy_queue);
+
+        storage.Enqueue(
+            first_values.data(),
+            0,
+            ResourceCast(destination.Get()),
+            0,
+            byte_size
+        );
+        storage.EnqueueSignal(done, 1);
+        storage.Commit();
+        if (ResourceCast(done.Get())->HostWait(1) != VK_SUCCESS) {
+            throw std::runtime_error(
+                "first Vulkan storage Copy commit did not signal completion"
+            );
+        }
+        RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
+
+        // The first session is now terminal. A second Enqueue must recycle it
+        // without dropping the newly staged command or signal.
+        storage.Enqueue(
+            expected.data(),
+            0,
+            ResourceCast(destination.Get()),
+            0,
+            byte_size
+        );
+        storage.EnqueueSignal(done, 2);
+        storage.Commit();
+        if (ResourceCast(done.Get())->HostWait(2) != VK_SUCCESS) {
+            throw std::runtime_error(
+                "second Vulkan storage Copy commit did not signal completion"
+            );
+        }
+        RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
+    }
+
+    if (native_capture.Overflowed() || native_capture.Count() != 2) {
+        throw std::runtime_error(
+            "Vulkan storage commits did not issue exactly two native submits"
+        );
+    }
+    const uint32 submission_thread_id =
+        native_capture.Event(0).thread_id;
+    for (size_t index = 0; index < native_capture.Count(); ++index) {
+        const VulkanNativeSubmissionEvent& event =
+            native_capture.Event(index);
+        if (event.queue != EQueueType::Copy ||
+            event.thread_role != ERHIThreadRole::Submission ||
+            event.thread_id != submission_thread_id ||
+            event.thread_id == Platform::GetCurrentThreadID() ||
+            !event.outcome.WasSubmitted()) {
+            throw std::runtime_error(
+                "Vulkan storage Copy commit escaped the unified "
+                "Submission owner"
+            );
+        }
+    }
+    if (ResourceCast(done.Get())->IsRejected(1) ||
+        ResourceCast(done.Get())->IsRejected(2) ||
+        ResourceCast(done.Get())->IsFailed()) {
+        throw std::runtime_error(
+            "Vulkan storage Copy signals were terminalized incorrectly"
+        );
+    }
+
+    CommandList verify(EQueueType::Copy);
+    verify.CopyFrom(
+        destination->GetView(),
+        WritableBytes(readback),
+        "Phase15BIOCopyReadback"
+    );
+    RHIExecutor::Get().Submit(
+        EQueueType::Copy,
+        verify.Submit(),
+        ERHIExecSubmitFlags::FlushGPU
+    );
+    RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
+    if (readback != expected) {
+        throw std::runtime_error(
+            "Vulkan storage unified Copy submission readback mismatch"
+        );
+    }
+
+    LOG_INFO(
+        "[TESTCASE][PASS] name=VulkanStorageUnifiedCopySubmission "
+        "commits=2 signals=2 native_submit=2 native_owner=Submission "
+        "session_recycle=verified readback=verified"
     );
 }
 
@@ -3599,7 +4085,12 @@ void RunShutdownDependencyCancellation() {
     std::atomic<uint32> callbacks{0};
     std::atomic<uint32> success_callbacks{0};
     std::atomic<bool>   sync_returned{false};
-    std::binary_semaphore sync_started{0};
+    NativeSubmissionCapture        native_capture{};
+    ScopedNativeSubmissionObserver native_observer(native_capture);
+    CopyDependencyWaitCapture      copy_wait_capture{};
+    ScopedDependencyWaitObserver   wait_observer(copy_wait_capture);
+    BackendSyncWaitCapture         sync_wait_capture{};
+    ScopedBackendSyncWaitObserver  sync_wait_observer(sync_wait_capture);
 
     CommandList graphics(EQueueType::Graphics);
     graphics.AddCallback([&] {
@@ -3623,26 +4114,35 @@ void RunShutdownDependencyCancellation() {
     copy_submit.Wait(copy_dependency.Get(), 1).Signal(copy_done.Get(), 1);
 
     RHIExecutor::Get().Submit(
-        EQueueType::Graphics,
-        std::move(graphics_submit),
-        ERHIExecSubmitFlags::FlushGPU
-    );
-    RHIExecutor::Get().Submit(
         EQueueType::Copy,
         std::move(copy_submit),
         ERHIExecSubmitFlags::FlushGPU
     );
+    if (!copy_wait_capture.entered.try_acquire_for(5s) ||
+        copy_wait_capture.count.load(std::memory_order_acquire) != 1 ||
+        copy_wait_capture.wrong_owner.load(std::memory_order_acquire) ||
+        native_capture.Count() != 0) {
+        throw std::runtime_error(
+            "Copy did not enter its unpublished dependency wait on the sole "
+            "Submission owner"
+        );
+    }
+    RHIExecutor::Get().Submit(
+        EQueueType::Graphics,
+        std::move(graphics_submit),
+        ERHIExecSubmitFlags::FlushGPU
+    );
 
     std::jthread sync_waiter([&] {
-        sync_started.release();
         RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
         sync_returned.store(true, std::memory_order_release);
     });
-    sync_started.acquire();
-    std::this_thread::sleep_for(100ms);
-    if (sync_returned.load(std::memory_order_acquire)) {
+    if (!sync_wait_capture.entered.try_acquire_for(5s) ||
+        sync_wait_capture.count.load(std::memory_order_acquire) != 1 ||
+        sync_returned.load(std::memory_order_acquire)) {
         throw std::runtime_error(
-            "Sync returned before unpublished dependencies were cancelled"
+            "concurrent Sync was not registered behind the unpublished "
+            "dependency wait"
         );
     }
 
@@ -3672,10 +4172,17 @@ void RunShutdownDependencyCancellation() {
             "shutdown dependency cancellation did not release concurrent Sync"
         );
     }
+    if (native_capture.Count() != 0) {
+        throw std::runtime_error(
+            "shutdown-cancelled dependencies reached native submit"
+        );
+    }
 
     LOG_INFO(
         "[TESTCASE][PASS] name=ShutdownDependencyCancellation "
-        "queues=Graphics,Copy dependency=unpublished concurrent_sync=drained"
+        "queues=Copy,Graphics copy_wait=entered "
+        "dependency=unpublished native_submit=0 sync_wait=registered "
+        "concurrent_sync=drained"
     );
 }
 
@@ -3764,6 +4271,8 @@ int main(int argc, const char** argv) {
         RunContinuousFrameInFlightRetirement();
         RunRecoverableCopyDependencyRejection();
         RunCrossQueueTopologyBatch();
+        RunDirectCopyExecuteRejected();
+        RunVulkanStorageUnifiedCopySubmission();
         RunAsyncQueueParallelTranslateSmoke();
         RunParallelTranslateRecoverableRejection();
         RunRuntimeRejectCompletionOwnership();

--- a/source/test/RHIParallelRecordVulkanTest.cpp
+++ b/source/test/RHIParallelRecordVulkanTest.cpp
@@ -47,39 +47,15 @@ constexpr uint32 kHeavyCopyCount = kHeavyCopiesPerWave * 2;
 
 class TranslateProbeCommand final : public VkCustomDispatchCmd {
 public:
-    explicit TranslateProbeCommand(std::binary_semaphore* _translated) :
-        translated(_translated) {}
+    explicit TranslateProbeCommand(
+        std::binary_semaphore* _translated,
+        EQueueType             _queue = EQueueType::Graphics
+    ) :
+        translated(_translated),
+        queue(_queue) {}
 
     void Execute(const VkDispatchContext&) const override {
         translated->release();
-    }
-
-    EQueueType GetQueueType() const override {
-        return EQueueType::Graphics;
-    }
-
-private:
-    std::span<const ResourceUsage> GetResourceUsages() const override {
-        return {};
-    }
-
-    std::binary_semaphore* translated;
-};
-
-class BlockingTranslateProbeCommand final : public VkCustomDispatchCmd {
-public:
-    BlockingTranslateProbeCommand(
-        EQueueType             _queue,
-        std::binary_semaphore* _entered,
-        std::binary_semaphore* _release
-    ) :
-        queue(_queue),
-        entered(_entered),
-        release(_release) {}
-
-    void Execute(const VkDispatchContext&) const override {
-        entered->release();
-        release->acquire();
     }
 
     EQueueType GetQueueType() const override {
@@ -91,9 +67,55 @@ private:
         return {};
     }
 
+    std::binary_semaphore* translated;
     EQueueType             queue;
-    std::binary_semaphore* entered;
-    std::binary_semaphore* release;
+};
+
+class BlockingTranslateProbeCommand final : public VkCustomDispatchCmd {
+public:
+    BlockingTranslateProbeCommand(
+        EQueueType               _queue,
+        std::binary_semaphore*   _entered,
+        std::binary_semaphore*   _release,
+        std::atomic<bool>*       _finished                      = nullptr,
+        const std::atomic<bool>* _predecessor_finished          = nullptr,
+        std::atomic<bool>*       _observed_predecessor_finished = nullptr
+    ) :
+        queue(_queue),
+        entered(_entered),
+        release(_release),
+        finished(_finished),
+        predecessor_finished(_predecessor_finished),
+        observed_predecessor_finished(_observed_predecessor_finished) {}
+
+    void Execute(const VkDispatchContext&) const override {
+        if (predecessor_finished != nullptr && observed_predecessor_finished != nullptr) {
+            observed_predecessor_finished->store(
+                predecessor_finished->load(std::memory_order_acquire), std::memory_order_release
+            );
+        }
+        entered->release();
+        release->acquire();
+        if (finished != nullptr) {
+            finished->store(true, std::memory_order_release);
+        }
+    }
+
+    EQueueType GetQueueType() const override {
+        return queue;
+    }
+
+private:
+    std::span<const ResourceUsage> GetResourceUsages() const override {
+        return {};
+    }
+
+    EQueueType               queue;
+    std::binary_semaphore*   entered;
+    std::binary_semaphore*   release;
+    std::atomic<bool>*       finished;
+    const std::atomic<bool>* predecessor_finished;
+    std::atomic<bool>*       observed_predecessor_finished;
 };
 
 class ThrowingTranslateProbeCommand final : public VkCustomDispatchCmd {
@@ -419,7 +441,8 @@ void ValidateArguments(int _argc, const char** _argv) {
         const std::string_view argument = _argv[index];
         if (argument != "--parallel" && argument != "--inject-worker-failure" &&
             argument != "--production-gate" && argument != "--production-heavy" &&
-            argument != "--inject-translate-failure") {
+            argument != "--inject-translate-failure" &&
+            argument != "--inject-multi-segment-translate-failure") {
             throw std::invalid_argument("unsupported argument: " + std::string(argument));
         }
     }
@@ -439,6 +462,12 @@ void ValidateArguments(int _argc, const char** _argv) {
         HasArgument(_argc, _argv, "--inject-worker-failure")) {
         throw std::invalid_argument("--inject-translate-failure cannot be combined with "
                                     "--inject-worker-failure");
+    }
+    if (HasArgument(_argc, _argv, "--inject-multi-segment-translate-failure") &&
+        (HasArgument(_argc, _argv, "--inject-worker-failure") ||
+         HasArgument(_argc, _argv, "--inject-translate-failure"))) {
+        throw std::invalid_argument("--inject-multi-segment-translate-failure cannot be combined with "
+                                    "another fault injection");
     }
 }
 
@@ -3235,6 +3264,611 @@ void RunAsyncQueueParallelTranslateSmoke() {
     );
 }
 
+void RunMultiSegmentCompletionAggregateCpuProbe() {
+    const VulkanMultiSegmentCompletionProbeResult result = RunVulkanMultiSegmentCompletionProbeForTesting();
+    if (!result.suffix_retirement_deferred_callbacks || !result.prefix_retirement_completed_callbacks ||
+        !result.repeated_retirement_suppressed || result.ordinary_callback_count != 1 ||
+        result.success_callback_count != 0) {
+        throw std::runtime_error("multi-segment completion aggregate CPU probe violated callback ordering");
+    }
+
+    LOG_INFO("[TESTCASE][PASS] name=MultiSegmentCompletionAggregateCpuProbe "
+             "suffix_first=deferred prefix_second=ordinary1_success0 replay=0");
+}
+
+void RunMultiSegmentSourceExecution() {
+    using namespace std::chrono_literals;
+
+    auto&                  device            = RenderDevice::Get();
+    const RHIQueueTopology topology          = device.GetQueueTopology();
+    constexpr uint64       async_queue_scope = 0x50483135434D554Cull;
+    if (!topology.graphics.available || !topology.compute.available) {
+        LOG_INFO(
+            "[TESTCASE][SKIP] name=MultiSegmentSourceExecution "
+            "reason=queue_unavailable graphics_native={} compute_native={}",
+            topology.graphics.native_queue_id,
+            topology.compute.native_queue_id
+        );
+        return;
+    }
+
+    const bool distinct_native = topology.graphics.native_queue_id != topology.compute.native_queue_id;
+    SourceSubmissionCapture        source_capture(async_queue_scope);
+    ScopedSourceSubmissionObserver source_observer(source_capture);
+    NativeSubmissionCapture        native_capture{};
+    ScopedNativeSubmissionObserver native_observer(native_capture);
+    FenceRef                       source_done = device.CreateFence();
+    std::atomic<uint32>            ordinary_callbacks{0};
+    std::atomic<uint32>            success_callbacks{0};
+    std::binary_semaphore          graphics_entered{0};
+    std::binary_semaphore          compute_entered{0};
+    std::binary_semaphore          release_graphics{0};
+    std::binary_semaphore          release_compute{0};
+    OneShotSemaphoreRelease        release_graphics_guard(release_graphics);
+    OneShotSemaphoreRelease        release_compute_guard(release_compute);
+    std::atomic<bool>              graphics_translate_finished{false};
+    std::atomic<bool>              compute_observed_graphics_finished{false};
+    const uint32                   main_thread_id = Platform::GetCurrentThreadID();
+
+    try {
+        CommandList source(EQueueType::Graphics);
+        source.SetResourceStateOwnership(ERHIResourceStateOwnership::Explicit);
+        source.AddCustomCommand(
+            MakeUnique<BlockingTranslateProbeCommand>(
+                EQueueType::Graphics, &graphics_entered, &release_graphics, &graphics_translate_finished
+            ),
+            "MultiSegmentGraphicsTranslateProbe"
+        );
+        source.AddCustomCommand(
+            MakeUnique<BlockingTranslateProbeCommand>(
+                EQueueType::Compute,
+                &compute_entered,
+                &release_compute,
+                nullptr,
+                &graphics_translate_finished,
+                &compute_observed_graphics_finished
+            ),
+            "MultiSegmentComputeTranslateProbe"
+        );
+        source.AddCallback([&] {
+            ordinary_callbacks.fetch_add(1, std::memory_order_relaxed);
+        });
+        source.AddSuccessCallback([&] {
+            success_callbacks.fetch_add(1, std::memory_order_relaxed);
+        });
+
+        CmdSubmit submit = source.Submit();
+        submit.SetTranslateExecutionClass(ERHITranslateExecutionClass::Parallel);
+        submit.SetResourceStateOwnership(ERHIResourceStateOwnership::Explicit);
+        submit.async_queue_scope = async_queue_scope;
+        submit.segments          = {
+            RHISubmitSegment{EQueueType::Graphics, 0, 1},
+            RHISubmitSegment{EQueueType::Compute, 1, 2},
+        };
+        submit.Signal(source_done.Get(), 1);
+
+        Array<RHIBackendSubmissionBatchEntry> batch{};
+        batch.emplace_back(EQueueType::Graphics, std::move(submit));
+        RHIExecutor::Get().Submit(std::move(batch), ERHIExecSubmitFlags::FlushGPU);
+
+        if (!graphics_entered.try_acquire_for(5s)) {
+            throw std::runtime_error("multi-segment Graphics Translate did not enter");
+        }
+        if (distinct_native) {
+            if (!compute_entered.try_acquire_for(5s)) {
+                throw std::runtime_error("distinct-native multi-segment Translate did not enter "
+                                         "Graphics and Compute in one ready wave");
+            }
+        }
+
+        release_graphics_guard.Release();
+        if (!distinct_native && !compute_entered.try_acquire_for(5s)) {
+            throw std::runtime_error("native-alias multi-segment Translate did not advance to "
+                                     "Compute after Graphics release");
+        }
+        const bool compute_saw_graphics_finished =
+            compute_observed_graphics_finished.load(std::memory_order_acquire);
+        if (!distinct_native && !compute_saw_graphics_finished) {
+            throw std::runtime_error(
+                "native-alias Compute Translate entered before Graphics Translate returned"
+            );
+        }
+        release_compute_guard.Release();
+        RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
+
+        if (ResourceCast(source_done.Get())->HostWait(1) != VK_SUCCESS ||
+            ResourceCast(source_done.Get())->IsRejected(1) || ResourceCast(source_done.Get())->IsFailed()) {
+            throw std::runtime_error("multi-segment source signal did not complete successfully");
+        }
+        if (ordinary_callbacks.load(std::memory_order_acquire) != 1 ||
+            success_callbacks.load(std::memory_order_acquire) != 1) {
+            throw std::runtime_error("multi-segment source aggregate callbacks did not retire "
+                                     "exactly once");
+        }
+
+        if (source_capture.Overflowed() || source_capture.Count() != 2) {
+            throw std::runtime_error("multi-segment source observer did not report exactly two "
+                                     "executable segments");
+        }
+        constexpr std::array expected_queues{
+            EQueueType::Graphics,
+            EQueueType::Compute,
+        };
+        const uint64 batch_sequence = source_capture.Event(0).batch_sequence;
+        if (batch_sequence == 0) {
+            throw std::runtime_error("multi-segment source observer reported an invalid batch");
+        }
+        for (size_t index = 0; index < expected_queues.size(); ++index) {
+            const VulkanSourceSubmissionEvent& event = source_capture.Event(index);
+            if (event.batch_sequence != batch_sequence || event.source_index != index ||
+                event.original_source_index != 0 || event.source_segment_index != index ||
+                event.source_segment_count != 2 || event.queue != expected_queues[index] ||
+                event.async_queue_scope != async_queue_scope ||
+                event.cross_native_predecessor_wait != (index == 1 && distinct_native)) {
+                throw std::runtime_error("multi-segment source observer lost stable source or "
+                                         "segment identity");
+            }
+        }
+
+        if (native_capture.Overflowed() || native_capture.Count() != 2) {
+            throw std::runtime_error("multi-segment source did not issue exactly two native submits");
+        }
+        const uint32 submission_thread_id = native_capture.Event(0).thread_id;
+        for (size_t index = 0; index < expected_queues.size(); ++index) {
+            const VulkanNativeSubmissionEvent& event = native_capture.Event(index);
+            if (event.queue != expected_queues[index] || event.thread_role != ERHIThreadRole::Submission ||
+                event.thread_id != submission_thread_id || event.thread_id == main_thread_id ||
+                !event.outcome.WasSubmitted()) {
+                throw std::runtime_error("multi-segment native submission escaped stable "
+                                         "Graphics-to-Compute Submission ownership");
+            }
+        }
+        if ((native_capture.Event(0).native_queue_handle == native_capture.Event(1).native_queue_handle) !=
+            !distinct_native) {
+            throw std::runtime_error("multi-segment native observer disagrees with queue topology");
+        }
+
+        RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
+        if (source_capture.Count() != 2 || native_capture.Count() != 2 ||
+            ordinary_callbacks.load(std::memory_order_acquire) != 1 ||
+            success_callbacks.load(std::memory_order_acquire) != 1) {
+            throw std::runtime_error("a second Sync replayed multi-segment submission or callbacks");
+        }
+    } catch (...) {
+        const std::exception_ptr failure = std::current_exception();
+        release_graphics_guard.Release();
+        release_compute_guard.Release();
+        try {
+            RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
+        } catch (...) {
+            std::terminate();
+        }
+        std::rethrow_exception(failure);
+    }
+
+    LOG_INFO(
+        "[TESTCASE][PASS] name=MultiSegmentSourceExecution "
+        "source=1 segments=2 queues=Graphics,Compute native_alias={} "
+        "first_ready_lanes={} observed_submit_order=G,C "
+        "source_segments=0:0/2,0:1/2 predecessor_waits={} "
+        "compute_saw_graphics_finished={} "
+        "native_owner=Submission callbacks=exactly_once signal=success replay=0",
+        !distinct_native,
+        distinct_native ? "G,C" : "G",
+        distinct_native ? 1 : 0,
+        compute_observed_graphics_finished.load(std::memory_order_acquire)
+    );
+}
+
+void RunMultiSegmentCopyRoundTrip() {
+    auto&                  device            = RenderDevice::Get();
+    const RHIQueueTopology topology          = device.GetQueueTopology();
+    constexpr uint64       async_queue_scope = 0x50483135434F5059ull;
+    if (!topology.graphics.available || !topology.copy.available) {
+        LOG_INFO(
+            "[TESTCASE][SKIP] name=MultiSegmentCopyRoundTrip "
+            "reason=copy_queue_unavailable graphics_native={} copy_native={}",
+            topology.graphics.native_queue_id,
+            topology.copy.native_queue_id
+        );
+        return;
+    }
+
+    constexpr size_t        element_count = 32;
+    const EBufferUsageFlags usage         = EBufferUsageFlags::TRANSFER_SRC | EBufferUsageFlags::TRANSFER_DST;
+    BufferRef source     = device.CreateBuffer<uint32>("multi_segment_copy_source", element_count, usage);
+    BufferRef copy_stage = device.CreateBuffer<uint32>("multi_segment_copy_stage", element_count, usage);
+    std::array<uint32, element_count> expected{};
+    std::array<uint32, element_count> readback{};
+    for (uint32 index = 0; index < expected.size(); ++index) {
+        expected[index] = 0x15C00000u + index * 59u + 11u;
+    }
+
+    const bool graphics_copy_alias = topology.graphics.native_queue_id == topology.copy.native_queue_id;
+    SourceSubmissionCapture        source_capture(async_queue_scope);
+    ScopedSourceSubmissionObserver source_observer(source_capture);
+    NativeSubmissionCapture        native_capture{};
+    ScopedNativeSubmissionObserver native_observer(native_capture);
+    FenceRef                       source_done = device.CreateFence();
+    std::atomic<uint32>            ordinary_callbacks{0};
+    std::atomic<uint32>            success_callbacks{0};
+    const uint32                   main_thread_id = Platform::GetCurrentThreadID();
+
+    CommandList source_commands(EQueueType::Graphics);
+    source_commands.SetTranslateExecutionClass(ERHITranslateExecutionClass::Parallel);
+    source_commands.SetResourceStateOwnership(ERHIResourceStateOwnership::Explicit);
+
+    source_commands.CopyFrom(OwnedBytes(expected), source->GetView(), "MultiSegmentCopyUpload");
+    source_commands.ExportResourcesToQueue(
+        EQueueType::Copy, {}, Array<ExportBuffer>{{source->GetView(), EBufferState::TRANSFER}}
+    );
+
+    source_commands.ImportResourcesFromQueue(
+        EQueueType::Graphics, {}, Array<ImportBuffer>{{source->GetView(), EBufferState::TRANSFER}}
+    );
+    source_commands.CopyFrom(source->GetView(), copy_stage->GetView(), "MultiSegmentCopyNativeCopy");
+    source_commands.ExportResourcesToQueue(
+        EQueueType::Graphics, {}, Array<ExportBuffer>{{copy_stage->GetView(), EBufferState::TRANSFER}}
+    );
+
+    source_commands.ImportResourcesFromQueue(
+        EQueueType::Copy, {}, Array<ImportBuffer>{{copy_stage->GetView(), EBufferState::TRANSFER}}
+    );
+    source_commands.CopyFrom(copy_stage->GetView(), WritableBytes(readback), "MultiSegmentCopyReadback");
+    source_commands.AddCallback([&] {
+        ordinary_callbacks.fetch_add(1, std::memory_order_relaxed);
+    });
+    source_commands.AddSuccessCallback([&] {
+        success_callbacks.fetch_add(1, std::memory_order_relaxed);
+    });
+
+    CmdSubmit submit = source_commands.Submit();
+    submit.SetTranslateExecutionClass(ERHITranslateExecutionClass::Parallel);
+    submit.SetResourceStateOwnership(ERHIResourceStateOwnership::Explicit);
+    submit.async_queue_scope = async_queue_scope;
+    submit.segments          = {
+        RHISubmitSegment{EQueueType::Graphics, 0, 2},
+        RHISubmitSegment{EQueueType::Copy, 2, 5},
+        RHISubmitSegment{EQueueType::Graphics, 5, 7},
+    };
+    submit.Signal(source_done.Get(), 1);
+
+    Array<RHIBackendSubmissionBatchEntry> batch{};
+    batch.emplace_back(EQueueType::Graphics, std::move(submit));
+    RHIExecutor::Get().Submit(std::move(batch), ERHIExecSubmitFlags::FlushGPU);
+    RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
+
+    if (readback != expected) {
+        throw std::runtime_error("multi-segment Copy source GPU readback mismatch");
+    }
+    if (ResourceCast(source_done.Get())->HostWait(1) != VK_SUCCESS ||
+        ResourceCast(source_done.Get())->IsRejected(1) || ResourceCast(source_done.Get())->IsFailed()) {
+        throw std::runtime_error("multi-segment Copy source signal did not complete successfully");
+    }
+    if (ordinary_callbacks.load(std::memory_order_acquire) != 1 ||
+        success_callbacks.load(std::memory_order_acquire) != 1) {
+        throw std::runtime_error("multi-segment Copy source callbacks did not retire exactly once");
+    }
+
+    constexpr std::array expected_queues{
+        EQueueType::Graphics,
+        EQueueType::Copy,
+        EQueueType::Graphics,
+    };
+    if (source_capture.Overflowed() || source_capture.Count() != expected_queues.size()) {
+        throw std::runtime_error("multi-segment Copy source observer did not report three segments");
+    }
+    const uint64 batch_sequence = source_capture.Event(0).batch_sequence;
+    if (batch_sequence == 0) {
+        throw std::runtime_error("multi-segment Copy source observer reported an invalid batch");
+    }
+    for (size_t index = 0; index < expected_queues.size(); ++index) {
+        const VulkanSourceSubmissionEvent& event                     = source_capture.Event(index);
+        const bool                         expected_predecessor_wait = index != 0 && !graphics_copy_alias;
+        if (event.batch_sequence != batch_sequence || event.source_index != index ||
+            event.original_source_index != 0 || event.source_segment_index != index ||
+            event.source_segment_count != expected_queues.size() || event.queue != expected_queues[index] ||
+            event.async_queue_scope != async_queue_scope ||
+            event.cross_native_predecessor_wait != expected_predecessor_wait) {
+            throw std::runtime_error(
+                "multi-segment Copy source observer lost stable segment identity or dependency"
+            );
+        }
+    }
+
+    if (native_capture.Overflowed() || native_capture.Count() != expected_queues.size()) {
+        throw std::runtime_error("multi-segment Copy source did not issue three native submits");
+    }
+    const uint32 submission_thread_id = native_capture.Event(0).thread_id;
+    for (size_t index = 0; index < expected_queues.size(); ++index) {
+        const VulkanNativeSubmissionEvent& event = native_capture.Event(index);
+        if (event.queue != expected_queues[index] || event.thread_role != ERHIThreadRole::Submission ||
+            event.thread_id != submission_thread_id || event.thread_id == main_thread_id ||
+            !event.outcome.WasSubmitted()) {
+            throw std::runtime_error(
+                "multi-segment Copy native submits lost stable Submission order or ownership"
+            );
+        }
+    }
+    if ((native_capture.Event(0).native_queue_handle == native_capture.Event(1).native_queue_handle) !=
+            graphics_copy_alias ||
+        native_capture.Event(0).native_queue_handle != native_capture.Event(2).native_queue_handle) {
+        throw std::runtime_error("multi-segment Copy native observer disagrees with queue topology");
+    }
+
+    RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
+    if (source_capture.Count() != expected_queues.size() ||
+        native_capture.Count() != expected_queues.size() ||
+        ordinary_callbacks.load(std::memory_order_acquire) != 1 ||
+        success_callbacks.load(std::memory_order_acquire) != 1) {
+        throw std::runtime_error("a second Sync replayed multi-segment Copy work or callbacks");
+    }
+
+    LOG_INFO(
+        "[TESTCASE][PASS] name=MultiSegmentCopyRoundTrip "
+        "source=1 segments=3 queues=Graphics,Copy,Graphics native_alias={} "
+        "observed_submit_order=G,Copy,G source_segments=0:0/3,0:1/3,0:2/3 "
+        "predecessor_waits={} native_owner=Submission callbacks=exactly_once "
+        "signal=success readback=verified replay=0",
+        graphics_copy_alias,
+        graphics_copy_alias ? 0 : 2
+    );
+}
+
+void RunMultiSegmentRecoverableRejection() {
+    auto&                  device            = RenderDevice::Get();
+    const RHIQueueTopology topology          = device.GetQueueTopology();
+    constexpr uint64       async_queue_scope = 0x504831354D52454Aull;
+    if (!topology.graphics.available || !topology.compute.available) {
+        LOG_INFO(
+            "[TESTCASE][SKIP] name=MultiSegmentRecoverableRejection "
+            "reason=queue_unavailable graphics_native={} compute_native={}",
+            topology.graphics.native_queue_id,
+            topology.compute.native_queue_id
+        );
+        return;
+    }
+
+    const bool distinct_native     = topology.graphics.native_queue_id != topology.compute.native_queue_id;
+    FenceRef   rejected_dependency = device.CreateFence();
+    FenceRef   rejected_done       = device.CreateFence();
+    FenceRef   recovered_done      = device.CreateFence();
+    rejected_dependency->Reject(1);
+
+    std::atomic<uint32>            rejected_callbacks{0};
+    std::atomic<uint32>            rejected_success_callbacks{0};
+    std::atomic<uint32>            recovered_callbacks{0};
+    std::atomic<uint32>            recovered_success_callbacks{0};
+    std::binary_semaphore          graphics_translated{0};
+    std::binary_semaphore          compute_translated{0};
+    std::binary_semaphore          recovered_translated{0};
+    NativeSubmissionCapture        native_capture{};
+    ScopedNativeSubmissionObserver native_observer(native_capture);
+    const uint32                   main_thread_id = Platform::GetCurrentThreadID();
+
+    CommandList rejected(EQueueType::Graphics);
+    rejected.SetResourceStateOwnership(ERHIResourceStateOwnership::Explicit);
+    rejected.AddCustomCommand(
+        MakeUnique<TranslateProbeCommand>(&graphics_translated, EQueueType::Graphics),
+        "MultiSegmentRejectedGraphicsTranslateProbe"
+    );
+    rejected.AddCustomCommand(
+        MakeUnique<TranslateProbeCommand>(&compute_translated, EQueueType::Compute),
+        "MultiSegmentRejectedComputeTranslateProbe"
+    );
+    rejected.AddCallback([&] {
+        rejected_callbacks.fetch_add(1, std::memory_order_relaxed);
+    });
+    rejected.AddSuccessCallback([&] {
+        rejected_success_callbacks.fetch_add(1, std::memory_order_relaxed);
+    });
+
+    CmdSubmit rejected_submit = rejected.Submit();
+    rejected_submit.SetTranslateExecutionClass(ERHITranslateExecutionClass::Parallel);
+    rejected_submit.SetResourceStateOwnership(ERHIResourceStateOwnership::Explicit);
+    rejected_submit.async_queue_scope = async_queue_scope;
+    rejected_submit.segments          = {
+        RHISubmitSegment{EQueueType::Graphics, 0, 1},
+        RHISubmitSegment{EQueueType::Compute, 1, 2},
+    };
+    rejected_submit.Wait(rejected_dependency.Get(), 1);
+    rejected_submit.Signal(rejected_done.Get(), 1);
+
+    Array<RHIBackendSubmissionBatchEntry> rejected_batch{};
+    rejected_batch.emplace_back(EQueueType::Graphics, std::move(rejected_submit));
+    RHIExecutor::Get().Submit(std::move(rejected_batch), ERHIExecSubmitFlags::FlushGPU);
+    if (ResourceCast(rejected_done.Get())->HostWait(1) != VK_ERROR_UNKNOWN ||
+        !ResourceCast(rejected_done.Get())->IsRejected(1) || ResourceCast(rejected_done.Get())->IsFailed()) {
+        throw std::runtime_error("multi-segment rejected dependency did not reject the source signal");
+    }
+
+    const bool graphics_was_translated = graphics_translated.try_acquire();
+    const bool compute_was_translated  = compute_translated.try_acquire();
+    if (!graphics_was_translated || compute_was_translated != distinct_native) {
+        throw std::runtime_error("multi-segment recoverable rejection did not preserve "
+                                 "native-lane Translate wave semantics");
+    }
+
+    CommandList recovered(EQueueType::Graphics);
+    recovered.SetResourceStateOwnership(ERHIResourceStateOwnership::Explicit);
+    recovered.AddCustomCommand(
+        MakeUnique<TranslateProbeCommand>(&recovered_translated, EQueueType::Graphics),
+        "MultiSegmentRejectionRecoveryProbe"
+    );
+    recovered.AddCallback([&] {
+        recovered_callbacks.fetch_add(1, std::memory_order_relaxed);
+    });
+    recovered.AddSuccessCallback([&] {
+        recovered_success_callbacks.fetch_add(1, std::memory_order_relaxed);
+    });
+    CmdSubmit recovered_submit = recovered.Submit();
+    recovered_submit.SetTranslateExecutionClass(ERHITranslateExecutionClass::Parallel);
+    recovered_submit.SetResourceStateOwnership(ERHIResourceStateOwnership::Explicit);
+    recovered_submit.async_queue_scope = async_queue_scope;
+    recovered_submit.Signal(recovered_done.Get(), 1);
+    RHIExecutor::Get().Submit(
+        EQueueType::Graphics, std::move(recovered_submit), ERHIExecSubmitFlags::FlushGPU
+    );
+    RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
+
+    if (!recovered_translated.try_acquire() ||
+        ResourceCast(recovered_done.Get())->HostWait(1) != VK_SUCCESS ||
+        ResourceCast(recovered_done.Get())->IsRejected(1) || ResourceCast(recovered_done.Get())->IsFailed()) {
+        throw std::runtime_error("multi-segment dependency rejection latched the runtime");
+    }
+    if (rejected_callbacks.load(std::memory_order_acquire) != 1 ||
+        rejected_success_callbacks.load(std::memory_order_acquire) != 0 ||
+        recovered_callbacks.load(std::memory_order_acquire) != 1 ||
+        recovered_success_callbacks.load(std::memory_order_acquire) != 1) {
+        throw std::runtime_error("multi-segment aggregate callback retirement was not exactly once");
+    }
+    if (native_capture.Overflowed() || native_capture.Count() != 1) {
+        throw std::runtime_error("rejected multi-segment source reached native submit or recovery "
+                                 "did not submit exactly once");
+    }
+    const VulkanNativeSubmissionEvent& recovered_event = native_capture.Event(0);
+    if (recovered_event.queue != EQueueType::Graphics ||
+        recovered_event.thread_role != ERHIThreadRole::Submission ||
+        recovered_event.thread_id == main_thread_id || !recovered_event.outcome.WasSubmitted()) {
+        throw std::runtime_error("multi-segment rejection recovery escaped Submission ownership");
+    }
+
+    RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
+    if (native_capture.Count() != 1 || rejected_callbacks.load(std::memory_order_acquire) != 1 ||
+        rejected_success_callbacks.load(std::memory_order_acquire) != 0 ||
+        recovered_callbacks.load(std::memory_order_acquire) != 1 ||
+        recovered_success_callbacks.load(std::memory_order_acquire) != 1) {
+        throw std::runtime_error("a second Sync replayed multi-segment rejection retirement");
+    }
+
+    LOG_INFO(
+        "[TESTCASE][PASS] name=MultiSegmentRecoverableRejection "
+        "source=1 segments=2 dependency=rejected distinct_native={} "
+        "suffix_recorded={} native_rejected=0 "
+        "callbacks=ordinary1_success0 signal=rejected "
+        "native_accepted=1 recovered_callbacks=ordinary1_success1 "
+        "runtime=recovered replay=0",
+        distinct_native,
+        compute_was_translated
+    );
+}
+
+void RunMultiSegmentPrefixSubmitSuffixTranslateFailure() {
+    auto&            device            = RenderDevice::Get();
+    constexpr uint64 async_queue_scope = 0x50483135434D4844ull;
+
+    FenceRef                       source_done = device.CreateFence();
+    FenceRef                       later_done  = device.CreateFence();
+    std::atomic<uint32>            source_callbacks{0};
+    std::atomic<uint32>            source_success_callbacks{0};
+    std::atomic<uint32>            later_callbacks{0};
+    std::atomic<uint32>            later_success_callbacks{0};
+    std::binary_semaphore          prefix_translated{0};
+    SourceSubmissionCapture        source_capture(async_queue_scope);
+    ScopedSourceSubmissionObserver source_observer(source_capture);
+    NativeSubmissionCapture        native_capture{};
+    ScopedNativeSubmissionObserver native_observer(native_capture);
+    const uint32                   main_thread_id = Platform::GetCurrentThreadID();
+
+    CommandList source(EQueueType::Graphics);
+    source.SetResourceStateOwnership(ERHIResourceStateOwnership::Explicit);
+    source.AddCustomCommand(
+        MakeUnique<TranslateProbeCommand>(&prefix_translated, EQueueType::Graphics),
+        "MultiSegmentHardFailureAcceptedPrefix"
+    );
+    source.AddCustomCommand(
+        MakeUnique<ThrowingTranslateProbeCommand>(true), "MultiSegmentHardFailureThrowingSuffix"
+    );
+    source.AddCallback([&] {
+        source_callbacks.fetch_add(1, std::memory_order_relaxed);
+    });
+    source.AddSuccessCallback([&] {
+        source_success_callbacks.fetch_add(1, std::memory_order_relaxed);
+    });
+
+    CmdSubmit submit = source.Submit();
+    submit.SetTranslateExecutionClass(ERHITranslateExecutionClass::Parallel);
+    submit.SetResourceStateOwnership(ERHIResourceStateOwnership::Explicit);
+    submit.async_queue_scope = async_queue_scope;
+    submit.segments          = {
+        RHISubmitSegment{EQueueType::Graphics, 0, 1},
+        RHISubmitSegment{EQueueType::Graphics, 1, 2},
+    };
+    submit.Signal(source_done.Get(), 1);
+
+    Array<RHIBackendSubmissionBatchEntry> batch{};
+    batch.emplace_back(EQueueType::Graphics, std::move(submit));
+    RHIExecutor::Get().Submit(std::move(batch), ERHIExecSubmitFlags::FlushGPU);
+    RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
+
+    if (!prefix_translated.try_acquire()) {
+        throw std::runtime_error("multi-segment hard failure did not Translate the prefix");
+    }
+    if (!ResourceCast(source_done.Get())->IsFailed() || ResourceCast(source_done.Get())->IsRejected(1)) {
+        throw std::runtime_error("multi-segment hard failure did not fail the tail external signal");
+    }
+    if (source_callbacks.load(std::memory_order_acquire) != 1 ||
+        source_success_callbacks.load(std::memory_order_acquire) != 0) {
+        throw std::runtime_error("multi-segment hard failure did not aggregate source callbacks exactly once"
+        );
+    }
+    if (source_capture.Overflowed() || source_capture.Count() != 1) {
+        throw std::runtime_error(
+            "multi-segment hard failure did not publish exactly one accepted prefix source"
+        );
+    }
+    const VulkanSourceSubmissionEvent& source_event = source_capture.Event(0);
+    if (source_event.original_source_index != 0 || source_event.source_segment_index != 0 ||
+        source_event.source_segment_count != 2 || source_event.queue != EQueueType::Graphics) {
+        throw std::runtime_error("multi-segment hard failure lost accepted prefix source identity");
+    }
+    if (native_capture.Overflowed() || native_capture.Count() != 1) {
+        throw std::runtime_error("multi-segment hard failure did not native-submit exactly one prefix");
+    }
+    const VulkanNativeSubmissionEvent& native_event = native_capture.Event(0);
+    if (native_event.queue != EQueueType::Graphics ||
+        native_event.thread_role != ERHIThreadRole::Submission || native_event.thread_id == main_thread_id ||
+        !native_event.outcome.WasSubmitted()) {
+        throw std::runtime_error("multi-segment hard-failure prefix escaped native Submission ownership");
+    }
+
+    CommandList later(EQueueType::Graphics);
+    later.AddCallback([&] {
+        later_callbacks.fetch_add(1, std::memory_order_relaxed);
+    });
+    later.AddSuccessCallback([&] {
+        later_success_callbacks.fetch_add(1, std::memory_order_relaxed);
+    });
+    CmdSubmit later_submit = later.Submit();
+    later_submit.Signal(later_done.Get(), 1);
+    RHIExecutor::Get().Submit(EQueueType::Graphics, std::move(later_submit), ERHIExecSubmitFlags::FlushGPU);
+    RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
+
+    if (!ResourceCast(later_done.Get())->IsFailed() || ResourceCast(later_done.Get())->IsRejected(1)) {
+        throw std::runtime_error("multi-segment hard failure did not latch a later batch");
+    }
+    if (later_callbacks.load(std::memory_order_acquire) != 1 ||
+        later_success_callbacks.load(std::memory_order_acquire) != 0) {
+        throw std::runtime_error("multi-segment hard latch did not retire later callbacks exactly once");
+    }
+
+    RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
+    if (native_capture.Count() != 1 || source_capture.Count() != 1 ||
+        source_callbacks.load(std::memory_order_acquire) != 1 ||
+        source_success_callbacks.load(std::memory_order_acquire) != 0 ||
+        later_callbacks.load(std::memory_order_acquire) != 1 ||
+        later_success_callbacks.load(std::memory_order_acquire) != 0) {
+        throw std::runtime_error("multi-segment hard failure replayed submission or callback retirement");
+    }
+
+    LOG_INFO("[TESTCASE][PASS] name=MultiSegmentPrefixSubmitSuffixTranslateFailure "
+             "source=1 segments=2 queues=Graphics,Graphics "
+             "prefix_translated=true source_submitted=0:0/2 "
+             "native_accepted_prefix=1 native_owner=Submission "
+             "callbacks=ordinary1_success0 signal=failed "
+             "later_callbacks=ordinary1_success0 hard_latch=later_batch_failed replay=0");
+}
+
 void RunParallelTranslateFailureRetirement() {
     auto&                  device            = RenderDevice::Get();
     const RHIQueueTopology topology          = device.GetQueueTopology();
@@ -4226,6 +4860,8 @@ int main(int argc, const char** argv) {
             HasArgument(argc, argv, "--production-gate") || production_heavy;
         const bool inject_translate_failure =
             HasArgument(argc, argv, "--inject-translate-failure");
+        const bool inject_multi_segment_translate_failure =
+            HasArgument(argc, argv, "--inject-multi-segment-translate-failure");
 
         LogSystem::Init();
         ConfigManager::GetInstance().Init(std::filesystem::current_path());
@@ -4245,9 +4881,18 @@ int main(int argc, const char** argv) {
             .parallel_record_worker_throw_trigger = inject_worker_failure ? 1u : 0u,
         });
         render_device_initialized = true;
+        RunMultiSegmentCompletionAggregateCpuProbe();
 
         if (inject_translate_failure) {
             RunParallelTranslateFailureRetirement();
+            RenderDevice::Dispose();
+            render_device_initialized = false;
+            TaskSystem::ShutDown();
+            task_system_initialized = false;
+            return 0;
+        }
+        if (inject_multi_segment_translate_failure) {
+            RunMultiSegmentPrefixSubmitSuffixTranslateFailure();
             RenderDevice::Dispose();
             render_device_initialized = false;
             TaskSystem::ShutDown();
@@ -4274,6 +4919,9 @@ int main(int argc, const char** argv) {
         RunDirectCopyExecuteRejected();
         RunVulkanStorageUnifiedCopySubmission();
         RunAsyncQueueParallelTranslateSmoke();
+        RunMultiSegmentSourceExecution();
+        RunMultiSegmentCopyRoundTrip();
+        RunMultiSegmentRecoverableRejection();
         RunParallelTranslateRecoverableRejection();
         RunRuntimeRejectCompletionOwnership();
         PrimeGlobalTransientPoolForDispose();

--- a/source/test/RHIParallelRecordVulkanTest.cpp
+++ b/source/test/RHIParallelRecordVulkanTest.cpp
@@ -10,6 +10,7 @@
 #include "rhi/vulkan/VulkanCustomCommand.h"
 #include "rhi/vulkan/VulkanQueue.h"
 #include "rhi/vulkan/VulkanRHIResource.h"
+#include "rhi/vulkan/VulkanSubmissionDiagnostics.h"
 #include "taskgraph/TaskSystem.h"
 
 #include <algorithm>
@@ -62,6 +63,54 @@ private:
     std::binary_semaphore* translated;
 };
 
+class BlockingTranslateProbeCommand final : public VkCustomDispatchCmd {
+public:
+    BlockingTranslateProbeCommand(
+        EQueueType             _queue,
+        std::binary_semaphore* _entered,
+        std::binary_semaphore* _release
+    ) :
+        queue(_queue),
+        entered(_entered),
+        release(_release) {}
+
+    void Execute(const VkDispatchContext&) const override {
+        entered->release();
+        release->acquire();
+    }
+
+    EQueueType GetQueueType() const override {
+        return queue;
+    }
+
+private:
+    std::span<const ResourceUsage> GetResourceUsages() const override {
+        return {};
+    }
+
+    EQueueType             queue;
+    std::binary_semaphore* entered;
+    std::binary_semaphore* release;
+};
+
+class ThrowingTranslateProbeCommand final : public VkCustomDispatchCmd {
+public:
+    explicit ThrowingTranslateProbeCommand(bool) {}
+
+    void Execute(const VkDispatchContext&) const override {
+        throw std::runtime_error("injected outer Translate failure");
+    }
+
+    EQueueType GetQueueType() const override {
+        return EQueueType::Graphics;
+    }
+
+private:
+    std::span<const ResourceUsage> GetResourceUsages() const override {
+        return {};
+    }
+};
+
 class OneShotSemaphoreRelease final {
 public:
     explicit OneShotSemaphoreRelease(std::binary_semaphore& _semaphore) :
@@ -85,6 +134,71 @@ public:
 private:
     std::binary_semaphore& semaphore;
     bool                   armed{true};
+};
+
+class SourceSubmissionCapture final {
+public:
+    explicit SourceSubmissionCapture(uint64 _async_queue_scope) : async_queue_scope(_async_queue_scope) {}
+
+    static void Observe(void* _context, const VulkanSourceSubmissionEvent& _event) noexcept {
+        auto& capture = *static_cast<SourceSubmissionCapture*>(_context);
+        if (_event.async_queue_scope != capture.async_queue_scope) {
+            return;
+        }
+
+        const size_t index = capture.count.load(std::memory_order_relaxed);
+        if (index >= capture.events.size()) {
+            capture.overflow.store(true, std::memory_order_release);
+            return;
+        }
+        capture.events[index] = _event;
+        capture.count.store(index + 1, std::memory_order_release);
+    }
+
+    [[nodiscard]] size_t Count() const noexcept {
+        return count.load(std::memory_order_acquire);
+    }
+
+    [[nodiscard]] bool Overflowed() const noexcept {
+        return overflow.load(std::memory_order_acquire);
+    }
+
+    [[nodiscard]] const VulkanSourceSubmissionEvent& Event(size_t _index) const noexcept {
+        return events[_index];
+    }
+
+private:
+    uint64                                     async_queue_scope{0};
+    std::array<VulkanSourceSubmissionEvent, 3> events{};
+    std::atomic<size_t>                        count{0};
+    std::atomic<bool>                          overflow{false};
+};
+
+class ScopedSourceSubmissionObserver final {
+public:
+    explicit ScopedSourceSubmissionObserver(SourceSubmissionCapture& _capture) :
+        observer{
+            .context  = &_capture,
+            .callback = &SourceSubmissionCapture::Observe,
+        } {
+        if (!TryInstallVulkanSourceSubmissionObserver(&observer)) {
+            throw std::runtime_error("Vulkan source submission observer was already installed");
+        }
+        installed = true;
+    }
+
+    ~ScopedSourceSubmissionObserver() noexcept {
+        if (installed && !RemoveVulkanSourceSubmissionObserver(&observer)) {
+            std::terminate();
+        }
+    }
+
+    ScopedSourceSubmissionObserver(const ScopedSourceSubmissionObserver&)            = delete;
+    ScopedSourceSubmissionObserver& operator=(const ScopedSourceSubmissionObserver&) = delete;
+
+private:
+    VulkanSourceSubmissionObserver observer{};
+    bool                           installed{false};
 };
 
 template<size_t N>
@@ -115,7 +229,8 @@ void ValidateArguments(int _argc, const char** _argv) {
     for (int index = 1; index < _argc; ++index) {
         const std::string_view argument = _argv[index];
         if (argument != "--parallel" && argument != "--inject-worker-failure" &&
-            argument != "--production-gate" && argument != "--production-heavy") {
+            argument != "--production-gate" && argument != "--production-heavy" &&
+            argument != "--inject-translate-failure") {
             throw std::invalid_argument("unsupported argument: " + std::string(argument));
         }
     }
@@ -130,6 +245,11 @@ void ValidateArguments(int _argc, const char** _argv) {
     if (HasArgument(_argc, _argv, "--production-heavy") &&
         !HasArgument(_argc, _argv, "--parallel")) {
         throw std::invalid_argument("--production-heavy requires --parallel");
+    }
+    if (HasArgument(_argc, _argv, "--inject-translate-failure") &&
+        HasArgument(_argc, _argv, "--inject-worker-failure")) {
+        throw std::invalid_argument("--inject-translate-failure cannot be combined with "
+                                    "--inject-worker-failure");
     }
 }
 
@@ -2666,6 +2786,419 @@ void RunCrossQueueTopologyBatch() {
     );
 }
 
+void RunAsyncQueueParallelTranslateSmoke() {
+    using namespace std::chrono_literals;
+
+    const RHIQueueTopology topology = RenderDevice::Get().GetQueueTopology();
+    if (!topology.graphics.available || !topology.compute.available) {
+        LOG_INFO(
+            "[TESTCASE][SKIP] name=AsyncQueueParallelTranslateSmoke "
+            "graphics_native={} compute_native={} reason=queue_unavailable "
+            "cpu_seam=VulkanTranslateWaveScheduler",
+            topology.graphics.native_queue_id,
+            topology.compute.native_queue_id
+        );
+        return;
+    }
+    if (topology.graphics.native_queue_id == topology.compute.native_queue_id) {
+        LOG_INFO(
+            "[TESTCASE][SKIP] name=AsyncQueueParallelTranslateSmoke "
+            "graphics_native={} compute_native={} reason=native_queue_alias "
+            "cpu_seam=VulkanTranslateWaveScheduler",
+            topology.graphics.native_queue_id,
+            topology.compute.native_queue_id
+        );
+        return;
+    }
+
+    constexpr uint64                   async_queue_scope = 0x5048415345313541ull;
+    SourceSubmissionCapture            submission_capture(async_queue_scope);
+    ScopedSourceSubmissionObserver     submission_observer(submission_capture);
+    std::array<std::atomic<uint32>, 3> ordinary_callbacks{};
+    std::array<std::atomic<uint32>, 3> success_callbacks{};
+    std::binary_semaphore              graphics_front_entered{0};
+    std::binary_semaphore              graphics_tail_entered{0};
+    std::binary_semaphore              compute_later_entered{0};
+    std::binary_semaphore              release_graphics_front{0};
+    std::binary_semaphore              release_compute_later{0};
+    OneShotSemaphoreRelease            release_graphics_guard(release_graphics_front);
+    OneShotSemaphoreRelease            release_compute_guard(release_compute_later);
+
+    try {
+        CommandList graphics_front(EQueueType::Graphics);
+        graphics_front.SetResourceStateOwnership(ERHIResourceStateOwnership::Explicit);
+        graphics_front.AddCustomCommand(
+            MakeUnique<BlockingTranslateProbeCommand>(
+                EQueueType::Graphics, &graphics_front_entered, &release_graphics_front
+            ),
+            "AsyncQueueGraphicsFrontBlockingTranslateProbe"
+        );
+        graphics_front.AddCallback([&] {
+            ordinary_callbacks[0].fetch_add(1, std::memory_order_relaxed);
+        });
+        graphics_front.AddSuccessCallback([&] {
+            success_callbacks[0].fetch_add(1, std::memory_order_relaxed);
+        });
+        CmdSubmit graphics_front_submit = graphics_front.Submit();
+        graphics_front_submit.SetTranslateExecutionClass(ERHITranslateExecutionClass::Parallel);
+        graphics_front_submit.SetResourceStateOwnership(ERHIResourceStateOwnership::Explicit);
+        graphics_front_submit.async_queue_scope = async_queue_scope;
+
+        CommandList graphics_tail(EQueueType::Graphics);
+        graphics_tail.SetResourceStateOwnership(ERHIResourceStateOwnership::Explicit);
+        graphics_tail.AddCustomCommand(
+            MakeUnique<TranslateProbeCommand>(&graphics_tail_entered), "AsyncQueueGraphicsTailTranslateProbe"
+        );
+        graphics_tail.AddCallback([&] {
+            ordinary_callbacks[1].fetch_add(1, std::memory_order_relaxed);
+        });
+        graphics_tail.AddSuccessCallback([&] {
+            success_callbacks[1].fetch_add(1, std::memory_order_relaxed);
+        });
+        CmdSubmit graphics_tail_submit = graphics_tail.Submit();
+        graphics_tail_submit.SetTranslateExecutionClass(ERHITranslateExecutionClass::Parallel);
+        graphics_tail_submit.SetResourceStateOwnership(ERHIResourceStateOwnership::Explicit);
+        graphics_tail_submit.async_queue_scope = async_queue_scope;
+
+        CommandList compute_later(EQueueType::Compute);
+        compute_later.SetResourceStateOwnership(ERHIResourceStateOwnership::Explicit);
+        compute_later.AddCustomCommand(
+            MakeUnique<BlockingTranslateProbeCommand>(
+                EQueueType::Compute, &compute_later_entered, &release_compute_later
+            ),
+            "AsyncQueueComputeLaterBlockingTranslateProbe"
+        );
+        compute_later.AddCallback([&] {
+            ordinary_callbacks[2].fetch_add(1, std::memory_order_relaxed);
+        });
+        compute_later.AddSuccessCallback([&] {
+            success_callbacks[2].fetch_add(1, std::memory_order_relaxed);
+        });
+        CmdSubmit compute_later_submit = compute_later.Submit();
+        compute_later_submit.SetTranslateExecutionClass(ERHITranslateExecutionClass::Parallel);
+        compute_later_submit.SetResourceStateOwnership(ERHIResourceStateOwnership::Explicit);
+        compute_later_submit.async_queue_scope = async_queue_scope;
+
+        Array<RHIBackendSubmissionBatchEntry> submits{};
+        submits.emplace_back(EQueueType::Graphics, std::move(graphics_front_submit));
+        submits.emplace_back(EQueueType::Graphics, std::move(graphics_tail_submit));
+        submits.emplace_back(EQueueType::Compute, std::move(compute_later_submit));
+        RHIExecutor::Get().Submit(std::move(submits), ERHIExecSubmitFlags::FlushGPU);
+
+        const auto deadline                             = std::chrono::steady_clock::now() + 5s;
+        const bool graphics_front_translate_entered     = graphics_front_entered.try_acquire_until(deadline);
+        const bool compute_later_translate_entered      = compute_later_entered.try_acquire_until(deadline);
+        const bool graphics_tail_entered_before_release = graphics_tail_entered.try_acquire();
+        release_graphics_guard.Release();
+        release_compute_guard.Release();
+
+        RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
+        const bool graphics_tail_translate_entered =
+            graphics_tail_entered_before_release || graphics_tail_entered.try_acquire();
+
+        if (!graphics_front_translate_entered || !compute_later_translate_entered ||
+            graphics_tail_entered_before_release || !graphics_tail_translate_entered) {
+            throw std::runtime_error("ready native lane did not bypass a blocked same-native "
+                                     "successor while preserving its release gate");
+        }
+        for (size_t index = 0; index < ordinary_callbacks.size(); ++index) {
+            if (ordinary_callbacks[index].load(std::memory_order_acquire) != 1 ||
+                success_callbacks[index].load(std::memory_order_acquire) != 1) {
+                throw std::runtime_error("parallel Translate callbacks did not retire exactly once");
+            }
+        }
+
+        if (submission_capture.Overflowed() || submission_capture.Count() != 3) {
+            throw std::runtime_error("parallel Translate did not produce exactly three observed "
+                                     "source submissions");
+        }
+        constexpr std::array expected_queues{
+            EQueueType::Graphics,
+            EQueueType::Graphics,
+            EQueueType::Compute,
+        };
+        const uint64 observed_batch_sequence = submission_capture.Event(0).batch_sequence;
+        if (observed_batch_sequence == 0) {
+            throw std::runtime_error("Submission observer reported an invalid batch sequence");
+        }
+        for (size_t index = 0; index < expected_queues.size(); ++index) {
+            const VulkanSourceSubmissionEvent& event = submission_capture.Event(index);
+            if (event.source_index != index || event.queue != expected_queues[index] ||
+                event.batch_sequence != observed_batch_sequence) {
+                throw std::runtime_error("Submission owner did not preserve stable G,G,C source "
+                                         "order in one batch");
+            }
+        }
+
+        RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
+        for (size_t index = 0; index < ordinary_callbacks.size(); ++index) {
+            if (ordinary_callbacks[index].load(std::memory_order_acquire) != 1 ||
+                success_callbacks[index].load(std::memory_order_acquire) != 1) {
+                throw std::runtime_error("a second Sync replayed parallel Translate callbacks");
+            }
+        }
+    } catch (...) {
+        const std::exception_ptr failure = std::current_exception();
+        release_graphics_guard.Release();
+        release_compute_guard.Release();
+        try {
+            RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
+        } catch (...) {
+            std::terminate();
+        }
+        std::rethrow_exception(failure);
+    }
+
+    LOG_INFO(
+        "[TESTCASE][PASS] name=AsyncQueueParallelTranslateSmoke "
+        "graphics_native={} compute_native={} sources=3 batch=1 "
+        "source_order=G,G,C first_ready_lanes=G,C "
+        "observed_submit_order=G,G,C async_scope={} explicit_state=true "
+        "callbacks=exactly_once",
+        topology.graphics.native_queue_id,
+        topology.compute.native_queue_id,
+        async_queue_scope
+    );
+}
+
+void RunParallelTranslateFailureRetirement() {
+    auto&                  device            = RenderDevice::Get();
+    const RHIQueueTopology topology          = device.GetQueueTopology();
+    constexpr uint64       async_queue_scope = 0x5048313541464149ull;
+
+    FenceRef                           graphics_done = device.CreateFence();
+    FenceRef                           compute_done  = device.CreateFence();
+    FenceRef                           later_done    = device.CreateFence();
+    std::array<std::atomic<uint32>, 3> ordinary_callbacks{};
+    std::array<std::atomic<uint32>, 3> success_callbacks{};
+    std::binary_semaphore              compute_translated{0};
+
+    CommandList graphics(EQueueType::Graphics);
+    graphics.SetResourceStateOwnership(ERHIResourceStateOwnership::Explicit);
+    graphics.AddCustomCommand(
+        MakeUnique<ThrowingTranslateProbeCommand>(true), "InjectedOuterTranslateFailure"
+    );
+    graphics.AddCallback([&] {
+        ordinary_callbacks[0].fetch_add(1, std::memory_order_relaxed);
+    });
+    graphics.AddSuccessCallback([&] {
+        success_callbacks[0].fetch_add(1, std::memory_order_relaxed);
+    });
+    CmdSubmit graphics_submit = graphics.Submit();
+    graphics_submit.SetTranslateExecutionClass(ERHITranslateExecutionClass::Parallel);
+    graphics_submit.SetResourceStateOwnership(ERHIResourceStateOwnership::Explicit);
+    graphics_submit.async_queue_scope = async_queue_scope;
+    graphics_submit.Signal(graphics_done.Get(), 1);
+
+    CommandList compute(EQueueType::Compute);
+    compute.SetResourceStateOwnership(ERHIResourceStateOwnership::Explicit);
+    compute.AddCustomCommand(
+        MakeUnique<TranslateProbeCommand>(&compute_translated), "ParallelTranslateRecordedSuffixProbe"
+    );
+    compute.AddCallback([&] {
+        ordinary_callbacks[1].fetch_add(1, std::memory_order_relaxed);
+    });
+    compute.AddSuccessCallback([&] {
+        success_callbacks[1].fetch_add(1, std::memory_order_relaxed);
+    });
+    CmdSubmit compute_submit = compute.Submit();
+    compute_submit.SetTranslateExecutionClass(ERHITranslateExecutionClass::Parallel);
+    compute_submit.SetResourceStateOwnership(ERHIResourceStateOwnership::Explicit);
+    compute_submit.async_queue_scope = async_queue_scope;
+    compute_submit.Signal(compute_done.Get(), 1);
+
+    Array<RHIBackendSubmissionBatchEntry> failing_batch{};
+    failing_batch.emplace_back(EQueueType::Graphics, std::move(graphics_submit));
+    failing_batch.emplace_back(EQueueType::Compute, std::move(compute_submit));
+    RHIExecutor::Get().Submit(std::move(failing_batch), ERHIExecSubmitFlags::FlushGPU);
+    RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
+
+    const bool distinct_native       = topology.graphics.native_queue_id != topology.compute.native_queue_id;
+    const bool suffix_was_translated = compute_translated.try_acquire();
+    if (suffix_was_translated != distinct_native) {
+        throw std::runtime_error("parallel Translate failure did not preserve native-lane wave "
+                                 "dispatch semantics");
+    }
+    if (!ResourceCast(graphics_done.Get())->IsFailed() || !ResourceCast(compute_done.Get())->IsFailed() ||
+        ResourceCast(graphics_done.Get())->IsRejected(1) || ResourceCast(compute_done.Get())->IsRejected(1)) {
+        throw std::runtime_error("hard parallel Translate failure did not fail every wave signal");
+    }
+
+    // A hard Translate failure latches the backend. A later independent
+    // source must be terminalized without entering Translate or replaying any
+    // earlier packet ownership.
+    CommandList later(EQueueType::Graphics);
+    later.AddCallback([&] {
+        ordinary_callbacks[2].fetch_add(1, std::memory_order_relaxed);
+    });
+    later.AddSuccessCallback([&] {
+        success_callbacks[2].fetch_add(1, std::memory_order_relaxed);
+    });
+    CmdSubmit later_submit = later.Submit();
+    later_submit.Signal(later_done.Get(), 1);
+    RHIExecutor::Get().Submit(EQueueType::Graphics, std::move(later_submit), ERHIExecSubmitFlags::FlushGPU);
+    RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
+
+    if (!ResourceCast(later_done.Get())->IsFailed() || ResourceCast(later_done.Get())->IsRejected(1)) {
+        throw std::runtime_error("hard Translate failure did not fail a later batch");
+    }
+    for (size_t index = 0; index < ordinary_callbacks.size(); ++index) {
+        if (ordinary_callbacks[index].load(std::memory_order_acquire) != 1 ||
+            success_callbacks[index].load(std::memory_order_acquire) != 0) {
+            throw std::runtime_error("hard Translate failure did not terminalize callbacks "
+                                     "exactly once");
+        }
+    }
+
+    RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
+    for (size_t index = 0; index < ordinary_callbacks.size(); ++index) {
+        if (ordinary_callbacks[index].load(std::memory_order_acquire) != 1 ||
+            success_callbacks[index].load(std::memory_order_acquire) != 0) {
+            throw std::runtime_error("hard Translate failure replayed callback retirement");
+        }
+    }
+
+    LOG_INFO(
+        "[TESTCASE][PASS] name=ParallelTranslateFailureRetirement "
+        "distinct_native={} suffix_recorded={} signals=failed "
+        "callbacks=exactly_once hard_latch=later_batch_failed",
+        distinct_native,
+        suffix_was_translated
+    );
+}
+
+void RunParallelTranslateRecoverableRejection() {
+    auto&                  device            = RenderDevice::Get();
+    const RHIQueueTopology topology          = device.GetQueueTopology();
+    constexpr uint64       async_queue_scope = 0x5048313541524543ull;
+
+    FenceRef                           rejected_dependency = device.CreateFence();
+    FenceRef                           graphics_done       = device.CreateFence();
+    FenceRef                           compute_done        = device.CreateFence();
+    FenceRef                           recovered_done      = device.CreateFence();
+    std::array<std::atomic<uint32>, 3> ordinary_callbacks{};
+    std::array<std::atomic<uint32>, 3> success_callbacks{};
+    std::binary_semaphore              graphics_translated{0};
+    std::binary_semaphore              compute_translated{0};
+    std::binary_semaphore              recovered_translated{0};
+
+    rejected_dependency->Reject(1);
+
+    CommandList graphics(EQueueType::Graphics);
+    graphics.SetResourceStateOwnership(ERHIResourceStateOwnership::Explicit);
+    graphics.AddCustomCommand(
+        MakeUnique<TranslateProbeCommand>(&graphics_translated), "RecoverableGraphicsTranslateProbe"
+    );
+    graphics.AddCallback([&] {
+        ordinary_callbacks[0].fetch_add(1, std::memory_order_relaxed);
+    });
+    graphics.AddSuccessCallback([&] {
+        success_callbacks[0].fetch_add(1, std::memory_order_relaxed);
+    });
+    CmdSubmit graphics_submit = graphics.Submit();
+    graphics_submit.SetTranslateExecutionClass(ERHITranslateExecutionClass::Parallel);
+    graphics_submit.SetResourceStateOwnership(ERHIResourceStateOwnership::Explicit);
+    graphics_submit.async_queue_scope = async_queue_scope;
+    graphics_submit.Wait(rejected_dependency.Get(), 1);
+    graphics_submit.Signal(graphics_done.Get(), 1);
+
+    CommandList compute(EQueueType::Compute);
+    compute.SetResourceStateOwnership(ERHIResourceStateOwnership::Explicit);
+    compute.AddCustomCommand(
+        MakeUnique<TranslateProbeCommand>(&compute_translated), "RecoverableComputeRecordedSuffixProbe"
+    );
+    compute.AddCallback([&] {
+        ordinary_callbacks[1].fetch_add(1, std::memory_order_relaxed);
+    });
+    compute.AddSuccessCallback([&] {
+        success_callbacks[1].fetch_add(1, std::memory_order_relaxed);
+    });
+    CmdSubmit compute_submit = compute.Submit();
+    compute_submit.SetTranslateExecutionClass(ERHITranslateExecutionClass::Parallel);
+    compute_submit.SetResourceStateOwnership(ERHIResourceStateOwnership::Explicit);
+    compute_submit.async_queue_scope = async_queue_scope;
+    compute_submit.Signal(compute_done.Get(), 1);
+
+    Array<RHIBackendSubmissionBatchEntry> rejected_batch{};
+    rejected_batch.emplace_back(EQueueType::Graphics, std::move(graphics_submit));
+    rejected_batch.emplace_back(EQueueType::Compute, std::move(compute_submit));
+    RHIExecutor::Get().Submit(std::move(rejected_batch), ERHIExecSubmitFlags::FlushGPU);
+
+    // Wait for exact Submission-side publication without calling Sync:
+    // ProcessSync itself clears async-scope admission state and would hide a
+    // stale seen-lane bug between two backend batches reusing this scope.
+    if (ResourceCast(graphics_done.Get())->HostWait(1) != VK_ERROR_UNKNOWN ||
+        ResourceCast(compute_done.Get())->HostWait(1) != VK_ERROR_UNKNOWN) {
+        throw std::runtime_error("recoverable parallel Translate signals were not published");
+    }
+
+    const bool distinct_native = topology.graphics.native_queue_id != topology.compute.native_queue_id;
+    if (!graphics_translated.try_acquire() || compute_translated.try_acquire() != distinct_native) {
+        throw std::runtime_error("recoverable parallel Translate wave did not preserve native-lane "
+                                 "dispatch semantics");
+    }
+    if (!ResourceCast(graphics_done.Get())->IsRejected(1) ||
+        !ResourceCast(compute_done.Get())->IsRejected(1) || ResourceCast(graphics_done.Get())->IsFailed() ||
+        ResourceCast(compute_done.Get())->IsFailed()) {
+        throw std::runtime_error("recoverable parallel Translate failure did not reject exact "
+                                 "signal values");
+    }
+
+    // The rejected dependency is packet-local. A later independent source
+    // must still enter Translate, submit, and complete successfully.
+    CommandList recovered(EQueueType::Compute);
+    recovered.SetResourceStateOwnership(ERHIResourceStateOwnership::Explicit);
+    recovered.AddCustomCommand(
+        MakeUnique<TranslateProbeCommand>(&recovered_translated), "ParallelTranslateRecoveryProbe"
+    );
+    recovered.AddCallback([&] {
+        ordinary_callbacks[2].fetch_add(1, std::memory_order_relaxed);
+    });
+    recovered.AddSuccessCallback([&] {
+        success_callbacks[2].fetch_add(1, std::memory_order_relaxed);
+    });
+    CmdSubmit recovered_submit = recovered.Submit();
+    recovered_submit.SetTranslateExecutionClass(ERHITranslateExecutionClass::Parallel);
+    recovered_submit.SetResourceStateOwnership(ERHIResourceStateOwnership::Explicit);
+    recovered_submit.async_queue_scope = async_queue_scope;
+    recovered_submit.Signal(recovered_done.Get(), 1);
+    RHIExecutor::Get().Submit(
+        EQueueType::Compute, std::move(recovered_submit), ERHIExecSubmitFlags::FlushGPU
+    );
+    RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
+
+    if (!recovered_translated.try_acquire() ||
+        ResourceCast(recovered_done.Get())->HostWait(1) != VK_SUCCESS ||
+        ResourceCast(recovered_done.Get())->IsRejected(1) || ResourceCast(recovered_done.Get())->IsFailed()) {
+        throw std::runtime_error("recoverable parallel Translate rejection latched the runtime");
+    }
+    for (size_t index = 0; index < ordinary_callbacks.size(); ++index) {
+        const uint32 expected_success = index == 2 ? 1u : 0u;
+        if (ordinary_callbacks[index].load(std::memory_order_acquire) != 1 ||
+            success_callbacks[index].load(std::memory_order_acquire) != expected_success) {
+            throw std::runtime_error("recoverable parallel Translate callbacks retired incorrectly");
+        }
+    }
+
+    RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
+    for (size_t index = 0; index < ordinary_callbacks.size(); ++index) {
+        const uint32 expected_success = index == 2 ? 1u : 0u;
+        if (ordinary_callbacks[index].load(std::memory_order_acquire) != 1 ||
+            success_callbacks[index].load(std::memory_order_acquire) != expected_success) {
+            throw std::runtime_error("recoverable parallel Translate retirement replayed callbacks");
+        }
+    }
+
+    LOG_INFO(
+        "[TESTCASE][PASS] name=ParallelTranslateRecoverableRejection "
+        "distinct_native={} suffix_recorded={} signals=rejected "
+        "callbacks=exactly_once runtime=recovered "
+        "same_scope_reentry=Compute",
+        distinct_native,
+        distinct_native
+    );
+}
+
 void RunRecoverableCopyDependencyRejection() {
     using namespace std::chrono_literals;
 
@@ -3184,6 +3717,8 @@ int main(int argc, const char** argv) {
         const bool production_heavy = HasArgument(argc, argv, "--production-heavy");
         const bool production_gate =
             HasArgument(argc, argv, "--production-gate") || production_heavy;
+        const bool inject_translate_failure =
+            HasArgument(argc, argv, "--inject-translate-failure");
 
         LogSystem::Init();
         ConfigManager::GetInstance().Init(std::filesystem::current_path());
@@ -3204,6 +3739,15 @@ int main(int argc, const char** argv) {
         });
         render_device_initialized = true;
 
+        if (inject_translate_failure) {
+            RunParallelTranslateFailureRetirement();
+            RenderDevice::Dispose();
+            render_device_initialized = false;
+            TaskSystem::ShutDown();
+            task_system_initialized = false;
+            return 0;
+        }
+
         RunOrderedReadback(
             parallel, inject_worker_failure, production_gate, production_heavy
         );
@@ -3220,6 +3764,8 @@ int main(int argc, const char** argv) {
         RunContinuousFrameInFlightRetirement();
         RunRecoverableCopyDependencyRejection();
         RunCrossQueueTopologyBatch();
+        RunAsyncQueueParallelTranslateSmoke();
+        RunParallelTranslateRecoverableRejection();
         RunRuntimeRejectCompletionOwnership();
         PrimeGlobalTransientPoolForDispose();
         // This explicitly stops the runtime and must remain the final test

--- a/source/test/RHISubmissionTopologyTest.cpp
+++ b/source/test/RHISubmissionTopologyTest.cpp
@@ -113,8 +113,66 @@ void CoverageAndBoundaryMetadataAreExplicit() {
            "synthesized segment did not cover the complete source submit");
     Expect(synthesized.segments[0].inherit_source_wait_events &&
                synthesized.segments[0].inherit_source_signal_events_and_callbacks &&
-               synthesized.segments[0].inherit_source_runtime_payload,
-           "single segment did not inherit both source boundaries");
+               !synthesized.segments[0].inherit_source_runtime_payload,
+           "pure Copy source unexpectedly inherited runtime payload");
+}
+
+void RuntimePayloadSkipsCopySegments() {
+    constexpr std::array mixed_segments{
+        RHISubmitSegment{EQueueType::Graphics, 0, 1},
+        RHISubmitSegment{EQueueType::Copy, 1, 2},
+        RHISubmitSegment{EQueueType::Graphics, 2, 3},
+    };
+    const std::array mixed_descriptions{
+        Describe(EQueueType::Graphics, 3, mixed_segments),
+    };
+    const RHISubmissionTopologyPlan mixed =
+        BuildRHISubmissionTopology(mixed_descriptions, 9);
+    Expect(mixed.IsValid() && mixed.segments.size() == 3,
+           "mixed Graphics/Copy/Graphics source did not build");
+    Expect(mixed.segments[0].inherit_source_wait_events &&
+               !mixed.segments[0].inherit_source_runtime_payload &&
+               !mixed.segments[1].inherit_source_wait_events &&
+               !mixed.segments[1].inherit_source_runtime_payload &&
+               !mixed.segments[2].inherit_source_wait_events &&
+               mixed.segments[2].inherit_source_signal_events_and_callbacks &&
+               mixed.segments[2].inherit_source_runtime_payload,
+           "mixed source boundary metadata selected the wrong runtime owner");
+
+    constexpr std::array copy_tail_segments{
+        RHISubmitSegment{EQueueType::Graphics, 0, 1},
+        RHISubmitSegment{EQueueType::Copy, 1, 2},
+    };
+    const std::array copy_tail_descriptions{
+        Describe(EQueueType::Graphics, 2, copy_tail_segments),
+    };
+    const RHISubmissionTopologyPlan copy_tail =
+        BuildRHISubmissionTopology(copy_tail_descriptions, 10);
+    Expect(copy_tail.IsValid() && copy_tail.segments.size() == 2,
+           "Graphics/Copy source did not build");
+    Expect(copy_tail.segments[0].inherit_source_wait_events &&
+               copy_tail.segments[0].inherit_source_runtime_payload &&
+               !copy_tail.segments[0].inherit_source_signal_events_and_callbacks &&
+               !copy_tail.segments[1].inherit_source_runtime_payload &&
+               copy_tail.segments[1].inherit_source_signal_events_and_callbacks,
+           "Copy tail incorrectly displaced the non-Copy runtime owner");
+
+    constexpr std::array pure_copy_segments{
+        RHISubmitSegment{EQueueType::Copy, 0, 1},
+        RHISubmitSegment{EQueueType::Copy, 1, 2},
+    };
+    const std::array pure_copy_descriptions{
+        Describe(EQueueType::Copy, 2, pure_copy_segments),
+    };
+    const RHISubmissionTopologyPlan pure_copy =
+        BuildRHISubmissionTopology(pure_copy_descriptions, 11);
+    Expect(pure_copy.IsValid() && pure_copy.segments.size() == 2,
+           "pure Copy source did not build");
+    Expect(pure_copy.segments[0].inherit_source_wait_events &&
+               !pure_copy.segments[0].inherit_source_runtime_payload &&
+               !pure_copy.segments[1].inherit_source_runtime_payload &&
+               pure_copy.segments[1].inherit_source_signal_events_and_callbacks,
+           "pure Copy source unexpectedly selected a runtime owner");
 }
 
 void SerialControlCreatesStableFrontierBarriers() {
@@ -236,6 +294,7 @@ int main() {
     try {
         StableInputOrderAndKeysArePreserved();
         CoverageAndBoundaryMetadataAreExplicit();
+        RuntimePayloadSkipsCopySegments();
         SerialControlCreatesStableFrontierBarriers();
         InvalidRangesAndQueuesFailClosed();
         EmptySubmitsRequireSideEffects();

--- a/source/test/VulkanTranslateWaveSchedulerTest.cpp
+++ b/source/test/VulkanTranslateWaveSchedulerTest.cpp
@@ -1,0 +1,300 @@
+#include "rhi/vulkan/VulkanTranslateWaveScheduler.h"
+#include "taskgraph/TaskGraph.h"
+
+#include <array>
+#include <initializer_list>
+#include <iostream>
+#include <stdexcept>
+#include <vector>
+
+using namespace Moer::Render;
+using namespace Moer::Render::VulkanTranslateWaveDetail;
+
+static_assert(noexcept(std::declval<TaskGraph&>()
+                           .QueueTask(nullptr, EThread::AnyThread_NormalPri, EThread::UNKNOWN_THREAD, true)));
+static_assert(noexcept(std::declval<BaseGraphTask&>().QueueTask(EThread::UNKNOWN_THREAD, true)));
+static_assert(noexcept(std::declval<BaseGraphTask&>().ConditionalQueueTask(EThread::UNKNOWN_THREAD, true)));
+static_assert(noexcept(std::declval<BaseGraphTask&>().PrerequestsComplete(EThread::UNKNOWN_THREAD, 0, true)));
+
+namespace {
+
+constexpr uint64_t BatchSequence = 71;
+
+[[nodiscard]] constexpr SubmissionKey Key(uint32_t _index) noexcept {
+    return SubmissionKey{BatchSequence, _index};
+}
+
+void Expect(bool _condition, const char* _message) {
+    if (!_condition) {
+        throw std::runtime_error(_message);
+    }
+}
+
+void ExpectWave(
+    const std::vector<SubmissionKey>&    _actual,
+    std::initializer_list<SubmissionKey> _expected,
+    const char*                          _message
+) {
+    if (_actual.size() != _expected.size()) {
+        throw std::runtime_error(_message);
+    }
+    size_t index = 0;
+    for (const SubmissionKey& expected : _expected) {
+        if (!(_actual[index++] == expected)) {
+            throw std::runtime_error(_message);
+        }
+    }
+}
+
+void IndependentNativeQueuesShareAStableWave() {
+    const std::array nodes{
+        TranslateWaveNode{.key = Key(0), .native_queue_id = 3, .async_translate = true},
+        TranslateWaveNode{.key = Key(1), .native_queue_id = 8, .async_translate = true},
+    };
+
+    TranslateWaveScheduler scheduler;
+    Expect(scheduler.Build(nodes), "independent roots failed to build");
+    ExpectWave(
+        scheduler.NextWave(), {Key(0), Key(1)}, "independent native queues did not share one stable wave"
+    );
+    ExpectWave(scheduler.NextWave(), {}, "already scheduled roots were returned twice");
+    Expect(
+        scheduler.MarkTranslated(Key(1)) && scheduler.MarkTranslated(Key(0)),
+        "independent roots could not complete translation out of order"
+    );
+    Expect(
+        scheduler.MarkReleased(Key(0)) && scheduler.MarkReleased(Key(1)) && scheduler.IsComplete(),
+        "independent roots did not release exactly once"
+    );
+}
+
+void SameNativeQueueWaitsForReleaseWithoutBlockingAnotherLane() {
+    const std::array nodes{
+        TranslateWaveNode{.key = Key(0), .native_queue_id = 4, .async_translate = true},
+        // A logical Compute alias of the same physical queue.
+        TranslateWaveNode{.key = Key(1), .native_queue_id = 4, .async_translate = true},
+        TranslateWaveNode{.key = Key(2), .native_queue_id = 9, .async_translate = true},
+    };
+
+    TranslateWaveScheduler scheduler;
+    Expect(scheduler.Build(nodes), "same-native topology failed to build");
+    ExpectWave(
+        scheduler.NextWave(), {Key(0), Key(2)}, "blocked same-native successor hid a ready independent lane"
+    );
+    Expect(
+        scheduler.MarkTranslated(Key(0)) && scheduler.MarkTranslated(Key(2)),
+        "first native-lane ready set did not finish translation"
+    );
+    ExpectWave(scheduler.NextWave(), {}, "same-native successor started before packet release");
+    Expect(scheduler.MarkReleased(Key(0)), "same-native predecessor packet was not released");
+    ExpectWave(
+        scheduler.NextWave(),
+        {Key(1)},
+        "released alias did not unlock its successor while the later lane was held"
+    );
+    Expect(
+        scheduler.MarkTranslated(Key(1)) && scheduler.MarkReleased(Key(1)) &&
+            scheduler.MarkReleased(Key(2)) && scheduler.IsComplete(),
+        "held later-lane packet did not preserve ordered-release ownership"
+    );
+}
+
+void ExplicitDependencyUnlocksAtTranslated() {
+    constexpr std::array dependency{Key(0)};
+    const std::array     nodes{
+        TranslateWaveNode{.key = Key(0), .native_queue_id = 1, .async_translate = true},
+        TranslateWaveNode{
+                .key             = Key(1),
+                .native_queue_id = 2,
+                .async_translate = true,
+                .dependencies    = dependency,
+        },
+    };
+
+    TranslateWaveScheduler scheduler;
+    Expect(scheduler.Build(nodes), "explicit dependency failed to build");
+    ExpectWave(scheduler.NextWave(), {Key(0)}, "dependent node entered its prerequisite wave");
+    ExpectWave(scheduler.NextWave(), {}, "dependent node started before prerequisite translation");
+    Expect(scheduler.MarkTranslated(Key(0)), "explicit prerequisite did not translate");
+    ExpectWave(scheduler.NextWave(), {Key(1)}, "explicit dependency incorrectly waited for packet release");
+}
+
+void FanInAndFanOutRemainDeterministic() {
+    constexpr std::array fan_in_dependencies{Key(0), Key(1)};
+    constexpr std::array fan_out_dependency{Key(2)};
+    const std::array     nodes{
+        TranslateWaveNode{.key = Key(0), .native_queue_id = 10, .async_translate = true},
+        TranslateWaveNode{.key = Key(1), .native_queue_id = 11, .async_translate = true},
+        TranslateWaveNode{
+                .key             = Key(2),
+                .native_queue_id = 12,
+                .async_translate = true,
+                .dependencies    = fan_in_dependencies,
+        },
+        TranslateWaveNode{
+                .key             = Key(3),
+                .native_queue_id = 13,
+                .async_translate = true,
+                .dependencies    = fan_out_dependency,
+        },
+        TranslateWaveNode{
+                .key             = Key(4),
+                .native_queue_id = 14,
+                .async_translate = true,
+                .dependencies    = fan_out_dependency,
+        },
+    };
+
+    TranslateWaveScheduler scheduler;
+    Expect(scheduler.Build(nodes), "fan-in/fan-out topology failed to build");
+    ExpectWave(scheduler.NextWave(), {Key(0), Key(1)}, "fan-in roots did not form the first wave");
+    Expect(scheduler.MarkTranslated(Key(0)), "first fan-in prerequisite did not translate");
+    ExpectWave(scheduler.NextWave(), {}, "fan-in node started with one incomplete prerequisite");
+    Expect(scheduler.MarkTranslated(Key(1)), "second fan-in prerequisite did not translate");
+    ExpectWave(scheduler.NextWave(), {Key(2)}, "fan-in node did not wait for both prerequisites");
+    Expect(scheduler.MarkTranslated(Key(2)), "fan-out prerequisite did not translate");
+    ExpectWave(
+        scheduler.NextWave(), {Key(3), Key(4)}, "fan-out nodes did not retain stable order in one wave"
+    );
+}
+
+void NonAsyncNodeIsAnExclusiveReleaseBoundary() {
+    constexpr std::array control_dependency{Key(2)};
+    const std::array     nodes{
+        TranslateWaveNode{.key = Key(0), .native_queue_id = 20, .async_translate = true},
+        TranslateWaveNode{.key = Key(1), .native_queue_id = 21, .async_translate = true},
+        TranslateWaveNode{.key = Key(2), .native_queue_id = 22, .async_translate = false},
+        TranslateWaveNode{
+                .key             = Key(3),
+                .native_queue_id = 23,
+                .async_translate = true,
+                .dependencies    = control_dependency,
+        },
+    };
+
+    TranslateWaveScheduler scheduler;
+    Expect(scheduler.Build(nodes), "hard-boundary topology failed to build");
+    ExpectWave(scheduler.NextWave(), {Key(0), Key(1)}, "hard boundary joined an async wave");
+    Expect(
+        scheduler.MarkTranslated(Key(0)) && scheduler.MarkTranslated(Key(1)),
+        "hard-boundary prefix did not translate"
+    );
+    ExpectWave(scheduler.NextWave(), {}, "hard boundary started before the earlier prefix was released");
+    Expect(scheduler.MarkReleased(Key(0)), "first hard-boundary prefix packet did not release");
+    ExpectWave(scheduler.NextWave(), {}, "hard boundary ignored an unreleased earlier packet");
+    Expect(scheduler.MarkReleased(Key(1)), "second hard-boundary prefix packet did not release");
+    ExpectWave(scheduler.NextWave(), {Key(2)}, "hard boundary was not emitted as an exclusive wave");
+    Expect(scheduler.MarkTranslated(Key(2)), "hard boundary did not finish translation");
+    ExpectWave(scheduler.NextWave(), {}, "hard-boundary dependent started before release");
+    Expect(scheduler.MarkReleased(Key(2)), "hard-boundary packet did not release");
+    ExpectWave(scheduler.NextWave(), {Key(3)}, "hard-boundary release did not unlock its suffix");
+}
+
+void UnknownAndFutureDependenciesFailClosed() {
+    constexpr std::array unknown_dependency{SubmissionKey{BatchSequence, 99}};
+    const std::array     unknown_nodes{
+        TranslateWaveNode{
+                .key             = Key(0),
+                .native_queue_id = 1,
+                .async_translate = true,
+                .dependencies    = unknown_dependency,
+        },
+    };
+
+    TranslateWaveScheduler unknown;
+    Expect(
+        !unknown.Build(unknown_nodes) &&
+            unknown.GetBuildError() == ETranslateWaveBuildError::UnknownDependency &&
+            unknown.GetErrorNodeIndex() == 0 && unknown.GetErrorDependencyIndex() == 0,
+        "unknown dependency did not fail closed with stable diagnostics"
+    );
+    ExpectWave(unknown.NextWave(), {}, "invalid scheduler emitted work for an unknown dependency");
+
+    constexpr std::array future_dependency{Key(1)};
+    const std::array     future_nodes{
+        TranslateWaveNode{
+                .key             = Key(0),
+                .native_queue_id = 1,
+                .async_translate = true,
+                .dependencies    = future_dependency,
+        },
+        TranslateWaveNode{.key = Key(1), .native_queue_id = 2, .async_translate = true},
+    };
+
+    TranslateWaveScheduler future;
+    Expect(
+        !future.Build(future_nodes) && future.GetBuildError() == ETranslateWaveBuildError::FutureDependency,
+        "future dependency did not fail closed"
+    );
+
+    const std::array duplicate_nodes{
+        TranslateWaveNode{.key = Key(0), .native_queue_id = 1, .async_translate = true},
+        TranslateWaveNode{.key = Key(0), .native_queue_id = 2, .async_translate = true},
+    };
+    TranslateWaveScheduler duplicate;
+    Expect(
+        !duplicate.Build(duplicate_nodes) &&
+            duplicate.GetBuildError() == ETranslateWaveBuildError::DuplicateKey &&
+            duplicate.GetErrorNodeIndex() == 1,
+        "duplicate key did not fail closed"
+    );
+}
+
+void CancellationRetainsOnlyOutstandingPacketLeases() {
+    const std::array nodes{
+        TranslateWaveNode{.key = Key(0), .native_queue_id = 31, .async_translate = true},
+        TranslateWaveNode{.key = Key(1), .native_queue_id = 31, .async_translate = true},
+        TranslateWaveNode{.key = Key(2), .native_queue_id = 32, .async_translate = true},
+    };
+
+    TranslateWaveScheduler scheduler;
+    Expect(scheduler.Build(nodes), "cancellation topology failed to build");
+    ExpectWave(
+        scheduler.NextWave(), {Key(0), Key(2)}, "cancellation fixture did not expose every ready native lane"
+    );
+    scheduler.Cancel();
+    Expect(scheduler.IsCancelled() && !scheduler.IsComplete(), "cancellation lost an in-flight packet lease");
+    ExpectWave(scheduler.NextWave(), {}, "cancelled scheduler emitted later work");
+    Expect(
+        scheduler.GetState(Key(1)) == ETranslateWaveNodeState::Cancelled &&
+            scheduler.GetState(Key(2)) == ETranslateWaveNodeState::Translating,
+        "cancellation did not terminalize the unscheduled suffix"
+    );
+    Expect(
+        scheduler.MarkReleased(Key(0)) && scheduler.MarkReleased(Key(2)) && scheduler.IsComplete(),
+        "cancelled in-flight packets could not be released exactly once"
+    );
+    Expect(
+        !scheduler.MarkReleased(Key(0)) && !scheduler.MarkTranslated(Key(1)),
+        "invalid terminal transitions were accepted"
+    );
+}
+
+void EmptyBuildIsImmediatelyComplete() {
+    TranslateWaveScheduler scheduler;
+    Expect(
+        scheduler.Build({}) && scheduler.IsValid() && scheduler.IsComplete(),
+        "empty valid topology was not immediately complete"
+    );
+    ExpectWave(scheduler.NextWave(), {}, "empty valid topology emitted a wave");
+}
+
+} // namespace
+
+int main() {
+    try {
+        IndependentNativeQueuesShareAStableWave();
+        SameNativeQueueWaitsForReleaseWithoutBlockingAnotherLane();
+        ExplicitDependencyUnlocksAtTranslated();
+        FanInAndFanOutRemainDeterministic();
+        NonAsyncNodeIsAnExclusiveReleaseBoundary();
+        UnknownAndFutureDependenciesFailClosed();
+        CancellationRetainsOnlyOutstandingPacketLeases();
+        EmptyBuildIsImmediatelyComplete();
+        std::cout << "Vulkan translate-wave scheduler tests passed\n";
+        return 0;
+    } catch (const std::exception& error) {
+        std::cerr << "Vulkan translate-wave scheduler test failed: " << error.what() << '\n';
+        return 1;
+    }
+}

--- a/tools/threading/README.md
+++ b/tools/threading/README.md
@@ -359,7 +359,7 @@ changes, and native copy/clear calls contribute units; GPU byte counts,
 dispatch group counts, and indirect draw counts do not. A wave needs at least
 two qualifying jobs, otherwise it safely uses the serial recorder.
 
-Run the six-mode Vulkan correctness/fallback gate after building the target:
+Run the seven-mode Vulkan correctness/fallback gate after building the target:
 
 ```powershell
 python tools/threading/run_parallel_record_vulkan_test.py `
@@ -368,8 +368,9 @@ python tools/threading/run_parallel_record_vulkan_test.py `
 ```
 
 The runner checks serial, forced-parallel, injected worker failure, production
-gate rejection, production-heavy admission, and hard cross-queue Translate
-failure retirement. It requires real worker overlap, stable
+gate rejection, production-heavy admission, hard cross-queue Translate failure
+retirement, and multi-segment prefix-submit/suffix-failure retirement. It
+requires real worker overlap, stable
 `wave -> serial island -> wave` assembly, GPU readback correctness, exact
 failure/fallback counts, no native submit after the injected hard fault, and
 clean Vulkan logs. The ready-native-lane gate accepts a PASS only when the

--- a/tools/threading/README.md
+++ b/tools/threading/README.md
@@ -359,7 +359,7 @@ changes, and native copy/clear calls contribute units; GPU byte counts,
 dispatch group counts, and indirect draw counts do not. A wave needs at least
 two qualifying jobs, otherwise it safely uses the serial recorder.
 
-Run the five-mode Vulkan correctness/fallback gate after building the target:
+Run the six-mode Vulkan correctness/fallback gate after building the target:
 
 ```powershell
 python tools/threading/run_parallel_record_vulkan_test.py `
@@ -368,9 +368,17 @@ python tools/threading/run_parallel_record_vulkan_test.py `
 ```
 
 The runner checks serial, forced-parallel, injected worker failure, production
-gate rejection, and production-heavy admission. It requires real worker
-overlap, stable `wave -> serial island -> wave` assembly, GPU readback
-correctness, exact failure/fallback counts, and clean Vulkan logs.
+gate rejection, production-heavy admission, and hard cross-queue Translate
+failure retirement. It requires real worker overlap, stable
+`wave -> serial island -> wave` assembly, GPU readback correctness, exact
+failure/fallback counts, no native submit after the injected hard fault, and
+clean Vulkan logs. The ready-native-lane gate accepts a PASS only when the
+`G,G,C` source order produces first-ready `G,C` Translate lanes and an actually
+observed serial Submission-owner order of `G,G,C`; a SKIP is limited to an
+unavailable or aliased native queue and must retain the CPU scheduler seam.
+The recoverable gate also requires matching native-lane/suffix-recording
+observations, exact rejected signals, exactly-once callbacks, and successful
+same-scope runtime re-entry.
 
 For Release A/B, enable `parallel_record_profile` in isolated configs and feed
 at least two independent logs per side to `parallel_record_ab.py`. The parser

--- a/tools/threading/run_parallel_record_vulkan_test.py
+++ b/tools/threading/run_parallel_record_vulkan_test.py
@@ -51,6 +51,126 @@ def _testcase_marker(name: str, text: str) -> tuple[str, dict[str, str]] | None:
     return marker.group("status"), fields
 
 
+def _require_phase15b_copy_contracts(mode: str, text: str) -> None:
+    round_trip = _testcase_marker("ActiveRdgGraphicsCopyRoundTrip", text)
+    _require(
+        round_trip is not None,
+        f"{mode}: missing active RDG Graphics-Copy round-trip marker",
+    )
+    round_trip_status, round_trip_fields = round_trip
+    if round_trip_status == "PASS":
+        native_alias = round_trip_fields.get("native_alias")
+        expected_gpu_syncs = "0" if native_alias == "true" else "2"
+        expected_mode = "serial" if mode == "serial" else "parallel"
+        graphics_native = round_trip_fields.get("graphics_native")
+        copy_native = round_trip_fields.get("copy_native")
+        _require(
+            native_alias in {"true", "false"}
+            and round_trip_fields.get("mode") == expected_mode
+            and round_trip_fields.get("ownership")
+            in {"local-acquire", "release-acquire"}
+            and round_trip_fields.get("transfers") == "2"
+            and round_trip_fields.get("gpu_syncs") == expected_gpu_syncs
+            and graphics_native is not None
+            and copy_native is not None
+            and ((graphics_native == copy_native) == (native_alias == "true"))
+            and round_trip_fields.get("readback") == "verified",
+            f"{mode}: incomplete active RDG Graphics-Copy round-trip contract",
+        )
+    else:
+        _require(
+            round_trip_fields.get("reason") == "copy_queue_unavailable",
+            f"{mode}: invalid active RDG Graphics-Copy round-trip SKIP contract",
+        )
+
+    recoverable_copy = _testcase_marker(
+        "RecoverableCopyDependencyRejection", text
+    )
+    _require(
+        recoverable_copy is not None and recoverable_copy[0] == "PASS",
+        f"{mode}: missing recoverable Copy rejection marker",
+    )
+    _, recoverable_copy_fields = recoverable_copy
+    _require(
+        recoverable_copy_fields.get("fence") == "reused"
+        and recoverable_copy_fields.get("rejected") == "N"
+        and recoverable_copy_fields.get("recovered") == "N+1"
+        and recoverable_copy_fields.get("stale_wait") == "rejected"
+        and recoverable_copy_fields.get("publication") == "Submission"
+        and recoverable_copy_fields.get("native_rejected") == "0"
+        and recoverable_copy_fields.get("native_accepted") == "3"
+        and recoverable_copy_fields.get("native_owner") == "verified"
+        and recoverable_copy_fields.get("runtime") == "recovered"
+        and recoverable_copy_fields.get("replay") == "0",
+        f"{mode}: incomplete recoverable Copy rejection contract",
+    )
+
+    cross_queue = _testcase_marker("CrossQueueSubmissionTopology", text)
+    _require(
+        cross_queue is not None and cross_queue[0] == "PASS",
+        f"{mode}: missing cross-queue Submission ownership marker",
+    )
+    _, cross_queue_fields = cross_queue
+    _require(
+        cross_queue_fields.get("batches") == "4"
+        and cross_queue_fields.get("queues")
+        == "Graphics,Compute,Copy,Graphics"
+        and cross_queue_fields.get("ownership") == "explicit"
+        and cross_queue_fields.get("native_owner") == "verified"
+        and cross_queue_fields.get("native_alias") in {"true", "false"}
+        and cross_queue_fields.get("callbacks") == "exactly_once"
+        and cross_queue_fields.get("replay") == "0",
+        f"{mode}: incomplete cross-queue Submission ownership contract",
+    )
+
+    direct_copy = _testcase_marker("DirectCopyExecuteRejected", text)
+    _require(
+        direct_copy is not None and direct_copy[0] == "PASS",
+        f"{mode}: missing direct Copy fail-closed marker",
+    )
+    _, direct_copy_fields = direct_copy
+    _require(
+        direct_copy_fields.get("runtime_claim") == "exclusive"
+        and direct_copy_fields.get("native_submit") == "0"
+        and direct_copy_fields.get("callbacks") == "exactly_once"
+        and direct_copy_fields.get("signal") == "rejected"
+        and direct_copy_fields.get("replay") == "0",
+        f"{mode}: incomplete direct Copy fail-closed contract",
+    )
+
+    io_copy = _testcase_marker("VulkanStorageUnifiedCopySubmission", text)
+    _require(
+        io_copy is not None and io_copy[0] == "PASS",
+        f"{mode}: missing VulkanStorage unified Copy submission marker",
+    )
+    _, io_copy_fields = io_copy
+    _require(
+        io_copy_fields.get("commits") == "2"
+        and io_copy_fields.get("signals") == "2"
+        and io_copy_fields.get("native_submit") == "2"
+        and io_copy_fields.get("native_owner") == "Submission"
+        and io_copy_fields.get("session_recycle") == "verified"
+        and io_copy_fields.get("readback") == "verified",
+        f"{mode}: incomplete VulkanStorage unified Copy submission contract",
+    )
+
+    shutdown = _testcase_marker("ShutdownDependencyCancellation", text)
+    _require(
+        shutdown is not None and shutdown[0] == "PASS",
+        f"{mode}: missing shutdown dependency cancellation marker",
+    )
+    _, shutdown_fields = shutdown
+    _require(
+        shutdown_fields.get("queues") == "Copy,Graphics"
+        and shutdown_fields.get("copy_wait") == "entered"
+        and shutdown_fields.get("dependency") == "unpublished"
+        and shutdown_fields.get("native_submit") == "0"
+        and shutdown_fields.get("sync_wait") == "registered"
+        and shutdown_fields.get("concurrent_sync") == "drained",
+        f"{mode}: incomplete shutdown dependency cancellation contract",
+    )
+
+
 def validate_log(mode: str, text: str) -> None:
     _require("[TESTCASE][FAIL]" not in text, f"{mode}: test emitted a FAIL marker")
     _require("VUID-" not in text, f"{mode}: Vulkan validation VUID was emitted")
@@ -128,6 +248,8 @@ def validate_log(mode: str, text: str) -> None:
         and recoverable_fields.get("same_scope_reentry") == "Compute",
         f"{mode}: incomplete recoverable Translate retirement contract",
     )
+
+    _require_phase15b_copy_contracts(mode, text)
 
     expected_fault = "true" if mode == "fallback" else "false"
     expected_mode = "serial" if mode == "serial" else "parallel"

--- a/tools/threading/run_parallel_record_vulkan_test.py
+++ b/tools/threading/run_parallel_record_vulkan_test.py
@@ -63,6 +63,40 @@ def _testcase_marker(name: str, text: str) -> tuple[str, dict[str, str]] | None:
     return marker.group("status"), fields
 
 
+def _vulkan_fault_summary(text: str) -> dict[str, str]:
+    matches = list(re.finditer(r"\[VulkanFault\]\[Summary\][^\r\n]*", text))
+    _require(
+        len(matches) == 1,
+        f"VulkanFault Summary: expected exactly one marker, got {len(matches)}",
+    )
+    field_pairs = re.findall(
+        r"(?:^|\s)([A-Za-z0-9_]+)=([^\s]+)", matches[0].group(0)
+    )
+    seen_fields: set[str] = set()
+    duplicate_fields: set[str] = set()
+    for key, _ in field_pairs:
+        if key in seen_fields:
+            duplicate_fields.add(key)
+        seen_fields.add(key)
+    _require(
+        not duplicate_fields,
+        "VulkanFault Summary: duplicate fields: "
+        + ", ".join(sorted(duplicate_fields)),
+    )
+    return dict(field_pairs)
+
+
+def _require_clean_hard_fault_summary(mode: str, text: str) -> None:
+    fields = _vulkan_fault_summary(text)
+    _require(
+        fields.get("first_fault_count") == "1"
+        and fields.get("native_submit_after_fault") == "0"
+        and fields.get("native_present_after_fault") == "0"
+        and fields.get("device_lost") == "false",
+        f"{mode}: incomplete clean hard-fault ownership summary",
+    )
+
+
 def _require_phase15b_copy_contracts(mode: str, text: str) -> None:
     round_trip = _testcase_marker("ActiveRdgGraphicsCopyRoundTrip", text)
     _require(
@@ -322,31 +356,24 @@ def validate_log(mode: str, text: str) -> None:
     _require("Validation Error" not in text, f"{mode}: Vulkan validation error was emitted")
     _require_phase15c_completion_aggregate_cpu_probe(mode, text)
     if mode == "translate-hard":
-        retirement = re.search(
-            r"\[TESTCASE\]\[PASS\].*name=ParallelTranslateFailureRetirement"
-            r".*distinct_native=(?P<distinct>true|false)"
-            r".*suffix_recorded=(?P<suffix>true|false).*signals=failed"
-            r".*callbacks=exactly_once.*hard_latch=later_batch_failed",
-            text,
+        retirement = _testcase_marker(
+            "ParallelTranslateFailureRetirement", text
         )
         _require(
-            retirement is not None,
+            retirement is not None and retirement[0] == "PASS",
             "translate-hard: missing failure-retirement PASS marker",
         )
+        _, retirement_fields = retirement
         _require(
-            retirement.group("distinct") == retirement.group("suffix"),
-            "translate-hard: suffix recording disagrees with native queue topology",
+            retirement_fields.get("distinct_native")
+            == retirement_fields.get("suffix_recorded")
+            and retirement_fields.get("distinct_native") in {"true", "false"}
+            and retirement_fields.get("signals") == "failed"
+            and retirement_fields.get("callbacks") == "exactly_once"
+            and retirement_fields.get("hard_latch") == "later_batch_failed",
+            "translate-hard: incomplete failure-retirement contract",
         )
-        _require(
-            re.search(
-                r"\[VulkanFault\]\[Summary\].*first_fault_count=1(?:\s|$)"
-                r".*native_submit_after_fault=0.*native_present_after_fault=0"
-                r".*device_lost=false",
-                text,
-            )
-            is not None,
-            "translate-hard: missing clean hard-fault ownership summary",
-        )
+        _require_clean_hard_fault_summary(mode, text)
         return
 
     if mode == "multi-segment-hard":
@@ -374,16 +401,7 @@ def validate_log(mode: str, text: str) -> None:
             and retirement_fields.get("replay") == "0",
             "multi-segment-hard: incomplete aggregate retirement contract",
         )
-        _require(
-            re.search(
-                r"\[VulkanFault\]\[Summary\].*first_fault_count=1(?:\s|$)"
-                r".*native_submit_after_fault=0.*native_present_after_fault=0"
-                r".*device_lost=false",
-                text,
-            )
-            is not None,
-            "multi-segment-hard: missing clean hard-fault ownership summary",
-        )
+        _require_clean_hard_fault_summary(mode, text)
         return
 
     ready_marker = _testcase_marker("AsyncQueueParallelTranslateSmoke", text)
@@ -404,11 +422,19 @@ def validate_log(mode: str, text: str) -> None:
             f"{mode}: incomplete ready-native-lane Translate PASS contract",
         )
     else:
+        graphics_native = ready_fields.get("graphics_native")
+        compute_native = ready_fields.get("compute_native")
         _require(
             ready_fields.get("reason")
             in {"queue_unavailable", "native_queue_alias"}
             and ready_fields.get("cpu_seam")
-            == "VulkanTranslateWaveScheduler",
+            == "VulkanTranslateWaveScheduler"
+            and graphics_native is not None
+            and compute_native is not None
+            and (
+                ready_fields.get("reason") != "native_queue_alias"
+                or graphics_native == compute_native
+            ),
             f"{mode}: invalid ready-native-lane Translate SKIP contract",
         )
 

--- a/tools/threading/run_parallel_record_vulkan_test.py
+++ b/tools/threading/run_parallel_record_vulkan_test.py
@@ -30,10 +30,105 @@ def _require(condition: bool, message: str) -> None:
         raise VulkanTestError(message)
 
 
+def _testcase_marker(name: str, text: str) -> tuple[str, dict[str, str]] | None:
+    matches = list(
+        re.finditer(
+            rf"\[TESTCASE\]\[(?P<status>PASS|SKIP)\]"
+            rf"[^\r\n]*\bname={re.escape(name)}(?:\s|$)[^\r\n]*",
+            text,
+        )
+    )
+    _require(
+        len(matches) <= 1,
+        f"{name}: expected at most one terminal marker, got {len(matches)}",
+    )
+    if not matches:
+        return None
+    marker = matches[0]
+    fields = dict(
+        re.findall(r"(?:^|\s)([A-Za-z0-9_]+)=([^\s]+)", marker.group(0))
+    )
+    return marker.group("status"), fields
+
+
 def validate_log(mode: str, text: str) -> None:
     _require("[TESTCASE][FAIL]" not in text, f"{mode}: test emitted a FAIL marker")
     _require("VUID-" not in text, f"{mode}: Vulkan validation VUID was emitted")
     _require("Validation Error" not in text, f"{mode}: Vulkan validation error was emitted")
+    if mode == "translate-hard":
+        retirement = re.search(
+            r"\[TESTCASE\]\[PASS\].*name=ParallelTranslateFailureRetirement"
+            r".*distinct_native=(?P<distinct>true|false)"
+            r".*suffix_recorded=(?P<suffix>true|false).*signals=failed"
+            r".*callbacks=exactly_once.*hard_latch=later_batch_failed",
+            text,
+        )
+        _require(
+            retirement is not None,
+            "translate-hard: missing failure-retirement PASS marker",
+        )
+        _require(
+            retirement.group("distinct") == retirement.group("suffix"),
+            "translate-hard: suffix recording disagrees with native queue topology",
+        )
+        _require(
+            re.search(
+                r"\[VulkanFault\]\[Summary\].*first_fault_count=1(?:\s|$)"
+                r".*native_submit_after_fault=0.*native_present_after_fault=0"
+                r".*device_lost=false",
+                text,
+            )
+            is not None,
+            "translate-hard: missing clean hard-fault ownership summary",
+        )
+        return
+
+    ready_marker = _testcase_marker("AsyncQueueParallelTranslateSmoke", text)
+    _require(
+        ready_marker is not None,
+        f"{mode}: missing ready-native-lane Translate smoke marker",
+    )
+    ready_status, ready_fields = ready_marker
+    if ready_status == "PASS":
+        _require(
+            ready_fields.get("sources") == "3"
+            and ready_fields.get("batch") == "1"
+            and ready_fields.get("source_order") == "G,G,C"
+            and ready_fields.get("first_ready_lanes") == "G,C"
+            and ready_fields.get("observed_submit_order") == "G,G,C"
+            and ready_fields.get("explicit_state") == "true"
+            and ready_fields.get("callbacks") == "exactly_once",
+            f"{mode}: incomplete ready-native-lane Translate PASS contract",
+        )
+    else:
+        _require(
+            ready_fields.get("reason")
+            in {"queue_unavailable", "native_queue_alias"}
+            and ready_fields.get("cpu_seam")
+            == "VulkanTranslateWaveScheduler",
+            f"{mode}: invalid ready-native-lane Translate SKIP contract",
+        )
+
+    recoverable_marker = _testcase_marker(
+        "ParallelTranslateRecoverableRejection", text
+    )
+    _require(
+        recoverable_marker is not None
+        and recoverable_marker[0] == "PASS",
+        f"{mode}: missing recoverable Translate retirement marker",
+    )
+    _, recoverable_fields = recoverable_marker
+    _require(
+        recoverable_fields.get("distinct_native")
+        == recoverable_fields.get("suffix_recorded")
+        and recoverable_fields.get("distinct_native") in {"true", "false"}
+        and recoverable_fields.get("signals") == "rejected"
+        and recoverable_fields.get("callbacks") == "exactly_once"
+        and recoverable_fields.get("runtime") == "recovered"
+        and recoverable_fields.get("same_scope_reentry") == "Compute",
+        f"{mode}: incomplete recoverable Translate retirement contract",
+    )
+
     expected_fault = "true" if mode == "fallback" else "false"
     expected_mode = "serial" if mode == "serial" else "parallel"
     expected_production_gate = "true" if mode in ("gated", "heavy") else "false"
@@ -142,7 +237,7 @@ def validate_log(mode: str, text: str) -> None:
 
 def run_case(executable: Path, outdir: Path, mode: str, timeout: float) -> Path:
     arguments: list[str] = []
-    if mode != "serial":
+    if mode in ("parallel", "fallback", "gated", "heavy"):
         arguments.append("--parallel")
     if mode == "fallback":
         arguments.append("--inject-worker-failure")
@@ -150,6 +245,8 @@ def run_case(executable: Path, outdir: Path, mode: str, timeout: float) -> Path:
         arguments.append("--production-gate")
     if mode == "heavy":
         arguments.append("--production-heavy")
+    if mode == "translate-hard":
+        arguments.append("--inject-translate-failure")
 
     completed = subprocess.run(
         [str(executable), *arguments],
@@ -192,7 +289,14 @@ def main(argv: Sequence[str] | None = None) -> int:
     try:
         logs = [
             run_case(executable, args.outdir, mode, args.timeout)
-            for mode in ("serial", "parallel", "fallback", "gated", "heavy")
+            for mode in (
+                "serial",
+                "parallel",
+                "fallback",
+                "gated",
+                "heavy",
+                "translate-hard",
+            )
         ]
     except (OSError, subprocess.TimeoutExpired, VulkanTestError) as error:
         print(f"parallel Vulkan test: FAIL: {error}", file=sys.stderr)

--- a/tools/threading/run_parallel_record_vulkan_test.py
+++ b/tools/threading/run_parallel_record_vulkan_test.py
@@ -45,9 +45,21 @@ def _testcase_marker(name: str, text: str) -> tuple[str, dict[str, str]] | None:
     if not matches:
         return None
     marker = matches[0]
-    fields = dict(
-        re.findall(r"(?:^|\s)([A-Za-z0-9_]+)=([^\s]+)", marker.group(0))
+    field_pairs = re.findall(
+        r"(?:^|\s)([A-Za-z0-9_]+)=([^\s]+)", marker.group(0)
     )
+    seen_fields: set[str] = set()
+    duplicate_fields: set[str] = set()
+    for key, _ in field_pairs:
+        if key in seen_fields:
+            duplicate_fields.add(key)
+        seen_fields.add(key)
+    _require(
+        not duplicate_fields,
+        f"{name}: duplicate terminal marker fields: "
+        + ", ".join(sorted(duplicate_fields)),
+    )
+    fields = dict(field_pairs)
     return marker.group("status"), fields
 
 
@@ -171,10 +183,144 @@ def _require_phase15b_copy_contracts(mode: str, text: str) -> None:
     )
 
 
+def _require_phase15c_multi_segment_contracts(mode: str, text: str) -> None:
+    execution = _testcase_marker("MultiSegmentSourceExecution", text)
+    _require(
+        execution is not None,
+        f"{mode}: missing Phase15C multi-segment source execution marker",
+    )
+    recovery = _testcase_marker("MultiSegmentRecoverableRejection", text)
+    _require(
+        recovery is not None,
+        f"{mode}: missing Phase15C multi-segment recoverable rejection marker",
+    )
+    copy_round_trip = _testcase_marker("MultiSegmentCopyRoundTrip", text)
+    _require(
+        copy_round_trip is not None,
+        f"{mode}: missing Phase15C multi-segment Copy round-trip marker",
+    )
+
+    copy_status, copy_fields = copy_round_trip
+    if copy_status == "SKIP":
+        _require(
+            copy_fields.get("reason") == "copy_queue_unavailable"
+            and copy_fields.get("graphics_native") is not None
+            and copy_fields.get("copy_native") is not None,
+            f"{mode}: invalid Phase15C multi-segment Copy SKIP contract",
+        )
+    else:
+        copy_native_alias = copy_fields.get("native_alias")
+        _require(
+            copy_native_alias in {"true", "false"},
+            f"{mode}: Phase15C multi-segment Copy source omitted native alias state",
+        )
+        expected_copy_predecessor_waits = (
+            "0" if copy_native_alias == "true" else "2"
+        )
+        _require(
+            copy_fields.get("source") == "1"
+            and copy_fields.get("segments") == "3"
+            and copy_fields.get("queues") == "Graphics,Copy,Graphics"
+            and copy_fields.get("observed_submit_order") == "G,Copy,G"
+            and copy_fields.get("source_segments") == "0:0/3,0:1/3,0:2/3"
+            and copy_fields.get("predecessor_waits")
+            == expected_copy_predecessor_waits
+            and copy_fields.get("native_owner") == "Submission"
+            and copy_fields.get("callbacks") == "exactly_once"
+            and copy_fields.get("signal") == "success"
+            and copy_fields.get("readback") == "verified"
+            and copy_fields.get("replay") == "0",
+            f"{mode}: incomplete Phase15C multi-segment Copy round-trip contract",
+        )
+
+    execution_status, execution_fields = execution
+    recovery_status, recovery_fields = recovery
+    _require(
+        execution_status == recovery_status,
+        f"{mode}: Phase15C multi-segment execution/recovery status mismatch",
+    )
+    if execution_status == "SKIP":
+        _require(
+            execution_fields.get("reason") == "queue_unavailable"
+            and execution_fields.get("graphics_native") is not None
+            and execution_fields.get("compute_native") is not None
+            and recovery_fields.get("reason") == "queue_unavailable"
+            and recovery_fields.get("graphics_native") is not None
+            and recovery_fields.get("compute_native") is not None,
+            f"{mode}: invalid Phase15C multi-segment SKIP contract",
+        )
+        return
+
+    native_alias = execution_fields.get("native_alias")
+    _require(
+        native_alias in {"true", "false"},
+        f"{mode}: Phase15C multi-segment source omitted native alias state",
+    )
+    expected_first_ready = "G" if native_alias == "true" else "G,C"
+    expected_predecessor_waits = "0" if native_alias == "true" else "1"
+    expected_compute_saw_graphics_finished = (
+        "true" if native_alias == "true" else "false"
+    )
+    _require(
+        execution_fields.get("source") == "1"
+        and execution_fields.get("segments") == "2"
+        and execution_fields.get("queues") == "Graphics,Compute"
+        and execution_fields.get("first_ready_lanes") == expected_first_ready
+        and execution_fields.get("observed_submit_order") == "G,C"
+        and execution_fields.get("source_segments") == "0:0/2,0:1/2"
+        and execution_fields.get("predecessor_waits")
+        == expected_predecessor_waits
+        and execution_fields.get("compute_saw_graphics_finished")
+        == expected_compute_saw_graphics_finished
+        and execution_fields.get("native_owner") == "Submission"
+        and execution_fields.get("callbacks") == "exactly_once"
+        and execution_fields.get("signal") == "success"
+        and execution_fields.get("replay") == "0",
+        f"{mode}: incomplete Phase15C multi-segment source execution contract",
+    )
+
+    distinct_native = recovery_fields.get("distinct_native")
+    _require(
+        recovery_fields.get("source") == "1"
+        and recovery_fields.get("segments") == "2"
+        and recovery_fields.get("dependency") == "rejected"
+        and distinct_native in {"true", "false"}
+        and distinct_native == recovery_fields.get("suffix_recorded")
+        and (distinct_native == "true") == (native_alias == "false")
+        and recovery_fields.get("native_rejected") == "0"
+        and recovery_fields.get("callbacks") == "ordinary1_success0"
+        and recovery_fields.get("signal") == "rejected"
+        and recovery_fields.get("native_accepted") == "1"
+        and recovery_fields.get("recovered_callbacks")
+        == "ordinary1_success1"
+        and recovery_fields.get("runtime") == "recovered"
+        and recovery_fields.get("replay") == "0",
+        f"{mode}: incomplete Phase15C multi-segment recoverable rejection contract",
+    )
+
+
+def _require_phase15c_completion_aggregate_cpu_probe(
+    mode: str, text: str
+) -> None:
+    probe = _testcase_marker("MultiSegmentCompletionAggregateCpuProbe", text)
+    _require(
+        probe is not None and probe[0] == "PASS",
+        f"{mode}: missing multi-segment completion aggregate CPU probe marker",
+    )
+    _, fields = probe
+    _require(
+        fields.get("suffix_first") == "deferred"
+        and fields.get("prefix_second") == "ordinary1_success0"
+        and fields.get("replay") == "0",
+        f"{mode}: incomplete multi-segment completion aggregate CPU probe contract",
+    )
+
+
 def validate_log(mode: str, text: str) -> None:
     _require("[TESTCASE][FAIL]" not in text, f"{mode}: test emitted a FAIL marker")
     _require("VUID-" not in text, f"{mode}: Vulkan validation VUID was emitted")
     _require("Validation Error" not in text, f"{mode}: Vulkan validation error was emitted")
+    _require_phase15c_completion_aggregate_cpu_probe(mode, text)
     if mode == "translate-hard":
         retirement = re.search(
             r"\[TESTCASE\]\[PASS\].*name=ParallelTranslateFailureRetirement"
@@ -200,6 +346,43 @@ def validate_log(mode: str, text: str) -> None:
             )
             is not None,
             "translate-hard: missing clean hard-fault ownership summary",
+        )
+        return
+
+    if mode == "multi-segment-hard":
+        retirement = _testcase_marker(
+            "MultiSegmentPrefixSubmitSuffixTranslateFailure", text
+        )
+        _require(
+            retirement is not None and retirement[0] == "PASS",
+            "multi-segment-hard: missing prefix-submit/suffix-failure PASS marker",
+        )
+        _, retirement_fields = retirement
+        _require(
+            retirement_fields.get("source") == "1"
+            and retirement_fields.get("segments") == "2"
+            and retirement_fields.get("queues") == "Graphics,Graphics"
+            and retirement_fields.get("prefix_translated") == "true"
+            and retirement_fields.get("source_submitted") == "0:0/2"
+            and retirement_fields.get("native_accepted_prefix") == "1"
+            and retirement_fields.get("native_owner") == "Submission"
+            and retirement_fields.get("callbacks") == "ordinary1_success0"
+            and retirement_fields.get("signal") == "failed"
+            and retirement_fields.get("later_callbacks")
+            == "ordinary1_success0"
+            and retirement_fields.get("hard_latch") == "later_batch_failed"
+            and retirement_fields.get("replay") == "0",
+            "multi-segment-hard: incomplete aggregate retirement contract",
+        )
+        _require(
+            re.search(
+                r"\[VulkanFault\]\[Summary\].*first_fault_count=1(?:\s|$)"
+                r".*native_submit_after_fault=0.*native_present_after_fault=0"
+                r".*device_lost=false",
+                text,
+            )
+            is not None,
+            "multi-segment-hard: missing clean hard-fault ownership summary",
         )
         return
 
@@ -249,6 +432,7 @@ def validate_log(mode: str, text: str) -> None:
         f"{mode}: incomplete recoverable Translate retirement contract",
     )
 
+    _require_phase15c_multi_segment_contracts(mode, text)
     _require_phase15b_copy_contracts(mode, text)
 
     expected_fault = "true" if mode == "fallback" else "false"
@@ -369,6 +553,8 @@ def run_case(executable: Path, outdir: Path, mode: str, timeout: float) -> Path:
         arguments.append("--production-heavy")
     if mode == "translate-hard":
         arguments.append("--inject-translate-failure")
+    if mode == "multi-segment-hard":
+        arguments.append("--inject-multi-segment-translate-failure")
 
     completed = subprocess.run(
         [str(executable), *arguments],
@@ -418,6 +604,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                 "gated",
                 "heavy",
                 "translate-hard",
+                "multi-segment-hard",
             )
         ]
     except (OSError, subprocess.TimeoutExpired, VulkanTestError) as error:

--- a/tools/threading/test_run_parallel_record_vulkan_test.py
+++ b/tools/threading/test_run_parallel_record_vulkan_test.py
@@ -2,7 +2,10 @@ from __future__ import annotations
 
 import unittest
 
-import run_parallel_record_vulkan_test as runner
+try:
+    from . import run_parallel_record_vulkan_test as runner
+except ImportError:
+    import run_parallel_record_vulkan_test as runner
 
 
 def completion_probe_line() -> str:
@@ -495,6 +498,29 @@ class VulkanRunnerTests(unittest.TestCase):
         ):
             runner.validate_log("serial", text + duplicate)
 
+    def test_ready_translate_alias_skip_requires_matching_native_queues(self) -> None:
+        text = replace_testcase_marker(
+            pass_line("serial", "false"),
+            "AsyncQueueParallelTranslateSmoke",
+            "[TESTCASE][SKIP] name=AsyncQueueParallelTranslateSmoke "
+            "reason=native_queue_alias cpu_seam=VulkanTranslateWaveScheduler "
+            "graphics_native=0 compute_native=1",
+        )
+        with self.assertRaisesRegex(
+            runner.VulkanTestError, "invalid ready-native-lane Translate SKIP"
+        ):
+            runner.validate_log("serial", text)
+
+    def test_ready_translate_alias_skip_accepts_matching_native_queues(self) -> None:
+        text = replace_testcase_marker(
+            pass_line("serial", "false"),
+            "AsyncQueueParallelTranslateSmoke",
+            "[TESTCASE][SKIP] name=AsyncQueueParallelTranslateSmoke "
+            "reason=native_queue_alias cpu_seam=VulkanTranslateWaveScheduler "
+            "graphics_native=0 compute_native=0",
+        )
+        runner.validate_log("serial", text)
+
     def test_parallel_requires_wave_island_wave_and_concurrency(self) -> None:
         text = wave(1, 0) + island(1) + wave(1, 1) + summary(1) + pass_line("parallel", "false")
         runner.validate_log("parallel", text)
@@ -581,6 +607,57 @@ class VulkanRunnerTests(unittest.TestCase):
         )
         runner.validate_log("translate-hard", text)
 
+    def test_translate_hard_rejects_duplicate_retirement_markers(self) -> None:
+        text = (
+            completion_probe_line()
+            + "[TESTCASE][PASS] name=ParallelTranslateFailureRetirement "
+            "distinct_native=true suffix_recorded=true signals=failed "
+            "callbacks=exactly_once hard_latch=later_batch_failed\n"
+            "[TESTCASE][PASS] name=ParallelTranslateFailureRetirement "
+            "distinct_native=false suffix_recorded=true signals=failed "
+            "callbacks=exactly_once hard_latch=later_batch_failed\n"
+            "[VulkanFault][Summary] first_fault_count=1 "
+            "native_submit_after_fault=0 native_present_after_fault=0 "
+            "device_lost=false\n"
+        )
+        with self.assertRaisesRegex(
+            runner.VulkanTestError, "at most one terminal marker"
+        ):
+            runner.validate_log("translate-hard", text)
+
+    def test_translate_hard_rejects_conflicting_fault_summaries(self) -> None:
+        text = (
+            completion_probe_line()
+            + "[TESTCASE][PASS] name=ParallelTranslateFailureRetirement "
+            "distinct_native=true suffix_recorded=true signals=failed "
+            "callbacks=exactly_once hard_latch=later_batch_failed\n"
+            "[VulkanFault][Summary] first_fault_count=1 "
+            "native_submit_after_fault=0 native_present_after_fault=0 "
+            "device_lost=false\n"
+            "[VulkanFault][Summary] first_fault_count=2 "
+            "native_submit_after_fault=7 native_present_after_fault=0 "
+            "device_lost=true\n"
+        )
+        with self.assertRaisesRegex(
+            runner.VulkanTestError, "expected exactly one marker"
+        ):
+            runner.validate_log("translate-hard", text)
+
+    def test_translate_hard_rejects_duplicate_fault_summary_fields(self) -> None:
+        text = (
+            completion_probe_line()
+            + "[TESTCASE][PASS] name=ParallelTranslateFailureRetirement "
+            "distinct_native=true suffix_recorded=true signals=failed "
+            "callbacks=exactly_once hard_latch=later_batch_failed\n"
+            "[VulkanFault][Summary] first_fault_count=1 first_fault_count=2 "
+            "native_submit_after_fault=0 native_present_after_fault=0 "
+            "device_lost=false\n"
+        )
+        with self.assertRaisesRegex(
+            runner.VulkanTestError, "duplicate fields"
+        ):
+            runner.validate_log("translate-hard", text)
+
     def test_translate_hard_rejects_multi_digit_fault_count_prefix(self) -> None:
         text = (
             completion_probe_line()
@@ -650,6 +727,29 @@ class VulkanRunnerTests(unittest.TestCase):
         )
         with self.assertRaisesRegex(
             runner.VulkanTestError, "aggregate retirement contract"
+        ):
+            runner.validate_log("multi-segment-hard", text)
+
+    def test_multi_segment_hard_rejects_duplicate_fault_summaries(self) -> None:
+        text = (
+            completion_probe_line()
+            + "[TESTCASE][PASS] "
+            "name=MultiSegmentPrefixSubmitSuffixTranslateFailure "
+            "source=1 segments=2 queues=Graphics,Graphics "
+            "prefix_translated=true source_submitted=0:0/2 "
+            "native_accepted_prefix=1 native_owner=Submission "
+            "callbacks=ordinary1_success0 signal=failed "
+            "later_callbacks=ordinary1_success0 "
+            "hard_latch=later_batch_failed replay=0\n"
+            "[VulkanFault][Summary] first_fault_count=1 "
+            "native_submit_after_fault=0 native_present_after_fault=0 "
+            "device_lost=false\n"
+            "[VulkanFault][Summary] first_fault_count=1 "
+            "native_submit_after_fault=3 native_present_after_fault=0 "
+            "device_lost=false\n"
+        )
+        with self.assertRaisesRegex(
+            runner.VulkanTestError, "expected exactly one marker"
         ):
             runner.validate_log("multi-segment-hard", text)
 

--- a/tools/threading/test_run_parallel_record_vulkan_test.py
+++ b/tools/threading/test_run_parallel_record_vulkan_test.py
@@ -15,6 +15,13 @@ def pass_line(
         "[TESTCASE][PASS] name=ParallelRecordOrderedReadback "
         f"mode={mode} worker_fault={fault} production_gate={production_gate} "
         f"production_heavy={production_heavy} iterations=24\n"
+        "[TESTCASE][PASS] name=AsyncQueueParallelTranslateSmoke "
+        "sources=3 batch=1 source_order=G,G,C first_ready_lanes=G,C "
+        "observed_submit_order=G,G,C explicit_state=true "
+        "callbacks=exactly_once\n"
+        "[TESTCASE][PASS] name=ParallelTranslateRecoverableRejection "
+        "distinct_native=true suffix_recorded=true signals=rejected "
+        "callbacks=exactly_once runtime=recovered same_scope_reentry=Compute\n"
     )
 
 
@@ -43,6 +50,64 @@ def summary(batch: int, outcome: str = "parallel") -> str:
 class VulkanRunnerTests(unittest.TestCase):
     def test_serial_accepts_only_pass_marker(self) -> None:
         runner.validate_log("serial", pass_line("serial", "false"))
+
+    def test_regular_mode_requires_parallel_translate_contracts(self) -> None:
+        text = (
+            "[TESTCASE][PASS] name=ParallelRecordOrderedReadback "
+            "mode=serial worker_fault=false production_gate=false "
+            "production_heavy=false iterations=24\n"
+        )
+        with self.assertRaisesRegex(
+            runner.VulkanTestError, "ready-native-lane Translate smoke"
+        ):
+            runner.validate_log("serial", text)
+
+    def test_ready_translate_rejects_unapproved_skip_reason(self) -> None:
+        text = pass_line("serial", "false").replace(
+            "[TESTCASE][PASS] name=AsyncQueueParallelTranslateSmoke "
+            "sources=3 batch=1 source_order=G,G,C first_ready_lanes=G,C "
+            "observed_submit_order=G,G,C explicit_state=true "
+            "callbacks=exactly_once",
+            "[TESTCASE][SKIP] name=AsyncQueueParallelTranslateSmoke "
+            "reason=test_disabled cpu_seam=VulkanTranslateWaveScheduler",
+        )
+        with self.assertRaisesRegex(
+            runner.VulkanTestError, "invalid ready-native-lane"
+        ):
+            runner.validate_log("serial", text)
+
+    def test_ready_translate_requires_observed_submit_order(self) -> None:
+        text = pass_line("serial", "false").replace(
+            "observed_submit_order=G,G,C", "observed_submit_order=G,C,G"
+        )
+        with self.assertRaisesRegex(
+            runner.VulkanTestError, "incomplete ready-native-lane"
+        ):
+            runner.validate_log("serial", text)
+
+    def test_recoverable_translate_requires_matching_suffix_observation(
+        self,
+    ) -> None:
+        text = pass_line("serial", "false").replace(
+            "distinct_native=true suffix_recorded=true",
+            "distinct_native=true suffix_recorded=false",
+        )
+        with self.assertRaisesRegex(
+            runner.VulkanTestError, "incomplete recoverable"
+        ):
+            runner.validate_log("serial", text)
+
+    def test_ready_translate_rejects_duplicate_terminal_markers(self) -> None:
+        text = pass_line("serial", "false")
+        duplicate = (
+            "[TESTCASE][SKIP] name=AsyncQueueParallelTranslateSmoke "
+            "reason=native_queue_alias "
+            "cpu_seam=VulkanTranslateWaveScheduler\n"
+        )
+        with self.assertRaisesRegex(
+            runner.VulkanTestError, "at most one terminal marker"
+        ):
+            runner.validate_log("serial", text + duplicate)
 
     def test_parallel_requires_wave_island_wave_and_concurrency(self) -> None:
         text = wave(1, 0) + island(1) + wave(1, 1) + summary(1) + pass_line("parallel", "false")
@@ -90,6 +155,56 @@ class VulkanRunnerTests(unittest.TestCase):
     def test_validation_vuid_is_fatal(self) -> None:
         with self.assertRaisesRegex(runner.VulkanTestError, "Vulkan validation VUID"):
             runner.validate_log("serial", "VUID-vkQueueSubmit-test\n" + pass_line("serial", "false"))
+
+    def test_translate_hard_requires_retirement_and_fault_summary(self) -> None:
+        text = (
+            "[TESTCASE][PASS] name=ParallelTranslateFailureRetirement "
+            "distinct_native=true suffix_recorded=true signals=failed "
+            "callbacks=exactly_once hard_latch=later_batch_failed\n"
+            "[VulkanFault][Summary] first_fault_count=1 "
+            "native_submit_after_fault=0 native_present_after_fault=0 "
+            "device_lost=false\n"
+        )
+        runner.validate_log("translate-hard", text)
+
+    def test_translate_hard_rejects_native_submit_after_fault(self) -> None:
+        text = (
+            "[TESTCASE][PASS] name=ParallelTranslateFailureRetirement "
+            "distinct_native=true suffix_recorded=true signals=failed "
+            "callbacks=exactly_once hard_latch=later_batch_failed\n"
+            "[VulkanFault][Summary] first_fault_count=1 "
+            "native_submit_after_fault=1 native_present_after_fault=0 "
+            "device_lost=false\n"
+        )
+        with self.assertRaisesRegex(
+            runner.VulkanTestError, "hard-fault ownership summary"
+        ):
+            runner.validate_log("translate-hard", text)
+
+    def test_translate_hard_accepts_native_alias_without_suffix_recording(self) -> None:
+        text = (
+            "[TESTCASE][PASS] name=ParallelTranslateFailureRetirement "
+            "distinct_native=false suffix_recorded=false signals=failed "
+            "callbacks=exactly_once hard_latch=later_batch_failed\n"
+            "[VulkanFault][Summary] first_fault_count=1 "
+            "native_submit_after_fault=0 native_present_after_fault=0 "
+            "device_lost=false\n"
+        )
+        runner.validate_log("translate-hard", text)
+
+    def test_translate_hard_rejects_multi_digit_fault_count_prefix(self) -> None:
+        text = (
+            "[TESTCASE][PASS] name=ParallelTranslateFailureRetirement "
+            "distinct_native=true suffix_recorded=true signals=failed "
+            "callbacks=exactly_once hard_latch=later_batch_failed\n"
+            "[VulkanFault][Summary] first_fault_count=10 "
+            "native_submit_after_fault=0 native_present_after_fault=0 "
+            "device_lost=false\n"
+        )
+        with self.assertRaisesRegex(
+            runner.VulkanTestError, "hard-fault ownership summary"
+        ):
+            runner.validate_log("translate-hard", text)
 
 
 if __name__ == "__main__":

--- a/tools/threading/test_run_parallel_record_vulkan_test.py
+++ b/tools/threading/test_run_parallel_record_vulkan_test.py
@@ -5,6 +5,13 @@ import unittest
 import run_parallel_record_vulkan_test as runner
 
 
+def completion_probe_line() -> str:
+    return (
+        "[TESTCASE][PASS] name=MultiSegmentCompletionAggregateCpuProbe "
+        "suffix_first=deferred prefix_second=ordinary1_success0 replay=0\n"
+    )
+
+
 def pass_line(
     mode: str,
     fault: str,
@@ -12,7 +19,8 @@ def pass_line(
     production_heavy: str = "false",
 ) -> str:
     return (
-        "[TESTCASE][PASS] name=ParallelRecordOrderedReadback "
+        completion_probe_line()
+        + "[TESTCASE][PASS] name=ParallelRecordOrderedReadback "
         f"mode={mode} worker_fault={fault} production_gate={production_gate} "
         f"production_heavy={production_heavy} iterations=24\n"
         "[TESTCASE][PASS] name=AsyncQueueParallelTranslateSmoke "
@@ -22,6 +30,22 @@ def pass_line(
         "[TESTCASE][PASS] name=ParallelTranslateRecoverableRejection "
         "distinct_native=true suffix_recorded=true signals=rejected "
         "callbacks=exactly_once runtime=recovered same_scope_reentry=Compute\n"
+        "[TESTCASE][PASS] name=MultiSegmentSourceExecution "
+        "source=1 segments=2 queues=Graphics,Compute native_alias=false "
+        "first_ready_lanes=G,C observed_submit_order=G,C "
+        "source_segments=0:0/2,0:1/2 predecessor_waits=1 "
+        "compute_saw_graphics_finished=false native_owner=Submission "
+        "callbacks=exactly_once signal=success replay=0\n"
+        "[TESTCASE][PASS] name=MultiSegmentCopyRoundTrip "
+        "source=1 segments=3 queues=Graphics,Copy,Graphics native_alias=false "
+        "observed_submit_order=G,Copy,G source_segments=0:0/3,0:1/3,0:2/3 "
+        "predecessor_waits=2 native_owner=Submission callbacks=exactly_once "
+        "signal=success readback=verified replay=0\n"
+        "[TESTCASE][PASS] name=MultiSegmentRecoverableRejection "
+        "source=1 segments=2 dependency=rejected distinct_native=true "
+        "suffix_recorded=true native_rejected=0 "
+        "callbacks=ordinary1_success0 signal=rejected native_accepted=1 "
+        "recovered_callbacks=ordinary1_success1 runtime=recovered replay=0\n"
         "[TESTCASE][PASS] name=ActiveRdgGraphicsCopyRoundTrip "
         f"mode={mode} ownership=release-acquire transfers=2 gpu_syncs=2 "
         "graphics_native=0 copy_native=2 native_alias=false readback=verified\n"
@@ -43,6 +67,15 @@ def pass_line(
         "queues=Copy,Graphics copy_wait=entered dependency=unpublished "
         "native_submit=0 sync_wait=registered concurrent_sync=drained\n"
     )
+
+
+def replace_testcase_marker(text: str, name: str, replacement: str) -> str:
+    marker = f"name={name} "
+    lines = [
+        replacement if marker in line else line
+        for line in text.splitlines()
+    ]
+    return "\n".join(lines) + "\n"
 
 
 def wave(batch: int, index: int) -> str:
@@ -71,9 +104,60 @@ class VulkanRunnerTests(unittest.TestCase):
     def test_serial_accepts_only_pass_marker(self) -> None:
         runner.validate_log("serial", pass_line("serial", "false"))
 
+    def test_completion_aggregate_cpu_probe_contract_is_accepted(self) -> None:
+        runner.validate_log("serial", pass_line("serial", "false"))
+
+    def test_completion_aggregate_cpu_probe_marker_is_required(self) -> None:
+        text = replace_testcase_marker(
+            pass_line("serial", "false"),
+            "MultiSegmentCompletionAggregateCpuProbe",
+            "",
+        )
+        with self.assertRaisesRegex(
+            runner.VulkanTestError,
+            "completion aggregate CPU probe marker",
+        ):
+            runner.validate_log("serial", text)
+
+    def test_completion_aggregate_cpu_probe_fields_are_required(self) -> None:
+        text = pass_line("serial", "false").replace(
+            "prefix_second=ordinary1_success0",
+            "prefix_second=ordinary1_success1",
+        )
+        with self.assertRaisesRegex(
+            runner.VulkanTestError,
+            "completion aggregate CPU probe contract",
+        ):
+            runner.validate_log("serial", text)
+
+    def test_marker_parser_accepts_unique_fields(self) -> None:
+        marker = runner._testcase_marker(
+            "UniqueFields",
+            "[TESTCASE][PASS] name=UniqueFields first=1 second=2\n",
+        )
+        self.assertEqual(
+            marker,
+            (
+                "PASS",
+                {"name": "UniqueFields", "first": "1", "second": "2"},
+            ),
+        )
+
+    def test_marker_parser_rejects_duplicate_fields(self) -> None:
+        with self.assertRaisesRegex(
+            runner.VulkanTestError,
+            "duplicate terminal marker fields: callbacks",
+        ):
+            runner._testcase_marker(
+                "DuplicateFields",
+                "[TESTCASE][PASS] name=DuplicateFields "
+                "callbacks=wrong callbacks=exactly_once\n",
+            )
+
     def test_regular_mode_requires_parallel_translate_contracts(self) -> None:
         text = (
-            "[TESTCASE][PASS] name=ParallelRecordOrderedReadback "
+            completion_probe_line()
+            + "[TESTCASE][PASS] name=ParallelRecordOrderedReadback "
             "mode=serial worker_fault=false production_gate=false "
             "production_heavy=false iterations=24\n"
         )
@@ -114,6 +198,190 @@ class VulkanRunnerTests(unittest.TestCase):
         )
         with self.assertRaisesRegex(
             runner.VulkanTestError, "incomplete recoverable"
+        ):
+            runner.validate_log("serial", text)
+
+    def test_multi_segment_requires_stable_source_segment_identity(self) -> None:
+        text = pass_line("serial", "false").replace(
+            "source_segments=0:0/2,0:1/2",
+            "source_segments=0:0/2,1:1/2",
+        )
+        with self.assertRaisesRegex(
+            runner.VulkanTestError,
+            "multi-segment source execution",
+        ):
+            runner.validate_log("serial", text)
+
+    def test_multi_segment_requires_deterministic_alias_observation(self) -> None:
+        text = pass_line("serial", "false").replace(
+            "compute_saw_graphics_finished=false",
+            "compute_saw_graphics_finished=true",
+        )
+        with self.assertRaisesRegex(
+            runner.VulkanTestError,
+            "multi-segment source execution",
+        ):
+            runner.validate_log("serial", text)
+
+    def test_multi_segment_queue_skip_contract_is_accepted(self) -> None:
+        text = replace_testcase_marker(
+            pass_line("serial", "false"),
+            "MultiSegmentSourceExecution",
+            "[TESTCASE][SKIP] name=MultiSegmentSourceExecution "
+            "reason=queue_unavailable graphics_native=0 compute_native=1",
+        )
+        text = replace_testcase_marker(
+            text,
+            "MultiSegmentRecoverableRejection",
+            "[TESTCASE][SKIP] name=MultiSegmentRecoverableRejection "
+            "reason=queue_unavailable graphics_native=0 compute_native=1",
+        )
+        runner.validate_log("serial", text)
+
+    def test_multi_segment_queue_skip_requires_topology_fields(self) -> None:
+        text = replace_testcase_marker(
+            pass_line("serial", "false"),
+            "MultiSegmentSourceExecution",
+            "[TESTCASE][SKIP] name=MultiSegmentSourceExecution "
+            "reason=queue_unavailable graphics_native=0",
+        )
+        text = replace_testcase_marker(
+            text,
+            "MultiSegmentRecoverableRejection",
+            "[TESTCASE][SKIP] name=MultiSegmentRecoverableRejection "
+            "reason=queue_unavailable graphics_native=0 compute_native=1",
+        )
+        with self.assertRaisesRegex(
+            runner.VulkanTestError,
+            "invalid Phase15C multi-segment SKIP contract",
+        ):
+            runner.validate_log("serial", text)
+
+    def test_multi_segment_recovery_skip_requires_topology_fields(self) -> None:
+        text = replace_testcase_marker(
+            pass_line("serial", "false"),
+            "MultiSegmentSourceExecution",
+            "[TESTCASE][SKIP] name=MultiSegmentSourceExecution "
+            "reason=queue_unavailable graphics_native=0 compute_native=1",
+        )
+        text = replace_testcase_marker(
+            text,
+            "MultiSegmentRecoverableRejection",
+            "[TESTCASE][SKIP] name=MultiSegmentRecoverableRejection "
+            "reason=queue_unavailable compute_native=1",
+        )
+        with self.assertRaisesRegex(
+            runner.VulkanTestError,
+            "invalid Phase15C multi-segment SKIP contract",
+        ):
+            runner.validate_log("serial", text)
+
+    def test_multi_segment_alias_requires_serial_translate_and_no_wait(
+        self,
+    ) -> None:
+        text = pass_line("serial", "false").replace(
+            "native_alias=false first_ready_lanes=G,C",
+            "native_alias=true first_ready_lanes=G,C",
+        )
+        with self.assertRaisesRegex(
+            runner.VulkanTestError,
+            "multi-segment source execution",
+        ):
+            runner.validate_log("serial", text)
+
+    def test_multi_segment_copy_requires_real_native_submit_order(self) -> None:
+        text = pass_line("serial", "false").replace(
+            "observed_submit_order=G,Copy,G",
+            "observed_submit_order=G,G,Copy",
+        )
+        with self.assertRaisesRegex(
+            runner.VulkanTestError,
+            "multi-segment Copy round-trip",
+        ):
+            runner.validate_log("serial", text)
+
+    def test_multi_segment_copy_alias_requires_no_predecessor_waits(self) -> None:
+        text = pass_line("serial", "false").replace(
+            "queues=Graphics,Copy,Graphics native_alias=false",
+            "queues=Graphics,Copy,Graphics native_alias=true",
+        )
+        with self.assertRaisesRegex(
+            runner.VulkanTestError,
+            "multi-segment Copy round-trip",
+        ):
+            runner.validate_log("serial", text)
+
+    def test_multi_segment_copy_native_alias_contract_is_accepted(self) -> None:
+        text = pass_line("serial", "false")
+        text = text.replace(
+            "queues=Graphics,Copy,Graphics native_alias=false",
+            "queues=Graphics,Copy,Graphics native_alias=true",
+        ).replace(
+            "source_segments=0:0/3,0:1/3,0:2/3 predecessor_waits=2",
+            "source_segments=0:0/3,0:1/3,0:2/3 predecessor_waits=0",
+        )
+        runner.validate_log("serial", text)
+
+    def test_multi_segment_copy_skip_contract_is_accepted(self) -> None:
+        text = replace_testcase_marker(
+            pass_line("serial", "false"),
+            "MultiSegmentCopyRoundTrip",
+            "[TESTCASE][SKIP] name=MultiSegmentCopyRoundTrip "
+            "reason=copy_queue_unavailable graphics_native=0 copy_native=2",
+        )
+        runner.validate_log("serial", text)
+
+    def test_multi_segment_copy_skip_requires_topology_fields(self) -> None:
+        text = replace_testcase_marker(
+            pass_line("serial", "false"),
+            "MultiSegmentCopyRoundTrip",
+            "[TESTCASE][SKIP] name=MultiSegmentCopyRoundTrip "
+            "reason=copy_queue_unavailable graphics_native=0",
+        )
+        with self.assertRaisesRegex(
+            runner.VulkanTestError,
+            "invalid Phase15C multi-segment Copy SKIP contract",
+        ):
+            runner.validate_log("serial", text)
+
+    def test_multi_segment_native_alias_contract_is_accepted(self) -> None:
+        text = pass_line("serial", "false")
+        text = text.replace(
+            "native_alias=false first_ready_lanes=G,C",
+            "native_alias=true first_ready_lanes=G",
+        ).replace(
+            "source_segments=0:0/2,0:1/2 predecessor_waits=1",
+            "source_segments=0:0/2,0:1/2 predecessor_waits=0",
+        ).replace(
+            "compute_saw_graphics_finished=false",
+            "compute_saw_graphics_finished=true",
+        ).replace(
+            "dependency=rejected distinct_native=true suffix_recorded=true",
+            "dependency=rejected distinct_native=false suffix_recorded=false",
+        )
+        runner.validate_log("serial", text)
+
+    def test_multi_segment_rejection_requires_aggregate_success_suppression(
+        self,
+    ) -> None:
+        text = pass_line("serial", "false").replace(
+            "callbacks=ordinary1_success0 signal=rejected",
+            "callbacks=ordinary1_success1 signal=rejected",
+        )
+        with self.assertRaisesRegex(
+            runner.VulkanTestError,
+            "multi-segment recoverable rejection",
+        ):
+            runner.validate_log("serial", text)
+
+    def test_multi_segment_rejection_must_skip_native_submit(self) -> None:
+        text = pass_line("serial", "false").replace(
+            "suffix_recorded=true native_rejected=0",
+            "suffix_recorded=true native_rejected=1",
+        )
+        with self.assertRaisesRegex(
+            runner.VulkanTestError,
+            "multi-segment recoverable rejection",
         ):
             runner.validate_log("serial", text)
 
@@ -276,7 +544,8 @@ class VulkanRunnerTests(unittest.TestCase):
 
     def test_translate_hard_requires_retirement_and_fault_summary(self) -> None:
         text = (
-            "[TESTCASE][PASS] name=ParallelTranslateFailureRetirement "
+            completion_probe_line()
+            + "[TESTCASE][PASS] name=ParallelTranslateFailureRetirement "
             "distinct_native=true suffix_recorded=true signals=failed "
             "callbacks=exactly_once hard_latch=later_batch_failed\n"
             "[VulkanFault][Summary] first_fault_count=1 "
@@ -287,7 +556,8 @@ class VulkanRunnerTests(unittest.TestCase):
 
     def test_translate_hard_rejects_native_submit_after_fault(self) -> None:
         text = (
-            "[TESTCASE][PASS] name=ParallelTranslateFailureRetirement "
+            completion_probe_line()
+            + "[TESTCASE][PASS] name=ParallelTranslateFailureRetirement "
             "distinct_native=true suffix_recorded=true signals=failed "
             "callbacks=exactly_once hard_latch=later_batch_failed\n"
             "[VulkanFault][Summary] first_fault_count=1 "
@@ -301,7 +571,8 @@ class VulkanRunnerTests(unittest.TestCase):
 
     def test_translate_hard_accepts_native_alias_without_suffix_recording(self) -> None:
         text = (
-            "[TESTCASE][PASS] name=ParallelTranslateFailureRetirement "
+            completion_probe_line()
+            + "[TESTCASE][PASS] name=ParallelTranslateFailureRetirement "
             "distinct_native=false suffix_recorded=false signals=failed "
             "callbacks=exactly_once hard_latch=later_batch_failed\n"
             "[VulkanFault][Summary] first_fault_count=1 "
@@ -312,7 +583,8 @@ class VulkanRunnerTests(unittest.TestCase):
 
     def test_translate_hard_rejects_multi_digit_fault_count_prefix(self) -> None:
         text = (
-            "[TESTCASE][PASS] name=ParallelTranslateFailureRetirement "
+            completion_probe_line()
+            + "[TESTCASE][PASS] name=ParallelTranslateFailureRetirement "
             "distinct_native=true suffix_recorded=true signals=failed "
             "callbacks=exactly_once hard_latch=later_batch_failed\n"
             "[VulkanFault][Summary] first_fault_count=10 "
@@ -323,6 +595,63 @@ class VulkanRunnerTests(unittest.TestCase):
             runner.VulkanTestError, "hard-fault ownership summary"
         ):
             runner.validate_log("translate-hard", text)
+
+    def test_multi_segment_hard_requires_aggregate_retirement(self) -> None:
+        text = (
+            completion_probe_line()
+            + "[TESTCASE][PASS] "
+            "name=MultiSegmentPrefixSubmitSuffixTranslateFailure "
+            "source=1 segments=2 queues=Graphics,Graphics "
+            "prefix_translated=true source_submitted=0:0/2 "
+            "native_accepted_prefix=1 native_owner=Submission "
+            "callbacks=ordinary1_success0 signal=failed "
+            "later_callbacks=ordinary1_success0 "
+            "hard_latch=later_batch_failed replay=0\n"
+            "[VulkanFault][Summary] first_fault_count=1 "
+            "native_submit_after_fault=0 native_present_after_fault=0 "
+            "device_lost=false\n"
+        )
+        runner.validate_log("multi-segment-hard", text)
+
+    def test_multi_segment_hard_rejects_early_source_success(self) -> None:
+        text = (
+            completion_probe_line()
+            + "[TESTCASE][PASS] "
+            "name=MultiSegmentPrefixSubmitSuffixTranslateFailure "
+            "source=1 segments=2 queues=Graphics,Graphics "
+            "prefix_translated=true source_submitted=0:0/2 "
+            "native_accepted_prefix=1 native_owner=Submission "
+            "callbacks=ordinary1_success1 signal=failed "
+            "later_callbacks=ordinary1_success0 "
+            "hard_latch=later_batch_failed replay=0\n"
+            "[VulkanFault][Summary] first_fault_count=1 "
+            "native_submit_after_fault=0 native_present_after_fault=0 "
+            "device_lost=false\n"
+        )
+        with self.assertRaisesRegex(
+            runner.VulkanTestError, "aggregate retirement contract"
+        ):
+            runner.validate_log("multi-segment-hard", text)
+
+    def test_multi_segment_hard_requires_exactly_one_native_prefix(self) -> None:
+        text = (
+            completion_probe_line()
+            + "[TESTCASE][PASS] "
+            "name=MultiSegmentPrefixSubmitSuffixTranslateFailure "
+            "source=1 segments=2 queues=Graphics,Graphics "
+            "prefix_translated=true source_submitted=0:0/2 "
+            "native_accepted_prefix=2 native_owner=Submission "
+            "callbacks=ordinary1_success0 signal=failed "
+            "later_callbacks=ordinary1_success0 "
+            "hard_latch=later_batch_failed replay=0\n"
+            "[VulkanFault][Summary] first_fault_count=1 "
+            "native_submit_after_fault=0 native_present_after_fault=0 "
+            "device_lost=false\n"
+        )
+        with self.assertRaisesRegex(
+            runner.VulkanTestError, "aggregate retirement contract"
+        ):
+            runner.validate_log("multi-segment-hard", text)
 
 
 if __name__ == "__main__":

--- a/tools/threading/test_run_parallel_record_vulkan_test.py
+++ b/tools/threading/test_run_parallel_record_vulkan_test.py
@@ -22,6 +22,26 @@ def pass_line(
         "[TESTCASE][PASS] name=ParallelTranslateRecoverableRejection "
         "distinct_native=true suffix_recorded=true signals=rejected "
         "callbacks=exactly_once runtime=recovered same_scope_reentry=Compute\n"
+        "[TESTCASE][PASS] name=ActiveRdgGraphicsCopyRoundTrip "
+        f"mode={mode} ownership=release-acquire transfers=2 gpu_syncs=2 "
+        "graphics_native=0 copy_native=2 native_alias=false readback=verified\n"
+        "[TESTCASE][PASS] name=RecoverableCopyDependencyRejection "
+        "fence=reused rejected=N recovered=N+1 stale_wait=rejected "
+        "publication=Submission native_rejected=0 native_accepted=3 "
+        "native_owner=verified runtime=recovered replay=0\n"
+        "[TESTCASE][PASS] name=CrossQueueSubmissionTopology "
+        "batches=4 queues=Graphics,Compute,Copy,Graphics ownership=explicit "
+        "native_owner=verified native_alias=false callbacks=exactly_once "
+        "replay=0\n"
+        "[TESTCASE][PASS] name=DirectCopyExecuteRejected "
+        "runtime_claim=exclusive native_submit=0 callbacks=exactly_once "
+        "signal=rejected replay=0\n"
+        "[TESTCASE][PASS] name=VulkanStorageUnifiedCopySubmission "
+        "commits=2 signals=2 native_submit=2 native_owner=Submission "
+        "session_recycle=verified readback=verified\n"
+        "[TESTCASE][PASS] name=ShutdownDependencyCancellation "
+        "queues=Copy,Graphics copy_wait=entered dependency=unpublished "
+        "native_submit=0 sync_wait=registered concurrent_sync=drained\n"
     )
 
 
@@ -94,6 +114,104 @@ class VulkanRunnerTests(unittest.TestCase):
         )
         with self.assertRaisesRegex(
             runner.VulkanTestError, "incomplete recoverable"
+        ):
+            runner.validate_log("serial", text)
+
+    def test_copy_contracts_require_real_native_submission_owner(self) -> None:
+        text = pass_line("serial", "false").replace(
+            "native_owner=verified runtime=recovered",
+            "native_owner=legacy runtime=recovered",
+            1,
+        )
+        with self.assertRaisesRegex(
+            runner.VulkanTestError, "recoverable Copy rejection"
+        ):
+            runner.validate_log("serial", text)
+
+    def test_copy_contracts_require_rejected_packets_skip_native_submit(
+        self,
+    ) -> None:
+        text = pass_line("serial", "false").replace(
+            "native_rejected=0 native_accepted=3",
+            "native_rejected=1 native_accepted=3",
+        )
+        with self.assertRaisesRegex(
+            runner.VulkanTestError, "recoverable Copy rejection"
+        ):
+            runner.validate_log("serial", text)
+
+    def test_copy_contracts_require_alias_aware_gpu_sync_count(self) -> None:
+        text = pass_line("serial", "false").replace(
+            "gpu_syncs=2 graphics_native=0 copy_native=2 native_alias=false",
+            "gpu_syncs=2 graphics_native=0 copy_native=0 native_alias=true",
+        )
+        with self.assertRaisesRegex(
+            runner.VulkanTestError, "Graphics-Copy round-trip"
+        ):
+            runner.validate_log("serial", text)
+
+    def test_copy_contracts_require_deterministic_shutdown_wait(self) -> None:
+        text = pass_line("serial", "false").replace(
+            "copy_wait=entered dependency=unpublished",
+            "copy_wait=unobserved dependency=unpublished",
+        )
+        with self.assertRaisesRegex(
+            runner.VulkanTestError, "shutdown dependency cancellation"
+        ):
+            runner.validate_log("serial", text)
+
+    def test_copy_contracts_require_cross_queue_native_owner(self) -> None:
+        text = pass_line("serial", "false").replace(
+            "ownership=explicit native_owner=verified native_alias=false",
+            "ownership=explicit native_owner=legacy native_alias=false",
+        )
+        with self.assertRaisesRegex(
+            runner.VulkanTestError, "cross-queue Submission ownership"
+        ):
+            runner.validate_log("serial", text)
+
+    def test_copy_contracts_require_direct_execute_skip_native_submit(
+        self,
+    ) -> None:
+        text = pass_line("serial", "false").replace(
+            "runtime_claim=exclusive native_submit=0 callbacks=exactly_once",
+            "runtime_claim=exclusive native_submit=1 callbacks=exactly_once",
+        )
+        with self.assertRaisesRegex(
+            runner.VulkanTestError, "direct Copy fail-closed"
+        ):
+            runner.validate_log("serial", text)
+
+    def test_copy_contracts_require_io_session_recycle_and_native_submit(
+        self,
+    ) -> None:
+        text = pass_line("serial", "false").replace(
+            "commits=2 signals=2 native_submit=2 native_owner=Submission",
+            "commits=2 signals=2 native_submit=1 native_owner=Submission",
+        )
+        with self.assertRaisesRegex(
+            runner.VulkanTestError, "VulkanStorage unified Copy submission"
+        ):
+            runner.validate_log("serial", text)
+
+    def test_copy_contracts_require_shutdown_skip_native_submit(self) -> None:
+        text = pass_line("serial", "false").replace(
+            "dependency=unpublished native_submit=0 sync_wait=registered",
+            "dependency=unpublished native_submit=1 sync_wait=registered",
+        )
+        with self.assertRaisesRegex(
+            runner.VulkanTestError, "shutdown dependency cancellation"
+        ):
+            runner.validate_log("serial", text)
+
+    def test_copy_contracts_require_round_trip_mode(self) -> None:
+        text = pass_line("serial", "false").replace(
+            "mode=serial ownership=release-acquire transfers=2",
+            "mode=parallel ownership=release-acquire transfers=2",
+            1,
+        )
+        with self.assertRaisesRegex(
+            runner.VulkanTestError, "Graphics-Copy round-trip"
         ):
             runner.validate_log("serial", text)
 


### PR DESCRIPTION
## What changed

- translate dependency-ready Graphics/Compute native queue lanes concurrently on TaskGraph workers while preserving one stable Submission owner
- split Copy translation/recording from native submission and route Copy through the same Submission ownership model
- materialize multi-segment source submits into executable per-segment packets, preserving stable flat-key order, cross-native predecessor waits, and exactly-once aggregate source callbacks
- add failure retirement, recoverable rejection, native-lane scheduler, Copy round-trip, multi-segment, and hard-fault validation coverage
- make hard-fault log validation fail closed on duplicate/conflicting terminal markers or fields, and topology-check native-alias SKIP evidence
- update the validation guide for the complete seven-mode gate

## Architecture impact

This is the first Phase15 batch after the RT RDG topology merge. Runtime ownership is now `Executor=1`, `TranslateCoordinator=1`, `TranslateWorkers=TaskGraph`, `Submission=1`, with Completion remaining a separate retirement owner. Translation may run concurrently across ready native lanes; submission remains serial and deterministic. The cross-batch window intentionally remains `batch_window=1`; bounded pipelining is the next batch.

The deferred Non-RDG automatic hazard/cross-queue inference option is not included in this PR.

## Validation

- Debug build: pass (Visual Studio 17 2022 / MSVC fallback; canonical Ninja/Clang tools were unavailable locally)
- Debug CTest: 17/17 pass
- Release build: pass
- Release CTest: 17/17 pass
- Python validation parser tests: 53/53 pass from both repository-root module invocation and direct script-directory invocation
- Debug Vulkan seven-mode matrix: pass (`serial`, `parallel`, `fallback`, `gated`, `heavy`, `translate-hard`, `multi-segment-hard`)
- Release Vulkan seven-mode matrix: pass
- Release editor runtime with threaded RT/RHI + RT RDG parallel recording: pass; five non-black captures across maximize/resize/restore/soak, clean exit, no VUID, device-lost, submit failure, assertion, or access violation

The first clean-config build for each configuration encountered the repository's existing GKlib generated `io.h` parallel-build race; the immediate incremental retry completed successfully.