### PR TITLE
Phase 19A: harden reentrant RHI rejection transactions

### DIFF
--- a/source/runtime/render/renderer/raytracing/RaytracingExportSubmission.h
+++ b/source/runtime/render/renderer/raytracing/RaytracingExportSubmission.h
@@ -268,7 +268,11 @@ private:
         std::function<void()> keepalive = [fence = _receipt] {};
         _submit.callbacks.reserve(_submit.callbacks.size() + 1);
         _submit.signal_events.reserve(_submit.signal_events.size() + 1);
+        _submit.signal_rejection_keepalives.reserve(
+            _submit.signal_rejection_keepalives.size() + 1
+        );
         _submit.callbacks.emplace_back(std::move(keepalive));
+        _submit.signal_rejection_keepalives.emplace_back(_receipt);
         _submit.Signal(_receipt.Get(), _value);
     }
 

--- a/source/runtime/render/rhi/RHICommand.h
+++ b/source/runtime/render/rhi/RHICommand.h
@@ -294,6 +294,10 @@ struct CmdSubmit {
 
     Array<WaitEvent>   wait_events;
     Array<SignalEvent> signal_events;
+    // SignalEvent is backend-facing raw identity. CommandList::Signal(FenceRef)
+    // mirrors its strong owners here so rejection can detach the complete
+    // lifetime set before Fence::Reject executes re-entrant user code.
+    Array<FenceRef>    signal_rejection_keepalives;
     bool               b_sync{false}; //force sync queue timeline
     // Kept as a compatibility bit for code which treats profiling as a submit
     // capability.  profiling_phase is authoritative for split frames.
@@ -404,6 +408,8 @@ struct CmdSubmit {
         query_publish_batch = _other.query_publish_batch;
         wait_events        = std::move(_other.wait_events);
         signal_events      = std::move(_other.signal_events);
+        signal_rejection_keepalives =
+            std::move(_other.signal_rejection_keepalives);
         cached_args        = std::move(_other.cached_args);
         segments           = std::move(_other.segments);
         b_sync             = _other.b_sync;
@@ -420,34 +426,42 @@ struct CmdSubmit {
         _other.query_tokens.clear();
         _other.query_publish_batch = {};
         _other.signal_events.clear();
+        _other.signal_rejection_keepalives.clear();
     }
 
     CmdSubmit& operator=(CmdSubmit&& _other) noexcept {
         if (this == &_other) {
             return *this;
         }
-        RejectPendingSignals();
-        Array<GpuCompletionToken> replaced_completion_tokens =
+        CmdSubmit replaced(
+            std::move(cmds),
+            std::move(callbacks),
+            std::move(success_callbacks),
+            std::move(cached_args)
+        );
+        replaced.gpu_completion_tokens =
             std::move(gpu_completion_tokens);
-        const GpuCompletionPublishBatch replaced_completion_batch =
-            gpu_completion_publish_batch.Valid() ?
-                gpu_completion_publish_batch :
-                GpuCompletionBackendAccess::BeginPublishBatch();
-        GpuCompletionBackendAccess::PublishErrorsIfPending(
-            replaced_completion_tokens,
-            "GPU completion submit was replaced before completion",
-            replaced_completion_batch
-        );
-        Array<QueryToken> replaced_query_tokens = std::move(query_tokens);
-        const QueryPublishBatch replaced_query_batch =
-            query_publish_batch.Valid() ?
-                query_publish_batch :
-                QueryBackendAccess::BeginPublishBatch();
-        QueryBackendAccess::PublishErrorsIfPending(
-            replaced_query_tokens,
-            "query submit was replaced before completion",
-            replaced_query_batch
-        );
+        replaced.gpu_completion_publish_batch =
+            gpu_completion_publish_batch;
+        replaced.query_tokens = std::move(query_tokens);
+        replaced.query_publish_batch = query_publish_batch;
+        replaced.segments = std::move(segments);
+        replaced.wait_events = std::move(wait_events);
+        replaced.signal_events = std::move(signal_events);
+        replaced.signal_rejection_keepalives =
+            std::move(signal_rejection_keepalives);
+        replaced.b_sync = b_sync;
+        replaced.b_tick_profiling = b_tick_profiling;
+        replaced.profiling_phase = profiling_phase;
+        replaced.b_delete_resources = b_delete_resources;
+        replaced.resource_state_ownership =
+            resource_state_ownership;
+        replaced.translate_execution_class =
+            translate_execution_class;
+        replaced.async_queue_scope = async_queue_scope;
+        replaced.debug_label = std::move(debug_label);
+        replaced.debug_label_color = debug_label_color;
+
         cmds               = std::move(_other.cmds);
         callbacks          = std::move(_other.callbacks);
         success_callbacks  = std::move(_other.success_callbacks);
@@ -460,6 +474,8 @@ struct CmdSubmit {
         query_publish_batch = _other.query_publish_batch;
         wait_events        = std::move(_other.wait_events);
         signal_events      = std::move(_other.signal_events);
+        signal_rejection_keepalives =
+            std::move(_other.signal_rejection_keepalives);
         cached_args        = std::move(_other.cached_args);
         segments           = std::move(_other.segments);
         b_sync             = _other.b_sync;
@@ -476,48 +492,138 @@ struct CmdSubmit {
         _other.query_tokens.clear();
         _other.query_publish_batch = {};
         _other.signal_events.clear();
+        _other.signal_rejection_keepalives.clear();
+        _other.cmds.clear();
+        _other.callbacks.clear();
+        _other.success_callbacks.clear();
+        _other.cached_args.clear();
+        _other.segments.clear();
+        _other.wait_events.clear();
+        _other.debug_label.clear();
 
-        // The replacement is fully installed before user Query callbacks can
-        // re-enter this object. No outer write may overwrite re-entrant state.
-        GpuCompletionBackendAccess::NotifyTerminals(
-            replaced_completion_tokens, replaced_completion_batch
+        // The replacement is fully installed before any Fence rejection,
+        // waiter wake-up, or callback can re-enter this object.
+        const GpuCompletionPublishBatch replaced_completion_batch =
+            replaced.gpu_completion_publish_batch.Valid() ?
+                replaced.gpu_completion_publish_batch :
+                GpuCompletionBackendAccess::BeginPublishBatch();
+        replaced.PublishPendingGpuCompletionErrors(
+            "GPU completion submit was replaced before completion",
+            replaced_completion_batch
         );
-        QueryBackendAccess::NotifyTerminals(
-            replaced_query_tokens, replaced_query_batch
+        const QueryPublishBatch replaced_query_batch =
+            replaced.query_publish_batch.Valid() ?
+                replaced.query_publish_batch :
+                QueryBackendAccess::BeginPublishBatch();
+        replaced.PublishPendingQueryErrors(
+            "query submit was replaced before completion",
+            replaced_query_batch
         );
+        // Publication wakes Wait/Get but does not release callbacks. Publish
+        // first so a synchronous Fence::Reject hook can safely wait on either
+        // host observation; reject every signal before callback notification.
+        replaced.RejectPendingSignals();
+        replaced.NotifyPendingGpuCompletions(
+            replaced_completion_batch
+        );
+        replaced.NotifyPendingQueries(replaced_query_batch);
         return *this;
     }
 
     ~CmdSubmit() {
-        RejectPendingSignals();
+        Array<UniquePtr<Command>> rejected_cmds =
+            std::move(cmds);
+        Array<std::function<void(void)>> rejected_callbacks =
+            std::move(callbacks);
+        Array<std::function<void(void)>> rejected_success_callbacks =
+            std::move(success_callbacks);
+        Array<GpuCompletionToken> rejected_completion_tokens =
+            std::move(gpu_completion_tokens);
         const GpuCompletionPublishBatch completion_batch =
             gpu_completion_publish_batch.Valid() ?
                 gpu_completion_publish_batch :
                 GpuCompletionBackendAccess::BeginPublishBatch();
+        Array<QueryToken> rejected_query_tokens =
+            std::move(query_tokens);
         const QueryPublishBatch query_batch =
             query_publish_batch.Valid() ?
                 query_publish_batch :
                 QueryBackendAccess::BeginPublishBatch();
-        PublishPendingGpuCompletionErrors(
+        TCachedArgArray rejected_cached_args =
+            std::move(cached_args);
+        Array<RHISubmitSegment> rejected_segments =
+            std::move(segments);
+        Array<WaitEvent> rejected_wait_events =
+            std::move(wait_events);
+        Array<SignalEvent> rejected_signals =
+            std::move(signal_events);
+        Array<FenceRef> rejected_signal_keepalives =
+            std::move(signal_rejection_keepalives);
+        std::string rejected_debug_label =
+            std::move(debug_label);
+
+        // A synchronous Fence/Future observer may re-enter while this
+        // destructor is still active. Detach every rejected payload first so
+        // it cannot be extracted or revisited.
+        gpu_completion_publish_batch = {};
+        query_publish_batch = {};
+        b_sync = false;
+        b_tick_profiling = false;
+        profiling_phase = ERHIProfilingPhase::Disabled;
+        b_delete_resources = false;
+        resource_state_ownership =
+            ERHIResourceStateOwnership::BackendTracked;
+        translate_execution_class =
+            ERHITranslateExecutionClass::Parallel;
+        async_queue_scope = 0;
+
+        GpuCompletionBackendAccess::PublishErrorsIfPending(
+            rejected_completion_tokens,
             "GPU completion submit was destroyed before completion",
             completion_batch
         );
-        PublishPendingQueryErrors(
+        QueryBackendAccess::PublishErrorsIfPending(
+            rejected_query_tokens,
             "query submit was destroyed before completion",
             query_batch
         );
-        NotifyPendingGpuCompletions(completion_batch);
-        NotifyPendingQueries(query_batch);
+        for (const SignalEvent& signal : rejected_signals) {
+            auto* fence =
+                reinterpret_cast<Fence*>(signal.timeline_handle);
+            if (fence != nullptr) {
+                fence->Reject(signal.value);
+            }
+        }
+        GpuCompletionBackendAccess::NotifyTerminals(
+            rejected_completion_tokens, completion_batch
+        );
+        QueryBackendAccess::NotifyTerminals(
+            rejected_query_tokens, query_batch
+        );
+        (void)rejected_cmds;
+        (void)rejected_callbacks;
+        (void)rejected_success_callbacks;
+        (void)rejected_cached_args;
+        (void)rejected_segments;
+        (void)rejected_wait_events;
+        (void)rejected_signal_keepalives;
+        (void)rejected_debug_label;
     }
 
     void RejectPendingSignals() noexcept {
-        for (const SignalEvent& signal : signal_events) {
+        Array<SignalEvent> rejected_signals =
+            std::move(signal_events);
+        Array<FenceRef> rejected_signal_keepalives =
+            std::move(signal_rejection_keepalives);
+        signal_events.clear();
+        signal_rejection_keepalives.clear();
+        for (const SignalEvent& signal : rejected_signals) {
             auto* fence = reinterpret_cast<Fence*>(signal.timeline_handle);
             if (fence != nullptr) {
                 fence->Reject(signal.value);
             }
         }
-        signal_events.clear();
+        (void)rejected_signal_keepalives;
     }
 
     void PublishPendingGpuCompletionOutcome(
@@ -873,6 +979,14 @@ public:
             command_list(&_command_list) {}
 
         CommandList* command_list{nullptr};
+    };
+
+    // Allocation-only first half of a rejection transaction. Batch owners
+    // construct one for every sibling before mutating any CommandList, so an
+    // allocation failure leaves the complete transaction untouched.
+    struct RecordingRejectionPreparation {
+        GpuCompletionCancellationDomain completion_domain{};
+        QueryCancellationDomain         query_domain{};
     };
 
     CommandList(const CommandList&)            = delete;
@@ -1769,11 +1883,26 @@ public:
     // cleanup. Unlike Submit(), this never creates a GPU-submittable payload.
     RENDER_API Array<std::function<void()>> DrainOrdinaryCallbacksForRejection();
 
+    // Transaction-wide rejection first phase. It detaches signals and cleanup
+    // callbacks, destroys the rejected GPU payload, and installs a fresh
+    // generation without running externally re-entrant code. RHIExecutor
+    // publishes and notifies only after every sibling crosses this boundary.
+    [[nodiscard]] RENDER_API CmdSubmit
+    PrepareRecordingRejectionDrain();
+    [[nodiscard]] RENDER_API CmdSubmit
+    PrepareRecordingRejectionDrain(
+        RecordingRejectionPreparation&& _preparation
+    ) noexcept;
+
     RENDER_API CmdSubmit Submit();
 
     // CommandList must remain at a stable address for the lifetime of the
     // returned lease.
     RENDER_API ManagedRecordingLease AcquireManagedRecordingLease();
+
+    [[nodiscard]] bool HasManagedRecordingLease() const noexcept {
+        return managed_recording_lease_count != 0;
+    }
 
     RENDER_API bool IsEmpty() const;
 
@@ -1824,6 +1953,7 @@ private:
     friend DrawDispatcher;
     friend ComputeDispatcher;
     friend class CommandQueue;
+
     RENDER_API void SetRenderCmds(
         PipelineHandle&  _handle,
         ArrayArguments&& _args,
@@ -1914,6 +2044,7 @@ private:
     Array<QueryToken>             active_query_stack;
     QueryCancellationDomain       query_cancellation_domain;
     Array<SignalEvent>            signal_events;
+    Array<FenceRef>               signal_rejection_keepalives;
     TCachedArgArray              cached_args;
     EQueueType                   queue_type{EQueueType::Graphics};
     ERHITranslateExecutionClass  translate_execution_class{

--- a/source/runtime/render/rhi/RHICommandList.cpp
+++ b/source/runtime/render/rhi/RHICommandList.cpp
@@ -41,6 +41,23 @@ void InvokeCallbacksNoexcept(Array<std::function<void()>>& _callbacks) noexcept 
     }
 }
 
+void RejectDetachedSignalsNoexcept(
+    Array<SignalEvent>& _signals
+) noexcept {
+    for (const SignalEvent& signal : _signals) {
+        auto* fence = reinterpret_cast<Fence*>(
+            signal.timeline_handle
+        );
+        if (fence != nullptr) {
+            try {
+                fence->Reject(signal.value);
+            } catch (...) {
+            }
+        }
+    }
+    _signals.clear();
+}
+
 } // namespace
 
 void CommandQueue::Test() {
@@ -73,52 +90,72 @@ CommandList::CommandList(EQueueType _queue_type) :
 }
 
 CommandList::~CommandList() {
-    RejectPendingSignals();
     GpuCompletionCancellationView completion_cancellation =
         gpu_completion_cancellation_domain.GetView();
-    Array<GpuCompletionToken> completion_tokens =
-        std::move(gpu_completion_tokens);
+    QueryCancellationView query_cancellation =
+        query_cancellation_domain.GetView();
     const GpuCompletionPublishBatch completion_batch =
         GpuCompletionBackendAccess::BeginPublishBatch();
+    const QueryPublishBatch query_batch =
+        QueryBackendAccess::BeginPublishBatch();
+
+    CmdSubmit rejected(
+        std::move(commands),
+        std::move(callbacks),
+        std::move(success_callbacks),
+        std::move(cached_args)
+    );
+    rejected.gpu_completion_tokens =
+        std::move(gpu_completion_tokens);
+    rejected.query_tokens = std::move(query_tokens);
+    rejected.signal_events = std::move(signal_events);
+    rejected.signal_rejection_keepalives =
+        std::move(signal_rejection_keepalives);
+    Array<QueryToken> rejected_active_queries =
+        std::move(active_query_stack);
+    while (!scope_stack.empty()) {
+        scope_stack.pop();
+    }
+    timestamp_scope_names.clear();
+
+    // No externally observable rejection may run while the dying object still
+    // exposes an extractable command generation.
+    current_barriers = nullptr;
+
     const bool completion_cancellation_published =
         completion_cancellation.PublishCancellation(
             "GPU completion command list was destroyed before submission",
             completion_batch
         );
-    GpuCompletionBackendAccess::PublishErrorsIfPending(
-        completion_tokens,
+    rejected.PublishPendingGpuCompletionErrors(
         "GPU completion command list was destroyed before submission",
         completion_batch
     );
-    const QueryPublishBatch query_batch =
-        QueryBackendAccess::BeginPublishBatch();
-    QueryCancellationView cancellation =
-        query_cancellation_domain.GetView();
-    Array<QueryToken> query_tokens = std::move(this->query_tokens);
     const bool cancellation_published =
-        cancellation.PublishCancellation(
+        query_cancellation.PublishCancellation(
             "query command list was destroyed before submission",
             query_batch
         );
-    QueryBackendAccess::PublishErrorsIfPending(
-        query_tokens,
+    rejected.PublishPendingQueryErrors(
         "query command list was destroyed before submission",
         query_batch
     );
-    GpuCompletionBackendAccess::NotifyTerminals(
-        completion_tokens, completion_batch
-    );
+    // Publication wakes Wait/Get but does not release callbacks. A
+    // Fence::Reject hook may synchronously wait on either host observation.
+    rejected.RejectPendingSignals();
     if (completion_cancellation_published) {
         completion_cancellation.NotifyCancellation(completion_batch);
     } else {
         completion_cancellation.NotifyPublishedCancellation();
     }
+    rejected.NotifyPendingGpuCompletions(completion_batch);
     if (cancellation_published) {
-        cancellation.NotifyCancellation(query_batch);
+        query_cancellation.NotifyCancellation(query_batch);
     } else {
-        cancellation.NotifyPublishedCancellation();
+        query_cancellation.NotifyPublishedCancellation();
     }
-    QueryBackendAccess::NotifyTerminals(query_tokens, query_batch);
+    rejected.NotifyPendingQueries(query_batch);
+    (void)rejected_active_queries;
 }
 
 CommandList::CommandList(CommandList&& _other) :
@@ -141,38 +178,38 @@ CommandList& CommandList::operator=(CommandList&& _other) {
     // ownership starts moving, every remaining operation below is noexcept.
     GpuCompletionCancellationDomain moved_from_completion_domain{};
     QueryCancellationDomain         moved_from_query_domain{};
-    RejectPendingSignals();
     GpuCompletionCancellationView replaced_completion_cancellation =
         gpu_completion_cancellation_domain.GetView();
-    Array<GpuCompletionToken> replaced_completion_tokens =
-        std::move(gpu_completion_tokens);
     const GpuCompletionPublishBatch replaced_completion_batch =
         GpuCompletionBackendAccess::BeginPublishBatch();
-    const bool replaced_completion_cancellation_published =
-        replaced_completion_cancellation.PublishCancellation(
-            "GPU completion command list was replaced before submission",
-            replaced_completion_batch
-        );
-    GpuCompletionBackendAccess::PublishErrorsIfPending(
-        replaced_completion_tokens,
-        "GPU completion command list was replaced before submission",
-        replaced_completion_batch
-    );
     QueryCancellationView replaced_query_cancellation =
         query_cancellation_domain.GetView();
-    Array<QueryToken> replaced_query_tokens = std::move(query_tokens);
     const QueryPublishBatch replaced_query_batch =
         QueryBackendAccess::BeginPublishBatch();
-    const bool replaced_cancellation_published =
-        replaced_query_cancellation.PublishCancellation(
-            "query command list was replaced before submission",
-            replaced_query_batch
-        );
-    QueryBackendAccess::PublishErrorsIfPending(
-        replaced_query_tokens,
-        "query command list was replaced before submission",
-        replaced_query_batch
+
+    CmdSubmit replaced(
+        std::move(commands),
+        std::move(callbacks),
+        std::move(success_callbacks),
+        std::move(cached_args)
     );
+    replaced.gpu_completion_tokens =
+        std::move(gpu_completion_tokens);
+    replaced.query_tokens = std::move(query_tokens);
+    replaced.signal_events = std::move(signal_events);
+    replaced.signal_rejection_keepalives =
+        std::move(signal_rejection_keepalives);
+    replaced.translate_execution_class =
+        translate_execution_class;
+    replaced.resource_state_ownership =
+        resource_state_ownership;
+    Array<QueryToken> replaced_active_queries =
+        std::move(active_query_stack);
+    while (!scope_stack.empty()) {
+        scope_stack.pop();
+    }
+    timestamp_scope_names.clear();
+
     commands                    = std::move(_other.commands);
     current_barriers            = _other.current_barriers;
     callbacks                   = std::move(_other.callbacks);
@@ -185,13 +222,19 @@ CommandList& CommandList::operator=(CommandList&& _other) {
     active_query_stack          = std::move(_other.active_query_stack);
     query_cancellation_domain   = std::move(_other.query_cancellation_domain);
     signal_events               = std::move(_other.signal_events);
+    signal_rejection_keepalives =
+        std::move(_other.signal_rejection_keepalives);
     cached_args                 = std::move(_other.cached_args);
     queue_type                  = _other.queue_type;
     translate_execution_class   = _other.translate_execution_class;
     resource_state_ownership    = _other.resource_state_ownership;
     seal_generation             = _other.seal_generation;
-    scope_stack                 = std::move(_other.scope_stack);
-    timestamp_scope_names       = std::move(_other.timestamp_scope_names);
+    static_assert(noexcept(scope_stack.swap(_other.scope_stack)));
+    static_assert(
+        noexcept(timestamp_scope_names.swap(_other.timestamp_scope_names))
+    );
+    scope_stack.swap(_other.scope_stack);
+    timestamp_scope_names.swap(_other.timestamp_scope_names);
     query_owner_id              = _other.query_owner_id;
 
     _other.current_barriers          = nullptr;
@@ -208,12 +251,38 @@ CommandList& CommandList::operator=(CommandList&& _other) {
     _other.query_tokens.clear();
     _other.active_query_stack.clear();
     _other.signal_events.clear();
+    _other.signal_rejection_keepalives.clear();
+    _other.commands.clear();
+    _other.callbacks.clear();
+    _other.success_callbacks.clear();
+    _other.cached_args.clear();
+    while (!_other.scope_stack.empty()) {
+        _other.scope_stack.pop();
+    }
+    _other.timestamp_scope_names.clear();
 
-    // Install the complete incoming generation before releasing user Query
-    // callbacks so re-entrant recording cannot be overwritten by this move.
-    GpuCompletionBackendAccess::NotifyTerminals(
-        replaced_completion_tokens, replaced_completion_batch
+    // Install the complete incoming generation before rejecting a Fence,
+    // publishing a terminal Future (which wakes Wait/Get), or releasing a
+    // callback. Re-entrant recording therefore targets only the replacement.
+    const bool replaced_completion_cancellation_published =
+        replaced_completion_cancellation.PublishCancellation(
+            "GPU completion command list was replaced before submission",
+            replaced_completion_batch
+        );
+    replaced.PublishPendingGpuCompletionErrors(
+        "GPU completion command list was replaced before submission",
+        replaced_completion_batch
     );
+    const bool replaced_cancellation_published =
+        replaced_query_cancellation.PublishCancellation(
+            "query command list was replaced before submission",
+            replaced_query_batch
+        );
+    replaced.PublishPendingQueryErrors(
+        "query command list was replaced before submission",
+        replaced_query_batch
+    );
+    replaced.RejectPendingSignals();
     if (replaced_completion_cancellation_published) {
         replaced_completion_cancellation.NotifyCancellation(
             replaced_completion_batch
@@ -222,6 +291,9 @@ CommandList& CommandList::operator=(CommandList&& _other) {
         replaced_completion_cancellation.
             NotifyPublishedCancellation();
     }
+    replaced.NotifyPendingGpuCompletions(
+        replaced_completion_batch
+    );
     if (replaced_cancellation_published) {
         replaced_query_cancellation.NotifyCancellation(
             replaced_query_batch
@@ -229,9 +301,8 @@ CommandList& CommandList::operator=(CommandList&& _other) {
     } else {
         replaced_query_cancellation.NotifyPublishedCancellation();
     }
-    QueryBackendAccess::NotifyTerminals(
-        replaced_query_tokens, replaced_query_batch
-    );
+    replaced.NotifyPendingQueries(replaced_query_batch);
+    (void)replaced_active_queries;
     return *this;
 }
 
@@ -418,6 +489,8 @@ CmdSubmit CommandList::Submit() {
     submit.gpu_completion_tokens = std::move(gpu_completion_tokens);
     submit.query_tokens = std::move(query_tokens);
     submit.signal_events = std::move(signal_events);
+    submit.signal_rejection_keepalives =
+        std::move(signal_rejection_keepalives);
     submit.segments      = std::move(submit_segments);
     submit.translate_execution_class = translate_execution_class;
     submit.resource_state_ownership   = resource_state_ownership;
@@ -460,6 +533,7 @@ CmdSubmit CommandList::Submit() {
         std::move(next_completion_domain);
     query_cancellation_domain = std::move(next_query_domain);
     signal_events.clear();
+    signal_rejection_keepalives.clear();
     timestamp_scope_names.clear();
     translate_execution_class = ERHITranslateExecutionClass::Parallel;
     resource_state_ownership  = ERHIResourceStateOwnership::BackendTracked;
@@ -467,21 +541,12 @@ CmdSubmit CommandList::Submit() {
 }
 
 Array<std::function<void()>> CommandList::DrainOrdinaryCallbacksForRejection() {
-    if (managed_recording_lease_count != 0) {
-        throw std::logic_error(
-            "CommandList rejection draining is forbidden while graph-managed recording is active"
-        );
-    }
-    // Do not move cleanup callbacks out until the replacement generation is
-    // guaranteed to exist; rejection must retain its no-throw ownership tail.
-    GpuCompletionCancellationDomain next_completion_domain{};
-    QueryCancellationDomain         next_query_domain{};
-    ++seal_generation;
-    RejectPendingSignals();
     GpuCompletionCancellationView rejected_completion_cancellation =
         gpu_completion_cancellation_domain.GetView();
-    Array<GpuCompletionToken> rejected_completion_tokens =
-        std::move(gpu_completion_tokens);
+    QueryCancellationView rejected_query_cancellation =
+        query_cancellation_domain.GetView();
+    CmdSubmit rejected = PrepareRecordingRejectionDrain();
+
     const GpuCompletionPublishBatch rejected_completion_batch =
         GpuCompletionBackendAccess::BeginPublishBatch();
     const bool rejected_completion_cancellation_published =
@@ -489,14 +554,10 @@ Array<std::function<void()>> CommandList::DrainOrdinaryCallbacksForRejection() {
             "GPU completion command list was rejected before completion",
             rejected_completion_batch
         );
-    GpuCompletionBackendAccess::PublishErrorsIfPending(
-        rejected_completion_tokens,
+    rejected.PublishPendingGpuCompletionErrors(
         "GPU completion command list was rejected before completion",
         rejected_completion_batch
     );
-    QueryCancellationView rejected_query_cancellation =
-        query_cancellation_domain.GetView();
-    Array<QueryToken> rejected_query_tokens = std::move(query_tokens);
     const QueryPublishBatch rejected_query_batch =
         QueryBackendAccess::BeginPublishBatch();
     const bool rejected_cancellation_published =
@@ -504,42 +565,15 @@ Array<std::function<void()>> CommandList::DrainOrdinaryCallbacksForRejection() {
             "query command list was rejected before completion",
             rejected_query_batch
         );
-    QueryBackendAccess::PublishErrorsIfPending(
-        rejected_query_tokens,
+    rejected.PublishPendingQueryErrors(
         "query command list was rejected before completion",
         rejected_query_batch
     );
-    Array<std::function<void()>> cleanup_callbacks = std::move(callbacks);
+    // Publication wakes Wait/Get but does not release callbacks. Publish the
+    // complete host batch first so Fence::Reject may safely wait on it, then
+    // terminalize signals before any callback notification.
+    rejected.RejectPendingSignals();
 
-    // This is deliberately not implemented in terms of Submit(). A failed
-    // producer may leave a partially-built barrier or an unmatched marker;
-    // neither is executable, and Submit() correctly asserts on that shape in
-    // Debug builds. Destroying the command payload releases its strong refs
-    // without manufacturing end-marker commands or submission segments.
-    commands.clear();
-    callbacks.clear();
-    success_callbacks.clear();
-    gpu_completion_tokens.clear();
-    query_tokens.clear();
-    active_query_stack.clear();
-    gpu_completion_cancellation_domain =
-        std::move(next_completion_domain);
-    query_cancellation_domain = std::move(next_query_domain);
-    signal_events.clear();
-    cached_args.clear();
-    current_barriers = nullptr;
-    while (!scope_stack.empty()) {
-        scope_stack.pop();
-    }
-    timestamp_scope_names.clear();
-    translate_execution_class = ERHITranslateExecutionClass::Parallel;
-    resource_state_ownership  = ERHIResourceStateOwnership::BackendTracked;
-
-    // The fresh generation is fully installed before Query callbacks can
-    // re-enter this CommandList and append new work.
-    GpuCompletionBackendAccess::NotifyTerminals(
-        rejected_completion_tokens, rejected_completion_batch
-    );
     if (rejected_completion_cancellation_published) {
         rejected_completion_cancellation.NotifyCancellation(
             rejected_completion_batch
@@ -548,6 +582,9 @@ Array<std::function<void()>> CommandList::DrainOrdinaryCallbacksForRejection() {
         rejected_completion_cancellation.
             NotifyPublishedCancellation();
     }
+    rejected.NotifyPendingGpuCompletions(
+        rejected_completion_batch
+    );
     if (rejected_cancellation_published) {
         rejected_query_cancellation.NotifyCancellation(
             rejected_query_batch
@@ -555,16 +592,89 @@ Array<std::function<void()>> CommandList::DrainOrdinaryCallbacksForRejection() {
     } else {
         rejected_query_cancellation.NotifyPublishedCancellation();
     }
-    QueryBackendAccess::NotifyTerminals(
-        rejected_query_tokens, rejected_query_batch
-    );
+    rejected.NotifyPendingQueries(rejected_query_batch);
+
+    Array<std::function<void()>> cleanup_callbacks =
+        std::move(rejected.callbacks);
+    rejected.success_callbacks.clear();
     return cleanup_callbacks;
+}
+
+CmdSubmit CommandList::PrepareRecordingRejectionDrain() {
+    if (managed_recording_lease_count != 0) {
+        throw std::logic_error(
+            "CommandList rejection draining is forbidden while graph-managed recording is active"
+        );
+    }
+    return PrepareRecordingRejectionDrain(
+        RecordingRejectionPreparation{}
+    );
+}
+
+CmdSubmit CommandList::PrepareRecordingRejectionDrain(
+    RecordingRejectionPreparation&& _preparation
+) noexcept {
+    // Batch owners verify this for every sibling before entering the
+    // allocation-free commit phase.
+    assert(managed_recording_lease_count == 0);
+    ++seal_generation;
+    CmdSubmit rejected(
+        std::move(commands),
+        std::move(callbacks),
+        std::move(success_callbacks),
+        std::move(cached_args)
+    );
+    rejected.gpu_completion_tokens =
+        std::move(gpu_completion_tokens);
+    rejected.query_tokens = std::move(query_tokens);
+    rejected.signal_events = std::move(signal_events);
+    rejected.signal_rejection_keepalives =
+        std::move(signal_rejection_keepalives);
+    rejected.translate_execution_class =
+        translate_execution_class;
+    rejected.resource_state_ownership =
+        resource_state_ownership;
+
+    // These containers can also own shared state or strings whose final
+    // release may execute arbitrary destructors. Move them away before the
+    // live object installs its replacement generation; their local lifetime
+    // ends only after that installation is complete.
+    Array<QueryToken> rejected_active_queries =
+        std::move(active_query_stack);
+
+    // Every potentially re-entrant owner now lives in rejected or a passive
+    // local. Mutating the moved-from containers below cannot destroy old
+    // payload.
+    commands.clear();
+    callbacks.clear();
+    success_callbacks.clear();
+    gpu_completion_tokens.clear();
+    query_tokens.clear();
+    active_query_stack.clear();
+    gpu_completion_cancellation_domain =
+        std::move(_preparation.completion_domain);
+    query_cancellation_domain =
+        std::move(_preparation.query_domain);
+    signal_events.clear();
+    signal_rejection_keepalives.clear();
+    cached_args.clear();
+    current_barriers = nullptr;
+    while (!scope_stack.empty()) {
+        scope_stack.pop();
+    }
+    timestamp_scope_names.clear();
+    translate_execution_class =
+        ERHITranslateExecutionClass::Parallel;
+    resource_state_ownership =
+        ERHIResourceStateOwnership::BackendTracked;
+    (void)rejected_active_queries;
+    return rejected;
 }
 
 bool CommandList::IsEmpty() const {
     return commands.empty() && callbacks.empty() &&
            success_callbacks.empty() && gpu_completion_tokens.empty() &&
-           signal_events.empty() &&
+           signal_events.empty() && signal_rejection_keepalives.empty() &&
            cached_args.empty() && query_tokens.empty() &&
            active_query_stack.empty();
 }
@@ -1183,13 +1293,13 @@ void CommandList::RejectPendingGpuCompletions(
 }
 
 void CommandList::RejectPendingSignals() noexcept {
-    for (const SignalEvent& signal : signal_events) {
-        auto* fence = reinterpret_cast<Fence*>(signal.timeline_handle);
-        if (fence != nullptr) {
-            fence->Reject(signal.value);
-        }
-    }
+    Array<SignalEvent> rejected_signals = std::move(signal_events);
+    Array<FenceRef> rejected_signal_keepalives =
+        std::move(signal_rejection_keepalives);
     signal_events.clear();
+    signal_rejection_keepalives.clear();
+    RejectDetachedSignalsNoexcept(rejected_signals);
+    (void)rejected_signal_keepalives;
 }
 
 void CommandList::Signal(Fence* _fence, uint64 _signal_value) {
@@ -1214,7 +1324,11 @@ void CommandList::Signal(const FenceRef& _fence, uint64 _signal_value) {
     std::function<void()> keepalive = [fence = _fence] {};
     callbacks.reserve(callbacks.size() + 1);
     signal_events.reserve(signal_events.size() + 1);
+    signal_rejection_keepalives.reserve(
+        signal_rejection_keepalives.size() + 1
+    );
     callbacks.emplace_back(std::move(keepalive));
+    signal_rejection_keepalives.emplace_back(_fence);
     signal_events.emplace_back(uint64(_fence.Get()), _signal_value);
 }
 

--- a/source/runtime/render/rhi/RHICompletion.h
+++ b/source/runtime/render/rhi/RHICompletion.h
@@ -33,6 +33,10 @@ class GpuCompletionToken;
 // Copyable host observation handle for one logical GPU submission. It does
 // not expose a backend fence: native synchronization remains owned by the
 // Submission/Completion pipeline. Pending transitions to Ready or Error once.
+// A terminal status is an observation result, not a recording-ownership
+// handoff. Opaque shutdown may publish Error while a producer or commit gate
+// is still Pending; only all ownership gates becoming terminal permits its
+// CommandList to be inspected.
 class RENDER_API GpuCompletionFuture {
     struct SharedState;
 
@@ -203,7 +207,9 @@ class CommandList;
 
 // Thread-safe shutdown view for one mutable CommandList generation. Cancel
 // publishes Error immediately so Wait/Get are bounded, while callback release
-// stays deferred until the producer reaches a safe ownership boundary.
+// stays deferred until the producer reaches a safe ownership boundary. It
+// neither completes producer/commit gates nor seals/transfers its CommandList;
+// their owners must still stop mutation and Signal()/Fail() those gates.
 class RENDER_API GpuCompletionCancellationView {
 public:
     GpuCompletionCancellationView() = default;

--- a/source/runtime/render/rhi/RHIExecutor.cpp
+++ b/source/runtime/render/rhi/RHIExecutor.cpp
@@ -489,18 +489,22 @@ void RejectRecordingSignalMetadata(
 bool RecordingSourceIsTerminal(
     const RHIRecordingSource& _source
 ) noexcept {
-    const bool producer_terminal =
-        _source.completion &&
-        _source.completion.Status() !=
-            ERHIRecordingStatus::Pending;
-    const bool transaction_terminal =
-        !_source.commit ||
-        _source.commit.Status() != ERHIRecordingStatus::Pending;
-    const bool mutable_owner_released =
-        !_source.command_list ||
-        !_source.command_list->HasManagedRecordingLease();
-    return producer_terminal && transaction_terminal &&
-           mutable_owner_released;
+    if (!_source.completion ||
+        _source.completion.Status() ==
+            ERHIRecordingStatus::Pending) {
+        return false;
+    }
+    if (_source.commit &&
+        _source.commit.Status() ==
+            ERHIRecordingStatus::Pending) {
+        return false;
+    }
+    // The recording and optional commit gates are the synchronization handoff
+    // for the producer-owned, non-atomic lease counter. Never inspect it while
+    // either gate remains Pending: RenderGraph releases the lease immediately
+    // before signaling its transaction gate.
+    return !_source.command_list ||
+           !_source.command_list->HasManagedRecordingLease();
 }
 
 // Future cancellation is one transaction across the complete recording group.

--- a/source/runtime/render/rhi/RHIExecutor.cpp
+++ b/source/runtime/render/rhi/RHIExecutor.cpp
@@ -5,14 +5,26 @@
 #include "rhi/RHIThreadOwnership.h"
 #include "vulkan/VulkanSubmissionExecutor.h"
 
+#include <atomic>
 #include <exception>
 #include <optional>
+#include <span>
 #include <stdexcept>
 #include <string_view>
+#include <type_traits>
 #include <utility>
 
 namespace Moer::Render {
 namespace {
+
+std::atomic<
+    const RHIDirectCommandListMaterializationOverrideForTesting*>
+    g_direct_command_list_materialization_override{nullptr};
+std::mutex g_direct_command_list_materialization_override_mutex{};
+std::condition_variable
+    g_direct_command_list_materialization_override_cv{};
+size_t g_direct_command_list_materialization_active_callbacks{0};
+bool g_direct_command_list_materialization_override_retiring{false};
 
 bool RejectOwnedThreadBlockingCall(std::string_view _operation) {
     if (IsRHIBlockingCallAllowedOnCurrentThread()) {
@@ -47,6 +59,43 @@ private:
     F callback;
 };
 
+void InvokeDirectCommandListMaterializationOverrideForTesting(
+    size_t _source_index
+) {
+    const auto* override =
+        g_direct_command_list_materialization_override.load(
+            std::memory_order_acquire
+        );
+    if (override == nullptr) {
+        return;
+    }
+    {
+        std::lock_guard lock(
+            g_direct_command_list_materialization_override_mutex
+        );
+        if (g_direct_command_list_materialization_override_retiring ||
+            g_direct_command_list_materialization_override.load(
+                std::memory_order_relaxed
+            ) != override) {
+            return;
+        }
+        ++g_direct_command_list_materialization_active_callbacks;
+    }
+    ScopeExit release_reader([&]() noexcept {
+        std::lock_guard lock(
+            g_direct_command_list_materialization_override_mutex
+        );
+        assert(
+            g_direct_command_list_materialization_active_callbacks != 0
+        );
+        --g_direct_command_list_materialization_active_callbacks;
+        if (g_direct_command_list_materialization_active_callbacks == 0) {
+            g_direct_command_list_materialization_override_cv.notify_all();
+        }
+    });
+    override->before_source(override->context, _source_index);
+}
+
 GraphEventRef MakeCompletedBackendEvent() {
     GraphEventRef event = GraphEvent::CreateGraphEvent();
     event->TryUnlockSubsequents(EThread::UNKNOWN_THREAD);
@@ -66,6 +115,35 @@ bool SubmitHasWork(const CmdSubmit& _submit) {
 bool IsSubmissionQueue(EQueueType _queue) {
     return _queue == EQueueType::Graphics || _queue == EQueueType::Compute ||
            _queue == EQueueType::Copy;
+}
+
+struct PreparedCommandListRejection {
+    std::optional<CmdSubmit> payload{};
+};
+
+void InvokeCleanupCallbacks(
+    Array<std::function<void()>>& _callbacks,
+    std::string_view              _context
+) noexcept {
+    for (std::function<void()>& callback : _callbacks) {
+        if (!callback) {
+            continue;
+        }
+        try {
+            callback();
+        } catch (const std::exception& exception) {
+            try {
+                LOG_ERROR("{} cleanup callback threw: {}", _context, exception.what());
+            } catch (...) {
+            }
+        } catch (...) {
+            try {
+                LOG_ERROR("{} cleanup callback threw", _context);
+            } catch (...) {
+            }
+        }
+    }
+    _callbacks.clear();
 }
 
 bool BatchHasWork(const RHIBackendSubmissionBatch& _batch) {
@@ -118,14 +196,9 @@ void FinalizeRejectedSubmissions(
     } catch (...) {
     }
 
-    // A rejected producer must publish a terminal failure before ordinary
-    // callbacks run. Otherwise a later submission can wait forever for a
-    // timeline value which this frontend path silently discarded.
-    for (RHIBackendSubmissionBatchEntry& entry : _submits) {
-        entry.submit.RejectPendingSignals();
-    }
-
-    // Terminalize every query in the rejected batch before invoking any user
+    // Terminalize every host observation in the rejected batch before
+    // invoking Fence::Reject or any user callback. A Fence rejection hook may
+    // synchronously wait on a Future from this batch.
     // callback. A callback from an earlier submit is allowed to inspect or
     // wait on a query from a later submit without depending on callback order.
     const GpuCompletionPublishBatch completion_batch =
@@ -139,7 +212,6 @@ void FinalizeRejectedSubmissions(
             _reason, entry_batch
         );
     }
-
     const QueryPublishBatch query_batch =
         QueryBackendAccess::BeginPublishBatch();
     for (RHIBackendSubmissionBatchEntry& entry : _submits) {
@@ -148,6 +220,13 @@ void FinalizeRejectedSubmissions(
                 entry.submit.query_publish_batch :
                 query_batch;
         entry.submit.PublishPendingQueryErrors(_reason, entry_batch);
+    }
+
+    // Publication wakes Wait/Get but deliberately does not release callbacks.
+    // Signals must be terminal before callback notification, while publication
+    // first prevents a synchronous Fence::Reject hook from self-deadlocking.
+    for (RHIBackendSubmissionBatchEntry& entry : _submits) {
+        entry.submit.RejectPendingSignals();
     }
 
     // A Present receipt is a public observation boundary for the complete
@@ -205,36 +284,46 @@ void FinalizeRejectedCommandListGroup(
     const Array<GpuCompletionCancellationView>&
                                                 _completion_cancellations,
     const Array<QueryCancellationView>&         _query_cancellations,
+    Array<CommandList::RecordingRejectionPreparation>&
+                                                _rejection_preparations,
+    Array<PreparedCommandListRejection>&         _prepared,
     const Array<size_t>&                        _materialized_source_indices,
     Array<RHIBackendSubmissionBatchEntry>&&     _submits,
     RHIPresentRequest*                          _present,
     std::string_view                            _reason
 ) noexcept {
-    for (RHIBackendSubmissionBatchEntry& entry : _submits) {
-        entry.submit.RejectPendingSignals();
-    }
-    for (CommandList& command_list : _command_lists) {
-        command_list.RejectPendingSignals();
+    assert(
+        _completion_cancellations.size() == _command_lists.size() &&
+        _query_cancellations.size() == _command_lists.size() &&
+        _rejection_preparations.size() == _command_lists.size() &&
+        _prepared.size() == _command_lists.size()
+    );
+    size_t materialized_cursor = 0;
+    for (size_t source_index = 0;
+         source_index < _command_lists.size(); ++source_index) {
+        if (materialized_cursor < _materialized_source_indices.size() &&
+            _materialized_source_indices[materialized_cursor] ==
+                source_index) {
+            ++materialized_cursor;
+            continue;
+        }
+        _prepared[source_index].payload.emplace(
+            _command_lists[source_index].
+                PrepareRecordingRejectionDrain(
+                    std::move(
+                        _rejection_preparations[source_index]
+                    )
+                )
+        );
     }
 
-    const bool captured_every_completion_generation =
-        _completion_cancellations.size() ==
-        _command_lists.size();
     const GpuCompletionPublishBatch completion_batch =
         GpuCompletionBackendAccess::BeginPublishBatch();
-    if (captured_every_completion_generation) {
-        for (const GpuCompletionCancellationView& cancellation :
-             _completion_cancellations) {
-            (void)cancellation.PublishCancellation(
-                _reason, completion_batch
-            );
-        }
-    } else {
-        assert(_submits.empty());
-        for (CommandList& command_list : _command_lists) {
-            (void)command_list.GetGpuCompletionCancellationView().
-                PublishCancellation(_reason, completion_batch);
-        }
+    for (const GpuCompletionCancellationView& cancellation :
+         _completion_cancellations) {
+        (void)cancellation.PublishCancellation(
+            _reason, completion_batch
+        );
     }
     for (RHIBackendSubmissionBatchEntry& entry : _submits) {
         const GpuCompletionPublishBatch entry_batch =
@@ -245,26 +334,19 @@ void FinalizeRejectedCommandListGroup(
             _reason, entry_batch
         );
     }
-
-    const bool captured_every_query_generation =
-        _query_cancellations.size() == _command_lists.size();
-    const QueryPublishBatch query_batch =
-        QueryBackendAccess::BeginPublishBatch();
-    if (captured_every_query_generation) {
-        for (const QueryCancellationView& cancellation :
-             _query_cancellations) {
-            (void)cancellation.PublishCancellation(_reason, query_batch);
-        }
-    } else {
-        // Capture can fail only before materialization starts. This fallback
-        // therefore addresses each still-current CommandList generation
-        // without cancelling a fresh post-Submit generation.
-        assert(_submits.empty());
-        for (CommandList& command_list : _command_lists) {
-            (void)command_list.GetQueryCancellationView().PublishCancellation(
-                _reason, query_batch
+    for (PreparedCommandListRejection& source : _prepared) {
+        if (source.payload) {
+            source.payload->PublishPendingGpuCompletionErrors(
+                _reason, completion_batch
             );
         }
+    }
+
+    const QueryPublishBatch query_batch =
+        QueryBackendAccess::BeginPublishBatch();
+    for (const QueryCancellationView& cancellation :
+         _query_cancellations) {
+        (void)cancellation.PublishCancellation(_reason, query_batch);
     }
     for (RHIBackendSubmissionBatchEntry& entry : _submits) {
         const QueryPublishBatch entry_batch =
@@ -273,24 +355,34 @@ void FinalizeRejectedCommandListGroup(
                 query_batch;
         entry.submit.PublishPendingQueryErrors(_reason, entry_batch);
     }
+    for (PreparedCommandListRejection& source : _prepared) {
+        if (source.payload) {
+            source.payload->PublishPendingQueryErrors(
+                _reason, query_batch
+            );
+        }
+    }
+
+    // Every sibling host state is terminal before synchronous Fence rejection.
+    // Callback tickets remain retained until the notification phase below.
+    for (RHIBackendSubmissionBatchEntry& entry : _submits) {
+        entry.submit.RejectPendingSignals();
+    }
+    for (PreparedCommandListRejection& source : _prepared) {
+        if (source.payload) {
+            source.payload->RejectPendingSignals();
+        }
+    }
 
     // Query state publication is distinct from callback notification. Resolve
     // Present only after the complete group is terminal, then release Query
     // callbacks so they may synchronously observe or wait for that receipt.
     ResolveRejectedPresent(_present);
 
-    if (captured_every_completion_generation) {
-        for (const size_t source_index :
-             _materialized_source_indices) {
-            if (source_index >=
-                _completion_cancellations.size()) {
-                continue;
-            }
-            const GpuCompletionCancellationView& cancellation =
-                _completion_cancellations[source_index];
-            cancellation.NotifyCancellation(completion_batch);
-            cancellation.NotifyPublishedCancellation();
-        }
+    for (const GpuCompletionCancellationView& cancellation :
+         _completion_cancellations) {
+        cancellation.NotifyCancellation(completion_batch);
+        cancellation.NotifyPublishedCancellation();
     }
     for (RHIBackendSubmissionBatchEntry& entry : _submits) {
         entry.submit.NotifyPendingGpuCompletions(
@@ -299,20 +391,18 @@ void FinalizeRejectedCommandListGroup(
                 completion_batch
         );
     }
-
-    if (captured_every_query_generation) {
-        for (const size_t source_index : _materialized_source_indices) {
-            if (source_index >= _query_cancellations.size()) {
-                continue;
-            }
-            const QueryCancellationView& cancellation =
-                _query_cancellations[source_index];
-            cancellation.NotifyCancellation(query_batch);
-            // A generation may already carry an opaque-shutdown ticket owned
-            // by another batch. Signals are terminal now, so release that
-            // original owner as well.
-            cancellation.NotifyPublishedCancellation();
+    for (PreparedCommandListRejection& source : _prepared) {
+        if (source.payload) {
+            source.payload->NotifyPendingGpuCompletions(
+                completion_batch
+            );
         }
+    }
+
+    for (const QueryCancellationView& cancellation :
+         _query_cancellations) {
+        cancellation.NotifyCancellation(query_batch);
+        cancellation.NotifyPublishedCancellation();
     }
     for (RHIBackendSubmissionBatchEntry& entry : _submits) {
         entry.submit.NotifyPendingQueries(
@@ -321,66 +411,25 @@ void FinalizeRejectedCommandListGroup(
                 query_batch
         );
     }
+    for (PreparedCommandListRejection& source : _prepared) {
+        if (source.payload) {
+            source.payload->NotifyPendingQueries(query_batch);
+        }
+    }
 
     FinalizeRejectedSubmissions(std::move(_submits), _reason);
 
     size_t cleanup_callback_count = 0;
-    size_t materialized_cursor    = 0;
-    for (size_t source_index = 0; source_index < _command_lists.size();
-         ++source_index) {
-        if (materialized_cursor < _materialized_source_indices.size() &&
-            _materialized_source_indices[materialized_cursor] ==
-                source_index) {
-            ++materialized_cursor;
-            // Submit() already installed a fresh recording generation.
-            // Query callbacks may have re-entered it above; never drain that
-            // new work as part of rejecting the sealed prior generation.
+    for (PreparedCommandListRejection& source : _prepared) {
+        if (!source.payload) {
             continue;
         }
-        CommandList& command_list = _command_lists[source_index];
-        try {
-            Array<std::function<void()>> callbacks =
-                command_list.DrainOrdinaryCallbacksForRejection();
-            cleanup_callback_count += callbacks.size();
-            for (std::function<void()>& callback : callbacks) {
-                if (!callback) {
-                    continue;
-                }
-                try {
-                    callback();
-                } catch (const std::exception& exception) {
-                    try {
-                        LOG_ERROR(
-                            "[RHIExecutor] rejected CommandList-group cleanup callback threw: {}",
-                            exception.what()
-                        );
-                    } catch (...) {
-                    }
-                } catch (...) {
-                    try {
-                        LOG_ERROR(
-                            "[RHIExecutor] rejected CommandList-group cleanup callback threw"
-                        );
-                    } catch (...) {
-                    }
-                }
-            }
-        } catch (const std::exception& exception) {
-            try {
-                LOG_ERROR(
-                    "[RHIExecutor] failed to drain rejected CommandList group: {}",
-                    exception.what()
-                );
-            } catch (...) {
-            }
-        } catch (...) {
-            try {
-                LOG_ERROR(
-                    "[RHIExecutor] failed to drain rejected CommandList group"
-                );
-            } catch (...) {
-            }
-        }
+        cleanup_callback_count += source.payload->callbacks.size();
+        InvokeCleanupCallbacks(
+            source.payload->callbacks,
+            "[RHIExecutor] rejected CommandList group"
+        );
+        source.payload->success_callbacks.clear();
     }
     try {
         LOG_ERROR(
@@ -395,16 +444,37 @@ void FinalizeRejectedCommandListGroup(
 }
 
 void RejectRecordingSignalMetadata(
-    const Array<RHIRecordingSource>& _sources
+    const Array<RHIRecordingSource>& _sources,
+    std::span<const uint8>           _owned_snapshot = {},
+    std::span<const size_t>          _transferred_signal_prefixes = {}
 ) noexcept {
     // Metadata is prepared source-by-source and preparation can allocate.
     // If any step throws, the entire immutable recording transaction is
-    // rejected, including producer values not yet copied into CmdSubmit.
-    // Fence rejection is idempotent, so already-materialized values may be
-    // terminalized again by FinalizeRejectedSubmissions below.
-    for (const RHIRecordingSource& source : _sources) {
-        for (const RHIRecordingFencePoint& point :
-             source.submit_metadata.signal_fences) {
+    // rejected, including producer values not yet transferred into CmdSubmit.
+    // A per-source committed prefix records points now owned by an immutable
+    // submit, so this fallback never invokes Fence::Reject twice and the
+    // published metadata itself remains immutable.
+    for (size_t source_index = 0;
+         source_index < _sources.size(); ++source_index) {
+        if (!_owned_snapshot.empty() &&
+            (source_index >= _owned_snapshot.size() ||
+             _owned_snapshot[source_index] != uint8{1})) {
+            continue;
+        }
+        const RHIRecordingSource& source = _sources[source_index];
+        const size_t transferred_prefix =
+            !_transferred_signal_prefixes.empty() &&
+                source_index < _transferred_signal_prefixes.size() ?
+                std::min(
+                    _transferred_signal_prefixes[source_index],
+                    source.submit_metadata.signal_fences.size()
+                ) :
+                0;
+        for (size_t signal_index = transferred_prefix;
+             signal_index < source.submit_metadata.signal_fences.size();
+             ++signal_index) {
+            const RHIRecordingFencePoint& point =
+                source.submit_metadata.signal_fences[signal_index];
             if (!point.fence.IsValid() || point.value == 0) {
                 continue;
             }
@@ -416,9 +486,21 @@ void RejectRecordingSignalMetadata(
     }
 }
 
-bool RecordingSourceIsTerminal(const RHIRecordingSource& _source) noexcept {
-    return _source.completion &&
-           _source.completion.Status() != ERHIRecordingStatus::Pending;
+bool RecordingSourceIsTerminal(
+    const RHIRecordingSource& _source
+) noexcept {
+    const bool producer_terminal =
+        _source.completion &&
+        _source.completion.Status() !=
+            ERHIRecordingStatus::Pending;
+    const bool transaction_terminal =
+        !_source.commit ||
+        _source.commit.Status() != ERHIRecordingStatus::Pending;
+    const bool mutable_owner_released =
+        !_source.command_list ||
+        !_source.command_list->HasManagedRecordingLease();
+    return producer_terminal && transaction_terminal &&
+           mutable_owner_released;
 }
 
 // Future cancellation is one transaction across the complete recording group.
@@ -428,41 +510,49 @@ bool RecordingSourceIsTerminal(const RHIRecordingSource& _source) noexcept {
 // but defer callback notification until their CommandList is safely owned.
 void TerminalizeRecordingSourceQueries(
     Array<RHIRecordingSource>& _sources,
-    std::string_view            _reason
+    std::string_view            _reason,
+    std::span<const uint8>      _terminal_snapshot = {},
+    std::span<PreparedCommandListRejection> _prepared = {}
 ) noexcept {
     // Status must be sampled exactly once. A producer may cross Pending ->
     // terminal after this snapshot; treating that source as terminal only in
     // the notification pass could run its Query callbacks before its still
     // opaque CommandList signals have been rejected.
-    Array<uint8> terminal_snapshot{};
-    try {
-        terminal_snapshot.resize(_sources.size(), uint8{0});
-    } catch (...) {
-        // Allocation failure is fail-closed: publish every Query Error below,
-        // but defer all callbacks until the owning CommandList is drained or
-        // submitted and can establish signal-before-query ordering.
-        terminal_snapshot.clear();
+    Array<uint8> local_terminal_snapshot{};
+    if (_terminal_snapshot.size() != _sources.size()) {
+        try {
+            local_terminal_snapshot.resize(
+                _sources.size(), uint8{0}
+            );
+            for (size_t source_index = 0;
+                 source_index < _sources.size(); ++source_index) {
+                local_terminal_snapshot[source_index] =
+                    RecordingSourceIsTerminal(
+                        _sources[source_index]
+                    ) ? uint8{1} : uint8{0};
+            }
+            _terminal_snapshot = local_terminal_snapshot;
+        } catch (...) {
+            // Allocation failure is fail-closed: publish every Error below,
+            // but release no callback until a later ownership boundary.
+            _terminal_snapshot = {};
+        }
     }
     const bool snapshot_available =
-        terminal_snapshot.size() == _sources.size();
-
-    for (size_t source_index = 0; source_index < _sources.size();
-         ++source_index) {
-        RHIRecordingSource& source = _sources[source_index];
-        const bool terminal = RecordingSourceIsTerminal(source);
-        if (snapshot_available) {
-            terminal_snapshot[source_index] = terminal ? uint8{1} : uint8{0};
-        }
-        if (terminal && source.command_list) {
-            source.command_list->RejectPendingSignals();
-        }
-    }
+        _terminal_snapshot.size() == _sources.size();
 
     const GpuCompletionPublishBatch completion_batch =
         GpuCompletionBackendAccess::BeginPublishBatch();
     for (RHIRecordingSource& source : _sources) {
         (void)source.gpu_completion_cancellation.
             PublishCancellation(_reason, completion_batch);
+    }
+    for (PreparedCommandListRejection& source : _prepared) {
+        if (source.payload) {
+            source.payload->PublishPendingGpuCompletionErrors(
+                _reason, completion_batch
+            );
+        }
     }
 
     const QueryPublishBatch query_batch =
@@ -472,17 +562,47 @@ void TerminalizeRecordingSourceQueries(
             _reason, query_batch
         );
     }
+    for (PreparedCommandListRejection& source : _prepared) {
+        if (source.payload) {
+            source.payload->PublishPendingQueryErrors(
+                _reason, query_batch
+            );
+        }
+    }
     if (snapshot_available) {
         for (size_t source_index = 0; source_index < _sources.size();
              ++source_index) {
-            if (terminal_snapshot[source_index] != 0) {
+            if (_terminal_snapshot[source_index] != 0) {
                 _sources[source_index].
                     gpu_completion_cancellation.NotifyCancellation(
                         completion_batch
                     );
-                _sources[source_index].query_cancellation.NotifyCancellation(
-                    query_batch
+                _sources[source_index].
+                    gpu_completion_cancellation.
+                        NotifyPublishedCancellation();
+            }
+        }
+        for (PreparedCommandListRejection& source : _prepared) {
+            if (source.payload) {
+                source.payload->NotifyPendingGpuCompletions(
+                    completion_batch
                 );
+            }
+        }
+        for (size_t source_index = 0; source_index < _sources.size();
+             ++source_index) {
+            if (_terminal_snapshot[source_index] == 0) {
+                continue;
+            }
+            _sources[source_index].query_cancellation.NotifyCancellation(
+                query_batch
+            );
+            _sources[source_index].query_cancellation.
+                NotifyPublishedCancellation();
+        }
+        for (PreparedCommandListRejection& source : _prepared) {
+            if (source.payload) {
+                source.payload->NotifyPendingQueries(query_batch);
             }
         }
     }
@@ -561,78 +681,132 @@ void ReportBackendPublicationFailure(
 
 void FinalizeCancelledRecordingSources(
     Array<RHIRecordingSource>&& _sources,
-    std::string_view             _reason
-) {
-    RejectRecordingSignalMetadata(_sources);
-    TerminalizeRecordingSourceQueries(_sources, _reason);
+    std::string_view             _reason,
+    Array<CommandList::RecordingRejectionPreparation>&
+                                 _rejection_preparations,
+    Array<PreparedCommandListRejection>& _prepared,
+    Array<uint8>&               _terminal_snapshot
+) noexcept {
     // A source protected by an incomplete recording gate must remain opaque:
     // even reading IsEmpty(), let alone draining callbacks, races its producer.
     // A terminal gate, however, is the ownership handoff point and its ordinary
     // callbacks still own CPU/resource cleanup even when shutdown cancels the
     // FIFO before the source can be materialized. Success-only callbacks must
     // never run because no GPU submission was published.
+    assert(
+        _rejection_preparations.size() == _sources.size() &&
+        _prepared.size() == _sources.size() &&
+        _terminal_snapshot.size() == _sources.size()
+    );
+    std::fill(
+        _terminal_snapshot.begin(),
+        _terminal_snapshot.end(),
+        uint8{0}
+    );
     size_t terminal_source_count = 0;
-    size_t opaque_source_count   = 0;
     size_t cleanup_callback_count = 0;
-    for (RHIRecordingSource& source : _sources) {
-        const bool terminal =
-            source.completion &&
-            source.completion.Status() != ERHIRecordingStatus::Pending;
-        if (!terminal) {
-            ++opaque_source_count;
-            continue;
-        }
-
-        ++terminal_source_count;
-        if (!source.command_list) {
-            continue;
-        }
-        try {
-            auto source_callbacks =
-                source.command_list->DrainOrdinaryCallbacksForRejection();
-            cleanup_callback_count += source_callbacks.size();
-            for (std::function<void()>& callback : source_callbacks) {
-                if (!callback) {
-                    continue;
-                }
-                try {
-                    callback();
-                } catch (const std::exception& exception) {
-                    LOG_ERROR(
-                        "[RHIExecutor] cancelled-recording cleanup callback threw: {}",
-                        exception.what()
-                    );
-                } catch (...) {
-                    LOG_ERROR("[RHIExecutor] cancelled-recording cleanup callback threw");
-                }
+    // Publish host Errors for the complete group before invoking any
+    // Fence::Reject hook. The all-zero snapshot intentionally releases no
+    // callback: ownership-complete sources are discovered and detached by the
+    // fixed-point loop below, while opaque sources remain callback-deferred.
+    TerminalizeRecordingSourceQueries(
+        _sources, _reason, _terminal_snapshot, _prepared
+    );
+    const auto prepare_newly_terminal_sources = [&]() {
+        bool prepared_any = false;
+        for (size_t source_index = 0;
+             source_index < _sources.size(); ++source_index) {
+            if (_terminal_snapshot[source_index] != 0) {
+                continue;
             }
-        } catch (const std::exception& exception) {
-            LOG_ERROR(
-                "[RHIExecutor] failed to drain cancelled recording source cleanup: {}",
-                exception.what()
+            RHIRecordingSource& source = _sources[source_index];
+            if (!RecordingSourceIsTerminal(source)) {
+                continue;
+            }
+
+            _terminal_snapshot[source_index] = uint8{1};
+            ++terminal_source_count;
+            prepared_any = true;
+            if (!source.command_list) {
+                continue;
+            }
+            _prepared[source_index].payload.emplace(
+                source.command_list->
+                    PrepareRecordingRejectionDrain(
+                        std::move(
+                            _rejection_preparations[source_index]
+                        )
+                    )
             );
-        } catch (...) {
-            LOG_ERROR("[RHIExecutor] failed to drain cancelled recording source cleanup");
+            cleanup_callback_count +=
+                _prepared[source_index].payload->callbacks.size();
+        }
+        return prepared_any;
+    };
+
+    // Sanitize every ownership-complete frontier before its metadata or
+    // payload Fence rejection. A rejection hook may synchronously complete
+    // another producer/commit gate; the next iteration detaches that newly
+    // owned generation before touching any of its re-entrant observers.
+    while (prepare_newly_terminal_sources()) {
+        RejectRecordingSignalMetadata(
+            _sources, _terminal_snapshot
+        );
+        for (size_t source_index = 0;
+             source_index < _prepared.size(); ++source_index) {
+            if (_terminal_snapshot[source_index] != uint8{1}) {
+                continue;
+            }
+            if (_prepared[source_index].payload) {
+                _prepared[source_index].payload->
+                    RejectPendingSignals();
+            }
+            _terminal_snapshot[source_index] = uint8{2};
         }
     }
 
-    LOG_WARNING(
-        "[RHIExecutor] rejected {} recording source(s): {}; "
-        "terminal_sources={} opaque_sources={} cleanup_callbacks={}",
-        _sources.size(),
-        _reason,
-        terminal_source_count,
-        opaque_source_count,
-        cleanup_callback_count
+    // Sources still absent from the fixed point remain opaque and receive
+    // Error publication without callback release.
+    const size_t opaque_source_count =
+        _sources.size() - terminal_source_count;
+    TerminalizeRecordingSourceQueries(
+        _sources, _reason, _terminal_snapshot, _prepared
     );
-    _sources.clear();
+    for (PreparedCommandListRejection& source : _prepared) {
+        if (!source.payload) {
+            continue;
+        }
+        InvokeCleanupCallbacks(
+            source.payload->callbacks,
+            "[RHIExecutor] cancelled recording"
+        );
+        source.payload->success_callbacks.clear();
+    }
+
+    try {
+        LOG_WARNING(
+            "[RHIExecutor] rejected {} recording source(s): {}; "
+            "terminal_sources={} opaque_sources={} cleanup_callbacks={}",
+            _sources.size(),
+            _reason,
+            terminal_source_count,
+            opaque_source_count,
+            cleanup_callback_count
+        );
+    } catch (...) {
+    }
 }
 
 void FinalizeFailedRecordingSources(
     Array<RHIRecordingSource>&& _sources,
-    std::string_view             _reason
-) {
-    RejectRecordingSignalMetadata(_sources);
+    std::string_view             _reason,
+    Array<CommandList::RecordingRejectionPreparation>&
+                                 _rejection_preparations,
+    Array<PreparedCommandListRejection>& _prepared,
+    Array<uint8>&               _terminal_snapshot,
+    Array<RHIBackendSubmissionBatchEntry> _materialized_submits = {},
+    std::span<const size_t> _metadata_signal_transfer_prefixes = {}
+) noexcept {
     // Reject is emitted only after every producer gate is terminal. This is
     // the ownership point at which failed/partial CommandLists are immutable
     // and may be destructively drained for their ordinary cleanup callbacks.
@@ -642,63 +816,194 @@ void FinalizeFailedRecordingSources(
         _sources.begin(),
         _sources.end(),
         [](const RHIRecordingSource& _source) {
-            return _source.completion &&
-                   _source.completion.Status() != ERHIRecordingStatus::Pending;
+            return RecordingSourceIsTerminal(_source);
         }
     );
     if (!all_terminal) {
-        LOG_ERROR(
-            "[RHIExecutor] failed recording group resolved before every producer became terminal"
-        );
+        try {
+            LOG_ERROR(
+                "[RHIExecutor] failed recording group resolved before every producer became terminal"
+            );
+        } catch (...) {
+        }
+        // Materialization is entered only after the handoff queue observes
+        // every prerequisite terminal. Keep this invariant explicit: an
+        // immutable prefix combined with an opaque producer cannot be safely
+        // notified as one transaction.
+        assert(_materialized_submits.empty());
         FinalizeCancelledRecordingSources(
             std::move(_sources),
-            "failed recording group still has a mutable producer"
+            "failed recording group still has a mutable producer",
+            _rejection_preparations,
+            _prepared,
+            _terminal_snapshot
         );
+        if (!_materialized_submits.empty()) {
+            FinalizeRejectedSubmissions(
+                std::move(_materialized_submits),
+                "failed recording group still has a mutable producer"
+            );
+        }
         return;
     }
-    TerminalizeRecordingSourceQueries(_sources, _reason);
 
     const size_t source_count = _sources.size();
+    assert(
+        _rejection_preparations.size() == _sources.size() &&
+        _prepared.size() == _sources.size() &&
+        _terminal_snapshot.size() == _sources.size()
+    );
     size_t       cleanup_callback_count = 0;
-    for (RHIRecordingSource& source : _sources) {
+    for (size_t source_index = 0; source_index < _sources.size();
+         ++source_index) {
+        RHIRecordingSource& source = _sources[source_index];
         if (!source.command_list) {
             continue;
         }
-        try {
-            auto source_callbacks =
-                source.command_list->DrainOrdinaryCallbacksForRejection();
-            cleanup_callback_count += source_callbacks.size();
-            for (std::function<void()>& callback : source_callbacks) {
-                if (!callback) {
-                    continue;
-                }
-                try {
-                    callback();
-                } catch (const std::exception& exception) {
-                    LOG_ERROR(
-                        "[RHIExecutor] rejected-recording cleanup callback threw: {}",
-                        exception.what()
-                    );
-                } catch (...) {
-                    LOG_ERROR("[RHIExecutor] rejected-recording cleanup callback threw");
-                }
-            }
-        } catch (const std::exception& exception) {
-            LOG_ERROR(
-                "[RHIExecutor] failed to drain rejected recording source cleanup: {}",
-                exception.what()
+        _prepared[source_index].payload.emplace(
+            source.command_list->
+                PrepareRecordingRejectionDrain(
+                    std::move(
+                        _rejection_preparations[source_index]
+                    )
+                )
+        );
+        cleanup_callback_count +=
+            _prepared[source_index].payload->callbacks.size();
+    }
+
+    // Publish every source-owned and already-materialized Future before
+    // notifying any one of them. A callback from either half may therefore
+    // synchronously wait on every sibling without depending on callback order.
+    const GpuCompletionPublishBatch completion_batch =
+        GpuCompletionBackendAccess::BeginPublishBatch();
+    for (RHIRecordingSource& source : _sources) {
+        (void)source.gpu_completion_cancellation.PublishCancellation(
+            _reason, completion_batch
+        );
+    }
+    for (RHIBackendSubmissionBatchEntry& entry : _materialized_submits) {
+        const GpuCompletionPublishBatch entry_batch =
+            entry.submit.gpu_completion_publish_batch.Valid() ?
+                entry.submit.gpu_completion_publish_batch :
+                completion_batch;
+        entry.submit.PublishPendingGpuCompletionErrors(
+            _reason, entry_batch
+        );
+    }
+    for (PreparedCommandListRejection& source : _prepared) {
+        if (source.payload) {
+            source.payload->PublishPendingGpuCompletionErrors(
+                _reason, completion_batch
             );
-        } catch (...) {
-            LOG_ERROR("[RHIExecutor] failed to drain rejected recording source cleanup");
         }
     }
-    _sources.clear();
-    LOG_ERROR(
-        "[RHIExecutor] rejected {} completed recording source(s): {}; cleanup_callbacks={}",
-        source_count,
-        _reason,
-        cleanup_callback_count
+
+    const QueryPublishBatch query_batch =
+        QueryBackendAccess::BeginPublishBatch();
+    for (RHIRecordingSource& source : _sources) {
+        (void)source.query_cancellation.PublishCancellation(
+            _reason, query_batch
+        );
+    }
+    for (RHIBackendSubmissionBatchEntry& entry : _materialized_submits) {
+        const QueryPublishBatch entry_batch =
+            entry.submit.query_publish_batch.Valid() ?
+                entry.submit.query_publish_batch :
+                query_batch;
+        entry.submit.PublishPendingQueryErrors(_reason, entry_batch);
+    }
+    for (PreparedCommandListRejection& source : _prepared) {
+        if (source.payload) {
+            source.payload->PublishPendingQueryErrors(
+                _reason, query_batch
+            );
+        }
+    }
+
+    // Batch phase B: every sibling has installed a fresh generation and every
+    // host observation is terminal before synchronous Fence rejection. A
+    // prefix may already be an immutable CmdSubmit; its signals remain owned
+    // here and must be rejected before callback notification.
+    RejectRecordingSignalMetadata(
+        _sources, {}, _metadata_signal_transfer_prefixes
     );
+    for (RHIBackendSubmissionBatchEntry& entry : _materialized_submits) {
+        entry.submit.RejectPendingSignals();
+    }
+    for (PreparedCommandListRejection& source : _prepared) {
+        if (source.payload) {
+            source.payload->RejectPendingSignals();
+        }
+    }
+
+    for (RHIRecordingSource& source : _sources) {
+        source.gpu_completion_cancellation.NotifyCancellation(
+            completion_batch
+        );
+        source.gpu_completion_cancellation.
+            NotifyPublishedCancellation();
+    }
+    for (RHIBackendSubmissionBatchEntry& entry : _materialized_submits) {
+        entry.submit.NotifyPendingGpuCompletions(
+            entry.submit.gpu_completion_publish_batch.Valid() ?
+                entry.submit.gpu_completion_publish_batch :
+                completion_batch
+        );
+    }
+    for (PreparedCommandListRejection& source : _prepared) {
+        if (source.payload) {
+            source.payload->NotifyPendingGpuCompletions(
+                completion_batch
+            );
+        }
+    }
+    for (RHIRecordingSource& source : _sources) {
+        source.query_cancellation.NotifyCancellation(query_batch);
+        source.query_cancellation.NotifyPublishedCancellation();
+    }
+    for (RHIBackendSubmissionBatchEntry& entry : _materialized_submits) {
+        entry.submit.NotifyPendingQueries(
+            entry.submit.query_publish_batch.Valid() ?
+                entry.submit.query_publish_batch :
+                query_batch
+        );
+    }
+    for (PreparedCommandListRejection& source : _prepared) {
+        if (source.payload) {
+            source.payload->NotifyPendingQueries(query_batch);
+        }
+    }
+
+    for (RHIBackendSubmissionBatchEntry& entry : _materialized_submits) {
+        cleanup_callback_count += entry.submit.callbacks.size();
+        InvokeCleanupCallbacks(
+            entry.submit.callbacks,
+            "[RHIExecutor] rejected materialized recording"
+        );
+        entry.submit.success_callbacks.clear();
+    }
+    for (PreparedCommandListRejection& source : _prepared) {
+        if (!source.payload) {
+            continue;
+        }
+        InvokeCleanupCallbacks(
+            source.payload->callbacks,
+            "[RHIExecutor] rejected recording"
+        );
+        source.payload->success_callbacks.clear();
+    }
+    try {
+        LOG_ERROR(
+            "[RHIExecutor] rejected {} completed recording source(s): {}; "
+            "materialized_submits={} cleanup_callbacks={}",
+            source_count,
+            _reason,
+            _materialized_submits.size(),
+            cleanup_callback_count
+        );
+    } catch (...) {
+    }
 }
 
 struct ReadySubmissionPayload {
@@ -709,6 +1014,11 @@ struct ReadySubmissionPayload {
 
 struct RecordingSubmissionPayload {
     Array<RHIRecordingSource> sources{};
+    Array<CommandList::RecordingRejectionPreparation>
+                              rejection_preparations{};
+    Array<PreparedCommandListRejection>
+                              prepared_rejections{};
+    Array<uint8>              terminal_snapshot{};
     ERHIExecSubmitFlags       flags{ERHIExecSubmitFlags::FlushGPU};
 };
 
@@ -1000,6 +1310,57 @@ std::exception_ptr TryPublishBackendBatch(
 
 } // namespace
 
+bool TryInstallRHIDirectCommandListMaterializationOverrideForTesting(
+    const RHIDirectCommandListMaterializationOverrideForTesting* _override
+) noexcept {
+    if (_override == nullptr || _override->before_source == nullptr) {
+        return false;
+    }
+    std::lock_guard lock(
+        g_direct_command_list_materialization_override_mutex
+    );
+    if (g_direct_command_list_materialization_override_retiring ||
+        g_direct_command_list_materialization_override.load(
+            std::memory_order_relaxed
+        ) != nullptr) {
+        return false;
+    }
+    g_direct_command_list_materialization_override.store(
+        _override, std::memory_order_release
+    );
+    return true;
+}
+
+bool RemoveRHIDirectCommandListMaterializationOverrideForTesting(
+    const RHIDirectCommandListMaterializationOverrideForTesting* _override
+) noexcept {
+    if (_override == nullptr) {
+        return false;
+    }
+    std::unique_lock lock(
+        g_direct_command_list_materialization_override_mutex
+    );
+    if (g_direct_command_list_materialization_override_retiring ||
+        g_direct_command_list_materialization_override.load(
+            std::memory_order_relaxed
+        ) != _override) {
+        return false;
+    }
+    g_direct_command_list_materialization_override_retiring = true;
+    g_direct_command_list_materialization_override.store(
+        nullptr, std::memory_order_release
+    );
+    g_direct_command_list_materialization_override_cv.wait(
+        lock,
+        [] {
+            return g_direct_command_list_materialization_active_callbacks ==
+                   0;
+        }
+    );
+    g_direct_command_list_materialization_override_retiring = false;
+    return true;
+}
+
 RHIExecutor& RHIExecutor::Get() {
     static RHIExecutor executor;
     return executor;
@@ -1099,23 +1460,41 @@ void RHIExecutor::Submit(
         payload->present.emplace(std::move(*_present));
     }
 
-    recording_handoff.RouteReady(RHIExecutorRecordingHandoffWork{
-        .prerequisites = {},
-        .resolve = [this, payload](ERHIRecordingHandoffResult _result) mutable {
-            RHIPresentRequest* present = payload->present.has_value() ?
-                                             &*payload->present :
-                                             nullptr;
-            if (_result != ERHIRecordingHandoffResult::Consume) {
-                FinalizeRejectedSubmissions(
+    try {
+        recording_handoff.RouteReady(RHIExecutorRecordingHandoffWork{
+            .prerequisites = {},
+            .resolve = [this, payload](
+                           ERHIRecordingHandoffResult _result
+                       ) mutable {
+                RHIPresentRequest* present =
+                    payload->present.has_value() ?
+                        &*payload->present :
+                        nullptr;
+                if (_result != ERHIRecordingHandoffResult::Consume) {
+                    FinalizeRejectedSubmissions(
+                        std::move(payload->submits),
+                        "recording handoff is stopped",
+                        present
+                    );
+                    return;
+                }
+                SubmitReady(
                     std::move(payload->submits),
-                    "recording handoff is stopped",
+                    payload->flags,
                     present
                 );
-                return;
-            }
-            SubmitReady(std::move(payload->submits), payload->flags, present);
-        },
-    });
+            },
+        });
+    } catch (...) {
+        RHIPresentRequest* present = payload->present.has_value() ?
+                                         &*payload->present :
+                                         nullptr;
+        FinalizeRejectedSubmissions(
+            std::move(payload->submits),
+            "ready handoff queue admission failed",
+            present
+        );
+    }
 }
 
 void RHIExecutor::SubmitReady(
@@ -1146,6 +1525,14 @@ void RHIExecutor::SubmitReady(
     // it.  `_flags` controls the backend flush depth, not whether the sealed
     // batch becomes visible to the backend FIFO.
     if (_present != nullptr) {
+        static_assert(
+            std::is_nothrow_move_constructible_v<
+                RHIBackendSubmissionBatchEntry
+            >
+        );
+        static_assert(
+            std::is_nothrow_move_constructible_v<RHIPresentRequest>
+        );
         bool reject_before_dispatch = false;
         {
             std::lock_guard lock(submit_mutex);
@@ -1165,6 +1552,7 @@ void RHIExecutor::SubmitReady(
         std::shared_ptr<RHIBackendExecutor> backend{};
         std::exception_ptr                  backend_creation_failure{};
         std::exception_ptr                  backend_publication_failure{};
+        std::exception_ptr                  staging_failure{};
         bool                                rejected = false;
         {
             std::lock_guard dispatch_lock(dispatch_mutex);
@@ -1173,26 +1561,36 @@ void RHIExecutor::SubmitReady(
                 rejected = lifecycle_state != ELifecycleState::Running ||
                            pending_present.has_value();
                 if (!rejected) {
-                    pending_submits.reserve(pending_submits.size() + _submits.size());
-                    for (RHIBackendSubmissionBatchEntry& entry : _submits) {
-                        pending_submits.emplace_back(std::move(entry));
-                    }
-                    pending_present.emplace(std::move(*_present));
                     try {
-                        // Construct the backend before detaching the accepted
-                        // payload from executor ownership. If construction
-                        // fails, move that payload into an explicit rejection
-                        // batch instead of letting a resolver exception destroy
-                        // callbacks and the Present receipt silently.
-                        backend = GetBackendExecutorLocked();
-                        batch   = TakePendingBatchLocked();
+                        pending_submits.reserve(
+                            pending_submits.size() + _submits.size()
+                        );
                     } catch (...) {
-                        backend_creation_failure = std::current_exception();
-                        failed_batch             = TakePendingBatchLocked();
+                        staging_failure = std::current_exception();
+                    }
+                    if (!staging_failure) {
+                        for (RHIBackendSubmissionBatchEntry& entry :
+                             _submits) {
+                            pending_submits.emplace_back(
+                                std::move(entry)
+                            );
+                        }
+                        pending_present.emplace(std::move(*_present));
+                        try {
+                            // Construct the backend before detaching the
+                            // accepted payload from executor ownership.
+                            backend = GetBackendExecutorLocked();
+                            batch   = TakePendingBatchLocked();
+                        } catch (...) {
+                            backend_creation_failure =
+                                std::current_exception();
+                            failed_batch = TakePendingBatchLocked();
+                        }
                     }
                 }
             }
-            if (!rejected && !backend_creation_failure) {
+            if (!rejected && !staging_failure &&
+                !backend_creation_failure) {
                 backend_publication_failure = TryPublishBackendBatch(
                     backend,
                     batch,
@@ -1203,6 +1601,17 @@ void RHIExecutor::SubmitReady(
                     backend->Flush(ERHIFlushDepth::SubmitGPU);
                 }
             }
+        }
+        if (staging_failure) {
+            ReportBackendCreationFailure(
+                "Present staging", staging_failure
+            );
+            FinalizeRejectedSubmissions(
+                std::move(_submits),
+                "allocation failed while staging Present",
+                _present
+            );
+            return;
         }
         if (backend_creation_failure) {
             ReportBackendCreationFailure("Present", backend_creation_failure);
@@ -1232,17 +1641,36 @@ void RHIExecutor::SubmitReady(
         return;
     }
 
-    bool rejected = false;
+    bool               rejected = false;
+    std::exception_ptr staging_failure{};
     {
         std::lock_guard lock(submit_mutex);
         rejected = lifecycle_state != ELifecycleState::Running ||
                    pending_present.has_value();
         if (!rejected) {
-            pending_submits.reserve(pending_submits.size() + _submits.size());
-            for (RHIBackendSubmissionBatchEntry& entry : _submits) {
-                pending_submits.emplace_back(std::move(entry));
+            try {
+                pending_submits.reserve(
+                    pending_submits.size() + _submits.size()
+                );
+            } catch (...) {
+                staging_failure = std::current_exception();
+            }
+            if (!staging_failure) {
+                for (RHIBackendSubmissionBatchEntry& entry : _submits) {
+                    pending_submits.emplace_back(std::move(entry));
+                }
             }
         }
+    }
+    if (staging_failure) {
+        ReportBackendCreationFailure(
+            "submission staging", staging_failure
+        );
+        FinalizeRejectedSubmissions(
+            std::move(_submits),
+            "allocation failed while staging submission"
+        );
+        return;
     }
     if (rejected) {
         FinalizeRejectedSubmissions(
@@ -1261,15 +1689,37 @@ void RHIExecutor::Submit(
     ERHIExecSubmitFlags  _flags,
     RHIPresentRequest*   _present
 ) {
+    // A managed recording lease is an exclusive mutable-owner capability.
+    // There is no cooperative cancellation handoff in this direct value-owned
+    // API, so rejection cannot safely inspect, drain, or notify that
+    // generation. Fail before capturing views or mutating any sibling; the
+    // caller may release the lease and retry the intact transaction.
+    if (std::any_of(
+            _command_lists.begin(),
+            _command_lists.end(),
+            [](const CommandList& command_list) {
+                return command_list.HasManagedRecordingLease();
+            }
+        )) {
+        throw std::logic_error(
+            "RHIExecutor::Submit cannot consume a CommandList group while a managed recording lease is active"
+        );
+    }
+
     Array<RHIBackendSubmissionBatchEntry> submits{};
     Array<GpuCompletionCancellationView> completion_cancellations{};
     Array<QueryCancellationView> query_cancellations{};
+    Array<CommandList::RecordingRejectionPreparation>
+        rejection_preparations{};
+    Array<PreparedCommandListRejection> prepared_rejections{};
     Array<size_t> materialized_source_indices{};
     try {
         submits.reserve(_command_lists.size());
         completion_cancellations.reserve(_command_lists.size());
         query_cancellations.reserve(_command_lists.size());
         materialized_source_indices.reserve(_command_lists.size());
+        rejection_preparations.resize(_command_lists.size());
+        prepared_rejections.resize(_command_lists.size());
         for (CommandList& command_list : _command_lists) {
             completion_cancellations.emplace_back(
                 command_list.GetGpuCompletionCancellationView()
@@ -1286,31 +1736,15 @@ void RHIExecutor::Submit(
             );
         } catch (...) {
         }
-        FinalizeRejectedCommandListGroup(
-            _command_lists,
-            completion_cancellations,
-            query_cancellations,
-            materialized_source_indices,
-            std::move(submits),
-            _present,
-            "CommandList group preparation failed"
-        );
-        return;
+        // No CommandList has been touched yet. Propagate the allocation
+        // failure with the complete caller-owned transaction intact.
+        throw;
     } catch (...) {
         try {
             LOG_ERROR("[RHIExecutor] failed to prepare CommandList group");
         } catch (...) {
         }
-        FinalizeRejectedCommandListGroup(
-            _command_lists,
-            completion_cancellations,
-            query_cancellations,
-            materialized_source_indices,
-            std::move(submits),
-            _present,
-            "CommandList group preparation failed"
-        );
-        return;
+        throw;
     }
 
     const bool group_valid = std::all_of(
@@ -1326,6 +1760,8 @@ void RHIExecutor::Submit(
             _command_lists,
             completion_cancellations,
             query_cancellations,
+            rejection_preparations,
+            prepared_rejections,
             materialized_source_indices,
             std::move(submits),
             _present,
@@ -1342,6 +1778,9 @@ void RHIExecutor::Submit(
             if (command_list.IsEmpty()) {
                 continue;
             }
+            InvokeDirectCommandListMaterializationOverrideForTesting(
+                source_index
+            );
             const EQueueType queue = command_list.GetQueueType();
             submits.emplace_back(queue, command_list.Submit());
             materialized_source_indices.emplace_back(source_index);
@@ -1358,6 +1797,8 @@ void RHIExecutor::Submit(
             _command_lists,
             completion_cancellations,
             query_cancellations,
+            rejection_preparations,
+            prepared_rejections,
             materialized_source_indices,
             std::move(submits),
             _present,
@@ -1373,6 +1814,8 @@ void RHIExecutor::Submit(
             _command_lists,
             completion_cancellations,
             query_cancellations,
+            rejection_preparations,
+            prepared_rejections,
             materialized_source_indices,
             std::move(submits),
             _present,
@@ -1444,6 +1887,14 @@ void RHIExecutor::SubmitRecording(
         return;
     }
 
+    Array<CommandList::RecordingRejectionPreparation>
+        rejection_preparations{};
+    Array<PreparedCommandListRejection> prepared_rejections{};
+    Array<uint8> terminal_snapshot{};
+    rejection_preparations.resize(_sources.size());
+    prepared_rejections.resize(_sources.size());
+    terminal_snapshot.resize(_sources.size(), uint8{0});
+
     const bool sources_valid = std::all_of(
         _sources.begin(),
         _sources.end(),
@@ -1455,18 +1906,17 @@ void RHIExecutor::SubmitRecording(
     if (!sources_valid) {
         FinalizeCancelledRecordingSources(
             std::move(_sources),
-            "missing completion gate or invalid queue"
+            "missing completion gate or invalid queue",
+            rejection_preparations,
+            prepared_rejections,
+            terminal_snapshot
         );
         return;
     }
 
-    auto payload     = std::make_shared<RecordingSubmissionPayload>();
-    payload->sources = std::move(_sources);
-    payload->flags   = _flags;
-
     std::vector<RHIRecordingGateRef> prerequisites{};
-    prerequisites.reserve(payload->sources.size() * 2);
-    for (const RHIRecordingSource& source : payload->sources) {
+    prerequisites.reserve(_sources.size() * 2);
+    for (const RHIRecordingSource& source : _sources) {
         prerequisites.emplace_back(source.completion.gate);
         if (source.commit &&
             std::find(
@@ -1478,29 +1928,55 @@ void RHIExecutor::SubmitRecording(
         }
     }
 
-    recording_handoff.EnqueueRecording(RHIExecutorRecordingHandoffWork{
-        .prerequisites = std::move(prerequisites),
-        .resolve = [this, payload](ERHIRecordingHandoffResult _result) mutable {
+    auto payload     = std::make_shared<RecordingSubmissionPayload>();
+    payload->sources = std::move(_sources);
+    payload->rejection_preparations =
+        std::move(rejection_preparations);
+    payload->prepared_rejections =
+        std::move(prepared_rejections);
+    payload->terminal_snapshot =
+        std::move(terminal_snapshot);
+    payload->flags   = _flags;
+
+    try {
+        recording_handoff.EnqueueRecording(
+            RHIExecutorRecordingHandoffWork{
+                .prerequisites = std::move(prerequisites),
+                .resolve = [this, payload](
+                               ERHIRecordingHandoffResult _result
+                           ) mutable {
             if (_result == ERHIRecordingHandoffResult::Cancel) {
                 FinalizeCancelledRecordingSources(
                     std::move(payload->sources),
-                    "completion gate cancelled during shutdown"
+                    "completion gate cancelled during shutdown",
+                    payload->rejection_preparations,
+                    payload->prepared_rejections,
+                    payload->terminal_snapshot
                 );
                 return;
             }
             if (_result == ERHIRecordingHandoffResult::Reject) {
                 FinalizeFailedRecordingSources(
                     std::move(payload->sources),
-                    "recording completion gate failed"
+                    "recording completion gate failed",
+                    payload->rejection_preparations,
+                    payload->prepared_rejections,
+                    payload->terminal_snapshot
                 );
                 return;
             }
 
             Array<RHIBackendSubmissionBatchEntry> submits{};
             Array<size_t> materialized_source_indices{};
-            submits.reserve(payload->sources.size());
-            materialized_source_indices.reserve(payload->sources.size());
+            Array<size_t> metadata_signal_transfer_prefixes{};
             try {
+                submits.reserve(payload->sources.size());
+                materialized_source_indices.reserve(
+                    payload->sources.size()
+                );
+                metadata_signal_transfer_prefixes.resize(
+                    payload->sources.size(), size_t{0}
+                );
                 // Validate the entire immutable group before transferring the
                 // first source. An unclosed query must not run rejection
                 // callbacks while a later source in the transaction is still
@@ -1571,6 +2047,21 @@ void RHIExecutor::SubmitRecording(
                         metadata.wait_fences.size() +
                         metadata.signal_fences.size()
                     );
+                    submit.wait_events.reserve(
+                        submit.wait_events.size() +
+                        metadata.wait_fences.size()
+                    );
+                    submit.signal_events.reserve(
+                        submit.signal_events.size() +
+                        metadata.signal_fences.size()
+                    );
+                    submit.signal_rejection_keepalives.reserve(
+                        submit.signal_rejection_keepalives.size() +
+                        metadata.signal_fences.size()
+                    );
+                    submit.callbacks.reserve(
+                        submit.callbacks.size() + 1
+                    );
                     for (const RHIRecordingFencePoint& point :
                          metadata.wait_fences) {
                         if (!point.fence.IsValid() || point.value == 0) {
@@ -1590,10 +2081,16 @@ void RHIExecutor::SubmitRecording(
                                 "recording signal fence point is invalid"
                             );
                         }
+                        submit.signal_rejection_keepalives.emplace_back(
+                            point.fence
+                        );
+                        sync_keepalive->emplace_back(point.fence);
                         submit.signal_events.emplace_back(
                             uint64(point.fence.Get()), point.value
                         );
-                        sync_keepalive->emplace_back(point.fence);
+                        ++metadata_signal_transfer_prefixes[
+                            materialized_source_indices[submit_index]
+                        ];
                     }
                     if (!sync_keepalive->empty()) {
                         // CmdSubmit callbacks are retained by the native
@@ -1602,52 +2099,54 @@ void RHIExecutor::SubmitRecording(
                     }
                 }
             } catch (const std::exception& exception) {
-                LOG_ERROR(
-                    "[RHIExecutor] failed to materialize recording sources: {}",
-                    exception.what()
-                );
-                RejectRecordingSignalMetadata(payload->sources);
-                for (RHIBackendSubmissionBatchEntry& entry : submits) {
-                    entry.submit.RejectPendingSignals();
-                }
-                TerminalizeRecordingSourceQueries(
-                    payload->sources,
-                    "recording source finalization failed"
-                );
-                FinalizeRejectedSubmissions(
-                    std::move(submits),
-                    "recording source finalization failed"
-                );
                 FinalizeFailedRecordingSources(
                     std::move(payload->sources),
-                    "recording source finalization failed"
+                    "recording source finalization failed",
+                    payload->rejection_preparations,
+                    payload->prepared_rejections,
+                    payload->terminal_snapshot,
+                    std::move(submits),
+                    metadata_signal_transfer_prefixes
                 );
+                try {
+                    LOG_ERROR(
+                        "[RHIExecutor] failed to materialize recording sources: {}",
+                        exception.what()
+                    );
+                } catch (...) {
+                }
                 return;
             } catch (...) {
-                LOG_ERROR("[RHIExecutor] failed to materialize recording sources");
-                RejectRecordingSignalMetadata(payload->sources);
-                for (RHIBackendSubmissionBatchEntry& entry : submits) {
-                    entry.submit.RejectPendingSignals();
-                }
-                TerminalizeRecordingSourceQueries(
-                    payload->sources,
-                    "recording source finalization failed"
-                );
-                FinalizeRejectedSubmissions(
-                    std::move(submits),
-                    "recording source finalization failed"
-                );
                 FinalizeFailedRecordingSources(
                     std::move(payload->sources),
-                    "recording source finalization failed"
+                    "recording source finalization failed",
+                    payload->rejection_preparations,
+                    payload->prepared_rejections,
+                    payload->terminal_snapshot,
+                    std::move(submits),
+                    metadata_signal_transfer_prefixes
                 );
+                try {
+                    LOG_ERROR(
+                        "[RHIExecutor] failed to materialize recording sources"
+                    );
+                } catch (...) {
+                }
                 return;
             }
 
             payload->sources.clear();
             SubmitReady(std::move(submits), payload->flags, nullptr);
-        },
-    });
+                },
+            }
+        );
+    } catch (...) {
+        // Work construction/queue admission is still part of preparation.
+        // No producer generation has been inspected or sealed, so restore the
+        // exact source transaction to the caller and propagate the failure.
+        _sources = std::move(payload->sources);
+        throw;
+    }
 }
 
 void RHIExecutor::Present(RHIPresentRequest&& _present, bool _flush) {

--- a/source/runtime/render/rhi/RHIExecutor.h
+++ b/source/runtime/render/rhi/RHIExecutor.h
@@ -21,6 +21,9 @@ struct RHIRecordingSubmitMetadata {
     float4                                     debug_label_color{GpuMarkerPalette::Pass()};
     std::optional<ERHIProfilingPhase>          profiling_phase{};
     std::optional<ERHITranslateExecutionClass> translate_execution_class{};
+    // Shutdown leaves this metadata untouched while either the producer or
+    // optional commit gate is Pending. Those fences remain with the opaque
+    // graph owner until the complete ownership boundary becomes terminal.
     Array<RHIRecordingFencePoint>              wait_fences{};
     Array<RHIRecordingFencePoint>              signal_fences{};
     /**
@@ -48,10 +51,38 @@ struct RHIRecordingSource {
     // Stable, thread-safe cancellation seam for the CommandList generation
     // being recorded. Shutdown may cancel pending host futures through these
     // views without reading or destroying a producer-owned command stream.
+    // Publishing Error only bounds host waiters: it neither completes the
+    // completion/commit gates nor transfers CommandList ownership. An opaque
+    // producer must still stop mutation and Signal()/Fail() its gate.
     GpuCompletionCancellationView
                                 gpu_completion_cancellation{};
     QueryCancellationView        query_cancellation{};
 };
+
+using RHIDirectCommandListMaterializationCallbackForTesting =
+    void (*)(void*, size_t);
+
+struct RHIDirectCommandListMaterializationOverrideForTesting {
+    void* context{nullptr};
+    RHIDirectCommandListMaterializationCallbackForTesting
+        before_source{nullptr};
+};
+
+// Narrow deterministic seam for exercising the mixed direct-submit rollback:
+// the callback runs immediately before a non-empty CommandList is sealed. It
+// may throw to emulate CommandList::Submit allocation failure, but must not
+// re-enter RHI or remove its own override. Storage is caller-owned and
+// immutable while installed. Successful removal waits for every callback that
+// already acquired the override, so the caller may then destroy both override
+// and context safely.
+[[nodiscard]] RENDER_API bool
+TryInstallRHIDirectCommandListMaterializationOverrideForTesting(
+    const RHIDirectCommandListMaterializationOverrideForTesting* _override
+) noexcept;
+[[nodiscard]] RENDER_API bool
+RemoveRHIDirectCommandListMaterializationOverrideForTesting(
+    const RHIDirectCommandListMaterializationOverrideForTesting* _override
+) noexcept;
 
 class RENDER_API RHIExecutor {
 public:

--- a/source/runtime/render/rhi/RHIExecutorBackend.h
+++ b/source/runtime/render/rhi/RHIExecutorBackend.h
@@ -4,6 +4,7 @@
 #include "taskgraph/GraphTask.h"
 
 #include <optional>
+#include <utility>
 
 namespace Moer::Render {
 
@@ -36,6 +37,31 @@ struct RHIPresentRequest {
     PresentReceiptRef receipt{};
 
     RHIPresentRequest() = default;
+    RHIPresentRequest(const RHIPresentRequest&) = default;
+    RHIPresentRequest& operator=(
+        const RHIPresentRequest&
+    ) = default;
+
+    RHIPresentRequest(RHIPresentRequest&& _other) noexcept :
+        source(_other.source) {
+        swapchain.Swap(_other.swapchain);
+        source_texture.Swap(_other.source_texture);
+        receipt.swap(_other.receipt);
+        _other.source = {};
+    }
+
+    RHIPresentRequest& operator=(
+        RHIPresentRequest&& _other
+    ) noexcept {
+        if (this == &_other) {
+            return *this;
+        }
+        swapchain.Swap(_other.swapchain);
+        source_texture.Swap(_other.source_texture);
+        receipt.swap(_other.receipt);
+        std::swap(source, _other.source);
+        return *this;
+    }
 
     RHIPresentRequest(
         SwapchainRef      _swapchain,

--- a/source/runtime/render/rhi/RHIQuery.h
+++ b/source/runtime/render/rhi/RHIQuery.h
@@ -55,7 +55,8 @@ class QueryToken;
 
 // Copyable handle to a single terminal query result. Resolution is one-shot:
 // Pending may transition to Ready or Error exactly once and never changes
-// afterwards.
+// afterwards. A terminal result is not a recording-ownership handoff: opaque
+// shutdown may publish Error while a producer or commit gate remains Pending.
 class RENDER_API QueryFuture {
     struct SharedState;
 
@@ -246,7 +247,9 @@ public:
     // user callbacks remain deferred until the owning CommandList reaches a
     // submission/destruction/rejection boundary. This makes the view safe for
     // opaque-producer shutdown without releasing client code on the arbitrary
-    // cancellation thread.
+    // cancellation thread. Error publication does not complete the recording
+    // gate or transfer CommandList ownership; the producer/graph remains the
+    // sole mutable owner until every producer and commit gate is terminal.
     bool Cancel(std::string_view _reason = "query generation was cancelled") const noexcept;
 
     // Cross-source rejection uses the same two-phase transaction as native

--- a/source/runtime/render/rhi/d3d12/D3D12Device.cpp
+++ b/source/runtime/render/rhi/d3d12/D3D12Device.cpp
@@ -1534,11 +1534,33 @@ WaitEvent D3D12GraphicsCommandQueue::Execute(CmdSubmit&& _submit) {
             if (!armed || submit == nullptr) {
                 return;
             }
+            const std::string_view rejection_reason =
+                "D3D12 submission was rejected before GPU completion";
+            const GpuCompletionPublishBatch completion_batch =
+                submit->gpu_completion_publish_batch.Valid() ?
+                    submit->gpu_completion_publish_batch :
+                    GpuCompletionBackendAccess::BeginPublishBatch();
+            submit->PublishPendingGpuCompletionErrors(
+                rejection_reason, completion_batch
+            );
+            const QueryPublishBatch query_batch =
+                submit->query_publish_batch.Valid() ?
+                    submit->query_publish_batch :
+                    QueryBackendAccess::BeginPublishBatch();
+            submit->PublishPendingQueryErrors(
+                rejection_reason, query_batch
+            );
+            Array<SignalEvent> rejected_signals =
+                std::move(submit->signal_events);
+            Array<FenceRef> rejected_signal_keepalives =
+                std::move(submit->signal_rejection_keepalives);
+            submit->signal_events.clear();
+            submit->signal_rejection_keepalives.clear();
             // Conservative fail-closed semantics: if translation, descriptor
             // setup, command-list close, Execute or any queue Signal throws,
             // no external waiter may treat this partially published source as
             // an accepted history transaction.
-            for (const SignalEvent& event : submit->signal_events) {
+            for (const SignalEvent& event : rejected_signals) {
                 auto* fence =
                     reinterpret_cast<D3D12Fence*>(event.timeline_handle);
                 if (fence == nullptr) {
@@ -1549,6 +1571,7 @@ WaitEvent D3D12GraphicsCommandQueue::Execute(CmdSubmit&& _submit) {
                 } catch (...) {
                 }
             }
+            (void)rejected_signal_keepalives;
         }
     } signal_failure_guard{&_submit};
 
@@ -1814,6 +1837,7 @@ WaitEvent D3D12GraphicsCommandQueue::Execute(CmdSubmit&& _submit) {
     _submit.query_tokens.clear();
     _submit.query_publish_batch = {};
     _submit.signal_events.clear();
+    _submit.signal_rejection_keepalives.clear();
     pending_fence_values.Enqueue(next_fence_value);
     retirement_lock.unlock();
     cv.notify_one();

--- a/source/runtime/render/rhi/vulkan/VulkanQueue.cpp
+++ b/source/runtime/render/rhi/vulkan/VulkanQueue.cpp
@@ -4945,11 +4945,6 @@ static void TerminalizeRejectedSubmit(
     }
 
     _device.RecordRejectedSubmit();
-    TerminalizeUnsubmittedSignals(
-        _device,
-        _submit.signal_events,
-        VulkanOperationResult{EVulkanOperationStatus::Rejected, _result}
-    );
     FinalizeRejectedBindlessUpdates(_submit);
     const GpuCompletionPublishBatch completion_batch =
         _submit.gpu_completion_publish_batch.Valid() ?
@@ -4963,6 +4958,17 @@ static void TerminalizeRejectedSubmit(
         _context, completion_batch
     );
     _submit.PublishPendingQueryErrors(_context, query_batch);
+    Array<SignalEvent> rejected_signals =
+        std::move(_submit.signal_events);
+    Array<FenceRef> rejected_signal_keepalives =
+        std::move(_submit.signal_rejection_keepalives);
+    _submit.signal_events.clear();
+    _submit.signal_rejection_keepalives.clear();
+    TerminalizeUnsubmittedSignals(
+        _device,
+        rejected_signals,
+        VulkanOperationResult{EVulkanOperationStatus::Rejected, _result}
+    );
     _submit.NotifyPendingGpuCompletions(completion_batch);
     _submit.NotifyPendingQueries(query_batch);
 
@@ -4976,10 +4982,10 @@ static void TerminalizeRejectedSubmit(
     _submit.cached_args.clear();
     _submit.segments.clear();
     _submit.wait_events.clear();
-    _submit.signal_events.clear();
     _submit.debug_label.clear();
 
     InvokeCallbacksNoexcept(callbacks, _context);
+    (void)rejected_signal_keepalives;
 }
 
 VkCommandQueue::VkCommandQueue(
@@ -5458,19 +5464,30 @@ void VkCommandQueue::RejectForRuntime(
     vk_device.RecordRejectedSubmit();
 
     try {
-        TerminalizeUnsubmittedSignals(
-            vk_device,
-            _submit.signal_events,
-            outcome
+        const std::string_view rejection_reason =
+            "Vulkan runtime rejected the submit before GPU completion";
+        const GpuCompletionPublishBatch completion_batch =
+            _submit.gpu_completion_publish_batch.Valid() ?
+                _submit.gpu_completion_publish_batch :
+                GpuCompletionBackendAccess::BeginPublishBatch();
+        _submit.PublishPendingGpuCompletionErrors(
+            rejection_reason, completion_batch
         );
-        // Rejection is now externally observable. Completion must not retain
-        // and dereference the raw fence pointers after a waiter releases its
-        // last FenceRef.
-        _submit.signal_events.clear();
         PublishUnsubmittedQueryErrors(
             _submit,
             nullptr,
-            "Vulkan runtime rejected the submit before GPU completion"
+            rejection_reason
+        );
+        Array<SignalEvent> rejected_signals =
+            std::move(_submit.signal_events);
+        Array<FenceRef> rejected_signal_keepalives =
+            std::move(_submit.signal_rejection_keepalives);
+        _submit.signal_events.clear();
+        _submit.signal_rejection_keepalives.clear();
+        TerminalizeUnsubmittedSignals(
+            vk_device,
+            rejected_signals,
+            outcome
         );
         std::unique_lock<std::mutex> lock(event_mutex);
         const uint64 retirement_serial = retirement_enqueued_serial + 1;
@@ -5512,6 +5529,7 @@ void VkCommandQueue::RejectForRuntime(
             );
         }
         retirement_enqueued_serial = retirement_serial;
+        (void)rejected_signal_keepalives;
     } catch (...) {
         // Continuing would destroy callbacks/signals outside Completion and
         // violate the ownership contract. Allocation failure is therefore
@@ -5879,26 +5897,40 @@ void VkCommandQueue::CommitRuntimeSubmitCompletion(
     assert(!_recorded.completion_committed);
     try {
         if (!_outcome.WasSubmitted()) {
+            _recorded.allocators.abandoned.reserve(
+                _recorded.allocators.abandoned.size() +
+                _recorded.allocators.submitted.size()
+            );
+            const std::string_view rejection_reason =
+                "Vulkan submission was rejected before GPU completion";
+            const GpuCompletionPublishBatch completion_batch =
+                _recorded.submit.gpu_completion_publish_batch.Valid() ?
+                    _recorded.submit.gpu_completion_publish_batch :
+                    GpuCompletionBackendAccess::BeginPublishBatch();
+            _recorded.submit.PublishPendingGpuCompletionErrors(
+                rejection_reason, completion_batch
+            );
+            PublishUnsubmittedQueryErrors(
+                _recorded.submit,
+                &_recorded.allocators,
+                rejection_reason
+            );
             TerminalizeUnsubmittedSignal(
                 vk_device,
                 timeline,
                 _recorded.timeline,
                 _outcome
             );
-            TerminalizeUnsubmittedSignals(
-                vk_device, _recorded.submit.signal_events, _outcome
-            );
-            // Exact signal rejection is published by Submission. Do not
-            // retain raw external fence pointers in the Completion packet.
+            Array<SignalEvent> rejected_signals =
+                std::move(_recorded.submit.signal_events);
+            Array<FenceRef> rejected_signal_keepalives =
+                std::move(
+                    _recorded.submit.signal_rejection_keepalives
+                );
             _recorded.submit.signal_events.clear();
-            PublishUnsubmittedQueryErrors(
-                _recorded.submit,
-                &_recorded.allocators,
-                "Vulkan submission was rejected before GPU completion"
-            );
-            _recorded.allocators.abandoned.reserve(
-                _recorded.allocators.abandoned.size() +
-                _recorded.allocators.submitted.size()
+            _recorded.submit.signal_rejection_keepalives.clear();
+            TerminalizeUnsubmittedSignals(
+                vk_device, rejected_signals, _outcome
             );
             for (auto& allocator : _recorded.allocators.submitted) {
                 _recorded.allocators.abandoned.emplace_back(
@@ -5906,6 +5938,7 @@ void VkCommandQueue::CommitRuntimeSubmitCompletion(
                 );
             }
             _recorded.allocators.submitted.clear();
+            (void)rejected_signal_keepalives;
         }
 
         std::unique_lock<std::mutex> lock(event_mutex);
@@ -10094,6 +10127,24 @@ void VkCopyQueue::CommitRuntimeSubmitCompletion(
     assert(!_recorded.completion_committed);
     try {
         if (!_outcome.WasSubmitted()) {
+            _recorded.allocators.abandoned.reserve(
+                _recorded.allocators.abandoned.size() +
+                _recorded.allocators.submitted.size()
+            );
+            const std::string_view rejection_reason =
+                "Vulkan Copy submission was rejected before GPU completion";
+            const GpuCompletionPublishBatch completion_batch =
+                _recorded.submit.gpu_completion_publish_batch.Valid() ?
+                    _recorded.submit.gpu_completion_publish_batch :
+                    GpuCompletionBackendAccess::BeginPublishBatch();
+            _recorded.submit.PublishPendingGpuCompletionErrors(
+                rejection_reason, completion_batch
+            );
+            PublishUnsubmittedQueryErrors(
+                _recorded.submit,
+                &_recorded.allocators,
+                rejection_reason
+            );
             if (_recorded.logical_timeline != 0) {
                 TerminalizeUnsubmittedSignal(
                     device,
@@ -10102,20 +10153,16 @@ void VkCopyQueue::CommitRuntimeSubmitCompletion(
                     _outcome
                 );
             }
-            TerminalizeUnsubmittedSignals(
-                device, _recorded.submit.signal_events, _outcome
-            );
-            // Exact signal rejection is published by Submission. Do not
-            // retain raw external fence pointers in the Completion packet.
+            Array<SignalEvent> rejected_signals =
+                std::move(_recorded.submit.signal_events);
+            Array<FenceRef> rejected_signal_keepalives =
+                std::move(
+                    _recorded.submit.signal_rejection_keepalives
+                );
             _recorded.submit.signal_events.clear();
-            PublishUnsubmittedQueryErrors(
-                _recorded.submit,
-                &_recorded.allocators,
-                "Vulkan Copy submission was rejected before GPU completion"
-            );
-            _recorded.allocators.abandoned.reserve(
-                _recorded.allocators.abandoned.size() +
-                _recorded.allocators.submitted.size()
+            _recorded.submit.signal_rejection_keepalives.clear();
+            TerminalizeUnsubmittedSignals(
+                device, rejected_signals, _outcome
             );
             for (auto& allocator : _recorded.allocators.submitted) {
                 _recorded.allocators.abandoned.emplace_back(
@@ -10123,6 +10170,7 @@ void VkCopyQueue::CommitRuntimeSubmitCompletion(
                 );
             }
             _recorded.allocators.submitted.clear();
+            (void)rejected_signal_keepalives;
         }
         std::unique_lock<std::mutex> lock(event_mutex);
         const uint64 retirement_serial = retirement_enqueued_serial + 1;

--- a/source/runtime/render/rhi/vulkan/VulkanSubmissionDiagnostics.h
+++ b/source/runtime/render/rhi/vulkan/VulkanSubmissionDiagnostics.h
@@ -135,6 +135,12 @@ struct VulkanMultiSegmentCompletionProbeResult {
     bool   repeated_retirement_suppressed{false};
     uint32 ordinary_callback_count{0};
     uint32 success_callback_count{0};
+    uint32 materialized_prefix_signal_count{0};
+    uint32 materialized_prefix_keepalive_count{0};
+    uint32 materialized_suffix_signal_count{0};
+    uint32 materialized_suffix_keepalive_count{0};
+    bool   materialized_signal_identity_matches{false};
+    bool   source_signal_remained_unrejected{false};
 };
 
 [[nodiscard]] RENDER_API VulkanMultiSegmentCompletionProbeResult

--- a/source/runtime/render/rhi/vulkan/VulkanSubmissionExecutor.cpp
+++ b/source/runtime/render/rhi/vulkan/VulkanSubmissionExecutor.cpp
@@ -407,6 +407,20 @@ struct VulkanOriginalSourceMaterialization {
     std::shared_ptr<VulkanMultiSegmentCompletionState> completion{};
 };
 
+class VulkanMaterializationProbeCommand final : public Command {
+public:
+    explicit VulkanMaterializationProbeCommand(EQueueType _queue) :
+        Command(EType::Custom, "VulkanMaterializationProbe"),
+        queue(_queue) {}
+
+    EQueueType GetQueueType() const override {
+        return queue;
+    }
+
+private:
+    EQueueType queue{EQueueType::Graphics};
+};
+
 CmdSubmit MakeEmptySubmit() {
     return CmdSubmit(
         Array<UniquePtr<Command>>{},
@@ -679,6 +693,11 @@ MaterializeMultiSegmentBatch(RHIBackendSubmissionBatch& _batch, const RHIQueueTo
                          source_submit.signal_events.size() :
                          0)
             );
+            segment_submit.signal_rejection_keepalives.reserve(
+                1 + (segment_plan.inherit_source_signal_events_and_callbacks ?
+                         source_submit.signal_rejection_keepalives.size() :
+                         0)
+            );
             segment_submit.wait_events.reserve(
                 (segment_plan.inherit_source_wait_events ? source_submit.wait_events.size() : 0) + 1
             );
@@ -707,6 +726,9 @@ MaterializeMultiSegmentBatch(RHIBackendSubmissionBatch& _batch, const RHIQueueTo
                 .timeline_handle = uint64(segment_outcome.Get()),
                 .value           = 1,
             });
+            segment_submit.signal_rejection_keepalives.emplace_back(
+                segment_outcome
+            );
             segment_submit.callbacks.emplace_back([completion = materialization.completion, segment_index] {
                 completion->RetireOrdinary(segment_index);
             });
@@ -826,10 +848,17 @@ MaterializeMultiSegmentBatch(RHIBackendSubmissionBatch& _batch, const RHIQueueTo
         for (const SignalEvent& signal : source_entry.submit.signal_events) {
             last_submit.signal_events.emplace_back(signal);
         }
+        for (FenceRef& keepalive :
+             source_entry.submit.signal_rejection_keepalives) {
+            last_submit.signal_rejection_keepalives.emplace_back(
+                std::move(keepalive)
+            );
+        }
         // Signal ownership has moved to the last executable segment. Leaving
         // the original handles live would make CmdSubmit::~CmdSubmit reject
         // values that have already been accepted by the native queue.
         source_entry.submit.signal_events.clear();
+        source_entry.submit.signal_rejection_keepalives.clear();
     }
 
     _batch.submits  = std::move(executable_sources);
@@ -908,6 +937,109 @@ VulkanMultiSegmentCompletionProbeResult RunVulkanMultiSegmentCompletionProbeForT
     result.repeated_retirement_suppressed = ordinary_callback_count == 1 && success_callback_count == 0;
     result.ordinary_callback_count        = ordinary_callback_count;
     result.success_callback_count         = success_callback_count;
+
+    CmdSubmit source_submit = MakeEmptySubmit();
+    source_submit.cmds.emplace_back(
+        MakeUnique<VulkanMaterializationProbeCommand>(
+            EQueueType::Graphics
+        )
+    );
+    source_submit.cmds.emplace_back(
+        MakeUnique<VulkanMaterializationProbeCommand>(
+            EQueueType::Compute
+        )
+    );
+    source_submit.segments = {
+        RHISubmitSegment{EQueueType::Graphics, 0, 1},
+        RHISubmitSegment{EQueueType::Compute, 1, 2},
+    };
+    source_submit.resource_state_ownership =
+        ERHIResourceStateOwnership::Explicit;
+    source_submit.async_queue_scope = 0x50483139414B4545ull;
+
+    FenceRef source_signal = RenderDevice::Get().CreateFence();
+    if (!source_signal.IsValid()) {
+        throw std::runtime_error(
+            "multi-segment materialization probe failed to create source fence"
+        );
+    }
+    auto* source_fence = ResourceCast(source_signal.Get());
+    source_submit.signal_events.emplace_back(SignalEvent{
+        .timeline_handle = uint64(source_signal.Get()),
+        .value           = 7,
+    });
+    source_submit.signal_rejection_keepalives.emplace_back(
+        source_signal
+    );
+
+    RHIBackendSubmissionBatch batch{};
+    batch.sequence = 0x504831394D41544Cull;
+    const RHISourceSubmitDescription description{
+        .root_queue      = EQueueType::Graphics,
+        .command_count   = source_submit.cmds.size(),
+        .segments        = source_submit.segments,
+        .execution_class = source_submit.translate_execution_class,
+        .has_side_effects = true,
+    };
+    batch.topology = BuildRHISubmissionTopology(
+        std::span<const RHISourceSubmitDescription>(
+            &description, 1
+        ),
+        batch.sequence
+    );
+    if (!batch.topology.IsValid()) {
+        throw std::runtime_error(
+            "multi-segment materialization probe built an invalid topology"
+        );
+    }
+    batch.submits.emplace_back(
+        EQueueType::Graphics, std::move(source_submit)
+    );
+
+    const VulkanSegmentMaterializationResult materialization =
+        MaterializeMultiSegmentBatch(
+            batch, RenderDevice::Get().GetQueueTopology()
+        );
+    if (!materialization.changed || batch.submits.size() != 2) {
+        throw std::runtime_error(
+            "multi-segment materialization probe did not split its source"
+        );
+    }
+
+    const CmdSubmit& prefix_submit = batch.submits[0].submit;
+    const CmdSubmit& suffix_submit = batch.submits[1].submit;
+    result.materialized_prefix_signal_count =
+        static_cast<uint32>(prefix_submit.signal_events.size());
+    result.materialized_prefix_keepalive_count =
+        static_cast<uint32>(
+            prefix_submit.signal_rejection_keepalives.size()
+        );
+    result.materialized_suffix_signal_count =
+        static_cast<uint32>(suffix_submit.signal_events.size());
+    result.materialized_suffix_keepalive_count =
+        static_cast<uint32>(
+            suffix_submit.signal_rejection_keepalives.size()
+        );
+    result.materialized_signal_identity_matches =
+        prefix_submit.signal_events.size() == 1 &&
+        prefix_submit.signal_rejection_keepalives.size() == 1 &&
+        prefix_submit.signal_events.front().timeline_handle ==
+            uint64(
+                prefix_submit.signal_rejection_keepalives.front().Get()
+            ) &&
+        suffix_submit.signal_events.size() == 2 &&
+        suffix_submit.signal_rejection_keepalives.size() == 2 &&
+        suffix_submit.signal_events.front().timeline_handle ==
+            uint64(
+                suffix_submit.signal_rejection_keepalives.front().Get()
+            ) &&
+        suffix_submit.signal_events.back().timeline_handle ==
+            uint64(source_signal.Get()) &&
+        suffix_submit.signal_rejection_keepalives.back().Get() ==
+            source_signal.Get();
+    result.source_signal_remained_unrejected =
+        source_fence != nullptr && !source_fence->IsRejected(7) &&
+        !source_fence->IsFailed();
     return result;
 }
 
@@ -1253,21 +1385,56 @@ void VulkanSubmissionExecutor::BatchRejectionPublication::PublishSuffix(
     bool             _recoverable,
     std::string_view _reason
 ) noexcept {
-    std::lock_guard lock(mutex);
     const size_t begin = std::min(_reject_from, sources.size());
     const VkResult result =
         _result == static_cast<int32>(VK_SUCCESS) ?
             VK_ERROR_UNKNOWN :
             static_cast<VkResult>(_result);
 
-    // Every signal in the suffix is terminal before any Query state is
-    // published. User Query callbacks remain deferred to their queue
-    // Completion packets, but Wait/Get can already observe the whole suffix.
+    const std::string_view reason =
+        _reason.empty() ?
+            "Vulkan submission suffix was rejected before GPU completion" :
+            _reason;
+
+    uint64 publication_epoch = 0;
+    std::lock_guard lock(mutex);
+    publication_epoch = next_publication_epoch++;
+    if (publication_epoch == 0) {
+        publication_epoch = next_publication_epoch++;
+    }
     for (size_t source_index = begin;
          source_index < sources.size();
          ++source_index) {
         RejectionSourceSnapshot& source = sources[source_index];
         if (source.terminalized) {
+            continue;
+        }
+        if (source.gpu_completion_batch.Valid()) {
+            GpuCompletionBackendAccess::PublishErrorsIfPending(
+                source.gpu_completion_tokens,
+                reason,
+                source.gpu_completion_batch
+            );
+        }
+        if (source.query_batch.Valid()) {
+            QueryBackendAccess::PublishErrorsIfPending(
+                source.query_tokens, reason, source.query_batch
+            );
+        }
+        source.publication_epoch = publication_epoch;
+        source.terminalized      = true;
+    }
+
+    // All matching host observations are terminal before external Fence code.
+    // Fence::Reject/Fail may synchronously re-enter this publication object;
+    // the recursive mutex lets that call observe the already-claimed sources
+    // while keeping concurrent publishers behind the complete signal phase.
+    // The epoch prevents the nested call from replaying any Fence operation.
+    for (size_t source_index = begin;
+         source_index < sources.size();
+         ++source_index) {
+        RejectionSourceSnapshot& source = sources[source_index];
+        if (source.publication_epoch != publication_epoch) {
             continue;
         }
         for (const RejectionSignalHandle& signal : source.signals) {
@@ -1289,44 +1456,6 @@ void VulkanSubmissionExecutor::BatchRejectionPublication::PublishSuffix(
                 fence->Reject(signal.value);
             }
         }
-    }
-
-    const std::string_view reason =
-        _reason.empty() ?
-            "Vulkan submission suffix was rejected before GPU completion" :
-            _reason;
-    for (size_t source_index = begin;
-         source_index < sources.size();
-         ++source_index) {
-        RejectionSourceSnapshot& source = sources[source_index];
-        if (source.terminalized) {
-            continue;
-        }
-        if (source.gpu_completion_batch.Valid()) {
-            GpuCompletionBackendAccess::PublishErrorsIfPending(
-                source.gpu_completion_tokens,
-                reason,
-                source.gpu_completion_batch
-            );
-        }
-    }
-    for (size_t source_index = begin;
-         source_index < sources.size();
-         ++source_index) {
-        RejectionSourceSnapshot& source = sources[source_index];
-        if (source.terminalized) {
-            continue;
-        }
-        if (source.query_batch.Valid()) {
-            QueryBackendAccess::PublishErrorsIfPending(
-                source.query_tokens, reason, source.query_batch
-            );
-        }
-    }
-    for (size_t source_index = begin;
-         source_index < sources.size();
-         ++source_index) {
-        sources[source_index].terminalized = true;
     }
 }
 
@@ -2387,34 +2516,6 @@ void VulkanSubmissionExecutor::RejectBatch(
             VK_ERROR_UNKNOWN :
             static_cast<VkResult>(_result);
 
-    // Terminal publication is atomic at the runtime-batch frontier: every
-    // signal and Query reaches its final classification before the first
-    // per-queue Completion packet can release callbacks.
-    for (size_t source_index = first_source;
-         source_index < _batch.submits.size();
-         ++source_index) {
-        CmdSubmit& submit = _batch.submits[source_index].submit;
-        if (_recoverable) {
-            submit.RejectPendingSignals();
-            continue;
-        }
-        for (const SignalEvent& signal : submit.signal_events) {
-            auto* fence =
-                reinterpret_cast<VulkanFence*>(signal.timeline_handle);
-            if (fence == nullptr) {
-                continue;
-            }
-            try {
-                fence->Fail(result);
-            } catch (...) {
-                fence->Reject(signal.value);
-            }
-        }
-        // Queue rejection must not add an exact-value rejection after a hard
-        // failure has already been published for the whole fence.
-        submit.signal_events.clear();
-    }
-
     const GpuCompletionPublishBatch completion_batch =
         GpuCompletionBackendAccess::BeginPublishBatch();
     for (size_t source_index = first_source;
@@ -2447,8 +2548,40 @@ void VulkanSubmissionExecutor::RejectBatch(
         submit.PublishPendingQueryErrors(_reason, source_query_batch);
     }
 
+    // Terminal publication is atomic at the runtime-batch frontier. Publish
+    // every host-visible state first so synchronous Fence rejection observers
+    // cannot block before their matching Future/Query becomes terminal.
+    for (size_t source_index = first_source;
+         source_index < _batch.submits.size();
+         ++source_index) {
+        CmdSubmit& submit = _batch.submits[source_index].submit;
+        if (_recoverable) {
+            submit.RejectPendingSignals();
+            continue;
+        }
+        Array<SignalEvent> rejected_signals =
+            std::move(submit.signal_events);
+        Array<FenceRef> rejected_signal_keepalives =
+            std::move(submit.signal_rejection_keepalives);
+        submit.signal_events.clear();
+        submit.signal_rejection_keepalives.clear();
+        for (const SignalEvent& signal : rejected_signals) {
+            auto* fence =
+                reinterpret_cast<VulkanFence*>(signal.timeline_handle);
+            if (fence == nullptr) {
+                continue;
+            }
+            try {
+                fence->Fail(result);
+            } catch (...) {
+                fence->Reject(signal.value);
+            }
+        }
+        (void)rejected_signal_keepalives;
+    }
+
     // A Present receipt is also user-visible batch state. Resolve it only
-    // after every submit signal and Query in the rejected suffix is terminal,
+    // after every host state and signal in the rejected suffix is terminal,
     // so a receipt waiter cannot observe a partially published batch.
     ResolveRejectedPresent(_batch.present);
 

--- a/source/runtime/render/rhi/vulkan/VulkanSubmissionExecutor.h
+++ b/source/runtime/render/rhi/vulkan/VulkanSubmissionExecutor.h
@@ -93,6 +93,7 @@ private:
         QueryPublishBatch            query_batch{};
         VulkanBatchCompletionTicket  completion_ticket{};
         bool                         terminalized{false};
+        uint64                       publication_epoch{0};
     };
 
     // Immutable, strongly-owned terminal handles captured before any source
@@ -115,7 +116,8 @@ private:
         ) const noexcept;
 
         Array<RejectionSourceSnapshot> sources{};
-        std::mutex                     mutex{};
+        std::recursive_mutex           mutex{};
+        uint64                         next_publication_epoch{1};
     };
 
     struct RuntimePreCompletionPublication {

--- a/source/test/CMakeLists.txt
+++ b/source/test/CMakeLists.txt
@@ -97,6 +97,7 @@ target_link_libraries(${test_target}
 )
 set_target_properties(${test_target} PROPERTIES FOLDER ${moer_test_folder})
 add_test(NAME RHIGpuCompletionContract COMMAND $<TARGET_FILE:${test_target}>)
+set_tests_properties(RHIGpuCompletionContract PROPERTIES TIMEOUT 60)
 
 set(test_target TestExternalCpuJoin)
 add_executable(${test_target} "ExternalCpuJoinTest.cpp")
@@ -137,6 +138,10 @@ target_link_libraries(${test_target}
 )
 set_target_properties(${test_target} PROPERTIES FOLDER ${moer_test_folder})
 add_test(NAME RHIExecutorRecordingHandoffContract COMMAND $<TARGET_FILE:${test_target}>)
+set_tests_properties(
+    RHIExecutorRecordingHandoffContract
+    PROPERTIES TIMEOUT 60
+)
 
 # CPU-only ownership contract for the Executor -> Translate -> Submission ->
 # Completion pipeline and the move-only queue lease crossing Translate/Submit.

--- a/source/test/RHIExecutorRecordingHandoffTest.cpp
+++ b/source/test/RHIExecutorRecordingHandoffTest.cpp
@@ -1,15 +1,18 @@
 #include "rhi/RHIExecutor.h"
 #include "rhi/RHIThreadOwnership.h"
+#include "renderer/raytracing/RaytracingExportSubmission.h"
 
 #include <array>
 #include <atomic>
 #include <chrono>
 #include <condition_variable>
+#include <cstdint>
 #include <cstdlib>
 #include <functional>
 #include <iostream>
 #include <mutex>
 #include <optional>
+#include <stdexcept>
 #include <thread>
 #include <vector>
 
@@ -50,6 +53,28 @@ bool Expect(bool _condition, const char* _message) {
     }
     std::cerr << "RHIExecutorRecordingHandoffContract: " << _message << '\n';
     return false;
+}
+
+bool HasNoRejectedGenerationPayload(const CmdSubmit& _submit) {
+    return _submit.cmds.empty() && _submit.callbacks.empty() &&
+           _submit.success_callbacks.empty() &&
+           _submit.gpu_completion_tokens.empty() &&
+           !_submit.gpu_completion_publish_batch.Valid() &&
+           _submit.query_tokens.empty() &&
+           !_submit.query_publish_batch.Valid() &&
+           _submit.cached_args.empty() &&
+           _submit.segments.empty() && _submit.wait_events.empty() &&
+           _submit.signal_events.empty() &&
+           _submit.signal_rejection_keepalives.empty() &&
+           !_submit.b_sync &&
+           !_submit.b_tick_profiling &&
+           _submit.profiling_phase == ERHIProfilingPhase::Disabled &&
+           !_submit.b_delete_resources &&
+           _submit.resource_state_ownership ==
+               ERHIResourceStateOwnership::BackendTracked &&
+           _submit.translate_execution_class ==
+               ERHITranslateExecutionClass::Parallel &&
+           _submit.async_queue_scope == 0 && _submit.debug_label.empty();
 }
 
 class RecordingFenceProbe final : public Fence {
@@ -114,6 +139,94 @@ private:
     std::atomic<uint64_t> rejected_value{0};
 };
 
+struct DirectMaterializationFaultContext {
+    size_t              fail_source{1};
+    std::atomic<size_t> visited_sources{0};
+};
+
+void InjectDirectMaterializationFailure(
+    void*  _context,
+    size_t _source_index
+) {
+    auto& context =
+        *static_cast<DirectMaterializationFaultContext*>(_context);
+    context.visited_sources.fetch_add(1, std::memory_order_release);
+    if (_source_index == context.fail_source) {
+        throw std::runtime_error(
+            "injected direct CommandList materialization failure"
+        );
+    }
+}
+
+struct BlockingDirectMaterializationContext {
+    std::mutex              mutex{};
+    std::condition_variable cv{};
+    bool                    entered{false};
+    bool                    release{false};
+};
+
+void BlockDirectMaterializationUntilReleased(
+    void*  _context,
+    size_t
+) {
+    auto& context =
+        *static_cast<BlockingDirectMaterializationContext*>(_context);
+    std::unique_lock lock(context.mutex);
+    context.entered = true;
+    context.cv.notify_all();
+    context.cv.wait(lock, [&] { return context.release; });
+    throw std::runtime_error(
+        "injected blocking direct materialization failure"
+    );
+}
+
+class ReentrantDestructorCommand final : public Command {
+public:
+    explicit ReentrantDestructorCommand(
+        std::function<void()> _on_destroy,
+        EQueueType            _queue = EQueueType::Graphics
+    ) :
+        Command(EType::Custom),
+        on_destroy(std::move(_on_destroy)),
+        queue(_queue) {}
+
+    ~ReentrantDestructorCommand() override {
+        if (!on_destroy) {
+            return;
+        }
+        try {
+            on_destroy();
+        } catch (...) {
+        }
+    }
+
+    EQueueType GetQueueType() const override {
+        return queue;
+    }
+
+private:
+    std::function<void()> on_destroy{};
+    EQueueType            queue{EQueueType::Graphics};
+};
+
+struct FinalReleaseHook {
+    std::function<void()> callback{};
+    std::atomic_bool*     threw{nullptr};
+
+    ~FinalReleaseHook() noexcept {
+        if (!callback) {
+            return;
+        }
+        try {
+            callback();
+        } catch (...) {
+            if (threw != nullptr) {
+                threw->store(true, std::memory_order_release);
+            }
+        }
+    }
+};
+
 bool CommandListSignalTracksNativeAcceptanceAndRejection() {
     RecordingFenceProbe accepted{};
     CommandList         accepted_commands(EQueueType::Graphics);
@@ -172,6 +285,7 @@ bool CommandListSignalTracksNativeAcceptanceAndRejection() {
     // destructor cannot revisit an already-retired raw fence pointer.
     owned_submit.signal_events.clear();
     owned_submit.callbacks.clear();
+    owned_submit.signal_rejection_keepalives.clear();
     if (!Expect(
             owned_destroyed->load(std::memory_order_acquire),
             "signal FenceRef survived after its completion callback retired"
@@ -213,6 +327,568 @@ bool CommandListSignalTracksNativeAcceptanceAndRejection() {
         "frontend-rejected signal was reported as natively submitted"
     );
     return okay;
+}
+
+bool CommandListFenceReentryCannotExtractRejectedGeneration() {
+    CommandList command_list(EQueueType::Graphics);
+    std::atomic<int>  signal_callbacks{0};
+    std::atomic<int>  ordinary_callbacks{0};
+    std::atomic<int>  success_callbacks{0};
+    std::atomic<bool> reentrant_submit_threw{false};
+    std::atomic<bool> rejected_payload_escaped{false};
+
+    RecordingFenceProbe signal(
+        {},
+        [&] {
+            signal_callbacks.fetch_add(1, std::memory_order_release);
+            try {
+                CmdSubmit reentrant = command_list.Submit();
+                rejected_payload_escaped.store(
+                    !HasNoRejectedGenerationPayload(reentrant),
+                    std::memory_order_release
+                );
+
+                // Keep the regression bounded even when run against an older
+                // implementation that exposes the rejected signal/callbacks.
+                // Their presence is recorded above; do not let destruction
+                // recursively reject the same raw Fence.
+                reentrant.cmds.clear();
+                reentrant.callbacks.clear();
+                reentrant.success_callbacks.clear();
+                reentrant.gpu_completion_tokens.clear();
+                reentrant.query_tokens.clear();
+                reentrant.cached_args.clear();
+                reentrant.segments.clear();
+                reentrant.wait_events.clear();
+                reentrant.signal_events.clear();
+            } catch (...) {
+                reentrant_submit_threw.store(
+                    true, std::memory_order_release
+                );
+            }
+        }
+    );
+
+    command_list.Signal(&signal, 19);
+    command_list.AddCallback([&] {
+        ordinary_callbacks.fetch_add(1, std::memory_order_release);
+    });
+    command_list.AddSuccessCallback([&] {
+        success_callbacks.fetch_add(1, std::memory_order_release);
+    });
+
+    Moer::Array<std::function<void()>> cleanup =
+        command_list.DrainOrdinaryCallbacksForRejection();
+    for (std::function<void()>& callback : cleanup) {
+        if (callback) {
+            callback();
+        }
+    }
+
+    return Expect(
+               signal_callbacks.load(std::memory_order_acquire) == 1 &&
+                   signal.IsRejected(19),
+               "CommandList rejection did not invoke its Fence observer exactly once"
+           ) &&
+           Expect(
+               !reentrant_submit_threw.load(std::memory_order_acquire),
+               "Fence rejection could not re-enter Submit on the replacement generation"
+           ) &&
+           Expect(
+               !rejected_payload_escaped.load(std::memory_order_acquire),
+               "Fence rejection re-entry extracted the rejected generation"
+           ) &&
+           Expect(
+               ordinary_callbacks.load(std::memory_order_acquire) == 1,
+               "Fence rejection did not return ordinary cleanup exactly once"
+           ) &&
+           Expect(
+               success_callbacks.load(std::memory_order_acquire) == 0,
+               "Fence rejection invoked a success-only callback"
+           ) &&
+           Expect(
+               command_list.IsEmpty(),
+               "Fence rejection left payload in the replacement generation"
+           );
+}
+
+bool FenceRejectionObservesPublishedHostsAndRetainsOwnedSignals() {
+    CommandList wait_list(EQueueType::Graphics);
+    const GpuCompletionFuture completion =
+        wait_list.TrackGpuCompletion("FenceRejectWaitCompletion");
+    QueryToken query =
+        wait_list.BeginTimestampQuery("FenceRejectWaitQuery");
+    wait_list.EndTimestampQuery(query);
+    const QueryFuture query_future = query.GetFuture();
+    std::atomic_bool completion_wait_satisfied{false};
+    std::atomic_bool query_wait_satisfied{false};
+    RecordingFenceProbe waiting_signal(
+        {},
+        [&] {
+            completion_wait_satisfied.store(
+                completion.WaitFor(100ms),
+                std::memory_order_release
+            );
+            query_wait_satisfied.store(
+                query_future.WaitFor(100ms),
+                std::memory_order_release
+            );
+        }
+    );
+    wait_list.Signal(&waiting_signal, 29);
+    auto cleanup = wait_list.DrainOrdinaryCallbacksForRejection();
+    cleanup.clear();
+
+    CommandList lifetime_list(EQueueType::Graphics);
+    auto first_destroyed =
+        std::make_shared<std::atomic_bool>(false);
+    auto second_destroyed =
+        std::make_shared<std::atomic_bool>(false);
+    std::atomic_int first_rejections{0};
+    std::atomic_int second_rejections{0};
+    FenceRef first{
+        MoerNew(RecordingFenceProbe)(
+            first_destroyed,
+            [&] {
+                first_rejections.fetch_add(
+                    1, std::memory_order_release
+                );
+                CmdSubmit reentrant = lifetime_list.Submit();
+                // Destroy the original callback-based keepalives while the
+                // outer rejection loop still has a second raw Fence pointer.
+                reentrant.callbacks.clear();
+                reentrant.signal_rejection_keepalives.clear();
+            }
+        )
+    };
+    FenceRef second{
+        MoerNew(RecordingFenceProbe)(
+            second_destroyed,
+            [&] {
+                second_rejections.fetch_add(
+                    1, std::memory_order_release
+                );
+            }
+        )
+    };
+    lifetime_list.Signal(first, 31);
+    lifetime_list.Signal(second, 32);
+    first = {};
+    second = {};
+    lifetime_list.RejectPendingSignals();
+
+    return Expect(
+               completion_wait_satisfied.load(
+                   std::memory_order_acquire
+               ) &&
+                   query_wait_satisfied.load(
+                       std::memory_order_acquire
+                   ),
+               "Fence::Reject observed Pending host state"
+           ) &&
+           Expect(
+               first_rejections.load(std::memory_order_acquire) == 1 &&
+                   second_rejections.load(
+                       std::memory_order_acquire
+                   ) == 1,
+               "re-entrant signal rejection skipped an owned Fence"
+           ) &&
+           Expect(
+               first_destroyed->load(std::memory_order_acquire) &&
+                   second_destroyed->load(std::memory_order_acquire),
+               "rejection keepalive outlived the rejected signal batch"
+           );
+}
+
+bool ExportReceiptSignalsOwnDedicatedRejectionKeepalives() {
+    using Moer::Render::Raytracing::ExportSubmissionTransaction;
+
+    auto run_case = [](bool _readback, uint64_t _value) {
+        auto destroyed =
+            std::make_shared<std::atomic_bool>(false);
+        auto rejected_value =
+            std::make_shared<std::atomic<uint64_t>>(0);
+        FenceRef receipt{
+            MoerNew(RecordingFenceProbe)(
+                destroyed,
+                [rejected_value, _value] {
+                    rejected_value->store(
+                        _value, std::memory_order_release
+                    );
+                }
+            )
+        };
+        Fence* const receipt_identity = receipt.Get();
+
+        CommandList commands(EQueueType::Graphics);
+        CmdSubmit   submit = commands.Submit();
+        FenceRef    source_receipt{};
+        {
+            if (_readback) {
+                source_receipt = FenceRef{
+                    MoerNew(RecordingFenceProbe)()
+                };
+                ExportSubmissionTransaction transaction(
+                    source_receipt, _value + 1
+                );
+                transaction.BeginReadback(receipt, _value);
+                transaction.AttachReadbackSignal(submit);
+            } else {
+                ExportSubmissionTransaction transaction(
+                    receipt, _value
+                );
+                transaction.AttachSignal(submit);
+            }
+
+            if (!Expect(
+                        submit.signal_events.size() == 1 &&
+                        submit.signal_events.front().timeline_handle ==
+                            reinterpret_cast<std::uintptr_t>(
+                                receipt_identity
+                            ) &&
+                        submit.signal_events.front().value == _value &&
+                        submit.signal_rejection_keepalives.size() == 1 &&
+                        submit.signal_rejection_keepalives.front().Get() ==
+                            receipt_identity,
+                    _readback ?
+                        "readback receipt signal did not install its dedicated rejection keepalive" :
+                        "export receipt signal did not install its dedicated rejection keepalive"
+                )) {
+                // Keep a failed structural assertion bounded when run against
+                // an older implementation that owns the receipt only through
+                // the ordinary callback tier.
+                submit.signal_events.clear();
+                submit.callbacks.clear();
+                submit.signal_rejection_keepalives.clear();
+                return false;
+            }
+        }
+
+        receipt       = {};
+        source_receipt = {};
+        // Simulate re-entrant code destroying the historical callback-based
+        // keeper while RejectPendingSignals is still responsible for the raw
+        // backend identity.
+        submit.callbacks.clear();
+        if (!Expect(
+                !destroyed->load(std::memory_order_acquire),
+                _readback ?
+                    "readback receipt died before rejection terminalization" :
+                    "export receipt died before rejection terminalization"
+            )) {
+            submit.signal_events.clear();
+            submit.signal_rejection_keepalives.clear();
+            return false;
+        }
+
+        submit.RejectPendingSignals();
+        return Expect(
+                   rejected_value->load(std::memory_order_acquire) ==
+                       _value,
+                   _readback ?
+                       "readback receipt was not rejected at its exact value" :
+                       "export receipt was not rejected at its exact value"
+               ) &&
+               Expect(
+                   destroyed->load(std::memory_order_acquire),
+                   _readback ?
+                       "readback receipt keepalive outlived its rejected signal" :
+                       "export receipt keepalive outlived its rejected signal"
+               );
+    };
+
+    return run_case(false, 41) && run_case(true, 43);
+}
+
+bool CommandDestructorReentryTargetsOnlyFreshGeneration() {
+    CommandList command_list(EQueueType::Graphics);
+    RecordingFenceProbe signal{};
+    std::atomic<int> command_destructors{0};
+    std::atomic<int> completion_callbacks{0};
+    std::atomic<int> query_callbacks{0};
+    std::atomic<int> ordinary_callbacks{0};
+    std::atomic<int> success_callbacks{0};
+    std::atomic<int> fresh_callbacks{0};
+    std::atomic<bool> destructor_observed_terminal_batch{false};
+
+    command_list.Signal(&signal, 23);
+    const GpuCompletionFuture completion =
+        command_list.TrackGpuCompletion(
+            "CommandDestructorRejectedCompletion"
+        );
+    QueryToken query = command_list.BeginTimestampQuery(
+        "CommandDestructorRejectedQuery"
+    );
+    command_list.EndTimestampQuery(query);
+    const QueryFuture query_future = query.GetFuture();
+    completion.Then([&](const GpuCompletionResult&) {
+        completion_callbacks.fetch_add(1, std::memory_order_release);
+    });
+    query_future.Then([&](const QueryResult&) {
+        query_callbacks.fetch_add(1, std::memory_order_release);
+    });
+    command_list.AddCallback([&] {
+        ordinary_callbacks.fetch_add(1, std::memory_order_release);
+    });
+    command_list.AddSuccessCallback([&] {
+        success_callbacks.fetch_add(1, std::memory_order_release);
+    });
+    command_list.AddCustomCommand(
+        Moer::MakeUnique<ReentrantDestructorCommand>([&] {
+            command_destructors.fetch_add(
+                1, std::memory_order_release
+            );
+            destructor_observed_terminal_batch.store(
+                signal.IsRejected(23) &&
+                    completion.Status() ==
+                        GpuCompletionStatus::Error &&
+                    query_future.Status() == QueryStatus::Error &&
+                    completion_callbacks.load(
+                        std::memory_order_acquire
+                    ) == 1 &&
+                    query_callbacks.load(
+                        std::memory_order_acquire
+                    ) == 1,
+                std::memory_order_release
+            );
+            command_list.AddCallback([&] {
+                fresh_callbacks.fetch_add(
+                    1, std::memory_order_release
+                );
+            });
+        }),
+        "RejectedDestructorReentry"
+    );
+
+    Moer::Array<std::function<void()>> cleanup =
+        command_list.DrainOrdinaryCallbacksForRejection();
+    for (std::function<void()>& callback : cleanup) {
+        if (callback) {
+            callback();
+        }
+    }
+    CmdSubmit fresh = command_list.Submit();
+    const bool fresh_generation_isolated =
+        fresh.cmds.empty() && fresh.callbacks.size() == 1 &&
+        fresh.success_callbacks.empty() &&
+        fresh.gpu_completion_tokens.empty() &&
+        fresh.query_tokens.empty() && fresh.signal_events.empty();
+    for (std::function<void()>& callback : fresh.callbacks) {
+        if (callback) {
+            callback();
+        }
+    }
+    fresh.callbacks.clear();
+
+    return Expect(
+               command_destructors.load(std::memory_order_acquire) == 1,
+               "rejected custom Command was not destroyed exactly once"
+           ) &&
+           Expect(
+               destructor_observed_terminal_batch.load(
+                   std::memory_order_acquire
+               ),
+               "custom Command destructor ran before the rejected terminal batch was fully notified"
+           ) &&
+           Expect(
+               ordinary_callbacks.load(std::memory_order_acquire) == 1 &&
+                   success_callbacks.load(std::memory_order_acquire) == 0,
+               "custom Command rejection violated ordinary/success callback semantics"
+           ) &&
+           Expect(
+               fresh_generation_isolated &&
+                   fresh_callbacks.load(std::memory_order_acquire) == 1,
+               "custom Command destructor re-entry was lost or mixed with the rejected generation"
+           );
+}
+
+bool CmdSubmitCallbackCaptureDestructorSeesCompleteReplacement() {
+    RecordingFenceProbe incoming_signal{};
+    std::optional<CmdSubmit> observed{};
+    std::atomic_bool hook_threw{false};
+    std::atomic<int> hook_calls{0};
+
+    CommandList empty_destination(EQueueType::Graphics);
+    CmdSubmit destination = empty_destination.Submit();
+    auto hook = std::make_shared<FinalReleaseHook>();
+    hook->threw = &hook_threw;
+    hook->callback = [&] {
+        hook_calls.fetch_add(1, std::memory_order_release);
+        observed.emplace(std::move(destination));
+    };
+    destination.callbacks.emplace_back([hook] {});
+    hook.reset();
+
+    CommandList incoming_commands(EQueueType::Graphics);
+    incoming_commands.AddCustomCommand(
+        Moer::MakeUnique<ReentrantDestructorCommand>(
+            std::function<void()>{}
+        ),
+        "CmdSubmitReplacementIncoming"
+    );
+    incoming_commands.AddCallback([] {});
+    incoming_commands.AddSuccessCallback([] {});
+    const GpuCompletionFuture completion =
+        incoming_commands.TrackGpuCompletion(
+            "CmdSubmitReplacementCompletion"
+        );
+    QueryToken query = incoming_commands.BeginTimestampQuery(
+        "CmdSubmitReplacementQuery"
+    );
+    incoming_commands.EndTimestampQuery(query);
+    const QueryFuture query_future = query.GetFuture();
+    incoming_commands.Signal(&incoming_signal, 29);
+    CmdSubmit incoming = incoming_commands.Submit();
+    incoming.b_sync = true;
+    incoming.b_delete_resources = true;
+    incoming.SetProfilingPhase(ERHIProfilingPhase::Begin);
+    incoming.SetResourceStateOwnership(
+        ERHIResourceStateOwnership::Explicit
+    );
+    incoming.SetTranslateExecutionClass(
+        ERHITranslateExecutionClass::SerialControl
+    );
+    incoming.async_queue_scope = 0xA5;
+    incoming.DebugLabel("CmdSubmitReplacementLabel");
+    const size_t expected_commands = incoming.cmds.size();
+    const size_t expected_callbacks = incoming.callbacks.size();
+    const size_t expected_success_callbacks =
+        incoming.success_callbacks.size();
+    const size_t expected_completion_tokens =
+        incoming.gpu_completion_tokens.size();
+    const size_t expected_query_tokens =
+        incoming.query_tokens.size();
+    const size_t expected_signals = incoming.signal_events.size();
+
+    destination = std::move(incoming);
+
+    const bool saw_complete_incoming =
+        observed.has_value() &&
+        observed->cmds.size() == expected_commands &&
+        observed->callbacks.size() == expected_callbacks &&
+        observed->success_callbacks.size() ==
+            expected_success_callbacks &&
+        observed->gpu_completion_tokens.size() ==
+            expected_completion_tokens &&
+        observed->query_tokens.size() == expected_query_tokens &&
+        observed->signal_events.size() == expected_signals &&
+        observed->signal_events.front().value == 29 &&
+        observed->b_sync && observed->b_delete_resources &&
+        observed->ProfilingPhase() == ERHIProfilingPhase::Begin &&
+        observed->resource_state_ownership ==
+            ERHIResourceStateOwnership::Explicit &&
+        observed->translate_execution_class ==
+            ERHITranslateExecutionClass::SerialControl &&
+        observed->async_queue_scope == 0xA5 &&
+        observed->debug_label == "CmdSubmitReplacementLabel";
+    const bool destination_payload_was_consumed =
+        destination.cmds.empty() && destination.callbacks.empty() &&
+        destination.success_callbacks.empty() &&
+        destination.gpu_completion_tokens.empty() &&
+        !destination.gpu_completion_publish_batch.Valid() &&
+        destination.query_tokens.empty() &&
+        !destination.query_publish_batch.Valid() &&
+        destination.cached_args.empty() &&
+        destination.segments.empty() &&
+        destination.wait_events.empty() &&
+        destination.signal_events.empty() &&
+        destination.debug_label.empty();
+
+    observed.reset();
+    return Expect(
+               !hook_threw.load(std::memory_order_acquire) &&
+                   hook_calls.load(std::memory_order_acquire) == 1,
+               "CmdSubmit callback capture destructor did not re-enter exactly once"
+           ) &&
+           Expect(
+               saw_complete_incoming &&
+                   destination_payload_was_consumed,
+               "CmdSubmit replacement exposed a partially installed incoming payload"
+           ) &&
+           Expect(
+               incoming_signal.IsRejected(29) &&
+                   completion.Status() ==
+                       GpuCompletionStatus::Error &&
+                   query_future.Status() == QueryStatus::Error,
+               "observed replacement payload did not terminalize on destruction"
+           );
+}
+
+bool CommandListCallbackCaptureDestructorSeesCompleteReplacement() {
+    RecordingFenceProbe incoming_signal{};
+    std::optional<CmdSubmit> observed{};
+    std::atomic_bool hook_threw{false};
+    std::atomic<int> hook_calls{0};
+
+    CommandList destination(EQueueType::Graphics);
+    auto hook = std::make_shared<FinalReleaseHook>();
+    hook->threw = &hook_threw;
+    hook->callback = [&] {
+        hook_calls.fetch_add(1, std::memory_order_release);
+        observed.emplace(destination.Submit());
+    };
+    destination.AddCallback([hook] {});
+    hook.reset();
+
+    CommandList incoming(EQueueType::Graphics);
+    incoming.AddCustomCommand(
+        Moer::MakeUnique<ReentrantDestructorCommand>(
+            std::function<void()>{}
+        ),
+        "CommandListReplacementIncoming"
+    );
+    incoming.AddCallback([] {});
+    incoming.AddSuccessCallback([] {});
+    const GpuCompletionFuture completion =
+        incoming.TrackGpuCompletion(
+            "CommandListReplacementCompletion"
+        );
+    QueryToken query = incoming.BeginTimestampQuery(
+        "CommandListReplacementQuery"
+    );
+    incoming.EndTimestampQuery(query);
+    const QueryFuture query_future = query.GetFuture();
+    incoming.Signal(&incoming_signal, 31);
+    incoming.SetResourceStateOwnership(
+        ERHIResourceStateOwnership::Explicit
+    );
+    incoming.SetTranslateExecutionClass(
+        ERHITranslateExecutionClass::SerialControl
+    );
+
+    destination = std::move(incoming);
+
+    const bool saw_complete_incoming =
+        observed.has_value() && observed->cmds.size() == 3 &&
+        observed->callbacks.size() == 2 &&
+        observed->success_callbacks.size() == 1 &&
+        observed->gpu_completion_tokens.size() == 1 &&
+        observed->query_tokens.size() == 1 &&
+        observed->signal_events.size() == 1 &&
+        observed->signal_events.front().value == 31 &&
+        observed->resource_state_ownership ==
+            ERHIResourceStateOwnership::Explicit &&
+        observed->translate_execution_class ==
+            ERHITranslateExecutionClass::SerialControl;
+    const bool destination_was_consumed = destination.IsEmpty();
+
+    observed.reset();
+    return Expect(
+               !hook_threw.load(std::memory_order_acquire) &&
+                   hook_calls.load(std::memory_order_acquire) == 1,
+               "CommandList callback capture destructor did not re-enter exactly once"
+           ) &&
+           Expect(
+               saw_complete_incoming && destination_was_consumed,
+               "CommandList replacement exposed a mixed or partial generation"
+           ) &&
+           Expect(
+               incoming_signal.IsRejected(31) &&
+                   completion.Status() ==
+                       GpuCompletionStatus::Error &&
+                   query_future.Status() == QueryStatus::Error,
+               "observed CommandList replacement did not terminalize on destruction"
+           );
 }
 
 bool FrontendQueryRejectionTerminalizesBeforeOrdinaryCallbacks() {
@@ -593,6 +1269,8 @@ bool DirectCommandListGroupPreflightRejectsEverySource() {
     std::array<std::atomic<bool>, 3> query_observed_present_rejection{};
     std::array<std::atomic<bool>, 3> ordinary_observed_own_query{};
     std::atomic<bool> first_query_observed_last_terminal{false};
+    std::optional<CmdSubmit> suffix_reentrant_submit{};
+    std::atomic<bool> suffix_reentrant_submit_threw{false};
     PresentReceiptRef receipt = std::make_shared<PresentReceipt>();
     RHIPresentRequest present{};
     present.receipt = receipt;
@@ -627,6 +1305,15 @@ bool DirectCommandListGroupPreflightRejectsEverySource() {
                         futures[2].Status() == QueryStatus::Error,
                     std::memory_order_release
                 );
+                try {
+                    suffix_reentrant_submit.emplace(
+                        command_lists[2].Submit()
+                    );
+                } catch (...) {
+                    suffix_reentrant_submit_threw.store(
+                        true, std::memory_order_release
+                    );
+                }
             }
             query_observed_error[index].store(
                 _result.status == QueryStatus::Error,
@@ -702,6 +1389,17 @@ bool DirectCommandListGroupPreflightRejectsEverySource() {
         first_query_observed_last_terminal.load(std::memory_order_acquire),
         "direct CommandList group preflight allowed an earlier Query callback to observe a later Future Pending"
     );
+    okay &= Expect(
+        !suffix_reentrant_submit_threw.load(std::memory_order_acquire) &&
+            suffix_reentrant_submit.has_value(),
+        "direct CommandList preflight callback could not re-enter the suffix"
+    );
+    if (suffix_reentrant_submit.has_value()) {
+        okay &= Expect(
+            HasNoRejectedGenerationPayload(*suffix_reentrant_submit),
+            "direct CommandList preflight callback extracted the rejected suffix generation"
+        );
+    }
     const PresentReceiptResult present_result =
         receipt->WaitForSubmission(100ms);
     okay &= Expect(
@@ -726,22 +1424,8 @@ bool DirectCommandListGroupPreflightRejectsEverySource() {
     return okay;
 }
 
-bool DirectCommandListGroupMaterializationFailureRejectsPrefixAndSuffix() {
-    std::optional<CommandList::ManagedRecordingLease> blocking_lease{};
-    RecordingFenceProbe prefix_signal(
-        {},
-        [&blocking_lease] {
-            blocking_lease.reset();
-        }
-    );
-    RecordingFenceProbe middle_signal{};
-    RecordingFenceProbe suffix_signal{};
-    const std::array<RecordingFenceProbe*, 3> signals{
-        &prefix_signal,
-        &middle_signal,
-        &suffix_signal,
-    };
-
+bool DirectCommandListGroupActiveLeaseFailsWithoutMutation() {
+    std::array<RecordingFenceProbe, 3> signals{};
     Moer::Array<CommandList> command_lists{};
     command_lists.reserve(3);
     for (size_t index = 0; index < 3; ++index) {
@@ -752,15 +1436,221 @@ bool DirectCommandListGroupMaterializationFailureRejectsPrefixAndSuffix() {
     std::array<std::atomic<int>, 3> query_callbacks{};
     std::array<std::atomic<int>, 3> ordinary_callbacks{};
     std::array<std::atomic<int>, 3> success_callbacks{};
-    std::array<std::atomic<bool>, 3> ordinary_observed_own_query{};
-    std::atomic<bool> prefix_observed_suffix_terminal{false};
-    std::atomic<int>  reentrant_callbacks{0};
-
     for (size_t index = 0; index < command_lists.size(); ++index) {
-        command_lists[index].Signal(signals[index], 50 + index);
+        command_lists[index].Signal(&signals[index], 50 + index);
         command_lists[index].AddCallback([&, index] {
-            ordinary_observed_own_query[index].store(
-                query_callbacks[index].load(std::memory_order_acquire) == 1,
+            ordinary_callbacks[index].fetch_add(
+                1, std::memory_order_release
+            );
+        });
+        command_lists[index].AddSuccessCallback([&, index] {
+            success_callbacks[index].fetch_add(
+                1, std::memory_order_release
+            );
+        });
+        QueryToken token = command_lists[index].BeginTimestampQuery(
+            "DirectSubmitActiveLeaseTimestamp"
+        );
+        command_lists[index].EndTimestampQuery(token);
+        futures[index] = token.GetFuture();
+        futures[index].Then([&, index](const QueryResult&) {
+            query_callbacks[index].fetch_add(
+                1, std::memory_order_release
+            );
+        });
+    }
+
+    PresentReceiptRef receipt = std::make_shared<PresentReceipt>();
+    RHIPresentRequest present{};
+    present.receipt = receipt;
+    auto blocking_lease =
+        command_lists[1].AcquireManagedRecordingLease();
+    bool threw_logic_error = false;
+    try {
+        RHIExecutor::Get().Submit(
+            std::move(command_lists),
+            ERHIExecSubmitFlags::None,
+            &present
+        );
+    } catch (const std::logic_error&) {
+        threw_logic_error = true;
+    } catch (...) {
+    }
+
+    bool okay = Expect(
+        threw_logic_error,
+        "direct CommandList group accepted an active managed recording lease"
+    );
+    for (size_t index = 0; index < command_lists.size(); ++index) {
+        okay &= Expect(
+            !signals[index].IsRejected(50 + index) &&
+                futures[index].Status() == QueryStatus::Pending &&
+                query_callbacks[index].load(std::memory_order_acquire) == 0 &&
+                ordinary_callbacks[index].load(std::memory_order_acquire) == 0 &&
+                success_callbacks[index].load(std::memory_order_acquire) == 0 &&
+                !command_lists[index].IsEmpty(),
+            "active-lease preflight mutated or notified the intact transaction"
+        );
+    }
+    okay &= Expect(
+        !receipt->WaitForSubmission(0ms).resolved,
+        "active-lease preflight resolved Present for an unconsumed transaction"
+    );
+
+    blocking_lease.Release();
+    for (CommandList& command_list : command_lists) {
+        auto callbacks =
+            command_list.DrainOrdinaryCallbacksForRejection();
+        for (auto& callback : callbacks) {
+            if (callback) {
+                callback();
+            }
+        }
+    }
+    for (size_t index = 0; index < command_lists.size(); ++index) {
+        okay &= Expect(
+            signals[index].IsRejected(50 + index) &&
+                futures[index].WaitFor(100ms) &&
+                futures[index].Status() == QueryStatus::Error &&
+                query_callbacks[index].load(std::memory_order_acquire) == 1 &&
+                ordinary_callbacks[index].load(std::memory_order_acquire) == 1 &&
+                success_callbacks[index].load(std::memory_order_acquire) == 0,
+            "caller-owned cleanup did not terminalize the intact active-lease transaction"
+        );
+    }
+    (void)receipt->Resolve(false);
+    return okay;
+}
+
+bool DirectCommandListGroupPartialMaterializationFailureIsAtomic() {
+    constexpr size_t SourceCount = 2;
+    Moer::Array<CommandList> command_lists{};
+    command_lists.reserve(SourceCount);
+    for (size_t index = 0; index < SourceCount; ++index) {
+        command_lists.emplace_back(EQueueType::Graphics);
+    }
+
+    std::array<FenceRef, SourceCount> signals{};
+    std::array<RecordingFenceProbe*, SourceCount> signal_probes{};
+    std::array<std::atomic<int>, SourceCount> signal_rejections{};
+    std::array<GpuCompletionFuture, SourceCount> completion_futures{};
+    std::array<QueryFuture, SourceCount> query_futures{};
+    std::array<std::atomic<int>, SourceCount> completion_callbacks{};
+    std::array<std::atomic<int>, SourceCount> query_callbacks{};
+    std::array<std::atomic<int>, SourceCount> ordinary_callbacks{};
+    std::array<std::atomic<int>, SourceCount> success_callbacks{};
+    std::array<std::atomic<bool>, SourceCount>
+        signal_observed_host_publication{};
+    std::array<std::atomic<bool>, SourceCount>
+        ordinary_observed_notifications{};
+    std::atomic<bool> first_completion_observed_atomic_group{false};
+    std::array<std::optional<CmdSubmit>, SourceCount> reentrant_submits{};
+    std::atomic<bool> reentrant_submit_threw{false};
+
+    for (size_t index = 0; index < SourceCount; ++index) {
+        signals[index] = MoerNew(RecordingFenceProbe)(
+            std::shared_ptr<std::atomic_bool>{},
+            [&, index] {
+                bool host_published_without_notification = true;
+                for (size_t sibling = 0;
+                     sibling < SourceCount;
+                     ++sibling) {
+                    host_published_without_notification &=
+                        completion_futures[sibling].Status() ==
+                            GpuCompletionStatus::Error &&
+                        query_futures[sibling].Status() ==
+                            QueryStatus::Error &&
+                        completion_callbacks[sibling].load(
+                            std::memory_order_acquire
+                        ) == 0 &&
+                        query_callbacks[sibling].load(
+                            std::memory_order_acquire
+                        ) == 0 &&
+                        ordinary_callbacks[sibling].load(
+                            std::memory_order_acquire
+                        ) == 0;
+                }
+                signal_observed_host_publication[index].store(
+                    host_published_without_notification,
+                    std::memory_order_release
+                );
+                signal_rejections[index].fetch_add(
+                    1, std::memory_order_release
+                );
+                if (index != 0) {
+                    return;
+                }
+                for (size_t source_index = 0;
+                     source_index < SourceCount;
+                     ++source_index) {
+                    try {
+                        reentrant_submits[source_index].emplace(
+                            command_lists[source_index].Submit()
+                        );
+                    } catch (...) {
+                        reentrant_submit_threw.store(
+                            true, std::memory_order_release
+                        );
+                    }
+                }
+            }
+        );
+        signal_probes[index] =
+            static_cast<RecordingFenceProbe*>(signals[index].Get());
+        command_lists[index].Signal(signals[index], 70 + index);
+
+        completion_futures[index] =
+            command_lists[index].TrackGpuCompletion(
+                "DirectPartialMaterializationCompletion"
+            );
+        completion_futures[index].Then(
+            [&, index](const GpuCompletionResult& _result) {
+                if (_result.status == GpuCompletionStatus::Error) {
+                    completion_callbacks[index].fetch_add(
+                        1, std::memory_order_release
+                    );
+                }
+                if (index != 0) {
+                    return;
+                }
+                const bool group_terminal =
+                    completion_futures[1].WaitFor(0ms) &&
+                    completion_futures[1].Status() ==
+                        GpuCompletionStatus::Error &&
+                    query_futures[0].WaitFor(0ms) &&
+                    query_futures[1].WaitFor(0ms) &&
+                    query_futures[0].Status() == QueryStatus::Error &&
+                    query_futures[1].Status() == QueryStatus::Error &&
+                    signal_probes[0]->IsRejected(70) &&
+                    signal_probes[1]->IsRejected(71);
+                first_completion_observed_atomic_group.store(
+                    group_terminal, std::memory_order_release
+                );
+            }
+        );
+
+        QueryToken query = command_lists[index].BeginTimestampQuery(
+            "DirectPartialMaterializationQuery"
+        );
+        command_lists[index].EndTimestampQuery(query);
+        query_futures[index] = query.GetFuture();
+        query_futures[index].Then(
+            [&, index](const QueryResult& _result) {
+                if (_result.status == QueryStatus::Error) {
+                    query_callbacks[index].fetch_add(
+                        1, std::memory_order_release
+                    );
+                }
+            }
+        );
+        command_lists[index].AddCallback([&, index] {
+            ordinary_observed_notifications[index].store(
+                completion_callbacks[index].load(
+                    std::memory_order_acquire
+                ) == 1 &&
+                    query_callbacks[index].load(
+                        std::memory_order_acquire
+                    ) == 1,
                 std::memory_order_release
             );
             ordinary_callbacks[index].fetch_add(
@@ -772,110 +1662,197 @@ bool DirectCommandListGroupMaterializationFailureRejectsPrefixAndSuffix() {
                 1, std::memory_order_release
             );
         });
-        QueryToken token = command_lists[index].BeginTimestampQuery(
-            "DirectSubmitMaterializationTimestamp"
-        );
-        command_lists[index].EndTimestampQuery(token);
-        futures[index] = token.GetFuture();
-        futures[index].Then([&, index](const QueryResult& _result) {
-            if (index == 0) {
-                prefix_observed_suffix_terminal.store(
-                    futures[2].WaitFor(100ms) &&
-                        futures[2].Status() == QueryStatus::Error,
-                    std::memory_order_release
-                );
-                // Source zero has already sealed. Re-entrant work belongs to
-                // its fresh generation and must survive rejection of the old
-                // materialized prefix.
-                command_lists[0].AddCallback([&reentrant_callbacks] {
-                    reentrant_callbacks.fetch_add(
-                        1, std::memory_order_release
-                    );
-                });
-            }
-            if (_result.status == QueryStatus::Error) {
-                query_callbacks[index].fetch_add(
-                    1, std::memory_order_release
-                );
-            }
-        });
     }
 
-    blocking_lease.emplace(
-        command_lists[1].AcquireManagedRecordingLease()
-    );
-    bool threw = false;
+    PresentReceiptRef receipt = std::make_shared<PresentReceipt>();
+    RHIPresentRequest present{};
+    present.receipt = receipt;
+    DirectMaterializationFaultContext fault_context{};
+    const RHIDirectCommandListMaterializationOverrideForTesting
+        materialization_override{
+            .context       = &fault_context,
+            .before_source = &InjectDirectMaterializationFailure,
+        };
+    if (!Expect(
+            TryInstallRHIDirectCommandListMaterializationOverrideForTesting(
+                &materialization_override
+            ),
+            "could not install direct materialization failure override"
+        )) {
+        return false;
+    }
+
+    bool submit_threw = false;
     try {
         RHIExecutor::Get().Submit(
             std::move(command_lists),
             ERHIExecSubmitFlags::None,
-            nullptr
+            &present
         );
     } catch (...) {
-        threw = true;
+        submit_threw = true;
     }
+    const bool override_removed =
+        RemoveRHIDirectCommandListMaterializationOverrideForTesting(
+            &materialization_override
+        );
 
-    bool okay = Expect(
-                    !threw,
-                    "direct CommandList group propagated a mid-materialization failure"
-                ) &&
-                Expect(
-                    !blocking_lease.has_value(),
-                    "materialization-failure trigger did not release its managed lease"
-                );
-    for (size_t index = 0; index < command_lists.size(); ++index) {
+    bool okay =
+        Expect(
+            !submit_threw && override_removed &&
+                fault_context.visited_sources.load(
+                    std::memory_order_acquire
+                ) == SourceCount,
+            "partial materialization fault did not traverse the intended mixed prefix/suffix path"
+        ) &&
+        Expect(
+            first_completion_observed_atomic_group.load(
+                std::memory_order_acquire
+            ),
+            "partial materialization callback observed a non-terminal sibling or signal"
+        ) &&
+        Expect(
+            !reentrant_submit_threw.load(std::memory_order_acquire),
+            "partial materialization callback could not re-enter a fresh generation"
+        );
+    for (size_t index = 0; index < SourceCount; ++index) {
         okay &= Expect(
-            signals[index]->IsRejected(50 + index),
-            "direct CommandList materialization failure left a signal Pending"
+            completion_futures[index].WaitFor(100ms) &&
+                completion_futures[index].Status() ==
+                    GpuCompletionStatus::Error &&
+                query_futures[index].WaitFor(100ms) &&
+                query_futures[index].Status() == QueryStatus::Error,
+            "partial materialization left a host Future Pending"
         );
         okay &= Expect(
-            futures[index].WaitFor(100ms) &&
-                futures[index].Status() == QueryStatus::Error,
-            "direct CommandList materialization failure left a QueryFuture Pending"
-        );
-        okay &= Expect(
-            query_callbacks[index].load(std::memory_order_acquire) == 1,
-            "direct CommandList materialization failure did not notify a Query callback exactly once"
-        );
-        okay &= Expect(
-            ordinary_callbacks[index].load(std::memory_order_acquire) == 1 &&
-                ordinary_observed_own_query[index].load(
+            signal_probes[index]->IsRejected(70 + index) &&
+                signal_rejections[index].load(
+                    std::memory_order_acquire
+                ) == 1 &&
+                signal_observed_host_publication[index].load(
                     std::memory_order_acquire
                 ),
-            "direct CommandList materialization failure did not run ordinary cleanup exactly once after Query notification"
+            "partial materialization did not publish hosts before rejecting a signal exactly once"
         );
         okay &= Expect(
-            success_callbacks[index].load(std::memory_order_acquire) == 0,
-            "direct CommandList materialization failure invoked a success-only callback"
+            completion_callbacks[index].load(
+                std::memory_order_acquire
+            ) == 1 &&
+                query_callbacks[index].load(
+                    std::memory_order_acquire
+                ) == 1 &&
+                ordinary_callbacks[index].load(
+                    std::memory_order_acquire
+                ) == 1 &&
+                ordinary_observed_notifications[index].load(
+                    std::memory_order_acquire
+                ),
+            "partial materialization did not release callbacks once in terminal order"
+        );
+        okay &= Expect(
+            success_callbacks[index].load(
+                std::memory_order_acquire
+            ) == 0,
+            "partial materialization invoked a success-only callback"
+        );
+        okay &= Expect(
+            reentrant_submits[index].has_value() &&
+                HasNoRejectedGenerationPayload(
+                    *reentrant_submits[index]
+                ) &&
+                command_lists[index].IsEmpty(),
+            "partial materialization exposed or restored a rejected generation"
         );
     }
+    const PresentReceiptResult present_result =
+        receipt->WaitForSubmission(100ms);
     okay &= Expect(
-        prefix_observed_suffix_terminal.load(std::memory_order_acquire),
-        "materialized-prefix Query callback observed a suffix Future Pending"
+        present_result.resolved && !present_result.submitted &&
+            receipt->ResolutionAttemptCount() == 1,
+        "partial materialization did not reject Present exactly once"
     );
-    okay &= Expect(
-        reentrant_callbacks.load(std::memory_order_acquire) == 0,
-        "group rejection consumed work re-entered into the prefix's fresh generation"
-    );
-    okay &= Expect(
-        command_lists[1].IsEmpty() && command_lists[2].IsEmpty(),
-        "direct CommandList materialization failure left an unmaterialized suffix undrained"
-    );
+    return okay;
+}
 
-    CmdSubmit reentrant_submit = command_lists[0].Submit();
-    okay &= Expect(
-        reentrant_submit.callbacks.size() == 1,
-        "materialized-prefix fresh generation did not retain re-entrant work"
-    );
-    for (auto& callback : reentrant_submit.callbacks) {
-        if (callback) {
-            callback();
+bool DirectMaterializationOverrideRemovalWaitsForReaders() {
+    BlockingDirectMaterializationContext context{};
+    const RHIDirectCommandListMaterializationOverrideForTesting
+        materialization_override{
+            .context       = &context,
+            .before_source = &BlockDirectMaterializationUntilReleased,
+        };
+    if (!Expect(
+            TryInstallRHIDirectCommandListMaterializationOverrideForTesting(
+                &materialization_override
+            ),
+            "could not install blocking materialization override"
+        )) {
+        return false;
+    }
+
+    RecordingFenceProbe signal{};
+    Moer::Array<CommandList> command_lists{};
+    command_lists.emplace_back(EQueueType::Graphics);
+    command_lists.front().Signal(&signal, 79);
+    std::atomic<bool> submit_returned{false};
+    std::atomic<bool> submit_threw{false};
+    std::jthread submit_thread([&] {
+        try {
+            RHIExecutor::Get().Submit(
+                std::move(command_lists),
+                ERHIExecSubmitFlags::None
+            );
+        } catch (...) {
+            submit_threw.store(true, std::memory_order_release);
+        }
+        submit_returned.store(true, std::memory_order_release);
+    });
+
+    {
+        std::unique_lock lock(context.mutex);
+        if (!context.cv.wait_for(
+                lock, 2s, [&] { return context.entered; }
+            )) {
+            context.release = true;
+            context.cv.notify_all();
+            submit_thread.join();
+            (void)RemoveRHIDirectCommandListMaterializationOverrideForTesting(
+                &materialization_override
+            );
+            return Expect(
+                false,
+                "blocking materialization override was not acquired"
+            );
         }
     }
-    reentrant_submit.callbacks.clear();
+
+    std::atomic<bool> release_issued{false};
+    std::jthread release_thread([&] {
+        std::this_thread::sleep_for(30ms);
+        {
+            std::lock_guard lock(context.mutex);
+            context.release = true;
+            release_issued.store(true, std::memory_order_release);
+        }
+        context.cv.notify_all();
+    });
+    const bool remove_succeeded =
+        RemoveRHIDirectCommandListMaterializationOverrideForTesting(
+            &materialization_override
+        );
+    bool okay = Expect(
+        remove_succeeded &&
+            release_issued.load(std::memory_order_acquire),
+        "override removal returned before its active reader released caller storage"
+    );
+    submit_thread.join();
+    release_thread.join();
+
     okay &= Expect(
-        reentrant_callbacks.load(std::memory_order_acquire) == 1,
-        "preserved re-entrant callback did not execute exactly once"
+        submit_returned.load(std::memory_order_acquire) &&
+            !submit_threw.load(std::memory_order_acquire) &&
+            signal.IsRejected(79),
+        "blocking materialization failure did not finish its rejected transaction"
     );
     return okay;
 }
@@ -1021,6 +1998,8 @@ bool RecordingPreflightFailureTerminalizesEveryCompletionGeneration() {
     std::array<std::atomic<int>, 3> completion_callbacks{};
     std::array<std::atomic<int>, 3> ordinary_callbacks{};
     std::array<std::atomic<int>, 3> success_callbacks{};
+    std::optional<CmdSubmit> completion_reentrant_submit{};
+    std::atomic<bool> completion_reentrant_submit_threw{false};
     for (size_t index = 0; index < command_lists.size(); ++index) {
         completion_futures[index] =
             command_lists[index]->TrackGpuCompletion(
@@ -1047,6 +2026,16 @@ bool RecordingPreflightFailureTerminalizesEveryCompletionGeneration() {
         });
     }
 
+    RecordingFenceProbe last_signal{};
+    last_list->Signal(&last_signal, 61);
+    QueryToken last_payload_query =
+        last_list->BeginTimestampQuery(
+            "CompletionPreflightSiblingPayload"
+        );
+    const QueryFuture last_payload_future =
+        last_payload_query.GetFuture();
+    last_list->EndTimestampQuery(last_payload_query);
+
     std::atomic<bool> first_observed_last_terminal{false};
     completion_futures[0].Then(
         [&](const GpuCompletionResult& _result) {
@@ -1057,6 +2046,19 @@ bool RecordingPreflightFailureTerminalizesEveryCompletionGeneration() {
                         GpuCompletionStatus::Error,
                 std::memory_order_release
             );
+            try {
+                // Publication and notification are externally re-entrant.
+                // Even though the last source has not reached Submit(), its
+                // rejected generation must already be detached before the
+                // first source's completion callback can inspect it.
+                completion_reentrant_submit.emplace(
+                    last_list->Submit()
+                );
+            } catch (...) {
+                completion_reentrant_submit_threw.store(
+                    true, std::memory_order_release
+                );
+            }
         }
     );
 
@@ -1116,6 +2118,30 @@ bool RecordingPreflightFailureTerminalizesEveryCompletionGeneration() {
     okay &= Expect(
         first_observed_last_terminal.load(std::memory_order_acquire),
         "an earlier completion callback observed a later source Pending"
+    );
+    okay &= Expect(
+        !completion_reentrant_submit_threw.load(
+            std::memory_order_acquire
+        ) &&
+            completion_reentrant_submit.has_value(),
+        "completion callback could not re-enter an unmaterialized sibling"
+    );
+    if (completion_reentrant_submit.has_value()) {
+        okay &= Expect(
+            HasNoRejectedGenerationPayload(
+                *completion_reentrant_submit
+            ),
+            "completion callback extracted a rejected sibling payload"
+        );
+    }
+    okay &= Expect(
+        last_signal.IsRejected(61),
+        "completion preflight failure left its sibling signal Pending"
+    );
+    okay &= Expect(
+        last_payload_future.WaitFor(100ms) &&
+            last_payload_future.Status() == QueryStatus::Error,
+        "completion preflight failure left its sibling Query token Pending"
     );
     okay &= Expect(
         trigger_future.WaitFor(100ms) &&
@@ -1590,22 +2616,205 @@ bool FailedCommitRejectsCompletedSources() {
     return okay;
 }
 
+bool ShutdownPreservesACompletedSourceUntilCommitHandoff() {
+    RHIExecutor::StartUp();
+
+    RecordingFenceProbe list_signal{};
+    FenceRef metadata_signal = MoerNew(RecordingFenceProbe)();
+    auto* metadata_probe =
+        static_cast<RecordingFenceProbe*>(metadata_signal.Get());
+    auto command_list =
+        Moer::MakeShared<CommandList>(EQueueType::Graphics);
+    command_list->Signal(&list_signal, 37);
+    const GpuCompletionFuture completion =
+        command_list->TrackGpuCompletion(
+            "CommitOpaqueShutdownCompletion"
+        );
+    QueryToken query = command_list->BeginTimestampQuery(
+        "CommitOpaqueShutdownQuery"
+    );
+    command_list->EndTimestampQuery(query);
+    const QueryFuture query_future = query.GetFuture();
+
+    std::atomic<int> completion_callbacks{0};
+    std::atomic<int> query_callbacks{0};
+    std::atomic<int> ordinary_callbacks{0};
+    std::atomic<int> success_callbacks{0};
+    completion.Then([&](const GpuCompletionResult&) {
+        completion_callbacks.fetch_add(
+            1, std::memory_order_release
+        );
+    });
+    query_future.Then([&](const QueryResult&) {
+        query_callbacks.fetch_add(1, std::memory_order_release);
+    });
+    command_list->AddCallback([&] {
+        ordinary_callbacks.fetch_add(1, std::memory_order_release);
+    });
+    command_list->AddSuccessCallback([&] {
+        success_callbacks.fetch_add(1, std::memory_order_release);
+    });
+
+    auto producer_complete = RHIRecordingGate::Create(true);
+    auto graph_commit = RHIRecordingGate::Create();
+    Moer::Array<RHIRecordingSource> sources{};
+    sources.emplace_back(RHIRecordingSource{
+        .command_list = command_list,
+        .completion   = producer_complete,
+        .commit       = graph_commit,
+        .submit_metadata = RHIRecordingSubmitMetadata{
+            .signal_fences = {
+                RHIRecordingFencePoint{
+                    .fence = metadata_signal,
+                    .value = 41,
+                },
+            },
+        },
+    });
+    RHIExecutor::Get().SubmitRecording(
+        std::move(sources),
+        ERHIExecSubmitFlags::None
+    );
+    RHIExecutor::ShutDown();
+
+    bool okay =
+        Expect(
+            graph_commit->Status() == ERHIRecordingStatus::Pending,
+            "shutdown changed a graph-owned Pending commit gate"
+        ) &&
+        Expect(
+            !command_list->IsEmpty() &&
+                !list_signal.IsRejected(37) &&
+                metadata_probe->RejectedValue() == 0,
+            "shutdown drained or rejected a source before commit handoff"
+        ) &&
+        Expect(
+            completion.Status() == GpuCompletionStatus::Error &&
+                query_future.Status() == QueryStatus::Error &&
+                completion_callbacks.load(
+                    std::memory_order_acquire
+                ) == 0 &&
+                query_callbacks.load(std::memory_order_acquire) == 0,
+            "opaque cancellation did not defer Future callbacks behind commit ownership"
+        ) &&
+        Expect(
+            ordinary_callbacks.load(std::memory_order_acquire) == 0 &&
+                success_callbacks.load(std::memory_order_acquire) == 0,
+            "shutdown released callbacks before commit ownership transferred"
+        );
+
+    graph_commit->Fail();
+    Moer::Array<std::function<void()>> cleanup =
+        command_list->DrainOrdinaryCallbacksForRejection();
+    for (std::function<void()>& callback : cleanup) {
+        if (callback) {
+            callback();
+        }
+    }
+    okay &= Expect(
+        list_signal.IsRejected(37) &&
+            completion_callbacks.load(
+                std::memory_order_acquire
+            ) == 1 &&
+            query_callbacks.load(std::memory_order_acquire) == 1 &&
+            ordinary_callbacks.load(std::memory_order_acquire) == 1 &&
+            success_callbacks.load(std::memory_order_acquire) == 0 &&
+            command_list->IsEmpty(),
+        "commit owner could not terminally drain the deferred cancellation"
+    );
+    return okay;
+}
+
 bool MetadataFailureRejectsEveryProducerSignal() {
     RHIExecutor::StartUp();
 
-    auto invalid_source = Moer::MakeShared<CommandList>(EQueueType::Graphics);
-    auto later_source   = Moer::MakeShared<CommandList>(EQueueType::Graphics);
-    FenceRef signal_fence = MoerNew(RecordingFenceProbe)();
-    auto* signal_probe =
-        static_cast<RecordingFenceProbe*>(signal_fence.Get());
+    auto transferred_source =
+        Moer::MakeShared<CommandList>(EQueueType::Graphics);
+    auto later_source =
+        Moer::MakeShared<CommandList>(EQueueType::Graphics);
+    std::array<GpuCompletionFuture, 2> completion_futures{
+        transferred_source->TrackGpuCompletion(
+            "MetadataTransferredCompletion"
+        ),
+        later_source->TrackGpuCompletion("MetadataFallbackCompletion"),
+    };
+    std::array<QueryFuture, 2> query_futures{};
+    {
+        QueryToken query = transferred_source->BeginTimestampQuery(
+            "MetadataTransferredQuery"
+        );
+        transferred_source->EndTimestampQuery(query);
+        query_futures[0] = query.GetFuture();
+    }
+    {
+        QueryToken query = later_source->BeginTimestampQuery(
+            "MetadataFallbackQuery"
+        );
+        later_source->EndTimestampQuery(query);
+        query_futures[1] = query.GetFuture();
+    }
+
+    std::array<std::atomic<int>, 2> signal_rejections{};
+    std::array<std::atomic<bool>, 2> signal_observed_host_terminal{};
+    std::optional<CmdSubmit> metadata_reentrant_submit{};
+    std::atomic<bool> metadata_reentrant_submit_threw{false};
+    const auto all_hosts_terminal = [&] {
+        return completion_futures[0].Status() ==
+                   GpuCompletionStatus::Error &&
+               completion_futures[1].Status() ==
+                   GpuCompletionStatus::Error &&
+               query_futures[0].Status() == QueryStatus::Error &&
+               query_futures[1].Status() == QueryStatus::Error;
+    };
+    FenceRef transferred_signal = MoerNew(RecordingFenceProbe)(
+        std::shared_ptr<std::atomic_bool>{},
+        [&] {
+            signal_observed_host_terminal[0].store(
+                all_hosts_terminal(), std::memory_order_release
+            );
+            signal_rejections[0].fetch_add(
+                1, std::memory_order_release
+            );
+            try {
+                metadata_reentrant_submit.emplace(
+                    transferred_source->Submit()
+                );
+            } catch (...) {
+                metadata_reentrant_submit_threw.store(
+                    true, std::memory_order_release
+                );
+            }
+        }
+    );
+    auto* transferred_probe =
+        static_cast<RecordingFenceProbe*>(transferred_signal.Get());
+    FenceRef fallback_signal = MoerNew(RecordingFenceProbe)(
+        std::shared_ptr<std::atomic_bool>{},
+        [&] {
+            signal_observed_host_terminal[1].store(
+                all_hosts_terminal(), std::memory_order_release
+            );
+            signal_rejections[1].fetch_add(
+                1, std::memory_order_release
+            );
+        }
+    );
+    auto* fallback_probe =
+        static_cast<RecordingFenceProbe*>(fallback_signal.Get());
 
     Moer::Array<RHIRecordingSource> sources{};
     sources.emplace_back(RHIRecordingSource{
-        .command_list = invalid_source,
+        .command_list = transferred_source,
         .completion   = RHIRecordingGate::Create(true),
         .submit_metadata = RHIRecordingSubmitMetadata{
-            .wait_fences = {
-                RHIRecordingFencePoint{.fence = {}, .value = 1},
+            .signal_fences = {
+                RHIRecordingFencePoint{
+                    .fence = transferred_signal,
+                    .value = 5,
+                },
+                // The first point has already transferred into CmdSubmit when
+                // this deterministic validation failure is reached.
+                RHIRecordingFencePoint{.fence = {}, .value = 6},
             },
         },
     });
@@ -1614,7 +2823,10 @@ bool MetadataFailureRejectsEveryProducerSignal() {
         .completion   = RHIRecordingGate::Create(true),
         .submit_metadata = RHIRecordingSubmitMetadata{
             .signal_fences = {
-                RHIRecordingFencePoint{.fence = signal_fence, .value = 7},
+                RHIRecordingFencePoint{
+                    .fence = fallback_signal,
+                    .value = 7,
+                },
             },
         },
     });
@@ -1625,10 +2837,40 @@ bool MetadataFailureRejectsEveryProducerSignal() {
     RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
     RHIExecutor::ShutDown();
 
-    bool okay = Expect(
-        signal_probe->RejectedValue() == 7,
-        "metadata failure did not reject a later producer signal"
-    );
+    bool okay =
+        Expect(
+            transferred_probe->RejectedValue() == 5 &&
+                signal_rejections[0].load(
+                    std::memory_order_acquire
+                ) == 1,
+            "metadata failure rejected a transferred producer signal more than once"
+        ) &&
+        Expect(
+            fallback_probe->RejectedValue() == 7 &&
+                signal_rejections[1].load(
+                    std::memory_order_acquire
+                ) == 1,
+            "metadata failure did not reject an untouched producer signal exactly once"
+        ) &&
+        Expect(
+            signal_observed_host_terminal[0].load(
+                std::memory_order_acquire
+            ) &&
+                signal_observed_host_terminal[1].load(
+                    std::memory_order_acquire
+                ),
+            "metadata rejection ran before every host Future was terminal"
+        ) &&
+        Expect(
+            !metadata_reentrant_submit_threw.load(
+                std::memory_order_acquire
+            ) &&
+                metadata_reentrant_submit.has_value() &&
+                HasNoRejectedGenerationPayload(
+                    *metadata_reentrant_submit
+                ),
+            "metadata rejection re-entry extracted the rejected generation"
+        );
 
     RHIExecutor::StartUp();
     FenceRef failed_gate_fence = MoerNew(RecordingFenceProbe)();
@@ -1683,8 +2925,8 @@ bool MetadataFailureRejectsEveryProducerSignal() {
     );
     RHIExecutor::ShutDown();
     okay &= Expect(
-        cancelled_probe->RejectedValue() == 13,
-        "shutdown cancellation did not reject its producer signal"
+        cancelled_probe->RejectedValue() == 0,
+        "shutdown cancellation touched metadata owned by an opaque producer"
     );
     return okay;
 }
@@ -2031,12 +3273,20 @@ bool ShutdownDrainsAcceptedReadyWork() {
 
 int main() {
     if (!CommandListSignalTracksNativeAcceptanceAndRejection() ||
+        !CommandListFenceReentryCannotExtractRejectedGeneration() ||
+        !FenceRejectionObservesPublishedHostsAndRetainsOwnedSignals() ||
+        !ExportReceiptSignalsOwnDedicatedRejectionKeepalives() ||
+        !CommandDestructorReentryTargetsOnlyFreshGeneration() ||
+        !CmdSubmitCallbackCaptureDestructorSeesCompleteReplacement() ||
+        !CommandListCallbackCaptureDestructorSeesCompleteReplacement() ||
         !FrontendQueryRejectionTerminalizesBeforeOrdinaryCallbacks() ||
         !FrontendCompletionRejectionIsOneTerminalTransaction() ||
         !FrontendPresentRejectionPublishesBatchBeforeReceipt() ||
         !DeferredOpaqueCancellationTicketSurvivesSubmit() ||
         !DirectCommandListGroupPreflightRejectsEverySource() ||
-        !DirectCommandListGroupMaterializationFailureRejectsPrefixAndSuffix() ||
+        !DirectCommandListGroupActiveLeaseFailsWithoutMutation() ||
+        !DirectCommandListGroupPartialMaterializationFailureIsAtomic() ||
+        !DirectMaterializationOverrideRemovalWaitsForReaders() ||
         !RecordingPreflightFailureTerminalizesEveryQueryGeneration() ||
         !RecordingPreflightFailureTerminalizesEveryCompletionGeneration() ||
         !SubmitRecordingRefreshesAStaleQueryCancellationView() ||
@@ -2046,6 +3296,7 @@ int main() {
         !FailedGateRejectsOnlyItsGroupAndPreservesFifo() ||
         !FailedRecordingDrainsCleanupExactlyOnce() ||
         !FailedCommitRejectsCompletedSources() ||
+        !ShutdownPreservesACompletedSourceUntilCommitHandoff() ||
         !MetadataFailureRejectsEveryProducerSignal() ||
         !BlockingWaitReportsTerminalStatus() ||
         !ShutdownDrainsTerminalSourceBehindPendingHead() ||

--- a/source/test/RHIGpuCompletionContractTest.cpp
+++ b/source/test/RHIGpuCompletionContractTest.cpp
@@ -360,22 +360,34 @@ void PublicationWakesWaitersBeforeDeferredCallbacks() {
         submit.gpu_completion_tokens.front();
 
     std::atomic_bool callback_called{false};
+    std::atomic_bool waiter_started{false};
     std::atomic_bool waiter_finished{false};
+    std::atomic_bool waiter_satisfied{false};
     future.Then([&](const GpuCompletionResult&) {
         callback_called.store(true, std::memory_order_release);
     });
     std::thread waiter([&] {
-        future.Wait();
+        waiter_started.store(true, std::memory_order_release);
+        waiter_satisfied.store(
+            future.WaitFor(5s), std::memory_order_release
+        );
         waiter_finished.store(true, std::memory_order_release);
     });
 
+    const auto start_deadline =
+        std::chrono::steady_clock::now() + 500ms;
+    while (!waiter_started.load(std::memory_order_acquire) &&
+           std::chrono::steady_clock::now() < start_deadline) {
+        std::this_thread::yield();
+    }
+    // Give the waiter an opportunity to enter the condition-variable wait;
+    // its own timeout keeps the later join bounded even if wake-up regresses.
+    std::this_thread::sleep_for(10ms);
     const GpuCompletionPublishBatch batch =
         GpuCompletionBackendAccess::BeginPublishBatch();
-    Expect(
-        GpuCompletionBackendAccess::PublishReady(token, batch),
-        "deferred publication could not publish Ready"
-    );
-    const auto deadline = std::chrono::steady_clock::now() + 500ms;
+    const bool published =
+        GpuCompletionBackendAccess::PublishReady(token, batch);
+    const auto deadline = std::chrono::steady_clock::now() + 2s;
     while (!waiter_finished.load(std::memory_order_acquire) &&
            std::chrono::steady_clock::now() < deadline) {
         std::this_thread::sleep_for(1ms);
@@ -387,7 +399,13 @@ void PublicationWakesWaitersBeforeDeferredCallbacks() {
     GpuCompletionBackendAccess::NotifyTerminal(token, batch);
     waiter.join();
     Expect(
-        waiter_woke_before_notification,
+        waiter_started.load(std::memory_order_acquire),
+        "completion waiter thread did not start"
+    );
+    Expect(published, "deferred publication could not publish Ready");
+    Expect(
+        waiter_woke_before_notification &&
+            waiter_satisfied.load(std::memory_order_acquire),
         "publication did not wake a waiter"
     );
     Expect(

--- a/source/test/RHIParallelRecordVulkanTest.cpp
+++ b/source/test/RHIParallelRecordVulkanTest.cpp
@@ -4394,12 +4394,19 @@ void RunMultiSegmentCompletionAggregateCpuProbe() {
     const VulkanMultiSegmentCompletionProbeResult result = RunVulkanMultiSegmentCompletionProbeForTesting();
     if (!result.suffix_retirement_deferred_callbacks || !result.prefix_retirement_completed_callbacks ||
         !result.repeated_retirement_suppressed || result.ordinary_callback_count != 1 ||
-        result.success_callback_count != 0) {
+        result.success_callback_count != 0 ||
+        result.materialized_prefix_signal_count != 1 ||
+        result.materialized_prefix_keepalive_count != 1 ||
+        result.materialized_suffix_signal_count != 2 ||
+        result.materialized_suffix_keepalive_count != 2 ||
+        !result.materialized_signal_identity_matches ||
+        !result.source_signal_remained_unrejected) {
         throw std::runtime_error("multi-segment completion aggregate CPU probe violated callback ordering");
     }
 
     LOG_INFO("[TESTCASE][PASS] name=MultiSegmentCompletionAggregateCpuProbe "
-             "suffix_first=deferred prefix_second=ordinary1_success0 replay=0");
+             "suffix_first=deferred prefix_second=ordinary1_success0 "
+             "signals=1,2 keepalives=1,2 identities=owned replay=0");
 }
 
 void RunMultiSegmentSourceExecution() {
@@ -5547,6 +5554,14 @@ void RunRaytracingExportAcceptanceRejection() {
         CmdSubmit attempt1_source_submit = attempt1_source.Submit();
         attempt1_source_submit.Wait(rejected_prefix_dependency.Get(), 1);
         attempt1_submission.AttachSignal(attempt1_source_submit);
+        if (attempt1_source_submit.signal_rejection_keepalives.size() != 1 ||
+            attempt1_source_submit.signal_rejection_keepalives.front().Get() !=
+                attempt1_submission.GetReceiptFence()) {
+            throw std::runtime_error(
+                "raytracing export receipt signal did not install an "
+                "explicit rejection keepalive"
+            );
+        }
         RHIExecutor::Get().Submit(
             EQueueType::Graphics,
             std::move(attempt1_source_submit),


### PR DESCRIPTION
## Summary
- make CmdSubmit/CommandList rejection a detached, host-first terminal transaction safe under synchronous re-entry
- preserve signal lifetime explicitly across recording metadata, RT export receipts, Vulkan multi-segment materialization, and D3D12/Vulkan pre-submit failure paths
- make direct/recording group rollback allocation-safe, exactly-once, and deterministic under partial materialization and shutdown fixed points
- add bounded waiter timeouts plus CPU/Vulkan regression coverage for ordering, lifetime, mixed prefix/suffix rollback, and test-override retirement

## Validation
- RelWithDebInfo: TestRHIExecutorRecordingHandoff, TestRHIGpuCompletion, TestRHIParallelRecordVulkan, MoerEditor
- CTest: 21/21 passed
- Vulkan: --timestamp-query, --timestamp-query-mid-failure, --timestamp-query-record-failure
- Vulkan: --inject-multi-segment-translate-failure
- Vulkan: --rt-export-rejection
- MoerEditor: Raytracing + Vulkan + RHI thread + parallel recording smoke runs (55s, 45s, final 30s), no runtime error markers
- three independent pre-PR audits: NO P0/P1/P2 on final head