### PR TITLE
fix(raster): correct missing material GBuffer semantics

### DIFF
--- a/shaders/pipelines/raster/deferred/geometry/GeometryPassPixel.hlsl
+++ b/shaders/pipelines/raster/deferred/geometry/GeometryPassPixel.hlsl
@@ -14,6 +14,14 @@ BINDLESS_BINDINGS(3, 2, 4, 5)
 
 [[vk::push_constant]] ConstantBuffer<Moer::GeometryPassBindlessParam> param;
 
+float SampleMaterialAlpha(Moer::GMaterial mat, float2 uv_in_map) {
+    const int albedo_map_hdl = int(mat.albedo_map_hdl);
+    if (albedo_map_hdl > 0) {
+        return TextureHandle(albedo_map_hdl).Sample2D<float4>(uv_in_map).a * mat.albedo_factor.a;
+    }
+    return mat.albedo_factor.a;
+}
+
 void DiscardByAlphaTest(uint material_id, float2 uv_in_map) {
     if (param.enable_alpha_test == 0) {
         return;
@@ -25,13 +33,13 @@ void DiscardByAlphaTest(uint material_id, float2 uv_in_map) {
 
     // 是否需要discard该像素（AlphaMode为BLEND或MASK时，需要进行discard）
     if (mat.alpha_mode == Moer::EAlphaMode::Mask) {
-        float alpha = TextureHandle(mat.albedo_map_hdl).Sample2D<float4>(uv_in_map).a * mat.albedo_factor.a;
+        float alpha = SampleMaterialAlpha(mat, uv_in_map);
         // printf("MASK: alpha: %f, cutoff: %f, albedo_map.a: %f, base_color.a: %f\n", alpha, mat.alpha_cutoff, TextureHandle(mat.albedo_map).Sample2D<float4>(uv_in_map).a, mat.base_color_factor.a);
         if (alpha < mat.alpha_cutoff) {
             discard;
         }
     } else if (mat.alpha_mode == Moer::EAlphaMode::Blend) {
-        float alpha = TextureHandle(mat.albedo_map_hdl).Sample2D<float4>(uv_in_map).a * mat.albedo_factor.a;
+        float alpha = SampleMaterialAlpha(mat, uv_in_map);
         // printf("BLEND: alpha: %f; albedo_map.a: %f; base_color.a: %f\n", alpha, TextureHandle(mat.albedo_map).Sample2D<float4>(uv_in_map).a, mat.base_color_factor.a);
         if (alpha < param.alpha_test_blend_pixel_cutoff) {
             discard;
@@ -79,7 +87,7 @@ PsOutput main(VsOutput input) : SV_TARGET {
     // Debug 可视化模式（debug_visualization_mode: 0=off, 1=Cluster ID, 2=frac(UV), 3=顶点法线）
     if (param.debug_visualization_mode > 0) {
         PsOutput output;
-        output.metal_rough_ao = float4(0.0, 0.5, 1.0, 0.0);
+        output.metal_rough_ao = float4(0.0, 0.5, 1.0, 1.0);
 
         if (param.debug_visualization_mode == 1) {
             output.base_color = float4(ClusterIdToColor(input.primitive_id), 1.0);
@@ -102,13 +110,13 @@ PsOutput main(VsOutput input) : SV_TARGET {
         mat.albedo_map_hdl,
         input.texcoord0,
         mat.albedo_factor.xyz,
-        MISSING_TEXTURE_COLOR
+        float3(1.0, 1.0, 1.0)
     );
     float2 metallic_roughness = SampleTextureAndApplyFactor(
         mat.metallic_roughness_map_hdl,
         input.texcoord0,
         float2(mat.metallic_factor, mat.roughness_factor),
-        float2(mat.metallic_factor, mat.roughness_factor)
+        float2(1.0, 1.0)
     );
     float material_ao = SampleTextureAndApplyFactor(mat.ao_map_hdl, input.texcoord0, 1.0, 1.0);
     float3 shading_normal = GetNormalFromNormalMap(
@@ -119,9 +127,9 @@ PsOutput main(VsOutput input) : SV_TARGET {
     );
 
     PsOutput output;
-    output.base_color = float4(base_color, 0.0);
+    output.base_color = float4(base_color, 1.0);
     output.normal = float4(Raster::PackNormal(shading_normal), 1.0);
-    output.metal_rough_ao = float4(metallic_roughness, material_ao, 0.0);
+    output.metal_rough_ao = float4(metallic_roughness.x, metallic_roughness.y, material_ao, 1.0);
 
     return output;
 }

--- a/shaders/pipelines/raster/deferred/geometry/TessellatedSurface.hlsl
+++ b/shaders/pipelines/raster/deferred/geometry/TessellatedSurface.hlsl
@@ -294,8 +294,8 @@ SurfacePixelOutput SurfacePS(SurfaceDomainOutput input) {
     }
 
     SurfacePixelOutput output;
-    output.base_color = float4(surface_color, 0.0);
+    output.base_color = float4(surface_color, 1.0);
     output.normal = float4(Raster::PackNormal(normal), 1.0);
-    output.metal_rough_ao = float4(0.0, surface_data.color_low_roughness.w, 1.0, 0.0);
+    output.metal_rough_ao = float4(0.0, surface_data.color_low_roughness.w, 1.0, 1.0);
     return output;
 }


### PR DESCRIPTION
## Summary

- use identity samples for missing BaseColor and Metallic/Roughness textures so material factors are applied exactly once
- make alpha-tested materials without an albedo texture fall back to `albedo_factor.a` instead of sampling an invalid bindless descriptor
- keep all displayable GBuffer writers opaque, including main-only debug and tessellated-surface paths

## Root cause

`SampleTextureAndApplyFactor` multiplies its selected sample by the material factor. Passing the factor itself as the missing Metallic/Roughness sample produced factor squared. In addition, material texture sentinels are stored in unsigned shared fields, so unconditional alpha sampling could turn `-1` into an invalid large descriptor index.

## Validation

- VS2022 Debug `MoerEditor` build
- GeometryPassPixel DXC preprocessing
- TessellatedSurface VS/HS/DS/PS DXC 1.9 SPIR-V compilation
- Raster linear `base_color` framebuffer runtime smoke: nonblack 0.9918, clean exit, no VUID/assert/device-lost
- Raster RDG + Render/RHI threads + parallel recording runtime smoke: nonblack 0.9918, clean exit, no fallback/VUID/assert/device-lost