### PR TITLE
feat(raytracing): close the RT render graph topology

### DIFF
--- a/shaders/features/ui/CombineGuiFrag.hlsl
+++ b/shaders/features/ui/CombineGuiFrag.hlsl
@@ -4,7 +4,6 @@ struct PSInput {
 };
 
 [[vk::binding(0, 0)]] Texture2D<float4> scene_color : register(t0);
-[[vk::binding(1, 0)]] Texture2D<float4> gui_color : register(t1);
 [[vk::binding(0, 1)]] SamplerState linear_sampler : register(s0);
 
 struct SceneRect {
@@ -16,10 +15,6 @@ struct SceneRect {
 
 float4 main(PSInput input) : SV_TARGET {
   if (any(input.uv < scene_rect.min_xy) || any(input.uv > scene_rect.max_xy)) {
-    // #if VULKAN
-    //     input.uv.y = 1.0 - input.uv.y;
-    // #endif
-    // return gui_color.Sample(linear_sampler, input.uv);
     return float4(0.0, 0.0, 0.0, 0.0);
   }
   float2 scene_uv =

--- a/source/editor/Editor.cpp
+++ b/source/editor/Editor.cpp
@@ -62,27 +62,6 @@ void Editor::Run(const ExtraHooks& extra_hooks) {
                 [this]() {
                     return m_editor_ui->NeedsReload();
                 },
-            .on_ui_combine_pass =
-                [this](
-                    UiCombinePass* ui_combine_pass,
-                    CommandList&   cmd_list,
-                    TextureView    input_color_texture,
-                    TextureView    input_ui_texture,
-                    TextureView    default_output_texture
-                ) {
-                    const auto window_frame_buffer = m_editor_ui->GetWindowFrameBuffer();
-                    return ui_combine_pass->Process(
-                        cmd_list,
-                        m_editor_ui->IsSeparateWindow(),
-                        m_editor_ui->GetConfig()->GetResolution(),
-                        m_editor_ui->GetSceneColorPos(),
-                        m_editor_ui->GetSceneColorResolution(),
-                        window_frame_buffer ? window_frame_buffer->GetView() : TextureView(),
-                        input_color_texture,
-                        input_ui_texture,
-                        default_output_texture
-                    );
-                },
             .on_capture_ui_composition =
                 [this]() {
                     return UiCompositionFrameData{

--- a/source/runtime/render/renderer/Renderer.h
+++ b/source/runtime/render/renderer/Renderer.h
@@ -20,24 +20,12 @@
 
 namespace Moer::Render {
 
-struct UiCompositionFrameData {
-    bool       enabled         = false;
-    bool       separate_window = false;
-    uint2      output_resolution{};
-    float2     scene_color_position{};
-    float2     scene_color_resolution{};
-    TextureRef window_frame_buffer{};
-};
-
 struct EngineHooks {
     // Common
     std::function<void(Scene&)> on_tick_scripting;
     std::function<void(Scene&)> on_tick_test;
     std::function<void(Scene&)> on_tick_ui;
     std::function<bool()>       should_reload;
-
-    std::function<TextureRef(UiCombinePass*, CommandList&, TextureView, TextureView, TextureView)>
-        on_ui_combine_pass;
 
     std::function<UiCompositionFrameData()> on_capture_ui_composition;
     std::function<UiDrawFramePacket()>      on_capture_ui_draw_frame;

--- a/source/runtime/render/renderer/common/UIRenderer.h
+++ b/source/runtime/render/renderer/common/UIRenderer.h
@@ -7,14 +7,35 @@
 #include "misc/STL.h"
 #include "rhi/RHI.h"
 #include <cstdint>
+#include <limits>
 #include <type_traits>
 
 namespace Moer::Render {
 class UiDrawFrameBackend;
 
+struct UiCompositionFrameData {
+    bool       enabled         = false;
+    bool       separate_window = false;
+    uint2      output_resolution{};
+    float2     scene_color_position{};
+    float2     scene_color_resolution{};
+    TextureRef window_frame_buffer{};
+};
+
 class RENDER_API UiViewportRenderResources {
 public:
     virtual ~UiViewportRenderResources() = default;
+
+    /**
+     * UI upload-ring selection is speculative until the command source is
+     * accepted by the native queue. The renderer records one frame at a time,
+     * so a read-only token can be frozen in the copied packet and committed
+     * only after Fence::WaitSubmitted succeeds.
+     */
+    [[nodiscard]] virtual uint64_t GetPendingRecordingSlot() const noexcept = 0;
+    [[nodiscard]] virtual bool
+    IsPendingRecordingSlot(uint64_t slot) const noexcept = 0;
+    virtual void CommitRecordingSlot(uint64_t slot) noexcept = 0;
 };
 
 enum class EUiDrawExecutionThread : uint8_t {
@@ -40,9 +61,13 @@ struct UiDrawCommand {
 };
 
 struct UiViewportDrawPacket {
+    static constexpr uint64_t InvalidRecordingSlot =
+        std::numeric_limits<uint64_t>::max();
+
     float2 display_position{};
     float2 display_size{};
     float2 framebuffer_scale{1.f, 1.f};
+    uint64_t recording_slot = InvalidRecordingSlot;
 
     Array<UiDrawVertex>  vertices;
     Array<UiDrawIndex>   indices;
@@ -76,7 +101,7 @@ public:
     virtual void RenderGUI(
         CommandList&           _cmd_list,
         const TextureView&     _main_framebuffer,
-        UiDrawFramePacket&     _frame,
+        const UiDrawFramePacket& _frame,
         EUiDrawExecutionThread _execution_thread
     ) = 0;
     virtual void
@@ -86,7 +111,7 @@ public:
 RENDER_API void RenderUiDrawFrame(
     CommandList&           _cmd_list,
     const TextureView&     _main_framebuffer,
-    UiDrawFramePacket&     _frame,
+    const UiDrawFramePacket& _frame,
     EUiDrawExecutionThread _execution_thread
 );
 RENDER_API void PresentUiDrawFrame(const UiDrawFramePacket& _frame, EUiDrawExecutionThread _execution_thread);

--- a/source/runtime/render/renderer/common/UIRenderer.h
+++ b/source/runtime/render/renderer/common/UIRenderer.h
@@ -6,6 +6,7 @@
 #include "RenderAPI.h"
 #include "misc/STL.h"
 #include "rhi/RHI.h"
+#include <atomic>
 #include <cstdint>
 #include <limits>
 #include <type_traits>
@@ -93,6 +94,51 @@ struct UiDrawFramePacket {
 
 static_assert(std::is_move_constructible_v<UiDrawFramePacket>);
 static_assert(!std::is_copy_constructible_v<UiDrawFramePacket>);
+
+/**
+ * Freezes the speculative upload-ring slots used by one copied UI frame.
+ *
+ * Recording alone does not retire a slot. The owner must publish exactly one
+ * terminal result after the command source crosses (or fails to cross) the
+ * native queue boundary. Duplicate viewport references to the same backend
+ * resource share one slot and are committed once.
+ */
+class RENDER_API UiDrawFrameSlotClaim final {
+public:
+    enum class EState : uint8_t {
+        Pending,
+        Accepted,
+        Rejected,
+    };
+
+    explicit UiDrawFrameSlotClaim(UiDrawFramePacket& frame);
+
+    UiDrawFrameSlotClaim(const UiDrawFrameSlotClaim&)            = delete;
+    UiDrawFrameSlotClaim& operator=(const UiDrawFrameSlotClaim&) = delete;
+    UiDrawFrameSlotClaim(UiDrawFrameSlotClaim&&)                 = delete;
+    UiDrawFrameSlotClaim& operator=(UiDrawFrameSlotClaim&&)      = delete;
+
+    [[nodiscard]] bool IsReadyForRecording() const noexcept;
+    [[nodiscard]] bool CommitAccepted() const noexcept;
+    void Reject() const noexcept;
+
+    [[nodiscard]] EState GetState() const noexcept {
+        return state.load(std::memory_order_acquire);
+    }
+
+private:
+    struct Slot {
+        SharedPtr<UiViewportRenderResources> resources;
+        uint64_t                             value = 0;
+    };
+
+    void Freeze(UiViewportDrawPacket& viewport);
+    [[nodiscard]] bool ValidatePendingSlots() const noexcept;
+
+    Array<Slot>        slots{};
+    bool               structurally_valid = true;
+    mutable std::atomic<EState> state{EState::Pending};
+};
 
 class RENDER_API UiDrawFrameBackend {
 public:

--- a/source/runtime/render/renderer/common/UiCombinePass.h
+++ b/source/runtime/render/renderer/common/UiCombinePass.h
@@ -20,11 +20,10 @@ public:
 
     DEFINE_RASTER_PIPELINE_CLASS(CombineUIPipeline);
     DEFINE_SHADER_TEX(scene_color);
-    DEFINE_SHADER_TEX(gui_color);
     DEFINE_SHADER_SAMPLER(linear_sampler);
     DEFINE_SHADER_CONSTANT_STRUCT(Param, scene_rect);
 
-    DEFINE_SHADER_ARGS(scene_color, gui_color, linear_sampler, scene_rect);
+    DEFINE_SHADER_ARGS(scene_color, linear_sampler, scene_rect);
 };
 
 class SampleTexturePipeline : public RasterPipeline {
@@ -70,7 +69,6 @@ public:
         float2       scene_color_resolution,
         TextureView  input_window_frame_buffer,
         TextureView  input_color_texture,
-        TextureView  input_ui_texture,
         TextureView  default_output_texture
     ) {
         ScopedGpuMarker ui_composition_marker(
@@ -116,7 +114,6 @@ public:
             .Gfx(
                 combine_ui_pipelines[default_output_texture.format],
                 input_color_texture,
-                input_ui_texture,
                 Sampler(SF_LINEAR, SAM_CLAMP_TO_EDGE),
                 CombineUIPipeline::Param{scene_rect_min, scene_rect_max}
             )

--- a/source/runtime/render/renderer/common/UiFrameGraphPass.cpp
+++ b/source/runtime/render/renderer/common/UiFrameGraphPass.cpp
@@ -1,0 +1,654 @@
+#include "UiFrameGraphPass.h"
+
+#include "rhi/RHICommand.h"
+
+#include <algorithm>
+#include <format>
+#include <stdexcept>
+
+namespace Moer::Render {
+namespace {
+
+RenderGraph::TextureAspect TextureAspects(const TextureRef& texture) {
+    RenderGraph::TextureAspect aspects = RenderGraph::TextureAspect::None;
+    const auto                 rhi_aspects = texture->GetAspectFlags();
+    if (uint32_t(rhi_aspects & ETextureAspectFlags::COLOR) != 0) {
+        aspects = aspects | RenderGraph::TextureAspect::Color;
+    }
+    if (uint32_t(rhi_aspects & ETextureAspectFlags::DEPTH_SLICE) != 0) {
+        aspects = aspects | RenderGraph::TextureAspect::Depth;
+    }
+    if (uint32_t(rhi_aspects & ETextureAspectFlags::STENCIL_SLICE) != 0) {
+        aspects = aspects | RenderGraph::TextureAspect::Stencil;
+    }
+    return aspects;
+}
+
+RenderGraph::TextureHandle ImportUiGraphTexture(
+    RenderGraph&      graph,
+    std::string_view  name,
+    const TextureRef& texture
+) {
+    if (!texture) {
+        return {};
+    }
+    const auto aspects = TextureAspects(texture);
+    if (aspects == RenderGraph::TextureAspect::None) {
+        return {};
+    }
+    return graph.ImportTexture(
+        name,
+        texture,
+        RenderGraph::TextureDesc{
+            .mip_count   = texture->GetNumMips(),
+            .layer_count = texture->GetNumArray(),
+            .aspects     = aspects,
+        }
+    );
+}
+
+void AddUniqueTarget(Array<TextureRef>& targets, const TextureRef& texture) {
+    if (!texture) {
+        return;
+    }
+    for (const auto& existing : targets) {
+        if (existing.Get() == texture.Get()) {
+            return;
+        }
+    }
+    targets.emplace_back(texture);
+}
+
+Array<TextureRef> CollectPresentationTargets(
+    const UiFrameGraphPass::PreparedFrame& frame,
+    const TextureRef&                      main_output
+) {
+    Array<TextureRef> targets{};
+    targets.reserve(frame.GetDrawFrame().platform_viewports.size() + 2);
+    AddUniqueTarget(targets, main_output);
+    const auto& composition = frame.GetComposition();
+    if (composition.enabled && composition.separate_window) {
+        AddUniqueTarget(targets, composition.window_frame_buffer);
+    }
+    for (const auto& viewport : frame.GetDrawFrame().platform_viewports) {
+        AddUniqueTarget(targets, viewport.framebuffer);
+    }
+    return targets;
+}
+
+bool HasTextureUsage(
+    const TextureRef&  texture,
+    ETextureUsageFlags required
+) {
+    if (!texture) {
+        return false;
+    }
+    const auto usage_bits = static_cast<uint32_t>(texture->GetUsage());
+    const auto required_bits = static_cast<uint32_t>(required);
+    return (usage_bits & required_bits) == required_bits;
+}
+
+bool IsColorOnlyTexture(const TextureRef& texture) {
+    if (!texture) {
+        return false;
+    }
+    const auto aspects = static_cast<uint32_t>(texture->GetAspectFlags());
+    return aspects == static_cast<uint32_t>(ETextureAspectFlags::COLOR);
+}
+
+bool SupportsUiPresentation(const TextureRef& texture) {
+    return IsColorOnlyTexture(texture) &&
+           HasTextureUsage(
+               texture,
+               ETextureUsageFlags::COLOR_ATTACHMENT |
+                   ETextureUsageFlags::TRANSFER_SRC |
+                   ETextureUsageFlags::TRANSFER_DST
+           );
+}
+
+bool SupportsUiSceneSampling(const TextureRef& texture) {
+    return IsColorOnlyTexture(texture) &&
+           HasTextureUsage(texture, ETextureUsageFlags::SAMPLED);
+}
+
+bool CollectValidatedPresentationTargets(
+    const UiFrameGraphPass::PreparedFrameRef& frame,
+    const TextureRef&                         scene_color,
+    const TextureRef&                         main_output,
+    Array<TextureRef>&                        targets
+) {
+    targets.clear();
+    if (!frame || !SupportsUiSceneSampling(scene_color) ||
+        !SupportsUiPresentation(main_output)) {
+        return false;
+    }
+    targets = CollectPresentationTargets(*frame, main_output);
+    return !targets.empty() &&
+           std::none_of(
+               targets.begin(),
+               targets.end(),
+               [](const TextureRef& target) {
+                   return !SupportsUiPresentation(target);
+               }
+           );
+}
+
+void FreezeRecordingSlot(UiViewportDrawPacket& viewport) {
+    if (!viewport.render_resources || viewport.commands.empty()) {
+        return;
+    }
+    viewport.recording_slot =
+        viewport.render_resources->GetPendingRecordingSlot();
+}
+
+TextureRef ResolveComposeTarget(
+    const UiFrameGraphPass::PreparedFrame& frame,
+    const TextureRef&                      main_output
+) {
+    const auto& composition = frame.GetComposition();
+    if (composition.enabled && composition.separate_window &&
+        composition.window_frame_buffer) {
+        return composition.window_frame_buffer;
+    }
+    return main_output;
+}
+
+} // namespace
+
+UiFrameGraphPass::PreparedFrame::PreparedFrame(
+    UiCompositionFrameData _composition,
+    UiDrawFramePacket      _draw_frame,
+    EUiDrawExecutionThread _execution_thread
+) :
+    composition(std::move(_composition)),
+    draw_frame(std::move(_draw_frame)),
+    execution_thread(_execution_thread) {
+    FreezeRecordingSlot(draw_frame.main_viewport);
+    for (auto& viewport : draw_frame.platform_viewports) {
+        FreezeRecordingSlot(viewport);
+    }
+}
+
+bool UiFrameGraphPass::PreparedFrame::BeginRecording() const noexcept {
+    ERecordingState expected = ERecordingState::Prepared;
+    return recording_state.compare_exchange_strong(
+        expected,
+        ERecordingState::Recording,
+        std::memory_order_acq_rel,
+        std::memory_order_acquire
+    );
+}
+
+bool UiFrameGraphPass::PreparedFrame::IsRecording() const noexcept {
+    return GetRecordingState() == ERecordingState::Recording;
+}
+
+void UiFrameGraphPass::PreparedFrame::FinishRecording() const noexcept {
+    ERecordingState expected = ERecordingState::Recording;
+    if (!recording_state.compare_exchange_strong(
+            expected,
+            ERecordingState::Recorded,
+            std::memory_order_release,
+            std::memory_order_acquire
+        )) {
+        RejectSource();
+    }
+}
+
+bool UiFrameGraphPass::PreparedFrame::ValidatePendingSlots() const noexcept {
+    const auto validate = [](const UiViewportDrawPacket& viewport) {
+        return viewport.recording_slot ==
+                   UiViewportDrawPacket::InvalidRecordingSlot ||
+               (viewport.render_resources &&
+                viewport.render_resources->IsPendingRecordingSlot(
+                    viewport.recording_slot
+                ));
+    };
+    if (!validate(draw_frame.main_viewport)) {
+        return false;
+    }
+    for (const auto& viewport : draw_frame.platform_viewports) {
+        if (!validate(viewport)) {
+            return false;
+        }
+    }
+    return true;
+}
+
+void UiFrameGraphPass::PreparedFrame::CommitPendingSlots() const noexcept {
+    Array<UiViewportRenderResources*> committed_resources{};
+    committed_resources.reserve(draw_frame.platform_viewports.size() + 1);
+    const auto commit = [&committed_resources](const UiViewportDrawPacket& viewport) {
+        if (viewport.recording_slot !=
+            UiViewportDrawPacket::InvalidRecordingSlot) {
+            auto* resources = viewport.render_resources.get();
+            for (const auto* committed : committed_resources) {
+                if (committed == resources) {
+                    return;
+                }
+            }
+            committed_resources.emplace_back(resources);
+            viewport.render_resources->CommitRecordingSlot(
+                viewport.recording_slot
+            );
+        }
+    };
+    commit(draw_frame.main_viewport);
+    for (const auto& viewport : draw_frame.platform_viewports) {
+        commit(viewport);
+    }
+}
+
+bool UiFrameGraphPass::PreparedFrame::CommitAcceptedSource() const noexcept {
+    const ERecordingState current = GetRecordingState();
+    if (current == ERecordingState::SourceAccepted ||
+        current == ERecordingState::FrameAccepted) {
+        return true;
+    }
+    if (current != ERecordingState::Recorded || !ValidatePendingSlots()) {
+        ERecordingState expected = ERecordingState::Recorded;
+        recording_state.compare_exchange_strong(
+            expected,
+            ERecordingState::Failed,
+            std::memory_order_release,
+            std::memory_order_acquire
+        );
+        return false;
+    }
+
+    ERecordingState expected = ERecordingState::Recorded;
+    if (!recording_state.compare_exchange_strong(
+        expected,
+        ERecordingState::SourceAccepted,
+        std::memory_order_release,
+        std::memory_order_acquire
+    )) {
+        return false;
+    }
+    CommitPendingSlots();
+    return true;
+}
+
+bool UiFrameGraphPass::PreparedFrame::CommitAcceptedFrame() const noexcept {
+    if (GetRecordingState() == ERecordingState::FrameAccepted) {
+        return true;
+    }
+    ERecordingState expected = ERecordingState::SourceAccepted;
+    return recording_state.compare_exchange_strong(
+        expected,
+        ERecordingState::FrameAccepted,
+        std::memory_order_release,
+        std::memory_order_acquire
+    );
+}
+
+void UiFrameGraphPass::PreparedFrame::RejectSource() const noexcept {
+    ERecordingState current = GetRecordingState();
+    while (current != ERecordingState::SourceAccepted &&
+           current != ERecordingState::FrameAccepted &&
+           current != ERecordingState::Failed) {
+        if (recording_state.compare_exchange_weak(
+                current,
+                ERecordingState::Failed,
+                std::memory_order_release,
+                std::memory_order_acquire
+            )) {
+            return;
+        }
+    }
+}
+
+void UiFrameGraphPass::PreparedFrame::Abandon() const noexcept {
+    RejectSource();
+}
+
+UiFrameGraphPass::PreparedFrameRef UiFrameGraphPass::Prepare(
+    UiCompositionFrameData composition,
+    UiDrawFramePacket      draw_frame,
+    EUiDrawExecutionThread execution_thread
+) {
+    return MakeShared<PreparedFrame>(
+        std::move(composition),
+        std::move(draw_frame),
+        execution_thread
+    );
+}
+
+bool UiFrameGraphPass::AddPasses(
+    RenderGraph&               graph,
+    UiCombinePass&             combine_pass,
+    const PreparedFrameRef&    frame,
+    RenderGraph::TextureHandle scene_color_handle,
+    const TextureRef&          scene_color,
+    const TextureRef&          main_output,
+    RenderGraph::TokenHandle   presentation_ready,
+    GraphPasses&               passes
+) {
+    return AddPassesWithComposeRecorder(
+        graph,
+        [&combine_pass, frame, scene_color, main_output](
+            CommandList& cmd_list
+        ) {
+            RecordCompose(
+                cmd_list,
+                combine_pass,
+                *frame,
+                scene_color,
+                main_output
+            );
+        },
+        frame,
+        scene_color_handle,
+        scene_color,
+        main_output,
+        presentation_ready,
+        passes
+    );
+}
+
+bool UiFrameGraphPass::AddPassesWithComposeRecorder(
+    RenderGraph&               graph,
+    ComposeRecorder            compose_recorder,
+    const PreparedFrameRef&    frame,
+    RenderGraph::TextureHandle scene_color_handle,
+    const TextureRef&          scene_color,
+    const TextureRef&          main_output,
+    RenderGraph::TokenHandle   presentation_ready,
+    GraphPasses&               passes
+) {
+    passes = {};
+    const TextureRef graph_scene_color =
+        graph.GetPhysicalTexture(scene_color_handle);
+    if (!compose_recorder || !graph_scene_color ||
+        graph_scene_color.Get() != scene_color.Get() ||
+        !scene_color_handle.IsValid() || !presentation_ready.IsValid()) {
+        return false;
+    }
+
+    Array<TextureRef> targets{};
+    if (!CollectValidatedPresentationTargets(
+            frame,
+            scene_color,
+            main_output,
+            targets
+        )) {
+        return false;
+    }
+
+    Array<RenderGraph::TextureHandle> target_handles{};
+    target_handles.reserve(targets.size());
+    RenderGraph::TextureHandle main_output_handle{};
+    RenderGraph::TextureHandle compose_target_handle{};
+    const TextureRef compose_target = ResolveComposeTarget(*frame, main_output);
+    for (size_t index = 0; index < targets.size(); ++index) {
+        const auto handle = ImportUiGraphTexture(
+            graph,
+            std::format("UI.presentation_target_{}", index),
+            targets[index]
+        );
+        if (!handle.IsValid()) {
+            return false;
+        }
+        graph.SetInitialState(
+            handle,
+            RenderGraph::TextureState::Undefined,
+            RenderGraph::QueueRole::None,
+            RenderGraph::AccessMode::None
+        );
+        if (targets[index].Get() == main_output.Get()) {
+            main_output_handle = handle;
+        }
+        if (targets[index].Get() == compose_target.Get()) {
+            compose_target_handle = handle;
+        }
+        target_handles.emplace_back(handle);
+    }
+    if (!main_output_handle.IsValid() || !compose_target_handle.IsValid()) {
+        return false;
+    }
+
+    passes.clear = graph.AddRecordPass(
+        "UI.ClearTargets",
+        [presentation_ready, target_handles](RenderGraph::PassBuilder& builder) {
+            builder
+                .ExecuteOn(
+                    RenderGraph::QueueRole::Graphics,
+                    RenderGraph::PipelineType::Copy
+                )
+                .Read(presentation_ready)
+                .SideEffect()
+                .SerialRecord();
+            for (const auto target : target_handles) {
+                builder.Write(
+                    target,
+                    RenderGraph::TextureState::TransferDestination
+                );
+            }
+        },
+        [frame, targets](CommandList& cmd_list) {
+            if (!frame->BeginRecording()) {
+                throw std::logic_error(
+                    "copied UI frame packet recording was already claimed"
+                );
+            }
+            ScopedGpuMarker marker(
+                cmd_list,
+                "UI Clear Targets",
+                GpuMarkerPalette::Ui()
+            );
+            RecordClear(cmd_list, targets);
+        },
+        RenderGraph::PassExecutionClass::SerialRecord
+    );
+
+    passes.compose = graph.AddRecordPass(
+        "UI.Compose",
+        [scene_color_handle, compose_target_handle, clear = passes.clear](
+            RenderGraph::PassBuilder& builder
+        ) {
+            builder
+                .ExecuteOn(
+                    RenderGraph::QueueRole::Graphics,
+                    RenderGraph::PipelineType::Graphics
+                )
+                .DependsOn(clear)
+                .Read(
+                    scene_color_handle,
+                    RenderGraph::TextureState::Sampled
+                )
+                .Write(
+                    compose_target_handle,
+                    RenderGraph::TextureState::RenderTarget
+                )
+                .SideEffect()
+                .SerialRecord();
+        },
+        [frame, compose_recorder = std::move(compose_recorder)](
+            CommandList& cmd_list
+        ) {
+            if (!frame->IsRecording()) {
+                throw std::logic_error(
+                    "copied UI frame packet compose executed outside its recording claim"
+                );
+            }
+            compose_recorder(cmd_list);
+        },
+        RenderGraph::PassExecutionClass::SerialRecord
+    );
+
+    passes.draw = graph.AddRecordPass(
+        "UI.DrawCopiedFrame",
+        [target_handles, compose = passes.compose](
+            RenderGraph::PassBuilder& builder
+        ) {
+            builder
+                .ExecuteOn(
+                    RenderGraph::QueueRole::Graphics,
+                    RenderGraph::PipelineType::Graphics
+                )
+                .DependsOn(compose)
+                .SideEffect()
+                .SerialRecord()
+                .TranslateSerialControl();
+            for (const auto target : target_handles) {
+                builder.ReadWrite(
+                    target,
+                    RenderGraph::TextureState::RenderTarget
+                );
+            }
+        },
+        [frame, main_output](CommandList& cmd_list) {
+            if (!frame->IsRecording()) {
+                throw std::logic_error(
+                    "copied UI frame packet draw executed outside its recording claim"
+                );
+            }
+            RecordDraw(cmd_list, *frame, main_output);
+            frame->FinishRecording();
+            if (frame->GetRecordingState() != ERecordingState::Recorded) {
+                throw std::logic_error(
+                    "copied UI frame packet failed to finalize recording"
+                );
+            }
+        },
+        RenderGraph::PassExecutionClass::SerialRecord
+    );
+
+    for (const auto target : target_handles) {
+        graph.Export(
+            target,
+            RenderGraph::TextureState::TransferSource,
+            RenderGraph::QueueRole::Graphics,
+            RenderGraph::AccessMode::Read
+        );
+    }
+
+    passes.main_output          = main_output_handle;
+    passes.presentation_targets = std::move(target_handles);
+    return passes.IsValid();
+}
+
+bool UiFrameGraphPass::ProcessLinear(
+    CommandList&            cmd_list,
+    UiCombinePass&          combine_pass,
+    const PreparedFrameRef& frame,
+    const TextureRef&       scene_color,
+    const TextureRef&       main_output
+) {
+    return ProcessLinearWithComposeRecorder(
+        cmd_list,
+        [&combine_pass, frame, scene_color, main_output](
+            CommandList& recording_list
+        ) {
+            RecordCompose(
+                recording_list,
+                combine_pass,
+                *frame,
+                scene_color,
+                main_output
+            );
+        },
+        frame,
+        scene_color,
+        main_output
+    );
+}
+
+bool UiFrameGraphPass::ProcessLinearWithComposeRecorder(
+    CommandList&            cmd_list,
+    ComposeRecorder         compose_recorder,
+    const PreparedFrameRef& frame,
+    const TextureRef&       scene_color,
+    const TextureRef&       main_output
+) {
+    Array<TextureRef> targets{};
+    if (!compose_recorder ||
+        !CollectValidatedPresentationTargets(
+            frame,
+            scene_color,
+            main_output,
+            targets
+        ) ||
+        !frame->BeginRecording()) {
+        return false;
+    }
+
+    try {
+        RecordClear(cmd_list, targets);
+        compose_recorder(cmd_list);
+        RecordDraw(cmd_list, *frame, main_output);
+        frame->FinishRecording();
+        return frame->GetRecordingState() == ERecordingState::Recorded;
+    } catch (...) {
+        frame->Abandon();
+        throw;
+    }
+}
+
+void UiFrameGraphPass::RecordClear(
+    CommandList&             cmd_list,
+    const Array<TextureRef>& targets
+) {
+    for (const auto& target : targets) {
+        if (target) {
+            cmd_list.ClearResource(
+                target->GetView(),
+                float4(0.f, 0.f, 0.f, 1.f)
+            );
+        }
+    }
+}
+
+void UiFrameGraphPass::RecordCompose(
+    CommandList&         cmd_list,
+    UiCombinePass&       combine_pass,
+    const PreparedFrame& frame,
+    const TextureRef&    scene_color,
+    const TextureRef&    main_output
+) {
+    const auto& composition = frame.GetComposition();
+    if (composition.enabled) {
+        const TextureView window_frame_buffer =
+            composition.window_frame_buffer ?
+                composition.window_frame_buffer->GetView() :
+                TextureView{};
+        combine_pass.Process(
+            cmd_list,
+            composition.separate_window,
+            composition.output_resolution,
+            composition.scene_color_position,
+            composition.scene_color_resolution,
+            window_frame_buffer,
+            scene_color->GetView(),
+            main_output->GetView()
+        );
+        return;
+    }
+
+    const auto extent = main_output->GetExtent();
+    combine_pass.Process(
+        cmd_list,
+        true,
+        uint2(extent.x, extent.y),
+        float2(0.f, 0.f),
+        float2(static_cast<float>(extent.x), static_cast<float>(extent.y)),
+        main_output->GetView(),
+        scene_color->GetView(),
+        main_output->GetView()
+    );
+}
+
+void UiFrameGraphPass::RecordDraw(
+    CommandList&         cmd_list,
+    const PreparedFrame& frame,
+    const TextureRef&    main_output
+) {
+    RenderUiDrawFrame(
+        cmd_list,
+        main_output->GetView(),
+        frame.GetDrawFrame(),
+        frame.GetExecutionThread()
+    );
+}
+
+} // namespace Moer::Render

--- a/source/runtime/render/renderer/common/UiFrameGraphPass.cpp
+++ b/source/runtime/render/renderer/common/UiFrameGraphPass.cpp
@@ -133,14 +133,6 @@ bool CollectValidatedPresentationTargets(
            );
 }
 
-void FreezeRecordingSlot(UiViewportDrawPacket& viewport) {
-    if (!viewport.render_resources || viewport.commands.empty()) {
-        return;
-    }
-    viewport.recording_slot =
-        viewport.render_resources->GetPendingRecordingSlot();
-}
-
 TextureRef ResolveComposeTarget(
     const UiFrameGraphPass::PreparedFrame& frame,
     const TextureRef&                      main_output
@@ -162,12 +154,8 @@ UiFrameGraphPass::PreparedFrame::PreparedFrame(
 ) :
     composition(std::move(_composition)),
     draw_frame(std::move(_draw_frame)),
-    execution_thread(_execution_thread) {
-    FreezeRecordingSlot(draw_frame.main_viewport);
-    for (auto& viewport : draw_frame.platform_viewports) {
-        FreezeRecordingSlot(viewport);
-    }
-}
+    slot_claim(draw_frame),
+    execution_thread(_execution_thread) {}
 
 bool UiFrameGraphPass::PreparedFrame::BeginRecording() const noexcept {
     ERecordingState expected = ERecordingState::Prepared;
@@ -195,57 +183,14 @@ void UiFrameGraphPass::PreparedFrame::FinishRecording() const noexcept {
     }
 }
 
-bool UiFrameGraphPass::PreparedFrame::ValidatePendingSlots() const noexcept {
-    const auto validate = [](const UiViewportDrawPacket& viewport) {
-        return viewport.recording_slot ==
-                   UiViewportDrawPacket::InvalidRecordingSlot ||
-               (viewport.render_resources &&
-                viewport.render_resources->IsPendingRecordingSlot(
-                    viewport.recording_slot
-                ));
-    };
-    if (!validate(draw_frame.main_viewport)) {
-        return false;
-    }
-    for (const auto& viewport : draw_frame.platform_viewports) {
-        if (!validate(viewport)) {
-            return false;
-        }
-    }
-    return true;
-}
-
-void UiFrameGraphPass::PreparedFrame::CommitPendingSlots() const noexcept {
-    Array<UiViewportRenderResources*> committed_resources{};
-    committed_resources.reserve(draw_frame.platform_viewports.size() + 1);
-    const auto commit = [&committed_resources](const UiViewportDrawPacket& viewport) {
-        if (viewport.recording_slot !=
-            UiViewportDrawPacket::InvalidRecordingSlot) {
-            auto* resources = viewport.render_resources.get();
-            for (const auto* committed : committed_resources) {
-                if (committed == resources) {
-                    return;
-                }
-            }
-            committed_resources.emplace_back(resources);
-            viewport.render_resources->CommitRecordingSlot(
-                viewport.recording_slot
-            );
-        }
-    };
-    commit(draw_frame.main_viewport);
-    for (const auto& viewport : draw_frame.platform_viewports) {
-        commit(viewport);
-    }
-}
-
 bool UiFrameGraphPass::PreparedFrame::CommitAcceptedSource() const noexcept {
     const ERecordingState current = GetRecordingState();
     if (current == ERecordingState::SourceAccepted ||
         current == ERecordingState::FrameAccepted) {
         return true;
     }
-    if (current != ERecordingState::Recorded || !ValidatePendingSlots()) {
+    if (current != ERecordingState::Recorded ||
+        !slot_claim.IsReadyForRecording()) {
         ERecordingState expected = ERecordingState::Recorded;
         recording_state.compare_exchange_strong(
             expected,
@@ -253,20 +198,31 @@ bool UiFrameGraphPass::PreparedFrame::CommitAcceptedSource() const noexcept {
             std::memory_order_release,
             std::memory_order_acquire
         );
+        slot_claim.Reject();
         return false;
     }
 
     ERecordingState expected = ERecordingState::Recorded;
     if (!recording_state.compare_exchange_strong(
-        expected,
-        ERecordingState::SourceAccepted,
-        std::memory_order_release,
-        std::memory_order_acquire
-    )) {
+            expected,
+            ERecordingState::SourceAccepted,
+            std::memory_order_release,
+            std::memory_order_acquire
+        )) {
         return false;
     }
-    CommitPendingSlots();
-    return true;
+    if (slot_claim.CommitAccepted()) {
+        return true;
+    }
+
+    expected = ERecordingState::SourceAccepted;
+    recording_state.compare_exchange_strong(
+        expected,
+        ERecordingState::Failed,
+        std::memory_order_release,
+        std::memory_order_acquire
+    );
+    return false;
 }
 
 bool UiFrameGraphPass::PreparedFrame::CommitAcceptedFrame() const noexcept {
@@ -293,8 +249,12 @@ void UiFrameGraphPass::PreparedFrame::RejectSource() const noexcept {
                 std::memory_order_release,
                 std::memory_order_acquire
             )) {
+            slot_claim.Reject();
             return;
         }
+    }
+    if (current == ERecordingState::Failed) {
+        slot_claim.Reject();
     }
 }
 

--- a/source/runtime/render/renderer/common/UiFrameGraphPass.h
+++ b/source/runtime/render/renderer/common/UiFrameGraphPass.h
@@ -68,11 +68,10 @@ public:
         [[nodiscard]] bool BeginRecording() const noexcept;
         [[nodiscard]] bool IsRecording() const noexcept;
         void FinishRecording() const noexcept;
-        [[nodiscard]] bool ValidatePendingSlots() const noexcept;
-        void CommitPendingSlots() const noexcept;
 
         UiCompositionFrameData composition{};
         UiDrawFramePacket      draw_frame{};
+        UiDrawFrameSlotClaim   slot_claim;
         EUiDrawExecutionThread execution_thread{EUiDrawExecutionThread::Game};
         mutable std::atomic<ERecordingState> recording_state{ERecordingState::Prepared};
 

--- a/source/runtime/render/renderer/common/UiFrameGraphPass.h
+++ b/source/runtime/render/renderer/common/UiFrameGraphPass.h
@@ -1,0 +1,168 @@
+#pragma once
+
+#include "UIRenderer.h"
+#include "UiCombinePass.h"
+#include "rendergraph/RenderGraph.h"
+
+#include <atomic>
+#include <functional>
+
+namespace Moer::Render {
+
+class UiFrameGraphPassTestAccess;
+
+/**
+ * Owns the copied editor draw packet across RenderGraph recording and the
+ * Executor-owned Present epilogue. The packet is immutable after capture; the
+ * one-shot state protects the mutable ImGui GPU upload-ring backend.
+ */
+class RENDER_API UiFrameGraphPass {
+public:
+    enum class ERecordingState : uint8_t {
+        Prepared,
+        Recording,
+        Recorded,
+        SourceAccepted,
+        FrameAccepted,
+        Failed,
+    };
+
+    class RENDER_API PreparedFrame {
+    public:
+        PreparedFrame(
+            UiCompositionFrameData composition,
+            UiDrawFramePacket      draw_frame,
+            EUiDrawExecutionThread execution_thread
+        );
+
+        PreparedFrame(const PreparedFrame&)            = delete;
+        PreparedFrame& operator=(const PreparedFrame&) = delete;
+
+        [[nodiscard]] const UiCompositionFrameData& GetComposition() const {
+            return composition;
+        }
+        [[nodiscard]] const UiDrawFramePacket& GetDrawFrame() const {
+            return draw_frame;
+        }
+        [[nodiscard]] EUiDrawExecutionThread GetExecutionThread() const {
+            return execution_thread;
+        }
+        [[nodiscard]] ERecordingState GetRecordingState() const noexcept {
+            return recording_state.load(std::memory_order_acquire);
+        }
+        [[nodiscard]] bool CanPresent() const noexcept {
+            return GetRecordingState() == ERecordingState::FrameAccepted;
+        }
+        [[nodiscard]] bool CommitAcceptedSource() const noexcept;
+        [[nodiscard]] bool CommitAcceptedFrame() const noexcept;
+        void RejectSource() const noexcept;
+
+        /**
+         * Makes any graph recording failure terminal for this packet. A graph
+         * may have entered Clear/Compose before another source fails, so the
+         * renderer must never replay the packet on a linear CommandList.
+         */
+        void Abandon() const noexcept;
+
+    private:
+        [[nodiscard]] bool BeginRecording() const noexcept;
+        [[nodiscard]] bool IsRecording() const noexcept;
+        void FinishRecording() const noexcept;
+        [[nodiscard]] bool ValidatePendingSlots() const noexcept;
+        void CommitPendingSlots() const noexcept;
+
+        UiCompositionFrameData composition{};
+        UiDrawFramePacket      draw_frame{};
+        EUiDrawExecutionThread execution_thread{EUiDrawExecutionThread::Game};
+        mutable std::atomic<ERecordingState> recording_state{ERecordingState::Prepared};
+
+        friend class UiFrameGraphPass;
+        friend class UiFrameGraphPassTestAccess;
+    };
+
+    using PreparedFrameRef = SharedPtr<PreparedFrame>;
+
+    struct GraphPasses {
+        RenderGraph::PassHandle    clear{};
+        RenderGraph::PassHandle    compose{};
+        RenderGraph::PassHandle    draw{};
+        RenderGraph::TextureHandle main_output{};
+        Array<RenderGraph::TextureHandle> presentation_targets{};
+
+        [[nodiscard]] bool IsValid() const {
+            return clear.IsValid() && compose.IsValid() && draw.IsValid() &&
+                   main_output.IsValid() && !presentation_targets.empty();
+        }
+    };
+
+    [[nodiscard]] static PreparedFrameRef Prepare(
+        UiCompositionFrameData composition,
+        UiDrawFramePacket      draw_frame,
+        EUiDrawExecutionThread execution_thread
+    );
+
+    [[nodiscard]] static bool AddPasses(
+        RenderGraph&                     graph,
+        UiCombinePass&                   combine_pass,
+        const PreparedFrameRef&          frame,
+        RenderGraph::TextureHandle       scene_color_handle,
+        const TextureRef&                scene_color,
+        const TextureRef&                main_output,
+        RenderGraph::TokenHandle         presentation_ready,
+        GraphPasses&                     passes
+    );
+
+    [[nodiscard]] static bool ProcessLinear(
+        CommandList&            cmd_list,
+        UiCombinePass&          combine_pass,
+        const PreparedFrameRef& frame,
+        const TextureRef&       scene_color,
+        const TextureRef&       main_output
+    );
+
+private:
+    /**
+     * Trusted declaration seam shared by the production compositor and the
+     * graph-contract test. The callback may only record the UI.Compose body;
+     * all resource declarations remain owned here.
+     */
+    using ComposeRecorder = std::function<void(CommandList&)>;
+    [[nodiscard]] static bool AddPassesWithComposeRecorder(
+        RenderGraph&               graph,
+        ComposeRecorder            compose_recorder,
+        const PreparedFrameRef&    frame,
+        RenderGraph::TextureHandle scene_color_handle,
+        const TextureRef&          scene_color,
+        const TextureRef&          main_output,
+        RenderGraph::TokenHandle   presentation_ready,
+        GraphPasses&               passes
+    );
+    [[nodiscard]] static bool ProcessLinearWithComposeRecorder(
+        CommandList&            cmd_list,
+        ComposeRecorder         compose_recorder,
+        const PreparedFrameRef& frame,
+        const TextureRef&       scene_color,
+        const TextureRef&       main_output
+    );
+
+    static void RecordClear(
+        CommandList&             cmd_list,
+        const Array<TextureRef>& targets
+    );
+    static void RecordCompose(
+        CommandList&            cmd_list,
+        UiCombinePass&          combine_pass,
+        const PreparedFrame&    frame,
+        const TextureRef&       scene_color,
+        const TextureRef&       main_output
+    );
+    static void RecordDraw(
+        CommandList&         cmd_list,
+        const PreparedFrame& frame,
+        const TextureRef&    main_output
+    );
+
+    friend class UiFrameGraphPassTestAccess;
+};
+
+} // namespace Moer::Render

--- a/source/runtime/render/renderer/common/ui/DearImGuiRenderer.cpp
+++ b/source/runtime/render/renderer/common/ui/DearImGuiRenderer.cpp
@@ -46,7 +46,7 @@ struct ImGuiData;
 
 void InitializeGuiPlatformInterface();
 void RenderGuiDrawPacket(
-    UiViewportDrawPacket& _draw_packet,
+    const UiViewportDrawPacket& _draw_packet,
     const TextureView&    _framebuffer,
     CommandList&          _cmd_list,
     ImGuiData&            _backend_data,
@@ -112,6 +112,21 @@ struct GuiViewportRenderResources final : UiViewportRenderResources {
     uint64_t frame_index = 0;
 
     explicit GuiViewportRenderResources(uint32_t _frame_in_flight) : render_buffers(_frame_in_flight) {}
+
+    uint64_t GetPendingRecordingSlot() const noexcept override {
+        return frame_index;
+    }
+
+    bool IsPendingRecordingSlot(uint64_t slot) const noexcept override {
+        return slot == frame_index;
+    }
+
+    void CommitRecordingSlot(uint64_t slot) noexcept override {
+        assert(slot == frame_index);
+        if (slot == frame_index) {
+            ++frame_index;
+        }
+    }
 };
 
 struct GuiViewportData {
@@ -516,7 +531,7 @@ UiDrawFramePacket ImGuiRenderBackend::CaptureDrawFrame() {
 void ImGuiRenderBackend::RenderGUI(
     CommandList&           _cmd_list,
     const TextureView&     _main_framebuffer,
-    UiDrawFramePacket&     _frame,
+    const UiDrawFramePacket& _frame,
     EUiDrawExecutionThread _execution_thread
 ) {
     assert(
@@ -533,7 +548,7 @@ void ImGuiRenderBackend::RenderGUI(
         RenderGuiDrawPacket(_frame.main_viewport, _main_framebuffer, _cmd_list, render_data, *this);
     }
     for (size_t viewport_index = 0; viewport_index < _frame.platform_viewports.size(); ++viewport_index) {
-        auto& viewport = _frame.platform_viewports[viewport_index];
+        const auto& viewport = _frame.platform_viewports[viewport_index];
         if (viewport.framebuffer && !viewport.commands.empty()) {
             ScopedGpuMarker viewport_marker(
                 _cmd_list,
@@ -674,27 +689,27 @@ static GuiPipeline::Constant CreateGuiProjection(const UiViewportDrawPacket& _dr
 
 static void UploadGuiDrawData(
     CommandList&                    _cmd_list,
-    UiViewportDrawPacket&           _draw_packet,
+    const UiViewportDrawPacket&     _draw_packet,
     Array<ImGuiDrawArgument>&       _arguments,
     const GuiFrameRenderBuffers&    _render_buffers
 ) {
     _cmd_list.CopyFrom(
-        std::span<Moer::byte>(
-            reinterpret_cast<Moer::byte*>(_draw_packet.vertices.data()),
+        std::span<const Moer::byte>(
+            reinterpret_cast<const Moer::byte*>(_draw_packet.vertices.data()),
             _draw_packet.vertices.size() * sizeof(UiDrawVertex)
         ),
         _render_buffers.vertex_buffer->GetView()
     );
     _cmd_list.CopyFrom(
-        std::span<Moer::byte>(
-            reinterpret_cast<Moer::byte*>(_draw_packet.indices.data()),
+        std::span<const Moer::byte>(
+            reinterpret_cast<const Moer::byte*>(_draw_packet.indices.data()),
             _draw_packet.indices.size() * sizeof(UiDrawIndex)
         ),
         _render_buffers.index_buffer->GetView()
     );
     _cmd_list.CopyFrom(
-        std::span<Moer::byte>(
-            reinterpret_cast<Moer::byte*>(_arguments.data()),
+        std::span<const Moer::byte>(
+            reinterpret_cast<const Moer::byte*>(_arguments.data()),
             _arguments.size() * sizeof(ImGuiDrawArgument)
         ),
         _render_buffers.argument_buffer->GetView()
@@ -702,7 +717,7 @@ static void UploadGuiDrawData(
 }
 
 void RenderGuiDrawPacket(
-    UiViewportDrawPacket& _draw_packet,
+    const UiViewportDrawPacket& _draw_packet,
     const TextureView&    _framebuffer,
     CommandList&          _cmd_list,
     ImGuiData&            _backend_data,
@@ -734,10 +749,16 @@ void RenderGuiDrawPacket(
         return;
     }
 
+    if (_draw_packet.recording_slot == UiViewportDrawPacket::InvalidRecordingSlot ||
+        !render_resources->IsPendingRecordingSlot(_draw_packet.recording_slot)) {
+        throw std::logic_error(
+            "copied UI draw packet does not own the current upload-ring slot"
+        );
+    }
     GuiFrameRenderBuffers& render_buffers =
-        render_resources
-            ->render_buffers[render_resources->frame_index % render_resources->render_buffers.size()];
-    render_resources->frame_index++;
+        render_resources->render_buffers[
+            _draw_packet.recording_slot % render_resources->render_buffers.size()
+        ];
 
     auto&        device        = _render_backend.device;
     const uint32 vertex_count  = static_cast<uint32>(_draw_packet.vertices.size());
@@ -767,10 +788,6 @@ void RenderGuiDrawPacket(
             ColorAttachment(_framebuffer.GetTexture(), EAttachmentAction::AC_LOAD_STORE)
         );
 
-    // CopyFrom 的源数据要持续到命令执行结束，因此通过空回调延长这些数组的生命周期。
-    _cmd_list.AddCallback([vertices(std::move(_draw_packet.vertices)),
-                           indices(std::move(_draw_packet.indices)),
-                           arguments(std::move(arguments))]() {});
 }
 
 void GuiCreateWindow(ImGuiViewport* _viewport);
@@ -838,7 +855,10 @@ void CreateOrResizeViewportResources(
     _resources->framebuffer = _device.CreateTexture(
         Extent2D(_extent.x, _extent.y),
         PF_R8G8B8A8_SRGB,
-        ETextureUsageFlags::COLOR_ATTACHMENT | ETextureUsageFlags::SAMPLED
+        ETextureUsageFlags::COLOR_ATTACHMENT |
+            ETextureUsageFlags::SAMPLED |
+            ETextureUsageFlags::TRANSFER_SRC |
+            ETextureUsageFlags::TRANSFER_DST
     );
     _resources->framebuffer->SetName(std::format("ImGui Window {}", _viewport_index));
 
@@ -1018,6 +1038,8 @@ void GuiRenderWindow(ImGuiViewport* _viewport, void* _cmd_list) {
 
     ImGuiData& backend_data = *GetImGuiBackendData();
     auto       draw_packet  = CaptureViewportDrawPacket(_viewport->DrawData, viewport_data);
+    draw_packet.recording_slot =
+        draw_packet.render_resources->GetPendingRecordingSlot();
     RenderGuiDrawPacket(
         draw_packet,
         viewport_data->render_resources->framebuffer->GetView(),
@@ -1025,6 +1047,13 @@ void GuiRenderWindow(ImGuiViewport* _viewport, void* _cmd_list) {
         backend_data,
         *backend_data.render_backend
     );
+    if (draw_packet.render_resources->IsPendingRecordingSlot(
+            draw_packet.recording_slot
+        )) {
+        draw_packet.render_resources->CommitRecordingSlot(
+            draw_packet.recording_slot
+        );
+    }
 }
 
 void GuiSwapBuffers(ImGuiViewport* _viewport, void*) {

--- a/source/runtime/render/renderer/common/ui/DearImGuiRenderer.h
+++ b/source/runtime/render/renderer/common/ui/DearImGuiRenderer.h
@@ -29,7 +29,7 @@ public:
     void RenderGUI(
         CommandList&           _cmd_list,
         const TextureView&     _main_framebuffer,
-        UiDrawFramePacket&     _frame,
+        const UiDrawFramePacket& _frame,
         EUiDrawExecutionThread _execution_thread
     ) override;
     void PresentWindows(const UiDrawFramePacket& _frame, EUiDrawExecutionThread _execution_thread) override;

--- a/source/runtime/render/renderer/common/ui/UIRenderer.cpp
+++ b/source/runtime/render/renderer/common/ui/UIRenderer.cpp
@@ -72,7 +72,7 @@ TextureRef UIRenderer::GetWindowFrameBuffer(void* _window) {
 void RenderUiDrawFrame(
     CommandList&           _cmd_list,
     const TextureView&     _main_framebuffer,
-    UiDrawFramePacket&     _frame,
+    const UiDrawFramePacket& _frame,
     EUiDrawExecutionThread _execution_thread
 ) {
     if (_frame.backend) {

--- a/source/runtime/render/renderer/common/ui/UIRenderer.cpp
+++ b/source/runtime/render/renderer/common/ui/UIRenderer.cpp
@@ -5,6 +5,100 @@
 #include "rhi/RHI.h"
 
 namespace Moer::Render {
+UiDrawFrameSlotClaim::UiDrawFrameSlotClaim(UiDrawFramePacket& frame) {
+    slots.reserve(frame.platform_viewports.size() + 1);
+    Freeze(frame.main_viewport);
+    for (UiViewportDrawPacket& viewport : frame.platform_viewports) {
+        Freeze(viewport);
+    }
+}
+
+void UiDrawFrameSlotClaim::Freeze(UiViewportDrawPacket& viewport) {
+    if (viewport.commands.empty()) {
+        return;
+    }
+    if (!viewport.render_resources) {
+        structurally_valid = false;
+        return;
+    }
+
+    const uint64_t pending_slot =
+        viewport.render_resources->GetPendingRecordingSlot();
+    viewport.recording_slot = pending_slot;
+
+    for (const Slot& slot : slots) {
+        if (slot.resources.get() != viewport.render_resources.get()) {
+            continue;
+        }
+        if (slot.value != pending_slot) {
+            structurally_valid = false;
+        }
+        return;
+    }
+    slots.emplace_back(Slot{
+        .resources = viewport.render_resources,
+        .value     = pending_slot,
+    });
+}
+
+bool UiDrawFrameSlotClaim::ValidatePendingSlots() const noexcept {
+    if (!structurally_valid) {
+        return false;
+    }
+    for (const Slot& slot : slots) {
+        if (!slot.resources ||
+            !slot.resources->IsPendingRecordingSlot(slot.value)) {
+            return false;
+        }
+    }
+    return true;
+}
+
+bool UiDrawFrameSlotClaim::IsReadyForRecording() const noexcept {
+    return GetState() == EState::Pending && ValidatePendingSlots();
+}
+
+bool UiDrawFrameSlotClaim::CommitAccepted() const noexcept {
+    EState current = GetState();
+    if (current == EState::Accepted) {
+        return true;
+    }
+    if (current != EState::Pending || !ValidatePendingSlots()) {
+        EState expected = EState::Pending;
+        state.compare_exchange_strong(
+            expected,
+            EState::Rejected,
+            std::memory_order_acq_rel,
+            std::memory_order_acquire
+        );
+        return false;
+    }
+
+    EState expected = EState::Pending;
+    if (!state.compare_exchange_strong(
+            expected,
+            EState::Accepted,
+            std::memory_order_acq_rel,
+            std::memory_order_acquire
+        )) {
+        return expected == EState::Accepted;
+    }
+    for (const Slot& slot : slots) {
+        slot.resources->CommitRecordingSlot(slot.value);
+    }
+    return true;
+}
+
+void UiDrawFrameSlotClaim::Reject() const noexcept {
+    EState expected = EState::Pending;
+    state.compare_exchange_strong(
+        expected,
+        EState::Rejected,
+        std::memory_order_acq_rel,
+        std::memory_order_acquire
+    );
+}
+
 struct UIRenderer::Impl {
     explicit Impl(RenderDevice& _device) : backend(MakeShared<ImGuiRenderBackend>(_device)) {}
 

--- a/source/runtime/render/renderer/raster/RasterRenderer.cpp
+++ b/source/runtime/render/renderer/raster/RasterRenderer.cpp
@@ -637,7 +637,6 @@ RasterFrameFeedback RasterRenderer::RenderFrame(RasterFramePacket frame_packet) 
             RenderGraph::TokenHandle   tonemapping_state;
             RenderGraph::TextureHandle tonemapping_output;
             RenderGraph::TextureHandle selected_framebuffer;
-            RenderGraph::TextureHandle ui_framebuffer;
             RenderGraph::TextureHandle window_framebuffer;
             RenderGraph::TextureHandle output;
             RenderGraph::BufferHandle  scene_lights;
@@ -1060,7 +1059,6 @@ RasterFrameFeedback RasterRenderer::RenderFrame(RasterFramePacket frame_packet) 
                             .Write(graph_resources.window_framebuffer);
                     } else {
                         builder.Read(graph_resources.selected_framebuffer)
-                            .Read(graph_resources.ui_framebuffer)
                             .Write(graph_resources.output);
                     }
                     builder.SideEffect();
@@ -1076,7 +1074,6 @@ RasterFrameFeedback RasterRenderer::RenderFrame(RasterFramePacket frame_packet) 
                             ui_frame.scene_color_resolution,
                             window_framebuffer_view,
                             selected_framebuffer_view,
-                            raster_context.textures.ui_frame_buffer.tex,
                             raster_context.textures.output.tex
                         );
                     } else {
@@ -1093,7 +1090,6 @@ RasterFrameFeedback RasterRenderer::RenderFrame(RasterFramePacket frame_packet) 
                             ),
                             TextureView(raster_context.textures.output.tex),
                             processing_image.tex,
-                            {},
                             raster_context.textures.output.tex
                         );
                     }
@@ -1241,8 +1237,6 @@ RasterFrameFeedback RasterRenderer::RenderFrame(RasterFramePacket frame_packet) 
                     );
                 }
             }
-            graph_resources.ui_framebuffer =
-                import_texture("ui_framebuffer", raster_context.textures.ui_frame_buffer.tex);
             if (ui_writes_external_window) {
                 graph_resources.window_framebuffer = import_physical_texture(
                     "window_framebuffer", window_framebuffer_view.GetTexture()

--- a/source/runtime/render/renderer/raster/RasterRenderer.cpp
+++ b/source/runtime/render/renderer/raster/RasterRenderer.cpp
@@ -1419,9 +1419,23 @@ RasterFrameFeedback RasterRenderer::RenderFrame(RasterFramePacket frame_packet) 
 
     const auto ui_execution_thread =
         IsRenderThreadInitialized() ? EUiDrawExecutionThread::Render : EUiDrawExecutionThread::Game;
-    RenderUiDrawFrame(
-        cmd_list, default_output_texture->GetView(), frame_packet.ui_draw_frame, ui_execution_thread
-    );
+    UiDrawFrameSlotClaim ui_slot_claim(frame_packet.ui_draw_frame);
+    const bool ui_recording_claimed =
+        ui_slot_claim.IsReadyForRecording();
+    if (ui_recording_claimed) {
+        RenderUiDrawFrame(
+            cmd_list,
+            default_output_texture->GetView(),
+            frame_packet.ui_draw_frame,
+            ui_execution_thread
+        );
+    } else {
+        ui_slot_claim.Reject();
+        LOG_CRITICAL(
+            "[Threading][UI] Raster copied-frame upload slots could not be "
+            "claimed; preserving the slots and skipping this UI frame."
+        );
+    }
 
     raster_context.probe_volume.TrackFrameSubmission(cmd_list, time);
     time++;
@@ -1477,7 +1491,21 @@ RasterFrameFeedback RasterRenderer::RenderFrame(RasterFramePacket frame_packet) 
         present_request ? &*present_request : nullptr
     );
 
-    if (!skip_present) {
+    const bool frame_native_accepted = timeline->WaitSubmitted(time);
+    bool       ui_source_accepted    = false;
+    if (frame_native_accepted && ui_recording_claimed) {
+        ui_source_accepted = ui_slot_claim.CommitAccepted();
+    } else {
+        ui_slot_claim.Reject();
+    }
+    if (!ui_source_accepted) {
+        LOG_CRITICAL(
+            "[Threading][UI] Raster frame submission rejected the copied UI "
+            "source; preserving its upload-ring slots."
+        );
+    }
+
+    if (!skip_present && frame_native_accepted && ui_source_accepted) {
         PresentUiDrawFrame(frame_packet.ui_draw_frame, ui_execution_thread);
     }
 

--- a/source/runtime/render/renderer/raster/RasterTextures.h
+++ b/source/runtime/render/renderer/raster/RasterTextures.h
@@ -50,8 +50,11 @@ namespace Moer::Render::Raster {
           .IndivisualMips()                                                                                     \
           .SamplerConfig(SF_LINEAR, SAM_CLAMP_TO_EDGE))                                                         \
     X(TexHandle, tonemapping_output, Tex2DTag, TexConfig::Default(PF_R8G8B8A8_UNORM).Usage(E_SAMPLED_COLOR))    \
-    X(TexHandle, ui_frame_buffer, Tex2DTag, TexConfig::Default(PF_R8G8B8A8_UNORM).Usage(E_SAMPLED_COLOR))       \
-    X(TexHandle, output, Tex2DTag, TexConfig::Default(PF_R8G8B8A8_SRGB).Usage(E_SAMPLED_COLOR))                 \
+    X(TexHandle,                                                                                                \
+      output,                                                                                                   \
+      Tex2DTag,                                                                                                 \
+      TexConfig::Default(PF_R8G8B8A8_SRGB)                                                                      \
+          .Usage(E_SAMPLED_COLOR | ETextureUsageFlags::TRANSFER_SRC | ETextureUsageFlags::TRANSFER_DST))        \
     X(DepthBufferWithHandle,                                                                                    \
       depth_linear_sampler,                                                                                     \
       TexDepthTag,                                                                                              \

--- a/source/runtime/render/renderer/raytracing/CompositionPass.cpp
+++ b/source/runtime/render/renderer/raytracing/CompositionPass.cpp
@@ -147,6 +147,7 @@ bool CompositionPass::AddPasses(
         !resources.diffuse_lighting || !resources.specular_lighting ||
         !resources.denoised_diffuse_lighting ||
         !resources.denoised_specular_lighting || !resources.bindless_array ||
+        !graph_resources.frame_setup.ready.IsValid() ||
         (command.constants.enable_env_map != 0 &&
          (!resources.env_map || !graph_resources.env_map.IsValid()))) {
         return false;
@@ -199,6 +200,7 @@ bool CompositionPass::AddPasses(
                     RenderGraph::PipelineType::Compute
                 )
                 .Read(constants, RenderGraph::BufferState::ShaderResource)
+                .Read(graph_resources.frame_setup.ready)
                 .Write(
                     graph_resources.hdr_color,
                     RenderGraph::TextureState::UnorderedAccess

--- a/source/runtime/render/renderer/raytracing/CompositionPass.cpp
+++ b/source/runtime/render/renderer/raytracing/CompositionPass.cpp
@@ -140,6 +140,12 @@ bool CompositionPass::AddPasses(
     const PreparedCommand command   = Prepare(rt_ctx);
     const RecordResources resources = CaptureResources(rt_ctx);
     const auto            owner     = recording_owner;
+    const bool nrd_active =
+#if WITH_NRD
+        IsNrdDenoiserActive(rt_ctx.config.denoiser_mode);
+#else
+        false;
+#endif
     if (!owner || !owner->constants || !resources.hdr_color ||
         !resources.motion || !resources.view_depth ||
         !resources.diffuse_albedo || !resources.specular_roughness ||
@@ -148,6 +154,10 @@ bool CompositionPass::AddPasses(
         !resources.denoised_diffuse_lighting ||
         !resources.denoised_specular_lighting || !resources.bindless_array ||
         !graph_resources.frame_setup.ready.IsValid() ||
+        (nrd_active &&
+         (!graph_resources.denoised_diffuse_lighting.IsValid() ||
+          !graph_resources.denoised_specular_lighting.IsValid() ||
+          !graph_resources.nrd_ready.IsValid())) ||
         (command.constants.enable_env_map != 0 &&
          (!resources.env_map || !graph_resources.env_map.IsValid()))) {
         return false;
@@ -237,6 +247,18 @@ bool CompositionPass::AddPasses(
                     graph_resources.specular_lighting,
                     RenderGraph::TextureState::Sampled
                 );
+            if (nrd_active) {
+                builder
+                    .Read(
+                        graph_resources.denoised_diffuse_lighting,
+                        RenderGraph::TextureState::Sampled
+                    )
+                    .Read(
+                        graph_resources.denoised_specular_lighting,
+                        RenderGraph::TextureState::Sampled
+                    )
+                    .Read(graph_resources.nrd_ready);
+            }
             if (graph_resources.env_map.IsValid()) {
                 builder.Read(
                     graph_resources.env_map,

--- a/source/runtime/render/renderer/raytracing/Configs.cpp
+++ b/source/runtime/render/renderer/raytracing/Configs.cpp
@@ -80,21 +80,33 @@ void ImportanceSamplingContext::UpdateReSTIRDIBufferIndices() {
     di_current_frame_output_reservoir        = di_buffer_indices.shading_input_buff_idx;
 }
 
+DI::LightBufferParams ImportanceSamplingContext::BuildLightBufferParams(
+    uint frame_offset,
+    uint num_finite_lights,
+    uint num_infinite_primitive_lights,
+    uint num_environment_lights
+) {
+    DI::LightBufferParams params{};
+    params.local_light_region.first_light_idx = frame_offset;
+    params.local_light_region.light_cnt       = num_finite_lights;
+    params.infinite_light_region.first_light_idx =
+        params.local_light_region.first_light_idx + params.local_light_region.light_cnt;
+    params.infinite_light_region.light_cnt = num_infinite_primitive_lights;
+    params.env_light.light_idx =
+        params.infinite_light_region.first_light_idx + params.infinite_light_region.light_cnt;
+    params.env_light.light_cnt = num_environment_lights;
+    return params;
+}
+
 void ImportanceSamplingContext::SetLightBufferParams(
     uint _frame_offset,
     uint _local_light_region_light_cnt,
     uint _infinite_light_region_light_cnt,
     uint _env_light_light_cnt
 ) {
-    light_buffer_params.local_light_region.first_light_idx = _frame_offset;
-    light_buffer_params.local_light_region.light_cnt       = _local_light_region_light_cnt;
-    light_buffer_params.infinite_light_region.first_light_idx =
-        light_buffer_params.local_light_region.light_cnt +
-        light_buffer_params.local_light_region.first_light_idx;
-    light_buffer_params.infinite_light_region.light_cnt = _infinite_light_region_light_cnt;
-    light_buffer_params.env_light.light_idx = light_buffer_params.infinite_light_region.first_light_idx +
-                                              light_buffer_params.infinite_light_region.light_cnt;
-    light_buffer_params.env_light.light_cnt = _env_light_light_cnt;
+    CommitAcceptedLightBufferParams(BuildLightBufferParams(
+        _frame_offset, _local_light_region_light_cnt, _infinite_light_region_light_cnt, _env_light_light_cnt
+    ));
 }
 
 void ImportanceSamplingContext::AdvanceFrameIdx(uint _frame_idx) {

--- a/source/runtime/render/renderer/raytracing/Configs.h
+++ b/source/runtime/render/renderer/raytracing/Configs.h
@@ -217,6 +217,17 @@ struct ImportanceSamplingContext {
         return light_buffer_params;
     }
 
+    static DI::LightBufferParams BuildLightBufferParams(
+        uint frame_offset,
+        uint num_finite_lights,
+        uint num_infinite_primitive_lights,
+        uint num_environment_lights
+    );
+
+    void CommitAcceptedLightBufferParams(const DI::LightBufferParams& params) noexcept {
+        light_buffer_params = params;
+    }
+
     void SetChangeableGridConfig(const GridChangeableConfig& _config) {
         grid_changeable_config                      = _config;
         grid_params.common_params.cell_size         = _config.cell_size;
@@ -240,9 +251,8 @@ struct ImportanceSamplingContext {
         di_initial_sample_params = _params;
     }
 
-    [[deprecated("Use SetReSTIRDIInitialSampleParams instead")]] void SetReSTIRDIIInitialSampleParams(
-        const DI::ReSTIRDIInitialSampleParams& _params
-    ) {
+    [[deprecated("Use SetReSTIRDIInitialSampleParams instead")]] void
+    SetReSTIRDIIInitialSampleParams(const DI::ReSTIRDIInitialSampleParams& _params) {
         SetReSTIRDIInitialSampleParams(_params);
     }
 
@@ -274,7 +284,8 @@ struct ImportanceSamplingContext {
         return grid_changeable_config;
     }
 
-    [[deprecated("Use GetGridChangeableConfig instead")]] GridChangeableConfig GetGridChangableConfig() const {
+    [[deprecated("Use GetGridChangeableConfig instead")]] GridChangeableConfig
+    GetGridChangableConfig() const {
         return GetGridChangeableConfig();
     }
 

--- a/source/runtime/render/renderer/raytracing/GBufferPass.cpp
+++ b/source/runtime/render/renderer/raytracing/GBufferPass.cpp
@@ -226,20 +226,19 @@ bool GBufferPass::AddPasses(
     RenderGraph&                 graph,
     const RTGraphFrameResources& graph_resources,
     const RTContext&             rt_ctx,
-    bool                         tlas_built_this_frame,
     bool                         normal_roughness_readable
 ) {
     const PreparedCommand command   = Prepare(rt_ctx);
     const RecordResources resources = CaptureResources(rt_ctx);
-    if (!resources.tlas || resources.tlas->GetUnderlyingBuffer() == nullptr) {
+    if (!resources.tlas || resources.tlas->GetUnderlyingBuffer() == nullptr ||
+        !graph_resources.frame_setup.ready.IsValid() ||
+        !graph_resources.frame_setup.current_tlas.IsValid()) {
         return false;
     }
 
-    const BufferRef tlas_buffer(resources.tlas->GetUnderlyingBuffer());
     const auto constants =
         ImportRTGraphBuffer(graph, "RT.GBuffer.constants", gbuffer_constants);
-    const auto tlas =
-        ImportRTGraphBuffer(graph, "RT.GBuffer.tlas", tlas_buffer);
+    const auto tlas = graph_resources.frame_setup.current_tlas;
 
     const auto initial_texture =
         [&](RenderGraph::TextureHandle texture,
@@ -305,17 +304,6 @@ bool GBufferPass::AddPasses(
         RenderGraph::QueueRole::Graphics,
         RenderGraph::AccessMode::Read
     );
-    graph.SetInitialState(
-        tlas,
-        tlas_built_this_frame ?
-            RenderGraph::BufferState::AccelerationStructureWrite :
-            RenderGraph::BufferState::AccelerationStructureRead,
-        RenderGraph::QueueRole::Graphics,
-        tlas_built_this_frame ?
-            RenderGraph::AccessMode::Write :
-            RenderGraph::AccessMode::Read
-    );
-
     graph.AddRecordPass(
         "RT.GBuffer.UploadConstants",
         [=](RenderGraph::PassBuilder& builder) {
@@ -345,6 +333,7 @@ bool GBufferPass::AddPasses(
                    )
                 .Read(constants, RenderGraph::BufferState::ShaderResource)
                 .Read(tlas, RenderGraph::BufferState::AccelerationStructureRead)
+                .Read(graph_resources.frame_setup.ready)
                 .Write(
                     graph_resources.current_view_depth,
                     RenderGraph::TextureState::UnorderedAccess
@@ -460,12 +449,6 @@ bool GBufferPass::AddPasses(
     graph.Export(
         constants,
         RenderGraph::BufferState::ShaderResource,
-        RenderGraph::QueueRole::Graphics,
-        RenderGraph::AccessMode::Read
-    );
-    graph.Export(
-        tlas,
-        RenderGraph::BufferState::AccelerationStructureRead,
         RenderGraph::QueueRole::Graphics,
         RenderGraph::AccessMode::Read
     );

--- a/source/runtime/render/renderer/raytracing/GBufferPass.h
+++ b/source/runtime/render/renderer/raytracing/GBufferPass.h
@@ -98,7 +98,6 @@ public:
         RenderGraph&                 graph,
         const RTGraphFrameResources& graph_resources,
         const RTContext&             rt_ctx,
-        bool                         tlas_built_this_frame,
         bool                         normal_roughness_readable
     );
 

--- a/source/runtime/render/renderer/raytracing/LightingPass.cpp
+++ b/source/runtime/render/renderer/raytracing/LightingPass.cpp
@@ -277,6 +277,9 @@ bool LightingPass::AddPasses(
         return tlas && tlas->GetUnderlyingBuffer() != nullptr;
     };
     if (!has_backing_buffer(resources.tlas) || !has_backing_buffer(resources.prev_tlas) ||
+        !graph_resources.frame_setup.ready.IsValid() ||
+        !graph_resources.frame_setup.current_tlas.IsValid() ||
+        !graph_resources.frame_setup.previous_tlas.IsValid() ||
         !resources.constants_buf || !resources.light_reservoir_buf || !resources.ris_buf ||
         !resources.ris_light_data_buf || !resources.neighbor_offset_buf || !resources.light_mapping_buf ||
         !resources.light_data_buf || !resources.primitive_to_light_buf || !resources.diffuse_lighting ||
@@ -289,13 +292,8 @@ bool LightingPass::AddPasses(
     }
 
     const auto      constants = ImportRTGraphBuffer(graph, "RT.Lighting.constants", resources.constants_buf);
-    const BufferRef tlas_buffer(resources.tlas->GetUnderlyingBuffer());
-    const auto      tlas                = ImportRTGraphBuffer(graph, "RT.Lighting.tlas", tlas_buffer);
-    RenderGraph::BufferHandle prev_tlas = tlas;
-    if (resources.prev_tlas.Get() != resources.tlas.Get()) {
-        const BufferRef prev_tlas_buffer(resources.prev_tlas->GetUnderlyingBuffer());
-        prev_tlas = ImportRTGraphBuffer(graph, "RT.Lighting.prev_tlas", prev_tlas_buffer);
-    }
+    const auto      tlas      = graph_resources.frame_setup.current_tlas;
+    const auto      prev_tlas = graph_resources.frame_setup.previous_tlas;
     const auto light_reservoir =
         ImportRTGraphBuffer(graph, "RT.Lighting.light_reservoir", resources.light_reservoir_buf);
     const auto ris = ImportRTGraphBuffer(graph, "RT.Lighting.ris", resources.ris_buf);
@@ -326,14 +324,6 @@ bool LightingPass::AddPasses(
         RenderGraph::QueueRole::Graphics,
         RenderGraph::AccessMode::Read
     );
-    if (prev_tlas != tlas) {
-        graph.SetInitialState(
-            prev_tlas,
-            RenderGraph::BufferState::AccelerationStructureRead,
-            RenderGraph::QueueRole::Graphics,
-            RenderGraph::AccessMode::Read
-        );
-    }
     for (const auto texture : {
              graph_resources.previous_view_depth,
              graph_resources.previous_diffuse_albedo,
@@ -429,6 +419,7 @@ bool LightingPass::AddPasses(
                     .Read(constants, RenderGraph::BufferState::ShaderResource)
                     .Read(tlas, RenderGraph::BufferState::AccelerationStructureRead)
                     .Read(prev_tlas, RenderGraph::BufferState::AccelerationStructureRead)
+                    .Read(graph_resources.frame_setup.ready)
                     .ReadWrite(light_reservoir, RenderGraph::BufferState::UnorderedAccess)
                     .ReadWrite(ris, RenderGraph::BufferState::UnorderedAccess)
                     .ReadWrite(ris_light_data, RenderGraph::BufferState::UnorderedAccess)
@@ -511,14 +502,6 @@ bool LightingPass::AddPasses(
         RenderGraph::QueueRole::Graphics,
         RenderGraph::AccessMode::Read
     );
-    if (prev_tlas != tlas) {
-        graph.Export(
-            prev_tlas,
-            RenderGraph::BufferState::AccelerationStructureRead,
-            RenderGraph::QueueRole::Graphics,
-            RenderGraph::AccessMode::Read
-        );
-    }
     for (const auto buffer : {
              light_reservoir,
              ris,

--- a/source/runtime/render/renderer/raytracing/LightingPass.cpp
+++ b/source/runtime/render/renderer/raytracing/LightingPass.cpp
@@ -52,132 +52,93 @@ LightingPass::LightingPass(ShaderManager& _manager, BindlessArrayRef bindless_ar
     );
 }
 
-LightingPass::PreparedCommand LightingPass::Prepare(const RTContext& rt_ctx) const {
-    const DI::ReSTIRDIRuntimeConfig& restir_di_runtime_config =
-        rt_ctx.is_ctx.GetReSTIRDIRuntimeConfig();
-    const ImportanceSamplingContext& is_ctx = rt_ctx.is_ctx;
+LightingPass::PreparedCommand
+LightingPass::Prepare(const RTContext& rt_ctx, const DI::LightBufferParams& light_buffer_params) const {
+    const DI::ReSTIRDIRuntimeConfig& restir_di_runtime_config = rt_ctx.is_ctx.GetReSTIRDIRuntimeConfig();
+    const ImportanceSamplingContext& is_ctx                   = rt_ctx.is_ctx;
 
     PreparedCommand command{};
-    auto&           constants = command.constants;
+    auto&           constants  = command.constants;
     constants.frame_idx        = is_ctx.GetFrameIdx();
     constants.main_view        = rt_ctx.main_view;
     constants.prev_view        = rt_ctx.prev_view;
     constants.enable_prev_tlas = true;
     constants.local_light_pdf_size =
         rt_ctx.local_light_pdf_tex ? rt_ctx.local_light_pdf_tex->GetExtent().xy : uint2(0);
-    constants.env_pdf_size =
-        rt_ctx.env_pdf_tex ? rt_ctx.env_pdf_tex->GetExtent().xy : uint2(0);
+    constants.env_pdf_size     = rt_ctx.env_pdf_tex ? rt_ctx.env_pdf_tex->GetExtent().xy : uint2(0);
     constants.bindless_handles = rt_ctx.GetBindlessHandles();
 
-    constants.di_params = restir_di_runtime_config.common_params;
-    auto initial_sample_params = is_ctx.GetDIInitialSampleParams();
-    command.sampling_decision.configured_mode =
-        initial_sample_params.local_light_sample_mode;
-    command.sampling_decision.local_light_count =
-        is_ctx.GetLightBufferParams().local_light_region.light_cnt;
+    constants.di_params                         = restir_di_runtime_config.common_params;
+    auto initial_sample_params                  = is_ctx.GetDIInitialSampleParams();
+    initial_sample_params.env_map_is            = light_buffer_params.env_light.light_cnt;
+    command.sampling_decision.configured_mode   = initial_sample_params.local_light_sample_mode;
+    command.sampling_decision.local_light_count = light_buffer_params.local_light_region.light_cnt;
     command.sampling_decision.adaptive_fallback_applied =
         rt_ctx.config.enable_adaptive_local_light_sampling &&
-        initial_sample_params.local_light_sample_mode ==
-            s_di_local_light_sample_mode_grid &&
-        command.sampling_decision.local_light_count <
-            rt_ctx.config.grid_min_local_light_count;
+        initial_sample_params.local_light_sample_mode == s_di_local_light_sample_mode_grid &&
+        command.sampling_decision.local_light_count < rt_ctx.config.grid_min_local_light_count;
     if (command.sampling_decision.adaptive_fallback_applied) {
-        initial_sample_params.local_light_sample_mode =
-            s_di_local_light_sample_mode_power_ris;
+        initial_sample_params.local_light_sample_mode = s_di_local_light_sample_mode_power_ris;
     }
-    command.sampling_decision.effective_mode =
-        initial_sample_params.local_light_sample_mode;
+    command.sampling_decision.effective_mode = initial_sample_params.local_light_sample_mode;
 
-    constants.restir_di_params.initial_sample_params = initial_sample_params;
-    constants.restir_di_params.temporal_resample_params =
-        is_ctx.GetDITemporalResampleParams();
-    constants.restir_di_params.spatial_resample_params =
-        is_ctx.GetDISpatialResampleParams();
-    constants.restir_di_params.reservoir_buffer_params =
-        restir_di_runtime_config.reservoir_buffer_params;
-    constants.restir_di_params.shading_params = is_ctx.GetDIShadingParams();
-    constants.restir_di_params.buffer_indices =
-        is_ctx.GetReSTIRDIBufferIndices();
+    constants.restir_di_params.initial_sample_params    = initial_sample_params;
+    constants.restir_di_params.temporal_resample_params = is_ctx.GetDITemporalResampleParams();
+    constants.restir_di_params.spatial_resample_params  = is_ctx.GetDISpatialResampleParams();
+    constants.restir_di_params.reservoir_buffer_params  = restir_di_runtime_config.reservoir_buffer_params;
+    constants.restir_di_params.shading_params           = is_ctx.GetDIShadingParams();
+    constants.restir_di_params.buffer_indices           = is_ctx.GetReSTIRDIBufferIndices();
 
-    constants.light_buffer_params = is_ctx.GetLightBufferParams();
-    constants.local_light_ris_buffer_params =
-        is_ctx.GetLocalLightRISBufferParams();
-    constants.env_light_ris_buffer_params =
-        is_ctx.GetEnvLightRISBufferParams();
-    constants.grid_params             = is_ctx.GetGridParams();
-    constants.scene_params            = rt_ctx.scene_params;
-    constants.enable_accumulation     = 1;
-    constants.discount_native_samples = 1;
-    constants.visualize_cells         = 0;
-    constants.denoiser_mode           = rt_ctx.config.denoiser_mode;
-    constants.reblur_diff_hit_dist_params =
-        rt_ctx.config.reblur_diffuse_hit_dist_params;
-    constants.reblur_spec_hit_dist_params =
-        rt_ctx.config.reblur_specular_hit_dist_params;
+    constants.light_buffer_params           = light_buffer_params;
+    constants.local_light_ris_buffer_params = is_ctx.GetLocalLightRISBufferParams();
+    constants.env_light_ris_buffer_params   = is_ctx.GetEnvLightRISBufferParams();
+    constants.grid_params                   = is_ctx.GetGridParams();
+    constants.scene_params                  = rt_ctx.scene_params;
+    constants.enable_accumulation           = 1;
+    constants.discount_native_samples       = 1;
+    constants.visualize_cells               = 0;
+    constants.denoiser_mode                 = rt_ctx.config.denoiser_mode;
+    constants.reblur_diff_hit_dist_params   = rt_ctx.config.reblur_diffuse_hit_dist_params;
+    constants.reblur_spec_hit_dist_params   = rt_ctx.config.reblur_specular_hit_dist_params;
 
     const auto div_ceil = [](uint value, uint divisor) -> uint {
         return (value + divisor - 1) / divisor;
     };
-    const bool has_local_candidates =
-        initial_sample_params.num_primary_local_lights > 0;
-    const bool uses_grid =
-        initial_sample_params.local_light_sample_mode ==
-        s_di_local_light_sample_mode_grid;
+    const bool has_local_candidates = initial_sample_params.num_primary_local_lights > 0;
+    const bool uses_grid = initial_sample_params.local_light_sample_mode == s_di_local_light_sample_mode_grid;
     const bool needs_power_ris =
-        initial_sample_params.local_light_sample_mode ==
-            s_di_local_light_sample_mode_power_ris ||
-        (uses_grid &&
-         constants.grid_params.common_params.local_light_sampling_fallback_mode ==
-             s_di_local_light_sample_mode_power_ris);
+        initial_sample_params.local_light_sample_mode == s_di_local_light_sample_mode_power_ris ||
+        (uses_grid && constants.grid_params.common_params.local_light_sampling_fallback_mode ==
+                          s_di_local_light_sample_mode_power_ris);
     command.record_presample_light =
-        command.sampling_decision.local_light_count != 0 &&
-        has_local_candidates && needs_power_ris;
-    command.record_presample_env =
-        is_ctx.GetLightBufferParams().env_light.light_cnt != 0;
+        command.sampling_decision.local_light_count != 0 && has_local_candidates && needs_power_ris;
+    command.record_presample_env = light_buffer_params.env_light.light_cnt != 0;
     command.record_presample_grid =
-        command.sampling_decision.local_light_count != 0 &&
-        has_local_candidates && uses_grid;
+        command.sampling_decision.local_light_count != 0 && has_local_candidates && uses_grid;
 
     command.presample_light_dispatch = uint3(
-        div_ceil(
-            is_ctx.GetLocalLightRISBufferParams().tile_size,
-            DI_PRESAMPLE_GRID_SIZE
-        ),
+        div_ceil(is_ctx.GetLocalLightRISBufferParams().tile_size, DI_PRESAMPLE_GRID_SIZE),
         is_ctx.GetLocalLightRISBufferParams().tile_cnt,
         1
     );
     command.presample_env_dispatch = uint3(
-        div_ceil(
-            is_ctx.GetEnvLightRISBufferParams().tile_size,
-            DI_PRESAMPLE_GRID_SIZE
-        ),
+        div_ceil(is_ctx.GetEnvLightRISBufferParams().tile_size, DI_PRESAMPLE_GRID_SIZE),
         is_ctx.GetEnvLightRISBufferParams().tile_cnt,
         1
     );
-    command.presample_grid_dispatch = uint3(
-        div_ceil(
-            is_ctx.GetGridRuntimeConfig().num_light_slot,
-            DI_PRESAMPLE_GRID_SIZE
-        ),
-        1,
-        1
-    );
+    command.presample_grid_dispatch =
+        uint3(div_ceil(is_ctx.GetGridRuntimeConfig().num_light_slot, DI_PRESAMPLE_GRID_SIZE), 1, 1);
     const uint2 lighting_extent = rt_ctx.frame_rt.diffuse_lighting->GetExtent().xy;
     command.screen_dispatch     = uint3(
-        div_ceil(lighting_extent.x, DI_SCREEN_TILE_SIZE),
-        div_ceil(lighting_extent.y, DI_SCREEN_TILE_SIZE),
-        1
+        div_ceil(lighting_extent.x, DI_SCREEN_TILE_SIZE), div_ceil(lighting_extent.y, DI_SCREEN_TILE_SIZE), 1
     );
     return command;
 }
 
-LightingPass::RecordResources
-LightingPass::CaptureResources(const RTContext& rt_ctx) const {
-    const bool current_frame = rt_ctx.b_current_frame;
-    RaytracingTlasRef tlas =
-        rt_ctx.rt_scene ? rt_ctx.rt_scene->GetTlas() : RaytracingTlasRef{};
-    RaytracingTlasRef prev_tlas =
-        rt_ctx.rt_scene ? rt_ctx.rt_scene->GetPrevTlas() : RaytracingTlasRef{};
+LightingPass::RecordResources LightingPass::CaptureResources(const RTContext& rt_ctx) const {
+    const bool        current_frame = rt_ctx.b_current_frame;
+    RaytracingTlasRef tlas          = rt_ctx.rt_scene ? rt_ctx.rt_scene->GetTlas() : RaytracingTlasRef{};
+    RaytracingTlasRef prev_tlas     = rt_ctx.rt_scene ? rt_ctx.rt_scene->GetPrevTlas() : RaytracingTlasRef{};
     if (!prev_tlas) {
         prev_tlas = tlas;
     }
@@ -197,9 +158,7 @@ LightingPass::CaptureResources(const RTContext& rt_ctx) const {
         .specular_lighting      = rt_ctx.frame_rt.specular_lighting,
         .temporal_sample_pos    = rt_ctx.frame_rt.temporal_sample_pos,
         .gradients              = rt_ctx.frame_rt.gradients,
-        .restir_luminance =
-            current_frame ? rt_ctx.frame_rt.restir_luminance :
-                            rt_ctx.frame_rt.prev_luminance,
+        .restir_luminance = current_frame ? rt_ctx.frame_rt.restir_luminance : rt_ctx.frame_rt.prev_luminance,
         .prev_diffuse_lighting = rt_ctx.frame_rt.prev_diffuse_lighting,
         .local_light_pdf       = rt_ctx.local_light_pdf_tex,
         .env_pdf               = rt_ctx.env_pdf_tex,
@@ -214,15 +173,8 @@ void LightingPass::RecordConstantsUpload(
     const RecordResources& resources
 ) const {
     Array<byte> upload_data(sizeof(ResampleConstants));
-    std::memcpy(
-        upload_data.data(),
-        &command.constants,
-        sizeof(ResampleConstants)
-    );
-    cmd_list.CopyFrom(
-        std::move(upload_data),
-        resources.constants_buf->GetView()
-    );
+    std::memcpy(upload_data.data(), &command.constants, sizeof(ResampleConstants));
+    cmd_list.CopyFrom(std::move(upload_data), resources.constants_buf->GetView());
 }
 
 void LightingPass::RecordDispatch(
@@ -231,19 +183,15 @@ void LightingPass::RecordDispatch(
     const RecordResources& resources,
     ELightingDispatch      dispatch
 ) {
-#define DI_BINDING_ARGS(ctx)                                                     \
-    ctx.tlas, ctx.prev_tlas, ctx.constants_buf, ctx.light_reservoir_buf,         \
-        ctx.diffuse_lighting, ctx.specular_lighting, ctx.temporal_sample_pos,    \
-        ctx.gradients, ctx.restir_luminance, ctx.prev_diffuse_lighting,          \
-        ctx.ris_buf, ctx.ris_light_data_buf, ctx.neighbor_offset_buf,            \
+#define DI_BINDING_ARGS(ctx)                                                                     \
+    ctx.tlas, ctx.prev_tlas, ctx.constants_buf, ctx.light_reservoir_buf, ctx.diffuse_lighting,   \
+        ctx.specular_lighting, ctx.temporal_sample_pos, ctx.gradients, ctx.restir_luminance,     \
+        ctx.prev_diffuse_lighting, ctx.ris_buf, ctx.ris_light_data_buf, ctx.neighbor_offset_buf, \
         ctx.bindless_array
 
     switch (dispatch) {
         case ELightingDispatch::PresampleLight:
-            cmd_list.Compute(
-                        presample_light_pipeline,
-                        DI_BINDING_ARGS(resources)
-                    )
+            cmd_list.Compute(presample_light_pipeline, DI_BINDING_ARGS(resources))
                 .Dispatch(
                     command.presample_light_dispatch,
                     "PresampleLight",
@@ -251,10 +199,7 @@ void LightingPass::RecordDispatch(
                 );
             break;
         case ELightingDispatch::PresampleEnvMap:
-            cmd_list.Compute(
-                        presample_env_map_pipeline,
-                        DI_BINDING_ARGS(resources)
-                    )
+            cmd_list.Compute(presample_env_map_pipeline, DI_BINDING_ARGS(resources))
                 .Dispatch(
                     command.presample_env_dispatch,
                     "PresampleEnvMap",
@@ -262,10 +207,7 @@ void LightingPass::RecordDispatch(
                 );
             break;
         case ELightingDispatch::PresampleLightGrid:
-            cmd_list.Compute(
-                        presample_light_grid_pipeline,
-                        DI_BINDING_ARGS(resources)
-                    )
+            cmd_list.Compute(presample_light_grid_pipeline, DI_BINDING_ARGS(resources))
                 .Dispatch(
                     command.presample_grid_dispatch,
                     "PresampleLightGrid",
@@ -273,108 +215,50 @@ void LightingPass::RecordDispatch(
                 );
             break;
         case ELightingDispatch::GenerateInitialSample:
-            cmd_list.Compute(
-                        generate_initial_sample_pipeline,
-                        DI_BINDING_ARGS(resources)
-                    )
+            cmd_list.Compute(generate_initial_sample_pipeline, DI_BINDING_ARGS(resources))
                 .Dispatch(
-                    command.screen_dispatch,
-                    "GenerateInitialSample",
-                    ProfileSection("ReSTIR DI Initial")
+                    command.screen_dispatch, "GenerateInitialSample", ProfileSection("ReSTIR DI Initial")
                 );
             break;
         case ELightingDispatch::TemporalResample:
-            cmd_list.Compute(
-                        temporal_resample_pipeline,
-                        DI_BINDING_ARGS(resources)
-                    )
-                .Dispatch(
-                    command.screen_dispatch,
-                    "TemporalResample",
-                    ProfileSection("ReSTIR DI Temporal")
-                );
+            cmd_list.Compute(temporal_resample_pipeline, DI_BINDING_ARGS(resources))
+                .Dispatch(command.screen_dispatch, "TemporalResample", ProfileSection("ReSTIR DI Temporal"));
             break;
         case ELightingDispatch::SpatialResample:
-            cmd_list.Compute(
-                        spatial_resample_pipeline,
-                        DI_BINDING_ARGS(resources)
-                    )
-                .Dispatch(
-                    command.screen_dispatch,
-                    "SpatialResample",
-                    ProfileSection("ReSTIR DI Spatial")
-                );
+            cmd_list.Compute(spatial_resample_pipeline, DI_BINDING_ARGS(resources))
+                .Dispatch(command.screen_dispatch, "SpatialResample", ProfileSection("ReSTIR DI Spatial"));
             break;
         case ELightingDispatch::ShadeSample:
-            cmd_list.Compute(
-                        di_shade_sample_pipeline,
-                        DI_BINDING_ARGS(resources)
-                    )
-                .Dispatch(
-                    command.screen_dispatch,
-                    "ShadeSample",
-                    ProfileSection("ReSTIR DI Shade")
-                );
+            cmd_list.Compute(di_shade_sample_pipeline, DI_BINDING_ARGS(resources))
+                .Dispatch(command.screen_dispatch, "ShadeSample", ProfileSection("ReSTIR DI Shade"));
             break;
     }
 #undef DI_BINDING_ARGS
 }
 
-LightingPass::LocalLightSamplingDecision
-LightingPass::Process(CommandList& cmd_list, RTContext& rt_ctx) {
-    const PreparedCommand command   = Prepare(rt_ctx);
+LightingPass::LocalLightSamplingDecision LightingPass::Process(
+    CommandList&                 cmd_list,
+    RTContext&                   rt_ctx,
+    const DI::LightBufferParams& light_buffer_params
+) {
+    const PreparedCommand command   = Prepare(rt_ctx, light_buffer_params);
     const RecordResources resources = CaptureResources(rt_ctx);
 
     cmd_list.PushScopeWithTimeScope("LightingPass");
     RecordConstantsUpload(cmd_list, command, resources);
     if (command.record_presample_light) {
-        RecordDispatch(
-            cmd_list,
-            command,
-            resources,
-            ELightingDispatch::PresampleLight
-        );
+        RecordDispatch(cmd_list, command, resources, ELightingDispatch::PresampleLight);
     }
     if (command.record_presample_env) {
-        RecordDispatch(
-            cmd_list,
-            command,
-            resources,
-            ELightingDispatch::PresampleEnvMap
-        );
+        RecordDispatch(cmd_list, command, resources, ELightingDispatch::PresampleEnvMap);
     }
     if (command.record_presample_grid) {
-        RecordDispatch(
-            cmd_list,
-            command,
-            resources,
-            ELightingDispatch::PresampleLightGrid
-        );
+        RecordDispatch(cmd_list, command, resources, ELightingDispatch::PresampleLightGrid);
     }
-    RecordDispatch(
-        cmd_list,
-        command,
-        resources,
-        ELightingDispatch::GenerateInitialSample
-    );
-    RecordDispatch(
-        cmd_list,
-        command,
-        resources,
-        ELightingDispatch::TemporalResample
-    );
-    RecordDispatch(
-        cmd_list,
-        command,
-        resources,
-        ELightingDispatch::SpatialResample
-    );
-    RecordDispatch(
-        cmd_list,
-        command,
-        resources,
-        ELightingDispatch::ShadeSample
-    );
+    RecordDispatch(cmd_list, command, resources, ELightingDispatch::GenerateInitialSample);
+    RecordDispatch(cmd_list, command, resources, ELightingDispatch::TemporalResample);
+    RecordDispatch(cmd_list, command, resources, ELightingDispatch::SpatialResample);
+    RecordDispatch(cmd_list, command, resources, ELightingDispatch::ShadeSample);
     cmd_list.PopScopeWithTimeScope();
     return command.sampling_decision;
 }
@@ -383,98 +267,56 @@ bool LightingPass::AddPasses(
     RenderGraph&                 graph,
     const RTGraphFrameResources& graph_resources,
     const RTContext&             rt_ctx,
+    const DI::LightBufferParams& light_buffer_params,
+    bool                         prepare_lights_in_graph,
     LocalLightSamplingDecision&  sampling_decision
 ) {
-    const PreparedCommand command   = Prepare(rt_ctx);
-    const RecordResources resources = CaptureResources(rt_ctx);
-    const auto has_backing_buffer = [](const RaytracingTlasRef& tlas) {
+    const PreparedCommand command            = Prepare(rt_ctx, light_buffer_params);
+    const RecordResources resources          = CaptureResources(rt_ctx);
+    const auto            has_backing_buffer = [](const RaytracingTlasRef& tlas) {
         return tlas && tlas->GetUnderlyingBuffer() != nullptr;
     };
-    if (!has_backing_buffer(resources.tlas) ||
-        !has_backing_buffer(resources.prev_tlas) ||
-        !resources.constants_buf || !resources.light_reservoir_buf ||
-        !resources.ris_buf ||
-        !resources.ris_light_data_buf || !resources.neighbor_offset_buf ||
-        !resources.light_mapping_buf || !resources.light_data_buf ||
-        !resources.primitive_to_light_buf || !resources.diffuse_lighting ||
-        !resources.specular_lighting || !resources.temporal_sample_pos ||
-        !resources.gradients || !resources.restir_luminance ||
-        !resources.prev_diffuse_lighting || !resources.bindless_array ||
+    if (!has_backing_buffer(resources.tlas) || !has_backing_buffer(resources.prev_tlas) ||
+        !resources.constants_buf || !resources.light_reservoir_buf || !resources.ris_buf ||
+        !resources.ris_light_data_buf || !resources.neighbor_offset_buf || !resources.light_mapping_buf ||
+        !resources.light_data_buf || !resources.primitive_to_light_buf || !resources.diffuse_lighting ||
+        !resources.specular_lighting || !resources.temporal_sample_pos || !resources.gradients ||
+        !resources.restir_luminance || !resources.prev_diffuse_lighting || !resources.bindless_array ||
         (command.record_presample_light && !resources.local_light_pdf) ||
         (command.record_presample_env && !resources.env_pdf) ||
-        (command.constants.scene_params.enable_env_map != 0 &&
-         !resources.env_map)) {
+        (command.constants.scene_params.enable_env_map != 0 && !resources.env_map)) {
         return false;
     }
 
-    const auto constants =
-        ImportRTGraphBuffer(
-            graph,
-            "RT.Lighting.constants",
-            resources.constants_buf
-        );
+    const auto      constants = ImportRTGraphBuffer(graph, "RT.Lighting.constants", resources.constants_buf);
     const BufferRef tlas_buffer(resources.tlas->GetUnderlyingBuffer());
-    const auto tlas =
-        ImportRTGraphBuffer(graph, "RT.Lighting.tlas", tlas_buffer);
+    const auto      tlas                = ImportRTGraphBuffer(graph, "RT.Lighting.tlas", tlas_buffer);
     RenderGraph::BufferHandle prev_tlas = tlas;
     if (resources.prev_tlas.Get() != resources.tlas.Get()) {
-        const BufferRef prev_tlas_buffer(
-            resources.prev_tlas->GetUnderlyingBuffer()
-        );
-        prev_tlas = ImportRTGraphBuffer(
-            graph,
-            "RT.Lighting.prev_tlas",
-            prev_tlas_buffer
-        );
+        const BufferRef prev_tlas_buffer(resources.prev_tlas->GetUnderlyingBuffer());
+        prev_tlas = ImportRTGraphBuffer(graph, "RT.Lighting.prev_tlas", prev_tlas_buffer);
     }
-    const auto light_reservoir = ImportRTGraphBuffer(
-        graph,
-        "RT.Lighting.light_reservoir",
-        resources.light_reservoir_buf
-    );
-    const auto ris =
-        ImportRTGraphBuffer(graph, "RT.Lighting.ris", resources.ris_buf);
-    const auto ris_light_data = ImportRTGraphBuffer(
-        graph,
-        "RT.Lighting.ris_light_data",
-        resources.ris_light_data_buf
-    );
-    const auto neighbor_offset = ImportRTGraphBuffer(
-        graph,
-        "RT.Lighting.neighbor_offset",
-        resources.neighbor_offset_buf
-    );
-    const auto light_mapping = ImportRTGraphBuffer(
-        graph,
-        "RT.Lighting.light_mapping",
-        resources.light_mapping_buf
-    );
-    const auto light_data = ImportRTGraphBuffer(
-        graph,
-        "RT.Lighting.light_data",
-        resources.light_data_buf
-    );
-    const auto primitive_to_light = ImportRTGraphBuffer(
-        graph,
-        "RT.Lighting.primitive_to_light",
-        resources.primitive_to_light_buf
-    );
+    const auto light_reservoir =
+        ImportRTGraphBuffer(graph, "RT.Lighting.light_reservoir", resources.light_reservoir_buf);
+    const auto ris = ImportRTGraphBuffer(graph, "RT.Lighting.ris", resources.ris_buf);
+    const auto ris_light_data =
+        ImportRTGraphBuffer(graph, "RT.Lighting.ris_light_data", resources.ris_light_data_buf);
+    const auto neighbor_offset =
+        ImportRTGraphBuffer(graph, "RT.Lighting.neighbor_offset", resources.neighbor_offset_buf);
+    const auto light_mapping =
+        ImportRTGraphBuffer(graph, "RT.Lighting.light_mapping", resources.light_mapping_buf);
+    const auto light_data = ImportRTGraphBuffer(graph, "RT.Lighting.light_data", resources.light_data_buf);
+    const auto primitive_to_light =
+        ImportRTGraphBuffer(graph, "RT.Lighting.primitive_to_light", resources.primitive_to_light_buf);
 
     RenderGraph::TextureHandle local_light_pdf{};
     if (resources.local_light_pdf) {
-        local_light_pdf = ImportRTGraphTexture(
-            graph,
-            "RT.Lighting.local_light_pdf",
-            resources.local_light_pdf
-        );
+        local_light_pdf =
+            ImportRTGraphTexture(graph, "RT.Lighting.local_light_pdf", resources.local_light_pdf);
     }
     RenderGraph::TextureHandle env_pdf{};
     if (resources.env_pdf) {
-        env_pdf = ImportRTGraphTexture(
-            graph,
-            "RT.Lighting.env_pdf",
-            resources.env_pdf
-        );
+        env_pdf = ImportRTGraphTexture(graph, "RT.Lighting.env_pdf", resources.env_pdf);
     }
     const RenderGraph::TextureHandle env_map = graph_resources.env_map;
 
@@ -525,25 +367,27 @@ bool LightingPass::AddPasses(
         RenderGraph::QueueRole::Graphics,
         RenderGraph::AccessMode::Read
     );
-    for (const auto buffer : {
-             light_mapping,
-             light_data,
-             primitive_to_light,
-         }) {
-        graph.SetInitialState(
-            buffer,
-            RenderGraph::BufferState::UnorderedAccess,
-            RenderGraph::QueueRole::Graphics,
-            RenderGraph::AccessMode::Write
-        );
-    }
-    if (local_light_pdf.IsValid()) {
-        graph.SetInitialState(
-            local_light_pdf,
-            RenderGraph::TextureState::UnorderedAccess,
-            RenderGraph::QueueRole::Graphics,
-            RenderGraph::AccessMode::Write
-        );
+    if (!prepare_lights_in_graph) {
+        for (const auto buffer : {
+                 light_mapping,
+                 light_data,
+                 primitive_to_light,
+             }) {
+            graph.SetInitialState(
+                buffer,
+                RenderGraph::BufferState::UnorderedAccess,
+                RenderGraph::QueueRole::Graphics,
+                RenderGraph::AccessMode::Write
+            );
+        }
+        if (local_light_pdf.IsValid()) {
+            graph.SetInitialState(
+                local_light_pdf,
+                RenderGraph::TextureState::UnorderedAccess,
+                RenderGraph::QueueRole::Graphics,
+                RenderGraph::AccessMode::Write
+            );
+        }
     }
     if (env_pdf.IsValid()) {
         graph.SetInitialState(
@@ -565,194 +409,80 @@ bool LightingPass::AddPasses(
     graph.AddRecordPass(
         "RT.Lighting.UploadConstants",
         [=](RenderGraph::PassBuilder& builder) {
-            builder.ExecuteOn(
-                       RenderGraph::QueueRole::Graphics,
-                       RenderGraph::PipelineType::Copy
-                   )
+            builder.ExecuteOn(RenderGraph::QueueRole::Graphics, RenderGraph::PipelineType::Copy)
                 .Write(constants, RenderGraph::BufferState::TransferDestination);
         },
         [this, command, resources](CommandList& cmd_list) {
             ScopedGpuMarker marker(
-                cmd_list,
-                "Pass: RT Lighting Constants Upload",
-                GpuMarkerPalette::Transfer()
+                cmd_list, "Pass: RT Lighting Constants Upload", GpuMarkerPalette::Transfer()
             );
             RecordConstantsUpload(cmd_list, command, resources);
         },
         RenderGraph::PassExecutionClass::ParallelRecordEligible
     );
 
-    const auto add_dispatch =
-        [&](std::string_view name, ELightingDispatch dispatch) {
-            graph.AddRecordPass(
-                name,
-                [=](RenderGraph::PassBuilder& builder) {
-                    builder
-                        .ExecuteOn(
-                            RenderGraph::QueueRole::Graphics,
-                            RenderGraph::PipelineType::Compute
-                        )
-                        .Read(
-                            constants,
-                            RenderGraph::BufferState::ShaderResource
-                        )
-                        .Read(
-                            tlas,
-                            RenderGraph::BufferState::AccelerationStructureRead
-                        )
-                        .Read(
-                            prev_tlas,
-                            RenderGraph::BufferState::AccelerationStructureRead
-                        )
-                        .ReadWrite(
-                            light_reservoir,
-                            RenderGraph::BufferState::UnorderedAccess
-                        )
-                        .ReadWrite(
-                            ris,
-                            RenderGraph::BufferState::UnorderedAccess
-                        )
-                        .ReadWrite(
-                            ris_light_data,
-                            RenderGraph::BufferState::UnorderedAccess
-                        )
-                        .Read(
-                            neighbor_offset,
-                            RenderGraph::BufferState::ShaderResource
-                        )
-                        .Read(
-                            light_mapping,
-                            RenderGraph::BufferState::ShaderResource
-                        )
-                        .Read(
-                            light_data,
-                            RenderGraph::BufferState::ShaderResource
-                        )
-                        .Read(
-                            primitive_to_light,
-                            RenderGraph::BufferState::ShaderResource
-                        )
-                        .ReadWrite(
-                            graph_resources.diffuse_lighting,
-                            RenderGraph::TextureState::UnorderedAccess
-                        )
-                        .ReadWrite(
-                            graph_resources.specular_lighting,
-                            RenderGraph::TextureState::UnorderedAccess
-                        )
-                        .Read(
-                            graph_resources.current_view_depth,
-                            RenderGraph::TextureState::Sampled
-                        )
-                        .Read(
-                            graph_resources.current_diffuse_albedo,
-                            RenderGraph::TextureState::Sampled
-                        )
-                        .Read(
-                            graph_resources.current_specular_roughness,
-                            RenderGraph::TextureState::Sampled
-                        )
-                        .Read(
-                            graph_resources.current_normal,
-                            RenderGraph::TextureState::Sampled
-                        )
-                        .Read(
-                            graph_resources.previous_view_depth,
-                            RenderGraph::TextureState::Sampled
-                        )
-                        .Read(
-                            graph_resources.previous_diffuse_albedo,
-                            RenderGraph::TextureState::Sampled
-                        )
-                        .Read(
-                            graph_resources.previous_specular_roughness,
-                            RenderGraph::TextureState::Sampled
-                        )
-                        .Read(
-                            graph_resources.previous_normal,
-                            RenderGraph::TextureState::Sampled
-                        )
-                        .Read(
-                            graph_resources.motion,
-                            RenderGraph::TextureState::Sampled
-                        );
-                    if (local_light_pdf.IsValid()) {
-                        builder.Read(
-                            local_light_pdf,
-                            RenderGraph::TextureState::Sampled
-                        );
-                    }
-                    if (env_pdf.IsValid()) {
-                        builder.Read(
-                            env_pdf,
-                            RenderGraph::TextureState::Sampled
-                        );
-                    }
-                    if (env_map.IsValid()) {
-                        builder.Read(
-                            env_map,
-                            RenderGraph::TextureState::Sampled
-                        );
-                    }
-                },
-                [this, command, resources, dispatch](CommandList& cmd_list) {
-                    RecordDispatch(
-                        cmd_list,
-                        command,
-                        resources,
-                        dispatch
-                    );
-                },
-                RenderGraph::PassExecutionClass::ParallelRecordEligible
-            );
-        };
+    const auto add_dispatch = [&](std::string_view name, ELightingDispatch dispatch) {
+        graph.AddRecordPass(
+            name,
+            [=](RenderGraph::PassBuilder& builder) {
+                builder.ExecuteOn(RenderGraph::QueueRole::Graphics, RenderGraph::PipelineType::Compute)
+                    .Read(constants, RenderGraph::BufferState::ShaderResource)
+                    .Read(tlas, RenderGraph::BufferState::AccelerationStructureRead)
+                    .Read(prev_tlas, RenderGraph::BufferState::AccelerationStructureRead)
+                    .ReadWrite(light_reservoir, RenderGraph::BufferState::UnorderedAccess)
+                    .ReadWrite(ris, RenderGraph::BufferState::UnorderedAccess)
+                    .ReadWrite(ris_light_data, RenderGraph::BufferState::UnorderedAccess)
+                    .Read(neighbor_offset, RenderGraph::BufferState::ShaderResource)
+                    .Read(light_mapping, RenderGraph::BufferState::ShaderResource)
+                    .Read(light_data, RenderGraph::BufferState::ShaderResource)
+                    .Read(primitive_to_light, RenderGraph::BufferState::ShaderResource)
+                    .ReadWrite(graph_resources.diffuse_lighting, RenderGraph::TextureState::UnorderedAccess)
+                    .ReadWrite(graph_resources.specular_lighting, RenderGraph::TextureState::UnorderedAccess)
+                    .Read(graph_resources.current_view_depth, RenderGraph::TextureState::Sampled)
+                    .Read(graph_resources.current_diffuse_albedo, RenderGraph::TextureState::Sampled)
+                    .Read(graph_resources.current_specular_roughness, RenderGraph::TextureState::Sampled)
+                    .Read(graph_resources.current_normal, RenderGraph::TextureState::Sampled)
+                    .Read(graph_resources.previous_view_depth, RenderGraph::TextureState::Sampled)
+                    .Read(graph_resources.previous_diffuse_albedo, RenderGraph::TextureState::Sampled)
+                    .Read(graph_resources.previous_specular_roughness, RenderGraph::TextureState::Sampled)
+                    .Read(graph_resources.previous_normal, RenderGraph::TextureState::Sampled)
+                    .Read(graph_resources.motion, RenderGraph::TextureState::Sampled);
+                if (local_light_pdf.IsValid()) {
+                    builder.Read(local_light_pdf, RenderGraph::TextureState::Sampled);
+                }
+                if (env_pdf.IsValid()) {
+                    builder.Read(env_pdf, RenderGraph::TextureState::Sampled);
+                }
+                if (env_map.IsValid()) {
+                    builder.Read(env_map, RenderGraph::TextureState::Sampled);
+                }
+            },
+            [this, command, resources, dispatch](CommandList& cmd_list) {
+                RecordDispatch(cmd_list, command, resources, dispatch);
+            },
+            RenderGraph::PassExecutionClass::ParallelRecordEligible
+        );
+    };
 
     if (command.record_presample_light) {
-        add_dispatch(
-            "RT.Lighting.PresampleLight",
-            ELightingDispatch::PresampleLight
-        );
+        add_dispatch("RT.Lighting.PresampleLight", ELightingDispatch::PresampleLight);
     }
     if (command.record_presample_env) {
-        add_dispatch(
-            "RT.Lighting.PresampleEnvMap",
-            ELightingDispatch::PresampleEnvMap
-        );
+        add_dispatch("RT.Lighting.PresampleEnvMap", ELightingDispatch::PresampleEnvMap);
     }
     if (command.record_presample_grid) {
-        add_dispatch(
-            "RT.Lighting.PresampleLightGrid",
-            ELightingDispatch::PresampleLightGrid
-        );
+        add_dispatch("RT.Lighting.PresampleLightGrid", ELightingDispatch::PresampleLightGrid);
     }
-    add_dispatch(
-        "RT.Lighting.GenerateInitialSample",
-        ELightingDispatch::GenerateInitialSample
-    );
-    add_dispatch(
-        "RT.Lighting.TemporalResample",
-        ELightingDispatch::TemporalResample
-    );
-    add_dispatch(
-        "RT.Lighting.SpatialResample",
-        ELightingDispatch::SpatialResample
-    );
-    add_dispatch(
-        "RT.Lighting.ShadeSample",
-        ELightingDispatch::ShadeSample
-    );
+    add_dispatch("RT.Lighting.GenerateInitialSample", ELightingDispatch::GenerateInitialSample);
+    add_dispatch("RT.Lighting.TemporalResample", ELightingDispatch::TemporalResample);
+    add_dispatch("RT.Lighting.SpatialResample", ELightingDispatch::SpatialResample);
+    add_dispatch("RT.Lighting.ShadeSample", ELightingDispatch::ShadeSample);
 
-    const auto export_texture =
-        [&](RenderGraph::TextureHandle texture,
-            RenderGraph::TextureState  state,
-            RenderGraph::AccessMode    access) {
-            graph.Export(
-                texture,
-                state,
-                RenderGraph::QueueRole::Graphics,
-                access
-            );
-        };
+    const auto export_texture = [&](RenderGraph::TextureHandle texture,
+                                    RenderGraph::TextureState  state,
+                                    RenderGraph::AccessMode    access) {
+        graph.Export(texture, state, RenderGraph::QueueRole::Graphics, access);
+    };
     for (const auto texture : {
              graph_resources.previous_view_depth,
              graph_resources.previous_diffuse_albedo,
@@ -761,32 +491,18 @@ bool LightingPass::AddPasses(
              graph_resources.diffuse_lighting,
              graph_resources.specular_lighting,
          }) {
-        export_texture(
-            texture,
-            RenderGraph::TextureState::ShaderResource,
-            RenderGraph::AccessMode::Read
-        );
+        export_texture(texture, RenderGraph::TextureState::ShaderResource, RenderGraph::AccessMode::Read);
     }
     if (local_light_pdf.IsValid()) {
         export_texture(
-            local_light_pdf,
-            RenderGraph::TextureState::ShaderResource,
-            RenderGraph::AccessMode::Read
+            local_light_pdf, RenderGraph::TextureState::ShaderResource, RenderGraph::AccessMode::Read
         );
     }
     if (env_pdf.IsValid()) {
-        export_texture(
-            env_pdf,
-            RenderGraph::TextureState::ShaderResource,
-            RenderGraph::AccessMode::Read
-        );
+        export_texture(env_pdf, RenderGraph::TextureState::ShaderResource, RenderGraph::AccessMode::Read);
     }
     if (env_map.IsValid()) {
-        export_texture(
-            env_map,
-            RenderGraph::TextureState::ShaderResource,
-            RenderGraph::AccessMode::Read
-        );
+        export_texture(env_map, RenderGraph::TextureState::ShaderResource, RenderGraph::AccessMode::Read);
     }
 
     graph.Export(

--- a/source/runtime/render/renderer/raytracing/LightingPass.h
+++ b/source/runtime/render/renderer/raytracing/LightingPass.h
@@ -97,11 +97,11 @@ public:
         uint configured_mode           = s_di_local_light_sample_mode_uniform;
         uint effective_mode            = s_di_local_light_sample_mode_uniform;
         bool adaptive_fallback_applied = false;
-        uint local_light_count          = 0;
+        uint local_light_count         = 0;
     };
 
     struct PreparedCommand {
-        ResampleConstants           constants{};
+        ResampleConstants          constants{};
         LocalLightSamplingDecision sampling_decision{};
         bool                       record_presample_light = false;
         bool                       record_presample_env   = false;
@@ -140,11 +140,14 @@ public:
 
     LightingPass(class ShaderManager& manager, BindlessArrayRef bindless_array);
 
-    LocalLightSamplingDecision Process(CommandList& cmd_list, RTContext& rt_ctx);
+    LocalLightSamplingDecision
+         Process(CommandList& cmd_list, RTContext& rt_ctx, const DI::LightBufferParams& light_buffer_params);
     bool AddPasses(
         RenderGraph&                 graph,
         const RTGraphFrameResources& graph_resources,
         const RTContext&             rt_ctx,
+        const DI::LightBufferParams& light_buffer_params,
+        bool                         prepare_lights_in_graph,
         LocalLightSamplingDecision&  sampling_decision
     );
 
@@ -159,13 +162,13 @@ private:
         ShadeSample
     };
 
-    PreparedCommand Prepare(const RTContext& rt_ctx) const;
+    PreparedCommand Prepare(const RTContext& rt_ctx, const DI::LightBufferParams& light_buffer_params) const;
     RecordResources CaptureResources(const RTContext& rt_ctx) const;
-    void RecordConstantsUpload(
-        CommandList&           cmd_list,
-        const PreparedCommand& command,
-        const RecordResources& resources
-    ) const;
+    void            RecordConstantsUpload(
+                   CommandList&           cmd_list,
+                   const PreparedCommand& command,
+                   const RecordResources& resources
+               ) const;
     void RecordDispatch(
         CommandList&           cmd_list,
         const PreparedCommand& command,

--- a/source/runtime/render/renderer/raytracing/NrdDenoisePass.cpp
+++ b/source/runtime/render/renderer/raytracing/NrdDenoisePass.cpp
@@ -1,0 +1,274 @@
+#include "NrdDenoisePass.h"
+
+#if WITH_NRD
+
+#include "rhi/RHICommand.h"
+
+namespace Moer::Render::Raytracing {
+
+NrdDenoisePass::PreparedCommand NrdDenoisePass::Prepare(
+    SharedPtr<Ext::NRDInterface> interface,
+    uint32                       frame_index,
+    const Vector2ui&             size,
+    const Vector2f&              jitter,
+    const Matrix4x4f&            view,
+    const Matrix4x4f&            projection,
+    nrd::Denoiser                denoiser,
+    const RTContext&             rt_ctx
+) {
+    if (!interface) {
+        return {};
+    }
+
+    const auto& frame = rt_ctx.frame_rt;
+    Ext::NRDInterface::FrameDesc desc{
+        .frame_index = frame_index,
+        .size         = size,
+        .jitter       = jitter,
+        .view         = view,
+        .projection   = projection,
+        .denoiser     = denoiser,
+    };
+    desc
+        .Set(
+            Ext::NRDInterface::EResourceSlot::MOTION_VECTOR,
+            frame.motion
+        )
+        .Set(
+            Ext::NRDInterface::EResourceSlot::NORMAL_ROUGHNESS,
+            frame.normal_roughness
+        )
+        .Set(
+            Ext::NRDInterface::EResourceSlot::VIEW_Z,
+            rt_ctx.b_current_frame ?
+                frame.view_depth :
+                frame.prev_view_depth
+        )
+        .Set(
+            Ext::NRDInterface::EResourceSlot::IN_DIFFUSE,
+            frame.diffuse_lighting
+        )
+        .Set(
+            Ext::NRDInterface::EResourceSlot::IN_SPECULAR,
+            frame.specular_lighting
+        )
+        .Set(
+            Ext::NRDInterface::EResourceSlot::OUT_DIFFUSE,
+            frame.denoised_diffuse_lighting
+        )
+        .Set(
+            Ext::NRDInterface::EResourceSlot::OUT_SPECULAR,
+            frame.denoised_specular_lighting
+        );
+
+    auto prepared_frame = interface->PrepareFrame(std::move(desc));
+    return PreparedCommand{
+        .interface        = std::move(interface),
+        .frame            = std::move(prepared_frame),
+        .submission_fence = RenderDevice::Get().CreateFence(),
+        .submission_value = 1,
+        .graph_submission_fence =
+            RenderDevice::Get().CreateFence(),
+    };
+}
+
+bool NrdDenoisePass::AddPasses(
+    RenderGraph&           graph,
+    RTGraphFrameResources& graph_resources,
+    const PreparedCommand& command,
+    bool                   outputs_initialized
+) {
+    if (!outputs_initialized || !command.IsValid() ||
+        !graph_resources.frame_setup.ready.IsValid() ||
+        !graph_resources.motion.IsValid() ||
+        !graph_resources.normal_roughness.IsValid() ||
+        !graph_resources.current_view_depth.IsValid() ||
+        !graph_resources.diffuse_lighting.IsValid() ||
+        !graph_resources.specular_lighting.IsValid() ||
+        !graph_resources.denoised_diffuse_lighting.IsValid() ||
+        !graph_resources.denoised_specular_lighting.IsValid()) {
+        return false;
+    }
+
+    const auto same_texture =
+        [&](RenderGraph::TextureHandle graph_texture,
+            Ext::NRDInterface::EResourceSlot slot) {
+            const TextureRef physical =
+                graph.GetPhysicalTexture(graph_texture);
+            return physical &&
+                   physical.Get() ==
+                       command.frame->GetResource(slot).Get();
+        };
+    if (!same_texture(
+            graph_resources.motion,
+            Ext::NRDInterface::EResourceSlot::MOTION_VECTOR
+        ) ||
+        !same_texture(
+            graph_resources.normal_roughness,
+            Ext::NRDInterface::EResourceSlot::NORMAL_ROUGHNESS
+        ) ||
+        !same_texture(
+            graph_resources.current_view_depth,
+            Ext::NRDInterface::EResourceSlot::VIEW_Z
+        ) ||
+        !same_texture(
+            graph_resources.diffuse_lighting,
+            Ext::NRDInterface::EResourceSlot::IN_DIFFUSE
+        ) ||
+        !same_texture(
+            graph_resources.specular_lighting,
+            Ext::NRDInterface::EResourceSlot::IN_SPECULAR
+        ) ||
+        !same_texture(
+            graph_resources.denoised_diffuse_lighting,
+            Ext::NRDInterface::EResourceSlot::OUT_DIFFUSE
+        ) ||
+        !same_texture(
+            graph_resources.denoised_specular_lighting,
+            Ext::NRDInterface::EResourceSlot::OUT_SPECULAR
+        )) {
+        return false;
+    }
+
+    graph.SetInitialState(
+        graph_resources.denoised_diffuse_lighting,
+        RenderGraph::TextureState::Sampled,
+        RenderGraph::QueueRole::Graphics,
+        RenderGraph::AccessMode::Read
+    );
+    graph.SetInitialState(
+        graph_resources.denoised_specular_lighting,
+        RenderGraph::TextureState::Sampled,
+        RenderGraph::QueueRole::Graphics,
+        RenderGraph::AccessMode::Read
+    );
+
+    const auto ready = graph.CreateTransientToken("RT.NRD.ready");
+    const auto pass = graph.AddRecordPass(
+        "RT.NRD",
+        [=](RenderGraph::PassBuilder& builder) {
+            builder
+                .ExecuteOn(
+                    RenderGraph::QueueRole::Graphics,
+                    RenderGraph::PipelineType::Compute
+                )
+                .Read(graph_resources.frame_setup.ready)
+                .Read(
+                    graph_resources.motion,
+                    RenderGraph::TextureState::Sampled
+                )
+                .Read(
+                    graph_resources.normal_roughness,
+                    RenderGraph::TextureState::Sampled
+                )
+                .Read(
+                    graph_resources.current_view_depth,
+                    RenderGraph::TextureState::Sampled
+                )
+                .Read(
+                    graph_resources.diffuse_lighting,
+                    RenderGraph::TextureState::Sampled
+                )
+                .Read(
+                    graph_resources.specular_lighting,
+                    RenderGraph::TextureState::Sampled
+                )
+                .ReadWrite(
+                    graph_resources.denoised_diffuse_lighting,
+                    RenderGraph::TextureState::UnorderedAccess
+                )
+                .ReadWrite(
+                    graph_resources.denoised_specular_lighting,
+                    RenderGraph::TextureState::UnorderedAccess
+                )
+                .Write(ready)
+                .SideEffect()
+                .SerialRecord()
+                .TranslateSerialControl();
+        },
+        [command](CommandList& cmd_list) {
+            ScopedGpuMarker marker(
+                cmd_list,
+                "Pass: Radiance Denoising",
+                GpuMarkerPalette::Pass(),
+                EGpuMarkerMode::Timestamp
+            );
+            Process(cmd_list, command);
+        },
+        RenderGraph::PassExecutionClass::SerialRecord
+    );
+    if (!pass.IsValid()) {
+        return false;
+    }
+
+    graph_resources.nrd_ready = ready;
+    graph_resources.nrd_pass  = pass;
+    graph.Export(
+        graph_resources.denoised_diffuse_lighting,
+        RenderGraph::TextureState::Sampled,
+        RenderGraph::QueueRole::Graphics,
+        RenderGraph::AccessMode::Read
+    );
+    graph.Export(
+        graph_resources.denoised_specular_lighting,
+        RenderGraph::TextureState::Sampled,
+        RenderGraph::QueueRole::Graphics,
+        RenderGraph::AccessMode::Read
+    );
+    return true;
+}
+
+void NrdDenoisePass::Process(
+    CommandList&           cmd_list,
+    const PreparedCommand& command
+) {
+    if (!command.IsValid()) {
+        throw std::invalid_argument(
+            "NRD pass requires a valid immutable prepared command"
+        );
+    }
+    command.interface->Denoise(
+        cmd_list,
+        command.frame,
+        "Radiance Denoising"
+    );
+    // This signal belongs to the same immutable CmdSubmit as the NRD custom
+    // command. Fence::WaitSubmitted therefore distinguishes native queue
+    // acceptance from frontend recording-handoff admission.
+    cmd_list.Signal(
+        command.submission_fence,
+        command.submission_value
+    );
+}
+
+bool NrdDenoisePass::CommitAcceptedSubmission(
+    const PreparedCommand& command,
+    const FenceRef&        frame_fence,
+    uint64                 frame_value,
+    uint64                 graph_submission_value_count
+) {
+    if (!command.IsValid() || !frame_fence || frame_value == 0 ||
+        !frame_fence->WaitSubmitted(frame_value)) {
+        return false;
+    }
+    // A recoverably rejected graph source must not be hidden by a later
+    // accepted final tail. Every managed source receives a monotonically
+    // increasing value on this transaction fence; inspect each value because
+    // a later accepted value does not erase an earlier explicit rejection.
+    for (uint64 value = 1; value <= graph_submission_value_count;
+         ++value) {
+        if (!command.graph_submission_fence->WaitSubmitted(value)) {
+            return false;
+        }
+    }
+    if (!command.submission_fence->WaitSubmitted(
+            command.submission_value
+        )) {
+        return false;
+    }
+    return command.interface->CommitFrame(command.frame);
+}
+
+} // namespace Moer::Render::Raytracing
+
+#endif

--- a/source/runtime/render/renderer/raytracing/NrdDenoisePass.h
+++ b/source/runtime/render/renderer/raytracing/NrdDenoisePass.h
@@ -1,0 +1,70 @@
+#pragma once
+
+#include "RaytracingGraphResources.h"
+#include "rhi/plugin/NrdPlugin.h"
+
+namespace Moer::Render::Raytracing {
+
+#if WITH_NRD
+
+/**
+ * NRD is an external mutable SDK, but its renderer-facing pass is immutable.
+ * Prepare freezes one accepted-history candidate and every TextureRef. The
+ * graph callback only appends that packet; SDK state changes happen later at
+ * a SerialControl translation frontier.
+ */
+class NrdDenoisePass {
+public:
+    struct PreparedCommand {
+        SharedPtr<Ext::NRDInterface>         interface{};
+        Ext::NRDInterface::PreparedFrameRef  frame{};
+        FenceRef                             submission_fence{};
+        uint64                               submission_value = 1;
+        FenceRef                             graph_submission_fence{};
+
+        [[nodiscard]] bool IsValid() const {
+            return interface && frame && frame->IsValid() &&
+                   submission_fence && submission_value != 0 &&
+                   graph_submission_fence;
+        }
+    };
+
+    [[nodiscard]] static PreparedCommand Prepare(
+        SharedPtr<Ext::NRDInterface> interface,
+        uint32                       frame_index,
+        const Vector2ui&             size,
+        const Vector2f&              jitter,
+        const Matrix4x4f&            view,
+        const Matrix4x4f&            projection,
+        nrd::Denoiser                denoiser,
+        const RTContext&             rt_ctx
+    );
+
+    static bool AddPasses(
+        RenderGraph&                graph,
+        RTGraphFrameResources&      graph_resources,
+        const PreparedCommand&      command,
+        bool                        outputs_initialized
+    );
+
+    static void Process(
+        CommandList&           cmd_list,
+        const PreparedCommand& command
+    );
+
+    /**
+     * Waits only for native queue acceptance, not GPU completion. Both the
+     * NRD-owning source and the final frame tail must be accepted before
+     * renderer-side temporal history advances.
+     */
+    [[nodiscard]] static bool CommitAcceptedSubmission(
+        const PreparedCommand& command,
+        const FenceRef&        frame_fence,
+        uint64                 frame_value,
+        uint64                 graph_submission_value_count
+    );
+};
+
+#endif
+
+} // namespace Moer::Render::Raytracing

--- a/source/runtime/render/renderer/raytracing/PreprocessLightPass.cpp
+++ b/source/runtime/render/renderer/raytracing/PreprocessLightPass.cpp
@@ -81,13 +81,6 @@ static_assert(RoundUpCapacity(129, 128) == 256);
 static_assert(RoundUpCapacity(1023, 1024) == 1024);
 static_assert(RoundUpCapacity(1025, 1024) == 2048);
 
-RenderGraph::TextureState PreferredReadState(const TextureRef& texture) {
-    const auto usage = texture->GetUsage();
-    const bool supports_uav =
-        (usage & ETextureUsageFlags::UNORDERED_ACCESS) == ETextureUsageFlags::UNORDERED_ACCESS;
-    return supports_uav ? RenderGraph::TextureState::ShaderResource : RenderGraph::TextureState::Sampled;
-}
-
 void RequireBufferCapacity(const BufferRef& buffer, size_t required_elements, std::string_view name) {
     if (!buffer || buffer->GetNumElement() < required_elements) {
         throw std::runtime_error(std::format(
@@ -545,24 +538,59 @@ void PrepareLightPass::RecordAcceptedBoundary(CommandList& cmd_list, const Prepa
 }
 
 bool PrepareLightPass::AddPasses(
-    RenderGraph&             graph,
-    const PreparedCommand&   command,
-    RenderGraph::TokenHandle frame_setup_ready
+    RenderGraph&                       graph,
+    const PreparedCommand&             command,
+    const RTGraphFrameSetupResources& frame_setup
 ) {
     const auto payload = command.record;
     if (!payload || !payload->resources.primitive_to_light_buf || !payload->resources.task_buf ||
         !payload->resources.prim_light_buf || !payload->resources.light_mapping_buf ||
         !payload->resources.light_data_buf || !payload->resources.local_light_pdf_tex ||
         !payload->resources.bindless_array || !payload->resources.shader_utils ||
-        !frame_setup_ready.IsValid()) {
+        !frame_setup.IsValid()) {
         return false;
     }
     if (payload->reads_scene_geometry &&
         (!payload->resources.primitive_buf || !payload->resources.instance_buf ||
          !payload->resources.material_buf || !payload->resources.position_buf ||
-         !payload->resources.index_buf)) {
+         !payload->resources.index_buf ||
+         frame_setup.scene.primitive_resource.Get() !=
+             payload->resources.primitive_buf.Get() ||
+         frame_setup.scene.instance_resource.Get() !=
+             payload->resources.instance_buf.Get() ||
+         frame_setup.scene.material_resource.Get() !=
+             payload->resources.material_buf.Get() ||
+         frame_setup.scene.position_resource.Get() !=
+             payload->resources.position_buf.Get() ||
+         frame_setup.scene.index_resource.Get() !=
+             payload->resources.index_buf.Get() ||
+         !frame_setup.scene.primitive.IsValid() ||
+         !frame_setup.scene.instance.IsValid() ||
+         !frame_setup.scene.material.IsValid() ||
+         !frame_setup.scene.position.IsValid() ||
+         !frame_setup.scene.index.IsValid() ||
+         (payload->resources.texcoord0_buf &&
+          (!frame_setup.scene.texcoord0.IsValid() ||
+           frame_setup.scene.texcoord0_resource.Get() !=
+               payload->resources.texcoord0_buf.Get())) ||
+         frame_setup.scene.material_textures.size() !=
+             payload->resources.material_textures.size() ||
+         frame_setup.scene.material_texture_resources.size() !=
+             payload->resources.material_textures.size())) {
         return false;
     }
+    if (payload->reads_scene_geometry) {
+        for (size_t index = 0;
+             index < payload->resources.material_textures.size();
+             ++index) {
+            if (frame_setup.scene.material_texture_resources[index].Get() !=
+                    payload->resources.material_textures[index].Get() ||
+                !frame_setup.scene.material_textures[index].IsValid()) {
+                return false;
+            }
+        }
+    }
+    const RenderGraph::TokenHandle frame_setup_ready = frame_setup.ready;
 
     const auto primitive_to_light = ImportRTGraphBuffer(
         graph, "RT.PrepareLights.primitive_to_light", payload->resources.primitive_to_light_buf
@@ -585,29 +613,15 @@ bool PrepareLightPass::AddPasses(
     RenderGraph::BufferHandle         texcoord0_buf{};
     Array<RenderGraph::TextureHandle> material_textures;
     if (payload->reads_scene_geometry) {
-        primitive_buf =
-            ImportRTGraphBuffer(graph, "RT.PrepareLights.scene_primitives", payload->resources.primitive_buf);
-        instance_buf =
-            ImportRTGraphBuffer(graph, "RT.PrepareLights.scene_instances", payload->resources.instance_buf);
-        material_buf =
-            ImportRTGraphBuffer(graph, "RT.PrepareLights.scene_materials", payload->resources.material_buf);
-        position_buf =
-            ImportRTGraphBuffer(graph, "RT.PrepareLights.scene_positions", payload->resources.position_buf);
-        index_buf =
-            ImportRTGraphBuffer(graph, "RT.PrepareLights.scene_indices", payload->resources.index_buf);
+        primitive_buf = frame_setup.scene.primitive;
+        instance_buf  = frame_setup.scene.instance;
+        material_buf  = frame_setup.scene.material;
+        position_buf  = frame_setup.scene.position;
+        index_buf     = frame_setup.scene.index;
         if (payload->resources.texcoord0_buf) {
-            texcoord0_buf = ImportRTGraphBuffer(
-                graph, "RT.PrepareLights.scene_texcoords", payload->resources.texcoord0_buf
-            );
+            texcoord0_buf = frame_setup.scene.texcoord0;
         }
-        material_textures.reserve(payload->resources.material_textures.size());
-        for (size_t index = 0; index < payload->resources.material_textures.size(); ++index) {
-            material_textures.emplace_back(ImportRTGraphTexture(
-                graph,
-                std::format("RT.PrepareLights.material_texture.{}", index),
-                payload->resources.material_textures[index]
-            ));
-        }
+        material_textures = frame_setup.scene.material_textures;
     }
 
     const auto initial_persistent_buffer = [&](RenderGraph::BufferHandle buffer, bool initialized) {
@@ -631,46 +645,6 @@ bool PrepareLightPass::AddPasses(
                                                RenderGraph::QueueRole::None,
         payload->local_light_pdf_initialized ? RenderGraph::AccessMode::Read : RenderGraph::AccessMode::None
     );
-
-    const auto initial_scene_buffer = [&](RenderGraph::BufferHandle buffer) {
-        graph.SetInitialState(
-            buffer,
-            RenderGraph::BufferState::ShaderResource,
-            RenderGraph::QueueRole::Graphics,
-            RenderGraph::AccessMode::Read
-        );
-        graph.Export(
-            buffer,
-            RenderGraph::BufferState::ShaderResource,
-            RenderGraph::QueueRole::Graphics,
-            RenderGraph::AccessMode::Read
-        );
-    };
-    if (payload->reads_scene_geometry) {
-        for (const auto buffer : {
-                 primitive_buf,
-                 instance_buf,
-                 material_buf,
-                 position_buf,
-                 index_buf,
-             }) {
-            initial_scene_buffer(buffer);
-        }
-        if (texcoord0_buf.IsValid()) {
-            initial_scene_buffer(texcoord0_buf);
-        }
-        for (size_t index = 0; index < material_textures.size(); ++index) {
-            const RenderGraph::TextureHandle texture = material_textures[index];
-            const RenderGraph::TextureState  read_state =
-                PreferredReadState(payload->resources.material_textures[index]);
-            graph.SetInitialState(
-                texture, read_state, RenderGraph::QueueRole::Graphics, RenderGraph::AccessMode::Read
-            );
-            graph.Export(
-                texture, read_state, RenderGraph::QueueRole::Graphics, RenderGraph::AccessMode::Read
-            );
-        }
-    }
 
     graph.AddRecordPass(
         "RT.PrepareLights.UploadInputs",

--- a/source/runtime/render/renderer/raytracing/PreprocessLightPass.cpp
+++ b/source/runtime/render/renderer/raytracing/PreprocessLightPass.cpp
@@ -1,10 +1,14 @@
 #include "PreprocessLightPass.h"
 
+#include "RaytracingGraphResources.h"
 #include "rhi/RHICommand.h"
 #include "shader/ShaderResourceManager.h"
 
 #include <algorithm>
 #include <cmath>
+#include <format>
+#include <stdexcept>
+#include <string_view>
 
 namespace Moer::Render::Raytracing {
 
@@ -62,6 +66,39 @@ void PackPolyLightColor(const float3& color, PolymorphicLightInfo& info) {
     info.log_radiance = packed_radiance;
 }
 
+constexpr uint RoundUpCapacity(uint count, uint chunk_size) {
+    if (count == 0) {
+        return 0;
+    }
+    return (count + chunk_size - 1) & ~(chunk_size - 1);
+}
+
+static_assert(RoundUpCapacity(0, 128) == 0);
+static_assert(RoundUpCapacity(1, 128) == 128);
+static_assert(RoundUpCapacity(127, 128) == 128);
+static_assert(RoundUpCapacity(128, 128) == 128);
+static_assert(RoundUpCapacity(129, 128) == 256);
+static_assert(RoundUpCapacity(1023, 1024) == 1024);
+static_assert(RoundUpCapacity(1025, 1024) == 2048);
+
+RenderGraph::TextureState PreferredReadState(const TextureRef& texture) {
+    const auto usage = texture->GetUsage();
+    const bool supports_uav =
+        (usage & ETextureUsageFlags::UNORDERED_ACCESS) == ETextureUsageFlags::UNORDERED_ACCESS;
+    return supports_uav ? RenderGraph::TextureState::ShaderResource : RenderGraph::TextureState::Sampled;
+}
+
+void RequireBufferCapacity(const BufferRef& buffer, size_t required_elements, std::string_view name) {
+    if (!buffer || buffer->GetNumElement() < required_elements) {
+        throw std::runtime_error(std::format(
+            "PrepareLights buffer '{}' capacity is {}, but {} elements are required",
+            name,
+            buffer ? buffer->GetNumElement() : 0,
+            required_elements
+        ));
+    }
+}
+
 } // namespace
 
 PrepareLightPass::PrepareLightPass(ShaderManager& manager, BindlessArrayRef bindless_array) :
@@ -70,36 +107,129 @@ PrepareLightPass::PrepareLightPass(ShaderManager& manager, BindlessArrayRef bind
         "pipelines/raytracing/lighting/precompute/PrepareLights.hlsl"
     )) {}
 
-void PrepareLightPass::Process(
-    CommandList&                        cmd_list,
+PrepareLightPass::RecordResources PrepareLightPass::CaptureResources(const RTContext& rt_ctx) const {
+    const RaytracingBindlessResources& scene = rt_ctx.GetBindlessResources();
+    return RecordResources{
+        .primitive_to_light_buf = rt_ctx.primitive_to_light_buf,
+        .task_buf               = rt_ctx.task_buf,
+        .prim_light_buf         = rt_ctx.prim_light_buf,
+        .light_mapping_buf      = rt_ctx.light_mapping_buf,
+        .light_data_buf         = rt_ctx.light_data_buf,
+        .primitive_buf          = scene.primitive_buf,
+        .instance_buf           = scene.instance_buf,
+        .material_buf           = scene.material_buf,
+        .position_buf           = scene.position_buf,
+        .index_buf              = scene.index_buf,
+        .texcoord0_buf          = scene.texcoord0_buf,
+        .local_light_pdf_tex    = rt_ctx.local_light_pdf_tex,
+        .local_light_pdf_mips   = rt_ctx.local_light_pdf_mips,
+        .material_textures      = scene.material_textures,
+        .bindless_array         = bindless_array,
+        .shader_utils           = &rt_ctx.sd_utils
+    };
+}
+
+PrepareLightPass::PreparedCommand PrepareLightPass::Prepare(
     RTContext&                          rt_ctx,
-    const RaytracingSceneFrameSnapshot& scene_snapshot
+    const RaytracingSceneFrameSnapshot& scene_snapshot,
+    uint64                              scene_revision
 ) {
-    Array<PrepareLightsTask>    tasks;
-    Array<PolymorphicLightInfo> primitive_light_infos;
-    Array<uint>                 primitive_to_light(scene_snapshot.primitive_count, s_invalid_light_idx);
+    static constexpr uint s_mesh_alloc_chunk      = 128;
+    static constexpr uint s_triangle_alloc_chunk  = 1024;
+    static constexpr uint s_primitive_alloc_chunk = 128;
+
+    uint emissive_mesh_count     = 0;
+    uint emissive_triangle_count = 0;
+    uint primitive_count         = std::max(scene_snapshot.primitive_count, 1u);
+    for (const auto& primitive : scene_snapshot.emissive_primitives) {
+        if (primitive.num_triangles == 0) {
+            continue;
+        }
+        ++emissive_mesh_count;
+        emissive_triangle_count += primitive.num_triangles;
+        primitive_count = std::max(primitive_count, primitive.primitive_id + 1);
+    }
+
+    const bool has_environment_light = rt_ctx.scene_params.enable_env_map && rt_ctx.env_pdf_tex;
+    const uint primitive_light_count =
+        static_cast<uint>(scene_snapshot.analytic_lights.size()) + static_cast<uint>(has_environment_light);
+    rt_ctx.CreateBuffersIfNeeded(
+        RoundUpCapacity(emissive_mesh_count, s_mesh_alloc_chunk),
+        RoundUpCapacity(emissive_triangle_count, s_triangle_alloc_chunk),
+        RoundUpCapacity(primitive_light_count, s_primitive_alloc_chunk),
+        primitive_count
+    );
+
+    auto payload                  = MakeShared<RecordPayload>();
+    payload->resources            = CaptureResources(rt_ctx);
+    payload->reads_scene_geometry = emissive_mesh_count != 0;
+
+    PreparedCommand command{};
+    command.next_primitive_to_light_identity = payload->resources.primitive_to_light_buf.Get();
+    command.next_tasks_identity              = payload->resources.task_buf.Get();
+    command.next_primitive_lights_identity   = payload->resources.prim_light_buf.Get();
+    command.next_light_mapping_identity      = payload->resources.light_mapping_buf.Get();
+    command.next_light_data_identity         = payload->resources.light_data_buf.Get();
+    command.next_local_light_pdf_identity    = payload->resources.local_light_pdf_tex.Get();
+    command.next_scene_revision              = scene_revision;
+
+    payload->primitive_to_light_initialized =
+        accepted_primitive_to_light_identity == command.next_primitive_to_light_identity;
+    payload->tasks_initialized = accepted_tasks_identity == command.next_tasks_identity;
+    payload->primitive_lights_initialized =
+        accepted_primitive_lights_identity == command.next_primitive_lights_identity;
+    payload->light_mapping_initialized =
+        accepted_light_mapping_identity == command.next_light_mapping_identity;
+    payload->light_data_initialized = accepted_light_data_identity == command.next_light_data_identity;
+    payload->local_light_pdf_initialized =
+        accepted_local_light_pdf_identity == command.next_local_light_pdf_identity;
+    payload->reset_light_history = !payload->light_mapping_initialized || !payload->light_data_initialized ||
+                                   accepted_scene_revision != scene_revision;
+
+    const UnorderedMap<uint64, EmissiveLightHistory> empty_instance_offsets{};
+    const UnorderedMap<uint64, uint>                 empty_primitive_offsets{};
+    const auto&                                      previous_instance_offsets =
+        payload->reset_light_history ? empty_instance_offsets : instance_light_buffer_offsets;
+    const auto& previous_primitive_offsets =
+        payload->reset_light_history ? empty_primitive_offsets : primitive_light_buffer_offsets;
+    const bool current_odd_frame = payload->reset_light_history ? false : b_odd_frame;
+
+    payload->primitive_to_light = Array<uint>(primitive_count, s_invalid_light_idx);
 
     uint light_buffer_offset          = 0;
     uint num_emissive_triangle_lights = 0;
     for (const auto& primitive : scene_snapshot.emissive_primitives) {
-        const auto previous = instance_light_buffer_offsets.find(primitive.stable_key);
+        if (primitive.num_triangles == 0) {
+            continue;
+        }
+        const auto previous = previous_instance_offsets.find(primitive.stable_key);
+        const bool previous_is_compatible =
+            previous != previous_instance_offsets.end() &&
+            previous->second.num_triangles == primitive.num_triangles &&
+            previous->second.index_start_idx == primitive.index_start_idx &&
+            previous->second.first_instance_idx == primitive.first_instance_idx;
 
         PrepareLightsTask task{};
         task.primitive_id       = primitive.primitive_id;
         task.light_offset       = light_buffer_offset;
         task.num_triangles      = primitive.num_triangles;
-        task.prev_light_offset  = previous == instance_light_buffer_offsets.end() ? -1 : previous->second;
+        task.prev_light_offset  = previous_is_compatible ? previous->second.light_offset : -1;
         task.index_start_idx    = primitive.index_start_idx;
         task.first_instance_idx = primitive.first_instance_idx;
 
-        if (primitive.primitive_id >= primitive_to_light.size()) {
-            primitive_to_light.resize(primitive.primitive_id + 1, s_invalid_light_idx);
+        if (primitive.primitive_id >= payload->primitive_to_light.size()) {
+            payload->primitive_to_light.resize(primitive.primitive_id + 1, s_invalid_light_idx);
         }
-        primitive_to_light[primitive.primitive_id]          = light_buffer_offset;
-        instance_light_buffer_offsets[primitive.stable_key] = light_buffer_offset;
+        payload->primitive_to_light[primitive.primitive_id]              = light_buffer_offset;
+        command.next_instance_light_buffer_offsets[primitive.stable_key] = EmissiveLightHistory{
+            .light_offset       = light_buffer_offset,
+            .num_triangles      = primitive.num_triangles,
+            .index_start_idx    = primitive.index_start_idx,
+            .first_instance_idx = primitive.first_instance_idx
+        };
         light_buffer_offset += task.num_triangles;
         num_emissive_triangle_lights += task.num_triangles;
-        tasks.emplace_back(task);
+        payload->tasks.emplace_back(task);
     }
 
     uint num_finite_primitive_lights   = 0;
@@ -107,18 +237,18 @@ void PrepareLightPass::Process(
     uint num_environment_lights        = 0;
 
     for (const auto& light : scene_snapshot.analytic_lights) {
-        const auto previous = primitive_light_buffer_offsets.find(light.stable_key);
+        const auto previous = previous_primitive_offsets.find(light.stable_key);
 
         PrepareLightsTask task{};
-        task.primitive_id      = static_cast<uint>(primitive_light_infos.size()) | g_task_prim_light_bit;
-        task.light_offset      = light_buffer_offset;
-        task.num_triangles     = 1;
-        task.prev_light_offset = previous == primitive_light_buffer_offsets.end() ? -1 : previous->second;
+        task.primitive_id  = static_cast<uint>(payload->primitive_light_infos.size()) | g_task_prim_light_bit;
+        task.light_offset  = light_buffer_offset;
+        task.num_triangles = 1;
+        task.prev_light_offset = previous == previous_primitive_offsets.end() ? -1 : previous->second;
 
-        primitive_light_buffer_offsets[light.stable_key] = light_buffer_offset;
+        command.next_primitive_light_buffer_offsets[light.stable_key] = light_buffer_offset;
         ++light_buffer_offset;
-        tasks.emplace_back(task);
-        primitive_light_infos.emplace_back(light.light_info);
+        payload->tasks.emplace_back(task);
+        payload->primitive_light_infos.emplace_back(light.light_info);
 
         switch (light.light_class) {
             case EAnalyticLightClass::Finite:
@@ -133,7 +263,7 @@ void PrepareLightPass::Process(
         }
     }
 
-    if (rt_ctx.scene_params.enable_env_map && rt_ctx.env_pdf_tex) {
+    if (has_environment_light) {
         PolymorphicLightInfo light_info{};
         light_info.color_type_flags = static_cast<uint>(EPolyLightType::ELEnv)
                                       << g_poly_morphic_light_type_shift;
@@ -146,97 +276,532 @@ void PrepareLightPass::Process(
         light_info.scalars |= g_poly_morphic_light_env_is_scalar_bit;
 
         constexpr uint64 environment_light_key = ~0ull;
-        const auto       previous              = primitive_light_buffer_offsets.find(environment_light_key);
+        const auto       previous              = previous_primitive_offsets.find(environment_light_key);
 
         PrepareLightsTask task{};
-        task.primitive_id      = static_cast<uint>(primitive_light_infos.size()) | g_task_prim_light_bit;
-        task.light_offset      = light_buffer_offset;
-        task.num_triangles     = 1;
-        task.prev_light_offset = previous == primitive_light_buffer_offsets.end() ? -1 : previous->second;
+        task.primitive_id  = static_cast<uint>(payload->primitive_light_infos.size()) | g_task_prim_light_bit;
+        task.light_offset  = light_buffer_offset;
+        task.num_triangles = 1;
+        task.prev_light_offset = previous == previous_primitive_offsets.end() ? -1 : previous->second;
 
-        primitive_light_buffer_offsets[environment_light_key] = light_buffer_offset;
+        command.next_primitive_light_buffer_offsets[environment_light_key] = light_buffer_offset;
         ++light_buffer_offset;
-        tasks.emplace_back(task);
-        primitive_light_infos.emplace_back(light_info);
+        payload->tasks.emplace_back(task);
+        payload->primitive_light_infos.emplace_back(light_info);
         ++num_environment_lights;
     }
 
-    cmd_list.PushScopeWithTimeScope("PrepareLights");
+    payload->params.num_tasks          = static_cast<uint>(payload->tasks.size());
+    payload->params.primitive_buf_hdl  = rt_ctx.GetBindlessHandles().primitive_buf_hdl;
+    payload->params.instance_buf_hdl   = rt_ctx.GetBindlessHandles().instance_buf_hdl;
+    payload->params.material_buf_hdl   = rt_ctx.GetBindlessHandles().material_buf_hdl;
+    payload->params.position_buf_hdl   = rt_ctx.GetBindlessHandles().position_buf_hdl;
+    payload->params.index_buf_hdl      = rt_ctx.GetBindlessHandles().index_buf_hdl;
+    payload->params.texcoord0_buf_hdl  = rt_ctx.GetBindlessHandles().texcoord0_buf_hdl;
+    payload->params.primitive_to_light = rt_ctx.GetBindlessHandles().primitive_to_light;
 
-    if (!primitive_to_light.empty()) {
-        cmd_list.CopyFrom(
-            std::span<byte>(
-                reinterpret_cast<byte*>(primitive_to_light.data()), primitive_to_light.size() * sizeof(uint)
-            ),
-            rt_ctx.primitive_to_light_buf->GetView(),
-            "Upload primitive_to_light"
-        );
-    }
-
-    cmd_list.CopyFrom(
-        std::span<byte>(reinterpret_cast<byte*>(tasks.data()), tasks.size() * sizeof(PrepareLightsTask)),
-        rt_ctx.task_buf->GetView(0, tasks.size() * sizeof(PrepareLightsTask)),
-        "Upload tasks"
-    );
-
-    if (!primitive_light_infos.empty()) {
-        cmd_list.CopyFrom(
-            std::span<byte>(
-                reinterpret_cast<byte*>(primitive_light_infos.data()),
-                primitive_light_infos.size() * sizeof(PolymorphicLightInfo)
-            ),
-            rt_ctx.prim_light_buf->GetView(),
-            "Upload prim light infos"
-        );
-    }
-
-    cmd_list.ClearResource(rt_ctx.light_mapping_buf->GetView(), 0u);
-    cmd_list.ClearResource(
-        rt_ctx.local_light_pdf_tex->GetView(0, rt_ctx.local_light_pdf_tex->GetNumMips()), float4(0.f)
-    );
-
-    PrepareLightsParams params{};
-    params.num_tasks          = static_cast<uint>(tasks.size());
-    params.primitive_buf_hdl  = rt_ctx.GetBindlessHandles().primitive_buf_hdl;
-    params.instance_buf_hdl   = rt_ctx.GetBindlessHandles().instance_buf_hdl;
-    params.material_buf_hdl   = rt_ctx.GetBindlessHandles().material_buf_hdl;
-    params.position_buf_hdl   = rt_ctx.GetBindlessHandles().position_buf_hdl;
-    params.index_buf_hdl      = rt_ctx.GetBindlessHandles().index_buf_hdl;
-    params.texcoord0_buf_hdl  = rt_ctx.GetBindlessHandles().texcoord0_buf_hdl;
-    params.primitive_to_light = rt_ctx.GetBindlessHandles().primitive_to_light;
-
-    const uint max_lights_in_buffer = static_cast<uint>(rt_ctx.light_data_buf->GetNumElement() / 2);
-    params.cur_light_offset         = max_lights_in_buffer * b_odd_frame;
-    params.prev_light_offset        = max_lights_in_buffer * !b_odd_frame;
-
-    rt_ctx.is_ctx.SetLightBufferParams(
-        params.cur_light_offset,
+    const uint max_lights_in_buffer   = static_cast<uint>(rt_ctx.light_data_buf->GetNumElement() / 2);
+    payload->params.cur_light_offset  = max_lights_in_buffer * static_cast<uint>(current_odd_frame);
+    payload->params.prev_light_offset = max_lights_in_buffer * static_cast<uint>(!current_odd_frame);
+    payload->light_buffer_params      = ImportanceSamplingContext::BuildLightBufferParams(
+        payload->params.cur_light_offset,
         num_finite_primitive_lights + num_emissive_triangle_lights,
         num_infinite_primitive_lights,
         num_environment_lights
     );
+    payload->dispatch_light_count = light_buffer_offset;
 
+    RequireBufferCapacity(
+        payload->resources.primitive_to_light_buf, payload->primitive_to_light.size(), "primitive_to_light"
+    );
+    RequireBufferCapacity(payload->resources.task_buf, payload->tasks.size(), "tasks");
+    RequireBufferCapacity(
+        payload->resources.prim_light_buf, payload->primitive_light_infos.size(), "primitive_lights"
+    );
+    RequireBufferCapacity(
+        payload->resources.light_mapping_buf,
+        static_cast<size_t>(payload->dispatch_light_count) * 2,
+        "light_mapping"
+    );
+    RequireBufferCapacity(
+        payload->resources.light_data_buf,
+        static_cast<size_t>(payload->dispatch_light_count) * 2,
+        "light_data"
+    );
+
+    constexpr uint max_destination_mips_per_dispatch = 5;
+    const uint     mip_count = static_cast<uint>(payload->resources.local_light_pdf_mips.size());
+    for (uint source_mip = 0; source_mip + 1 < mip_count; source_mip += max_destination_mips_per_dispatch) {
+        payload->mip_dispatches.emplace_back(MipDispatch{
+            .source_mip      = source_mip,
+            .bound_mip_count = std::min(max_destination_mips_per_dispatch + 1, mip_count - source_mip)
+        });
+    }
+
+    command.next_odd_frame = !current_odd_frame;
+    command.record         = std::move(payload);
+    return command;
+}
+
+void PrepareLightPass::RecordUploads(CommandList& cmd_list, SharedPtr<const RecordPayload> payload) {
+    if (!payload->primitive_to_light.empty()) {
+        cmd_list.CopyFrom(
+            std::span<byte>(
+                reinterpret_cast<byte*>(const_cast<uint*>(payload->primitive_to_light.data())),
+                payload->primitive_to_light.size() * sizeof(uint)
+            ),
+            payload->resources.primitive_to_light_buf->GetView(),
+            "Upload primitive_to_light"
+        );
+    }
+    if (payload->tasks.empty() && !payload->tasks_initialized) {
+        // A newly allocated empty task buffer still needs a concrete contents
+        // and state boundary before it can be exported as an SRV. This keeps
+        // empty-scene graph compilation complete without inventing an
+        // external initial state for the new allocation.
+        cmd_list.ClearResource(payload->resources.task_buf->GetView(), 0u);
+    } else if (!payload->tasks.empty()) {
+        cmd_list.CopyFrom(
+            std::span<byte>(
+                reinterpret_cast<byte*>(const_cast<PrepareLightsTask*>(payload->tasks.data())),
+                payload->tasks.size() * sizeof(PrepareLightsTask)
+            ),
+            payload->resources.task_buf->GetView(0, payload->tasks.size() * sizeof(PrepareLightsTask)),
+            "Upload tasks"
+        );
+    }
+    if (payload->primitive_light_infos.empty() && !payload->primitive_lights_initialized) {
+        cmd_list.ClearResource(payload->resources.prim_light_buf->GetView(), 0u);
+    } else if (!payload->primitive_light_infos.empty()) {
+        cmd_list.CopyFrom(
+            std::span<byte>(
+                reinterpret_cast<byte*>(const_cast<PolymorphicLightInfo*>(payload->primitive_light_infos.data(
+                ))),
+                payload->primitive_light_infos.size() * sizeof(PolymorphicLightInfo)
+            ),
+            payload->resources.prim_light_buf->GetView(),
+            "Upload prim light infos"
+        );
+    }
+    cmd_list.AddCallback([payload(std::move(payload))]() {});
+}
+
+void PrepareLightPass::RecordClears(CommandList& cmd_list, SharedPtr<const RecordPayload> payload) {
+    cmd_list.ClearResource(payload->resources.light_mapping_buf->GetView(), 0u);
+    if (payload->reset_light_history) {
+        cmd_list.ClearResource(payload->resources.light_data_buf->GetView(), 0u);
+    }
+    cmd_list.ClearResource(
+        payload->resources.local_light_pdf_tex->GetView(
+            0, payload->resources.local_light_pdf_tex->GetNumMips()
+        ),
+        float4(0.f)
+    );
+    cmd_list.AddCallback([payload(std::move(payload))]() {});
+}
+
+void PrepareLightPass::RecordSceneInputTransitions(
+    CommandList&                   cmd_list,
+    SharedPtr<const RecordPayload> payload
+) {
+    if (!payload->reads_scene_geometry) {
+        return;
+    }
+
+    Array<ReadBuffer> buffers;
+    buffers.reserve(6);
+    for (const BufferRef& buffer : {
+             payload->resources.primitive_buf,
+             payload->resources.instance_buf,
+             payload->resources.material_buf,
+             payload->resources.position_buf,
+             payload->resources.index_buf,
+         }) {
+        buffers.emplace_back(ReadBuffer{buffer->GetView(), EBufferState::SHADER_RESOURCE});
+    }
+    if (payload->resources.texcoord0_buf) {
+        buffers.emplace_back(
+            ReadBuffer{payload->resources.texcoord0_buf->GetView(), EBufferState::SHADER_RESOURCE}
+        );
+    }
+    cmd_list.BufferBarriers(
+        EQueueType::Graphics,
+        EQueueType::Graphics,
+        EPassType::Compute,
+        std::move(buffers),
+        Array<WriteBuffer>{}
+    );
+
+    if (!payload->resources.material_textures.empty()) {
+        Array<ReadTexture> textures;
+        textures.reserve(payload->resources.material_textures.size());
+        for (const TextureRef& texture : payload->resources.material_textures) {
+            textures.emplace_back(
+                ReadTexture{texture->GetView(0, texture->GetNumMips()), ETextureState::SAMPLE}
+            );
+        }
+        cmd_list.TextureBarriers(
+            EQueueType::Graphics, EQueueType::Graphics, EPassType::Compute, std::move(textures)
+        );
+    }
+}
+
+void PrepareLightPass::RecordDispatch(CommandList& cmd_list, SharedPtr<const RecordPayload> payload) {
+    if (payload->dispatch_light_count == 0) {
+        return;
+    }
     cmd_list
         .Compute(
             prepare_light_pipeline,
-            params,
-            rt_ctx.light_data_buf->GetView(),
-            rt_ctx.light_mapping_buf->GetView(),
-            rt_ctx.local_light_pdf_tex->GetView(),
-            rt_ctx.prim_light_buf->GetView(),
-            rt_ctx.task_buf->GetView(),
-            bindless_array
+            payload->params,
+            payload->resources.light_data_buf->GetView(),
+            payload->resources.light_mapping_buf->GetView(),
+            payload->resources.local_light_pdf_tex->GetView(),
+            payload->resources.prim_light_buf->GetView(),
+            payload->resources.task_buf->GetView(),
+            payload->resources.bindless_array
         )
-        .Dispatch(uint3((light_buffer_offset + 255) / 256, 1, 1), "PrepareLights");
+        .Dispatch(uint3((payload->dispatch_light_count + 255) / 256, 1, 1), "PrepareLights");
+    cmd_list.AddCallback([payload(std::move(payload))]() {});
+}
 
-    rt_ctx.sd_utils.GenerateMips(cmd_list, rt_ctx.local_light_pdf_mips);
+void PrepareLightPass::RecordGenerateMips(
+    CommandList&                   cmd_list,
+    SharedPtr<const RecordPayload> payload,
+    MipDispatch                    dispatch
+) {
+    std::span<TextureView> mips(
+        const_cast<TextureView*>(payload->resources.local_light_pdf_mips.data()) + dispatch.source_mip,
+        dispatch.bound_mip_count
+    );
+    payload->resources.shader_utils->GenerateMipsChunk(cmd_list, mips);
+    cmd_list.AddCallback([payload(std::move(payload))]() {});
+}
 
-    cmd_list.AddCallback([primitive_to_light(std::move(primitive_to_light)),
-                          primitive_light_infos(std::move(primitive_light_infos)),
-                          tasks(std::move(tasks))]() {});
-
+void PrepareLightPass::Process(CommandList& cmd_list, const PreparedCommand& command) {
+    const auto payload = command.record;
+    cmd_list.PushScopeWithTimeScope("PrepareLights");
+    RecordUploads(cmd_list, payload);
+    RecordClears(cmd_list, payload);
+    RecordSceneInputTransitions(cmd_list, payload);
+    RecordDispatch(cmd_list, payload);
+    for (const MipDispatch dispatch : payload->mip_dispatches) {
+        RecordGenerateMips(cmd_list, payload, dispatch);
+    }
     cmd_list.PopScopeWithTimeScope();
-    b_odd_frame = !b_odd_frame;
+}
+
+void PrepareLightPass::RecordLightingInputTransitions(CommandList& cmd_list, const PreparedCommand& command) {
+    const auto payload = command.record;
+    cmd_list.Barriers(
+        EQueueType::Graphics,
+        EQueueType::Graphics,
+        EPassType::Compute,
+        ReadBuffer{payload->resources.primitive_to_light_buf->GetView(), EBufferState::SHADER_RESOURCE},
+        ReadBuffer{payload->resources.light_mapping_buf->GetView(), EBufferState::SHADER_RESOURCE},
+        ReadBuffer{payload->resources.light_data_buf->GetView(), EBufferState::SHADER_RESOURCE},
+        ReadTexture{
+            payload->resources.local_light_pdf_tex->GetView(
+                0, payload->resources.local_light_pdf_tex->GetNumMips()
+            ),
+            ETextureState::SAMPLE
+        }
+    );
+}
+
+void PrepareLightPass::RecordAcceptedBoundary(CommandList& cmd_list, const PreparedCommand& command) {
+    const auto payload = command.record;
+
+    Array<ReadBuffer> buffers;
+    buffers.reserve(5);
+    for (const BufferRef& buffer : {
+             payload->resources.primitive_to_light_buf,
+             payload->resources.task_buf,
+             payload->resources.prim_light_buf,
+             payload->resources.light_mapping_buf,
+             payload->resources.light_data_buf,
+         }) {
+        buffers.emplace_back(ReadBuffer{buffer->GetView(), EBufferState::SHADER_RESOURCE});
+    }
+    cmd_list.BufferBarriers(
+        EQueueType::Graphics,
+        EQueueType::Graphics,
+        EPassType::Compute,
+        std::move(buffers),
+        Array<WriteBuffer>{}
+    );
+
+    cmd_list.TextureBarriers(
+        EQueueType::Graphics,
+        EQueueType::Graphics,
+        EPassType::Compute,
+        Array<ReadTexture>{ReadTexture{
+            payload->resources.local_light_pdf_tex->GetView(
+                0, payload->resources.local_light_pdf_tex->GetNumMips()
+            ),
+            ETextureState::SHADER_RESOURCE
+        }}
+    );
+}
+
+bool PrepareLightPass::AddPasses(RenderGraph& graph, const PreparedCommand& command) {
+    const auto payload = command.record;
+    if (!payload || !payload->resources.primitive_to_light_buf || !payload->resources.task_buf ||
+        !payload->resources.prim_light_buf || !payload->resources.light_mapping_buf ||
+        !payload->resources.light_data_buf || !payload->resources.local_light_pdf_tex ||
+        !payload->resources.bindless_array || !payload->resources.shader_utils) {
+        return false;
+    }
+    if (payload->reads_scene_geometry &&
+        (!payload->resources.primitive_buf || !payload->resources.instance_buf ||
+         !payload->resources.material_buf || !payload->resources.position_buf ||
+         !payload->resources.index_buf)) {
+        return false;
+    }
+
+    const auto primitive_to_light = ImportRTGraphBuffer(
+        graph, "RT.PrepareLights.primitive_to_light", payload->resources.primitive_to_light_buf
+    );
+    const auto tasks = ImportRTGraphBuffer(graph, "RT.PrepareLights.tasks", payload->resources.task_buf);
+    const auto primitive_lights =
+        ImportRTGraphBuffer(graph, "RT.PrepareLights.primitive_lights", payload->resources.prim_light_buf);
+    const auto light_mapping =
+        ImportRTGraphBuffer(graph, "RT.PrepareLights.light_mapping", payload->resources.light_mapping_buf);
+    const auto light_data =
+        ImportRTGraphBuffer(graph, "RT.PrepareLights.light_data", payload->resources.light_data_buf);
+    const auto local_light_pdf = ImportRTGraphTexture(
+        graph, "RT.PrepareLights.local_light_pdf", payload->resources.local_light_pdf_tex
+    );
+    const auto bindless =
+        graph.ImportToken("RT.PrepareLights.bindless", payload->resources.bindless_array.Get());
+
+    RenderGraph::BufferHandle         primitive_buf{};
+    RenderGraph::BufferHandle         instance_buf{};
+    RenderGraph::BufferHandle         material_buf{};
+    RenderGraph::BufferHandle         position_buf{};
+    RenderGraph::BufferHandle         index_buf{};
+    RenderGraph::BufferHandle         texcoord0_buf{};
+    Array<RenderGraph::TextureHandle> material_textures;
+    if (payload->reads_scene_geometry) {
+        primitive_buf =
+            ImportRTGraphBuffer(graph, "RT.PrepareLights.scene_primitives", payload->resources.primitive_buf);
+        instance_buf =
+            ImportRTGraphBuffer(graph, "RT.PrepareLights.scene_instances", payload->resources.instance_buf);
+        material_buf =
+            ImportRTGraphBuffer(graph, "RT.PrepareLights.scene_materials", payload->resources.material_buf);
+        position_buf =
+            ImportRTGraphBuffer(graph, "RT.PrepareLights.scene_positions", payload->resources.position_buf);
+        index_buf =
+            ImportRTGraphBuffer(graph, "RT.PrepareLights.scene_indices", payload->resources.index_buf);
+        if (payload->resources.texcoord0_buf) {
+            texcoord0_buf = ImportRTGraphBuffer(
+                graph, "RT.PrepareLights.scene_texcoords", payload->resources.texcoord0_buf
+            );
+        }
+        material_textures.reserve(payload->resources.material_textures.size());
+        for (size_t index = 0; index < payload->resources.material_textures.size(); ++index) {
+            material_textures.emplace_back(ImportRTGraphTexture(
+                graph,
+                std::format("RT.PrepareLights.material_texture.{}", index),
+                payload->resources.material_textures[index]
+            ));
+        }
+    }
+
+    const auto initial_persistent_buffer = [&](RenderGraph::BufferHandle buffer, bool initialized) {
+        graph.SetInitialState(
+            buffer,
+            initialized ? RenderGraph::BufferState::ShaderResource : RenderGraph::BufferState::Undefined,
+            initialized ? RenderGraph::QueueRole::Graphics : RenderGraph::QueueRole::None,
+            initialized ? RenderGraph::AccessMode::Read : RenderGraph::AccessMode::None
+        );
+    };
+    initial_persistent_buffer(primitive_to_light, payload->primitive_to_light_initialized);
+    initial_persistent_buffer(tasks, payload->tasks_initialized);
+    initial_persistent_buffer(primitive_lights, payload->primitive_lights_initialized);
+    initial_persistent_buffer(light_mapping, payload->light_mapping_initialized);
+    initial_persistent_buffer(light_data, payload->light_data_initialized);
+    graph.SetInitialState(
+        local_light_pdf,
+        payload->local_light_pdf_initialized ? RenderGraph::TextureState::ShaderResource :
+                                               RenderGraph::TextureState::Undefined,
+        payload->local_light_pdf_initialized ? RenderGraph::QueueRole::Graphics :
+                                               RenderGraph::QueueRole::None,
+        payload->local_light_pdf_initialized ? RenderGraph::AccessMode::Read : RenderGraph::AccessMode::None
+    );
+
+    const auto initial_scene_buffer = [&](RenderGraph::BufferHandle buffer) {
+        graph.SetInitialState(
+            buffer,
+            RenderGraph::BufferState::ShaderResource,
+            RenderGraph::QueueRole::Graphics,
+            RenderGraph::AccessMode::Read
+        );
+        graph.Export(
+            buffer,
+            RenderGraph::BufferState::ShaderResource,
+            RenderGraph::QueueRole::Graphics,
+            RenderGraph::AccessMode::Read
+        );
+    };
+    if (payload->reads_scene_geometry) {
+        for (const auto buffer : {
+                 primitive_buf,
+                 instance_buf,
+                 material_buf,
+                 position_buf,
+                 index_buf,
+             }) {
+            initial_scene_buffer(buffer);
+        }
+        if (texcoord0_buf.IsValid()) {
+            initial_scene_buffer(texcoord0_buf);
+        }
+        for (size_t index = 0; index < material_textures.size(); ++index) {
+            const RenderGraph::TextureHandle texture = material_textures[index];
+            const RenderGraph::TextureState  read_state =
+                PreferredReadState(payload->resources.material_textures[index]);
+            graph.SetInitialState(
+                texture, read_state, RenderGraph::QueueRole::Graphics, RenderGraph::AccessMode::Read
+            );
+            graph.Export(
+                texture, read_state, RenderGraph::QueueRole::Graphics, RenderGraph::AccessMode::Read
+            );
+        }
+    }
+
+    graph.AddRecordPass(
+        "RT.PrepareLights.UploadInputs",
+        [=](RenderGraph::PassBuilder& builder) {
+            builder.ExecuteOn(RenderGraph::QueueRole::Graphics, RenderGraph::PipelineType::Copy);
+            if (!payload->primitive_to_light.empty()) {
+                builder.Write(primitive_to_light, RenderGraph::BufferState::TransferDestination);
+            }
+            if (!payload->tasks.empty() || !payload->tasks_initialized) {
+                builder.Write(tasks, RenderGraph::BufferState::TransferDestination);
+            }
+            if (!payload->primitive_light_infos.empty() || !payload->primitive_lights_initialized) {
+                builder.Write(primitive_lights, RenderGraph::BufferState::TransferDestination);
+            }
+        },
+        [this, payload](CommandList& cmd_list) {
+            ScopedGpuMarker marker(cmd_list, "Pass: RT Prepare Lights Upload", GpuMarkerPalette::Transfer());
+            RecordUploads(cmd_list, payload);
+        },
+        RenderGraph::PassExecutionClass::ParallelRecordEligible
+    );
+
+    graph.AddRecordPass(
+        "RT.PrepareLights.ClearOutputs",
+        [=](RenderGraph::PassBuilder& builder) {
+            builder.ExecuteOn(RenderGraph::QueueRole::Graphics, RenderGraph::PipelineType::Copy)
+                .Write(light_mapping, RenderGraph::BufferState::TransferDestination)
+                .Write(local_light_pdf, RenderGraph::TextureState::TransferDestination);
+            if (payload->reset_light_history) {
+                builder.Write(light_data, RenderGraph::BufferState::TransferDestination);
+            }
+        },
+        [this, payload](CommandList& cmd_list) {
+            ScopedGpuMarker marker(cmd_list, "Pass: RT Prepare Lights Clear", GpuMarkerPalette::Transfer());
+            RecordClears(cmd_list, payload);
+        },
+        RenderGraph::PassExecutionClass::ParallelRecordEligible
+    );
+
+    if (payload->dispatch_light_count != 0) {
+        graph.AddRecordPass(
+            "RT.PrepareLights.Dispatch",
+            [=](RenderGraph::PassBuilder& builder) {
+                builder.ExecuteOn(RenderGraph::QueueRole::Graphics, RenderGraph::PipelineType::Compute)
+                    .Read(tasks, RenderGraph::BufferState::ShaderResource)
+                    .ReadWrite(light_data, RenderGraph::BufferState::UnorderedAccess)
+                    .ReadWrite(light_mapping, RenderGraph::BufferState::UnorderedAccess)
+                    .ReadWrite(
+                        local_light_pdf,
+                        RenderGraph::TextureState::UnorderedAccess,
+                        RenderGraph::TextureRange::Mips(0, 1)
+                    );
+                if (!payload->primitive_light_infos.empty()) {
+                    builder.Read(primitive_lights, RenderGraph::BufferState::ShaderResource);
+                }
+                if (payload->reads_scene_geometry) {
+                    builder.Read(primitive_buf, RenderGraph::BufferState::ShaderResource)
+                        .Read(instance_buf, RenderGraph::BufferState::ShaderResource)
+                        .Read(material_buf, RenderGraph::BufferState::ShaderResource)
+                        .Read(position_buf, RenderGraph::BufferState::ShaderResource)
+                        .Read(index_buf, RenderGraph::BufferState::ShaderResource)
+                        .Read(bindless);
+                    if (texcoord0_buf.IsValid()) {
+                        builder.Read(texcoord0_buf, RenderGraph::BufferState::ShaderResource);
+                    }
+                    for (const auto texture : material_textures) {
+                        builder.Read(texture, RenderGraph::TextureState::Sampled);
+                    }
+                }
+            },
+            [this, payload](CommandList& cmd_list) {
+                ScopedGpuMarker marker(
+                    cmd_list, "Pass: RT Prepare Lights Dispatch", GpuMarkerPalette::Subpass()
+                );
+                RecordDispatch(cmd_list, payload);
+            },
+            RenderGraph::PassExecutionClass::ParallelRecordEligible
+        );
+    }
+
+    for (const MipDispatch dispatch : payload->mip_dispatches) {
+        graph.AddRecordPass(
+            std::format("RT.PrepareLights.GenerateMips.{}", dispatch.source_mip),
+            [=](RenderGraph::PassBuilder& builder) {
+                builder.ExecuteOn(RenderGraph::QueueRole::Graphics, RenderGraph::PipelineType::Compute)
+                    .Read(
+                        local_light_pdf,
+                        RenderGraph::TextureState::UnorderedAccess,
+                        RenderGraph::TextureRange::Mips(dispatch.source_mip, 1)
+                    )
+                    .Write(
+                        local_light_pdf,
+                        RenderGraph::TextureState::UnorderedAccess,
+                        RenderGraph::TextureRange::Mips(dispatch.source_mip + 1, dispatch.bound_mip_count - 1)
+                    );
+            },
+            [this, payload, dispatch](CommandList& cmd_list) {
+                ScopedGpuMarker marker(
+                    cmd_list, "Pass: RT Prepare Lights Generate Mips", GpuMarkerPalette::Subpass()
+                );
+                RecordGenerateMips(cmd_list, payload, dispatch);
+            },
+            RenderGraph::PassExecutionClass::ParallelRecordEligible
+        );
+    }
+
+    graph.Export(
+        tasks,
+        RenderGraph::BufferState::ShaderResource,
+        RenderGraph::QueueRole::Graphics,
+        RenderGraph::AccessMode::Read
+    );
+    graph.Export(
+        primitive_lights,
+        RenderGraph::BufferState::ShaderResource,
+        RenderGraph::QueueRole::Graphics,
+        RenderGraph::AccessMode::Read
+    );
+    return true;
+}
+
+void PrepareLightPass::CommitAcceptedFrame(RTContext& rt_ctx, PreparedCommand&& command) noexcept {
+    instance_light_buffer_offsets.swap(command.next_instance_light_buffer_offsets);
+    primitive_light_buffer_offsets.swap(command.next_primitive_light_buffer_offsets);
+    b_odd_frame                          = command.next_odd_frame;
+    accepted_primitive_to_light_identity = command.next_primitive_to_light_identity;
+    accepted_tasks_identity              = command.next_tasks_identity;
+    accepted_primitive_lights_identity   = command.next_primitive_lights_identity;
+    accepted_light_mapping_identity      = command.next_light_mapping_identity;
+    accepted_light_data_identity         = command.next_light_data_identity;
+    accepted_local_light_pdf_identity    = command.next_local_light_pdf_identity;
+    accepted_scene_revision              = command.next_scene_revision;
+    rt_ctx.is_ctx.CommitAcceptedLightBufferParams(command.record->light_buffer_params);
 }
 
 } // namespace Moer::Render::Raytracing

--- a/source/runtime/render/renderer/raytracing/PreprocessLightPass.cpp
+++ b/source/runtime/render/renderer/raytracing/PreprocessLightPass.cpp
@@ -544,12 +544,17 @@ void PrepareLightPass::RecordAcceptedBoundary(CommandList& cmd_list, const Prepa
     );
 }
 
-bool PrepareLightPass::AddPasses(RenderGraph& graph, const PreparedCommand& command) {
+bool PrepareLightPass::AddPasses(
+    RenderGraph&             graph,
+    const PreparedCommand&   command,
+    RenderGraph::TokenHandle frame_setup_ready
+) {
     const auto payload = command.record;
     if (!payload || !payload->resources.primitive_to_light_buf || !payload->resources.task_buf ||
         !payload->resources.prim_light_buf || !payload->resources.light_mapping_buf ||
         !payload->resources.light_data_buf || !payload->resources.local_light_pdf_tex ||
-        !payload->resources.bindless_array || !payload->resources.shader_utils) {
+        !payload->resources.bindless_array || !payload->resources.shader_utils ||
+        !frame_setup_ready.IsValid()) {
         return false;
     }
     if (payload->reads_scene_geometry &&
@@ -572,9 +577,6 @@ bool PrepareLightPass::AddPasses(RenderGraph& graph, const PreparedCommand& comm
     const auto local_light_pdf = ImportRTGraphTexture(
         graph, "RT.PrepareLights.local_light_pdf", payload->resources.local_light_pdf_tex
     );
-    const auto bindless =
-        graph.ImportToken("RT.PrepareLights.bindless", payload->resources.bindless_array.Get());
-
     RenderGraph::BufferHandle         primitive_buf{};
     RenderGraph::BufferHandle         instance_buf{};
     RenderGraph::BufferHandle         material_buf{};
@@ -673,7 +675,8 @@ bool PrepareLightPass::AddPasses(RenderGraph& graph, const PreparedCommand& comm
     graph.AddRecordPass(
         "RT.PrepareLights.UploadInputs",
         [=](RenderGraph::PassBuilder& builder) {
-            builder.ExecuteOn(RenderGraph::QueueRole::Graphics, RenderGraph::PipelineType::Copy);
+            builder.ExecuteOn(RenderGraph::QueueRole::Graphics, RenderGraph::PipelineType::Copy)
+                .Read(frame_setup_ready);
             if (!payload->primitive_to_light.empty()) {
                 builder.Write(primitive_to_light, RenderGraph::BufferState::TransferDestination);
             }
@@ -695,6 +698,7 @@ bool PrepareLightPass::AddPasses(RenderGraph& graph, const PreparedCommand& comm
         "RT.PrepareLights.ClearOutputs",
         [=](RenderGraph::PassBuilder& builder) {
             builder.ExecuteOn(RenderGraph::QueueRole::Graphics, RenderGraph::PipelineType::Copy)
+                .Read(frame_setup_ready)
                 .Write(light_mapping, RenderGraph::BufferState::TransferDestination)
                 .Write(local_light_pdf, RenderGraph::TextureState::TransferDestination);
             if (payload->reset_light_history) {
@@ -713,6 +717,7 @@ bool PrepareLightPass::AddPasses(RenderGraph& graph, const PreparedCommand& comm
             "RT.PrepareLights.Dispatch",
             [=](RenderGraph::PassBuilder& builder) {
                 builder.ExecuteOn(RenderGraph::QueueRole::Graphics, RenderGraph::PipelineType::Compute)
+                    .Read(frame_setup_ready)
                     .Read(tasks, RenderGraph::BufferState::ShaderResource)
                     .ReadWrite(light_data, RenderGraph::BufferState::UnorderedAccess)
                     .ReadWrite(light_mapping, RenderGraph::BufferState::UnorderedAccess)
@@ -729,8 +734,7 @@ bool PrepareLightPass::AddPasses(RenderGraph& graph, const PreparedCommand& comm
                         .Read(instance_buf, RenderGraph::BufferState::ShaderResource)
                         .Read(material_buf, RenderGraph::BufferState::ShaderResource)
                         .Read(position_buf, RenderGraph::BufferState::ShaderResource)
-                        .Read(index_buf, RenderGraph::BufferState::ShaderResource)
-                        .Read(bindless);
+                        .Read(index_buf, RenderGraph::BufferState::ShaderResource);
                     if (texcoord0_buf.IsValid()) {
                         builder.Read(texcoord0_buf, RenderGraph::BufferState::ShaderResource);
                     }
@@ -753,8 +757,9 @@ bool PrepareLightPass::AddPasses(RenderGraph& graph, const PreparedCommand& comm
         graph.AddRecordPass(
             std::format("RT.PrepareLights.GenerateMips.{}", dispatch.source_mip),
             [=](RenderGraph::PassBuilder& builder) {
-                builder.ExecuteOn(RenderGraph::QueueRole::Graphics, RenderGraph::PipelineType::Compute)
-                    .Read(
+                    builder.ExecuteOn(RenderGraph::QueueRole::Graphics, RenderGraph::PipelineType::Compute)
+                        .Read(frame_setup_ready)
+                        .Read(
                         local_light_pdf,
                         RenderGraph::TextureState::UnorderedAccess,
                         RenderGraph::TextureRange::Mips(dispatch.source_mip, 1)

--- a/source/runtime/render/renderer/raytracing/PreprocessLightPass.h
+++ b/source/runtime/render/renderer/raytracing/PreprocessLightPass.h
@@ -114,7 +114,11 @@ public:
     void Process(class CommandList& cmd_list, const PreparedCommand& command);
     void RecordLightingInputTransitions(CommandList& cmd_list, const PreparedCommand& command);
     void RecordAcceptedBoundary(CommandList& cmd_list, const PreparedCommand& command);
-    bool AddPasses(RenderGraph& graph, const PreparedCommand& command);
+    bool AddPasses(
+        RenderGraph&             graph,
+        const PreparedCommand&   command,
+        RenderGraph::TokenHandle frame_setup_ready
+    );
     void CommitAcceptedFrame(RTContext& rt_ctx, PreparedCommand&& command) noexcept;
 
 private:

--- a/source/runtime/render/renderer/raytracing/PreprocessLightPass.h
+++ b/source/runtime/render/renderer/raytracing/PreprocessLightPass.h
@@ -2,6 +2,7 @@
 #define MOER_PREPARE_LIGHTS_PASS_H
 
 #include "RTResource.h"
+#include "RaytracingGraphTypes.h"
 #include "RaytracingSceneFrameSnapshot.h"
 #include "misc/STL.h"
 #include "misc/Traits.h"
@@ -115,9 +116,9 @@ public:
     void RecordLightingInputTransitions(CommandList& cmd_list, const PreparedCommand& command);
     void RecordAcceptedBoundary(CommandList& cmd_list, const PreparedCommand& command);
     bool AddPasses(
-        RenderGraph&             graph,
-        const PreparedCommand&   command,
-        RenderGraph::TokenHandle frame_setup_ready
+        RenderGraph&                       graph,
+        const PreparedCommand&             command,
+        const RTGraphFrameSetupResources& frame_setup
     );
     void CommitAcceptedFrame(RTContext& rt_ctx, PreparedCommand&& command) noexcept;
 

--- a/source/runtime/render/renderer/raytracing/PreprocessLightPass.h
+++ b/source/runtime/render/renderer/raytracing/PreprocessLightPass.h
@@ -5,6 +5,7 @@
 #include "RaytracingSceneFrameSnapshot.h"
 #include "misc/STL.h"
 #include "misc/Traits.h"
+#include "rendergraph/RenderGraph.h"
 #include "rhi/RHIResource.h"
 #include "shader/ShaderPipeline.h"
 #include "shaderheaders/shared/lighting/ShaderParameters.h"
@@ -26,18 +27,116 @@ public:
 };
 class PrepareLightPass {
 public:
+    struct EmissiveLightHistory {
+        uint light_offset       = 0;
+        uint num_triangles      = 0;
+        uint index_start_idx    = 0;
+        uint first_instance_idx = 0;
+    };
+
+    struct RecordResources {
+        BufferRef primitive_to_light_buf;
+        BufferRef task_buf;
+        BufferRef prim_light_buf;
+        BufferRef light_mapping_buf;
+        BufferRef light_data_buf;
+
+        BufferRef primitive_buf;
+        BufferRef instance_buf;
+        BufferRef material_buf;
+        BufferRef position_buf;
+        BufferRef index_buf;
+        BufferRef texcoord0_buf;
+
+        TextureRef         local_light_pdf_tex;
+        Array<TextureView> local_light_pdf_mips;
+        Array<TextureRef>  material_textures;
+        BindlessArrayRef   bindless_array;
+        ShaderUtils*       shader_utils = nullptr;
+    };
+
+    struct MipDispatch {
+        uint source_mip      = 0;
+        uint bound_mip_count = 0;
+    };
+
+    struct RecordPayload {
+        Array<uint>                 primitive_to_light;
+        Array<PrepareLightsTask>    tasks;
+        Array<PolymorphicLightInfo> primitive_light_infos;
+        PrepareLightsParams         params{};
+        DI::LightBufferParams       light_buffer_params{};
+        uint                        dispatch_light_count           = 0;
+        bool                        reads_scene_geometry           = false;
+        bool                        reset_light_history            = false;
+        bool                        primitive_to_light_initialized = false;
+        bool                        tasks_initialized              = false;
+        bool                        primitive_lights_initialized   = false;
+        bool                        light_mapping_initialized      = false;
+        bool                        light_data_initialized         = false;
+        bool                        local_light_pdf_initialized    = false;
+        Array<MipDispatch>          mip_dispatches;
+        RecordResources             resources{};
+    };
+
+    struct PreparedCommand {
+        PreparedCommand()                                  = default;
+        PreparedCommand(const PreparedCommand&)            = delete;
+        PreparedCommand& operator=(const PreparedCommand&) = delete;
+        PreparedCommand(PreparedCommand&&)                 = default;
+        PreparedCommand& operator=(PreparedCommand&&)      = default;
+
+        const DI::LightBufferParams& GetLightBufferParams() const {
+            return record->light_buffer_params;
+        }
+
+        bool ReadsSceneGeometry() const {
+            return record && record->reads_scene_geometry;
+        }
+
+        SharedPtr<const RecordPayload> record{};
+
+        UnorderedMap<uint64, EmissiveLightHistory> next_instance_light_buffer_offsets;
+        UnorderedMap<uint64, uint>                 next_primitive_light_buffer_offsets;
+        bool                                       next_odd_frame                   = false;
+        const Buffer*                              next_primitive_to_light_identity = nullptr;
+        const Buffer*                              next_tasks_identity              = nullptr;
+        const Buffer*                              next_primitive_lights_identity   = nullptr;
+        const Buffer*                              next_light_mapping_identity      = nullptr;
+        const Buffer*                              next_light_data_identity         = nullptr;
+        const Texture*                             next_local_light_pdf_identity    = nullptr;
+        uint64                                     next_scene_revision              = 0;
+    };
+
     PrepareLightPass(class ShaderManager& manager, BindlessArrayRef bindless_array);
-    void Process(
-        class CommandList&                  cmd_list,
-        RTContext&                          rt_ctx,
-        const RaytracingSceneFrameSnapshot& scene_snapshot
-    );
+    PreparedCommand
+    Prepare(RTContext& rt_ctx, const RaytracingSceneFrameSnapshot& scene_snapshot, uint64 scene_revision);
+    void Process(class CommandList& cmd_list, const PreparedCommand& command);
+    void RecordLightingInputTransitions(CommandList& cmd_list, const PreparedCommand& command);
+    void RecordAcceptedBoundary(CommandList& cmd_list, const PreparedCommand& command);
+    bool AddPasses(RenderGraph& graph, const PreparedCommand& command);
+    void CommitAcceptedFrame(RTContext& rt_ctx, PreparedCommand&& command) noexcept;
 
 private:
+    RecordResources CaptureResources(const RTContext& rt_ctx) const;
+    void            RecordUploads(CommandList& cmd_list, SharedPtr<const RecordPayload> payload);
+    void            RecordClears(CommandList& cmd_list, SharedPtr<const RecordPayload> payload);
+    void RecordSceneInputTransitions(CommandList& cmd_list, SharedPtr<const RecordPayload> payload);
+    void RecordDispatch(CommandList& cmd_list, SharedPtr<const RecordPayload> payload);
+    void
+    RecordGenerateMips(CommandList& cmd_list, SharedPtr<const RecordPayload> payload, MipDispatch dispatch);
+
     BindlessArrayRef bindless_array;
 
-    UnorderedMap<uint64, uint> instance_light_buffer_offsets;
-    UnorderedMap<uint64, uint> primitive_light_buffer_offsets;
+    UnorderedMap<uint64, EmissiveLightHistory> instance_light_buffer_offsets;
+    UnorderedMap<uint64, uint>                 primitive_light_buffer_offsets;
+    const Buffer*                              accepted_primitive_to_light_identity = nullptr;
+    const Buffer*                              accepted_tasks_identity              = nullptr;
+    const Buffer*                              accepted_primitive_lights_identity   = nullptr;
+    const Buffer*                              accepted_light_mapping_identity      = nullptr;
+    const Buffer*                              accepted_light_data_identity         = nullptr;
+    const Texture*                             accepted_local_light_pdf_identity    = nullptr;
+    uint64                                     accepted_scene_revision              = ~uint64{0};
 
     PrepareLightShaderPipeline prepare_light_pipeline;
 

--- a/source/runtime/render/renderer/raytracing/RTResource.cpp
+++ b/source/runtime/render/renderer/raytracing/RTResource.cpp
@@ -58,6 +58,26 @@ void RTContext::SetBindlessHandles(const GpuScene::Res& gpu_scene_res) {
     // RT 专用（mesh-level BLAS 方案）
     bindless_handles.rt_instance_buf_hdl        = gpu_scene_res.rt_instance_buf.hdl;
     bindless_handles.rt_primitive_table_buf_hdl = gpu_scene_res.rt_primitive_table_buf.hdl;
+
+    bindless_resources.light_buf              = gpu_scene_res.light_buf.buf;
+    bindless_resources.material_buf           = gpu_scene_res.material_buf.buf;
+    bindless_resources.primitive_buf          = gpu_scene_res.primitive_buf.buf;
+    bindless_resources.instance_buf           = gpu_scene_res.instance_buf.buf;
+    bindless_resources.position_buf           = gpu_scene_res.position_buf.buf;
+    bindless_resources.packed_normal_buf      = gpu_scene_res.packed_normal_buf.buf;
+    bindless_resources.packed_tangent_buf     = gpu_scene_res.packed_tangent_buf.buf;
+    bindless_resources.texcoord0_buf          = gpu_scene_res.texcoord0_buf.buf;
+    bindless_resources.index_buf              = gpu_scene_res.index_buf.buf;
+    bindless_resources.rt_instance_buf        = gpu_scene_res.rt_instance_buf.buf;
+    bindless_resources.rt_primitive_table_buf = gpu_scene_res.rt_primitive_table_buf.buf;
+
+    bindless_resources.material_textures.clear();
+    bindless_resources.material_textures.reserve(gpu_scene_res.texture_array.size());
+    for (const TextureWithHandle& texture : gpu_scene_res.texture_array) {
+        if (texture.tex) {
+            bindless_resources.material_textures.emplace_back(texture.tex);
+        }
+    }
 }
 
 void RTContext::FillFrameResources(uint2 _resolution) {
@@ -285,7 +305,7 @@ void RTContext::FillLowDiscrepancySequence(CommandList& _cmd_list) {
 
 void RTContext::CreateEnvMapResources(TextureWithHandle _env_tex, CommandList& _cmd_list) {
 
-    env_map = _env_tex.tex;
+    env_map              = _env_tex.tex;
     uint2         extent = env_map->GetExtent().xy;
     RenderDevice& device = RenderDevice::Get();
 
@@ -325,7 +345,7 @@ void RTContext::CreateBuffersIfNeeded(
 ) {
 
     RenderDevice& device   = RenderDevice::Get();
-    uint          task_num = _num_emissive_meshes + _num_prim_lights;
+    uint          task_num = Max(1u, _num_emissive_meshes + _num_prim_lights);
 
     if (!task_buf || task_num > task_buf->GetNumElement()) {
         task_buf = device.CreateBuffer<PrepareLightsTask>(
@@ -337,12 +357,11 @@ void RTContext::CreateBuffersIfNeeded(
     max_emissive_meshes    = _num_emissive_meshes;
     max_emissive_triangles = _num_emissive_triangles;
 
-    uint max_local_lights  = max_emissive_triangles + max_prim_lights;
+    uint max_local_lights  = Max(1u, max_emissive_triangles + max_prim_lights);
     uint light_buf_element = max_local_lights * 2;
-    // light_buf_element 必须大于 0（即使没有光源，也需要至少 1 个元素用于双缓冲）
-    assert(light_buf_element > 0 && "light_buf_element must be greater than 0");
 
-    if (!light_mapping_buf || light_buf_element > light_data_buf->GetNumElement()) {
+    if (!light_mapping_buf || !light_data_buf || light_buf_element > light_mapping_buf->GetNumElement() ||
+        light_buf_element > light_data_buf->GetNumElement()) {
         light_mapping_buf = device.CreateBuffer<uint>(
             "Raytracing::light_mapping_buf", light_buf_element, EBufferUsageFlags::UNORDERED_ACCESS
         );
@@ -362,12 +381,10 @@ void RTContext::CreateBuffersIfNeeded(
         );
     }
 
-    // 创建 primitive_to_light buffer（primitive_id -> light_offset 映射）
-    // _max_primitives 必须大于 0（场景必须至少有一个 primitive）
-    assert(_max_primitives > 0 && "_max_primitives must be greater than 0");
-    if (!primitive_to_light_buf || _max_primitives > primitive_to_light_buf->GetNumElement()) {
+    const uint primitive_capacity = Max(1u, _max_primitives);
+    if (!primitive_to_light_buf || primitive_capacity > primitive_to_light_buf->GetNumElement()) {
         primitive_to_light_buf = device.CreateBuffer<uint>(
-            "Raytracing::primitive_to_light_buf", _max_primitives, EBufferUsageFlags::UNORDERED_ACCESS
+            "Raytracing::primitive_to_light_buf", primitive_capacity, EBufferUsageFlags::UNORDERED_ACCESS
         );
         AllocateAndFreeBdlsIfNeeded(bindless_handles.primitive_to_light, primitive_to_light_buf->GetView());
     }

--- a/source/runtime/render/renderer/raytracing/RTResource.h
+++ b/source/runtime/render/renderer/raytracing/RTResource.h
@@ -24,8 +24,7 @@ namespace Moer::Render::Raytracing {
 
 inline constexpr bool IsNrdDenoiserActive(uint denoiser_mode) {
 #if WITH_NRD
-    return denoiser_mode == s_denoiser_mode_reblur ||
-           denoiser_mode == s_denoiser_mode_relax;
+    return denoiser_mode == s_denoiser_mode_reblur || denoiser_mode == s_denoiser_mode_relax;
 #else
     (void)denoiser_mode;
     return false;
@@ -71,6 +70,22 @@ struct DefaultResources {
     TextureRef white_tex;
 };
 
+struct RaytracingBindlessResources {
+    BufferRef light_buf;
+    BufferRef material_buf;
+    BufferRef primitive_buf;
+    BufferRef instance_buf;
+    BufferRef position_buf;
+    BufferRef packed_normal_buf;
+    BufferRef packed_tangent_buf;
+    BufferRef texcoord0_buf;
+    BufferRef index_buf;
+    BufferRef rt_instance_buf;
+    BufferRef rt_primitive_table_buf;
+
+    Array<TextureRef> material_textures;
+};
+
 struct RTContext {
 
     struct Config {
@@ -114,6 +129,10 @@ public:
 
     const RaytracingBindlessHandles& GetBindlessHandles() const {
         return bindless_handles;
+    }
+
+    const RaytracingBindlessResources& GetBindlessResources() const {
+        return bindless_resources;
     }
 
     void LoadDefaultResources(RuntimeAssets& _rt_res);
@@ -177,8 +196,9 @@ public:
     bool               b_current_frame = true;
 
 private:
-    RaytracingBindlessHandles bindless_handles{};
-    BindlessArrayRef          bdls;
+    RaytracingBindlessHandles   bindless_handles{};
+    RaytracingBindlessResources bindless_resources{};
+    BindlessArrayRef            bdls;
 };
 } // namespace Moer::Render::Raytracing
 

--- a/source/runtime/render/renderer/raytracing/RaytracingExportSubmission.h
+++ b/source/runtime/render/renderer/raytracing/RaytracingExportSubmission.h
@@ -9,9 +9,39 @@
 
 namespace Moer::Render::Raytracing {
 
+enum class EExportSubmissionOutcome : uint8 {
+    NotSubmitted,
+    Accepted,
+    Rejected,
+    Failed,
+};
+
+struct ExportFrameSubmissionDecision {
+    EExportSubmissionOutcome source_outcome{
+        EExportSubmissionOutcome::NotSubmitted
+    };
+    EExportSubmissionOutcome readback_outcome{
+        EExportSubmissionOutcome::NotSubmitted
+    };
+    EExportSubmissionOutcome tail_outcome{
+        EExportSubmissionOutcome::NotSubmitted
+    };
+    bool source_accepted{true};
+    bool tail_accepted{false};
+    bool readback_attempted{false};
+    bool readback_accepted{false};
+    bool encoder_dispatched{false};
+    bool export_consumed{false};
+    bool retry_requested{false};
+    bool frame_accepted{false};
+    bool independent_source_failed{false};
+    bool retryable_frame_rejection{false};
+    bool latch_renderer{false};
+};
+
 // Couples a backend-facing raw CmdSubmit fence identity with Completion-owned
-// strong references and provides the one acceptance rule shared by export
-// sources and their dependent frame tails.
+// strong references. The same production transaction owns render-prefix,
+// readback, encoder-dispatch, dependent-tail, retry and latch decisions.
 class ExportSubmissionTransaction final {
 public:
     ExportSubmissionTransaction() = default;
@@ -36,6 +66,10 @@ public:
         }
         receipt = std::move(_receipt);
         value   = _value;
+        readback_receipt    = FenceRef{};
+        readback_value     = 0;
+        readback_outcome   = EExportSubmissionOutcome::NotSubmitted;
+        encoder_dispatched = false;
     }
 
     [[nodiscard]] bool IsActive() const noexcept {
@@ -52,26 +86,23 @@ public:
 
     void AttachSignal(CmdSubmit& _submit) const {
         RequireActive();
-
-        std::function<void()> keepalive = [fence = receipt] {};
-        _submit.callbacks.reserve(_submit.callbacks.size() + 1);
-        _submit.signal_events.reserve(_submit.signal_events.size() + 1);
-        _submit.callbacks.emplace_back(std::move(keepalive));
-        _submit.Signal(receipt.Get(), value);
+        AttachReceiptSignal(_submit, receipt, value);
     }
 
     void AttachDependentWait(CmdSubmit& _submit) const {
         RequireActive();
-
-        std::function<void()> keepalive = [fence = receipt] {};
-        _submit.callbacks.reserve(_submit.callbacks.size() + 1);
-        _submit.wait_events.reserve(_submit.wait_events.size() + 1);
-        _submit.callbacks.emplace_back(std::move(keepalive));
-        _submit.Wait(receipt.Get(), value);
+        AttachReceiptWait(_submit, receipt, value);
     }
 
     [[nodiscard]] bool SourceAccepted() const {
-        return !IsActive() || receipt->WaitSubmitted(value);
+        return !IsActive() ||
+               SourceOutcome() == EExportSubmissionOutcome::Accepted;
+    }
+
+    [[nodiscard]] EExportSubmissionOutcome SourceOutcome() const {
+        return IsActive() ?
+                   ResolveReceiptOutcome(receipt.Get(), value) :
+                   EExportSubmissionOutcome::NotSubmitted;
     }
 
     [[nodiscard]] bool FoldAcceptance(bool _dependent_accepted) const {
@@ -79,7 +110,180 @@ public:
         return source_accepted && _dependent_accepted;
     }
 
+    void BeginReadback(FenceRef _receipt, uint64 _value = 1) {
+        RequireActive();
+        if (readback_receipt.IsValid()) {
+            throw std::logic_error(
+                "ExportSubmissionTransaction readback is already active"
+            );
+        }
+        if (!_receipt.IsValid() || _value == 0) {
+            throw std::invalid_argument(
+                "ExportSubmissionTransaction requires a valid readback receipt and non-zero value"
+            );
+        }
+        readback_receipt = std::move(_receipt);
+        readback_value   = _value;
+    }
+
+    void AttachReadbackSignal(CmdSubmit& _submit) const {
+        RequireReadbackActive();
+        AttachReceiptSignal(_submit, readback_receipt, readback_value);
+    }
+
+    [[nodiscard]] bool ResolveReadbackAcceptance() {
+        RequireReadbackActive();
+        if (readback_outcome == EExportSubmissionOutcome::NotSubmitted) {
+            readback_outcome = ResolveReceiptOutcome(
+                readback_receipt.Get(),
+                readback_value
+            );
+        }
+        return readback_outcome == EExportSubmissionOutcome::Accepted;
+    }
+
+    template <typename EncoderDispatch>
+    [[nodiscard]] bool DispatchEncoder(EncoderDispatch&& _dispatch) {
+        if (!ResolveReadbackAcceptance() || encoder_dispatched) {
+            return false;
+        }
+        std::invoke(std::forward<EncoderDispatch>(_dispatch));
+        encoder_dispatched = true;
+        return true;
+    }
+
+    [[nodiscard]] Fence* GetReadbackReceiptFence() const noexcept {
+        return readback_receipt.Get();
+    }
+
+    [[nodiscard]] uint64 GetReadbackReceiptValue() const noexcept {
+        return readback_value;
+    }
+
+    [[nodiscard]] EExportSubmissionOutcome ReadbackOutcome() const noexcept {
+        return readback_outcome;
+    }
+
+    [[nodiscard]] static EExportSubmissionOutcome ResolveReceiptOutcome(
+        Fence* _receipt,
+        uint64 _value
+    ) {
+        if (_receipt == nullptr || _value == 0) {
+            return EExportSubmissionOutcome::Failed;
+        }
+        if (_receipt->WaitSubmitted(_value)) {
+            return EExportSubmissionOutcome::Accepted;
+        }
+        // Every recoverable pre-native rejection must terminalize the exact
+        // value through Fence::Reject(). A false wait without that marker is
+        // therefore a fence/backend/device hard failure.
+        return _receipt->IsRejected(_value) ?
+                   EExportSubmissionOutcome::Rejected :
+                   EExportSubmissionOutcome::Failed;
+    }
+
+    [[nodiscard]] ExportFrameSubmissionDecision ClassifyFrameAcceptance(
+        EExportSubmissionOutcome _tail_outcome,
+        bool _dependent_sources_accepted,
+        bool _independent_source_failed
+    ) const {
+        return ResolveFrameDecision(
+            IsActive(),
+            SourceOutcome(),
+            readback_outcome,
+            _tail_outcome,
+            encoder_dispatched,
+            _dependent_sources_accepted,
+            _independent_source_failed
+        );
+    }
+
+    [[nodiscard]] static ExportFrameSubmissionDecision ResolveFrameDecision(
+        bool _export_active,
+        EExportSubmissionOutcome _source_outcome,
+        EExportSubmissionOutcome _readback_outcome,
+        EExportSubmissionOutcome _tail_outcome,
+        bool _encoder_dispatched,
+        bool _dependent_sources_accepted,
+        bool _independent_source_failed
+    ) {
+        ExportFrameSubmissionDecision decision{};
+        decision.source_outcome =
+            _source_outcome;
+        decision.readback_outcome =
+            _readback_outcome;
+        decision.tail_outcome =
+            _tail_outcome;
+        decision.source_accepted =
+            !_export_active ||
+            decision.source_outcome ==
+                EExportSubmissionOutcome::Accepted;
+        decision.tail_accepted =
+            decision.tail_outcome ==
+            EExportSubmissionOutcome::Accepted;
+        decision.readback_attempted =
+            decision.readback_outcome !=
+            EExportSubmissionOutcome::NotSubmitted;
+        decision.readback_accepted =
+            decision.readback_outcome ==
+            EExportSubmissionOutcome::Accepted;
+        decision.encoder_dispatched =
+            _encoder_dispatched;
+        decision.export_consumed =
+            decision.encoder_dispatched &&
+            decision.readback_accepted;
+        decision.retry_requested =
+            _export_active && !decision.export_consumed;
+        decision.independent_source_failed =
+            _independent_source_failed ||
+            decision.readback_outcome ==
+                EExportSubmissionOutcome::Failed ||
+            (decision.encoder_dispatched &&
+             !decision.readback_accepted);
+        decision.frame_accepted =
+            decision.source_accepted &&
+            decision.tail_accepted &&
+            _dependent_sources_accepted &&
+            !decision.independent_source_failed;
+        decision.retryable_frame_rejection =
+            _export_active &&
+            decision.source_outcome ==
+                EExportSubmissionOutcome::Rejected &&
+            decision.tail_outcome ==
+                EExportSubmissionOutcome::Rejected &&
+            !decision.independent_source_failed;
+        decision.latch_renderer =
+            decision.independent_source_failed ||
+            (!decision.frame_accepted &&
+             !decision.retryable_frame_rejection);
+        return decision;
+    }
+
 private:
+    static void AttachReceiptSignal(
+        CmdSubmit&      _submit,
+        const FenceRef& _receipt,
+        uint64          _value
+    ) {
+        std::function<void()> keepalive = [fence = _receipt] {};
+        _submit.callbacks.reserve(_submit.callbacks.size() + 1);
+        _submit.signal_events.reserve(_submit.signal_events.size() + 1);
+        _submit.callbacks.emplace_back(std::move(keepalive));
+        _submit.Signal(_receipt.Get(), _value);
+    }
+
+    static void AttachReceiptWait(
+        CmdSubmit&      _submit,
+        const FenceRef& _receipt,
+        uint64          _value
+    ) {
+        std::function<void()> keepalive = [fence = _receipt] {};
+        _submit.callbacks.reserve(_submit.callbacks.size() + 1);
+        _submit.wait_events.reserve(_submit.wait_events.size() + 1);
+        _submit.callbacks.emplace_back(std::move(keepalive));
+        _submit.Wait(_receipt.Get(), _value);
+    }
+
     void RequireActive() const {
         if (!IsActive()) {
             throw std::logic_error(
@@ -88,8 +292,22 @@ private:
         }
     }
 
+    void RequireReadbackActive() const {
+        if (!readback_receipt.IsValid()) {
+            throw std::logic_error(
+                "ExportSubmissionTransaction has no active readback receipt"
+            );
+        }
+    }
+
     FenceRef receipt{};
     uint64   value{0};
+    FenceRef readback_receipt{};
+    uint64   readback_value{0};
+    EExportSubmissionOutcome readback_outcome{
+        EExportSubmissionOutcome::NotSubmitted
+    };
+    bool     encoder_dispatched{false};
 };
 
 } // namespace Moer::Render::Raytracing

--- a/source/runtime/render/renderer/raytracing/RaytracingExportSubmission.h
+++ b/source/runtime/render/renderer/raytracing/RaytracingExportSubmission.h
@@ -1,0 +1,95 @@
+#pragma once
+
+#include "rhi/RHICommand.h"
+#include "rhi/RHIResource.h"
+
+#include <functional>
+#include <stdexcept>
+#include <utility>
+
+namespace Moer::Render::Raytracing {
+
+// Couples a backend-facing raw CmdSubmit fence identity with Completion-owned
+// strong references and provides the one acceptance rule shared by export
+// sources and their dependent frame tails.
+class ExportSubmissionTransaction final {
+public:
+    ExportSubmissionTransaction() = default;
+
+    explicit ExportSubmissionTransaction(
+        FenceRef _receipt,
+        uint64   _value = 1
+    ) {
+        Reset(std::move(_receipt), _value);
+    }
+
+    ExportSubmissionTransaction(const ExportSubmissionTransaction&) = delete;
+    ExportSubmissionTransaction& operator=(const ExportSubmissionTransaction&) = delete;
+    ExportSubmissionTransaction(ExportSubmissionTransaction&&) noexcept = default;
+    ExportSubmissionTransaction& operator=(ExportSubmissionTransaction&&) noexcept = default;
+
+    void Reset(FenceRef _receipt, uint64 _value = 1) {
+        if (!_receipt.IsValid() || _value == 0) {
+            throw std::invalid_argument(
+                "ExportSubmissionTransaction requires a valid receipt and non-zero value"
+            );
+        }
+        receipt = std::move(_receipt);
+        value   = _value;
+    }
+
+    [[nodiscard]] bool IsActive() const noexcept {
+        return receipt.IsValid();
+    }
+
+    [[nodiscard]] Fence* GetReceiptFence() const noexcept {
+        return receipt.Get();
+    }
+
+    [[nodiscard]] uint64 GetReceiptValue() const noexcept {
+        return value;
+    }
+
+    void AttachSignal(CmdSubmit& _submit) const {
+        RequireActive();
+
+        std::function<void()> keepalive = [fence = receipt] {};
+        _submit.callbacks.reserve(_submit.callbacks.size() + 1);
+        _submit.signal_events.reserve(_submit.signal_events.size() + 1);
+        _submit.callbacks.emplace_back(std::move(keepalive));
+        _submit.Signal(receipt.Get(), value);
+    }
+
+    void AttachDependentWait(CmdSubmit& _submit) const {
+        RequireActive();
+
+        std::function<void()> keepalive = [fence = receipt] {};
+        _submit.callbacks.reserve(_submit.callbacks.size() + 1);
+        _submit.wait_events.reserve(_submit.wait_events.size() + 1);
+        _submit.callbacks.emplace_back(std::move(keepalive));
+        _submit.Wait(receipt.Get(), value);
+    }
+
+    [[nodiscard]] bool SourceAccepted() const {
+        return !IsActive() || receipt->WaitSubmitted(value);
+    }
+
+    [[nodiscard]] bool FoldAcceptance(bool _dependent_accepted) const {
+        const bool source_accepted = SourceAccepted();
+        return source_accepted && _dependent_accepted;
+    }
+
+private:
+    void RequireActive() const {
+        if (!IsActive()) {
+            throw std::logic_error(
+                "ExportSubmissionTransaction has no active receipt"
+            );
+        }
+    }
+
+    FenceRef receipt{};
+    uint64   value{0};
+};
+
+} // namespace Moer::Render::Raytracing

--- a/source/runtime/render/renderer/raytracing/RaytracingFrameSetupPass.cpp
+++ b/source/runtime/render/renderer/raytracing/RaytracingFrameSetupPass.cpp
@@ -2,6 +2,7 @@
 
 #include "rhi/RHIImpl.h"
 
+#include <algorithm>
 #include <cassert>
 #include <format>
 #include <stdexcept>
@@ -78,7 +79,7 @@ RaytracingFrameSetupPass::PreparedCommand RaytracingFrameSetupPass::Prepare(
     BindlessArrayRef   bindless_array,
     uint64             target_revision,
     bool               build_tlas,
-    bool               scene_inputs_updated,
+    bool               scene_resources_refreshed,
     bool               external_tlas_built
 ) {
     auto payload = MakeShared<RecordPayload>();
@@ -86,32 +87,14 @@ RaytracingFrameSetupPass::PreparedCommand RaytracingFrameSetupPass::Prepare(
     payload->scene                = std::move(scene);
     payload->target_revision      = target_revision;
     payload->build_tlas           = build_tlas;
-    payload->scene_inputs_updated = scene_inputs_updated;
+    payload->scene_resources_refreshed = scene_resources_refreshed;
     payload->external_tlas_built  = external_tlas_built;
 
     if (!payload->bindless_array || !payload->scene) {
         return PreparedCommand{.record = std::move(payload)};
     }
 
-    const RaytracingBindlessResources& scene_resources = rt_ctx.GetBindlessResources();
-    for (const BufferRef& buffer : {
-             scene_resources.light_buf,
-             scene_resources.material_buf,
-             scene_resources.primitive_buf,
-             scene_resources.instance_buf,
-             scene_resources.position_buf,
-             scene_resources.packed_normal_buf,
-             scene_resources.packed_tangent_buf,
-             scene_resources.texcoord0_buf,
-             scene_resources.index_buf,
-             scene_resources.rt_instance_buf,
-             scene_resources.rt_primitive_table_buf,
-         }) {
-        AppendUnique(payload->scene_buffers, buffer);
-    }
-    for (const TextureRef& texture : scene_resources.material_textures) {
-        AppendUnique(payload->scene_textures, texture);
-    }
+    payload->scene_resources = rt_ctx.GetBindlessResources();
 
     if (build_tlas) {
         for (uint index = 0; index < payload->scene->GetInstanceCount(); ++index) {
@@ -175,9 +158,11 @@ RaytracingFrameSetupPass::PreparedCommand RaytracingFrameSetupPass::Prepare(
 }
 
 bool RaytracingFrameSetupPass::AddPasses(
-    RenderGraph&           graph,
-    const PreparedCommand& command
+    RenderGraph&                graph,
+    const PreparedCommand&      command,
+    RTGraphFrameSetupResources& graph_resources
 ) const {
+    graph_resources = {};
     const SharedPtr<RecordPayload> payload = command.record;
     if (!command || !payload->previous_tlas || !payload->previous_tlas_buffer) {
         return false;
@@ -191,9 +176,21 @@ bool RaytracingFrameSetupPass::AddPasses(
         !accepted_instance_buffers.contains(payload->instance_buffer.Get())) {
         return false;
     }
-    if (!payload->scene_inputs_updated) {
-        for (const BufferRef& buffer : payload->scene_buffers) {
-            if (!accepted_scene_buffers.contains(buffer.Get())) {
+    if (!payload->scene_resources_refreshed) {
+        for (const BufferRef& buffer : {
+                 payload->scene_resources.light_buf,
+                 payload->scene_resources.material_buf,
+                 payload->scene_resources.primitive_buf,
+                 payload->scene_resources.instance_buf,
+                 payload->scene_resources.position_buf,
+                 payload->scene_resources.packed_normal_buf,
+                 payload->scene_resources.packed_tangent_buf,
+                 payload->scene_resources.texcoord0_buf,
+                 payload->scene_resources.index_buf,
+                 payload->scene_resources.rt_instance_buf,
+                 payload->scene_resources.rt_primitive_table_buf,
+             }) {
+            if (buffer && !accepted_scene_buffers.contains(buffer.Get())) {
                 return false;
             }
         }
@@ -202,57 +199,179 @@ bool RaytracingFrameSetupPass::AddPasses(
         !accepted_tlas_buffers.contains(payload->destination_tlas_buffer.Get())) {
         return false;
     }
-
-    const auto bindless =
-        graph.ImportToken("RT.FrameSetup.bindless", payload->bindless_array.Get());
-    const auto current_tlas =
-        ImportBuffer(graph, "RT.FrameSetup.current_tlas", payload->destination_tlas_buffer);
-
-    Array<RenderGraph::BufferHandle> scene_buffers;
-    scene_buffers.reserve(payload->scene_buffers.size());
-    for (size_t index = 0; index < payload->scene_buffers.size(); ++index) {
-        const BufferRef& buffer = payload->scene_buffers[index];
-        const auto handle = ImportBuffer(
-            graph,
-            std::format("RT.FrameSetup.scene_buffer.{}", index),
-            buffer
-        );
-        graph.SetInitialState(
-            handle,
-            payload->scene_inputs_updated ?
-                RenderGraph::BufferState::UnorderedAccess :
-                RenderGraph::BufferState::ShaderResource,
-            RenderGraph::QueueRole::Graphics,
-            payload->scene_inputs_updated ?
-                RenderGraph::AccessMode::ReadWrite :
-                RenderGraph::AccessMode::Read
-        );
-        scene_buffers.emplace_back(handle);
+    if (payload->previous_tlas_buffer.Get() !=
+            payload->destination_tlas_buffer.Get() &&
+        !accepted_tlas_buffers.contains(payload->previous_tlas_buffer.Get())) {
+        return false;
     }
 
-    Array<RenderGraph::TextureHandle> scene_textures;
-    scene_textures.reserve(payload->scene_textures.size());
-    for (size_t index = 0; index < payload->scene_textures.size(); ++index) {
-        const TextureRef& texture = payload->scene_textures[index];
-        const auto handle = ImportTexture(
+    graph_resources.bindless =
+        graph.ImportToken("RT.FrameSetup.bindless", payload->bindless_array.Get());
+    graph_resources.ready =
+        graph.CreateTransientToken("RT.FrameSetup.ready");
+    graph_resources.current_tlas =
+        ImportBuffer(graph, "RT.FrameSetup.current_tlas", payload->destination_tlas_buffer);
+    graph_resources.previous_tlas = graph_resources.current_tlas;
+    if (payload->previous_tlas_buffer.Get() !=
+        payload->destination_tlas_buffer.Get()) {
+        graph_resources.previous_tlas = ImportBuffer(
             graph,
-            std::format("RT.FrameSetup.scene_texture.{}", index),
-            texture
+            "RT.FrameSetup.previous_tlas",
+            payload->previous_tlas_buffer
         );
         graph.SetInitialState(
-            handle,
-            PreferredReadState(texture),
+            graph_resources.previous_tlas,
+            RenderGraph::BufferState::AccelerationStructureRead,
             RenderGraph::QueueRole::Graphics,
             RenderGraph::AccessMode::Read
         );
-        scene_textures.emplace_back(handle);
     }
 
-    const auto update_bindless = graph.AddRecordPass(
+    const bool current_tlas_accepted =
+        accepted_tlas_buffers.contains(payload->destination_tlas_buffer.Get());
+    graph.SetInitialState(
+        graph_resources.current_tlas,
+        payload->external_tlas_built ?
+            RenderGraph::BufferState::AccelerationStructureWrite :
+            (current_tlas_accepted ?
+                 RenderGraph::BufferState::AccelerationStructureRead :
+                 RenderGraph::BufferState::Undefined),
+        payload->external_tlas_built || current_tlas_accepted ?
+            RenderGraph::QueueRole::Graphics :
+            RenderGraph::QueueRole::None,
+        payload->external_tlas_built ?
+            RenderGraph::AccessMode::Write :
+            (current_tlas_accepted ?
+                 RenderGraph::AccessMode::Read :
+                 RenderGraph::AccessMode::None)
+    );
+
+    Array<RenderGraph::BufferHandle> unique_scene_buffers;
+    const auto import_scene_buffer =
+        [&](std::string_view name, const BufferRef& buffer) {
+            if (!buffer) {
+                return RenderGraph::BufferHandle{};
+            }
+            const auto handle = ImportBuffer(graph, name, buffer);
+            const bool first_import = std::find(
+                                          unique_scene_buffers.begin(),
+                                          unique_scene_buffers.end(),
+                                          handle
+                                      ) == unique_scene_buffers.end();
+            if (first_import) {
+                graph.SetInitialState(
+                    handle,
+                    RenderGraph::BufferState::ShaderResource,
+                    RenderGraph::QueueRole::Graphics,
+                    RenderGraph::AccessMode::Read
+                );
+                unique_scene_buffers.emplace_back(handle);
+            }
+            return handle;
+        };
+    graph_resources.scene.light_resource = payload->scene_resources.light_buf;
+    graph_resources.scene.light = import_scene_buffer(
+        "RT.FrameSetup.scene.light",
+        payload->scene_resources.light_buf
+    );
+    graph_resources.scene.material_resource = payload->scene_resources.material_buf;
+    graph_resources.scene.material = import_scene_buffer(
+        "RT.FrameSetup.scene.material",
+        payload->scene_resources.material_buf
+    );
+    graph_resources.scene.primitive_resource = payload->scene_resources.primitive_buf;
+    graph_resources.scene.primitive = import_scene_buffer(
+        "RT.FrameSetup.scene.primitive",
+        payload->scene_resources.primitive_buf
+    );
+    graph_resources.scene.instance_resource = payload->scene_resources.instance_buf;
+    graph_resources.scene.instance = import_scene_buffer(
+        "RT.FrameSetup.scene.instance",
+        payload->scene_resources.instance_buf
+    );
+    graph_resources.scene.position_resource = payload->scene_resources.position_buf;
+    graph_resources.scene.position = import_scene_buffer(
+        "RT.FrameSetup.scene.position",
+        payload->scene_resources.position_buf
+    );
+    graph_resources.scene.packed_normal_resource = payload->scene_resources.packed_normal_buf;
+    graph_resources.scene.packed_normal = import_scene_buffer(
+        "RT.FrameSetup.scene.packed_normal",
+        payload->scene_resources.packed_normal_buf
+    );
+    graph_resources.scene.packed_tangent_resource = payload->scene_resources.packed_tangent_buf;
+    graph_resources.scene.packed_tangent = import_scene_buffer(
+        "RT.FrameSetup.scene.packed_tangent",
+        payload->scene_resources.packed_tangent_buf
+    );
+    graph_resources.scene.texcoord0_resource = payload->scene_resources.texcoord0_buf;
+    graph_resources.scene.texcoord0 = import_scene_buffer(
+        "RT.FrameSetup.scene.texcoord0",
+        payload->scene_resources.texcoord0_buf
+    );
+    graph_resources.scene.index_resource = payload->scene_resources.index_buf;
+    graph_resources.scene.index = import_scene_buffer(
+        "RT.FrameSetup.scene.index",
+        payload->scene_resources.index_buf
+    );
+    graph_resources.scene.rt_instance_resource = payload->scene_resources.rt_instance_buf;
+    graph_resources.scene.rt_instance = import_scene_buffer(
+        "RT.FrameSetup.scene.rt_instance",
+        payload->scene_resources.rt_instance_buf
+    );
+    graph_resources.scene.rt_primitive_table_resource =
+        payload->scene_resources.rt_primitive_table_buf;
+    graph_resources.scene.rt_primitive_table = import_scene_buffer(
+        "RT.FrameSetup.scene.rt_primitive_table",
+        payload->scene_resources.rt_primitive_table_buf
+    );
+
+    Array<RenderGraph::TextureHandle> unique_scene_textures;
+    Array<RenderGraph::TextureState>  unique_scene_texture_states;
+    graph_resources.scene.material_textures.reserve(
+        payload->scene_resources.material_textures.size()
+    );
+    graph_resources.scene.material_texture_resources =
+        payload->scene_resources.material_textures;
+    for (size_t index = 0;
+         index < payload->scene_resources.material_textures.size();
+         ++index) {
+        const TextureRef& texture =
+            payload->scene_resources.material_textures[index];
+        if (!texture) {
+            graph_resources.scene.material_textures.emplace_back();
+            continue;
+        }
+        const auto handle = ImportTexture(
+            graph,
+            std::format("RT.FrameSetup.scene.material_texture.{}", index),
+            texture
+        );
+        graph_resources.scene.material_textures.emplace_back(handle);
+        const bool first_import = std::find(
+                                      unique_scene_textures.begin(),
+                                      unique_scene_textures.end(),
+                                      handle
+                                  ) == unique_scene_textures.end();
+        if (first_import) {
+            graph.SetInitialState(
+                handle,
+                PreferredReadState(texture),
+                RenderGraph::QueueRole::Graphics,
+                RenderGraph::AccessMode::Read
+            );
+            unique_scene_textures.emplace_back(handle);
+            unique_scene_texture_states.emplace_back(
+                PreferredReadState(texture)
+            );
+        }
+    }
+
+    graph_resources.update_bindless = graph.AddRecordPass(
         "RT.FrameSetup.UpdateBindless",
         [=](RenderGraph::PassBuilder& builder) {
             builder.ExecuteOn(RenderGraph::QueueRole::Graphics, RenderGraph::PipelineType::Compute)
-                .Write(bindless)
+                .Write(graph_resources.bindless)
                 .SideEffect();
         },
         [payload](CommandList& cmd_list) {
@@ -266,20 +385,22 @@ bool RaytracingFrameSetupPass::AddPasses(
         RenderGraph::PassExecutionClass::SerialRecord
     );
 
-    const auto normalize_scene = graph.AddRecordPass(
+    graph_resources.normalize_scene = graph.AddRecordPass(
         "RT.FrameSetup.NormalizeSceneBindings",
         [=](RenderGraph::PassBuilder& builder) {
             builder.ExecuteOn(RenderGraph::QueueRole::Graphics, RenderGraph::PipelineType::Compute)
-                .DependsOn(update_bindless)
-                .Read(bindless)
+                .DependsOn(graph_resources.update_bindless)
+                .Read(graph_resources.bindless)
                 .SideEffect();
-            for (const auto buffer : scene_buffers) {
+            for (const auto buffer : unique_scene_buffers) {
                 builder.Read(buffer, RenderGraph::BufferState::ShaderResource);
             }
-            for (size_t index = 0; index < scene_textures.size(); ++index) {
+            for (size_t index = 0;
+                 index < unique_scene_textures.size();
+                 ++index) {
                 builder.Read(
-                    scene_textures[index],
-                    PreferredReadState(payload->scene_textures[index])
+                    unique_scene_textures[index],
+                    unique_scene_texture_states[index]
                 );
             }
         },
@@ -287,8 +408,8 @@ bool RaytracingFrameSetupPass::AddPasses(
         RenderGraph::PassExecutionClass::SerialRecord
     );
 
-    graph.Export(bindless);
-    for (const auto buffer : scene_buffers) {
+    graph.Export(graph_resources.bindless);
+    for (const auto buffer : unique_scene_buffers) {
         graph.Export(
             buffer,
             RenderGraph::BufferState::ShaderResource,
@@ -296,200 +417,198 @@ bool RaytracingFrameSetupPass::AddPasses(
             RenderGraph::AccessMode::Read
         );
     }
-    for (size_t index = 0; index < scene_textures.size(); ++index) {
+    for (size_t index = 0;
+         index < unique_scene_textures.size();
+         ++index) {
         graph.Export(
-            scene_textures[index],
-            PreferredReadState(payload->scene_textures[index]),
+            unique_scene_textures[index],
+            unique_scene_texture_states[index],
             RenderGraph::QueueRole::Graphics,
             RenderGraph::AccessMode::Read
         );
     }
 
-    if (!payload->build_tlas) {
+    RenderGraph::BufferHandle instance_buffer{};
+    RenderGraph::BufferHandle scratch_buffer{};
+    Array<RenderGraph::BufferHandle> geometry_buffers;
+    if (payload->build_tlas) {
+        instance_buffer =
+            ImportBuffer(graph, "RT.FrameSetup.tlas_instances", payload->instance_buffer);
+        scratch_buffer =
+            ImportBuffer(graph, "RT.FrameSetup.tlas_scratch", payload->scratch_buffer);
+        const bool instance_initialized =
+            accepted_instance_buffers.contains(payload->instance_buffer.Get());
         graph.SetInitialState(
-            current_tlas,
-            payload->external_tlas_built ?
-                RenderGraph::BufferState::AccelerationStructureWrite :
-                RenderGraph::BufferState::AccelerationStructureRead,
-            RenderGraph::QueueRole::Graphics,
-            payload->external_tlas_built ?
-                RenderGraph::AccessMode::Write :
-                RenderGraph::AccessMode::Read
+            instance_buffer,
+            instance_initialized ?
+                RenderGraph::BufferState::AccelerationStructureBuildInput :
+                RenderGraph::BufferState::Undefined,
+            instance_initialized ? RenderGraph::QueueRole::Graphics :
+                                   RenderGraph::QueueRole::None,
+            instance_initialized ? RenderGraph::AccessMode::Read :
+                                   RenderGraph::AccessMode::None
         );
-        graph.AddRecordPass(
-            "RT.FrameSetup.NormalizeTLAS",
+        const bool scratch_initialized =
+            accepted_scratch_buffers.contains(payload->scratch_buffer.Get());
+        graph.SetInitialState(
+            scratch_buffer,
+            scratch_initialized ?
+                RenderGraph::BufferState::AccelerationStructureWrite :
+                RenderGraph::BufferState::Undefined,
+            scratch_initialized ? RenderGraph::QueueRole::Graphics :
+                                  RenderGraph::QueueRole::None,
+            scratch_initialized ? RenderGraph::AccessMode::Write :
+                                  RenderGraph::AccessMode::None
+        );
+
+        geometry_buffers.reserve(payload->geometry_buffers.size());
+        for (size_t index = 0; index < payload->geometry_buffers.size(); ++index) {
+            const auto geometry = ImportBuffer(
+                graph,
+                std::format("RT.FrameSetup.geometry.{}", index),
+                payload->geometry_buffers[index]
+            );
+            graph.SetInitialState(
+                geometry,
+                RenderGraph::BufferState::AccelerationStructureRead,
+                RenderGraph::QueueRole::Graphics,
+                RenderGraph::AccessMode::Read
+            );
+            geometry_buffers.emplace_back(geometry);
+        }
+
+        graph_resources.build_tlas = graph.AddRecordPass(
+            "RT.FrameSetup.BuildTLAS",
             [=](RenderGraph::PassBuilder& builder) {
-                builder.ExecuteOn(
-                           RenderGraph::QueueRole::Graphics,
-                           RenderGraph::PipelineType::Compute
-                       )
-                    .DependsOn(normalize_scene)
-                    .Read(
-                        current_tlas,
-                        RenderGraph::BufferState::AccelerationStructureRead
+                auto& setup_builder =
+                    builder.ExecuteOn(
+                               RenderGraph::QueueRole::Graphics,
+                               RenderGraph::PipelineType::Compute
+                           )
+                    .DependsOn(graph_resources.normalize_scene)
+                    .Read(graph_resources.bindless);
+                if (payload->full_instance_upload) {
+                    setup_builder.Write(
+                        instance_buffer,
+                        RenderGraph::BufferState::UnorderedAccess
+                    );
+                } else {
+                    setup_builder.ReadWrite(
+                        instance_buffer,
+                        RenderGraph::BufferState::UnorderedAccess
+                    );
+                }
+                setup_builder
+                    .Write(
+                        scratch_buffer,
+                        RenderGraph::BufferState::AccelerationStructureWrite
                     )
-                    .SideEffect();
+                    .Write(
+                        graph_resources.current_tlas,
+                        RenderGraph::BufferState::AccelerationStructureWrite
+                    );
+                for (const auto geometry : geometry_buffers) {
+                    builder.Read(
+                        geometry,
+                        RenderGraph::BufferState::AccelerationStructureBuildInput
+                    );
+                }
             },
-            [](CommandList&) {},
+            [payload](CommandList& cmd_list) {
+                bool expected = false;
+                if (!payload->build_tlas_recorded.compare_exchange_strong(expected, true)) {
+                    throw std::logic_error(
+                        "RT FrameSetup BuildTLAS command was recorded more than once"
+                    );
+                }
+                ScopedGpuMarker marker(
+                    cmd_list,
+                    "Pass: Scene Acceleration Structure",
+                    GpuMarkerPalette::Pass()
+                );
+                cmd_list.PushScopeWithTimeScope("RTScene RendererTLAS");
+                cmd_list.UpdateRaytracingScene(
+                    std::move(payload->build_tlas_command)
+                );
+                cmd_list.PopScopeWithTimeScope();
+            },
             RenderGraph::PassExecutionClass::SerialRecord
         );
-        graph.Export(
-            current_tlas,
-            RenderGraph::BufferState::AccelerationStructureRead,
-            RenderGraph::QueueRole::Graphics,
-            RenderGraph::AccessMode::Read
-        );
-        return true;
     }
 
-    graph.SetInitialState(
-        current_tlas,
-        payload->external_tlas_built ?
-            RenderGraph::BufferState::AccelerationStructureWrite :
-            (accepted_tlas_buffers.contains(payload->destination_tlas_buffer.Get()) ?
-                 RenderGraph::BufferState::AccelerationStructureRead :
-                 RenderGraph::BufferState::Undefined),
-        payload->external_tlas_built ||
-                accepted_tlas_buffers.contains(payload->destination_tlas_buffer.Get()) ?
-            RenderGraph::QueueRole::Graphics :
-            RenderGraph::QueueRole::None,
-        payload->external_tlas_built ?
-            RenderGraph::AccessMode::Write :
-            (accepted_tlas_buffers.contains(payload->destination_tlas_buffer.Get()) ?
-                 RenderGraph::AccessMode::Read :
-                 RenderGraph::AccessMode::None)
-    );
-    const auto instance_buffer =
-        ImportBuffer(graph, "RT.FrameSetup.tlas_instances", payload->instance_buffer);
-    const auto scratch_buffer =
-        ImportBuffer(graph, "RT.FrameSetup.tlas_scratch", payload->scratch_buffer);
-    const bool instance_initialized =
-        accepted_instance_buffers.contains(payload->instance_buffer.Get());
-    graph.SetInitialState(
-        instance_buffer,
-        instance_initialized ?
-            RenderGraph::BufferState::AccelerationStructureBuildInput :
-            RenderGraph::BufferState::Undefined,
-        instance_initialized ? RenderGraph::QueueRole::Graphics :
-                               RenderGraph::QueueRole::None,
-        instance_initialized ? RenderGraph::AccessMode::Read :
-                               RenderGraph::AccessMode::None
-    );
-    const bool scratch_initialized =
-        accepted_scratch_buffers.contains(payload->scratch_buffer.Get());
-    graph.SetInitialState(
-        scratch_buffer,
-        scratch_initialized ?
-            RenderGraph::BufferState::AccelerationStructureWrite :
-            RenderGraph::BufferState::Undefined,
-        scratch_initialized ? RenderGraph::QueueRole::Graphics :
-                              RenderGraph::QueueRole::None,
-        scratch_initialized ? RenderGraph::AccessMode::Write :
-                              RenderGraph::AccessMode::None
-    );
-
-    Array<RenderGraph::BufferHandle> geometry_buffers;
-    geometry_buffers.reserve(payload->geometry_buffers.size());
-    for (size_t index = 0; index < payload->geometry_buffers.size(); ++index) {
-        const auto geometry = ImportBuffer(
-            graph,
-            std::format("RT.FrameSetup.geometry.{}", index),
-            payload->geometry_buffers[index]
-        );
-        graph.SetInitialState(
-            geometry,
-            RenderGraph::BufferState::AccelerationStructureRead,
-            RenderGraph::QueueRole::Graphics,
-            RenderGraph::AccessMode::Read
-        );
-        geometry_buffers.emplace_back(geometry);
-    }
-
-    graph.AddRecordPass(
-        "RT.FrameSetup.BuildTLAS",
+    graph_resources.finalize = graph.AddRecordPass(
+        "RT.FrameSetup.Finalize",
         [=](RenderGraph::PassBuilder& builder) {
-            auto& setup_builder =
+            auto& finalize_builder =
                 builder.ExecuteOn(
                            RenderGraph::QueueRole::Graphics,
                            RenderGraph::PipelineType::Compute
                        )
-                .DependsOn(normalize_scene)
-                .Read(bindless);
-            if (payload->full_instance_upload) {
-                // Prepare marks every live instance dirty before materializing
-                // the command, so this transaction fully overwrites the
-                // instance payload before the native TLAS build consumes it.
-                // Model the pass boundary as Write; the command's internal
-                // compute->AS barrier and the graph export establish the
-                // build-input read state seen by later transactions.
-                setup_builder.Write(
-                    instance_buffer,
-                    RenderGraph::BufferState::UnorderedAccess
-                );
-            } else {
-                // Future backends may legally materialize a partial update.
-                // That path is graph-safe only after the same physical buffer
-                // has an accepted predecessor whose untouched instances remain
-                // valid.
-                setup_builder.ReadWrite(
-                    instance_buffer,
-                    RenderGraph::BufferState::UnorderedAccess
-                );
+                    .DependsOn(graph_resources.normalize_scene)
+                    .Read(graph_resources.bindless)
+                    .Read(
+                        graph_resources.current_tlas,
+                        RenderGraph::BufferState::AccelerationStructureRead
+                    )
+                    .Write(graph_resources.ready)
+                    .SideEffect();
+            if (graph_resources.build_tlas.IsValid()) {
+                finalize_builder.DependsOn(graph_resources.build_tlas);
             }
-            setup_builder
-                .Write(scratch_buffer, RenderGraph::BufferState::AccelerationStructureWrite)
-                .Write(current_tlas, RenderGraph::BufferState::AccelerationStructureWrite);
-            for (const auto geometry : geometry_buffers) {
-                builder.Read(
-                    geometry,
-                    RenderGraph::BufferState::AccelerationStructureBuildInput
+            if (graph_resources.previous_tlas !=
+                graph_resources.current_tlas) {
+                finalize_builder.Read(
+                    graph_resources.previous_tlas,
+                    RenderGraph::BufferState::AccelerationStructureRead
                 );
             }
         },
-        [payload](CommandList& cmd_list) {
-            bool expected = false;
-            if (!payload->build_tlas_recorded.compare_exchange_strong(expected, true)) {
-                throw std::logic_error("RT FrameSetup BuildTLAS command was recorded more than once");
-            }
-            ScopedGpuMarker marker(
-                cmd_list,
-                "Pass: Scene Acceleration Structure",
-                GpuMarkerPalette::Pass()
-            );
-            cmd_list.PushScopeWithTimeScope("RTScene RendererTLAS");
-            cmd_list.UpdateRaytracingScene(std::move(payload->build_tlas_command));
-            cmd_list.PopScopeWithTimeScope();
+        [payload](CommandList&) {
+            // Retain the immutable setup packet through the unified graph's
+            // transaction gate, including no-build frames.
+            (void)payload;
         },
         RenderGraph::PassExecutionClass::SerialRecord
     );
 
     graph.Export(
-        current_tlas,
+        graph_resources.current_tlas,
         RenderGraph::BufferState::AccelerationStructureRead,
         RenderGraph::QueueRole::Graphics,
         RenderGraph::AccessMode::Read
     );
-    graph.Export(
-        instance_buffer,
-        RenderGraph::BufferState::AccelerationStructureBuildInput,
-        RenderGraph::QueueRole::Graphics,
-        RenderGraph::AccessMode::Read
-    );
-    graph.Export(
-        scratch_buffer,
-        RenderGraph::BufferState::AccelerationStructureWrite,
-        RenderGraph::QueueRole::Graphics,
-        RenderGraph::AccessMode::Write
-    );
-    for (const auto geometry : geometry_buffers) {
+    if (graph_resources.previous_tlas !=
+        graph_resources.current_tlas) {
         graph.Export(
-            geometry,
+            graph_resources.previous_tlas,
             RenderGraph::BufferState::AccelerationStructureRead,
             RenderGraph::QueueRole::Graphics,
             RenderGraph::AccessMode::Read
         );
     }
-    return true;
+    if (payload->build_tlas) {
+        graph.Export(
+            instance_buffer,
+            RenderGraph::BufferState::AccelerationStructureBuildInput,
+            RenderGraph::QueueRole::Graphics,
+            RenderGraph::AccessMode::Read
+        );
+        graph.Export(
+            scratch_buffer,
+            RenderGraph::BufferState::AccelerationStructureWrite,
+            RenderGraph::QueueRole::Graphics,
+            RenderGraph::AccessMode::Write
+        );
+        for (const auto geometry : geometry_buffers) {
+            graph.Export(
+                geometry,
+                RenderGraph::BufferState::AccelerationStructureRead,
+                RenderGraph::QueueRole::Graphics,
+                RenderGraph::AccessMode::Read
+            );
+        }
+    }
+    return graph_resources.IsValid();
 }
 
 bool RaytracingFrameSetupPass::ProcessLinear(
@@ -526,16 +645,30 @@ bool RaytracingFrameSetupPass::ProcessLinear(
     return true;
 }
 
-RaytracingFrameSetupPass::AcceptedSnapshot RaytracingFrameSetupPass::CommitAccepted(
+void RaytracingFrameSetupPass::CommitAccepted(
     const PreparedCommand& command
 ) noexcept {
     const SharedPtr<RecordPayload> payload = command.record;
     if (!payload) {
-        return {};
+        return;
     }
 
-    for (const BufferRef& buffer : payload->scene_buffers) {
-        accepted_scene_buffers.emplace(buffer.Get());
+    for (const BufferRef& buffer : {
+             payload->scene_resources.light_buf,
+             payload->scene_resources.material_buf,
+             payload->scene_resources.primitive_buf,
+             payload->scene_resources.instance_buf,
+             payload->scene_resources.position_buf,
+             payload->scene_resources.packed_normal_buf,
+             payload->scene_resources.packed_tangent_buf,
+             payload->scene_resources.texcoord0_buf,
+             payload->scene_resources.index_buf,
+             payload->scene_resources.rt_instance_buf,
+             payload->scene_resources.rt_primitive_table_buf,
+         }) {
+        if (buffer) {
+            accepted_scene_buffers.emplace(buffer.Get());
+        }
     }
     if (payload->destination_tlas_buffer) {
         accepted_tlas_buffers.emplace(payload->destination_tlas_buffer.Get());
@@ -549,17 +682,6 @@ RaytracingFrameSetupPass::AcceptedSnapshot RaytracingFrameSetupPass::CommitAccep
     if (payload->scratch_buffer) {
         accepted_scratch_buffers.emplace(payload->scratch_buffer.Get());
     }
-
-    return AcceptedSnapshot{
-        .bindless_array       = payload->bindless_array,
-        .scene                = payload->scene,
-        .current_tlas         = payload->destination_tlas,
-        .previous_tlas        = payload->previous_tlas,
-        .current_tlas_buffer  = payload->destination_tlas_buffer,
-        .previous_tlas_buffer = payload->previous_tlas_buffer,
-        .tlas_revision        = payload->target_revision,
-        .tlas_built           = payload->build_tlas
-    };
 }
 
 void RaytracingFrameSetupPass::ResetAcceptedResources() noexcept {

--- a/source/runtime/render/renderer/raytracing/RaytracingFrameSetupPass.cpp
+++ b/source/runtime/render/renderer/raytracing/RaytracingFrameSetupPass.cpp
@@ -1,0 +1,572 @@
+#include "RaytracingFrameSetupPass.h"
+
+#include "rhi/RHIImpl.h"
+
+#include <cassert>
+#include <format>
+#include <stdexcept>
+
+namespace Moer::Render::Raytracing {
+
+namespace {
+
+RenderGraph::TextureState PreferredReadState(const TextureRef& texture) {
+    const auto usage = texture->GetUsage();
+    const bool supports_uav =
+        (usage & ETextureUsageFlags::UNORDERED_ACCESS) == ETextureUsageFlags::UNORDERED_ACCESS;
+    return supports_uav ? RenderGraph::TextureState::ShaderResource :
+                          RenderGraph::TextureState::Sampled;
+}
+
+template<typename RefType>
+void AppendUnique(Array<RefType>& refs, RefType ref) {
+    if (!ref) {
+        return;
+    }
+    for (const RefType& existing : refs) {
+        if (existing.Get() == ref.Get()) {
+            return;
+        }
+    }
+    refs.emplace_back(std::move(ref));
+}
+
+RenderGraph::BufferHandle ImportBuffer(
+    RenderGraph&     graph,
+    std::string_view name,
+    const BufferRef& buffer
+) {
+    return graph.ImportBuffer(
+        name,
+        buffer,
+        RenderGraph::BufferDesc{.byte_size = buffer->GetByteSize()}
+    );
+}
+
+RenderGraph::TextureHandle ImportTexture(
+    RenderGraph&      graph,
+    std::string_view  name,
+    const TextureRef& texture
+) {
+    RenderGraph::TextureAspect aspects = RenderGraph::TextureAspect::None;
+    const auto                 rhi_aspects = texture->GetAspectFlags();
+    if (uint32_t(rhi_aspects & ETextureAspectFlags::COLOR) != 0) {
+        aspects = aspects | RenderGraph::TextureAspect::Color;
+    }
+    if (uint32_t(rhi_aspects & ETextureAspectFlags::DEPTH_SLICE) != 0) {
+        aspects = aspects | RenderGraph::TextureAspect::Depth;
+    }
+    if (uint32_t(rhi_aspects & ETextureAspectFlags::STENCIL_SLICE) != 0) {
+        aspects = aspects | RenderGraph::TextureAspect::Stencil;
+    }
+    return graph.ImportTexture(
+        name,
+        texture,
+        RenderGraph::TextureDesc{
+            .mip_count   = texture->GetNumMips(),
+            .layer_count = texture->GetNumArray(),
+            .aspects     = aspects
+        }
+    );
+}
+
+} // namespace
+
+RaytracingFrameSetupPass::PreparedCommand RaytracingFrameSetupPass::Prepare(
+    const RTContext&   rt_ctx,
+    RaytracingSceneRef scene,
+    BindlessArrayRef   bindless_array,
+    uint64             target_revision,
+    bool               build_tlas,
+    bool               scene_inputs_updated,
+    bool               external_tlas_built
+) {
+    auto payload = MakeShared<RecordPayload>();
+    payload->bindless_array       = std::move(bindless_array);
+    payload->scene                = std::move(scene);
+    payload->target_revision      = target_revision;
+    payload->build_tlas           = build_tlas;
+    payload->scene_inputs_updated = scene_inputs_updated;
+    payload->external_tlas_built  = external_tlas_built;
+
+    if (!payload->bindless_array || !payload->scene) {
+        return PreparedCommand{.record = std::move(payload)};
+    }
+
+    const RaytracingBindlessResources& scene_resources = rt_ctx.GetBindlessResources();
+    for (const BufferRef& buffer : {
+             scene_resources.light_buf,
+             scene_resources.material_buf,
+             scene_resources.primitive_buf,
+             scene_resources.instance_buf,
+             scene_resources.position_buf,
+             scene_resources.packed_normal_buf,
+             scene_resources.packed_tangent_buf,
+             scene_resources.texcoord0_buf,
+             scene_resources.index_buf,
+             scene_resources.rt_instance_buf,
+             scene_resources.rt_primitive_table_buf,
+         }) {
+        AppendUnique(payload->scene_buffers, buffer);
+    }
+    for (const TextureRef& texture : scene_resources.material_textures) {
+        AppendUnique(payload->scene_textures, texture);
+    }
+
+    if (build_tlas) {
+        for (uint index = 0; index < payload->scene->GetInstanceCount(); ++index) {
+            RaytracingInstance& instance = payload->scene->GetInstance(index);
+            payload->scene->MarkModified(instance.instance_id);
+        }
+
+        payload->build_tlas_command = payload->scene->UpdateScene();
+        if (!payload->build_tlas_command ||
+            payload->build_tlas_command->Type() != Command::EType::BuildTLAS) {
+            payload->build_tlas = false;
+            // A backend may legitimately report a no-op update while keeping
+            // an already-built TLAS alive. Preserve that accepted destination
+            // instead of turning the no-op into a renderer-wide fallback.
+            payload->destination_tlas = payload->scene->GetTlas();
+            payload->destination_tlas_buffer =
+                payload->destination_tlas ?
+                    BufferRef(payload->destination_tlas->GetUnderlyingBuffer()) :
+                    BufferRef{};
+        } else {
+            const auto* update =
+                static_cast<const UpdateRaytracingSceneCmd*>(payload->build_tlas_command.get());
+            payload->full_instance_upload =
+                update->InstancesToUpdate().size() ==
+                payload->scene->GetInstanceCount();
+            assert(
+                payload->full_instance_upload &&
+                "Renderer-owned TLAS build must upload every live instance"
+            );
+            payload->destination_tlas         = update->Tlas();
+            payload->instance_buffer         = update->InstanceBuffer();
+            payload->scratch_buffer          = update->ScratchBuffer();
+            payload->geometries              = update->GeometryRefs();
+            payload->destination_tlas_buffer =
+                payload->destination_tlas ?
+                    BufferRef(payload->destination_tlas->GetUnderlyingBuffer()) :
+                    BufferRef{};
+            for (const RaytracingGeometryRef& geometry : payload->geometries) {
+                if (geometry && geometry->GetUnderlyingBuffer()) {
+                    AppendUnique(
+                        payload->geometry_buffers,
+                        BufferRef(geometry->GetUnderlyingBuffer())
+                    );
+                }
+            }
+        }
+    } else {
+        payload->destination_tlas = payload->scene->GetTlas();
+        payload->destination_tlas_buffer =
+            payload->destination_tlas ?
+                BufferRef(payload->destination_tlas->GetUnderlyingBuffer()) :
+                BufferRef{};
+    }
+
+    payload->previous_tlas = payload->scene->GetPrevTlas();
+    payload->previous_tlas_buffer =
+        payload->previous_tlas ?
+            BufferRef(payload->previous_tlas->GetUnderlyingBuffer()) :
+            BufferRef{};
+    return PreparedCommand{.record = std::move(payload)};
+}
+
+bool RaytracingFrameSetupPass::AddPasses(
+    RenderGraph&           graph,
+    const PreparedCommand& command
+) const {
+    const SharedPtr<RecordPayload> payload = command.record;
+    if (!command || !payload->previous_tlas || !payload->previous_tlas_buffer) {
+        return false;
+    }
+    if (payload->build_tlas &&
+        (!payload->build_tlas_command || !payload->instance_buffer ||
+         !payload->scratch_buffer || payload->geometry_buffers.empty())) {
+        return false;
+    }
+    if (payload->build_tlas && !payload->full_instance_upload &&
+        !accepted_instance_buffers.contains(payload->instance_buffer.Get())) {
+        return false;
+    }
+    if (!payload->scene_inputs_updated) {
+        for (const BufferRef& buffer : payload->scene_buffers) {
+            if (!accepted_scene_buffers.contains(buffer.Get())) {
+                return false;
+            }
+        }
+    }
+    if (!payload->build_tlas && !payload->external_tlas_built &&
+        !accepted_tlas_buffers.contains(payload->destination_tlas_buffer.Get())) {
+        return false;
+    }
+
+    const auto bindless =
+        graph.ImportToken("RT.FrameSetup.bindless", payload->bindless_array.Get());
+    const auto current_tlas =
+        ImportBuffer(graph, "RT.FrameSetup.current_tlas", payload->destination_tlas_buffer);
+
+    Array<RenderGraph::BufferHandle> scene_buffers;
+    scene_buffers.reserve(payload->scene_buffers.size());
+    for (size_t index = 0; index < payload->scene_buffers.size(); ++index) {
+        const BufferRef& buffer = payload->scene_buffers[index];
+        const auto handle = ImportBuffer(
+            graph,
+            std::format("RT.FrameSetup.scene_buffer.{}", index),
+            buffer
+        );
+        graph.SetInitialState(
+            handle,
+            payload->scene_inputs_updated ?
+                RenderGraph::BufferState::UnorderedAccess :
+                RenderGraph::BufferState::ShaderResource,
+            RenderGraph::QueueRole::Graphics,
+            payload->scene_inputs_updated ?
+                RenderGraph::AccessMode::ReadWrite :
+                RenderGraph::AccessMode::Read
+        );
+        scene_buffers.emplace_back(handle);
+    }
+
+    Array<RenderGraph::TextureHandle> scene_textures;
+    scene_textures.reserve(payload->scene_textures.size());
+    for (size_t index = 0; index < payload->scene_textures.size(); ++index) {
+        const TextureRef& texture = payload->scene_textures[index];
+        const auto handle = ImportTexture(
+            graph,
+            std::format("RT.FrameSetup.scene_texture.{}", index),
+            texture
+        );
+        graph.SetInitialState(
+            handle,
+            PreferredReadState(texture),
+            RenderGraph::QueueRole::Graphics,
+            RenderGraph::AccessMode::Read
+        );
+        scene_textures.emplace_back(handle);
+    }
+
+    const auto update_bindless = graph.AddRecordPass(
+        "RT.FrameSetup.UpdateBindless",
+        [=](RenderGraph::PassBuilder& builder) {
+            builder.ExecuteOn(RenderGraph::QueueRole::Graphics, RenderGraph::PipelineType::Compute)
+                .Write(bindless)
+                .SideEffect();
+        },
+        [payload](CommandList& cmd_list) {
+            ScopedGpuMarker marker(
+                cmd_list,
+                "Pass: RT Update Bindless",
+                GpuMarkerPalette::Pass()
+            );
+            cmd_list.UpdateBindlessArray(payload->bindless_array);
+        },
+        RenderGraph::PassExecutionClass::SerialRecord
+    );
+
+    const auto normalize_scene = graph.AddRecordPass(
+        "RT.FrameSetup.NormalizeSceneBindings",
+        [=](RenderGraph::PassBuilder& builder) {
+            builder.ExecuteOn(RenderGraph::QueueRole::Graphics, RenderGraph::PipelineType::Compute)
+                .DependsOn(update_bindless)
+                .Read(bindless)
+                .SideEffect();
+            for (const auto buffer : scene_buffers) {
+                builder.Read(buffer, RenderGraph::BufferState::ShaderResource);
+            }
+            for (size_t index = 0; index < scene_textures.size(); ++index) {
+                builder.Read(
+                    scene_textures[index],
+                    PreferredReadState(payload->scene_textures[index])
+                );
+            }
+        },
+        [](CommandList&) {},
+        RenderGraph::PassExecutionClass::SerialRecord
+    );
+
+    graph.Export(bindless);
+    for (const auto buffer : scene_buffers) {
+        graph.Export(
+            buffer,
+            RenderGraph::BufferState::ShaderResource,
+            RenderGraph::QueueRole::Graphics,
+            RenderGraph::AccessMode::Read
+        );
+    }
+    for (size_t index = 0; index < scene_textures.size(); ++index) {
+        graph.Export(
+            scene_textures[index],
+            PreferredReadState(payload->scene_textures[index]),
+            RenderGraph::QueueRole::Graphics,
+            RenderGraph::AccessMode::Read
+        );
+    }
+
+    if (!payload->build_tlas) {
+        graph.SetInitialState(
+            current_tlas,
+            payload->external_tlas_built ?
+                RenderGraph::BufferState::AccelerationStructureWrite :
+                RenderGraph::BufferState::AccelerationStructureRead,
+            RenderGraph::QueueRole::Graphics,
+            payload->external_tlas_built ?
+                RenderGraph::AccessMode::Write :
+                RenderGraph::AccessMode::Read
+        );
+        graph.AddRecordPass(
+            "RT.FrameSetup.NormalizeTLAS",
+            [=](RenderGraph::PassBuilder& builder) {
+                builder.ExecuteOn(
+                           RenderGraph::QueueRole::Graphics,
+                           RenderGraph::PipelineType::Compute
+                       )
+                    .DependsOn(normalize_scene)
+                    .Read(
+                        current_tlas,
+                        RenderGraph::BufferState::AccelerationStructureRead
+                    )
+                    .SideEffect();
+            },
+            [](CommandList&) {},
+            RenderGraph::PassExecutionClass::SerialRecord
+        );
+        graph.Export(
+            current_tlas,
+            RenderGraph::BufferState::AccelerationStructureRead,
+            RenderGraph::QueueRole::Graphics,
+            RenderGraph::AccessMode::Read
+        );
+        return true;
+    }
+
+    graph.SetInitialState(
+        current_tlas,
+        payload->external_tlas_built ?
+            RenderGraph::BufferState::AccelerationStructureWrite :
+            (accepted_tlas_buffers.contains(payload->destination_tlas_buffer.Get()) ?
+                 RenderGraph::BufferState::AccelerationStructureRead :
+                 RenderGraph::BufferState::Undefined),
+        payload->external_tlas_built ||
+                accepted_tlas_buffers.contains(payload->destination_tlas_buffer.Get()) ?
+            RenderGraph::QueueRole::Graphics :
+            RenderGraph::QueueRole::None,
+        payload->external_tlas_built ?
+            RenderGraph::AccessMode::Write :
+            (accepted_tlas_buffers.contains(payload->destination_tlas_buffer.Get()) ?
+                 RenderGraph::AccessMode::Read :
+                 RenderGraph::AccessMode::None)
+    );
+    const auto instance_buffer =
+        ImportBuffer(graph, "RT.FrameSetup.tlas_instances", payload->instance_buffer);
+    const auto scratch_buffer =
+        ImportBuffer(graph, "RT.FrameSetup.tlas_scratch", payload->scratch_buffer);
+    const bool instance_initialized =
+        accepted_instance_buffers.contains(payload->instance_buffer.Get());
+    graph.SetInitialState(
+        instance_buffer,
+        instance_initialized ?
+            RenderGraph::BufferState::AccelerationStructureBuildInput :
+            RenderGraph::BufferState::Undefined,
+        instance_initialized ? RenderGraph::QueueRole::Graphics :
+                               RenderGraph::QueueRole::None,
+        instance_initialized ? RenderGraph::AccessMode::Read :
+                               RenderGraph::AccessMode::None
+    );
+    const bool scratch_initialized =
+        accepted_scratch_buffers.contains(payload->scratch_buffer.Get());
+    graph.SetInitialState(
+        scratch_buffer,
+        scratch_initialized ?
+            RenderGraph::BufferState::AccelerationStructureWrite :
+            RenderGraph::BufferState::Undefined,
+        scratch_initialized ? RenderGraph::QueueRole::Graphics :
+                              RenderGraph::QueueRole::None,
+        scratch_initialized ? RenderGraph::AccessMode::Write :
+                              RenderGraph::AccessMode::None
+    );
+
+    Array<RenderGraph::BufferHandle> geometry_buffers;
+    geometry_buffers.reserve(payload->geometry_buffers.size());
+    for (size_t index = 0; index < payload->geometry_buffers.size(); ++index) {
+        const auto geometry = ImportBuffer(
+            graph,
+            std::format("RT.FrameSetup.geometry.{}", index),
+            payload->geometry_buffers[index]
+        );
+        graph.SetInitialState(
+            geometry,
+            RenderGraph::BufferState::AccelerationStructureRead,
+            RenderGraph::QueueRole::Graphics,
+            RenderGraph::AccessMode::Read
+        );
+        geometry_buffers.emplace_back(geometry);
+    }
+
+    graph.AddRecordPass(
+        "RT.FrameSetup.BuildTLAS",
+        [=](RenderGraph::PassBuilder& builder) {
+            auto& setup_builder =
+                builder.ExecuteOn(
+                           RenderGraph::QueueRole::Graphics,
+                           RenderGraph::PipelineType::Compute
+                       )
+                .DependsOn(normalize_scene)
+                .Read(bindless);
+            if (payload->full_instance_upload) {
+                // Prepare marks every live instance dirty before materializing
+                // the command, so this transaction fully overwrites the
+                // instance payload before the native TLAS build consumes it.
+                // Model the pass boundary as Write; the command's internal
+                // compute->AS barrier and the graph export establish the
+                // build-input read state seen by later transactions.
+                setup_builder.Write(
+                    instance_buffer,
+                    RenderGraph::BufferState::UnorderedAccess
+                );
+            } else {
+                // Future backends may legally materialize a partial update.
+                // That path is graph-safe only after the same physical buffer
+                // has an accepted predecessor whose untouched instances remain
+                // valid.
+                setup_builder.ReadWrite(
+                    instance_buffer,
+                    RenderGraph::BufferState::UnorderedAccess
+                );
+            }
+            setup_builder
+                .Write(scratch_buffer, RenderGraph::BufferState::AccelerationStructureWrite)
+                .Write(current_tlas, RenderGraph::BufferState::AccelerationStructureWrite);
+            for (const auto geometry : geometry_buffers) {
+                builder.Read(
+                    geometry,
+                    RenderGraph::BufferState::AccelerationStructureBuildInput
+                );
+            }
+        },
+        [payload](CommandList& cmd_list) {
+            bool expected = false;
+            if (!payload->build_tlas_recorded.compare_exchange_strong(expected, true)) {
+                throw std::logic_error("RT FrameSetup BuildTLAS command was recorded more than once");
+            }
+            ScopedGpuMarker marker(
+                cmd_list,
+                "Pass: Scene Acceleration Structure",
+                GpuMarkerPalette::Pass()
+            );
+            cmd_list.PushScopeWithTimeScope("RTScene RendererTLAS");
+            cmd_list.UpdateRaytracingScene(std::move(payload->build_tlas_command));
+            cmd_list.PopScopeWithTimeScope();
+        },
+        RenderGraph::PassExecutionClass::SerialRecord
+    );
+
+    graph.Export(
+        current_tlas,
+        RenderGraph::BufferState::AccelerationStructureRead,
+        RenderGraph::QueueRole::Graphics,
+        RenderGraph::AccessMode::Read
+    );
+    graph.Export(
+        instance_buffer,
+        RenderGraph::BufferState::AccelerationStructureBuildInput,
+        RenderGraph::QueueRole::Graphics,
+        RenderGraph::AccessMode::Read
+    );
+    graph.Export(
+        scratch_buffer,
+        RenderGraph::BufferState::AccelerationStructureWrite,
+        RenderGraph::QueueRole::Graphics,
+        RenderGraph::AccessMode::Write
+    );
+    for (const auto geometry : geometry_buffers) {
+        graph.Export(
+            geometry,
+            RenderGraph::BufferState::AccelerationStructureRead,
+            RenderGraph::QueueRole::Graphics,
+            RenderGraph::AccessMode::Read
+        );
+    }
+    return true;
+}
+
+bool RaytracingFrameSetupPass::ProcessLinear(
+    CommandList&           cmd_list,
+    const PreparedCommand& command
+) const {
+    const SharedPtr<RecordPayload> payload = command.record;
+    if (!payload || !payload->bindless_array || !payload->destination_tlas ||
+        !payload->destination_tlas_buffer) {
+        return false;
+    }
+    if (payload->build_tlas &&
+        (!payload->build_tlas_command || !payload->instance_buffer ||
+         !payload->scratch_buffer || payload->geometry_buffers.empty())) {
+        return false;
+    }
+    cmd_list.UpdateBindlessArray(payload->bindless_array);
+    if (!payload->build_tlas || !payload->build_tlas_command) {
+        return true;
+    }
+
+    bool expected = false;
+    if (!payload->build_tlas_recorded.compare_exchange_strong(expected, true)) {
+        throw std::logic_error("RT FrameSetup BuildTLAS command was recorded more than once");
+    }
+    ScopedGpuMarker marker(
+        cmd_list,
+        "Pass: Scene Acceleration Structure",
+        GpuMarkerPalette::Pass()
+    );
+    cmd_list.PushScopeWithTimeScope("RTScene RendererTLAS");
+    cmd_list.UpdateRaytracingScene(std::move(payload->build_tlas_command));
+    cmd_list.PopScopeWithTimeScope();
+    return true;
+}
+
+RaytracingFrameSetupPass::AcceptedSnapshot RaytracingFrameSetupPass::CommitAccepted(
+    const PreparedCommand& command
+) noexcept {
+    const SharedPtr<RecordPayload> payload = command.record;
+    if (!payload) {
+        return {};
+    }
+
+    for (const BufferRef& buffer : payload->scene_buffers) {
+        accepted_scene_buffers.emplace(buffer.Get());
+    }
+    if (payload->destination_tlas_buffer) {
+        accepted_tlas_buffers.emplace(payload->destination_tlas_buffer.Get());
+    }
+    if (payload->previous_tlas_buffer) {
+        accepted_tlas_buffers.emplace(payload->previous_tlas_buffer.Get());
+    }
+    if (payload->instance_buffer) {
+        accepted_instance_buffers.emplace(payload->instance_buffer.Get());
+    }
+    if (payload->scratch_buffer) {
+        accepted_scratch_buffers.emplace(payload->scratch_buffer.Get());
+    }
+
+    return AcceptedSnapshot{
+        .bindless_array       = payload->bindless_array,
+        .scene                = payload->scene,
+        .current_tlas         = payload->destination_tlas,
+        .previous_tlas        = payload->previous_tlas,
+        .current_tlas_buffer  = payload->destination_tlas_buffer,
+        .previous_tlas_buffer = payload->previous_tlas_buffer,
+        .tlas_revision        = payload->target_revision,
+        .tlas_built           = payload->build_tlas
+    };
+}
+
+void RaytracingFrameSetupPass::ResetAcceptedResources() noexcept {
+    accepted_tlas_buffers.clear();
+    accepted_instance_buffers.clear();
+    accepted_scratch_buffers.clear();
+    accepted_scene_buffers.clear();
+}
+
+} // namespace Moer::Render::Raytracing

--- a/source/runtime/render/renderer/raytracing/RaytracingFrameSetupPass.h
+++ b/source/runtime/render/renderer/raytracing/RaytracingFrameSetupPass.h
@@ -1,0 +1,92 @@
+#pragma once
+
+#include "RTResource.h"
+#include "misc/STL.h"
+#include "rendergraph/RenderGraph.h"
+#include "rhi/RHICommand.h"
+#include "rhi/RHIResource.h"
+
+#include <atomic>
+
+namespace Moer::Render::Raytracing {
+
+class RaytracingFrameSetupPass {
+public:
+    struct AcceptedSnapshot {
+        BindlessArrayRef   bindless_array{};
+        RaytracingSceneRef scene{};
+        RaytracingTlasRef  current_tlas{};
+        RaytracingTlasRef  previous_tlas{};
+        BufferRef          current_tlas_buffer{};
+        BufferRef          previous_tlas_buffer{};
+        uint64             tlas_revision = 0;
+        bool               tlas_built    = false;
+
+        [[nodiscard]] bool IsValid() const {
+            return bindless_array && scene && current_tlas && previous_tlas &&
+                   current_tlas_buffer && previous_tlas_buffer;
+        }
+    };
+
+    struct RecordPayload {
+        BindlessArrayRef   bindless_array{};
+        RaytracingSceneRef scene{};
+        RaytracingTlasRef  destination_tlas{};
+        RaytracingTlasRef  previous_tlas{};
+        BufferRef          destination_tlas_buffer{};
+        BufferRef          previous_tlas_buffer{};
+        BufferRef          instance_buffer{};
+        BufferRef          scratch_buffer{};
+
+        Array<RaytracingGeometryRef> geometries;
+        Array<BufferRef>             geometry_buffers;
+        Array<BufferRef>             scene_buffers;
+        Array<TextureRef>            scene_textures;
+
+        UniquePtr<Command> build_tlas_command{};
+        std::atomic_bool   build_tlas_recorded{false};
+
+        uint64 target_revision      = 0;
+        bool   build_tlas           = false;
+        bool   full_instance_upload = false;
+        bool   scene_inputs_updated = false;
+        bool   external_tlas_built  = false;
+    };
+
+    struct PreparedCommand {
+        SharedPtr<RecordPayload> record{};
+
+        [[nodiscard]] explicit operator bool() const {
+            return record && record->bindless_array && record->scene &&
+                   record->destination_tlas && record->destination_tlas_buffer;
+        }
+
+        [[nodiscard]] bool BuildsTlas() const {
+            return record && record->build_tlas;
+        }
+    };
+
+    PreparedCommand Prepare(
+        const RTContext&    rt_ctx,
+        RaytracingSceneRef  scene,
+        BindlessArrayRef    bindless_array,
+        uint64              target_revision,
+        bool                build_tlas,
+        bool                scene_inputs_updated,
+        bool                external_tlas_built
+    );
+
+    bool AddPasses(RenderGraph& graph, const PreparedCommand& command) const;
+    bool ProcessLinear(CommandList& cmd_list, const PreparedCommand& command) const;
+
+    [[nodiscard]] AcceptedSnapshot CommitAccepted(const PreparedCommand& command) noexcept;
+    void                           ResetAcceptedResources() noexcept;
+
+private:
+    UnorderedSet<const Buffer*> accepted_tlas_buffers;
+    UnorderedSet<const Buffer*> accepted_instance_buffers;
+    UnorderedSet<const Buffer*> accepted_scratch_buffers;
+    UnorderedSet<const Buffer*> accepted_scene_buffers;
+};
+
+} // namespace Moer::Render::Raytracing

--- a/source/runtime/render/renderer/raytracing/RaytracingFrameSetupPass.h
+++ b/source/runtime/render/renderer/raytracing/RaytracingFrameSetupPass.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "RTResource.h"
+#include "RaytracingGraphTypes.h"
 #include "misc/STL.h"
 #include "rendergraph/RenderGraph.h"
 #include "rhi/RHICommand.h"
@@ -12,22 +13,6 @@ namespace Moer::Render::Raytracing {
 
 class RaytracingFrameSetupPass {
 public:
-    struct AcceptedSnapshot {
-        BindlessArrayRef   bindless_array{};
-        RaytracingSceneRef scene{};
-        RaytracingTlasRef  current_tlas{};
-        RaytracingTlasRef  previous_tlas{};
-        BufferRef          current_tlas_buffer{};
-        BufferRef          previous_tlas_buffer{};
-        uint64             tlas_revision = 0;
-        bool               tlas_built    = false;
-
-        [[nodiscard]] bool IsValid() const {
-            return bindless_array && scene && current_tlas && previous_tlas &&
-                   current_tlas_buffer && previous_tlas_buffer;
-        }
-    };
-
     struct RecordPayload {
         BindlessArrayRef   bindless_array{};
         RaytracingSceneRef scene{};
@@ -40,8 +25,7 @@ public:
 
         Array<RaytracingGeometryRef> geometries;
         Array<BufferRef>             geometry_buffers;
-        Array<BufferRef>             scene_buffers;
-        Array<TextureRef>            scene_textures;
+        RaytracingBindlessResources  scene_resources{};
 
         UniquePtr<Command> build_tlas_command{};
         std::atomic_bool   build_tlas_recorded{false};
@@ -49,7 +33,7 @@ public:
         uint64 target_revision      = 0;
         bool   build_tlas           = false;
         bool   full_instance_upload = false;
-        bool   scene_inputs_updated = false;
+        bool   scene_resources_refreshed = false;
         bool   external_tlas_built  = false;
     };
 
@@ -72,15 +56,19 @@ public:
         BindlessArrayRef    bindless_array,
         uint64              target_revision,
         bool                build_tlas,
-        bool                scene_inputs_updated,
+        bool                scene_resources_refreshed,
         bool                external_tlas_built
     );
 
-    bool AddPasses(RenderGraph& graph, const PreparedCommand& command) const;
+    bool AddPasses(
+        RenderGraph&                graph,
+        const PreparedCommand&      command,
+        RTGraphFrameSetupResources& graph_resources
+    ) const;
     bool ProcessLinear(CommandList& cmd_list, const PreparedCommand& command) const;
 
-    [[nodiscard]] AcceptedSnapshot CommitAccepted(const PreparedCommand& command) noexcept;
-    void                           ResetAcceptedResources() noexcept;
+    void CommitAccepted(const PreparedCommand& command) noexcept;
+    void ResetAcceptedResources() noexcept;
 
 private:
     UnorderedSet<const Buffer*> accepted_tlas_buffers;

--- a/source/runtime/render/renderer/raytracing/RaytracingGraphResources.h
+++ b/source/runtime/render/renderer/raytracing/RaytracingGraphResources.h
@@ -1,14 +1,24 @@
 #pragma once
 
 #include "RTResource.h"
+#include "RaytracingFrameSetupPass.h"
 #include "rendergraph/RenderGraph.h"
 
 #include <cassert>
 
 namespace Moer::Render::Raytracing {
 
+struct RTGraphFrameSetupResources {
+    RenderGraph::TokenHandle  ready{};
+    RenderGraph::BufferHandle current_tlas{};
+    RenderGraph::BufferHandle previous_tlas{};
+    RenderGraph::PassHandle   accepted_producer{};
+};
+
 struct RTGraphFrameResources {
     bool current_frame{};
+
+    RTGraphFrameSetupResources frame_setup{};
 
     RenderGraph::TextureHandle view_depth{};
     RenderGraph::TextureHandle diffuse_albedo{};
@@ -91,8 +101,9 @@ inline RenderGraph::BufferHandle ImportRTGraphBuffer(
 }
 
 inline RTGraphFrameResources RegisterRTGraphFrameResources(
-    RenderGraph&     graph,
-    const RTContext& rt_ctx
+    RenderGraph&                                                        graph,
+    const RTContext&                                                    rt_ctx,
+    SharedPtr<const RaytracingFrameSetupPass::AcceptedSnapshot> accepted_setup
 ) {
     const FrameResources& frame = rt_ctx.frame_rt;
     RTGraphFrameResources resources{
@@ -157,6 +168,83 @@ inline RTGraphFrameResources RegisterRTGraphFrameResources(
         resources.current_frame ? resources.prev_specular_roughness :
                                   resources.specular_roughness;
     resources.previous_normal = resources.current_frame ? resources.prev_normal : resources.normal;
+
+    if (!accepted_setup || !accepted_setup->IsValid()) {
+        return resources;
+    }
+
+    resources.frame_setup.current_tlas = ImportRTGraphBuffer(
+        graph,
+        "RT.FrameSetup.accepted_current_tlas",
+        accepted_setup->current_tlas_buffer
+    );
+    resources.frame_setup.previous_tlas = resources.frame_setup.current_tlas;
+    if (accepted_setup->previous_tlas_buffer.Get() !=
+        accepted_setup->current_tlas_buffer.Get()) {
+        resources.frame_setup.previous_tlas = ImportRTGraphBuffer(
+            graph,
+            "RT.FrameSetup.accepted_previous_tlas",
+            accepted_setup->previous_tlas_buffer
+        );
+    }
+    graph.SetInitialState(
+        resources.frame_setup.current_tlas,
+        RenderGraph::BufferState::AccelerationStructureRead,
+        RenderGraph::QueueRole::Graphics,
+        RenderGraph::AccessMode::Read
+    );
+    if (resources.frame_setup.previous_tlas != resources.frame_setup.current_tlas) {
+        graph.SetInitialState(
+            resources.frame_setup.previous_tlas,
+            RenderGraph::BufferState::AccelerationStructureRead,
+            RenderGraph::QueueRole::Graphics,
+            RenderGraph::AccessMode::Read
+        );
+    }
+
+    resources.frame_setup.ready =
+        graph.CreateTransientToken("RT.FrameSetup.accepted");
+    resources.frame_setup.accepted_producer = graph.AddRecordPass(
+        "RT.FrameSetup.AcceptedProducer",
+        [setup = resources.frame_setup](RenderGraph::PassBuilder& builder) {
+            builder.ExecuteOn(
+                       RenderGraph::QueueRole::Graphics,
+                       RenderGraph::PipelineType::Compute
+                   )
+                .Read(
+                    setup.current_tlas,
+                    RenderGraph::BufferState::AccelerationStructureRead
+                )
+                .Read(
+                    setup.previous_tlas,
+                    RenderGraph::BufferState::AccelerationStructureRead
+                )
+                .Write(setup.ready)
+                .SideEffect();
+        },
+        [accepted_setup = std::move(accepted_setup)](CommandList&) {
+            // The no-op producer turns the independently accepted FrameSetup
+            // transaction into a primary-graph dependency root while keeping
+            // its scene/TLAS owners alive through managed recording.
+            (void)accepted_setup;
+        },
+        RenderGraph::PassExecutionClass::SerialRecord
+    );
+    graph.Export(
+        resources.frame_setup.current_tlas,
+        RenderGraph::BufferState::AccelerationStructureRead,
+        RenderGraph::QueueRole::Graphics,
+        RenderGraph::AccessMode::Read
+    );
+    if (resources.frame_setup.previous_tlas != resources.frame_setup.current_tlas) {
+        graph.Export(
+            resources.frame_setup.previous_tlas,
+            RenderGraph::BufferState::AccelerationStructureRead,
+            RenderGraph::QueueRole::Graphics,
+            RenderGraph::AccessMode::Read
+        );
+    }
+    graph.Export(resources.frame_setup.ready);
     return resources;
 }
 

--- a/source/runtime/render/renderer/raytracing/RaytracingGraphResources.h
+++ b/source/runtime/render/renderer/raytracing/RaytracingGraphResources.h
@@ -37,6 +37,7 @@ struct RTGraphFrameResources {
     RenderGraph::TextureHandle feedback_color_ping{};
     RenderGraph::TextureHandle feedback_color_pong{};
     RenderGraph::TextureHandle env_map{};
+    RenderGraph::TokenHandle   presentation_ready{};
     RenderGraph::TokenHandle   nrd_ready{};
     RenderGraph::PassHandle    nrd_pass{};
 
@@ -157,6 +158,8 @@ inline RTGraphFrameResources RegisterRTGraphFrameResources(
         resources.env_map =
             ImportRTGraphTexture(graph, "RT.env_map", rt_ctx.env_map);
     }
+    resources.presentation_ready =
+        graph.CreateTransientToken("RT.presentation_ready");
 
     resources.current_view_depth = resources.current_frame ? resources.view_depth :
                                                              resources.prev_view_depth;

--- a/source/runtime/render/renderer/raytracing/RaytracingGraphResources.h
+++ b/source/runtime/render/renderer/raytracing/RaytracingGraphResources.h
@@ -28,6 +28,8 @@ struct RTGraphFrameResources {
     RenderGraph::TextureHandle normal_roughness{};
     RenderGraph::TextureHandle diffuse_lighting{};
     RenderGraph::TextureHandle specular_lighting{};
+    RenderGraph::TextureHandle denoised_diffuse_lighting{};
+    RenderGraph::TextureHandle denoised_specular_lighting{};
     RenderGraph::TextureHandle hdr_color{};
     RenderGraph::TextureHandle resolved_color{};
     RenderGraph::TextureHandle ldr_color{};
@@ -35,6 +37,8 @@ struct RTGraphFrameResources {
     RenderGraph::TextureHandle feedback_color_ping{};
     RenderGraph::TextureHandle feedback_color_pong{};
     RenderGraph::TextureHandle env_map{};
+    RenderGraph::TokenHandle   nrd_ready{};
+    RenderGraph::PassHandle    nrd_pass{};
 
     RenderGraph::TextureHandle current_view_depth{};
     RenderGraph::TextureHandle current_diffuse_albedo{};
@@ -120,6 +124,16 @@ inline RTGraphFrameResources RegisterRTGraphFrameResources(
             ImportRTGraphTexture(graph, "RT.diffuse_lighting", frame.diffuse_lighting),
         .specular_lighting =
             ImportRTGraphTexture(graph, "RT.specular_lighting", frame.specular_lighting),
+        .denoised_diffuse_lighting = ImportRTGraphTexture(
+            graph,
+            "RT.denoised_diffuse_lighting",
+            frame.denoised_diffuse_lighting
+        ),
+        .denoised_specular_lighting = ImportRTGraphTexture(
+            graph,
+            "RT.denoised_specular_lighting",
+            frame.denoised_specular_lighting
+        ),
         .hdr_color =
             ImportRTGraphTexture(graph, "RT.hdr_color", frame.hdr_color),
         .resolved_color =

--- a/source/runtime/render/renderer/raytracing/RaytracingGraphResources.h
+++ b/source/runtime/render/renderer/raytracing/RaytracingGraphResources.h
@@ -1,19 +1,12 @@
 #pragma once
 
 #include "RTResource.h"
-#include "RaytracingFrameSetupPass.h"
+#include "RaytracingGraphTypes.h"
 #include "rendergraph/RenderGraph.h"
 
 #include <cassert>
 
 namespace Moer::Render::Raytracing {
-
-struct RTGraphFrameSetupResources {
-    RenderGraph::TokenHandle  ready{};
-    RenderGraph::BufferHandle current_tlas{};
-    RenderGraph::BufferHandle previous_tlas{};
-    RenderGraph::PassHandle   accepted_producer{};
-};
 
 struct RTGraphFrameResources {
     bool current_frame{};
@@ -101,9 +94,9 @@ inline RenderGraph::BufferHandle ImportRTGraphBuffer(
 }
 
 inline RTGraphFrameResources RegisterRTGraphFrameResources(
-    RenderGraph&                                                        graph,
-    const RTContext&                                                    rt_ctx,
-    SharedPtr<const RaytracingFrameSetupPass::AcceptedSnapshot> accepted_setup
+    RenderGraph&                       graph,
+    const RTContext&                   rt_ctx,
+    const RTGraphFrameSetupResources& frame_setup
 ) {
     const FrameResources& frame = rt_ctx.frame_rt;
     RTGraphFrameResources resources{
@@ -168,83 +161,7 @@ inline RTGraphFrameResources RegisterRTGraphFrameResources(
         resources.current_frame ? resources.prev_specular_roughness :
                                   resources.specular_roughness;
     resources.previous_normal = resources.current_frame ? resources.prev_normal : resources.normal;
-
-    if (!accepted_setup || !accepted_setup->IsValid()) {
-        return resources;
-    }
-
-    resources.frame_setup.current_tlas = ImportRTGraphBuffer(
-        graph,
-        "RT.FrameSetup.accepted_current_tlas",
-        accepted_setup->current_tlas_buffer
-    );
-    resources.frame_setup.previous_tlas = resources.frame_setup.current_tlas;
-    if (accepted_setup->previous_tlas_buffer.Get() !=
-        accepted_setup->current_tlas_buffer.Get()) {
-        resources.frame_setup.previous_tlas = ImportRTGraphBuffer(
-            graph,
-            "RT.FrameSetup.accepted_previous_tlas",
-            accepted_setup->previous_tlas_buffer
-        );
-    }
-    graph.SetInitialState(
-        resources.frame_setup.current_tlas,
-        RenderGraph::BufferState::AccelerationStructureRead,
-        RenderGraph::QueueRole::Graphics,
-        RenderGraph::AccessMode::Read
-    );
-    if (resources.frame_setup.previous_tlas != resources.frame_setup.current_tlas) {
-        graph.SetInitialState(
-            resources.frame_setup.previous_tlas,
-            RenderGraph::BufferState::AccelerationStructureRead,
-            RenderGraph::QueueRole::Graphics,
-            RenderGraph::AccessMode::Read
-        );
-    }
-
-    resources.frame_setup.ready =
-        graph.CreateTransientToken("RT.FrameSetup.accepted");
-    resources.frame_setup.accepted_producer = graph.AddRecordPass(
-        "RT.FrameSetup.AcceptedProducer",
-        [setup = resources.frame_setup](RenderGraph::PassBuilder& builder) {
-            builder.ExecuteOn(
-                       RenderGraph::QueueRole::Graphics,
-                       RenderGraph::PipelineType::Compute
-                   )
-                .Read(
-                    setup.current_tlas,
-                    RenderGraph::BufferState::AccelerationStructureRead
-                )
-                .Read(
-                    setup.previous_tlas,
-                    RenderGraph::BufferState::AccelerationStructureRead
-                )
-                .Write(setup.ready)
-                .SideEffect();
-        },
-        [accepted_setup = std::move(accepted_setup)](CommandList&) {
-            // The no-op producer turns the independently accepted FrameSetup
-            // transaction into a primary-graph dependency root while keeping
-            // its scene/TLAS owners alive through managed recording.
-            (void)accepted_setup;
-        },
-        RenderGraph::PassExecutionClass::SerialRecord
-    );
-    graph.Export(
-        resources.frame_setup.current_tlas,
-        RenderGraph::BufferState::AccelerationStructureRead,
-        RenderGraph::QueueRole::Graphics,
-        RenderGraph::AccessMode::Read
-    );
-    if (resources.frame_setup.previous_tlas != resources.frame_setup.current_tlas) {
-        graph.Export(
-            resources.frame_setup.previous_tlas,
-            RenderGraph::BufferState::AccelerationStructureRead,
-            RenderGraph::QueueRole::Graphics,
-            RenderGraph::AccessMode::Read
-        );
-    }
-    graph.Export(resources.frame_setup.ready);
+    resources.frame_setup = frame_setup;
     return resources;
 }
 

--- a/source/runtime/render/renderer/raytracing/RaytracingGraphTypes.h
+++ b/source/runtime/render/renderer/raytracing/RaytracingGraphTypes.h
@@ -1,0 +1,59 @@
+#pragma once
+
+#include "misc/STL.h"
+#include "rendergraph/RenderGraph.h"
+#include "rhi/RHIResource.h"
+
+namespace Moer::Render::Raytracing {
+
+struct RTGraphSceneResources {
+    RenderGraph::BufferHandle light{};
+    RenderGraph::BufferHandle material{};
+    RenderGraph::BufferHandle primitive{};
+    RenderGraph::BufferHandle instance{};
+    RenderGraph::BufferHandle position{};
+    RenderGraph::BufferHandle packed_normal{};
+    RenderGraph::BufferHandle packed_tangent{};
+    RenderGraph::BufferHandle texcoord0{};
+    RenderGraph::BufferHandle index{};
+    RenderGraph::BufferHandle rt_instance{};
+    RenderGraph::BufferHandle rt_primitive_table{};
+
+    BufferRef light_resource{};
+    BufferRef material_resource{};
+    BufferRef primitive_resource{};
+    BufferRef instance_resource{};
+    BufferRef position_resource{};
+    BufferRef packed_normal_resource{};
+    BufferRef packed_tangent_resource{};
+    BufferRef texcoord0_resource{};
+    BufferRef index_resource{};
+    BufferRef rt_instance_resource{};
+    BufferRef rt_primitive_table_resource{};
+
+    Array<RenderGraph::TextureHandle> material_textures;
+    Array<TextureRef>                 material_texture_resources;
+};
+
+struct RTGraphFrameSetupResources {
+    RenderGraph::TokenHandle  ready{};
+    RenderGraph::TokenHandle  bindless{};
+    RenderGraph::BufferHandle current_tlas{};
+    RenderGraph::BufferHandle previous_tlas{};
+
+    RTGraphSceneResources scene{};
+
+    RenderGraph::PassHandle update_bindless{};
+    RenderGraph::PassHandle normalize_scene{};
+    RenderGraph::PassHandle build_tlas{};
+    RenderGraph::PassHandle finalize{};
+
+    [[nodiscard]] bool IsValid() const {
+        return ready.IsValid() && bindless.IsValid() &&
+               current_tlas.IsValid() && previous_tlas.IsValid() &&
+               update_bindless.IsValid() && normalize_scene.IsValid() &&
+               finalize.IsValid();
+    }
+};
+
+} // namespace Moer::Render::Raytracing

--- a/source/runtime/render/renderer/raytracing/RaytracingRenderer.cpp
+++ b/source/runtime/render/renderer/raytracing/RaytracingRenderer.cpp
@@ -23,6 +23,7 @@
 #include "LightingPass.h"
 #include "NrdDenoisePass.h"
 #include "PreprocessLightPass.h"
+#include "RaytracingExportSubmission.h"
 #include "RaytracingFrameSetupPass.h"
 #include "RTResource.h"
 #include "ShaderUtils.h"
@@ -678,6 +679,7 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
     ShowTextureParams                                show_texture_params{};
     FenceRef                                         graph_submission_fence{};
     FenceRef                                         ui_graph_submission_fence{};
+    ExportSubmissionTransaction                      export_submission{};
     uint64                                           graph_submission_value_count = 0;
     UiFrameGraphPass::GraphPasses                    ui_graph_passes{};
 
@@ -1379,27 +1381,49 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
 
         if (state.b_export) {
             close_renderer_marker();
-            RHIExecutor::Get().Submit(
-                EQueueType::Graphics,
+            export_submission.Reset(device.CreateFence());
+            CmdSubmit export_submit =
                 cmd_list.Submit()
                     .DebugLabel(
                         std::format("Raytracing Export Frame {}", frame_packet.frame_id),
                         GpuMarkerPalette::Frame()
                     )
-                    .TickProfiling(),
+                    .TickProfiling();
+            export_submission.AttachSignal(export_submit);
+            RHIExecutor::Get().Submit(
+                EQueueType::Graphics,
+                std::move(export_submit),
                 ERHIExecSubmitFlags::FlushGPU
             );
             RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
-            DumpTextureToFile(
-                ui_config.export_cfg,
-                state.rt_ctx->frame_rt,
-                device,
-                gfx_queue,
-                state.exported_file_path,
-                std::to_string(time)
-            );
-            state.b_export           = false;
-            feedback.export_consumed = true;
+            if (export_submission.SourceAccepted()) {
+                const bool readback_accepted = DumpTextureToFile(
+                    ui_config.export_cfg,
+                    state.rt_ctx->frame_rt,
+                    device,
+                    gfx_queue,
+                    state.exported_file_path,
+                    std::to_string(time)
+                );
+                if (readback_accepted) {
+                    state.b_export           = false;
+                    feedback.export_consumed = true;
+                } else {
+                    LOG_CRITICAL(
+                        "[Raytracing][Export] Texture readback was not "
+                        "accepted for frame {}. Skipping encode and retaining "
+                        "the export request for retry.",
+                        frame_packet.frame_id
+                    );
+                }
+            } else {
+                LOG_CRITICAL(
+                    "[Raytracing][Export] Native submission rejected export "
+                    "frame {}. Skipping readback and retaining the export "
+                    "request for retry.",
+                    frame_packet.frame_id
+                );
+            }
         }
     }
 
@@ -1454,6 +1478,12 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
             .DebugLabel(std::format("Raytracing Frame {}", frame_packet.frame_id), GpuMarkerPalette::Frame())
             .Signal(timeline, time)
             .DeleteResources();
+    if (export_submission.IsActive()) {
+        // The final UI/present tail belongs to the same frame transaction as
+        // the separately submitted export prefix. A rejected prefix must not
+        // publish or present an otherwise accepted stale tail.
+        export_submission.AttachDependentWait(frame_submit);
+    }
     if (split_graph_profiling_frame) {
         frame_submit.SetProfilingPhase(ERHIProfilingPhase::End);
     } else {
@@ -1497,9 +1527,11 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
     );
     // Accepted renderer state follows native queue publication, not CPU
     // recording completion. The final tail proves the ordered suffix was
-    // accepted; the per-source graph fence prevents an accepted tail from
-    // hiding a rejected managed source.
+    // accepted; the export and per-source graph fences prevent an accepted
+    // tail from hiding a rejected separately submitted source.
     bool frame_native_accepted = timeline->WaitSubmitted(time);
+    frame_native_accepted =
+        export_submission.FoldAcceptance(frame_native_accepted);
     if (graph_submission_fence) {
         for (uint64 value = 1; value <= graph_submission_value_count; ++value) {
             const bool source_accepted =
@@ -1579,7 +1611,7 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
         state.render_graph_recording_failure_latched = true;
         LOG_CRITICAL(
             "[RenderGraph][Raytracing] Native submission rejected the final "
-            "tail, a managed graph source, or the copied UI source. "
+            "tail, export source, managed graph source, or copied UI source. "
             "Preserving accepted renderer history and disabling managed "
             "recording for this renderer instance."
         );

--- a/source/runtime/render/renderer/raytracing/RaytracingRenderer.cpp
+++ b/source/runtime/render/renderer/raytracing/RaytracingRenderer.cpp
@@ -10,6 +10,7 @@
 #include "rhi/RHIExecutor.h"
 #include "rhi/RHIResource.h"
 #include "rhi/plugin/NrdPlugin.h"
+#include "renderer/common/UiFrameGraphPass.h"
 #include "scene/GpuScene.h"
 #include "shader/ShaderResourceManager.h"
 #include "window/WindowContext.h"
@@ -321,7 +322,6 @@ struct RaytracingRenderer::RuntimeState {
     UnorderedMap<std::string, TextureWithHandle> material_textures;
 
     TextureRef output;
-    TextureRef ui_frame_buffer;
 
     Timer timer;
 
@@ -380,13 +380,9 @@ struct RaytracingRenderer::RuntimeState {
         output(renderer.device.CreateTexture(
             Extent2D(renderer.resolution.x, renderer.resolution.y),
             renderer.swapchain->format,
-            ETextureUsageFlags::COLOR_ATTACHMENT
-        )),
-        ui_frame_buffer(renderer.device.CreateTexture(
-            "ui_frame_buffer",
-            Extent2D(renderer.resolution.x, renderer.resolution.y),
-            PF_R8G8B8A8_SRGB,
-            ETextureUsageFlags::COLOR_ATTACHMENT | ETextureUsageFlags::SAMPLED
+            ETextureUsageFlags::COLOR_ATTACHMENT |
+                ETextureUsageFlags::TRANSFER_SRC |
+                ETextureUsageFlags::TRANSFER_DST
         )),
         exported_file_path(ConfigManager::GetInstance().GetWorkspacePath() / "saved"),
         prepare_light_pass(MakeUnique<PrepareLightPass>(renderer.manager, renderer.bindless_array)),
@@ -627,6 +623,15 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
 
     auto& state     = *runtime_state;
     auto& ui_config = frame_packet.config;
+    const auto ui_execution_thread =
+        IsCurrentlyRenderThread() ?
+            EUiDrawExecutionThread::Render :
+            EUiDrawExecutionThread::Game;
+    const auto prepared_ui = UiFrameGraphPass::Prepare(
+        std::move(frame_packet.ui_composition),
+        std::move(frame_packet.ui_draw_frame),
+        ui_execution_thread
+    );
 
     if (frame_packet.frame_id == 0) {
         const uint32_t frame_thread_id = IsCurrentlyRenderThread() ? GetRenderThreadId() : GetGameThreadId();
@@ -649,12 +654,14 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
     bool  graph_tone_mapping_recorded     = false;
     bool  graph_visualize_recorded        = false;
     bool  graph_show_texture_recorded     = false;
+    bool  graph_ui_recorded               = false;
     bool  graph_recording_failed          = state.render_graph_recording_failure_latched;
     bool  linear_gbuffer_recorded         = false;
     bool  linear_lighting_recorded        = false;
     bool  linear_antialias_recorded       = false;
     bool  linear_tone_mapping_recorded    = false;
     bool  linear_visualize_recorded       = false;
+    bool  linear_ui_recorded              = false;
     bool  nrd_recorded                    = false;
     uint8 gbuffer_history_bit             = 0;
     float tone_mapping_elapsed_for_commit = 0.f;
@@ -669,6 +676,10 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
     TextureRef                                       selected_debug_texture{};
     bool                                             show_texture_requested = false;
     ShowTextureParams                                show_texture_params{};
+    FenceRef                                         graph_submission_fence{};
+    FenceRef                                         ui_graph_submission_fence{};
+    uint64                                           graph_submission_value_count = 0;
+    UiFrameGraphPass::GraphPasses                    ui_graph_passes{};
 
     switch (frame_packet.window.state) {
         case EWindowState::Hiding:
@@ -1093,17 +1104,36 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
                                                                   show_texture_params,
                                                                   selected_debug_texture,
                                                                   state.rt_ctx->frame_rt.ldr_color,
-                                                                  graph_resources.frame_setup.ready
+                                                                  graph_resources.frame_setup.ready,
+                                                                  graph_resources.presentation_ready
                                                               ));
+            const TextureRef graph_final_color =
+                frame_packet.debug_input.show_final_texture ?
+                    state.rt_ctx->frame_rt.ldr_color :
+                    state.rt_ctx->frame_rt.debug_color;
+            const RenderGraph::TextureHandle graph_final_color_handle =
+                frame_packet.debug_input.show_final_texture ?
+                    graph_resources.ldr_color :
+                    graph_resources.debug_color;
+            const bool ui_added =
+                show_texture_added &&
+                UiFrameGraphPass::AddPasses(
+                    graph,
+                    *ui_combine_pass,
+                    prepared_ui,
+                    graph_final_color_handle,
+                    graph_final_color,
+                    state.output,
+                    graph_resources.presentation_ready,
+                    ui_graph_passes
+                );
             const bool graph_passes_added = prepare_lights_added && gbuffer_added && lighting_added &&
                                             nrd_added && composition_added && antialias_added &&
                                             tone_mapping_added &&
-                                            visualize_added && show_texture_added;
+                                            visualize_added && show_texture_added && ui_added;
             if (graph_passes_added && IsRenderGraphRecordingFailureInjected()) {
                 const RenderGraph::PassHandle fault_dependency =
-                    graph_resources.nrd_pass.IsValid() ?
-                        graph_resources.nrd_pass :
-                        setup_resources.finalize;
+                    ui_graph_passes.draw;
                 graph.AddRecordPass(
                     "RT.FaultInjection.RecordingFailure",
                     [fault_dependency](RenderGraph::PassBuilder& builder) {
@@ -1127,7 +1157,7 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
                 LOG_ERROR("[RenderGraph][Fallback] Raytracing unified graph could not "
                           "import a required FrameSetup/PrepareLights/GBuffer/Lighting/"
                           "NRD/Composition/AntiAlias/"
-                          "ToneMapping/Visualize/ShowTexture resource. Using the linear "
+                          "ToneMapping/Visualize/ShowTexture/UI resource. Using the linear "
                           "path for this renderer instance.");
             } else if (!graph.Compile()) {
                 state.render_graph_fallback_latched = true;
@@ -1166,6 +1196,8 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
                 }
 
                 bool       graph_recording_profiling_started = split_graph_profiling_frame;
+                graph_submission_fence    = device.CreateFence();
+                ui_graph_submission_fence = device.CreateFence();
                 const auto configure_recording_source        = [&](const RenderGraph::ExecutedPassInfo& pass,
                                                             RHIRecordingSource&                  source) {
                     source.submit_metadata.debug_label =
@@ -1175,6 +1207,20 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
                                                                           ERHIProfilingPhase::Continue :
                                                                           ERHIProfilingPhase::Begin;
                     graph_recording_profiling_started        = true;
+                    source.submit_metadata.signal_fences.emplace_back(
+                        RHIRecordingFencePoint{
+                            .fence = graph_submission_fence,
+                            .value = ++graph_submission_value_count,
+                        }
+                    );
+                    if (pass.handle == ui_graph_passes.draw) {
+                        source.submit_metadata.signal_fences.emplace_back(
+                            RHIRecordingFencePoint{
+                                .fence = ui_graph_submission_fence,
+                                .value = 1,
+                            }
+                        );
+                    }
 #if WITH_NRD
                     if (nrd_active_this_frame && prepared_nrd) {
                         source.submit_metadata.signal_fences.emplace_back(
@@ -1207,6 +1253,7 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
                     graph_tone_mapping_recorded = tone_mapping_in_graph;
                     graph_visualize_recorded    = visualize_in_graph;
                     graph_show_texture_recorded = show_texture_in_graph;
+                    graph_ui_recorded           = ui_added;
                 } else {
                     // ExecuteRecording joins every producer and fails the
                     // graph-wide commit gate. Sync only joins the resulting
@@ -1216,6 +1263,7 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
                     graph_recording_failed                       = true;
                     state.render_graph_fallback_latched          = true;
                     state.render_graph_recording_failure_latched = true;
+                    prepared_ui->Abandon();
                     LOG_ERROR(
                         "[RenderGraph][Fallback] Raytracing unified graph "
                         "recording failed before transaction commit: {}. "
@@ -1258,7 +1306,7 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
             );
             state.prepare_light_pass->RecordAcceptedBoundary(cmd_list, *prepared_lights);
             linear_lighting_recorded = true;
-        } else if (graph_primary_recorded) {
+        } else if (graph_primary_recorded && !graph_ui_recorded) {
             state.g_buffer_pass->RecordLegacyTailBridge(
                 cmd_list,
                 *state.rt_ctx,
@@ -1359,38 +1407,46 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
                                        state.rt_ctx->frame_rt.ldr_color :
                                        state.rt_ctx->frame_rt.debug_color;
 
-    if (frame_packet.ui_composition.enabled) {
-        const auto& ui_frame = frame_packet.ui_composition;
-        const auto  window_frame_buffer =
-            ui_frame.window_frame_buffer ? ui_frame.window_frame_buffer->GetView() : TextureView();
-        ui_combine_pass->Process(
-            cmd_list,
-            ui_frame.separate_window,
-            ui_frame.output_resolution,
-            ui_frame.scene_color_position,
-            ui_frame.scene_color_resolution,
-            window_frame_buffer,
-            final_color,
-            state.ui_frame_buffer,
-            state.output
-        );
-    } else {
-        ui_combine_pass->Process(
-            cmd_list,
-            true,
-            resolution,
-            float2(0.f, 0.f),
-            float2(static_cast<float>(resolution.x), static_cast<float>(resolution.y)),
-            TextureView(state.output),
-            state.rt_ctx->frame_rt.ldr_color,
-            {},
-            state.output
-        );
+    if (!graph_ui_recorded &&
+        prepared_ui->GetRecordingState() ==
+            UiFrameGraphPass::ERecordingState::Prepared) {
+        try {
+            linear_ui_recorded = UiFrameGraphPass::ProcessLinear(
+                cmd_list,
+                *ui_combine_pass,
+                prepared_ui,
+                final_color,
+                state.output
+            );
+        } catch (const std::exception& exception) {
+            // UI recording is part of the frame transaction. Discard every
+            // caller-owned command already recorded into this tail rather
+            // than submitting a partially composed/potentially replayed
+            // packet.
+            static_cast<void>(cmd_list.Submit());
+            prepared_ui->Abandon();
+            graph_recording_failed                       = true;
+            state.render_graph_fallback_latched          = true;
+            state.render_graph_recording_failure_latched = true;
+            LOG_CRITICAL(
+                "[RenderGraph][UI] Linear copied-frame recording failed: {}. "
+                "Discarding the frame tail and preserving the last accepted "
+                "presentation.",
+                exception.what()
+            );
+        } catch (...) {
+            static_cast<void>(cmd_list.Submit());
+            prepared_ui->Abandon();
+            graph_recording_failed                       = true;
+            state.render_graph_fallback_latched          = true;
+            state.render_graph_recording_failure_latched = true;
+            LOG_CRITICAL(
+                "[RenderGraph][UI] Linear copied-frame recording failed. "
+                "Discarding the frame tail and preserving the last accepted "
+                "presentation."
+            );
+        }
     }
-
-    const auto ui_execution_thread =
-        IsCurrentlyRenderThread() ? EUiDrawExecutionThread::Render : EUiDrawExecutionThread::Game;
-    RenderUiDrawFrame(cmd_list, state.output->GetView(), frame_packet.ui_draw_frame, ui_execution_thread);
 
     time++;
     CmdSubmit frame_submit =
@@ -1414,7 +1470,7 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
                 output_view.extent.y,
                 swapchain->size.x,
                 swapchain->size.y,
-                frame_packet.ui_draw_frame.platform_viewports.size()
+                prepared_ui->GetDrawFrame().platform_viewports.size()
             );
         }
         if (output_view.extent.x == swapchain->size.x && output_view.extent.y == swapchain->size.y) {
@@ -1439,17 +1495,60 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
         ERHIExecSubmitFlags::FlushGPU,
         present_request ? &*present_request : nullptr
     );
-    bool frame_native_accepted = true;
+    // Accepted renderer state follows native queue publication, not CPU
+    // recording completion. The final tail proves the ordered suffix was
+    // accepted; the per-source graph fence prevents an accepted tail from
+    // hiding a rejected managed source.
+    bool frame_native_accepted = timeline->WaitSubmitted(time);
+    if (graph_submission_fence) {
+        for (uint64 value = 1; value <= graph_submission_value_count; ++value) {
+            const bool source_accepted =
+                graph_submission_fence->WaitSubmitted(value);
+            frame_native_accepted =
+                source_accepted && frame_native_accepted;
+        }
+    }
+
+    bool ui_source_accepted = false;
+    if (graph_ui_recorded && ui_graph_submission_fence) {
+        ui_source_accepted =
+            ui_graph_submission_fence->WaitSubmitted(1);
+    } else if (linear_ui_recorded) {
+        // Linear UI work lives in the final tail itself.
+        ui_source_accepted = timeline->WaitSubmitted(time);
+    }
+    bool ui_recording_committed = false;
+    if (prepared_ui->GetRecordingState() ==
+        UiFrameGraphPass::ERecordingState::Recorded) {
+        if (ui_source_accepted) {
+            ui_recording_committed =
+                prepared_ui->CommitAcceptedSource();
+        } else {
+            prepared_ui->RejectSource();
+        }
+    } else if (prepared_ui->GetRecordingState() ==
+                   UiFrameGraphPass::ERecordingState::SourceAccepted ||
+               prepared_ui->GetRecordingState() ==
+                   UiFrameGraphPass::ERecordingState::FrameAccepted) {
+        ui_recording_committed = true;
+    } else {
+        prepared_ui->RejectSource();
+    }
+    frame_native_accepted =
+        frame_native_accepted && ui_recording_committed;
 #if WITH_NRD
     if (nrd_recorded && prepared_nrd) {
-        frame_native_accepted =
+        const bool nrd_submission_accepted =
+            frame_native_accepted &&
             NrdDenoisePass::CommitAcceptedSubmission(
                 *prepared_nrd,
                 timeline,
                 time,
                 nrd_graph_submission_value_count
             );
-        if (frame_native_accepted) {
+        frame_native_accepted =
+            frame_native_accepted && nrd_submission_accepted;
+        if (nrd_submission_accepted) {
             ++state.nrd_time;
             state.nrd_outputs_initialized = true;
         } else {
@@ -1471,6 +1570,20 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
         }
     }
 #endif
+    if (frame_native_accepted) {
+        frame_native_accepted =
+            prepared_ui->CommitAcceptedFrame();
+    }
+    if (!frame_native_accepted) {
+        state.render_graph_fallback_latched          = true;
+        state.render_graph_recording_failure_latched = true;
+        LOG_CRITICAL(
+            "[RenderGraph][Raytracing] Native submission rejected the final "
+            "tail, a managed graph source, or the copied UI source. "
+            "Preserving accepted renderer history and disabling managed "
+            "recording for this renderer instance."
+        );
+    }
     const bool frame_setup_accepted =
         frame_native_accepted &&
         (frame_setup_graph_recorded || frame_setup_linear_recorded);
@@ -1541,8 +1654,11 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
         state.rt_scene->AdvanceFrame();
         std::swap(state.current_tlas_revision, state.previous_tlas_revision);
     }
-    if (!skip_present && frame_native_accepted) {
-        PresentUiDrawFrame(frame_packet.ui_draw_frame, ui_execution_thread);
+    if (!skip_present && frame_native_accepted && prepared_ui->CanPresent()) {
+        PresentUiDrawFrame(
+            prepared_ui->GetDrawFrame(),
+            ui_execution_thread
+        );
     }
 
     feedback.profiler_data             = gfx_queue.GetProfilerEntry();
@@ -1746,13 +1862,9 @@ void RaytracingRenderer::RecreateFrameResources(uint2 new_extent) {
         "output",
         Extent2D(new_extent.x, new_extent.y),
         swapchain->format,
-        ETextureUsageFlags::COLOR_ATTACHMENT
-    );
-    state.ui_frame_buffer = device.CreateTexture(
-        "ui_frame_buffer",
-        Extent2D(new_extent.x, new_extent.y),
-        PF_R8G8B8A8_SRGB,
-        ETextureUsageFlags::COLOR_ATTACHMENT | ETextureUsageFlags::SAMPLED
+        ETextureUsageFlags::COLOR_ATTACHMENT |
+            ETextureUsageFlags::TRANSFER_SRC |
+            ETextureUsageFlags::TRANSFER_DST
     );
 
     if (state.render_graph_recording_failure_latched) {

--- a/source/runtime/render/renderer/raytracing/RaytracingRenderer.cpp
+++ b/source/runtime/render/renderer/raytracing/RaytracingRenderer.cpp
@@ -177,6 +177,88 @@ void TickAndLogProfiling(const RaytracingFrameFeedback& feedback) {
     LOG_INFO("{}", stream.str());
 }
 
+void RecordGpuSceneReadBoundary(
+    CommandList&         cmd_list,
+    const GpuScene::Res& resources
+) {
+    Array<ReadBuffer>    buffer_reads;
+    Array<const Buffer*> seen_buffers;
+    const auto append_buffer = [&](const BufferWithHandle& resource) {
+        if (!resource.buf ||
+            std::find(
+                seen_buffers.begin(),
+                seen_buffers.end(),
+                resource.buf.Get()
+            ) != seen_buffers.end()) {
+            return;
+        }
+        seen_buffers.emplace_back(resource.buf.Get());
+        buffer_reads.emplace_back(
+            ReadBuffer{
+                resource.buf->GetView(),
+                EBufferState::SHADER_RESOURCE
+            }
+        );
+    };
+    for (const BufferWithHandle* resource : {
+             &resources.light_buf,
+             &resources.material_buf,
+             &resources.primitive_buf,
+             &resources.instance_buf,
+             &resources.position_buf,
+             &resources.packed_normal_buf,
+             &resources.packed_tangent_buf,
+             &resources.texcoord0_buf,
+             &resources.index_buf,
+             &resources.rt_instance_buf,
+             &resources.rt_primitive_table_buf,
+         }) {
+        append_buffer(*resource);
+    }
+    if (!buffer_reads.empty()) {
+        cmd_list.BufferBarriers(
+            EQueueType::Graphics,
+            EQueueType::Graphics,
+            EPassType::Compute,
+            std::move(buffer_reads),
+            Array<WriteBuffer>{}
+        );
+    }
+
+    Array<ReadTexture>    texture_reads;
+    Array<const Texture*> seen_textures;
+    for (const TextureWithHandle& resource : resources.texture_array) {
+        if (!resource.tex ||
+            std::find(
+                seen_textures.begin(),
+                seen_textures.end(),
+                resource.tex.Get()
+            ) != seen_textures.end()) {
+            continue;
+        }
+        seen_textures.emplace_back(resource.tex.Get());
+        const auto usage = resource.tex->GetUsage();
+        const bool supports_uav =
+            (usage & ETextureUsageFlags::UNORDERED_ACCESS) ==
+            ETextureUsageFlags::UNORDERED_ACCESS;
+        texture_reads.emplace_back(
+            ReadTexture{
+                resource.tex->GetView(0, resource.tex->GetNumMips()),
+                supports_uav ? ETextureState::SHADER_RESOURCE :
+                               ETextureState::SAMPLE
+            }
+        );
+    }
+    if (!texture_reads.empty()) {
+        cmd_list.TextureBarriers(
+            EQueueType::Graphics,
+            EQueueType::Graphics,
+            EPassType::Compute,
+            std::move(texture_reads)
+        );
+    }
+}
+
 void ExecuteSceneUpdate(
     RenderScene&     render_scene,
     GpuSceneUpdate&& update,
@@ -186,6 +268,14 @@ void ExecuteSceneUpdate(
     (void)gfx_queue;
     (void)device;
     auto                                  scene_cmd_list = render_scene.ApplyUpdate(std::move(update));
+    // GpuScene uploads may finish as transfer writes while untouched aliases
+    // retain their previous read state. Publish one deterministic SRV/Sampled
+    // boundary on the same graphics stream so the following managed RT graph
+    // never has to guess per-resource backend state.
+    RecordGpuSceneReadBoundary(
+        scene_cmd_list.gfx_queue_cmd_list,
+        render_scene.GetGpuSceneRes()
+    );
     Array<RHIBackendSubmissionBatchEntry> submissions{};
     submissions.emplace_back(EQueueType::Copy, scene_cmd_list.copy_queue_cmd_list.Submit());
     submissions.emplace_back(
@@ -554,7 +644,6 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
     LightingPass::LocalLightSamplingDecision         local_light_sampling{};
     std::optional<PrepareLightPass::PreparedCommand> prepared_lights{};
     std::optional<RaytracingFrameSetupPass::PreparedCommand> prepared_frame_setup{};
-    SharedPtr<const RaytracingFrameSetupPass::AcceptedSnapshot> accepted_frame_setup{};
     TextureRef                                       selected_debug_texture{};
     bool                                             show_texture_requested = false;
     ShowTextureParams                                show_texture_params{};
@@ -582,13 +671,20 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
     feedback.frame_id                = frame_packet.frame_id;
     feedback.export_request_finished = ui_config.export_cfg.b_export;
 
-    if (frame_packet.scene_updates.scene_ready && frame_packet.runtime_assets_ready) {
-        const bool render_graph_boundary_frame = state.first_load || state.b_new_env_map ||
-                                                 frame_packet.window.state == EWindowState::SizeChanged ||
-                                                 ui_config.export_cfg.b_export;
+    if (frame_packet.scene_updates.scene_ready && frame_packet.runtime_assets_ready &&
+        !graph_recording_failed) {
+        bool render_graph_boundary_frame = state.first_load || state.b_new_env_map ||
+                                           frame_packet.window.state == EWindowState::SizeChanged ||
+                                           ui_config.export_cfg.b_export;
         const bool nrd_active_this_frame = IsNrdDenoiserActive(ui_config.denoiser_cfg.denoiser_type);
         const SceneUpdateResult scene_update =
             ExecuteSceneUpdates(frame_packet.scene_updates);
+        // Scene updates publish and drain a deterministic SRV/Sampled boundary
+        // before returning. FrameSetup captures those refreshed identities and
+        // normalizes only the external ASWrite TLAS inside the managed graph,
+        // matching dev_parallel_rhi for dynamic-scene frames.
+        render_graph_boundary_frame =
+            render_graph_boundary_frame || scene_update.rt_scene_replaced;
 
         if (state.first_load) {
             state.first_load    = false;
@@ -614,14 +710,32 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
                 }
             }
 
-            RefreshSceneRuntimeRefs();
+            (void)RefreshSceneRuntimeRefs();
             state.rt_ctx->FillLowDiscrepancySequence(cmd_list);
             cmd_list.UpdateBindlessArray(bindless_array);
             RHIExecutor::Get().Submit(EQueueType::Graphics, cmd_list.Submit(), ERHIExecSubmitFlags::FlushGPU);
             RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
         }
 
-        ScopedGpuMarker renderer_marker(cmd_list, "Raytracing Renderer", GpuMarkerPalette::Renderer());
+        std::optional<ScopedGpuMarker> renderer_marker{};
+        const auto ensure_renderer_marker = [&]() {
+            if (!renderer_marker) {
+                renderer_marker.emplace(
+                    cmd_list,
+                    "Raytracing Renderer",
+                    GpuMarkerPalette::Renderer()
+                );
+            }
+        };
+        if (render_graph_boundary_frame || !state.render_graph_enabled ||
+            state.render_graph_fallback_latched) {
+            ensure_renderer_marker();
+        }
+        const auto close_renderer_marker = [&]() {
+            if (renderer_marker) {
+                renderer_marker->Close();
+            }
+        };
 
         if (state.b_new_env_map) {
             ScopedGpuMarker environment_marker(cmd_list, "Pass: Environment Setup", GpuMarkerPalette::Pass());
@@ -801,142 +915,39 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
             ));
         }
 
-        const bool frame_setup_graph_eligible =
+        const bool unified_graph_eligible =
             prepared_frame_setup && state.render_graph_enabled &&
-            !state.render_graph_fallback_latched && !render_graph_boundary_frame;
-        if (frame_setup_graph_eligible) {
-            RenderGraph setup_graph("Raytracing.FrameSetup");
-            const bool setup_passes_added =
-                state.frame_setup_pass->AddPasses(setup_graph, *prepared_frame_setup);
-            if (!setup_passes_added) {
-                state.render_graph_fallback_latched = true;
-                LOG_ERROR(
-                    "[RenderGraph][Fallback] Raytracing FrameSetup could not import "
-                    "Bindless/scene/TLAS resources. Using the linear path for this "
-                    "renderer instance."
-                );
-            } else if (!setup_graph.Compile()) {
-                state.render_graph_fallback_latched = true;
-                LOG_ERROR(
-                    "[RenderGraph][Fallback] Raytracing FrameSetup compile failed "
-                    "before execution: {}. Using the linear path for this renderer "
-                    "instance.",
-                    setup_graph.GetCompileError()
-                );
-            } else {
-                if (state.render_graph_debug_dump) {
-                    std::string dump = setup_graph.Dump();
-                    if (state.logged_render_graph_dumps.emplace(dump).second) {
-                        LOG_INFO("[RenderGraph][Raytracing][DebugDump]\n{}", dump);
-                    }
-                }
-
-                // FrameSetup and the primary graph are independent accepted
-                // transactions. Publishing the caller-owned prefix first and
-                // then both graph source sets on Graphics preserves the real
-                // cross-graph dependency through Executor handoff/FIFO.
-                renderer_marker.Close();
-                if (!cmd_list.IsEmpty()) {
-                    CmdSubmit prefix_submit = cmd_list.Submit().DebugLabel(
-                        std::format(
-                            "Raytracing Frame {}/FrameSetup Prefix",
-                            frame_packet.frame_id
-                        ),
-                        GpuMarkerPalette::Renderer()
-                    );
-                    prefix_submit.SetProfilingPhase(
-                        split_graph_profiling_frame ?
-                            ERHIProfilingPhase::Continue :
-                            ERHIProfilingPhase::Begin
-                    );
-                    split_graph_profiling_frame = true;
-                    RHIExecutor::Get().Submit(
-                        EQueueType::Graphics,
-                        std::move(prefix_submit),
-                        ERHIExecSubmitFlags::None
-                    );
-                }
-
-                bool setup_profiling_started = split_graph_profiling_frame;
-                const auto configure_setup_source =
-                    [&](const RenderGraph::ExecutedPassInfo& pass,
-                        RHIRecordingSource&                  source) {
-                        source.submit_metadata.debug_label = std::format(
-                            "Raytracing Frame {}/{}",
-                            frame_packet.frame_id,
-                            pass.name
-                        );
-                        source.submit_metadata.debug_label_color =
-                            GpuMarkerPalette::Pass();
-                        source.submit_metadata.profiling_phase =
-                            setup_profiling_started ?
-                                ERHIProfilingPhase::Continue :
-                                ERHIProfilingPhase::Begin;
-                        setup_profiling_started = true;
-                    };
-                if (setup_graph.ExecuteRecording(
-                        {},
-                        configure_setup_source,
-                        false,
-                        {},
-                        RenderGraph::ActiveRecordingOptions{.enabled = true}
-                    )) {
-                    split_graph_profiling_frame = setup_profiling_started;
-                    frame_setup_graph_recorded  = true;
-                    auto snapshot =
-                        state.frame_setup_pass->CommitAccepted(*prepared_frame_setup);
-                    accepted_frame_setup =
-                        MakeShared<RaytracingFrameSetupPass::AcceptedSnapshot>(
-                            std::move(snapshot)
-                        );
-                    if (prepared_frame_setup->BuildsTlas()) {
-                        state.current_tlas_revision = state.rt_instance_revision;
-                        ++state.renderer_tlas_build_count;
-                    } else {
-                        ++state.renderer_tlas_skip_count;
-                    }
-                } else {
-                    RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
-                    graph_recording_failed                       = true;
-                    state.render_graph_fallback_latched          = true;
-                    state.render_graph_recording_failure_latched = true;
-                    LOG_ERROR(
-                        "[RenderGraph][Fallback] Raytracing FrameSetup recording "
-                        "failed before transaction commit: {}. Preserving the last "
-                        "accepted output and disabling managed renderer passes until "
-                        "this renderer instance is recreated.",
-                        setup_graph.GetCompileError()
-                    );
-                }
-            }
-        }
-        if (!graph_recording_failed && prepared_frame_setup &&
-            !frame_setup_graph_recorded) {
-            frame_setup_linear_recorded =
-                state.frame_setup_pass->ProcessLinear(cmd_list, *prepared_frame_setup);
-            if (!frame_setup_linear_recorded) {
-                graph_recording_failed              = true;
-                state.render_graph_fallback_latched = true;
-                LOG_ERROR(
-                    "[RenderGraph][Fallback] Raytracing linear FrameSetup has no "
-                    "valid TLAS destination. Preserving the last accepted output."
-                );
-            }
-        }
-
-        if (frame_setup_graph_recorded && accepted_frame_setup &&
-            state.render_graph_enabled && !state.render_graph_fallback_latched &&
+            !state.render_graph_fallback_latched &&
             state.gbuffer_initialized_history_mask == uint8(0b11) &&
             state.lighting_initialized_reservoir_mask == uint8(0b111) &&
             (nrd_active_this_frame || state.antialias_pass->IsHistoryReadyForGraph()) &&
-            !render_graph_boundary_frame) {
-            RenderGraph graph(nrd_active_this_frame ? "Raytracing.PreDenoise" : "Raytracing.FrameCore");
+            !render_graph_boundary_frame;
+
+        if (unified_graph_eligible) {
+            RenderGraph graph(
+                nrd_active_this_frame ?
+                    "Raytracing.PreDenoise" :
+                    "Raytracing.Frame"
+            );
+            RTGraphFrameSetupResources setup_resources{};
+            const bool setup_passes_added = state.frame_setup_pass->AddPasses(
+                graph,
+                *prepared_frame_setup,
+                setup_resources
+            );
             const RTGraphFrameResources graph_resources =
-                RegisterRTGraphFrameResources(graph, *state.rt_ctx, accepted_frame_setup);
-            const bool prepare_lights_added = state.prepare_light_pass->AddPasses(
+                setup_passes_added ?
+                    RegisterRTGraphFrameResources(
+                        graph,
+                        *state.rt_ctx,
+                        setup_resources
+                    ) :
+                    RTGraphFrameResources{};
+            const bool prepare_lights_added =
+                setup_passes_added && state.prepare_light_pass->AddPasses(
                 graph,
                 *prepared_lights,
-                graph_resources.frame_setup.ready
+                setup_resources
             );
             const bool gbuffer_added        = prepare_lights_added && state.g_buffer_pass->AddPasses(
                                                                    graph,
@@ -1005,9 +1016,10 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
             if (graph_passes_added && IsRenderGraphRecordingFailureInjected()) {
                 graph.AddRecordPass(
                     "RT.FaultInjection.RecordingFailure",
-                    [](RenderGraph::PassBuilder& builder) {
+                    [finalize = setup_resources.finalize](RenderGraph::PassBuilder& builder) {
                         builder
                             .ExecuteOn(RenderGraph::QueueRole::Graphics, RenderGraph::PipelineType::Compute)
+                            .DependsOn(finalize)
                             .SideEffect();
                     },
                     [](CommandList&) {
@@ -1021,15 +1033,17 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
             }
             if (!graph_passes_added) {
                 state.render_graph_fallback_latched = true;
-                LOG_ERROR("[RenderGraph][Fallback] Raytracing primary graph could not "
-                          "import a required PrepareLights/GBuffer/Lighting/"
+                ensure_renderer_marker();
+                LOG_ERROR("[RenderGraph][Fallback] Raytracing unified graph could not "
+                          "import a required FrameSetup/PrepareLights/GBuffer/Lighting/"
                           "Composition/AntiAlias/"
                           "ToneMapping/Visualize/ShowTexture resource. Using the linear "
                           "path for this renderer instance.");
             } else if (!graph.Compile()) {
                 state.render_graph_fallback_latched = true;
+                ensure_renderer_marker();
                 LOG_ERROR(
-                    "[RenderGraph][Fallback] Raytracing primary graph compile "
+                    "[RenderGraph][Fallback] Raytracing unified graph compile "
                     "failed before execution: {}. Using the linear path for "
                     "this renderer instance.",
                     graph.GetCompileError()
@@ -1042,13 +1056,11 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
                     }
                 }
 
-                // The existing single-queue success path intentionally keeps
-                // Prefix as a normal ordered submit. If managed recording later
-                // fails, no dependent renderer pass is recorded or submitted:
-                // the renderer presents its last accepted output until it is
-                // recreated, so the accepted Prefix has no same-frame legacy
-                // consumer that would require a missing visibility bridge.
-                renderer_marker.Close();
+                // The unified graph is the first managed transaction on a
+                // steady-state frame. Boundary work normally makes the graph
+                // ineligible, so this prefix is only a defensive ordered
+                // submission for an unexpected caller-side command.
+                close_renderer_marker();
                 if (!cmd_list.IsEmpty()) {
                     CmdSubmit prefix_submit = cmd_list.Submit().DebugLabel(
                         std::format("Raytracing Frame {}/Graph Prefix", frame_packet.frame_id),
@@ -1082,6 +1094,7 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
                         RenderGraph::ActiveRecordingOptions{.enabled = true}
                     )) {
                     split_graph_profiling_frame = graph_recording_profiling_started;
+                    frame_setup_graph_recorded  = true;
                     graph_primary_recorded      = true;
                     graph_composition_recorded  = composition_in_graph;
                     graph_antialias_recorded    = antialias_in_graph;
@@ -1098,7 +1111,7 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
                     state.render_graph_fallback_latched          = true;
                     state.render_graph_recording_failure_latched = true;
                     LOG_ERROR(
-                        "[RenderGraph][Fallback] Raytracing primary graph "
+                        "[RenderGraph][Fallback] Raytracing unified graph "
                         "recording failed before transaction commit: {}. "
                         "Preserving the last accepted output and disabling "
                         "managed renderer passes until this renderer instance "
@@ -1106,6 +1119,20 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
                         graph.GetCompileError()
                     );
                 }
+            }
+        }
+        if (!graph_recording_failed && prepared_frame_setup &&
+            !frame_setup_graph_recorded) {
+            frame_setup_linear_recorded =
+                state.frame_setup_pass->ProcessLinear(cmd_list, *prepared_frame_setup);
+            if (!frame_setup_linear_recorded) {
+                graph_recording_failed              = true;
+                state.render_graph_fallback_latched = true;
+                LOG_ERROR(
+                    "[RenderGraph][Fallback] Raytracing linear FrameSetup could not "
+                    "record a valid bindless/TLAS boundary. Skipping managed "
+                    "rendering for this frame; the linear path will retry next frame."
+                );
             }
         }
         if (!graph_recording_failed && !graph_primary_recorded) {
@@ -1229,12 +1256,8 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
             );
         }
 
-        if (!graph_recording_failed) {
-            state.rt_ctx->AdvanceFrame();
-        }
-
         if (state.b_export) {
-            renderer_marker.Close();
+            close_renderer_marker();
             RHIExecutor::Get().Submit(
                 EQueueType::Graphics,
                 cmd_list.Submit()
@@ -1343,24 +1366,16 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
         ERHIExecSubmitFlags::FlushGPU,
         present_request ? &*present_request : nullptr
     );
-    if (frame_setup_linear_recorded && prepared_frame_setup) {
-        (void)state.frame_setup_pass->CommitAccepted(*prepared_frame_setup);
+    const bool frame_setup_accepted =
+        frame_setup_graph_recorded || frame_setup_linear_recorded;
+    if (frame_setup_accepted && prepared_frame_setup) {
+        state.frame_setup_pass->CommitAccepted(*prepared_frame_setup);
         if (prepared_frame_setup->BuildsTlas()) {
             state.current_tlas_revision = state.rt_instance_revision;
             ++state.renderer_tlas_build_count;
         } else {
             ++state.renderer_tlas_skip_count;
         }
-    }
-    if ((frame_setup_graph_recorded || frame_setup_linear_recorded) &&
-        state.rt_scene) {
-        // RaytracingScene is a ping-pong builder: the TLAS consumed by this
-        // accepted frame becomes GetPrevTlas(), while GetTlas() rotates to the
-        // slot that may need rebuilding next frame. Mirror that slot rotation
-        // in the revision pair instead of treating the names as immutable
-        // temporal roles.
-        state.rt_scene->AdvanceFrame();
-        std::swap(state.current_tlas_revision, state.previous_tlas_revision);
     }
     if (prepared_lights && (linear_lighting_recorded || graph_primary_recorded)) {
         state.prepare_light_pass->CommitAcceptedFrame(*state.rt_ctx, std::move(*prepared_lights));
@@ -1400,6 +1415,18 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
         state.normal_roughness_readable = true;
     } else if (linear_gbuffer_recorded) {
         state.normal_roughness_readable = nrd_recorded || linear_visualize_recorded;
+    }
+    if (frame_setup_accepted) {
+        state.rt_ctx->AdvanceFrame();
+    }
+    if (frame_setup_accepted && state.rt_scene) {
+        // RaytracingScene is a ping-pong builder: the TLAS consumed by this
+        // accepted frame becomes GetPrevTlas(), while GetTlas() rotates to the
+        // slot that may need rebuilding next frame. Mirror that slot rotation
+        // in the revision pair instead of treating the names as immutable
+        // temporal roles.
+        state.rt_scene->AdvanceFrame();
+        std::swap(state.current_tlas_revision, state.previous_tlas_revision);
     }
     if (!skip_present) {
         PresentUiDrawFrame(frame_packet.ui_draw_frame, ui_execution_thread);
@@ -1506,7 +1533,7 @@ void RaytracingRenderer::EnsureDebugUiRegistered(const EngineHooks& hooks) {
     debug_ui_registered = true;
 }
 
-void RaytracingRenderer::RefreshSceneRuntimeRefs() {
+bool RaytracingRenderer::RefreshSceneRuntimeRefs() {
     auto&       state            = *runtime_state;
     const auto& gpu_scene_res    = render_scene->GetGpuSceneRes();
     const bool  rt_scene_changed = state.rt_scene.Get() != gpu_scene_res.rt_scene.Get();
@@ -1539,11 +1566,19 @@ void RaytracingRenderer::RefreshSceneRuntimeRefs() {
     }
 
     if (rt_scene_changed) {
-        state.b_feedback_valid       = false;
-        state.current_tlas_revision  = RuntimeState::invalid_tlas_revision;
-        state.previous_tlas_revision = RuntimeState::invalid_tlas_revision;
+        state.b_feedback_valid                    = false;
+        state.current_tlas_revision               = RuntimeState::invalid_tlas_revision;
+        state.previous_tlas_revision              = RuntimeState::invalid_tlas_revision;
+        state.gbuffer_initialized_history_mask    = 0;
+        state.lighting_initialized_reservoir_mask = 0;
+        state.normal_roughness_readable           = false;
         state.frame_setup_pass->ResetAcceptedResources();
+        LOG_INFO(
+            "[RenderGraph][Raytracing] RT scene identity changed; resetting "
+            "FrameSetup acceptance and temporal graph warmup."
+        );
     }
+    return rt_scene_changed;
 }
 
 RaytracingRenderer::SceneUpdateResult RaytracingRenderer::ExecuteSceneUpdates(
@@ -1574,15 +1609,14 @@ RaytracingRenderer::SceneUpdateResult RaytracingRenderer::ExecuteSceneUpdates(
             ++state.scene_tlas_update_count;
         }
     }
-    if (updated) {
-        RefreshSceneRuntimeRefs();
-    }
+    const bool rt_scene_replaced = updated && RefreshSceneRuntimeRefs();
     if (rt_scene_updated && state.rt_scene) {
         state.current_tlas_revision = state.rt_instance_revision;
     }
     return SceneUpdateResult{
         .gpu_resources_updated = updated,
-        .tlas_built             = rt_scene_updated
+        .tlas_built             = rt_scene_updated,
+        .rt_scene_replaced      = rt_scene_replaced
     };
 }
 

--- a/source/runtime/render/renderer/raytracing/RaytracingRenderer.cpp
+++ b/source/runtime/render/renderer/raytracing/RaytracingRenderer.cpp
@@ -20,6 +20,7 @@
 #include "Configs.h"
 #include "GBufferPass.h"
 #include "LightingPass.h"
+#include "NrdDenoisePass.h"
 #include "PreprocessLightPass.h"
 #include "RaytracingFrameSetupPass.h"
 #include "RTResource.h"
@@ -176,6 +177,19 @@ void TickAndLogProfiling(const RaytracingFrameFeedback& feedback) {
            << " LocalLights=" << feedback.local_light_count;
     LOG_INFO("{}", stream.str());
 }
+
+#if WITH_NRD
+nrd::Denoiser ResolveNrdDenoiser(int denoiser_mode) {
+    switch (denoiser_mode) {
+        case s_denoiser_mode_reblur:
+            return nrd::Denoiser::REBLUR_DIFFUSE_SPECULAR;
+        case s_denoiser_mode_relax:
+            return nrd::Denoiser::RELAX_DIFFUSE_SPECULAR;
+        default:
+            return nrd::Denoiser::MAX_NUM;
+    }
+}
+#endif
 
 void RecordGpuSceneReadBoundary(
     CommandList&         cmd_list,
@@ -349,9 +363,12 @@ struct RaytracingRenderer::RuntimeState {
     UniquePtr<AntialiasPass>  antialias_pass;
 
 #if WITH_NRD
-    uint64                       nrd_time   = 0ull;
-    Ext::NRDPlugin*              nrd_plugin = nullptr;
-    UniquePtr<Ext::NRDInterface> nrd_interface;
+    uint64                        nrd_time       = 0ull;
+    int                           nrd_mode       = -1;
+    bool                          nrd_was_active = false;
+    bool                          nrd_outputs_initialized = false;
+    Ext::NRDPlugin*               nrd_plugin     = nullptr;
+    SharedPtr<Ext::NRDInterface>  nrd_interface;
 #endif
 
     VisualizeConfig visualize_config{};
@@ -626,6 +643,7 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
     bool  frame_setup_graph_recorded      = false;
     bool  frame_setup_linear_recorded     = false;
     bool  graph_primary_recorded          = false;
+    bool  graph_nrd_recorded              = false;
     bool  graph_composition_recorded      = false;
     bool  graph_antialias_recorded        = false;
     bool  graph_tone_mapping_recorded     = false;
@@ -644,6 +662,10 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
     LightingPass::LocalLightSamplingDecision         local_light_sampling{};
     std::optional<PrepareLightPass::PreparedCommand> prepared_lights{};
     std::optional<RaytracingFrameSetupPass::PreparedCommand> prepared_frame_setup{};
+#if WITH_NRD
+    std::optional<NrdDenoisePass::PreparedCommand>           prepared_nrd{};
+    uint64                                                   nrd_graph_submission_value_count = 0;
+#endif
     TextureRef                                       selected_debug_texture{};
     bool                                             show_texture_requested = false;
     ShowTextureParams                                show_texture_params{};
@@ -679,6 +701,30 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
         const bool nrd_active_this_frame = IsNrdDenoiserActive(ui_config.denoiser_cfg.denoiser_type);
         const SceneUpdateResult scene_update =
             ExecuteSceneUpdates(frame_packet.scene_updates);
+#if WITH_NRD
+        const int nrd_mode_this_frame =
+            ui_config.denoiser_cfg.denoiser_type;
+        if (nrd_active_this_frame) {
+            if (!state.nrd_was_active ||
+                state.nrd_mode != nrd_mode_this_frame) {
+                state.nrd_interface->ResetAcceptedHistory();
+                state.nrd_time = 0;
+                if (!state.nrd_outputs_initialized) {
+                    LOG_INFO(
+                        "[NRD] Warming denoised output state on the linear "
+                        "path before managed graph activation."
+                    );
+                }
+            }
+            state.nrd_was_active = true;
+            state.nrd_mode       = nrd_mode_this_frame;
+        } else if (state.nrd_was_active) {
+            state.nrd_interface->ResetAcceptedHistory();
+            state.nrd_time       = 0;
+            state.nrd_mode       = -1;
+            state.nrd_was_active = false;
+        }
+#endif
         // Scene updates publish and drain a deterministic SRV/Sampled boundary
         // before returning. FrameSetup captures those refreshed identities and
         // normalizes only the external ASWrite TLAS inside the managed graph,
@@ -914,28 +960,48 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
                 scene_update.tlas_built
             ));
         }
+#if WITH_NRD
+        if (!graph_recording_failed && nrd_active_this_frame) {
+            auto command = NrdDenoisePass::Prepare(
+                state.nrd_interface,
+                static_cast<uint32>(state.nrd_time),
+                Vector2ui(resolution.x, resolution.y),
+                state.antialias_pass->GetPixelOffset(),
+                Transpose(camera.GetViewMatrix()),
+                Transpose(camera.GetProjectionMatrix()),
+                ResolveNrdDenoiser(
+                    ui_config.denoiser_cfg.denoiser_type
+                ),
+                *state.rt_ctx
+            );
+            if (command.IsValid()) {
+                prepared_nrd.emplace(std::move(command));
+            }
+        }
+#endif
 
         const bool unified_graph_eligible =
             prepared_frame_setup && state.render_graph_enabled &&
             !state.render_graph_fallback_latched &&
             state.gbuffer_initialized_history_mask == uint8(0b11) &&
             state.lighting_initialized_reservoir_mask == uint8(0b111) &&
-            (nrd_active_this_frame || state.antialias_pass->IsHistoryReadyForGraph()) &&
+            state.antialias_pass->IsHistoryReadyForGraph() &&
+#if WITH_NRD
+            (!nrd_active_this_frame ||
+             (prepared_nrd.has_value() &&
+              state.nrd_outputs_initialized)) &&
+#endif
             !render_graph_boundary_frame;
 
         if (unified_graph_eligible) {
-            RenderGraph graph(
-                nrd_active_this_frame ?
-                    "Raytracing.PreDenoise" :
-                    "Raytracing.Frame"
-            );
+            RenderGraph graph("Raytracing.Frame");
             RTGraphFrameSetupResources setup_resources{};
             const bool setup_passes_added = state.frame_setup_pass->AddPasses(
                 graph,
                 *prepared_frame_setup,
                 setup_resources
             );
-            const RTGraphFrameResources graph_resources =
+            RTGraphFrameResources graph_resources =
                 setup_passes_added ?
                     RegisterRTGraphFrameResources(
                         graph,
@@ -963,13 +1029,30 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
                                                              true,
                                                              local_light_sampling
                                                          );
-            const bool composition_in_graph = !nrd_active_this_frame;
+            bool nrd_added = true;
+#if WITH_NRD
+            if (nrd_active_this_frame) {
+                nrd_added =
+                    lighting_added && prepared_nrd &&
+                    NrdDenoisePass::AddPasses(
+                        graph,
+                        graph_resources,
+                        *prepared_nrd,
+                        state.nrd_outputs_initialized
+                    );
+            }
+#endif
+            const bool composition_in_graph = true;
             const bool composition_added =
-                !composition_in_graph ||
-                (lighting_added && state.composition_pass->AddPasses(graph, graph_resources, *state.rt_ctx));
-            const bool antialias_in_graph = composition_in_graph;
+                lighting_added && nrd_added &&
+                state.composition_pass->AddPasses(
+                    graph,
+                    graph_resources,
+                    *state.rt_ctx
+                );
+            const bool antialias_in_graph = true;
             const bool antialias_added =
-                !antialias_in_graph || (composition_added && state.antialias_pass->AddPasses(
+                composition_added && state.antialias_pass->AddPasses(
                                                                  graph,
                                                                  graph_resources,
                                                                  *state.rt_ctx,
@@ -977,24 +1060,26 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
                                                                  state.b_feedback_valid,
                                                                  state.rt_ctx->frame_rt.hdr_color,
                                                                  state.rt_ctx->frame_rt.resolved_color
-                                                             ));
-            const bool tone_mapping_in_graph = antialias_in_graph;
+                                                             );
+            const bool tone_mapping_in_graph = true;
             const bool tone_mapping_added =
-                !tone_mapping_in_graph || (antialias_added && state.tone_mapping_pass->AddPasses(
+                antialias_added && state.tone_mapping_pass->AddPasses(
                                                                   graph,
                                                                   graph_resources,
                                                                   *state.rt_ctx,
                                                                   tone_params,
                                                                   state.rt_ctx->frame_rt.resolved_color,
                                                                   state.rt_ctx->frame_rt.ldr_color
-                                                              ));
-            const bool visualize_in_graph = tone_mapping_in_graph;
+                                                              );
+            const bool visualize_in_graph = true;
             const bool visualize_added =
-                !visualize_in_graph ||
-                (tone_mapping_added && state.visualize_pass->AddPasses(
-                                           graph, graph_resources, *state.rt_ctx, state.visualize_config
-                                       ));
-            const bool                 show_texture_in_graph = visualize_in_graph && show_texture_requested;
+                tone_mapping_added && state.visualize_pass->AddPasses(
+                    graph,
+                    graph_resources,
+                    *state.rt_ctx,
+                    state.visualize_config
+                );
+            const bool show_texture_in_graph = show_texture_requested;
             RenderGraph::TextureHandle selected_graph_texture{};
             if (show_texture_in_graph) {
                 selected_graph_texture =
@@ -1011,15 +1096,20 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
                                                                   graph_resources.frame_setup.ready
                                                               ));
             const bool graph_passes_added = prepare_lights_added && gbuffer_added && lighting_added &&
-                                            composition_added && antialias_added && tone_mapping_added &&
+                                            nrd_added && composition_added && antialias_added &&
+                                            tone_mapping_added &&
                                             visualize_added && show_texture_added;
             if (graph_passes_added && IsRenderGraphRecordingFailureInjected()) {
+                const RenderGraph::PassHandle fault_dependency =
+                    graph_resources.nrd_pass.IsValid() ?
+                        graph_resources.nrd_pass :
+                        setup_resources.finalize;
                 graph.AddRecordPass(
                     "RT.FaultInjection.RecordingFailure",
-                    [finalize = setup_resources.finalize](RenderGraph::PassBuilder& builder) {
+                    [fault_dependency](RenderGraph::PassBuilder& builder) {
                         builder
                             .ExecuteOn(RenderGraph::QueueRole::Graphics, RenderGraph::PipelineType::Compute)
-                            .DependsOn(finalize)
+                            .DependsOn(fault_dependency)
                             .SideEffect();
                     },
                     [](CommandList&) {
@@ -1036,7 +1126,7 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
                 ensure_renderer_marker();
                 LOG_ERROR("[RenderGraph][Fallback] Raytracing unified graph could not "
                           "import a required FrameSetup/PrepareLights/GBuffer/Lighting/"
-                          "Composition/AntiAlias/"
+                          "NRD/Composition/AntiAlias/"
                           "ToneMapping/Visualize/ShowTexture resource. Using the linear "
                           "path for this renderer instance.");
             } else if (!graph.Compile()) {
@@ -1085,6 +1175,18 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
                                                                           ERHIProfilingPhase::Continue :
                                                                           ERHIProfilingPhase::Begin;
                     graph_recording_profiling_started        = true;
+#if WITH_NRD
+                    if (nrd_active_this_frame && prepared_nrd) {
+                        source.submit_metadata.signal_fences.emplace_back(
+                            RHIRecordingFencePoint{
+                                .fence =
+                                    prepared_nrd->graph_submission_fence,
+                                .value =
+                                    ++nrd_graph_submission_value_count,
+                            }
+                        );
+                    }
+#endif
                 };
                 if (graph.ExecuteRecording(
                         {},
@@ -1096,6 +1198,10 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
                     split_graph_profiling_frame = graph_recording_profiling_started;
                     frame_setup_graph_recorded  = true;
                     graph_primary_recorded      = true;
+#if WITH_NRD
+                    graph_nrd_recorded          =
+                        nrd_active_this_frame && nrd_added;
+#endif
                     graph_composition_recorded  = composition_in_graph;
                     graph_antialias_recorded    = antialias_in_graph;
                     graph_tone_mapping_recorded = tone_mapping_in_graph;
@@ -1168,55 +1274,22 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
         feedback.local_light_count                     = local_light_sampling.local_light_count;
 
 #if WITH_NRD
-        if (!graph_recording_failed) {
-            const bool    b_current_frame = state.rt_ctx->b_current_frame;
-            const auto&   frame_rt        = state.rt_ctx->frame_rt;
-            nrd::Denoiser denoiser        = nrd::Denoiser::MAX_NUM;
-            switch (ui_config.denoiser_cfg.denoiser_type) {
-                case s_denoiser_mode_reblur:
-                    denoiser = nrd::Denoiser::REBLUR_DIFFUSE_SPECULAR;
-                    break;
-                case s_denoiser_mode_relax:
-                    denoiser = nrd::Denoiser::RELAX_DIFFUSE_SPECULAR;
-                    break;
-            }
-
-            if (denoiser != nrd::Denoiser::MAX_NUM) {
+        if (!graph_recording_failed && nrd_active_this_frame) {
+            if (graph_nrd_recorded) {
+                nrd_recorded = true;
+            } else if (prepared_nrd) {
                 ScopedGpuMarker denoiser_marker(
                     cmd_list, "Pass: Radiance Denoising", GpuMarkerPalette::Pass()
                 );
-                state.nrd_interface->Begin();
-                state.nrd_interface->UpdateCommonSettings(
-                    state.nrd_time++,
-                    Vector2ui(resolution.x, resolution.y),
-                    state.antialias_pass->GetPixelOffset(),
-                    Transpose(camera.GetViewMatrix()),
-                    Transpose(camera.GetProjectionMatrix())
-                );
-                state.nrd_interface->SetInput(
-                    Ext::NRDInterface::EResourceSlot::MOTION_VECTOR, state.rt_ctx->frame_rt.motion
-                );
-                state.nrd_interface->SetInput(
-                    Ext::NRDInterface::EResourceSlot::NORMAL_ROUGHNESS, frame_rt.normal_roughness
-                );
-                state.nrd_interface->SetInput(
-                    Ext::NRDInterface::EResourceSlot::VIEW_Z,
-                    b_current_frame ? frame_rt.view_depth : frame_rt.prev_view_depth
-                );
-                state.nrd_interface->SetInput(
-                    Ext::NRDInterface::EResourceSlot::IN_DIFFUSE, frame_rt.diffuse_lighting
-                );
-                state.nrd_interface->SetInput(
-                    Ext::NRDInterface::EResourceSlot::IN_SPECULAR, frame_rt.specular_lighting
-                );
-                state.nrd_interface->SetOutput(
-                    Ext::NRDInterface::EResourceSlot::OUT_DIFFUSE, frame_rt.denoised_diffuse_lighting
-                );
-                state.nrd_interface->SetOutput(
-                    Ext::NRDInterface::EResourceSlot::OUT_SPECULAR, frame_rt.denoised_specular_lighting
-                );
-                state.nrd_interface->Denoise(cmd_list, denoiser, "Radiance Denoising");
+                NrdDenoisePass::Process(cmd_list, *prepared_nrd);
                 nrd_recorded = true;
+            } else {
+                graph_recording_failed              = true;
+                state.render_graph_fallback_latched = true;
+                LOG_ERROR(
+                    "[NRD] Failed to prepare an immutable denoise frame. "
+                    "Preserving the last accepted output."
+                );
             }
         }
 #endif
@@ -1366,8 +1439,41 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
         ERHIExecSubmitFlags::FlushGPU,
         present_request ? &*present_request : nullptr
     );
+    bool frame_native_accepted = true;
+#if WITH_NRD
+    if (nrd_recorded && prepared_nrd) {
+        frame_native_accepted =
+            NrdDenoisePass::CommitAcceptedSubmission(
+                *prepared_nrd,
+                timeline,
+                time,
+                nrd_graph_submission_value_count
+            );
+        if (frame_native_accepted) {
+            ++state.nrd_time;
+            state.nrd_outputs_initialized = true;
+        } else {
+            // NRD NewFrame/Denoise may already have translated before a later
+            // graph source or the final tail was rejected. Renderer temporal
+            // state must not pretend that partial frame was accepted; force
+            // the next linear frame to CLEAR_AND_RESTART.
+            prepared_nrd->interface->ResetAcceptedHistory();
+            state.nrd_time                = 0;
+            state.nrd_outputs_initialized = false;
+            state.render_graph_fallback_latched          = true;
+            state.render_graph_recording_failure_latched = true;
+            LOG_CRITICAL(
+                "[NRD] Native submission rejected the NRD source or final "
+                "frame tail, or the immutable temporal snapshot could not "
+                "commit; disabling managed RT passes for this renderer "
+                "instance without advancing NRD history."
+            );
+        }
+    }
+#endif
     const bool frame_setup_accepted =
-        frame_setup_graph_recorded || frame_setup_linear_recorded;
+        frame_native_accepted &&
+        (frame_setup_graph_recorded || frame_setup_linear_recorded);
     if (frame_setup_accepted && prepared_frame_setup) {
         state.frame_setup_pass->CommitAccepted(*prepared_frame_setup);
         if (prepared_frame_setup->BuildsTlas()) {
@@ -1377,22 +1483,26 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
             ++state.renderer_tlas_skip_count;
         }
     }
-    if (prepared_lights && (linear_lighting_recorded || graph_primary_recorded)) {
+    if (frame_native_accepted && prepared_lights &&
+        (linear_lighting_recorded || graph_primary_recorded)) {
         state.prepare_light_pass->CommitAcceptedFrame(*state.rt_ctx, std::move(*prepared_lights));
     }
-    if (linear_antialias_recorded || graph_antialias_recorded) {
+    if (frame_native_accepted &&
+        (linear_antialias_recorded || graph_antialias_recorded)) {
         state.antialias_pass->CommitAcceptedFrame();
         state.b_feedback_valid = true;
     }
-    if (linear_tone_mapping_recorded || graph_tone_mapping_recorded) {
+    if (frame_native_accepted &&
+        (linear_tone_mapping_recorded || graph_tone_mapping_recorded)) {
         state.tone_mapping_pass->CommitAcceptedFrame(
             tone_mapping_elapsed_for_commit, tone_mapping_enabled_for_commit
         );
     }
-    if (linear_gbuffer_recorded || graph_primary_recorded) {
+    if (frame_native_accepted &&
+        (linear_gbuffer_recorded || graph_primary_recorded)) {
         state.gbuffer_initialized_history_mask |= gbuffer_history_bit;
     }
-    if (linear_lighting_recorded) {
+    if (frame_native_accepted && linear_lighting_recorded) {
         const uint8 previous_reservoir_mask = state.lighting_initialized_reservoir_mask;
         const auto& buffer_indices          = state.rt_ctx->is_ctx.GetReSTIRDIBufferIndices();
         for (const uint reservoir_slice : {
@@ -1411,10 +1521,13 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
                      "both GBuffer history pings are initialized.");
         }
     }
-    if (graph_primary_recorded) {
-        state.normal_roughness_readable = true;
-    } else if (linear_gbuffer_recorded) {
-        state.normal_roughness_readable = nrd_recorded || linear_visualize_recorded;
+    if (frame_native_accepted) {
+        if (graph_primary_recorded) {
+            state.normal_roughness_readable = true;
+        } else if (linear_gbuffer_recorded) {
+            state.normal_roughness_readable =
+                nrd_recorded || linear_visualize_recorded;
+        }
     }
     if (frame_setup_accepted) {
         state.rt_ctx->AdvanceFrame();
@@ -1428,7 +1541,7 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
         state.rt_scene->AdvanceFrame();
         std::swap(state.current_tlas_revision, state.previous_tlas_revision);
     }
-    if (!skip_present) {
+    if (!skip_present && frame_native_accepted) {
         PresentUiDrawFrame(frame_packet.ui_draw_frame, ui_execution_thread);
     }
 
@@ -1573,6 +1686,12 @@ bool RaytracingRenderer::RefreshSceneRuntimeRefs() {
         state.lighting_initialized_reservoir_mask = 0;
         state.normal_roughness_readable           = false;
         state.frame_setup_pass->ResetAcceptedResources();
+#if WITH_NRD
+        if (state.nrd_interface) {
+            state.nrd_interface->ResetAcceptedHistory();
+            state.nrd_time = 0;
+        }
+#endif
         LOG_INFO(
             "[RenderGraph][Raytracing] RT scene identity changed; resetting "
             "FrameSetup acceptance and temporal graph warmup."
@@ -1655,6 +1774,10 @@ void RaytracingRenderer::RecreateFrameResources(uint2 new_extent) {
 #if WITH_NRD
     state.nrd_interface =
         state.nrd_plugin->RecreateInterface(std::move(state.nrd_interface), new_extent.x, new_extent.y);
+    state.nrd_time       = 0;
+    state.nrd_mode       = -1;
+    state.nrd_was_active = false;
+    state.nrd_outputs_initialized = false;
 #endif
 
     state.antialias_pass_info.motion              = state.rt_ctx->frame_rt.motion;

--- a/source/runtime/render/renderer/raytracing/RaytracingRenderer.cpp
+++ b/source/runtime/render/renderer/raytracing/RaytracingRenderer.cpp
@@ -21,6 +21,7 @@
 #include "GBufferPass.h"
 #include "LightingPass.h"
 #include "PreprocessLightPass.h"
+#include "RaytracingFrameSetupPass.h"
 #include "RTResource.h"
 #include "ShaderUtils.h"
 #include "ShowTexturePass.h"
@@ -245,6 +246,7 @@ struct RaytracingRenderer::RuntimeState {
     std::filesystem::path exported_file_path;
 
     UniquePtr<PrepareLightPass> prepare_light_pass;
+    UniquePtr<RaytracingFrameSetupPass> frame_setup_pass;
     UniquePtr<GBufferPass>      g_buffer_pass;
     UniquePtr<LightingPass>     lighting_pass;
     UniquePtr<CompositionPass>  composition_pass;
@@ -281,6 +283,7 @@ struct RaytracingRenderer::RuntimeState {
         )),
         exported_file_path(ConfigManager::GetInstance().GetWorkspacePath() / "saved"),
         prepare_light_pass(MakeUnique<PrepareLightPass>(renderer.manager, renderer.bindless_array)),
+        frame_setup_pass(MakeUnique<RaytracingFrameSetupPass>()),
         g_buffer_pass(MakeUnique<GBufferPass>(renderer.device, renderer.manager, renderer.bindless_array)),
         lighting_pass(MakeUnique<LightingPass>(renderer.manager, renderer.bindless_array)),
         composition_pass(
@@ -530,6 +533,8 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
     PrepareRenderFrame(frame_packet.window);
     bool  skip_present                    = false;
     bool  split_graph_profiling_frame     = false;
+    bool  frame_setup_graph_recorded      = false;
+    bool  frame_setup_linear_recorded     = false;
     bool  graph_primary_recorded          = false;
     bool  graph_composition_recorded      = false;
     bool  graph_antialias_recorded        = false;
@@ -548,6 +553,8 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
     bool  tone_mapping_enabled_for_commit = false;
     LightingPass::LocalLightSamplingDecision         local_light_sampling{};
     std::optional<PrepareLightPass::PreparedCommand> prepared_lights{};
+    std::optional<RaytracingFrameSetupPass::PreparedCommand> prepared_frame_setup{};
+    SharedPtr<const RaytracingFrameSetupPass::AcceptedSnapshot> accepted_frame_setup{};
     TextureRef                                       selected_debug_texture{};
     bool                                             show_texture_requested = false;
     ShowTextureParams                                show_texture_params{};
@@ -580,7 +587,8 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
                                                  frame_packet.window.state == EWindowState::SizeChanged ||
                                                  ui_config.export_cfg.b_export;
         const bool nrd_active_this_frame = IsNrdDenoiserActive(ui_config.denoiser_cfg.denoiser_type);
-        const bool scene_tlas_updated    = ExecuteSceneUpdates(frame_packet.scene_updates);
+        const SceneUpdateResult scene_update =
+            ExecuteSceneUpdates(frame_packet.scene_updates);
 
         if (state.first_load) {
             state.first_load    = false;
@@ -654,29 +662,6 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
         Camera& camera = frame_packet.scene_updates.main_camera;
         state.rt_ctx->FillLowDiscrepancySequence(cmd_list);
         state.b_export = ui_config.export_cfg.b_export;
-
-        bool tlas_built_this_frame = scene_tlas_updated;
-        if (state.rt_scene) {
-            const bool needs_tlas_build =
-                IsLegacyTlasUpdateEnabled() || state.current_tlas_revision != state.rt_instance_revision;
-            if (needs_tlas_build) {
-                ScopedGpuMarker tlas_marker(
-                    cmd_list, "Pass: Scene Acceleration Structure", GpuMarkerPalette::Pass()
-                );
-                for (size_t i = 0; i < state.rt_scene->GetInstanceCount(); i++) {
-                    auto& instance = state.rt_scene->GetInstance(i);
-                    state.rt_scene->MarkModified(instance.instance_id);
-                }
-                cmd_list.PushScopeWithTimeScope("RTScene RendererTLAS");
-                cmd_list.UpdateRaytracingScene(state.rt_scene);
-                cmd_list.PopScopeWithTimeScope();
-                state.current_tlas_revision = state.rt_instance_revision;
-                ++state.renderer_tlas_build_count;
-                tlas_built_this_frame = true;
-            } else {
-                ++state.renderer_tlas_skip_count;
-            }
-        }
 
         ToneMappingPass::Params tone_params{};
         AntialiasPass::Params   aa_params{};
@@ -801,20 +786,162 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
         prepared_lights.emplace(
             state.prepare_light_pass->Prepare(*state.rt_ctx, scene_snapshot, state.rt_instance_revision)
         );
-        cmd_list.UpdateBindlessArray(bindless_array);
-        if (state.render_graph_enabled && !state.render_graph_fallback_latched &&
-            !prepared_lights->ReadsSceneGeometry() && state.gbuffer_initialized_history_mask == uint8(0b11) &&
+        if (!graph_recording_failed && state.rt_scene) {
+            const bool needs_tlas_build =
+                IsLegacyTlasUpdateEnabled() ||
+                state.current_tlas_revision != state.rt_instance_revision;
+            prepared_frame_setup.emplace(state.frame_setup_pass->Prepare(
+                *state.rt_ctx,
+                state.rt_scene,
+                bindless_array,
+                state.rt_instance_revision,
+                needs_tlas_build,
+                scene_update.gpu_resources_updated,
+                scene_update.tlas_built
+            ));
+        }
+
+        const bool frame_setup_graph_eligible =
+            prepared_frame_setup && state.render_graph_enabled &&
+            !state.render_graph_fallback_latched && !render_graph_boundary_frame;
+        if (frame_setup_graph_eligible) {
+            RenderGraph setup_graph("Raytracing.FrameSetup");
+            const bool setup_passes_added =
+                state.frame_setup_pass->AddPasses(setup_graph, *prepared_frame_setup);
+            if (!setup_passes_added) {
+                state.render_graph_fallback_latched = true;
+                LOG_ERROR(
+                    "[RenderGraph][Fallback] Raytracing FrameSetup could not import "
+                    "Bindless/scene/TLAS resources. Using the linear path for this "
+                    "renderer instance."
+                );
+            } else if (!setup_graph.Compile()) {
+                state.render_graph_fallback_latched = true;
+                LOG_ERROR(
+                    "[RenderGraph][Fallback] Raytracing FrameSetup compile failed "
+                    "before execution: {}. Using the linear path for this renderer "
+                    "instance.",
+                    setup_graph.GetCompileError()
+                );
+            } else {
+                if (state.render_graph_debug_dump) {
+                    std::string dump = setup_graph.Dump();
+                    if (state.logged_render_graph_dumps.emplace(dump).second) {
+                        LOG_INFO("[RenderGraph][Raytracing][DebugDump]\n{}", dump);
+                    }
+                }
+
+                // FrameSetup and the primary graph are independent accepted
+                // transactions. Publishing the caller-owned prefix first and
+                // then both graph source sets on Graphics preserves the real
+                // cross-graph dependency through Executor handoff/FIFO.
+                renderer_marker.Close();
+                if (!cmd_list.IsEmpty()) {
+                    CmdSubmit prefix_submit = cmd_list.Submit().DebugLabel(
+                        std::format(
+                            "Raytracing Frame {}/FrameSetup Prefix",
+                            frame_packet.frame_id
+                        ),
+                        GpuMarkerPalette::Renderer()
+                    );
+                    prefix_submit.SetProfilingPhase(
+                        split_graph_profiling_frame ?
+                            ERHIProfilingPhase::Continue :
+                            ERHIProfilingPhase::Begin
+                    );
+                    split_graph_profiling_frame = true;
+                    RHIExecutor::Get().Submit(
+                        EQueueType::Graphics,
+                        std::move(prefix_submit),
+                        ERHIExecSubmitFlags::None
+                    );
+                }
+
+                bool setup_profiling_started = split_graph_profiling_frame;
+                const auto configure_setup_source =
+                    [&](const RenderGraph::ExecutedPassInfo& pass,
+                        RHIRecordingSource&                  source) {
+                        source.submit_metadata.debug_label = std::format(
+                            "Raytracing Frame {}/{}",
+                            frame_packet.frame_id,
+                            pass.name
+                        );
+                        source.submit_metadata.debug_label_color =
+                            GpuMarkerPalette::Pass();
+                        source.submit_metadata.profiling_phase =
+                            setup_profiling_started ?
+                                ERHIProfilingPhase::Continue :
+                                ERHIProfilingPhase::Begin;
+                        setup_profiling_started = true;
+                    };
+                if (setup_graph.ExecuteRecording(
+                        {},
+                        configure_setup_source,
+                        false,
+                        {},
+                        RenderGraph::ActiveRecordingOptions{.enabled = true}
+                    )) {
+                    split_graph_profiling_frame = setup_profiling_started;
+                    frame_setup_graph_recorded  = true;
+                    auto snapshot =
+                        state.frame_setup_pass->CommitAccepted(*prepared_frame_setup);
+                    accepted_frame_setup =
+                        MakeShared<RaytracingFrameSetupPass::AcceptedSnapshot>(
+                            std::move(snapshot)
+                        );
+                    if (prepared_frame_setup->BuildsTlas()) {
+                        state.current_tlas_revision = state.rt_instance_revision;
+                        ++state.renderer_tlas_build_count;
+                    } else {
+                        ++state.renderer_tlas_skip_count;
+                    }
+                } else {
+                    RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
+                    graph_recording_failed                       = true;
+                    state.render_graph_fallback_latched          = true;
+                    state.render_graph_recording_failure_latched = true;
+                    LOG_ERROR(
+                        "[RenderGraph][Fallback] Raytracing FrameSetup recording "
+                        "failed before transaction commit: {}. Preserving the last "
+                        "accepted output and disabling managed renderer passes until "
+                        "this renderer instance is recreated.",
+                        setup_graph.GetCompileError()
+                    );
+                }
+            }
+        }
+        if (!graph_recording_failed && prepared_frame_setup &&
+            !frame_setup_graph_recorded) {
+            frame_setup_linear_recorded =
+                state.frame_setup_pass->ProcessLinear(cmd_list, *prepared_frame_setup);
+            if (!frame_setup_linear_recorded) {
+                graph_recording_failed              = true;
+                state.render_graph_fallback_latched = true;
+                LOG_ERROR(
+                    "[RenderGraph][Fallback] Raytracing linear FrameSetup has no "
+                    "valid TLAS destination. Preserving the last accepted output."
+                );
+            }
+        }
+
+        if (frame_setup_graph_recorded && accepted_frame_setup &&
+            state.render_graph_enabled && !state.render_graph_fallback_latched &&
+            state.gbuffer_initialized_history_mask == uint8(0b11) &&
             state.lighting_initialized_reservoir_mask == uint8(0b111) &&
             (nrd_active_this_frame || state.antialias_pass->IsHistoryReadyForGraph()) &&
             !render_graph_boundary_frame) {
             RenderGraph graph(nrd_active_this_frame ? "Raytracing.PreDenoise" : "Raytracing.FrameCore");
-            const RTGraphFrameResources graph_resources = RegisterRTGraphFrameResources(graph, *state.rt_ctx);
-            const bool prepare_lights_added = state.prepare_light_pass->AddPasses(graph, *prepared_lights);
+            const RTGraphFrameResources graph_resources =
+                RegisterRTGraphFrameResources(graph, *state.rt_ctx, accepted_frame_setup);
+            const bool prepare_lights_added = state.prepare_light_pass->AddPasses(
+                graph,
+                *prepared_lights,
+                graph_resources.frame_setup.ready
+            );
             const bool gbuffer_added        = prepare_lights_added && state.g_buffer_pass->AddPasses(
                                                                    graph,
                                                                    graph_resources,
                                                                    *state.rt_ctx,
-                                                                   tlas_built_this_frame,
                                                                    state.normal_roughness_readable
                                                                );
             const bool lighting_added = gbuffer_added && state.lighting_pass->AddPasses(
@@ -869,7 +996,8 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
                                                                   graph_resources.ldr_color,
                                                                   show_texture_params,
                                                                   selected_debug_texture,
-                                                                  state.rt_ctx->frame_rt.ldr_color
+                                                                  state.rt_ctx->frame_rt.ldr_color,
+                                                                  graph_resources.frame_setup.ready
                                                               ));
             const bool graph_passes_added = prepare_lights_added && gbuffer_added && lighting_added &&
                                             composition_added && antialias_added && tone_mapping_added &&
@@ -1168,11 +1296,6 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
         IsCurrentlyRenderThread() ? EUiDrawExecutionThread::Render : EUiDrawExecutionThread::Game;
     RenderUiDrawFrame(cmd_list, state.output->GetView(), frame_packet.ui_draw_frame, ui_execution_thread);
 
-    if (state.rt_scene) {
-        state.rt_scene->AdvanceFrame();
-        std::swap(state.current_tlas_revision, state.previous_tlas_revision);
-    }
-
     time++;
     CmdSubmit frame_submit =
         cmd_list.Submit()
@@ -1220,6 +1343,25 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
         ERHIExecSubmitFlags::FlushGPU,
         present_request ? &*present_request : nullptr
     );
+    if (frame_setup_linear_recorded && prepared_frame_setup) {
+        (void)state.frame_setup_pass->CommitAccepted(*prepared_frame_setup);
+        if (prepared_frame_setup->BuildsTlas()) {
+            state.current_tlas_revision = state.rt_instance_revision;
+            ++state.renderer_tlas_build_count;
+        } else {
+            ++state.renderer_tlas_skip_count;
+        }
+    }
+    if ((frame_setup_graph_recorded || frame_setup_linear_recorded) &&
+        state.rt_scene) {
+        // RaytracingScene is a ping-pong builder: the TLAS consumed by this
+        // accepted frame becomes GetPrevTlas(), while GetTlas() rotates to the
+        // slot that may need rebuilding next frame. Mirror that slot rotation
+        // in the revision pair instead of treating the names as immutable
+        // temporal roles.
+        state.rt_scene->AdvanceFrame();
+        std::swap(state.current_tlas_revision, state.previous_tlas_revision);
+    }
     if (prepared_lights && (linear_lighting_recorded || graph_primary_recorded)) {
         state.prepare_light_pass->CommitAcceptedFrame(*state.rt_ctx, std::move(*prepared_lights));
     }
@@ -1400,10 +1542,13 @@ void RaytracingRenderer::RefreshSceneRuntimeRefs() {
         state.b_feedback_valid       = false;
         state.current_tlas_revision  = RuntimeState::invalid_tlas_revision;
         state.previous_tlas_revision = RuntimeState::invalid_tlas_revision;
+        state.frame_setup_pass->ResetAcceptedResources();
     }
 }
 
-bool RaytracingRenderer::ExecuteSceneUpdates(SceneUpdateBatch& batch) {
+RaytracingRenderer::SceneUpdateResult RaytracingRenderer::ExecuteSceneUpdates(
+    SceneUpdateBatch& batch
+) {
     auto& state            = *runtime_state;
     bool  updated          = false;
     bool  rt_scene_updated = false;
@@ -1435,7 +1580,10 @@ bool RaytracingRenderer::ExecuteSceneUpdates(SceneUpdateBatch& batch) {
     if (rt_scene_updated && state.rt_scene) {
         state.current_tlas_revision = state.rt_instance_revision;
     }
-    return rt_scene_updated;
+    return SceneUpdateResult{
+        .gpu_resources_updated = updated,
+        .tlas_built             = rt_scene_updated
+    };
 }
 
 void RaytracingRenderer::RecreateFrameResources(uint2 new_extent) {

--- a/source/runtime/render/renderer/raytracing/RaytracingRenderer.cpp
+++ b/source/runtime/render/renderer/raytracing/RaytracingRenderer.cpp
@@ -167,12 +167,10 @@ void TickAndLogProfiling(const RaytracingFrameFeedback& feedback) {
            << " SceneTLASUpdates=" << feedback.scene_tlas_update_count
            << " RTRevision=" << feedback.rt_instance_revision
            << " CurrentTLASRevision=" << feedback.current_tlas_revision
-           << " PreviousTLASRevision=" << feedback.previous_tlas_revision
-           << " ConfiguredLocalLightSampling="
+           << " PreviousTLASRevision=" << feedback.previous_tlas_revision << " ConfiguredLocalLightSampling="
            << LocalLightSampleModeName(feedback.configured_local_light_sample_mode)
            << " EffectiveLocalLightSampling="
-           << LocalLightSampleModeName(feedback.effective_local_light_sample_mode)
-           << " AdaptiveFallback="
+           << LocalLightSampleModeName(feedback.effective_local_light_sample_mode) << " AdaptiveFallback="
            << (feedback.adaptive_local_light_fallback_applied ? "Applied" : "NotApplied")
            << " LocalLights=" << feedback.local_light_count;
     LOG_INFO("{}", stream.str());
@@ -186,17 +184,13 @@ void ExecuteSceneUpdate(
 ) {
     (void)gfx_queue;
     (void)device;
-    auto scene_cmd_list = render_scene.ApplyUpdate(std::move(update));
+    auto                                  scene_cmd_list = render_scene.ApplyUpdate(std::move(update));
     Array<RHIBackendSubmissionBatchEntry> submissions{};
     submissions.emplace_back(EQueueType::Copy, scene_cmd_list.copy_queue_cmd_list.Submit());
     submissions.emplace_back(
-        EQueueType::Graphics,
-        scene_cmd_list.gfx_queue_cmd_list.Submit().TickProfiling()
+        EQueueType::Graphics, scene_cmd_list.gfx_queue_cmd_list.Submit().TickProfiling()
     );
-    RHIExecutor::Get().Submit(
-        std::move(submissions),
-        ERHIExecSubmitFlags::FlushGPU
-    );
+    RHIExecutor::Get().Submit(std::move(submissions), ERHIExecSubmitFlags::FlushGPU);
     RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
 }
 
@@ -214,7 +208,7 @@ struct RaytracingRenderer::RuntimeState {
     RaytracingSceneRef rt_scene{};
 
     ShaderUtils               shader_utils;
-    ImportanceSamplingParams   importance_sampling_params;
+    ImportanceSamplingParams  importance_sampling_params;
     ImportanceSamplingContext importance_sampling_context;
 
     bool first_load = true;
@@ -229,13 +223,13 @@ struct RaytracingRenderer::RuntimeState {
     bool b_feedback_valid = false;
     bool b_export         = false;
 
-    bool                         render_graph_enabled                 = false;
-    bool                         render_graph_debug_dump              = false;
-    bool                         render_graph_parallel_recording      = false;
-    bool                         render_graph_fallback_latched        = false;
+    bool                         render_graph_enabled                   = false;
+    bool                         render_graph_debug_dump                = false;
+    bool                         render_graph_parallel_recording        = false;
+    bool                         render_graph_fallback_latched          = false;
     bool                         render_graph_recording_failure_latched = false;
-    uint8                        gbuffer_initialized_history_mask     = 0;
-    bool                         normal_roughness_readable            = false;
+    uint8                        gbuffer_initialized_history_mask       = 0;
+    bool                         normal_roughness_readable              = false;
     std::array<const Buffer*, 3> lighting_working_set{};
     uint                         lighting_reservoir_block_array_pitch = 0;
     uint8                        lighting_initialized_reservoir_mask  = 0;
@@ -293,9 +287,7 @@ struct RaytracingRenderer::RuntimeState {
             MakeUnique<CompositionPass>(renderer.device, renderer.manager, renderer.bindless_array)
         ),
         visualize_pass(MakeUnique<VisualizePass>(renderer.device, renderer.manager)),
-        show_texture_pass(
-            MakeUnique<ShowTexturePass>(renderer.manager, renderer.bindless_array)
-        ),
+        show_texture_pass(MakeUnique<ShowTexturePass>(renderer.manager, renderer.bindless_array)),
         rt_ctx(MakeUnique<RTContext>(shader_utils, importance_sampling_context, renderer.bindless_array)) {
         if (!std::filesystem::exists(exported_file_path)) {
             std::filesystem::create_directory(exported_file_path);
@@ -332,17 +324,14 @@ RaytracingRenderer::RaytracingRenderer(
     Renderer(resolution, config),
     runtime_assets(runtime_assets),
     runtime_state(MakeUnique<RuntimeState>(*this)) {
-    const auto& graph_config =
-        ConfigManager::GetInstance().GetConfig().engine.render.raytracing;
-    runtime_state->render_graph_enabled            = graph_config.render_graph;
+    const auto& graph_config            = ConfigManager::GetInstance().GetConfig().engine.render.raytracing;
+    runtime_state->render_graph_enabled = graph_config.render_graph;
     runtime_state->render_graph_debug_dump         = graph_config.render_graph_debug_dump;
-    runtime_state->render_graph_parallel_recording =
-        graph_config.render_graph_parallel_recording;
+    runtime_state->render_graph_parallel_recording = graph_config.render_graph_parallel_recording;
     LOG_INFO(
         "[RenderGraph] Raytracing execution mode: {}, primary graph recording: {}",
         runtime_state->render_graph_enabled ? "graph-pilot" : "linear",
-        runtime_state->render_graph_parallel_recording ? "parallel-eligible" :
-                                                         "serial"
+        runtime_state->render_graph_parallel_recording ? "parallel-eligible" : "serial"
     );
 }
 
@@ -539,28 +528,29 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
     }
 
     PrepareRenderFrame(frame_packet.window);
-    bool skip_present                       = false;
-    bool split_graph_profiling_frame       = false;
-    bool graph_primary_recorded             = false;
-    bool graph_composition_recorded         = false;
-    bool graph_antialias_recorded           = false;
-    bool graph_tone_mapping_recorded        = false;
-    bool graph_visualize_recorded           = false;
-    bool graph_show_texture_recorded         = false;
-    bool graph_recording_failed              = state.render_graph_recording_failure_latched;
-    bool linear_gbuffer_recorded            = false;
-    bool linear_lighting_recorded           = false;
-    bool linear_antialias_recorded           = false;
-    bool linear_tone_mapping_recorded       = false;
-    bool linear_visualize_recorded          = false;
-    bool nrd_recorded                       = false;
-    uint8 gbuffer_history_bit               = 0;
-    float tone_mapping_elapsed_for_commit   = 0.f;
-    bool tone_mapping_enabled_for_commit    = false;
-    LightingPass::LocalLightSamplingDecision local_light_sampling{};
-    TextureRef selected_debug_texture{};
-    bool       show_texture_requested        = false;
-    ShowTextureParams show_texture_params{};
+    bool  skip_present                    = false;
+    bool  split_graph_profiling_frame     = false;
+    bool  graph_primary_recorded          = false;
+    bool  graph_composition_recorded      = false;
+    bool  graph_antialias_recorded        = false;
+    bool  graph_tone_mapping_recorded     = false;
+    bool  graph_visualize_recorded        = false;
+    bool  graph_show_texture_recorded     = false;
+    bool  graph_recording_failed          = state.render_graph_recording_failure_latched;
+    bool  linear_gbuffer_recorded         = false;
+    bool  linear_lighting_recorded        = false;
+    bool  linear_antialias_recorded       = false;
+    bool  linear_tone_mapping_recorded    = false;
+    bool  linear_visualize_recorded       = false;
+    bool  nrd_recorded                    = false;
+    uint8 gbuffer_history_bit             = 0;
+    float tone_mapping_elapsed_for_commit = 0.f;
+    bool  tone_mapping_enabled_for_commit = false;
+    LightingPass::LocalLightSamplingDecision         local_light_sampling{};
+    std::optional<PrepareLightPass::PreparedCommand> prepared_lights{};
+    TextureRef                                       selected_debug_texture{};
+    bool                                             show_texture_requested = false;
+    ShowTextureParams                                show_texture_params{};
 
     switch (frame_packet.window.state) {
         case EWindowState::Hiding:
@@ -586,14 +576,11 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
     feedback.export_request_finished = ui_config.export_cfg.b_export;
 
     if (frame_packet.scene_updates.scene_ready && frame_packet.runtime_assets_ready) {
-        const bool render_graph_boundary_frame =
-            state.first_load || state.b_new_env_map ||
-            frame_packet.window.state == EWindowState::SizeChanged ||
-            ui_config.export_cfg.b_export;
-        const bool nrd_active_this_frame =
-            IsNrdDenoiserActive(ui_config.denoiser_cfg.denoiser_type);
-        const bool scene_tlas_updated =
-            ExecuteSceneUpdates(frame_packet.scene_updates);
+        const bool render_graph_boundary_frame = state.first_load || state.b_new_env_map ||
+                                                 frame_packet.window.state == EWindowState::SizeChanged ||
+                                                 ui_config.export_cfg.b_export;
+        const bool nrd_active_this_frame = IsNrdDenoiserActive(ui_config.denoiser_cfg.denoiser_type);
+        const bool scene_tlas_updated    = ExecuteSceneUpdates(frame_packet.scene_updates);
 
         if (state.first_load) {
             state.first_load    = false;
@@ -622,22 +609,16 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
             RefreshSceneRuntimeRefs();
             state.rt_ctx->FillLowDiscrepancySequence(cmd_list);
             cmd_list.UpdateBindlessArray(bindless_array);
-            RHIExecutor::Get().Submit(
-                EQueueType::Graphics, cmd_list.Submit(), ERHIExecSubmitFlags::FlushGPU
-            );
+            RHIExecutor::Get().Submit(EQueueType::Graphics, cmd_list.Submit(), ERHIExecSubmitFlags::FlushGPU);
             RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
         }
 
-        ScopedGpuMarker renderer_marker(
-            cmd_list, "Raytracing Renderer", GpuMarkerPalette::Renderer()
-        );
+        ScopedGpuMarker renderer_marker(cmd_list, "Raytracing Renderer", GpuMarkerPalette::Renderer());
 
         if (state.b_new_env_map) {
-            ScopedGpuMarker environment_marker(
-                cmd_list, "Pass: Environment Setup", GpuMarkerPalette::Pass()
-            );
-            auto src_env_map = runtime_assets.GetDefaultEnvMap();
-            state.env_map    = device.CreateTexture(
+            ScopedGpuMarker environment_marker(cmd_list, "Pass: Environment Setup", GpuMarkerPalette::Pass());
+            auto            src_env_map = runtime_assets.GetDefaultEnvMap();
+            state.env_map               = device.CreateTexture(
                 src_env_map->GetName(),
                 Extent3D(src_env_map->GetExtent()),
                 PF_R16G16B16A16_SFLOAT,
@@ -676,8 +657,8 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
 
         bool tlas_built_this_frame = scene_tlas_updated;
         if (state.rt_scene) {
-            const bool needs_tlas_build = IsLegacyTlasUpdateEnabled() ||
-                                          state.current_tlas_revision != state.rt_instance_revision;
+            const bool needs_tlas_build =
+                IsLegacyTlasUpdateEnabled() || state.current_tlas_revision != state.rt_instance_revision;
             if (needs_tlas_build) {
                 ScopedGpuMarker tlas_marker(
                     cmd_list, "Pass: Scene Acceleration Structure", GpuMarkerPalette::Pass()
@@ -704,7 +685,7 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
             grid_cfg.cell_size = ui_config.grid_config.cell_size;
             grid_cfg.center    = camera.GetPosition();
 
-            auto grid_static_cfg           = state.importance_sampling_context.GetGridConfig();
+            auto grid_static_cfg = state.importance_sampling_context.GetGridConfig();
             grid_static_cfg.SetLightsPerCell(ui_config.grid_config.GetLightsPerCell());
             grid_static_cfg.grid_mode = ui_config.grid_config.grid_mode;
             state.importance_sampling_context.SetGridConfig(grid_static_cfg);
@@ -727,9 +708,9 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
             state.rt_ctx->config.enable_adaptive_local_light_sampling =
                 ui_config.restir_di_cfg.initial_sample_config.enable_adaptive_local_light_sampling &&
                 !IsLightGridForced();
-            state.rt_ctx->config.grid_min_local_light_count = static_cast<uint>(std::max(
-                ui_config.restir_di_cfg.initial_sample_config.grid_min_local_light_count, 1
-            ));
+            state.rt_ctx->config.grid_min_local_light_count = static_cast<uint>(
+                std::max(ui_config.restir_di_cfg.initial_sample_config.grid_min_local_light_count, 1)
+            );
             di_initial_sample_config.env_map_is =
                 state.importance_sampling_context.GetLightBufferParams().env_light.light_cnt;
             di_temporal_resampling_config.bias_correction_mode =
@@ -762,9 +743,8 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
             tone_params.histogram_high_percentile = tone_cfg.histogram_high_percentile;
             tone_params.white_point               = tone_cfg.white_point;
             tone_params.enable_tone_mapping       = tone_cfg.enable_tone_mapping;
-            tone_mapping_elapsed_for_commit        = camera.GetDeltaTime();
-            tone_mapping_enabled_for_commit =
-                tone_params.enable_tone_mapping;
+            tone_mapping_elapsed_for_commit       = camera.GetDeltaTime();
+            tone_mapping_enabled_for_commit       = tone_params.enable_tone_mapping;
 
             const auto& aa_cfg             = ui_config.aa_cfg;
             aa_params.clamping_factor      = aa_cfg.clamping_factor;
@@ -780,36 +760,19 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
         state.importance_sampling_context.TickFrame(time);
         state.visualize_config.visualize_mode = ui_config.final_color;
 
-        static constexpr uint s_mesh_alloc_chunk      = 128;
-        static constexpr uint s_triangle_alloc_chunk  = 1024;
-        static constexpr uint s_primitive_alloc_chunk = 128;
-        const auto&           scene_snapshot          = frame_packet.scene_snapshot;
-        state.rt_ctx->CreateBuffersIfNeeded(
-            (scene_snapshot.emissive_instance_count + s_mesh_alloc_chunk - 1) & ~(s_mesh_alloc_chunk - 1),
-            (scene_snapshot.emissive_triangle_count + s_triangle_alloc_chunk - 1) &
-                ~(s_triangle_alloc_chunk - 1),
-            (scene_snapshot.light_count + s_primitive_alloc_chunk - 1) & ~(s_primitive_alloc_chunk - 1),
-            scene_snapshot.primitive_count
-        );
-        cmd_list.UpdateBindlessArray(bindless_array);
+        const auto& scene_snapshot = frame_packet.scene_snapshot;
 
         const auto& debug_input = frame_packet.debug_input;
-        const auto selected_texture_it =
-            state.material_textures.find(
-                debug_input.selected_material_texture_name
-            );
-        show_texture_requested =
-            debug_input.show_final_texture &&
-            selected_texture_it != state.material_textures.end() &&
-            selected_texture_it->second.tex;
+        const auto  selected_texture_it =
+            state.material_textures.find(debug_input.selected_material_texture_name);
+        show_texture_requested = debug_input.show_final_texture &&
+                                 selected_texture_it != state.material_textures.end() &&
+                                 selected_texture_it->second.tex;
         if (show_texture_requested) {
-            selected_debug_texture = selected_texture_it->second.tex;
-            show_texture_params.bdls_handle = selected_texture_it->second.hdl;
-            show_texture_params.mip_level = static_cast<uint>(
-                std::max(debug_input.mip_level, 0)
-            );
-            show_texture_params.use_bindless =
-                debug_input.use_bindless ? 1u : 0u;
+            selected_debug_texture           = selected_texture_it->second.tex;
+            show_texture_params.bdls_handle  = selected_texture_it->second.hdl;
+            show_texture_params.mip_level    = static_cast<uint>(std::max(debug_input.mip_level, 0));
+            show_texture_params.use_bindless = debug_input.use_bindless ? 1u : 0u;
         }
 
         state.rt_ctx->Tick(camera, state.antialias_pass->GetPixelOffset());
@@ -820,14 +783,11 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
             state.rt_ctx->ris_light_data_buf.Get()
         };
         const uint lighting_reservoir_block_array_pitch =
-            state.rt_ctx->is_ctx.GetReSTIRDIRuntimeConfig()
-                .reservoir_buffer_params.block_array_pitch;
+            state.rt_ctx->is_ctx.GetReSTIRDIRuntimeConfig().reservoir_buffer_params.block_array_pitch;
         if (state.lighting_working_set != lighting_working_set ||
-            state.lighting_reservoir_block_array_pitch !=
-                lighting_reservoir_block_array_pitch) {
-            state.lighting_working_set = lighting_working_set;
-            state.lighting_reservoir_block_array_pitch =
-                lighting_reservoir_block_array_pitch;
+            state.lighting_reservoir_block_array_pitch != lighting_reservoir_block_array_pitch) {
+            state.lighting_working_set                 = lighting_working_set;
+            state.lighting_reservoir_block_array_pitch = lighting_reservoir_block_array_pitch;
             // ReSTIR DI rotates three logical reservoir slices. Track the
             // slices actually written by accepted linear frames rather than
             // coupling graph eligibility to an implicit frame countdown.
@@ -838,141 +798,106 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
                 lighting_reservoir_block_array_pitch
             );
         }
-        {
-            ScopedGpuMarker pass_marker(
-                cmd_list, "Pass: Prepare Lights", GpuMarkerPalette::Pass()
-            );
-            state.prepare_light_pass->Process(cmd_list, *state.rt_ctx, scene_snapshot);
-        }
+        prepared_lights.emplace(
+            state.prepare_light_pass->Prepare(*state.rt_ctx, scene_snapshot, state.rt_instance_revision)
+        );
+        cmd_list.UpdateBindlessArray(bindless_array);
         if (state.render_graph_enabled && !state.render_graph_fallback_latched &&
-            state.gbuffer_initialized_history_mask == uint8(0b11) &&
+            !prepared_lights->ReadsSceneGeometry() && state.gbuffer_initialized_history_mask == uint8(0b11) &&
             state.lighting_initialized_reservoir_mask == uint8(0b111) &&
-            (nrd_active_this_frame ||
-             state.antialias_pass->IsHistoryReadyForGraph()) &&
+            (nrd_active_this_frame || state.antialias_pass->IsHistoryReadyForGraph()) &&
             !render_graph_boundary_frame) {
-            RenderGraph graph(
-                nrd_active_this_frame ?
-                    "Raytracing.PreDenoise" :
-                    "Raytracing.FrameCore"
-            );
-            const RTGraphFrameResources graph_resources =
-                RegisterRTGraphFrameResources(graph, *state.rt_ctx);
-            const bool gbuffer_added = state.g_buffer_pass->AddPasses(
-                    graph,
-                    graph_resources,
-                    *state.rt_ctx,
-                    tlas_built_this_frame,
-                    state.normal_roughness_readable
-                );
-            const bool lighting_added =
-                gbuffer_added &&
-                state.lighting_pass->AddPasses(
-                    graph,
-                    graph_resources,
-                    *state.rt_ctx,
-                    local_light_sampling
-                );
+            RenderGraph graph(nrd_active_this_frame ? "Raytracing.PreDenoise" : "Raytracing.FrameCore");
+            const RTGraphFrameResources graph_resources = RegisterRTGraphFrameResources(graph, *state.rt_ctx);
+            const bool prepare_lights_added = state.prepare_light_pass->AddPasses(graph, *prepared_lights);
+            const bool gbuffer_added        = prepare_lights_added && state.g_buffer_pass->AddPasses(
+                                                                   graph,
+                                                                   graph_resources,
+                                                                   *state.rt_ctx,
+                                                                   tlas_built_this_frame,
+                                                                   state.normal_roughness_readable
+                                                               );
+            const bool lighting_added = gbuffer_added && state.lighting_pass->AddPasses(
+                                                             graph,
+                                                             graph_resources,
+                                                             *state.rt_ctx,
+                                                             prepared_lights->GetLightBufferParams(),
+                                                             true,
+                                                             local_light_sampling
+                                                         );
             const bool composition_in_graph = !nrd_active_this_frame;
             const bool composition_added =
                 !composition_in_graph ||
-                (lighting_added &&
-                 state.composition_pass->AddPasses(
-                     graph,
-                     graph_resources,
-                     *state.rt_ctx
-                 ));
+                (lighting_added && state.composition_pass->AddPasses(graph, graph_resources, *state.rt_ctx));
             const bool antialias_in_graph = composition_in_graph;
             const bool antialias_added =
-                !antialias_in_graph ||
-                (composition_added &&
-                 state.antialias_pass->AddPasses(
-                     graph,
-                     graph_resources,
-                     *state.rt_ctx,
-                     aa_params,
-                     state.b_feedback_valid,
-                     state.rt_ctx->frame_rt.hdr_color,
-                     state.rt_ctx->frame_rt.resolved_color
-                 ));
+                !antialias_in_graph || (composition_added && state.antialias_pass->AddPasses(
+                                                                 graph,
+                                                                 graph_resources,
+                                                                 *state.rt_ctx,
+                                                                 aa_params,
+                                                                 state.b_feedback_valid,
+                                                                 state.rt_ctx->frame_rt.hdr_color,
+                                                                 state.rt_ctx->frame_rt.resolved_color
+                                                             ));
             const bool tone_mapping_in_graph = antialias_in_graph;
             const bool tone_mapping_added =
-                !tone_mapping_in_graph ||
-                (antialias_added &&
-                 state.tone_mapping_pass->AddPasses(
-                     graph,
-                     graph_resources,
-                     *state.rt_ctx,
-                     tone_params,
-                     state.rt_ctx->frame_rt.resolved_color,
-                     state.rt_ctx->frame_rt.ldr_color
-                 ));
+                !tone_mapping_in_graph || (antialias_added && state.tone_mapping_pass->AddPasses(
+                                                                  graph,
+                                                                  graph_resources,
+                                                                  *state.rt_ctx,
+                                                                  tone_params,
+                                                                  state.rt_ctx->frame_rt.resolved_color,
+                                                                  state.rt_ctx->frame_rt.ldr_color
+                                                              ));
             const bool visualize_in_graph = tone_mapping_in_graph;
             const bool visualize_added =
                 !visualize_in_graph ||
-                (tone_mapping_added &&
-                 state.visualize_pass->AddPasses(
-                     graph,
-                     graph_resources,
-                     *state.rt_ctx,
-                     state.visualize_config
-                 ));
-            const bool show_texture_in_graph =
-                visualize_in_graph && show_texture_requested;
+                (tone_mapping_added && state.visualize_pass->AddPasses(
+                                           graph, graph_resources, *state.rt_ctx, state.visualize_config
+                                       ));
+            const bool                 show_texture_in_graph = visualize_in_graph && show_texture_requested;
             RenderGraph::TextureHandle selected_graph_texture{};
             if (show_texture_in_graph) {
-                selected_graph_texture = ImportRTGraphTexture(
-                    graph,
-                    "RT.selected_material_texture",
-                    selected_debug_texture
-                );
+                selected_graph_texture =
+                    ImportRTGraphTexture(graph, "RT.selected_material_texture", selected_debug_texture);
             }
             const bool show_texture_added =
-                !show_texture_in_graph ||
-                (visualize_added &&
-                 state.show_texture_pass->AddPass(
-                     graph,
-                     selected_graph_texture,
-                     graph_resources.ldr_color,
-                     show_texture_params,
-                     selected_debug_texture,
-                     state.rt_ctx->frame_rt.ldr_color
-                 ));
-            const bool graph_passes_added =
-                gbuffer_added && lighting_added && composition_added &&
-                antialias_added && tone_mapping_added && visualize_added &&
-                show_texture_added;
+                !show_texture_in_graph || (visualize_added && state.show_texture_pass->AddPass(
+                                                                  graph,
+                                                                  selected_graph_texture,
+                                                                  graph_resources.ldr_color,
+                                                                  show_texture_params,
+                                                                  selected_debug_texture,
+                                                                  state.rt_ctx->frame_rt.ldr_color
+                                                              ));
+            const bool graph_passes_added = prepare_lights_added && gbuffer_added && lighting_added &&
+                                            composition_added && antialias_added && tone_mapping_added &&
+                                            visualize_added && show_texture_added;
             if (graph_passes_added && IsRenderGraphRecordingFailureInjected()) {
                 graph.AddRecordPass(
                     "RT.FaultInjection.RecordingFailure",
                     [](RenderGraph::PassBuilder& builder) {
                         builder
-                            .ExecuteOn(
-                                RenderGraph::QueueRole::Graphics,
-                                RenderGraph::PipelineType::Compute
-                            )
+                            .ExecuteOn(RenderGraph::QueueRole::Graphics, RenderGraph::PipelineType::Compute)
                             .SideEffect();
                     },
                     [](CommandList&) {
-                        throw std::runtime_error(
-                            "MOER_RT_RDG_RECORDING_FAIL requested a synthetic "
-                            "managed-record failure"
-                        );
+                        throw std::runtime_error("MOER_RT_RDG_RECORDING_FAIL requested a synthetic "
+                                                 "managed-record failure");
                     },
                     RenderGraph::PassExecutionClass::ParallelRecordEligible
                 );
-                LOG_WARNING(
-                    "[RenderGraph][Injection] Raytracing managed-record failure "
-                    "armed by MOER_RT_RDG_RECORDING_FAIL."
-                );
+                LOG_WARNING("[RenderGraph][Injection] Raytracing managed-record failure "
+                            "armed by MOER_RT_RDG_RECORDING_FAIL.");
             }
             if (!graph_passes_added) {
                 state.render_graph_fallback_latched = true;
-                LOG_ERROR(
-                    "[RenderGraph][Fallback] Raytracing primary graph could not "
-                    "import a required GBuffer/Lighting/Composition/AntiAlias/"
-                    "ToneMapping/Visualize/ShowTexture resource. Using the linear "
-                    "path for this renderer instance."
-                );
+                LOG_ERROR("[RenderGraph][Fallback] Raytracing primary graph could not "
+                          "import a required PrepareLights/GBuffer/Lighting/"
+                          "Composition/AntiAlias/"
+                          "ToneMapping/Visualize/ShowTexture resource. Using the linear "
+                          "path for this renderer instance.");
             } else if (!graph.Compile()) {
                 state.render_graph_fallback_latched = true;
                 LOG_ERROR(
@@ -997,45 +922,30 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
                 // consumer that would require a missing visibility bridge.
                 renderer_marker.Close();
                 if (!cmd_list.IsEmpty()) {
-                    CmdSubmit prefix_submit =
-                        cmd_list.Submit().DebugLabel(
-                            std::format(
-                                "Raytracing Frame {}/Graph Prefix",
-                                frame_packet.frame_id
-                            ),
-                            GpuMarkerPalette::Renderer()
-                        );
+                    CmdSubmit prefix_submit = cmd_list.Submit().DebugLabel(
+                        std::format("Raytracing Frame {}/Graph Prefix", frame_packet.frame_id),
+                        GpuMarkerPalette::Renderer()
+                    );
                     prefix_submit.SetProfilingPhase(
-                        split_graph_profiling_frame ?
-                            ERHIProfilingPhase::Continue :
-                            ERHIProfilingPhase::Begin
+                        split_graph_profiling_frame ? ERHIProfilingPhase::Continue : ERHIProfilingPhase::Begin
                     );
                     split_graph_profiling_frame = true;
                     RHIExecutor::Get().Submit(
-                        EQueueType::Graphics,
-                        std::move(prefix_submit),
-                        ERHIExecSubmitFlags::None
+                        EQueueType::Graphics, std::move(prefix_submit), ERHIExecSubmitFlags::None
                     );
                 }
 
-                bool graph_recording_profiling_started =
-                    split_graph_profiling_frame;
-                const auto configure_recording_source =
-                    [&](const RenderGraph::ExecutedPassInfo& pass,
-                        RHIRecordingSource&                  source) {
-                        source.submit_metadata.debug_label = std::format(
-                            "Raytracing Frame {}/{}",
-                            frame_packet.frame_id,
-                            pass.name
-                        );
-                        source.submit_metadata.debug_label_color =
-                            GpuMarkerPalette::Pass();
-                        source.submit_metadata.profiling_phase =
-                            graph_recording_profiling_started ?
-                                ERHIProfilingPhase::Continue :
-                                ERHIProfilingPhase::Begin;
-                        graph_recording_profiling_started = true;
-                    };
+                bool       graph_recording_profiling_started = split_graph_profiling_frame;
+                const auto configure_recording_source        = [&](const RenderGraph::ExecutedPassInfo& pass,
+                                                            RHIRecordingSource&                  source) {
+                    source.submit_metadata.debug_label =
+                        std::format("Raytracing Frame {}/{}", frame_packet.frame_id, pass.name);
+                    source.submit_metadata.debug_label_color = GpuMarkerPalette::Pass();
+                    source.submit_metadata.profiling_phase   = graph_recording_profiling_started ?
+                                                                          ERHIProfilingPhase::Continue :
+                                                                          ERHIProfilingPhase::Begin;
+                    graph_recording_profiling_started        = true;
+                };
                 if (graph.ExecuteRecording(
                         {},
                         configure_recording_source,
@@ -1043,24 +953,21 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
                         {},
                         RenderGraph::ActiveRecordingOptions{.enabled = true}
                     )) {
-                    split_graph_profiling_frame =
-                        graph_recording_profiling_started;
-                    graph_primary_recorded     = true;
-                    graph_composition_recorded = composition_in_graph;
-                    graph_antialias_recorded   = antialias_in_graph;
-                    graph_tone_mapping_recorded =
-                        tone_mapping_in_graph;
-                    graph_visualize_recorded = visualize_in_graph;
-                    graph_show_texture_recorded =
-                        show_texture_in_graph;
+                    split_graph_profiling_frame = graph_recording_profiling_started;
+                    graph_primary_recorded      = true;
+                    graph_composition_recorded  = composition_in_graph;
+                    graph_antialias_recorded    = antialias_in_graph;
+                    graph_tone_mapping_recorded = tone_mapping_in_graph;
+                    graph_visualize_recorded    = visualize_in_graph;
+                    graph_show_texture_recorded = show_texture_in_graph;
                 } else {
                     // ExecuteRecording joins every producer and fails the
                     // graph-wide commit gate. Sync only joins the resulting
                     // rejection cleanup and the already accepted Prefix; it is
                     // not used as a resource-state substitute.
                     RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
-                    graph_recording_failed = true;
-                    state.render_graph_fallback_latched = true;
+                    graph_recording_failed                       = true;
+                    state.render_graph_fallback_latched          = true;
                     state.render_graph_recording_failure_latched = true;
                     LOG_ERROR(
                         "[RenderGraph][Fallback] Raytracing primary graph "
@@ -1074,18 +981,21 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
             }
         }
         if (!graph_recording_failed && !graph_primary_recorded) {
-            ScopedGpuMarker pass_marker(
-                cmd_list, "Pass: GBuffer", GpuMarkerPalette::Pass()
-            );
+            {
+                ScopedGpuMarker pass_marker(cmd_list, "Pass: Prepare Lights", GpuMarkerPalette::Pass());
+                state.prepare_light_pass->Process(cmd_list, *prepared_lights);
+            }
+            ScopedGpuMarker pass_marker(cmd_list, "Pass: GBuffer", GpuMarkerPalette::Pass());
             state.g_buffer_pass->Process(cmd_list, *state.rt_ctx);
             linear_gbuffer_recorded = true;
 
             pass_marker.Close();
-            ScopedGpuMarker lighting_marker(
-                cmd_list, "Pass: Lighting", GpuMarkerPalette::Pass()
+            ScopedGpuMarker lighting_marker(cmd_list, "Pass: Lighting", GpuMarkerPalette::Pass());
+            state.prepare_light_pass->RecordLightingInputTransitions(cmd_list, *prepared_lights);
+            local_light_sampling = state.lighting_pass->Process(
+                cmd_list, *state.rt_ctx, prepared_lights->GetLightBufferParams()
             );
-            local_light_sampling =
-                state.lighting_pass->Process(cmd_list, *state.rt_ctx);
+            state.prepare_light_pass->RecordAcceptedBoundary(cmd_list, *prepared_lights);
             linear_lighting_recorded = true;
         } else if (graph_primary_recorded) {
             state.g_buffer_pass->RecordLegacyTailBridge(
@@ -1097,11 +1007,10 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
                 graph_visualize_recorded
             );
         }
-        feedback.configured_local_light_sample_mode = local_light_sampling.configured_mode;
-        feedback.effective_local_light_sample_mode  = local_light_sampling.effective_mode;
-        feedback.adaptive_local_light_fallback_applied =
-            local_light_sampling.adaptive_fallback_applied;
-        feedback.local_light_count = local_light_sampling.local_light_count;
+        feedback.configured_local_light_sample_mode    = local_light_sampling.configured_mode;
+        feedback.effective_local_light_sample_mode     = local_light_sampling.effective_mode;
+        feedback.adaptive_local_light_fallback_applied = local_light_sampling.adaptive_fallback_applied;
+        feedback.local_light_count                     = local_light_sampling.local_light_count;
 
 #if WITH_NRD
         if (!graph_recording_failed) {
@@ -1158,15 +1067,11 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
 #endif
 
         if (!graph_recording_failed && !graph_composition_recorded) {
-            ScopedGpuMarker pass_marker(
-                cmd_list, "Pass: Composition", GpuMarkerPalette::Pass()
-            );
+            ScopedGpuMarker pass_marker(cmd_list, "Pass: Composition", GpuMarkerPalette::Pass());
             state.composition_pass->Process(cmd_list, *state.rt_ctx);
         }
         if (!graph_recording_failed && !graph_antialias_recorded) {
-            ScopedGpuMarker pass_marker(
-                cmd_list, "Pass: Anti Aliasing", GpuMarkerPalette::Pass()
-            );
+            ScopedGpuMarker pass_marker(cmd_list, "Pass: Anti Aliasing", GpuMarkerPalette::Pass());
             state.antialias_pass->Process(
                 cmd_list,
                 aa_params,
@@ -1177,37 +1082,22 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
             linear_antialias_recorded = true;
         }
         if (!graph_recording_failed && !graph_tone_mapping_recorded) {
-            ScopedGpuMarker pass_marker(
-                cmd_list, "Pass: Tone Mapping", GpuMarkerPalette::Pass()
-            );
+            ScopedGpuMarker pass_marker(cmd_list, "Pass: Tone Mapping", GpuMarkerPalette::Pass());
             state.tone_mapping_pass->Process(
-                cmd_list,
-                tone_params,
-                state.rt_ctx->frame_rt.resolved_color,
-                state.rt_ctx->frame_rt.ldr_color
+                cmd_list, tone_params, state.rt_ctx->frame_rt.resolved_color, state.rt_ctx->frame_rt.ldr_color
             );
             linear_tone_mapping_recorded = true;
         }
         if (!graph_recording_failed && !graph_visualize_recorded) {
-            ScopedGpuMarker pass_marker(
-                cmd_list, "Pass: Visualize", GpuMarkerPalette::Pass()
-            );
-            state.visualize_pass->Process(
-                cmd_list, *state.rt_ctx, state.visualize_config
-            );
+            ScopedGpuMarker pass_marker(cmd_list, "Pass: Visualize", GpuMarkerPalette::Pass());
+            state.visualize_pass->Process(cmd_list, *state.rt_ctx, state.visualize_config);
             linear_visualize_recorded = true;
         }
 
-        if (!graph_recording_failed && show_texture_requested &&
-            !graph_show_texture_recorded) {
-            ScopedGpuMarker debug_texture_marker(
-                cmd_list, "Pass: Debug Texture", GpuMarkerPalette::Pass()
-            );
+        if (!graph_recording_failed && show_texture_requested && !graph_show_texture_recorded) {
+            ScopedGpuMarker debug_texture_marker(cmd_list, "Pass: Debug Texture", GpuMarkerPalette::Pass());
             state.show_texture_pass->Process(
-                cmd_list,
-                show_texture_params,
-                selected_debug_texture,
-                state.rt_ctx->frame_rt.ldr_color
+                cmd_list, show_texture_params, selected_debug_texture, state.rt_ctx->frame_rt.ldr_color
             );
         }
 
@@ -1239,7 +1129,6 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
             state.b_export           = false;
             feedback.export_consumed = true;
         }
-
     }
 
     const TextureRef final_color = frame_packet.debug_input.show_final_texture ?
@@ -1287,10 +1176,7 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
     time++;
     CmdSubmit frame_submit =
         cmd_list.Submit()
-            .DebugLabel(
-                std::format("Raytracing Frame {}", frame_packet.frame_id),
-                GpuMarkerPalette::Frame()
-            )
+            .DebugLabel(std::format("Raytracing Frame {}", frame_packet.frame_id), GpuMarkerPalette::Frame())
             .Signal(timeline, time)
             .DeleteResources();
     if (split_graph_profiling_frame) {
@@ -1303,7 +1189,8 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
         const auto output_view = state.output->GetView();
         if (frame_packet.window.state == EWindowState::SizeChanged) {
             LOG_INFO(
-                "[Threading][Resize] Raytracing main present source={}x{}, swapchain={}x{}, UI platform viewports={}.",
+                "[Threading][Resize] Raytracing main present source={}x{}, swapchain={}x{}, UI platform "
+                "viewports={}.",
                 output_view.extent.x,
                 output_view.extent.y,
                 swapchain->size.x,
@@ -1333,54 +1220,50 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
         ERHIExecSubmitFlags::FlushGPU,
         present_request ? &*present_request : nullptr
     );
+    if (prepared_lights && (linear_lighting_recorded || graph_primary_recorded)) {
+        state.prepare_light_pass->CommitAcceptedFrame(*state.rt_ctx, std::move(*prepared_lights));
+    }
     if (linear_antialias_recorded || graph_antialias_recorded) {
         state.antialias_pass->CommitAcceptedFrame();
         state.b_feedback_valid = true;
     }
     if (linear_tone_mapping_recorded || graph_tone_mapping_recorded) {
         state.tone_mapping_pass->CommitAcceptedFrame(
-            tone_mapping_elapsed_for_commit,
-            tone_mapping_enabled_for_commit
+            tone_mapping_elapsed_for_commit, tone_mapping_enabled_for_commit
         );
     }
     if (linear_gbuffer_recorded || graph_primary_recorded) {
         state.gbuffer_initialized_history_mask |= gbuffer_history_bit;
     }
     if (linear_lighting_recorded) {
-        const uint8 previous_reservoir_mask =
-            state.lighting_initialized_reservoir_mask;
-        const auto& buffer_indices =
-            state.rt_ctx->is_ctx.GetReSTIRDIBufferIndices();
+        const uint8 previous_reservoir_mask = state.lighting_initialized_reservoir_mask;
+        const auto& buffer_indices          = state.rt_ctx->is_ctx.GetReSTIRDIBufferIndices();
         for (const uint reservoir_slice : {
                  buffer_indices.initial_sample_output_buff_idx,
                  buffer_indices.temperal_resample_output_buff_idx,
                  buffer_indices.spatial_resample_output_buff_idx,
              }) {
             if (reservoir_slice < 3) {
-                state.lighting_initialized_reservoir_mask |=
-                    uint8(1u << reservoir_slice);
+                state.lighting_initialized_reservoir_mask |= uint8(1u << reservoir_slice);
             }
         }
         if (previous_reservoir_mask != uint8(0b111) &&
             state.lighting_initialized_reservoir_mask == uint8(0b111)) {
-            LOG_INFO(
-                "[RenderGraph][Raytracing] All Lighting reservoir slices have "
-                "accepted linear submissions; active RDG is eligible once "
-                "both GBuffer history pings are initialized."
-            );
+            LOG_INFO("[RenderGraph][Raytracing] All Lighting reservoir slices have "
+                     "accepted linear submissions; active RDG is eligible once "
+                     "both GBuffer history pings are initialized.");
         }
     }
     if (graph_primary_recorded) {
         state.normal_roughness_readable = true;
     } else if (linear_gbuffer_recorded) {
-        state.normal_roughness_readable =
-            nrd_recorded || linear_visualize_recorded;
+        state.normal_roughness_readable = nrd_recorded || linear_visualize_recorded;
     }
     if (!skip_present) {
         PresentUiDrawFrame(frame_packet.ui_draw_frame, ui_execution_thread);
     }
 
-    feedback.profiler_data = gfx_queue.GetProfilerEntry();
+    feedback.profiler_data             = gfx_queue.GetProfilerEntry();
     feedback.renderer_tlas_build_count = state.renderer_tlas_build_count;
     feedback.renderer_tlas_skip_count  = state.renderer_tlas_skip_count;
     feedback.scene_tlas_update_count   = state.scene_tlas_update_count;
@@ -1493,12 +1376,9 @@ void RaytracingRenderer::RefreshSceneRuntimeRefs() {
     state.material_textures.clear();
     state.material_textures.reserve(gpu_scene_res.texture_array.size());
     for (const TextureWithHandle& texture : gpu_scene_res.texture_array) {
-        if (!texture.tex ||
-            texture.tex->GetDimension() != ETextureDimension::TEX_2D ||
-            texture.tex->GetNumArray() != 1 ||
-            texture.tex->GetNumMips() == 0 ||
-            texture.tex->GetExtent().x == 0 ||
-            texture.tex->GetExtent().y == 0) {
+        if (!texture.tex || texture.tex->GetDimension() != ETextureDimension::TEX_2D ||
+            texture.tex->GetNumArray() != 1 || texture.tex->GetNumMips() == 0 ||
+            texture.tex->GetExtent().x == 0 || texture.tex->GetExtent().y == 0) {
             continue;
         }
         std::string base_name(texture.tex->GetName());
@@ -1507,38 +1387,29 @@ void RaytracingRenderer::RefreshSceneRuntimeRefs() {
         }
         std::string display_name = base_name;
         if (state.material_textures.contains(display_name)) {
-            display_name =
-                std::format("{} [{}]", base_name, texture.hdl);
+            display_name = std::format("{} [{}]", base_name, texture.hdl);
         }
         uint duplicate_index = 2;
         while (state.material_textures.contains(display_name)) {
-            display_name = std::format(
-                "{} [{}:{}]",
-                base_name,
-                texture.hdl,
-                duplicate_index++
-            );
+            display_name = std::format("{} [{}:{}]", base_name, texture.hdl, duplicate_index++);
         }
-        state.material_textures.emplace(
-            std::move(display_name),
-            texture
-        );
+        state.material_textures.emplace(std::move(display_name), texture);
     }
 
     if (rt_scene_changed) {
-        state.b_feedback_valid = false;
+        state.b_feedback_valid       = false;
         state.current_tlas_revision  = RuntimeState::invalid_tlas_revision;
         state.previous_tlas_revision = RuntimeState::invalid_tlas_revision;
     }
 }
 
 bool RaytracingRenderer::ExecuteSceneUpdates(SceneUpdateBatch& batch) {
-    auto& state = *runtime_state;
-    bool  updated = false;
+    auto& state            = *runtime_state;
+    bool  updated          = false;
     bool  rt_scene_updated = false;
     if (batch.initial_gpu_update) {
-        const bool has_rt_update = batch.initial_gpu_update->raytracing_update !=
-                                   EGpuSceneRaytracingUpdate::None;
+        const bool has_rt_update =
+            batch.initial_gpu_update->raytracing_update != EGpuSceneRaytracingUpdate::None;
         ExecuteSceneUpdate(*render_scene, std::move(*batch.initial_gpu_update), device, gfx_queue);
         updated          = true;
         rt_scene_updated = rt_scene_updated || has_rt_update;
@@ -1548,8 +1419,8 @@ bool RaytracingRenderer::ExecuteSceneUpdates(SceneUpdateBatch& batch) {
         }
     }
     if (batch.update_gpu_update) {
-        const bool has_rt_update = batch.update_gpu_update->raytracing_update !=
-                                   EGpuSceneRaytracingUpdate::None;
+        const bool has_rt_update =
+            batch.update_gpu_update->raytracing_update != EGpuSceneRaytracingUpdate::None;
         ExecuteSceneUpdate(*render_scene, std::move(*batch.update_gpu_update), device, gfx_queue);
         updated          = true;
         rt_scene_updated = rt_scene_updated || has_rt_update;
@@ -1608,12 +1479,12 @@ void RaytracingRenderer::RecreateFrameResources(uint2 new_extent) {
     state.antialias_pass_info.feedback_color_ping = state.rt_ctx->frame_rt.feedback_color_ping;
     state.antialias_pass_info.feedback_color_pong = state.rt_ctx->frame_rt.feedback_color_pong;
     state.antialias_pass   = MakeUnique<AntialiasPass>(device, manager, state.antialias_pass_info);
-    state.b_feedback_valid                       = false;
-    state.gbuffer_initialized_history_mask       = 0;
-    state.normal_roughness_readable              = false;
-    state.lighting_working_set                   = {};
+    state.b_feedback_valid = false;
+    state.gbuffer_initialized_history_mask     = 0;
+    state.normal_roughness_readable            = false;
+    state.lighting_working_set                 = {};
     state.lighting_reservoir_block_array_pitch = 0;
-    state.lighting_initialized_reservoir_mask    = 0;
+    state.lighting_initialized_reservoir_mask  = 0;
 }
 
 } // namespace Moer::Render::Raytracing

--- a/source/runtime/render/renderer/raytracing/RaytracingRenderer.cpp
+++ b/source/runtime/render/renderer/raytracing/RaytracingRenderer.cpp
@@ -1396,31 +1396,53 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
                 ERHIExecSubmitFlags::FlushGPU
             );
             RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
-            if (export_submission.SourceAccepted()) {
+            const auto export_source_outcome =
+                export_submission.SourceOutcome();
+            if (export_source_outcome ==
+                EExportSubmissionOutcome::Accepted) {
                 const bool readback_accepted = DumpTextureToFile(
                     ui_config.export_cfg,
                     state.rt_ctx->frame_rt,
                     device,
                     gfx_queue,
                     state.exported_file_path,
-                    std::to_string(time)
+                    std::to_string(time),
+                    export_submission
                 );
-                if (readback_accepted) {
-                    state.b_export           = false;
-                    feedback.export_consumed = true;
-                } else {
-                    LOG_CRITICAL(
-                        "[Raytracing][Export] Texture readback was not "
-                        "accepted for frame {}. Skipping encode and retaining "
-                        "the export request for retry.",
-                        frame_packet.frame_id
-                    );
+                if (!readback_accepted) {
+                    if (export_submission.ReadbackOutcome() ==
+                        EExportSubmissionOutcome::Failed) {
+                        LOG_CRITICAL(
+                            "[Raytracing][Export] Texture readback failed "
+                            "without an explicit recoverable rejection for "
+                            "frame {}. Skipping encode; the frame failure "
+                            "policy will latch the renderer.",
+                            frame_packet.frame_id
+                        );
+                    } else {
+                        LOG_WARNING(
+                            "[Raytracing][Export] Texture readback was rejected "
+                            "or could not be scheduled for frame {}. Skipping "
+                            "encode and retaining the export request for retry.",
+                            frame_packet.frame_id
+                        );
+                    }
                 }
-            } else {
+            } else if (
+                export_source_outcome ==
+                EExportSubmissionOutcome::Rejected
+            ) {
                 LOG_CRITICAL(
                     "[Raytracing][Export] Native submission rejected export "
                     "frame {}. Skipping readback and retaining the export "
                     "request for retry.",
+                    frame_packet.frame_id
+                );
+            } else {
+                LOG_CRITICAL(
+                    "[Raytracing][Export] Export frame {} failed without an "
+                    "explicit recoverable rejection. Skipping readback; the "
+                    "frame failure policy will latch the renderer.",
                     frame_packet.frame_id
                 );
             }
@@ -1529,13 +1551,30 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
     // recording completion. The final tail proves the ordered suffix was
     // accepted; the export and per-source graph fences prevent an accepted
     // tail from hiding a rejected separately submitted source.
-    bool frame_native_accepted = timeline->WaitSubmitted(time);
+    const EExportSubmissionOutcome tail_submission_outcome =
+        ExportSubmissionTransaction::ResolveReceiptOutcome(
+            timeline.Get(),
+            time
+        );
+    bool frame_native_accepted =
+        tail_submission_outcome ==
+        EExportSubmissionOutcome::Accepted;
+    bool independent_submission_source_failed =
+        state.render_graph_recording_failure_latched;
     frame_native_accepted =
         export_submission.FoldAcceptance(frame_native_accepted);
+    if (export_submission.ReadbackOutcome() ==
+        EExportSubmissionOutcome::Failed) {
+        independent_submission_source_failed = true;
+        frame_native_accepted                 = false;
+    }
     if (graph_submission_fence) {
         for (uint64 value = 1; value <= graph_submission_value_count; ++value) {
             const bool source_accepted =
                 graph_submission_fence->WaitSubmitted(value);
+            independent_submission_source_failed =
+                independent_submission_source_failed ||
+                !source_accepted;
             frame_native_accepted =
                 source_accepted && frame_native_accepted;
         }
@@ -1545,9 +1584,14 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
     if (graph_ui_recorded && ui_graph_submission_fence) {
         ui_source_accepted =
             ui_graph_submission_fence->WaitSubmitted(1);
+        independent_submission_source_failed =
+            independent_submission_source_failed ||
+            !ui_source_accepted;
     } else if (linear_ui_recorded) {
         // Linear UI work lives in the final tail itself.
-        ui_source_accepted = timeline->WaitSubmitted(time);
+        ui_source_accepted =
+            tail_submission_outcome ==
+            EExportSubmissionOutcome::Accepted;
     }
     bool ui_recording_committed = false;
     if (prepared_ui->GetRecordingState() ==
@@ -1555,6 +1599,9 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
         if (ui_source_accepted) {
             ui_recording_committed =
                 prepared_ui->CommitAcceptedSource();
+            independent_submission_source_failed =
+                independent_submission_source_failed ||
+                !ui_recording_committed;
         } else {
             prepared_ui->RejectSource();
         }
@@ -1564,20 +1611,27 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
                    UiFrameGraphPass::ERecordingState::FrameAccepted) {
         ui_recording_committed = true;
     } else {
+        independent_submission_source_failed = true;
         prepared_ui->RejectSource();
     }
     frame_native_accepted =
         frame_native_accepted && ui_recording_committed;
 #if WITH_NRD
     if (nrd_recorded && prepared_nrd) {
+        const bool upstream_sources_accepted =
+            frame_native_accepted;
         const bool nrd_submission_accepted =
-            frame_native_accepted &&
+            upstream_sources_accepted &&
             NrdDenoisePass::CommitAcceptedSubmission(
                 *prepared_nrd,
                 timeline,
                 time,
                 nrd_graph_submission_value_count
             );
+        if (upstream_sources_accepted &&
+            !nrd_submission_accepted) {
+            independent_submission_source_failed = true;
+        }
         frame_native_accepted =
             frame_native_accepted && nrd_submission_accepted;
         if (nrd_submission_accepted) {
@@ -1591,30 +1645,62 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
             prepared_nrd->interface->ResetAcceptedHistory();
             state.nrd_time                = 0;
             state.nrd_outputs_initialized = false;
-            state.render_graph_fallback_latched          = true;
-            state.render_graph_recording_failure_latched = true;
-            LOG_CRITICAL(
-                "[NRD] Native submission rejected the NRD source or final "
-                "frame tail, or the immutable temporal snapshot could not "
-                "commit; disabling managed RT passes for this renderer "
-                "instance without advancing NRD history."
-            );
+            if (upstream_sources_accepted) {
+                LOG_CRITICAL(
+                    "[NRD] Native submission rejected the NRD source or the "
+                    "immutable temporal snapshot could not commit. Resetting "
+                    "NRD history; the independent frame failure will latch "
+                    "managed RT recording."
+                );
+            } else {
+                LOG_WARNING(
+                    "[NRD] Upstream export/frame submission was rejected. "
+                    "Resetting NRD history without independently latching the "
+                    "renderer."
+                );
+            }
         }
     }
 #endif
     if (frame_native_accepted) {
-        frame_native_accepted =
+        const bool ui_frame_committed =
             prepared_ui->CommitAcceptedFrame();
+        independent_submission_source_failed =
+            independent_submission_source_failed ||
+            !ui_frame_committed;
+        frame_native_accepted =
+            frame_native_accepted && ui_frame_committed;
+    }
+    const ExportFrameSubmissionDecision export_frame_decision =
+        export_submission.ClassifyFrameAcceptance(
+            tail_submission_outcome,
+            frame_native_accepted,
+            independent_submission_source_failed
+        );
+    frame_native_accepted = export_frame_decision.frame_accepted;
+    feedback.export_consumed =
+        export_frame_decision.export_consumed;
+    if (feedback.export_consumed) {
+        state.b_export = false;
     }
     if (!frame_native_accepted) {
-        state.render_graph_fallback_latched          = true;
-        state.render_graph_recording_failure_latched = true;
-        LOG_CRITICAL(
-            "[RenderGraph][Raytracing] Native submission rejected the final "
-            "tail, export source, managed graph source, or copied UI source. "
-            "Preserving accepted renderer history and disabling managed "
-            "recording for this renderer instance."
-        );
+        if (export_frame_decision.latch_renderer) {
+            state.render_graph_fallback_latched          = true;
+            state.render_graph_recording_failure_latched = true;
+            LOG_CRITICAL(
+                "[RenderGraph][Raytracing] Native submission rejected the "
+                "final tail, a managed graph/UI/NRD source, or failed without "
+                "an explicit recoverable outcome. Preserving accepted "
+                "renderer history and disabling managed recording for this "
+                "renderer instance."
+            );
+        } else {
+            LOG_WARNING(
+                "[Raytracing][Export] Export prefix and its dependent tail "
+                "were recoverably rejected. Preserving renderer history and "
+                "the export request without latching managed recording."
+            );
+        }
     }
     const bool frame_setup_accepted =
         frame_native_accepted &&

--- a/source/runtime/render/renderer/raytracing/RaytracingRenderer.h
+++ b/source/runtime/render/renderer/raytracing/RaytracingRenderer.h
@@ -68,7 +68,7 @@ private:
     SceneUpdateResult ExecuteSceneUpdates(SceneUpdateBatch& batch);
     void RecreateFrameResources(uint2 new_extent);
 
-    void DumpTextureToFile(
+    [[nodiscard]] bool DumpTextureToFile(
         const ExportConfig&    _config,
         FrameResources&        _frame_rt,
         RenderDevice&          _device,

--- a/source/runtime/render/renderer/raytracing/RaytracingRenderer.h
+++ b/source/runtime/render/renderer/raytracing/RaytracingRenderer.h
@@ -8,6 +8,7 @@
 #include <optional>
 
 namespace Moer::Render::Raytracing {
+class ExportSubmissionTransaction;
 struct FrameResources;
 }
 
@@ -74,7 +75,8 @@ private:
         RenderDevice&          _device,
         CommandQueue&          _gfx_queue,
         std::filesystem::path& _exported_file_path,
-        std::string_view       _suffix
+        std::string_view       _suffix,
+        ExportSubmissionTransaction& _export_submission
     );
 };
 

--- a/source/runtime/render/renderer/raytracing/RaytracingRenderer.h
+++ b/source/runtime/render/renderer/raytracing/RaytracingRenderer.h
@@ -49,6 +49,7 @@ private:
     struct SceneUpdateResult {
         bool gpu_resources_updated = false;
         bool tlas_built             = false;
+        bool rt_scene_replaced      = false;
     };
 
     RuntimeAssets&          runtime_assets;
@@ -63,7 +64,7 @@ private:
     bool                                   export_request_in_flight        = false;
 
     void EnsureDebugUiRegistered(const EngineHooks& hooks);
-    void RefreshSceneRuntimeRefs();
+    bool RefreshSceneRuntimeRefs();
     SceneUpdateResult ExecuteSceneUpdates(SceneUpdateBatch& batch);
     void RecreateFrameResources(uint2 new_extent);
 

--- a/source/runtime/render/renderer/raytracing/RaytracingRenderer.h
+++ b/source/runtime/render/renderer/raytracing/RaytracingRenderer.h
@@ -46,6 +46,10 @@ public:
 
 private:
     struct RuntimeState;
+    struct SceneUpdateResult {
+        bool gpu_resources_updated = false;
+        bool tlas_built             = false;
+    };
 
     RuntimeAssets&          runtime_assets;
     UniquePtr<RuntimeState> runtime_state;
@@ -60,7 +64,7 @@ private:
 
     void EnsureDebugUiRegistered(const EngineHooks& hooks);
     void RefreshSceneRuntimeRefs();
-    bool ExecuteSceneUpdates(SceneUpdateBatch& batch);
+    SceneUpdateResult ExecuteSceneUpdates(SceneUpdateBatch& batch);
     void RecreateFrameResources(uint2 new_extent);
 
     void DumpTextureToFile(

--- a/source/runtime/render/renderer/raytracing/RaytracingRendererExport.cpp
+++ b/source/runtime/render/renderer/raytracing/RaytracingRendererExport.cpp
@@ -1,6 +1,7 @@
 #include "RaytracingRenderer.h"
 
 #include "RTResource.h"
+#include "RaytracingExportSubmission.h"
 #include "rhi/RHIExecutor.h"
 #include "taskgraph/TaskGraph.h"
 
@@ -20,7 +21,7 @@ union FloatBits {
 
 } // namespace
 
-void RaytracingRenderer::DumpTextureToFile(
+bool RaytracingRenderer::DumpTextureToFile(
     const ExportConfig&    config,
     FrameResources&        frame_resources,
     RenderDevice&          device,
@@ -80,15 +81,22 @@ void RaytracingRenderer::DumpTextureToFile(
     }
 
     if (size == 0) {
-        return;
+        return false;
     }
 
+    ExportSubmissionTransaction readback_submission(device.CreateFence());
+    CmdSubmit                    readback_submit =
+        command_list.Submit().TickProfiling();
+    readback_submission.AttachSignal(readback_submit);
     RHIExecutor::Get().Submit(
         EQueueType::Graphics,
-        command_list.Submit().TickProfiling(),
+        std::move(readback_submit),
         ERHIExecSubmitFlags::FlushGPU
     );
     RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
+    if (!readback_submission.SourceAccepted()) {
+        return false;
+    }
 
     if (hdr) {
         assert(
@@ -157,6 +165,7 @@ void RaytracingRenderer::DumpTextureToFile(
         }
         std::atomic_thread_fence(std::memory_order_seq_cst);
     }).Dispatch();
+    return true;
 }
 
 } // namespace Moer::Render::Raytracing

--- a/source/runtime/render/renderer/raytracing/RaytracingRendererExport.cpp
+++ b/source/runtime/render/renderer/raytracing/RaytracingRendererExport.cpp
@@ -27,7 +27,8 @@ bool RaytracingRenderer::DumpTextureToFile(
     RenderDevice&          device,
     CommandQueue&          gfx_queue,
     std::filesystem::path& exported_file_path,
-    std::string_view       suffix
+    std::string_view       suffix,
+    ExportSubmissionTransaction& export_submission
 ) {
     (void)gfx_queue;
     CommandList command_list{};
@@ -84,17 +85,17 @@ bool RaytracingRenderer::DumpTextureToFile(
         return false;
     }
 
-    ExportSubmissionTransaction readback_submission(device.CreateFence());
-    CmdSubmit                    readback_submit =
+    export_submission.BeginReadback(device.CreateFence());
+    CmdSubmit readback_submit =
         command_list.Submit().TickProfiling();
-    readback_submission.AttachSignal(readback_submit);
+    export_submission.AttachReadbackSignal(readback_submit);
     RHIExecutor::Get().Submit(
         EQueueType::Graphics,
         std::move(readback_submit),
         ERHIExecSubmitFlags::FlushGPU
     );
     RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
-    if (!readback_submission.SourceAccepted()) {
+    if (!export_submission.ResolveReadbackAcceptance()) {
         return false;
     }
 
@@ -109,63 +110,64 @@ bool RaytracingRenderer::DumpTextureToFile(
         );
     }
 
-    LambdaTask::Create([=,
-                        data(std::move(copy_back_data)),
-                        dequantize_byte_to_srgb(std::move(dequantize_byte_to_srgb)),
-                        dequantize_half(std::move(dequantize_half))]() mutable {
-        auto copy_back_data = std::move(data);
-        if (hdr) {
-            constexpr uint range_count = 8;
-            const uint     range       = copy_back_data.size() / range_count;
-            Array<float4>  copy_back_data_f4(copy_back_data.size() / 8);
-            ParallelFor(range_count, [&](uint index) {
-                const size_t start = range * index;
-                const size_t end   = range * (index + 1);
-                for (size_t i = start; i < copy_back_data.size() && i < end; i += 8) {
-                    float4* output = &copy_back_data_f4[i / 8];
-                    short*  input  = reinterpret_cast<short*>(&copy_back_data[i]);
-                    output->x      = dequantize_half(input[0]);
-                    output->y      = dequantize_half(input[1]);
-                    output->z      = dequantize_half(input[2]);
-                    output->w      = dequantize_half(input[3]);
-                }
-            });
-            stbi_write_hdr(
-                (exported_file_path / file_name).generic_string().data(),
-                resolution.x,
-                resolution.y,
-                4,
-                reinterpret_cast<float*>(copy_back_data_f4.data())
-            );
-        } else {
-            constexpr uint range_count = 8;
-            const uint     range       = copy_back_data.size() / range_count;
-            ParallelFor(range_count, [&](uint index) {
-                const size_t start = range * index;
-                const size_t end   = range * (index + 1);
-                for (size_t i = start; i < copy_back_data.size() && i < end; i += 4) {
-                    copy_back_data[i] =
-                        static_cast<Moer::byte>(dequantize_byte_to_srgb(ubyte(copy_back_data[i])));
-                    copy_back_data[i + 1] =
-                        static_cast<Moer::byte>(dequantize_byte_to_srgb(ubyte(copy_back_data[i + 1])));
-                    copy_back_data[i + 2] =
-                        static_cast<Moer::byte>(dequantize_byte_to_srgb(ubyte(copy_back_data[i + 2])));
-                    copy_back_data[i + 3] =
-                        static_cast<Moer::byte>(dequantize_byte_to_srgb(ubyte(copy_back_data[i + 3])));
-                }
-            });
-            stbi_write_png(
-                (exported_file_path / file_name).generic_string().data(),
-                resolution.x,
-                resolution.y,
-                4,
-                copy_back_data.data(),
-                4 * resolution.x
-            );
-        }
-        std::atomic_thread_fence(std::memory_order_seq_cst);
-    }).Dispatch();
-    return true;
+    return export_submission.DispatchEncoder([&] {
+        LambdaTask::Create([=,
+                            data(std::move(copy_back_data)),
+                            dequantize_byte_to_srgb(std::move(dequantize_byte_to_srgb)),
+                            dequantize_half(std::move(dequantize_half))]() mutable {
+            auto copy_back_data = std::move(data);
+            if (hdr) {
+                constexpr uint range_count = 8;
+                const uint     range       = copy_back_data.size() / range_count;
+                Array<float4>  copy_back_data_f4(copy_back_data.size() / 8);
+                ParallelFor(range_count, [&](uint index) {
+                    const size_t start = range * index;
+                    const size_t end   = range * (index + 1);
+                    for (size_t i = start; i < copy_back_data.size() && i < end; i += 8) {
+                        float4* output = &copy_back_data_f4[i / 8];
+                        short*  input  = reinterpret_cast<short*>(&copy_back_data[i]);
+                        output->x      = dequantize_half(input[0]);
+                        output->y      = dequantize_half(input[1]);
+                        output->z      = dequantize_half(input[2]);
+                        output->w      = dequantize_half(input[3]);
+                    }
+                });
+                stbi_write_hdr(
+                    (exported_file_path / file_name).generic_string().data(),
+                    resolution.x,
+                    resolution.y,
+                    4,
+                    reinterpret_cast<float*>(copy_back_data_f4.data())
+                );
+            } else {
+                constexpr uint range_count = 8;
+                const uint     range       = copy_back_data.size() / range_count;
+                ParallelFor(range_count, [&](uint index) {
+                    const size_t start = range * index;
+                    const size_t end   = range * (index + 1);
+                    for (size_t i = start; i < copy_back_data.size() && i < end; i += 4) {
+                        copy_back_data[i] =
+                            static_cast<Moer::byte>(dequantize_byte_to_srgb(ubyte(copy_back_data[i])));
+                        copy_back_data[i + 1] =
+                            static_cast<Moer::byte>(dequantize_byte_to_srgb(ubyte(copy_back_data[i + 1])));
+                        copy_back_data[i + 2] =
+                            static_cast<Moer::byte>(dequantize_byte_to_srgb(ubyte(copy_back_data[i + 2])));
+                        copy_back_data[i + 3] =
+                            static_cast<Moer::byte>(dequantize_byte_to_srgb(ubyte(copy_back_data[i + 3])));
+                    }
+                });
+                stbi_write_png(
+                    (exported_file_path / file_name).generic_string().data(),
+                    resolution.x,
+                    resolution.y,
+                    4,
+                    copy_back_data.data(),
+                    4 * resolution.x
+                );
+            }
+            std::atomic_thread_fence(std::memory_order_seq_cst);
+        }).Dispatch();
+    });
 }
 
 } // namespace Moer::Render::Raytracing

--- a/source/runtime/render/renderer/raytracing/ShaderUtils.cpp
+++ b/source/runtime/render/renderer/raytracing/ShaderUtils.cpp
@@ -18,6 +18,16 @@ constexpr uint DivCeil(uint value, uint divisor) {
     return (value + divisor - 1) / divisor;
 }
 
+constexpr uint MipExtent(uint base_extent, uint mip_level) {
+    return std::max(1u, base_extent >> std::min(mip_level, 31u));
+}
+
+static_assert(MipExtent(4096, 0) == 4096);
+static_assert(MipExtent(4096, 5) == 128);
+static_assert(MipExtent(4096, 10) == 4);
+static_assert(MipExtent(4096, 12) == 1);
+static_assert(MipExtent(1, 13) == 1);
+
 } // namespace
 
 ShaderUtils::ShaderUtils(ShaderManager& manager) {
@@ -41,7 +51,7 @@ void ShaderUtils::GenerateLowDiscrepancySequence(
 ) {
     assert(_param.num_dimensions == 2);
     assert(_param.num_samples * _param.num_dimensions <= _output.GetByteSize());
-    Array<int8> data(_param.num_samples * 2);
+    Array<int8>   data(_param.num_samples * 2);
     constexpr int radius_scale = 250;
     const float   phi2         = 1.0f / 1.3247179572447f;
     uint32_t      num          = 0;
@@ -94,6 +104,23 @@ void ShaderUtils::GenerateMipPdf(
         width  = std::max(1u, width >> 5);
         height = std::max(1u, height >> 5);
     }
+}
+
+void ShaderUtils::GenerateMipsChunk(CommandList& cmd_list, std::span<TextureView> mips) {
+    if (mips.size() < 2) {
+        return;
+    }
+
+    assert(mips.size() <= 6);
+    const TextureView& source_mip = mips.front();
+    const uint         width      = MipExtent(source_mip.extent.x, source_mip.mip_level);
+    const uint         height     = MipExtent(source_mip.extent.y, source_mip.mip_level);
+    BuildMipsParam     param{};
+    param.num_mip_levels = static_cast<uint>(mips.size());
+    param.src_mip_level  = 0;
+    param.src_size       = uint2(width, height);
+    cmd_list.Compute(generate_mips_pipeline, mips, param)
+        .Dispatch(uint3(DivCeil(width, 32), DivCeil(height, 32), 1), "GenerateMips");
 }
 
 void ShaderUtils::GenerateMips(CommandList& _cmd_list, std::span<TextureView> _mips) {

--- a/source/runtime/render/renderer/raytracing/ShaderUtils.h
+++ b/source/runtime/render/renderer/raytracing/ShaderUtils.h
@@ -64,10 +64,8 @@ using UtilsSampleTexturePipelineCS [[deprecated("Use CopyTextureComputePipeline 
 class ShaderUtils {
 public:
     explicit ShaderUtils(ShaderManager& manager);
-    [[deprecated("RenderDevice is no longer required; use ShaderUtils(ShaderManager&) instead")]] ShaderUtils(
-        RenderDevice& device,
-        ShaderManager& manager
-    );
+    [[deprecated("RenderDevice is no longer required; use ShaderUtils(ShaderManager&) instead"
+    )]] ShaderUtils(RenderDevice& device, ShaderManager& manager);
 
     GenLowDiscrepancyPipeline& GetGenLowDiscrepancyPipeline() {
         return gen_low_discrepancy_pipeline;
@@ -91,6 +89,7 @@ public:
         const TextureView&     _env_map,
         std::span<TextureView> _integrated_mips
     );
+    void GenerateMipsChunk(CommandList& cmd_list, std::span<TextureView> mips);
     void GenerateMips(CommandList& _cmd_list, std::span<TextureView> _mips);
     void SampleTextureCS(CommandList& cmd_list, TextureView input_texture, TextureView output_texture);
 

--- a/source/runtime/render/renderer/raytracing/ShowTexturePass.cpp
+++ b/source/runtime/render/renderer/raytracing/ShowTexturePass.cpp
@@ -118,13 +118,14 @@ bool ShowTexturePass::AddPass(
     ShowTextureParams          params,
     const TextureRef&          source,
     const TextureRef&          target,
-    RenderGraph::TokenHandle   frame_setup_ready
+    RenderGraph::TokenHandle   frame_setup_ready,
+    RenderGraph::TokenHandle   presentation_ready
 ) {
     const auto owner = recording_owner;
     if (!owner || !owner->bindless_array ||
         !CanRecordShowTexture(source, target) ||
         !source_handle.IsValid() || !target_handle.IsValid() ||
-        !frame_setup_ready.IsValid()) {
+        !frame_setup_ready.IsValid() || !presentation_ready.IsValid()) {
         return false;
     }
 
@@ -148,6 +149,7 @@ bool ShowTexturePass::AddPass(
                     RenderGraph::PipelineType::Graphics
                 )
                 .Read(frame_setup_ready)
+                .ReadWrite(presentation_ready)
                 .Read(source_handle, RenderGraph::TextureState::Sampled)
                 .Write(target_handle, RenderGraph::TextureState::RenderTarget);
         },

--- a/source/runtime/render/renderer/raytracing/ShowTexturePass.cpp
+++ b/source/runtime/render/renderer/raytracing/ShowTexturePass.cpp
@@ -117,12 +117,14 @@ bool ShowTexturePass::AddPass(
     RenderGraph::TextureHandle target_handle,
     ShowTextureParams          params,
     const TextureRef&          source,
-    const TextureRef&          target
+    const TextureRef&          target,
+    RenderGraph::TokenHandle   frame_setup_ready
 ) {
     const auto owner = recording_owner;
     if (!owner || !owner->bindless_array ||
         !CanRecordShowTexture(source, target) ||
-        !source_handle.IsValid() || !target_handle.IsValid()) {
+        !source_handle.IsValid() || !target_handle.IsValid() ||
+        !frame_setup_ready.IsValid()) {
         return false;
     }
 
@@ -145,6 +147,7 @@ bool ShowTexturePass::AddPass(
                     RenderGraph::QueueRole::Graphics,
                     RenderGraph::PipelineType::Graphics
                 )
+                .Read(frame_setup_ready)
                 .Read(source_handle, RenderGraph::TextureState::Sampled)
                 .Write(target_handle, RenderGraph::TextureState::RenderTarget);
         },

--- a/source/runtime/render/renderer/raytracing/ShowTexturePass.h
+++ b/source/runtime/render/renderer/raytracing/ShowTexturePass.h
@@ -46,7 +46,8 @@ public:
         RenderGraph::TextureHandle target_handle,
         ShowTextureParams          params,
         const TextureRef&          source,
-        const TextureRef&          target
+        const TextureRef&          target,
+        RenderGraph::TokenHandle   frame_setup_ready
     );
 
 private:

--- a/source/runtime/render/renderer/raytracing/ShowTexturePass.h
+++ b/source/runtime/render/renderer/raytracing/ShowTexturePass.h
@@ -47,7 +47,8 @@ public:
         ShowTextureParams          params,
         const TextureRef&          source,
         const TextureRef&          target,
-        RenderGraph::TokenHandle   frame_setup_ready
+        RenderGraph::TokenHandle   frame_setup_ready,
+        RenderGraph::TokenHandle   presentation_ready
     );
 
 private:

--- a/source/runtime/render/renderer/raytracing/VisualizePass.cpp
+++ b/source/runtime/render/renderer/raytracing/VisualizePass.cpp
@@ -136,7 +136,8 @@ bool VisualizePass::AddPasses(
         !graph_resources.current_specular_roughness.IsValid() ||
         !graph_resources.motion.IsValid() ||
         !graph_resources.normal_roughness.IsValid() ||
-        !graph_resources.debug_color.IsValid()) {
+        !graph_resources.debug_color.IsValid() ||
+        !graph_resources.presentation_ready.IsValid()) {
         return false;
     }
 
@@ -266,7 +267,8 @@ bool VisualizePass::AddPasses(
                 .Write(
                     graph_resources.debug_color,
                     RenderGraph::TextureState::UnorderedAccess
-                );
+                )
+                .Write(graph_resources.presentation_ready);
         },
         [owner, command, resources](CommandList& cmd_list) {
             ScopedGpuMarker marker(

--- a/source/runtime/render/rendergraph/RenderGraph.cpp
+++ b/source/runtime/render/rendergraph/RenderGraph.cpp
@@ -125,6 +125,16 @@ const char* ToString(RenderGraph::PassExecutionClass execution) {
     return "unknown";
 }
 
+const char* ToString(ERHITranslateExecutionClass execution) {
+    switch (execution) {
+        case ERHITranslateExecutionClass::Parallel:
+            return "parallel";
+        case ERHITranslateExecutionClass::SerialControl:
+            return "serial-control";
+    }
+    return "unknown";
+}
+
 const char* ToString(RenderGraph::TextureState state) {
     switch (state) {
         case RenderGraph::TextureState::Automatic:
@@ -738,6 +748,14 @@ RenderGraph::PassBuilder& RenderGraph::PassBuilder::ParallelRecord(uint32_t work
     return *this;
 }
 
+RenderGraph::PassBuilder& RenderGraph::PassBuilder::TranslateSerialControl() {
+    graph.SetPassTranslateExecutionClass(
+        pass_index,
+        ERHITranslateExecutionClass::SerialControl
+    );
+    return *this;
+}
+
 RenderGraph::ResourceHandle
 RenderGraph::Import(std::string_view resource_name, ResourceKind kind, const void* physical_identity) {
     return ImportInternal(resource_name, kind, physical_identity, nullptr, nullptr);
@@ -1270,6 +1288,8 @@ bool RenderGraph::Execute(const PassCompletedCallback& after_pass) {
                 .domain      = pass.domain,
                 .side_effect = pass.side_effect,
                 .execution_class = pass.execution_class,
+                .translate_execution_class =
+                    pass.translate_execution_class,
             });
         }
     }
@@ -1594,6 +1614,9 @@ bool RenderGraph::ExecuteRecording(
         RecordCallback      record{};
         SharedPtr<CommandList> command_list{};
         RHIRecordingGateRef completion{};
+        ERHITranslateExecutionClass translate_execution_class{
+            ERHITranslateExecutionClass::Parallel
+        };
         std::vector<BarrierCreateInfo>                    before{};
         std::vector<BarrierCreateInfo>                    after{};
         std::vector<RenderGraphLowering::PhysicalBinding> keepalive{};
@@ -1801,6 +1824,8 @@ bool RenderGraph::ExecuteRecording(
             .domain          = pass.domain,
             .side_effect     = pass.side_effect,
             .execution_class = pass.execution_class,
+            .translate_execution_class =
+                pass.translate_execution_class,
         };
     };
 
@@ -2025,7 +2050,12 @@ bool RenderGraph::ExecuteRecording(
                 .record       = pass.record,
                 .command_list = MakeShared<CommandList>(queue),
                 .completion   = RHIRecordingGate::Create(),
+                .translate_execution_class =
+                    batch.translate_execution_class,
             };
+            job.command_list->SetTranslateExecutionClass(
+                job.translate_execution_class
+            );
             if (active_recording.enabled) {
                 const auto& pass_state = active_pass_states[handle.index];
                 job.before             = pass_state.before;
@@ -2037,6 +2067,11 @@ bool RenderGraph::ExecuteRecording(
                 .completion   = job.completion,
                 .commit       = active_recording_commit,
             };
+            if (batch.translate_execution_class !=
+                ERHITranslateExecutionClass::Parallel) {
+                source.submit_metadata.translate_execution_class =
+                    batch.translate_execution_class;
+            }
             if (active_recording.enabled) {
                 const auto& pass_state = active_pass_states[handle.index];
                 source.submit_metadata.wait_fences =
@@ -2093,6 +2128,16 @@ bool RenderGraph::ExecuteRecording(
                                     pass.name + "'";
                     return false;
                 }
+                if (batch.translate_execution_class ==
+                        ERHITranslateExecutionClass::SerialControl &&
+                    source.submit_metadata.translate_execution_class !=
+                        ERHITranslateExecutionClass::SerialControl) {
+                    compile_error =
+                        "recording source configuration weakened the declared "
+                        "SerialControl translation policy for pass '" +
+                        pass.name + "'";
+                    return false;
+                }
                 if (job.completion->Status() != ERHIRecordingStatus::Pending) {
                     compile_error =
                         "recording source configuration completed the producer gate for pass '" +
@@ -2111,7 +2156,7 @@ bool RenderGraph::ExecuteRecording(
                 if (!source.command_list->IsEmpty() ||
                     source.command_list->HasExplicitResourceStateOwnership() ||
                     source.command_list->GetTranslateExecutionClass() !=
-                        ERHITranslateExecutionClass::Parallel) {
+                        batch.translate_execution_class) {
                     compile_error =
                         "recording source configuration may only change submit metadata "
                         "for pass '" +
@@ -2200,7 +2245,7 @@ bool RenderGraph::ExecuteRecording(
                     );
                 }
                 if (job.command_list->GetTranslateExecutionClass() !=
-                    ERHITranslateExecutionClass::Parallel) {
+                    job.translate_execution_class) {
                     throw std::logic_error(
                         "record callback changed its managed translation class"
                     );
@@ -2263,7 +2308,7 @@ bool RenderGraph::ExecuteRecording(
                 !job.command_list->IsEmpty() ||
                 job.command_list->HasExplicitResourceStateOwnership() ||
                 job.command_list->GetTranslateExecutionClass() !=
-                    ERHITranslateExecutionClass::Parallel ||
+                    job.translate_execution_class ||
                 (active_recording_commit &&
                  active_recording_commit->Status() !=
                      ERHIRecordingStatus::Pending)) {
@@ -2404,6 +2449,7 @@ std::string RenderGraph::Dump() const {
                << " queue=" << ToString(pass.domain.queue)
                << " pipeline=" << ToString(pass.domain.pipeline)
                << " cpu=" << ToString(pass.execution_class)
+               << " translate=" << ToString(pass.translate_execution_class)
                << " workload=" << pass.workload
                << " side_effect=" << (pass.side_effect ? "true" : "false") << " accesses=[";
         for (uint32_t access_index = 0; access_index < pass.accesses.size(); ++access_index) {
@@ -2730,7 +2776,9 @@ std::string RenderGraph::Dump() const {
     for (const auto& batch : compiled_plan.recording_batches) {
         stream << "  [" << batch.id << "] queue=" << ToString(batch.queue.role)
                << "/native" << batch.queue.native_queue_id << "/family" << batch.queue.family_id
-               << " cpu=" << ToString(batch.execution) << " workload=" << batch.workload
+               << " cpu=" << ToString(batch.execution)
+               << " translate=" << ToString(batch.translate_execution_class)
+               << " workload=" << batch.workload
                << " wave=";
         if (batch.dependency_wave == PassHandle::InvalidIndex) {
             stream << "none";
@@ -2921,6 +2969,30 @@ void RenderGraph::SetPassExecutionClass(
     }
     passes[pass_index].execution_class = execution_class;
     passes[pass_index].workload        = workload;
+}
+
+void RenderGraph::SetPassTranslateExecutionClass(
+    uint32_t                    pass_index,
+    ERHITranslateExecutionClass execution_class
+) {
+    if (!InvalidateCompile()) {
+        return;
+    }
+    if (pass_index >= passes.size()) {
+        declaration_errors.emplace_back(
+            "translation-class declaration has invalid pass index"
+        );
+        return;
+    }
+    if (execution_class != ERHITranslateExecutionClass::Parallel &&
+        execution_class != ERHITranslateExecutionClass::SerialControl) {
+        declaration_errors.emplace_back(
+            "pass '" + passes[pass_index].name +
+            "' has an invalid translation execution class"
+        );
+        return;
+    }
+    passes[pass_index].translate_execution_class = execution_class;
 }
 
 bool RenderGraph::InvalidateCompile() {

--- a/source/runtime/render/rendergraph/RenderGraph.h
+++ b/source/runtime/render/rendergraph/RenderGraph.h
@@ -460,6 +460,9 @@ public:
         QueueBinding            queue{};
         std::vector<PassHandle> passes{};
         PassExecutionClass      execution = PassExecutionClass::SerialRecord;
+        ERHITranslateExecutionClass translate_execution_class{
+            ERHITranslateExecutionClass::Parallel
+        };
         uint32_t                workload = 1;
         uint32_t                dependency_wave = PassHandle::InvalidIndex;
     };
@@ -695,6 +698,13 @@ public:
         PassBuilder& ExternalControl();
         PassBuilder& SerialRecord(uint32_t workload = 1);
         PassBuilder& ParallelRecord(uint32_t workload = 1);
+        /**
+         * Makes backend translation of this recorded source a stable CPU
+         * frontier. The callback still owns an ordinary graph CommandList;
+         * this policy is for external mutable integrations that must not
+         * translate concurrently with earlier or later sources.
+         */
+        PassBuilder& TranslateSerialControl();
 
     private:
         PassBuilder(RenderGraph& graph, uint32_t pass_index) : graph(graph), pass_index(pass_index) {}
@@ -711,6 +721,9 @@ public:
         ExecutionDomain domain{};
         bool             side_effect{false};
         PassExecutionClass execution_class = PassExecutionClass::MainThread;
+        ERHITranslateExecutionClass translate_execution_class{
+            ERHITranslateExecutionClass::Parallel
+        };
     };
 
     using SetupCallback         = std::function<void(PassBuilder&)>;
@@ -966,6 +979,9 @@ private:
         ExecutionDomain               domain{};
         bool                           side_effect = false;
         PassExecutionClass             execution_class = PassExecutionClass::MainThread;
+        ERHITranslateExecutionClass     translate_execution_class{
+            ERHITranslateExecutionClass::Parallel
+        };
         uint32_t                       workload = 1;
     };
 
@@ -1010,6 +1026,10 @@ private:
         uint32_t           pass_index,
         PassExecutionClass execution_class,
         uint32_t           workload
+    );
+    void SetPassTranslateExecutionClass(
+        uint32_t                    pass_index,
+        ERHITranslateExecutionClass execution_class
     );
     bool InvalidateCompile();
     bool FailCompile(std::string message);

--- a/source/runtime/render/rendergraph/RenderGraphCompiler.cpp
+++ b/source/runtime/render/rendergraph/RenderGraphCompiler.cpp
@@ -298,6 +298,14 @@ bool RenderGraphCompiler::NormalizeDeclarations() {
                 "record pass '" + pass.name + "' must use SerialRecord or ParallelRecordEligible"
             );
         }
+        if (has_execute &&
+            pass.translate_execution_class !=
+                ERHITranslateExecutionClass::Parallel) {
+            return Fail(
+                "caller-thread pass '" + pass.name +
+                "' cannot declare a backend translation policy"
+            );
+        }
         if (pass.workload == 0) {
             return Fail("pass '" + pass.name + "' has zero recording workload");
         }
@@ -1697,6 +1705,8 @@ void RenderGraphCompiler::BuildRecordingBatches() {
             .queue           = graph.queue_topology.Resolve(pass.domain.queue),
             .passes          = {pass_handle},
             .execution       = pass.execution_class,
+            .translate_execution_class =
+                pass.translate_execution_class,
             .workload        = pass.workload,
             .dependency_wave = pass_to_wave[pass_handle.index],
         });

--- a/source/runtime/render/rhi/RHICommand.h
+++ b/source/runtime/render/rhi/RHICommand.h
@@ -1326,9 +1326,19 @@ public:
         std::string_view _name = Command::typenames[(uint)Command::EType::UploadBuffer]
     );
     RENDER_API void CopyFrom(
+        std::span<const byte> _data,
+        BufferView            _dst,
+        std::string_view      _name = Command::typenames[(uint)Command::EType::UploadBuffer]
+    );
+    RENDER_API void CopyFrom(
         std::span<byte>  _data,
         TextureView      _dst,
         std::string_view _name = Command::typenames[(uint)Command::EType::UploadTexture]
+    );
+    RENDER_API void CopyFrom(
+        std::span<const byte> _data,
+        TextureView           _dst,
+        std::string_view      _name = Command::typenames[(uint)Command::EType::UploadTexture]
     );
     RENDER_API void CopyFrom(
         Array<byte>&&    _data,

--- a/source/runtime/render/rhi/RHICommand.h
+++ b/source/runtime/render/rhi/RHICommand.h
@@ -1524,6 +1524,7 @@ public:
     RENDER_API void BuildAccelerationStructures(Array<AccelerationStructureBuildParam>&& _params);
 
     RENDER_API void UpdateRaytracingScene(RaytracingSceneRef _scene);
+    RENDER_API void UpdateRaytracingScene(UniquePtr<Command>&& _prepared_update);
 
 #pragma endregion
 

--- a/source/runtime/render/rhi/RHICommand.h
+++ b/source/runtime/render/rhi/RHICommand.h
@@ -1751,6 +1751,7 @@ public:
     void Resolve(bool _submitted, bool _recreate_swapchain = false) {
         {
             std::unique_lock<std::mutex> lock(mutex);
+            ++resolution_attempts;
             if (resolved) {
                 return;
             }
@@ -1772,11 +1773,17 @@ public:
         return result;
     }
 
+    [[nodiscard]] uint32 ResolutionAttemptCount() const noexcept {
+        std::unique_lock<std::mutex> lock(mutex);
+        return resolution_attempts;
+    }
+
 private:
-    std::mutex               mutex;
+    mutable std::mutex       mutex;
     std::condition_variable  cv;
     PresentReceiptResult     result{};
     bool                     resolved{false};
+    uint32                   resolution_attempts{0};
 };
 
 using PresentReceiptRef = SharedPtr<PresentReceipt>;

--- a/source/runtime/render/rhi/RHICommand.h
+++ b/source/runtime/render/rhi/RHICommand.h
@@ -425,7 +425,7 @@ struct CmdSubmit {
         Array<std::function<void(void)>>&& _callbacks,
         Array<std::function<void(void)>>&& _success_callbacks,
         TCachedArgArray&&                  _cached_args
-    ) :
+    ) noexcept :
         cmds(std::move(_cmds)),
         callbacks(std::move(_callbacks)),
         success_callbacks(std::move(_success_callbacks)),
@@ -1539,6 +1539,13 @@ public:
 
     RENDER_API void AddCallback(std::function<void()>&& _callback);
     RENDER_API void AddSuccessCallback(std::function<void()>&& _callback);
+    /**
+     * Attaches a native-submission acceptance marker to this CommandList.
+     * Unlike CmdSubmit::Signal(), this form is available to independently
+     * recorded graph sources before the graph seals their immutable submit.
+     */
+    RENDER_API void Signal(Fence* _fence, uint64 _signal_value);
+    RENDER_API void Signal(const FenceRef& _fence, uint64 _signal_value);
 
     RENDER_API ArrayArgReference RegisterArgs(ArrayArguments&& _args);
 
@@ -1659,6 +1666,7 @@ private:
     Command*                     current_barriers{nullptr};
     Array<std::function<void()>> callbacks;
     Array<std::function<void()>> success_callbacks;
+    Array<SignalEvent>            signal_events;
     TCachedArgArray              cached_args;
     EQueueType                   queue_type{EQueueType::Graphics};
     ERHITranslateExecutionClass  translate_execution_class{

--- a/source/runtime/render/rhi/RHICommandList.cpp
+++ b/source/runtime/render/rhi/RHICommandList.cpp
@@ -554,7 +554,23 @@ void CommandList::BuildAccelerationStructures(Array<AccelerationStructureBuildPa
 }
 
 void CommandList::UpdateRaytracingScene(RaytracingSceneRef _scene) {
-    commands.emplace_back(_scene->UpdateScene());
+    if (!_scene) {
+        return;
+    }
+    UniquePtr<Command> command = _scene->UpdateScene();
+    if (command) {
+        commands.emplace_back(std::move(command));
+    }
+}
+
+void CommandList::UpdateRaytracingScene(UniquePtr<Command>&& _prepared_update) {
+    assert(
+        _prepared_update && _prepared_update->Type() == Command::EType::BuildTLAS &&
+        "Prepared ray tracing scene update must be a BuildTLAS command"
+    );
+    if (_prepared_update && _prepared_update->Type() == Command::EType::BuildTLAS) {
+        commands.emplace_back(std::move(_prepared_update));
+    }
 }
 
 #pragma endregion

--- a/source/runtime/render/rhi/RHICommandList.cpp
+++ b/source/runtime/render/rhi/RHICommandList.cpp
@@ -356,6 +356,14 @@ void CommandList::CopyFrom(BufferView _src, TextureView _dst, std::string_view _
 }
 
 void CommandList::CopyFrom(std::span<byte> _data, TextureView _texture, std::string_view _name) {
+    CopyFrom(std::span<const byte>(_data.data(), _data.size()), _texture, _name);
+}
+
+void CommandList::CopyFrom(
+    std::span<const byte> _data,
+    TextureView           _texture,
+    std::string_view      _name
+) {
     uint3 extent = uint3(
         std::max(uint(_texture.extent.x) >> _texture.mip_level, 1u),
         std::max(uint(_texture.extent.y) >> _texture.mip_level, 1u),
@@ -377,6 +385,14 @@ void CommandList::CopyFrom(std::span<byte> _data, TextureView _texture, std::str
 }
 
 void CommandList::CopyFrom(std::span<byte> _data, BufferView _buffer, std::string_view _name) {
+    CopyFrom(std::span<const byte>(_data.data(), _data.size()), _buffer, _name);
+}
+
+void CommandList::CopyFrom(
+    std::span<const byte> _data,
+    BufferView            _buffer,
+    std::string_view      _name
+) {
     if (_data.size() == 0) {
         return;
     }

--- a/source/runtime/render/rhi/RHICommandList.cpp
+++ b/source/runtime/render/rhi/RHICommandList.cpp
@@ -60,6 +60,7 @@ CommandList& CommandList::operator=(CommandList&& _other) {
     current_barriers            = _other.current_barriers;
     callbacks                   = std::move(_other.callbacks);
     success_callbacks           = std::move(_other.success_callbacks);
+    signal_events               = std::move(_other.signal_events);
     cached_args                 = std::move(_other.cached_args);
     queue_type                  = _other.queue_type;
     translate_execution_class   = _other.translate_execution_class;
@@ -219,28 +220,35 @@ CmdSubmit CommandList::Submit() {
             scope_stack.pop();
         }
     }
+    const bool has_submit_side_effects =
+        !callbacks.empty() || !success_callbacks.empty() ||
+        !signal_events.empty();
+    Array<RHISubmitSegment> submit_segments{};
+    if (!commands.empty() || has_submit_side_effects) {
+        // Allocate the segment before transferring signal/callback ownership.
+        // If allocation fails, the CommandList remains intact and can still
+        // be retried or terminally drained by the recording owner.
+        submit_segments.emplace_back(RHISubmitSegment{
+            .queue = queue_type,
+            .begin = 0,
+            .end   = commands.size(),
+        });
+    }
+
     CmdSubmit submit(
         std::move(commands),
         std::move(callbacks),
         std::move(success_callbacks),
         std::move(cached_args)
     );
-    const bool has_submit_side_effects =
-        !submit.callbacks.empty() || !submit.success_callbacks.empty() ||
-        !submit.wait_events.empty() || !submit.signal_events.empty() ||
-        submit.b_delete_resources;
-    if (!submit.cmds.empty() || has_submit_side_effects) {
-        submit.segments.emplace_back(RHISubmitSegment{
-            .queue = queue_type,
-            .begin = 0,
-            .end   = submit.cmds.size(),
-        });
-    }
+    submit.signal_events = std::move(signal_events);
+    submit.segments      = std::move(submit_segments);
     submit.translate_execution_class = translate_execution_class;
     submit.resource_state_ownership   = resource_state_ownership;
     commands.clear();
     callbacks.clear();
     success_callbacks.clear();
+    signal_events.clear();
     timestamp_scope_names.clear();
     translate_execution_class = ERHITranslateExecutionClass::Parallel;
     resource_state_ownership  = ERHIResourceStateOwnership::BackendTracked;
@@ -256,6 +264,13 @@ Array<std::function<void()>> CommandList::DrainOrdinaryCallbacksForRejection() {
     ++seal_generation;
     Array<std::function<void()>> cleanup_callbacks = std::move(callbacks);
 
+    for (const SignalEvent& signal : signal_events) {
+        auto* fence = reinterpret_cast<Fence*>(signal.timeline_handle);
+        if (fence != nullptr) {
+            fence->Reject(signal.value);
+        }
+    }
+
     // This is deliberately not implemented in terms of Submit(). A failed
     // producer may leave a partially-built barrier or an unmatched marker;
     // neither is executable, and Submit() correctly asserts on that shape in
@@ -264,6 +279,7 @@ Array<std::function<void()>> CommandList::DrainOrdinaryCallbacksForRejection() {
     commands.clear();
     callbacks.clear();
     success_callbacks.clear();
+    signal_events.clear();
     cached_args.clear();
     current_barriers = nullptr;
     while (!scope_stack.empty()) {
@@ -276,7 +292,9 @@ Array<std::function<void()>> CommandList::DrainOrdinaryCallbacksForRejection() {
 }
 
 bool CommandList::IsEmpty() const {
-    return commands.empty() && callbacks.empty() && success_callbacks.empty() && cached_args.empty();
+    return commands.empty() && callbacks.empty() &&
+           success_callbacks.empty() && signal_events.empty() &&
+           cached_args.empty();
 }
 
 void CommandList::CopyFrom(BufferView _src, BufferView _dst, std::string_view _name) {
@@ -714,6 +732,32 @@ void CommandList::AddCallback(std::function<void()>&& _callback) {
 
 void CommandList::AddSuccessCallback(std::function<void()>&& _callback) {
     success_callbacks.emplace_back(std::move(_callback));
+}
+
+void CommandList::Signal(Fence* _fence, uint64 _signal_value) {
+    if (_fence == nullptr || _signal_value == 0) {
+        throw std::invalid_argument(
+            "CommandList::Signal requires a valid fence and non-zero value"
+        );
+    }
+    signal_events.emplace_back(uint64(_fence), _signal_value);
+}
+
+void CommandList::Signal(const FenceRef& _fence, uint64 _signal_value) {
+    if (!_fence.IsValid() || _signal_value == 0) {
+        throw std::invalid_argument(
+            "CommandList::Signal requires a valid fence and non-zero value"
+        );
+    }
+
+    // SignalEvent is a backend-facing raw identity. Prepare every allocation
+    // before publishing either half of the pair so an allocation failure can
+    // never leave a raw fence without its strong-reference keepalive.
+    std::function<void()> keepalive = [fence = _fence] {};
+    callbacks.reserve(callbacks.size() + 1);
+    signal_events.reserve(signal_events.size() + 1);
+    callbacks.emplace_back(std::move(keepalive));
+    signal_events.emplace_back(uint64(_fence.Get()), _signal_value);
 }
 
 void CommandList::BeginBarriers(

--- a/source/runtime/render/rhi/RHIExecutor.cpp
+++ b/source/runtime/render/rhi/RHIExecutor.cpp
@@ -232,6 +232,36 @@ void ReportBackendCreationFailure(
     }
 }
 
+void ReportBackendPublicationFailure(
+    std::string_view          _operation,
+    const std::exception_ptr& _failure
+) noexcept {
+    try {
+        if (_failure) {
+            std::rethrow_exception(_failure);
+        }
+    } catch (const std::exception& exception) {
+        try {
+            LOG_ERROR(
+                "[RHIExecutor] backend publication failed during {}: {}",
+                _operation,
+                exception.what()
+            );
+        } catch (...) {
+        }
+        return;
+    } catch (...) {
+    }
+
+    try {
+        LOG_ERROR(
+            "[RHIExecutor] backend publication failed during {}",
+            _operation
+        );
+    } catch (...) {
+    }
+}
+
 void FinalizeCancelledRecordingSources(
     Array<RHIRecordingSource>&& _sources,
     std::string_view             _reason
@@ -417,6 +447,36 @@ public:
             ordered_copy_timeline = ordered_tail_copy_timeline;
         }
 
+        const RHIQueueTopology queue_topology =
+            RenderDevice::Get().GetQueueTopology();
+        for (const RHIBackendSubmissionBatchEntry& entry : _batch.submits) {
+            if (SubmitHasWork(entry.submit) &&
+                !queue_topology.Resolve(entry.queue).available) {
+                throw std::runtime_error(
+                    "legacy RHI backend received work for an unavailable queue"
+                );
+            }
+        }
+        if (_batch.present.has_value() &&
+            !queue_topology.graphics.available) {
+            throw std::runtime_error(
+                "legacy RHI backend cannot Present without a graphics queue"
+            );
+        }
+
+        // Enqueue's exception contract leaves only the unaccepted suffix in
+        // `_batch`. Publish the accepted prefix tail even if a later queue
+        // operation throws, so subsequent D3D12 batches cannot overtake work
+        // which already crossed a native queue boundary.
+        ScopeExit publish_ordered_tail([&]() noexcept {
+            try {
+                std::lock_guard lock(state_mutex);
+                ordered_tail_queue         = last_queue;
+                ordered_tail_copy_timeline = ordered_copy_timeline;
+            } catch (...) {
+            }
+        });
+
         for (RHIBackendSubmissionBatchEntry& entry : _batch.submits) {
             if (!SubmitHasWork(entry.submit)) {
                 continue;
@@ -441,14 +501,15 @@ public:
                 case EQueueType::Ignore:
                 case EQueueType::Num:
                 default:
-                    LOG_ERROR(
-                        "[RHIExecutor] batch {} rejected invalid queue {}",
-                        _batch.sequence,
-                        static_cast<uint32>(entry.queue)
+                    throw std::runtime_error(
+                        "legacy RHI backend received an invalid queue"
                     );
-                    assert(false && "RHI backend batch contains an invalid queue");
-                    continue;
             }
+            // Queue::Execute has either accepted the native work and retained
+            // its callbacks, or thrown while leaving this submit available to
+            // the outer rejection finalizer. Clear only after a successful
+            // return so a later entry failure cannot re-reject this prefix.
+            ResetAcceptedSubmit(entry.submit);
             {
                 std::lock_guard lock(state_mutex);
                 used_queues[static_cast<size_t>(entry.queue)] = true;
@@ -467,17 +528,12 @@ public:
                     present.source,
                     std::move(present.receipt)
                 );
+            _batch.present.reset();
             last_queue             = EQueueType::Graphics;
             ordered_copy_timeline = 0;
             std::lock_guard lock(state_mutex);
             used_queues[static_cast<size_t>(EQueueType::Graphics)] = true;
             present_seen = true;
-        }
-
-        {
-            std::lock_guard lock(state_mutex);
-            ordered_tail_queue         = last_queue;
-            ordered_tail_copy_timeline = ordered_copy_timeline;
         }
     }
 
@@ -515,6 +571,27 @@ public:
     }
 
 private:
+    static void ResetAcceptedSubmit(CmdSubmit& _submit) noexcept {
+        _submit.cmds.clear();
+        _submit.callbacks.clear();
+        _submit.success_callbacks.clear();
+        _submit.cached_args.clear();
+        _submit.segments.clear();
+        _submit.wait_events.clear();
+        _submit.signal_events.clear();
+        _submit.b_sync             = false;
+        _submit.b_tick_profiling   = false;
+        _submit.profiling_phase    = ERHIProfilingPhase::Disabled;
+        _submit.b_delete_resources = false;
+        _submit.resource_state_ownership =
+            ERHIResourceStateOwnership::BackendTracked;
+        _submit.translate_execution_class =
+            ERHITranslateExecutionClass::Parallel;
+        _submit.async_queue_scope = 0;
+        _submit.debug_label.clear();
+        _submit.debug_label_color = GpuMarkerPalette::Frame();
+    }
+
     static void WaitForQueue(EQueueType _queue, uint64 _copy_timeline) {
         switch (_queue) {
             case EQueueType::Graphics:
@@ -570,6 +647,25 @@ RHISubmissionTopologyPlan BuildBatchTopology(const RHIBackendSubmissionBatch& _b
         });
     }
     return BuildRHISubmissionTopology(descriptions, _batch.sequence);
+}
+
+std::exception_ptr TryPublishBackendBatch(
+    const std::shared_ptr<RHIBackendExecutor>& _backend,
+    RHIBackendSubmissionBatch&                 _batch,
+    RHIBackendSubmissionBatch&                 _failed_batch
+) noexcept {
+    try {
+        _batch.topology = BuildBatchTopology(_batch);
+        _backend->Enqueue(std::move(_batch));
+        return {};
+    } catch (...) {
+        // Backend Enqueue implementations must preserve the not-yet-consumed
+        // suffix in the rvalue object on failure. Finalizing that suffix is
+        // what terminalizes every signal waiter instead of silently dropping
+        // a moved CmdSubmit behind the asynchronous handoff.
+        _failed_batch = std::move(_batch);
+        return std::current_exception();
+    }
 }
 
 } // namespace
@@ -738,6 +834,7 @@ void RHIExecutor::SubmitReady(
         RHIBackendSubmissionBatch          failed_batch{};
         std::shared_ptr<RHIBackendExecutor> backend{};
         std::exception_ptr                  backend_creation_failure{};
+        std::exception_ptr                  backend_publication_failure{};
         bool                                rejected = false;
         {
             std::lock_guard dispatch_lock(dispatch_mutex);
@@ -766,9 +863,13 @@ void RHIExecutor::SubmitReady(
                 }
             }
             if (!rejected && !backend_creation_failure) {
-                batch.topology = BuildBatchTopology(batch);
-                backend->Enqueue(std::move(batch));
-                if (HasRHIExecSubmitFlag(_flags, ERHIExecSubmitFlags::FlushGPU)) {
+                backend_publication_failure = TryPublishBackendBatch(
+                    backend,
+                    batch,
+                    failed_batch
+                );
+                if (!backend_publication_failure &&
+                    HasRHIExecSubmitFlag(_flags, ERHIExecSubmitFlags::FlushGPU)) {
                     backend->Flush(ERHIFlushDepth::SubmitGPU);
                 }
             }
@@ -777,6 +878,17 @@ void RHIExecutor::SubmitReady(
             ReportBackendCreationFailure("Present", backend_creation_failure);
             FinalizeRejectedBackendBatch(
                 std::move(failed_batch), "backend creation failed while publishing Present"
+            );
+            return;
+        }
+        if (backend_publication_failure) {
+            ReportBackendPublicationFailure(
+                "Present",
+                backend_publication_failure
+            );
+            FinalizeRejectedBackendBatch(
+                std::move(failed_batch),
+                "backend publication failed while publishing Present"
             );
             return;
         }
@@ -974,7 +1086,18 @@ void RHIExecutor::SubmitRecording(
                         submit.SetProfilingPhase(*metadata.profiling_phase);
                     }
                     if (metadata.translate_execution_class) {
-                        submit.SetTranslateExecutionClass(*metadata.translate_execution_class);
+                        // SerialControl is a scheduling floor. Graph-declared
+                        // sources also carry it on the CommandList, so a
+                        // publisher may add a stronger metadata policy but
+                        // cannot weaken the immutable source frontier.
+                        if (submit.translate_execution_class !=
+                                ERHITranslateExecutionClass::SerialControl ||
+                            *metadata.translate_execution_class ==
+                                ERHITranslateExecutionClass::SerialControl) {
+                            submit.SetTranslateExecutionClass(
+                                *metadata.translate_execution_class
+                            );
+                        }
                     }
                     submit.async_queue_scope = metadata.async_queue_scope;
 
@@ -1072,6 +1195,7 @@ void RHIExecutor::FlushReady(ERHIFlushDepth _depth) {
     RHIBackendSubmissionBatch          failed_batch{};
     std::shared_ptr<RHIBackendExecutor> backend;
     std::exception_ptr                  backend_creation_failure{};
+    std::exception_ptr                  backend_publication_failure{};
     {
         std::lock_guard dispatch_lock(dispatch_mutex);
         {
@@ -1095,10 +1219,13 @@ void RHIExecutor::FlushReady(ERHIFlushDepth _depth) {
         }
         if (!backend_creation_failure) {
             if (BatchHasWork(batch)) {
-                batch.topology = BuildBatchTopology(batch);
-                backend->Enqueue(std::move(batch));
+                backend_publication_failure = TryPublishBackendBatch(
+                    backend,
+                    batch,
+                    failed_batch
+                );
             }
-            if (backend) {
+            if (!backend_publication_failure && backend) {
                 backend->Flush(_depth);
             }
         }
@@ -1107,6 +1234,17 @@ void RHIExecutor::FlushReady(ERHIFlushDepth _depth) {
         ReportBackendCreationFailure("Flush", backend_creation_failure);
         FinalizeRejectedBackendBatch(
             std::move(failed_batch), "backend creation failed while flushing"
+        );
+        return;
+    }
+    if (backend_publication_failure) {
+        ReportBackendPublicationFailure(
+            "Flush",
+            backend_publication_failure
+        );
+        FinalizeRejectedBackendBatch(
+            std::move(failed_batch),
+            "backend publication failed while flushing"
         );
     }
 }
@@ -1139,6 +1277,7 @@ void RHIExecutor::SyncReady(ERHISyncDepth _depth) {
     std::shared_ptr<RHIBackendExecutor> backend{};
     RHIBackendSubmissionBatch           failed_batch{};
     std::exception_ptr                   backend_creation_failure{};
+    std::exception_ptr                   backend_publication_failure{};
     bool                                sync_registered = false;
     auto finish_sync_call = [this, &sync_registered, &backend] {
         // A zero active-sync count is the shutdown handoff point. Release this
@@ -1185,10 +1324,13 @@ void RHIExecutor::SyncReady(ERHISyncDepth _depth) {
         }
         if (!backend_creation_failure) {
             if (BatchHasWork(batch)) {
-                batch.topology = BuildBatchTopology(batch);
-                backend->Enqueue(std::move(batch));
+                backend_publication_failure = TryPublishBackendBatch(
+                    backend,
+                    batch,
+                    failed_batch
+                );
             }
-            if (backend) {
+            if (!backend_publication_failure && backend) {
                 backend->Flush(ERHIFlushDepth::SubmitGPU);
             }
         }
@@ -1198,6 +1340,17 @@ void RHIExecutor::SyncReady(ERHISyncDepth _depth) {
         ReportBackendCreationFailure("Sync", backend_creation_failure);
         FinalizeRejectedBackendBatch(
             std::move(failed_batch), "backend creation failed while synchronizing"
+        );
+        return;
+    }
+    if (backend_publication_failure) {
+        ReportBackendPublicationFailure(
+            "Sync",
+            backend_publication_failure
+        );
+        FinalizeRejectedBackendBatch(
+            std::move(failed_batch),
+            "backend publication failed while synchronizing"
         );
         return;
     }
@@ -1274,6 +1427,7 @@ void RHIExecutor::ShutDown() {
     RHIBackendSubmissionBatch           batch{};
     RHIBackendSubmissionBatch           failed_batch{};
     std::exception_ptr                   backend_creation_failure{};
+    std::exception_ptr                   backend_publication_failure{};
     {
         std::lock_guard dispatch_lock(executor.dispatch_mutex);
         {
@@ -1293,10 +1447,14 @@ void RHIExecutor::ShutDown() {
             backend = std::move(executor.backend_executor);
         }
         if (!backend_creation_failure && BatchHasWork(batch) && backend) {
-            batch.topology = BuildBatchTopology(batch);
-            backend->Enqueue(std::move(batch));
+            backend_publication_failure = TryPublishBackendBatch(
+                backend,
+                batch,
+                failed_batch
+            );
         }
-        if (!backend_creation_failure && backend) {
+        if (!backend_creation_failure && !backend_publication_failure &&
+            backend) {
             backend->Flush(ERHIFlushDepth::SubmitGPU);
         }
     }
@@ -1305,6 +1463,15 @@ void RHIExecutor::ShutDown() {
         ReportBackendCreationFailure("ShutDown", backend_creation_failure);
         FinalizeRejectedBackendBatch(
             std::move(failed_batch), "backend creation failed during shutdown"
+        );
+    } else if (backend_publication_failure) {
+        ReportBackendPublicationFailure(
+            "ShutDown",
+            backend_publication_failure
+        );
+        FinalizeRejectedBackendBatch(
+            std::move(failed_batch),
+            "backend publication failed during shutdown"
         );
     }
 

--- a/source/runtime/render/rhi/RHIExecutorBackend.h
+++ b/source/runtime/render/rhi/RHIExecutorBackend.h
@@ -66,6 +66,20 @@ struct RHIBackendSubmissionBatch {
     Array<RHIBackendSubmissionBatchEntry>    submits{};
     std::optional<RHIPresentRequest>          present{};
     RHISubmissionTopologyPlan                 topology{};
+
+    RHIBackendSubmissionBatch() = default;
+    RHIBackendSubmissionBatch(
+        RHIBackendSubmissionBatch&&
+    ) noexcept = default;
+    RHIBackendSubmissionBatch& operator=(
+        RHIBackendSubmissionBatch&&
+    ) noexcept = default;
+    RHIBackendSubmissionBatch(
+        const RHIBackendSubmissionBatch&
+    ) = delete;
+    RHIBackendSubmissionBatch& operator=(
+        const RHIBackendSubmissionBatch&
+    ) = delete;
 };
 
 class RHIBackendExecutor {

--- a/source/runtime/render/rhi/RHIImpl.h
+++ b/source/runtime/render/rhi/RHIImpl.h
@@ -1576,10 +1576,11 @@ private:
 public:
     UpdateRaytracingSceneCmd(
         UnorderedMap<uint64, uint32>&& _related_geoms,
-        uint64                         _scene_handle,
-        uint64                         _instance_buffer_handle,
-        uint64                         _scratch_buffer_handle,
-        uint64                         _tlas_handle,
+        RaytracingSceneRef             _scene,
+        BufferRef                      _instance_buffer,
+        BufferRef                      _scratch_buffer,
+        RaytracingTlasRef              _tlas,
+        Array<RaytracingGeometryRef>&&  _geometry_refs,
         Array<uint>&&                  _instances_to_update,
         Array<byte>&&                  _instance_data,
         uint                           _instance_cnt,
@@ -1587,10 +1588,11 @@ public:
         std::string_view               _name = typenames[uint(EType::BuildTLAS)]
     ) :
         related_geometries(std::move(_related_geoms)),
-        scene_handle(_scene_handle),
-        instance_buffer_handle(_instance_buffer_handle),
-        scratch_buffer_handle(_scratch_buffer_handle),
-        tlas_handle(_tlas_handle),
+        scene(std::move(_scene)),
+        instance_buffer(std::move(_instance_buffer)),
+        scratch_buffer(std::move(_scratch_buffer)),
+        tlas(std::move(_tlas)),
+        geometry_refs(std::move(_geometry_refs)),
 
         instance_to_update_ids(std::move(_instances_to_update)),
         instance_data(std::move(_instance_data)),
@@ -1617,17 +1619,17 @@ public:
     }
 
     auto SceneHandle() const {
-        return scene_handle;
+        return uint64(scene.Get());
     }
 
     uint64 InstanceBufferHandle() const {
-        return instance_buffer_handle;
+        return uint64(instance_buffer.Get());
     }
     uint64 ScratchBufferHandle() const {
-        return scratch_buffer_handle;
+        return uint64(scratch_buffer.Get());
     }
     uint64 TlasHandle() const {
-        return tlas_handle;
+        return uint64(tlas.Get());
     }
 
     uint32 InstanceCount() const {
@@ -1638,18 +1640,39 @@ public:
         return related_geometries.find(_handle) != related_geometries.end();
     }
 
+    const auto& RelatedGeometries() const {
+        return related_geometries;
+    }
+
+    const RaytracingSceneRef& Scene() const {
+        return scene;
+    }
+    const BufferRef& InstanceBuffer() const {
+        return instance_buffer;
+    }
+    const BufferRef& ScratchBuffer() const {
+        return scratch_buffer;
+    }
+    const RaytracingTlasRef& Tlas() const {
+        return tlas;
+    }
+    const Array<RaytracingGeometryRef>& GeometryRefs() const {
+        return geometry_refs;
+    }
+
     bool ForceUpdate() const {
         return b_full_refit;
     }
 
 private:
-    uint64      scene_handle;
     Array<uint> instance_to_update_ids;
     Array<byte> instance_data;
 
-    uint64 instance_buffer_handle;
-    uint64 scratch_buffer_handle;
-    uint64 tlas_handle;
+    RaytracingSceneRef            scene;
+    BufferRef                     instance_buffer;
+    BufferRef                     scratch_buffer;
+    RaytracingTlasRef             tlas;
+    Array<RaytracingGeometryRef> geometry_refs;
 
     uint                       modifiable_instance_cnt = 0;
     bool                       b_full_refit            = false;

--- a/source/runtime/render/rhi/RHIResource.h
+++ b/source/runtime/render/rhi/RHIResource.h
@@ -1033,12 +1033,25 @@ public:
     virtual uint64_t GetValue() const      = 0;
     virtual void     Wait(uint64_t _value) = 0;
 
+    // Native-submission acceptance is intentionally distinct from GPU
+    // completion. A renderer history transaction may advance as soon as its
+    // signal-owning submit has reached the native queue, but must not advance
+    // merely because the frontend handoff accepted the CmdSubmit.
+    virtual void MarkSubmitted(uint64_t _value) = 0;
+    [[nodiscard]] virtual bool WaitSubmitted(
+        uint64_t               _value,
+        const std::atomic_bool* _continue_waiting = nullptr,
+        EQueueType              _waiting_queue = EQueueType::Ignore,
+        uint32                  _dependency_count = 0
+    ) = 0;
+    [[nodiscard]] virtual bool IsRejected(uint64_t _value) const = 0;
+
     // Terminalize a timeline value which can no longer be published because
     // its owning submission was rejected before reaching a GPU queue. This is
     // deliberately distinct from host-signalling the value: treating rejected
     // producer work as successfully complete could let dependent GPU work read
     // resources which were never written.
-    virtual void Reject(uint64_t _value) = 0;
+    virtual void Reject(uint64_t _value) noexcept = 0;
 };
 
 struct BackBufferInfo {

--- a/source/runtime/render/rhi/d3d12/D3D12Device.cpp
+++ b/source/runtime/render/rhi/d3d12/D3D12Device.cpp
@@ -17,6 +17,7 @@
 #include <optional>
 #include <platform/Platform.h>
 #include <shared_mutex>
+#include <stdexcept>
 #include <variant>
 
 namespace Moer::Render {
@@ -1052,11 +1053,10 @@ void D3D12GraphicsCommandQueue::ExecuteThread(std::stop_token _st) {
             evt->event.Match(
                 [&fence_value, this](UniquePtr<D3D12CommandResourceAllocator>& allocator) {
                     queue_fence.WaitOnHost(fence_value);
+                    allocator->ReleaseDescriptorChunks();
                     allocator->OnComplete(); // callbacks,
                     allocator->Reset();
                     ready_allocators.Push(allocator.release());
-                    GetDevice()->GetCsuHeapGpuDyn()->EndPushDescriptors();
-                    GetDevice()->GetSamplerHeapGpuDyn()->EndPushDescriptors();
                     //LOG_INFO("visit event: allocator, {}", fence_value);
                     AtomicMaximum(
                         last_completed_fence_value, fence_value
@@ -1510,49 +1510,104 @@ void D3D12GraphicsCommandQueue::Wait(WaitEvent _event) {
 }
 
 WaitEvent D3D12GraphicsCommandQueue::Execute(CmdSubmit&& _submit) {
-    const bool rejected_dependency = std::any_of(
+    struct SignalFailureGuard {
+        CmdSubmit* submit{nullptr};
+        bool       armed{true};
+
+        void Disarm() noexcept {
+            armed = false;
+        }
+
+        ~SignalFailureGuard() noexcept {
+            if (!armed || submit == nullptr) {
+                return;
+            }
+            // Conservative fail-closed semantics: if translation, descriptor
+            // setup, command-list close, Execute or any queue Signal throws,
+            // no external waiter may treat this partially published source as
+            // an accepted history transaction.
+            for (const SignalEvent& event : submit->signal_events) {
+                auto* fence =
+                    reinterpret_cast<D3D12Fence*>(event.timeline_handle);
+                if (fence == nullptr) {
+                    continue;
+                }
+                try {
+                    fence->Reject(event.value);
+                } catch (...) {
+                }
+            }
+        }
+    } signal_failure_guard{&_submit};
+
+    // D3D12 must never publish a native queue wait for a value whose producer
+    // has not already crossed its own native submission boundary. A later
+    // host-side Reject cannot release an ID3D12CommandQueue::Wait and would
+    // permanently wedge the queue. Use WaitSubmitted with a false continuation
+    // token as a non-blocking exact-value query and fail closed for both
+    // pending and rejected dependencies.
+    const std::atomic_bool do_not_wait{false};
+    const uint32 dependency_count =
+        static_cast<uint32>(_submit.wait_events.size());
+    const bool unaccepted_dependency = std::any_of(
         _submit.wait_events.begin(),
         _submit.wait_events.end(),
-        [](const WaitEvent& _event) {
-            const auto* fence =
-                reinterpret_cast<const D3D12Fence*>(_event.timeline_handle);
-            return fence == nullptr || fence->IsRejected(_event.value);
+        [&do_not_wait, dependency_count](const WaitEvent& _event) {
+            auto* fence =
+                reinterpret_cast<D3D12Fence*>(_event.timeline_handle);
+            return fence == nullptr ||
+                   !fence->WaitSubmitted(
+                       _event.value,
+                       &do_not_wait,
+                       EQueueType::Graphics,
+                       dependency_count
+                   );
         }
     );
-    if (rejected_dependency) {
-        // A rejected producer is terminal, but not successfully complete.
-        // Propagate that state instead of inserting a native queue wait which
-        // can never resolve and would wedge every later D3D12 submission.
-        for (const SignalEvent& event : _submit.signal_events) {
-            auto* fence = reinterpret_cast<D3D12Fence*>(event.timeline_handle);
-            if (fence != nullptr) {
-                fence->Reject(event.value);
-            }
-        }
-        for (std::function<void()>& callback : _submit.callbacks) {
-            if (!callback) {
-                continue;
-            }
-            try {
-                callback();
-            } catch (const std::exception& exception) {
-                LOG_ERROR(
-                    "[RHIExecutor][D3D12] rejected-submit callback threw: {}",
-                    exception.what()
-                );
-            } catch (...) {
-                LOG_ERROR("[RHIExecutor][D3D12] rejected-submit callback threw");
-            }
-        }
-        _submit.success_callbacks.clear();
-        return WaitEvent{
-            uint64(&queue_fence),
-            last_submitted_fence_value.load(std::memory_order_acquire)
-        };
+    if (unaccepted_dependency) {
+        // A pending or rejected producer is not successfully submit-complete.
+        // Abort the backend batch instead of running ordinary callbacks here:
+        // Execute is called while RHIExecutor holds its publication gate, and
+        // a callback may legally re-enter Submit/Flush/Sync. The outer
+        // exception path terminalizes signals and invokes cleanup only after
+        // that gate has been released.
+        signal_failure_guard.Disarm();
+        throw std::runtime_error(
+            "D3D12 submission depends on a rejected fence value"
+        );
     }
 
     auto allocator = RequestCommandResourceAllocator();
     auto cmd_list  = allocator->GetCommandList();
+    struct DescriptorPushFailureGuard {
+        D3D12GpuDescriptorAllocator* csu{nullptr};
+        D3D12GpuDescriptorAllocator* sampler{nullptr};
+        uint                         csu_chunk{0};
+        uint                         sampler_chunk{0};
+
+        void Disarm() noexcept {
+            csu_chunk     = 0;
+            sampler_chunk = 0;
+        }
+
+        ~DescriptorPushFailureGuard() noexcept {
+            if (sampler_chunk != 0 && sampler != nullptr) {
+                try {
+                    sampler->EndPushDescriptors(sampler_chunk);
+                } catch (...) {
+                }
+            }
+            if (csu_chunk != 0 && csu != nullptr) {
+                try {
+                    csu->EndPushDescriptors(csu_chunk);
+                } catch (...) {
+                }
+            }
+        }
+    } descriptor_push_guard{
+        device->GetCsuHeapGpuDyn(),
+        device->GetSamplerHeapGpuDyn()
+    };
 
     //FunctionTable function_table{
     //    .is_resource_write       = &IsBufferTextureWrite,
@@ -1566,6 +1621,14 @@ WaitEvent D3D12GraphicsCommandQueue::Execute(CmdSubmit&& _submit) {
     //const auto& cmd_lists = reorderer.m_cmd_lists;
 
     cmd_list->Begin();
+    descriptor_push_guard.csu_chunk =
+        descriptor_push_guard.csu->BeginPushDescriptors();
+    descriptor_push_guard.sampler_chunk =
+        descriptor_push_guard.sampler->BeginPushDescriptors();
+    allocator->AdoptDescriptorChunks(
+        descriptor_push_guard.csu_chunk,
+        descriptor_push_guard.sampler_chunk
+    );
     if (!_submit.cmds.empty()) {
         D3D12CommandVisitor           cmd_visitor(*allocator);
         D3D12CommandPreprocessVisitor preprocess_visitor(*allocator);
@@ -1576,8 +1639,6 @@ WaitEvent D3D12GraphicsCommandQueue::Execute(CmdSubmit&& _submit) {
             device->GetCsuHeapGpuDyn()->Native(), device->GetSamplerHeapGpuDyn()->Native()
         };
         cmd_list->Native()->SetDescriptorHeaps(2, heaps);
-        device->GetCsuHeapGpuDyn()->BeginPushDescriptors();
-        device->GetSamplerHeapGpuDyn()->BeginPushDescriptors();
 
         for (const auto& cmd : _submit.cmds) { // todo reorder
             preprocess_visitor.VisitCmd(cmd.get());
@@ -1601,40 +1662,82 @@ WaitEvent D3D12GraphicsCommandQueue::Execute(CmdSubmit&& _submit) {
         LOG_INFO("on complete {}", next_fence_value);
     });
 
+    // Build the complete retirement packet before crossing the native submit
+    // boundary. Ordinary callbacks are copied so the original submit remains
+    // intact if preparation or a native queue call fails; success callbacks
+    // join the accepted completion packet but remain skipped on rejection.
+    Array<std::function<void()>> completion_callbacks{};
+    completion_callbacks.reserve(
+        _submit.callbacks.size() + _submit.success_callbacks.size()
+    );
+    for (const std::function<void()>& callback : _submit.callbacks) {
+        completion_callbacks.emplace_back(callback);
+    }
+    for (const std::function<void()>& callback : _submit.success_callbacks) {
+        completion_callbacks.emplace_back(callback);
+    }
+
+    EventList retirement_events{};
+    retirement_events.emplace_back(
+        std::move(allocator), next_fence_value, true
+    );
+    for (const SignalEvent& event : _submit.signal_events) {
+        retirement_events.emplace_back(event, next_fence_value, false);
+    }
+    if (!completion_callbacks.empty()) {
+        retirement_events.emplace_back(
+            std::move(completion_callbacks), next_fence_value, true
+        );
+    }
+
+    // Acquire the retirement queue lock before native submission. Once every
+    // native Signal succeeds, list::splice and the remaining state updates are
+    // allocation-free, so Execute cannot leak a post-native exception back to
+    // the outer batch rejection path.
+    std::unique_lock retirement_lock(mtx);
     for (auto&& e : _submit.wait_events) {
-        queue->Wait(reinterpret_cast<D3D12Fence*>(e.timeline_handle)->Native(), e.value);
+        DX_CHECK_HRESULT(
+            queue->Wait(
+                reinterpret_cast<D3D12Fence*>(e.timeline_handle)->Native(),
+                e.value
+            )
+        );
     }
-    {
-        ID3D12CommandList* ppCommandLists[]{cmd_list->Native()};
-        queue->ExecuteCommandLists(1, ppCommandLists);
-    }
-    queue->Signal(queue_fence.Native(), next_fence_value);
-    for (auto&& e : _submit.signal_events) {
-        queue->Signal(reinterpret_cast<D3D12Fence*>(e.timeline_handle)->Native(), e.value);
-    }
-
-    // TODO our event queue
-    {
-        std::unique_lock lck(mtx);
-
-        // to reset allocator
-        event_queue.emplace_back(std::move(allocator), next_fence_value, true);
-
-        if (!_submit.callbacks.empty() || !_submit.signal_events.empty()) {
-
-            // signal fence after execute
-            for (auto&& e : _submit.signal_events) {
-                event_queue.emplace_back(std::move(e), next_fence_value, false);
-            }
-
-            // call backs after execute
-            if (!_submit.callbacks.empty()) {
-                event_queue.emplace_back(std::move(_submit.callbacks), next_fence_value, true);
-            }
+    bool native_commands_published = false;
+    try {
+        {
+            ID3D12CommandList* ppCommandLists[]{cmd_list->Native()};
+            queue->ExecuteCommandLists(1, ppCommandLists);
+            native_commands_published = true;
         }
-        cv.notify_one();
+        DX_CHECK_HRESULT(queue->Signal(queue_fence.Native(), next_fence_value));
+        queue_fence.MarkSubmitted(next_fence_value);
+        for (auto&& e : _submit.signal_events) {
+            auto* fence = reinterpret_cast<D3D12Fence*>(e.timeline_handle);
+            DX_CHECK_HRESULT(queue->Signal(fence->Native(), e.value));
+            fence->MarkSubmitted(e.value);
+        }
+    } catch (...) {
+        if (native_commands_published) {
+            // The command list may already reference allocator/callback-owned
+            // resources, but a failed completion Signal leaves no safe CPU
+            // retirement point. Never unwind those owners into the generic
+            // rejection finalizer; fail-stop is the only safe legacy-D3D12
+            // policy until device-loss quarantine is implemented.
+            std::terminate();
+        }
+        throw;
     }
+    signal_failure_guard.Disarm();
+    descriptor_push_guard.Disarm();
+
+    event_queue.splice(event_queue.end(), retirement_events);
+    _submit.callbacks.clear();
+    _submit.success_callbacks.clear();
+    _submit.signal_events.clear();
     pending_fence_values.Enqueue(next_fence_value);
+    retirement_lock.unlock();
+    cv.notify_one();
 
     return WaitEvent(uint64(&queue_fence), next_fence_value);
 }
@@ -1685,17 +1788,48 @@ void D3D12Fence::Wait(uint64_t _value) {
     WaitOnHost(_value);
 }
 
-void D3D12Fence::Reject(uint64_t _value) {
+void D3D12Fence::MarkSubmitted(uint64_t _value) {
+    AtomicMaximum(submitted_value, _value);
+    submission_cv.notify_all();
+}
+
+bool D3D12Fence::WaitSubmitted(
+    uint64_t               _value,
+    const std::atomic_bool* _continue_waiting,
+    EQueueType,
+    uint32
+) {
+    std::unique_lock lock(submission_mutex);
+    while (submitted_value.load(std::memory_order_acquire) < _value &&
+           !IsRejected(_value) &&
+           (_continue_waiting == nullptr ||
+            _continue_waiting->load(std::memory_order_acquire))) {
+        submission_cv.wait_for(lock, std::chrono::milliseconds(50));
+    }
+    return submitted_value.load(std::memory_order_acquire) >= _value &&
+           !IsRejected(_value);
+}
+
+void D3D12Fence::Reject(uint64_t _value) noexcept {
     {
         std::lock_guard lock(rejection_mutex);
-        rejected_values.emplace(_value);
+        if (!reject_all_values) {
+            try {
+                rejected_values.emplace(_value);
+            } catch (...) {
+                // Preserve terminal failure under OOM instead of leaving an
+                // acceptance waiter blocked on an exact value forever.
+                reject_all_values = true;
+            }
+        }
     }
     SetEvent(event);
+    submission_cv.notify_all();
 }
 
 bool D3D12Fence::IsRejected(uint64 _value) const {
     std::lock_guard lock(rejection_mutex);
-    return rejected_values.contains(_value);
+    return reject_all_values || rejected_values.contains(_value);
 }
 
 bool D3D12Fence::IsFenceComplete(uint64 _value) {
@@ -1748,6 +1882,7 @@ D3D12CommandResourceAllocator::D3D12CommandResourceAllocator(D3D12GraphicsComman
 }
 
 void D3D12CommandResourceAllocator::Reset() {
+    ASSERT(csu_descriptor_chunk == 0 && sampler_descriptor_chunk == 0);
     cmd_allocator->Reset();
     on_complete_callbacks.clear();
     default_buffer_allocator.Reset();
@@ -1758,6 +1893,31 @@ void D3D12CommandResourceAllocator::Reset() {
         buffer->Native()->Unmap(0, nullptr);
     }
     large_buffers.clear();
+}
+
+void D3D12CommandResourceAllocator::AdoptDescriptorChunks(
+    uint _csu_descriptor_chunk,
+    uint _sampler_descriptor_chunk
+) noexcept {
+    ASSERT(csu_descriptor_chunk == 0 && sampler_descriptor_chunk == 0);
+    ASSERT(_csu_descriptor_chunk != 0 && _sampler_descriptor_chunk != 0);
+    csu_descriptor_chunk     = _csu_descriptor_chunk;
+    sampler_descriptor_chunk = _sampler_descriptor_chunk;
+}
+
+void D3D12CommandResourceAllocator::ReleaseDescriptorChunks() noexcept {
+    if (sampler_descriptor_chunk != 0) {
+        device->GetSamplerHeapGpuDyn()->EndPushDescriptors(
+            sampler_descriptor_chunk
+        );
+        sampler_descriptor_chunk = 0;
+    }
+    if (csu_descriptor_chunk != 0) {
+        device->GetCsuHeapGpuDyn()->EndPushDescriptors(
+            csu_descriptor_chunk
+        );
+        csu_descriptor_chunk = 0;
+    }
 }
 
 static UniquePtr<D3D12Buffer>
@@ -3042,7 +3202,7 @@ D3D12GpuDescriptorAllocator::D3D12GpuDescriptorAllocator(
     max_descriptors_per_execution(std::min(_max_descriptors_per_execution, GetNumTotalDescriptors() / 3)),
     num_descriptor_chunk(GetNumTotalDescriptors() / max_descriptors_per_execution) {}
 
-void D3D12GpuDescriptorAllocator::BeginPushDescriptors() {
+uint D3D12GpuDescriptorAllocator::BeginPushDescriptors() {
     uint idx = ready_chunk_indices.Pop(); // return 0, if empty. so our valid indices start from 1.
     if (idx) {
         current_chunk_index  = idx;
@@ -3052,10 +3212,12 @@ void D3D12GpuDescriptorAllocator::BeginPushDescriptors() {
         current_chunk_index  = ++num_used_chunks;
         current_chunk_offset = 0;
     }
+    return current_chunk_index;
 }
 
-void D3D12GpuDescriptorAllocator::EndPushDescriptors() {
-    ready_chunk_indices.Push(current_chunk_index);
+void D3D12GpuDescriptorAllocator::EndPushDescriptors(uint _chunk_index) {
+    ASSERT(_chunk_index != 0 && _chunk_index <= num_descriptor_chunk);
+    ready_chunk_indices.Push(_chunk_index);
 }
 
 DescriptorIndex D3D12GpuDescriptorAllocator::Allocate(uint count) {

--- a/source/runtime/render/rhi/d3d12/D3D12Device.h
+++ b/source/runtime/render/rhi/d3d12/D3D12Device.h
@@ -21,6 +21,7 @@
 #include <D3D12MemAlloc.h>
 #include <dxgi1_6.h>
 #include <dxgidebug.h>
+#include <list>
 #include <optional>
 
 template<typename T>
@@ -453,8 +454,8 @@ public:
         uint32_t                   _max_descriptors_per_execution
     );
 
-    void BeginPushDescriptors();
-    void EndPushDescriptors();
+    [[nodiscard]] uint BeginPushDescriptors();
+    void               EndPushDescriptors(uint _chunk_index);
 
     DescriptorIndex Allocate(uint count = 1); // now should only be called by device...
 };
@@ -594,8 +595,12 @@ private:
     ComPtr<ID3D12Fence> fence;
     HANDLE              event;
     std::atomic<uint64> current_value = 0;
+    std::atomic<uint64> submitted_value = 0;
+    mutable std::mutex   submission_mutex;
+    std::condition_variable submission_cv;
     mutable std::mutex   rejection_mutex;
     UnorderedSet<uint64> rejected_values;
+    bool                 reject_all_values{false};
 
 public:
     D3D12Fence(D3D12Device* _device);
@@ -607,10 +612,17 @@ public:
     }
     uint64_t GetValue() const override; // by default, get latest value, not cached 'current_value'
     void     Wait(uint64_t _value) override;
-    void     Reject(uint64_t _value) override;
+    void     MarkSubmitted(uint64_t _value) override;
+    [[nodiscard]] bool WaitSubmitted(
+        uint64_t               _value,
+        const std::atomic_bool* _continue_waiting = nullptr,
+        EQueueType              _waiting_queue = EQueueType::Ignore,
+        uint32                  _dependency_count = 0
+    ) override;
+    void     Reject(uint64_t _value) noexcept override;
 
     bool IsFenceComplete(uint64 _value);
-    bool IsRejected(uint64 _value) const;
+    bool IsRejected(uint64 _value) const override;
     void WaitOnHost(uint64 _value);
     void SignalOnHost(uint64 _value);
 };
@@ -906,6 +918,8 @@ private:
     D3D12MultiBuddyAllocatorAutoFree upload_allocator;
     D3D12MultiBuddyAllocatorAutoFree readback_allocator;
     D3D12FastConstantAllocator       constant_allocator;
+    uint                            csu_descriptor_chunk{0};
+    uint                            sampler_descriptor_chunk{0};
 
     // in terms of each buffer may need different state, this can't use manual sub-allocation from a big buffer
     // rather we prefer sub-allocation from a heap, which simply rely on D3D12MA
@@ -941,6 +955,11 @@ public:
 
 public:
     void Reset();
+    void AdoptDescriptorChunks(
+        uint _csu_descriptor_chunk,
+        uint _sampler_descriptor_chunk
+    ) noexcept;
+    void ReleaseDescriptorChunks() noexcept;
     void AddOnComplete(std::function<void()>&& _func) {
         on_complete_callbacks.push_back(std::move(_func));
     }
@@ -998,7 +1017,8 @@ private:
             timeline(_other.timeline),
             wake_thread(_other.wake_thread) {}
     };
-    DEQueue<QueueEvent>         event_queue;
+    using EventList = std::list<QueueEvent, m_defualt_allocator<QueueEvent>>;
+    EventList                   event_queue;
     std::mutex                  mtx;
     std::condition_variable_any cv;
 

--- a/source/runtime/render/rhi/plugin/NrdPlugin.h
+++ b/source/runtime/render/rhi/plugin/NrdPlugin.h
@@ -21,10 +21,12 @@
 // 2
 #include <Extensions/NRIHelper.h>
 // 3
-#include <Extensions/NRIWrapperVK.h>
+#include <Extensions/NRIRayTracing.h>
 // 4
-#include <NRD.h>
+#include <Extensions/NRIWrapperVK.h>
 // 5
+#include <NRD.h>
+// 6
 #include <NRDIntegration.h>
 
 #else
@@ -85,19 +87,36 @@ typedef uint32_t Identifier;
 
 namespace Moer::Render::Ext {
 
-class NRDInterface {
+[[nodiscard]] inline constexpr bool
+IsReblurDenoiser(nrd::Denoiser denoiser) {
+    switch (denoiser) {
+        case nrd::Denoiser::REBLUR_DIFFUSE_SPECULAR:
+        case nrd::Denoiser::REBLUR_DIFFUSE:
+        case nrd::Denoiser::REBLUR_SPECULAR:
+            return true;
+        default:
+            return false;
+    }
+}
+
+[[nodiscard]] inline constexpr bool
+IsRelaxDenoiser(nrd::Denoiser denoiser) {
+    switch (denoiser) {
+        case nrd::Denoiser::RELAX_DIFFUSE_SPECULAR:
+        case nrd::Denoiser::RELAX_DIFFUSE:
+        case nrd::Denoiser::RELAX_SPECULAR:
+            return true;
+        default:
+            return false;
+    }
+}
+
+class NRDInterface : public std::enable_shared_from_this<NRDInterface> {
 public:
     NRDInterface() = default;
 
     virtual ~NRDInterface();
 
-    virtual void Begin() = 0;
-
-    virtual void Denoise(CommandList& _cmd_list, const nrd::Denoiser _denoiser, std::string_view _name) = 0;
-
-    virtual void Reinitialize(uint16 _frame_width, uint16 _frame_height) = 0;
-
-public:
     enum struct EResourceSlot : uint8 {
         // Reblur/Relax
         MOTION_VECTOR,
@@ -121,22 +140,94 @@ public:
         SLOT_NUM
     };
 
-public:
-    virtual void SetInput(EResourceSlot _index, TextureRef _texture)  = 0;
-    virtual void SetOutput(EResourceSlot _index, TextureRef _texture) = 0;
+    static constexpr uint8 resource_slot_count =
+        uint8(EResourceSlot::SLOT_NUM);
 
-    RENDER_API void UpdateCommonSettings(
-        uint32            _frame_index,
-        const Vector2ui&  _size,
-        const Vector2f&   _jitter,
-        const Matrix4x4f& _view,
-        const Matrix4x4f& _proj
-    );
-    RENDER_API void SetCommonSettings(const nrd::CommonSettings& _settings);
-    RENDER_API void SetDenoiserSettings(const nrd::Denoiser _type, const nrd::ReblurSettings& _settings);
-    RENDER_API void SetDenoiserSettings(const nrd::Denoiser _type, const nrd::RelaxSettings& _settings);
+    struct FrameDesc {
+        uint32            frame_index = 0;
+        Vector2ui         size{};
+        Vector2f          jitter{};
+        Matrix4x4f        view{};
+        Matrix4x4f        projection{};
+        nrd::Denoiser     denoiser = nrd::Denoiser::MAX_NUM;
+        StaticArray<TextureRef, resource_slot_count> resources{};
+
+        FrameDesc& Set(EResourceSlot slot, TextureRef texture) {
+            resources[uint8(slot)] = std::move(texture);
+            return *this;
+        }
+    };
+
+    /**
+     * Immutable renderer-to-RHI transaction payload. It freezes every native
+     * resource and temporal setting before graph recording; backend commands
+     * may never consult the live interface for per-frame bindings.
+     */
+    class PreparedFrame {
+    public:
+        [[nodiscard]] bool IsValid() const;
+        [[nodiscard]] uint64 GetBaseRevision() const {
+            return base_revision;
+        }
+        [[nodiscard]] nrd::Denoiser GetDenoiser() const {
+            return denoiser;
+        }
+        [[nodiscard]] const nrd::CommonSettings& GetCommonSettings() const {
+            return common_settings;
+        }
+        [[nodiscard]] const TextureRef& GetResource(EResourceSlot slot) const {
+            return resources[uint8(slot)];
+        }
+        [[nodiscard]] const StaticArray<TextureRef, resource_slot_count>&
+        GetResources() const {
+            return resources;
+        }
+
+    private:
+        uint64            base_revision = 0;
+        nrd::Denoiser     denoiser = nrd::Denoiser::MAX_NUM;
+        nrd::CommonSettings common_settings{};
+        StaticArray<TextureRef, resource_slot_count> resources{};
+        SharedPtr<uint8> generation_token{};
+
+        friend class NRDInterface;
+    };
+
+    using PreparedFrameRef = SharedPtr<const PreparedFrame>;
+
+    /**
+     * Pure preparation: no NRD/NRI call and no accepted-history mutation.
+     */
+    [[nodiscard]] RENDER_API PreparedFrameRef
+    PrepareFrame(FrameDesc _desc) const;
+
+    /**
+     * Advances only renderer-side accepted history. Call once after the whole
+     * frame graph and final submit have been accepted.
+     */
+    RENDER_API bool CommitFrame(const PreparedFrameRef& _frame);
+    RENDER_API void ResetAcceptedHistory();
+    [[nodiscard]] uint8 GetMaxFrameInFlight() const {
+        return nrd.max_frame_in_flight;
+    }
+
+    /**
+     * Records one immutable custom command. NewFrame, settings, resource
+     * binding and NRD dispatch are delayed until native translation.
+     */
+    virtual void Denoise(
+        CommandList&            _cmd_list,
+        PreparedFrameRef        _frame,
+        std::string_view        _name
+    ) = 0;
 
 protected:
+    [[nodiscard]] bool OwnsPreparedFrame(
+        const PreparedFrameRef& frame
+    ) const {
+        return frame &&
+               frame->generation_token.get() == generation_token.get();
+    }
     void SetDefaultDenoiserSettings(const nrd::Identifier _denoiser_id);
     void SetDefaultCommonSettings(uint16 _frame_width, uint16 _frame_height);
 
@@ -160,8 +251,6 @@ protected:
         NRIEntry nri = {};
 
         nrd::Integration integration = {};
-
-        nrd::UserPool user_pool = {};
     };
 
     NRDEntry nrd = {};
@@ -170,6 +259,11 @@ protected:
         {};
 
     UnorderedMap<uint64, nri::CommandBuffer*> cmd_lists_on_use = {};
+
+    uint64        accepted_revision      = 0;
+    bool          accepted_history_valid = false;
+    nrd::Denoiser accepted_denoiser      = nrd::Denoiser::MAX_NUM;
+    SharedPtr<uint8> generation_token = MakeShared<uint8>(0);
 };
 
 class NRDPlugin : public RuntimePlugin {
@@ -177,11 +271,11 @@ public:
     ~NRDPlugin()                        = default;
     static constexpr std::string_view name = "NRDPlugin";
 
-    virtual UniquePtr<NRDInterface>
+    virtual SharedPtr<NRDInterface>
     CreateInterface(uint8 _max_frame_in_flight = 0, uint16 _frame_width = 0, uint16 _frame_height = 0) = 0;
 
-    virtual UniquePtr<NRDInterface> RecreateInterface(
-        UniquePtr<NRDInterface> _interface,
+    virtual SharedPtr<NRDInterface> RecreateInterface(
+        SharedPtr<NRDInterface> _interface,
         uint16                  _frame_width  = 0,
         uint16                  _frame_height = 0
     ) = 0;

--- a/source/runtime/render/rhi/vulkan/VulkanQueue.cpp
+++ b/source/runtime/render/rhi/vulkan/VulkanQueue.cpp
@@ -41,6 +41,8 @@ std::atomic<const VulkanSubmissionDependencyWaitObserver*>
     g_submission_dependency_wait_observer{nullptr};
 std::atomic<const VulkanBackendSyncWaitObserver*>
     g_backend_sync_wait_observer{nullptr};
+std::atomic<const VulkanScriptedPresentOverrideForTesting*>
+    g_scripted_present_override{nullptr};
 
 void NotifyNativeSubmission(
     EQueueType                   _queue,
@@ -128,6 +130,36 @@ bool RemoveVulkanNativeSubmissionObserver(
     }
     const VulkanNativeSubmissionObserver* expected = _observer;
     return g_native_submission_observer.compare_exchange_strong(
+        expected,
+        nullptr,
+        std::memory_order_acq_rel,
+        std::memory_order_acquire
+    );
+}
+
+bool TryInstallVulkanScriptedPresentOverrideForTesting(
+    const VulkanScriptedPresentOverrideForTesting* _override
+) noexcept {
+    if (_override == nullptr || _override->callback == nullptr) {
+        return false;
+    }
+    const VulkanScriptedPresentOverrideForTesting* expected = nullptr;
+    return g_scripted_present_override.compare_exchange_strong(
+        expected,
+        _override,
+        std::memory_order_release,
+        std::memory_order_relaxed
+    );
+}
+
+bool RemoveVulkanScriptedPresentOverrideForTesting(
+    const VulkanScriptedPresentOverrideForTesting* _override
+) noexcept {
+    if (_override == nullptr) {
+        return false;
+    }
+    const VulkanScriptedPresentOverrideForTesting* expected = _override;
+    return g_scripted_present_override.compare_exchange_strong(
         expected,
         nullptr,
         std::memory_order_acq_rel,
@@ -4242,6 +4274,66 @@ VulkanRuntimeSubmissionResult VkCommandQueue::PresentForRuntime(
         std::unique_lock<std::mutex> execution_lock(exec_mtx);
         const uint64 current_timeline =
             last_frame.fetch_add(1, std::memory_order_relaxed) + 1;
+        const VulkanScriptedPresentOverrideForTesting* scripted_override =
+            g_scripted_present_override.load(std::memory_order_acquire);
+        if (scripted_override != nullptr) {
+            VulkanScriptedPresentResult scripted =
+                scripted_override->callback(
+                    scripted_override->context,
+                    current_timeline
+                );
+            switch (scripted.outcome.status) {
+                case EVulkanOperationStatus::Retry:
+                case EVulkanOperationStatus::Recreate:
+                    break;
+                case EVulkanOperationStatus::Rejected:
+                    vk_device.RecordRejectedPresent();
+                    break;
+                case EVulkanOperationStatus::Faulted:
+                case EVulkanOperationStatus::Success:
+                default:
+                    // A headless test hook must never claim native success or
+                    // mutate VulkanDevice fault state.
+                    scripted.outcome.status =
+                        EVulkanOperationStatus::Rejected;
+                    if (scripted.outcome.result == VK_SUCCESS) {
+                        scripted.outcome.result = VK_ERROR_UNKNOWN;
+                    }
+                    vk_device.RecordRejectedPresent();
+                    break;
+            }
+
+            const VulkanOperationContext context{
+                .operation   = EVulkanFaultOperation::PresentSubmit,
+                .queue_type  = queue.GetType(),
+                .queue       = queue.GetHandle(),
+                .timeline    = current_timeline,
+                .work_serial = current_timeline,
+            };
+            Array<RHIResource*> deferred_releases = TakeDeferredReleases();
+            CommitPresentCompletion(
+                scripted.outcome,
+                context,
+                false,
+                EVulkanPresentorRetirementState::Unused,
+                {},
+                std::move(_swapchain),
+                std::move(source_texture),
+                std::move(deferred_releases),
+                current_timeline
+            );
+            ResolvePresentReceiptNoexcept(
+                _receipt,
+                false,
+                scripted.outcome.status ==
+                    EVulkanOperationStatus::Recreate
+            );
+            return {
+                .outcome               = scripted.outcome,
+                .completion            = std::nullopt,
+                .recoverable_rejection = false,
+            };
+        }
         return PresentNow(
             std::move(_swapchain),
             std::move(source_texture),

--- a/source/runtime/render/rhi/vulkan/VulkanRHIResource.cpp
+++ b/source/runtime/render/rhi/vulkan/VulkanRHIResource.cpp
@@ -3686,8 +3686,13 @@ VkAccessFlags2 VulkanEnumTranslator::METoVkAccessFlags2(ERHIAccessFlags _flags) 
         VulkanRaytracingGeometry* geometry = ResourceCast(_geometry.Get());
         assert(geometry && "Invalid geometry");
         auto iter = related_geometries.find(uint64(geometry));
-        if(iter != related_geometries.end()){
-            iter->second++;
+        if (iter == related_geometries.end()) {
+            return;
+        }
+        if (iter->second > 1) {
+            --iter->second;
+        } else {
+            related_geometries.erase(iter);
         }
 
     }
@@ -3710,6 +3715,12 @@ VkAccessFlags2 VulkanEnumTranslator::METoVkAccessFlags2(ERHIAccessFlags _flags) 
 
         related_geometries.clear();
         temp_update_instances.clear();
+        if (instances.empty()) {
+            temp_update_instance_ids.clear();
+            temp_modified_instance_ids.clear();
+            prev_modified_instance_ids.clear();
+            return {};
+        }
 
                 //update gpu buffer
         bool b_full_refit = false;
@@ -3769,13 +3780,22 @@ VkAccessFlags2 VulkanEnumTranslator::METoVkAccessFlags2(ERHIAccessFlags _flags) 
                 uint indice = &idx - &temp_update_instance_ids[0];
                 std::memcpy(temp_update_instances.data() + indice * sizeof(VkAccelerationStructureInstanceKHR), &vk_instance, sizeof(VkAccelerationStructureInstanceKHR));
 
-                auto pair = related_geometries.try_emplace(uint64(geometry), 1);
-                if(!pair.second){
-                    related_geometries[uint64(geometry)]++;
-                }
             }
         }
 
+        Array<RaytracingGeometryRef> geometry_refs;
+        geometry_refs.reserve(instances.size());
+        for (const RaytracingInstance& instance : instances) {
+            if (!instance.geom) {
+                continue;
+            }
+            auto pair = related_geometries.try_emplace(uint64(instance.geom), 1);
+            if (pair.second) {
+                geometry_refs.emplace_back(instance.geom);
+            } else {
+                ++pair.first->second;
+            }
+        }
 
         //maybe we should calculate relative blas here
         // Array<uint> instance_ids_to_update = temp_update_instance_ids;
@@ -3783,10 +3803,11 @@ VkAccessFlags2 VulkanEnumTranslator::METoVkAccessFlags2(ERHIAccessFlags _flags) 
         // RefitTLASAndScratchBuffer();
         auto cmd = MakeUnique<UpdateRaytracingSceneCmd>(
             std::move(related_geometries),
-            uint64(this),
-            uint64(instance_buffer.Get()),
-            uint64(scratch_buffer.Get()),
-            uint64(tlas.Get()),
+            RaytracingSceneRef(this),
+            BufferRef(instance_buffer.Get()),
+            BufferRef(scratch_buffer.Get()),
+            RaytracingTlasRef(tlas.Get()),
+            std::move(geometry_refs),
             std::move(temp_update_instance_ids),
             std::move(temp_update_instances),
             vk_instances.size(),

--- a/source/runtime/render/rhi/vulkan/VulkanRHIResource.cpp
+++ b/source/runtime/render/rhi/vulkan/VulkanRHIResource.cpp
@@ -4061,10 +4061,18 @@ VkAccessFlags2 VulkanEnumTranslator::METoVkAccessFlags2(ERHIAccessFlags _flags) 
         }
     }
 
-    void VulkanFence::Reject(uint64_t _value) {
+    void VulkanFence::Reject(uint64_t _value) noexcept {
         {
             std::unique_lock<std::mutex> lock(cv_m);
-            rejected_values.emplace(_value);
+            try {
+                rejected_values.emplace(_value);
+            } catch (...) {
+                // A rejected value must always become terminal. If the exact
+                // value set cannot grow, conservatively fail the whole fence
+                // rather than leaving submission waiters blocked forever.
+                failed         = true;
+                failure_result = VK_ERROR_OUT_OF_HOST_MEMORY;
+            }
         }
         cv.notify_all();
     }

--- a/source/runtime/render/rhi/vulkan/VulkanRHIResource.h
+++ b/source/runtime/render/rhi/vulkan/VulkanRHIResource.h
@@ -1046,19 +1046,19 @@ public:
     uint64 GetDeviceValue() const;
 
     void Wait(uint64_t _value) override;
-    void Reject(uint64_t _value) override;
+    void Reject(uint64_t _value) noexcept override;
     // can be called on any thread to block current thread
     void Sync(uint64);
     // can be called on any thread to signal fence
     void  Notify(uint64);
-    void  MarkSubmitted(uint64_t _value);
+    void  MarkSubmitted(uint64_t _value) override;
     RENDER_API bool WaitSubmitted(
         uint64_t               _value,
         const std::atomic_bool* _continue_waiting = nullptr,
         EQueueType              _waiting_queue = EQueueType::Ignore,
         uint32                  _dependency_count = 0
-    );
-    RENDER_API bool IsRejected(uint64_t _value) const;
+    ) override;
+    RENDER_API bool IsRejected(uint64_t _value) const override;
     RENDER_API VkResult HostWait(
         uint64_t                      _value,
         const VulkanOperationContext& _context = VulkanOperationContext{}

--- a/source/runtime/render/rhi/vulkan/VulkanSubmissionDiagnostics.h
+++ b/source/runtime/render/rhi/vulkan/VulkanSubmissionDiagnostics.h
@@ -31,6 +31,64 @@ struct VulkanSourceSubmissionObserver {
     VulkanSourceSubmissionCallback callback{nullptr};
 };
 
+enum class EVulkanSubmissionBoundaryKind : uint8_t {
+    SerialControl = 0,
+    PresentBridge,
+    Present,
+};
+
+enum class EVulkanSubmissionBoundaryPhase : uint8_t {
+    Dispatch = 0,
+    Terminal,
+};
+
+// Read-only observation of the stable Vulkan Submission cursor. Source
+// operations use their executable source index. PresentBridge reserves the
+// slot immediately after the source suffix and Present uses the following
+// slot even when no bridge is needed, so operation identity does not depend
+// on runtime queue aliasing or frontier state.
+struct VulkanSubmissionBoundaryEvent {
+    uint64                        batch_sequence{0};
+    uint32                        operation_index{0};
+    EQueueType                    queue{EQueueType::Ignore};
+    EVulkanSubmissionBoundaryKind kind{
+        EVulkanSubmissionBoundaryKind::SerialControl
+    };
+    EVulkanSubmissionBoundaryPhase phase{
+        EVulkanSubmissionBoundaryPhase::Dispatch
+    };
+    uint32                        dependency_wait_count{0};
+    uint32                        thread_id{0};
+    ERHIThreadRole                thread_role{ERHIThreadRole::Unknown};
+    VulkanOperationResult         outcome{};
+    bool                          outcome_valid{false};
+    bool                          gpu_submitted{false};
+    bool                          recoverable_rejection{false};
+    uint32                        present_receipt_resolution_attempts{0};
+};
+
+using VulkanSubmissionBoundaryCallback =
+    void (*)(void*, const VulkanSubmissionBoundaryEvent&) noexcept;
+
+struct VulkanSubmissionBoundaryObserver {
+    void*                            context{nullptr};
+    VulkanSubmissionBoundaryCallback callback{nullptr};
+};
+
+// Callback storage is caller-owned and immutable while installed. Callbacks
+// run on the sole Submission owner immediately before an ordered queue
+// operation and again after it reaches a terminal runtime result. They must be
+// short, non-blocking, noexcept, and must not re-enter RHI. Quiesce observed
+// work before removal; removal does not wait for an already-loaded callback.
+[[nodiscard]] RENDER_API bool
+TryInstallVulkanSubmissionBoundaryObserver(
+    const VulkanSubmissionBoundaryObserver* _observer
+) noexcept;
+[[nodiscard]] RENDER_API bool
+RemoveVulkanSubmissionBoundaryObserver(
+    const VulkanSubmissionBoundaryObserver* _observer
+) noexcept;
+
 enum class EVulkanSourceTranslationPhase : uint8_t {
     Begin = 0,
     Recorded,
@@ -216,6 +274,43 @@ TryInstallVulkanBackendSyncWaitObserver(
 [[nodiscard]] RENDER_API bool
 RemoveVulkanBackendSyncWaitObserver(
     const VulkanBackendSyncWaitObserver* _observer
+) noexcept;
+
+struct VulkanScriptedPresentResult {
+    VulkanOperationResult outcome{
+        EVulkanOperationStatus::Retry,
+        VK_NOT_READY,
+    };
+};
+
+using VulkanScriptedPresentCallback =
+    VulkanScriptedPresentResult (*)(void*, uint64) noexcept;
+
+struct VulkanScriptedPresentOverrideForTesting {
+    void*                           context{nullptr};
+    VulkanScriptedPresentCallback  callback{nullptr};
+};
+
+// Narrow deterministic test seam for no-GPU-tail Present outcomes. The
+// callback runs on the Submission owner while the queue execution mutex and
+// runtime execution lease are held. It must be short, non-blocking, noexcept,
+// and must not re-enter RHI. It is queried only after the real owner has
+// serialized execution and reserved the logical Present timeline. Success is
+// deliberately forbidden: tests may script Retry, Recreate, or Rejected,
+// while the production path remains the only route that can report a native
+// Present success or device fault.
+//
+// Override storage and context are caller-owned and immutable while installed.
+// Quiesce with Sync(Present) or shutdown before removal and destroy the
+// override/context only after removal. Removal does not wait for a callback
+// which has already loaded the pointer.
+[[nodiscard]] RENDER_API bool
+TryInstallVulkanScriptedPresentOverrideForTesting(
+    const VulkanScriptedPresentOverrideForTesting* _override
+) noexcept;
+[[nodiscard]] RENDER_API bool
+RemoveVulkanScriptedPresentOverrideForTesting(
+    const VulkanScriptedPresentOverrideForTesting* _override
 ) noexcept;
 
 // Backend-internal notification points shared across Vulkan translation,

--- a/source/runtime/render/rhi/vulkan/VulkanSubmissionExecutor.cpp
+++ b/source/runtime/render/rhi/vulkan/VulkanSubmissionExecutor.cpp
@@ -29,6 +29,83 @@ std::atomic<const VulkanSourceTranslationObserver*>
     g_source_translation_observer{nullptr};
 std::atomic<const VulkanBatchPreflightRejectionObserver*>
     g_batch_preflight_rejection_observer{nullptr};
+std::atomic<const VulkanSubmissionBoundaryObserver*>
+    g_submission_boundary_observer{nullptr};
+
+struct SubmissionBoundaryIdentity {
+    uint64                       batch_sequence{0};
+    uint32                       operation_index{0};
+    EQueueType                   queue{EQueueType::Ignore};
+    EVulkanSubmissionBoundaryKind kind{
+        EVulkanSubmissionBoundaryKind::SerialControl
+    };
+    uint32                       dependency_wait_count{0};
+};
+
+void NotifySubmissionBoundary(
+    const SubmissionBoundaryIdentity&    _identity,
+    EVulkanSubmissionBoundaryPhase       _phase,
+    const VulkanRuntimeSubmissionResult* _result = nullptr,
+    uint32 _present_receipt_resolution_attempts = 0
+) noexcept {
+    assert(
+        GetCurrentRHIThreadRole() == ERHIThreadRole::Submission &&
+        "submission boundary diagnostics must run on the Submission owner"
+    );
+    const VulkanSubmissionBoundaryObserver* observer =
+        g_submission_boundary_observer.load(std::memory_order_acquire);
+    if (observer == nullptr) {
+        return;
+    }
+    observer->callback(
+        observer->context,
+        VulkanSubmissionBoundaryEvent{
+            .batch_sequence       = _identity.batch_sequence,
+            .operation_index      = _identity.operation_index,
+            .queue                 = _identity.queue,
+            .kind                  = _identity.kind,
+            .phase                 = _phase,
+            .dependency_wait_count =
+                _identity.dependency_wait_count,
+            .thread_id             = Platform::GetCurrentThreadID(),
+            .thread_role           = GetCurrentRHIThreadRole(),
+            .outcome               =
+                _result != nullptr ?
+                    _result->outcome :
+                    VulkanOperationResult{},
+            .outcome_valid         = _result != nullptr,
+            .gpu_submitted =
+                _result != nullptr && _result->WasSubmitted(),
+            .recoverable_rejection =
+                _result != nullptr &&
+                _result->IsRecoverableRejection(),
+            .present_receipt_resolution_attempts =
+                _present_receipt_resolution_attempts,
+        }
+    );
+}
+
+template<typename SubmitCallable>
+VulkanRuntimeSubmissionResult ExecuteObservedSubmissionBoundary(
+    const SubmissionBoundaryIdentity& _identity,
+    SubmitCallable&&                 _submit,
+    const PresentReceiptRef&         _present_receipt = {}
+) noexcept {
+    NotifySubmissionBoundary(
+        _identity,
+        EVulkanSubmissionBoundaryPhase::Dispatch
+    );
+    VulkanRuntimeSubmissionResult result = _submit();
+    NotifySubmissionBoundary(
+        _identity,
+        EVulkanSubmissionBoundaryPhase::Terminal,
+        &result,
+        _present_receipt ?
+            _present_receipt->ResolutionAttemptCount() :
+            0
+    );
+    return result;
+}
 
 void NotifySourceSubmitted(
     uint64     _batch_sequence,
@@ -169,6 +246,13 @@ bool IsParallelTranslateCandidate(const RHIBackendSubmissionBatchEntry& _entry) 
     return IsNativeQueue(_entry.queue) &&
            _entry.submit.translate_execution_class == ERHITranslateExecutionClass::Parallel &&
            _entry.submit.HasExplicitResourceStateOwnership() && _entry.submit.async_queue_scope != 0;
+}
+
+bool IsSerialControlSource(
+    ERHITranslateExecutionClass _execution_class
+) noexcept {
+    return _execution_class ==
+           ERHITranslateExecutionClass::SerialControl;
 }
 
 void InvokeSourceCallbacksNoexcept(
@@ -780,6 +864,36 @@ bool RemoveVulkanSourceSubmissionObserver(const VulkanSourceSubmissionObserver* 
     const VulkanSourceSubmissionObserver* expected = _observer;
     return g_source_submission_observer.compare_exchange_strong(
         expected, nullptr, std::memory_order_acq_rel, std::memory_order_acquire
+    );
+}
+
+bool TryInstallVulkanSubmissionBoundaryObserver(
+    const VulkanSubmissionBoundaryObserver* _observer
+) noexcept {
+    if (_observer == nullptr || _observer->callback == nullptr) {
+        return false;
+    }
+    const VulkanSubmissionBoundaryObserver* expected = nullptr;
+    return g_submission_boundary_observer.compare_exchange_strong(
+        expected,
+        _observer,
+        std::memory_order_release,
+        std::memory_order_relaxed
+    );
+}
+
+bool RemoveVulkanSubmissionBoundaryObserver(
+    const VulkanSubmissionBoundaryObserver* _observer
+) noexcept {
+    if (_observer == nullptr) {
+        return false;
+    }
+    const VulkanSubmissionBoundaryObserver* expected = _observer;
+    return g_submission_boundary_observer.compare_exchange_strong(
+        expected,
+        nullptr,
+        std::memory_order_acq_rel,
+        std::memory_order_acquire
     );
 }
 
@@ -2227,6 +2341,20 @@ void VulkanSubmissionExecutor::ProcessBatch(
                 append_unique_wait(submit, *frontier[index]);
             }
         };
+    auto has_foreign_same_native_frontier =
+        [&](EQueueType target_queue, const auto& frontier) {
+            for (size_t index = 0; index < frontier.size(); ++index) {
+                if (!frontier[index].has_value()) {
+                    continue;
+                }
+                const auto source_queue = static_cast<EQueueType>(index);
+                if (source_queue != target_queue &&
+                    same_native_queue(source_queue, target_queue)) {
+                    return true;
+                }
+            }
+            return false;
+        };
     auto update_frontier =
         [&](EQueueType queue, WaitEvent completion, bool collapse) {
             UpdateStreamFrontier(queue, completion, collapse);
@@ -2835,6 +2963,10 @@ void VulkanSubmissionExecutor::ProcessBatch(
         }
 
         const uint64 async_scope = entry.submit.async_queue_scope;
+        const bool serial_control =
+            IsSerialControlSource(
+                entry.submit.translate_execution_class
+            );
         if (entry.queue == EQueueType::Copy) {
             auto& copy_queue = static_cast<VkCopyQueue&>(RenderDevice::Get().GetCopyQueue());
             std::optional<VkCopyQueue::CurrentVulkanCopyRecordedSubmit>
@@ -2869,12 +3001,28 @@ void VulkanSubmissionExecutor::ProcessBatch(
                         batch_sequence = _batch.sequence,
                         source_index = static_cast<uint32>(source_index),
                         source_metadata = materialization.sources[source_index],
-                        async_scope
+                        async_scope,
+                        serial_control
                     ]() mutable {
-                        VulkanRuntimeSubmissionResult result =
-                            copy_queue.SubmitRecordedForRuntime(
+                        auto submit = [&copy_queue, packet]() mutable {
+                            return copy_queue.SubmitRecordedForRuntime(
                                 std::move(*packet)
                             );
+                        };
+                        VulkanRuntimeSubmissionResult result =
+                            serial_control ?
+                                ExecuteObservedSubmissionBoundary(
+                                    SubmissionBoundaryIdentity{
+                                        .batch_sequence = batch_sequence,
+                                        .operation_index = source_index,
+                                        .queue = EQueueType::Copy,
+                                        .kind =
+                                            EVulkanSubmissionBoundaryKind::
+                                                SerialControl,
+                                    },
+                                    submit
+                                ) :
+                                submit();
                         if (result.WasSubmitted()) {
                             NotifySourceSubmitted(
                                 batch_sequence,
@@ -2980,10 +3128,28 @@ void VulkanSubmissionExecutor::ProcessBatch(
                         source_index = static_cast<uint32>(source_index),
                         source_metadata = materialization.sources[source_index],
                         queue_type = entry.queue,
-                        async_scope
+                        async_scope,
+                        serial_control
                     ]() mutable {
+                        auto submit = [&queue, packet]() mutable {
+                            return queue.SubmitRecordedForRuntime(
+                                std::move(*packet)
+                            );
+                        };
                         VulkanRuntimeSubmissionResult result =
-                            queue.SubmitRecordedForRuntime(std::move(*packet));
+                            serial_control ?
+                                ExecuteObservedSubmissionBoundary(
+                                    SubmissionBoundaryIdentity{
+                                        .batch_sequence = batch_sequence,
+                                        .operation_index = source_index,
+                                        .queue = queue_type,
+                                        .kind =
+                                            EVulkanSubmissionBoundaryKind::
+                                                SerialControl,
+                                    },
+                                    submit
+                                ) :
+                                submit();
                         if (result.WasSubmitted()) {
                             NotifySourceSubmitted(
                                 batch_sequence,
@@ -3059,7 +3225,18 @@ void VulkanSubmissionExecutor::ProcessBatch(
         );
         CmdSubmit bridge = CommandList(EQueueType::Graphics).Submit();
         append_frontier_waits(bridge, EQueueType::Graphics, gpu_frontier);
-        if (!bridge.wait_events.empty()) {
+        // A foreign logical queue sharing Graphics' native queue needs no GPU
+        // semaphore wait, but it has an independent Completion owner. Emit an
+        // empty Graphics marker so no-GPU-tail Retry/Recreate retirement stays
+        // behind that predecessor instead of retiring resources immediately.
+        const bool alias_completion_marker =
+            has_foreign_same_native_frontier(
+                EQueueType::Graphics,
+                gpu_frontier
+            );
+        if (!bridge.wait_events.empty() || alias_completion_marker) {
+            const uint32 bridge_dependency_wait_count =
+                static_cast<uint32>(bridge.wait_events.size());
             std::optional<VkCommandQueue::CurrentVulkanRecordedSubmit> recorded =
                 graphics_queue.TranslateForRuntime(std::move(bridge));
             used_queues[static_cast<size_t>(EQueueType::Graphics)] = true;
@@ -3075,9 +3252,30 @@ void VulkanSubmissionExecutor::ProcessBatch(
             VulkanRuntimeSubmissionResult bridge_result{};
             try {
                 bridge_result = ExecuteOnSubmissionThread(
-                    [&graphics_queue, packet = &*recorded]() mutable {
-                        return graphics_queue.SubmitRecordedForRuntime(
-                            std::move(*packet)
+                    [
+                        &graphics_queue,
+                        packet = &*recorded,
+                        batch_sequence = _batch.sequence,
+                        operation_index =
+                            static_cast<uint32>(_batch.submits.size()),
+                        bridge_dependency_wait_count
+                    ]() mutable {
+                        return ExecuteObservedSubmissionBoundary(
+                            SubmissionBoundaryIdentity{
+                                .batch_sequence  = batch_sequence,
+                                .operation_index = operation_index,
+                                .queue            = EQueueType::Graphics,
+                                .kind =
+                                    EVulkanSubmissionBoundaryKind::
+                                        PresentBridge,
+                                .dependency_wait_count =
+                                    bridge_dependency_wait_count,
+                            },
+                            [&graphics_queue, packet]() mutable {
+                                return graphics_queue.SubmitRecordedForRuntime(
+                                    std::move(*packet)
+                                );
+                            }
                         );
                     }
                 );
@@ -3123,13 +3321,33 @@ void VulkanSubmissionExecutor::ProcessBatch(
             used_queues[static_cast<size_t>(EQueueType::Graphics)] = true;
         }
         const VulkanRuntimeSubmissionResult present_result = ExecuteOnSubmissionThread(
-            [&graphics_queue, present = &present]() mutable {
-                return graphics_queue.PresentForRuntime(
-                    std::move(present->swapchain),
-                    present->source,
-                    // Keep the request's receipt copy until the Submission
-                    // owner returns so the exception barrier can resolve it.
-                    present->receipt
+            [
+                &graphics_queue,
+                present = &present,
+                batch_sequence = _batch.sequence,
+                operation_index =
+                    static_cast<uint32>(_batch.submits.size() + 1)
+            ]() mutable {
+                const PresentReceiptRef receipt = present->receipt;
+                return ExecuteObservedSubmissionBoundary(
+                    SubmissionBoundaryIdentity{
+                        .batch_sequence  = batch_sequence,
+                        .operation_index = operation_index,
+                        .queue            = EQueueType::Graphics,
+                        .kind =
+                            EVulkanSubmissionBoundaryKind::Present,
+                    },
+                    [&graphics_queue, present]() mutable {
+                        return graphics_queue.PresentForRuntime(
+                            std::move(present->swapchain),
+                            present->source,
+                            // Keep the request's receipt copy until the
+                            // Submission owner returns so the exception
+                            // barrier can resolve it.
+                            present->receipt
+                        );
+                    },
+                    receipt
                 );
             }
         );

--- a/source/runtime/render/rhi/vulkan/VulkanSubmissionExecutor.cpp
+++ b/source/runtime/render/rhi/vulkan/VulkanSubmissionExecutor.cpp
@@ -1141,16 +1141,24 @@ VulkanSubmissionExecutor::PipelineBatchState::ReadFailure() const noexcept {
 }
 
 void VulkanSubmissionExecutor::Enqueue(RHIBackendSubmissionBatch&& _batch) {
+    static_assert(
+        std::is_nothrow_move_assignable_v<RHIBackendSubmissionBatch>,
+        "backend FIFO publication requires a nonthrowing batch handoff"
+    );
     bool rejected = false;
     {
         std::lock_guard lock(mutex);
         if (!accepting) {
             rejected = true;
         } else {
-            requests.emplace_back(Request{
-                .kind       = ERequestKind::Submit,
-                .batch      = std::move(_batch),
-            });
+            // Allocate the deque slot before moving the batch. If allocation
+            // throws, RHIExecutor still owns an intact batch and can reject
+            // every signal/receipt. The subsequent assignment is statically
+            // required to be nonthrowing.
+            requests.emplace_back();
+            Request& request = requests.back();
+            request.kind     = ERequestKind::Submit;
+            request.batch    = std::move(_batch);
         }
     }
     if (rejected) {

--- a/source/runtime/render/rhi/vulkan/plugin/NrdPlugin.cpp
+++ b/source/runtime/render/rhi/vulkan/plugin/NrdPlugin.cpp
@@ -2,6 +2,8 @@
 
 #if WITH_NRD
 
+#include <cstring>
+
 namespace Moer::Render::Ext {
 
 NRDInterface::~NRDInterface() {
@@ -20,78 +22,128 @@ NRDInterface::~NRDInterface() {
     nri::nriDestroyDevice(*nrd.nri.device);
 }
 
-void NRDInterface::UpdateCommonSettings(
-    uint32            _frame_index,
-    const Vector2ui&  _size,
-    const Vector2f&   _jitter,
-    const Matrix4x4f& _view,
-    const Matrix4x4f& _proj
-) {
-    nrd_common_settings.frameIndex = _frame_index;
-
-    nrd_common_settings.motionVectorScale[0] = 1.f / _size.x;
-    nrd_common_settings.motionVectorScale[1] = 1.f / _size.y;
-
-    nrd_common_settings.cameraJitterPrev[0] = nrd_common_settings.cameraJitter[0];
-    nrd_common_settings.cameraJitterPrev[1] = nrd_common_settings.cameraJitter[1];
-    nrd_common_settings.cameraJitter[0]     = _jitter.x;
-    nrd_common_settings.cameraJitter[1]     = _jitter.y;
-
-    nrd_common_settings.resourceSizePrev[0] = nrd_common_settings.resourceSize[0];
-    nrd_common_settings.resourceSizePrev[1] = nrd_common_settings.resourceSize[1];
-    nrd_common_settings.resourceSize[0]     = _size.x;
-    nrd_common_settings.resourceSize[1]     = _size.y;
-
-    nrd_common_settings.rectSizePrev[0] = nrd_common_settings.rectSize[0];
-    nrd_common_settings.rectSizePrev[1] = nrd_common_settings.rectSize[1];
-    nrd_common_settings.rectSize[0]     = _size.x;
-    nrd_common_settings.rectSize[1]     = _size.y;
-
-    nrd_common_settings.rectOrigin[0] = 0;
-    nrd_common_settings.rectOrigin[1] = 0;
-
-    // Set common settings
-    memcpy(
-        nrd_common_settings.worldToViewMatrixPrev,
-        nrd_common_settings.worldToViewMatrix,
-        sizeof(nrd_common_settings.worldToViewMatrix)
-    );
-    memcpy(
-        nrd_common_settings.viewToClipMatrixPrev,
-        nrd_common_settings.viewToClipMatrix,
-        sizeof(nrd_common_settings.viewToClipMatrix)
-    );
-    memcpy(nrd_common_settings.worldToViewMatrix, &_view, sizeof(nrd_common_settings.worldToViewMatrix));
-    memcpy(nrd_common_settings.viewToClipMatrix, &_proj, sizeof(nrd_common_settings.viewToClipMatrix));
-    nrd.integration.SetCommonSettings(nrd_common_settings);
+bool NRDInterface::PreparedFrame::IsValid() const {
+    const auto has = [&](EResourceSlot slot) {
+        return static_cast<bool>(resources[uint8(slot)]);
+    };
+    if (denoiser == nrd::Denoiser::MAX_NUM ||
+        !has(EResourceSlot::MOTION_VECTOR) ||
+        !has(EResourceSlot::NORMAL_ROUGHNESS) ||
+        !has(EResourceSlot::VIEW_Z)) {
+        return false;
+    }
+    switch (denoiser) {
+        case nrd::Denoiser::REBLUR_DIFFUSE_SPECULAR:
+        case nrd::Denoiser::RELAX_DIFFUSE_SPECULAR:
+            return has(EResourceSlot::IN_DIFFUSE) &&
+                   has(EResourceSlot::IN_SPECULAR) &&
+                   has(EResourceSlot::OUT_DIFFUSE) &&
+                   has(EResourceSlot::OUT_SPECULAR);
+        case nrd::Denoiser::REBLUR_DIFFUSE:
+        case nrd::Denoiser::RELAX_DIFFUSE:
+            return has(EResourceSlot::IN_DIFFUSE) &&
+                   has(EResourceSlot::OUT_DIFFUSE);
+        case nrd::Denoiser::REBLUR_SPECULAR:
+        case nrd::Denoiser::RELAX_SPECULAR:
+            return has(EResourceSlot::IN_SPECULAR) &&
+                   has(EResourceSlot::OUT_SPECULAR);
+        default:
+            return false;
+    }
 }
 
-void NRDInterface::SetCommonSettings(const nrd::CommonSettings& _settings) {
-    nrd.integration.SetCommonSettings(_settings);
-}
+NRDInterface::PreparedFrameRef
+NRDInterface::PrepareFrame(FrameDesc _desc) const {
+    if (_desc.size.x == 0 || _desc.size.y == 0) {
+        return {};
+    }
 
-void NRDInterface::SetDenoiserSettings(const nrd::Denoiser _type, const nrd::ReblurSettings& _settings) {
-    assert(_type < nrd::Denoiser::RELAX_DIFFUSE && "Denoiser type is not reblur");
-    nrd.integration.SetDenoiserSettings(nrd::Identifier(_type), &_settings);
-}
+    auto prepared = MakeShared<PreparedFrame>();
+    prepared->base_revision  = accepted_revision;
+    prepared->denoiser       = _desc.denoiser;
+    prepared->resources      = std::move(_desc.resources);
+    prepared->common_settings = nrd_common_settings;
+    prepared->generation_token = generation_token;
 
-void NRDInterface::SetDenoiserSettings(const nrd::Denoiser _type, const nrd::RelaxSettings& _settings) {
-    assert(
-        _type >= nrd::Denoiser::RELAX_DIFFUSE && _type < nrd::Denoiser::SIGMA_SHADOW &&
-        "Denoiser type is not relax"
+    auto& settings = prepared->common_settings;
+    settings.frameIndex = _desc.frame_index;
+    settings.motionVectorScale[0] = 1.f / _desc.size.x;
+    settings.motionVectorScale[1] = 1.f / _desc.size.y;
+
+    settings.cameraJitterPrev[0] = settings.cameraJitter[0];
+    settings.cameraJitterPrev[1] = settings.cameraJitter[1];
+    settings.cameraJitter[0]     = _desc.jitter.x;
+    settings.cameraJitter[1]     = _desc.jitter.y;
+
+    settings.resourceSizePrev[0] = settings.resourceSize[0];
+    settings.resourceSizePrev[1] = settings.resourceSize[1];
+    settings.resourceSize[0]     = _desc.size.x;
+    settings.resourceSize[1]     = _desc.size.y;
+
+    settings.rectSizePrev[0] = settings.rectSize[0];
+    settings.rectSizePrev[1] = settings.rectSize[1];
+    settings.rectSize[0]     = _desc.size.x;
+    settings.rectSize[1]     = _desc.size.y;
+    settings.rectOrigin[0]   = 0;
+    settings.rectOrigin[1]   = 0;
+
+    std::memcpy(
+        settings.worldToViewMatrixPrev,
+        settings.worldToViewMatrix,
+        sizeof(settings.worldToViewMatrix)
     );
-    nrd.integration.SetDenoiserSettings(nrd::Identifier(_type), &_settings);
+    std::memcpy(
+        settings.viewToClipMatrixPrev,
+        settings.viewToClipMatrix,
+        sizeof(settings.viewToClipMatrix)
+    );
+    std::memcpy(
+        settings.worldToViewMatrix,
+        &_desc.view,
+        sizeof(settings.worldToViewMatrix)
+    );
+    std::memcpy(
+        settings.viewToClipMatrix,
+        &_desc.projection,
+        sizeof(settings.viewToClipMatrix)
+    );
+    settings.accumulationMode =
+        accepted_history_valid && accepted_denoiser == _desc.denoiser ?
+            nrd::AccumulationMode::CONTINUE :
+            nrd::AccumulationMode::CLEAR_AND_RESTART;
+
+    return prepared->IsValid() ? prepared : PreparedFrameRef{};
+}
+
+bool NRDInterface::CommitFrame(const PreparedFrameRef& _frame) {
+    if (!OwnsPreparedFrame(_frame) || !_frame->IsValid() ||
+        _frame->base_revision != accepted_revision) {
+        return false;
+    }
+    nrd_common_settings     = _frame->common_settings;
+    accepted_denoiser      = _frame->denoiser;
+    accepted_history_valid = true;
+    ++accepted_revision;
+    return true;
+}
+
+void NRDInterface::ResetAcceptedHistory() {
+    SetDefaultCommonSettings(nrd.frame_width, nrd.frame_height);
+    accepted_history_valid = false;
+    accepted_denoiser      = nrd::Denoiser::MAX_NUM;
+    ++accepted_revision;
 }
 
 void NRDInterface::SetDefaultDenoiserSettings(const nrd::Identifier _denoiser_id) {
     // import from RTXDI
-    if (_denoiser_id < nrd::Identifier(nrd::Denoiser::RELAX_DIFFUSE)) {
+    const auto denoiser = static_cast<nrd::Denoiser>(_denoiser_id);
+    if (IsReblurDenoiser(denoiser)) {
         auto reblur_settings                      = nrd::ReblurSettings();
         reblur_settings.enableAntiFirefly         = true;
         reblur_settings.diffusePrepassBlurRadius  = 30.0f;
         reblur_settings.specularPrepassBlurRadius = 30.0f;
         nrd.integration.SetDenoiserSettings(_denoiser_id, &reblur_settings);
-    } else if (_denoiser_id < nrd::Identifier(nrd::Denoiser::SIGMA_SHADOW)) {
+    } else if (IsRelaxDenoiser(denoiser)) {
         auto relax_settings                                      = nrd::RelaxSettings();
         relax_settings.diffuseMaxFastAccumulatedFrameNum         = 1;
         relax_settings.specularMaxFastAccumulatedFrameNum        = 1;

--- a/source/runtime/render/rhi/vulkan/plugin/VulkanNrdPlugin.cpp
+++ b/source/runtime/render/rhi/vulkan/plugin/VulkanNrdPlugin.cpp
@@ -117,7 +117,7 @@ public:
                 {NRD_ID(RELAX_SPECULAR), nrd::Denoiser::RELAX_SPECULAR},
                 // SIGMA
                 {NRD_ID(SIGMA_SHADOW_TRANSLUCENCY), nrd::Denoiser::SIGMA_SHADOW_TRANSLUCENCY},
-                {NRD_ID(SIGMA_SHADOW), nrd::Denoiser::SIGMA_SHADOW_TRANSLUCENCY},
+                {NRD_ID(SIGMA_SHADOW), nrd::Denoiser::SIGMA_SHADOW},
                 // REFERENCE
                 // {NRD_ID(REFERENCE), nrd::Denoiser::REFERENCE},
             };
@@ -153,24 +153,18 @@ public:
 #undef NRD_ID
     }
 
-    void Begin() override {
-        // Must be called once on a frame start
-        nrd.integration.NewFrame();
-    }
+    void Denoise(
+        CommandList&     _cmd_list,
+        PreparedFrameRef _frame,
+        std::string_view _name
+    ) override;
 
-    void Denoise(CommandList& _cmd_list, const nrd::Denoiser _denoiser, std::string_view _name) override;
-
-    void Reinitialize(uint16 _frame_width, uint16 _frame_height) override {
-        nrd.frame_width  = _frame_width;
-        nrd.frame_height = _frame_height;
-        nrd.integration.RecreateResources(_frame_width, _frame_height);
-
-        SetDefaultCommonSettings(_frame_width, _frame_height);
-
-        LOG_INFO("[NRD]: NRD Texture Resources recreated.");
-    }
-
-    void SetInput(EResourceSlot _index, TextureRef _texture) override {
+private:
+    void SetInput(
+        nrd::UserPool&     _user_pool,
+        EResourceSlot      _index,
+        const TextureRef&  _texture
+    ) {
         assert(_index < EResourceSlot::OUT_DIFFUSE && "Invalid resource slot index");
         auto* vk_tex = ResourceCast(_texture);
 
@@ -184,7 +178,7 @@ public:
                 tex_barrier_desc.after.access = nri::AccessBits::SHADER_RESOURCE;
                 tex_barrier_desc.after.layout = nri::Layout::SHADER_RESOURCE;
             }
-            nrd::Integration_SetResource(nrd.user_pool, ResourceSlot(_index), &tex_barrier_desc);
+            nrd::Integration_SetResource(_user_pool, ResourceSlot(_index), &tex_barrier_desc);
         } else {
             auto& tex_barrier_desc = tex_barrier_desc_map[desc_key];
             // Wrap required textures (better do it only once on initialization)
@@ -206,7 +200,14 @@ public:
             // Useful information:
             //    SRV = nri::AccessBits::SHADER_RESOURCE, nri::TextureLayout::SHADER_RESOURCE
             //    UAV = nri::AccessBits::SHADER_RESOURCE_STORAGE, nri::TextureLayout::GENERAL
-            nrd.nri.rhi.CreateTextureVK(*nrd.nri.device, tex_desc, (nri::Texture*&)tex_barrier_desc.texture);
+            CHECK_ASSERT(
+                nrd.nri.rhi.CreateTextureVK(
+                    *nrd.nri.device,
+                    tex_desc,
+                    (nri::Texture*&)tex_barrier_desc.texture
+                ) == nri::Result::SUCCESS,
+                "Failed to wrap an NRD input texture"
+            );
             tex_barrier_desc.before.access = nri::AccessBits::SHADER_RESOURCE;
             tex_barrier_desc.before.layout = nri::Layout::SHADER_RESOURCE;
             tex_barrier_desc.before.stages = nri::StageBits::COMPUTE_SHADER;
@@ -218,28 +219,15 @@ public:
             tex_barrier_desc.layerOffset   = 0;
             tex_barrier_desc.layerNum      = vk_tex->GetNumArray();
             tex_barrier_desc.planes        = nri::PlaneBits::COLOR;
-            nrd::Integration_SetResource(nrd.user_pool, ResourceSlot(_index), &tex_barrier_desc);
-        }
-
-        // Resource usage
-        if (resource_usages_indices[uint8(_index)] == 0) {
-            VulkanShaderResourceState pipeline_flags{};
-            pipeline_flags.desc_type     = VDT_SAMPLED_IMAGE;
-            pipeline_flags.b_sampled     = 1;
-            pipeline_flags.resource_type = SRT_SRV;
-
-            ParamInfoFlags read_flag = {pipeline_flags(), VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT};
-
-            resource_usages.emplace_back(_texture, read_flag);
-            resource_usages_indices[uint8(_index)] = resource_usages.size();
-        } else {
-            // Update resource usage
-            auto& usage    = resource_usages[resource_usages_indices[uint8(_index)] - 1];
-            usage.resource = _texture;
+            nrd::Integration_SetResource(_user_pool, ResourceSlot(_index), &tex_barrier_desc);
         }
     }
 
-    void SetOutput(EResourceSlot _index, TextureRef _texture) override {
+    void SetOutput(
+        nrd::UserPool&     _user_pool,
+        EResourceSlot      _index,
+        const TextureRef&  _texture
+    ) {
         assert(_index >= EResourceSlot::OUT_DIFFUSE && "Output resource index is invalid");
         auto* vk_tex = ResourceCast(_texture);
 
@@ -248,7 +236,7 @@ public:
         auto desc_key = uint64(vk_tex->GetHandle());
         if (tex_barrier_desc_map.contains(desc_key)) {
             auto& tex_barrier_desc = tex_barrier_desc_map[desc_key];
-            nrd::Integration_SetResource(nrd.user_pool, ResourceSlot(_index), &tex_barrier_desc);
+            nrd::Integration_SetResource(_user_pool, ResourceSlot(_index), &tex_barrier_desc);
         } else {
             auto& tex_barrier_desc = tex_barrier_desc_map[desc_key];
             // Wrap required textures (better do it only once on initialization)
@@ -270,7 +258,14 @@ public:
             // Useful information:
             //    SRV = nri::AccessBits::SHADER_RESOURCE, nri::TextureLayout::SHADER_RESOURCE
             //    UAV = nri::AccessBits::SHADER_RESOURCE_STORAGE, nri::TextureLayout::GENERAL
-            nrd.nri.rhi.CreateTextureVK(*nrd.nri.device, tex_desc, (nri::Texture*&)tex_barrier_desc.texture);
+            CHECK_ASSERT(
+                nrd.nri.rhi.CreateTextureVK(
+                    *nrd.nri.device,
+                    tex_desc,
+                    (nri::Texture*&)tex_barrier_desc.texture
+                ) == nri::Result::SUCCESS,
+                "Failed to wrap an NRD output texture"
+            );
             tex_barrier_desc.before.access = nri::AccessBits::SHADER_RESOURCE_STORAGE;
             tex_barrier_desc.before.layout = nri::Layout::SHADER_RESOURCE_STORAGE;
             tex_barrier_desc.before.stages = nri::StageBits::COMPUTE_SHADER;
@@ -282,31 +277,11 @@ public:
             tex_barrier_desc.layerOffset   = 0;
             tex_barrier_desc.layerNum      = vk_tex->GetNumArray();
             tex_barrier_desc.planes        = nri::PlaneBits::COLOR;
-            nrd::Integration_SetResource(nrd.user_pool, ResourceSlot(_index), &tex_barrier_desc);
-        }
-
-        // Resource usage
-        if (resource_usages_indices[uint8(_index)] == 0) {
-            VulkanShaderResourceState pipeline_flags{};
-            pipeline_flags.desc_type     = VDT_STORAGE_IMAGE;
-            pipeline_flags.b_sampled     = 1;
-            pipeline_flags.resource_type = SRT_UAV;
-
-            ParamInfoFlags write_flag = {pipeline_flags(), VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT};
-
-            resource_usages.emplace_back(_texture, write_flag);
-            resource_usages_indices[uint8(_index)] = resource_usages.size();
-        } else {
-            // Update resource usage
-            auto& usage    = resource_usages[resource_usages_indices[uint8(_index)] - 1];
-            usage.resource = _texture;
+            nrd::Integration_SetResource(_user_pool, ResourceSlot(_index), &tex_barrier_desc);
         }
     };
 
 private:
-    Array<CustomDispatchCmd::ResourceUsage>            resource_usages;
-    StaticArray<uint8, uint8(EResourceSlot::SLOT_NUM)> resource_usages_indices = {};
-
     constexpr nrd::ResourceType ResourceSlot(const EResourceSlot _index) {
         switch (_index) {
             case EResourceSlot::MOTION_VECTOR:
@@ -337,85 +312,263 @@ private:
     }
 };
 
-UniquePtr<NRDInterface>
+SharedPtr<NRDInterface>
 VkNRDPlugin::CreateInterface(uint8 _max_frame_in_flight, uint16 _frame_width, uint16 _frame_height) {
-
-    return MakeUnique<VkNRDInterface>(m_device, _max_frame_in_flight, _frame_width, _frame_height);
+    return MakeShared<VkNRDInterface>(
+        m_device,
+        _max_frame_in_flight,
+        _frame_width,
+        _frame_height
+    );
 }
 
-UniquePtr<NRDInterface> VkNRDPlugin::RecreateInterface(
-    UniquePtr<NRDInterface> _interface,
+SharedPtr<NRDInterface> VkNRDPlugin::RecreateInterface(
+    SharedPtr<NRDInterface> _interface,
     uint16                  _frame_width,
     uint16                  _frame_height
 ) {
-
-    auto* vk_interface = static_cast<VkNRDInterface*>(_interface.get());
-
-    vk_interface->Reinitialize(_frame_width, _frame_height);
-
-    return std::move(_interface);
+    const uint8 max_frame_in_flight =
+        _interface ? _interface->GetMaxFrameInFlight() : 0;
+    // A published custom command owns the previous shared interface until
+    // completion. Resize therefore creates a new backend generation instead
+    // of mutating Integration/resources that may still be translating.
+    return CreateInterface(
+        max_frame_in_flight,
+        _frame_width,
+        _frame_height
+    );
 }
 
 class VkNrdDenoiseCmd final : public VkCustomDispatchCmd {
 private:
     std::span<const ResourceUsage> GetResourceUsages() const override {
-        return nrd_interface.resource_usages;
+        return resource_usages;
     }
 
 private:
-    VkNRDInterface& nrd_interface;
-    nrd::Denoiser   denoiser;
+    SharedPtr<VkNRDInterface>        nrd_interface;
+    NRDInterface::PreparedFrameRef   frame;
+    Array<ResourceUsage>             resource_usages{};
 
 public:
-    VkNrdDenoiseCmd(VkNRDInterface& _nrd, const nrd::Denoiser _denoiser) :
-        nrd_interface(_nrd),
-        denoiser(_denoiser) {}
+    VkNrdDenoiseCmd(
+        SharedPtr<VkNRDInterface>      _nrd,
+        NRDInterface::PreparedFrameRef _frame
+    ) :
+        nrd_interface(std::move(_nrd)),
+        frame(std::move(_frame)) {
+        for (uint8 index = 0;
+             index < NRDInterface::resource_slot_count;
+             ++index) {
+            const auto slot =
+                static_cast<NRDInterface::EResourceSlot>(index);
+            const TextureRef& texture = frame->GetResource(slot);
+            if (!texture) {
+                continue;
+            }
+
+            VulkanShaderResourceState pipeline_flags{};
+            pipeline_flags.b_sampled = 1;
+            if (slot < NRDInterface::EResourceSlot::OUT_DIFFUSE) {
+                pipeline_flags.desc_type     = VDT_SAMPLED_IMAGE;
+                pipeline_flags.resource_type = SRT_SRV;
+            } else {
+                pipeline_flags.desc_type     = VDT_STORAGE_IMAGE;
+                pipeline_flags.resource_type = SRT_UAV;
+            }
+            resource_usages.emplace_back(
+                texture,
+                ParamInfoFlags{
+                    pipeline_flags(),
+                    VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT
+                }
+            );
+        }
+    }
 
     EQueueType GetQueueType() const override {
         return EQueueType::Graphics;
     }
 
     void Execute(const VkDispatchContext& _context) const override {
-        auto& nrd_integration = nrd_interface.nrd.integration;
-        auto& nri             = nrd_interface.nrd.nri;
+        auto& nrd_integration = nrd_interface->nrd.integration;
+        auto& nri             = nrd_interface->nrd.nri;
+        nrd::UserPool user_pool{};
+
+        nrd_integration.NewFrame();
+        CHECK_ASSERT(
+            nrd_integration.SetCommonSettings(frame->GetCommonSettings()),
+            "Failed to apply immutable NRD common settings"
+        );
+        for (uint8 index = 0;
+             index < uint8(NRDInterface::EResourceSlot::OUT_DIFFUSE);
+             ++index) {
+            const auto slot =
+                static_cast<NRDInterface::EResourceSlot>(index);
+            const TextureRef& texture = frame->GetResource(slot);
+            if (texture) {
+                nrd_interface->SetInput(user_pool, slot, texture);
+            }
+        }
+        for (uint8 index =
+                 uint8(NRDInterface::EResourceSlot::OUT_DIFFUSE);
+             index < NRDInterface::resource_slot_count;
+             ++index) {
+            const auto slot =
+                static_cast<NRDInterface::EResourceSlot>(index);
+            const TextureRef& texture = frame->GetResource(slot);
+            if (texture) {
+                nrd_interface->SetOutput(user_pool, slot, texture);
+            }
+        }
         //=======================================================================================================
         // RENDER - DENOISE
         //=======================================================================================================
         // Wrap a command buffer
-        if (nrd_interface.cmd_lists_on_use.contains(uint64(_context.cmd_list))) {
-            nri.cmd_list = nrd_interface.cmd_lists_on_use[uint64(_context.cmd_list)];
+        if (nrd_interface->cmd_lists_on_use.contains(uint64(_context.cmd_list))) {
+            nri.cmd_list =
+                nrd_interface->cmd_lists_on_use[uint64(_context.cmd_list)];
         } else {
             nri::CommandBufferVKDesc cmd_buffer_desc = {};
             cmd_buffer_desc.commandQueueType         = nri::CommandQueueType::GRAPHICS;
             cmd_buffer_desc.vkCommandBuffer          = _context.cmd_list;
-            nri.rhi.CreateCommandBufferVK(*nri.device, cmd_buffer_desc, nri.cmd_list);
-            nrd_interface.cmd_lists_on_use[uint64(_context.cmd_list)] = nri.cmd_list;
+            CHECK_ASSERT(
+                nri.rhi.CreateCommandBufferVK(
+                    *nri.device, cmd_buffer_desc, nri.cmd_list
+                ) == nri::Result::SUCCESS,
+                "Failed to wrap the Vulkan command buffer for NRD"
+            );
+            nrd_interface->cmd_lists_on_use[uint64(_context.cmd_list)] =
+                nri.cmd_list;
         }
 
+        const nrd::Denoiser denoiser = frame->GetDenoiser();
         const nrd::Identifier denoiser_id = nrd::Identifier(denoiser);
-        nrd_integration.Denoise(&denoiser_id, 1, *nri.cmd_list, nrd_interface.nrd.user_pool);
+        nrd_integration.Denoise(
+            &denoiser_id,
+            1,
+            *nri.cmd_list,
+            user_pool
+        );
 
-        // The motion vector has been trasitioned to GENERAL layout by NRD REBLUR Denoisers, so we need to flush the state
-        auto mv_usage_slot =
-            nrd_interface.resource_usages_indices[uint8(NRDInterface::EResourceSlot::MOTION_VECTOR)];
-        if (denoiser < nrd::Denoiser::RELAX_DIFFUSE && mv_usage_slot) {
-            auto* mv = ResourceCast(
-                std::get<TextureView>(nrd_interface.resource_usages[mv_usage_slot - 1].resource).GetTexture()
+        // Old UserPool-based NRD leaves REBLUR motion in GENERAL. Restore the
+        // graph-declared Sampled state with a real native barrier; changing
+        // only VkTracker would make the next explicit RDG barrier name the
+        // wrong oldLayout.
+        if (IsReblurDenoiser(denoiser)) {
+            const TextureRef& motion = frame->GetResource(
+                NRDInterface::EResourceSlot::MOTION_VECTOR
             );
-            auto* vk_tracker = (VkTracker*)_context.user_data;
-            vk_tracker->FlushSrcState(
-                mv,
-                VK_ACCESS_SHADER_READ_BIT | VK_ACCESS_SHADER_WRITE_BIT,
-                VK_IMAGE_LAYOUT_GENERAL,
-                VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT
-            );
+            auto* vk_motion = ResourceCast(motion);
+            VkImageMemoryBarrier2 restore_motion{
+                VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER_2
+            };
+            restore_motion.srcStageMask =
+                VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT;
+            restore_motion.srcAccessMask =
+                VK_ACCESS_2_SHADER_READ_BIT |
+                VK_ACCESS_2_SHADER_WRITE_BIT;
+            restore_motion.dstStageMask =
+                VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT;
+            restore_motion.dstAccessMask =
+                VK_ACCESS_2_SHADER_SAMPLED_READ_BIT;
+            restore_motion.oldLayout = VK_IMAGE_LAYOUT_GENERAL;
+            restore_motion.newLayout =
+                VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+            restore_motion.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+            restore_motion.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+            restore_motion.image = vk_motion->GetHandle();
+            restore_motion.subresourceRange = VkImageSubresourceRange{
+                .aspectMask =
+                    VulkanEnumTranslator::METoVKImageAspectFlags(
+                        vk_motion->GetAspectFlags()
+                    ),
+                .baseMipLevel   = 0,
+                .levelCount     = vk_motion->GetNumMips(),
+                .baseArrayLayer = 0,
+                .layerCount     = vk_motion->GetNumArray(),
+            };
+            const VkDependencyInfo dependency{
+                .sType                   =
+                    VK_STRUCTURE_TYPE_DEPENDENCY_INFO,
+                .pNext                   = nullptr,
+                .dependencyFlags         = 0,
+                .memoryBarrierCount      = 0,
+                .pMemoryBarriers         = nullptr,
+                .bufferMemoryBarrierCount = 0,
+                .pBufferMemoryBarriers   = nullptr,
+                .imageMemoryBarrierCount = 1,
+                .pImageMemoryBarriers    = &restore_motion,
+            };
+            vkCmdPipelineBarrier2(_context.cmd_list, &dependency);
+        }
+
+        auto* vk_tracker = static_cast<VkTracker*>(_context.user_data);
+        for (uint8 index = 0;
+             index < NRDInterface::resource_slot_count;
+             ++index) {
+            const auto slot =
+                static_cast<NRDInterface::EResourceSlot>(index);
+            const TextureRef& texture = frame->GetResource(slot);
+            if (!texture) {
+                continue;
+            }
+            auto* vk_texture = ResourceCast(texture);
+            if (slot < NRDInterface::EResourceSlot::OUT_DIFFUSE) {
+                vk_tracker->FlushSrcState(
+                    vk_texture,
+                    VK_ACCESS_2_SHADER_SAMPLED_READ_BIT,
+                    VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
+                    VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT
+                );
+            } else {
+                vk_tracker->FlushSrcState(
+                    vk_texture,
+                    static_cast<VkAccessFlagBits2>(
+                        VK_ACCESS_2_SHADER_STORAGE_READ_BIT |
+                        VK_ACCESS_2_SHADER_STORAGE_WRITE_BIT
+                    ),
+                    VK_IMAGE_LAYOUT_GENERAL,
+                    VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT
+                );
+            }
         }
         // IMPORTANT: NRD integration binds own descriptor pool, don't forget to re-bind back your pool (heap)
     }
 };
 
-void VkNRDInterface::Denoise(CommandList& _cmd_list, const nrd::Denoiser _denoiser, std::string_view _name) {
-    _cmd_list.AddCustomCommand(MakeUnique<VkNrdDenoiseCmd>(*this, _denoiser), _name);
+void VkNRDInterface::Denoise(
+    CommandList&     _cmd_list,
+    PreparedFrameRef _frame,
+    std::string_view _name
+) {
+    if (!_frame || !_frame->IsValid()) {
+        throw std::invalid_argument(
+            "NRD denoise requires a valid immutable prepared frame"
+        );
+    }
+    if (!OwnsPreparedFrame(_frame)) {
+        throw std::invalid_argument(
+            "NRD denoise prepared frame belongs to another interface generation"
+        );
+    }
+    // The external NRD/NRI integration owns mutable descriptor and native
+    // command-buffer wrapper caches. Make SerialControl a backend invariant
+    // for every caller, including the linear warm-up path; the graph policy is
+    // retained as a declarative compiler contract.
+    _cmd_list.SetTranslateExecutionClass(
+        ERHITranslateExecutionClass::SerialControl
+    );
+    auto owner = std::static_pointer_cast<VkNRDInterface>(
+        shared_from_this()
+    );
+    _cmd_list.AddCustomCommand(
+        MakeUnique<VkNrdDenoiseCmd>(
+            std::move(owner),
+            std::move(_frame)
+        ),
+        _name
+    );
 }
 
 } // namespace Moer::Render::Ext

--- a/source/runtime/render/rhi/vulkan/plugin/VulkanNrdPlugin.h
+++ b/source/runtime/render/rhi/vulkan/plugin/VulkanNrdPlugin.h
@@ -12,14 +12,14 @@ public:
     VkNRDPlugin(VulkanDevice* _device) : VulkanDeviceObject(_device) {}
     ~VkNRDPlugin() = default;
 
-    UniquePtr<NRDInterface> CreateInterface(
+    SharedPtr<NRDInterface> CreateInterface(
         uint8  _max_frame_in_flight = 0,
         uint16 _frame_width         = 0,
         uint16 _frame_height        = 0
     ) override;
 
-    UniquePtr<NRDInterface> RecreateInterface(
-        UniquePtr<NRDInterface> _interface,
+    SharedPtr<NRDInterface> RecreateInterface(
+        SharedPtr<NRDInterface> _interface,
         uint16                  _frame_width  = 0,
         uint16                  _frame_height = 0
     ) override;

--- a/source/test/RHICommandMarkerTest.cpp
+++ b/source/test/RHICommandMarkerTest.cpp
@@ -21,6 +21,71 @@ void Expect(bool condition, std::string_view message) {
     }
 }
 
+class RetainedTestBuffer final : public Buffer {
+public:
+    RetainedTestBuffer() :
+        Buffer(BufferInfo{4096, 1, EBufferUsageFlags::ACCELERATION_STRUCTURE}) {}
+
+    void SetName(const std::string_view) override {}
+};
+
+class RetainedTestTlas final : public RaytracingTlas {
+public:
+    explicit RetainedTestTlas(BufferRef buffer) : buffer(std::move(buffer)) {}
+
+    Buffer* GetUnderlyingBuffer() const override {
+        return buffer.Get();
+    }
+
+private:
+    BufferRef buffer;
+};
+
+class RetainedTestGeometry final : public RaytracingGeometry {
+public:
+    explicit RetainedTestGeometry(BufferRef buffer) :
+        RaytracingGeometry(RaytracingGeometryInfo{}),
+        buffer(std::move(buffer)) {}
+
+    Buffer* GetUnderlyingBuffer() const override {
+        return buffer.Get();
+    }
+
+private:
+    BufferRef buffer;
+};
+
+class RetainedTestScene final : public RaytracingScene {
+public:
+    RetainedTestScene(RaytracingTlasRef current, RaytracingTlasRef previous) :
+        current(std::move(current)),
+        previous(std::move(previous)) {}
+
+    RaytracingInstance& AddInstance() override {
+        throw std::logic_error("RetainedTestScene::AddInstance is not used");
+    }
+    void FreeInstance(uint) override {}
+    void MarkModified(uint) override {}
+    UniquePtr<Command> UpdateScene() override {
+        return {};
+    }
+    void AdvanceFrame() override {
+        std::swap(current, previous);
+    }
+    void RegisterGeometry(RaytracingGeometryRef) override {}
+    void UnregisterGeometry(RaytracingGeometryRef) override {}
+    RaytracingTlasRef GetTlas() const override {
+        return current;
+    }
+    RaytracingTlasRef GetPrevTlas() const override {
+        return previous;
+    }
+
+private:
+    RaytracingTlasRef current;
+    RaytracingTlasRef previous;
+};
+
 const ScopeCmd& ScopeAt(const CmdSubmit& submit, size_t index) {
     Expect(index < submit.cmds.size(), "scope command index is out of range");
     Expect(submit.cmds[index]->Type() == Command::EType::Scope, "expected a ScopeCmd");
@@ -153,6 +218,103 @@ void PointAndCsmMarkerNamesAreCompleteAndDisjoint() {
     }
 }
 
+void PreparedRaytracingUpdatesAreNullSafeAndOneShot() {
+    CommandList cmd_list;
+    cmd_list.UpdateRaytracingScene(RaytracingSceneRef{});
+    Expect(cmd_list.IsEmpty(), "a null ray tracing scene emitted a command");
+
+    auto prepared = MakeUnique<UpdateRaytracingSceneCmd>(
+        UnorderedMap<uint64, uint32>{},
+        RaytracingSceneRef{},
+        BufferRef{},
+        BufferRef{},
+        RaytracingTlasRef{},
+        Array<RaytracingGeometryRef>{},
+        Array<uint>{},
+        Array<byte>{},
+        0,
+        false
+    );
+    cmd_list.UpdateRaytracingScene(std::move(prepared));
+    Expect(!prepared, "prepared TLAS command ownership was not consumed");
+
+    CmdSubmit submit = cmd_list.Submit();
+    Expect(submit.cmds.size() == 1, "prepared TLAS command was not emitted exactly once");
+    Expect(
+        submit.cmds.front()->Type() == Command::EType::BuildTLAS,
+        "prepared TLAS command changed command type"
+    );
+}
+
+void PreparedRaytracingUpdatesRetainEveryNativeInput() {
+    BufferRef instance_buffer(MoerNew(RetainedTestBuffer)());
+    BufferRef scratch_buffer(MoerNew(RetainedTestBuffer)());
+    BufferRef tlas_buffer(MoerNew(RetainedTestBuffer)());
+    BufferRef previous_tlas_buffer(MoerNew(RetainedTestBuffer)());
+    BufferRef geometry_buffer(MoerNew(RetainedTestBuffer)());
+    RaytracingTlasRef tlas(MoerNew(RetainedTestTlas)(tlas_buffer));
+    RaytracingTlasRef previous_tlas(
+        MoerNew(RetainedTestTlas)(previous_tlas_buffer)
+    );
+    RaytracingGeometryRef geometry(
+        MoerNew(RetainedTestGeometry)(geometry_buffer)
+    );
+    RaytracingSceneRef scene(
+        MoerNew(RetainedTestScene)(tlas, previous_tlas)
+    );
+
+    const RaytracingScene*    scene_identity    = scene.Get();
+    const Buffer*             instance_identity = instance_buffer.Get();
+    const Buffer*             scratch_identity  = scratch_buffer.Get();
+    const RaytracingTlas*     tlas_identity     = tlas.Get();
+    const RaytracingGeometry* geometry_identity = geometry.Get();
+
+    auto prepared = MakeUnique<UpdateRaytracingSceneCmd>(
+        UnorderedMap<uint64, uint32>{{uint64(geometry.Get()), 1}},
+        scene,
+        instance_buffer,
+        scratch_buffer,
+        tlas,
+        Array<RaytracingGeometryRef>{geometry},
+        Array<uint>{0},
+        Array<byte>{},
+        1,
+        false
+    );
+    CommandList cmd_list;
+    cmd_list.UpdateRaytracingScene(std::move(prepared));
+
+    scene           = {};
+    instance_buffer = {};
+    scratch_buffer  = {};
+    tlas            = {};
+    previous_tlas   = {};
+    geometry        = {};
+    tlas_buffer     = {};
+    previous_tlas_buffer = {};
+    geometry_buffer = {};
+
+    CmdSubmit submit = cmd_list.Submit();
+    Expect(submit.cmds.size() == 1, "retained TLAS command was not emitted");
+    const auto* update =
+        static_cast<const UpdateRaytracingSceneCmd*>(submit.cmds.front().get());
+    Expect(update->Scene().Get() == scene_identity, "prepared update dropped its scene owner");
+    Expect(
+        update->InstanceBuffer().Get() == instance_identity,
+        "prepared update dropped its instance buffer owner"
+    );
+    Expect(
+        update->ScratchBuffer().Get() == scratch_identity,
+        "prepared update dropped its scratch buffer owner"
+    );
+    Expect(update->Tlas().Get() == tlas_identity, "prepared update dropped its TLAS owner");
+    Expect(
+        update->GeometryRefs().size() == 1 &&
+            update->GeometryRefs().front().Get() == geometry_identity,
+        "prepared update dropped a related geometry owner"
+    );
+}
+
 } // namespace
 
 int main() {
@@ -160,6 +322,8 @@ int main() {
         MarkerScopesAreBalancedColoredAndImmobile();
         ProfilingPhasesPreserveOneLogicalFrame();
         PointAndCsmMarkerNamesAreCompleteAndDisjoint();
+        PreparedRaytracingUpdatesAreNullSafeAndOneShot();
+        PreparedRaytracingUpdatesRetainEveryNativeInput();
         std::cout << "RHI command marker tests passed\n";
         return 0;
     } catch (const std::exception& error) {

--- a/source/test/RHICommandMarkerTest.cpp
+++ b/source/test/RHICommandMarkerTest.cpp
@@ -2,6 +2,7 @@
 #include "rhi/RHICommand.h"
 #include "rhi/RHIImpl.h"
 
+#include <algorithm>
 #include <iostream>
 #include <set>
 #include <stdexcept>
@@ -181,6 +182,60 @@ void ProfilingPhasesPreserveOneLogicalFrame() {
     );
 }
 
+void ConstSpanUploadsOwnImmutableSnapshots() {
+    BufferRef target_buffer(MoerNew(RetainedTestBuffer)());
+    const Array<byte> expected{
+        byte{0x11},
+        byte{0x22},
+        byte{0x7f},
+        byte{0xa5},
+        byte{0x00},
+        byte{0xff},
+    };
+
+    const auto validate_snapshot = [&](const CmdSubmit& submit) {
+        Expect(
+            submit.cmds.size() == 1,
+            "const-span upload did not emit exactly one command"
+        );
+        Expect(
+            submit.cmds.front()->Type() == Command::EType::UploadBuffer,
+            "const-span upload changed command type"
+        );
+        const auto& upload =
+            *static_cast<const UploadBufferCmd*>(submit.cmds.front().get());
+        const auto data = upload.Data();
+        Expect(
+            data.size() == expected.size() &&
+                std::equal(data.begin(), data.end(), expected.begin()),
+            "const-span upload did not retain an immutable byte snapshot"
+        );
+        Expect(
+            upload.Handle() == reinterpret_cast<uint64>(target_buffer.Get()),
+            "const-span upload changed its destination buffer"
+        );
+        Expect(upload.Offset() == 128, "const-span upload changed its destination offset");
+    };
+
+    const auto record_snapshot = [&]() {
+        CommandList cmd_list;
+        Array<byte> source = expected;
+        cmd_list.CopyFrom(
+            std::span<const byte>(source.data(), source.size()),
+            target_buffer->GetView(128, source.size()),
+            "ConstSpanUploadSnapshot"
+        );
+
+        CmdSubmit submit = cmd_list.Submit();
+        std::fill(source.begin(), source.end(), byte{0xee});
+        validate_snapshot(submit);
+        return submit;
+    };
+
+    CmdSubmit retained_submit = record_snapshot();
+    validate_snapshot(retained_submit);
+}
+
 void PointAndCsmMarkerNamesAreCompleteAndDisjoint() {
     std::set<std::string_view> point_faces;
     std::set<std::string_view> point_culling;
@@ -321,6 +376,7 @@ int main() {
     try {
         MarkerScopesAreBalancedColoredAndImmobile();
         ProfilingPhasesPreserveOneLogicalFrame();
+        ConstSpanUploadsOwnImmutableSnapshots();
         PointAndCsmMarkerNamesAreCompleteAndDisjoint();
         PreparedRaytracingUpdatesAreNullSafeAndOneShot();
         PreparedRaytracingUpdatesRetainEveryNativeInput();

--- a/source/test/RHIExecutorRecordingHandoffTest.cpp
+++ b/source/test/RHIExecutorRecordingHandoffTest.cpp
@@ -51,14 +51,43 @@ bool Expect(bool _condition, const char* _message) {
 
 class RecordingFenceProbe final : public Fence {
 public:
+    explicit RecordingFenceProbe(
+        std::shared_ptr<std::atomic_bool> _destroyed = {}
+    ) :
+        destroyed(std::move(_destroyed)) {}
+
+    ~RecordingFenceProbe() override {
+        if (destroyed) {
+            destroyed->store(true, std::memory_order_release);
+        }
+    }
+
     uint64_t GetValue() const override {
         return 0;
     }
 
     void Wait(uint64_t) override {}
 
-    void Reject(uint64_t _value) override {
+    void MarkSubmitted(uint64_t _value) override {
+        submitted_value.store(_value, std::memory_order_release);
+    }
+
+    bool WaitSubmitted(
+        uint64_t               _value,
+        const std::atomic_bool* = nullptr,
+        EQueueType              = EQueueType::Ignore,
+        Moer::uint32            = 0
+    ) override {
+        return submitted_value.load(std::memory_order_acquire) >= _value &&
+               !IsRejected(_value);
+    }
+
+    void Reject(uint64_t _value) noexcept override {
         rejected_value.store(_value, std::memory_order_release);
+    }
+
+    bool IsRejected(uint64_t _value) const override {
+        return rejected_value.load(std::memory_order_acquire) == _value;
     }
 
     [[nodiscard]] uint64_t RejectedValue() const {
@@ -66,8 +95,107 @@ public:
     }
 
 private:
+    std::shared_ptr<std::atomic_bool> destroyed{};
+    std::atomic<uint64_t> submitted_value{0};
     std::atomic<uint64_t> rejected_value{0};
 };
+
+bool CommandListSignalTracksNativeAcceptanceAndRejection() {
+    RecordingFenceProbe accepted{};
+    CommandList         accepted_commands(EQueueType::Graphics);
+    accepted_commands.Signal(&accepted, 3);
+    if (!Expect(
+            !accepted_commands.IsEmpty(),
+            "a CommandList signal was not treated as submit work"
+        )) {
+        return false;
+    }
+    CmdSubmit accepted_submit = accepted_commands.Submit();
+    if (!Expect(
+            accepted_submit.signal_events.size() == 1 &&
+                accepted_submit.signal_events.front().value == 3,
+            "CommandList::Submit dropped its native-acceptance signal"
+        )) {
+        return false;
+    }
+    accepted.MarkSubmitted(3);
+    if (!Expect(
+            accepted.WaitSubmitted(3),
+            "accepted signal did not publish native-submission state"
+        )) {
+        return false;
+    }
+
+    auto owned_destroyed = std::make_shared<std::atomic_bool>(false);
+    FenceRef owned_fence{
+        MoerNew(RecordingFenceProbe)(owned_destroyed)
+    };
+    auto* owned_probe =
+        static_cast<RecordingFenceProbe*>(owned_fence.Get());
+    CommandList owned_commands(EQueueType::Graphics);
+    owned_commands.Signal(owned_fence, 5);
+    owned_fence = {};
+    if (!Expect(
+            !owned_destroyed->load(std::memory_order_acquire),
+            "CommandList::Signal(FenceRef) dropped its owner before sealing"
+        )) {
+        return false;
+    }
+    CmdSubmit owned_submit = owned_commands.Submit();
+    if (!Expect(
+            !owned_destroyed->load(std::memory_order_acquire) &&
+                owned_submit.callbacks.size() == 1,
+            "sealed signal did not retain its FenceRef through completion"
+        )) {
+        return false;
+    }
+    owned_probe->MarkSubmitted(5);
+    for (auto& callback : owned_submit.callbacks) {
+        callback();
+    }
+    owned_submit.callbacks.clear();
+    if (!Expect(
+            owned_destroyed->load(std::memory_order_acquire),
+            "signal FenceRef survived after its completion callback retired"
+        )) {
+        return false;
+    }
+
+    RecordingFenceProbe rejected{};
+    CommandList         rejected_commands(EQueueType::Graphics);
+    rejected_commands.Signal(&rejected, 7);
+    (void)rejected_commands.DrainOrdinaryCallbacksForRejection();
+    bool okay = Expect(
+                    rejected.IsRejected(7),
+                    "rejected graph source did not terminalize its signal"
+                ) &&
+                Expect(
+                    !rejected.WaitSubmitted(7),
+                    "rejected signal was reported as natively submitted"
+                ) &&
+                Expect(
+                    rejected_commands.IsEmpty(),
+                    "rejected graph source retained its signal"
+                );
+
+    RecordingFenceProbe frontend_rejected{};
+    CommandList         sealed_commands(EQueueType::Graphics);
+    sealed_commands.Signal(&frontend_rejected, 9);
+    RHIExecutor::Get().Submit(
+        EQueueType::Ignore,
+        sealed_commands.Submit(),
+        ERHIExecSubmitFlags::None
+    );
+    okay &= Expect(
+        frontend_rejected.IsRejected(9),
+        "frontend rejection did not terminalize a sealed signal"
+    );
+    okay &= Expect(
+        !frontend_rejected.WaitSubmitted(9),
+        "frontend-rejected signal was reported as natively submitted"
+    );
+    return okay;
+}
 
 bool PerSourceGatesPreserveFifo() {
     RHIExecutorRecordingHandoffQueue queue{};
@@ -709,7 +837,8 @@ bool ShutdownDrainsAcceptedReadyWork() {
 } // namespace
 
 int main() {
-    if (!PerSourceGatesPreserveFifo() ||
+    if (!CommandListSignalTracksNativeAcceptanceAndRejection() ||
+        !PerSourceGatesPreserveFifo() ||
         !ReadyWorkUsesStableExecutorOwnerAndCannotBeOvertaken() ||
         !FailedGateRejectsOnlyItsGroupAndPreservesFifo() ||
         !FailedRecordingDrainsCleanupExactlyOnce() ||

--- a/source/test/RHIParallelRecordVulkanTest.cpp
+++ b/source/test/RHIParallelRecordVulkanTest.cpp
@@ -15,6 +15,7 @@
 #include "rhi/vulkan/VulkanQueue.h"
 #include "rhi/vulkan/VulkanRHIResource.h"
 #include "rhi/vulkan/VulkanSubmissionDiagnostics.h"
+#include "renderer/raytracing/RaytracingExportSubmission.h"
 #include "taskgraph/TaskSystem.h"
 
 #include <algorithm>
@@ -38,6 +39,7 @@
 
 using namespace Moer;
 using namespace Moer::Render;
+using Moer::Render::Raytracing::ExportSubmissionTransaction;
 
 namespace {
 
@@ -877,7 +879,8 @@ void ValidateArguments(int _argc, const char** _argv) {
             argument != "--pipeline-window1" &&
             argument != "--pipeline-window2" &&
             argument != "--present-boundary" &&
-            argument != "--present-hard") {
+            argument != "--present-hard" &&
+            argument != "--rt-export-rejection") {
             throw std::invalid_argument("unsupported argument: " + std::string(argument));
         }
     }
@@ -4910,6 +4913,249 @@ void RunParallelTranslateRecoverableRejection() {
     );
 }
 
+void RunRaytracingExportAcceptanceRejection() {
+    using namespace std::chrono_literals;
+
+    auto& device = RenderDevice::Get();
+
+    FenceRef rejected_dependency = device.CreateFence();
+    ExportSubmissionTransaction export_submission(device.CreateFence());
+    FenceRef frame_tail_receipt = device.CreateFence();
+    ExportSubmissionTransaction recovery_submission(device.CreateFence());
+    rejected_dependency->Reject(1);
+
+    const EBufferUsageFlags usage =
+        EBufferUsageFlags::TRANSFER_SRC | EBufferUsageFlags::TRANSFER_DST;
+    BufferRef export_source_buffer = device.CreateBuffer<uint32>(
+        "rt_export_rejected_source", 4, usage
+    );
+    BufferRef frame_tail_target = device.CreateBuffer<uint32>(
+        "rt_export_rejected_tail", 4, usage
+    );
+    BufferRef recovery_target = device.CreateBuffer<uint32>(
+        "rt_export_rejection_recovery", 4, usage
+    );
+
+    std::atomic<uint32> blocker_callbacks{0};
+    std::atomic<uint32> export_callbacks{0};
+    std::atomic<uint32> export_success_callbacks{0};
+    std::atomic<uint32> frame_tail_callbacks{0};
+    std::atomic<uint32> frame_tail_success_callbacks{0};
+    std::atomic<uint32> recovery_callbacks{0};
+    std::atomic<uint32> recovery_success_callbacks{0};
+    std::atomic<uint32> encoder_dispatches{0};
+    std::atomic<uint32> temporal_commits{0};
+    std::atomic<uint32> history_commits{0};
+    std::atomic<uint32> tlas_commits{0};
+    bool                export_consumed = false;
+    std::binary_semaphore blocker_entered{0};
+    std::binary_semaphore release_blocker{0};
+    OneShotSemaphoreRelease release_guard(release_blocker);
+
+    // Hold Completion so the test can observe that both raw CmdSubmit fence
+    // identities still have callback-owned strong references after Submission
+    // has published terminal rejection.
+    CommandList blocker(EQueueType::Graphics);
+    blocker.AddCallback([&] {
+        blocker_callbacks.fetch_add(1, std::memory_order_relaxed);
+        blocker_entered.release();
+        release_blocker.acquire();
+    });
+    RHIExecutor::Get().Submit(
+        EQueueType::Graphics,
+        blocker.Submit(),
+        ERHIExecSubmitFlags::FlushGPU
+    );
+    if (!blocker_entered.try_acquire_for(5s)) {
+        throw std::runtime_error(
+            "raytracing export acceptance test could not block Completion"
+        );
+    }
+
+    NativeSubmissionCapture        native_capture{};
+    ScopedNativeSubmissionObserver native_observer(native_capture);
+
+    try {
+        CommandList export_source(EQueueType::Graphics);
+        export_source.CopyFrom(
+            OwnedBytes(std::array<uint32, 4>{11, 13, 17, 19}),
+            export_source_buffer->GetView(),
+            "RaytracingExportRejectedSource"
+        );
+        export_source.AddCallback([&] {
+            export_callbacks.fetch_add(1, std::memory_order_relaxed);
+        });
+        export_source.AddSuccessCallback([&] {
+            export_success_callbacks.fetch_add(1, std::memory_order_relaxed);
+        });
+        CmdSubmit export_submit = export_source.Submit();
+        export_submit.Wait(rejected_dependency.Get(), 1);
+        export_submission.AttachSignal(export_submit);
+        RHIExecutor::Get().Submit(
+            EQueueType::Graphics,
+            std::move(export_submit),
+            ERHIExecSubmitFlags::FlushGPU
+        );
+
+        CommandList frame_tail(EQueueType::Graphics);
+        frame_tail.CopyFrom(
+            OwnedBytes(std::array<uint32, 4>{23, 29, 31, 37}),
+            frame_tail_target->GetView(),
+            "RaytracingExportDependentTail"
+        );
+        frame_tail.AddCallback([&] {
+            frame_tail_callbacks.fetch_add(1, std::memory_order_relaxed);
+        });
+        frame_tail.AddSuccessCallback([&] {
+            frame_tail_success_callbacks.fetch_add(
+                1, std::memory_order_relaxed
+            );
+        });
+        CmdSubmit frame_tail_submit = frame_tail.Submit();
+        export_submission.AttachDependentWait(frame_tail_submit);
+        frame_tail_submit.Signal(frame_tail_receipt.Get(), 1);
+        RHIExecutor::Get().Submit(
+            EQueueType::Graphics,
+            std::move(frame_tail_submit),
+            ERHIExecSubmitFlags::FlushGPU
+        );
+
+        const bool tail_accepted =
+            frame_tail_receipt->WaitSubmitted(1);
+        const bool export_accepted =
+            export_submission.SourceAccepted();
+        const bool frame_native_accepted =
+            export_submission.FoldAcceptance(tail_accepted);
+        if (export_accepted) {
+            encoder_dispatches.fetch_add(1, std::memory_order_relaxed);
+            export_consumed = true;
+        }
+        if (frame_native_accepted) {
+            temporal_commits.fetch_add(1, std::memory_order_relaxed);
+            history_commits.fetch_add(1, std::memory_order_relaxed);
+            tlas_commits.fetch_add(1, std::memory_order_relaxed);
+        }
+
+        if (frame_native_accepted || export_consumed ||
+            encoder_dispatches.load(std::memory_order_acquire) != 0 ||
+            !ResourceCast(export_submission.GetReceiptFence())
+                 ->IsRejected(export_submission.GetReceiptValue()) ||
+            !ResourceCast(frame_tail_receipt.Get())->IsRejected(1)) {
+            throw std::runtime_error(
+                "rejected raytracing export source did not reject the whole "
+                "frame transaction"
+            );
+        }
+        if (temporal_commits.load(std::memory_order_acquire) != 0 ||
+            history_commits.load(std::memory_order_acquire) != 0 ||
+            tlas_commits.load(std::memory_order_acquire) != 0) {
+            throw std::runtime_error(
+                "rejected raytracing export transaction advanced accepted "
+                "renderer state"
+            );
+        }
+        if (export_callbacks.load(std::memory_order_acquire) != 0 ||
+            frame_tail_callbacks.load(std::memory_order_acquire) != 0 ||
+            export_submission.GetReceiptFence()->GetRefCount() < 3) {
+            throw std::runtime_error(
+                "raytracing export receipt keepalive retired before terminal "
+                "Completion callbacks"
+            );
+        }
+        if (native_capture.Overflowed() || native_capture.Count() != 0) {
+            throw std::runtime_error(
+                "rejected raytracing export transaction reached native submit"
+            );
+        }
+
+        release_guard.Release();
+        RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
+
+        if (blocker_callbacks.load(std::memory_order_acquire) != 1 ||
+            export_callbacks.load(std::memory_order_acquire) != 1 ||
+            export_success_callbacks.load(std::memory_order_acquire) != 0 ||
+            frame_tail_callbacks.load(std::memory_order_acquire) != 1 ||
+            frame_tail_success_callbacks.load(std::memory_order_acquire) != 0 ||
+            export_submission.GetReceiptFence()->GetRefCount() != 1) {
+            throw std::runtime_error(
+                "raytracing export rejection did not retire callbacks and "
+                "keepalives exactly once"
+            );
+        }
+
+        RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
+        if (export_callbacks.load(std::memory_order_acquire) != 1 ||
+            frame_tail_callbacks.load(std::memory_order_acquire) != 1 ||
+            export_submission.GetReceiptFence()->GetRefCount() != 1 ||
+            encoder_dispatches.load(std::memory_order_acquire) != 0 ||
+            export_consumed ||
+            temporal_commits.load(std::memory_order_acquire) != 0 ||
+            history_commits.load(std::memory_order_acquire) != 0 ||
+            tlas_commits.load(std::memory_order_acquire) != 0 ||
+            native_capture.Count() != 0) {
+            throw std::runtime_error(
+                "a second Sync replayed rejected raytracing export work"
+            );
+        }
+
+        CommandList recovery(EQueueType::Graphics);
+        recovery.CopyFrom(
+            OwnedBytes(std::array<uint32, 4>{41, 43, 47, 53}),
+            recovery_target->GetView(),
+            "RaytracingExportRejectionRecovery"
+        );
+        recovery.AddCallback([&] {
+            recovery_callbacks.fetch_add(1, std::memory_order_relaxed);
+        });
+        recovery.AddSuccessCallback([&] {
+            recovery_success_callbacks.fetch_add(
+                1, std::memory_order_relaxed
+            );
+        });
+        CmdSubmit recovery_submit = recovery.Submit();
+        recovery_submission.AttachSignal(recovery_submit);
+        RHIExecutor::Get().Submit(
+            EQueueType::Graphics,
+            std::move(recovery_submit),
+            ERHIExecSubmitFlags::FlushGPU
+        );
+        RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
+
+        if (!recovery_submission.SourceAccepted() ||
+            ResourceCast(recovery_submission.GetReceiptFence())
+                ->IsRejected(recovery_submission.GetReceiptValue()) ||
+            recovery_callbacks.load(std::memory_order_acquire) != 1 ||
+            recovery_success_callbacks.load(std::memory_order_acquire) != 1 ||
+            native_capture.Overflowed() || native_capture.Count() != 1 ||
+            !native_capture.Event(0).outcome.WasSubmitted()) {
+            throw std::runtime_error(
+                "raytracing export dependency rejection poisoned recovery"
+            );
+        }
+
+        RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
+        if (recovery_callbacks.load(std::memory_order_acquire) != 1 ||
+            recovery_success_callbacks.load(std::memory_order_acquire) != 1 ||
+            native_capture.Count() != 1) {
+            throw std::runtime_error(
+                "a second Sync replayed raytracing export recovery"
+            );
+        }
+    } catch (...) {
+        release_guard.Release();
+        RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
+        throw;
+    }
+
+    LOG_INFO(
+        "[TESTCASE][PASS] name=RaytracingExportAcceptanceRejection "
+        "source=rejected tail=dependency_rejected readback=skipped "
+        "encoder=skipped export_consumed=false "
+        "temporal=0 history=0 tlas=0 native_rejected=0 "
+        "callbacks=exactly_once keepalive=terminal recovery=accepted replay=0"
+    );
+}
+
 void RunRecoverableCopyDependencyRejection() {
     using namespace std::chrono_literals;
 
@@ -8183,6 +8429,8 @@ int main(int argc, const char** argv) {
             HasArgument(argc, argv, "--present-hard");
         const bool present_mode =
             present_boundary || present_hard;
+        const bool rt_export_rejection =
+            HasArgument(argc, argv, "--rt-export-rejection");
         const uint32 submission_batch_window =
             pipeline_window1 ? 1u : 2u;
 
@@ -8218,6 +8466,15 @@ int main(int argc, const char** argv) {
             } else {
                 RunPresentHardFailureBoundary();
             }
+            RenderDevice::Dispose();
+            render_device_initialized = false;
+            TaskSystem::ShutDown();
+            task_system_initialized = false;
+            return 0;
+        }
+
+        if (rt_export_rejection) {
+            RunRaytracingExportAcceptanceRejection();
             RenderDevice::Dispose();
             render_device_initialized = false;
             TaskSystem::ShutDown();

--- a/source/test/RHIParallelRecordVulkanTest.cpp
+++ b/source/test/RHIParallelRecordVulkanTest.cpp
@@ -39,6 +39,7 @@
 
 using namespace Moer;
 using namespace Moer::Render;
+using Moer::Render::Raytracing::EExportSubmissionOutcome;
 using Moer::Render::Raytracing::ExportSubmissionTransaction;
 
 namespace {
@@ -4918,36 +4919,132 @@ void RunRaytracingExportAcceptanceRejection() {
 
     auto& device = RenderDevice::Get();
 
-    FenceRef rejected_dependency = device.CreateFence();
-    ExportSubmissionTransaction export_submission(device.CreateFence());
-    FenceRef frame_tail_receipt = device.CreateFence();
+    using Outcome = EExportSubmissionOutcome;
+
+    const auto source_failed = ExportSubmissionTransaction::ResolveFrameDecision(
+        true,
+        Outcome::Failed,
+        Outcome::NotSubmitted,
+        Outcome::Accepted,
+        false,
+        true,
+        false
+    );
+    const auto tail_independently_rejected =
+        ExportSubmissionTransaction::ResolveFrameDecision(
+            true,
+            Outcome::Accepted,
+            Outcome::Accepted,
+            Outcome::Rejected,
+            true,
+            true,
+            false
+        );
+    const auto prefix_tail_rejected_with_independent_failure =
+        ExportSubmissionTransaction::ResolveFrameDecision(
+            true,
+            Outcome::Rejected,
+            Outcome::NotSubmitted,
+            Outcome::Rejected,
+            false,
+            true,
+            true
+        );
+    const auto prefix_rejected_tail_accepted =
+        ExportSubmissionTransaction::ResolveFrameDecision(
+            true,
+            Outcome::Rejected,
+            Outcome::NotSubmitted,
+            Outcome::Accepted,
+            false,
+            true,
+            false
+        );
+    const auto readback_hard_failed =
+        ExportSubmissionTransaction::ResolveFrameDecision(
+            true,
+            Outcome::Accepted,
+            Outcome::Failed,
+            Outcome::Accepted,
+            false,
+            true,
+            false
+        );
+    if (source_failed.frame_accepted ||
+        source_failed.retryable_frame_rejection ||
+        !source_failed.retry_requested || !source_failed.latch_renderer ||
+        tail_independently_rejected.frame_accepted ||
+        tail_independently_rejected.retry_requested ||
+        tail_independently_rejected.retryable_frame_rejection ||
+        !tail_independently_rejected.export_consumed ||
+        !tail_independently_rejected.latch_renderer ||
+        prefix_tail_rejected_with_independent_failure.frame_accepted ||
+        prefix_tail_rejected_with_independent_failure.retryable_frame_rejection ||
+        !prefix_tail_rejected_with_independent_failure.retry_requested ||
+        !prefix_tail_rejected_with_independent_failure.independent_source_failed ||
+        !prefix_tail_rejected_with_independent_failure.latch_renderer ||
+        prefix_rejected_tail_accepted.frame_accepted ||
+        prefix_rejected_tail_accepted.retryable_frame_rejection ||
+        !prefix_rejected_tail_accepted.retry_requested ||
+        !prefix_rejected_tail_accepted.latch_renderer ||
+        readback_hard_failed.frame_accepted ||
+        readback_hard_failed.export_consumed ||
+        !readback_hard_failed.retry_requested ||
+        !readback_hard_failed.independent_source_failed ||
+        readback_hard_failed.retryable_frame_rejection ||
+        !readback_hard_failed.latch_renderer) {
+        throw std::runtime_error(
+            "raytracing export production decision table misclassified a "
+            "failed source/readback, independent tail, or inconsistent "
+            "prefix/tail"
+        );
+    }
+
+    FenceRef rejected_prefix_dependency   = device.CreateFence();
+    FenceRef rejected_readback_dependency = device.CreateFence();
+    rejected_prefix_dependency->Reject(1);
+    rejected_readback_dependency->Reject(1);
+
+    ExportSubmissionTransaction attempt1_submission(device.CreateFence());
+    ExportSubmissionTransaction readback_retry_submission(device.CreateFence());
     ExportSubmissionTransaction recovery_submission(device.CreateFence());
-    rejected_dependency->Reject(1);
+    FenceRef attempt1_tail_receipt       = device.CreateFence();
+    FenceRef readback_retry_tail_receipt = device.CreateFence();
+    FenceRef recovery_tail_receipt       = device.CreateFence();
 
     const EBufferUsageFlags usage =
         EBufferUsageFlags::TRANSFER_SRC | EBufferUsageFlags::TRANSFER_DST;
-    BufferRef export_source_buffer = device.CreateBuffer<uint32>(
-        "rt_export_rejected_source", 4, usage
+    BufferRef attempt1_source_buffer = device.CreateBuffer<uint32>(
+        "rt_export_attempt1_source", 4, usage
     );
-    BufferRef frame_tail_target = device.CreateBuffer<uint32>(
-        "rt_export_rejected_tail", 4, usage
+    BufferRef attempt1_tail_target = device.CreateBuffer<uint32>(
+        "rt_export_attempt1_tail", 4, usage
     );
-    BufferRef recovery_target = device.CreateBuffer<uint32>(
-        "rt_export_rejection_recovery", 4, usage
+    BufferRef readback_retry_source = device.CreateBuffer<uint32>(
+        "rt_export_readback_retry_source", 4, usage
+    );
+    BufferRef readback_retry_tail_target = device.CreateBuffer<uint32>(
+        "rt_export_readback_retry_tail", 4, usage
+    );
+    BufferRef recovery_source = device.CreateBuffer<uint32>(
+        "rt_export_recovery_source", 4, usage
+    );
+    BufferRef recovery_tail_target = device.CreateBuffer<uint32>(
+        "rt_export_recovery_tail", 4, usage
     );
 
     std::atomic<uint32> blocker_callbacks{0};
-    std::atomic<uint32> export_callbacks{0};
-    std::atomic<uint32> export_success_callbacks{0};
-    std::atomic<uint32> frame_tail_callbacks{0};
-    std::atomic<uint32> frame_tail_success_callbacks{0};
-    std::atomic<uint32> recovery_callbacks{0};
-    std::atomic<uint32> recovery_success_callbacks{0};
+    std::array<std::atomic<uint32>, 2> attempt1_callbacks{};
+    std::array<std::atomic<uint32>, 2> attempt1_success_callbacks{};
+    std::array<std::atomic<uint32>, 3> readback_retry_callbacks{};
+    std::array<std::atomic<uint32>, 3> readback_retry_success_callbacks{};
+    std::array<std::atomic<uint32>, 3> recovery_callbacks{};
+    std::array<std::atomic<uint32>, 3> recovery_success_callbacks{};
     std::atomic<uint32> encoder_dispatches{0};
-    std::atomic<uint32> temporal_commits{0};
-    std::atomic<uint32> history_commits{0};
-    std::atomic<uint32> tlas_commits{0};
-    bool                export_consumed = false;
+    const std::array<uint32, 4> readback_retry_expected{41, 43, 47, 53};
+    const std::array<uint32, 4> recovery_expected{59, 61, 67, 71};
+    std::array<uint32, 4>       rejected_readback{};
+    std::array<uint32, 4>       recovered_readback{};
     std::binary_semaphore blocker_entered{0};
     std::binary_semaphore release_blocker{0};
     OneShotSemaphoreRelease release_guard(release_blocker);
@@ -4976,87 +5073,81 @@ void RunRaytracingExportAcceptanceRejection() {
     ScopedNativeSubmissionObserver native_observer(native_capture);
 
     try {
-        CommandList export_source(EQueueType::Graphics);
-        export_source.CopyFrom(
+        CommandList attempt1_source(EQueueType::Graphics);
+        attempt1_source.CopyFrom(
             OwnedBytes(std::array<uint32, 4>{11, 13, 17, 19}),
-            export_source_buffer->GetView(),
-            "RaytracingExportRejectedSource"
+            attempt1_source_buffer->GetView(),
+            "RaytracingExportAttempt1Source"
         );
-        export_source.AddCallback([&] {
-            export_callbacks.fetch_add(1, std::memory_order_relaxed);
+        attempt1_source.AddCallback([&] {
+            attempt1_callbacks[0].fetch_add(1, std::memory_order_relaxed);
         });
-        export_source.AddSuccessCallback([&] {
-            export_success_callbacks.fetch_add(1, std::memory_order_relaxed);
-        });
-        CmdSubmit export_submit = export_source.Submit();
-        export_submit.Wait(rejected_dependency.Get(), 1);
-        export_submission.AttachSignal(export_submit);
-        RHIExecutor::Get().Submit(
-            EQueueType::Graphics,
-            std::move(export_submit),
-            ERHIExecSubmitFlags::FlushGPU
-        );
-
-        CommandList frame_tail(EQueueType::Graphics);
-        frame_tail.CopyFrom(
-            OwnedBytes(std::array<uint32, 4>{23, 29, 31, 37}),
-            frame_tail_target->GetView(),
-            "RaytracingExportDependentTail"
-        );
-        frame_tail.AddCallback([&] {
-            frame_tail_callbacks.fetch_add(1, std::memory_order_relaxed);
-        });
-        frame_tail.AddSuccessCallback([&] {
-            frame_tail_success_callbacks.fetch_add(
+        attempt1_source.AddSuccessCallback([&] {
+            attempt1_success_callbacks[0].fetch_add(
                 1, std::memory_order_relaxed
             );
         });
-        CmdSubmit frame_tail_submit = frame_tail.Submit();
-        export_submission.AttachDependentWait(frame_tail_submit);
-        frame_tail_submit.Signal(frame_tail_receipt.Get(), 1);
+        CmdSubmit attempt1_source_submit = attempt1_source.Submit();
+        attempt1_source_submit.Wait(rejected_prefix_dependency.Get(), 1);
+        attempt1_submission.AttachSignal(attempt1_source_submit);
         RHIExecutor::Get().Submit(
             EQueueType::Graphics,
-            std::move(frame_tail_submit),
+            std::move(attempt1_source_submit),
             ERHIExecSubmitFlags::FlushGPU
         );
 
-        const bool tail_accepted =
-            frame_tail_receipt->WaitSubmitted(1);
-        const bool export_accepted =
-            export_submission.SourceAccepted();
-        const bool frame_native_accepted =
-            export_submission.FoldAcceptance(tail_accepted);
-        if (export_accepted) {
-            encoder_dispatches.fetch_add(1, std::memory_order_relaxed);
-            export_consumed = true;
-        }
-        if (frame_native_accepted) {
-            temporal_commits.fetch_add(1, std::memory_order_relaxed);
-            history_commits.fetch_add(1, std::memory_order_relaxed);
-            tlas_commits.fetch_add(1, std::memory_order_relaxed);
-        }
+        CommandList attempt1_tail(EQueueType::Graphics);
+        attempt1_tail.CopyFrom(
+            OwnedBytes(std::array<uint32, 4>{23, 29, 31, 37}),
+            attempt1_tail_target->GetView(),
+            "RaytracingExportAttempt1DependentTail"
+        );
+        attempt1_tail.AddCallback([&] {
+            attempt1_callbacks[1].fetch_add(1, std::memory_order_relaxed);
+        });
+        attempt1_tail.AddSuccessCallback([&] {
+            attempt1_success_callbacks[1].fetch_add(
+                1, std::memory_order_relaxed
+            );
+        });
+        CmdSubmit attempt1_tail_submit = attempt1_tail.Submit();
+        attempt1_submission.AttachDependentWait(attempt1_tail_submit);
+        attempt1_tail_submit.Signal(attempt1_tail_receipt.Get(), 1);
+        RHIExecutor::Get().Submit(
+            EQueueType::Graphics,
+            std::move(attempt1_tail_submit),
+            ERHIExecSubmitFlags::FlushGPU
+        );
 
-        if (frame_native_accepted || export_consumed ||
-            encoder_dispatches.load(std::memory_order_acquire) != 0 ||
-            !ResourceCast(export_submission.GetReceiptFence())
-                 ->IsRejected(export_submission.GetReceiptValue()) ||
-            !ResourceCast(frame_tail_receipt.Get())->IsRejected(1)) {
+        const Outcome attempt1_tail_outcome =
+            ExportSubmissionTransaction::ResolveReceiptOutcome(
+                attempt1_tail_receipt.Get(), 1
+            );
+        const auto attempt1_decision =
+            attempt1_submission.ClassifyFrameAcceptance(
+                attempt1_tail_outcome,
+                false,
+                false
+            );
+        if (attempt1_decision.source_outcome != Outcome::Rejected ||
+            attempt1_decision.tail_outcome != Outcome::Rejected ||
+            attempt1_decision.frame_accepted ||
+            attempt1_decision.export_consumed ||
+            !attempt1_decision.retry_requested ||
+            !attempt1_decision.retryable_frame_rejection ||
+            attempt1_decision.latch_renderer ||
+            attempt1_decision.readback_attempted ||
+            !ResourceCast(attempt1_submission.GetReceiptFence())
+                 ->IsRejected(attempt1_submission.GetReceiptValue()) ||
+            !ResourceCast(attempt1_tail_receipt.Get())->IsRejected(1)) {
             throw std::runtime_error(
-                "rejected raytracing export source did not reject the whole "
-                "frame transaction"
+                "production export decision did not keep the rejected prefix "
+                "and dependent tail retryable"
             );
         }
-        if (temporal_commits.load(std::memory_order_acquire) != 0 ||
-            history_commits.load(std::memory_order_acquire) != 0 ||
-            tlas_commits.load(std::memory_order_acquire) != 0) {
-            throw std::runtime_error(
-                "rejected raytracing export transaction advanced accepted "
-                "renderer state"
-            );
-        }
-        if (export_callbacks.load(std::memory_order_acquire) != 0 ||
-            frame_tail_callbacks.load(std::memory_order_acquire) != 0 ||
-            export_submission.GetReceiptFence()->GetRefCount() < 3) {
+        if (attempt1_callbacks[0].load(std::memory_order_acquire) != 0 ||
+            attempt1_callbacks[1].load(std::memory_order_acquire) != 0 ||
+            attempt1_submission.GetReceiptFence()->GetRefCount() < 3) {
             throw std::runtime_error(
                 "raytracing export receipt keepalive retired before terminal "
                 "Completion callbacks"
@@ -5072,11 +5163,11 @@ void RunRaytracingExportAcceptanceRejection() {
         RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
 
         if (blocker_callbacks.load(std::memory_order_acquire) != 1 ||
-            export_callbacks.load(std::memory_order_acquire) != 1 ||
-            export_success_callbacks.load(std::memory_order_acquire) != 0 ||
-            frame_tail_callbacks.load(std::memory_order_acquire) != 1 ||
-            frame_tail_success_callbacks.load(std::memory_order_acquire) != 0 ||
-            export_submission.GetReceiptFence()->GetRefCount() != 1) {
+            attempt1_callbacks[0].load(std::memory_order_acquire) != 1 ||
+            attempt1_callbacks[1].load(std::memory_order_acquire) != 1 ||
+            attempt1_success_callbacks[0].load(std::memory_order_acquire) != 0 ||
+            attempt1_success_callbacks[1].load(std::memory_order_acquire) != 0 ||
+            attempt1_submission.GetReceiptFence()->GetRefCount() != 1) {
             throw std::runtime_error(
                 "raytracing export rejection did not retire callbacks and "
                 "keepalives exactly once"
@@ -5084,61 +5175,357 @@ void RunRaytracingExportAcceptanceRejection() {
         }
 
         RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
-        if (export_callbacks.load(std::memory_order_acquire) != 1 ||
-            frame_tail_callbacks.load(std::memory_order_acquire) != 1 ||
-            export_submission.GetReceiptFence()->GetRefCount() != 1 ||
-            encoder_dispatches.load(std::memory_order_acquire) != 0 ||
-            export_consumed ||
-            temporal_commits.load(std::memory_order_acquire) != 0 ||
-            history_commits.load(std::memory_order_acquire) != 0 ||
-            tlas_commits.load(std::memory_order_acquire) != 0 ||
+        if (attempt1_callbacks[0].load(std::memory_order_acquire) != 1 ||
+            attempt1_callbacks[1].load(std::memory_order_acquire) != 1 ||
+            attempt1_submission.GetReceiptFence()->GetRefCount() != 1 ||
             native_capture.Count() != 0) {
             throw std::runtime_error(
                 "a second Sync replayed rejected raytracing export work"
             );
         }
 
-        CommandList recovery(EQueueType::Graphics);
-        recovery.CopyFrom(
-            OwnedBytes(std::array<uint32, 4>{41, 43, 47, 53}),
-            recovery_target->GetView(),
-            "RaytracingExportRejectionRecovery"
+        CommandList readback_retry_prefix(EQueueType::Graphics);
+        readback_retry_prefix.CopyFrom(
+            OwnedBytes(readback_retry_expected),
+            readback_retry_source->GetView(),
+            "RaytracingExportReadbackRetryPrefix"
         );
-        recovery.AddCallback([&] {
-            recovery_callbacks.fetch_add(1, std::memory_order_relaxed);
-        });
-        recovery.AddSuccessCallback([&] {
-            recovery_success_callbacks.fetch_add(
+        readback_retry_prefix.AddCallback([&] {
+            readback_retry_callbacks[0].fetch_add(
                 1, std::memory_order_relaxed
             );
         });
-        CmdSubmit recovery_submit = recovery.Submit();
-        recovery_submission.AttachSignal(recovery_submit);
+        readback_retry_prefix.AddSuccessCallback([&] {
+            readback_retry_success_callbacks[0].fetch_add(
+                1, std::memory_order_relaxed
+            );
+        });
+        CmdSubmit readback_retry_prefix_submit =
+            readback_retry_prefix.Submit();
+        readback_retry_submission.AttachSignal(
+            readback_retry_prefix_submit
+        );
         RHIExecutor::Get().Submit(
             EQueueType::Graphics,
-            std::move(recovery_submit),
+            std::move(readback_retry_prefix_submit),
+            ERHIExecSubmitFlags::FlushGPU
+        );
+        RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
+        if (readback_retry_submission.SourceOutcome() != Outcome::Accepted) {
+            throw std::runtime_error(
+                "raytracing readback-retry prefix was not accepted"
+            );
+        }
+
+        readback_retry_submission.BeginReadback(device.CreateFence());
+        CommandList rejected_readback_commands(EQueueType::Graphics);
+        rejected_readback_commands.CopyFrom(
+            readback_retry_source->GetView(),
+            WritableBytes(rejected_readback),
+            "RaytracingExportRejectedReadback"
+        );
+        rejected_readback_commands.AddCallback([&] {
+            readback_retry_callbacks[1].fetch_add(
+                1, std::memory_order_relaxed
+            );
+        });
+        rejected_readback_commands.AddSuccessCallback([&] {
+            readback_retry_success_callbacks[1].fetch_add(
+                1, std::memory_order_relaxed
+            );
+        });
+        CmdSubmit rejected_readback_submit =
+            rejected_readback_commands.Submit();
+        rejected_readback_submit.Wait(
+            rejected_readback_dependency.Get(), 1
+        );
+        readback_retry_submission.AttachReadbackSignal(
+            rejected_readback_submit
+        );
+        RHIExecutor::Get().Submit(
+            EQueueType::Graphics,
+            std::move(rejected_readback_submit),
+            ERHIExecSubmitFlags::FlushGPU
+        );
+        RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
+        if (readback_retry_submission.ResolveReadbackAcceptance() ||
+            readback_retry_submission.ReadbackOutcome() != Outcome::Rejected ||
+            readback_retry_submission.DispatchEncoder([&] {
+                encoder_dispatches.fetch_add(
+                    1, std::memory_order_relaxed
+                );
+            })) {
+            throw std::runtime_error(
+                "rejected production readback dispatched the export encoder"
+            );
+        }
+
+        CommandList readback_retry_tail(EQueueType::Graphics);
+        readback_retry_tail.CopyFrom(
+            OwnedBytes(std::array<uint32, 4>{73, 79, 83, 89}),
+            readback_retry_tail_target->GetView(),
+            "RaytracingExportReadbackRetryTail"
+        );
+        readback_retry_tail.AddCallback([&] {
+            readback_retry_callbacks[2].fetch_add(
+                1, std::memory_order_relaxed
+            );
+        });
+        readback_retry_tail.AddSuccessCallback([&] {
+            readback_retry_success_callbacks[2].fetch_add(
+                1, std::memory_order_relaxed
+            );
+        });
+        CmdSubmit readback_retry_tail_submit =
+            readback_retry_tail.Submit();
+        readback_retry_submission.AttachDependentWait(
+            readback_retry_tail_submit
+        );
+        readback_retry_tail_submit.Signal(
+            readback_retry_tail_receipt.Get(), 1
+        );
+        RHIExecutor::Get().Submit(
+            EQueueType::Graphics,
+            std::move(readback_retry_tail_submit),
+            ERHIExecSubmitFlags::FlushGPU
+        );
+        RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
+        const Outcome readback_retry_tail_outcome =
+            ExportSubmissionTransaction::ResolveReceiptOutcome(
+                readback_retry_tail_receipt.Get(), 1
+            );
+        const auto readback_retry_decision =
+            readback_retry_submission.ClassifyFrameAcceptance(
+                readback_retry_tail_outcome,
+                true,
+                false
+            );
+        if (!readback_retry_decision.frame_accepted ||
+            readback_retry_decision.export_consumed ||
+            !readback_retry_decision.retry_requested ||
+            readback_retry_decision.retryable_frame_rejection ||
+            readback_retry_decision.latch_renderer ||
+            !readback_retry_decision.readback_attempted ||
+            readback_retry_decision.readback_accepted ||
+            readback_retry_decision.encoder_dispatched ||
+            encoder_dispatches.load(std::memory_order_acquire) != 0 ||
+            std::any_of(
+                rejected_readback.begin(),
+                rejected_readback.end(),
+                [](uint32 value) { return value != 0; }
+            )) {
+            throw std::runtime_error(
+                "production readback rejection did not preserve an accepted "
+                "frame and pending export request"
+            );
+        }
+        for (size_t index = 0; index < readback_retry_callbacks.size();
+             ++index) {
+            const uint32 expected_success = index == 1 ? 0u : 1u;
+            if (readback_retry_callbacks[index].load(
+                    std::memory_order_acquire
+                ) != 1 ||
+                readback_retry_success_callbacks[index].load(
+                    std::memory_order_acquire
+                ) != expected_success) {
+                throw std::runtime_error(
+                    "raytracing readback-retry callbacks retired incorrectly"
+                );
+            }
+        }
+        if (readback_retry_submission.GetReceiptFence()->GetRefCount() != 1 ||
+            readback_retry_submission.GetReadbackReceiptFence()->GetRefCount() !=
+                1 ||
+            native_capture.Overflowed() || native_capture.Count() != 2 ||
+            !native_capture.Event(0).outcome.WasSubmitted() ||
+            !native_capture.Event(1).outcome.WasSubmitted()) {
+            throw std::runtime_error(
+                "raytracing readback rejection reached native submit or "
+                "retained a terminal receipt"
+            );
+        }
+        RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
+        for (size_t index = 0; index < readback_retry_callbacks.size();
+             ++index) {
+            const uint32 expected_success = index == 1 ? 0u : 1u;
+            if (readback_retry_callbacks[index].load(
+                    std::memory_order_acquire
+                ) != 1 ||
+                readback_retry_success_callbacks[index].load(
+                    std::memory_order_acquire
+                ) != expected_success) {
+                throw std::runtime_error(
+                    "a second Sync replayed raytracing readback-retry work"
+                );
+            }
+        }
+        if (native_capture.Count() != 2) {
+            throw std::runtime_error(
+                "a second Sync replayed raytracing readback-retry native work"
+            );
+        }
+
+        CommandList recovery_prefix(EQueueType::Graphics);
+        recovery_prefix.CopyFrom(
+            OwnedBytes(recovery_expected),
+            recovery_source->GetView(),
+            "RaytracingExportRecoveryPrefix"
+        );
+        recovery_prefix.AddCallback([&] {
+            recovery_callbacks[0].fetch_add(
+                1, std::memory_order_relaxed
+            );
+        });
+        recovery_prefix.AddSuccessCallback([&] {
+            recovery_success_callbacks[0].fetch_add(
+                1, std::memory_order_relaxed
+            );
+        });
+        CmdSubmit recovery_prefix_submit = recovery_prefix.Submit();
+        recovery_submission.AttachSignal(recovery_prefix_submit);
+        RHIExecutor::Get().Submit(
+            EQueueType::Graphics,
+            std::move(recovery_prefix_submit),
             ERHIExecSubmitFlags::FlushGPU
         );
         RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
 
-        if (!recovery_submission.SourceAccepted() ||
-            ResourceCast(recovery_submission.GetReceiptFence())
-                ->IsRejected(recovery_submission.GetReceiptValue()) ||
-            recovery_callbacks.load(std::memory_order_acquire) != 1 ||
-            recovery_success_callbacks.load(std::memory_order_acquire) != 1 ||
-            native_capture.Overflowed() || native_capture.Count() != 1 ||
-            !native_capture.Event(0).outcome.WasSubmitted()) {
+        recovery_submission.BeginReadback(device.CreateFence());
+        CommandList recovery_readback_commands(EQueueType::Graphics);
+        recovery_readback_commands.CopyFrom(
+            recovery_source->GetView(),
+            WritableBytes(recovered_readback),
+            "RaytracingExportRecoveryReadback"
+        );
+        recovery_readback_commands.AddCallback([&] {
+            recovery_callbacks[1].fetch_add(
+                1, std::memory_order_relaxed
+            );
+        });
+        recovery_readback_commands.AddSuccessCallback([&] {
+            recovery_success_callbacks[1].fetch_add(
+                1, std::memory_order_relaxed
+            );
+        });
+        CmdSubmit recovery_readback_submit =
+            recovery_readback_commands.Submit();
+        recovery_submission.AttachReadbackSignal(
+            recovery_readback_submit
+        );
+        RHIExecutor::Get().Submit(
+            EQueueType::Graphics,
+            std::move(recovery_readback_submit),
+            ERHIExecSubmitFlags::FlushGPU
+        );
+        RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
+        if (!recovery_submission.DispatchEncoder([&] {
+                encoder_dispatches.fetch_add(
+                    1, std::memory_order_relaxed
+                );
+            }) ||
+            recovery_submission.DispatchEncoder([&] {
+                encoder_dispatches.fetch_add(
+                    100, std::memory_order_relaxed
+                );
+            })) {
             throw std::runtime_error(
-                "raytracing export dependency rejection poisoned recovery"
+                "accepted production readback did not dispatch the encoder "
+                "exactly once"
             );
         }
 
+        CommandList recovery_tail(EQueueType::Graphics);
+        recovery_tail.CopyFrom(
+            OwnedBytes(std::array<uint32, 4>{97, 101, 103, 107}),
+            recovery_tail_target->GetView(),
+            "RaytracingExportRecoveryTail"
+        );
+        recovery_tail.AddCallback([&] {
+            recovery_callbacks[2].fetch_add(
+                1, std::memory_order_relaxed
+            );
+        });
+        recovery_tail.AddSuccessCallback([&] {
+            recovery_success_callbacks[2].fetch_add(
+                1, std::memory_order_relaxed
+            );
+        });
+        CmdSubmit recovery_tail_submit = recovery_tail.Submit();
+        recovery_submission.AttachDependentWait(recovery_tail_submit);
+        recovery_tail_submit.Signal(recovery_tail_receipt.Get(), 1);
+        RHIExecutor::Get().Submit(
+            EQueueType::Graphics,
+            std::move(recovery_tail_submit),
+            ERHIExecSubmitFlags::FlushGPU
+        );
         RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
-        if (recovery_callbacks.load(std::memory_order_acquire) != 1 ||
-            recovery_success_callbacks.load(std::memory_order_acquire) != 1 ||
-            native_capture.Count() != 1) {
+        const Outcome recovery_tail_outcome =
+            ExportSubmissionTransaction::ResolveReceiptOutcome(
+                recovery_tail_receipt.Get(), 1
+            );
+        const auto recovery_decision =
+            recovery_submission.ClassifyFrameAcceptance(
+                recovery_tail_outcome,
+                true,
+                false
+            );
+        if (!recovery_decision.frame_accepted ||
+            !recovery_decision.export_consumed ||
+            recovery_decision.retry_requested ||
+            recovery_decision.retryable_frame_rejection ||
+            recovery_decision.latch_renderer ||
+            !recovery_decision.readback_attempted ||
+            !recovery_decision.readback_accepted ||
+            !recovery_decision.encoder_dispatched ||
+            encoder_dispatches.load(std::memory_order_acquire) != 1 ||
+            recovered_readback != recovery_expected) {
             throw std::runtime_error(
-                "a second Sync replayed raytracing export recovery"
+                "accepted raytracing export recovery did not consume the "
+                "request exactly once"
+            );
+        }
+        for (size_t index = 0; index < recovery_callbacks.size(); ++index) {
+            if (recovery_callbacks[index].load(std::memory_order_acquire) != 1 ||
+                recovery_success_callbacks[index].load(
+                    std::memory_order_acquire
+                ) != 1) {
+                throw std::runtime_error(
+                    "accepted raytracing export recovery callbacks retired "
+                    "incorrectly"
+                );
+            }
+        }
+        if (recovery_submission.GetReceiptFence()->GetRefCount() != 1 ||
+            recovery_submission.GetReadbackReceiptFence()->GetRefCount() != 1 ||
+            native_capture.Overflowed() || native_capture.Count() != 5) {
+            throw std::runtime_error(
+                "accepted raytracing export recovery had unexpected native "
+                "submissions or receipt lifetime"
+            );
+        }
+        for (size_t index = 0; index < native_capture.Count(); ++index) {
+            if (!native_capture.Event(index).outcome.WasSubmitted()) {
+                throw std::runtime_error(
+                    "raytracing export test observed a rejected native submit"
+                );
+            }
+        }
+
+        RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
+        for (size_t index = 0; index < recovery_callbacks.size(); ++index) {
+            if (recovery_callbacks[index].load(std::memory_order_acquire) != 1 ||
+                recovery_success_callbacks[index].load(
+                    std::memory_order_acquire
+                ) != 1) {
+                throw std::runtime_error(
+                    "a second Sync replayed accepted raytracing export recovery"
+                );
+            }
+        }
+        if (native_capture.Count() != 5 ||
+            encoder_dispatches.load(std::memory_order_acquire) != 1) {
+            throw std::runtime_error(
+                "a second Sync replayed raytracing export recovery work"
             );
         }
     } catch (...) {
@@ -5149,10 +5536,11 @@ void RunRaytracingExportAcceptanceRejection() {
 
     LOG_INFO(
         "[TESTCASE][PASS] name=RaytracingExportAcceptanceRejection "
-        "source=rejected tail=dependency_rejected readback=skipped "
-        "encoder=skipped export_consumed=false "
-        "temporal=0 history=0 tlas=0 native_rejected=0 "
-        "callbacks=exactly_once keepalive=terminal recovery=accepted replay=0"
+        "attempt1=prefix_rejected attempt1_tail=dependency_rejected "
+        "attempt1_latch=false request_pending=true "
+        "readback_retry=frame_accepted recovery_consumed=true encoder=once "
+        "decision_table=verified native_rejected=0 callbacks=exactly_once "
+        "keepalive=terminal replay=0"
     );
 }
 

--- a/source/test/RHIParallelRecordVulkanTest.cpp
+++ b/source/test/RHIParallelRecordVulkanTest.cpp
@@ -202,6 +202,17 @@ private:
     bool                   armed{true};
 };
 
+class HeadlessScriptedSwapchain final : public Swapchain {
+public:
+    HeadlessScriptedSwapchain() {
+        format = PF_R8G8B8A8_UNORM;
+        size   = Extent2D(4, 4);
+    }
+
+    void Recreate(const SwapchainCreateInfo&) override {}
+    void Sync() override {}
+};
+
 class SourceSubmissionCapture final {
 public:
     explicit SourceSubmissionCapture(uint64 _async_queue_scope) : async_queue_scope(_async_queue_scope) {}
@@ -490,6 +501,156 @@ private:
     bool                           installed{false};
 };
 
+class SubmissionBoundaryCapture final {
+public:
+    static void Observe(
+        void*                              _context,
+        const VulkanSubmissionBoundaryEvent& _event
+    ) noexcept {
+        auto& capture =
+            *static_cast<SubmissionBoundaryCapture*>(_context);
+        const size_t index =
+            capture.count.load(std::memory_order_relaxed);
+        if (index >= capture.events.size()) {
+            capture.overflow.store(true, std::memory_order_release);
+            return;
+        }
+        capture.events[index] = _event;
+        capture.count.store(index + 1, std::memory_order_release);
+        if (_event.thread_role != ERHIThreadRole::Submission) {
+            capture.wrong_owner.store(true, std::memory_order_release);
+        }
+    }
+
+    [[nodiscard]] size_t Count() const noexcept {
+        return count.load(std::memory_order_acquire);
+    }
+
+    [[nodiscard]] const VulkanSubmissionBoundaryEvent& Event(
+        size_t _index
+    ) const noexcept {
+        return events[_index];
+    }
+
+    [[nodiscard]] bool IsValid() const noexcept {
+        return !overflow.load(std::memory_order_acquire) &&
+               !wrong_owner.load(std::memory_order_acquire);
+    }
+
+private:
+    std::array<VulkanSubmissionBoundaryEvent, 32> events{};
+    std::atomic<size_t>                         count{0};
+    std::atomic<bool>                           overflow{false};
+    std::atomic<bool>                           wrong_owner{false};
+};
+
+class ScopedSubmissionBoundaryObserver final {
+public:
+    explicit ScopedSubmissionBoundaryObserver(
+        SubmissionBoundaryCapture& _capture
+    ) :
+        observer{
+            .context  = &_capture,
+            .callback = &SubmissionBoundaryCapture::Observe,
+        } {
+        if (!TryInstallVulkanSubmissionBoundaryObserver(&observer)) {
+            throw std::runtime_error(
+                "Vulkan submission-boundary observer was already installed"
+            );
+        }
+        installed = true;
+    }
+
+    ~ScopedSubmissionBoundaryObserver() noexcept {
+        if (installed &&
+            !RemoveVulkanSubmissionBoundaryObserver(&observer)) {
+            std::terminate();
+        }
+    }
+
+    ScopedSubmissionBoundaryObserver(
+        const ScopedSubmissionBoundaryObserver&
+    ) = delete;
+    ScopedSubmissionBoundaryObserver& operator=(
+        const ScopedSubmissionBoundaryObserver&
+    ) = delete;
+
+private:
+    VulkanSubmissionBoundaryObserver observer{};
+    bool                             installed{false};
+};
+
+class ScriptedPresentCapture final {
+public:
+    explicit ScriptedPresentCapture(
+        VulkanScriptedPresentResult _result
+    ) :
+        result(_result) {}
+
+    static VulkanScriptedPresentResult Observe(
+        void*  _context,
+        uint64 _timeline
+    ) noexcept {
+        auto& capture =
+            *static_cast<ScriptedPresentCapture*>(_context);
+        capture.timeline.store(_timeline, std::memory_order_relaxed);
+        capture.thread_id.store(
+            Platform::GetCurrentThreadID(), std::memory_order_relaxed
+        );
+        if (GetCurrentRHIThreadRole() != ERHIThreadRole::Submission) {
+            capture.wrong_owner.store(true, std::memory_order_relaxed);
+        }
+        capture.count.fetch_add(1, std::memory_order_acq_rel);
+        return capture.result;
+    }
+
+    VulkanScriptedPresentResult result{};
+    std::atomic<uint32>         count{0};
+    std::atomic<uint64>         timeline{0};
+    std::atomic<uint32>         thread_id{0};
+    std::atomic<bool>           wrong_owner{false};
+};
+
+class ScopedScriptedPresentOverride final {
+public:
+    explicit ScopedScriptedPresentOverride(
+        ScriptedPresentCapture& _capture
+    ) :
+        scripted_override{
+            .context  = &_capture,
+            .callback = &ScriptedPresentCapture::Observe,
+        } {
+        if (!TryInstallVulkanScriptedPresentOverrideForTesting(
+                &scripted_override
+            )) {
+            throw std::runtime_error(
+                "Vulkan scripted Present override was already installed"
+            );
+        }
+        installed = true;
+    }
+
+    ~ScopedScriptedPresentOverride() noexcept {
+        if (installed &&
+            !RemoveVulkanScriptedPresentOverrideForTesting(
+                &scripted_override
+            )) {
+            std::terminate();
+        }
+    }
+
+    ScopedScriptedPresentOverride(
+        const ScopedScriptedPresentOverride&
+    ) = delete;
+    ScopedScriptedPresentOverride& operator=(
+        const ScopedScriptedPresentOverride&
+    ) = delete;
+
+private:
+    VulkanScriptedPresentOverrideForTesting scripted_override{};
+    bool                                    installed{false};
+};
+
 class DependencyWaitCapture final {
 public:
     explicit DependencyWaitCapture(EQueueType _queue) :
@@ -714,7 +875,9 @@ void ValidateArguments(int _argc, const char** _argv) {
             argument != "--inject-translate-failure" &&
             argument != "--inject-multi-segment-translate-failure" &&
             argument != "--pipeline-window1" &&
-            argument != "--pipeline-window2") {
+            argument != "--pipeline-window2" &&
+            argument != "--present-boundary" &&
+            argument != "--present-hard") {
             throw std::invalid_argument("unsupported argument: " + std::string(argument));
         }
     }
@@ -722,6 +885,12 @@ void ValidateArguments(int _argc, const char** _argv) {
         HasArgument(_argc, _argv, "--pipeline-window2")) {
         throw std::invalid_argument(
             "--pipeline-window1 and --pipeline-window2 are mutually exclusive"
+        );
+    }
+    if (HasArgument(_argc, _argv, "--present-boundary") &&
+        HasArgument(_argc, _argv, "--present-hard")) {
+        throw std::invalid_argument(
+            "--present-boundary and --present-hard are mutually exclusive"
         );
     }
     if (HasArgument(_argc, _argv, "--inject-worker-failure") &&
@@ -6760,6 +6929,1206 @@ void RunShutdownDependencyCancellation() {
     );
 }
 
+void RunSerialControlPipelineBoundary() {
+    using namespace std::chrono_literals;
+
+    auto& device = RenderDevice::Get();
+    constexpr uint64 async_queue_scope =
+        0x5048313546534552ull;
+    const uint32 main_thread_id =
+        Platform::GetCurrentThreadID();
+
+    SourceSubmissionCapture source_capture(async_queue_scope);
+    ScopedSourceSubmissionObserver source_observer(source_capture);
+    SubmissionBoundaryCapture boundary_capture{};
+    ScopedSubmissionBoundaryObserver boundary_observer(
+        boundary_capture
+    );
+    NativeSubmissionCapture        native_capture{};
+    ScopedNativeSubmissionObserver native_observer(native_capture);
+    DependencyWaitCapture          wait_capture{EQueueType::Graphics};
+    ScopedDependencyWaitObserver   wait_observer(wait_capture);
+
+    constexpr size_t element_count = 16;
+    constexpr std::array<uint32, element_count> expected{
+        0x15F10001u,
+        0x15F10002u,
+        0x15F10003u,
+        0x15F10004u,
+        0x15F10005u,
+        0x15F10006u,
+        0x15F10007u,
+        0x15F10008u,
+        0x15F10009u,
+        0x15F1000Au,
+        0x15F1000Bu,
+        0x15F1000Cu,
+        0x15F1000Du,
+        0x15F1000Eu,
+        0x15F1000Fu,
+        0x15F10010u,
+    };
+    std::array<uint32, element_count> readback{};
+    const EBufferUsageFlags usage =
+        EBufferUsageFlags::TRANSFER_SRC |
+        EBufferUsageFlags::TRANSFER_DST;
+    BufferRef source = device.CreateBuffer<uint32>(
+        "phase15f_serial_control_source",
+        element_count,
+        usage
+    );
+    BufferRef destination = device.CreateBuffer<uint32>(
+        "phase15f_serial_control_destination",
+        element_count,
+        usage
+    );
+    if (!source.IsValid() || !destination.IsValid()) {
+        throw std::runtime_error(
+            "Phase15F SerialControl resources were not created"
+        );
+    }
+
+    FenceRef dependency  = device.CreateFence();
+    FenceRef prefix_done = device.CreateFence();
+    FenceRef control_done = device.CreateFence();
+    FenceRef later_done  = device.CreateFence();
+    std::array<std::atomic<uint32>, 3> ordinary_callbacks{};
+    std::array<std::atomic<uint32>, 3> success_callbacks{};
+    std::binary_semaphore later_translated{0};
+    bool dependency_released = false;
+
+    const auto release_dependency = [&] {
+        if (dependency_released) {
+            return;
+        }
+        ResourceCast(dependency.Get())->SignalHost(1);
+        dependency_released = true;
+    };
+
+    try {
+        CommandList prefix(EQueueType::Graphics);
+        prefix.SetResourceStateOwnership(
+            ERHIResourceStateOwnership::Explicit
+        );
+        prefix.CopyFrom(
+            OwnedBytes(expected),
+            source->GetView(),
+            "SerialControlBoundaryBlockedPrefix"
+        );
+        prefix.AddCallback([&] {
+            ordinary_callbacks[0].fetch_add(
+                1, std::memory_order_relaxed
+            );
+        });
+        prefix.AddSuccessCallback([&] {
+            success_callbacks[0].fetch_add(
+                1, std::memory_order_relaxed
+            );
+        });
+        CmdSubmit prefix_submit = prefix.Submit();
+        prefix_submit.SetTranslateExecutionClass(
+            ERHITranslateExecutionClass::Parallel
+        );
+        prefix_submit.SetResourceStateOwnership(
+            ERHIResourceStateOwnership::Explicit
+        );
+        prefix_submit.async_queue_scope = async_queue_scope;
+        prefix_submit.Wait(dependency.Get(), 1)
+            .Signal(prefix_done.Get(), 1);
+        RHIExecutor::Get().Submit(
+            EQueueType::Graphics,
+            std::move(prefix_submit),
+            ERHIExecSubmitFlags::FlushGPU
+        );
+
+        if (!wait_capture.entered.try_acquire_for(5s) ||
+            wait_capture.count.load(std::memory_order_acquire) != 1 ||
+            wait_capture.wrong_owner.load(std::memory_order_acquire) ||
+            source_capture.Count() != 0 ||
+            boundary_capture.Count() != 0 ||
+            native_capture.Count() != 0) {
+            throw std::runtime_error(
+                "SerialControl prefix did not block on the sole "
+                "Submission owner"
+            );
+        }
+
+        CommandList control(EQueueType::Graphics);
+        control.SetTranslateExecutionClass(
+            ERHITranslateExecutionClass::SerialControl
+        );
+        control.SetResourceStateOwnership(
+            ERHIResourceStateOwnership::Explicit
+        );
+        control.CopyFrom(
+            source->GetView(),
+            destination->GetView(),
+            "SerialControlBoundaryCopy"
+        );
+        control.AddCallback([&] {
+            ordinary_callbacks[1].fetch_add(
+                1, std::memory_order_relaxed
+            );
+        });
+        control.AddSuccessCallback([&] {
+            success_callbacks[1].fetch_add(
+                1, std::memory_order_relaxed
+            );
+        });
+        CmdSubmit control_submit = control.Submit();
+        control_submit.Signal(control_done.Get(), 1);
+        RHIExecutor::Get().Submit(
+            EQueueType::Graphics,
+            std::move(control_submit),
+            ERHIExecSubmitFlags::FlushGPU
+        );
+
+        CommandList later(EQueueType::Graphics);
+        later.SetResourceStateOwnership(
+            ERHIResourceStateOwnership::Explicit
+        );
+        later.CopyFrom(
+            destination->GetView(),
+            WritableBytes(readback),
+            "SerialControlBoundaryLaterReadback"
+        );
+        later.AddCustomCommand(
+            MakeUnique<TranslateProbeCommand>(
+                &later_translated,
+                EQueueType::Graphics
+            ),
+            "SerialControlBoundaryLaterParallelSource"
+        );
+        later.AddCallback([&] {
+            ordinary_callbacks[2].fetch_add(
+                1, std::memory_order_relaxed
+            );
+        });
+        later.AddSuccessCallback([&] {
+            success_callbacks[2].fetch_add(
+                1, std::memory_order_relaxed
+            );
+        });
+        CmdSubmit later_submit = later.Submit();
+        later_submit.SetTranslateExecutionClass(
+            ERHITranslateExecutionClass::Parallel
+        );
+        later_submit.SetResourceStateOwnership(
+            ERHIResourceStateOwnership::Explicit
+        );
+        later_submit.async_queue_scope = async_queue_scope;
+        later_submit.Signal(later_done.Get(), 1);
+        RHIExecutor::Get().Submit(
+            EQueueType::Graphics,
+            std::move(later_submit),
+            ERHIExecSubmitFlags::FlushGPU
+        );
+
+        bool callback_advanced = false;
+        for (size_t index = 0; index < ordinary_callbacks.size(); ++index) {
+            callback_advanced =
+                callback_advanced ||
+                ordinary_callbacks[index].load(
+                    std::memory_order_acquire
+                ) != 0 ||
+                success_callbacks[index].load(
+                    std::memory_order_acquire
+                ) != 0;
+        }
+        if (later_translated.try_acquire_for(250ms) ||
+            callback_advanced ||
+            source_capture.Count() != 0 ||
+            boundary_capture.Count() != 0 ||
+            native_capture.Count() != 0) {
+            throw std::runtime_error(
+                "SerialControl or a later source overtook the blocked "
+                "pipeline prefix"
+            );
+        }
+
+        release_dependency();
+        RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
+
+        if (!later_translated.try_acquire() ||
+            readback != expected) {
+            throw std::runtime_error(
+                "SerialControl did not preserve prefix/control/later "
+                "GPU ordering"
+            );
+        }
+        if (ResourceCast(prefix_done.Get())->HostWait(1) != VK_SUCCESS ||
+            ResourceCast(control_done.Get())->HostWait(1) != VK_SUCCESS ||
+            ResourceCast(later_done.Get())->HostWait(1) != VK_SUCCESS) {
+            throw std::runtime_error(
+                "SerialControl boundary signals did not succeed"
+            );
+        }
+        for (size_t index = 0; index < ordinary_callbacks.size(); ++index) {
+            if (ordinary_callbacks[index].load(
+                    std::memory_order_acquire
+                ) != 1 ||
+                success_callbacks[index].load(
+                    std::memory_order_acquire
+                ) != 1) {
+                throw std::runtime_error(
+                    "SerialControl boundary callbacks were not retired "
+                    "exactly once"
+                );
+            }
+        }
+
+        if (source_capture.Overflowed() ||
+            source_capture.Count() != 2) {
+            throw std::runtime_error(
+                "SerialControl boundary lost a parallel source submission"
+            );
+        }
+        const VulkanSourceSubmissionEvent& prefix_source =
+            source_capture.Event(0);
+        const VulkanSourceSubmissionEvent& later_source =
+            source_capture.Event(1);
+        if (prefix_source.batch_sequence == 0 ||
+            later_source.batch_sequence !=
+                prefix_source.batch_sequence + 2 ||
+            prefix_source.source_index != 0 ||
+            later_source.source_index != 0 ||
+            prefix_source.queue != EQueueType::Graphics ||
+            later_source.queue != EQueueType::Graphics) {
+            throw std::runtime_error(
+                "SerialControl did not remain between its prefix and "
+                "later source"
+            );
+        }
+
+        if (native_capture.Overflowed() ||
+            native_capture.Count() != 3) {
+            throw std::runtime_error(
+                "SerialControl boundary emitted the wrong native "
+                "submission count"
+            );
+        }
+        const uint32 submission_thread_id =
+            native_capture.Event(0).thread_id;
+        for (size_t index = 0; index < native_capture.Count(); ++index) {
+            const VulkanNativeSubmissionEvent& event =
+                native_capture.Event(index);
+            if (event.queue != EQueueType::Graphics ||
+                event.thread_role != ERHIThreadRole::Submission ||
+                event.thread_id != submission_thread_id ||
+                event.thread_id == main_thread_id ||
+                !event.outcome.WasSubmitted()) {
+                throw std::runtime_error(
+                    "SerialControl native submission order or owner changed"
+                );
+            }
+        }
+
+        if (!boundary_capture.IsValid() ||
+            boundary_capture.Count() != 2) {
+            throw std::runtime_error(
+                "SerialControl emitted the wrong boundary event count"
+            );
+        }
+        const VulkanSubmissionBoundaryEvent& dispatch =
+            boundary_capture.Event(0);
+        const VulkanSubmissionBoundaryEvent& terminal =
+            boundary_capture.Event(1);
+        const uint64 control_batch_sequence =
+            prefix_source.batch_sequence + 1;
+        if (dispatch.batch_sequence != control_batch_sequence ||
+            terminal.batch_sequence != control_batch_sequence ||
+            dispatch.operation_index != 0 ||
+            terminal.operation_index != 0 ||
+            dispatch.kind !=
+                EVulkanSubmissionBoundaryKind::SerialControl ||
+            terminal.kind !=
+                EVulkanSubmissionBoundaryKind::SerialControl ||
+            dispatch.queue != EQueueType::Graphics ||
+            terminal.queue != EQueueType::Graphics ||
+            dispatch.phase !=
+                EVulkanSubmissionBoundaryPhase::Dispatch ||
+            terminal.phase !=
+                EVulkanSubmissionBoundaryPhase::Terminal ||
+            dispatch.outcome_valid ||
+            !terminal.outcome_valid ||
+            !terminal.gpu_submitted ||
+            !terminal.outcome.Succeeded() ||
+            dispatch.dependency_wait_count != 0 ||
+            terminal.dependency_wait_count != 0 ||
+            dispatch.present_receipt_resolution_attempts != 0 ||
+            terminal.present_receipt_resolution_attempts != 0 ||
+            dispatch.thread_id != submission_thread_id ||
+            terminal.thread_id != submission_thread_id) {
+            throw std::runtime_error(
+                "SerialControl boundary identity, outcome, or owner changed"
+            );
+        }
+
+        const size_t sources_before_second_sync =
+            source_capture.Count();
+        const size_t boundaries_before_second_sync =
+            boundary_capture.Count();
+        const size_t native_before_second_sync =
+            native_capture.Count();
+        RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
+        bool callback_replayed = false;
+        for (size_t index = 0; index < ordinary_callbacks.size(); ++index) {
+            callback_replayed =
+                callback_replayed ||
+                ordinary_callbacks[index].load(
+                    std::memory_order_acquire
+                ) != 1 ||
+                success_callbacks[index].load(
+                    std::memory_order_acquire
+                ) != 1;
+        }
+        if (source_capture.Count() != sources_before_second_sync ||
+            boundary_capture.Count() !=
+                boundaries_before_second_sync ||
+            native_capture.Count() != native_before_second_sync ||
+            callback_replayed) {
+            throw std::runtime_error(
+                "a second RHI Sync replayed SerialControl boundary work"
+            );
+        }
+
+        LOG_INFO(
+            "[TESTCASE][PASS] name=SerialControlPipelineBoundary "
+            "order=Prefix,SerialControl,Later owner=Submission "
+            "later_translate=blocked readback=verified signals=success "
+            "boundary_events=2 native_submits=3 replay=0"
+        );
+    } catch (...) {
+        release_dependency();
+        RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
+        throw;
+    }
+}
+
+void RunPresentPipelineBoundary() {
+    using namespace std::chrono_literals;
+
+    auto&                  device   = RenderDevice::Get();
+    const RHIQueueTopology topology = device.GetQueueTopology();
+    const EQueueType prefix_queue =
+        topology.copy.available ?
+            EQueueType::Copy :
+            EQueueType::Graphics;
+    const uint32 prefix_native =
+        prefix_queue == EQueueType::Copy ?
+            topology.copy.native_queue_id :
+            topology.graphics.native_queue_id;
+    const bool bridge_required =
+        prefix_queue != EQueueType::Graphics;
+    const uint32 bridge_dependency_wait_count =
+        bridge_required &&
+                prefix_native != topology.graphics.native_queue_id ?
+            1u :
+            0u;
+    constexpr uint64 async_queue_scope =
+        0x5048313546524545ull;
+    const uint32 main_thread_id =
+        Platform::GetCurrentThreadID();
+
+    SourceSubmissionCapture source_capture(async_queue_scope);
+    ScopedSourceSubmissionObserver source_observer(source_capture);
+    SubmissionBoundaryCapture boundary_capture{};
+    ScopedSubmissionBoundaryObserver boundary_observer(
+        boundary_capture
+    );
+    NativeSubmissionCapture        native_capture{};
+    ScopedNativeSubmissionObserver native_observer(native_capture);
+    DependencyWaitCapture          wait_capture{prefix_queue};
+    ScopedDependencyWaitObserver   wait_observer(wait_capture);
+    ScriptedPresentCapture scripted_capture(
+        VulkanScriptedPresentResult{
+            .outcome = {
+                EVulkanOperationStatus::Recreate,
+                VK_ERROR_OUT_OF_DATE_KHR,
+            },
+        }
+    );
+    ScopedScriptedPresentOverride scripted_override(
+        scripted_capture
+    );
+
+    TextureRef present_source = device.CreateTexture(
+        "phase15f_present_source",
+        Extent3D(4, 4, 1),
+        PF_R8G8B8A8_UNORM,
+        ETextureUsageFlags::TRANSFER_SRC |
+            ETextureUsageFlags::TRANSFER_DST
+    );
+    SwapchainRef scripted_swapchain{
+        MoerNew(HeadlessScriptedSwapchain)()
+    };
+    BufferRef transfer_buffer = device.CreateBuffer<uint32>(
+        "phase15f_present_bridge_buffer",
+        4,
+        EBufferUsageFlags::TRANSFER_SRC |
+            EBufferUsageFlags::TRANSFER_DST
+    );
+    if (!present_source.IsValid() || !scripted_swapchain.IsValid() ||
+        !transfer_buffer.IsValid()) {
+        throw std::runtime_error(
+            "Phase15F Present boundary resources were not created"
+        );
+    }
+
+    constexpr std::array<uint32, 4> expected{
+        0x15F00001u,
+        0x15F00002u,
+        0x15F00003u,
+        0x15F00004u,
+    };
+    std::array<uint32, expected.size()> readback{};
+    FenceRef dependency = device.CreateFence();
+    FenceRef prefix_done = device.CreateFence();
+    FenceRef later_done  = device.CreateFence();
+    std::array<std::atomic<uint32>, 2> ordinary_callbacks{};
+    std::array<std::atomic<uint32>, 2> success_callbacks{};
+    std::binary_semaphore later_translated{0};
+    bool dependency_released = false;
+
+    const auto release_dependency = [&] {
+        if (dependency_released) {
+            return;
+        }
+        ResourceCast(dependency.Get())->SignalHost(1);
+        dependency_released = true;
+    };
+
+    try {
+        CommandList prefix(prefix_queue);
+        prefix.SetResourceStateOwnership(
+            ERHIResourceStateOwnership::Explicit
+        );
+        prefix.CopyFrom(
+            OwnedBytes(expected),
+            transfer_buffer->GetView(),
+            "PresentBoundaryBlockedPrefix"
+        );
+        prefix.AddCallback([&] {
+            ordinary_callbacks[0].fetch_add(
+                1, std::memory_order_relaxed
+            );
+        });
+        prefix.AddSuccessCallback([&] {
+            success_callbacks[0].fetch_add(
+                1, std::memory_order_relaxed
+            );
+        });
+        CmdSubmit prefix_submit = prefix.Submit();
+        prefix_submit.SetTranslateExecutionClass(
+            ERHITranslateExecutionClass::Parallel
+        );
+        prefix_submit.SetResourceStateOwnership(
+            ERHIResourceStateOwnership::Explicit
+        );
+        prefix_submit.async_queue_scope = async_queue_scope;
+        prefix_submit.Wait(dependency.Get(), 1)
+            .Signal(prefix_done.Get(), 1);
+        RHIExecutor::Get().Submit(
+            prefix_queue,
+            std::move(prefix_submit),
+            ERHIExecSubmitFlags::FlushGPU
+        );
+
+        if (!wait_capture.entered.try_acquire_for(5s) ||
+            wait_capture.count.load(std::memory_order_acquire) != 1 ||
+            wait_capture.wrong_owner.load(std::memory_order_acquire) ||
+            source_capture.Count() != 0 ||
+            boundary_capture.Count() != 0 ||
+            scripted_capture.count.load(std::memory_order_acquire) != 0 ||
+            native_capture.Count() != 0) {
+            throw std::runtime_error(
+                "Present boundary prefix did not block on the sole "
+                "Submission owner"
+            );
+        }
+
+        PresentReceiptRef receipt = MakeShared<PresentReceipt>();
+        RHIExecutor::Get().Present(
+            RHIPresentRequest(
+                scripted_swapchain,
+                present_source->GetView(),
+                receipt
+            ),
+            true
+        );
+
+        CommandList later(EQueueType::Graphics);
+        later.SetResourceStateOwnership(
+            ERHIResourceStateOwnership::Explicit
+        );
+        later.CopyFrom(
+            transfer_buffer->GetView(),
+            WritableBytes(readback),
+            "PresentBoundaryLaterReadback"
+        );
+        later.AddCustomCommand(
+            MakeUnique<TranslateProbeCommand>(
+                &later_translated,
+                EQueueType::Graphics
+            ),
+            "PresentBoundaryLaterParallelSource"
+        );
+        later.AddCallback([&] {
+            ordinary_callbacks[1].fetch_add(
+                1, std::memory_order_relaxed
+            );
+        });
+        later.AddSuccessCallback([&] {
+            success_callbacks[1].fetch_add(
+                1, std::memory_order_relaxed
+            );
+        });
+        CmdSubmit later_submit = later.Submit();
+        later_submit.SetTranslateExecutionClass(
+            ERHITranslateExecutionClass::Parallel
+        );
+        later_submit.SetResourceStateOwnership(
+            ERHIResourceStateOwnership::Explicit
+        );
+        later_submit.async_queue_scope = async_queue_scope;
+        later_submit.Signal(later_done.Get(), 1);
+        RHIExecutor::Get().Submit(
+            EQueueType::Graphics,
+            std::move(later_submit),
+            ERHIExecSubmitFlags::FlushGPU
+        );
+
+        if (later_translated.try_acquire_for(250ms) ||
+            scripted_capture.count.load(std::memory_order_acquire) != 0 ||
+            source_capture.Count() != 0 ||
+            boundary_capture.Count() != 0 ||
+            native_capture.Count() != 0) {
+            throw std::runtime_error(
+                "Present or a later source overtook the blocked "
+                "pipeline prefix"
+            );
+        }
+
+        release_dependency();
+        const PresentReceiptResult receipt_result =
+            receipt->WaitForSubmission(5s);
+        if (!receipt_result.resolved ||
+            receipt_result.submitted ||
+            !receipt_result.recreate_swapchain) {
+            throw std::runtime_error(
+                "scripted Recreate Present resolved the wrong receipt state"
+            );
+        }
+        RHIExecutor::Get().Sync(ERHISyncDepth::Present);
+
+        if (!later_translated.try_acquire() ||
+            receipt->ResolutionAttemptCount() != 1 ||
+            scripted_capture.count.load(std::memory_order_acquire) != 1 ||
+            scripted_capture.timeline.load(std::memory_order_acquire) == 0 ||
+            scripted_capture.wrong_owner.load(std::memory_order_acquire) ||
+            readback != expected) {
+            throw std::runtime_error(
+                "scripted Present did not preserve bridge ordering, "
+                "readback, or exactly-once receipt ownership"
+            );
+        }
+        for (size_t index = 0; index < ordinary_callbacks.size(); ++index) {
+            if (ordinary_callbacks[index].load(
+                    std::memory_order_acquire
+                ) != 1 ||
+                success_callbacks[index].load(
+                    std::memory_order_acquire
+                ) != 1) {
+                throw std::runtime_error(
+                    "Present boundary source callbacks were not retired "
+                    "exactly once"
+                );
+            }
+        }
+        if (ResourceCast(prefix_done.Get())->HostWait(1) != VK_SUCCESS ||
+            ResourceCast(later_done.Get())->HostWait(1) != VK_SUCCESS) {
+            throw std::runtime_error(
+                "Present boundary source signals did not succeed"
+            );
+        }
+        if (source_capture.Overflowed() ||
+            source_capture.Count() != 2) {
+            throw std::runtime_error(
+                "Present boundary lost a source submission"
+            );
+        }
+        const VulkanSourceSubmissionEvent& prefix_source =
+            source_capture.Event(0);
+        const VulkanSourceSubmissionEvent& later_source =
+            source_capture.Event(1);
+        if (prefix_source.batch_sequence == 0 ||
+            later_source.batch_sequence !=
+                prefix_source.batch_sequence + 2 ||
+            prefix_source.source_index != 0 ||
+            later_source.source_index != 0 ||
+            prefix_source.queue != prefix_queue ||
+            later_source.queue != EQueueType::Graphics) {
+            throw std::runtime_error(
+                "Present did not remain between its prefix and later source"
+            );
+        }
+
+        const size_t expected_native_count =
+            bridge_required ? 3 : 2;
+        if (native_capture.Overflowed() ||
+            native_capture.Count() != expected_native_count) {
+            throw std::runtime_error(
+                "scripted Present emitted or lost a native submission"
+            );
+        }
+        const std::array<EQueueType, 3> expected_native_queues{
+            prefix_queue,
+            EQueueType::Graphics,
+            EQueueType::Graphics,
+        };
+        const uint32 submission_thread_id =
+            native_capture.Event(0).thread_id;
+        for (size_t index = 0; index < expected_native_count; ++index) {
+            const size_t queue_index =
+                !bridge_required && index == 1 ? 2 : index;
+            const VulkanNativeSubmissionEvent& event =
+                native_capture.Event(index);
+            if (event.queue != expected_native_queues[queue_index] ||
+                event.thread_role != ERHIThreadRole::Submission ||
+                event.thread_id != submission_thread_id ||
+                event.thread_id == main_thread_id ||
+                !event.outcome.WasSubmitted()) {
+                throw std::runtime_error(
+                    "Present boundary native submission order or owner changed"
+                );
+            }
+        }
+
+        const size_t first_present_event_count =
+            bridge_required ? 4 : 2;
+        if (!boundary_capture.IsValid() ||
+            boundary_capture.Count() !=
+                first_present_event_count) {
+            throw std::runtime_error(
+                "Present boundary emitted the wrong boundary event count"
+            );
+        }
+        const auto expect_pair =
+            [&](size_t index,
+                uint64 batch_sequence,
+                uint32 operation_index,
+                EVulkanSubmissionBoundaryKind kind,
+                uint32 dependency_wait_count) {
+                const VulkanSubmissionBoundaryEvent& dispatch =
+                    boundary_capture.Event(index);
+                const VulkanSubmissionBoundaryEvent& terminal =
+                    boundary_capture.Event(index + 1);
+                if (dispatch.batch_sequence != batch_sequence ||
+                    terminal.batch_sequence != batch_sequence ||
+                    dispatch.operation_index != operation_index ||
+                    terminal.operation_index != operation_index ||
+                    dispatch.kind != kind || terminal.kind != kind ||
+                    dispatch.queue != EQueueType::Graphics ||
+                    terminal.queue != EQueueType::Graphics ||
+                    dispatch.phase !=
+                        EVulkanSubmissionBoundaryPhase::Dispatch ||
+                    terminal.phase !=
+                        EVulkanSubmissionBoundaryPhase::Terminal ||
+                    dispatch.outcome_valid ||
+                    !terminal.outcome_valid ||
+                    dispatch.dependency_wait_count !=
+                        dependency_wait_count ||
+                    terminal.dependency_wait_count !=
+                        dependency_wait_count ||
+                    dispatch.thread_id != submission_thread_id ||
+                    terminal.thread_id != submission_thread_id) {
+                    throw std::runtime_error(
+                        "submission-boundary identity or owner changed"
+                    );
+                }
+            };
+
+        size_t boundary_cursor = 0;
+        const uint64 present_batch_sequence =
+            prefix_source.batch_sequence + 1;
+        if (bridge_required) {
+            expect_pair(
+                boundary_cursor,
+                present_batch_sequence,
+                0,
+                EVulkanSubmissionBoundaryKind::PresentBridge,
+                bridge_dependency_wait_count
+            );
+            const VulkanSubmissionBoundaryEvent& bridge_terminal =
+                boundary_capture.Event(boundary_cursor + 1);
+            if (!bridge_terminal.gpu_submitted ||
+                !bridge_terminal.outcome.Succeeded()) {
+                throw std::runtime_error(
+                    "Present bridge did not submit its cross-queue wait"
+                );
+            }
+            boundary_cursor += 2;
+        }
+        expect_pair(
+            boundary_cursor,
+            present_batch_sequence,
+            1,
+            EVulkanSubmissionBoundaryKind::Present,
+            0
+        );
+        const VulkanSubmissionBoundaryEvent& present_terminal =
+            boundary_capture.Event(boundary_cursor + 1);
+        if (present_terminal.outcome.status !=
+                EVulkanOperationStatus::Recreate ||
+            present_terminal.gpu_submitted ||
+            present_terminal.recoverable_rejection ||
+            present_terminal.present_receipt_resolution_attempts != 1) {
+            throw std::runtime_error(
+                "Present terminal diagnostics lost Recreate state"
+            );
+        }
+
+        PresentReceiptRef present_only_receipt =
+            MakeShared<PresentReceipt>();
+        RHIExecutor::Get().Present(
+            RHIPresentRequest(
+                scripted_swapchain,
+                present_source->GetView(),
+                present_only_receipt
+            ),
+            true
+        );
+        const PresentReceiptResult present_only_result =
+            present_only_receipt->WaitForSubmission(5s);
+        if (!present_only_result.resolved ||
+            present_only_result.submitted ||
+            !present_only_result.recreate_swapchain) {
+            throw std::runtime_error(
+                "Present-only batch resolved the wrong receipt state"
+            );
+        }
+        RHIExecutor::Get().Sync(ERHISyncDepth::Present);
+        if (present_only_receipt->ResolutionAttemptCount() != 1 ||
+            scripted_capture.count.load(std::memory_order_acquire) != 2 ||
+            boundary_capture.Count() !=
+                first_present_event_count + 2 ||
+            native_capture.Count() != expected_native_count) {
+            throw std::runtime_error(
+                "Present-only batch emitted an unexpected bridge, "
+                "native submit, or receipt replay"
+            );
+        }
+        expect_pair(
+            first_present_event_count,
+            present_batch_sequence + 2,
+            1,
+            EVulkanSubmissionBoundaryKind::Present,
+            0
+        );
+
+        const size_t boundaries_before_second_sync =
+            boundary_capture.Count();
+        const size_t native_before_second_sync =
+            native_capture.Count();
+        RHIExecutor::Get().Sync(ERHISyncDepth::Present);
+        if (boundary_capture.Count() !=
+                boundaries_before_second_sync ||
+            native_capture.Count() != native_before_second_sync ||
+            scripted_capture.count.load(std::memory_order_acquire) != 2) {
+            throw std::runtime_error(
+                "a second Present Sync replayed boundary work"
+            );
+        }
+
+        LOG_INFO(
+            "[TESTCASE][PASS] name=PresentPipelineBoundary "
+            "outcome=Recreate order=Prefix,Bridge?,Present,Later "
+            "owner=Submission receipt_attempts=1 submitted=false "
+            "recreate=true completion=drained later_batch=success "
+            "present_only=verified bridge={} graphics_native={} "
+            "prefix_native={} readback=verified replay=0",
+            bridge_required ? "required" : "elided",
+            topology.graphics.native_queue_id,
+            prefix_native
+        );
+    } catch (...) {
+        release_dependency();
+        RHIExecutor::Get().Sync(ERHISyncDepth::Present);
+        throw;
+    }
+}
+
+void RunQueuedPresentShutdownBoundary() {
+    using namespace std::chrono_literals;
+
+    auto& device = RenderDevice::Get();
+    constexpr uint64 async_queue_scope =
+        0x5048313546534844ull;
+    const uint32 main_thread_id =
+        Platform::GetCurrentThreadID();
+
+    SourceSubmissionCapture source_capture(async_queue_scope);
+    ScopedSourceSubmissionObserver source_observer(source_capture);
+    SubmissionBoundaryCapture boundary_capture{};
+    ScopedSubmissionBoundaryObserver boundary_observer(
+        boundary_capture
+    );
+    NativeSubmissionCapture        native_capture{};
+    ScopedNativeSubmissionObserver native_observer(native_capture);
+    DependencyWaitCapture          wait_capture{EQueueType::Graphics};
+    ScopedDependencyWaitObserver   wait_observer(wait_capture);
+    ScriptedPresentCapture scripted_capture(
+        VulkanScriptedPresentResult{
+            .outcome = {
+                EVulkanOperationStatus::Retry,
+                VK_NOT_READY,
+            },
+        }
+    );
+    ScopedScriptedPresentOverride scripted_override(
+        scripted_capture
+    );
+
+    TextureRef present_source = device.CreateTexture(
+        "phase15f_shutdown_present_source",
+        Extent3D(4, 4, 1),
+        PF_R8G8B8A8_UNORM,
+        ETextureUsageFlags::TRANSFER_SRC |
+            ETextureUsageFlags::TRANSFER_DST
+    );
+    SwapchainRef scripted_swapchain{
+        MoerNew(HeadlessScriptedSwapchain)()
+    };
+    if (!present_source.IsValid() || !scripted_swapchain.IsValid()) {
+        throw std::runtime_error(
+            "Phase15F shutdown Present resources were not created"
+        );
+    }
+
+    FenceRef dependency = device.CreateFence();
+    FenceRef prefix_done = device.CreateFence();
+    PresentReceiptRef receipt = MakeShared<PresentReceipt>();
+    std::atomic<uint32> ordinary_callbacks{0};
+    std::atomic<uint32> success_callbacks{0};
+    bool runtime_stopped = false;
+
+    const auto stop_runtime = [&] {
+        if (runtime_stopped) {
+            return;
+        }
+        RHIExecutor::ShutDown();
+        runtime_stopped = true;
+    };
+
+    try {
+        CommandList prefix(EQueueType::Graphics);
+        prefix.SetResourceStateOwnership(
+            ERHIResourceStateOwnership::Explicit
+        );
+        prefix.AddCallback([&] {
+            ordinary_callbacks.fetch_add(
+                1, std::memory_order_relaxed
+            );
+        });
+        prefix.AddSuccessCallback([&] {
+            success_callbacks.fetch_add(
+                1, std::memory_order_relaxed
+            );
+        });
+        CmdSubmit prefix_submit = prefix.Submit();
+        prefix_submit.SetTranslateExecutionClass(
+            ERHITranslateExecutionClass::Parallel
+        );
+        prefix_submit.SetResourceStateOwnership(
+            ERHIResourceStateOwnership::Explicit
+        );
+        prefix_submit.async_queue_scope = async_queue_scope;
+        prefix_submit.Wait(dependency.Get(), 1)
+            .Signal(prefix_done.Get(), 1);
+        RHIExecutor::Get().Submit(
+            EQueueType::Graphics,
+            std::move(prefix_submit),
+            ERHIExecSubmitFlags::FlushGPU
+        );
+
+        if (!wait_capture.entered.try_acquire_for(5s) ||
+            wait_capture.count.load(std::memory_order_acquire) != 1 ||
+            wait_capture.wrong_owner.load(std::memory_order_acquire) ||
+            source_capture.Count() != 0 ||
+            boundary_capture.Count() != 0 ||
+            native_capture.Count() != 0) {
+            throw std::runtime_error(
+                "shutdown Present prefix did not block on the sole "
+                "Submission owner"
+            );
+        }
+
+        RHIExecutor::Get().Present(
+            RHIPresentRequest(
+                scripted_swapchain,
+                present_source->GetView(),
+                receipt
+            ),
+            true
+        );
+        if (receipt->WaitForSubmission(250ms).resolved ||
+            scripted_capture.count.load(std::memory_order_acquire) != 0 ||
+            boundary_capture.Count() != 0 ||
+            native_capture.Count() != 0) {
+            throw std::runtime_error(
+                "queued Present overtook the shutdown-blocked prefix"
+            );
+        }
+
+        stop_runtime();
+
+        const PresentReceiptResult result =
+            receipt->WaitForSubmission(5s);
+        if (!result.resolved ||
+            result.submitted ||
+            result.recreate_swapchain ||
+            receipt->ResolutionAttemptCount() != 1) {
+            throw std::runtime_error(
+                "shutdown Retry Present resolved the wrong receipt state"
+            );
+        }
+        if (ResourceCast(prefix_done.Get())->HostWait(1) !=
+                VK_ERROR_UNKNOWN ||
+            !ResourceCast(prefix_done.Get())->IsRejected(1) ||
+            ResourceCast(prefix_done.Get())->IsFailed() ||
+            ordinary_callbacks.load(std::memory_order_acquire) != 1 ||
+            success_callbacks.load(std::memory_order_acquire) != 0 ||
+            source_capture.Count() != 0 ||
+            native_capture.Count() != 0) {
+            throw std::runtime_error(
+                "shutdown did not reject the blocked prefix and retire "
+                "the queued Present without native work"
+            );
+        }
+        if (scripted_capture.count.load(
+                std::memory_order_acquire
+            ) != 1 ||
+            scripted_capture.wrong_owner.load(
+                std::memory_order_acquire
+            ) ||
+            scripted_capture.thread_id.load(
+                std::memory_order_acquire
+            ) == main_thread_id) {
+            throw std::runtime_error(
+                "shutdown Retry Present escaped the Submission owner"
+            );
+        }
+
+        if (!boundary_capture.IsValid() ||
+            boundary_capture.Count() != 2) {
+            throw std::runtime_error(
+                "shutdown Retry Present emitted the wrong boundary events"
+            );
+        }
+        const VulkanSubmissionBoundaryEvent& dispatch =
+            boundary_capture.Event(0);
+        const VulkanSubmissionBoundaryEvent& terminal =
+            boundary_capture.Event(1);
+        if (dispatch.batch_sequence == 0 ||
+            terminal.batch_sequence != dispatch.batch_sequence ||
+            dispatch.operation_index != 1 ||
+            terminal.operation_index != 1 ||
+            dispatch.kind !=
+                EVulkanSubmissionBoundaryKind::Present ||
+            terminal.kind !=
+                EVulkanSubmissionBoundaryKind::Present ||
+            dispatch.phase !=
+                EVulkanSubmissionBoundaryPhase::Dispatch ||
+            terminal.phase !=
+                EVulkanSubmissionBoundaryPhase::Terminal ||
+            dispatch.outcome_valid ||
+            !terminal.outcome_valid ||
+            terminal.outcome.status !=
+                EVulkanOperationStatus::Retry ||
+            terminal.gpu_submitted ||
+            terminal.recoverable_rejection ||
+            terminal.present_receipt_resolution_attempts != 1 ||
+            dispatch.thread_id != terminal.thread_id ||
+            dispatch.thread_id != scripted_capture.thread_id.load(
+                std::memory_order_acquire
+            )) {
+            throw std::runtime_error(
+                "shutdown Retry Present lost identity, outcome, or owner"
+            );
+        }
+
+        LOG_INFO(
+            "[TESTCASE][PASS] name=QueuedPresentShutdownBoundary "
+            "outcome=Retry prefix=rejected receipt_attempts=1 "
+            "submitted=false recreate=false owner=Submission "
+            "native_submit=0 owners=stopped replay=0"
+        );
+    } catch (...) {
+        const std::exception_ptr failure =
+            std::current_exception();
+        stop_runtime();
+        std::rethrow_exception(failure);
+    }
+}
+
+void RunPresentHardFailureBoundary() {
+    using namespace std::chrono_literals;
+
+    auto& device = RenderDevice::Get();
+    const uint32 main_thread_id =
+        Platform::GetCurrentThreadID();
+    TextureRef present_source = device.CreateTexture(
+        "phase15f_present_hard_source",
+        Extent3D(4, 4, 1),
+        PF_R8G8B8A8_UNORM,
+        ETextureUsageFlags::TRANSFER_SRC |
+            ETextureUsageFlags::TRANSFER_DST
+    );
+    SwapchainRef scripted_swapchain{
+        MoerNew(HeadlessScriptedSwapchain)()
+    };
+    if (!present_source.IsValid() || !scripted_swapchain.IsValid()) {
+        throw std::runtime_error(
+            "Phase15F hard Present resources were not created"
+        );
+    }
+
+    SubmissionBoundaryCapture boundary_capture{};
+    ScopedSubmissionBoundaryObserver boundary_observer(
+        boundary_capture
+    );
+    NativeSubmissionCapture        native_capture{};
+    ScopedNativeSubmissionObserver native_observer(native_capture);
+    ScriptedPresentCapture scripted_capture(
+        VulkanScriptedPresentResult{
+            .outcome = {
+                EVulkanOperationStatus::Rejected,
+                VK_ERROR_DEVICE_LOST,
+            },
+        }
+    );
+    ScopedScriptedPresentOverride scripted_override(
+        scripted_capture
+    );
+
+    PresentReceiptRef receipt = MakeShared<PresentReceipt>();
+    FenceRef later_done = device.CreateFence();
+    std::atomic<uint32> ordinary_callbacks{0};
+    std::atomic<uint32> success_callbacks{0};
+
+    try {
+        RHIExecutor::Get().Present(
+            RHIPresentRequest(
+                scripted_swapchain,
+                present_source->GetView(),
+                receipt
+            ),
+            true
+        );
+        const PresentReceiptResult receipt_result =
+            receipt->WaitForSubmission(5s);
+        if (!receipt_result.resolved || receipt_result.submitted ||
+            receipt_result.recreate_swapchain ||
+            receipt->ResolutionAttemptCount() != 1) {
+            throw std::runtime_error(
+                "hard Present resolved the wrong receipt state"
+            );
+        }
+
+        CommandList later(EQueueType::Graphics);
+        later.AddCallback([&] {
+            ordinary_callbacks.fetch_add(
+                1, std::memory_order_relaxed
+            );
+        });
+        later.AddSuccessCallback([&] {
+            success_callbacks.fetch_add(
+                1, std::memory_order_relaxed
+            );
+        });
+        CmdSubmit later_submit = later.Submit();
+        later_submit.Signal(later_done.Get(), 1);
+        RHIExecutor::Get().Submit(
+            EQueueType::Graphics,
+            std::move(later_submit),
+            ERHIExecSubmitFlags::FlushGPU
+        );
+        RHIExecutor::Get().Sync(ERHISyncDepth::Present);
+
+        if (scripted_capture.count.load(
+                std::memory_order_acquire
+            ) != 1 ||
+            scripted_capture.wrong_owner.load(
+                std::memory_order_acquire
+            ) ||
+            boundary_capture.Count() != 2 ||
+            !boundary_capture.IsValid() ||
+            native_capture.Count() != 0 ||
+            ordinary_callbacks.load(std::memory_order_acquire) != 1 ||
+            success_callbacks.load(std::memory_order_acquire) != 0 ||
+            !ResourceCast(later_done.Get())->IsFailed()) {
+            throw std::runtime_error(
+                "hard Present did not latch, reject, and retire exactly once"
+            );
+        }
+        const VulkanSubmissionBoundaryEvent& dispatch =
+            boundary_capture.Event(0);
+        const VulkanSubmissionBoundaryEvent& terminal =
+            boundary_capture.Event(1);
+        if (dispatch.kind !=
+                EVulkanSubmissionBoundaryKind::Present ||
+            terminal.kind !=
+                EVulkanSubmissionBoundaryKind::Present ||
+            dispatch.phase !=
+                EVulkanSubmissionBoundaryPhase::Dispatch ||
+            terminal.phase !=
+                EVulkanSubmissionBoundaryPhase::Terminal ||
+            dispatch.outcome_valid ||
+            !terminal.outcome_valid ||
+            dispatch.operation_index != 1 ||
+            terminal.operation_index != 1 ||
+            dispatch.thread_role != ERHIThreadRole::Submission ||
+            terminal.thread_role != ERHIThreadRole::Submission ||
+            dispatch.thread_id != terminal.thread_id ||
+            dispatch.thread_id != scripted_capture.thread_id.load(
+                std::memory_order_acquire
+            ) ||
+            dispatch.thread_id == main_thread_id ||
+            terminal.outcome.status !=
+                EVulkanOperationStatus::Rejected ||
+            terminal.outcome.result != VK_ERROR_DEVICE_LOST ||
+            terminal.gpu_submitted ||
+            terminal.recoverable_rejection ||
+            terminal.present_receipt_resolution_attempts != 1) {
+            throw std::runtime_error(
+                "hard Present boundary diagnostics were incomplete"
+            );
+        }
+
+        RHIExecutor::Get().Sync(ERHISyncDepth::Present);
+        if (scripted_capture.count.load(
+                std::memory_order_acquire
+            ) != 1 ||
+            boundary_capture.Count() != 2 ||
+            native_capture.Count() != 0 ||
+            ordinary_callbacks.load(std::memory_order_acquire) != 1 ||
+            success_callbacks.load(std::memory_order_acquire) != 0) {
+            throw std::runtime_error(
+                "a second Sync replayed hard Present work"
+            );
+        }
+
+        LOG_INFO(
+            "[TESTCASE][PASS] name=PresentHardFailureBoundary "
+            "outcome=Rejected owner=Submission receipt_attempts=1 "
+            "submitted=false recreate=false later_batch=rejected "
+            "native_after_present=0 hard_latch=verified replay=0"
+        );
+    } catch (...) {
+        RHIExecutor::Get().Sync(ERHISyncDepth::Present);
+        throw;
+    }
+}
 void PrimeGlobalTransientPoolForDispose() {
     auto& pool = RenderGraphResourcePool::Global();
     pool.Reset();
@@ -6808,6 +8177,12 @@ int main(int argc, const char** argv) {
             HasArgument(argc, argv, "--pipeline-window2");
         const bool pipeline_window_mode =
             pipeline_window1 || pipeline_window2;
+        const bool present_boundary =
+            HasArgument(argc, argv, "--present-boundary");
+        const bool present_hard =
+            HasArgument(argc, argv, "--present-hard");
+        const bool present_mode =
+            present_boundary || present_hard;
         const uint32 submission_batch_window =
             pipeline_window1 ? 1u : 2u;
 
@@ -6822,14 +8197,33 @@ int main(int argc, const char** argv) {
             .rhi_api_version  = "1.3",
             .rhi_thread       = true,
             .rhi_bypass       = false,
-            .parallel_recording = parallel || pipeline_window_mode,
+            .parallel_recording =
+                parallel || pipeline_window_mode || present_mode,
             .parallel_record_workers = 4,
-            .parallel_record_verify = parallel || pipeline_window_mode,
+            .parallel_record_verify =
+                parallel || pipeline_window_mode || present_mode,
             .parallel_record_min_work_units_per_job = production_gate ? 64u : 1u,
             .submission_batch_window = submission_batch_window,
             .parallel_record_worker_throw_trigger = inject_worker_failure ? 1u : 0u,
         });
         render_device_initialized = true;
+
+        if (present_mode) {
+            if (present_boundary) {
+                RunSerialControlPipelineBoundary();
+                RunPresentPipelineBoundary();
+                // This is the terminal focused lifecycle test: it stops and
+                // joins the RHI runtime before returning.
+                RunQueuedPresentShutdownBoundary();
+            } else {
+                RunPresentHardFailureBoundary();
+            }
+            RenderDevice::Dispose();
+            render_device_initialized = false;
+            TaskSystem::ShutDown();
+            task_system_initialized = false;
+            return 0;
+        }
 
         if (pipeline_window_mode) {
             RunBoundedCrossBatchSubmissionPipeline(

--- a/source/test/RenderGraphTest.cpp
+++ b/source/test/RenderGraphTest.cpp
@@ -1,4 +1,5 @@
 #include "rendergraph/RenderGraph.h"
+#include "rhi/plugin/NrdPlugin.h"
 #include "taskgraph/TaskGraph.h"
 #include "taskgraph/TaskSystem.h"
 
@@ -3544,7 +3545,10 @@ void TestRecordingBatchPlanAndClassification(TestSuite& suite) {
     );
     suite.Check(
         Contains(graph.Dump(), "recording_batches:\n") &&
-            Contains(graph.Dump(), "cpu=parallel-record workload=8 wave=0"),
+            Contains(
+                graph.Dump(),
+                "cpu=parallel-record translate=parallel workload=8 wave=0"
+            ),
         test_name,
         "the deterministic dump must expose the executable CPU recording schedule"
     );
@@ -3674,6 +3678,131 @@ void TestExternalControlIsAnUnmanagedJoinBoundary(TestSuite& suite) {
         published_groups == 1 && managed_observers == 1,
         test_name,
         "only owned record batches are published and only managed main-thread passes are observed"
+    );
+}
+
+void TestSerialControlTranslationIsADeclaredRecordingPolicy(TestSuite& suite) {
+    constexpr std::string_view test_name =
+        "serial-control translation recording policy";
+    RenderGraph graph("SerialControlTranslation");
+    bool        recorded  = false;
+    bool        published = false;
+
+    graph.AddRecordPass(
+        "NRDIsland",
+        [](RenderGraph::PassBuilder& builder) {
+            builder
+                .ExecuteOn(
+                    RenderGraph::QueueRole::Graphics,
+                    RenderGraph::PipelineType::Compute
+                )
+                .SideEffect()
+                .SerialRecord()
+                .TranslateSerialControl();
+        },
+        [&](Moer::Render::CommandList&) { recorded = true; },
+        RenderGraph::PassExecutionClass::SerialRecord
+    );
+
+    suite.Check(graph.Compile(), test_name, graph.GetCompileError());
+    const auto& plan = graph.GetCompiledPlan();
+    suite.Check(
+        plan.recording_batches.size() == 1 &&
+            plan.recording_batches.front().execution ==
+                RenderGraph::PassExecutionClass::SerialRecord &&
+            plan.recording_batches.front().translate_execution_class ==
+                Moer::Render::ERHITranslateExecutionClass::SerialControl &&
+            Contains(graph.Dump(), "translate=serial-control"),
+        test_name,
+        "the compiler and dump must retain the declared translation frontier"
+    );
+
+    const bool executed = graph.ExecuteRecording(
+        {},
+        {},
+        false,
+        [&](Moer::Array<Moer::Render::RHIRecordingSource>&& sources) {
+            published = sources.size() == 1 &&
+                        sources.front()
+                                .submit_metadata.translate_execution_class ==
+                            Moer::Render::ERHITranslateExecutionClass::
+                                SerialControl;
+        }
+    );
+    suite.Check(
+        executed && recorded && published,
+        test_name,
+        "the graph handoff must publish SerialControl metadata without "
+        "mutating the producer CommandList"
+    );
+
+    RenderGraph weakened("SerialControlCannotBeWeakened");
+    weakened.AddRecordPass(
+        "NRDIsland",
+        [](RenderGraph::PassBuilder& builder) {
+            builder.SideEffect().SerialRecord().TranslateSerialControl();
+        },
+        [](Moer::Render::CommandList&) {},
+        RenderGraph::PassExecutionClass::SerialRecord
+    );
+    suite.Check(weakened.Compile(), test_name, weakened.GetCompileError());
+    bool weakened_published = false;
+    const bool weakened_executed = weakened.ExecuteRecording(
+        {},
+        [](const RenderGraph::ExecutedPassInfo&,
+           Moer::Render::RHIRecordingSource& source) {
+            source.submit_metadata.translate_execution_class.reset();
+        },
+        false,
+        [&](Moer::Array<Moer::Render::RHIRecordingSource>&&) {
+            weakened_published = true;
+        }
+    );
+    suite.Check(
+        !weakened_executed && !weakened_published &&
+            Contains(
+                weakened.GetCompileError(),
+                "weakened the declared SerialControl"
+            ),
+        test_name,
+        "source configuration must not weaken a graph-declared translation "
+        "frontier"
+    );
+
+    RenderGraph publisher_attempt("SerialControlPublisherFloor");
+    publisher_attempt.AddRecordPass(
+        "NRDIsland",
+        [](RenderGraph::PassBuilder& builder) {
+            builder.SideEffect().SerialRecord().TranslateSerialControl();
+        },
+        [](Moer::Render::CommandList&) {},
+        RenderGraph::PassExecutionClass::SerialRecord
+    );
+    suite.Check(
+        publisher_attempt.Compile(),
+        test_name,
+        publisher_attempt.GetCompileError()
+    );
+    bool command_list_kept_floor = false;
+    const bool publisher_attempt_executed =
+        publisher_attempt.ExecuteRecording(
+            {},
+            {},
+            false,
+            [&](Moer::Array<Moer::Render::RHIRecordingSource>&& sources) {
+                sources.front()
+                    .submit_metadata.translate_execution_class.reset();
+                command_list_kept_floor =
+                    sources.front()
+                        .command_list->GetTranslateExecutionClass() ==
+                    Moer::Render::ERHITranslateExecutionClass::SerialControl;
+            }
+        );
+    suite.Check(
+        publisher_attempt_executed && command_list_kept_floor,
+        test_name,
+        "the CommandList must retain the graph-declared SerialControl floor "
+        "even if a custom publisher drops optional metadata"
     );
 }
 
@@ -4525,6 +4654,236 @@ void TestFrameSetupTokenAndTlasBoundaryContract(TestSuite& suite) {
     );
 }
 
+void TestNrdSerialControlIslandContract(TestSuite& suite) {
+    constexpr std::string_view test_name =
+        "NRD immutable serial-control island";
+    RenderGraph graph("NrdIslandContract");
+    int motion_identity = 0;
+    int normal_identity = 0;
+    int depth_identity = 0;
+    int diffuse_identity = 0;
+    int specular_identity = 0;
+    int denoised_diffuse_identity = 0;
+    int denoised_specular_identity = 0;
+    const RenderGraph::TextureDesc desc{
+        .mip_count   = 1,
+        .layer_count = 1,
+        .aspects     = RenderGraph::TextureAspect::Color,
+    };
+    const auto motion =
+        graph.ImportTexture("Motion", &motion_identity, desc);
+    const auto normal =
+        graph.ImportTexture("NormalRoughness", &normal_identity, desc);
+    const auto depth =
+        graph.ImportTexture("ViewDepth", &depth_identity, desc);
+    const auto diffuse =
+        graph.ImportTexture("DiffuseLighting", &diffuse_identity, desc);
+    const auto specular =
+        graph.ImportTexture("SpecularLighting", &specular_identity, desc);
+    const auto denoised_diffuse = graph.ImportTexture(
+        "DenoisedDiffuse",
+        &denoised_diffuse_identity,
+        desc
+    );
+    const auto denoised_specular = graph.ImportTexture(
+        "DenoisedSpecular",
+        &denoised_specular_identity,
+        desc
+    );
+    const auto setup_ready = graph.CreateTransientToken("FrameSetupReady");
+    const auto nrd_ready   = graph.CreateTransientToken("NrdReady");
+
+    for (const auto texture : {
+             motion,
+             normal,
+             depth,
+             diffuse,
+             specular,
+             denoised_diffuse,
+             denoised_specular,
+         }) {
+        graph.SetInitialState(
+            texture,
+            RenderGraph::TextureState::Sampled,
+            RenderGraph::QueueRole::Graphics,
+            RenderGraph::AccessMode::Read
+        );
+    }
+
+    graph.AddRecordPass(
+        "FrameSetup",
+        [=](RenderGraph::PassBuilder& builder) {
+            builder.Write(setup_ready).SideEffect().SerialRecord();
+        },
+        [](Moer::Render::CommandList&) {},
+        RenderGraph::PassExecutionClass::SerialRecord
+    );
+    const auto lighting = graph.AddRecordPass(
+        "Lighting",
+        [=](RenderGraph::PassBuilder& builder) {
+            builder
+                .Read(setup_ready)
+                .Write(
+                    diffuse,
+                    RenderGraph::TextureState::UnorderedAccess
+                )
+                .Write(
+                    specular,
+                    RenderGraph::TextureState::UnorderedAccess
+                );
+        },
+        [](Moer::Render::CommandList&) {},
+        RenderGraph::PassExecutionClass::ParallelRecordEligible
+    );
+    const auto nrd = graph.AddRecordPass(
+        "NRD",
+        [=](RenderGraph::PassBuilder& builder) {
+            builder
+                .Read(setup_ready)
+                .Read(motion, RenderGraph::TextureState::Sampled)
+                .Read(normal, RenderGraph::TextureState::Sampled)
+                .Read(depth, RenderGraph::TextureState::Sampled)
+                .Read(diffuse, RenderGraph::TextureState::Sampled)
+                .Read(specular, RenderGraph::TextureState::Sampled)
+                .ReadWrite(
+                    denoised_diffuse,
+                    RenderGraph::TextureState::UnorderedAccess
+                )
+                .ReadWrite(
+                    denoised_specular,
+                    RenderGraph::TextureState::UnorderedAccess
+                )
+                .Write(nrd_ready)
+                .SideEffect()
+                .SerialRecord()
+                .TranslateSerialControl();
+        },
+        [](Moer::Render::CommandList&) {},
+        RenderGraph::PassExecutionClass::SerialRecord
+    );
+    const auto composition = graph.AddRecordPass(
+        "Composition",
+        [=](RenderGraph::PassBuilder& builder) {
+            builder
+                .Read(nrd_ready)
+                .Read(
+                    denoised_diffuse,
+                    RenderGraph::TextureState::Sampled
+                )
+                .Read(
+                    denoised_specular,
+                    RenderGraph::TextureState::Sampled
+                );
+        },
+        [](Moer::Render::CommandList&) {},
+        RenderGraph::PassExecutionClass::ParallelRecordEligible
+    );
+    graph.Export(
+        denoised_diffuse,
+        RenderGraph::TextureState::Sampled,
+        RenderGraph::QueueRole::Graphics,
+        RenderGraph::AccessMode::Read
+    );
+    graph.Export(
+        denoised_specular,
+        RenderGraph::TextureState::Sampled,
+        RenderGraph::QueueRole::Graphics,
+        RenderGraph::AccessMode::Read
+    );
+
+    suite.Check(graph.Compile(), test_name, graph.GetCompileError());
+    const auto& plan = graph.GetCompiledPlan();
+    suite.Check(
+        HasEdgeReason(
+            plan,
+            lighting,
+            nrd,
+            RenderGraph::EdgeReasonKind::ReadAfterWrite,
+            diffuse.Untyped()
+        ) &&
+            HasEdgeReason(
+                plan,
+                lighting,
+                nrd,
+                RenderGraph::EdgeReasonKind::ReadAfterWrite,
+                specular.Untyped()
+            ),
+        test_name,
+        "Lighting outputs must be RAW predecessors of NRD"
+    );
+    suite.Check(
+        HasEdgeReason(
+            plan,
+            nrd,
+            composition,
+            RenderGraph::EdgeReasonKind::ReadAfterWrite,
+            denoised_diffuse.Untyped()
+        ) &&
+            HasEdgeReason(
+                plan,
+                nrd,
+                composition,
+                RenderGraph::EdgeReasonKind::ReadAfterWrite,
+                nrd_ready.Untyped()
+            ),
+        test_name,
+        "NRD outputs and ready token must order Composition"
+    );
+    const auto* denoised_barrier = FindBarrier(
+        plan,
+        denoised_diffuse.Untyped(),
+        nrd,
+        composition
+    );
+    suite.Check(
+        denoised_barrier != nullptr &&
+            denoised_barrier->before_state ==
+                RenderGraph::ResourceState::Texture(
+                    RenderGraph::TextureState::UnorderedAccess
+                ) &&
+            denoised_barrier->after_state ==
+                RenderGraph::ResourceState::Texture(
+                    RenderGraph::TextureState::Sampled
+                ),
+        test_name,
+        "NRD storage outputs must normalize to Sampled before Composition"
+    );
+    suite.Check(
+        plan.recording_batches[nrd.index].execution ==
+                RenderGraph::PassExecutionClass::SerialRecord &&
+            plan.recording_batches[nrd.index].translate_execution_class ==
+                Moer::Render::ERHITranslateExecutionClass::SerialControl,
+        test_name,
+        "only the NRD island must carry the explicit translation frontier"
+    );
+}
+
+void TestNrdDenoiserFamiliesAreExplicit(TestSuite& suite) {
+    constexpr std::string_view test_name =
+        "NRD denoiser family classification";
+    using Moer::Render::Ext::IsReblurDenoiser;
+    using Moer::Render::Ext::IsRelaxDenoiser;
+
+    suite.Check(
+        IsReblurDenoiser(nrd::Denoiser::REBLUR_DIFFUSE_SPECULAR) &&
+            IsReblurDenoiser(nrd::Denoiser::REBLUR_DIFFUSE) &&
+            IsReblurDenoiser(nrd::Denoiser::REBLUR_SPECULAR) &&
+            !IsReblurDenoiser(nrd::Denoiser::RELAX_DIFFUSE_SPECULAR) &&
+            !IsReblurDenoiser(nrd::Denoiser::MAX_NUM),
+        test_name,
+        "ReBLUR classification must not depend on enum ordering"
+    );
+    suite.Check(
+        IsRelaxDenoiser(nrd::Denoiser::RELAX_DIFFUSE_SPECULAR) &&
+            IsRelaxDenoiser(nrd::Denoiser::RELAX_DIFFUSE) &&
+            IsRelaxDenoiser(nrd::Denoiser::RELAX_SPECULAR) &&
+            !IsRelaxDenoiser(nrd::Denoiser::REBLUR_DIFFUSE_SPECULAR) &&
+            !IsRelaxDenoiser(nrd::Denoiser::MAX_NUM),
+        test_name,
+        "RELAX classification must not depend on enum ordering"
+    );
+}
+
 } // namespace
 
 int main() {
@@ -4580,6 +4939,7 @@ int main() {
     TestRecordingBatchPlanAndClassification(suite);
     TestRecordingCallbackClassMismatchFails(suite);
     TestExternalControlIsAnUnmanagedJoinBoundary(suite);
+    TestSerialControlTranslationIsADeclaredRecordingPolicy(suite);
     TestCpuPrepareReferencesIdentityWithoutGpuAccess(suite);
     TestCpuPrepareRejectsGpuAccess(suite);
     TestCpuPrepareIsExcludedFromGpuQueuePlan(suite);
@@ -4588,6 +4948,8 @@ int main() {
     TestCpuRecordingDependenciesSplitParallelGroups(suite);
     TestRecordingPublicationFailureTerminatesGates(suite);
     TestFrameSetupTokenAndTlasBoundaryContract(suite);
+    TestNrdSerialControlIslandContract(suite);
+    TestNrdDenoiserFamiliesAreExplicit(suite);
 
     if (suite.FailureCount() != 0) {
         std::cerr << "TestRenderGraph: " << suite.FailureCount() << " failure(s)\n";

--- a/source/test/RenderGraphTest.cpp
+++ b/source/test/RenderGraphTest.cpp
@@ -3783,11 +3783,27 @@ public:
     void RenderGUI(
         Moer::Render::CommandList&,
         const Moer::Render::TextureView&,
-        const Moer::Render::UiDrawFramePacket&,
+        const Moer::Render::UiDrawFramePacket& frame,
         Moer::Render::EUiDrawExecutionThread execution_thread
     ) override {
         ++render_count;
         last_execution_thread = execution_thread;
+        const auto validate = [](const Moer::Render::UiViewportDrawPacket& viewport) {
+            return viewport.commands.empty() ||
+                   (viewport.recording_slot !=
+                        Moer::Render::UiViewportDrawPacket::
+                            InvalidRecordingSlot &&
+                    viewport.render_resources &&
+                    viewport.render_resources->IsPendingRecordingSlot(
+                        viewport.recording_slot
+                    ));
+        };
+        saw_valid_recording_slots =
+            saw_valid_recording_slots && validate(frame.main_viewport);
+        for (const auto& viewport : frame.platform_viewports) {
+            saw_valid_recording_slots =
+                saw_valid_recording_slots && validate(viewport);
+        }
     }
 
     void PresentWindows(
@@ -3799,6 +3815,7 @@ public:
 
     uint32_t render_count = 0;
     uint32_t present_count = 0;
+    bool saw_valid_recording_slots = true;
     Moer::Render::EUiDrawExecutionThread last_execution_thread{
         Moer::Render::EUiDrawExecutionThread::Game
     };
@@ -3860,6 +3877,87 @@ Moer::Render::UiDrawFramePacket MakeUiDrawPacket(
         packet.platform_viewports.emplace_back(std::move(platform));
     }
     return packet;
+}
+
+void TestRasterStyleUiSlotClaimTracksNativeAcceptance(TestSuite& suite) {
+    using namespace Moer::Render;
+    constexpr std::string_view test_name =
+        "Raster copied UI slot native acceptance";
+
+    auto rejected_resources =
+        Moer::MakeShared<FakeUiViewportResources>(11);
+    auto rejected_backend = Moer::MakeShared<FakeUiDrawBackend>();
+    auto rejected_frame =
+        MakeUiDrawPacket(rejected_resources, rejected_backend, true);
+    UiDrawFrameSlotClaim rejected_claim(rejected_frame);
+    CommandList         rejected_commands;
+    suite.Check(
+        rejected_claim.IsReadyForRecording() &&
+            rejected_frame.main_viewport.recording_slot == 11 &&
+            rejected_frame.platform_viewports.front().recording_slot == 11,
+        test_name,
+        "Raster-style copied frame did not freeze a shared pending slot"
+    );
+    RenderUiDrawFrame(
+        rejected_commands,
+        {},
+        rejected_frame,
+        EUiDrawExecutionThread::Game
+    );
+    suite.Check(
+        rejected_backend->render_count == 1 &&
+            rejected_backend->saw_valid_recording_slots,
+        test_name,
+        "non-empty Raster UI reached the backend without a valid slot claim"
+    );
+    rejected_claim.Reject();
+    rejected_claim.Reject();
+    suite.Check(
+        rejected_claim.GetState() ==
+                UiDrawFrameSlotClaim::EState::Rejected &&
+            !rejected_claim.CommitAccepted() &&
+            rejected_resources->PendingSlot() == 11 &&
+            rejected_resources->CommitCount() == 0,
+        test_name,
+        "native rejection advanced or resurrected the copied-frame slot"
+    );
+
+    auto accepted_resources =
+        Moer::MakeShared<FakeUiViewportResources>(23);
+    auto accepted_backend = Moer::MakeShared<FakeUiDrawBackend>();
+    auto accepted_frame =
+        MakeUiDrawPacket(accepted_resources, accepted_backend, true);
+    UiDrawFrameSlotClaim accepted_claim(accepted_frame);
+    CommandList         accepted_commands;
+    RenderUiDrawFrame(
+        accepted_commands,
+        {},
+        accepted_frame,
+        EUiDrawExecutionThread::Game
+    );
+    suite.Check(
+        accepted_backend->render_count == 1 &&
+            accepted_backend->saw_valid_recording_slots &&
+            accepted_resources->PendingSlot() == 23 &&
+            accepted_resources->CommitCount() == 0,
+        test_name,
+        "recording advanced the Raster UI upload ring before native acceptance"
+    );
+    suite.Check(
+        accepted_claim.CommitAccepted() &&
+            accepted_claim.CommitAccepted(),
+        test_name,
+        "native acceptance was not idempotent"
+    );
+    accepted_claim.Reject();
+    suite.Check(
+        accepted_claim.GetState() ==
+                UiDrawFrameSlotClaim::EState::Accepted &&
+            accepted_resources->PendingSlot() == 24 &&
+            accepted_resources->CommitCount() == 1,
+        test_name,
+        "shared Raster UI slot was not committed exactly once"
+    );
 }
 
 void TestUiPreparedFrameLifecycleIsOneShot(TestSuite& suite) {
@@ -5550,6 +5648,7 @@ int main() {
     TestSuite suite;
     TestStableSerialCallbackOrder(suite);
     TestPassCompletionObserverRunsAfterEachCallback(suite);
+    TestRasterStyleUiSlotClaimTracksNativeAcceptance(suite);
     TestUiPreparedFrameLifecycleIsOneShot(suite);
     TestUiFrameGraphTailContract(suite);
     TestUiFrameGraphRejectsInvalidPhysicalContracts(suite);

--- a/source/test/RenderGraphTest.cpp
+++ b/source/test/RenderGraphTest.cpp
@@ -1,4 +1,5 @@
 #include "rendergraph/RenderGraph.h"
+#include "renderer/common/UiFrameGraphPass.h"
 #include "rhi/plugin/NrdPlugin.h"
 #include "taskgraph/TaskGraph.h"
 #include "taskgraph/TaskSystem.h"
@@ -15,6 +16,62 @@
 #include <string_view>
 #include <thread>
 #include <vector>
+
+namespace Moer::Render {
+
+class UiFrameGraphPassTestAccess {
+public:
+    [[nodiscard]] static bool
+    BeginRecording(const UiFrameGraphPass::PreparedFrame& frame) {
+        return frame.BeginRecording();
+    }
+
+    static void FinishRecording(
+        const UiFrameGraphPass::PreparedFrame& frame
+    ) {
+        frame.FinishRecording();
+    }
+
+    [[nodiscard]] static bool AddPassesWithComposeRecorder(
+        RenderGraph&                          graph,
+        std::function<void(CommandList&)>     compose_recorder,
+        const UiFrameGraphPass::PreparedFrameRef& frame,
+        RenderGraph::TextureHandle            scene_color_handle,
+        const TextureRef&                     scene_color,
+        const TextureRef&                     main_output,
+        RenderGraph::TokenHandle              presentation_ready,
+        UiFrameGraphPass::GraphPasses&        passes
+    ) {
+        return UiFrameGraphPass::AddPassesWithComposeRecorder(
+            graph,
+            std::move(compose_recorder),
+            frame,
+            scene_color_handle,
+            scene_color,
+            main_output,
+            presentation_ready,
+            passes
+        );
+    }
+
+    [[nodiscard]] static bool ProcessLinearWithComposeRecorder(
+        CommandList&                              cmd_list,
+        std::function<void(CommandList&)>         compose_recorder,
+        const UiFrameGraphPass::PreparedFrameRef& frame,
+        const TextureRef&                         scene_color,
+        const TextureRef&                         main_output
+    ) {
+        return UiFrameGraphPass::ProcessLinearWithComposeRecorder(
+            cmd_list,
+            std::move(compose_recorder),
+            frame,
+            scene_color,
+            main_output
+        );
+    }
+};
+
+} // namespace Moer::Render
 
 namespace {
 
@@ -3681,6 +3738,609 @@ void TestExternalControlIsAnUnmanagedJoinBoundary(TestSuite& suite) {
     );
 }
 
+class FakeUiViewportResources final :
+    public Moer::Render::UiViewportRenderResources {
+public:
+    explicit FakeUiViewportResources(uint64_t pending_slot) :
+        pending_slot(pending_slot) {}
+
+    [[nodiscard]] uint64_t
+    GetPendingRecordingSlot() const noexcept override {
+        return pending_slot;
+    }
+
+    [[nodiscard]] bool
+    IsPendingRecordingSlot(uint64_t slot) const noexcept override {
+        return slot == pending_slot;
+    }
+
+    void CommitRecordingSlot(uint64_t slot) noexcept override {
+        if (slot == pending_slot) {
+            ++pending_slot;
+            ++commit_count;
+        }
+    }
+
+    [[nodiscard]] uint64_t PendingSlot() const {
+        return pending_slot;
+    }
+
+    [[nodiscard]] uint32_t CommitCount() const {
+        return commit_count;
+    }
+
+    void SetPendingSlot(uint64_t slot) {
+        pending_slot = slot;
+    }
+
+private:
+    uint64_t pending_slot = 0;
+    uint32_t commit_count = 0;
+};
+
+class FakeUiDrawBackend final : public Moer::Render::UiDrawFrameBackend {
+public:
+    void RenderGUI(
+        Moer::Render::CommandList&,
+        const Moer::Render::TextureView&,
+        const Moer::Render::UiDrawFramePacket&,
+        Moer::Render::EUiDrawExecutionThread execution_thread
+    ) override {
+        ++render_count;
+        last_execution_thread = execution_thread;
+    }
+
+    void PresentWindows(
+        const Moer::Render::UiDrawFramePacket&,
+        Moer::Render::EUiDrawExecutionThread
+    ) override {
+        ++present_count;
+    }
+
+    uint32_t render_count = 0;
+    uint32_t present_count = 0;
+    Moer::Render::EUiDrawExecutionThread last_execution_thread{
+        Moer::Render::EUiDrawExecutionThread::Game
+    };
+};
+
+class FakeUiTexture final : public Moer::Render::Texture {
+public:
+    explicit FakeUiTexture(
+        std::string_view    name,
+        ETextureUsageFlags usage =
+            ETextureUsageFlags::SAMPLED |
+            ETextureUsageFlags::COLOR_ATTACHMENT |
+            ETextureUsageFlags::TRANSFER_SRC |
+            ETextureUsageFlags::TRANSFER_DST,
+        ETextureAspectFlags aspects = ETextureAspectFlags::COLOR
+    ) :
+        Texture(MakeInfo(usage, aspects)) {
+        SetName(name);
+    }
+
+    Moer::uint GetMipByteSize(Moer::uint) const override {
+        return 4;
+    }
+
+    void SetName(std::string_view name) override {
+        debug_name = std::string(name);
+    }
+
+private:
+    static Moer::Render::TextureInfo MakeInfo(
+        ETextureUsageFlags  usage,
+        ETextureAspectFlags aspects
+    ) {
+        using namespace Moer::Render;
+        TextureInfo info{};
+        info.usage        = usage;
+        info.extent       = {64, 64};
+        info.num_mips     = 1;
+        info.array_size   = 1;
+        info.format       = PF_R8G8B8A8_UNORM;
+        info.aspect_flags = aspects;
+        return info;
+    }
+};
+
+Moer::Render::UiDrawFramePacket MakeUiDrawPacket(
+    const Moer::SharedPtr<FakeUiViewportResources>& resources,
+    const Moer::SharedPtr<FakeUiDrawBackend>&       backend,
+    bool                                             duplicate_resource
+) {
+    Moer::Render::UiDrawFramePacket packet{};
+    packet.backend = backend;
+    packet.main_viewport.render_resources = resources;
+    packet.main_viewport.commands.emplace_back();
+    if (duplicate_resource) {
+        Moer::Render::UiViewportDrawPacket platform{};
+        platform.render_resources = resources;
+        platform.commands.emplace_back();
+        packet.platform_viewports.emplace_back(std::move(platform));
+    }
+    return packet;
+}
+
+void TestUiPreparedFrameLifecycleIsOneShot(TestSuite& suite) {
+    using namespace Moer::Render;
+    constexpr std::string_view test_name =
+        "UI prepared frame one-shot lifecycle";
+
+    auto resources = Moer::MakeShared<FakeUiViewportResources>(17);
+    auto backend   = Moer::MakeShared<FakeUiDrawBackend>();
+    std::weak_ptr<FakeUiViewportResources> resource_owner = resources;
+    std::weak_ptr<FakeUiDrawBackend>        backend_owner  = backend;
+    auto accepted = UiFrameGraphPass::Prepare(
+        {},
+        MakeUiDrawPacket(resources, backend, true),
+        EUiDrawExecutionThread::Render
+    );
+    resources.reset();
+    backend.reset();
+
+    suite.Check(
+        !resource_owner.expired() && !backend_owner.expired(),
+        test_name,
+        "prepared frame did not retain copied UI backend/resources"
+    );
+    suite.Check(
+        accepted->GetDrawFrame().main_viewport.recording_slot == 17 &&
+            accepted->GetDrawFrame().platform_viewports.front().recording_slot ==
+                17,
+        test_name,
+        "Prepare did not freeze the pending upload-ring slot"
+    );
+    auto accepted_resources = resource_owner.lock();
+    suite.Check(
+        accepted_resources && accepted_resources->PendingSlot() == 17 &&
+            accepted_resources->CommitCount() == 0,
+        test_name,
+        "Prepare advanced the upload-ring before native acceptance"
+    );
+    suite.Check(
+        UiFrameGraphPassTestAccess::BeginRecording(*accepted),
+        test_name,
+        "first recording claim failed"
+    );
+    suite.Check(
+        !UiFrameGraphPassTestAccess::BeginRecording(*accepted),
+        test_name,
+        "a second recording claim replayed the copied packet"
+    );
+    UiFrameGraphPassTestAccess::FinishRecording(*accepted);
+    suite.Check(
+        accepted->GetRecordingState() ==
+                UiFrameGraphPass::ERecordingState::Recorded &&
+            !accepted->CanPresent() &&
+            accepted_resources->CommitCount() == 0,
+        test_name,
+        "recording completion prematurely committed or presented the UI frame"
+    );
+    suite.Check(
+        accepted->CommitAcceptedSource() &&
+            accepted->GetRecordingState() ==
+                UiFrameGraphPass::ERecordingState::SourceAccepted &&
+            !accepted->CanPresent() &&
+            accepted_resources->PendingSlot() == 18 &&
+            accepted_resources->CommitCount() == 1,
+        test_name,
+        "native UI-source acceptance did not retire exactly one shared slot"
+    );
+    suite.Check(
+        accepted->CommitAcceptedSource() &&
+            accepted_resources->CommitCount() == 1,
+        test_name,
+        "repeated source acceptance advanced the upload ring twice"
+    );
+    accepted->RejectSource();
+    accepted->Abandon();
+    suite.Check(
+        accepted->GetRecordingState() ==
+            UiFrameGraphPass::ERecordingState::SourceAccepted,
+        test_name,
+        "a late reject/abandon reversed an accepted source"
+    );
+    suite.Check(
+        accepted->CommitAcceptedFrame() && accepted->CanPresent() &&
+            accepted->CommitAcceptedFrame(),
+        test_name,
+        "whole-frame acceptance was not idempotent"
+    );
+    accepted->RejectSource();
+    accepted->Abandon();
+    suite.Check(
+        accepted->GetRecordingState() ==
+                UiFrameGraphPass::ERecordingState::FrameAccepted &&
+            accepted->CanPresent() &&
+            accepted_resources->CommitCount() == 1,
+        test_name,
+        "an accepted frame was downgraded or recommitted"
+    );
+
+    auto failed_resources = Moer::MakeShared<FakeUiViewportResources>(41);
+    auto failed_backend   = Moer::MakeShared<FakeUiDrawBackend>();
+    auto failed = UiFrameGraphPass::Prepare(
+        {},
+        MakeUiDrawPacket(failed_resources, failed_backend, false),
+        EUiDrawExecutionThread::Render
+    );
+    suite.Check(
+        UiFrameGraphPassTestAccess::BeginRecording(*failed),
+        test_name,
+        "failure-path recording claim failed"
+    );
+    failed->Abandon();
+    UiFrameGraphPassTestAccess::FinishRecording(*failed);
+    suite.Check(
+        failed->GetRecordingState() ==
+                UiFrameGraphPass::ERecordingState::Failed &&
+            !failed->CanPresent() &&
+            failed_resources->PendingSlot() == 41 &&
+            failed_resources->CommitCount() == 0 &&
+            !failed->CommitAcceptedSource() &&
+            !UiFrameGraphPassTestAccess::BeginRecording(*failed),
+        test_name,
+        "failed recording remained replayable or retired an unaccepted slot"
+    );
+
+    auto stale_resources = Moer::MakeShared<FakeUiViewportResources>(73);
+    auto stale_backend   = Moer::MakeShared<FakeUiDrawBackend>();
+    auto stale = UiFrameGraphPass::Prepare(
+        {},
+        MakeUiDrawPacket(stale_resources, stale_backend, false),
+        EUiDrawExecutionThread::Render
+    );
+    suite.Check(
+        UiFrameGraphPassTestAccess::BeginRecording(*stale),
+        test_name,
+        "stale-slot recording claim failed"
+    );
+    UiFrameGraphPassTestAccess::FinishRecording(*stale);
+    stale_resources->SetPendingSlot(74);
+    suite.Check(
+        !stale->CommitAcceptedSource() &&
+            stale->GetRecordingState() ==
+                UiFrameGraphPass::ERecordingState::Failed &&
+            stale_resources->CommitCount() == 0 &&
+            !stale->CommitAcceptedFrame(),
+        test_name,
+        "a stale upload-ring token was committed or made presentable"
+    );
+}
+
+void TestUiFrameGraphTailContract(TestSuite& suite) {
+    using namespace Moer::Render;
+    constexpr std::string_view test_name =
+        "UI frame graph presentation tail";
+
+    TextureRef scene_color(MoerNew(FakeUiTexture)("SceneColor"));
+    TextureRef main_output(MoerNew(FakeUiTexture)("MainOutput"));
+    TextureRef window_output(MoerNew(FakeUiTexture)("SceneWindow"));
+    TextureRef platform_output(MoerNew(FakeUiTexture)("PlatformOutput"));
+
+    auto shared_slots = Moer::MakeShared<FakeUiViewportResources>(5);
+    auto platform_slots = Moer::MakeShared<FakeUiViewportResources>(9);
+    auto backend = Moer::MakeShared<FakeUiDrawBackend>();
+    UiDrawFramePacket draw_frame{};
+    draw_frame.backend = backend;
+    draw_frame.main_viewport.render_resources = shared_slots;
+    draw_frame.main_viewport.commands.emplace_back();
+
+    const auto append_platform = [&](TextureRef framebuffer,
+                                     Moer::SharedPtr<FakeUiViewportResources> slots) {
+        UiViewportDrawPacket viewport{};
+        viewport.framebuffer      = std::move(framebuffer);
+        viewport.render_resources = std::move(slots);
+        viewport.commands.emplace_back();
+        draw_frame.platform_viewports.emplace_back(std::move(viewport));
+    };
+    append_platform(main_output, shared_slots);
+    append_platform(window_output, shared_slots);
+    append_platform(platform_output, platform_slots);
+
+    UiCompositionFrameData composition{
+        .enabled                 = true,
+        .separate_window         = true,
+        .output_resolution       = Moer::uint2(64, 64),
+        .scene_color_position    = Moer::float2(0.f, 0.f),
+        .scene_color_resolution  = Moer::float2(64.f, 64.f),
+        .window_frame_buffer     = window_output,
+    };
+    auto prepared = UiFrameGraphPass::Prepare(
+        std::move(composition),
+        std::move(draw_frame),
+        EUiDrawExecutionThread::Render
+    );
+
+    RenderGraph graph("UiFrameGraphTailContract");
+    const auto scene = graph.ImportTexture(
+        "SceneColor",
+        scene_color,
+        RenderGraph::TextureDesc{
+            .mip_count   = 1,
+            .layer_count = 1,
+            .aspects     = RenderGraph::TextureAspect::Color,
+        }
+    );
+    graph.SetInitialState(
+        scene,
+        RenderGraph::TextureState::Undefined,
+        RenderGraph::QueueRole::None,
+        RenderGraph::AccessMode::None
+    );
+    const auto presentation_ready =
+        graph.CreateTransientToken("PresentationReady");
+    const auto producer = graph.AddRecordPass(
+        "ShowTexture",
+        [=](RenderGraph::PassBuilder& builder) {
+            builder
+                .ExecuteOn(
+                    RenderGraph::QueueRole::Graphics,
+                    RenderGraph::PipelineType::Graphics
+                )
+                .Write(scene, RenderGraph::TextureState::RenderTarget)
+                .Write(presentation_ready)
+                .SideEffect()
+                .ParallelRecord();
+        },
+        [](CommandList&) {},
+        RenderGraph::PassExecutionClass::ParallelRecordEligible
+    );
+
+    UiFrameGraphPass::GraphPasses ui_passes{};
+    const bool added = UiFrameGraphPassTestAccess::AddPassesWithComposeRecorder(
+        graph,
+        [](CommandList&) {},
+        prepared,
+        scene,
+        scene_color,
+        main_output,
+        presentation_ready,
+        ui_passes
+    );
+    suite.Check(added && ui_passes.IsValid(), test_name, "UI tail was not declared");
+    suite.Check(
+        ui_passes.presentation_targets.size() == 3 &&
+            ui_passes.main_output == ui_passes.presentation_targets.front(),
+        test_name,
+        "physical presentation aliases were not deduplicated"
+    );
+    suite.Check(graph.Compile(), test_name, graph.GetCompileError());
+    if (!graph.IsCompiled()) {
+        return;
+    }
+
+    const auto& plan = graph.GetCompiledPlan();
+    suite.Check(
+        plan.state_plan_complete,
+        test_name,
+        "UI tail left an incomplete explicit resource-state plan"
+    );
+    suite.Check(
+        HasEdgeReason(
+            plan,
+            producer,
+            ui_passes.clear,
+            RenderGraph::EdgeReasonKind::ReadAfterWrite,
+            presentation_ready.Untyped()
+        ) &&
+            HasEdgeReason(
+                plan,
+                ui_passes.clear,
+                ui_passes.compose,
+                RenderGraph::EdgeReasonKind::Explicit
+            ) &&
+            HasEdgeReason(
+                plan,
+                ui_passes.compose,
+                ui_passes.draw,
+                RenderGraph::EdgeReasonKind::Explicit
+            ),
+        test_name,
+        "ShowTexture -> Clear -> Compose -> Draw ordering was not explicit"
+    );
+
+    const auto& clear_batch =
+        plan.recording_batches[ui_passes.clear.index];
+    const auto& compose_batch =
+        plan.recording_batches[ui_passes.compose.index];
+    const auto& draw_batch =
+        plan.recording_batches[ui_passes.draw.index];
+    suite.Check(
+        clear_batch.execution == RenderGraph::PassExecutionClass::SerialRecord &&
+            compose_batch.execution ==
+                RenderGraph::PassExecutionClass::SerialRecord &&
+            draw_batch.execution ==
+                RenderGraph::PassExecutionClass::SerialRecord &&
+            clear_batch.translate_execution_class ==
+                ERHITranslateExecutionClass::Parallel &&
+            compose_batch.translate_execution_class ==
+                ERHITranslateExecutionClass::Parallel &&
+            draw_batch.translate_execution_class ==
+                ERHITranslateExecutionClass::SerialControl,
+        test_name,
+        "UI recording/translation ownership classes changed"
+    );
+
+    bool access_contract_valid = true;
+    bool export_contract_valid = true;
+    for (const auto target : ui_passes.presentation_targets) {
+        const auto* clear_access =
+            FindAccess(plan, ui_passes.clear, target.Untyped());
+        const auto* draw_access =
+            FindAccess(plan, ui_passes.draw, target.Untyped());
+        const auto* export_barrier =
+            FindBarrier(plan, target.Untyped(), ui_passes.draw, {});
+        access_contract_valid =
+            access_contract_valid && clear_access && draw_access &&
+            clear_access->mode == RenderGraph::AccessMode::Write &&
+            clear_access->state ==
+                RenderGraph::ResourceState::Texture(
+                    RenderGraph::TextureState::TransferDestination
+                ) &&
+            clear_access->domain.queue == RenderGraph::QueueRole::Graphics &&
+            clear_access->domain.pipeline ==
+                RenderGraph::PipelineType::Copy &&
+            draw_access->mode == RenderGraph::AccessMode::ReadWrite &&
+            draw_access->state ==
+                RenderGraph::ResourceState::Texture(
+                    RenderGraph::TextureState::RenderTarget
+                ) &&
+            draw_access->domain.queue == RenderGraph::QueueRole::Graphics &&
+            draw_access->domain.pipeline ==
+                RenderGraph::PipelineType::Graphics;
+        export_contract_valid =
+            export_contract_valid && export_barrier &&
+            export_barrier->export_boundary &&
+            export_barrier->after_state ==
+                RenderGraph::ResourceState::Texture(
+                    RenderGraph::TextureState::TransferSource
+                ) &&
+            export_barrier->after_access == RenderGraph::AccessMode::Read;
+    }
+    const auto* compose_access = FindAccess(
+        plan,
+        ui_passes.compose,
+        ui_passes.presentation_targets[1].Untyped()
+    );
+    suite.Check(
+        access_contract_valid && compose_access &&
+            compose_access->mode == RenderGraph::AccessMode::Write &&
+            compose_access->state ==
+                RenderGraph::ResourceState::Texture(
+                    RenderGraph::TextureState::RenderTarget
+                ) &&
+            compose_access->domain.queue ==
+                RenderGraph::QueueRole::Graphics &&
+            compose_access->domain.pipeline ==
+                RenderGraph::PipelineType::Graphics,
+        test_name,
+        "UI Clear/Compose/Draw access declarations changed"
+    );
+    suite.Check(
+        export_contract_valid,
+        test_name,
+        "a presentation target was not exported as Graphics TransferSource/Read"
+    );
+    const std::string dump = graph.Dump();
+    suite.Check(
+        Contains(dump, "UI.ClearTargets") &&
+            Contains(dump, "UI.Compose") &&
+            Contains(dump, "UI.DrawCopiedFrame") &&
+            Contains(dump, "translate=serial-control") &&
+            !Contains(dump, "texture:present") &&
+            !Contains(dump, "ui_framebuffer") &&
+            !Contains(dump, "gui_color"),
+        test_name,
+        "UI tail dump lost nodes/frontier or regained legacy fake dependencies"
+    );
+
+    bool draw_source_kept_serial_control = false;
+    const bool executed = graph.ExecuteRecording(
+        {},
+        [&](const RenderGraph::ExecutedPassInfo& pass,
+            RHIRecordingSource& source) {
+            if (pass.handle == ui_passes.draw) {
+                draw_source_kept_serial_control =
+                    source.command_list->GetTranslateExecutionClass() ==
+                        ERHITranslateExecutionClass::SerialControl &&
+                    source.submit_metadata.translate_execution_class ==
+                        ERHITranslateExecutionClass::SerialControl;
+            }
+        },
+        false,
+        [](Moer::Array<RHIRecordingSource>&&) {}
+    );
+    suite.Check(
+        executed && draw_source_kept_serial_control &&
+            backend->render_count == 1 &&
+            backend->last_execution_thread ==
+                EUiDrawExecutionThread::Render &&
+            prepared->GetRecordingState() ==
+                UiFrameGraphPass::ERecordingState::Recorded &&
+            shared_slots->CommitCount() == 0 &&
+            platform_slots->CommitCount() == 0,
+        test_name,
+        "UI tail did not record once with immutable ownership"
+    );
+}
+
+void TestUiFrameGraphRejectsInvalidPhysicalContracts(TestSuite& suite) {
+    using namespace Moer::Render;
+    constexpr std::string_view test_name =
+        "UI frame graph physical contract rejection";
+
+    TextureRef scene_color(MoerNew(FakeUiTexture)("SceneColor"));
+    TextureRef other_scene(MoerNew(FakeUiTexture)("OtherScene"));
+    TextureRef invalid_output(MoerNew(FakeUiTexture)(
+        "InvalidOutput",
+        ETextureUsageFlags::SAMPLED |
+            ETextureUsageFlags::COLOR_ATTACHMENT
+    ));
+
+    auto slots   = Moer::MakeShared<FakeUiViewportResources>(23);
+    auto backend = Moer::MakeShared<FakeUiDrawBackend>();
+    auto prepared = UiFrameGraphPass::Prepare(
+        {},
+        MakeUiDrawPacket(slots, backend, false),
+        EUiDrawExecutionThread::Render
+    );
+
+    RenderGraph graph("UiFrameGraphInvalidPhysicalContracts");
+    const auto mismatched_scene_handle = graph.ImportTexture(
+        "OtherScene",
+        other_scene,
+        RenderGraph::TextureDesc{
+            .mip_count   = 1,
+            .layer_count = 1,
+            .aspects     = RenderGraph::TextureAspect::Color,
+        }
+    );
+    const auto presentation_ready =
+        graph.CreateTransientToken("PresentationReady");
+    UiFrameGraphPass::GraphPasses ui_passes{};
+    suite.Check(
+        !UiFrameGraphPassTestAccess::AddPassesWithComposeRecorder(
+            graph,
+            [](CommandList&) {},
+            prepared,
+            mismatched_scene_handle,
+            scene_color,
+            invalid_output,
+            presentation_ready,
+            ui_passes
+        ) &&
+            !ui_passes.IsValid() &&
+            prepared->GetRecordingState() ==
+                UiFrameGraphPass::ERecordingState::Prepared,
+        test_name,
+        "graph declaration accepted mismatched scene identity or invalid "
+        "presentation usage"
+    );
+
+    CommandList linear_commands{};
+    const bool linear_recorded =
+        UiFrameGraphPassTestAccess::ProcessLinearWithComposeRecorder(
+            linear_commands,
+            [](CommandList&) {},
+            prepared,
+            scene_color,
+            invalid_output
+        );
+    const CmdSubmit rejected_submit = linear_commands.Submit();
+    suite.Check(
+        !linear_recorded && rejected_submit.cmds.empty() &&
+            backend->render_count == 0 && slots->CommitCount() == 0 &&
+            slots->PendingSlot() == 23 &&
+            prepared->GetRecordingState() ==
+                UiFrameGraphPass::ERecordingState::Prepared,
+        test_name,
+        "linear fallback bypassed UI target validation or claimed the copied "
+        "packet"
+    );
+}
+
 void TestSerialControlTranslationIsADeclaredRecordingPolicy(TestSuite& suite) {
     constexpr std::string_view test_name =
         "serial-control translation recording policy";
@@ -4890,6 +5550,9 @@ int main() {
     TestSuite suite;
     TestStableSerialCallbackOrder(suite);
     TestPassCompletionObserverRunsAfterEachCallback(suite);
+    TestUiPreparedFrameLifecycleIsOneShot(suite);
+    TestUiFrameGraphTailContract(suite);
+    TestUiFrameGraphRejectsInvalidPhysicalContracts(suite);
     TestImportedAliasIdentityAndDump(suite);
     TestHazardsAndDeterministicDump(suite);
     TestTransientReadBeforeProducerFailsWithoutCallbacks(suite);

--- a/source/test/RenderGraphTest.cpp
+++ b/source/test/RenderGraphTest.cpp
@@ -4167,6 +4167,208 @@ void TestRecordingPublicationFailureTerminatesGates(TestSuite& suite) {
     );
 }
 
+void TestFrameSetupTokenAndTlasBoundaryContract(TestSuite& suite) {
+    constexpr std::string_view test_name = "frame setup token and TLAS boundary";
+    RenderGraph                graph("FrameSetupContract");
+    int                        bindless_identity = 0;
+    int                        tlas_identity     = 0;
+    int                        instance_identity = 0;
+    const auto bindless = graph.ImportToken("Bindless", &bindless_identity);
+    const auto tlas = graph.ImportBuffer(
+        "CurrentTLAS",
+        &tlas_identity,
+        RenderGraph::BufferDesc{.byte_size = 4096}
+    );
+    const auto instances = graph.ImportBuffer(
+        "TLASInstances",
+        &instance_identity,
+        RenderGraph::BufferDesc{.byte_size = 4096}
+    );
+    graph.SetInitialState(
+        tlas,
+        RenderGraph::BufferState::Undefined,
+        RenderGraph::QueueRole::None,
+        RenderGraph::AccessMode::None
+    );
+    graph.SetInitialState(
+        instances,
+        RenderGraph::BufferState::Undefined,
+        RenderGraph::QueueRole::None,
+        RenderGraph::AccessMode::None
+    );
+
+    const auto update = graph.AddRecordPass(
+        "UpdateBindless",
+        [=](RenderGraph::PassBuilder& builder) {
+            builder.Write(bindless).SideEffect();
+        },
+        [](Moer::Render::CommandList&) {},
+        RenderGraph::PassExecutionClass::SerialRecord
+    );
+    const auto normalize = graph.AddRecordPass(
+        "NormalizeScene",
+        [=](RenderGraph::PassBuilder& builder) {
+            builder.Read(bindless).SideEffect();
+        },
+        [](Moer::Render::CommandList&) {},
+        RenderGraph::PassExecutionClass::SerialRecord
+    );
+    const auto build = graph.AddRecordPass(
+        "BuildTLAS",
+        [=](RenderGraph::PassBuilder& builder) {
+            builder.DependsOn(normalize)
+                .Read(bindless)
+                .Write(
+                    instances,
+                    RenderGraph::BufferState::UnorderedAccess
+                )
+                .Write(
+                    tlas,
+                    RenderGraph::BufferState::AccelerationStructureWrite
+                );
+        },
+        [](Moer::Render::CommandList&) {},
+        RenderGraph::PassExecutionClass::SerialRecord
+    );
+    graph.Export(
+        tlas,
+        RenderGraph::BufferState::AccelerationStructureRead,
+        RenderGraph::QueueRole::Graphics,
+        RenderGraph::AccessMode::Read
+    );
+    graph.Export(
+        instances,
+        RenderGraph::BufferState::AccelerationStructureBuildInput,
+        RenderGraph::QueueRole::Graphics,
+        RenderGraph::AccessMode::Read
+    );
+
+    suite.Check(graph.Compile(), test_name, graph.GetCompileError());
+    const auto& plan = graph.GetCompiledPlan();
+    suite.Check(
+        HasEdgeReason(
+            plan,
+            update,
+            normalize,
+            RenderGraph::EdgeReasonKind::ReadAfterWrite,
+            bindless.Untyped()
+        ),
+        test_name,
+        "bindless update must be a RAW predecessor of scene normalization"
+    );
+    suite.Check(
+        HasEdgeReason(
+            plan,
+            normalize,
+            build,
+            RenderGraph::EdgeReasonKind::Explicit
+        ),
+        test_name,
+        "BuildTLAS must retain the explicit normalization dependency"
+    );
+    const auto* import_barrier =
+        FindBarrier(plan, tlas.Untyped(), {}, build);
+    const auto* export_barrier =
+        FindBarrier(plan, tlas.Untyped(), build, {});
+    suite.Check(
+        import_barrier != nullptr && import_barrier->state_transition &&
+            import_barrier->after_state ==
+                RenderGraph::ResourceState::Buffer(
+                    RenderGraph::BufferState::AccelerationStructureWrite
+                ),
+        test_name,
+        "BuildTLAS must acquire an AS-write destination from the import boundary"
+    );
+    suite.Check(
+        export_barrier != nullptr && export_barrier->state_transition &&
+            export_barrier->after_state ==
+                RenderGraph::ResourceState::Buffer(
+                    RenderGraph::BufferState::AccelerationStructureRead
+                ),
+        test_name,
+        "FrameSetup must export TLAS as an AS-readable consumer boundary"
+    );
+    const auto* instance_import_barrier =
+        FindBarrier(plan, instances.Untyped(), {}, build);
+    suite.Check(
+        instance_import_barrier != nullptr &&
+            instance_import_barrier->state_transition &&
+            instance_import_barrier->after_state ==
+                RenderGraph::ResourceState::Buffer(
+                    RenderGraph::BufferState::UnorderedAccess
+                ),
+        test_name,
+        "a fresh TLAS instance payload must be a write-only producer"
+    );
+
+    RenderGraph next_graph("PrimaryContract");
+    const auto  next_bindless =
+        next_graph.ImportToken("Bindless", &bindless_identity);
+    suite.Check(
+        next_bindless.Untyped().owner_id != bindless.Untyped().owner_id,
+        test_name,
+        "same physical token identity in another graph must remain a distinct transaction"
+    );
+
+    RenderGraph external_graph("ExternalTLASNormalizeContract");
+    int         external_tlas_identity = 0;
+    const auto  external_tlas = external_graph.ImportBuffer(
+        "ExternallyBuiltTLAS",
+        &external_tlas_identity,
+        RenderGraph::BufferDesc{.byte_size = 4096}
+    );
+    external_graph.SetInitialState(
+        external_tlas,
+        RenderGraph::BufferState::AccelerationStructureWrite,
+        RenderGraph::QueueRole::Graphics,
+        RenderGraph::AccessMode::Write
+    );
+    const auto external_normalize = external_graph.AddRecordPass(
+        "NormalizeExternalTLAS",
+        [=](RenderGraph::PassBuilder& builder) {
+            builder
+                .Read(
+                    external_tlas,
+                    RenderGraph::BufferState::AccelerationStructureRead
+                )
+                .SideEffect();
+        },
+        [](Moer::Render::CommandList&) {},
+        RenderGraph::PassExecutionClass::SerialRecord
+    );
+    external_graph.Export(
+        external_tlas,
+        RenderGraph::BufferState::AccelerationStructureRead,
+        RenderGraph::QueueRole::Graphics,
+        RenderGraph::AccessMode::Read
+    );
+    suite.Check(
+        external_graph.Compile(),
+        test_name,
+        external_graph.GetCompileError()
+    );
+    const auto* external_import_barrier = FindBarrier(
+        external_graph.GetCompiledPlan(),
+        external_tlas.Untyped(),
+        {},
+        external_normalize
+    );
+    suite.Check(
+        external_import_barrier != nullptr &&
+            external_import_barrier->state_transition &&
+            external_import_barrier->before_state ==
+                RenderGraph::ResourceState::Buffer(
+                    RenderGraph::BufferState::AccelerationStructureWrite
+                ) &&
+            external_import_barrier->after_state ==
+                RenderGraph::ResourceState::Buffer(
+                    RenderGraph::BufferState::AccelerationStructureRead
+                ),
+        test_name,
+        "an externally built TLAS must normalize AS-write to AS-read"
+    );
+}
+
 } // namespace
 
 int main() {
@@ -4229,6 +4431,7 @@ int main() {
     TestParallelRecordingDispatchAndJoin(suite);
     TestCpuRecordingDependenciesSplitParallelGroups(suite);
     TestRecordingPublicationFailureTerminatesGates(suite);
+    TestFrameSetupTokenAndTlasBoundaryContract(suite);
 
     if (suite.FailureCount() != 0) {
         std::cerr << "TestRenderGraph: " << suite.FailureCount() << " failure(s)\n";

--- a/source/test/RenderGraphTest.cpp
+++ b/source/test/RenderGraphTest.cpp
@@ -4173,9 +4173,16 @@ void TestFrameSetupTokenAndTlasBoundaryContract(TestSuite& suite) {
     int                        bindless_identity = 0;
     int                        tlas_identity     = 0;
     int                        instance_identity = 0;
+    int                        scene_identity    = 0;
     const auto bindless = graph.ImportToken("Bindless", &bindless_identity);
+    const auto ready    = graph.CreateTransientToken("FrameSetupReady");
     const auto tlas = graph.ImportBuffer(
         "CurrentTLAS",
+        &tlas_identity,
+        RenderGraph::BufferDesc{.byte_size = 4096}
+    );
+    const auto previous_tlas = graph.ImportBuffer(
+        "PreviousTLAS",
         &tlas_identity,
         RenderGraph::BufferDesc{.byte_size = 4096}
     );
@@ -4183,6 +4190,16 @@ void TestFrameSetupTokenAndTlasBoundaryContract(TestSuite& suite) {
         "TLASInstances",
         &instance_identity,
         RenderGraph::BufferDesc{.byte_size = 4096}
+    );
+    const auto scene = graph.ImportBuffer(
+        "SceneInstances",
+        &scene_identity,
+        RenderGraph::BufferDesc{.byte_size = 4096}
+    );
+    suite.Check(
+        previous_tlas == tlas,
+        test_name,
+        "current/previous TLAS aliases must reuse one graph-local handle"
     );
     graph.SetInitialState(
         tlas,
@@ -4196,6 +4213,12 @@ void TestFrameSetupTokenAndTlasBoundaryContract(TestSuite& suite) {
         RenderGraph::QueueRole::None,
         RenderGraph::AccessMode::None
     );
+    graph.SetInitialState(
+        scene,
+        RenderGraph::BufferState::ShaderResource,
+        RenderGraph::QueueRole::Graphics,
+        RenderGraph::AccessMode::Read
+    );
 
     const auto update = graph.AddRecordPass(
         "UpdateBindless",
@@ -4208,7 +4231,10 @@ void TestFrameSetupTokenAndTlasBoundaryContract(TestSuite& suite) {
     const auto normalize = graph.AddRecordPass(
         "NormalizeScene",
         [=](RenderGraph::PassBuilder& builder) {
-            builder.Read(bindless).SideEffect();
+            builder
+                .Read(bindless)
+                .Read(scene, RenderGraph::BufferState::ShaderResource)
+                .SideEffect();
         },
         [](Moer::Render::CommandList&) {},
         RenderGraph::PassExecutionClass::SerialRecord
@@ -4229,6 +4255,38 @@ void TestFrameSetupTokenAndTlasBoundaryContract(TestSuite& suite) {
         },
         [](Moer::Render::CommandList&) {},
         RenderGraph::PassExecutionClass::SerialRecord
+    );
+    const auto finalize = graph.AddRecordPass(
+        "FinalizeFrameSetup",
+        [=](RenderGraph::PassBuilder& builder) {
+            builder.DependsOn(normalize)
+                .DependsOn(build)
+                .Read(bindless)
+                .Read(
+                    tlas,
+                    RenderGraph::BufferState::AccelerationStructureRead
+                )
+                .Write(ready)
+                .SideEffect();
+        },
+        [](Moer::Render::CommandList&) {},
+        RenderGraph::PassExecutionClass::SerialRecord
+    );
+    const auto prepare_lights = graph.AddRecordPass(
+        "PrepareLights",
+        [=](RenderGraph::PassBuilder& builder) {
+            builder
+                .Read(ready)
+                .Read(bindless)
+                .Read(
+                    previous_tlas,
+                    RenderGraph::BufferState::AccelerationStructureRead
+                )
+                .Read(scene, RenderGraph::BufferState::ShaderResource)
+                .SideEffect();
+        },
+        [](Moer::Render::CommandList&) {},
+        RenderGraph::PassExecutionClass::ParallelRecordEligible
     );
     graph.Export(
         tlas,
@@ -4266,10 +4324,32 @@ void TestFrameSetupTokenAndTlasBoundaryContract(TestSuite& suite) {
         test_name,
         "BuildTLAS must retain the explicit normalization dependency"
     );
+    suite.Check(
+        HasEdgeReason(
+            plan,
+            build,
+            finalize,
+            RenderGraph::EdgeReasonKind::ReadAfterWrite,
+            tlas.Untyped()
+        ),
+        test_name,
+        "FinalizeFrameSetup must normalize the built TLAS through a RAW edge"
+    );
+    suite.Check(
+        HasEdgeReason(
+            plan,
+            finalize,
+            prepare_lights,
+            RenderGraph::EdgeReasonKind::ReadAfterWrite,
+            ready.Untyped()
+        ),
+        test_name,
+        "PrepareLights must consume the same-transaction FrameSetup ready token"
+    );
     const auto* import_barrier =
         FindBarrier(plan, tlas.Untyped(), {}, build);
-    const auto* export_barrier =
-        FindBarrier(plan, tlas.Untyped(), build, {});
+    const auto* consumer_barrier =
+        FindBarrier(plan, tlas.Untyped(), build, finalize);
     suite.Check(
         import_barrier != nullptr && import_barrier->state_transition &&
             import_barrier->after_state ==
@@ -4280,13 +4360,13 @@ void TestFrameSetupTokenAndTlasBoundaryContract(TestSuite& suite) {
         "BuildTLAS must acquire an AS-write destination from the import boundary"
     );
     suite.Check(
-        export_barrier != nullptr && export_barrier->state_transition &&
-            export_barrier->after_state ==
+        consumer_barrier != nullptr && consumer_barrier->state_transition &&
+            consumer_barrier->after_state ==
                 RenderGraph::ResourceState::Buffer(
                     RenderGraph::BufferState::AccelerationStructureRead
                 ),
         test_name,
-        "FrameSetup must export TLAS as an AS-readable consumer boundary"
+        "FinalizeFrameSetup must establish the AS-readable consumer boundary"
     );
     const auto* instance_import_barrier =
         FindBarrier(plan, instances.Untyped(), {}, build);
@@ -4308,6 +4388,82 @@ void TestFrameSetupTokenAndTlasBoundaryContract(TestSuite& suite) {
         next_bindless.Untyped().owner_id != bindless.Untyped().owner_id,
         test_name,
         "same physical token identity in another graph must remain a distinct transaction"
+    );
+
+    RenderGraph scene_update_graph("ExternalSceneReadBoundaryContract");
+    int         updated_scene_identity = 0;
+    int         stable_scene_identity  = 0;
+    const auto  updated_scene = scene_update_graph.ImportBuffer(
+        "UpdatedScene",
+        &updated_scene_identity,
+        RenderGraph::BufferDesc{.byte_size = 4096}
+    );
+    const auto stable_scene = scene_update_graph.ImportBuffer(
+        "StableScene",
+        &stable_scene_identity,
+        RenderGraph::BufferDesc{.byte_size = 4096}
+    );
+    scene_update_graph.SetInitialState(
+        updated_scene,
+        RenderGraph::BufferState::TransferDestination,
+        RenderGraph::QueueRole::Graphics,
+        RenderGraph::AccessMode::Write
+    );
+    scene_update_graph.SetInitialState(
+        stable_scene,
+        RenderGraph::BufferState::ShaderResource,
+        RenderGraph::QueueRole::Graphics,
+        RenderGraph::AccessMode::Read
+    );
+    const auto scene_read_boundary = scene_update_graph.AddRecordPass(
+        "PublishSceneReads",
+        [=](RenderGraph::PassBuilder& builder) {
+            builder
+                .Read(updated_scene, RenderGraph::BufferState::ShaderResource)
+                .Read(stable_scene, RenderGraph::BufferState::ShaderResource)
+                .SideEffect();
+        },
+        [](Moer::Render::CommandList&) {},
+        RenderGraph::PassExecutionClass::SerialRecord
+    );
+    suite.Check(
+        scene_update_graph.Compile(),
+        test_name,
+        scene_update_graph.GetCompileError()
+    );
+    const auto* updated_scene_barrier = FindBarrier(
+        scene_update_graph.GetCompiledPlan(),
+        updated_scene.Untyped(),
+        {},
+        scene_read_boundary
+    );
+    suite.Check(
+        updated_scene_barrier != nullptr &&
+            updated_scene_barrier->state_transition &&
+            updated_scene_barrier->memory_dependency &&
+            updated_scene_barrier->before_state ==
+                RenderGraph::ResourceState::Buffer(
+                    RenderGraph::BufferState::TransferDestination
+                ) &&
+            updated_scene_barrier->after_state ==
+                RenderGraph::ResourceState::Buffer(
+                    RenderGraph::BufferState::ShaderResource
+                ),
+        test_name,
+        "an uploaded scene buffer must publish transfer-write to shader-read"
+    );
+    const auto* stable_scene_boundary = FindBarrier(
+        scene_update_graph.GetCompiledPlan(),
+        stable_scene.Untyped(),
+        {},
+        scene_read_boundary
+    );
+    suite.Check(
+        stable_scene_boundary == nullptr ||
+            (!stable_scene_boundary->state_transition &&
+             !stable_scene_boundary->memory_dependency),
+        test_name,
+        "an untouched shader-readable scene buffer must not invent a write boundary"
     );
 
     RenderGraph external_graph("ExternalTLASNormalizeContract");

--- a/tools/threading/run_parallel_record_vulkan_test.py
+++ b/tools/threading/run_parallel_record_vulkan_test.py
@@ -710,12 +710,109 @@ def _require_bounded_cross_batch_pipeline(mode: str, text: str) -> None:
     )
 
 
+def _require_phase15f_present_boundary(mode: str, text: str) -> None:
+    if mode == "present-boundary":
+        serial_control = _testcase_marker(
+            "SerialControlPipelineBoundary", text
+        )
+        _require(
+            serial_control is not None and serial_control[0] == "PASS",
+            f"{mode}: missing SerialControlPipelineBoundary PASS marker",
+        )
+        _, serial_fields = serial_control
+        _require(
+            serial_fields.get("order")
+            == "Prefix,SerialControl,Later"
+            and serial_fields.get("owner") == "Submission"
+            and serial_fields.get("later_translate") == "blocked"
+            and serial_fields.get("readback") == "verified"
+            and serial_fields.get("signals") == "success"
+            and serial_fields.get("boundary_events") == "2"
+            and serial_fields.get("native_submits") == "3"
+            and serial_fields.get("replay") == "0",
+            f"{mode}: incomplete SerialControl pipeline-boundary contract",
+        )
+        shutdown = _testcase_marker(
+            "QueuedPresentShutdownBoundary", text
+        )
+        _require(
+            shutdown is not None and shutdown[0] == "PASS",
+            f"{mode}: missing QueuedPresentShutdownBoundary PASS marker",
+        )
+        _, shutdown_fields = shutdown
+        _require(
+            shutdown_fields.get("outcome") == "Retry"
+            and shutdown_fields.get("prefix") == "rejected"
+            and shutdown_fields.get("receipt_attempts") == "1"
+            and shutdown_fields.get("submitted") == "false"
+            and shutdown_fields.get("recreate") == "false"
+            and shutdown_fields.get("owner") == "Submission"
+            and shutdown_fields.get("native_submit") == "0"
+            and shutdown_fields.get("owners") == "stopped"
+            and shutdown_fields.get("replay") == "0",
+            f"{mode}: incomplete queued Present shutdown contract",
+        )
+
+    marker_name = (
+        "PresentPipelineBoundary"
+        if mode == "present-boundary"
+        else "PresentHardFailureBoundary"
+    )
+    marker = _testcase_marker(marker_name, text)
+    _require(
+        marker is not None and marker[0] == "PASS",
+        f"{mode}: missing {marker_name} PASS marker",
+    )
+    _, fields = marker
+    if mode == "present-boundary":
+        _require(
+            fields.get("outcome") == "Recreate"
+            and fields.get("order")
+            == "Prefix,Bridge?,Present,Later"
+            and fields.get("owner") == "Submission"
+            and fields.get("receipt_attempts") == "1"
+            and fields.get("submitted") == "false"
+            and fields.get("recreate") == "true"
+            and fields.get("completion") == "drained"
+            and fields.get("later_batch") == "success"
+            and fields.get("present_only") == "verified"
+            and fields.get("bridge") in {"required", "elided"}
+            and fields.get("graphics_native") is not None
+            and fields.get("prefix_native") is not None
+            and fields.get("readback") == "verified"
+            and (
+                fields.get("bridge") == "required"
+                or fields.get("graphics_native")
+                == fields.get("prefix_native")
+            )
+            and fields.get("replay") == "0",
+            f"{mode}: incomplete Present pipeline-boundary contract",
+        )
+        return
+
+    _require(
+        fields.get("outcome") == "Rejected"
+        and fields.get("owner") == "Submission"
+        and fields.get("receipt_attempts") == "1"
+        and fields.get("submitted") == "false"
+        and fields.get("recreate") == "false"
+        and fields.get("later_batch") == "rejected"
+        and fields.get("native_after_present") == "0"
+        and fields.get("hard_latch") == "verified"
+        and fields.get("replay") == "0",
+        f"{mode}: incomplete hard Present boundary contract",
+    )
+
+
 def validate_log(mode: str, text: str) -> None:
     _require("[TESTCASE][FAIL]" not in text, f"{mode}: test emitted a FAIL marker")
     _require("VUID-" not in text, f"{mode}: Vulkan validation VUID was emitted")
     _require("Validation Error" not in text, f"{mode}: Vulkan validation error was emitted")
     if mode in ("pipeline-window1", "pipeline-window2"):
         _require_bounded_cross_batch_pipeline(mode, text)
+        return
+    if mode in ("present-boundary", "present-hard"):
+        _require_phase15f_present_boundary(mode, text)
         return
     _require_phase15c_completion_aggregate_cpu_probe(mode, text)
     if mode == "translate-hard":
@@ -995,6 +1092,10 @@ def run_case(executable: Path, outdir: Path, mode: str, timeout: float) -> Path:
         arguments.append("--pipeline-window1")
     if mode == "pipeline-window2":
         arguments.append("--pipeline-window2")
+    if mode == "present-boundary":
+        arguments.append("--present-boundary")
+    if mode == "present-hard":
+        arguments.append("--present-hard")
 
     completed = subprocess.run(
         [str(executable), *arguments],
@@ -1047,6 +1148,8 @@ def main(argv: Sequence[str] | None = None) -> int:
                 "multi-segment-hard",
                 "pipeline-window1",
                 "pipeline-window2",
+                "present-boundary",
+                "present-hard",
             )
         ]
     except (OSError, subprocess.TimeoutExpired, VulkanTestError) as error:

--- a/tools/threading/run_parallel_record_vulkan_test.py
+++ b/tools/threading/run_parallel_record_vulkan_test.py
@@ -364,18 +364,17 @@ def _require_rt_export_rejection(text: str) -> None:
     )
     _, fields = marker
     _require(
-        fields.get("source") == "rejected"
-        and fields.get("tail") == "dependency_rejected"
-        and fields.get("readback") == "skipped"
-        and fields.get("encoder") == "skipped"
-        and fields.get("export_consumed") == "false"
-        and fields.get("temporal") == "0"
-        and fields.get("history") == "0"
-        and fields.get("tlas") == "0"
+        fields.get("attempt1") == "prefix_rejected"
+        and fields.get("attempt1_tail") == "dependency_rejected"
+        and fields.get("attempt1_latch") == "false"
+        and fields.get("request_pending") == "true"
+        and fields.get("readback_retry") == "frame_accepted"
+        and fields.get("recovery_consumed") == "true"
+        and fields.get("encoder") == "once"
+        and fields.get("decision_table") == "verified"
         and fields.get("native_rejected") == "0"
         and fields.get("callbacks") == "exactly_once"
         and fields.get("keepalive") == "terminal"
-        and fields.get("recovery") == "accepted"
         and fields.get("replay") == "0",
         "rt-export-rejection: incomplete export transaction contract",
     )

--- a/tools/threading/run_parallel_record_vulkan_test.py
+++ b/tools/threading/run_parallel_record_vulkan_test.py
@@ -354,6 +354,33 @@ def _require_phase15c_completion_aggregate_cpu_probe(
     )
 
 
+def _require_rt_export_rejection(text: str) -> None:
+    marker = _testcase_marker(
+        "RaytracingExportAcceptanceRejection", text
+    )
+    _require(
+        marker is not None and marker[0] == "PASS",
+        "rt-export-rejection: missing export rejection PASS marker",
+    )
+    _, fields = marker
+    _require(
+        fields.get("source") == "rejected"
+        and fields.get("tail") == "dependency_rejected"
+        and fields.get("readback") == "skipped"
+        and fields.get("encoder") == "skipped"
+        and fields.get("export_consumed") == "false"
+        and fields.get("temporal") == "0"
+        and fields.get("history") == "0"
+        and fields.get("tlas") == "0"
+        and fields.get("native_rejected") == "0"
+        and fields.get("callbacks") == "exactly_once"
+        and fields.get("keepalive") == "terminal"
+        and fields.get("recovery") == "accepted"
+        and fields.get("replay") == "0",
+        "rt-export-rejection: incomplete export transaction contract",
+    )
+
+
 def _require_bounded_cross_batch_pipeline(mode: str, text: str) -> None:
     expected_window = {
         "pipeline-window1": "1",
@@ -808,6 +835,9 @@ def validate_log(mode: str, text: str) -> None:
     _require("[TESTCASE][FAIL]" not in text, f"{mode}: test emitted a FAIL marker")
     _require("VUID-" not in text, f"{mode}: Vulkan validation VUID was emitted")
     _require("Validation Error" not in text, f"{mode}: Vulkan validation error was emitted")
+    if mode == "rt-export-rejection":
+        _require_rt_export_rejection(text)
+        return
     if mode in ("pipeline-window1", "pipeline-window2"):
         _require_bounded_cross_batch_pipeline(mode, text)
         return
@@ -1096,6 +1126,8 @@ def run_case(executable: Path, outdir: Path, mode: str, timeout: float) -> Path:
         arguments.append("--present-boundary")
     if mode == "present-hard":
         arguments.append("--present-hard")
+    if mode == "rt-export-rejection":
+        arguments.append("--rt-export-rejection")
 
     completed = subprocess.run(
         [str(executable), *arguments],
@@ -1150,6 +1182,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                 "pipeline-window2",
                 "present-boundary",
                 "present-hard",
+                "rt-export-rejection",
             )
         ]
     except (OSError, subprocess.TimeoutExpired, VulkanTestError) as error:

--- a/tools/threading/test_run_parallel_record_vulkan_test.py
+++ b/tools/threading/test_run_parallel_record_vulkan_test.py
@@ -170,6 +170,16 @@ def present_hard_line() -> str:
     )
 
 
+def rt_export_rejection_line() -> str:
+    return (
+        "[TESTCASE][PASS] name=RaytracingExportAcceptanceRejection "
+        "source=rejected tail=dependency_rejected readback=skipped "
+        "encoder=skipped export_consumed=false temporal=0 history=0 "
+        "tlas=0 native_rejected=0 callbacks=exactly_once "
+        "keepalive=terminal recovery=accepted replay=0\n"
+    )
+
+
 def pass_line(
     mode: str,
     fault: str,
@@ -950,6 +960,11 @@ class VulkanRunnerTests(unittest.TestCase):
                 "--present-hard",
                 present_hard_line(),
             ),
+            (
+                "rt-export-rejection",
+                "--rt-export-rejection",
+                rt_export_rejection_line(),
+            ),
         )
         with tempfile.TemporaryDirectory() as temporary_directory:
             for mode, expected_argument, output in cases:
@@ -978,6 +993,22 @@ class VulkanRunnerTests(unittest.TestCase):
                             expected_argument,
                         ],
                     )
+
+    def test_rt_export_rejection_contract_is_accepted(self) -> None:
+        runner.validate_log(
+            "rt-export-rejection",
+            rt_export_rejection_line(),
+        )
+
+    def test_rt_export_rejection_rejects_state_commit(self) -> None:
+        with self.assertRaisesRegex(
+            runner.VulkanTestError,
+            "incomplete export transaction contract",
+        ):
+            runner.validate_log(
+                "rt-export-rejection",
+                rt_export_rejection_line().replace("tlas=0", "tlas=1"),
+            )
 
     def test_present_boundary_contract_is_accepted(self) -> None:
         runner.validate_log(

--- a/tools/threading/test_run_parallel_record_vulkan_test.py
+++ b/tools/threading/test_run_parallel_record_vulkan_test.py
@@ -173,10 +173,11 @@ def present_hard_line() -> str:
 def rt_export_rejection_line() -> str:
     return (
         "[TESTCASE][PASS] name=RaytracingExportAcceptanceRejection "
-        "source=rejected tail=dependency_rejected readback=skipped "
-        "encoder=skipped export_consumed=false temporal=0 history=0 "
-        "tlas=0 native_rejected=0 callbacks=exactly_once "
-        "keepalive=terminal recovery=accepted replay=0\n"
+        "attempt1=prefix_rejected attempt1_tail=dependency_rejected "
+        "attempt1_latch=false request_pending=true "
+        "readback_retry=frame_accepted recovery_consumed=true encoder=once "
+        "decision_table=verified native_rejected=0 callbacks=exactly_once "
+        "keepalive=terminal replay=0\n"
     )
 
 
@@ -1000,14 +1001,29 @@ class VulkanRunnerTests(unittest.TestCase):
             rt_export_rejection_line(),
         )
 
-    def test_rt_export_rejection_rejects_state_commit(self) -> None:
+    def test_rt_export_rejection_rejects_retry_latch(self) -> None:
         with self.assertRaisesRegex(
             runner.VulkanTestError,
             "incomplete export transaction contract",
         ):
             runner.validate_log(
                 "rt-export-rejection",
-                rt_export_rejection_line().replace("tlas=0", "tlas=1"),
+                rt_export_rejection_line().replace(
+                    "attempt1_latch=false", "attempt1_latch=true"
+                ),
+            )
+
+    def test_rt_export_rejection_requires_readback_recovery(self) -> None:
+        with self.assertRaisesRegex(
+            runner.VulkanTestError,
+            "incomplete export transaction contract",
+        ):
+            runner.validate_log(
+                "rt-export-rejection",
+                rt_export_rejection_line().replace(
+                    "readback_retry=frame_accepted",
+                    "readback_retry=frame_rejected",
+                ),
             )
 
     def test_present_boundary_contract_is_accepted(self) -> None:

--- a/tools/threading/test_run_parallel_record_vulkan_test.py
+++ b/tools/threading/test_run_parallel_record_vulkan_test.py
@@ -129,6 +129,47 @@ def pipeline_line(
     )
 
 
+def serial_control_boundary_line() -> str:
+    return (
+        "[TESTCASE][PASS] name=SerialControlPipelineBoundary "
+        "order=Prefix,SerialControl,Later owner=Submission "
+        "later_translate=blocked readback=verified signals=success "
+        "boundary_events=2 native_submits=3 replay=0\n"
+    )
+
+
+def queued_present_shutdown_line() -> str:
+    return (
+        "[TESTCASE][PASS] name=QueuedPresentShutdownBoundary "
+        "outcome=Retry prefix=rejected receipt_attempts=1 "
+        "submitted=false recreate=false owner=Submission "
+        "native_submit=0 owners=stopped replay=0\n"
+    )
+
+
+def present_boundary_line(bridge: str = "required") -> str:
+    prefix_native = "2" if bridge == "required" else "0"
+    return (
+        serial_control_boundary_line()
+        + "[TESTCASE][PASS] name=PresentPipelineBoundary "
+        "outcome=Recreate order=Prefix,Bridge?,Present,Later "
+        "owner=Submission receipt_attempts=1 submitted=false "
+        "recreate=true completion=drained later_batch=success "
+        f"present_only=verified bridge={bridge} graphics_native=0 "
+        f"prefix_native={prefix_native} readback=verified replay=0\n"
+        + queued_present_shutdown_line()
+    )
+
+
+def present_hard_line() -> str:
+    return (
+        "[TESTCASE][PASS] name=PresentHardFailureBoundary "
+        "outcome=Rejected owner=Submission receipt_attempts=1 "
+        "submitted=false recreate=false later_batch=rejected "
+        "native_after_present=0 hard_latch=verified replay=0\n"
+    )
+
+
 def pass_line(
     mode: str,
     fault: str,
@@ -899,6 +940,16 @@ class VulkanRunnerTests(unittest.TestCase):
                 "--pipeline-window2",
                 pipeline_line(2, "false", "verified"),
             ),
+            (
+                "present-boundary",
+                "--present-boundary",
+                present_boundary_line(),
+            ),
+            (
+                "present-hard",
+                "--present-hard",
+                present_hard_line(),
+            ),
         )
         with tempfile.TemporaryDirectory() as temporary_directory:
             for mode, expected_argument, output in cases:
@@ -927,6 +978,121 @@ class VulkanRunnerTests(unittest.TestCase):
                             expected_argument,
                         ],
                     )
+
+    def test_present_boundary_contract_is_accepted(self) -> None:
+        runner.validate_log(
+            "present-boundary", present_boundary_line()
+        )
+        runner.validate_log(
+            "present-boundary", present_boundary_line("elided")
+        )
+
+    def test_present_boundary_requires_serial_control_gate(self) -> None:
+        with self.assertRaisesRegex(
+            runner.VulkanTestError,
+            "SerialControlPipelineBoundary",
+        ):
+            runner.validate_log(
+                "present-boundary",
+                present_boundary_line().replace(
+                    serial_control_boundary_line(), ""
+                ),
+            )
+
+    def test_serial_control_boundary_requires_blocked_later_translate(
+        self,
+    ) -> None:
+        with self.assertRaisesRegex(
+            runner.VulkanTestError,
+            "SerialControl pipeline-boundary contract",
+        ):
+            runner.validate_log(
+                "present-boundary",
+                present_boundary_line().replace(
+                    "later_translate=blocked",
+                    "later_translate=overtook",
+                ),
+            )
+
+    def test_present_boundary_requires_shutdown_gate(self) -> None:
+        with self.assertRaisesRegex(
+            runner.VulkanTestError,
+            "QueuedPresentShutdownBoundary",
+        ):
+            runner.validate_log(
+                "present-boundary",
+                present_boundary_line().replace(
+                    queued_present_shutdown_line(), ""
+                ),
+            )
+
+    def test_queued_present_shutdown_requires_retry(self) -> None:
+        with self.assertRaisesRegex(
+            runner.VulkanTestError,
+            "queued Present shutdown contract",
+        ):
+            runner.validate_log(
+                "present-boundary",
+                present_boundary_line().replace(
+                    "outcome=Retry prefix=rejected",
+                    "outcome=Recreate prefix=rejected",
+                ),
+            )
+
+    def test_present_boundary_requires_exactly_one_receipt_attempt(
+        self,
+    ) -> None:
+        with self.assertRaisesRegex(
+            runner.VulkanTestError,
+            "Present pipeline-boundary contract",
+        ):
+            runner.validate_log(
+                "present-boundary",
+                present_boundary_line().replace(
+                    "owner=Submission receipt_attempts=1 submitted=false",
+                    "owner=Submission receipt_attempts=2 submitted=false",
+                ),
+            )
+
+    def test_present_boundary_bridge_matches_native_identity(self) -> None:
+        with self.assertRaisesRegex(
+            runner.VulkanTestError,
+            "Present pipeline-boundary contract",
+        ):
+            runner.validate_log(
+                "present-boundary",
+                present_boundary_line("elided").replace(
+                    "prefix_native=0", "prefix_native=2"
+                ),
+            )
+
+    def test_present_boundary_accepts_alias_completion_marker(
+        self,
+    ) -> None:
+        runner.validate_log(
+            "present-boundary",
+            present_boundary_line("required").replace(
+                "prefix_native=2", "prefix_native=0"
+            ),
+        )
+
+    def test_present_hard_contract_is_accepted(self) -> None:
+        runner.validate_log("present-hard", present_hard_line())
+
+    def test_present_hard_rejects_native_work_after_boundary(
+        self,
+    ) -> None:
+        with self.assertRaisesRegex(
+            runner.VulkanTestError,
+            "hard Present boundary contract",
+        ):
+            runner.validate_log(
+                "present-hard",
+                present_hard_line().replace(
+                    "native_after_present=0",
+                    "native_after_present=1",
+                ),
+            )
 
     def test_serial_accepts_only_pass_marker(self) -> None:
         runner.validate_log("serial", pass_line("serial", "false"))


### PR DESCRIPTION
## Summary

- migrate PrepareLights, FrameSetup, bindless uploads, TLAS, GBuffer, lighting, NRD, post-processing, copied UI composition and the Present source into one explicit RT steady-state graph
- preserve immutable setup packets and explicit per-source/native-acceptance receipts; only advance renderer temporal state after the whole frame transaction is accepted
- isolate NRD and copied UI backend mutation as narrow `SerialControl` islands while leaving ordinary translate/record work parallel
- keep native WSI Present under the single Executor/Submission owner and export exact graph source state for it
- fix the Raster copied-UI path found during pre-merge review by claiming upload slots before recording and committing them exactly once only after native submission acceptance
- add rejection, stale-slot, shutdown, no-replay, topology, resource-state and Present-boundary contract coverage

## Validation

- `MoerEditor` Release target: PASS
- `TestRenderGraph` Debug and Release: PASS
- Release CTest: 18/18 PASS
- RTX 5080 Vulkan `--present-boundary`: PASS, replay=0
- RTX 5080 Vulkan `--present-hard`: PASS, replay=0
- RTX 5080 Vulkan `--parallel --production-gate`: PASS, 24 iterations, replay=0
- Vulkan + Raster + Render/RHI threads + real non-empty copied ImGui packet runtime smoke: >2 minutes, four distinct record workers / max_active=4, no invalid slot, UI critical, VUID, SYNC-HAZARD, assert, fatal, or device lost
- conditional `WITH_NRD=1` syntax build against repository NRI 1.154 / NRD 4.11.2 headers: PASS (runtime NRD SDK is not available in this checkout)

## Known unrelated build caveat

The product and every test target link successfully. The aggregate third-party `ALL_BUILD` target still exits non-zero because pinned GKlib passes GNU `-include io.h` to MSVC; the explicit `MoerEditor` product target exits 0. This pre-existing third-party CMake issue is intentionally outside this PR.