### PR TITLE
Phase 19B: add owning RHI readback futures

### DIFF
--- a/source/runtime/render/renderer/raster/CullingPass.h
+++ b/source/runtime/render/renderer/raster/CullingPass.h
@@ -18,10 +18,12 @@
 #include "shaderheaders/shared/scene/SharedSceneStruct.h"
 
 #include "RasterConfig.h"
+#include "CullingReadbackState.h"
 #include "RasterResource.h"
 
 #include <algorithm>
 #include <cstring>
+#include <memory>
 
 namespace Moer::Render::Raster {
 
@@ -274,34 +276,65 @@ private:
     }
 
     void ConsumeCounterReadback() {
-        if (!m_counter_readback.Valid()) {
-            return;
+        if (m_counter_readback.Valid()) {
+            const std::optional<ReadbackResult> result =
+                m_counter_readback.TryGet();
+            if (!result.has_value()) {
+                return;
+            }
+            if (result->status == ReadbackStatus::Ready) {
+                const std::optional<GpuCullingCounterData> counters =
+                    result->ReadValue<GpuCullingCounterData>();
+                if (counters.has_value()) {
+                    m_readback_counters = *counters;
+                }
+            }
+            m_counter_readback = {};
         }
 
-        const std::optional<ReadbackResult> result =
-            m_counter_readback.TryGet();
-        if (!result.has_value()) {
+        if (!m_legacy_counter_readback) {
             return;
         }
-        if (result->status == ReadbackStatus::Ready) {
-            const std::optional<GpuCullingCounterData> counters =
-                result->ReadValue<GpuCullingCounterData>();
-            if (counters.has_value()) {
-                m_readback_counters = *counters;
-            }
+        const Detail::LegacyCounterReadbackStatus legacy_status =
+            m_legacy_counter_readback->GetStatus();
+        if (legacy_status ==
+            Detail::LegacyCounterReadbackStatus::Pending) {
+            return;
         }
-        m_counter_readback = {};
+        if (legacy_status ==
+            Detail::LegacyCounterReadbackStatus::Ready) {
+            m_readback_counters =
+                m_legacy_counter_readback->counters;
+        }
+        m_legacy_counter_readback.reset();
     }
 
     void QueueCounterReadback(
         CommandList& _command_list,
         BufferView   _counter_buffer
     ) {
-        if (!m_counter_readback.Valid()) {
+        if (m_counter_readback.Valid() ||
+            m_legacy_counter_readback) {
+            return;
+        }
+
+        Buffer* source = _counter_buffer.GetBuffer();
+        if (source == nullptr) {
+            return;
+        }
+        if (source->SupportsOwningReadback()) {
             m_counter_readback = _command_list.Readback(
                 _counter_buffer, "RasterGpuCullingCounters"
             );
+            return;
         }
+
+        m_legacy_counter_readback =
+            Detail::QueueLegacyCounterReadback(
+                _command_list,
+                _counter_buffer,
+                "RasterGpuCullingCountersLegacy"
+            );
     }
 
     // Dispatches the culling compute pass and prepares its outputs for indirect drawing.
@@ -403,6 +436,8 @@ private:
     BufferRef                m_cluster_group_dummy_buf;
     GpuCullingCounterData    m_readback_counters{};
     ReadbackFuture           m_counter_readback{};
+    std::shared_ptr<Detail::LegacyCounterReadbackState>
+        m_legacy_counter_readback{};
 };
 
 } // namespace Moer::Render::Raster

--- a/source/runtime/render/renderer/raster/CullingPass.h
+++ b/source/runtime/render/renderer/raster/CullingPass.h
@@ -273,6 +273,37 @@ private:
         }
     }
 
+    void ConsumeCounterReadback() {
+        if (!m_counter_readback.Valid()) {
+            return;
+        }
+
+        const std::optional<ReadbackResult> result =
+            m_counter_readback.TryGet();
+        if (!result.has_value()) {
+            return;
+        }
+        if (result->status == ReadbackStatus::Ready) {
+            const std::optional<GpuCullingCounterData> counters =
+                result->ReadValue<GpuCullingCounterData>();
+            if (counters.has_value()) {
+                m_readback_counters = *counters;
+            }
+        }
+        m_counter_readback = {};
+    }
+
+    void QueueCounterReadback(
+        CommandList& _command_list,
+        BufferView   _counter_buffer
+    ) {
+        if (!m_counter_readback.Valid()) {
+            m_counter_readback = _command_list.Readback(
+                _counter_buffer, "RasterGpuCullingCounters"
+            );
+        }
+    }
+
     // Dispatches the culling compute pass and prepares its outputs for indirect drawing.
     void Process(
         RasterContext&                    context,
@@ -291,6 +322,7 @@ private:
             context.device, context.bdls, context.cmd_list, "Raster::GpuCulling", draw_count, instance_count
         );
 
+        ConsumeCounterReadback();
         if (out_stats) {
             *out_stats = ToStatistics(m_readback_counters);
         }
@@ -298,9 +330,9 @@ private:
         context.cmd_list.ClearResource(visibility_set.counter_buf->GetView(), 0u);
 
         if (draw_count == 0) {
-            context.cmd_list.CopyFrom(
-                visibility_set.counter_buf->GetView(),
-                std::span<byte>(reinterpret_cast<byte*>(&m_readback_counters), sizeof(GpuCullingCounterData))
+            QueueCounterReadback(
+                context.cmd_list,
+                visibility_set.counter_buf->GetView()
             );
             return;
         }
@@ -358,9 +390,9 @@ private:
             context.cmd_list.PopScopeWithTimeScope();
         }
 
-        context.cmd_list.CopyFrom(
-            visibility_set.counter_buf->GetView(),
-            std::span<byte>(reinterpret_cast<byte*>(&m_readback_counters), sizeof(GpuCullingCounterData))
+        QueueCounterReadback(
+            context.cmd_list,
+            visibility_set.counter_buf->GetView()
         );
     }
 
@@ -370,6 +402,7 @@ private:
     BufferRef                m_cull_data_buffer;
     BufferRef                m_cluster_group_dummy_buf;
     GpuCullingCounterData    m_readback_counters{};
+    ReadbackFuture           m_counter_readback{};
 };
 
 } // namespace Moer::Render::Raster

--- a/source/runtime/render/renderer/raster/CullingReadbackState.h
+++ b/source/runtime/render/renderer/raster/CullingReadbackState.h
@@ -1,0 +1,108 @@
+#pragma once
+
+#include "rhi/RHICommand.h"
+#include "shaderheaders/shared/raster/culling/ShaderParameters.h"
+
+#include <atomic>
+#include <memory>
+#include <span>
+#include <stdexcept>
+#include <string_view>
+#include <utility>
+
+namespace Moer::Render::Raster::Detail {
+
+enum class LegacyCounterReadbackStatus : uint8 {
+    Pending,
+    Ready,
+    Error,
+};
+
+struct LegacyCounterReadbackState {
+    [[nodiscard]] LegacyCounterReadbackStatus GetStatus() const noexcept {
+        return status.load(std::memory_order_acquire);
+    }
+
+    void Publish(LegacyCounterReadbackStatus _status) noexcept {
+        LegacyCounterReadbackStatus expected =
+            LegacyCounterReadbackStatus::Pending;
+        (void)status.compare_exchange_strong(
+            expected,
+            _status,
+            std::memory_order_release,
+            std::memory_order_relaxed
+        );
+    }
+
+    GpuCullingCounterData counters{};
+
+private:
+    std::atomic<LegacyCounterReadbackStatus> status{
+        LegacyCounterReadbackStatus::Pending
+    };
+};
+
+// The success callback is retained by an accepted submission until GPU
+// retirement. Keeping the destination state in the same lease makes the raw
+// CopyBackBufferCmd pointer safe even if the CullingPass is destroyed first.
+// Destruction without successful retirement converts Pending to Error.
+class LegacyCounterReadbackCompletion final {
+public:
+    explicit LegacyCounterReadbackCompletion(
+        std::shared_ptr<LegacyCounterReadbackState> _state
+    ) noexcept :
+        state_(std::move(_state)) {}
+
+    ~LegacyCounterReadbackCompletion() {
+        state_->Publish(LegacyCounterReadbackStatus::Error);
+    }
+
+    void PublishReady() noexcept {
+        state_->Publish(LegacyCounterReadbackStatus::Ready);
+    }
+
+private:
+    std::shared_ptr<LegacyCounterReadbackState> state_;
+};
+
+[[nodiscard]] inline std::shared_ptr<LegacyCounterReadbackState>
+QueueLegacyCounterReadback(
+    CommandList&     _command_list,
+    BufferView       _counter_buffer,
+    std::string_view _name
+) {
+    if (_counter_buffer.GetBuffer() == nullptr ||
+        _counter_buffer.GetByteSize() !=
+            sizeof(GpuCullingCounterData)) {
+        throw std::invalid_argument(
+            "legacy culling counter readback requires one complete "
+            "GpuCullingCounterData buffer view"
+        );
+    }
+
+    auto state = std::make_shared<LegacyCounterReadbackState>();
+    auto completion =
+        std::make_shared<LegacyCounterReadbackCompletion>(state);
+
+    // Register the only destination owner before recording the raw pointer.
+    // Rejection discards success callbacks, whose final lease publishes Error.
+    _command_list.AddSuccessCallback(
+        [completion] { completion->PublishReady(); }
+    );
+    try {
+        _command_list.CopyFrom(
+            _counter_buffer,
+            std::span<byte>(
+                reinterpret_cast<byte*>(&state->counters),
+                sizeof(state->counters)
+            ),
+            _name
+        );
+    } catch (...) {
+        state->Publish(LegacyCounterReadbackStatus::Error);
+        throw;
+    }
+    return state;
+}
+
+} // namespace Moer::Render::Raster::Detail

--- a/source/runtime/render/renderer/raytracing/RTResource.cpp
+++ b/source/runtime/render/renderer/raytracing/RTResource.cpp
@@ -230,7 +230,9 @@ void RTContext::FillFrameResources(uint2 _resolution) {
         "ldr_color",
         Extent2D(_resolution),
         PF_R8G8B8A8_UNORM,
-        ETextureUsageFlags::COLOR_ATTACHMENT | ETextureUsageFlags::SAMPLED
+        ETextureUsageFlags::COLOR_ATTACHMENT |
+            ETextureUsageFlags::SAMPLED |
+            ETextureUsageFlags::TRANSFER_SRC
     );
     frame_rt.hdr_color = device.CreateTexture(
         "hdr_color",
@@ -255,7 +257,9 @@ void RTContext::FillFrameResources(uint2 _resolution) {
         "resolved_color",
         Extent2D(_resolution),
         PF_R16G16B16A16_SFLOAT,
-        ETextureUsageFlags::UNORDERED_ACCESS | ETextureUsageFlags::SAMPLED
+        ETextureUsageFlags::UNORDERED_ACCESS |
+            ETextureUsageFlags::SAMPLED |
+            ETextureUsageFlags::TRANSFER_SRC
     );
     Sampler spl{ESamplerFilter::SF_LINEAR, ESamplerAddressMode::SAM_CLAMP_TO_EDGE};
     AllocateAndFreeBdlsIfNeeded(bindless_handles.gbuffer_depth, frame_rt.view_depth->GetView(), spl);

--- a/source/runtime/render/renderer/raytracing/RaytracingExportSubmission.h
+++ b/source/runtime/render/renderer/raytracing/RaytracingExportSubmission.h
@@ -142,6 +142,19 @@ public:
         return readback_outcome == EExportSubmissionOutcome::Accepted;
     }
 
