### PR TITLE
feat(rhi): define presentation source contract

### DIFF
--- a/source/runtime/render/renderer/common/UiFrameGraphPass.cpp
+++ b/source/runtime/render/renderer/common/UiFrameGraphPass.cpp
@@ -101,6 +101,7 @@ bool SupportsUiPresentation(const TextureRef& texture) {
            HasTextureUsage(
                texture,
                ETextureUsageFlags::COLOR_ATTACHMENT |
+                   ETextureUsageFlags::PRESENTATION_SOURCE |
                    ETextureUsageFlags::TRANSFER_SRC |
                    ETextureUsageFlags::TRANSFER_DST
            );
@@ -477,7 +478,7 @@ bool UiFrameGraphPass::AddPassesWithComposeRecorder(
     for (const auto target : target_handles) {
         graph.Export(
             target,
-            RenderGraph::TextureState::TransferSource,
+            RenderGraph::TextureState::PresentationSource,
             RenderGraph::QueueRole::Graphics,
             RenderGraph::AccessMode::Read
         );

--- a/source/runtime/render/renderer/common/UiFrameGraphPass.cpp
+++ b/source/runtime/render/renderer/common/UiFrameGraphPass.cpp
@@ -60,17 +60,17 @@ void AddUniqueTarget(Array<TextureRef>& targets, const TextureRef& texture) {
 }
 
 Array<TextureRef> CollectPresentationTargets(
-    const UiFrameGraphPass::PreparedFrame& frame,
-    const TextureRef&                      main_output
+    const UiCompositionFrameData& composition,
+    const UiDrawFramePacket&      draw_frame,
+    const TextureRef&             main_output
 ) {
     Array<TextureRef> targets{};
-    targets.reserve(frame.GetDrawFrame().platform_viewports.size() + 2);
+    targets.reserve(draw_frame.platform_viewports.size() + 2);
     AddUniqueTarget(targets, main_output);
-    const auto& composition = frame.GetComposition();
     if (composition.enabled && composition.separate_window) {
         AddUniqueTarget(targets, composition.window_frame_buffer);
     }
-    for (const auto& viewport : frame.GetDrawFrame().platform_viewports) {
+    for (const auto& viewport : draw_frame.platform_viewports) {
         AddUniqueTarget(targets, viewport.framebuffer);
     }
     return targets;
@@ -113,6 +113,25 @@ bool SupportsUiSceneSampling(const TextureRef& texture) {
 }
 
 bool CollectValidatedPresentationTargets(
+    const UiCompositionFrameData& composition,
+    const UiDrawFramePacket&      draw_frame,
+    const TextureRef&             main_output,
+    Array<TextureRef>&            targets
+) {
+    targets = CollectPresentationTargets(
+        composition, draw_frame, main_output
+    );
+    return !targets.empty() &&
+           std::none_of(
+               targets.begin(),
+               targets.end(),
+               [](const TextureRef& target) {
+                   return !SupportsUiPresentation(target);
+               }
+           );
+}
+
+bool CollectValidatedPresentationTargets(
     const UiFrameGraphPass::PreparedFrameRef& frame,
     const TextureRef&                         scene_color,
     const TextureRef&                         main_output,
@@ -123,15 +142,12 @@ bool CollectValidatedPresentationTargets(
         !SupportsUiPresentation(main_output)) {
         return false;
     }
-    targets = CollectPresentationTargets(*frame, main_output);
-    return !targets.empty() &&
-           std::none_of(
-               targets.begin(),
-               targets.end(),
-               [](const TextureRef& target) {
-                   return !SupportsUiPresentation(target);
-               }
-           );
+    return CollectValidatedPresentationTargets(
+        frame->GetComposition(),
+        frame->GetDrawFrame(),
+        main_output,
+        targets
+    );
 }
 
 TextureRef ResolveComposeTarget(
@@ -538,12 +554,63 @@ bool UiFrameGraphPass::ProcessLinearWithComposeRecorder(
         RecordClear(cmd_list, targets);
         compose_recorder(cmd_list);
         RecordDraw(cmd_list, *frame, main_output);
+
+        if (!RecordPresentationBoundary(
+                cmd_list,
+                frame->GetComposition(),
+                frame->GetDrawFrame(),
+                main_output
+            )) {
+            frame->Abandon();
+            return false;
+        }
+
         frame->FinishRecording();
         return frame->GetRecordingState() == ERecordingState::Recorded;
     } catch (...) {
         frame->Abandon();
         throw;
     }
+}
+
+bool UiFrameGraphPass::RecordPresentationBoundary(
+    CommandList&                  cmd_list,
+    const UiCompositionFrameData& composition,
+    const UiDrawFramePacket&      draw_frame,
+    const TextureRef&             main_output
+) {
+    Array<TextureRef> targets{};
+    if (!CollectValidatedPresentationTargets(
+            composition, draw_frame, main_output, targets
+        )) {
+        return false;
+    }
+
+    // Linear warm-up/fallback and Raster frame-tail packets remain
+    // BackendTracked. Declare their presentation boundary with a terminal
+    // legacy read instead of switching a mixed command stream to Explicit
+    // ownership. Vulkan restores these targets to their semantic preferred
+    // GENERAL layout and publishes readiness only after native acceptance.
+    Array<ReadTexture> presentation_sources{};
+    presentation_sources.reserve(targets.size());
+    for (const auto& target : targets) {
+        presentation_sources.emplace_back(ReadTexture{
+            target->GetView(
+                0,
+                static_cast<uint8>(target->GetNumMips())
+            ),
+            ETextureState::TRANSFER,
+            true,
+        });
+    }
+    cmd_list.TextureBarriers(
+        EQueueType::Graphics,
+        EQueueType::Graphics,
+        EPassType::Copy,
+        std::move(presentation_sources),
+        {}
+    );
+    return true;
 }
 
 void UiFrameGraphPass::RecordClear(

--- a/source/runtime/render/renderer/common/UiFrameGraphPass.h
+++ b/source/runtime/render/renderer/common/UiFrameGraphPass.h
@@ -119,6 +119,19 @@ public:
         const TextureRef&       main_output
     );
 
+    /**
+     * Records the terminal BackendTracked export used by UI paths whose draw
+     * commands live outside an explicit RenderGraph packet. Every main,
+     * detached-scene, and platform-window target is deduplicated and published
+     * only after the containing native Graphics submit is accepted.
+     */
+    [[nodiscard]] static bool RecordPresentationBoundary(
+        CommandList&                  cmd_list,
+        const UiCompositionFrameData& composition,
+        const UiDrawFramePacket&      draw_frame,
+        const TextureRef&             main_output
+    );
+
 private:
     /**
      * Trusted declaration seam shared by the production compositor and the

--- a/source/runtime/render/renderer/common/ui/DearImGuiRenderer.cpp
+++ b/source/runtime/render/renderer/common/ui/DearImGuiRenderer.cpp
@@ -857,6 +857,7 @@ void CreateOrResizeViewportResources(
         PF_R8G8B8A8_SRGB,
         ETextureUsageFlags::COLOR_ATTACHMENT |
             ETextureUsageFlags::SAMPLED |
+            ETextureUsageFlags::PRESENTATION_SOURCE |
             ETextureUsageFlags::TRANSFER_SRC |
             ETextureUsageFlags::TRANSFER_DST
     );

--- a/source/runtime/render/renderer/raster/RasterRenderer.cpp
+++ b/source/runtime/render/renderer/raster/RasterRenderer.cpp
@@ -26,6 +26,7 @@
 #include "config/ConfigManager.h"
 #include "debug/RenderDocApi.h"
 #include "misc/ScopedLogTimer.h"
+#include "renderer/common/UiFrameGraphPass.h"
 #include "rendergraph/RenderGraph.h"
 #include "rhi/RHIExecutor.h"
 #include "scene/testcase/SceneTestCaseDispatcher.h"
@@ -1493,13 +1494,28 @@ RasterFrameFeedback RasterRenderer::RenderFrame(RasterFramePacket frame_packet) 
         );
     } else {
         ui_slot_claim.Reject();
+        skip_present = true;
         LOG_CRITICAL(
             "[Threading][UI] Raster copied-frame upload slots could not be "
-            "claimed; preserving the slots and skipping this UI frame."
+            "claimed; preserving the slots and skipping this frame's presents."
         );
     }
 
     raster_context.probe_volume.TrackFrameSubmission(cmd_list, time);
+    if (!skip_present && ui_recording_claimed &&
+        !UiFrameGraphPass::RecordPresentationBoundary(
+            cmd_list,
+            frame_packet.ui_composition,
+            frame_packet.ui_draw_frame,
+            default_output_texture
+        )) {
+        skip_present = true;
+        LOG_CRITICAL(
+            "[Presentation] Raster UI frame tail did not satisfy the "
+            "presentation-source resource contract; skipping this frame's "
+            "main and platform-window presents."
+        );
+    }
     time++;
     // Host 同步的 copy 操作已经完成。此处触发 timeline，向 validation layer 传递执行顺序，
     // 无需再额外等待 copy queue。

--- a/source/runtime/render/renderer/raster/RasterTextures.h
+++ b/source/runtime/render/renderer/raster/RasterTextures.h
@@ -54,7 +54,8 @@ namespace Moer::Render::Raster {
       output,                                                                                                   \
       Tex2DTag,                                                                                                 \
       TexConfig::Default(PF_R8G8B8A8_SRGB)                                                                      \
-          .Usage(E_SAMPLED_COLOR | ETextureUsageFlags::TRANSFER_SRC | ETextureUsageFlags::TRANSFER_DST)         \
+          .Usage(E_SAMPLED_COLOR | ETextureUsageFlags::PRESENTATION_SOURCE |                                    \
+                 ETextureUsageFlags::TRANSFER_SRC | ETextureUsageFlags::TRANSFER_DST)                           \
           .OutputSize())                                                                                        \
     X(DepthBufferWithHandle,                                                                                    \
       depth_linear_sampler,                                                                                     \

--- a/source/runtime/render/renderer/raytracing/RaytracingRenderer.cpp
+++ b/source/runtime/render/renderer/raytracing/RaytracingRenderer.cpp
@@ -382,6 +382,7 @@ struct RaytracingRenderer::RuntimeState {
             Extent2D(renderer.resolution.x, renderer.resolution.y),
             renderer.swapchain->format,
             ETextureUsageFlags::COLOR_ATTACHMENT |
+                ETextureUsageFlags::PRESENTATION_SOURCE |
                 ETextureUsageFlags::TRANSFER_SRC |
                 ETextureUsageFlags::TRANSFER_DST
         )),
@@ -1981,6 +1982,7 @@ void RaytracingRenderer::RecreateFrameResources(uint2 new_extent) {
         Extent2D(new_extent.x, new_extent.y),
         swapchain->format,
         ETextureUsageFlags::COLOR_ATTACHMENT |
+            ETextureUsageFlags::PRESENTATION_SOURCE |
             ETextureUsageFlags::TRANSFER_SRC |
             ETextureUsageFlags::TRANSFER_DST
     );

--- a/source/runtime/render/rendergraph/RenderGraph.cpp
+++ b/source/runtime/render/rendergraph/RenderGraph.cpp
@@ -696,6 +696,7 @@ ToBarrierState(const RenderGraphLowering::Scope& scope, bool texture) {
             ToBarrierState(instruction.destination, true),
             instruction.texture_aspects
         );
+        output.publish_external_state = instruction.export_boundary;
         return materialize_transfer();
     }
 

--- a/source/runtime/render/rendergraph/RenderGraph.cpp
+++ b/source/runtime/render/rendergraph/RenderGraph.cpp
@@ -143,6 +143,8 @@ const char* ToString(RenderGraph::TextureState state) {
             return "undefined";
         case RenderGraph::TextureState::TransferSource:
             return "transfer-src";
+        case RenderGraph::TextureState::PresentationSource:
+            return "presentation-src";
         case RenderGraph::TextureState::TransferDestination:
             return "transfer-dst";
         case RenderGraph::TextureState::ShaderResource:

--- a/source/runtime/render/rendergraph/RenderGraph.h
+++ b/source/runtime/render/rendergraph/RenderGraph.h
@@ -328,6 +328,12 @@ public:
         Automatic,
         Undefined,
         TransferSource,
+        /**
+         * External presentation-copy source. This boundary-only state keeps
+         * the image in COMMON/GENERAL while establishing transfer-read
+         * visibility for the presentation queue.
+         */
+        PresentationSource,
         TransferDestination,
         ShaderResource,
         Sampled,

--- a/source/runtime/render/rendergraph/RenderGraphCompiler.cpp
+++ b/source/runtime/render/rendergraph/RenderGraphCompiler.cpp
@@ -87,6 +87,7 @@ ReasonLess(const RenderGraph::CompiledEdgeReason& lhs, const RenderGraph::Compil
         case State::Undefined:
             return false;
         case State::TransferSource:
+        case State::PresentationSource:
         case State::ShaderResource:
         case State::Sampled:
         case State::DepthStencilRead:
@@ -111,6 +112,7 @@ ReasonLess(const RenderGraph::CompiledEdgeReason& lhs, const RenderGraph::Compil
     switch (state) {
         case RenderGraph::TextureState::RenderTarget:
         case RenderGraph::TextureState::UnorderedAccess:
+        case RenderGraph::TextureState::PresentationSource:
         case RenderGraph::TextureState::Present:
             return selected == AspectMask(TextureAspect::Color);
         case RenderGraph::TextureState::DepthStencilRead:
@@ -555,7 +557,9 @@ bool RenderGraphCompiler::ValidateAccessState(
     if (resource.kind == ResourceKind::Texture) {
         supported = TextureStateSupports(state.texture, mode) &&
                     state.texture != RenderGraph::TextureState::Undefined &&
-                    state.texture != RenderGraph::TextureState::Present;
+                    state.texture != RenderGraph::TextureState::Present &&
+                    state.texture !=
+                        RenderGraph::TextureState::PresentationSource;
         transfer_state = state.texture == RenderGraph::TextureState::TransferSource ||
                          state.texture == RenderGraph::TextureState::TransferDestination;
         const bool attachment_state = state.texture == RenderGraph::TextureState::RenderTarget ||

--- a/source/runtime/render/rendergraph/RenderGraphCompiler.cpp
+++ b/source/runtime/render/rendergraph/RenderGraphCompiler.cpp
@@ -363,6 +363,23 @@ bool RenderGraphCompiler::NormalizeDeclarations() {
                 if (declaration.state.IsAutomatic()) {
                     return Fail("boundary state cannot be automatic on resource '" + resource.name + "'");
                 }
+                const bool presentation_source =
+                    resource.kind == ResourceKind::Texture &&
+                    declaration.state.texture ==
+                        RenderGraph::TextureState::PresentationSource;
+                if (presentation_source && initial) {
+                    return Fail(
+                        "PresentationSource is an export-boundary-only state on resource '" +
+                        resource.name + "'"
+                    );
+                }
+                if (presentation_source &&
+                    declaration.queue != RenderGraph::QueueRole::Graphics) {
+                    return Fail(
+                        "PresentationSource export requires the Graphics queue on resource '" +
+                        resource.name + "'"
+                    );
+                }
                 if (declaration.queue == RenderGraph::QueueRole::None &&
                     !declaration.state.IsUndefined()) {
                     return Fail("a known boundary state requires an owner queue on resource '" + resource.name + "'");

--- a/source/runtime/render/rendergraph/RenderGraphLowering.cpp
+++ b/source/runtime/render/rendergraph/RenderGraphLowering.cpp
@@ -807,6 +807,21 @@ bool RenderGraphLowering::Lower(
                     resource.name + "'";
             return false;
         }
+        if (state.state.kind == ResourceKind::Texture &&
+            state.state.texture == TextureState::PresentationSource) {
+            if (initial) {
+                error =
+                    "PresentationSource is an export-boundary-only state on resource '" +
+                    resource.name + "'";
+                return false;
+            }
+            if (state.queue != RenderGraph::QueueRole::Graphics) {
+                error =
+                    "PresentationSource export requires the Graphics queue on resource '" +
+                    resource.name + "'";
+                return false;
+            }
+        }
         if (!initial && state.state.IsUndefined()) {
             error = "Undefined state cannot be an export destination on resource '" +
                     resource.name + "'";

--- a/source/runtime/render/rendergraph/RenderGraphLowering.cpp
+++ b/source/runtime/render/rendergraph/RenderGraphLowering.cpp
@@ -75,6 +75,9 @@ template<typename Enum>
         case TextureState::TransferSource:
             layout = ETextureLayout::TEXTURE_LAYOUT_TRANSFER_SRC;
             return true;
+        case TextureState::PresentationSource:
+            layout = ETextureLayout::TEXTURE_LAYOUT_COMMON;
+            return true;
         case TextureState::TransferDestination:
             layout = ETextureLayout::TEXTURE_LAYOUT_TRANSFER_DST;
             return true;
@@ -147,6 +150,10 @@ template<typename Enum>
                 scope.access = ERHIAccessFlags::UNDEFINED;
                 return true;
             case TextureState::TransferSource:
+                scope.stages = ERHIPipelineStageFlags::PS_TRANSFER;
+                scope.access = ERHIAccessFlags::TRANSFER_READ;
+                return true;
+            case TextureState::PresentationSource:
                 scope.stages = ERHIPipelineStageFlags::PS_TRANSFER;
                 scope.access = ERHIAccessFlags::TRANSFER_READ;
                 return true;
@@ -773,6 +780,13 @@ bool RenderGraphLowering::Lower(
             access.state.texture == TextureState::Present) {
             return fail("Present state requires an external synchronization endpoint on resource '" +
                         resource.name + "'");
+        }
+        if (access.state.kind == ResourceKind::Texture &&
+            access.state.texture == TextureState::PresentationSource) {
+            return fail(
+                "PresentationSource is an export-boundary-only state on resource '" +
+                resource.name + "'"
+            );
         }
     }
 

--- a/source/runtime/render/rhi/RHICommand.h
+++ b/source/runtime/render/rhi/RHICommand.h
@@ -523,6 +523,10 @@ struct CmdSubmit {
 struct ReadTexture {
     TextureView   texture;
     ETextureState state;
+    // BackendTracked analogue of an explicit export boundary. The Vulkan
+    // backend may publish the restored external state only after the native
+    // submit containing this terminal read has been accepted.
+    bool          publish_external_state{false};
 };
 struct WriteTexture {
     TextureView   texture;
@@ -628,6 +632,10 @@ struct BarrierCreateInfo {
     // or a plane subset is transitioned.
     ETextureAspectFlags texture_aspects{ETextureAspectFlags::NONE};
     BarrierQueueTransfer queue_transfer{};
+    // Marks an upper-level export boundary whose accepted destination state
+    // may be consumed outside this command stream. Backends publish it only
+    // after the native submit has been accepted.
+    bool publish_external_state{false};
 
     static BarrierCreateInfo Transition(
         TextureView         _texture,
@@ -1752,7 +1760,12 @@ private:
         InnerWriteBuffer(_buffer.buffer, _buffer.state, _pass);
     }
     RENDER_API void InnerBarrier(ReadTexture _texture, EPassType _pass) {
-        InnerReadTexture(_texture.texture, _texture.state, _pass);
+        InnerReadTexture(
+            _texture.texture,
+            _texture.state,
+            _pass,
+            _texture.publish_external_state
+        );
     }
     RENDER_API void InnerBarrier(WriteTexture _texture, EPassType _pass) {
         InnerWriteTexture(_texture.texture, _texture.state, _pass);
@@ -1760,7 +1773,12 @@ private:
 
     RENDER_API void InnerReadBuffer(BufferView _buffer, EBufferState _state, EPassType _pass);
     RENDER_API void InnerWriteBuffer(BufferView _buffer, EBufferState _state, EPassType _pass);
-    RENDER_API void InnerReadTexture(TextureView _texture, ETextureState _state, EPassType _pass);
+    RENDER_API void InnerReadTexture(
+        TextureView   _texture,
+        ETextureState _state,
+        EPassType     _pass,
+        bool          _publish_external_state = false
+    );
     RENDER_API void InnerWriteTexture(TextureView _texture, ETextureState _state, EPassType _pass);
     RENDER_API void EndBarriers();
 

--- a/source/runtime/render/rhi/RHICommandList.cpp
+++ b/source/runtime/render/rhi/RHICommandList.cpp
@@ -1073,9 +1073,19 @@ void CommandList::InnerWriteBuffer(BufferView _buffer, EBufferState _state, EPas
     barrier->WriteBuffer(_buffer, _state, _pass);
 }
 
-void CommandList::InnerReadTexture(TextureView _texture, ETextureState _state, EPassType _pass) {
+void CommandList::InnerReadTexture(
+    TextureView   _texture,
+    ETextureState _state,
+    EPassType     _pass,
+    bool          _publish_external_state
+) {
     BarrierCmd* barrier = static_cast<BarrierCmd*>(current_barriers);
-    barrier->ReadTexture(_texture, _state, _pass);
+    barrier->ReadTexture(
+        _texture,
+        _state,
+        _pass,
+        _publish_external_state
+    );
 }
 
 void CommandList::InnerWriteTexture(TextureView _texture, ETextureState _state, EPassType _pass) {

--- a/source/runtime/render/rhi/RHICommon.h
+++ b/source/runtime/render/rhi/RHICommon.h
@@ -960,7 +960,12 @@ enum class ETextureUsageFlags : uint32_t {
     FRAGMENT_SHADING_RATE_ATTACHMENT = 1 << 15,
 
     VIDEO_ENCODE = 1 << 16,
-    // ATTACHMENT_FEEDBACK_LOOP = 1 << 17,
+    /**
+     * Texture is handed to the presentation-copy path. This is a semantic
+     * usage bit: native image usage is still supplied by TRANSFER_SRC, while
+     * backends keep the idle/preferred state compatible with presentation.
+     */
+    PRESENTATION_SOURCE = 1 << 17,
     // SRGB    = 1 << 18, // 这个Enum貌似没用
     PRESENT = 1 << 19,
     Num     = 20

--- a/source/runtime/render/rhi/RHIImpl.h
+++ b/source/runtime/render/rhi/RHIImpl.h
@@ -540,6 +540,7 @@ struct TextureBarrier {
     uint64        handle;
     ETextureState state;
     EPassType     pass_type;
+    bool          publish_external_state{false};
     uint          mip_level : 8;
     uint          mip_cnt : 8;
     uint          array_layer : 8;
@@ -560,6 +561,7 @@ struct ExplicitTextureBarrier {
     BarrierState        dst_state{};
     ETextureAspectFlags texture_aspects{ETextureAspectFlags::NONE};
     BarrierQueueTransfer queue_transfer{};
+    bool                publish_external_state{false};
     uint8               mip_level{};
     uint8               mip_count{1};
     uint8               array_layer{};
@@ -589,12 +591,18 @@ private:
     bool                  b_queue_transition = false;
 
 public:
-    BarrierCmd& ReadTexture(const TextureView& _view, ETextureState _dst_state, EPassType _pass_type) {
+    BarrierCmd& ReadTexture(
+        const TextureView& _view,
+        ETextureState      _dst_state,
+        EPassType          _pass_type,
+        bool               _publish_external_state = false
+    ) {
         read_textures.emplace_back(
             TextureBarrier{
                 reinterpret_cast<uint64>(_view.texture),
                 _dst_state,
                 _pass_type,
+                _publish_external_state,
                 _view.mip_level,
                 _view.num_mips,
                 _view.array_layer,
@@ -609,6 +617,7 @@ public:
                 reinterpret_cast<uint64>(_view.texture),
                 _dst_state,
                 _pass_type,
+                false,
                 _view.mip_level,
                 _view.num_mips,
                 _view.array_layer,
@@ -658,6 +667,8 @@ public:
                         .dst_state       = _barrier.dst_state,
                         .texture_aspects = _barrier.texture_aspects,
                         .queue_transfer  = _barrier.queue_transfer,
+                        .publish_external_state =
+                            _barrier.publish_external_state,
                         .mip_level       = _resource.mip_level,
                         .mip_count       = _resource.num_mips,
                         .array_layer     = _resource.array_layer,

--- a/source/runtime/render/rhi/RHIResource.h
+++ b/source/runtime/render/rhi/RHIResource.h
@@ -658,6 +658,9 @@ public:
     uint32_t GetNumArray() const {
         return info.array_size;
     }
+    uint32_t GetNumSamples() const {
+        return info.num_samples;
+    }
     uint32_t GetDepth() const {
         return info.depth;
     }

--- a/source/runtime/render/rhi/vulkan/RHICmdReorderer.h
+++ b/source/runtime/render/rhi/vulkan/RHICmdReorderer.h
@@ -1520,11 +1520,26 @@ public:
     void VisitCmd(const CustomDispatchCmd* _cmd) {
         m_arg_write_resources.clear();
         m_arg_read_resources.clear();
+        temp_writed_resources.clear();
         layer_offset = m_cmd_lists.size(); // make sure the custom dispatch command is in a separate scope
-        auto func    = [&](const TArg& _arg, ParamInfoFlags _flag) {
+        Array<BindlessArrayRef> bindless_arrays{};
+        UnorderedSet<BindlessArray*> seen_bindless{};
+        auto func = [&](const TArg& _arg, ParamInfoFlags _flag) {
+            if (std::holds_alternative<BindlessArrayRef>(_arg)) {
+                const BindlessArrayRef& bindless =
+                    std::get<BindlessArrayRef>(_arg);
+                if (bindless &&
+                    seen_bindless.emplace(bindless.Get()).second) {
+                    bindless_arrays.emplace_back(bindless);
+                }
+                return;
+            }
             VisitArgs(_arg, _flag.state_flags);
         };
         _cmd->IterateArgs(func);
+        for (const BindlessArrayRef& bindless : bindless_arrays) {
+            VisitBindlessArg(bindless, temp_writed_resources);
+        }
 
         // A side-effect-only custom dispatch may intentionally expose no
         // resource usages. Keep it in the isolated custom-command scope
@@ -1535,6 +1550,10 @@ public:
         }
         for (const auto& read_res : m_arg_read_resources) {
             RecordRead(std::get<1>(read_res), std::get<0>(read_res), m_dispatch_layer);
+        }
+        if (!bindless_arrays.empty()) {
+            m_max_bdls_layer =
+                std::max(m_max_bdls_layer, m_dispatch_layer);
         }
         AddCmd(_cmd, m_dispatch_layer);
         layer_offset = m_cmd_lists.size();

--- a/source/runtime/render/rhi/vulkan/RHICmdReorderer.h
+++ b/source/runtime/render/rhi/vulkan/RHICmdReorderer.h
@@ -896,7 +896,8 @@ public:
             read_resources.emplace_back(range_handle);
             read_ranges.emplace_back(range);
         }
-        for (const auto& [handle, state, pass_type, mip_level, mip_cnt, array_layer, array_cnt] :
+        for (const auto& [handle, state, pass_type, publish_external_state,
+                          mip_level, mip_cnt, array_layer, array_cnt] :
              _cmd->ReadTextures()) {
             RangeHandle* range_handle =
                 static_cast<RangeHandle*>(GetHandle(handle, ResourceType::Texture_Buffer));
@@ -915,7 +916,8 @@ public:
             write_ranges.emplace_back(range);
         }
 
-        for (const auto& [handle, state, pass_type, mip_level, mip_cnt, array_layer, array_cnt] :
+        for (const auto& [handle, state, pass_type, publish_external_state,
+                          mip_level, mip_cnt, array_layer, array_cnt] :
              _cmd->WriteTextures()) {
             RangeHandle* range_handle =
                 static_cast<RangeHandle*>(GetHandle(handle, ResourceType::Texture_Buffer));

--- a/source/runtime/render/rhi/vulkan/VulkanCommand.h
+++ b/source/runtime/render/rhi/vulkan/VulkanCommand.h
@@ -112,7 +112,9 @@ public:
         uint3          _src_offset,
         uint3          _dst_offset,
         uint32         _src_mip_level,
-        uint32         _dst_mip_level
+        uint32         _dst_mip_level,
+        VkImageLayout  _src_layout = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
+        VkImageLayout  _dst_layout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL
     );
     void BeginRendering(VkRenderingInfo&& _info);
     void EndRendering();

--- a/source/runtime/render/rhi/vulkan/VulkanCommandList.cpp
+++ b/source/runtime/render/rhi/vulkan/VulkanCommandList.cpp
@@ -476,8 +476,18 @@ void VulkanCmdList::CopyTexture(
     uint3          _src_offset,
     uint3          _dst_offset,
     uint32         _src_mip_level,
-    uint32         _dst_mip_level
+    uint32         _dst_mip_level,
+    VkImageLayout  _src_layout,
+    VkImageLayout  _dst_layout
 ) {
+    if ((_src_layout != VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL &&
+         _src_layout != VK_IMAGE_LAYOUT_GENERAL) ||
+        (_dst_layout != VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL &&
+         _dst_layout != VK_IMAGE_LAYOUT_GENERAL)) {
+        throw std::invalid_argument(
+            "vkCmdCopyImage requires GENERAL or transfer-optimal layouts"
+        );
+    }
     VkImageCopy copy_region = {
         .srcSubresource =
             {.aspectMask     = VK_IMAGE_ASPECT_COLOR_BIT,
@@ -507,9 +517,9 @@ void VulkanCmdList::CopyTexture(
     vkCmdCopyImage(
         command_buffer,
         _src->GetHandle(),
-        VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
+        _src_layout,
         _dst->GetHandle(),
-        VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+        _dst_layout,
         1,
         &copy_region
     );

--- a/source/runtime/render/rhi/vulkan/VulkanQueue.cpp
+++ b/source/runtime/render/rhi/vulkan/VulkanQueue.cpp
@@ -4103,10 +4103,14 @@ static void MarkSubmissionAccepted(
            _barrier.array_cnt == _texture.GetNumArray();
 }
 
+using VulkanPresentationSourceSnapshotCache =
+    UnorderedMap<VulkanBindlessArray*, Array<TextureRef>>;
+
 template<typename TVisitor>
 static void VisitPresentationTextureArgument(
-    const TArg& _argument,
-    TVisitor&&  _visitor
+    const TArg&                            _argument,
+    VulkanPresentationSourceSnapshotCache& _snapshot_cache,
+    TVisitor&&                             _visitor
 ) {
     std::visit(
         [&](const auto& _resource) {
@@ -4127,8 +4131,15 @@ static void VisitPresentationTextureArgument(
                         static_cast<VulkanBindlessArray*>(
                             _resource.Get()
                         );
+                    auto [snapshot_it, inserted] =
+                        _snapshot_cache.try_emplace(bindless);
+                    if (inserted) {
+                        snapshot_it->second =
+                            bindless
+                                ->SnapshotPresentationSourceTextures();
+                    }
                     for (const TextureRef& texture :
-                         bindless->SnapshotPresentationSourceTextures()) {
+                         snapshot_it->second) {
                         _visitor(texture.Get());
                     }
                 }
@@ -4140,25 +4151,30 @@ static void VisitPresentationTextureArgument(
 
 template<typename TVisitor>
 static void VisitPresentationTextureArguments(
-    const ArrayArguments& _arguments,
-    TVisitor&&             _visitor
+    const ArrayArguments&                   _arguments,
+    VulkanPresentationSourceSnapshotCache&  _snapshot_cache,
+    TVisitor&&                              _visitor
 ) {
     for (const TArg& argument : _arguments.args) {
         VisitPresentationTextureArgument(
-            argument, std::forward<TVisitor>(_visitor)
+            argument,
+            _snapshot_cache,
+            std::forward<TVisitor>(_visitor)
         );
     }
 }
 
 template<typename TVisitor>
 static void VisitPresentationTextureArguments(
-    const TShaderArgArray& _arguments,
-    const TCachedArgArray& _cached_arguments,
-    TVisitor&&             _visitor
+    const TShaderArgArray&                  _arguments,
+    const TCachedArgArray&                  _cached_arguments,
+    VulkanPresentationSourceSnapshotCache& _snapshot_cache,
+    TVisitor&&                              _visitor
 ) {
     if (std::holds_alternative<ArrayArguments>(_arguments)) {
         VisitPresentationTextureArguments(
             std::get<ArrayArguments>(_arguments),
+            _snapshot_cache,
             std::forward<TVisitor>(_visitor)
         );
         return;
@@ -4169,6 +4185,7 @@ static void VisitPresentationTextureArguments(
         if (index < _cached_arguments.size()) {
             VisitPresentationTextureArguments(
                 _cached_arguments[index],
+                _snapshot_cache,
                 std::forward<TVisitor>(_visitor)
             );
         }
@@ -4186,6 +4203,7 @@ BuildPresentationSourceStateDelta(
 ) {
     Array<VulkanPresentationSourceStateDelta> delta{};
     delta.reserve(_submit.cmds.size());
+    VulkanPresentationSourceSnapshotCache bindless_snapshot_cache{};
 
     const auto record_texture =
         [&](Texture* _texture, bool _ready) {
@@ -4221,6 +4239,7 @@ BuildPresentationSourceStateDelta(
             VisitPresentationTextureArguments(
                 _arguments,
                 _submit.cached_args,
+                bindless_snapshot_cache,
                 [&](Texture* _texture) {
                     record_texture(_texture, false);
                 }
@@ -4346,6 +4365,7 @@ BuildPresentationSourceStateDelta(
                     *static_cast<const DispatchCmd*>(command);
                 VisitPresentationTextureArguments(
                     dispatch.Args(_submit.cached_args),
+                    bindless_snapshot_cache,
                     [&](Texture* _texture) {
                         record_texture(_texture, false);
                     }
@@ -4357,6 +4377,7 @@ BuildPresentationSourceStateDelta(
                     *static_cast<const TraceRayCmd*>(command);
                 VisitPresentationTextureArguments(
                     trace.Args(),
+                    bindless_snapshot_cache,
                     [&](Texture* _texture) {
                         record_texture(_texture, false);
                     }
@@ -4409,6 +4430,7 @@ BuildPresentationSourceStateDelta(
                     *static_cast<const SetDrawStateCmd*>(command);
                 VisitPresentationTextureArguments(
                     draw.Args(),
+                    bindless_snapshot_cache,
                     [&](Texture* _texture) {
                         record_texture(_texture, false);
                     }
@@ -4445,6 +4467,7 @@ BuildPresentationSourceStateDelta(
                         [&](const TArg& argument, ParamInfoFlags) {
                             VisitPresentationTextureArgument(
                                 argument,
+                                bindless_snapshot_cache,
                                 [&](Texture* _texture) {
                                     record_texture(_texture, false);
                                 }

--- a/source/runtime/render/rhi/vulkan/VulkanQueue.cpp
+++ b/source/runtime/render/rhi/vulkan/VulkanQueue.cpp
@@ -49,6 +49,126 @@ std::atomic<const VulkanScriptedQueryPreparationOverrideForTesting*>
 std::atomic<const VulkanScriptedPresentOverrideForTesting*>
     g_scripted_present_override{nullptr};
 
+struct VulkanPresentSourceContract {
+    bool        valid{false};
+    const char* reason{"unknown present-source contract failure"};
+};
+
+[[nodiscard]] bool AreVulkanCopyFormatsSizeCompatible(
+    EPixelFormat _source,
+    EPixelFormat _destination
+) noexcept {
+    const uint source_index = static_cast<uint>(_source);
+    const uint destination_index = static_cast<uint>(_destination);
+    constexpr uint first_single_plane_color =
+        static_cast<uint>(PF_R4G4_UNORM_PACK8);
+    constexpr uint last_single_plane_color =
+        static_cast<uint>(PF_E5B9G9R9_UFLOAT_PACK32);
+    const auto is_known_single_plane_color = [](
+        uint _format_index
+    ) noexcept {
+        return _format_index >= first_single_plane_color &&
+               _format_index <= last_single_plane_color;
+    };
+    if (!is_known_single_plane_color(source_index) ||
+        !is_known_single_plane_color(destination_index)) {
+        return false;
+    }
+
+    const FormatInfo& source =
+        g_platform_pixel_formats[source_index];
+    const FormatInfo& destination =
+        g_platform_pixel_formats[destination_index];
+    return source.format != VK_FORMAT_UNDEFINED &&
+           destination.format != VK_FORMAT_UNDEFINED &&
+           source.stride != 0 &&
+           source.stride == destination.stride;
+}
+
+[[nodiscard]] VulkanPresentSourceContract ValidatePresentSourceContract(
+    const TextureView& _view,
+    const Swapchain*   _swapchain
+) noexcept {
+    if (_swapchain == nullptr) {
+        return {false, "Vulkan Present requires a swapchain"};
+    }
+    const Texture* texture = _view.texture;
+    if (texture == nullptr) {
+        return {false, "Vulkan Present requires a source texture"};
+    }
+    if ((texture->GetUsage() &
+         ETextureUsageFlags::PRESENTATION_SOURCE) !=
+        ETextureUsageFlags::PRESENTATION_SOURCE) {
+        return {
+            false,
+            "Vulkan present source must declare PRESENTATION_SOURCE usage"
+        };
+    }
+    if ((texture->GetUsage() &
+         ETextureUsageFlags::TRANSFER_SRC) !=
+        ETextureUsageFlags::TRANSFER_SRC) {
+        return {
+            false,
+            "Vulkan present source must declare TRANSFER_SRC usage"
+        };
+    }
+    if (texture->GetDimension() != ETextureDimension::TEX_2D) {
+        return {false, "Vulkan present source must be a 2D texture"};
+    }
+    if (texture->GetAspectFlags() != ETextureAspectFlags::COLOR) {
+        return {false, "Vulkan present source must be color-only"};
+    }
+    if (texture->GetNumSamples() != 1) {
+        return {
+            false,
+            "Vulkan present source must be single-sampled for vkCmdCopyImage"
+        };
+    }
+    if (!AreVulkanCopyFormatsSizeCompatible(
+            texture->GetFormat(), _swapchain->format
+        )) {
+        return {
+            false,
+            "Vulkan present source and swapchain formats must be size-compatible"
+        };
+    }
+    if (_view.offset.x != 0 || _view.offset.y != 0 ||
+        _view.offset.z != 0) {
+        return {false, "Vulkan present source offset must be zero"};
+    }
+    if (_view.mip_level != 0 || _view.num_mips != 1) {
+        return {
+            false,
+            "Vulkan present source must select exactly mip level zero"
+        };
+    }
+    if (_view.array_layer != 0 || _view.num_array != 1) {
+        return {
+            false,
+            "Vulkan present source must select exactly array layer zero"
+        };
+    }
+
+    const uint3 texture_extent = texture->GetExtent();
+    if (_view.extent.x != texture_extent.x ||
+        _view.extent.y != texture_extent.y ||
+        _view.extent.z != texture_extent.z) {
+        return {
+            false,
+            "Vulkan present source view must cover the complete texture extent"
+        };
+    }
+    if (_view.extent.z != 1 ||
+        _view.extent.x != _swapchain->size.x ||
+        _view.extent.y != _swapchain->size.y) {
+        return {
+            false,
+            "Vulkan present source extent must match the 2D swapchain"
+        };
+    }
+    return {true, ""};
+}
+
 void NotifyNativeSubmission(
     EQueueType                   _queue,
     VkQueue                      _native_queue,
@@ -4547,9 +4667,30 @@ VulkanRuntimeSubmissionResult VkCommandQueue::PresentForRuntime(
         GetCurrentRHIThreadRole() == ERHIThreadRole::Submission &&
         "runtime Present must run on the Submission owner"
     );
-    assert(_source.texture != nullptr && "Present source texture is null");
     try {
         TextureRef source_texture{_source.texture};
+        const VulkanPresentSourceContract source_contract =
+            ValidatePresentSourceContract(
+                _source, _swapchain.Get()
+            );
+        if (!source_contract.valid) {
+            vk_device.RecordRejectedPresent();
+            ResolvePresentReceiptNoexcept(_receipt, false, false);
+            try {
+                LOG_ERROR(
+                    "[RHIExecutor][Vulkan] rejected Present source contract: {}",
+                    source_contract.reason
+                );
+            } catch (...) {
+            }
+            return {
+                .outcome = {
+                    EVulkanOperationStatus::Rejected,
+                    VK_ERROR_UNKNOWN
+                },
+                .recoverable_rejection = true,
+            };
+        }
         if (vk_device.IsFaulted()) {
             vk_device.RecordRejectedPresent();
             ResolvePresentReceiptNoexcept(_receipt, false, false);
@@ -6656,7 +6797,6 @@ void VkCommandQueue::Present(
     TextureView       _view,
     PresentReceiptRef _receipt
 ) {
-    assert(_view.texture != nullptr && "Present source texture is null");
     TextureRef source_texture{_view.texture};
 
     if (!ClaimLegacyOwnership("Present")) {
@@ -6766,6 +6906,13 @@ VulkanRuntimeSubmissionResult VkCommandQueue::PresentNow(
     Array<RHIResource*>        deferred_releases{};
 
     try {
+        const VulkanPresentSourceContract source_contract =
+            ValidatePresentSourceContract(_view, _sc.Get());
+        if (!source_contract.valid) {
+            throw std::invalid_argument(source_contract.reason);
+        }
+        auto* vk_source_texture =
+            static_cast<VulkanTexture*>(_view.texture);
         if (vk_device.IsFaulted()) {
             vk_device.RecordRejectedPresent();
             final_outcome = {
@@ -6797,7 +6944,7 @@ VulkanRuntimeSubmissionResult VkCommandQueue::PresentNow(
                     auto& vk_allocator = *presentor;
                     auto& vk_cmd_list  = vk_allocator.GetCmdList();
                     auto& vk_tracker   = vk_allocator.GetTracker();
-                    auto* vk_src_tex   = static_cast<VulkanTexture*>(_view.texture);
+                    auto* vk_src_tex   = vk_source_texture;
                     const uint idx     = acquire.image_index;
                     auto* swapchain_tex =
                         ResourceCast(sc->GetSwapchainImage(idx).texture);
@@ -6809,9 +6956,32 @@ VulkanRuntimeSubmissionResult VkCommandQueue::PresentNow(
                         present_label, {0.0f, 0.85f, 0.95f, 1.0f}
                     );
                     vk_tracker.SetPassType(EPassType::Graphics);
-                    vk_tracker.RecordState(
+                    // PRESENTATION_SOURCE is a producer-side terminal
+                    // contract. The active graph exports GENERAL with
+                    // TRANSFER_READ visibility, while legacy recording
+                    // restores these textures to their GENERAL preferred
+                    // layout. Present consumes that state directly instead
+                    // of guessing and changing the source layout here. A
+                    // GENERAL->GENERAL memory barrier still connects the
+                    // accepted producer writes to this copy.
+                    vk_tracker.EmitExplicitBarrier(
                         vk_src_tex,
-                        vk_tracker.ReadTexture(vk_src_tex, ETextureState::TRANSFER)
+                        VulkanEnumTranslator::METoVKImageAspectFlags(
+                            vk_src_tex->GetAspectFlags()
+                        ),
+                        0,
+                        1,
+                        0,
+                        1,
+                        EBarrierQueueTransferPhase::None,
+                        VK_QUEUE_FAMILY_IGNORED,
+                        VK_QUEUE_FAMILY_IGNORED,
+                        VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT,
+                        VK_ACCESS_2_MEMORY_WRITE_BIT,
+                        VK_IMAGE_LAYOUT_GENERAL,
+                        VK_PIPELINE_STAGE_2_COPY_BIT,
+                        VK_ACCESS_2_TRANSFER_READ_BIT,
+                        VK_IMAGE_LAYOUT_GENERAL
                     );
                     vk_tracker.RecordState(
                         swapchain_tex,
@@ -6831,7 +7001,9 @@ VulkanRuntimeSubmissionResult VkCommandQueue::PresentNow(
                         {0, 0, 0},
                         {0, 0, 0},
                         0,
-                        0
+                        0,
+                        VK_IMAGE_LAYOUT_GENERAL,
+                        VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL
                     );
                     vk_tracker.RecordState(
                         swapchain_tex,
@@ -6840,8 +7012,6 @@ VulkanRuntimeSubmissionResult VkCommandQueue::PresentNow(
                         VK_PIPELINE_STAGE_2_COPY_BIT
                     );
                     vk_tracker.ResolveBarriers();
-                    vk_tracker.DispatchBarriers(vk_cmd_list);
-                    vk_tracker.RestoreState();
                     vk_tracker.DispatchBarriers(vk_cmd_list);
                     vk_cmd_list.EndLabel();
                     VK_CHECK_RESULT(vk_cmd_list.End());

--- a/source/runtime/render/rhi/vulkan/VulkanQueue.cpp
+++ b/source/runtime/render/rhi/vulkan/VulkanQueue.cpp
@@ -54,6 +54,31 @@ struct VulkanPresentSourceContract {
     const char* reason{"unknown present-source contract failure"};
 };
 
+void InvokePresentSourceRejectionCallbackForTesting(
+    const VulkanScriptedPresentOverrideForTesting* _override
+) noexcept {
+    if (_override != nullptr &&
+        _override->before_source_rejection != nullptr) {
+        _override->before_source_rejection(_override->context);
+    }
+}
+
+[[nodiscard]] VulkanOperationResult ClassifyPresentSourceRejection(
+    VulkanDevice& _device,
+    bool&         _recoverable_rejection
+) noexcept {
+    // This acquire is the rejection linearization point. A device fault may
+    // latch after the optimistic check at Present entry while the source
+    // contract/readiness is being inspected; never report that already
+    // latched hard failure as a recoverable source error.
+    const bool faulted = _device.IsFaulted();
+    _recoverable_rejection = !faulted;
+    return {
+        EVulkanOperationStatus::Rejected,
+        faulted ? _device.GetFirstFaultResult() : VK_ERROR_UNKNOWN,
+    };
+}
+
 [[nodiscard]] bool AreVulkanCopyFormatsSizeCompatible(
     EPixelFormat _source,
     EPixelFormat _destination
@@ -4027,44 +4052,12 @@ static void MarkSubmissionAccepted(
 }
 
 [[nodiscard]] static bool IsPresentationSourceTexture(
-    const VulkanTexture* _texture
+    const Texture* _texture
 ) noexcept {
     return _texture != nullptr &&
            (_texture->GetUsage() &
             ETextureUsageFlags::PRESENTATION_SOURCE) ==
                ETextureUsageFlags::PRESENTATION_SOURCE;
-}
-
-[[nodiscard]] static bool BarrierReferencesTexture(
-    const BarrierCmd& _command,
-    uint64            _handle
-) noexcept {
-    const auto matches = [_handle](const auto& _barrier) {
-        return _barrier.handle == _handle;
-    };
-    return std::ranges::any_of(_command.ReadTextures(), matches) ||
-           std::ranges::any_of(_command.WriteTextures(), matches) ||
-           std::ranges::any_of(_command.ExplicitTextures(), matches);
-}
-
-[[nodiscard]] static bool HasLaterTextureBarrierReference(
-    const CmdSubmit& _submit,
-    size_t           _command_index,
-    uint64           _handle
-) noexcept {
-    for (size_t index = _command_index + 1;
-         index < _submit.cmds.size();
-         ++index) {
-        const Command* command = _submit.cmds[index].get();
-        if (command != nullptr &&
-            command->Type() == Command::EType::Barrier &&
-            BarrierReferencesTexture(
-                static_cast<const BarrierCmd&>(*command), _handle
-            )) {
-            return true;
-        }
-    }
-    return false;
 }
 
 [[nodiscard]] static bool IsAcceptedPresentationSourcePublication(
@@ -4110,104 +4103,397 @@ static void MarkSubmissionAccepted(
            _barrier.array_cnt == _texture.GetNumArray();
 }
 
-// Commit only the final presentation-source delta from an accepted native
-// packet. A later accepted barrier that leaves the external GENERAL /
-// TRANSFER_READ contract clears readiness; rejected packets never call here.
-static void PublishAcceptedPresentationSourceStates(
-    const CmdSubmit& _submit,
-    EQueueType       _accepted_queue
-) noexcept {
-    for (size_t command_index = 0;
-         command_index < _submit.cmds.size();
-         ++command_index) {
-        const Command* command = _submit.cmds[command_index].get();
-        if (command == nullptr ||
-            command->Type() != Command::EType::Barrier) {
-            continue;
+template<typename TVisitor>
+static void VisitPresentationTextureArgument(
+    const TArg& _argument,
+    TVisitor&&  _visitor
+) {
+    std::visit(
+        [&](const auto& _resource) {
+            using TResource = std::decay_t<decltype(_resource)>;
+            if constexpr (std::is_same_v<TResource, TextureView>) {
+                _visitor(_resource.GetTexture());
+            } else if constexpr (
+                std::is_same_v<TResource, TextureViewArray>
+            ) {
+                for (const TextureView& view : _resource) {
+                    _visitor(view.GetTexture());
+                }
+            } else if constexpr (
+                std::is_same_v<TResource, BindlessArrayRef>
+            ) {
+                if (_resource) {
+                    auto* bindless =
+                        static_cast<VulkanBindlessArray*>(
+                            _resource.Get()
+                        );
+                    for (const TextureRef& texture :
+                         bindless->SnapshotPresentationSourceTextures()) {
+                        _visitor(texture.Get());
+                    }
+                }
+            }
+        },
+        _argument
+    );
+}
+
+template<typename TVisitor>
+static void VisitPresentationTextureArguments(
+    const ArrayArguments& _arguments,
+    TVisitor&&             _visitor
+) {
+    for (const TArg& argument : _arguments.args) {
+        VisitPresentationTextureArgument(
+            argument, std::forward<TVisitor>(_visitor)
+        );
+    }
+}
+
+template<typename TVisitor>
+static void VisitPresentationTextureArguments(
+    const TShaderArgArray& _arguments,
+    const TCachedArgArray& _cached_arguments,
+    TVisitor&&             _visitor
+) {
+    if (std::holds_alternative<ArrayArguments>(_arguments)) {
+        VisitPresentationTextureArguments(
+            std::get<ArrayArguments>(_arguments),
+            std::forward<TVisitor>(_visitor)
+        );
+        return;
+    }
+    if (std::holds_alternative<ArrayArgReference>(_arguments)) {
+        const uint index =
+            std::get<ArrayArgReference>(_arguments).handle;
+        if (index < _cached_arguments.size()) {
+            VisitPresentationTextureArguments(
+                _cached_arguments[index],
+                std::forward<TVisitor>(_visitor)
+            );
         }
-        const auto& barrier_command =
-            static_cast<const BarrierCmd&>(*command);
+    }
+}
 
-        const auto publish_terminal =
-            [&](uint64 _handle) noexcept {
-                if (HasLaterTextureBarrierReference(
-                        _submit, command_index, _handle
-                    )) {
-                    return;
-                }
-                auto* texture =
-                    reinterpret_cast<VulkanTexture*>(_handle);
-                if (!IsPresentationSourceTexture(texture)) {
-                    return;
-                }
+// Freeze one last-reference-wins delta from source command order before
+// CmdReorderer or parallel translation can change execution topology. Every
+// declared use closes a previous export; only an exact terminal Graphics
+// publication re-opens the external Present contract.
+static Array<VulkanPresentationSourceStateDelta>
+BuildPresentationSourceStateDelta(
+    const CmdSubmit& _submit,
+    EQueueType       _queue
+) {
+    Array<VulkanPresentationSourceStateDelta> delta{};
+    delta.reserve(_submit.cmds.size());
 
-                bool ready = false;
-                if (_accepted_queue != EQueueType::Graphics) {
-                    ready = false;
-                } else if (_submit.HasExplicitResourceStateOwnership()) {
-                    const auto& explicit_barriers =
-                        barrier_command.ExplicitTextures();
-                    const auto terminal = std::find_if(
-                        explicit_barriers.rbegin(),
-                        explicit_barriers.rend(),
-                        [_handle](const ExplicitTextureBarrier& _barrier) {
-                            return _barrier.handle == _handle;
-                        }
-                    );
+    const auto record_texture =
+        [&](Texture* _texture, bool _ready) {
+            if (!IsPresentationSourceTexture(_texture)) {
+                return;
+            }
+            auto existing = std::find_if(
+                delta.begin(),
+                delta.end(),
+                [_texture](
+                    const VulkanPresentationSourceStateDelta& _entry
+                ) {
+                    return _entry.texture.Get() == _texture;
+                }
+            );
+            if (existing != delta.end()) {
+                existing->ready = _ready;
+                return;
+            }
+            delta.emplace_back(
+                VulkanPresentationSourceStateDelta{
+                    .texture = TextureRef(_texture),
+                    .ready   = _ready,
+                }
+            );
+        };
+    const auto record_view =
+        [&](const TextureView& _view) {
+            record_texture(_view.GetTexture(), false);
+        };
+    const auto record_shader_arguments =
+        [&](const auto& _arguments) {
+            VisitPresentationTextureArguments(
+                _arguments,
+                _submit.cached_args,
+                [&](Texture* _texture) {
+                    record_texture(_texture, false);
+                }
+            );
+        };
+    const auto record_render_pass =
+        [&](const RenderPassInfo& _render_pass) {
+            if (_render_pass.depth_attachment.Valid()) {
+                record_texture(
+                    _render_pass.depth_attachment.target, false
+                );
+            }
+            for (const ColorAttachment& attachment :
+                 _render_pass.color_attachments) {
+                record_texture(attachment.target, false);
+            }
+        };
+    const auto record_barrier =
+        [&](const BarrierCmd& _command, uint64 _handle) {
+            auto* texture =
+                reinterpret_cast<VulkanTexture*>(_handle);
+            if (!IsPresentationSourceTexture(texture)) {
+                return;
+            }
+
+            size_t reference_count = 0;
+            const TextureBarrier* legacy_publication = nullptr;
+            const ExplicitTextureBarrier*
+                explicit_publication = nullptr;
+            for (const TextureBarrier& barrier :
+                 _command.ReadTextures()) {
+                if (barrier.handle == _handle) {
+                    ++reference_count;
+                    legacy_publication = &barrier;
+                }
+            }
+            for (const TextureBarrier& barrier :
+                 _command.WriteTextures()) {
+                if (barrier.handle == _handle) {
+                    ++reference_count;
+                }
+            }
+            for (const ExplicitTextureBarrier& barrier :
+                 _command.ExplicitTextures()) {
+                if (barrier.handle == _handle) {
+                    ++reference_count;
+                    explicit_publication = &barrier;
+                }
+            }
+
+            bool ready = false;
+            if (_queue == EQueueType::Graphics &&
+                reference_count == 1) {
+                if (_submit.HasExplicitResourceStateOwnership()) {
                     ready =
-                        terminal != explicit_barriers.rend() &&
+                        explicit_publication != nullptr &&
                         IsAcceptedPresentationSourcePublication(
-                            *terminal, *texture
+                            *explicit_publication, *texture
                         );
                 } else {
-                    // A successful BackendTracked translation restores every
-                    // touched texture after its terminal legacy barrier. Only
-                    // one full-range, explicitly published TRANSFER read is a
-                    // presentation boundary; terminal writes, partial reads,
-                    // or incidental legacy barriers clear readiness.
-                    const TextureBarrier* publication = nullptr;
-                    size_t reference_count = 0;
-                    for (const TextureBarrier& barrier :
-                         barrier_command.ReadTextures()) {
-                        if (barrier.handle == _handle) {
-                            ++reference_count;
-                            publication = &barrier;
-                        }
-                    }
-                    for (const TextureBarrier& barrier :
-                         barrier_command.WriteTextures()) {
-                        if (barrier.handle == _handle) {
-                            ++reference_count;
-                        }
-                    }
-                    for (const ExplicitTextureBarrier& barrier :
-                         barrier_command.ExplicitTextures()) {
-                        if (barrier.handle == _handle) {
-                            ++reference_count;
-                        }
-                    }
                     ready =
-                        reference_count == 1 &&
-                        publication != nullptr &&
+                        legacy_publication != nullptr &&
                         IsAcceptedPresentationSourcePublication(
-                            *publication, *texture
+                            *legacy_publication, *texture
                         );
                 }
-                texture->PublishPresentationSourceReady(ready);
-            };
+            }
+            record_texture(texture, ready);
+        };
 
-        for (const TextureBarrier& barrier :
-             barrier_command.ReadTextures()) {
-            publish_terminal(barrier.handle);
+    for (const UniquePtr<Command>& command_owner :
+         _submit.cmds) {
+        const Command* command = command_owner.get();
+        if (command == nullptr) {
+            continue;
         }
-        for (const TextureBarrier& barrier :
-             barrier_command.WriteTextures()) {
-            publish_terminal(barrier.handle);
+        switch (command->Type()) {
+            case Command::EType::CopyBackTexture: {
+                const auto& copy =
+                    *static_cast<const CopyBackTextureCmd*>(command);
+                record_texture(
+                    reinterpret_cast<Texture*>(copy.Handle()), false
+                );
+                break;
+            }
+            case Command::EType::BufferToTexture: {
+                const auto& copy =
+                    *static_cast<const CopyBufferToTextureCmd*>(command);
+                record_texture(
+                    reinterpret_cast<Texture*>(copy.DstHandle()), false
+                );
+                break;
+            }
+            case Command::EType::TextureToBuffer: {
+                const auto& copy =
+                    *static_cast<const CopyTextureToBufferCmd*>(command);
+                record_texture(
+                    reinterpret_cast<Texture*>(copy.SrcHandle()), false
+                );
+                break;
+            }
+            case Command::EType::UploadTexture: {
+                const auto& upload =
+                    *static_cast<const UploadTextureCmd*>(command);
+                record_texture(
+                    reinterpret_cast<Texture*>(upload.Handle()), false
+                );
+                break;
+            }
+            case Command::EType::TextureToTexture: {
+                const auto& copy =
+                    *static_cast<const CopyTextureCmd*>(command);
+                record_texture(
+                    reinterpret_cast<Texture*>(copy.SrcHandle()), false
+                );
+                record_texture(
+                    reinterpret_cast<Texture*>(copy.DstHandle()), false
+                );
+                break;
+            }
+            case Command::EType::ShaderDispatch: {
+                const auto& dispatch =
+                    *static_cast<const DispatchCmd*>(command);
+                VisitPresentationTextureArguments(
+                    dispatch.Args(_submit.cached_args),
+                    [&](Texture* _texture) {
+                        record_texture(_texture, false);
+                    }
+                );
+                break;
+            }
+            case Command::EType::TraceRay: {
+                const auto& trace =
+                    *static_cast<const TraceRayCmd*>(command);
+                VisitPresentationTextureArguments(
+                    trace.Args(),
+                    [&](Texture* _texture) {
+                        record_texture(_texture, false);
+                    }
+                );
+                break;
+            }
+            case Command::EType::Barrier: {
+                const auto& barrier_command =
+                    *static_cast<const BarrierCmd*>(command);
+                for (const TextureBarrier& barrier :
+                     barrier_command.ReadTextures()) {
+                    record_barrier(
+                        barrier_command, barrier.handle
+                    );
+                }
+                for (const TextureBarrier& barrier :
+                     barrier_command.WriteTextures()) {
+                    record_barrier(
+                        barrier_command, barrier.handle
+                    );
+                }
+                for (const ExplicitTextureBarrier& barrier :
+                     barrier_command.ExplicitTextures()) {
+                    record_barrier(
+                        barrier_command, barrier.handle
+                    );
+                }
+                break;
+            }
+            case Command::EType::QueueTransfer: {
+                const auto& transfer =
+                    *static_cast<const QueueTransferCmd*>(command);
+                if (transfer.IsImport()) {
+                    for (const auto& [view, state] :
+                         transfer.ImportTextures()) {
+                        (void)state;
+                        record_view(view);
+                    }
+                } else {
+                    for (const auto& [view, state] :
+                         transfer.ExportTextures()) {
+                        (void)state;
+                        record_view(view);
+                    }
+                }
+                break;
+            }
+            case Command::EType::SetDrawState: {
+                const auto& draw =
+                    *static_cast<const SetDrawStateCmd*>(command);
+                VisitPresentationTextureArguments(
+                    draw.Args(),
+                    [&](Texture* _texture) {
+                        record_texture(_texture, false);
+                    }
+                );
+                record_render_pass(draw.RenderPassInfo());
+                break;
+            }
+            case Command::EType::MultiDraw: {
+                const auto& draw =
+                    *static_cast<const MultiDrawCmd*>(command);
+                for (const DrawBatchElement& element :
+                     draw.draw_batch.draw_cmds) {
+                    record_shader_arguments(element.args);
+                }
+                record_render_pass(draw.RenderPassInfo());
+                break;
+            }
+            case Command::EType::ClearResource: {
+                const auto& clear =
+                    *static_cast<const ClearResourceCmd*>(command);
+                if (clear.IsTexture()) {
+                    record_view(clear.Texture());
+                }
+                break;
+            }
+            case Command::EType::Custom: {
+                const auto& custom =
+                    *static_cast<const CustomCmd*>(command);
+                if (custom.CustomId() ==
+                    CustomCmd::CustomCmdId::CUSTOM_DISPATCH) {
+                    static_cast<const CustomDispatchCmd&>(
+                        custom
+                    ).IterateArgs(
+                        [&](const TArg& argument, ParamInfoFlags) {
+                            VisitPresentationTextureArgument(
+                                argument,
+                                [&](Texture* _texture) {
+                                    record_texture(_texture, false);
+                                }
+                            );
+                        }
+                    );
+                } else {
+                    // Vulkan cannot currently execute CUSTOM_RASTER, and an
+                    // unknown opaque command has no typed resource
+                    // declaration from which to prove that it leaves an
+                    // accepted presentation source untouched. Fail closed
+                    // before native recording instead of preserving stale
+                    // readiness.
+                    throw std::logic_error(
+                        "unsupported opaque custom command in "
+                        "presentation-state collection"
+                    );
+                }
+                break;
+            }
+            case Command::EType::UploadBuffer:
+            case Command::EType::CopyBackBuffer:
+            case Command::EType::BufferToBuffer:
+            case Command::EType::BuildAccel:
+            case Command::EType::BuildTLAS:
+            case Command::EType::UpdateBindlessArray:
+            case Command::EType::Query:
+            case Command::EType::Scope:
+                break;
+            case Command::EType::SetGeometryPassDrawState:
+            case Command::EType::Count:
+                throw std::logic_error(
+                    "unsupported command in presentation-state collection"
+                );
         }
-        for (const ExplicitTextureBarrier& barrier :
-             barrier_command.ExplicitTextures()) {
-            publish_terminal(barrier.handle);
+    }
+    return delta;
+}
+
+static void CommitAcceptedPresentationSourceStateDelta(
+    const Array<VulkanPresentationSourceStateDelta>& _delta
+) noexcept {
+    for (const VulkanPresentationSourceStateDelta& entry :
+         _delta) {
+        if (!entry.texture) {
+            continue;
         }
+        static_cast<VulkanTexture*>(entry.texture.Get())
+            ->PublishPresentationSourceReady(entry.ready);
     }
 }
 
@@ -4885,11 +5171,21 @@ VulkanRuntimeSubmissionResult VkCommandQueue::PresentForRuntime(
             };
         }
         TextureRef source_texture{_source.texture};
+        const VulkanScriptedPresentOverrideForTesting* scripted_override =
+            g_scripted_present_override.load(std::memory_order_acquire);
         const VulkanPresentSourceContract source_contract =
             ValidatePresentSourceContract(
                 _source, _swapchain.Get()
             );
         if (!source_contract.valid) {
+            InvokePresentSourceRejectionCallbackForTesting(
+                scripted_override
+            );
+            bool recoverable_rejection = false;
+            const VulkanOperationResult rejection =
+                ClassifyPresentSourceRejection(
+                    vk_device, recoverable_rejection
+                );
             vk_device.RecordRejectedPresent();
             ResolvePresentReceiptNoexcept(_receipt, false, false);
             try {
@@ -4900,20 +5196,23 @@ VulkanRuntimeSubmissionResult VkCommandQueue::PresentForRuntime(
             } catch (...) {
             }
             return {
-                .outcome = {
-                    EVulkanOperationStatus::Rejected,
-                    VK_ERROR_UNKNOWN
-                },
-                .recoverable_rejection = true,
+                .outcome               = rejection,
+                .recoverable_rejection = recoverable_rejection,
             };
         }
         auto* vk_source_texture =
             static_cast<VulkanTexture*>(_source.texture);
-        const VulkanScriptedPresentOverrideForTesting* scripted_override =
-            g_scripted_present_override.load(std::memory_order_acquire);
         if (!vk_source_texture->IsPresentationSourceReady() &&
             (scripted_override == nullptr ||
              scripted_override->require_present_source_ready)) {
+            InvokePresentSourceRejectionCallbackForTesting(
+                scripted_override
+            );
+            bool recoverable_rejection = false;
+            const VulkanOperationResult rejection =
+                ClassifyPresentSourceRejection(
+                    vk_device, recoverable_rejection
+                );
             vk_device.RecordRejectedPresent();
             ResolvePresentReceiptNoexcept(_receipt, false, false);
             try {
@@ -4924,11 +5223,8 @@ VulkanRuntimeSubmissionResult VkCommandQueue::PresentForRuntime(
             } catch (...) {
             }
             return {
-                .outcome = {
-                    EVulkanOperationStatus::Rejected,
-                    VK_ERROR_UNKNOWN
-                },
-                .recoverable_rejection = true,
+                .outcome               = rejection,
+                .recoverable_rejection = recoverable_rejection,
             };
         }
 
@@ -5090,8 +5386,8 @@ VkCommandQueue::SubmitRecorded(
             // exposing the timeline first would let that thread observe an
             // accepted source while its presentation readiness was still
             // stale.
-            PublishAcceptedPresentationSourceStates(
-                _recorded.submit, queue.GetType()
+            CommitAcceptedPresentationSourceStateDelta(
+                _recorded.presentation_source_delta
             );
             MarkSubmissionAccepted(
                 timeline, _recorded.timeline, _recorded.submit.signal_events
@@ -5216,6 +5512,8 @@ bool VkCommandQueue::TryExecuteParallel(
     const CmdReorderer&            _reorderer,
     double                         _reorder_time,
     std::chrono::steady_clock::time_point _profile_started,
+    Array<VulkanPresentationSourceStateDelta>&
+                                  _presentation_source_delta,
     std::optional<CurrentVulkanRecordedSubmit>* _out_recorded
 ) {
     const ERHIProfilingPhase profiling_phase = _submit.ProfilingPhase();
@@ -6128,6 +6426,8 @@ bool VkCommandQueue::TryExecuteParallel(
     CurrentVulkanRecordedSubmit recorded_submit{
         std::move(_submit), _context, _timeline
     };
+    recorded_submit.presentation_source_delta =
+        std::move(_presentation_source_delta);
     recorded_submit.has_commands      = true;
     recorded_submit.ordered_cmd_lists = std::move(ordered_cmd_lists);
     recorded_submit.allocators = VulkanAllocatorBatch{
@@ -6340,6 +6640,51 @@ void VkCommandQueue::ExecuteNow(
             }
         };
 
+    Array<VulkanPresentationSourceStateDelta>
+        presentation_source_delta{};
+    try {
+        presentation_source_delta =
+            BuildPresentationSourceStateDelta(
+                _submit, queue.GetType()
+            );
+    } catch (const std::logic_error& error) {
+        reject_before_native_record(
+            VulkanOperationResult{
+                EVulkanOperationStatus::Rejected,
+                VK_ERROR_FEATURE_NOT_PRESENT
+            },
+            error.what()
+        );
+        return;
+    } catch (const std::bad_alloc& error) {
+        reject_before_native_record(
+            VulkanOperationResult{
+                EVulkanOperationStatus::Rejected,
+                VK_ERROR_OUT_OF_HOST_MEMORY
+            },
+            error.what()
+        );
+        return;
+    } catch (const std::exception& error) {
+        reject_before_native_record(
+            VulkanOperationResult{
+                EVulkanOperationStatus::Faulted,
+                VK_ERROR_UNKNOWN
+            },
+            error.what()
+        );
+        return;
+    } catch (...) {
+        reject_before_native_record(
+            VulkanOperationResult{
+                EVulkanOperationStatus::Rejected,
+                VK_ERROR_OUT_OF_HOST_MEMORY
+            },
+            "presentation-state delta construction failed"
+        );
+        return;
+    }
+
     if (timestamp_query_slot_count != 0 &&
         vk_device.GetTimestampValidBits(queue.GetType()) == 0) {
         // Queue capability is known before any command buffer begins. Treat
@@ -6397,6 +6742,7 @@ void VkCommandQueue::ExecuteNow(
             reorderer,
             reorder_time,
             parallel_profile_started,
+            presentation_source_delta,
             _out_recorded
         )) {
         if (_out_terminalized != nullptr && _out_recorded != nullptr &&
@@ -6972,6 +7318,8 @@ void VkCommandQueue::ExecuteNow(
     CurrentVulkanRecordedSubmit recorded_submit{
         std::move(_submit), context, _timeline
     };
+    recorded_submit.presentation_source_delta =
+        std::move(presentation_source_delta);
     recorded_submit.has_commands = has_cmd;
     recorded_submit.ordered_cmd_lists =
         std::move(serial_cmd_lists);
@@ -7143,6 +7491,10 @@ VulkanRuntimeSubmissionResult VkCommandQueue::PresentNow(
     Array<RHIResource*>        deferred_releases{};
 
     try {
+        const VulkanScriptedPresentOverrideForTesting*
+            scripted_override = g_scripted_present_override.load(
+                std::memory_order_acquire
+            );
         if (vk_device.IsFaulted()) {
             vk_device.RecordRejectedPresent();
             final_outcome = {
@@ -7152,15 +7504,29 @@ VulkanRuntimeSubmissionResult VkCommandQueue::PresentNow(
         } else if (const VulkanPresentSourceContract source_contract =
                        ValidatePresentSourceContract(_view, _sc.Get());
                    !source_contract.valid) {
-            throw std::invalid_argument(source_contract.reason);
+            InvokePresentSourceRejectionCallbackForTesting(
+                scripted_override
+            );
+            final_outcome = ClassifyPresentSourceRejection(
+                vk_device, recoverable_rejection
+            );
+            vk_device.RecordRejectedPresent();
+            try {
+                LOG_ERROR(
+                    "[RHIExecutor][Vulkan] rejected Present source contract: {}",
+                    source_contract.reason
+                );
+            } catch (...) {
+            }
         } else if (!static_cast<VulkanTexture*>(_view.texture)
                         ->IsPresentationSourceReady()) {
+            InvokePresentSourceRejectionCallbackForTesting(
+                scripted_override
+            );
+            final_outcome = ClassifyPresentSourceRejection(
+                vk_device, recoverable_rejection
+            );
             vk_device.RecordRejectedPresent();
-            final_outcome = {
-                EVulkanOperationStatus::Rejected,
-                VK_ERROR_UNKNOWN
-            };
-            recoverable_rejection = true;
         } else {
             auto* vk_source_texture =
                 static_cast<VulkanTexture*>(_view.texture);
@@ -8847,6 +9213,10 @@ VkCopyQueue::TranslateForRuntime(CmdSubmit&& _evt) noexcept {
     try {
         recorded.emplace(std::move(_evt));
         recorded->execution_lease = std::move(execution_lease);
+        recorded->presentation_source_delta =
+            BuildPresentationSourceStateDelta(
+                recorded->submit, EQueueType::Copy
+            );
 
         const bool has_queue_work =
             !recorded->submit.cmds.empty() ||
@@ -9058,8 +9428,8 @@ VulkanRuntimeSubmissionResult VkCopyQueue::SubmitRecordedForRuntime(
                     );
                 _recorded.native_submit_resolved = true;
                 if (_recorded.retirement_outcome.WasSubmitted()) {
-                    PublishAcceptedPresentationSourceStates(
-                        _recorded.submit, EQueueType::Copy
+                    CommitAcceptedPresentationSourceStateDelta(
+                        _recorded.presentation_source_delta
                     );
                     MarkSubmissionAccepted(
                         timeline.Get(),

--- a/source/runtime/render/rhi/vulkan/VulkanQueue.cpp
+++ b/source/runtime/render/rhi/vulkan/VulkanQueue.cpp
@@ -356,6 +356,27 @@ bool RemoveVulkanScriptedPresentOverrideForTesting(
     );
 }
 
+bool TryLatchVulkanDeviceFaultForTesting(VkResult _result) noexcept {
+    try {
+        auto* device = static_cast<VulkanDevice*>(
+            RenderDevice::Get().GetImpl()
+        );
+        if (device == nullptr) {
+            return false;
+        }
+        const VulkanOperationContext context{
+            .operation  = EVulkanFaultOperation::PresentSubmit,
+            .queue_type = EQueueType::Graphics,
+        };
+        return device->TryLatchFirstFault(
+                   context, _result, true, false, true
+               ) ||
+               device->IsFaulted();
+    } catch (...) {
+        return false;
+    }
+}
+
 bool TryInstallVulkanSubmissionDependencyWaitObserver(
     const VulkanSubmissionDependencyWaitObserver* _observer
 ) noexcept {
@@ -4005,6 +4026,191 @@ static void MarkSubmissionAccepted(
     }
 }
 
+[[nodiscard]] static bool IsPresentationSourceTexture(
+    const VulkanTexture* _texture
+) noexcept {
+    return _texture != nullptr &&
+           (_texture->GetUsage() &
+            ETextureUsageFlags::PRESENTATION_SOURCE) ==
+               ETextureUsageFlags::PRESENTATION_SOURCE;
+}
+
+[[nodiscard]] static bool BarrierReferencesTexture(
+    const BarrierCmd& _command,
+    uint64            _handle
+) noexcept {
+    const auto matches = [_handle](const auto& _barrier) {
+        return _barrier.handle == _handle;
+    };
+    return std::ranges::any_of(_command.ReadTextures(), matches) ||
+           std::ranges::any_of(_command.WriteTextures(), matches) ||
+           std::ranges::any_of(_command.ExplicitTextures(), matches);
+}
+
+[[nodiscard]] static bool HasLaterTextureBarrierReference(
+    const CmdSubmit& _submit,
+    size_t           _command_index,
+    uint64           _handle
+) noexcept {
+    for (size_t index = _command_index + 1;
+         index < _submit.cmds.size();
+         ++index) {
+        const Command* command = _submit.cmds[index].get();
+        if (command != nullptr &&
+            command->Type() == Command::EType::Barrier &&
+            BarrierReferencesTexture(
+                static_cast<const BarrierCmd&>(*command), _handle
+            )) {
+            return true;
+        }
+    }
+    return false;
+}
+
+[[nodiscard]] static bool IsAcceptedPresentationSourcePublication(
+    const ExplicitTextureBarrier& _barrier,
+    const VulkanTexture&          _texture
+) noexcept {
+    return _barrier.publish_external_state &&
+           _barrier.queue_transfer.phase ==
+               EBarrierQueueTransferPhase::None &&
+           _barrier.dst_state.stage ==
+               ERHIPipelineStageFlags::PS_TRANSFER &&
+           _barrier.dst_state.access ==
+               ERHIAccessFlags::TRANSFER_READ &&
+           _barrier.dst_state.texture_layout ==
+               ETextureLayout::TEXTURE_LAYOUT_COMMON &&
+           _barrier.texture_aspects ==
+               ETextureAspectFlags::COLOR &&
+           _barrier.mip_level == 0 &&
+           _barrier.mip_count == _texture.GetNumMips() &&
+           _barrier.array_layer == 0 &&
+           _barrier.array_count == _texture.GetNumArray();
+}
+
+[[nodiscard]] static bool IsAcceptedPresentationSourcePublication(
+    const TextureBarrier& _barrier,
+    const VulkanTexture&  _texture
+) noexcept {
+    const ETextureUsageFlags required_usage =
+        ETextureUsageFlags::PRESENTATION_SOURCE |
+        ETextureUsageFlags::TRANSFER_SRC;
+    return _barrier.publish_external_state &&
+           _barrier.state == ETextureState::TRANSFER &&
+           _barrier.pass_type == EPassType::Copy &&
+           (_texture.GetUsage() & required_usage) == required_usage &&
+           _texture.GetAspectFlags() == ETextureAspectFlags::COLOR &&
+           _texture.GetNumSamples() == 1 &&
+           !_texture.b_present &&
+           _texture.GetPreferredLayout() ==
+               VK_IMAGE_LAYOUT_GENERAL &&
+           _barrier.mip_level == 0 &&
+           _barrier.mip_cnt == _texture.GetNumMips() &&
+           _barrier.array_layer == 0 &&
+           _barrier.array_cnt == _texture.GetNumArray();
+}
+
+// Commit only the final presentation-source delta from an accepted native
+// packet. A later accepted barrier that leaves the external GENERAL /
+// TRANSFER_READ contract clears readiness; rejected packets never call here.
+static void PublishAcceptedPresentationSourceStates(
+    const CmdSubmit& _submit,
+    EQueueType       _accepted_queue
+) noexcept {
+    for (size_t command_index = 0;
+         command_index < _submit.cmds.size();
+         ++command_index) {
+        const Command* command = _submit.cmds[command_index].get();
+        if (command == nullptr ||
+            command->Type() != Command::EType::Barrier) {
+            continue;
+        }
+        const auto& barrier_command =
+            static_cast<const BarrierCmd&>(*command);
+
+        const auto publish_terminal =
+            [&](uint64 _handle) noexcept {
+                if (HasLaterTextureBarrierReference(
+                        _submit, command_index, _handle
+                    )) {
+                    return;
+                }
+                auto* texture =
+                    reinterpret_cast<VulkanTexture*>(_handle);
+                if (!IsPresentationSourceTexture(texture)) {
+                    return;
+                }
+
+                bool ready = false;
+                if (_accepted_queue != EQueueType::Graphics) {
+                    ready = false;
+                } else if (_submit.HasExplicitResourceStateOwnership()) {
+                    const auto& explicit_barriers =
+                        barrier_command.ExplicitTextures();
+                    const auto terminal = std::find_if(
+                        explicit_barriers.rbegin(),
+                        explicit_barriers.rend(),
+                        [_handle](const ExplicitTextureBarrier& _barrier) {
+                            return _barrier.handle == _handle;
+                        }
+                    );
+                    ready =
+                        terminal != explicit_barriers.rend() &&
+                        IsAcceptedPresentationSourcePublication(
+                            *terminal, *texture
+                        );
+                } else {
+                    // A successful BackendTracked translation restores every
+                    // touched texture after its terminal legacy barrier. Only
+                    // one full-range, explicitly published TRANSFER read is a
+                    // presentation boundary; terminal writes, partial reads,
+                    // or incidental legacy barriers clear readiness.
+                    const TextureBarrier* publication = nullptr;
+                    size_t reference_count = 0;
+                    for (const TextureBarrier& barrier :
+                         barrier_command.ReadTextures()) {
+                        if (barrier.handle == _handle) {
+                            ++reference_count;
+                            publication = &barrier;
+                        }
+                    }
+                    for (const TextureBarrier& barrier :
+                         barrier_command.WriteTextures()) {
+                        if (barrier.handle == _handle) {
+                            ++reference_count;
+                        }
+                    }
+                    for (const ExplicitTextureBarrier& barrier :
+                         barrier_command.ExplicitTextures()) {
+                        if (barrier.handle == _handle) {
+                            ++reference_count;
+                        }
+                    }
+                    ready =
+                        reference_count == 1 &&
+                        publication != nullptr &&
+                        IsAcceptedPresentationSourcePublication(
+                            *publication, *texture
+                        );
+                }
+                texture->PublishPresentationSourceReady(ready);
+            };
+
+        for (const TextureBarrier& barrier :
+             barrier_command.ReadTextures()) {
+            publish_terminal(barrier.handle);
+        }
+        for (const TextureBarrier& barrier :
+             barrier_command.WriteTextures()) {
+            publish_terminal(barrier.handle);
+        }
+        for (const ExplicitTextureBarrier& barrier :
+             barrier_command.ExplicitTextures()) {
+            publish_terminal(barrier.handle);
+        }
+    }
+}
+
 static bool IsRecoverableUnsubmittedSignal(
     VulkanDevice& _device, const VulkanOperationResult& _outcome
 ) {
@@ -4668,6 +4874,16 @@ VulkanRuntimeSubmissionResult VkCommandQueue::PresentForRuntime(
         "runtime Present must run on the Submission owner"
     );
     try {
+        if (vk_device.IsFaulted()) {
+            vk_device.RecordRejectedPresent();
+            ResolvePresentReceiptNoexcept(_receipt, false, false);
+            return {
+                .outcome = {
+                    EVulkanOperationStatus::Rejected,
+                    vk_device.GetFirstFaultResult()
+                }
+            };
+        }
         TextureRef source_texture{_source.texture};
         const VulkanPresentSourceContract source_contract =
             ValidatePresentSourceContract(
@@ -4691,14 +4907,28 @@ VulkanRuntimeSubmissionResult VkCommandQueue::PresentForRuntime(
                 .recoverable_rejection = true,
             };
         }
-        if (vk_device.IsFaulted()) {
+        auto* vk_source_texture =
+            static_cast<VulkanTexture*>(_source.texture);
+        const VulkanScriptedPresentOverrideForTesting* scripted_override =
+            g_scripted_present_override.load(std::memory_order_acquire);
+        if (!vk_source_texture->IsPresentationSourceReady() &&
+            (scripted_override == nullptr ||
+             scripted_override->require_present_source_ready)) {
             vk_device.RecordRejectedPresent();
             ResolvePresentReceiptNoexcept(_receipt, false, false);
+            try {
+                LOG_ERROR(
+                    "[RHIExecutor][Vulkan] rejected Present source before an "
+                    "accepted producer export published GENERAL / TRANSFER_READ"
+                );
+            } catch (...) {
+            }
             return {
                 .outcome = {
                     EVulkanOperationStatus::Rejected,
-                    vk_device.GetFirstFaultResult()
-                }
+                    VK_ERROR_UNKNOWN
+                },
+                .recoverable_rejection = true,
             };
         }
 
@@ -4706,8 +4936,6 @@ VulkanRuntimeSubmissionResult VkCommandQueue::PresentForRuntime(
         std::unique_lock<std::mutex> execution_lock(exec_mtx);
         const uint64 current_timeline =
             last_frame.fetch_add(1, std::memory_order_relaxed) + 1;
-        const VulkanScriptedPresentOverrideForTesting* scripted_override =
-            g_scripted_present_override.load(std::memory_order_acquire);
         if (scripted_override != nullptr) {
             VulkanScriptedPresentResult scripted =
                 scripted_override->callback(
@@ -4857,6 +5085,14 @@ VkCommandQueue::SubmitRecorded(
         // exception must still retire it as GPU-submitted.
         _recorded.retirement_outcome = submit_outcome;
         if (submit_outcome.WasSubmitted()) {
+            // Publish accepted resource state before waking any host waiter.
+            // Raster uses WaitSubmitted() to gate platform-window presents;
+            // exposing the timeline first would let that thread observe an
+            // accepted source while its presentation readiness was still
+            // stale.
+            PublishAcceptedPresentationSourceStates(
+                _recorded.submit, queue.GetType()
+            );
             MarkSubmissionAccepted(
                 timeline, _recorded.timeline, _recorded.submit.signal_events
             );
@@ -6900,26 +7136,34 @@ VulkanRuntimeSubmissionResult VkCommandQueue::PresentNow(
     bool                            gpu_submitted = false;
     bool                            present_accepted = false;
     bool                            recreate_swapchain = false;
+    bool                            recoverable_rejection = false;
     EVulkanPresentorRetirementState presentor_state =
         EVulkanPresentorRetirementState::Unused;
     UniquePtr<VulkanPresentor> presentor{};
     Array<RHIResource*>        deferred_releases{};
 
     try {
-        const VulkanPresentSourceContract source_contract =
-            ValidatePresentSourceContract(_view, _sc.Get());
-        if (!source_contract.valid) {
-            throw std::invalid_argument(source_contract.reason);
-        }
-        auto* vk_source_texture =
-            static_cast<VulkanTexture*>(_view.texture);
         if (vk_device.IsFaulted()) {
             vk_device.RecordRejectedPresent();
             final_outcome = {
                 EVulkanOperationStatus::Rejected,
                 vk_device.GetFirstFaultResult()
             };
+        } else if (const VulkanPresentSourceContract source_contract =
+                       ValidatePresentSourceContract(_view, _sc.Get());
+                   !source_contract.valid) {
+            throw std::invalid_argument(source_contract.reason);
+        } else if (!static_cast<VulkanTexture*>(_view.texture)
+                        ->IsPresentationSourceReady()) {
+            vk_device.RecordRejectedPresent();
+            final_outcome = {
+                EVulkanOperationStatus::Rejected,
+                VK_ERROR_UNKNOWN
+            };
+            recoverable_rejection = true;
         } else {
+            auto* vk_source_texture =
+                static_cast<VulkanTexture*>(_view.texture);
             VkSwapchain* sc = ResourceCast(_sc.Get());
             presentor       = GetPresentor();
             if (!sc->WaitFrameInFlight()) {
@@ -7099,7 +7343,10 @@ VulkanRuntimeSubmissionResult VkCommandQueue::PresentNow(
         _receipt, present_accepted, recreate_swapchain
     );
 
-    VulkanRuntimeSubmissionResult runtime_result{.outcome = final_outcome};
+    VulkanRuntimeSubmissionResult runtime_result{
+        .outcome = final_outcome,
+        .recoverable_rejection = recoverable_rejection,
+    };
     if (gpu_submitted) {
         runtime_result.completion = WaitEvent{uint64(timeline), _timeline};
     }
@@ -8811,6 +9058,9 @@ VulkanRuntimeSubmissionResult VkCopyQueue::SubmitRecordedForRuntime(
                     );
                 _recorded.native_submit_resolved = true;
                 if (_recorded.retirement_outcome.WasSubmitted()) {
+                    PublishAcceptedPresentationSourceStates(
+                        _recorded.submit, EQueueType::Copy
+                    );
                     MarkSubmissionAccepted(
                         timeline.Get(),
                         _recorded.logical_timeline,

--- a/source/runtime/render/rhi/vulkan/VulkanQueue.cpp
+++ b/source/runtime/render/rhi/vulkan/VulkanQueue.cpp
@@ -6677,8 +6677,8 @@ void VkCommandQueue::ExecuteNow(
     } catch (...) {
         reject_before_native_record(
             VulkanOperationResult{
-                EVulkanOperationStatus::Rejected,
-                VK_ERROR_OUT_OF_HOST_MEMORY
+                EVulkanOperationStatus::Faulted,
+                VK_ERROR_UNKNOWN
             },
             "presentation-state delta construction failed"
         );

--- a/source/runtime/render/rhi/vulkan/VulkanQueue.cpp
+++ b/source/runtime/render/rhi/vulkan/VulkanQueue.cpp
@@ -4103,45 +4103,28 @@ static void MarkSubmissionAccepted(
            _barrier.array_cnt == _texture.GetNumArray();
 }
 
-using VulkanPresentationSourceSnapshotCache =
-    UnorderedMap<VulkanBindlessArray*, Array<TextureRef>>;
-
-template<typename TVisitor>
+template<typename TTextureVisitor, typename TBindlessVisitor>
 static void VisitPresentationTextureArgument(
-    const TArg&                            _argument,
-    VulkanPresentationSourceSnapshotCache& _snapshot_cache,
-    TVisitor&&                             _visitor
+    const TArg&        _argument,
+    TTextureVisitor&   _texture_visitor,
+    TBindlessVisitor&  _bindless_visitor
 ) {
     std::visit(
         [&](const auto& _resource) {
             using TResource = std::decay_t<decltype(_resource)>;
             if constexpr (std::is_same_v<TResource, TextureView>) {
-                _visitor(_resource.GetTexture());
+                _texture_visitor(_resource.GetTexture());
             } else if constexpr (
                 std::is_same_v<TResource, TextureViewArray>
             ) {
                 for (const TextureView& view : _resource) {
-                    _visitor(view.GetTexture());
+                    _texture_visitor(view.GetTexture());
                 }
             } else if constexpr (
                 std::is_same_v<TResource, BindlessArrayRef>
             ) {
                 if (_resource) {
-                    auto* bindless =
-                        static_cast<VulkanBindlessArray*>(
-                            _resource.Get()
-                        );
-                    auto [snapshot_it, inserted] =
-                        _snapshot_cache.try_emplace(bindless);
-                    if (inserted) {
-                        snapshot_it->second =
-                            bindless
-                                ->SnapshotPresentationSourceTextures();
-                    }
-                    for (const TextureRef& texture :
-                         snapshot_it->second) {
-                        _visitor(texture.Get());
-                    }
+                    _bindless_visitor(_resource);
                 }
             }
         },
@@ -4149,33 +4132,45 @@ static void VisitPresentationTextureArgument(
     );
 }
 
-template<typename TVisitor>
+template<typename TTextureVisitor, typename TBindlessVisitor>
 static void VisitPresentationTextureArguments(
-    const ArrayArguments&                   _arguments,
-    VulkanPresentationSourceSnapshotCache&  _snapshot_cache,
-    TVisitor&&                              _visitor
+    const ArrayArguments& _arguments,
+    TTextureVisitor&      _texture_visitor,
+    TBindlessVisitor&     _bindless_visitor
 ) {
     for (const TArg& argument : _arguments.args) {
         VisitPresentationTextureArgument(
             argument,
-            _snapshot_cache,
-            std::forward<TVisitor>(_visitor)
+            _texture_visitor,
+            _bindless_visitor
         );
     }
 }
 
-template<typename TVisitor>
+template<typename TTextureVisitor, typename TBindlessVisitor>
 static void VisitPresentationTextureArguments(
-    const TShaderArgArray&                  _arguments,
-    const TCachedArgArray&                  _cached_arguments,
-    VulkanPresentationSourceSnapshotCache& _snapshot_cache,
-    TVisitor&&                              _visitor
+    const ArrayArguments& _arguments,
+    const TCachedArgArray&,
+    TTextureVisitor&      _texture_visitor,
+    TBindlessVisitor&     _bindless_visitor
+) {
+    VisitPresentationTextureArguments(
+        _arguments, _texture_visitor, _bindless_visitor
+    );
+}
+
+template<typename TTextureVisitor, typename TBindlessVisitor>
+static void VisitPresentationTextureArguments(
+    const TShaderArgArray& _arguments,
+    const TCachedArgArray& _cached_arguments,
+    TTextureVisitor&       _texture_visitor,
+    TBindlessVisitor&      _bindless_visitor
 ) {
     if (std::holds_alternative<ArrayArguments>(_arguments)) {
         VisitPresentationTextureArguments(
             std::get<ArrayArguments>(_arguments),
-            _snapshot_cache,
-            std::forward<TVisitor>(_visitor)
+            _texture_visitor,
+            _bindless_visitor
         );
         return;
     }
@@ -4185,64 +4180,80 @@ static void VisitPresentationTextureArguments(
         if (index < _cached_arguments.size()) {
             VisitPresentationTextureArguments(
                 _cached_arguments[index],
-                _snapshot_cache,
-                std::forward<TVisitor>(_visitor)
+                _texture_visitor,
+                _bindless_visitor
             );
         }
     }
 }
 
-// Freeze one last-reference-wins delta from source command order before
-// CmdReorderer or parallel translation can change execution topology. Every
-// declared use closes a previous export; only an exact terminal Graphics
-// publication re-opens the external Present contract.
-static Array<VulkanPresentationSourceStateDelta>
-BuildPresentationSourceStateDelta(
+// Freeze source command order before CmdReorderer or parallel translation can
+// change execution topology. Direct texture uses become concrete events;
+// bindless uses remain symbolic until Submission can observe the last
+// natively accepted descriptor membership.
+static VulkanPresentationSourceStateProgram
+BuildPresentationSourceStateProgram(
     const CmdSubmit& _submit,
     EQueueType       _queue
 ) {
-    Array<VulkanPresentationSourceStateDelta> delta{};
-    delta.reserve(_submit.cmds.size());
-    VulkanPresentationSourceSnapshotCache bindless_snapshot_cache{};
+    VulkanPresentationSourceStateProgram program{};
+    program.events.reserve(_submit.cmds.size());
 
     const auto record_texture =
         [&](Texture* _texture, bool _ready) {
             if (!IsPresentationSourceTexture(_texture)) {
                 return;
             }
-            auto existing = std::find_if(
-                delta.begin(),
-                delta.end(),
-                [_texture](
-                    const VulkanPresentationSourceStateDelta& _entry
-                ) {
-                    return _entry.texture.Get() == _texture;
-                }
-            );
-            if (existing != delta.end()) {
-                existing->ready = _ready;
-                return;
-            }
-            delta.emplace_back(
-                VulkanPresentationSourceStateDelta{
+            program.events.emplace_back(
+                VulkanPresentationSourceStateEvent{
+                    .type =
+                        EVulkanPresentationSourceStateEventType::
+                            TextureState,
                     .texture = TextureRef(_texture),
                     .ready   = _ready,
                 }
             );
+        };
+    const auto record_bindless =
+        [&](const BindlessArrayRef& _array) {
+            if (!_array) {
+                return;
+            }
+            program.events.emplace_back(
+                VulkanPresentationSourceStateEvent{
+                    .type =
+                        EVulkanPresentationSourceStateEventType::
+                            BindlessAccess,
+                    .bindless_array = _array,
+                }
+            );
+            program.has_bindless_state = true;
         };
     const auto record_view =
         [&](const TextureView& _view) {
             record_texture(_view.GetTexture(), false);
         };
     const auto record_shader_arguments =
-        [&](const auto& _arguments) {
+        [&](const auto& _arguments,
+            UnorderedSet<BindlessArray*>& _seen_bindless) {
+            auto record_unique_bindless =
+                [&](const BindlessArrayRef& _array) {
+                    if (_array &&
+                        _seen_bindless.emplace(
+                            _array.Get()
+                        ).second) {
+                        record_bindless(_array);
+                    }
+                };
+            auto record_direct_texture =
+                [&](Texture* _texture) {
+                    record_texture(_texture, false);
+                };
             VisitPresentationTextureArguments(
                 _arguments,
                 _submit.cached_args,
-                bindless_snapshot_cache,
-                [&](Texture* _texture) {
-                    record_texture(_texture, false);
-                }
+                record_direct_texture,
+                record_unique_bindless
             );
         };
     const auto record_render_pass =
@@ -4363,24 +4374,19 @@ BuildPresentationSourceStateDelta(
             case Command::EType::ShaderDispatch: {
                 const auto& dispatch =
                     *static_cast<const DispatchCmd*>(command);
-                VisitPresentationTextureArguments(
+                UnorderedSet<BindlessArray*> seen_bindless{};
+                record_shader_arguments(
                     dispatch.Args(_submit.cached_args),
-                    bindless_snapshot_cache,
-                    [&](Texture* _texture) {
-                        record_texture(_texture, false);
-                    }
+                    seen_bindless
                 );
                 break;
             }
             case Command::EType::TraceRay: {
                 const auto& trace =
                     *static_cast<const TraceRayCmd*>(command);
-                VisitPresentationTextureArguments(
-                    trace.Args(),
-                    bindless_snapshot_cache,
-                    [&](Texture* _texture) {
-                        record_texture(_texture, false);
-                    }
+                UnorderedSet<BindlessArray*> seen_bindless{};
+                record_shader_arguments(
+                    trace.Args(), seen_bindless
                 );
                 break;
             }
@@ -4428,12 +4434,9 @@ BuildPresentationSourceStateDelta(
             case Command::EType::SetDrawState: {
                 const auto& draw =
                     *static_cast<const SetDrawStateCmd*>(command);
-                VisitPresentationTextureArguments(
-                    draw.Args(),
-                    bindless_snapshot_cache,
-                    [&](Texture* _texture) {
-                        record_texture(_texture, false);
-                    }
+                UnorderedSet<BindlessArray*> seen_bindless{};
+                record_shader_arguments(
+                    draw.Args(), seen_bindless
                 );
                 record_render_pass(draw.RenderPassInfo());
                 break;
@@ -4441,9 +4444,12 @@ BuildPresentationSourceStateDelta(
             case Command::EType::MultiDraw: {
                 const auto& draw =
                     *static_cast<const MultiDrawCmd*>(command);
+                UnorderedSet<BindlessArray*> seen_bindless{};
                 for (const DrawBatchElement& element :
                      draw.draw_batch.draw_cmds) {
-                    record_shader_arguments(element.args);
+                    record_shader_arguments(
+                        element.args, seen_bindless
+                    );
                 }
                 record_render_pass(draw.RenderPassInfo());
                 break;
@@ -4461,16 +4467,28 @@ BuildPresentationSourceStateDelta(
                     *static_cast<const CustomCmd*>(command);
                 if (custom.CustomId() ==
                     CustomCmd::CustomCmdId::CUSTOM_DISPATCH) {
+                    UnorderedSet<BindlessArray*> seen_bindless{};
+                    auto record_unique_bindless =
+                        [&](const BindlessArrayRef& _array) {
+                            if (_array &&
+                                seen_bindless.emplace(
+                                    _array.Get()
+                                ).second) {
+                                record_bindless(_array);
+                            }
+                        };
+                    auto record_custom_texture =
+                        [&](Texture* _texture) {
+                            record_texture(_texture, false);
+                        };
                     static_cast<const CustomDispatchCmd&>(
                         custom
                     ).IterateArgs(
                         [&](const TArg& argument, ParamInfoFlags) {
                             VisitPresentationTextureArgument(
                                 argument,
-                                bindless_snapshot_cache,
-                                [&](Texture* _texture) {
-                                    record_texture(_texture, false);
-                                }
+                                record_custom_texture,
+                                record_unique_bindless
                             );
                         }
                     );
@@ -4488,12 +4506,62 @@ BuildPresentationSourceStateDelta(
                 }
                 break;
             }
+            case Command::EType::UpdateBindlessArray: {
+                const auto& update_command =
+                    *static_cast<const UpdateBindlessArrayCmd*>(
+                        command
+                    );
+                BindlessArrayRef bindless_array(
+                    update_command.Handle()
+                );
+                if (!bindless_array) {
+                    throw std::logic_error(
+                        "bindless update has no array"
+                    );
+                }
+                for (const BindlessArray::UpdateCmd& update :
+                     update_command.UpdateCommands()) {
+                    std::visit(
+                        [&](const auto& _update) {
+                            using TUpdate =
+                                std::decay_t<decltype(_update)>;
+                            if constexpr (
+                                std::is_same_v<
+                                    TUpdate,
+                                    BindlessArray::
+                                        TextureUpdateInfo>) {
+                                if (!IsPresentationSourceTexture(
+                                        _update.texture.Get()
+                                    )) {
+                                    return;
+                                }
+                                program.events.emplace_back(
+                                    VulkanPresentationSourceStateEvent{
+                                        .type =
+                                            EVulkanPresentationSourceStateEventType::
+                                                BindlessTextureMembership,
+                                        .texture = _update.texture,
+                                        .bindless_array =
+                                            bindless_array,
+                                        .bindless_slot =
+                                            _update.array_idx,
+                                        .membership_delta =
+                                            _update.free ? -1 : 1,
+                                    }
+                                );
+                                program.has_bindless_state = true;
+                            }
+                        },
+                        update
+                    );
+                }
+                break;
+            }
             case Command::EType::UploadBuffer:
             case Command::EType::CopyBackBuffer:
             case Command::EType::BufferToBuffer:
             case Command::EType::BuildAccel:
             case Command::EType::BuildTLAS:
-            case Command::EType::UpdateBindlessArray:
             case Command::EType::Query:
             case Command::EType::Scope:
                 break;
@@ -4504,7 +4572,246 @@ BuildPresentationSourceStateDelta(
                 );
         }
     }
-    return delta;
+    return program;
+}
+
+struct VulkanPresentationSourceMembershipCommit {
+    BindlessArrayRef bindless_array{};
+    VulkanBindlessArray::PresentationSourceMembershipSnapshot
+        membership{};
+};
+
+struct VulkanPresentationSourceStateTransaction {
+    Array<VulkanPresentationSourceStateDelta>       delta{};
+    Array<VulkanPresentationSourceMembershipCommit> membership_commits{};
+    std::unique_lock<std::mutex>                     submission_lock{};
+};
+
+static std::mutex& PresentationSourceBindlessSubmissionMutex() {
+    static std::mutex mutex;
+    return mutex;
+}
+
+static VulkanPresentationSourceStateTransaction
+EvaluatePresentationSourceStateProgram(
+    const VulkanPresentationSourceStateProgram& _program
+) {
+    using Membership =
+        VulkanBindlessArray::PresentationSourceMembership;
+    struct WorkingMembership {
+        BindlessArrayRef            bindless_array{};
+        std::shared_ptr<Membership> membership{};
+    };
+
+    VulkanPresentationSourceStateTransaction transaction{};
+    transaction.delta.reserve(_program.events.size());
+    if (_program.has_bindless_state) {
+        // The runtime has one Submission owner, but standalone queue use can
+        // still enter this path directly. Keep snapshot -> vkQueueSubmit ->
+        // accepted publication one global transaction in both modes.
+        transaction.submission_lock =
+            std::unique_lock<std::mutex>(
+                PresentationSourceBindlessSubmissionMutex()
+            );
+    }
+
+    Array<WorkingMembership> working_memberships{};
+    UnorderedMap<VulkanBindlessArray*, size_t>
+        working_membership_indices{};
+
+    const auto& get_working_membership =
+        [&](const BindlessArrayRef& _array) -> WorkingMembership& {
+            if (!_array) {
+                throw std::logic_error(
+                    "presentation-state program references a null "
+                    "bindless array"
+                );
+            }
+            auto* bindless =
+                static_cast<VulkanBindlessArray*>(_array.Get());
+            const auto existing =
+                working_membership_indices.find(bindless);
+            if (existing != working_membership_indices.end()) {
+                return working_memberships[existing->second];
+            }
+
+            const auto accepted =
+                bindless
+                    ->SnapshotAcceptedPresentationSourceMembership();
+            if (!accepted) {
+                throw std::logic_error(
+                    "bindless array has no accepted presentation "
+                    "membership state"
+                );
+            }
+            const size_t index = working_memberships.size();
+            working_memberships.emplace_back(
+                WorkingMembership{
+                    .bindless_array = _array,
+                    .membership =
+                        std::make_shared<Membership>(*accepted),
+                }
+            );
+            working_membership_indices.emplace(bindless, index);
+            return working_memberships.back();
+        };
+
+    const auto record_texture =
+        [&](const TextureRef& _texture, bool _ready) {
+            if (!_texture ||
+                !IsPresentationSourceTexture(_texture.Get())) {
+                return;
+            }
+            auto existing = std::find_if(
+                transaction.delta.begin(),
+                transaction.delta.end(),
+                [&](const VulkanPresentationSourceStateDelta& _entry) {
+                    return _entry.texture.Get() == _texture.Get();
+                }
+            );
+            if (existing != transaction.delta.end()) {
+                existing->ready = _ready;
+                return;
+            }
+            transaction.delta.emplace_back(
+                VulkanPresentationSourceStateDelta{
+                    .texture = _texture,
+                    .ready   = _ready,
+                }
+            );
+        };
+
+    for (const VulkanPresentationSourceStateEvent& event :
+         _program.events) {
+        switch (event.type) {
+            case EVulkanPresentationSourceStateEventType::
+                TextureState:
+                record_texture(event.texture, event.ready);
+                break;
+            case EVulkanPresentationSourceStateEventType::
+                BindlessAccess: {
+                const WorkingMembership& working =
+                    get_working_membership(event.bindless_array);
+                for (const auto& [texture, record] :
+                     working.membership->textures) {
+                    (void)texture;
+                    if (record.count != 0) {
+                        record_texture(record.texture, false);
+                    }
+                }
+                break;
+            }
+            case EVulkanPresentationSourceStateEventType::
+                BindlessTextureMembership: {
+                if (!event.texture ||
+                    !IsPresentationSourceTexture(
+                        event.texture.Get()
+                    ) ||
+                    event.bindless_slot == 0 ||
+                    (event.membership_delta != 1 &&
+                     event.membership_delta != -1)) {
+                    throw std::logic_error(
+                        "invalid bindless presentation membership "
+                        "mutation"
+                    );
+                }
+                WorkingMembership& working =
+                    get_working_membership(event.bindless_array);
+                auto& membership = *working.membership;
+                const auto decrement_texture =
+                    [&](const TextureRef& _texture) {
+                        const auto texture =
+                            membership.textures.find(
+                                _texture.Get()
+                            );
+                        if (texture ==
+                                membership.textures.end() ||
+                            texture->second.count == 0) {
+                            throw std::logic_error(
+                                "bindless presentation membership "
+                                "slot/count mismatch"
+                            );
+                        }
+                        if (--texture->second.count == 0) {
+                            membership.textures.erase(texture);
+                        }
+                    };
+                const auto increment_texture =
+                    [&](const TextureRef& _texture) {
+                        auto [texture, inserted] =
+                            membership.textures.try_emplace(
+                                _texture.Get(),
+                                VulkanBindlessArray::
+                                    PresentationSourceMembershipRecord{
+                                        .texture = _texture,
+                                        .count   = 0,
+                                    }
+                            );
+                        (void)inserted;
+                        if (texture->second.count ==
+                            std::numeric_limits<uint32>::max()) {
+                            throw std::logic_error(
+                                "bindless presentation membership "
+                                "count overflow"
+                            );
+                        }
+                        ++texture->second.count;
+                    };
+                auto slot = membership.slots.find(
+                    event.bindless_slot
+                );
+                if (event.membership_delta > 0) {
+                    if (slot != membership.slots.end()) {
+                        if (slot->second.Get() ==
+                            event.texture.Get()) {
+                            break;
+                        }
+                        decrement_texture(slot->second);
+                        slot->second = event.texture;
+                    } else {
+                        membership.slots.emplace(
+                            event.bindless_slot,
+                            event.texture
+                        );
+                    }
+                    increment_texture(event.texture);
+                    break;
+                }
+                // Clearing a slot which was never natively published is an
+                // accepted idempotent descriptor update. This can occur when
+                // a pending add is canceled/rejected before its later free.
+                if (slot == membership.slots.end()) {
+                    break;
+                }
+                if (slot->second.Get() != event.texture.Get()) {
+                    throw std::logic_error(
+                        "bindless presentation free targets a "
+                        "different accepted slot resource"
+                    );
+                }
+                decrement_texture(slot->second);
+                membership.slots.erase(slot);
+                break;
+            }
+        }
+    }
+
+    transaction.membership_commits.reserve(
+        working_memberships.size()
+    );
+    for (WorkingMembership& working : working_memberships) {
+        transaction.membership_commits.emplace_back(
+            VulkanPresentationSourceMembershipCommit{
+                .bindless_array =
+                    std::move(working.bindless_array),
+                .membership =
+                    std::shared_ptr<const Membership>(
+                        std::move(working.membership)
+                    ),
+            }
+        );
+    }
+    return transaction;
 }
 
 static void CommitAcceptedPresentationSourceStateDelta(
@@ -4518,6 +4825,29 @@ static void CommitAcceptedPresentationSourceStateDelta(
         static_cast<VulkanTexture*>(entry.texture.Get())
             ->PublishPresentationSourceReady(entry.ready);
     }
+}
+
+static void CommitAcceptedPresentationSourceStateTransaction(
+    VulkanPresentationSourceStateTransaction& _transaction
+) noexcept {
+    assert(
+        _transaction.membership_commits.empty() ||
+        _transaction.submission_lock.owns_lock()
+    );
+    for (VulkanPresentationSourceMembershipCommit& commit :
+         _transaction.membership_commits) {
+        if (!commit.bindless_array || !commit.membership) {
+            continue;
+        }
+        static_cast<VulkanBindlessArray*>(
+            commit.bindless_array.Get()
+        )->PublishAcceptedPresentationSourceMembership(
+            std::move(commit.membership)
+        );
+    }
+    CommitAcceptedPresentationSourceStateDelta(
+        _transaction.delta
+    );
 }
 
 static bool IsRecoverableUnsubmittedSignal(
@@ -5376,45 +5706,119 @@ VkCommandQueue::SubmitRecorded(
         _recorded.native_submit_resolved = true;
         _recorded.retirement_outcome     = submit_outcome;
     } else {
-        queue.Signal(timeline, _recorded.timeline, end_tag);
-        for (auto& event : _recorded.submit.wait_events) {
-            queue.Wait(
-                reinterpret_cast<VulkanFence*>(event.timeline_handle),
-                event.value,
-                VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT
+        std::optional<VulkanPresentationSourceStateTransaction>
+            presentation_transaction{};
+        const auto reject_presentation_transaction =
+            [&](const VulkanOperationResult& _outcome,
+                std::string_view             _reason) {
+                try {
+                    LOG_ERROR(
+                        "[RHIExecutor][Vulkan] rejected before native "
+                        "submit: timeline={} reason={} VkResult={}",
+                        _recorded.timeline,
+                        _reason,
+                        static_cast<int32>(_outcome.result)
+                    );
+                } catch (...) {
+                }
+                vk_device.RecordRejectedSubmit();
+                submit_outcome = _outcome;
+                _recorded.recoverable_rejection =
+                    _outcome.status ==
+                        EVulkanOperationStatus::Rejected &&
+                    !vk_device.IsFaulted() &&
+                    _outcome.result != VK_ERROR_DEVICE_LOST;
+                _recorded.native_submit_resolved = true;
+                _recorded.retirement_outcome     = _outcome;
+            };
+        try {
+            presentation_transaction.emplace(
+                EvaluatePresentationSourceStateProgram(
+                    _recorded.presentation_source_program
+                )
+            );
+        } catch (const std::logic_error& error) {
+            reject_presentation_transaction(
+                VulkanOperationResult{
+                    EVulkanOperationStatus::Rejected,
+                    VK_ERROR_FEATURE_NOT_PRESENT
+                },
+                error.what()
+            );
+        } catch (const std::bad_alloc& error) {
+            reject_presentation_transaction(
+                VulkanOperationResult{
+                    EVulkanOperationStatus::Rejected,
+                    VK_ERROR_OUT_OF_HOST_MEMORY
+                },
+                error.what()
+            );
+        } catch (const std::exception& error) {
+            reject_presentation_transaction(
+                VulkanOperationResult{
+                    EVulkanOperationStatus::Faulted,
+                    VK_ERROR_UNKNOWN
+                },
+                error.what()
+            );
+        } catch (...) {
+            reject_presentation_transaction(
+                VulkanOperationResult{
+                    EVulkanOperationStatus::Faulted,
+                    VK_ERROR_UNKNOWN
+                },
+                "presentation-state transaction evaluation failed"
             );
         }
-        for (auto& event : _recorded.submit.signal_events) {
-            queue.Signal(
-                reinterpret_cast<VulkanFence*>(event.timeline_handle), event.value, end_tag
-            );
-        }
-        submit_outcome = _recorded.has_commands ?
-                             queue.Submit(
-                                 std::span<VulkanCmdList* const>(
-                                     _recorded.ordered_cmd_lists.data(),
-                                     _recorded.ordered_cmd_lists.size()
-                                 ),
-                                 _recorded.context
-                             ) :
-                             queue.SubmitEmpty(_recorded.context);
-        _recorded.native_submit_resolved = true;
-        // Persist the native result before any signal-fence bookkeeping can
-        // throw. Once vkQueueSubmit2 has accepted the packet, every later
-        // exception must still retire it as GPU-submitted.
-        _recorded.retirement_outcome = submit_outcome;
-        if (submit_outcome.WasSubmitted()) {
-            // Publish accepted resource state before waking any host waiter.
-            // Raster uses WaitSubmitted() to gate platform-window presents;
-            // exposing the timeline first would let that thread observe an
-            // accepted source while its presentation readiness was still
-            // stale.
-            CommitAcceptedPresentationSourceStateDelta(
-                _recorded.presentation_source_delta
-            );
-            MarkSubmissionAccepted(
-                timeline, _recorded.timeline, _recorded.submit.signal_events
-            );
+
+        if (!_recorded.native_submit_resolved) {
+            queue.Signal(timeline, _recorded.timeline, end_tag);
+            for (auto& event : _recorded.submit.wait_events) {
+                queue.Wait(
+                    reinterpret_cast<VulkanFence*>(
+                        event.timeline_handle
+                    ),
+                    event.value,
+                    VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT
+                );
+            }
+            for (auto& event : _recorded.submit.signal_events) {
+                queue.Signal(
+                    reinterpret_cast<VulkanFence*>(
+                        event.timeline_handle
+                    ),
+                    event.value,
+                    end_tag
+                );
+            }
+            submit_outcome = _recorded.has_commands ?
+                                 queue.Submit(
+                                     std::span<VulkanCmdList* const>(
+                                         _recorded.ordered_cmd_lists.data(),
+                                         _recorded.ordered_cmd_lists.size()
+                                     ),
+                                     _recorded.context
+                                 ) :
+                                 queue.SubmitEmpty(
+                                     _recorded.context
+                                 );
+            _recorded.native_submit_resolved = true;
+            // Persist the native result before any signal-fence bookkeeping
+            // can throw. Once vkQueueSubmit2 accepts the packet, every later
+            // exception must still retire it as GPU-submitted.
+            _recorded.retirement_outcome = submit_outcome;
+            if (submit_outcome.WasSubmitted()) {
+                // Descriptor membership and texture readiness publish as one
+                // accepted transaction before any host fence is observable.
+                CommitAcceptedPresentationSourceStateTransaction(
+                    *presentation_transaction
+                );
+                MarkSubmissionAccepted(
+                    timeline,
+                    _recorded.timeline,
+                    _recorded.submit.signal_events
+                );
+            }
         }
     }
     const double profile_submit_cpu_ms = _recorded.profile.enabled ?
@@ -5535,8 +5939,8 @@ bool VkCommandQueue::TryExecuteParallel(
     const CmdReorderer&            _reorderer,
     double                         _reorder_time,
     std::chrono::steady_clock::time_point _profile_started,
-    Array<VulkanPresentationSourceStateDelta>&
-                                  _presentation_source_delta,
+    VulkanPresentationSourceStateProgram&
+                                  _presentation_source_program,
     std::optional<CurrentVulkanRecordedSubmit>* _out_recorded
 ) {
     const ERHIProfilingPhase profiling_phase = _submit.ProfilingPhase();
@@ -6449,8 +6853,8 @@ bool VkCommandQueue::TryExecuteParallel(
     CurrentVulkanRecordedSubmit recorded_submit{
         std::move(_submit), _context, _timeline
     };
-    recorded_submit.presentation_source_delta =
-        std::move(_presentation_source_delta);
+    recorded_submit.presentation_source_program =
+        std::move(_presentation_source_program);
     recorded_submit.has_commands      = true;
     recorded_submit.ordered_cmd_lists = std::move(ordered_cmd_lists);
     recorded_submit.allocators = VulkanAllocatorBatch{
@@ -6458,23 +6862,23 @@ bool VkCommandQueue::TryExecuteParallel(
     };
     recorded_submit.descriptor_lease.emplace(std::move(descriptor_lease));
     recorded_submit.deferred_releases = std::move(deferred_releases);
+    recorded_submit.profile.sample = {
+        .requested       = true,
+        .planned         = true,
+        .effective       = parallel_recorded,
+        .worker_fallback = !parallel_recorded,
+        .record_wall_ms  = profile_record_wall_ms,
+        .reorder_ms      = _reorder_time,
+        .preprocess_ms   = preprocess_time,
+        .worker_join_ms  = worker_join_time,
+        .layers          = static_cast<uint32>(runtime_layers.size()),
+        .jobs            = static_cast<uint32>(total_job_count),
+        .work_units      = parallel_work_units,
+        .max_active      = max_active_jobs.load(std::memory_order_relaxed),
+    };
     if (parallel_record_profile) {
         recorded_submit.profile.enabled         = true;
         recorded_submit.profile.execute_started = _profile_started;
-        recorded_submit.profile.sample = {
-            .requested       = true,
-            .planned         = true,
-            .effective       = parallel_recorded,
-            .worker_fallback = !parallel_recorded,
-            .record_wall_ms  = profile_record_wall_ms,
-            .reorder_ms      = _reorder_time,
-            .preprocess_ms   = preprocess_time,
-            .worker_join_ms  = worker_join_time,
-            .layers          = static_cast<uint32>(runtime_layers.size()),
-            .jobs            = static_cast<uint32>(total_job_count),
-            .work_units      = parallel_work_units,
-            .max_active      = max_active_jobs.load(std::memory_order_relaxed),
-        };
     }
     const uint32 recorded_cmd_list_count =
         static_cast<uint32>(recorded_submit.ordered_cmd_lists.size());
@@ -6663,11 +7067,11 @@ void VkCommandQueue::ExecuteNow(
             }
         };
 
-    Array<VulkanPresentationSourceStateDelta>
-        presentation_source_delta{};
+    VulkanPresentationSourceStateProgram
+        presentation_source_program{};
     try {
-        presentation_source_delta =
-            BuildPresentationSourceStateDelta(
+        presentation_source_program =
+            BuildPresentationSourceStateProgram(
                 _submit, queue.GetType()
             );
     } catch (const std::logic_error& error) {
@@ -6765,7 +7169,7 @@ void VkCommandQueue::ExecuteNow(
             reorderer,
             reorder_time,
             parallel_profile_started,
-            presentation_source_delta,
+            presentation_source_program,
             _out_recorded
         )) {
         if (_out_terminalized != nullptr && _out_recorded != nullptr &&
@@ -7341,30 +7745,30 @@ void VkCommandQueue::ExecuteNow(
     CurrentVulkanRecordedSubmit recorded_submit{
         std::move(_submit), context, _timeline
     };
-    recorded_submit.presentation_source_delta =
-        std::move(presentation_source_delta);
+    recorded_submit.presentation_source_program =
+        std::move(presentation_source_program);
     recorded_submit.has_commands = has_cmd;
     recorded_submit.ordered_cmd_lists =
         std::move(serial_cmd_lists);
     recorded_submit.allocators = std::move(serial_allocators);
     recorded_submit.descriptor_lease  = std::move(descriptor_lease);
     recorded_submit.deferred_releases = std::move(deferred_releases);
+    recorded_submit.profile.sample = {
+        .requested       = parallel_record_requested,
+        .planned         = false,
+        .effective       = false,
+        .worker_fallback = false,
+        .record_wall_ms  = profile_record_wall_ms,
+        .reorder_ms      = reorder_time,
+        .preprocess_ms   = preprocess_time,
+        .worker_join_ms  = 0.0,
+        .layers          = serial_layer_count,
+        .jobs            = 0,
+        .max_active      = 0,
+    };
     if (parallel_record_profile) {
         recorded_submit.profile.enabled         = true;
         recorded_submit.profile.execute_started = parallel_profile_started;
-        recorded_submit.profile.sample = {
-            .requested       = parallel_record_requested,
-            .planned         = false,
-            .effective       = false,
-            .worker_fallback = false,
-            .record_wall_ms  = profile_record_wall_ms,
-            .reorder_ms      = reorder_time,
-            .preprocess_ms   = preprocess_time,
-            .worker_join_ms  = 0.0,
-            .layers          = serial_layer_count,
-            .jobs            = 0,
-            .max_active      = 0,
-        };
     }
     CurrentVulkanSubmitResult submit_result{};
     if (_out_recorded != nullptr) {
@@ -9236,8 +9640,8 @@ VkCopyQueue::TranslateForRuntime(CmdSubmit&& _evt) noexcept {
     try {
         recorded.emplace(std::move(_evt));
         recorded->execution_lease = std::move(execution_lease);
-        recorded->presentation_source_delta =
-            BuildPresentationSourceStateDelta(
+        recorded->presentation_source_program =
+            BuildPresentationSourceStateProgram(
                 recorded->submit, EQueueType::Copy
             );
 
@@ -9283,7 +9687,9 @@ VkCopyQueue::TranslateForRuntime(CmdSubmit&& _evt) noexcept {
             .is_resource_write       = &IsBufferTextureWrite,
             .is_resource_read        = &IsBufferTextureRead,
             .is_texture_sampled      = &IsTextureSampled,
-            .is_resource_in_bindless = &IsResourceInBindlessArray
+            .is_resource_in_bindless = &IsResourceInBindlessArray,
+            .lock_bdls_array         = &LockBindlessArray,
+            .unlock_bdls_array       = &UnlockBindlessArray
         };
         CmdReorderer reorderer{
             function_table, recorded->submit.cached_args
@@ -9415,50 +9821,124 @@ VulkanRuntimeSubmissionResult VkCopyQueue::SubmitRecordedForRuntime(
                     !device.IsFaulted();
                 _recorded.native_submit_resolved = true;
             } else {
-                queue.Signal(
-                    timeline,
-                    _recorded.logical_timeline,
-                    VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT
-                );
-                for (auto& event : _recorded.submit.wait_events) {
-                    queue.Wait(
-                        reinterpret_cast<VulkanFence*>(
-                            event.timeline_handle
-                        ),
-                        event.value
+                std::optional<
+                    VulkanPresentationSourceStateTransaction>
+                    presentation_transaction{};
+                const auto reject_presentation_transaction =
+                    [&](const VulkanOperationResult& _outcome,
+                        std::string_view             _reason) {
+                        try {
+                            LOG_ERROR(
+                                "[RHIExecutor][Vulkan] Copy rejected "
+                                "before native submit: timeline={} "
+                                "reason={} VkResult={}",
+                                _recorded.logical_timeline,
+                                _reason,
+                                static_cast<int32>(_outcome.result)
+                            );
+                        } catch (...) {
+                        }
+                        device.RecordRejectedSubmit();
+                        _recorded.retirement_outcome = _outcome;
+                        _recorded.recoverable_rejection =
+                            _outcome.status ==
+                                EVulkanOperationStatus::Rejected &&
+                            !device.IsFaulted() &&
+                            _outcome.result !=
+                                VK_ERROR_DEVICE_LOST;
+                        _recorded.native_submit_resolved = true;
+                    };
+                try {
+                    presentation_transaction.emplace(
+                        EvaluatePresentationSourceStateProgram(
+                            _recorded.presentation_source_program
+                        )
                     );
-                }
-                for (auto& event : _recorded.submit.signal_events) {
-                    queue.Signal(
-                        reinterpret_cast<VulkanFence*>(
-                            event.timeline_handle
-                        ),
-                        event.value,
-                        VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT
+                } catch (const std::logic_error& error) {
+                    reject_presentation_transaction(
+                        VulkanOperationResult{
+                            EVulkanOperationStatus::Rejected,
+                            VK_ERROR_FEATURE_NOT_PRESENT
+                        },
+                        error.what()
+                    );
+                } catch (const std::bad_alloc& error) {
+                    reject_presentation_transaction(
+                        VulkanOperationResult{
+                            EVulkanOperationStatus::Rejected,
+                            VK_ERROR_OUT_OF_HOST_MEMORY
+                        },
+                        error.what()
+                    );
+                } catch (const std::exception& error) {
+                    reject_presentation_transaction(
+                        VulkanOperationResult{
+                            EVulkanOperationStatus::Faulted,
+                            VK_ERROR_UNKNOWN
+                        },
+                        error.what()
+                    );
+                } catch (...) {
+                    reject_presentation_transaction(
+                        VulkanOperationResult{
+                            EVulkanOperationStatus::Faulted,
+                            VK_ERROR_UNKNOWN
+                        },
+                        "presentation-state transaction evaluation "
+                        "failed"
                     );
                 }
 
-                assert(
-                    _recorded.allocators.submitted.size() == 1 &&
-                    "Copy Translate must publish exactly one command allocator"
-                );
-                auto& vk_allocator =
-                    *_recorded.allocators.submitted.front();
-                _recorded.retirement_outcome =
-                    queue.Submit(
-                        vk_allocator.GetCmdList(),
-                        _recorded.context
-                    );
-                _recorded.native_submit_resolved = true;
-                if (_recorded.retirement_outcome.WasSubmitted()) {
-                    CommitAcceptedPresentationSourceStateDelta(
-                        _recorded.presentation_source_delta
-                    );
-                    MarkSubmissionAccepted(
-                        timeline.Get(),
+                if (!_recorded.native_submit_resolved) {
+                    queue.Signal(
+                        timeline,
                         _recorded.logical_timeline,
-                        _recorded.submit.signal_events
+                        VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT
                     );
+                    for (auto& event :
+                         _recorded.submit.wait_events) {
+                        queue.Wait(
+                            reinterpret_cast<VulkanFence*>(
+                                event.timeline_handle
+                            ),
+                            event.value
+                        );
+                    }
+                    for (auto& event :
+                         _recorded.submit.signal_events) {
+                        queue.Signal(
+                            reinterpret_cast<VulkanFence*>(
+                                event.timeline_handle
+                            ),
+                            event.value,
+                            VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT
+                        );
+                    }
+
+                    assert(
+                        _recorded.allocators.submitted.size() ==
+                                1 &&
+                        "Copy Translate must publish exactly one "
+                        "command allocator"
+                    );
+                    auto& vk_allocator =
+                        *_recorded.allocators.submitted.front();
+                    _recorded.retirement_outcome =
+                        queue.Submit(
+                            vk_allocator.GetCmdList(),
+                            _recorded.context
+                        );
+                    _recorded.native_submit_resolved = true;
+                    if (_recorded.retirement_outcome.WasSubmitted()) {
+                        CommitAcceptedPresentationSourceStateTransaction(
+                            *presentation_transaction
+                        );
+                        MarkSubmissionAccepted(
+                            timeline.Get(),
+                            _recorded.logical_timeline,
+                            _recorded.submit.signal_events
+                        );
+                    }
                 }
             }
         } catch (const std::exception& error) {

--- a/source/runtime/render/rhi/vulkan/VulkanQueue.h
+++ b/source/runtime/render/rhi/vulkan/VulkanQueue.h
@@ -100,6 +100,14 @@ struct QueryFrameDiagnostics {
     uint32 used_query_count{0};
 };
 
+// Immutable per-submit publication delta built from the original command
+// order before dependency reordering or native recording. Submission commits
+// it only after the corresponding native packet has been accepted.
+struct VulkanPresentationSourceStateDelta {
+    TextureRef texture;
+    bool       ready{false};
+};
+
 struct ProfilerStorage {
     static constexpr int s_max_num_profiler_queries_per_frame =
         s_query_max_storage * 2; // *2 is for begin&end
@@ -750,6 +758,8 @@ private:
         std::optional<VulkanDescriptorPushLease> descriptor_lease;
         Array<RHIResource*>                     deferred_releases;
         VulkanBatchCompletionTicket             batch_completion{};
+        Array<VulkanPresentationSourceStateDelta>
+                                                presentation_source_delta;
         CurrentVulkanRecordedSubmitProfile      profile;
         RHITransferableOwnershipGate::Lease     execution_lease{};
         VulkanOperationResult                   retirement_outcome{
@@ -812,6 +822,8 @@ private:
         const CmdReorderer&            _reorderer,
         double                         _reorder_time,
         std::chrono::steady_clock::time_point _profile_started,
+        Array<VulkanPresentationSourceStateDelta>&
+                                      _presentation_source_delta,
         std::optional<CurrentVulkanRecordedSubmit>* _out_recorded = nullptr
     );
     VulkanRuntimeSubmissionResult PresentNow(
@@ -1074,6 +1086,8 @@ private:
         uint64                              logical_timeline{0};
         VulkanAllocatorBatch                allocators{};
         VulkanBatchCompletionTicket         batch_completion{};
+        Array<VulkanPresentationSourceStateDelta>
+                                            presentation_source_delta;
         RHITransferableOwnershipGate::Lease execution_lease{};
         VulkanOperationResult               retirement_outcome{
             EVulkanOperationStatus::Rejected, VK_ERROR_UNKNOWN

--- a/source/runtime/render/rhi/vulkan/VulkanQueue.h
+++ b/source/runtime/render/rhi/vulkan/VulkanQueue.h
@@ -100,12 +100,34 @@ struct QueryFrameDiagnostics {
     uint32 used_query_count{0};
 };
 
-// Immutable per-submit publication delta built from the original command
-// order before dependency reordering or native recording. Submission commits
-// it only after the corresponding native packet has been accepted.
+// Immutable source-order program built before dependency reordering or native
+// recording. Bindless accesses remain symbolic until the Submission owner can
+// evaluate them against the last natively accepted descriptor membership.
 struct VulkanPresentationSourceStateDelta {
     TextureRef texture;
     bool       ready{false};
+};
+
+enum class EVulkanPresentationSourceStateEventType : uint8 {
+    TextureState,
+    BindlessAccess,
+    BindlessTextureMembership,
+};
+
+struct VulkanPresentationSourceStateEvent {
+    EVulkanPresentationSourceStateEventType type{
+        EVulkanPresentationSourceStateEventType::TextureState
+    };
+    TextureRef       texture{};
+    BindlessArrayRef bindless_array{};
+    uint             bindless_slot{0};
+    int32            membership_delta{0};
+    bool             ready{false};
+};
+
+struct VulkanPresentationSourceStateProgram {
+    Array<VulkanPresentationSourceStateEvent> events{};
+    bool                                      has_bindless_state{false};
 };
 
 struct ProfilerStorage {
@@ -758,8 +780,7 @@ private:
         std::optional<VulkanDescriptorPushLease> descriptor_lease;
         Array<RHIResource*>                     deferred_releases;
         VulkanBatchCompletionTicket             batch_completion{};
-        Array<VulkanPresentationSourceStateDelta>
-                                                presentation_source_delta;
+        VulkanPresentationSourceStateProgram    presentation_source_program;
         CurrentVulkanRecordedSubmitProfile      profile;
         RHITransferableOwnershipGate::Lease     execution_lease{};
         VulkanOperationResult                   retirement_outcome{
@@ -822,8 +843,8 @@ private:
         const CmdReorderer&            _reorderer,
         double                         _reorder_time,
         std::chrono::steady_clock::time_point _profile_started,
-        Array<VulkanPresentationSourceStateDelta>&
-                                      _presentation_source_delta,
+        VulkanPresentationSourceStateProgram&
+                                      _presentation_source_program,
         std::optional<CurrentVulkanRecordedSubmit>* _out_recorded = nullptr
     );
     VulkanRuntimeSubmissionResult PresentNow(
@@ -1086,8 +1107,7 @@ private:
         uint64                              logical_timeline{0};
         VulkanAllocatorBatch                allocators{};
         VulkanBatchCompletionTicket         batch_completion{};
-        Array<VulkanPresentationSourceStateDelta>
-                                            presentation_source_delta;
+        VulkanPresentationSourceStateProgram presentation_source_program;
         RHITransferableOwnershipGate::Lease execution_lease{};
         VulkanOperationResult               retirement_outcome{
             EVulkanOperationStatus::Rejected, VK_ERROR_UNKNOWN

--- a/source/runtime/render/rhi/vulkan/VulkanRHIResource.cpp
+++ b/source/runtime/render/rhi/vulkan/VulkanRHIResource.cpp
@@ -1817,7 +1817,10 @@ VkAccessFlags2 VulkanEnumTranslator::METoVkAccessFlags2(ERHIAccessFlags _flags) 
     buffer_slot_claim_tokens(_max_size, 0),
     handles(_max_size),
     texture_view_infos(_max_size),
-    texture_offset_in_buffer(GetBindlessTextureDescriptorOffset(*_device)) {
+    texture_offset_in_buffer(GetBindlessTextureDescriptorOffset(*_device)),
+    accepted_presentation_source_membership(
+        std::make_shared<const PresentationSourceMembership>()
+    ) {
         const uint storage_buffer_descriptor_size =
             g_heap.GetDescriptorSize(VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
         const uint sampled_image_descriptor_size =
@@ -2602,29 +2605,24 @@ VkAccessFlags2 VulkanEnumTranslator::METoVkAccessFlags2(ERHIAccessFlags _flags) 
         return resource_allocation_counts.find(_resource) != resource_allocation_counts.end();
     }
 
-    Array<TextureRef>
-    VulkanBindlessArray::SnapshotPresentationSourceTextures() {
-        std::unique_lock<std::mutex> lock(mtx);
-        Array<TextureRef> textures{};
-        textures.reserve(resource_allocation_counts.size());
-        for (const auto& [handle, allocation] :
-             resource_allocation_counts) {
-            (void)handle;
-            RHIResource* resource = allocation.resource.Get();
-            if (resource == nullptr ||
-                resource->GetResourceType() != RRT_TEXTURE) {
-                continue;
-            }
-            auto* texture =
-                static_cast<::Moer::Render::Texture*>(resource);
-            if ((texture->GetUsage() &
-                 ETextureUsageFlags::PRESENTATION_SOURCE) !=
-                ETextureUsageFlags::PRESENTATION_SOURCE) {
-                continue;
-            }
-            textures.emplace_back(texture);
-        }
-        return textures;
+    VulkanBindlessArray::PresentationSourceMembershipSnapshot
+    VulkanBindlessArray::SnapshotAcceptedPresentationSourceMembership(
+    ) const noexcept {
+        return std::atomic_load_explicit(
+            &accepted_presentation_source_membership,
+            std::memory_order_acquire
+        );
+    }
+
+    void VulkanBindlessArray::PublishAcceptedPresentationSourceMembership(
+        PresentationSourceMembershipSnapshot _membership
+    ) noexcept {
+        assert(_membership);
+        std::atomic_store_explicit(
+            &accepted_presentation_source_membership,
+            std::move(_membership),
+            std::memory_order_release
+        );
     }
 
     bool VulkanBindlessArray::IsTextureViewAllocated(

--- a/source/runtime/render/rhi/vulkan/VulkanRHIResource.cpp
+++ b/source/runtime/render/rhi/vulkan/VulkanRHIResource.cpp
@@ -1625,8 +1625,7 @@ VkAccessFlags2 VulkanEnumTranslator::METoVkAccessFlags2(ERHIAccessFlags _flags) 
     VulkanTexture::VulkanTexture(const TextureInfo& _info, VulkanDevice* _device, VkImage _image)
         : Texture(_info), VulkanDeviceObject(_device) {
         b_present = (_info.usage & ETextureUsageFlags::PRESENT) == ETextureUsageFlags::PRESENT;
-        bool b_prefer_sample = (_info.usage & ETextureUsageFlags::SAMPLED) == ETextureUsageFlags::SAMPLED && (_info.usage & ETextureUsageFlags::UNORDERED_ACCESS) == ETextureUsageFlags::UNDEFINED;
-        m_preferred_layout = b_prefer_sample ? VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL : VK_IMAGE_LAYOUT_GENERAL;
+        m_preferred_layout = PreferredLayoutForUsage(_info.usage);
 
         if (_image != VK_NULL_HANDLE) {
             m_alloc.image = _image;

--- a/source/runtime/render/rhi/vulkan/VulkanRHIResource.cpp
+++ b/source/runtime/render/rhi/vulkan/VulkanRHIResource.cpp
@@ -2602,6 +2602,31 @@ VkAccessFlags2 VulkanEnumTranslator::METoVkAccessFlags2(ERHIAccessFlags _flags) 
         return resource_allocation_counts.find(_resource) != resource_allocation_counts.end();
     }
 
+    Array<TextureRef>
+    VulkanBindlessArray::SnapshotPresentationSourceTextures() {
+        std::unique_lock<std::mutex> lock(mtx);
+        Array<TextureRef> textures{};
+        textures.reserve(resource_allocation_counts.size());
+        for (const auto& [handle, allocation] :
+             resource_allocation_counts) {
+            (void)handle;
+            RHIResource* resource = allocation.resource.Get();
+            if (resource == nullptr ||
+                resource->GetResourceType() != RRT_TEXTURE) {
+                continue;
+            }
+            auto* texture =
+                static_cast<::Moer::Render::Texture*>(resource);
+            if ((texture->GetUsage() &
+                 ETextureUsageFlags::PRESENTATION_SOURCE) !=
+                ETextureUsageFlags::PRESENTATION_SOURCE) {
+                continue;
+            }
+            textures.emplace_back(texture);
+        }
+        return textures;
+    }
+
     bool VulkanBindlessArray::IsTextureViewAllocated(
         uint64 _texture,
         uint8  _mip_level,

--- a/source/runtime/render/rhi/vulkan/VulkanRHIResource.h
+++ b/source/runtime/render/rhi/vulkan/VulkanRHIResource.h
@@ -718,7 +718,15 @@ public:
     void          SetName(const std::string_view _name) override;
     bool          b_has_preferred_state : 1 = false;
     bool          b_present : 1             = false;
-    VkImageLayout GetPreferredLayout() {
+    void PublishPresentationSourceReady(bool _ready) noexcept {
+        presentation_source_ready.store(
+            _ready, std::memory_order_release
+        );
+    }
+    [[nodiscard]] bool IsPresentationSourceReady() const noexcept {
+        return presentation_source_ready.load(std::memory_order_acquire);
+    }
+    VkImageLayout GetPreferredLayout() const {
         return m_preferred_layout;
     };
 
@@ -773,6 +781,7 @@ private:
     UnorderedMap<uint64, VkImageView> m_views;
     mutable std::mutex                m_views_mutex;
     VkImageLayout                     m_preferred_layout = VK_IMAGE_LAYOUT_GENERAL;
+    std::atomic_bool                  presentation_source_ready{false};
 };
 
 class VulkanBindlessArray final : public BindlessArray, public VulkanDeviceObject {

--- a/source/runtime/render/rhi/vulkan/VulkanRHIResource.h
+++ b/source/runtime/render/rhi/vulkan/VulkanRHIResource.h
@@ -691,6 +691,21 @@ public:
 
     static VkImageType       METoVKImageType(ETextureDimension _dim);
     static VkImageUsageFlags METoVKImageUsageFlags(ETextureUsageFlags _me_flags);
+    [[nodiscard]] static VkImageLayout PreferredLayoutForUsage(
+        ETextureUsageFlags _usage
+    ) noexcept {
+        const bool presentation_source =
+            (_usage & ETextureUsageFlags::PRESENTATION_SOURCE) ==
+            ETextureUsageFlags::PRESENTATION_SOURCE;
+        const bool prefer_sample =
+            !presentation_source &&
+            (_usage & ETextureUsageFlags::SAMPLED) ==
+                ETextureUsageFlags::SAMPLED &&
+            (_usage & ETextureUsageFlags::UNORDERED_ACCESS) ==
+                ETextureUsageFlags::UNDEFINED;
+        return prefer_sample ? VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL :
+                               VK_IMAGE_LAYOUT_GENERAL;
+    }
 
     uint        GetMipByteSize(uint _mip_idx) const override;
     VkImageView GetView(

--- a/source/runtime/render/rhi/vulkan/VulkanRHIResource.h
+++ b/source/runtime/render/rhi/vulkan/VulkanRHIResource.h
@@ -830,6 +830,10 @@ public:
         uint8  _array_layer,
         uint8  _array_count
     ) const;
+    // Returns a stable intrusive-reference snapshot while holding the
+    // bindless allocation lock. Presentation-state collection uses it before
+    // translation so opaque bindless accesses cannot leave stale readiness.
+    Array<TextureRef> SnapshotPresentationSourceTextures();
     void DeAllocateResource(uint64 _handle);
     void FinalizeUpdateCommand(
         const Array<BindlessArray::UpdateCmd>& _updates,

--- a/source/runtime/render/rhi/vulkan/VulkanRHIResource.h
+++ b/source/runtime/render/rhi/vulkan/VulkanRHIResource.h
@@ -20,6 +20,7 @@
 #include "VulkanTypeDefs.h"
 #include <atomic>
 #include <cstddef>
+#include <memory>
 #include <mutex>
 
 // #include <vk_mem_alloc.h>
@@ -830,10 +831,28 @@ public:
         uint8  _array_layer,
         uint8  _array_count
     ) const;
-    // Returns a stable intrusive-reference snapshot while holding the
-    // bindless allocation lock. Presentation-state collection uses it before
-    // translation so opaque bindless accesses cannot leave stale readiness.
-    Array<TextureRef> SnapshotPresentationSourceTextures();
+    struct PresentationSourceMembershipRecord {
+        TextureRef texture{};
+        uint32     count{0};
+    };
+    struct PresentationSourceMembership {
+        UnorderedMap<uint, TextureRef> slots{};
+        UnorderedMap<
+            ::Moer::Render::Texture*,
+            PresentationSourceMembershipRecord>
+            textures{};
+    };
+    using PresentationSourceMembershipSnapshot =
+        std::shared_ptr<const PresentationSourceMembership>;
+
+    // Descriptor membership becomes visible only after the packet which
+    // updates it reaches vkQueueSubmit. CPU allocation state belongs to a
+    // different timeline and cannot classify an older immutable submit.
+    [[nodiscard]] PresentationSourceMembershipSnapshot
+        SnapshotAcceptedPresentationSourceMembership() const noexcept;
+    void PublishAcceptedPresentationSourceMembership(
+        PresentationSourceMembershipSnapshot _membership
+    ) noexcept;
     void DeAllocateResource(uint64 _handle);
     void FinalizeUpdateCommand(
         const Array<BindlessArray::UpdateCmd>& _updates,
@@ -912,6 +931,8 @@ protected:
         uint32                    count{0};
     };
     UnorderedMap<uint64, ResourceAllocationRecord> resource_allocation_counts;
+    PresentationSourceMembershipSnapshot
+        accepted_presentation_source_membership;
     UnorderedMap<
         uint64,
         UnorderedMap<

--- a/source/runtime/render/rhi/vulkan/VulkanSubmissionDiagnostics.h
+++ b/source/runtime/render/rhi/vulkan/VulkanSubmissionDiagnostics.h
@@ -347,6 +347,9 @@ using VulkanScriptedPresentCallback =
 struct VulkanScriptedPresentOverrideForTesting {
     void*                           context{nullptr};
     VulkanScriptedPresentCallback  callback{nullptr};
+    // Opt-in for source-state boundary tests. Ordinary scripted outcomes do
+    // not record/copy an image and therefore need no native source layout.
+    bool require_present_source_ready{false};
 };
 
 // Narrow deterministic test seam for no-GPU-tail Present outcomes. The
@@ -370,6 +373,11 @@ TryInstallVulkanScriptedPresentOverrideForTesting(
 RemoveVulkanScriptedPresentOverrideForTesting(
     const VulkanScriptedPresentOverrideForTesting* _override
 ) noexcept;
+
+// Terminal test seam used only by isolated fault-boundary executables. It
+// publishes a synthetic first Vulkan fault without issuing a native call.
+[[nodiscard]] RENDER_API bool
+TryLatchVulkanDeviceFaultForTesting(VkResult _result) noexcept;
 
 // Backend-internal notification points shared across Vulkan translation,
 // resource, and submission implementation units.

--- a/source/runtime/render/rhi/vulkan/VulkanSubmissionDiagnostics.h
+++ b/source/runtime/render/rhi/vulkan/VulkanSubmissionDiagnostics.h
@@ -110,6 +110,9 @@ struct VulkanSourceTranslationEvent {
     uint64                        async_queue_scope{0};
     uint32                        thread_id{0};
     ERHIThreadRole                thread_role{ERHIThreadRole::Unknown};
+    bool                          parallel_record_requested{false};
+    bool                          parallel_record_planned{false};
+    bool                          parallel_record_effective{false};
     EVulkanSourceTranslationPhase phase{
         EVulkanSourceTranslationPhase::Begin
     };

--- a/source/runtime/render/rhi/vulkan/VulkanSubmissionDiagnostics.h
+++ b/source/runtime/render/rhi/vulkan/VulkanSubmissionDiagnostics.h
@@ -343,6 +343,8 @@ struct VulkanScriptedPresentResult {
 
 using VulkanScriptedPresentCallback =
     VulkanScriptedPresentResult (*)(void*, uint64) noexcept;
+using VulkanPresentSourceRejectionCallback =
+    void (*)(void*) noexcept;
 
 struct VulkanScriptedPresentOverrideForTesting {
     void*                           context{nullptr};
@@ -350,6 +352,12 @@ struct VulkanScriptedPresentOverrideForTesting {
     // Opt-in for source-state boundary tests. Ordinary scripted outcomes do
     // not record/copy an image and therefore need no native source layout.
     bool require_present_source_ready{false};
+    // Optional race-injection point after the initial device-fault check has
+    // passed but immediately before an invalid/not-ready source is
+    // classified. This keeps fault-priority tests deterministic without
+    // weakening the production source contract.
+    VulkanPresentSourceRejectionCallback
+        before_source_rejection{nullptr};
 };
 
 // Narrow deterministic test seam for no-GPU-tail Present outcomes. The

--- a/source/runtime/render/rhi/vulkan/VulkanSubmissionExecutor.cpp
+++ b/source/runtime/render/rhi/vulkan/VulkanSubmissionExecutor.cpp
@@ -150,7 +150,10 @@ void NotifySourceTranslation(
     EQueueType                    _queue,
     uint32                        _native_queue_id,
     uint64                        _async_queue_scope,
-    EVulkanSourceTranslationPhase _phase
+    EVulkanSourceTranslationPhase _phase,
+    bool                          _parallel_record_requested = false,
+    bool                          _parallel_record_planned = false,
+    bool                          _parallel_record_effective = false
 ) noexcept {
     assert(
         GetCurrentRHIThreadRole() == ERHIThreadRole::Translate &&
@@ -176,6 +179,11 @@ void NotifySourceTranslation(
             .async_queue_scope     = _async_queue_scope,
             .thread_id             = Platform::GetCurrentThreadID(),
             .thread_role           = GetCurrentRHIThreadRole(),
+            .parallel_record_requested =
+                _parallel_record_requested,
+            .parallel_record_planned = _parallel_record_planned,
+            .parallel_record_effective =
+                _parallel_record_effective,
             .phase                 = _phase,
         }
     );
@@ -3074,6 +3082,21 @@ void VulkanSubmissionExecutor::ProcessBatch(
                             slot.source_index
                         )
                     );
+                bool parallel_record_requested = false;
+                bool parallel_record_planned   = false;
+                bool parallel_record_effective = false;
+                if (const auto* graphics_packet =
+                        std::get_if<
+                            VkCommandQueue::
+                                CurrentVulkanRecordedSubmit>(
+                            &slot.recorded
+                        )) {
+                    const auto& sample =
+                        graphics_packet->profile.sample;
+                    parallel_record_requested = sample.requested;
+                    parallel_record_planned   = sample.planned;
+                    parallel_record_effective = sample.effective;
+                }
                 NotifySourceTranslation(
                     _batch.sequence,
                     static_cast<uint32>(slot.source_index),
@@ -3085,7 +3108,10 @@ void VulkanSubmissionExecutor::ProcessBatch(
                     slot.async_queue_scope,
                     HasRecordedSourcePacket(slot.recorded) ?
                         EVulkanSourceTranslationPhase::Recorded :
-                        EVulkanSourceTranslationPhase::Failed
+                        EVulkanSourceTranslationPhase::Failed,
+                    parallel_record_requested,
+                    parallel_record_planned,
+                    parallel_record_effective
                 );
             };
         auto fail_group = [&](size_t           failure_source,

--- a/source/test/RHIExplicitBarrierTest.cpp
+++ b/source/test/RHIExplicitBarrierTest.cpp
@@ -345,6 +345,63 @@ void PresentationSourceUsageSelectsGeneralPreferredLayout() {
     );
 }
 
+void BackendTrackedPublicationMarkerPreservesLegacyOwnership() {
+    TestTexture texture_resource(
+        3,
+        2,
+        ETextureAspectFlags::COLOR
+    );
+    Array<ReadTexture> publications{
+        ReadTexture{
+            texture_resource.GetView(0, 3),
+            ETextureState::TRANSFER,
+            true,
+        },
+    };
+
+    CommandList list(EQueueType::Graphics);
+    list.TextureBarriers(
+        EQueueType::Graphics,
+        EQueueType::Graphics,
+        EPassType::Copy,
+        std::move(publications),
+        {}
+    );
+    CmdSubmit submit = list.Submit();
+
+    Expect(
+        !submit.HasExplicitResourceStateOwnership(),
+        "backend-tracked publication marker changed resource-state ownership"
+    );
+    Expect(
+        submit.cmds.size() == 1 &&
+            submit.cmds.front()->Type() == Command::EType::Barrier,
+        "backend-tracked publication marker did not produce one barrier"
+    );
+    const auto& barrier =
+        *static_cast<const BarrierCmd*>(submit.cmds.front().get());
+    Expect(
+        barrier.ReadTextures().size() == 1 &&
+            barrier.WriteTextures().empty() &&
+            barrier.ExplicitTextures().empty(),
+        "backend-tracked publication marker changed barrier shape"
+    );
+    const TextureBarrier& publication =
+        barrier.ReadTextures().front();
+    Expect(
+        publication.handle ==
+                reinterpret_cast<uint64>(&texture_resource) &&
+            publication.state == ETextureState::TRANSFER &&
+            publication.pass_type == EPassType::Copy &&
+            publication.publish_external_state &&
+            publication.mip_level == 0 &&
+            publication.mip_cnt == 3 &&
+            publication.array_layer == 0 &&
+            publication.array_cnt == 2,
+        "backend-tracked publication marker lost its full-range read contract"
+    );
+}
+
 void LocalExplicitPayloadAndOwnershipArePreserved() {
     TestBuffer       buffer_resource(256);
     TestTexture      texture_resource(6, 4, ETextureAspectFlags::DEPTH_SLICE);
@@ -372,11 +429,19 @@ void LocalExplicitPayloadAndOwnershipArePreserved() {
         ERHIAccessFlags::SHADER_SAMPLED_READ,
         ETextureLayout::TEXTURE_LAYOUT_SHADER_READ_ONLY_OPTIMAL
     );
+    BarrierCreateInfo texture_transition =
+        BarrierCreateInfo::Transition(
+            texture,
+            texture_src,
+            texture_dst,
+            ETextureAspectFlags::DEPTH_SLICE
+        );
+    texture_transition.publish_external_state = true;
 
     CommandList list(EQueueType::Graphics);
     list.Barriers({
         BarrierCreateInfo::Transition(buffer, buffer_src, buffer_dst),
-        BarrierCreateInfo::Transition(texture, texture_src, texture_dst, ETextureAspectFlags::DEPTH_SLICE),
+        texture_transition,
     });
     CmdSubmit submit = list.Submit();
 
@@ -416,6 +481,10 @@ void LocalExplicitPayloadAndOwnershipArePreserved() {
     );
     Expect(recorded_texture.src_state == texture_src, "explicit texture src state changed");
     Expect(recorded_texture.dst_state == texture_dst, "explicit texture dst state changed");
+    Expect(
+        recorded_texture.publish_external_state,
+        "explicit texture lost external-state publication metadata"
+    );
     Expect(
         recorded_texture.queue_transfer == BarrierQueueTransfer{},
         "local explicit texture acquired queue-transfer metadata"
@@ -886,6 +955,7 @@ int main() {
     try {
         LegacyVulkanStateMappingIsStageCompatible();
         PresentationSourceUsageSelectsGeneralPreferredLayout();
+        BackendTrackedPublicationMarkerPreservesLegacyOwnership();
         LocalExplicitPayloadAndOwnershipArePreserved();
         ReleaseAndAcquirePayloadsPreserveEndpointAffinity();
         InvalidQueueTransferEndpointsFailWithoutMutation();

--- a/source/test/RHIExplicitBarrierTest.cpp
+++ b/source/test/RHIExplicitBarrierTest.cpp
@@ -323,6 +323,28 @@ int64 FindCommandLayer(
     return -1;
 }
 
+void PresentationSourceUsageSelectsGeneralPreferredLayout() {
+    const ETextureUsageFlags sampled_output_usage =
+        ETextureUsageFlags::SAMPLED |
+        ETextureUsageFlags::COLOR_ATTACHMENT |
+        ETextureUsageFlags::TRANSFER_SRC |
+        ETextureUsageFlags::TRANSFER_DST;
+
+    Expect(
+        VulkanTexture::PreferredLayoutForUsage(
+            sampled_output_usage |
+            ETextureUsageFlags::PRESENTATION_SOURCE
+        ) == VK_IMAGE_LAYOUT_GENERAL,
+        "sampled presentation source must prefer GENERAL"
+    );
+    Expect(
+        VulkanTexture::PreferredLayoutForUsage(
+            sampled_output_usage
+        ) == VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
+        "ordinary sampled texture must keep its shader-read preferred layout"
+    );
+}
+
 void LocalExplicitPayloadAndOwnershipArePreserved() {
     TestBuffer       buffer_resource(256);
     TestTexture      texture_resource(6, 4, ETextureAspectFlags::DEPTH_SLICE);
@@ -863,6 +885,7 @@ void ReleaseSentinelOverlapUsesExactBufferAndTextureRanges() {
 int main() {
     try {
         LegacyVulkanStateMappingIsStageCompatible();
+        PresentationSourceUsageSelectsGeneralPreferredLayout();
         LocalExplicitPayloadAndOwnershipArePreserved();
         ReleaseAndAcquirePayloadsPreserveEndpointAffinity();
         InvalidQueueTransferEndpointsFailWithoutMutation();

--- a/source/test/RHIParallelRecordVulkanTest.cpp
+++ b/source/test/RHIParallelRecordVulkanTest.cpp
@@ -756,11 +756,14 @@ public:
 class ScopedScriptedPresentOverride final {
 public:
     explicit ScopedScriptedPresentOverride(
-        ScriptedPresentCapture& _capture
+        ScriptedPresentCapture& _capture,
+        bool _require_present_source_ready = false
     ) :
         scripted_override{
             .context  = &_capture,
             .callback = &ScriptedPresentCapture::Observe,
+            .require_present_source_ready =
+                _require_present_source_ready,
         } {
         if (!TryInstallVulkanScriptedPresentOverrideForTesting(
                 &scripted_override
@@ -8255,6 +8258,39 @@ void RunPresentSourceContractRejection() {
         PF_R8G8B8A8_UNORM,
         present_source_usage
     );
+    TextureRef rejected_export_source = device.CreateTexture(
+        "present_source_contract_rejected_export",
+        Extent3D(4, 4, 1),
+        PF_R8G8B8A8_UNORM,
+        present_source_usage
+    );
+    TextureRef wrong_queue_source = device.CreateTexture(
+        "present_source_contract_wrong_queue_export",
+        Extent3D(4, 4, 1),
+        PF_R8G8B8A8_UNORM,
+        present_source_usage
+    );
+    TextureRef backend_tracked_source = device.CreateTexture(
+        "present_source_contract_backend_tracked",
+        Extent3D(4, 4, 1),
+        PF_R8G8B8A8_UNORM,
+        present_source_usage
+    );
+    TextureRef rejected_backend_tracked_source =
+        device.CreateTexture(
+            "present_source_contract_rejected_backend_tracked",
+            Extent3D(4, 4, 1),
+            PF_R8G8B8A8_UNORM,
+            present_source_usage
+        );
+    TextureRef backend_nonterminal_source =
+        device.CreateTexture(
+            "present_source_contract_backend_nonterminal",
+            Extent3D(4, 4, 1),
+            PF_R8G8B8A8_UNORM,
+            present_source_usage |
+                ETextureUsageFlags::COLOR_ATTACHMENT
+        );
     TextureRef missing_usage_source = device.CreateTexture(
         "present_source_contract_missing_usage",
         Extent3D(4, 4, 1),
@@ -8303,6 +8339,11 @@ void RunPresentSourceContractRejection() {
     compressed_stride_swapchain->format =
         PF_R16G16B16A16_SFLOAT;
     if (!valid_source.IsValid() ||
+        !rejected_export_source.IsValid() ||
+        !wrong_queue_source.IsValid() ||
+        !backend_tracked_source.IsValid() ||
+        !rejected_backend_tracked_source.IsValid() ||
+        !backend_nonterminal_source.IsValid() ||
         !missing_usage_source.IsValid() ||
         !missing_transfer_source.IsValid() ||
         !multisampled_source.IsValid() ||
@@ -8324,7 +8365,8 @@ void RunPresentSourceContractRejection() {
         }
     );
     ScopedScriptedPresentOverride scripted_override(
-        scripted_capture
+        scripted_capture,
+        true
     );
 
     uint32 rejected_count = 0;
@@ -8334,6 +8376,10 @@ void RunPresentSourceContractRejection() {
             std::string_view  _case_name,
             const SwapchainRef& _swapchain
         ) {
+            const uint32 scripted_before =
+                scripted_capture.count.load(
+                    std::memory_order_acquire
+                );
             PresentReceiptRef receipt = MakeShared<PresentReceipt>();
             RHIExecutor::Get().Present(
                 RHIPresentRequest(
@@ -8350,7 +8396,7 @@ void RunPresentSourceContractRejection() {
                 receipt->ResolutionAttemptCount() != 1 ||
                 scripted_capture.count.load(
                     std::memory_order_acquire
-                ) != 0) {
+                ) != scripted_before) {
                 throw std::runtime_error(
                     "Present source contract did not reject " +
                     std::string(_case_name) +
@@ -8428,6 +8474,378 @@ void RunPresentSourceContractRejection() {
         scripted_swapchain
     );
 
+    expect_rejected(
+        valid_source->GetView(),
+        "fresh source without an accepted producer export",
+        scripted_swapchain
+    );
+
+    const auto make_backend_tracked_publication =
+        [&](const TextureRef& _texture,
+            const FenceRef&   _signal,
+            uint64            _signal_value) {
+            CommandList producer(EQueueType::Graphics);
+            producer.ClearResource(
+                _texture->GetView(),
+                float4(0.f, 0.f, 0.f, 1.f)
+            );
+            Array<ReadTexture> publications{
+                ReadTexture{
+                    _texture->GetView(
+                        0,
+                        static_cast<uint8>(
+                            _texture->GetNumMips()
+                        )
+                    ),
+                    ETextureState::TRANSFER,
+                    true,
+                },
+            };
+            producer.TextureBarriers(
+                EQueueType::Graphics,
+                EQueueType::Graphics,
+                EPassType::Copy,
+                std::move(publications),
+                {}
+            );
+            CmdSubmit submit = producer.Submit();
+            if (submit.HasExplicitResourceStateOwnership()) {
+                throw std::runtime_error(
+                    "linear Present publication changed to Explicit ownership"
+                );
+            }
+            submit.Signal(_signal.Get(), _signal_value);
+            return submit;
+        };
+
+    FenceRef backend_tracked_done = device.CreateFence();
+    PresentReceiptRef backend_tracked_receipt =
+        MakeShared<PresentReceipt>();
+    RHIPresentRequest backend_tracked_present(
+        scripted_swapchain,
+        backend_tracked_source->GetView(),
+        backend_tracked_receipt
+    );
+    RHIExecutor::Get().Submit(
+        EQueueType::Graphics,
+        make_backend_tracked_publication(
+            backend_tracked_source,
+            backend_tracked_done,
+            1
+        ),
+        ERHIExecSubmitFlags::FlushGPU,
+        &backend_tracked_present
+    );
+    const PresentReceiptResult backend_tracked_result =
+        backend_tracked_receipt->WaitForSubmission(5s);
+    RHIExecutor::Get().Sync(ERHISyncDepth::Present);
+    if (!ResourceCast(backend_tracked_done.Get())
+             ->WaitSubmitted(1) ||
+        !ResourceCast(backend_tracked_source.Get())
+             ->IsPresentationSourceReady() ||
+        !backend_tracked_result.resolved ||
+        backend_tracked_result.submitted ||
+        !backend_tracked_result.recreate_swapchain ||
+        backend_tracked_receipt->ResolutionAttemptCount() != 1 ||
+        scripted_capture.count.load(
+            std::memory_order_acquire
+        ) != 1) {
+        throw std::runtime_error(
+            "accepted BackendTracked producer did not publish readiness "
+            "before its same-batch Present"
+        );
+    }
+
+    FenceRef rejected_backend_dependency = device.CreateFence();
+    FenceRef rejected_backend_done = device.CreateFence();
+    rejected_backend_dependency->Reject(1);
+    CmdSubmit rejected_backend_submit =
+        make_backend_tracked_publication(
+            rejected_backend_tracked_source,
+            rejected_backend_done,
+            1
+        );
+    rejected_backend_submit.Wait(
+        rejected_backend_dependency.Get(),
+        1
+    );
+    PresentReceiptRef rejected_backend_receipt =
+        MakeShared<PresentReceipt>();
+    RHIPresentRequest rejected_backend_present(
+        scripted_swapchain,
+        rejected_backend_tracked_source->GetView(),
+        rejected_backend_receipt
+    );
+    RHIExecutor::Get().Submit(
+        EQueueType::Graphics,
+        std::move(rejected_backend_submit),
+        ERHIExecSubmitFlags::FlushGPU,
+        &rejected_backend_present
+    );
+    const PresentReceiptResult rejected_backend_result =
+        rejected_backend_receipt->WaitForSubmission(5s);
+    RHIExecutor::Get().Sync(ERHISyncDepth::Present);
+    if (!ResourceCast(rejected_backend_done.Get())
+             ->IsRejected(1) ||
+        ResourceCast(rejected_backend_done.Get())->IsFailed() ||
+        ResourceCast(rejected_backend_tracked_source.Get())
+            ->IsPresentationSourceReady() ||
+        !rejected_backend_result.resolved ||
+        rejected_backend_result.submitted ||
+        rejected_backend_result.recreate_swapchain ||
+        rejected_backend_receipt->ResolutionAttemptCount() != 1 ||
+        scripted_capture.count.load(
+            std::memory_order_acquire
+        ) != 1) {
+        throw std::runtime_error(
+            "rejected BackendTracked producer published readiness or "
+            "reached its same-batch Present"
+        );
+    }
+
+    FenceRef backend_nonterminal_done = device.CreateFence();
+    CommandList backend_nonterminal_producer(
+        EQueueType::Graphics
+    );
+    backend_nonterminal_producer.ClearResource(
+        backend_nonterminal_source->GetView(),
+        float4(0.f, 0.f, 0.f, 1.f)
+    );
+    backend_nonterminal_producer.TextureBarriers(
+        EQueueType::Graphics,
+        EQueueType::Graphics,
+        EPassType::Copy,
+        Array<ReadTexture>{
+            ReadTexture{
+                backend_nonterminal_source->GetView(),
+                ETextureState::TRANSFER,
+                true,
+            },
+        },
+        {}
+    );
+    backend_nonterminal_producer.TextureBarriers(
+        EQueueType::Graphics,
+        EQueueType::Graphics,
+        EPassType::Graphics,
+        {},
+        Array<WriteTexture>{
+            WriteTexture{
+                backend_nonterminal_source->GetView(),
+                ETextureState::RENDER_TARGET,
+            },
+        }
+    );
+    CmdSubmit backend_nonterminal_submit =
+        backend_nonterminal_producer.Submit();
+    backend_nonterminal_submit.Signal(
+        backend_nonterminal_done.Get(), 1
+    );
+    PresentReceiptRef backend_nonterminal_receipt =
+        MakeShared<PresentReceipt>();
+    RHIPresentRequest backend_nonterminal_present(
+        scripted_swapchain,
+        backend_nonterminal_source->GetView(),
+        backend_nonterminal_receipt
+    );
+    RHIExecutor::Get().Submit(
+        EQueueType::Graphics,
+        std::move(backend_nonterminal_submit),
+        ERHIExecSubmitFlags::FlushGPU,
+        &backend_nonterminal_present
+    );
+    const PresentReceiptResult backend_nonterminal_result =
+        backend_nonterminal_receipt->WaitForSubmission(5s);
+    RHIExecutor::Get().Sync(ERHISyncDepth::Present);
+    if (!ResourceCast(backend_nonterminal_done.Get())
+             ->WaitSubmitted(1) ||
+        ResourceCast(backend_nonterminal_source.Get())
+            ->IsPresentationSourceReady() ||
+        !backend_nonterminal_result.resolved ||
+        backend_nonterminal_result.submitted ||
+        backend_nonterminal_result.recreate_swapchain ||
+        backend_nonterminal_receipt->ResolutionAttemptCount() != 1 ||
+        scripted_capture.count.load(
+            std::memory_order_acquire
+        ) != 1) {
+        throw std::runtime_error(
+            "a BackendTracked publication followed by a terminal write "
+            "remained ready or reached Present"
+        );
+    }
+
+    const auto submit_source_state =
+        [&](const TextureRef& _texture,
+            EQueueType        _queue,
+            BarrierState      _source,
+            BarrierState _destination,
+            bool         _publish_external_state,
+            uint64       _signal_value) {
+            FenceRef accepted = device.CreateFence();
+            BarrierCreateInfo transition =
+                BarrierCreateInfo::Transition(
+                    _texture->GetView(),
+                    _source,
+                    _destination,
+                    ETextureAspectFlags::COLOR
+                );
+            transition.publish_external_state =
+                _publish_external_state;
+
+            CommandList producer(_queue);
+            producer.SetResourceStateOwnership(
+                ERHIResourceStateOwnership::Explicit
+            );
+            producer.Barriers({transition});
+            CmdSubmit submit = producer.Submit();
+            submit.SetResourceStateOwnership(
+                ERHIResourceStateOwnership::Explicit
+            );
+            submit.Signal(accepted.Get(), _signal_value);
+            RHIExecutor::Get().Submit(
+                _queue,
+                std::move(submit),
+                ERHIExecSubmitFlags::FlushGPU
+            );
+            RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
+            auto* vk_accepted = ResourceCast(accepted.Get());
+            if (vk_accepted->IsFailed() ||
+                vk_accepted->IsRejected(_signal_value)) {
+                throw std::runtime_error(
+                    "Present source state publication was not natively accepted"
+                );
+            }
+        };
+
+    const BarrierState undefined_state = BarrierState::Texture(
+        ERHIPipelineStageFlags::PS_NONE,
+        ERHIAccessFlags::UNDEFINED,
+        ETextureLayout::TEXTURE_LAYOUT_UNDEFINED
+    );
+    const BarrierState presentation_state = BarrierState::Texture(
+        ERHIPipelineStageFlags::PS_TRANSFER,
+        ERHIAccessFlags::TRANSFER_READ,
+        ETextureLayout::TEXTURE_LAYOUT_COMMON
+    );
+    const BarrierState transfer_write_state = BarrierState::Texture(
+        ERHIPipelineStageFlags::PS_TRANSFER,
+        ERHIAccessFlags::TRANSFER_WRITE,
+        ETextureLayout::TEXTURE_LAYOUT_COMMON
+    );
+
+    submit_source_state(
+        valid_source,
+        EQueueType::Graphics,
+        undefined_state,
+        presentation_state,
+        true,
+        1
+    );
+    auto* vk_valid_source = ResourceCast(valid_source.Get());
+    if (!vk_valid_source->IsPresentationSourceReady()) {
+        throw std::runtime_error(
+            "accepted producer export did not publish Present readiness"
+        );
+    }
+
+    submit_source_state(
+        valid_source,
+        EQueueType::Graphics,
+        presentation_state,
+        transfer_write_state,
+        false,
+        2
+    );
+    if (vk_valid_source->IsPresentationSourceReady()) {
+        throw std::runtime_error(
+            "a later accepted non-export state left stale Present readiness"
+        );
+    }
+    expect_rejected(
+        valid_source->GetView(),
+        "source moved away from its published presentation state",
+        scripted_swapchain
+    );
+
+    submit_source_state(
+        valid_source,
+        EQueueType::Graphics,
+        transfer_write_state,
+        presentation_state,
+        true,
+        3
+    );
+    if (!vk_valid_source->IsPresentationSourceReady()) {
+        throw std::runtime_error(
+            "accepted producer re-export did not restore Present readiness"
+        );
+    }
+
+    const RHIQueueTopology topology = device.GetQueueTopology();
+    if (topology.compute.available) {
+        submit_source_state(
+            wrong_queue_source,
+            EQueueType::Compute,
+            undefined_state,
+            presentation_state,
+            true,
+            1
+        );
+        if (ResourceCast(wrong_queue_source.Get())
+                ->IsPresentationSourceReady()) {
+            throw std::runtime_error(
+                "a non-Graphics export published Present readiness"
+            );
+        }
+        expect_rejected(
+            wrong_queue_source->GetView(),
+            "source exported by a non-Graphics queue",
+            scripted_swapchain
+        );
+    }
+
+    FenceRef rejected_dependency = device.CreateFence();
+    FenceRef rejected_export_done = device.CreateFence();
+    rejected_dependency->Reject(1);
+    BarrierCreateInfo rejected_export =
+        BarrierCreateInfo::Transition(
+            rejected_export_source->GetView(),
+            undefined_state,
+            presentation_state,
+            ETextureAspectFlags::COLOR
+        );
+    rejected_export.publish_external_state = true;
+    CommandList rejected_producer(EQueueType::Graphics);
+    rejected_producer.SetResourceStateOwnership(
+        ERHIResourceStateOwnership::Explicit
+    );
+    rejected_producer.Barriers({rejected_export});
+    CmdSubmit rejected_submit = rejected_producer.Submit();
+    rejected_submit.SetResourceStateOwnership(
+        ERHIResourceStateOwnership::Explicit
+    );
+    rejected_submit.Wait(rejected_dependency.Get(), 1);
+    rejected_submit.Signal(rejected_export_done.Get(), 1);
+    RHIExecutor::Get().Submit(
+        EQueueType::Graphics,
+        std::move(rejected_submit),
+        ERHIExecSubmitFlags::FlushGPU
+    );
+    RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
+    if (!ResourceCast(rejected_export_done.Get())->IsRejected(1) ||
+        ResourceCast(rejected_export_done.Get())->IsFailed() ||
+        ResourceCast(rejected_export_source.Get())
+            ->IsPresentationSourceReady()) {
+        throw std::runtime_error(
+            "a rejected producer export published Present readiness"
+        );
+    }
+    expect_rejected(
+        rejected_export_source->GetView(),
+        "source whose producer export was rejected",
+        scripted_swapchain
+    );
+
     PresentReceiptRef valid_receipt = MakeShared<PresentReceipt>();
     RHIExecutor::Get().Present(
         RHIPresentRequest(
@@ -8445,7 +8863,7 @@ void RunPresentSourceContractRejection() {
         valid_receipt->ResolutionAttemptCount() != 1 ||
         scripted_capture.count.load(
             std::memory_order_acquire
-        ) != 1 ||
+        ) != 2 ||
         scripted_capture.timeline.load(
             std::memory_order_acquire
         ) == 0 ||
@@ -8461,7 +8879,11 @@ void RunPresentSourceContractRejection() {
         "[TESTCASE][PASS] name=PresentSourceContractRejection "
         "rejected={} null=true usage=true transfer_src=true samples=true "
         "format=true compressed=true mip=true layer=true offset=true extent=true "
-        "valid_override=1 owner=Submission",
+        "fresh=true accepted_export=true stale_clear=true "
+        "backend_tracked_same_batch=true backend_rejected=true "
+        "backend_nonterminal_clear=true "
+        "wrong_queue_clear=true rejected_export_clear=true "
+        "valid_override=2 owner=Submission",
         rejected_count
     );
 }
@@ -9140,18 +9562,18 @@ void RunPresentHardFailureBoundary() {
     auto& device = RenderDevice::Get();
     const uint32 main_thread_id =
         Platform::GetCurrentThreadID();
-    TextureRef present_source = device.CreateTexture(
-        "phase15f_present_hard_source",
+    TextureRef invalid_present_source = device.CreateTexture(
+        "phase15f_fault_priority_invalid_source",
         Extent3D(4, 4, 1),
         PF_R8G8B8A8_UNORM,
-        ETextureUsageFlags::PRESENTATION_SOURCE |
-            ETextureUsageFlags::TRANSFER_SRC |
+        ETextureUsageFlags::TRANSFER_SRC |
             ETextureUsageFlags::TRANSFER_DST
     );
     SwapchainRef scripted_swapchain{
         MoerNew(HeadlessScriptedSwapchain)()
     };
-    if (!present_source.IsValid() || !scripted_swapchain.IsValid()) {
+    if (!invalid_present_source.IsValid() ||
+        !scripted_swapchain.IsValid()) {
         throw std::runtime_error(
             "Phase15F hard Present resources were not created"
         );
@@ -9181,10 +9603,18 @@ void RunPresentHardFailureBoundary() {
     std::atomic<uint32> success_callbacks{0};
 
     try {
+        if (!TryLatchVulkanDeviceFaultForTesting(
+                VK_ERROR_DEVICE_LOST
+            )) {
+            throw std::runtime_error(
+                "hard Present fixture could not pre-fault the Vulkan device"
+            );
+        }
+
         RHIExecutor::Get().Present(
             RHIPresentRequest(
                 scripted_swapchain,
-                present_source->GetView(),
+                invalid_present_source->GetView(),
                 receipt
             ),
             true
@@ -9221,7 +9651,7 @@ void RunPresentHardFailureBoundary() {
 
         if (scripted_capture.count.load(
                 std::memory_order_acquire
-            ) != 1 ||
+            ) != 0 ||
             scripted_capture.wrong_owner.load(
                 std::memory_order_acquire
             ) ||
@@ -9254,9 +9684,6 @@ void RunPresentHardFailureBoundary() {
             dispatch.thread_role != ERHIThreadRole::Submission ||
             terminal.thread_role != ERHIThreadRole::Submission ||
             dispatch.thread_id != terminal.thread_id ||
-            dispatch.thread_id != scripted_capture.thread_id.load(
-                std::memory_order_acquire
-            ) ||
             dispatch.thread_id == main_thread_id ||
             terminal.outcome.status !=
                 EVulkanOperationStatus::Rejected ||
@@ -9272,7 +9699,7 @@ void RunPresentHardFailureBoundary() {
         RHIExecutor::Get().Sync(ERHISyncDepth::Present);
         if (scripted_capture.count.load(
                 std::memory_order_acquire
-            ) != 1 ||
+            ) != 0 ||
             boundary_capture.Count() != 2 ||
             native_capture.Count() != 0 ||
             ordinary_callbacks.load(std::memory_order_acquire) != 1 ||
@@ -9286,7 +9713,8 @@ void RunPresentHardFailureBoundary() {
             "[TESTCASE][PASS] name=PresentHardFailureBoundary "
             "outcome=Rejected owner=Submission receipt_attempts=1 "
             "submitted=false recreate=false later_batch=rejected "
-            "native_after_present=0 hard_latch=verified replay=0"
+            "native_after_present=0 device_fault_priority=true "
+            "invalid_source=true hard_latch=verified replay=0"
         );
     } catch (...) {
         RHIExecutor::Get().Sync(ERHISyncDepth::Present);

--- a/source/test/RHIParallelRecordVulkanTest.cpp
+++ b/source/test/RHIParallelRecordVulkanTest.cpp
@@ -8241,6 +8241,231 @@ void RunSerialControlPipelineBoundary() {
     }
 }
 
+void RunPresentSourceContractRejection() {
+    using namespace std::chrono_literals;
+
+    auto& device = RenderDevice::Get();
+    constexpr ETextureUsageFlags present_source_usage =
+        ETextureUsageFlags::PRESENTATION_SOURCE |
+        ETextureUsageFlags::TRANSFER_SRC |
+        ETextureUsageFlags::TRANSFER_DST;
+    TextureRef valid_source = device.CreateTexture(
+        "present_source_contract_valid",
+        Extent3D(4, 4, 1),
+        PF_R8G8B8A8_UNORM,
+        present_source_usage
+    );
+    TextureRef missing_usage_source = device.CreateTexture(
+        "present_source_contract_missing_usage",
+        Extent3D(4, 4, 1),
+        PF_R8G8B8A8_UNORM,
+        ETextureUsageFlags::TRANSFER_SRC |
+            ETextureUsageFlags::TRANSFER_DST
+    );
+    TextureRef missing_transfer_source = device.CreateTexture(
+        "present_source_contract_missing_transfer_src",
+        Extent3D(4, 4, 1),
+        PF_R8G8B8A8_UNORM,
+        ETextureUsageFlags::PRESENTATION_SOURCE |
+            ETextureUsageFlags::TRANSFER_DST
+    );
+    TextureRef multisampled_source = device.CreateTexture(
+        "present_source_contract_multisampled",
+        TextureInfo{
+            ETextureDimension::TEX_2D,
+            present_source_usage,
+            PF_R8G8B8A8_UNORM,
+            EClearAttachment{},
+            Extent3D(4, 4, 1),
+            1,
+            1,
+            4
+        }
+    );
+    TextureRef incompatible_format_source = device.CreateTexture(
+        "present_source_contract_incompatible_format",
+        Extent3D(4, 4, 1),
+        PF_R16G16B16A16_SFLOAT,
+        present_source_usage
+    );
+    TextureRef compressed_source = device.CreateTexture(
+        "present_source_contract_compressed",
+        Extent3D(4, 4, 1),
+        PF_BC1_RGBA_UNORM_BLOCK,
+        present_source_usage
+    );
+    SwapchainRef scripted_swapchain{
+        MoerNew(HeadlessScriptedSwapchain)()
+    };
+    SwapchainRef compressed_stride_swapchain{
+        MoerNew(HeadlessScriptedSwapchain)()
+    };
+    compressed_stride_swapchain->format =
+        PF_R16G16B16A16_SFLOAT;
+    if (!valid_source.IsValid() ||
+        !missing_usage_source.IsValid() ||
+        !missing_transfer_source.IsValid() ||
+        !multisampled_source.IsValid() ||
+        !incompatible_format_source.IsValid() ||
+        !compressed_source.IsValid() ||
+        !scripted_swapchain.IsValid() ||
+        !compressed_stride_swapchain.IsValid()) {
+        throw std::runtime_error(
+            "Present source-contract resources were not created"
+        );
+    }
+
+    ScriptedPresentCapture scripted_capture(
+        VulkanScriptedPresentResult{
+            .outcome = {
+                EVulkanOperationStatus::Recreate,
+                VK_ERROR_OUT_OF_DATE_KHR,
+            },
+        }
+    );
+    ScopedScriptedPresentOverride scripted_override(
+        scripted_capture
+    );
+
+    uint32 rejected_count = 0;
+    const auto expect_rejected =
+        [&](
+            TextureView       _source,
+            std::string_view  _case_name,
+            const SwapchainRef& _swapchain
+        ) {
+            PresentReceiptRef receipt = MakeShared<PresentReceipt>();
+            RHIExecutor::Get().Present(
+                RHIPresentRequest(
+                    _swapchain,
+                    _source,
+                    receipt
+                ),
+                true
+            );
+            const PresentReceiptResult result =
+                receipt->WaitForSubmission(5s);
+            if (!result.resolved || result.submitted ||
+                result.recreate_swapchain ||
+                receipt->ResolutionAttemptCount() != 1 ||
+                scripted_capture.count.load(
+                    std::memory_order_acquire
+                ) != 0) {
+                throw std::runtime_error(
+                    "Present source contract did not reject " +
+                    std::string(_case_name) +
+                    " before the scripted override"
+                );
+            }
+            ++rejected_count;
+        };
+
+    expect_rejected(
+        TextureView{},
+        "null source texture",
+        scripted_swapchain
+    );
+
+    expect_rejected(
+        missing_usage_source->GetView(),
+        "missing PRESENTATION_SOURCE usage",
+        scripted_swapchain
+    );
+
+    expect_rejected(
+        missing_transfer_source->GetView(),
+        "missing TRANSFER_SRC usage",
+        scripted_swapchain
+    );
+
+    expect_rejected(
+        multisampled_source->GetView(),
+        "multisampled source",
+        scripted_swapchain
+    );
+
+    expect_rejected(
+        incompatible_format_source->GetView(),
+        "size-incompatible format",
+        scripted_swapchain
+    );
+
+    expect_rejected(
+        compressed_source->GetView(),
+        "compressed format with matching block stride",
+        compressed_stride_swapchain
+    );
+
+    TextureView invalid_mip = valid_source->GetView();
+    invalid_mip.mip_level   = 1;
+    expect_rejected(
+        invalid_mip,
+        "nonzero mip",
+        scripted_swapchain
+    );
+
+    TextureView invalid_layer = valid_source->GetView();
+    invalid_layer.array_layer = 1;
+    expect_rejected(
+        invalid_layer,
+        "nonzero array layer",
+        scripted_swapchain
+    );
+
+    TextureView invalid_offset = valid_source->GetView();
+    invalid_offset.offset.x    = 1;
+    expect_rejected(
+        invalid_offset,
+        "nonzero offset",
+        scripted_swapchain
+    );
+
+    TextureView invalid_extent = valid_source->GetView();
+    --invalid_extent.extent.x;
+    expect_rejected(
+        invalid_extent,
+        "partial extent",
+        scripted_swapchain
+    );
+
+    PresentReceiptRef valid_receipt = MakeShared<PresentReceipt>();
+    RHIExecutor::Get().Present(
+        RHIPresentRequest(
+            scripted_swapchain,
+            valid_source->GetView(),
+            valid_receipt
+        ),
+        true
+    );
+    const PresentReceiptResult valid_result =
+        valid_receipt->WaitForSubmission(5s);
+    RHIExecutor::Get().Sync(ERHISyncDepth::Present);
+    if (!valid_result.resolved || valid_result.submitted ||
+        !valid_result.recreate_swapchain ||
+        valid_receipt->ResolutionAttemptCount() != 1 ||
+        scripted_capture.count.load(
+            std::memory_order_acquire
+        ) != 1 ||
+        scripted_capture.timeline.load(
+            std::memory_order_acquire
+        ) == 0 ||
+        scripted_capture.wrong_owner.load(
+            std::memory_order_acquire
+        )) {
+        throw std::runtime_error(
+            "a valid Present source did not reach the scripted override"
+        );
+    }
+
+    LOG_INFO(
+        "[TESTCASE][PASS] name=PresentSourceContractRejection "
+        "rejected={} null=true usage=true transfer_src=true samples=true "
+        "format=true compressed=true mip=true layer=true offset=true extent=true "
+        "valid_override=1 owner=Submission",
+        rejected_count
+    );
+}
+
 void RunPresentPipelineBoundary() {
     using namespace std::chrono_literals;
 
@@ -8292,7 +8517,8 @@ void RunPresentPipelineBoundary() {
         "phase15f_present_source",
         Extent3D(4, 4, 1),
         PF_R8G8B8A8_UNORM,
-        ETextureUsageFlags::TRANSFER_SRC |
+        ETextureUsageFlags::PRESENTATION_SOURCE |
+            ETextureUsageFlags::TRANSFER_SRC |
             ETextureUsageFlags::TRANSFER_DST
     );
     SwapchainRef scripted_swapchain{
@@ -8729,7 +8955,8 @@ void RunQueuedPresentShutdownBoundary() {
         "phase15f_shutdown_present_source",
         Extent3D(4, 4, 1),
         PF_R8G8B8A8_UNORM,
-        ETextureUsageFlags::TRANSFER_SRC |
+        ETextureUsageFlags::PRESENTATION_SOURCE |
+            ETextureUsageFlags::TRANSFER_SRC |
             ETextureUsageFlags::TRANSFER_DST
     );
     SwapchainRef scripted_swapchain{
@@ -8917,7 +9144,8 @@ void RunPresentHardFailureBoundary() {
         "phase15f_present_hard_source",
         Extent3D(4, 4, 1),
         PF_R8G8B8A8_UNORM,
-        ETextureUsageFlags::TRANSFER_SRC |
+        ETextureUsageFlags::PRESENTATION_SOURCE |
+            ETextureUsageFlags::TRANSFER_SRC |
             ETextureUsageFlags::TRANSFER_DST
     );
     SwapchainRef scripted_swapchain{
@@ -11391,6 +11619,7 @@ int main(int argc, const char** argv) {
 
         if (present_mode) {
             if (present_boundary) {
+                RunPresentSourceContractRejection();
                 RunSerialControlPipelineBoundary();
                 RunPresentPipelineBoundary();
                 // This is the terminal focused lifecycle test: it stops and

--- a/source/test/RHIParallelRecordVulkanTest.cpp
+++ b/source/test/RHIParallelRecordVulkanTest.cpp
@@ -75,6 +75,19 @@ private:
     EQueueType             queue;
 };
 
+class OpaquePresentationStateProbeCommand final : public CustomCmd {
+public:
+    OpaquePresentationStateProbeCommand() :
+        CustomCmd(
+            CustomCmdId::CUSTOM_CMD_NONE,
+            "OpaquePresentationStateProbe"
+        ) {}
+
+    EQueueType GetQueueType() const override {
+        return EQueueType::Graphics;
+    }
+};
+
 class PipelineTranslateProbeCommand final : public VkCustomDispatchCmd {
 public:
     PipelineTranslateProbeCommand(
@@ -746,24 +759,49 @@ public:
         return capture.result;
     }
 
+    static void LatchDeviceFaultBeforeSourceRejection(
+        void* _context
+    ) noexcept {
+        auto& capture =
+            *static_cast<ScriptedPresentCapture*>(_context);
+        capture.source_rejection_hook_count.fetch_add(
+            1, std::memory_order_acq_rel
+        );
+        if (!TryLatchVulkanDeviceFaultForTesting(
+                VK_ERROR_DEVICE_LOST
+            )) {
+            capture.source_rejection_hook_failed.store(
+                true, std::memory_order_release
+            );
+        }
+    }
+
     VulkanScriptedPresentResult result{};
     std::atomic<uint32>         count{0};
     std::atomic<uint64>         timeline{0};
     std::atomic<uint32>         thread_id{0};
     std::atomic<bool>           wrong_owner{false};
+    std::atomic<uint32>         source_rejection_hook_count{0};
+    std::atomic<bool>           source_rejection_hook_failed{false};
 };
 
 class ScopedScriptedPresentOverride final {
 public:
     explicit ScopedScriptedPresentOverride(
         ScriptedPresentCapture& _capture,
-        bool _require_present_source_ready = false
+        bool _require_present_source_ready = false,
+        bool _latch_fault_before_source_rejection = false
     ) :
         scripted_override{
             .context  = &_capture,
             .callback = &ScriptedPresentCapture::Observe,
             .require_present_source_ready =
                 _require_present_source_ready,
+            .before_source_rejection =
+                _latch_fault_before_source_rejection ?
+                    &ScriptedPresentCapture::
+                        LatchDeviceFaultBeforeSourceRejection :
+                    nullptr,
         } {
         if (!TryInstallVulkanScriptedPresentOverrideForTesting(
                 &scripted_override
@@ -8291,6 +8329,26 @@ void RunPresentSourceContractRejection() {
             present_source_usage |
                 ETextureUsageFlags::COLOR_ATTACHMENT
         );
+    TextureRef rejected_suffix_source = device.CreateTexture(
+        "present_source_contract_rejected_suffix",
+        Extent3D(4, 4, 1),
+        PF_R8G8B8A8_UNORM,
+        present_source_usage
+    );
+    TextureRef copy_commit_source = device.CreateTexture(
+        "present_source_contract_copy_commit",
+        Extent3D(4, 4, 1),
+        PF_R8G8B8A8_UNORM,
+        present_source_usage
+    );
+    TextureRef mutation_copy_source = device.CreateTexture(
+        "present_source_contract_mutation_copy_source",
+        Extent3D(4, 4, 1),
+        PF_R8G8B8A8_UNORM,
+        ETextureUsageFlags::TRANSFER_SRC |
+            ETextureUsageFlags::TRANSFER_DST |
+            ETextureUsageFlags::COLOR_ATTACHMENT
+    );
     TextureRef missing_usage_source = device.CreateTexture(
         "present_source_contract_missing_usage",
         Extent3D(4, 4, 1),
@@ -8344,6 +8402,9 @@ void RunPresentSourceContractRejection() {
         !backend_tracked_source.IsValid() ||
         !rejected_backend_tracked_source.IsValid() ||
         !backend_nonterminal_source.IsValid() ||
+        !rejected_suffix_source.IsValid() ||
+        !copy_commit_source.IsValid() ||
+        !mutation_copy_source.IsValid() ||
         !missing_usage_source.IsValid() ||
         !missing_transfer_source.IsValid() ||
         !multisampled_source.IsValid() ||
@@ -8556,6 +8617,154 @@ void RunPresentSourceContractRejection() {
         );
     }
 
+    // An independently accepted mutation must close the publication from the
+    // previous packet even when no trailing BarrierCmd describes that touch.
+    FenceRef accepted_mutation_done = device.CreateFence();
+    CommandList accepted_mutation(EQueueType::Graphics);
+    accepted_mutation.ClearResource(
+        backend_tracked_source->GetView(),
+        float4(0.25f, 0.f, 0.f, 1.f)
+    );
+    CmdSubmit accepted_mutation_submit =
+        accepted_mutation.Submit();
+    accepted_mutation_submit.Signal(
+        accepted_mutation_done.Get(), 1
+    );
+    RHIExecutor::Get().Submit(
+        EQueueType::Graphics,
+        std::move(accepted_mutation_submit),
+        ERHIExecSubmitFlags::FlushGPU
+    );
+    RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
+    if (!ResourceCast(accepted_mutation_done.Get())
+             ->WaitSubmitted(1) ||
+        ResourceCast(backend_tracked_source.Get())
+            ->IsPresentationSourceReady()) {
+        throw std::runtime_error(
+            "an accepted standalone Clear left stale Present readiness"
+        );
+    }
+    expect_rejected(
+        backend_tracked_source->GetView(),
+        "source cleared by a later accepted packet",
+        scripted_swapchain
+    );
+
+    // Re-publish, then reject a later mutation before native acceptance. The
+    // rejected packet must not speculatively clear the accepted readiness.
+    FenceRef republished_done = device.CreateFence();
+    RHIExecutor::Get().Submit(
+        EQueueType::Graphics,
+        make_backend_tracked_publication(
+            backend_tracked_source,
+            republished_done,
+            1
+        ),
+        ERHIExecSubmitFlags::FlushGPU
+    );
+    RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
+    if (!ResourceCast(republished_done.Get())->WaitSubmitted(1) ||
+        !ResourceCast(backend_tracked_source.Get())
+             ->IsPresentationSourceReady()) {
+        throw std::runtime_error(
+            "accepted re-publication did not restore Present readiness"
+        );
+    }
+
+    FenceRef rejected_mutation_dependency = device.CreateFence();
+    FenceRef rejected_mutation_done       = device.CreateFence();
+    rejected_mutation_dependency->Reject(1);
+    CommandList rejected_mutation(EQueueType::Graphics);
+    rejected_mutation.ClearResource(
+        backend_tracked_source->GetView(),
+        float4(0.f, 0.25f, 0.f, 1.f)
+    );
+    CmdSubmit rejected_mutation_submit =
+        rejected_mutation.Submit();
+    rejected_mutation_submit.Wait(
+        rejected_mutation_dependency.Get(), 1
+    );
+    rejected_mutation_submit.Signal(
+        rejected_mutation_done.Get(), 1
+    );
+    RHIExecutor::Get().Submit(
+        EQueueType::Graphics,
+        std::move(rejected_mutation_submit),
+        ERHIExecSubmitFlags::FlushGPU
+    );
+    RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
+    if (!ResourceCast(rejected_mutation_done.Get())
+             ->IsRejected(1) ||
+        ResourceCast(rejected_mutation_done.Get())->IsFailed() ||
+        !ResourceCast(backend_tracked_source.Get())
+             ->IsPresentationSourceReady()) {
+        throw std::runtime_error(
+            "a rejected standalone Clear polluted accepted Present readiness"
+        );
+    }
+
+    const uint32 scripted_before_rejected_mutation_present =
+        scripted_capture.count.load(std::memory_order_acquire);
+    PresentReceiptRef rejected_mutation_receipt =
+        MakeShared<PresentReceipt>();
+    RHIExecutor::Get().Present(
+        RHIPresentRequest(
+            scripted_swapchain,
+            backend_tracked_source->GetView(),
+            rejected_mutation_receipt
+        ),
+        true
+    );
+    const PresentReceiptResult rejected_mutation_result =
+        rejected_mutation_receipt->WaitForSubmission(5s);
+    RHIExecutor::Get().Sync(ERHISyncDepth::Present);
+    if (!rejected_mutation_result.resolved ||
+        rejected_mutation_result.submitted ||
+        !rejected_mutation_result.recreate_swapchain ||
+        rejected_mutation_receipt->ResolutionAttemptCount() != 1 ||
+        scripted_capture.count.load(std::memory_order_acquire) !=
+            scripted_before_rejected_mutation_present + 1) {
+        throw std::runtime_error(
+            "a rejected standalone Clear hid the last accepted publication"
+        );
+    }
+
+    // Keep the fixture on Graphics: the source was published there, and this
+    // test targets state-ledger invalidation rather than queue-family transfer
+    // ownership (covered separately by the explicit multi-queue tests).
+    constexpr EQueueType mutation_queue = EQueueType::Graphics;
+    FenceRef accepted_copy_mutation_done = device.CreateFence();
+    CommandList accepted_copy_mutation(mutation_queue);
+    accepted_copy_mutation.CopyFrom(
+        mutation_copy_source->GetView(),
+        backend_tracked_source->GetView(),
+        "PresentSourceAcceptedCopyMutation"
+    );
+    CmdSubmit accepted_copy_mutation_submit =
+        accepted_copy_mutation.Submit();
+    accepted_copy_mutation_submit.Signal(
+        accepted_copy_mutation_done.Get(), 1
+    );
+    RHIExecutor::Get().Submit(
+        mutation_queue,
+        std::move(accepted_copy_mutation_submit),
+        ERHIExecSubmitFlags::FlushGPU
+    );
+    RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
+    if (!ResourceCast(accepted_copy_mutation_done.Get())
+             ->WaitSubmitted(1) ||
+        ResourceCast(backend_tracked_source.Get())
+            ->IsPresentationSourceReady()) {
+        throw std::runtime_error(
+            "an accepted TextureToTexture copy left stale Present readiness"
+        );
+    }
+    expect_rejected(
+        backend_tracked_source->GetView(),
+        "source overwritten by an accepted texture copy",
+        scripted_swapchain
+    );
+
     FenceRef rejected_backend_dependency = device.CreateFence();
     FenceRef rejected_backend_done = device.CreateFence();
     rejected_backend_dependency->Reject(1);
@@ -8576,6 +8785,8 @@ void RunPresentSourceContractRejection() {
         rejected_backend_tracked_source->GetView(),
         rejected_backend_receipt
     );
+    const uint32 scripted_before_rejected_backend =
+        scripted_capture.count.load(std::memory_order_acquire);
     RHIExecutor::Get().Submit(
         EQueueType::Graphics,
         std::move(rejected_backend_submit),
@@ -8596,7 +8807,7 @@ void RunPresentSourceContractRejection() {
         rejected_backend_receipt->ResolutionAttemptCount() != 1 ||
         scripted_capture.count.load(
             std::memory_order_acquire
-        ) != 1) {
+        ) != scripted_before_rejected_backend) {
         throw std::runtime_error(
             "rejected BackendTracked producer published readiness or "
             "reached its same-batch Present"
@@ -8624,17 +8835,9 @@ void RunPresentSourceContractRejection() {
         },
         {}
     );
-    backend_nonterminal_producer.TextureBarriers(
-        EQueueType::Graphics,
-        EQueueType::Graphics,
-        EPassType::Graphics,
-        {},
-        Array<WriteTexture>{
-            WriteTexture{
-                backend_nonterminal_source->GetView(),
-                ETextureState::RENDER_TARGET,
-            },
-        }
+    backend_nonterminal_producer.ClearResource(
+        backend_nonterminal_source->GetView(),
+        float4(0.f, 0.f, 0.25f, 1.f)
     );
     CmdSubmit backend_nonterminal_submit =
         backend_nonterminal_producer.Submit();
@@ -8648,6 +8851,8 @@ void RunPresentSourceContractRejection() {
         backend_nonterminal_source->GetView(),
         backend_nonterminal_receipt
     );
+    const uint32 scripted_before_backend_nonterminal =
+        scripted_capture.count.load(std::memory_order_acquire);
     RHIExecutor::Get().Submit(
         EQueueType::Graphics,
         std::move(backend_nonterminal_submit),
@@ -8667,7 +8872,7 @@ void RunPresentSourceContractRejection() {
         backend_nonterminal_receipt->ResolutionAttemptCount() != 1 ||
         scripted_capture.count.load(
             std::memory_order_acquire
-        ) != 1) {
+        ) != scripted_before_backend_nonterminal) {
         throw std::runtime_error(
             "a BackendTracked publication followed by a terminal write "
             "remained ready or reached Present"
@@ -8732,6 +8937,197 @@ void RunPresentSourceContractRejection() {
         ERHIAccessFlags::TRANSFER_WRITE,
         ETextureLayout::TEXTURE_LAYOUT_COMMON
     );
+    const RHIQueueTopology topology = device.GetQueueTopology();
+
+    // The materializer commits each accepted segment independently. Verify
+    // that a publication accepted by the first segment is closed by a later
+    // accepted mutation before the submit-level Present is resolved.
+    constexpr uint64 segmented_present_scope =
+        0x5048313850524553ull;
+    FenceRef segmented_present_done = device.CreateFence();
+    CommandList segmented_present_producer(
+        EQueueType::Graphics
+    );
+    segmented_present_producer.SetResourceStateOwnership(
+        ERHIResourceStateOwnership::Explicit
+    );
+    BarrierCreateInfo segmented_publication =
+        BarrierCreateInfo::Transition(
+            backend_nonterminal_source->GetView(),
+            undefined_state,
+            presentation_state,
+            ETextureAspectFlags::COLOR
+        );
+    segmented_publication.publish_external_state = true;
+    segmented_present_producer.Barriers(
+        {segmented_publication}
+    );
+    segmented_present_producer.Barriers(
+        {BarrierCreateInfo::Transition(
+            backend_nonterminal_source->GetView(),
+            presentation_state,
+            transfer_write_state,
+            ETextureAspectFlags::COLOR
+        )}
+    );
+    CmdSubmit segmented_present_submit =
+        segmented_present_producer.Submit();
+    segmented_present_submit.SetResourceStateOwnership(
+        ERHIResourceStateOwnership::Explicit
+    );
+    segmented_present_submit.async_queue_scope =
+        segmented_present_scope;
+    segmented_present_submit.segments = {
+        RHISubmitSegment{EQueueType::Graphics, 0, 1},
+        RHISubmitSegment{EQueueType::Graphics, 1, 2},
+    };
+    segmented_present_submit.Signal(
+        segmented_present_done.Get(), 1
+    );
+    PresentReceiptRef segmented_present_receipt =
+        MakeShared<PresentReceipt>();
+    RHIPresentRequest segmented_present(
+        scripted_swapchain,
+        backend_nonterminal_source->GetView(),
+        segmented_present_receipt
+    );
+    const uint32 scripted_before_segmented_present =
+        scripted_capture.count.load(std::memory_order_acquire);
+    RHIExecutor::Get().Submit(
+        EQueueType::Graphics,
+        std::move(segmented_present_submit),
+        ERHIExecSubmitFlags::FlushGPU,
+        &segmented_present
+    );
+    const PresentReceiptResult segmented_present_result =
+        segmented_present_receipt->WaitForSubmission(5s);
+    RHIExecutor::Get().Sync(ERHISyncDepth::Present);
+    if (!ResourceCast(segmented_present_done.Get())
+             ->WaitSubmitted(1) ||
+        ResourceCast(backend_nonterminal_source.Get())
+            ->IsPresentationSourceReady() ||
+        !segmented_present_result.resolved ||
+        segmented_present_result.submitted ||
+        segmented_present_result.recreate_swapchain ||
+        segmented_present_receipt->ResolutionAttemptCount() != 1 ||
+        scripted_capture.count.load(
+            std::memory_order_acquire
+        ) != scripted_before_segmented_present) {
+        throw std::runtime_error(
+            "an accepted later segment did not close an earlier "
+            "presentation-source publication"
+        );
+    }
+
+    // A later materialized segment can reject before native recording without
+    // rolling back an earlier segment that Vulkan already accepted. The
+    // accepted publication remains the externally visible final state.
+    constexpr uint64 rejected_suffix_scope =
+        0x5048313852535546ull;
+    FenceRef rejected_suffix_done = device.CreateFence();
+    CommandList rejected_suffix_producer(
+        EQueueType::Graphics
+    );
+    rejected_suffix_producer.SetResourceStateOwnership(
+        ERHIResourceStateOwnership::Explicit
+    );
+    BarrierCreateInfo rejected_suffix_publication =
+        BarrierCreateInfo::Transition(
+            rejected_suffix_source->GetView(),
+            undefined_state,
+            presentation_state,
+            ETextureAspectFlags::COLOR
+        );
+    rejected_suffix_publication.publish_external_state = true;
+    rejected_suffix_producer.Barriers(
+        {rejected_suffix_publication}
+    );
+    rejected_suffix_producer.AddCustomCommand(
+        MakeUnique<OpaquePresentationStateProbeCommand>(),
+        "RejectedPresentationStateSuffix"
+    );
+    CmdSubmit rejected_suffix_submit =
+        rejected_suffix_producer.Submit();
+    rejected_suffix_submit.SetResourceStateOwnership(
+        ERHIResourceStateOwnership::Explicit
+    );
+    rejected_suffix_submit.async_queue_scope =
+        rejected_suffix_scope;
+    rejected_suffix_submit.segments = {
+        RHISubmitSegment{EQueueType::Graphics, 0, 1},
+        RHISubmitSegment{EQueueType::Graphics, 1, 2},
+    };
+    rejected_suffix_submit.Signal(
+        rejected_suffix_done.Get(), 1
+    );
+    RHIExecutor::Get().Submit(
+        EQueueType::Graphics,
+        std::move(rejected_suffix_submit),
+        ERHIExecSubmitFlags::FlushGPU
+    );
+    RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
+    if (!ResourceCast(rejected_suffix_done.Get())
+             ->IsRejected(1) ||
+        ResourceCast(rejected_suffix_done.Get())->IsFailed() ||
+        !ResourceCast(rejected_suffix_source.Get())
+             ->IsPresentationSourceReady()) {
+        throw std::runtime_error(
+            "a rejected materialized suffix rolled back or hid its "
+            "accepted presentation-source prefix"
+        );
+    }
+
+    const uint32 scripted_before_rejected_suffix_present =
+        scripted_capture.count.load(std::memory_order_acquire);
+    PresentReceiptRef rejected_suffix_receipt =
+        MakeShared<PresentReceipt>();
+    RHIExecutor::Get().Present(
+        RHIPresentRequest(
+            scripted_swapchain,
+            rejected_suffix_source->GetView(),
+            rejected_suffix_receipt
+        ),
+        true
+    );
+    const PresentReceiptResult rejected_suffix_result =
+        rejected_suffix_receipt->WaitForSubmission(5s);
+    RHIExecutor::Get().Sync(ERHISyncDepth::Present);
+    if (!rejected_suffix_result.resolved ||
+        rejected_suffix_result.submitted ||
+        !rejected_suffix_result.recreate_swapchain ||
+        rejected_suffix_receipt->ResolutionAttemptCount() != 1 ||
+        scripted_capture.count.load(std::memory_order_acquire) !=
+            scripted_before_rejected_suffix_present + 1) {
+        throw std::runtime_error(
+            "an accepted presentation-source prefix was not visible after "
+            "its recoverably rejected suffix"
+        );
+    }
+
+    if (topology.copy.available) {
+        auto* vk_copy_commit_source =
+            ResourceCast(copy_commit_source.Get());
+        vk_copy_commit_source->PublishPresentationSourceReady(true);
+        submit_source_state(
+            copy_commit_source,
+            EQueueType::Copy,
+            undefined_state,
+            transfer_write_state,
+            false,
+            1
+        );
+        if (vk_copy_commit_source->IsPresentationSourceReady()) {
+            throw std::runtime_error(
+                "an accepted Copy queue packet did not commit its "
+                "presentation-source invalidation"
+            );
+        }
+        expect_rejected(
+            copy_commit_source->GetView(),
+            "source invalidated by an accepted Copy queue packet",
+            scripted_swapchain
+        );
+    }
 
     submit_source_state(
         valid_source,
@@ -8781,7 +9177,6 @@ void RunPresentSourceContractRejection() {
         );
     }
 
-    const RHIQueueTopology topology = device.GetQueueTopology();
     if (topology.compute.available) {
         submit_source_state(
             wrong_queue_source,
@@ -8863,7 +9258,7 @@ void RunPresentSourceContractRejection() {
         valid_receipt->ResolutionAttemptCount() != 1 ||
         scripted_capture.count.load(
             std::memory_order_acquire
-        ) != 2 ||
+        ) != 4 ||
         scripted_capture.timeline.load(
             std::memory_order_acquire
         ) == 0 ||
@@ -8881,9 +9276,12 @@ void RunPresentSourceContractRejection() {
         "format=true compressed=true mip=true layer=true offset=true extent=true "
         "fresh=true accepted_export=true stale_clear=true "
         "backend_tracked_same_batch=true backend_rejected=true "
-        "backend_nonterminal_clear=true "
+        "marker_then_clear=true accepted_mutation_clear=true "
+        "rejected_mutation_preserves=true accepted_copy_mutation=true "
+        "marker_then_segmented_state_change=true "
+        "accepted_prefix_rejected_suffix=true copy_commit=true "
         "wrong_queue_clear=true rejected_export_clear=true "
-        "valid_override=2 owner=Submission",
+        "valid_override=4 owner=Submission",
         rejected_count
     );
 }
@@ -9594,7 +9992,9 @@ void RunPresentHardFailureBoundary() {
         }
     );
     ScopedScriptedPresentOverride scripted_override(
-        scripted_capture
+        scripted_capture,
+        false,
+        true
     );
 
     PresentReceiptRef receipt = MakeShared<PresentReceipt>();
@@ -9603,14 +10003,6 @@ void RunPresentHardFailureBoundary() {
     std::atomic<uint32> success_callbacks{0};
 
     try {
-        if (!TryLatchVulkanDeviceFaultForTesting(
-                VK_ERROR_DEVICE_LOST
-            )) {
-            throw std::runtime_error(
-                "hard Present fixture could not pre-fault the Vulkan device"
-            );
-        }
-
         RHIExecutor::Get().Present(
             RHIPresentRequest(
                 scripted_swapchain,
@@ -9653,6 +10045,12 @@ void RunPresentHardFailureBoundary() {
                 std::memory_order_acquire
             ) != 0 ||
             scripted_capture.wrong_owner.load(
+                std::memory_order_acquire
+            ) ||
+            scripted_capture.source_rejection_hook_count.load(
+                std::memory_order_acquire
+            ) != 1 ||
+            scripted_capture.source_rejection_hook_failed.load(
                 std::memory_order_acquire
             ) ||
             boundary_capture.Count() != 2 ||
@@ -9714,7 +10112,7 @@ void RunPresentHardFailureBoundary() {
             "outcome=Rejected owner=Submission receipt_attempts=1 "
             "submitted=false recreate=false later_batch=rejected "
             "native_after_present=0 device_fault_priority=true "
-            "invalid_source=true hard_latch=verified replay=0"
+            "invalid_source=true concurrent_hard_latch=verified replay=0"
         );
     } catch (...) {
         RHIExecutor::Get().Sync(ERHISyncDepth::Present);

--- a/source/test/RHIParallelRecordVulkanTest.cpp
+++ b/source/test/RHIParallelRecordVulkanTest.cpp
@@ -8430,7 +8430,8 @@ void RunPresentSourceContractRejection() {
         true
     );
 
-    uint32 rejected_count = 0;
+    uint32 rejected_count       = 0;
+    bool   copy_commit_verified = false;
     const auto expect_rejected =
         [&](
             TextureView       _source,
@@ -9105,6 +9106,11 @@ void RunPresentSourceContractRejection() {
     }
 
     if (topology.copy.available) {
+        // White-box seed isolates the Copy SubmitRecorded commit point from
+        // queue-family transfer ownership. The accepted explicit barrier is
+        // real queue work; if Copy omits its accepted delta commit, the seed
+        // remains observable here. Cross-queue ownership is covered by the
+        // dedicated explicit multi-queue fixtures.
         auto* vk_copy_commit_source =
             ResourceCast(copy_commit_source.Get());
         vk_copy_commit_source->PublishPresentationSourceReady(true);
@@ -9127,6 +9133,7 @@ void RunPresentSourceContractRejection() {
             "source invalidated by an accepted Copy queue packet",
             scripted_swapchain
         );
+        copy_commit_verified = true;
     }
 
     submit_source_state(
@@ -9279,10 +9286,11 @@ void RunPresentSourceContractRejection() {
         "marker_then_clear=true accepted_mutation_clear=true "
         "rejected_mutation_preserves=true accepted_copy_mutation=true "
         "marker_then_segmented_state_change=true "
-        "accepted_prefix_rejected_suffix=true copy_commit=true "
+        "accepted_prefix_rejected_suffix=true copy_commit={} "
         "wrong_queue_clear=true rejected_export_clear=true "
         "valid_override=4 owner=Submission",
-        rejected_count
+        rejected_count,
+        copy_commit_verified ? "verified" : "skipped"
     );
 }
 

--- a/source/test/RHIParallelRecordVulkanTest.cpp
+++ b/source/test/RHIParallelRecordVulkanTest.cpp
@@ -88,6 +88,39 @@ public:
     }
 };
 
+class BindlessPresentationAccessProbeCommand final
+    : public VkCustomDispatchCmd {
+public:
+    explicit BindlessPresentationAccessProbeCommand(
+        BindlessArrayRef _bindless,
+        EQueueType       _queue = EQueueType::Graphics
+    ) :
+        queue(_queue) {
+        usages.emplace_back(
+            std::move(_bindless),
+            ParamInfoFlags{
+                .state_flags    = 0,
+                .pipeline_flags = 0,
+            }
+        );
+    }
+
+    void Execute(const VkDispatchContext&) const override {}
+
+    EQueueType GetQueueType() const override {
+        return queue;
+    }
+
+private:
+    std::span<const ResourceUsage>
+    GetResourceUsages() const override {
+        return usages;
+    }
+
+    Array<ResourceUsage> usages{};
+    EQueueType           queue{EQueueType::Graphics};
+};
+
 class PipelineTranslateProbeCommand final : public VkCustomDispatchCmd {
 public:
     PipelineTranslateProbeCommand(
@@ -8580,6 +8613,895 @@ void RunPresentSourceContractRejection() {
             return submit;
         };
 
+    const auto create_bindless_present_source =
+        [&](std::string_view _name) {
+            return device.CreateTexture(
+                _name,
+                Extent3D(4, 4, 1),
+                PF_R8G8B8A8_UNORM,
+                present_source_usage |
+                    ETextureUsageFlags::SAMPLED
+            );
+        };
+    TextureRef bindless_access_then_add =
+        create_bindless_present_source(
+            "present_bindless_access_then_add"
+        );
+    TextureRef bindless_add_then_access =
+        create_bindless_present_source(
+            "present_bindless_add_then_access"
+        );
+    TextureRef bindless_duplicate =
+        create_bindless_present_source(
+            "present_bindless_duplicate"
+        );
+    TextureRef bindless_rejected_add =
+        create_bindless_present_source(
+            "present_bindless_rejected_add"
+        );
+    TextureRef bindless_rejected_free =
+        create_bindless_present_source(
+            "present_bindless_rejected_free"
+        );
+    TextureRef bindless_future_allocation =
+        create_bindless_present_source(
+            "present_bindless_future_allocation"
+        );
+    TextureRef bindless_segment_access_add =
+        create_bindless_present_source(
+            "present_bindless_segment_access_add"
+        );
+    TextureRef bindless_segment_add_access =
+        create_bindless_present_source(
+            "present_bindless_segment_add_access"
+        );
+    TextureRef bindless_accepted_add_prefix =
+        create_bindless_present_source(
+            "present_bindless_accepted_add_prefix"
+        );
+    TextureRef bindless_accepted_free_prefix =
+        create_bindless_present_source(
+            "present_bindless_accepted_free_prefix"
+        );
+    TextureRef bindless_cross_queue =
+        create_bindless_present_source(
+            "present_bindless_cross_queue"
+        );
+    TextureRef bindless_parallel_record =
+        create_bindless_present_source(
+            "present_bindless_parallel_record"
+        );
+    BindlessArrayRef bindless =
+        device.CreateBindlessArray(32);
+    BindlessArrayRef future_bindless =
+        device.CreateBindlessArray(8);
+    if (!bindless_access_then_add ||
+        !bindless_add_then_access ||
+        !bindless_duplicate ||
+        !bindless_rejected_add ||
+        !bindless_rejected_free ||
+        !bindless_future_allocation ||
+        !bindless_segment_access_add ||
+        !bindless_segment_add_access ||
+        !bindless_accepted_add_prefix ||
+        !bindless_accepted_free_prefix ||
+        !bindless_cross_queue ||
+        !bindless_parallel_record ||
+        !bindless ||
+        !future_bindless) {
+        throw std::runtime_error(
+            "bindless Present contract resources were not created"
+        );
+    }
+
+    const Sampler bindless_sampler(
+        SF_LINEAR, SAM_CLAMP_TO_EDGE
+    );
+    const auto add_bindless_access =
+        [&](CommandList&          _commands,
+            const BindlessArrayRef& _bindless,
+            std::string_view      _name,
+            EQueueType _queue = EQueueType::Graphics) {
+            _commands.AddCustomCommand(
+                MakeUnique<
+                    BindlessPresentationAccessProbeCommand>(
+                    _bindless, _queue
+                ),
+                _name
+            );
+        };
+    const auto submit_accepted_commands =
+        [&](CommandList& _commands, std::string_view _name) {
+            FenceRef accepted = device.CreateFence();
+            if (!accepted) {
+                throw std::runtime_error(
+                    "failed to create bindless Present acceptance fence"
+                );
+            }
+            CmdSubmit submit = _commands.Submit();
+            submit.Signal(accepted.Get(), 1);
+            RHIExecutor::Get().Submit(
+                _commands.GetQueueType(),
+                std::move(submit),
+                ERHIExecSubmitFlags::FlushGPU
+            );
+            RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
+            auto* vk_accepted = ResourceCast(accepted.Get());
+            if (!vk_accepted->WaitSubmitted(1) ||
+                vk_accepted->IsRejected(1) ||
+                vk_accepted->IsFailed()) {
+                throw std::runtime_error(
+                    std::string(_name) +
+                    " did not reach native submission"
+                );
+            }
+        };
+    const auto submit_dependency_rejected_commands =
+        [&](CommandList& _commands, std::string_view _name) {
+            FenceRef dependency = device.CreateFence();
+            FenceRef rejected   = device.CreateFence();
+            if (!dependency || !rejected) {
+                throw std::runtime_error(
+                    "failed to create bindless Present rejection fences"
+                );
+            }
+            dependency->Reject(1);
+            CmdSubmit submit = _commands.Submit();
+            submit.Wait(dependency.Get(), 1);
+            submit.Signal(rejected.Get(), 1);
+            RHIExecutor::Get().Submit(
+                _commands.GetQueueType(),
+                std::move(submit),
+                ERHIExecSubmitFlags::FlushGPU
+            );
+            RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
+            auto* vk_rejected = ResourceCast(rejected.Get());
+            if (!vk_rejected->IsRejected(1) ||
+                vk_rejected->IsFailed()) {
+                throw std::runtime_error(
+                    std::string(_name) +
+                    " was not recoverably rejected"
+                );
+            }
+        };
+    const auto publish_bindless_source =
+        [&](const TextureRef& _texture,
+            std::string_view  _name) {
+            FenceRef accepted = device.CreateFence();
+            if (!accepted) {
+                throw std::runtime_error(
+                    "failed to create bindless publication fence"
+                );
+            }
+            RHIExecutor::Get().Submit(
+                EQueueType::Graphics,
+                make_backend_tracked_publication(
+                    _texture, accepted, 1
+                ),
+                ERHIExecSubmitFlags::FlushGPU
+            );
+            RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
+            if (!ResourceCast(accepted.Get())->WaitSubmitted(1) ||
+                !ResourceCast(_texture.Get())
+                     ->IsPresentationSourceReady()) {
+                throw std::runtime_error(
+                    std::string(_name) +
+                    " failed to publish Present readiness"
+                );
+            }
+        };
+    const auto require_bindless_ready =
+        [&](const TextureRef& _texture,
+            bool              _expected,
+            std::string_view  _case_name) {
+            const bool ready =
+                ResourceCast(_texture.Get())
+                    ->IsPresentationSourceReady();
+            if (ready != _expected) {
+                throw std::runtime_error(
+                    std::string(_case_name) +
+                    (_expected ?
+                         " unexpectedly lost Present readiness" :
+                         " left stale Present readiness")
+                );
+            }
+        };
+
+    // Access -> Add: the access sees the accepted entry membership, not the
+    // frontend allocation created later in this same command source.
+    publish_bindless_source(
+        bindless_access_then_add, "bindless Access->Add"
+    );
+    CommandList access_then_add(EQueueType::Graphics);
+    add_bindless_access(
+        access_then_add,
+        bindless,
+        "BindlessPresentAccessThenAdd"
+    );
+    const uint access_then_add_slot =
+        bindless->AllocateTexture(
+            bindless_access_then_add->GetView(),
+            bindless_sampler
+        );
+    access_then_add.UpdateBindlessArray(bindless);
+    submit_accepted_commands(
+        access_then_add, "bindless Access->Add"
+    );
+    require_bindless_ready(
+        bindless_access_then_add,
+        true,
+        "bindless Access->Add"
+    );
+
+    // Access -> Free still observes the old accepted slot before the update.
+    CommandList access_then_free(EQueueType::Graphics);
+    add_bindless_access(
+        access_then_free,
+        bindless,
+        "BindlessPresentAccessThenFree"
+    );
+    bindless->UnbindTexture(access_then_add_slot);
+    access_then_free.UpdateBindlessArray(bindless);
+    submit_accepted_commands(
+        access_then_free, "bindless Access->Free"
+    );
+    require_bindless_ready(
+        bindless_access_then_add,
+        false,
+        "bindless Access->Free"
+    );
+
+    // Add -> Access sees the new descriptor membership from the preceding
+    // update command in the same source.
+    publish_bindless_source(
+        bindless_add_then_access, "bindless Add->Access"
+    );
+    const uint add_then_access_slot =
+        bindless->AllocateTexture(
+            bindless_add_then_access->GetView(),
+            bindless_sampler
+        );
+    CommandList add_then_access(EQueueType::Graphics);
+    add_then_access.UpdateBindlessArray(bindless);
+    add_bindless_access(
+        add_then_access,
+        bindless,
+        "BindlessPresentAddThenAccess"
+    );
+    submit_accepted_commands(
+        add_then_access, "bindless Add->Access"
+    );
+    require_bindless_ready(
+        bindless_add_then_access,
+        false,
+        "bindless Add->Access"
+    );
+
+    // Free -> Access no longer sees the removed accepted slot.
+    publish_bindless_source(
+        bindless_add_then_access, "bindless Free->Access"
+    );
+    bindless->UnbindTexture(add_then_access_slot);
+    CommandList free_then_access(EQueueType::Graphics);
+    free_then_access.UpdateBindlessArray(bindless);
+    add_bindless_access(
+        free_then_access,
+        bindless,
+        "BindlessPresentFreeThenAccess"
+    );
+    submit_accepted_commands(
+        free_then_access, "bindless Free->Access"
+    );
+    require_bindless_ready(
+        bindless_add_then_access,
+        true,
+        "bindless Free->Access"
+    );
+
+    // Two descriptor slots can reference one texture. Removing one slot must
+    // retain membership; removing the final slot must close it.
+    const uint duplicate_slot_a =
+        bindless->AllocateTexture(
+            bindless_duplicate->GetView(), bindless_sampler
+        );
+    const uint duplicate_slot_b =
+        bindless->AllocateTexture(
+            bindless_duplicate->GetView(), bindless_sampler
+        );
+    CommandList add_duplicate(EQueueType::Graphics);
+    add_duplicate.UpdateBindlessArray(bindless);
+    submit_accepted_commands(
+        add_duplicate, "bindless duplicate add"
+    );
+    publish_bindless_source(
+        bindless_duplicate, "bindless duplicate first free"
+    );
+    bindless->UnbindTexture(duplicate_slot_a);
+    CommandList free_one_duplicate(EQueueType::Graphics);
+    free_one_duplicate.UpdateBindlessArray(bindless);
+    add_bindless_access(
+        free_one_duplicate,
+        bindless,
+        "BindlessPresentFreeOneDuplicate"
+    );
+    submit_accepted_commands(
+        free_one_duplicate, "bindless duplicate first free"
+    );
+    require_bindless_ready(
+        bindless_duplicate,
+        false,
+        "bindless duplicate first free"
+    );
+    publish_bindless_source(
+        bindless_duplicate, "bindless duplicate final free"
+    );
+    bindless->UnbindTexture(duplicate_slot_b);
+    CommandList free_last_duplicate(EQueueType::Graphics);
+    free_last_duplicate.UpdateBindlessArray(bindless);
+    add_bindless_access(
+        free_last_duplicate,
+        bindless,
+        "BindlessPresentFreeLastDuplicate"
+    );
+    submit_accepted_commands(
+        free_last_duplicate, "bindless duplicate final free"
+    );
+    require_bindless_ready(
+        bindless_duplicate,
+        true,
+        "bindless duplicate final free"
+    );
+
+    // A rejected add never enters accepted descriptor membership.
+    publish_bindless_source(
+        bindless_rejected_add, "bindless rejected add"
+    );
+    (void)bindless->AllocateTexture(
+        bindless_rejected_add->GetView(), bindless_sampler
+    );
+    CommandList rejected_add(EQueueType::Graphics);
+    rejected_add.UpdateBindlessArray(bindless);
+    submit_dependency_rejected_commands(
+        rejected_add, "bindless rejected add"
+    );
+    CommandList access_after_rejected_add(
+        EQueueType::Graphics
+    );
+    add_bindless_access(
+        access_after_rejected_add,
+        bindless,
+        "BindlessPresentAccessAfterRejectedAdd"
+    );
+    submit_accepted_commands(
+        access_after_rejected_add,
+        "bindless access after rejected add"
+    );
+    require_bindless_ready(
+        bindless_rejected_add,
+        true,
+        "bindless access after rejected add"
+    );
+
+    // Conversely, a rejected free preserves the last accepted membership.
+    const uint rejected_free_slot =
+        bindless->AllocateTexture(
+            bindless_rejected_free->GetView(),
+            bindless_sampler
+        );
+    CommandList accepted_before_rejected_free(
+        EQueueType::Graphics
+    );
+    accepted_before_rejected_free.UpdateBindlessArray(bindless);
+    submit_accepted_commands(
+        accepted_before_rejected_free,
+        "bindless accepted add before rejected free"
+    );
+    publish_bindless_source(
+        bindless_rejected_free, "bindless rejected free"
+    );
+    bindless->UnbindTexture(rejected_free_slot);
+    CommandList rejected_free(EQueueType::Graphics);
+    rejected_free.UpdateBindlessArray(bindless);
+    submit_dependency_rejected_commands(
+        rejected_free, "bindless rejected free"
+    );
+    CommandList access_after_rejected_free(
+        EQueueType::Graphics
+    );
+    add_bindless_access(
+        access_after_rejected_free,
+        bindless,
+        "BindlessPresentAccessAfterRejectedFree"
+    );
+    submit_accepted_commands(
+        access_after_rejected_free,
+        "bindless access after rejected free"
+    );
+    require_bindless_ready(
+        bindless_rejected_free,
+        false,
+        "bindless access after rejected free"
+    );
+
+    // Seal S0 before a later frontend allocation. Even if Allocate happens
+    // before S0 reaches Translate, S0 must read accepted (empty) membership.
+    publish_bindless_source(
+        bindless_future_allocation,
+        "bindless future allocation"
+    );
+    CommandList future_access_commands(EQueueType::Graphics);
+    add_bindless_access(
+        future_access_commands,
+        future_bindless,
+        "BindlessPresentFutureAllocationAccess"
+    );
+    CmdSubmit sealed_future_access =
+        future_access_commands.Submit();
+    (void)future_bindless->AllocateTexture(
+        bindless_future_allocation->GetView(),
+        bindless_sampler
+    );
+    CommandList rejected_future_update(
+        EQueueType::Graphics
+    );
+    rejected_future_update.UpdateBindlessArray(
+        future_bindless
+    );
+    FenceRef future_access_done = device.CreateFence();
+    sealed_future_access.Signal(
+        future_access_done.Get(), 1
+    );
+    RHIExecutor::Get().Submit(
+        EQueueType::Graphics,
+        std::move(sealed_future_access),
+        ERHIExecSubmitFlags::FlushGPU
+    );
+    RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
+    if (!ResourceCast(future_access_done.Get())
+             ->WaitSubmitted(1)) {
+        throw std::runtime_error(
+            "sealed bindless access was not submitted"
+        );
+    }
+    require_bindless_ready(
+        bindless_future_allocation,
+        true,
+        "sealed bindless access with a future allocation"
+    );
+    submit_dependency_rejected_commands(
+        rejected_future_update,
+        "future bindless update"
+    );
+    CommandList access_after_rejected_future(
+        EQueueType::Graphics
+    );
+    add_bindless_access(
+        access_after_rejected_future,
+        future_bindless,
+        "BindlessPresentAccessAfterRejectedFutureUpdate"
+    );
+    submit_accepted_commands(
+        access_after_rejected_future,
+        "access after rejected future bindless update"
+    );
+    require_bindless_ready(
+        bindless_future_allocation,
+        true,
+        "access after rejected future bindless update"
+    );
+
+    constexpr uint64 bindless_segment_scope =
+        0x5042494e444c4553ull;
+    publish_bindless_source(
+        bindless_segment_access_add,
+        "segmented bindless Access->Add"
+    );
+    CommandList segmented_access_add(EQueueType::Graphics);
+    segmented_access_add.SetResourceStateOwnership(
+        ERHIResourceStateOwnership::Explicit
+    );
+    add_bindless_access(
+        segmented_access_add,
+        bindless,
+        "SegmentedBindlessAccess"
+    );
+    (void)bindless->AllocateTexture(
+        bindless_segment_access_add->GetView(),
+        bindless_sampler
+    );
+    segmented_access_add.UpdateBindlessArray(bindless);
+    CmdSubmit segmented_access_add_submit =
+        segmented_access_add.Submit();
+    segmented_access_add_submit.async_queue_scope =
+        bindless_segment_scope;
+    segmented_access_add_submit.segments = {
+        RHISubmitSegment{EQueueType::Graphics, 0, 1},
+        RHISubmitSegment{EQueueType::Graphics, 1, 2},
+    };
+    FenceRef segmented_access_add_done =
+        device.CreateFence();
+    segmented_access_add_submit.Signal(
+        segmented_access_add_done.Get(), 1
+    );
+    RHIExecutor::Get().Submit(
+        EQueueType::Graphics,
+        std::move(segmented_access_add_submit),
+        ERHIExecSubmitFlags::FlushGPU
+    );
+    RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
+    if (!ResourceCast(segmented_access_add_done.Get())
+             ->WaitSubmitted(1)) {
+        throw std::runtime_error(
+            "segmented bindless Access->Add was not submitted"
+        );
+    }
+    require_bindless_ready(
+        bindless_segment_access_add,
+        true,
+        "segmented bindless Access->Add"
+    );
+
+    publish_bindless_source(
+        bindless_segment_add_access,
+        "segmented bindless Add->Access"
+    );
+    (void)bindless->AllocateTexture(
+        bindless_segment_add_access->GetView(),
+        bindless_sampler
+    );
+    CommandList segmented_add_access(EQueueType::Graphics);
+    segmented_add_access.SetResourceStateOwnership(
+        ERHIResourceStateOwnership::Explicit
+    );
+    segmented_add_access.UpdateBindlessArray(bindless);
+    add_bindless_access(
+        segmented_add_access,
+        bindless,
+        "SegmentedBindlessAccessAfterAdd"
+    );
+    CmdSubmit segmented_add_access_submit =
+        segmented_add_access.Submit();
+    segmented_add_access_submit.async_queue_scope =
+        bindless_segment_scope + 1;
+    segmented_add_access_submit.segments = {
+        RHISubmitSegment{EQueueType::Graphics, 0, 1},
+        RHISubmitSegment{EQueueType::Graphics, 1, 2},
+    };
+    FenceRef segmented_add_access_done =
+        device.CreateFence();
+    segmented_add_access_submit.Signal(
+        segmented_add_access_done.Get(), 1
+    );
+    RHIExecutor::Get().Submit(
+        EQueueType::Graphics,
+        std::move(segmented_add_access_submit),
+        ERHIExecSubmitFlags::FlushGPU
+    );
+    RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
+    if (!ResourceCast(segmented_add_access_done.Get())
+             ->WaitSubmitted(1)) {
+        throw std::runtime_error(
+            "segmented bindless Add->Access was not submitted"
+        );
+    }
+    require_bindless_ready(
+        bindless_segment_add_access,
+        false,
+        "segmented bindless Add->Access"
+    );
+
+    // A materialized accepted membership prefix survives an opaque rejected
+    // suffix and is visible to the next independently accepted source.
+    publish_bindless_source(
+        bindless_accepted_add_prefix,
+        "bindless accepted add prefix"
+    );
+    (void)bindless->AllocateTexture(
+        bindless_accepted_add_prefix->GetView(),
+        bindless_sampler
+    );
+    CommandList accepted_add_prefix(EQueueType::Graphics);
+    accepted_add_prefix.SetResourceStateOwnership(
+        ERHIResourceStateOwnership::Explicit
+    );
+    accepted_add_prefix.UpdateBindlessArray(bindless);
+    accepted_add_prefix.AddCustomCommand(
+        MakeUnique<OpaquePresentationStateProbeCommand>(),
+        "RejectedAfterAcceptedBindlessAdd"
+    );
+    CmdSubmit accepted_add_prefix_submit =
+        accepted_add_prefix.Submit();
+    accepted_add_prefix_submit.async_queue_scope =
+        bindless_segment_scope + 2;
+    accepted_add_prefix_submit.segments = {
+        RHISubmitSegment{EQueueType::Graphics, 0, 1},
+        RHISubmitSegment{EQueueType::Graphics, 1, 2},
+    };
+    FenceRef accepted_add_prefix_done =
+        device.CreateFence();
+    accepted_add_prefix_submit.Signal(
+        accepted_add_prefix_done.Get(), 1
+    );
+    RHIExecutor::Get().Submit(
+        EQueueType::Graphics,
+        std::move(accepted_add_prefix_submit),
+        ERHIExecSubmitFlags::FlushGPU
+    );
+    RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
+    if (!ResourceCast(accepted_add_prefix_done.Get())
+             ->IsRejected(1) ||
+        ResourceCast(accepted_add_prefix_done.Get())
+            ->IsFailed()) {
+        throw std::runtime_error(
+            "bindless accepted add prefix suffix was not "
+            "recoverably rejected"
+        );
+    }
+    CommandList access_after_add_prefix(
+        EQueueType::Graphics
+    );
+    add_bindless_access(
+        access_after_add_prefix,
+        bindless,
+        "BindlessPresentAccessAfterAcceptedAddPrefix"
+    );
+    submit_accepted_commands(
+        access_after_add_prefix,
+        "access after accepted bindless add prefix"
+    );
+    require_bindless_ready(
+        bindless_accepted_add_prefix,
+        false,
+        "access after accepted bindless add prefix"
+    );
+
+    const uint accepted_free_prefix_slot =
+        bindless->AllocateTexture(
+            bindless_accepted_free_prefix->GetView(),
+            bindless_sampler
+        );
+    CommandList add_before_free_prefix(
+        EQueueType::Graphics
+    );
+    add_before_free_prefix.UpdateBindlessArray(bindless);
+    submit_accepted_commands(
+        add_before_free_prefix,
+        "add before accepted bindless free prefix"
+    );
+    publish_bindless_source(
+        bindless_accepted_free_prefix,
+        "bindless accepted free prefix"
+    );
+    bindless->UnbindTexture(accepted_free_prefix_slot);
+    CommandList accepted_free_prefix(
+        EQueueType::Graphics
+    );
+    accepted_free_prefix.SetResourceStateOwnership(
+        ERHIResourceStateOwnership::Explicit
+    );
+    accepted_free_prefix.UpdateBindlessArray(bindless);
+    accepted_free_prefix.AddCustomCommand(
+        MakeUnique<OpaquePresentationStateProbeCommand>(),
+        "RejectedAfterAcceptedBindlessFree"
+    );
+    CmdSubmit accepted_free_prefix_submit =
+        accepted_free_prefix.Submit();
+    accepted_free_prefix_submit.async_queue_scope =
+        bindless_segment_scope + 3;
+    accepted_free_prefix_submit.segments = {
+        RHISubmitSegment{EQueueType::Graphics, 0, 1},
+        RHISubmitSegment{EQueueType::Graphics, 1, 2},
+    };
+    FenceRef accepted_free_prefix_done =
+        device.CreateFence();
+    accepted_free_prefix_submit.Signal(
+        accepted_free_prefix_done.Get(), 1
+    );
+    RHIExecutor::Get().Submit(
+        EQueueType::Graphics,
+        std::move(accepted_free_prefix_submit),
+        ERHIExecSubmitFlags::FlushGPU
+    );
+    RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
+    if (!ResourceCast(accepted_free_prefix_done.Get())
+             ->IsRejected(1) ||
+        ResourceCast(accepted_free_prefix_done.Get())
+            ->IsFailed()) {
+        throw std::runtime_error(
+            "bindless accepted free prefix suffix was not "
+            "recoverably rejected"
+        );
+    }
+    CommandList access_after_free_prefix(
+        EQueueType::Graphics
+    );
+    add_bindless_access(
+        access_after_free_prefix,
+        bindless,
+        "BindlessPresentAccessAfterAcceptedFreePrefix"
+    );
+    submit_accepted_commands(
+        access_after_free_prefix,
+        "access after accepted bindless free prefix"
+    );
+    require_bindless_ready(
+        bindless_accepted_free_prefix,
+        true,
+        "access after accepted bindless free prefix"
+    );
+
+    if (device.GetQueueTopology().compute.available) {
+        (void)bindless->AllocateTexture(
+            bindless_cross_queue->GetView(),
+            bindless_sampler
+        );
+        CommandList cross_queue_add(EQueueType::Graphics);
+        cross_queue_add.UpdateBindlessArray(bindless);
+        submit_accepted_commands(
+            cross_queue_add,
+            "Graphics bindless add before Compute access"
+        );
+        publish_bindless_source(
+            bindless_cross_queue,
+            "Graphics bindless add before Compute access"
+        );
+        CommandList compute_access(EQueueType::Compute);
+        add_bindless_access(
+            compute_access,
+            bindless,
+            "BindlessPresentComputeAccess",
+            EQueueType::Compute
+        );
+        submit_accepted_commands(
+            compute_access,
+            "Compute bindless access after Graphics add"
+        );
+        require_bindless_ready(
+            bindless_cross_queue,
+            false,
+            "Compute bindless access after Graphics add"
+        );
+    }
+
+    // Carry the source-order program through an actually parallel inner
+    // recorder, not just the serial fallback. Four independent copies form a
+    // worker-eligible layer while the bindless update/access remain ordered
+    // serial islands in the same immutable source.
+    constexpr uint64 bindless_parallel_scope =
+        bindless_segment_scope + 4;
+    constexpr size_t bindless_parallel_copy_count = 4;
+    const EBufferUsageFlags bindless_parallel_buffer_usage =
+        EBufferUsageFlags::TRANSFER_SRC |
+        EBufferUsageFlags::TRANSFER_DST;
+    std::array<BufferRef, bindless_parallel_copy_count>
+        bindless_parallel_sources{};
+    std::array<BufferRef, bindless_parallel_copy_count>
+        bindless_parallel_destinations{};
+    for (size_t index = 0;
+         index < bindless_parallel_copy_count;
+         ++index) {
+        bindless_parallel_sources[index] =
+            device.CreateBuffer<uint32>(
+                "bindless_parallel_source_" +
+                    std::to_string(index),
+                kElementCount,
+                bindless_parallel_buffer_usage
+            );
+        bindless_parallel_destinations[index] =
+            device.CreateBuffer<uint32>(
+                "bindless_parallel_destination_" +
+                    std::to_string(index),
+                kElementCount,
+                bindless_parallel_buffer_usage
+            );
+        if (!bindless_parallel_sources[index] ||
+            !bindless_parallel_destinations[index]) {
+            throw std::runtime_error(
+                "failed to create bindless parallel-record buffers"
+            );
+        }
+    }
+
+    publish_bindless_source(
+        bindless_parallel_record,
+        "parallel-record bindless Add->Access"
+    );
+    (void)bindless->AllocateTexture(
+        bindless_parallel_record->GetView(),
+        bindless_sampler
+    );
+    CommandList parallel_bindless_access(EQueueType::Graphics);
+    parallel_bindless_access.UpdateBindlessArray(bindless);
+    add_bindless_access(
+        parallel_bindless_access,
+        bindless,
+        "BindlessPresentParallelRecordAccess"
+    );
+    for (size_t index = 0;
+         index < bindless_parallel_copy_count;
+         ++index) {
+        parallel_bindless_access.CopyFrom(
+            bindless_parallel_sources[index]->GetView(),
+            bindless_parallel_destinations[index]->GetView(),
+            "BindlessParallelRecordCopy"
+        );
+    }
+    FenceRef parallel_bindless_done = device.CreateFence();
+    CmdSubmit parallel_bindless_submit =
+        parallel_bindless_access.Submit();
+    parallel_bindless_submit.SetTranslateExecutionClass(
+        ERHITranslateExecutionClass::Parallel
+    );
+    parallel_bindless_submit.SetResourceStateOwnership(
+        ERHIResourceStateOwnership::Explicit
+    );
+    parallel_bindless_submit.async_queue_scope =
+        bindless_parallel_scope;
+    parallel_bindless_submit.Signal(
+        parallel_bindless_done.Get(), 1
+    );
+    SourceTranslationCapture parallel_bindless_capture(
+        bindless_parallel_scope,
+        EQueueType::Graphics
+    );
+    {
+        ScopedSourceTranslationObserver translation_observer(
+            parallel_bindless_capture
+        );
+        RHIExecutor::Get().Submit(
+            EQueueType::Graphics,
+            std::move(parallel_bindless_submit),
+            ERHIExecSubmitFlags::FlushGPU
+        );
+        RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
+    }
+    auto* vk_parallel_bindless_done =
+        ResourceCast(parallel_bindless_done.Get());
+    if (!vk_parallel_bindless_done->WaitSubmitted(1) ||
+        vk_parallel_bindless_done->IsRejected(1) ||
+        vk_parallel_bindless_done->IsFailed()) {
+        throw std::runtime_error(
+            "parallel bindless source did not reach native submission"
+        );
+    }
+    if (!parallel_bindless_capture.IsValid() ||
+        !parallel_bindless_capture.Seen(
+            0,
+            EVulkanSourceTranslationPhase::Recorded
+        )) {
+        throw std::runtime_error(
+            "parallel bindless source translation was not observed"
+        );
+    }
+    const VulkanSourceTranslationEvent&
+        parallel_bindless_translation =
+            parallel_bindless_capture.Event(
+                0,
+                EVulkanSourceTranslationPhase::Recorded
+            );
+    if (parallel_bindless_translation.async_queue_scope !=
+        bindless_parallel_scope) {
+        throw std::runtime_error(
+            "parallel bindless translation lost its async queue scope"
+        );
+    }
+    if (!parallel_bindless_translation
+             .parallel_record_requested ||
+        !parallel_bindless_translation
+             .parallel_record_planned ||
+        !parallel_bindless_translation
+             .parallel_record_effective) {
+        throw std::runtime_error(
+            "bindless source-order program did not traverse the "
+            "effective parallel recorder"
+        );
+    }
+    require_bindless_ready(
+        bindless_parallel_record,
+        false,
+        "parallel-record bindless Add->Access"
+    );
+
     FenceRef backend_tracked_done = device.CreateFence();
     PresentReceiptRef backend_tracked_receipt =
         MakeShared<PresentReceipt>();
@@ -9288,9 +10210,13 @@ void RunPresentSourceContractRejection() {
         "marker_then_segmented_state_change=true "
         "accepted_prefix_rejected_suffix=true copy_commit={} "
         "wrong_queue_clear=true rejected_export_clear=true "
+        "bindless_source_order=true bindless_refcount=true "
+        "bindless_rejected_update=true bindless_segments=true "
+        "bindless_cross_queue={} bindless_parallel_record=true "
         "valid_override=4 owner=Submission",
         rejected_count,
-        copy_commit_verified ? "verified" : "skipped"
+        copy_commit_verified ? "verified" : "skipped",
+        topology.compute.available ? "verified" : "skipped"
     );
 }
 

--- a/source/test/RenderGraphLoweringTest.cpp
+++ b/source/test/RenderGraphLoweringTest.cpp
@@ -429,6 +429,68 @@ void TestPresentationSourceLowersToCommonTransferRead(TestSuite& suite) {
         test_name,
         "presentation export must lower to COMMON / TRANSFER / TRANSFER_READ"
     );
+
+    TextureRef rejected_texture =
+        MoerNew(FakeTexture)(1, 1, ETextureAspectFlags::COLOR);
+    RenderGraph rejected_graph("PresentationSourceImportLoweringRejected");
+    const auto rejected_color = rejected_graph.ImportTexture(
+        "Color",
+        rejected_texture,
+        RenderGraph::TextureDesc{
+            .mip_count   = 1,
+            .layer_count = 1,
+            .aspects     = RenderGraph::TextureAspect::Color,
+        }
+    );
+    rejected_graph.SetInitialState(
+        rejected_color,
+        RenderGraph::TextureState::PresentationSource,
+        RenderGraph::QueueRole::Graphics,
+        RenderGraph::AccessMode::Read
+    );
+    rejected_graph.AddPass(
+        "ReadImportedColor",
+        [=](RenderGraph::PassBuilder& builder) {
+            builder
+                .Read(
+                    rejected_color,
+                    RenderGraph::TextureState::ShaderResource
+                )
+                .SideEffect();
+        },
+        [] {}
+    );
+    rejected_graph.Export(
+        rejected_color,
+        RenderGraph::TextureState::ShaderResource,
+        RenderGraph::QueueRole::Graphics,
+        RenderGraph::AccessMode::Read
+    );
+
+    suite.Check(
+        !rejected_graph.Compile() &&
+            Contains(
+                rejected_graph.GetCompileError(),
+                "export-boundary-only"
+            ),
+        test_name,
+        "PresentationSource must be rejected as an import boundary before lowering"
+    );
+    RenderGraphLowering::LoweredPlan rejected_lowered{};
+    std::string rejected_error{};
+    suite.Check(
+        !RenderGraphLowering::Lower(
+            rejected_graph,
+            rejected_lowered,
+            rejected_error
+        ) &&
+            rejected_lowered.prologue.empty() &&
+            rejected_lowered.passes.empty() &&
+            rejected_lowered.queue_syncs.empty() &&
+            Contains(rejected_error, "compiled before lowering"),
+        test_name,
+        "a graph with a PresentationSource import boundary reached lowering"
+    );
 }
 
 void TestSameStateReadGetsStateSeed(TestSuite& suite) {

--- a/source/test/RenderGraphLoweringTest.cpp
+++ b/source/test/RenderGraphLoweringTest.cpp
@@ -358,6 +358,79 @@ void TestDepthAttachmentReadUsesBackendAttachmentLayout(TestSuite& suite) {
     );
 }
 
+void TestPresentationSourceLowersToCommonTransferRead(TestSuite& suite) {
+    constexpr std::string_view test_name =
+        "presentation source lowers to common transfer read";
+    TextureRef texture =
+        MoerNew(FakeTexture)(1, 1, ETextureAspectFlags::COLOR);
+
+    RenderGraph graph("PresentationSourceLowering");
+    const auto  color = graph.ImportTexture(
+        "Color",
+        texture,
+        RenderGraph::TextureDesc{
+            .mip_count   = 1,
+            .layer_count = 1,
+            .aspects     = RenderGraph::TextureAspect::Color,
+        }
+    );
+    graph.SetInitialState(
+        color,
+        RenderGraph::TextureState::Undefined,
+        RenderGraph::QueueRole::None,
+        RenderGraph::AccessMode::None
+    );
+    const auto writer = graph.AddPass(
+        "Writer",
+        [=](RenderGraph::PassBuilder& builder) {
+            builder.Write(color, RenderGraph::TextureState::RenderTarget)
+                .SideEffect();
+        },
+        [] {}
+    );
+    graph.Export(
+        color,
+        RenderGraph::TextureState::PresentationSource,
+        RenderGraph::QueueRole::Graphics,
+        RenderGraph::AccessMode::Read
+    );
+
+    suite.Check(graph.Compile(), test_name, graph.GetCompileError());
+    RenderGraphLowering::LoweredPlan lowered{};
+    std::string error{};
+    suite.Check(
+        RenderGraphLowering::Lower(graph, lowered, error),
+        test_name,
+        error
+    );
+
+    const auto after_writer = lowered.After(writer);
+    const auto transition = std::find_if(
+        after_writer.begin(),
+        after_writer.end(),
+        [](const RenderGraphLowering::LoweredInstruction& instruction) {
+            return instruction.instruction_kind ==
+                       RenderGraphLowering::InstructionKind::Barrier &&
+                   instruction.export_boundary &&
+                   instruction.after_state ==
+                       RenderGraph::ResourceState::Texture(
+                           RenderGraph::TextureState::PresentationSource
+                       );
+        }
+    );
+    suite.Check(
+        transition != after_writer.end() &&
+            transition->destination.layout ==
+                ETextureLayout::TEXTURE_LAYOUT_COMMON &&
+            transition->destination.stages ==
+                ERHIPipelineStageFlags::PS_TRANSFER &&
+            transition->destination.access ==
+                ERHIAccessFlags::TRANSFER_READ,
+        test_name,
+        "presentation export must lower to COMMON / TRANSFER / TRANSFER_READ"
+    );
+}
+
 void TestSameStateReadGetsStateSeed(TestSuite& suite) {
     constexpr std::string_view test_name = "same-state read receives explicit state seed";
     BufferRef buffer = MoerNew(FakeBuffer)(256);
@@ -1451,6 +1524,7 @@ int main() {
     TestTextureFanInAndDeterminism(suite);
     TestShaderResourceAndSampledLayoutsRemainDistinct(suite);
     TestDepthAttachmentReadUsesBackendAttachmentLayout(suite);
+    TestPresentationSourceLowersToCommonTransferRead(suite);
     TestSameStateReadGetsStateSeed(suite);
     TestCrossNativeTokenSynchronization(suite);
     TestSameNativeTokenSynchronizationNeedsNoGpuSync(suite);

--- a/source/test/RenderGraphTest.cpp
+++ b/source/test/RenderGraphTest.cpp
@@ -1,13 +1,16 @@
 #include "rendergraph/RenderGraph.h"
 #include "renderer/common/UiFrameGraphPass.h"
+#include "rhi/RHIImpl.h"
 #include "rhi/plugin/NrdPlugin.h"
 #include "taskgraph/TaskGraph.h"
 #include "taskgraph/TaskSystem.h"
 
 #include <algorithm>
+#include <array>
 #include <atomic>
 #include <chrono>
 #include <condition_variable>
+#include <cstdint>
 #include <cstdlib>
 #include <iostream>
 #include <mutex>
@@ -1321,6 +1324,74 @@ void TestPresentationSourceBoundaryContract(TestSuite& suite) {
         test_name,
         "a color texture must be exportable as a read-only presentation source: " +
             valid_graph.GetCompileError()
+    );
+
+    for (const auto [graph_name, queue] :
+         {std::pair{"ComputePresentationSourceRejected",
+                    RenderGraph::QueueRole::Compute},
+          std::pair{"CopyPresentationSourceRejected",
+                    RenderGraph::QueueRole::Copy},
+          std::pair{"UnownedPresentationSourceRejected",
+                    RenderGraph::QueueRole::None}}) {
+        RenderGraph queue_graph(graph_name);
+        int         queue_physical = 0;
+        const auto  queue_texture =
+            import_color(queue_graph, queue_physical);
+        queue_graph.Export(
+            queue_texture,
+            RenderGraph::TextureState::PresentationSource,
+            queue,
+            RenderGraph::AccessMode::Read
+        );
+        suite.Check(
+            !queue_graph.Compile() &&
+                Contains(queue_graph.GetCompileError(), "Graphics queue"),
+            test_name,
+            "a presentation source export accepted a non-Graphics owner queue"
+        );
+    }
+
+    RenderGraph initial_graph("PresentationSourceImportRejected");
+    int         initial_physical = 0;
+    const auto  initial_texture = initial_graph.ImportTexture(
+        "Color",
+        &initial_physical,
+        RenderGraph::TextureDesc{
+            .aspects = RenderGraph::TextureAspect::Color,
+        }
+    );
+    initial_graph.SetInitialState(
+        initial_texture,
+        RenderGraph::TextureState::PresentationSource,
+        RenderGraph::QueueRole::Graphics,
+        RenderGraph::AccessMode::Read
+    );
+    initial_graph.AddPass(
+        "ReadImportedColor",
+        [initial_texture](RenderGraph::PassBuilder& builder) {
+            builder
+                .Read(
+                    initial_texture,
+                    RenderGraph::TextureState::ShaderResource
+                )
+                .SideEffect();
+        },
+        [] {}
+    );
+    initial_graph.Export(
+        initial_texture,
+        RenderGraph::TextureState::ShaderResource,
+        RenderGraph::QueueRole::Graphics,
+        RenderGraph::AccessMode::Read
+    );
+    suite.Check(
+        !initial_graph.Compile() &&
+            Contains(
+                initial_graph.GetCompileError(),
+                "export-boundary-only"
+            ),
+        test_name,
+        "an import boundary accepted the export-only PresentationSource state"
     );
 
     RenderGraph write_graph("PresentationSourceWriteRejected");
@@ -4042,21 +4113,77 @@ void TestRasterStyleUiSlotClaimTracksNativeAcceptance(TestSuite& suite) {
     auto accepted_backend = Moer::MakeShared<FakeUiDrawBackend>();
     auto accepted_frame =
         MakeUiDrawPacket(accepted_resources, accepted_backend, true);
+    TextureRef accepted_main_output(
+        MoerNew(FakeUiTexture)("RasterMainOutput")
+    );
+    TextureRef accepted_platform_output(
+        MoerNew(FakeUiTexture)("RasterPlatformOutput")
+    );
+    accepted_frame.platform_viewports.front().framebuffer =
+        accepted_platform_output;
     UiDrawFrameSlotClaim accepted_claim(accepted_frame);
     CommandList         accepted_commands;
     RenderUiDrawFrame(
         accepted_commands,
-        {},
+        accepted_main_output->GetView(),
         accepted_frame,
         EUiDrawExecutionThread::Game
     );
+    const bool raster_boundary_recorded =
+        UiFrameGraphPass::RecordPresentationBoundary(
+            accepted_commands,
+            {},
+            accepted_frame,
+            accepted_main_output
+        );
+    const CmdSubmit accepted_submit = accepted_commands.Submit();
+    bool raster_boundary_valid =
+        raster_boundary_recorded &&
+        !accepted_submit.HasExplicitResourceStateOwnership() &&
+        !accepted_submit.cmds.empty() &&
+        accepted_submit.cmds.back()->Type() ==
+            Command::EType::Barrier;
+    if (raster_boundary_valid) {
+        const auto& terminal = *static_cast<const BarrierCmd*>(
+            accepted_submit.cmds.back().get()
+        );
+        const std::array<Texture*, 2> expected{
+            accepted_main_output.Get(),
+            accepted_platform_output.Get(),
+        };
+        raster_boundary_valid =
+            terminal.ReadTextures().size() == expected.size() &&
+            terminal.WriteTextures().empty() &&
+            terminal.ExplicitTextures().empty();
+        for (Texture* texture : expected) {
+            const auto matches = std::count_if(
+                terminal.ReadTextures().begin(),
+                terminal.ReadTextures().end(),
+                [texture](const TextureBarrier& barrier) {
+                    return barrier.handle ==
+                               reinterpret_cast<std::uint64_t>(texture) &&
+                           barrier.state == ETextureState::TRANSFER &&
+                           barrier.pass_type == EPassType::Copy &&
+                           barrier.publish_external_state &&
+                           barrier.mip_level == 0 &&
+                           barrier.mip_cnt == texture->GetNumMips() &&
+                           barrier.array_layer == 0 &&
+                           barrier.array_cnt == texture->GetNumArray();
+                }
+            );
+            raster_boundary_valid =
+                raster_boundary_valid && matches == 1;
+        }
+    }
     suite.Check(
         accepted_backend->render_count == 1 &&
             accepted_backend->saw_valid_recording_slots &&
             accepted_resources->PendingSlot() == 23 &&
-            accepted_resources->CommitCount() == 0,
+            accepted_resources->CommitCount() == 0 &&
+            raster_boundary_valid,
         test_name,
-        "recording advanced the Raster UI upload ring before native acceptance"
+        "Raster UI recording advanced the upload ring or omitted its terminal "
+        "presentation-source boundary before native acceptance"
     );
     suite.Check(
         accepted_claim.CommitAccepted() &&
@@ -4264,6 +4391,106 @@ void TestUiFrameGraphTailContract(TestSuite& suite) {
         std::move(composition),
         std::move(draw_frame),
         EUiDrawExecutionThread::Render
+    );
+
+    auto linear_shared_slots =
+        Moer::MakeShared<FakeUiViewportResources>(15);
+    auto linear_platform_slots =
+        Moer::MakeShared<FakeUiViewportResources>(19);
+    auto linear_backend = Moer::MakeShared<FakeUiDrawBackend>();
+    UiDrawFramePacket linear_draw_frame{};
+    linear_draw_frame.backend = linear_backend;
+    linear_draw_frame.main_viewport.render_resources =
+        linear_shared_slots;
+    linear_draw_frame.main_viewport.commands.emplace_back();
+    const auto append_linear_platform =
+        [&](TextureRef framebuffer,
+            Moer::SharedPtr<FakeUiViewportResources> slots) {
+            UiViewportDrawPacket viewport{};
+            viewport.framebuffer      = std::move(framebuffer);
+            viewport.render_resources = std::move(slots);
+            viewport.commands.emplace_back();
+            linear_draw_frame.platform_viewports.emplace_back(
+                std::move(viewport)
+            );
+        };
+    append_linear_platform(main_output, linear_shared_slots);
+    append_linear_platform(window_output, linear_shared_slots);
+    append_linear_platform(platform_output, linear_platform_slots);
+    auto linear_prepared = UiFrameGraphPass::Prepare(
+        UiCompositionFrameData{
+            .enabled                = true,
+            .separate_window        = true,
+            .output_resolution      = Moer::uint2(64, 64),
+            .scene_color_position   = Moer::float2(0.f, 0.f),
+            .scene_color_resolution = Moer::float2(64.f, 64.f),
+            .window_frame_buffer    = window_output,
+        },
+        std::move(linear_draw_frame),
+        EUiDrawExecutionThread::Render
+    );
+    CommandList linear_commands(EQueueType::Graphics);
+    const bool linear_recorded =
+        UiFrameGraphPassTestAccess::ProcessLinearWithComposeRecorder(
+            linear_commands,
+            [](CommandList&) {},
+            linear_prepared,
+            scene_color,
+            main_output
+        );
+    CmdSubmit linear_submit = linear_commands.Submit();
+    bool linear_publications_valid =
+        linear_recorded &&
+        !linear_submit.HasExplicitResourceStateOwnership() &&
+        !linear_submit.cmds.empty() &&
+        linear_submit.cmds.back()->Type() ==
+            Command::EType::Barrier;
+    if (linear_publications_valid) {
+        const auto& terminal = *static_cast<const BarrierCmd*>(
+            linear_submit.cmds.back().get()
+        );
+        const std::array<Texture*, 3> expected{
+            main_output.Get(),
+            window_output.Get(),
+            platform_output.Get(),
+        };
+        linear_publications_valid =
+            terminal.ReadTextures().size() == expected.size() &&
+            terminal.WriteTextures().empty() &&
+            terminal.ExplicitTextures().empty();
+        for (Texture* texture : expected) {
+            const auto matches = std::count_if(
+                terminal.ReadTextures().begin(),
+                terminal.ReadTextures().end(),
+                [texture](const TextureBarrier& barrier) {
+                    return barrier.handle ==
+                               reinterpret_cast<std::uint64_t>(
+                                   texture
+                               ) &&
+                           barrier.state ==
+                               ETextureState::TRANSFER &&
+                           barrier.pass_type == EPassType::Copy &&
+                           barrier.publish_external_state &&
+                           barrier.mip_level == 0 &&
+                           barrier.mip_cnt ==
+                               texture->GetNumMips() &&
+                           barrier.array_layer == 0 &&
+                           barrier.array_cnt ==
+                               texture->GetNumArray();
+                }
+            );
+            linear_publications_valid =
+                linear_publications_valid && matches == 1;
+        }
+    }
+    suite.Check(
+        linear_publications_valid &&
+            linear_prepared->GetRecordingState() ==
+                UiFrameGraphPass::ERecordingState::Recorded &&
+            linear_backend->render_count == 1,
+        test_name,
+        "linear UI tail did not retain BackendTracked ownership with one "
+        "terminal full-range publication per presentation target"
     );
 
     RenderGraph graph("UiFrameGraphTailContract");

--- a/source/test/RenderGraphTest.cpp
+++ b/source/test/RenderGraphTest.cpp
@@ -1279,6 +1279,120 @@ void TestTextureAttachmentStateMatchesSelectedAspects(TestSuite& suite) {
     );
 }
 
+void TestPresentationSourceBoundaryContract(TestSuite& suite) {
+    constexpr std::string_view test_name =
+        "presentation source boundary contract";
+    auto import_color = [](RenderGraph& graph, int& physical) {
+        const auto texture = graph.ImportTexture(
+            "Color",
+            &physical,
+            RenderGraph::TextureDesc{
+                .aspects = RenderGraph::TextureAspect::Color,
+            }
+        );
+        graph.SetInitialState(
+            texture,
+            RenderGraph::TextureState::ShaderResource,
+            RenderGraph::QueueRole::Graphics,
+            RenderGraph::AccessMode::Read
+        );
+        graph.AddPass(
+            "SideEffect",
+            [](RenderGraph::PassBuilder& builder) {
+                builder.SideEffect();
+            },
+            [] {}
+        );
+        return texture;
+    };
+
+    RenderGraph valid_graph("ValidPresentationSource");
+    int         valid_physical = 0;
+    const auto  valid_texture =
+        import_color(valid_graph, valid_physical);
+    valid_graph.Export(
+        valid_texture,
+        RenderGraph::TextureState::PresentationSource,
+        RenderGraph::QueueRole::Graphics,
+        RenderGraph::AccessMode::Read
+    );
+    suite.Check(
+        valid_graph.Compile(),
+        test_name,
+        "a color texture must be exportable as a read-only presentation source: " +
+            valid_graph.GetCompileError()
+    );
+
+    RenderGraph write_graph("PresentationSourceWriteRejected");
+    int         write_physical = 0;
+    const auto  write_texture =
+        import_color(write_graph, write_physical);
+    write_graph.Export(
+        write_texture,
+        RenderGraph::TextureState::PresentationSource,
+        RenderGraph::QueueRole::Graphics,
+        RenderGraph::AccessMode::Write
+    );
+    suite.Check(
+        !write_graph.Compile() &&
+            Contains(write_graph.GetCompileError(), "boundary access"),
+        test_name,
+        "a presentation source boundary must reject write access"
+    );
+
+    RenderGraph read_write_graph("PresentationSourceReadWriteRejected");
+    int         read_write_physical = 0;
+    const auto  read_write_texture =
+        import_color(read_write_graph, read_write_physical);
+    read_write_graph.Export(
+        read_write_texture,
+        RenderGraph::TextureState::PresentationSource,
+        RenderGraph::QueueRole::Graphics,
+        RenderGraph::AccessMode::ReadWrite
+    );
+    suite.Check(
+        !read_write_graph.Compile() &&
+            Contains(read_write_graph.GetCompileError(), "boundary access"),
+        test_name,
+        "a presentation source boundary must reject read-write access"
+    );
+
+    RenderGraph depth_graph("DepthPresentationSourceRejected");
+    int         depth_physical = 0;
+    const auto  depth_texture = depth_graph.ImportTexture(
+        "Depth",
+        &depth_physical,
+        RenderGraph::TextureDesc{
+            .aspects = RenderGraph::TextureAspect::Depth,
+        }
+    );
+    depth_graph.SetInitialState(
+        depth_texture,
+        RenderGraph::TextureState::DepthStencilRead,
+        RenderGraph::QueueRole::Graphics,
+        RenderGraph::AccessMode::Read
+    );
+    depth_graph.AddPass(
+        "SideEffect",
+        [](RenderGraph::PassBuilder& builder) {
+            builder.SideEffect();
+        },
+        [] {}
+    );
+    depth_graph.Export(
+        depth_texture,
+        RenderGraph::TextureState::PresentationSource,
+        RenderGraph::QueueRole::Graphics,
+        RenderGraph::AccessMode::Read
+    );
+    suite.Check(
+        !depth_graph.Compile() &&
+            Contains(depth_graph.GetCompileError(), "selected aspects"),
+        test_name,
+        "only a color aspect may be exported as a presentation source"
+    );
+}
+
 void TestTypedAliasDescriptorMismatchIsRejected(TestSuite& suite) {
     constexpr std::string_view test_name = "typed alias descriptor mismatch";
     RenderGraph                graph("AliasDescriptorMismatch");
@@ -3828,6 +3942,7 @@ public:
         ETextureUsageFlags usage =
             ETextureUsageFlags::SAMPLED |
             ETextureUsageFlags::COLOR_ATTACHMENT |
+            ETextureUsageFlags::PRESENTATION_SOURCE |
             ETextureUsageFlags::TRANSFER_SRC |
             ETextureUsageFlags::TRANSFER_DST,
         ETextureAspectFlags aspects = ETextureAspectFlags::COLOR
@@ -4293,7 +4408,7 @@ void TestUiFrameGraphTailContract(TestSuite& suite) {
             export_barrier->export_boundary &&
             export_barrier->after_state ==
                 RenderGraph::ResourceState::Texture(
-                    RenderGraph::TextureState::TransferSource
+                    RenderGraph::TextureState::PresentationSource
                 ) &&
             export_barrier->after_access == RenderGraph::AccessMode::Read;
     }
@@ -4319,7 +4434,7 @@ void TestUiFrameGraphTailContract(TestSuite& suite) {
     suite.Check(
         export_contract_valid,
         test_name,
-        "a presentation target was not exported as Graphics TransferSource/Read"
+        "a presentation target was not exported as Graphics PresentationSource/Read"
     );
     const std::string dump = graph.Dump();
     suite.Check(
@@ -4375,6 +4490,13 @@ void TestUiFrameGraphRejectsInvalidPhysicalContracts(TestSuite& suite) {
         "InvalidOutput",
         ETextureUsageFlags::SAMPLED |
             ETextureUsageFlags::COLOR_ATTACHMENT
+    ));
+    TextureRef missing_presentation_usage(MoerNew(FakeUiTexture)(
+        "MissingPresentationUsage",
+        ETextureUsageFlags::SAMPLED |
+            ETextureUsageFlags::COLOR_ATTACHMENT |
+            ETextureUsageFlags::TRANSFER_SRC |
+            ETextureUsageFlags::TRANSFER_DST
     ));
 
     auto slots   = Moer::MakeShared<FakeUiViewportResources>(23);
@@ -4436,6 +4558,61 @@ void TestUiFrameGraphRejectsInvalidPhysicalContracts(TestSuite& suite) {
         test_name,
         "linear fallback bypassed UI target validation or claimed the copied "
         "packet"
+    );
+
+    RenderGraph semantic_graph("UiFrameGraphMissingPresentationUsage");
+    const auto  scene_handle = semantic_graph.ImportTexture(
+        "SceneColor",
+        scene_color,
+        RenderGraph::TextureDesc{
+            .mip_count   = 1,
+            .layer_count = 1,
+            .aspects     = RenderGraph::TextureAspect::Color,
+        }
+    );
+    const auto semantic_ready =
+        semantic_graph.CreateTransientToken("PresentationReady");
+    UiFrameGraphPass::GraphPasses semantic_passes{};
+    suite.Check(
+        !UiFrameGraphPassTestAccess::AddPassesWithComposeRecorder(
+            semantic_graph,
+            [](CommandList&) {},
+            prepared,
+            scene_handle,
+            scene_color,
+            missing_presentation_usage,
+            semantic_ready,
+            semantic_passes
+        ) &&
+            !semantic_passes.IsValid() &&
+            prepared->GetRecordingState() ==
+                UiFrameGraphPass::ERecordingState::Prepared,
+        test_name,
+        "graph declaration accepted a target without PRESENTATION_SOURCE "
+        "usage"
+    );
+
+    CommandList semantic_linear_commands{};
+    const bool semantic_linear_recorded =
+        UiFrameGraphPassTestAccess::ProcessLinearWithComposeRecorder(
+            semantic_linear_commands,
+            [](CommandList&) {},
+            prepared,
+            scene_color,
+            missing_presentation_usage
+        );
+    const CmdSubmit semantic_rejected_submit =
+        semantic_linear_commands.Submit();
+    suite.Check(
+        !semantic_linear_recorded &&
+            semantic_rejected_submit.cmds.empty() &&
+            backend->render_count == 0 && slots->CommitCount() == 0 &&
+            slots->PendingSlot() == 23 &&
+            prepared->GetRecordingState() ==
+                UiFrameGraphPass::ERecordingState::Prepared,
+        test_name,
+        "linear fallback accepted a target without PRESENTATION_SOURCE "
+        "usage"
     );
 }
 
@@ -5669,6 +5846,7 @@ int main() {
     TestInvalidTypedRangeIsRejected(suite);
     TestUnknownTextureAspectIsRejected(suite);
     TestTextureAttachmentStateMatchesSelectedAspects(suite);
+    TestPresentationSourceBoundaryContract(suite);
     TestTypedAliasDescriptorMismatchIsRejected(suite);
     TestMultipleReadersProduceAllWarEdges(suite);
     TestExplicitStateValidation(suite);


### PR DESCRIPTION
## Summary
- add a boundary-only RenderGraph PresentationSource state that lowers to COMMON/GENERAL with transfer-read visibility
- add semantic PRESENTATION_SOURCE usage and keep presentation textures in Vulkan GENERAL preferred layout
- make Present consume the source in GENERAL and validate native copy requirements before any scripted/native submission
- fail closed for null, missing usage, MSAA, compressed/unsupported formats, partial subresources, offsets, and extent mismatches with exactly-once receipts

## Validation
- built MoerEditor, TestRenderGraph, TestRenderGraphLowering, TestRHIExplicitBarrier, TestRHIParallelRecordVulkan, TestRHIThreadOwnership, TestVulkanHeaderContract
- CTest: RenderGraphContract, RenderGraphLoweringContract, RHIExplicitBarrierContract, RHIThreadOwnershipContract, VulkanHeaderContract
- TestRHIParallelRecordVulkan --present-boundary
- TestRHIParallelRecordVulkan --present-hard
- RT RenderGraph + parallel-record runtime: resize, normal shutdown, 0 VUID/error/fatal
- Raster RenderGraph + parallel-record runtime: resize, normal shutdown, 0 VUID/error/fatal
- independent local review: P0/P1/P2 = 0 at diff hash e0fcd2290df247b64e5ba595d5af79a5aba00303