### PR TITLE
Phase 19A: add GPU completion futures

### DIFF
--- a/source/runtime/render/rhi/RHICommand.h
+++ b/source/runtime/render/rhi/RHICommand.h
@@ -9,6 +9,7 @@
 #include "misc/STL.h"
 #include "misc/Traits.h"
 #include "rhi/RHICommon.h"
+#include "rhi/RHICompletion.h"
 #include "rhi/RHIQuery.h"
 #include "rhi/RHIResource.h"
 #include "rhi/RHISubmissionTopology.h"
@@ -282,6 +283,8 @@ struct CmdSubmit {
     Array<UniquePtr<Command>>        cmds;
     Array<std::function<void(void)>> callbacks;
     Array<std::function<void(void)>> success_callbacks;
+    Array<GpuCompletionToken>        gpu_completion_tokens;
+    GpuCompletionPublishBatch        gpu_completion_publish_batch{};
     Array<QueryToken>                query_tokens;
     // Optional owner ticket when a whole backend batch publishes Query
     // terminal states before per-submit Completion packets are enqueued.
@@ -392,6 +395,11 @@ struct CmdSubmit {
         cmds               = std::move(_other.cmds);
         callbacks          = std::move(_other.callbacks);
         success_callbacks  = std::move(_other.success_callbacks);
+        gpu_completion_tokens = std::move(
+            _other.gpu_completion_tokens
+        );
+        gpu_completion_publish_batch =
+            _other.gpu_completion_publish_batch;
         query_tokens        = std::move(_other.query_tokens);
         query_publish_batch = _other.query_publish_batch;
         wait_events        = std::move(_other.wait_events);
@@ -407,6 +415,8 @@ struct CmdSubmit {
         async_queue_scope  = _other.async_queue_scope;
         debug_label        = std::move(_other.debug_label);
         debug_label_color  = _other.debug_label_color;
+        _other.gpu_completion_tokens.clear();
+        _other.gpu_completion_publish_batch = {};
         _other.query_tokens.clear();
         _other.query_publish_batch = {};
         _other.signal_events.clear();
@@ -417,6 +427,17 @@ struct CmdSubmit {
             return *this;
         }
         RejectPendingSignals();
+        Array<GpuCompletionToken> replaced_completion_tokens =
+            std::move(gpu_completion_tokens);
+        const GpuCompletionPublishBatch replaced_completion_batch =
+            gpu_completion_publish_batch.Valid() ?
+                gpu_completion_publish_batch :
+                GpuCompletionBackendAccess::BeginPublishBatch();
+        GpuCompletionBackendAccess::PublishErrorsIfPending(
+            replaced_completion_tokens,
+            "GPU completion submit was replaced before completion",
+            replaced_completion_batch
+        );
         Array<QueryToken> replaced_query_tokens = std::move(query_tokens);
         const QueryPublishBatch replaced_query_batch =
             query_publish_batch.Valid() ?
@@ -430,6 +451,11 @@ struct CmdSubmit {
         cmds               = std::move(_other.cmds);
         callbacks          = std::move(_other.callbacks);
         success_callbacks  = std::move(_other.success_callbacks);
+        gpu_completion_tokens = std::move(
+            _other.gpu_completion_tokens
+        );
+        gpu_completion_publish_batch =
+            _other.gpu_completion_publish_batch;
         query_tokens        = std::move(_other.query_tokens);
         query_publish_batch = _other.query_publish_batch;
         wait_events        = std::move(_other.wait_events);
@@ -445,12 +471,17 @@ struct CmdSubmit {
         async_queue_scope  = _other.async_queue_scope;
         debug_label        = std::move(_other.debug_label);
         debug_label_color  = _other.debug_label_color;
+        _other.gpu_completion_tokens.clear();
+        _other.gpu_completion_publish_batch = {};
         _other.query_tokens.clear();
         _other.query_publish_batch = {};
         _other.signal_events.clear();
 
         // The replacement is fully installed before user Query callbacks can
         // re-enter this object. No outer write may overwrite re-entrant state.
+        GpuCompletionBackendAccess::NotifyTerminals(
+            replaced_completion_tokens, replaced_completion_batch
+        );
         QueryBackendAccess::NotifyTerminals(
             replaced_query_tokens, replaced_query_batch
         );
@@ -459,7 +490,24 @@ struct CmdSubmit {
 
     ~CmdSubmit() {
         RejectPendingSignals();
-        RejectPendingQueries("query submit was destroyed before completion");
+        const GpuCompletionPublishBatch completion_batch =
+            gpu_completion_publish_batch.Valid() ?
+                gpu_completion_publish_batch :
+                GpuCompletionBackendAccess::BeginPublishBatch();
+        const QueryPublishBatch query_batch =
+            query_publish_batch.Valid() ?
+                query_publish_batch :
+                QueryBackendAccess::BeginPublishBatch();
+        PublishPendingGpuCompletionErrors(
+            "GPU completion submit was destroyed before completion",
+            completion_batch
+        );
+        PublishPendingQueryErrors(
+            "query submit was destroyed before completion",
+            query_batch
+        );
+        NotifyPendingGpuCompletions(completion_batch);
+        NotifyPendingQueries(query_batch);
     }
 
     void RejectPendingSignals() noexcept {
@@ -470,6 +518,57 @@ struct CmdSubmit {
             }
         }
         signal_events.clear();
+    }
+
+    void PublishPendingGpuCompletionOutcome(
+        bool                      _gpu_success,
+        std::string_view          _failure_reason,
+        GpuCompletionPublishBatch _batch
+    ) noexcept {
+        const GpuCompletionPublishBatch effective_batch =
+            gpu_completion_publish_batch.Valid() ?
+                gpu_completion_publish_batch :
+                _batch;
+        gpu_completion_publish_batch = effective_batch;
+        GpuCompletionBackendAccess::PublishOutcome(
+            gpu_completion_tokens,
+            _gpu_success,
+            _failure_reason,
+            effective_batch
+        );
+    }
+
+    void PublishPendingGpuCompletionErrors(
+        std::string_view          _reason,
+        GpuCompletionPublishBatch _batch
+    ) noexcept {
+        PublishPendingGpuCompletionOutcome(false, _reason, _batch);
+    }
+
+    void NotifyPendingGpuCompletions(
+        GpuCompletionPublishBatch _batch
+    ) noexcept {
+        Array<GpuCompletionToken> tokens =
+            std::move(gpu_completion_tokens);
+        const GpuCompletionPublishBatch effective_batch =
+            gpu_completion_publish_batch.Valid() ?
+                gpu_completion_publish_batch :
+                _batch;
+        gpu_completion_publish_batch = {};
+        GpuCompletionBackendAccess::NotifyTerminals(
+            tokens, effective_batch
+        );
+    }
+
+    void RejectPendingGpuCompletions(
+        std::string_view _reason
+    ) noexcept {
+        const GpuCompletionPublishBatch batch =
+            gpu_completion_publish_batch.Valid() ?
+                gpu_completion_publish_batch :
+                GpuCompletionBackendAccess::BeginPublishBatch();
+        PublishPendingGpuCompletionErrors(_reason, batch);
+        NotifyPendingGpuCompletions(batch);
     }
 
     void PublishPendingQueryErrors(
@@ -1642,6 +1741,13 @@ public:
 
     RENDER_API void AddCallback(std::function<void()>&& _callback);
     RENDER_API void AddSuccessCallback(std::function<void()>&& _callback);
+
+    // Creates a host-visible terminal handle for this recording generation.
+    // The Future resolves only after the complete logical submission reaches
+    // successful GPU retirement, or Error on any terminal rejection/fault.
+    RENDER_API GpuCompletionFuture TrackGpuCompletion(
+        std::string_view _name = {}
+    );
     /**
      * Attaches a native-submission acceptance marker to this CommandList.
      * Unlike CmdSubmit::Signal(), this form is available to independently
@@ -1677,6 +1783,11 @@ public:
 
     [[nodiscard]] QueryCancellationView GetQueryCancellationView() const noexcept {
         return query_cancellation_domain.GetView();
+    }
+
+    [[nodiscard]] GpuCompletionCancellationView
+    GetGpuCompletionCancellationView() const noexcept {
+        return gpu_completion_cancellation_domain.GetView();
     }
 
     [[nodiscard]] bool HasOpenTimestampQueries() const noexcept {
@@ -1783,6 +1894,9 @@ private:
     RENDER_API void EndBarriers();
 
     RENDER_API void RejectPendingQueries(std::string_view _reason) noexcept;
+    RENDER_API void RejectPendingGpuCompletions(
+        std::string_view _reason
+    ) noexcept;
 
 #pragma region[ raytracing ]
     RENDER_API void TraceRays(PipelineHandle _pipeline, ArrayArguments&& _args, uint3 _extent);
@@ -1793,6 +1907,9 @@ private:
     Command*                     current_barriers{nullptr};
     Array<std::function<void()>> callbacks;
     Array<std::function<void()>> success_callbacks;
+    Array<GpuCompletionToken>     gpu_completion_tokens;
+    GpuCompletionCancellationDomain
+                                  gpu_completion_cancellation_domain;
     Array<QueryToken>             query_tokens;
     Array<QueryToken>             active_query_stack;
     QueryCancellationDomain       query_cancellation_domain;

--- a/source/runtime/render/rhi/RHICommandList.cpp
+++ b/source/runtime/render/rhi/RHICommandList.cpp
@@ -17,6 +17,7 @@ namespace {
 
 std::atomic<uint64> g_query_token_id{1};
 std::atomic<uint64> g_query_owner_id{1};
+std::atomic<uint64> g_gpu_completion_token_id{1};
 
 uint64 NextNonZeroId(std::atomic<uint64>& _counter) noexcept {
     uint64 id = _counter.fetch_add(1, std::memory_order_relaxed);
@@ -73,7 +74,51 @@ CommandList::CommandList(EQueueType _queue_type) :
 
 CommandList::~CommandList() {
     RejectPendingSignals();
-    RejectPendingQueries("query command list was destroyed before submission");
+    GpuCompletionCancellationView completion_cancellation =
+        gpu_completion_cancellation_domain.GetView();
+    Array<GpuCompletionToken> completion_tokens =
+        std::move(gpu_completion_tokens);
+    const GpuCompletionPublishBatch completion_batch =
+        GpuCompletionBackendAccess::BeginPublishBatch();
+    const bool completion_cancellation_published =
+        completion_cancellation.PublishCancellation(
+            "GPU completion command list was destroyed before submission",
+            completion_batch
+        );
+    GpuCompletionBackendAccess::PublishErrorsIfPending(
+        completion_tokens,
+        "GPU completion command list was destroyed before submission",
+        completion_batch
+    );
+    const QueryPublishBatch query_batch =
+        QueryBackendAccess::BeginPublishBatch();
+    QueryCancellationView cancellation =
+        query_cancellation_domain.GetView();
+    Array<QueryToken> query_tokens = std::move(this->query_tokens);
+    const bool cancellation_published =
+        cancellation.PublishCancellation(
+            "query command list was destroyed before submission",
+            query_batch
+        );
+    QueryBackendAccess::PublishErrorsIfPending(
+        query_tokens,
+        "query command list was destroyed before submission",
+        query_batch
+    );
+    GpuCompletionBackendAccess::NotifyTerminals(
+        completion_tokens, completion_batch
+    );
+    if (completion_cancellation_published) {
+        completion_cancellation.NotifyCancellation(completion_batch);
+    } else {
+        completion_cancellation.NotifyPublishedCancellation();
+    }
+    if (cancellation_published) {
+        cancellation.NotifyCancellation(query_batch);
+    } else {
+        cancellation.NotifyPublishedCancellation();
+    }
+    QueryBackendAccess::NotifyTerminals(query_tokens, query_batch);
 }
 
 CommandList::CommandList(CommandList&& _other) :
@@ -94,8 +139,25 @@ CommandList& CommandList::operator=(CommandList&& _other) {
 
     // Allocate the replacement generation before changing either list. Once
     // ownership starts moving, every remaining operation below is noexcept.
-    QueryCancellationDomain moved_from_query_domain{};
+    GpuCompletionCancellationDomain moved_from_completion_domain{};
+    QueryCancellationDomain         moved_from_query_domain{};
     RejectPendingSignals();
+    GpuCompletionCancellationView replaced_completion_cancellation =
+        gpu_completion_cancellation_domain.GetView();
+    Array<GpuCompletionToken> replaced_completion_tokens =
+        std::move(gpu_completion_tokens);
+    const GpuCompletionPublishBatch replaced_completion_batch =
+        GpuCompletionBackendAccess::BeginPublishBatch();
+    const bool replaced_completion_cancellation_published =
+        replaced_completion_cancellation.PublishCancellation(
+            "GPU completion command list was replaced before submission",
+            replaced_completion_batch
+        );
+    GpuCompletionBackendAccess::PublishErrorsIfPending(
+        replaced_completion_tokens,
+        "GPU completion command list was replaced before submission",
+        replaced_completion_batch
+    );
     QueryCancellationView replaced_query_cancellation =
         query_cancellation_domain.GetView();
     Array<QueryToken> replaced_query_tokens = std::move(query_tokens);
@@ -115,6 +177,10 @@ CommandList& CommandList::operator=(CommandList&& _other) {
     current_barriers            = _other.current_barriers;
     callbacks                   = std::move(_other.callbacks);
     success_callbacks           = std::move(_other.success_callbacks);
+    gpu_completion_tokens       =
+        std::move(_other.gpu_completion_tokens);
+    gpu_completion_cancellation_domain =
+        std::move(_other.gpu_completion_cancellation_domain);
     query_tokens                = std::move(_other.query_tokens);
     active_query_stack          = std::move(_other.active_query_stack);
     query_cancellation_domain   = std::move(_other.query_cancellation_domain);
@@ -136,12 +202,26 @@ CommandList& CommandList::operator=(CommandList&& _other) {
     _other.seal_generation   = 0;
     _other.query_owner_id    = NextNonZeroId(g_query_owner_id);
     _other.query_cancellation_domain = std::move(moved_from_query_domain);
+    _other.gpu_completion_cancellation_domain =
+        std::move(moved_from_completion_domain);
+    _other.gpu_completion_tokens.clear();
     _other.query_tokens.clear();
     _other.active_query_stack.clear();
     _other.signal_events.clear();
 
     // Install the complete incoming generation before releasing user Query
     // callbacks so re-entrant recording cannot be overwritten by this move.
+    GpuCompletionBackendAccess::NotifyTerminals(
+        replaced_completion_tokens, replaced_completion_batch
+    );
+    if (replaced_completion_cancellation_published) {
+        replaced_completion_cancellation.NotifyCancellation(
+            replaced_completion_batch
+        );
+    } else {
+        replaced_completion_cancellation.
+            NotifyPublishedCancellation();
+    }
     if (replaced_cancellation_published) {
         replaced_query_cancellation.NotifyCancellation(
             replaced_query_batch
@@ -295,7 +375,10 @@ CmdSubmit CommandList::Submit() {
     // Construct the next recording generation before transferring callbacks,
     // signals, and query ownership into CmdSubmit. Allocation failure therefore
     // leaves the current generation intact and terminalizable.
-    QueryCancellationDomain next_query_domain{};
+    GpuCompletionCancellationDomain next_completion_domain{};
+    QueryCancellationDomain         next_query_domain{};
+    GpuCompletionCancellationView submitted_completion_cancellation =
+        gpu_completion_cancellation_domain.GetView();
     QueryCancellationView submitted_query_cancellation =
         query_cancellation_domain.GetView();
     ++seal_generation;
@@ -313,7 +396,7 @@ CmdSubmit CommandList::Submit() {
     }
     const bool has_submit_side_effects =
         !callbacks.empty() || !success_callbacks.empty() ||
-        !signal_events.empty();
+        !gpu_completion_tokens.empty() || !signal_events.empty();
     Array<RHISubmitSegment> submit_segments{};
     if (!commands.empty() || has_submit_side_effects) {
         // Allocate the segment before transferring signal/callback ownership.
@@ -332,11 +415,27 @@ CmdSubmit CommandList::Submit() {
         std::move(success_callbacks),
         std::move(cached_args)
     );
+    submit.gpu_completion_tokens = std::move(gpu_completion_tokens);
     submit.query_tokens = std::move(query_tokens);
     submit.signal_events = std::move(signal_events);
     submit.segments      = std::move(submit_segments);
     submit.translate_execution_class = translate_execution_class;
     submit.resource_state_ownership   = resource_state_ownership;
+    Array<GpuCompletionToken>
+        deferred_completion_cancellation_tokens{};
+    const GpuCompletionPublishBatch
+        deferred_completion_cancellation_batch =
+            submitted_completion_cancellation.
+                TakePublishedCancellationBatch(
+                    deferred_completion_cancellation_tokens
+                );
+    if (deferred_completion_cancellation_batch.Valid()) {
+        submit.gpu_completion_tokens.swap(
+            deferred_completion_cancellation_tokens
+        );
+        submit.gpu_completion_publish_batch =
+            deferred_completion_cancellation_batch;
+    }
     // Opaque shutdown publishes Query Error while deliberately retaining the
     // callback ticket until the producer reaches an ownership boundary. If
     // that boundary is Submit(), transfer the complete cancellation token set
@@ -354,8 +453,11 @@ CmdSubmit CommandList::Submit() {
     commands.clear();
     callbacks.clear();
     success_callbacks.clear();
+    gpu_completion_tokens.clear();
     query_tokens.clear();
     active_query_stack.clear();
+    gpu_completion_cancellation_domain =
+        std::move(next_completion_domain);
     query_cancellation_domain = std::move(next_query_domain);
     signal_events.clear();
     timestamp_scope_names.clear();
@@ -372,9 +474,26 @@ Array<std::function<void()>> CommandList::DrainOrdinaryCallbacksForRejection() {
     }
     // Do not move cleanup callbacks out until the replacement generation is
     // guaranteed to exist; rejection must retain its no-throw ownership tail.
-    QueryCancellationDomain next_query_domain{};
+    GpuCompletionCancellationDomain next_completion_domain{};
+    QueryCancellationDomain         next_query_domain{};
     ++seal_generation;
     RejectPendingSignals();
+    GpuCompletionCancellationView rejected_completion_cancellation =
+        gpu_completion_cancellation_domain.GetView();
+    Array<GpuCompletionToken> rejected_completion_tokens =
+        std::move(gpu_completion_tokens);
+    const GpuCompletionPublishBatch rejected_completion_batch =
+        GpuCompletionBackendAccess::BeginPublishBatch();
+    const bool rejected_completion_cancellation_published =
+        rejected_completion_cancellation.PublishCancellation(
+            "GPU completion command list was rejected before completion",
+            rejected_completion_batch
+        );
+    GpuCompletionBackendAccess::PublishErrorsIfPending(
+        rejected_completion_tokens,
+        "GPU completion command list was rejected before completion",
+        rejected_completion_batch
+    );
     QueryCancellationView rejected_query_cancellation =
         query_cancellation_domain.GetView();
     Array<QueryToken> rejected_query_tokens = std::move(query_tokens);
@@ -400,8 +519,11 @@ Array<std::function<void()>> CommandList::DrainOrdinaryCallbacksForRejection() {
     commands.clear();
     callbacks.clear();
     success_callbacks.clear();
+    gpu_completion_tokens.clear();
     query_tokens.clear();
     active_query_stack.clear();
+    gpu_completion_cancellation_domain =
+        std::move(next_completion_domain);
     query_cancellation_domain = std::move(next_query_domain);
     signal_events.clear();
     cached_args.clear();
@@ -415,6 +537,17 @@ Array<std::function<void()>> CommandList::DrainOrdinaryCallbacksForRejection() {
 
     // The fresh generation is fully installed before Query callbacks can
     // re-enter this CommandList and append new work.
+    GpuCompletionBackendAccess::NotifyTerminals(
+        rejected_completion_tokens, rejected_completion_batch
+    );
+    if (rejected_completion_cancellation_published) {
+        rejected_completion_cancellation.NotifyCancellation(
+            rejected_completion_batch
+        );
+    } else {
+        rejected_completion_cancellation.
+            NotifyPublishedCancellation();
+    }
     if (rejected_cancellation_published) {
         rejected_query_cancellation.NotifyCancellation(
             rejected_query_batch
@@ -430,7 +563,8 @@ Array<std::function<void()>> CommandList::DrainOrdinaryCallbacksForRejection() {
 
 bool CommandList::IsEmpty() const {
     return commands.empty() && callbacks.empty() &&
-           success_callbacks.empty() && signal_events.empty() &&
+           success_callbacks.empty() && gpu_completion_tokens.empty() &&
+           signal_events.empty() &&
            cached_args.empty() && query_tokens.empty() &&
            active_query_stack.empty();
 }
@@ -888,6 +1022,20 @@ void CommandList::AddSuccessCallback(std::function<void()>&& _callback) {
     success_callbacks.emplace_back(std::move(_callback));
 }
 
+GpuCompletionFuture CommandList::TrackGpuCompletion(
+    std::string_view _name
+) {
+    GpuCompletionToken token(
+        NextNonZeroId(g_gpu_completion_token_id), _name
+    );
+    GpuCompletionFuture future = token.GetFuture();
+    gpu_completion_tokens.emplace_back(std::move(token));
+    gpu_completion_cancellation_domain.Register(
+        gpu_completion_tokens.back()
+    );
+    return future;
+}
+
 QueryToken CommandList::BeginTimestampQuery(std::string_view _name) {
     QueryToken token(
         NextNonZeroId(g_query_token_id),
@@ -1010,6 +1158,28 @@ void CommandList::RejectPendingQueries(std::string_view _reason) noexcept {
         cancellation.NotifyPublishedCancellation();
     }
     QueryBackendAccess::NotifyTerminals(tokens, batch);
+}
+
+void CommandList::RejectPendingGpuCompletions(
+    std::string_view _reason
+) noexcept {
+    GpuCompletionCancellationView cancellation =
+        gpu_completion_cancellation_domain.GetView();
+    Array<GpuCompletionToken> tokens =
+        std::move(gpu_completion_tokens);
+    const GpuCompletionPublishBatch batch =
+        GpuCompletionBackendAccess::BeginPublishBatch();
+    const bool cancellation_published =
+        cancellation.PublishCancellation(_reason, batch);
+    GpuCompletionBackendAccess::PublishErrorsIfPending(
+        tokens, _reason, batch
+    );
+    if (cancellation_published) {
+        cancellation.NotifyCancellation(batch);
+    } else {
+        cancellation.NotifyPublishedCancellation();
+    }
+    GpuCompletionBackendAccess::NotifyTerminals(tokens, batch);
 }
 
 void CommandList::RejectPendingSignals() noexcept {

--- a/source/runtime/render/rhi/RHICompletion.cpp
+++ b/source/runtime/render/rhi/RHICompletion.cpp
@@ -1,0 +1,579 @@
+#include "rhi/RHICompletion.h"
+#include "rhi/RHIThreadOwnership.h"
+
+#include <atomic>
+#include <condition_variable>
+#include <mutex>
+#include <stdexcept>
+#include <utility>
+
+namespace Moer::Render {
+namespace {
+
+std::atomic<std::uint64_t> g_gpu_completion_publish_batch_id{1};
+
+std::uint64_t NextGpuCompletionPublishBatchId() noexcept {
+    std::uint64_t id = g_gpu_completion_publish_batch_id.fetch_add(
+        1, std::memory_order_relaxed
+    );
+    while (id == 0) {
+        id = g_gpu_completion_publish_batch_id.fetch_add(
+            1, std::memory_order_relaxed
+        );
+    }
+    return id;
+}
+
+GpuCompletionResult InvalidFutureResult() {
+    GpuCompletionResult result{};
+    result.status       = GpuCompletionStatus::Error;
+    result.error_reason = "invalid GPU completion future";
+    return result;
+}
+
+void InvokeCallbackNoexcept(
+    const GpuCompletionFuture::Callback& _callback,
+    const GpuCompletionResult&           _result
+) noexcept {
+    if (!_callback) {
+        return;
+    }
+    try {
+        _callback(_result);
+    } catch (...) {
+        // A faulty observer must not terminate the Completion owner.
+    }
+}
+
+} // namespace
+
+struct GpuCompletionFuture::SharedState {
+    mutable std::mutex      mutex{};
+    std::condition_variable cv{};
+    GpuCompletionResult     result{};
+    Array<Callback>         callbacks{};
+    bool                    notification_released{false};
+    std::uint64_t           notification_owner{0};
+};
+
+struct GpuCompletionCancellationState {
+    mutable std::mutex       mutex{};
+    bool                     cancelled{false};
+    bool                     sealed{false};
+    std::string              reason{};
+    Array<GpuCompletionToken> tokens{};
+    std::uint64_t            notification_owner{0};
+};
+
+GpuCompletionFuture::GpuCompletionFuture(
+    std::shared_ptr<SharedState> _state
+) noexcept :
+    state_(std::move(_state)) {}
+
+GpuCompletionFuture GpuCompletionFuture::Create(
+    std::uint64_t    _completion_id,
+    std::string_view _name
+) {
+    auto state                  = std::make_shared<SharedState>();
+    state->result.completion_id = _completion_id;
+    state->result.name          = _name;
+    return GpuCompletionFuture(std::move(state));
+}
+
+bool GpuCompletionFuture::Valid() const noexcept {
+    return static_cast<bool>(state_);
+}
+
+bool GpuCompletionFuture::IsReady() const noexcept {
+    if (!state_) {
+        return false;
+    }
+    std::scoped_lock lock(state_->mutex);
+    return state_->result.status != GpuCompletionStatus::Pending;
+}
+
+GpuCompletionStatus GpuCompletionFuture::Status() const noexcept {
+    if (!state_) {
+        return GpuCompletionStatus::Error;
+    }
+    std::scoped_lock lock(state_->mutex);
+    return state_->result.status;
+}
+
+void GpuCompletionFuture::Wait() const {
+    if (!state_) {
+        return;
+    }
+    std::unique_lock lock(state_->mutex);
+    if (state_->result.status == GpuCompletionStatus::Pending &&
+        !IsRHIBlockingCallAllowedOnCurrentThread()) {
+        throw std::logic_error(
+            "an RHI owner thread cannot block on a pending GPU completion"
+        );
+    }
+    state_->cv.wait(lock, [state = state_] {
+        return state->result.status != GpuCompletionStatus::Pending;
+    });
+}
+
+bool GpuCompletionFuture::WaitFor(
+    std::chrono::nanoseconds _timeout
+) const {
+    if (!state_) {
+        return false;
+    }
+    std::unique_lock lock(state_->mutex);
+    if (state_->result.status == GpuCompletionStatus::Pending &&
+        !IsRHIBlockingCallAllowedOnCurrentThread()) {
+        throw std::logic_error(
+            "an RHI owner thread cannot block on a pending GPU completion"
+        );
+    }
+    return state_->cv.wait_for(lock, _timeout, [state = state_] {
+        return state->result.status != GpuCompletionStatus::Pending;
+    });
+}
+
+GpuCompletionResult GpuCompletionFuture::Get() const {
+    if (!state_) {
+        return InvalidFutureResult();
+    }
+    Wait();
+    std::scoped_lock lock(state_->mutex);
+    return state_->result;
+}
+
+std::optional<GpuCompletionResult> GpuCompletionFuture::TryGet() const {
+    if (!state_) {
+        return InvalidFutureResult();
+    }
+    std::scoped_lock lock(state_->mutex);
+    if (state_->result.status == GpuCompletionStatus::Pending) {
+        return std::nullopt;
+    }
+    return state_->result;
+}
+
+void GpuCompletionFuture::Then(Callback _callback) const {
+    const std::shared_ptr<SharedState> state = state_;
+    if (!state || !_callback) {
+        return;
+    }
+
+    bool invoke_now = false;
+    {
+        std::scoped_lock lock(state->mutex);
+        if (state->result.status == GpuCompletionStatus::Pending ||
+            !state->notification_released) {
+            state->callbacks.emplace_back(std::move(_callback));
+        } else {
+            invoke_now = true;
+        }
+    }
+    if (invoke_now) {
+        InvokeCallbackNoexcept(_callback, state->result);
+    }
+}
+
+bool GpuCompletionFuture::PublishReady(
+    std::uint64_t _notification_owner
+) const noexcept {
+    if (!state_ || _notification_owner == 0) {
+        return false;
+    }
+    {
+        std::scoped_lock lock(state_->mutex);
+        if (state_->result.status != GpuCompletionStatus::Pending) {
+            return false;
+        }
+        state_->result.status = GpuCompletionStatus::Ready;
+        state_->result.error_reason.clear();
+        state_->notification_released = false;
+        state_->notification_owner    = _notification_owner;
+    }
+    state_->cv.notify_all();
+    return true;
+}
+
+bool GpuCompletionFuture::PublishError(
+    std::string_view _reason,
+    std::uint64_t    _notification_owner
+) const noexcept {
+    if (!state_ || _notification_owner == 0) {
+        return false;
+    }
+
+    std::string reason{};
+    try {
+        reason.assign(_reason);
+    } catch (...) {
+        // Error is still a valid terminal classification under allocation
+        // pressure even when its diagnostic text cannot be retained.
+    }
+
+    {
+        std::scoped_lock lock(state_->mutex);
+        if (state_->result.status != GpuCompletionStatus::Pending) {
+            return false;
+        }
+        state_->result.status       = GpuCompletionStatus::Error;
+        state_->result.error_reason = std::move(reason);
+        state_->notification_released = false;
+        state_->notification_owner    = _notification_owner;
+    }
+    state_->cv.notify_all();
+    return true;
+}
+
+void GpuCompletionFuture::NotifyTerminal(
+    std::uint64_t _notification_owner
+) const noexcept {
+    const std::shared_ptr<SharedState> state = state_;
+    if (!state || _notification_owner == 0) {
+        return;
+    }
+
+    Array<Callback> callbacks{};
+    {
+        std::scoped_lock lock(state->mutex);
+        if (state->result.status == GpuCompletionStatus::Pending ||
+            state->notification_released ||
+            state->notification_owner != _notification_owner) {
+            return;
+        }
+        state->notification_released = true;
+        callbacks = std::move(state->callbacks);
+    }
+    for (const Callback& callback : callbacks) {
+        InvokeCallbackNoexcept(callback, state->result);
+    }
+}
+
+GpuCompletionToken::GpuCompletionToken(
+    std::uint64_t    _id,
+    std::string_view _name
+) :
+    id_(_id),
+    name_(std::make_shared<const std::string>(_name)),
+    future_(GpuCompletionFuture::Create(_id, *name_)) {}
+
+bool GpuCompletionToken::Valid() const noexcept {
+    return id_ != 0 && future_.Valid();
+}
+
+bool GpuCompletionToken::IsReady() const noexcept {
+    return future_.IsReady();
+}
+
+std::uint64_t GpuCompletionToken::Id() const noexcept {
+    return id_;
+}
+
+const std::string& GpuCompletionToken::Name() const noexcept {
+    static const std::string empty_name{};
+    return name_ ? *name_ : empty_name;
+}
+
+GpuCompletionFuture GpuCompletionToken::GetFuture() const noexcept {
+    return future_;
+}
+
+void GpuCompletionToken::Then(
+    GpuCompletionFuture::Callback _callback
+) const {
+    future_.Then(std::move(_callback));
+}
+
+bool GpuCompletionToken::PublishReady(
+    std::uint64_t _notification_owner
+) const noexcept {
+    return Valid() && future_.PublishReady(_notification_owner);
+}
+
+bool GpuCompletionToken::PublishErrorIfPending(
+    std::string_view _reason,
+    std::uint64_t    _notification_owner
+) const noexcept {
+    return Valid() &&
+           future_.PublishError(_reason, _notification_owner);
+}
+
+void GpuCompletionToken::NotifyTerminal(
+    std::uint64_t _notification_owner
+) const noexcept {
+    future_.NotifyTerminal(_notification_owner);
+}
+
+GpuCompletionPublishBatch
+GpuCompletionBackendAccess::BeginPublishBatch() noexcept {
+    return GpuCompletionPublishBatch(
+        NextGpuCompletionPublishBatchId()
+    );
+}
+
+bool GpuCompletionBackendAccess::ResolveReady(
+    const GpuCompletionToken& _token
+) noexcept {
+    const GpuCompletionPublishBatch batch = BeginPublishBatch();
+    const bool published = PublishReady(_token, batch);
+    if (published) {
+        NotifyTerminal(_token, batch);
+    }
+    return published;
+}
+
+bool GpuCompletionBackendAccess::ResolveErrorIfPending(
+    const GpuCompletionToken& _token,
+    std::string_view          _reason
+) noexcept {
+    const GpuCompletionPublishBatch batch = BeginPublishBatch();
+    const bool published =
+        PublishErrorIfPending(_token, _reason, batch);
+    if (published) {
+        NotifyTerminal(_token, batch);
+    }
+    return published;
+}
+
+bool GpuCompletionBackendAccess::PublishReady(
+    const GpuCompletionToken& _token,
+    GpuCompletionPublishBatch _batch
+) noexcept {
+    return _token.PublishReady(_batch.notification_owner_);
+}
+
+bool GpuCompletionBackendAccess::PublishErrorIfPending(
+    const GpuCompletionToken& _token,
+    std::string_view          _reason,
+    GpuCompletionPublishBatch _batch
+) noexcept {
+    return _token.PublishErrorIfPending(
+        _reason, _batch.notification_owner_
+    );
+}
+
+void GpuCompletionBackendAccess::NotifyTerminal(
+    const GpuCompletionToken& _token,
+    GpuCompletionPublishBatch _batch
+) noexcept {
+    _token.NotifyTerminal(_batch.notification_owner_);
+}
+
+void GpuCompletionBackendAccess::PublishReady(
+    std::span<const GpuCompletionToken> _tokens,
+    GpuCompletionPublishBatch           _batch
+) noexcept {
+    for (const GpuCompletionToken& token : _tokens) {
+        (void)PublishReady(token, _batch);
+    }
+}
+
+void GpuCompletionBackendAccess::PublishErrorsIfPending(
+    std::span<const GpuCompletionToken> _tokens,
+    std::string_view                    _reason,
+    GpuCompletionPublishBatch           _batch
+) noexcept {
+    for (const GpuCompletionToken& token : _tokens) {
+        (void)PublishErrorIfPending(token, _reason, _batch);
+    }
+}
+
+void GpuCompletionBackendAccess::PublishOutcome(
+    std::span<const GpuCompletionToken> _tokens,
+    bool                                _gpu_success,
+    std::string_view                    _failure_reason,
+    GpuCompletionPublishBatch           _batch
+) noexcept {
+    if (_gpu_success) {
+        PublishReady(_tokens, _batch);
+    } else {
+        PublishErrorsIfPending(_tokens, _failure_reason, _batch);
+    }
+}
+
+void GpuCompletionBackendAccess::NotifyTerminals(
+    std::span<const GpuCompletionToken> _tokens,
+    GpuCompletionPublishBatch           _batch
+) noexcept {
+    for (const GpuCompletionToken& token : _tokens) {
+        NotifyTerminal(token, _batch);
+    }
+}
+
+void GpuCompletionBackendAccess::ResolveErrorsIfPending(
+    std::span<const GpuCompletionToken> _tokens,
+    std::string_view                    _reason
+) noexcept {
+    const GpuCompletionPublishBatch batch = BeginPublishBatch();
+    PublishErrorsIfPending(_tokens, _reason, batch);
+    NotifyTerminals(_tokens, batch);
+}
+
+GpuCompletionCancellationView::GpuCompletionCancellationView(
+    std::shared_ptr<GpuCompletionCancellationState> _state
+) noexcept :
+    state_(std::move(_state)) {}
+
+bool GpuCompletionCancellationView::Valid() const noexcept {
+    return static_cast<bool>(state_);
+}
+
+bool GpuCompletionCancellationView::IsCancelled() const noexcept {
+    if (!state_) {
+        return false;
+    }
+    std::scoped_lock lock(state_->mutex);
+    return state_->cancelled;
+}
+
+bool GpuCompletionCancellationView::Cancel(
+    std::string_view _reason
+) const noexcept {
+    return PublishCancellation(
+        _reason, GpuCompletionBackendAccess::BeginPublishBatch()
+    );
+}
+
+bool GpuCompletionCancellationView::PublishCancellation(
+    std::string_view          _reason,
+    GpuCompletionPublishBatch _batch
+) const noexcept {
+    if (!state_ || !_batch.Valid()) {
+        return false;
+    }
+
+    std::string reason{};
+    try {
+        reason.assign(_reason);
+    } catch (...) {
+    }
+
+    {
+        std::scoped_lock lock(state_->mutex);
+        if (state_->cancelled || state_->sealed) {
+            return false;
+        }
+        state_->cancelled          = true;
+        state_->reason             = std::move(reason);
+        state_->notification_owner = _batch.notification_owner_;
+        GpuCompletionBackendAccess::PublishErrorsIfPending(
+            state_->tokens, state_->reason, _batch
+        );
+    }
+    return true;
+}
+
+void GpuCompletionCancellationView::NotifyCancellation(
+    GpuCompletionPublishBatch _batch
+) const noexcept {
+    if (!state_ || !_batch.Valid()) {
+        return;
+    }
+
+    Array<GpuCompletionToken> tokens{};
+    {
+        std::scoped_lock lock(state_->mutex);
+        if (state_->notification_owner !=
+            _batch.notification_owner_) {
+            return;
+        }
+        state_->notification_owner = 0;
+        tokens = std::move(state_->tokens);
+    }
+    GpuCompletionBackendAccess::NotifyTerminals(tokens, _batch);
+}
+
+void GpuCompletionCancellationView::NotifyPublishedCancellation()
+    const noexcept {
+    if (!state_) {
+        return;
+    }
+
+    Array<GpuCompletionToken> tokens{};
+    std::uint64_t             notification_owner = 0;
+    {
+        std::scoped_lock lock(state_->mutex);
+        notification_owner = state_->notification_owner;
+        if (notification_owner == 0) {
+            return;
+        }
+        state_->notification_owner = 0;
+        tokens = std::move(state_->tokens);
+    }
+    GpuCompletionBackendAccess::NotifyTerminals(
+        tokens, GpuCompletionPublishBatch(notification_owner)
+    );
+}
+
+GpuCompletionPublishBatch
+GpuCompletionCancellationView::TakePublishedCancellationBatch(
+    Array<GpuCompletionToken>& _tokens
+) const noexcept {
+    if (!state_) {
+        return {};
+    }
+
+    std::uint64_t notification_owner = 0;
+    {
+        std::scoped_lock lock(state_->mutex);
+        state_->sealed     = true;
+        notification_owner = state_->notification_owner;
+        if (notification_owner == 0) {
+            state_->tokens.clear();
+            return {};
+        }
+        state_->notification_owner = 0;
+        _tokens.clear();
+        _tokens.swap(state_->tokens);
+    }
+    return GpuCompletionPublishBatch(notification_owner);
+}
+
+GpuCompletionCancellationDomain::GpuCompletionCancellationDomain() :
+    state_(std::make_shared<GpuCompletionCancellationState>()) {}
+
+GpuCompletionCancellationView
+GpuCompletionCancellationDomain::GetView() const noexcept {
+    return GpuCompletionCancellationView(state_);
+}
+
+bool GpuCompletionCancellationDomain::IsCancelled() const noexcept {
+    return GetView().IsCancelled();
+}
+
+void GpuCompletionCancellationDomain::Register(
+    const GpuCompletionToken& _token
+) const {
+    if (!_token.Valid() || !state_) {
+        return;
+    }
+
+    bool             cancel_now = false;
+    std::string_view reason{};
+    {
+        std::scoped_lock lock(state_->mutex);
+        if (state_->cancelled) {
+            if (state_->notification_owner != 0) {
+                const GpuCompletionPublishBatch deferred_batch(
+                    state_->notification_owner
+                );
+                state_->tokens.emplace_back(_token);
+                GpuCompletionBackendAccess::PublishErrorIfPending(
+                    _token, state_->reason, deferred_batch
+                );
+                return;
+            }
+            cancel_now = true;
+            reason     = state_->reason;
+        } else {
+            state_->tokens.emplace_back(_token);
+        }
+    }
+    if (cancel_now) {
+        GpuCompletionBackendAccess::ResolveErrorIfPending(
+            _token, reason
+        );
+    }
+}
+
+} // namespace Moer::Render

--- a/source/runtime/render/rhi/RHICompletion.h
+++ b/source/runtime/render/rhi/RHICompletion.h
@@ -1,0 +1,270 @@
+#ifndef MOER_ENGINE_RHI_COMPLETION_H
+#define MOER_ENGINE_RHI_COMPLETION_H
+
+#include "RenderAPI.h"
+#include "misc/STL.h"
+
+#include <chrono>
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <optional>
+#include <span>
+#include <string>
+#include <string_view>
+
+namespace Moer::Render {
+
+enum class GpuCompletionStatus : std::uint8_t {
+    Pending = 0,
+    Ready   = 1,
+    Error   = 2,
+};
+
+struct GpuCompletionResult {
+    GpuCompletionStatus status{GpuCompletionStatus::Pending};
+    std::uint64_t       completion_id{0};
+    std::string         name{};
+    std::string         error_reason{};
+};
+
+class GpuCompletionToken;
+
+// Copyable host observation handle for one logical GPU submission. It does
+// not expose a backend fence: native synchronization remains owned by the
+// Submission/Completion pipeline. Pending transitions to Ready or Error once.
+class RENDER_API GpuCompletionFuture {
+    struct SharedState;
+
+public:
+    using Callback = std::function<void(const GpuCompletionResult&)>;
+
+    GpuCompletionFuture() = default;
+
+    [[nodiscard]] bool Valid() const noexcept;
+    [[nodiscard]] bool IsReady() const noexcept;
+    [[nodiscard]] GpuCompletionStatus Status() const noexcept;
+
+    // Blocking on a pending future from an RHI owner thread would deadlock
+    // its own producer, so Wait/WaitFor/Get throw std::logic_error there.
+    // Terminal results remain readable from every thread.
+    void Wait() const;
+    [[nodiscard]] bool WaitFor(std::chrono::nanoseconds _timeout) const;
+
+    template<typename Rep, typename Period>
+    [[nodiscard]] bool WaitFor(
+        std::chrono::duration<Rep, Period> _timeout
+    ) const {
+        return WaitFor(
+            std::chrono::duration_cast<std::chrono::nanoseconds>(_timeout)
+        );
+    }
+
+    [[nodiscard]] GpuCompletionResult Get() const;
+    [[nodiscard]] std::optional<GpuCompletionResult> TryGet() const;
+
+    // A registered callback runs exactly once. Exceptions from user code are
+    // contained by the resolving Completion/rejection owner.
+    void Then(Callback _callback) const;
+
+private:
+    explicit GpuCompletionFuture(
+        std::shared_ptr<SharedState> _state
+    ) noexcept;
+
+    static GpuCompletionFuture Create(
+        std::uint64_t    _completion_id,
+        std::string_view _name
+    );
+
+    bool PublishReady(std::uint64_t _notification_owner) const noexcept;
+    bool PublishError(
+        std::string_view _reason,
+        std::uint64_t    _notification_owner
+    ) const noexcept;
+    void NotifyTerminal(std::uint64_t _notification_owner) const noexcept;
+
+    std::shared_ptr<SharedState> state_{};
+
+    friend class GpuCompletionToken;
+};
+
+// Strong identity retained by CommandList, CmdSubmit and the native
+// Completion packet. Mutation is restricted to GpuCompletionBackendAccess.
+class RENDER_API GpuCompletionToken {
+public:
+    GpuCompletionToken() = default;
+
+    [[nodiscard]] bool Valid() const noexcept;
+    [[nodiscard]] bool IsReady() const noexcept;
+    [[nodiscard]] std::uint64_t Id() const noexcept;
+    [[nodiscard]] const std::string& Name() const noexcept;
+    [[nodiscard]] GpuCompletionFuture GetFuture() const noexcept;
+
+    void Then(GpuCompletionFuture::Callback _callback) const;
+
+private:
+    GpuCompletionToken(
+        std::uint64_t    _id,
+        std::string_view _name
+    );
+
+    bool PublishReady(std::uint64_t _notification_owner) const noexcept;
+    bool PublishErrorIfPending(
+        std::string_view _reason,
+        std::uint64_t    _notification_owner
+    ) const noexcept;
+    void NotifyTerminal(std::uint64_t _notification_owner) const noexcept;
+
+    std::uint64_t                    id_{0};
+    std::shared_ptr<const std::string> name_{};
+    GpuCompletionFuture              future_{};
+
+    friend class CommandList;
+    friend class GpuCompletionBackendAccess;
+};
+
+// Opaque ticket separating terminal-state publication from callback release.
+// A whole backend batch can publish every sibling first, then notify in stable
+// source order without callback-induced Completion deadlocks.
+class RENDER_API GpuCompletionPublishBatch {
+public:
+    GpuCompletionPublishBatch() = default;
+
+    [[nodiscard]] bool Valid() const noexcept {
+        return notification_owner_ != 0;
+    }
+
+private:
+    explicit GpuCompletionPublishBatch(
+        std::uint64_t _notification_owner
+    ) noexcept :
+        notification_owner_(_notification_owner) {}
+
+    std::uint64_t notification_owner_{0};
+
+    friend class GpuCompletionBackendAccess;
+    friend class GpuCompletionCancellationDomain;
+    friend class GpuCompletionCancellationView;
+};
+
+class RENDER_API GpuCompletionBackendAccess final {
+public:
+    [[nodiscard]] static GpuCompletionPublishBatch
+    BeginPublishBatch() noexcept;
+
+    static bool ResolveReady(const GpuCompletionToken& _token) noexcept;
+    static bool ResolveErrorIfPending(
+        const GpuCompletionToken& _token,
+        std::string_view          _reason
+    ) noexcept;
+
+    static bool PublishReady(
+        const GpuCompletionToken& _token,
+        GpuCompletionPublishBatch _batch
+    ) noexcept;
+    static bool PublishErrorIfPending(
+        const GpuCompletionToken& _token,
+        std::string_view          _reason,
+        GpuCompletionPublishBatch _batch
+    ) noexcept;
+    static void NotifyTerminal(
+        const GpuCompletionToken& _token,
+        GpuCompletionPublishBatch _batch
+    ) noexcept;
+
+    static void PublishReady(
+        std::span<const GpuCompletionToken> _tokens,
+        GpuCompletionPublishBatch           _batch
+    ) noexcept;
+    static void PublishErrorsIfPending(
+        std::span<const GpuCompletionToken> _tokens,
+        std::string_view                    _reason,
+        GpuCompletionPublishBatch           _batch
+    ) noexcept;
+    static void PublishOutcome(
+        std::span<const GpuCompletionToken> _tokens,
+        bool                                _gpu_success,
+        std::string_view                    _failure_reason,
+        GpuCompletionPublishBatch           _batch
+    ) noexcept;
+    static void NotifyTerminals(
+        std::span<const GpuCompletionToken> _tokens,
+        GpuCompletionPublishBatch           _batch
+    ) noexcept;
+    static void ResolveErrorsIfPending(
+        std::span<const GpuCompletionToken> _tokens,
+        std::string_view                    _reason
+    ) noexcept;
+};
+
+struct GpuCompletionCancellationState;
+class CommandList;
+
+// Thread-safe shutdown view for one mutable CommandList generation. Cancel
+// publishes Error immediately so Wait/Get are bounded, while callback release
+// stays deferred until the producer reaches a safe ownership boundary.
+class RENDER_API GpuCompletionCancellationView {
+public:
+    GpuCompletionCancellationView() = default;
+
+    [[nodiscard]] bool Valid() const noexcept;
+    [[nodiscard]] bool IsCancelled() const noexcept;
+
+    bool Cancel(
+        std::string_view _reason =
+            "GPU completion generation was cancelled"
+    ) const noexcept;
+    bool PublishCancellation(
+        std::string_view          _reason,
+        GpuCompletionPublishBatch _batch
+    ) const noexcept;
+    void NotifyCancellation(
+        GpuCompletionPublishBatch _batch
+    ) const noexcept;
+    void NotifyPublishedCancellation() const noexcept;
+
+private:
+    [[nodiscard]] GpuCompletionPublishBatch
+    TakePublishedCancellationBatch(
+        Array<GpuCompletionToken>& _tokens
+    ) const noexcept;
+
+    explicit GpuCompletionCancellationView(
+        std::shared_ptr<GpuCompletionCancellationState> _state
+    ) noexcept;
+
+    std::shared_ptr<GpuCompletionCancellationState> state_{};
+
+    friend class GpuCompletionCancellationDomain;
+    friend class CommandList;
+};
+
+class RENDER_API GpuCompletionCancellationDomain {
+public:
+    GpuCompletionCancellationDomain();
+
+    GpuCompletionCancellationDomain(
+        const GpuCompletionCancellationDomain&
+    ) = delete;
+    GpuCompletionCancellationDomain& operator=(
+        const GpuCompletionCancellationDomain&
+    ) = delete;
+    GpuCompletionCancellationDomain(
+        GpuCompletionCancellationDomain&&
+    ) noexcept = default;
+    GpuCompletionCancellationDomain& operator=(
+        GpuCompletionCancellationDomain&&
+    ) noexcept = default;
+
+    [[nodiscard]] GpuCompletionCancellationView GetView() const noexcept;
+    [[nodiscard]] bool IsCancelled() const noexcept;
+    void Register(const GpuCompletionToken& _token) const;
+
+private:
+    std::shared_ptr<GpuCompletionCancellationState> state_{};
+};
+
+} // namespace Moer::Render
+
+#endif

--- a/source/runtime/render/rhi/RHIExecutor.cpp
+++ b/source/runtime/render/rhi/RHIExecutor.cpp
@@ -55,7 +55,9 @@ GraphEventRef MakeCompletedBackendEvent() {
 
 bool SubmitHasWork(const CmdSubmit& _submit) {
     return !_submit.cmds.empty() || !_submit.callbacks.empty() ||
-           !_submit.success_callbacks.empty() || !_submit.query_tokens.empty() ||
+           !_submit.success_callbacks.empty() ||
+           !_submit.gpu_completion_tokens.empty() ||
+           !_submit.query_tokens.empty() ||
            !_submit.wait_events.empty() ||
            !_submit.signal_events.empty() || _submit.b_sync ||
            _submit.b_tick_profiling || _submit.b_delete_resources;
@@ -126,6 +128,18 @@ void FinalizeRejectedSubmissions(
     // Terminalize every query in the rejected batch before invoking any user
     // callback. A callback from an earlier submit is allowed to inspect or
     // wait on a query from a later submit without depending on callback order.
+    const GpuCompletionPublishBatch completion_batch =
+        GpuCompletionBackendAccess::BeginPublishBatch();
+    for (RHIBackendSubmissionBatchEntry& entry : _submits) {
+        const GpuCompletionPublishBatch entry_batch =
+            entry.submit.gpu_completion_publish_batch.Valid() ?
+                entry.submit.gpu_completion_publish_batch :
+                completion_batch;
+        entry.submit.PublishPendingGpuCompletionErrors(
+            _reason, entry_batch
+        );
+    }
+
     const QueryPublishBatch query_batch =
         QueryBackendAccess::BeginPublishBatch();
     for (RHIBackendSubmissionBatchEntry& entry : _submits) {
@@ -142,6 +156,13 @@ void FinalizeRejectedSubmissions(
     // notification so user code can safely wait for the receipt.
     ResolveRejectedPresent(_present);
 
+    for (RHIBackendSubmissionBatchEntry& entry : _submits) {
+        entry.submit.NotifyPendingGpuCompletions(
+            entry.submit.gpu_completion_publish_batch.Valid() ?
+                entry.submit.gpu_completion_publish_batch :
+                completion_batch
+        );
+    }
     for (RHIBackendSubmissionBatchEntry& entry : _submits) {
         entry.submit.NotifyPendingQueries(
             entry.submit.query_publish_batch.Valid() ?
@@ -181,6 +202,8 @@ void FinalizeRejectedSubmissions(
 // before any Query or ordinary cleanup callback is allowed to run.
 void FinalizeRejectedCommandListGroup(
     Array<CommandList>&                         _command_lists,
+    const Array<GpuCompletionCancellationView>&
+                                                _completion_cancellations,
     const Array<QueryCancellationView>&         _query_cancellations,
     const Array<size_t>&                        _materialized_source_indices,
     Array<RHIBackendSubmissionBatchEntry>&&     _submits,
@@ -194,11 +217,40 @@ void FinalizeRejectedCommandListGroup(
         command_list.RejectPendingSignals();
     }
 
-    const bool captured_every_generation =
+    const bool captured_every_completion_generation =
+        _completion_cancellations.size() ==
+        _command_lists.size();
+    const GpuCompletionPublishBatch completion_batch =
+        GpuCompletionBackendAccess::BeginPublishBatch();
+    if (captured_every_completion_generation) {
+        for (const GpuCompletionCancellationView& cancellation :
+             _completion_cancellations) {
+            (void)cancellation.PublishCancellation(
+                _reason, completion_batch
+            );
+        }
+    } else {
+        assert(_submits.empty());
+        for (CommandList& command_list : _command_lists) {
+            (void)command_list.GetGpuCompletionCancellationView().
+                PublishCancellation(_reason, completion_batch);
+        }
+    }
+    for (RHIBackendSubmissionBatchEntry& entry : _submits) {
+        const GpuCompletionPublishBatch entry_batch =
+            entry.submit.gpu_completion_publish_batch.Valid() ?
+                entry.submit.gpu_completion_publish_batch :
+                completion_batch;
+        entry.submit.PublishPendingGpuCompletionErrors(
+            _reason, entry_batch
+        );
+    }
+
+    const bool captured_every_query_generation =
         _query_cancellations.size() == _command_lists.size();
     const QueryPublishBatch query_batch =
         QueryBackendAccess::BeginPublishBatch();
-    if (captured_every_generation) {
+    if (captured_every_query_generation) {
         for (const QueryCancellationView& cancellation :
              _query_cancellations) {
             (void)cancellation.PublishCancellation(_reason, query_batch);
@@ -227,7 +279,28 @@ void FinalizeRejectedCommandListGroup(
     // callbacks so they may synchronously observe or wait for that receipt.
     ResolveRejectedPresent(_present);
 
-    if (captured_every_generation) {
+    if (captured_every_completion_generation) {
+        for (const size_t source_index :
+             _materialized_source_indices) {
+            if (source_index >=
+                _completion_cancellations.size()) {
+                continue;
+            }
+            const GpuCompletionCancellationView& cancellation =
+                _completion_cancellations[source_index];
+            cancellation.NotifyCancellation(completion_batch);
+            cancellation.NotifyPublishedCancellation();
+        }
+    }
+    for (RHIBackendSubmissionBatchEntry& entry : _submits) {
+        entry.submit.NotifyPendingGpuCompletions(
+            entry.submit.gpu_completion_publish_batch.Valid() ?
+                entry.submit.gpu_completion_publish_batch :
+                completion_batch
+        );
+    }
+
+    if (captured_every_query_generation) {
         for (const size_t source_index : _materialized_source_indices) {
             if (source_index >= _query_cancellations.size()) {
                 continue;
@@ -348,11 +421,11 @@ bool RecordingSourceIsTerminal(const RHIRecordingSource& _source) noexcept {
            _source.completion.Status() != ERHIRecordingStatus::Pending;
 }
 
-// Query cancellation is one transaction across the complete recording group.
-// Terminal sources reject their declared signal values first, then all query
-// states publish Error, and only then may callbacks run. Mutable/opaque sources
-// publish Error so Wait/Get remain bounded during shutdown, but defer callback
-// notification until their CommandList can safely reject its internal signals.
+// Future cancellation is one transaction across the complete recording group.
+// Terminal sources reject their declared signal values first, then all
+// Completion/Query states publish Error, and only then may callbacks run.
+// Mutable sources publish Error so Wait/Get remain bounded during shutdown,
+// but defer callback notification until their CommandList is safely owned.
 void TerminalizeRecordingSourceQueries(
     Array<RHIRecordingSource>& _sources,
     std::string_view            _reason
@@ -385,6 +458,13 @@ void TerminalizeRecordingSourceQueries(
         }
     }
 
+    const GpuCompletionPublishBatch completion_batch =
+        GpuCompletionBackendAccess::BeginPublishBatch();
+    for (RHIRecordingSource& source : _sources) {
+        (void)source.gpu_completion_cancellation.
+            PublishCancellation(_reason, completion_batch);
+    }
+
     const QueryPublishBatch query_batch =
         QueryBackendAccess::BeginPublishBatch();
     for (RHIRecordingSource& source : _sources) {
@@ -396,6 +476,10 @@ void TerminalizeRecordingSourceQueries(
         for (size_t source_index = 0; source_index < _sources.size();
              ++source_index) {
             if (terminal_snapshot[source_index] != 0) {
+                _sources[source_index].
+                    gpu_completion_cancellation.NotifyCancellation(
+                        completion_batch
+                    );
                 _sources[source_index].query_cancellation.NotifyCancellation(
                     query_batch
                 );
@@ -679,10 +763,22 @@ public:
             );
         }
 
-        // D3D12 intentionally exposes timestamp Query as unsupported in
-        // Phase 17A. Publish the complete legacy batch before the first queue
-        // can retire so an earlier Query callback may safely wait on a later
-        // source; each native Completion packet still owns callback release.
+        // The legacy D3D12 backend has no reliable per-submit fault outcome.
+        // Fail closed for host completion futures rather than reporting a
+        // false Ready. Publish the whole batch before the first queue can
+        // retire; each native Completion packet still owns callback release.
+        const GpuCompletionPublishBatch completion_batch =
+            GpuCompletionBackendAccess::BeginPublishBatch();
+        for (RHIBackendSubmissionBatchEntry& entry : _batch.submits) {
+            if (!entry.submit.gpu_completion_tokens.empty()) {
+                entry.submit.PublishPendingGpuCompletionErrors(
+                    "D3D12 GPU completion futures are unsupported",
+                    completion_batch
+                );
+            }
+        }
+
+        // D3D12 intentionally exposes timestamp Query as unsupported.
         const QueryPublishBatch query_batch =
             QueryBackendAccess::BeginPublishBatch();
         for (RHIBackendSubmissionBatchEntry& entry : _batch.submits) {
@@ -805,6 +901,8 @@ private:
         _submit.cmds.clear();
         _submit.callbacks.clear();
         _submit.success_callbacks.clear();
+        _submit.gpu_completion_tokens.clear();
+        _submit.gpu_completion_publish_batch = {};
         _submit.query_tokens.clear();
         _submit.query_publish_batch = {};
         _submit.cached_args.clear();
@@ -1164,13 +1262,18 @@ void RHIExecutor::Submit(
     RHIPresentRequest*   _present
 ) {
     Array<RHIBackendSubmissionBatchEntry> submits{};
+    Array<GpuCompletionCancellationView> completion_cancellations{};
     Array<QueryCancellationView> query_cancellations{};
     Array<size_t> materialized_source_indices{};
     try {
         submits.reserve(_command_lists.size());
+        completion_cancellations.reserve(_command_lists.size());
         query_cancellations.reserve(_command_lists.size());
         materialized_source_indices.reserve(_command_lists.size());
         for (CommandList& command_list : _command_lists) {
+            completion_cancellations.emplace_back(
+                command_list.GetGpuCompletionCancellationView()
+            );
             query_cancellations.emplace_back(
                 command_list.GetQueryCancellationView()
             );
@@ -1185,6 +1288,7 @@ void RHIExecutor::Submit(
         }
         FinalizeRejectedCommandListGroup(
             _command_lists,
+            completion_cancellations,
             query_cancellations,
             materialized_source_indices,
             std::move(submits),
@@ -1199,6 +1303,7 @@ void RHIExecutor::Submit(
         }
         FinalizeRejectedCommandListGroup(
             _command_lists,
+            completion_cancellations,
             query_cancellations,
             materialized_source_indices,
             std::move(submits),
@@ -1219,6 +1324,7 @@ void RHIExecutor::Submit(
     if (!group_valid) {
         FinalizeRejectedCommandListGroup(
             _command_lists,
+            completion_cancellations,
             query_cancellations,
             materialized_source_indices,
             std::move(submits),
@@ -1250,6 +1356,7 @@ void RHIExecutor::Submit(
         }
         FinalizeRejectedCommandListGroup(
             _command_lists,
+            completion_cancellations,
             query_cancellations,
             materialized_source_indices,
             std::move(submits),
@@ -1264,6 +1371,7 @@ void RHIExecutor::Submit(
         }
         FinalizeRejectedCommandListGroup(
             _command_lists,
+            completion_cancellations,
             query_cancellations,
             materialized_source_indices,
             std::move(submits),
@@ -1323,6 +1431,9 @@ void RHIExecutor::SubmitRecording(
         // Publication seals the current CommandList generation. Never trust a
         // caller-supplied valid view: it may belong to an earlier Submit() and
         // would leave the actual producer generation Pending on shutdown.
+        source.gpu_completion_cancellation =
+            source.command_list->
+                GetGpuCompletionCancellationView();
         source.query_cancellation =
             source.command_list->GetQueryCancellationView();
     }

--- a/source/runtime/render/rhi/RHIExecutor.h
+++ b/source/runtime/render/rhi/RHIExecutor.h
@@ -46,8 +46,10 @@ struct RHIRecordingSource {
     RHIRecordingGateView         commit{};
     RHIRecordingSubmitMetadata   submit_metadata{};
     // Stable, thread-safe cancellation seam for the CommandList generation
-    // being recorded. Shutdown may cancel pending query futures through this
-    // view without reading or destroying a producer-owned command stream.
+    // being recorded. Shutdown may cancel pending host futures through these
+    // views without reading or destroying a producer-owned command stream.
+    GpuCompletionCancellationView
+                                gpu_completion_cancellation{};
     QueryCancellationView        query_cancellation{};
 };
 

--- a/source/runtime/render/rhi/d3d12/D3D12Device.cpp
+++ b/source/runtime/render/rhi/d3d12/D3D12Device.cpp
@@ -1675,10 +1675,35 @@ WaitEvent D3D12GraphicsCommandQueue::Execute(CmdSubmit&& _submit) {
     });
 
     // Build the complete retirement packet before crossing the native submit
-    // boundary. Query capability failure is published by the Completion owner
-    // after the GPU fence and submit signals, but before ordinary callbacks.
-    // This keeps user Query callbacks outside RHIExecutor's publication gate
-    // and preserves the same terminal ordering as native query backends.
+    // boundary. The legacy backend fails GPU completion futures closed as an
+    // unsupported capability, but the native Completion owner still releases
+    // their callbacks after the fence and submit signals.
+    Array<GpuCompletionToken> gpu_completion_tokens =
+        _submit.gpu_completion_tokens;
+    Array<std::function<void()>> gpu_completion_callbacks{};
+    if (!gpu_completion_tokens.empty()) {
+        const GpuCompletionPublishBatch completion_batch =
+            _submit.gpu_completion_publish_batch.Valid() ?
+                _submit.gpu_completion_publish_batch :
+                GpuCompletionBackendAccess::BeginPublishBatch();
+        _submit.gpu_completion_publish_batch = completion_batch;
+        GpuCompletionBackendAccess::PublishErrorsIfPending(
+            gpu_completion_tokens,
+            "D3D12 GPU completion futures are unsupported",
+            completion_batch
+        );
+        gpu_completion_callbacks.emplace_back(
+            [tokens = std::move(gpu_completion_tokens),
+             completion_batch] {
+                GpuCompletionBackendAccess::NotifyTerminals(
+                    tokens, completion_batch
+                );
+            }
+        );
+    }
+
+    // Query capability failure follows the same publication/notification
+    // split and remains ordered before ordinary callbacks.
     Array<QueryToken> query_tokens = _submit.query_tokens;
     Array<std::function<void()>> query_completion_callbacks{};
     if (!query_tokens.empty()) {
@@ -1719,6 +1744,13 @@ WaitEvent D3D12GraphicsCommandQueue::Execute(CmdSubmit&& _submit) {
     );
     for (const SignalEvent& event : _submit.signal_events) {
         retirement_events.emplace_back(event, next_fence_value, false);
+    }
+    if (!gpu_completion_callbacks.empty()) {
+        retirement_events.emplace_back(
+            std::move(gpu_completion_callbacks),
+            next_fence_value,
+            true
+        );
     }
     if (!query_completion_callbacks.empty()) {
         retirement_events.emplace_back(
@@ -1777,6 +1809,8 @@ WaitEvent D3D12GraphicsCommandQueue::Execute(CmdSubmit&& _submit) {
     event_queue.splice(event_queue.end(), retirement_events);
     _submit.callbacks.clear();
     _submit.success_callbacks.clear();
+    _submit.gpu_completion_tokens.clear();
+    _submit.gpu_completion_publish_batch = {};
     _submit.query_tokens.clear();
     _submit.query_publish_batch = {};
     _submit.signal_events.clear();

--- a/source/runtime/render/rhi/vulkan/VulkanQueue.cpp
+++ b/source/runtime/render/rhi/vulkan/VulkanQueue.cpp
@@ -716,10 +716,20 @@ void VulkanBatchCompletionGroup::Arrive(
         ready    = std::move(participants);
     }
 
-    // Every participant has already published its Fence and Query terminal
-    // state. Release Query callbacks first across the whole batch, then the
-    // two ordinary callback tiers, and keep resources alive until all user
-    // code has returned. The last arriver is itself a Completion owner.
+    // Every participant has already published its Fence, Completion and Query
+    // terminal state. Release Future callbacks across the whole batch before
+    // either ordinary tier, and keep resources alive until user code returns.
+    // The last arriver is itself a Completion owner.
+    for (auto& slot : ready) {
+        Participant& participant = *slot;
+        if (!participant.gpu_completion_tokens.empty()) {
+            GpuCompletionBackendAccess::NotifyTerminals(
+                participant.gpu_completion_tokens,
+                participant.gpu_completion_batch
+            );
+            participant.gpu_completion_tokens.clear();
+        }
+    }
     for (auto& slot : ready) {
         Participant& participant = *slot;
         if (!participant.query_tokens.empty()) {
@@ -4941,7 +4951,20 @@ static void TerminalizeRejectedSubmit(
         VulkanOperationResult{EVulkanOperationStatus::Rejected, _result}
     );
     FinalizeRejectedBindlessUpdates(_submit);
-    _submit.RejectPendingQueries(_context);
+    const GpuCompletionPublishBatch completion_batch =
+        _submit.gpu_completion_publish_batch.Valid() ?
+            _submit.gpu_completion_publish_batch :
+            GpuCompletionBackendAccess::BeginPublishBatch();
+    const QueryPublishBatch query_batch =
+        _submit.query_publish_batch.Valid() ?
+            _submit.query_publish_batch :
+            QueryBackendAccess::BeginPublishBatch();
+    _submit.PublishPendingGpuCompletionErrors(
+        _context, completion_batch
+    );
+    _submit.PublishPendingQueryErrors(_context, query_batch);
+    _submit.NotifyPendingGpuCompletions(completion_batch);
+    _submit.NotifyPendingQueries(query_batch);
 
     // Completion callbacks are the only user code retained on a rejected
     // packet. Success callbacks are intentionally destroyed without running.
@@ -9071,6 +9094,20 @@ void VkCommandQueue::CompletionThreadMain() {
                         query_failure_reason, query_batch
                     );
 
+                    const GpuCompletionPublishBatch
+                        gpu_completion_batch =
+                            _batch.submit.
+                                    gpu_completion_publish_batch.Valid() ?
+                                _batch.submit.
+                                    gpu_completion_publish_batch :
+                                GpuCompletionBackendAccess::
+                                    BeginPublishBatch();
+                    _batch.submit.PublishPendingGpuCompletionOutcome(
+                        batch_gpu_success,
+                        "Vulkan submission did not reach successful GPU completion",
+                        gpu_completion_batch
+                    );
+
                     bool recycle_batch =
                         batch_gpu_success && !vk_device.IsFaulted();
                     if (recycle_batch) {
@@ -9098,6 +9135,12 @@ void VkCommandQueue::CompletionThreadMain() {
                         grouped_completion{};
                     if (_batch.batch_completion.Valid()) {
                         grouped_completion.emplace();
+                        grouped_completion->gpu_completion_tokens =
+                            std::move(
+                                _batch.submit.gpu_completion_tokens
+                            );
+                        grouped_completion->gpu_completion_batch =
+                            gpu_completion_batch;
                         grouped_completion->query_tokens =
                             std::move(_batch.submit.query_tokens);
                         grouped_completion->query_batch = query_batch;
@@ -9112,6 +9155,8 @@ void VkCommandQueue::CompletionThreadMain() {
                             batch_gpu_success;
                         grouped_completion->release_safe =
                             batch_release_safe;
+                        _batch.submit.gpu_completion_publish_batch =
+                            {};
                         _batch.submit.query_publish_batch = {};
                     } else {
                         callbacks =
@@ -9127,6 +9172,9 @@ void VkCommandQueue::CompletionThreadMain() {
                     _batch.submit.debug_label.clear();
 
                     if (!grouped_completion.has_value()) {
+                        _batch.submit.NotifyPendingGpuCompletions(
+                            gpu_completion_batch
+                        );
                         _batch.submit.NotifyPendingQueries(query_batch);
                         for (auto& allocator : _batch.allocators.submitted) {
                             allocator->NotifyTimestampQueriesAfterGpuCompletion(
@@ -9651,6 +9699,7 @@ VkCopyQueue::TranslateForRuntime(CmdSubmit&& _evt) noexcept {
             !recorded->submit.signal_events.empty() ||
             !recorded->submit.callbacks.empty() ||
             !recorded->submit.success_callbacks.empty() ||
+            !recorded->submit.gpu_completion_tokens.empty() ||
             !recorded->submit.query_tokens.empty() ||
             recorded->submit.b_sync ||
             recorded->submit.b_tick_profiling ||
@@ -10287,6 +10336,20 @@ void VkCopyQueue::ExecuteThread() {
                         query_failure_reason, query_batch
                     );
 
+                    const GpuCompletionPublishBatch
+                        gpu_completion_batch =
+                            _batch.submit.
+                                    gpu_completion_publish_batch.Valid() ?
+                                _batch.submit.
+                                    gpu_completion_publish_batch :
+                                GpuCompletionBackendAccess::
+                                    BeginPublishBatch();
+                    _batch.submit.PublishPendingGpuCompletionOutcome(
+                        batch_gpu_success,
+                        "Vulkan Copy submission did not reach successful GPU completion",
+                        gpu_completion_batch
+                    );
+
                     bool recycle_batch =
                         batch_gpu_success && !device.IsFaulted();
                     if (recycle_batch) {
@@ -10314,6 +10377,12 @@ void VkCopyQueue::ExecuteThread() {
                         grouped_completion{};
                     if (_batch.batch_completion.Valid()) {
                         grouped_completion.emplace();
+                        grouped_completion->gpu_completion_tokens =
+                            std::move(
+                                _batch.submit.gpu_completion_tokens
+                            );
+                        grouped_completion->gpu_completion_batch =
+                            gpu_completion_batch;
                         grouped_completion->query_tokens =
                             std::move(_batch.submit.query_tokens);
                         grouped_completion->query_batch = query_batch;
@@ -10327,6 +10396,8 @@ void VkCopyQueue::ExecuteThread() {
                         grouped_completion->gpu_success  =
                             batch_gpu_success;
                         grouped_completion->release_safe = false;
+                        _batch.submit.gpu_completion_publish_batch =
+                            {};
                         _batch.submit.query_publish_batch = {};
                     } else {
                         callbacks =
@@ -10342,6 +10413,9 @@ void VkCopyQueue::ExecuteThread() {
                     _batch.submit.debug_label.clear();
 
                     if (!grouped_completion.has_value()) {
+                        _batch.submit.NotifyPendingGpuCompletions(
+                            gpu_completion_batch
+                        );
                         _batch.submit.NotifyPendingQueries(query_batch);
                         for (auto& allocator : _batch.allocators.submitted) {
                             allocator->NotifyTimestampQueriesAfterGpuCompletion(

--- a/source/runtime/render/rhi/vulkan/VulkanQueue.h
+++ b/source/runtime/render/rhi/vulkan/VulkanQueue.h
@@ -295,6 +295,8 @@ struct VulkanDeferredReleaseBatch {
 class VulkanBatchCompletionGroup final {
 public:
     struct Participant {
+        Array<GpuCompletionToken>         gpu_completion_tokens;
+        GpuCompletionPublishBatch         gpu_completion_batch{};
         Array<QueryToken>                query_tokens;
         QueryPublishBatch                query_batch{};
         Array<std::function<void()>>     callbacks;

--- a/source/runtime/render/rhi/vulkan/VulkanSubmissionExecutor.cpp
+++ b/source/runtime/render/rhi/vulkan/VulkanSubmissionExecutor.cpp
@@ -223,6 +223,7 @@ GraphEventRef MakeCompletedEvent() {
 
 bool SubmitHasSideEffects(const CmdSubmit& _submit) {
     return !_submit.callbacks.empty() || !_submit.success_callbacks.empty() ||
+           !_submit.gpu_completion_tokens.empty() ||
            !_submit.query_tokens.empty() ||
            !_submit.wait_events.empty() || !_submit.signal_events.empty() || _submit.b_sync ||
            _submit.b_tick_profiling || _submit.b_delete_resources;
@@ -817,6 +818,11 @@ MaterializeMultiSegmentBatch(RHIBackendSubmissionBatch& _batch, const RHIQueueTo
         CmdSubmit& last_submit =
             executable_sources[materialization.executable_begin + materialization.executable_count - 1]
                 .submit;
+        last_submit.gpu_completion_tokens =
+            std::move(source_entry.submit.gpu_completion_tokens);
+        last_submit.gpu_completion_publish_batch =
+            source_entry.submit.gpu_completion_publish_batch;
+        source_entry.submit.gpu_completion_publish_batch = {};
         for (const SignalEvent& signal : source_entry.submit.signal_events) {
             last_submit.signal_events.emplace_back(signal);
         }
@@ -1141,10 +1147,13 @@ void VulkanSubmissionExecutor::Completion::Wait() {
 VulkanSubmissionExecutor::BatchRejectionPublication::
     BatchRejectionPublication(RHIBackendSubmissionBatch& _batch) {
     sources.reserve(_batch.submits.size());
+    const GpuCompletionPublishBatch common_completion_batch =
+        GpuCompletionBackendAccess::BeginPublishBatch();
     const QueryPublishBatch common_query_batch =
         QueryBackendAccess::BeginPublishBatch();
 
     size_t executable_count = 0;
+    bool   has_completion   = false;
     bool   has_query        = false;
     if (_batch.topology.source_plans.size() == _batch.submits.size()) {
         for (size_t source_index = 0;
@@ -1155,13 +1164,18 @@ VulkanSubmissionExecutor::BatchRejectionPublication::
                 continue;
             }
             ++executable_count;
+            has_completion =
+                has_completion ||
+                !_batch.submits[source_index].submit.
+                    gpu_completion_tokens.empty();
             has_query =
                 has_query ||
                 !_batch.submits[source_index].submit.query_tokens.empty();
         }
     }
     std::shared_ptr<VulkanBatchCompletionGroup> completion_group{};
-    if (executable_count > 1 && has_query) {
+    if (executable_count > 1 &&
+        (has_completion || has_query)) {
         completion_group =
             std::make_shared<VulkanBatchCompletionGroup>(
                 executable_count
@@ -1186,6 +1200,16 @@ VulkanSubmissionExecutor::BatchRejectionPublication::
             }
         }
 
+        source.gpu_completion_tokens =
+            entry.submit.gpu_completion_tokens;
+        if (!source.gpu_completion_tokens.empty()) {
+            source.gpu_completion_batch =
+                entry.submit.gpu_completion_publish_batch.Valid() ?
+                    entry.submit.gpu_completion_publish_batch :
+                    common_completion_batch;
+            entry.submit.gpu_completion_publish_batch =
+                source.gpu_completion_batch;
+        }
         source.query_tokens = entry.submit.query_tokens;
         if (!source.query_tokens.empty()) {
             source.query_batch =
@@ -1271,6 +1295,21 @@ void VulkanSubmissionExecutor::BatchRejectionPublication::PublishSuffix(
         _reason.empty() ?
             "Vulkan submission suffix was rejected before GPU completion" :
             _reason;
+    for (size_t source_index = begin;
+         source_index < sources.size();
+         ++source_index) {
+        RejectionSourceSnapshot& source = sources[source_index];
+        if (source.terminalized) {
+            continue;
+        }
+        if (source.gpu_completion_batch.Valid()) {
+            GpuCompletionBackendAccess::PublishErrorsIfPending(
+                source.gpu_completion_tokens,
+                reason,
+                source.gpu_completion_batch
+            );
+        }
+    }
     for (size_t source_index = begin;
          source_index < sources.size();
          ++source_index) {
@@ -2374,6 +2413,21 @@ void VulkanSubmissionExecutor::RejectBatch(
         // Queue rejection must not add an exact-value rejection after a hard
         // failure has already been published for the whole fence.
         submit.signal_events.clear();
+    }
+
+    const GpuCompletionPublishBatch completion_batch =
+        GpuCompletionBackendAccess::BeginPublishBatch();
+    for (size_t source_index = first_source;
+         source_index < _batch.submits.size();
+         ++source_index) {
+        CmdSubmit& submit = _batch.submits[source_index].submit;
+        const GpuCompletionPublishBatch source_completion_batch =
+            submit.gpu_completion_publish_batch.Valid() ?
+                submit.gpu_completion_publish_batch :
+                completion_batch;
+        submit.PublishPendingGpuCompletionErrors(
+            _reason, source_completion_batch
+        );
     }
 
     const QueryPublishBatch query_batch =

--- a/source/runtime/render/rhi/vulkan/VulkanSubmissionExecutor.h
+++ b/source/runtime/render/rhi/vulkan/VulkanSubmissionExecutor.h
@@ -87,6 +87,8 @@ private:
 
     struct RejectionSourceSnapshot {
         Array<RejectionSignalHandle> signals{};
+        Array<GpuCompletionToken>     gpu_completion_tokens{};
+        GpuCompletionPublishBatch     gpu_completion_batch{};
         Array<QueryToken>            query_tokens{};
         QueryPublishBatch            query_batch{};
         VulkanBatchCompletionTicket  completion_ticket{};

--- a/source/test/CMakeLists.txt
+++ b/source/test/CMakeLists.txt
@@ -90,6 +90,14 @@ target_link_libraries(${test_target}
 set_target_properties(${test_target} PROPERTIES FOLDER ${moer_test_folder})
 add_test(NAME RHIQueryContract COMMAND $<TARGET_FILE:${test_target}>)
 
+set(test_target TestRHIGpuCompletion)
+add_executable(${test_target} "RHIGpuCompletionContractTest.cpp")
+target_link_libraries(${test_target}
+    PRIVATE Moer::Render
+)
+set_target_properties(${test_target} PROPERTIES FOLDER ${moer_test_folder})
+add_test(NAME RHIGpuCompletionContract COMMAND $<TARGET_FILE:${test_target}>)
+
 set(test_target TestExternalCpuJoin)
 add_executable(${test_target} "ExternalCpuJoinTest.cpp")
 target_link_libraries(${test_target}

--- a/source/test/RHIExecutorRecordingHandoffTest.cpp
+++ b/source/test/RHIExecutorRecordingHandoffTest.cpp
@@ -270,6 +270,107 @@ bool FrontendQueryRejectionTerminalizesBeforeOrdinaryCallbacks() {
             );
 }
 
+bool FrontendCompletionRejectionIsOneTerminalTransaction() {
+    std::atomic<int>  stage{0};
+    std::atomic<int>  completion_callbacks{0};
+    std::atomic<int>  query_callbacks{0};
+    std::atomic<int>  ordinary_callbacks{0};
+    std::atomic<int>  success_callbacks{0};
+    std::atomic<bool> signal_ordered{false};
+    std::atomic<bool> completion_ordered{false};
+    std::atomic<bool> query_ordered{false};
+    std::atomic<bool> ordinary_ordered{false};
+
+    RecordingFenceProbe signal(
+        {},
+        [&] {
+            signal_ordered.store(
+                stage.load(std::memory_order_acquire) == 0,
+                std::memory_order_release
+            );
+            stage.store(1, std::memory_order_release);
+        }
+    );
+    CommandList commands(EQueueType::Graphics);
+    commands.Signal(&signal, 15);
+    const GpuCompletionFuture completion =
+        commands.TrackGpuCompletion("FrontendRejectedCompletion");
+    QueryToken query =
+        commands.BeginTimestampQuery("FrontendRejectedPeerQuery");
+    commands.EndTimestampQuery(query);
+    const QueryFuture query_future = query.GetFuture();
+
+    completion.Then([&](const GpuCompletionResult& _result) {
+        const auto peer = query_future.TryGet();
+        completion_ordered.store(
+            _result.status == GpuCompletionStatus::Error &&
+                signal.IsRejected(15) &&
+                peer.has_value() &&
+                peer->status == QueryStatus::Error &&
+                stage.load(std::memory_order_acquire) == 1,
+            std::memory_order_release
+        );
+        stage.store(2, std::memory_order_release);
+        completion_callbacks.fetch_add(1, std::memory_order_release);
+    });
+    query_future.Then([&](const QueryResult& _result) {
+        query_ordered.store(
+            _result.status == QueryStatus::Error &&
+                completion.Status() == GpuCompletionStatus::Error &&
+                stage.load(std::memory_order_acquire) == 2,
+            std::memory_order_release
+        );
+        stage.store(3, std::memory_order_release);
+        query_callbacks.fetch_add(1, std::memory_order_release);
+    });
+    commands.AddCallback([&] {
+        ordinary_ordered.store(
+            stage.load(std::memory_order_acquire) == 3,
+            std::memory_order_release
+        );
+        stage.store(4, std::memory_order_release);
+        ordinary_callbacks.fetch_add(1, std::memory_order_release);
+    });
+    commands.AddSuccessCallback([&] {
+        success_callbacks.fetch_add(1, std::memory_order_release);
+    });
+
+    RHIExecutor::Get().Submit(
+        EQueueType::Ignore,
+        commands.Submit(),
+        ERHIExecSubmitFlags::None
+    );
+
+    return Expect(
+               signal_ordered.load(std::memory_order_acquire),
+               "frontend rejection did not reject Signal first"
+           ) &&
+           Expect(
+               completion_ordered.load(std::memory_order_acquire) &&
+                   completion_callbacks.load(
+                       std::memory_order_acquire
+                   ) == 1,
+               "Completion callback observed a partial terminal batch"
+           ) &&
+           Expect(
+               query_ordered.load(std::memory_order_acquire) &&
+                   query_callbacks.load(std::memory_order_acquire) == 1,
+               "Query callback did not follow Completion notification"
+           ) &&
+           Expect(
+               ordinary_ordered.load(std::memory_order_acquire) &&
+                   ordinary_callbacks.load(
+                       std::memory_order_acquire
+                   ) == 1 &&
+                   stage.load(std::memory_order_acquire) == 4,
+               "ordinary callback ran before Future notifications"
+           ) &&
+           Expect(
+               success_callbacks.load(std::memory_order_acquire) == 0,
+               "frontend rejection invoked a success-only callback"
+           );
+}
+
 bool FrontendPresentRejectionPublishesBatchBeforeReceipt() {
     PresentReceiptRef receipt = std::make_shared<PresentReceipt>();
     std::atomic<bool> signal_observed_pending_receipt{false};
@@ -901,6 +1002,131 @@ bool RecordingPreflightFailureTerminalizesEveryQueryGeneration() {
     return okay;
 }
 
+bool RecordingPreflightFailureTerminalizesEveryCompletionGeneration() {
+    RHIExecutor::StartUp();
+
+    auto first_list =
+        Moer::MakeShared<CommandList>(EQueueType::Graphics);
+    auto middle_list =
+        Moer::MakeShared<CommandList>(EQueueType::Graphics);
+    auto last_list =
+        Moer::MakeShared<CommandList>(EQueueType::Graphics);
+    const std::array<Moer::SharedPtr<CommandList>, 3> command_lists{
+        first_list,
+        middle_list,
+        last_list,
+    };
+
+    std::array<GpuCompletionFuture, 3> completion_futures{};
+    std::array<std::atomic<int>, 3> completion_callbacks{};
+    std::array<std::atomic<int>, 3> ordinary_callbacks{};
+    std::array<std::atomic<int>, 3> success_callbacks{};
+    for (size_t index = 0; index < command_lists.size(); ++index) {
+        completion_futures[index] =
+            command_lists[index]->TrackGpuCompletion(
+                "RecordingPreflightCompletion"
+            );
+        completion_futures[index].Then(
+            [&, index](const GpuCompletionResult& _result) {
+                if (_result.status == GpuCompletionStatus::Error) {
+                    completion_callbacks[index].fetch_add(
+                        1, std::memory_order_release
+                    );
+                }
+            }
+        );
+        command_lists[index]->AddCallback([&, index] {
+            ordinary_callbacks[index].fetch_add(
+                1, std::memory_order_release
+            );
+        });
+        command_lists[index]->AddSuccessCallback([&, index] {
+            success_callbacks[index].fetch_add(
+                1, std::memory_order_release
+            );
+        });
+    }
+
+    std::atomic<bool> first_observed_last_terminal{false};
+    completion_futures[0].Then(
+        [&](const GpuCompletionResult& _result) {
+            first_observed_last_terminal.store(
+                _result.status == GpuCompletionStatus::Error &&
+                    completion_futures[2].WaitFor(100ms) &&
+                    completion_futures[2].Status() ==
+                        GpuCompletionStatus::Error,
+                std::memory_order_release
+            );
+        }
+    );
+
+    QueryToken unclosed =
+        middle_list->BeginTimestampQuery(
+            "CompletionPreflightTrigger"
+        );
+    const QueryFuture trigger_future = unclosed.GetFuture();
+
+    Moer::Array<RHIRecordingSource> sources{};
+    for (const Moer::SharedPtr<CommandList>& command_list :
+         command_lists) {
+        sources.emplace_back(RHIRecordingSource{
+            .command_list = command_list,
+            .completion   = RHIRecordingGate::Create(true),
+        });
+    }
+    RHIExecutor::Get().SubmitRecording(
+        std::move(sources),
+        ERHIExecSubmitFlags::None
+    );
+    RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
+
+    bool okay = true;
+    for (size_t index = 0;
+         index < completion_futures.size();
+         ++index) {
+        okay &= Expect(
+            completion_futures[index].WaitFor(100ms) &&
+                completion_futures[index].Status() ==
+                    GpuCompletionStatus::Error,
+            "recording preflight failure left a completion Pending"
+        );
+        okay &= Expect(
+            completion_callbacks[index].load(
+                std::memory_order_acquire
+            ) == 1,
+            "recording preflight failure did not notify a completion once"
+        );
+        okay &= Expect(
+            ordinary_callbacks[index].load(
+                std::memory_order_acquire
+            ) == 1,
+            "recording preflight failure did not drain ordinary cleanup"
+        );
+        okay &= Expect(
+            success_callbacks[index].load(
+                std::memory_order_acquire
+            ) == 0,
+            "recording preflight failure invoked success cleanup"
+        );
+        okay &= Expect(
+            command_lists[index]->IsEmpty(),
+            "recording preflight failure left a completion generation"
+        );
+    }
+    okay &= Expect(
+        first_observed_last_terminal.load(std::memory_order_acquire),
+        "an earlier completion callback observed a later source Pending"
+    );
+    okay &= Expect(
+        trigger_future.WaitFor(100ms) &&
+            trigger_future.Status() == QueryStatus::Error,
+        "completion preflight trigger query did not terminalize"
+    );
+
+    RHIExecutor::ShutDown();
+    return okay;
+}
+
 bool SubmitRecordingRefreshesAStaleQueryCancellationView() {
     RHIExecutor::StartUp();
 
@@ -970,6 +1196,76 @@ bool SubmitRecordingRefreshesAStaleQueryCancellationView() {
     okay &= Expect(
         command_list->IsEmpty(),
         "stale cancellation-view shutdown left the current CommandList generation undrained"
+    );
+    return okay;
+}
+
+bool SubmitRecordingRefreshesAStaleCompletionCancellationView() {
+    RHIExecutor::StartUp();
+
+    auto command_list =
+        Moer::MakeShared<CommandList>(EQueueType::Graphics);
+    GpuCompletionCancellationView stale_cancellation =
+        command_list->GetGpuCompletionCancellationView();
+    {
+        CmdSubmit prior_generation = command_list->Submit();
+    }
+
+    const GpuCompletionFuture current_future =
+        command_list->TrackGpuCompletion(
+            "CurrentCompletionGeneration"
+        );
+    std::atomic<int> current_callbacks{0};
+    std::atomic<bool> callback_observed_error{false};
+    current_future.Then([&](const GpuCompletionResult& _result) {
+        callback_observed_error.store(
+            _result.status == GpuCompletionStatus::Error,
+            std::memory_order_release
+        );
+        current_callbacks.fetch_add(1, std::memory_order_release);
+    });
+
+    auto pending_gate = RHIRecordingGate::Create();
+    Moer::Array<RHIRecordingSource> sources{};
+    sources.emplace_back(RHIRecordingSource{
+        .command_list = command_list,
+        .completion   = pending_gate,
+        .gpu_completion_cancellation = stale_cancellation,
+    });
+    RHIExecutor::Get().SubmitRecording(
+        std::move(sources),
+        ERHIExecSubmitFlags::None
+    );
+    RHIExecutor::ShutDown();
+
+    bool okay = Expect(
+                    stale_cancellation.Valid() &&
+                        !stale_cancellation.IsCancelled(),
+                    "SubmitRecording cancelled a stale completion generation"
+                ) &&
+                Expect(
+                    current_future.WaitFor(100ms) &&
+                        current_future.Status() ==
+                            GpuCompletionStatus::Error,
+                    "shutdown left the current completion generation Pending"
+                ) &&
+                Expect(
+                    current_callbacks.load(
+                        std::memory_order_acquire
+                    ) == 0,
+                    "opaque shutdown released a completion callback early"
+                );
+
+    pending_gate->Signal();
+    (void)command_list->DrainOrdinaryCallbacksForRejection();
+    okay &= Expect(
+        current_callbacks.load(std::memory_order_acquire) == 1 &&
+            callback_observed_error.load(std::memory_order_acquire),
+        "safe producer ownership did not release completion callback once"
+    );
+    okay &= Expect(
+        command_list->IsEmpty(),
+        "stale completion-view shutdown left its generation undrained"
     );
     return okay;
 }
@@ -1736,12 +2032,15 @@ bool ShutdownDrainsAcceptedReadyWork() {
 int main() {
     if (!CommandListSignalTracksNativeAcceptanceAndRejection() ||
         !FrontendQueryRejectionTerminalizesBeforeOrdinaryCallbacks() ||
+        !FrontendCompletionRejectionIsOneTerminalTransaction() ||
         !FrontendPresentRejectionPublishesBatchBeforeReceipt() ||
         !DeferredOpaqueCancellationTicketSurvivesSubmit() ||
         !DirectCommandListGroupPreflightRejectsEverySource() ||
         !DirectCommandListGroupMaterializationFailureRejectsPrefixAndSuffix() ||
         !RecordingPreflightFailureTerminalizesEveryQueryGeneration() ||
+        !RecordingPreflightFailureTerminalizesEveryCompletionGeneration() ||
         !SubmitRecordingRefreshesAStaleQueryCancellationView() ||
+        !SubmitRecordingRefreshesAStaleCompletionCancellationView() ||
         !PerSourceGatesPreserveFifo() ||
         !ReadyWorkUsesStableExecutorOwnerAndCannotBeOvertaken() ||
         !FailedGateRejectsOnlyItsGroupAndPreservesFifo() ||

--- a/source/test/RHIGpuCompletionContractTest.cpp
+++ b/source/test/RHIGpuCompletionContractTest.cpp
@@ -1,0 +1,713 @@
+#include "rhi/RHICommand.h"
+#include "rhi/RHICompletion.h"
+#include "rhi/RHIImpl.h"
+#include "rhi/RHIThreadOwnership.h"
+
+#include <atomic>
+#include <chrono>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <thread>
+#include <type_traits>
+#include <vector>
+
+namespace {
+
+using namespace Moer::Render;
+using namespace std::chrono_literals;
+
+void Expect(bool _condition, std::string_view _message) {
+    if (!_condition) {
+        throw std::runtime_error(std::string(_message));
+    }
+}
+
+template<typename TException, typename TCallback>
+void ExpectThrows(TCallback&& _callback, std::string_view _message) {
+    bool threw_expected = false;
+    try {
+        _callback();
+    } catch (const TException&) {
+        threw_expected = true;
+    }
+    Expect(threw_expected, _message);
+}
+
+class CompletionFenceProbe final : public Fence {
+public:
+    uint64_t GetValue() const override {
+        return 0;
+    }
+
+    void Wait(uint64_t) override {}
+
+    void MarkSubmitted(uint64_t _value) override {
+        submitted_value.store(_value, std::memory_order_release);
+    }
+
+    bool WaitSubmitted(
+        uint64_t,
+        const std::atomic_bool* = nullptr,
+        EQueueType              = EQueueType::Ignore,
+        Moer::uint32            = 0
+    ) override {
+        return false;
+    }
+
+    bool IsRejected(uint64_t _value) const override {
+        return rejected_value.load(std::memory_order_acquire) == _value;
+    }
+
+    void Reject(uint64_t _value) noexcept override {
+        rejected_value.store(_value, std::memory_order_release);
+    }
+
+private:
+    std::atomic<uint64_t> submitted_value{0};
+    std::atomic<uint64_t> rejected_value{0};
+};
+
+void InvalidFutureIsBoundedAndExplicit() {
+    GpuCompletionFuture invalid{};
+    Expect(!invalid.Valid(), "default completion future was valid");
+    Expect(!invalid.IsReady(), "invalid completion future reported Ready");
+    Expect(
+        invalid.Status() == GpuCompletionStatus::Error,
+        "invalid completion future did not fail closed"
+    );
+    invalid.Wait();
+    Expect(
+        !invalid.WaitFor(1ms),
+        "invalid completion future unexpectedly satisfied WaitFor"
+    );
+    const auto try_result = invalid.TryGet();
+    Expect(
+        try_result.has_value() &&
+            try_result->status == GpuCompletionStatus::Error,
+        "invalid completion TryGet did not return an Error"
+    );
+    Expect(
+        invalid.Get().status == GpuCompletionStatus::Error,
+        "invalid completion Get did not return an Error"
+    );
+}
+
+void FutureIsThreadSafeOneShotAndContainsCallbackExceptions() {
+    CommandList list(EQueueType::Graphics);
+    const GpuCompletionFuture future =
+        list.TrackGpuCompletion("ConcurrentCompletion");
+    CmdSubmit submit = list.Submit();
+    Expect(
+        submit.gpu_completion_tokens.size() == 1,
+        "Submit lost its completion token"
+    );
+    const GpuCompletionToken token =
+        submit.gpu_completion_tokens.front();
+
+    Expect(future.Valid(), "recorded completion returned an invalid future");
+    Expect(!future.IsReady(), "new completion future was already terminal");
+    Expect(
+        future.Status() == GpuCompletionStatus::Pending,
+        "new completion future was not Pending"
+    );
+    Expect(
+        !future.WaitFor(1ms),
+        "pending completion unexpectedly satisfied WaitFor"
+    );
+    Expect(
+        !future.TryGet().has_value(),
+        "pending completion unexpectedly had a result"
+    );
+
+    constexpr int callback_thread_count = 32;
+    std::atomic<int>  callback_count{0};
+    std::atomic<bool> start{false};
+    std::vector<std::thread> threads{};
+    threads.reserve(callback_thread_count);
+    for (int index = 0; index < callback_thread_count; ++index) {
+        threads.emplace_back([&, future] {
+            while (!start.load(std::memory_order_acquire)) {
+                std::this_thread::yield();
+            }
+            future.Then([&](const GpuCompletionResult& _result) {
+                Expect(
+                    _result.status == GpuCompletionStatus::Ready,
+                    "concurrent callback observed a non-Ready result"
+                );
+                callback_count.fetch_add(1, std::memory_order_relaxed);
+            });
+        });
+    }
+    future.Then([](const GpuCompletionResult&) {
+        throw std::runtime_error("client callback failure");
+    });
+    start.store(true, std::memory_order_release);
+    for (std::thread& thread : threads) {
+        thread.join();
+    }
+
+    Expect(
+        GpuCompletionBackendAccess::ResolveReady(token),
+        "first completion did not win the one-shot transition"
+    );
+    future.Wait();
+    Expect(future.WaitFor(1ms), "terminal future did not satisfy WaitFor");
+    Expect(
+        callback_count.load(std::memory_order_relaxed) ==
+            callback_thread_count,
+        "pre-terminal callbacks were not invoked exactly once"
+    );
+
+    future.Then([&](const GpuCompletionResult& _result) {
+        Expect(
+            _result.status == GpuCompletionStatus::Ready,
+            "post-terminal callback observed the wrong status"
+        );
+        callback_count.fetch_add(1, std::memory_order_relaxed);
+        throw std::runtime_error("post-terminal callback failure");
+    });
+    Expect(
+        callback_count.load(std::memory_order_relaxed) ==
+            callback_thread_count + 1,
+        "post-terminal callback was not invoked synchronously once"
+    );
+    Expect(
+        !GpuCompletionBackendAccess::ResolveErrorIfPending(
+            token, "late rejection"
+        ),
+        "a second terminal transition overwrote Ready"
+    );
+
+    const GpuCompletionResult result = future.Get();
+    Expect(
+        result.status == GpuCompletionStatus::Ready,
+        "Get lost Ready status"
+    );
+    Expect(
+        result.completion_id == token.Id(),
+        "Get lost completion identity"
+    );
+    Expect(
+        result.name == "ConcurrentCompletion",
+        "Get lost completion name"
+    );
+    Expect(
+        result.error_reason.empty(),
+        "Ready result retained an error reason"
+    );
+    submit.gpu_completion_tokens.clear();
+}
+
+void ReadyAndErrorRaceHasExactlyOneWinner() {
+    constexpr int race_iterations = 128;
+    for (int iteration = 0; iteration < race_iterations; ++iteration) {
+        CommandList list(EQueueType::Graphics);
+        const GpuCompletionFuture future =
+            list.TrackGpuCompletion("ResolveRace");
+        CmdSubmit submit = list.Submit();
+        const GpuCompletionToken token =
+            submit.gpu_completion_tokens.front();
+
+        std::atomic<int>  callback_count{0};
+        std::atomic<bool> start{false};
+        bool              ready_won = false;
+        bool              error_won = false;
+        future.Then([&](const GpuCompletionResult& _result) {
+            Expect(
+                _result.status == GpuCompletionStatus::Ready ||
+                    _result.status == GpuCompletionStatus::Error,
+                "resolve race callback observed Pending"
+            );
+            callback_count.fetch_add(1, std::memory_order_relaxed);
+        });
+
+        std::thread ready_thread([&] {
+            while (!start.load(std::memory_order_acquire)) {
+                std::this_thread::yield();
+            }
+            ready_won =
+                GpuCompletionBackendAccess::ResolveReady(token);
+        });
+        std::thread error_thread([&] {
+            while (!start.load(std::memory_order_acquire)) {
+                std::this_thread::yield();
+            }
+            error_won =
+                GpuCompletionBackendAccess::ResolveErrorIfPending(
+                    token, "injected completion failure"
+                );
+        });
+        start.store(true, std::memory_order_release);
+        ready_thread.join();
+        error_thread.join();
+
+        Expect(
+            ready_won != error_won,
+            "Ready/Error race did not have exactly one winner"
+        );
+        Expect(future.IsReady(), "race left the future Pending");
+        Expect(
+            callback_count.load(std::memory_order_relaxed) == 1,
+            "race invoked its callback more or less than once"
+        );
+        Expect(
+            future.Get().status ==
+                (ready_won ? GpuCompletionStatus::Ready :
+                             GpuCompletionStatus::Error),
+            "race result disagrees with its winner"
+        );
+        submit.gpu_completion_tokens.clear();
+    }
+}
+
+void BatchPublishesEveryPeerBeforeNotification() {
+    CommandList list(EQueueType::Graphics);
+    const GpuCompletionFuture first =
+        list.TrackGpuCompletion("BatchFirst");
+    const GpuCompletionFuture second =
+        list.TrackGpuCompletion("BatchSecond");
+    CmdSubmit submit = list.Submit();
+
+    std::atomic<int>  callback_count{0};
+    std::atomic_bool  first_observed_second_ready{false};
+    first.Then([&](const GpuCompletionResult& _result) {
+        const auto peer = second.TryGet();
+        first_observed_second_ready.store(
+            _result.status == GpuCompletionStatus::Ready &&
+                peer.has_value() &&
+                peer->status == GpuCompletionStatus::Ready,
+            std::memory_order_release
+        );
+        callback_count.fetch_add(1, std::memory_order_relaxed);
+    });
+    second.Then([&](const GpuCompletionResult& _result) {
+        if (_result.status == GpuCompletionStatus::Ready) {
+            callback_count.fetch_add(1, std::memory_order_relaxed);
+        }
+    });
+
+    const GpuCompletionPublishBatch batch =
+        GpuCompletionBackendAccess::BeginPublishBatch();
+    GpuCompletionBackendAccess::PublishReady(
+        submit.gpu_completion_tokens, batch
+    );
+    Expect(
+        first.IsReady() && second.IsReady(),
+        "batch publication did not make every peer terminal"
+    );
+    Expect(
+        callback_count.load(std::memory_order_relaxed) == 0,
+        "batch publication released callbacks before notification"
+    );
+    GpuCompletionBackendAccess::NotifyTerminals(
+        submit.gpu_completion_tokens, batch
+    );
+    Expect(
+        first_observed_second_ready.load(std::memory_order_acquire) &&
+            callback_count.load(std::memory_order_relaxed) == 2,
+        "batch notification exposed a partially published peer set"
+    );
+    submit.gpu_completion_tokens.clear();
+}
+
+void LosingBatchCannotStealNotificationOwnership() {
+    CommandList list(EQueueType::Graphics);
+    const GpuCompletionFuture future =
+        list.TrackGpuCompletion("WinningTicket");
+    CmdSubmit submit = list.Submit();
+    const GpuCompletionToken token =
+        submit.gpu_completion_tokens.front();
+    std::atomic<int> callback_count{0};
+    future.Then([&](const GpuCompletionResult&) {
+        callback_count.fetch_add(1, std::memory_order_relaxed);
+    });
+
+    const GpuCompletionPublishBatch winner =
+        GpuCompletionBackendAccess::BeginPublishBatch();
+    const GpuCompletionPublishBatch loser =
+        GpuCompletionBackendAccess::BeginPublishBatch();
+    Expect(
+        GpuCompletionBackendAccess::PublishReady(token, winner),
+        "winning batch could not publish Ready"
+    );
+    Expect(
+        !GpuCompletionBackendAccess::PublishErrorIfPending(
+            token, "losing batch", loser
+        ),
+        "losing batch overwrote Ready"
+    );
+    GpuCompletionBackendAccess::NotifyTerminal(token, loser);
+    Expect(
+        callback_count.load(std::memory_order_relaxed) == 0,
+        "losing batch stole notification ownership"
+    );
+    GpuCompletionBackendAccess::NotifyTerminal(token, winner);
+    Expect(
+        callback_count.load(std::memory_order_relaxed) == 1,
+        "winning batch did not release its callback"
+    );
+    submit.gpu_completion_tokens.clear();
+}
+
+void PublicationWakesWaitersBeforeDeferredCallbacks() {
+    CommandList list(EQueueType::Graphics);
+    const GpuCompletionFuture future =
+        list.TrackGpuCompletion("DeferredNotification");
+    CmdSubmit submit = list.Submit();
+    const GpuCompletionToken token =
+        submit.gpu_completion_tokens.front();
+
+    std::atomic_bool callback_called{false};
+    std::atomic_bool waiter_finished{false};
+    future.Then([&](const GpuCompletionResult&) {
+        callback_called.store(true, std::memory_order_release);
+    });
+    std::thread waiter([&] {
+        future.Wait();
+        waiter_finished.store(true, std::memory_order_release);
+    });
+
+    const GpuCompletionPublishBatch batch =
+        GpuCompletionBackendAccess::BeginPublishBatch();
+    Expect(
+        GpuCompletionBackendAccess::PublishReady(token, batch),
+        "deferred publication could not publish Ready"
+    );
+    const auto deadline = std::chrono::steady_clock::now() + 500ms;
+    while (!waiter_finished.load(std::memory_order_acquire) &&
+           std::chrono::steady_clock::now() < deadline) {
+        std::this_thread::sleep_for(1ms);
+    }
+    const bool waiter_woke_before_notification =
+        waiter_finished.load(std::memory_order_acquire);
+    const bool callback_ran_before_notification =
+        callback_called.load(std::memory_order_acquire);
+    GpuCompletionBackendAccess::NotifyTerminal(token, batch);
+    waiter.join();
+    Expect(
+        waiter_woke_before_notification,
+        "publication did not wake a waiter"
+    );
+    Expect(
+        !callback_ran_before_notification,
+        "publication released callbacks before explicit notification"
+    );
+    Expect(
+        callback_called.load(std::memory_order_acquire),
+        "explicit notification did not release the callback"
+    );
+    submit.gpu_completion_tokens.clear();
+}
+
+void OwnerThreadsCannotBlockOnPendingCompletion() {
+    CommandList list(EQueueType::Graphics);
+    const GpuCompletionFuture future =
+        list.TrackGpuCompletion("OwnerThreadWaitGuard");
+    CmdSubmit submit = list.Submit();
+    const GpuCompletionToken token =
+        submit.gpu_completion_tokens.front();
+
+    {
+        RHIThreadRoleScope completion_owner(
+            ERHIThreadRole::Completion
+        );
+        ExpectThrows<std::logic_error>(
+            [&] { future.Wait(); },
+            "Completion owner could block in Wait on Pending"
+        );
+        ExpectThrows<std::logic_error>(
+            [&] { (void)future.WaitFor(1ms); },
+            "Completion owner could block in WaitFor on Pending"
+        );
+        ExpectThrows<std::logic_error>(
+            [&] { (void)future.Get(); },
+            "Completion owner could block in Get on Pending"
+        );
+        Expect(
+            !future.TryGet().has_value(),
+            "owner-thread TryGet changed a Pending completion"
+        );
+    }
+
+    Expect(
+        GpuCompletionBackendAccess::ResolveReady(token),
+        "owner-thread guard token could not resolve"
+    );
+    {
+        RHIThreadRoleScope submission_owner(
+            ERHIThreadRole::Submission
+        );
+        future.Wait();
+        Expect(
+            future.WaitFor(1ms) &&
+                future.Get().status ==
+                    GpuCompletionStatus::Ready,
+            "owner thread could not inspect a terminal completion"
+        );
+    }
+    submit.gpu_completion_tokens.clear();
+}
+
+void DestructionAndReplacementAreTerminalAndOrdered() {
+    GpuCompletionFuture list_destruction{};
+    {
+        CommandList list(EQueueType::Graphics);
+        list_destruction =
+            list.TrackGpuCompletion("ListDestruction");
+    }
+    Expect(
+        list_destruction.Get().status == GpuCompletionStatus::Error,
+        "CommandList destruction left a completion Pending"
+    );
+
+    GpuCompletionFuture submit_destruction{};
+    {
+        CommandList list(EQueueType::Graphics);
+        submit_destruction =
+            list.TrackGpuCompletion("SubmitDestruction");
+        [[maybe_unused]] CmdSubmit abandoned = list.Submit();
+    }
+    Expect(
+        submit_destruction.Get().status == GpuCompletionStatus::Error,
+        "CmdSubmit destruction left a completion Pending"
+    );
+
+    GpuCompletionFuture replaced{};
+    CmdSubmit destination =
+        CommandList(EQueueType::Graphics).Submit();
+    {
+        CommandList list(EQueueType::Graphics);
+        replaced = list.TrackGpuCompletion("ReplacedSubmit");
+        destination = list.Submit();
+    }
+    destination = CommandList(EQueueType::Graphics).Submit();
+    Expect(
+        replaced.Get().status == GpuCompletionStatus::Error,
+        "CmdSubmit replacement left a completion Pending"
+    );
+}
+
+void SignalAndQueryPublishBeforeCompletionCallbacks() {
+    CompletionFenceProbe fence{};
+    std::atomic_bool callback_observed_signal{false};
+    std::atomic_bool callback_observed_query{false};
+    GpuCompletionFuture completion{};
+    QueryFuture query{};
+    {
+        CommandList list(EQueueType::Graphics);
+        list.Signal(&fence, 41);
+        QueryToken query_token =
+            list.BeginTimestampQuery("CompletionPeerQuery");
+        list.EndTimestampQuery(query_token);
+        query = query_token.GetFuture();
+        completion =
+            list.TrackGpuCompletion("DestructionOrdering");
+        completion.Then([&](const GpuCompletionResult& _result) {
+            callback_observed_signal.store(
+                _result.status == GpuCompletionStatus::Error &&
+                    fence.IsRejected(41),
+                std::memory_order_release
+            );
+            const auto query_result = query.TryGet();
+            callback_observed_query.store(
+                query_result.has_value() &&
+                    query_result->status == QueryStatus::Error,
+                std::memory_order_release
+            );
+        });
+        [[maybe_unused]] CmdSubmit submit = list.Submit();
+    }
+    Expect(
+        completion.Get().status == GpuCompletionStatus::Error &&
+            callback_observed_signal.load(std::memory_order_acquire) &&
+            callback_observed_query.load(std::memory_order_acquire),
+        "completion callback observed a partial terminal transaction"
+    );
+}
+
+void CompletionOnlySubmitIsExecutableWork() {
+    CommandList list(EQueueType::Graphics);
+    const GpuCompletionFuture future =
+        list.TrackGpuCompletion("EmptyBoundary");
+    Expect(
+        !list.IsEmpty(),
+        "completion-only CommandList was classified empty"
+    );
+    CmdSubmit submit = list.Submit();
+    Expect(
+        submit.cmds.empty() &&
+            submit.gpu_completion_tokens.size() == 1 &&
+            submit.segments.size() == 1,
+        "completion-only submit lost its executable boundary"
+    );
+    Expect(
+        submit.segments.front().begin == 0 &&
+            submit.segments.front().end == 0,
+        "completion-only submit emitted a non-empty command range"
+    );
+    submit.RejectPendingGpuCompletions("test cleanup");
+    Expect(
+        future.Get().status == GpuCompletionStatus::Error,
+        "completion-only cleanup did not terminalize its future"
+    );
+}
+
+void CancellationIsDeferredAndGenerationScoped() {
+    CommandList sealed_list(EQueueType::Graphics);
+    const GpuCompletionCancellationView sealed_view =
+        sealed_list.GetGpuCompletionCancellationView();
+    const GpuCompletionFuture sealed_future =
+        sealed_list.TrackGpuCompletion("SealedGeneration");
+    CmdSubmit sealed_submit = sealed_list.Submit();
+    Expect(
+        !sealed_view.Cancel("late stale-view cancellation"),
+        "a stale cancellation view mutated a submitted generation"
+    );
+    Expect(
+        sealed_future.Status() == GpuCompletionStatus::Pending,
+        "stale cancellation changed a submitted completion"
+    );
+    Expect(
+        GpuCompletionBackendAccess::ResolveReady(
+            sealed_submit.gpu_completion_tokens.front()
+        ),
+        "submitted generation could not resolve after stale cancellation"
+    );
+    sealed_submit.gpu_completion_tokens.clear();
+
+    CommandList list(EQueueType::Graphics);
+    const GpuCompletionCancellationView first_generation =
+        list.GetGpuCompletionCancellationView();
+    const GpuCompletionFuture existing =
+        list.TrackGpuCompletion("BeforeCancel");
+    std::atomic<int> callback_count{0};
+    existing.Then([&](const GpuCompletionResult&) {
+        callback_count.fetch_add(1, std::memory_order_relaxed);
+    });
+
+    Expect(
+        first_generation.Cancel("recording source shutdown"),
+        "first cancellation did not win"
+    );
+    Expect(
+        !first_generation.Cancel("duplicate shutdown"),
+        "cancellation domain was not one-shot"
+    );
+    Expect(
+        existing.Get().status == GpuCompletionStatus::Error,
+        "cancellation did not publish Error immediately"
+    );
+    Expect(
+        callback_count.load(std::memory_order_relaxed) == 0,
+        "opaque cancellation released a callback on the producer"
+    );
+
+    const GpuCompletionFuture late =
+        list.TrackGpuCompletion("AfterCancel");
+    Expect(
+        late.Status() == GpuCompletionStatus::Error,
+        "registration after cancellation did not fail immediately"
+    );
+    CmdSubmit cancelled_submit = list.Submit();
+    Expect(
+        callback_count.load(std::memory_order_relaxed) == 0,
+        "Submit released a deferred callback before Completion ownership"
+    );
+    cancelled_submit.RejectPendingGpuCompletions("cancelled cleanup");
+    Expect(
+        callback_count.load(std::memory_order_relaxed) == 1,
+        "CmdSubmit did not release the deferred cancellation callback"
+    );
+
+    const GpuCompletionCancellationView second_generation =
+        list.GetGpuCompletionCancellationView();
+    Expect(
+        second_generation.Valid() &&
+            !second_generation.IsCancelled() &&
+            first_generation.IsCancelled(),
+        "Submit did not rotate cancellation generations"
+    );
+    const GpuCompletionFuture next =
+        list.TrackGpuCompletion("NextGeneration");
+    Expect(
+        next.Status() == GpuCompletionStatus::Pending,
+        "old cancellation leaked into the next generation"
+    );
+    Expect(
+        second_generation.Cancel("next shutdown"),
+        "next generation could not cancel"
+    );
+    Expect(
+        next.Get().status == GpuCompletionStatus::Error,
+        "next cancellation left its future Pending"
+    );
+}
+
+void CallbacksMayReleaseTheirLastHandles() {
+    CommandList list(EQueueType::Graphics);
+    GpuCompletionFuture future =
+        list.TrackGpuCompletion("SelfRelease");
+    CmdSubmit submit = list.Submit();
+    std::atomic_bool callback_called{false};
+    future.Then([&](const GpuCompletionResult& _result) {
+        Expect(
+            _result.status == GpuCompletionStatus::Ready,
+            "self-release callback observed the wrong status"
+        );
+        future = {};
+        callback_called.store(true, std::memory_order_release);
+    });
+    Expect(
+        GpuCompletionBackendAccess::ResolveReady(
+            submit.gpu_completion_tokens.front()
+        ),
+        "self-release token could not resolve"
+    );
+    Expect(
+        callback_called.load(std::memory_order_acquire) &&
+            !future.Valid(),
+        "callback could not release its last public handle"
+    );
+    submit.gpu_completion_tokens.clear();
+}
+
+} // namespace
+
+int main() {
+    static_assert(std::is_copy_constructible_v<GpuCompletionFuture>);
+    static_assert(std::is_copy_constructible_v<GpuCompletionToken>);
+    static_assert(
+        std::is_nothrow_copy_constructible_v<GpuCompletionToken>
+    );
+    static_assert(
+        !std::is_copy_constructible_v<GpuCompletionCancellationDomain>
+    );
+    static_assert(
+        std::is_copy_constructible_v<GpuCompletionCancellationView>
+    );
+
+    try {
+        InvalidFutureIsBoundedAndExplicit();
+        FutureIsThreadSafeOneShotAndContainsCallbackExceptions();
+        ReadyAndErrorRaceHasExactlyOneWinner();
+        BatchPublishesEveryPeerBeforeNotification();
+        LosingBatchCannotStealNotificationOwnership();
+        PublicationWakesWaitersBeforeDeferredCallbacks();
+        OwnerThreadsCannotBlockOnPendingCompletion();
+        DestructionAndReplacementAreTerminalAndOrdered();
+        SignalAndQueryPublishBeforeCompletionCallbacks();
+        CompletionOnlySubmitIsExecutableWork();
+        CancellationIsDeferredAndGenerationScoped();
+        CallbacksMayReleaseTheirLastHandles();
+    } catch (const std::exception& exception) {
+        std::cerr
+            << "RHIGpuCompletionContract: "
+            << exception.what() << '\n';
+        return 1;
+    }
+
+    std::cout << "RHIGpuCompletionContract: all checks passed\n";
+    return 0;
+}

--- a/source/test/RHIParallelRecordVulkanTest.cpp
+++ b/source/test/RHIParallelRecordVulkanTest.cpp
@@ -4663,7 +4663,6 @@ void RunMultiSegmentCopyRoundTrip() {
     batch.emplace_back(EQueueType::Graphics, std::move(submit));
     RHIExecutor::Get().Submit(std::move(batch), ERHIExecSubmitFlags::FlushGPU);
     RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
-
     if (readback != expected) {
         throw std::runtime_error("multi-segment Copy source GPU readback mismatch");
     }
@@ -4887,8 +4886,11 @@ void RunMultiSegmentPrefixSubmitSuffixTranslateFailure() {
     FenceRef                       later_done  = device.CreateFence();
     std::atomic<uint32>            source_callbacks{0};
     std::atomic<uint32>            source_success_callbacks{0};
+    std::atomic<uint32>            source_completion_callbacks{0};
     std::atomic<uint32>            later_callbacks{0};
     std::atomic<uint32>            later_success_callbacks{0};
+    std::atomic<uint32>            later_completion_callbacks{0};
+    std::atomic<uint32>            completion_callback_errors{0};
     std::binary_semaphore          prefix_translated{0};
     SourceSubmissionCapture        source_capture(async_queue_scope);
     ScopedSourceSubmissionObserver source_observer(source_capture);
@@ -4898,6 +4900,10 @@ void RunMultiSegmentPrefixSubmitSuffixTranslateFailure() {
 
     CommandList source(EQueueType::Graphics);
     source.SetResourceStateOwnership(ERHIResourceStateOwnership::Explicit);
+    GpuCompletionFuture source_completion =
+        source.TrackGpuCompletion(
+            "Phase19AMultiSegmentTailCompletion"
+        );
     source.AddCustomCommand(
         MakeUnique<TranslateProbeCommand>(&prefix_translated, EQueueType::Graphics),
         "MultiSegmentHardFailureAcceptedPrefix"
@@ -4905,7 +4911,30 @@ void RunMultiSegmentPrefixSubmitSuffixTranslateFailure() {
     source.AddCustomCommand(
         MakeUnique<ThrowingTranslateProbeCommand>(true), "MultiSegmentHardFailureThrowingSuffix"
     );
+    source_completion.Then(
+        [&](const GpuCompletionResult& _result) {
+            if (_result.status != GpuCompletionStatus::Error ||
+                _result.error_reason.empty() ||
+                GetCurrentRHIThreadRole() !=
+                    ERHIThreadRole::Completion ||
+                !ResourceCast(source_done.Get())->IsFailed()) {
+                completion_callback_errors.fetch_add(
+                    1, std::memory_order_relaxed
+                );
+            }
+            source_completion_callbacks.fetch_add(
+                1, std::memory_order_release
+            );
+        }
+    );
     source.AddCallback([&] {
+        if (source_completion_callbacks.load(
+                std::memory_order_acquire
+            ) != 1) {
+            completion_callback_errors.fetch_add(
+                1, std::memory_order_relaxed
+            );
+        }
         source_callbacks.fetch_add(1, std::memory_order_relaxed);
     });
     source.AddSuccessCallback([&] {
@@ -4927,6 +4956,8 @@ void RunMultiSegmentPrefixSubmitSuffixTranslateFailure() {
     RHIExecutor::Get().Submit(std::move(batch), ERHIExecSubmitFlags::FlushGPU);
     RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
 
+    const GpuCompletionResult source_completion_result =
+        source_completion.Get();
     if (!prefix_translated.try_acquire()) {
         throw std::runtime_error("multi-segment hard failure did not Translate the prefix");
     }
@@ -4934,7 +4965,16 @@ void RunMultiSegmentPrefixSubmitSuffixTranslateFailure() {
         throw std::runtime_error("multi-segment hard failure did not fail the tail external signal");
     }
     if (source_callbacks.load(std::memory_order_acquire) != 1 ||
-        source_success_callbacks.load(std::memory_order_acquire) != 0) {
+        source_success_callbacks.load(std::memory_order_acquire) != 0 ||
+        source_completion_callbacks.load(
+            std::memory_order_acquire
+        ) != 1 ||
+        source_completion_result.status !=
+            GpuCompletionStatus::Error ||
+        source_completion_result.error_reason.empty() ||
+        completion_callback_errors.load(
+            std::memory_order_acquire
+        ) != 0) {
         throw std::runtime_error("multi-segment hard failure did not aggregate source callbacks exactly once"
         );
     }
@@ -4959,7 +4999,32 @@ void RunMultiSegmentPrefixSubmitSuffixTranslateFailure() {
     }
 
     CommandList later(EQueueType::Graphics);
+    GpuCompletionFuture later_completion =
+        later.TrackGpuCompletion(
+            "Phase19AHardLatchCompletion"
+        );
+    later_completion.Then(
+        [&](const GpuCompletionResult& _result) {
+            if (_result.status != GpuCompletionStatus::Error ||
+                GetCurrentRHIThreadRole() !=
+                    ERHIThreadRole::Completion) {
+                completion_callback_errors.fetch_add(
+                    1, std::memory_order_relaxed
+                );
+            }
+            later_completion_callbacks.fetch_add(
+                1, std::memory_order_release
+            );
+        }
+    );
     later.AddCallback([&] {
+        if (later_completion_callbacks.load(
+                std::memory_order_acquire
+            ) != 1) {
+            completion_callback_errors.fetch_add(
+                1, std::memory_order_relaxed
+            );
+        }
         later_callbacks.fetch_add(1, std::memory_order_relaxed);
     });
     later.AddSuccessCallback([&] {
@@ -4969,12 +5034,22 @@ void RunMultiSegmentPrefixSubmitSuffixTranslateFailure() {
     later_submit.Signal(later_done.Get(), 1);
     RHIExecutor::Get().Submit(EQueueType::Graphics, std::move(later_submit), ERHIExecSubmitFlags::FlushGPU);
     RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
+    const GpuCompletionResult later_completion_result =
+        later_completion.Get();
 
     if (!ResourceCast(later_done.Get())->IsFailed() || ResourceCast(later_done.Get())->IsRejected(1)) {
         throw std::runtime_error("multi-segment hard failure did not latch a later batch");
     }
     if (later_callbacks.load(std::memory_order_acquire) != 1 ||
-        later_success_callbacks.load(std::memory_order_acquire) != 0) {
+        later_success_callbacks.load(std::memory_order_acquire) != 0 ||
+        later_completion_callbacks.load(
+            std::memory_order_acquire
+        ) != 1 ||
+        later_completion_result.status !=
+            GpuCompletionStatus::Error ||
+        completion_callback_errors.load(
+            std::memory_order_acquire
+        ) != 0) {
         throw std::runtime_error("multi-segment hard latch did not retire later callbacks exactly once");
     }
 
@@ -4982,8 +5057,14 @@ void RunMultiSegmentPrefixSubmitSuffixTranslateFailure() {
     if (native_capture.Count() != 1 || source_capture.Count() != 1 ||
         source_callbacks.load(std::memory_order_acquire) != 1 ||
         source_success_callbacks.load(std::memory_order_acquire) != 0 ||
+        source_completion_callbacks.load(
+            std::memory_order_acquire
+        ) != 1 ||
         later_callbacks.load(std::memory_order_acquire) != 1 ||
-        later_success_callbacks.load(std::memory_order_acquire) != 0) {
+        later_success_callbacks.load(std::memory_order_acquire) != 0 ||
+        later_completion_callbacks.load(
+            std::memory_order_acquire
+        ) != 1) {
         throw std::runtime_error("multi-segment hard failure replayed submission or callback retirement");
     }
 
@@ -4991,7 +5072,7 @@ void RunMultiSegmentPrefixSubmitSuffixTranslateFailure() {
              "source=1 segments=2 queues=Graphics,Graphics "
              "prefix_translated=true source_submitted=0:0/2 "
              "native_accepted_prefix=1 native_owner=Submission "
-             "callbacks=ordinary1_success0 signal=failed "
+             "completion=Error callbacks=ordinary1_success0 signal=failed "
              "later_callbacks=ordinary1_success0 hard_latch=later_batch_failed replay=0");
 }
 
@@ -11098,9 +11179,16 @@ void RunTimestampQueryCompletionOwnership() {
 
     std::atomic<uint32> callback_count{0};
     std::atomic<uint32> callback_errors{0};
+    std::atomic<uint32> completion_callback_count{0};
+    std::atomic<uint32> ordinary_callback_count{0};
+    std::atomic<uint32> callback_stage{0};
     FenceRef            query_done = device.CreateFence();
 
     CommandList commands(EQueueType::Graphics);
+    GpuCompletionFuture gpu_completion =
+        commands.TrackGpuCompletion(
+            "Phase19AGraphicsCompletion"
+        );
     commands.CopyFrom(
         OwnedBytes(values),
         source->GetView(),
@@ -11109,6 +11197,24 @@ void RunTimestampQueryCompletionOwnership() {
 
     QueryToken  query  = commands.BeginTimestampQuery("Phase17ATimestamp");
     QueryFuture future = query.GetFuture();
+    gpu_completion.Then([&](const GpuCompletionResult& _result) {
+        const auto query_result = future.TryGet();
+        if (GetCurrentRHIThreadRole() !=
+                ERHIThreadRole::Completion ||
+            _result.status != GpuCompletionStatus::Ready ||
+            query_done.Get()->GetValue() < 1 ||
+            query_done.Get()->IsRejected(1) ||
+            ResourceCast(query_done.Get())->IsFailed() ||
+            !query_result.has_value() ||
+            query_result->status != QueryStatus::Ready ||
+            callback_stage.load(std::memory_order_acquire) != 0) {
+            callback_errors.fetch_add(1, std::memory_order_relaxed);
+        }
+        callback_stage.store(1, std::memory_order_release);
+        completion_callback_count.fetch_add(
+            1, std::memory_order_release
+        );
+    });
     future.Then([&](const QueryResult& _result) {
         if (GetCurrentRHIThreadRole() != ERHIThreadRole::Completion ||
             _result.status != QueryStatus::Ready ||
@@ -11116,9 +11222,13 @@ void RunTimestampQueryCompletionOwnership() {
             std::get_if<TimestampQueryResult>(&_result.payload) == nullptr ||
             query_done.Get()->GetValue() < 1 ||
             query_done.Get()->IsRejected(1) ||
-            ResourceCast(query_done.Get())->IsFailed()) {
+            ResourceCast(query_done.Get())->IsFailed() ||
+            gpu_completion.Status() !=
+                GpuCompletionStatus::Ready ||
+            callback_stage.load(std::memory_order_acquire) != 1) {
             callback_errors.fetch_add(1, std::memory_order_relaxed);
         }
+        callback_stage.store(2, std::memory_order_release);
         callback_count.fetch_add(1, std::memory_order_release);
     });
 
@@ -11143,6 +11253,17 @@ void RunTimestampQueryCompletionOwnership() {
         WritableBytes(readback),
         "TimestampQueryReadback"
     );
+    commands.AddCallback([&] {
+        if (GetCurrentRHIThreadRole() !=
+                ERHIThreadRole::Completion ||
+            callback_stage.load(std::memory_order_acquire) != 2) {
+            callback_errors.fetch_add(1, std::memory_order_relaxed);
+        }
+        callback_stage.store(3, std::memory_order_release);
+        ordinary_callback_count.fetch_add(
+            1, std::memory_order_release
+        );
+    });
 
     CmdSubmit first_submit = commands.Submit();
     first_submit.Signal(query_done.Get(), 1);
@@ -11153,6 +11274,8 @@ void RunTimestampQueryCompletionOwnership() {
     );
     RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
 
+    const GpuCompletionResult completion_result =
+        gpu_completion.Get();
     const QueryResult result = future.Get();
     const auto* timestamp = std::get_if<TimestampQueryResult>(&result.payload);
     if (result.status != QueryStatus::Ready ||
@@ -11167,9 +11290,18 @@ void RunTimestampQueryCompletionOwnership() {
         );
     }
     if (callback_count.load(std::memory_order_acquire) != 1 ||
-        callback_errors.load(std::memory_order_acquire) != 0) {
+        completion_callback_count.load(
+            std::memory_order_acquire
+        ) != 1 ||
+        ordinary_callback_count.load(
+            std::memory_order_acquire
+        ) != 1 ||
+        callback_stage.load(std::memory_order_acquire) != 3 ||
+        callback_errors.load(std::memory_order_acquire) != 0 ||
+        completion_result.status !=
+            GpuCompletionStatus::Ready) {
         throw std::runtime_error(
-            "Vulkan timestamp query callback escaped Completion ownership"
+            "Vulkan completion/query callbacks violated Completion ordering"
         );
     }
     if (readback != values) {
@@ -11334,7 +11466,8 @@ void RunTimestampQueryCompletionOwnership() {
 
     LOG_INFO(
         "[TESTCASE][PASS] name=TimestampQueryCompletionOwnership "
-        "status=Ready owner=Completion signal_terminal_before_callback=true "
+        "status=Ready gpu_completion=Ready owner=Completion "
+        "order=signal->completion->query->ordinary "
         "allocator_slot_reuse=verified large_query_pairs={} "
         "post_growth_submit=accepted valid_bits={} duration_ns={} "
         "reused_duration_ns={} readback=verified replay=0",
@@ -11592,7 +11725,9 @@ void RunTimestampQueryCrossQueueBatchPublication() {
         device.CreateFence(),
     };
     std::array<QueryFuture, 2> futures{};
+    std::array<GpuCompletionFuture, 2> completions{};
     std::array<std::atomic<uint32>, 2> query_callbacks{};
+    std::array<std::atomic<uint32>, 2> completion_callbacks{};
     std::array<std::atomic<uint32>, 2> ordinary_callbacks{};
     std::array<std::atomic<uint32>, 2> success_callbacks{};
     std::atomic<uint32> callback_errors{0};
@@ -11629,6 +11764,9 @@ void RunTimestampQueryCrossQueueBatchPublication() {
     graphics.SetResourceStateOwnership(
         ERHIResourceStateOwnership::Explicit
     );
+    completions[0] = graphics.TrackGpuCompletion(
+        "Phase19ACrossQueueGraphicsCompletion"
+    );
     QueryToken graphics_query =
         graphics.BeginTimestampQuery("Phase17ACrossQueueGraphics");
     futures[0] = graphics_query.GetFuture();
@@ -11638,16 +11776,61 @@ void RunTimestampQueryCrossQueueBatchPublication() {
     compute.SetResourceStateOwnership(
         ERHIResourceStateOwnership::Explicit
     );
+    completions[1] = compute.TrackGpuCompletion(
+        "Phase19ACrossQueueComputeCompletion"
+    );
     QueryToken compute_query =
         compute.BeginTimestampQuery("Phase17ACrossQueueCompute");
     futures[1] = compute_query.GetFuture();
     compute.EndTimestampQuery(compute_query);
+
+    for (size_t index = 0; index < completions.size(); ++index) {
+        completions[index].Then(
+            [&, index](const GpuCompletionResult& _result) {
+                const size_t peer = 1 - index;
+                const auto peer_completion =
+                    completions[peer].TryGet();
+                const auto own_query = futures[index].TryGet();
+                const auto peer_query = futures[peer].TryGet();
+                if (GetCurrentRHIThreadRole() !=
+                        ERHIThreadRole::Completion ||
+                    _result.status !=
+                        GpuCompletionStatus::Ready ||
+                    !peer_completion.has_value() ||
+                    peer_completion->status !=
+                        GpuCompletionStatus::Ready ||
+                    !own_query.has_value() ||
+                    own_query->status != QueryStatus::Ready ||
+                    !peer_query.has_value() ||
+                    peer_query->status != QueryStatus::Ready ||
+                    !signal_succeeded(0) ||
+                    !signal_succeeded(1)) {
+                    callback_errors.fetch_add(
+                        1, std::memory_order_relaxed
+                    );
+                }
+                completion_callbacks[index].fetch_add(
+                    1, std::memory_order_release
+                );
+            }
+        );
+    }
 
     futures[0].Then([&](const QueryResult& _result) {
         if (GetCurrentRHIThreadRole() !=
                 ERHIThreadRole::Completion ||
             _result.status != QueryStatus::Ready ||
             !peer_ready(1) ||
+            completions[0].Status() !=
+                GpuCompletionStatus::Ready ||
+            completions[1].Status() !=
+                GpuCompletionStatus::Ready ||
+            completion_callbacks[0].load(
+                std::memory_order_acquire
+            ) != 1 ||
+            completion_callbacks[1].load(
+                std::memory_order_acquire
+            ) != 1 ||
             !signal_succeeded(0) ||
             !signal_succeeded(1)) {
             callback_errors.fetch_add(
@@ -11663,6 +11846,16 @@ void RunTimestampQueryCrossQueueBatchPublication() {
                 ERHIThreadRole::Completion ||
             _result.status != QueryStatus::Ready ||
             !peer_ready(0) ||
+            completions[0].Status() !=
+                GpuCompletionStatus::Ready ||
+            completions[1].Status() !=
+                GpuCompletionStatus::Ready ||
+            completion_callbacks[0].load(
+                std::memory_order_acquire
+            ) != 1 ||
+            completion_callbacks[1].load(
+                std::memory_order_acquire
+            ) != 1 ||
             !signal_succeeded(0) ||
             !signal_succeeded(1)) {
             callback_errors.fetch_add(
@@ -11839,10 +12032,16 @@ void RunTimestampQueryCrossQueueBatchPublication() {
 
     for (size_t index = 0; index < futures.size(); ++index) {
         const QueryResult result = futures[index].Get();
+        const GpuCompletionResult completion =
+            completions[index].Get();
         if (result.status != QueryStatus::Ready ||
+            completion.status != GpuCompletionStatus::Ready ||
             result.kind != QueryKind::Timestamp ||
             !signal_succeeded(index) ||
             query_callbacks[index].load(
+                std::memory_order_acquire
+            ) != 1 ||
+            completion_callbacks[index].load(
                 std::memory_order_acquire
             ) != 1 ||
             ordinary_callbacks[index].load(
@@ -11910,6 +12109,9 @@ void RunTimestampQueryCrossQueueBatchPublication() {
         if (query_callbacks[index].load(
                 std::memory_order_acquire
             ) != 1 ||
+            completion_callbacks[index].load(
+                std::memory_order_acquire
+            ) != 1 ||
             ordinary_callbacks[index].load(
                 std::memory_order_acquire
             ) != 1 ||
@@ -11927,6 +12129,7 @@ void RunTimestampQueryCrossQueueBatchPublication() {
         "name=TimestampQueryCrossQueueBatchPublication "
         "sources=2 queues=Graphics,Compute native_alias={} "
         "queries=batch_published_before_notify "
+        "completions=batch_published_before_notify "
         "cross_future_wait=ready owner=Completion "
         "queue_local_sync=blocked_until_group_settled "
         "callbacks=exactly_once replay=0",
@@ -12190,7 +12393,9 @@ void RunTimestampQueryCopyOnlyPayloadArrival() {
 
     QueryFuture graphics_future{};
     QueryFuture copy_future{};
+    GpuCompletionFuture copy_completion{};
     std::array<std::atomic<uint32>, 2> query_callbacks{};
+    std::atomic<uint32> completion_callbacks{0};
     std::atomic<uint32> callback_errors{0};
     FenceRef graphics_done = device.CreateFence();
 
@@ -12208,6 +12413,10 @@ void RunTimestampQueryCopyOnlyPayloadArrival() {
     // and strip its native commands to exercise the executable-source
     // contract that batch admission and rejection paths may still construct.
     CommandList copy_payload_builder(EQueueType::Graphics);
+    copy_completion =
+        copy_payload_builder.TrackGpuCompletion(
+            "Phase19ACopyPayloadCompletion"
+        );
     QueryToken copy_query =
         copy_payload_builder.BeginTimestampQuery(
             "Phase17ACopyOnlyPayload"
@@ -12273,6 +12482,25 @@ void RunTimestampQueryCopyOnlyPayloadArrival() {
             1, std::memory_order_release
         );
     });
+    copy_completion.Then([&](const GpuCompletionResult& _result) {
+        const auto graphics_result = graphics_future.TryGet();
+        const auto copy_result = copy_future.TryGet();
+        if (GetCurrentRHIThreadRole() !=
+                ERHIThreadRole::Completion ||
+            _result.status != GpuCompletionStatus::Ready ||
+            !graphics_result.has_value() ||
+            graphics_result->status != QueryStatus::Ready ||
+            !copy_result.has_value() ||
+            copy_result->status != QueryStatus::Error ||
+            !graphics_signal_succeeded()) {
+            callback_errors.fetch_add(
+                1, std::memory_order_relaxed
+            );
+        }
+        completion_callbacks.fetch_add(
+            1, std::memory_order_release
+        );
+    });
 
     CmdSubmit graphics_submit = graphics.Submit();
     graphics_submit.SetTranslateExecutionClass(
@@ -12283,6 +12511,45 @@ void RunTimestampQueryCopyOnlyPayloadArrival() {
     );
     graphics_submit.async_queue_scope = async_queue_scope;
     graphics_submit.Signal(graphics_done.Get(), 1);
+
+    // A completion-only Copy submit must still cross the native queue and
+    // reach Completion. This specifically guards the Copy translator's
+    // has_queue_work classification.
+    CommandList completion_only_copy(EQueueType::Copy);
+    GpuCompletionFuture completion_only_future =
+        completion_only_copy.TrackGpuCompletion(
+            "Phase19ACompletionOnlyCopy"
+        );
+    std::atomic<uint32> completion_only_callbacks{0};
+    completion_only_future.Then(
+        [&](const GpuCompletionResult& _result) {
+            if (GetCurrentRHIThreadRole() !=
+                    ERHIThreadRole::Completion ||
+                _result.status != GpuCompletionStatus::Ready) {
+                callback_errors.fetch_add(
+                    1, std::memory_order_relaxed
+                );
+            }
+            completion_only_callbacks.fetch_add(
+                1, std::memory_order_release
+            );
+        }
+    );
+    RHIExecutor::Get().Submit(
+        EQueueType::Copy,
+        completion_only_copy.Submit(),
+        ERHIExecSubmitFlags::FlushGPU
+    );
+    RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
+    if (completion_only_future.Get().status !=
+            GpuCompletionStatus::Ready ||
+        completion_only_callbacks.load(
+            std::memory_order_acquire
+        ) != 1) {
+        throw std::runtime_error(
+            "completion-only Copy submit did not reach Completion"
+        );
+    }
 
     SourceSubmissionCapture        source_capture(async_queue_scope);
     ScopedSourceSubmissionObserver source_observer(source_capture);
@@ -12301,11 +12568,19 @@ void RunTimestampQueryCopyOnlyPayloadArrival() {
 
     const QueryResult graphics_result = graphics_future.Get();
     const QueryResult copy_result = copy_future.Get();
+    const GpuCompletionResult copy_completion_result =
+        copy_completion.Get();
     if (graphics_result.status != QueryStatus::Ready ||
         copy_result.status != QueryStatus::Error ||
+        copy_completion_result.status !=
+            GpuCompletionStatus::Ready ||
         copy_result.error_reason.empty() ||
         query_callbacks[0].load(std::memory_order_acquire) != 1 ||
         query_callbacks[1].load(std::memory_order_acquire) != 1 ||
+        completion_callbacks.load(std::memory_order_acquire) != 1 ||
+        completion_only_callbacks.load(
+            std::memory_order_acquire
+        ) != 1 ||
         callback_errors.load(std::memory_order_acquire) != 0 ||
         !graphics_signal_succeeded() ||
         source_capture.Overflowed() ||
@@ -12357,6 +12632,7 @@ void RunTimestampQueryCopyOnlyPayloadArrival() {
         "name=TimestampQueryCopyOnlyPayloadArrival "
         "sources=2 queues=Graphics,Copy "
         "copy_payload=query_only copy_query=Error "
+        "copy_completion=Ready completion_only_copy=Ready "
         "group_arrival=verified owner=Completion "
         "callbacks=exactly_once native_submit=2 replay=0"
     );
@@ -12770,6 +13046,8 @@ void RunTimestampQueryMidBatchTranslateFailure() {
     );
     std::atomic<uint32>   prefix_query_callbacks{0};
     std::atomic<uint32>   suffix_query_callbacks{0};
+    std::atomic<uint32>   prefix_completion_callbacks{0};
+    std::atomic<uint32>   suffix_completion_callbacks{0};
     std::atomic<uint32>   prefix_ordinary_callbacks{0};
     std::atomic<uint32>   suffix_ordinary_callbacks{0};
     std::atomic<uint32>   prefix_success_callbacks{0};
@@ -12780,6 +13058,10 @@ void RunTimestampQueryMidBatchTranslateFailure() {
     prefix.SetResourceStateOwnership(
         ERHIResourceStateOwnership::Explicit
     );
+    GpuCompletionFuture prefix_completion =
+        prefix.TrackGpuCompletion(
+            "Phase19AMidBatchPrefixCompletion"
+        );
     QueryToken prefix_query =
         prefix.BeginTimestampQuery("Phase17AMidBatchPrefixTimestamp");
     QueryFuture prefix_future = prefix_query.GetFuture();
@@ -12807,6 +13089,10 @@ void RunTimestampQueryMidBatchTranslateFailure() {
     suffix.SetResourceStateOwnership(
         ERHIResourceStateOwnership::Explicit
     );
+    GpuCompletionFuture suffix_completion =
+        suffix.TrackGpuCompletion(
+            "Phase19AMidBatchSuffixCompletion"
+        );
     QueryToken suffix_query =
         suffix.BeginTimestampQuery("Phase17AMidBatchFailingTimestamp");
     QueryFuture suffix_future = suffix_query.GetFuture();
@@ -12846,6 +13132,41 @@ void RunTimestampQueryMidBatchTranslateFailure() {
     // earlier callback from driving a later source's Translate. The test
     // thread releases the blocked suffix only after proving that no callback
     // escaped before every executable source reached a terminal packet.
+    prefix_completion.Then(
+        [&](const GpuCompletionResult& _result) {
+            const auto suffix_result =
+                suffix_completion.TryGet();
+            if (_result.status !=
+                    GpuCompletionStatus::Ready ||
+                GetCurrentRHIThreadRole() !=
+                    ERHIThreadRole::Completion ||
+                !suffix_result.has_value() ||
+                suffix_result->status !=
+                    GpuCompletionStatus::Error) {
+                callback_errors.fetch_add(
+                    1, std::memory_order_relaxed
+                );
+            }
+            prefix_completion_callbacks.fetch_add(
+                1, std::memory_order_release
+            );
+        }
+    );
+    suffix_completion.Then(
+        [&](const GpuCompletionResult& _result) {
+            if (_result.status !=
+                    GpuCompletionStatus::Error ||
+                GetCurrentRHIThreadRole() !=
+                    ERHIThreadRole::Completion) {
+                callback_errors.fetch_add(
+                    1, std::memory_order_relaxed
+                );
+            }
+            suffix_completion_callbacks.fetch_add(
+                1, std::memory_order_release
+            );
+        }
+    );
     prefix_future.Then([&](const QueryResult& _result) {
         prefix_query_callback_entered.release();
         const bool suffix_terminal = suffix_future.WaitFor(500ms);
@@ -12861,14 +13182,27 @@ void RunTimestampQueryMidBatchTranslateFailure() {
             prefix_fence->IsFailed() ||
             !suffix_terminal ||
             !suffix_result.has_value() ||
-            suffix_result->status != QueryStatus::Error) {
+            suffix_result->status != QueryStatus::Error ||
+            prefix_completion_callbacks.load(
+                std::memory_order_acquire
+            ) != 1 ||
+            suffix_completion_callbacks.load(
+                std::memory_order_acquire
+            ) != 1) {
             callback_errors.fetch_add(1, std::memory_order_relaxed);
         }
         prefix_query_callbacks.fetch_add(1, std::memory_order_release);
     });
     suffix_future.Then([&](const QueryResult& _result) {
         if (_result.status != QueryStatus::Error ||
-            GetCurrentRHIThreadRole() != ERHIThreadRole::Completion) {
+            GetCurrentRHIThreadRole() !=
+                ERHIThreadRole::Completion ||
+            prefix_completion_callbacks.load(
+                std::memory_order_acquire
+            ) != 1 ||
+            suffix_completion_callbacks.load(
+                std::memory_order_acquire
+            ) != 1) {
             callback_errors.fetch_add(1, std::memory_order_relaxed);
         }
         suffix_query_callbacks.fetch_add(1, std::memory_order_release);
@@ -12894,10 +13228,19 @@ void RunTimestampQueryMidBatchTranslateFailure() {
     }
     const std::optional<QueryResult> published_prefix =
         prefix_future.TryGet();
+    const bool prefix_completion_published =
+        prefix_completion.WaitFor(5s);
+    const auto published_prefix_completion =
+        prefix_completion.TryGet();
     if (!published_prefix.has_value() ||
-        published_prefix->status != QueryStatus::Ready) {
+        published_prefix->status != QueryStatus::Ready ||
+        !prefix_completion_published ||
+        !published_prefix_completion.has_value() ||
+        published_prefix_completion->status !=
+            GpuCompletionStatus::Ready ||
+        suffix_completion.TryGet().has_value()) {
         throw std::runtime_error(
-            "mid-batch timestamp prefix was not Ready before suffix failure"
+            "mid-batch prefix completion did not preserve the terminal frontier"
         );
     }
     const bool prefix_callback_entered_before_terminal =
@@ -12907,6 +13250,12 @@ void RunTimestampQueryMidBatchTranslateFailure() {
     }
     if (prefix_query_callbacks.load(std::memory_order_acquire) != 0 ||
         suffix_query_callbacks.load(std::memory_order_acquire) != 0 ||
+        prefix_completion_callbacks.load(
+            std::memory_order_acquire
+        ) != 0 ||
+        suffix_completion_callbacks.load(
+            std::memory_order_acquire
+        ) != 0 ||
         prefix_ordinary_callbacks.load(std::memory_order_acquire) != 0 ||
         suffix_ordinary_callbacks.load(std::memory_order_acquire) != 0) {
         throw std::runtime_error(
@@ -12918,13 +13267,28 @@ void RunTimestampQueryMidBatchTranslateFailure() {
 
     const QueryResult prefix_result = prefix_future.Get();
     const QueryResult suffix_result = suffix_future.Get();
+    const GpuCompletionResult prefix_completion_result =
+        prefix_completion.Get();
+    const GpuCompletionResult suffix_completion_result =
+        suffix_completion.Get();
     auto* suffix_fence =
         static_cast<VulkanFence*>(ResourceCast(suffix_done.Get()));
     if (prefix_result.status != QueryStatus::Ready ||
         suffix_result.status != QueryStatus::Error ||
+        prefix_completion_result.status !=
+            GpuCompletionStatus::Ready ||
+        suffix_completion_result.status !=
+            GpuCompletionStatus::Error ||
+        suffix_completion_result.error_reason.empty() ||
         suffix_result.error_reason.empty() ||
         prefix_query_callbacks.load(std::memory_order_acquire) != 1 ||
         suffix_query_callbacks.load(std::memory_order_acquire) != 1 ||
+        prefix_completion_callbacks.load(
+            std::memory_order_acquire
+        ) != 1 ||
+        suffix_completion_callbacks.load(
+            std::memory_order_acquire
+        ) != 1 ||
         prefix_ordinary_callbacks.load(std::memory_order_acquire) != 1 ||
         suffix_ordinary_callbacks.load(std::memory_order_acquire) != 1 ||
         prefix_success_callbacks.load(std::memory_order_acquire) != 1 ||
@@ -12954,6 +13318,12 @@ void RunTimestampQueryMidBatchTranslateFailure() {
     RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
     if (prefix_query_callbacks.load(std::memory_order_acquire) != 1 ||
         suffix_query_callbacks.load(std::memory_order_acquire) != 1 ||
+        prefix_completion_callbacks.load(
+            std::memory_order_acquire
+        ) != 1 ||
+        suffix_completion_callbacks.load(
+            std::memory_order_acquire
+        ) != 1 ||
         prefix_ordinary_callbacks.load(std::memory_order_acquire) != 1 ||
         suffix_ordinary_callbacks.load(std::memory_order_acquire) != 1 ||
         native_capture.Count() != 1) {
@@ -12966,6 +13336,7 @@ void RunTimestampQueryMidBatchTranslateFailure() {
         "[TESTCASE][PASS] name=TimestampQueryMidBatchTranslateFailure "
         "queues=Graphics,Graphics native_prefix_submit=1 "
         "suffix_translate=main-thread-released suffix_status=Error "
+        "prefix_completion=Ready suffix_completion=Error "
         "pre_terminal_callback_entry=0 "
         "batch_terminal_before_notify=true "
         "bounded_cross_future_wait=true "


### PR DESCRIPTION
## What changed

- adds a backend-opaque `GpuCompletionFuture` / token API for observing one logical GPU submission
- transfers completion ownership through `CommandList -> CmdSubmit -> native Completion packet`
- publishes batch terminal states before notifications/callbacks to prevent completion-thread re-entrancy deadlocks
- supports Vulkan Graphics, Compute, Copy, multi-source batches, multi-segment sources, partial-prefix success, rejection, and shutdown cancellation
- fails closed as Unsupported on the currently incomplete D3D12 submission path
- adds owner-thread blocking guards and exact-once callback/error semantics
- adds CPU contract coverage and real Vulkan fault-injection coverage

## Why

This ports the useful CPU-observation portion of `dev_parallel_rhi` SyncPoint semantics onto main's newer RDG queue DAG and Executor/Submission/Completion ownership architecture. Native fences remain backend-owned; GPU-to-GPU dependencies continue to use RDG lowering rather than leaking synchronization primitives upward.

## Important invariants

- `Pending` transitions exactly once to `Ready` or `Error`
- a logical multi-segment completion becomes Ready only after its final native segment completes
- when a prefix was submitted but a suffix fails, prefix completions become Ready and suffix completions become Error
- all terminal states in a batch are visible before any waiter/callback is notified
- pending waits from an RHI owner thread throw instead of self-deadlocking
- completion-only Copy submissions are treated as real queue work

## Validation

- RelWithDebInfo full build passed
- default CTest: 21/21 passed
- `TestRHIParallelRecordVulkan --timestamp-query` passed on RTX 5080
- `TestRHIParallelRecordVulkan --timestamp-query-mid-failure` passed on RTX 5080
- `TestRHIParallelRecordVulkan --inject-multi-segment-translate-failure` passed on RTX 5080
- MoerEditor Raytracing/Vulkan runtime smoke ran for 30+ seconds without validation errors or device faults
- `git diff --check` passed

## Review focus

Please scrutinize terminal publication ordering, move/destructor re-entrancy, multi-segment frontier mapping, Copy completion-only work detection, cancellation generations, and RHI-owner wait guards.