+    // Native submission acceptance is necessary but not sufficient for an
+    // export readback. A staging/materialization failure after acceptance is
+    // a hard readback failure and must participate in frame latch policy.
+    void MarkAcceptedReadbackFailed() {
+        RequireReadbackActive();
+        if (!ResolveReadbackAcceptance()) {
+            throw std::logic_error(
+                "only an accepted export readback can fail materialization"
+            );
+        }
+        readback_outcome = EExportSubmissionOutcome::Failed;
+    }
+
     template <typename EncoderDispatch>
     [[nodiscard]] bool DispatchEncoder(EncoderDispatch&& _dispatch) {
         if (!ResolveReadbackAcceptance() || encoder_dispatched) {

--- a/source/runtime/render/renderer/raytracing/RaytracingRendererExport.cpp
+++ b/source/runtime/render/renderer/raytracing/RaytracingRendererExport.cpp
@@ -55,24 +55,28 @@ bool RaytracingRenderer::DumpTextureToFile(
         return static_cast<unsigned char>(color * 255.f);
     };
 
-    size_t            size = 0;
-    Array<Moer::byte> copy_back_data;
-    std::string       file_name = "screenshot_";
-    bool              hdr       = false;
+    size_t         size = 0;
+    ReadbackFuture readback{};
+    std::string    file_name = "screenshot_";
+    bool           hdr       = false;
 
     const uint3 resolution = frame_resources.ldr_color->GetExtent();
     switch (config.output_texture) {
         case EOT_LDR:
             size = sizeof(uint) * resolution.x * resolution.y;
-            copy_back_data.resize(size);
-            command_list.CopyFrom(frame_resources.ldr_color->GetView(), copy_back_data);
+            readback = command_list.Readback(
+                frame_resources.ldr_color->GetView(),
+                "RaytracingExportLdrReadback"
+            );
             file_name += suffix;
             file_name += ".png";
             break;
         case EOT_HDR:
             size = sizeof(float2) * resolution.x * resolution.y;
-            copy_back_data.resize(size);
-            command_list.CopyFrom(frame_resources.resolved_color->GetView(), copy_back_data);
+            readback = command_list.Readback(
+                frame_resources.resolved_color->GetView(),
+                "RaytracingExportHdrReadback"
+            );
             file_name += suffix;
             file_name += ".exr";
             hdr = true;
@@ -81,7 +85,7 @@ bool RaytracingRenderer::DumpTextureToFile(
             break;
     }
 
-    if (size == 0) {
+    if (size == 0 || !readback.Valid()) {
         return false;
     }
 
@@ -94,8 +98,21 @@ bool RaytracingRenderer::DumpTextureToFile(
         std::move(readback_submit),
         ERHIExecSubmitFlags::FlushGPU
     );
-    RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
     if (!export_submission.ResolveReadbackAcceptance()) {
+        return false;
+    }
+    ReadbackResult readback_result = readback.Get();
+    if (readback_result.status != ReadbackStatus::Ready ||
+        readback_result.ByteSize() != size) {
+        export_submission.MarkAcceptedReadbackFailed();
+        LOG_ERROR(
+            "Raytracing export readback failed: status={} expected_bytes={} "
+            "actual_bytes={} reason={}",
+            static_cast<uint32>(readback_result.status),
+            size,
+            readback_result.ByteSize(),
+            readback_result.error_reason
+        );
         return false;
     }
 
@@ -110,22 +127,31 @@ bool RaytracingRenderer::DumpTextureToFile(
         );
     }
 
-    return export_submission.DispatchEncoder([&] {
+    const std::shared_ptr<const Array<byte>> payload =
+        readback_result.data;
+    return export_submission.DispatchEncoder([&, payload] {
         LambdaTask::Create([=,
-                            data(std::move(copy_back_data)),
                             dequantize_byte_to_srgb(std::move(dequantize_byte_to_srgb)),
                             dequantize_half(std::move(dequantize_half))]() mutable {
-            auto copy_back_data = std::move(data);
+            Array<byte> copy_back_data(
+                payload->begin(), payload->end()
+            );
+            const size_t pixel_count =
+                static_cast<size_t>(resolution.x) *
+                static_cast<size_t>(resolution.y);
             if (hdr) {
                 constexpr uint range_count = 8;
-                const uint     range       = copy_back_data.size() / range_count;
-                Array<float4>  copy_back_data_f4(copy_back_data.size() / 8);
+                Array<float4>  copy_back_data_f4(pixel_count);
                 ParallelFor(range_count, [&](uint index) {
-                    const size_t start = range * index;
-                    const size_t end   = range * (index + 1);
-                    for (size_t i = start; i < copy_back_data.size() && i < end; i += 8) {
-                        float4* output = &copy_back_data_f4[i / 8];
-                        short*  input  = reinterpret_cast<short*>(&copy_back_data[i]);
+                    const size_t begin =
+                        pixel_count * index / range_count;
+                    const size_t end =
+                        pixel_count * (index + 1) / range_count;
+                    for (size_t pixel = begin; pixel < end; ++pixel) {
+                        float4* output = &copy_back_data_f4[pixel];
+                        short* input = reinterpret_cast<short*>(
+                            &copy_back_data[pixel * 8]
+                        );
                         output->x      = dequantize_half(input[0]);
                         output->y      = dequantize_half(input[1]);
                         output->z      = dequantize_half(input[2]);
@@ -141,19 +167,21 @@ bool RaytracingRenderer::DumpTextureToFile(
                 );
             } else {
                 constexpr uint range_count = 8;
-                const uint     range       = copy_back_data.size() / range_count;
                 ParallelFor(range_count, [&](uint index) {
-                    const size_t start = range * index;
-                    const size_t end   = range * (index + 1);
-                    for (size_t i = start; i < copy_back_data.size() && i < end; i += 4) {
-                        copy_back_data[i] =
-                            static_cast<Moer::byte>(dequantize_byte_to_srgb(ubyte(copy_back_data[i])));
-                        copy_back_data[i + 1] =
-                            static_cast<Moer::byte>(dequantize_byte_to_srgb(ubyte(copy_back_data[i + 1])));
-                        copy_back_data[i + 2] =
-                            static_cast<Moer::byte>(dequantize_byte_to_srgb(ubyte(copy_back_data[i + 2])));
-                        copy_back_data[i + 3] =
-                            static_cast<Moer::byte>(dequantize_byte_to_srgb(ubyte(copy_back_data[i + 3])));
+                    const size_t begin =
+                        pixel_count * index / range_count;
+                    const size_t end =
+                        pixel_count * (index + 1) / range_count;
+                    for (size_t pixel = begin; pixel < end; ++pixel) {
+                        const size_t offset = pixel * 4;
+                        copy_back_data[offset] =
+                            static_cast<Moer::byte>(dequantize_byte_to_srgb(ubyte(copy_back_data[offset])));
+                        copy_back_data[offset + 1] =
+                            static_cast<Moer::byte>(dequantize_byte_to_srgb(ubyte(copy_back_data[offset + 1])));
+                        copy_back_data[offset + 2] =
+                            static_cast<Moer::byte>(dequantize_byte_to_srgb(ubyte(copy_back_data[offset + 2])));
+                        copy_back_data[offset + 3] =
+                            static_cast<Moer::byte>(dequantize_byte_to_srgb(ubyte(copy_back_data[offset + 3])));
                     }
                 });
                 stbi_write_png(

--- a/source/runtime/render/rhi/RHICommand.h
+++ b/source/runtime/render/rhi/RHICommand.h
@@ -11,6 +11,7 @@
 #include "rhi/RHICommon.h"
 #include "rhi/RHICompletion.h"
 #include "rhi/RHIQuery.h"
+#include "rhi/RHIReadback.h"
 #include "rhi/RHIResource.h"
 #include "rhi/RHISubmissionTopology.h"
 #include "shader/ShaderPipeline.h"
@@ -1658,6 +1659,18 @@ public:
     RENDER_API void CopyFrom(
         TextureView      _src,
         std::span<byte>  _data,
+        std::string_view _name = Command::typenames[(uint)Command::EType::CopyBackTexture]
+    );
+
+    // Owning host readback. The returned Future does not expose native
+    // synchronization or mapped staging memory; Ready means the GPU copy has
+    // retired and an immutable CPU byte snapshot has been materialized.
+    [[nodiscard]] RENDER_API ReadbackFuture Readback(
+        BufferView       _src,
+        std::string_view _name = Command::typenames[(uint)Command::EType::CopyBackBuffer]
+    );
+    [[nodiscard]] RENDER_API ReadbackFuture Readback(
+        TextureView      _src,
         std::string_view _name = Command::typenames[(uint)Command::EType::CopyBackTexture]
     );
 

--- a/source/runtime/render/rhi/RHICommandList.cpp
+++ b/source/runtime/render/rhi/RHICommandList.cpp
@@ -11,6 +11,7 @@
 #include "shader/ShaderPipeline.h"
 #include "shader/ShaderResourceManager.h"
 #include <atomic>
+#include <limits>
 #include <stdexcept>
 namespace Moer::Render {
 namespace {
@@ -18,6 +19,7 @@ namespace {
 std::atomic<uint64> g_query_token_id{1};
 std::atomic<uint64> g_query_owner_id{1};
 std::atomic<uint64> g_gpu_completion_token_id{1};
+std::atomic<uint64> g_readback_token_id{1};
 
 uint64 NextNonZeroId(std::atomic<uint64>& _counter) noexcept {
     uint64 id = _counter.fetch_add(1, std::memory_order_relaxed);
@@ -25,6 +27,77 @@ uint64 NextNonZeroId(std::atomic<uint64>& _counter) noexcept {
         id = _counter.fetch_add(1, std::memory_order_relaxed);
     }
     return id;
+}
+
+uint3 FullTextureMipExtent(
+    const Texture& _texture,
+    uint           _mip_level
+) noexcept {
+    const uint3 base_extent = _texture.GetExtent();
+    const auto mip_dimension = [_mip_level](uint _dimension) noexcept {
+        if (_mip_level >= std::numeric_limits<uint>::digits) {
+            return 1u;
+        }
+        return std::max(_dimension >> _mip_level, 1u);
+    };
+    return uint3(
+        mip_dimension(uint(base_extent.x)),
+        mip_dimension(uint(base_extent.y)),
+        mip_dimension(uint(base_extent.z))
+    );
+}
+
+uint3 TextureCopyExtent(const TextureView& _view) noexcept {
+    const Texture* texture = _view.GetTexture();
+    if (texture == nullptr) {
+        return _view.extent;
+    }
+    const uint3 base_extent = texture->GetExtent();
+    if (_view.extent.x != base_extent.x ||
+        _view.extent.y != base_extent.y ||
+        _view.extent.z != base_extent.z) {
+        // IO and explicit region callers already describe the selected mip
+        // or partial region. Do not apply the mip shift a second time.
+        return _view.extent;
+    }
+    return FullTextureMipExtent(*texture, _view.mip_level);
+}
+
+bool IsOwningTextureReadbackSupported(
+    const TextureView& _view
+) noexcept {
+    const Texture* texture = _view.GetTexture();
+    if (texture == nullptr) {
+        return false;
+    }
+
+    // GetMipByteSize is currently a texel-stride calculation. Keep the
+    // owning contract honest by accepting only the contiguous,
+    // single-plane color range until block-compressed and multi-plane
+    // packing is represented explicitly by the RHI.
+    const uint format = static_cast<uint>(texture->GetFormat());
+    const bool contiguous_single_plane_color =
+        format >= static_cast<uint>(PF_R4G4_UNORM_PACK8) &&
+        format <= static_cast<uint>(PF_E5B9G9R9_UFLOAT_PACK32);
+    const ETextureUsageFlags required_usage =
+        ETextureUsageFlags::TRANSFER_SRC;
+    const uint3 base_extent = texture->GetExtent();
+    const uint3 mip_extent =
+        FullTextureMipExtent(*texture, _view.mip_level);
+    const bool full_subresource_extent =
+        (_view.extent.x == base_extent.x &&
+         _view.extent.y == base_extent.y &&
+         _view.extent.z == base_extent.z) ||
+        (_view.extent.x == mip_extent.x &&
+         _view.extent.y == mip_extent.y &&
+         _view.extent.z == mip_extent.z);
+    return contiguous_single_plane_color &&
+           _view.format == texture->GetFormat() &&
+           texture->GetAspectFlags() == ETextureAspectFlags::COLOR &&
+           texture->GetNumSamples() == 1 &&
+           (texture->GetUsage() & required_usage) == required_usage &&
+           _view.offset.x == 0 && _view.offset.y == 0 &&
+           _view.offset.z == 0 && full_subresource_extent;
 }
 
 void InvokeCallbacksNoexcept(Array<std::function<void()>>& _callbacks) noexcept {
@@ -714,7 +787,7 @@ void CommandList::CopyFrom(TextureView _src, BufferView _dst, std::string_view _
             reinterpret_cast<uint64>(_dst.GetBuffer()),
             _src.offset,
             _dst.byte_offset,
-            _src.extent,
+            TextureCopyExtent(_src),
             _src.mip_level,
             _src.array_layer,
             _name
@@ -729,7 +802,7 @@ void CommandList::CopyFrom(BufferView _src, TextureView _dst, std::string_view _
             reinterpret_cast<uint64>(_dst.texture),
             _src.byte_offset,
             _dst.offset,
-            _dst.extent,
+            TextureCopyExtent(_dst),
             _dst.mip_level,
             _dst.array_layer,
             _name
@@ -815,12 +888,94 @@ void CommandList::CopyFrom(TextureView _src, std::span<byte> _data, std::string_
         MakeUnique<CopyBackTextureCmd>(
             reinterpret_cast<uint64>(_src.texture),
             _src.mip_level,
+            _src.array_layer,
             _src.offset,
-            _src.extent,
+            TextureCopyExtent(_src),
             std::span<byte>(_data.data(), mip_size),
             _name
         )
     );
+}
+
+ReadbackFuture CommandList::Readback(
+    BufferView       _src,
+    std::string_view _name
+) {
+    if (_src.GetBuffer() == nullptr || _src.GetByteSize() == 0) {
+        return {};
+    }
+
+    GpuCompletionToken completion_token(
+        NextNonZeroId(g_gpu_completion_token_id), _name
+    );
+    GpuCompletionFuture completion = completion_token.GetFuture();
+    ReadbackToken token = ReadbackBackendAccess::Create(
+        NextNonZeroId(g_readback_token_id),
+        static_cast<std::size_t>(_src.GetByteSize()),
+        _name,
+        std::move(completion)
+    );
+    ReadbackFuture future = token.GetFuture();
+    UniquePtr<Command> command = MakeUnique<CopyBackBufferCmd>(
+        reinterpret_cast<uint64>(_src.GetBuffer()),
+        _src.GetByteOffset(),
+        _src.GetByteSize(),
+        std::move(token),
+        _name
+    );
+    commands.reserve(commands.size() + 1);
+    gpu_completion_tokens.reserve(gpu_completion_tokens.size() + 1);
+    gpu_completion_cancellation_domain.Register(completion_token);
+    gpu_completion_tokens.emplace_back(std::move(completion_token));
+    commands.emplace_back(std::move(command));
+    return future;
+}
+
+ReadbackFuture CommandList::Readback(
+    TextureView      _src,
+    std::string_view _name
+) {
+    const Texture* texture = _src.GetTexture();
+    if (texture == nullptr ||
+        _src.num_mips != 1 || _src.num_array != 1 ||
+        _src.mip_level >= texture->GetNumMips() ||
+        _src.array_layer >= texture->GetNumArray() ||
+        !IsOwningTextureReadbackSupported(_src)) {
+        return {};
+    }
+
+    const uint64 byte_size =
+        texture->GetMipByteSize(_src.mip_level);
+    if (byte_size == 0) {
+        return {};
+    }
+
+    GpuCompletionToken completion_token(
+        NextNonZeroId(g_gpu_completion_token_id), _name
+    );
+    GpuCompletionFuture completion = completion_token.GetFuture();
+    ReadbackToken token = ReadbackBackendAccess::Create(
+        NextNonZeroId(g_readback_token_id),
+        static_cast<std::size_t>(byte_size),
+        _name,
+        std::move(completion)
+    );
+    ReadbackFuture future = token.GetFuture();
+    UniquePtr<Command> command = MakeUnique<CopyBackTextureCmd>(
+        reinterpret_cast<uint64>(_src.texture),
+        _src.mip_level,
+        _src.array_layer,
+        _src.offset,
+        TextureCopyExtent(_src),
+        std::move(token),
+        _name
+    );
+    commands.reserve(commands.size() + 1);
+    gpu_completion_tokens.reserve(gpu_completion_tokens.size() + 1);
+    gpu_completion_cancellation_domain.Register(completion_token);
+    gpu_completion_tokens.emplace_back(std::move(completion_token));
+    commands.emplace_back(std::move(command));
+    return future;
 }
 
 void CommandList::CopyFrom(Array<byte>&& _data, BufferView _dst, std::string_view _name) {
@@ -849,7 +1004,7 @@ void CommandList::CopyFrom(Array<byte>&& _data, TextureView _dst, std::string_vi
             _dst.mip_level,
             _dst.array_layer,
             _dst.offset,
-            _dst.extent,
+            TextureCopyExtent(_dst),
             std::move(_data),
             _name
         )

--- a/source/runtime/render/rhi/RHICommandList.cpp
+++ b/source/runtime/render/rhi/RHICommandList.cpp
@@ -901,7 +901,8 @@ ReadbackFuture CommandList::Readback(
     BufferView       _src,
     std::string_view _name
 ) {
-    if (_src.GetBuffer() == nullptr || _src.GetByteSize() == 0) {
+    if (_src.GetBuffer() == nullptr || _src.GetByteSize() == 0 ||
+        !_src.GetBuffer()->SupportsOwningReadback()) {
         return {};
     }
 
@@ -940,6 +941,7 @@ ReadbackFuture CommandList::Readback(
         _src.num_mips != 1 || _src.num_array != 1 ||
         _src.mip_level >= texture->GetNumMips() ||
         _src.array_layer >= texture->GetNumArray() ||
+        !texture->SupportsOwningReadback() ||
         !IsOwningTextureReadbackSupported(_src)) {
         return {};
     }

--- a/source/runtime/render/rhi/RHIImpl.h
+++ b/source/runtime/render/rhi/RHIImpl.h
@@ -99,7 +99,8 @@ private:
     uint64      handle{};
     uint64      offset{};
     uint64      byte_size{};
-    void* const data{};
+    void*       data{};
+    ReadbackToken owning_readback{};
     CopyBackBufferCmd() : Command(EType::CopyBackBuffer) {}
 
 public:
@@ -115,6 +116,19 @@ public:
         offset(_offset),
         byte_size(_byte_size),
         data(_data) {}
+
+    CopyBackBufferCmd(
+        uint64           _handle,
+        uint64           _offset,
+        uint64           _byte_size,
+        ReadbackToken    _owning_readback,
+        std::string_view _name = typenames[uint(EType::CopyBackBuffer)]
+    ) :
+        Command(EType::CopyBackBuffer, _name),
+        handle(_handle),
+        offset(_offset),
+        byte_size(_byte_size),
+        owning_readback(std::move(_owning_readback)) {}
 
     //generate getters
     EQueueType GetQueueType() const override {
@@ -132,6 +146,12 @@ public:
     auto Data() const {
         return data;
     }
+    bool HasOwningReadback() const noexcept {
+        return owning_readback.Valid();
+    }
+    const ReadbackToken& OwningReadback() const noexcept {
+        return owning_readback;
+    }
 
     mutable BufferView staging_buffer;
 };
@@ -140,15 +160,19 @@ struct CopyBackTextureCmd : public Command {
 private:
     uint64          handle{};
     uint            mip_level{};
+    uint            array_layer{};
     uint3           offset{};
     uint3           size{};
+    uint64          byte_size{};
     std::span<byte> data;
+    ReadbackToken   owning_readback{};
     CopyBackTextureCmd() : Command(EType::CopyBackTexture) {}
 
 public:
     CopyBackTextureCmd(
         uint64           _handle,
         uint             _mip_level,
+        uint             _array_layer,
         uint3            _offset,
         uint3            _size,
         std::span<byte>  _data,
@@ -157,9 +181,29 @@ public:
         Command(EType::CopyBackTexture, _name),
         handle(_handle),
         mip_level(_mip_level),
+        array_layer(_array_layer),
         offset{_offset.x, _offset.y, _offset.z},
         size{_size.x, _size.y, _size.z},
+        byte_size(_data.size_bytes()),
         data(_data) {}
+
+    CopyBackTextureCmd(
+        uint64           _handle,
+        uint             _mip_level,
+        uint             _array_layer,
+        uint3            _offset,
+        uint3            _size,
+        ReadbackToken    _owning_readback,
+        std::string_view _name = typenames[uint(EType::CopyBackTexture)]
+    ) :
+        Command(EType::CopyBackTexture, _name),
+        handle(_handle),
+        mip_level(_mip_level),
+        array_layer(_array_layer),
+        offset{_offset.x, _offset.y, _offset.z},
+        size{_size.x, _size.y, _size.z},
+        byte_size(_owning_readback.ByteSize()),
+        owning_readback(std::move(_owning_readback)) {}
 
     EQueueType GetQueueType() const override {
         return EQueueType::Copy;
@@ -171,6 +215,9 @@ public:
     auto MipLevel() const {
         return mip_level;
     }
+    auto ArrayLayer() const {
+        return array_layer;
+    }
     auto Offset() const {
         return offset;
     }
@@ -179,6 +226,15 @@ public:
     }
     auto Data() const {
         return data;
+    }
+    auto ByteSize() const {
+        return byte_size;
+    }
+    bool HasOwningReadback() const noexcept {
+        return owning_readback.Valid();
+    }
+    const ReadbackToken& OwningReadback() const noexcept {
+        return owning_readback;
     }
 
     mutable BufferView staging_buffer;

--- a/source/runtime/render/rhi/RHIReadback.cpp
+++ b/source/runtime/render/rhi/RHIReadback.cpp
@@ -1,0 +1,456 @@
+#include "rhi/RHIReadback.h"
+
+#include "rhi/RHIThreadOwnership.h"
+
+#include <condition_variable>
+#include <mutex>
+#include <stdexcept>
+#include <utility>
+
+namespace Moer::Render {
+namespace {
+
+enum class ReadbackPayloadStatus : std::uint8_t {
+    Pending = 0,
+    Ready   = 1,
+    Error   = 2,
+};
+
+ReadbackResult InvalidReadbackResult() {
+    ReadbackResult result{};
+    result.status       = ReadbackStatus::Error;
+    result.error_reason = "invalid readback future";
+    return result;
+}
+
+void InvokeReadbackCallbackNoexcept(
+    const ReadbackFuture::Callback& _callback,
+    const ReadbackResult&           _result
+) noexcept {
+    if (!_callback) {
+        return;
+    }
+    try {
+        _callback(_result);
+    } catch (...) {
+        // A faulty observer must not terminate a Completion/rejection owner.
+    }
+}
+
+} // namespace
+
+struct ReadbackPayloadState {
+    explicit ReadbackPayloadState(std::size_t _byte_size) :
+        bytes(std::make_shared<Array<byte>>(_byte_size)) {}
+
+    mutable std::mutex           mutex{};
+    std::condition_variable      cv{};
+    std::shared_ptr<Array<byte>> bytes{};
+    ReadbackPayloadStatus        status{ReadbackPayloadStatus::Pending};
+    std::string                  error_reason{};
+};
+
+struct ReadbackProducerLease {
+    explicit ReadbackProducerLease(
+        std::weak_ptr<ReadbackPayloadState> _state
+    ) noexcept :
+        state(std::move(_state)) {}
+
+    ~ReadbackProducerLease() {
+        const std::shared_ptr<ReadbackPayloadState> payload = state.lock();
+        if (!payload) {
+            return;
+        }
+
+        bool notify = false;
+        {
+            std::scoped_lock lock(payload->mutex);
+            if (payload->status == ReadbackPayloadStatus::Pending) {
+                payload->status = ReadbackPayloadStatus::Error;
+                try {
+                    payload->error_reason =
+                        "readback producer retired without materializing payload";
+                } catch (...) {
+                }
+                notify = true;
+            }
+        }
+        if (notify) {
+            payload->cv.notify_all();
+        }
+    }
+
+    std::weak_ptr<ReadbackPayloadState> state{};
+};
+
+ReadbackFuture::ReadbackFuture(
+    std::uint64_t                         _readback_id,
+    std::shared_ptr<const std::string>    _name,
+    std::shared_ptr<ReadbackPayloadState> _state,
+    GpuCompletionFuture                   _completion
+) noexcept :
+    readback_id_(_readback_id),
+    name_(std::move(_name)),
+    state_(std::move(_state)),
+    completion_(std::move(_completion)) {}
+
+bool ReadbackFuture::Valid() const noexcept {
+    return readback_id_ != 0 && name_ && state_ && completion_.Valid();
+}
+
+ReadbackStatus ReadbackFuture::Status() const noexcept {
+    if (!Valid()) {
+        return ReadbackStatus::Error;
+    }
+
+    const GpuCompletionStatus completion_status = completion_.Status();
+    if (completion_status == GpuCompletionStatus::Pending) {
+        return ReadbackStatus::Pending;
+    }
+    if (completion_status == GpuCompletionStatus::Error) {
+        return ReadbackStatus::Error;
+    }
+
+    std::scoped_lock lock(state_->mutex);
+    switch (state_->status) {
+        case ReadbackPayloadStatus::Ready:
+            return ReadbackStatus::Ready;
+        case ReadbackPayloadStatus::Error:
+            return ReadbackStatus::Error;
+        case ReadbackPayloadStatus::Pending:
+        default:
+            return ReadbackStatus::Pending;
+    }
+}
+
+bool ReadbackFuture::IsReady() const noexcept {
+    return Valid() && Status() != ReadbackStatus::Pending;
+}
+
+std::size_t ReadbackFuture::ExpectedByteSize() const noexcept {
+    if (!state_ || !state_->bytes) {
+        return 0;
+    }
+    return state_->bytes->size();
+}
+
+void ReadbackFuture::Wait() const {
+    if (!Valid()) {
+        return;
+    }
+
+    const GpuCompletionResult completion_result = completion_.Get();
+    if (completion_result.status != GpuCompletionStatus::Ready) {
+        return;
+    }
+
+    std::unique_lock lock(state_->mutex);
+    if (state_->status == ReadbackPayloadStatus::Pending &&
+        !IsRHIBlockingCallAllowedOnCurrentThread()) {
+        throw std::logic_error(
+            "an RHI owner thread cannot block on a pending readback payload"
+        );
+    }
+    state_->cv.wait(lock, [state = state_] {
+        return state->status != ReadbackPayloadStatus::Pending;
+    });
+}
+
+bool ReadbackFuture::WaitFor(
+    std::chrono::nanoseconds _timeout
+) const {
+    if (!Valid()) {
+        return false;
+    }
+
+    const auto deadline = std::chrono::steady_clock::now() + _timeout;
+    if (!completion_.WaitFor(_timeout)) {
+        return false;
+    }
+    const std::optional<GpuCompletionResult> completion_result =
+        completion_.TryGet();
+    if (!completion_result.has_value()) {
+        return false;
+    }
+    if (completion_result->status != GpuCompletionStatus::Ready) {
+        return true;
+    }
+
+    std::unique_lock lock(state_->mutex);
+    if (state_->status == ReadbackPayloadStatus::Pending &&
+        !IsRHIBlockingCallAllowedOnCurrentThread()) {
+        throw std::logic_error(
+            "an RHI owner thread cannot block on a pending readback payload"
+        );
+    }
+    return state_->cv.wait_until(lock, deadline, [state = state_] {
+        return state->status != ReadbackPayloadStatus::Pending;
+    });
+}
+
+ReadbackResult ReadbackFuture::BuildResult(
+    const GpuCompletionResult& _completion_result
+) const {
+    if (!Valid()) {
+        return InvalidReadbackResult();
+    }
+
+    ReadbackResult result{};
+    result.readback_id = readback_id_;
+    result.name        = name_ ? *name_ : std::string{};
+
+    if (_completion_result.status == GpuCompletionStatus::Pending) {
+        result.status = ReadbackStatus::Pending;
+        return result;
+    }
+    if (_completion_result.status == GpuCompletionStatus::Error) {
+        result.status       = ReadbackStatus::Error;
+        result.error_reason = _completion_result.error_reason;
+        return result;
+    }
+
+    std::scoped_lock lock(state_->mutex);
+    switch (state_->status) {
+        case ReadbackPayloadStatus::Ready:
+            result.status = ReadbackStatus::Ready;
+            result.data = std::static_pointer_cast<const Array<byte>>(
+                state_->bytes
+            );
+            break;
+        case ReadbackPayloadStatus::Error:
+            result.status       = ReadbackStatus::Error;
+            result.error_reason = state_->error_reason;
+            break;
+        case ReadbackPayloadStatus::Pending:
+        default:
+            result.status = ReadbackStatus::Pending;
+            break;
+    }
+    return result;
+}
+
+ReadbackResult ReadbackFuture::Get() const {
+    if (!Valid()) {
+        return InvalidReadbackResult();
+    }
+    Wait();
+    const GpuCompletionResult completion_result = completion_.Get();
+    return BuildResult(completion_result);
+}
+
+std::optional<ReadbackResult> ReadbackFuture::TryGet() const {
+    if (!Valid()) {
+        return InvalidReadbackResult();
+    }
+
+    const std::optional<GpuCompletionResult> completion_result =
+        completion_.TryGet();
+    if (!completion_result.has_value()) {
+        return std::nullopt;
+    }
+    const ReadbackResult result = BuildResult(*completion_result);
+    if (result.status == ReadbackStatus::Pending) {
+        return std::nullopt;
+    }
+    return result;
+}
+
+void ReadbackFuture::Then(Callback _callback) const {
+    if (!_callback) {
+        return;
+    }
+    if (!Valid()) {
+        InvokeReadbackCallbackNoexcept(
+            _callback, InvalidReadbackResult()
+        );
+        return;
+    }
+
+    const ReadbackFuture self = *this;
+    completion_.Then(
+        [self, callback = std::move(_callback)](
+            const GpuCompletionResult& _result
+        ) {
+            try {
+                ReadbackResult result = self.BuildResult(_result);
+                if (result.status == ReadbackStatus::Pending) {
+                    // The token's internal guard is registered before this
+                    // adapter and terminalizes a missing payload first.
+                    result.status = ReadbackStatus::Error;
+                    result.error_reason =
+                        "readback notification observed a pending payload";
+                }
+                InvokeReadbackCallbackNoexcept(callback, result);
+            } catch (...) {
+                // Preserve exactly-once callback delivery even if assembling
+                // the diagnostic/name snapshot runs out of memory.
+                ReadbackResult fallback{};
+                fallback.status      = ReadbackStatus::Error;
+                fallback.readback_id = self.readback_id_;
+                InvokeReadbackCallbackNoexcept(callback, fallback);
+            }
+        }
+    );
+}
+
+ReadbackToken::ReadbackToken(
+    std::uint64_t       _readback_id,
+    std::size_t         _byte_size,
+    std::string_view    _name,
+    GpuCompletionFuture _completion
+) :
+    readback_id_(_readback_id),
+    name_(std::make_shared<const std::string>(_name)),
+    state_(std::make_shared<ReadbackPayloadState>(_byte_size)),
+    producer_lease_(
+        std::make_shared<ReadbackProducerLease>(state_)
+    ),
+    completion_(std::move(_completion)) {
+    // Register exactly one guard before the token or a derived Future can
+    // escape. Vulkan publishes logical GPU completion before running
+    // allocator completion callbacks, but releases notifications only after
+    // those callbacks. A still-Pending payload at notification is therefore
+    // a backend failure.
+    const std::shared_ptr<ReadbackPayloadState> state = state_;
+    completion_.Then(
+        [state](const GpuCompletionResult& _result) noexcept {
+            if (!state ||
+                _result.status != GpuCompletionStatus::Ready) {
+                return;
+            }
+
+            bool notify = false;
+            {
+                std::scoped_lock lock(state->mutex);
+                if (state->status == ReadbackPayloadStatus::Pending) {
+                    state->status = ReadbackPayloadStatus::Error;
+                    try {
+                        state->error_reason =
+                            "GPU completed without materializing readback payload";
+                    } catch (...) {
+                    }
+                    notify = true;
+                }
+            }
+            if (notify) {
+                state->cv.notify_all();
+            }
+        }
+    );
+}
+
+bool ReadbackToken::Valid() const noexcept {
+    return readback_id_ != 0 && name_ && state_ && producer_lease_ &&
+           completion_.Valid();
+}
+
+std::uint64_t ReadbackToken::Id() const noexcept {
+    return readback_id_;
+}
+
+std::size_t ReadbackToken::ByteSize() const noexcept {
+    return state_ && state_->bytes ? state_->bytes->size() : 0;
+}
+
+const std::string& ReadbackToken::Name() const noexcept {
+    static const std::string empty_name{};
+    return name_ ? *name_ : empty_name;
+}
+
+ReadbackFuture ReadbackToken::GetFuture() const noexcept {
+    if (!Valid()) {
+        return {};
+    }
+    return ReadbackFuture(
+        readback_id_, name_, state_, completion_
+    );
+}
+
+ReadbackToken ReadbackBackendAccess::Create(
+    std::uint64_t       _readback_id,
+    std::size_t         _byte_size,
+    std::string_view    _name,
+    GpuCompletionFuture _completion
+) {
+    if (_readback_id == 0 || _byte_size == 0 || !_completion.Valid()) {
+        return {};
+    }
+    return ReadbackToken(
+        _readback_id, _byte_size, _name, std::move(_completion)
+    );
+}
+
+bool ReadbackBackendAccess::MaterializePayload(
+    const ReadbackToken& _token,
+    void*                _context,
+    PayloadWriter        _writer
+) noexcept {
+    if (!_token.Valid() || !_writer) {
+        return false;
+    }
+
+    bool succeeded = false;
+    {
+        std::scoped_lock lock(_token.state_->mutex);
+        if (_token.state_->status != ReadbackPayloadStatus::Pending) {
+            return false;
+        }
+        try {
+            _writer(
+                _context,
+                std::span<byte>(
+                    _token.state_->bytes->data(),
+                    _token.state_->bytes->size()
+                )
+            );
+            _token.state_->status = ReadbackPayloadStatus::Ready;
+            _token.state_->error_reason.clear();
+            succeeded = true;
+        } catch (const std::exception& error) {
+            _token.state_->status = ReadbackPayloadStatus::Error;
+            try {
+                _token.state_->error_reason =
+                    std::string("readback payload materialization failed: ") +
+                    error.what();
+            } catch (...) {
+            }
+        } catch (...) {
+            _token.state_->status = ReadbackPayloadStatus::Error;
+            try {
+                _token.state_->error_reason =
+                    "readback payload materialization failed";
+            } catch (...) {
+            }
+        }
+    }
+    _token.state_->cv.notify_all();
+    return succeeded;
+}
+
+bool ReadbackBackendAccess::PublishPayloadErrorIfPending(
+    const ReadbackToken& _token,
+    std::string_view     _reason
+) noexcept {
+    if (!_token.Valid()) {
+        return false;
+    }
+
+    std::string reason{};
+    try {
+        reason.assign(_reason);
+    } catch (...) {
+    }
+
+    {
+        std::scoped_lock lock(_token.state_->mutex);
+        if (_token.state_->status != ReadbackPayloadStatus::Pending) {
+            return false;
+        }
+        _token.state_->status       = ReadbackPayloadStatus::Error;
+        _token.state_->error_reason = std::move(reason);
+    }
+    _token.state_->cv.notify_all();
+    return true;
+}
+
+} // namespace Moer::Render

--- a/source/runtime/render/rhi/RHIReadback.h
+++ b/source/runtime/render/rhi/RHIReadback.h
@@ -1,0 +1,208 @@
+#ifndef MOER_ENGINE_RHI_READBACK_H
+#define MOER_ENGINE_RHI_READBACK_H
+
+#include "RenderAPI.h"
+#include "misc/STL.h"
+#include "misc/Traits.h"
+#include "rhi/RHICompletion.h"
+
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <functional>
+#include <memory>
+#include <optional>
+#include <span>
+#include <string>
+#include <string_view>
+#include <type_traits>
+
+namespace Moer::Render {
+
+enum class ReadbackStatus : std::uint8_t {
+    Pending = 0,
+    Ready   = 1,
+    Error   = 2,
+};
+
+// An owning immutable snapshot. Keeping the result alive keeps its byte
+// storage alive even after the originating ReadbackFuture is released.
+struct ReadbackResult {
+    ReadbackStatus                    status{ReadbackStatus::Pending};
+    std::uint64_t                     readback_id{0};
+    std::string                       name{};
+    std::shared_ptr<const Array<byte>> data{};
+    std::string                       error_reason{};
+
+    [[nodiscard]] std::span<const byte> Bytes() const noexcept {
+        if (!data) {
+            return {};
+        }
+        return std::span<const byte>(data->data(), data->size());
+    }
+
+    [[nodiscard]] std::size_t ByteSize() const noexcept {
+        return data ? data->size() : 0;
+    }
+
+    template<typename T>
+        requires std::is_trivially_copyable_v<T>
+    [[nodiscard]] std::optional<T> ReadValue(
+        std::size_t _byte_offset = 0
+    ) const noexcept {
+        if (status != ReadbackStatus::Ready || !data) {
+            return std::nullopt;
+        }
+        const std::span<const byte> bytes = Bytes();
+        if (_byte_offset > bytes.size() ||
+            sizeof(T) > bytes.size() - _byte_offset) {
+            return std::nullopt;
+        }
+        T value{};
+        std::memcpy(
+            &value, bytes.data() + _byte_offset, sizeof(T)
+        );
+        return value;
+    }
+
+    template<typename T>
+        requires std::is_trivially_copyable_v<T>
+    [[nodiscard]] std::optional<Array<T>> CopyAs() const {
+        if (status != ReadbackStatus::Ready || !data) {
+            return std::nullopt;
+        }
+        const std::span<const byte> bytes = Bytes();
+        if (bytes.size() % sizeof(T) != 0) {
+            return std::nullopt;
+        }
+        Array<T> values(bytes.size() / sizeof(T));
+        if (!bytes.empty()) {
+            std::memcpy(values.data(), bytes.data(), bytes.size());
+        }
+        return values;
+    }
+};
+
+class ReadbackToken;
+struct ReadbackPayloadState;
+struct ReadbackProducerLease;
+
+// Copyable host handle for one owning readback. Public readiness is the
+// conjunction of logical GPU completion and payload materialization:
+// observing the GPU completion alone is not enough because main publishes
+// that state before staging-to-host completion callbacks run.
+class RENDER_API ReadbackFuture {
+public:
+    using Callback = std::function<void(const ReadbackResult&)>;
+
+    ReadbackFuture() = default;
+
+    [[nodiscard]] bool Valid() const noexcept;
+    [[nodiscard]] bool IsReady() const noexcept;
+    [[nodiscard]] ReadbackStatus Status() const noexcept;
+    [[nodiscard]] std::size_t ExpectedByteSize() const noexcept;
+
+    // As with GpuCompletionFuture, an RHI owner cannot block on a component
+    // that is still Pending. Terminal results remain readable everywhere.
+    void Wait() const;
+    [[nodiscard]] bool WaitFor(std::chrono::nanoseconds _timeout) const;
+
+    template<typename Rep, typename Period>
+    [[nodiscard]] bool WaitFor(
+        std::chrono::duration<Rep, Period> _timeout
+    ) const {
+        return WaitFor(
+            std::chrono::duration_cast<std::chrono::nanoseconds>(_timeout)
+        );
+    }
+
+    [[nodiscard]] ReadbackResult Get() const;
+    [[nodiscard]] std::optional<ReadbackResult> TryGet() const;
+
+    // Notification is delegated to the logical GpuCompletionFuture. The
+    // token registers one internal payload guard before any Future escapes,
+    // so callbacks never observe a successful GPU completion with an
+    // unmaterialized payload.
+    void Then(Callback _callback) const;
+
+private:
+    ReadbackFuture(
+        std::uint64_t                         _readback_id,
+        std::shared_ptr<const std::string>    _name,
+        std::shared_ptr<ReadbackPayloadState> _state,
+        GpuCompletionFuture                   _completion
+    ) noexcept;
+
+    [[nodiscard]] ReadbackResult BuildResult(
+        const GpuCompletionResult& _completion_result
+    ) const;
+
+    std::uint64_t                         readback_id_{0};
+    std::shared_ptr<const std::string>    name_{};
+    std::shared_ptr<ReadbackPayloadState> state_{};
+    GpuCompletionFuture                   completion_{};
+
+    friend class ReadbackToken;
+    friend class ReadbackBackendAccess;
+};
+
+// Producer-side payload identity retained by CopyBack commands and native
+// allocator callbacks. It intentionally exposes no user callback API.
+class RENDER_API ReadbackToken {
+public:
+    ReadbackToken() = default;
+
+    [[nodiscard]] bool Valid() const noexcept;
+    [[nodiscard]] std::uint64_t Id() const noexcept;
+    [[nodiscard]] std::size_t ByteSize() const noexcept;
+    [[nodiscard]] const std::string& Name() const noexcept;
+    [[nodiscard]] ReadbackFuture GetFuture() const noexcept;
+
+private:
+    ReadbackToken(
+        std::uint64_t        _readback_id,
+        std::size_t          _byte_size,
+        std::string_view     _name,
+        GpuCompletionFuture  _completion
+    );
+
+    std::uint64_t                              readback_id_{0};
+    std::shared_ptr<const std::string>         name_{};
+    std::shared_ptr<ReadbackPayloadState>      state_{};
+    std::shared_ptr<ReadbackProducerLease>     producer_lease_{};
+    GpuCompletionFuture                        completion_{};
+
+    friend class ReadbackBackendAccess;
+};
+
+// Narrow seam used by CommandList construction and native readback recorders.
+// Payload mutation remains separate from GPU terminal publication.
+class RENDER_API ReadbackBackendAccess final {
+public:
+    [[nodiscard]] static ReadbackToken Create(
+        std::uint64_t        _readback_id,
+        std::size_t          _byte_size,
+        std::string_view     _name,
+        GpuCompletionFuture  _completion
+    );
+
+    using PayloadWriter = void (*)(void*, std::span<byte>);
+
+    // Invokes the trusted backend writer synchronously while the payload is
+    // exclusively Pending, then atomically publishes an immutable snapshot.
+    // The writable span is valid only for the duration of _writer.
+    static bool MaterializePayload(
+        const ReadbackToken& _token,
+        void*                _context,
+        PayloadWriter        _writer
+    ) noexcept;
+    static bool PublishPayloadErrorIfPending(
+        const ReadbackToken& _token,
+        std::string_view     _reason
+    ) noexcept;
+};
+
+} // namespace Moer::Render
+
+#endif

--- a/source/runtime/render/rhi/RHIResource.h
+++ b/source/runtime/render/rhi/RHIResource.h
@@ -505,6 +505,13 @@ public:
     RENDER_API BufferView GetView(uint64 _byte_offset = 0, uint64 _byte_size = UINT64_MAX);
     RENDER_API BufferView GetView(EPixelFormat _fmt, uint64 _byte_offset = 0, uint64 _byte_size = UINT64_MAX);
     virtual RENDER_API void SetName(const std::string_view _name) = 0;
+    // Owning readback requires both payload materialization and a backend
+    // completion path capable of publishing Ready. Backends must opt in
+    // explicitly so CommandList never returns a Future that is guaranteed to
+    // fail after recording.
+    [[nodiscard]] virtual bool SupportsOwningReadback() const noexcept {
+        return false;
+    }
 
 protected:
     /**
@@ -692,6 +699,9 @@ public:
     RENDER_API TextureView  GetView(uint8 _mip_idx = 0u, uint8 _mip_num = 1u);
     RENDER_API TextureView  GetView(EPixelFormat _format, uint8 _mip_idx = 0u, uint8 _mip_num = 1u);
     virtual RENDER_API void SetName(const std::string_view _name) = 0;
+    [[nodiscard]] virtual bool SupportsOwningReadback() const noexcept {
+        return false;
+    }
 
 protected:
     std::optional<std::string> debug_name;

--- a/source/runtime/render/rhi/d3d12/D3D12Device.cpp
+++ b/source/runtime/render/rhi/d3d12/D3D12Device.cpp
@@ -1335,55 +1335,29 @@ struct D3D12CommandVisitor {
     }
 
     void Visit(const CopyBackBufferCmd& _cmd) {
+        if (_cmd.HasOwningReadback()) {
+            // CommandList rejects this before recording because D3D12 does
+            // not yet have a successful GpuCompletionFuture retirement path.
+            // Keep the visitor fail-closed for manually constructed commands.
+            throw std::runtime_error(
+                "D3D12 owning buffer readback is unsupported"
+            );
+        }
         auto tmp_buffer = allocator.AllocateReadbackBuffer(_cmd.ByteSize(), 256); // ? not sure alignment
         D3D12Buffer* src_buffer = reinterpret_cast<D3D12Buffer*>(_cmd.Handle());
         cmd_list.CopyBuffer(
             src_buffer, tmp_buffer.buffer, _cmd.ByteSize(), _cmd.Offset(), tmp_buffer.byte_offset
         );
-        if (_cmd.HasOwningReadback()) {
-            const ReadbackToken readback = _cmd.OwningReadback();
-            const uint64 logical_size = _cmd.ByteSize();
-            allocator.AddOnComplete(
-                [tmp_buffer, &cmd_list(cmd_list), readback, logical_size] {
-                    struct WriterContext {
-                        D3D12CommandList*       command_list{};
-                        D3D12StagingBufferView staging{};
-                        uint64                 byte_size{};
-                    } context{&cmd_list, tmp_buffer, logical_size};
-                    (void)ReadbackBackendAccess::MaterializePayload(
-                        readback,
-                        &context,
-                        [](void* _context, std::span<byte> _destination) {
-                            auto* writer =
-                                static_cast<WriterContext*>(_context);
-                            if (writer == nullptr ||
-                                _destination.size_bytes() !=
-                                    writer->byte_size) {
-                                throw std::runtime_error(
-                                    "D3D12 buffer readback payload size mismatch"
-                                );
-                            }
-                            writer->command_list->CopyData(
-                                _destination.data(),
-                                writer->staging,
-                                writer->byte_size
-                            );
-                        }
-                    );
-                }
-            );
-        } else {
-            allocator.AddOnComplete(
-                [tmp_buffer,
-                 &cmd_list(cmd_list),
-                 destination(_cmd.Data()),
-                 logical_size = _cmd.ByteSize()] {
-                    cmd_list.CopyData(
-                        destination, tmp_buffer, logical_size
-                    );
-                }
-            );
-        }
+        allocator.AddOnComplete(
+            [tmp_buffer,
+             &cmd_list(cmd_list),
+             destination(_cmd.Data()),
+             logical_size = _cmd.ByteSize()] {
+                cmd_list.CopyData(
+                    destination, tmp_buffer, logical_size
+                );
+            }
+        );
     }
 
     void Visit(const CopyBufferCmd& _cmd) {

--- a/source/runtime/render/rhi/d3d12/D3D12Device.cpp
+++ b/source/runtime/render/rhi/d3d12/D3D12Device.cpp
@@ -1277,6 +1277,10 @@ struct D3D12CommandPreprocessVisitor {
             case Command::EType::CopyBackBuffer:
                 Visit(static_cast<const CopyBackBufferCmd&>(*_cmd));
                 break;
+            case Command::EType::CopyBackTexture:
+                throw std::runtime_error(
+                    "D3D12 texture readback is unsupported"
+                );
             case Command::EType::BufferToBuffer:
                 Visit(static_cast<const CopyBufferCmd&>(*_cmd));
                 break;
@@ -1336,9 +1340,50 @@ struct D3D12CommandVisitor {
         cmd_list.CopyBuffer(
             src_buffer, tmp_buffer.buffer, _cmd.ByteSize(), _cmd.Offset(), tmp_buffer.byte_offset
         );
-        allocator.AddOnComplete([tmp_buffer, &cmd_list(cmd_list), dst(_cmd.Data()), size(_cmd.ByteSize())] {
-            cmd_list.CopyData(dst, tmp_buffer, size);
-        });
+        if (_cmd.HasOwningReadback()) {
+            const ReadbackToken readback = _cmd.OwningReadback();
+            const uint64 logical_size = _cmd.ByteSize();
+            allocator.AddOnComplete(
+                [tmp_buffer, &cmd_list(cmd_list), readback, logical_size] {
+                    struct WriterContext {
+                        D3D12CommandList*       command_list{};
+                        D3D12StagingBufferView staging{};
+                        uint64                 byte_size{};
+                    } context{&cmd_list, tmp_buffer, logical_size};
+                    (void)ReadbackBackendAccess::MaterializePayload(
+                        readback,
+                        &context,
+                        [](void* _context, std::span<byte> _destination) {
+                            auto* writer =
+                                static_cast<WriterContext*>(_context);
+                            if (writer == nullptr ||
+                                _destination.size_bytes() !=
+                                    writer->byte_size) {
+                                throw std::runtime_error(
+                                    "D3D12 buffer readback payload size mismatch"
+                                );
+                            }
+                            writer->command_list->CopyData(
+                                _destination.data(),
+                                writer->staging,
+                                writer->byte_size
+                            );
+                        }
+                    );
+                }
+            );
+        } else {
+            allocator.AddOnComplete(
+                [tmp_buffer,
+                 &cmd_list(cmd_list),
+                 destination(_cmd.Data()),
+                 logical_size = _cmd.ByteSize()] {
+                    cmd_list.CopyData(
+                        destination, tmp_buffer, logical_size
+                    );
+                }
+            );
+        }
     }
 
     void Visit(const CopyBufferCmd& _cmd) {
@@ -1424,6 +1469,10 @@ struct D3D12CommandVisitor {
             case Command::EType::CopyBackBuffer:
                 Visit(static_cast<const CopyBackBufferCmd&>(*_cmd));
                 break;
+            case Command::EType::CopyBackTexture:
+                throw std::runtime_error(
+                    "D3D12 texture readback is unsupported"
+                );
             case Command::EType::BufferToBuffer:
                 Visit(static_cast<const CopyBufferCmd&>(*_cmd));
                 break;

--- a/source/runtime/render/rhi/vulkan/VulkanCommand.h
+++ b/source/runtime/render/rhi/vulkan/VulkanCommand.h
@@ -52,7 +52,8 @@ public:
         uint3          _src_offset,
         uint64         _dst_offset,
         uint3          _src_extent,
-        uint32         _mip_level
+        uint32         _mip_level,
+        uint32         _array_layer
     );
     void  CopyData(const BufferView& _dst, const void* _data, uint64 _size);
     void  CopyData(void* _dst, const BufferView& _src, uint64 _size);

--- a/source/runtime/render/rhi/vulkan/VulkanCommandList.cpp
+++ b/source/runtime/render/rhi/vulkan/VulkanCommandList.cpp
@@ -284,7 +284,8 @@ void VulkanCmdList::CopyTextureToBuffer(
     uint3          _src_offset,
     uint64         _dst_offset,
     uint3          _extent,
-    uint32         _mip_level
+    uint32         _mip_level,
+    uint32         _array_layer
 ) {
     VkImageAspectFlags aspect =
         _src->GetResourceType() == RRT_DEPTH ? VK_IMAGE_ASPECT_DEPTH_BIT : VK_IMAGE_ASPECT_COLOR_BIT;
@@ -293,7 +294,10 @@ void VulkanCmdList::CopyTextureToBuffer(
         .bufferRowLength   = 0,
         .bufferImageHeight = 0,
         .imageSubresource =
-            {.aspectMask = aspect, .mipLevel = _mip_level, .baseArrayLayer = 0, .layerCount = 1},
+            {.aspectMask = aspect,
+             .mipLevel = _mip_level,
+             .baseArrayLayer = _array_layer,
+             .layerCount = 1},
         .imageOffset =
             {static_cast<int32_t>(_src_offset.x),
              static_cast<int32_t>(_src_offset.y),

--- a/source/runtime/render/rhi/vulkan/VulkanQueue.cpp
+++ b/source/runtime/render/rhi/vulkan/VulkanQueue.cpp
@@ -1201,7 +1201,10 @@ struct VkCmdPreprocessor {
             VK_ACCESS_2_TRANSFER_READ_BIT,
             VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
             VK_PIPELINE_STAGE_2_TRANSFER_BIT,
-            _cmd->MipLevel()
+            _cmd->MipLevel(),
+            1, // mip_count
+            _cmd->ArrayLayer(),
+            1  // array_count
         );
         tracker.RecordState(vk_dst_buffer, VK_ACCESS_2_TRANSFER_WRITE_BIT, VK_PIPELINE_STAGE_2_TRANSFER_BIT);
     }

--- a/source/runtime/render/rhi/vulkan/VulkanQueue.cpp
+++ b/source/runtime/render/rhi/vulkan/VulkanQueue.cpp
@@ -1218,7 +1218,7 @@ struct VkCmdPreprocessor {
     }
 
     void Visit(const CopyBackTextureCmd* _cmd) {
-        auto tmp_buffer      = allocator.AllocateReadbackBuffer(_cmd->Data().size_bytes(), 16);
+        auto tmp_buffer      = allocator.AllocateReadbackBuffer(_cmd->ByteSize(), 16);
         _cmd->staging_buffer = tmp_buffer;
 
         auto* vk_texture = reinterpret_cast<VulkanTexture*>(_cmd->Handle());
@@ -1227,7 +1227,10 @@ struct VkCmdPreprocessor {
             VK_ACCESS_2_TRANSFER_READ_BIT,
             VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
             VK_PIPELINE_STAGE_2_TRANSFER_BIT,
-            _cmd->MipLevel()
+            _cmd->MipLevel(),
+            1,
+            _cmd->ArrayLayer(),
+            1
         );
         tracker.RegisterFlushBufferRange(
             _cmd->staging_buffer, VK_ACCESS_2_TRANSFER_WRITE_BIT, VK_PIPELINE_STAGE_2_TRANSFER_BIT
@@ -2253,9 +2256,50 @@ public:
         // LOG_INFO("copyback temp buffer handle {} offset {} size {}", (uint64)ResourceCast(tmp_buffer.GetBuffer())->GetHandle(), tmp_buffer.GetByteOffset(), tmp_buffer.GetByteSize());
 
         // tracker.RegisterFlushBuffer(VulkanBuffer *_buffer, VkAccessFlagBits2 _access, VkPipelineStageFlagBits2 _stage)
-        allocator.AddOnComplete([tmp_buffer, &cmd_list(cmd_list), src_data(_cmd.Data())]() {
-            cmd_list.CopyData(src_data, tmp_buffer, tmp_buffer.GetByteSize());
-        });
+        if (_cmd.HasOwningReadback()) {
+            const ReadbackToken readback = _cmd.OwningReadback();
+            const uint64 logical_size = _cmd.ByteSize();
+            allocator.AddOnComplete(
+                [tmp_buffer, &cmd_list(cmd_list), readback, logical_size] {
+                    struct WriterContext {
+                        VulkanCmdList* command_list{};
+                        BufferView     staging{};
+                        uint64         byte_size{};
+                    } context{&cmd_list, tmp_buffer, logical_size};
+                    (void)ReadbackBackendAccess::MaterializePayload(
+                        readback,
+                        &context,
+                        [](void* _context, std::span<byte> _destination) {
+                            auto* writer =
+                                static_cast<WriterContext*>(_context);
+                            if (writer == nullptr ||
+                                _destination.size_bytes() !=
+                                    writer->byte_size) {
+                                throw std::runtime_error(
+                                    "Vulkan buffer readback payload size mismatch"
+                                );
+                            }
+                            writer->command_list->CopyData(
+                                _destination.data(),
+                                writer->staging,
+                                writer->byte_size
+                            );
+                        }
+                    );
+                }
+            );
+        } else {
+            allocator.AddOnComplete(
+                [tmp_buffer,
+                 &cmd_list(cmd_list),
+                 destination(_cmd.Data()),
+                 logical_size = _cmd.ByteSize()] {
+                    cmd_list.CopyData(
+                        destination, tmp_buffer, logical_size
+                    );
+                }
+            );
+        }
     }
 
     void Visit(const CopyBackTextureCmd& _cmd) {
@@ -2268,18 +2312,58 @@ public:
         cmd_list.CopyTextureToBuffer(
             src_texture,
             reinterpret_cast<VulkanBuffer*>(tmp_buffer.GetBuffer()),
-            _cmd.Data().size_bytes(),
+            _cmd.ByteSize(),
             _cmd.Offset(),
             tmp_buffer.GetByteOffset(),
             _cmd.Size(),
-            _cmd.MipLevel()
+            _cmd.MipLevel(),
+            _cmd.ArrayLayer()
         );
 
-        // LOG_INFO("copyback temp buffer handle {} offset {} size {}", (uint64)ResourceCast(tmp_buffer.GetBuffer())->GetHandle(), tmp_buffer.GetByteOffset(), tmp_buffer.GetByteSize());
-
-        allocator.AddOnComplete([tmp_buffer, &cmd_list(cmd_list), src_data(_cmd.Data())]() {
-            cmd_list.CopyData(src_data.data(), tmp_buffer, tmp_buffer.GetByteSize());
-        });
+        if (_cmd.HasOwningReadback()) {
+            const ReadbackToken readback = _cmd.OwningReadback();
+            const uint64 logical_size = _cmd.ByteSize();
+            allocator.AddOnComplete(
+                [tmp_buffer, &cmd_list(cmd_list), readback, logical_size] {
+                    struct WriterContext {
+                        VulkanCmdList* command_list{};
+                        BufferView     staging{};
+                        uint64         byte_size{};
+                    } context{&cmd_list, tmp_buffer, logical_size};
+                    (void)ReadbackBackendAccess::MaterializePayload(
+                        readback,
+                        &context,
+                        [](void* _context, std::span<byte> _destination) {
+                            auto* writer =
+                                static_cast<WriterContext*>(_context);
+                            if (writer == nullptr ||
+                                _destination.size_bytes() !=
+                                    writer->byte_size) {
+                                throw std::runtime_error(
+                                    "Vulkan texture readback payload size mismatch"
+                                );
+                            }
+                            writer->command_list->CopyData(
+                                _destination.data(),
+                                writer->staging,
+                                writer->byte_size
+                            );
+                        }
+                    );
+                }
+            );
+        } else {
+            allocator.AddOnComplete(
+                [tmp_buffer,
+                 &cmd_list(cmd_list),
+                 destination(_cmd.Data()),
+                 logical_size = _cmd.ByteSize()] {
+                    cmd_list.CopyData(
+                        destination.data(), tmp_buffer, logical_size
+                    );
+                }
+            );
+        }
     }
 
     void Visit(const CopyTextureCmd& _cmd) {
@@ -2327,7 +2411,8 @@ public:
             _cmd.SrcOffset(),
             _cmd.DstOffset(),
             _cmd.Size(),
-            _cmd.MipLevel()
+            _cmd.MipLevel(),
+            _cmd.ArrayLayer()
         );
     }
 

--- a/source/runtime/render/rhi/vulkan/VulkanRHIResource.h
+++ b/source/runtime/render/rhi/vulkan/VulkanRHIResource.h
@@ -608,6 +608,9 @@ public:
     virtual ~VulkanBuffer();
     virtual void Destroy() override;
     void         SetName(const std::string_view _name) override;
+    [[nodiscard]] bool SupportsOwningReadback() const noexcept override {
+        return true;
+    }
 
     VulkanBuffer(std::string_view _name, const BufferInfo& _info, VulkanDevice& _device);
     VulkanBuffer(
@@ -709,6 +712,9 @@ public:
     }
 
     uint        GetMipByteSize(uint _mip_idx) const override;
+    [[nodiscard]] bool SupportsOwningReadback() const noexcept override {
+        return true;
+    }
     VkImageView GetView(
         uint _mip_level  = 0,
         uint _mip_cnt    = 1,

--- a/source/runtime/render/rhi/vulkan/VulkanResourceTracker.cpp
+++ b/source/runtime/render/rhi/vulkan/VulkanResourceTracker.cpp
@@ -1411,11 +1411,110 @@ void VkTracker::DispatchBarriers(VulkanCmdList& _cmdlist) {
 }
 
 void VkTracker::RestoreState() {
+    Set<VulkanTexture*> first_restore_textures;
+    for (const auto& [key, state] : texture_states) {
+        (void)state;
+        VulkanTexture* texture = key.texture;
+        if (exported_textures.find(texture) !=
+            exported_textures.end()) {
+            continue;
+        }
+        if (texture->b_present) {
+            // Presentation images keep their externally managed layout
+            // contract and must not receive UNDEFINED complement barriers.
+            texture->b_has_preferred_state = true;
+            continue;
+        }
+        if (!texture->b_has_preferred_state) {
+            first_restore_textures.insert(texture);
+        }
+    }
+
+    // b_has_preferred_state is a whole-image promise used by the next
+    // submission. When the first submit touches only one mip/layer, restore
+    // every untouched cell from UNDEFINED as well before publishing that
+    // promise. The ranges are complementary to texture_states, so they never
+    // overlap the ordinary current-layout -> preferred-layout barriers below.
+    for (VulkanTexture* texture : first_restore_textures) {
+        const VkImageLayout layout =
+            texture->GetQueuePreferredLayout(queue_type);
+        const VkImageAspectFlags aspects =
+            VulkanEnumTranslator::METoVKImageAspectFlags(
+                texture->GetAspectFlags()
+            );
+        const uint32 mip_count = texture->GetNumMips();
+        const uint32 array_count = texture->GetNumArray();
+        const auto is_tracked =
+            [&](uint32 mip, uint32 layer) {
+                for (const auto& [key, state] : texture_states) {
+                    (void)state;
+                    if (key.texture != texture) {
+                        continue;
+                    }
+                    const uint32 mip_end =
+                        static_cast<uint32>(key.mip_level) +
+                        static_cast<uint32>(key.mip_count);
+                    const uint32 layer_end =
+                        static_cast<uint32>(key.array_layer) +
+                        static_cast<uint32>(key.array_count);
+                    if (mip >= key.mip_level && mip < mip_end &&
+                        layer >= key.array_layer &&
+                        layer < layer_end) {
+                        return true;
+                    }
+                }
+                return false;
+            };
+
+        for (uint32 mip = 0; mip < mip_count; ++mip) {
+            uint32 layer = 0;
+            while (layer < array_count) {
+                if (is_tracked(mip, layer)) {
+                    ++layer;
+                    continue;
+                }
+                const uint32 first_layer = layer;
+                do {
+                    ++layer;
+                } while (layer < array_count &&
+                         !is_tracked(mip, layer));
+
+                texture_barriers.emplace_back(
+                    VkImageMemoryBarrier2{
+                        .sType =
+                            VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER_2,
+                        .pNext = nullptr,
+                        .srcStageMask = VK_PIPELINE_STAGE_2_NONE,
+                        .srcAccessMask = VK_ACCESS_2_NONE,
+                        .dstStageMask =
+                            VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT,
+                        .dstAccessMask = VK_ACCESS_2_NONE,
+                        .oldLayout = VK_IMAGE_LAYOUT_UNDEFINED,
+                        .newLayout = layout,
+                        .srcQueueFamilyIndex =
+                            VK_QUEUE_FAMILY_IGNORED,
+                        .dstQueueFamilyIndex =
+                            VK_QUEUE_FAMILY_IGNORED,
+                        .image = texture->GetHandle(),
+                        .subresourceRange =
+                            VkImageSubresourceRange{
+                                .aspectMask = aspects,
+                                .baseMipLevel = mip,
+                                .levelCount = 1,
+                                .baseArrayLayer = first_layer,
+                                .layerCount = layer - first_layer,
+                            },
+                    }
+                );
+            }
+        }
+        texture->b_has_preferred_state = true;
+    }
+
     for (auto& [key, state] : texture_states) {
         VulkanTexture* texture = key.texture;
         if (exported_textures.find(texture) != exported_textures.end())
             continue;
-        texture->b_has_preferred_state = true;
         VkImageLayout layout           = texture->GetQueuePreferredLayout(queue_type);
         if (texture->b_present)
             continue;

--- a/source/runtime/render/rhi/vulkan/VulkanSerialGolden.cpp
+++ b/source/runtime/render/rhi/vulkan/VulkanSerialGolden.cpp
@@ -529,9 +529,10 @@ struct VulkanSerialGoldenTrace::Impl {
                 const auto& command = *static_cast<const CopyBackTextureCmd*>(_command);
                 resources.push_back(RegisterTexture(reinterpret_cast<Texture*>(uintptr_t(command.Handle()))));
                 hash.Add(command.MipLevel());
+                hash.Add(command.ArrayLayer());
                 AddUint3(hash, command.Offset());
                 AddUint3(hash, command.Size());
-                hash.Add(command.Data().size());
+                hash.Add(command.ByteSize());
                 break;
             }
             case Command::EType::ShaderDispatch: {

--- a/source/test/CMakeLists.txt
+++ b/source/test/CMakeLists.txt
@@ -99,6 +99,15 @@ set_target_properties(${test_target} PROPERTIES FOLDER ${moer_test_folder})
 add_test(NAME RHIGpuCompletionContract COMMAND $<TARGET_FILE:${test_target}>)
 set_tests_properties(RHIGpuCompletionContract PROPERTIES TIMEOUT 60)
 
+set(test_target TestRHIReadback)
+add_executable(${test_target} "RHIReadbackContractTest.cpp")
+target_link_libraries(${test_target}
+    PRIVATE Moer::Render
+)
+set_target_properties(${test_target} PROPERTIES FOLDER ${moer_test_folder})
+add_test(NAME RHIReadbackContract COMMAND $<TARGET_FILE:${test_target}>)
+set_tests_properties(RHIReadbackContract PROPERTIES TIMEOUT 60)
+
 set(test_target TestExternalCpuJoin)
 add_executable(${test_target} "ExternalCpuJoinTest.cpp")
 target_link_libraries(${test_target}

--- a/source/test/RHIParallelRecordVulkanTest.cpp
+++ b/source/test/RHIParallelRecordVulkanTest.cpp
@@ -1254,6 +1254,7 @@ void ValidateArguments(int _argc, const char** _argv) {
             argument != "--present-boundary" &&
             argument != "--present-hard" &&
             argument != "--rt-export-rejection" &&
+            argument != "--readback-future" &&
             argument != "--timestamp-query" &&
             argument != "--timestamp-query-success-batch" &&
             argument != "--timestamp-query-mid-failure" &&
@@ -5507,8 +5508,6 @@ void RunRaytracingExportAcceptanceRejection() {
     std::atomic<uint32> encoder_dispatches{0};
     const std::array<uint32, 4> readback_retry_expected{41, 43, 47, 53};
     const std::array<uint32, 4> recovery_expected{59, 61, 67, 71};
-    std::array<uint32, 4>       rejected_readback{};
-    std::array<uint32, 4>       recovered_readback{};
     std::binary_semaphore blocker_entered{0};
     std::binary_semaphore release_blocker{0};
     OneShotSemaphoreRelease release_guard(release_blocker);
@@ -5691,9 +5690,9 @@ void RunRaytracingExportAcceptanceRejection() {
 
         readback_retry_submission.BeginReadback(device.CreateFence());
         CommandList rejected_readback_commands(EQueueType::Graphics);
-        rejected_readback_commands.CopyFrom(
+        ReadbackFuture rejected_readback =
+            rejected_readback_commands.Readback(
             readback_retry_source->GetView(),
-            WritableBytes(rejected_readback),
             "RaytracingExportRejectedReadback"
         );
         rejected_readback_commands.AddCallback([&] {
@@ -5720,8 +5719,12 @@ void RunRaytracingExportAcceptanceRejection() {
             ERHIExecSubmitFlags::FlushGPU
         );
         RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
+        const ReadbackResult rejected_readback_result =
+            rejected_readback.Get();
         if (readback_retry_submission.ResolveReadbackAcceptance() ||
             readback_retry_submission.ReadbackOutcome() != Outcome::Rejected ||
+            rejected_readback_result.status != ReadbackStatus::Error ||
+            !rejected_readback_result.Bytes().empty() ||
             readback_retry_submission.DispatchEncoder([&] {
                 encoder_dispatches.fetch_add(
                     1, std::memory_order_relaxed
@@ -5780,12 +5783,7 @@ void RunRaytracingExportAcceptanceRejection() {
             !readback_retry_decision.readback_attempted ||
             readback_retry_decision.readback_accepted ||
             readback_retry_decision.encoder_dispatched ||
-            encoder_dispatches.load(std::memory_order_acquire) != 0 ||
-            std::any_of(
-                rejected_readback.begin(),
-                rejected_readback.end(),
-                [](uint32 value) { return value != 0; }
-            )) {
+            encoder_dispatches.load(std::memory_order_acquire) != 0) {
             throw std::runtime_error(
                 "production readback rejection did not preserve an accepted "
                 "frame and pending export request"
@@ -5864,9 +5862,9 @@ void RunRaytracingExportAcceptanceRejection() {
 
         recovery_submission.BeginReadback(device.CreateFence());
         CommandList recovery_readback_commands(EQueueType::Graphics);
-        recovery_readback_commands.CopyFrom(
+        ReadbackFuture recovered_readback =
+            recovery_readback_commands.Readback(
             recovery_source->GetView(),
-            WritableBytes(recovered_readback),
             "RaytracingExportRecoveryReadback"
         );
         recovery_readback_commands.AddCallback([&] {
@@ -5890,7 +5888,14 @@ void RunRaytracingExportAcceptanceRejection() {
             ERHIExecSubmitFlags::FlushGPU
         );
         RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
-        if (!recovery_submission.DispatchEncoder([&] {
+        const ReadbackResult recovered_readback_result =
+            recovered_readback.Get();
+        const auto recovered_values =
+            recovered_readback_result.CopyAs<uint32>();
+        if (recovered_readback_result.status !=
+                ReadbackStatus::Ready ||
+            !recovered_values.has_value() ||
+            !recovery_submission.DispatchEncoder([&] {
                 encoder_dispatches.fetch_add(
                     1, std::memory_order_relaxed
                 );
@@ -5950,7 +5955,11 @@ void RunRaytracingExportAcceptanceRejection() {
             !recovery_decision.readback_accepted ||
             !recovery_decision.encoder_dispatched ||
             encoder_dispatches.load(std::memory_order_acquire) != 1 ||
-            recovered_readback != recovery_expected) {
+            *recovered_values !=
+                Array<uint32>(
+                    recovery_expected.begin(),
+                    recovery_expected.end()
+                )) {
             throw std::runtime_error(
                 "accepted raytracing export recovery did not consume the "
                 "request exactly once"
@@ -6013,6 +6022,119 @@ void RunRaytracingExportAcceptanceRejection() {
         "readback_retry=frame_accepted recovery_consumed=true encoder=once "
         "decision_table=verified native_rejected=0 callbacks=exactly_once "
         "keepalive=terminal replay=0"
+    );
+}
+
+void RunRaytracingAcceptedReadbackMaterializationFailure() {
+    auto& device = RenderDevice::Get();
+    using Outcome = EExportSubmissionOutcome;
+
+    const EBufferUsageFlags usage =
+        EBufferUsageFlags::TRANSFER_SRC |
+        EBufferUsageFlags::TRANSFER_DST;
+    BufferRef source = device.CreateBuffer<uint32>(
+        "rt_export_materialization_failure_source", 4, usage
+    );
+    ExportSubmissionTransaction submission(device.CreateFence());
+
+    CommandList source_commands(EQueueType::Graphics);
+    source_commands.CopyFrom(
+        OwnedBytes(std::array<uint32, 4>{109, 113, 127, 131}),
+        source->GetView(),
+        "RaytracingExportMaterializationFailureSource"
+    );
+    CmdSubmit source_submit = source_commands.Submit();
+    submission.AttachSignal(source_submit);
+    RHIExecutor::Get().Submit(
+        EQueueType::Graphics,
+        std::move(source_submit),
+        ERHIExecSubmitFlags::FlushGPU
+    );
+    if (submission.SourceOutcome() != Outcome::Accepted) {
+        throw std::runtime_error(
+            "materialization-failure source was not accepted"
+        );
+    }
+
+    submission.BeginReadback(device.CreateFence());
+    CommandList readback_commands(EQueueType::Graphics);
+    ReadbackFuture readback = readback_commands.Readback(
+        source->GetView(),
+        "RaytracingExportInjectedMaterializationFailure"
+    );
+    CmdSubmit readback_submit = readback_commands.Submit();
+    if (readback_submit.cmds.size() != 1 ||
+        readback_submit.cmds.front()->Type() !=
+            Command::EType::CopyBackBuffer) {
+        throw std::runtime_error(
+            "materialization-failure readback command was not recorded"
+        );
+    }
+    const ReadbackToken backend_token =
+        static_cast<const CopyBackBufferCmd&>(
+            *readback_submit.cmds.front()
+        ).OwningReadback();
+    if (ReadbackBackendAccess::MaterializePayload(
+            backend_token,
+            nullptr,
+            [](void*, std::span<Moer::byte>) {
+                throw std::runtime_error(
+                    "injected accepted readback materialization failure"
+                );
+            }
+        )) {
+        throw std::runtime_error(
+            "throwing readback writer unexpectedly materialized a payload"
+        );
+    }
+
+    submission.AttachReadbackSignal(readback_submit);
+    RHIExecutor::Get().Submit(
+        EQueueType::Graphics,
+        std::move(readback_submit),
+        ERHIExecSubmitFlags::FlushGPU
+    );
+    if (!submission.ResolveReadbackAcceptance()) {
+        throw std::runtime_error(
+            "materialization-failure readback was not natively accepted"
+        );
+    }
+
+    const ReadbackResult result = readback.Get();
+    if (result.status != ReadbackStatus::Error ||
+        result.error_reason.empty() || !result.Bytes().empty()) {
+        throw std::runtime_error(
+            "accepted materialization failure did not resolve Error"
+        );
+    }
+    submission.MarkAcceptedReadbackFailed();
+    if (submission.ReadbackOutcome() != Outcome::Failed ||
+        submission.DispatchEncoder([] {})) {
+        throw std::runtime_error(
+            "accepted materialization failure dispatched the encoder"
+        );
+    }
+
+    const auto decision = submission.ClassifyFrameAcceptance(
+        Outcome::Accepted, true, false
+    );
+    if (decision.frame_accepted || decision.export_consumed ||
+        !decision.retry_requested ||
+        !decision.independent_source_failed ||
+        !decision.latch_renderer ||
+        !decision.readback_attempted ||
+        decision.readback_accepted ||
+        decision.encoder_dispatched) {
+        throw std::runtime_error(
+            "accepted materialization failure did not latch frame policy"
+        );
+    }
+    RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
+
+    LOG_INFO(
+        "[TESTCASE][PASS] "
+        "name=RaytracingAcceptedReadbackMaterializationFailure "
+        "native=accepted payload=error encoder=0 latch=true"
     );
 }
 
@@ -13643,6 +13765,245 @@ void RunTimestampQuerySerialRecordFailure() {
     );
 }
 
+void RunOwningReadbackFuture() {
+    auto& device = RenderDevice::Get();
+    constexpr size_t buffer_element_count = 16;
+    constexpr size_t readback_first_element = 4;
+    constexpr size_t readback_element_count = 8;
+    constexpr uint32 texture_width = 8;
+    constexpr uint32 texture_height = 8;
+    constexpr uint32 texture_mip = 1;
+    constexpr uint32 texture_layer = 1;
+
+    const EBufferUsageFlags buffer_usage =
+        EBufferUsageFlags::TRANSFER_SRC |
+        EBufferUsageFlags::TRANSFER_DST;
+    BufferRef buffer = device.CreateBuffer<uint32>(
+        "owning_readback_buffer",
+        buffer_element_count,
+        buffer_usage
+    );
+    TextureRef texture = device.CreateTexture(
+        "owning_readback_texture",
+        Extent3D(texture_width, texture_height, 1),
+        PF_R8G8B8A8_UNORM,
+        ETextureUsageFlags::TRANSFER_SRC |
+            ETextureUsageFlags::TRANSFER_DST,
+        2,
+        2
+    );
+    TextureRef compressed_texture = device.CreateTexture(
+        "owning_readback_unsupported_bc1",
+        Extent3D(texture_width, texture_height, 1),
+        PF_BC1_RGBA_UNORM_BLOCK,
+        ETextureUsageFlags::TRANSFER_SRC |
+            ETextureUsageFlags::TRANSFER_DST
+    );
+    const TextureInfo msaa_info(
+        ETextureDimension::TEX_2D,
+        ETextureUsageFlags::TRANSFER_SRC |
+            ETextureUsageFlags::TRANSFER_DST,
+        PF_R8G8B8A8_UNORM,
+        EClearAttachment::COLOR,
+        Extent3D(texture_width, texture_height, 1),
+        1,
+        1,
+        4
+    );
+    TextureRef msaa_texture = device.CreateTexture(
+        "owning_readback_unsupported_msaa", msaa_info
+    );
+
+    TextureView offset_view = texture->GetView(0, 1).Slice(0, 1);
+    offset_view.offset.x = 1;
+    TextureView partial_view = texture->GetView(0, 1).Slice(0, 1);
+    partial_view.extent.x = texture_width / 2;
+    TextureView invalid_mip_view =
+        texture->GetView(0, 1).Slice(0, 1);
+    invalid_mip_view.mip_level = 255;
+    CommandList unsupported_commands(EQueueType::Copy);
+    const ReadbackFuture compressed_readback =
+        unsupported_commands.Readback(
+            compressed_texture->GetView(0, 1).Slice(0, 1),
+            "OwningReadbackRejectCompressed"
+        );
+    const ReadbackFuture msaa_readback =
+        unsupported_commands.Readback(
+            msaa_texture->GetView(0, 1).Slice(0, 1),
+            "OwningReadbackRejectMsaa"
+        );
+    const ReadbackFuture offset_readback =
+        unsupported_commands.Readback(
+            offset_view, "OwningReadbackRejectOffset"
+        );
+    const ReadbackFuture partial_readback =
+        unsupported_commands.Readback(
+            partial_view, "OwningReadbackRejectPartial"
+        );
+    const ReadbackFuture invalid_mip_readback =
+        unsupported_commands.Readback(
+            invalid_mip_view, "OwningReadbackRejectInvalidMip"
+        );
+    CmdSubmit unsupported_submit = unsupported_commands.Submit();
+    if (compressed_readback.Valid() || msaa_readback.Valid() ||
+        offset_readback.Valid() || partial_readback.Valid() ||
+        invalid_mip_readback.Valid() ||
+        !unsupported_submit.cmds.empty() ||
+        !unsupported_submit.gpu_completion_tokens.empty()) {
+        throw std::runtime_error(
+            "owning texture readback admitted an unsupported compressed, "
+            "multisampled, or partial subresource"
+        );
+    }
+
+    std::array<uint32, buffer_element_count> buffer_values{};
+    for (uint32 index = 0; index < buffer_values.size(); ++index) {
+        buffer_values[index] =
+            0x19B00000u + index * 37u + 5u;
+    }
+    constexpr size_t texture_mip_width =
+        texture_width >> texture_mip;
+    constexpr size_t texture_mip_height =
+        texture_height >> texture_mip;
+    std::array<uint32, texture_mip_width * texture_mip_height>
+        texture_values{};
+    for (uint32 index = 0; index < texture_values.size(); ++index) {
+        texture_values[index] =
+            0xFF000000u | (index * 0x00070311u);
+    }
+
+    TextureView texture_view =
+        texture->GetView(texture_mip, 1).Slice(texture_layer, 1);
+    TextureView texture_upload_view = texture_view;
+    texture_upload_view.extent = uint3(
+        texture_mip_width, texture_mip_height, 1
+    );
+    BufferView buffer_view = buffer->GetView(
+        readback_first_element * sizeof(uint32),
+        readback_element_count * sizeof(uint32)
+    );
+
+    CommandList commands(EQueueType::Copy);
+    commands.CopyFrom(
+        OwnedBytes(buffer_values),
+        buffer->GetView(),
+        "OwningReadbackBufferUpload"
+    );
+    commands.CopyFrom(
+        OwnedBytes(texture_values),
+        texture_upload_view,
+        "OwningReadbackTextureUpload"
+    );
+    ReadbackFuture buffer_future = commands.Readback(
+        buffer_view, "OwningReadbackBuffer"
+    );
+    ReadbackFuture texture_future = commands.Readback(
+        texture_view, "OwningReadbackTexture"
+    );
+    if (!buffer_future.Valid() || !texture_future.Valid() ||
+        buffer_future.ExpectedByteSize() !=
+            readback_element_count * sizeof(uint32) ||
+        texture_future.ExpectedByteSize() !=
+            texture_values.size() * sizeof(uint32)) {
+        throw std::runtime_error(
+            "owning readback did not preserve logical byte sizes"
+        );
+    }
+
+    std::atomic<uint32> callback_count{0};
+    std::atomic_bool callbacks_observed_siblings_terminal{true};
+    buffer_future.Then([&](const ReadbackResult& _result) {
+        if (_result.status != ReadbackStatus::Ready ||
+            texture_future.Status() == ReadbackStatus::Pending) {
+            callbacks_observed_siblings_terminal.store(
+                false, std::memory_order_release
+            );
+        }
+        callback_count.fetch_add(1, std::memory_order_relaxed);
+    });
+    texture_future.Then([&](const ReadbackResult& _result) {
+        if (_result.status != ReadbackStatus::Ready ||
+            buffer_future.Status() == ReadbackStatus::Pending) {
+            callbacks_observed_siblings_terminal.store(
+                false, std::memory_order_release
+            );
+        }
+        callback_count.fetch_add(1, std::memory_order_relaxed);
+    });
+
+    RHIExecutor::Get().Submit(
+        EQueueType::Copy,
+        commands.Submit(),
+        ERHIExecSubmitFlags::FlushGPU
+    );
+
+    const ReadbackResult buffer_result = buffer_future.Get();
+    const ReadbackResult texture_result = texture_future.Get();
+    const auto readback_buffer_values =
+        buffer_result.CopyAs<uint32>();
+    const auto readback_texture_values =
+        texture_result.CopyAs<uint32>();
+    if (buffer_result.status != ReadbackStatus::Ready ||
+        texture_result.status != ReadbackStatus::Ready ||
+        !readback_buffer_values.has_value() ||
+        !readback_texture_values.has_value()) {
+        throw std::runtime_error(
+            "owning readback Future did not resolve Ready with typed data"
+        );
+    }
+    if (!std::equal(
+            readback_buffer_values->begin(),
+            readback_buffer_values->end(),
+            buffer_values.begin() + readback_first_element
+        )) {
+        LOG_ERROR(
+            "owning buffer subrange mismatch actual_first={} "
+            "expected_first={} actual_last={} expected_last={}",
+            readback_buffer_values->front(),
+            buffer_values[readback_first_element],
+            readback_buffer_values->back(),
+            buffer_values[
+                readback_first_element +
+                readback_element_count - 1
+            ]
+        );
+        throw std::runtime_error(
+            "owning buffer subrange readback mismatch"
+        );
+    }
+    const Array<uint32> expected_texture_values(
+        texture_values.begin(), texture_values.end()
+    );
+    if (*readback_texture_values != expected_texture_values) {
+        throw std::runtime_error(
+            "owning mip/layer texture readback mismatch"
+        );
+    }
+    // Get is released by terminal publication; callback notification is a
+    // deliberately later phase. Data acquisition above therefore does not
+    // require a global Sync, while this Sync makes callback accounting
+    // deterministic for the test.
+    RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
+    if (callback_count.load(std::memory_order_acquire) != 2 ||
+        !callbacks_observed_siblings_terminal.load(
+            std::memory_order_acquire
+        )) {
+        throw std::runtime_error(
+            "owning readback callbacks did not observe terminal siblings"
+        );
+    }
+
+    LOG_INFO(
+        "[TESTCASE][PASS] name=OwningReadbackFuture "
+        "queue=Copy buffer=subrange texture=mip1,layer1 "
+        "bytes={},{} callbacks=exactly_once siblings=terminal "
+        "native_staging=completion-owned host_snapshot=future-owned "
+        "unsupported=compressed,msaa,partial",
+        buffer_result.ByteSize(),
+        texture_result.ByteSize()
+    );
+}
+
 } // namespace
 
 int main(int argc, const char** argv) {
@@ -13674,6 +14035,8 @@ int main(int argc, const char** argv) {
             present_boundary || present_hard;
         const bool rt_export_rejection =
             HasArgument(argc, argv, "--rt-export-rejection");
+        const bool readback_future_mode =
+            HasArgument(argc, argv, "--readback-future");
         const bool timestamp_query_mode =
             HasArgument(argc, argv, "--timestamp-query");
         const bool timestamp_query_success_batch_mode =
@@ -13702,6 +14065,7 @@ int main(int argc, const char** argv) {
             .rhi_bypass       = false,
             .parallel_recording =
                 parallel || pipeline_window_mode || present_mode ||
+                readback_future_mode ||
                 timestamp_query_mode ||
                 timestamp_query_success_batch_mode ||
                 timestamp_query_mid_failure_mode ||
@@ -13709,6 +14073,7 @@ int main(int argc, const char** argv) {
             .parallel_record_workers = 4,
             .parallel_record_verify =
                 parallel || pipeline_window_mode || present_mode ||
+                readback_future_mode ||
                 timestamp_query_mode ||
                 timestamp_query_success_batch_mode ||
                 timestamp_query_mid_failure_mode ||
@@ -13718,6 +14083,15 @@ int main(int argc, const char** argv) {
             .parallel_record_worker_throw_trigger = inject_worker_failure ? 1u : 0u,
         });
         render_device_initialized = true;
+
+        if (readback_future_mode) {
+            RunOwningReadbackFuture();
+            RenderDevice::Dispose();
+            render_device_initialized = false;
+            TaskSystem::ShutDown();
+            task_system_initialized = false;
+            return 0;
+        }
 
         if (timestamp_query_success_batch_mode) {
             RunTimestampQuerySuccessfulBatchPublication();
@@ -13783,6 +14157,7 @@ int main(int argc, const char** argv) {
 
         if (rt_export_rejection) {
             RunRaytracingExportAcceptanceRejection();
+            RunRaytracingAcceptedReadbackMaterializationFailure();
             RenderDevice::Dispose();
             render_device_initialized = false;
             TaskSystem::ShutDown();

--- a/source/test/RHIParallelRecordVulkanTest.cpp
+++ b/source/test/RHIParallelRecordVulkanTest.cpp
@@ -13783,8 +13783,28 @@ void RunOwningReadbackFuture() {
         buffer_element_count,
         buffer_usage
     );
+    BufferRef texture_copy_buffer = device.CreateBuffer<uint32>(
+        "owning_readback_texture_copy_buffer",
+        (texture_width >> texture_mip) *
+            (texture_height >> texture_mip),
+        buffer_usage
+    );
+    BufferRef sibling_copy_buffer = device.CreateBuffer<uint32>(
+        "owning_readback_sibling_copy_buffer",
+        texture_width * texture_height,
+        buffer_usage
+    );
     TextureRef texture = device.CreateTexture(
         "owning_readback_texture",
+        Extent3D(texture_width, texture_height, 1),
+        PF_R8G8B8A8_UNORM,
+        ETextureUsageFlags::TRANSFER_SRC |
+            ETextureUsageFlags::TRANSFER_DST,
+        2,
+        2
+    );
+    TextureRef layer_copy_texture = device.CreateTexture(
+        "owning_readback_layer_copy_texture",
         Extent3D(texture_width, texture_height, 1),
         PF_R8G8B8A8_UNORM,
         ETextureUsageFlags::TRANSFER_SRC |
@@ -13871,6 +13891,12 @@ void RunOwningReadbackFuture() {
         texture_values[index] =
             0xFF000000u | (index * 0x00070311u);
     }
+    std::array<uint32, texture_width * texture_height>
+        sibling_values{};
+    for (uint32 index = 0; index < sibling_values.size(); ++index) {
+        sibling_values[index] =
+            0x19B10000u + index * 53u + 9u;
+    }
 
     TextureView texture_view =
         texture->GetView(texture_mip, 1).Slice(texture_layer, 1);
@@ -13878,10 +13904,128 @@ void RunOwningReadbackFuture() {
     texture_upload_view.extent = uint3(
         texture_mip_width, texture_mip_height, 1
     );
+    TextureView layer_copy_view =
+        layer_copy_texture->GetView(texture_mip, 1).Slice(
+            texture_layer, 1
+        );
+    layer_copy_view.extent = uint3(
+        texture_mip_width, texture_mip_height, 1
+    );
+    TextureView sibling_view =
+        layer_copy_texture->GetView(0, 1).Slice(0, 1);
+    sibling_view.extent = uint3(
+        texture_width, texture_height, 1
+    );
     BufferView buffer_view = buffer->GetView(
         readback_first_element * sizeof(uint32),
         readback_element_count * sizeof(uint32)
     );
+
+    // Keep the nonzero-layer texture-to-buffer copy in its own submission.
+    // A later texture readback must not be able to repair a missing transition
+    // for the copied layer and accidentally make this regression pass.
+    CommandList layer_copy_commands(EQueueType::Copy);
+    layer_copy_commands.CopyFrom(
+        OwnedBytes(texture_values),
+        layer_copy_view,
+        "OwningReadbackTextureLayerUpload"
+    );
+    layer_copy_commands.CopyFrom(
+        layer_copy_view,
+        texture_copy_buffer->GetView(),
+        "OwningReadbackTextureLayerCopy"
+    );
+    RHIExecutor::Get().Submit(
+        EQueueType::Copy,
+        layer_copy_commands.Submit(),
+        ERHIExecSubmitFlags::FlushGPU
+    );
+
+    CommandList layer_copy_readback_commands(EQueueType::Copy);
+    ReadbackFuture texture_copy_future =
+        layer_copy_readback_commands.Readback(
+            texture_copy_buffer->GetView(),
+            "OwningReadbackTextureLayerCopyBuffer"
+        );
+    if (!texture_copy_future.Valid() ||
+        texture_copy_future.ExpectedByteSize() !=
+            texture_values.size() * sizeof(uint32)) {
+        throw std::runtime_error(
+            "nonzero-layer texture copy did not create a valid readback"
+        );
+    }
+    RHIExecutor::Get().Submit(
+        EQueueType::Copy,
+        layer_copy_readback_commands.Submit(),
+        ERHIExecSubmitFlags::FlushGPU
+    );
+    const ReadbackResult texture_copy_result =
+        texture_copy_future.Get();
+    const auto readback_texture_copy_values =
+        texture_copy_result.CopyAs<uint32>();
+    const Array<uint32> expected_texture_values(
+        texture_values.begin(), texture_values.end()
+    );
+    if (texture_copy_result.status != ReadbackStatus::Ready ||
+        !readback_texture_copy_values.has_value() ||
+        *readback_texture_copy_values != expected_texture_values) {
+        throw std::runtime_error(
+            "isolated nonzero-layer texture-to-buffer readback mismatch"
+        );
+    }
+
+    // The first partial restore publishes a whole-image preferred-state
+    // promise. Exercise an untouched sibling in the next submission so that
+    // the promise is valid only if the first restore initialized its
+    // complementary subresources as well.
+    CommandList sibling_commands(EQueueType::Copy);
+    sibling_commands.CopyFrom(
+        OwnedBytes(sibling_values),
+        sibling_view,
+        "OwningReadbackSiblingUpload"
+    );
+    sibling_commands.CopyFrom(
+        sibling_view,
+        sibling_copy_buffer->GetView(),
+        "OwningReadbackSiblingCopy"
+    );
+    RHIExecutor::Get().Submit(
+        EQueueType::Copy,
+        sibling_commands.Submit(),
+        ERHIExecSubmitFlags::FlushGPU
+    );
+
+    CommandList sibling_readback_commands(EQueueType::Copy);
+    ReadbackFuture sibling_future =
+        sibling_readback_commands.Readback(
+            sibling_copy_buffer->GetView(),
+            "OwningReadbackSiblingCopyBuffer"
+        );
+    if (!sibling_future.Valid() ||
+        sibling_future.ExpectedByteSize() !=
+            sibling_values.size() * sizeof(uint32)) {
+        throw std::runtime_error(
+            "sibling subresource copy did not create a valid readback"
+        );
+    }
+    RHIExecutor::Get().Submit(
+        EQueueType::Copy,
+        sibling_readback_commands.Submit(),
+        ERHIExecSubmitFlags::FlushGPU
+    );
+    const ReadbackResult sibling_result = sibling_future.Get();
+    const auto readback_sibling_values =
+        sibling_result.CopyAs<uint32>();
+    const Array<uint32> expected_sibling_values(
+        sibling_values.begin(), sibling_values.end()
+    );
+    if (sibling_result.status != ReadbackStatus::Ready ||
+        !readback_sibling_values.has_value() ||
+        *readback_sibling_values != expected_sibling_values) {
+        throw std::runtime_error(
+            "next-submit sibling subresource readback mismatch"
+        );
+    }
 
     CommandList commands(EQueueType::Copy);
     commands.CopyFrom(
@@ -13971,9 +14115,6 @@ void RunOwningReadbackFuture() {
             "owning buffer subrange readback mismatch"
         );
     }
-    const Array<uint32> expected_texture_values(
-        texture_values.begin(), texture_values.end()
-    );
     if (*readback_texture_values != expected_texture_values) {
         throw std::runtime_error(
             "owning mip/layer texture readback mismatch"
@@ -13996,11 +14137,16 @@ void RunOwningReadbackFuture() {
     LOG_INFO(
         "[TESTCASE][PASS] name=OwningReadbackFuture "
         "queue=Copy buffer=subrange texture=mip1,layer1 "
-        "bytes={},{} callbacks=exactly_once siblings=terminal "
+        "layer_copy=isolated_nonzero_layer "
+        "sibling=next_submit_mip0_layer0 "
+        "state_restore=whole_image bytes={},{},{},{} "
+        "callbacks=exactly_once siblings=terminal "
         "native_staging=completion-owned host_snapshot=future-owned "
         "unsupported=compressed,msaa,partial",
         buffer_result.ByteSize(),
-        texture_result.ByteSize()
+        texture_result.ByteSize(),
+        texture_copy_result.ByteSize(),
+        sibling_result.ByteSize()
     );
 }
 

--- a/source/test/RHIReadbackContractTest.cpp
+++ b/source/test/RHIReadbackContractTest.cpp
@@ -2,6 +2,7 @@
 #include "rhi/RHIImpl.h"
 #include "rhi/RHIReadback.h"
 #include "rhi/RHIThreadOwnership.h"
+#include "renderer/raster/CullingReadbackState.h"
 
 #include <algorithm>
 #include <array>
@@ -9,8 +10,10 @@
 #include <chrono>
 #include <cstddef>
 #include <cstdint>
+#include <cstring>
 #include <iostream>
 #include <limits>
+#include <memory>
 #include <semaphore>
 #include <stdexcept>
 #include <string>
@@ -647,6 +650,223 @@ void UnsupportedBackendFailsBeforeRecording() {
     );
 }
 
+GpuCullingCounterData TestLegacyCounters(std::uint32_t _seed) {
+    return GpuCullingCounterData{
+        .draw_count                   = _seed + 1,
+        .visible_instance_count       = _seed + 2,
+        .total_instances_before       = _seed + 3,
+        .total_instances_after        = _seed + 4,
+        .visible_draws                = _seed + 5,
+        .total_draws                  = _seed + 6,
+        .frustum_culled_instances     = _seed + 7,
+        .occlusion_culled_instances   = _seed + 8,
+        .lod_culled_instances         = _seed + 9,
+    };
+}
+
+bool LegacyCountersEqual(
+    const GpuCullingCounterData& _lhs,
+    const GpuCullingCounterData& _rhs
+) {
+    return _lhs.draw_count == _rhs.draw_count &&
+           _lhs.visible_instance_count ==
+               _rhs.visible_instance_count &&
+           _lhs.total_instances_before ==
+               _rhs.total_instances_before &&
+           _lhs.total_instances_after ==
+               _rhs.total_instances_after &&
+           _lhs.visible_draws == _rhs.visible_draws &&
+           _lhs.total_draws == _rhs.total_draws &&
+           _lhs.frustum_culled_instances ==
+               _rhs.frustum_culled_instances &&
+           _lhs.occlusion_culled_instances ==
+               _rhs.occlusion_culled_instances &&
+           _lhs.lod_culled_instances ==
+               _rhs.lod_culled_instances;
+}
+
+BufferView LegacyCounterBufferView(ReadbackTestBuffer& _buffer) {
+    return BufferView(
+        &_buffer, 0, sizeof(GpuCullingCounterData), 1
+    );
+}
+
+void LegacyFallbackPublishesReadyAfterPayload() {
+    using namespace Moer::Render::Raster::Detail;
+
+    ReadbackTestBuffer unsupported_buffer{false};
+    CommandList        list(EQueueType::Copy);
+    auto state = QueueLegacyCounterReadback(
+        list,
+        LegacyCounterBufferView(unsupported_buffer),
+        "LegacyFallbackSuccess"
+    );
+    CmdSubmit submit = list.Submit();
+
+    Expect(
+        submit.cmds.size() == 1 &&
+            submit.cmds.front()->Type() ==
+                Command::EType::CopyBackBuffer &&
+            submit.success_callbacks.size() == 1,
+        "legacy fallback did not record one raw readback and success lease"
+    );
+    const auto& command = *static_cast<const CopyBackBufferCmd*>(
+        submit.cmds.front().get()
+    );
+    Expect(
+        !command.HasOwningReadback() &&
+            command.ByteSize() ==
+                sizeof(GpuCullingCounterData) &&
+            command.Data() == &state->counters,
+        "legacy fallback did not bind its leased raw destination"
+    );
+
+    // D3D12 copies callbacks into a retirement packet before clearing the
+    // accepted CmdSubmit. Keeping the copied lease must not publish Error.
+    auto retirement_callbacks = submit.success_callbacks;
+    submit.success_callbacks.clear();
+    Expect(
+        state->GetStatus() ==
+            LegacyCounterReadbackStatus::Pending,
+        "copying the accepted success callback prematurely rejected the lease"
+    );
+
+    const GpuCullingCounterData expected =
+        TestLegacyCounters(100);
+    std::thread completion_thread(
+        [destination = command.Data(),
+         expected,
+         callbacks = std::move(retirement_callbacks)]() mutable {
+            std::memcpy(
+                destination, &expected, sizeof(expected)
+            );
+            for (auto& callback : callbacks) {
+                callback();
+            }
+            callbacks.clear();
+        }
+    );
+    completion_thread.join();
+
+    Expect(
+        state->GetStatus() ==
+                LegacyCounterReadbackStatus::Ready &&
+            LegacyCountersEqual(state->counters, expected),
+        "legacy fallback exposed Ready before payload publication or lost data"
+    );
+}
+
+void LegacyFallbackRejectionAndAbandonAreTerminal() {
+    using namespace Moer::Render::Raster::Detail;
+
+    ReadbackTestBuffer unsupported_buffer{false};
+    {
+        CommandList list(EQueueType::Copy);
+        auto state = QueueLegacyCounterReadback(
+            list,
+            LegacyCounterBufferView(unsupported_buffer),
+            "LegacyFallbackRejected"
+        );
+        const auto cleanup =
+            list.DrainOrdinaryCallbacksForRejection();
+        Expect(
+            cleanup.empty() &&
+                state->GetStatus() ==
+                    LegacyCounterReadbackStatus::Error,
+            "recording rejection left the legacy fallback Pending"
+        );
+    }
+
+    std::shared_ptr<LegacyCounterReadbackState>
+        abandoned_submit_state{};
+    {
+        CommandList list(EQueueType::Copy);
+        abandoned_submit_state = QueueLegacyCounterReadback(
+            list,
+            LegacyCounterBufferView(unsupported_buffer),
+            "LegacyFallbackAbandonedSubmit"
+        );
+        [[maybe_unused]] CmdSubmit abandoned = list.Submit();
+    }
+    Expect(
+        abandoned_submit_state->GetStatus() ==
+            LegacyCounterReadbackStatus::Error,
+        "abandoned CmdSubmit left the legacy fallback Pending"
+    );
+
+    std::shared_ptr<LegacyCounterReadbackState>
+        destroyed_list_state{};
+    {
+        CommandList list(EQueueType::Copy);
+        destroyed_list_state = QueueLegacyCounterReadback(
+            list,
+            LegacyCounterBufferView(unsupported_buffer),
+            "LegacyFallbackDestroyedList"
+        );
+    }
+    Expect(
+        destroyed_list_state->GetStatus() ==
+            LegacyCounterReadbackStatus::Error,
+        "CommandList destruction left the legacy fallback Pending"
+    );
+}
+
+void LegacyFallbackLeaseOutlivesConsumer() {
+    using namespace Moer::Render::Raster::Detail;
+
+    ReadbackTestBuffer unsupported_buffer{false};
+    CommandList        list(EQueueType::Copy);
+    auto consumer_state = QueueLegacyCounterReadback(
+        list,
+        LegacyCounterBufferView(unsupported_buffer),
+        "LegacyFallbackConsumerDestruction"
+    );
+    std::weak_ptr<LegacyCounterReadbackState> weak_state =
+        consumer_state;
+    CmdSubmit submit = list.Submit();
+    const auto& command = *static_cast<const CopyBackBufferCmd*>(
+        submit.cmds.front().get()
+    );
+    void* destination = command.Data();
+    auto retirement_callbacks =
+        std::move(submit.success_callbacks);
+    submit.success_callbacks.clear();
+    submit.cmds.clear();
+
+    // Simulate CullingPass destruction while the accepted native submission
+    // still owns the raw-destination success lease.
+    consumer_state.reset();
+    Expect(
+        !weak_state.expired(),
+        "consumer destruction released an in-flight raw destination"
+    );
+
+    const GpuCullingCounterData expected =
+        TestLegacyCounters(200);
+    std::memcpy(destination, &expected, sizeof(expected));
+    Expect(
+        retirement_callbacks.size() == 1,
+        "consumer destruction test lost its retirement callback"
+    );
+    retirement_callbacks.front()();
+    auto observed_state = weak_state.lock();
+    Expect(
+        observed_state != nullptr &&
+            observed_state->GetStatus() ==
+                LegacyCounterReadbackStatus::Ready &&
+            LegacyCountersEqual(
+                observed_state->counters, expected
+            ),
+        "in-flight lease did not preserve payload publication after consumer destruction"
+    );
+    observed_state.reset();
+    retirement_callbacks.clear();
+    Expect(
+        weak_state.expired(),
+        "retired legacy destination lease leaked after its final callback owner"
+    );
+}
+
 } // namespace
 
 int main() {
@@ -665,6 +885,9 @@ int main() {
         OwnerThreadsCannotBlockOnPendingReadback();
         CommandOwnershipAndDestructionAreTerminal();
         UnsupportedBackendFailsBeforeRecording();
+        LegacyFallbackPublishesReadyAfterPayload();
+        LegacyFallbackRejectionAndAbandonAreTerminal();
+        LegacyFallbackLeaseOutlivesConsumer();
     } catch (const std::exception& exception) {
         std::cerr
             << "RHIReadbackContract: "

--- a/source/test/RHIReadbackContractTest.cpp
+++ b/source/test/RHIReadbackContractTest.cpp
@@ -25,6 +25,24 @@ using namespace Moer::Render;
 using namespace std::chrono_literals;
 using Moer::byte;
 
+class ReadbackTestBuffer final : public Buffer {
+public:
+    explicit ReadbackTestBuffer(bool _supports_owning_readback) :
+        Buffer(BufferInfo{
+            64, 1, EBufferUsageFlags::TRANSFER_SRC
+        }),
+        supports_owning_readback_(_supports_owning_readback) {}
+
+    void SetName(const std::string_view) override {}
+
+    [[nodiscard]] bool SupportsOwningReadback() const noexcept override {
+        return supports_owning_readback_;
+    }
+
+private:
+    bool supports_owning_readback_{false};
+};
+
 void Expect(bool _condition, std::string_view _message) {
     if (!_condition) {
         throw std::runtime_error(std::string(_message));
@@ -127,8 +145,9 @@ BufferView FakeBufferView(
     std::uint64_t _byte_offset = 0,
     std::uint64_t _byte_size = 16
 ) {
+    static ReadbackTestBuffer supported_buffer{true};
     return BufferView(
-        reinterpret_cast<Buffer*>(std::uintptr_t{1}),
+        &supported_buffer,
         _byte_offset,
         _byte_size,
         1
@@ -609,6 +628,25 @@ void CommandOwnershipAndDestructionAreTerminal() {
     );
 }
 
+void UnsupportedBackendFailsBeforeRecording() {
+    ReadbackTestBuffer unsupported_buffer{false};
+    CommandList        list(EQueueType::Copy);
+    const ReadbackFuture future = list.Readback(
+        BufferView(&unsupported_buffer, 0, 16, 1),
+        "UnsupportedOwningReadback"
+    );
+    Expect(
+        !future.Valid(),
+        "unsupported backend returned a valid readback Future"
+    );
+    CmdSubmit submit = list.Submit();
+    Expect(
+        submit.cmds.empty() &&
+            submit.gpu_completion_tokens.empty(),
+        "unsupported backend recorded readback ownership"
+    );
+}
+
 } // namespace
 
 int main() {
@@ -626,6 +664,7 @@ int main() {
         CallbacksAreExactlyOnceAndExceptionContained();
         OwnerThreadsCannotBlockOnPendingReadback();
         CommandOwnershipAndDestructionAreTerminal();
+        UnsupportedBackendFailsBeforeRecording();
     } catch (const std::exception& exception) {
         std::cerr
             << "RHIReadbackContract: "

--- a/source/test/RHIReadbackContractTest.cpp
+++ b/source/test/RHIReadbackContractTest.cpp
@@ -1,0 +1,638 @@
+#include "rhi/RHICommand.h"
+#include "rhi/RHIImpl.h"
+#include "rhi/RHIReadback.h"
+#include "rhi/RHIThreadOwnership.h"
+
+#include <algorithm>
+#include <array>
+#include <atomic>
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <iostream>
+#include <limits>
+#include <semaphore>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <thread>
+#include <type_traits>
+#include <vector>
+
+namespace {
+
+using namespace Moer::Render;
+using namespace std::chrono_literals;
+using Moer::byte;
+
+void Expect(bool _condition, std::string_view _message) {
+    if (!_condition) {
+        throw std::runtime_error(std::string(_message));
+    }
+}
+
+template<typename TException, typename TCallback>
+void ExpectThrows(TCallback&& _callback, std::string_view _message) {
+    bool threw_expected = false;
+    try {
+        _callback();
+    } catch (const TException&) {
+        threw_expected = true;
+    }
+    Expect(threw_expected, _message);
+}
+
+struct ByteWriterContext {
+    std::span<const byte> source{};
+    bool                  throw_failure{false};
+};
+
+void WriteBytes(void* _context, std::span<byte> _destination) {
+    auto* context = static_cast<ByteWriterContext*>(_context);
+    if (context == nullptr || context->throw_failure) {
+        throw std::runtime_error("injected readback materialization failure");
+    }
+    if (context->source.size_bytes() != _destination.size_bytes()) {
+        throw std::runtime_error("readback test payload size mismatch");
+    }
+    std::copy(
+        context->source.begin(),
+        context->source.end(),
+        _destination.begin()
+    );
+}
+
+struct ReadbackHarness {
+    CommandList         list{EQueueType::Copy};
+    GpuCompletionFuture completion{};
+    ReadbackToken       token{};
+    ReadbackFuture      future{};
+
+    explicit ReadbackHarness(
+        std::size_t      _byte_size,
+        std::string_view _name = "ReadbackHarness"
+    ) {
+        completion = list.TrackGpuCompletion(_name);
+        token = ReadbackBackendAccess::Create(
+            1, _byte_size, _name, completion
+        );
+        future = token.GetFuture();
+    }
+
+    CmdSubmit Submit() {
+        return list.Submit();
+    }
+};
+
+void PublishCompletion(
+    CmdSubmit& _submit,
+    bool       _ready,
+    bool       _notify = true
+) {
+    const GpuCompletionPublishBatch batch =
+        GpuCompletionBackendAccess::BeginPublishBatch();
+    if (_ready) {
+        GpuCompletionBackendAccess::PublishReady(
+            _submit.gpu_completion_tokens, batch
+        );
+    } else {
+        GpuCompletionBackendAccess::PublishErrorsIfPending(
+            _submit.gpu_completion_tokens,
+            "injected readback completion failure",
+            batch
+        );
+    }
+    if (_notify) {
+        GpuCompletionBackendAccess::NotifyTerminals(
+            _submit.gpu_completion_tokens, batch
+        );
+        _submit.gpu_completion_tokens.clear();
+    } else {
+        _submit.gpu_completion_publish_batch = batch;
+    }
+}
+
+void NotifyPublishedCompletion(CmdSubmit& _submit) {
+    const GpuCompletionPublishBatch batch =
+        _submit.gpu_completion_publish_batch;
+    Expect(batch.Valid(), "readback test lost its completion batch");
+    GpuCompletionBackendAccess::NotifyTerminals(
+        _submit.gpu_completion_tokens, batch
+    );
+    _submit.gpu_completion_tokens.clear();
+    _submit.gpu_completion_publish_batch = {};
+}
+
+BufferView FakeBufferView(
+    std::uint64_t _byte_offset = 0,
+    std::uint64_t _byte_size = 16
+) {
+    return BufferView(
+        reinterpret_cast<Buffer*>(std::uintptr_t{1}),
+        _byte_offset,
+        _byte_size,
+        1
+    );
+}
+
+void InvalidFutureIsBoundedAndExplicit() {
+    ReadbackFuture invalid{};
+    Expect(!invalid.Valid(), "default readback future was valid");
+    Expect(!invalid.IsReady(), "invalid readback future reported Ready");
+    Expect(
+        invalid.Status() == ReadbackStatus::Error,
+        "invalid readback future did not fail closed"
+    );
+    invalid.Wait();
+    Expect(
+        !invalid.WaitFor(1ms),
+        "invalid readback unexpectedly satisfied WaitFor"
+    );
+    const auto try_result = invalid.TryGet();
+    Expect(
+        try_result.has_value() &&
+            try_result->status == ReadbackStatus::Error,
+        "invalid readback TryGet did not return Error"
+    );
+    Expect(
+        invalid.Get().status == ReadbackStatus::Error,
+        "invalid readback Get did not return Error"
+    );
+
+    Expect(
+        !ReadbackBackendAccess::Create(
+             0, 4, "InvalidId", GpuCompletionFuture{}
+         ).Valid(),
+        "invalid readback creation unexpectedly succeeded"
+    );
+}
+
+void ReadinessRequiresCompletionAndPayload() {
+    constexpr std::array<std::uint32_t, 2> expected{
+        0x12345678u, 0x90abcdefu
+    };
+    const auto bytes = std::as_bytes(std::span(expected));
+
+    ReadbackHarness payload_first(bytes.size_bytes(), "PayloadFirst");
+    ByteWriterContext writer{bytes};
+    Expect(
+        ReadbackBackendAccess::MaterializePayload(
+            payload_first.token, &writer, WriteBytes
+        ),
+        "payload-first materialization failed"
+    );
+    Expect(
+        payload_first.future.Status() == ReadbackStatus::Pending,
+        "payload alone made the readback Ready"
+    );
+    CmdSubmit payload_submit = payload_first.Submit();
+    PublishCompletion(payload_submit, true);
+    Expect(
+        payload_first.future.Status() == ReadbackStatus::Ready,
+        "payload-first readback did not become Ready"
+    );
+
+    ReadbackHarness completion_first(
+        bytes.size_bytes(), "CompletionFirst"
+    );
+    CmdSubmit completion_submit = completion_first.Submit();
+    PublishCompletion(completion_submit, true, false);
+    Expect(
+        completion_first.completion.Status() ==
+            GpuCompletionStatus::Ready,
+        "completion publication did not wake the logical completion"
+    );
+    Expect(
+        completion_first.future.Status() == ReadbackStatus::Pending &&
+            !completion_first.future.TryGet().has_value(),
+        "completion publication exposed an unmaterialized payload"
+    );
+    Expect(
+        ReadbackBackendAccess::MaterializePayload(
+            completion_first.token, &writer, WriteBytes
+        ),
+        "completion-first payload materialization failed"
+    );
+    Expect(
+        completion_first.future.Status() == ReadbackStatus::Ready,
+        "materialized completion-first readback stayed Pending"
+    );
+    NotifyPublishedCompletion(completion_submit);
+
+    ReadbackHarness missing_payload(
+        bytes.size_bytes(), "MissingPayload"
+    );
+    CmdSubmit missing_submit = missing_payload.Submit();
+    PublishCompletion(missing_submit, true);
+    Expect(
+        missing_payload.future.Status() == ReadbackStatus::Error,
+        "GPU Ready notification did not reject a missing payload"
+    );
+    Expect(
+        !missing_payload.future.Get().error_reason.empty(),
+        "missing payload Error lost its diagnostic"
+    );
+}
+
+void PayloadOutcomeIsOneShotAndImmutable() {
+    constexpr std::array<std::uint32_t, 3> expected{
+        7u, 11u, 13u
+    };
+    const auto bytes = std::as_bytes(std::span(expected));
+
+    ReadbackHarness harness(bytes.size_bytes(), "ImmutableSnapshot");
+    ByteWriterContext writer{bytes};
+    Expect(
+        ReadbackBackendAccess::MaterializePayload(
+            harness.token, &writer, WriteBytes
+        ),
+        "first payload publication failed"
+    );
+    Expect(
+        !ReadbackBackendAccess::MaterializePayload(
+            harness.token, &writer, WriteBytes
+        ),
+        "Ready payload admitted a second writer"
+    );
+    Expect(
+        !ReadbackBackendAccess::PublishPayloadErrorIfPending(
+            harness.token, "late payload failure"
+        ),
+        "late payload Error overwrote Ready"
+    );
+
+    CmdSubmit submit = harness.Submit();
+    PublishCompletion(submit, true);
+    ReadbackResult result = harness.future.Get();
+    Expect(
+        result.status == ReadbackStatus::Ready,
+        "immutable snapshot did not resolve Ready"
+    );
+    const auto values = result.CopyAs<std::uint32_t>();
+    Expect(
+        values.has_value() &&
+            std::equal(
+                values->begin(), values->end(), expected.begin()
+            ),
+        "typed readback snapshot changed its payload"
+    );
+    const auto last = result.ReadValue<std::uint32_t>(
+        sizeof(std::uint32_t) * 2
+    );
+    Expect(
+        last.has_value() && *last == expected.back(),
+        "typed readback lost the last valid value"
+    );
+    Expect(
+        !result.ReadValue<std::uint32_t>(
+             result.ByteSize() - sizeof(std::uint32_t) + 1
+         ).has_value() &&
+            !result.ReadValue<std::uint32_t>(
+                 std::numeric_limits<std::size_t>::max()
+             ).has_value(),
+        "typed readback accepted an out-of-bounds offset"
+    );
+
+    harness.token = {};
+    harness.future = {};
+    Expect(
+        result.CopyAs<std::uint32_t>().has_value(),
+        "result did not own its immutable byte snapshot"
+    );
+
+    ReadbackResult error_result{};
+    error_result.status = ReadbackStatus::Error;
+    Expect(
+        !error_result.CopyAs<std::uint32_t>().has_value(),
+        "Error result masqueraded as an empty typed payload"
+    );
+}
+
+void PayloadReadyErrorRaceHasOneWinner() {
+    constexpr std::array<byte, 4> expected{
+        byte{1}, byte{2}, byte{3}, byte{4}
+    };
+
+    for (int iteration = 0; iteration < 64; ++iteration) {
+        ReadbackHarness harness(expected.size(), "PayloadRace");
+        ByteWriterContext writer{std::span<const byte>(expected)};
+        std::atomic_bool start{false};
+        bool ready_won = false;
+        bool error_won = false;
+
+        std::thread ready_thread([&] {
+            while (!start.load(std::memory_order_acquire)) {
+                std::this_thread::yield();
+            }
+            ready_won = ReadbackBackendAccess::MaterializePayload(
+                harness.token, &writer, WriteBytes
+            );
+        });
+        std::thread error_thread([&] {
+            while (!start.load(std::memory_order_acquire)) {
+                std::this_thread::yield();
+            }
+            error_won =
+                ReadbackBackendAccess::PublishPayloadErrorIfPending(
+                    harness.token, "injected payload race"
+                );
+        });
+        start.store(true, std::memory_order_release);
+        ready_thread.join();
+        error_thread.join();
+
+        Expect(
+            ready_won != error_won,
+            "payload Ready/Error race did not have one winner"
+        );
+        CmdSubmit submit = harness.Submit();
+        PublishCompletion(submit, true);
+        Expect(
+            harness.future.Get().status ==
+                (ready_won ? ReadbackStatus::Ready :
+                             ReadbackStatus::Error),
+            "payload race result disagreed with its winner"
+        );
+    }
+}
+
+void MaterializationFailureIsTerminal() {
+    ReadbackHarness harness(8, "MaterializationFailure");
+    ByteWriterContext writer{
+        .source = {},
+        .throw_failure = true,
+    };
+    Expect(
+        !ReadbackBackendAccess::MaterializePayload(
+            harness.token, &writer, WriteBytes
+        ),
+        "throwing payload writer unexpectedly succeeded"
+    );
+
+    CmdSubmit submit = harness.Submit();
+    PublishCompletion(submit, true);
+    const ReadbackResult result = harness.future.Get();
+    Expect(
+        result.status == ReadbackStatus::Error &&
+            result.Bytes().empty() &&
+            !result.error_reason.empty(),
+        "payload writer failure did not resolve a bounded Error"
+    );
+}
+
+void AsyncSnapshotCaptureOutlivesHandlesAndResult() {
+    constexpr std::array<std::uint16_t, 8> expected{
+        0x3c00u, 0x4000u, 0x4200u, 0x4400u,
+        0x4500u, 0x4600u, 0x4700u, 0x4800u,
+    };
+    const auto bytes = std::as_bytes(std::span(expected));
+    ReadbackHarness harness(bytes.size_bytes(), "AsyncHdrSnapshot");
+    ByteWriterContext writer{bytes};
+    Expect(
+        ReadbackBackendAccess::MaterializePayload(
+            harness.token, &writer, WriteBytes
+        ),
+        "asynchronous snapshot payload materialization failed"
+    );
+    CmdSubmit submit = harness.Submit();
+    PublishCompletion(submit, true);
+    ReadbackResult result = harness.future.Get();
+
+    std::binary_semaphore encoder_started{0};
+    std::binary_semaphore release_encoder{0};
+    Moer::Array<byte>     observed{};
+    std::string           observed_name{};
+    std::thread encoder(
+        [payload = result.data,
+         name = result.name,
+         &encoder_started,
+         &release_encoder,
+         &observed,
+         &observed_name] {
+            encoder_started.release();
+            release_encoder.acquire();
+            observed.assign(payload->begin(), payload->end());
+            observed_name = name;
+        }
+    );
+    encoder_started.acquire();
+
+    result         = {};
+    harness.future = {};
+    harness.token  = {};
+    release_encoder.release();
+    encoder.join();
+
+    Expect(
+        observed == Moer::Array<byte>(bytes.begin(), bytes.end()) &&
+            observed_name == "AsyncHdrSnapshot",
+        "asynchronous encoder capture lost payload or metadata after "
+        "Future/Result destruction"
+    );
+}
+
+void CallbacksAreExactlyOnceAndExceptionContained() {
+    constexpr std::array<byte, 3> expected{
+        byte{4}, byte{5}, byte{6}
+    };
+    ReadbackHarness harness(expected.size(), "Callbacks");
+    ByteWriterContext writer{std::span<const byte>(expected)};
+    Expect(
+        ReadbackBackendAccess::MaterializePayload(
+            harness.token, &writer, WriteBytes
+        ),
+        "callback payload materialization failed"
+    );
+
+    constexpr int callback_thread_count = 24;
+    std::atomic<int>  callback_count{0};
+    std::atomic_bool  start{false};
+    std::vector<std::thread> threads{};
+    threads.reserve(callback_thread_count);
+    for (int index = 0; index < callback_thread_count; ++index) {
+        threads.emplace_back([&, future = harness.future] {
+            while (!start.load(std::memory_order_acquire)) {
+                std::this_thread::yield();
+            }
+            future.Then([&](const ReadbackResult& _result) {
+                Expect(
+                    _result.status == ReadbackStatus::Ready,
+                    "concurrent readback callback observed non-Ready"
+                );
+                callback_count.fetch_add(1, std::memory_order_relaxed);
+            });
+        });
+    }
+    harness.future.Then([](const ReadbackResult&) {
+        throw std::runtime_error("client readback callback failure");
+    });
+    start.store(true, std::memory_order_release);
+    for (std::thread& thread : threads) {
+        thread.join();
+    }
+
+    CmdSubmit submit = harness.Submit();
+    PublishCompletion(submit, true);
+    Expect(
+        callback_count.load(std::memory_order_relaxed) ==
+            callback_thread_count,
+        "pre-terminal callbacks were not invoked exactly once"
+    );
+    harness.future.Then([&](const ReadbackResult& _result) {
+        Expect(
+            _result.status == ReadbackStatus::Ready,
+            "post-terminal callback observed non-Ready"
+        );
+        callback_count.fetch_add(1, std::memory_order_relaxed);
+        throw std::runtime_error("post-terminal callback failure");
+    });
+    Expect(
+        callback_count.load(std::memory_order_relaxed) ==
+            callback_thread_count + 1,
+        "post-terminal callback was not invoked exactly once"
+    );
+}
+
+void OwnerThreadsCannotBlockOnPendingReadback() {
+    ReadbackHarness harness(4, "OwnerWaitGuard");
+    CmdSubmit submit = harness.Submit();
+    {
+        RHIThreadRoleScope completion_owner(
+            ERHIThreadRole::Completion
+        );
+        ExpectThrows<std::logic_error>(
+            [&] { harness.future.Wait(); },
+            "Completion owner blocked on pending readback Wait"
+        );
+        ExpectThrows<std::logic_error>(
+            [&] { (void)harness.future.WaitFor(1ms); },
+            "Completion owner blocked on pending readback WaitFor"
+        );
+        ExpectThrows<std::logic_error>(
+            [&] { (void)harness.future.Get(); },
+            "Completion owner blocked on pending readback Get"
+        );
+    }
+
+    constexpr std::array<byte, 4> expected{
+        byte{9}, byte{8}, byte{7}, byte{6}
+    };
+    ByteWriterContext writer{std::span<const byte>(expected)};
+    Expect(
+        ReadbackBackendAccess::MaterializePayload(
+            harness.token, &writer, WriteBytes
+        ),
+        "owner guard payload materialization failed"
+    );
+    PublishCompletion(submit, true);
+    {
+        RHIThreadRoleScope submission_owner(
+            ERHIThreadRole::Submission
+        );
+        harness.future.Wait();
+        Expect(
+            harness.future.WaitFor(1ms) &&
+                harness.future.Get().status ==
+                    ReadbackStatus::Ready,
+            "owner thread could not inspect terminal readback"
+        );
+    }
+}
+
+void CommandOwnershipAndDestructionAreTerminal() {
+    ReadbackFuture list_destruction{};
+    {
+        CommandList list(EQueueType::Copy);
+        list_destruction = list.Readback(
+            FakeBufferView(8, 12), "ListReadbackDestruction"
+        );
+        Expect(
+            list_destruction.Valid(),
+            "CommandList readback returned invalid Future"
+        );
+    }
+    Expect(
+        list_destruction.Get().status == ReadbackStatus::Error,
+        "CommandList destruction left readback Pending"
+    );
+
+    ReadbackFuture submit_destruction{};
+    {
+        CommandList list(EQueueType::Copy);
+        submit_destruction = list.Readback(
+            FakeBufferView(4, 8), "SubmitReadbackDestruction"
+        );
+        [[maybe_unused]] CmdSubmit abandoned = list.Submit();
+    }
+    Expect(
+        submit_destruction.Get().status == ReadbackStatus::Error,
+        "CmdSubmit destruction left readback Pending"
+    );
+
+    CommandList list(EQueueType::Copy);
+    ReadbackFuture future = list.Readback(
+        FakeBufferView(16, 8), "CommandIntegration"
+    );
+    CmdSubmit submit = list.Submit();
+    Expect(
+        submit.cmds.size() == 1 &&
+            submit.cmds.front()->Type() ==
+                Command::EType::CopyBackBuffer &&
+            submit.gpu_completion_tokens.size() == 1,
+        "owning readback command lost its completion identity"
+    );
+    const auto& command = *static_cast<const CopyBackBufferCmd*>(
+        submit.cmds.front().get()
+    );
+    Expect(
+        command.HasOwningReadback() &&
+            command.ByteSize() == 8 &&
+            command.Offset() == 16,
+        "owning CopyBackBufferCmd lost its source range"
+    );
+
+    constexpr std::array<byte, 8> expected{
+        byte{0}, byte{1}, byte{2}, byte{3},
+        byte{4}, byte{5}, byte{6}, byte{7}
+    };
+    ByteWriterContext writer{std::span<const byte>(expected)};
+    Expect(
+        ReadbackBackendAccess::MaterializePayload(
+            command.OwningReadback(), &writer, WriteBytes
+        ),
+        "command-owned payload could not materialize"
+    );
+    PublishCompletion(submit, true);
+    Expect(
+        future.Get().Bytes().size_bytes() == expected.size(),
+        "command-owned readback returned the wrong byte count"
+    );
+}
+
+} // namespace
+
+int main() {
+    static_assert(std::is_copy_constructible_v<ReadbackFuture>);
+    static_assert(std::is_copy_constructible_v<ReadbackToken>);
+    static_assert(std::is_nothrow_copy_constructible_v<ReadbackToken>);
+
+    try {
+        InvalidFutureIsBoundedAndExplicit();
+        ReadinessRequiresCompletionAndPayload();
+        PayloadOutcomeIsOneShotAndImmutable();
+        PayloadReadyErrorRaceHasOneWinner();
+        MaterializationFailureIsTerminal();
+        AsyncSnapshotCaptureOutlivesHandlesAndResult();
+        CallbacksAreExactlyOnceAndExceptionContained();
+        OwnerThreadsCannotBlockOnPendingReadback();
+        CommandOwnershipAndDestructionAreTerminal();
+    } catch (const std::exception& exception) {
+        std::cerr
+            << "RHIReadbackContract: "
+            << exception.what() << '\n';
+        return 1;
+    }
+
+    std::cout << "RHIReadbackContract: all checks passed\n";
+    return 0;
+}

--- a/tools/threading/run_parallel_record_vulkan_test.py
+++ b/tools/threading/run_parallel_record_vulkan_test.py
@@ -933,10 +933,37 @@ def _require_timestamp_query_success_batch(text: str) -> None:
     )
 
 
+def _require_owning_readback_future(text: str) -> None:
+    marker = _testcase_marker("OwningReadbackFuture", text)
+    _require(
+        marker is not None and marker[0] == "PASS",
+        "readback-future: missing owning readback PASS marker",
+    )
+    _, fields = marker
+    _require(
+        fields.get("queue") == "Copy"
+        and fields.get("buffer") == "subrange"
+        and fields.get("texture") == "mip1,layer1"
+        and fields.get("layer_copy") == "isolated_nonzero_layer"
+        and fields.get("sibling") == "next_submit_mip0_layer0"
+        and fields.get("state_restore") == "whole_image"
+        and fields.get("bytes") == "32,64,64,256"
+        and fields.get("callbacks") == "exactly_once"
+        and fields.get("siblings") == "terminal"
+        and fields.get("native_staging") == "completion-owned"
+        and fields.get("host_snapshot") == "future-owned"
+        and fields.get("unsupported") == "compressed,msaa,partial",
+        "readback-future: incomplete owning readback contract",
+    )
+
+
 def validate_log(mode: str, text: str) -> None:
     _require("[TESTCASE][FAIL]" not in text, f"{mode}: test emitted a FAIL marker")
     _require("VUID-" not in text, f"{mode}: Vulkan validation VUID was emitted")
     _require("Validation Error" not in text, f"{mode}: Vulkan validation error was emitted")
+    if mode == "readback-future":
+        _require_owning_readback_future(text)
+        return
     if mode == "timestamp-query-success-batch":
         _require_timestamp_query_success_batch(text)
         return
@@ -1233,6 +1260,8 @@ def run_case(executable: Path, outdir: Path, mode: str, timeout: float) -> Path:
         arguments.append("--present-hard")
     if mode == "rt-export-rejection":
         arguments.append("--rt-export-rejection")
+    if mode == "readback-future":
+        arguments.append("--readback-future")
     if mode == "timestamp-query-success-batch":
         arguments.append("--timestamp-query-success-batch")
 
@@ -1290,6 +1319,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                 "present-boundary",
                 "present-hard",
                 "rt-export-rejection",
+                "readback-future",
                 "timestamp-query-success-batch",
             )
         ]

--- a/tools/threading/test_run_parallel_record_vulkan_test.py
+++ b/tools/threading/test_run_parallel_record_vulkan_test.py
@@ -181,6 +181,18 @@ def rt_export_rejection_line() -> str:
     )
 
 
+def readback_future_line() -> str:
+    return (
+        "[TESTCASE][PASS] name=OwningReadbackFuture "
+        "queue=Copy buffer=subrange texture=mip1,layer1 "
+        "layer_copy=isolated_nonzero_layer "
+        "sibling=next_submit_mip0_layer0 state_restore=whole_image "
+        "bytes=32,64,64,256 callbacks=exactly_once siblings=terminal "
+        "native_staging=completion-owned host_snapshot=future-owned "
+        "unsupported=compressed,msaa,partial\n"
+    )
+
+
 def timestamp_query_success_batch_line() -> str:
     return (
         "[TESTCASE][PASS] "
@@ -1001,6 +1013,11 @@ class VulkanRunnerTests(unittest.TestCase):
                 rt_export_rejection_line(),
             ),
             (
+                "readback-future",
+                "--readback-future",
+                readback_future_line(),
+            ),
+            (
                 "timestamp-query-success-batch",
                 "--timestamp-query-success-batch",
                 timestamp_query_success_batch_line(),
@@ -1033,6 +1050,37 @@ class VulkanRunnerTests(unittest.TestCase):
                             expected_argument,
                         ],
                     )
+
+    def test_readback_future_contract_is_accepted(self) -> None:
+        runner.validate_log(
+            "readback-future",
+            readback_future_line(),
+        )
+
+    def test_readback_future_requires_whole_image_restore_marker(
+        self,
+    ) -> None:
+        with self.assertRaisesRegex(
+            runner.VulkanTestError,
+            "incomplete owning readback contract",
+        ):
+            runner.validate_log(
+                "readback-future",
+                readback_future_line().replace(
+                    " state_restore=whole_image", ""
+                ),
+            )
+
+    def test_readback_future_rejects_validation_vuid(self) -> None:
+        with self.assertRaisesRegex(
+            runner.VulkanTestError,
+            "Vulkan validation VUID",
+        ):
+            runner.validate_log(
+                "readback-future",
+                "VUID-VkImageMemoryBarrier2-oldLayout-01197\n"
+                + readback_future_line(),
+            )
 
     def test_timestamp_query_success_batch_contract_is_accepted(
         self,


### PR DESCRIPTION
## Summary
- add an owning `ReadbackFuture` / immutable `ReadbackResult` contract with separate GPU-completion and payload-materialization gates
- implement precise buffer and strict full-subresource texture readback across command recording and Vulkan completion ownership; fail closed for unsupported D3D12 texture readback
- migrate raytracing export and raster culling away from production raw-span readback and export-specific global synchronization
- add CPU concurrency/lifetime contracts plus real Vulkan readback and accepted-materialization-failure coverage

## Validation
- `cmake --build build-vs --config RelWithDebInfo --target TestRHIReadback TestRHIParallelRecordVulkan MoerEditor`
- `ctest --test-dir build-vs -C RelWithDebInfo --output-on-failure` (22/22)
- RTX 5080 Vulkan `TestRHIParallelRecordVulkan --readback-future`
- RTX 5080 Vulkan `TestRHIParallelRecordVulkan --rt-export-rejection`
- Raytracing editor smoke (~28s), Vulkan + RHI thread + parallel recording
- Raster editor smoke (~20s), Vulkan + RHI thread + parallel recording
- `git diff --cached --check`

## Architecture note
This ports the useful asynchronous readback semantics from `dev_parallel_rhi`, but deliberately replaces caller-owned writable spans and extra global sync points with main's stronger Completion/cancellation/ownership model.