### PR TITLE
fix(vulkan): correct legacy resource stage mapping

### DIFF
--- a/source/runtime/render/rhi/vulkan/VulkanResourceTracker.cpp
+++ b/source/runtime/render/rhi/vulkan/VulkanResourceTracker.cpp
@@ -23,6 +23,41 @@ uint64_t BarrierNativeHandleKey(T _handle) {
         return static_cast<uint64_t>(_handle);
     }
 }
+
+[[noreturn]] void RejectLegacyResourceState(const char* _message) {
+    throw std::invalid_argument(_message);
+}
+
+void ValidateLegacyPassType(EPassType _type) {
+    switch (_type) {
+        case EPassType::Graphics:
+        case EPassType::Compute:
+        case EPassType::Raytracing:
+        case EPassType::Copy:
+            return;
+        default:
+            RejectLegacyResourceState("Unknown legacy pass type");
+    }
+}
+
+VkPipelineStageFlags2 LegacyShaderStagesForPass(EPassType _type) {
+    switch (_type) {
+        case EPassType::Graphics:
+            return VK_PIPELINE_STAGE_2_VERTEX_SHADER_BIT |
+                   VK_PIPELINE_STAGE_2_FRAGMENT_SHADER_BIT;
+        case EPassType::Compute:
+            return VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT;
+        case EPassType::Raytracing:
+            return VK_PIPELINE_STAGE_2_RAY_TRACING_SHADER_BIT_KHR;
+        case EPassType::Copy:
+            RejectLegacyResourceState(
+                "Copy pass cannot use a shader resource state"
+            );
+        default:
+            RejectLegacyResourceState("Unknown legacy pass type");
+    }
+}
+
 } // namespace
 /**
      * @brief 
@@ -49,319 +84,198 @@ uint64_t BarrierNativeHandleKey(T _handle) {
      * @param _usage 
      * @return std::tuple<VkAccessFlags2, VkPipelineStageFlags2> 
      */
