### PR TITLE
RHI Phase 15E: pipeline Copy translation on ready native lanes

### DIFF
--- a/source/runtime/render/rhi/RHISubmissionPipelinePolicy.h
+++ b/source/runtime/render/rhi/RHISubmissionPipelinePolicy.h
@@ -31,11 +31,34 @@ inline constexpr uint32_t MaxBatchWindow     = 8;
                _topology.compute.native_queue_id;
 }
 
+[[nodiscard]] constexpr bool HasAvailableNativeLaneAlias(
+    const RHIQueueTopology& _topology
+) noexcept {
+    const bool graphics_compute_alias =
+        _topology.graphics.available &&
+        _topology.compute.available &&
+        _topology.graphics.native_queue_id ==
+            _topology.compute.native_queue_id;
+    const bool graphics_copy_alias =
+        _topology.graphics.available &&
+        _topology.copy.available &&
+        _topology.graphics.native_queue_id ==
+            _topology.copy.native_queue_id;
+    const bool compute_copy_alias =
+        _topology.compute.available &&
+        _topology.copy.available &&
+        _topology.compute.native_queue_id ==
+            _topology.copy.native_queue_id;
+    return graphics_compute_alias ||
+           graphics_copy_alias ||
+           compute_copy_alias;
+}
+
 [[nodiscard]] constexpr uint32_t ResolveEffectiveBatchWindow(
     uint32_t                _configured,
     const RHIQueueTopology& _topology
 ) noexcept {
-    return GraphicsComputeShareNativeLane(_topology) ?
+    return HasAvailableNativeLaneAlias(_topology) ?
                MinBatchWindow :
                ClampBatchWindow(_configured);
 }

--- a/source/runtime/render/rhi/vulkan/VulkanSubmissionDiagnostics.h
+++ b/source/runtime/render/rhi/vulkan/VulkanSubmissionDiagnostics.h
@@ -31,6 +31,40 @@ struct VulkanSourceSubmissionObserver {
     VulkanSourceSubmissionCallback callback{nullptr};
 };
 
+enum class EVulkanSourceTranslationPhase : uint8_t {
+    Begin = 0,
+    Recorded,
+    Failed,
+};
+
+// Observation around one explicit-RDG source's Translate operation. Recorded
+// proves that the move-only packet has acquired its queue allocator/session
+// state and is ready for the stable Submission cursor; it does not imply a
+// native submit.
+struct VulkanSourceTranslationEvent {
+    uint64                        batch_sequence{0};
+    uint32                        source_index{0};
+    uint32                        original_source_index{0};
+    uint32                        source_segment_index{0};
+    uint32                        source_segment_count{1};
+    EQueueType                    queue{EQueueType::Ignore};
+    uint32                        native_queue_id{0};
+    uint64                        async_queue_scope{0};
+    uint32                        thread_id{0};
+    ERHIThreadRole                thread_role{ERHIThreadRole::Unknown};
+    EVulkanSourceTranslationPhase phase{
+        EVulkanSourceTranslationPhase::Begin
+    };
+};
+
+using VulkanSourceTranslationCallback =
+    void (*)(void*, const VulkanSourceTranslationEvent&) noexcept;
+
+struct VulkanSourceTranslationObserver {
+    void*                           context{nullptr};
+    VulkanSourceTranslationCallback callback{nullptr};
+};
+
 // Narrow for-testing seam for the real multi-segment completion aggregate.
 // It deliberately exposes only observable callback ordering/counts, not the
 // backend-private aggregate or its synchronization storage.
@@ -55,6 +89,18 @@ RunVulkanMultiSegmentCompletionProbeForTesting();
 TryInstallVulkanSourceSubmissionObserver(const VulkanSourceSubmissionObserver* _observer) noexcept;
 [[nodiscard]] RENDER_API bool
 RemoveVulkanSourceSubmissionObserver(const VulkanSourceSubmissionObserver* _observer) noexcept;
+
+// Observer storage is caller-owned and immutable while installed. The
+// callback runs on a Translate owner and must be short, non-blocking, noexcept,
+// and must not re-enter RHI. Quiesce the observed work before removal.
+[[nodiscard]] RENDER_API bool
+TryInstallVulkanSourceTranslationObserver(
+    const VulkanSourceTranslationObserver* _observer
+) noexcept;
+[[nodiscard]] RENDER_API bool
+RemoveVulkanSourceTranslationObserver(
+    const VulkanSourceTranslationObserver* _observer
+) noexcept;
 
 struct VulkanBatchPreflightRejectionEvent {
     uint64         batch_sequence{0};

--- a/source/runtime/render/rhi/vulkan/VulkanSubmissionExecutor.cpp
+++ b/source/runtime/render/rhi/vulkan/VulkanSubmissionExecutor.cpp
@@ -25,6 +25,8 @@ namespace Moer::Render {
 namespace {
 
 std::atomic<const VulkanSourceSubmissionObserver*> g_source_submission_observer{nullptr};
+std::atomic<const VulkanSourceTranslationObserver*>
+    g_source_translation_observer{nullptr};
 std::atomic<const VulkanBatchPreflightRejectionObserver*>
     g_batch_preflight_rejection_observer{nullptr};
 
@@ -58,6 +60,46 @@ void NotifySourceSubmitted(
             .queue             = _queue,
             .async_queue_scope = _async_queue_scope,
             .cross_native_predecessor_wait = _cross_native_predecessor_wait,
+        }
+    );
+}
+
+void NotifySourceTranslation(
+    uint64                        _batch_sequence,
+    uint32                        _source_index,
+    uint32                        _original_source_index,
+    uint32                        _source_segment_index,
+    uint32                        _source_segment_count,
+    EQueueType                    _queue,
+    uint32                        _native_queue_id,
+    uint64                        _async_queue_scope,
+    EVulkanSourceTranslationPhase _phase
+) noexcept {
+    assert(
+        GetCurrentRHIThreadRole() == ERHIThreadRole::Translate &&
+        "source translation diagnostics must run on a Translate owner"
+    );
+    const VulkanSourceTranslationObserver* observer =
+        g_source_translation_observer.load(
+            std::memory_order_acquire
+        );
+    if (observer == nullptr) {
+        return;
+    }
+    observer->callback(
+        observer->context,
+        VulkanSourceTranslationEvent{
+            .batch_sequence       = _batch_sequence,
+            .source_index         = _source_index,
+            .original_source_index = _original_source_index,
+            .source_segment_index = _source_segment_index,
+            .source_segment_count = _source_segment_count,
+            .queue                 = _queue,
+            .native_queue_id       = _native_queue_id,
+            .async_queue_scope     = _async_queue_scope,
+            .thread_id             = Platform::GetCurrentThreadID(),
+            .thread_role           = GetCurrentRHIThreadRole(),
+            .phase                 = _phase,
         }
     );
 }
@@ -124,7 +166,7 @@ bool IsCopyCommand(Command::EType _type) {
 }
 
 bool IsParallelTranslateCandidate(const RHIBackendSubmissionBatchEntry& _entry) {
-    return (_entry.queue == EQueueType::Graphics || _entry.queue == EQueueType::Compute) &&
+    return IsNativeQueue(_entry.queue) &&
            _entry.submit.translate_execution_class == ERHITranslateExecutionClass::Parallel &&
            _entry.submit.HasExplicitResourceStateOwnership() && _entry.submit.async_queue_scope != 0;
 }
@@ -741,6 +783,36 @@ bool RemoveVulkanSourceSubmissionObserver(const VulkanSourceSubmissionObserver* 
     );
 }
 
