### PR TITLE
Raster: decouple SceneColor render extent

### DIFF
--- a/shaders/pipelines/postprocess/denoise/RtaoDenoiser.hlsl
+++ b/shaders/pipelines/postprocess/denoise/RtaoDenoiser.hlsl
@@ -48,7 +48,8 @@ float get_motion_history_scale(float2 motion_vector_uv) {
 }
 
 void get_reprojected_ao(float2 uv, float curr_ao, out float out_history_ao, out float out_history_weight) {
-    out_history_ao = curr_ao;
+    out_history_ao     = curr_ao;
+    out_history_weight = param.history_ratio;
 
     float2 motion_vector_ndc =
         TextureHandle(param.motion_vector_tex).Sample2D<float2>(uv).rg; // value in [-1, 1] (NDC Space)

--- a/source/runtime/render/renderer/SceneRenderExtent.h
+++ b/source/runtime/render/renderer/SceneRenderExtent.h
@@ -1,0 +1,147 @@
+#pragma once
+
+#include "misc/Traits.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <limits>
+
+namespace Moer::Render {
+
+// Raster bloom currently owns six explicit mip levels. Keeping the native
+// scene extent at least 32 pixels makes that fixed chain valid while a docked
+// SceneColor viewport is being collapsed or resized.
+inline constexpr uint k_min_scene_render_extent = 32u;
+inline constexpr uint8_t k_scene_render_extent_stable_observations = 2u;
+
+struct SceneRenderExtentRequest {
+    uint2 extent{};
+    bool  valid     = false;
+    bool  immediate = false;
+};
+
+[[nodiscard]] inline bool IsValidRenderExtent(uint2 extent) noexcept {
+    return extent.x > 0u && extent.y > 0u;
+}
+
+[[nodiscard]] inline bool EqualRenderExtent(uint2 lhs, uint2 rhs) noexcept {
+    return lhs.x == rhs.x && lhs.y == rhs.y;
+}
+
+[[nodiscard]] inline uint2 NormalizeSceneRenderExtent(uint2 extent) noexcept {
+    return uint2(
+        std::max(k_min_scene_render_extent, extent.x),
+        std::max(k_min_scene_render_extent, extent.y)
+    );
+}
+
+[[nodiscard]] inline SceneRenderExtentRequest CaptureSceneRenderExtentRequest(
+    bool   ui_composition_enabled,
+    float2 scene_color_resolution,
+    uint2  window_extent
+) noexcept {
+    if (!ui_composition_enabled) {
+        if (!IsValidRenderExtent(window_extent)) {
+            return {};
+        }
+        return SceneRenderExtentRequest{
+            .extent    = NormalizeSceneRenderExtent(window_extent),
+            .valid     = true,
+            .immediate = true
+        };
+    }
+
+    if (!std::isfinite(scene_color_resolution.x) || !std::isfinite(scene_color_resolution.y) ||
+        scene_color_resolution.x <= 0.f || scene_color_resolution.y <= 0.f) {
+        return {};
+    }
+
+    const auto quantize = [](float value) noexcept {
+        const double bounded = std::min(
+            static_cast<double>(value),
+            static_cast<double>(std::numeric_limits<uint>::max())
+        );
+        return std::max(k_min_scene_render_extent, static_cast<uint>(bounded));
+    };
+
+    return SceneRenderExtentRequest{
+        .extent    = uint2(quantize(scene_color_resolution.x), quantize(scene_color_resolution.y)),
+        .valid     = true,
+        .immediate = false
+    };
+}
+
+// Render-thread-owned admission policy for UI-driven native render extents.
+// Invalid (including 0x0) requests retain the last allocated extent. Docked UI
+// changes must remain stable for two observations so a drag does not allocate
+// a full render target set for every intermediate pixel. Headless/UI-disabled
+// window extents are accepted immediately.
+class SceneRenderExtentTracker {
+public:
+    explicit SceneRenderExtentTracker(uint2 initial_extent) noexcept :
+        active_extent(
+            NormalizeSceneRenderExtent(
+                IsValidRenderExtent(initial_extent) ?
+                    initial_extent :
+                    uint2(k_min_scene_render_extent, k_min_scene_render_extent)
+            )
+        ) {}
+
+    [[nodiscard]] bool Observe(SceneRenderExtentRequest request) noexcept {
+        if (!request.valid || !IsValidRenderExtent(request.extent)) {
+            ClearPending();
+            return false;
+        }
+
+        request.extent = NormalizeSceneRenderExtent(request.extent);
+        if (EqualRenderExtent(request.extent, active_extent)) {
+            ClearPending();
+            return false;
+        }
+
+        if (request.immediate) {
+            active_extent = request.extent;
+            ClearPending();
+            return true;
+        }
+
+        if (!pending_valid || !EqualRenderExtent(request.extent, pending_extent)) {
+            pending_extent       = request.extent;
+            pending_observations = 1u;
+            pending_valid        = true;
+            return false;
+        }
+
+        pending_observations++;
+        if (pending_observations < k_scene_render_extent_stable_observations) {
+            return false;
+        }
+
+        active_extent = pending_extent;
+        ClearPending();
+        return true;
+    }
+
+    [[nodiscard]] uint2 GetActiveExtent() const noexcept {
+        return active_extent;
+    }
+
+    [[nodiscard]] bool HasPendingExtent() const noexcept {
+        return pending_valid;
+    }
+
+private:
+    void ClearPending() noexcept {
+        pending_extent       = uint2(0u, 0u);
+        pending_observations = 0u;
+        pending_valid        = false;
+    }
+
+    uint2   active_extent{};
+    uint2   pending_extent{};
+    uint8_t pending_observations = 0u;
+    bool    pending_valid        = false;
+};
+
+} // namespace Moer::Render

--- a/source/runtime/render/renderer/raster/AaPass.h
+++ b/source/runtime/render/renderer/raster/AaPass.h
@@ -194,9 +194,23 @@ public:
         // Other resources initialization
         aa_texture_34[0] = &tex.aa_texture_3;
         aa_texture_34[1] = &tex.aa_texture_4;
-        frame_parity     = 0;
+        ResetHistory();
 
         LoadSmaaResources(context);
+    }
+
+    void ResetHistory() {
+        frame_parity          = 0;
+        history_valid         = false;
+        current_view_proj     = Matrix4x4f::Identity();
+        previous_view_proj    = Matrix4x4f::Identity();
+        current_inv_view_proj = Matrix4x4f::Identity();
+    }
+
+    [[nodiscard]] uint8 NextSmaaT2xPhase() const noexcept {
+        return history_valid ?
+                   static_cast<uint8>(frame_parity ^ 1u) :
+                   0u;
     }
 
     void LoadSmaaResources(RasterContext& context) {
@@ -238,15 +252,26 @@ public:
         RasterContext&      context,
         const RasterConfig& ui_config,
         const Camera&       camera,
-        TextureWithHandle   input_image
+        TextureWithHandle   input_image,
+        uint8               smaa_t2x_phase
     ) {
+        if (ui_config.aa_mode != EAaMode::SMAA_T2X && history_valid) {
+            ResetHistory();
+        }
+
         if (ui_config.aa_mode == EAaMode::NONE || ui_config.aa_mode == EAaMode::FXAA_SIMPLIFIED ||
             ui_config.aa_mode == EAaMode::FXAA_QUALITY) {
             return ProcessFxaa(context, ui_config, camera, input_image);
         }
 
         if (ui_config.aa_mode == EAaMode::SMAA_1X || ui_config.aa_mode == EAaMode::SMAA_T2X) {
-            return ProcessSmaa(context, ui_config, camera, input_image);
+            return ProcessSmaa(
+                context,
+                ui_config,
+                camera,
+                input_image,
+                smaa_t2x_phase
+            );
         }
 
         assert(false && "Invalid antialiasing mode");
@@ -291,7 +316,8 @@ public:
         RasterContext&      context,
         const RasterConfig& ui_config,
         const Camera&       camera,
-        TextureWithHandle   input_image
+        TextureWithHandle   input_image,
+        uint8               smaa_t2x_phase
     ) {
         // TODO: optimize the following code
         //           以下是我会写出这段代码的原因：
@@ -316,15 +342,17 @@ public:
             // return sampler_idx;
         };
 