-auto VkTracker::ReadBuffer(VulkanBuffer* _buffer, EBufferState _state, EPassType _type)
+auto VkTracker::ResolveBufferState(
+    EBufferState _state,
+    EPassType    _type,
+    bool         _is_write
+)
     -> std::tuple<VkAccessFlags2, VkPipelineStageFlags2> {
-    static constexpr VkAccessFlags2 buffer_access_rules[] = {
-        //GFX PASS ACCESS
-        VK_ACCESS_2_NONE,
-        VK_ACCESS_2_TRANSFER_READ_BIT,
-        VK_ACCESS_2_VERTEX_ATTRIBUTE_READ_BIT,
-        VK_ACCESS_2_INDEX_READ_BIT,
-        VK_ACCESS_2_INDIRECT_COMMAND_READ_BIT,
-        VK_ACCESS_2_SHADER_READ_BIT,
-        VK_ACCESS_2_SHADER_READ_BIT | VK_ACCESS_2_SHADER_WRITE_BIT,
-        //COMPUTE PASS ACCESS
-        VK_ACCESS_2_NONE,
-        VK_ACCESS_2_TRANSFER_READ_BIT,
-        VK_ACCESS_2_SHADER_READ_BIT,
-        VK_ACCESS_2_SHADER_READ_BIT,
-        VK_ACCESS_2_SHADER_READ_BIT,
-        VK_ACCESS_2_SHADER_READ_BIT,
-        VK_ACCESS_2_SHADER_READ_BIT | VK_ACCESS_2_SHADER_WRITE_BIT,
-        //RAYTRACING PASS ACCESS
-        VK_ACCESS_2_NONE,
-        VK_ACCESS_2_TRANSFER_READ_BIT,
-        VK_ACCESS_2_SHADER_READ_BIT,
-        VK_ACCESS_2_SHADER_READ_BIT,
-        VK_ACCESS_2_SHADER_READ_BIT,
-        VK_ACCESS_2_SHADER_READ_BIT,
-        VK_ACCESS_2_SHADER_READ_BIT | VK_ACCESS_2_SHADER_WRITE_BIT
-    };
-
-    static constexpr VkPipelineStageFlags2 stage_rules[] = {
-        //GFX PASS STAGES
-        VK_PIPELINE_STAGE_2_NONE,
-        VK_PIPELINE_STAGE_2_TRANSFER_BIT,
-        VK_PIPELINE_STAGE_2_VERTEX_INPUT_BIT,
-        VK_PIPELINE_STAGE_2_VERTEX_INPUT_BIT,
-        VK_PIPELINE_STAGE_2_DRAW_INDIRECT_BIT,
-        VK_PIPELINE_STAGE_2_VERTEX_SHADER_BIT | VK_PIPELINE_STAGE_2_FRAGMENT_SHADER_BIT,
-        VK_PIPELINE_STAGE_2_VERTEX_SHADER_BIT | VK_PIPELINE_STAGE_2_FRAGMENT_SHADER_BIT,
-        //COMPUTE PASS STAGES
-        VK_PIPELINE_STAGE_2_NONE,
-        VK_PIPELINE_STAGE_2_TRANSFER_BIT,
-        VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT,
-        VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT,
-        VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT,
-        VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT,
-        VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT,
-        //RAYTRACING PASS STAGES
-        VK_PIPELINE_STAGE_2_NONE,
-        VK_PIPELINE_STAGE_2_TRANSFER_BIT,
-        VK_PIPELINE_STAGE_2_RAY_TRACING_SHADER_BIT_KHR,
-        VK_PIPELINE_STAGE_2_RAY_TRACING_SHADER_BIT_KHR,
-        VK_PIPELINE_STAGE_2_RAY_TRACING_SHADER_BIT_KHR,
-        VK_PIPELINE_STAGE_2_RAY_TRACING_SHADER_BIT_KHR,
-        VK_PIPELINE_STAGE_2_RAY_TRACING_SHADER_BIT_KHR
-    };
-
-    uint buffer_index = static_cast<uint32>(_state) + static_cast<uint32>(_type) * uint(EBufferState::Num);
-    return {buffer_access_rules[buffer_index], stage_rules[buffer_index]};
-}
-
-auto VkTracker::WriteBuffer(VulkanBuffer* _buffer, EBufferState _state, EPassType _type)
-    -> std::tuple<VkAccessFlags2, VkPipelineStageFlags2> {
-    static constexpr VkAccessFlags2 buffer_access_rules[] = {
-        //GFX PASS ACCESS
-        VK_ACCESS_2_NONE,
-        VK_ACCESS_2_TRANSFER_WRITE_BIT,
-        VK_ACCESS_2_NONE,
-        VK_ACCESS_2_NONE,
-        VK_ACCESS_2_NONE,
-        VK_ACCESS_2_NONE,
-        VK_ACCESS_2_SHADER_READ_BIT | VK_ACCESS_2_SHADER_WRITE_BIT,
-        //COMPUTE PASS ACCESS
-        VK_ACCESS_2_NONE,
-        VK_ACCESS_2_TRANSFER_WRITE_BIT,
-        VK_ACCESS_2_SHADER_READ_BIT,
-        VK_ACCESS_2_SHADER_READ_BIT,
-        VK_ACCESS_2_SHADER_READ_BIT,
-        VK_ACCESS_2_SHADER_READ_BIT,
-        VK_ACCESS_2_SHADER_READ_BIT | VK_ACCESS_2_SHADER_WRITE_BIT,
-        //RAYTRACING PASS ACCESS
-        VK_ACCESS_2_NONE,
-        VK_ACCESS_2_TRANSFER_WRITE_BIT,
-        VK_ACCESS_2_SHADER_READ_BIT,
-        VK_ACCESS_2_SHADER_READ_BIT,
-        VK_ACCESS_2_SHADER_READ_BIT,
-        VK_ACCESS_2_SHADER_READ_BIT,
-        VK_ACCESS_2_SHADER_READ_BIT | VK_ACCESS_2_SHADER_WRITE_BIT
-    };
-
-    static constexpr VkPipelineStageFlags2 stage_rules[] = {
-        //GFX PASS STAGES
-        VK_PIPELINE_STAGE_2_NONE,
-        VK_PIPELINE_STAGE_2_TRANSFER_BIT,
-        VK_ACCESS_2_NONE,
-        VK_ACCESS_2_NONE,
-        VK_ACCESS_2_NONE,
-        VK_PIPELINE_STAGE_2_VERTEX_SHADER_BIT | VK_PIPELINE_STAGE_2_FRAGMENT_SHADER_BIT,
-        VK_PIPELINE_STAGE_2_VERTEX_SHADER_BIT | VK_PIPELINE_STAGE_2_FRAGMENT_SHADER_BIT,
-        //COMPUTE PASS STAGES
-        VK_PIPELINE_STAGE_2_NONE,
-        VK_PIPELINE_STAGE_2_TRANSFER_BIT,
-        VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT,
-        VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT,
-        VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT,
-        VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT,
-        VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT,
-        //RAYTRACING PASS STAGES
-        VK_PIPELINE_STAGE_2_NONE,
-        VK_PIPELINE_STAGE_2_TRANSFER_BIT,
-        VK_PIPELINE_STAGE_2_RAY_TRACING_SHADER_BIT_KHR,
-        VK_PIPELINE_STAGE_2_RAY_TRACING_SHADER_BIT_KHR,
-        VK_PIPELINE_STAGE_2_RAY_TRACING_SHADER_BIT_KHR,
-        VK_PIPELINE_STAGE_2_RAY_TRACING_SHADER_BIT_KHR,
-        VK_PIPELINE_STAGE_2_RAY_TRACING_SHADER_BIT_KHR
-    };
-
-    uint buffer_index = static_cast<uint32>(_state) + static_cast<uint32>(_type) * uint(EBufferState::Num);
-
-    return {buffer_access_rules[buffer_index], stage_rules[buffer_index]};
-}
-static constexpr VkPipelineStageFlags2 tex_read_stage_rules[] = {
-    //GFX PASS STAGES
-    VK_PIPELINE_STAGE_2_NONE,
-    VK_PIPELINE_STAGE_2_COPY_BIT,
-    VK_PIPELINE_STAGE_2_FRAGMENT_SHADER_BIT,
-    VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT,
-    VK_PIPELINE_STAGE_2_EARLY_FRAGMENT_TESTS_BIT,
-    VK_PIPELINE_STAGE_2_FRAGMENT_SHADER_BIT,
-    VK_PIPELINE_STAGE_2_FRAGMENT_SHADER_BIT,
-    VK_PIPELINE_STAGE_2_FRAGMENT_SHADER_BIT,
-    //COMPUTE PASS STAGES
-    VK_PIPELINE_STAGE_2_NONE,
-    VK_PIPELINE_STAGE_2_TRANSFER_BIT,
-    VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT,
-    VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT,
-    VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT,
-    VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT,
-    VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT,
-    VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT
-};
-
-static constexpr VkPipelineStageFlagBits2 tex_write_stage_rules[] = {
-    //GFX PASS STAGES
-    VK_PIPELINE_STAGE_2_NONE,
-    VK_PIPELINE_STAGE_2_COPY_BIT,
-    VK_PIPELINE_STAGE_2_FRAGMENT_SHADER_BIT,
-    VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT,
-    VK_PIPELINE_STAGE_2_EARLY_FRAGMENT_TESTS_BIT,
-    VK_PIPELINE_STAGE_2_FRAGMENT_SHADER_BIT,
-    VK_PIPELINE_STAGE_2_FRAGMENT_SHADER_BIT,
-    VK_PIPELINE_STAGE_2_FRAGMENT_SHADER_BIT,
-    //COMPUTE PASS STAGES
-    VK_PIPELINE_STAGE_2_NONE,
-    VK_PIPELINE_STAGE_2_TRANSFER_BIT,
-    VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT,
-    VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT,
-    VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT,
-    VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT,
-    VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT,
-    VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT
-};
-
-static constexpr VkImageLayout tex_read_layout_rules[] = {
-    //GFX PASS LAYOUTS
-    VK_IMAGE_LAYOUT_UNDEFINED,
-    VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
-    VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
-    VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
-    VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL,
-    VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
-    VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
-    //COMPUTE PASS LAYOUTS
-    VK_IMAGE_LAYOUT_UNDEFINED,
-    VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
-    VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
-    VK_IMAGE_LAYOUT_GENERAL,
-    VK_IMAGE_LAYOUT_GENERAL,
-    VK_IMAGE_LAYOUT_GENERAL,
-    VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
-    //RAYTRACING PASS LAYOUTS
-    VK_IMAGE_LAYOUT_UNDEFINED,
-    VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
-    VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
-    VK_IMAGE_LAYOUT_GENERAL,
-    VK_IMAGE_LAYOUT_GENERAL,
-    VK_IMAGE_LAYOUT_GENERAL,
-    VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL
-};
-
-static constexpr VkImageLayout depth_read_layout_rules[] = {
-    //GFX PASS LAYOUTS
-    VK_IMAGE_LAYOUT_UNDEFINED,
-    VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
-    VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL,
-    VK_IMAGE_LAYOUT_GENERAL,
-    VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL,
-    VK_IMAGE_LAYOUT_GENERAL,
-    VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL,
-    //COMPUTE PASS LAYOUTS
-    VK_IMAGE_LAYOUT_UNDEFINED,
-    VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
-    VK_IMAGE_LAYOUT_GENERAL,
-    VK_IMAGE_LAYOUT_GENERAL,
-    VK_IMAGE_LAYOUT_GENERAL,
-    VK_IMAGE_LAYOUT_GENERAL,
-    VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL,
-    //RAYTRACING PASS LAYOUTS
-    VK_IMAGE_LAYOUT_UNDEFINED,
-    VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
-    VK_IMAGE_LAYOUT_GENERAL,
-    VK_IMAGE_LAYOUT_GENERAL,
-    VK_IMAGE_LAYOUT_GENERAL,
-    VK_IMAGE_LAYOUT_GENERAL,
-    VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL
-};
-
-static constexpr VkAccessFlags2 tex_read_access_rules[] = {
-    //GFX PASS ACCESS
-    VK_ACCESS_2_NONE,
-    VK_ACCESS_2_TRANSFER_READ_BIT,
-    VK_ACCESS_2_SHADER_READ_BIT,
-    VK_ACCESS_2_COLOR_ATTACHMENT_READ_BIT,
-    VK_ACCESS_2_DEPTH_STENCIL_ATTACHMENT_READ_BIT,
-    VK_ACCESS_2_SHADER_READ_BIT,
-    VK_ACCESS_2_SHADER_SAMPLED_READ_BIT,
-    //COMPUTE PASS ACCESS
-    VK_ACCESS_2_NONE,
-    VK_ACCESS_2_TRANSFER_READ_BIT,
-    VK_ACCESS_2_SHADER_READ_BIT,
-    VK_ACCESS_2_SHADER_READ_BIT,
-    VK_ACCESS_2_SHADER_READ_BIT,
-    VK_ACCESS_2_SHADER_READ_BIT,
-    VK_ACCESS_2_SHADER_SAMPLED_READ_BIT,
-    //RAYTRACING PASS ACCESS
-    VK_ACCESS_2_NONE,
-    VK_ACCESS_2_TRANSFER_READ_BIT,
-    VK_ACCESS_2_SHADER_READ_BIT,
-    VK_ACCESS_2_SHADER_READ_BIT,
-    VK_ACCESS_2_SHADER_READ_BIT,
-    VK_ACCESS_2_SHADER_READ_BIT,
-    VK_ACCESS_2_SHADER_SAMPLED_READ_BIT
-
-};
-auto VkTracker::ReadTexture(VulkanTexture* _texture, ETextureState _state, EPassType _type)
-    -> std::tuple<VkAccessFlags2, VkImageLayout, VkPipelineStageFlags2> {
-
-    // static constexpr VkAccessFlags2 gfx_rules[] = {
-    //     VK_ACCESS_2_NONE,
-    //     VK_ACCESS_2_TRANSFER_READ_BIT,
-    //     VK_ACCESS_2_SHADER_READ_BIT,
-    //     VK_ACCESS_2_COLOR_ATTACHMENT_READ_BIT,
-    //     VK_ACCESS_2_DEPTH_STENCIL_ATTACHMENT_READ_BIT,
-    //     VK_ACCESS_2_SHADER_READ_BIT,
-    //     VK_ACCESS_2_SHADER_SAMPLED_READ_BIT};
-
-    // static constexpr VkImageLayout gfx_layout_rules[] = {
-    //     VK_IMAGE_LAYOUT_UNDEFINED,
-    //     VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
-    //     VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
-    //     VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
-    //     VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL,
-    //     VK_IMAGE_LAYOUT_READ_ONLY_OPTIMAL,
-    //     VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL};
-
-    // static constexpr VkImageLayout depth_layout_rules[] = {
-    //     VK_IMAGE_LAYOUT_UNDEFINED,
-    //     VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
-    //     VK_IMAGE_LAYOUT_GENERAL,
-    //     VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
-    //     VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL,
-    //     VK_IMAGE_LAYOUT_READ_ONLY_OPTIMAL,
-    //     VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL};
-
-    auto index      = static_cast<uint32>(_state);
-    auto pass_index = static_cast<uint32>(_state) + uint32(ETextureState::Num) * uint32(_type);
-    if (uint(_texture->GetAspectFlags() & ETextureAspectFlags::DEPTH_SLICE) != 0u) {
-        return {
-            tex_read_access_rules[pass_index],
-            depth_read_layout_rules[pass_index],
-            tex_read_stage_rules[pass_index]
-        };
+    ValidateLegacyPassType(_type);
+    switch (_state) {
+        case EBufferState::UNDEFINED:
+            return {VK_ACCESS_2_NONE, VK_PIPELINE_STAGE_2_NONE};
+        case EBufferState::TRANSFER:
+            return {
+                _is_write ? VK_ACCESS_2_TRANSFER_WRITE_BIT :
+                            VK_ACCESS_2_TRANSFER_READ_BIT,
+                VK_PIPELINE_STAGE_2_TRANSFER_BIT
+            };
+        case EBufferState::VERTEX:
+            if (_is_write || _type != EPassType::Graphics) {
+                RejectLegacyResourceState(
+                    "Vertex buffers are read-only graphics resources"
+                );
+            }
+            return {
+                VK_ACCESS_2_VERTEX_ATTRIBUTE_READ_BIT,
+                VK_PIPELINE_STAGE_2_VERTEX_INPUT_BIT
+            };
+        case EBufferState::INDEX:
+            if (_is_write || _type != EPassType::Graphics) {
+                RejectLegacyResourceState(
+                    "Index buffers are read-only graphics resources"
+                );
+            }
+            return {
+                VK_ACCESS_2_INDEX_READ_BIT,
+                VK_PIPELINE_STAGE_2_VERTEX_INPUT_BIT
+            };
+        case EBufferState::INDIRECT:
+            if (_is_write || _type == EPassType::Copy) {
+                RejectLegacyResourceState(
+                    "Indirect buffers are read-only non-copy resources"
+                );
+            }
+            return {
+                VK_ACCESS_2_INDIRECT_COMMAND_READ_BIT,
+                VK_PIPELINE_STAGE_2_DRAW_INDIRECT_BIT
+            };
+        case EBufferState::SHADER_RESOURCE:
+            if (_is_write || _type == EPassType::Copy) {
+                RejectLegacyResourceState(
+                    "Shader-resource buffers are read-only non-copy resources"
+                );
+            }
+            return {
+                VK_ACCESS_2_SHADER_READ_BIT,
+                LegacyShaderStagesForPass(_type)
+            };
+        case EBufferState::UNORDERED_ACCESS:
+            if (_type == EPassType::Copy) {
+                RejectLegacyResourceState(
+                    "Copy pass cannot use an unordered-access buffer state"
+                );
+            }
+            return {
+                VK_ACCESS_2_SHADER_READ_BIT | VK_ACCESS_2_SHADER_WRITE_BIT,
+                LegacyShaderStagesForPass(_type)
+            };
+        case EBufferState::Num:
+        default:
+            RejectLegacyResourceState("Unknown legacy buffer state");
     }
-
-    return {
-        tex_read_access_rules[pass_index], tex_read_layout_rules[pass_index], tex_read_stage_rules[pass_index]
-    };
 }
 
-auto VkTracker::WriteTexture(VulkanTexture* _texture, ETextureState _state, EPassType _type)
+auto VkTracker::ReadBuffer(
+    VulkanBuffer* _buffer,
+    EBufferState  _state,
+    EPassType     _type
+)
+    -> std::tuple<VkAccessFlags2, VkPipelineStageFlags2> {
+    (void)_buffer;
+    return ResolveBufferState(_state, _type, false);
+}
+auto VkTracker::WriteBuffer(
+    VulkanBuffer* _buffer,
+    EBufferState  _state,
+    EPassType     _type
+)
+    -> std::tuple<VkAccessFlags2, VkPipelineStageFlags2> {
+    (void)_buffer;
+    return ResolveBufferState(_state, _type, true);
+}
+
+auto VkTracker::ResolveTextureState(
+    ETextureState _state,
+    EPassType     _type,
+    bool          _is_write,
+    bool          _is_depth
+)
     -> std::tuple<VkAccessFlags2, VkImageLayout, VkPipelineStageFlags2> {
-    static constexpr VkAccessFlags2 gfx_rules[] = {
-        VK_ACCESS_2_NONE,
-        VK_ACCESS_2_TRANSFER_WRITE_BIT,
-        VK_ACCESS_2_SHADER_READ_BIT | VK_ACCESS_2_SHADER_WRITE_BIT,
-        VK_ACCESS_2_COLOR_ATTACHMENT_WRITE_BIT,
-        VK_ACCESS_2_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT,
-        VK_ACCESS_2_SHADER_READ_BIT | VK_ACCESS_2_SHADER_WRITE_BIT,
-        VK_ACCESS_2_NONE
-    };
+    ValidateLegacyPassType(_type);
+    switch (_state) {
+        case ETextureState::UNDEFINED:
+            return {
+                VK_ACCESS_2_NONE,
+                VK_IMAGE_LAYOUT_UNDEFINED,
+                VK_PIPELINE_STAGE_2_NONE
+            };
+        case ETextureState::TRANSFER:
+            return {
+                _is_write ? VK_ACCESS_2_TRANSFER_WRITE_BIT :
+                            VK_ACCESS_2_TRANSFER_READ_BIT,
+                _is_write ? VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL :
+                            VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
+                VK_PIPELINE_STAGE_2_TRANSFER_BIT
+            };
+        case ETextureState::SHADER_RESOURCE:
+        case ETextureState::SAMPLE:
+            if (_is_write || _type == EPassType::Copy) {
+                RejectLegacyResourceState(
+                    "Shader-resource textures are read-only non-copy resources"
+                );
+            }
+            return {
+                _state == ETextureState::SAMPLE ?
+                    VK_ACCESS_2_SHADER_SAMPLED_READ_BIT :
+                    VK_ACCESS_2_SHADER_READ_BIT,
+                _is_depth ? VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL :
+                            VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
+                LegacyShaderStagesForPass(_type)
+            };
+        case ETextureState::RENDER_TARGET:
+            if (_type != EPassType::Graphics) {
+                RejectLegacyResourceState(
+                    "Render targets are graphics attachments"
+                );
+            }
+            return {
+                _is_write ? VK_ACCESS_2_COLOR_ATTACHMENT_WRITE_BIT :
+                            VK_ACCESS_2_COLOR_ATTACHMENT_READ_BIT,
+                VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
+                VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT
+            };
+        case ETextureState::DEPTH_STENCIL:
+            if (_type != EPassType::Graphics) {
+                RejectLegacyResourceState(
+                    "Depth-stencil textures are graphics attachments"
+                );
+            }
+            return {
+                _is_write ? VK_ACCESS_2_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT :
+                            VK_ACCESS_2_DEPTH_STENCIL_ATTACHMENT_READ_BIT,
+                _is_write ? VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL :
+                            VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL,
+                VK_PIPELINE_STAGE_2_EARLY_FRAGMENT_TESTS_BIT |
+                    VK_PIPELINE_STAGE_2_LATE_FRAGMENT_TESTS_BIT
+            };
+        case ETextureState::UNORDERED_ACCESS:
+            if (_type == EPassType::Copy) {
+                RejectLegacyResourceState(
+                    "Copy pass cannot use an unordered-access texture state"
+                );
+            }
+            return {
+                VK_ACCESS_2_SHADER_READ_BIT | VK_ACCESS_2_SHADER_WRITE_BIT,
+                VK_IMAGE_LAYOUT_GENERAL,
+                LegacyShaderStagesForPass(_type)
+            };
+        case ETextureState::Num:
+        default:
+            RejectLegacyResourceState("Unknown legacy texture state");
+    }
+}
 
-    static constexpr VkImageLayout layout_rules[] = {
-        VK_IMAGE_LAYOUT_UNDEFINED,
-        VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
-        VK_IMAGE_LAYOUT_GENERAL,
-        VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
-        VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL,
-        VK_IMAGE_LAYOUT_GENERAL,
-        VK_IMAGE_LAYOUT_UNDEFINED
-    }; // Invalid
+auto VkTracker::ReadTexture(
+    VulkanTexture* _texture,
+    ETextureState  _state,
+    EPassType      _type
+)
+    -> std::tuple<VkAccessFlags2, VkImageLayout, VkPipelineStageFlags2> {
+    const bool is_depth =
+        uint(_texture->GetAspectFlags() & ETextureAspectFlags::DEPTH_SLICE) != 0u;
+    return ResolveTextureState(_state, _type, false, is_depth);
+}
 
-    auto index      = static_cast<uint32>(_state);
-    auto pass_index = static_cast<uint32>(_state) + uint32(ETextureState::Num) * uint32(_type);
-    return {gfx_rules[index], layout_rules[index], tex_write_stage_rules[pass_index]};
+auto VkTracker::WriteTexture(
+    VulkanTexture* _texture,
+    ETextureState  _state,
+    EPassType      _type
+)
+    -> std::tuple<VkAccessFlags2, VkImageLayout, VkPipelineStageFlags2> {
+    const bool is_depth =
+        uint(_texture->GetAspectFlags() & ETextureAspectFlags::DEPTH_SLICE) != 0u;
+    return ResolveTextureState(_state, _type, true, is_depth);
 }
 
 static bool IsWriteState(VkImageLayout _layout, VkAccessFlags2 _access) {

--- a/source/runtime/render/rhi/vulkan/VulkanResourceTracker.h
+++ b/source/runtime/render/rhi/vulkan/VulkanResourceTracker.h
@@ -283,6 +283,23 @@ public:
     auto WriteTexture(VulkanTexture*, ETextureState, EPassType _type = EPassType::Graphics)
         -> std::tuple<VkAccessFlags2, VkImageLayout, VkPipelineStageFlags2>;
 
+    // Pure legacy-state resolvers keep backend validation testable without a
+    // Vulkan device. Copy is valid only for TRANSFER/UNDEFINED; shader and
+    // attachment state/pass mismatches are rejected instead of indexing past
+    // a lookup table.
+    RENDER_API static auto ResolveBufferState(
+        EBufferState _state,
+        EPassType    _type,
+        bool         _is_write
+    )
+        -> std::tuple<VkAccessFlags2, VkPipelineStageFlags2>;
+    RENDER_API static auto ResolveTextureState(
+        ETextureState _state,
+        EPassType     _type,
+        bool          _is_write,
+        bool          _is_depth
+    ) -> std::tuple<VkAccessFlags2, VkImageLayout, VkPipelineStageFlags2>;
+
     void EmplaceWriteBLAS(uint64 _blas_buf);
     bool ContainsWriteBLAS(uint64 _blas_buf);
 

--- a/source/test/RHIExplicitBarrierTest.cpp
+++ b/source/test/RHIExplicitBarrierTest.cpp
@@ -5,6 +5,7 @@
 #include <array>
 #include <iostream>
 #include <stdexcept>
+#include <utility>
 
 using namespace Moer;
 using namespace Moer::Render;
@@ -74,6 +75,236 @@ FunctionTable MakeFunctionTable() {
         .lock_bdls_array         = &NoopBindlessLock,
         .unlock_bdls_array       = &NoopBindlessLock,
     };
+}
+
+template<typename TCallable>
+void ExpectInvalidArgument(TCallable&& _callable, const char* _message) {
+    try {
+        std::forward<TCallable>(_callable)();
+    } catch (const std::invalid_argument&) {
+        return;
+    }
+    throw std::runtime_error(_message);
+}
+
+void LegacyVulkanStateMappingIsStageCompatible() {
+    const auto compute_srv = VkTracker::ResolveTextureState(
+        ETextureState::SHADER_RESOURCE,
+        EPassType::Compute,
+        false,
+        false
+    );
+    Expect(
+        std::get<0>(compute_srv) == VK_ACCESS_2_SHADER_READ_BIT &&
+            std::get<1>(compute_srv) ==
+                VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL &&
+            std::get<2>(compute_srv) ==
+                VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT,
+        "compute SRV texture mapping is not shader-stage compatible"
+    );
+
+    const auto raytracing_sampled = VkTracker::ResolveTextureState(
+        ETextureState::SAMPLE,
+        EPassType::Raytracing,
+        false,
+        false
+    );
+    Expect(
+        std::get<0>(raytracing_sampled) ==
+                VK_ACCESS_2_SHADER_SAMPLED_READ_BIT &&
+            std::get<2>(raytracing_sampled) ==
+                VK_PIPELINE_STAGE_2_RAY_TRACING_SHADER_BIT_KHR,
+        "raytracing sampled texture mapping lost its shader stage"
+    );
+
+    const auto graphics_srv = VkTracker::ResolveTextureState(
+        ETextureState::SHADER_RESOURCE,
+        EPassType::Graphics,
+        false,
+        false
+    );
+    Expect(
+        std::get<2>(graphics_srv) ==
+            (VK_PIPELINE_STAGE_2_VERTEX_SHADER_BIT |
+             VK_PIPELINE_STAGE_2_FRAGMENT_SHADER_BIT),
+        "graphics SRV texture mapping must cover vertex and fragment shaders"
+    );
+
+    const auto graphics_render_target_read =
+        VkTracker::ResolveTextureState(
+            ETextureState::RENDER_TARGET,
+            EPassType::Graphics,
+            false,
+            false
+        );
+    Expect(
+        std::get<0>(graphics_render_target_read) ==
+                VK_ACCESS_2_COLOR_ATTACHMENT_READ_BIT &&
+            std::get<1>(graphics_render_target_read) ==
+                VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL &&
+            std::get<2>(graphics_render_target_read) ==
+                VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT,
+        "graphics render-target read mapping lost queue-transfer compatibility"
+    );
+
+    const auto copy_src = VkTracker::ResolveTextureState(
+        ETextureState::TRANSFER,
+        EPassType::Copy,
+        false,
+        false
+    );
+    const auto copy_dst = VkTracker::ResolveTextureState(
+        ETextureState::TRANSFER,
+        EPassType::Copy,
+        true,
+        false
+    );
+    Expect(
+        std::get<0>(copy_src) == VK_ACCESS_2_TRANSFER_READ_BIT &&
+            std::get<1>(copy_src) == VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL &&
+            std::get<2>(copy_src) == VK_PIPELINE_STAGE_2_TRANSFER_BIT &&
+            std::get<0>(copy_dst) == VK_ACCESS_2_TRANSFER_WRITE_BIT &&
+            std::get<1>(copy_dst) == VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL &&
+            std::get<2>(copy_dst) == VK_PIPELINE_STAGE_2_TRANSFER_BIT,
+        "copy texture mapping is not transfer-stage compatible"
+    );
+
+    const auto depth_read = VkTracker::ResolveTextureState(
+        ETextureState::DEPTH_STENCIL,
+        EPassType::Graphics,
+        false,
+        true
+    );
+    Expect(
+        std::get<0>(depth_read) ==
+                VK_ACCESS_2_DEPTH_STENCIL_ATTACHMENT_READ_BIT &&
+            std::get<1>(depth_read) ==
+                VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL &&
+            std::get<2>(depth_read) ==
+                (VK_PIPELINE_STAGE_2_EARLY_FRAGMENT_TESTS_BIT |
+                 VK_PIPELINE_STAGE_2_LATE_FRAGMENT_TESTS_BIT),
+        "depth read mapping is not attachment-stage compatible"
+    );
+
+    const auto compute_uav = VkTracker::ResolveTextureState(
+        ETextureState::UNORDERED_ACCESS,
+        EPassType::Compute,
+        true,
+        false
+    );
+    Expect(
+        std::get<0>(compute_uav) ==
+                (VK_ACCESS_2_SHADER_READ_BIT |
+                 VK_ACCESS_2_SHADER_WRITE_BIT) &&
+            std::get<1>(compute_uav) == VK_IMAGE_LAYOUT_GENERAL &&
+            std::get<2>(compute_uav) ==
+                VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT,
+        "compute UAV texture mapping is not shader-stage compatible"
+    );
+
+    const auto copy_buffer_src = VkTracker::ResolveBufferState(
+        EBufferState::TRANSFER,
+        EPassType::Copy,
+        false
+    );
+    const auto raytracing_buffer_srv = VkTracker::ResolveBufferState(
+        EBufferState::SHADER_RESOURCE,
+        EPassType::Raytracing,
+        false
+    );
+    const auto graphics_buffer_srv = VkTracker::ResolveBufferState(
+        EBufferState::SHADER_RESOURCE,
+        EPassType::Graphics,
+        false
+    );
+    Expect(
+        std::get<0>(copy_buffer_src) == VK_ACCESS_2_TRANSFER_READ_BIT &&
+            std::get<1>(copy_buffer_src) ==
+                VK_PIPELINE_STAGE_2_TRANSFER_BIT &&
+            std::get<0>(raytracing_buffer_srv) ==
+                VK_ACCESS_2_SHADER_READ_BIT &&
+            std::get<1>(raytracing_buffer_srv) ==
+                VK_PIPELINE_STAGE_2_RAY_TRACING_SHADER_BIT_KHR &&
+            std::get<1>(graphics_buffer_srv) ==
+                (VK_PIPELINE_STAGE_2_VERTEX_SHADER_BIT |
+                 VK_PIPELINE_STAGE_2_FRAGMENT_SHADER_BIT),
+        "legacy buffer mapping lost copy or raytracing stage semantics"
+    );
+
+    ExpectInvalidArgument(
+        [] {
+            (void)VkTracker::ResolveTextureState(
+                ETextureState::SHADER_RESOURCE,
+                EPassType::Copy,
+                false,
+                false
+            );
+        },
+        "copy pass accepted a shader-resource texture"
+    );
+    ExpectInvalidArgument(
+        [] {
+            (void)VkTracker::ResolveTextureState(
+                ETextureState::RENDER_TARGET,
+                EPassType::Compute,
+                true,
+                false
+            );
+        },
+        "compute pass accepted a render-target attachment"
+    );
+    ExpectInvalidArgument(
+        [] {
+            (void)VkTracker::ResolveTextureState(
+                ETextureState::SAMPLE,
+                EPassType::Graphics,
+                true,
+                false
+            );
+        },
+        "write path accepted a sampled texture"
+    );
+    ExpectInvalidArgument(
+        [] {
+            (void)VkTracker::ResolveBufferState(
+                EBufferState::SHADER_RESOURCE,
+                EPassType::Copy,
+                false
+            );
+        },
+        "copy pass accepted a shader-resource buffer"
+    );
+    ExpectInvalidArgument(
+        [] {
+            (void)VkTracker::ResolveBufferState(
+                EBufferState::VERTEX,
+                EPassType::Graphics,
+                true
+            );
+        },
+        "write path accepted a vertex buffer"
+    );
+    ExpectInvalidArgument(
+        [] {
+            (void)VkTracker::ResolveTextureState(
+                ETextureState::TRANSFER,
+                static_cast<EPassType>(99),
+                false,
+                false
+            );
+        },
+        "texture mapping accepted an unknown pass type"
+    );
+    ExpectInvalidArgument(
+        [] {
+            (void)VkTracker::ResolveBufferState(
+                static_cast<EBufferState>(99),
+                EPassType::Graphics,
+                false
+            );
+        },
+        "buffer mapping accepted an unknown state"
+    );
 }
 
 int64 FindCommandLayer(
@@ -631,6 +862,7 @@ void ReleaseSentinelOverlapUsesExactBufferAndTextureRanges() {
 
 int main() {
     try {
+        LegacyVulkanStateMappingIsStageCompatible();
         LocalExplicitPayloadAndOwnershipArePreserved();
         ReleaseAndAcquirePayloadsPreserveEndpointAffinity();
         InvalidQueueTransferEndpointsFailWithoutMutation();


### PR DESCRIPTION
## Summary
- replace the mis-sized legacy Vulkan resource-state lookup tables with validated switch-based resolvers
- map Graphics, Compute, and Raytracing shader access to compatible Vulkan pipeline stages
- keep legacy QueueTransfer render-target and read/write UAV semantics intact while rejecting invalid Copy shader/attachment states
- cover the original Compute + SHADER_RESOURCE failure, Raytracing, Copy, attachment, UAV, and invalid-state cases in the explicit-barrier contract

## Why
The old texture stage tables used eight entries per row while indexing with `ETextureState::Num == 7`, and omitted the Raytracing row. Compute SHADER_RESOURCE consequently became SHADER_READ + TRANSFER, producing VUID 07454; Raytracing could index out of bounds. Buffer Copy states had the same row-boundary risk.

## Validation
- `cmake --build build-vs --config Debug --target MoerEditor TestRHIExplicitBarrier TestRHIParallelRecord TestRHIThreadOwnership TestRenderGraph TestVulkanHeaderContract -j 30`
- `ctest --test-dir build-vs -C Debug -R RHIExplicitBarrierContract|RHIParallelRecordContract|RHIThreadOwnershipContract|RenderGraphContract|VulkanHeaderContract --output-on-failure` (5/5 passed)
- Raytracing linear smoke: rendered Sponza, clean shutdown, zero Vulkan VUIDs; the previous 07454 batch is gone
- Raytracing RDG/parallel smoke: rendered Sponza and no 07454; a separate pre-existing graph-only presentation/UI layout VUID 09600 remains outside this PR