### PR TITLE
Phase 20: add completion-owned occlusion queries

### DIFF
--- a/source/runtime/render/rhi/RHICommand.h
+++ b/source/runtime/render/rhi/RHICommand.h
@@ -1692,11 +1692,10 @@ public:
     );
     RENDER_API void PopScopeWithTimeScope();
 
-    // Phase 17A deliberately exposes timestamp queries only. QueryKind keeps
-    // the Occlusion value reserved so the ABI can grow without conflating the
-    // two result payloads.
     RENDER_API QueryToken BeginTimestampQuery(std::string_view _name = "TimestampQuery");
     RENDER_API void EndTimestampQuery(const QueryToken& _token);
+    RENDER_API QueryToken BeginOcclusionQuery(std::string_view _name = "OcclusionQuery");
+    RENDER_API void EndOcclusionQuery(const QueryToken& _token);
 
     template<typename T, typename... Args>
     struct CountType;
@@ -1932,8 +1931,26 @@ public:
         return gpu_completion_cancellation_domain.GetView();
     }
 
-    [[nodiscard]] bool HasOpenTimestampQueries() const noexcept {
+    [[nodiscard]] bool HasOpenQueries() const noexcept {
         return !active_query_stack.empty();
+    }
+
+    [[nodiscard]] bool HasOpenTimestampQueries() const noexcept {
+        for (const QueryToken& token : active_query_stack) {
+            if (token.Kind() == QueryKind::Timestamp) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    [[nodiscard]] bool HasOpenOcclusionQueries() const noexcept {
+        for (const QueryToken& token : active_query_stack) {
+            if (token.Kind() == QueryKind::Occlusion) {
+                return true;
+            }
+        }
+        return false;
     }
 
     EQueueType GetQueueType() const noexcept {

--- a/source/runtime/render/rhi/RHICommandList.cpp
+++ b/source/runtime/render/rhi/RHICommandList.cpp
@@ -513,7 +513,7 @@ CmdSubmit CommandList::Submit() {
             DrainOrdinaryCallbacksForRejection();
         InvokeCallbacksNoexcept(cleanup_callbacks);
         throw std::logic_error(
-            "CommandList::Submit rejected an unclosed timestamp query"
+            "CommandList::Submit rejected an unclosed query"
         );
     }
     // Construct the next recording generation before transferring callbacks,
@@ -1402,6 +1402,120 @@ void CommandList::EndTimestampQuery(const QueryToken& _token) {
     auto command = MakeUnique<QueryCmd>(
         _token,
         QueryCmd::EOp::EndTimestamp,
+        queue_type,
+        _token.Name()
+    );
+    commands.emplace_back(std::move(command));
+    active_query_stack.pop_back();
+}
+
+QueryToken CommandList::BeginOcclusionQuery(std::string_view _name) {
+    if (HasOpenOcclusionQueries()) {
+        throw std::logic_error(
+            "nested occlusion queries are unsupported"
+        );
+    }
+
+    QueryToken token(
+        NextNonZeroId(g_query_token_id),
+        QueryKind::Occlusion,
+        query_owner_id,
+        _name
+    );
+    query_cancellation_domain.Register(token);
+
+    // Vulkan and D3D visibility queries execute inside a graphics command
+    // stream. Return an inspectable terminal capability result on every other
+    // queue without manufacturing an untranslatable QueryCmd.
+    if (queue_type != EQueueType::Graphics) {
+        QueryBackendAccess::ResolveErrorIfPending(
+            token,
+            "occlusion queries are unsupported on non-Graphics queues"
+        );
+        return token;
+    }
+
+    auto command = MakeUnique<QueryCmd>(
+        token,
+        QueryCmd::EOp::BeginOcclusion,
+        queue_type,
+        token.Name()
+    );
+    std::function<void()> rejection_fallback = [token] {
+        QueryBackendAccess::ResolveErrorIfPending(
+            token,
+            "occlusion query submission did not reach GPU completion"
+        );
+    };
+
+    commands.reserve(commands.size() + 1);
+    callbacks.reserve(callbacks.size() + 1);
+    query_tokens.reserve(query_tokens.size() + 1);
+    active_query_stack.reserve(active_query_stack.size() + 1);
+
+    const size_t command_count  = commands.size();
+    const size_t callback_count = callbacks.size();
+    const size_t query_count    = query_tokens.size();
+    const size_t stack_depth    = active_query_stack.size();
+    try {
+        commands.emplace_back(std::move(command));
+        callbacks.emplace_back(std::move(rejection_fallback));
+        query_tokens.emplace_back(token);
+        active_query_stack.emplace_back(token);
+    } catch (...) {
+        commands.resize(command_count);
+        callbacks.resize(callback_count);
+        query_tokens.resize(query_count);
+        active_query_stack.resize(stack_depth);
+        QueryBackendAccess::ResolveErrorIfPending(
+            token,
+            "occlusion query recording failed before Begin was published"
+        );
+        throw;
+    }
+    return token;
+}
+
+void CommandList::EndOcclusionQuery(const QueryToken& _token) {
+    if (!_token.Valid()) {
+        throw std::invalid_argument(
+            "EndOcclusionQuery requires a valid QueryToken"
+        );
+    }
+    if (_token.OwnerId() != query_owner_id) {
+        throw std::invalid_argument(
+            "EndOcclusionQuery token belongs to another CommandList"
+        );
+    }
+    if (_token.Kind() != QueryKind::Occlusion) {
+        throw std::invalid_argument(
+            "EndOcclusionQuery token has the wrong query kind"
+        );
+    }
+    if (queue_type != EQueueType::Graphics) {
+        // BeginOcclusionQuery on Compute/Copy intentionally records no Begin
+        // command and resolves the returned token as a capability Error.
+        if (_token.GetFuture().Status() == QueryStatus::Error) {
+            return;
+        }
+        throw std::logic_error(
+            "non-Graphics occlusion token has no terminal capability result"
+        );
+    }
+    if (active_query_stack.empty()) {
+        throw std::logic_error(
+            "EndOcclusionQuery has no matching open query"
+        );
+    }
+    if (active_query_stack.back().Id() != _token.Id()) {
+        throw std::logic_error(
+            "EndOcclusionQuery violates strict LIFO query pairing"
+        );
+    }
+
+    auto command = MakeUnique<QueryCmd>(
+        _token,
+        QueryCmd::EOp::EndOcclusion,
         queue_type,
         _token.Name()
     );

--- a/source/runtime/render/rhi/RHIExecutor.cpp
+++ b/source/runtime/render/rhi/RHIExecutor.cpp
@@ -1092,15 +1092,28 @@ public:
             }
         }
 
-        // D3D12 intentionally exposes timestamp Query as unsupported.
+        // D3D12 intentionally exposes GPU Query as unsupported. Preserve the
+        // requested kind in the terminal diagnostic so an occlusion caller is
+        // never reported as a timestamp capability failure.
         const QueryPublishBatch query_batch =
             QueryBackendAccess::BeginPublishBatch();
         for (RHIBackendSubmissionBatchEntry& entry : _batch.submits) {
             if (!entry.submit.query_tokens.empty()) {
-                entry.submit.PublishPendingQueryErrors(
-                    "D3D12 timestamp queries are unsupported",
-                    query_batch
-                );
+                const QueryPublishBatch effective_batch =
+                    entry.submit.query_publish_batch.Valid() ?
+                        entry.submit.query_publish_batch :
+                        query_batch;
+                entry.submit.query_publish_batch = effective_batch;
+                for (const QueryToken& token :
+                     entry.submit.query_tokens) {
+                    QueryBackendAccess::PublishErrorIfPending(
+                        token,
+                        token.Kind() == QueryKind::Occlusion ?
+                            "D3D12 occlusion queries are unsupported" :
+                            "D3D12 timestamp queries are unsupported",
+                        effective_batch
+                    );
+                }
             }
         }
 
@@ -1756,7 +1769,7 @@ void RHIExecutor::Submit(
         _command_lists.end(),
         [](const CommandList& command_list) {
             return IsSubmissionQueue(command_list.GetQueueType()) &&
-                   !command_list.HasOpenTimestampQueries();
+                   !command_list.HasOpenQueries();
         }
     );
     if (!group_valid) {
@@ -1769,7 +1782,7 @@ void RHIExecutor::Submit(
             materialized_source_indices,
             std::move(submits),
             _present,
-            "CommandList group contains an invalid queue or open timestamp query"
+            "CommandList group contains an invalid queue or open query"
         );
         return;
     }
@@ -1993,9 +2006,9 @@ void RHIExecutor::SubmitRecording(
                             "recorded source changed to an invalid queue"
                         );
                     }
-                    if (source.command_list->HasOpenTimestampQueries()) {
+                    if (source.command_list->HasOpenQueries()) {
                         throw std::logic_error(
-                            "recorded source contains an unclosed timestamp query"
+                            "recorded source contains an unclosed query"
                         );
                     }
                 }

--- a/source/runtime/render/rhi/RHIImpl.h
+++ b/source/runtime/render/rhi/RHIImpl.h
@@ -1747,14 +1747,16 @@ private:
     UnorderedMap<uint64, uint> related_geometries;
 };
 
-// Backend-neutral timestamp query boundary. The token is copied into both
-// boundaries so every translated command buffer retains the same completion
-// identity independently of CommandList/CmdSubmit movement.
+// Backend-neutral query boundary. The token is copied into both boundaries so
+// every translated command buffer retains the same completion identity
+// independently of CommandList/CmdSubmit movement.
 struct QueryCmd : public Command {
 public:
     enum class EOp : uint8_t {
         BeginTimestamp = 0,
         EndTimestamp   = 1,
+        BeginOcclusion = 2,
+        EndOcclusion   = 3,
     };
 
     QueryCmd(
@@ -1781,11 +1783,19 @@ public:
     }
 
     bool IsBegin() const noexcept {
-        return op == EOp::BeginTimestamp;
+        return op == EOp::BeginTimestamp || op == EOp::BeginOcclusion;
     }
 
     bool IsEnd() const noexcept {
-        return op == EOp::EndTimestamp;
+        return op == EOp::EndTimestamp || op == EOp::EndOcclusion;
+    }
+
+    bool IsTimestamp() const noexcept {
+        return op == EOp::BeginTimestamp || op == EOp::EndTimestamp;
+    }
+
+    bool IsOcclusion() const noexcept {
+        return op == EOp::BeginOcclusion || op == EOp::EndOcclusion;
     }
 
 private:

--- a/source/runtime/render/rhi/RHIQuery.cpp
+++ b/source/runtime/render/rhi/RHIQuery.cpp
@@ -188,6 +188,29 @@ bool QueryFuture::PublishTimestamp(
     return true;
 }
 
+bool QueryFuture::PublishOcclusion(
+    const OcclusionQueryResult& _result,
+    std::uint64_t               _notification_owner
+) const noexcept {
+    if (!state_ || _notification_owner == 0) {
+        return false;
+    }
+
+    {
+        std::scoped_lock lock(state_->mutex);
+        if (state_->result.status != QueryStatus::Pending) {
+            return false;
+        }
+        state_->result.status = QueryStatus::Ready;
+        state_->result.payload.emplace<OcclusionQueryResult>(_result);
+        state_->result.error_reason.clear();
+        state_->notification_released = false;
+        state_->notification_owner    = _notification_owner;
+    }
+    state_->cv.notify_all();
+    return true;
+}
+
 bool QueryFuture::PublishError(
     std::string_view _reason,
     std::uint64_t    _notification_owner
@@ -294,6 +317,16 @@ bool QueryToken::PublishTimestamp(
     return future_.PublishTimestamp(_result, _notification_owner);
 }
 
+bool QueryToken::PublishOcclusion(
+    const OcclusionQueryResult& _result,
+    std::uint64_t               _notification_owner
+) const noexcept {
+    if (!Valid() || kind_ != QueryKind::Occlusion) {
+        return false;
+    }
+    return future_.PublishOcclusion(_result, _notification_owner);
+}
+
 bool QueryToken::PublishErrorIfPending(
     std::string_view _reason,
     std::uint64_t    _notification_owner
@@ -331,6 +364,19 @@ bool QueryBackendAccess::ResolveTimestamp(
     return published;
 }
 
+bool QueryBackendAccess::ResolveOcclusion(
+    const QueryToken&           _token,
+    const OcclusionQueryResult& _result
+) noexcept {
+    const QueryPublishBatch batch = BeginPublishBatch();
+    const bool published =
+        _token.PublishOcclusion(_result, batch.notification_owner_);
+    if (published) {
+        _token.NotifyTerminal(batch.notification_owner_);
+    }
+    return published;
+}
+
 bool QueryBackendAccess::ResolveErrorIfPending(
     const QueryToken& _token,
     std::string_view  _reason
@@ -350,6 +396,14 @@ bool QueryBackendAccess::PublishTimestamp(
     QueryPublishBatch           _batch
 ) noexcept {
     return _token.PublishTimestamp(_result, _batch.notification_owner_);
+}
+
+bool QueryBackendAccess::PublishOcclusion(
+    const QueryToken&           _token,
+    const OcclusionQueryResult& _result,
+    QueryPublishBatch           _batch
+) noexcept {
+    return _token.PublishOcclusion(_result, _batch.notification_owner_);
 }
 
 bool QueryBackendAccess::PublishErrorIfPending(

--- a/source/runtime/render/rhi/RHIQuery.h
+++ b/source/runtime/render/rhi/RHIQuery.h
@@ -18,8 +18,6 @@ namespace Moer::Render {
 
 enum class QueryKind : std::uint8_t {
     Timestamp = 0,
-    // Reserved for the next query slice. Phase 17A intentionally exposes no
-    // occlusion-recording API until its backend contract is implemented.
     Occlusion = 1,
 };
 
@@ -98,6 +96,10 @@ private:
         const TimestampQueryResult& _result,
         std::uint64_t               _notification_owner
     ) const noexcept;
+    bool PublishOcclusion(
+        const OcclusionQueryResult& _result,
+        std::uint64_t               _notification_owner
+    ) const noexcept;
     bool PublishError(
         std::string_view _reason,
         std::uint64_t    _notification_owner
@@ -136,6 +138,10 @@ private:
     [[nodiscard]] std::uint64_t OwnerId() const noexcept;
     bool PublishTimestamp(
         const TimestampQueryResult& _result,
+        std::uint64_t               _notification_owner
+    ) const noexcept;
+    bool PublishOcclusion(
+        const OcclusionQueryResult& _result,
         std::uint64_t               _notification_owner
     ) const noexcept;
     bool PublishErrorIfPending(
@@ -189,6 +195,10 @@ public:
         const QueryToken&           _token,
         const TimestampQueryResult& _result
     ) noexcept;
+    static bool ResolveOcclusion(
+        const QueryToken&           _token,
+        const OcclusionQueryResult& _result
+    ) noexcept;
     static bool ResolveErrorIfPending(
         const QueryToken& _token,
         std::string_view  _reason
@@ -201,6 +211,11 @@ public:
     static bool PublishTimestamp(
         const QueryToken&           _token,
         const TimestampQueryResult& _result,
+        QueryPublishBatch           _batch
+    ) noexcept;
+    static bool PublishOcclusion(
+        const QueryToken&           _token,
+        const OcclusionQueryResult& _result,
         QueryPublishBatch           _batch
     ) noexcept;
     static bool PublishErrorIfPending(

--- a/source/runtime/render/rhi/RHIQuery.h
+++ b/source/runtime/render/rhi/RHIQuery.h
@@ -36,8 +36,11 @@ struct TimestampQueryResult {
 };
 
 struct OcclusionQueryResult {
-    std::uint64_t sample_count{0};
-    bool          visible{false};
+    // Exact only when the backend requested a precise native query. A
+    // visibility-only backend leaves this empty instead of exposing an
+    // implementation-defined nonzero value as a real sample count.
+    std::optional<std::uint64_t> sample_count{};
+    bool                         visible{false};
 };
 
 struct QueryResult {

--- a/source/runtime/render/rhi/RHIRecordDiagnostics.h
+++ b/source/runtime/render/rhi/RHIRecordDiagnostics.h
@@ -713,6 +713,8 @@ enum class SerialQueryEvent : uint8_t {
     End,
     Timestamp,
     Reset,
+    OcclusionBegin,
+    OcclusionEnd,
 };
 
 class SerialQuerySectionBuilder {

--- a/source/runtime/render/rhi/d3d12/D3D12Device.cpp
+++ b/source/runtime/render/rhi/d3d12/D3D12Device.cpp
@@ -1303,7 +1303,7 @@ struct D3D12CommandPreprocessVisitor {
                 Visit(static_cast<const DispatchCmd&>(*_cmd));
                 break;
             case Command::EType::Query:
-                // Timestamp queries are rejected once at Execute entry. The
+                // GPU queries are rejected once at Execute entry. The
                 // command remains an explicit no-op here so unrelated work in
                 // the same submit can still be translated.
                 break;
@@ -1472,7 +1472,7 @@ struct D3D12CommandVisitor {
                 Visit(static_cast<const DispatchCmd&>(*_cmd));
                 break;
             case Command::EType::Query:
-                // Timestamp queries are rejected once at Execute entry. The
+                // GPU queries are rejected once at Execute entry. The
                 // command remains an explicit no-op here so unrelated work in
                 // the same submit can still be recorded and submitted.
                 break;
@@ -1758,11 +1758,15 @@ WaitEvent D3D12GraphicsCommandQueue::Execute(CmdSubmit&& _submit) {
                 _submit.query_publish_batch :
                 QueryBackendAccess::BeginPublishBatch();
         _submit.query_publish_batch = query_batch;
-        QueryBackendAccess::PublishErrorsIfPending(
-            query_tokens,
-            "D3D12 timestamp queries are unsupported",
-            query_batch
-        );
+        for (const QueryToken& token : query_tokens) {
+            QueryBackendAccess::PublishErrorIfPending(
+                token,
+                token.Kind() == QueryKind::Occlusion ?
+                    "D3D12 occlusion queries are unsupported" :
+                    "D3D12 timestamp queries are unsupported",
+                query_batch
+            );
+        }
         query_completion_callbacks.emplace_back(
             [tokens = std::move(query_tokens), query_batch] {
                 QueryBackendAccess::NotifyTerminals(tokens, query_batch);

--- a/source/runtime/render/rhi/vulkan/VulkanAllocator.cpp
+++ b/source/runtime/render/rhi/vulkan/VulkanAllocator.cpp
@@ -360,6 +360,26 @@ VulkanAllocator::FindTimestampQueryRecord(uint64 _token_id) noexcept {
     return iter == timestamp_query_records.end() ? nullptr : &*iter;
 }
 
+VulkanAllocator::OcclusionQueryRecord*
+VulkanAllocator::FindOcclusionQueryRecord(uint64 _token_id) noexcept {
+    const auto iter = std::find_if(
+        occlusion_query_records.begin(),
+        occlusion_query_records.end(),
+        [_token_id](const OcclusionQueryRecord& _record) {
+            return _record.token.Id() == _token_id;
+        }
+    );
+    return iter == occlusion_query_records.end() ? nullptr : &*iter;
+}
+
+void VulkanAllocator::EnsureQueryCapacity(
+    size_t _timestamp_slot_count,
+    size_t _occlusion_pair_count
+) {
+    EnsureTimestampQueryCapacity(_timestamp_slot_count);
+    EnsureOcclusionQueryCapacity(_occlusion_pair_count);
+}
+
 void VulkanAllocator::EnsureTimestampQueryCapacity(size_t _required_count) {
     if (_required_count == 0) {
         return;
@@ -398,6 +418,40 @@ void VulkanAllocator::EnsureTimestampQueryCapacity(size_t _required_count) {
     timestamp_pool->EnsureCapacity(required_count);
 }
 
+void VulkanAllocator::EnsureOcclusionQueryCapacity(size_t _required_count) {
+    if (_required_count == 0) {
+        return;
+    }
+    if (queue_type != EQueueType::Graphics) {
+        throw std::runtime_error(
+            "Vulkan occlusion queries require a Graphics allocator"
+        );
+    }
+    if (next_occlusion_query != 0 || !occlusion_query_records.empty()) {
+        throw std::logic_error(
+            "Vulkan occlusion query pool can grow only before recording"
+        );
+    }
+    if (_required_count > std::numeric_limits<uint32>::max()) {
+        throw std::length_error(
+            "Vulkan occlusion query pair count exceeds uint32 capacity"
+        );
+    }
+
+    const uint32 required_count = static_cast<uint32>(_required_count);
+    occlusion_query_records.reserve(_required_count);
+    if (!occlusion_pool) {
+        occlusion_pool.emplace(
+            *m_device,
+            VK_QUERY_TYPE_OCCLUSION,
+            required_count,
+            queue_type
+        );
+        return;
+    }
+    occlusion_pool->EnsureCapacity(required_count);
+}
+
 uint32 VulkanAllocator::AllocateTimestampQuerySlot() {
     if (!timestamp_pool ||
         next_timestamp_query >= timestamp_pool->GetCount()) {
@@ -406,6 +460,47 @@ uint32 VulkanAllocator::AllocateTimestampQuerySlot() {
         );
     }
     return next_timestamp_query++;
+}
+
+uint32 VulkanAllocator::AllocateOcclusionQuerySlot() {
+    if (!occlusion_pool ||
+        next_occlusion_query >= occlusion_pool->GetCount()) {
+        throw std::runtime_error(
+            "Vulkan occlusion query pool exhausted for one recorded command buffer"
+        );
+    }
+    return next_occlusion_query++;
+}
+
+void VulkanAllocator::RecordQuery(
+    VulkanCmdList& _cmd_list,
+    const QueryCmd& _cmd
+) {
+    const QueryToken& token = _cmd.Token();
+    if (!token.Valid()) {
+        throw std::runtime_error("invalid Vulkan query token");
+    }
+
+    switch (token.Kind()) {
+        case QueryKind::Timestamp:
+            if (!_cmd.IsTimestamp()) {
+                throw std::runtime_error(
+                    "Vulkan timestamp query token has an occlusion operation"
+                );
+            }
+            RecordTimestampQuery(_cmd_list, _cmd);
+            return;
+        case QueryKind::Occlusion:
+            if (!_cmd.IsOcclusion()) {
+                throw std::runtime_error(
+                    "Vulkan occlusion query token has a timestamp operation"
+                );
+            }
+            RecordOcclusionQuery(_cmd_list, _cmd);
+            return;
+        default:
+            throw std::runtime_error("unsupported Vulkan query kind");
+    }
 }
 
 void VulkanAllocator::RecordTimestampQuery(
@@ -455,6 +550,50 @@ void VulkanAllocator::RecordTimestampQuery(
         *timestamp_pool, slot, VK_PIPELINE_STAGE_2_BOTTOM_OF_PIPE_BIT
     );
     record->end_slot = slot;
+}
+
+void VulkanAllocator::RecordOcclusionQuery(
+    VulkanCmdList& _cmd_list,
+    const QueryCmd& _cmd
+) {
+    const QueryToken& token = _cmd.Token();
+    if (!token.Valid() || token.Kind() != QueryKind::Occlusion) {
+        throw std::runtime_error("invalid Vulkan occlusion query token");
+    }
+    if (queue_type != EQueueType::Graphics ||
+        _cmd.GetQueueType() != EQueueType::Graphics) {
+        throw std::runtime_error(
+            "Vulkan occlusion queries require the Graphics queue"
+        );
+    }
+
+    constexpr uint32 invalid_slot = std::numeric_limits<uint32>::max();
+    if (_cmd.IsBegin()) {
+        if (FindOcclusionQueryRecord(token.Id()) != nullptr) {
+            throw std::runtime_error("duplicate Vulkan occlusion query begin");
+        }
+        const uint32 slot = AllocateOcclusionQuerySlot();
+        _cmd_list.ResetQueryPool(*occlusion_pool, slot, 1);
+        _cmd_list.BeginQuery(*occlusion_pool, slot, 0);
+        occlusion_query_records.emplace_back(OcclusionQueryRecord{
+            .token = token,
+            .slot  = slot,
+        });
+        return;
+    }
+
+    OcclusionQueryRecord* record =
+        FindOcclusionQueryRecord(token.Id());
+    if (record == nullptr || record->slot == invalid_slot) {
+        throw std::runtime_error(
+            "Vulkan occlusion query end has no matching begin"
+        );
+    }
+    if (record->ended) {
+        throw std::runtime_error("duplicate Vulkan occlusion query end");
+    }
+    _cmd_list.EndQuery(*occlusion_pool, record->slot);
+    record->ended = true;
 }
 
 VkResult VulkanAllocator::PrepareTimestampQueriesAfterGpuCompletion(
@@ -562,6 +701,83 @@ VkResult VulkanAllocator::PrepareTimestampQueriesAfterGpuCompletion(
     return VK_SUCCESS;
 }
 
+VkResult VulkanAllocator::PrepareOcclusionQueriesAfterGpuCompletion(
+    const VulkanOperationContext& _context
+) noexcept {
+    constexpr uint32 invalid_slot = std::numeric_limits<uint32>::max();
+
+    struct NativeOcclusionResult {
+        uint64 sample_count{0};
+        uint64 available{0};
+    };
+
+    for (OcclusionQueryRecord& record : occlusion_query_records) {
+        record.prepared_state =
+            OcclusionQueryRecord::EPreparedState::Unprepared;
+        record.prepared_result = {};
+
+        if (record.slot == invalid_slot || !record.ended) {
+            record.prepared_state =
+                OcclusionQueryRecord::EPreparedState::Incomplete;
+            continue;
+        }
+
+        NativeOcclusionResult native_result{};
+        if (!occlusion_pool) {
+            record.prepared_state =
+                OcclusionQueryRecord::EPreparedState::NativeFault;
+            return VK_ERROR_UNKNOWN;
+        }
+        const VkResult result = vkGetQueryPoolResults(
+            m_device->GetDevice(),
+            occlusion_pool->GetHandle(),
+            record.slot,
+            1,
+            sizeof(native_result),
+            &native_result,
+            sizeof(native_result),
+            VK_QUERY_RESULT_64_BIT |
+                VK_QUERY_RESULT_WITH_AVAILABILITY_BIT
+        );
+        if (result == VK_NOT_READY ||
+            (result == VK_SUCCESS && native_result.available == 0)) {
+            record.prepared_state =
+                OcclusionQueryRecord::EPreparedState::Unavailable;
+            continue;
+        }
+        if (result != VK_SUCCESS) {
+            record.prepared_state =
+                OcclusionQueryRecord::EPreparedState::NativeFault;
+            VulkanOperationContext query_context = _context;
+            query_context.operation = EVulkanFaultOperation::QueryPoolResults;
+            if (query_context.queue_type == EQueueType::Ignore) {
+                query_context.queue_type = queue_type;
+            }
+            m_device->TryLatchFirstFault(query_context, result);
+            return result;
+        }
+
+        record.prepared_result = OcclusionQueryResult{
+            .sample_count = native_result.sample_count,
+            .visible      = native_result.sample_count != 0,
+        };
+        record.prepared_state =
+            OcclusionQueryRecord::EPreparedState::Ready;
+    }
+    return VK_SUCCESS;
+}
+
+VkResult VulkanAllocator::PrepareQueriesAfterGpuCompletion(
+    const VulkanOperationContext& _context
+) noexcept {
+    const VkResult timestamp_result =
+        PrepareTimestampQueriesAfterGpuCompletion(_context);
+    if (timestamp_result != VK_SUCCESS) {
+        return timestamp_result;
+    }
+    return PrepareOcclusionQueriesAfterGpuCompletion(_context);
+}
+
 void VulkanAllocator::PublishTimestampQueriesAfterGpuCompletion(
     QueryPublishBatch _batch,
     bool              _gpu_success,
@@ -625,6 +841,77 @@ void VulkanAllocator::PublishTimestampQueriesAfterGpuCompletion(
     }
 }
 
+void VulkanAllocator::PublishOcclusionQueriesAfterGpuCompletion(
+    QueryPublishBatch _batch,
+    bool              _gpu_success,
+    std::string_view  _failure_reason
+) noexcept {
+    for (const OcclusionQueryRecord& record : occlusion_query_records) {
+        if (!_gpu_success) {
+            QueryBackendAccess::PublishErrorIfPending(
+                record.token,
+                _failure_reason.empty() ?
+                    "Vulkan submission did not reach successful GPU completion" :
+                    _failure_reason,
+                _batch
+            );
+            continue;
+        }
+
+        switch (record.prepared_state) {
+            case OcclusionQueryRecord::EPreparedState::Ready:
+                QueryBackendAccess::PublishOcclusion(
+                    record.token, record.prepared_result, _batch
+                );
+                break;
+            case OcclusionQueryRecord::EPreparedState::Incomplete:
+                QueryBackendAccess::PublishErrorIfPending(
+                    record.token,
+                    "Vulkan occlusion query pair is incomplete",
+                    _batch
+                );
+                break;
+            case OcclusionQueryRecord::EPreparedState::Unavailable:
+                QueryBackendAccess::PublishErrorIfPending(
+                    record.token,
+                    "Vulkan occlusion query result is unavailable",
+                    _batch
+                );
+                break;
+            case OcclusionQueryRecord::EPreparedState::NativeFault:
+                QueryBackendAccess::PublishErrorIfPending(
+                    record.token,
+                    "Vulkan occlusion query result readback faulted",
+                    _batch
+                );
+                break;
+            case OcclusionQueryRecord::EPreparedState::Unprepared:
+            default:
+                QueryBackendAccess::PublishErrorIfPending(
+                    record.token,
+                    "Vulkan occlusion query was not prepared for completion",
+                    _batch
+                );
+                break;
+        }
+    }
+}
+
+void VulkanAllocator::PublishQueriesAfterGpuCompletion(
+    QueryPublishBatch _batch,
+    bool              _gpu_success,
+    std::string_view  _failure_reason
+) noexcept {
+    // Publish every token in the allocator before releasing any callback.
+    // A callback may synchronously inspect another query from this packet.
+    PublishTimestampQueriesAfterGpuCompletion(
+        _batch, _gpu_success, _failure_reason
+    );
+    PublishOcclusionQueriesAfterGpuCompletion(
+        _batch, _gpu_success, _failure_reason
+    );
+}
+
 void VulkanAllocator::NotifyTimestampQueriesAfterGpuCompletion(
     QueryPublishBatch _batch
 ) noexcept {
@@ -633,15 +920,32 @@ void VulkanAllocator::NotifyTimestampQueriesAfterGpuCompletion(
     }
 }
 
+void VulkanAllocator::NotifyOcclusionQueriesAfterGpuCompletion(
+    QueryPublishBatch _batch
+) noexcept {
+    for (const OcclusionQueryRecord& record : occlusion_query_records) {
+        QueryBackendAccess::NotifyTerminal(record.token, _batch);
+    }
+}
+
+void VulkanAllocator::NotifyQueriesAfterGpuCompletion(
+    QueryPublishBatch _batch
+) noexcept {
+    NotifyTimestampQueriesAfterGpuCompletion(_batch);
+    NotifyOcclusionQueriesAfterGpuCompletion(_batch);
+}
+
 bool VulkanAllocator::CompleteSuccessCallbacks() noexcept {
     return InvokeAllocatorCompletionCallbacksNoexcept(
         on_complete, "allocator"
     );
 }
 
-void VulkanAllocator::ClearTimestampQueries() noexcept {
+void VulkanAllocator::ClearQueries() noexcept {
     timestamp_query_records.clear();
+    occlusion_query_records.clear();
     next_timestamp_query = 0;
+    next_occlusion_query = 0;
 }
 
 bool VulkanAllocator::CompleteSuccess() noexcept {
@@ -650,17 +954,17 @@ bool VulkanAllocator::CompleteSuccess() noexcept {
         .queue_type = queue_type,
     };
     const VkResult prepare_result =
-        PrepareTimestampQueriesAfterGpuCompletion(context);
+        PrepareQueriesAfterGpuCompletion(context);
     const bool callbacks_succeeded =
         prepare_result == VK_SUCCESS && CompleteSuccessCallbacks();
     const QueryPublishBatch query_batch =
         QueryBackendAccess::BeginPublishBatch();
-    PublishTimestampQueriesAfterGpuCompletion(
+    PublishQueriesAfterGpuCompletion(
         query_batch,
         prepare_result == VK_SUCCESS,
-        "Vulkan timestamp query result preparation failed"
+        "Vulkan query result preparation failed"
     );
-    NotifyTimestampQueriesAfterGpuCompletion(query_batch);
+    NotifyQueriesAfterGpuCompletion(query_batch);
     return prepare_result == VK_SUCCESS && callbacks_succeeded;
 }
 
@@ -669,7 +973,7 @@ bool VulkanAllocator::Reset() {
         return false;
     }
     ResetBufferAlloc();
-    ClearTimestampQueries();
+    ClearQueries();
     return true;
 }
 

--- a/source/runtime/render/rhi/vulkan/VulkanAllocator.cpp
+++ b/source/runtime/render/rhi/vulkan/VulkanAllocator.cpp
@@ -573,11 +573,21 @@ void VulkanAllocator::RecordOcclusionQuery(
             throw std::runtime_error("duplicate Vulkan occlusion query begin");
         }
         const uint32 slot = AllocateOcclusionQuerySlot();
+        // VulkanDevice enables the complete supported core feature set at
+        // device creation. Preserve visibility-only support on devices
+        // without occlusionQueryPrecise, but do not expose their
+        // implementation-defined nonzero value as an exact sample count.
+        const bool precise =
+            m_device->GetCoreFeatures().core_1_0.occlusionQueryPrecise ==
+            VK_TRUE;
+        const VkQueryControlFlags flags =
+            precise ? VK_QUERY_CONTROL_PRECISE_BIT : 0;
         _cmd_list.ResetQueryPool(*occlusion_pool, slot, 1);
-        _cmd_list.BeginQuery(*occlusion_pool, slot, 0);
+        _cmd_list.BeginQuery(*occlusion_pool, slot, flags);
         occlusion_query_records.emplace_back(OcclusionQueryRecord{
-            .token = token,
-            .slot  = slot,
+            .token   = token,
+            .slot    = slot,
+            .precise = precise,
         });
         return;
     }
@@ -758,7 +768,11 @@ VkResult VulkanAllocator::PrepareOcclusionQueriesAfterGpuCompletion(
         }
 
         record.prepared_result = OcclusionQueryResult{
-            .sample_count = native_result.sample_count,
+            .sample_count = record.precise ?
+                                std::optional<uint64>{
+                                    native_result.sample_count
+                                } :
+                                std::nullopt,
             .visible      = native_result.sample_count != 0,
         };
         record.prepared_state =

--- a/source/runtime/render/rhi/vulkan/VulkanAllocator.h
+++ b/source/runtime/render/rhi/vulkan/VulkanAllocator.h
@@ -152,31 +152,36 @@ public:
 
     void ResetBufferAlloc();
 
-    // Timestamp slots and their tokens are allocator-local. The allocator is
-    // the native command-buffer owner and already travels in the atomic
-    // Submission -> Completion packet, so query state never needs a global
-    // active-recording map or lock.
-    void EnsureTimestampQueryCapacity(size_t _required_count);
-    void RecordTimestampQuery(VulkanCmdList& _cmd_list, const QueryCmd& _cmd);
+    // Query slots and their tokens are allocator-local. The allocator is the
+    // native command-buffer owner and already travels in the atomic Submission
+    // -> Completion packet, so query state never needs a global active-
+    // recording map or lock. Timestamp boundaries consume one slot each;
+    // every occlusion begin/end pair shares one slot.
+    void EnsureQueryCapacity(
+        size_t _timestamp_slot_count,
+        size_t _occlusion_pair_count
+    );
+    void RecordQuery(VulkanCmdList& _cmd_list, const QueryCmd& _cmd);
     // GPU completion is a two-stage transaction. Prepare performs native
     // readback and fault classification without publishing user callbacks.
     // The queue Completion owner later terminalizes submit signals, invokes
     // allocator retirement callbacks, publishes every query in the batch, and
     // only then releases Query callbacks.
-    [[nodiscard]] VkResult PrepareTimestampQueriesAfterGpuCompletion(
+    [[nodiscard]] VkResult PrepareQueriesAfterGpuCompletion(
         const VulkanOperationContext& _context
     ) noexcept;
-    void PublishTimestampQueriesAfterGpuCompletion(
+    void PublishQueriesAfterGpuCompletion(
         QueryPublishBatch _batch,
         bool              _gpu_success,
         std::string_view  _failure_reason
     ) noexcept;
-    void NotifyTimestampQueriesAfterGpuCompletion(
+    void NotifyQueriesAfterGpuCompletion(
         QueryPublishBatch _batch
     ) noexcept;
     bool CompleteSuccessCallbacks() noexcept;
-    [[nodiscard]] bool HasTimestampQueries() const noexcept {
-        return !timestamp_query_records.empty();
+    [[nodiscard]] bool HasQueries() const noexcept {
+        return !timestamp_query_records.empty() ||
+               !occlusion_query_records.empty();
     }
 
     bool CompleteSuccess() noexcept override;
@@ -254,17 +259,64 @@ private:
         TimestampQueryResult prepared_result{};
     };
 
+    struct OcclusionQueryRecord {
+        enum class EPreparedState : uint8 {
+            Unprepared,
+            Ready,
+            Incomplete,
+            Unavailable,
+            NativeFault,
+        };
+
+        QueryToken token{};
+        uint32     slot{std::numeric_limits<uint32>::max()};
+        bool       ended{false};
+        EPreparedState       prepared_state{EPreparedState::Unprepared};
+        OcclusionQueryResult prepared_result{};
+    };
+
+    void EnsureTimestampQueryCapacity(size_t _required_count);
+    void EnsureOcclusionQueryCapacity(size_t _required_count);
+    void RecordTimestampQuery(VulkanCmdList& _cmd_list, const QueryCmd& _cmd);
+    void RecordOcclusionQuery(VulkanCmdList& _cmd_list, const QueryCmd& _cmd);
     TimestampQueryRecord* FindTimestampQueryRecord(uint64 _token_id) noexcept;
+    OcclusionQueryRecord* FindOcclusionQueryRecord(uint64 _token_id) noexcept;
     uint32                AllocateTimestampQuerySlot();
-    void                  ClearTimestampQueries() noexcept;
+    uint32                AllocateOcclusionQuerySlot();
+    [[nodiscard]] VkResult PrepareTimestampQueriesAfterGpuCompletion(
+        const VulkanOperationContext& _context
+    ) noexcept;
+    [[nodiscard]] VkResult PrepareOcclusionQueriesAfterGpuCompletion(
+        const VulkanOperationContext& _context
+    ) noexcept;
+    void PublishTimestampQueriesAfterGpuCompletion(
+        QueryPublishBatch _batch,
+        bool              _gpu_success,
+        std::string_view  _failure_reason
+    ) noexcept;
+    void PublishOcclusionQueriesAfterGpuCompletion(
+        QueryPublishBatch _batch,
+        bool              _gpu_success,
+        std::string_view  _failure_reason
+    ) noexcept;
+    void NotifyTimestampQueriesAfterGpuCompletion(
+        QueryPublishBatch _batch
+    ) noexcept;
+    void NotifyOcclusionQueriesAfterGpuCompletion(
+        QueryPublishBatch _batch
+    ) noexcept;
+    void ClearQueries() noexcept;
 
     Array<TimestampQueryRecord> timestamp_query_records;
+    Array<OcclusionQueryRecord> occlusion_query_records;
     uint32                      next_timestamp_query{0};
+    uint32                      next_occlusion_query{0};
     uint32                      timestamp_valid_bits{0};
     double                      timestamp_period_ns{0.0};
     // Most allocators never record an explicit Query command. Lazily creating
     // this pool avoids adding a native driver object to every ordinary,
     // parallel-worker, fallback, and Copy allocator.
     std::optional<VkNativeQueryPool> timestamp_pool;
+    std::optional<VkNativeQueryPool> occlusion_pool;
 };
 } // namespace Moer::Render

--- a/source/runtime/render/rhi/vulkan/VulkanAllocator.h
+++ b/source/runtime/render/rhi/vulkan/VulkanAllocator.h
@@ -271,6 +271,7 @@ private:
         QueryToken token{};
         uint32     slot{std::numeric_limits<uint32>::max()};
         bool       ended{false};
+        bool       precise{false};
         EPreparedState       prepared_state{EPreparedState::Unprepared};
         OcclusionQueryResult prepared_result{};
     };

--- a/source/runtime/render/rhi/vulkan/VulkanCommand.h
+++ b/source/runtime/render/rhi/vulkan/VulkanCommand.h
@@ -136,6 +136,12 @@ public:
         const VkImageSubresourceRange& _range
     );
     void ResetQueryPool(class VkNativeQueryPool& _query_pool, uint32 _first_query, uint32 _query_count);
+    void BeginQuery(
+        VkNativeQueryPool&  _query_pool,
+        uint32              _query,
+        VkQueryControlFlags _flags = 0
+    );
+    void EndQuery(VkNativeQueryPool& _query_pool, uint32 _query);
     void WriteTimeStamp(VkNativeQueryPool& _query_pool, uint32 _query, VkPipelineStageFlagBits2 _stage);
 
     void Dispatch(uint32_t _group_count_x, uint32_t _group_count_y, uint32_t _group_count_z);

--- a/source/runtime/render/rhi/vulkan/VulkanCommandList.cpp
+++ b/source/runtime/render/rhi/vulkan/VulkanCommandList.cpp
@@ -577,6 +577,23 @@ void VulkanCmdList::ResetQueryPool(VkNativeQueryPool& _query_pool, uint32 _first
     vkCmdResetQueryPool(command_buffer, _query_pool.GetHandle(), _first_query, _query_cnt);
 }
 
+void VulkanCmdList::BeginQuery(
+    VkNativeQueryPool&  _query_pool,
+    uint32              _query,
+    VkQueryControlFlags _flags
+) {
+    vkCmdBeginQuery(
+        command_buffer, _query_pool.GetHandle(), _query, _flags
+    );
+}
+
+void VulkanCmdList::EndQuery(
+    VkNativeQueryPool& _query_pool,
+    uint32             _query
+) {
+    vkCmdEndQuery(command_buffer, _query_pool.GetHandle(), _query);
+}
+
 void VulkanCmdList::WriteTimeStamp(
     VkNativeQueryPool&       _query_pool,
     uint32                   _query_idx,

--- a/source/runtime/render/rhi/vulkan/VulkanQueue.cpp
+++ b/source/runtime/render/rhi/vulkan/VulkanQueue.cpp
@@ -3397,7 +3397,7 @@ public:
     }
 
     void Visit(const QueryCmd& _cmd) {
-        allocator.RecordTimestampQuery(cmd_list, _cmd);
+        allocator.RecordQuery(cmd_list, _cmd);
     }
 
     void Visit(const BuildAccelerationStructuresCmd& _cmd) {
@@ -5002,14 +5002,14 @@ static QueryPublishBatch PublishUnsubmittedQueryErrors(
     if (_allocators != nullptr) {
         for (auto& allocator : _allocators->submitted) {
             if (allocator) {
-                allocator->PublishTimestampQueriesAfterGpuCompletion(
+                allocator->PublishQueriesAfterGpuCompletion(
                     query_batch, false, _reason
                 );
             }
         }
         for (auto& allocator : _allocators->abandoned) {
             if (allocator) {
-                allocator->PublishTimestampQueriesAfterGpuCompletion(
+                allocator->PublishQueriesAfterGpuCompletion(
                     query_batch, false, _reason
                 );
             }
@@ -6145,7 +6145,7 @@ bool VkCommandQueue::TryExecuteParallel(
         // A query pair must stay in one native command buffer owned by one
         // allocator. Other source packets can still translate concurrently;
         // only this source falls back to its serial recorder.
-        verify_fallback("timestamp-query-serial-island");
+        verify_fallback("query-serial-island");
         return false;
     }
 
@@ -7146,16 +7146,19 @@ void VkCommandQueue::ExecuteNow(
         return;
     }
 
-    const size_t timestamp_query_slot_count = static_cast<size_t>(
-        std::count_if(
-            _submit.cmds.begin(),
-            _submit.cmds.end(),
-            [](const UniquePtr<Command>& _command) {
-                return _command &&
-                       _command->Type() == Command::EType::Query;
-            }
-        )
-    );
+    size_t timestamp_query_slot_count = 0;
+    size_t occlusion_query_pair_count = 0;
+    for (const UniquePtr<Command>& command : _submit.cmds) {
+        if (!command || command->Type() != Command::EType::Query) {
+            continue;
+        }
+        const auto& query = *static_cast<const QueryCmd*>(command.get());
+        if (query.IsTimestamp()) {
+            ++timestamp_query_slot_count;
+        } else if (query.IsOcclusion() && query.IsBegin()) {
+            ++occlusion_query_pair_count;
+        }
+    }
     auto reject_before_native_record =
         [&](const VulkanOperationResult& _outcome,
             std::string_view             _reason,
@@ -7270,6 +7273,17 @@ void VkCommandQueue::ExecuteNow(
         );
         return;
     }
+    if (occlusion_query_pair_count != 0 &&
+        queue.GetType() != EQueueType::Graphics) {
+        reject_before_native_record(
+            VulkanOperationResult{
+                EVulkanOperationStatus::Rejected,
+                VK_ERROR_FEATURE_NOT_PRESENT
+            },
+            "occlusion queries require the Graphics queue"
+        );
+        return;
+    }
     if (timestamp_query_slot_count >
         std::numeric_limits<uint32>::max()) {
         reject_before_native_record(
@@ -7278,6 +7292,17 @@ void VkCommandQueue::ExecuteNow(
                 VK_ERROR_OUT_OF_POOL_MEMORY
             },
             "timestamp query slot count exceeds uint32 capacity"
+        );
+        return;
+    }
+    if (occlusion_query_pair_count >
+        std::numeric_limits<uint32>::max()) {
+        reject_before_native_record(
+            VulkanOperationResult{
+                EVulkanOperationStatus::Rejected,
+                VK_ERROR_OUT_OF_POOL_MEMORY
+            },
+            "occlusion query pair count exceeds uint32 capacity"
         );
         return;
     }
@@ -7376,16 +7401,18 @@ void VkCommandQueue::ExecuteNow(
     }
     try {
         // Explicit Query commands force this source onto the serial recorder.
-        // Size (and lazily create) its allocator-local pool before Begin() so
+        // Size (and lazily create) its allocator-local pools before Begin() so
         // a legal large query packet cannot fail after native recording has
-        // already produced side effects.
-        vk_allocator.EnsureTimestampQueryCapacity(
-            timestamp_query_slot_count
+        // already produced side effects. Timestamp boundaries consume one
+        // slot each; an occlusion begin/end pair shares one slot.
+        vk_allocator.EnsureQueryCapacity(
+            timestamp_query_slot_count,
+            occlusion_query_pair_count
         );
     } catch (const std::exception& error) {
         try {
             LOG_ERROR(
-                "[RHIExecutor][Vulkan] timestamp query pool preparation "
+                "[RHIExecutor][Vulkan] query pool preparation "
                 "failed: {}",
                 error.what()
             );
@@ -7401,7 +7428,7 @@ void VkCommandQueue::ExecuteNow(
                     vk_device.GetFirstFaultResult() :
                     VK_ERROR_OUT_OF_POOL_MEMORY
             },
-            "timestamp query pool preparation failed",
+            "query pool preparation failed",
             &allocator_ptr
         );
         return;
@@ -7416,7 +7443,7 @@ void VkCommandQueue::ExecuteNow(
                     vk_device.GetFirstFaultResult() :
                     VK_ERROR_OUT_OF_POOL_MEMORY
             },
-            "timestamp query pool preparation failed",
+            "query pool preparation failed",
             &allocator_ptr
         );
         return;
@@ -7702,14 +7729,21 @@ void VkCommandQueue::ExecuteNow(
                 );
                 if (cmd->Type() == Command::EType::Query) {
                     const auto& query = *static_cast<const QueryCmd*>(cmd);
+                    const bool is_occlusion = query.IsOcclusion();
                     serial_golden->RecordQueryEvent(
-                        query.IsBegin() ?
-                            SerialQueryEvent::Begin :
-                            SerialQueryEvent::End,
+                        is_occlusion ?
+                            (query.IsBegin() ?
+                                 SerialQueryEvent::OcclusionBegin :
+                                 SerialQueryEvent::OcclusionEnd) :
+                            (query.IsBegin() ?
+                                 SerialQueryEvent::Begin :
+                                 SerialQueryEvent::End),
                         query.Token().Name(),
-                        query.IsBegin() ?
-                            VK_PIPELINE_STAGE_2_TOP_OF_PIPE_BIT :
-                            VK_PIPELINE_STAGE_2_BOTTOM_OF_PIPE_BIT
+                        is_occlusion ?
+                            VK_PIPELINE_STAGE_2_NONE :
+                            (query.IsBegin() ?
+                                 VK_PIPELINE_STAGE_2_TOP_OF_PIPE_BIT :
+                                 VK_PIPELINE_STAGE_2_BOTTOM_OF_PIPE_BIT)
                     );
                 } else if (emits_profiling_queries && cmd->Type() == Command::EType::Scope) {
                     const auto& scope = *static_cast<const ScopeCmd*>(cmd);
@@ -9129,7 +9163,7 @@ void VkCommandQueue::CompletionThreadMain() {
 
                             for (auto& allocator : _batch.allocators.submitted) {
                                 const VkResult query_result =
-                                    allocator->PrepareTimestampQueriesAfterGpuCompletion(
+                                    allocator->PrepareQueriesAfterGpuCompletion(
                                         _batch.context
                                     );
                                 if (query_result != VK_SUCCESS) {
@@ -9191,20 +9225,20 @@ void VkCommandQueue::CompletionThreadMain() {
                             QueryBackendAccess::BeginPublishBatch();
                     const std::string_view query_failure_reason =
                         batch_gpu_success ?
-                            "Vulkan timestamp query did not resolve after GPU completion" :
+                            "Vulkan query did not resolve after GPU completion" :
                             "Vulkan submission did not reach successful GPU completion";
                     for (auto& allocator : _batch.allocators.submitted) {
-                        allocator->PublishTimestampQueriesAfterGpuCompletion(
+                        allocator->PublishQueriesAfterGpuCompletion(
                             query_batch,
                             batch_gpu_success,
                             query_failure_reason
                         );
                     }
                     for (auto& allocator : _batch.allocators.abandoned) {
-                        allocator->PublishTimestampQueriesAfterGpuCompletion(
+                        allocator->PublishQueriesAfterGpuCompletion(
                             query_batch,
                             false,
-                            "Vulkan timestamp query recorder was abandoned before native submission"
+                            "Vulkan query recorder was abandoned before native submission"
                         );
                     }
                     // Every CmdSubmit token must become terminal even if a
@@ -9298,12 +9332,12 @@ void VkCommandQueue::CompletionThreadMain() {
                         );
                         _batch.submit.NotifyPendingQueries(query_batch);
                         for (auto& allocator : _batch.allocators.submitted) {
-                            allocator->NotifyTimestampQueriesAfterGpuCompletion(
+                            allocator->NotifyQueriesAfterGpuCompletion(
                                 query_batch
                             );
                         }
                         for (auto& allocator : _batch.allocators.abandoned) {
-                            allocator->NotifyTimestampQueriesAfterGpuCompletion(
+                            allocator->NotifyQueriesAfterGpuCompletion(
                                 query_batch
                             );
                         }
@@ -10392,7 +10426,7 @@ void VkCopyQueue::ExecuteThread() {
 
                             for (auto& allocator : _batch.allocators.submitted) {
                                 const VkResult query_result =
-                                    allocator->PrepareTimestampQueriesAfterGpuCompletion(
+                                    allocator->PrepareQueriesAfterGpuCompletion(
                                         _batch.context
                                     );
                                 if (query_result != VK_SUCCESS) {
@@ -10452,20 +10486,20 @@ void VkCopyQueue::ExecuteThread() {
                             QueryBackendAccess::BeginPublishBatch();
                     const std::string_view query_failure_reason =
                         batch_gpu_success ?
-                            "Vulkan timestamp query did not resolve after GPU completion" :
+                            "Vulkan query did not resolve after GPU completion" :
                             "Vulkan submission did not reach successful GPU completion";
                     for (auto& allocator : _batch.allocators.submitted) {
-                        allocator->PublishTimestampQueriesAfterGpuCompletion(
+                        allocator->PublishQueriesAfterGpuCompletion(
                             query_batch,
                             batch_gpu_success,
                             query_failure_reason
                         );
                     }
                     for (auto& allocator : _batch.allocators.abandoned) {
-                        allocator->PublishTimestampQueriesAfterGpuCompletion(
+                        allocator->PublishQueriesAfterGpuCompletion(
                             query_batch,
                             false,
-                            "Vulkan Copy timestamp query recorder was abandoned before native submission"
+                            "Vulkan Copy query recorder was abandoned before native submission"
                         );
                     }
                     _batch.submit.PublishPendingQueryErrors(
@@ -10554,12 +10588,12 @@ void VkCopyQueue::ExecuteThread() {
                         );
                         _batch.submit.NotifyPendingQueries(query_batch);
                         for (auto& allocator : _batch.allocators.submitted) {
-                            allocator->NotifyTimestampQueriesAfterGpuCompletion(
+                            allocator->NotifyQueriesAfterGpuCompletion(
                                 query_batch
                             );
                         }
                         for (auto& allocator : _batch.allocators.abandoned) {
-                            allocator->NotifyTimestampQueriesAfterGpuCompletion(
+                            allocator->NotifyQueriesAfterGpuCompletion(
                                 query_batch
                             );
                         }

--- a/source/test/RHIParallelRecordVulkanTest.cpp
+++ b/source/test/RHIParallelRecordVulkanTest.cpp
@@ -1255,6 +1255,7 @@ void ValidateArguments(int _argc, const char** _argv) {
             argument != "--present-hard" &&
             argument != "--rt-export-rejection" &&
             argument != "--readback-future" &&
+            argument != "--occlusion-query" &&
             argument != "--timestamp-query" &&
             argument != "--timestamp-query-success-batch" &&
             argument != "--timestamp-query-mid-failure" &&
@@ -11615,6 +11616,295 @@ void RunTimestampQueryCompletionOwnership() {
     );
 }
 
+void RunOcclusionQueryCompletionOwnership() {
+    auto& device = RenderDevice::Get();
+    const EBufferUsageFlags usage =
+        EBufferUsageFlags::TRANSFER_SRC |
+        EBufferUsageFlags::TRANSFER_DST;
+
+    BufferRef source = device.CreateBuffer<uint32>(
+        "occlusion_query_source", kElementCount, usage
+    );
+    BufferRef destination = device.CreateBuffer<uint32>(
+        "occlusion_query_destination", kElementCount, usage
+    );
+    std::array<uint32, kElementCount> values{};
+    std::array<uint32, kElementCount> readback{};
+    for (uint32 index = 0; index < values.size(); ++index) {
+        values[index] = 0x200C0000u + index * 31u;
+    }
+
+    std::atomic<uint32> callback_count{0};
+    std::atomic<uint32> completion_callback_count{0};
+    std::atomic<uint32> ordinary_callback_count{0};
+    std::atomic<uint32> callback_errors{0};
+    std::atomic<uint32> callback_stage{0};
+    FenceRef            query_done = device.CreateFence();
+
+    CommandList commands(EQueueType::Graphics);
+    GpuCompletionFuture gpu_completion =
+        commands.TrackGpuCompletion("Phase20OcclusionCompletion");
+    commands.CopyFrom(
+        OwnedBytes(values),
+        source->GetView(),
+        "OcclusionQueryInitialize"
+    );
+
+    QueryToken query =
+        commands.BeginOcclusionQuery("Phase20Occlusion");
+    QueryFuture future = query.GetFuture();
+    gpu_completion.Then([&](const GpuCompletionResult& _result) {
+        const std::optional<QueryResult> query_result =
+            future.TryGet();
+        if (GetCurrentRHIThreadRole() !=
+                ERHIThreadRole::Completion ||
+            _result.status != GpuCompletionStatus::Ready ||
+            !query_result.has_value() ||
+            query_result->status != QueryStatus::Ready ||
+            query_done.Get()->GetValue() < 1 ||
+            query_done.Get()->IsRejected(1) ||
+            ResourceCast(query_done.Get())->IsFailed() ||
+            callback_stage.load(std::memory_order_acquire) != 0) {
+            callback_errors.fetch_add(
+                1, std::memory_order_relaxed
+            );
+        }
+        callback_stage.store(1, std::memory_order_release);
+        completion_callback_count.fetch_add(
+            1, std::memory_order_release
+        );
+    });
+    future.Then([&](const QueryResult& _result) {
+        const auto* occlusion =
+            std::get_if<OcclusionQueryResult>(&_result.payload);
+        if (GetCurrentRHIThreadRole() !=
+                ERHIThreadRole::Completion ||
+            _result.status != QueryStatus::Ready ||
+            _result.kind != QueryKind::Occlusion ||
+            occlusion == nullptr ||
+            occlusion->sample_count != 0 ||
+            occlusion->visible ||
+            gpu_completion.Status() !=
+                GpuCompletionStatus::Ready ||
+            callback_stage.load(std::memory_order_acquire) != 1) {
+            callback_errors.fetch_add(
+                1, std::memory_order_relaxed
+            );
+        }
+        callback_stage.store(2, std::memory_order_release);
+        callback_count.fetch_add(1, std::memory_order_release);
+    });
+
+    // A visibility query can legally span non-raster commands. This gives the
+    // real Vulkan path observable work while retaining the deterministic
+    // zero-sample result needed by the headless gate.
+    for (uint32 copy = 0; copy < 16; ++copy) {
+        if ((copy & 1u) == 0) {
+            commands.CopyFrom(
+                source->GetView(),
+                destination->GetView(),
+                "OcclusionQueryForwardCopy"
+            );
+        } else {
+            commands.CopyFrom(
+                destination->GetView(),
+                source->GetView(),
+                "OcclusionQueryReverseCopy"
+            );
+        }
+    }
+    commands.EndOcclusionQuery(query);
+    commands.CopyFrom(
+        destination->GetView(),
+        WritableBytes(readback),
+        "OcclusionQueryReadback"
+    );
+    commands.AddCallback([&] {
+        if (GetCurrentRHIThreadRole() !=
+                ERHIThreadRole::Completion ||
+            callback_stage.load(std::memory_order_acquire) != 2) {
+            callback_errors.fetch_add(
+                1, std::memory_order_relaxed
+            );
+        }
+        callback_stage.store(3, std::memory_order_release);
+        ordinary_callback_count.fetch_add(
+            1, std::memory_order_release
+        );
+    });
+
+    CmdSubmit submit = commands.Submit();
+    submit.Signal(query_done.Get(), 1);
+    RHIExecutor::Get().Submit(
+        EQueueType::Graphics,
+        std::move(submit),
+        ERHIExecSubmitFlags::FlushGPU
+    );
+    RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
+
+    const GpuCompletionResult completion_result =
+        gpu_completion.Get();
+    const QueryResult result = future.Get();
+    const auto* occlusion =
+        std::get_if<OcclusionQueryResult>(&result.payload);
+    if (result.status != QueryStatus::Ready ||
+        result.kind != QueryKind::Occlusion ||
+        occlusion == nullptr ||
+        occlusion->sample_count != 0 ||
+        occlusion->visible ||
+        completion_result.status !=
+            GpuCompletionStatus::Ready ||
+        callback_count.load(std::memory_order_acquire) != 1 ||
+        completion_callback_count.load(
+            std::memory_order_acquire
+        ) != 1 ||
+        ordinary_callback_count.load(
+            std::memory_order_acquire
+        ) != 1 ||
+        callback_stage.load(std::memory_order_acquire) != 3 ||
+        callback_errors.load(std::memory_order_acquire) != 0 ||
+        readback != values) {
+        throw std::runtime_error(
+            "Vulkan occlusion query violated result or Completion ordering"
+        );
+    }
+
+    constexpr size_t bulk_pair_count = 48;
+    std::array<QueryFuture, bulk_pair_count> bulk_futures{};
+    std::array<std::atomic<uint32>, bulk_pair_count>
+        bulk_callback_counts{};
+    std::atomic<uint32> bulk_callback_errors{0};
+    CommandList bulk_commands(EQueueType::Graphics);
+    for (size_t index = 0; index < bulk_pair_count; ++index) {
+        QueryToken bulk_query =
+            bulk_commands.BeginOcclusionQuery(
+                "Phase20OcclusionBulk"
+            );
+        bulk_futures[index] = bulk_query.GetFuture();
+        bulk_futures[index].Then(
+            [&, index](const QueryResult& _result) {
+                const auto* bulk_occlusion =
+                    std::get_if<OcclusionQueryResult>(
+                        &_result.payload
+                    );
+                if (GetCurrentRHIThreadRole() !=
+                        ERHIThreadRole::Completion ||
+                    _result.status != QueryStatus::Ready ||
+                    _result.kind != QueryKind::Occlusion ||
+                    bulk_occlusion == nullptr ||
+                    bulk_occlusion->sample_count != 0 ||
+                    bulk_occlusion->visible) {
+                    bulk_callback_errors.fetch_add(
+                        1, std::memory_order_relaxed
+                    );
+                }
+                bulk_callback_counts[index].fetch_add(
+                    1, std::memory_order_release
+                );
+            }
+        );
+        bulk_commands.EndOcclusionQuery(bulk_query);
+    }
+    RHIExecutor::Get().Submit(
+        EQueueType::Graphics,
+        bulk_commands.Submit(),
+        ERHIExecSubmitFlags::FlushGPU
+    );
+    RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
+    for (size_t index = 0; index < bulk_pair_count; ++index) {
+        const QueryResult bulk_result =
+            bulk_futures[index].Get();
+        const auto* bulk_occlusion =
+            std::get_if<OcclusionQueryResult>(
+                &bulk_result.payload
+            );
+        if (bulk_result.status != QueryStatus::Ready ||
+            bulk_result.kind != QueryKind::Occlusion ||
+            bulk_occlusion == nullptr ||
+            bulk_occlusion->sample_count != 0 ||
+            bulk_occlusion->visible ||
+            bulk_callback_counts[index].load(
+                std::memory_order_acquire
+            ) != 1) {
+            throw std::runtime_error(
+                "bulk Vulkan occlusion query did not resolve exactly once"
+            );
+        }
+    }
+    if (bulk_callback_errors.load(
+            std::memory_order_acquire
+        ) != 0) {
+        throw std::runtime_error(
+            "bulk Vulkan occlusion query callbacks left Completion ownership"
+        );
+    }
+
+    std::atomic<uint32> reused_callback_count{0};
+    CommandList reused_commands(EQueueType::Graphics);
+    QueryToken reused_query =
+        reused_commands.BeginOcclusionQuery(
+            "Phase20OcclusionPostGrowthReuse"
+        );
+    QueryFuture reused_future = reused_query.GetFuture();
+    reused_future.Then([&](const QueryResult& _result) {
+        const auto* reused_occlusion =
+            std::get_if<OcclusionQueryResult>(&_result.payload);
+        if (GetCurrentRHIThreadRole() !=
+                ERHIThreadRole::Completion ||
+            _result.status != QueryStatus::Ready ||
+            _result.kind != QueryKind::Occlusion ||
+            reused_occlusion == nullptr ||
+            reused_occlusion->sample_count != 0 ||
+            reused_occlusion->visible) {
+            callback_errors.fetch_add(
+                1, std::memory_order_relaxed
+            );
+        }
+        reused_callback_count.fetch_add(
+            1, std::memory_order_release
+        );
+    });
+    reused_commands.EndOcclusionQuery(reused_query);
+    RHIExecutor::Get().Submit(
+        EQueueType::Graphics,
+        reused_commands.Submit(),
+        ERHIExecSubmitFlags::FlushGPU
+    );
+    RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
+
+    const QueryResult reused_result = reused_future.Get();
+    const auto* reused_occlusion =
+        std::get_if<OcclusionQueryResult>(
+            &reused_result.payload
+        );
+    if (reused_result.status != QueryStatus::Ready ||
+        reused_result.kind != QueryKind::Occlusion ||
+        reused_occlusion == nullptr ||
+        reused_occlusion->sample_count != 0 ||
+        reused_occlusion->visible ||
+        reused_callback_count.load(
+            std::memory_order_acquire
+        ) != 1 ||
+        callback_errors.load(std::memory_order_acquire) != 0) {
+        throw std::runtime_error(
+            "Vulkan occlusion query allocator reuse failed"
+        );
+    }
+
+    LOG_INFO(
+        "[TESTCASE][PASS] name=OcclusionQueryCompletionOwnership "
+        "queue=Graphics status=Ready samples={} visible={} "
+        "availability=explicit pool=allocator_local bulk_pairs={} "
+        "growth=verified reuse=verified "
+        "recording=serial_island "
+        "order=signal->completion->query->ordinary "
+        "callbacks=exactly_once readback=verified replay=0",
+        occlusion->sample_count,
+        occlusion->visible,
+        bulk_pair_count
+    );
+}
+
 void RunTimestampQuerySuccessfulBatchPublication() {
     using namespace std::chrono_literals;
 
@@ -14183,6 +14473,8 @@ int main(int argc, const char** argv) {
             HasArgument(argc, argv, "--rt-export-rejection");
         const bool readback_future_mode =
             HasArgument(argc, argv, "--readback-future");
+        const bool occlusion_query_mode =
+            HasArgument(argc, argv, "--occlusion-query");
         const bool timestamp_query_mode =
             HasArgument(argc, argv, "--timestamp-query");
         const bool timestamp_query_success_batch_mode =
@@ -14212,6 +14504,7 @@ int main(int argc, const char** argv) {
             .parallel_recording =
                 parallel || pipeline_window_mode || present_mode ||
                 readback_future_mode ||
+                occlusion_query_mode ||
                 timestamp_query_mode ||
                 timestamp_query_success_batch_mode ||
                 timestamp_query_mid_failure_mode ||
@@ -14220,6 +14513,7 @@ int main(int argc, const char** argv) {
             .parallel_record_verify =
                 parallel || pipeline_window_mode || present_mode ||
                 readback_future_mode ||
+                occlusion_query_mode ||
                 timestamp_query_mode ||
                 timestamp_query_success_batch_mode ||
                 timestamp_query_mid_failure_mode ||
@@ -14232,6 +14526,15 @@ int main(int argc, const char** argv) {
 
         if (readback_future_mode) {
             RunOwningReadbackFuture();
+            RenderDevice::Dispose();
+            render_device_initialized = false;
+            TaskSystem::ShutDown();
+            task_system_initialized = false;
+            return 0;
+        }
+
+        if (occlusion_query_mode) {
+            RunOcclusionQueryCompletionOwnership();
             RenderDevice::Dispose();
             render_device_initialized = false;
             TaskSystem::ShutDown();

--- a/source/test/RHIParallelRecordVulkanTest.cpp
+++ b/source/test/RHIParallelRecordVulkanTest.cpp
@@ -29,6 +29,7 @@
 #include <filesystem>
 #include <iostream>
 #include <mutex>
+#include <optional>
 #include <semaphore>
 #include <span>
 #include <stdexcept>
@@ -48,6 +49,19 @@ constexpr size_t kElementCount = 64;
 constexpr uint32 kIterations   = 24;
 constexpr uint32 kHeavyCopiesPerWave = 48;
 constexpr uint32 kHeavyCopyCount = kHeavyCopiesPerWave * 2;
+
+bool IsExpectedZeroOcclusionResult(
+    const OcclusionQueryResult* _result,
+    bool                        _precise
+) {
+    if (_result == nullptr || _result->visible) {
+        return false;
+    }
+    return _precise ?
+               _result->sample_count ==
+                   std::optional<std::uint64_t>{0} :
+               !_result->sample_count.has_value();
+}
 
 class TranslateProbeCommand final : public VkCustomDispatchCmd {
 public:
@@ -11618,6 +11632,12 @@ void RunTimestampQueryCompletionOwnership() {
 
 void RunOcclusionQueryCompletionOwnership() {
     auto& device = RenderDevice::Get();
+    const auto* vulkan_device =
+        static_cast<const VulkanDevice*>(device.GetImpl());
+    const bool precise_sample_count =
+        vulkan_device != nullptr &&
+        vulkan_device->GetCoreFeatures().core_1_0.occlusionQueryPrecise ==
+            VK_TRUE;
     const EBufferUsageFlags usage =
         EBufferUsageFlags::TRANSFER_SRC |
         EBufferUsageFlags::TRANSFER_DST;
@@ -11681,9 +11701,9 @@ void RunOcclusionQueryCompletionOwnership() {
                 ERHIThreadRole::Completion ||
             _result.status != QueryStatus::Ready ||
             _result.kind != QueryKind::Occlusion ||
-            occlusion == nullptr ||
-            occlusion->sample_count != 0 ||
-            occlusion->visible ||
+            !IsExpectedZeroOcclusionResult(
+                occlusion, precise_sample_count
+            ) ||
             gpu_completion.Status() !=
                 GpuCompletionStatus::Ready ||
             callback_stage.load(std::memory_order_acquire) != 1) {
@@ -11749,9 +11769,9 @@ void RunOcclusionQueryCompletionOwnership() {
         std::get_if<OcclusionQueryResult>(&result.payload);
     if (result.status != QueryStatus::Ready ||
         result.kind != QueryKind::Occlusion ||
-        occlusion == nullptr ||
-        occlusion->sample_count != 0 ||
-        occlusion->visible ||
+        !IsExpectedZeroOcclusionResult(
+            occlusion, precise_sample_count
+        ) ||
         completion_result.status !=
             GpuCompletionStatus::Ready ||
         callback_count.load(std::memory_order_acquire) != 1 ||
@@ -11791,9 +11811,9 @@ void RunOcclusionQueryCompletionOwnership() {
                         ERHIThreadRole::Completion ||
                     _result.status != QueryStatus::Ready ||
                     _result.kind != QueryKind::Occlusion ||
-                    bulk_occlusion == nullptr ||
-                    bulk_occlusion->sample_count != 0 ||
-                    bulk_occlusion->visible) {
+                    !IsExpectedZeroOcclusionResult(
+                        bulk_occlusion, precise_sample_count
+                    )) {
                     bulk_callback_errors.fetch_add(
                         1, std::memory_order_relaxed
                     );
@@ -11820,9 +11840,9 @@ void RunOcclusionQueryCompletionOwnership() {
             );
         if (bulk_result.status != QueryStatus::Ready ||
             bulk_result.kind != QueryKind::Occlusion ||
-            bulk_occlusion == nullptr ||
-            bulk_occlusion->sample_count != 0 ||
-            bulk_occlusion->visible ||
+            !IsExpectedZeroOcclusionResult(
+                bulk_occlusion, precise_sample_count
+            ) ||
             bulk_callback_counts[index].load(
                 std::memory_order_acquire
             ) != 1) {
@@ -11853,9 +11873,9 @@ void RunOcclusionQueryCompletionOwnership() {
                 ERHIThreadRole::Completion ||
             _result.status != QueryStatus::Ready ||
             _result.kind != QueryKind::Occlusion ||
-            reused_occlusion == nullptr ||
-            reused_occlusion->sample_count != 0 ||
-            reused_occlusion->visible) {
+            !IsExpectedZeroOcclusionResult(
+                reused_occlusion, precise_sample_count
+            )) {
             callback_errors.fetch_add(
                 1, std::memory_order_relaxed
             );
@@ -11879,9 +11899,9 @@ void RunOcclusionQueryCompletionOwnership() {
         );
     if (reused_result.status != QueryStatus::Ready ||
         reused_result.kind != QueryKind::Occlusion ||
-        reused_occlusion == nullptr ||
-        reused_occlusion->sample_count != 0 ||
-        reused_occlusion->visible ||
+        !IsExpectedZeroOcclusionResult(
+            reused_occlusion, precise_sample_count
+        ) ||
         reused_callback_count.load(
             std::memory_order_acquire
         ) != 1 ||
@@ -11894,13 +11914,15 @@ void RunOcclusionQueryCompletionOwnership() {
     LOG_INFO(
         "[TESTCASE][PASS] name=OcclusionQueryCompletionOwnership "
         "queue=Graphics status=Ready samples={} visible={} "
+        "count_precise={} "
         "availability=explicit pool=allocator_local bulk_pairs={} "
         "growth=verified reuse=verified "
         "recording=serial_island "
         "order=signal->completion->query->ordinary "
         "callbacks=exactly_once readback=verified replay=0",
-        occlusion->sample_count,
+        occlusion->sample_count.value_or(0),
         occlusion->visible,
+        precise_sample_count,
         bulk_pair_count
     );
 }

--- a/source/test/RHIQueryContractTest.cpp
+++ b/source/test/RHIQueryContractTest.cpp
@@ -102,6 +102,13 @@ OcclusionQueryResult TestOcclusionResult(
     };
 }
 
+OcclusionQueryResult TestVisibilityOnlyOcclusionResult(bool _visible) {
+    return OcclusionQueryResult{
+        .sample_count = std::nullopt,
+        .visible      = _visible,
+    };
+}
+
 void OcclusionPayloadAndBatchResolutionAreTyped() {
     CommandList single_list(EQueueType::Graphics);
     QueryToken  single = single_list.BeginOcclusionQuery("SingleOcclusion");
@@ -137,6 +144,27 @@ void OcclusionPayloadAndBatchResolutionAreTyped() {
         single_payload != nullptr && single_payload->sample_count == 91 &&
             single_payload->visible,
         "occlusion result has the wrong typed payload"
+    );
+
+    CommandList visibility_list(EQueueType::Graphics);
+    QueryToken visibility =
+        visibility_list.BeginOcclusionQuery("VisibilityOnlyOcclusion");
+    visibility_list.EndOcclusionQuery(visibility);
+    CmdSubmit visibility_submit = visibility_list.Submit();
+    Expect(
+        QueryBackendAccess::ResolveOcclusion(
+            visibility, TestVisibilityOnlyOcclusionResult(true)
+        ),
+        "visibility-only occlusion resolution did not become terminal"
+    );
+    const QueryResult visibility_result = visibility.GetFuture().Get();
+    const auto* visibility_payload =
+        std::get_if<OcclusionQueryResult>(&visibility_result.payload);
+    Expect(
+        visibility_payload != nullptr &&
+            !visibility_payload->sample_count.has_value() &&
+            visibility_payload->visible,
+        "visibility-only occlusion result exposed an inexact sample count"
     );
 
     CommandList timestamp_list(EQueueType::Graphics);

--- a/source/test/RHIQueryContractTest.cpp
+++ b/source/test/RHIQueryContractTest.cpp
@@ -92,6 +92,269 @@ TimestampQueryResult TestTimestampResult() {
     };
 }
 
+OcclusionQueryResult TestOcclusionResult(
+    std::uint64_t _sample_count = 37,
+    bool          _visible      = true
+) {
+    return OcclusionQueryResult{
+        .sample_count = _sample_count,
+        .visible      = _visible,
+    };
+}
+
+void OcclusionPayloadAndBatchResolutionAreTyped() {
+    CommandList single_list(EQueueType::Graphics);
+    QueryToken  single = single_list.BeginOcclusionQuery("SingleOcclusion");
+    single_list.EndOcclusionQuery(single);
+    CmdSubmit single_submit = single_list.Submit();
+
+    Expect(
+        !QueryBackendAccess::ResolveTimestamp(single, TestTimestampResult()),
+        "timestamp resolution accepted an occlusion token"
+    );
+    Expect(
+        single.GetFuture().Status() == QueryStatus::Pending,
+        "wrong-kind resolution terminalized an occlusion query"
+    );
+    Expect(
+        QueryBackendAccess::ResolveOcclusion(
+            single, TestOcclusionResult(91, true)
+        ),
+        "occlusion resolution did not win the one-shot transition"
+    );
+    const QueryResult single_result = single.GetFuture().Get();
+    Expect(
+        single_result.status == QueryStatus::Ready &&
+            single_result.kind == QueryKind::Occlusion &&
+            single_result.query_id == single.Id() &&
+            single_result.name == "SingleOcclusion" &&
+            single_result.error_reason.empty(),
+        "occlusion result lost its terminal metadata"
+    );
+    const auto* single_payload =
+        std::get_if<OcclusionQueryResult>(&single_result.payload);
+    Expect(
+        single_payload != nullptr && single_payload->sample_count == 91 &&
+            single_payload->visible,
+        "occlusion result has the wrong typed payload"
+    );
+
+    CommandList timestamp_list(EQueueType::Graphics);
+    QueryToken timestamp =
+        timestamp_list.BeginTimestampQuery("WrongKindTimestamp");
+    timestamp_list.EndTimestampQuery(timestamp);
+    CmdSubmit timestamp_submit = timestamp_list.Submit();
+    Expect(
+        !QueryBackendAccess::ResolveOcclusion(
+            timestamp, TestOcclusionResult()
+        ),
+        "occlusion resolution accepted a timestamp token"
+    );
+    Expect(
+        timestamp.GetFuture().Status() == QueryStatus::Pending,
+        "wrong-kind occlusion resolution terminalized a timestamp query"
+    );
+    QueryBackendAccess::ResolveErrorIfPending(
+        timestamp, "wrong-kind test cleanup"
+    );
+
+    CommandList batch_list(EQueueType::Graphics);
+    QueryToken batch_first =
+        batch_list.BeginOcclusionQuery("BatchOcclusionFirst");
+    batch_list.EndOcclusionQuery(batch_first);
+    QueryToken batch_second =
+        batch_list.BeginOcclusionQuery("BatchOcclusionSecond");
+    batch_list.EndOcclusionQuery(batch_second);
+    CmdSubmit batch_submit = batch_list.Submit();
+
+    std::atomic<int> batch_callback_count{0};
+    std::atomic_bool first_observed_second_ready{false};
+    const QueryFuture second_future = batch_second.GetFuture();
+    batch_first.Then([&](const QueryResult& _result) {
+        const auto* payload =
+            std::get_if<OcclusionQueryResult>(&_result.payload);
+        first_observed_second_ready.store(
+            _result.status == QueryStatus::Ready &&
+                payload != nullptr && payload->sample_count == 11 &&
+                second_future.Status() == QueryStatus::Ready,
+            std::memory_order_release
+        );
+        batch_callback_count.fetch_add(1, std::memory_order_relaxed);
+    });
+    batch_second.Then([&](const QueryResult& _result) {
+        const auto* payload =
+            std::get_if<OcclusionQueryResult>(&_result.payload);
+        if (_result.status == QueryStatus::Ready && payload != nullptr &&
+            payload->sample_count == 0 && !payload->visible) {
+            batch_callback_count.fetch_add(1, std::memory_order_relaxed);
+        }
+    });
+
+    const QueryPublishBatch batch =
+        QueryBackendAccess::BeginPublishBatch();
+    Expect(
+        QueryBackendAccess::PublishOcclusion(
+            batch_first, TestOcclusionResult(11, true), batch
+        ) &&
+            QueryBackendAccess::PublishOcclusion(
+                batch_second, TestOcclusionResult(0, false), batch
+            ),
+        "occlusion batch did not publish every result"
+    );
+    Expect(
+        batch_callback_count.load(std::memory_order_relaxed) == 0,
+        "occlusion batch released callbacks during publication"
+    );
+    QueryBackendAccess::NotifyTerminals(batch_submit.query_tokens, batch);
+    Expect(
+        first_observed_second_ready.load(std::memory_order_acquire) &&
+            batch_callback_count.load(std::memory_order_relaxed) == 2,
+        "occlusion batch did not publish peers before notification"
+    );
+}
+
+void OcclusionQueueCapabilityAndCommandOpsAreExplicit() {
+    CommandList graphics(EQueueType::Graphics);
+    QueryToken token = graphics.BeginOcclusionQuery("GraphicsOcclusion");
+    graphics.EndOcclusionQuery(token);
+    CmdSubmit graphics_submit = graphics.Submit();
+
+    Expect(
+        graphics_submit.cmds.size() == 2 &&
+            QueryAt(graphics_submit, 0).Op() ==
+                QueryCmd::EOp::BeginOcclusion &&
+            QueryAt(graphics_submit, 1).Op() ==
+                QueryCmd::EOp::EndOcclusion,
+        "graphics occlusion query did not emit its exact command pair"
+    );
+    Expect(
+        QueryAt(graphics_submit, 0).IsBegin() &&
+            QueryAt(graphics_submit, 1).IsEnd() &&
+            QueryAt(graphics_submit, 0).IsOcclusion() &&
+            !QueryAt(graphics_submit, 0).IsTimestamp() &&
+            QueryAt(graphics_submit, 0).GetQueueType() ==
+                EQueueType::Graphics &&
+            QueryAt(graphics_submit, 0).Token().Kind() ==
+                QueryKind::Occlusion,
+        "QueryCmd lost its occlusion operation, kind, or queue"
+    );
+    QueryBackendAccess::ResolveErrorIfPending(
+        token, "graphics command contract cleanup"
+    );
+
+    for (const EQueueType queue :
+         {EQueueType::Compute, EQueueType::Copy}) {
+        CommandList unsupported(queue);
+        QueryToken unsupported_token =
+            unsupported.BeginOcclusionQuery("UnsupportedOcclusion");
+        const QueryResult result = unsupported_token.GetFuture().Get();
+        Expect(
+            unsupported_token.Valid() &&
+                unsupported_token.Kind() == QueryKind::Occlusion &&
+                result.status == QueryStatus::Error &&
+                !result.error_reason.empty(),
+            "non-Graphics occlusion query did not return a capability Error"
+        );
+        unsupported.EndOcclusionQuery(unsupported_token);
+        Expect(
+            unsupported.IsEmpty(),
+            "non-Graphics occlusion capability failure recorded a command"
+        );
+    }
+}
+
+void MixedQueryNestingIsStrictAndOcclusionIsNotRecursive() {
+    CommandList mixed(EQueueType::Graphics);
+    QueryToken outer_timestamp =
+        mixed.BeginTimestampQuery("MixedOuterTimestamp");
+    QueryToken occlusion = mixed.BeginOcclusionQuery("MixedOcclusion");
+    QueryToken inner_timestamp =
+        mixed.BeginTimestampQuery("MixedInnerTimestamp");
+
+    Expect(
+        mixed.HasOpenQueries() && mixed.HasOpenTimestampQueries() &&
+            mixed.HasOpenOcclusionQueries(),
+        "mixed query stack did not report every open kind"
+    );
+    ExpectThrows<std::logic_error>(
+        [&] {
+            mixed.EndOcclusionQuery(occlusion);
+        },
+        "mixed query stack accepted an out-of-order occlusion End"
+    );
+    ExpectThrows<std::logic_error>(
+        [&] {
+            [[maybe_unused]] QueryToken nested_occlusion =
+                mixed.BeginOcclusionQuery("IllegalNestedOcclusion");
+        },
+        "nested occlusion query was accepted"
+    );
+    ExpectThrows<std::invalid_argument>(
+        [&] {
+            mixed.EndTimestampQuery(occlusion);
+        },
+        "EndTimestampQuery accepted an occlusion token"
+    );
+    ExpectThrows<std::invalid_argument>(
+        [&] {
+            mixed.EndOcclusionQuery(inner_timestamp);
+        },
+        "EndOcclusionQuery accepted a timestamp token"
+    );
+
+    mixed.EndTimestampQuery(inner_timestamp);
+    mixed.EndOcclusionQuery(occlusion);
+    mixed.EndTimestampQuery(outer_timestamp);
+    Expect(
+        !mixed.HasOpenQueries() && !mixed.HasOpenTimestampQueries() &&
+            !mixed.HasOpenOcclusionQueries(),
+        "closed mixed query stack still reported an open query"
+    );
+
+    CmdSubmit mixed_submit = mixed.Submit();
+    Expect(
+        mixed_submit.cmds.size() == 6 &&
+            QueryAt(mixed_submit, 0).Op() ==
+                QueryCmd::EOp::BeginTimestamp &&
+            QueryAt(mixed_submit, 1).Op() ==
+                QueryCmd::EOp::BeginOcclusion &&
+            QueryAt(mixed_submit, 2).Op() ==
+                QueryCmd::EOp::BeginTimestamp &&
+            QueryAt(mixed_submit, 3).Op() ==
+                QueryCmd::EOp::EndTimestamp &&
+            QueryAt(mixed_submit, 4).Op() ==
+                QueryCmd::EOp::EndOcclusion &&
+            QueryAt(mixed_submit, 5).Op() ==
+                QueryCmd::EOp::EndTimestamp,
+        "mixed query stack did not preserve strict LIFO command order"
+    );
+
+    CommandList owner(EQueueType::Graphics);
+    CommandList foreign(EQueueType::Graphics);
+    QueryToken owned = owner.BeginOcclusionQuery("OwnedOcclusion");
+    ExpectThrows<std::invalid_argument>(
+        [&] {
+            foreign.EndOcclusionQuery(owned);
+        },
+        "a different CommandList accepted an occlusion token"
+    );
+    owner.EndOcclusionQuery(owned);
+    CmdSubmit owner_submit = owner.Submit();
+
+    QueryBackendAccess::ResolveErrorIfPending(
+        outer_timestamp, "mixed contract cleanup"
+    );
+    QueryBackendAccess::ResolveErrorIfPending(
+        inner_timestamp, "mixed contract cleanup"
+    );
+    QueryBackendAccess::ResolveErrorIfPending(
+        occlusion, "mixed contract cleanup"
+    );
+    QueryBackendAccess::ResolveErrorIfPending(
+        owned, "mixed contract cleanup"
+    );
+}
+
 void FutureIsThreadSafeOneShotAndContainsCallbackExceptions() {
     CommandList list(EQueueType::Graphics);
     QueryToken  token = list.BeginTimestampQuery("ConcurrentTimestamp");
@@ -682,6 +945,32 @@ void InvalidSubmissionRejectionAndDestructionAreTerminal() {
         "invalid Submit did not terminalize its query"
     );
 
+    QueryFuture unclosed_occlusion_future{};
+    {
+        CommandList unclosed(EQueueType::Graphics);
+        QueryToken token =
+            unclosed.BeginOcclusionQuery("UnclosedOcclusionSubmit");
+        unclosed_occlusion_future = token.GetFuture();
+        ExpectThrows<std::logic_error>(
+            [&] {
+                [[maybe_unused]] CmdSubmit rejected = unclosed.Submit();
+            },
+            "Submit accepted an unclosed occlusion query"
+        );
+        Expect(
+            unclosed.IsEmpty(),
+            "invalid Submit retained a partial occlusion query stream"
+        );
+    }
+    const QueryResult unclosed_occlusion_result =
+        unclosed_occlusion_future.Get();
+    Expect(
+        unclosed_occlusion_result.status == QueryStatus::Error &&
+            unclosed_occlusion_result.kind == QueryKind::Occlusion &&
+            !unclosed_occlusion_result.error_reason.empty(),
+        "invalid Submit did not terminalize its occlusion query"
+    );
+
     QueryFuture drained_future{};
     {
         CommandList rejected(EQueueType::Graphics);
@@ -950,6 +1239,52 @@ void MoveAndSubmitRetainIdentityAndLifetime() {
     moved_submit.query_tokens.clear();
     Expect(moved_future.Get().status == QueryStatus::Ready, "moved query did not retain the Ready result");
 
+    QueryFuture moved_occlusion_future{};
+    {
+        CommandList source(EQueueType::Graphics);
+        QueryToken token =
+            source.BeginOcclusionQuery("MovedOcclusionList");
+        moved_occlusion_future = token.GetFuture();
+
+        CommandList destination(std::move(source));
+        destination.EndOcclusionQuery(token);
+        ExpectThrows<std::invalid_argument>(
+            [&] {
+                source.EndOcclusionQuery(token);
+            },
+            "moved-from CommandList retained occlusion query ownership"
+        );
+
+        CmdSubmit submit = destination.Submit();
+        Expect(
+            submit.query_tokens.size() == 1 &&
+                QueryAt(submit, 0).Op() ==
+                    QueryCmd::EOp::BeginOcclusion &&
+                QueryAt(submit, 1).Op() ==
+                    QueryCmd::EOp::EndOcclusion,
+            "CommandList move lost its occlusion query stream"
+        );
+        Expect(
+            QueryBackendAccess::ResolveOcclusion(
+                submit.query_tokens.front(),
+                TestOcclusionResult(123, true)
+            ),
+            "moved occlusion query could not be resolved"
+        );
+    }
+    const QueryResult moved_occlusion_result =
+        moved_occlusion_future.Get();
+    const auto* moved_occlusion_payload =
+        std::get_if<OcclusionQueryResult>(
+            &moved_occlusion_result.payload
+        );
+    Expect(
+        moved_occlusion_result.status == QueryStatus::Ready &&
+            moved_occlusion_payload != nullptr &&
+            moved_occlusion_payload->sample_count == 123,
+        "moved occlusion query did not retain its Ready payload"
+    );
+
     QueryFuture overwritten_future{};
     CmdSubmit   destination = CommandList(EQueueType::Graphics).Submit();
     {
@@ -1000,14 +1335,19 @@ void CancellationViewIsStableAndGenerationScoped() {
 
     QueryToken existing = list.BeginTimestampQuery("BeforeCancel");
     list.EndTimestampQuery(existing);
+    QueryToken existing_occlusion =
+        list.BeginOcclusionQuery("OcclusionBeforeCancel");
+    list.EndOcclusionQuery(existing_occlusion);
     Expect(
         first_generation.Cancel("recording source shutdown"),
         "first cancellation did not win the generation transition"
     );
     Expect(!first_generation.Cancel("duplicate shutdown"), "cancellation domain was not one-shot");
     Expect(
-        existing.GetFuture().Get().status == QueryStatus::Error,
-        "cancellation did not terminate an existing token"
+        existing.GetFuture().Get().status == QueryStatus::Error &&
+            existing_occlusion.GetFuture().Get().status ==
+                QueryStatus::Error,
+        "cancellation did not terminate every existing query kind"
     );
 
     QueryToken late = list.BeginTimestampQuery("AfterCancel");
@@ -1050,6 +1390,9 @@ int main() {
     static_assert(std::is_copy_constructible_v<QueryCancellationView>);
 
     try {
+        OcclusionPayloadAndBatchResolutionAreTyped();
+        OcclusionQueueCapabilityAndCommandOpsAreExplicit();
+        MixedQueryNestingIsStrictAndOcclusionIsNotRecursive();
         FutureIsThreadSafeOneShotAndContainsCallbackExceptions();
         ReadyAndErrorResolutionRaceHasOneWinner();
         ReadyBatchPublishesEveryPeerBeforeNotification();

--- a/source/test/RHIRecordDiagnosticsTest.cpp
+++ b/source/test/RHIRecordDiagnosticsTest.cpp
@@ -551,6 +551,39 @@ void QueryDigestIgnoresRingPlacementButPreservesEvents() {
     Expect(baseline.digest != different_stage.digest, "query pipeline stage was omitted");
 }
 
+void QueryDigestDistinguishesTimestampAndOcclusion() {
+    SerialQuerySectionBuilder timestamp_builder;
+    timestamp_builder.AddEvent(
+        SerialQueryEvent::Begin, "Visibility", 0, 0
+    );
+    timestamp_builder.AddEvent(
+        SerialQueryEvent::End, "Visibility", 1, 0
+    );
+
+    SerialQuerySectionBuilder occlusion_builder;
+    occlusion_builder.AddEvent(
+        SerialQueryEvent::OcclusionBegin, "Visibility", 0, 0
+    );
+    occlusion_builder.AddEvent(
+        SerialQueryEvent::OcclusionEnd, "Visibility", 1, 0
+    );
+
+    const SerialGoldenSection timestamp =
+        timestamp_builder.Finish();
+    const SerialGoldenSection occlusion =
+        occlusion_builder.Finish();
+    Expect(
+        timestamp.digest != occlusion.digest,
+        "timestamp and occlusion events collapsed to one query digest"
+    );
+    Expect(
+        timestamp.item_count == 2 &&
+            occlusion.item_count == 2 &&
+            timestamp.complete && occlusion.complete,
+        "typed query events changed diagnostics completeness"
+    );
+}
+
 void CombinedDigestKeepsSectionIdentity() {
     const SerialCommandLayerSection commands = BuildAliasedCommandSection(0x4000);
     AliasedTokens tokens = MakeAliasedTokens(0x5000);
@@ -814,6 +847,7 @@ int main() {
         QueueFamilyRolesAreStableCompleteAndDirectional();
         DescriptorDigestIncludesLayoutResourceAndSemanticBytes();
         QueryDigestIgnoresRingPlacementButPreservesEvents();
+        QueryDigestDistinguishesTimestampAndOcclusion();
         CombinedDigestKeepsSectionIdentity();
         UnresolvedAndOpaqueObjectsFailClosed();
         BindlessUpdateLifecycleIsOneShotAndDiscardSafe();

--- a/tools/threading/run_parallel_record_vulkan_test.py
+++ b/tools/threading/run_parallel_record_vulkan_test.py
@@ -971,6 +971,7 @@ def _require_occlusion_query(text: str) -> None:
         and fields.get("status") == "Ready"
         and fields.get("samples") == "0"
         and fields.get("visible") == "false"
+        and fields.get("count_precise") in {"true", "false"}
         and fields.get("availability") == "explicit"
         and fields.get("pool") == "allocator_local"
         and fields.get("bulk_pairs") == "48"

--- a/tools/threading/run_parallel_record_vulkan_test.py
+++ b/tools/threading/run_parallel_record_vulkan_test.py
@@ -957,12 +957,41 @@ def _require_owning_readback_future(text: str) -> None:
     )
 
 
+def _require_occlusion_query(text: str) -> None:
+    marker = _testcase_marker("OcclusionQueryCompletionOwnership", text)
+    _require(
+        marker is not None and marker[0] == "PASS",
+        "occlusion-query: missing occlusion query PASS marker",
+    )
+    _, fields = marker
+    _require(
+        fields.get("queue") == "Graphics"
+        and fields.get("status") == "Ready"
+        and fields.get("samples") == "0"
+        and fields.get("visible") == "false"
+        and fields.get("availability") == "explicit"
+        and fields.get("pool") == "allocator_local"
+        and fields.get("bulk_pairs") == "48"
+        and fields.get("growth") == "verified"
+        and fields.get("reuse") == "verified"
+        and fields.get("recording") == "serial_island"
+        and fields.get("order") == "signal->completion->query->ordinary"
+        and fields.get("callbacks") == "exactly_once"
+        and fields.get("readback") == "verified"
+        and fields.get("replay") == "0",
+        "occlusion-query: incomplete native query contract",
+    )
+
+
 def validate_log(mode: str, text: str) -> None:
     _require("[TESTCASE][FAIL]" not in text, f"{mode}: test emitted a FAIL marker")
     _require("VUID-" not in text, f"{mode}: Vulkan validation VUID was emitted")
     _require("Validation Error" not in text, f"{mode}: Vulkan validation error was emitted")
     if mode == "readback-future":
         _require_owning_readback_future(text)
+        return
+    if mode == "occlusion-query":
+        _require_occlusion_query(text)
         return
     if mode == "timestamp-query-success-batch":
         _require_timestamp_query_success_batch(text)
@@ -1262,6 +1291,8 @@ def run_case(executable: Path, outdir: Path, mode: str, timeout: float) -> Path:
         arguments.append("--rt-export-rejection")
     if mode == "readback-future":
         arguments.append("--readback-future")
+    if mode == "occlusion-query":
+        arguments.append("--occlusion-query")
     if mode == "timestamp-query-success-batch":
         arguments.append("--timestamp-query-success-batch")
 
@@ -1320,6 +1351,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                 "present-hard",
                 "rt-export-rejection",
                 "readback-future",
+                "occlusion-query",
                 "timestamp-query-success-batch",
             )
         ]

--- a/tools/threading/run_parallel_record_vulkan_test.py
+++ b/tools/threading/run_parallel_record_vulkan_test.py
@@ -824,7 +824,9 @@ def _require_phase15f_present_boundary(mode: str, text: str) -> None:
         and fields.get("recreate") == "false"
         and fields.get("later_batch") == "rejected"
         and fields.get("native_after_present") == "0"
-        and fields.get("hard_latch") == "verified"
+        and fields.get("device_fault_priority") == "true"
+        and fields.get("invalid_source") == "true"
+        and fields.get("concurrent_hard_latch") == "verified"
         and fields.get("replay") == "0",
         f"{mode}: incomplete hard Present boundary contract",
     )

--- a/tools/threading/test_run_parallel_record_vulkan_test.py
+++ b/tools/threading/test_run_parallel_record_vulkan_test.py
@@ -166,7 +166,8 @@ def present_hard_line() -> str:
         "[TESTCASE][PASS] name=PresentHardFailureBoundary "
         "outcome=Rejected owner=Submission receipt_attempts=1 "
         "submitted=false recreate=false later_batch=rejected "
-        "native_after_present=0 hard_latch=verified replay=0\n"
+        "native_after_present=0 device_fault_priority=true "
+        "invalid_source=true concurrent_hard_latch=verified replay=0\n"
     )
 
 
@@ -1340,6 +1341,26 @@ class VulkanRunnerTests(unittest.TestCase):
                     "native_after_present=1",
                 ),
             )
+
+    def test_present_hard_requires_fault_priority_and_concurrent_latch(
+        self,
+    ) -> None:
+        for original, replacement in (
+            ("device_fault_priority=true", "device_fault_priority=false"),
+            ("invalid_source=true", "invalid_source=false"),
+            (
+                "concurrent_hard_latch=verified",
+                "concurrent_hard_latch=missing",
+            ),
+        ):
+            with self.subTest(field=original), self.assertRaisesRegex(
+                runner.VulkanTestError,
+                "hard Present boundary contract",
+            ):
+                runner.validate_log(
+                    "present-hard",
+                    present_hard_line().replace(original, replacement),
+                )
 
     def test_serial_accepts_only_pass_marker(self) -> None:
         runner.validate_log("serial", pass_line("serial", "false"))

--- a/tools/threading/test_run_parallel_record_vulkan_test.py
+++ b/tools/threading/test_run_parallel_record_vulkan_test.py
@@ -193,6 +193,18 @@ def readback_future_line() -> str:
     )
 
 
+def occlusion_query_line() -> str:
+    return (
+        "[TESTCASE][PASS] name=OcclusionQueryCompletionOwnership "
+        "queue=Graphics status=Ready samples=0 visible=false "
+        "availability=explicit pool=allocator_local bulk_pairs=48 "
+        "growth=verified reuse=verified "
+        "recording=serial_island "
+        "order=signal->completion->query->ordinary "
+        "callbacks=exactly_once readback=verified replay=0\n"
+    )
+
+
 def timestamp_query_success_batch_line() -> str:
     return (
         "[TESTCASE][PASS] "
@@ -1018,6 +1030,11 @@ class VulkanRunnerTests(unittest.TestCase):
                 readback_future_line(),
             ),
             (
+                "occlusion-query",
+                "--occlusion-query",
+                occlusion_query_line(),
+            ),
+            (
                 "timestamp-query-success-batch",
                 "--timestamp-query-success-batch",
                 timestamp_query_success_batch_line(),
@@ -1080,6 +1097,49 @@ class VulkanRunnerTests(unittest.TestCase):
                 "readback-future",
                 "VUID-VkImageMemoryBarrier2-oldLayout-01197\n"
                 + readback_future_line(),
+            )
+
+    def test_occlusion_query_contract_is_accepted(self) -> None:
+        runner.validate_log(
+            "occlusion-query",
+            occlusion_query_line(),
+        )
+
+    def test_occlusion_query_requires_serial_island(self) -> None:
+        with self.assertRaisesRegex(
+            runner.VulkanTestError,
+            "incomplete native query contract",
+        ):
+            runner.validate_log(
+                "occlusion-query",
+                occlusion_query_line().replace(
+                    "recording=serial_island",
+                    "recording=parallel_wave",
+                ),
+            )
+
+    def test_occlusion_query_requires_bulk_growth(self) -> None:
+        with self.assertRaisesRegex(
+            runner.VulkanTestError,
+            "incomplete native query contract",
+        ):
+            runner.validate_log(
+                "occlusion-query",
+                occlusion_query_line().replace(
+                    "bulk_pairs=48 growth=verified",
+                    "bulk_pairs=1 growth=unverified",
+                ),
+            )
+
+    def test_occlusion_query_rejects_validation_vuid(self) -> None:
+        with self.assertRaisesRegex(
+            runner.VulkanTestError,
+            "Vulkan validation VUID",
+        ):
+            runner.validate_log(
+                "occlusion-query",
+                "VUID-vkCmdBeginQuery-None-00807\n"
+                + occlusion_query_line(),
             )
 
     def test_timestamp_query_success_batch_contract_is_accepted(

--- a/tools/threading/test_run_parallel_record_vulkan_test.py
+++ b/tools/threading/test_run_parallel_record_vulkan_test.py
@@ -198,6 +198,7 @@ def occlusion_query_line() -> str:
     return (
         "[TESTCASE][PASS] name=OcclusionQueryCompletionOwnership "
         "queue=Graphics status=Ready samples=0 visible=false "
+        "count_precise=true "
         "availability=explicit pool=allocator_local bulk_pairs=48 "
         "growth=verified reuse=verified "
         "recording=serial_island "
@@ -1129,6 +1130,31 @@ class VulkanRunnerTests(unittest.TestCase):
                 occlusion_query_line().replace(
                     "bulk_pairs=48 growth=verified",
                     "bulk_pairs=1 growth=unverified",
+                ),
+            )
+
+    def test_occlusion_query_requires_precision_capability(self) -> None:
+        with self.assertRaisesRegex(
+            runner.VulkanTestError,
+            "incomplete native query contract",
+        ):
+            runner.validate_log(
+                "occlusion-query",
+                occlusion_query_line().replace(
+                    "count_precise=true ",
+                    "",
+                ),
+            )
+
+        with self.assertRaisesRegex(
+            runner.VulkanTestError,
+            "incomplete native query contract",
+        ):
+            runner.validate_log(
+                "occlusion-query",
+                occlusion_query_line().replace(
+                    "count_precise=true",
+                    "count_precise=unknown",
                 ),
             )
 


### PR DESCRIPTION
## What changed

- expose typed `BeginOcclusionQuery` / `EndOcclusionQuery` on Graphics command lists while Compute/Copy fail closed without recording native work
- preserve owner/kind validation, mixed-query strict LIFO, cancellation, move, destruction, and generic open-query preflight semantics
- add allocator-local Vulkan occlusion query pools with one slot per pair, explicit availability reads, no `WAIT_BIT`, and unified Timestamp/Occlusion publish-before-notify completion
- request `VK_QUERY_CONTROL_PRECISE_BIT` when the enabled device feature is available; otherwise publish reliable visibility with `sample_count=nullopt` instead of an implementation-defined count
- keep query sources as serial recording islands while unrelated sources retain parallel translate/record behavior
- make D3D12 query capability errors kind-aware and fail closed
- distinguish Timestamp and Occlusion in serial golden diagnostics
- add CPU contracts and a standard real-Vulkan `occlusion-query` gate covering 48-pair pool growth, allocator reuse, Completion-thread callback ordering, readback, capability-aware count semantics, and replay safety
- align the existing `present-hard` runner parser with its current device-fault-priority/concurrent-latch production marker and add negative parser tests

## Why

`dev_parallel_rhi` contains useful Occlusion Query semantics, but its global active-query runtime, mutex ownership, and waiting readback path conflict with main's newer Executor / Submission / Completion model. This PR ports the capability onto main's `QueryFuture`, allocator retirement, rejection transaction, and batch notification contracts instead of copying the old runtime.

## Validation

- RelWithDebInfo: `TestRHIQuery`, `TestRHIRecordDiagnostics`, `TestRHIExecutorRecordingHandoff`, `TestRHIParallelRecordVulkan`, `MoerEditor`
- CTest: 22/22 passed
- runner unit tests: 129/129 passed
- complete Vulkan runner matrix logs: 15/15 validated
- RTX 5080 `occlusion-query`: passed, `count_precise=true`, 48 pairs + growth + reuse, no VUID/Validation Error
- RTX 5080 `timestamp-query-success-batch`: passed
- Raytracing and Raster editor 30-second Vulkan/RHI-thread/parallel-recording smoke runs: clean
- four independent local reviews: no remaining P0/P1/P2