+bool TryInstallVulkanSourceTranslationObserver(
+    const VulkanSourceTranslationObserver* _observer
+) noexcept {
+    if (_observer == nullptr || _observer->callback == nullptr) {
+        return false;
+    }
+    const VulkanSourceTranslationObserver* expected = nullptr;
+    return g_source_translation_observer.compare_exchange_strong(
+        expected,
+        _observer,
+        std::memory_order_release,
+        std::memory_order_relaxed
+    );
+}
+
+bool RemoveVulkanSourceTranslationObserver(
+    const VulkanSourceTranslationObserver* _observer
+) noexcept {
+    if (_observer == nullptr) {
+        return false;
+    }
+    const VulkanSourceTranslationObserver* expected = _observer;
+    return g_source_translation_observer.compare_exchange_strong(
+        expected,
+        nullptr,
+        std::memory_order_acq_rel,
+        std::memory_order_acquire
+    );
+}
+
 bool TryInstallVulkanBatchPreflightRejectionObserver(
     const VulkanBatchPreflightRejectionObserver* _observer
 ) noexcept {
@@ -778,13 +850,13 @@ VulkanSubmissionExecutor::VulkanSubmissionExecutor(uint32 _batch_window) :
     const size_t configured_batch_window = batch_window;
     const RHIQueueTopology queue_topology =
         RenderDevice::Get().GetQueueTopology();
-    graphics_compute_share_native_lane =
-        RHISubmissionPipelinePolicy::GraphicsComputeShareNativeLane(
+    runtime_queues_share_native_lane =
+        RHISubmissionPipelinePolicy::HasAvailableNativeLaneAlias(
             queue_topology
         );
-    // Graphics and Compute are distinct logical queue wrappers with
-    // independent transferable gates. Keep one batch in flight when they
-    // alias so those gates cannot admit two packets for the same native lane.
+    // Logical queue wrappers own independent transferable gates. Keep one
+    // batch in flight whenever any available Graphics/Compute/Copy pair
+    // aliases so those gates cannot admit two packets for one native lane.
     batch_window =
         RHISubmissionPipelinePolicy::ResolveEffectiveBatchWindow(
             _batch_window, queue_topology
@@ -828,10 +900,10 @@ VulkanSubmissionExecutor::VulkanSubmissionExecutor(uint32 _batch_window) :
             "[RHIExecutor][Vulkan] ownership runtime started "
             "Executor=1 TranslateCoordinator=1 TranslateWorkers=TaskGraph "
             "Submission=1 configured_batch_window={} batch_window={} "
-            "graphics_compute_native_alias={}",
+            "runtime_native_alias={}",
             configured_batch_window,
             batch_window,
-            graphics_compute_share_native_lane
+            runtime_queues_share_native_lane
         );
     } catch (...) {
         graphics_queue.CancelRuntimeDependencyWaits();
@@ -1367,6 +1439,226 @@ bool VulkanSubmissionExecutor::IsHardFailureAtOrBefore(
     return rejected;
 }
 
+bool VulkanSubmissionExecutor::HasRecordedSourcePacket(
+    const RecordedSourcePacket& _packet
+) noexcept {
+    return !std::holds_alternative<std::monostate>(_packet);
+}
+
+CmdSubmit* VulkanSubmissionExecutor::GetRecordedSourceSubmit(
+    RecordedSourcePacket& _packet
+) noexcept {
+    if (auto* packet =
+            std::get_if<VkCommandQueue::CurrentVulkanRecordedSubmit>(
+                &_packet
+            )) {
+        return &packet->submit;
+    }
+    if (auto* packet =
+            std::get_if<VkCopyQueue::CurrentVulkanCopyRecordedSubmit>(
+                &_packet
+            )) {
+        return &packet->submit;
+    }
+    return nullptr;
+}
+
+VulkanSubmissionExecutor::RecordedSourcePacket
+VulkanSubmissionExecutor::TranslateSourceForRuntime(
+    EQueueType _queue,
+    CmdSubmit&& _submit
+) noexcept {
+    if (_queue == EQueueType::Copy) {
+        auto& copy_queue =
+            static_cast<VkCopyQueue&>(RenderDevice::Get().GetCopyQueue());
+        auto recorded =
+            copy_queue.TranslateForRuntime(std::move(_submit));
+        if (recorded) {
+            return RecordedSourcePacket{
+                std::in_place_type<
+                    VkCopyQueue::CurrentVulkanCopyRecordedSubmit>,
+                std::move(*recorded)
+            };
+        }
+        return {};
+    }
+
+    if (_queue == EQueueType::Graphics ||
+        _queue == EQueueType::Compute) {
+        auto& queue = static_cast<VkCommandQueue&>(
+            RenderDevice::Get().GetCommandQueue(_queue)
+        );
+        auto recorded =
+            queue.TranslateForRuntime(std::move(_submit));
+        if (recorded) {
+            return RecordedSourcePacket{
+                std::in_place_type<
+                    VkCommandQueue::CurrentVulkanRecordedSubmit>,
+                std::move(*recorded)
+            };
+        }
+        return {};
+    }
+
+    RejectSourceForRuntime(
+        _queue, std::move(_submit), VK_ERROR_UNKNOWN
+    );
+    return {};
+}
+
+VulkanRuntimeSubmissionResult
+VulkanSubmissionExecutor::SubmitRecordedSourceForRuntime(
+    EQueueType             _queue,
+    RecordedSourcePacket&& _packet
+) noexcept {
+    if (_queue == EQueueType::Copy) {
+        if (auto* packet =
+                std::get_if<
+                    VkCopyQueue::CurrentVulkanCopyRecordedSubmit>(
+                    &_packet
+                )) {
+            auto& copy_queue =
+                static_cast<VkCopyQueue&>(
+                    RenderDevice::Get().GetCopyQueue()
+                );
+            return copy_queue.SubmitRecordedForRuntime(
+                std::move(*packet)
+            );
+        }
+    } else if (
+        _queue == EQueueType::Graphics ||
+        _queue == EQueueType::Compute
+    ) {
+        if (auto* packet =
+                std::get_if<
+                    VkCommandQueue::CurrentVulkanRecordedSubmit>(
+                    &_packet
+                )) {
+            auto& queue = static_cast<VkCommandQueue&>(
+                RenderDevice::Get().GetCommandQueue(_queue)
+            );
+            return queue.SubmitRecordedForRuntime(
+                std::move(*packet)
+            );
+        }
+    }
+
+    RejectRecordedSourceForRuntime(
+        _queue, std::move(_packet), VK_ERROR_UNKNOWN
+    );
+    return {
+        .outcome = {
+            EVulkanOperationStatus::Rejected, VK_ERROR_UNKNOWN
+        },
+    };
+}
+
+void VulkanSubmissionExecutor::RejectRecordedSourceForRuntime(
+    EQueueType             _queue,
+    RecordedSourcePacket&& _packet,
+    VkResult               _result
+) noexcept {
+    if (_result == VK_SUCCESS) {
+        _result = VK_ERROR_UNKNOWN;
+    }
+    if (auto* packet =
+            std::get_if<VkCopyQueue::CurrentVulkanCopyRecordedSubmit>(
+                &_packet
+            )) {
+        assert(
+            _queue == EQueueType::Copy &&
+            "Copy recorded packet queue tag mismatch"
+        );
+        auto& copy_queue =
+            static_cast<VkCopyQueue&>(
+                RenderDevice::Get().GetCopyQueue()
+            );
+        copy_queue.RejectRecordedForRuntime(
+            std::move(*packet), _result
+        );
+        return;
+    }
+    if (auto* packet =
+            std::get_if<VkCommandQueue::CurrentVulkanRecordedSubmit>(
+                &_packet
+            )) {
+        EQueueType packet_queue = packet->context.queue_type;
+        if (packet_queue != EQueueType::Graphics &&
+            packet_queue != EQueueType::Compute) {
+            packet_queue = _queue;
+        }
+        assert(
+            packet_queue == _queue &&
+            "command recorded packet queue tag mismatch"
+        );
+        auto& queue = static_cast<VkCommandQueue&>(
+            RenderDevice::Get().GetCommandQueue(packet_queue)
+        );
+        queue.RejectRecordedForRuntime(
+            std::move(*packet), _result
+        );
+    }
+}
+
+void VulkanSubmissionExecutor::RejectSourceForRuntime(
+    EQueueType _queue,
+    CmdSubmit&& _submit,
+    VkResult    _result
+) noexcept {
+    if (_queue == EQueueType::Copy) {
+        auto& copy_queue =
+            static_cast<VkCopyQueue&>(
+                RenderDevice::Get().GetCopyQueue()
+            );
+        copy_queue.RejectForRuntime(
+            std::move(_submit), _result
+        );
+        return;
+    }
+    if (_queue == EQueueType::Graphics ||
+        _queue == EQueueType::Compute) {
+        auto& queue = static_cast<VkCommandQueue&>(
+            RenderDevice::Get().GetCommandQueue(_queue)
+        );
+        queue.RejectForRuntime(
+            std::move(_submit), _result
+        );
+        return;
+    }
+
+    try {
+        LOG_ERROR(
+            "[RHIExecutor][Vulkan] cannot terminalize unsupported queue type={}",
+            static_cast<uint32>(_queue)
+        );
+    } catch (...) {
+    }
+}
+
+VkResult VulkanSubmissionExecutor::GetQueueFaultResult(
+    EQueueType _queue
+) const noexcept {
+    if (_queue == EQueueType::Copy) {
+        auto& copy_queue =
+            static_cast<VkCopyQueue&>(
+                RenderDevice::Get().GetCopyQueue()
+            );
+        return copy_queue.device.IsFaulted() ?
+                   copy_queue.device.GetFirstFaultResult() :
+                   VK_ERROR_UNKNOWN;
+    }
+    if (_queue == EQueueType::Graphics ||
+        _queue == EQueueType::Compute) {
+        auto& queue = static_cast<VkCommandQueue&>(
+            RenderDevice::Get().GetCommandQueue(_queue)
+        );
+        return queue.vk_device.IsFaulted() ?
+                   queue.vk_device.GetFirstFaultResult() :
+                   VK_ERROR_UNKNOWN;
+    }
+    return VK_ERROR_UNKNOWN;
+}
+
 void VulkanSubmissionExecutor::ExecutePipelineSource(
     const std::shared_ptr<PipelineBatchState>& _batch,
     size_t                                     _source_index
@@ -1391,14 +1683,13 @@ void VulkanSubmissionExecutor::ExecutePipelineSource(
         if (_result == VK_SUCCESS) {
             _result = VK_ERROR_UNKNOWN;
         }
-        if (slot.command_packet) {
-            auto& queue = static_cast<VkCommandQueue&>(
-                RenderDevice::Get().GetCommandQueue(slot.queue)
+        if (HasRecordedSourcePacket(slot.recorded_packet)) {
+            RejectRecordedSourceForRuntime(
+                slot.queue,
+                std::move(slot.recorded_packet),
+                _result
             );
-            queue.RejectRecordedForRuntime(
-                std::move(*slot.command_packet), _result
-            );
-            slot.command_packet.reset();
+            slot.recorded_packet.emplace<std::monostate>();
         }
     };
 
@@ -1416,7 +1707,7 @@ void VulkanSubmissionExecutor::ExecutePipelineSource(
         return;
     }
 
-    if (!slot.command_packet) {
+    if (!HasRecordedSourcePacket(slot.recorded_packet)) {
         LatchHardFailure(
             StreamPosition{_batch->sequence, _source_index + 1},
             static_cast<int32>(VK_ERROR_UNKNOWN)
@@ -1429,10 +1720,26 @@ void VulkanSubmissionExecutor::ExecutePipelineSource(
         ResetStreamScope();
         return;
     }
-    CmdSubmit& submit = slot.command_packet->submit;
+    CmdSubmit* submit = GetRecordedSourceSubmit(
+        slot.recorded_packet
+    );
+    if (submit == nullptr) {
+        reject_packet(VK_ERROR_UNKNOWN);
+        _batch->PublishFailure(
+            _source_index + 1,
+            static_cast<int32>(VK_ERROR_UNKNOWN),
+            false
+        );
+        LatchHardFailure(
+            StreamPosition{_batch->sequence, _source_index + 1},
+            static_cast<int32>(VK_ERROR_UNKNOWN)
+        );
+        ResetStreamScope();
+        return;
+    }
 
     try {
-        PrepareStreamSubmit(submit, slot.queue);
+        PrepareStreamSubmit(*submit, slot.queue);
     } catch (...) {
         ReportRequestFailure(
             ERequestKind::Submit,
@@ -1453,12 +1760,11 @@ void VulkanSubmissionExecutor::ExecutePipelineSource(
         return;
     }
 
-    auto& queue = static_cast<VkCommandQueue&>(
-        RenderDevice::Get().GetCommandQueue(slot.queue)
-    );
     VulkanRuntimeSubmissionResult submit_result =
-        queue.SubmitRecordedForRuntime(std::move(*slot.command_packet));
-    slot.command_packet.reset();
+        SubmitRecordedSourceForRuntime(
+            slot.queue, std::move(slot.recorded_packet)
+        );
+    slot.recorded_packet.emplace<std::monostate>();
 
     if (submit_result.WasSubmitted()) {
         assert(submit_result.completion.has_value());
@@ -1472,6 +1778,12 @@ void VulkanSubmissionExecutor::ExecutePipelineSource(
             slot.async_queue_scope,
             slot.cross_native_predecessor_wait
         );
+        if (slot.queue == EQueueType::Copy) {
+            last_copy_timeline = std::max(
+                last_copy_timeline,
+                submit_result.completion->value
+            );
+        }
         UpdateStreamFrontier(
             slot.queue,
             *submit_result.completion,
@@ -1705,25 +2017,38 @@ void VulkanSubmissionExecutor::ProcessBatch(
         );
     }
 
-    const bool batch_crosses_aliased_graphics_compute_lane =
-        graphics_compute_share_native_lane &&
-        std::any_of(
-            _batch.submits.begin(),
-            _batch.submits.end(),
-            [](const RHIBackendSubmissionBatchEntry& entry) {
-                return entry.queue == EQueueType::Graphics;
+    bool batch_crosses_aliased_native_lane = false;
+    if (runtime_queues_share_native_lane) {
+        for (size_t lhs = 0;
+             lhs < _batch.submits.size() &&
+             !batch_crosses_aliased_native_lane;
+             ++lhs) {
+            const EQueueType lhs_queue = _batch.submits[lhs].queue;
+            const RHIQueueBinding lhs_binding =
+                queue_topology.Resolve(lhs_queue);
+            for (size_t rhs = lhs + 1;
+                 rhs < _batch.submits.size();
+                 ++rhs) {
+                const EQueueType rhs_queue =
+                    _batch.submits[rhs].queue;
+                if (lhs_queue == rhs_queue) {
+                    continue;
+                }
+                const RHIQueueBinding rhs_binding =
+                    queue_topology.Resolve(rhs_queue);
+                if (lhs_binding.available &&
+                    rhs_binding.available &&
+                    lhs_binding.native_queue_id ==
+                        rhs_binding.native_queue_id) {
+                    batch_crosses_aliased_native_lane = true;
+                    break;
+                }
             }
-        ) &&
-        std::any_of(
-            _batch.submits.begin(),
-            _batch.submits.end(),
-            [](const RHIBackendSubmissionBatchEntry& entry) {
-                return entry.queue == EQueueType::Compute;
-            }
-        );
+        }
+    }
     const bool pipeline_mode =
         !_batch.present.has_value() && !_batch.submits.empty() &&
-        !batch_crosses_aliased_graphics_compute_lane &&
+        !batch_crosses_aliased_native_lane &&
         std::all_of(
             _batch.submits.begin(),
             _batch.submits.end(),
@@ -1739,10 +2064,11 @@ void VulkanSubmissionExecutor::ProcessBatch(
     if (pipeline_mode) {
         WaitForPipelineCapacity();
     } else {
-        // Copy, Present, legacy/direct state inference, and serial control
-        // remain explicit pipeline boundaries in Phase 15D. Once the tail
-        // marker completes, this coordinator may safely reuse the synchronous
-        // path and its existing failure semantics.
+        // Present, legacy/direct state inference, serial control, and a batch
+        // crossing distinct logical wrappers of one native lane remain
+        // explicit pipeline boundaries. Once the tail marker completes, this
+        // coordinator may safely reuse the synchronous path and its existing
+        // failure semantics.
         DrainPipelineBatches();
     }
 
@@ -1988,15 +2314,14 @@ void VulkanSubmissionExecutor::ProcessBatch(
         }
 
         struct TranslateGroupSlot {
-            size_t                                                     source_index{0};
-            SubmissionKey                                              key{};
-            VkCommandQueue*                                            queue{nullptr};
-            EQueueType                                                 queue_type{EQueueType::Ignore};
-            uint64                                                     async_queue_scope{0};
-            bool                                                       prepared{false};
-            bool                                                       attempted{false};
-            bool                                                       terminalized{false};
-            std::optional<VkCommandQueue::CurrentVulkanRecordedSubmit> recorded{};
+            size_t               source_index{0};
+            SubmissionKey        key{};
+            EQueueType           queue_type{EQueueType::Ignore};
+            uint64               async_queue_scope{0};
+            bool                 prepared{false};
+            bool                 attempted{false};
+            bool                 terminalized{false};
+            RecordedSourcePacket recorded{};
         };
 
         Array<TranslateGroupSlot> slots{};
@@ -2006,13 +2331,9 @@ void VulkanSubmissionExecutor::ProcessBatch(
             const RHISourceSubmitPlan&      source_plan  = _batch.topology.source_plans[source_index];
             const RHISubmissionSegmentPlan& segment_plan =
                 _batch.topology.segments[source_plan.segment_plan_begin];
-            auto& queue = static_cast<VkCommandQueue&>(
-                RenderDevice::Get().GetCommandQueue(_batch.submits[source_index].queue)
-            );
             slots.emplace_back(TranslateGroupSlot{
                 .source_index      = source_index,
                 .key               = segment_plan.key,
-                .queue             = &queue,
                 .queue_type        = _batch.submits[source_index].queue,
                 .async_queue_scope = _batch.submits[source_index].submit.async_queue_scope,
             });
@@ -2076,10 +2397,21 @@ void VulkanSubmissionExecutor::ProcessBatch(
                         continue;
                     }
                     RHIBackendSubmissionBatchEntry& entry = batch->submits[slot.source_index];
-                    if (slot.recorded) {
-                        slot.queue->RejectRecordedForRuntime(std::move(*slot.recorded), result);
+                    if (owner->HasRecordedSourcePacket(
+                            slot.recorded
+                        )) {
+                        owner->RejectRecordedSourceForRuntime(
+                            slot.queue_type,
+                            std::move(slot.recorded),
+                            result
+                        );
+                        slot.recorded.emplace<std::monostate>();
                     } else if (!slot.attempted) {
-                        slot.queue->RejectForRuntime(std::move(entry.submit), result);
+                        owner->RejectSourceForRuntime(
+                            slot.queue_type,
+                            std::move(entry.submit),
+                            result
+                        );
                     }
                     // A null result from an attempted Translate already
                     // owns a rejected Completion retirement.
@@ -2115,6 +2447,44 @@ void VulkanSubmissionExecutor::ProcessBatch(
             assert(slots[local_index].key == key);
             return slots[local_index];
         };
+        auto translate_slot =
+            [&](TranslateGroupSlot& slot, CmdSubmit&& submit) noexcept {
+                const VulkanExecutableSourceMetadata& metadata =
+                    materialization.sources[slot.source_index];
+                const uint32 native_queue_id =
+                    queue_topology.Resolve(
+                        slot.queue_type
+                    ).native_queue_id;
+                slot.attempted = true;
+                NotifySourceTranslation(
+                    _batch.sequence,
+                    static_cast<uint32>(slot.source_index),
+                    metadata.original_source_index,
+                    metadata.source_segment_index,
+                    metadata.source_segment_count,
+                    slot.queue_type,
+                    native_queue_id,
+                    slot.async_queue_scope,
+                    EVulkanSourceTranslationPhase::Begin
+                );
+                slot.recorded =
+                    TranslateSourceForRuntime(
+                        slot.queue_type, std::move(submit)
+                    );
+                NotifySourceTranslation(
+                    _batch.sequence,
+                    static_cast<uint32>(slot.source_index),
+                    metadata.original_source_index,
+                    metadata.source_segment_index,
+                    metadata.source_segment_count,
+                    slot.queue_type,
+                    native_queue_id,
+                    slot.async_queue_scope,
+                    HasRecordedSourcePacket(slot.recorded) ?
+                        EVulkanSourceTranslationPhase::Recorded :
+                        EVulkanSourceTranslationPhase::Failed
+                );
+            };
         auto fail_group = [&](size_t           failure_source,
                               VkResult         failure_result,
                               bool             recoverable_failure,
@@ -2191,10 +2561,11 @@ void VulkanSubmissionExecutor::ProcessBatch(
                     try {
                         RHIBackendSubmissionBatchEntry* entry = &_batch.submits[slot->source_index];
                         (void)LambdaTask::Dispatch(
-                            [slot, entry, &completed] {
+                            [slot, entry, &completed, &translate_slot] {
                                 RHIThreadRoleScope translate_worker(ERHIThreadRole::Translate);
-                                slot->attempted = true;
-                                slot->recorded  = slot->queue->TranslateForRuntime(std::move(entry->submit));
+                                translate_slot(
+                                    *slot, std::move(entry->submit)
+                                );
                                 completed.count_down();
                             },
                             EThread::AnyThread_NormalPri
@@ -2210,8 +2581,9 @@ void VulkanSubmissionExecutor::ProcessBatch(
             } else {
                 for (TranslateGroupSlot* slot : wave_slots) {
                     RHIBackendSubmissionBatchEntry& entry = _batch.submits[slot->source_index];
-                    slot->attempted                       = true;
-                    slot->recorded = slot->queue->TranslateForRuntime(std::move(entry.submit));
+                    translate_slot(
+                        *slot, std::move(entry.submit)
+                    );
                 }
             }
 
@@ -2232,15 +2604,14 @@ void VulkanSubmissionExecutor::ProcessBatch(
                     translation_failure_source = slot->source_index;
                     translation_failure_reason = "parallel Translate scheduler state failure";
                 }
-                if (!slot->recorded) {
+                if (!HasRecordedSourcePacket(slot->recorded)) {
                     // TranslateForRuntime already committed the rejected
                     // Completion marker for this source.
                     slot->terminalized = true;
                     if (!translation_failure_source) {
                         translation_failure_source = slot->source_index;
-                        translation_failure_result = slot->queue->vk_device.IsFaulted() ?
-                                                         slot->queue->vk_device.GetFirstFaultResult() :
-                                                         VK_ERROR_UNKNOWN;
+                        translation_failure_result =
+                            GetQueueFaultResult(slot->queue_type);
                         translation_failure_reason = "parallel command translation failure";
                     }
                 }
@@ -2277,11 +2648,10 @@ void VulkanSubmissionExecutor::ProcessBatch(
                 if (!state || *state != ETranslateWaveNodeState::Translated) {
                     break;
                 }
-                assert(slot.recorded);
+                assert(HasRecordedSourcePacket(slot.recorded));
                 assert(!slot.terminalized);
 
                 RHIBackendSubmissionBatchEntry& entry = _batch.submits[slot.source_index];
-                VkCommandQueue&                 queue = *slot.queue;
 
                 if (pipeline_state) {
                     PipelineSourceSlot& pipeline_slot =
@@ -2298,7 +2668,9 @@ void VulkanSubmissionExecutor::ProcessBatch(
                         source_metadata.source_segment_count;
                     pipeline_slot.cross_native_predecessor_wait =
                         source_metadata.cross_native_predecessor_wait;
-                    pipeline_slot.command_packet = std::move(slot.recorded);
+                    pipeline_slot.recorded_packet =
+                        std::move(slot.recorded);
+                    slot.recorded.emplace<std::monostate>();
 
                     pipeline_state->AddWork();
                     bool handoff_succeeded = false;
@@ -2321,9 +2693,15 @@ void VulkanSubmissionExecutor::ProcessBatch(
                     }
                     if (!handoff_succeeded) {
                         pipeline_state->FinishWork();
-                        if (pipeline_slot.command_packet) {
+                        if (HasRecordedSourcePacket(
+                                pipeline_slot.recorded_packet
+                            )) {
                             slot.recorded =
-                                std::move(pipeline_slot.command_packet);
+                                std::move(
+                                    pipeline_slot.recorded_packet
+                                );
+                            pipeline_slot.recorded_packet.emplace<
+                                std::monostate>();
                         }
                         return fail_group(
                             slot.source_index,
@@ -2351,8 +2729,8 @@ void VulkanSubmissionExecutor::ProcessBatch(
                 VulkanRuntimeSubmissionResult submit_result{};
                 try {
                     submit_result =
-                        ExecuteOnSubmissionThread([&queue,
-                                                   packet         = &*slot.recorded,
+                        ExecuteOnSubmissionThread([this,
+                                                   packet         = &slot.recorded,
                                                    batch_sequence = _batch.sequence,
                                                    source_index   = static_cast<uint32>(slot.source_index),
                                                    source_metadata =
@@ -2360,7 +2738,10 @@ void VulkanSubmissionExecutor::ProcessBatch(
                                                    queue_type     = slot.queue_type,
                                                    async_scope    = slot.async_queue_scope]() mutable {
                             VulkanRuntimeSubmissionResult result =
-                                queue.SubmitRecordedForRuntime(std::move(*packet));
+                                SubmitRecordedSourceForRuntime(
+                                    queue_type, std::move(*packet)
+                                );
+                            packet->emplace<std::monostate>();
                             if (result.WasSubmitted()) {
                                 NotifySourceSubmitted(
                                     batch_sequence,
@@ -2381,7 +2762,12 @@ void VulkanSubmissionExecutor::ProcessBatch(
                         VulkanSubmissionDetail::EWorkerRequestFailurePhase::Process,
                         std::current_exception()
                     );
-                    queue.RejectRecordedForRuntime(std::move(*slot.recorded), VK_ERROR_UNKNOWN);
+                    RejectRecordedSourceForRuntime(
+                        slot.queue_type,
+                        std::move(slot.recorded),
+                        VK_ERROR_UNKNOWN
+                    );
+                    slot.recorded.emplace<std::monostate>();
                     submit_result.outcome = {EVulkanOperationStatus::Rejected, VK_ERROR_UNKNOWN};
                 }
                 slot.terminalized                        = true;
@@ -2398,6 +2784,12 @@ void VulkanSubmissionExecutor::ProcessBatch(
 
                 if (submit_result.WasSubmitted()) {
                     assert(submit_result.completion.has_value());
+                    if (entry.queue == EQueueType::Copy) {
+                        last_copy_timeline = std::max(
+                            last_copy_timeline,
+                            submit_result.completion->value
+                        );
+                    }
                     update_frontier(entry.queue, *submit_result.completion, false);
                     continue;
                 }

--- a/source/runtime/render/rhi/vulkan/VulkanSubmissionExecutor.h
+++ b/source/runtime/render/rhi/vulkan/VulkanSubmissionExecutor.h
@@ -18,6 +18,7 @@
 #include <thread>
 #include <type_traits>
 #include <utility>
+#include <variant>
 
 namespace Moer::Render {
 
@@ -75,6 +76,11 @@ private:
         bool   recoverable{false};
     };
 
+    using RecordedSourcePacket = std::variant<
+        std::monostate,
+        VkCommandQueue::CurrentVulkanRecordedSubmit,
+        VkCopyQueue::CurrentVulkanCopyRecordedSubmit>;
+
     struct PipelineSourceSlot {
         EQueueType queue{EQueueType::Ignore};
         uint64     async_queue_scope{0};
@@ -82,7 +88,7 @@ private:
         uint32     source_segment_index{0};
         uint32     source_segment_count{1};
         bool       cross_native_predecessor_wait{false};
-        std::optional<VkCommandQueue::CurrentVulkanRecordedSubmit> command_packet{};
+        RecordedSourcePacket recorded_packet{};
     };
 
     struct PipelineBatchState {
@@ -151,6 +157,33 @@ private:
         const std::shared_ptr<PipelineBatchState>& _batch,
         size_t                                     _source_index
     ) noexcept;
+    [[nodiscard]] RecordedSourcePacket TranslateSourceForRuntime(
+        EQueueType _queue,
+        CmdSubmit&& _submit
+    ) noexcept;
+    [[nodiscard]] VulkanRuntimeSubmissionResult SubmitRecordedSourceForRuntime(
+        EQueueType            _queue,
+        RecordedSourcePacket&& _packet
+    ) noexcept;
+    void RejectRecordedSourceForRuntime(
+        EQueueType             _queue,
+        RecordedSourcePacket&& _packet,
+        VkResult               _result
+    ) noexcept;
+    void RejectSourceForRuntime(
+        EQueueType _queue,
+        CmdSubmit&& _submit,
+        VkResult    _result
+    ) noexcept;
+    [[nodiscard]] static bool HasRecordedSourcePacket(
+        const RecordedSourcePacket& _packet
+    ) noexcept;
+    [[nodiscard]] static CmdSubmit* GetRecordedSourceSubmit(
+        RecordedSourcePacket& _packet
+    ) noexcept;
+    [[nodiscard]] VkResult GetQueueFaultResult(
+        EQueueType _queue
+    ) const noexcept;
     void WaitForPipelineCapacity();
     void DrainPipelineBatches();
     void PrepareStreamSubmit(CmdSubmit& _submit, EQueueType _queue);
@@ -198,7 +231,7 @@ private:
     bool                       logged_cross_batch_pipeline{false};
     std::shared_ptr<Completion> stop_completion{};
     size_t                     batch_window{2};
-    bool                       graphics_compute_share_native_lane{false};
+    bool                       runtime_queues_share_native_lane{false};
     std::deque<std::shared_ptr<Completion>> in_flight_batches{};
 
     mutable std::mutex         hard_failure_mutex{};

--- a/source/runtime/render/rhi/vulkan/VulkanTranslateWaveScheduler.h
+++ b/source/runtime/render/rhi/vulkan/VulkanTranslateWaveScheduler.h
@@ -43,9 +43,9 @@ enum class ETranslateWaveNodeState : uint8_t {
 // their CPU prerequisite is complete at that point. Physical-queue ordering is
 // stricter: a node sharing native_queue_id with an earlier node waits for
 // MarkReleased, which represents transfer of that packet lease to Submit or
-// Reject. A non-async node is an exclusive Copy/control boundary; it waits for
-// the complete earlier prefix to be released and blocks the later suffix until
-// it is released.
+// Reject. A non-async node is an exclusive serial/control boundary; it waits
+// for the complete earlier prefix to be released and blocks the later suffix
+// until it is released.
 //
 // NextWave scans the complete stable input and emits every currently-ready
 // native lane. A blocked same-native node therefore cannot hide a later,
@@ -131,7 +131,7 @@ public:
             node.state = ETranslateWaveNodeState::Translating;
             wave.emplace_back(node.key);
 
-            // Copy/control work is ready only after its full earlier prefix
+            // Serial/control work is ready only after its full earlier prefix
             // has released, and it remains an exclusive wave.
             if (!node.async_translate) {
                 break;

--- a/source/test/RHIParallelRecordVulkanTest.cpp
+++ b/source/test/RHIParallelRecordVulkanTest.cpp
@@ -7,6 +7,7 @@
 #include "rhi/RHI.h"
 #include "rhi/RHICommand.h"
 #include "rhi/RHIExecutor.h"
+#include "rhi/RHISubmissionPipelinePolicy.h"
 #include "rhi/RHIThreadOwnership.h"
 #include "rhi/vulkan/VulkanCustomCommand.h"
 #include "rhi/vulkan/VulkanDevice.h"
@@ -234,7 +235,7 @@ public:
 
 private:
     uint64                                     async_queue_scope{0};
-    std::array<VulkanSourceSubmissionEvent, 3> events{};
+    std::array<VulkanSourceSubmissionEvent, 16> events{};
     std::atomic<size_t>                        count{0};
     std::atomic<bool>                          overflow{false};
 };
@@ -264,6 +265,157 @@ public:
 private:
     VulkanSourceSubmissionObserver observer{};
     bool                           installed{false};
+};
+
+class SourceTranslationCapture final {
+public:
+    explicit SourceTranslationCapture(
+        uint64     _async_queue_scope,
+        EQueueType _queue_filter = EQueueType::Ignore
+    ) :
+        async_queue_scope(_async_queue_scope),
+        queue_filter(_queue_filter) {}
+
+    static void Observe(
+        void*                               _context,
+        const VulkanSourceTranslationEvent& _event
+    ) noexcept {
+        auto& capture =
+            *static_cast<SourceTranslationCapture*>(_context);
+        if (_event.async_queue_scope != capture.async_queue_scope) {
+            return;
+        }
+        if (capture.queue_filter != EQueueType::Ignore &&
+            _event.queue != capture.queue_filter) {
+            return;
+        }
+
+        const size_t phase =
+            static_cast<size_t>(_event.phase);
+        if (_event.source_index >= MaxSources ||
+            phase >= PhaseCount) {
+            capture.overflow.store(true, std::memory_order_release);
+            return;
+        }
+        const size_t index =
+            static_cast<size_t>(_event.source_index) *
+                PhaseCount +
+            phase;
+        const bool duplicate =
+            capture.claimed[index].exchange(
+                true, std::memory_order_acq_rel
+            );
+        if (duplicate) {
+            capture.duplicate.store(true, std::memory_order_release);
+            return;
+        }
+        capture.events[index] = _event;
+        capture.seen[index].store(
+            true, std::memory_order_release
+        );
+        if (_event.thread_role != ERHIThreadRole::Translate) {
+            capture.wrong_owner.store(true, std::memory_order_release);
+        }
+        if (_event.queue == EQueueType::Copy &&
+            _event.phase ==
+                EVulkanSourceTranslationPhase::Recorded &&
+            !capture.copy_recorded_signalled.exchange(
+                true, std::memory_order_acq_rel
+            )) {
+            capture.copy_recorded.release();
+        }
+    }
+
+    [[nodiscard]] bool Seen(
+        uint32                        _source_index,
+        EVulkanSourceTranslationPhase _phase
+    ) const noexcept {
+        if (_source_index >= MaxSources) {
+            return false;
+        }
+        const size_t index =
+            static_cast<size_t>(_source_index) *
+                PhaseCount +
+            static_cast<size_t>(_phase);
+        return seen[index].load(std::memory_order_acquire);
+    }
+
+    [[nodiscard]] const VulkanSourceTranslationEvent& Event(
+        uint32                        _source_index,
+        EVulkanSourceTranslationPhase _phase
+    ) const noexcept {
+        const size_t index =
+            static_cast<size_t>(_source_index) *
+                PhaseCount +
+            static_cast<size_t>(_phase);
+        return events[index];
+    }
+
+    [[nodiscard]] bool IsValid() const noexcept {
+        return !overflow.load(std::memory_order_acquire) &&
+               !duplicate.load(std::memory_order_acquire) &&
+               !wrong_owner.load(std::memory_order_acquire);
+    }
+
+    std::binary_semaphore copy_recorded{0};
+
+private:
+    static constexpr size_t MaxSources = 16;
+    static constexpr size_t PhaseCount = 3;
+
+    uint64 async_queue_scope{0};
+    EQueueType queue_filter{EQueueType::Ignore};
+    std::array<
+        VulkanSourceTranslationEvent,
+        MaxSources * PhaseCount> events{};
+    std::array<
+        std::atomic<bool>,
+        MaxSources * PhaseCount> claimed{};
+    std::array<
+        std::atomic<bool>,
+        MaxSources * PhaseCount> seen{};
+    std::atomic<bool> overflow{false};
+    std::atomic<bool> duplicate{false};
+    std::atomic<bool> wrong_owner{false};
+    std::atomic<bool> copy_recorded_signalled{false};
+};
+
+class ScopedSourceTranslationObserver final {
+public:
+    explicit ScopedSourceTranslationObserver(
+        SourceTranslationCapture& _capture
+    ) :
+        observer{
+            .context  = &_capture,
+            .callback = &SourceTranslationCapture::Observe,
+        } {
+        if (!TryInstallVulkanSourceTranslationObserver(
+                &observer
+            )) {
+            throw std::runtime_error(
+                "Vulkan source translation observer was already installed"
+            );
+        }
+        installed = true;
+    }
+
+    ~ScopedSourceTranslationObserver() noexcept {
+        if (installed &&
+            !RemoveVulkanSourceTranslationObserver(&observer)) {
+            std::terminate();
+        }
+    }
+
+    ScopedSourceTranslationObserver(
+        const ScopedSourceTranslationObserver&
+    ) = delete;
+    ScopedSourceTranslationObserver& operator=(
+        const ScopedSourceTranslationObserver&
+    ) = delete;
+
+private:
+    VulkanSourceTranslationObserver observer{};
+    bool                            installed{false};
 };
 
 class NativeSubmissionCapture final {
@@ -3218,47 +3370,111 @@ void RunCrossQueueTopologyBatch() {
 void RunAsyncQueueParallelTranslateSmoke() {
     using namespace std::chrono_literals;
 
-    const RHIQueueTopology topology = RenderDevice::Get().GetQueueTopology();
-    if (!topology.graphics.available || !topology.compute.available) {
+    auto&                  device   = RenderDevice::Get();
+    const RHIQueueTopology topology = device.GetQueueTopology();
+    if (!topology.graphics.available ||
+        !topology.compute.available ||
+        !topology.copy.available) {
         LOG_INFO(
             "[TESTCASE][SKIP] name=AsyncQueueParallelTranslateSmoke "
-            "graphics_native={} compute_native={} reason=queue_unavailable "
+            "graphics_available={} compute_available={} copy_available={} "
+            "graphics_native={} compute_native={} copy_native={} "
+            "reason=queue_unavailable "
             "cpu_seam=VulkanTranslateWaveScheduler",
+            topology.graphics.available,
+            topology.compute.available,
+            topology.copy.available,
             topology.graphics.native_queue_id,
-            topology.compute.native_queue_id
+            topology.compute.native_queue_id,
+            topology.copy.native_queue_id
         );
         return;
     }
     if (topology.graphics.native_queue_id == topology.compute.native_queue_id) {
         LOG_INFO(
             "[TESTCASE][SKIP] name=AsyncQueueParallelTranslateSmoke "
-            "graphics_native={} compute_native={} reason=native_queue_alias "
+            "graphics_available={} compute_available={} copy_available={} "
+            "graphics_native={} compute_native={} copy_native={} "
+            "reason=graphics_compute_native_alias "
             "cpu_seam=VulkanTranslateWaveScheduler",
+            topology.graphics.available,
+            topology.compute.available,
+            topology.copy.available,
             topology.graphics.native_queue_id,
-            topology.compute.native_queue_id
+            topology.compute.native_queue_id,
+            topology.copy.native_queue_id
         );
         return;
     }
 
-    constexpr uint64                   async_queue_scope = 0x5048415345313541ull;
-    SourceSubmissionCapture            submission_capture(async_queue_scope);
-    ScopedSourceSubmissionObserver     submission_observer(submission_capture);
-    std::array<std::atomic<uint32>, 3> ordinary_callbacks{};
-    std::array<std::atomic<uint32>, 3> success_callbacks{};
-    std::binary_semaphore              graphics_front_entered{0};
-    std::binary_semaphore              graphics_tail_entered{0};
-    std::binary_semaphore              compute_later_entered{0};
-    std::binary_semaphore              release_graphics_front{0};
-    std::binary_semaphore              release_compute_later{0};
-    OneShotSemaphoreRelease            release_graphics_guard(release_graphics_front);
-    OneShotSemaphoreRelease            release_compute_guard(release_compute_later);
+    constexpr uint64 async_queue_scope =
+        0x5048415345313545ull;
+    constexpr std::array<uint32, 8> copy_expected{
+        0x15E00001u,
+        0x15E00002u,
+        0x15E00003u,
+        0x15E00004u,
+        0x15E00005u,
+        0x15E00006u,
+        0x15E00007u,
+        0x15E00008u,
+    };
+    std::array<uint32, copy_expected.size()> copy_readback{};
+    BufferRef copy_buffer = device.CreateBuffer<uint32>(
+        "phase15e_copy_ready_lane",
+        copy_expected.size(),
+        EBufferUsageFlags::TRANSFER_SRC |
+            EBufferUsageFlags::TRANSFER_DST
+    );
+    FenceRef copy_done = device.CreateFence();
+
+    SourceSubmissionCapture        submission_capture(
+        async_queue_scope
+    );
+    ScopedSourceSubmissionObserver submission_observer(
+        submission_capture
+    );
+    SourceTranslationCapture        translation_capture(
+        async_queue_scope
+    );
+    ScopedSourceTranslationObserver translation_observer(
+        translation_capture
+    );
+    NativeSubmissionCapture        native_capture{};
+    ScopedNativeSubmissionObserver native_observer(
+        native_capture
+    );
+    std::array<std::atomic<uint32>, 4> ordinary_callbacks{};
+    std::array<std::atomic<uint32>, 4> success_callbacks{};
+    std::binary_semaphore graphics_front_entered{0};
+    std::binary_semaphore graphics_tail_entered{0};
+    std::binary_semaphore compute_later_entered{0};
+    std::binary_semaphore release_graphics_front{0};
+    std::binary_semaphore release_compute_later{0};
+    OneShotSemaphoreRelease release_graphics_guard(
+        release_graphics_front
+    );
+    OneShotSemaphoreRelease release_compute_guard(
+        release_compute_later
+    );
+    const bool copy_has_independent_native_lane =
+        topology.copy.native_queue_id !=
+            topology.graphics.native_queue_id &&
+        topology.copy.native_queue_id !=
+            topology.compute.native_queue_id;
+    const uint32 main_thread_id =
+        Platform::GetCurrentThreadID();
 
     try {
         CommandList graphics_front(EQueueType::Graphics);
-        graphics_front.SetResourceStateOwnership(ERHIResourceStateOwnership::Explicit);
+        graphics_front.SetResourceStateOwnership(
+            ERHIResourceStateOwnership::Explicit
+        );
         graphics_front.AddCustomCommand(
             MakeUnique<BlockingTranslateProbeCommand>(
-                EQueueType::Graphics, &graphics_front_entered, &release_graphics_front
+                EQueueType::Graphics,
+                &graphics_front_entered,
+                &release_graphics_front
             ),
             "AsyncQueueGraphicsFrontBlockingTranslateProbe"
         );
@@ -3269,14 +3485,23 @@ void RunAsyncQueueParallelTranslateSmoke() {
             success_callbacks[0].fetch_add(1, std::memory_order_relaxed);
         });
         CmdSubmit graphics_front_submit = graphics_front.Submit();
-        graphics_front_submit.SetTranslateExecutionClass(ERHITranslateExecutionClass::Parallel);
-        graphics_front_submit.SetResourceStateOwnership(ERHIResourceStateOwnership::Explicit);
+        graphics_front_submit.SetTranslateExecutionClass(
+            ERHITranslateExecutionClass::Parallel
+        );
+        graphics_front_submit.SetResourceStateOwnership(
+            ERHIResourceStateOwnership::Explicit
+        );
         graphics_front_submit.async_queue_scope = async_queue_scope;
 
         CommandList graphics_tail(EQueueType::Graphics);
-        graphics_tail.SetResourceStateOwnership(ERHIResourceStateOwnership::Explicit);
+        graphics_tail.SetResourceStateOwnership(
+            ERHIResourceStateOwnership::Explicit
+        );
         graphics_tail.AddCustomCommand(
-            MakeUnique<TranslateProbeCommand>(&graphics_tail_entered), "AsyncQueueGraphicsTailTranslateProbe"
+            MakeUnique<TranslateProbeCommand>(
+                &graphics_tail_entered
+            ),
+            "AsyncQueueGraphicsTailTranslateProbe"
         );
         graphics_tail.AddCallback([&] {
             ordinary_callbacks[1].fetch_add(1, std::memory_order_relaxed);
@@ -3285,15 +3510,23 @@ void RunAsyncQueueParallelTranslateSmoke() {
             success_callbacks[1].fetch_add(1, std::memory_order_relaxed);
         });
         CmdSubmit graphics_tail_submit = graphics_tail.Submit();
-        graphics_tail_submit.SetTranslateExecutionClass(ERHITranslateExecutionClass::Parallel);
-        graphics_tail_submit.SetResourceStateOwnership(ERHIResourceStateOwnership::Explicit);
+        graphics_tail_submit.SetTranslateExecutionClass(
+            ERHITranslateExecutionClass::Parallel
+        );
+        graphics_tail_submit.SetResourceStateOwnership(
+            ERHIResourceStateOwnership::Explicit
+        );
         graphics_tail_submit.async_queue_scope = async_queue_scope;
 
         CommandList compute_later(EQueueType::Compute);
-        compute_later.SetResourceStateOwnership(ERHIResourceStateOwnership::Explicit);
+        compute_later.SetResourceStateOwnership(
+            ERHIResourceStateOwnership::Explicit
+        );
         compute_later.AddCustomCommand(
             MakeUnique<BlockingTranslateProbeCommand>(
-                EQueueType::Compute, &compute_later_entered, &release_compute_later
+                EQueueType::Compute,
+                &compute_later_entered,
+                &release_compute_later
             ),
             "AsyncQueueComputeLaterBlockingTranslateProbe"
         );
@@ -3304,67 +3537,281 @@ void RunAsyncQueueParallelTranslateSmoke() {
             success_callbacks[2].fetch_add(1, std::memory_order_relaxed);
         });
         CmdSubmit compute_later_submit = compute_later.Submit();
-        compute_later_submit.SetTranslateExecutionClass(ERHITranslateExecutionClass::Parallel);
-        compute_later_submit.SetResourceStateOwnership(ERHIResourceStateOwnership::Explicit);
+        compute_later_submit.SetTranslateExecutionClass(
+            ERHITranslateExecutionClass::Parallel
+        );
+        compute_later_submit.SetResourceStateOwnership(
+            ERHIResourceStateOwnership::Explicit
+        );
         compute_later_submit.async_queue_scope = async_queue_scope;
 
-        Array<RHIBackendSubmissionBatchEntry> submits{};
-        submits.emplace_back(EQueueType::Graphics, std::move(graphics_front_submit));
-        submits.emplace_back(EQueueType::Graphics, std::move(graphics_tail_submit));
-        submits.emplace_back(EQueueType::Compute, std::move(compute_later_submit));
-        RHIExecutor::Get().Submit(std::move(submits), ERHIExecSubmitFlags::FlushGPU);
+        CommandList copy(EQueueType::Copy);
+        copy.SetResourceStateOwnership(
+            ERHIResourceStateOwnership::Explicit
+        );
+        copy.CopyFrom(
+            OwnedBytes(copy_expected),
+            copy_buffer->GetView(),
+            "Phase15ECopyReadyUpload"
+        );
+        copy.CopyFrom(
+            copy_buffer->GetView(),
+            WritableBytes(copy_readback),
+            "Phase15ECopyReadyReadback"
+        );
+        copy.AddCallback([&] {
+            ordinary_callbacks[3].fetch_add(
+                1, std::memory_order_relaxed
+            );
+        });
+        copy.AddSuccessCallback([&] {
+            success_callbacks[3].fetch_add(
+                1, std::memory_order_relaxed
+            );
+        });
+        CmdSubmit copy_submit = copy.Submit();
+        copy_submit.SetTranslateExecutionClass(
+            ERHITranslateExecutionClass::Parallel
+        );
+        copy_submit.SetResourceStateOwnership(
+            ERHIResourceStateOwnership::Explicit
+        );
+        copy_submit.async_queue_scope = async_queue_scope;
+        copy_submit.Signal(copy_done.Get(), 1);
 
-        const auto deadline                             = std::chrono::steady_clock::now() + 5s;
-        const bool graphics_front_translate_entered     = graphics_front_entered.try_acquire_until(deadline);
-        const bool compute_later_translate_entered      = compute_later_entered.try_acquire_until(deadline);
-        const bool graphics_tail_entered_before_release = graphics_tail_entered.try_acquire();
+        Array<RHIBackendSubmissionBatchEntry> submits{};
+        submits.emplace_back(
+            EQueueType::Graphics,
+            std::move(graphics_front_submit)
+        );
+        submits.emplace_back(
+            EQueueType::Graphics,
+            std::move(graphics_tail_submit)
+        );
+        submits.emplace_back(
+            EQueueType::Compute,
+            std::move(compute_later_submit)
+        );
+        submits.emplace_back(
+            EQueueType::Copy,
+            std::move(copy_submit)
+        );
+        RHIExecutor::Get().Submit(
+            std::move(submits),
+            ERHIExecSubmitFlags::FlushGPU
+        );
+
+        const auto deadline =
+            std::chrono::steady_clock::now() + 5s;
+        const bool graphics_front_translate_entered =
+            graphics_front_entered.try_acquire_until(deadline);
+        const bool compute_later_translate_entered =
+            compute_later_entered.try_acquire_until(deadline);
+        bool copy_recorded_before_release = false;
+        if (copy_has_independent_native_lane) {
+            copy_recorded_before_release =
+                translation_capture.copy_recorded.try_acquire_until(
+                    deadline
+                );
+        }
+        const bool graphics_tail_entered_before_release =
+            graphics_tail_entered.try_acquire();
+        const bool source_submitted_before_release =
+            submission_capture.Count() != 0;
+        const bool native_submitted_before_release =
+            native_capture.Count() != 0;
         release_graphics_guard.Release();
         release_compute_guard.Release();
 
         RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
         const bool graphics_tail_translate_entered =
-            graphics_tail_entered_before_release || graphics_tail_entered.try_acquire();
+            graphics_tail_entered_before_release ||
+            graphics_tail_entered.try_acquire();
 
-        if (!graphics_front_translate_entered || !compute_later_translate_entered ||
-            graphics_tail_entered_before_release || !graphics_tail_translate_entered) {
-            throw std::runtime_error("ready native lane did not bypass a blocked same-native "
-                                     "successor while preserving its release gate");
+        if (!graphics_front_translate_entered ||
+            !compute_later_translate_entered ||
+            (copy_has_independent_native_lane &&
+             !copy_recorded_before_release) ||
+            graphics_tail_entered_before_release ||
+            source_submitted_before_release ||
+            native_submitted_before_release ||
+            !graphics_tail_translate_entered) {
+            throw std::runtime_error(
+                "G/C/Copy ready native lanes or stable submission cursor "
+                "violated their release contract"
+            );
+        }
+        if (copy_readback != copy_expected) {
+            throw std::runtime_error(
+                "Copy ready-lane GPU readback mismatch"
+            );
+        }
+        auto* vk_copy_done = ResourceCast(copy_done.Get());
+        if (vk_copy_done->HostWait(1) != VK_SUCCESS ||
+            vk_copy_done->IsRejected(1) ||
+            vk_copy_done->IsFailed()) {
+            throw std::runtime_error(
+                "Copy ready-lane signal did not complete successfully"
+            );
         }
         for (size_t index = 0; index < ordinary_callbacks.size(); ++index) {
-            if (ordinary_callbacks[index].load(std::memory_order_acquire) != 1 ||
-                success_callbacks[index].load(std::memory_order_acquire) != 1) {
-                throw std::runtime_error("parallel Translate callbacks did not retire exactly once");
+            if (ordinary_callbacks[index].load(
+                    std::memory_order_acquire
+                ) != 1 ||
+                success_callbacks[index].load(
+                    std::memory_order_acquire
+                ) != 1) {
+                throw std::runtime_error(
+                    "G/C/Copy parallel Translate callbacks did not "
+                    "retire exactly once"
+                );
             }
         }
 
-        if (submission_capture.Overflowed() || submission_capture.Count() != 3) {
-            throw std::runtime_error("parallel Translate did not produce exactly three observed "
-                                     "source submissions");
+        if (submission_capture.Overflowed() ||
+            submission_capture.Count() != 4) {
+            throw std::runtime_error(
+                "G/C/Copy parallel Translate did not produce exactly "
+                "four source submissions"
+            );
         }
         constexpr std::array expected_queues{
             EQueueType::Graphics,
             EQueueType::Graphics,
             EQueueType::Compute,
+            EQueueType::Copy,
         };
-        const uint64 observed_batch_sequence = submission_capture.Event(0).batch_sequence;
+        const uint64 observed_batch_sequence =
+            submission_capture.Event(0).batch_sequence;
         if (observed_batch_sequence == 0) {
-            throw std::runtime_error("Submission observer reported an invalid batch sequence");
+            throw std::runtime_error(
+                "Submission observer reported an invalid batch sequence"
+            );
         }
         for (size_t index = 0; index < expected_queues.size(); ++index) {
-            const VulkanSourceSubmissionEvent& event = submission_capture.Event(index);
-            if (event.source_index != index || event.queue != expected_queues[index] ||
+            const VulkanSourceSubmissionEvent& event =
+                submission_capture.Event(index);
+            if (event.source_index != index ||
+                event.queue != expected_queues[index] ||
                 event.batch_sequence != observed_batch_sequence) {
-                throw std::runtime_error("Submission owner did not preserve stable G,G,C source "
-                                         "order in one batch");
+                throw std::runtime_error(
+                    "Submission owner did not preserve stable G,G,C,Copy "
+                    "source order in one batch"
+                );
             }
         }
 
+        if (!translation_capture.IsValid()) {
+            throw std::runtime_error(
+                "source translation observer overflowed, duplicated a "
+                "phase, or observed a wrong owner"
+            );
+        }
+        for (size_t index = 0; index < expected_queues.size();
+             ++index) {
+            if (!translation_capture.Seen(
+                    static_cast<uint32>(index),
+                    EVulkanSourceTranslationPhase::Begin
+                ) ||
+                !translation_capture.Seen(
+                    static_cast<uint32>(index),
+                    EVulkanSourceTranslationPhase::Recorded
+                ) ||
+                translation_capture.Seen(
+                    static_cast<uint32>(index),
+                    EVulkanSourceTranslationPhase::Failed
+                )) {
+                throw std::runtime_error(
+                    "source translation observer lost a successful "
+                    "G/G/C/Copy phase"
+                );
+            }
+            const VulkanSourceTranslationEvent& event =
+                translation_capture.Event(
+                    static_cast<uint32>(index),
+                    EVulkanSourceTranslationPhase::Recorded
+                );
+            if (event.queue != expected_queues[index] ||
+                event.batch_sequence != observed_batch_sequence ||
+                event.thread_role != ERHIThreadRole::Translate ||
+                event.native_queue_id !=
+                    topology.Resolve(event.queue).native_queue_id) {
+                throw std::runtime_error(
+                    "source translation observer reported unstable "
+                    "identity or ownership"
+                );
+            }
+        }
+
+        if (native_capture.Overflowed() ||
+            native_capture.Count() != expected_queues.size()) {
+            throw std::runtime_error(
+                "G/G/C/Copy ready-lane batch did not issue exactly four "
+                "native submits"
+            );
+        }
+        const uint32 submission_thread_id =
+            native_capture.Event(0).thread_id;
+        for (size_t index = 0; index < expected_queues.size();
+             ++index) {
+            const VulkanNativeSubmissionEvent& event =
+                native_capture.Event(index);
+            if (event.queue != expected_queues[index] ||
+                event.thread_role != ERHIThreadRole::Submission ||
+                event.thread_id != submission_thread_id ||
+                event.thread_id == main_thread_id ||
+                !event.outcome.WasSubmitted()) {
+                throw std::runtime_error(
+                    "native G/G/C/Copy submit lost stable order or the "
+                    "sole Submission owner"
+                );
+            }
+        }
+        for (size_t lhs = 0; lhs < expected_queues.size(); ++lhs) {
+            for (size_t rhs = lhs + 1;
+                 rhs < expected_queues.size();
+                 ++rhs) {
+                const bool topology_alias =
+                    topology.Resolve(expected_queues[lhs])
+                        .native_queue_id ==
+                    topology.Resolve(expected_queues[rhs])
+                        .native_queue_id;
+                const bool observed_alias =
+                    native_capture.Event(lhs).native_queue_handle ==
+                    native_capture.Event(rhs).native_queue_handle;
+                if (topology_alias != observed_alias) {
+                    throw std::runtime_error(
+                        "native observer queue alias disagreed with "
+                        "RHIQueueTopology"
+                    );
+                }
+            }
+        }
+
+        const size_t source_count_before_replay =
+            submission_capture.Count();
+        const size_t native_count_before_replay =
+            native_capture.Count();
         RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
         for (size_t index = 0; index < ordinary_callbacks.size(); ++index) {
-            if (ordinary_callbacks[index].load(std::memory_order_acquire) != 1 ||
-                success_callbacks[index].load(std::memory_order_acquire) != 1) {
-                throw std::runtime_error("a second Sync replayed parallel Translate callbacks");
+            if (ordinary_callbacks[index].load(
+                    std::memory_order_acquire
+                ) != 1 ||
+                success_callbacks[index].load(
+                    std::memory_order_acquire
+                ) != 1) {
+                throw std::runtime_error(
+                    "a second Sync replayed G/C/Copy Translate callbacks"
+                );
             }
+        }
+        if (submission_capture.Count() !=
+                source_count_before_replay ||
+            native_capture.Count() !=
+                native_count_before_replay) {
+            throw std::runtime_error(
+                "a second Sync replayed source or native submission"
+            );
         }
     } catch (...) {
         const std::exception_ptr failure = std::current_exception();
@@ -3380,12 +3827,16 @@ void RunAsyncQueueParallelTranslateSmoke() {
 
     LOG_INFO(
         "[TESTCASE][PASS] name=AsyncQueueParallelTranslateSmoke "
-        "graphics_native={} compute_native={} sources=3 batch=1 "
-        "source_order=G,G,C first_ready_lanes=G,C "
-        "observed_submit_order=G,G,C async_scope={} explicit_state=true "
-        "callbacks=exactly_once",
+        "graphics_native={} compute_native={} copy_native={} "
+        "sources=4 batch=1 source_order=G,G,C,Copy "
+        "first_ready_lanes={} observed_submit_order=G,G,C,Copy "
+        "copy_translate_owner=Translate native_owner=Submission "
+        "async_scope={} explicit_state=true readback=verified "
+        "callbacks=exactly_once replay=0",
         topology.graphics.native_queue_id,
         topology.compute.native_queue_id,
+        topology.copy.native_queue_id,
+        copy_has_independent_native_lane ? "G,C,Copy" : "alias_fallback",
         async_queue_scope
     );
 }
@@ -3998,14 +4449,35 @@ void RunMultiSegmentPrefixSubmitSuffixTranslateFailure() {
 void RunParallelTranslateFailureRetirement() {
     auto&                  device            = RenderDevice::Get();
     const RHIQueueTopology topology          = device.GetQueueTopology();
-    constexpr uint64       async_queue_scope = 0x5048313541464149ull;
+    constexpr uint64       async_queue_scope = 0x5048313545464149ull;
 
     FenceRef                           graphics_done = device.CreateFence();
-    FenceRef                           compute_done  = device.CreateFence();
+    FenceRef                           copy_done     = device.CreateFence();
     FenceRef                           later_done    = device.CreateFence();
     std::array<std::atomic<uint32>, 3> ordinary_callbacks{};
     std::array<std::atomic<uint32>, 3> success_callbacks{};
-    std::binary_semaphore              compute_translated{0};
+    SourceSubmissionCapture            source_capture(async_queue_scope);
+    ScopedSourceSubmissionObserver     source_observer(source_capture);
+    SourceTranslationCapture           translation_capture(
+        async_queue_scope, EQueueType::Copy
+    );
+    ScopedSourceTranslationObserver translation_observer(
+        translation_capture
+    );
+    NativeSubmissionCapture        native_capture{};
+    ScopedNativeSubmissionObserver native_observer(native_capture);
+    constexpr std::array<uint32, 4> copy_values{
+        0x15E30001u,
+        0x15E30002u,
+        0x15E30003u,
+        0x15E30004u,
+    };
+    BufferRef copy_destination = device.CreateBuffer<uint32>(
+        "phase15e_hard_failure_copy_suffix",
+        copy_values.size(),
+        EBufferUsageFlags::TRANSFER_SRC |
+            EBufferUsageFlags::TRANSFER_DST
+    );
 
     CommandList graphics(EQueueType::Graphics);
     graphics.SetResourceStateOwnership(ERHIResourceStateOwnership::Explicit);
@@ -4024,38 +4496,67 @@ void RunParallelTranslateFailureRetirement() {
     graphics_submit.async_queue_scope = async_queue_scope;
     graphics_submit.Signal(graphics_done.Get(), 1);
 
-    CommandList compute(EQueueType::Compute);
-    compute.SetResourceStateOwnership(ERHIResourceStateOwnership::Explicit);
-    compute.AddCustomCommand(
-        MakeUnique<TranslateProbeCommand>(&compute_translated), "ParallelTranslateRecordedSuffixProbe"
+    CommandList copy(EQueueType::Copy);
+    copy.SetResourceStateOwnership(
+        ERHIResourceStateOwnership::Explicit
     );
-    compute.AddCallback([&] {
+    copy.CopyFrom(
+        OwnedBytes(copy_values),
+        copy_destination->GetView(),
+        "ParallelTranslateRecordedCopySuffix"
+    );
+    copy.AddCallback([&] {
         ordinary_callbacks[1].fetch_add(1, std::memory_order_relaxed);
     });
-    compute.AddSuccessCallback([&] {
+    copy.AddSuccessCallback([&] {
         success_callbacks[1].fetch_add(1, std::memory_order_relaxed);
     });
-    CmdSubmit compute_submit = compute.Submit();
-    compute_submit.SetTranslateExecutionClass(ERHITranslateExecutionClass::Parallel);
-    compute_submit.SetResourceStateOwnership(ERHIResourceStateOwnership::Explicit);
-    compute_submit.async_queue_scope = async_queue_scope;
-    compute_submit.Signal(compute_done.Get(), 1);
+    CmdSubmit copy_submit = copy.Submit();
+    copy_submit.SetTranslateExecutionClass(
+        ERHITranslateExecutionClass::Parallel
+    );
+    copy_submit.SetResourceStateOwnership(
+        ERHIResourceStateOwnership::Explicit
+    );
+    copy_submit.async_queue_scope = async_queue_scope;
+    copy_submit.Signal(copy_done.Get(), 1);
 
     Array<RHIBackendSubmissionBatchEntry> failing_batch{};
     failing_batch.emplace_back(EQueueType::Graphics, std::move(graphics_submit));
-    failing_batch.emplace_back(EQueueType::Compute, std::move(compute_submit));
+    failing_batch.emplace_back(EQueueType::Copy, std::move(copy_submit));
     RHIExecutor::Get().Submit(std::move(failing_batch), ERHIExecSubmitFlags::FlushGPU);
     RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
 
-    const bool distinct_native       = topology.graphics.native_queue_id != topology.compute.native_queue_id;
-    const bool suffix_was_translated = compute_translated.try_acquire();
+    const bool distinct_native =
+        topology.graphics.native_queue_id !=
+        topology.copy.native_queue_id;
+    const bool suffix_was_translated =
+        translation_capture.Seen(
+            1,
+            EVulkanSourceTranslationPhase::Recorded
+        );
     if (suffix_was_translated != distinct_native) {
         throw std::runtime_error("parallel Translate failure did not preserve native-lane wave "
                                  "dispatch semantics");
     }
-    if (!ResourceCast(graphics_done.Get())->IsFailed() || !ResourceCast(compute_done.Get())->IsFailed() ||
-        ResourceCast(graphics_done.Get())->IsRejected(1) || ResourceCast(compute_done.Get())->IsRejected(1)) {
+    if (!translation_capture.IsValid()) {
+        throw std::runtime_error(
+            "hard-failure Copy translation observer lost ownership or "
+            "published duplicate phases"
+        );
+    }
+    if (!ResourceCast(graphics_done.Get())->IsFailed() ||
+        !ResourceCast(copy_done.Get())->IsFailed() ||
+        ResourceCast(graphics_done.Get())->IsRejected(1) ||
+        ResourceCast(copy_done.Get())->IsRejected(1)) {
         throw std::runtime_error("hard parallel Translate failure did not fail every wave signal");
+    }
+    if (source_capture.Count() != 0 ||
+        native_capture.Count() != 0) {
+        throw std::runtime_error(
+            "hard-failure recorded Copy suffix reached source or native "
+            "submission"
+        );
     }
 
     // A hard Translate failure latches the backend. A later independent
@@ -4091,11 +4592,18 @@ void RunParallelTranslateFailureRetirement() {
             throw std::runtime_error("hard Translate failure replayed callback retirement");
         }
     }
+    if (source_capture.Count() != 0 ||
+        native_capture.Count() != 0) {
+        throw std::runtime_error(
+            "hard Translate failure replayed a rejected Copy packet"
+        );
+    }
 
     LOG_INFO(
         "[TESTCASE][PASS] name=ParallelTranslateFailureRetirement "
         "distinct_native={} suffix_recorded={} signals=failed "
-        "callbacks=exactly_once hard_latch=later_batch_failed",
+        "suffix_queue=Copy native_submit=0 callbacks=exactly_once "
+        "hard_latch=later_batch_failed replay=0",
         distinct_native,
         suffix_was_translated
     );
@@ -4847,9 +5355,12 @@ void RunBoundedCrossBatchSubmissionPipeline(uint32 _batch_window) {
     if (!topology.graphics.available || !topology.compute.available) {
         LOG_INFO(
             "[TESTCASE][SKIP] name=BoundedCrossBatchSubmissionPipeline "
-            "window={} reason=queue_unavailable graphics_native={} "
-            "compute_native={}",
+            "window={} reason=queue_unavailable "
+            "graphics_available={} compute_available={} "
+            "graphics_native={} compute_native={}",
             _batch_window,
+            topology.graphics.available,
+            topology.compute.available,
             topology.graphics.native_queue_id,
             topology.compute.native_queue_id
         );
@@ -4859,6 +5370,10 @@ void RunBoundedCrossBatchSubmissionPipeline(uint32 _batch_window) {
     constexpr uint64 async_queue_scope = 0x5048313544504950ull;
     const bool distinct_native =
         topology.graphics.native_queue_id != topology.compute.native_queue_id;
+    const bool runtime_native_alias =
+        RHISubmissionPipelinePolicy::HasAvailableNativeLaneAlias(
+            topology
+        );
     const uint32 main_thread_id = Platform::GetCurrentThreadID();
 
     SourceSubmissionCapture        source_capture(async_queue_scope);
@@ -4991,7 +5506,7 @@ void RunBoundedCrossBatchSubmissionPipeline(uint32 _batch_window) {
         );
 
         bool compute_translate_observed = false;
-        if (_batch_window == 2 && distinct_native) {
+        if (_batch_window == 2 && !runtime_native_alias) {
             compute_translate_observed =
                 compute_translated.try_acquire_for(5s);
             if (!compute_translate_observed ||
@@ -5015,7 +5530,7 @@ void RunBoundedCrossBatchSubmissionPipeline(uint32 _batch_window) {
                 compute_translated.try_acquire_for(250ms);
             if (compute_translate_observed) {
                 throw std::runtime_error(
-                    "Graphics/Compute native alias did not reduce the "
+                    "runtime native queue alias did not reduce the "
                     "effective window to 1"
                 );
             }
@@ -5024,9 +5539,10 @@ void RunBoundedCrossBatchSubmissionPipeline(uint32 _batch_window) {
                 "name=BoundedCrossBatchSubmissionPipelineOverlap "
                 "requested_window=2 effective_window=1 "
                 "reason=native_queue_alias graphics_native={} "
-                "compute_native={} admission=blocked",
+                "compute_native={} copy_native={} admission=blocked",
                 topology.graphics.native_queue_id,
-                topology.compute.native_queue_id
+                topology.compute.native_queue_id,
+                topology.copy.native_queue_id
             );
         }
 
@@ -5045,7 +5561,7 @@ void RunBoundedCrossBatchSubmissionPipeline(uint32 _batch_window) {
                 "cross-batch Translate probes did not execute exactly once"
             );
         }
-        if ((_batch_window == 1 || !distinct_native) &&
+        if ((_batch_window == 1 || runtime_native_alias) &&
             !compute_observed_release.load(std::memory_order_acquire)) {
             throw std::runtime_error(
                 "effective window 1 batch 1 Translate started before "
@@ -5164,8 +5680,10 @@ void RunBoundedCrossBatchSubmissionPipeline(uint32 _batch_window) {
         "queues=Graphics,Compute source_order=G,C "
         "native_owner=Submission signals=success callbacks=exactly_once replay=0",
         _batch_window,
-        !distinct_native,
-        _batch_window == 2 && distinct_native ? "verified" : "blocked"
+        runtime_native_alias,
+        _batch_window == 2 && !runtime_native_alias ?
+            "verified" :
+            "blocked"
     );
 }
 
@@ -5469,37 +5987,67 @@ void RunBoundedCrossBatchRecoverableRejection() {
 
     auto&                  device   = RenderDevice::Get();
     const RHIQueueTopology topology = device.GetQueueTopology();
-    if (!topology.graphics.available || !topology.compute.available) {
+    if (!topology.graphics.available || !topology.copy.available) {
         LOG_INFO(
             "[TESTCASE][SKIP] name=BoundedCrossBatchRecoverableRejection "
-            "reason=queue_unavailable graphics_native={} compute_native={}",
+            "window=2 reason=queue_unavailable "
+            "graphics_available={} copy_available={} "
+            "graphics_native={} copy_native={}",
+            topology.graphics.available,
+            topology.copy.available,
             topology.graphics.native_queue_id,
-            topology.compute.native_queue_id
+            topology.copy.native_queue_id
         );
         return;
     }
 
-    constexpr uint64 async_queue_scope = 0x504831354452454Aull;
-    const bool distinct_native =
-        topology.graphics.native_queue_id != topology.compute.native_queue_id;
-    const uint32 main_thread_id = Platform::GetCurrentThreadID();
+    constexpr uint64 async_queue_scope =
+        0x504831354552454Aull;
+    const bool runtime_native_alias =
+        RHISubmissionPipelinePolicy::HasAvailableNativeLaneAlias(
+            topology
+        );
+    const uint32 main_thread_id =
+        Platform::GetCurrentThreadID();
 
     SourceSubmissionCapture        source_capture(async_queue_scope);
     ScopedSourceSubmissionObserver source_observer(source_capture);
+    SourceTranslationCapture        translation_capture(
+        async_queue_scope, EQueueType::Copy
+    );
+    ScopedSourceTranslationObserver translation_observer(
+        translation_capture
+    );
     NativeSubmissionCapture        native_capture{};
     ScopedNativeSubmissionObserver native_observer(native_capture);
-    DependencyWaitCapture          graphics_wait_capture{EQueueType::Graphics};
-    ScopedDependencyWaitObserver   wait_observer(graphics_wait_capture);
+    DependencyWaitCapture graphics_wait_capture{
+        EQueueType::Graphics
+    };
+    ScopedDependencyWaitObserver wait_observer(
+        graphics_wait_capture
+    );
 
     FenceRef dependency    = device.CreateFence();
     FenceRef graphics_done = device.CreateFence();
-    FenceRef compute_done  = device.CreateFence();
+    FenceRef copy_done     = device.CreateFence();
 
     std::array<std::atomic<uint32>, 2> ordinary_callbacks{};
     std::array<std::atomic<uint32>, 2> success_callbacks{};
-    std::binary_semaphore              graphics_translated{0};
-    std::binary_semaphore              compute_translated{0};
-    bool                               dependency_rejected{false};
+    std::binary_semaphore graphics_translated{0};
+    bool                  dependency_rejected{false};
+    constexpr std::array<uint32, 4> expected{
+        0x15E10001u,
+        0x15E10002u,
+        0x15E10003u,
+        0x15E10004u,
+    };
+    std::array<uint32, expected.size()> readback{};
+    BufferRef destination = device.CreateBuffer<uint32>(
+        "phase15e_cross_batch_copy_recovery",
+        expected.size(),
+        EBufferUsageFlags::TRANSFER_SRC |
+            EBufferUsageFlags::TRANSFER_DST
+    );
 
     const auto reject_dependency = [&] {
         if (dependency_rejected) {
@@ -5558,69 +6106,69 @@ void RunBoundedCrossBatchRecoverableRejection() {
             );
         }
 
-        CommandList compute(EQueueType::Compute);
-        compute.SetResourceStateOwnership(
+        CommandList copy(EQueueType::Copy);
+        copy.SetResourceStateOwnership(
             ERHIResourceStateOwnership::Explicit
         );
-        compute.AddCustomCommand(
-            MakeUnique<TranslateProbeCommand>(
-                &compute_translated, EQueueType::Compute
-            ),
-            "PipelineRecoverableComputeTranslateProbe"
+        copy.CopyFrom(
+            OwnedBytes(expected),
+            destination->GetView(),
+            "PipelineRecoverableCopyUpload"
         );
-        compute.AddCallback([&] {
+        copy.CopyFrom(
+            destination->GetView(),
+            WritableBytes(readback),
+            "PipelineRecoverableCopyReadback"
+        );
+        copy.AddCallback([&] {
             ordinary_callbacks[1].fetch_add(
                 1, std::memory_order_relaxed
             );
         });
-        compute.AddSuccessCallback([&] {
+        copy.AddSuccessCallback([&] {
             success_callbacks[1].fetch_add(
                 1, std::memory_order_relaxed
             );
         });
-        CmdSubmit compute_submit = compute.Submit();
-        compute_submit.SetTranslateExecutionClass(
+        CmdSubmit copy_submit = copy.Submit();
+        copy_submit.SetTranslateExecutionClass(
             ERHITranslateExecutionClass::Parallel
         );
-        compute_submit.SetResourceStateOwnership(
+        copy_submit.SetResourceStateOwnership(
             ERHIResourceStateOwnership::Explicit
         );
-        compute_submit.async_queue_scope = async_queue_scope;
-        compute_submit.Signal(compute_done.Get(), 1);
+        copy_submit.async_queue_scope = async_queue_scope;
+        copy_submit.Signal(copy_done.Get(), 1);
 
         RHIExecutor::Get().Submit(
-            EQueueType::Compute,
-            std::move(compute_submit),
+            EQueueType::Copy,
+            std::move(copy_submit),
             ERHIExecSubmitFlags::FlushGPU
         );
 
-        bool compute_translate_observed = false;
-        if (distinct_native) {
-            compute_translate_observed =
-                compute_translated.try_acquire_for(5s);
-            if (!compute_translate_observed) {
+        bool copy_translate_observed = false;
+        if (!runtime_native_alias) {
+            copy_translate_observed =
+                translation_capture.copy_recorded.try_acquire_for(
+                    5s
+                );
+            if (!copy_translate_observed) {
                 throw std::runtime_error(
-                    "window 2 did not Translate recoverable batch 1 while "
-                    "batch 0 Submission was blocked"
+                    "window 2 did not record Copy batch 1 while batch 0 "
+                    "Submission was blocked"
                 );
             }
         } else {
-            compute_translate_observed =
-                compute_translated.try_acquire_for(250ms);
-            if (compute_translate_observed) {
-                throw std::runtime_error(
-                    "recoverable alias topology admitted batch 1 before "
-                    "batch 0 reached a terminal state"
-                );
-            }
             LOG_INFO(
                 "[TESTCASE][PASS] "
                 "name=BoundedCrossBatchRecoverableRejectionOverlap "
                 "requested_window=2 effective_window=1 "
                 "reason=native_queue_alias graphics_native={} "
-                "compute_native={} admission=blocked",
+                "compute_native={} copy_native={} admission=blocked "
+                "cpu_seam=RHISubmissionPipelinePolicy",
                 topology.graphics.native_queue_id,
-                topology.compute.native_queue_id
+                topology.compute.native_queue_id,
+                topology.copy.native_queue_id
             );
         }
 
@@ -5633,10 +6181,28 @@ void RunBoundedCrossBatchRecoverableRejection() {
         reject_dependency();
         RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
 
-        if (!compute_translate_observed &&
-            !compute_translated.try_acquire()) {
+        if (!translation_capture.Seen(
+                0,
+                EVulkanSourceTranslationPhase::Recorded
+            )) {
             throw std::runtime_error(
-                "recoverable batch 1 did not Translate after batch 0 rejection"
+                "recoverable Copy batch 1 never reached recorded state"
+            );
+        }
+        const VulkanSourceTranslationEvent& translation_event =
+            translation_capture.Event(
+                0,
+                EVulkanSourceTranslationPhase::Recorded
+            );
+        if (!translation_capture.IsValid() ||
+            translation_event.queue != EQueueType::Copy ||
+            translation_event.native_queue_id !=
+                topology.copy.native_queue_id ||
+            translation_event.thread_role !=
+                ERHIThreadRole::Translate) {
+            throw std::runtime_error(
+                "recoverable Copy translation lost queue identity or "
+                "Translate ownership"
             );
         }
         if (ResourceCast(graphics_done.Get())->HostWait(1) !=
@@ -5647,11 +6213,16 @@ void RunBoundedCrossBatchRecoverableRejection() {
                 "recoverable batch 0 did not reject its exact signal value"
             );
         }
-        if (ResourceCast(compute_done.Get())->HostWait(1) != VK_SUCCESS ||
-            ResourceCast(compute_done.Get())->IsRejected(1) ||
-            ResourceCast(compute_done.Get())->IsFailed()) {
+        if (ResourceCast(copy_done.Get())->HostWait(1) != VK_SUCCESS ||
+            ResourceCast(copy_done.Get())->IsRejected(1) ||
+            ResourceCast(copy_done.Get())->IsFailed()) {
             throw std::runtime_error(
                 "recoverable batch 0 rejection contaminated batch 1"
+            );
+        }
+        if (readback != expected) {
+            throw std::runtime_error(
+                "recoverable Copy batch 1 readback mismatch"
             );
         }
         if (ordinary_callbacks[0].load(std::memory_order_acquire) != 1 ||
@@ -5674,10 +6245,10 @@ void RunBoundedCrossBatchRecoverableRejection() {
         if (source_event.batch_sequence == 0 ||
             source_event.source_index != 0 ||
             source_event.original_source_index != 0 ||
-            source_event.queue != EQueueType::Compute ||
+            source_event.queue != EQueueType::Copy ||
             source_event.async_queue_scope != async_queue_scope) {
             throw std::runtime_error(
-                "recovered batch 1 lost stable source identity"
+                "recovered Copy batch 1 lost stable source identity"
             );
         }
 
@@ -5689,12 +6260,12 @@ void RunBoundedCrossBatchRecoverableRejection() {
         }
         const VulkanNativeSubmissionEvent& native_event =
             native_capture.Event(0);
-        if (native_event.queue != EQueueType::Compute ||
+        if (native_event.queue != EQueueType::Copy ||
             native_event.thread_role != ERHIThreadRole::Submission ||
             native_event.thread_id == main_thread_id ||
             !native_event.outcome.WasSubmitted()) {
             throw std::runtime_error(
-                "recovered batch 1 escaped stable Submission ownership"
+                "recovered Copy batch 1 escaped stable Submission ownership"
             );
         }
 
@@ -5722,12 +6293,14 @@ void RunBoundedCrossBatchRecoverableRejection() {
     LOG_INFO(
         "[TESTCASE][PASS] name=BoundedCrossBatchRecoverableRejection "
         "window=2 native_alias={} overlap_assertion={} batches=2 "
+        "queues=Graphics,Copy "
         "batch0_native_submit=0 batch0_callbacks=ordinary1_success0 "
         "batch0_signal=rejected batch1_native_submit=1 "
         "batch1_callbacks=ordinary1_success1 batch1_signal=success "
-        "native_owner=Submission replay=0",
-        !distinct_native,
-        distinct_native ? "verified" : "blocked"
+        "copy_translate_owner=Translate native_owner=Submission "
+        "readback=verified replay=0",
+        runtime_native_alias,
+        runtime_native_alias ? "blocked" : "verified"
     );
 }
 
@@ -5736,24 +6309,37 @@ void RunBoundedPipelineShutdownCancellation() {
 
     auto&                  device   = RenderDevice::Get();
     const RHIQueueTopology topology = device.GetQueueTopology();
-    if (!topology.graphics.available || !topology.compute.available) {
+    if (!topology.graphics.available || !topology.copy.available) {
         LOG_INFO(
             "[TESTCASE][SKIP] name=BoundedPipelineShutdownCancellation "
-            "window=2 reason=queue_unavailable graphics_native={} "
-            "compute_native={}",
+            "window=2 reason=queue_unavailable "
+            "graphics_available={} copy_available={} "
+            "graphics_native={} copy_native={}",
+            topology.graphics.available,
+            topology.copy.available,
             topology.graphics.native_queue_id,
-            topology.compute.native_queue_id
+            topology.copy.native_queue_id
         );
         return;
     }
 
-    constexpr uint64 async_queue_scope = 0x5048313544534844ull;
-    const bool distinct_native =
-        topology.graphics.native_queue_id != topology.compute.native_queue_id;
-    const uint32 main_thread_id = Platform::GetCurrentThreadID();
+    constexpr uint64 async_queue_scope =
+        0x5048313545534844ull;
+    const bool runtime_native_alias =
+        RHISubmissionPipelinePolicy::HasAvailableNativeLaneAlias(
+            topology
+        );
+    const uint32 main_thread_id =
+        Platform::GetCurrentThreadID();
 
     SourceSubmissionCapture        source_capture(async_queue_scope);
     ScopedSourceSubmissionObserver source_observer(source_capture);
+    SourceTranslationCapture        translation_capture(
+        async_queue_scope, EQueueType::Copy
+    );
+    ScopedSourceTranslationObserver translation_observer(
+        translation_capture
+    );
     NativeSubmissionCapture        native_capture{};
     ScopedNativeSubmissionObserver native_observer(native_capture);
     DependencyWaitCapture          graphics_wait_capture{EQueueType::Graphics};
@@ -5765,15 +6351,27 @@ void RunBoundedPipelineShutdownCancellation() {
 
     FenceRef dependency    = device.CreateFence();
     FenceRef graphics_done = device.CreateFence();
-    FenceRef compute_done  = device.CreateFence();
+    FenceRef copy_done     = device.CreateFence();
 
     std::array<std::atomic<uint32>, 2> ordinary_callbacks{};
     std::array<std::atomic<uint32>, 2> success_callbacks{};
-    std::binary_semaphore              graphics_translated{0};
-    std::binary_semaphore              compute_translated{0};
-    std::atomic<bool>                  sync_returned{false};
-    std::jthread                       sync_waiter{};
-    bool                               runtime_stopped{false};
+    std::binary_semaphore graphics_translated{0};
+    std::atomic<bool>     sync_returned{false};
+    std::jthread          sync_waiter{};
+    bool                  runtime_stopped{false};
+    constexpr std::array<uint32, 4> expected{
+        0x15E20001u,
+        0x15E20002u,
+        0x15E20003u,
+        0x15E20004u,
+    };
+    std::array<uint32, expected.size()> readback{};
+    BufferRef destination = device.CreateBuffer<uint32>(
+        "phase15e_shutdown_copy_suffix",
+        expected.size(),
+        EBufferUsageFlags::TRANSFER_SRC |
+            EBufferUsageFlags::TRANSFER_DST
+    );
 
     const auto stop_runtime = [&] {
         if (runtime_stopped) {
@@ -5832,69 +6430,69 @@ void RunBoundedPipelineShutdownCancellation() {
             );
         }
 
-        CommandList compute(EQueueType::Compute);
-        compute.SetResourceStateOwnership(
+        CommandList copy(EQueueType::Copy);
+        copy.SetResourceStateOwnership(
             ERHIResourceStateOwnership::Explicit
         );
-        compute.AddCustomCommand(
-            MakeUnique<TranslateProbeCommand>(
-                &compute_translated, EQueueType::Compute
-            ),
-            "PipelineShutdownComputeTranslateProbe"
+        copy.CopyFrom(
+            OwnedBytes(expected),
+            destination->GetView(),
+            "PipelineShutdownCopyUpload"
         );
-        compute.AddCallback([&] {
+        copy.CopyFrom(
+            destination->GetView(),
+            WritableBytes(readback),
+            "PipelineShutdownCopyReadback"
+        );
+        copy.AddCallback([&] {
             ordinary_callbacks[1].fetch_add(
                 1, std::memory_order_relaxed
             );
         });
-        compute.AddSuccessCallback([&] {
+        copy.AddSuccessCallback([&] {
             success_callbacks[1].fetch_add(
                 1, std::memory_order_relaxed
             );
         });
-        CmdSubmit compute_submit = compute.Submit();
-        compute_submit.SetTranslateExecutionClass(
+        CmdSubmit copy_submit = copy.Submit();
+        copy_submit.SetTranslateExecutionClass(
             ERHITranslateExecutionClass::Parallel
         );
-        compute_submit.SetResourceStateOwnership(
+        copy_submit.SetResourceStateOwnership(
             ERHIResourceStateOwnership::Explicit
         );
-        compute_submit.async_queue_scope = async_queue_scope;
-        compute_submit.Signal(compute_done.Get(), 1);
+        copy_submit.async_queue_scope = async_queue_scope;
+        copy_submit.Signal(copy_done.Get(), 1);
 
         RHIExecutor::Get().Submit(
-            EQueueType::Compute,
-            std::move(compute_submit),
+            EQueueType::Copy,
+            std::move(copy_submit),
             ERHIExecSubmitFlags::FlushGPU
         );
 
-        bool compute_translate_observed = false;
-        if (distinct_native) {
-            compute_translate_observed =
-                compute_translated.try_acquire_for(5s);
-            if (!compute_translate_observed) {
+        bool copy_translate_observed = false;
+        if (!runtime_native_alias) {
+            copy_translate_observed =
+                translation_capture.copy_recorded.try_acquire_for(
+                    5s
+                );
+            if (!copy_translate_observed) {
                 throw std::runtime_error(
-                    "window 2 did not Translate shutdown batch 1 while "
+                    "window 2 did not record shutdown Copy batch 1 while "
                     "batch 0 Submission was blocked"
                 );
             }
         } else {
-            compute_translate_observed =
-                compute_translated.try_acquire_for(250ms);
-            if (compute_translate_observed) {
-                throw std::runtime_error(
-                    "shutdown alias topology admitted batch 1 before "
-                    "batch 0 reached a terminal state"
-                );
-            }
             LOG_INFO(
                 "[TESTCASE][PASS] "
                 "name=BoundedPipelineShutdownCancellationOverlap "
                 "requested_window=2 effective_window=1 "
                 "reason=native_queue_alias graphics_native={} "
-                "compute_native={} admission=blocked",
+                "compute_native={} copy_native={} admission=blocked "
+                "cpu_seam=RHISubmissionPipelinePolicy",
                 topology.graphics.native_queue_id,
-                topology.compute.native_queue_id
+                topology.compute.native_queue_id,
+                topology.copy.native_queue_id
             );
         }
 
@@ -5920,10 +6518,29 @@ void RunBoundedPipelineShutdownCancellation() {
         stop_runtime();
         sync_waiter.join();
 
-        if (!compute_translate_observed &&
-            !compute_translated.try_acquire()) {
+        if (!translation_capture.Seen(
+                0,
+                EVulkanSourceTranslationPhase::Recorded
+            )) {
             throw std::runtime_error(
-                "shutdown batch 1 did not Translate while draining the pipeline"
+                "shutdown Copy batch 1 did not record while draining "
+                "the pipeline"
+            );
+        }
+        const VulkanSourceTranslationEvent& translation_event =
+            translation_capture.Event(
+                0,
+                EVulkanSourceTranslationPhase::Recorded
+            );
+        if (!translation_capture.IsValid() ||
+            translation_event.queue != EQueueType::Copy ||
+            translation_event.native_queue_id !=
+                topology.copy.native_queue_id ||
+            translation_event.thread_role !=
+                ERHIThreadRole::Translate) {
+            throw std::runtime_error(
+                "shutdown Copy batch lost Translate ownership or queue "
+                "identity"
             );
         }
         if (!sync_returned.load(std::memory_order_acquire)) {
@@ -5939,11 +6556,16 @@ void RunBoundedPipelineShutdownCancellation() {
                 "pipeline shutdown did not reject batch 0's exact signal value"
             );
         }
-        if (ResourceCast(compute_done.Get())->HostWait(1) != VK_SUCCESS ||
-            ResourceCast(compute_done.Get())->IsRejected(1) ||
-            ResourceCast(compute_done.Get())->IsFailed()) {
+        if (ResourceCast(copy_done.Get())->HostWait(1) != VK_SUCCESS ||
+            ResourceCast(copy_done.Get())->IsRejected(1) ||
+            ResourceCast(copy_done.Get())->IsFailed()) {
             throw std::runtime_error(
                 "pipeline shutdown did not drain batch 1 successfully"
+            );
+        }
+        if (readback != expected) {
+            throw std::runtime_error(
+                "pipeline shutdown Copy batch readback mismatch"
             );
         }
         if (ordinary_callbacks[0].load(std::memory_order_acquire) != 1 ||
@@ -5966,7 +6588,7 @@ void RunBoundedPipelineShutdownCancellation() {
         if (source_event.batch_sequence == 0 ||
             source_event.source_index != 0 ||
             source_event.original_source_index != 0 ||
-            source_event.queue != EQueueType::Compute ||
+            source_event.queue != EQueueType::Copy ||
             source_event.async_queue_scope != async_queue_scope) {
             throw std::runtime_error(
                 "pipeline shutdown lost drained batch 1 source identity"
@@ -5981,7 +6603,7 @@ void RunBoundedPipelineShutdownCancellation() {
         }
         const VulkanNativeSubmissionEvent& native_event =
             native_capture.Event(0);
-        if (native_event.queue != EQueueType::Compute ||
+        if (native_event.queue != EQueueType::Copy ||
             native_event.thread_role != ERHIThreadRole::Submission ||
             native_event.thread_id == main_thread_id ||
             !native_event.outcome.WasSubmitted()) {
@@ -6017,9 +6639,11 @@ void RunBoundedPipelineShutdownCancellation() {
         "window=2 native_alias={} overlap_assertion={} "
         "batch0_native_submit=0 batch1_native_submit=1 "
         "batch0_signal=rejected batch1_signal=success "
+        "queues=Graphics,Copy copy_translate_owner=Translate "
+        "native_owner=Submission readback=verified "
         "callbacks=exactly_once concurrent_sync=drained owners=stopped",
-        !distinct_native,
-        distinct_native ? "verified" : "blocked"
+        runtime_native_alias,
+        runtime_native_alias ? "blocked" : "verified"
     );
 }
 

--- a/source/test/RHISubmissionPipelinePolicyTest.cpp
+++ b/source/test/RHISubmissionPipelinePolicyTest.cpp
@@ -17,17 +17,21 @@ void Expect(bool _condition, const char* _message) {
     }
 }
 
-RHIQueueTopology MakeTopology(
+constexpr RHIQueueTopology MakeTopology(
     bool     _graphics_available,
     uint32_t _graphics_native,
     bool     _compute_available,
-    uint32_t _compute_native
+    uint32_t _compute_native,
+    bool     _copy_available,
+    uint32_t _copy_native
 ) {
     RHIQueueTopology topology{};
     topology.graphics.available       = _graphics_available;
     topology.graphics.native_queue_id = _graphics_native;
     topology.compute.available        = _compute_available;
     topology.compute.native_queue_id  = _compute_native;
+    topology.copy.available           = _copy_available;
+    topology.copy.native_queue_id     = _copy_native;
     return topology;
 }
 
@@ -54,25 +58,56 @@ void DistinctNativeQueuesPreserveTheClampedWindow() {
         RHIQueueTopology result{};
         result.graphics.native_queue_id = 3;
         result.compute.native_queue_id  = 7;
+        result.copy.native_queue_id     = 11;
         return result;
     }();
     static_assert(!GraphicsComputeShareNativeLane(topology));
+    static_assert(!HasAvailableNativeLaneAlias(topology));
     static_assert(ResolveEffectiveBatchWindow(0, topology) == 1);
     static_assert(ResolveEffectiveBatchWindow(2, topology) == 2);
     static_assert(ResolveEffectiveBatchWindow(9, topology) == 8);
 }
 
-void GraphicsComputeAliasForcesOneBatchInFlight() {
+void AnyAvailableNativeLaneAliasForcesOneBatchInFlight() {
     using namespace RHISubmissionPipelinePolicy;
 
-    const RHIQueueTopology topology = MakeTopology(true, 5, true, 5);
+    constexpr RHIQueueTopology graphics_compute =
+        MakeTopology(true, 5, true, 5, true, 9);
     Expect(
-        GraphicsComputeShareNativeLane(topology),
+        GraphicsComputeShareNativeLane(graphics_compute),
         "available Graphics/Compute alias was not detected"
     );
     Expect(
-        ResolveEffectiveBatchWindow(8, topology) == 1,
+        HasAvailableNativeLaneAlias(graphics_compute) &&
+            ResolveEffectiveBatchWindow(8, graphics_compute) == 1,
         "Graphics/Compute alias did not force a single in-flight batch"
+    );
+
+    constexpr RHIQueueTopology graphics_copy =
+        MakeTopology(true, 13, true, 17, true, 13);
+    static_assert(!GraphicsComputeShareNativeLane(graphics_copy));
+    Expect(
+        HasAvailableNativeLaneAlias(graphics_copy) &&
+            ResolveEffectiveBatchWindow(8, graphics_copy) == 1,
+        "Graphics/Copy alias did not force a single in-flight batch"
+    );
+
+    constexpr RHIQueueTopology compute_copy =
+        MakeTopology(true, 19, true, 23, true, 23);
+    static_assert(!GraphicsComputeShareNativeLane(compute_copy));
+    Expect(
+        HasAvailableNativeLaneAlias(compute_copy) &&
+            ResolveEffectiveBatchWindow(8, compute_copy) == 1,
+        "Compute/Copy alias did not force a single in-flight batch"
+    );
+
+    constexpr RHIQueueTopology all_alias =
+        MakeTopology(true, 29, true, 29, true, 29);
+    Expect(
+        GraphicsComputeShareNativeLane(all_alias) &&
+            HasAvailableNativeLaneAlias(all_alias) &&
+            ResolveEffectiveBatchWindow(8, all_alias) == 1,
+        "three-way native queue alias did not force a single in-flight batch"
     );
 }
 
@@ -80,9 +115,10 @@ void UnavailableLogicalQueuesDoNotTriggerAliasFallback() {
     using namespace RHISubmissionPipelinePolicy;
 
     const RHIQueueTopology compute_unavailable =
-        MakeTopology(true, 0, false, 0);
+        MakeTopology(true, 0, false, 0, true, 2);
     Expect(
-        !GraphicsComputeShareNativeLane(compute_unavailable),
+        !GraphicsComputeShareNativeLane(compute_unavailable) &&
+            !HasAvailableNativeLaneAlias(compute_unavailable),
         "unavailable Compute queue triggered alias fallback"
     );
     Expect(
@@ -91,14 +127,34 @@ void UnavailableLogicalQueuesDoNotTriggerAliasFallback() {
     );
 
     const RHIQueueTopology graphics_unavailable =
-        MakeTopology(false, 11, true, 11);
+        MakeTopology(false, 11, true, 11, true, 17);
     Expect(
-        !GraphicsComputeShareNativeLane(graphics_unavailable),
+        !GraphicsComputeShareNativeLane(graphics_unavailable) &&
+            !HasAvailableNativeLaneAlias(graphics_unavailable),
         "unavailable Graphics queue triggered alias fallback"
     );
     Expect(
         ResolveEffectiveBatchWindow(9, graphics_unavailable) == 8,
         "unavailable Graphics queue bypassed the ordinary clamp"
+    );
+
+    const RHIQueueTopology copy_unavailable =
+        MakeTopology(true, 31, true, 37, false, 31);
+    Expect(
+        !HasAvailableNativeLaneAlias(copy_unavailable),
+        "unavailable Copy queue triggered alias fallback"
+    );
+    Expect(
+        ResolveEffectiveBatchWindow(6, copy_unavailable) == 6,
+        "unavailable Copy queue changed the configured batch window"
+    );
+
+    const RHIQueueTopology only_copy_available =
+        MakeTopology(false, 41, false, 41, true, 41);
+    Expect(
+        !HasAvailableNativeLaneAlias(only_copy_available) &&
+            ResolveEffectiveBatchWindow(3, only_copy_available) == 3,
+        "unavailable duplicate logical queues aliased the sole available Copy queue"
     );
 }
 
@@ -221,7 +277,7 @@ int main() {
     try {
         ClampContract();
         DistinctNativeQueuesPreserveTheClampedWindow();
-        GraphicsComputeAliasForcesOneBatchInFlight();
+        AnyAvailableNativeLaneAliasForcesOneBatchInFlight();
         UnavailableLogicalQueuesDoNotTriggerAliasFallback();
         BatchWorkStateSequentialContract();
         BatchWorkStateSealFinishRaceHasOneTerminalOwner();

--- a/source/test/VulkanTranslateWaveSchedulerTest.cpp
+++ b/source/test/VulkanTranslateWaveSchedulerTest.cpp
@@ -68,6 +68,59 @@ void IndependentNativeQueuesShareAStableWave() {
     );
 }
 
+void GraphicsComputeCopyShareTheFirstReadyWave() {
+    const std::array nodes{
+        // Graphics front.
+        TranslateWaveNode{.key = Key(0), .native_queue_id = 40, .async_translate = true},
+        // Graphics tail shares the same physical lane as the front.
+        TranslateWaveNode{.key = Key(1), .native_queue_id = 40, .async_translate = true},
+        // Independent Compute and Copy lanes.
+        TranslateWaveNode{.key = Key(2), .native_queue_id = 41, .async_translate = true},
+        TranslateWaveNode{.key = Key(3), .native_queue_id = 42, .async_translate = true},
+    };
+
+    TranslateWaveScheduler scheduler;
+    Expect(scheduler.Build(nodes), "Graphics/Compute/Copy topology failed to build");
+    ExpectWave(
+        scheduler.NextWave(),
+        {Key(0), Key(2), Key(3)},
+        "first ready wave did not expose Graphics, Compute, and Copy"
+    );
+    Expect(
+        scheduler.MarkTranslated(Key(3)) && scheduler.MarkTranslated(Key(2)) &&
+            scheduler.MarkTranslated(Key(0)),
+        "independent Graphics/Compute/Copy lanes could not translate out of order"
+    );
+    ExpectWave(
+        scheduler.NextWave(),
+        {},
+        "same-native Graphics tail started before its packet predecessor released"
+    );
+    Expect(
+        scheduler.MarkReleased(Key(0)),
+        "Graphics front packet did not release its native lane"
+    );
+    ExpectWave(
+        scheduler.NextWave(),
+        {Key(1)},
+        "Graphics front release did not unlock its same-native tail"
+    );
+    Expect(
+        scheduler.MarkTranslated(Key(1)) &&
+            scheduler.MarkReleased(Key(1)) &&
+            scheduler.MarkReleased(Key(2)) &&
+            scheduler.MarkReleased(Key(3)) &&
+            scheduler.IsComplete(),
+        "Graphics/Compute/Copy packets did not retire exactly once"
+    );
+    Expect(
+        !scheduler.MarkReleased(Key(0)) &&
+            !scheduler.MarkReleased(Key(2)) &&
+            !scheduler.MarkReleased(Key(3)),
+        "Graphics/Compute/Copy packet release was accepted more than once"
+    );
+}
+
 void SameNativeQueueWaitsForReleaseWithoutBlockingAnotherLane() {
     const std::array nodes{
         TranslateWaveNode{.key = Key(0), .native_queue_id = 4, .async_translate = true},
@@ -96,6 +149,90 @@ void SameNativeQueueWaitsForReleaseWithoutBlockingAnotherLane() {
         scheduler.MarkTranslated(Key(1)) && scheduler.MarkReleased(Key(1)) &&
             scheduler.MarkReleased(Key(2)) && scheduler.IsComplete(),
         "held later-lane packet did not preserve ordered-release ownership"
+    );
+}
+
+void GraphicsCopyAliasWaitsForReleaseWithoutBlockingCompute() {
+    const std::array nodes{
+        // Graphics and Copy are distinct logical queues on native lane 50.
+        TranslateWaveNode{.key = Key(0), .native_queue_id = 50, .async_translate = true},
+        TranslateWaveNode{.key = Key(1), .native_queue_id = 50, .async_translate = true},
+        TranslateWaveNode{.key = Key(2), .native_queue_id = 51, .async_translate = true},
+    };
+
+    TranslateWaveScheduler scheduler;
+    Expect(scheduler.Build(nodes), "Graphics/Copy alias topology failed to build");
+    ExpectWave(
+        scheduler.NextWave(),
+        {Key(0), Key(2)},
+        "Graphics/Copy alias hid its independent Compute lane"
+    );
+    Expect(
+        scheduler.MarkTranslated(Key(0)) && scheduler.MarkTranslated(Key(2)),
+        "Graphics/Compute first wave did not finish translation"
+    );
+    ExpectWave(
+        scheduler.NextWave(),
+        {},
+        "Copy entered Translate before its aliased Graphics packet released"
+    );
+    Expect(
+        scheduler.MarkReleased(Key(0)),
+        "Graphics packet did not release its aliased Copy lane"
+    );
+    ExpectWave(
+        scheduler.NextWave(),
+        {Key(1)},
+        "Graphics release did not unlock its aliased Copy successor"
+    );
+    Expect(
+        scheduler.MarkTranslated(Key(1)) &&
+            scheduler.MarkReleased(Key(1)) &&
+            scheduler.MarkReleased(Key(2)) &&
+            scheduler.IsComplete(),
+        "Graphics/Copy alias packets did not retire exactly once"
+    );
+}
+
+void ComputeCopyAliasWaitsForReleaseWithoutBlockingGraphics() {
+    const std::array nodes{
+        // Compute and Copy are distinct logical queues on native lane 60.
+        TranslateWaveNode{.key = Key(0), .native_queue_id = 60, .async_translate = true},
+        TranslateWaveNode{.key = Key(1), .native_queue_id = 60, .async_translate = true},
+        TranslateWaveNode{.key = Key(2), .native_queue_id = 61, .async_translate = true},
+    };
+
+    TranslateWaveScheduler scheduler;
+    Expect(scheduler.Build(nodes), "Compute/Copy alias topology failed to build");
+    ExpectWave(
+        scheduler.NextWave(),
+        {Key(0), Key(2)},
+        "Compute/Copy alias hid its independent Graphics lane"
+    );
+    Expect(
+        scheduler.MarkTranslated(Key(0)) && scheduler.MarkTranslated(Key(2)),
+        "Compute/Graphics first wave did not finish translation"
+    );
+    ExpectWave(
+        scheduler.NextWave(),
+        {},
+        "Copy entered Translate before its aliased Compute packet released"
+    );
+    Expect(
+        scheduler.MarkReleased(Key(0)),
+        "Compute packet did not release its aliased Copy lane"
+    );
+    ExpectWave(
+        scheduler.NextWave(),
+        {Key(1)},
+        "Compute release did not unlock its aliased Copy successor"
+    );
+    Expect(
+        scheduler.MarkTranslated(Key(1)) &&
+            scheduler.MarkReleased(Key(1)) &&
+            scheduler.MarkReleased(Key(2)) &&
+            scheduler.IsComplete(),
+        "Compute/Copy alias packets did not retire exactly once"
     );
 }
 
@@ -240,17 +377,21 @@ void UnknownAndFutureDependenciesFailClosed() {
     );
 }
 
-void CancellationRetainsOnlyOutstandingPacketLeases() {
+void CancellationRetainsOnlyOutstandingGraphicsCopyPacketLeases() {
     const std::array nodes{
+        // Graphics front and Copy tail alias native lane 31.
         TranslateWaveNode{.key = Key(0), .native_queue_id = 31, .async_translate = true},
         TranslateWaveNode{.key = Key(1), .native_queue_id = 31, .async_translate = true},
+        // Compute remains independently ready.
         TranslateWaveNode{.key = Key(2), .native_queue_id = 32, .async_translate = true},
     };
 
     TranslateWaveScheduler scheduler;
-    Expect(scheduler.Build(nodes), "cancellation topology failed to build");
+    Expect(scheduler.Build(nodes), "Graphics/Copy cancellation topology failed to build");
     ExpectWave(
-        scheduler.NextWave(), {Key(0), Key(2)}, "cancellation fixture did not expose every ready native lane"
+        scheduler.NextWave(),
+        {Key(0), Key(2)},
+        "Graphics/Copy cancellation fixture did not expose every ready native lane"
     );
     scheduler.Cancel();
     Expect(scheduler.IsCancelled() && !scheduler.IsComplete(), "cancellation lost an in-flight packet lease");
@@ -284,12 +425,15 @@ void EmptyBuildIsImmediatelyComplete() {
 int main() {
     try {
         IndependentNativeQueuesShareAStableWave();
+        GraphicsComputeCopyShareTheFirstReadyWave();
         SameNativeQueueWaitsForReleaseWithoutBlockingAnotherLane();
+        GraphicsCopyAliasWaitsForReleaseWithoutBlockingCompute();
+        ComputeCopyAliasWaitsForReleaseWithoutBlockingGraphics();
         ExplicitDependencyUnlocksAtTranslated();
         FanInAndFanOutRemainDeterministic();
         NonAsyncNodeIsAnExclusiveReleaseBoundary();
         UnknownAndFutureDependenciesFailClosed();
-        CancellationRetainsOnlyOutstandingPacketLeases();
+        CancellationRetainsOnlyOutstandingGraphicsCopyPacketLeases();
         EmptyBuildIsImmediatelyComplete();
         std::cout << "Vulkan translate-wave scheduler tests passed\n";
         return 0;

--- a/tools/threading/README.md
+++ b/tools/threading/README.md
@@ -359,7 +359,7 @@ changes, and native copy/clear calls contribute units; GPU byte counts,
 dispatch group counts, and indirect draw counts do not. A wave needs at least
 two qualifying jobs, otherwise it safely uses the serial recorder.
 
-Run the seven-mode Vulkan correctness/fallback gate after building the target:
+Run the nine-mode Vulkan correctness/fallback gate after building the target:
 
 ```powershell
 python tools/threading/run_parallel_record_vulkan_test.py `
@@ -369,17 +369,30 @@ python tools/threading/run_parallel_record_vulkan_test.py `
 
 The runner checks serial, forced-parallel, injected worker failure, production
 gate rejection, production-heavy admission, hard cross-queue Translate failure
-retirement, and multi-segment prefix-submit/suffix-failure retirement. It
-requires real worker overlap, stable
+retirement, multi-segment prefix-submit/suffix-failure retirement, and bounded
+Submission-pipeline windows 1 and 2. It requires real worker overlap, stable
 `wave -> serial island -> wave` assembly, GPU readback correctness, exact
 failure/fallback counts, no native submit after the injected hard fault, and
 clean Vulkan logs. The ready-native-lane gate accepts a PASS only when the
-`G,G,C` source order produces first-ready `G,C` Translate lanes and an actually
-observed serial Submission-owner order of `G,G,C`; a SKIP is limited to an
-unavailable or aliased native queue and must retain the CPU scheduler seam.
-The recoverable gate also requires matching native-lane/suffix-recording
-observations, exact rejected signals, exactly-once callbacks, and successful
-same-scope runtime re-entry.
+`G,G,C,Copy` source order produces first-ready `G,C,Copy` Translate lanes and
+an actually observed serial Submission-owner order of `G,G,C,Copy`. When Copy
+aliases Graphics or Compute, the marker must explicitly report
+`first_ready_lanes=alias_fallback`; Graphics and Compute still need distinct
+native lanes. A SKIP is limited to queue unavailability or a
+Graphics/Compute native alias, must report all three native queue identities,
+and must retain the `VulkanTranslateWaveScheduler` CPU seam.
+
+The recoverable and shutdown gates use a Graphics-to-Copy suffix to prove that
+Copy translation remains on the Translate owner, native submission remains on
+the Submission owner, the readback is verified, callbacks retire exactly once,
+and rejected work is neither natively submitted nor replayed. Bounded window-2
+overlap falls back to effective window 1 when any available
+Graphics/Compute/Copy native-queue pair aliases. Its overlap marker must carry
+all three stable queue identities, blocked admission, and the
+`RHISubmissionPipelinePolicy` CPU seam. A focused bounded subtest may report
+`reason=queue_unavailable` only when its required logical queues are absent;
+the runner validates that SKIP separately instead of weakening the remaining
+available-queue contracts.
 
 For Release A/B, enable `parallel_record_profile` in isolated configs and feed
 at least two independent logs per side to `parallel_record_ab.py`. The parser

--- a/tools/threading/run_parallel_record_vulkan_test.py
+++ b/tools/threading/run_parallel_record_vulkan_test.py
@@ -30,6 +30,10 @@ def _require(condition: bool, message: str) -> None:
         raise VulkanTestError(message)
 
 
+def _native_ids_have_alias(*native_ids: str) -> bool:
+    return len(set(native_ids)) != len(native_ids)
+
+
 def _testcase_marker(name: str, text: str) -> tuple[str, dict[str, str]] | None:
     matches = list(
         re.finditer(
@@ -359,45 +363,78 @@ def _require_bounded_cross_batch_pipeline(mode: str, text: str) -> None:
         "BoundedCrossBatchSubmissionPipeline", text
     )
     _require(
-        pipeline is not None and pipeline[0] == "PASS",
-        f"{mode}: missing bounded cross-batch pipeline PASS marker",
+        pipeline is not None,
+        f"{mode}: missing bounded cross-batch pipeline terminal marker",
     )
-    _, fields = pipeline
-    native_alias = fields.get("native_alias")
-    expected_overlap = (
-        "blocked"
-        if expected_window == "1" or native_alias == "true"
-        else "verified"
-    )
-    _require(
-        fields.get("window") == expected_window
-        and native_alias in {"true", "false"}
-        and fields.get("overlap_assertion") == expected_overlap
-        and fields.get("batches") == "2"
-        and fields.get("queues") == "Graphics,Compute"
-        and fields.get("source_order") == "G,C"
-        and fields.get("native_owner") == "Submission"
-        and fields.get("signals") == "success"
-        and fields.get("callbacks") == "exactly_once"
-        and fields.get("replay") == "0",
-        f"{mode}: incomplete bounded cross-batch pipeline contract",
-    )
+    pipeline_status, fields = pipeline
+    pipeline_skipped = pipeline_status == "SKIP"
+    native_alias: str | None = None
+    pipeline_graphics_available = "true"
+    pipeline_compute_available = "true"
+    if pipeline_skipped:
+        pipeline_graphics_available = fields.get(
+            "graphics_available", ""
+        )
+        pipeline_compute_available = fields.get(
+            "compute_available", ""
+        )
+        _require(
+            fields.get("window") == expected_window
+            and fields.get("reason") == "queue_unavailable"
+            and pipeline_graphics_available in {"true", "false"}
+            and pipeline_compute_available in {"true", "false"}
+            and "false"
+            in {
+                pipeline_graphics_available,
+                pipeline_compute_available,
+            }
+            and fields.get("graphics_native") is not None
+            and fields.get("compute_native") is not None,
+            f"{mode}: invalid bounded cross-batch pipeline SKIP contract",
+        )
+    else:
+        _require(
+            pipeline_status == "PASS",
+            f"{mode}: invalid bounded cross-batch pipeline terminal marker",
+        )
+        native_alias = fields.get("native_alias")
+        expected_overlap = (
+            "blocked"
+            if expected_window == "1" or native_alias == "true"
+            else "verified"
+        )
+        _require(
+            fields.get("window") == expected_window
+            and native_alias in {"true", "false"}
+            and fields.get("overlap_assertion") == expected_overlap
+            and fields.get("batches") == "2"
+            and fields.get("queues") == "Graphics,Compute"
+            and fields.get("source_order") == "G,C"
+            and fields.get("native_owner") == "Submission"
+            and fields.get("signals") == "success"
+            and fields.get("callbacks") == "exactly_once"
+            and fields.get("replay") == "0",
+            f"{mode}: incomplete bounded cross-batch pipeline contract",
+        )
 
     overlap = _testcase_marker(
         "BoundedCrossBatchSubmissionPipelineOverlap", text
     )
     require_overlap_marker = (
-        expected_window == "2" and native_alias == "true"
+        not pipeline_skipped
+        and expected_window == "2"
+        and native_alias == "true"
     )
     _require(
         (overlap is not None) == require_overlap_marker,
         f"{mode}: invalid bounded cross-batch alias overlap marker presence contract",
     )
-    alias_native_ids: tuple[str, str] | None = None
+    alias_native_ids: tuple[str, str, str] | None = None
     if overlap is not None:
         overlap_status, overlap_fields = overlap
         graphics_native = overlap_fields.get("graphics_native")
         compute_native = overlap_fields.get("compute_native")
+        copy_native = overlap_fields.get("copy_native")
         _require(
             expected_window == "2"
             and native_alias == "true"
@@ -407,11 +444,18 @@ def _require_bounded_cross_batch_pipeline(mode: str, text: str) -> None:
             and overlap_fields.get("reason") == "native_queue_alias"
             and graphics_native is not None
             and compute_native is not None
-            and graphics_native == compute_native
+            and copy_native is not None
+            and _native_ids_have_alias(
+                graphics_native, compute_native, copy_native
+            )
             and overlap_fields.get("admission") == "blocked",
             f"{mode}: invalid bounded cross-batch alias fallback contract",
         )
-        alias_native_ids = (graphics_native, compute_native)
+        alias_native_ids = (
+            graphics_native,
+            compute_native,
+            copy_native,
+        )
 
     if expected_window == "1":
         return
@@ -420,56 +464,96 @@ def _require_bounded_cross_batch_pipeline(mode: str, text: str) -> None:
         "BoundedCrossBatchMalformedPreflightOrdering", text
     )
     _require(
-        malformed is not None and malformed[0] == "PASS",
-        f"{mode}: missing malformed-preflight ordering PASS marker",
+        malformed is not None,
+        f"{mode}: missing malformed-preflight ordering terminal marker",
     )
-    _, malformed_fields = malformed
-    _require(
-        malformed_fields.get("window") == "2"
-        and malformed_fields.get("batches") == "2"
-        and malformed_fields.get("queue") == "Graphics"
-        and malformed_fields.get("prefix") == "committed"
-        and malformed_fields.get("malformed") == "rejected"
-        and malformed_fields.get("callback_order") == "prefix,malformed"
-        and malformed_fields.get("signals") == "success,rejected"
-        and malformed_fields.get("native_owner") == "Submission"
-        and malformed_fields.get("replay") == "0"
-        and malformed_fields.get("malformed_translate") == "0"
-        and malformed_fields.get("runtime") == "restarted",
-        f"{mode}: incomplete malformed-preflight ordering contract",
-    )
+    malformed_status, malformed_fields = malformed
+    if malformed_status == "SKIP":
+        _require(
+            malformed_fields.get("reason")
+            == "graphics_queue_unavailable"
+            and pipeline_graphics_available == "false",
+            f"{mode}: invalid malformed-preflight ordering SKIP contract",
+        )
+    else:
+        _require(
+            malformed_status == "PASS"
+            and pipeline_graphics_available == "true"
+            and malformed_fields.get("window") == "2"
+            and malformed_fields.get("batches") == "2"
+            and malformed_fields.get("queue") == "Graphics"
+            and malformed_fields.get("prefix") == "committed"
+            and malformed_fields.get("malformed") == "rejected"
+            and malformed_fields.get("callback_order")
+            == "prefix,malformed"
+            and malformed_fields.get("signals") == "success,rejected"
+            and malformed_fields.get("native_owner") == "Submission"
+            and malformed_fields.get("replay") == "0"
+            and malformed_fields.get("malformed_translate") == "0"
+            and malformed_fields.get("runtime") == "restarted",
+            f"{mode}: incomplete malformed-preflight ordering contract",
+        )
 
     rejection = _testcase_marker(
         "BoundedCrossBatchRecoverableRejection", text
     )
     _require(
-        rejection is not None and rejection[0] == "PASS",
-        f"{mode}: missing bounded cross-batch recoverable rejection PASS marker",
+        rejection is not None,
+        f"{mode}: missing bounded recoverable rejection terminal marker",
     )
-    _, rejection_fields = rejection
-    rejection_native_alias = rejection_fields.get("native_alias")
-    expected_rejection_overlap = (
-        "blocked" if rejection_native_alias == "true" else "verified"
-    )
-    _require(
-        rejection_fields.get("window") == "2"
-        and rejection_native_alias in {"true", "false"}
-        and rejection_native_alias == native_alias
-        and rejection_fields.get("overlap_assertion")
-        == expected_rejection_overlap
-        and rejection_fields.get("batches") == "2"
-        and rejection_fields.get("batch0_native_submit") == "0"
-        and rejection_fields.get("batch0_callbacks")
-        == "ordinary1_success0"
-        and rejection_fields.get("batch0_signal") == "rejected"
-        and rejection_fields.get("batch1_native_submit") == "1"
-        and rejection_fields.get("batch1_callbacks")
-        == "ordinary1_success1"
-        and rejection_fields.get("batch1_signal") == "success"
-        and rejection_fields.get("native_owner") == "Submission"
-        and rejection_fields.get("replay") == "0",
-        f"{mode}: incomplete bounded cross-batch recoverable rejection contract",
-    )
+    rejection_status, rejection_fields = rejection
+    rejection_native_alias: str | None = None
+    rejection_availability = ("true", "true")
+    if rejection_status == "SKIP":
+        rejection_availability = (
+            rejection_fields.get("graphics_available", ""),
+            rejection_fields.get("copy_available", ""),
+        )
+        _require(
+            rejection_fields.get("window") == "2"
+            and rejection_fields.get("reason") == "queue_unavailable"
+            and all(
+                value in {"true", "false"}
+                for value in rejection_availability
+            )
+            and "false" in rejection_availability
+            and rejection_fields.get("graphics_native") is not None
+            and rejection_fields.get("copy_native") is not None,
+            f"{mode}: invalid bounded recoverable rejection SKIP contract",
+        )
+    else:
+        rejection_native_alias = rejection_fields.get("native_alias")
+        expected_rejection_overlap = (
+            "blocked"
+            if rejection_native_alias == "true"
+            else "verified"
+        )
+        _require(
+            rejection_status == "PASS"
+            and rejection_fields.get("window") == "2"
+            and rejection_native_alias in {"true", "false"}
+            and (
+                native_alias is None
+                or rejection_native_alias == native_alias
+            )
+            and rejection_fields.get("overlap_assertion")
+            == expected_rejection_overlap
+            and rejection_fields.get("batches") == "2"
+            and rejection_fields.get("queues") == "Graphics,Copy"
+            and rejection_fields.get("batch0_native_submit") == "0"
+            and rejection_fields.get("batch0_callbacks")
+            == "ordinary1_success0"
+            and rejection_fields.get("batch0_signal") == "rejected"
+            and rejection_fields.get("batch1_native_submit") == "1"
+            and rejection_fields.get("batch1_callbacks")
+            == "ordinary1_success1"
+            and rejection_fields.get("batch1_signal") == "success"
+            and rejection_fields.get("copy_translate_owner") == "Translate"
+            and rejection_fields.get("native_owner") == "Submission"
+            and rejection_fields.get("readback") == "verified"
+            and rejection_fields.get("replay") == "0",
+            f"{mode}: incomplete bounded cross-batch recoverable rejection contract",
+        )
 
     rejection_overlap = _testcase_marker(
         "BoundedCrossBatchRecoverableRejectionOverlap", text
@@ -483,6 +567,7 @@ def _require_bounded_cross_batch_pipeline(mode: str, text: str) -> None:
         rejection_overlap_status, rejection_overlap_fields = rejection_overlap
         graphics_native = rejection_overlap_fields.get("graphics_native")
         compute_native = rejection_overlap_fields.get("compute_native")
+        copy_native = rejection_overlap_fields.get("copy_native")
         _require(
             rejection_overlap_status == "PASS"
             and rejection_overlap_fields.get("requested_window") == "2"
@@ -491,39 +576,99 @@ def _require_bounded_cross_batch_pipeline(mode: str, text: str) -> None:
             == "native_queue_alias"
             and graphics_native is not None
             and compute_native is not None
-            and graphics_native == compute_native
-            and (graphics_native, compute_native) == alias_native_ids
-            and rejection_overlap_fields.get("admission") == "blocked",
+            and copy_native is not None
+            and _native_ids_have_alias(
+                graphics_native, compute_native, copy_native
+            )
+            and (
+                alias_native_ids is None
+                or (
+                    graphics_native,
+                    compute_native,
+                    copy_native,
+                )
+                == alias_native_ids
+            )
+            and rejection_overlap_fields.get("admission") == "blocked"
+            and rejection_overlap_fields.get("cpu_seam")
+            == "RHISubmissionPipelinePolicy",
             f"{mode}: invalid bounded recoverable alias fallback contract",
         )
+        if alias_native_ids is None:
+            alias_native_ids = (
+                graphics_native,
+                compute_native,
+                copy_native,
+            )
 
     shutdown = _testcase_marker(
         "BoundedPipelineShutdownCancellation", text
     )
     _require(
-        shutdown is not None and shutdown[0] == "PASS",
-        f"{mode}: missing bounded pipeline shutdown cancellation PASS marker",
+        shutdown is not None,
+        f"{mode}: missing bounded shutdown cancellation terminal marker",
     )
-    _, shutdown_fields = shutdown
-    shutdown_native_alias = shutdown_fields.get("native_alias")
-    expected_shutdown_overlap = (
-        "blocked" if shutdown_native_alias == "true" else "verified"
+    shutdown_status, shutdown_fields = shutdown
+    shutdown_native_alias: str | None = None
+    shutdown_availability = ("true", "true")
+    if shutdown_status == "SKIP":
+        shutdown_availability = (
+            shutdown_fields.get("graphics_available", ""),
+            shutdown_fields.get("copy_available", ""),
+        )
+        _require(
+            shutdown_fields.get("window") == "2"
+            and shutdown_fields.get("reason") == "queue_unavailable"
+            and all(
+                value in {"true", "false"}
+                for value in shutdown_availability
+            )
+            and "false" in shutdown_availability
+            and shutdown_fields.get("graphics_native") is not None
+            and shutdown_fields.get("copy_native") is not None,
+            f"{mode}: invalid bounded shutdown cancellation SKIP contract",
+        )
+    else:
+        shutdown_native_alias = shutdown_fields.get("native_alias")
+        expected_shutdown_overlap = (
+            "blocked"
+            if shutdown_native_alias == "true"
+            else "verified"
+        )
+        _require(
+            shutdown_status == "PASS"
+            and shutdown_fields.get("window") == "2"
+            and shutdown_native_alias in {"true", "false"}
+            and (
+                native_alias is None
+                or shutdown_native_alias == native_alias
+            )
+            and (
+                rejection_native_alias is None
+                or shutdown_native_alias == rejection_native_alias
+            )
+            and shutdown_fields.get("overlap_assertion")
+            == expected_shutdown_overlap
+            and shutdown_fields.get("queues") == "Graphics,Copy"
+            and shutdown_fields.get("batch0_native_submit") == "0"
+            and shutdown_fields.get("batch1_native_submit") == "1"
+            and shutdown_fields.get("batch0_signal") == "rejected"
+            and shutdown_fields.get("batch1_signal") == "success"
+            and shutdown_fields.get("copy_translate_owner") == "Translate"
+            and shutdown_fields.get("native_owner") == "Submission"
+            and shutdown_fields.get("readback") == "verified"
+            and shutdown_fields.get("callbacks") == "exactly_once"
+            and shutdown_fields.get("concurrent_sync") == "drained"
+            and shutdown_fields.get("owners") == "stopped",
+            f"{mode}: incomplete bounded pipeline shutdown cancellation contract",
+        )
+    _require(
+        shutdown_availability == rejection_availability,
+        f"{mode}: inconsistent bounded Graphics/Copy availability contract",
     )
     _require(
-        shutdown_fields.get("window") == "2"
-        and shutdown_native_alias in {"true", "false"}
-        and shutdown_native_alias == native_alias
-        and shutdown_native_alias == rejection_native_alias
-        and shutdown_fields.get("overlap_assertion")
-        == expected_shutdown_overlap
-        and shutdown_fields.get("batch0_native_submit") == "0"
-        and shutdown_fields.get("batch1_native_submit") == "1"
-        and shutdown_fields.get("batch0_signal") == "rejected"
-        and shutdown_fields.get("batch1_signal") == "success"
-        and shutdown_fields.get("callbacks") == "exactly_once"
-        and shutdown_fields.get("concurrent_sync") == "drained"
-        and shutdown_fields.get("owners") == "stopped",
-        f"{mode}: incomplete bounded pipeline shutdown cancellation contract",
+        rejection_availability[0] == pipeline_graphics_available,
+        f"{mode}: inconsistent bounded pipeline Graphics availability contract",
     )
 
     shutdown_overlap = _testcase_marker(
@@ -539,6 +684,7 @@ def _require_bounded_cross_batch_pipeline(mode: str, text: str) -> None:
     shutdown_overlap_status, shutdown_overlap_fields = shutdown_overlap
     graphics_native = shutdown_overlap_fields.get("graphics_native")
     compute_native = shutdown_overlap_fields.get("compute_native")
+    copy_native = shutdown_overlap_fields.get("copy_native")
     _require(
         shutdown_native_alias == "true"
         and shutdown_overlap_status == "PASS"
@@ -547,9 +693,19 @@ def _require_bounded_cross_batch_pipeline(mode: str, text: str) -> None:
         and shutdown_overlap_fields.get("reason") == "native_queue_alias"
         and graphics_native is not None
         and compute_native is not None
-        and graphics_native == compute_native
-        and (graphics_native, compute_native) == alias_native_ids
-        and shutdown_overlap_fields.get("admission") == "blocked",
+        and copy_native is not None
+        and _native_ids_have_alias(
+            graphics_native, compute_native, copy_native
+        )
+        and (
+            graphics_native,
+            compute_native,
+            copy_native,
+        )
+        == alias_native_ids
+        and shutdown_overlap_fields.get("admission") == "blocked"
+        and shutdown_overlap_fields.get("cpu_seam")
+        == "RHISubmissionPipelinePolicy",
         f"{mode}: invalid bounded pipeline shutdown alias fallback contract",
     )
 
@@ -575,9 +731,12 @@ def validate_log(mode: str, text: str) -> None:
             retirement_fields.get("distinct_native")
             == retirement_fields.get("suffix_recorded")
             and retirement_fields.get("distinct_native") in {"true", "false"}
+            and retirement_fields.get("suffix_queue") == "Copy"
+            and retirement_fields.get("native_submit") == "0"
             and retirement_fields.get("signals") == "failed"
             and retirement_fields.get("callbacks") == "exactly_once"
-            and retirement_fields.get("hard_latch") == "later_batch_failed",
+            and retirement_fields.get("hard_latch") == "later_batch_failed"
+            and retirement_fields.get("replay") == "0",
             "translate-hard: incomplete failure-retirement contract",
         )
         _require_clean_hard_fault_summary(mode, text)
@@ -618,29 +777,73 @@ def validate_log(mode: str, text: str) -> None:
     )
     ready_status, ready_fields = ready_marker
     if ready_status == "PASS":
+        graphics_native = ready_fields.get("graphics_native")
+        compute_native = ready_fields.get("compute_native")
+        copy_native = ready_fields.get("copy_native")
+        expected_first_ready_lanes = (
+            "G,C,Copy"
+            if graphics_native is not None
+            and compute_native is not None
+            and copy_native is not None
+            and copy_native not in {graphics_native, compute_native}
+            else "alias_fallback"
+        )
         _require(
-            ready_fields.get("sources") == "3"
+            graphics_native is not None
+            and compute_native is not None
+            and copy_native is not None
+            and graphics_native != compute_native
+            and ready_fields.get("sources") == "4"
             and ready_fields.get("batch") == "1"
-            and ready_fields.get("source_order") == "G,G,C"
-            and ready_fields.get("first_ready_lanes") == "G,C"
-            and ready_fields.get("observed_submit_order") == "G,G,C"
+            and ready_fields.get("source_order") == "G,G,C,Copy"
+            and ready_fields.get("first_ready_lanes")
+            == expected_first_ready_lanes
+            and ready_fields.get("observed_submit_order")
+            == "G,G,C,Copy"
+            and ready_fields.get("copy_translate_owner") == "Translate"
+            and ready_fields.get("native_owner") == "Submission"
             and ready_fields.get("explicit_state") == "true"
-            and ready_fields.get("callbacks") == "exactly_once",
+            and ready_fields.get("readback") == "verified"
+            and ready_fields.get("callbacks") == "exactly_once"
+            and ready_fields.get("replay") == "0",
             f"{mode}: incomplete ready-native-lane Translate PASS contract",
         )
     else:
         graphics_native = ready_fields.get("graphics_native")
         compute_native = ready_fields.get("compute_native")
+        copy_native = ready_fields.get("copy_native")
+        skip_reason = ready_fields.get("reason")
+        ready_availability = (
+            ready_fields.get("graphics_available"),
+            ready_fields.get("compute_available"),
+            ready_fields.get("copy_available"),
+        )
         _require(
-            ready_fields.get("reason")
-            in {"queue_unavailable", "native_queue_alias"}
+            ready_status == "SKIP"
+            and skip_reason
+            in {"queue_unavailable", "graphics_compute_native_alias"}
             and ready_fields.get("cpu_seam")
             == "VulkanTranslateWaveScheduler"
+            and all(
+                value in {"true", "false"}
+                for value in ready_availability
+            )
             and graphics_native is not None
             and compute_native is not None
+            and copy_native is not None
             and (
-                ready_fields.get("reason") != "native_queue_alias"
-                or graphics_native == compute_native
+                (
+                    skip_reason == "queue_unavailable"
+                    and "false" in ready_availability
+                )
+                or (
+                    skip_reason == "graphics_compute_native_alias"
+                    and all(
+                        value == "true"
+                        for value in ready_availability
+                    )
+                    and graphics_native == compute_native
+                )
             ),
             f"{mode}: invalid ready-native-lane Translate SKIP contract",
         )

--- a/tools/threading/test_run_parallel_record_vulkan_test.py
+++ b/tools/threading/test_run_parallel_record_vulkan_test.py
@@ -42,7 +42,7 @@ def pipeline_line(
             "name=BoundedCrossBatchSubmissionPipelineOverlap "
             "requested_window=2 effective_window=1 "
             "reason=native_queue_alias graphics_native=7 "
-            "compute_native=7 admission=blocked\n"
+            "compute_native=11 copy_native=7 admission=blocked\n"
         )
     recoverable_rejection = ""
     if window == 2 and include_recoverable_rejection:
@@ -51,11 +51,13 @@ def pipeline_line(
             "name=BoundedCrossBatchRecoverableRejection "
             f"window=2 native_alias={native_alias} "
             f"overlap_assertion={overlap_assertion} batches=2 "
+            "queues=Graphics,Copy "
             "batch0_native_submit=0 "
             "batch0_callbacks=ordinary1_success0 "
             "batch0_signal=rejected batch1_native_submit=1 "
             "batch1_callbacks=ordinary1_success1 "
-            "batch1_signal=success native_owner=Submission replay=0\n"
+            "batch1_signal=success copy_translate_owner=Translate "
+            "native_owner=Submission readback=verified replay=0\n"
         )
     emit_recoverable_overlap_marker = (
         alias_window2
@@ -69,7 +71,8 @@ def pipeline_line(
             "name=BoundedCrossBatchRecoverableRejectionOverlap "
             "requested_window=2 effective_window=1 "
             "reason=native_queue_alias graphics_native=7 "
-            "compute_native=7 admission=blocked\n"
+            "compute_native=11 copy_native=7 admission=blocked "
+            "cpu_seam=RHISubmissionPipelinePolicy\n"
         )
     emit_shutdown_overlap_marker = (
         alias_window2
@@ -83,7 +86,8 @@ def pipeline_line(
             "name=BoundedPipelineShutdownCancellationOverlap "
             "requested_window=2 effective_window=1 "
             "reason=native_queue_alias graphics_native=7 "
-            "compute_native=7 admission=blocked\n"
+            "compute_native=11 copy_native=7 admission=blocked "
+            "cpu_seam=RHISubmissionPipelinePolicy\n"
         )
     malformed_ordering = ""
     if window == 2:
@@ -102,9 +106,12 @@ def pipeline_line(
             "name=BoundedPipelineShutdownCancellation "
             f"window=2 native_alias={native_alias} "
             f"overlap_assertion={overlap_assertion} "
+            "queues=Graphics,Copy "
             "batch0_native_submit=0 batch1_native_submit=1 "
             "batch0_signal=rejected batch1_signal=success "
-            "callbacks=exactly_once concurrent_sync=drained owners=stopped\n"
+            "copy_translate_owner=Translate native_owner=Submission "
+            "readback=verified callbacks=exactly_once "
+            "concurrent_sync=drained owners=stopped\n"
         )
     return (
         overlap
@@ -134,9 +141,12 @@ def pass_line(
         f"mode={mode} worker_fault={fault} production_gate={production_gate} "
         f"production_heavy={production_heavy} iterations=24\n"
         "[TESTCASE][PASS] name=AsyncQueueParallelTranslateSmoke "
-        "sources=3 batch=1 source_order=G,G,C first_ready_lanes=G,C "
-        "observed_submit_order=G,G,C explicit_state=true "
-        "callbacks=exactly_once\n"
+        "graphics_native=0 compute_native=1 copy_native=2 "
+        "sources=4 batch=1 source_order=G,G,C,Copy "
+        "first_ready_lanes=G,C,Copy observed_submit_order=G,G,C,Copy "
+        "copy_translate_owner=Translate native_owner=Submission "
+        "explicit_state=true readback=verified "
+        "callbacks=exactly_once replay=0\n"
         "[TESTCASE][PASS] name=ParallelTranslateRecoverableRejection "
         "distinct_native=true suffix_recorded=true signals=rejected "
         "callbacks=exactly_once runtime=recovered same_scope_reentry=Compute\n"
@@ -239,6 +249,202 @@ class VulkanRunnerTests(unittest.TestCase):
             ),
         )
 
+    def test_pipeline_window1_queue_unavailable_skip_is_accepted(
+        self,
+    ) -> None:
+        text = replace_testcase_marker(
+            pipeline_line(1, "false", "blocked"),
+            "BoundedCrossBatchSubmissionPipeline",
+            "[TESTCASE][SKIP] "
+            "name=BoundedCrossBatchSubmissionPipeline "
+            "window=1 reason=queue_unavailable "
+            "graphics_available=false compute_available=true "
+            "graphics_native=0 compute_native=1",
+        )
+        runner.validate_log("pipeline-window1", text)
+
+    def test_pipeline_window2_compute_unavailable_skip_is_accepted(
+        self,
+    ) -> None:
+        text = replace_testcase_marker(
+            pipeline_line(2, "false", "verified"),
+            "BoundedCrossBatchSubmissionPipeline",
+            "[TESTCASE][SKIP] "
+            "name=BoundedCrossBatchSubmissionPipeline "
+            "window=2 reason=queue_unavailable "
+            "graphics_available=true compute_available=false "
+            "graphics_native=0 compute_native=1",
+        )
+        runner.validate_log("pipeline-window2", text)
+
+    def test_pipeline_window2_copy_unavailable_skips_are_accepted(
+        self,
+    ) -> None:
+        text = pipeline_line(2, "false", "verified")
+        text = replace_testcase_marker(
+            text,
+            "BoundedCrossBatchRecoverableRejection",
+            "[TESTCASE][SKIP] "
+            "name=BoundedCrossBatchRecoverableRejection "
+            "window=2 reason=queue_unavailable "
+            "graphics_available=true copy_available=false "
+            "graphics_native=0 copy_native=2",
+        )
+        text = replace_testcase_marker(
+            text,
+            "BoundedPipelineShutdownCancellation",
+            "[TESTCASE][SKIP] "
+            "name=BoundedPipelineShutdownCancellation "
+            "window=2 reason=queue_unavailable "
+            "graphics_available=true copy_available=false "
+            "graphics_native=0 copy_native=2",
+        )
+        runner.validate_log("pipeline-window2", text)
+
+    def test_pipeline_window2_graphics_unavailable_skips_are_accepted(
+        self,
+    ) -> None:
+        text = pipeline_line(2, "false", "verified")
+        text = replace_testcase_marker(
+            text,
+            "BoundedCrossBatchSubmissionPipeline",
+            "[TESTCASE][SKIP] "
+            "name=BoundedCrossBatchSubmissionPipeline "
+            "window=2 reason=queue_unavailable "
+            "graphics_available=false compute_available=true "
+            "graphics_native=0 compute_native=1",
+        )
+        text = replace_testcase_marker(
+            text,
+            "BoundedCrossBatchMalformedPreflightOrdering",
+            "[TESTCASE][SKIP] "
+            "name=BoundedCrossBatchMalformedPreflightOrdering "
+            "reason=graphics_queue_unavailable",
+        )
+        text = replace_testcase_marker(
+            text,
+            "BoundedCrossBatchRecoverableRejection",
+            "[TESTCASE][SKIP] "
+            "name=BoundedCrossBatchRecoverableRejection "
+            "window=2 reason=queue_unavailable "
+            "graphics_available=false copy_available=true "
+            "graphics_native=0 copy_native=2",
+        )
+        text = replace_testcase_marker(
+            text,
+            "BoundedPipelineShutdownCancellation",
+            "[TESTCASE][SKIP] "
+            "name=BoundedPipelineShutdownCancellation "
+            "window=2 reason=queue_unavailable "
+            "graphics_available=false copy_available=true "
+            "graphics_native=0 copy_native=2",
+        )
+        runner.validate_log("pipeline-window2", text)
+
+    def test_pipeline_recoverable_skip_requires_queue_ids(self) -> None:
+        text = replace_testcase_marker(
+            pipeline_line(2, "false", "verified"),
+            "BoundedCrossBatchRecoverableRejection",
+            "[TESTCASE][SKIP] "
+            "name=BoundedCrossBatchRecoverableRejection "
+            "window=2 reason=queue_unavailable "
+            "graphics_available=true copy_available=false "
+            "graphics_native=0",
+        )
+        with self.assertRaisesRegex(
+            runner.VulkanTestError,
+            "invalid bounded recoverable rejection SKIP contract",
+        ):
+            runner.validate_log("pipeline-window2", text)
+
+    def test_pipeline_pass_rejects_graphics_unavailable_malformed_skip(
+        self,
+    ) -> None:
+        text = replace_testcase_marker(
+            pipeline_line(2, "false", "verified"),
+            "BoundedCrossBatchMalformedPreflightOrdering",
+            "[TESTCASE][SKIP] "
+            "name=BoundedCrossBatchMalformedPreflightOrdering "
+            "reason=graphics_queue_unavailable",
+        )
+        with self.assertRaisesRegex(
+            runner.VulkanTestError,
+            "invalid malformed-preflight ordering SKIP contract",
+        ):
+            runner.validate_log("pipeline-window2", text)
+
+    def test_pipeline_rejects_inconsistent_graphics_copy_availability(
+        self,
+    ) -> None:
+        text = replace_testcase_marker(
+            pipeline_line(2, "false", "verified"),
+            "BoundedCrossBatchRecoverableRejection",
+            "[TESTCASE][SKIP] "
+            "name=BoundedCrossBatchRecoverableRejection "
+            "window=2 reason=queue_unavailable "
+            "graphics_available=true copy_available=false "
+            "graphics_native=0 copy_native=2",
+        )
+        with self.assertRaisesRegex(
+            runner.VulkanTestError,
+            "inconsistent bounded Graphics/Copy availability contract",
+        ):
+            runner.validate_log("pipeline-window2", text)
+
+    def test_pipeline_pass_rejects_graphics_unavailable_copy_skips(
+        self,
+    ) -> None:
+        text = pipeline_line(2, "false", "verified")
+        text = replace_testcase_marker(
+            text,
+            "BoundedCrossBatchRecoverableRejection",
+            "[TESTCASE][SKIP] "
+            "name=BoundedCrossBatchRecoverableRejection "
+            "window=2 reason=queue_unavailable "
+            "graphics_available=false copy_available=true "
+            "graphics_native=0 copy_native=2",
+        )
+        text = replace_testcase_marker(
+            text,
+            "BoundedPipelineShutdownCancellation",
+            "[TESTCASE][SKIP] "
+            "name=BoundedPipelineShutdownCancellation "
+            "window=2 reason=queue_unavailable "
+            "graphics_available=false copy_available=true "
+            "graphics_native=0 copy_native=2",
+        )
+        with self.assertRaisesRegex(
+            runner.VulkanTestError,
+            "inconsistent bounded pipeline Graphics availability contract",
+        ):
+            runner.validate_log("pipeline-window2", text)
+
+    def test_pipeline_graphics_unavailable_rejects_copy_passes(
+        self,
+    ) -> None:
+        text = pipeline_line(2, "false", "verified")
+        text = replace_testcase_marker(
+            text,
+            "BoundedCrossBatchSubmissionPipeline",
+            "[TESTCASE][SKIP] "
+            "name=BoundedCrossBatchSubmissionPipeline "
+            "window=2 reason=queue_unavailable "
+            "graphics_available=false compute_available=true "
+            "graphics_native=0 compute_native=1",
+        )
+        text = replace_testcase_marker(
+            text,
+            "BoundedCrossBatchMalformedPreflightOrdering",
+            "[TESTCASE][SKIP] "
+            "name=BoundedCrossBatchMalformedPreflightOrdering "
+            "reason=graphics_queue_unavailable",
+        )
+        with self.assertRaisesRegex(
+            runner.VulkanTestError,
+            "inconsistent bounded pipeline Graphics availability contract",
+        ):
+            runner.validate_log("pipeline-window2", text)
+
     def test_pipeline_window2_alias_requires_pipeline_overlap_marker(
         self,
     ) -> None:
@@ -305,7 +511,7 @@ class VulkanRunnerTests(unittest.TestCase):
         text = pipeline_line(2, "false", "verified").replace(marker, "")
         with self.assertRaisesRegex(
             runner.VulkanTestError,
-            "malformed-preflight ordering PASS marker",
+            "malformed-preflight ordering terminal marker",
         ):
             runner.validate_log("pipeline-window2", text)
 
@@ -344,7 +550,7 @@ class VulkanRunnerTests(unittest.TestCase):
         )
         with self.assertRaisesRegex(
             runner.VulkanTestError,
-            "recoverable rejection PASS marker",
+            "recoverable rejection terminal marker",
         ):
             runner.validate_log("pipeline-window2", text)
 
@@ -433,11 +639,39 @@ class VulkanRunnerTests(unittest.TestCase):
             "name=BoundedCrossBatchRecoverableRejectionOverlap "
             "requested_window=2 effective_window=1 "
             "reason=native_queue_alias graphics_native=7 "
-            "compute_native=7 admission=blocked",
+            "compute_native=11 copy_native=7 admission=blocked",
             "name=BoundedCrossBatchRecoverableRejectionOverlap "
             "requested_window=2 effective_window=1 "
             "reason=native_queue_alias graphics_native=8 "
-            "compute_native=8 admission=blocked",
+            "compute_native=11 copy_native=8 admission=blocked",
+        )
+        with self.assertRaisesRegex(
+            runner.VulkanTestError,
+            "invalid bounded recoverable alias fallback contract",
+        ):
+            runner.validate_log("pipeline-window2", text)
+
+    def test_pipeline_recoverable_rejection_requires_copy_contract(
+        self,
+    ) -> None:
+        text = pipeline_line(2, "false", "verified").replace(
+            "copy_translate_owner=Translate",
+            "copy_translate_owner=Submission",
+            1,
+        )
+        with self.assertRaisesRegex(
+            runner.VulkanTestError,
+            "incomplete bounded cross-batch recoverable rejection contract",
+        ):
+            runner.validate_log("pipeline-window2", text)
+
+    def test_pipeline_recoverable_overlap_requires_policy_seam(
+        self,
+    ) -> None:
+        text = pipeline_line(2, "true", "blocked").replace(
+            "cpu_seam=RHISubmissionPipelinePolicy",
+            "cpu_seam=VulkanTranslateWaveScheduler",
+            1,
         )
         with self.assertRaisesRegex(
             runner.VulkanTestError,
@@ -456,7 +690,7 @@ class VulkanRunnerTests(unittest.TestCase):
         )
         with self.assertRaisesRegex(
             runner.VulkanTestError,
-            "shutdown cancellation PASS marker",
+            "shutdown cancellation terminal marker",
         ):
             runner.validate_log("pipeline-window2", text)
 
@@ -517,11 +751,46 @@ class VulkanRunnerTests(unittest.TestCase):
             "name=BoundedPipelineShutdownCancellationOverlap "
             "requested_window=2 effective_window=1 "
             "reason=native_queue_alias graphics_native=7 "
-            "compute_native=7 admission=blocked",
+            "compute_native=11 copy_native=7 admission=blocked",
             "name=BoundedPipelineShutdownCancellationOverlap "
             "requested_window=2 effective_window=1 "
             "reason=native_queue_alias graphics_native=8 "
-            "compute_native=8 admission=blocked",
+            "compute_native=11 copy_native=8 admission=blocked",
+        )
+        with self.assertRaisesRegex(
+            runner.VulkanTestError,
+            "invalid bounded pipeline shutdown alias fallback contract",
+        ):
+            runner.validate_log("pipeline-window2", text)
+
+    def test_pipeline_shutdown_cancellation_requires_copy_readback(
+        self,
+    ) -> None:
+        text = pipeline_line(2, "false", "verified").replace(
+            "readback=verified callbacks=exactly_once",
+            "readback=missing callbacks=exactly_once",
+            1,
+        )
+        with self.assertRaisesRegex(
+            runner.VulkanTestError,
+            "incomplete bounded pipeline shutdown cancellation contract",
+        ):
+            runner.validate_log("pipeline-window2", text)
+
+    def test_pipeline_shutdown_overlap_requires_policy_seam(
+        self,
+    ) -> None:
+        text = pipeline_line(2, "true", "blocked").replace(
+            "name=BoundedPipelineShutdownCancellationOverlap "
+            "requested_window=2 effective_window=1 "
+            "reason=native_queue_alias graphics_native=7 "
+            "compute_native=11 copy_native=7 admission=blocked "
+            "cpu_seam=RHISubmissionPipelinePolicy",
+            "name=BoundedPipelineShutdownCancellationOverlap "
+            "requested_window=2 effective_window=1 "
+            "reason=native_queue_alias graphics_native=7 "
+            "compute_native=11 copy_native=7 admission=blocked "
+            "cpu_seam=VulkanTranslateWaveScheduler",
         )
         with self.assertRaisesRegex(
             runner.VulkanTestError,
@@ -582,7 +851,25 @@ class VulkanRunnerTests(unittest.TestCase):
             "true",
             "blocked",
             include_overlap_marker=True,
-        ).replace("compute_native=7", "compute_native=8", 1)
+        ).replace("copy_native=7", "copy_native=8", 1)
+        with self.assertRaisesRegex(
+            runner.VulkanTestError,
+            "invalid bounded cross-batch alias fallback contract",
+        ):
+            runner.validate_log("pipeline-window2", text)
+
+    def test_pipeline_alias_overlap_requires_an_actual_native_alias(
+        self,
+    ) -> None:
+        text = pipeline_line(
+            2,
+            "true",
+            "blocked",
+            include_overlap_marker=True,
+        ).replace(
+            "graphics_native=7 compute_native=11 copy_native=7",
+            "graphics_native=7 compute_native=11 copy_native=13",
+        )
         with self.assertRaisesRegex(
             runner.VulkanTestError,
             "invalid bounded cross-batch alias fallback contract",
@@ -707,13 +994,14 @@ class VulkanRunnerTests(unittest.TestCase):
             runner.validate_log("serial", text)
 
     def test_ready_translate_rejects_unapproved_skip_reason(self) -> None:
-        text = pass_line("serial", "false").replace(
-            "[TESTCASE][PASS] name=AsyncQueueParallelTranslateSmoke "
-            "sources=3 batch=1 source_order=G,G,C first_ready_lanes=G,C "
-            "observed_submit_order=G,G,C explicit_state=true "
-            "callbacks=exactly_once",
+        text = replace_testcase_marker(
+            pass_line("serial", "false"),
+            "AsyncQueueParallelTranslateSmoke",
             "[TESTCASE][SKIP] name=AsyncQueueParallelTranslateSmoke "
-            "reason=test_disabled cpu_seam=VulkanTranslateWaveScheduler",
+            "reason=test_disabled cpu_seam=VulkanTranslateWaveScheduler "
+            "graphics_available=true compute_available=true "
+            "copy_available=true "
+            "graphics_native=0 compute_native=1 copy_native=2",
         )
         with self.assertRaisesRegex(
             runner.VulkanTestError, "invalid ready-native-lane"
@@ -722,7 +1010,57 @@ class VulkanRunnerTests(unittest.TestCase):
 
     def test_ready_translate_requires_observed_submit_order(self) -> None:
         text = pass_line("serial", "false").replace(
-            "observed_submit_order=G,G,C", "observed_submit_order=G,C,G"
+            "observed_submit_order=G,G,C,Copy",
+            "observed_submit_order=G,C,G,Copy",
+        )
+        with self.assertRaisesRegex(
+            runner.VulkanTestError, "incomplete ready-native-lane"
+        ):
+            runner.validate_log("serial", text)
+
+    def test_ready_translate_requires_copy_translate_owner(self) -> None:
+        text = pass_line("serial", "false").replace(
+            "copy_translate_owner=Translate",
+            "copy_translate_owner=Submission",
+            1,
+        )
+        with self.assertRaisesRegex(
+            runner.VulkanTestError, "incomplete ready-native-lane"
+        ):
+            runner.validate_log("serial", text)
+
+    def test_ready_translate_requires_verified_readback_and_no_replay(
+        self,
+    ) -> None:
+        text = pass_line("serial", "false").replace(
+            "readback=verified callbacks=exactly_once replay=0",
+            "readback=verified callbacks=exactly_once replay=1",
+            1,
+        )
+        with self.assertRaisesRegex(
+            runner.VulkanTestError, "incomplete ready-native-lane"
+        ):
+            runner.validate_log("serial", text)
+
+    def test_ready_translate_copy_alias_uses_alias_fallback(self) -> None:
+        text = pass_line("serial", "false").replace(
+            "graphics_native=0 compute_native=1 copy_native=2",
+            "graphics_native=0 compute_native=1 copy_native=0",
+            1,
+        ).replace(
+            "first_ready_lanes=G,C,Copy",
+            "first_ready_lanes=alias_fallback",
+            1,
+        )
+        runner.validate_log("serial", text)
+
+    def test_ready_translate_copy_alias_rejects_distinct_lane_claim(
+        self,
+    ) -> None:
+        text = pass_line("serial", "false").replace(
+            "graphics_native=0 compute_native=1 copy_native=2",
+            "graphics_native=0 compute_native=1 copy_native=0",
+            1,
         )
         with self.assertRaisesRegex(
             runner.VulkanTestError, "incomplete ready-native-lane"
@@ -1027,8 +1365,11 @@ class VulkanRunnerTests(unittest.TestCase):
         text = pass_line("serial", "false")
         duplicate = (
             "[TESTCASE][SKIP] name=AsyncQueueParallelTranslateSmoke "
-            "reason=native_queue_alias "
-            "cpu_seam=VulkanTranslateWaveScheduler\n"
+            "reason=graphics_compute_native_alias "
+            "cpu_seam=VulkanTranslateWaveScheduler "
+            "graphics_available=true compute_available=true "
+            "copy_available=true "
+            "graphics_native=0 compute_native=0 copy_native=2\n"
         )
         with self.assertRaisesRegex(
             runner.VulkanTestError, "at most one terminal marker"
@@ -1040,8 +1381,11 @@ class VulkanRunnerTests(unittest.TestCase):
             pass_line("serial", "false"),
             "AsyncQueueParallelTranslateSmoke",
             "[TESTCASE][SKIP] name=AsyncQueueParallelTranslateSmoke "
-            "reason=native_queue_alias cpu_seam=VulkanTranslateWaveScheduler "
-            "graphics_native=0 compute_native=1",
+            "reason=graphics_compute_native_alias "
+            "cpu_seam=VulkanTranslateWaveScheduler "
+            "graphics_available=true compute_available=true "
+            "copy_available=true "
+            "graphics_native=0 compute_native=1 copy_native=2",
         )
         with self.assertRaisesRegex(
             runner.VulkanTestError, "invalid ready-native-lane Translate SKIP"
@@ -1053,8 +1397,44 @@ class VulkanRunnerTests(unittest.TestCase):
             pass_line("serial", "false"),
             "AsyncQueueParallelTranslateSmoke",
             "[TESTCASE][SKIP] name=AsyncQueueParallelTranslateSmoke "
-            "reason=native_queue_alias cpu_seam=VulkanTranslateWaveScheduler "
-            "graphics_native=0 compute_native=0",
+            "reason=graphics_compute_native_alias "
+            "cpu_seam=VulkanTranslateWaveScheduler "
+            "graphics_available=true compute_available=true "
+            "copy_available=true "
+            "graphics_native=0 compute_native=0 copy_native=2",
+        )
+        runner.validate_log("serial", text)
+
+    def test_ready_translate_queue_unavailable_skip_requires_copy_id(
+        self,
+    ) -> None:
+        text = replace_testcase_marker(
+            pass_line("serial", "false"),
+            "AsyncQueueParallelTranslateSmoke",
+            "[TESTCASE][SKIP] name=AsyncQueueParallelTranslateSmoke "
+            "reason=queue_unavailable "
+            "cpu_seam=VulkanTranslateWaveScheduler "
+            "graphics_available=true compute_available=true "
+            "copy_available=false "
+            "graphics_native=0 compute_native=1",
+        )
+        with self.assertRaisesRegex(
+            runner.VulkanTestError, "invalid ready-native-lane Translate SKIP"
+        ):
+            runner.validate_log("serial", text)
+
+    def test_ready_translate_queue_unavailable_skip_is_accepted(
+        self,
+    ) -> None:
+        text = replace_testcase_marker(
+            pass_line("serial", "false"),
+            "AsyncQueueParallelTranslateSmoke",
+            "[TESTCASE][SKIP] name=AsyncQueueParallelTranslateSmoke "
+            "reason=queue_unavailable "
+            "cpu_seam=VulkanTranslateWaveScheduler "
+            "graphics_available=true compute_available=true "
+            "copy_available=false "
+            "graphics_native=0 compute_native=1 copy_native=2",
         )
         runner.validate_log("serial", text)
 
@@ -1109,8 +1489,9 @@ class VulkanRunnerTests(unittest.TestCase):
         text = (
             completion_probe_line()
             + "[TESTCASE][PASS] name=ParallelTranslateFailureRetirement "
-            "distinct_native=true suffix_recorded=true signals=failed "
-            "callbacks=exactly_once hard_latch=later_batch_failed\n"
+            "distinct_native=true suffix_recorded=true suffix_queue=Copy "
+            "native_submit=0 signals=failed callbacks=exactly_once "
+            "hard_latch=later_batch_failed replay=0\n"
             "[VulkanFault][Summary] first_fault_count=1 "
             "native_submit_after_fault=0 native_present_after_fault=0 "
             "device_lost=false\n"
@@ -1121,8 +1502,9 @@ class VulkanRunnerTests(unittest.TestCase):
         text = (
             completion_probe_line()
             + "[TESTCASE][PASS] name=ParallelTranslateFailureRetirement "
-            "distinct_native=true suffix_recorded=true signals=failed "
-            "callbacks=exactly_once hard_latch=later_batch_failed\n"
+            "distinct_native=true suffix_recorded=true suffix_queue=Copy "
+            "native_submit=0 signals=failed callbacks=exactly_once "
+            "hard_latch=later_batch_failed replay=0\n"
             "[VulkanFault][Summary] first_fault_count=1 "
             "native_submit_after_fault=1 native_present_after_fault=0 "
             "device_lost=false\n"
@@ -1136,23 +1518,56 @@ class VulkanRunnerTests(unittest.TestCase):
         text = (
             completion_probe_line()
             + "[TESTCASE][PASS] name=ParallelTranslateFailureRetirement "
-            "distinct_native=false suffix_recorded=false signals=failed "
-            "callbacks=exactly_once hard_latch=later_batch_failed\n"
+            "distinct_native=false suffix_recorded=false suffix_queue=Copy "
+            "native_submit=0 signals=failed callbacks=exactly_once "
+            "hard_latch=later_batch_failed replay=0\n"
             "[VulkanFault][Summary] first_fault_count=1 "
             "native_submit_after_fault=0 native_present_after_fault=0 "
             "device_lost=false\n"
         )
         runner.validate_log("translate-hard", text)
 
+    def test_translate_hard_requires_copy_no_submit_no_replay(self) -> None:
+        base = (
+            completion_probe_line()
+            + "[TESTCASE][PASS] name=ParallelTranslateFailureRetirement "
+            "distinct_native=true suffix_recorded=true suffix_queue=Copy "
+            "native_submit=0 signals=failed callbacks=exactly_once "
+            "hard_latch=later_batch_failed replay=0\n"
+            "[VulkanFault][Summary] first_fault_count=1 "
+            "native_submit_after_fault=0 native_present_after_fault=0 "
+            "device_lost=false\n"
+        )
+        mutations = (
+            ("suffix_queue=Copy", "suffix_queue=Compute"),
+            ("native_submit=0", "native_submit=1"),
+            (
+                "hard_latch=later_batch_failed replay=0",
+                "hard_latch=later_batch_failed replay=1",
+            ),
+        )
+        for original, replacement in mutations:
+            with self.subTest(field=original):
+                with self.assertRaisesRegex(
+                    runner.VulkanTestError,
+                    "incomplete failure-retirement contract",
+                ):
+                    runner.validate_log(
+                        "translate-hard",
+                        base.replace(original, replacement, 1),
+                    )
+
     def test_translate_hard_rejects_duplicate_retirement_markers(self) -> None:
         text = (
             completion_probe_line()
             + "[TESTCASE][PASS] name=ParallelTranslateFailureRetirement "
-            "distinct_native=true suffix_recorded=true signals=failed "
-            "callbacks=exactly_once hard_latch=later_batch_failed\n"
+            "distinct_native=true suffix_recorded=true suffix_queue=Copy "
+            "native_submit=0 signals=failed callbacks=exactly_once "
+            "hard_latch=later_batch_failed replay=0\n"
             "[TESTCASE][PASS] name=ParallelTranslateFailureRetirement "
-            "distinct_native=false suffix_recorded=true signals=failed "
-            "callbacks=exactly_once hard_latch=later_batch_failed\n"
+            "distinct_native=false suffix_recorded=true suffix_queue=Copy "
+            "native_submit=0 signals=failed callbacks=exactly_once "
+            "hard_latch=later_batch_failed replay=0\n"
             "[VulkanFault][Summary] first_fault_count=1 "
             "native_submit_after_fault=0 native_present_after_fault=0 "
             "device_lost=false\n"
@@ -1166,8 +1581,9 @@ class VulkanRunnerTests(unittest.TestCase):
         text = (
             completion_probe_line()
             + "[TESTCASE][PASS] name=ParallelTranslateFailureRetirement "
-            "distinct_native=true suffix_recorded=true signals=failed "
-            "callbacks=exactly_once hard_latch=later_batch_failed\n"
+            "distinct_native=true suffix_recorded=true suffix_queue=Copy "
+            "native_submit=0 signals=failed callbacks=exactly_once "
+            "hard_latch=later_batch_failed replay=0\n"
             "[VulkanFault][Summary] first_fault_count=1 "
             "native_submit_after_fault=0 native_present_after_fault=0 "
             "device_lost=false\n"
@@ -1184,8 +1600,9 @@ class VulkanRunnerTests(unittest.TestCase):
         text = (
             completion_probe_line()
             + "[TESTCASE][PASS] name=ParallelTranslateFailureRetirement "
-            "distinct_native=true suffix_recorded=true signals=failed "
-            "callbacks=exactly_once hard_latch=later_batch_failed\n"
+            "distinct_native=true suffix_recorded=true suffix_queue=Copy "
+            "native_submit=0 signals=failed callbacks=exactly_once "
+            "hard_latch=later_batch_failed replay=0\n"
             "[VulkanFault][Summary] first_fault_count=1 first_fault_count=2 "
             "native_submit_after_fault=0 native_present_after_fault=0 "
             "device_lost=false\n"
@@ -1199,8 +1616,9 @@ class VulkanRunnerTests(unittest.TestCase):
         text = (
             completion_probe_line()
             + "[TESTCASE][PASS] name=ParallelTranslateFailureRetirement "
-            "distinct_native=true suffix_recorded=true signals=failed "
-            "callbacks=exactly_once hard_latch=later_batch_failed\n"
+            "distinct_native=true suffix_recorded=true suffix_queue=Copy "
+            "native_submit=0 signals=failed callbacks=exactly_once "
+            "hard_latch=later_batch_failed replay=0\n"
             "[VulkanFault][Summary] first_fault_count=10 "
             "native_submit_after_fault=0 native_present_after_fault=0 "
             "device_lost=false\n"


### PR DESCRIPTION
## Summary

- Promote eligible explicit-RDG Copy sources into the existing ready-native-lane Translate graph alongside Graphics and Compute.
- Carry Graphics/Compute and Copy recorded packets through one move-only tagged runtime packet, while preserving their existing queue-specific Translate, Submit, Reject, fault, allocator, and Completion behavior.
- Keep Translate parallel and native submission serial/stable: first-ready lanes can be `G,C,Copy`, while source submission remains `G,G,C,Copy`.
- Extend the bounded cross-batch pipeline to Copy, including later-batch Copy translation while an earlier Graphics submission is dependency-blocked.
- Generalize physical native-queue alias protection to every available G/C/Copy pair. Any alias reduces the effective batch window to 1, and same-batch logical aliases use the drained synchronous path.
- Update Copy submission bookkeeping (`last_copy_timeline`, Copy GPU frontier, used-queue tracking) on the sole Submission owner.
- Add translation diagnostics that prove Copy recording occurred on a Translate worker instead of inferring it from eventual native submission.
- Add fail-closed CPU, Vulkan, runner, and parser coverage for ready lanes, real Copy readback, recoverable rejection, hard failure, Shutdown drain, exact retirement, stable order, and topology/availability consistency.

## Eligibility and boundaries

Copy enters the pipeline only when the source is parallel-Translate eligible, uses explicit resource-state ownership, has a non-zero async queue scope, and passes existing command/preflight constraints. Scope-zero VulkanStorage, ordinary upload, legacy/backend-tracked Copy, Present, profiling, resource deletion, and serial/control payloads remain drain boundaries.

This PR intentionally does not implement the separately recorded conditional Non-RDG automatic hazard/cross-queue inference gap. It also does not pipeline D3D12, Present, or performance-adaptive batch windows.

## Reference choices

The topology follows `origin/dev_parallel_rhi` and UE-style separation of parallel command translation from a single ordered submission owner. It retains main's stricter explicit Resource State/Barrier ownership, active-RDG source/segment metadata, bounded batch admission, physical queue-alias fallback, recoverable rejection, hard-fault latch, allocator quarantine, and Completion retirement semantics.

## Validation (head `a5ca0ded678b245efded3e99fd7de1a20ae9054d`)

- Debug full build: pass
- Release full build: pass (one known third-party high-parallel generation race on the first pass; incremental rerun pass)
- Debug CTest: 18/18
- Release CTest: 18/18
- Python runner/parser contracts: 103/103; `py_compile` pass
- Debug Vulkan nine-mode matrix: 9/9
- Release Vulkan nine-mode matrix: 9/9 final rerun
- Release fallback focused repeat: 3/3
- Debug and Release MoerEditor: Vulkan + Raytracing + RDG parallel startup, interaction/soak, and clean shutdown pass
- Runtime logs: no VUID, validation error, device loss, assertion, or fatal error
- Two independent local reviews found no remaining P0-P2 issues after the final parser-invariant fixes

Environment note: exploratory Release runs observed one process-start sharing violation and one non-reproducing runner child-process stall. Both occurred outside a reproducible RHI failure signature; direct repeats and the final full matrices passed. These events are recorded in the Phase 15E TechRecord.

## Review focus

- Exactly-once terminalization of the tagged recorded packet across Translate/Submit/Reject
- Transferable gate and allocator ownership from Translate to Submission/Completion
- Copy timeline/frontier/used-queue publication on the sole Submission owner
- Stable source/batch FIFO despite out-of-order Translate completion
- Any-pair G/C/Copy native-alias fallback
- Recoverable suffix rejection, hard-failure latch, and Shutdown dependency cancellation
- Fail-closed marker parsing across queue availability and alias topology
