### PR TITLE
RHI Phase 15D: bounded cross-batch Translate/Submission pipeline

### DIFF
--- a/source/runtime/Engine.cpp
+++ b/source/runtime/Engine.cpp
@@ -7,6 +7,7 @@
 #include "remote/RemoteModule.h"
 #include "RenderThread.h"
 #include "rhi/RHI.h"
+#include "rhi/RHISubmissionPipelinePolicy.h"
 #include "scripting/PythonRuntimeConfig.h"
 #include "scripting/ScriptHost.h"
 #include "shader/ShaderResourceManager.h"
@@ -595,6 +596,18 @@ void Engine::Init(
         ParseThreadingRasterLifecycleValidation(argc, argv);
     const auto raster_framebuffer_validation =
         ParseThreadingRasterFramebufferValidation(argc, argv);
+    const uint submission_batch_window =
+        RHISubmissionPipelinePolicy::ClampBatchWindow(
+            config.engine.threading.submission_batch_window
+        );
+    if (submission_batch_window != config.engine.threading.submission_batch_window) {
+        LOG_WARNING(
+            "[Threading] submission_batch_window={} is outside the supported range; "
+            "clamping to {}.",
+            config.engine.threading.submission_batch_window,
+            submission_batch_window
+        );
+    }
     if (renderer_switch_validation_enabled && raster_lifecycle_validation_enabled) {
         throw std::invalid_argument(
             "renderer-switch and Raster lifecycle validation modes are mutually exclusive"
@@ -619,7 +632,7 @@ void Engine::Init(
         "[Threading] render_thread={}, rhi_thread={}, rhi_bypass={}, max_frame_lag={}, "
         "profile_logging={}, parallel_recording={}, parallel_record_workers={}, "
         "parallel_record_verify={}, parallel_record_profile={}, "
-        "parallel_record_min_work_units_per_job={}",
+        "parallel_record_min_work_units_per_job={}, submission_batch_window={}",
         config.engine.threading.render_thread,
         config.engine.threading.rhi_thread,
         config.engine.threading.rhi_bypass,
@@ -629,7 +642,8 @@ void Engine::Init(
         config.engine.threading.parallel_record_workers,
         config.engine.threading.parallel_record_verify,
         config.engine.threading.parallel_record_profile,
-        config.engine.threading.parallel_record_min_work_units_per_job
+        config.engine.threading.parallel_record_min_work_units_per_job,
+        submission_batch_window
     );
 
     if (config.engine.threading.render_thread) {
@@ -690,6 +704,7 @@ void Engine::Init(
                 .parallel_record_profile = config.engine.threading.parallel_record_profile,
                 .parallel_record_min_work_units_per_job =
                     config.engine.threading.parallel_record_min_work_units_per_job,
+                .submission_batch_window = submission_batch_window,
                 .parallel_record_worker_throw_trigger =
                     parallel_record_worker_throw_trigger,
                 .vulkan_present_submit_fault_trigger = vulkan_present_submit_fault_trigger,

--- a/source/runtime/core/include/config/GlobalConfig.h
+++ b/source/runtime/core/include/config/GlobalConfig.h
@@ -41,6 +41,7 @@ struct CORE_API GlobalConfig {
             bool parallel_record_verify  = false;
             bool parallel_record_profile = false;
             uint parallel_record_min_work_units_per_job = 64;
+            uint submission_batch_window = 2;
             uint max_frame_lag           = 0;
         } threading;
 

--- a/source/runtime/core/source/config/GlobalConfig.cpp
+++ b/source/runtime/core/source/config/GlobalConfig.cpp
@@ -49,6 +49,8 @@ GlobalConfig GlobalConfig::LoadConfigFromTomlFile(const std::string_view& toml_p
     loaded_config.engine.threading.parallel_record_min_work_units_per_job =
         toml_config.at_path("engine.threading.parallel_record_min_work_units_per_job")
             .value_or(uint{64});
+    loaded_config.engine.threading.submission_batch_window =
+        toml_config.at_path("engine.threading.submission_batch_window").value_or(uint{2});
     loaded_config.engine.threading.max_frame_lag =
         toml_config.at_path("engine.threading.max_frame_lag").value_or(uint{0});
 

--- a/source/runtime/render/rhi/RHI.cpp
+++ b/source/runtime/render/rhi/RHI.cpp
@@ -84,7 +84,7 @@ void RenderDevice::Init(DeviceInitInfo&& _info) {
             break;
     }
     Get().rhi_type = _info.rhi_type;
-    RHIExecutor::StartUp();
+    RHIExecutor::StartUp(_info.submission_batch_window);
     Get().impl->PostInit();
 }
 void RenderDevice::Dispose() {

--- a/source/runtime/render/rhi/RHI.h
+++ b/source/runtime/render/rhi/RHI.h
@@ -4,6 +4,7 @@
 #include "PixelFormat.h"
 #include "RenderAPI.h"
 #include "rhi/RHICommon.h"
+#include "rhi/RHISubmissionPipelinePolicy.h"
 #include "rhi/plugin/RHICooperative.h"
 #include "rhi/RHIResource.h"
 #include "taskgraph/ThreadManager.h"
@@ -45,6 +46,8 @@ struct DeviceInitInfo {
     bool             parallel_record_verify              = false;
     bool             parallel_record_profile             = false;
     uint32_t         parallel_record_min_work_units_per_job = 64;
+    uint32_t         submission_batch_window =
+        Moer::Render::RHISubmissionPipelinePolicy::DefaultBatchWindow;
     uint64_t         parallel_record_worker_throw_trigger = 0;
     uint64_t         vulkan_present_submit_fault_trigger = 0;
 };

--- a/source/runtime/render/rhi/RHIExecutor.cpp
+++ b/source/runtime/render/rhi/RHIExecutor.cpp
@@ -5,7 +5,6 @@
 #include "rhi/RHIThreadOwnership.h"
 #include "vulkan/VulkanSubmissionExecutor.h"
 
-#include <algorithm>
 #include <exception>
 #include <optional>
 #include <stdexcept>
@@ -543,10 +542,10 @@ private:
     uint64                    ordered_tail_copy_timeline{0};
 };
 
-std::shared_ptr<RHIBackendExecutor> CreateBackendExecutor() {
+std::shared_ptr<RHIBackendExecutor> CreateBackendExecutor(uint32 _submission_batch_window) {
     switch (RenderDevice::Get().GetRHIType()) {
         case ERHIType::Vulkan:
-            return std::make_shared<VulkanSubmissionExecutor>();
+            return std::make_shared<VulkanSubmissionExecutor>(_submission_batch_window);
         case ERHIType::D3D12:
             LOG_WARNING(
                 "[RHIExecutor] D3D12 uses the legacy queue adapter; upper Vulkan topology is unavailable"
@@ -581,6 +580,10 @@ RHIExecutor& RHIExecutor::Get() {
 }
 
 void RHIExecutor::StartUp() {
+    StartUp(RHISubmissionPipelinePolicy::DefaultBatchWindow);
+}
+
+void RHIExecutor::StartUp(uint32 _submission_batch_window) {
     if (RejectOwnedThreadBlockingCall("StartUp")) {
         return;
     }
@@ -597,13 +600,18 @@ void RHIExecutor::StartUp() {
     assert(executor.pending_submits.empty() && !executor.pending_present.has_value());
     assert(executor.active_sync_calls == 0 && "RHIExecutor sync survived device shutdown");
     executor.next_batch_sequence = 1;
+    executor.submission_batch_window =
+        RHISubmissionPipelinePolicy::ClampBatchWindow(
+            _submission_batch_window
+        );
     executor.recording_handoff.Start();
     executor.lifecycle_state     = ELifecycleState::Running;
 }
 
 std::shared_ptr<RHIBackendExecutor> RHIExecutor::GetBackendExecutorLocked() {
     if (!backend_executor) {
-        std::shared_ptr<RHIBackendExecutor> created = CreateBackendExecutor();
+        std::shared_ptr<RHIBackendExecutor> created =
+            CreateBackendExecutor(submission_batch_window);
         if (!created) {
             throw std::runtime_error("RHI backend factory returned no executor");
         }

--- a/source/runtime/render/rhi/RHIExecutor.h
+++ b/source/runtime/render/rhi/RHIExecutor.h
@@ -3,6 +3,7 @@
 #include "RenderAPI.h"
 #include "rhi/RHIExecutorBackend.h"
 #include "rhi/RHIExecutorRecordingHandoff.h"
+#include "rhi/RHISubmissionPipelinePolicy.h"
 
 #include <condition_variable>
 #include <memory>
@@ -50,6 +51,7 @@ class RENDER_API RHIExecutor {
 public:
     static RHIExecutor& Get();
     static void StartUp();
+    static void StartUp(uint32 _submission_batch_window);
 
     void Submit(
         EQueueType             _queue,
@@ -126,6 +128,9 @@ private:
     size_t                                   active_sync_calls{0};
     uint64                                   shutdown_generation{0};
     uint64                                   completed_shutdown_generation{0};
+    uint32                                   submission_batch_window{
+        RHISubmissionPipelinePolicy::DefaultBatchWindow
+    };
     ELifecycleState                          lifecycle_state{ELifecycleState::Stopped};
     RHIExecutorRecordingHandoffQueue         recording_handoff{};
 };

--- a/source/runtime/render/rhi/RHISubmissionPipelinePolicy.h
+++ b/source/runtime/render/rhi/RHISubmissionPipelinePolicy.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include "rhi/RHICommon.h"
+
+#include <cstdint>
+
+namespace Moer::Render::RHISubmissionPipelinePolicy {
+
+inline constexpr uint32_t DefaultBatchWindow = 2;
+inline constexpr uint32_t MinBatchWindow     = 1;
+inline constexpr uint32_t MaxBatchWindow     = 8;
+
+[[nodiscard]] constexpr uint32_t ClampBatchWindow(
+    uint32_t _configured
+) noexcept {
+    return _configured < MinBatchWindow ? MinBatchWindow :
+           _configured > MaxBatchWindow ? MaxBatchWindow :
+                                          _configured;
+}
+
+[[nodiscard]] constexpr bool GraphicsComputeShareNativeLane(
+    const RHIQueueTopology& _topology
+) noexcept {
+    return _topology.graphics.available &&
+           _topology.compute.available &&
+           _topology.graphics.native_queue_id ==
+               _topology.compute.native_queue_id;
+}
+
+[[nodiscard]] constexpr uint32_t ResolveEffectiveBatchWindow(
+    uint32_t                _configured,
+    const RHIQueueTopology& _topology
+) noexcept {
+    return GraphicsComputeShareNativeLane(_topology) ?
+               MinBatchWindow :
+               ClampBatchWindow(_configured);
+}
+
+} // namespace Moer::Render::RHISubmissionPipelinePolicy

--- a/source/runtime/render/rhi/RHISubmissionPipelinePolicy.h
+++ b/source/runtime/render/rhi/RHISubmissionPipelinePolicy.h
@@ -2,7 +2,11 @@
 
 #include "rhi/RHICommon.h"
 
+#include <atomic>
+#include <cassert>
+#include <cstddef>
 #include <cstdint>
+#include <limits>
 
 namespace Moer::Render::RHISubmissionPipelinePolicy {
 
@@ -35,5 +39,59 @@ inline constexpr uint32_t MaxBatchWindow     = 8;
                MinBatchWindow :
                ClampBatchWindow(_configured);
 }
+
+// A single atomic word owns both the sealed bit and outstanding Submission
+// work count. This prevents Seal() and the final FinishWork() from each
+// observing stale state in different atomics and losing the terminal edge.
+class PipelineBatchWorkState final {
+public:
+    // Precondition: the batch is not sealed and the outstanding count has
+    // capacity. The executor registers each item before publishing it to the
+    // Submission worker, so violating this contract is an internal bug.
+    void AddWork() noexcept {
+        const size_t previous =
+            state.fetch_add(1, std::memory_order_relaxed);
+        assert(
+            (previous & SealedMask) == 0 &&
+            "pipeline work cannot be added after the batch is sealed"
+        );
+        assert(
+            (previous & WorkCountMask) != WorkCountMask &&
+            "pipeline batch work count overflow"
+        );
+    }
+
+    // Precondition: this call retires one item previously registered by
+    // AddWork(). Returns true exactly for the operation which transitions a
+    // sealed batch from one outstanding item to its terminal zero-work state.
+    [[nodiscard]] bool FinishWork() noexcept {
+        const size_t previous =
+            state.fetch_sub(1, std::memory_order_acq_rel);
+        const size_t previous_count = previous & WorkCountMask;
+        assert(
+            previous_count != 0 &&
+            "pipeline batch work count underflow"
+        );
+        return previous_count == 1 &&
+               (previous & SealedMask) != 0;
+    }
+
+    // Returns true exactly for the operation which seals an already-empty
+    // batch. If work is still outstanding, the final FinishWork() owns the
+    // terminal transition instead.
+    [[nodiscard]] bool Seal() noexcept {
+        const size_t previous =
+            state.fetch_or(SealedMask, std::memory_order_acq_rel);
+        return (previous & SealedMask) == 0 &&
+               (previous & WorkCountMask) == 0;
+    }
+
+private:
+    static constexpr size_t SealedMask =
+        size_t{1} << (std::numeric_limits<size_t>::digits - 1);
+    static constexpr size_t WorkCountMask = ~SealedMask;
+
+    std::atomic<size_t> state{0};
+};
 
 } // namespace Moer::Render::RHISubmissionPipelinePolicy

--- a/source/runtime/render/rhi/vulkan/VulkanRHIResource.h
+++ b/source/runtime/render/rhi/vulkan/VulkanRHIResource.h
@@ -1065,7 +1065,7 @@ public:
     );
     RENDER_API void Fail(VkResult _result);
     RENDER_API bool IsFailed() const;
-    void  SignalHost(uint64_t _value);
+    RENDER_API void SignalHost(uint64_t _value);
     auto& GetFence() {
         return timeline;
     }

--- a/source/runtime/render/rhi/vulkan/VulkanSubmissionDiagnostics.h
+++ b/source/runtime/render/rhi/vulkan/VulkanSubmissionDiagnostics.h
@@ -56,6 +56,38 @@ TryInstallVulkanSourceSubmissionObserver(const VulkanSourceSubmissionObserver* _
 [[nodiscard]] RENDER_API bool
 RemoveVulkanSourceSubmissionObserver(const VulkanSourceSubmissionObserver* _observer) noexcept;
 
+struct VulkanBatchPreflightRejectionEvent {
+    uint64         batch_sequence{0};
+    uint32         thread_id{0};
+    ERHIThreadRole thread_role{ERHIThreadRole::Unknown};
+    bool           executable_preflight{false};
+};
+
+using VulkanBatchPreflightRejectionCallback =
+    void (*)(void*, const VulkanBatchPreflightRejectionEvent&) noexcept;
+
+struct VulkanBatchPreflightRejectionObserver {
+    void*                                 context{nullptr};
+    VulkanBatchPreflightRejectionCallback callback{nullptr};
+};
+
+// Narrow diagnostic seam reached after batch validation fails and before any
+// accepted pipeline prefix is drained or the malformed batch is terminalized.
+// The callback runs on the Translate owner and must not block or re-enter RHI.
+// Observer storage is caller-owned and must remain immutable while installed.
+// Quiesce Translate work before removal, then remove the observer before
+// destroying it or its context; removal does not wait for a callback that has
+// already loaded the observer. It is only queried on an already-failing
+// preflight path.
+[[nodiscard]] RENDER_API bool
+TryInstallVulkanBatchPreflightRejectionObserver(
+    const VulkanBatchPreflightRejectionObserver* _observer
+) noexcept;
+[[nodiscard]] RENDER_API bool
+RemoveVulkanBatchPreflightRejectionObserver(
+    const VulkanBatchPreflightRejectionObserver* _observer
+) noexcept;
+
 // A direct observation at the VkNativeQueue -> VulkanDevice submit boundary.
 // Unlike the source-packet observer above, this proves which OS thread and RHI
 // role actually invoked the native queue operation.

--- a/source/runtime/render/rhi/vulkan/VulkanSubmissionExecutor.cpp
+++ b/source/runtime/render/rhi/vulkan/VulkanSubmissionExecutor.cpp
@@ -3,6 +3,7 @@
 #include "log/LogSystem.h"
 #include "platform/Platform.h"
 #include "rhi/RHI.h"
+#include "rhi/RHISubmissionPipelinePolicy.h"
 #include "rhi/RHIThreadOwnership.h"
 #include "taskgraph/TaskGraph.h"
 #include "VulkanDevice.h"
@@ -712,7 +713,25 @@ bool RemoveVulkanSourceSubmissionObserver(const VulkanSourceSubmissionObserver* 
     );
 }
 
-VulkanSubmissionExecutor::VulkanSubmissionExecutor() {
+VulkanSubmissionExecutor::VulkanSubmissionExecutor(uint32 _batch_window) :
+    batch_window(
+        RHISubmissionPipelinePolicy::ClampBatchWindow(_batch_window)
+    ) {
+    const size_t configured_batch_window = batch_window;
+    const RHIQueueTopology queue_topology =
+        RenderDevice::Get().GetQueueTopology();
+    graphics_compute_share_native_lane =
+        RHISubmissionPipelinePolicy::GraphicsComputeShareNativeLane(
+            queue_topology
+        );
+    // Graphics and Compute are distinct logical queue wrappers with
+    // independent transferable gates. Keep one batch in flight when they
+    // alias so those gates cannot admit two packets for the same native lane.
+    batch_window =
+        RHISubmissionPipelinePolicy::ResolveEffectiveBatchWindow(
+            _batch_window, queue_topology
+        );
+
     auto& graphics_queue = static_cast<VkCommandQueue&>(
         RenderDevice::Get().GetCommandQueue(EQueueType::Graphics)
     );
@@ -750,7 +769,11 @@ VulkanSubmissionExecutor::VulkanSubmissionExecutor() {
         LOG_INFO(
             "[RHIExecutor][Vulkan] ownership runtime started "
             "Executor=1 TranslateCoordinator=1 TranslateWorkers=TaskGraph "
-            "Submission=1 batch_window=1"
+            "Submission=1 configured_batch_window={} batch_window={} "
+            "graphics_compute_native_alias={}",
+            configured_batch_window,
+            batch_window,
+            graphics_compute_share_native_lane
         );
     } catch (...) {
         graphics_queue.CancelRuntimeDependencyWaits();
@@ -811,6 +834,70 @@ void VulkanSubmissionExecutor::Completion::Signal() {
 void VulkanSubmissionExecutor::Completion::Wait() {
     std::unique_lock lock(mutex);
     cv.wait(lock, [this] { return done; });
+}
+
+VulkanSubmissionExecutor::PipelineBatchState::PipelineBatchState(
+    uint64                      _sequence,
+    size_t                      _source_count,
+    std::shared_ptr<Completion> _completion
+) :
+    sequence(_sequence),
+    slots(_source_count),
+    completion(std::move(_completion)) {}
+
+void VulkanSubmissionExecutor::PipelineBatchState::AddWork() noexcept {
+    outstanding_work.fetch_add(1, std::memory_order_relaxed);
+}
+
+void VulkanSubmissionExecutor::PipelineBatchState::FinishWork() noexcept {
+    const size_t previous =
+        outstanding_work.fetch_sub(1, std::memory_order_acq_rel);
+    assert(previous != 0 && "pipeline batch work count underflow");
+    if (previous != 1 || !sealed.load(std::memory_order_acquire)) {
+        return;
+    }
+    bool expected = false;
+    if (completion_signalled.compare_exchange_strong(
+            expected, true, std::memory_order_acq_rel, std::memory_order_acquire
+        )) {
+        completion->Signal();
+    }
+}
+
+void VulkanSubmissionExecutor::PipelineBatchState::Seal() noexcept {
+    sealed.store(true, std::memory_order_release);
+    if (outstanding_work.load(std::memory_order_acquire) != 0) {
+        return;
+    }
+    bool expected = false;
+    if (completion_signalled.compare_exchange_strong(
+            expected, true, std::memory_order_acq_rel, std::memory_order_acquire
+        )) {
+        completion->Signal();
+    }
+}
+
+void VulkanSubmissionExecutor::PipelineBatchState::PublishFailure(
+    size_t _reject_from,
+    int32  _result,
+    bool   _recoverable
+) noexcept {
+    std::lock_guard lock(failure_mutex);
+    if (_reject_from >= failure.reject_from) {
+        return;
+    }
+    failure.reject_from = _reject_from;
+    failure.result =
+        _result == static_cast<int32>(VK_SUCCESS) ?
+            static_cast<int32>(VK_ERROR_UNKNOWN) :
+            _result;
+    failure.recoverable = _recoverable;
+}
+
+VulkanSubmissionExecutor::PipelineFailure
+VulkanSubmissionExecutor::PipelineBatchState::ReadFailure() const noexcept {
+    std::lock_guard lock(failure_mutex);
+    return failure;
 }
 
 void VulkanSubmissionExecutor::Enqueue(RHIBackendSubmissionBatch&& _batch) {
@@ -970,15 +1057,21 @@ void VulkanSubmissionExecutor::RunExecutor() {
                     if (request.kind == ERequestKind::Submit) {
                         ProcessBatch(request.batch, exception_state);
                     } else {
+                        DrainPipelineBatches();
                         ProcessSync(request.sync_depth);
                     }
                 },
                 [&] {
-                    hard_failed         = true;
-                    hard_failure_result = static_cast<int32>(VK_ERROR_UNKNOWN);
+                    LatchHardFailure(
+                        StreamPosition{
+                            request.batch.sequence,
+                            exception_state.first_unconsumed_source,
+                        },
+                        static_cast<int32>(VK_ERROR_UNKNOWN)
+                    );
                     RejectBatch(
                         std::move(request.batch),
-                        hard_failure_result,
+                        static_cast<int32>(VK_ERROR_UNKNOWN),
                         "unhandled submission request exception",
                         exception_state.first_unconsumed_source,
                         &exception_state.first_unconsumed_source
@@ -987,8 +1080,13 @@ void VulkanSubmissionExecutor::RunExecutor() {
                 [&] { CompleteRequest(request.completion); },
                 [&](VulkanSubmissionDetail::EWorkerRequestFailurePhase _phase,
                     const std::exception_ptr& _exception) {
-                    hard_failed         = true;
-                    hard_failure_result = static_cast<int32>(VK_ERROR_UNKNOWN);
+                    LatchHardFailure(
+                        StreamPosition{
+                            request.batch.sequence,
+                            exception_state.first_unconsumed_source,
+                        },
+                        static_cast<int32>(VK_ERROR_UNKNOWN)
+                    );
                     ReportRequestFailure(request.kind, _phase, _exception);
                 }
             );
@@ -1044,6 +1142,295 @@ void VulkanSubmissionExecutor::StopSubmissionThread() {
     submission_cv.notify_all();
     if (submission_thread.joinable()) {
         submission_thread.join();
+    }
+}
+
+void VulkanSubmissionExecutor::WaitForPipelineCapacity() {
+    while (in_flight_batches.size() >= batch_window) {
+        std::shared_ptr<Completion> completion =
+            std::move(in_flight_batches.front());
+        in_flight_batches.pop_front();
+        completion->Wait();
+    }
+}
+
+void VulkanSubmissionExecutor::DrainPipelineBatches() {
+    while (!in_flight_batches.empty()) {
+        std::shared_ptr<Completion> completion =
+            std::move(in_flight_batches.front());
+        in_flight_batches.pop_front();
+        completion->Wait();
+    }
+}
+
+void VulkanSubmissionExecutor::ResetStreamScope() noexcept {
+    active_async_queue_scope = 0;
+    async_scope_entry_frontier.fill(std::nullopt);
+    async_scope_seen_queues.fill(false);
+}
+
+void VulkanSubmissionExecutor::PrepareStreamSubmit(
+    CmdSubmit& _submit,
+    EQueueType _queue
+) {
+    const RHIQueueTopology queue_topology =
+        RenderDevice::Get().GetQueueTopology();
+    auto same_native_queue = [&](EQueueType lhs, EQueueType rhs) {
+        return queue_topology.Resolve(lhs).native_queue_id ==
+               queue_topology.Resolve(rhs).native_queue_id;
+    };
+    auto append_unique_wait = [](CmdSubmit& submit, WaitEvent event) {
+        const bool exists = std::any_of(
+            submit.wait_events.begin(),
+            submit.wait_events.end(),
+            [&](const WaitEvent& candidate) {
+                return candidate.timeline_handle == event.timeline_handle &&
+                       candidate.value == event.value;
+            }
+        );
+        if (!exists) {
+            submit.wait_events.emplace_back(event);
+        }
+    };
+    auto append_frontier_waits =
+        [&](const auto& frontier) {
+            for (size_t index = 0; index < frontier.size(); ++index) {
+                if (!frontier[index].has_value()) {
+                    continue;
+                }
+                const auto source_queue = static_cast<EQueueType>(index);
+                if (same_native_queue(source_queue, _queue)) {
+                    continue;
+                }
+                append_unique_wait(_submit, *frontier[index]);
+            }
+        };
+    auto mark_scope_queue_seen = [&] {
+        for (size_t index = 0; index < async_scope_seen_queues.size();
+             ++index) {
+            if (same_native_queue(static_cast<EQueueType>(index), _queue)) {
+                async_scope_seen_queues[index] = true;
+            }
+        }
+    };
+
+    const uint64 async_scope = _submit.async_queue_scope;
+    if (async_scope == 0) {
+        ResetStreamScope();
+        append_frontier_waits(gpu_frontier);
+        return;
+    }
+
+    if (active_async_queue_scope != async_scope) {
+        active_async_queue_scope   = async_scope;
+        async_scope_entry_frontier = gpu_frontier;
+        async_scope_seen_queues.fill(false);
+        if (!logged_async_queue_scope) {
+            LOG_INFO(
+                "[RHIExecutor][Vulkan][AsyncQueueScope] "
+                "mode=dependency-led native_submit_owner=serial "
+                "legacy_boundary=frontier"
+            );
+            logged_async_queue_scope = true;
+        }
+    }
+
+    const size_t queue_index = static_cast<size_t>(_queue);
+    if (!async_scope_seen_queues[queue_index]) {
+        append_frontier_waits(async_scope_entry_frontier);
+        mark_scope_queue_seen();
+    }
+}
+
+void VulkanSubmissionExecutor::UpdateStreamFrontier(
+    EQueueType _queue,
+    WaitEvent  _completion,
+    bool       _collapse
+) {
+    const RHIQueueTopology queue_topology =
+        RenderDevice::Get().GetQueueTopology();
+    auto same_native_queue = [&](EQueueType lhs, EQueueType rhs) {
+        return queue_topology.Resolve(lhs).native_queue_id ==
+               queue_topology.Resolve(rhs).native_queue_id;
+    };
+
+    if (_collapse) {
+        gpu_frontier.fill(std::nullopt);
+    } else {
+        for (size_t index = 0; index < gpu_frontier.size(); ++index) {
+            if (same_native_queue(static_cast<EQueueType>(index), _queue)) {
+                gpu_frontier[index].reset();
+            }
+        }
+    }
+    gpu_frontier[static_cast<size_t>(_queue)] = _completion;
+}
+
+void VulkanSubmissionExecutor::LatchHardFailure(
+    StreamPosition _position,
+    int32          _result
+) noexcept {
+    std::lock_guard lock(hard_failure_mutex);
+    const bool earlier =
+        !hard_failure_position.has_value() ||
+        _position.batch_sequence < hard_failure_position->batch_sequence ||
+        (_position.batch_sequence == hard_failure_position->batch_sequence &&
+         _position.source_index < hard_failure_position->source_index);
+    if (!earlier) {
+        return;
+    }
+    hard_failure_position = _position;
+    hard_failure_result =
+        _result == static_cast<int32>(VK_SUCCESS) ?
+            static_cast<int32>(VK_ERROR_UNKNOWN) :
+            _result;
+}
+
+bool VulkanSubmissionExecutor::IsHardFailureAtOrBefore(
+    StreamPosition _position,
+    int32*         _result
+) const noexcept {
+    std::lock_guard lock(hard_failure_mutex);
+    if (!hard_failure_position.has_value()) {
+        return false;
+    }
+    const bool rejected =
+        hard_failure_position->batch_sequence < _position.batch_sequence ||
+        (hard_failure_position->batch_sequence == _position.batch_sequence &&
+         hard_failure_position->source_index <= _position.source_index);
+    if (rejected && _result != nullptr) {
+        *_result = hard_failure_result;
+    }
+    return rejected;
+}
+
+void VulkanSubmissionExecutor::ExecutePipelineSource(
+    const std::shared_ptr<PipelineBatchState>& _batch,
+    size_t                                     _source_index
+) noexcept {
+    struct WorkCompletion final {
+        std::shared_ptr<PipelineBatchState> batch;
+        ~WorkCompletion() {
+            batch->FinishWork();
+        }
+    } work_completion{_batch};
+
+    if (_source_index >= _batch->slots.size()) {
+        LatchHardFailure(
+            StreamPosition{_batch->sequence, _source_index},
+            static_cast<int32>(VK_ERROR_UNKNOWN)
+        );
+        return;
+    }
+
+    PipelineSourceSlot& slot = _batch->slots[_source_index];
+    auto reject_packet = [&](VkResult _result) noexcept {
+        if (_result == VK_SUCCESS) {
+            _result = VK_ERROR_UNKNOWN;
+        }
+        if (slot.command_packet) {
+            auto& queue = static_cast<VkCommandQueue&>(
+                RenderDevice::Get().GetCommandQueue(slot.queue)
+            );
+            queue.RejectRecordedForRuntime(
+                std::move(*slot.command_packet), _result
+            );
+            slot.command_packet.reset();
+        }
+    };
+
+    int32 hard_result = static_cast<int32>(VK_ERROR_UNKNOWN);
+    const PipelineFailure batch_failure = _batch->ReadFailure();
+    if (IsHardFailureAtOrBefore(
+            StreamPosition{_batch->sequence, _source_index},
+            &hard_result
+        )) {
+        reject_packet(static_cast<VkResult>(hard_result));
+        return;
+    }
+    if (_source_index >= batch_failure.reject_from) {
+        reject_packet(static_cast<VkResult>(batch_failure.result));
+        return;
+    }
+
+    if (!slot.command_packet) {
+        LatchHardFailure(
+            StreamPosition{_batch->sequence, _source_index + 1},
+            static_cast<int32>(VK_ERROR_UNKNOWN)
+        );
+        _batch->PublishFailure(
+            _source_index + 1,
+            static_cast<int32>(VK_ERROR_UNKNOWN),
+            false
+        );
+        ResetStreamScope();
+        return;
+    }
+    CmdSubmit& submit = slot.command_packet->submit;
+
+    try {
+        PrepareStreamSubmit(submit, slot.queue);
+    } catch (...) {
+        ReportRequestFailure(
+            ERequestKind::Submit,
+            VulkanSubmissionDetail::EWorkerRequestFailurePhase::Process,
+            std::current_exception()
+        );
+        reject_packet(VK_ERROR_UNKNOWN);
+        _batch->PublishFailure(
+            _source_index + 1,
+            static_cast<int32>(VK_ERROR_UNKNOWN),
+            false
+        );
+        LatchHardFailure(
+            StreamPosition{_batch->sequence, _source_index + 1},
+            static_cast<int32>(VK_ERROR_UNKNOWN)
+        );
+        ResetStreamScope();
+        return;
+    }
+
+    auto& queue = static_cast<VkCommandQueue&>(
+        RenderDevice::Get().GetCommandQueue(slot.queue)
+    );
+    VulkanRuntimeSubmissionResult submit_result =
+        queue.SubmitRecordedForRuntime(std::move(*slot.command_packet));
+    slot.command_packet.reset();
+
+    if (submit_result.WasSubmitted()) {
+        assert(submit_result.completion.has_value());
+        NotifySourceSubmitted(
+            _batch->sequence,
+            static_cast<uint32>(_source_index),
+            slot.original_source_index,
+            slot.source_segment_index,
+            slot.source_segment_count,
+            slot.queue,
+            slot.async_queue_scope,
+            slot.cross_native_predecessor_wait
+        );
+        UpdateStreamFrontier(
+            slot.queue,
+            *submit_result.completion,
+            slot.async_queue_scope == 0
+        );
+        return;
+    }
+
+    const int32 failure_result =
+        submit_result.outcome.result == VK_SUCCESS ?
+            static_cast<int32>(VK_ERROR_UNKNOWN) :
+            static_cast<int32>(submit_result.outcome.result);
+    const bool recoverable = submit_result.IsRecoverableRejection();
+    _batch->PublishFailure(
+        _source_index + 1, failure_result, recoverable
+    );
+    ResetStreamScope();
+    if (!recoverable) {
+        LatchHardFailure(
+            StreamPosition{_batch->sequence, _source_index + 1},
+            failure_result
+        );
     }
 }
 
@@ -1152,10 +1539,14 @@ void VulkanSubmissionExecutor::ProcessBatch(
     RHIBackendSubmissionBatch& _batch,
     BatchExceptionState&       _exception_state
 ) {
-    if (hard_failed) {
+    int32 latched_failure_result = static_cast<int32>(VK_ERROR_UNKNOWN);
+    if (IsHardFailureAtOrBefore(
+            StreamPosition{_batch.sequence, 0},
+            &latched_failure_result
+        )) {
         RejectBatch(
             std::move(_batch),
-            hard_failure_result,
+            latched_failure_result,
             "submission runtime is latched after a hard failure",
             0,
             &_exception_state.first_unconsumed_source
@@ -1174,8 +1565,10 @@ void VulkanSubmissionExecutor::ProcessBatch(
             preflight.source_index,
             preflight.command_index
         );
-        hard_failed         = true;
-        hard_failure_result = static_cast<int32>(VK_ERROR_UNKNOWN);
+        LatchHardFailure(
+            StreamPosition{_batch.sequence, 0},
+            static_cast<int32>(VK_ERROR_UNKNOWN)
+        );
         RejectBatch(
             std::move(_batch),
             static_cast<int32>(VK_ERROR_UNKNOWN),
@@ -1202,8 +1595,10 @@ void VulkanSubmissionExecutor::ProcessBatch(
                 executable_preflight.source_index,
                 executable_preflight.command_index
             );
-            hard_failed         = true;
-            hard_failure_result = static_cast<int32>(VK_ERROR_UNKNOWN);
+            LatchHardFailure(
+                StreamPosition{_batch.sequence, 0},
+                static_cast<int32>(VK_ERROR_UNKNOWN)
+            );
             RejectBatch(
                 std::move(_batch),
                 static_cast<int32>(VK_ERROR_UNKNOWN),
@@ -1238,6 +1633,91 @@ void VulkanSubmissionExecutor::ProcessBatch(
         );
     }
 
+    const bool batch_crosses_aliased_graphics_compute_lane =
+        graphics_compute_share_native_lane &&
+        std::any_of(
+            _batch.submits.begin(),
+            _batch.submits.end(),
+            [](const RHIBackendSubmissionBatchEntry& entry) {
+                return entry.queue == EQueueType::Graphics;
+            }
+        ) &&
+        std::any_of(
+            _batch.submits.begin(),
+            _batch.submits.end(),
+            [](const RHIBackendSubmissionBatchEntry& entry) {
+                return entry.queue == EQueueType::Compute;
+            }
+        );
+    const bool pipeline_mode =
+        !_batch.present.has_value() && !_batch.submits.empty() &&
+        !batch_crosses_aliased_graphics_compute_lane &&
+        std::all_of(
+            _batch.submits.begin(),
+            _batch.submits.end(),
+            [](const RHIBackendSubmissionBatchEntry& entry) {
+                return IsParallelTranslateCandidate(entry) &&
+                       !entry.submit.b_sync &&
+                       !entry.submit.b_tick_profiling &&
+                       !entry.submit.b_delete_resources &&
+                       !entry.submit.EmitsProfilingQueries();
+            }
+        );
+
+    if (pipeline_mode) {
+        WaitForPipelineCapacity();
+    } else {
+        // Copy, Present, legacy/direct state inference, and serial control
+        // remain explicit pipeline boundaries in Phase 15D. Once the tail
+        // marker completes, this coordinator may safely reuse the synchronous
+        // path and its existing failure semantics.
+        DrainPipelineBatches();
+    }
+
+    if (IsHardFailureAtOrBefore(
+            StreamPosition{_batch.sequence, 0},
+            &latched_failure_result
+        )) {
+        RejectBatch(
+            std::move(_batch),
+            latched_failure_result,
+            "submission runtime latched while waiting for pipeline admission",
+            0,
+            &_exception_state.first_unconsumed_source
+        );
+        return;
+    }
+
+    struct PipelineSealGuard final {
+        std::shared_ptr<PipelineBatchState> state{};
+        ~PipelineSealGuard() {
+            if (state) {
+                state->Seal();
+            }
+        }
+    };
+
+    std::shared_ptr<PipelineBatchState> pipeline_state{};
+    PipelineSealGuard                 pipeline_seal{};
+    if (pipeline_mode) {
+        auto completion = std::make_shared<Completion>();
+        pipeline_state  = std::make_shared<PipelineBatchState>(
+            _batch.sequence, _batch.submits.size(), completion
+        );
+        pipeline_seal.state = pipeline_state;
+        in_flight_batches.emplace_back(std::move(completion));
+        if (!logged_cross_batch_pipeline) {
+            logged_cross_batch_pipeline = true;
+            LOG_INFO(
+                "[RHIExecutor][Vulkan][SubmissionPipeline] "
+                "mode=bounded-cross-batch batch_window={} "
+                "per_native_lane_recorded_limit=1 "
+                "ordered_submission=stable",
+                batch_window
+            );
+        }
+    }
+
     auto reject_remaining = [&](size_t _begin, VkResult _result, std::string_view _reason) {
         if (_result == VK_SUCCESS) {
             _result = VK_ERROR_UNKNOWN;
@@ -1247,11 +1727,17 @@ void VulkanSubmissionExecutor::ProcessBatch(
         // gpu_frontier for successfully submitted work, but force the next
         // batch (even one reusing the same graph scope id) to freeze a fresh
         // entry frontier and republish its first-lane waits.
-        active_async_queue_scope = 0;
-        async_scope_entry_frontier.fill(std::nullopt);
-        async_scope_seen_queues.fill(false);
-        hard_failed         = true;
-        hard_failure_result = static_cast<int32>(_result);
+        if (pipeline_state) {
+            pipeline_state->PublishFailure(
+                _begin, static_cast<int32>(_result), false
+            );
+        } else {
+            ResetStreamScope();
+        }
+        LatchHardFailure(
+            StreamPosition{_batch.sequence, _begin},
+            static_cast<int32>(_result)
+        );
         _exception_state.first_unconsumed_source =
             std::min(_begin, _batch.submits.size());
         RejectBatch(
@@ -1268,9 +1754,13 @@ void VulkanSubmissionExecutor::ProcessBatch(
             if (_result == VK_SUCCESS) {
                 _result = VK_ERROR_UNKNOWN;
             }
-            active_async_queue_scope = 0;
-            async_scope_entry_frontier.fill(std::nullopt);
-            async_scope_seen_queues.fill(false);
+            if (pipeline_state) {
+                pipeline_state->PublishFailure(
+                    _begin, static_cast<int32>(_result), true
+                );
+            } else {
+                ResetStreamScope();
+            }
             _exception_state.first_unconsumed_source =
                 std::min(_begin, _batch.submits.size());
             RejectBatch(
@@ -1315,26 +1805,9 @@ void VulkanSubmissionExecutor::ProcessBatch(
                 append_unique_wait(submit, *frontier[index]);
             }
         };
-    auto mark_scope_queue_seen = [&](EQueueType queue) {
-        for (size_t index = 0; index < async_scope_seen_queues.size();
-             ++index) {
-            if (same_native_queue(static_cast<EQueueType>(index), queue)) {
-                async_scope_seen_queues[index] = true;
-            }
-        }
-    };
     auto update_frontier =
         [&](EQueueType queue, WaitEvent completion, bool collapse) {
-            if (collapse) {
-                gpu_frontier.fill(std::nullopt);
-            } else {
-                for (size_t index = 0; index < gpu_frontier.size(); ++index) {
-                    if (same_native_queue(static_cast<EQueueType>(index), queue)) {
-                        gpu_frontier[index].reset();
-                    }
-                }
-            }
-            gpu_frontier[static_cast<size_t>(queue)] = completion;
+            UpdateStreamFrontier(queue, completion, collapse);
         };
     auto prepare_source = [&](size_t source_index) {
         RHIBackendSubmissionBatchEntry& entry = _batch.submits[source_index];
@@ -1353,39 +1826,10 @@ void VulkanSubmissionExecutor::ProcessBatch(
             .end   = entry.submit.cmds.size(),
         }};
 
-        const uint64 async_scope = entry.submit.async_queue_scope;
-        if (async_scope == 0) {
-            // Legacy/direct submits retain a conservative total GPU order.
-            active_async_queue_scope = 0;
-            async_scope_entry_frontier.fill(std::nullopt);
-            async_scope_seen_queues.fill(false);
-            append_frontier_waits(entry.submit, entry.queue, gpu_frontier);
+        if (pipeline_mode) {
             return true;
         }
-
-            if (active_async_queue_scope != async_scope) {
-                // A new graph transaction begins after the complete prior
-            // frontier. Each native queue waits that frozen entry frontier
-            // once, while explicit RDG waits order work inside the scope.
-                active_async_queue_scope    = async_scope;
-                async_scope_entry_frontier  = gpu_frontier;
-                async_scope_seen_queues.fill(false);
-                if (!logged_async_queue_scope) {
-                    LOG_INFO(
-                        "[RHIExecutor][Vulkan][AsyncQueueScope] "
-                        "mode=dependency-led native_submit_owner=serial "
-                        "legacy_boundary=frontier"
-                    );
-                    logged_async_queue_scope = true;
-                }
-            }
-            const size_t queue_index = static_cast<size_t>(entry.queue);
-            if (!async_scope_seen_queues[queue_index]) {
-                append_frontier_waits(
-                    entry.submit, entry.queue, async_scope_entry_frontier
-                );
-                mark_scope_queue_seen(entry.queue);
-            }
+        PrepareStreamSubmit(entry.submit, entry.queue);
         return true;
     };
     auto is_parallel_translate_candidate = [&](size_t source_index) {
@@ -1420,7 +1864,7 @@ void VulkanSubmissionExecutor::ProcessBatch(
                 // group belongs to an already terminalized prefix.
                 if (dependency.submit_idx >= first_segment && dependency.submit_idx <= last_segment) {
                     dependencies.emplace_back(dependency);
-        }
+                }
             }
 
             schedule_nodes.emplace_back(TranslateWaveNode{
@@ -1696,8 +2140,9 @@ void VulkanSubmissionExecutor::ProcessBatch(
                     "[RHIExecutor][Vulkan][ParallelTranslate] "
                     "mode=ready-native-lanes workers=TaskGraph "
                     "native_lanes={} ordered_submit_owner=serial "
-                    "batch_window=1",
-                    wave_slots.size()
+                    "batch_window={}",
+                    wave_slots.size(),
+                    batch_window
                 );
             }
 
@@ -1716,6 +2161,71 @@ void VulkanSubmissionExecutor::ProcessBatch(
 
                 RHIBackendSubmissionBatchEntry& entry = _batch.submits[slot.source_index];
                 VkCommandQueue&                 queue = *slot.queue;
+
+                if (pipeline_state) {
+                    PipelineSourceSlot& pipeline_slot =
+                        pipeline_state->slots[slot.source_index];
+                    const VulkanExecutableSourceMetadata& source_metadata =
+                        materialization.sources[slot.source_index];
+                    pipeline_slot.queue                         = slot.queue_type;
+                    pipeline_slot.async_queue_scope             = slot.async_queue_scope;
+                    pipeline_slot.original_source_index         =
+                        source_metadata.original_source_index;
+                    pipeline_slot.source_segment_index          =
+                        source_metadata.source_segment_index;
+                    pipeline_slot.source_segment_count          =
+                        source_metadata.source_segment_count;
+                    pipeline_slot.cross_native_predecessor_wait =
+                        source_metadata.cross_native_predecessor_wait;
+                    pipeline_slot.command_packet = std::move(slot.recorded);
+
+                    pipeline_state->AddWork();
+                    bool handoff_succeeded = false;
+                    try {
+                        handoff_succeeded = EnqueueSubmissionWork(SubmissionWork{
+                            .execute = std::packaged_task<void()>(
+                                [this,
+                                 state = pipeline_state,
+                                 source_index = slot.source_index] {
+                                    ExecutePipelineSource(state, source_index);
+                                }
+                            ),
+                        });
+                    } catch (...) {
+                        ReportRequestFailure(
+                            ERequestKind::Submit,
+                            VulkanSubmissionDetail::EWorkerRequestFailurePhase::Process,
+                            std::current_exception()
+                        );
+                    }
+                    if (!handoff_succeeded) {
+                        pipeline_state->FinishWork();
+                        if (pipeline_slot.command_packet) {
+                            slot.recorded =
+                                std::move(pipeline_slot.command_packet);
+                        }
+                        return fail_group(
+                            slot.source_index,
+                            VK_ERROR_UNKNOWN,
+                            false,
+                            "parallel Translate pipeline handoff failure"
+                        );
+                    }
+
+                    slot.terminalized = true;
+                    _exception_state.first_unconsumed_source =
+                        slot.source_index + 1;
+                    if (!scheduler.MarkReleased(slot.key)) {
+                        return fail_group(
+                            slot.source_index,
+                            VK_ERROR_UNKNOWN,
+                            false,
+                            "parallel Translate scheduler handoff release failure"
+                        );
+                    }
+                    ++next_release_local;
+                    continue;
+                }
 
                 VulkanRuntimeSubmissionResult submit_result{};
                 try {
@@ -1796,7 +2306,7 @@ void VulkanSubmissionExecutor::ProcessBatch(
                    _batch.submits[group_end].submit.async_queue_scope == async_scope) {
                 ++group_end;
             }
-            if (group_end - source_index > 1) {
+            if (pipeline_mode || group_end - source_index > 1) {
                 if (!process_parallel_translate_group(source_index, group_end)) {
                     return;
                 }
@@ -2132,11 +2642,13 @@ void VulkanSubmissionExecutor::ProcessBatch(
                 static_cast<uint32>(present_result.outcome.status),
                 static_cast<int32>(present_result.outcome.result)
             );
-            hard_failed = true;
-            hard_failure_result = static_cast<int32>(
-                present_result.outcome.result == VK_SUCCESS ?
-                    VK_ERROR_UNKNOWN :
-                    present_result.outcome.result
+            LatchHardFailure(
+                StreamPosition{_batch.sequence, _batch.submits.size()},
+                static_cast<int32>(
+                    present_result.outcome.result == VK_SUCCESS ?
+                        VK_ERROR_UNKNOWN :
+                        present_result.outcome.result
+                )
             );
         }
         // Retry/Recreate means no copy submit happened.  Keep the previous

--- a/source/runtime/render/rhi/vulkan/VulkanSubmissionExecutor.cpp
+++ b/source/runtime/render/rhi/vulkan/VulkanSubmissionExecutor.cpp
@@ -904,14 +904,11 @@ VulkanSubmissionExecutor::PipelineBatchState::PipelineBatchState(
     completion(std::move(_completion)) {}
 
 void VulkanSubmissionExecutor::PipelineBatchState::AddWork() noexcept {
-    outstanding_work.fetch_add(1, std::memory_order_relaxed);
+    work_state.AddWork();
 }
 
 void VulkanSubmissionExecutor::PipelineBatchState::FinishWork() noexcept {
-    const size_t previous =
-        outstanding_work.fetch_sub(1, std::memory_order_acq_rel);
-    assert(previous != 0 && "pipeline batch work count underflow");
-    if (previous != 1 || !sealed.load(std::memory_order_acquire)) {
+    if (!work_state.FinishWork()) {
         return;
     }
     bool expected = false;
@@ -923,8 +920,7 @@ void VulkanSubmissionExecutor::PipelineBatchState::FinishWork() noexcept {
 }
 
 void VulkanSubmissionExecutor::PipelineBatchState::Seal() noexcept {
-    sealed.store(true, std::memory_order_release);
-    if (outstanding_work.load(std::memory_order_acquire) != 0) {
+    if (!work_state.Seal()) {
         return;
     }
     bool expected = false;

--- a/source/runtime/render/rhi/vulkan/VulkanSubmissionExecutor.cpp
+++ b/source/runtime/render/rhi/vulkan/VulkanSubmissionExecutor.cpp
@@ -25,6 +25,8 @@ namespace Moer::Render {
 namespace {
 
 std::atomic<const VulkanSourceSubmissionObserver*> g_source_submission_observer{nullptr};
+std::atomic<const VulkanBatchPreflightRejectionObserver*>
+    g_batch_preflight_rejection_observer{nullptr};
 
 void NotifySourceSubmitted(
     uint64     _batch_sequence,
@@ -56,6 +58,32 @@ void NotifySourceSubmitted(
             .queue             = _queue,
             .async_queue_scope = _async_queue_scope,
             .cross_native_predecessor_wait = _cross_native_predecessor_wait,
+        }
+    );
+}
+
+void NotifyBatchPreflightRejected(
+    uint64 _batch_sequence,
+    bool   _executable_preflight
+) noexcept {
+    assert(
+        GetCurrentRHIThreadRole() == ERHIThreadRole::Translate &&
+        "batch preflight diagnostics must run on the Translate owner"
+    );
+    const VulkanBatchPreflightRejectionObserver* observer =
+        g_batch_preflight_rejection_observer.load(
+            std::memory_order_acquire
+        );
+    if (observer == nullptr) {
+        return;
+    }
+    observer->callback(
+        observer->context,
+        VulkanBatchPreflightRejectionEvent{
+            .batch_sequence       = _batch_sequence,
+            .thread_id            = Platform::GetCurrentThreadID(),
+            .thread_role          = GetCurrentRHIThreadRole(),
+            .executable_preflight = _executable_preflight,
         }
     );
 }
@@ -713,6 +741,36 @@ bool RemoveVulkanSourceSubmissionObserver(const VulkanSourceSubmissionObserver* 
     );
 }
 
+bool TryInstallVulkanBatchPreflightRejectionObserver(
+    const VulkanBatchPreflightRejectionObserver* _observer
+) noexcept {
+    if (_observer == nullptr || _observer->callback == nullptr) {
+        return false;
+    }
+    const VulkanBatchPreflightRejectionObserver* expected = nullptr;
+    return g_batch_preflight_rejection_observer.compare_exchange_strong(
+        expected,
+        _observer,
+        std::memory_order_release,
+        std::memory_order_relaxed
+    );
+}
+
+bool RemoveVulkanBatchPreflightRejectionObserver(
+    const VulkanBatchPreflightRejectionObserver* _observer
+) noexcept {
+    if (_observer == nullptr) {
+        return false;
+    }
+    const VulkanBatchPreflightRejectionObserver* expected = _observer;
+    return g_batch_preflight_rejection_observer.compare_exchange_strong(
+        expected,
+        nullptr,
+        std::memory_order_acq_rel,
+        std::memory_order_acquire
+    );
+}
+
 VulkanSubmissionExecutor::VulkanSubmissionExecutor(uint32 _batch_window) :
     batch_window(
         RHISubmissionPipelinePolicy::ClampBatchWindow(_batch_window)
@@ -1062,6 +1120,11 @@ void VulkanSubmissionExecutor::RunExecutor() {
                     }
                 },
                 [&] {
+                    // ProcessBatch may throw before it reaches the ordinary
+                    // pipeline admission/drain decision. Preserve the
+                    // already-admitted stream prefix before publishing any
+                    // rejection markers for this request.
+                    DrainPipelineBatches();
                     LatchHardFailure(
                         StreamPosition{
                             request.batch.sequence,
@@ -1155,6 +1218,10 @@ void VulkanSubmissionExecutor::WaitForPipelineCapacity() {
 }
 
 void VulkanSubmissionExecutor::DrainPipelineBatches() {
+    assert(
+        GetCurrentRHIThreadRole() != ERHIThreadRole::Submission &&
+        "Submission owner must not wait on its own pipeline work"
+    );
     while (!in_flight_batches.empty()) {
         std::shared_ptr<Completion> completion =
             std::move(in_flight_batches.front());
@@ -1544,6 +1611,7 @@ void VulkanSubmissionExecutor::ProcessBatch(
             StreamPosition{_batch.sequence, 0},
             &latched_failure_result
         )) {
+        DrainPipelineBatches();
         RejectBatch(
             std::move(_batch),
             latched_failure_result,
@@ -1565,6 +1633,12 @@ void VulkanSubmissionExecutor::ProcessBatch(
             preflight.source_index,
             preflight.command_index
         );
+        NotifyBatchPreflightRejected(_batch.sequence, false);
+        // Validation runs before the ordinary admission decision so a later
+        // malformed batch can be discovered while an earlier pipeline batch
+        // is still owned by Submission. Commit that accepted prefix before
+        // its queue receives this batch's rejection markers.
+        DrainPipelineBatches();
         LatchHardFailure(
             StreamPosition{_batch.sequence, 0},
             static_cast<int32>(VK_ERROR_UNKNOWN)
@@ -1595,6 +1669,8 @@ void VulkanSubmissionExecutor::ProcessBatch(
                 executable_preflight.source_index,
                 executable_preflight.command_index
             );
+            NotifyBatchPreflightRejected(_batch.sequence, true);
+            DrainPipelineBatches();
             LatchHardFailure(
                 StreamPosition{_batch.sequence, 0},
                 static_cast<int32>(VK_ERROR_UNKNOWN)
@@ -1678,6 +1754,10 @@ void VulkanSubmissionExecutor::ProcessBatch(
             StreamPosition{_batch.sequence, 0},
             &latched_failure_result
         )) {
+        // Windowed admission can leave an already-accepted batch behind the
+        // capacity item just retired above. Its Submission work must publish
+        // terminal markers before this later batch is rejected directly.
+        DrainPipelineBatches();
         RejectBatch(
             std::move(_batch),
             latched_failure_result,
@@ -1690,10 +1770,18 @@ void VulkanSubmissionExecutor::ProcessBatch(
 
     struct PipelineSealGuard final {
         std::shared_ptr<PipelineBatchState> state{};
-        ~PipelineSealGuard() {
-            if (state) {
-                state->Seal();
+
+        void Seal() noexcept {
+            if (!state) {
+                return;
             }
+            std::shared_ptr<PipelineBatchState> sealed_state =
+                std::move(state);
+            sealed_state->Seal();
+        }
+
+        ~PipelineSealGuard() {
+            Seal();
         }
     };
 
@@ -1718,6 +1806,16 @@ void VulkanSubmissionExecutor::ProcessBatch(
         }
     }
 
+    auto seal_and_drain_pipeline = [&]() noexcept {
+        if (!pipeline_state) {
+            return;
+        }
+        // The current state is itself present in in_flight_batches. Seal it
+        // before waiting so an empty or partially handed-off failing batch
+        // can publish its terminal completion instead of self-deadlocking.
+        pipeline_seal.Seal();
+        DrainPipelineBatches();
+    };
     auto reject_remaining = [&](size_t _begin, VkResult _result, std::string_view _reason) {
         if (_result == VK_SUCCESS) {
             _result = VK_ERROR_UNKNOWN;
@@ -1731,6 +1829,7 @@ void VulkanSubmissionExecutor::ProcessBatch(
             pipeline_state->PublishFailure(
                 _begin, static_cast<int32>(_result), false
             );
+            seal_and_drain_pipeline();
         } else {
             ResetStreamScope();
         }
@@ -1758,6 +1857,7 @@ void VulkanSubmissionExecutor::ProcessBatch(
                 pipeline_state->PublishFailure(
                     _begin, static_cast<int32>(_result), true
                 );
+                seal_and_drain_pipeline();
             } else {
                 ResetStreamScope();
             }
@@ -1931,18 +2031,27 @@ void VulkanSubmissionExecutor::ProcessBatch(
             Array<TranslateGroupSlot>* slots{nullptr};
             size_t                     group_end{0};
             size_t*                    first_unconsumed_source{nullptr};
+            VulkanSubmissionExecutor*  owner{nullptr};
+            std::shared_ptr<PipelineBatchState>* pipeline_state{nullptr};
+            PipelineSealGuard*         pipeline_seal{nullptr};
             bool                       armed{true};
 
             TranslateGroupTerminalizer(
                 RHIBackendSubmissionBatch* _batch,
                 Array<TranslateGroupSlot>* _slots,
                 size_t                     _group_end,
-                size_t*                    _first_unconsumed_source
+                size_t*                    _first_unconsumed_source,
+                VulkanSubmissionExecutor*  _owner,
+                std::shared_ptr<PipelineBatchState>* _pipeline_state,
+                PipelineSealGuard*         _pipeline_seal
             ) noexcept :
                 batch(_batch),
                 slots(_slots),
                 group_end(_group_end),
-                first_unconsumed_source(_first_unconsumed_source) {}
+                first_unconsumed_source(_first_unconsumed_source),
+                owner(_owner),
+                pipeline_state(_pipeline_state),
+                pipeline_seal(_pipeline_seal) {}
 
             TranslateGroupTerminalizer(const TranslateGroupTerminalizer&)            = delete;
             TranslateGroupTerminalizer& operator=(const TranslateGroupTerminalizer&) = delete;
@@ -1957,6 +2066,14 @@ void VulkanSubmissionExecutor::ProcessBatch(
                 }
                 if (result == VK_SUCCESS) {
                     result = VK_ERROR_UNKNOWN;
+                }
+                if (pipeline_state != nullptr && *pipeline_state) {
+                    // Direct queue rejection is observable through callbacks
+                    // and signals. Preserve every already-handed-off prefix
+                    // before terminalizing the current group, including this
+                    // guard's exception-unwind path.
+                    pipeline_seal->Seal();
+                    owner->DrainPipelineBatches();
                 }
                 for (TranslateGroupSlot& slot : *slots) {
                     if (slot.terminalized) {
@@ -1984,7 +2101,15 @@ void VulkanSubmissionExecutor::ProcessBatch(
                 }
                 armed = false;
             }
-        } terminalizer{&_batch, &slots, group_end, &_exception_state.first_unconsumed_source};
+        } terminalizer{
+            &_batch,
+            &slots,
+            group_end,
+            &_exception_state.first_unconsumed_source,
+            this,
+            &pipeline_state,
+            &pipeline_seal,
+        };
 
         auto slot_for_key = [&](const SubmissionKey& key) -> TranslateGroupSlot& {
             assert(key.op_seq == _batch.sequence);

--- a/source/runtime/render/rhi/vulkan/VulkanSubmissionExecutor.h
+++ b/source/runtime/render/rhi/vulkan/VulkanSubmissionExecutor.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "rhi/RHIExecutorBackend.h"
+#include "rhi/RHISubmissionPipelinePolicy.h"
 #include "VulkanQueue.h"
 #include "VulkanSubmissionRequestDispatch.h"
 
@@ -104,8 +105,7 @@ private:
         uint64                       sequence{0};
         Array<PipelineSourceSlot>    slots{};
         std::shared_ptr<Completion>  completion{};
-        std::atomic<size_t>          outstanding_work{0};
-        std::atomic_bool             sealed{false};
+        RHISubmissionPipelinePolicy::PipelineBatchWorkState work_state{};
         std::atomic_bool             completion_signalled{false};
         mutable std::mutex           failure_mutex{};
         PipelineFailure              failure{};

--- a/source/runtime/render/rhi/vulkan/VulkanSubmissionExecutor.h
+++ b/source/runtime/render/rhi/vulkan/VulkanSubmissionExecutor.h
@@ -1,12 +1,15 @@
 #pragma once
 
 #include "rhi/RHIExecutorBackend.h"
+#include "VulkanQueue.h"
 #include "VulkanSubmissionRequestDispatch.h"
 
+#include <atomic>
 #include <condition_variable>
 #include <deque>
 #include <exception>
 #include <future>
+#include <limits>
 #include <memory>
 #include <mutex>
 #include <stdexcept>
@@ -25,7 +28,7 @@ namespace Moer::Render {
 // GPU execution across distinct native queues.
 class VulkanSubmissionExecutor final : public RHIBackendExecutor {
 public:
-    VulkanSubmissionExecutor();
+    explicit VulkanSubmissionExecutor(uint32 _batch_window = 2);
     ~VulkanSubmissionExecutor() override;
 
     void          Enqueue(RHIBackendSubmissionBatch&& _batch) override;
@@ -65,6 +68,54 @@ private:
         std::packaged_task<void()> execute{};
     };
 
+    struct PipelineFailure {
+        size_t reject_from{std::numeric_limits<size_t>::max()};
+        int32  result{0};
+        bool   recoverable{false};
+    };
+
+    struct PipelineSourceSlot {
+        EQueueType queue{EQueueType::Ignore};
+        uint64     async_queue_scope{0};
+        uint32     original_source_index{0};
+        uint32     source_segment_index{0};
+        uint32     source_segment_count{1};
+        bool       cross_native_predecessor_wait{false};
+        std::optional<VkCommandQueue::CurrentVulkanRecordedSubmit> command_packet{};
+    };
+
+    struct PipelineBatchState {
+        explicit PipelineBatchState(
+            uint64                      _sequence,
+            size_t                      _source_count,
+            std::shared_ptr<Completion> _completion
+        );
+
+        void AddWork() noexcept;
+        void FinishWork() noexcept;
+        void Seal() noexcept;
+        void PublishFailure(
+            size_t _reject_from,
+            int32  _result,
+            bool   _recoverable
+        ) noexcept;
+        [[nodiscard]] PipelineFailure ReadFailure() const noexcept;
+
+        uint64                       sequence{0};
+        Array<PipelineSourceSlot>    slots{};
+        std::shared_ptr<Completion>  completion{};
+        std::atomic<size_t>          outstanding_work{0};
+        std::atomic_bool             sealed{false};
+        std::atomic_bool             completion_signalled{false};
+        mutable std::mutex           failure_mutex{};
+        PipelineFailure              failure{};
+    };
+
+    struct StreamPosition {
+        uint64 batch_sequence{0};
+        size_t source_index{0};
+    };
+
     void RunExecutor();
     void RunSubmission();
     bool EnqueueSubmissionWork(SubmissionWork&& _work);
@@ -96,6 +147,27 @@ private:
         RHIBackendSubmissionBatch& _batch,
         BatchExceptionState&       _exception_state
     );
+    void ExecutePipelineSource(
+        const std::shared_ptr<PipelineBatchState>& _batch,
+        size_t                                     _source_index
+    ) noexcept;
+    void WaitForPipelineCapacity();
+    void DrainPipelineBatches();
+    void PrepareStreamSubmit(CmdSubmit& _submit, EQueueType _queue);
+    void UpdateStreamFrontier(
+        EQueueType _queue,
+        WaitEvent  _completion,
+        bool       _collapse
+    );
+    void ResetStreamScope() noexcept;
+    void LatchHardFailure(
+        StreamPosition _position,
+        int32          _result
+    ) noexcept;
+    [[nodiscard]] bool IsHardFailureAtOrBefore(
+        StreamPosition _position,
+        int32*         _result = nullptr
+    ) const noexcept;
     void ProcessSync(ERHISyncDepth _depth);
     void RejectBatch(
         RHIBackendSubmissionBatch&& _batch,
@@ -119,13 +191,20 @@ private:
     bool                       constructor_abort{false};
     bool                       stopped{false};
     bool                       claims_owned{false};
-    bool                       hard_failed{false};
     bool                       logged_multi_source_topology{false};
     bool                       logged_multi_segment_topology{false};
     bool                       logged_async_queue_scope{false};
-    bool                                                    logged_parallel_translate_wave{false};
-    int32                      hard_failure_result{0};
+    bool                       logged_parallel_translate_wave{false};
+    bool                       logged_cross_batch_pipeline{false};
     std::shared_ptr<Completion> stop_completion{};
+    size_t                     batch_window{2};
+    bool                       graphics_compute_share_native_lane{false};
+    std::deque<std::shared_ptr<Completion>> in_flight_batches{};
+
+    mutable std::mutex         hard_failure_mutex{};
+    std::optional<StreamPosition> hard_failure_position{};
+    int32                      hard_failure_result{0};
+
     StaticArray<bool, static_cast<size_t>(EQueueType::Num)> used_queues{};
     uint64                     last_copy_timeline{0};
     StaticArray<

--- a/source/test/CMakeLists.txt
+++ b/source/test/CMakeLists.txt
@@ -124,6 +124,17 @@ target_link_libraries(${test_target}
 set_target_properties(${test_target} PROPERTIES FOLDER ${moer_test_folder})
 add_test(NAME RHIThreadOwnershipContract COMMAND $<TARGET_FILE:${test_target}>)
 
+# CPU-only contract for the bounded cross-batch submission policy. It verifies
+# the configured window clamp and the correctness-critical Graphics/Compute
+# native-queue alias fallback without requiring alias-capable Vulkan hardware.
+set(test_target TestRHISubmissionPipelinePolicy)
+add_executable(${test_target} "RHISubmissionPipelinePolicyTest.cpp")
+target_link_libraries(${test_target}
+    PRIVATE Moer::Render
+)
+set_target_properties(${test_target} PROPERTIES FOLDER ${moer_test_folder})
+add_test(NAME RHISubmissionPipelinePolicyContract COMMAND $<TARGET_FILE:${test_target}>)
+
 # CPU-only contract for the Vulkan recorder work heuristic. This uses RHI
 # command payloads but does not create a Vulkan instance or device.
 set(test_target TestVulkanParallelRecordWorkEstimator)

--- a/source/test/RHIParallelRecordVulkanTest.cpp
+++ b/source/test/RHIParallelRecordVulkanTest.cpp
@@ -71,6 +71,46 @@ private:
     EQueueType             queue;
 };
 
+class PipelineTranslateProbeCommand final : public VkCustomDispatchCmd {
+public:
+    PipelineTranslateProbeCommand(
+        EQueueType               _queue,
+        std::binary_semaphore*   _translated,
+        std::atomic<uint32>*     _translate_count,
+        const std::atomic<bool>* _dependency_release_started,
+        std::atomic<bool>*       _observed_dependency_release
+    ) :
+        queue(_queue),
+        translated(_translated),
+        translate_count(_translate_count),
+        dependency_release_started(_dependency_release_started),
+        observed_dependency_release(_observed_dependency_release) {}
+
+    void Execute(const VkDispatchContext&) const override {
+        observed_dependency_release->store(
+            dependency_release_started->load(std::memory_order_acquire),
+            std::memory_order_release
+        );
+        translate_count->fetch_add(1, std::memory_order_acq_rel);
+        translated->release();
+    }
+
+    EQueueType GetQueueType() const override {
+        return queue;
+    }
+
+private:
+    std::span<const ResourceUsage> GetResourceUsages() const override {
+        return {};
+    }
+
+    EQueueType               queue;
+    std::binary_semaphore*   translated;
+    std::atomic<uint32>*     translate_count;
+    const std::atomic<bool>* dependency_release_started;
+    std::atomic<bool>*       observed_dependency_release;
+};
+
 class BlockingTranslateProbeCommand final : public VkCustomDispatchCmd {
 public:
     BlockingTranslateProbeCommand(
@@ -298,15 +338,18 @@ private:
     bool                           installed{false};
 };
 
-class CopyDependencyWaitCapture final {
+class DependencyWaitCapture final {
 public:
+    explicit DependencyWaitCapture(EQueueType _queue) :
+        queue(_queue) {}
+
     static void Observe(
         void*                                        _context,
         const VulkanSubmissionDependencyWaitEvent& _event
     ) noexcept {
         auto& capture =
-            *static_cast<CopyDependencyWaitCapture*>(_context);
-        if (_event.queue != EQueueType::Copy) {
+            *static_cast<DependencyWaitCapture*>(_context);
+        if (_event.queue != capture.queue) {
             return;
         }
         if (_event.thread_role != ERHIThreadRole::Submission) {
@@ -320,16 +363,19 @@ public:
     std::binary_semaphore entered{0};
     std::atomic<uint32>   count{0};
     std::atomic<bool>     wrong_owner{false};
+
+private:
+    EQueueType queue{EQueueType::Ignore};
 };
 
 class ScopedDependencyWaitObserver final {
 public:
     explicit ScopedDependencyWaitObserver(
-        CopyDependencyWaitCapture& _capture
+        DependencyWaitCapture& _capture
     ) :
         observer{
             .context  = &_capture,
-            .callback = &CopyDependencyWaitCapture::Observe,
+            .callback = &DependencyWaitCapture::Observe,
         } {
         if (!TryInstallVulkanSubmissionDependencyWaitObserver(
                 &observer
@@ -442,9 +488,17 @@ void ValidateArguments(int _argc, const char** _argv) {
         if (argument != "--parallel" && argument != "--inject-worker-failure" &&
             argument != "--production-gate" && argument != "--production-heavy" &&
             argument != "--inject-translate-failure" &&
-            argument != "--inject-multi-segment-translate-failure") {
+            argument != "--inject-multi-segment-translate-failure" &&
+            argument != "--pipeline-window1" &&
+            argument != "--pipeline-window2") {
             throw std::invalid_argument("unsupported argument: " + std::string(argument));
         }
+    }
+    if (HasArgument(_argc, _argv, "--pipeline-window1") &&
+        HasArgument(_argc, _argv, "--pipeline-window2")) {
+        throw std::invalid_argument(
+            "--pipeline-window1 and --pipeline-window2 are mutually exclusive"
+        );
     }
     if (HasArgument(_argc, _argv, "--inject-worker-failure") &&
         !HasArgument(_argc, _argv, "--parallel")) {
@@ -4707,6 +4761,901 @@ void RunRuntimeRejectCompletionOwnership() {
     );
 }
 
+void RunBoundedCrossBatchSubmissionPipeline(uint32 _batch_window) {
+    using namespace std::chrono_literals;
+
+    if (_batch_window != 1 && _batch_window != 2) {
+        throw std::invalid_argument(
+            "bounded cross-batch pipeline test requires window 1 or 2"
+        );
+    }
+
+    auto&                  device   = RenderDevice::Get();
+    const RHIQueueTopology topology = device.GetQueueTopology();
+    if (!topology.graphics.available || !topology.compute.available) {
+        LOG_INFO(
+            "[TESTCASE][SKIP] name=BoundedCrossBatchSubmissionPipeline "
+            "window={} reason=queue_unavailable graphics_native={} "
+            "compute_native={}",
+            _batch_window,
+            topology.graphics.native_queue_id,
+            topology.compute.native_queue_id
+        );
+        return;
+    }
+
+    constexpr uint64 async_queue_scope = 0x5048313544504950ull;
+    const bool distinct_native =
+        topology.graphics.native_queue_id != topology.compute.native_queue_id;
+    const uint32 main_thread_id = Platform::GetCurrentThreadID();
+
+    SourceSubmissionCapture        source_capture(async_queue_scope);
+    ScopedSourceSubmissionObserver source_observer(source_capture);
+    NativeSubmissionCapture        native_capture{};
+    ScopedNativeSubmissionObserver native_observer(native_capture);
+    DependencyWaitCapture          graphics_wait_capture{EQueueType::Graphics};
+    ScopedDependencyWaitObserver   wait_observer(graphics_wait_capture);
+
+    FenceRef dependency    = device.CreateFence();
+    FenceRef graphics_done = device.CreateFence();
+    FenceRef compute_done  = device.CreateFence();
+
+    std::array<std::atomic<uint32>, 2> ordinary_callbacks{};
+    std::array<std::atomic<uint32>, 2> success_callbacks{};
+    std::array<std::atomic<uint32>, 2> translate_counts{};
+    std::binary_semaphore              graphics_translated{0};
+    std::binary_semaphore              compute_translated{0};
+    std::atomic<bool>                  dependency_release_started{false};
+    std::atomic<bool>                  graphics_observed_release{true};
+    std::atomic<bool>                  compute_observed_release{false};
+    bool                               dependency_released{false};
+
+    const auto release_dependency = [&] {
+        if (dependency_released) {
+            return;
+        }
+        dependency_release_started.store(true, std::memory_order_release);
+        ResourceCast(dependency.Get())->SignalHost(1);
+        dependency_released = true;
+    };
+
+    try {
+        CommandList graphics(EQueueType::Graphics);
+        graphics.SetResourceStateOwnership(
+            ERHIResourceStateOwnership::Explicit
+        );
+        graphics.AddCustomCommand(
+            MakeUnique<PipelineTranslateProbeCommand>(
+                EQueueType::Graphics,
+                &graphics_translated,
+                &translate_counts[0],
+                &dependency_release_started,
+                &graphics_observed_release
+            ),
+            "PipelineWindowGraphicsTranslateProbe"
+        );
+        graphics.AddCallback([&] {
+            ordinary_callbacks[0].fetch_add(
+                1, std::memory_order_relaxed
+            );
+        });
+        graphics.AddSuccessCallback([&] {
+            success_callbacks[0].fetch_add(
+                1, std::memory_order_relaxed
+            );
+        });
+        CmdSubmit graphics_submit = graphics.Submit();
+        graphics_submit.SetTranslateExecutionClass(
+            ERHITranslateExecutionClass::Parallel
+        );
+        graphics_submit.SetResourceStateOwnership(
+            ERHIResourceStateOwnership::Explicit
+        );
+        graphics_submit.async_queue_scope = async_queue_scope;
+        graphics_submit.Wait(dependency.Get(), 1)
+            .Signal(graphics_done.Get(), 1);
+
+        RHIExecutor::Get().Submit(
+            EQueueType::Graphics,
+            std::move(graphics_submit),
+            ERHIExecSubmitFlags::FlushGPU
+        );
+        if (!graphics_wait_capture.entered.try_acquire_for(5s) ||
+            graphics_wait_capture.count.load(std::memory_order_acquire) != 1 ||
+            graphics_wait_capture.wrong_owner.load(std::memory_order_acquire) ||
+            native_capture.Count() != 0 ||
+            source_capture.Count() != 0 ||
+            !graphics_translated.try_acquire()) {
+            throw std::runtime_error(
+                "batch 0 did not block its translated Graphics packet on "
+                "the sole Submission owner"
+            );
+        }
+        if (translate_counts[0].load(std::memory_order_acquire) != 1 ||
+            graphics_observed_release.load(std::memory_order_acquire)) {
+            throw std::runtime_error(
+                "batch 0 Translate did not precede dependency release exactly once"
+            );
+        }
+
+        CommandList compute(EQueueType::Compute);
+        compute.SetResourceStateOwnership(
+            ERHIResourceStateOwnership::Explicit
+        );
+        compute.AddCustomCommand(
+            MakeUnique<PipelineTranslateProbeCommand>(
+                EQueueType::Compute,
+                &compute_translated,
+                &translate_counts[1],
+                &dependency_release_started,
+                &compute_observed_release
+            ),
+            "PipelineWindowComputeTranslateProbe"
+        );
+        compute.AddCallback([&] {
+            ordinary_callbacks[1].fetch_add(
+                1, std::memory_order_relaxed
+            );
+        });
+        compute.AddSuccessCallback([&] {
+            success_callbacks[1].fetch_add(
+                1, std::memory_order_relaxed
+            );
+        });
+        CmdSubmit compute_submit = compute.Submit();
+        compute_submit.SetTranslateExecutionClass(
+            ERHITranslateExecutionClass::Parallel
+        );
+        compute_submit.SetResourceStateOwnership(
+            ERHIResourceStateOwnership::Explicit
+        );
+        compute_submit.async_queue_scope = async_queue_scope;
+        compute_submit.Signal(compute_done.Get(), 1);
+
+        RHIExecutor::Get().Submit(
+            EQueueType::Compute,
+            std::move(compute_submit),
+            ERHIExecSubmitFlags::FlushGPU
+        );
+
+        bool compute_translate_observed = false;
+        if (_batch_window == 2 && distinct_native) {
+            compute_translate_observed =
+                compute_translated.try_acquire_for(5s);
+            if (!compute_translate_observed ||
+                compute_observed_release.load(std::memory_order_acquire)) {
+                throw std::runtime_error(
+                    "window 2 did not Translate batch 1 while batch 0 "
+                    "Submission was blocked"
+                );
+            }
+        } else if (_batch_window == 1) {
+            compute_translate_observed =
+                compute_translated.try_acquire_for(250ms);
+            if (compute_translate_observed) {
+                throw std::runtime_error(
+                    "window 1 admitted batch 1 Translate before batch 0 "
+                    "Submission reached a terminal state"
+                );
+            }
+        } else {
+            compute_translate_observed =
+                compute_translated.try_acquire_for(250ms);
+            if (compute_translate_observed) {
+                throw std::runtime_error(
+                    "Graphics/Compute native alias did not reduce the "
+                    "effective window to 1"
+                );
+            }
+            LOG_INFO(
+                "[TESTCASE][PASS] "
+                "name=BoundedCrossBatchSubmissionPipelineOverlap "
+                "requested_window=2 effective_window=1 "
+                "reason=native_queue_alias graphics_native={} "
+                "compute_native={} admission=blocked",
+                topology.graphics.native_queue_id,
+                topology.compute.native_queue_id
+            );
+        }
+
+        release_dependency();
+        RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
+
+        if (!compute_translate_observed &&
+            !compute_translated.try_acquire()) {
+            throw std::runtime_error(
+                "batch 1 Translate did not complete after dependency release"
+            );
+        }
+        if (translate_counts[0].load(std::memory_order_acquire) != 1 ||
+            translate_counts[1].load(std::memory_order_acquire) != 1) {
+            throw std::runtime_error(
+                "cross-batch Translate probes did not execute exactly once"
+            );
+        }
+        if ((_batch_window == 1 || !distinct_native) &&
+            !compute_observed_release.load(std::memory_order_acquire)) {
+            throw std::runtime_error(
+                "effective window 1 batch 1 Translate started before "
+                "dependency release"
+            );
+        }
+
+        if (source_capture.Overflowed() || source_capture.Count() != 2) {
+            throw std::runtime_error(
+                "cross-batch pipeline did not report exactly two source submissions"
+            );
+        }
+        const VulkanSourceSubmissionEvent& graphics_source =
+            source_capture.Event(0);
+        const VulkanSourceSubmissionEvent& compute_source =
+            source_capture.Event(1);
+        if (graphics_source.batch_sequence == 0 ||
+            compute_source.batch_sequence !=
+                graphics_source.batch_sequence + 1 ||
+            graphics_source.source_index != 0 ||
+            compute_source.source_index != 0 ||
+            graphics_source.original_source_index != 0 ||
+            compute_source.original_source_index != 0 ||
+            graphics_source.queue != EQueueType::Graphics ||
+            compute_source.queue != EQueueType::Compute ||
+            graphics_source.async_queue_scope != async_queue_scope ||
+            compute_source.async_queue_scope != async_queue_scope) {
+            throw std::runtime_error(
+                "Submission owner did not preserve stable Graphics-to-Compute "
+                "source order across consecutive batches"
+            );
+        }
+
+        if (native_capture.Overflowed() || native_capture.Count() != 2) {
+            throw std::runtime_error(
+                "cross-batch pipeline did not issue exactly two native submits"
+            );
+        }
+        constexpr std::array expected_queues{
+            EQueueType::Graphics,
+            EQueueType::Compute,
+        };
+        const uint32 submission_thread_id =
+            native_capture.Event(0).thread_id;
+        for (size_t index = 0; index < expected_queues.size(); ++index) {
+            const VulkanNativeSubmissionEvent& event =
+                native_capture.Event(index);
+            if (event.queue != expected_queues[index] ||
+                event.thread_role != ERHIThreadRole::Submission ||
+                event.thread_id != submission_thread_id ||
+                event.thread_id == main_thread_id ||
+                !event.outcome.WasSubmitted()) {
+                throw std::runtime_error(
+                    "native submission escaped the sole Submission owner "
+                    "or changed cross-batch source order"
+                );
+            }
+        }
+        if ((native_capture.Event(0).native_queue_handle ==
+             native_capture.Event(1).native_queue_handle) !=
+            !distinct_native) {
+            throw std::runtime_error(
+                "cross-batch native observer disagrees with queue topology"
+            );
+        }
+
+        if (ResourceCast(graphics_done.Get())->HostWait(1) != VK_SUCCESS ||
+            ResourceCast(compute_done.Get())->HostWait(1) != VK_SUCCESS ||
+            ResourceCast(graphics_done.Get())->IsRejected(1) ||
+            ResourceCast(compute_done.Get())->IsRejected(1) ||
+            ResourceCast(graphics_done.Get())->IsFailed() ||
+            ResourceCast(compute_done.Get())->IsFailed()) {
+            throw std::runtime_error(
+                "cross-batch pipeline signals did not complete successfully"
+            );
+        }
+        for (size_t index = 0; index < ordinary_callbacks.size(); ++index) {
+            if (ordinary_callbacks[index].load(std::memory_order_acquire) != 1 ||
+                success_callbacks[index].load(std::memory_order_acquire) != 1) {
+                throw std::runtime_error(
+                    "cross-batch callbacks did not retire exactly once"
+                );
+            }
+        }
+
+        RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
+        if (source_capture.Count() != 2 || native_capture.Count() != 2 ||
+            translate_counts[0].load(std::memory_order_acquire) != 1 ||
+            translate_counts[1].load(std::memory_order_acquire) != 1) {
+            throw std::runtime_error(
+                "a second Sync replayed cross-batch Translate or submission"
+            );
+        }
+        for (size_t index = 0; index < ordinary_callbacks.size(); ++index) {
+            if (ordinary_callbacks[index].load(std::memory_order_acquire) != 1 ||
+                success_callbacks[index].load(std::memory_order_acquire) != 1) {
+                throw std::runtime_error(
+                    "a second Sync replayed cross-batch callbacks"
+                );
+            }
+        }
+    } catch (...) {
+        const std::exception_ptr failure = std::current_exception();
+        release_dependency();
+        try {
+            RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
+        } catch (...) {
+            std::terminate();
+        }
+        std::rethrow_exception(failure);
+    }
+
+    LOG_INFO(
+        "[TESTCASE][PASS] name=BoundedCrossBatchSubmissionPipeline "
+        "window={} native_alias={} overlap_assertion={} batches=2 "
+        "queues=Graphics,Compute source_order=G,C "
+        "native_owner=Submission signals=success callbacks=exactly_once replay=0",
+        _batch_window,
+        !distinct_native,
+        _batch_window == 2 && distinct_native ? "verified" : "blocked"
+    );
+}
+
+void RunBoundedCrossBatchRecoverableRejection() {
+    using namespace std::chrono_literals;
+
+    auto&                  device   = RenderDevice::Get();
+    const RHIQueueTopology topology = device.GetQueueTopology();
+    if (!topology.graphics.available || !topology.compute.available) {
+        LOG_INFO(
+            "[TESTCASE][SKIP] name=BoundedCrossBatchRecoverableRejection "
+            "reason=queue_unavailable graphics_native={} compute_native={}",
+            topology.graphics.native_queue_id,
+            topology.compute.native_queue_id
+        );
+        return;
+    }
+
+    constexpr uint64 async_queue_scope = 0x504831354452454Aull;
+    const bool distinct_native =
+        topology.graphics.native_queue_id != topology.compute.native_queue_id;
+    const uint32 main_thread_id = Platform::GetCurrentThreadID();
+
+    SourceSubmissionCapture        source_capture(async_queue_scope);
+    ScopedSourceSubmissionObserver source_observer(source_capture);
+    NativeSubmissionCapture        native_capture{};
+    ScopedNativeSubmissionObserver native_observer(native_capture);
+    DependencyWaitCapture          graphics_wait_capture{EQueueType::Graphics};
+    ScopedDependencyWaitObserver   wait_observer(graphics_wait_capture);
+
+    FenceRef dependency    = device.CreateFence();
+    FenceRef graphics_done = device.CreateFence();
+    FenceRef compute_done  = device.CreateFence();
+
+    std::array<std::atomic<uint32>, 2> ordinary_callbacks{};
+    std::array<std::atomic<uint32>, 2> success_callbacks{};
+    std::binary_semaphore              graphics_translated{0};
+    std::binary_semaphore              compute_translated{0};
+    bool                               dependency_rejected{false};
+
+    const auto reject_dependency = [&] {
+        if (dependency_rejected) {
+            return;
+        }
+        dependency->Reject(1);
+        dependency_rejected = true;
+    };
+
+    try {
+        CommandList graphics(EQueueType::Graphics);
+        graphics.SetResourceStateOwnership(
+            ERHIResourceStateOwnership::Explicit
+        );
+        graphics.AddCustomCommand(
+            MakeUnique<TranslateProbeCommand>(
+                &graphics_translated, EQueueType::Graphics
+            ),
+            "PipelineRecoverableGraphicsTranslateProbe"
+        );
+        graphics.AddCallback([&] {
+            ordinary_callbacks[0].fetch_add(
+                1, std::memory_order_relaxed
+            );
+        });
+        graphics.AddSuccessCallback([&] {
+            success_callbacks[0].fetch_add(
+                1, std::memory_order_relaxed
+            );
+        });
+        CmdSubmit graphics_submit = graphics.Submit();
+        graphics_submit.SetTranslateExecutionClass(
+            ERHITranslateExecutionClass::Parallel
+        );
+        graphics_submit.SetResourceStateOwnership(
+            ERHIResourceStateOwnership::Explicit
+        );
+        graphics_submit.async_queue_scope = async_queue_scope;
+        graphics_submit.Wait(dependency.Get(), 1)
+            .Signal(graphics_done.Get(), 1);
+
+        RHIExecutor::Get().Submit(
+            EQueueType::Graphics,
+            std::move(graphics_submit),
+            ERHIExecSubmitFlags::FlushGPU
+        );
+        if (!graphics_wait_capture.entered.try_acquire_for(5s) ||
+            graphics_wait_capture.count.load(std::memory_order_acquire) != 1 ||
+            graphics_wait_capture.wrong_owner.load(std::memory_order_acquire) ||
+            !graphics_translated.try_acquire() ||
+            source_capture.Count() != 0 ||
+            native_capture.Count() != 0) {
+            throw std::runtime_error(
+                "recoverable batch 0 did not block its translated Graphics "
+                "packet on the sole Submission owner"
+            );
+        }
+
+        CommandList compute(EQueueType::Compute);
+        compute.SetResourceStateOwnership(
+            ERHIResourceStateOwnership::Explicit
+        );
+        compute.AddCustomCommand(
+            MakeUnique<TranslateProbeCommand>(
+                &compute_translated, EQueueType::Compute
+            ),
+            "PipelineRecoverableComputeTranslateProbe"
+        );
+        compute.AddCallback([&] {
+            ordinary_callbacks[1].fetch_add(
+                1, std::memory_order_relaxed
+            );
+        });
+        compute.AddSuccessCallback([&] {
+            success_callbacks[1].fetch_add(
+                1, std::memory_order_relaxed
+            );
+        });
+        CmdSubmit compute_submit = compute.Submit();
+        compute_submit.SetTranslateExecutionClass(
+            ERHITranslateExecutionClass::Parallel
+        );
+        compute_submit.SetResourceStateOwnership(
+            ERHIResourceStateOwnership::Explicit
+        );
+        compute_submit.async_queue_scope = async_queue_scope;
+        compute_submit.Signal(compute_done.Get(), 1);
+
+        RHIExecutor::Get().Submit(
+            EQueueType::Compute,
+            std::move(compute_submit),
+            ERHIExecSubmitFlags::FlushGPU
+        );
+
+        bool compute_translate_observed = false;
+        if (distinct_native) {
+            compute_translate_observed =
+                compute_translated.try_acquire_for(5s);
+            if (!compute_translate_observed) {
+                throw std::runtime_error(
+                    "window 2 did not Translate recoverable batch 1 while "
+                    "batch 0 Submission was blocked"
+                );
+            }
+        } else {
+            compute_translate_observed =
+                compute_translated.try_acquire_for(250ms);
+            if (compute_translate_observed) {
+                throw std::runtime_error(
+                    "recoverable alias topology admitted batch 1 before "
+                    "batch 0 reached a terminal state"
+                );
+            }
+            LOG_INFO(
+                "[TESTCASE][PASS] "
+                "name=BoundedCrossBatchRecoverableRejectionOverlap "
+                "requested_window=2 effective_window=1 "
+                "reason=native_queue_alias graphics_native={} "
+                "compute_native={} admission=blocked",
+                topology.graphics.native_queue_id,
+                topology.compute.native_queue_id
+            );
+        }
+
+        if (source_capture.Count() != 0 || native_capture.Count() != 0) {
+            throw std::runtime_error(
+                "a cross-batch packet overtook the blocked Submission owner"
+            );
+        }
+
+        reject_dependency();
+        RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
+
+        if (!compute_translate_observed &&
+            !compute_translated.try_acquire()) {
+            throw std::runtime_error(
+                "recoverable batch 1 did not Translate after batch 0 rejection"
+            );
+        }
+        if (ResourceCast(graphics_done.Get())->HostWait(1) !=
+                VK_ERROR_UNKNOWN ||
+            !ResourceCast(graphics_done.Get())->IsRejected(1) ||
+            ResourceCast(graphics_done.Get())->IsFailed()) {
+            throw std::runtime_error(
+                "recoverable batch 0 did not reject its exact signal value"
+            );
+        }
+        if (ResourceCast(compute_done.Get())->HostWait(1) != VK_SUCCESS ||
+            ResourceCast(compute_done.Get())->IsRejected(1) ||
+            ResourceCast(compute_done.Get())->IsFailed()) {
+            throw std::runtime_error(
+                "recoverable batch 0 rejection contaminated batch 1"
+            );
+        }
+        if (ordinary_callbacks[0].load(std::memory_order_acquire) != 1 ||
+            success_callbacks[0].load(std::memory_order_acquire) != 0 ||
+            ordinary_callbacks[1].load(std::memory_order_acquire) != 1 ||
+            success_callbacks[1].load(std::memory_order_acquire) != 1) {
+            throw std::runtime_error(
+                "cross-batch recoverable callbacks did not retire exactly once"
+            );
+        }
+
+        if (source_capture.Overflowed() || source_capture.Count() != 1) {
+            throw std::runtime_error(
+                "rejected batch 0 reached source submission or recovered "
+                "batch 1 was not observed exactly once"
+            );
+        }
+        const VulkanSourceSubmissionEvent& source_event =
+            source_capture.Event(0);
+        if (source_event.batch_sequence == 0 ||
+            source_event.source_index != 0 ||
+            source_event.original_source_index != 0 ||
+            source_event.queue != EQueueType::Compute ||
+            source_event.async_queue_scope != async_queue_scope) {
+            throw std::runtime_error(
+                "recovered batch 1 lost stable source identity"
+            );
+        }
+
+        if (native_capture.Overflowed() || native_capture.Count() != 1) {
+            throw std::runtime_error(
+                "rejected batch 0 reached native submit or recovered batch 1 "
+                "did not submit exactly once"
+            );
+        }
+        const VulkanNativeSubmissionEvent& native_event =
+            native_capture.Event(0);
+        if (native_event.queue != EQueueType::Compute ||
+            native_event.thread_role != ERHIThreadRole::Submission ||
+            native_event.thread_id == main_thread_id ||
+            !native_event.outcome.WasSubmitted()) {
+            throw std::runtime_error(
+                "recovered batch 1 escaped stable Submission ownership"
+            );
+        }
+
+        RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
+        if (source_capture.Count() != 1 || native_capture.Count() != 1 ||
+            ordinary_callbacks[0].load(std::memory_order_acquire) != 1 ||
+            success_callbacks[0].load(std::memory_order_acquire) != 0 ||
+            ordinary_callbacks[1].load(std::memory_order_acquire) != 1 ||
+            success_callbacks[1].load(std::memory_order_acquire) != 1) {
+            throw std::runtime_error(
+                "a second Sync replayed cross-batch recoverable retirement"
+            );
+        }
+    } catch (...) {
+        const std::exception_ptr failure = std::current_exception();
+        reject_dependency();
+        try {
+            RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
+        } catch (...) {
+            std::terminate();
+        }
+        std::rethrow_exception(failure);
+    }
+
+    LOG_INFO(
+        "[TESTCASE][PASS] name=BoundedCrossBatchRecoverableRejection "
+        "window=2 native_alias={} overlap_assertion={} batches=2 "
+        "batch0_native_submit=0 batch0_callbacks=ordinary1_success0 "
+        "batch0_signal=rejected batch1_native_submit=1 "
+        "batch1_callbacks=ordinary1_success1 batch1_signal=success "
+        "native_owner=Submission replay=0",
+        !distinct_native,
+        distinct_native ? "verified" : "blocked"
+    );
+}
+
+void RunBoundedPipelineShutdownCancellation() {
+    using namespace std::chrono_literals;
+
+    auto&                  device   = RenderDevice::Get();
+    const RHIQueueTopology topology = device.GetQueueTopology();
+    if (!topology.graphics.available || !topology.compute.available) {
+        LOG_INFO(
+            "[TESTCASE][SKIP] name=BoundedPipelineShutdownCancellation "
+            "window=2 reason=queue_unavailable graphics_native={} "
+            "compute_native={}",
+            topology.graphics.native_queue_id,
+            topology.compute.native_queue_id
+        );
+        return;
+    }
+
+    constexpr uint64 async_queue_scope = 0x5048313544534844ull;
+    const bool distinct_native =
+        topology.graphics.native_queue_id != topology.compute.native_queue_id;
+    const uint32 main_thread_id = Platform::GetCurrentThreadID();
+
+    SourceSubmissionCapture        source_capture(async_queue_scope);
+    ScopedSourceSubmissionObserver source_observer(source_capture);
+    NativeSubmissionCapture        native_capture{};
+    ScopedNativeSubmissionObserver native_observer(native_capture);
+    DependencyWaitCapture          graphics_wait_capture{EQueueType::Graphics};
+    ScopedDependencyWaitObserver   dependency_wait_observer(
+        graphics_wait_capture
+    );
+    BackendSyncWaitCapture        sync_wait_capture{};
+    ScopedBackendSyncWaitObserver sync_wait_observer(sync_wait_capture);
+
+    FenceRef dependency    = device.CreateFence();
+    FenceRef graphics_done = device.CreateFence();
+    FenceRef compute_done  = device.CreateFence();
+
+    std::array<std::atomic<uint32>, 2> ordinary_callbacks{};
+    std::array<std::atomic<uint32>, 2> success_callbacks{};
+    std::binary_semaphore              graphics_translated{0};
+    std::binary_semaphore              compute_translated{0};
+    std::atomic<bool>                  sync_returned{false};
+    std::jthread                       sync_waiter{};
+    bool                               runtime_stopped{false};
+
+    const auto stop_runtime = [&] {
+        if (runtime_stopped) {
+            return;
+        }
+        RHIExecutor::ShutDown();
+        runtime_stopped = true;
+    };
+
+    try {
+        CommandList graphics(EQueueType::Graphics);
+        graphics.SetResourceStateOwnership(
+            ERHIResourceStateOwnership::Explicit
+        );
+        graphics.AddCustomCommand(
+            MakeUnique<TranslateProbeCommand>(
+                &graphics_translated, EQueueType::Graphics
+            ),
+            "PipelineShutdownGraphicsTranslateProbe"
+        );
+        graphics.AddCallback([&] {
+            ordinary_callbacks[0].fetch_add(
+                1, std::memory_order_relaxed
+            );
+        });
+        graphics.AddSuccessCallback([&] {
+            success_callbacks[0].fetch_add(
+                1, std::memory_order_relaxed
+            );
+        });
+        CmdSubmit graphics_submit = graphics.Submit();
+        graphics_submit.SetTranslateExecutionClass(
+            ERHITranslateExecutionClass::Parallel
+        );
+        graphics_submit.SetResourceStateOwnership(
+            ERHIResourceStateOwnership::Explicit
+        );
+        graphics_submit.async_queue_scope = async_queue_scope;
+        graphics_submit.Wait(dependency.Get(), 1)
+            .Signal(graphics_done.Get(), 1);
+
+        RHIExecutor::Get().Submit(
+            EQueueType::Graphics,
+            std::move(graphics_submit),
+            ERHIExecSubmitFlags::FlushGPU
+        );
+        if (!graphics_wait_capture.entered.try_acquire_for(5s) ||
+            graphics_wait_capture.count.load(std::memory_order_acquire) != 1 ||
+            graphics_wait_capture.wrong_owner.load(std::memory_order_acquire) ||
+            !graphics_translated.try_acquire() ||
+            source_capture.Count() != 0 ||
+            native_capture.Count() != 0) {
+            throw std::runtime_error(
+                "shutdown batch 0 did not block its translated Graphics "
+                "packet on the sole Submission owner"
+            );
+        }
+
+        CommandList compute(EQueueType::Compute);
+        compute.SetResourceStateOwnership(
+            ERHIResourceStateOwnership::Explicit
+        );
+        compute.AddCustomCommand(
+            MakeUnique<TranslateProbeCommand>(
+                &compute_translated, EQueueType::Compute
+            ),
+            "PipelineShutdownComputeTranslateProbe"
+        );
+        compute.AddCallback([&] {
+            ordinary_callbacks[1].fetch_add(
+                1, std::memory_order_relaxed
+            );
+        });
+        compute.AddSuccessCallback([&] {
+            success_callbacks[1].fetch_add(
+                1, std::memory_order_relaxed
+            );
+        });
+        CmdSubmit compute_submit = compute.Submit();
+        compute_submit.SetTranslateExecutionClass(
+            ERHITranslateExecutionClass::Parallel
+        );
+        compute_submit.SetResourceStateOwnership(
+            ERHIResourceStateOwnership::Explicit
+        );
+        compute_submit.async_queue_scope = async_queue_scope;
+        compute_submit.Signal(compute_done.Get(), 1);
+
+        RHIExecutor::Get().Submit(
+            EQueueType::Compute,
+            std::move(compute_submit),
+            ERHIExecSubmitFlags::FlushGPU
+        );
+
+        bool compute_translate_observed = false;
+        if (distinct_native) {
+            compute_translate_observed =
+                compute_translated.try_acquire_for(5s);
+            if (!compute_translate_observed) {
+                throw std::runtime_error(
+                    "window 2 did not Translate shutdown batch 1 while "
+                    "batch 0 Submission was blocked"
+                );
+            }
+        } else {
+            compute_translate_observed =
+                compute_translated.try_acquire_for(250ms);
+            if (compute_translate_observed) {
+                throw std::runtime_error(
+                    "shutdown alias topology admitted batch 1 before "
+                    "batch 0 reached a terminal state"
+                );
+            }
+            LOG_INFO(
+                "[TESTCASE][PASS] "
+                "name=BoundedPipelineShutdownCancellationOverlap "
+                "requested_window=2 effective_window=1 "
+                "reason=native_queue_alias graphics_native={} "
+                "compute_native={} admission=blocked",
+                topology.graphics.native_queue_id,
+                topology.compute.native_queue_id
+            );
+        }
+
+        if (source_capture.Count() != 0 || native_capture.Count() != 0) {
+            throw std::runtime_error(
+                "shutdown batch 1 overtook the blocked Submission owner"
+            );
+        }
+
+        sync_waiter = std::jthread([&] {
+            RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
+            sync_returned.store(true, std::memory_order_release);
+        });
+        if (!sync_wait_capture.entered.try_acquire_for(5s) ||
+            sync_wait_capture.count.load(std::memory_order_acquire) != 1 ||
+            sync_returned.load(std::memory_order_acquire)) {
+            throw std::runtime_error(
+                "concurrent Sync was not registered behind the bounded "
+                "pipeline dependency wait"
+            );
+        }
+
+        stop_runtime();
+        sync_waiter.join();
+
+        if (!compute_translate_observed &&
+            !compute_translated.try_acquire()) {
+            throw std::runtime_error(
+                "shutdown batch 1 did not Translate while draining the pipeline"
+            );
+        }
+        if (!sync_returned.load(std::memory_order_acquire)) {
+            throw std::runtime_error(
+                "pipeline shutdown did not release the concurrent Sync"
+            );
+        }
+        if (ResourceCast(graphics_done.Get())->HostWait(1) !=
+                VK_ERROR_UNKNOWN ||
+            !ResourceCast(graphics_done.Get())->IsRejected(1) ||
+            ResourceCast(graphics_done.Get())->IsFailed()) {
+            throw std::runtime_error(
+                "pipeline shutdown did not reject batch 0's exact signal value"
+            );
+        }
+        if (ResourceCast(compute_done.Get())->HostWait(1) != VK_SUCCESS ||
+            ResourceCast(compute_done.Get())->IsRejected(1) ||
+            ResourceCast(compute_done.Get())->IsFailed()) {
+            throw std::runtime_error(
+                "pipeline shutdown did not drain batch 1 successfully"
+            );
+        }
+        if (ordinary_callbacks[0].load(std::memory_order_acquire) != 1 ||
+            success_callbacks[0].load(std::memory_order_acquire) != 0 ||
+            ordinary_callbacks[1].load(std::memory_order_acquire) != 1 ||
+            success_callbacks[1].load(std::memory_order_acquire) != 1) {
+            throw std::runtime_error(
+                "pipeline shutdown callbacks did not retire exactly once"
+            );
+        }
+
+        if (source_capture.Overflowed() || source_capture.Count() != 1) {
+            throw std::runtime_error(
+                "shutdown-cancelled batch 0 reached source submission or "
+                "batch 1 was not observed exactly once"
+            );
+        }
+        const VulkanSourceSubmissionEvent& source_event =
+            source_capture.Event(0);
+        if (source_event.batch_sequence == 0 ||
+            source_event.source_index != 0 ||
+            source_event.original_source_index != 0 ||
+            source_event.queue != EQueueType::Compute ||
+            source_event.async_queue_scope != async_queue_scope) {
+            throw std::runtime_error(
+                "pipeline shutdown lost drained batch 1 source identity"
+            );
+        }
+
+        if (native_capture.Overflowed() || native_capture.Count() != 1) {
+            throw std::runtime_error(
+                "shutdown-cancelled batch 0 reached native submit or "
+                "batch 1 did not submit exactly once"
+            );
+        }
+        const VulkanNativeSubmissionEvent& native_event =
+            native_capture.Event(0);
+        if (native_event.queue != EQueueType::Compute ||
+            native_event.thread_role != ERHIThreadRole::Submission ||
+            native_event.thread_id == main_thread_id ||
+            !native_event.outcome.WasSubmitted()) {
+            throw std::runtime_error(
+                "pipeline shutdown drained batch 1 outside the Submission owner"
+            );
+        }
+
+        // Shutdown is the terminal lifecycle boundary for this focused mode.
+        // Its return proves the Executor, Translate, Submission, and Completion
+        // owners have drained and joined; the stable counters below therefore
+        // also prove there is no deferred callback or submission replay.
+        if (source_capture.Count() != 1 || native_capture.Count() != 1 ||
+            ordinary_callbacks[0].load(std::memory_order_acquire) != 1 ||
+            success_callbacks[0].load(std::memory_order_acquire) != 0 ||
+            ordinary_callbacks[1].load(std::memory_order_acquire) != 1 ||
+            success_callbacks[1].load(std::memory_order_acquire) != 1) {
+            throw std::runtime_error(
+                "pipeline shutdown left replayable work after owner join"
+            );
+        }
+    } catch (...) {
+        const std::exception_ptr failure = std::current_exception();
+        stop_runtime();
+        if (sync_waiter.joinable()) {
+            sync_waiter.join();
+        }
+        std::rethrow_exception(failure);
+    }
+
+    LOG_INFO(
+        "[TESTCASE][PASS] name=BoundedPipelineShutdownCancellation "
+        "window=2 native_alias={} overlap_assertion={} "
+        "batch0_native_submit=0 batch1_native_submit=1 "
+        "batch0_signal=rejected batch1_signal=success "
+        "callbacks=exactly_once concurrent_sync=drained owners=stopped",
+        !distinct_native,
+        distinct_native ? "verified" : "blocked"
+    );
+}
+
 void RunShutdownDependencyCancellation() {
     using namespace std::chrono_literals;
 
@@ -4721,7 +5670,7 @@ void RunShutdownDependencyCancellation() {
     std::atomic<bool>   sync_returned{false};
     NativeSubmissionCapture        native_capture{};
     ScopedNativeSubmissionObserver native_observer(native_capture);
-    CopyDependencyWaitCapture      copy_wait_capture{};
+    DependencyWaitCapture          copy_wait_capture{EQueueType::Copy};
     ScopedDependencyWaitObserver   wait_observer(copy_wait_capture);
     BackendSyncWaitCapture         sync_wait_capture{};
     ScopedBackendSyncWaitObserver  sync_wait_observer(sync_wait_capture);
@@ -4862,6 +5811,14 @@ int main(int argc, const char** argv) {
             HasArgument(argc, argv, "--inject-translate-failure");
         const bool inject_multi_segment_translate_failure =
             HasArgument(argc, argv, "--inject-multi-segment-translate-failure");
+        const bool pipeline_window1 =
+            HasArgument(argc, argv, "--pipeline-window1");
+        const bool pipeline_window2 =
+            HasArgument(argc, argv, "--pipeline-window2");
+        const bool pipeline_window_mode =
+            pipeline_window1 || pipeline_window2;
+        const uint32 submission_batch_window =
+            pipeline_window1 ? 1u : 2u;
 
         LogSystem::Init();
         ConfigManager::GetInstance().Init(std::filesystem::current_path());
@@ -4874,13 +5831,32 @@ int main(int argc, const char** argv) {
             .rhi_api_version  = "1.3",
             .rhi_thread       = true,
             .rhi_bypass       = false,
-            .parallel_recording = parallel,
+            .parallel_recording = parallel || pipeline_window_mode,
             .parallel_record_workers = 4,
-            .parallel_record_verify = parallel,
+            .parallel_record_verify = parallel || pipeline_window_mode,
             .parallel_record_min_work_units_per_job = production_gate ? 64u : 1u,
+            .submission_batch_window = submission_batch_window,
             .parallel_record_worker_throw_trigger = inject_worker_failure ? 1u : 0u,
         });
         render_device_initialized = true;
+
+        if (pipeline_window_mode) {
+            RunBoundedCrossBatchSubmissionPipeline(
+                submission_batch_window
+            );
+            if (pipeline_window2) {
+                RunBoundedCrossBatchRecoverableRejection();
+                // This stops the RHI runtime and must remain the final focused
+                // lifecycle test before RenderDevice::Dispose().
+                RunBoundedPipelineShutdownCancellation();
+            }
+            RenderDevice::Dispose();
+            render_device_initialized = false;
+            TaskSystem::ShutDown();
+            task_system_initialized = false;
+            return 0;
+        }
+
         RunMultiSegmentCompletionAggregateCpuProbe();
 
         if (inject_translate_failure) {

--- a/source/test/RHIParallelRecordVulkanTest.cpp
+++ b/source/test/RHIParallelRecordVulkanTest.cpp
@@ -458,6 +458,78 @@ private:
     bool                          installed{false};
 };
 
+class BatchPreflightRejectionCapture final {
+public:
+    static void Observe(
+        void*                                      _context,
+        const VulkanBatchPreflightRejectionEvent& _event
+    ) noexcept {
+        auto& capture =
+            *static_cast<BatchPreflightRejectionCapture*>(_context);
+        capture.batch_sequence.store(
+            _event.batch_sequence, std::memory_order_relaxed
+        );
+        capture.thread_id.store(
+            _event.thread_id, std::memory_order_relaxed
+        );
+        if (_event.thread_role != ERHIThreadRole::Translate) {
+            capture.wrong_owner.store(true, std::memory_order_relaxed);
+        }
+        if (_event.executable_preflight) {
+            capture.executable_preflight.store(
+                true, std::memory_order_relaxed
+            );
+        }
+        if (capture.count.fetch_add(1, std::memory_order_acq_rel) == 0) {
+            capture.entered.release();
+        }
+    }
+
+    std::binary_semaphore entered{0};
+    std::atomic<uint32>   count{0};
+    std::atomic<uint32>   thread_id{0};
+    std::atomic<uint64>   batch_sequence{0};
+    std::atomic<bool>     wrong_owner{false};
+    std::atomic<bool>     executable_preflight{false};
+};
+
+class ScopedBatchPreflightRejectionObserver final {
+public:
+    explicit ScopedBatchPreflightRejectionObserver(
+        BatchPreflightRejectionCapture& _capture
+    ) :
+        observer{
+            .context  = &_capture,
+            .callback = &BatchPreflightRejectionCapture::Observe,
+        } {
+        if (!TryInstallVulkanBatchPreflightRejectionObserver(&observer)) {
+            throw std::runtime_error(
+                "Vulkan batch preflight-rejection observer was already "
+                "installed"
+            );
+        }
+        installed = true;
+    }
+
+    ~ScopedBatchPreflightRejectionObserver() noexcept {
+        if (installed &&
+            !RemoveVulkanBatchPreflightRejectionObserver(&observer)) {
+            std::terminate();
+        }
+    }
+
+    ScopedBatchPreflightRejectionObserver(
+        const ScopedBatchPreflightRejectionObserver&
+    ) = delete;
+    ScopedBatchPreflightRejectionObserver& operator=(
+        const ScopedBatchPreflightRejectionObserver&
+    ) = delete;
+
+private:
+    VulkanBatchPreflightRejectionObserver observer{};
+    bool                                  installed{false};
+};
+
 template<size_t N>
 Array<Moer::byte> OwnedBytes(const std::array<uint32, N>& _values) {
     Array<Moer::byte> bytes(sizeof(uint32) * N);
@@ -5097,6 +5169,301 @@ void RunBoundedCrossBatchSubmissionPipeline(uint32 _batch_window) {
     );
 }
 
+void RunBoundedCrossBatchMalformedPreflightOrdering() {
+    using namespace std::chrono_literals;
+
+    auto&                  device   = RenderDevice::Get();
+    const RHIQueueTopology topology = device.GetQueueTopology();
+    if (!topology.graphics.available) {
+        LOG_INFO(
+            "[TESTCASE][SKIP] "
+            "name=BoundedCrossBatchMalformedPreflightOrdering "
+            "reason=graphics_queue_unavailable"
+        );
+        return;
+    }
+
+    constexpr uint64 async_queue_scope = 0x50483135444D414Cull;
+    const uint32     main_thread_id    = Platform::GetCurrentThreadID();
+
+    SourceSubmissionCapture        source_capture(async_queue_scope);
+    ScopedSourceSubmissionObserver source_observer(source_capture);
+    NativeSubmissionCapture        native_capture{};
+    ScopedNativeSubmissionObserver native_observer(native_capture);
+    DependencyWaitCapture          wait_capture{EQueueType::Graphics};
+    ScopedDependencyWaitObserver   wait_observer(wait_capture);
+    BackendSyncWaitCapture         sync_wait_capture{};
+    ScopedBackendSyncWaitObserver  sync_wait_observer(sync_wait_capture);
+    BatchPreflightRejectionCapture preflight_capture{};
+    ScopedBatchPreflightRejectionObserver preflight_observer(
+        preflight_capture
+    );
+
+    FenceRef dependency     = device.CreateFence();
+    FenceRef prefix_done    = device.CreateFence();
+    FenceRef malformed_done = device.CreateFence();
+
+    std::array<std::atomic<uint32>, 2> ordinary_callbacks{};
+    std::array<std::atomic<uint32>, 2> success_callbacks{};
+    std::binary_semaphore              prefix_translated{0};
+    std::binary_semaphore              malformed_translated{0};
+    std::binary_semaphore              malformed_callback_retired{0};
+    std::mutex                         callback_order_mutex{};
+    std::vector<uint32>                callback_order{};
+    std::atomic<bool>                  sync_returned{false};
+    std::jthread                       sync_waiter{};
+    bool                               dependency_released{false};
+
+    const auto release_dependency = [&] {
+        if (dependency_released) {
+            return;
+        }
+        ResourceCast(dependency.Get())->SignalHost(1);
+        dependency_released = true;
+    };
+    const auto record_callback = [&](size_t _index) {
+        {
+            std::lock_guard lock(callback_order_mutex);
+            callback_order.emplace_back(static_cast<uint32>(_index));
+        }
+        ordinary_callbacks[_index].fetch_add(
+            1, std::memory_order_relaxed
+        );
+        if (_index == 1) {
+            malformed_callback_retired.release();
+        }
+    };
+
+    try {
+        CommandList prefix(EQueueType::Graphics);
+        prefix.SetResourceStateOwnership(
+            ERHIResourceStateOwnership::Explicit
+        );
+        prefix.AddCustomCommand(
+            MakeUnique<TranslateProbeCommand>(
+                &prefix_translated, EQueueType::Graphics
+            ),
+            "PipelineMalformedPrefixTranslateProbe"
+        );
+        prefix.AddCallback([&] { record_callback(0); });
+        prefix.AddSuccessCallback([&] {
+            success_callbacks[0].fetch_add(
+                1, std::memory_order_relaxed
+            );
+        });
+        CmdSubmit prefix_submit = prefix.Submit();
+        prefix_submit.SetTranslateExecutionClass(
+            ERHITranslateExecutionClass::Parallel
+        );
+        prefix_submit.SetResourceStateOwnership(
+            ERHIResourceStateOwnership::Explicit
+        );
+        prefix_submit.async_queue_scope = async_queue_scope;
+        prefix_submit.Wait(dependency.Get(), 1)
+            .Signal(prefix_done.Get(), 1);
+
+        RHIExecutor::Get().Submit(
+            EQueueType::Graphics,
+            std::move(prefix_submit),
+            ERHIExecSubmitFlags::FlushGPU
+        );
+        if (!wait_capture.entered.try_acquire_for(5s) ||
+            wait_capture.count.load(std::memory_order_acquire) != 1 ||
+            wait_capture.wrong_owner.load(std::memory_order_acquire) ||
+            !prefix_translated.try_acquire() ||
+            source_capture.Count() != 0 ||
+            native_capture.Count() != 0) {
+            throw std::runtime_error(
+                "malformed-ordering prefix did not block on the sole "
+                "Submission owner"
+            );
+        }
+
+        CommandList malformed(EQueueType::Graphics);
+        malformed.SetResourceStateOwnership(
+            ERHIResourceStateOwnership::Explicit
+        );
+        malformed.AddCustomCommand(
+            MakeUnique<TranslateProbeCommand>(
+                &malformed_translated, EQueueType::Graphics
+            ),
+            "PipelineMalformedRejectedTranslateProbe"
+        );
+        malformed.AddCallback([&] { record_callback(1); });
+        malformed.AddSuccessCallback([&] {
+            success_callbacks[1].fetch_add(
+                1, std::memory_order_relaxed
+            );
+        });
+        CmdSubmit malformed_submit = malformed.Submit();
+        malformed_submit.SetTranslateExecutionClass(
+            ERHITranslateExecutionClass::Parallel
+        );
+        malformed_submit.SetResourceStateOwnership(
+            ERHIResourceStateOwnership::Explicit
+        );
+        malformed_submit.async_queue_scope = async_queue_scope;
+        malformed_submit.Signal(malformed_done.Get(), 1);
+        malformed_submit.segments = {RHISubmitSegment{
+            .queue = EQueueType::Graphics,
+            .begin = 1,
+            .end   = 0,
+        }};
+
+        RHIExecutor::Get().Submit(
+            EQueueType::Graphics,
+            std::move(malformed_submit),
+            ERHIExecSubmitFlags::FlushGPU
+        );
+
+        sync_waiter = std::jthread([&] {
+            RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
+            sync_returned.store(true, std::memory_order_release);
+        });
+        if (!sync_wait_capture.entered.try_acquire_for(5s) ||
+            sync_wait_capture.count.load(std::memory_order_acquire) != 1 ||
+            sync_returned.load(std::memory_order_acquire)) {
+            throw std::runtime_error(
+                "malformed-ordering Sync was not published behind both "
+                "batches"
+            );
+        }
+        if (!preflight_capture.entered.try_acquire_for(5s) ||
+            preflight_capture.count.load(std::memory_order_acquire) != 1 ||
+            preflight_capture.batch_sequence.load(
+                std::memory_order_acquire
+            ) == 0 ||
+            preflight_capture.thread_id.load(
+                std::memory_order_acquire
+            ) == main_thread_id ||
+            preflight_capture.wrong_owner.load(
+                std::memory_order_acquire
+            ) ||
+            preflight_capture.executable_preflight.load(
+                std::memory_order_acquire
+            )) {
+            throw std::runtime_error(
+                "malformed batch did not reach initial preflight rejection "
+                "on the Translate owner"
+            );
+        }
+
+        if (malformed_callback_retired.try_acquire_for(500ms) ||
+            malformed_translated.try_acquire() ||
+            ordinary_callbacks[0].load(std::memory_order_acquire) != 0 ||
+            ordinary_callbacks[1].load(std::memory_order_acquire) != 0 ||
+            success_callbacks[0].load(std::memory_order_acquire) != 0 ||
+            success_callbacks[1].load(std::memory_order_acquire) != 0 ||
+            source_capture.Count() != 0 ||
+            native_capture.Count() != 0) {
+            throw std::runtime_error(
+                "malformed batch retired before the accepted pipeline "
+                "prefix committed"
+            );
+        }
+
+        release_dependency();
+        sync_waiter.join();
+        if (!sync_returned.load(std::memory_order_acquire)) {
+            throw std::runtime_error(
+                "malformed-ordering Sync did not drain after prefix release"
+            );
+        }
+
+        if (ResourceCast(prefix_done.Get())->HostWait(1) != VK_SUCCESS ||
+            ResourceCast(prefix_done.Get())->IsRejected(1) ||
+            ResourceCast(prefix_done.Get())->IsFailed()) {
+            throw std::runtime_error(
+                "malformed-ordering prefix did not complete successfully"
+            );
+        }
+        if (ResourceCast(malformed_done.Get())->HostWait(1) !=
+                VK_ERROR_UNKNOWN ||
+            !ResourceCast(malformed_done.Get())->IsRejected(1) ||
+            ResourceCast(malformed_done.Get())->IsFailed()) {
+            throw std::runtime_error(
+                "malformed batch did not reject its exact signal value"
+            );
+        }
+        if (ordinary_callbacks[0].load(std::memory_order_acquire) != 1 ||
+            ordinary_callbacks[1].load(std::memory_order_acquire) != 1 ||
+            success_callbacks[0].load(std::memory_order_acquire) != 1 ||
+            success_callbacks[1].load(std::memory_order_acquire) != 0) {
+            throw std::runtime_error(
+                "malformed-ordering callbacks did not retire exactly once"
+            );
+        }
+        {
+            std::lock_guard lock(callback_order_mutex);
+            if (callback_order != std::vector<uint32>{0, 1}) {
+                throw std::runtime_error(
+                    "malformed batch callback retired before its accepted "
+                    "pipeline prefix"
+                );
+            }
+        }
+        if (source_capture.Overflowed() || source_capture.Count() != 1 ||
+            source_capture.Event(0).queue != EQueueType::Graphics ||
+            source_capture.Event(0).async_queue_scope !=
+                async_queue_scope) {
+            throw std::runtime_error(
+                "malformed batch reached source submission or the prefix "
+                "was not observed exactly once"
+            );
+        }
+        if (native_capture.Overflowed() || native_capture.Count() != 1 ||
+            native_capture.Event(0).queue != EQueueType::Graphics ||
+            native_capture.Event(0).thread_role !=
+                ERHIThreadRole::Submission ||
+            native_capture.Event(0).thread_id == main_thread_id ||
+            !native_capture.Event(0).outcome.WasSubmitted()) {
+            throw std::runtime_error(
+                "malformed-ordering prefix escaped stable Submission "
+                "ownership"
+            );
+        }
+
+        RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
+        if (source_capture.Count() != 1 || native_capture.Count() != 1 ||
+            ordinary_callbacks[0].load(std::memory_order_acquire) != 1 ||
+            ordinary_callbacks[1].load(std::memory_order_acquire) != 1 ||
+            success_callbacks[0].load(std::memory_order_acquire) != 1 ||
+            success_callbacks[1].load(std::memory_order_acquire) != 0 ||
+            malformed_translated.try_acquire()) {
+            throw std::runtime_error(
+                "a second Sync replayed malformed-ordering retirement"
+            );
+        }
+    } catch (...) {
+        const std::exception_ptr failure = std::current_exception();
+        release_dependency();
+        try {
+            if (sync_waiter.joinable()) {
+                sync_waiter.join();
+            } else {
+                RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
+            }
+        } catch (...) {
+            std::terminate();
+        }
+        std::rethrow_exception(failure);
+    }
+
+    // Invalid topology intentionally hard-latches this backend instance.
+    // Restart it before the remaining focused window-2 lifecycle contracts.
+    RHIExecutor::ShutDown();
+    RHIExecutor::StartUp(2);
+
+    LOG_INFO(
+        "[TESTCASE][PASS] "
+        "name=BoundedCrossBatchMalformedPreflightOrdering "
+        "window=2 batches=2 queue=Graphics prefix=committed "
+        "malformed=rejected callback_order=prefix,malformed "
+        "signals=success,rejected native_owner=Submission replay=0 "
+        "malformed_translate=0 runtime=restarted"
+    );
+}
+
 void RunBoundedCrossBatchRecoverableRejection() {
     using namespace std::chrono_literals;
 
@@ -5845,6 +6212,7 @@ int main(int argc, const char** argv) {
                 submission_batch_window
             );
             if (pipeline_window2) {
+                RunBoundedCrossBatchMalformedPreflightOrdering();
                 RunBoundedCrossBatchRecoverableRejection();
                 // This stops the RHI runtime and must remain the final focused
                 // lifecycle test before RenderDevice::Dispose().

--- a/source/test/RHISubmissionPipelinePolicyTest.cpp
+++ b/source/test/RHISubmissionPipelinePolicyTest.cpp
@@ -1,8 +1,11 @@
 #include "rhi/RHISubmissionPipelinePolicy.h"
 
+#include <atomic>
+#include <barrier>
 #include <iostream>
 #include <limits>
 #include <stdexcept>
+#include <thread>
 
 using namespace Moer::Render;
 
@@ -99,6 +102,119 @@ void UnavailableLogicalQueuesDoNotTriggerAliasFallback() {
     );
 }
 
+void BatchWorkStateSequentialContract() {
+    using RHISubmissionPipelinePolicy::PipelineBatchWorkState;
+
+    PipelineBatchWorkState empty{};
+    Expect(
+        empty.Seal(),
+        "sealing an empty batch did not own its terminal transition"
+    );
+    Expect(
+        !empty.Seal(),
+        "an empty batch published more than one terminal transition"
+    );
+
+    PipelineBatchWorkState seal_first{};
+    seal_first.AddWork();
+    Expect(
+        !seal_first.Seal(),
+        "a sealed batch with outstanding work terminated early"
+    );
+    Expect(
+        seal_first.FinishWork(),
+        "final work retirement did not terminate a sealed batch"
+    );
+
+    PipelineBatchWorkState finish_first{};
+    finish_first.AddWork();
+    Expect(
+        !finish_first.FinishWork(),
+        "an unsealed batch terminated on its final work retirement"
+    );
+    Expect(
+        finish_first.Seal(),
+        "sealing an already-empty batch did not terminate it"
+    );
+
+    PipelineBatchWorkState multiple{};
+    multiple.AddWork();
+    multiple.AddWork();
+    Expect(
+        !multiple.Seal(),
+        "a multi-work batch terminated while work was outstanding"
+    );
+    Expect(
+        !multiple.FinishWork(),
+        "the first multi-work retirement terminated the batch"
+    );
+    Expect(
+        multiple.FinishWork(),
+        "the final multi-work retirement did not terminate the batch"
+    );
+}
+
+void BatchWorkStateSealFinishRaceHasOneTerminalOwner() {
+    using RHISubmissionPipelinePolicy::PipelineBatchWorkState;
+
+    constexpr uint32_t iterations = 20000;
+    std::barrier        phase(3);
+    std::atomic<PipelineBatchWorkState*> active_state{nullptr};
+    std::atomic<uint32_t>                terminal_owners{0};
+
+    std::jthread seal_thread([&] {
+        for (uint32_t iteration = 0; iteration < iterations; ++iteration) {
+            phase.arrive_and_wait();
+            PipelineBatchWorkState* state =
+                active_state.load(std::memory_order_acquire);
+            if ((iteration & 1u) == 0) {
+                std::this_thread::yield();
+            }
+            if (state->Seal()) {
+                terminal_owners.fetch_add(
+                    1, std::memory_order_relaxed
+                );
+            }
+            phase.arrive_and_wait();
+        }
+    });
+    std::jthread finish_thread([&] {
+        for (uint32_t iteration = 0; iteration < iterations; ++iteration) {
+            phase.arrive_and_wait();
+            PipelineBatchWorkState* state =
+                active_state.load(std::memory_order_acquire);
+            if ((iteration & 1u) != 0) {
+                std::this_thread::yield();
+            }
+            if (state->FinishWork()) {
+                terminal_owners.fetch_add(
+                    1, std::memory_order_relaxed
+                );
+            }
+            phase.arrive_and_wait();
+        }
+    });
+
+    uint32_t mismatch_count = 0;
+    for (uint32_t iteration = 0; iteration < iterations; ++iteration) {
+        PipelineBatchWorkState state{};
+        state.AddWork();
+        terminal_owners.store(0, std::memory_order_relaxed);
+        active_state.store(&state, std::memory_order_release);
+        phase.arrive_and_wait();
+        phase.arrive_and_wait();
+        if (terminal_owners.load(std::memory_order_relaxed) != 1) {
+            ++mismatch_count;
+        }
+    }
+    seal_thread.join();
+    finish_thread.join();
+    Expect(
+        mismatch_count == 0,
+        "Seal/FinishWork race lost or duplicated the terminal transition"
+    );
+}
+
 } // namespace
 
 int main() {
@@ -107,6 +223,8 @@ int main() {
         DistinctNativeQueuesPreserveTheClampedWindow();
         GraphicsComputeAliasForcesOneBatchInFlight();
         UnavailableLogicalQueuesDoNotTriggerAliasFallback();
+        BatchWorkStateSequentialContract();
+        BatchWorkStateSealFinishRaceHasOneTerminalOwner();
         std::cout << "RHI submission pipeline policy tests passed\n";
         return 0;
     } catch (const std::exception& error) {

--- a/source/test/RHISubmissionPipelinePolicyTest.cpp
+++ b/source/test/RHISubmissionPipelinePolicyTest.cpp
@@ -1,0 +1,117 @@
+#include "rhi/RHISubmissionPipelinePolicy.h"
+
+#include <iostream>
+#include <limits>
+#include <stdexcept>
+
+using namespace Moer::Render;
+
+namespace {
+
+void Expect(bool _condition, const char* _message) {
+    if (!_condition) {
+        throw std::runtime_error(_message);
+    }
+}
+
+RHIQueueTopology MakeTopology(
+    bool     _graphics_available,
+    uint32_t _graphics_native,
+    bool     _compute_available,
+    uint32_t _compute_native
+) {
+    RHIQueueTopology topology{};
+    topology.graphics.available       = _graphics_available;
+    topology.graphics.native_queue_id = _graphics_native;
+    topology.compute.available        = _compute_available;
+    topology.compute.native_queue_id  = _compute_native;
+    return topology;
+}
+
+void ClampContract() {
+    using namespace RHISubmissionPipelinePolicy;
+
+    static_assert(DefaultBatchWindow == 2);
+    static_assert(MinBatchWindow == 1);
+    static_assert(MaxBatchWindow == 8);
+    static_assert(ClampBatchWindow(0) == 1);
+    static_assert(ClampBatchWindow(1) == 1);
+    static_assert(ClampBatchWindow(2) == 2);
+    static_assert(ClampBatchWindow(8) == 8);
+    static_assert(ClampBatchWindow(9) == 8);
+    static_assert(
+        ClampBatchWindow(std::numeric_limits<uint32_t>::max()) == 8
+    );
+}
+
+void DistinctNativeQueuesPreserveTheClampedWindow() {
+    using namespace RHISubmissionPipelinePolicy;
+
+    constexpr RHIQueueTopology topology = [] {
+        RHIQueueTopology result{};
+        result.graphics.native_queue_id = 3;
+        result.compute.native_queue_id  = 7;
+        return result;
+    }();
+    static_assert(!GraphicsComputeShareNativeLane(topology));
+    static_assert(ResolveEffectiveBatchWindow(0, topology) == 1);
+    static_assert(ResolveEffectiveBatchWindow(2, topology) == 2);
+    static_assert(ResolveEffectiveBatchWindow(9, topology) == 8);
+}
+
+void GraphicsComputeAliasForcesOneBatchInFlight() {
+    using namespace RHISubmissionPipelinePolicy;
+
+    const RHIQueueTopology topology = MakeTopology(true, 5, true, 5);
+    Expect(
+        GraphicsComputeShareNativeLane(topology),
+        "available Graphics/Compute alias was not detected"
+    );
+    Expect(
+        ResolveEffectiveBatchWindow(8, topology) == 1,
+        "Graphics/Compute alias did not force a single in-flight batch"
+    );
+}
+
+void UnavailableLogicalQueuesDoNotTriggerAliasFallback() {
+    using namespace RHISubmissionPipelinePolicy;
+
+    const RHIQueueTopology compute_unavailable =
+        MakeTopology(true, 0, false, 0);
+    Expect(
+        !GraphicsComputeShareNativeLane(compute_unavailable),
+        "unavailable Compute queue triggered alias fallback"
+    );
+    Expect(
+        ResolveEffectiveBatchWindow(4, compute_unavailable) == 4,
+        "unavailable Compute queue changed the configured batch window"
+    );
+
+    const RHIQueueTopology graphics_unavailable =
+        MakeTopology(false, 11, true, 11);
+    Expect(
+        !GraphicsComputeShareNativeLane(graphics_unavailable),
+        "unavailable Graphics queue triggered alias fallback"
+    );
+    Expect(
+        ResolveEffectiveBatchWindow(9, graphics_unavailable) == 8,
+        "unavailable Graphics queue bypassed the ordinary clamp"
+    );
+}
+
+} // namespace
+
+int main() {
+    try {
+        ClampContract();
+        DistinctNativeQueuesPreserveTheClampedWindow();
+        GraphicsComputeAliasForcesOneBatchInFlight();
+        UnavailableLogicalQueuesDoNotTriggerAliasFallback();
+        std::cout << "RHI submission pipeline policy tests passed\n";
+        return 0;
+    } catch (const std::exception& error) {
+        std::cerr << "RHI submission pipeline policy test failed: "
+                  << error.what() << '\n';
+        return 1;
+    }
+}

--- a/template.MoerEngine.toml
+++ b/template.MoerEngine.toml
@@ -26,6 +26,10 @@ parallel_record_verify = false
 parallel_record_profile = false
 # Backend CPU-recording work units per job; this is not a draw-count threshold.
 parallel_record_min_work_units_per_job = 64
+# Bounded number of RHI batches allowed to overlap Translate and Submission.
+# Runtime clamps this value to the supported range [1, 8].
+# If Graphics and Compute alias the same native queue, the effective window is 1.
+submission_batch_window = 2
 
 [engine.rhi]
 type = "Vulkan"

--- a/tools/threading/run_parallel_record_vulkan_test.py
+++ b/tools/threading/run_parallel_record_vulkan_test.py
@@ -350,10 +350,194 @@ def _require_phase15c_completion_aggregate_cpu_probe(
     )
 
 
+def _require_bounded_cross_batch_pipeline(mode: str, text: str) -> None:
+    expected_window = {
+        "pipeline-window1": "1",
+        "pipeline-window2": "2",
+    }[mode]
+    pipeline = _testcase_marker(
+        "BoundedCrossBatchSubmissionPipeline", text
+    )
+    _require(
+        pipeline is not None and pipeline[0] == "PASS",
+        f"{mode}: missing bounded cross-batch pipeline PASS marker",
+    )
+    _, fields = pipeline
+    native_alias = fields.get("native_alias")
+    expected_overlap = (
+        "blocked"
+        if expected_window == "1" or native_alias == "true"
+        else "verified"
+    )
+    _require(
+        fields.get("window") == expected_window
+        and native_alias in {"true", "false"}
+        and fields.get("overlap_assertion") == expected_overlap
+        and fields.get("batches") == "2"
+        and fields.get("queues") == "Graphics,Compute"
+        and fields.get("source_order") == "G,C"
+        and fields.get("native_owner") == "Submission"
+        and fields.get("signals") == "success"
+        and fields.get("callbacks") == "exactly_once"
+        and fields.get("replay") == "0",
+        f"{mode}: incomplete bounded cross-batch pipeline contract",
+    )
+
+    overlap = _testcase_marker(
+        "BoundedCrossBatchSubmissionPipelineOverlap", text
+    )
+    require_overlap_marker = (
+        expected_window == "2" and native_alias == "true"
+    )
+    _require(
+        (overlap is not None) == require_overlap_marker,
+        f"{mode}: invalid bounded cross-batch alias overlap marker presence contract",
+    )
+    alias_native_ids: tuple[str, str] | None = None
+    if overlap is not None:
+        overlap_status, overlap_fields = overlap
+        graphics_native = overlap_fields.get("graphics_native")
+        compute_native = overlap_fields.get("compute_native")
+        _require(
+            expected_window == "2"
+            and native_alias == "true"
+            and overlap_status == "PASS"
+            and overlap_fields.get("requested_window") == "2"
+            and overlap_fields.get("effective_window") == "1"
+            and overlap_fields.get("reason") == "native_queue_alias"
+            and graphics_native is not None
+            and compute_native is not None
+            and graphics_native == compute_native
+            and overlap_fields.get("admission") == "blocked",
+            f"{mode}: invalid bounded cross-batch alias fallback contract",
+        )
+        alias_native_ids = (graphics_native, compute_native)
+
+    if expected_window == "1":
+        return
+
+    rejection = _testcase_marker(
+        "BoundedCrossBatchRecoverableRejection", text
+    )
+    _require(
+        rejection is not None and rejection[0] == "PASS",
+        f"{mode}: missing bounded cross-batch recoverable rejection PASS marker",
+    )
+    _, rejection_fields = rejection
+    rejection_native_alias = rejection_fields.get("native_alias")
+    expected_rejection_overlap = (
+        "blocked" if rejection_native_alias == "true" else "verified"
+    )
+    _require(
+        rejection_fields.get("window") == "2"
+        and rejection_native_alias in {"true", "false"}
+        and rejection_native_alias == native_alias
+        and rejection_fields.get("overlap_assertion")
+        == expected_rejection_overlap
+        and rejection_fields.get("batches") == "2"
+        and rejection_fields.get("batch0_native_submit") == "0"
+        and rejection_fields.get("batch0_callbacks")
+        == "ordinary1_success0"
+        and rejection_fields.get("batch0_signal") == "rejected"
+        and rejection_fields.get("batch1_native_submit") == "1"
+        and rejection_fields.get("batch1_callbacks")
+        == "ordinary1_success1"
+        and rejection_fields.get("batch1_signal") == "success"
+        and rejection_fields.get("native_owner") == "Submission"
+        and rejection_fields.get("replay") == "0",
+        f"{mode}: incomplete bounded cross-batch recoverable rejection contract",
+    )
+
+    rejection_overlap = _testcase_marker(
+        "BoundedCrossBatchRecoverableRejectionOverlap", text
+    )
+    _require(
+        (rejection_overlap is not None)
+        == (rejection_native_alias == "true"),
+        f"{mode}: invalid bounded recoverable alias overlap marker presence contract",
+    )
+    if rejection_overlap is not None:
+        rejection_overlap_status, rejection_overlap_fields = rejection_overlap
+        graphics_native = rejection_overlap_fields.get("graphics_native")
+        compute_native = rejection_overlap_fields.get("compute_native")
+        _require(
+            rejection_overlap_status == "PASS"
+            and rejection_overlap_fields.get("requested_window") == "2"
+            and rejection_overlap_fields.get("effective_window") == "1"
+            and rejection_overlap_fields.get("reason")
+            == "native_queue_alias"
+            and graphics_native is not None
+            and compute_native is not None
+            and graphics_native == compute_native
+            and (graphics_native, compute_native) == alias_native_ids
+            and rejection_overlap_fields.get("admission") == "blocked",
+            f"{mode}: invalid bounded recoverable alias fallback contract",
+        )
+
+    shutdown = _testcase_marker(
+        "BoundedPipelineShutdownCancellation", text
+    )
+    _require(
+        shutdown is not None and shutdown[0] == "PASS",
+        f"{mode}: missing bounded pipeline shutdown cancellation PASS marker",
+    )
+    _, shutdown_fields = shutdown
+    shutdown_native_alias = shutdown_fields.get("native_alias")
+    expected_shutdown_overlap = (
+        "blocked" if shutdown_native_alias == "true" else "verified"
+    )
+    _require(
+        shutdown_fields.get("window") == "2"
+        and shutdown_native_alias in {"true", "false"}
+        and shutdown_native_alias == native_alias
+        and shutdown_native_alias == rejection_native_alias
+        and shutdown_fields.get("overlap_assertion")
+        == expected_shutdown_overlap
+        and shutdown_fields.get("batch0_native_submit") == "0"
+        and shutdown_fields.get("batch1_native_submit") == "1"
+        and shutdown_fields.get("batch0_signal") == "rejected"
+        and shutdown_fields.get("batch1_signal") == "success"
+        and shutdown_fields.get("callbacks") == "exactly_once"
+        and shutdown_fields.get("concurrent_sync") == "drained"
+        and shutdown_fields.get("owners") == "stopped",
+        f"{mode}: incomplete bounded pipeline shutdown cancellation contract",
+    )
+
+    shutdown_overlap = _testcase_marker(
+        "BoundedPipelineShutdownCancellationOverlap", text
+    )
+    _require(
+        (shutdown_overlap is not None)
+        == (shutdown_native_alias == "true"),
+        f"{mode}: invalid bounded pipeline shutdown alias marker presence contract",
+    )
+    if shutdown_overlap is None:
+        return
+    shutdown_overlap_status, shutdown_overlap_fields = shutdown_overlap
+    graphics_native = shutdown_overlap_fields.get("graphics_native")
+    compute_native = shutdown_overlap_fields.get("compute_native")
+    _require(
+        shutdown_native_alias == "true"
+        and shutdown_overlap_status == "PASS"
+        and shutdown_overlap_fields.get("requested_window") == "2"
+        and shutdown_overlap_fields.get("effective_window") == "1"
+        and shutdown_overlap_fields.get("reason") == "native_queue_alias"
+        and graphics_native is not None
+        and compute_native is not None
+        and graphics_native == compute_native
+        and (graphics_native, compute_native) == alias_native_ids
+        and shutdown_overlap_fields.get("admission") == "blocked",
+        f"{mode}: invalid bounded pipeline shutdown alias fallback contract",
+    )
+
+
 def validate_log(mode: str, text: str) -> None:
     _require("[TESTCASE][FAIL]" not in text, f"{mode}: test emitted a FAIL marker")
     _require("VUID-" not in text, f"{mode}: Vulkan validation VUID was emitted")
     _require("Validation Error" not in text, f"{mode}: Vulkan validation error was emitted")
+    if mode in ("pipeline-window1", "pipeline-window2"):
+        _require_bounded_cross_batch_pipeline(mode, text)
+        return
     _require_phase15c_completion_aggregate_cpu_probe(mode, text)
     if mode == "translate-hard":
         retirement = _testcase_marker(
@@ -581,6 +765,10 @@ def run_case(executable: Path, outdir: Path, mode: str, timeout: float) -> Path:
         arguments.append("--inject-translate-failure")
     if mode == "multi-segment-hard":
         arguments.append("--inject-multi-segment-translate-failure")
+    if mode == "pipeline-window1":
+        arguments.append("--pipeline-window1")
+    if mode == "pipeline-window2":
+        arguments.append("--pipeline-window2")
 
     completed = subprocess.run(
         [str(executable), *arguments],
@@ -631,6 +819,8 @@ def main(argv: Sequence[str] | None = None) -> int:
                 "heavy",
                 "translate-hard",
                 "multi-segment-hard",
+                "pipeline-window1",
+                "pipeline-window2",
             )
         ]
     except (OSError, subprocess.TimeoutExpired, VulkanTestError) as error:

--- a/tools/threading/run_parallel_record_vulkan_test.py
+++ b/tools/threading/run_parallel_record_vulkan_test.py
@@ -416,6 +416,29 @@ def _require_bounded_cross_batch_pipeline(mode: str, text: str) -> None:
     if expected_window == "1":
         return
 
+    malformed = _testcase_marker(
+        "BoundedCrossBatchMalformedPreflightOrdering", text
+    )
+    _require(
+        malformed is not None and malformed[0] == "PASS",
+        f"{mode}: missing malformed-preflight ordering PASS marker",
+    )
+    _, malformed_fields = malformed
+    _require(
+        malformed_fields.get("window") == "2"
+        and malformed_fields.get("batches") == "2"
+        and malformed_fields.get("queue") == "Graphics"
+        and malformed_fields.get("prefix") == "committed"
+        and malformed_fields.get("malformed") == "rejected"
+        and malformed_fields.get("callback_order") == "prefix,malformed"
+        and malformed_fields.get("signals") == "success,rejected"
+        and malformed_fields.get("native_owner") == "Submission"
+        and malformed_fields.get("replay") == "0"
+        and malformed_fields.get("malformed_translate") == "0"
+        and malformed_fields.get("runtime") == "restarted",
+        f"{mode}: incomplete malformed-preflight ordering contract",
+    )
+
     rejection = _testcase_marker(
         "BoundedCrossBatchRecoverableRejection", text
     )

--- a/tools/threading/test_run_parallel_record_vulkan_test.py
+++ b/tools/threading/test_run_parallel_record_vulkan_test.py
@@ -85,6 +85,16 @@ def pipeline_line(
             "reason=native_queue_alias graphics_native=7 "
             "compute_native=7 admission=blocked\n"
         )
+    malformed_ordering = ""
+    if window == 2:
+        malformed_ordering = (
+            "[TESTCASE][PASS] "
+            "name=BoundedCrossBatchMalformedPreflightOrdering "
+            "window=2 batches=2 queue=Graphics prefix=committed "
+            "malformed=rejected callback_order=prefix,malformed "
+            "signals=success,rejected native_owner=Submission replay=0 "
+            "malformed_translate=0 runtime=restarted\n"
+        )
     shutdown_cancellation = ""
     if window == 2 and include_shutdown_cancellation:
         shutdown_cancellation = (
@@ -104,6 +114,7 @@ def pipeline_line(
         "queues=Graphics,Compute source_order=G,C "
         "native_owner=Submission signals=success callbacks=exactly_once "
         "replay=0\n"
+        + malformed_ordering
         + recoverable_overlap
         + recoverable_rejection
         + shutdown_overlap
@@ -277,6 +288,48 @@ class VulkanRunnerTests(unittest.TestCase):
         with self.assertRaisesRegex(
             runner.VulkanTestError,
             "incomplete bounded cross-batch pipeline contract",
+        ):
+            runner.validate_log("pipeline-window2", text)
+
+    def test_pipeline_window2_requires_malformed_ordering_marker(
+        self,
+    ) -> None:
+        marker = (
+            "[TESTCASE][PASS] "
+            "name=BoundedCrossBatchMalformedPreflightOrdering "
+            "window=2 batches=2 queue=Graphics prefix=committed "
+            "malformed=rejected callback_order=prefix,malformed "
+            "signals=success,rejected native_owner=Submission replay=0 "
+            "malformed_translate=0 runtime=restarted\n"
+        )
+        text = pipeline_line(2, "false", "verified").replace(marker, "")
+        with self.assertRaisesRegex(
+            runner.VulkanTestError,
+            "malformed-preflight ordering PASS marker",
+        ):
+            runner.validate_log("pipeline-window2", text)
+
+    def test_pipeline_malformed_ordering_requires_prefix_callback_order(
+        self,
+    ) -> None:
+        text = pipeline_line(2, "false", "verified").replace(
+            "callback_order=prefix,malformed",
+            "callback_order=malformed,prefix",
+        )
+        with self.assertRaisesRegex(
+            runner.VulkanTestError,
+            "incomplete malformed-preflight ordering contract",
+        ):
+            runner.validate_log("pipeline-window2", text)
+
+    def test_pipeline_malformed_ordering_requires_no_translate(self) -> None:
+        text = pipeline_line(2, "false", "verified").replace(
+            "malformed_translate=0",
+            "malformed_translate=1",
+        )
+        with self.assertRaisesRegex(
+            runner.VulkanTestError,
+            "incomplete malformed-preflight ordering contract",
         ):
             runner.validate_log("pipeline-window2", text)
 

--- a/tools/threading/test_run_parallel_record_vulkan_test.py
+++ b/tools/threading/test_run_parallel_record_vulkan_test.py
@@ -1,6 +1,10 @@
 from __future__ import annotations
 
+import subprocess
+import tempfile
 import unittest
+from pathlib import Path
+from unittest import mock
 
 try:
     from . import run_parallel_record_vulkan_test as runner
@@ -12,6 +16,98 @@ def completion_probe_line() -> str:
     return (
         "[TESTCASE][PASS] name=MultiSegmentCompletionAggregateCpuProbe "
         "suffix_first=deferred prefix_second=ordinary1_success0 replay=0\n"
+    )
+
+
+def pipeline_line(
+    window: int,
+    native_alias: str,
+    overlap_assertion: str,
+    include_overlap_marker: bool | None = None,
+    include_recoverable_rejection: bool = True,
+    include_recoverable_overlap_marker: bool | None = None,
+    include_shutdown_cancellation: bool = True,
+    include_shutdown_overlap_marker: bool | None = None,
+) -> str:
+    alias_window2 = window == 2 and native_alias == "true"
+    emit_overlap_marker = (
+        alias_window2
+        if include_overlap_marker is None
+        else include_overlap_marker
+    )
+    overlap = ""
+    if emit_overlap_marker:
+        overlap = (
+            "[TESTCASE][PASS] "
+            "name=BoundedCrossBatchSubmissionPipelineOverlap "
+            "requested_window=2 effective_window=1 "
+            "reason=native_queue_alias graphics_native=7 "
+            "compute_native=7 admission=blocked\n"
+        )
+    recoverable_rejection = ""
+    if window == 2 and include_recoverable_rejection:
+        recoverable_rejection = (
+            "[TESTCASE][PASS] "
+            "name=BoundedCrossBatchRecoverableRejection "
+            f"window=2 native_alias={native_alias} "
+            f"overlap_assertion={overlap_assertion} batches=2 "
+            "batch0_native_submit=0 "
+            "batch0_callbacks=ordinary1_success0 "
+            "batch0_signal=rejected batch1_native_submit=1 "
+            "batch1_callbacks=ordinary1_success1 "
+            "batch1_signal=success native_owner=Submission replay=0\n"
+        )
+    emit_recoverable_overlap_marker = (
+        alias_window2
+        if include_recoverable_overlap_marker is None
+        else include_recoverable_overlap_marker
+    )
+    recoverable_overlap = ""
+    if emit_recoverable_overlap_marker:
+        recoverable_overlap = (
+            "[TESTCASE][PASS] "
+            "name=BoundedCrossBatchRecoverableRejectionOverlap "
+            "requested_window=2 effective_window=1 "
+            "reason=native_queue_alias graphics_native=7 "
+            "compute_native=7 admission=blocked\n"
+        )
+    emit_shutdown_overlap_marker = (
+        alias_window2
+        if include_shutdown_overlap_marker is None
+        else include_shutdown_overlap_marker
+    )
+    shutdown_overlap = ""
+    if emit_shutdown_overlap_marker:
+        shutdown_overlap = (
+            "[TESTCASE][PASS] "
+            "name=BoundedPipelineShutdownCancellationOverlap "
+            "requested_window=2 effective_window=1 "
+            "reason=native_queue_alias graphics_native=7 "
+            "compute_native=7 admission=blocked\n"
+        )
+    shutdown_cancellation = ""
+    if window == 2 and include_shutdown_cancellation:
+        shutdown_cancellation = (
+            "[TESTCASE][PASS] "
+            "name=BoundedPipelineShutdownCancellation "
+            f"window=2 native_alias={native_alias} "
+            f"overlap_assertion={overlap_assertion} "
+            "batch0_native_submit=0 batch1_native_submit=1 "
+            "batch0_signal=rejected batch1_signal=success "
+            "callbacks=exactly_once concurrent_sync=drained owners=stopped\n"
+        )
+    return (
+        overlap
+        + "[TESTCASE][PASS] name=BoundedCrossBatchSubmissionPipeline "
+        f"window={window} native_alias={native_alias} "
+        f"overlap_assertion={overlap_assertion} batches=2 "
+        "queues=Graphics,Compute source_order=G,C "
+        "native_owner=Submission signals=success callbacks=exactly_once "
+        "replay=0\n"
+        + recoverable_overlap
+        + recoverable_rejection
+        + shutdown_overlap
+        + shutdown_cancellation
     )
 
 
@@ -104,6 +200,394 @@ def summary(batch: int, outcome: str = "parallel") -> str:
 
 
 class VulkanRunnerTests(unittest.TestCase):
+    def test_pipeline_window1_contract_is_accepted(self) -> None:
+        runner.validate_log(
+            "pipeline-window1",
+            pipeline_line(1, "false", "blocked"),
+        )
+
+    def test_pipeline_window2_distinct_native_contract_is_accepted(
+        self,
+    ) -> None:
+        runner.validate_log(
+            "pipeline-window2",
+            pipeline_line(2, "false", "verified"),
+        )
+
+    def test_pipeline_window2_alias_fallback_contract_is_accepted(
+        self,
+    ) -> None:
+        runner.validate_log(
+            "pipeline-window2",
+            pipeline_line(
+                2,
+                "true",
+                "blocked",
+                include_overlap_marker=True,
+                include_shutdown_overlap_marker=True,
+            ),
+        )
+
+    def test_pipeline_window2_alias_requires_pipeline_overlap_marker(
+        self,
+    ) -> None:
+        text = pipeline_line(
+            2,
+            "true",
+            "blocked",
+            include_overlap_marker=False,
+        )
+        with self.assertRaisesRegex(
+            runner.VulkanTestError,
+            "alias overlap marker presence contract",
+        ):
+            runner.validate_log("pipeline-window2", text)
+
+    def test_pipeline_window_requires_common_contract_fields(self) -> None:
+        text = pipeline_line(1, "false", "blocked").replace(
+            "source_order=G,C",
+            "source_order=C,G",
+        )
+        with self.assertRaisesRegex(
+            runner.VulkanTestError,
+            "incomplete bounded cross-batch pipeline contract",
+        ):
+            runner.validate_log("pipeline-window1", text)
+
+    def test_pipeline_window1_requires_blocked_overlap(self) -> None:
+        text = pipeline_line(1, "false", "verified")
+        with self.assertRaisesRegex(
+            runner.VulkanTestError,
+            "incomplete bounded cross-batch pipeline contract",
+        ):
+            runner.validate_log("pipeline-window1", text)
+
+    def test_pipeline_window2_distinct_native_requires_verified_overlap(
+        self,
+    ) -> None:
+        text = pipeline_line(2, "false", "skipped")
+        with self.assertRaisesRegex(
+            runner.VulkanTestError,
+            "incomplete bounded cross-batch pipeline contract",
+        ):
+            runner.validate_log("pipeline-window2", text)
+
+    def test_pipeline_window2_alias_requires_blocked_overlap(self) -> None:
+        text = pipeline_line(2, "true", "verified")
+        with self.assertRaisesRegex(
+            runner.VulkanTestError,
+            "incomplete bounded cross-batch pipeline contract",
+        ):
+            runner.validate_log("pipeline-window2", text)
+
+    def test_pipeline_window2_requires_recoverable_rejection_marker(
+        self,
+    ) -> None:
+        text = pipeline_line(
+            2,
+            "false",
+            "verified",
+            include_recoverable_rejection=False,
+        )
+        with self.assertRaisesRegex(
+            runner.VulkanTestError,
+            "recoverable rejection PASS marker",
+        ):
+            runner.validate_log("pipeline-window2", text)
+
+    def test_pipeline_recoverable_rejection_requires_no_rejected_submit(
+        self,
+    ) -> None:
+        text = pipeline_line(2, "false", "verified").replace(
+            "batch0_native_submit=0",
+            "batch0_native_submit=1",
+        )
+        with self.assertRaisesRegex(
+            runner.VulkanTestError,
+            "incomplete bounded cross-batch recoverable rejection contract",
+        ):
+            runner.validate_log("pipeline-window2", text)
+
+    def test_pipeline_recoverable_rejection_requires_matching_alias(
+        self,
+    ) -> None:
+        text = pipeline_line(2, "false", "verified").replace(
+            "name=BoundedCrossBatchRecoverableRejection "
+            "window=2 native_alias=false",
+            "name=BoundedCrossBatchRecoverableRejection "
+            "window=2 native_alias=true",
+        )
+        with self.assertRaisesRegex(
+            runner.VulkanTestError,
+            "incomplete bounded cross-batch recoverable rejection contract",
+        ):
+            runner.validate_log("pipeline-window2", text)
+
+    def test_pipeline_recoverable_rejection_marker_must_be_unique(
+        self,
+    ) -> None:
+        text = pipeline_line(2, "false", "verified")
+        duplicate = (
+            "[TESTCASE][PASS] "
+            "name=BoundedCrossBatchRecoverableRejection "
+            "window=2 native_alias=false overlap_assertion=verified "
+            "batches=2 batch0_native_submit=0 "
+            "batch0_callbacks=ordinary1_success0 "
+            "batch0_signal=rejected batch1_native_submit=1 "
+            "batch1_callbacks=ordinary1_success1 "
+            "batch1_signal=success native_owner=Submission replay=0\n"
+        )
+        with self.assertRaisesRegex(
+            runner.VulkanTestError,
+            "expected at most one terminal marker",
+        ):
+            runner.validate_log("pipeline-window2", text + duplicate)
+
+    def test_pipeline_alias_requires_recoverable_overlap_marker(
+        self,
+    ) -> None:
+        text = pipeline_line(
+            2,
+            "true",
+            "blocked",
+            include_recoverable_overlap_marker=False,
+        )
+        with self.assertRaisesRegex(
+            runner.VulkanTestError,
+            "recoverable alias overlap marker presence contract",
+        ):
+            runner.validate_log("pipeline-window2", text)
+
+    def test_pipeline_recoverable_overlap_marker_rejected_for_distinct_queues(
+        self,
+    ) -> None:
+        text = pipeline_line(
+            2,
+            "false",
+            "verified",
+            include_recoverable_overlap_marker=True,
+        )
+        with self.assertRaisesRegex(
+            runner.VulkanTestError,
+            "recoverable alias overlap marker presence contract",
+        ):
+            runner.validate_log("pipeline-window2", text)
+
+    def test_pipeline_recoverable_overlap_requires_consistent_queue_ids(
+        self,
+    ) -> None:
+        text = pipeline_line(2, "true", "blocked").replace(
+            "name=BoundedCrossBatchRecoverableRejectionOverlap "
+            "requested_window=2 effective_window=1 "
+            "reason=native_queue_alias graphics_native=7 "
+            "compute_native=7 admission=blocked",
+            "name=BoundedCrossBatchRecoverableRejectionOverlap "
+            "requested_window=2 effective_window=1 "
+            "reason=native_queue_alias graphics_native=8 "
+            "compute_native=8 admission=blocked",
+        )
+        with self.assertRaisesRegex(
+            runner.VulkanTestError,
+            "invalid bounded recoverable alias fallback contract",
+        ):
+            runner.validate_log("pipeline-window2", text)
+
+    def test_pipeline_window2_requires_shutdown_cancellation_marker(
+        self,
+    ) -> None:
+        text = pipeline_line(
+            2,
+            "false",
+            "verified",
+            include_shutdown_cancellation=False,
+        )
+        with self.assertRaisesRegex(
+            runner.VulkanTestError,
+            "shutdown cancellation PASS marker",
+        ):
+            runner.validate_log("pipeline-window2", text)
+
+    def test_pipeline_shutdown_cancellation_requires_stopped_owners(
+        self,
+    ) -> None:
+        text = pipeline_line(2, "false", "verified").replace(
+            "owners=stopped",
+            "owners=running",
+        )
+        with self.assertRaisesRegex(
+            runner.VulkanTestError,
+            "incomplete bounded pipeline shutdown cancellation contract",
+        ):
+            runner.validate_log("pipeline-window2", text)
+
+    def test_pipeline_shutdown_cancellation_requires_matching_alias(
+        self,
+    ) -> None:
+        text = pipeline_line(2, "false", "verified").replace(
+            "name=BoundedPipelineShutdownCancellation "
+            "window=2 native_alias=false",
+            "name=BoundedPipelineShutdownCancellation "
+            "window=2 native_alias=true",
+        )
+        with self.assertRaisesRegex(
+            runner.VulkanTestError,
+            "incomplete bounded pipeline shutdown cancellation contract",
+        ):
+            runner.validate_log("pipeline-window2", text)
+
+    def test_pipeline_shutdown_cancellation_marker_must_be_unique(
+        self,
+    ) -> None:
+        text = pipeline_line(2, "false", "verified")
+        duplicate = (
+            "[TESTCASE][PASS] name=BoundedPipelineShutdownCancellation "
+            "window=2 native_alias=false overlap_assertion=verified "
+            "batch0_native_submit=0 batch1_native_submit=1 "
+            "batch0_signal=rejected batch1_signal=success "
+            "callbacks=exactly_once concurrent_sync=drained owners=stopped\n"
+        )
+        with self.assertRaisesRegex(
+            runner.VulkanTestError,
+            "expected at most one terminal marker",
+        ):
+            runner.validate_log("pipeline-window2", text + duplicate)
+
+    def test_pipeline_shutdown_overlap_requires_consistent_queue_ids(
+        self,
+    ) -> None:
+        text = pipeline_line(
+            2,
+            "true",
+            "blocked",
+            include_shutdown_overlap_marker=True,
+        ).replace(
+            "name=BoundedPipelineShutdownCancellationOverlap "
+            "requested_window=2 effective_window=1 "
+            "reason=native_queue_alias graphics_native=7 "
+            "compute_native=7 admission=blocked",
+            "name=BoundedPipelineShutdownCancellationOverlap "
+            "requested_window=2 effective_window=1 "
+            "reason=native_queue_alias graphics_native=8 "
+            "compute_native=8 admission=blocked",
+        )
+        with self.assertRaisesRegex(
+            runner.VulkanTestError,
+            "invalid bounded pipeline shutdown alias fallback contract",
+        ):
+            runner.validate_log("pipeline-window2", text)
+
+    def test_pipeline_alias_requires_shutdown_overlap_marker(
+        self,
+    ) -> None:
+        text = pipeline_line(
+            2,
+            "true",
+            "blocked",
+            include_shutdown_overlap_marker=False,
+        )
+        with self.assertRaisesRegex(
+            runner.VulkanTestError,
+            "shutdown alias marker presence contract",
+        ):
+            runner.validate_log("pipeline-window2", text)
+
+    def test_pipeline_shutdown_overlap_marker_rejected_for_distinct_queues(
+        self,
+    ) -> None:
+        text = pipeline_line(
+            2,
+            "false",
+            "verified",
+            include_shutdown_overlap_marker=True,
+        )
+        with self.assertRaisesRegex(
+            runner.VulkanTestError,
+            "shutdown alias marker presence contract",
+        ):
+            runner.validate_log("pipeline-window2", text)
+
+    def test_pipeline_alias_overlap_marker_is_rejected_for_distinct_native_queues(
+        self,
+    ) -> None:
+        text = pipeline_line(
+            2,
+            "false",
+            "verified",
+            include_overlap_marker=True,
+        )
+        with self.assertRaisesRegex(
+            runner.VulkanTestError,
+            "alias overlap marker presence contract",
+        ):
+            runner.validate_log("pipeline-window2", text)
+
+    def test_pipeline_alias_overlap_requires_matching_native_queue_ids(
+        self,
+    ) -> None:
+        text = pipeline_line(
+            2,
+            "true",
+            "blocked",
+            include_overlap_marker=True,
+        ).replace("compute_native=7", "compute_native=8", 1)
+        with self.assertRaisesRegex(
+            runner.VulkanTestError,
+            "invalid bounded cross-batch alias fallback contract",
+        ):
+            runner.validate_log("pipeline-window2", text)
+
+    def test_pipeline_modes_reject_validation_failures(self) -> None:
+        with self.assertRaisesRegex(
+            runner.VulkanTestError,
+            "Vulkan validation VUID",
+        ):
+            runner.validate_log(
+                "pipeline-window1",
+                "VUID-vkQueueSubmit-test\n"
+                + pipeline_line(1, "false", "blocked"),
+            )
+
+    def test_pipeline_modes_map_to_focused_executable_arguments(self) -> None:
+        cases = (
+            (
+                "pipeline-window1",
+                "--pipeline-window1",
+                pipeline_line(1, "false", "blocked"),
+            ),
+            (
+                "pipeline-window2",
+                "--pipeline-window2",
+                pipeline_line(2, "false", "verified"),
+            ),
+        )
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            for mode, expected_argument, output in cases:
+                with self.subTest(mode=mode):
+                    completed = subprocess.CompletedProcess(
+                        args=[],
+                        returncode=0,
+                        stdout=output,
+                        stderr="",
+                    )
+                    with mock.patch.object(
+                        runner.subprocess,
+                        "run",
+                        return_value=completed,
+                    ) as run:
+                        runner.run_case(
+                            Path("TestRHIParallelRecordVulkan.exe"),
+                            Path(temporary_directory),
+                            mode,
+                            30.0,
+                        )
+                    self.assertEqual(
+                        run.call_args.args[0],
+                        [
+                            "TestRHIParallelRecordVulkan.exe",
+                            expected_argument,
+                        ],
+                    )
+
     def test_serial_accepts_only_pass_marker(self) -> None:
         runner.validate_log("serial", pass_line("serial", "false"))
 


### PR DESCRIPTION
## Summary

- Add a configurable bounded submission batch window (`submission_batch_window`, default `2`, clamped to `[1, 8]`).
- Allow the Translate coordinator and TaskGraph workers to prepare a later explicit-RDG Graphics/Compute batch while the sole Submission owner terminalizes the preceding batch.
- Preserve stable source/batch handoff and native submission order, one recorded packet per native lane, and the existing Completion ownership model.
- Keep Copy, Present, Sync/Stop, legacy/direct state inference, resource deletion, and profiling work as explicit drain boundaries.
- Preserve submitted prefixes on hard failure, reject the current/later suffix, latch later batches, and keep recoverable dependency rejection scoped to the current batch.
- Drain already-admitted pipeline work before malformed/direct rejection so same-queue callback and signal retirement cannot overtake the accepted prefix. The current failing state is sealed before draining, including terminalizer exception-unwind paths.
- Store the sealed bit and outstanding Submission work count in one atomic state word, so `Seal()` racing the final `FinishWork()` cannot lose the unique terminal transition.
- Force the effective window to `1` when logical Graphics and Compute alias the same native queue; mixed G/C alias batches remain on the drained synchronous path.
- Add shared CPU-only contracts for submission-window policy and batch terminalization, including a 20,000-iteration Seal/Finish race test, plus fail-closed focused Vulkan gates for window 1/2, malformed preflight ordering, recoverable rejection, hard failure, shutdown cancellation, and native-alias fallback.

The previously recorded conditional Non-RDG automatic hazard/cross-queue inference gap is intentionally out of scope for this PR.

## Scope and boundaries

- The pipelined executor path is Vulkan-only. Every source in an admitted batch must be Graphics/Compute, parallel-Translate eligible, explicit resource-state owned, in a non-zero async queue scope, and free of Present/control/profiling payloads.
- The window counts CPU-side Submission work reaching a terminal state; it does not wait for GPU completion.
- Stable order means Translate-to-Submission handoff and native submit FIFO order. It is not a claim of global GPU-completion or callback total order across distinct native queues.
- The malformed-preflight review fix orders preflight/direct `RejectBatch`, raw-source, and recorded-packet rejection behind already handed-off prefixes. If `TranslateForRuntime()` itself returns null after already publishing its rejected completion, this PR does not claim a stronger cross-batch callback total-order guarantee for that failure path.
- D3D12, Copy ready-lane pipelining, Present, and legacy/direct automatic hazard inference remain outside this phase.

## Validation (head `bb04dbefd1094f0b87fdffd18fa149ec2f2d875b`)

- Debug build: pass
- Release build: pass
- Debug CTest: 18/18
- Release CTest: 18/18
- Debug Vulkan focused matrix: 9/9 (standalone rerun)
- Release Vulkan focused matrix: 9/9
- CPU batch terminal contract: sequential Seal-first/Finish-first/multi-work cases plus 20,000 concurrent Seal/Finish races, pass in Debug and Release
- Python gate/parser tests: 94/94 from both supported entry points; `py_compile` pass
- Window-2 regression deterministically observes invalid preflight on the Translate owner before release, proves prefix commit precedes malformed rejection, verifies callback/signal order, zero malformed translation, no replay, and successful runtime restart
- Additional Release `--parallel` stability probe: 70/70 clean repeats after the formal matrix
- Release editor runtime: 49.2 s; first present and maximize/resize/restore/input/15 s soak succeeded; five captures non-black (0.950–0.956); clean exit; no VUID, device lost, submit failure, assertion, or access violation
- Runtime log confirms configured/effective batch window `2`; production RT graph reached upper submission topology. Cross-batch overlap semantics are proven by the focused window tests rather than inferred from ordinary editor startup.

Environment note: extra exploratory repetition observed one transient Debug timeout and one non-reproducing WER `StackHash` BEX64. Windows Application history contains the same unknown-module signature on pre-fix worktrees. Direct reruns, both formal 9/9 matrices, the 70/70 Release probe, and the final editor run were clean.

## Review focus

- `PipelineBatchState` completion/lifetime and admission accounting
- single-atomic Seal/final-Finish terminal ownership and memory ordering
- stable FIFO ownership across Translate and Submission threads
- seal-before-drain behavior in failure and exception-unwind paths
- malformed preflight and direct suffix retirement ordering
- hard/recoverable failure prefix/suffix semantics
- Sync/Stop drain and shutdown cancellation
- Graphics/Compute native-alias fallback policy and its deterministic CPU contract
