### PR TITLE
feat(rhi): add completion-owned GPU query futures

### DIFF
--- a/source/runtime/render/rhi/RHICommand.h
+++ b/source/runtime/render/rhi/RHICommand.h
@@ -9,6 +9,7 @@
 #include "misc/STL.h"
 #include "misc/Traits.h"
 #include "rhi/RHICommon.h"
+#include "rhi/RHIQuery.h"
 #include "rhi/RHIResource.h"
 #include "rhi/RHISubmissionTopology.h"
 #include "shader/ShaderPipeline.h"
@@ -99,6 +100,7 @@ public:
         MultiDraw,
         UpdateBindlessArray,
         ClearResource,
+        Query,
         Scope,
         Custom,
         Count
@@ -109,8 +111,8 @@ public:
         "TextureToBuffer", "UploadTexture",       "TextureToTexture", "CopyBackTexture",
         "ShaderDispatch",  "BuildAccel",          "BuildTLAS",      "TraceRay",
         "Barrier",         "QueueTransfer",       "SetDrawState",   "SetGeometryPassDrawState",
-        "MultiDraw",       "UpdateBindlessArray", "ClearResource",  "Scope",
-        "Custom"
+        "MultiDraw",       "UpdateBindlessArray", "ClearResource",  "Query",
+        "Scope",           "Custom"
     };
 
 private:
@@ -280,6 +282,10 @@ struct CmdSubmit {
     Array<UniquePtr<Command>>        cmds;
     Array<std::function<void(void)>> callbacks;
     Array<std::function<void(void)>> success_callbacks;
+    Array<QueryToken>                query_tokens;
+    // Optional owner ticket when a whole backend batch publishes Query
+    // terminal states before per-submit Completion packets are enqueued.
+    QueryPublishBatch                query_publish_batch{};
     TCachedArgArray                  cached_args;
     Array<RHISubmitSegment>          segments;
 
@@ -386,6 +392,8 @@ struct CmdSubmit {
         cmds               = std::move(_other.cmds);
         callbacks          = std::move(_other.callbacks);
         success_callbacks  = std::move(_other.success_callbacks);
+        query_tokens        = std::move(_other.query_tokens);
+        query_publish_batch = _other.query_publish_batch;
         wait_events        = std::move(_other.wait_events);
         signal_events      = std::move(_other.signal_events);
         cached_args        = std::move(_other.cached_args);
@@ -399,12 +407,31 @@ struct CmdSubmit {
         async_queue_scope  = _other.async_queue_scope;
         debug_label        = std::move(_other.debug_label);
         debug_label_color  = _other.debug_label_color;
+        _other.query_tokens.clear();
+        _other.query_publish_batch = {};
+        _other.signal_events.clear();
     }
 
     CmdSubmit& operator=(CmdSubmit&& _other) noexcept {
+        if (this == &_other) {
+            return *this;
+        }
+        RejectPendingSignals();
+        Array<QueryToken> replaced_query_tokens = std::move(query_tokens);
+        const QueryPublishBatch replaced_query_batch =
+            query_publish_batch.Valid() ?
+                query_publish_batch :
+                QueryBackendAccess::BeginPublishBatch();
+        QueryBackendAccess::PublishErrorsIfPending(
+            replaced_query_tokens,
+            "query submit was replaced before completion",
+            replaced_query_batch
+        );
         cmds               = std::move(_other.cmds);
         callbacks          = std::move(_other.callbacks);
         success_callbacks  = std::move(_other.success_callbacks);
+        query_tokens        = std::move(_other.query_tokens);
+        query_publish_batch = _other.query_publish_batch;
         wait_events        = std::move(_other.wait_events);
         signal_events      = std::move(_other.signal_events);
         cached_args        = std::move(_other.cached_args);
@@ -418,7 +445,58 @@ struct CmdSubmit {
         async_queue_scope  = _other.async_queue_scope;
         debug_label        = std::move(_other.debug_label);
         debug_label_color  = _other.debug_label_color;
+        _other.query_tokens.clear();
+        _other.query_publish_batch = {};
+        _other.signal_events.clear();
+
+        // The replacement is fully installed before user Query callbacks can
+        // re-enter this object. No outer write may overwrite re-entrant state.
+        QueryBackendAccess::NotifyTerminals(
+            replaced_query_tokens, replaced_query_batch
+        );
         return *this;
+    }
+
+    ~CmdSubmit() {
+        RejectPendingSignals();
+        RejectPendingQueries("query submit was destroyed before completion");
+    }
+
+    void RejectPendingSignals() noexcept {
+        for (const SignalEvent& signal : signal_events) {
+            auto* fence = reinterpret_cast<Fence*>(signal.timeline_handle);
+            if (fence != nullptr) {
+                fence->Reject(signal.value);
+            }
+        }
+        signal_events.clear();
+    }
+
+    void PublishPendingQueryErrors(
+        std::string_view  _reason,
+        QueryPublishBatch _batch
+    ) noexcept {
+        const QueryPublishBatch effective_batch =
+            query_publish_batch.Valid() ? query_publish_batch : _batch;
+        query_publish_batch = effective_batch;
+        QueryBackendAccess::PublishErrorsIfPending(
+            query_tokens, _reason, effective_batch
+        );
+    }
+
+    void NotifyPendingQueries(QueryPublishBatch _batch) noexcept {
+        Array<QueryToken> tokens = std::move(query_tokens);
+        query_publish_batch = {};
+        QueryBackendAccess::NotifyTerminals(tokens, _batch);
+    }
+
+    void RejectPendingQueries(std::string_view _reason) noexcept {
+        const QueryPublishBatch batch =
+            query_publish_batch.Valid() ?
+                query_publish_batch :
+                QueryBackendAccess::BeginPublishBatch();
+        PublishPendingQueryErrors(_reason, batch);
+        NotifyPendingQueries(batch);
     }
     CmdSubmit(
         Array<UniquePtr<Command>>&&        _cmds,
@@ -1247,6 +1325,7 @@ public:
 public:
     RENDER_API CommandList();
     RENDER_API explicit CommandList(EQueueType _queue_type);
+    RENDER_API ~CommandList();
     class Impl;
 
     template<is_shader_pipeline TGfxPso, typename... TArgs>
@@ -1378,6 +1457,12 @@ public:
         float4           _color = GpuMarkerPalette::Scope()
     );
     RENDER_API void PopScopeWithTimeScope();
+
+    // Phase 17A deliberately exposes timestamp queries only. QueryKind keeps
+    // the Occlusion value reserved so the ABI can grow without conflating the
+    // two result payloads.
+    RENDER_API QueryToken BeginTimestampQuery(std::string_view _name = "TimestampQuery");
+    RENDER_API void EndTimestampQuery(const QueryToken& _token);
 
     template<typename T, typename... Args>
     struct CountType;
@@ -1557,6 +1642,10 @@ public:
     RENDER_API void Signal(Fence* _fence, uint64 _signal_value);
     RENDER_API void Signal(const FenceRef& _fence, uint64 _signal_value);
 
+    // Rejection-only seam for a terminal recording owner. It must never be
+    // called while a producer can still mutate this CommandList.
+    RENDER_API void RejectPendingSignals() noexcept;
+
     RENDER_API ArrayArgReference RegisterArgs(ArrayArguments&& _args);
 
     // Terminal rejection-only ownership path. The producer must have stopped
@@ -1576,6 +1665,14 @@ public:
 
     [[nodiscard]] uint64 GetSealGeneration() const noexcept {
         return seal_generation;
+    }
+
+    [[nodiscard]] QueryCancellationView GetQueryCancellationView() const noexcept {
+        return query_cancellation_domain.GetView();
+    }
+
+    [[nodiscard]] bool HasOpenTimestampQueries() const noexcept {
+        return !active_query_stack.empty();
     }
 
     EQueueType GetQueueType() const noexcept {
@@ -1667,6 +1764,8 @@ private:
     RENDER_API void InnerWriteTexture(TextureView _texture, ETextureState _state, EPassType _pass);
     RENDER_API void EndBarriers();
 
+    RENDER_API void RejectPendingQueries(std::string_view _reason) noexcept;
+
 #pragma region[ raytracing ]
     RENDER_API void TraceRays(PipelineHandle _pipeline, ArrayArguments&& _args, uint3 _extent);
     RENDER_API void TraceRayIndirect(PipelineHandle _pipeline, BufferView _buffer);
@@ -1676,6 +1775,9 @@ private:
     Command*                     current_barriers{nullptr};
     Array<std::function<void()>> callbacks;
     Array<std::function<void()>> success_callbacks;
+    Array<QueryToken>             query_tokens;
+    Array<QueryToken>             active_query_stack;
+    QueryCancellationDomain       query_cancellation_domain;
     Array<SignalEvent>            signal_events;
     TCachedArgArray              cached_args;
     EQueueType                   queue_type{EQueueType::Graphics};
@@ -1690,6 +1792,7 @@ private:
     // silently split or discard a graph-owned command stream.
     uint64 seal_generation{0};
     uint32 managed_recording_lease_count{0};
+    uint64 query_owner_id{0};
     struct ScopeState {
         std::string name;
         float4      color;

--- a/source/runtime/render/rhi/RHICommandList.cpp
+++ b/source/runtime/render/rhi/RHICommandList.cpp
@@ -10,8 +10,37 @@
 #include "rhi/RHIResourceInitilizer.h"
 #include "shader/ShaderPipeline.h"
 #include "shader/ShaderResourceManager.h"
+#include <atomic>
 #include <stdexcept>
 namespace Moer::Render {
+namespace {
+
+std::atomic<uint64> g_query_token_id{1};
+std::atomic<uint64> g_query_owner_id{1};
+
+uint64 NextNonZeroId(std::atomic<uint64>& _counter) noexcept {
+    uint64 id = _counter.fetch_add(1, std::memory_order_relaxed);
+    while (id == 0) {
+        id = _counter.fetch_add(1, std::memory_order_relaxed);
+    }
+    return id;
+}
+
+void InvokeCallbacksNoexcept(Array<std::function<void()>>& _callbacks) noexcept {
+    for (auto& callback : _callbacks) {
+        if (!callback) {
+            continue;
+        }
+        try {
+            callback();
+        } catch (...) {
+            // An invalid query shape is already terminal. Cleanup callbacks
+            // must not replace the structural error reported by Submit().
+        }
+    }
+}
+
+} // namespace
 
 void CommandQueue::Test() {
     ShaderManager manager = ShaderManager::Get();
@@ -33,11 +62,18 @@ void CommandQueue::Test() {
 
 CommandList::CommandList() : CommandList(EQueueType::Graphics) {}
 
-CommandList::CommandList(EQueueType _queue_type) : queue_type(_queue_type) {
+CommandList::CommandList(EQueueType _queue_type) :
+    queue_type(_queue_type),
+    query_owner_id(NextNonZeroId(g_query_owner_id)) {
     assert(
         _queue_type == EQueueType::Graphics || _queue_type == EQueueType::Compute ||
         _queue_type == EQueueType::Copy
     );
+}
+
+CommandList::~CommandList() {
+    RejectPendingSignals();
+    RejectPendingQueries("query command list was destroyed before submission");
 }
 
 CommandList::CommandList(CommandList&& _other) :
@@ -56,10 +92,32 @@ CommandList& CommandList::operator=(CommandList&& _other) {
         );
     }
 
+    // Allocate the replacement generation before changing either list. Once
+    // ownership starts moving, every remaining operation below is noexcept.
+    QueryCancellationDomain moved_from_query_domain{};
+    RejectPendingSignals();
+    QueryCancellationView replaced_query_cancellation =
+        query_cancellation_domain.GetView();
+    Array<QueryToken> replaced_query_tokens = std::move(query_tokens);
+    const QueryPublishBatch replaced_query_batch =
+        QueryBackendAccess::BeginPublishBatch();
+    const bool replaced_cancellation_published =
+        replaced_query_cancellation.PublishCancellation(
+            "query command list was replaced before submission",
+            replaced_query_batch
+        );
+    QueryBackendAccess::PublishErrorsIfPending(
+        replaced_query_tokens,
+        "query command list was replaced before submission",
+        replaced_query_batch
+    );
     commands                    = std::move(_other.commands);
     current_barriers            = _other.current_barriers;
     callbacks                   = std::move(_other.callbacks);
     success_callbacks           = std::move(_other.success_callbacks);
+    query_tokens                = std::move(_other.query_tokens);
+    active_query_stack          = std::move(_other.active_query_stack);
+    query_cancellation_domain   = std::move(_other.query_cancellation_domain);
     signal_events               = std::move(_other.signal_events);
     cached_args                 = std::move(_other.cached_args);
     queue_type                  = _other.queue_type;
@@ -68,13 +126,32 @@ CommandList& CommandList::operator=(CommandList&& _other) {
     seal_generation             = _other.seal_generation;
     scope_stack                 = std::move(_other.scope_stack);
     timestamp_scope_names       = std::move(_other.timestamp_scope_names);
+    query_owner_id              = _other.query_owner_id;
 
     _other.current_barriers          = nullptr;
     _other.translate_execution_class =
         ERHITranslateExecutionClass::Parallel;
     _other.resource_state_ownership =
         ERHIResourceStateOwnership::BackendTracked;
-    _other.seal_generation = 0;
+    _other.seal_generation   = 0;
+    _other.query_owner_id    = NextNonZeroId(g_query_owner_id);
+    _other.query_cancellation_domain = std::move(moved_from_query_domain);
+    _other.query_tokens.clear();
+    _other.active_query_stack.clear();
+    _other.signal_events.clear();
+
+    // Install the complete incoming generation before releasing user Query
+    // callbacks so re-entrant recording cannot be overwritten by this move.
+    if (replaced_cancellation_published) {
+        replaced_query_cancellation.NotifyCancellation(
+            replaced_query_batch
+        );
+    } else {
+        replaced_query_cancellation.NotifyPublishedCancellation();
+    }
+    QueryBackendAccess::NotifyTerminals(
+        replaced_query_tokens, replaced_query_batch
+    );
     return *this;
 }
 
@@ -207,6 +284,20 @@ CmdSubmit CommandList::Submit() {
             "CommandList::Submit is forbidden while graph-managed recording is active"
         );
     }
+    if (!active_query_stack.empty()) {
+        Array<std::function<void()>> cleanup_callbacks =
+            DrainOrdinaryCallbacksForRejection();
+        InvokeCallbacksNoexcept(cleanup_callbacks);
+        throw std::logic_error(
+            "CommandList::Submit rejected an unclosed timestamp query"
+        );
+    }
+    // Construct the next recording generation before transferring callbacks,
+    // signals, and query ownership into CmdSubmit. Allocation failure therefore
+    // leaves the current generation intact and terminalizable.
+    QueryCancellationDomain next_query_domain{};
+    QueryCancellationView submitted_query_cancellation =
+        query_cancellation_domain.GetView();
     ++seal_generation;
     if (!scope_stack.empty()) {
         assert(scope_stack.empty() && "CommandList::Submit called with unclosed GPU marker scopes");
@@ -241,13 +332,31 @@ CmdSubmit CommandList::Submit() {
         std::move(success_callbacks),
         std::move(cached_args)
     );
+    submit.query_tokens = std::move(query_tokens);
     submit.signal_events = std::move(signal_events);
     submit.segments      = std::move(submit_segments);
     submit.translate_execution_class = translate_execution_class;
     submit.resource_state_ownership   = resource_state_ownership;
+    // Opaque shutdown publishes Query Error while deliberately retaining the
+    // callback ticket until the producer reaches an ownership boundary. If
+    // that boundary is Submit(), transfer the complete cancellation token set
+    // and its original ticket into CmdSubmit instead of losing the owner when
+    // this CommandList rotates to its next recording generation.
+    Array<QueryToken> deferred_cancellation_tokens{};
+    const QueryPublishBatch deferred_cancellation_batch =
+        submitted_query_cancellation.TakePublishedCancellationBatch(
+            deferred_cancellation_tokens
+        );
+    if (deferred_cancellation_batch.Valid()) {
+        submit.query_tokens.swap(deferred_cancellation_tokens);
+        submit.query_publish_batch = deferred_cancellation_batch;
+    }
     commands.clear();
     callbacks.clear();
     success_callbacks.clear();
+    query_tokens.clear();
+    active_query_stack.clear();
+    query_cancellation_domain = std::move(next_query_domain);
     signal_events.clear();
     timestamp_scope_names.clear();
     translate_execution_class = ERHITranslateExecutionClass::Parallel;
@@ -261,15 +370,27 @@ Array<std::function<void()>> CommandList::DrainOrdinaryCallbacksForRejection() {
             "CommandList rejection draining is forbidden while graph-managed recording is active"
         );
     }
+    // Do not move cleanup callbacks out until the replacement generation is
+    // guaranteed to exist; rejection must retain its no-throw ownership tail.
+    QueryCancellationDomain next_query_domain{};
     ++seal_generation;
+    RejectPendingSignals();
+    QueryCancellationView rejected_query_cancellation =
+        query_cancellation_domain.GetView();
+    Array<QueryToken> rejected_query_tokens = std::move(query_tokens);
+    const QueryPublishBatch rejected_query_batch =
+        QueryBackendAccess::BeginPublishBatch();
+    const bool rejected_cancellation_published =
+        rejected_query_cancellation.PublishCancellation(
+            "query command list was rejected before completion",
+            rejected_query_batch
+        );
+    QueryBackendAccess::PublishErrorsIfPending(
+        rejected_query_tokens,
+        "query command list was rejected before completion",
+        rejected_query_batch
+    );
     Array<std::function<void()>> cleanup_callbacks = std::move(callbacks);
-
-    for (const SignalEvent& signal : signal_events) {
-        auto* fence = reinterpret_cast<Fence*>(signal.timeline_handle);
-        if (fence != nullptr) {
-            fence->Reject(signal.value);
-        }
-    }
 
     // This is deliberately not implemented in terms of Submit(). A failed
     // producer may leave a partially-built barrier or an unmatched marker;
@@ -279,6 +400,9 @@ Array<std::function<void()>> CommandList::DrainOrdinaryCallbacksForRejection() {
     commands.clear();
     callbacks.clear();
     success_callbacks.clear();
+    query_tokens.clear();
+    active_query_stack.clear();
+    query_cancellation_domain = std::move(next_query_domain);
     signal_events.clear();
     cached_args.clear();
     current_barriers = nullptr;
@@ -288,13 +412,27 @@ Array<std::function<void()>> CommandList::DrainOrdinaryCallbacksForRejection() {
     timestamp_scope_names.clear();
     translate_execution_class = ERHITranslateExecutionClass::Parallel;
     resource_state_ownership  = ERHIResourceStateOwnership::BackendTracked;
+
+    // The fresh generation is fully installed before Query callbacks can
+    // re-enter this CommandList and append new work.
+    if (rejected_cancellation_published) {
+        rejected_query_cancellation.NotifyCancellation(
+            rejected_query_batch
+        );
+    } else {
+        rejected_query_cancellation.NotifyPublishedCancellation();
+    }
+    QueryBackendAccess::NotifyTerminals(
+        rejected_query_tokens, rejected_query_batch
+    );
     return cleanup_callbacks;
 }
 
 bool CommandList::IsEmpty() const {
     return commands.empty() && callbacks.empty() &&
            success_callbacks.empty() && signal_events.empty() &&
-           cached_args.empty();
+           cached_args.empty() && query_tokens.empty() &&
+           active_query_stack.empty();
 }
 
 void CommandList::CopyFrom(BufferView _src, BufferView _dst, std::string_view _name) {
@@ -748,6 +886,140 @@ void CommandList::AddCallback(std::function<void()>&& _callback) {
 
 void CommandList::AddSuccessCallback(std::function<void()>&& _callback) {
     success_callbacks.emplace_back(std::move(_callback));
+}
+
+QueryToken CommandList::BeginTimestampQuery(std::string_view _name) {
+    QueryToken token(
+        NextNonZeroId(g_query_token_id),
+        QueryKind::Timestamp,
+        query_owner_id,
+        _name
+    );
+    query_cancellation_domain.Register(token);
+
+    // Phase 17A does not translate timestamp queries on the Copy queue. Return
+    // a terminal token without manufacturing an untranslatable command.
+    if (queue_type == EQueueType::Copy) {
+        QueryBackendAccess::ResolveErrorIfPending(
+            token,
+            "timestamp queries are unsupported on Copy queues"
+        );
+        return token;
+    }
+
+    auto command = MakeUnique<QueryCmd>(
+        token,
+        QueryCmd::EOp::BeginTimestamp,
+        queue_type,
+        token.Name()
+    );
+    std::function<void()> rejection_fallback = [token] {
+        QueryBackendAccess::ResolveErrorIfPending(
+            token,
+            "timestamp query submission did not reach GPU completion"
+        );
+    };
+
+    commands.reserve(commands.size() + 1);
+    callbacks.reserve(callbacks.size() + 1);
+    query_tokens.reserve(query_tokens.size() + 1);
+    active_query_stack.reserve(active_query_stack.size() + 1);
+
+    const size_t command_count  = commands.size();
+    const size_t callback_count = callbacks.size();
+    const size_t query_count    = query_tokens.size();
+    const size_t stack_depth    = active_query_stack.size();
+    try {
+        commands.emplace_back(std::move(command));
+        callbacks.emplace_back(std::move(rejection_fallback));
+        query_tokens.emplace_back(token);
+        active_query_stack.emplace_back(token);
+    } catch (...) {
+        commands.resize(command_count);
+        callbacks.resize(callback_count);
+        query_tokens.resize(query_count);
+        active_query_stack.resize(stack_depth);
+        QueryBackendAccess::ResolveErrorIfPending(
+            token,
+            "timestamp query recording failed before Begin was published"
+        );
+        throw;
+    }
+    return token;
+}
+
+void CommandList::EndTimestampQuery(const QueryToken& _token) {
+    if (!_token.Valid()) {
+        throw std::invalid_argument(
+            "EndTimestampQuery requires a valid QueryToken"
+        );
+    }
+    if (_token.OwnerId() != query_owner_id) {
+        throw std::invalid_argument(
+            "EndTimestampQuery token belongs to another CommandList"
+        );
+    }
+    if (_token.Kind() != QueryKind::Timestamp) {
+        throw std::invalid_argument(
+            "EndTimestampQuery token has the wrong query kind"
+        );
+    }
+    if (queue_type == EQueueType::Copy) {
+        // BeginTimestampQuery on Copy intentionally records no Begin command.
+        if (_token.GetFuture().Status() == QueryStatus::Error) {
+            return;
+        }
+        throw std::logic_error(
+            "Copy queue timestamp token has no terminal capability result"
+        );
+    }
+    if (active_query_stack.empty()) {
+        throw std::logic_error(
+            "EndTimestampQuery has no matching open query"
+        );
+    }
+    if (active_query_stack.back().Id() != _token.Id()) {
+        throw std::logic_error(
+            "EndTimestampQuery violates strict LIFO query pairing"
+        );
+    }
+
+    auto command = MakeUnique<QueryCmd>(
+        _token,
+        QueryCmd::EOp::EndTimestamp,
+        queue_type,
+        _token.Name()
+    );
+    commands.emplace_back(std::move(command));
+    active_query_stack.pop_back();
+}
+
+void CommandList::RejectPendingQueries(std::string_view _reason) noexcept {
+    const QueryPublishBatch batch = QueryBackendAccess::BeginPublishBatch();
+    QueryCancellationView cancellation =
+        query_cancellation_domain.GetView();
+    Array<QueryToken> tokens = std::move(query_tokens);
+    const bool cancellation_published =
+        cancellation.PublishCancellation(_reason, batch);
+    QueryBackendAccess::PublishErrorsIfPending(
+        tokens, _reason, batch
+    );
+    if (cancellation_published) {
+        cancellation.NotifyCancellation(batch);
+    } else {
+        cancellation.NotifyPublishedCancellation();
+    }
+    QueryBackendAccess::NotifyTerminals(tokens, batch);
+}
+
+void CommandList::RejectPendingSignals() noexcept {
+    for (const SignalEvent& signal : signal_events) {
+        auto* fence = reinterpret_cast<Fence*>(signal.timeline_handle);
+        if (fence != nullptr) {
+            fence->Reject(signal.value);
+        }
+    }
+    signal_events.clear();
 }
 
 void CommandList::Signal(Fence* _fence, uint64 _signal_value) {

--- a/source/runtime/render/rhi/RHIExecutor.cpp
+++ b/source/runtime/render/rhi/RHIExecutor.cpp
@@ -91,7 +91,8 @@ void ResolveRejectedPresent(RHIPresentRequest* _present) noexcept {
 // user code only after all executor locks have been released.
 void FinalizeRejectedSubmissions(
     Array<RHIBackendSubmissionBatchEntry>&& _submits,
-    std::string_view                         _reason
+    std::string_view                         _reason,
+    RHIPresentRequest*                       _present = nullptr
 ) noexcept {
     size_t callback_count       = 0;
     size_t success_callback_cnt = 0;
@@ -134,6 +135,13 @@ void FinalizeRejectedSubmissions(
                 query_batch;
         entry.submit.PublishPendingQueryErrors(_reason, entry_batch);
     }
+
+    // A Present receipt is a public observation boundary for the complete
+    // frontend batch. Publish every sibling Signal and Query terminal state
+    // before waking its waiter, but resolve it before Query/ordinary callback
+    // notification so user code can safely wait for the receipt.
+    ResolveRejectedPresent(_present);
+
     for (RHIBackendSubmissionBatchEntry& entry : _submits) {
         entry.submit.NotifyPendingQueries(
             entry.submit.query_publish_batch.Valid() ?
@@ -214,6 +222,11 @@ void FinalizeRejectedCommandListGroup(
         entry.submit.PublishPendingQueryErrors(_reason, entry_batch);
     }
 
+    // Query state publication is distinct from callback notification. Resolve
+    // Present only after the complete group is terminal, then release Query
+    // callbacks so they may synchronously observe or wait for that receipt.
+    ResolveRejectedPresent(_present);
+
     if (captured_every_generation) {
         for (const size_t source_index : _materialized_source_indices) {
             if (source_index >= _query_cancellations.size()) {
@@ -236,9 +249,6 @@ void FinalizeRejectedCommandListGroup(
         );
     }
 
-    // Present resolution and ordinary callbacks are user-code boundaries.
-    // Enter them only after every signal and Query in the group is terminal.
-    ResolveRejectedPresent(_present);
     FinalizeRejectedSubmissions(std::move(_submits), _reason);
 
     size_t cleanup_callback_count = 0;
@@ -400,8 +410,9 @@ void FinalizeRejectedBackendBatch(
 ) noexcept {
     RHIPresentRequest* present =
         _batch.present.has_value() ? &*_batch.present : nullptr;
-    ResolveRejectedPresent(present);
-    FinalizeRejectedSubmissions(std::move(_batch.submits), _reason);
+    FinalizeRejectedSubmissions(
+        std::move(_batch.submits), _reason, present
+    );
 }
 
 void ReportBackendCreationFailure(
@@ -975,10 +986,10 @@ void RHIExecutor::Submit(
         }
     );
     if (!present_valid || !queues_valid) {
-        ResolveRejectedPresent(_present);
         FinalizeRejectedSubmissions(
             std::move(_submits),
-            present_valid ? "invalid queue" : "invalid Present request"
+            present_valid ? "invalid queue" : "invalid Present request",
+            _present
         );
         return;
     }
@@ -997,10 +1008,10 @@ void RHIExecutor::Submit(
                                              &*payload->present :
                                              nullptr;
             if (_result != ERHIRecordingHandoffResult::Consume) {
-                ResolveRejectedPresent(present);
                 FinalizeRejectedSubmissions(
                     std::move(payload->submits),
-                    "recording handoff is stopped"
+                    "recording handoff is stopped",
+                    present
                 );
                 return;
             }
@@ -1024,10 +1035,10 @@ void RHIExecutor::SubmitReady(
             }
         );
     if (legacy_multi_segment_source) {
-        ResolveRejectedPresent(_present);
         FinalizeRejectedSubmissions(
             std::move(_submits),
-            "legacy backend does not support multi-segment sources"
+            "legacy backend does not support multi-segment sources",
+            _present
         );
         return;
     }
@@ -1043,10 +1054,10 @@ void RHIExecutor::SubmitReady(
             reject_before_dispatch = lifecycle_state != ELifecycleState::Running;
         }
         if (reject_before_dispatch) {
-            ResolveRejectedPresent(_present);
             FinalizeRejectedSubmissions(
                 std::move(_submits),
-                "executor is stopping or stopped"
+                "executor is stopping or stopped",
+                _present
             );
             return;
         }
@@ -1114,10 +1125,10 @@ void RHIExecutor::SubmitReady(
             return;
         }
         if (rejected) {
-            ResolveRejectedPresent(_present);
             FinalizeRejectedSubmissions(
                 std::move(_submits),
-                "executor stopped while publishing Present"
+                "executor stopped while publishing Present",
+                _present
             );
         }
         return;

--- a/source/runtime/render/rhi/RHIExecutor.cpp
+++ b/source/runtime/render/rhi/RHIExecutor.cpp
@@ -55,7 +55,8 @@ GraphEventRef MakeCompletedBackendEvent() {
 
 bool SubmitHasWork(const CmdSubmit& _submit) {
     return !_submit.cmds.empty() || !_submit.callbacks.empty() ||
-           !_submit.success_callbacks.empty() || !_submit.wait_events.empty() ||
+           !_submit.success_callbacks.empty() || !_submit.query_tokens.empty() ||
+           !_submit.wait_events.empty() ||
            !_submit.signal_events.empty() || _submit.b_sync ||
            _submit.b_tick_profiling || _submit.b_delete_resources;
 }
@@ -118,31 +119,27 @@ void FinalizeRejectedSubmissions(
     // callbacks run. Otherwise a later submission can wait forever for a
     // timeline value which this frontend path silently discarded.
     for (RHIBackendSubmissionBatchEntry& entry : _submits) {
-        for (const SignalEvent& signal : entry.submit.signal_events) {
-            auto* fence = reinterpret_cast<Fence*>(signal.timeline_handle);
-            if (fence == nullptr) {
-                continue;
-            }
-            try {
-                fence->Reject(signal.value);
-            } catch (const std::exception& exception) {
-                try {
-                    LOG_ERROR(
-                        "[RHIExecutor] rejected-submit signal terminalization "
-                        "threw: {}",
-                        exception.what()
-                    );
-                } catch (...) {
-                }
-            } catch (...) {
-                try {
-                    LOG_ERROR(
-                        "[RHIExecutor] rejected-submit signal terminalization threw"
-                    );
-                } catch (...) {
-                }
-            }
-        }
+        entry.submit.RejectPendingSignals();
+    }
+
+    // Terminalize every query in the rejected batch before invoking any user
+    // callback. A callback from an earlier submit is allowed to inspect or
+    // wait on a query from a later submit without depending on callback order.
+    const QueryPublishBatch query_batch =
+        QueryBackendAccess::BeginPublishBatch();
+    for (RHIBackendSubmissionBatchEntry& entry : _submits) {
+        const QueryPublishBatch entry_batch =
+            entry.submit.query_publish_batch.Valid() ?
+                entry.submit.query_publish_batch :
+                query_batch;
+        entry.submit.PublishPendingQueryErrors(_reason, entry_batch);
+    }
+    for (RHIBackendSubmissionBatchEntry& entry : _submits) {
+        entry.submit.NotifyPendingQueries(
+            entry.submit.query_publish_batch.Valid() ?
+                entry.submit.query_publish_batch :
+                query_batch
+        );
     }
 
     for (RHIBackendSubmissionBatchEntry& entry : _submits) {
@@ -170,6 +167,150 @@ void FinalizeRejectedSubmissions(
     }
 }
 
+// Value-owned CommandList batches are one frontend transaction just like
+// asynchronously recorded source groups. If sealing one member fails, both
+// already-materialized submits and the untouched suffix must become terminal
+// before any Query or ordinary cleanup callback is allowed to run.
+void FinalizeRejectedCommandListGroup(
+    Array<CommandList>&                         _command_lists,
+    const Array<QueryCancellationView>&         _query_cancellations,
+    const Array<size_t>&                        _materialized_source_indices,
+    Array<RHIBackendSubmissionBatchEntry>&&     _submits,
+    RHIPresentRequest*                          _present,
+    std::string_view                            _reason
+) noexcept {
+    for (RHIBackendSubmissionBatchEntry& entry : _submits) {
+        entry.submit.RejectPendingSignals();
+    }
+    for (CommandList& command_list : _command_lists) {
+        command_list.RejectPendingSignals();
+    }
+
+    const bool captured_every_generation =
+        _query_cancellations.size() == _command_lists.size();
+    const QueryPublishBatch query_batch =
+        QueryBackendAccess::BeginPublishBatch();
+    if (captured_every_generation) {
+        for (const QueryCancellationView& cancellation :
+             _query_cancellations) {
+            (void)cancellation.PublishCancellation(_reason, query_batch);
+        }
+    } else {
+        // Capture can fail only before materialization starts. This fallback
+        // therefore addresses each still-current CommandList generation
+        // without cancelling a fresh post-Submit generation.
+        assert(_submits.empty());
+        for (CommandList& command_list : _command_lists) {
+            (void)command_list.GetQueryCancellationView().PublishCancellation(
+                _reason, query_batch
+            );
+        }
+    }
+    for (RHIBackendSubmissionBatchEntry& entry : _submits) {
+        const QueryPublishBatch entry_batch =
+            entry.submit.query_publish_batch.Valid() ?
+                entry.submit.query_publish_batch :
+                query_batch;
+        entry.submit.PublishPendingQueryErrors(_reason, entry_batch);
+    }
+
+    if (captured_every_generation) {
+        for (const size_t source_index : _materialized_source_indices) {
+            if (source_index >= _query_cancellations.size()) {
+                continue;
+            }
+            const QueryCancellationView& cancellation =
+                _query_cancellations[source_index];
+            cancellation.NotifyCancellation(query_batch);
+            // A generation may already carry an opaque-shutdown ticket owned
+            // by another batch. Signals are terminal now, so release that
+            // original owner as well.
+            cancellation.NotifyPublishedCancellation();
+        }
+    }
+    for (RHIBackendSubmissionBatchEntry& entry : _submits) {
+        entry.submit.NotifyPendingQueries(
+            entry.submit.query_publish_batch.Valid() ?
+                entry.submit.query_publish_batch :
+                query_batch
+        );
+    }
+
+    // Present resolution and ordinary callbacks are user-code boundaries.
+    // Enter them only after every signal and Query in the group is terminal.
+    ResolveRejectedPresent(_present);
+    FinalizeRejectedSubmissions(std::move(_submits), _reason);
+
+    size_t cleanup_callback_count = 0;
+    size_t materialized_cursor    = 0;
+    for (size_t source_index = 0; source_index < _command_lists.size();
+         ++source_index) {
+        if (materialized_cursor < _materialized_source_indices.size() &&
+            _materialized_source_indices[materialized_cursor] ==
+                source_index) {
+            ++materialized_cursor;
+            // Submit() already installed a fresh recording generation.
+            // Query callbacks may have re-entered it above; never drain that
+            // new work as part of rejecting the sealed prior generation.
+            continue;
+        }
+        CommandList& command_list = _command_lists[source_index];
+        try {
+            Array<std::function<void()>> callbacks =
+                command_list.DrainOrdinaryCallbacksForRejection();
+            cleanup_callback_count += callbacks.size();
+            for (std::function<void()>& callback : callbacks) {
+                if (!callback) {
+                    continue;
+                }
+                try {
+                    callback();
+                } catch (const std::exception& exception) {
+                    try {
+                        LOG_ERROR(
+                            "[RHIExecutor] rejected CommandList-group cleanup callback threw: {}",
+                            exception.what()
+                        );
+                    } catch (...) {
+                    }
+                } catch (...) {
+                    try {
+                        LOG_ERROR(
+                            "[RHIExecutor] rejected CommandList-group cleanup callback threw"
+                        );
+                    } catch (...) {
+                    }
+                }
+            }
+        } catch (const std::exception& exception) {
+            try {
+                LOG_ERROR(
+                    "[RHIExecutor] failed to drain rejected CommandList group: {}",
+                    exception.what()
+                );
+            } catch (...) {
+            }
+        } catch (...) {
+            try {
+                LOG_ERROR(
+                    "[RHIExecutor] failed to drain rejected CommandList group"
+                );
+            } catch (...) {
+            }
+        }
+    }
+    try {
+        LOG_ERROR(
+            "[RHIExecutor] rejected {} CommandList source(s): {}; "
+            "cleanup_callbacks={}",
+            _command_lists.size(),
+            _reason,
+            cleanup_callback_count
+        );
+    } catch (...) {
+    }
+}
+
 void RejectRecordingSignalMetadata(
     const Array<RHIRecordingSource>& _sources
 ) noexcept {
@@ -187,6 +328,67 @@ void RejectRecordingSignalMetadata(
             try {
                 point.fence->Reject(point.value);
             } catch (...) {
+            }
+        }
+    }
+}
+
+bool RecordingSourceIsTerminal(const RHIRecordingSource& _source) noexcept {
+    return _source.completion &&
+           _source.completion.Status() != ERHIRecordingStatus::Pending;
+}
+
+// Query cancellation is one transaction across the complete recording group.
+// Terminal sources reject their declared signal values first, then all query
+// states publish Error, and only then may callbacks run. Mutable/opaque sources
+// publish Error so Wait/Get remain bounded during shutdown, but defer callback
+// notification until their CommandList can safely reject its internal signals.
+void TerminalizeRecordingSourceQueries(
+    Array<RHIRecordingSource>& _sources,
+    std::string_view            _reason
+) noexcept {
+    // Status must be sampled exactly once. A producer may cross Pending ->
+    // terminal after this snapshot; treating that source as terminal only in
+    // the notification pass could run its Query callbacks before its still
+    // opaque CommandList signals have been rejected.
+    Array<uint8> terminal_snapshot{};
+    try {
+        terminal_snapshot.resize(_sources.size(), uint8{0});
+    } catch (...) {
+        // Allocation failure is fail-closed: publish every Query Error below,
+        // but defer all callbacks until the owning CommandList is drained or
+        // submitted and can establish signal-before-query ordering.
+        terminal_snapshot.clear();
+    }
+    const bool snapshot_available =
+        terminal_snapshot.size() == _sources.size();
+
+    for (size_t source_index = 0; source_index < _sources.size();
+         ++source_index) {
+        RHIRecordingSource& source = _sources[source_index];
+        const bool terminal = RecordingSourceIsTerminal(source);
+        if (snapshot_available) {
+            terminal_snapshot[source_index] = terminal ? uint8{1} : uint8{0};
+        }
+        if (terminal && source.command_list) {
+            source.command_list->RejectPendingSignals();
+        }
+    }
+
+    const QueryPublishBatch query_batch =
+        QueryBackendAccess::BeginPublishBatch();
+    for (RHIRecordingSource& source : _sources) {
+        (void)source.query_cancellation.PublishCancellation(
+            _reason, query_batch
+        );
+    }
+    if (snapshot_available) {
+        for (size_t source_index = 0; source_index < _sources.size();
+             ++source_index) {
+            if (terminal_snapshot[source_index] != 0) {
+                _sources[source_index].query_cancellation.NotifyCancellation(
+                    query_batch
+                );
             }
         }
     }
@@ -267,6 +469,7 @@ void FinalizeCancelledRecordingSources(
     std::string_view             _reason
 ) {
     RejectRecordingSignalMetadata(_sources);
+    TerminalizeRecordingSourceQueries(_sources, _reason);
     // A source protected by an incomplete recording gate must remain opaque:
     // even reading IsEmpty(), let alone draining callbacks, races its producer.
     // A terminal gate, however, is the ownership handoff point and its ordinary
@@ -358,6 +561,7 @@ void FinalizeFailedRecordingSources(
         );
         return;
     }
+    TerminalizeRecordingSourceQueries(_sources, _reason);
 
     const size_t source_count = _sources.size();
     size_t       cleanup_callback_count = 0;
@@ -462,6 +666,21 @@ public:
             throw std::runtime_error(
                 "legacy RHI backend cannot Present without a graphics queue"
             );
+        }
+
+        // D3D12 intentionally exposes timestamp Query as unsupported in
+        // Phase 17A. Publish the complete legacy batch before the first queue
+        // can retire so an earlier Query callback may safely wait on a later
+        // source; each native Completion packet still owns callback release.
+        const QueryPublishBatch query_batch =
+            QueryBackendAccess::BeginPublishBatch();
+        for (RHIBackendSubmissionBatchEntry& entry : _batch.submits) {
+            if (!entry.submit.query_tokens.empty()) {
+                entry.submit.PublishPendingQueryErrors(
+                    "D3D12 timestamp queries are unsupported",
+                    query_batch
+                );
+            }
         }
 
         // Enqueue's exception contract leaves only the unaccepted suffix in
@@ -575,6 +794,8 @@ private:
         _submit.cmds.clear();
         _submit.callbacks.clear();
         _submit.success_callbacks.clear();
+        _submit.query_tokens.clear();
+        _submit.query_publish_batch = {};
         _submit.cached_args.clear();
         _submit.segments.clear();
         _submit.wait_events.clear();
@@ -932,13 +1153,113 @@ void RHIExecutor::Submit(
     RHIPresentRequest*   _present
 ) {
     Array<RHIBackendSubmissionBatchEntry> submits{};
-    submits.reserve(_command_lists.size());
-    for (CommandList& command_list : _command_lists) {
-        if (command_list.IsEmpty()) {
-            continue;
+    Array<QueryCancellationView> query_cancellations{};
+    Array<size_t> materialized_source_indices{};
+    try {
+        submits.reserve(_command_lists.size());
+        query_cancellations.reserve(_command_lists.size());
+        materialized_source_indices.reserve(_command_lists.size());
+        for (CommandList& command_list : _command_lists) {
+            query_cancellations.emplace_back(
+                command_list.GetQueryCancellationView()
+            );
         }
-        const EQueueType queue = command_list.GetQueueType();
-        submits.emplace_back(queue, command_list.Submit());
+    } catch (const std::exception& exception) {
+        try {
+            LOG_ERROR(
+                "[RHIExecutor] failed to prepare CommandList group: {}",
+                exception.what()
+            );
+        } catch (...) {
+        }
+        FinalizeRejectedCommandListGroup(
+            _command_lists,
+            query_cancellations,
+            materialized_source_indices,
+            std::move(submits),
+            _present,
+            "CommandList group preparation failed"
+        );
+        return;
+    } catch (...) {
+        try {
+            LOG_ERROR("[RHIExecutor] failed to prepare CommandList group");
+        } catch (...) {
+        }
+        FinalizeRejectedCommandListGroup(
+            _command_lists,
+            query_cancellations,
+            materialized_source_indices,
+            std::move(submits),
+            _present,
+            "CommandList group preparation failed"
+        );
+        return;
+    }
+
+    const bool group_valid = std::all_of(
+        _command_lists.begin(),
+        _command_lists.end(),
+        [](const CommandList& command_list) {
+            return IsSubmissionQueue(command_list.GetQueueType()) &&
+                   !command_list.HasOpenTimestampQueries();
+        }
+    );
+    if (!group_valid) {
+        FinalizeRejectedCommandListGroup(
+            _command_lists,
+            query_cancellations,
+            materialized_source_indices,
+            std::move(submits),
+            _present,
+            "CommandList group contains an invalid queue or open timestamp query"
+        );
+        return;
+    }
+
+    try {
+        for (size_t source_index = 0;
+             source_index < _command_lists.size();
+             ++source_index) {
+            CommandList& command_list = _command_lists[source_index];
+            if (command_list.IsEmpty()) {
+                continue;
+            }
+            const EQueueType queue = command_list.GetQueueType();
+            submits.emplace_back(queue, command_list.Submit());
+            materialized_source_indices.emplace_back(source_index);
+        }
+    } catch (const std::exception& exception) {
+        try {
+            LOG_ERROR(
+                "[RHIExecutor] failed to materialize CommandList group: {}",
+                exception.what()
+            );
+        } catch (...) {
+        }
+        FinalizeRejectedCommandListGroup(
+            _command_lists,
+            query_cancellations,
+            materialized_source_indices,
+            std::move(submits),
+            _present,
+            "CommandList group materialization failed"
+        );
+        return;
+    } catch (...) {
+        try {
+            LOG_ERROR("[RHIExecutor] failed to materialize CommandList group");
+        } catch (...) {
+        }
+        FinalizeRejectedCommandListGroup(
+            _command_lists,
+            query_cancellations,
+            materialized_source_indices,
+            std::move(submits),
+            _present,
+            "CommandList group materialization failed"
+        );
+        return;
     }
     Submit(std::move(submits), _flags, _present);
 }
@@ -986,6 +1307,14 @@ void RHIExecutor::SubmitRecording(
         ),
         _sources.end()
     );
+
+    for (RHIRecordingSource& source : _sources) {
+        // Publication seals the current CommandList generation. Never trust a
+        // caller-supplied valid view: it may belong to an earlier Submit() and
+        // would leave the actual producer generation Pending on shutdown.
+        source.query_cancellation =
+            source.command_list->GetQueryCancellationView();
+    }
 
     if (_sources.empty()) {
         Array<RHIBackendSubmissionBatchEntry> submits{};
@@ -1050,20 +1379,34 @@ void RHIExecutor::SubmitRecording(
             submits.reserve(payload->sources.size());
             materialized_source_indices.reserve(payload->sources.size());
             try {
+                // Validate the entire immutable group before transferring the
+                // first source. An unclosed query must not run rejection
+                // callbacks while a later source in the transaction is still
+                // Pending.
+                for (const RHIRecordingSource& source : payload->sources) {
+                    const EQueueType queue =
+                        source.command_list->GetQueueType();
+                    if (!IsSubmissionQueue(queue)) {
+                        throw std::runtime_error(
+                            "recorded source changed to an invalid queue"
+                        );
+                    }
+                    if (source.command_list->HasOpenTimestampQueries()) {
+                        throw std::logic_error(
+                            "recorded source contains an unclosed timestamp query"
+                        );
+                    }
+                }
+
                 // First seal every source. Only after the whole recording
                 // group owns immutable CmdSubmit payloads may metadata be
                 // applied. If a later metadata copy fails, the existing
                 // frontend rejection path can then terminalize callbacks and
                 // rollback payload for the complete materialized group.
                 for (size_t source_index = 0; source_index < payload->sources.size();
-                     ++source_index) {
+                    ++source_index) {
                     RHIRecordingSource& source = payload->sources[source_index];
-                    // Queue type is stable for a CommandList, but validate it
-                    // again at the ownership transition before materializing.
                     const EQueueType queue = source.command_list->GetQueueType();
-                    if (!IsSubmissionQueue(queue)) {
-                        throw std::runtime_error("recorded source changed to an invalid queue");
-                    }
                     const bool metadata_queue_work =
                         !source.submit_metadata.wait_fences.empty() ||
                         !source.submit_metadata.signal_fences.empty();
@@ -1142,16 +1485,38 @@ void RHIExecutor::SubmitRecording(
                     exception.what()
                 );
                 RejectRecordingSignalMetadata(payload->sources);
+                for (RHIBackendSubmissionBatchEntry& entry : submits) {
+                    entry.submit.RejectPendingSignals();
+                }
+                TerminalizeRecordingSourceQueries(
+                    payload->sources,
+                    "recording source finalization failed"
+                );
                 FinalizeRejectedSubmissions(
                     std::move(submits),
+                    "recording source finalization failed"
+                );
+                FinalizeFailedRecordingSources(
+                    std::move(payload->sources),
                     "recording source finalization failed"
                 );
                 return;
             } catch (...) {
                 LOG_ERROR("[RHIExecutor] failed to materialize recording sources");
                 RejectRecordingSignalMetadata(payload->sources);
+                for (RHIBackendSubmissionBatchEntry& entry : submits) {
+                    entry.submit.RejectPendingSignals();
+                }
+                TerminalizeRecordingSourceQueries(
+                    payload->sources,
+                    "recording source finalization failed"
+                );
                 FinalizeRejectedSubmissions(
                     std::move(submits),
+                    "recording source finalization failed"
+                );
+                FinalizeFailedRecordingSources(
+                    std::move(payload->sources),
                     "recording source finalization failed"
                 );
                 return;

--- a/source/runtime/render/rhi/RHIExecutor.h
+++ b/source/runtime/render/rhi/RHIExecutor.h
@@ -45,6 +45,10 @@ struct RHIRecordingSource {
     RHIRecordingGateView         completion{};
     RHIRecordingGateView         commit{};
     RHIRecordingSubmitMetadata   submit_metadata{};
+    // Stable, thread-safe cancellation seam for the CommandList generation
+    // being recorded. Shutdown may cancel pending query futures through this
+    // view without reading or destroying a producer-owned command stream.
+    QueryCancellationView        query_cancellation{};
 };
 
 class RENDER_API RHIExecutor {

--- a/source/runtime/render/rhi/RHIImpl.h
+++ b/source/runtime/render/rhi/RHIImpl.h
@@ -1680,6 +1680,53 @@ private:
     UnorderedMap<uint64, uint> related_geometries;
 };
 
+// Backend-neutral timestamp query boundary. The token is copied into both
+// boundaries so every translated command buffer retains the same completion
+// identity independently of CommandList/CmdSubmit movement.
+struct QueryCmd : public Command {
+public:
+    enum class EOp : uint8_t {
+        BeginTimestamp = 0,
+        EndTimestamp   = 1,
+    };
+
+    QueryCmd(
+        QueryToken       _token,
+        EOp              _op,
+        EQueueType       _queue_type,
+        std::string_view _name = typenames[uint(EType::Query)]
+    ) :
+        Command(EType::Query, _name),
+        token(std::move(_token)),
+        op(_op),
+        queue_type(_queue_type) {}
+
+    EQueueType GetQueueType() const override {
+        return queue_type;
+    }
+
+    const QueryToken& Token() const noexcept {
+        return token;
+    }
+
+    EOp Op() const noexcept {
+        return op;
+    }
+
+    bool IsBegin() const noexcept {
+        return op == EOp::BeginTimestamp;
+    }
+
+    bool IsEnd() const noexcept {
+        return op == EOp::EndTimestamp;
+    }
+
+private:
+    QueryToken token{};
+    EOp        op{EOp::BeginTimestamp};
+    EQueueType queue_type{EQueueType::Graphics};
+};
+
 //command for push/pop debug scope
 struct ScopeCmd : public Command {
 public:

--- a/source/runtime/render/rhi/RHIQuery.cpp
+++ b/source/runtime/render/rhi/RHIQuery.cpp
@@ -1,0 +1,557 @@
+#include "rhi/RHIQuery.h"
+
+#include "misc/STL.h"
+
+#include <atomic>
+#include <condition_variable>
+#include <mutex>
+#include <utility>
+
+namespace Moer::Render {
+namespace {
+
+std::atomic<std::uint64_t> g_query_publish_batch_id{1};
+
+std::uint64_t NextQueryPublishBatchId() noexcept {
+    std::uint64_t id =
+        g_query_publish_batch_id.fetch_add(1, std::memory_order_relaxed);
+    while (id == 0) {
+        id = g_query_publish_batch_id.fetch_add(1, std::memory_order_relaxed);
+    }
+    return id;
+}
+
+QueryResult InvalidFutureResult() {
+    QueryResult result{};
+    result.status       = QueryStatus::Error;
+    result.error_reason = "invalid query future";
+    return result;
+}
+
+void InvokeCallbackNoexcept(
+    const QueryFuture::Callback& _callback,
+    const QueryResult&           _result
+) noexcept {
+    if (!_callback) {
+        return;
+    }
+    try {
+        _callback(_result);
+    } catch (...) {
+        // Completion and rejection owners must remain alive even when client
+        // notification code is faulty.
+    }
+}
+
+} // namespace
+
+struct QueryFuture::SharedState {
+    mutable std::mutex      mutex{};
+    std::condition_variable cv{};
+    QueryResult             result{};
+    Array<Callback>         callbacks{};
+    bool                    notification_released{false};
+    std::uint64_t           notification_owner{0};
+};
+
+struct QueryCancellationState {
+    mutable std::mutex mutex{};
+    bool               cancelled{false};
+    std::string        reason{};
+    Array<QueryToken>  tokens{};
+    std::uint64_t      notification_owner{0};
+};
+
+QueryFuture::QueryFuture(std::shared_ptr<SharedState> _state) noexcept :
+    state_(std::move(_state)) {}
+
+QueryFuture QueryFuture::Create(
+    QueryKind        _kind,
+    std::uint64_t    _query_id,
+    std::string_view _name
+) {
+    auto state             = std::make_shared<SharedState>();
+    state->result.kind     = _kind;
+    state->result.query_id = _query_id;
+    state->result.name     = _name;
+    return QueryFuture(std::move(state));
+}
+
+bool QueryFuture::Valid() const noexcept {
+    return static_cast<bool>(state_);
+}
+
+bool QueryFuture::IsReady() const noexcept {
+    if (!state_) {
+        return false;
+    }
+    std::scoped_lock lock(state_->mutex);
+    return state_->result.status != QueryStatus::Pending;
+}
+
+QueryStatus QueryFuture::Status() const noexcept {
+    if (!state_) {
+        return QueryStatus::Error;
+    }
+    std::scoped_lock lock(state_->mutex);
+    return state_->result.status;
+}
+
+void QueryFuture::Wait() const {
+    if (!state_) {
+        return;
+    }
+    std::unique_lock lock(state_->mutex);
+    state_->cv.wait(lock, [state = state_] {
+        return state->result.status != QueryStatus::Pending;
+    });
+}
+
+bool QueryFuture::WaitFor(std::chrono::nanoseconds _timeout) const {
+    if (!state_) {
+        return false;
+    }
+    std::unique_lock lock(state_->mutex);
+    return state_->cv.wait_for(lock, _timeout, [state = state_] {
+        return state->result.status != QueryStatus::Pending;
+    });
+}
+
+QueryResult QueryFuture::Get() const {
+    if (!state_) {
+        return InvalidFutureResult();
+    }
+    Wait();
+    std::scoped_lock lock(state_->mutex);
+    return state_->result;
+}
+
+std::optional<QueryResult> QueryFuture::TryGet() const {
+    if (!state_) {
+        return InvalidFutureResult();
+    }
+    std::scoped_lock lock(state_->mutex);
+    if (state_->result.status == QueryStatus::Pending) {
+        return std::nullopt;
+    }
+    return state_->result;
+}
+
+void QueryFuture::Then(Callback _callback) const {
+    // A callback may release the QueryFuture/QueryToken that invoked it. Keep
+    // the shared state alive until the callback returns so its QueryResult
+    // reference and any later callbacks in this notification remain valid.
+    const std::shared_ptr<SharedState> state = state_;
+    if (!state || !_callback) {
+        return;
+    }
+
+    bool invoke_now = false;
+    {
+        std::scoped_lock lock(state->mutex);
+        if (state->result.status == QueryStatus::Pending ||
+            !state->notification_released) {
+            state->callbacks.emplace_back(std::move(_callback));
+        } else {
+            invoke_now = true;
+        }
+    }
+    if (invoke_now) {
+        InvokeCallbackNoexcept(_callback, state->result);
+    }
+}
+
+bool QueryFuture::PublishTimestamp(
+    const TimestampQueryResult& _result,
+    std::uint64_t               _notification_owner
+) const noexcept {
+    if (!state_ || _notification_owner == 0) {
+        return false;
+    }
+
+    {
+        std::scoped_lock lock(state_->mutex);
+        if (state_->result.status != QueryStatus::Pending) {
+            return false;
+        }
+        state_->result.status = QueryStatus::Ready;
+        state_->result.payload.emplace<TimestampQueryResult>(_result);
+        state_->result.error_reason.clear();
+        state_->notification_released = false;
+        state_->notification_owner    = _notification_owner;
+    }
+    // Wait/Get observe terminal state independently from callback ownership.
+    // In particular, opaque shutdown may defer user callbacks until the
+    // producer retires while still guaranteeing bounded waiters.
+    state_->cv.notify_all();
+    return true;
+}
+
+bool QueryFuture::PublishError(
+    std::string_view _reason,
+    std::uint64_t    _notification_owner
+) const noexcept {
+    if (!state_ || _notification_owner == 0) {
+        return false;
+    }
+
+    std::string reason{};
+    try {
+        reason.assign(_reason);
+    } catch (...) {
+        // The state must still become terminal under memory pressure. An empty
+        // reason remains distinguishable from a successful result by status.
+    }
+
+    {
+        std::scoped_lock lock(state_->mutex);
+        if (state_->result.status != QueryStatus::Pending) {
+            return false;
+        }
+        state_->result.status = QueryStatus::Error;
+        state_->result.payload.emplace<std::monostate>();
+        state_->result.error_reason = std::move(reason);
+        state_->notification_released = false;
+        state_->notification_owner    = _notification_owner;
+    }
+    state_->cv.notify_all();
+    return true;
+}
+
+void QueryFuture::NotifyTerminal(
+    std::uint64_t _notification_owner
+) const noexcept {
+    const std::shared_ptr<SharedState> state = state_;
+    if (!state || _notification_owner == 0) {
+        return;
+    }
+
+    Array<Callback> callbacks{};
+    {
+        std::scoped_lock lock(state->mutex);
+        if (state->result.status == QueryStatus::Pending ||
+            state->notification_released ||
+            state->notification_owner != _notification_owner) {
+            return;
+        }
+        state->notification_released = true;
+        callbacks = std::move(state->callbacks);
+    }
+    for (const Callback& callback : callbacks) {
+        InvokeCallbackNoexcept(callback, state->result);
+    }
+}
+
+QueryToken::QueryToken(
+    std::uint64_t    _id,
+    QueryKind        _kind,
+    std::uint64_t    _owner_id,
+    std::string_view _name
+) :
+    id_(_id),
+    kind_(_kind),
+    owner_id_(_owner_id),
+    name_(std::make_shared<const std::string>(_name)),
+    future_(QueryFuture::Create(_kind, _id, *name_)) {}
+
+bool QueryToken::Valid() const noexcept {
+    return id_ != 0 && owner_id_ != 0 && future_.Valid();
+}
+
+bool QueryToken::IsReady() const noexcept {
+    return future_.IsReady();
+}
+
+std::uint64_t QueryToken::Id() const noexcept {
+    return id_;
+}
+
+QueryKind QueryToken::Kind() const noexcept {
+    return kind_;
+}
+
+const std::string& QueryToken::Name() const noexcept {
+    static const std::string empty_name{};
+    return name_ ? *name_ : empty_name;
+}
+
+QueryFuture QueryToken::GetFuture() const noexcept {
+    return future_;
+}
+
+void QueryToken::Then(QueryFuture::Callback _callback) const {
+    future_.Then(std::move(_callback));
+}
+
+bool QueryToken::PublishTimestamp(
+    const TimestampQueryResult& _result,
+    std::uint64_t               _notification_owner
+) const noexcept {
+    if (!Valid() || kind_ != QueryKind::Timestamp) {
+        return false;
+    }
+    return future_.PublishTimestamp(_result, _notification_owner);
+}
+
+bool QueryToken::PublishErrorIfPending(
+    std::string_view _reason,
+    std::uint64_t    _notification_owner
+) const noexcept {
+    if (!Valid()) {
+        return false;
+    }
+    return future_.PublishError(_reason, _notification_owner);
+}
+
+void QueryToken::NotifyTerminal(
+    std::uint64_t _notification_owner
+) const noexcept {
+    future_.NotifyTerminal(_notification_owner);
+}
+
+std::uint64_t QueryToken::OwnerId() const noexcept {
+    return owner_id_;
+}
+
+QueryPublishBatch QueryBackendAccess::BeginPublishBatch() noexcept {
+    return QueryPublishBatch(NextQueryPublishBatchId());
+}
+
+bool QueryBackendAccess::ResolveTimestamp(
+    const QueryToken&           _token,
+    const TimestampQueryResult& _result
+) noexcept {
+    const QueryPublishBatch batch = BeginPublishBatch();
+    const bool published =
+        _token.PublishTimestamp(_result, batch.notification_owner_);
+    if (published) {
+        _token.NotifyTerminal(batch.notification_owner_);
+    }
+    return published;
+}
+
+bool QueryBackendAccess::ResolveErrorIfPending(
+    const QueryToken& _token,
+    std::string_view  _reason
+) noexcept {
+    const QueryPublishBatch batch = BeginPublishBatch();
+    const bool published =
+        _token.PublishErrorIfPending(_reason, batch.notification_owner_);
+    if (published) {
+        _token.NotifyTerminal(batch.notification_owner_);
+    }
+    return published;
+}
+
+bool QueryBackendAccess::PublishTimestamp(
+    const QueryToken&           _token,
+    const TimestampQueryResult& _result,
+    QueryPublishBatch           _batch
+) noexcept {
+    return _token.PublishTimestamp(_result, _batch.notification_owner_);
+}
+
+bool QueryBackendAccess::PublishErrorIfPending(
+    const QueryToken& _token,
+    std::string_view  _reason,
+    QueryPublishBatch _batch
+) noexcept {
+    return _token.PublishErrorIfPending(
+        _reason, _batch.notification_owner_
+    );
+}
+
+void QueryBackendAccess::NotifyTerminal(
+    const QueryToken& _token,
+    QueryPublishBatch _batch
+) noexcept {
+    _token.NotifyTerminal(_batch.notification_owner_);
+}
+
+void QueryBackendAccess::PublishErrorsIfPending(
+    std::span<const QueryToken> _tokens,
+    std::string_view            _reason,
+    QueryPublishBatch           _batch
+) noexcept {
+    for (const QueryToken& token : _tokens) {
+        PublishErrorIfPending(token, _reason, _batch);
+    }
+}
+
+void QueryBackendAccess::NotifyTerminals(
+    std::span<const QueryToken> _tokens,
+    QueryPublishBatch           _batch
+) noexcept {
+    for (const QueryToken& token : _tokens) {
+        NotifyTerminal(token, _batch);
+    }
+}
+
+void QueryBackendAccess::ResolveErrorsIfPending(
+    std::span<const QueryToken> _tokens,
+    std::string_view            _reason
+) noexcept {
+    const QueryPublishBatch batch = BeginPublishBatch();
+    PublishErrorsIfPending(_tokens, _reason, batch);
+    NotifyTerminals(_tokens, batch);
+}
+
+QueryCancellationView::QueryCancellationView(
+    std::shared_ptr<QueryCancellationState> _state
+) noexcept :
+    state_(std::move(_state)) {}
+
+bool QueryCancellationView::Valid() const noexcept {
+    return static_cast<bool>(state_);
+}
+
+bool QueryCancellationView::IsCancelled() const noexcept {
+    if (!state_) {
+        return false;
+    }
+    std::scoped_lock lock(state_->mutex);
+    return state_->cancelled;
+}
+
+bool QueryCancellationView::Cancel(std::string_view _reason) const noexcept {
+    const QueryPublishBatch batch = QueryBackendAccess::BeginPublishBatch();
+    if (!PublishCancellation(_reason, batch)) {
+        return false;
+    }
+    NotifyCancellation(batch);
+    return true;
+}
+
+bool QueryCancellationView::PublishCancellation(
+    std::string_view  _reason,
+    QueryPublishBatch _batch
+) const noexcept {
+    if (!state_ || !_batch.Valid()) {
+        return false;
+    }
+
+    std::string reason{};
+    try {
+        reason.assign(_reason);
+    } catch (...) {
+    }
+
+    {
+        std::scoped_lock lock(state_->mutex);
+        if (state_->cancelled) {
+            return false;
+        }
+        state_->cancelled = true;
+        state_->reason    = std::move(reason);
+        state_->notification_owner = _batch.notification_owner_;
+        QueryBackendAccess::PublishErrorsIfPending(
+            state_->tokens, state_->reason, _batch
+        );
+    }
+    return true;
+}
+
+void QueryCancellationView::NotifyCancellation(
+    QueryPublishBatch _batch
+) const noexcept {
+    if (!state_ || !_batch.Valid()) {
+        return;
+    }
+
+    Array<QueryToken> tokens{};
+    {
+        std::scoped_lock lock(state_->mutex);
+        if (state_->notification_owner != _batch.notification_owner_) {
+            return;
+        }
+        state_->notification_owner = 0;
+        tokens = std::move(state_->tokens);
+    }
+    QueryBackendAccess::NotifyTerminals(tokens, _batch);
+}
+
+void QueryCancellationView::NotifyPublishedCancellation() const noexcept {
+    if (!state_) {
+        return;
+    }
+
+    Array<QueryToken> tokens{};
+    std::uint64_t     notification_owner = 0;
+    {
+        std::scoped_lock lock(state_->mutex);
+        notification_owner = state_->notification_owner;
+        if (notification_owner == 0) {
+            return;
+        }
+        state_->notification_owner = 0;
+        tokens = std::move(state_->tokens);
+    }
+    QueryBackendAccess::NotifyTerminals(
+        tokens, QueryPublishBatch(notification_owner)
+    );
+}
+
+QueryPublishBatch QueryCancellationView::TakePublishedCancellationBatch(
+    Array<QueryToken>& _tokens
+) const noexcept {
+    if (!state_) {
+        return {};
+    }
+
+    std::uint64_t notification_owner = 0;
+    {
+        std::scoped_lock lock(state_->mutex);
+        notification_owner = state_->notification_owner;
+        if (notification_owner == 0) {
+            return {};
+        }
+        state_->notification_owner = 0;
+        _tokens.clear();
+        _tokens.swap(state_->tokens);
+    }
+    return QueryPublishBatch(notification_owner);
+}
+
+QueryCancellationDomain::QueryCancellationDomain() :
+    state_(std::make_shared<QueryCancellationState>()) {}
+
+QueryCancellationView QueryCancellationDomain::GetView() const noexcept {
+    return QueryCancellationView(state_);
+}
+
+bool QueryCancellationDomain::IsCancelled() const noexcept {
+    return GetView().IsCancelled();
+}
+
+void QueryCancellationDomain::Register(const QueryToken& _token) const {
+    if (!_token.Valid() || !state_) {
+        return;
+    }
+
+    bool             cancel_now = false;
+    std::string_view reason{};
+    {
+        std::scoped_lock lock(state_->mutex);
+        if (state_->cancelled) {
+            if (state_->notification_owner != 0) {
+                const QueryPublishBatch deferred_batch(
+                    state_->notification_owner
+                );
+                state_->tokens.emplace_back(_token);
+                QueryBackendAccess::PublishErrorIfPending(
+                    _token, state_->reason, deferred_batch
+                );
+                return;
+            }
+            cancel_now = true;
+            reason     = state_->reason;
+        } else {
+            state_->tokens.emplace_back(_token);
+        }
+    }
+    if (cancel_now) {
+        QueryBackendAccess::ResolveErrorIfPending(_token, reason);
+    }
+}
+
+} // namespace Moer::Render

--- a/source/runtime/render/rhi/RHIQuery.cpp
+++ b/source/runtime/render/rhi/RHIQuery.cpp
@@ -57,6 +57,7 @@ struct QueryFuture::SharedState {
 struct QueryCancellationState {
     mutable std::mutex mutex{};
     bool               cancelled{false};
+    bool               sealed{false};
     std::string        reason{};
     Array<QueryToken>  tokens{};
     std::uint64_t      notification_owner{0};
@@ -415,11 +416,11 @@ bool QueryCancellationView::IsCancelled() const noexcept {
 
 bool QueryCancellationView::Cancel(std::string_view _reason) const noexcept {
     const QueryPublishBatch batch = QueryBackendAccess::BeginPublishBatch();
-    if (!PublishCancellation(_reason, batch)) {
-        return false;
-    }
-    NotifyCancellation(batch);
-    return true;
+    // Opaque shutdown may call Cancel from a thread that does not own the
+    // mutable producer. Publish Error immediately so waiters cannot hang, but
+    // leave callback notification with the CommandList generation's eventual
+    // submission/destruction/rejection owner.
+    return PublishCancellation(_reason, batch);
 }
 
 bool QueryCancellationView::PublishCancellation(
@@ -438,7 +439,7 @@ bool QueryCancellationView::PublishCancellation(
 
     {
         std::scoped_lock lock(state_->mutex);
-        if (state_->cancelled) {
+        if (state_->cancelled || state_->sealed) {
             return false;
         }
         state_->cancelled = true;
@@ -501,8 +502,13 @@ QueryPublishBatch QueryCancellationView::TakePublishedCancellationBatch(
     std::uint64_t notification_owner = 0;
     {
         std::scoped_lock lock(state_->mutex);
+        state_->sealed = true;
         notification_owner = state_->notification_owner;
         if (notification_owner == 0) {
+            // CmdSubmit already owns the canonical token array. Do not let a
+            // stale cancellation view retain a second copy after ownership
+            // has crossed the recording boundary.
+            state_->tokens.clear();
             return {};
         }
         state_->notification_owner = 0;

--- a/source/runtime/render/rhi/RHIQuery.h
+++ b/source/runtime/render/rhi/RHIQuery.h
@@ -229,8 +229,10 @@ public:
 struct QueryCancellationState;
 class CommandList;
 
-// Copyable shutdown handle for one immutable CommandList generation. Views
-// remain valid after the originating CommandList submits, drains, or moves.
+// Copyable shutdown handle for one CommandList generation. Views remain valid
+// for identity/diagnostics after the originating list submits or drains, but
+// Cancel can win only while that generation is still owned by a mutable
+// producer.
 class RENDER_API QueryCancellationView {
 public:
     QueryCancellationView() = default;
@@ -238,13 +240,19 @@ public:
     [[nodiscard]] bool Valid() const noexcept;
     [[nodiscard]] bool IsCancelled() const noexcept;
 
-    // Returns true only for the thread that performs the one-shot transition.
-    // All registered tokens become Error before this function returns.
+    // Returns true only for the thread that performs the one-shot transition;
+    // stale views return false once Submit has sealed the generation.
+    // All registered tokens become Error before this function returns, but
+    // user callbacks remain deferred until the owning CommandList reaches a
+    // submission/destruction/rejection boundary. This makes the view safe for
+    // opaque-producer shutdown without releasing client code on the arbitrary
+    // cancellation thread.
     bool Cancel(std::string_view _reason = "query generation was cancelled") const noexcept;
 
     // Cross-source rejection uses the same two-phase transaction as native
     // completion: publish every cancellation first, then release callbacks for
-    // every source. The convenience Cancel() performs both phases locally.
+    // every source. These transaction calls are internal ownership seams;
+    // Cancel() deliberately performs only the publish phase.
     bool PublishCancellation(
         std::string_view _reason,
         QueryPublishBatch _batch
@@ -259,7 +267,8 @@ public:
     void NotifyPublishedCancellation() const noexcept;
 
 private:
-    // Transfers a deferred cancellation transaction into an immutable submit.
+    // Seals this generation and transfers a deferred cancellation transaction
+    // into an immutable submit.
     // A valid result owns every token registered with this generation; the
     // caller must retain that token set and use the returned batch when it
     // eventually releases terminal callbacks.

--- a/source/runtime/render/rhi/RHIQuery.h
+++ b/source/runtime/render/rhi/RHIQuery.h
@@ -1,0 +1,302 @@
+#ifndef MOER_ENGINE_RHI_QUERY_H
+#define MOER_ENGINE_RHI_QUERY_H
+
+#include "RenderAPI.h"
+#include "misc/STL.h"
+
+#include <chrono>
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <optional>
+#include <span>
+#include <string>
+#include <string_view>
+#include <variant>
+
+namespace Moer::Render {
+
+enum class QueryKind : std::uint8_t {
+    Timestamp = 0,
+    // Reserved for the next query slice. Phase 17A intentionally exposes no
+    // occlusion-recording API until its backend contract is implemented.
+    Occlusion = 1,
+};
+
+enum class QueryStatus : std::uint8_t {
+    Pending = 0,
+    Ready   = 1,
+    Error   = 2,
+};
+
+struct TimestampQueryResult {
+    std::uint64_t begin_tick{0};
+    std::uint64_t end_tick{0};
+    std::uint32_t valid_bits{0};
+    double        tick_period_ns{0.0};
+    double        duration_ns{0.0};
+};
+
+struct OcclusionQueryResult {
+    std::uint64_t sample_count{0};
+    bool          visible{false};
+};
+
+struct QueryResult {
+    QueryKind   kind{QueryKind::Timestamp};
+    QueryStatus status{QueryStatus::Pending};
+    std::uint64_t query_id{0};
+    std::string name{};
+    std::variant<std::monostate, TimestampQueryResult, OcclusionQueryResult> payload{};
+    std::string error_reason{};
+};
+
+class QueryToken;
+
+// Copyable handle to a single terminal query result. Resolution is one-shot:
+// Pending may transition to Ready or Error exactly once and never changes
+// afterwards.
+class RENDER_API QueryFuture {
+    struct SharedState;
+
+public:
+    using Callback = std::function<void(const QueryResult&)>;
+
+    QueryFuture() = default;
+
+    [[nodiscard]] bool Valid() const noexcept;
+    [[nodiscard]] bool IsReady() const noexcept;
+    [[nodiscard]] QueryStatus Status() const noexcept;
+
+    void Wait() const;
+    [[nodiscard]] bool WaitFor(std::chrono::nanoseconds _timeout) const;
+
+    template<typename Rep, typename Period>
+    [[nodiscard]] bool WaitFor(std::chrono::duration<Rep, Period> _timeout) const {
+        return WaitFor(std::chrono::duration_cast<std::chrono::nanoseconds>(_timeout));
+    }
+
+    [[nodiscard]] QueryResult Get() const;
+    [[nodiscard]] std::optional<QueryResult> TryGet() const;
+
+    // Every successfully registered callback is invoked exactly once. User
+    // callback exceptions are contained and never escape the resolver or this
+    // function.
+    void Then(Callback _callback) const;
+
+private:
+    explicit QueryFuture(std::shared_ptr<SharedState> _state) noexcept;
+
+    static QueryFuture Create(
+        QueryKind       _kind,
+        std::uint64_t   _query_id,
+        std::string_view _name
+    );
+
+    bool PublishTimestamp(
+        const TimestampQueryResult& _result,
+        std::uint64_t               _notification_owner
+    ) const noexcept;
+    bool PublishError(
+        std::string_view _reason,
+        std::uint64_t    _notification_owner
+    ) const noexcept;
+    void NotifyTerminal(std::uint64_t _notification_owner) const noexcept;
+
+    std::shared_ptr<SharedState> state_{};
+
+    friend class QueryToken;
+};
+
+// Stable query identity carried by CommandList, CmdSubmit, QueryCmd and user
+// futures. The Resolve* functions form the backend/completion-owner seam; they
+// are idempotent and cannot overwrite an existing terminal result.
+class RENDER_API QueryToken {
+public:
+    QueryToken() = default;
+
+    [[nodiscard]] bool Valid() const noexcept;
+    [[nodiscard]] bool IsReady() const noexcept;
+    [[nodiscard]] std::uint64_t Id() const noexcept;
+    [[nodiscard]] QueryKind Kind() const noexcept;
+    [[nodiscard]] const std::string& Name() const noexcept;
+    [[nodiscard]] QueryFuture GetFuture() const noexcept;
+
+    void Then(QueryFuture::Callback _callback) const;
+
+private:
+    QueryToken(
+        std::uint64_t   _id,
+        QueryKind       _kind,
+        std::uint64_t   _owner_id,
+        std::string_view _name
+    );
+
+    [[nodiscard]] std::uint64_t OwnerId() const noexcept;
+    bool PublishTimestamp(
+        const TimestampQueryResult& _result,
+        std::uint64_t               _notification_owner
+    ) const noexcept;
+    bool PublishErrorIfPending(
+        std::string_view _reason,
+        std::uint64_t    _notification_owner
+    ) const noexcept;
+    void NotifyTerminal(std::uint64_t _notification_owner) const noexcept;
+
+    std::uint64_t id_{0};
+    QueryKind     kind_{QueryKind::Timestamp};
+    std::uint64_t owner_id_{0};
+    std::shared_ptr<const std::string> name_{};
+    QueryFuture   future_{};
+
+    friend class CommandList;
+    friend class QueryBackendAccess;
+};
+
+// Opaque ownership ticket for a terminalization transaction. Only the
+// transaction that wins Pending -> Ready/Error may release callbacks. This
+// preserves Completion-thread ownership when GPU completion races shutdown or
+// frontend rejection.
+class RENDER_API QueryPublishBatch {
+public:
+    QueryPublishBatch() = default;
+
+    [[nodiscard]] bool Valid() const noexcept {
+        return notification_owner_ != 0;
+    }
+
+private:
+    explicit QueryPublishBatch(std::uint64_t _notification_owner) noexcept :
+        notification_owner_(_notification_owner) {}
+
+    std::uint64_t notification_owner_{0};
+
+    friend class QueryBackendAccess;
+    friend class QueryCancellationDomain;
+    friend class QueryCancellationView;
+};
+
+// Narrow internal seam used by native query runtimes, completion ownership,
+// and terminal rejection paths. QueryToken intentionally exposes no direct
+// Ready/Error mutation to normal query consumers.
+class RENDER_API QueryBackendAccess final {
+public:
+    [[nodiscard]] static QueryPublishBatch BeginPublishBatch() noexcept;
+
+    // Single-token convenience APIs publish and notify immediately.
+    static bool ResolveTimestamp(
+        const QueryToken&           _token,
+        const TimestampQueryResult& _result
+    ) noexcept;
+    static bool ResolveErrorIfPending(
+        const QueryToken& _token,
+        std::string_view  _reason
+    ) noexcept;
+
+    // Batch owners use a two-phase transition: publish every result first,
+    // then notify. This prevents one query callback from blocking on another
+    // query in the same completion/cancellation transaction while it is still
+    // Pending.
+    static bool PublishTimestamp(
+        const QueryToken&           _token,
+        const TimestampQueryResult& _result,
+        QueryPublishBatch           _batch
+    ) noexcept;
+    static bool PublishErrorIfPending(
+        const QueryToken& _token,
+        std::string_view  _reason,
+        QueryPublishBatch _batch
+    ) noexcept;
+    static void NotifyTerminal(
+        const QueryToken& _token,
+        QueryPublishBatch _batch
+    ) noexcept;
+    static void PublishErrorsIfPending(
+        std::span<const QueryToken> _tokens,
+        std::string_view            _reason,
+        QueryPublishBatch           _batch
+    ) noexcept;
+    static void NotifyTerminals(
+        std::span<const QueryToken> _tokens,
+        QueryPublishBatch           _batch
+    ) noexcept;
+    static void ResolveErrorsIfPending(
+        std::span<const QueryToken> _tokens,
+        std::string_view            _reason
+    ) noexcept;
+};
+
+struct QueryCancellationState;
+class CommandList;
+
+// Copyable shutdown handle for one immutable CommandList generation. Views
+// remain valid after the originating CommandList submits, drains, or moves.
+class RENDER_API QueryCancellationView {
+public:
+    QueryCancellationView() = default;
+
+    [[nodiscard]] bool Valid() const noexcept;
+    [[nodiscard]] bool IsCancelled() const noexcept;
+
+    // Returns true only for the thread that performs the one-shot transition.
+    // All registered tokens become Error before this function returns.
+    bool Cancel(std::string_view _reason = "query generation was cancelled") const noexcept;
+
+    // Cross-source rejection uses the same two-phase transaction as native
+    // completion: publish every cancellation first, then release callbacks for
+    // every source. The convenience Cancel() performs both phases locally.
+    bool PublishCancellation(
+        std::string_view _reason,
+        QueryPublishBatch _batch
+    ) const noexcept;
+    void NotifyCancellation(QueryPublishBatch _batch) const noexcept;
+
+    // Used by the owning CommandList after an opaque shutdown cancellation.
+    // Shutdown may publish Error without running callbacks while the producer
+    // is still mutable; once the producer reaches submission, destruction, or
+    // rejection it transfers or releases the stored notification owner behind
+    // its signals.
+    void NotifyPublishedCancellation() const noexcept;
+
+private:
+    // Transfers a deferred cancellation transaction into an immutable submit.
+    // A valid result owns every token registered with this generation; the
+    // caller must retain that token set and use the returned batch when it
+    // eventually releases terminal callbacks.
+    [[nodiscard]] QueryPublishBatch TakePublishedCancellationBatch(
+        Array<QueryToken>& _tokens
+    ) const noexcept;
+
+    explicit QueryCancellationView(
+        std::shared_ptr<QueryCancellationState> _state
+    ) noexcept;
+
+    std::shared_ptr<QueryCancellationState> state_{};
+
+    friend class QueryCancellationDomain;
+    friend class CommandList;
+};
+
+// Mutable registration owner held by CommandList. A fresh domain is created
+// after every Submit/rejection drain so cancellation cannot leak into a later
+// recording generation.
+class RENDER_API QueryCancellationDomain {
+public:
+    QueryCancellationDomain();
+
+    QueryCancellationDomain(const QueryCancellationDomain&)            = delete;
+    QueryCancellationDomain& operator=(const QueryCancellationDomain&) = delete;
+    QueryCancellationDomain(QueryCancellationDomain&&) noexcept        = default;
+    QueryCancellationDomain& operator=(QueryCancellationDomain&&) noexcept = default;
+
+    [[nodiscard]] QueryCancellationView GetView() const noexcept;
+    [[nodiscard]] bool IsCancelled() const noexcept;
+    void Register(const QueryToken& _token) const;
+
+private:
+    std::shared_ptr<QueryCancellationState> state_{};
+};
+
+} // namespace Moer::Render
+
+#endif

--- a/source/runtime/render/rhi/RHIRecordDiagnostics.h
+++ b/source/runtime/render/rhi/RHIRecordDiagnostics.h
@@ -122,6 +122,8 @@ constexpr CommandRecordTraits GetCommandRecordTraits(Command::EType _type) {
         case Type::ClearResource:
             return {"ClearResource", Capability::ParallelPrimarySafe, true,
                     Constraint::GlobalResourceState};
+        case Type::Query:
+            return {"Query", Capability::SerialOnly, false, Constraint::ProfilerOrScope};
         case Type::Scope:
             return {"Scope", Capability::SerialOnly, false, Constraint::ProfilerOrScope};
         case Type::Custom:

--- a/source/runtime/render/rhi/d3d12/D3D12Device.cpp
+++ b/source/runtime/render/rhi/d3d12/D3D12Device.cpp
@@ -4,6 +4,7 @@
 
 #include "log/LogSystem.h"
 #include "rhi/RHIResourceInitilizer.h"
+#include "rhi/RHIThreadOwnership.h"
 
 #include "Core.h"
 #include "shader/ShaderResourceManager.h"
@@ -1024,6 +1025,7 @@ Allocation D3D12GpuGlobalAllocator::AllocateTextureHeap(
 }
 
 void D3D12GraphicsCommandQueue::ExecuteThread(std::stop_token _st) {
+    RHIThreadRoleScope completion_owner(ERHIThreadRole::Completion);
     do {
         {
             std::unique_lock lck(mtx);
@@ -1296,6 +1298,11 @@ struct D3D12CommandPreprocessVisitor {
             case Command::EType::ShaderDispatch:
                 Visit(static_cast<const DispatchCmd&>(*_cmd));
                 break;
+            case Command::EType::Query:
+                // Timestamp queries are rejected once at Execute entry. The
+                // command remains an explicit no-op here so unrelated work in
+                // the same submit can still be translated.
+                break;
 
             default:
                 FATAL("not implemented cmdtype {}", Command::typenames[uint(_cmd->Type())]);
@@ -1440,6 +1447,11 @@ struct D3D12CommandVisitor {
                 break;
             case Command::EType::ShaderDispatch:
                 Visit(static_cast<const DispatchCmd&>(*_cmd));
+                break;
+            case Command::EType::Query:
+                // Timestamp queries are rejected once at Execute entry. The
+                // command remains an explicit no-op here so unrelated work in
+                // the same submit can still be recorded and submitted.
                 break;
                 //CopyBackTexture,
                 //BuildAccel,
@@ -1663,9 +1675,33 @@ WaitEvent D3D12GraphicsCommandQueue::Execute(CmdSubmit&& _submit) {
     });
 
     // Build the complete retirement packet before crossing the native submit
-    // boundary. Ordinary callbacks are copied so the original submit remains
-    // intact if preparation or a native queue call fails; success callbacks
-    // join the accepted completion packet but remain skipped on rejection.
+    // boundary. Query capability failure is published by the Completion owner
+    // after the GPU fence and submit signals, but before ordinary callbacks.
+    // This keeps user Query callbacks outside RHIExecutor's publication gate
+    // and preserves the same terminal ordering as native query backends.
+    Array<QueryToken> query_tokens = _submit.query_tokens;
+    Array<std::function<void()>> query_completion_callbacks{};
+    if (!query_tokens.empty()) {
+        const QueryPublishBatch query_batch =
+            _submit.query_publish_batch.Valid() ?
+                _submit.query_publish_batch :
+                QueryBackendAccess::BeginPublishBatch();
+        _submit.query_publish_batch = query_batch;
+        QueryBackendAccess::PublishErrorsIfPending(
+            query_tokens,
+            "D3D12 timestamp queries are unsupported",
+            query_batch
+        );
+        query_completion_callbacks.emplace_back(
+            [tokens = std::move(query_tokens), query_batch] {
+                QueryBackendAccess::NotifyTerminals(tokens, query_batch);
+            }
+        );
+    }
+
+    // Ordinary callbacks are copied so the original submit remains intact if
+    // preparation or a native queue call fails; success callbacks join the
+    // accepted completion packet but remain skipped on rejection.
     Array<std::function<void()>> completion_callbacks{};
     completion_callbacks.reserve(
         _submit.callbacks.size() + _submit.success_callbacks.size()
@@ -1683,6 +1719,13 @@ WaitEvent D3D12GraphicsCommandQueue::Execute(CmdSubmit&& _submit) {
     );
     for (const SignalEvent& event : _submit.signal_events) {
         retirement_events.emplace_back(event, next_fence_value, false);
+    }
+    if (!query_completion_callbacks.empty()) {
+        retirement_events.emplace_back(
+            std::move(query_completion_callbacks),
+            next_fence_value,
+            true
+        );
     }
     if (!completion_callbacks.empty()) {
         retirement_events.emplace_back(
@@ -1734,6 +1777,8 @@ WaitEvent D3D12GraphicsCommandQueue::Execute(CmdSubmit&& _submit) {
     event_queue.splice(event_queue.end(), retirement_events);
     _submit.callbacks.clear();
     _submit.success_callbacks.clear();
+    _submit.query_tokens.clear();
+    _submit.query_publish_batch = {};
     _submit.signal_events.clear();
     pending_fence_values.Enqueue(next_fence_value);
     retirement_lock.unlock();

--- a/source/runtime/render/rhi/vulkan/RHICmdReorderer.h
+++ b/source/runtime/render/rhi/vulkan/RHICmdReorderer.h
@@ -1493,6 +1493,15 @@ public:
         layer_offset = m_cmd_lists.size();
     }
 
+    void VisitCmd(const QueryCmd* _cmd) {
+        const uint64 query_layer = m_cmd_lists.size();
+        AddCmd(_cmd, query_layer);
+        // Timestamp boundaries are observable ordering points. Isolating both
+        // boundaries prevents resource-independent work from moving outside
+        // the measured interval, and keeps the pair in source order.
+        layer_offset = m_cmd_lists.size();
+    }
+
     void VisitCmd(const CustomCmd* _cmd) {
         switch (_cmd->CustomId()) {
             case CustomCmd::CustomCmdId::CUSTOM_RASTER:
@@ -1585,6 +1594,9 @@ public:
                 break;
             case Command::EType::ClearResource:
                 VisitCmd(static_cast<const ClearResourceCmd*>(_cmd));
+                break;
+            case Command::EType::Query:
+                VisitCmd(static_cast<const QueryCmd*>(_cmd));
                 break;
             case Command::EType::Scope:
                 VisitCmd(static_cast<const ScopeCmd*>(_cmd));

--- a/source/runtime/render/rhi/vulkan/VulkanAllocator.cpp
+++ b/source/runtime/render/rhi/vulkan/VulkanAllocator.cpp
@@ -140,14 +140,26 @@ VkNativeQueryPool::VkNativeQueryPool(
     EQueueType     _queue_type
 ) :
     device(_device),
-    count(_query_count),
     type(_type),
     queue_type(_queue_type) {
+    query_pool = CreatePool(_query_count);
+    count      = _query_count;
+}
+
+VkQueryPool VkNativeQueryPool::CreatePool(uint32 _query_count) {
+    if (_query_count == 0) {
+        throw std::invalid_argument(
+            "Vulkan query-pool creation requires at least one slot"
+        );
+    }
+
     VkQueryPoolCreateInfo create_info{VK_STRUCTURE_TYPE_QUERY_POOL_CREATE_INFO};
-    create_info.queryType  = _type;
+    create_info.queryType  = type;
     create_info.queryCount = _query_count;
-    const VkResult result =
-        vkCreateQueryPool(device.GetDevice(), &create_info, nullptr, &query_pool);
+    VkQueryPool new_pool = VK_NULL_HANDLE;
+    const VkResult result = vkCreateQueryPool(
+        device.GetDevice(), &create_info, nullptr, &new_pool
+    );
     if (result != VK_SUCCESS) {
         device.TryLatchFirstFault(
             VulkanOperationContext{
@@ -161,6 +173,7 @@ VkNativeQueryPool::VkNativeQueryPool(
             std::string(VulkanResultName(result))
         );
     }
+    return new_pool;
 }
 
 VkNativeQueryPool::~VkNativeQueryPool() {
@@ -175,16 +188,58 @@ VkResult VkNativeQueryPool::GetResults(
     uint32             _query_count,
     VkQueryResultFlags _flags
 ) {
+    if (_query_count == 0) {
+        return VK_SUCCESS;
+    }
+    if (_first_query > count || _query_count > count - _first_query) {
+        throw std::out_of_range(
+            "Vulkan query result range exceeds the native pool"
+        );
+    }
+
+    const size_t values_per_query =
+        (_flags & VK_QUERY_RESULT_WITH_AVAILABILITY_BIT) != 0 ? 2u : 1u;
+    if (_query_count > _data.size() / values_per_query) {
+        throw std::invalid_argument(
+            "Vulkan query result span is too small for the requested flags"
+        );
+    }
+    const VkDeviceSize stride =
+        sizeof(uint64) * static_cast<VkDeviceSize>(values_per_query);
     return vkGetQueryPoolResults(
         device.GetDevice(),
         query_pool,
         _first_query,
         _query_count,
-        _data.size(),
+        _data.size_bytes(),
         _data.data(),
-        sizeof(uint64),
+        stride,
         VK_QUERY_RESULT_64_BIT | _flags
     );
+}
+
+void VkNativeQueryPool::EnsureCapacity(uint32 _required_count) {
+    if (_required_count <= count) {
+        return;
+    }
+
+    uint32 grown_count = std::max(count, uint32{1});
+    while (grown_count < _required_count) {
+        if (grown_count > std::numeric_limits<uint32>::max() / 2) {
+            grown_count = _required_count;
+            break;
+        }
+        grown_count *= 2;
+    }
+
+    // Allocate first so a failed growth preserves the old idle pool. The
+    // owning VulkanAllocator calls this only before beginning native record.
+    VkQueryPool replacement = CreatePool(grown_count);
+    if (query_pool != VK_NULL_HANDLE) {
+        vkDestroyQueryPool(device.GetDevice(), query_pool, nullptr);
+    }
+    query_pool = replacement;
+    count      = grown_count;
 }
 
 #pragma endregion
@@ -198,8 +253,7 @@ VulkanAllocator::VulkanAllocator(VulkanDevice* _device, EQueueType _type) :
     scratch_allocator(_device, &allocator),
     shader_buffer_allocator(_device, &allocator),
     timestamp_valid_bits(_device->GetTimestampValidBits(_type)),
-    timestamp_period_ns(_device->GetCoreProperties().core_1_0.limits.timestampPeriod),
-    timestamp_pool(*_device, VK_QUERY_TYPE_TIMESTAMP, 1000, _type) {}
+    timestamp_period_ns(_device->GetCoreProperties().core_1_0.limits.timestampPeriod) {}
 
 VulkanAllocator::~VulkanAllocator() {
     upload_allocator.Dispose();
@@ -262,8 +316,47 @@ VulkanAllocator::FindTimestampQueryRecord(uint64 _token_id) noexcept {
     return iter == timestamp_query_records.end() ? nullptr : &*iter;
 }
 
+void VulkanAllocator::EnsureTimestampQueryCapacity(size_t _required_count) {
+    if (_required_count == 0) {
+        return;
+    }
+    if (next_timestamp_query != 0 || !timestamp_query_records.empty()) {
+        throw std::logic_error(
+            "Vulkan timestamp query pool can grow only before recording"
+        );
+    }
+    if (timestamp_valid_bits == 0) {
+        throw std::runtime_error(
+            "Vulkan queue family does not support timestamp queries"
+        );
+    }
+    if (_required_count > std::numeric_limits<uint32>::max()) {
+        throw std::length_error(
+            "Vulkan timestamp query slot count exceeds uint32 capacity"
+        );
+    }
+
+    const uint32 required_count = static_cast<uint32>(_required_count);
+    // Reserve every CPU-side record before native recording begins. A Query
+    // begin writes commands immediately; allowing emplace_back to allocate
+    // afterwards could turn an otherwise legal packet into a partial native
+    // recording that cannot be replayed safely.
+    timestamp_query_records.reserve(_required_count);
+    if (!timestamp_pool) {
+        timestamp_pool.emplace(
+            *m_device,
+            VK_QUERY_TYPE_TIMESTAMP,
+            required_count,
+            queue_type
+        );
+        return;
+    }
+    timestamp_pool->EnsureCapacity(required_count);
+}
+
 uint32 VulkanAllocator::AllocateTimestampQuerySlot() {
-    if (next_timestamp_query >= timestamp_pool.GetCount()) {
+    if (!timestamp_pool ||
+        next_timestamp_query >= timestamp_pool->GetCount()) {
         throw std::runtime_error(
             "Vulkan timestamp query pool exhausted for one recorded command buffer"
         );
@@ -291,9 +384,9 @@ void VulkanAllocator::RecordTimestampQuery(
             throw std::runtime_error("duplicate Vulkan timestamp query begin");
         }
         const uint32 slot = AllocateTimestampQuerySlot();
-        _cmd_list.ResetQueryPool(timestamp_pool, slot, 1);
+        _cmd_list.ResetQueryPool(*timestamp_pool, slot, 1);
         _cmd_list.WriteTimeStamp(
-            timestamp_pool, slot, VK_PIPELINE_STAGE_2_TOP_OF_PIPE_BIT
+            *timestamp_pool, slot, VK_PIPELINE_STAGE_2_TOP_OF_PIPE_BIT
         );
         timestamp_query_records.emplace_back(TimestampQueryRecord{
             .token      = token,
@@ -313,9 +406,9 @@ void VulkanAllocator::RecordTimestampQuery(
         throw std::runtime_error("duplicate Vulkan timestamp query end");
     }
     const uint32 slot = AllocateTimestampQuerySlot();
-    _cmd_list.ResetQueryPool(timestamp_pool, slot, 1);
+    _cmd_list.ResetQueryPool(*timestamp_pool, slot, 1);
     _cmd_list.WriteTimeStamp(
-        timestamp_pool, slot, VK_PIPELINE_STAGE_2_BOTTOM_OF_PIPE_BIT
+        *timestamp_pool, slot, VK_PIPELINE_STAGE_2_BOTTOM_OF_PIPE_BIT
     );
     record->end_slot = slot;
 }
@@ -337,9 +430,12 @@ VkResult VulkanAllocator::PrepareTimestampQueriesAfterGpuCompletion(
 
     auto resolve_slot = [&](uint32 _slot, uint64& _value) noexcept {
         NativeTimestampResult native_result{};
+        if (!timestamp_pool) {
+            return VK_ERROR_UNKNOWN;
+        }
         const VkResult result = vkGetQueryPoolResults(
             m_device->GetDevice(),
-            timestamp_pool.GetHandle(),
+            timestamp_pool->GetHandle(),
             _slot,
             1,
             sizeof(native_result),

--- a/source/runtime/render/rhi/vulkan/VulkanAllocator.cpp
+++ b/source/runtime/render/rhi/vulkan/VulkanAllocator.cpp
@@ -4,6 +4,12 @@
 #include "VulkanMacroUtils.h"
 #include "VulkanRHIResource.h"
 #include "VulkanResourceTracker.h"
+#include "rhi/RHIImpl.h"
+
+#include <algorithm>
+#include <limits>
+#include <stdexcept>
+
 namespace Moer::Render {
 
 namespace {
@@ -127,27 +133,49 @@ bool VulkanPresentor::CompleteSuccess() noexcept {
 
 #pragma region[ Query Pool ]
 
-VkNativeQueryPool::VkNativeQueryPool(VulkanDevice& _device, VkQueryType _type, uint32 _query_count) :
+VkNativeQueryPool::VkNativeQueryPool(
+    VulkanDevice& _device,
+    VkQueryType    _type,
+    uint32         _query_count,
+    EQueueType     _queue_type
+) :
     device(_device),
+    count(_query_count),
     type(_type),
-    count(_query_count) {
+    queue_type(_queue_type) {
     VkQueryPoolCreateInfo create_info{VK_STRUCTURE_TYPE_QUERY_POOL_CREATE_INFO};
     create_info.queryType  = _type;
     create_info.queryCount = _query_count;
-    vkCreateQueryPool(device.GetDevice(), &create_info, nullptr, &query_pool);
+    const VkResult result =
+        vkCreateQueryPool(device.GetDevice(), &create_info, nullptr, &query_pool);
+    if (result != VK_SUCCESS) {
+        device.TryLatchFirstFault(
+            VulkanOperationContext{
+                .operation  = EVulkanFaultOperation::QueryPoolCreate,
+                .queue_type = queue_type,
+            },
+            result
+        );
+        throw std::runtime_error(
+            "Vulkan query-pool creation failed: " +
+            std::string(VulkanResultName(result))
+        );
+    }
 }
 
 VkNativeQueryPool::~VkNativeQueryPool() {
-    vkDestroyQueryPool(device.GetDevice(), query_pool, nullptr);
+    if (query_pool != VK_NULL_HANDLE) {
+        vkDestroyQueryPool(device.GetDevice(), query_pool, nullptr);
+    }
 }
 
-void VkNativeQueryPool::GetResults(
+VkResult VkNativeQueryPool::GetResults(
     std::span<uint64>  _data,
     uint32             _first_query,
     uint32             _query_count,
     VkQueryResultFlags _flags
 ) {
-    vkGetQueryPoolResults(
+    return vkGetQueryPoolResults(
         device.GetDevice(),
         query_pool,
         _first_query,
@@ -169,7 +197,9 @@ VulkanAllocator::VulkanAllocator(VulkanDevice* _device, EQueueType _type) :
     readback_allocator(&allocator, small_block_size, 1.5),
     scratch_allocator(_device, &allocator),
     shader_buffer_allocator(_device, &allocator),
-    timestamp_pool(*_device, VK_QUERY_TYPE_TIMESTAMP, 1000) {}
+    timestamp_valid_bits(_device->GetTimestampValidBits(_type)),
+    timestamp_period_ns(_device->GetCoreProperties().core_1_0.limits.timestampPeriod),
+    timestamp_pool(*_device, VK_QUERY_TYPE_TIMESTAMP, 1000, _type) {}
 
 VulkanAllocator::~VulkanAllocator() {
     upload_allocator.Dispose();
@@ -220,10 +250,278 @@ void VulkanAllocator::ResetBufferAlloc() {
     shader_buffer_allocator.Reset();
 }
 
-bool VulkanAllocator::CompleteSuccess() noexcept {
+VulkanAllocator::TimestampQueryRecord*
+VulkanAllocator::FindTimestampQueryRecord(uint64 _token_id) noexcept {
+    const auto iter = std::find_if(
+        timestamp_query_records.begin(),
+        timestamp_query_records.end(),
+        [_token_id](const TimestampQueryRecord& _record) {
+            return _record.token.Id() == _token_id;
+        }
+    );
+    return iter == timestamp_query_records.end() ? nullptr : &*iter;
+}
+
+uint32 VulkanAllocator::AllocateTimestampQuerySlot() {
+    if (next_timestamp_query >= timestamp_pool.GetCount()) {
+        throw std::runtime_error(
+            "Vulkan timestamp query pool exhausted for one recorded command buffer"
+        );
+    }
+    return next_timestamp_query++;
+}
+
+void VulkanAllocator::RecordTimestampQuery(
+    VulkanCmdList& _cmd_list,
+    const QueryCmd& _cmd
+) {
+    const QueryToken& token = _cmd.Token();
+    if (!token.Valid() || token.Kind() != QueryKind::Timestamp) {
+        throw std::runtime_error("invalid Vulkan timestamp query token");
+    }
+    if (timestamp_valid_bits == 0) {
+        throw std::runtime_error(
+            "Vulkan queue family does not support timestamp queries"
+        );
+    }
+
+    constexpr uint32 invalid_slot = std::numeric_limits<uint32>::max();
+    if (_cmd.IsBegin()) {
+        if (FindTimestampQueryRecord(token.Id()) != nullptr) {
+            throw std::runtime_error("duplicate Vulkan timestamp query begin");
+        }
+        const uint32 slot = AllocateTimestampQuerySlot();
+        _cmd_list.ResetQueryPool(timestamp_pool, slot, 1);
+        _cmd_list.WriteTimeStamp(
+            timestamp_pool, slot, VK_PIPELINE_STAGE_2_TOP_OF_PIPE_BIT
+        );
+        timestamp_query_records.emplace_back(TimestampQueryRecord{
+            .token      = token,
+            .begin_slot = slot,
+            .end_slot   = invalid_slot,
+        });
+        return;
+    }
+
+    TimestampQueryRecord* record = FindTimestampQueryRecord(token.Id());
+    if (record == nullptr || record->begin_slot == invalid_slot) {
+        throw std::runtime_error(
+            "Vulkan timestamp query end has no matching begin"
+        );
+    }
+    if (record->end_slot != invalid_slot) {
+        throw std::runtime_error("duplicate Vulkan timestamp query end");
+    }
+    const uint32 slot = AllocateTimestampQuerySlot();
+    _cmd_list.ResetQueryPool(timestamp_pool, slot, 1);
+    _cmd_list.WriteTimeStamp(
+        timestamp_pool, slot, VK_PIPELINE_STAGE_2_BOTTOM_OF_PIPE_BIT
+    );
+    record->end_slot = slot;
+}
+
+VkResult VulkanAllocator::PrepareTimestampQueriesAfterGpuCompletion(
+    const VulkanOperationContext& _context
+) noexcept {
+    constexpr uint32 invalid_slot = std::numeric_limits<uint32>::max();
+    const uint32 valid_bits = std::min(timestamp_valid_bits, uint32{64});
+    const uint64 valid_mask =
+        valid_bits == 64 ? std::numeric_limits<uint64>::max() :
+        valid_bits == 0  ? 0 :
+                           (uint64{1} << valid_bits) - 1;
+
+    struct NativeTimestampResult {
+        uint64 value{0};
+        uint64 available{0};
+    };
+
+    auto resolve_slot = [&](uint32 _slot, uint64& _value) noexcept {
+        NativeTimestampResult native_result{};
+        const VkResult result = vkGetQueryPoolResults(
+            m_device->GetDevice(),
+            timestamp_pool.GetHandle(),
+            _slot,
+            1,
+            sizeof(native_result),
+            &native_result,
+            sizeof(native_result),
+            VK_QUERY_RESULT_64_BIT | VK_QUERY_RESULT_WITH_AVAILABILITY_BIT
+        );
+        if (result == VK_SUCCESS) {
+            if (native_result.available == 0) {
+                return VK_NOT_READY;
+            }
+            _value = native_result.value & valid_mask;
+            return VK_SUCCESS;
+        }
+        if (result != VK_NOT_READY) {
+            VulkanOperationContext query_context = _context;
+            query_context.operation = EVulkanFaultOperation::QueryPoolResults;
+            if (query_context.queue_type == EQueueType::Ignore) {
+                query_context.queue_type = queue_type;
+            }
+            m_device->TryLatchFirstFault(query_context, result);
+        }
+        return result;
+    };
+
+    for (TimestampQueryRecord& record : timestamp_query_records) {
+        record.prepared_state =
+            TimestampQueryRecord::EPreparedState::Unprepared;
+        record.prepared_result = {};
+
+        if (valid_bits == 0 || record.begin_slot == invalid_slot ||
+            record.end_slot == invalid_slot) {
+            record.prepared_state =
+                valid_bits == 0 ?
+                    TimestampQueryRecord::EPreparedState::InvalidValidBits :
+                    TimestampQueryRecord::EPreparedState::Incomplete;
+            continue;
+        }
+
+        uint64 begin_tick = 0;
+        uint64 end_tick   = 0;
+        const VkResult begin_result =
+            resolve_slot(record.begin_slot, begin_tick);
+        if (begin_result != VK_SUCCESS) {
+            record.prepared_state =
+                begin_result == VK_NOT_READY ?
+                    TimestampQueryRecord::EPreparedState::Unavailable :
+                    TimestampQueryRecord::EPreparedState::NativeFault;
+            if (begin_result != VK_NOT_READY) {
+                return begin_result;
+            }
+            continue;
+        }
+
+        const VkResult end_result =
+            resolve_slot(record.end_slot, end_tick);
+        if (end_result != VK_SUCCESS) {
+            record.prepared_state =
+                end_result == VK_NOT_READY ?
+                    TimestampQueryRecord::EPreparedState::Unavailable :
+                    TimestampQueryRecord::EPreparedState::NativeFault;
+            if (end_result != VK_NOT_READY) {
+                return end_result;
+            }
+            continue;
+        }
+
+        const uint64 delta_tick = (end_tick - begin_tick) & valid_mask;
+        record.prepared_result = TimestampQueryResult{
+            .begin_tick     = begin_tick,
+            .end_tick       = end_tick,
+            .valid_bits     = valid_bits,
+            .tick_period_ns = timestamp_period_ns,
+            .duration_ns    = static_cast<double>(delta_tick) *
+                           timestamp_period_ns,
+        };
+        record.prepared_state =
+            TimestampQueryRecord::EPreparedState::Ready;
+    }
+    return VK_SUCCESS;
+}
+
+void VulkanAllocator::PublishTimestampQueriesAfterGpuCompletion(
+    QueryPublishBatch _batch,
+    bool              _gpu_success,
+    std::string_view  _failure_reason
+) noexcept {
+    for (const TimestampQueryRecord& record : timestamp_query_records) {
+        if (!_gpu_success) {
+            QueryBackendAccess::PublishErrorIfPending(
+                record.token,
+                _failure_reason.empty() ?
+                    "Vulkan submission did not reach successful GPU completion" :
+                    _failure_reason,
+                _batch
+            );
+            continue;
+        }
+
+        switch (record.prepared_state) {
+            case TimestampQueryRecord::EPreparedState::Ready:
+                QueryBackendAccess::PublishTimestamp(
+                    record.token, record.prepared_result, _batch
+                );
+                break;
+            case TimestampQueryRecord::EPreparedState::InvalidValidBits:
+                QueryBackendAccess::PublishErrorIfPending(
+                    record.token,
+                    "Vulkan queue family has timestampValidBits == 0",
+                    _batch
+                );
+                break;
+            case TimestampQueryRecord::EPreparedState::Incomplete:
+                QueryBackendAccess::PublishErrorIfPending(
+                    record.token,
+                    "Vulkan timestamp query pair is incomplete",
+                    _batch
+                );
+                break;
+            case TimestampQueryRecord::EPreparedState::Unavailable:
+                QueryBackendAccess::PublishErrorIfPending(
+                    record.token,
+                    "Vulkan timestamp query result is unavailable",
+                    _batch
+                );
+                break;
+            case TimestampQueryRecord::EPreparedState::NativeFault:
+                QueryBackendAccess::PublishErrorIfPending(
+                    record.token,
+                    "Vulkan timestamp query result readback faulted",
+                    _batch
+                );
+                break;
+            case TimestampQueryRecord::EPreparedState::Unprepared:
+            default:
+                QueryBackendAccess::PublishErrorIfPending(
+                    record.token,
+                    "Vulkan timestamp query was not prepared for completion",
+                    _batch
+                );
+                break;
+        }
+    }
+}
+
+void VulkanAllocator::NotifyTimestampQueriesAfterGpuCompletion(
+    QueryPublishBatch _batch
+) noexcept {
+    for (const TimestampQueryRecord& record : timestamp_query_records) {
+        QueryBackendAccess::NotifyTerminal(record.token, _batch);
+    }
+}
+
+bool VulkanAllocator::CompleteSuccessCallbacks() noexcept {
     return InvokeAllocatorCompletionCallbacksNoexcept(
         on_complete, "allocator"
     );
+}
+
+void VulkanAllocator::ClearTimestampQueries() noexcept {
+    timestamp_query_records.clear();
+    next_timestamp_query = 0;
+}
+
+bool VulkanAllocator::CompleteSuccess() noexcept {
+    VulkanOperationContext context{
+        .operation  = EVulkanFaultOperation::QueryPoolResults,
+        .queue_type = queue_type,
+    };
+    const VkResult prepare_result =
+        PrepareTimestampQueriesAfterGpuCompletion(context);
+    const bool callbacks_succeeded =
+        prepare_result == VK_SUCCESS && CompleteSuccessCallbacks();
+    const QueryPublishBatch query_batch =
+        QueryBackendAccess::BeginPublishBatch();
+    PublishTimestampQueriesAfterGpuCompletion(
+        query_batch,
+        prepare_result == VK_SUCCESS,
+        "Vulkan timestamp query result preparation failed"
+    );
+    NotifyTimestampQueriesAfterGpuCompletion(query_batch);
+    return prepare_result == VK_SUCCESS && callbacks_succeeded;
 }
 
 bool VulkanAllocator::Reset() {
@@ -231,6 +529,7 @@ bool VulkanAllocator::Reset() {
         return false;
     }
     ResetBufferAlloc();
+    ClearTimestampQueries();
     return true;
 }
 

--- a/source/runtime/render/rhi/vulkan/VulkanAllocator.h
+++ b/source/runtime/render/rhi/vulkan/VulkanAllocator.h
@@ -6,8 +6,13 @@
 #include "VulkanRHIResource.h"
 #include "VulkanResourceTracker.h"
 #include "rhi/RHICommon.h"
+#include "rhi/RHIQuery.h"
+
+#include <limits>
 
 namespace Moer::Render {
+
+struct QueryCmd;
 
 class VulkanCmdAllocator : public VulkanDeviceObject {
 private:
@@ -78,7 +83,12 @@ protected:
 
 class VkNativeQueryPool {
 public:
-    VkNativeQueryPool(VulkanDevice& _device, VkQueryType _type, uint32 _count);
+    VkNativeQueryPool(
+        VulkanDevice& _device,
+        VkQueryType    _type,
+        uint32         _count,
+        EQueueType     _queue_type
+    );
     ~VkNativeQueryPool();
     VkQueryPool GetHandle() const {
         return query_pool;
@@ -86,17 +96,22 @@ public:
     uint32 GetCount() const {
         return count;
     }
-    void
-    GetResults(std::span<uint64> _results, uint32 _first_query, uint32 _query_cnt, VkQueryResultFlags _flags);
+    [[nodiscard]] VkResult GetResults(
+        std::span<uint64>  _results,
+        uint32             _first_query,
+        uint32             _query_count,
+        VkQueryResultFlags _flags
+    );
     VulkanDevice& GetDevice() const {
         return device;
     }
 
 private:
     VulkanDevice& device;
-    VkQueryPool   query_pool;
+    VkQueryPool   query_pool{VK_NULL_HANDLE};
     uint32        count;
     VkQueryType   type;
+    EQueueType    queue_type{EQueueType::Ignore};
 };
 
 class VulkanPresentor : public VulkanAllocatorBase {
@@ -120,6 +135,32 @@ public:
     BufferView AllocateShaderBuffer(uint64 _size);
 
     void ResetBufferAlloc();
+
+    // Timestamp slots and their tokens are allocator-local. The allocator is
+    // the native command-buffer owner and already travels in the atomic
+    // Submission -> Completion packet, so query state never needs a global
+    // active-recording map or lock.
+    void RecordTimestampQuery(VulkanCmdList& _cmd_list, const QueryCmd& _cmd);
+    // GPU completion is a two-stage transaction. Prepare performs native
+    // readback and fault classification without publishing user callbacks.
+    // The queue Completion owner later terminalizes submit signals, invokes
+    // allocator retirement callbacks, publishes every query in the batch, and
+    // only then releases Query callbacks.
+    [[nodiscard]] VkResult PrepareTimestampQueriesAfterGpuCompletion(
+        const VulkanOperationContext& _context
+    ) noexcept;
+    void PublishTimestampQueriesAfterGpuCompletion(
+        QueryPublishBatch _batch,
+        bool              _gpu_success,
+        std::string_view  _failure_reason
+    ) noexcept;
+    void NotifyTimestampQueriesAfterGpuCompletion(
+        QueryPublishBatch _batch
+    ) noexcept;
+    bool CompleteSuccessCallbacks() noexcept;
+    [[nodiscard]] bool HasTimestampQueries() const noexcept {
+        return !timestamp_query_records.empty();
+    }
 
     bool CompleteSuccess() noexcept override;
     bool Reset() override;
@@ -179,6 +220,31 @@ private:
     ScratchAllocator      scratch_allocator;
     ShaderBufferAllocator shader_buffer_allocator;
 
+    struct TimestampQueryRecord {
+        enum class EPreparedState : uint8 {
+            Unprepared,
+            Ready,
+            InvalidValidBits,
+            Incomplete,
+            Unavailable,
+            NativeFault,
+        };
+
+        QueryToken token{};
+        uint32     begin_slot{std::numeric_limits<uint32>::max()};
+        uint32     end_slot{std::numeric_limits<uint32>::max()};
+        EPreparedState       prepared_state{EPreparedState::Unprepared};
+        TimestampQueryResult prepared_result{};
+    };
+
+    TimestampQueryRecord* FindTimestampQueryRecord(uint64 _token_id) noexcept;
+    uint32                AllocateTimestampQuerySlot();
+    void                  ClearTimestampQueries() noexcept;
+
+    Array<TimestampQueryRecord> timestamp_query_records;
+    uint32                      next_timestamp_query{0};
+    uint32                      timestamp_valid_bits{0};
+    double                      timestamp_period_ns{0.0};
     VkNativeQueryPool timestamp_pool;
 };
 } // namespace Moer::Render

--- a/source/runtime/render/rhi/vulkan/VulkanAllocator.h
+++ b/source/runtime/render/rhi/vulkan/VulkanAllocator.h
@@ -90,6 +90,9 @@ public:
         EQueueType     _queue_type
     );
     ~VkNativeQueryPool();
+    VkNativeQueryPool(const VkNativeQueryPool&)            = delete;
+    VkNativeQueryPool& operator=(const VkNativeQueryPool&) = delete;
+
     VkQueryPool GetHandle() const {
         return query_pool;
     }
@@ -105,11 +108,17 @@ public:
     VulkanDevice& GetDevice() const {
         return device;
     }
+    // The owning allocator may grow an idle pool before command-buffer
+    // recording starts. Existing pools are never replaced while they are
+    // referenced by submitted work.
+    void EnsureCapacity(uint32 _required_count);
 
 private:
+    [[nodiscard]] VkQueryPool CreatePool(uint32 _query_count);
+
     VulkanDevice& device;
     VkQueryPool   query_pool{VK_NULL_HANDLE};
-    uint32        count;
+    uint32        count{0};
     VkQueryType   type;
     EQueueType    queue_type{EQueueType::Ignore};
 };
@@ -140,6 +149,7 @@ public:
     // the native command-buffer owner and already travels in the atomic
     // Submission -> Completion packet, so query state never needs a global
     // active-recording map or lock.
+    void EnsureTimestampQueryCapacity(size_t _required_count);
     void RecordTimestampQuery(VulkanCmdList& _cmd_list, const QueryCmd& _cmd);
     // GPU completion is a two-stage transaction. Prepare performs native
     // readback and fault classification without publishing user callbacks.
@@ -245,6 +255,9 @@ private:
     uint32                      next_timestamp_query{0};
     uint32                      timestamp_valid_bits{0};
     double                      timestamp_period_ns{0.0};
-    VkNativeQueryPool timestamp_pool;
+    // Most allocators never record an explicit Query command. Lazily creating
+    // this pool avoids adding a native driver object to every ordinary,
+    // parallel-worker, fallback, and Copy allocator.
+    std::optional<VkNativeQueryPool> timestamp_pool;
 };
 } // namespace Moer::Render

--- a/source/runtime/render/rhi/vulkan/VulkanDevice.h
+++ b/source/runtime/render/rhi/vulkan/VulkanDevice.h
@@ -232,6 +232,12 @@ public:
     inline QueueFamilyIndices GetQueueFamilyIndices() const {
         return m_device_info.queue_family_indices;
     }
+    inline uint32_t GetTimestampValidBits(EQueueType _queue_type) const {
+        const uint32_t family_index = GetQueueFamilyIndex(_queue_type);
+        return family_index < m_device_info.queue_family_props.size() ?
+                   m_device_info.queue_family_props[family_index].timestampValidBits :
+                   0u;
+    }
     inline VkDescriptorSetLayout GetEmptyDescriptorSetLayout() const {
         return empty_descriptor_set_layout;
     }

--- a/source/runtime/render/rhi/vulkan/VulkanFault.h
+++ b/source/runtime/render/rhi/vulkan/VulkanFault.h
@@ -25,6 +25,8 @@ enum class EVulkanFaultOperation : uint8_t {
     PresentFenceWait,
     PresentFenceReset,
     CommandPoolReset,
+    QueryPoolCreate,
+    QueryPoolResults,
     SwapchainCreate,
     SwapchainGetImages,
     SwapchainSemaphoreCreate,
@@ -96,6 +98,10 @@ struct VulkanFaultRecord {
             return "PresentFenceReset";
         case EVulkanFaultOperation::CommandPoolReset:
             return "CommandPoolReset";
+        case EVulkanFaultOperation::QueryPoolCreate:
+            return "QueryPoolCreate";
+        case EVulkanFaultOperation::QueryPoolResults:
+            return "QueryPoolResults";
         case EVulkanFaultOperation::SwapchainCreate:
             return "SwapchainCreate";
         case EVulkanFaultOperation::SwapchainGetImages:

--- a/source/runtime/render/rhi/vulkan/VulkanParallelRecordWorkEstimator.cpp
+++ b/source/runtime/render/rhi/vulkan/VulkanParallelRecordWorkEstimator.cpp
@@ -134,6 +134,11 @@ uint32 EstimateWorkUnits(
             // Marker pair plus one copy/clear call. Bytes and extents are GPU work.
             work_units = 3;
             break;
+        case Command::EType::Query:
+            // Query commands are serial ordering islands, but keeping their
+            // estimate explicit makes diagnostics total and stable.
+            work_units = 1;
+            break;
         default:
             // Serial-only commands never reach a worker, but diagnostics stay total.
             work_units = 1;

--- a/source/runtime/render/rhi/vulkan/VulkanQueue.cpp
+++ b/source/runtime/render/rhi/vulkan/VulkanQueue.cpp
@@ -724,7 +724,9 @@ struct VkCmdPreprocessor {
             case Command::EType::Custom:
                 Visit(static_cast<const CustomCmd*>(_cmd));
                 break;
+            case Command::EType::Query:
             case Command::EType::Scope:
+                // Query/marker commands have no resource-state dependency.
                 break;
             default:
                 assert(false && "Invalid command type");
@@ -1806,6 +1808,9 @@ public:
                 break;
             case Command::EType::Scope:
                 Visit(static_cast<const ScopeCmd&>(*_cmd));
+                break;
+            case Command::EType::Query:
+                Visit(static_cast<const QueryCmd&>(*_cmd));
                 break;
             case Command::EType::Custom:
                 Visit(static_cast<const CustomCmd&>(*_cmd));
@@ -2926,6 +2931,10 @@ public:
         }
     }
 
+    void Visit(const QueryCmd& _cmd) {
+        allocator.RecordTimestampQuery(cmd_list, _cmd);
+    }
+
     void Visit(const BuildAccelerationStructuresCmd& _cmd) {
         const Array<AccelerationStructureBuildParam>& build_params = _cmd.Params();
 
@@ -3701,6 +3710,39 @@ static void TerminalizeUnsubmittedSignals(
     }
 }
 
+static QueryPublishBatch PublishUnsubmittedQueryErrors(
+    CmdSubmit&             _submit,
+    VulkanAllocatorBatch*  _allocators,
+    std::string_view       _reason
+) noexcept {
+    const QueryPublishBatch query_batch =
+        _submit.query_publish_batch.Valid() ?
+            _submit.query_publish_batch :
+            QueryBackendAccess::BeginPublishBatch();
+
+    if (_allocators != nullptr) {
+        for (auto& allocator : _allocators->submitted) {
+            if (allocator) {
+                allocator->PublishTimestampQueriesAfterGpuCompletion(
+                    query_batch, false, _reason
+                );
+            }
+        }
+        for (auto& allocator : _allocators->abandoned) {
+            if (allocator) {
+                allocator->PublishTimestampQueriesAfterGpuCompletion(
+                    query_batch, false, _reason
+                );
+            }
+        }
+    }
+    // The submit-token pass is also the malformed/native-record fallback in
+    // the opposite direction: a token without an allocator record still
+    // becomes terminal in the same transaction.
+    _submit.PublishPendingQueryErrors(_reason, query_batch);
+    return query_batch;
+}
+
 static void TerminalizeRejectedSubmit(
     VulkanDevice&    _device,
     CmdSubmit&&      _submit,
@@ -3718,6 +3760,7 @@ static void TerminalizeRejectedSubmit(
         VulkanOperationResult{EVulkanOperationStatus::Rejected, _result}
     );
     FinalizeRejectedBindlessUpdates(_submit);
+    _submit.RejectPendingQueries(_context);
 
     // Completion callbacks are the only user code retained on a rejected
     // packet. Success callbacks are intentionally destroyed without running.
@@ -3753,7 +3796,8 @@ VkCommandQueue::VkCommandQueue(
     timestamp_pool(
         _device,
         VK_QUERY_TYPE_TIMESTAMP,
-        s_queue_max_frame_in_flight * s_query_max_storage * 4
+        s_queue_max_frame_in_flight * s_query_max_storage * 4,
+        _type
     ),
     profiler_storage(timestamp_pool),
     rhi_thread_enabled(_enable_rhi_thread),
@@ -4212,6 +4256,11 @@ void VkCommandQueue::RejectForRuntime(CmdSubmit&& _submit, VkResult _result) noe
         // and dereference the raw fence pointers after a waiter releases its
         // last FenceRef.
         _submit.signal_events.clear();
+        PublishUnsubmittedQueryErrors(
+            _submit,
+            nullptr,
+            "Vulkan runtime rejected the submit before GPU completion"
+        );
         std::unique_lock<std::mutex> lock(event_mutex);
         const uint64 retirement_serial = retirement_enqueued_serial + 1;
         event_queue.emplace_back(
@@ -4469,6 +4518,11 @@ void VkCommandQueue::CommitRuntimeSubmitCompletion(
             // Exact signal rejection is published by Submission. Do not
             // retain raw external fence pointers in the Completion packet.
             _recorded.submit.signal_events.clear();
+            PublishUnsubmittedQueryErrors(
+                _recorded.submit,
+                &_recorded.allocators,
+                "Vulkan submission was rejected before GPU completion"
+            );
             _recorded.allocators.abandoned.reserve(
                 _recorded.allocators.abandoned.size() +
                 _recorded.allocators.submitted.size()
@@ -4563,6 +4617,20 @@ bool VkCommandQueue::TryExecuteParallel(
     batch_serial = ++parallel_record_batch_serial;
     if (thread_profile) {
         verify_fallback("record-diagnostics-enabled");
+        return false;
+    }
+    if (std::any_of(
+            _submit.cmds.begin(),
+            _submit.cmds.end(),
+            [](const UniquePtr<Command>& _command) {
+                return _command &&
+                       _command->Type() == Command::EType::Query;
+            }
+        )) {
+        // A query pair must stay in one native command buffer owned by one
+        // allocator. Other source packets can still translate concurrently;
+        // only this source falls back to its serial recorder.
+        verify_fallback("timestamp-query-serial-island");
         return false;
     }
 
@@ -5921,7 +5989,18 @@ void VkCommandQueue::ExecuteNow(
                     diagnostics.descriptor_begin,
                     diagnostics.descriptor_bytes
                 );
-                if (emits_profiling_queries && cmd->Type() == Command::EType::Scope) {
+                if (cmd->Type() == Command::EType::Query) {
+                    const auto& query = *static_cast<const QueryCmd*>(cmd);
+                    serial_golden->RecordQueryEvent(
+                        query.IsBegin() ?
+                            SerialQueryEvent::Begin :
+                            SerialQueryEvent::End,
+                        query.Token().Name(),
+                        query.IsBegin() ?
+                            VK_PIPELINE_STAGE_2_TOP_OF_PIPE_BIT :
+                            VK_PIPELINE_STAGE_2_BOTTOM_OF_PIPE_BIT
+                    );
+                } else if (emits_profiling_queries && cmd->Type() == Command::EType::Scope) {
                     const auto& scope = *static_cast<const ScopeCmd*>(cmd);
                     if (scope.QueryTimestamp()) {
                         serial_golden->RecordQueryEvent(
@@ -7254,11 +7333,35 @@ void VkCommandQueue::CompletionThreadMain() {
                         wait_context.operation = EVulkanFaultOperation::TimelineHostWait;
                         const VkResult wait_result =
                             timeline->HostWait(event_timeline, wait_context);
-                        if (wait_result == VK_SUCCESS && !vk_device.IsDeviceLost()) {
-                            timeline->Notify(event_timeline);
+                        if (wait_result == VK_SUCCESS && !vk_device.IsFaulted()) {
                             batch_gpu_success = true;
                             batch_release_safe = true;
                             completion_result = VK_SUCCESS;
+
+                            for (auto& allocator : _batch.allocators.submitted) {
+                                const VkResult query_result =
+                                    allocator->PrepareTimestampQueriesAfterGpuCompletion(
+                                        _batch.context
+                                    );
+                                if (query_result != VK_SUCCESS) {
+                                    completion_result = query_result;
+                                    batch_gpu_success = false;
+                                    batch_release_safe = false;
+                                    break;
+                                }
+                            }
+                            if (batch_gpu_success && vk_device.IsFaulted()) {
+                                completion_result =
+                                    vk_device.GetFirstFaultResult();
+                                batch_gpu_success = false;
+                                batch_release_safe = false;
+                            }
+
+                            if (batch_gpu_success) {
+                                timeline->Notify(event_timeline);
+                            } else if (_batch.owns_queue_timeline) {
+                                timeline->Fail(completion_result);
+                            }
                         } else {
                             completion_result =
                                 wait_result != VK_SUCCESS ?
@@ -7278,14 +7381,95 @@ void VkCommandQueue::CompletionThreadMain() {
                         }
                     }
 
+                    for (const SignalEvent& event : _batch.submit.signal_events) {
+                        auto* fence =
+                            reinterpret_cast<VulkanFence*>(event.timeline_handle);
+                        if (fence == nullptr) {
+                            continue;
+                        }
+                        if (batch_gpu_success) {
+                            fence->Notify(event.value);
+                        } else if (recoverable_rejection) {
+                            fence->Reject(event.value);
+                        } else {
+                            fence->Fail(completion_result);
+                        }
+                    }
+
+                    const QueryPublishBatch query_batch =
+                        _batch.submit.query_publish_batch.Valid() ?
+                            _batch.submit.query_publish_batch :
+                            QueryBackendAccess::BeginPublishBatch();
+                    const std::string_view query_failure_reason =
+                        batch_gpu_success ?
+                            "Vulkan timestamp query did not resolve after GPU completion" :
+                            "Vulkan submission did not reach successful GPU completion";
+                    for (auto& allocator : _batch.allocators.submitted) {
+                        allocator->PublishTimestampQueriesAfterGpuCompletion(
+                            query_batch,
+                            batch_gpu_success,
+                            query_failure_reason
+                        );
+                    }
+                    for (auto& allocator : _batch.allocators.abandoned) {
+                        allocator->PublishTimestampQueriesAfterGpuCompletion(
+                            query_batch,
+                            false,
+                            "Vulkan timestamp query recorder was abandoned before native submission"
+                        );
+                    }
+                    // Every CmdSubmit token must become terminal even if a
+                    // backend bug failed to associate it with a native
+                    // allocator record. Publish the fallback in the same
+                    // transaction, but defer all notifications.
+                    _batch.submit.PublishPendingQueryErrors(
+                        query_failure_reason, query_batch
+                    );
+
                     bool recycle_batch =
                         batch_gpu_success && !vk_device.IsFaulted();
                     if (recycle_batch) {
                         for (auto& allocator : _batch.allocators.submitted) {
                             recycle_batch =
-                                allocator->CompleteSuccess() && recycle_batch;
+                                allocator->CompleteSuccessCallbacks() &&
+                                recycle_batch;
                         }
                     }
+
+                    if (_batch.descriptor_lease.has_value()) {
+                        vk_device.GetGlobalDescriptorHeap().RecyclePushDescriptors(
+                            std::move(*_batch.descriptor_lease)
+                        );
+                        _batch.descriptor_lease.reset();
+                    }
+
+                    if (!_batch.gpu_submitted) {
+                        FinalizeRejectedBindlessUpdates(_batch.submit);
+                    }
+                    Array<std::function<void()>> callbacks =
+                        std::move(_batch.submit.callbacks);
+                    Array<std::function<void()>> success_callbacks =
+                        std::move(_batch.submit.success_callbacks);
+                    _batch.submit.cmds.clear();
+                    _batch.submit.cached_args.clear();
+                    _batch.submit.segments.clear();
+                    _batch.submit.wait_events.clear();
+                    _batch.submit.signal_events.clear();
+                    _batch.submit.debug_label.clear();
+
+                    _batch.submit.NotifyPendingQueries(query_batch);
+                    for (auto& allocator : _batch.allocators.submitted) {
+                        allocator->NotifyTimestampQueriesAfterGpuCompletion(
+                            query_batch
+                        );
+                    }
+                    for (auto& allocator : _batch.allocators.abandoned) {
+                        allocator->NotifyTimestampQueriesAfterGpuCompletion(
+                            query_batch
+                        );
+                    }
+                    _batch.submit.query_tokens.clear();
+
                     if (recycle_batch) {
                         for (auto& allocator : _batch.allocators.submitted) {
                             recycle_batch = allocator->Reset() && recycle_batch;
@@ -7314,42 +7498,6 @@ void VkCommandQueue::CompletionThreadMain() {
                             allocator_quarantine.emplace_back(std::move(allocator));
                         }
                     }
-
-                    if (_batch.descriptor_lease.has_value()) {
-                        vk_device.GetGlobalDescriptorHeap().RecyclePushDescriptors(
-                            std::move(*_batch.descriptor_lease)
-                        );
-                        _batch.descriptor_lease.reset();
-                    }
-
-                    for (const SignalEvent& event : _batch.submit.signal_events) {
-                        auto* fence =
-                            reinterpret_cast<VulkanFence*>(event.timeline_handle);
-                        if (fence == nullptr) {
-                            continue;
-                        }
-                        if (batch_gpu_success) {
-                            fence->Notify(event.value);
-                        } else if (recoverable_rejection) {
-                            fence->Reject(event.value);
-                        } else {
-                            fence->Fail(completion_result);
-                        }
-                    }
-
-                    if (!_batch.gpu_submitted) {
-                        FinalizeRejectedBindlessUpdates(_batch.submit);
-                    }
-                    Array<std::function<void()>> callbacks =
-                        std::move(_batch.submit.callbacks);
-                    Array<std::function<void()>> success_callbacks =
-                        std::move(_batch.submit.success_callbacks);
-                    _batch.submit.cmds.clear();
-                    _batch.submit.cached_args.clear();
-                    _batch.submit.segments.clear();
-                    _batch.submit.wait_events.clear();
-                    _batch.submit.signal_events.clear();
-                    _batch.submit.debug_label.clear();
 
                     InvokeCallbacksNoexcept(
                         callbacks, "[VulkanQueue] runtime completion"
@@ -8094,6 +8242,11 @@ void VkCopyQueue::CommitRuntimeSubmitCompletion(
             // Exact signal rejection is published by Submission. Do not
             // retain raw external fence pointers in the Completion packet.
             _recorded.submit.signal_events.clear();
+            PublishUnsubmittedQueryErrors(
+                _recorded.submit,
+                &_recorded.allocators,
+                "Vulkan Copy submission was rejected before GPU completion"
+            );
             _recorded.allocators.abandoned.reserve(
                 _recorded.allocators.abandoned.size() +
                 _recorded.allocators.submitted.size()
@@ -8212,10 +8365,32 @@ void VkCopyQueue::ExecuteThread() {
                         wait_context.operation = EVulkanFaultOperation::TimelineHostWait;
                         const VkResult wait_result =
                             timeline->HostWait(event_timeline, wait_context);
-                        if (wait_result == VK_SUCCESS && !device.IsDeviceLost()) {
-                            timeline->Notify(event_timeline);
+                        if (wait_result == VK_SUCCESS && !device.IsFaulted()) {
                             batch_gpu_success = true;
                             completion_result = VK_SUCCESS;
+
+                            for (auto& allocator : _batch.allocators.submitted) {
+                                const VkResult query_result =
+                                    allocator->PrepareTimestampQueriesAfterGpuCompletion(
+                                        _batch.context
+                                    );
+                                if (query_result != VK_SUCCESS) {
+                                    completion_result = query_result;
+                                    batch_gpu_success = false;
+                                    break;
+                                }
+                            }
+                            if (batch_gpu_success && device.IsFaulted()) {
+                                completion_result =
+                                    device.GetFirstFaultResult();
+                                batch_gpu_success = false;
+                            }
+
+                            if (batch_gpu_success) {
+                                timeline->Notify(event_timeline);
+                            } else if (_batch.owns_queue_timeline) {
+                                timeline->Fail(completion_result);
+                            }
                         } else {
                             completion_result =
                                 wait_result != VK_SUCCESS ?
@@ -8235,14 +8410,91 @@ void VkCopyQueue::ExecuteThread() {
                         }
                     }
 
+                    for (const SignalEvent& event : _batch.submit.signal_events) {
+                        auto* fence =
+                            reinterpret_cast<VulkanFence*>(event.timeline_handle);
+                        if (fence == nullptr) {
+                            continue;
+                        }
+                        if (batch_gpu_success) {
+                            fence->Notify(event.value);
+                        } else if (recoverable_rejection) {
+                            fence->Reject(event.value);
+                        } else {
+                            fence->Fail(completion_result);
+                        }
+                    }
+
+                    const QueryPublishBatch query_batch =
+                        _batch.submit.query_publish_batch.Valid() ?
+                            _batch.submit.query_publish_batch :
+                            QueryBackendAccess::BeginPublishBatch();
+                    const std::string_view query_failure_reason =
+                        batch_gpu_success ?
+                            "Vulkan timestamp query did not resolve after GPU completion" :
+                            "Vulkan submission did not reach successful GPU completion";
+                    for (auto& allocator : _batch.allocators.submitted) {
+                        allocator->PublishTimestampQueriesAfterGpuCompletion(
+                            query_batch,
+                            batch_gpu_success,
+                            query_failure_reason
+                        );
+                    }
+                    for (auto& allocator : _batch.allocators.abandoned) {
+                        allocator->PublishTimestampQueriesAfterGpuCompletion(
+                            query_batch,
+                            false,
+                            "Vulkan Copy timestamp query recorder was abandoned before native submission"
+                        );
+                    }
+                    _batch.submit.PublishPendingQueryErrors(
+                        query_failure_reason, query_batch
+                    );
+
                     bool recycle_batch =
                         batch_gpu_success && !device.IsFaulted();
                     if (recycle_batch) {
                         for (auto& allocator : _batch.allocators.submitted) {
                             recycle_batch =
-                                allocator->CompleteSuccess() && recycle_batch;
+                                allocator->CompleteSuccessCallbacks() &&
+                                recycle_batch;
                         }
                     }
+
+                    if (_batch.descriptor_lease.has_value()) {
+                        device.GetGlobalDescriptorHeap().RecyclePushDescriptors(
+                            std::move(*_batch.descriptor_lease)
+                        );
+                        _batch.descriptor_lease.reset();
+                    }
+
+                    if (!_batch.gpu_submitted) {
+                        FinalizeRejectedBindlessUpdates(_batch.submit);
+                    }
+                    Array<std::function<void()>> callbacks =
+                        std::move(_batch.submit.callbacks);
+                    Array<std::function<void()>> success_callbacks =
+                        std::move(_batch.submit.success_callbacks);
+                    _batch.submit.cmds.clear();
+                    _batch.submit.cached_args.clear();
+                    _batch.submit.segments.clear();
+                    _batch.submit.wait_events.clear();
+                    _batch.submit.signal_events.clear();
+                    _batch.submit.debug_label.clear();
+
+                    _batch.submit.NotifyPendingQueries(query_batch);
+                    for (auto& allocator : _batch.allocators.submitted) {
+                        allocator->NotifyTimestampQueriesAfterGpuCompletion(
+                            query_batch
+                        );
+                    }
+                    for (auto& allocator : _batch.allocators.abandoned) {
+                        allocator->NotifyTimestampQueriesAfterGpuCompletion(
+                            query_batch
+                        );
+                    }
+                    _batch.submit.query_tokens.clear();
+
                     if (recycle_batch) {
                         for (auto& allocator : _batch.allocators.submitted) {
                             recycle_batch = allocator->Reset() && recycle_batch;
@@ -8271,42 +8523,6 @@ void VkCopyQueue::ExecuteThread() {
                             allocator_quarantine.emplace_back(std::move(allocator));
                         }
                     }
-
-                    if (_batch.descriptor_lease.has_value()) {
-                        device.GetGlobalDescriptorHeap().RecyclePushDescriptors(
-                            std::move(*_batch.descriptor_lease)
-                        );
-                        _batch.descriptor_lease.reset();
-                    }
-
-                    for (const SignalEvent& event : _batch.submit.signal_events) {
-                        auto* fence =
-                            reinterpret_cast<VulkanFence*>(event.timeline_handle);
-                        if (fence == nullptr) {
-                            continue;
-                        }
-                        if (batch_gpu_success) {
-                            fence->Notify(event.value);
-                        } else if (recoverable_rejection) {
-                            fence->Reject(event.value);
-                        } else {
-                            fence->Fail(completion_result);
-                        }
-                    }
-
-                    if (!_batch.gpu_submitted) {
-                        FinalizeRejectedBindlessUpdates(_batch.submit);
-                    }
-                    Array<std::function<void()>> callbacks =
-                        std::move(_batch.submit.callbacks);
-                    Array<std::function<void()>> success_callbacks =
-                        std::move(_batch.submit.success_callbacks);
-                    _batch.submit.cmds.clear();
-                    _batch.submit.cached_args.clear();
-                    _batch.submit.segments.clear();
-                    _batch.submit.wait_events.clear();
-                    _batch.submit.signal_events.clear();
-                    _batch.submit.debug_label.clear();
 
                     InvokeCallbacksNoexcept(
                         callbacks, "[VulkanCopyQueue] runtime completion"

--- a/source/runtime/render/rhi/vulkan/VulkanQueue.cpp
+++ b/source/runtime/render/rhi/vulkan/VulkanQueue.cpp
@@ -29,6 +29,7 @@
 #include <exception>
 #include <memory>
 #include <mutex>
+#include <stdexcept>
 #include <string>
 #include <thread>
 #include <variant>
@@ -41,6 +42,8 @@ std::atomic<const VulkanSubmissionDependencyWaitObserver*>
     g_submission_dependency_wait_observer{nullptr};
 std::atomic<const VulkanBackendSyncWaitObserver*>
     g_backend_sync_wait_observer{nullptr};
+std::atomic<const VulkanQueueLocalSyncWaitObserver*>
+    g_queue_local_sync_wait_observer{nullptr};
 std::atomic<const VulkanScriptedQueryPreparationOverrideForTesting*>
     g_scripted_query_preparation_override{nullptr};
 std::atomic<const VulkanScriptedPresentOverrideForTesting*>
@@ -66,6 +69,38 @@ void NotifyNativeSubmission(
             .thread_role         = GetCurrentRHIThreadRole(),
             .outcome             = _outcome,
             .empty_submit        = _empty_submit,
+        }
+    );
+}
+
+void NotifyQueueLocalSyncWait(
+    EQueueType _queue,
+    uint64     _target_retirement_serial,
+    size_t     _completion_group_count
+) noexcept {
+    const VulkanQueueLocalSyncWaitObserver* observer =
+        g_queue_local_sync_wait_observer.load(
+            std::memory_order_acquire
+        );
+    if (observer == nullptr) {
+        return;
+    }
+    observer->callback(
+        observer->context,
+        VulkanQueueLocalSyncWaitEvent{
+            .queue       = _queue,
+            .thread_id   = Platform::GetCurrentThreadID(),
+            .thread_role = GetCurrentRHIThreadRole(),
+            .target_retirement_serial =
+                _target_retirement_serial,
+            .completion_group_count = static_cast<uint32>(
+                std::min(
+                    _completion_group_count,
+                    static_cast<size_t>(
+                        std::numeric_limits<uint32>::max()
+                    )
+                )
+            ),
         }
     );
 }
@@ -261,6 +296,36 @@ bool RemoveVulkanBackendSyncWaitObserver(
     );
 }
 
+bool TryInstallVulkanQueueLocalSyncWaitObserver(
+    const VulkanQueueLocalSyncWaitObserver* _observer
+) noexcept {
+    if (_observer == nullptr || _observer->callback == nullptr) {
+        return false;
+    }
+    const VulkanQueueLocalSyncWaitObserver* expected = nullptr;
+    return g_queue_local_sync_wait_observer.compare_exchange_strong(
+        expected,
+        _observer,
+        std::memory_order_release,
+        std::memory_order_relaxed
+    );
+}
+
+bool RemoveVulkanQueueLocalSyncWaitObserver(
+    const VulkanQueueLocalSyncWaitObserver* _observer
+) noexcept {
+    if (_observer == nullptr) {
+        return false;
+    }
+    const VulkanQueueLocalSyncWaitObserver* expected = _observer;
+    return g_queue_local_sync_wait_observer.compare_exchange_strong(
+        expected,
+        nullptr,
+        std::memory_order_acq_rel,
+        std::memory_order_acquire
+    );
+}
+
 #pragma region[ utils ]
 
 VkRenderingAttachmentInfo FromColorAttachmentInfo(const ColorAttachment& _attachment) {
@@ -445,6 +510,108 @@ static void InvokeCallbacksNoexcept(
             }
         }
     }
+}
+
+VulkanBatchCompletionGroup::VulkanBatchCompletionGroup(
+    size_t _participant_count
+) :
+    participants(_participant_count),
+    remaining(_participant_count) {
+    if (_participant_count == 0) {
+        throw std::invalid_argument(
+            "Vulkan batch Completion group requires a participant"
+        );
+    }
+}
+
+void VulkanBatchCompletionGroup::Arrive(
+    size_t        _participant_index,
+    Participant&& _participant
+) noexcept {
+    Array<std::optional<Participant>> ready{};
+    {
+        std::lock_guard lock(mutex);
+        if (released || _participant_index >= participants.size() ||
+            participants[_participant_index].has_value() ||
+            remaining == 0) {
+            // A duplicate or invalid arrival means one ownership packet was
+            // replayed or lost. Continuing could release user callbacks while
+            // a sibling is still non-terminal.
+            std::terminate();
+        }
+        participants[_participant_index].emplace(
+            std::move(_participant)
+        );
+        --remaining;
+        if (remaining != 0) {
+            return;
+        }
+        released = true;
+        ready    = std::move(participants);
+    }
+
+    // Every participant has already published its Fence and Query terminal
+    // state. Release Query callbacks first across the whole batch, then the
+    // two ordinary callback tiers, and keep resources alive until all user
+    // code has returned. The last arriver is itself a Completion owner.
+    for (auto& slot : ready) {
+        Participant& participant = *slot;
+        if (!participant.query_tokens.empty()) {
+            QueryBackendAccess::NotifyTerminals(
+                participant.query_tokens, participant.query_batch
+            );
+            participant.query_tokens.clear();
+        }
+    }
+    for (auto& slot : ready) {
+        InvokeCallbacksNoexcept(
+            slot->callbacks,
+            "[VulkanBatchCompletion] runtime completion"
+        );
+    }
+    for (auto& slot : ready) {
+        if (!slot->gpu_success) {
+            continue;
+        }
+        InvokeCallbacksNoexcept(
+            slot->success_callbacks,
+            "[VulkanBatchCompletion] runtime success completion"
+        );
+    }
+    for (auto& slot : ready) {
+        Participant& participant = *slot;
+        if (participant.deferred_releases.empty()) {
+            continue;
+        }
+        if (participant.device == nullptr) {
+            std::terminate();
+        }
+        if (participant.gpu_success || participant.release_safe) {
+            for (auto* resource : participant.deferred_releases) {
+                MoerDelete(resource);
+            }
+        } else {
+            for (auto* resource : participant.deferred_releases) {
+                participant.device->EnqueueDeferredRelease(resource);
+            }
+        }
+    }
+
+    {
+        std::lock_guard lock(mutex);
+        if (!released || settled) {
+            std::terminate();
+        }
+        settled = true;
+    }
+    settled_cv.notify_all();
+}
+
+void VulkanBatchCompletionGroup::WaitUntilSettled() {
+    std::unique_lock lock(mutex);
+    settled_cv.wait(lock, [this] {
+        return settled;
+    });
 }
 
 static void ResolvePresentReceiptNoexcept(
@@ -4294,7 +4461,8 @@ void VkCommandQueue::RejectRecordedForRuntime(
 void VkCommandQueue::RejectForRuntime(
     CmdSubmit&& _submit,
     VkResult    _result,
-    bool        _recoverable
+    bool        _recoverable,
+    VulkanBatchCompletionTicket _batch_completion
 ) noexcept {
     ResetSplitProfilingCpuFrame();
     const VulkanOperationResult outcome =
@@ -4318,6 +4486,10 @@ void VkCommandQueue::RejectForRuntime(
         );
         std::unique_lock<std::mutex> lock(event_mutex);
         const uint64 retirement_serial = retirement_enqueued_serial + 1;
+        const std::shared_ptr<VulkanBatchCompletionGroup>
+            completion_group = _batch_completion.Valid() ?
+                _batch_completion.group :
+                nullptr;
         event_queue.emplace_back(
             std::in_place_type<VulkanSubmitCompletionBatch>,
             0,
@@ -4334,8 +4506,23 @@ void VkCommandQueue::RejectForRuntime(
             std::move(_submit),
             VulkanAllocatorBatch{},
             std::optional<VulkanDescriptorPushLease>{},
-            Array<RHIResource*>{}
+            Array<RHIResource*>{},
+            std::move(_batch_completion)
         );
+        if (completion_group) {
+            std::erase_if(
+                batch_completion_settlements,
+                [](const VulkanBatchCompletionSettlement& settlement) {
+                    return settlement.group.expired();
+                }
+            );
+            batch_completion_settlements.emplace_back(
+                VulkanBatchCompletionSettlement{
+                    .retirement_serial = retirement_serial,
+                    .group             = completion_group,
+                }
+            );
+        }
         retirement_enqueued_serial = retirement_serial;
     } catch (...) {
         // Continuing would destroy callbacks/signals outside Completion and
@@ -4600,6 +4787,10 @@ void VkCommandQueue::CommitRuntimeSubmitCompletion(
 
         std::unique_lock<std::mutex> lock(event_mutex);
         const uint64 retirement_serial = retirement_enqueued_serial + 1;
+        const std::shared_ptr<VulkanBatchCompletionGroup>
+            completion_group = _recorded.batch_completion.Valid() ?
+                _recorded.batch_completion.group :
+                nullptr;
         event_queue.emplace_back(
             std::in_place_type<VulkanSubmitCompletionBatch>,
             _recorded.timeline,
@@ -4612,8 +4803,23 @@ void VkCommandQueue::CommitRuntimeSubmitCompletion(
             std::move(_recorded.submit),
             std::move(_recorded.allocators),
             std::move(_recorded.descriptor_lease),
-            std::move(_recorded.deferred_releases)
+            std::move(_recorded.deferred_releases),
+            std::move(_recorded.batch_completion)
         );
+        if (completion_group) {
+            std::erase_if(
+                batch_completion_settlements,
+                [](const VulkanBatchCompletionSettlement& settlement) {
+                    return settlement.group.expired();
+                }
+            );
+            batch_completion_settlements.emplace_back(
+                VulkanBatchCompletionSettlement{
+                    .retirement_serial = retirement_serial,
+                    .group             = completion_group,
+                }
+            );
+        }
         retirement_enqueued_serial     = retirement_serial;
         _recorded.completion_committed = true;
     } catch (...) {
@@ -7672,10 +7878,34 @@ void VkCommandQueue::CompletionThreadMain() {
                     if (!_batch.gpu_submitted) {
                         FinalizeRejectedBindlessUpdates(_batch.submit);
                     }
-                    Array<std::function<void()>> callbacks =
-                        std::move(_batch.submit.callbacks);
-                    Array<std::function<void()>> success_callbacks =
-                        std::move(_batch.submit.success_callbacks);
+                    Array<std::function<void()>> callbacks{};
+                    Array<std::function<void()>> success_callbacks{};
+                    std::optional<
+                        VulkanBatchCompletionGroup::Participant>
+                        grouped_completion{};
+                    if (_batch.batch_completion.Valid()) {
+                        grouped_completion.emplace();
+                        grouped_completion->query_tokens =
+                            std::move(_batch.submit.query_tokens);
+                        grouped_completion->query_batch = query_batch;
+                        grouped_completion->callbacks =
+                            std::move(_batch.submit.callbacks);
+                        grouped_completion->success_callbacks =
+                            std::move(_batch.submit.success_callbacks);
+                        grouped_completion->deferred_releases =
+                            std::move(_batch.deferred_releases);
+                        grouped_completion->device       = &vk_device;
+                        grouped_completion->gpu_success  =
+                            batch_gpu_success;
+                        grouped_completion->release_safe =
+                            batch_release_safe;
+                        _batch.submit.query_publish_batch = {};
+                    } else {
+                        callbacks =
+                            std::move(_batch.submit.callbacks);
+                        success_callbacks =
+                            std::move(_batch.submit.success_callbacks);
+                    }
                     _batch.submit.cmds.clear();
                     _batch.submit.cached_args.clear();
                     _batch.submit.segments.clear();
@@ -7683,18 +7913,20 @@ void VkCommandQueue::CompletionThreadMain() {
                     _batch.submit.signal_events.clear();
                     _batch.submit.debug_label.clear();
 
-                    _batch.submit.NotifyPendingQueries(query_batch);
-                    for (auto& allocator : _batch.allocators.submitted) {
-                        allocator->NotifyTimestampQueriesAfterGpuCompletion(
-                            query_batch
-                        );
+                    if (!grouped_completion.has_value()) {
+                        _batch.submit.NotifyPendingQueries(query_batch);
+                        for (auto& allocator : _batch.allocators.submitted) {
+                            allocator->NotifyTimestampQueriesAfterGpuCompletion(
+                                query_batch
+                            );
+                        }
+                        for (auto& allocator : _batch.allocators.abandoned) {
+                            allocator->NotifyTimestampQueriesAfterGpuCompletion(
+                                query_batch
+                            );
+                        }
+                        _batch.submit.query_tokens.clear();
                     }
-                    for (auto& allocator : _batch.allocators.abandoned) {
-                        allocator->NotifyTimestampQueriesAfterGpuCompletion(
-                            query_batch
-                        );
-                    }
-                    _batch.submit.query_tokens.clear();
 
                     if (recycle_batch) {
                         for (auto& allocator : _batch.allocators.submitted) {
@@ -7725,23 +7957,32 @@ void VkCommandQueue::CompletionThreadMain() {
                         }
                     }
 
-                    InvokeCallbacksNoexcept(
-                        callbacks, "[VulkanQueue] runtime completion"
-                    );
-                    if (batch_gpu_success) {
-                        InvokeCallbacksNoexcept(
-                            success_callbacks,
-                            "[VulkanQueue] runtime success completion"
+                    if (grouped_completion.has_value()) {
+                        VulkanBatchCompletionTicket ticket =
+                            std::move(_batch.batch_completion);
+                        ticket.group->Arrive(
+                            ticket.participant_index,
+                            std::move(*grouped_completion)
                         );
-                    }
-
-                    if (batch_gpu_success || batch_release_safe) {
-                        for (auto* resource : _batch.deferred_releases) {
-                            MoerDelete(resource);
-                        }
                     } else {
-                        for (auto* resource : _batch.deferred_releases) {
-                            vk_device.EnqueueDeferredRelease(resource);
+                        InvokeCallbacksNoexcept(
+                            callbacks, "[VulkanQueue] runtime completion"
+                        );
+                        if (batch_gpu_success) {
+                            InvokeCallbacksNoexcept(
+                                success_callbacks,
+                                "[VulkanQueue] runtime success completion"
+                            );
+                        }
+
+                        if (batch_gpu_success || batch_release_safe) {
+                            for (auto* resource : _batch.deferred_releases) {
+                                MoerDelete(resource);
+                            }
+                        } else {
+                            for (auto* resource : _batch.deferred_releases) {
+                                vk_device.EnqueueDeferredRelease(resource);
+                            }
                         }
                     }
                     _batch.deferred_releases.clear();
@@ -7959,13 +8200,58 @@ void VkCommandQueue::CompletionThreadMain() {
 }
 
 void VkCommandQueue::CompleteAll(uint64 _timeline) {
+    Array<std::shared_ptr<VulkanBatchCompletionGroup>>
+        completion_groups{};
+    uint64 target_retirement_serial = 0;
+    {
+        std::unique_lock<std::mutex> lock(event_mutex);
+        target_retirement_serial = retirement_enqueued_serial;
+        for (const VulkanBatchCompletionSettlement& settlement :
+             batch_completion_settlements) {
+            if (settlement.retirement_serial >
+                target_retirement_serial) {
+                continue;
+            }
+            if (auto group = settlement.group.lock()) {
+                completion_groups.emplace_back(std::move(group));
+            }
+        }
+        NotifyQueueLocalSyncWait(
+            queue.GetType(),
+            target_retirement_serial,
+            completion_groups.size()
+        );
+        queue_cv.wait(
+            lock,
+            [this, _timeline, target_retirement_serial]() {
+                return cpu_settled_frame.load(
+                           std::memory_order_acquire
+                       ) >= _timeline &&
+                       retirement_settled_serial.load(
+                           std::memory_order_acquire
+                       ) >= target_retirement_serial;
+            }
+        );
+    }
+
+    // A grouped packet can finish its queue-local retirement before the last
+    // sibling owner releases the batch-wide Query/callback/deferred-release
+    // tiers. External queue Sync must include that release, while Completion
+    // owners remain strictly non-blocking.
+    for (const auto& group : completion_groups) {
+        group->WaitUntilSettled();
+    }
+
     std::unique_lock<std::mutex> lock(event_mutex);
-    const uint64 target_retirement_serial = retirement_enqueued_serial;
-    queue_cv.wait(lock, [this, _timeline, target_retirement_serial]() {
-        return cpu_settled_frame.load(std::memory_order_acquire) >= _timeline &&
-               retirement_settled_serial.load(std::memory_order_acquire) >=
+    std::erase_if(
+        batch_completion_settlements,
+        [target_retirement_serial](
+            const VulkanBatchCompletionSettlement& settlement
+        ) {
+            return settlement.retirement_serial <=
                    target_retirement_serial;
-    });
+        }
+    );
 }
 
 #pragma endregion
@@ -8148,6 +8434,7 @@ VkCopyQueue::TranslateForRuntime(CmdSubmit&& _evt) noexcept {
             !recorded->submit.signal_events.empty() ||
             !recorded->submit.callbacks.empty() ||
             !recorded->submit.success_callbacks.empty() ||
+            !recorded->submit.query_tokens.empty() ||
             recorded->submit.b_sync ||
             recorded->submit.b_tick_profiling ||
             recorded->submit.b_delete_resources;
@@ -8435,10 +8722,12 @@ void VkCopyQueue::RejectRecordedForRuntime(
 void VkCopyQueue::RejectForRuntime(
     CmdSubmit&& _submit,
     VkResult    _result,
-    bool        _recoverable
+    bool        _recoverable,
+    VulkanBatchCompletionTicket _batch_completion
 ) noexcept {
     device.RecordRejectedSubmit();
     CurrentVulkanCopyRecordedSubmit rejected{std::move(_submit)};
+    rejected.batch_completion = std::move(_batch_completion);
     rejected.context = VulkanOperationContext{
         .operation  = EVulkanFaultOperation::QueueSubmit,
         .queue_type = EQueueType::Copy,
@@ -8492,6 +8781,10 @@ void VkCopyQueue::CommitRuntimeSubmitCompletion(
         }
         std::unique_lock<std::mutex> lock(event_mutex);
         const uint64 retirement_serial = retirement_enqueued_serial + 1;
+        const std::shared_ptr<VulkanBatchCompletionGroup>
+            completion_group = _recorded.batch_completion.Valid() ?
+                _recorded.batch_completion.group :
+                nullptr;
         event_queue.emplace_back(
             std::in_place_type<VulkanSubmitCompletionBatch>,
             _recorded.logical_timeline,
@@ -8504,8 +8797,23 @@ void VkCopyQueue::CommitRuntimeSubmitCompletion(
             std::move(_recorded.submit),
             std::move(_recorded.allocators),
             std::optional<VulkanDescriptorPushLease>{},
-            Array<RHIResource*>{}
+            Array<RHIResource*>{},
+            std::move(_recorded.batch_completion)
         );
+        if (completion_group) {
+            std::erase_if(
+                batch_completion_settlements,
+                [](const VulkanBatchCompletionSettlement& settlement) {
+                    return settlement.group.expired();
+                }
+            );
+            batch_completion_settlements.emplace_back(
+                VulkanBatchCompletionSettlement{
+                    .retirement_serial = retirement_serial,
+                    .group             = completion_group,
+                }
+            );
+        }
         retirement_enqueued_serial = retirement_serial;
         _recorded.completion_committed = true;
     } catch (...) {
@@ -8703,10 +9011,33 @@ void VkCopyQueue::ExecuteThread() {
                     if (!_batch.gpu_submitted) {
                         FinalizeRejectedBindlessUpdates(_batch.submit);
                     }
-                    Array<std::function<void()>> callbacks =
-                        std::move(_batch.submit.callbacks);
-                    Array<std::function<void()>> success_callbacks =
-                        std::move(_batch.submit.success_callbacks);
+                    Array<std::function<void()>> callbacks{};
+                    Array<std::function<void()>> success_callbacks{};
+                    std::optional<
+                        VulkanBatchCompletionGroup::Participant>
+                        grouped_completion{};
+                    if (_batch.batch_completion.Valid()) {
+                        grouped_completion.emplace();
+                        grouped_completion->query_tokens =
+                            std::move(_batch.submit.query_tokens);
+                        grouped_completion->query_batch = query_batch;
+                        grouped_completion->callbacks =
+                            std::move(_batch.submit.callbacks);
+                        grouped_completion->success_callbacks =
+                            std::move(_batch.submit.success_callbacks);
+                        grouped_completion->deferred_releases =
+                            std::move(_batch.deferred_releases);
+                        grouped_completion->device       = &device;
+                        grouped_completion->gpu_success  =
+                            batch_gpu_success;
+                        grouped_completion->release_safe = false;
+                        _batch.submit.query_publish_batch = {};
+                    } else {
+                        callbacks =
+                            std::move(_batch.submit.callbacks);
+                        success_callbacks =
+                            std::move(_batch.submit.success_callbacks);
+                    }
                     _batch.submit.cmds.clear();
                     _batch.submit.cached_args.clear();
                     _batch.submit.segments.clear();
@@ -8714,18 +9045,20 @@ void VkCopyQueue::ExecuteThread() {
                     _batch.submit.signal_events.clear();
                     _batch.submit.debug_label.clear();
 
-                    _batch.submit.NotifyPendingQueries(query_batch);
-                    for (auto& allocator : _batch.allocators.submitted) {
-                        allocator->NotifyTimestampQueriesAfterGpuCompletion(
-                            query_batch
-                        );
+                    if (!grouped_completion.has_value()) {
+                        _batch.submit.NotifyPendingQueries(query_batch);
+                        for (auto& allocator : _batch.allocators.submitted) {
+                            allocator->NotifyTimestampQueriesAfterGpuCompletion(
+                                query_batch
+                            );
+                        }
+                        for (auto& allocator : _batch.allocators.abandoned) {
+                            allocator->NotifyTimestampQueriesAfterGpuCompletion(
+                                query_batch
+                            );
+                        }
+                        _batch.submit.query_tokens.clear();
                     }
-                    for (auto& allocator : _batch.allocators.abandoned) {
-                        allocator->NotifyTimestampQueriesAfterGpuCompletion(
-                            query_batch
-                        );
-                    }
-                    _batch.submit.query_tokens.clear();
 
                     if (recycle_batch) {
                         for (auto& allocator : _batch.allocators.submitted) {
@@ -8756,21 +9089,30 @@ void VkCopyQueue::ExecuteThread() {
                         }
                     }
 
-                    InvokeCallbacksNoexcept(
-                        callbacks, "[VulkanCopyQueue] runtime completion"
-                    );
-                    if (batch_gpu_success) {
-                        InvokeCallbacksNoexcept(
-                            success_callbacks,
-                            "[VulkanCopyQueue] runtime success completion"
+                    if (grouped_completion.has_value()) {
+                        VulkanBatchCompletionTicket ticket =
+                            std::move(_batch.batch_completion);
+                        ticket.group->Arrive(
+                            ticket.participant_index,
+                            std::move(*grouped_completion)
                         );
-                    }
-
-                    for (auto* resource : _batch.deferred_releases) {
+                    } else {
+                        InvokeCallbacksNoexcept(
+                            callbacks, "[VulkanCopyQueue] runtime completion"
+                        );
                         if (batch_gpu_success) {
-                            MoerDelete(resource);
-                        } else {
-                            device.EnqueueDeferredRelease(resource);
+                            InvokeCallbacksNoexcept(
+                                success_callbacks,
+                                "[VulkanCopyQueue] runtime success completion"
+                            );
+                        }
+
+                        for (auto* resource : _batch.deferred_releases) {
+                            if (batch_gpu_success) {
+                                MoerDelete(resource);
+                            } else {
+                                device.EnqueueDeferredRelease(resource);
+                            }
                         }
                     }
                     _batch.deferred_releases.clear();
@@ -9047,13 +9389,54 @@ UniquePtr<VulkanAllocator> VkCopyQueue::GetAllocator() {
 }
 
 void VkCopyQueue::CompleteAll(uint64 _timeline) {
+    Array<std::shared_ptr<VulkanBatchCompletionGroup>>
+        completion_groups{};
+    uint64 target_retirement_serial = 0;
+    {
+        std::unique_lock<std::mutex> lock(event_mutex);
+        target_retirement_serial = retirement_enqueued_serial;
+        for (const VulkanBatchCompletionSettlement& settlement :
+             batch_completion_settlements) {
+            if (settlement.retirement_serial >
+                target_retirement_serial) {
+                continue;
+            }
+            if (auto group = settlement.group.lock()) {
+                completion_groups.emplace_back(std::move(group));
+            }
+        }
+        NotifyQueueLocalSyncWait(
+            EQueueType::Copy,
+            target_retirement_serial,
+            completion_groups.size()
+        );
+        settled_cv.wait(
+            lock,
+            [this, _timeline, target_retirement_serial]() {
+                return cpu_settled_frame.load(
+                           std::memory_order_acquire
+                       ) >= _timeline &&
+                       retirement_settled_serial.load(
+                           std::memory_order_acquire
+                       ) >= target_retirement_serial;
+            }
+        );
+    }
+
+    for (const auto& group : completion_groups) {
+        group->WaitUntilSettled();
+    }
+
     std::unique_lock<std::mutex> lock(event_mutex);
-    const uint64 target_retirement_serial = retirement_enqueued_serial;
-    settled_cv.wait(lock, [this, _timeline, target_retirement_serial]() {
-        return cpu_settled_frame.load(std::memory_order_acquire) >= _timeline &&
-               retirement_settled_serial.load(std::memory_order_acquire) >=
+    std::erase_if(
+        batch_completion_settlements,
+        [target_retirement_serial](
+            const VulkanBatchCompletionSettlement& settlement
+        ) {
+            return settlement.retirement_serial <=
                    target_retirement_serial;
-    });
+        }
+    );
 }
 #pragma endregion
 } // namespace Moer::Render

--- a/source/runtime/render/rhi/vulkan/VulkanQueue.cpp
+++ b/source/runtime/render/rhi/vulkan/VulkanQueue.cpp
@@ -41,6 +41,8 @@ std::atomic<const VulkanSubmissionDependencyWaitObserver*>
     g_submission_dependency_wait_observer{nullptr};
 std::atomic<const VulkanBackendSyncWaitObserver*>
     g_backend_sync_wait_observer{nullptr};
+std::atomic<const VulkanScriptedQueryPreparationOverrideForTesting*>
+    g_scripted_query_preparation_override{nullptr};
 std::atomic<const VulkanScriptedPresentOverrideForTesting*>
     g_scripted_present_override{nullptr};
 
@@ -130,6 +132,38 @@ bool RemoveVulkanNativeSubmissionObserver(
     }
     const VulkanNativeSubmissionObserver* expected = _observer;
     return g_native_submission_observer.compare_exchange_strong(
+        expected,
+        nullptr,
+        std::memory_order_acq_rel,
+        std::memory_order_acquire
+    );
+}
+
+bool TryInstallVulkanScriptedQueryPreparationOverrideForTesting(
+    const VulkanScriptedQueryPreparationOverrideForTesting* _override
+) noexcept {
+    if (_override == nullptr || _override->callback == nullptr) {
+        return false;
+    }
+    const VulkanScriptedQueryPreparationOverrideForTesting* expected =
+        nullptr;
+    return g_scripted_query_preparation_override.compare_exchange_strong(
+        expected,
+        _override,
+        std::memory_order_release,
+        std::memory_order_relaxed
+    );
+}
+
+bool RemoveVulkanScriptedQueryPreparationOverrideForTesting(
+    const VulkanScriptedQueryPreparationOverrideForTesting* _override
+) noexcept {
+    if (_override == nullptr) {
+        return false;
+    }
+    const VulkanScriptedQueryPreparationOverrideForTesting* expected =
+        _override;
+    return g_scripted_query_preparation_override.compare_exchange_strong(
         expected,
         nullptr,
         std::memory_order_acq_rel,
@@ -3660,6 +3694,21 @@ static VkResult GetRejectedSubmitResult(VulkanDevice& _device) {
     return _device.IsFaulted() ? _device.GetFirstFaultResult() : VK_ERROR_UNKNOWN;
 }
 
+static VulkanOperationResult MakeUnsubmittedOutcome(
+    VkResult _result,
+    bool     _recoverable
+) {
+    if (_result == VK_SUCCESS) {
+        _result = VK_ERROR_UNKNOWN;
+    }
+    return {
+        _recoverable ?
+            EVulkanOperationStatus::Rejected :
+            EVulkanOperationStatus::Faulted,
+        _result
+    };
+}
+
 static void MarkSubmissionAccepted(
     VulkanFence* _queue_timeline, uint64 _timeline, const Array<SignalEvent>& _signal_events
 ) {
@@ -4085,7 +4134,6 @@ VkCommandQueue::TranslateForRuntime(CmdSubmit&& _submit) noexcept {
     );
     auto execution_lease = runtime_execution_gate.Acquire();
     uint64 current_timeline = 0;
-    bool translation_terminalized = false;
     std::optional<CurrentVulkanRecordedSubmit> recorded{};
     try {
         std::unique_lock<std::mutex> execution_lock(exec_mtx);
@@ -4097,7 +4145,7 @@ VkCommandQueue::TranslateForRuntime(CmdSubmit&& _submit) noexcept {
             current_timeline,
             &recorded,
             true,
-            &translation_terminalized
+            nullptr
         );
     } catch (const std::exception& error) {
         try {
@@ -4117,18 +4165,12 @@ VkCommandQueue::TranslateForRuntime(CmdSubmit&& _submit) noexcept {
         recorded->execution_lease = std::move(execution_lease);
         return recorded;
     }
-    if (translation_terminalized) {
-        return std::nullopt;
-    }
 
-    if (current_timeline == 0) {
-        RejectForRuntime(std::move(_submit), VK_ERROR_UNKNOWN);
-        return std::nullopt;
-    }
-
-    // A timeline is reserved before translation begins. Unexpected translate
-    // failures must still publish a matching Completion retirement; otherwise
-    // queue Sync would wait forever on an orphaned last_frame value.
+    // Unexpected translate failures still travel through Submission as a
+    // terminal packet. This lets the executor publish the whole failed batch
+    // suffix before the current source becomes visible to Completion
+    // callbacks. current_timeline remains zero only if queue ownership could
+    // not be entered at all; that packet still has no native work to replay.
     CurrentVulkanRecordedSubmit rejected{
         std::move(_submit),
         VulkanOperationContext{
@@ -4142,16 +4184,16 @@ VkCommandQueue::TranslateForRuntime(CmdSubmit&& _submit) noexcept {
     };
     rejected.execution_lease       = std::move(execution_lease);
     rejected.retirement_outcome    = {
-        EVulkanOperationStatus::Rejected, VK_ERROR_UNKNOWN
+        EVulkanOperationStatus::Faulted, VK_ERROR_UNKNOWN
     };
     rejected.native_submit_resolved = true;
     vk_device.RecordRejectedSubmit();
-    CommitRuntimeSubmitCompletion(rejected, rejected.retirement_outcome);
-    return std::nullopt;
+    return rejected;
 }
 
 VulkanRuntimeSubmissionResult VkCommandQueue::SubmitRecordedForRuntime(
-    CurrentVulkanRecordedSubmit _recorded
+    CurrentVulkanRecordedSubmit           _recorded,
+    const VulkanRuntimePreCompletionHook* _pre_completion
 ) noexcept {
     assert(
         GetCurrentRHIThreadRole() == ERHIThreadRole::Submission &&
@@ -4166,43 +4208,43 @@ VulkanRuntimeSubmissionResult VkCommandQueue::SubmitRecordedForRuntime(
         _recorded.submit.EmitsProfilingQueries() &&
         _recorded.submit.ProfilingPhase() != ERHIProfilingPhase::Complete;
 
-    try {
-        std::unique_lock<std::mutex> execution_lock(exec_mtx);
-        const CurrentVulkanSubmitResult submit_result =
-            SubmitRecorded(_recorded, &runtime_dependency_waits_enabled);
-        if (split_profiling_frame && !submit_result.outcome.WasSubmitted()) {
-            ResetSplitProfilingCpuFrame();
-        }
-    } catch (const std::exception& error) {
+    if (!_recorded.native_submit_resolved) {
         try {
-            LOG_ERROR(
-                "[RHIExecutor][Vulkan] recorded submission threw before retirement: {}",
-                error.what()
-            );
+            std::unique_lock<std::mutex> execution_lock(exec_mtx);
+            const CurrentVulkanSubmitResult submit_result =
+                SubmitRecorded(
+                    _recorded,
+                    &runtime_dependency_waits_enabled,
+                    true
+                );
+            if (split_profiling_frame && !submit_result.outcome.WasSubmitted()) {
+                ResetSplitProfilingCpuFrame();
+            }
+        } catch (const std::exception& error) {
+            try {
+                LOG_ERROR(
+                    "[RHIExecutor][Vulkan] recorded submission threw before retirement: {}",
+                    error.what()
+                );
+            } catch (...) {
+            }
         } catch (...) {
-        }
-    } catch (...) {
-        try {
-            LOG_ERROR(
-                "[RHIExecutor][Vulkan] recorded submission threw before retirement"
-            );
-        } catch (...) {
+            try {
+                LOG_ERROR(
+                    "[RHIExecutor][Vulkan] recorded submission threw before retirement"
+                );
+            } catch (...) {
+            }
         }
     }
 
     if (!_recorded.native_submit_resolved) {
         queue.DiscardPendingSubmitState();
         vk_device.RecordRejectedSubmit();
-        _recorded.retirement_outcome = {
-            EVulkanOperationStatus::Rejected, VK_ERROR_UNKNOWN
-        };
+        _recorded.retirement_outcome =
+            MakeUnsubmittedOutcome(VK_ERROR_UNKNOWN, false);
+        _recorded.recoverable_rejection = false;
         _recorded.native_submit_resolved = true;
-    }
-    if (!_recorded.completion_committed) {
-        CommitRuntimeSubmitCompletion(_recorded, _recorded.retirement_outcome);
-    }
-    if (split_profiling_frame && !_recorded.retirement_outcome.WasSubmitted()) {
-        ResetSplitProfilingCpuFrame();
     }
 
     VulkanRuntimeSubmissionResult runtime_result{
@@ -4212,45 +4254,58 @@ VulkanRuntimeSubmissionResult VkCommandQueue::SubmitRecordedForRuntime(
     if (_recorded.retirement_outcome.WasSubmitted()) {
         runtime_result.completion = WaitEvent{uint64(timeline), submitted_timeline};
     }
+    if (_pre_completion != nullptr &&
+        _pre_completion->callback != nullptr) {
+        _pre_completion->callback(
+            _pre_completion->context, runtime_result
+        );
+    }
+    if (!_recorded.completion_committed) {
+        CommitRuntimeSubmitCompletion(_recorded, _recorded.retirement_outcome);
+    }
+    if (split_profiling_frame && !_recorded.retirement_outcome.WasSubmitted()) {
+        ResetSplitProfilingCpuFrame();
+    }
     return runtime_result;
 }
 
 void VkCommandQueue::RejectRecordedForRuntime(
     CurrentVulkanRecordedSubmit&& _recorded,
-    VkResult                       _result
+    VkResult                       _result,
+    bool                           _recoverable
 ) noexcept {
     assert(
         _recorded.execution_lease.OwnsGate() &&
         "a failed Translate -> Submission handoff must retain queue ownership"
     );
-    if (_result == VK_SUCCESS) {
-        _result = VK_ERROR_UNKNOWN;
-    }
     ResetSplitProfilingCpuFrame();
-    vk_device.RecordRejectedSubmit();
-    _recorded.retirement_outcome = {
-        EVulkanOperationStatus::Rejected, _result
-    };
-    _recorded.native_submit_resolved = true;
+    if (!_recorded.native_submit_resolved) {
+        vk_device.RecordRejectedSubmit();
+        _recorded.retirement_outcome =
+            MakeUnsubmittedOutcome(_result, _recoverable);
+        _recorded.recoverable_rejection = _recoverable;
+        _recorded.native_submit_resolved = true;
+    }
     if (!_recorded.completion_committed) {
         CommitRuntimeSubmitCompletion(_recorded, _recorded.retirement_outcome);
     }
 }
 
-void VkCommandQueue::RejectForRuntime(CmdSubmit&& _submit, VkResult _result) noexcept {
+void VkCommandQueue::RejectForRuntime(
+    CmdSubmit&& _submit,
+    VkResult    _result,
+    bool        _recoverable
+) noexcept {
     ResetSplitProfilingCpuFrame();
-    if (_result == VK_SUCCESS) {
-        _result = VK_ERROR_UNKNOWN;
-    }
+    const VulkanOperationResult outcome =
+        MakeUnsubmittedOutcome(_result, _recoverable);
     vk_device.RecordRejectedSubmit();
 
     try {
         TerminalizeUnsubmittedSignals(
             vk_device,
             _submit.signal_events,
-            VulkanOperationResult{
-                EVulkanOperationStatus::Rejected, _result
-            }
+            outcome
         );
         // Rejection is now externally observable. Completion must not retain
         // and dereference the raw fence pointers after a waiter releases its
@@ -4268,7 +4323,7 @@ void VkCommandQueue::RejectForRuntime(CmdSubmit&& _submit, VkResult _result) noe
             0,
             true,
             retirement_serial,
-            VulkanOperationResult{EVulkanOperationStatus::Rejected, _result},
+            outcome,
             VulkanOperationContext{
                 .operation  = EVulkanFaultOperation::QueueSubmit,
                 .queue_type = queue.GetType(),
@@ -4415,8 +4470,14 @@ VulkanRuntimeSubmissionResult VkCommandQueue::PresentForRuntime(
 VkCommandQueue::CurrentVulkanSubmitResult
 VkCommandQueue::SubmitRecorded(
     CurrentVulkanRecordedSubmit& _recorded,
-    const std::atomic_bool*       _continue_waiting
+    const std::atomic_bool*       _continue_waiting,
+    bool                          _defer_completion
 ) {
+    assert(
+        !_recorded.native_submit_resolved &&
+        !_recorded.completion_committed &&
+        "SubmitRecorded cannot replay a terminal Vulkan packet"
+    );
     assert(
         _recorded.has_commands == !_recorded.ordered_cmd_lists.empty() &&
         "recorded Vulkan submit command-list ownership mismatch"
@@ -4482,7 +4543,9 @@ VkCommandQueue::SubmitRecorded(
     const uint32 ordered_cmd_list_count =
         static_cast<uint32>(_recorded.ordered_cmd_lists.size());
 
-    CommitRuntimeSubmitCompletion(_recorded, submit_outcome);
+    if (!_defer_completion) {
+        CommitRuntimeSubmitCompletion(_recorded, submit_outcome);
+    }
 
     if (_recorded.profile.enabled) {
         _recorded.profile.sample.submit_cpu_ms = profile_submit_cpu_ms;
@@ -4890,30 +4953,26 @@ bool VkCommandQueue::TryExecuteParallel(
         collect_allocator(tracker_owner);
 
         Array<RHIResource*> deferred_releases = TakeDeferredReleases();
-        try {
-            std::unique_lock<std::mutex> lock(event_mutex);
-            const uint64 retirement_serial = retirement_enqueued_serial + 1;
-            event_queue.emplace_back(
-                std::in_place_type<VulkanSubmitCompletionBatch>,
-                _timeline,
-                true,
-                retirement_serial,
-                VulkanOperationResult{
-                    EVulkanOperationStatus::Rejected, _result
-                },
-                _context,
-                false,
-                true,
-                std::move(_submit),
-                VulkanAllocatorBatch{{}, std::move(abandoned_allocators)},
-                std::move(descriptor_lease),
-                std::move(deferred_releases)
+        CurrentVulkanRecordedSubmit rejected{
+            std::move(_submit), _context, _timeline
+        };
+        rejected.allocators.abandoned = std::move(abandoned_allocators);
+        rejected.descriptor_lease.emplace(std::move(descriptor_lease));
+        rejected.deferred_releases   = std::move(deferred_releases);
+        rejected.retirement_outcome = {
+            EVulkanOperationStatus::Rejected, _result
+        };
+        rejected.native_submit_resolved = true;
+        if (_out_recorded != nullptr) {
+            // Runtime Translate must hand the terminal packet to Submission.
+            // Its pre-Completion hook publishes the entire rejected suffix
+            // before this source can release any Completion callback.
+            _out_recorded->emplace(std::move(rejected));
+        } else {
+            CommitRuntimeSubmitCompletion(
+                rejected, rejected.retirement_outcome
             );
-            retirement_enqueued_serial = retirement_serial;
-        } catch (...) {
-            std::terminate();
         }
-        queue_cv.notify_one();
         if (parallel_record_verify) {
             try {
                 LOG_INFO(
@@ -5613,33 +5672,114 @@ void VkCommandQueue::ExecuteNow(
         ResetSplitProfilingCpuFrame();
         vk_device.RecordRejectedSubmit();
         const VkResult rejected_result = vk_device.GetFirstFaultResult();
-        try {
-            std::unique_lock<std::mutex> lock(event_mutex);
-            const uint64 retirement_serial = retirement_enqueued_serial + 1;
-            event_queue.emplace_back(
-                std::in_place_type<VulkanSubmitCompletionBatch>,
-                _timeline,
-                true,
-                retirement_serial,
-                VulkanOperationResult{
-                    EVulkanOperationStatus::Rejected, rejected_result
-                },
-                context,
-                false,
-                true,
-                std::move(_submit),
-                VulkanAllocatorBatch{},
-                std::optional<VulkanDescriptorPushLease>{},
-                Array<RHIResource*>{}
+        CurrentVulkanRecordedSubmit rejected{
+            std::move(_submit), context, _timeline
+        };
+        rejected.retirement_outcome = {
+            EVulkanOperationStatus::Rejected, rejected_result
+        };
+        rejected.native_submit_resolved = true;
+        if (_out_recorded != nullptr) {
+            _out_recorded->emplace(std::move(rejected));
+        } else {
+            CommitRuntimeSubmitCompletion(
+                rejected, rejected.retirement_outcome
             );
-            retirement_enqueued_serial = retirement_serial;
-        } catch (...) {
-            std::terminate();
+            if (_out_terminalized != nullptr) {
+                *_out_terminalized = true;
+            }
         }
-        queue_cv.notify_one();
-        if (_out_terminalized != nullptr) {
-            *_out_terminalized = true;
-        }
+        return;
+    }
+
+    const size_t timestamp_query_slot_count = static_cast<size_t>(
+        std::count_if(
+            _submit.cmds.begin(),
+            _submit.cmds.end(),
+            [](const UniquePtr<Command>& _command) {
+                return _command &&
+                       _command->Type() == Command::EType::Query;
+            }
+        )
+    );
+    auto reject_before_native_record =
+        [&](const VulkanOperationResult& _outcome,
+            std::string_view             _reason,
+            UniquePtr<VulkanAllocator>*  _abandoned_allocator = nullptr) {
+            try {
+                LOG_ERROR(
+                    "[RHIExecutor][Vulkan] rejected before native record: "
+                    "timeline={} reason={} VkResult={}",
+                    _timeline,
+                    _reason,
+                    static_cast<int32_t>(_outcome.result)
+                );
+            } catch (...) {
+            }
+
+            ResetSplitProfilingCpuFrame();
+            Array<UniquePtr<VulkanAllocator>> abandoned_allocators;
+            if (_abandoned_allocator != nullptr &&
+                *_abandoned_allocator) {
+                // Complete every allocation before CmdSubmit moves into the
+                // terminal packet. If reserve/emplace fails, the submit is
+                // still owned by ExecuteNow and cannot notify on Translate.
+                abandoned_allocators.reserve(1);
+                abandoned_allocators.emplace_back(
+                    std::move(*_abandoned_allocator)
+                );
+            }
+            CurrentVulkanRecordedSubmit rejected{
+                std::move(_submit), context, _timeline
+            };
+            rejected.allocators.abandoned =
+                std::move(abandoned_allocators);
+            rejected.retirement_outcome     = _outcome;
+            rejected.recoverable_rejection =
+                _outcome.status == EVulkanOperationStatus::Rejected &&
+                !vk_device.IsFaulted() &&
+                _outcome.result != VK_ERROR_DEVICE_LOST;
+            rejected.native_submit_resolved = true;
+            vk_device.RecordRejectedSubmit();
+            if (_out_recorded != nullptr) {
+                assert(
+                    !_out_recorded->has_value() &&
+                    "pre-record rejection cannot overwrite a recorded packet"
+                );
+                _out_recorded->emplace(std::move(rejected));
+                return;
+            }
+            CommitRuntimeSubmitCompletion(
+                rejected, rejected.retirement_outcome
+            );
+            if (_out_terminalized != nullptr) {
+                *_out_terminalized = true;
+            }
+        };
+
+    if (timestamp_query_slot_count != 0 &&
+        vk_device.GetTimestampValidBits(queue.GetType()) == 0) {
+        // Queue capability is known before any command buffer begins. Treat
+        // unsupported timestamps as a recoverable query-submit rejection, not
+        // as a native-record/device fault.
+        reject_before_native_record(
+            VulkanOperationResult{
+                EVulkanOperationStatus::Rejected,
+                VK_ERROR_FEATURE_NOT_PRESENT
+            },
+            "queue family does not support timestamp queries"
+        );
+        return;
+    }
+    if (timestamp_query_slot_count >
+        std::numeric_limits<uint32>::max()) {
+        reject_before_native_record(
+            VulkanOperationResult{
+                EVulkanOperationStatus::Rejected,
+                VK_ERROR_OUT_OF_POOL_MEMORY
+            },
+            "timestamp query slot count exceeds uint32 capacity"
+        );
         return;
     }
 
@@ -5703,6 +5843,84 @@ void VkCommandQueue::ExecuteNow(
     //Get Allocators for buffer, texture and commandlist
     auto  allocator_ptr = std::move(GetAllocator());
     auto& vk_allocator  = *allocator_ptr;
+    if (timestamp_query_slot_count != 0) {
+        const VulkanScriptedQueryPreparationOverrideForTesting*
+            scripted_override =
+                g_scripted_query_preparation_override.load(
+                    std::memory_order_acquire
+                );
+        if (scripted_override != nullptr) {
+            VkResult scripted_result = scripted_override->callback(
+                scripted_override->context,
+                queue.GetType(),
+                _timeline,
+                static_cast<uint32>(timestamp_query_slot_count)
+            );
+            if (scripted_result != VK_SUCCESS) {
+                // This seam must never masquerade as a native device loss.
+                // Keep malformed test callbacks inside the recoverable path.
+                if (scripted_result == VK_ERROR_DEVICE_LOST) {
+                    scripted_result = VK_ERROR_FEATURE_NOT_PRESENT;
+                }
+                reject_before_native_record(
+                    VulkanOperationResult{
+                        EVulkanOperationStatus::Rejected,
+                        scripted_result
+                    },
+                    "scripted timestamp query preparation rejection",
+                    &allocator_ptr
+                );
+                return;
+            }
+        }
+    }
+    try {
+        // Explicit Query commands force this source onto the serial recorder.
+        // Size (and lazily create) its allocator-local pool before Begin() so
+        // a legal large query packet cannot fail after native recording has
+        // already produced side effects.
+        vk_allocator.EnsureTimestampQueryCapacity(
+            timestamp_query_slot_count
+        );
+    } catch (const std::exception& error) {
+        try {
+            LOG_ERROR(
+                "[RHIExecutor][Vulkan] timestamp query pool preparation "
+                "failed: {}",
+                error.what()
+            );
+        } catch (...) {
+        }
+        const bool device_faulted = vk_device.IsFaulted();
+        reject_before_native_record(
+            VulkanOperationResult{
+                device_faulted ?
+                    EVulkanOperationStatus::Faulted :
+                    EVulkanOperationStatus::Rejected,
+                device_faulted ?
+                    vk_device.GetFirstFaultResult() :
+                    VK_ERROR_OUT_OF_POOL_MEMORY
+            },
+            "timestamp query pool preparation failed",
+            &allocator_ptr
+        );
+        return;
+    } catch (...) {
+        const bool device_faulted = vk_device.IsFaulted();
+        reject_before_native_record(
+            VulkanOperationResult{
+                device_faulted ?
+                    EVulkanOperationStatus::Faulted :
+                    EVulkanOperationStatus::Rejected,
+                device_faulted ?
+                    vk_device.GetFirstFaultResult() :
+                    VK_ERROR_OUT_OF_POOL_MEMORY
+            },
+            "timestamp query pool preparation failed",
+            &allocator_ptr
+        );
+        return;
+    }
 
     //Get Resource State Tracker
     auto& tracker = vk_allocator.GetTracker();
@@ -5815,32 +6033,25 @@ void VkCommandQueue::ExecuteNow(
             abandoned_allocators.push_back(std::move(allocator_ptr));
         }
         Array<RHIResource*> deferred_releases = TakeDeferredReleases();
-        try {
-            std::unique_lock<std::mutex> lock(event_mutex);
-            const uint64 retirement_serial = retirement_enqueued_serial + 1;
-            event_queue.emplace_back(
-                std::in_place_type<VulkanSubmitCompletionBatch>,
-                _timeline,
-                true,
-                retirement_serial,
-                VulkanOperationResult{
-                    EVulkanOperationStatus::Rejected, _result
-                },
-                context,
-                false,
-                true,
-                std::move(_submit),
-                VulkanAllocatorBatch{{}, std::move(abandoned_allocators)},
-                std::move(descriptor_lease),
-                std::move(deferred_releases)
+        CurrentVulkanRecordedSubmit rejected{
+            std::move(_submit), context, _timeline
+        };
+        rejected.allocators.abandoned = std::move(abandoned_allocators);
+        rejected.descriptor_lease     = std::move(descriptor_lease);
+        rejected.deferred_releases    = std::move(deferred_releases);
+        rejected.retirement_outcome = {
+            EVulkanOperationStatus::Rejected, _result
+        };
+        rejected.native_submit_resolved = true;
+        if (_out_recorded != nullptr) {
+            _out_recorded->emplace(std::move(rejected));
+        } else {
+            CommitRuntimeSubmitCompletion(
+                rejected, rejected.retirement_outcome
             );
-            retirement_enqueued_serial = retirement_serial;
-        } catch (...) {
-            std::terminate();
-        }
-        queue_cv.notify_one();
-        if (_out_terminalized != nullptr) {
-            *_out_terminalized = true;
+            if (_out_terminalized != nullptr) {
+                *_out_terminalized = true;
+            }
         }
     };
 
@@ -6159,14 +6370,29 @@ void VkCommandQueue::ExecuteNow(
                                                   std::chrono::steady_clock::now()
                                               ) :
                                               0.0;
+    Array<VulkanCmdList*> serial_cmd_lists;
+    VulkanAllocatorBatch serial_allocators;
+    if (has_cmd) {
+        serial_cmd_lists.reserve(1);
+        serial_cmd_lists.emplace_back(
+            &vk_allocator.GetCmdList()
+        );
+    }
+    serial_allocators.submitted.reserve(1);
+    serial_allocators.submitted.emplace_back(
+        std::move(allocator_ptr)
+    );
+
+    // From this point onward every ownership member is moved through noexcept
+    // constructors/assignments. No allocation may unwind a moved CmdSubmit on
+    // the Translate owner.
     CurrentVulkanRecordedSubmit recorded_submit{
         std::move(_submit), context, _timeline
     };
     recorded_submit.has_commands = has_cmd;
-    if (has_cmd) {
-        recorded_submit.ordered_cmd_lists.push_back(&vk_allocator.GetCmdList());
-    }
-    recorded_submit.allocators.submitted.push_back(std::move(allocator_ptr));
+    recorded_submit.ordered_cmd_lists =
+        std::move(serial_cmd_lists);
+    recorded_submit.allocators = std::move(serial_allocators);
     recorded_submit.descriptor_lease  = std::move(descriptor_lease);
     recorded_submit.deferred_releases = std::move(deferred_releases);
     if (parallel_record_profile) {
@@ -7894,7 +8120,7 @@ IOWaitEvt VkCopyQueue::Execute(CmdSubmit&& _evt) {
         );
     } catch (...) {
     }
-    RejectForRuntime(std::move(_evt), VK_ERROR_UNKNOWN);
+    RejectForRuntime(std::move(_evt), VK_ERROR_UNKNOWN, true);
     return {0, 0};
 }
 
@@ -7950,10 +8176,7 @@ VkCopyQueue::TranslateForRuntime(CmdSubmit&& _evt) noexcept {
                 device.GetFirstFaultResult()
             };
             recorded->native_submit_resolved = true;
-            CommitRuntimeSubmitCompletion(
-                *recorded, recorded->retirement_outcome
-            );
-            return std::nullopt;
+            return recorded;
         }
 
         FunctionTable function_table{
@@ -8036,26 +8259,22 @@ VkCopyQueue::TranslateForRuntime(CmdSubmit&& _evt) noexcept {
     }
 
     if (!recorded) {
-        RejectForRuntime(std::move(_evt), VK_ERROR_UNKNOWN);
-        return std::nullopt;
+        recorded.emplace(std::move(_evt));
+        recorded->execution_lease = std::move(execution_lease);
     }
     if (!recorded->native_submit_resolved) {
         device.RecordRejectedSubmit();
         recorded->retirement_outcome = {
-            EVulkanOperationStatus::Rejected, VK_ERROR_UNKNOWN
+            EVulkanOperationStatus::Faulted, VK_ERROR_UNKNOWN
         };
         recorded->native_submit_resolved = true;
     }
-    if (!recorded->completion_committed) {
-        CommitRuntimeSubmitCompletion(
-            *recorded, recorded->retirement_outcome
-        );
-    }
-    return std::nullopt;
+    return recorded;
 }
 
 VulkanRuntimeSubmissionResult VkCopyQueue::SubmitRecordedForRuntime(
-    CurrentVulkanCopyRecordedSubmit _recorded
+    CurrentVulkanCopyRecordedSubmit       _recorded,
+    const VulkanRuntimePreCompletionHook* _pre_completion
 ) noexcept {
     assert(
         execution_ownership_mode.load(std::memory_order_acquire) ==
@@ -8071,99 +8290,100 @@ VulkanRuntimeSubmissionResult VkCopyQueue::SubmitRecordedForRuntime(
         "runtime Copy packet must retain queue execution ownership"
     );
 
-    if (_recorded.logical_timeline == 0) {
+    if (_recorded.logical_timeline == 0 &&
+        _recorded.completion_committed) {
         return {
             .outcome = _recorded.retirement_outcome,
         };
     }
 
-    try {
-        std::unique_lock<std::mutex> execution_lock(exec_mutex);
-        if (!WaitForSubmittedDependencies(
-                device,
-                _recorded.submit.wait_events,
-                EQueueType::Copy,
-                &dependency_waits_enabled
-            )) {
-            device.RecordRejectedSubmit();
-            _recorded.retirement_outcome = {
-                EVulkanOperationStatus::Rejected,
-                GetRejectedSubmitResult(device)
-            };
-            _recorded.recoverable_rejection = !device.IsFaulted();
-            _recorded.native_submit_resolved = true;
-        } else {
-            queue.Signal(
-                timeline,
-                _recorded.logical_timeline,
-                VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT
-            );
-            for (auto& event : _recorded.submit.wait_events) {
-                queue.Wait(
-                    reinterpret_cast<VulkanFence*>(
-                        event.timeline_handle
-                    ),
-                    event.value
-                );
-            }
-            for (auto& event : _recorded.submit.signal_events) {
+    if (!_recorded.native_submit_resolved) {
+        try {
+            std::unique_lock<std::mutex> execution_lock(exec_mutex);
+            if (!WaitForSubmittedDependencies(
+                    device,
+                    _recorded.submit.wait_events,
+                    EQueueType::Copy,
+                    &dependency_waits_enabled
+                )) {
+                device.RecordRejectedSubmit();
+                _recorded.retirement_outcome = {
+                    EVulkanOperationStatus::Rejected,
+                    GetRejectedSubmitResult(device)
+                };
+                _recorded.recoverable_rejection =
+                    !device.IsFaulted();
+                _recorded.native_submit_resolved = true;
+            } else {
                 queue.Signal(
-                    reinterpret_cast<VulkanFence*>(
-                        event.timeline_handle
-                    ),
-                    event.value,
+                    timeline,
+                    _recorded.logical_timeline,
                     VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT
                 );
-            }
+                for (auto& event : _recorded.submit.wait_events) {
+                    queue.Wait(
+                        reinterpret_cast<VulkanFence*>(
+                            event.timeline_handle
+                        ),
+                        event.value
+                    );
+                }
+                for (auto& event : _recorded.submit.signal_events) {
+                    queue.Signal(
+                        reinterpret_cast<VulkanFence*>(
+                            event.timeline_handle
+                        ),
+                        event.value,
+                        VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT
+                    );
+                }
 
-            assert(
-                _recorded.allocators.submitted.size() == 1 &&
-                "Copy Translate must publish exactly one command allocator"
-            );
-            auto& vk_allocator =
-                *_recorded.allocators.submitted.front();
-            _recorded.retirement_outcome =
-                queue.Submit(vk_allocator.GetCmdList(), _recorded.context);
-            _recorded.native_submit_resolved = true;
-            if (_recorded.retirement_outcome.WasSubmitted()) {
-                MarkSubmissionAccepted(
-                    timeline.Get(),
-                    _recorded.logical_timeline,
-                    _recorded.submit.signal_events
+                assert(
+                    _recorded.allocators.submitted.size() == 1 &&
+                    "Copy Translate must publish exactly one command allocator"
                 );
+                auto& vk_allocator =
+                    *_recorded.allocators.submitted.front();
+                _recorded.retirement_outcome =
+                    queue.Submit(
+                        vk_allocator.GetCmdList(),
+                        _recorded.context
+                    );
+                _recorded.native_submit_resolved = true;
+                if (_recorded.retirement_outcome.WasSubmitted()) {
+                    MarkSubmissionAccepted(
+                        timeline.Get(),
+                        _recorded.logical_timeline,
+                        _recorded.submit.signal_events
+                    );
+                }
             }
-        }
-    } catch (const std::exception& error) {
-        try {
-            LOG_ERROR(
-                "[RHIExecutor][Vulkan] Copy recorded submit threw before retirement: {}",
-                error.what()
-            );
+        } catch (const std::exception& error) {
+            try {
+                LOG_ERROR(
+                    "[RHIExecutor][Vulkan] Copy recorded submit threw before retirement: {}",
+                    error.what()
+                );
+            } catch (...) {
+            }
         } catch (...) {
-        }
-    } catch (...) {
-        try {
-            LOG_ERROR(
-                "[RHIExecutor][Vulkan] Copy recorded submit threw before retirement"
-            );
-        } catch (...) {
+            try {
+                LOG_ERROR(
+                    "[RHIExecutor][Vulkan] Copy recorded submit threw before retirement"
+                );
+            } catch (...) {
+            }
         }
     }
 
     if (!_recorded.native_submit_resolved) {
         queue.DiscardPendingSubmitState();
         device.RecordRejectedSubmit();
-        _recorded.retirement_outcome = {
-            EVulkanOperationStatus::Rejected, VK_ERROR_UNKNOWN
-        };
+        _recorded.retirement_outcome =
+            MakeUnsubmittedOutcome(VK_ERROR_UNKNOWN, false);
+        _recorded.recoverable_rejection = false;
         _recorded.native_submit_resolved = true;
     }
-    if (!_recorded.completion_committed) {
-        CommitRuntimeSubmitCompletion(
-            _recorded, _recorded.retirement_outcome
-        );
-    }
-
     VulkanRuntimeSubmissionResult runtime_result{
         .outcome               = _recorded.retirement_outcome,
         .recoverable_rejection = _recorded.recoverable_rejection,
@@ -8175,36 +8395,48 @@ VulkanRuntimeSubmissionResult VkCopyQueue::SubmitRecordedForRuntime(
                 _recorded.logical_timeline
             };
     }
+    if (_pre_completion != nullptr &&
+        _pre_completion->callback != nullptr) {
+        _pre_completion->callback(
+            _pre_completion->context, runtime_result
+        );
+    }
+    if (!_recorded.completion_committed) {
+        CommitRuntimeSubmitCompletion(
+            _recorded, _recorded.retirement_outcome
+        );
+    }
     return runtime_result;
 }
 
 void VkCopyQueue::RejectRecordedForRuntime(
     CurrentVulkanCopyRecordedSubmit&& _recorded,
-    VkResult                           _result
+    VkResult                           _result,
+    bool                               _recoverable
 ) noexcept {
     assert(
         _recorded.execution_lease.OwnsGate() &&
         "a failed Copy Translate -> Submission handoff must retain ownership"
     );
-    if (_result == VK_SUCCESS) {
-        _result = VK_ERROR_UNKNOWN;
+    if (!_recorded.native_submit_resolved) {
+        queue.DiscardPendingSubmitState();
+        device.RecordRejectedSubmit();
+        _recorded.retirement_outcome =
+            MakeUnsubmittedOutcome(_result, _recoverable);
+        _recorded.recoverable_rejection = _recoverable;
+        _recorded.native_submit_resolved = true;
     }
-    queue.DiscardPendingSubmitState();
-    device.RecordRejectedSubmit();
-    _recorded.retirement_outcome = {
-        EVulkanOperationStatus::Rejected, _result
-    };
-    _recorded.native_submit_resolved = true;
     if (!_recorded.completion_committed) {
         CommitRuntimeSubmitCompletion(
             _recorded, _recorded.retirement_outcome
         );
     }
 }
-void VkCopyQueue::RejectForRuntime(CmdSubmit&& _submit, VkResult _result) noexcept {
-    if (_result == VK_SUCCESS) {
-        _result = VK_ERROR_UNKNOWN;
-    }
+void VkCopyQueue::RejectForRuntime(
+    CmdSubmit&& _submit,
+    VkResult    _result,
+    bool        _recoverable
+) noexcept {
     device.RecordRejectedSubmit();
     CurrentVulkanCopyRecordedSubmit rejected{std::move(_submit)};
     rejected.context = VulkanOperationContext{
@@ -8212,9 +8444,9 @@ void VkCopyQueue::RejectForRuntime(CmdSubmit&& _submit, VkResult _result) noexce
         .queue_type = EQueueType::Copy,
         .queue      = queue.GetHandle(),
     };
-    rejected.retirement_outcome = {
-        EVulkanOperationStatus::Rejected, _result
-    };
+    rejected.retirement_outcome =
+        MakeUnsubmittedOutcome(_result, _recoverable);
+    rejected.recoverable_rejection = _recoverable;
     rejected.native_submit_resolved = true;
     CommitRuntimeSubmitCompletion(
         rejected, rejected.retirement_outcome

--- a/source/runtime/render/rhi/vulkan/VulkanQueue.h
+++ b/source/runtime/render/rhi/vulkan/VulkanQueue.h
@@ -232,6 +232,14 @@ struct VulkanRuntimeSubmissionResult {
     }
 };
 
+using VulkanRuntimePreCompletionCallback =
+    void (*)(void*, const VulkanRuntimeSubmissionResult&) noexcept;
+
+struct VulkanRuntimePreCompletionHook {
+    void*                                context{nullptr};
+    VulkanRuntimePreCompletionCallback  callback{nullptr};
+};
+
 struct VulkanCallbackBatch {
     Array<std::function<void()>> callbacks;
     bool                         success_only{false};
@@ -667,7 +675,7 @@ private:
             CmdSubmit&&                   _submit,
             const VulkanOperationContext& _context,
             uint64                        _timeline
-        ) :
+        ) noexcept :
             submit(std::move(_submit)), context(_context), timeline(_timeline) {}
 
         CurrentVulkanRecordedSubmit(const CurrentVulkanRecordedSubmit&) = delete;
@@ -708,18 +716,25 @@ private:
     );
     CurrentVulkanSubmitResult SubmitRecorded(
         CurrentVulkanRecordedSubmit& _recorded,
-        const std::atomic_bool*       _continue_waiting = nullptr
+        const std::atomic_bool*       _continue_waiting = nullptr,
+        bool                          _defer_completion = false
     );
     std::optional<CurrentVulkanRecordedSubmit>
         TranslateForRuntime(CmdSubmit&& _submit) noexcept;
     VulkanRuntimeSubmissionResult SubmitRecordedForRuntime(
-        CurrentVulkanRecordedSubmit _recorded
+        CurrentVulkanRecordedSubmit             _recorded,
+        const VulkanRuntimePreCompletionHook*   _pre_completion = nullptr
     ) noexcept;
     void RejectRecordedForRuntime(
         CurrentVulkanRecordedSubmit&& _recorded,
-        VkResult                       _result
+        VkResult                       _result,
+        bool                           _recoverable
     ) noexcept;
-    void RejectForRuntime(CmdSubmit&& _submit, VkResult _result) noexcept;
+    void RejectForRuntime(
+        CmdSubmit&& _submit,
+        VkResult    _result,
+        bool        _recoverable
+    ) noexcept;
     [[nodiscard]] bool ClaimRuntimeOwnership();
     void ReleaseRuntimeOwnership() noexcept;
     void CancelRuntimeDependencyWaits() noexcept;
@@ -965,12 +980,18 @@ private:
     void RHIThreadLoop();
 
 private:
-    void RejectForRuntime(CmdSubmit&& _submit, VkResult _result) noexcept;
+    void RejectForRuntime(
+        CmdSubmit&& _submit,
+        VkResult    _result,
+        bool        _recoverable
+    ) noexcept;
     void EnableRuntimeDependencyWaits() noexcept;
     void CancelRuntimeDependencyWaits() noexcept;
 
     struct CurrentVulkanCopyRecordedSubmit {
-        explicit CurrentVulkanCopyRecordedSubmit(CmdSubmit&& _submit) :
+        explicit CurrentVulkanCopyRecordedSubmit(
+            CmdSubmit&& _submit
+        ) noexcept :
             submit(std::move(_submit)) {}
 
         CurrentVulkanCopyRecordedSubmit(
@@ -1002,11 +1023,13 @@ private:
     std::optional<CurrentVulkanCopyRecordedSubmit>
         TranslateForRuntime(CmdSubmit&& _submit) noexcept;
     VulkanRuntimeSubmissionResult SubmitRecordedForRuntime(
-        CurrentVulkanCopyRecordedSubmit _recorded
+        CurrentVulkanCopyRecordedSubmit         _recorded,
+        const VulkanRuntimePreCompletionHook*   _pre_completion = nullptr
     ) noexcept;
     void RejectRecordedForRuntime(
         CurrentVulkanCopyRecordedSubmit&& _recorded,
-        VkResult                           _result
+        VkResult                           _result,
+        bool                               _recoverable
     ) noexcept;
     [[nodiscard]] bool ClaimRuntimeOwnership();
     void ReleaseRuntimeOwnership() noexcept;

--- a/source/runtime/render/rhi/vulkan/VulkanQueue.h
+++ b/source/runtime/render/rhi/vulkan/VulkanQueue.h
@@ -18,6 +18,8 @@
 #include <chrono>
 #include <condition_variable>
 #include <functional>
+#include <limits>
+#include <memory>
 #include <mutex>
 #include <optional>
 #include <string_view>
@@ -254,6 +256,57 @@ struct VulkanDeferredReleaseBatch {
     Array<RHIResource*> resources;
 };
 
+// A runtime backend batch may retire through several logical Completion
+// owners. Query/Fence waiters used by an earlier source callback must not
+// block the only owner capable of publishing a later source. Every
+// executable source therefore publishes its terminal state independently,
+// then arrives here without waiting. The last Completion owner releases all
+// user notifications in stable source order.
+class VulkanBatchCompletionGroup final {
+public:
+    struct Participant {
+        Array<QueryToken>                query_tokens;
+        QueryPublishBatch                query_batch{};
+        Array<std::function<void()>>     callbacks;
+        Array<std::function<void()>>     success_callbacks;
+        Array<RHIResource*>              deferred_releases;
+        VulkanDevice*                    device{nullptr};
+        bool                             gpu_success{false};
+        bool                             release_safe{false};
+    };
+
+    explicit VulkanBatchCompletionGroup(size_t _participant_count);
+
+    VulkanBatchCompletionGroup(const VulkanBatchCompletionGroup&) = delete;
+    VulkanBatchCompletionGroup& operator=(const VulkanBatchCompletionGroup&) = delete;
+
+    void Arrive(size_t _participant_index, Participant&& _participant) noexcept;
+    void WaitUntilSettled();
+
+private:
+    std::mutex                         mutex{};
+    std::condition_variable            settled_cv{};
+    Array<std::optional<Participant>> participants{};
+    size_t                             remaining{0};
+    bool                               released{false};
+    bool                               settled{false};
+};
+
+struct VulkanBatchCompletionTicket {
+    std::shared_ptr<VulkanBatchCompletionGroup> group{};
+    size_t participant_index{std::numeric_limits<size_t>::max()};
+
+    [[nodiscard]] bool Valid() const noexcept {
+        return group != nullptr &&
+               participant_index != std::numeric_limits<size_t>::max();
+    }
+};
+
+struct VulkanBatchCompletionSettlement {
+    uint64                                    retirement_serial{0};
+    std::weak_ptr<VulkanBatchCompletionGroup> group{};
+};
+
 // Runtime-recorded submissions cross the Submission -> Completion boundary as
 // one move-only ownership packet.  Keeping the command payload, allocator
 // retirement, descriptor lease, callbacks, signals, and deferred releases in
@@ -268,7 +321,8 @@ struct VulkanSubmitCompletionBatch {
         CmdSubmit&&                              _submit,
         VulkanAllocatorBatch&&                   _allocators,
         std::optional<VulkanDescriptorPushLease>&& _descriptor_lease,
-        Array<RHIResource*>&&                    _deferred_releases
+        Array<RHIResource*>&&                    _deferred_releases,
+        VulkanBatchCompletionTicket              _batch_completion = {}
     ) noexcept :
         outcome(_outcome),
         context(_context),
@@ -277,7 +331,8 @@ struct VulkanSubmitCompletionBatch {
         submit(std::move(_submit)),
         allocators(std::move(_allocators)),
         descriptor_lease(std::move(_descriptor_lease)),
-        deferred_releases(std::move(_deferred_releases)) {}
+        deferred_releases(std::move(_deferred_releases)),
+        batch_completion(std::move(_batch_completion)) {}
 
     VulkanSubmitCompletionBatch(
         VulkanOperationResult      _outcome,
@@ -287,7 +342,8 @@ struct VulkanSubmitCompletionBatch {
         CmdSubmit&&                _submit,
         VulkanAllocatorBatch&&     _allocators,
         VulkanDescriptorPushLease&& _descriptor_lease,
-        Array<RHIResource*>&&      _deferred_releases
+        Array<RHIResource*>&&      _deferred_releases,
+        VulkanBatchCompletionTicket _batch_completion = {}
     ) noexcept :
         outcome(_outcome),
         context(_context),
@@ -296,7 +352,8 @@ struct VulkanSubmitCompletionBatch {
         submit(std::move(_submit)),
         allocators(std::move(_allocators)),
         descriptor_lease(std::move(_descriptor_lease)),
-        deferred_releases(std::move(_deferred_releases)) {}
+        deferred_releases(std::move(_deferred_releases)),
+        batch_completion(std::move(_batch_completion)) {}
 
     VulkanSubmitCompletionBatch(const VulkanSubmitCompletionBatch&) = delete;
     VulkanSubmitCompletionBatch& operator=(const VulkanSubmitCompletionBatch&) = delete;
@@ -311,6 +368,7 @@ struct VulkanSubmitCompletionBatch {
     VulkanAllocatorBatch                     allocators;
     std::optional<VulkanDescriptorPushLease> descriptor_lease;
     Array<RHIResource*>                      deferred_releases;
+    VulkanBatchCompletionTicket              batch_completion{};
 };
 
 enum class EVulkanPresentorRetirementState : uint8_t {
@@ -691,6 +749,7 @@ private:
         VulkanAllocatorBatch                    allocators;
         std::optional<VulkanDescriptorPushLease> descriptor_lease;
         Array<RHIResource*>                     deferred_releases;
+        VulkanBatchCompletionTicket             batch_completion{};
         CurrentVulkanRecordedSubmitProfile      profile;
         RHITransferableOwnershipGate::Lease     execution_lease{};
         VulkanOperationResult                   retirement_outcome{
@@ -733,7 +792,8 @@ private:
     void RejectForRuntime(
         CmdSubmit&& _submit,
         VkResult    _result,
-        bool        _recoverable
+        bool        _recoverable,
+        VulkanBatchCompletionTicket _batch_completion = {}
     ) noexcept;
     [[nodiscard]] bool ClaimRuntimeOwnership();
     void ReleaseRuntimeOwnership() noexcept;
@@ -818,6 +878,7 @@ private:
     std::atomic<uint64>                                cpu_settled_frame = 0;
     uint64                                             retirement_enqueued_serial{0};
     std::atomic<uint64>                                retirement_settled_serial{0};
+    Array<VulkanBatchCompletionSettlement>             batch_completion_settlements{};
     VulkanFence*                                       timeline = nullptr;
     std::mutex                                         event_mutex;
     bool                                               completion_worker_running{false};
@@ -983,7 +1044,8 @@ private:
     void RejectForRuntime(
         CmdSubmit&& _submit,
         VkResult    _result,
-        bool        _recoverable
+        bool        _recoverable,
+        VulkanBatchCompletionTicket _batch_completion = {}
     ) noexcept;
     void EnableRuntimeDependencyWaits() noexcept;
     void CancelRuntimeDependencyWaits() noexcept;
@@ -1011,6 +1073,7 @@ private:
         VulkanOperationContext              context{};
         uint64                              logical_timeline{0};
         VulkanAllocatorBatch                allocators{};
+        VulkanBatchCompletionTicket         batch_completion{};
         RHITransferableOwnershipGate::Lease execution_lease{};
         VulkanOperationResult               retirement_outcome{
             EVulkanOperationStatus::Rejected, VK_ERROR_UNKNOWN
@@ -1054,6 +1117,7 @@ private:
     std::atomic<uint64>     cpu_settled_frame = 0;
     uint64                  retirement_enqueued_serial{0};
     std::atomic<uint64>     retirement_settled_serial{0};
+    Array<VulkanBatchCompletionSettlement> batch_completion_settlements{};
     VulkanFenceRef          timeline       = nullptr;
     std::mutex              event_mutex;
     std::atomic_bool        enabled{false};

--- a/source/runtime/render/rhi/vulkan/VulkanSerialGolden.cpp
+++ b/source/runtime/render/rhi/vulkan/VulkanSerialGolden.cpp
@@ -782,6 +782,13 @@ struct VulkanSerialGoldenTrace::Impl {
                 }
                 break;
             }
+            case Command::EType::Query: {
+                const auto& command = *static_cast<const QueryCmd*>(_command);
+                hash.Add(static_cast<uint64_t>(command.Token().Kind()));
+                hash.Add(static_cast<uint64_t>(command.Op()));
+                hash.AddString(command.Token().Name());
+                break;
+            }
             case Command::EType::Scope: {
                 const auto& command = *static_cast<const ScopeCmd*>(_command);
                 hash.Add(command.IsPush() ? 1u : 0u);

--- a/source/runtime/render/rhi/vulkan/VulkanSubmissionDiagnostics.h
+++ b/source/runtime/render/rhi/vulkan/VulkanSubmissionDiagnostics.h
@@ -276,6 +276,38 @@ RemoveVulkanBackendSyncWaitObserver(
     const VulkanBackendSyncWaitObserver* _observer
 ) noexcept;
 
+struct VulkanQueueLocalSyncWaitEvent {
+    EQueueType     queue{EQueueType::Ignore};
+    uint32         thread_id{0};
+    ERHIThreadRole thread_role{ERHIThreadRole::Unknown};
+    uint64         target_retirement_serial{0};
+    uint32         completion_group_count{0};
+};
+
+using VulkanQueueLocalSyncWaitCallback =
+    void (*)(
+        void*,
+        const VulkanQueueLocalSyncWaitEvent&
+    ) noexcept;
+
+struct VulkanQueueLocalSyncWaitObserver {
+    void*                            context{nullptr};
+    VulkanQueueLocalSyncWaitCallback callback{nullptr};
+};
+
+// Fires inside queue-local CompleteAll after it snapshots the target
+// retirement serial and every associated batch Completion group, immediately
+// before it waits. The callback runs while the queue event mutex is held and
+// therefore must be non-blocking, noexcept, and must not re-enter RHI.
+[[nodiscard]] RENDER_API bool
+TryInstallVulkanQueueLocalSyncWaitObserver(
+    const VulkanQueueLocalSyncWaitObserver* _observer
+) noexcept;
+[[nodiscard]] RENDER_API bool
+RemoveVulkanQueueLocalSyncWaitObserver(
+    const VulkanQueueLocalSyncWaitObserver* _observer
+) noexcept;
+
 using VulkanScriptedQueryPreparationCallback =
     VkResult (*)(void*, EQueueType, uint64, uint32) noexcept;
 

--- a/source/runtime/render/rhi/vulkan/VulkanSubmissionDiagnostics.h
+++ b/source/runtime/render/rhi/vulkan/VulkanSubmissionDiagnostics.h
@@ -276,6 +276,32 @@ RemoveVulkanBackendSyncWaitObserver(
     const VulkanBackendSyncWaitObserver* _observer
 ) noexcept;
 
+using VulkanScriptedQueryPreparationCallback =
+    VkResult (*)(void*, EQueueType, uint64, uint32) noexcept;
+
+struct VulkanScriptedQueryPreparationOverrideForTesting {
+    void*                                    context{nullptr};
+    VulkanScriptedQueryPreparationCallback  callback{nullptr};
+};
+
+// Narrow deterministic seam for a recoverable timestamp-pool preparation
+// rejection. The callback runs on the Translate owner while queue execution is
+// serialized, after the logical timeline is reserved but before command-buffer
+// recording or native query-pool allocation. VK_SUCCESS continues through the
+// production path; a non-device-loss error rejects this source without latching
+// the Vulkan device.
+//
+// Override storage and context are caller-owned and immutable while installed.
+// Quiesce the RHI runtime before removal and destroy them only after removal.
+[[nodiscard]] RENDER_API bool
+TryInstallVulkanScriptedQueryPreparationOverrideForTesting(
+    const VulkanScriptedQueryPreparationOverrideForTesting* _override
+) noexcept;
+[[nodiscard]] RENDER_API bool
+RemoveVulkanScriptedQueryPreparationOverrideForTesting(
+    const VulkanScriptedQueryPreparationOverrideForTesting* _override
+) noexcept;
+
 struct VulkanScriptedPresentResult {
     VulkanOperationResult outcome{
         EVulkanOperationStatus::Retry,

--- a/source/runtime/render/rhi/vulkan/VulkanSubmissionExecutor.cpp
+++ b/source/runtime/render/rhi/vulkan/VulkanSubmissionExecutor.cpp
@@ -297,8 +297,10 @@ class VulkanMultiSegmentCompletionState final {
 public:
     explicit VulkanMultiSegmentCompletionState(Array<FenceRef>&& _segment_outcomes) :
         segment_outcomes(std::move(_segment_outcomes)),
-        retired(segment_outcomes.size(), uint8{0}),
-        remaining(segment_outcomes.size()) {}
+        ordinary_retired(segment_outcomes.size(), uint8{0}),
+        success_retired(segment_outcomes.size(), uint8{0}),
+        ordinary_remaining(segment_outcomes.size()),
+        success_remaining(segment_outcomes.size()) {}
 
     void AdoptSourceCallbacks(
         Array<std::function<void()>>&& _callbacks,
@@ -312,47 +314,64 @@ public:
         return segment_outcomes[_segment_index];
     }
 
-    void Retire(size_t _segment_index) noexcept {
-        bool segment_success = false;
-        if (_segment_index < segment_outcomes.size()) {
-            auto* outcome   = ResourceCast(segment_outcomes[_segment_index].Get());
-            segment_success = outcome != nullptr && outcome->GetValue() >= 1 && !outcome->IsRejected(1) &&
-                              !outcome->IsFailed();
-        }
-
+    void RetireOrdinary(size_t _segment_index) noexcept {
         Array<std::function<void()>> final_callbacks{};
-        Array<std::function<void()>> final_success_callbacks{};
-        bool                         invoke_success = false;
         {
             std::lock_guard lock(mutex);
-            if (_segment_index >= retired.size() || retired[_segment_index] != 0) {
+            if (_segment_index >= ordinary_retired.size() ||
+                ordinary_retired[_segment_index] != 0) {
                 return;
             }
-            retired[_segment_index] = 1;
-            all_success             = all_success && segment_success;
-            assert(remaining != 0);
-            --remaining;
-            if (remaining != 0) {
+            ordinary_retired[_segment_index] = 1;
+            assert(ordinary_remaining != 0);
+            --ordinary_remaining;
+            if (ordinary_remaining != 0) {
                 return;
             }
-            invoke_success          = all_success;
-            final_callbacks         = std::move(callbacks);
+            final_callbacks = std::move(callbacks);
+        }
+
+        InvokeSourceCallbacksNoexcept(
+            final_callbacks,
+            "[RHIExecutor][Vulkan][MultiSegment] ordinary"
+        );
+    }
+
+    void RetireSuccess(size_t _segment_index) noexcept {
+        Array<std::function<void()>> final_success_callbacks{};
+        {
+            std::lock_guard lock(mutex);
+            if (_segment_index >= success_retired.size() ||
+                success_retired[_segment_index] != 0) {
+                return;
+            }
+            // Every packet runs its ordinary tier before its success tier.
+            // Treat a violation as a backend ownership bug instead of
+            // allowing the aggregate success tier to overtake ordinary work.
+            if (ordinary_retired[_segment_index] == 0) {
+                std::terminate();
+            }
+            success_retired[_segment_index] = 1;
+            assert(success_remaining != 0);
+            --success_remaining;
+            if (success_remaining != 0) {
+                return;
+            }
             final_success_callbacks = std::move(success_callbacks);
         }
 
-        InvokeSourceCallbacksNoexcept(final_callbacks, "[RHIExecutor][Vulkan][MultiSegment] ordinary");
-        if (invoke_success) {
-            InvokeSourceCallbacksNoexcept(
-                final_success_callbacks, "[RHIExecutor][Vulkan][MultiSegment] success"
-            );
-        }
+        InvokeSourceCallbacksNoexcept(
+            final_success_callbacks,
+            "[RHIExecutor][Vulkan][MultiSegment] success"
+        );
     }
 
 private:
     Array<FenceRef>              segment_outcomes{};
-    Array<uint8>                 retired{};
-    size_t                       remaining{0};
-    bool                         all_success{true};
+    Array<uint8>                 ordinary_retired{};
+    Array<uint8>                 success_retired{};
+    size_t                       ordinary_remaining{0};
+    size_t                       success_remaining{0};
     std::mutex                   mutex{};
     Array<std::function<void()>> callbacks{};
     Array<std::function<void()>> success_callbacks{};
@@ -645,6 +664,7 @@ MaterializeMultiSegmentBatch(RHIBackendSubmissionBatch& _batch, const RHIQueueTo
             CmdSubmit segment_submit = MakeEmptySubmit();
             segment_submit.cmds.reserve(command_count);
             segment_submit.callbacks.reserve(1);
+            segment_submit.success_callbacks.reserve(1);
             segment_submit.signal_events.reserve(
                 1 + (segment_plan.inherit_source_signal_events_and_callbacks ?
                          source_submit.signal_events.size() :
@@ -679,8 +699,13 @@ MaterializeMultiSegmentBatch(RHIBackendSubmissionBatch& _batch, const RHIQueueTo
                 .value           = 1,
             });
             segment_submit.callbacks.emplace_back([completion = materialization.completion, segment_index] {
-                completion->Retire(segment_index);
+                completion->RetireOrdinary(segment_index);
             });
+            segment_submit.success_callbacks.emplace_back(
+                [completion = materialization.completion, segment_index] {
+                    completion->RetireSuccess(segment_index);
+                }
+            );
 
             bool cross_native_predecessor_wait = false;
             if (segment_index != 0) {
@@ -855,16 +880,17 @@ VulkanMultiSegmentCompletionProbeResult RunVulkanMultiSegmentCompletionProbeForT
     }
 
     suffix->Fail(VK_ERROR_UNKNOWN);
-    completion->Retire(1);
+    completion->RetireOrdinary(1);
     result.suffix_retirement_deferred_callbacks = ordinary_callback_count == 0 && success_callback_count == 0;
 
     prefix->Notify(1);
-    completion->Retire(0);
+    completion->RetireOrdinary(0);
     result.prefix_retirement_completed_callbacks =
         ordinary_callback_count == 1 && success_callback_count == 0;
 
-    completion->Retire(1);
-    completion->Retire(0);
+    completion->RetireOrdinary(1);
+    completion->RetireOrdinary(0);
+    completion->RetireSuccess(0);
     result.repeated_retirement_suppressed = ordinary_callback_count == 1 && success_callback_count == 0;
     result.ordinary_callback_count        = ordinary_callback_count;
     result.success_callback_count         = success_callback_count;
@@ -1110,7 +1136,36 @@ VulkanSubmissionExecutor::BatchRejectionPublication::
     const QueryPublishBatch common_query_batch =
         QueryBackendAccess::BeginPublishBatch();
 
-    for (RHIBackendSubmissionBatchEntry& entry : _batch.submits) {
+    size_t executable_count = 0;
+    bool   has_query        = false;
+    if (_batch.topology.source_plans.size() == _batch.submits.size()) {
+        for (size_t source_index = 0;
+             source_index < _batch.submits.size();
+             ++source_index) {
+            if (_batch.topology.source_plans[source_index].
+                    segment_plan_count == 0) {
+                continue;
+            }
+            ++executable_count;
+            has_query =
+                has_query ||
+                !_batch.submits[source_index].submit.query_tokens.empty();
+        }
+    }
+    std::shared_ptr<VulkanBatchCompletionGroup> completion_group{};
+    if (executable_count > 1 && has_query) {
+        completion_group =
+            std::make_shared<VulkanBatchCompletionGroup>(
+                executable_count
+            );
+    }
+
+    size_t participant_index = 0;
+    for (size_t source_index = 0;
+         source_index < _batch.submits.size();
+         ++source_index) {
+        RHIBackendSubmissionBatchEntry& entry =
+            _batch.submits[source_index];
         RejectionSourceSnapshot source{};
         source.signals.reserve(entry.submit.signal_events.size());
         for (const SignalEvent& signal : entry.submit.signal_events) {
@@ -1133,8 +1188,31 @@ VulkanSubmissionExecutor::BatchRejectionPublication::
             // into either a recorded packet or a per-queue Completion packet.
             entry.submit.query_publish_batch = source.query_batch;
         }
+        const bool executable =
+            source_index < _batch.topology.source_plans.size() &&
+            _batch.topology.source_plans[source_index].
+                segment_plan_count != 0;
+        if (completion_group && executable) {
+            source.completion_ticket = VulkanBatchCompletionTicket{
+                .group             = completion_group,
+                .participant_index = participant_index++,
+            };
+        }
         sources.emplace_back(std::move(source));
     }
+    assert(
+        !completion_group || participant_index == executable_count
+    );
+}
+
+VulkanBatchCompletionTicket
+VulkanSubmissionExecutor::BatchRejectionPublication::CompletionTicket(
+    size_t _source_index
+) const noexcept {
+    if (_source_index >= sources.size()) {
+        return {};
+    }
+    return sources[_source_index].completion_ticket;
 }
 
 void VulkanSubmissionExecutor::BatchRejectionPublication::PublishSuffix(
@@ -1498,7 +1576,8 @@ void VulkanSubmissionExecutor::RunExecutor() {
                         "unhandled submission request exception",
                         false,
                         exception_state.first_unconsumed_source,
-                        &exception_state.first_unconsumed_source
+                        &exception_state.first_unconsumed_source,
+                        exception_state.rejection_publication
                     );
                 },
                 [&] { CompleteRequest(request.completion); },
@@ -1759,7 +1838,8 @@ CmdSubmit* VulkanSubmissionExecutor::GetRecordedSourceSubmit(
 VulkanSubmissionExecutor::RecordedSourcePacket
 VulkanSubmissionExecutor::TranslateSourceForRuntime(
     EQueueType _queue,
-    CmdSubmit&& _submit
+    CmdSubmit&& _submit,
+    VulkanBatchCompletionTicket _completion_ticket
 ) noexcept {
     if (_queue == EQueueType::Copy) {
         auto& copy_queue =
@@ -1767,6 +1847,8 @@ VulkanSubmissionExecutor::TranslateSourceForRuntime(
         auto recorded =
             copy_queue.TranslateForRuntime(std::move(_submit));
         if (recorded) {
+            recorded->batch_completion =
+                std::move(_completion_ticket);
             return RecordedSourcePacket{
                 std::in_place_type<
                     VkCopyQueue::CurrentVulkanCopyRecordedSubmit>,
@@ -1784,6 +1866,8 @@ VulkanSubmissionExecutor::TranslateSourceForRuntime(
         auto recorded =
             queue.TranslateForRuntime(std::move(_submit));
         if (recorded) {
+            recorded->batch_completion =
+                std::move(_completion_ticket);
             return RecordedSourcePacket{
                 std::in_place_type<
                     VkCommandQueue::CurrentVulkanRecordedSubmit>,
@@ -1794,7 +1878,11 @@ VulkanSubmissionExecutor::TranslateSourceForRuntime(
     }
 
     RejectSourceForRuntime(
-        _queue, std::move(_submit), VK_ERROR_UNKNOWN, false
+        _queue,
+        std::move(_submit),
+        VK_ERROR_UNKNOWN,
+        false,
+        std::move(_completion_ticket)
     );
     return {};
 }
@@ -1906,7 +1994,8 @@ void VulkanSubmissionExecutor::RejectSourceForRuntime(
     EQueueType _queue,
     CmdSubmit&& _submit,
     VkResult    _result,
-    bool        _recoverable
+    bool        _recoverable,
+    VulkanBatchCompletionTicket _completion_ticket
 ) noexcept {
     if (_queue == EQueueType::Copy) {
         auto& copy_queue =
@@ -1914,7 +2003,10 @@ void VulkanSubmissionExecutor::RejectSourceForRuntime(
                 RenderDevice::Get().GetCopyQueue()
             );
         copy_queue.RejectForRuntime(
-            std::move(_submit), _result, _recoverable
+            std::move(_submit),
+            _result,
+            _recoverable,
+            std::move(_completion_ticket)
         );
         return;
     }
@@ -1924,7 +2016,10 @@ void VulkanSubmissionExecutor::RejectSourceForRuntime(
             RenderDevice::Get().GetCommandQueue(_queue)
         );
         queue.RejectForRuntime(
-            std::move(_submit), _result, _recoverable
+            std::move(_submit),
+            _result,
+            _recoverable,
+            std::move(_completion_ticket)
         );
         return;
     }
@@ -2235,7 +2330,9 @@ void VulkanSubmissionExecutor::RejectBatch(
     std::string_view            _reason,
     bool                        _recoverable,
     size_t                      _first_source,
-    size_t*                     _next_unconsumed_source
+    size_t*                     _next_unconsumed_source,
+    std::shared_ptr<BatchRejectionPublication>
+        _rejection_publication
 ) {
     const size_t first_source = std::min(_first_source, _batch.submits.size());
     const VkResult result =
@@ -2297,10 +2394,17 @@ void VulkanSubmissionExecutor::RejectBatch(
          source_index < _batch.submits.size();
          ++source_index) {
         RHIBackendSubmissionBatchEntry& entry = _batch.submits[source_index];
+        VulkanBatchCompletionTicket completion_ticket =
+            _rejection_publication ?
+                _rejection_publication->CompletionTicket(source_index) :
+                VulkanBatchCompletionTicket{};
         if (entry.queue == EQueueType::Copy) {
             auto& queue = static_cast<VkCopyQueue&>(RenderDevice::Get().GetCopyQueue());
             queue.RejectForRuntime(
-                std::move(entry.submit), result, _recoverable
+                std::move(entry.submit),
+                result,
+                _recoverable,
+                std::move(completion_ticket)
             );
             if (_next_unconsumed_source != nullptr) {
                 *_next_unconsumed_source = source_index + 1;
@@ -2316,7 +2420,10 @@ void VulkanSubmissionExecutor::RejectBatch(
             RenderDevice::Get().GetCommandQueue(queue_type)
         );
         queue.RejectForRuntime(
-            std::move(entry.submit), result, _recoverable
+            std::move(entry.submit),
+            result,
+            _recoverable,
+            std::move(completion_ticket)
         );
         if (_next_unconsumed_source != nullptr) {
             *_next_unconsumed_source = source_index + 1;
@@ -2521,6 +2628,8 @@ void VulkanSubmissionExecutor::ProcessBatch(
     // Completion packets that may sit behind a blocking callback.
     auto rejection_publication =
         std::make_shared<BatchRejectionPublication>(_batch);
+    _exception_state.rejection_publication =
+        rejection_publication;
 
     struct PipelineSealGuard final {
         std::shared_ptr<PipelineBatchState> state{};
@@ -2605,7 +2714,8 @@ void VulkanSubmissionExecutor::ProcessBatch(
             _reason,
             false,
             _exception_state.first_unconsumed_source,
-            &_exception_state.first_unconsumed_source
+            &_exception_state.first_unconsumed_source,
+            rejection_publication
         );
         _exception_state.first_unconsumed_source = _batch.submits.size();
     };
@@ -2633,7 +2743,8 @@ void VulkanSubmissionExecutor::ProcessBatch(
                 _reason,
                 true,
                 _exception_state.first_unconsumed_source,
-                &_exception_state.first_unconsumed_source
+                &_exception_state.first_unconsumed_source,
+                rejection_publication
             );
             _exception_state.first_unconsumed_source = _batch.submits.size();
         };
@@ -2892,7 +3003,10 @@ void VulkanSubmissionExecutor::ProcessBatch(
                             slot.queue_type,
                             std::move(entry.submit),
                             result,
-                            false
+                            false,
+                            rejection_publication->CompletionTicket(
+                                slot.source_index
+                            )
                         );
                     }
                     // Runtime Translate normally returns a terminal packet.
@@ -2954,7 +3068,11 @@ void VulkanSubmissionExecutor::ProcessBatch(
                 );
                 slot.recorded =
                     TranslateSourceForRuntime(
-                        slot.queue_type, std::move(submit)
+                        slot.queue_type,
+                        std::move(submit),
+                        rejection_publication->CompletionTicket(
+                            slot.source_index
+                        )
                     );
                 NotifySourceTranslation(
                     _batch.sequence,
@@ -3381,6 +3499,10 @@ void VulkanSubmissionExecutor::ProcessBatch(
             std::optional<VkCopyQueue::CurrentVulkanCopyRecordedSubmit>
                 recorded =
                     copy_queue.TranslateForRuntime(std::move(entry.submit));
+            if (recorded) {
+                recorded->batch_completion =
+                    rejection_publication->CompletionTicket(source_index);
+            }
             used_queues[static_cast<size_t>(EQueueType::Copy)] = true;
             if (!recorded) {
                 _exception_state.first_unconsumed_source =
@@ -3549,6 +3671,10 @@ void VulkanSubmissionExecutor::ProcessBatch(
             );
             std::optional<VkCommandQueue::CurrentVulkanRecordedSubmit> recorded =
                 queue.TranslateForRuntime(std::move(entry.submit));
+            if (recorded) {
+                recorded->batch_completion =
+                    rejection_publication->CompletionTicket(source_index);
+            }
             // Translation reserves a logical queue timeline and always
             // publishes a CPU completion marker, including rejected paths.
             used_queues[static_cast<size_t>(entry.queue)] = true;

--- a/source/runtime/render/rhi/vulkan/VulkanSubmissionExecutor.cpp
+++ b/source/runtime/render/rhi/vulkan/VulkanSubmissionExecutor.cpp
@@ -787,6 +787,10 @@ MaterializeMultiSegmentBatch(RHIBackendSubmissionBatch& _batch, const RHIQueueTo
         for (const SignalEvent& signal : source_entry.submit.signal_events) {
             last_submit.signal_events.emplace_back(signal);
         }
+        // Signal ownership has moved to the last executable segment. Leaving
+        // the original handles live would make CmdSubmit::~CmdSubmit reject
+        // values that have already been accepted by the native queue.
+        source_entry.submit.signal_events.clear();
     }
 
     _batch.submits  = std::move(executable_sources);
@@ -1201,6 +1205,33 @@ void VulkanSubmissionExecutor::BatchRejectionPublication::PublishSuffix(
     }
 }
 
+void VulkanSubmissionExecutor::PublishRuntimeFailureBeforeCompletion(
+    void*                                _context,
+    const VulkanRuntimeSubmissionResult& _result
+) noexcept {
+    if (_result.WasSubmitted() || _context == nullptr) {
+        return;
+    }
+    auto& publication =
+        *static_cast<RuntimePreCompletionPublication*>(_context);
+    if (!publication.rejection_publication) {
+        return;
+    }
+    const int32 result =
+        _result.outcome.result == VK_SUCCESS ?
+            static_cast<int32>(VK_ERROR_UNKNOWN) :
+            static_cast<int32>(_result.outcome.result);
+    const bool recoverable = _result.IsRecoverableRejection();
+    publication.rejection_publication->PublishSuffix(
+        publication.reject_from,
+        result,
+        recoverable,
+        recoverable ?
+            "Vulkan submission suffix was rejected before Completion notification" :
+            "Vulkan submission suffix failed before Completion notification"
+    );
+}
+
 VulkanSubmissionExecutor::PipelineBatchState::PipelineBatchState(
     uint64                      _sequence,
     size_t                      _source_count,
@@ -1305,7 +1336,8 @@ void VulkanSubmissionExecutor::Enqueue(RHIBackendSubmissionBatch&& _batch) {
         RejectBatch(
             std::move(_batch),
             static_cast<int32>(VK_ERROR_UNKNOWN),
-            "submission runtime is stopping or stopped"
+            "submission runtime is stopping or stopped",
+            true
         );
         return;
     }
@@ -1464,6 +1496,7 @@ void VulkanSubmissionExecutor::RunExecutor() {
                         std::move(request.batch),
                         static_cast<int32>(VK_ERROR_UNKNOWN),
                         "unhandled submission request exception",
+                        false,
                         exception_state.first_unconsumed_source,
                         &exception_state.first_unconsumed_source
                     );
@@ -1761,15 +1794,16 @@ VulkanSubmissionExecutor::TranslateSourceForRuntime(
     }
 
     RejectSourceForRuntime(
-        _queue, std::move(_submit), VK_ERROR_UNKNOWN
+        _queue, std::move(_submit), VK_ERROR_UNKNOWN, false
     );
     return {};
 }
 
 VulkanRuntimeSubmissionResult
 VulkanSubmissionExecutor::SubmitRecordedSourceForRuntime(
-    EQueueType             _queue,
-    RecordedSourcePacket&& _packet
+    EQueueType                            _queue,
+    RecordedSourcePacket&&                _packet,
+    const VulkanRuntimePreCompletionHook* _pre_completion
 ) noexcept {
     if (_queue == EQueueType::Copy) {
         if (auto* packet =
@@ -1780,9 +1814,9 @@ VulkanSubmissionExecutor::SubmitRecordedSourceForRuntime(
             auto& copy_queue =
                 static_cast<VkCopyQueue&>(
                     RenderDevice::Get().GetCopyQueue()
-                );
+            );
             return copy_queue.SubmitRecordedForRuntime(
-                std::move(*packet)
+                std::move(*packet), _pre_completion
             );
         }
     } else if (
@@ -1798,25 +1832,33 @@ VulkanSubmissionExecutor::SubmitRecordedSourceForRuntime(
                 RenderDevice::Get().GetCommandQueue(_queue)
             );
             return queue.SubmitRecordedForRuntime(
-                std::move(*packet)
+                std::move(*packet), _pre_completion
             );
         }
     }
 
-    RejectRecordedSourceForRuntime(
-        _queue, std::move(_packet), VK_ERROR_UNKNOWN
-    );
-    return {
+    const VulkanRuntimeSubmissionResult rejected{
         .outcome = {
             EVulkanOperationStatus::Rejected, VK_ERROR_UNKNOWN
         },
     };
+    if (_pre_completion != nullptr &&
+        _pre_completion->callback != nullptr) {
+        _pre_completion->callback(
+            _pre_completion->context, rejected
+        );
+    }
+    RejectRecordedSourceForRuntime(
+        _queue, std::move(_packet), VK_ERROR_UNKNOWN, false
+    );
+    return rejected;
 }
 
 void VulkanSubmissionExecutor::RejectRecordedSourceForRuntime(
     EQueueType             _queue,
     RecordedSourcePacket&& _packet,
-    VkResult               _result
+    VkResult               _result,
+    bool                   _recoverable
 ) noexcept {
     if (_result == VK_SUCCESS) {
         _result = VK_ERROR_UNKNOWN;
@@ -1834,7 +1876,7 @@ void VulkanSubmissionExecutor::RejectRecordedSourceForRuntime(
                 RenderDevice::Get().GetCopyQueue()
             );
         copy_queue.RejectRecordedForRuntime(
-            std::move(*packet), _result
+            std::move(*packet), _result, _recoverable
         );
         return;
     }
@@ -1855,7 +1897,7 @@ void VulkanSubmissionExecutor::RejectRecordedSourceForRuntime(
             RenderDevice::Get().GetCommandQueue(packet_queue)
         );
         queue.RejectRecordedForRuntime(
-            std::move(*packet), _result
+            std::move(*packet), _result, _recoverable
         );
     }
 }
@@ -1863,7 +1905,8 @@ void VulkanSubmissionExecutor::RejectRecordedSourceForRuntime(
 void VulkanSubmissionExecutor::RejectSourceForRuntime(
     EQueueType _queue,
     CmdSubmit&& _submit,
-    VkResult    _result
+    VkResult    _result,
+    bool        _recoverable
 ) noexcept {
     if (_queue == EQueueType::Copy) {
         auto& copy_queue =
@@ -1871,7 +1914,7 @@ void VulkanSubmissionExecutor::RejectSourceForRuntime(
                 RenderDevice::Get().GetCopyQueue()
             );
         copy_queue.RejectForRuntime(
-            std::move(_submit), _result
+            std::move(_submit), _result, _recoverable
         );
         return;
     }
@@ -1881,7 +1924,7 @@ void VulkanSubmissionExecutor::RejectSourceForRuntime(
             RenderDevice::Get().GetCommandQueue(_queue)
         );
         queue.RejectForRuntime(
-            std::move(_submit), _result
+            std::move(_submit), _result, _recoverable
         );
         return;
     }
@@ -1958,7 +2001,8 @@ void VulkanSubmissionExecutor::ExecutePipelineSource(
             RejectRecordedSourceForRuntime(
                 slot.queue,
                 std::move(slot.recorded_packet),
-                _result
+                _result,
+                _recoverable
             );
             slot.recorded_packet.emplace<std::monostate>();
         }
@@ -2057,9 +2101,21 @@ void VulkanSubmissionExecutor::ExecutePipelineSource(
         return;
     }
 
+    RuntimePreCompletionPublication pre_completion_publication{
+        .rejection_publication = _batch->rejection_publication,
+        .reject_from           = _source_index,
+    };
+    const VulkanRuntimePreCompletionHook pre_completion{
+        .context  = &pre_completion_publication,
+        .callback =
+            &VulkanSubmissionExecutor::
+                PublishRuntimeFailureBeforeCompletion,
+    };
     VulkanRuntimeSubmissionResult submit_result =
         SubmitRecordedSourceForRuntime(
-            slot.queue, std::move(slot.recorded_packet)
+            slot.queue,
+            std::move(slot.recorded_packet),
+            &pre_completion
         );
     slot.recorded_packet.emplace<std::monostate>();
 
@@ -2177,21 +2233,42 @@ void VulkanSubmissionExecutor::RejectBatch(
     RHIBackendSubmissionBatch&& _batch,
     int32                       _result,
     std::string_view            _reason,
+    bool                        _recoverable,
     size_t                      _first_source,
     size_t*                     _next_unconsumed_source
 ) {
     const size_t first_source = std::min(_first_source, _batch.submits.size());
-    ResolveRejectedPresent(_batch.present);
-    const VkResult result = static_cast<VkResult>(_result);
+    const VkResult result =
+        _result == static_cast<int32>(VK_SUCCESS) ?
+            VK_ERROR_UNKNOWN :
+            static_cast<VkResult>(_result);
 
-    // Rejection is atomic at the runtime-batch frontier: every signal is
-    // terminal and every Query is Error before the first per-queue Completion
-    // packet can release callbacks.
+    // Terminal publication is atomic at the runtime-batch frontier: every
+    // signal and Query reaches its final classification before the first
+    // per-queue Completion packet can release callbacks.
     for (size_t source_index = first_source;
          source_index < _batch.submits.size();
          ++source_index) {
         CmdSubmit& submit = _batch.submits[source_index].submit;
-        submit.RejectPendingSignals();
+        if (_recoverable) {
+            submit.RejectPendingSignals();
+            continue;
+        }
+        for (const SignalEvent& signal : submit.signal_events) {
+            auto* fence =
+                reinterpret_cast<VulkanFence*>(signal.timeline_handle);
+            if (fence == nullptr) {
+                continue;
+            }
+            try {
+                fence->Fail(result);
+            } catch (...) {
+                fence->Reject(signal.value);
+            }
+        }
+        // Queue rejection must not add an exact-value rejection after a hard
+        // failure has already been published for the whole fence.
+        submit.signal_events.clear();
     }
 
     const QueryPublishBatch query_batch =
@@ -2211,13 +2288,20 @@ void VulkanSubmissionExecutor::RejectBatch(
         submit.PublishPendingQueryErrors(_reason, source_query_batch);
     }
 
+    // A Present receipt is also user-visible batch state. Resolve it only
+    // after every submit signal and Query in the rejected suffix is terminal,
+    // so a receipt waiter cannot observe a partially published batch.
+    ResolveRejectedPresent(_batch.present);
+
     for (size_t source_index = first_source;
          source_index < _batch.submits.size();
          ++source_index) {
         RHIBackendSubmissionBatchEntry& entry = _batch.submits[source_index];
         if (entry.queue == EQueueType::Copy) {
             auto& queue = static_cast<VkCopyQueue&>(RenderDevice::Get().GetCopyQueue());
-            queue.RejectForRuntime(std::move(entry.submit), result);
+            queue.RejectForRuntime(
+                std::move(entry.submit), result, _recoverable
+            );
             if (_next_unconsumed_source != nullptr) {
                 *_next_unconsumed_source = source_index + 1;
             }
@@ -2231,7 +2315,9 @@ void VulkanSubmissionExecutor::RejectBatch(
         auto& queue = static_cast<VkCommandQueue&>(
             RenderDevice::Get().GetCommandQueue(queue_type)
         );
-        queue.RejectForRuntime(std::move(entry.submit), result);
+        queue.RejectForRuntime(
+            std::move(entry.submit), result, _recoverable
+        );
         if (_next_unconsumed_source != nullptr) {
             *_next_unconsumed_source = source_index + 1;
         }
@@ -2259,6 +2345,7 @@ void VulkanSubmissionExecutor::ProcessBatch(
             std::move(_batch),
             latched_failure_result,
             "submission runtime is latched after a hard failure",
+            false,
             0,
             &_exception_state.first_unconsumed_source
         );
@@ -2290,6 +2377,7 @@ void VulkanSubmissionExecutor::ProcessBatch(
             std::move(_batch),
             static_cast<int32>(VK_ERROR_UNKNOWN),
             preflight.reason,
+            true,
             0,
             &_exception_state.first_unconsumed_source
         );
@@ -2322,6 +2410,7 @@ void VulkanSubmissionExecutor::ProcessBatch(
                 std::move(_batch),
                 static_cast<int32>(VK_ERROR_UNKNOWN),
                 executable_preflight.reason,
+                true,
                 0,
                 &_exception_state.first_unconsumed_source
             );
@@ -2419,6 +2508,7 @@ void VulkanSubmissionExecutor::ProcessBatch(
             std::move(_batch),
             latched_failure_result,
             "submission runtime latched while waiting for pipeline admission",
+            false,
             0,
             &_exception_state.first_unconsumed_source
         );
@@ -2513,6 +2603,7 @@ void VulkanSubmissionExecutor::ProcessBatch(
             std::move(_batch),
             static_cast<int32>(_result),
             _reason,
+            false,
             _exception_state.first_unconsumed_source,
             &_exception_state.first_unconsumed_source
         );
@@ -2540,6 +2631,7 @@ void VulkanSubmissionExecutor::ProcessBatch(
                 std::move(_batch),
                 static_cast<int32>(_result),
                 _reason,
+                true,
                 _exception_state.first_unconsumed_source,
                 &_exception_state.first_unconsumed_source
             );
@@ -2714,6 +2806,7 @@ void VulkanSubmissionExecutor::ProcessBatch(
             size_t                     group_end{0};
             size_t*                    first_unconsumed_source{nullptr};
             VulkanSubmissionExecutor*  owner{nullptr};
+            std::shared_ptr<BatchRejectionPublication> rejection_publication{};
             std::shared_ptr<PipelineBatchState>* pipeline_state{nullptr};
             PipelineSealGuard*         pipeline_seal{nullptr};
             bool                       armed{true};
@@ -2724,6 +2817,7 @@ void VulkanSubmissionExecutor::ProcessBatch(
                 size_t                     _group_end,
                 size_t*                    _first_unconsumed_source,
                 VulkanSubmissionExecutor*  _owner,
+                std::shared_ptr<BatchRejectionPublication> _rejection_publication,
                 std::shared_ptr<PipelineBatchState>* _pipeline_state,
                 PipelineSealGuard*         _pipeline_seal
             ) noexcept :
@@ -2732,6 +2826,7 @@ void VulkanSubmissionExecutor::ProcessBatch(
                 group_end(_group_end),
                 first_unconsumed_source(_first_unconsumed_source),
                 owner(_owner),
+                rejection_publication(std::move(_rejection_publication)),
                 pipeline_state(_pipeline_state),
                 pipeline_seal(_pipeline_seal) {}
 
@@ -2757,6 +2852,26 @@ void VulkanSubmissionExecutor::ProcessBatch(
                     pipeline_seal->Seal();
                     owner->DrainPipelineBatches();
                 }
+                size_t rejection_begin = group_end;
+                for (const TranslateGroupSlot& slot : *slots) {
+                    if (!slot.terminalized) {
+                        rejection_begin =
+                            std::min(rejection_begin, slot.source_index);
+                    }
+                }
+                if (rejection_begin < group_end &&
+                    rejection_publication) {
+                    // This guard also runs during exception unwinding, where
+                    // fail_group() may never execute. Publish terminal state
+                    // before any direct queue rejection can enqueue a
+                    // Completion packet.
+                    rejection_publication->PublishSuffix(
+                        rejection_begin,
+                        static_cast<int32>(result),
+                        false,
+                        "parallel Translate group failed before Completion notification"
+                    );
+                }
                 for (TranslateGroupSlot& slot : *slots) {
                     if (slot.terminalized) {
                         continue;
@@ -2768,18 +2883,22 @@ void VulkanSubmissionExecutor::ProcessBatch(
                         owner->RejectRecordedSourceForRuntime(
                             slot.queue_type,
                             std::move(slot.recorded),
-                            result
+                            result,
+                            false
                         );
                         slot.recorded.emplace<std::monostate>();
                     } else if (!slot.attempted) {
                         owner->RejectSourceForRuntime(
                             slot.queue_type,
                             std::move(entry.submit),
-                            result
+                            result,
+                            false
                         );
                     }
-                    // A null result from an attempted Translate already
-                    // owns a rejected Completion retirement.
+                    // Runtime Translate normally returns a terminal packet.
+                    // If an attempted Translate returned no packet, its
+                    // payload has already been consumed and cannot be
+                    // terminalized a second time here.
                     slot.terminalized = true;
                 }
                 if (first_unconsumed_source != nullptr) {
@@ -2800,6 +2919,7 @@ void VulkanSubmissionExecutor::ProcessBatch(
             group_end,
             &_exception_state.first_unconsumed_source,
             this,
+            rejection_publication,
             &pipeline_state,
             &pipeline_seal,
         };
@@ -2867,10 +2987,9 @@ void VulkanSubmissionExecutor::ProcessBatch(
                         std::min(rejection_begin, slot.source_index);
                 }
             }
-            // TranslateForRuntime owns the rejected Completion packet after a
-            // null result, so that slot is already marked terminalized above.
-            // It is still the failure source whose Query state must be
-            // published before any earlier same-queue callback can run.
+            // Include the failed source even when Translate could not return
+            // a terminal packet. Its Query state must be published before any
+            // earlier same-queue callback can run.
             rejection_begin = std::min(
                 rejection_begin,
                 rejection_source.value_or(failure_source)
@@ -2993,8 +3112,10 @@ void VulkanSubmissionExecutor::ProcessBatch(
                     translation_failure_reason = "parallel Translate scheduler state failure";
                 }
                 if (!HasRecordedSourcePacket(slot->recorded)) {
-                    // TranslateForRuntime already committed the rejected
-                    // Completion marker for this source.
+                    // Runtime Translate normally returns a terminal packet
+                    // for native-record failures. A missing packet is an
+                    // unexpected handoff failure and has no Completion packet
+                    // left for the group terminalizer to retire.
                     slot->terminalized = true;
                     if (!translation_failure_source) {
                         translation_failure_source = slot->source_index;
@@ -3123,12 +3244,29 @@ void VulkanSubmissionExecutor::ProcessBatch(
                                                    batch_sequence = _batch.sequence,
                                                    source_index   = static_cast<uint32>(slot.source_index),
                                                    source_metadata =
-                                                       materialization.sources[slot.source_index],
+                                                        materialization.sources[slot.source_index],
                                                    queue_type     = slot.queue_type,
-                                                   async_scope    = slot.async_queue_scope]() mutable {
+                                                   async_scope    = slot.async_queue_scope,
+                                                   rejection_publication]() mutable {
+                            RuntimePreCompletionPublication
+                                pre_completion_publication{
+                                    .rejection_publication =
+                                        rejection_publication,
+                                    .reject_from = source_index,
+                                };
+                            const VulkanRuntimePreCompletionHook
+                                pre_completion{
+                                    .context =
+                                        &pre_completion_publication,
+                                    .callback =
+                                        &VulkanSubmissionExecutor::
+                                            PublishRuntimeFailureBeforeCompletion,
+                                };
                             VulkanRuntimeSubmissionResult result =
                                 SubmitRecordedSourceForRuntime(
-                                    queue_type, std::move(*packet)
+                                    queue_type,
+                                    std::move(*packet),
+                                    &pre_completion
                                 );
                             packet->emplace<std::monostate>();
                             if (result.WasSubmitted()) {
@@ -3151,10 +3289,17 @@ void VulkanSubmissionExecutor::ProcessBatch(
                         VulkanSubmissionDetail::EWorkerRequestFailurePhase::Process,
                         std::current_exception()
                     );
+                    rejection_publication->PublishSuffix(
+                        slot.source_index,
+                        static_cast<int32>(VK_ERROR_UNKNOWN),
+                        false,
+                        "parallel Submission handoff failed before Completion notification"
+                    );
                     RejectRecordedSourceForRuntime(
                         slot.queue_type,
                         std::move(slot.recorded),
-                        VK_ERROR_UNKNOWN
+                        VK_ERROR_UNKNOWN,
+                        false
                     );
                     slot.recorded.emplace<std::monostate>();
                     submit_result.outcome = {EVulkanOperationStatus::Rejected, VK_ERROR_UNKNOWN};
@@ -3272,11 +3417,28 @@ void VulkanSubmissionExecutor::ProcessBatch(
                         source_index = static_cast<uint32>(source_index),
                         source_metadata = materialization.sources[source_index],
                         async_scope,
-                        serial_control
+                        serial_control,
+                        rejection_publication
                     ]() mutable {
-                        auto submit = [&copy_queue, packet]() mutable {
+                        RuntimePreCompletionPublication
+                            pre_completion_publication{
+                                .rejection_publication =
+                                    rejection_publication,
+                                .reject_from = source_index,
+                            };
+                        const VulkanRuntimePreCompletionHook
+                            pre_completion{
+                                .context = &pre_completion_publication,
+                                .callback =
+                                    &VulkanSubmissionExecutor::
+                                        PublishRuntimeFailureBeforeCompletion,
+                            };
+                        auto submit =
+                            [&copy_queue,
+                             packet,
+                             &pre_completion]() mutable {
                             return copy_queue.SubmitRecordedForRuntime(
-                                std::move(*packet)
+                                std::move(*packet), &pre_completion
                             );
                         };
                         VulkanRuntimeSubmissionResult result =
@@ -3314,8 +3476,14 @@ void VulkanSubmissionExecutor::ProcessBatch(
                     VulkanSubmissionDetail::EWorkerRequestFailurePhase::Process,
                     std::current_exception()
                 );
+                rejection_publication->PublishSuffix(
+                    source_index,
+                    static_cast<int32>(VK_ERROR_UNKNOWN),
+                    false,
+                    "Copy Submission handoff failed before Completion notification"
+                );
                 copy_queue.RejectRecordedForRuntime(
-                    std::move(*recorded), VK_ERROR_UNKNOWN
+                    std::move(*recorded), VK_ERROR_UNKNOWN, false
                 );
                 submit_result.outcome = {
                     EVulkanOperationStatus::Rejected,
@@ -3417,11 +3585,28 @@ void VulkanSubmissionExecutor::ProcessBatch(
                         source_metadata = materialization.sources[source_index],
                         queue_type = entry.queue,
                         async_scope,
-                        serial_control
+                        serial_control,
+                        rejection_publication
                     ]() mutable {
-                        auto submit = [&queue, packet]() mutable {
+                        RuntimePreCompletionPublication
+                            pre_completion_publication{
+                                .rejection_publication =
+                                    rejection_publication,
+                                .reject_from = source_index,
+                            };
+                        const VulkanRuntimePreCompletionHook
+                            pre_completion{
+                                .context = &pre_completion_publication,
+                                .callback =
+                                    &VulkanSubmissionExecutor::
+                                        PublishRuntimeFailureBeforeCompletion,
+                            };
+                        auto submit =
+                            [&queue,
+                             packet,
+                             &pre_completion]() mutable {
                             return queue.SubmitRecordedForRuntime(
-                                std::move(*packet)
+                                std::move(*packet), &pre_completion
                             );
                         };
                         VulkanRuntimeSubmissionResult result =
@@ -3459,8 +3644,14 @@ void VulkanSubmissionExecutor::ProcessBatch(
                     VulkanSubmissionDetail::EWorkerRequestFailurePhase::Process,
                     std::current_exception()
                 );
+                rejection_publication->PublishSuffix(
+                    source_index,
+                    static_cast<int32>(VK_ERROR_UNKNOWN),
+                    false,
+                    "command Submission handoff failed before Completion notification"
+                );
                 queue.RejectRecordedForRuntime(
-                    std::move(*recorded), VK_ERROR_UNKNOWN
+                    std::move(*recorded), VK_ERROR_UNKNOWN, false
                 );
                 submit_result.outcome = {
                     EVulkanOperationStatus::Rejected, VK_ERROR_UNKNOWN
@@ -3586,7 +3777,7 @@ void VulkanSubmissionExecutor::ProcessBatch(
                     std::current_exception()
                 );
                 graphics_queue.RejectRecordedForRuntime(
-                    std::move(*recorded), VK_ERROR_UNKNOWN
+                    std::move(*recorded), VK_ERROR_UNKNOWN, false
                 );
                 bridge_result.outcome = {
                     EVulkanOperationStatus::Rejected, VK_ERROR_UNKNOWN

--- a/source/runtime/render/rhi/vulkan/VulkanSubmissionExecutor.cpp
+++ b/source/runtime/render/rhi/vulkan/VulkanSubmissionExecutor.cpp
@@ -215,8 +215,21 @@ GraphEventRef MakeCompletedEvent() {
 
 bool SubmitHasSideEffects(const CmdSubmit& _submit) {
     return !_submit.callbacks.empty() || !_submit.success_callbacks.empty() ||
+           !_submit.query_tokens.empty() ||
            !_submit.wait_events.empty() || !_submit.signal_events.empty() || _submit.b_sync ||
            _submit.b_tick_profiling || _submit.b_delete_resources;
+}
+
+bool SubmitContainsQuery(const CmdSubmit& _submit) {
+    return !_submit.query_tokens.empty() ||
+           std::any_of(
+               _submit.cmds.begin(),
+               _submit.cmds.end(),
+               [](const UniquePtr<Command>& _command) {
+                   return _command &&
+                          _command->Type() == Command::EType::Query;
+               }
+           );
 }
 
 bool IsNativeQueue(EQueueType _queue) {
@@ -445,6 +458,13 @@ BatchPreflightResult ValidateBatch(const RHIBackendSubmissionBatch& _batch) {
         if (multi_segment && (!submit.HasExplicitResourceStateOwnership() || submit.async_queue_scope == 0)) {
             return RejectPreflight(
                 "multi-segment source requires explicit state and async scope", source_index
+            );
+        }
+        if (multi_segment && SubmitContainsQuery(submit)) {
+            // A Phase 17A timestamp pair is allocator-local and must not cross
+            // a materialized native command-buffer/queue segment boundary.
+            return RejectPreflight(
+                "multi-segment source contains timestamp query", source_index
             );
         }
         if (multi_segment && (submit.b_sync || submit.b_delete_resources ||
@@ -1080,14 +1100,118 @@ void VulkanSubmissionExecutor::Completion::Wait() {
     cv.wait(lock, [this] { return done; });
 }
 
+VulkanSubmissionExecutor::BatchRejectionPublication::
+    BatchRejectionPublication(RHIBackendSubmissionBatch& _batch) {
+    sources.reserve(_batch.submits.size());
+    const QueryPublishBatch common_query_batch =
+        QueryBackendAccess::BeginPublishBatch();
+
+    for (RHIBackendSubmissionBatchEntry& entry : _batch.submits) {
+        RejectionSourceSnapshot source{};
+        source.signals.reserve(entry.submit.signal_events.size());
+        for (const SignalEvent& signal : entry.submit.signal_events) {
+            auto* fence = reinterpret_cast<Fence*>(signal.timeline_handle);
+            if (fence != nullptr) {
+                source.signals.emplace_back(RejectionSignalHandle{
+                    .fence = FenceRef(fence),
+                    .value = signal.value,
+                });
+            }
+        }
+
+        source.query_tokens = entry.submit.query_tokens;
+        if (!source.query_tokens.empty()) {
+            source.query_batch =
+                entry.submit.query_publish_batch.Valid() ?
+                    entry.submit.query_publish_batch :
+                    common_query_batch;
+            // Install the notification ticket before the CmdSubmit can move
+            // into either a recorded packet or a per-queue Completion packet.
+            entry.submit.query_publish_batch = source.query_batch;
+        }
+        sources.emplace_back(std::move(source));
+    }
+}
+
+void VulkanSubmissionExecutor::BatchRejectionPublication::PublishSuffix(
+    size_t           _reject_from,
+    int32            _result,
+    bool             _recoverable,
+    std::string_view _reason
+) noexcept {
+    std::lock_guard lock(mutex);
+    const size_t begin = std::min(_reject_from, sources.size());
+    const VkResult result =
+        _result == static_cast<int32>(VK_SUCCESS) ?
+            VK_ERROR_UNKNOWN :
+            static_cast<VkResult>(_result);
+
+    // Every signal in the suffix is terminal before any Query state is
+    // published. User Query callbacks remain deferred to their queue
+    // Completion packets, but Wait/Get can already observe the whole suffix.
+    for (size_t source_index = begin;
+         source_index < sources.size();
+         ++source_index) {
+        RejectionSourceSnapshot& source = sources[source_index];
+        if (source.terminalized) {
+            continue;
+        }
+        for (const RejectionSignalHandle& signal : source.signals) {
+            auto* fence =
+                reinterpret_cast<VulkanFence*>(signal.fence.Get());
+            if (fence == nullptr) {
+                continue;
+            }
+            if (_recoverable) {
+                fence->Reject(signal.value);
+                continue;
+            }
+            try {
+                fence->Fail(result);
+            } catch (...) {
+                // Preserve terminal progress even if platform synchronization
+                // bookkeeping itself cannot publish the richer hard-fault
+                // classification.
+                fence->Reject(signal.value);
+            }
+        }
+    }
+
+    const std::string_view reason =
+        _reason.empty() ?
+            "Vulkan submission suffix was rejected before GPU completion" :
+            _reason;
+    for (size_t source_index = begin;
+         source_index < sources.size();
+         ++source_index) {
+        RejectionSourceSnapshot& source = sources[source_index];
+        if (source.terminalized) {
+            continue;
+        }
+        if (source.query_batch.Valid()) {
+            QueryBackendAccess::PublishErrorsIfPending(
+                source.query_tokens, reason, source.query_batch
+            );
+        }
+    }
+    for (size_t source_index = begin;
+         source_index < sources.size();
+         ++source_index) {
+        sources[source_index].terminalized = true;
+    }
+}
+
 VulkanSubmissionExecutor::PipelineBatchState::PipelineBatchState(
     uint64                      _sequence,
     size_t                      _source_count,
-    std::shared_ptr<Completion> _completion
+    std::shared_ptr<Completion> _completion,
+    std::shared_ptr<BatchRejectionPublication>
+        _rejection_publication
 ) :
     sequence(_sequence),
     slots(_source_count),
-    completion(std::move(_completion)) {}
+    completion(std::move(_completion)),
+    rejection_publication(std::move(_rejection_publication)) {}
 
 void VulkanSubmissionExecutor::PipelineBatchState::AddWork() noexcept {
     work_state.AddWork();
@@ -1122,16 +1246,30 @@ void VulkanSubmissionExecutor::PipelineBatchState::PublishFailure(
     int32  _result,
     bool   _recoverable
 ) noexcept {
-    std::lock_guard lock(failure_mutex);
-    if (_reject_from >= failure.reject_from) {
-        return;
+    bool published_earlier_failure = false;
+    {
+        std::lock_guard lock(failure_mutex);
+        if (_reject_from >= failure.reject_from) {
+            return;
+        }
+        failure.reject_from = _reject_from;
+        failure.result =
+            _result == static_cast<int32>(VK_SUCCESS) ?
+                static_cast<int32>(VK_ERROR_UNKNOWN) :
+                _result;
+        failure.recoverable = _recoverable;
+        published_earlier_failure = true;
     }
-    failure.reject_from = _reject_from;
-    failure.result =
-        _result == static_cast<int32>(VK_SUCCESS) ?
-            static_cast<int32>(VK_ERROR_UNKNOWN) :
-            _result;
-    failure.recoverable = _recoverable;
+    if (published_earlier_failure && rejection_publication) {
+        rejection_publication->PublishSuffix(
+            _reject_from,
+            _result,
+            _recoverable,
+            _recoverable ?
+                "Vulkan submission pipeline suffix was rejected by a dependency" :
+                "Vulkan submission pipeline suffix was rejected after a hard failure"
+        );
+    }
 }
 
 VulkanSubmissionExecutor::PipelineFailure
@@ -1801,9 +1939,20 @@ void VulkanSubmissionExecutor::ExecutePipelineSource(
     }
 
     PipelineSourceSlot& slot = _batch->slots[_source_index];
-    auto reject_packet = [&](VkResult _result) noexcept {
+    auto reject_packet =
+        [&](VkResult _result,
+            bool _recoverable,
+            std::string_view _reason) noexcept {
         if (_result == VK_SUCCESS) {
             _result = VK_ERROR_UNKNOWN;
+        }
+        if (_batch->rejection_publication) {
+            _batch->rejection_publication->PublishSuffix(
+                _source_index,
+                static_cast<int32>(_result),
+                _recoverable,
+                _reason
+            );
         }
         if (HasRecordedSourcePacket(slot.recorded_packet)) {
             RejectRecordedSourceForRuntime(
@@ -1821,15 +1970,33 @@ void VulkanSubmissionExecutor::ExecutePipelineSource(
             StreamPosition{_batch->sequence, _source_index},
             &hard_result
         )) {
-        reject_packet(static_cast<VkResult>(hard_result));
+        reject_packet(
+            static_cast<VkResult>(hard_result),
+            false,
+            "Vulkan pipeline source was rejected after a hard failure"
+        );
         return;
     }
     if (_source_index >= batch_failure.reject_from) {
-        reject_packet(static_cast<VkResult>(batch_failure.result));
+        reject_packet(
+            static_cast<VkResult>(batch_failure.result),
+            batch_failure.recoverable,
+            batch_failure.recoverable ?
+                "Vulkan pipeline source was rejected by a dependency" :
+                "Vulkan pipeline source was rejected after a hard failure"
+        );
         return;
     }
 
     if (!HasRecordedSourcePacket(slot.recorded_packet)) {
+        if (_batch->rejection_publication) {
+            _batch->rejection_publication->PublishSuffix(
+                _source_index,
+                static_cast<int32>(VK_ERROR_UNKNOWN),
+                false,
+                "Vulkan pipeline source lost its recorded packet"
+            );
+        }
         LatchHardFailure(
             StreamPosition{_batch->sequence, _source_index + 1},
             static_cast<int32>(VK_ERROR_UNKNOWN)
@@ -1846,7 +2013,11 @@ void VulkanSubmissionExecutor::ExecutePipelineSource(
         slot.recorded_packet
     );
     if (submit == nullptr) {
-        reject_packet(VK_ERROR_UNKNOWN);
+        reject_packet(
+            VK_ERROR_UNKNOWN,
+            false,
+            "Vulkan pipeline source lost its submit payload"
+        );
         _batch->PublishFailure(
             _source_index + 1,
             static_cast<int32>(VK_ERROR_UNKNOWN),
@@ -1868,7 +2039,11 @@ void VulkanSubmissionExecutor::ExecutePipelineSource(
             VulkanSubmissionDetail::EWorkerRequestFailurePhase::Process,
             std::current_exception()
         );
-        reject_packet(VK_ERROR_UNKNOWN);
+        reject_packet(
+            VK_ERROR_UNKNOWN,
+            false,
+            "Vulkan pipeline source preparation failed"
+        );
         _batch->PublishFailure(
             _source_index + 1,
             static_cast<int32>(VK_ERROR_UNKNOWN),
@@ -1919,6 +2094,16 @@ void VulkanSubmissionExecutor::ExecutePipelineSource(
             static_cast<int32>(VK_ERROR_UNKNOWN) :
             static_cast<int32>(submit_result.outcome.result);
     const bool recoverable = submit_result.IsRecoverableRejection();
+    if (_batch->rejection_publication) {
+        _batch->rejection_publication->PublishSuffix(
+            _source_index,
+            failure_result,
+            recoverable,
+            recoverable ?
+                "Vulkan pipeline source submission was rejected by a dependency" :
+                "Vulkan pipeline source submission failed"
+        );
+    }
     _batch->PublishFailure(
         _source_index + 1, failure_result, recoverable
     );
@@ -1998,6 +2183,34 @@ void VulkanSubmissionExecutor::RejectBatch(
     const size_t first_source = std::min(_first_source, _batch.submits.size());
     ResolveRejectedPresent(_batch.present);
     const VkResult result = static_cast<VkResult>(_result);
+
+    // Rejection is atomic at the runtime-batch frontier: every signal is
+    // terminal and every Query is Error before the first per-queue Completion
+    // packet can release callbacks.
+    for (size_t source_index = first_source;
+         source_index < _batch.submits.size();
+         ++source_index) {
+        CmdSubmit& submit = _batch.submits[source_index].submit;
+        submit.RejectPendingSignals();
+    }
+
+    const QueryPublishBatch query_batch =
+        QueryBackendAccess::BeginPublishBatch();
+    for (size_t source_index = first_source;
+         source_index < _batch.submits.size();
+         ++source_index) {
+        CmdSubmit& submit = _batch.submits[source_index].submit;
+        // Batch admission may already have installed the winning notification
+        // ticket. Rejection must publish through that owner instead of
+        // replacing it with the fallback shared by previously unsnapshotted
+        // entries.
+        const QueryPublishBatch source_query_batch =
+            submit.query_publish_batch.Valid() ?
+                submit.query_publish_batch :
+                query_batch;
+        submit.PublishPendingQueryErrors(_reason, source_query_batch);
+    }
+
     for (size_t source_index = first_source;
          source_index < _batch.submits.size();
          ++source_index) {
@@ -2212,6 +2425,13 @@ void VulkanSubmissionExecutor::ProcessBatch(
         return;
     }
 
+    // Capture strong, copyable terminal handles before any CmdSubmit moves
+    // into a Translate worker. A pipeline failure can then publish every raw
+    // or already-recorded suffix Future without waiting for per-queue
+    // Completion packets that may sit behind a blocking callback.
+    auto rejection_publication =
+        std::make_shared<BatchRejectionPublication>(_batch);
+
     struct PipelineSealGuard final {
         std::shared_ptr<PipelineBatchState> state{};
 
@@ -2234,7 +2454,10 @@ void VulkanSubmissionExecutor::ProcessBatch(
     if (pipeline_mode) {
         auto completion = std::make_shared<Completion>();
         pipeline_state  = std::make_shared<PipelineBatchState>(
-            _batch.sequence, _batch.submits.size(), completion
+            _batch.sequence,
+            _batch.submits.size(),
+            completion,
+            rejection_publication
         );
         pipeline_seal.state = pipeline_state;
         in_flight_batches.emplace_back(std::move(completion));
@@ -2264,6 +2487,9 @@ void VulkanSubmissionExecutor::ProcessBatch(
         if (_result == VK_SUCCESS) {
             _result = VK_ERROR_UNKNOWN;
         }
+        rejection_publication->PublishSuffix(
+            _begin, static_cast<int32>(_result), false, _reason
+        );
         // prepare_source may have admitted a later ready native lane before
         // the stable submission cursor rejects an earlier source. Preserve
         // gpu_frontier for successfully submitted work, but force the next
@@ -2297,6 +2523,9 @@ void VulkanSubmissionExecutor::ProcessBatch(
             if (_result == VK_SUCCESS) {
                 _result = VK_ERROR_UNKNOWN;
             }
+            rejection_publication->PublishSuffix(
+                _begin, static_cast<int32>(_result), true, _reason
+            );
             if (pipeline_state) {
                 pipeline_state->PublishFailure(
                     _begin, static_cast<int32>(_result), true
@@ -2624,11 +2853,34 @@ void VulkanSubmissionExecutor::ProcessBatch(
         auto fail_group = [&](size_t           failure_source,
                               VkResult         failure_result,
                               bool             recoverable_failure,
-                              std::string_view failure_reason) {
+                              std::string_view failure_reason,
+                              std::optional<size_t> rejection_source =
+                                  std::nullopt) {
             if (failure_result == VK_SUCCESS) {
                 failure_result = VK_ERROR_UNKNOWN;
             }
             scheduler.Cancel();
+            size_t rejection_begin = group_end;
+            for (const TranslateGroupSlot& slot : slots) {
+                if (!slot.terminalized) {
+                    rejection_begin =
+                        std::min(rejection_begin, slot.source_index);
+                }
+            }
+            // TranslateForRuntime owns the rejected Completion packet after a
+            // null result, so that slot is already marked terminalized above.
+            // It is still the failure source whose Query state must be
+            // published before any earlier same-queue callback can run.
+            rejection_begin = std::min(
+                rejection_begin,
+                rejection_source.value_or(failure_source)
+            );
+            rejection_publication->PublishSuffix(
+                rejection_begin,
+                static_cast<int32>(failure_result),
+                recoverable_failure,
+                failure_reason
+            );
             terminalizer.TerminalizeAll(failure_result);
             LOG_ERROR(
                 "[RHIExecutor][Vulkan][ParallelTranslate] "
@@ -2855,7 +3107,8 @@ void VulkanSubmissionExecutor::ProcessBatch(
                             slot.source_index,
                             VK_ERROR_UNKNOWN,
                             false,
-                            "parallel Translate scheduler handoff release failure"
+                            "parallel Translate scheduler handoff release failure",
+                            slot.source_index + 1
                         );
                     }
                     ++next_release_local;
@@ -2913,7 +3166,10 @@ void VulkanSubmissionExecutor::ProcessBatch(
                         slot.source_index,
                         VK_ERROR_UNKNOWN,
                         false,
-                        "parallel Translate scheduler release failure"
+                        "parallel Translate scheduler release failure",
+                        submit_result.WasSubmitted() ?
+                            slot.source_index + 1 :
+                            slot.source_index
                     );
                 }
                 ++next_release_local;
@@ -2991,6 +3247,12 @@ void VulkanSubmissionExecutor::ProcessBatch(
                     "[RHIExecutor][Vulkan] batch={} Copy translation failed result={}",
                     _batch.sequence,
                     static_cast<int32>(result)
+                );
+                rejection_publication->PublishSuffix(
+                    source_index,
+                    static_cast<int32>(result),
+                    false,
+                    "Copy translation failure"
                 );
                 reject_remaining(
                     source_index + 1,
@@ -3078,6 +3340,12 @@ void VulkanSubmissionExecutor::ProcessBatch(
                 // current source on Completion, reject the rest of this
                 // topology batch, and keep the runtime available for a later
                 // independent batch.
+                rejection_publication->PublishSuffix(
+                    source_index,
+                    static_cast<int32>(submit_result.outcome.result),
+                    true,
+                    "Copy submission dependency rejection"
+                );
                 reject_remaining_recoverable(
                     source_index + 1,
                     submit_result.outcome.result,
@@ -3094,6 +3362,12 @@ void VulkanSubmissionExecutor::ProcessBatch(
                 // A failed native Copy submit still publishes a CPU retirement
                 // marker. ProcessSync always enters Copy Sync, whose independent
                 // retirement serial drains it without reading Copy-owner state.
+                rejection_publication->PublishSuffix(
+                    source_index,
+                    static_cast<int32>(submit_result.outcome.result),
+                    false,
+                    "Copy submission hard failure"
+                );
                 reject_remaining(
                     source_index + 1,
                     submit_result.outcome.result,
@@ -3121,6 +3395,12 @@ void VulkanSubmissionExecutor::ProcessBatch(
                 const VkResult result = vk_device.IsFaulted() ?
                                             vk_device.GetFirstFaultResult() :
                                             VK_ERROR_UNKNOWN;
+                rejection_publication->PublishSuffix(
+                    source_index,
+                    static_cast<int32>(result),
+                    false,
+                    "command translation failure"
+                );
                 reject_remaining(
                     source_index + 1, result, "command translation failure"
                 );
@@ -3198,6 +3478,12 @@ void VulkanSubmissionExecutor::ProcessBatch(
                 );
                 used_queues[static_cast<size_t>(entry.queue)] = true;
             } else if (submit_result.IsRecoverableRejection()) {
+                rejection_publication->PublishSuffix(
+                    source_index,
+                    static_cast<int32>(submit_result.outcome.result),
+                    true,
+                    "command submission dependency rejection"
+                );
                 reject_remaining_recoverable(
                     source_index + 1,
                     submit_result.outcome.result,
@@ -3212,6 +3498,12 @@ void VulkanSubmissionExecutor::ProcessBatch(
                     static_cast<uint32>(entry.queue),
                     static_cast<uint32>(submit_result.outcome.status),
                     static_cast<int32>(submit_result.outcome.result)
+                );
+                rejection_publication->PublishSuffix(
+                    source_index,
+                    static_cast<int32>(submit_result.outcome.result),
+                    false,
+                    "command submission hard failure"
                 );
                 reject_remaining(
                     source_index + 1,

--- a/source/runtime/render/rhi/vulkan/VulkanSubmissionExecutor.h
+++ b/source/runtime/render/rhi/vulkan/VulkanSubmissionExecutor.h
@@ -108,6 +108,11 @@ private:
         std::mutex                     mutex{};
     };
 
+    struct RuntimePreCompletionPublication {
+        std::shared_ptr<BatchRejectionPublication> rejection_publication{};
+        size_t                                     reject_from{0};
+    };
+
     using RecordedSourcePacket = std::variant<
         std::monostate,
         VkCommandQueue::CurrentVulkanRecordedSubmit,
@@ -198,18 +203,25 @@ private:
         CmdSubmit&& _submit
     ) noexcept;
     [[nodiscard]] VulkanRuntimeSubmissionResult SubmitRecordedSourceForRuntime(
-        EQueueType            _queue,
-        RecordedSourcePacket&& _packet
+        EQueueType                            _queue,
+        RecordedSourcePacket&&                _packet,
+        const VulkanRuntimePreCompletionHook* _pre_completion = nullptr
+    ) noexcept;
+    static void PublishRuntimeFailureBeforeCompletion(
+        void*                                _context,
+        const VulkanRuntimeSubmissionResult& _result
     ) noexcept;
     void RejectRecordedSourceForRuntime(
         EQueueType             _queue,
         RecordedSourcePacket&& _packet,
-        VkResult               _result
+        VkResult               _result,
+        bool                   _recoverable
     ) noexcept;
     void RejectSourceForRuntime(
         EQueueType _queue,
         CmdSubmit&& _submit,
-        VkResult    _result
+        VkResult    _result,
+        bool        _recoverable
     ) noexcept;
     [[nodiscard]] static bool HasRecordedSourcePacket(
         const RecordedSourcePacket& _packet
@@ -242,6 +254,7 @@ private:
         RHIBackendSubmissionBatch&& _batch,
         int32                       _result,
         std::string_view            _reason,
+        bool                        _recoverable,
         size_t                      _first_source = 0,
         size_t*                     _next_unconsumed_source = nullptr
     );

--- a/source/runtime/render/rhi/vulkan/VulkanSubmissionExecutor.h
+++ b/source/runtime/render/rhi/vulkan/VulkanSubmissionExecutor.h
@@ -76,6 +76,38 @@ private:
         bool   recoverable{false};
     };
 
+    struct RejectionSignalHandle {
+        FenceRef fence{};
+        uint64   value{0};
+    };
+
+    struct RejectionSourceSnapshot {
+        Array<RejectionSignalHandle> signals{};
+        Array<QueryToken>            query_tokens{};
+        QueryPublishBatch            query_batch{};
+        bool                         terminalized{false};
+    };
+
+    // Immutable, strongly-owned terminal handles captured before any source
+    // leaves the request-owned batch. Pipeline workers can therefore publish a
+    // failed suffix immediately even when its later raw CmdSubmits have not yet
+    // entered Translate.
+    struct BatchRejectionPublication {
+        explicit BatchRejectionPublication(
+            RHIBackendSubmissionBatch& _batch
+        );
+
+        void PublishSuffix(
+            size_t           _reject_from,
+            int32            _result,
+            bool             _recoverable,
+            std::string_view _reason
+        ) noexcept;
+
+        Array<RejectionSourceSnapshot> sources{};
+        std::mutex                     mutex{};
+    };
+
     using RecordedSourcePacket = std::variant<
         std::monostate,
         VkCommandQueue::CurrentVulkanRecordedSubmit,
@@ -95,7 +127,9 @@ private:
         explicit PipelineBatchState(
             uint64                      _sequence,
             size_t                      _source_count,
-            std::shared_ptr<Completion> _completion
+            std::shared_ptr<Completion> _completion,
+            std::shared_ptr<BatchRejectionPublication>
+                _rejection_publication
         );
 
         void AddWork() noexcept;
@@ -115,6 +149,8 @@ private:
         std::atomic_bool             completion_signalled{false};
         mutable std::mutex           failure_mutex{};
         PipelineFailure              failure{};
+        std::shared_ptr<BatchRejectionPublication>
+            rejection_publication{};
     };
 
     struct StreamPosition {

--- a/source/runtime/render/rhi/vulkan/VulkanSubmissionExecutor.h
+++ b/source/runtime/render/rhi/vulkan/VulkanSubmissionExecutor.h
@@ -49,6 +49,8 @@ private:
         bool                    done{false};
     };
 
+    struct BatchRejectionPublication;
+
     using ERequestKind = VulkanSubmissionDetail::EWorkerRequestKind;
 
     struct Request {
@@ -64,6 +66,8 @@ private:
         // several entries; its source-level callback lifetime is protected by
         // a completion aggregate spanning every segment.
         size_t first_unconsumed_source{0};
+        std::shared_ptr<BatchRejectionPublication>
+            rejection_publication{};
     };
 
     struct SubmissionWork {
@@ -85,6 +89,7 @@ private:
         Array<RejectionSignalHandle> signals{};
         Array<QueryToken>            query_tokens{};
         QueryPublishBatch            query_batch{};
+        VulkanBatchCompletionTicket  completion_ticket{};
         bool                         terminalized{false};
     };
 
@@ -103,6 +108,9 @@ private:
             bool             _recoverable,
             std::string_view _reason
         ) noexcept;
+        [[nodiscard]] VulkanBatchCompletionTicket CompletionTicket(
+            size_t _source_index
+        ) const noexcept;
 
         Array<RejectionSourceSnapshot> sources{};
         std::mutex                     mutex{};
@@ -200,7 +208,8 @@ private:
     ) noexcept;
     [[nodiscard]] RecordedSourcePacket TranslateSourceForRuntime(
         EQueueType _queue,
-        CmdSubmit&& _submit
+        CmdSubmit&& _submit,
+        VulkanBatchCompletionTicket _completion_ticket = {}
     ) noexcept;
     [[nodiscard]] VulkanRuntimeSubmissionResult SubmitRecordedSourceForRuntime(
         EQueueType                            _queue,
@@ -221,7 +230,8 @@ private:
         EQueueType _queue,
         CmdSubmit&& _submit,
         VkResult    _result,
-        bool        _recoverable
+        bool        _recoverable,
+        VulkanBatchCompletionTicket _completion_ticket = {}
     ) noexcept;
     [[nodiscard]] static bool HasRecordedSourcePacket(
         const RecordedSourcePacket& _packet
@@ -256,7 +266,9 @@ private:
         std::string_view            _reason,
         bool                        _recoverable,
         size_t                      _first_source = 0,
-        size_t*                     _next_unconsumed_source = nullptr
+        size_t*                     _next_unconsumed_source = nullptr,
+        std::shared_ptr<BatchRejectionPublication>
+            _rejection_publication = {}
     );
     void CompleteRequest(const std::shared_ptr<Completion>& _completion);
     void ReportRequestFailure(

--- a/source/test/CMakeLists.txt
+++ b/source/test/CMakeLists.txt
@@ -74,6 +74,14 @@ target_link_libraries(${test_target}
 set_target_properties(${test_target} PROPERTIES FOLDER ${moer_test_folder})
 add_test(NAME RHICommandMarkerContract COMMAND $<TARGET_FILE:${test_target}>)
 
+set(test_target TestRHIQuery)
+add_executable(${test_target} "RHIQueryContractTest.cpp")
+target_link_libraries(${test_target}
+    PRIVATE Moer::Render
+)
+set_target_properties(${test_target} PROPERTIES FOLDER ${moer_test_folder})
+add_test(NAME RHIQueryContract COMMAND $<TARGET_FILE:${test_target}>)
+
 set(test_target TestExternalCpuJoin)
 add_executable(${test_target} "ExternalCpuJoinTest.cpp")
 target_link_libraries(${test_target}

--- a/source/test/RHIExecutorRecordingHandoffTest.cpp
+++ b/source/test/RHIExecutorRecordingHandoffTest.cpp
@@ -267,6 +267,111 @@ bool FrontendQueryRejectionTerminalizesBeforeOrdinaryCallbacks() {
                result.has_value() && result->status == QueryStatus::Error &&
                    !result->error_reason.empty(),
                "frontend rejection left the timestamp query non-terminal"
+            );
+}
+
+bool FrontendPresentRejectionPublishesBatchBeforeReceipt() {
+    PresentReceiptRef receipt = std::make_shared<PresentReceipt>();
+    std::atomic<bool> signal_observed_pending_receipt{false};
+    std::atomic<bool> query_observed_terminal_batch_and_receipt{false};
+    std::atomic<bool> ordinary_observed_query_notification{false};
+    std::atomic<int>  query_callbacks{0};
+    std::atomic<int>  ordinary_callbacks{0};
+    std::atomic<int>  success_callbacks{0};
+
+    RecordingFenceProbe signal(
+        std::shared_ptr<std::atomic_bool>{},
+        [&] {
+            const PresentReceiptResult result =
+                receipt->WaitForSubmission(0ms);
+            signal_observed_pending_receipt.store(
+                !result.resolved,
+                std::memory_order_release
+            );
+        }
+    );
+
+    CommandList commands(EQueueType::Graphics);
+    commands.Signal(&signal, 13);
+    commands.AddCallback([&] {
+        const PresentReceiptResult present_result =
+            receipt->WaitForSubmission(0ms);
+        ordinary_observed_query_notification.store(
+            present_result.resolved && !present_result.submitted &&
+                signal.IsRejected(13) &&
+                query_callbacks.load(std::memory_order_acquire) == 1,
+            std::memory_order_release
+        );
+        ordinary_callbacks.fetch_add(1, std::memory_order_release);
+    });
+    commands.AddSuccessCallback([&] {
+        success_callbacks.fetch_add(1, std::memory_order_release);
+    });
+
+    QueryToken token =
+        commands.BeginTimestampQuery("FrontendRejectedPresentTimestamp");
+    QueryFuture future = token.GetFuture();
+    commands.EndTimestampQuery(token);
+    future.Then([&](const QueryResult& _result) {
+        const PresentReceiptResult present_result =
+            receipt->WaitForSubmission(0ms);
+        query_observed_terminal_batch_and_receipt.store(
+            _result.status == QueryStatus::Error && signal.IsRejected(13) &&
+                present_result.resolved && !present_result.submitted,
+            std::memory_order_release
+        );
+        query_callbacks.fetch_add(1, std::memory_order_release);
+    });
+
+    // The invalid Present request is rejected synchronously, without requiring
+    // a RenderDevice. Its receipt must remain Pending while sibling Signals
+    // are rejected, then resolve after Query state publication and before any
+    // Query or ordinary callback notification.
+    RHIPresentRequest present{};
+    present.receipt = receipt;
+    RHIExecutor::Get().Submit(
+        EQueueType::Graphics,
+        commands.Submit(),
+        ERHIExecSubmitFlags::None,
+        &present
+    );
+
+    const PresentReceiptResult present_result =
+        receipt->WaitForSubmission(100ms);
+    const std::optional<QueryResult> query_result = future.TryGet();
+    return Expect(
+               signal_observed_pending_receipt.load(
+                   std::memory_order_acquire
+               ),
+               "frontend Present receipt resolved before a sibling signal became terminal"
+           ) &&
+           Expect(
+               present_result.resolved && !present_result.submitted &&
+                   receipt->ResolutionAttemptCount() == 1,
+               "frontend Present rejection did not resolve its receipt exactly once"
+           ) &&
+           Expect(
+               query_result.has_value() &&
+                   query_result->status == QueryStatus::Error,
+               "frontend Present rejection left a sibling Query Pending"
+           ) &&
+           Expect(
+               query_callbacks.load(std::memory_order_acquire) == 1 &&
+                   query_observed_terminal_batch_and_receipt.load(
+                       std::memory_order_acquire
+                   ),
+               "Query callback ran before the rejected batch and Present receipt were terminal"
+           ) &&
+           Expect(
+               ordinary_callbacks.load(std::memory_order_acquire) == 1 &&
+                   ordinary_observed_query_notification.load(
+                       std::memory_order_acquire
+                   ),
+               "ordinary callback ran before Query notification or Present rejection"
+           ) &&
+           Expect(
+               success_callbacks.load(std::memory_order_acquire) == 0,
+               "frontend Present rejection invoked a success-only callback"
            );
 }
 
@@ -384,8 +489,12 @@ bool DirectCommandListGroupPreflightRejectsEverySource() {
     std::array<std::atomic<int>, 3> ordinary_callbacks{};
     std::array<std::atomic<int>, 3> success_callbacks{};
     std::array<std::atomic<bool>, 3> query_observed_error{};
+    std::array<std::atomic<bool>, 3> query_observed_present_rejection{};
     std::array<std::atomic<bool>, 3> ordinary_observed_own_query{};
     std::atomic<bool> first_query_observed_last_terminal{false};
+    PresentReceiptRef receipt = std::make_shared<PresentReceipt>();
+    RHIPresentRequest present{};
+    present.receipt = receipt;
 
     for (size_t index = 0; index < command_lists.size(); ++index) {
         command_lists[index].Signal(&signals[index], 40 + index);
@@ -422,6 +531,12 @@ bool DirectCommandListGroupPreflightRejectsEverySource() {
                 _result.status == QueryStatus::Error,
                 std::memory_order_release
             );
+            const PresentReceiptResult present_result =
+                receipt->WaitForSubmission(0ms);
+            query_observed_present_rejection[index].store(
+                present_result.resolved && !present_result.submitted,
+                std::memory_order_release
+            );
             query_callbacks[index].fetch_add(
                 1, std::memory_order_release
             );
@@ -433,7 +548,7 @@ bool DirectCommandListGroupPreflightRejectsEverySource() {
         RHIExecutor::Get().Submit(
             std::move(command_lists),
             ERHIExecSubmitFlags::None,
-            nullptr
+            &present
         );
     } catch (...) {
         threw = true;
@@ -461,6 +576,12 @@ bool DirectCommandListGroupPreflightRejectsEverySource() {
             "direct CommandList group preflight did not notify a Query callback exactly once"
         );
         okay &= Expect(
+            query_observed_present_rejection[index].load(
+                std::memory_order_acquire
+            ),
+            "direct CommandList group Query callback ran before Present rejection"
+        );
+        okay &= Expect(
             ordinary_callbacks[index].load(std::memory_order_acquire) == 1 &&
                 ordinary_observed_own_query[index].load(
                     std::memory_order_acquire
@@ -479,6 +600,13 @@ bool DirectCommandListGroupPreflightRejectsEverySource() {
     okay &= Expect(
         first_query_observed_last_terminal.load(std::memory_order_acquire),
         "direct CommandList group preflight allowed an earlier Query callback to observe a later Future Pending"
+    );
+    const PresentReceiptResult present_result =
+        receipt->WaitForSubmission(100ms);
+    okay &= Expect(
+        present_result.resolved && !present_result.submitted &&
+            receipt->ResolutionAttemptCount() == 1,
+        "direct CommandList group preflight did not reject Present exactly once"
     );
 
     // Keep the regression bounded and release raw fence ownership even when
@@ -1608,6 +1736,7 @@ bool ShutdownDrainsAcceptedReadyWork() {
 int main() {
     if (!CommandListSignalTracksNativeAcceptanceAndRejection() ||
         !FrontendQueryRejectionTerminalizesBeforeOrdinaryCallbacks() ||
+        !FrontendPresentRejectionPublishesBatchBeforeReceipt() ||
         !DeferredOpaqueCancellationTicketSurvivesSubmit() ||
         !DirectCommandListGroupPreflightRejectsEverySource() ||
         !DirectCommandListGroupMaterializationFailureRejectsPrefixAndSuffix() ||

--- a/source/test/RHIExecutorRecordingHandoffTest.cpp
+++ b/source/test/RHIExecutorRecordingHandoffTest.cpp
@@ -1,12 +1,15 @@
 #include "rhi/RHIExecutor.h"
 #include "rhi/RHIThreadOwnership.h"
 
+#include <array>
 #include <atomic>
 #include <chrono>
 #include <condition_variable>
 #include <cstdlib>
+#include <functional>
 #include <iostream>
 #include <mutex>
+#include <optional>
 #include <thread>
 #include <vector>
 
@@ -51,10 +54,14 @@ bool Expect(bool _condition, const char* _message) {
 
 class RecordingFenceProbe final : public Fence {
 public:
+    RecordingFenceProbe() = default;
+
     explicit RecordingFenceProbe(
-        std::shared_ptr<std::atomic_bool> _destroyed = {}
+        std::shared_ptr<std::atomic_bool> _destroyed,
+        std::function<void()>             _on_reject = {}
     ) :
-        destroyed(std::move(_destroyed)) {}
+        destroyed(std::move(_destroyed)),
+        on_reject(std::move(_on_reject)) {}
 
     ~RecordingFenceProbe() override {
         if (destroyed) {
@@ -84,6 +91,12 @@ public:
 
     void Reject(uint64_t _value) noexcept override {
         rejected_value.store(_value, std::memory_order_release);
+        if (on_reject) {
+            try {
+                on_reject();
+            } catch (...) {
+            }
+        }
     }
 
     bool IsRejected(uint64_t _value) const override {
@@ -96,6 +109,7 @@ public:
 
 private:
     std::shared_ptr<std::atomic_bool> destroyed{};
+    std::function<void()>             on_reject{};
     std::atomic<uint64_t> submitted_value{0};
     std::atomic<uint64_t> rejected_value{0};
 };
@@ -153,6 +167,10 @@ bool CommandListSignalTracksNativeAcceptanceAndRejection() {
     for (auto& callback : owned_submit.callbacks) {
         callback();
     }
+    // Native completion consumes signal ownership before releasing the
+    // keepalive callback. Mirror that ordering so CmdSubmit's fail-closed
+    // destructor cannot revisit an already-retired raw fence pointer.
+    owned_submit.signal_events.clear();
     owned_submit.callbacks.clear();
     if (!Expect(
             owned_destroyed->load(std::memory_order_acquire),
@@ -193,6 +211,637 @@ bool CommandListSignalTracksNativeAcceptanceAndRejection() {
     okay &= Expect(
         !frontend_rejected.WaitSubmitted(9),
         "frontend-rejected signal was reported as natively submitted"
+    );
+    return okay;
+}
+
+bool FrontendQueryRejectionTerminalizesBeforeOrdinaryCallbacks() {
+    CommandList commands(EQueueType::Graphics);
+    QueryFuture future{};
+
+    std::atomic<int>  ordinary_callbacks{0};
+    std::atomic<int>  success_callbacks{0};
+    std::atomic<bool> ordinary_callback_observed_error{false};
+
+    // Register this before BeginTimestampQuery so it also precedes the query's
+    // own rejection fallback in CmdSubmit::callbacks. Frontend rejection must
+    // terminalize every query before invoking either callback.
+    commands.AddCallback([&] {
+        const std::optional<QueryResult> result = future.TryGet();
+        ordinary_callback_observed_error.store(
+            result.has_value() && result->status == QueryStatus::Error &&
+                !result->error_reason.empty(),
+            std::memory_order_release
+        );
+        ordinary_callbacks.fetch_add(1, std::memory_order_release);
+    });
+    commands.AddSuccessCallback([&] {
+        success_callbacks.fetch_add(1, std::memory_order_release);
+    });
+
+    QueryToken token =
+        commands.BeginTimestampQuery("FrontendRejectedTimestamp");
+    future = token.GetFuture();
+    commands.EndTimestampQuery(token);
+
+    RHIExecutor::Get().Submit(
+        EQueueType::Ignore,
+        commands.Submit(),
+        ERHIExecSubmitFlags::None
+    );
+
+    const std::optional<QueryResult> result = future.TryGet();
+    return Expect(
+               ordinary_callbacks.load(std::memory_order_acquire) == 1,
+               "frontend rejection did not invoke the ordinary callback exactly once"
+           ) &&
+           Expect(
+               ordinary_callback_observed_error.load(std::memory_order_acquire),
+               "ordinary callback ran before the rejected query became Error"
+           ) &&
+           Expect(
+               success_callbacks.load(std::memory_order_acquire) == 0,
+               "frontend rejection invoked a success-only callback"
+           ) &&
+           Expect(
+               result.has_value() && result->status == QueryStatus::Error &&
+                   !result->error_reason.empty(),
+               "frontend rejection left the timestamp query non-terminal"
+           );
+}
+
+bool DeferredOpaqueCancellationTicketSurvivesSubmit() {
+    RecordingFenceProbe signal{};
+    CommandList         commands(EQueueType::Graphics);
+    std::atomic<int>    query_callbacks{0};
+    std::atomic<int>    ordinary_callbacks{0};
+    std::atomic<int>    success_callbacks{0};
+    std::atomic<bool>   query_observed_signal_rejection{false};
+    std::atomic<bool>   ordinary_observed_query_notification{false};
+
+    commands.Signal(&signal, 17);
+    commands.AddCallback([&] {
+        ordinary_observed_query_notification.store(
+            signal.IsRejected(17) &&
+                query_callbacks.load(std::memory_order_acquire) == 1,
+            std::memory_order_release
+        );
+        ordinary_callbacks.fetch_add(1, std::memory_order_release);
+    });
+    commands.AddSuccessCallback([&] {
+        success_callbacks.fetch_add(1, std::memory_order_release);
+    });
+    QueryToken token =
+        commands.BeginTimestampQuery("DeferredCancellationSubmit");
+    commands.EndTimestampQuery(token);
+    QueryFuture future = token.GetFuture();
+
+    QueryCancellationView cancellation =
+        commands.GetQueryCancellationView();
+    const QueryPublishBatch cancellation_batch =
+        QueryBackendAccess::BeginPublishBatch();
+    const bool cancellation_published =
+        cancellation.PublishCancellation(
+            "opaque source cancelled during shutdown",
+            cancellation_batch
+        );
+    future.Then([&](const QueryResult& _result) {
+        query_observed_signal_rejection.store(
+            _result.status == QueryStatus::Error &&
+                signal.IsRejected(17) &&
+                ordinary_callbacks.load(std::memory_order_acquire) == 0,
+            std::memory_order_release
+        );
+        query_callbacks.fetch_add(1, std::memory_order_release);
+    });
+
+    const bool callback_was_deferred =
+        query_callbacks.load(std::memory_order_acquire) == 0;
+    CmdSubmit submit = commands.Submit();
+    const bool ticket_transferred =
+        submit.query_publish_batch.Valid() &&
+        submit.query_tokens.size() == 1;
+    const bool callback_still_deferred =
+        query_callbacks.load(std::memory_order_acquire) == 0;
+
+    // Invalid-queue rejection is synchronous and exercises the ordinary
+    // frontend terminalization path without constructing a native backend.
+    RHIExecutor::Get().Submit(
+        EQueueType::Ignore,
+        std::move(submit),
+        ERHIExecSubmitFlags::None
+    );
+    cancellation.NotifyPublishedCancellation();
+
+    const std::optional<QueryResult> result = future.TryGet();
+    return Expect(
+               cancellation_published,
+               "opaque cancellation did not publish its Query Error"
+           ) &&
+           Expect(
+               callback_was_deferred && callback_still_deferred,
+               "opaque cancellation released its callback before signal ownership transferred"
+           ) &&
+           Expect(
+               ticket_transferred,
+               "CommandList::Submit dropped the deferred cancellation ticket or tokens"
+           ) &&
+           Expect(
+               query_callbacks.load(std::memory_order_acquire) == 1,
+               "deferred Query callback was not released exactly once"
+           ) &&
+           Expect(
+               query_observed_signal_rejection.load(std::memory_order_acquire),
+               "deferred Query callback ran before its submitted signal was rejected"
+           ) &&
+           Expect(
+               ordinary_callbacks.load(std::memory_order_acquire) == 1 &&
+                   ordinary_observed_query_notification.load(
+                       std::memory_order_acquire
+                   ),
+               "ordinary callback did not run exactly once after Query notification"
+           ) &&
+           Expect(
+               success_callbacks.load(std::memory_order_acquire) == 0,
+               "rejection invoked a success-only callback"
+           ) &&
+           Expect(
+               result.has_value() && result->status == QueryStatus::Error,
+               "deferred cancellation result did not remain Error"
+           );
+}
+
+bool DirectCommandListGroupPreflightRejectsEverySource() {
+    std::array<RecordingFenceProbe, 3> signals{};
+    Moer::Array<CommandList>           command_lists{};
+    command_lists.reserve(3);
+    for (size_t index = 0; index < 3; ++index) {
+        command_lists.emplace_back(EQueueType::Graphics);
+    }
+
+    std::array<QueryFuture, 3> futures{};
+    std::array<std::atomic<int>, 3> query_callbacks{};
+    std::array<std::atomic<int>, 3> ordinary_callbacks{};
+    std::array<std::atomic<int>, 3> success_callbacks{};
+    std::array<std::atomic<bool>, 3> query_observed_error{};
+    std::array<std::atomic<bool>, 3> ordinary_observed_own_query{};
+    std::atomic<bool> first_query_observed_last_terminal{false};
+
+    for (size_t index = 0; index < command_lists.size(); ++index) {
+        command_lists[index].Signal(&signals[index], 40 + index);
+        command_lists[index].AddCallback([&, index] {
+            ordinary_observed_own_query[index].store(
+                query_callbacks[index].load(std::memory_order_acquire) == 1,
+                std::memory_order_release
+            );
+            ordinary_callbacks[index].fetch_add(
+                1, std::memory_order_release
+            );
+        });
+        command_lists[index].AddSuccessCallback([&, index] {
+            success_callbacks[index].fetch_add(
+                1, std::memory_order_release
+            );
+        });
+        QueryToken token = command_lists[index].BeginTimestampQuery(
+            "DirectSubmitPreflightTimestamp"
+        );
+        futures[index] = token.GetFuture();
+        if (index != 1) {
+            command_lists[index].EndTimestampQuery(token);
+        }
+        futures[index].Then([&, index](const QueryResult& _result) {
+            if (index == 0) {
+                first_query_observed_last_terminal.store(
+                    futures[2].WaitFor(100ms) &&
+                        futures[2].Status() == QueryStatus::Error,
+                    std::memory_order_release
+                );
+            }
+            query_observed_error[index].store(
+                _result.status == QueryStatus::Error,
+                std::memory_order_release
+            );
+            query_callbacks[index].fetch_add(
+                1, std::memory_order_release
+            );
+        });
+    }
+
+    bool threw = false;
+    try {
+        RHIExecutor::Get().Submit(
+            std::move(command_lists),
+            ERHIExecSubmitFlags::None,
+            nullptr
+        );
+    } catch (...) {
+        threw = true;
+    }
+
+    bool okay = Expect(
+        !threw,
+        "direct CommandList group preflight propagated an open-query failure"
+    );
+    for (size_t index = 0; index < command_lists.size(); ++index) {
+        okay &= Expect(
+            signals[index].IsRejected(40 + index),
+            "direct CommandList group preflight left a signal Pending"
+        );
+        okay &= Expect(
+            futures[index].WaitFor(100ms) &&
+                futures[index].Status() == QueryStatus::Error,
+            "direct CommandList group preflight left a QueryFuture Pending"
+        );
+        okay &= Expect(
+            query_callbacks[index].load(std::memory_order_acquire) == 1 &&
+                query_observed_error[index].load(
+                    std::memory_order_acquire
+                ),
+            "direct CommandList group preflight did not notify a Query callback exactly once"
+        );
+        okay &= Expect(
+            ordinary_callbacks[index].load(std::memory_order_acquire) == 1 &&
+                ordinary_observed_own_query[index].load(
+                    std::memory_order_acquire
+                ),
+            "direct CommandList group preflight did not run ordinary cleanup after its Query callback"
+        );
+        okay &= Expect(
+            success_callbacks[index].load(std::memory_order_acquire) == 0,
+            "direct CommandList group preflight invoked a success-only callback"
+        );
+        okay &= Expect(
+            command_lists[index].IsEmpty(),
+            "direct CommandList group preflight left a source undrained"
+        );
+    }
+    okay &= Expect(
+        first_query_observed_last_terminal.load(std::memory_order_acquire),
+        "direct CommandList group preflight allowed an earlier Query callback to observe a later Future Pending"
+    );
+
+    // Keep the regression bounded and release raw fence ownership even when
+    // running against an older implementation that propagates the exception.
+    for (CommandList& command_list : command_lists) {
+        if (!command_list.IsEmpty()) {
+            auto callbacks =
+                command_list.DrainOrdinaryCallbacksForRejection();
+            for (auto& callback : callbacks) {
+                if (callback) {
+                    callback();
+                }
+            }
+        }
+    }
+    return okay;
+}
+
+bool DirectCommandListGroupMaterializationFailureRejectsPrefixAndSuffix() {
+    std::optional<CommandList::ManagedRecordingLease> blocking_lease{};
+    RecordingFenceProbe prefix_signal(
+        {},
+        [&blocking_lease] {
+            blocking_lease.reset();
+        }
+    );
+    RecordingFenceProbe middle_signal{};
+    RecordingFenceProbe suffix_signal{};
+    const std::array<RecordingFenceProbe*, 3> signals{
+        &prefix_signal,
+        &middle_signal,
+        &suffix_signal,
+    };
+
+    Moer::Array<CommandList> command_lists{};
+    command_lists.reserve(3);
+    for (size_t index = 0; index < 3; ++index) {
+        command_lists.emplace_back(EQueueType::Graphics);
+    }
+
+    std::array<QueryFuture, 3> futures{};
+    std::array<std::atomic<int>, 3> query_callbacks{};
+    std::array<std::atomic<int>, 3> ordinary_callbacks{};
+    std::array<std::atomic<int>, 3> success_callbacks{};
+    std::array<std::atomic<bool>, 3> ordinary_observed_own_query{};
+    std::atomic<bool> prefix_observed_suffix_terminal{false};
+    std::atomic<int>  reentrant_callbacks{0};
+
+    for (size_t index = 0; index < command_lists.size(); ++index) {
+        command_lists[index].Signal(signals[index], 50 + index);
+        command_lists[index].AddCallback([&, index] {
+            ordinary_observed_own_query[index].store(
+                query_callbacks[index].load(std::memory_order_acquire) == 1,
+                std::memory_order_release
+            );
+            ordinary_callbacks[index].fetch_add(
+                1, std::memory_order_release
+            );
+        });
+        command_lists[index].AddSuccessCallback([&, index] {
+            success_callbacks[index].fetch_add(
+                1, std::memory_order_release
+            );
+        });
+        QueryToken token = command_lists[index].BeginTimestampQuery(
+            "DirectSubmitMaterializationTimestamp"
+        );
+        command_lists[index].EndTimestampQuery(token);
+        futures[index] = token.GetFuture();
+        futures[index].Then([&, index](const QueryResult& _result) {
+            if (index == 0) {
+                prefix_observed_suffix_terminal.store(
+                    futures[2].WaitFor(100ms) &&
+                        futures[2].Status() == QueryStatus::Error,
+                    std::memory_order_release
+                );
+                // Source zero has already sealed. Re-entrant work belongs to
+                // its fresh generation and must survive rejection of the old
+                // materialized prefix.
+                command_lists[0].AddCallback([&reentrant_callbacks] {
+                    reentrant_callbacks.fetch_add(
+                        1, std::memory_order_release
+                    );
+                });
+            }
+            if (_result.status == QueryStatus::Error) {
+                query_callbacks[index].fetch_add(
+                    1, std::memory_order_release
+                );
+            }
+        });
+    }
+
+    blocking_lease.emplace(
+        command_lists[1].AcquireManagedRecordingLease()
+    );
+    bool threw = false;
+    try {
+        RHIExecutor::Get().Submit(
+            std::move(command_lists),
+            ERHIExecSubmitFlags::None,
+            nullptr
+        );
+    } catch (...) {
+        threw = true;
+    }
+
+    bool okay = Expect(
+                    !threw,
+                    "direct CommandList group propagated a mid-materialization failure"
+                ) &&
+                Expect(
+                    !blocking_lease.has_value(),
+                    "materialization-failure trigger did not release its managed lease"
+                );
+    for (size_t index = 0; index < command_lists.size(); ++index) {
+        okay &= Expect(
+            signals[index]->IsRejected(50 + index),
+            "direct CommandList materialization failure left a signal Pending"
+        );
+        okay &= Expect(
+            futures[index].WaitFor(100ms) &&
+                futures[index].Status() == QueryStatus::Error,
+            "direct CommandList materialization failure left a QueryFuture Pending"
+        );
+        okay &= Expect(
+            query_callbacks[index].load(std::memory_order_acquire) == 1,
+            "direct CommandList materialization failure did not notify a Query callback exactly once"
+        );
+        okay &= Expect(
+            ordinary_callbacks[index].load(std::memory_order_acquire) == 1 &&
+                ordinary_observed_own_query[index].load(
+                    std::memory_order_acquire
+                ),
+            "direct CommandList materialization failure did not run ordinary cleanup exactly once after Query notification"
+        );
+        okay &= Expect(
+            success_callbacks[index].load(std::memory_order_acquire) == 0,
+            "direct CommandList materialization failure invoked a success-only callback"
+        );
+    }
+    okay &= Expect(
+        prefix_observed_suffix_terminal.load(std::memory_order_acquire),
+        "materialized-prefix Query callback observed a suffix Future Pending"
+    );
+    okay &= Expect(
+        reentrant_callbacks.load(std::memory_order_acquire) == 0,
+        "group rejection consumed work re-entered into the prefix's fresh generation"
+    );
+    okay &= Expect(
+        command_lists[1].IsEmpty() && command_lists[2].IsEmpty(),
+        "direct CommandList materialization failure left an unmaterialized suffix undrained"
+    );
+
+    CmdSubmit reentrant_submit = command_lists[0].Submit();
+    okay &= Expect(
+        reentrant_submit.callbacks.size() == 1,
+        "materialized-prefix fresh generation did not retain re-entrant work"
+    );
+    for (auto& callback : reentrant_submit.callbacks) {
+        if (callback) {
+            callback();
+        }
+    }
+    reentrant_submit.callbacks.clear();
+    okay &= Expect(
+        reentrant_callbacks.load(std::memory_order_acquire) == 1,
+        "preserved re-entrant callback did not execute exactly once"
+    );
+    return okay;
+}
+
+bool RecordingPreflightFailureTerminalizesEveryQueryGeneration() {
+    RHIExecutor::StartUp();
+
+    auto first_list  = Moer::MakeShared<CommandList>(EQueueType::Graphics);
+    auto middle_list = Moer::MakeShared<CommandList>(EQueueType::Graphics);
+    auto last_list   = Moer::MakeShared<CommandList>(EQueueType::Graphics);
+
+    QueryToken first_query =
+        first_list->BeginTimestampQuery("PreflightFirstTimestamp");
+    QueryFuture first_future = first_query.GetFuture();
+    first_list->EndTimestampQuery(first_query);
+
+    QueryToken middle_query =
+        middle_list->BeginTimestampQuery("PreflightUnclosedTimestamp");
+    QueryFuture middle_future = middle_query.GetFuture();
+
+    QueryToken last_query =
+        last_list->BeginTimestampQuery("PreflightLastTimestamp");
+    QueryFuture last_future = last_query.GetFuture();
+    last_list->EndTimestampQuery(last_query);
+
+    std::array<std::atomic<int>, 3> query_callbacks{};
+    std::array<std::atomic<int>, 3> ordinary_callbacks{};
+    std::array<std::atomic<int>, 3> success_callbacks{};
+    std::array<std::atomic<bool>, 3> query_callbacks_observed_error{};
+    std::atomic<bool> first_query_observed_last_terminal{false};
+
+    first_future.Then([&](const QueryResult& _result) {
+        first_query_observed_last_terminal.store(
+            last_future.WaitFor(100ms) &&
+                last_future.Status() == QueryStatus::Error,
+            std::memory_order_release
+        );
+        query_callbacks_observed_error[0].store(
+            _result.status == QueryStatus::Error,
+            std::memory_order_release
+        );
+        query_callbacks[0].fetch_add(1, std::memory_order_release);
+    });
+    middle_future.Then([&](const QueryResult& _result) {
+        query_callbacks_observed_error[1].store(
+            _result.status == QueryStatus::Error,
+            std::memory_order_release
+        );
+        query_callbacks[1].fetch_add(1, std::memory_order_release);
+    });
+    last_future.Then([&](const QueryResult& _result) {
+        query_callbacks_observed_error[2].store(
+            _result.status == QueryStatus::Error,
+            std::memory_order_release
+        );
+        query_callbacks[2].fetch_add(1, std::memory_order_release);
+    });
+
+    const std::array<Moer::SharedPtr<CommandList>, 3> command_lists{
+        first_list,
+        middle_list,
+        last_list,
+    };
+    for (size_t index = 0; index < command_lists.size(); ++index) {
+        command_lists[index]->AddCallback([&, index] {
+            ordinary_callbacks[index].fetch_add(1, std::memory_order_release);
+        });
+        command_lists[index]->AddSuccessCallback([&, index] {
+            success_callbacks[index].fetch_add(1, std::memory_order_release);
+        });
+    }
+
+    Moer::Array<RHIRecordingSource> sources{};
+    for (const Moer::SharedPtr<CommandList>& command_list : command_lists) {
+        sources.emplace_back(RHIRecordingSource{
+            .command_list = command_list,
+            .completion   = RHIRecordingGate::Create(true),
+        });
+    }
+    RHIExecutor::Get().SubmitRecording(
+        std::move(sources),
+        ERHIExecSubmitFlags::None
+    );
+    RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
+
+    const std::array<QueryFuture, 3> futures{
+        first_future,
+        middle_future,
+        last_future,
+    };
+    bool okay = true;
+    for (size_t index = 0; index < futures.size(); ++index) {
+        okay &= Expect(
+            futures[index].WaitFor(100ms) &&
+                futures[index].Status() == QueryStatus::Error,
+            "recording preflight failure left a QueryFuture non-terminal"
+        );
+        okay &= Expect(
+            query_callbacks[index].load(std::memory_order_acquire) == 1 &&
+                query_callbacks_observed_error[index].load(
+                    std::memory_order_acquire
+                ),
+            "recording preflight failure did not invoke a query callback exactly once with Error"
+        );
+        okay &= Expect(
+            ordinary_callbacks[index].load(std::memory_order_acquire) == 1,
+            "recording preflight failure did not drain an ordinary callback exactly once"
+        );
+        okay &= Expect(
+            success_callbacks[index].load(std::memory_order_acquire) == 0,
+            "recording preflight failure invoked a success-only callback"
+        );
+        okay &= Expect(
+            command_lists[index]->IsEmpty(),
+            "recording preflight failure left a CommandList generation undrained"
+        );
+    }
+    okay &= Expect(
+        first_query_observed_last_terminal.load(std::memory_order_acquire),
+        "an earlier query callback observed a later source query still Pending"
+    );
+
+    RHIExecutor::ShutDown();
+    return okay;
+}
+
+bool SubmitRecordingRefreshesAStaleQueryCancellationView() {
+    RHIExecutor::StartUp();
+
+    auto command_list =
+        Moer::MakeShared<CommandList>(EQueueType::Graphics);
+    QueryCancellationView stale_cancellation =
+        command_list->GetQueryCancellationView();
+    {
+        // Even an empty Submit rotates the CommandList cancellation domain.
+        // The caller intentionally publishes the still-valid prior view below.
+        CmdSubmit prior_generation = command_list->Submit();
+    }
+
+    QueryToken current_query =
+        command_list->BeginTimestampQuery("CurrentGenerationTimestamp");
+    QueryFuture current_future = current_query.GetFuture();
+    command_list->EndTimestampQuery(current_query);
+
+    std::atomic<int> current_query_callbacks{0};
+    std::atomic<bool> current_callback_observed_error{false};
+    current_future.Then([&](const QueryResult& _result) {
+        current_callback_observed_error.store(
+            _result.status == QueryStatus::Error,
+            std::memory_order_release
+        );
+        current_query_callbacks.fetch_add(1, std::memory_order_release);
+    });
+
+    auto pending_gate = RHIRecordingGate::Create();
+    Moer::Array<RHIRecordingSource> sources{};
+    sources.emplace_back(RHIRecordingSource{
+        .command_list       = command_list,
+        .completion         = pending_gate,
+        .query_cancellation = stale_cancellation,
+    });
+    RHIExecutor::Get().SubmitRecording(
+        std::move(sources),
+        ERHIExecSubmitFlags::None
+    );
+
+    // The pending producer remains opaque during shutdown. Only the refreshed
+    // cancellation view can publish Error for its current query generation.
+    RHIExecutor::ShutDown();
+
+    bool okay = Expect(
+                    stale_cancellation.Valid() &&
+                        !stale_cancellation.IsCancelled(),
+                    "SubmitRecording cancelled the caller's stale generation"
+                ) &&
+                Expect(
+                    current_future.WaitFor(100ms) &&
+                        current_future.Status() == QueryStatus::Error,
+                    "shutdown left the current query generation Pending when a stale view was supplied"
+                ) &&
+                Expect(
+                    current_query_callbacks.load(std::memory_order_acquire) == 0,
+                    "opaque shutdown released a current-generation query callback too early"
+                );
+
+    pending_gate->Signal();
+    (void)command_list->DrainOrdinaryCallbacksForRejection();
+    okay &= Expect(
+        current_query_callbacks.load(std::memory_order_acquire) == 1 &&
+            current_callback_observed_error.load(std::memory_order_acquire),
+        "current-generation query callback was not released exactly once after producer ownership became safe"
+    );
+    okay &= Expect(
+        command_list->IsEmpty(),
+        "stale cancellation-view shutdown left the current CommandList generation undrained"
     );
     return okay;
 }
@@ -662,6 +1311,10 @@ bool ShutdownDrainsTerminalSourceBehindPendingHead() {
     std::atomic<int> success_callbacks{0};
     auto pending_list  = Moer::MakeShared<CommandList>(EQueueType::Graphics);
     auto terminal_list = Moer::MakeShared<CommandList>(EQueueType::Graphics);
+    QueryToken pending_query =
+        pending_list->BeginTimestampQuery("OpaqueShutdownQuery");
+    pending_list->EndTimestampQuery(pending_query);
+    QueryFuture pending_query_future = pending_query.GetFuture();
     terminal_list->AddCallback([&ordinary_callbacks] {
         ordinary_callbacks.fetch_add(1);
     });
@@ -706,10 +1359,126 @@ bool ShutdownDrainsTerminalSourceBehindPendingHead() {
         Expect(
             pending_gate->Status() == ERHIRecordingStatus::Pending,
             "shutdown changed the producer-owned pending gate"
+        ) &&
+        Expect(
+            pending_query_future.IsReady() &&
+                pending_query_future.Status() == QueryStatus::Error,
+            "shutdown left an opaque recording query Pending"
         );
 
     pending_gate->Signal();
     return okay;
+}
+
+bool ShutdownUsesOneTerminalSnapshotForSignalAndQueryNotification() {
+    RHIExecutor::StartUp();
+
+    auto promoted_gate =
+        RHIRecordingGate::Create();
+    RecordingFenceProbe promoted_signal{};
+    auto promoted_list =
+        Moer::MakeShared<CommandList>(EQueueType::Graphics);
+    promoted_list->Signal(&promoted_signal, 31);
+
+    std::atomic<int>  query_callbacks{0};
+    std::atomic<int>  ordinary_callbacks{0};
+    std::atomic<int>  success_callbacks{0};
+    std::atomic<bool> query_observed_signal_rejection{false};
+    std::atomic<bool> ordinary_observed_query_notification{false};
+    QueryToken promoted_query =
+        promoted_list->BeginTimestampQuery("PromotedDuringCancellation");
+    promoted_list->EndTimestampQuery(promoted_query);
+    QueryFuture promoted_future = promoted_query.GetFuture();
+    promoted_future.Then([&](const QueryResult& _result) {
+        query_observed_signal_rejection.store(
+            _result.status == QueryStatus::Error &&
+                promoted_signal.IsRejected(31),
+            std::memory_order_release
+        );
+        query_callbacks.fetch_add(1, std::memory_order_release);
+    });
+    promoted_list->AddCallback([&] {
+        ordinary_observed_query_notification.store(
+            promoted_signal.IsRejected(31) &&
+                query_callbacks.load(std::memory_order_acquire) == 1,
+            std::memory_order_release
+        );
+        ordinary_callbacks.fetch_add(1, std::memory_order_release);
+    });
+    promoted_list->AddSuccessCallback([&] {
+        success_callbacks.fetch_add(1, std::memory_order_release);
+    });
+
+    // The first source is Pending when cancellation classification starts.
+    // Rejecting the later terminal source promotes it synchronously after that
+    // first observation but before Query notification. A second status read
+    // would release the promoted callback without rejecting its signal.
+    RecordingFenceProbe promotion_trigger(
+        {},
+        [promoted_gate] {
+            promoted_gate->Signal();
+        }
+    );
+    auto terminal_list =
+        Moer::MakeShared<CommandList>(EQueueType::Graphics);
+    terminal_list->Signal(&promotion_trigger, 32);
+
+    Moer::Array<RHIRecordingSource> sources{};
+    sources.emplace_back(RHIRecordingSource{
+        .command_list = promoted_list,
+        .completion   = promoted_gate,
+    });
+    sources.emplace_back(RHIRecordingSource{
+        .command_list = terminal_list,
+        .completion   = RHIRecordingGate::Create(true),
+    });
+    RHIExecutor::Get().SubmitRecording(
+        std::move(sources),
+        ERHIExecSubmitFlags::None
+    );
+    RHIExecutor::ShutDown();
+
+    CmdSubmit drained_promoted = promoted_list->Submit();
+    const std::optional<QueryResult> result =
+        promoted_future.TryGet();
+    return Expect(
+               promoted_gate->Status() == ERHIRecordingStatus::Succeeded,
+               "test did not promote the Pending source during cancellation"
+           ) &&
+           Expect(
+               promoted_signal.IsRejected(31),
+               "newly-terminal source signal was not rejected by its drain owner"
+           ) &&
+           Expect(
+               query_callbacks.load(std::memory_order_acquire) == 1 &&
+                   query_observed_signal_rejection.load(
+                       std::memory_order_acquire
+                   ),
+               "newly-terminal Query callback ran before signal rejection or not exactly once"
+           ) &&
+           Expect(
+               ordinary_callbacks.load(std::memory_order_acquire) == 1 &&
+                   ordinary_observed_query_notification.load(
+                       std::memory_order_acquire
+                   ),
+               "newly-terminal ordinary cleanup did not run once after Query notification"
+           ) &&
+           Expect(
+               success_callbacks.load(std::memory_order_acquire) == 0,
+               "shutdown cancellation invoked a success-only callback"
+           ) &&
+           Expect(
+               result.has_value() && result->status == QueryStatus::Error,
+               "newly-terminal Query did not preserve its cancellation Error"
+           ) &&
+           Expect(
+               drained_promoted.cmds.empty() &&
+                   drained_promoted.callbacks.empty() &&
+                   drained_promoted.success_callbacks.empty() &&
+                   drained_promoted.query_tokens.empty() &&
+                   drained_promoted.segments.empty(),
+               "newly-terminal source was not destructively drained"
+           );
 }
 
 bool ShutdownCancelsAnUnsignalledGate() {
@@ -838,6 +1607,12 @@ bool ShutdownDrainsAcceptedReadyWork() {
 
 int main() {
     if (!CommandListSignalTracksNativeAcceptanceAndRejection() ||
+        !FrontendQueryRejectionTerminalizesBeforeOrdinaryCallbacks() ||
+        !DeferredOpaqueCancellationTicketSurvivesSubmit() ||
+        !DirectCommandListGroupPreflightRejectsEverySource() ||
+        !DirectCommandListGroupMaterializationFailureRejectsPrefixAndSuffix() ||
+        !RecordingPreflightFailureTerminalizesEveryQueryGeneration() ||
+        !SubmitRecordingRefreshesAStaleQueryCancellationView() ||
         !PerSourceGatesPreserveFifo() ||
         !ReadyWorkUsesStableExecutorOwnerAndCannotBeOvertaken() ||
         !FailedGateRejectsOnlyItsGroupAndPreservesFifo() ||
@@ -846,6 +1621,7 @@ int main() {
         !MetadataFailureRejectsEveryProducerSignal() ||
         !BlockingWaitReportsTerminalStatus() ||
         !ShutdownDrainsTerminalSourceBehindPendingHead() ||
+        !ShutdownUsesOneTerminalSnapshotForSignalAndQueryNotification() ||
         !ShutdownCancelsAnUnsignalledGate() ||
         !ShutdownDrainsAcceptedReadyWork()) {
         return EXIT_FAILURE;

--- a/source/test/RHIParallelRecordTest.cpp
+++ b/source/test/RHIParallelRecordTest.cpp
@@ -134,6 +134,36 @@ void SerialIslandBreaksSingletonRecordingWaves() {
            "profitable wave was not retained");
 }
 
+void QueryCommandsRemainSerialAndBreakRecordingWaves() {
+    const std::vector<Type> first{Type::SetDrawState};
+    const std::vector<Type> query{Type::Query};
+    const std::vector<Type> third{Type::ClearResource};
+    const std::vector<ParallelRecordLayerDescription> layers{
+        Describe(first), Describe(query), Describe(third)
+    };
+
+    const ParallelRecordPlan plan = BuildParallelRecordPlan(layers, 4, 1);
+    Expect(
+        plan.fallback_reason == ParallelRecordFallbackReason::InsufficientConcurrency,
+        "query command did not split otherwise parallel singleton waves"
+    );
+    Expect(
+        plan.jobs.empty() && plan.layers.empty(),
+        "query-separated singleton waves published parallel work"
+    );
+
+    const std::vector<Type> query_only{Type::Query, Type::Query};
+    const std::vector<ParallelRecordLayerDescription> query_layers{
+        Describe(query_only)
+    };
+    const ParallelRecordPlan query_plan =
+        BuildParallelRecordPlan(query_layers, 4, 1);
+    Expect(
+        query_plan.fallback_reason == ParallelRecordFallbackReason::NoEligibleLayer,
+        "query-only layer was considered parallel-record eligible"
+    );
+}
+
 void InvalidInputsFailClosedWithoutPublishingJobs() {
     const std::vector<Type> eligible{Type::TextureToTexture, Type::TextureToTexture};
     const std::vector<ParallelRecordLayerDescription> layers{Describe(eligible)};
@@ -375,6 +405,7 @@ int main() {
         RuntimeConstraintForcesAnOtherwiseEligibleLayerSerial();
         OrderedSingletonLayersFormAParallelRecordingWave();
         SerialIslandBreaksSingletonRecordingWaves();
+        QueryCommandsRemainSerialAndBreakRecordingWaves();
         InvalidInputsFailClosedWithoutPublishingJobs();
         StableMergeOrderReconstructsOriginalLayerOrder();
         WorkGranularityGateAmortizesWorkerAndPrimaryOverhead();

--- a/source/test/RHIParallelRecordVulkanTest.cpp
+++ b/source/test/RHIParallelRecordVulkanTest.cpp
@@ -988,6 +988,90 @@ private:
     bool                          installed{false};
 };
 
+class QueueLocalSyncWaitCapture final {
+public:
+    static void Observe(
+        void*                                    _context,
+        const VulkanQueueLocalSyncWaitEvent& _event
+    ) noexcept {
+        auto& capture =
+            *static_cast<QueueLocalSyncWaitCapture*>(_context);
+        const uint32 queue_bit =
+            _event.queue == EQueueType::Graphics ? 1u :
+            _event.queue == EQueueType::Compute ? 2u :
+            _event.queue == EQueueType::Copy ? 4u :
+            0u;
+        if (queue_bit == 0 ||
+            _event.thread_role == ERHIThreadRole::Completion ||
+            _event.target_retirement_serial == 0 ||
+            _event.completion_group_count == 0) {
+            capture.invalid.store(true, std::memory_order_release);
+        }
+        capture.queue_mask.fetch_or(
+            queue_bit, std::memory_order_acq_rel
+        );
+        capture.count.fetch_add(1, std::memory_order_acq_rel);
+        capture.entered.release();
+    }
+
+    [[nodiscard]] bool WaitForTwo(
+        std::chrono::milliseconds _timeout
+    ) noexcept {
+        return entered.try_acquire_for(_timeout) &&
+               entered.try_acquire_for(_timeout);
+    }
+
+    [[nodiscard]] bool ValidGraphicsComputePair() const noexcept {
+        return !invalid.load(std::memory_order_acquire) &&
+               count.load(std::memory_order_acquire) == 2 &&
+               queue_mask.load(std::memory_order_acquire) == 3u;
+    }
+
+private:
+    std::counting_semaphore<2> entered{0};
+    std::atomic<uint32>        count{0};
+    std::atomic<uint32>        queue_mask{0};
+    std::atomic<bool>          invalid{false};
+};
+
+class ScopedQueueLocalSyncWaitObserver final {
+public:
+    explicit ScopedQueueLocalSyncWaitObserver(
+        QueueLocalSyncWaitCapture& _capture
+    ) :
+        observer{
+            .context  = &_capture,
+            .callback = &QueueLocalSyncWaitCapture::Observe,
+        } {
+        if (!TryInstallVulkanQueueLocalSyncWaitObserver(
+                &observer
+            )) {
+            throw std::runtime_error(
+                "Vulkan queue-local Sync observer was already installed"
+            );
+        }
+        installed = true;
+    }
+
+    ~ScopedQueueLocalSyncWaitObserver() noexcept {
+        if (installed &&
+            !RemoveVulkanQueueLocalSyncWaitObserver(&observer)) {
+            std::terminate();
+        }
+    }
+
+    ScopedQueueLocalSyncWaitObserver(
+        const ScopedQueueLocalSyncWaitObserver&
+    ) = delete;
+    ScopedQueueLocalSyncWaitObserver& operator=(
+        const ScopedQueueLocalSyncWaitObserver&
+    ) = delete;
+
+private:
+    VulkanQueueLocalSyncWaitObserver observer{};
+    bool                             installed{false};
+};
+
 class BatchPreflightRejectionCapture final {
 public:
     static void Observe(
@@ -1097,6 +1181,7 @@ void ValidateArguments(int _argc, const char** _argv) {
             argument != "--present-hard" &&
             argument != "--rt-export-rejection" &&
             argument != "--timestamp-query" &&
+            argument != "--timestamp-query-success-batch" &&
             argument != "--timestamp-query-mid-failure" &&
             argument != "--timestamp-query-record-failure") {
             throw std::invalid_argument("unsupported argument: " + std::string(argument));
@@ -9272,6 +9357,1023 @@ void RunTimestampQueryCompletionOwnership() {
     );
 }
 
+void RunTimestampQuerySuccessfulBatchPublication() {
+    using namespace std::chrono_literals;
+
+    auto&            device            = RenderDevice::Get();
+    constexpr uint64 async_queue_scope = 0x5048313751534241ull;
+
+    std::array<FenceRef, 2> signals{
+        device.CreateFence(),
+        device.CreateFence(),
+    };
+    std::array<QueryFuture, 2> futures{};
+    std::array<std::atomic<uint32>, 2> query_callbacks{};
+    std::array<std::atomic<uint32>, 2> ordinary_callbacks{};
+    std::array<std::atomic<uint32>, 2> success_callbacks{};
+    std::atomic<uint32>                callback_errors{0};
+
+    CommandList first(EQueueType::Graphics);
+    first.SetResourceStateOwnership(
+        ERHIResourceStateOwnership::Explicit
+    );
+    QueryToken first_query =
+        first.BeginTimestampQuery("Phase17ASuccessBatchFirst");
+    futures[0] = first_query.GetFuture();
+    first.EndTimestampQuery(first_query);
+
+    CommandList second(EQueueType::Graphics);
+    second.SetResourceStateOwnership(
+        ERHIResourceStateOwnership::Explicit
+    );
+    QueryToken second_query =
+        second.BeginTimestampQuery("Phase17ASuccessBatchSecond");
+    futures[1] = second_query.GetFuture();
+    second.EndTimestampQuery(second_query);
+
+    auto signal_succeeded = [&](size_t _index) {
+        auto* fence = static_cast<VulkanFence*>(
+            ResourceCast(signals[_index].Get())
+        );
+        return fence != nullptr && signals[_index]->GetValue() >= 1 &&
+               !fence->IsRejected(1) && !fence->IsFailed();
+    };
+    auto peer_ready = [&](size_t _index) {
+        if (!futures[_index].WaitFor(500ms)) {
+            return false;
+        }
+        const std::optional<QueryResult> result =
+            futures[_index].TryGet();
+        return result.has_value() &&
+               result->status == QueryStatus::Ready &&
+               result->kind == QueryKind::Timestamp;
+    };
+
+    futures[0].Then([&](const QueryResult& _result) {
+        if (GetCurrentRHIThreadRole() != ERHIThreadRole::Completion ||
+            _result.status != QueryStatus::Ready ||
+            !peer_ready(1) ||
+            !signal_succeeded(0) ||
+            !signal_succeeded(1)) {
+            callback_errors.fetch_add(1, std::memory_order_relaxed);
+        }
+        query_callbacks[0].fetch_add(1, std::memory_order_release);
+    });
+    futures[1].Then([&](const QueryResult& _result) {
+        if (GetCurrentRHIThreadRole() != ERHIThreadRole::Completion ||
+            _result.status != QueryStatus::Ready ||
+            !peer_ready(0) ||
+            !signal_succeeded(0) ||
+            !signal_succeeded(1)) {
+            callback_errors.fetch_add(1, std::memory_order_relaxed);
+        }
+        query_callbacks[1].fetch_add(1, std::memory_order_release);
+    });
+
+    first.AddCallback([&] {
+        if (GetCurrentRHIThreadRole() != ERHIThreadRole::Completion ||
+            !peer_ready(1) ||
+            query_callbacks[0].load(std::memory_order_acquire) != 1 ||
+            query_callbacks[1].load(std::memory_order_acquire) != 1) {
+            callback_errors.fetch_add(1, std::memory_order_relaxed);
+        }
+        ordinary_callbacks[0].fetch_add(1, std::memory_order_release);
+    });
+    second.AddCallback([&] {
+        if (GetCurrentRHIThreadRole() != ERHIThreadRole::Completion ||
+            !peer_ready(0) ||
+            query_callbacks[0].load(std::memory_order_acquire) != 1 ||
+            query_callbacks[1].load(std::memory_order_acquire) != 1) {
+            callback_errors.fetch_add(1, std::memory_order_relaxed);
+        }
+        ordinary_callbacks[1].fetch_add(1, std::memory_order_release);
+    });
+    first.AddSuccessCallback([&] {
+        if (GetCurrentRHIThreadRole() != ERHIThreadRole::Completion ||
+            ordinary_callbacks[0].load(std::memory_order_acquire) != 1 ||
+            ordinary_callbacks[1].load(std::memory_order_acquire) != 1) {
+            callback_errors.fetch_add(1, std::memory_order_relaxed);
+        }
+        success_callbacks[0].fetch_add(1, std::memory_order_release);
+    });
+    second.AddSuccessCallback([&] {
+        if (GetCurrentRHIThreadRole() != ERHIThreadRole::Completion ||
+            ordinary_callbacks[0].load(std::memory_order_acquire) != 1 ||
+            ordinary_callbacks[1].load(std::memory_order_acquire) != 1) {
+            callback_errors.fetch_add(1, std::memory_order_relaxed);
+        }
+        success_callbacks[1].fetch_add(1, std::memory_order_release);
+    });
+
+    CmdSubmit first_submit = first.Submit();
+    first_submit.SetTranslateExecutionClass(
+        ERHITranslateExecutionClass::Parallel
+    );
+    first_submit.SetResourceStateOwnership(
+        ERHIResourceStateOwnership::Explicit
+    );
+    first_submit.async_queue_scope = async_queue_scope;
+    first_submit.Signal(signals[0].Get(), 1);
+
+    CmdSubmit second_submit = second.Submit();
+    second_submit.SetTranslateExecutionClass(
+        ERHITranslateExecutionClass::Parallel
+    );
+    second_submit.SetResourceStateOwnership(
+        ERHIResourceStateOwnership::Explicit
+    );
+    second_submit.async_queue_scope = async_queue_scope;
+    second_submit.Signal(signals[1].Get(), 1);
+
+    SourceSubmissionCapture        source_capture(async_queue_scope);
+    ScopedSourceSubmissionObserver source_observer(source_capture);
+    NativeSubmissionCapture        native_capture{};
+    ScopedNativeSubmissionObserver native_observer(native_capture);
+
+    Array<RHIBackendSubmissionBatchEntry> batch{};
+    batch.emplace_back(
+        EQueueType::Graphics, std::move(first_submit)
+    );
+    batch.emplace_back(
+        EQueueType::Graphics, std::move(second_submit)
+    );
+    RHIExecutor::Get().Submit(
+        std::move(batch), ERHIExecSubmitFlags::FlushGPU
+    );
+    RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
+
+    for (size_t index = 0; index < futures.size(); ++index) {
+        const QueryResult result = futures[index].Get();
+        if (result.status != QueryStatus::Ready ||
+            result.kind != QueryKind::Timestamp ||
+            !signal_succeeded(index) ||
+            query_callbacks[index].load(std::memory_order_acquire) != 1 ||
+            ordinary_callbacks[index].load(std::memory_order_acquire) != 1 ||
+            success_callbacks[index].load(std::memory_order_acquire) != 1) {
+            throw std::runtime_error(
+                "successful timestamp batch did not retire exactly once"
+            );
+        }
+    }
+    if (callback_errors.load(std::memory_order_acquire) != 0 ||
+        source_capture.Overflowed() || source_capture.Count() != 2 ||
+        native_capture.Overflowed() || native_capture.Count() != 2) {
+        throw std::runtime_error(
+            "successful timestamp batch exposed a partial terminal frontier"
+        );
+    }
+
+    const uint64 batch_sequence =
+        source_capture.Event(0).batch_sequence;
+    if (batch_sequence == 0) {
+        throw std::runtime_error(
+            "successful timestamp batch lost its backend sequence"
+        );
+    }
+    for (size_t index = 0; index < 2; ++index) {
+        const VulkanSourceSubmissionEvent& source_event =
+            source_capture.Event(index);
+        const VulkanNativeSubmissionEvent& native_event =
+            native_capture.Event(index);
+        if (source_event.batch_sequence != batch_sequence ||
+            source_event.source_index != index ||
+            source_event.queue != EQueueType::Graphics ||
+            source_event.async_queue_scope != async_queue_scope ||
+            native_event.queue != EQueueType::Graphics ||
+            native_event.thread_role != ERHIThreadRole::Submission ||
+            !native_event.outcome.WasSubmitted()) {
+            throw std::runtime_error(
+                "successful timestamp batch escaped stable Submission ordering"
+            );
+        }
+    }
+    if (native_capture.Event(0).native_queue_handle !=
+        native_capture.Event(1).native_queue_handle) {
+        throw std::runtime_error(
+            "successful timestamp batch did not exercise one native queue"
+        );
+    }
+
+    RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
+    for (size_t index = 0; index < futures.size(); ++index) {
+        if (query_callbacks[index].load(std::memory_order_acquire) != 1 ||
+            ordinary_callbacks[index].load(std::memory_order_acquire) != 1 ||
+            success_callbacks[index].load(std::memory_order_acquire) != 1) {
+            throw std::runtime_error(
+                "a second RHI Sync replayed successful batch callbacks"
+            );
+        }
+    }
+
+    LOG_INFO(
+        "[TESTCASE][PASS] "
+        "name=TimestampQuerySuccessfulBatchPublication "
+        "sources=2 queues=Graphics,Graphics batch_sequence={} "
+        "signals=terminal_before_query_callbacks "
+        "queries=batch_published_before_notify "
+        "cross_future_wait=ready owner=Completion "
+        "query_callbacks=exactly_once "
+        "ordinary_callbacks=exactly_once "
+        "success_callbacks=exactly_once "
+        "native_submit=2 native_owner=Submission replay=0",
+        batch_sequence
+    );
+}
+
+void RunTimestampQueryCrossQueueBatchPublication() {
+    using namespace std::chrono_literals;
+
+    auto& device = RenderDevice::Get();
+    const RHIQueueTopology topology = device.GetQueueTopology();
+    if (!topology.graphics.available || !topology.compute.available) {
+        LOG_INFO(
+            "[TESTCASE][SKIP] "
+            "name=TimestampQueryCrossQueueBatchPublication "
+            "reason=queue_unavailable"
+        );
+        return;
+    }
+
+    constexpr uint64 async_queue_scope = 0x504831375143524Full;
+    const bool native_alias =
+        topology.graphics.native_queue_id ==
+        topology.compute.native_queue_id;
+
+    std::array<FenceRef, 2> signals{
+        device.CreateFence(),
+        device.CreateFence(),
+    };
+    std::array<QueryFuture, 2> futures{};
+    std::array<std::atomic<uint32>, 2> query_callbacks{};
+    std::array<std::atomic<uint32>, 2> ordinary_callbacks{};
+    std::array<std::atomic<uint32>, 2> success_callbacks{};
+    std::atomic<uint32> callback_errors{0};
+    std::atomic<uint32> queue_sync_returns{0};
+    std::atomic<uint32> sync_before_callback_finished{0};
+    std::atomic<bool> blocking_callback_finished{false};
+    std::binary_semaphore blocking_callback_entered{0};
+    std::binary_semaphore release_blocking_callback{0};
+    std::counting_semaphore<2> queue_sync_returned{0};
+    QueueLocalSyncWaitCapture queue_sync_wait_capture{};
+    OneShotSemaphoreRelease release_callback_guard(
+        release_blocking_callback
+    );
+
+    auto signal_succeeded = [&](size_t _index) {
+        auto* fence = static_cast<VulkanFence*>(
+            ResourceCast(signals[_index].Get())
+        );
+        return fence != nullptr && signals[_index]->GetValue() >= 1 &&
+               !fence->IsRejected(1) && !fence->IsFailed();
+    };
+    auto peer_ready = [&](size_t _index) {
+        if (!futures[_index].WaitFor(500ms)) {
+            return false;
+        }
+        const std::optional<QueryResult> result =
+            futures[_index].TryGet();
+        return result.has_value() &&
+               result->status == QueryStatus::Ready &&
+               result->kind == QueryKind::Timestamp;
+    };
+
+    CommandList graphics(EQueueType::Graphics);
+    graphics.SetResourceStateOwnership(
+        ERHIResourceStateOwnership::Explicit
+    );
+    QueryToken graphics_query =
+        graphics.BeginTimestampQuery("Phase17ACrossQueueGraphics");
+    futures[0] = graphics_query.GetFuture();
+    graphics.EndTimestampQuery(graphics_query);
+
+    CommandList compute(EQueueType::Compute);
+    compute.SetResourceStateOwnership(
+        ERHIResourceStateOwnership::Explicit
+    );
+    QueryToken compute_query =
+        compute.BeginTimestampQuery("Phase17ACrossQueueCompute");
+    futures[1] = compute_query.GetFuture();
+    compute.EndTimestampQuery(compute_query);
+
+    futures[0].Then([&](const QueryResult& _result) {
+        if (GetCurrentRHIThreadRole() !=
+                ERHIThreadRole::Completion ||
+            _result.status != QueryStatus::Ready ||
+            !peer_ready(1) ||
+            !signal_succeeded(0) ||
+            !signal_succeeded(1)) {
+            callback_errors.fetch_add(
+                1, std::memory_order_relaxed
+            );
+        }
+        query_callbacks[0].fetch_add(
+            1, std::memory_order_release
+        );
+    });
+    futures[1].Then([&](const QueryResult& _result) {
+        if (GetCurrentRHIThreadRole() !=
+                ERHIThreadRole::Completion ||
+            _result.status != QueryStatus::Ready ||
+            !peer_ready(0) ||
+            !signal_succeeded(0) ||
+            !signal_succeeded(1)) {
+            callback_errors.fetch_add(
+                1, std::memory_order_relaxed
+            );
+        }
+        query_callbacks[1].fetch_add(
+            1, std::memory_order_release
+        );
+    });
+
+    graphics.AddCallback([&] {
+        if (GetCurrentRHIThreadRole() !=
+                ERHIThreadRole::Completion ||
+            query_callbacks[0].load(
+                std::memory_order_acquire
+            ) != 1 ||
+            query_callbacks[1].load(
+                std::memory_order_acquire
+            ) != 1) {
+            callback_errors.fetch_add(
+                1, std::memory_order_relaxed
+            );
+        }
+        blocking_callback_entered.release();
+        release_blocking_callback.acquire();
+        ordinary_callbacks[0].fetch_add(
+            1, std::memory_order_release
+        );
+        blocking_callback_finished.store(
+            true, std::memory_order_release
+        );
+    });
+    compute.AddCallback([&] {
+        if (GetCurrentRHIThreadRole() !=
+                ERHIThreadRole::Completion ||
+            query_callbacks[0].load(
+                std::memory_order_acquire
+            ) != 1 ||
+            query_callbacks[1].load(
+                std::memory_order_acquire
+            ) != 1) {
+            callback_errors.fetch_add(
+                1, std::memory_order_relaxed
+            );
+        }
+        ordinary_callbacks[1].fetch_add(
+            1, std::memory_order_release
+        );
+    });
+    graphics.AddSuccessCallback([&] {
+        if (ordinary_callbacks[0].load(
+                std::memory_order_acquire
+            ) != 1 ||
+            ordinary_callbacks[1].load(
+                std::memory_order_acquire
+            ) != 1) {
+            callback_errors.fetch_add(
+                1, std::memory_order_relaxed
+            );
+        }
+        success_callbacks[0].fetch_add(
+            1, std::memory_order_release
+        );
+    });
+    compute.AddSuccessCallback([&] {
+        if (ordinary_callbacks[0].load(
+                std::memory_order_acquire
+            ) != 1 ||
+            ordinary_callbacks[1].load(
+                std::memory_order_acquire
+            ) != 1) {
+            callback_errors.fetch_add(
+                1, std::memory_order_relaxed
+            );
+        }
+        success_callbacks[1].fetch_add(
+            1, std::memory_order_release
+        );
+    });
+
+    CmdSubmit graphics_submit = graphics.Submit();
+    graphics_submit.SetTranslateExecutionClass(
+        ERHITranslateExecutionClass::Parallel
+    );
+    graphics_submit.SetResourceStateOwnership(
+        ERHIResourceStateOwnership::Explicit
+    );
+    graphics_submit.async_queue_scope = async_queue_scope;
+    graphics_submit.Signal(signals[0].Get(), 1);
+
+    CmdSubmit compute_submit = compute.Submit();
+    compute_submit.SetTranslateExecutionClass(
+        ERHITranslateExecutionClass::Parallel
+    );
+    compute_submit.SetResourceStateOwnership(
+        ERHIResourceStateOwnership::Explicit
+    );
+    compute_submit.async_queue_scope = async_queue_scope;
+    compute_submit.Signal(signals[1].Get(), 1);
+
+    SourceSubmissionCapture        source_capture(async_queue_scope);
+    ScopedSourceSubmissionObserver source_observer(source_capture);
+    NativeSubmissionCapture        native_capture{};
+    ScopedNativeSubmissionObserver native_observer(native_capture);
+
+    Array<RHIBackendSubmissionBatchEntry> batch{};
+    batch.emplace_back(
+        EQueueType::Graphics, std::move(graphics_submit)
+    );
+    batch.emplace_back(
+        EQueueType::Compute, std::move(compute_submit)
+    );
+    RHIExecutor::Get().Submit(
+        std::move(batch), ERHIExecSubmitFlags::FlushGPU
+    );
+
+    if (!blocking_callback_entered.try_acquire_for(5s)) {
+        throw std::runtime_error(
+            "cross-queue timestamp batch did not enter its grouped callback"
+        );
+    }
+
+    auto queue_sync = [&](EQueueType _queue) {
+        device.GetCommandQueue(_queue).Sync();
+        if (!blocking_callback_finished.load(
+                std::memory_order_acquire
+            )) {
+            sync_before_callback_finished.fetch_add(
+                1, std::memory_order_relaxed
+            );
+        }
+        queue_sync_returns.fetch_add(
+            1, std::memory_order_release
+        );
+        queue_sync_returned.release();
+    };
+
+    bool both_sync_waits_entered = false;
+    bool sync_returned_before_release = false;
+    size_t observed_sync_returns = 0;
+    {
+        ScopedQueueLocalSyncWaitObserver queue_sync_wait_observer(
+            queue_sync_wait_capture
+        );
+        std::jthread graphics_sync_thread(
+            [&] { queue_sync(EQueueType::Graphics); }
+        );
+        std::jthread compute_sync_thread(
+            [&] { queue_sync(EQueueType::Compute); }
+        );
+
+        // The observer fires only after CompleteAll has captured the target
+        // retirement serial and the associated Completion group. This closes
+        // the scheduler gap between starting the helper and actually entering
+        // the wait contract.
+        both_sync_waits_entered =
+            queue_sync_wait_capture.WaitForTwo(5s);
+        if (both_sync_waits_entered &&
+            queue_sync_returned.try_acquire_for(200ms)) {
+            sync_returned_before_release = true;
+            observed_sync_returns = 1;
+        }
+
+        release_callback_guard.Release();
+        while (observed_sync_returns < 2 &&
+               queue_sync_returned.try_acquire_for(5s)) {
+            ++observed_sync_returns;
+        }
+        graphics_sync_thread.join();
+        compute_sync_thread.join();
+    }
+    RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
+
+    for (size_t index = 0; index < futures.size(); ++index) {
+        const QueryResult result = futures[index].Get();
+        if (result.status != QueryStatus::Ready ||
+            result.kind != QueryKind::Timestamp ||
+            !signal_succeeded(index) ||
+            query_callbacks[index].load(
+                std::memory_order_acquire
+            ) != 1 ||
+            ordinary_callbacks[index].load(
+                std::memory_order_acquire
+            ) != 1 ||
+            success_callbacks[index].load(
+                std::memory_order_acquire
+            ) != 1) {
+            throw std::runtime_error(
+                "cross-queue timestamp batch did not retire exactly once"
+            );
+        }
+    }
+    if (!both_sync_waits_entered ||
+        !queue_sync_wait_capture.ValidGraphicsComputePair() ||
+        sync_returned_before_release ||
+        observed_sync_returns != 2 ||
+        queue_sync_returns.load(std::memory_order_acquire) != 2 ||
+        sync_before_callback_finished.load(
+            std::memory_order_acquire
+        ) != 0 ||
+        callback_errors.load(std::memory_order_acquire) != 0 ||
+        source_capture.Overflowed() ||
+        source_capture.Count() != 2 ||
+        native_capture.Overflowed() ||
+        native_capture.Count() != 2) {
+        throw std::runtime_error(
+            "queue-local Sync escaped the cross-queue completion group"
+        );
+    }
+
+    constexpr std::array expected_queues{
+        EQueueType::Graphics,
+        EQueueType::Compute,
+    };
+    const uint64 batch_sequence =
+        source_capture.Event(0).batch_sequence;
+    for (size_t index = 0; index < expected_queues.size(); ++index) {
+        const VulkanSourceSubmissionEvent& source_event =
+            source_capture.Event(index);
+        const VulkanNativeSubmissionEvent& native_event =
+            native_capture.Event(index);
+        if (batch_sequence == 0 ||
+            source_event.batch_sequence != batch_sequence ||
+            source_event.source_index != index ||
+            source_event.queue != expected_queues[index] ||
+            source_event.async_queue_scope != async_queue_scope ||
+            native_event.queue != expected_queues[index] ||
+            native_event.thread_role != ERHIThreadRole::Submission ||
+            !native_event.outcome.WasSubmitted()) {
+            throw std::runtime_error(
+                "cross-queue timestamp batch lost stable submission ownership"
+            );
+        }
+    }
+    if ((native_capture.Event(0).native_queue_handle ==
+         native_capture.Event(1).native_queue_handle) != native_alias) {
+        throw std::runtime_error(
+            "cross-queue timestamp batch disagreed with queue topology"
+        );
+    }
+
+    RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
+    for (size_t index = 0; index < futures.size(); ++index) {
+        if (query_callbacks[index].load(
+                std::memory_order_acquire
+            ) != 1 ||
+            ordinary_callbacks[index].load(
+                std::memory_order_acquire
+            ) != 1 ||
+            success_callbacks[index].load(
+                std::memory_order_acquire
+            ) != 1) {
+            throw std::runtime_error(
+                "a second Sync replayed cross-queue batch callbacks"
+            );
+        }
+    }
+
+    LOG_INFO(
+        "[TESTCASE][PASS] "
+        "name=TimestampQueryCrossQueueBatchPublication "
+        "sources=2 queues=Graphics,Compute native_alias={} "
+        "queries=batch_published_before_notify "
+        "cross_future_wait=ready owner=Completion "
+        "queue_local_sync=blocked_until_group_settled "
+        "callbacks=exactly_once replay=0",
+        native_alias
+    );
+}
+
+void RunTimestampQueryMixedMultiSegmentCallbackTiers() {
+    auto& device = RenderDevice::Get();
+    constexpr uint64 async_queue_scope = 0x50483137514D4958ull;
+
+    std::array<FenceRef, 2> signals{
+        device.CreateFence(),
+        device.CreateFence(),
+    };
+    std::binary_semaphore first_translated{0};
+    std::binary_semaphore second_translated{0};
+    std::atomic<uint32> phase{0};
+    std::atomic<uint32> callback_errors{0};
+    std::atomic<uint32> query_callbacks{0};
+    std::array<std::atomic<uint32>, 2> ordinary_callbacks{};
+    std::array<std::atomic<uint32>, 2> success_callbacks{};
+
+    auto signal_succeeded = [&](size_t _index) {
+        auto* fence = static_cast<VulkanFence*>(
+            ResourceCast(signals[_index].Get())
+        );
+        return fence != nullptr && signals[_index]->GetValue() >= 1 &&
+               !fence->IsRejected(1) && !fence->IsFailed();
+    };
+    auto advance_phase = [&](uint32 _expected) {
+        if (phase.fetch_add(1, std::memory_order_acq_rel) !=
+            _expected) {
+            callback_errors.fetch_add(
+                1, std::memory_order_relaxed
+            );
+        }
+    };
+
+    CommandList multi_segment(EQueueType::Graphics);
+    multi_segment.SetResourceStateOwnership(
+        ERHIResourceStateOwnership::Explicit
+    );
+    multi_segment.AddCustomCommand(
+        MakeUnique<TranslateProbeCommand>(
+            &first_translated, EQueueType::Graphics
+        ),
+        "Phase17AMixedTierFirstSegment"
+    );
+    multi_segment.AddCustomCommand(
+        MakeUnique<TranslateProbeCommand>(
+            &second_translated, EQueueType::Graphics
+        ),
+        "Phase17AMixedTierSecondSegment"
+    );
+    multi_segment.AddCallback([&] {
+        if (GetCurrentRHIThreadRole() !=
+            ERHIThreadRole::Completion) {
+            callback_errors.fetch_add(
+                1, std::memory_order_relaxed
+            );
+        }
+        advance_phase(1);
+        ordinary_callbacks[0].fetch_add(
+            1, std::memory_order_release
+        );
+    });
+    multi_segment.AddSuccessCallback([&] {
+        advance_phase(3);
+        success_callbacks[0].fetch_add(
+            1, std::memory_order_release
+        );
+    });
+
+    CommandList query_source(EQueueType::Graphics);
+    query_source.SetResourceStateOwnership(
+        ERHIResourceStateOwnership::Explicit
+    );
+    QueryToken query =
+        query_source.BeginTimestampQuery("Phase17AMixedTierQuery");
+    QueryFuture future = query.GetFuture();
+    query_source.EndTimestampQuery(query);
+    future.Then([&](const QueryResult& _result) {
+        if (GetCurrentRHIThreadRole() !=
+                ERHIThreadRole::Completion ||
+            _result.status != QueryStatus::Ready ||
+            !signal_succeeded(0) ||
+            !signal_succeeded(1)) {
+            callback_errors.fetch_add(
+                1, std::memory_order_relaxed
+            );
+        }
+        advance_phase(0);
+        query_callbacks.fetch_add(
+            1, std::memory_order_release
+        );
+    });
+    query_source.AddCallback([&] {
+        if (GetCurrentRHIThreadRole() !=
+                ERHIThreadRole::Completion ||
+            query_callbacks.load(
+                std::memory_order_acquire
+            ) != 1) {
+            callback_errors.fetch_add(
+                1, std::memory_order_relaxed
+            );
+        }
+        advance_phase(2);
+        ordinary_callbacks[1].fetch_add(
+            1, std::memory_order_release
+        );
+    });
+    query_source.AddSuccessCallback([&] {
+        advance_phase(4);
+        success_callbacks[1].fetch_add(
+            1, std::memory_order_release
+        );
+    });
+
+    CmdSubmit multi_submit = multi_segment.Submit();
+    multi_submit.SetTranslateExecutionClass(
+        ERHITranslateExecutionClass::Parallel
+    );
+    multi_submit.SetResourceStateOwnership(
+        ERHIResourceStateOwnership::Explicit
+    );
+    multi_submit.async_queue_scope = async_queue_scope;
+    multi_submit.segments = {
+        RHISubmitSegment{EQueueType::Graphics, 0, 1},
+        RHISubmitSegment{EQueueType::Graphics, 1, 2},
+    };
+    multi_submit.Signal(signals[0].Get(), 1);
+
+    CmdSubmit query_submit = query_source.Submit();
+    query_submit.SetTranslateExecutionClass(
+        ERHITranslateExecutionClass::Parallel
+    );
+    query_submit.SetResourceStateOwnership(
+        ERHIResourceStateOwnership::Explicit
+    );
+    query_submit.async_queue_scope = async_queue_scope;
+    query_submit.Signal(signals[1].Get(), 1);
+
+    SourceSubmissionCapture        source_capture(async_queue_scope);
+    ScopedSourceSubmissionObserver source_observer(source_capture);
+    NativeSubmissionCapture        native_capture{};
+    ScopedNativeSubmissionObserver native_observer(native_capture);
+
+    Array<RHIBackendSubmissionBatchEntry> batch{};
+    batch.emplace_back(
+        EQueueType::Graphics, std::move(multi_submit)
+    );
+    batch.emplace_back(
+        EQueueType::Graphics, std::move(query_submit)
+    );
+    RHIExecutor::Get().Submit(
+        std::move(batch), ERHIExecSubmitFlags::FlushGPU
+    );
+    RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
+
+    const QueryResult result = future.Get();
+    if (result.status != QueryStatus::Ready ||
+        result.kind != QueryKind::Timestamp ||
+        phase.load(std::memory_order_acquire) != 5 ||
+        callback_errors.load(std::memory_order_acquire) != 0 ||
+        query_callbacks.load(std::memory_order_acquire) != 1 ||
+        ordinary_callbacks[0].load(
+            std::memory_order_acquire
+        ) != 1 ||
+        ordinary_callbacks[1].load(
+            std::memory_order_acquire
+        ) != 1 ||
+        success_callbacks[0].load(
+            std::memory_order_acquire
+        ) != 1 ||
+        success_callbacks[1].load(
+            std::memory_order_acquire
+        ) != 1 ||
+        !signal_succeeded(0) ||
+        !signal_succeeded(1) ||
+        !first_translated.try_acquire() ||
+        !second_translated.try_acquire() ||
+        source_capture.Overflowed() ||
+        source_capture.Count() != 3 ||
+        native_capture.Overflowed() ||
+        native_capture.Count() != 3) {
+        throw std::runtime_error(
+            "mixed multi-segment timestamp batch violated callback tiers"
+        );
+    }
+
+    constexpr std::array expected_segment_indices{
+        uint32{0}, uint32{1}, uint32{0}
+    };
+    constexpr std::array expected_segment_counts{
+        uint32{2}, uint32{2}, uint32{1}
+    };
+    constexpr std::array expected_original_sources{
+        uint32{0}, uint32{0}, uint32{1}
+    };
+    const uint64 batch_sequence =
+        source_capture.Event(0).batch_sequence;
+    for (size_t index = 0; index < 3; ++index) {
+        const VulkanSourceSubmissionEvent& source_event =
+            source_capture.Event(index);
+        if (batch_sequence == 0 ||
+            source_event.batch_sequence != batch_sequence ||
+            source_event.source_index != index ||
+            source_event.original_source_index !=
+                expected_original_sources[index] ||
+            source_event.source_segment_index !=
+                expected_segment_indices[index] ||
+            source_event.source_segment_count !=
+                expected_segment_counts[index] ||
+            source_event.queue != EQueueType::Graphics ||
+            source_event.async_queue_scope != async_queue_scope ||
+            native_capture.Event(index).queue !=
+                EQueueType::Graphics ||
+            native_capture.Event(index).thread_role !=
+                ERHIThreadRole::Submission ||
+            !native_capture.Event(index).outcome.WasSubmitted()) {
+            throw std::runtime_error(
+                "mixed timestamp batch lost materialized source identity"
+            );
+        }
+    }
+
+    RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
+    if (phase.load(std::memory_order_acquire) != 5 ||
+        query_callbacks.load(std::memory_order_acquire) != 1 ||
+        ordinary_callbacks[0].load(
+            std::memory_order_acquire
+        ) != 1 ||
+        ordinary_callbacks[1].load(
+            std::memory_order_acquire
+        ) != 1 ||
+        success_callbacks[0].load(
+            std::memory_order_acquire
+        ) != 1 ||
+        success_callbacks[1].load(
+            std::memory_order_acquire
+        ) != 1) {
+        throw std::runtime_error(
+            "a second Sync replayed mixed topology callbacks"
+        );
+    }
+
+    LOG_INFO(
+        "[TESTCASE][PASS] "
+        "name=TimestampQueryMixedMultiSegmentCallbackTiers "
+        "original_sources=2 executable_sources=3 "
+        "source0_segments=2 source1_query=true "
+        "order=Query,AllOrdinary,AllSuccess "
+        "owner=Completion callbacks=exactly_once replay=0"
+    );
+}
+
+void RunTimestampQueryCopyOnlyPayloadArrival() {
+    auto& device = RenderDevice::Get();
+    constexpr uint64 async_queue_scope = 0x5048313751434F50ull;
+
+    QueryFuture graphics_future{};
+    QueryFuture copy_future{};
+    std::array<std::atomic<uint32>, 2> query_callbacks{};
+    std::atomic<uint32> callback_errors{0};
+    FenceRef graphics_done = device.CreateFence();
+
+    CommandList graphics(EQueueType::Graphics);
+    graphics.SetResourceStateOwnership(
+        ERHIResourceStateOwnership::Explicit
+    );
+    QueryToken graphics_query =
+        graphics.BeginTimestampQuery("Phase17ACopyOnlyPeer");
+    graphics_future = graphics_query.GetFuture();
+    graphics.EndTimestampQuery(graphics_query);
+
+    // The public Copy API resolves timestamp capability as an immediate
+    // Error. Build the backend-internal query-only payload from a valid token
+    // and strip its native commands to exercise the executable-source
+    // contract that batch admission and rejection paths may still construct.
+    CommandList copy_payload_builder(EQueueType::Graphics);
+    QueryToken copy_query =
+        copy_payload_builder.BeginTimestampQuery(
+            "Phase17ACopyOnlyPayload"
+        );
+    copy_future = copy_query.GetFuture();
+    copy_payload_builder.EndTimestampQuery(copy_query);
+    CmdSubmit copy_submit = copy_payload_builder.Submit();
+    copy_submit.cmds.clear();
+    copy_submit.callbacks.clear();
+    copy_submit.success_callbacks.clear();
+    copy_submit.cached_args.clear();
+    copy_submit.segments.clear();
+    copy_submit.wait_events.clear();
+    copy_submit.signal_events.clear();
+    copy_submit.SetTranslateExecutionClass(
+        ERHITranslateExecutionClass::Parallel
+    );
+    copy_submit.SetResourceStateOwnership(
+        ERHIResourceStateOwnership::Explicit
+    );
+    copy_submit.async_queue_scope = async_queue_scope;
+
+    auto graphics_signal_succeeded = [&] {
+        auto* fence = static_cast<VulkanFence*>(
+            ResourceCast(graphics_done.Get())
+        );
+        return fence != nullptr && graphics_done->GetValue() >= 1 &&
+               !fence->IsRejected(1) && !fence->IsFailed();
+    };
+    graphics_future.Then([&](const QueryResult& _result) {
+        const std::optional<QueryResult> copy_result =
+            copy_future.TryGet();
+        if (GetCurrentRHIThreadRole() !=
+                ERHIThreadRole::Completion ||
+            _result.status != QueryStatus::Ready ||
+            !copy_result.has_value() ||
+            copy_result->status != QueryStatus::Error ||
+            copy_result->error_reason.empty() ||
+            !graphics_signal_succeeded()) {
+            callback_errors.fetch_add(
+                1, std::memory_order_relaxed
+            );
+        }
+        query_callbacks[0].fetch_add(
+            1, std::memory_order_release
+        );
+    });
+    copy_future.Then([&](const QueryResult& _result) {
+        const std::optional<QueryResult> graphics_result =
+            graphics_future.TryGet();
+        if (GetCurrentRHIThreadRole() !=
+                ERHIThreadRole::Completion ||
+            _result.status != QueryStatus::Error ||
+            _result.error_reason.empty() ||
+            !graphics_result.has_value() ||
+            graphics_result->status != QueryStatus::Ready ||
+            !graphics_signal_succeeded()) {
+            callback_errors.fetch_add(
+                1, std::memory_order_relaxed
+            );
+        }
+        query_callbacks[1].fetch_add(
+            1, std::memory_order_release
+        );
+    });
+
+    CmdSubmit graphics_submit = graphics.Submit();
+    graphics_submit.SetTranslateExecutionClass(
+        ERHITranslateExecutionClass::Parallel
+    );
+    graphics_submit.SetResourceStateOwnership(
+        ERHIResourceStateOwnership::Explicit
+    );
+    graphics_submit.async_queue_scope = async_queue_scope;
+    graphics_submit.Signal(graphics_done.Get(), 1);
+
+    SourceSubmissionCapture        source_capture(async_queue_scope);
+    ScopedSourceSubmissionObserver source_observer(source_capture);
+    NativeSubmissionCapture        native_capture{};
+    ScopedNativeSubmissionObserver native_observer(native_capture);
+
+    Array<RHIBackendSubmissionBatchEntry> batch{};
+    batch.emplace_back(
+        EQueueType::Graphics, std::move(graphics_submit)
+    );
+    batch.emplace_back(EQueueType::Copy, std::move(copy_submit));
+    RHIExecutor::Get().Submit(
+        std::move(batch), ERHIExecSubmitFlags::FlushGPU
+    );
+    RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
+
+    const QueryResult graphics_result = graphics_future.Get();
+    const QueryResult copy_result = copy_future.Get();
+    if (graphics_result.status != QueryStatus::Ready ||
+        copy_result.status != QueryStatus::Error ||
+        copy_result.error_reason.empty() ||
+        query_callbacks[0].load(std::memory_order_acquire) != 1 ||
+        query_callbacks[1].load(std::memory_order_acquire) != 1 ||
+        callback_errors.load(std::memory_order_acquire) != 0 ||
+        !graphics_signal_succeeded() ||
+        source_capture.Overflowed() ||
+        source_capture.Count() != 2 ||
+        native_capture.Overflowed() ||
+        native_capture.Count() != 2) {
+        throw std::runtime_error(
+            "query-only Copy payload did not arrive at Completion group"
+        );
+    }
+
+    constexpr std::array expected_queues{
+        EQueueType::Graphics,
+        EQueueType::Copy,
+    };
+    const uint64 batch_sequence =
+        source_capture.Event(0).batch_sequence;
+    for (size_t index = 0; index < expected_queues.size(); ++index) {
+        const VulkanSourceSubmissionEvent& source_event =
+            source_capture.Event(index);
+        const VulkanNativeSubmissionEvent& native_event =
+            native_capture.Event(index);
+        if (batch_sequence == 0 ||
+            source_event.batch_sequence != batch_sequence ||
+            source_event.source_index != index ||
+            source_event.queue != expected_queues[index] ||
+            source_event.async_queue_scope != async_queue_scope ||
+            native_event.queue != expected_queues[index] ||
+            native_event.thread_role != ERHIThreadRole::Submission ||
+            !native_event.outcome.WasSubmitted()) {
+            throw std::runtime_error(
+                "query-only Copy payload lost stable source ownership"
+            );
+        }
+    }
+
+    RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
+    if (query_callbacks[0].load(std::memory_order_acquire) != 1 ||
+        query_callbacks[1].load(std::memory_order_acquire) != 1 ||
+        source_capture.Count() != 2 ||
+        native_capture.Count() != 2) {
+        throw std::runtime_error(
+            "a second Sync replayed query-only Copy retirement"
+        );
+    }
+
+    LOG_INFO(
+        "[TESTCASE][PASS] "
+        "name=TimestampQueryCopyOnlyPayloadArrival "
+        "sources=2 queues=Graphics,Copy "
+        "copy_payload=query_only copy_query=Error "
+        "group_arrival=verified owner=Completion "
+        "callbacks=exactly_once native_submit=2 replay=0"
+    );
+}
+
 void RunTimestampQueryPreparationRejection() {
     constexpr uint64 async_queue_scope = 0x5048313751505245ull;
 
@@ -9674,6 +10776,10 @@ void RunTimestampQueryMidBatchTranslateFailure() {
     FenceRef suffix_done = device.CreateFence();
     std::binary_semaphore suffix_translate_entered{0};
     std::binary_semaphore release_suffix_translate{0};
+    std::binary_semaphore prefix_query_callback_entered{0};
+    OneShotSemaphoreRelease release_suffix_guard(
+        release_suffix_translate
+    );
     std::atomic<uint32>   prefix_query_callbacks{0};
     std::atomic<uint32>   suffix_query_callbacks{0};
     std::atomic<uint32>   prefix_ordinary_callbacks{0};
@@ -9748,13 +10854,12 @@ void RunTimestampQueryMidBatchTranslateFailure() {
     suffix_submit.async_queue_scope = async_queue_scope;
     suffix_submit.Signal(suffix_done.Get(), 1);
 
-    // The suffix Translate cannot fail until this prefix Query callback is
-    // executing on the same native queue's Completion owner. Before the
-    // rejection publication fix, suffix Error was only published by the
-    // Completion packet queued behind this callback, so WaitFor necessarily
-    // timed out.
+    // A successful-batch notification barrier deliberately prevents an
+    // earlier callback from driving a later source's Translate. The test
+    // thread releases the blocked suffix only after proving that no callback
+    // escaped before every executable source reached a terminal packet.
     prefix_future.Then([&](const QueryResult& _result) {
-        release_suffix_translate.release();
+        prefix_query_callback_entered.release();
         const bool suffix_terminal = suffix_future.WaitFor(500ms);
         const std::optional<QueryResult> suffix_result =
             suffix_future.TryGet();
@@ -9789,14 +10894,45 @@ void RunTimestampQueryMidBatchTranslateFailure() {
     RHIExecutor::Get().Submit(
         std::move(batch), ERHIExecSubmitFlags::FlushGPU
     );
+    if (!suffix_translate_entered.try_acquire_for(5s)) {
+        throw std::runtime_error(
+            "mid-batch timestamp suffix Translate did not enter"
+        );
+    }
+    if (!prefix_future.WaitFor(5s)) {
+        throw std::runtime_error(
+            "mid-batch timestamp prefix did not publish before suffix release"
+        );
+    }
+    const std::optional<QueryResult> published_prefix =
+        prefix_future.TryGet();
+    if (!published_prefix.has_value() ||
+        published_prefix->status != QueryStatus::Ready) {
+        throw std::runtime_error(
+            "mid-batch timestamp prefix was not Ready before suffix failure"
+        );
+    }
+    const bool prefix_callback_entered_before_terminal =
+        prefix_query_callback_entered.try_acquire_for(100ms);
+    if (prefix_callback_entered_before_terminal) {
+        callback_errors.fetch_add(1, std::memory_order_relaxed);
+    }
+    if (prefix_query_callbacks.load(std::memory_order_acquire) != 0 ||
+        suffix_query_callbacks.load(std::memory_order_acquire) != 0 ||
+        prefix_ordinary_callbacks.load(std::memory_order_acquire) != 0 ||
+        suffix_ordinary_callbacks.load(std::memory_order_acquire) != 0) {
+        throw std::runtime_error(
+            "mid-batch timestamp callback escaped before suffix terminalization"
+        );
+    }
+    release_suffix_guard.Release();
     RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
 
     const QueryResult prefix_result = prefix_future.Get();
     const QueryResult suffix_result = suffix_future.Get();
     auto* suffix_fence =
         static_cast<VulkanFence*>(ResourceCast(suffix_done.Get()));
-    if (!suffix_translate_entered.try_acquire() ||
-        prefix_result.status != QueryStatus::Ready ||
+    if (prefix_result.status != QueryStatus::Ready ||
         suffix_result.status != QueryStatus::Error ||
         suffix_result.error_reason.empty() ||
         prefix_query_callbacks.load(std::memory_order_acquire) != 1 ||
@@ -9805,6 +10941,8 @@ void RunTimestampQueryMidBatchTranslateFailure() {
         suffix_ordinary_callbacks.load(std::memory_order_acquire) != 1 ||
         prefix_success_callbacks.load(std::memory_order_acquire) != 1 ||
         suffix_success_callbacks.load(std::memory_order_acquire) != 0 ||
+        (!prefix_callback_entered_before_terminal &&
+         !prefix_query_callback_entered.try_acquire()) ||
         callback_errors.load(std::memory_order_acquire) != 0 ||
         suffix_fence == nullptr ||
         (!suffix_fence->IsRejected(1) && !suffix_fence->IsFailed()) ||
@@ -9839,8 +10977,10 @@ void RunTimestampQueryMidBatchTranslateFailure() {
     LOG_INFO(
         "[TESTCASE][PASS] name=TimestampQueryMidBatchTranslateFailure "
         "queues=Graphics,Graphics native_prefix_submit=1 "
-        "suffix_translate=blocked-until-prefix-callback suffix_status=Error "
-        "publish_before_enqueue=true bounded_cross_future_wait=true "
+        "suffix_translate=main-thread-released suffix_status=Error "
+        "pre_terminal_callback_entry=0 "
+        "batch_terminal_before_notify=true "
+        "bounded_cross_future_wait=true "
         "owner=Completion callbacks=exactly_once replay=0"
     );
 }
@@ -10162,6 +11302,10 @@ int main(int argc, const char** argv) {
             HasArgument(argc, argv, "--rt-export-rejection");
         const bool timestamp_query_mode =
             HasArgument(argc, argv, "--timestamp-query");
+        const bool timestamp_query_success_batch_mode =
+            HasArgument(
+                argc, argv, "--timestamp-query-success-batch"
+            );
         const bool timestamp_query_mid_failure_mode =
             HasArgument(argc, argv, "--timestamp-query-mid-failure");
         const bool timestamp_query_record_failure_mode =
@@ -10185,12 +11329,14 @@ int main(int argc, const char** argv) {
             .parallel_recording =
                 parallel || pipeline_window_mode || present_mode ||
                 timestamp_query_mode ||
+                timestamp_query_success_batch_mode ||
                 timestamp_query_mid_failure_mode ||
                 timestamp_query_record_failure_mode,
             .parallel_record_workers = 4,
             .parallel_record_verify =
                 parallel || pipeline_window_mode || present_mode ||
                 timestamp_query_mode ||
+                timestamp_query_success_batch_mode ||
                 timestamp_query_mid_failure_mode ||
                 timestamp_query_record_failure_mode,
             .parallel_record_min_work_units_per_job = production_gate ? 64u : 1u,
@@ -10199,6 +11345,17 @@ int main(int argc, const char** argv) {
         });
         render_device_initialized = true;
 
+        if (timestamp_query_success_batch_mode) {
+            RunTimestampQuerySuccessfulBatchPublication();
+            RunTimestampQueryCrossQueueBatchPublication();
+            RunTimestampQueryMixedMultiSegmentCallbackTiers();
+            RunTimestampQueryCopyOnlyPayloadArrival();
+            RenderDevice::Dispose();
+            render_device_initialized = false;
+            TaskSystem::ShutDown();
+            task_system_initialized = false;
+            return 0;
+        }
         if (timestamp_query_record_failure_mode) {
             RunTimestampQuerySerialRecordFailure();
             RenderDevice::Dispose();
@@ -10217,6 +11374,10 @@ int main(int argc, const char** argv) {
         }
         if (timestamp_query_mode) {
             RunTimestampQueryCompletionOwnership();
+            RunTimestampQuerySuccessfulBatchPublication();
+            RunTimestampQueryCrossQueueBatchPublication();
+            RunTimestampQueryMixedMultiSegmentCallbackTiers();
+            RunTimestampQueryCopyOnlyPayloadArrival();
             RunTimestampQueryPreparationRejection();
             // This malformed-batch rejection hard-latches the runtime, so the
             // mid-batch Translate failure has its own focused invocation.

--- a/source/test/RHIParallelRecordVulkanTest.cpp
+++ b/source/test/RHIParallelRecordVulkanTest.cpp
@@ -881,7 +881,9 @@ void ValidateArguments(int _argc, const char** _argv) {
             argument != "--pipeline-window2" &&
             argument != "--present-boundary" &&
             argument != "--present-hard" &&
-            argument != "--rt-export-rejection") {
+            argument != "--rt-export-rejection" &&
+            argument != "--timestamp-query" &&
+            argument != "--timestamp-query-mid-failure") {
             throw std::invalid_argument("unsupported argument: " + std::string(argument));
         }
     }
@@ -8788,6 +8790,532 @@ void PrimeGlobalTransientPoolForDispose() {
     }
 }
 
+void RunTimestampQueryCompletionOwnership() {
+    auto& device = RenderDevice::Get();
+    const EBufferUsageFlags usage =
+        EBufferUsageFlags::TRANSFER_SRC | EBufferUsageFlags::TRANSFER_DST;
+
+    BufferRef source = device.CreateBuffer<uint32>(
+        "timestamp_query_source", kElementCount, usage
+    );
+    BufferRef destination = device.CreateBuffer<uint32>(
+        "timestamp_query_destination", kElementCount, usage
+    );
+
+    std::array<uint32, kElementCount> values{};
+    std::array<uint32, kElementCount> readback{};
+    for (uint32 index = 0; index < values.size(); ++index) {
+        values[index] = 0x170A0000u + index * 29u;
+    }
+
+    std::atomic<uint32> callback_count{0};
+    std::atomic<uint32> callback_errors{0};
+    FenceRef            query_done = device.CreateFence();
+
+    CommandList commands(EQueueType::Graphics);
+    commands.CopyFrom(
+        OwnedBytes(values),
+        source->GetView(),
+        "TimestampQueryInitialize"
+    );
+
+    QueryToken  query  = commands.BeginTimestampQuery("Phase17ATimestamp");
+    QueryFuture future = query.GetFuture();
+    future.Then([&](const QueryResult& _result) {
+        if (GetCurrentRHIThreadRole() != ERHIThreadRole::Completion ||
+            _result.status != QueryStatus::Ready ||
+            _result.kind != QueryKind::Timestamp ||
+            std::get_if<TimestampQueryResult>(&_result.payload) == nullptr ||
+            query_done.Get()->GetValue() < 1 ||
+            query_done.Get()->IsRejected(1) ||
+            ResourceCast(query_done.Get())->IsFailed()) {
+            callback_errors.fetch_add(1, std::memory_order_relaxed);
+        }
+        callback_count.fetch_add(1, std::memory_order_release);
+    });
+
+    for (uint32 copy = 0; copy < 64; ++copy) {
+        if ((copy & 1u) == 0) {
+            commands.CopyFrom(
+                source->GetView(),
+                destination->GetView(),
+                "TimestampQueryForwardCopy"
+            );
+        } else {
+            commands.CopyFrom(
+                destination->GetView(),
+                source->GetView(),
+                "TimestampQueryReverseCopy"
+            );
+        }
+    }
+    commands.EndTimestampQuery(query);
+    commands.CopyFrom(
+        destination->GetView(),
+        WritableBytes(readback),
+        "TimestampQueryReadback"
+    );
+
+    CmdSubmit first_submit = commands.Submit();
+    first_submit.Signal(query_done.Get(), 1);
+    RHIExecutor::Get().Submit(
+        EQueueType::Graphics,
+        std::move(first_submit),
+        ERHIExecSubmitFlags::FlushGPU
+    );
+    RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
+
+    const QueryResult result = future.Get();
+    const auto* timestamp = std::get_if<TimestampQueryResult>(&result.payload);
+    if (result.status != QueryStatus::Ready ||
+        result.kind != QueryKind::Timestamp ||
+        timestamp == nullptr ||
+        timestamp->valid_bits == 0 ||
+        timestamp->valid_bits > 64 ||
+        timestamp->tick_period_ns <= 0.0 ||
+        timestamp->duration_ns < 0.0) {
+        throw std::runtime_error(
+            "Vulkan timestamp query did not produce a valid Ready payload"
+        );
+    }
+    if (callback_count.load(std::memory_order_acquire) != 1 ||
+        callback_errors.load(std::memory_order_acquire) != 0) {
+        throw std::runtime_error(
+            "Vulkan timestamp query callback escaped Completion ownership"
+        );
+    }
+    if (readback != values) {
+        throw std::runtime_error(
+            "Vulkan timestamp query workload readback mismatch"
+        );
+    }
+
+    // A second submission after full Completion is expected to reuse a pooled
+    // allocator. Its timestamp cursor must have returned to slot zero and the
+    // recycled pool slots must be reset before the new writes.
+    std::array<uint32, kElementCount> reused_readback{};
+    std::atomic<uint32>               reused_callback_count{0};
+    std::atomic<uint32>               reused_callback_errors{0};
+
+    CommandList reused_commands(EQueueType::Graphics);
+    QueryToken reused_query =
+        reused_commands.BeginTimestampQuery("Phase17ATimestampAllocatorReuse");
+    QueryFuture reused_future = reused_query.GetFuture();
+    reused_future.Then([&](const QueryResult& _result) {
+        if (GetCurrentRHIThreadRole() != ERHIThreadRole::Completion ||
+            _result.status != QueryStatus::Ready ||
+            _result.kind != QueryKind::Timestamp ||
+            std::get_if<TimestampQueryResult>(&_result.payload) == nullptr) {
+            reused_callback_errors.fetch_add(1, std::memory_order_relaxed);
+        }
+        reused_callback_count.fetch_add(1, std::memory_order_release);
+    });
+    for (uint32 copy = 0; copy < 8; ++copy) {
+        if ((copy & 1u) == 0) {
+            reused_commands.CopyFrom(
+                source->GetView(),
+                destination->GetView(),
+                "TimestampQueryReuseForwardCopy"
+            );
+        } else {
+            reused_commands.CopyFrom(
+                destination->GetView(),
+                source->GetView(),
+                "TimestampQueryReuseReverseCopy"
+            );
+        }
+    }
+    reused_commands.EndTimestampQuery(reused_query);
+    reused_commands.CopyFrom(
+        destination->GetView(),
+        WritableBytes(reused_readback),
+        "TimestampQueryReuseReadback"
+    );
+    RHIExecutor::Get().Submit(
+        EQueueType::Graphics,
+        reused_commands.Submit(),
+        ERHIExecSubmitFlags::FlushGPU
+    );
+    RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
+
+    const QueryResult reused_result = reused_future.Get();
+    const auto* reused_timestamp =
+        std::get_if<TimestampQueryResult>(&reused_result.payload);
+    if (reused_result.status != QueryStatus::Ready ||
+        reused_result.kind != QueryKind::Timestamp ||
+        reused_timestamp == nullptr ||
+        reused_timestamp->valid_bits == 0 ||
+        reused_timestamp->valid_bits > 64 ||
+        reused_timestamp->tick_period_ns <= 0.0 ||
+        reused_timestamp->duration_ns < 0.0 ||
+        reused_callback_count.load(std::memory_order_acquire) != 1 ||
+        reused_callback_errors.load(std::memory_order_acquire) != 0 ||
+        reused_readback != values) {
+        throw std::runtime_error(
+            "recycled Vulkan timestamp query allocator did not reset and reuse safely"
+        );
+    }
+
+    std::atomic<uint32> late_callback_count{0};
+    future.Then([&](const QueryResult& _result) {
+        if (_result.status == QueryStatus::Ready) {
+            late_callback_count.fetch_add(1, std::memory_order_release);
+        }
+    });
+    if (late_callback_count.load(std::memory_order_acquire) != 1) {
+        throw std::runtime_error(
+            "terminal Vulkan timestamp query did not invoke a late callback"
+        );
+    }
+
+    RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
+    if (callback_count.load(std::memory_order_acquire) != 1 ||
+        reused_callback_count.load(std::memory_order_acquire) != 1 ||
+        late_callback_count.load(std::memory_order_acquire) != 1) {
+        throw std::runtime_error(
+            "a second RHI Sync replayed Vulkan timestamp query callbacks"
+        );
+    }
+
+    LOG_INFO(
+        "[TESTCASE][PASS] name=TimestampQueryCompletionOwnership "
+        "status=Ready owner=Completion signal_terminal_before_callback=true "
+        "allocator_slot_reuse=verified valid_bits={} duration_ns={} "
+        "reused_duration_ns={} readback=verified replay=0",
+        timestamp->valid_bits,
+        timestamp->duration_ns,
+        reused_timestamp->duration_ns
+    );
+}
+
+void RunTimestampQueryPreflightRejection() {
+    using namespace std::chrono_literals;
+
+    constexpr uint64 async_queue_scope = 0x5048313751554552ull;
+
+    std::array<std::atomic<uint32>, 2> ordinary_callbacks{};
+    std::array<std::atomic<uint32>, 2> query_callbacks{};
+    std::array<std::atomic<uint32>, 2> callback_errors{};
+    std::array<std::atomic<uint32>, 2> success_callbacks{};
+    QueryFuture                         future{};
+    QueryFuture                         sibling_future{};
+
+    CommandList commands(EQueueType::Graphics);
+    // This callback intentionally precedes the Query fallback in recording
+    // order. Preflight rejection must terminalize every Future before any
+    // ordinary callback, so observing the result here can never self-block.
+    commands.AddCallback([&] {
+        const std::optional<QueryResult> result = future.TryGet();
+        if (!result.has_value() ||
+            result->status != QueryStatus::Error ||
+            GetCurrentRHIThreadRole() != ERHIThreadRole::Completion) {
+            callback_errors[0].fetch_add(1, std::memory_order_relaxed);
+        }
+        ordinary_callbacks[0].fetch_add(1, std::memory_order_release);
+    });
+
+    QueryToken query = commands.BeginTimestampQuery(
+        "Phase17ARejectedMultiSegmentTimestamp"
+    );
+    future = query.GetFuture();
+    future.Then([&](const QueryResult& _result) {
+        const bool sibling_terminal = sibling_future.WaitFor(250ms);
+        const std::optional<QueryResult> sibling_result =
+            sibling_future.TryGet();
+        if (_result.status != QueryStatus::Error ||
+            GetCurrentRHIThreadRole() != ERHIThreadRole::Completion ||
+            !sibling_terminal ||
+            !sibling_result.has_value() ||
+            sibling_result->status != QueryStatus::Error) {
+            callback_errors[0].fetch_add(1, std::memory_order_relaxed);
+        }
+        query_callbacks[0].fetch_add(1, std::memory_order_release);
+    });
+    commands.EndTimestampQuery(query);
+    commands.AddSuccessCallback([&] {
+        success_callbacks[0].fetch_add(1, std::memory_order_relaxed);
+    });
+
+    CmdSubmit submit = commands.Submit();
+    submit.SetResourceStateOwnership(ERHIResourceStateOwnership::Explicit);
+    submit.SetTranslateExecutionClass(ERHITranslateExecutionClass::Parallel);
+    submit.async_queue_scope = async_queue_scope;
+    submit.segments = {
+        RHISubmitSegment{EQueueType::Graphics, 0, 1},
+        RHISubmitSegment{EQueueType::Graphics, 1, 2},
+    };
+
+    // The sibling is valid in isolation. The malformed multi-segment query in
+    // source zero rejects the whole native-runtime batch, so both query states
+    // must be published before either source is allowed to notify callbacks.
+    CommandList sibling_commands(EQueueType::Graphics);
+    QueryToken sibling_query = sibling_commands.BeginTimestampQuery(
+        "Phase17ARejectedBatchSiblingTimestamp"
+    );
+    sibling_future = sibling_query.GetFuture();
+    sibling_future.Then([&](const QueryResult& _result) {
+        if (_result.status != QueryStatus::Error ||
+            GetCurrentRHIThreadRole() != ERHIThreadRole::Completion) {
+            callback_errors[1].fetch_add(1, std::memory_order_relaxed);
+        }
+        query_callbacks[1].fetch_add(1, std::memory_order_release);
+    });
+    sibling_commands.EndTimestampQuery(sibling_query);
+    sibling_commands.AddCallback([&] {
+        const std::optional<QueryResult> first_result = future.TryGet();
+        const std::optional<QueryResult> second_result =
+            sibling_future.TryGet();
+        if (!first_result.has_value() ||
+            first_result->status != QueryStatus::Error ||
+            !second_result.has_value() ||
+            second_result->status != QueryStatus::Error ||
+            GetCurrentRHIThreadRole() != ERHIThreadRole::Completion) {
+            callback_errors[1].fetch_add(1, std::memory_order_relaxed);
+        }
+        ordinary_callbacks[1].fetch_add(1, std::memory_order_release);
+    });
+    sibling_commands.AddSuccessCallback([&] {
+        success_callbacks[1].fetch_add(1, std::memory_order_relaxed);
+    });
+
+    Array<RHIBackendSubmissionBatchEntry> rejected_batch{};
+    rejected_batch.emplace_back(EQueueType::Graphics, std::move(submit));
+    rejected_batch.emplace_back(
+        EQueueType::Graphics,
+        sibling_commands.Submit()
+    );
+    NativeSubmissionCapture        native_capture{};
+    ScopedNativeSubmissionObserver native_observer(native_capture);
+    RHIExecutor::Get().Submit(
+        std::move(rejected_batch),
+        ERHIExecSubmitFlags::FlushGPU
+    );
+    RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
+
+    const QueryResult result = future.Get();
+    const QueryResult sibling_result = sibling_future.Get();
+    if (result.status != QueryStatus::Error ||
+        sibling_result.status != QueryStatus::Error ||
+        result.error_reason.empty() ||
+        sibling_result.error_reason.empty() ||
+        ordinary_callbacks[0].load(std::memory_order_acquire) != 1 ||
+        ordinary_callbacks[1].load(std::memory_order_acquire) != 1 ||
+        query_callbacks[0].load(std::memory_order_acquire) != 1 ||
+        query_callbacks[1].load(std::memory_order_acquire) != 1 ||
+        callback_errors[0].load(std::memory_order_acquire) != 0 ||
+        callback_errors[1].load(std::memory_order_acquire) != 0 ||
+        success_callbacks[0].load(std::memory_order_acquire) != 0 ||
+        success_callbacks[1].load(std::memory_order_acquire) != 0 ||
+        native_capture.Overflowed() ||
+        native_capture.Count() != 0) {
+        throw std::runtime_error(
+            "Vulkan query preflight rejection violated terminal ordering"
+        );
+    }
+
+    RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
+    if (ordinary_callbacks[0].load(std::memory_order_acquire) != 1 ||
+        ordinary_callbacks[1].load(std::memory_order_acquire) != 1 ||
+        query_callbacks[0].load(std::memory_order_acquire) != 1 ||
+        query_callbacks[1].load(std::memory_order_acquire) != 1 ||
+        success_callbacks[0].load(std::memory_order_acquire) != 0 ||
+        success_callbacks[1].load(std::memory_order_acquire) != 0 ||
+        native_capture.Count() != 0) {
+        throw std::runtime_error(
+            "a second RHI Sync replayed rejected timestamp query callbacks"
+        );
+    }
+
+    LOG_INFO(
+        "[TESTCASE][PASS] name=TimestampQueryPreflightRejection "
+        "reason=multi-segment-query sources=2 status=Error owner=Completion "
+        "batch_terminal_before_notify=true bounded_cross_future_wait=true "
+        "ordinary_callback=exactly_once query_callback=exactly_once "
+        "success_callback=0 native_submit=0 replay=0"
+    );
+}
+
+void RunTimestampQueryMidBatchTranslateFailure() {
+    using namespace std::chrono_literals;
+
+    auto&            device            = RenderDevice::Get();
+    constexpr uint64 async_queue_scope = 0x50483137514D4944ull;
+
+    FenceRef prefix_done = device.CreateFence();
+    FenceRef suffix_done = device.CreateFence();
+    std::binary_semaphore suffix_translate_entered{0};
+    std::binary_semaphore release_suffix_translate{0};
+    std::atomic<uint32>   prefix_query_callbacks{0};
+    std::atomic<uint32>   suffix_query_callbacks{0};
+    std::atomic<uint32>   prefix_ordinary_callbacks{0};
+    std::atomic<uint32>   suffix_ordinary_callbacks{0};
+    std::atomic<uint32>   prefix_success_callbacks{0};
+    std::atomic<uint32>   suffix_success_callbacks{0};
+    std::atomic<uint32>   callback_errors{0};
+
+    CommandList prefix(EQueueType::Graphics);
+    prefix.SetResourceStateOwnership(
+        ERHIResourceStateOwnership::Explicit
+    );
+    QueryToken prefix_query =
+        prefix.BeginTimestampQuery("Phase17AMidBatchPrefixTimestamp");
+    QueryFuture prefix_future = prefix_query.GetFuture();
+    prefix.EndTimestampQuery(prefix_query);
+    prefix.AddCallback([&] {
+        if (GetCurrentRHIThreadRole() != ERHIThreadRole::Completion) {
+            callback_errors.fetch_add(1, std::memory_order_relaxed);
+        }
+        prefix_ordinary_callbacks.fetch_add(1, std::memory_order_release);
+    });
+    prefix.AddSuccessCallback([&] {
+        prefix_success_callbacks.fetch_add(1, std::memory_order_release);
+    });
+    CmdSubmit prefix_submit = prefix.Submit();
+    prefix_submit.SetTranslateExecutionClass(
+        ERHITranslateExecutionClass::Parallel
+    );
+    prefix_submit.SetResourceStateOwnership(
+        ERHIResourceStateOwnership::Explicit
+    );
+    prefix_submit.async_queue_scope = async_queue_scope;
+    prefix_submit.Signal(prefix_done.Get(), 1);
+
+    CommandList suffix(EQueueType::Graphics);
+    suffix.SetResourceStateOwnership(
+        ERHIResourceStateOwnership::Explicit
+    );
+    QueryToken suffix_query =
+        suffix.BeginTimestampQuery("Phase17AMidBatchFailingTimestamp");
+    QueryFuture suffix_future = suffix_query.GetFuture();
+    suffix.AddCustomCommand(
+        MakeUnique<BlockingTranslateProbeCommand>(
+            EQueueType::Graphics,
+            &suffix_translate_entered,
+            &release_suffix_translate
+        ),
+        "Phase17AMidBatchBlockedSuffixTranslate"
+    );
+    suffix.AddCustomCommand(
+        MakeUnique<ThrowingTranslateProbeCommand>(true),
+        "Phase17AMidBatchThrowingSuffixTranslate"
+    );
+    suffix.EndTimestampQuery(suffix_query);
+    suffix.AddCallback([&] {
+        if (GetCurrentRHIThreadRole() != ERHIThreadRole::Completion) {
+            callback_errors.fetch_add(1, std::memory_order_relaxed);
+        }
+        suffix_ordinary_callbacks.fetch_add(1, std::memory_order_release);
+    });
+    suffix.AddSuccessCallback([&] {
+        suffix_success_callbacks.fetch_add(1, std::memory_order_release);
+    });
+    CmdSubmit suffix_submit = suffix.Submit();
+    suffix_submit.SetTranslateExecutionClass(
+        ERHITranslateExecutionClass::Parallel
+    );
+    suffix_submit.SetResourceStateOwnership(
+        ERHIResourceStateOwnership::Explicit
+    );
+    suffix_submit.async_queue_scope = async_queue_scope;
+    suffix_submit.Signal(suffix_done.Get(), 1);
+
+    // The suffix Translate cannot fail until this prefix Query callback is
+    // executing on the same native queue's Completion owner. Before the
+    // rejection publication fix, suffix Error was only published by the
+    // Completion packet queued behind this callback, so WaitFor necessarily
+    // timed out.
+    prefix_future.Then([&](const QueryResult& _result) {
+        release_suffix_translate.release();
+        const bool suffix_terminal = suffix_future.WaitFor(500ms);
+        const std::optional<QueryResult> suffix_result =
+            suffix_future.TryGet();
+        auto* prefix_fence =
+            static_cast<VulkanFence*>(ResourceCast(prefix_done.Get()));
+        if (_result.status != QueryStatus::Ready ||
+            GetCurrentRHIThreadRole() != ERHIThreadRole::Completion ||
+            prefix_fence == nullptr ||
+            prefix_done->GetValue() < 1 ||
+            prefix_fence->IsRejected(1) ||
+            prefix_fence->IsFailed() ||
+            !suffix_terminal ||
+            !suffix_result.has_value() ||
+            suffix_result->status != QueryStatus::Error) {
+            callback_errors.fetch_add(1, std::memory_order_relaxed);
+        }
+        prefix_query_callbacks.fetch_add(1, std::memory_order_release);
+    });
+    suffix_future.Then([&](const QueryResult& _result) {
+        if (_result.status != QueryStatus::Error ||
+            GetCurrentRHIThreadRole() != ERHIThreadRole::Completion) {
+            callback_errors.fetch_add(1, std::memory_order_relaxed);
+        }
+        suffix_query_callbacks.fetch_add(1, std::memory_order_release);
+    });
+
+    NativeSubmissionCapture        native_capture{};
+    ScopedNativeSubmissionObserver native_observer(native_capture);
+    Array<RHIBackendSubmissionBatchEntry> batch{};
+    batch.emplace_back(EQueueType::Graphics, std::move(prefix_submit));
+    batch.emplace_back(EQueueType::Graphics, std::move(suffix_submit));
+    RHIExecutor::Get().Submit(
+        std::move(batch), ERHIExecSubmitFlags::FlushGPU
+    );
+    RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
+
+    const QueryResult prefix_result = prefix_future.Get();
+    const QueryResult suffix_result = suffix_future.Get();
+    auto* suffix_fence =
+        static_cast<VulkanFence*>(ResourceCast(suffix_done.Get()));
+    if (!suffix_translate_entered.try_acquire() ||
+        prefix_result.status != QueryStatus::Ready ||
+        suffix_result.status != QueryStatus::Error ||
+        suffix_result.error_reason.empty() ||
+        prefix_query_callbacks.load(std::memory_order_acquire) != 1 ||
+        suffix_query_callbacks.load(std::memory_order_acquire) != 1 ||
+        prefix_ordinary_callbacks.load(std::memory_order_acquire) != 1 ||
+        suffix_ordinary_callbacks.load(std::memory_order_acquire) != 1 ||
+        prefix_success_callbacks.load(std::memory_order_acquire) != 1 ||
+        suffix_success_callbacks.load(std::memory_order_acquire) != 0 ||
+        callback_errors.load(std::memory_order_acquire) != 0 ||
+        suffix_fence == nullptr ||
+        (!suffix_fence->IsRejected(1) && !suffix_fence->IsFailed()) ||
+        native_capture.Overflowed() ||
+        native_capture.Count() != 1) {
+        throw std::runtime_error(
+            "mid-batch timestamp Query rejection was not published before same-queue Completion notification"
+        );
+    }
+
+    const VulkanNativeSubmissionEvent& native_event =
+        native_capture.Event(0);
+    if (native_event.queue != EQueueType::Graphics ||
+        native_event.thread_role != ERHIThreadRole::Submission ||
+        !native_event.outcome.WasSubmitted()) {
+        throw std::runtime_error(
+            "mid-batch timestamp Query test did not submit exactly its prefix source"
+        );
+    }
+
+    RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
+    if (prefix_query_callbacks.load(std::memory_order_acquire) != 1 ||
+        suffix_query_callbacks.load(std::memory_order_acquire) != 1 ||
+        prefix_ordinary_callbacks.load(std::memory_order_acquire) != 1 ||
+        suffix_ordinary_callbacks.load(std::memory_order_acquire) != 1 ||
+        native_capture.Count() != 1) {
+        throw std::runtime_error(
+            "mid-batch timestamp Query failure replayed Completion callbacks"
+        );
+    }
+
+    LOG_INFO(
+        "[TESTCASE][PASS] name=TimestampQueryMidBatchTranslateFailure "
+        "queues=Graphics,Graphics native_prefix_submit=1 "
+        "suffix_translate=blocked-until-prefix-callback suffix_status=Error "
+        "publish_before_enqueue=true bounded_cross_future_wait=true "
+        "owner=Completion callbacks=exactly_once replay=0"
+    );
+}
+
 } // namespace
 
 int main(int argc, const char** argv) {
@@ -8819,6 +9347,10 @@ int main(int argc, const char** argv) {
             present_boundary || present_hard;
         const bool rt_export_rejection =
             HasArgument(argc, argv, "--rt-export-rejection");
+        const bool timestamp_query_mode =
+            HasArgument(argc, argv, "--timestamp-query");
+        const bool timestamp_query_mid_failure_mode =
+            HasArgument(argc, argv, "--timestamp-query-mid-failure");
         const uint32 submission_batch_window =
             pipeline_window1 ? 1u : 2u;
 
@@ -8834,15 +9366,37 @@ int main(int argc, const char** argv) {
             .rhi_thread       = true,
             .rhi_bypass       = false,
             .parallel_recording =
-                parallel || pipeline_window_mode || present_mode,
+                parallel || pipeline_window_mode || present_mode ||
+                timestamp_query_mode || timestamp_query_mid_failure_mode,
             .parallel_record_workers = 4,
             .parallel_record_verify =
-                parallel || pipeline_window_mode || present_mode,
+                parallel || pipeline_window_mode || present_mode ||
+                timestamp_query_mode || timestamp_query_mid_failure_mode,
             .parallel_record_min_work_units_per_job = production_gate ? 64u : 1u,
             .submission_batch_window = submission_batch_window,
             .parallel_record_worker_throw_trigger = inject_worker_failure ? 1u : 0u,
         });
         render_device_initialized = true;
+
+        if (timestamp_query_mid_failure_mode) {
+            RunTimestampQueryMidBatchTranslateFailure();
+            RenderDevice::Dispose();
+            render_device_initialized = false;
+            TaskSystem::ShutDown();
+            task_system_initialized = false;
+            return 0;
+        }
+        if (timestamp_query_mode) {
+            RunTimestampQueryCompletionOwnership();
+            // This malformed-batch rejection hard-latches the runtime, so the
+            // mid-batch Translate failure has its own focused invocation.
+            RunTimestampQueryPreflightRejection();
+            RenderDevice::Dispose();
+            render_device_initialized = false;
+            TaskSystem::ShutDown();
+            task_system_initialized = false;
+            return 0;
+        }
 
         if (present_mode) {
             if (present_boundary) {

--- a/source/test/RHIParallelRecordVulkanTest.cpp
+++ b/source/test/RHIParallelRecordVulkanTest.cpp
@@ -432,6 +432,145 @@ private:
     bool                            installed{false};
 };
 
+class SerialQueryRecordFailureTranslationGate final {
+public:
+    explicit SerialQueryRecordFailureTranslationGate(
+        uint64 _async_queue_scope
+    ) :
+        async_queue_scope(_async_queue_scope),
+        observer{
+            .context  = this,
+            .callback =
+                &SerialQueryRecordFailureTranslationGate::Observe,
+        } {
+        if (!TryInstallVulkanSourceTranslationObserver(
+                &observer
+            )) {
+            throw std::runtime_error(
+                "Vulkan source translation observer was already installed"
+            );
+        }
+        installed = true;
+    }
+
+    ~SerialQueryRecordFailureTranslationGate() noexcept {
+        ReleaseTerminalPhase();
+        if (installed &&
+            !RemoveVulkanSourceTranslationObserver(&observer)) {
+            std::terminate();
+        }
+    }
+
+    SerialQueryRecordFailureTranslationGate(
+        const SerialQueryRecordFailureTranslationGate&
+    ) = delete;
+    SerialQueryRecordFailureTranslationGate& operator=(
+        const SerialQueryRecordFailureTranslationGate&
+    ) = delete;
+
+    void NotifyFailureCallbackEntryChecked() noexcept {
+        const uint32 entry =
+            callback_entries_checked.fetch_add(
+                1, std::memory_order_acq_rel
+            ) +
+            1;
+        if (entry == 1) {
+            early_failure_callback_entered.release();
+        }
+    }
+
+    [[nodiscard]] bool WaitForTerminalPhase(
+        std::chrono::milliseconds _timeout
+    ) noexcept {
+        return terminal_phase_entered.try_acquire_for(_timeout);
+    }
+
+    [[nodiscard]] bool FailureCallbackEnteredBeforeRelease(
+        std::chrono::milliseconds _timeout
+    ) noexcept {
+        return early_failure_callback_entered.try_acquire_for(
+            _timeout
+        );
+    }
+
+    void ReleaseTerminalPhase() noexcept {
+        if (!terminal_phase_release_sent.exchange(
+                true, std::memory_order_acq_rel
+            )) {
+            terminal_phase_release.release();
+        }
+    }
+
+    [[nodiscard]] uint32 FailurePhaseCount() const noexcept {
+        return failure_phase_count.load(std::memory_order_acquire);
+    }
+
+    [[nodiscard]] uint32 RecordedPhaseCount() const noexcept {
+        return recorded_phase_count.load(std::memory_order_acquire);
+    }
+
+    [[nodiscard]] uint32 CheckedCallbackEntryCount() const noexcept {
+        return callback_entries_checked.load(std::memory_order_acquire);
+    }
+
+    [[nodiscard]] bool TimedOut() const noexcept {
+        return timed_out.load(std::memory_order_acquire);
+    }
+
+private:
+    static void Observe(
+        void*                               _context,
+        const VulkanSourceTranslationEvent& _event
+    ) noexcept {
+        using namespace std::chrono_literals;
+
+        auto& gate =
+            *static_cast<
+                SerialQueryRecordFailureTranslationGate*>(_context);
+        if (_event.async_queue_scope != gate.async_queue_scope ||
+            _event.source_index != 0) {
+            return;
+        }
+        if (_event.phase ==
+            EVulkanSourceTranslationPhase::Failed) {
+            gate.failure_phase_count.fetch_add(
+                1, std::memory_order_acq_rel
+            );
+        } else if (
+            _event.phase ==
+            EVulkanSourceTranslationPhase::Recorded) {
+            gate.recorded_phase_count.fetch_add(
+                1, std::memory_order_acq_rel
+            );
+        } else {
+            return;
+        }
+
+        // TranslateForRuntime has returned, but Submission has not yet
+        // consumed that result. The terminal-packet path therefore cannot
+        // have enqueued Completion yet. The regressed path enqueued the
+        // current source directly before reporting Failed; while this gate is
+        // held, its callback can deterministically expose a still-Pending
+        // sibling.
+        gate.terminal_phase_entered.release();
+        if (!gate.terminal_phase_release.try_acquire_for(2s)) {
+            gate.timed_out.store(true, std::memory_order_release);
+        }
+    }
+
+    uint64 async_queue_scope{0};
+    VulkanSourceTranslationObserver observer{};
+    std::binary_semaphore           terminal_phase_entered{0};
+    std::binary_semaphore           terminal_phase_release{0};
+    std::binary_semaphore           early_failure_callback_entered{0};
+    std::atomic<uint32>             failure_phase_count{0};
+    std::atomic<uint32>             recorded_phase_count{0};
+    std::atomic<uint32>             callback_entries_checked{0};
+    std::atomic<bool>               timed_out{false};
+    std::atomic<bool>               terminal_phase_release_sent{false};
+    bool                            installed{false};
+};
+
 class NativeSubmissionCapture final {
 public:
     static void Observe(
@@ -652,6 +791,81 @@ public:
 private:
     VulkanScriptedPresentOverrideForTesting scripted_override{};
     bool                                    installed{false};
+};
+
+class ScriptedQueryPreparationCapture final {
+public:
+    static VkResult Observe(
+        void*      _context,
+        EQueueType _queue,
+        uint64     _timeline,
+        uint32     _query_count
+    ) noexcept {
+        auto& capture =
+            *static_cast<ScriptedQueryPreparationCapture*>(_context);
+        if (GetCurrentRHIThreadRole() != ERHIThreadRole::Translate) {
+            capture.wrong_owner.store(true, std::memory_order_relaxed);
+        }
+        const uint32 invocation =
+            capture.count.fetch_add(1, std::memory_order_acq_rel);
+        if (invocation != 0) {
+            return VK_SUCCESS;
+        }
+        capture.queue.store(
+            static_cast<uint32>(_queue), std::memory_order_relaxed
+        );
+        capture.timeline.store(_timeline, std::memory_order_relaxed);
+        capture.query_count.store(_query_count, std::memory_order_relaxed);
+        return VK_ERROR_FEATURE_NOT_PRESENT;
+    }
+
+    std::atomic<uint32> count{0};
+    std::atomic<uint32> queue{
+        static_cast<uint32>(EQueueType::Ignore)
+    };
+    std::atomic<uint64> timeline{0};
+    std::atomic<uint32> query_count{0};
+    std::atomic<bool>   wrong_owner{false};
+};
+
+class ScopedScriptedQueryPreparationOverride final {
+public:
+    explicit ScopedScriptedQueryPreparationOverride(
+        ScriptedQueryPreparationCapture& _capture
+    ) :
+        scripted_override{
+            .context  = &_capture,
+            .callback = &ScriptedQueryPreparationCapture::Observe,
+        } {
+        if (!TryInstallVulkanScriptedQueryPreparationOverrideForTesting(
+                &scripted_override
+            )) {
+            throw std::runtime_error(
+                "Vulkan scripted Query preparation override was already installed"
+            );
+        }
+        installed = true;
+    }
+
+    ~ScopedScriptedQueryPreparationOverride() noexcept {
+        if (installed &&
+            !RemoveVulkanScriptedQueryPreparationOverrideForTesting(
+                &scripted_override
+            )) {
+            std::terminate();
+        }
+    }
+
+    ScopedScriptedQueryPreparationOverride(
+        const ScopedScriptedQueryPreparationOverride&
+    ) = delete;
+    ScopedScriptedQueryPreparationOverride& operator=(
+        const ScopedScriptedQueryPreparationOverride&
+    ) = delete;
+
+private:
+    VulkanScriptedQueryPreparationOverrideForTesting scripted_override{};
+    bool                                             installed{false};
 };
 
 class DependencyWaitCapture final {
@@ -883,7 +1097,8 @@ void ValidateArguments(int _argc, const char** _argv) {
             argument != "--present-hard" &&
             argument != "--rt-export-rejection" &&
             argument != "--timestamp-query" &&
-            argument != "--timestamp-query-mid-failure") {
+            argument != "--timestamp-query-mid-failure" &&
+            argument != "--timestamp-query-record-failure") {
             throw std::invalid_argument("unsupported argument: " + std::string(argument));
         }
     }
@@ -8956,6 +9171,73 @@ void RunTimestampQueryCompletionOwnership() {
         );
     }
 
+    // The original fixed allocator pool held 1000 slots (500 begin/end
+    // pairs). Exercise the first legal packet beyond that boundary. Pool
+    // sizing must happen before native Begin(), and every Future must still
+    // retire Ready without latching the Vulkan runtime.
+    constexpr uint32 large_query_pair_count = 501;
+    CommandList      large_query_commands(EQueueType::Graphics);
+    Array<QueryFuture> large_query_futures{};
+    large_query_futures.reserve(large_query_pair_count);
+    for (uint32 index = 0; index < large_query_pair_count; ++index) {
+        QueryToken token = large_query_commands.BeginTimestampQuery(
+            "Phase17ALargeTimestampPacket"
+        );
+        large_query_futures.emplace_back(token.GetFuture());
+        large_query_commands.EndTimestampQuery(token);
+    }
+
+    FenceRef large_query_done = device.CreateFence();
+    CmdSubmit large_query_submit = large_query_commands.Submit();
+    large_query_submit.Signal(large_query_done.Get(), 1);
+    RHIExecutor::Get().Submit(
+        EQueueType::Graphics,
+        std::move(large_query_submit),
+        ERHIExecSubmitFlags::FlushGPU
+    );
+    RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
+
+    if (!large_query_done.Get()->WaitSubmitted(1) ||
+        large_query_done.Get()->IsRejected(1) ||
+        ResourceCast(large_query_done.Get())->IsFailed()) {
+        throw std::runtime_error(
+            "large Vulkan timestamp packet was rejected at the old pool boundary"
+        );
+    }
+    for (const QueryFuture& large_future : large_query_futures) {
+        const QueryResult large_result = large_future.Get();
+        const auto* large_timestamp =
+            std::get_if<TimestampQueryResult>(&large_result.payload);
+        if (large_result.status != QueryStatus::Ready ||
+            large_result.kind != QueryKind::Timestamp ||
+            large_timestamp == nullptr ||
+            large_timestamp->valid_bits == 0 ||
+            large_timestamp->valid_bits > 64 ||
+            large_timestamp->duration_ns < 0.0) {
+            throw std::runtime_error(
+                "large Vulkan timestamp packet did not resolve every Future"
+            );
+        }
+    }
+
+    FenceRef post_growth_done = device.CreateFence();
+    CommandList post_growth_commands(EQueueType::Graphics);
+    CmdSubmit post_growth_submit = post_growth_commands.Submit();
+    post_growth_submit.Signal(post_growth_done.Get(), 1);
+    RHIExecutor::Get().Submit(
+        EQueueType::Graphics,
+        std::move(post_growth_submit),
+        ERHIExecSubmitFlags::FlushGPU
+    );
+    RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
+    if (!post_growth_done.Get()->WaitSubmitted(1) ||
+        post_growth_done.Get()->IsRejected(1) ||
+        ResourceCast(post_growth_done.Get())->IsFailed()) {
+        throw std::runtime_error(
+            "timestamp pool growth left the Vulkan runtime latched"
+        );
+    }
+
     std::atomic<uint32> late_callback_count{0};
     future.Then([&](const QueryResult& _result) {
         if (_result.status == QueryStatus::Ready) {
@@ -8980,11 +9262,258 @@ void RunTimestampQueryCompletionOwnership() {
     LOG_INFO(
         "[TESTCASE][PASS] name=TimestampQueryCompletionOwnership "
         "status=Ready owner=Completion signal_terminal_before_callback=true "
-        "allocator_slot_reuse=verified valid_bits={} duration_ns={} "
+        "allocator_slot_reuse=verified large_query_pairs={} "
+        "post_growth_submit=accepted valid_bits={} duration_ns={} "
         "reused_duration_ns={} readback=verified replay=0",
+        large_query_pair_count,
         timestamp->valid_bits,
         timestamp->duration_ns,
         reused_timestamp->duration_ns
+    );
+}
+
+void RunTimestampQueryPreparationRejection() {
+    constexpr uint64 async_queue_scope = 0x5048313751505245ull;
+
+    auto& device = RenderDevice::Get();
+
+    FenceRef rejected_done = device.CreateFence();
+    FenceRef sibling_done  = device.CreateFence();
+    FenceRef recovered_done = device.CreateFence();
+    auto* rejected_fence = static_cast<VulkanFence*>(
+        ResourceCast(rejected_done.Get())
+    );
+    auto* sibling_fence = static_cast<VulkanFence*>(
+        ResourceCast(sibling_done.Get())
+    );
+    auto* recovered_fence = static_cast<VulkanFence*>(
+        ResourceCast(recovered_done.Get())
+    );
+    if (rejected_fence == nullptr || sibling_fence == nullptr ||
+        recovered_fence == nullptr) {
+        throw std::runtime_error(
+            "timestamp Query preparation rejection could not access Vulkan fences"
+        );
+    }
+
+    std::array<std::atomic<uint32>, 2> ordinary_callbacks{};
+    std::array<std::atomic<uint32>, 2> query_callbacks{};
+    std::array<std::atomic<uint32>, 2> success_callbacks{};
+    std::atomic<uint32>                callback_errors{0};
+    QueryFuture                        rejected_future{};
+    QueryFuture                        sibling_future{};
+
+    CommandList rejected(EQueueType::Graphics);
+    rejected.SetResourceStateOwnership(
+        ERHIResourceStateOwnership::Explicit
+    );
+    QueryToken rejected_query =
+        rejected.BeginTimestampQuery("Phase17AQueryPrepareRejected");
+    rejected_future = rejected_query.GetFuture();
+    rejected.EndTimestampQuery(rejected_query);
+    rejected.AddCallback([&] {
+        const std::optional<QueryResult> sibling_result =
+            sibling_future.TryGet();
+        if (GetCurrentRHIThreadRole() != ERHIThreadRole::Completion ||
+            !sibling_result.has_value() ||
+            sibling_result->status != QueryStatus::Error ||
+            !sibling_fence->IsRejected(1) ||
+            sibling_fence->IsFailed()) {
+            callback_errors.fetch_add(1, std::memory_order_relaxed);
+        }
+        ordinary_callbacks[0].fetch_add(1, std::memory_order_release);
+    });
+    rejected.AddSuccessCallback([&] {
+        success_callbacks[0].fetch_add(1, std::memory_order_relaxed);
+    });
+    CmdSubmit rejected_submit = rejected.Submit();
+    rejected_submit.SetTranslateExecutionClass(
+        ERHITranslateExecutionClass::Parallel
+    );
+    rejected_submit.SetResourceStateOwnership(
+        ERHIResourceStateOwnership::Explicit
+    );
+    rejected_submit.async_queue_scope = async_queue_scope;
+    rejected_submit.Signal(rejected_done.Get(), 1);
+
+    CommandList sibling(EQueueType::Graphics);
+    sibling.SetResourceStateOwnership(
+        ERHIResourceStateOwnership::Explicit
+    );
+    QueryToken sibling_query =
+        sibling.BeginTimestampQuery("Phase17AQueryPrepareSibling");
+    sibling_future = sibling_query.GetFuture();
+    sibling.EndTimestampQuery(sibling_query);
+    sibling.AddCallback([&] {
+        const std::optional<QueryResult> rejected_result =
+            rejected_future.TryGet();
+        if (GetCurrentRHIThreadRole() != ERHIThreadRole::Completion ||
+            !rejected_result.has_value() ||
+            rejected_result->status != QueryStatus::Error ||
+            !rejected_fence->IsRejected(1) ||
+            rejected_fence->IsFailed()) {
+            callback_errors.fetch_add(1, std::memory_order_relaxed);
+        }
+        ordinary_callbacks[1].fetch_add(1, std::memory_order_release);
+    });
+    sibling.AddSuccessCallback([&] {
+        success_callbacks[1].fetch_add(1, std::memory_order_relaxed);
+    });
+    CmdSubmit sibling_submit = sibling.Submit();
+    sibling_submit.SetTranslateExecutionClass(
+        ERHITranslateExecutionClass::Parallel
+    );
+    sibling_submit.SetResourceStateOwnership(
+        ERHIResourceStateOwnership::Explicit
+    );
+    sibling_submit.async_queue_scope = async_queue_scope;
+    sibling_submit.Signal(sibling_done.Get(), 1);
+
+    rejected_future.Then([&](const QueryResult& _result) {
+        const std::optional<QueryResult> sibling_result =
+            sibling_future.TryGet();
+        if (_result.status != QueryStatus::Error ||
+            GetCurrentRHIThreadRole() != ERHIThreadRole::Completion ||
+            !sibling_result.has_value() ||
+            sibling_result->status != QueryStatus::Error ||
+            !sibling_fence->IsRejected(1) ||
+            sibling_fence->IsFailed()) {
+            callback_errors.fetch_add(1, std::memory_order_relaxed);
+        }
+        query_callbacks[0].fetch_add(1, std::memory_order_release);
+    });
+    sibling_future.Then([&](const QueryResult& _result) {
+        if (_result.status != QueryStatus::Error ||
+            GetCurrentRHIThreadRole() != ERHIThreadRole::Completion) {
+            callback_errors.fetch_add(1, std::memory_order_relaxed);
+        }
+        query_callbacks[1].fetch_add(1, std::memory_order_release);
+    });
+
+    ScriptedQueryPreparationCapture scripted_capture{};
+    NativeSubmissionCapture         native_capture{};
+    ScopedNativeSubmissionObserver  native_observer(native_capture);
+    {
+        ScopedScriptedQueryPreparationOverride scripted_override(
+            scripted_capture
+        );
+        Array<RHIBackendSubmissionBatchEntry> rejected_batch{};
+        rejected_batch.emplace_back(
+            EQueueType::Graphics, std::move(rejected_submit)
+        );
+        rejected_batch.emplace_back(
+            EQueueType::Graphics, std::move(sibling_submit)
+        );
+        RHIExecutor::Get().Submit(
+            std::move(rejected_batch),
+            ERHIExecSubmitFlags::FlushGPU
+        );
+        RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
+    }
+
+    const QueryResult rejected_result = rejected_future.Get();
+    const QueryResult sibling_result  = sibling_future.Get();
+    const uint32 scripted_prepare_count =
+        scripted_capture.count.load(std::memory_order_acquire);
+    if (scripted_prepare_count == 0 || scripted_prepare_count > 2 ||
+        scripted_capture.queue.load(std::memory_order_acquire) !=
+            static_cast<uint32>(EQueueType::Graphics) ||
+        scripted_capture.timeline.load(std::memory_order_acquire) == 0 ||
+        scripted_capture.query_count.load(std::memory_order_acquire) != 2 ||
+        scripted_capture.wrong_owner.load(std::memory_order_acquire) ||
+        rejected_result.status != QueryStatus::Error ||
+        sibling_result.status != QueryStatus::Error ||
+        !rejected_fence->IsRejected(1) ||
+        rejected_fence->IsFailed() ||
+        !sibling_fence->IsRejected(1) ||
+        sibling_fence->IsFailed() ||
+        ordinary_callbacks[0].load(std::memory_order_acquire) != 1 ||
+        ordinary_callbacks[1].load(std::memory_order_acquire) != 1 ||
+        query_callbacks[0].load(std::memory_order_acquire) != 1 ||
+        query_callbacks[1].load(std::memory_order_acquire) != 1 ||
+        success_callbacks[0].load(std::memory_order_acquire) != 0 ||
+        success_callbacks[1].load(std::memory_order_acquire) != 0 ||
+        callback_errors.load(std::memory_order_acquire) != 0 ||
+        native_capture.Overflowed() ||
+        native_capture.Count() != 0) {
+        throw std::runtime_error(
+            "recoverable timestamp Query preparation rejection violated "
+            "pre-Completion suffix publication"
+        );
+    }
+
+    std::atomic<uint32> recovered_callbacks{0};
+    std::atomic<uint32> recovered_success_callbacks{0};
+    CommandList recovered(EQueueType::Graphics);
+    recovered.SetResourceStateOwnership(
+        ERHIResourceStateOwnership::Explicit
+    );
+    recovered.AddCallback([&] {
+        if (GetCurrentRHIThreadRole() != ERHIThreadRole::Completion) {
+            callback_errors.fetch_add(1, std::memory_order_relaxed);
+        }
+        recovered_callbacks.fetch_add(1, std::memory_order_release);
+    });
+    recovered.AddSuccessCallback([&] {
+        recovered_success_callbacks.fetch_add(
+            1, std::memory_order_release
+        );
+    });
+    CmdSubmit recovered_submit = recovered.Submit();
+    recovered_submit.SetTranslateExecutionClass(
+        ERHITranslateExecutionClass::Parallel
+    );
+    recovered_submit.SetResourceStateOwnership(
+        ERHIResourceStateOwnership::Explicit
+    );
+    recovered_submit.async_queue_scope = async_queue_scope;
+    recovered_submit.Signal(recovered_done.Get(), 1);
+    Array<RHIBackendSubmissionBatchEntry> recovered_batch{};
+    recovered_batch.emplace_back(
+        EQueueType::Graphics, std::move(recovered_submit)
+    );
+    RHIExecutor::Get().Submit(
+        std::move(recovered_batch), ERHIExecSubmitFlags::FlushGPU
+    );
+    RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
+
+    if (recovered_done->GetValue() < 1 ||
+        recovered_fence->IsRejected(1) ||
+        recovered_fence->IsFailed() ||
+        recovered_callbacks.load(std::memory_order_acquire) != 1 ||
+        recovered_success_callbacks.load(std::memory_order_acquire) != 1 ||
+        callback_errors.load(std::memory_order_acquire) != 0 ||
+        native_capture.Overflowed() ||
+        native_capture.Count() != 1 ||
+        !native_capture.Event(0).outcome.WasSubmitted() ||
+        native_capture.Event(0).thread_role !=
+            ERHIThreadRole::Submission) {
+        throw std::runtime_error(
+            "timestamp Query preparation rejection hard-latched the runtime"
+        );
+    }
+
+    RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
+    if (ordinary_callbacks[0].load(std::memory_order_acquire) != 1 ||
+        ordinary_callbacks[1].load(std::memory_order_acquire) != 1 ||
+        query_callbacks[0].load(std::memory_order_acquire) != 1 ||
+        query_callbacks[1].load(std::memory_order_acquire) != 1 ||
+        recovered_callbacks.load(std::memory_order_acquire) != 1 ||
+        recovered_success_callbacks.load(std::memory_order_acquire) != 1 ||
+        native_capture.Count() != 1) {
+        throw std::runtime_error(
+            "timestamp Query preparation rejection replayed Completion work"
+        );
+    }
+
+    LOG_INFO(
+        "[TESTCASE][PASS] name=TimestampQueryPreparationRejection "
+        "async_scope={} prepare_calls={} status=Error suffix_query=Error "
+        "publish_before_completion=true signal=rejected-not-failed "
+        "native_rejected_batch=0 recovery_submit=accepted "
+        "owner=Completion callbacks=exactly_once replay=0",
+        async_queue_scope,
+        scripted_prepare_count
     );
 }
 
@@ -9316,6 +9845,290 @@ void RunTimestampQueryMidBatchTranslateFailure() {
     );
 }
 
+void RunTimestampQuerySerialRecordFailure() {
+    auto&            device            = RenderDevice::Get();
+    constexpr uint64 async_queue_scope = 0x5048313751535246ull;
+
+    FenceRef failing_done = device.CreateFence();
+    FenceRef sibling_done = device.CreateFence();
+    QueryFuture failing_future{};
+    QueryFuture sibling_future{};
+    std::array<std::atomic<uint32>, 2> query_callbacks{};
+    std::array<std::atomic<uint32>, 2> ordinary_callbacks{};
+    std::array<std::atomic<uint32>, 2> success_callbacks{};
+    std::atomic<uint32>                callback_errors{0};
+
+    SerialQueryRecordFailureTranslationGate translation_gate(
+        async_queue_scope
+    );
+    SourceSubmissionCapture source_capture(async_queue_scope);
+    ScopedSourceSubmissionObserver source_observer(source_capture);
+    NativeSubmissionCapture        native_capture{};
+    ScopedNativeSubmissionObserver native_observer(native_capture);
+
+    auto fence_failed =
+        [](const FenceRef& _fence) {
+            auto* fence = static_cast<VulkanFence*>(
+                ResourceCast(_fence.Get())
+            );
+            return fence != nullptr && fence->IsFailed() &&
+                   !fence->IsRejected(1);
+        };
+    auto query_failed =
+        [](const QueryFuture& _future) {
+            const std::optional<QueryResult> result =
+                _future.TryGet();
+            return result.has_value() &&
+                   result->status == QueryStatus::Error &&
+                   !result->error_reason.empty();
+        };
+    auto sibling_terminal =
+        [&] {
+            return query_failed(sibling_future) &&
+                   fence_failed(sibling_done);
+        };
+
+    CommandList failing(EQueueType::Graphics);
+    failing.SetResourceStateOwnership(
+        ERHIResourceStateOwnership::Explicit
+    );
+    QueryToken failing_query =
+        failing.BeginTimestampQuery(
+            "Phase17ASerialRecordFailingTimestamp"
+        );
+    failing_future = failing_query.GetFuture();
+    failing_future.Then([&](const QueryResult& _result) {
+        // Take the sibling snapshot before doing any other callback work.
+        // TryGet and the fence predicates are non-blocking: this proves the
+        // entire suffix was already terminal when notification began.
+        const bool sibling_was_terminal = sibling_terminal();
+        const bool completion_owned =
+            GetCurrentRHIThreadRole() ==
+            ERHIThreadRole::Completion;
+        if (!sibling_was_terminal || !completion_owned ||
+            _result.status != QueryStatus::Error ||
+            _result.error_reason.empty()) {
+            callback_errors.fetch_add(
+                1, std::memory_order_relaxed
+            );
+        }
+        query_callbacks[0].fetch_add(
+            1, std::memory_order_release
+        );
+        translation_gate.NotifyFailureCallbackEntryChecked();
+    });
+    failing.AddCustomCommand(
+        MakeUnique<ThrowingTranslateProbeCommand>(true),
+        "Phase17ASerialQueryNativeRecordFailure"
+    );
+    failing.EndTimestampQuery(failing_query);
+    failing.AddCallback([&] {
+        const bool sibling_was_terminal = sibling_terminal();
+        const bool failing_was_terminal =
+            query_failed(failing_future);
+        const bool completion_owned =
+            GetCurrentRHIThreadRole() ==
+            ERHIThreadRole::Completion;
+        if (!sibling_was_terminal || !failing_was_terminal ||
+            !completion_owned) {
+            callback_errors.fetch_add(
+                1, std::memory_order_relaxed
+            );
+        }
+        ordinary_callbacks[0].fetch_add(
+            1, std::memory_order_release
+        );
+        translation_gate.NotifyFailureCallbackEntryChecked();
+    });
+    failing.AddSuccessCallback([&] {
+        success_callbacks[0].fetch_add(
+            1, std::memory_order_release
+        );
+    });
+    CmdSubmit failing_submit = failing.Submit();
+    failing_submit.SetTranslateExecutionClass(
+        ERHITranslateExecutionClass::Parallel
+    );
+    failing_submit.SetResourceStateOwnership(
+        ERHIResourceStateOwnership::Explicit
+    );
+    failing_submit.async_queue_scope = async_queue_scope;
+    failing_submit.Signal(failing_done.Get(), 1);
+
+    CommandList sibling(EQueueType::Graphics);
+    sibling.SetResourceStateOwnership(
+        ERHIResourceStateOwnership::Explicit
+    );
+    QueryToken sibling_query =
+        sibling.BeginTimestampQuery(
+            "Phase17ASerialRecordFailureSiblingTimestamp"
+        );
+    sibling_future = sibling_query.GetFuture();
+    sibling_future.Then([&](const QueryResult& _result) {
+        const bool both_fences_terminal =
+            fence_failed(failing_done) &&
+            fence_failed(sibling_done);
+        if (_result.status != QueryStatus::Error ||
+            _result.error_reason.empty() ||
+            !both_fences_terminal ||
+            GetCurrentRHIThreadRole() !=
+                ERHIThreadRole::Completion) {
+            callback_errors.fetch_add(
+                1, std::memory_order_relaxed
+            );
+        }
+        query_callbacks[1].fetch_add(
+            1, std::memory_order_release
+        );
+    });
+    sibling.EndTimestampQuery(sibling_query);
+    sibling.AddCallback([&] {
+        const bool both_queries_terminal =
+            query_failed(failing_future) &&
+            query_failed(sibling_future);
+        const bool both_fences_terminal =
+            fence_failed(failing_done) &&
+            fence_failed(sibling_done);
+        if (!both_queries_terminal || !both_fences_terminal ||
+            GetCurrentRHIThreadRole() !=
+                ERHIThreadRole::Completion) {
+            callback_errors.fetch_add(
+                1, std::memory_order_relaxed
+            );
+        }
+        ordinary_callbacks[1].fetch_add(
+            1, std::memory_order_release
+        );
+    });
+    sibling.AddSuccessCallback([&] {
+        success_callbacks[1].fetch_add(
+            1, std::memory_order_release
+        );
+    });
+    CmdSubmit sibling_submit = sibling.Submit();
+    sibling_submit.SetTranslateExecutionClass(
+        ERHITranslateExecutionClass::Parallel
+    );
+    sibling_submit.SetResourceStateOwnership(
+        ERHIResourceStateOwnership::Explicit
+    );
+    sibling_submit.async_queue_scope = async_queue_scope;
+    sibling_submit.Signal(sibling_done.Get(), 1);
+
+    Array<RHIBackendSubmissionBatchEntry> batch{};
+    batch.emplace_back(
+        EQueueType::Graphics, std::move(failing_submit)
+    );
+    batch.emplace_back(
+        EQueueType::Graphics, std::move(sibling_submit)
+    );
+    RHIExecutor::Get().Submit(
+        std::move(batch), ERHIExecSubmitFlags::FlushGPU
+    );
+
+    const bool terminal_phase_observed =
+        translation_gate.WaitForTerminalPhase(
+            std::chrono::milliseconds(2000)
+        );
+    const bool callback_entered_before_release =
+        terminal_phase_observed &&
+        translation_gate.FailureCallbackEnteredBeforeRelease(
+            std::chrono::milliseconds(500)
+        );
+    const bool callbacks_zero_before_release =
+        query_callbacks[0].load(std::memory_order_acquire) ==
+            0 &&
+        ordinary_callbacks[0].load(
+            std::memory_order_acquire
+        ) == 0;
+    // Always release the observer, including the timeout path, so a late
+    // Translate notification cannot strand shutdown.
+    translation_gate.ReleaseTerminalPhase();
+    RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
+
+    const QueryResult failing_result = failing_future.Get();
+    const QueryResult sibling_result = sibling_future.Get();
+    if (failing_result.status != QueryStatus::Error ||
+        sibling_result.status != QueryStatus::Error ||
+        failing_result.error_reason.empty() ||
+        sibling_result.error_reason.empty() ||
+        !fence_failed(failing_done) ||
+        !fence_failed(sibling_done) ||
+        query_callbacks[0].load(std::memory_order_acquire) !=
+            1 ||
+        query_callbacks[1].load(std::memory_order_acquire) !=
+            1 ||
+        ordinary_callbacks[0].load(
+            std::memory_order_acquire
+        ) != 1 ||
+        ordinary_callbacks[1].load(
+            std::memory_order_acquire
+        ) != 1 ||
+        success_callbacks[0].load(
+            std::memory_order_acquire
+        ) != 0 ||
+        success_callbacks[1].load(
+            std::memory_order_acquire
+        ) != 0 ||
+        callback_errors.load(std::memory_order_acquire) !=
+            0 ||
+        !terminal_phase_observed ||
+        callback_entered_before_release ||
+        !callbacks_zero_before_release ||
+        translation_gate.TimedOut() ||
+        translation_gate.CheckedCallbackEntryCount() != 2 ||
+        translation_gate.RecordedPhaseCount() +
+                translation_gate.FailurePhaseCount() !=
+            1 ||
+        source_capture.Overflowed() ||
+        source_capture.Count() != 0 ||
+        native_capture.Overflowed() ||
+        native_capture.Count() != 0) {
+        throw std::runtime_error(
+            "serial timestamp Query native-record failure notified "
+            "Completion before publishing the whole batch suffix"
+        );
+    }
+
+    RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
+    if (query_callbacks[0].load(std::memory_order_acquire) !=
+            1 ||
+        query_callbacks[1].load(std::memory_order_acquire) !=
+            1 ||
+        ordinary_callbacks[0].load(
+            std::memory_order_acquire
+        ) != 1 ||
+        ordinary_callbacks[1].load(
+            std::memory_order_acquire
+        ) != 1 ||
+        success_callbacks[0].load(
+            std::memory_order_acquire
+        ) != 0 ||
+        success_callbacks[1].load(
+            std::memory_order_acquire
+        ) != 0 ||
+        source_capture.Count() != 0 ||
+        native_capture.Count() != 0) {
+        throw std::runtime_error(
+            "serial timestamp Query native-record failure replayed "
+            "Completion or native submission"
+        );
+    }
+
+    LOG_INFO(
+        "[TESTCASE][PASS] "
+        "name=TimestampQuerySerialRecordFailure "
+        "sources=2 failing_source=0 serial_query_island=true "
+        "sibling_query=Error sibling_signal=failed "
+        "batch_terminal_before_notify=true "
+        "recorded_phase_gate_count={} failed_phase_gate_count={} "
+        "pre_release_callback=0 owner=Completion "
+        "callbacks=exactly_once native_submit=0 replay=0",
+        translation_gate.RecordedPhaseCount(),
+        translation_gate.FailurePhaseCount()
+    );
+}
+
 } // namespace
 
 int main(int argc, const char** argv) {
@@ -9351,6 +10164,10 @@ int main(int argc, const char** argv) {
             HasArgument(argc, argv, "--timestamp-query");
         const bool timestamp_query_mid_failure_mode =
             HasArgument(argc, argv, "--timestamp-query-mid-failure");
+        const bool timestamp_query_record_failure_mode =
+            HasArgument(
+                argc, argv, "--timestamp-query-record-failure"
+            );
         const uint32 submission_batch_window =
             pipeline_window1 ? 1u : 2u;
 
@@ -9367,17 +10184,29 @@ int main(int argc, const char** argv) {
             .rhi_bypass       = false,
             .parallel_recording =
                 parallel || pipeline_window_mode || present_mode ||
-                timestamp_query_mode || timestamp_query_mid_failure_mode,
+                timestamp_query_mode ||
+                timestamp_query_mid_failure_mode ||
+                timestamp_query_record_failure_mode,
             .parallel_record_workers = 4,
             .parallel_record_verify =
                 parallel || pipeline_window_mode || present_mode ||
-                timestamp_query_mode || timestamp_query_mid_failure_mode,
+                timestamp_query_mode ||
+                timestamp_query_mid_failure_mode ||
+                timestamp_query_record_failure_mode,
             .parallel_record_min_work_units_per_job = production_gate ? 64u : 1u,
             .submission_batch_window = submission_batch_window,
             .parallel_record_worker_throw_trigger = inject_worker_failure ? 1u : 0u,
         });
         render_device_initialized = true;
 
+        if (timestamp_query_record_failure_mode) {
+            RunTimestampQuerySerialRecordFailure();
+            RenderDevice::Dispose();
+            render_device_initialized = false;
+            TaskSystem::ShutDown();
+            task_system_initialized = false;
+            return 0;
+        }
         if (timestamp_query_mid_failure_mode) {
             RunTimestampQueryMidBatchTranslateFailure();
             RenderDevice::Dispose();
@@ -9388,6 +10217,7 @@ int main(int argc, const char** argv) {
         }
         if (timestamp_query_mode) {
             RunTimestampQueryCompletionOwnership();
+            RunTimestampQueryPreparationRejection();
             // This malformed-batch rejection hard-latches the runtime, so the
             // mid-batch Translate failure has its own focused invocation.
             RunTimestampQueryPreflightRejection();

--- a/source/test/RHIQueryContractTest.cpp
+++ b/source/test/RHIQueryContractTest.cpp
@@ -348,20 +348,37 @@ void BulkErrorPathsPublishEveryPeerBeforeNotification() {
         }
     });
 
+    std::atomic_bool cancellation_won{false};
+    std::thread cancellation_thread([&] {
+        cancellation_won.store(
+            cancellation.Cancel("test cancellation"),
+            std::memory_order_release
+        );
+    });
+    cancellation_thread.join();
     Expect(
-        cancellation.Cancel("test cancellation"),
+        cancellation_won.load(std::memory_order_acquire),
         "QueryCancellationView did not win its cancellation transition"
     );
     Expect(
-        cancel_first_observed_second_error.load(std::memory_order_acquire),
-        "cancellation callback could not observe its peer as terminal"
+        cancel_first.GetFuture().Status() == QueryStatus::Error &&
+            cancel_second.GetFuture().Status() == QueryStatus::Error,
+        "cancellation did not publish every token before returning"
     );
     Expect(
-        cancellation_callback_count.load(std::memory_order_relaxed) == 2,
-        "bulk cancellation did not notify both callbacks exactly once"
+        cancellation_callback_count.load(std::memory_order_relaxed) == 0,
+        "opaque cancellation released callbacks on the cancellation thread"
     );
 
     auto cleanup = cancellation_list.DrainOrdinaryCallbacksForRejection();
+    Expect(
+        cancel_first_observed_second_error.load(std::memory_order_acquire),
+        "deferred cancellation callback could not observe its peer as terminal"
+    );
+    Expect(
+        cancellation_callback_count.load(std::memory_order_relaxed) == 2,
+        "ownership-boundary cancellation did not notify both callbacks exactly once"
+    );
     for (auto& callback : cleanup) {
         callback();
     }
@@ -950,6 +967,33 @@ void MoveAndSubmitRetainIdentityAndLifetime() {
 }
 
 void CancellationViewIsStableAndGenerationScoped() {
+    CommandList sealed_list(EQueueType::Graphics);
+    QueryCancellationView sealed_view =
+        sealed_list.GetQueryCancellationView();
+    QueryToken sealed_token =
+        sealed_list.BeginTimestampQuery("SealedGenerationTimestamp");
+    sealed_list.EndTimestampQuery(sealed_token);
+    QueryFuture sealed_future = sealed_token.GetFuture();
+    CmdSubmit sealed_submit = sealed_list.Submit();
+    Expect(
+        !sealed_view.Cancel("late stale-view cancellation"),
+        "a stale cancellation view mutated a submitted generation"
+    );
+    Expect(
+        sealed_future.Status() == QueryStatus::Pending,
+        "stale cancellation changed the submitted query result"
+    );
+    Expect(
+        QueryBackendAccess::ResolveTimestamp(
+            sealed_submit.query_tokens.front(), TestTimestampResult()
+        ),
+        "submitted generation could not resolve after stale cancellation lost"
+    );
+    Expect(
+        sealed_future.Get().status == QueryStatus::Ready,
+        "submitted generation lost its Ready result after stale cancellation"
+    );
+
     CommandList           list(EQueueType::Graphics);
     QueryCancellationView first_generation = list.GetQueryCancellationView();
     Expect(first_generation.Valid(), "CommandList exposed an invalid cancellation view");

--- a/source/test/RHIQueryContractTest.cpp
+++ b/source/test/RHIQueryContractTest.cpp
@@ -1,0 +1,1028 @@
+#include "rhi/RHICommand.h"
+#include "rhi/RHIImpl.h"
+#include "rhi/RHIQuery.h"
+
+#include <atomic>
+#include <chrono>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <thread>
+#include <type_traits>
+#include <vector>
+
+namespace {
+
+using namespace Moer::Render;
+using namespace std::chrono_literals;
+
+void Expect(bool _condition, std::string_view _message) {
+    if (!_condition) {
+        throw std::runtime_error(std::string(_message));
+    }
+}
+
+bool WaitForFlag(const std::atomic_bool& _flag, std::chrono::milliseconds _timeout = 500ms) {
+    const auto deadline = std::chrono::steady_clock::now() + _timeout;
+    while (!_flag.load(std::memory_order_acquire) && std::chrono::steady_clock::now() < deadline) {
+        std::this_thread::sleep_for(1ms);
+    }
+    return _flag.load(std::memory_order_acquire);
+}
+
+class QueryFenceProbe final : public Fence {
+public:
+    uint64_t GetValue() const override {
+        return 0;
+    }
+
+    void Wait(uint64_t) override {}
+
+    void MarkSubmitted(uint64_t _value) override {
+        submitted_value.store(_value, std::memory_order_release);
+    }
+
+    bool WaitSubmitted(
+        uint64_t,
+        const std::atomic_bool* = nullptr,
+        EQueueType              = EQueueType::Ignore,
+        Moer::uint32            = 0
+    ) override {
+        return false;
+    }
+
+    bool IsRejected(uint64_t _value) const override {
+        return rejected_value.load(std::memory_order_acquire) == _value;
+    }
+
+    void Reject(uint64_t _value) noexcept override {
+        rejected_value.store(_value, std::memory_order_release);
+    }
+
+private:
+    std::atomic<uint64_t> submitted_value{0};
+    std::atomic<uint64_t> rejected_value{0};
+};
+
+template<typename TException, typename TCallback>
+void ExpectThrows(TCallback&& _callback, std::string_view _message) {
+    bool threw_expected = false;
+    try {
+        _callback();
+    } catch (const TException&) {
+        threw_expected = true;
+    }
+    Expect(threw_expected, _message);
+}
+
+const QueryCmd& QueryAt(const CmdSubmit& _submit, size_t _index) {
+    Expect(_index < _submit.cmds.size(), "query command index is out of range");
+    Expect(_submit.cmds[_index]->Type() == Command::EType::Query, "expected QueryCmd");
+    return *static_cast<const QueryCmd*>(_submit.cmds[_index].get());
+}
+
+TimestampQueryResult TestTimestampResult() {
+    return TimestampQueryResult{
+        .begin_tick     = 120,
+        .end_tick       = 180,
+        .valid_bits     = 64,
+        .tick_period_ns = 2.0,
+        .duration_ns    = 120.0,
+    };
+}
+
+void FutureIsThreadSafeOneShotAndContainsCallbackExceptions() {
+    CommandList list(EQueueType::Graphics);
+    QueryToken  token = list.BeginTimestampQuery("ConcurrentTimestamp");
+    list.EndTimestampQuery(token);
+    CmdSubmit submit = list.Submit();
+
+    QueryFuture future = token.GetFuture();
+    Expect(future.Valid(), "recorded query returned an invalid future");
+    Expect(!future.IsReady(), "new query future was already terminal");
+    Expect(future.Status() == QueryStatus::Pending, "new query was not Pending");
+    Expect(!future.WaitFor(1ms), "pending query unexpectedly satisfied WaitFor");
+    Expect(!future.TryGet().has_value(), "pending query unexpectedly had a result");
+
+    constexpr int            callback_thread_count = 32;
+    std::atomic<int>         callback_count{0};
+    std::atomic<bool>        start{false};
+    std::vector<std::thread> threads{};
+    threads.reserve(callback_thread_count);
+    for (int index = 0; index < callback_thread_count; ++index) {
+        threads.emplace_back([&, future] {
+            while (!start.load(std::memory_order_acquire)) {
+                std::this_thread::yield();
+            }
+            future.Then([&](const QueryResult& _result) {
+                Expect(
+                    _result.status == QueryStatus::Ready, "concurrent callback observed a non-Ready result"
+                );
+                callback_count.fetch_add(1, std::memory_order_relaxed);
+            });
+        });
+    }
+
+    future.Then([](const QueryResult&) {
+        throw std::runtime_error("client callback failure");
+    });
+    start.store(true, std::memory_order_release);
+    for (std::thread& thread : threads) {
+        thread.join();
+    }
+
+    Expect(
+        QueryBackendAccess::ResolveTimestamp(token, TestTimestampResult()),
+        "first timestamp completion did not win the one-shot transition"
+    );
+    future.Wait();
+    Expect(future.WaitFor(1ms), "terminal future did not satisfy WaitFor");
+    Expect(
+        callback_count.load(std::memory_order_relaxed) == callback_thread_count,
+        "pre-terminal callbacks were not invoked exactly once"
+    );
+
+    future.Then([&](const QueryResult& _result) {
+        Expect(_result.status == QueryStatus::Ready, "post-terminal callback observed the wrong status");
+        callback_count.fetch_add(1, std::memory_order_relaxed);
+        throw std::runtime_error("post-terminal callback failure");
+    });
+    Expect(
+        callback_count.load(std::memory_order_relaxed) == callback_thread_count + 1,
+        "post-terminal callback was not invoked synchronously exactly once"
+    );
+
+    Expect(
+        !QueryBackendAccess::ResolveErrorIfPending(token, "late rejection"),
+        "a second terminal transition overwrote the Ready result"
+    );
+    const QueryResult result = future.Get();
+    Expect(result.status == QueryStatus::Ready, "Get lost Ready status");
+    Expect(result.kind == QueryKind::Timestamp, "Get lost query kind");
+    Expect(result.query_id == token.Id(), "Get lost query identity");
+    Expect(result.name == "ConcurrentTimestamp", "Get lost query name");
+    Expect(result.error_reason.empty(), "Ready result retained an error reason");
+    const auto* timestamp = std::get_if<TimestampQueryResult>(&result.payload);
+    Expect(timestamp != nullptr, "Ready result has the wrong payload type");
+    Expect(
+        timestamp->begin_tick == 120 && timestamp->end_tick == 180 && timestamp->valid_bits == 64 &&
+            timestamp->duration_ns == 120.0,
+        "timestamp payload changed during resolution"
+    );
+
+    // Simulate Completion ordering: backend resolves first and the ordinary
+    // rejection fallback becomes an idempotent no-op.
+    for (auto& callback : submit.callbacks) {
+        callback();
+    }
+    submit.callbacks.clear();
+    submit.query_tokens.clear();
+}
+
+void ReadyAndErrorResolutionRaceHasOneWinner() {
+    constexpr int race_iterations = 128;
+    for (int iteration = 0; iteration < race_iterations; ++iteration) {
+        CommandList list(EQueueType::Graphics);
+        QueryToken  token = list.BeginTimestampQuery("ResolveRace");
+        list.EndTimestampQuery(token);
+        CmdSubmit submit = list.Submit();
+
+        std::atomic<int>  callback_count{0};
+        std::atomic<bool> start{false};
+        bool              ready_won = false;
+        bool              error_won = false;
+        token.Then([&](const QueryResult& _result) {
+            Expect(
+                _result.status == QueryStatus::Ready || _result.status == QueryStatus::Error,
+                "resolve race callback observed a non-terminal result"
+            );
+            callback_count.fetch_add(1, std::memory_order_relaxed);
+        });
+
+        std::thread ready_thread([&] {
+            while (!start.load(std::memory_order_acquire)) {
+                std::this_thread::yield();
+            }
+            ready_won = QueryBackendAccess::ResolveTimestamp(token, TestTimestampResult());
+        });
+        std::thread error_thread([&] {
+            while (!start.load(std::memory_order_acquire)) {
+                std::this_thread::yield();
+            }
+            error_won = QueryBackendAccess::ResolveErrorIfPending(token, "injected completion failure");
+        });
+        start.store(true, std::memory_order_release);
+        ready_thread.join();
+        error_thread.join();
+
+        Expect(ready_won != error_won, "Ready/Error race did not have exactly one winner");
+        Expect(token.GetFuture().IsReady(), "Ready/Error race left the future Pending");
+        Expect(
+            callback_count.load(std::memory_order_relaxed) == 1,
+            "Ready/Error race invoked its callback more or less than once"
+        );
+        const QueryResult result = token.GetFuture().Get();
+        Expect(
+            result.status == (ready_won ? QueryStatus::Ready : QueryStatus::Error),
+            "Ready/Error race result disagrees with the winning resolver"
+        );
+
+        for (auto& callback : submit.callbacks) {
+            callback();
+        }
+        submit.callbacks.clear();
+        submit.query_tokens.clear();
+    }
+}
+
+void ReadyBatchPublishesEveryPeerBeforeNotification() {
+    CommandList list(EQueueType::Graphics);
+    QueryToken  first = list.BeginTimestampQuery("ReadyBatchFirst");
+    list.EndTimestampQuery(first);
+    QueryToken second = list.BeginTimestampQuery("ReadyBatchSecond");
+    list.EndTimestampQuery(second);
+    CmdSubmit submit = list.Submit();
+
+    const QueryFuture second_future = second.GetFuture();
+    std::atomic<int>  callback_count{0};
+    std::atomic_bool  first_observed_second_ready{false};
+    first.Then([&](const QueryResult& _result) {
+        const bool peer_ready = second_future.WaitFor(100ms) && second_future.Status() == QueryStatus::Ready;
+        first_observed_second_ready.store(
+            _result.status == QueryStatus::Ready && peer_ready, std::memory_order_release
+        );
+        callback_count.fetch_add(1, std::memory_order_relaxed);
+    });
+    second.Then([&](const QueryResult& _result) {
+        if (_result.status == QueryStatus::Ready) {
+            callback_count.fetch_add(1, std::memory_order_relaxed);
+        }
+    });
+
+    const QueryPublishBatch batch = QueryBackendAccess::BeginPublishBatch();
+    Expect(
+        QueryBackendAccess::PublishTimestamp(first, TestTimestampResult(), batch),
+        "Ready batch did not publish its first query"
+    );
+    Expect(
+        QueryBackendAccess::PublishTimestamp(second, TestTimestampResult(), batch),
+        "Ready batch did not publish its second query"
+    );
+    Expect(
+        callback_count.load(std::memory_order_relaxed) == 0,
+        "Ready batch released a callback during its publish phase"
+    );
+
+    QueryBackendAccess::NotifyTerminals(submit.query_tokens, batch);
+    Expect(
+        first_observed_second_ready.load(std::memory_order_acquire),
+        "first Ready callback could not observe its peer as terminal"
+    );
+    Expect(
+        callback_count.load(std::memory_order_relaxed) == 2,
+        "Ready batch did not notify both callbacks exactly once"
+    );
+}
+
+void BulkErrorPathsPublishEveryPeerBeforeNotification() {
+    QueryFuture      submit_first_future{};
+    QueryFuture      submit_second_future{};
+    std::atomic<int> submit_callback_count{0};
+    std::atomic_bool submit_first_observed_second_error{false};
+    {
+        CommandList list(EQueueType::Graphics);
+        QueryToken  first = list.BeginTimestampQuery("SubmitErrorFirst");
+        list.EndTimestampQuery(first);
+        QueryToken second = list.BeginTimestampQuery("SubmitErrorSecond");
+        list.EndTimestampQuery(second);
+        submit_first_future  = first.GetFuture();
+        submit_second_future = second.GetFuture();
+
+        first.Then([&](const QueryResult& _result) {
+            const bool peer_error =
+                submit_second_future.WaitFor(100ms) && submit_second_future.Status() == QueryStatus::Error;
+            submit_first_observed_second_error.store(
+                _result.status == QueryStatus::Error && peer_error, std::memory_order_release
+            );
+            submit_callback_count.fetch_add(1, std::memory_order_relaxed);
+        });
+        second.Then([&](const QueryResult& _result) {
+            if (_result.status == QueryStatus::Error) {
+                submit_callback_count.fetch_add(1, std::memory_order_relaxed);
+            }
+        });
+
+        [[maybe_unused]] CmdSubmit abandoned = list.Submit();
+    }
+    Expect(
+        submit_first_observed_second_error.load(std::memory_order_acquire),
+        "CmdSubmit Error callback could not observe its peer as terminal"
+    );
+    Expect(
+        submit_callback_count.load(std::memory_order_relaxed) == 2,
+        "CmdSubmit bulk Error did not notify both callbacks exactly once"
+    );
+
+    CommandList           cancellation_list(EQueueType::Graphics);
+    QueryCancellationView cancellation = cancellation_list.GetQueryCancellationView();
+    QueryToken            cancel_first = cancellation_list.BeginTimestampQuery("CancellationFirst");
+    cancellation_list.EndTimestampQuery(cancel_first);
+    QueryToken cancel_second = cancellation_list.BeginTimestampQuery("CancellationSecond");
+    cancellation_list.EndTimestampQuery(cancel_second);
+
+    const QueryFuture cancel_second_future = cancel_second.GetFuture();
+    std::atomic<int>  cancellation_callback_count{0};
+    std::atomic_bool  cancel_first_observed_second_error{false};
+    cancel_first.Then([&](const QueryResult& _result) {
+        const bool peer_error =
+            cancel_second_future.WaitFor(100ms) && cancel_second_future.Status() == QueryStatus::Error;
+        cancel_first_observed_second_error.store(
+            _result.status == QueryStatus::Error && peer_error, std::memory_order_release
+        );
+        cancellation_callback_count.fetch_add(1, std::memory_order_relaxed);
+    });
+    cancel_second.Then([&](const QueryResult& _result) {
+        if (_result.status == QueryStatus::Error) {
+            cancellation_callback_count.fetch_add(1, std::memory_order_relaxed);
+        }
+    });
+
+    Expect(
+        cancellation.Cancel("test cancellation"),
+        "QueryCancellationView did not win its cancellation transition"
+    );
+    Expect(
+        cancel_first_observed_second_error.load(std::memory_order_acquire),
+        "cancellation callback could not observe its peer as terminal"
+    );
+    Expect(
+        cancellation_callback_count.load(std::memory_order_relaxed) == 2,
+        "bulk cancellation did not notify both callbacks exactly once"
+    );
+
+    auto cleanup = cancellation_list.DrainOrdinaryCallbacksForRejection();
+    for (auto& callback : cleanup) {
+        callback();
+    }
+}
+
+void LosingBatchCannotStealNotificationOwnership() {
+    CommandList list(EQueueType::Graphics);
+    QueryToken  token = list.BeginTimestampQuery("PublishTicketOwner");
+    list.EndTimestampQuery(token);
+    CmdSubmit submit = list.Submit();
+
+    std::atomic<int> callback_count{0};
+    std::atomic_bool callback_observed_ready{false};
+    token.Then([&](const QueryResult& _result) {
+        callback_observed_ready.store(_result.status == QueryStatus::Ready, std::memory_order_release);
+        callback_count.fetch_add(1, std::memory_order_relaxed);
+    });
+
+    const QueryPublishBatch ready_batch = QueryBackendAccess::BeginPublishBatch();
+    Expect(
+        QueryBackendAccess::PublishTimestamp(token, TestTimestampResult(), ready_batch),
+        "Ready publisher did not win the terminal transition"
+    );
+
+    QueryBackendAccess::ResolveErrorsIfPending(submit.query_tokens, "competing rejection");
+    Expect(
+        callback_count.load(std::memory_order_relaxed) == 0,
+        "losing Error batch stole the Ready publisher's callback ownership"
+    );
+
+    QueryBackendAccess::NotifyTerminal(token, ready_batch);
+    Expect(
+        callback_count.load(std::memory_order_relaxed) == 1 &&
+            callback_observed_ready.load(std::memory_order_acquire),
+        "Ready publisher did not retain exactly-once callback ownership"
+    );
+
+    CommandList stored_ticket_list(EQueueType::Graphics);
+    QueryToken  stored_ticket_token =
+        stored_ticket_list.BeginTimestampQuery("StoredPublishTicketOwner");
+    stored_ticket_list.EndTimestampQuery(stored_ticket_token);
+    CmdSubmit stored_ticket_submit = stored_ticket_list.Submit();
+
+    std::atomic<int> stored_ticket_callback_count{0};
+    stored_ticket_token.Then([&](const QueryResult& _result) {
+        if (_result.status == QueryStatus::Ready) {
+            stored_ticket_callback_count.fetch_add(
+                1, std::memory_order_relaxed
+            );
+        }
+    });
+
+    const QueryPublishBatch stored_ready_batch =
+        QueryBackendAccess::BeginPublishBatch();
+    stored_ticket_submit.query_publish_batch = stored_ready_batch;
+    Expect(
+        QueryBackendAccess::PublishTimestamp(
+            stored_ticket_token,
+            TestTimestampResult(),
+            stored_ready_batch
+        ),
+        "stored-ticket Ready publisher did not win"
+    );
+
+    const QueryPublishBatch competing_error_batch =
+        QueryBackendAccess::BeginPublishBatch();
+    stored_ticket_submit.PublishPendingQueryErrors(
+        "competing submit rejection",
+        competing_error_batch
+    );
+    stored_ticket_submit.NotifyPendingQueries(
+        stored_ticket_submit.query_publish_batch
+    );
+    Expect(
+        stored_ticket_callback_count.load(std::memory_order_relaxed) == 1,
+        "CmdSubmit overwrote the stored winning notification ticket"
+    );
+    QueryBackendAccess::NotifyTerminal(
+        stored_ticket_token,
+        stored_ready_batch
+    );
+    Expect(
+        stored_ticket_callback_count.load(std::memory_order_relaxed) == 1,
+        "stored winning ticket released its callback more than once"
+    );
+}
+
+void PublishWakesWaitersBeforeDeferredCallbackNotification() {
+    CommandList           list(EQueueType::Graphics);
+    QueryCancellationView cancellation = list.GetQueryCancellationView();
+    QueryToken            token        = list.BeginTimestampQuery("DeferredNotification");
+    list.EndTimestampQuery(token);
+    QueryFuture future = token.GetFuture();
+
+    std::atomic<int>         callback_count{0};
+    std::atomic_bool         waiter_entered{false};
+    std::atomic_bool         waiter_returned{false};
+    std::atomic<QueryStatus> waiter_status{QueryStatus::Pending};
+    future.Then([&](const QueryResult& _result) {
+        if (_result.status == QueryStatus::Error) {
+            callback_count.fetch_add(1, std::memory_order_relaxed);
+        }
+    });
+
+    std::thread waiter([&] {
+        waiter_entered.store(true, std::memory_order_release);
+        future.Wait();
+        waiter_status.store(future.Status(), std::memory_order_release);
+        waiter_returned.store(true, std::memory_order_release);
+    });
+    const bool  waiter_started = WaitForFlag(waiter_entered);
+    std::this_thread::sleep_for(10ms);
+    const bool pending_before_publication = !waiter_returned.load(std::memory_order_acquire);
+
+    const QueryPublishBatch batch     = QueryBackendAccess::BeginPublishBatch();
+    const bool              published = cancellation.PublishCancellation("deferred shutdown", batch);
+    const bool              woke_before_notification      = published && WaitForFlag(waiter_returned);
+    const int               callbacks_before_notification = callback_count.load(std::memory_order_relaxed);
+
+    // Always release the callback owner before joining so a regression reports
+    // a bounded failure instead of hanging the test executable.
+    cancellation.NotifyCancellation(batch);
+    if (!published) {
+        QueryBackendAccess::ResolveErrorIfPending(token, "deferred shutdown test cleanup");
+    }
+    waiter.join();
+
+    Expect(waiter_started, "waiter did not enter QueryFuture::Wait");
+    Expect(pending_before_publication, "Pending QueryFuture waiter returned before publication");
+    Expect(published, "deferred cancellation did not publish");
+    Expect(
+        woke_before_notification && waiter_status.load(std::memory_order_acquire) == QueryStatus::Error,
+        "Publish did not wake a pre-blocked waiter before callback notification"
+    );
+    Expect(callbacks_before_notification == 0, "Publish released a callback that was intentionally deferred");
+    Expect(
+        callback_count.load(std::memory_order_relaxed) == 1, "deferred callback was not released exactly once"
+    );
+
+    auto cleanup = list.DrainOrdinaryCallbacksForRejection();
+    for (auto& callback : cleanup) {
+        callback();
+    }
+}
+
+void CallbacksMayReleaseTheirLastQueryHandles() {
+    CommandList terminal_list(EQueueType::Graphics);
+    QueryToken  terminal_token = terminal_list.BeginTimestampQuery("SynchronousSelfRelease");
+    terminal_list.EndTimestampQuery(terminal_token);
+    CmdSubmit   terminal_submit = terminal_list.Submit();
+    QueryFuture terminal_future = terminal_token.GetFuture();
+    Expect(
+        QueryBackendAccess::ResolveTimestamp(terminal_token, TestTimestampResult()),
+        "self-release setup did not resolve its query"
+    );
+
+    // Leave terminal_future as the only state owner before Then invokes the
+    // already-terminal callback synchronously.
+    terminal_submit.cmds.clear();
+    terminal_submit.callbacks.clear();
+    terminal_submit.query_tokens.clear();
+    terminal_token = {};
+
+    std::atomic<int> terminal_callback_count{0};
+    std::atomic_bool result_survived_synchronous_release{false};
+    terminal_future.Then([&](const QueryResult& _result) {
+        terminal_future = {};
+        result_survived_synchronous_release.store(
+            _result.status == QueryStatus::Ready && _result.name == "SynchronousSelfRelease",
+            std::memory_order_release
+        );
+        terminal_callback_count.fetch_add(1, std::memory_order_relaxed);
+    });
+    Expect(
+        !terminal_future.Valid() && result_survived_synchronous_release.load(std::memory_order_acquire) &&
+            terminal_callback_count.load(std::memory_order_relaxed) == 1,
+        "synchronous Then callback could not release its last QueryFuture safely"
+    );
+
+    CommandList notify_list(EQueueType::Graphics);
+    QueryToken  notify_token = notify_list.BeginTimestampQuery("NotifySelfRelease");
+    notify_list.EndTimestampQuery(notify_token);
+    CmdSubmit   notify_submit = notify_list.Submit();
+    QueryFuture notify_future = notify_token.GetFuture();
+
+    std::atomic<int> notify_callback_count{0};
+    std::atomic_bool first_result_survived_release{false};
+    std::atomic_bool second_callback_observed_ready{false};
+    notify_future.Then([&](const QueryResult& _result) {
+        notify_future = {};
+        notify_token  = {};
+        first_result_survived_release.store(
+            _result.status == QueryStatus::Ready && _result.name == "NotifySelfRelease",
+            std::memory_order_release
+        );
+        notify_callback_count.fetch_add(1, std::memory_order_relaxed);
+    });
+    notify_future.Then([&](const QueryResult& _result) {
+        second_callback_observed_ready.store(_result.status == QueryStatus::Ready, std::memory_order_release);
+        notify_callback_count.fetch_add(1, std::memory_order_relaxed);
+    });
+
+    // Remove every packet-held token. NotifyTerminal's local strong state must
+    // carry the result and remaining callbacks after the first callback drops
+    // the last public handles.
+    notify_submit.cmds.clear();
+    notify_submit.callbacks.clear();
+    notify_submit.query_tokens.clear();
+    const QueryPublishBatch batch = QueryBackendAccess::BeginPublishBatch();
+    Expect(
+        QueryBackendAccess::PublishTimestamp(notify_token, TestTimestampResult(), batch),
+        "multi-callback self-release query was not published"
+    );
+    QueryBackendAccess::NotifyTerminal(notify_token, batch);
+
+    Expect(
+        !notify_future.Valid() && !notify_token.Valid() &&
+            first_result_survived_release.load(std::memory_order_acquire) &&
+            second_callback_observed_ready.load(std::memory_order_acquire) &&
+            notify_callback_count.load(std::memory_order_relaxed) == 2,
+        "self-release invalidated the result or skipped a later callback"
+    );
+}
+
+void PairingIsSameListSameKindAndStrictLifo() {
+    CommandList first(EQueueType::Compute);
+    QueryToken  outer = first.BeginTimestampQuery("Outer");
+    QueryToken  inner = first.BeginTimestampQuery("Inner");
+
+    ExpectThrows<std::logic_error>(
+        [&] {
+            first.EndTimestampQuery(outer);
+        },
+        "out-of-order query end was accepted"
+    );
+    first.EndTimestampQuery(inner);
+    first.EndTimestampQuery(outer);
+    CmdSubmit nested = first.Submit();
+    Expect(nested.cmds.size() == 4, "nested query pair emitted the wrong command count");
+    Expect(QueryAt(nested, 0).IsBegin(), "outer query did not begin first");
+    Expect(QueryAt(nested, 1).IsBegin(), "inner query did not begin second");
+    Expect(QueryAt(nested, 2).IsEnd(), "inner query did not end first");
+    Expect(QueryAt(nested, 3).IsEnd(), "outer query did not end last");
+    Expect(
+        QueryAt(nested, 0).Token().Id() == QueryAt(nested, 3).Token().Id() &&
+            QueryAt(nested, 1).Token().Id() == QueryAt(nested, 2).Token().Id(),
+        "nested query command identities were not paired"
+    );
+    Expect(
+        QueryAt(nested, 0).GetQueueType() == EQueueType::Compute, "query command lost its recording queue"
+    );
+
+    CommandList owner(EQueueType::Graphics);
+    CommandList foreign(EQueueType::Graphics);
+    QueryToken  owned = owner.BeginTimestampQuery("Owned");
+    ExpectThrows<std::invalid_argument>(
+        [&] {
+            foreign.EndTimestampQuery(owned);
+        },
+        "a different CommandList accepted the token"
+    );
+    owner.EndTimestampQuery(owned);
+    CmdSubmit owner_submit = owner.Submit();
+
+    QueryToken foreign_token = foreign.BeginTimestampQuery("Foreign");
+    foreign.EndTimestampQuery(foreign_token);
+    CmdSubmit foreign_submit = foreign.Submit();
+
+    ExpectThrows<std::invalid_argument>(
+        [&] {
+            CommandList invalid_owner;
+            invalid_owner.EndTimestampQuery(QueryToken{});
+        },
+        "an invalid token was accepted"
+    );
+
+    // Keep these test-only packets from reporting abandonment during teardown.
+    QueryBackendAccess::ResolveErrorIfPending(outer, "test retired");
+    QueryBackendAccess::ResolveErrorIfPending(inner, "test retired");
+    QueryBackendAccess::ResolveErrorIfPending(owned, "test retired");
+    QueryBackendAccess::ResolveErrorIfPending(foreign_token, "test retired");
+}
+
+void InvalidSubmissionRejectionAndDestructionAreTerminal() {
+    QueryFuture unclosed_future{};
+    {
+        CommandList unclosed(EQueueType::Graphics);
+        QueryToken  token = unclosed.BeginTimestampQuery("UnclosedSubmit");
+        unclosed_future   = token.GetFuture();
+        ExpectThrows<std::logic_error>(
+            [&] {
+                [[maybe_unused]] CmdSubmit rejected = unclosed.Submit();
+            },
+            "Submit accepted an unclosed timestamp query"
+        );
+        Expect(unclosed.IsEmpty(), "invalid Submit retained a partial query stream");
+    }
+    QueryResult unclosed_result = unclosed_future.Get();
+    Expect(
+        unclosed_result.status == QueryStatus::Error && !unclosed_result.error_reason.empty(),
+        "invalid Submit did not terminalize its query"
+    );
+
+    QueryFuture drained_future{};
+    {
+        CommandList rejected(EQueueType::Graphics);
+        QueryToken  token = rejected.BeginTimestampQuery("Rejected");
+        rejected.EndTimestampQuery(token);
+        drained_future = token.GetFuture();
+        auto callbacks = rejected.DrainOrdinaryCallbacksForRejection();
+        Expect(drained_future.Status() == QueryStatus::Error, "rejection drain left a closed query Pending");
+        for (auto& callback : callbacks) {
+            callback();
+        }
+        Expect(rejected.IsEmpty(), "rejection drain retained query state");
+    }
+
+    QueryFuture list_destruction_future{};
+    {
+        CommandList abandoned(EQueueType::Graphics);
+        QueryToken  token = abandoned.BeginTimestampQuery("AbandonedList");
+        abandoned.EndTimestampQuery(token);
+        list_destruction_future = token.GetFuture();
+    }
+    Expect(
+        list_destruction_future.Get().status == QueryStatus::Error,
+        "CommandList destruction left a query Pending"
+    );
+
+    QueryFuture submit_destruction_future{};
+    {
+        CommandList list(EQueueType::Graphics);
+        QueryToken  token = list.BeginTimestampQuery("AbandonedSubmit");
+        list.EndTimestampQuery(token);
+        submit_destruction_future                   = token.GetFuture();
+        [[maybe_unused]] CmdSubmit abandoned_submit = list.Submit();
+    }
+    Expect(
+        submit_destruction_future.Get().status == QueryStatus::Error,
+        "CmdSubmit destruction left a query Pending"
+    );
+
+    CommandList copy(EQueueType::Copy);
+    QueryToken  copy_token = copy.BeginTimestampQuery("UnsupportedCopy");
+    Expect(
+        copy_token.GetFuture().Get().status == QueryStatus::Error,
+        "Copy queue timestamp query did not fail closed"
+    );
+    copy.EndTimestampQuery(copy_token);
+    Expect(copy.IsEmpty(), "Copy queue capability failure emitted a QueryCmd");
+}
+
+void SignalRejectionPrecedesQueryCallbacksAndPreservesReentrantState() {
+    QueryFenceProbe  list_destruction_fence{};
+    std::atomic<int> list_destruction_callback_count{0};
+    std::atomic_bool list_destruction_observed_signal{false};
+    {
+        CommandList list(EQueueType::Graphics);
+        list.Signal(&list_destruction_fence, 11);
+        QueryToken token = list.BeginTimestampQuery("ListDestructionOrder");
+        list.EndTimestampQuery(token);
+        token.Then([&](const QueryResult& _result) {
+            list_destruction_observed_signal.store(
+                _result.status == QueryStatus::Error && list_destruction_fence.IsRejected(11),
+                std::memory_order_release
+            );
+            list_destruction_callback_count.fetch_add(1, std::memory_order_relaxed);
+        });
+    }
+    Expect(
+        list_destruction_observed_signal.load(std::memory_order_acquire) &&
+            list_destruction_callback_count.load(std::memory_order_relaxed) == 1,
+        "CommandList destruction notified Query before rejecting its signal"
+    );
+
+    QueryFenceProbe  submit_destruction_fence{};
+    std::atomic<int> submit_destruction_callback_count{0};
+    std::atomic_bool submit_destruction_observed_signal{false};
+    {
+        CommandList list(EQueueType::Graphics);
+        list.Signal(&submit_destruction_fence, 12);
+        QueryToken token = list.BeginTimestampQuery("SubmitDestructionOrder");
+        list.EndTimestampQuery(token);
+        token.Then([&](const QueryResult& _result) {
+            submit_destruction_observed_signal.store(
+                _result.status == QueryStatus::Error && submit_destruction_fence.IsRejected(12),
+                std::memory_order_release
+            );
+            submit_destruction_callback_count.fetch_add(1, std::memory_order_relaxed);
+        });
+        [[maybe_unused]] CmdSubmit submit = list.Submit();
+    }
+    Expect(
+        submit_destruction_observed_signal.load(std::memory_order_acquire) &&
+            submit_destruction_callback_count.load(std::memory_order_relaxed) == 1,
+        "CmdSubmit destruction notified Query before rejecting its signal"
+    );
+
+    QueryFenceProbe  replaced_submit_fence{};
+    QueryFenceProbe  incoming_submit_fence{};
+    QueryFenceProbe  reentrant_submit_fence{};
+    std::atomic<int> submit_move_callback_count{0};
+    std::atomic_bool submit_move_observed_signal{false};
+    CommandList      old_submit_list(EQueueType::Graphics);
+    old_submit_list.Signal(&replaced_submit_fence, 21);
+    QueryToken replaced_submit_token = old_submit_list.BeginTimestampQuery("ReplacedSubmit");
+    old_submit_list.EndTimestampQuery(replaced_submit_token);
+    CmdSubmit destination_submit = old_submit_list.Submit();
+    replaced_submit_token.Then([&](const QueryResult& _result) {
+        submit_move_observed_signal.store(
+            _result.status == QueryStatus::Error && replaced_submit_fence.IsRejected(21),
+            std::memory_order_release
+        );
+        destination_submit.Signal(&reentrant_submit_fence, 23);
+        submit_move_callback_count.fetch_add(1, std::memory_order_relaxed);
+    });
+
+    CommandList incoming_submit_list(EQueueType::Graphics);
+    incoming_submit_list.Signal(&incoming_submit_fence, 22);
+    CmdSubmit incoming_submit = incoming_submit_list.Submit();
+    destination_submit        = std::move(incoming_submit);
+    Expect(
+        submit_move_observed_signal.load(std::memory_order_acquire) &&
+            submit_move_callback_count.load(std::memory_order_relaxed) == 1,
+        "CmdSubmit move assignment notified Query before rejecting its signal"
+    );
+    Expect(
+        destination_submit.signal_events.size() == 2, "CmdSubmit move assignment overwrote a reentrant signal"
+    );
+    destination_submit.RejectPendingSignals();
+    Expect(
+        incoming_submit_fence.IsRejected(22) && reentrant_submit_fence.IsRejected(23),
+        "CmdSubmit move assignment did not preserve both installed signals"
+    );
+
+    QueryFenceProbe  replaced_list_fence{};
+    QueryFenceProbe  incoming_list_fence{};
+    QueryFenceProbe  reentrant_list_fence{};
+    std::atomic<int> list_move_callback_count{0};
+    std::atomic_bool list_move_observed_signal{false};
+    std::atomic_bool list_move_recorded_reentrant_query{false};
+    QueryFuture      reentrant_move_future{};
+    CommandList      destination_list(EQueueType::Graphics);
+    destination_list.Signal(&replaced_list_fence, 31);
+    QueryToken replaced_list_token = destination_list.BeginTimestampQuery("ReplacedList");
+    destination_list.EndTimestampQuery(replaced_list_token);
+    replaced_list_token.Then([&](const QueryResult& _result) {
+        list_move_observed_signal.store(
+            _result.status == QueryStatus::Error && replaced_list_fence.IsRejected(31),
+            std::memory_order_release
+        );
+        destination_list.Signal(&reentrant_list_fence, 33);
+        QueryToken reentrant = destination_list.BeginTimestampQuery("ReentrantMoveQuery");
+        destination_list.EndTimestampQuery(reentrant);
+        reentrant_move_future = reentrant.GetFuture();
+        list_move_recorded_reentrant_query.store(true, std::memory_order_release);
+        list_move_callback_count.fetch_add(1, std::memory_order_relaxed);
+    });
+
+    CommandList incoming_list(EQueueType::Graphics);
+    incoming_list.Signal(&incoming_list_fence, 32);
+    destination_list = std::move(incoming_list);
+    Expect(
+        list_move_observed_signal.load(std::memory_order_acquire) &&
+            list_move_recorded_reentrant_query.load(std::memory_order_acquire) &&
+            list_move_callback_count.load(std::memory_order_relaxed) == 1,
+        "CommandList move assignment lost ordering or reentrant recording"
+    );
+    {
+        CmdSubmit preserved = destination_list.Submit();
+        Expect(
+            preserved.signal_events.size() == 2 && preserved.query_tokens.size() == 1,
+            "CommandList move assignment overwrote reentrant Query/signal state"
+        );
+        preserved.RejectPendingSignals();
+        preserved.RejectPendingQueries("test cleanup");
+    }
+    Expect(
+        incoming_list_fence.IsRejected(32) && reentrant_list_fence.IsRejected(33) &&
+            reentrant_move_future.Get().status == QueryStatus::Error,
+        "CommandList move assignment did not retain its reentrant generation"
+    );
+
+    QueryFenceProbe  drained_list_fence{};
+    QueryFenceProbe  reentrant_drain_fence{};
+    std::atomic<int> drain_callback_count{0};
+    std::atomic_bool drain_observed_signal{false};
+    std::atomic_bool drain_recorded_reentrant_query{false};
+    QueryFuture      reentrant_drain_future{};
+    CommandList      drained_list(EQueueType::Graphics);
+    drained_list.Signal(&drained_list_fence, 41);
+    QueryToken drained_token = drained_list.BeginTimestampQuery("DrainedList");
+    drained_list.EndTimestampQuery(drained_token);
+    drained_token.Then([&](const QueryResult& _result) {
+        drain_observed_signal.store(
+            _result.status == QueryStatus::Error && drained_list_fence.IsRejected(41),
+            std::memory_order_release
+        );
+        drained_list.Signal(&reentrant_drain_fence, 42);
+        QueryToken reentrant = drained_list.BeginTimestampQuery("ReentrantDrainQuery");
+        drained_list.EndTimestampQuery(reentrant);
+        reentrant_drain_future = reentrant.GetFuture();
+        drain_recorded_reentrant_query.store(true, std::memory_order_release);
+        drain_callback_count.fetch_add(1, std::memory_order_relaxed);
+    });
+
+    auto cleanup = drained_list.DrainOrdinaryCallbacksForRejection();
+    for (auto& callback : cleanup) {
+        callback();
+    }
+    Expect(
+        drain_observed_signal.load(std::memory_order_acquire) &&
+            drain_recorded_reentrant_query.load(std::memory_order_acquire) &&
+            drain_callback_count.load(std::memory_order_relaxed) == 1,
+        "rejection drain lost signal ordering or reentrant recording"
+    );
+    {
+        CmdSubmit preserved = drained_list.Submit();
+        Expect(
+            preserved.signal_events.size() == 1 && preserved.query_tokens.size() == 1,
+            "rejection drain cleared its reentrant Query/signal generation"
+        );
+        preserved.RejectPendingSignals();
+        preserved.RejectPendingQueries("test cleanup");
+    }
+    Expect(
+        reentrant_drain_fence.IsRejected(42) && reentrant_drain_future.Get().status == QueryStatus::Error,
+        "rejection drain did not retain its reentrant generation"
+    );
+}
+
+void MoveAndSubmitRetainIdentityAndLifetime() {
+    QueryFuture moved_future{};
+    CmdSubmit   moved_submit = CommandList(EQueueType::Graphics).Submit();
+    {
+        CommandList source(EQueueType::Graphics);
+        QueryToken  token = source.BeginTimestampQuery("MovedList");
+        moved_future      = token.GetFuture();
+
+        CommandList destination(std::move(source));
+        destination.EndTimestampQuery(token);
+        ExpectThrows<std::invalid_argument>(
+            [&] {
+                source.EndTimestampQuery(token);
+            },
+            "moved-from CommandList retained query ownership"
+        );
+
+        CmdSubmit sealed = destination.Submit();
+        Expect(sealed.query_tokens.size() == 1, "Submit lost its strong QueryToken owner");
+        moved_submit = std::move(sealed);
+        Expect(
+            moved_submit.query_tokens.size() == 1 && sealed.query_tokens.empty(),
+            "CmdSubmit move duplicated or dropped query ownership"
+        );
+    }
+    Expect(
+        moved_future.Status() == QueryStatus::Pending,
+        "CommandList/token destruction outlived the moved CmdSubmit owner"
+    );
+    Expect(
+        QueryBackendAccess::ResolveTimestamp(moved_submit.query_tokens.front(), TestTimestampResult()),
+        "moved CmdSubmit token could not be resolved"
+    );
+    for (auto& callback : moved_submit.callbacks) {
+        callback();
+    }
+    moved_submit.callbacks.clear();
+    moved_submit.query_tokens.clear();
+    Expect(moved_future.Get().status == QueryStatus::Ready, "moved query did not retain the Ready result");
+
+    QueryFuture overwritten_future{};
+    CmdSubmit   destination = CommandList(EQueueType::Graphics).Submit();
+    {
+        CommandList list(EQueueType::Graphics);
+        QueryToken  token = list.BeginTimestampQuery("OverwrittenSubmit");
+        list.EndTimestampQuery(token);
+        overwritten_future = token.GetFuture();
+        destination        = list.Submit();
+    }
+    destination = CommandList(EQueueType::Graphics).Submit();
+    Expect(
+        overwritten_future.Get().status == QueryStatus::Error,
+        "CmdSubmit move assignment left replaced query ownership Pending"
+    );
+}
+
+void CancellationViewIsStableAndGenerationScoped() {
+    CommandList           list(EQueueType::Graphics);
+    QueryCancellationView first_generation = list.GetQueryCancellationView();
+    Expect(first_generation.Valid(), "CommandList exposed an invalid cancellation view");
+
+    QueryToken existing = list.BeginTimestampQuery("BeforeCancel");
+    list.EndTimestampQuery(existing);
+    Expect(
+        first_generation.Cancel("recording source shutdown"),
+        "first cancellation did not win the generation transition"
+    );
+    Expect(!first_generation.Cancel("duplicate shutdown"), "cancellation domain was not one-shot");
+    Expect(
+        existing.GetFuture().Get().status == QueryStatus::Error,
+        "cancellation did not terminate an existing token"
+    );
+
+    QueryToken late = list.BeginTimestampQuery("AfterCancel");
+    Expect(
+        late.GetFuture().Status() == QueryStatus::Error,
+        "registration after cancellation did not fail immediately"
+    );
+    list.EndTimestampQuery(late);
+    CmdSubmit cancelled_submit = list.Submit();
+
+    QueryCancellationView second_generation = list.GetQueryCancellationView();
+    Expect(
+        second_generation.Valid() && !second_generation.IsCancelled(),
+        "Submit did not create an independent cancellation generation"
+    );
+    Expect(first_generation.IsCancelled(), "old cancellation view changed identity after Submit");
+
+    QueryToken next = list.BeginTimestampQuery("NextGeneration");
+    list.EndTimestampQuery(next);
+    Expect(
+        next.GetFuture().Status() == QueryStatus::Pending, "old cancellation leaked into the next generation"
+    );
+    Expect(
+        second_generation.Cancel("next generation shutdown"),
+        "new cancellation view could not cancel its own generation"
+    );
+    Expect(
+        next.GetFuture().Get().status == QueryStatus::Error,
+        "new generation cancellation left its token Pending"
+    );
+}
+
+} // namespace
+
+int main() {
+    static_assert(std::is_copy_constructible_v<QueryFuture>);
+    static_assert(std::is_copy_constructible_v<QueryToken>);
+    static_assert(std::is_nothrow_copy_constructible_v<QueryToken>);
+    static_assert(!std::is_copy_constructible_v<QueryCancellationDomain>);
+    static_assert(std::is_copy_constructible_v<QueryCancellationView>);
+
+    try {
+        FutureIsThreadSafeOneShotAndContainsCallbackExceptions();
+        ReadyAndErrorResolutionRaceHasOneWinner();
+        ReadyBatchPublishesEveryPeerBeforeNotification();
+        BulkErrorPathsPublishEveryPeerBeforeNotification();
+        LosingBatchCannotStealNotificationOwnership();
+        PublishWakesWaitersBeforeDeferredCallbackNotification();
+        CallbacksMayReleaseTheirLastQueryHandles();
+        PairingIsSameListSameKindAndStrictLifo();
+        InvalidSubmissionRejectionAndDestructionAreTerminal();
+        SignalRejectionPrecedesQueryCallbacksAndPreservesReentrantState();
+        MoveAndSubmitRetainIdentityAndLifetime();
+        CancellationViewIsStableAndGenerationScoped();
+    } catch (const std::exception& exception) {
+        std::cerr << "RHIQueryContract: " << exception.what() << '\n';
+        return 1;
+    }
+
+    std::cout << "RHIQueryContract: all checks passed\n";
+    return 0;
+}

--- a/source/test/RHIRecordDiagnosticsTest.cpp
+++ b/source/test/RHIRecordDiagnosticsTest.cpp
@@ -100,6 +100,18 @@ void CapabilityTableIsExplicitAndFailClosed() {
     Expect(serial_count > 0, "capability table has no serial fallback entries");
     Expect(candidate_count == 4, "unexpected Phase 9.0 candidate command count");
     Expect(safe_count == expected_parallel_safe.size(), "unexpected parallel-safe command count");
+    const CommandRecordTraits query_traits =
+        GetCommandRecordTraits(Command::EType::Query);
+    Expect(query_traits.stable_name == "Query", "query command has no stable trait entry");
+    Expect(
+        query_traits.capability == RecordCapability::SerialOnly &&
+            !query_traits.measurement_candidate,
+        "query command was exposed to parallel primary recording"
+    );
+    Expect(
+        query_traits.constraints == RecordConstraint::ProfilerOrScope,
+        "query command does not carry the profiler/query-state constraint"
+    );
     Expect(
         GetCommandRecordTraits(Command::EType::Count).capability == RecordCapability::SerialOnly,
         "invalid command type did not fail closed"
@@ -124,6 +136,8 @@ void ParallelReplayContractExcludesSideEffects() {
            "payload-mutating upload was marked replay safe");
     Expect(!IsParallelRecordReplaySafe(Command::EType::Scope),
            "profiler scope was marked replay safe");
+    Expect(!IsParallelRecordReplaySafe(Command::EType::Query),
+           "timestamp query was marked replay safe");
     Expect(!IsParallelRecordReplaySafe(Command::EType::Custom),
            "host callback command was marked replay safe");
 }

--- a/tools/threading/run_parallel_record_vulkan_test.py
+++ b/tools/threading/run_parallel_record_vulkan_test.py
@@ -830,10 +830,116 @@ def _require_phase15f_present_boundary(mode: str, text: str) -> None:
     )
 
 
+def _require_timestamp_query_success_batch(text: str) -> None:
+    marker = _testcase_marker(
+        "TimestampQuerySuccessfulBatchPublication", text
+    )
+    _require(
+        marker is not None and marker[0] == "PASS",
+        "timestamp-query-success-batch: missing successful batch PASS marker",
+    )
+    _, fields = marker
+    batch_sequence = fields.get("batch_sequence")
+    _require(
+        fields.get("sources") == "2"
+        and fields.get("queues") == "Graphics,Graphics"
+        and batch_sequence is not None
+        and batch_sequence.isdigit()
+        and int(batch_sequence) > 0
+        and fields.get("signals")
+        == "terminal_before_query_callbacks"
+        and fields.get("queries")
+        == "batch_published_before_notify"
+        and fields.get("cross_future_wait") == "ready"
+        and fields.get("owner") == "Completion"
+        and fields.get("query_callbacks") == "exactly_once"
+        and fields.get("ordinary_callbacks") == "exactly_once"
+        and fields.get("success_callbacks") == "exactly_once"
+        and fields.get("native_submit") == "2"
+        and fields.get("native_owner") == "Submission"
+        and fields.get("replay") == "0",
+        "timestamp-query-success-batch: incomplete batch publication contract",
+    )
+
+    cross_queue = _testcase_marker(
+        "TimestampQueryCrossQueueBatchPublication", text
+    )
+    _require(
+        cross_queue is not None,
+        "timestamp-query-success-batch: missing cross-queue batch marker",
+    )
+    cross_status, cross_fields = cross_queue
+    if cross_status == "SKIP":
+        _require(
+            cross_fields.get("reason") == "queue_unavailable",
+            "timestamp-query-success-batch: invalid cross-queue skip",
+        )
+    else:
+        _require(
+            cross_status == "PASS"
+            and cross_fields.get("sources") == "2"
+            and cross_fields.get("queues") == "Graphics,Compute"
+            and cross_fields.get("native_alias") in {"true", "false"}
+            and cross_fields.get("queries")
+            == "batch_published_before_notify"
+            and cross_fields.get("cross_future_wait") == "ready"
+            and cross_fields.get("owner") == "Completion"
+            and cross_fields.get("queue_local_sync")
+            == "blocked_until_group_settled"
+            and cross_fields.get("callbacks") == "exactly_once"
+            and cross_fields.get("replay") == "0",
+            "timestamp-query-success-batch: incomplete cross-queue settlement contract",
+        )
+
+    mixed_topology = _testcase_marker(
+        "TimestampQueryMixedMultiSegmentCallbackTiers", text
+    )
+    _require(
+        mixed_topology is not None and mixed_topology[0] == "PASS",
+        "timestamp-query-success-batch: missing mixed-topology PASS marker",
+    )
+    _, mixed_fields = mixed_topology
+    _require(
+        mixed_fields.get("original_sources") == "2"
+        and mixed_fields.get("executable_sources") == "3"
+        and mixed_fields.get("source0_segments") == "2"
+        and mixed_fields.get("source1_query") == "true"
+        and mixed_fields.get("order") == "Query,AllOrdinary,AllSuccess"
+        and mixed_fields.get("owner") == "Completion"
+        and mixed_fields.get("callbacks") == "exactly_once"
+        and mixed_fields.get("replay") == "0",
+        "timestamp-query-success-batch: incomplete mixed-topology callback-tier contract",
+    )
+
+    copy_only = _testcase_marker(
+        "TimestampQueryCopyOnlyPayloadArrival", text
+    )
+    _require(
+        copy_only is not None and copy_only[0] == "PASS",
+        "timestamp-query-success-batch: missing Copy query-only PASS marker",
+    )
+    _, copy_fields = copy_only
+    _require(
+        copy_fields.get("sources") == "2"
+        and copy_fields.get("queues") == "Graphics,Copy"
+        and copy_fields.get("copy_payload") == "query_only"
+        and copy_fields.get("copy_query") == "Error"
+        and copy_fields.get("group_arrival") == "verified"
+        and copy_fields.get("owner") == "Completion"
+        and copy_fields.get("callbacks") == "exactly_once"
+        and copy_fields.get("native_submit") == "2"
+        and copy_fields.get("replay") == "0",
+        "timestamp-query-success-batch: incomplete Copy query-only arrival contract",
+    )
+
+
 def validate_log(mode: str, text: str) -> None:
     _require("[TESTCASE][FAIL]" not in text, f"{mode}: test emitted a FAIL marker")
     _require("VUID-" not in text, f"{mode}: Vulkan validation VUID was emitted")
     _require("Validation Error" not in text, f"{mode}: Vulkan validation error was emitted")
+    if mode == "timestamp-query-success-batch":
+        _require_timestamp_query_success_batch(text)
+        return
     if mode == "rt-export-rejection":
         _require_rt_export_rejection(text)
         return
@@ -1127,6 +1233,8 @@ def run_case(executable: Path, outdir: Path, mode: str, timeout: float) -> Path:
         arguments.append("--present-hard")
     if mode == "rt-export-rejection":
         arguments.append("--rt-export-rejection")
+    if mode == "timestamp-query-success-batch":
+        arguments.append("--timestamp-query-success-batch")
 
     completed = subprocess.run(
         [str(executable), *arguments],
@@ -1182,6 +1290,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                 "present-boundary",
                 "present-hard",
                 "rt-export-rejection",
+                "timestamp-query-success-batch",
             )
         ]
     except (OSError, subprocess.TimeoutExpired, VulkanTestError) as error:

--- a/tools/threading/test_run_parallel_record_vulkan_test.py
+++ b/tools/threading/test_run_parallel_record_vulkan_test.py
@@ -181,6 +181,40 @@ def rt_export_rejection_line() -> str:
     )
 
 
+def timestamp_query_success_batch_line() -> str:
+    return (
+        "[TESTCASE][PASS] "
+        "name=TimestampQuerySuccessfulBatchPublication "
+        "sources=2 queues=Graphics,Graphics batch_sequence=7 "
+        "signals=terminal_before_query_callbacks "
+        "queries=batch_published_before_notify "
+        "cross_future_wait=ready owner=Completion "
+        "query_callbacks=exactly_once "
+        "ordinary_callbacks=exactly_once "
+        "success_callbacks=exactly_once "
+        "native_submit=2 native_owner=Submission replay=0\n"
+        "[TESTCASE][PASS] "
+        "name=TimestampQueryCrossQueueBatchPublication "
+        "sources=2 queues=Graphics,Compute native_alias=false "
+        "queries=batch_published_before_notify "
+        "cross_future_wait=ready owner=Completion "
+        "queue_local_sync=blocked_until_group_settled "
+        "callbacks=exactly_once replay=0\n"
+        "[TESTCASE][PASS] "
+        "name=TimestampQueryMixedMultiSegmentCallbackTiers "
+        "original_sources=2 executable_sources=3 "
+        "source0_segments=2 source1_query=true "
+        "order=Query,AllOrdinary,AllSuccess "
+        "owner=Completion callbacks=exactly_once replay=0\n"
+        "[TESTCASE][PASS] "
+        "name=TimestampQueryCopyOnlyPayloadArrival "
+        "sources=2 queues=Graphics,Copy "
+        "copy_payload=query_only copy_query=Error "
+        "group_arrival=verified owner=Completion "
+        "callbacks=exactly_once native_submit=2 replay=0\n"
+    )
+
+
 def pass_line(
     mode: str,
     fault: str,
@@ -966,6 +1000,11 @@ class VulkanRunnerTests(unittest.TestCase):
                 "--rt-export-rejection",
                 rt_export_rejection_line(),
             ),
+            (
+                "timestamp-query-success-batch",
+                "--timestamp-query-success-batch",
+                timestamp_query_success_batch_line(),
+            ),
         )
         with tempfile.TemporaryDirectory() as temporary_directory:
             for mode, expected_argument, output in cases:
@@ -994,6 +1033,59 @@ class VulkanRunnerTests(unittest.TestCase):
                             expected_argument,
                         ],
                     )
+
+    def test_timestamp_query_success_batch_contract_is_accepted(
+        self,
+    ) -> None:
+        runner.validate_log(
+            "timestamp-query-success-batch",
+            timestamp_query_success_batch_line(),
+        )
+
+    def test_timestamp_query_success_batch_rejects_partial_publication(
+        self,
+    ) -> None:
+        with self.assertRaisesRegex(
+            runner.VulkanTestError,
+            "incomplete batch publication contract",
+        ):
+            runner.validate_log(
+                "timestamp-query-success-batch",
+                timestamp_query_success_batch_line().replace(
+                    "queries=batch_published_before_notify",
+                    "queries=per_packet_notify",
+                ),
+            )
+
+    def test_timestamp_query_success_batch_rejects_early_queue_sync(
+        self,
+    ) -> None:
+        with self.assertRaisesRegex(
+            runner.VulkanTestError,
+            "incomplete cross-queue settlement contract",
+        ):
+            runner.validate_log(
+                "timestamp-query-success-batch",
+                timestamp_query_success_batch_line().replace(
+                    "queue_local_sync=blocked_until_group_settled",
+                    "queue_local_sync=returned_before_group_settled",
+                ),
+            )
+
+    def test_timestamp_query_success_batch_rejects_mixed_tier_inversion(
+        self,
+    ) -> None:
+        with self.assertRaisesRegex(
+            runner.VulkanTestError,
+            "incomplete mixed-topology callback-tier contract",
+        ):
+            runner.validate_log(
+                "timestamp-query-success-batch",
+                timestamp_query_success_batch_line().replace(
+                    "order=Query,AllOrdinary,AllSuccess",
+                    "order=Query,SuccessInsideOrdinary",
+                ),
+            )
 
     def test_rt_export_rejection_contract_is_accepted(self) -> None:
         runner.validate_log(


### PR DESCRIPTION
## What changed

- add backend-neutral timestamp `QueryToken` / `QueryFuture` APIs with wait, polling and exactly-once callbacks
- add Completion-owned query publication, cancellation sealing and callback notification
- implement allocator-local lazy/growing Vulkan timestamp query pools, readback and nanosecond conversion
- route Graphics/Compute/Copy Translate failures through terminal recorded packets and a pre-Completion batch publication hook
- keep recoverable rejection distinct from hard failure, prevent terminal Copy packet replay, and order Present receipts after same-batch Signals/Queries
- fail closed for unsupported D3D12 timestamps and multi-segment sources carrying Query commands
- add deterministic success, growth, preflight, preparation, mid-batch and native-record failure tests

## Why

`dev_parallel_rhi` had the desired generic GPU-query feature shape, but depended on its older global active-context/submission model. This ports the feature onto main's explicit Executor → Translate → Submission → Completion ownership architecture, while preserving stable serial native submission and exact failure retirement.

The critical race was that a current source could reach Completion before the failed suffix's Query states were published. A Query callback could then wait on a later Future and self-block the Completion owner. Batch admission tickets plus the Submission pre-Completion hook now publish the complete failure boundary before any related callback is released.

## Impact

Vulkan callers can issue timestamp queries as ordinary RHI commands and consume results asynchronously. Query sources form explicit serial recording islands; sibling sources retain parallel Translate. D3D12 returns a clear unsupported Query error without blocking ordinary work. Occlusion queries and cross-submit GPU event streams remain deferred.

## Validation

- affected Release targets: 3/3 built
- `MoerEditor` Release target built
- CTest: 19/19
- Python runner tests: 116/116
- Vulkan matrix: 12/12 modes, 159 PASS / 0 FAIL
- focused timestamp modes: 5 PASS / 0 FAIL, including 501 query pairs and deterministic record failure
- log gates: 0 VUID, SYNC-HAZARD, Validation Error, device lost, post-fault native submit or replay
- Vulkan + Raytracing editor smoke: ~45 seconds, responsive, no Query/Completion/Vulkan validation errors
- independent strict architecture and Query-lifetime reviews: no P0–P3 actionable findings

Full Windows `ALL_BUILD` remains outside this evidence because an unrelated GKlib/MSVC `-include /io.h` third-party issue is present; all feature-relevant targets above build successfully.