-        static Matrix4x4f current_view_proj     = Matrix4x4f::Identity();
-        static Matrix4x4f previous_view_proj    = Matrix4x4f::Identity();
-        static Matrix4x4f current_inv_view_proj = Matrix4x4f::Identity();
-
-        previous_view_proj    = current_view_proj;
+        const bool uses_temporal_history =
+            ui_config.aa_mode == EAaMode::SMAA_T2X;
+        const bool had_valid_history =
+            uses_temporal_history && history_valid;
+        previous_view_proj =
+            had_valid_history ? current_view_proj : camera.GetViewProjectionMatrix();
         current_view_proj     = camera.GetViewProjectionMatrix();
         current_inv_view_proj = camera.GetViewProjectionMatrixInv();
-
-        frame_parity ^= 1;
+        frame_parity = uses_temporal_history ? smaa_t2x_phase : 0u;
+        assert(frame_parity < aa_texture_34.size());
+        history_valid = uses_temporal_history;
 
         auto smaa_shared_param = [&]() {
             SmaaSharedPipelineBindlessParam param;
@@ -337,7 +365,10 @@ public:
             param.edges_tex          = context.textures.aa_texture_1.hdl;
             param.blend_tex          = context.textures.aa_texture_2.hdl;
             param.current_color_tex  = aa_texture_34[frame_parity]->hdl;
-            param.previous_color_tex = aa_texture_34[frame_parity ^ 1]->hdl;
+            param.previous_color_tex =
+                aa_texture_34[
+                    had_valid_history ? static_cast<uint8>(frame_parity ^ 1u) : frame_parity
+                ]->hdl;
             param.frame_index        = frame_parity;
             param.point_sampler      = GetSamplerIdx(Sampler(SF_NEAREST, SAM_CLAMP_TO_EDGE));
             param.linear_sampler     = GetSamplerIdx(Sampler(SF_LINEAR, SAM_CLAMP_TO_EDGE));
@@ -409,6 +440,10 @@ private:
     // smaa resources
     StaticArray<TextureWithHandle*, 2> aa_texture_34;
     uint8                              frame_parity = 0;
+    bool                               history_valid = false;
+    Matrix4x4f                         current_view_proj = Matrix4x4f::Identity();
+    Matrix4x4f                         previous_view_proj = Matrix4x4f::Identity();
+    Matrix4x4f                         current_inv_view_proj = Matrix4x4f::Identity();
 
     TextureWithHandle smaa_area_tex;
     TextureWithHandle smaa_search_tex;

--- a/source/runtime/render/renderer/raster/AssetTool.h
+++ b/source/runtime/render/renderer/raster/AssetTool.h
@@ -37,6 +37,7 @@ struct TexConfig {
     bool        is_asset           = false;
     bool        b_create_mip_views = false;
     bool        b_downsampled      = false;
+    bool        b_output_size      = false;
 
     //为Depth设计，共用一张纹理
     template<typename T>
@@ -109,6 +110,11 @@ struct TexConfig {
 
     TexConfig& DownSampled(bool b = true) {
         b_downsampled = b;
+        return *this;
+    }
+
+    TexConfig& OutputSize(bool b = true) {
+        b_output_size = b;
         return *this;
     }
 

--- a/source/runtime/render/renderer/raster/RasterFramePacket.h
+++ b/source/runtime/render/renderer/raster/RasterFramePacket.h
@@ -3,6 +3,7 @@
 #include "RasterConfig.h"
 #include "renderer/EditorConfig.h"
 #include "renderer/Renderer.h"
+#include "renderer/SceneRenderExtent.h"
 #include "scene/Scene.h"
 #include "scene/camera/Camera.h"
 
@@ -21,6 +22,7 @@ struct RasterFramePacket {
     SceneViewGizmoConfig       scene_view_gizmos{};
     Camera                     render_camera{};
     uint2                      camera_viewport_resolution{};
+    SceneRenderExtentRequest   scene_render_extent{};
     UiCompositionFrameData     ui_composition{};
     UiDrawFramePacket          ui_draw_frame{};
     SceneUpdateBatch           scene_updates{};

--- a/source/runtime/render/renderer/raster/RasterRenderer.cpp
+++ b/source/runtime/render/renderer/raster/RasterRenderer.cpp
@@ -59,7 +59,8 @@ RasterRenderer::RasterRenderer(
     uint2                   initial_resolution,
     SharedPtr<EditorConfig> config
 ) :
-    Renderer(initial_resolution, config) {
+    Renderer(initial_resolution, config),
+    scene_render_extent_tracker(initial_resolution) {
     ScopedLogTimer startup_timer("[Startup][RasterRenderer] RasterRenderer::Constructor() total");
 
     const auto& engine_config = ConfigManager::GetInstance().GetConfig().engine;
@@ -84,7 +85,7 @@ RasterRenderer::RasterRenderer(
     );
     auto& raster_context = *raster_context_ptr;
 
-    raster_context.CreateFrameBuffers();
+    raster_context.CreateFrameBuffers(resolution, resolution);
     raster_context.UploadExternalFrameBuffers();
     raster_context.AllocateFrameBuffers();
 
@@ -422,6 +423,11 @@ RasterRenderer::PrepareFrame(const SharedPtr<EditorConfig> editor_config, const 
         if (hooks.on_capture_ui_composition) {
             frame_packet.ui_composition = hooks.on_capture_ui_composition();
         }
+        frame_packet.scene_render_extent = CaptureSceneRenderExtentRequest(
+            frame_packet.ui_composition.enabled,
+            frame_packet.ui_composition.scene_color_resolution,
+            frame_packet.window.resolution
+        );
     }
     {
         ScopedFramePrepareProfileTimer timer(profile_logging, prepare_profile.ui_draw_packet_ms);
@@ -450,7 +456,14 @@ RasterFrameFeedback RasterRenderer::RenderFrame(RasterFramePacket frame_packet) 
     assert(!IsRenderThreadInitialized() || IsCurrentlyRenderThread());
 
     auto& raster_context = *raster_context_ptr;
-    raster_context.SetResolution(frame_packet.window.resolution);
+    auto scene_extent_request = frame_packet.scene_render_extent;
+    // An OS-window resize already requires a presentation rebuild. Accept the
+    // matching SceneColor layout immediately so the two resource domains move
+    // together; dock-only drags retain the two-observation debounce.
+    if (frame_packet.window.state == EWindowState::SizeChanged && scene_extent_request.valid) {
+        scene_extent_request.immediate = true;
+    }
+    (void)scene_render_extent_tracker.Observe(scene_extent_request);
     raster_context.BeginSceneFrame(frame_packet.scene_updates);
     PrepareRenderFrame(frame_packet.window);
 
@@ -470,29 +483,72 @@ RasterFrameFeedback RasterRenderer::RenderFrame(RasterFramePacket frame_packet) 
         // 窗口最小化后无法 present，此处主动让出线程，避免高频空转。
         std::this_thread::yield();
         skip_present = true;
+    } else {
+        assert(
+            frame_packet.window.state == EWindowState::Default ||
+            frame_packet.window.state == EWindowState::SizeChanged
+        );
+    }
 
-    } else if (frame_packet.window.state == EWindowState::SizeChanged) {
-        LOG_INFO("Size Changed.");
+    const uint2 active_scene_extent = scene_render_extent_tracker.GetActiveExtent();
+    const bool  recreate_scene_resources =
+        !EqualRenderExtent(raster_context.GetResolution(), active_scene_extent);
+    const bool recreate_output_resources =
+        !EqualRenderExtent(raster_context.GetOutputResolution(), frame_packet.window.resolution);
 
-        raster_context.FreeFrameBuffers(false);
-        raster_context.CreateFrameBuffers();
-        // 外部纹理与分辨率无关，窗口尺寸变化后仍然有效。
-        raster_context.AllocateFrameBuffers();
+    if (!skip_present && (recreate_scene_resources || recreate_output_resources)) {
+        raster_context.FreeFrameBuffers(
+            false, recreate_scene_resources, recreate_output_resources
+        );
+        raster_context.CreateFrameBuffers(
+            active_scene_extent,
+            frame_packet.window.resolution,
+            recreate_scene_resources,
+            recreate_output_resources
+        );
+        // External assets are resolution-independent and retain their bindless
+        // handles. Only the selected resource domains are allocated again.
+        raster_context.AllocateFrameBuffers(
+            recreate_scene_resources, recreate_output_resources
+        );
+
+        if (recreate_scene_resources) {
+            raster_context.csm_data.shadow_cache_config_snapshot_valid = false;
+            aa_pass->ResetHistory();
+            rtao_denoiser_pass->ResetHistory();
 
 #if WITH_CUDA
-        tensor_rt_pass->RecreateResource(
-            raster_context,
-            raster_context.textures.ao_output_ambient_only.tex,
-            raster_context.textures.depth_linear_sampler.tex->CastToTextureRef(),
-            // 下面这个color，需要传入lighting_output，而非ao_output，因为模型的输入需要不带ao的color
-            raster_context.textures.lighting_output.tex,
-            raster_context.textures.camera_motion_vector.tex,
-            raster_context.textures.ao_output_ambient_only_1.tex
-        );
+            cuda_pass->RecreateResource(raster_context.textures.ao_output.tex);
+            tensor_rt_pass->RecreateResource(
+                raster_context,
+                raster_context.textures.ao_output_ambient_only.tex,
+                raster_context.textures.depth_linear_sampler.tex->CastToTextureRef(),
+                raster_context.textures.lighting_output.tex,
+                raster_context.textures.camera_motion_vector.tex,
+                raster_context.textures.ao_output_ambient_only_1.tex
+            );
 #endif
+        }
 
-    } else {
-        assert(frame_packet.window.state == EWindowState::Default);
+        render_extent_generation++;
+        LOG_INFO(
+            "[RenderExtent][Raster] generation={} requested={}x{} request_valid={} "
+            "active_scene={}x{} presentation_output={}x{} swapchain={}x{} "
+            "scene_recreated={} output_recreated={} temporal_history_reset={}.",
+            render_extent_generation,
+            frame_packet.scene_render_extent.extent.x,
+            frame_packet.scene_render_extent.extent.y,
+            frame_packet.scene_render_extent.valid,
+            raster_context.GetResolution().x,
+            raster_context.GetResolution().y,
+            raster_context.GetOutputResolution().x,
+            raster_context.GetOutputResolution().y,
+            swapchain->size.x,
+            swapchain->size.y,
+            recreate_scene_resources,
+            recreate_output_resources,
+            recreate_scene_resources
+        );
     }
 
     TextureRef default_output_texture = raster_context.textures.output.tex;
@@ -536,21 +592,22 @@ RasterFrameFeedback RasterRenderer::RenderFrame(RasterFramePacket frame_packet) 
 
         const Camera& main_camera = scene_updates.main_camera;
         Camera        camera      = frame_packet.render_camera;
+        const uint8 smaa_t2x_phase =
+            raster_config.aa_mode == EAaMode::SMAA_T2X ?
+                aa_pass->NextSmaaT2xPhase() :
+                0u;
 
         {
             // 在不修改已捕获相机的前提下，交替使用两个 SMAA T2x 亚像素偏移。
-            static uint8_t s_smaa_frame_index = 0;
             if (raster_config.aa_mode == EAaMode::SMAA_T2X) {
-                s_smaa_frame_index ^= 1;
                 static const StaticArray<float2, 2> s_smaa_jitter_offsets = {
                     float2(0.25f, -0.25f),
                     float2(-0.25f, 0.25f)
                 };
-                const uint2 jitter_resolution = frame_packet.camera_viewport_resolution.x > 0 &&
-                                                        frame_packet.camera_viewport_resolution.y > 0 ?
-                                                    frame_packet.camera_viewport_resolution :
-                                                    frame_packet.window.resolution;
-                camera.SetJitterMatrix(s_smaa_jitter_offsets[s_smaa_frame_index], jitter_resolution);
+                camera.SetJitterMatrix(
+                    s_smaa_jitter_offsets[smaa_t2x_phase],
+                    raster_context.GetResolution()
+                );
             }
         }
 
@@ -992,8 +1049,13 @@ RasterFrameFeedback RasterRenderer::RenderFrame(RasterFramePacket frame_packet) 
                         .Write(graph_resources.aa_output);
                 },
                 [&]() {
-                    processing_image =
-                        aa_pass->Process(raster_context, raster_config, camera, processing_image);
+                    processing_image = aa_pass->Process(
+                        raster_context,
+                        raster_config,
+                        camera,
+                        processing_image,
+                        smaa_t2x_phase
+                    );
                 }
             );
             schedule(

--- a/source/runtime/render/renderer/raster/RasterRenderer.h
+++ b/source/runtime/render/renderer/raster/RasterRenderer.h
@@ -102,6 +102,9 @@ private:
     bool   capture_scene_geometry_snapshot = true;
 
     uint64_t next_frame_id = 0;
+    uint64_t render_extent_generation = 0;
+
+    SceneRenderExtentTracker scene_render_extent_tracker;
 
     bool                            render_graph_enabled = false;
     bool                            render_graph_debug_dump = false;

--- a/source/runtime/render/renderer/raster/RasterResource.h
+++ b/source/runtime/render/renderer/raster/RasterResource.h
@@ -50,8 +50,12 @@ public:
 
     float frame_time;
 
-    uint2 GetResolution() {
-        return uint2(resolution.x, resolution.y);
+    uint2 GetResolution() const {
+        return scene_resolution;
+    }
+
+    uint2 GetOutputResolution() const {
+        return output_resolution;
     }
 
     // MARK: Hold ownership
@@ -173,7 +177,8 @@ private:
         });
     }
 
-    uint2 resolution;
+    uint2 scene_resolution;
+    uint2 output_resolution;
 
 public:
     // Constructor
@@ -184,7 +189,7 @@ public:
         BindlessArrayRef bdls,
         CommandList&     cmd_list,
         RenderScene&     render_scene,
-        uint2            resolution
+        uint2            initial_resolution
     ) :
         device(device),
         manager(manager),
@@ -192,7 +197,8 @@ public:
         bdls(bdls),
         cmd_list(cmd_list),
         render_scene(render_scene),
-        resolution(resolution) {
+        scene_resolution(initial_resolution),
+        output_resolution(initial_resolution) {
 
         // textures
         textures = RasterTextures{};
@@ -204,10 +210,6 @@ public:
 
     void Update(float delta_time) {
         frame_time = delta_time;
-    }
-
-    void SetResolution(uint2 new_resolution) {
-        resolution = new_resolution;
     }
 
     void BeginSceneFrame(const SceneUpdateBatch& updates) {
@@ -237,10 +239,28 @@ public:
 
     // MARK: Frame Buffers
 
-    void CreateFrameBuffers() {
-        textures.CreateFrameBuffers(device, resolution);
-        hiz_data.previous_valid = false;
-        hiz_data.mip_count      = textures.hiz_current.tex ? textures.hiz_current.tex->GetNumMips() : 0;
+    void CreateFrameBuffers(
+        uint2 new_scene_resolution,
+        uint2 new_output_resolution,
+        bool  create_scene_resources = true,
+        bool  create_output_resources = true
+    ) {
+        textures.CreateFrameBuffers(
+            device,
+            new_scene_resolution,
+            new_output_resolution,
+            create_scene_resources,
+            create_output_resources
+        );
+        if (create_scene_resources) {
+            scene_resolution       = new_scene_resolution;
+            hiz_data.previous_valid = false;
+            hiz_data.mip_count =
+                textures.hiz_current.tex ? textures.hiz_current.tex->GetNumMips() : 0;
+        }
+        if (create_output_resources) {
+            output_resolution = new_output_resolution;
+        }
     }
 
     //功能：加载外部纹理并在这一步Create它们的buffer
@@ -248,14 +268,27 @@ public:
         textures.LoadAndUploadAssets(device, cmd_list);
     }
 
-    void AllocateFrameBuffers() {
-        textures.AllocateFrameBuffers(cmd_list, bdls);
+    void AllocateFrameBuffers(
+        bool allocate_scene_resources = true,
+        bool allocate_output_resources = true
+    ) {
+        textures.AllocateFrameBuffers(
+            cmd_list, bdls, allocate_scene_resources, allocate_output_resources
+        );
     }
 
-    void FreeFrameBuffers(bool is_free_external_assets) {
-        textures.FreeFrameBuffers(bdls, is_free_external_assets);
-        hiz_data.previous_valid = false;
-        hiz_data.mip_count      = 0;
+    void FreeFrameBuffers(
+        bool is_free_external_assets,
+        bool free_scene_resources = true,
+        bool free_output_resources = true
+    ) {
+        textures.FreeFrameBuffers(
+            bdls, is_free_external_assets, free_scene_resources, free_output_resources
+        );
+        if (free_scene_resources) {
+            hiz_data.previous_valid = false;
+            hiz_data.mip_count      = 0;
+        }
     }
 
     void InvalidateHiZHistory() {

--- a/source/runtime/render/renderer/raster/RasterTextures.h
+++ b/source/runtime/render/renderer/raster/RasterTextures.h
@@ -54,7 +54,8 @@ namespace Moer::Render::Raster {
       output,                                                                                                   \
       Tex2DTag,                                                                                                 \
       TexConfig::Default(PF_R8G8B8A8_SRGB)                                                                      \
-          .Usage(E_SAMPLED_COLOR | ETextureUsageFlags::TRANSFER_SRC | ETextureUsageFlags::TRANSFER_DST))        \
+          .Usage(E_SAMPLED_COLOR | ETextureUsageFlags::TRANSFER_SRC | ETextureUsageFlags::TRANSFER_DST)         \
+          .OutputSize())                                                                                        \
     X(DepthBufferWithHandle,                                                                                    \
       depth_linear_sampler,                                                                                     \
       TexDepthTag,                                                                                              \
@@ -160,20 +161,32 @@ struct RasterTextures {
         return cfg;
     }
 
-    void CreateFrameBuffers(RenderDevice& device, const uint2& size) {
+    void CreateFrameBuffers(
+        RenderDevice& device,
+        const uint2&  scene_size,
+        const uint2&  output_size,
+        bool          create_scene_resources = true,
+        bool          create_output_resources = true
+    ) {
         // Full-resolution textures
-#define X(TYPE, NAME, TEXTYPE, CONFIG)                                                  \
-    {                                                                                   \
-        TexConfig cfg = (CONFIG);                                                       \
-        AssetTool::CreateRasterResource<TEXTYPE>(this->NAME, device, #NAME, size, cfg); \
+#define X(TYPE, NAME, TEXTYPE, CONFIG)                                                        \
+    {                                                                                         \
+        TexConfig cfg = (CONFIG);                                                             \
+        const bool create_resource =                                                          \
+            cfg.b_output_size ? create_output_resources : create_scene_resources;             \
+        if (create_resource) {                                                                 \
+            const uint2& texture_size = cfg.b_output_size ? output_size : scene_size;          \
+            AssetTool::CreateRasterResource<TEXTYPE>(this->NAME, device, #NAME, texture_size, cfg); \
+        }                                                                                     \
     }
         RASTER_TEXTURES_TABLE
         RASTER_TEXTURES_TABLE_DOWNSAMPLED
 #undef X
 
         // Half-resolution variants
-        {
-            uint2 half_size = uint2(std::max(1u, size.x / 2), std::max(1u, size.y / 2));
+        if (create_scene_resources) {
+            uint2 half_size =
+                uint2(std::max(1u, scene_size.x / 2), std::max(1u, scene_size.y / 2));
 #define X(TYPE, NAME, TEXTYPE, CONFIG)                                                                    \
     {                                                                                                     \
         TexConfig cfg = (CONFIG);                                                                         \
@@ -183,11 +196,13 @@ struct RasterTextures {
 #undef X
         }
 
-        {
-            TexConfig hiz_cfg = CreateHiZConfig(size);
-            AssetTool::CreateRasterResource<Tex2DTag>(hiz_current, device, "hiz_current", size, hiz_cfg, false);
+        if (create_scene_resources) {
+            TexConfig hiz_cfg = CreateHiZConfig(scene_size);
             AssetTool::CreateRasterResource<Tex2DTag>(
-                hiz_previous, device, "hiz_previous", size, hiz_cfg, false
+                hiz_current, device, "hiz_current", scene_size, hiz_cfg, false
+            );
+            AssetTool::CreateRasterResource<Tex2DTag>(
+                hiz_previous, device, "hiz_previous", scene_size, hiz_cfg, false
             );
         }
     }
@@ -205,15 +220,28 @@ struct RasterTextures {
 #undef X
     }
 
-    void AllocateFrameBuffers(CommandList& cmd_list, BindlessArrayRef& bindless_array) {
+    void AllocateFrameBuffers(
+        CommandList&       cmd_list,
+        BindlessArrayRef&   bindless_array,
+        bool                allocate_scene_resources = true,
+        bool                allocate_output_resources = true
+    ) {
         // Full-resolution textures
-#define X(TYPE, NAME, TEXTYPE, CONFIG) \
-    AssetTool::AllocateRasterResourceHandle(bindless_array, NAME, (CONFIG));
+#define X(TYPE, NAME, TEXTYPE, CONFIG)                                                       \
+    {                                                                                        \
+        TexConfig cfg = (CONFIG);                                                            \
+        const bool allocate_resource =                                                       \
+            cfg.b_output_size ? allocate_output_resources : allocate_scene_resources;        \
+        if (allocate_resource && (!cfg.is_asset || NAME.hdl == 0u)) {                        \
+            AssetTool::AllocateRasterResourceHandle(bindless_array, NAME, cfg);              \
+        }                                                                                    \
+    }
         RASTER_TEXTURES_TABLE
         RASTER_TEXTURES_TABLE_DOWNSAMPLED
 #undef X
 
         // Half-resolution variants (LINEAR sampler for bilinear upsampling)
+        if (allocate_scene_resources) {
 #define X(TYPE, NAME, TEXTYPE, CONFIG)                                                         \
     {                                                                                          \
         TexConfig half_cfg;                                                                    \
@@ -222,8 +250,9 @@ struct RasterTextures {
     }
         RASTER_TEXTURES_TABLE_DOWNSAMPLED
 #undef X
+        }
 
-        {
+        if (allocate_scene_resources) {
             TexConfig hiz_cfg = CreateHiZConfig(hiz_current.GetSize());
             AssetTool::AllocateRasterResourceHandle(bindless_array, hiz_current, hiz_cfg);
             AssetTool::AllocateRasterResourceHandle(bindless_array, hiz_previous, hiz_cfg);
@@ -232,26 +261,37 @@ struct RasterTextures {
         cmd_list.UpdateBindlessArray(bindless_array);
     }
 
-    void FreeFrameBuffers(BindlessArrayRef& bindless_array, bool is_free_external_assets) {
-#define X(TYPE, NAME, TEXTYPE, CONFIG)                                 \
-    {                                                                  \
-        TexConfig cfg = (CONFIG);                                      \
-        if (!cfg.is_asset || is_free_external_assets) {                \
-            AssetTool::FreeRasterResourceHandle(bindless_array, NAME); \
-        }                                                              \
+    void FreeFrameBuffers(
+        BindlessArrayRef& bindless_array,
+        bool              is_free_external_assets,
+        bool              free_scene_resources = true,
+        bool              free_output_resources = true
+    ) {
+#define X(TYPE, NAME, TEXTYPE, CONFIG)                                      \
+    {                                                                       \
+        TexConfig cfg = (CONFIG);                                           \
+        const bool free_resource =                                          \
+            cfg.b_output_size ? free_output_resources : free_scene_resources; \
+        if (free_resource && (!cfg.is_asset || is_free_external_assets)) {   \
+            AssetTool::FreeRasterResourceHandle(bindless_array, NAME);      \
+        }                                                                   \
     }
         RASTER_TEXTURES_TABLE
         RASTER_TEXTURES_TABLE_DOWNSAMPLED
 #undef X
 
         // Half-resolution variants
+        if (free_scene_resources) {
 #define X(TYPE, NAME, TEXTYPE, CONFIG) \
     AssetTool::FreeRasterResourceHandle(bindless_array, NAME##_half);
         RASTER_TEXTURES_TABLE_DOWNSAMPLED
 #undef X
+        }
 
-        AssetTool::FreeRasterResourceHandle(bindless_array, hiz_current);
-        AssetTool::FreeRasterResourceHandle(bindless_array, hiz_previous);
+        if (free_scene_resources) {
+            AssetTool::FreeRasterResourceHandle(bindless_array, hiz_current);
+            AssetTool::FreeRasterResourceHandle(bindless_array, hiz_previous);
+        }
     }
 
     Array<TextureView> GetDisplayableFrameBuffersView() {

--- a/source/runtime/render/renderer/raster/RtaoDenoiserPass.h
+++ b/source/runtime/render/renderer/raster/RtaoDenoiserPass.h
@@ -62,16 +62,32 @@ public:
         }
     }
 
+    void ResetHistory() {
+        history_valid               = false;
+        history_configuration_valid = false;
+    }
+
     // 注意，这个函数是原地操作
     uint ProcessInPlace(RasterContext& context, const RasterConfig& ui_config, uint ao_only_idx) {
         // AO不为RTAO或RTAO_AO_ONLY => return
-        if (ui_config.ao_mode != EAoMode::RTAO && ui_config.ao_mode != EAoMode::RTAO_AO_ONLY)
+        if (ui_config.ao_mode != EAoMode::RTAO &&
+            ui_config.ao_mode != EAoMode::RTAO_AO_ONLY) {
+            ResetHistory();
             return ao_only_idx;
+        }
         // 没有开启降噪 => return
-        if (!ui_config.rtao_denoiser_enable)
+        if (!ui_config.rtao_denoiser_enable) {
+            ResetHistory();
             return ao_only_idx;
+        }
 
         const bool half_res = ui_config.ao_half_resolution;
+        if (!history_configuration_valid ||
+            history_half_resolution != half_res) {
+            history_valid               = false;
+            history_half_resolution     = half_res;
+            history_configuration_valid = true;
+        }
 
         if (ao_only_idx == 0) {
             img_denoiser_history_read  = half_res ? context.textures.ao_denoiser_accumulate_1_half :
@@ -105,7 +121,7 @@ public:
         param.normal_tex        = context.textures.normal.hdl;
         param.inv_resolution    = float2(1.0f) / float2(img_ao_only.GetSize());
 
-        param.history_ratio          = ui_config.rtao_denoiser_history_ratio;
+        param.history_ratio          = history_valid ? ui_config.rtao_denoiser_history_ratio : 0.f;
         param.valid_depth_threshold  = ui_config.rtao_denoiser_valid_depth_threshold;
         param.valid_normal_threshold = ui_config.rtao_denoiser_valid_normal_threshold;
 
@@ -134,6 +150,7 @@ public:
                 ColorAttachment(img_ao_only.tex)
             );
 
+        history_valid = true;
         return ao_only_idx ^ 1; // 0 <-> 1
     }
 
@@ -144,6 +161,9 @@ private:
     TextureWithHandle        img_denoiser_history_read;
     TextureWithHandle        img_ao_only;
     TextureWithHandle        img_ao_only_prev;
+    bool                     history_valid               = false;
+    bool                     history_configuration_valid = false;
+    bool                     history_half_resolution     = false;
 };
 
 } // namespace Moer::Render::Raster

--- a/source/runtime/render/rhi/vulkan/VulkanAllocator.cpp
+++ b/source/runtime/render/rhi/vulkan/VulkanAllocator.cpp
@@ -121,9 +121,53 @@ bool VulkanAllocatorBase::ResetAbandoned() {
 
 // VulkanPresentor
 VulkanPresentor::VulkanPresentor(VulkanDevice* _device, EQueueType _type) :
-    VulkanAllocatorBase(_device, _type) {}
+    VulkanAllocatorBase(_device, _type) {
+    VkSemaphoreCreateInfo semaphore_info{
+        VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO
+    };
+    const VkResult result = vkCreateSemaphore(
+        m_device->GetDevice(),
+        &semaphore_info,
+        VK_NULL_HANDLE,
+        &image_ready_semaphore
+    );
+    if (result != VK_SUCCESS) {
+        image_ready_semaphore = VK_NULL_HANDLE;
+        m_device->TryLatchFirstFault(
+            VulkanOperationContext{
+                .operation  = EVulkanFaultOperation::SwapchainSemaphoreCreate,
+                .queue_type = _type,
+            },
+            result
+        );
+        throw std::runtime_error(
+            "failed to create Vulkan presentor image-ready semaphore"
+        );
+    }
+    try {
+        m_device->SetResourceName(
+            uint64(image_ready_semaphore),
+            VK_OBJECT_TYPE_SEMAPHORE,
+            "PresentorImageReadySemaphore_" +
+                std::to_string(reinterpret_cast<uintptr_t>(this))
+        );
+    } catch (...) {
+        vkDestroySemaphore(
+            m_device->GetDevice(), image_ready_semaphore, VK_NULL_HANDLE
+        );
+        image_ready_semaphore = VK_NULL_HANDLE;
+        throw;
+    }
+}
 
-VulkanPresentor::~VulkanPresentor() {}
+VulkanPresentor::~VulkanPresentor() {
+    if (image_ready_semaphore != VK_NULL_HANDLE) {
+        vkDestroySemaphore(
+            m_device->GetDevice(), image_ready_semaphore, VK_NULL_HANDLE
+        );
+        image_ready_semaphore = VK_NULL_HANDLE;
+    }
+}
 
 bool VulkanPresentor::CompleteSuccess() noexcept {
     return InvokeAllocatorCompletionCallbacksNoexcept(

--- a/source/runtime/render/rhi/vulkan/VulkanAllocator.h
+++ b/source/runtime/render/rhi/vulkan/VulkanAllocator.h
@@ -128,7 +128,14 @@ public:
     VulkanPresentor(VulkanDevice* _device, EQueueType _queue_type);
     virtual ~VulkanPresentor();
 
+    [[nodiscard]] VkSemaphore GetImageReadySemaphore() const noexcept {
+        return image_ready_semaphore;
+    }
+
     bool CompleteSuccess() noexcept override;
+
+private:
+    VkSemaphore image_ready_semaphore{VK_NULL_HANDLE};
 };
 
 class VulkanAllocator : public VulkanAllocatorBase {

--- a/source/runtime/render/rhi/vulkan/VulkanQueue.cpp
+++ b/source/runtime/render/rhi/vulkan/VulkanQueue.cpp
@@ -6783,7 +6783,10 @@ VulkanRuntimeSubmissionResult VkCommandQueue::PresentNow(
                 };
             } else {
                 const VkSwapchain::AcquireResult acquire =
-                    sc->AquireNextImage(rhi_thread_enabled ? 0 : 50'000'000);
+                    sc->AquireNextImage(
+                        presentor->GetImageReadySemaphore(),
+                        rhi_thread_enabled ? 0 : 50'000'000
+                    );
                 final_outcome      = acquire.outcome;
                 recreate_swapchain =
                     acquire.outcome.status == EVulkanOperationStatus::Recreate;

--- a/source/runtime/render/rhi/vulkan/VulkanSwapChain.cpp
+++ b/source/runtime/render/rhi/vulkan/VulkanSwapChain.cpp
@@ -245,7 +245,6 @@ void VkSwapchain::CreateOrRecreate(const SwapchainCreateInfo& _info, bool _force
     }
 
     VkSwapchainKHR          new_sc = VK_NULL_HANDLE;
-    Array<VkSemaphore>      new_image_ready_fences;
     Array<VkSemaphore>      new_render_finished_fences;
     Array<VkFence>          new_in_flight_fences;
     Array<VulkanTexture*>   new_swapchain_textures;
@@ -255,11 +254,6 @@ void VkSwapchain::CreateOrRecreate(const SwapchainCreateInfo& _info, bool _force
         for (auto* texture : new_swapchain_textures) {
             if (texture != nullptr) {
                 MoerDelete(texture);
-            }
-        }
-        for (VkSemaphore semaphore : new_image_ready_fences) {
-            if (semaphore != VK_NULL_HANDLE) {
-                vkDestroySemaphore(device.GetDevice(), semaphore, VK_NULL_HANDLE);
             }
         }
         for (VkSemaphore semaphore : new_render_finished_fences) {
@@ -286,10 +280,6 @@ void VkSwapchain::CreateOrRecreate(const SwapchainCreateInfo& _info, bool _force
         }
         swapchain_textures.clear();
         swapchain_views.clear();
-        for (VkSemaphore semaphore : image_ready_fences) {
-            vkDestroySemaphore(device.GetDevice(), semaphore, VK_NULL_HANDLE);
-        }
-        image_ready_fences.clear();
         for (VkSemaphore semaphore : render_finished_fences) {
             vkDestroySemaphore(device.GetDevice(), semaphore, VK_NULL_HANDLE);
         }
@@ -378,26 +368,9 @@ void VkSwapchain::CreateOrRecreate(const SwapchainCreateInfo& _info, bool _force
 
     const uint new_max_frames_in_flight = std::min(max_frames_in_flight, uint(image_cnt));
     const bool recreate_fences = in_flight_fences.size() != new_max_frames_in_flight;
-    new_image_ready_fences.resize(image_cnt, VK_NULL_HANDLE);
     new_render_finished_fences.resize(image_cnt, VK_NULL_HANDLE);
     VkSemaphoreCreateInfo semaphore_info{VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO};
     for (uint i = 0; i < image_cnt; i++) {
-        result = vkCreateSemaphore(
-            device.GetDevice(), &semaphore_info, VK_NULL_HANDLE, &new_image_ready_fences[i]
-        );
-        if (result != VK_SUCCESS) {
-            new_image_ready_fences[i] = VK_NULL_HANDLE;
-        }
-        if (!check_device_result(result, EVulkanFaultOperation::SwapchainSemaphoreCreate)) {
-            abort_transaction();
-            return;
-        }
-        device.SetResourceName(
-            uint64(new_image_ready_fences[i]),
-            VK_OBJECT_TYPE_SEMAPHORE,
-            "ImageReadySemaphore_" + std::to_string(i)
-        );
-
         result = vkCreateSemaphore(
             device.GetDevice(), &semaphore_info, VK_NULL_HANDLE, &new_render_finished_fences[i]
         );
@@ -470,7 +443,6 @@ void VkSwapchain::CreateOrRecreate(const SwapchainCreateInfo& _info, bool _force
     size                      = new_size;
     format                    = new_format;
     max_frames_in_flight      = new_max_frames_in_flight;
-    image_ready_fences        = std::move(new_image_ready_fences);
     render_finished_fences    = std::move(new_render_finished_fences);
     swapchain_textures        = std::move(new_swapchain_textures);
     swapchain_views           = std::move(new_swapchain_views);
@@ -490,15 +462,11 @@ VkSwapchain::~VkSwapchain() {
     }
     for (size_t i = 0; i < swapchain_textures.size(); ++i) {
         MoerDelete(swapchain_textures[i]);
-        vkDestroySemaphore(device.GetDevice(), image_ready_fences[i], VK_NULL_HANDLE);
         vkDestroySemaphore(device.GetDevice(), render_finished_fences[i], VK_NULL_HANDLE);
     }
     for (uint i = 0; i < in_flight_fences.size(); i++) {
         vkDestroyFence(device.GetDevice(), in_flight_fences[i], VK_NULL_HANDLE);
     }
-}
-VkSemaphore VkSwapchain::GetImageReadyFence(uint _index) {
-    return image_ready_fences[_index % image_ready_fences.size()];
 }
 VkSemaphore VkSwapchain::GetRenderFinishedFence(uint _image_index) {
     return render_finished_fences[_image_index % render_finished_fences.size()];
@@ -506,14 +474,16 @@ VkSemaphore VkSwapchain::GetRenderFinishedFence(uint _image_index) {
 TextureView VkSwapchain::GetSwapchainImage(uint _index) {
     return swapchain_views[_index % swapchain_views.size()];
 }
-VkSwapchain::AcquireResult VkSwapchain::AquireNextImage(uint64 _timeout) {
-    uint32_t    aquire_idx = UINT32_MAX;
-    VkSemaphore ready_sem  = image_ready_fences[image_idx % image_ready_fences.size()];
-
+VkSwapchain::AcquireResult VkSwapchain::AquireNextImage(
+    VkSemaphore _ready_semaphore,
+    uint64      _timeout
+) {
+    assert(_ready_semaphore != VK_NULL_HANDLE);
+    uint32_t aquire_idx = UINT32_MAX;
     const VulkanOperationResult outcome = device.AcquireNextImage(
         handle,
         _timeout,
-        ready_sem,
+        _ready_semaphore,
         VK_NULL_HANDLE,
         &aquire_idx,
         VulkanOperationContext{
@@ -525,7 +495,12 @@ VkSwapchain::AcquireResult VkSwapchain::AquireNextImage(uint64 _timeout) {
     );
     if ((outcome.result == VK_SUCCESS || outcome.result == VK_SUBOPTIMAL_KHR) &&
         aquire_idx != UINT32_MAX) {
-        return {outcome, ready_sem, aquire_idx, image_idx};
+        return {
+            outcome,
+            _ready_semaphore,
+            aquire_idx,
+            image_idx
+        };
     }
     return {outcome, VK_NULL_HANDLE, UINT32_MAX, image_idx};
 }

--- a/source/runtime/render/rhi/vulkan/VulkanSwapChain.h
+++ b/source/runtime/render/rhi/vulkan/VulkanSwapChain.h
@@ -50,9 +50,11 @@ public:
     ~VkSwapchain();
     void Recreate(const SwapchainCreateInfo& _info) override;
     void CreateOrRecreate(const SwapchainCreateInfo& _info, bool _force_recreate = false);
-    AcquireResult                       AquireNextImage(uint64 _timeout = UINT64_MAX);
+    AcquireResult AquireNextImage(
+        VkSemaphore _ready_semaphore,
+        uint64      _timeout = UINT64_MAX
+    );
     TextureView                         GetSwapchainImage(uint _index);
-    VkSemaphore                         GetImageReadyFence(uint _index);
     VkSemaphore                         GetRenderFinishedFence(uint _image_index);
     VulkanOperationResult Present(
         VkQueue _queue,
@@ -70,7 +72,6 @@ public:
     }
     VkSurfaceFormatKHR fmt;
 
-    Array<VkSemaphore>          image_ready_fences;
     Array<VkSemaphore>          render_finished_fences;
     Array<class VulkanTexture*> swapchain_textures;
     Array<TextureView>          swapchain_views;

--- a/source/test/CMakeLists.txt
+++ b/source/test/CMakeLists.txt
@@ -50,6 +50,14 @@ target_link_libraries(${test_target}
 set_target_properties(${test_target} PROPERTIES FOLDER ${moer_test_folder})
 add_test(NAME RenderGraphResourcePoolContract COMMAND $<TARGET_FILE:${test_target}>)
 
+set(test_target TestSceneRenderExtent)
+add_executable(${test_target} "SceneRenderExtentTest.cpp")
+target_link_libraries(${test_target}
+    PRIVATE Moer::Render
+)
+set_target_properties(${test_target} PROPERTIES FOLDER ${moer_test_folder})
+add_test(NAME SceneRenderExtentContract COMMAND $<TARGET_FILE:${test_target}>)
+
 set(test_target TestRHICmdReorderer)
 add_executable(${test_target} "RHICmdReordererTest.cpp")
 target_link_libraries(${test_target}

--- a/source/test/SceneRenderExtentTest.cpp
+++ b/source/test/SceneRenderExtentTest.cpp
@@ -1,0 +1,122 @@
+#include "renderer/SceneRenderExtent.h"
+
+#include <iostream>
+#include <limits>
+#include <string_view>
+
+namespace {
+
+class TestSuite {
+public:
+    void Check(bool condition, std::string_view message) {
+        if (condition) {
+            return;
+        }
+        ++failures;
+        std::cerr << "[FAIL] " << message << '\n';
+    }
+
+    [[nodiscard]] int FailureCount() const {
+        return failures;
+    }
+
+private:
+    int failures = 0;
+};
+
+} // namespace
+
+int main() {
+    using namespace Moer;
+    using namespace Moer::Render;
+
+    TestSuite suite;
+
+    const auto headless = CaptureSceneRenderExtentRequest(
+        false, float2(0.f, 0.f), uint2(1600u, 900u)
+    );
+    suite.Check(headless.valid, "UI-disabled window extent must be valid");
+    suite.Check(headless.immediate, "UI-disabled window extent must bypass debounce");
+    suite.Check(
+        EqualRenderExtent(headless.extent, uint2(1600u, 900u)),
+        "UI-disabled scene extent must follow the window"
+    );
+
+    const auto docked = CaptureSceneRenderExtentRequest(
+        true, float2(913.9f, 513.2f), uint2(1600u, 900u)
+    );
+    suite.Check(docked.valid && !docked.immediate, "docked extent must be debounced");
+    suite.Check(
+        EqualRenderExtent(docked.extent, uint2(913u, 513u)),
+        "docked floating-point extent must be frozen to integer pixels"
+    );
+
+    const auto collapsed = CaptureSceneRenderExtentRequest(
+        true, float2(0.f, 0.f), uint2(1600u, 900u)
+    );
+    suite.Check(!collapsed.valid, "collapsed SceneColor must not request zero-sized resources");
+
+    const auto non_finite = CaptureSceneRenderExtentRequest(
+        true,
+        float2(std::numeric_limits<float>::infinity(), 900.f),
+        uint2(1600u, 900u)
+    );
+    suite.Check(!non_finite.valid, "non-finite SceneColor extent must be rejected");
+
+    const auto tiny = CaptureSceneRenderExtentRequest(
+        true, float2(4.f, 7.f), uint2(1600u, 900u)
+    );
+    suite.Check(
+        EqualRenderExtent(
+            tiny.extent,
+            uint2(k_min_scene_render_extent, k_min_scene_render_extent)
+        ),
+        "scene extent must preserve the fixed six-mip bloom contract"
+    );
+
+    SceneRenderExtentTracker tracker(uint2(1600u, 900u));
+    suite.Check(!tracker.Observe(docked), "first docked observation must remain pending");
+    suite.Check(
+        EqualRenderExtent(tracker.GetActiveExtent(), uint2(1600u, 900u)),
+        "pending request must retain the allocated extent"
+    );
+    suite.Check(tracker.Observe(docked), "second stable observation must commit");
+    suite.Check(
+        EqualRenderExtent(tracker.GetActiveExtent(), docked.extent),
+        "committed docked request must become active"
+    );
+
+    const auto first_drag = CaptureSceneRenderExtentRequest(
+        true, float2(917.f, 517.f), uint2(1600u, 900u)
+    );
+    const auto second_drag = CaptureSceneRenderExtentRequest(
+        true, float2(920.f, 520.f), uint2(1600u, 900u)
+    );
+    suite.Check(!tracker.Observe(first_drag), "drag request must start pending");
+    suite.Check(!tracker.Observe(second_drag), "changed drag request must restart debounce");
+    suite.Check(
+        !tracker.Observe(collapsed),
+        "invalid request must retain the active allocation"
+    );
+    suite.Check(!tracker.HasPendingExtent(), "invalid request must clear stale pending state");
+    suite.Check(
+        EqualRenderExtent(tracker.GetActiveExtent(), docked.extent),
+        "collapsed SceneColor must retain the last valid allocation"
+    );
+
+    const auto window_resize = CaptureSceneRenderExtentRequest(
+        false, float2(0.f, 0.f), uint2(1920u, 1080u)
+    );
+    suite.Check(tracker.Observe(window_resize), "headless window resize must commit immediately");
+    suite.Check(
+        EqualRenderExtent(tracker.GetActiveExtent(), uint2(1920u, 1080u)),
+        "immediate request must update the active extent"
+    );
+
+    if (suite.FailureCount() != 0) {
+        std::cerr << "TestSceneRenderExtent: " << suite.FailureCount() << " failure(s)\n";
+        return 1;
+    }
+    std::cout << "TestSceneRenderExtent: all checks passed\n";
+    return 0;
+}


### PR DESCRIPTION
## Summary
- split Raster SceneColor and output/swapchain extent domains through a by-value frame request and render-thread-owned extent tracker
- rebuild only the affected texture domain and reset SMAA, RTAO, HiZ, CSM, and CUDA/TensorRT temporal state when SceneColor extent changes
- make Vulkan acquire semaphore ownership follow the in-flight presentor lifetime so swapchain resize stress cannot reuse a semaphore before its queue wait completes
- add a focused SceneRenderExtent contract test

## Validation
- Debug build: MoerEditor, TestSceneRenderExtent, TestRenderGraph, TestRHIThreadOwnership, TestVulkanHeaderContract, TestRHIQuery, TestRHIParallelRecord
- CTest: RenderGraphContract, SceneRenderExtentContract, RHIQueryContract, RHIParallelRecordContract, RHIThreadOwnershipContract, VulkanHeaderContract (6/6 passed)
- Raster linear/serial resize stress: normal exit, non-black output, both extent domains rebuilt, no Vulkan VUID
- Raster graph/parallel resize stress: normal exit, non-black output, parallel graph effective, both extent domains rebuilt, no Vulkan VUID

## Scope
This is Phase B1 of the dev_parallel_rhi migration. Ray-tracing SceneColor extent is intentionally reserved for B2.