### PR TITLE
Phase 21A: add bounded ProfileDump core

### DIFF
--- a/source/runtime/core/CMakeLists.txt
+++ b/source/runtime/core/CMakeLists.txt
@@ -2,9 +2,9 @@
 
 set(target_name moer_core)
 
-file(GLOB_RECURSE core_headers "include/*.h" "include/*.inl")
-file(GLOB_RECURSE core_sources "source/*.cpp")
-file(GLOB_RECURSE core_private_headers "source/*.h")
+file(GLOB_RECURSE core_headers CONFIGURE_DEPENDS "include/*.h" "include/*.inl")
+file(GLOB_RECURSE core_sources CONFIGURE_DEPENDS "source/*.cpp")
+file(GLOB_RECURSE core_private_headers CONFIGURE_DEPENDS "source/*.h")
 
 source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR} FILES ${core_headers} ${core_sources} ${core_private_headers})
 

--- a/source/runtime/core/include/profile/ProfileDump.h
+++ b/source/runtime/core/include/profile/ProfileDump.h
@@ -1,0 +1,176 @@
+#ifndef MOER_ENGINE_PROFILE_DUMP_H
+#define MOER_ENGINE_PROFILE_DUMP_H
+
+#include "API_Macro.h"
+#include "profile/ProfileDumpCodec.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <filesystem>
+#include <span>
+#include <string>
+
+namespace Moer::ProfileDump {
+
+enum class RuntimeState : std::uint8_t {
+    Stopped = 0,
+    Starting,
+    Running,
+    Draining,
+    Faulted,
+};
+
+enum class StartResult : std::uint8_t {
+    Started = 0,
+    AlreadyRunning,
+    Busy,
+    InvalidConfig,
+    OutputExists,
+    FileOpenFailed,
+    ThreadCreateFailed,
+    ResourceExhausted,
+};
+
+enum class FlushResult : std::uint8_t {
+    Completed = 0,
+    NothingPending,
+    Rejected,
+    Faulted,
+};
+
+enum class ShutdownResult : std::uint8_t {
+    Completed = 0,
+    AlreadyStopped,
+    Faulted,
+};
+
+enum class SchemaStatus : std::uint8_t {
+    Registered = 0,
+    AlreadyRegistered,
+    NotRunning,
+    InvalidSchema,
+    SchemaLimit,
+    SchemaBytesLimit,
+    HashCollision,
+};
+
+enum class EmitStatus : std::uint8_t {
+    Accepted = 0,
+    Disabled,
+    InvalidHandle,
+    ValueCountMismatch,
+    ValueTypeMismatch,
+    StringTooLarge,
+    RecordTooLarge,
+    QueueFull,
+    SinkFault,
+};
+
+enum class RuntimeFault : std::uint8_t {
+    None = 0,
+    OpenTempFile,
+    WritePacket,
+    FlushFile,
+    CloseFile,
+    RenameFinal,
+    WriterException,
+};
+
+struct RuntimeConfig {
+    std::filesystem::path output_path{};
+    CodecLimits           codec_limits{};
+
+    std::size_t max_schemas{1024};
+    std::size_t max_schema_bytes{1024 * 1024};
+    std::size_t max_record_bytes{64 * 1024};
+
+    std::size_t tls_publish_records{64};
+    std::size_t tls_publish_bytes{16 * 1024};
+    std::size_t tls_max_records{256};
+    std::size_t tls_max_bytes{256 * 1024};
+
+    std::size_t queue_max_chunks{128};
+    std::size_t queue_max_records{65536};
+    std::size_t queue_max_bytes{64 * 1024 * 1024};
+
+    bool replace_existing{false};
+};
+
+struct SchemaHandle {
+    std::uint64_t hash{0};
+    std::uint64_t generation{0};
+
+    [[nodiscard]] explicit operator bool() const noexcept {
+        return hash != 0 && generation != 0;
+    }
+
+    friend bool operator==(const SchemaHandle&, const SchemaHandle&) = default;
+};
+
+struct SchemaRegistration {
+    SchemaStatus status{SchemaStatus::NotRunning};
+    SchemaHandle handle{};
+};
+
+struct RuntimeStats {
+    RuntimeState  state{RuntimeState::Stopped};
+    RuntimeFault  last_fault{RuntimeFault::None};
+    std::uint64_t generation{0};
+
+    std::uint64_t records_committed{0};
+    std::uint64_t records_enqueued{0};
+    std::uint64_t records_written{0};
+    std::uint64_t records_dropped_stopped{0};
+    std::uint64_t records_dropped_stale_generation{0};
+    std::uint64_t records_dropped_oversized{0};
+    std::uint64_t records_dropped_queue_full{0};
+    std::uint64_t records_dropped_after_fault{0};
+
+    std::uint64_t chunks_enqueued{0};
+    std::uint64_t chunks_written{0};
+    std::uint64_t chunks_dropped{0};
+
+    std::uint64_t resident_chunks{0};
+    std::uint64_t resident_records{0};
+    std::uint64_t resident_bytes{0};
+    std::uint64_t high_water_chunks{0};
+    std::uint64_t high_water_records{0};
+    std::uint64_t high_water_bytes{0};
+
+    std::uint64_t file_bytes_written{0};
+    std::uint64_t flush_completed{0};
+    std::uint64_t flush_failed{0};
+    std::uint64_t io_faults{0};
+};
+
+[[nodiscard]] CORE_API StartResult Start(const RuntimeConfig& _config) noexcept;
+
+[[nodiscard]] CORE_API SchemaRegistration RegisterSchema(const SchemaDescriptor& _schema) noexcept;
+
+[[nodiscard]] CORE_API EmitStatus
+Emit(SchemaHandle _schema, std::span<const FieldValueView> _values) noexcept;
+
+// Producer-thread operation. Publishes only the calling thread's TLS shard,
+// then waits until the already-published writer interval has been flushed to
+// the in-progress stream. This is not an fsync/power-loss durability
+// guarantee. Each producer must call this before it exits, or exit and let its
+// TLS destructor publish, before the owner begins final shutdown.
+[[nodiscard]] CORE_API FlushResult FlushThreadLocal() noexcept;
+
+// Process-owner synchronization fence for chunks that producers have already
+// published to the global queue. It cannot discover another live thread's
+// sub-threshold TLS shard and therefore is not a substitute for producer
+// FlushThreadLocal/exit.
+[[nodiscard]] CORE_API FlushResult FlushAll() noexcept;
+
+// Process-owner finalization. All producer threads must first FlushThreadLocal
+// or exit and be joined. The owner calls Shutdown last; it drains accepted
+// emitters, closes the writer, and publishes .inprogress as the final file.
+[[nodiscard]] CORE_API ShutdownResult Shutdown() noexcept;
+
+[[nodiscard]] CORE_API RuntimeState GetRuntimeState() noexcept;
+[[nodiscard]] CORE_API RuntimeStats GetRuntimeStats() noexcept;
+
+} // namespace Moer::ProfileDump
+
+#endif // MOER_ENGINE_PROFILE_DUMP_H

--- a/source/runtime/core/include/profile/ProfileDumpCodec.h
+++ b/source/runtime/core/include/profile/ProfileDumpCodec.h
@@ -1,0 +1,219 @@
+#ifndef MOER_ENGINE_PROFILE_DUMP_CODEC_H
+#define MOER_ENGINE_PROFILE_DUMP_CODEC_H
+
+#include "API_Macro.h"
+#include "misc/STL.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <span>
+#include <string>
+#include <string_view>
+#include <variant>
+
+namespace Moer::ProfileDump {
+
+// ProfileDump values cross the Moer::Core DLL boundary. Use the engine
+// allocator explicitly so an owning string allocated by the codec is released
+// through Memory::Free in every consuming module.
+using ProfileString = std::basic_string<char, std::char_traits<char>, MoerStlAllocator<char>>;
+
+inline constexpr std::uint32_t kPacketMagic       = 0x5344504Du;
+inline constexpr std::uint16_t kWireVersion       = 3;
+inline constexpr std::uint16_t kPacketHeaderBytes = 32;
+
+enum class Channel : std::uint8_t {
+    CpuThread = 0,
+    GpuQueue  = 1,
+};
+
+enum class EventKind : std::uint8_t {
+    Scope   = 0,
+    Counter = 1,
+    Instant = 2,
+};
+
+enum class FieldType : std::uint8_t {
+    Bool = 0,
+    Int32,
+    UInt32,
+    Int64,
+    UInt64,
+    Float32,
+    Float64,
+    String,
+};
+
+enum class PacketType : std::uint16_t {
+    SessionBegin = 1,
+    Schema       = 2,
+    Record       = 3,
+    Loss         = 4,
+    SessionEnd   = 5,
+};
+
+enum class EncodeStatus : std::uint8_t {
+    Ok = 0,
+    InvalidSchema,
+    ValueCountMismatch,
+    ValueTypeMismatch,
+    StringTooLarge,
+    PayloadTooLarge,
+};
+
+enum class DecodeStatus : std::uint8_t {
+    Ok = 0,
+    NeedMoreData,
+    InvalidMagic,
+    UnsupportedVersion,
+    InvalidHeader,
+    UnknownPacketType,
+    UnsupportedFlags,
+    PayloadTooLarge,
+    ChecksumMismatch,
+    MalformedPayload,
+    LimitExceeded,
+    SchemaHashMismatch,
+    UnknownSchema,
+};
+
+struct CodecLimits {
+    std::size_t   max_packet_payload_bytes{1024 * 1024};
+    std::size_t   max_string_bytes{16 * 1024};
+    std::uint32_t max_fields{64};
+};
+
+struct SchemaField {
+    ProfileString name{};
+    FieldType     type{FieldType::Bool};
+
+    friend bool operator==(const SchemaField&, const SchemaField&) = default;
+};
+
+struct SchemaDescriptor {
+    ProfileString      name{};
+    ProfileString      event_type{};
+    EventKind          kind{EventKind::Scope};
+    Channel            channel{Channel::CpuThread};
+    std::uint32_t      schema_version{1};
+    Array<SchemaField> fields{};
+
+    friend bool operator==(const SchemaDescriptor&, const SchemaDescriptor&) = default;
+};
+
+using FieldValue = std::
+    variant<bool, std::int32_t, std::uint32_t, std::int64_t, std::uint64_t, float, double, ProfileString>;
+
+using FieldValueView = std::
+    variant<bool, std::int32_t, std::uint32_t, std::int64_t, std::uint64_t, float, double, std::string_view>;
+
+struct PacketHeader {
+    std::uint32_t magic{kPacketMagic};
+    std::uint16_t wire_version{kWireVersion};
+    std::uint16_t header_bytes{kPacketHeaderBytes};
+    PacketType    type{PacketType::SessionBegin};
+    std::uint16_t flags{0};
+    std::uint32_t payload_bytes{0};
+    std::uint64_t packet_index{0};
+    std::uint32_t payload_crc32{0};
+    std::uint32_t header_crc32{0};
+};
+
+struct PacketView {
+    PacketHeader                  header{};
+    std::span<const std::uint8_t> payload{};
+};
+
+struct DecodedRecord {
+    std::uint64_t     schema_hash{0};
+    std::uint64_t     sequence{0};
+    Array<FieldValue> values{};
+};
+
+enum class LossReason : std::uint32_t {
+    None            = 0,
+    Oversized       = 1u << 0,
+    QueueFull       = 1u << 1,
+    StaleGeneration = 1u << 2,
+    AfterShutdown   = 1u << 3,
+    SinkFault       = 1u << 4,
+};
+
+struct LossNotice {
+    std::uint64_t first_sequence{0};
+    std::uint64_t last_sequence{0};
+    std::uint64_t record_count{0};
+    std::uint64_t value_bytes{0};
+    std::uint32_t reason_mask{0};
+};
+
+struct SessionBeginInfo {
+    std::uint64_t generation{0};
+    std::uint64_t started_unix_ns{0};
+};
+
+struct SessionEndInfo {
+    std::uint64_t generation{0};
+    std::uint64_t records_written{0};
+    std::uint64_t records_dropped{0};
+};
+
+[[nodiscard]] CORE_API std::uint64_t ComputeSchemaHash(const SchemaDescriptor& _schema) noexcept;
+
+[[nodiscard]] CORE_API EncodeStatus EncodeSchemaPayload(
+    const SchemaDescriptor& _schema,
+    const CodecLimits&      _limits,
+    Array<std::uint8_t>&    _payload
+);
+
+[[nodiscard]] CORE_API EncodeStatus EncodeRecordPayload(
+    std::uint64_t                   _schema_hash,
+    std::uint64_t                   _sequence,
+    std::span<const SchemaField>    _fields,
+    std::span<const FieldValueView> _values,
+    const CodecLimits&              _limits,
+    Array<std::uint8_t>&            _payload
+);
+
+CORE_API void EncodeLossPayload(const LossNotice& _loss, Array<std::uint8_t>& _payload);
+
+CORE_API void EncodeSessionBeginPayload(const SessionBeginInfo& _session, Array<std::uint8_t>& _payload);
+
+CORE_API void EncodeSessionEndPayload(const SessionEndInfo& _session, Array<std::uint8_t>& _payload);
+
+[[nodiscard]] CORE_API EncodeStatus WrapPacket(
+    PacketType                    _type,
+    std::uint64_t                 _packet_index,
+    std::span<const std::uint8_t> _payload,
+    const CodecLimits&            _limits,
+    Array<std::uint8_t>&          _packet
+);
+
+[[nodiscard]] CORE_API DecodeStatus DecodePacket(
+    std::span<const std::uint8_t> _input,
+    const CodecLimits&            _limits,
+    PacketView&                   _packet,
+    std::size_t&                  _consumed
+) noexcept;
+
+[[nodiscard]] CORE_API DecodeStatus
+DecodeSchemaPayload(const PacketView& _packet, const CodecLimits& _limits, SchemaDescriptor& _schema);
+
+[[nodiscard]] CORE_API DecodeStatus DecodeRecordPayload(
+    const PacketView&       _packet,
+    const SchemaDescriptor& _schema,
+    const CodecLimits&      _limits,
+    DecodedRecord&          _record
+);
+
+[[nodiscard]] CORE_API DecodeStatus DecodeLossPayload(const PacketView& _packet, LossNotice& _loss) noexcept;
+
+[[nodiscard]] CORE_API DecodeStatus
+DecodeSessionBeginPayload(const PacketView& _packet, SessionBeginInfo& _session) noexcept;
+
+[[nodiscard]] CORE_API DecodeStatus
+DecodeSessionEndPayload(const PacketView& _packet, SessionEndInfo& _session) noexcept;
+
+} // namespace Moer::ProfileDump
+
+#endif // MOER_ENGINE_PROFILE_DUMP_CODEC_H

--- a/source/runtime/core/include/profile/ProfileDumpTemplates.h
+++ b/source/runtime/core/include/profile/ProfileDumpTemplates.h
@@ -1,0 +1,53 @@
+#ifndef MOER_ENGINE_PROFILE_DUMP_TEMPLATES_H
+#define MOER_ENGINE_PROFILE_DUMP_TEMPLATES_H
+
+#include "profile/ProfileDump.h"
+
+#include <array>
+#include <span>
+
+namespace Moer::ProfileDump::Templates {
+
+inline const SchemaDescriptor& CpuScope() {
+    static const SchemaDescriptor schema{
+        .name           = "CpuScope",
+        .event_type     = "timing.cpu_scope",
+        .kind           = EventKind::Scope,
+        .channel        = Channel::CpuThread,
+        .schema_version = 1,
+        .fields =
+            {
+                {"thread_id", FieldType::UInt64},
+                {"name", FieldType::String},
+                {"begin_ns", FieldType::UInt64},
+                {"end_ns", FieldType::UInt64},
+                {"depth", FieldType::UInt32},
+            },
+    };
+    return schema;
+}
+
+inline const SchemaDescriptor& GpuScope() {
+    static const SchemaDescriptor schema{
+        .name           = "GpuScope",
+        .event_type     = "timing.gpu_scope",
+        .kind           = EventKind::Scope,
+        .channel        = Channel::GpuQueue,
+        .schema_version = 1,
+        .fields =
+            {
+                {"frame_id", FieldType::UInt64},
+                {"queue_domain", FieldType::UInt64},
+                {"name", FieldType::String},
+                {"begin_tick", FieldType::UInt64},
+                {"end_tick", FieldType::UInt64},
+                {"tick_period_ns", FieldType::Float64},
+                {"depth", FieldType::UInt32},
+            },
+    };
+    return schema;
+}
+
+} // namespace Moer::ProfileDump::Templates
+
+#endif // MOER_ENGINE_PROFILE_DUMP_TEMPLATES_H

--- a/source/runtime/core/source/profile/ProfileDump.cpp
+++ b/source/runtime/core/source/profile/ProfileDump.cpp
@@ -1,0 +1,1625 @@
+#include "profile/ProfileDump.h"
+
+#include "ProfileDumpTesting.h"
+#include "platform/Platform.h"
+
+#include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <cstdio>
+#include <deque>
+#include <limits>
+#include <memory>
+#include <mutex>
+#include <new>
+#include <optional>
+#include <thread>
+#include <type_traits>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+#include <variant>
+#include <vector>
+
+#if PLATFORM_WINDOWS
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#include <Windows.h>
+#else
+#include <unistd.h>
+#endif
+
+namespace Moer::ProfileDump {
+
+namespace {
+
+using namespace std::chrono_literals;
+
+struct PendingRecord {
+    std::uint64_t       schema_hash{0};
+    std::uint64_t       sequence{0};
+    Array<std::uint8_t> payload{};
+};
+
+struct ImmutableChunk {
+    std::uint64_t              generation{0};
+    std::vector<PendingRecord> records{};
+    std::size_t                payload_bytes{0};
+    std::uint64_t              first_sequence{0};
+    std::uint64_t              last_sequence{0};
+    std::uint64_t              value_bytes{0};
+};
+
+struct FlushFence {
+    std::mutex              mutex{};
+    std::condition_variable cv{};
+    bool                    complete{false};
+    FlushResult             result{FlushResult::Rejected};
+};
+
+struct FlushMessage {
+    std::shared_ptr<FlushFence> fence{};
+};
+
+struct FinalizeMessage {
+    std::shared_ptr<FlushFence> fence{};
+};
+
+using WriterMessage = std::variant<ImmutableChunk, FlushMessage, FinalizeMessage>;
+
+struct SchemaEntry {
+    SchemaDescriptor descriptor{};
+    std::size_t      encoded_bytes{0};
+};
+
+using SchemaMap = std::unordered_map<std::uint64_t, std::shared_ptr<const SchemaEntry>>;
+
+struct Admission {
+    std::uint64_t              generation{0};
+    RuntimeConfig              config{};
+    std::atomic<std::uint64_t> next_sequence{1};
+    // Protected by Hub::mutex. Shutdown closes admission first, then waits
+    // until every registered emitter has either published its TLS shard or
+    // left the active set.
+    bool          closing{false};
+    std::uint64_t active_emitters{0};
+};
+
+struct AtomicStats {
+    std::atomic<std::uint64_t> records_committed{0};
+    std::atomic<std::uint64_t> records_enqueued{0};
+    std::atomic<std::uint64_t> records_written{0};
+    std::atomic<std::uint64_t> records_dropped_stopped{0};
+    std::atomic<std::uint64_t> records_dropped_stale_generation{0};
+    std::atomic<std::uint64_t> records_dropped_oversized{0};
+    std::atomic<std::uint64_t> records_dropped_queue_full{0};
+    std::atomic<std::uint64_t> records_dropped_after_fault{0};
+
+    std::atomic<std::uint64_t> chunks_enqueued{0};
+    std::atomic<std::uint64_t> chunks_written{0};
+    std::atomic<std::uint64_t> chunks_dropped{0};
+
+    std::atomic<std::uint64_t> resident_chunks{0};
+    std::atomic<std::uint64_t> resident_records{0};
+    std::atomic<std::uint64_t> resident_bytes{0};
+    std::atomic<std::uint64_t> high_water_chunks{0};
+    std::atomic<std::uint64_t> high_water_records{0};
+    std::atomic<std::uint64_t> high_water_bytes{0};
+
+    std::atomic<std::uint64_t> file_bytes_written{0};
+    std::atomic<std::uint64_t> flush_completed{0};
+    std::atomic<std::uint64_t> flush_failed{0};
+    std::atomic<std::uint64_t> io_faults{0};
+
+    void Reset() noexcept {
+        records_committed.store(0, std::memory_order_relaxed);
+        records_enqueued.store(0, std::memory_order_relaxed);
+        records_written.store(0, std::memory_order_relaxed);
+        records_dropped_stopped.store(0, std::memory_order_relaxed);
+        records_dropped_stale_generation.store(0, std::memory_order_relaxed);
+        records_dropped_oversized.store(0, std::memory_order_relaxed);
+        records_dropped_queue_full.store(0, std::memory_order_relaxed);
+        records_dropped_after_fault.store(0, std::memory_order_relaxed);
+        chunks_enqueued.store(0, std::memory_order_relaxed);
+        chunks_written.store(0, std::memory_order_relaxed);
+        chunks_dropped.store(0, std::memory_order_relaxed);
+        resident_chunks.store(0, std::memory_order_relaxed);
+        resident_records.store(0, std::memory_order_relaxed);
+        resident_bytes.store(0, std::memory_order_relaxed);
+        high_water_chunks.store(0, std::memory_order_relaxed);
+        high_water_records.store(0, std::memory_order_relaxed);
+        high_water_bytes.store(0, std::memory_order_relaxed);
+        file_bytes_written.store(0, std::memory_order_relaxed);
+        flush_completed.store(0, std::memory_order_relaxed);
+        flush_failed.store(0, std::memory_order_relaxed);
+        io_faults.store(0, std::memory_order_relaxed);
+    }
+};
+
+struct TestHooks {
+    Testing::FaultPoint fault_point{Testing::FaultPoint::None};
+    std::uint64_t       trigger_hit{1};
+    std::uint64_t       matching_hits{0};
+    bool                fault_fired{false};
+    bool                pause_before_temp_open{false};
+    bool                pause_after_start{false};
+    bool                writer_paused{false};
+    bool                writer_resume{false};
+};
+
+struct PendingLossSlot {
+    bool          pending{false};
+    std::uint64_t generation{0};
+    LossNotice    notice{};
+};
+
+struct Hub {
+    std::mutex              lifecycle_mutex{};
+    std::mutex              worker_join_mutex{};
+    std::mutex              mutex{};
+    std::condition_variable work_cv{};
+    std::condition_variable start_cv{};
+    std::condition_variable test_cv{};
+    std::condition_variable emitter_cv{};
+
+    std::atomic<RuntimeState>  state{RuntimeState::Stopped};
+    std::atomic<RuntimeFault>  last_fault{RuntimeFault::None};
+    std::atomic<std::uint64_t> generation{0};
+    std::uint64_t              generation_counter{0};
+
+    RuntimeConfig             config{};
+    std::filesystem::path     temp_path{};
+    std::deque<WriterMessage> messages{};
+    bool                      file_dirty{false};
+    PendingLossSlot           pending_loss{};
+
+    std::atomic<std::shared_ptr<Admission>>       admission{};
+    std::atomic<std::shared_ptr<const SchemaMap>> schemas{std::make_shared<const SchemaMap>()};
+    std::size_t                                   schema_bytes{0};
+
+    std::jthread                worker{};
+    bool                        start_complete{false};
+    StartResult                 start_result{StartResult::FileOpenFailed};
+    std::shared_ptr<FlushFence> shutdown_fence{};
+    std::shared_ptr<FlushFence> active_flush_fence{};
+    // Protected by mutex. Keeps a closing generation alive after admission is
+    // unpublished so Shutdown can wait for every already-admitted Emit call.
+    std::shared_ptr<Admission> retired_admission{};
+
+    AtomicStats stats{};
+    TestHooks   test_hooks{};
+};
+
+Hub& GetHub() {
+    // Intentionally leaked. A TLS shard may be destroyed after ordinary
+    // function-local statics; the process hub must remain a valid publication
+    // target until the last producer thread exits.
+    static Hub* hub = new Hub();
+    return *hub;
+}
+
+enum class PublishResult : std::uint8_t {
+    Nothing,
+    Accepted,
+    QueueFull,
+    Rejected,
+    Faulted,
+    Stale,
+};
+
+struct ThreadLocalShard {
+    std::uint64_t              generation{0};
+    std::vector<PendingRecord> records{};
+    std::size_t                payload_bytes{0};
+
+    ~ThreadLocalShard();
+};
+
+thread_local ThreadLocalShard g_tls_shard{};
+
+void UpdateHighWater(std::atomic<std::uint64_t>& _counter, std::uint64_t _value) noexcept {
+    std::uint64_t observed = _counter.load(std::memory_order_relaxed);
+    while (observed < _value && !_counter.compare_exchange_weak(
+                                    observed, _value, std::memory_order_relaxed, std::memory_order_relaxed
+                                )) {
+    }
+}
+
+std::uint64_t SaturatingAdd(std::uint64_t _lhs, std::uint64_t _rhs) noexcept {
+    constexpr std::uint64_t max = std::numeric_limits<std::uint64_t>::max();
+    return _rhs > max - _lhs ? max : _lhs + _rhs;
+}
+
+bool WouldExceedLimit(std::uint64_t _resident, std::uint64_t _additional, std::uint64_t _limit) noexcept {
+    return _resident > _limit || _additional > _limit - _resident;
+}
+
+std::uint64_t RecordValueBytes(const PendingRecord& _record) noexcept {
+    constexpr std::size_t record_prefix_bytes = sizeof(std::uint64_t) * 2 + sizeof(std::uint32_t);
+    return _record.payload.size() > record_prefix_bytes ?
+               static_cast<std::uint64_t>(_record.payload.size() - record_prefix_bytes) :
+               0;
+}
+
+std::uint64_t EncodedRecordValueBytes(std::span<const std::uint8_t> _payload) noexcept {
+    constexpr std::size_t record_prefix_bytes = sizeof(std::uint64_t) * 2 + sizeof(std::uint32_t);
+    return _payload.size() > record_prefix_bytes ?
+               static_cast<std::uint64_t>(_payload.size() - record_prefix_bytes) :
+               0;
+}
+
+std::uint64_t EstimateValueBytes(std::span<const FieldValueView> _values) noexcept {
+    std::uint64_t bytes = 0;
+    for (const FieldValueView& value : _values) {
+        const std::uint64_t field_bytes = std::visit(
+            [](const auto& field) -> std::uint64_t {
+                using FieldT = std::decay_t<decltype(field)>;
+                if constexpr (std::is_same_v<FieldT, bool>) {
+                    return 1;
+                } else if constexpr (std::is_same_v<FieldT, std::string_view>) {
+                    return SaturatingAdd(sizeof(std::uint32_t), static_cast<std::uint64_t>(field.size()));
+                } else {
+                    return sizeof(FieldT);
+                }
+            },
+            value
+        );
+        bytes = SaturatingAdd(bytes, field_bytes);
+    }
+    return bytes;
+}
+
+void AccumulateLossLocked(
+    Hub&          _hub,
+    std::uint64_t _generation,
+    std::uint64_t _first_sequence,
+    std::uint64_t _last_sequence,
+    std::uint64_t _record_count,
+    std::uint64_t _value_bytes,
+    LossReason    _reason
+) noexcept {
+    if (_record_count == 0 || _hub.state.load(std::memory_order_acquire) != RuntimeState::Running ||
+        _generation != _hub.generation.load(std::memory_order_acquire)) {
+        return;
+    }
+
+    PendingLossSlot& slot = _hub.pending_loss;
+    if (!slot.pending || slot.generation != _generation) {
+        slot.pending    = true;
+        slot.generation = _generation;
+        slot.notice     = LossNotice{
+                .first_sequence = _first_sequence,
+                .last_sequence  = _last_sequence,
+                .record_count   = _record_count,
+                .value_bytes    = _value_bytes,
+                .reason_mask    = static_cast<std::uint32_t>(_reason),
+        };
+        return;
+    }
+
+    slot.notice.first_sequence = std::min(slot.notice.first_sequence, _first_sequence);
+    slot.notice.last_sequence  = std::max(slot.notice.last_sequence, _last_sequence);
+    slot.notice.record_count   = SaturatingAdd(slot.notice.record_count, _record_count);
+    slot.notice.value_bytes    = SaturatingAdd(slot.notice.value_bytes, _value_bytes);
+    slot.notice.reason_mask |= static_cast<std::uint32_t>(_reason);
+}
+
+void AccumulateLoss(
+    std::uint64_t _generation,
+    std::uint64_t _first_sequence,
+    std::uint64_t _last_sequence,
+    std::uint64_t _record_count,
+    std::uint64_t _value_bytes,
+    LossReason    _reason
+) noexcept {
+    Hub& hub = GetHub();
+    {
+        std::lock_guard lock(hub.mutex);
+        AccumulateLossLocked(
+            hub, _generation, _first_sequence, _last_sequence, _record_count, _value_bytes, _reason
+        );
+    }
+    hub.work_cv.notify_one();
+}
+
+std::optional<LossNotice> TakePendingLossLocked(Hub& _hub, std::uint64_t _generation) noexcept {
+    if (!_hub.pending_loss.pending || _hub.pending_loss.generation != _generation) {
+        return std::nullopt;
+    }
+    LossNotice notice = _hub.pending_loss.notice;
+    _hub.pending_loss = {};
+    return notice;
+}
+
+void SignalFence(const std::shared_ptr<FlushFence>& _fence, FlushResult _result) noexcept {
+    if (!_fence) {
+        return;
+    }
+    {
+        std::lock_guard lock(_fence->mutex);
+        _fence->result   = _result;
+        _fence->complete = true;
+    }
+    _fence->cv.notify_all();
+}
+
+FlushResult WaitFence(const std::shared_ptr<FlushFence>& _fence) noexcept {
+    if (!_fence) {
+        return FlushResult::Rejected;
+    }
+    std::unique_lock lock(_fence->mutex);
+    _fence->cv.wait(lock, [&] {
+        return _fence->complete;
+    });
+    return _fence->result;
+}
+
+bool IsIoFault(RuntimeFault _fault) noexcept {
+    return _fault == RuntimeFault::OpenTempFile || _fault == RuntimeFault::WritePacket ||
+           _fault == RuntimeFault::FlushFile || _fault == RuntimeFault::CloseFile ||
+           _fault == RuntimeFault::RenameFinal;
+}
+
+bool ShouldInject(Testing::FaultPoint _point) noexcept {
+    Hub&            hub = GetHub();
+    std::lock_guard lock(hub.mutex);
+    TestHooks&      hooks = hub.test_hooks;
+    if (hooks.fault_point != _point || hooks.fault_fired) {
+        return false;
+    }
+    ++hooks.matching_hits;
+    if (hooks.matching_hits != std::max<std::uint64_t>(hooks.trigger_hit, 1)) {
+        return false;
+    }
+    hooks.fault_fired = true;
+    return true;
+}
+
+struct WriterFailure {
+    RuntimeFault fault{RuntimeFault::WriterException};
+};
+
+void InjectOrContinue(Testing::FaultPoint _point, RuntimeFault _fault) {
+    if (ShouldInject(_point)) {
+        throw WriterFailure{_fault};
+    }
+}
+
+void ResetShard(ThreadLocalShard& _shard) noexcept {
+    _shard.records.clear();
+    _shard.records.shrink_to_fit();
+    _shard.payload_bytes = 0;
+    _shard.generation    = 0;
+}
+
+void CountDroppedChunk(Hub& _hub, const ImmutableChunk& _chunk, PublishResult _reason) noexcept {
+    const std::uint64_t record_count = static_cast<std::uint64_t>(_chunk.records.size());
+    if (record_count == 0) {
+        return;
+    }
+    _hub.stats.chunks_dropped.fetch_add(1, std::memory_order_relaxed);
+    switch (_reason) {
+        case PublishResult::QueueFull:
+            _hub.stats.records_dropped_queue_full.fetch_add(record_count, std::memory_order_relaxed);
+            break;
+        case PublishResult::Faulted:
+            _hub.stats.records_dropped_after_fault.fetch_add(record_count, std::memory_order_relaxed);
+            break;
+        case PublishResult::Stale:
+            _hub.stats.records_dropped_stale_generation.fetch_add(record_count, std::memory_order_relaxed);
+            break;
+        default:
+            _hub.stats.records_dropped_stopped.fetch_add(record_count, std::memory_order_relaxed);
+            break;
+    }
+}
+
+PublishResult PublishTlsShard(ThreadLocalShard& _shard) noexcept {
+    if (_shard.records.empty()) {
+        return PublishResult::Nothing;
+    }
+
+    ImmutableChunk chunk{
+        .generation    = _shard.generation,
+        .records       = std::move(_shard.records),
+        .payload_bytes = _shard.payload_bytes,
+    };
+    if (!chunk.records.empty()) {
+        chunk.first_sequence = chunk.records.front().sequence;
+        chunk.last_sequence  = chunk.records.front().sequence;
+        for (const PendingRecord& record : chunk.records) {
+            chunk.first_sequence = std::min(chunk.first_sequence, record.sequence);
+            chunk.last_sequence  = std::max(chunk.last_sequence, record.sequence);
+            chunk.value_bytes    = SaturatingAdd(chunk.value_bytes, RecordValueBytes(record));
+        }
+    }
+    _shard.records       = {};
+    _shard.payload_bytes = 0;
+    _shard.generation    = 0;
+
+    Hub&          hub    = GetHub();
+    PublishResult result = PublishResult::Rejected;
+    {
+        std::lock_guard     lock(hub.mutex);
+        const RuntimeState  state      = hub.state.load(std::memory_order_acquire);
+        const std::uint64_t generation = hub.generation.load(std::memory_order_acquire);
+
+        if (state == RuntimeState::Faulted) {
+            result = PublishResult::Faulted;
+        } else if (chunk.generation != generation || chunk.generation == 0) {
+            result = PublishResult::Stale;
+        } else if (state != RuntimeState::Running) {
+            result = PublishResult::Rejected;
+        } else {
+            const std::uint64_t resident_chunks  = hub.stats.resident_chunks.load(std::memory_order_relaxed);
+            const std::uint64_t resident_records = hub.stats.resident_records.load(std::memory_order_relaxed);
+            const std::uint64_t resident_bytes   = hub.stats.resident_bytes.load(std::memory_order_relaxed);
+            const std::uint64_t chunk_records    = static_cast<std::uint64_t>(chunk.records.size());
+            const std::uint64_t chunk_bytes      = static_cast<std::uint64_t>(chunk.payload_bytes);
+
+            const bool full =
+                WouldExceedLimit(
+                    resident_chunks, 1, static_cast<std::uint64_t>(hub.config.queue_max_chunks)
+                ) ||
+                WouldExceedLimit(
+                    resident_records, chunk_records, static_cast<std::uint64_t>(hub.config.queue_max_records)
+                ) ||
+                WouldExceedLimit(
+                    resident_bytes, chunk_bytes, static_cast<std::uint64_t>(hub.config.queue_max_bytes)
+                );
+            if (full) {
+                result = PublishResult::QueueFull;
+            } else {
+                try {
+                    hub.messages.emplace_back(std::move(chunk));
+                    hub.stats.resident_chunks.store(resident_chunks + 1, std::memory_order_relaxed);
+                    hub.stats.resident_records.store(
+                        resident_records + chunk_records, std::memory_order_relaxed
+                    );
+                    hub.stats.resident_bytes.store(resident_bytes + chunk_bytes, std::memory_order_relaxed);
+                    UpdateHighWater(hub.stats.high_water_chunks, resident_chunks + 1);
+                    UpdateHighWater(hub.stats.high_water_records, resident_records + chunk_records);
+                    UpdateHighWater(hub.stats.high_water_bytes, resident_bytes + chunk_bytes);
+                    hub.stats.records_enqueued.fetch_add(chunk_records, std::memory_order_relaxed);
+                    hub.stats.chunks_enqueued.fetch_add(1, std::memory_order_relaxed);
+                    result = PublishResult::Accepted;
+                } catch (...) {
+                    result = PublishResult::QueueFull;
+                }
+            }
+        }
+        if (result == PublishResult::QueueFull) {
+            AccumulateLossLocked(
+                hub,
+                chunk.generation,
+                chunk.first_sequence,
+                chunk.last_sequence,
+                static_cast<std::uint64_t>(chunk.records.size()),
+                chunk.value_bytes,
+                LossReason::QueueFull
+            );
+        }
+    }
+
+    if (result == PublishResult::Accepted) {
+        hub.work_cv.notify_one();
+    } else {
+        CountDroppedChunk(hub, chunk, result);
+        if (result == PublishResult::QueueFull) {
+            hub.work_cv.notify_one();
+        }
+    }
+    return result;
+}
+
+ThreadLocalShard::~ThreadLocalShard() {
+    (void)PublishTlsShard(*this);
+}
+
+std::shared_ptr<Admission> AcquireEmitter(Hub& _hub) noexcept {
+    const auto candidate = _hub.admission.load(std::memory_order_acquire);
+    if (!candidate) {
+        return {};
+    }
+
+    std::lock_guard lock(_hub.mutex);
+    const auto      current = _hub.admission.load(std::memory_order_acquire);
+    if (current != candidate || _hub.state.load(std::memory_order_acquire) != RuntimeState::Running ||
+        candidate->closing) {
+        return {};
+    }
+    ++candidate->active_emitters;
+    return candidate;
+}
+
+EmitStatus ReleaseEmitter(const std::shared_ptr<Admission>& _admission, EmitStatus _result) noexcept {
+    Hub& hub           = GetHub();
+    bool force_publish = false;
+    {
+        std::lock_guard lock(hub.mutex);
+        if (_admission->active_emitters == 0) {
+            return _result;
+        }
+        if (!_admission->closing) {
+            --_admission->active_emitters;
+            if (_admission->active_emitters == 0) {
+                hub.emitter_cv.notify_all();
+            }
+            return _result;
+        }
+        // Keep this emitter active while publishing. Shutdown leaves the hub
+        // in Running and waits for active_emitters to reach zero, so the
+        // sub-threshold TLS chunk remains admissible before Finalize.
+        force_publish = true;
+    }
+
+    const PublishResult publish_result =
+        force_publish ? PublishTlsShard(g_tls_shard) : PublishResult::Nothing;
+
+    {
+        std::lock_guard lock(hub.mutex);
+        if (_admission->active_emitters > 0) {
+            --_admission->active_emitters;
+        }
+        if (_admission->active_emitters == 0) {
+            hub.emitter_cv.notify_all();
+        }
+    }
+
+    if (_result != EmitStatus::Accepted || publish_result == PublishResult::Nothing ||
+        publish_result == PublishResult::Accepted) {
+        return _result;
+    }
+    if (publish_result == PublishResult::QueueFull) {
+        return EmitStatus::QueueFull;
+    }
+    if (publish_result == PublishResult::Faulted) {
+        return EmitStatus::SinkFault;
+    }
+    return EmitStatus::Disabled;
+}
+
+void DecrementResidentLocked(Hub& _hub, const ImmutableChunk& _chunk) noexcept {
+    const std::uint64_t records = static_cast<std::uint64_t>(_chunk.records.size());
+    const std::uint64_t bytes   = static_cast<std::uint64_t>(_chunk.payload_bytes);
+    _hub.stats.resident_chunks.fetch_sub(1, std::memory_order_relaxed);
+    _hub.stats.resident_records.fetch_sub(records, std::memory_order_relaxed);
+    _hub.stats.resident_bytes.fetch_sub(bytes, std::memory_order_relaxed);
+}
+
+void CountChunkAfterFault(
+    Hub&                  _hub,
+    const ImmutableChunk& _chunk,
+    std::size_t           _records_already_written
+) noexcept {
+    const std::size_t total = _chunk.records.size();
+    if (_records_already_written < total) {
+        _hub.stats.records_dropped_after_fault.fetch_add(
+            static_cast<std::uint64_t>(total - _records_already_written), std::memory_order_relaxed
+        );
+    }
+    _hub.stats.chunks_dropped.fetch_add(1, std::memory_order_relaxed);
+}
+
+void CloseFileNoThrow(std::FILE*& _stream) noexcept {
+    if (_stream) {
+        std::FILE* closing = std::exchange(_stream, nullptr);
+        static_cast<void>(std::fclose(closing));
+    }
+}
+
+std::FILE* OpenTempFileExclusive(const std::filesystem::path& _path) noexcept {
+#if PLATFORM_WINDOWS
+    std::FILE* stream = nullptr;
+    return ::_wfopen_s(&stream, _path.c_str(), L"wbx") == 0 ? stream : nullptr;
+#else
+    return std::fopen(_path.c_str(), "wbx");
+#endif
+}
+
+void FailWriter(
+    Hub&                          _hub,
+    RuntimeFault                  _fault,
+    std::optional<WriterMessage>& _current,
+    std::size_t                   _records_already_written,
+    std::FILE*&                   _stream
+) noexcept {
+    CloseFileNoThrow(_stream);
+
+    {
+        std::lock_guard lock(_hub.mutex);
+        const auto      fault_admission = _hub.admission.load(std::memory_order_acquire);
+        if (fault_admission) {
+            fault_admission->closing = true;
+            _hub.retired_admission   = fault_admission;
+        }
+        _hub.admission.store({}, std::memory_order_release);
+        _hub.state.store(RuntimeState::Faulted, std::memory_order_release);
+        _hub.last_fault.store(_fault, std::memory_order_release);
+        _hub.file_dirty = false;
+        if (IsIoFault(_fault)) {
+            _hub.stats.io_faults.fetch_add(1, std::memory_order_relaxed);
+        }
+
+        auto reject_message = [&](WriterMessage& message, bool current) {
+            if (auto* chunk = std::get_if<ImmutableChunk>(&message)) {
+                CountChunkAfterFault(_hub, *chunk, current ? _records_already_written : 0);
+                DecrementResidentLocked(_hub, *chunk);
+            } else if (auto* flush = std::get_if<FlushMessage>(&message)) {
+                _hub.stats.flush_failed.fetch_add(1, std::memory_order_relaxed);
+                SignalFence(flush->fence, FlushResult::Faulted);
+            } else if (auto* finalize = std::get_if<FinalizeMessage>(&message)) {
+                _hub.stats.flush_failed.fetch_add(1, std::memory_order_relaxed);
+                SignalFence(finalize->fence, FlushResult::Faulted);
+            }
+        };
+
+        if (_current) {
+            reject_message(*_current, true);
+        }
+        while (!_hub.messages.empty()) {
+            WriterMessage message = std::move(_hub.messages.front());
+            _hub.messages.pop_front();
+            reject_message(message, false);
+        }
+        _hub.active_flush_fence.reset();
+    }
+
+    _hub.work_cv.notify_all();
+    _hub.test_cv.notify_all();
+    _hub.emitter_cv.notify_all();
+}
+
+void WritePacketChecked(
+    Hub&                          _hub,
+    std::FILE*                    _stream,
+    PacketType                    _type,
+    std::uint64_t&                _packet_index,
+    std::span<const std::uint8_t> _payload
+) {
+    InjectOrContinue(Testing::FaultPoint::WritePacket, RuntimeFault::WritePacket);
+
+    Array<std::uint8_t> packet;
+    if (WrapPacket(_type, _packet_index++, _payload, _hub.config.codec_limits, packet) != EncodeStatus::Ok) {
+        throw WriterFailure{RuntimeFault::WriterException};
+    }
+
+    const std::size_t written = std::fwrite(packet.data(), 1, packet.size(), _stream);
+    if (written != packet.size() || std::ferror(_stream) != 0) {
+        throw WriterFailure{RuntimeFault::WritePacket};
+    }
+    _hub.stats.file_bytes_written.fetch_add(
+        static_cast<std::uint64_t>(packet.size()), std::memory_order_relaxed
+    );
+}
+
+void WriteLossChecked(Hub& _hub, std::FILE* _stream, std::uint64_t& _packet_index, const LossNotice& _loss) {
+    Array<std::uint8_t> loss_payload;
+    EncodeLossPayload(_loss, loss_payload);
+    WritePacketChecked(_hub, _stream, PacketType::Loss, _packet_index, loss_payload);
+    std::lock_guard lock(_hub.mutex);
+    _hub.file_dirty = true;
+}
+
+void FlushFileChecked(std::FILE* _stream) {
+    InjectOrContinue(Testing::FaultPoint::FlushFile, RuntimeFault::FlushFile);
+    if (std::fflush(_stream) != 0) {
+        throw WriterFailure{RuntimeFault::FlushFile};
+    }
+}
+
+void CloseFileChecked(std::FILE*& _stream) {
+    InjectOrContinue(Testing::FaultPoint::CloseFile, RuntimeFault::CloseFile);
+    std::FILE* closing = std::exchange(_stream, nullptr);
+    if (!closing || std::fclose(closing) != 0) {
+        throw WriterFailure{RuntimeFault::CloseFile};
+    }
+}
+
+void RenameFinalChecked(Hub& _hub) {
+    InjectOrContinue(Testing::FaultPoint::RenameFinal, RuntimeFault::RenameFinal);
+#if PLATFORM_WINDOWS
+    DWORD flags = MOVEFILE_WRITE_THROUGH;
+    if (_hub.config.replace_existing) {
+        flags |= MOVEFILE_REPLACE_EXISTING;
+    }
+    if (!::MoveFileExW(_hub.temp_path.c_str(), _hub.config.output_path.c_str(), flags)) {
+        throw WriterFailure{RuntimeFault::RenameFinal};
+    }
+#else
+    if (_hub.config.replace_existing) {
+        std::error_code error;
+        std::filesystem::rename(_hub.temp_path, _hub.config.output_path, error);
+        if (error) {
+            throw WriterFailure{RuntimeFault::RenameFinal};
+        }
+    } else {
+        // POSIX link() creates the final name atomically and fails with
+        // EEXIST instead of replacing a concurrently-created final. The temp
+        // and final live in the same directory, so they are on one filesystem.
+        if (::link(_hub.temp_path.c_str(), _hub.config.output_path.c_str()) != 0) {
+            throw WriterFailure{RuntimeFault::RenameFinal};
+        }
+        // Publication already succeeded. A best-effort unlink avoids turning
+        // a cleanup-only failure into a false capture failure with a visible
+        // valid final.
+        static_cast<void>(::unlink(_hub.temp_path.c_str()));
+    }
+#endif
+}
+
+void SignalStartFailure(Hub& _hub, RuntimeFault _fault, StartResult _result, std::FILE*& _stream) noexcept {
+    const bool owns_temp = _stream != nullptr;
+    CloseFileNoThrow(_stream);
+    if (owns_temp) {
+        std::error_code ignored;
+        std::filesystem::remove(_hub.temp_path, ignored);
+    }
+
+    {
+        std::lock_guard lock(_hub.mutex);
+        _hub.admission.store({}, std::memory_order_release);
+        _hub.state.store(RuntimeState::Stopped, std::memory_order_release);
+        _hub.last_fault.store(_fault, std::memory_order_release);
+        if (IsIoFault(_fault)) {
+            _hub.stats.io_faults.fetch_add(1, std::memory_order_relaxed);
+        }
+        _hub.start_result   = _result;
+        _hub.start_complete = true;
+    }
+    _hub.start_cv.notify_all();
+}
+
+std::uint64_t DroppedRecordCount(const Hub& _hub) noexcept {
+    return _hub.stats.records_dropped_stopped.load(std::memory_order_relaxed) +
+           _hub.stats.records_dropped_stale_generation.load(std::memory_order_relaxed) +
+           _hub.stats.records_dropped_oversized.load(std::memory_order_relaxed) +
+           _hub.stats.records_dropped_queue_full.load(std::memory_order_relaxed) +
+           _hub.stats.records_dropped_after_fault.load(std::memory_order_relaxed);
+}
+
+void WriterMain(Hub& _hub, std::shared_ptr<Admission> _session_admission) noexcept {
+    Platform::SetCurrentThreadName("Moer ProfileDump Writer");
+
+    std::FILE*    stream       = nullptr;
+    std::uint64_t packet_index = 0;
+    try {
+        InjectOrContinue(Testing::FaultPoint::OpenTempFile, RuntimeFault::OpenTempFile);
+        const std::filesystem::path parent = _hub.temp_path.parent_path();
+        if (!parent.empty()) {
+            std::error_code directory_error;
+            std::filesystem::create_directories(parent, directory_error);
+            if (directory_error) {
+                throw WriterFailure{RuntimeFault::OpenTempFile};
+            }
+        }
+        {
+            std::unique_lock lock(_hub.mutex);
+            if (_hub.test_hooks.pause_before_temp_open) {
+                _hub.test_hooks.writer_paused = true;
+                _hub.test_cv.notify_all();
+                _hub.test_cv.wait(lock, [&] {
+                    return _hub.test_hooks.writer_resume ||
+                           _hub.state.load(std::memory_order_acquire) != RuntimeState::Starting;
+                });
+                _hub.test_hooks.writer_paused = false;
+            }
+        }
+        stream = OpenTempFileExclusive(_hub.temp_path);
+        if (!stream) {
+            throw WriterFailure{RuntimeFault::OpenTempFile};
+        }
+
+        Array<std::uint8_t> session_payload;
+        const auto          now = std::chrono::system_clock::now().time_since_epoch();
+        EncodeSessionBeginPayload(
+            SessionBeginInfo{
+                .generation      = _hub.generation.load(std::memory_order_acquire),
+                .started_unix_ns = static_cast<std::uint64_t>(
+                    std::chrono::duration_cast<std::chrono::nanoseconds>(now).count()
+                ),
+            },
+            session_payload
+        );
+        WritePacketChecked(_hub, stream, PacketType::SessionBegin, packet_index, session_payload);
+    } catch (const WriterFailure& failure) {
+        SignalStartFailure(_hub, failure.fault, StartResult::FileOpenFailed, stream);
+        return;
+    } catch (const std::bad_alloc&) {
+        SignalStartFailure(_hub, RuntimeFault::WriterException, StartResult::ResourceExhausted, stream);
+        return;
+    } catch (...) {
+        SignalStartFailure(_hub, RuntimeFault::WriterException, StartResult::FileOpenFailed, stream);
+        return;
+    }
+
+    {
+        std::lock_guard lock(_hub.mutex);
+        _hub.file_dirty = true;
+        _hub.state.store(RuntimeState::Running, std::memory_order_release);
+        _hub.admission.store(std::move(_session_admission), std::memory_order_release);
+        _hub.start_result   = StartResult::Started;
+        _hub.start_complete = true;
+    }
+    _hub.start_cv.notify_all();
+
+    {
+        std::unique_lock lock(_hub.mutex);
+        if (_hub.test_hooks.pause_after_start) {
+            _hub.test_hooks.writer_paused = true;
+            _hub.test_cv.notify_all();
+            _hub.test_cv.wait(lock, [&] {
+                const RuntimeState state = _hub.state.load(std::memory_order_acquire);
+                return _hub.test_hooks.writer_resume || state == RuntimeState::Draining ||
+                       state == RuntimeState::Faulted;
+            });
+            _hub.test_hooks.writer_paused = false;
+        }
+    }
+
+    std::unordered_set<std::uint64_t> emitted_schemas;
+    for (;;) {
+        std::optional<WriterMessage> current;
+        std::optional<LossNotice>    pending_loss;
+        std::size_t                  records_written_from_current = 0;
+        try {
+            InjectOrContinue(Testing::FaultPoint::WriterException, RuntimeFault::WriterException);
+
+            {
+                std::unique_lock lock(_hub.mutex);
+                _hub.work_cv.wait(lock, [&] {
+                    return !_hub.messages.empty() || _hub.pending_loss.pending ||
+                           _hub.state.load(std::memory_order_acquire) == RuntimeState::Faulted;
+                });
+                if (_hub.messages.empty() && !_hub.pending_loss.pending) {
+                    return;
+                }
+                pending_loss = TakePendingLossLocked(_hub, _hub.generation.load(std::memory_order_acquire));
+                if (pending_loss) {
+                    // A concurrent FlushAll must observe work in flight even
+                    // after the fixed loss slot has been atomically taken.
+                    _hub.file_dirty = true;
+                }
+                if (!_hub.messages.empty()) {
+                    current.emplace(std::move(_hub.messages.front()));
+                    _hub.messages.pop_front();
+                    if (auto* flush = std::get_if<FlushMessage>(&*current)) {
+                        _hub.active_flush_fence = flush->fence;
+                    }
+                }
+            }
+
+            // Loss has one fixed process slot. The writer atomically takes
+            // the current aggregate before each queued message and writes it
+            // first. Sequence bounds describe the observed dropped interval;
+            // they do not impose a total order on TLS chunks that publish
+            // later with an older reserved sequence.
+            if (pending_loss) {
+                WriteLossChecked(_hub, stream, packet_index, *pending_loss);
+            }
+            if (!current) {
+                continue;
+            }
+
+            if (auto* chunk = std::get_if<ImmutableChunk>(&*current)) {
+                const auto schemas = _hub.schemas.load(std::memory_order_acquire);
+                for (const PendingRecord& record : chunk->records) {
+                    const auto schema_it = schemas->find(record.schema_hash);
+                    if (schema_it == schemas->end()) {
+                        throw WriterFailure{RuntimeFault::WriterException};
+                    }
+
+                    if (!emitted_schemas.contains(record.schema_hash)) {
+                        Array<std::uint8_t> schema_payload;
+                        if (EncodeSchemaPayload(
+                                schema_it->second->descriptor, _hub.config.codec_limits, schema_payload
+                            ) != EncodeStatus::Ok) {
+                            throw WriterFailure{RuntimeFault::WriterException};
+                        }
+                        WritePacketChecked(_hub, stream, PacketType::Schema, packet_index, schema_payload);
+                        emitted_schemas.emplace(record.schema_hash);
+                    }
+
+                    WritePacketChecked(_hub, stream, PacketType::Record, packet_index, record.payload);
+                    ++records_written_from_current;
+                    _hub.stats.records_written.fetch_add(1, std::memory_order_relaxed);
+                }
+
+                {
+                    std::lock_guard lock(_hub.mutex);
+                    DecrementResidentLocked(_hub, *chunk);
+                    _hub.file_dirty = true;
+                }
+                _hub.stats.chunks_written.fetch_add(1, std::memory_order_relaxed);
+                current.reset();
+                continue;
+            }
+
+            if (auto* flush = std::get_if<FlushMessage>(&*current)) {
+                FlushFileChecked(stream);
+                {
+                    std::lock_guard lock(_hub.mutex);
+                    _hub.file_dirty = false;
+                    if (_hub.active_flush_fence == flush->fence) {
+                        _hub.active_flush_fence.reset();
+                    }
+                }
+                _hub.stats.flush_completed.fetch_add(1, std::memory_order_relaxed);
+                SignalFence(flush->fence, FlushResult::Completed);
+                current.reset();
+                continue;
+            }
+
+            auto* finalize = std::get_if<FinalizeMessage>(&*current);
+            if (!finalize) {
+                throw WriterFailure{RuntimeFault::WriterException};
+            }
+
+            // Admission is closed before Finalize is enqueued. Drain the
+            // single slot once more immediately before SessionEnd so every
+            // clean-session loss published before the shutdown linearization
+            // point is represented in the file.
+            std::optional<LossNotice> final_loss;
+            {
+                std::lock_guard lock(_hub.mutex);
+                final_loss = TakePendingLossLocked(_hub, _hub.generation.load(std::memory_order_acquire));
+            }
+            if (final_loss) {
+                WriteLossChecked(_hub, stream, packet_index, *final_loss);
+            }
+
+            Array<std::uint8_t> end_payload;
+            EncodeSessionEndPayload(
+                SessionEndInfo{
+                    .generation      = _hub.generation.load(std::memory_order_acquire),
+                    .records_written = _hub.stats.records_written.load(std::memory_order_relaxed),
+                    .records_dropped = DroppedRecordCount(_hub),
+                },
+                end_payload
+            );
+            WritePacketChecked(_hub, stream, PacketType::SessionEnd, packet_index, end_payload);
+            FlushFileChecked(stream);
+            CloseFileChecked(stream);
+            RenameFinalChecked(_hub);
+
+            {
+                std::lock_guard lock(_hub.mutex);
+                _hub.file_dirty = false;
+                _hub.state.store(RuntimeState::Stopped, std::memory_order_release);
+            }
+            _hub.stats.flush_completed.fetch_add(1, std::memory_order_relaxed);
+            SignalFence(finalize->fence, FlushResult::Completed);
+            _hub.work_cv.notify_all();
+            return;
+        } catch (const WriterFailure& failure) {
+            FailWriter(_hub, failure.fault, current, records_written_from_current, stream);
+            return;
+        } catch (...) {
+            FailWriter(_hub, RuntimeFault::WriterException, current, records_written_from_current, stream);
+            return;
+        }
+    }
+}
+
+bool ValidateConfig(const RuntimeConfig& _config) noexcept {
+    if (_config.output_path.empty() || _config.max_schemas == 0 || _config.max_schema_bytes == 0 ||
+        _config.max_record_bytes == 0 || _config.tls_publish_records == 0 || _config.tls_publish_bytes == 0 ||
+        _config.tls_max_records == 0 || _config.tls_max_bytes == 0 || _config.queue_max_chunks == 0 ||
+        _config.queue_max_records == 0 || _config.queue_max_bytes == 0) {
+        return false;
+    }
+    if (_config.tls_publish_records > _config.tls_max_records ||
+        _config.tls_publish_bytes > _config.tls_max_bytes ||
+        _config.max_record_bytes > _config.tls_max_bytes ||
+        _config.max_record_bytes > _config.queue_max_bytes ||
+        _config.tls_max_records > _config.queue_max_records ||
+        _config.tls_max_bytes > _config.queue_max_bytes ||
+        _config.max_record_bytes > _config.codec_limits.max_packet_payload_bytes ||
+        _config.codec_limits.max_fields == 0 || _config.codec_limits.max_string_bytes == 0 ||
+        _config.codec_limits.max_packet_payload_bytes == 0) {
+        return false;
+    }
+    return true;
+}
+
+void ReapWorker(Hub& _hub) noexcept {
+    std::lock_guard join_lock(_hub.worker_join_mutex);
+    if (_hub.worker.joinable()) {
+        _hub.worker.join();
+    }
+}
+
+EmitStatus MapEncodeStatus(EncodeStatus _status) noexcept {
+    switch (_status) {
+        case EncodeStatus::Ok:
+            return EmitStatus::Accepted;
+        case EncodeStatus::ValueCountMismatch:
+            return EmitStatus::ValueCountMismatch;
+        case EncodeStatus::ValueTypeMismatch:
+            return EmitStatus::ValueTypeMismatch;
+        case EncodeStatus::StringTooLarge:
+            return EmitStatus::StringTooLarge;
+        case EncodeStatus::PayloadTooLarge:
+            return EmitStatus::RecordTooLarge;
+        default:
+            return EmitStatus::InvalidHandle;
+    }
+}
+
+FlushResult PublishResultToFlush(PublishResult _result) noexcept {
+    switch (_result) {
+        case PublishResult::Nothing:
+            return FlushResult::NothingPending;
+        case PublishResult::Accepted:
+            return FlushResult::Completed;
+        case PublishResult::Faulted:
+            return FlushResult::Faulted;
+        default:
+            return FlushResult::Rejected;
+    }
+}
+
+} // namespace
+
+StartResult Start(const RuntimeConfig& _config) noexcept {
+    try {
+        Hub&            hub = GetHub();
+        std::lock_guard lifecycle_lock(hub.lifecycle_mutex);
+
+        const RuntimeState initial_state = hub.state.load(std::memory_order_acquire);
+        if (initial_state == RuntimeState::Running) {
+            return StartResult::AlreadyRunning;
+        }
+        if (initial_state != RuntimeState::Stopped) {
+            return StartResult::Busy;
+        }
+        if (!ValidateConfig(_config)) {
+            return StartResult::InvalidConfig;
+        }
+
+        ReapWorker(hub);
+
+        if (ShouldInject(Testing::FaultPoint::StartAllocation)) {
+            throw std::bad_alloc{};
+        }
+        RuntimeConfig         prepared_config = _config;
+        std::filesystem::path temp_path       = prepared_config.output_path;
+        temp_path += ".inprogress";
+        auto initial_schemas      = std::make_shared<const SchemaMap>();
+        auto session_admission    = std::make_shared<Admission>();
+        session_admission->config = prepared_config;
+
+        std::error_code error;
+        const bool      final_exists = std::filesystem::exists(prepared_config.output_path, error);
+        if (error) {
+            return StartResult::FileOpenFailed;
+        }
+        const bool temp_exists = std::filesystem::exists(temp_path, error);
+        if (error) {
+            return StartResult::FileOpenFailed;
+        }
+        if (!prepared_config.replace_existing && (final_exists || temp_exists)) {
+            return StartResult::OutputExists;
+        }
+        // A stale/incomplete temp capture may be discarded for an explicit
+        // replacement. Keep the previous valid final until the new writer has
+        // closed successfully and can atomically publish over it.
+        if (prepared_config.replace_existing && temp_exists) {
+            std::filesystem::remove(temp_path, error);
+            if (error) {
+                return StartResult::FileOpenFailed;
+            }
+        }
+
+        {
+            std::lock_guard lock(hub.mutex);
+            hub.config    = std::move(prepared_config);
+            hub.temp_path = std::move(temp_path);
+            hub.messages.clear();
+            hub.file_dirty   = false;
+            hub.pending_loss = {};
+            hub.schema_bytes = 0;
+            hub.shutdown_fence.reset();
+            hub.active_flush_fence.reset();
+            hub.retired_admission.reset();
+            hub.start_complete = false;
+            hub.start_result   = StartResult::FileOpenFailed;
+            hub.stats.Reset();
+            hub.last_fault.store(RuntimeFault::None, std::memory_order_release);
+            const std::uint64_t generation = ++hub.generation_counter;
+            session_admission->generation  = generation;
+            hub.generation.store(generation, std::memory_order_release);
+            hub.schemas.store(std::move(initial_schemas), std::memory_order_release);
+            hub.admission.store({}, std::memory_order_release);
+            hub.test_hooks.matching_hits = 0;
+            hub.test_hooks.fault_fired   = false;
+            hub.test_hooks.writer_paused = false;
+            hub.test_hooks.writer_resume = false;
+            hub.state.store(RuntimeState::Starting, std::memory_order_release);
+        }
+
+        if (ShouldInject(Testing::FaultPoint::BeforeThreadCreate)) {
+            hub.state.store(RuntimeState::Stopped, std::memory_order_release);
+            return StartResult::ThreadCreateFailed;
+        }
+
+        try {
+            hub.worker = std::jthread([&hub, admission = std::move(session_admission)]() mutable {
+                WriterMain(hub, std::move(admission));
+            });
+        } catch (...) {
+            hub.state.store(RuntimeState::Stopped, std::memory_order_release);
+            return StartResult::ThreadCreateFailed;
+        }
+
+        StartResult result = StartResult::FileOpenFailed;
+        {
+            std::unique_lock lock(hub.mutex);
+            hub.start_cv.wait(lock, [&] {
+                return hub.start_complete;
+            });
+            result = hub.start_result;
+        }
+        if (result != StartResult::Started) {
+            ReapWorker(hub);
+        }
+        return result;
+    } catch (...) {
+        return StartResult::ResourceExhausted;
+    }
+}
+
+SchemaRegistration RegisterSchema(const SchemaDescriptor& _schema) noexcept {
+    Hub&       hub       = GetHub();
+    const auto admission = hub.admission.load(std::memory_order_acquire);
+    if (!admission) {
+        return {.status = SchemaStatus::NotRunning};
+    }
+
+    Array<std::uint8_t> encoded;
+    try {
+        if (EncodeSchemaPayload(_schema, admission->config.codec_limits, encoded) != EncodeStatus::Ok) {
+            return {.status = SchemaStatus::InvalidSchema};
+        }
+    } catch (...) {
+        return {.status = SchemaStatus::InvalidSchema};
+    }
+
+    const std::uint64_t hash = ComputeSchemaHash(_schema);
+    if (hash == 0) {
+        return {.status = SchemaStatus::InvalidSchema};
+    }
+
+    std::lock_guard lock(hub.mutex);
+    const auto      current_admission = hub.admission.load(std::memory_order_acquire);
+    if (!current_admission || current_admission->generation != admission->generation ||
+        hub.state.load(std::memory_order_acquire) != RuntimeState::Running) {
+        return {.status = SchemaStatus::NotRunning};
+    }
+
+    const std::uint64_t generation = admission->generation;
+    const auto          current    = hub.schemas.load(std::memory_order_acquire);
+    if (const auto found = current->find(hash); found != current->end()) {
+        if (found->second->descriptor == _schema) {
+            return {
+                .status = SchemaStatus::AlreadyRegistered,
+                .handle =
+                    SchemaHandle{
+                        .hash       = hash,
+                        .generation = generation,
+                    },
+            };
+        }
+        return {.status = SchemaStatus::HashCollision};
+    }
+
+    if (current->size() >= admission->config.max_schemas) {
+        return {.status = SchemaStatus::SchemaLimit};
+    }
+    if (encoded.size() > admission->config.max_schema_bytes - hub.schema_bytes) {
+        return {.status = SchemaStatus::SchemaBytesLimit};
+    }
+
+    try {
+        auto next = std::make_shared<SchemaMap>(*current);
+        next->emplace(
+            hash,
+            std::make_shared<const SchemaEntry>(SchemaEntry{
+                .descriptor    = _schema,
+                .encoded_bytes = encoded.size(),
+            })
+        );
+        hub.schema_bytes += encoded.size();
+        hub.schemas.store(std::move(next), std::memory_order_release);
+    } catch (...) {
+        return {.status = SchemaStatus::SchemaLimit};
+    }
+
+    return {
+        .status = SchemaStatus::Registered,
+        .handle =
+            SchemaHandle{
+                .hash       = hash,
+                .generation = generation,
+            },
+    };
+}
+
+EmitStatus Emit(SchemaHandle _schema, std::span<const FieldValueView> _values) noexcept {
+    Hub&       hub       = GetHub();
+    const auto admission = AcquireEmitter(hub);
+    if (!admission) {
+        if (hub.state.load(std::memory_order_acquire) == RuntimeState::Faulted) {
+            hub.stats.records_dropped_after_fault.fetch_add(1, std::memory_order_relaxed);
+            return EmitStatus::SinkFault;
+        }
+        hub.stats.records_dropped_stopped.fetch_add(1, std::memory_order_relaxed);
+        return EmitStatus::Disabled;
+    }
+    const auto finish = [&](EmitStatus _result) noexcept {
+        return ReleaseEmitter(admission, _result);
+    };
+
+    if (!_schema || _schema.generation != admission->generation) {
+        hub.stats.records_dropped_stale_generation.fetch_add(1, std::memory_order_relaxed);
+        return finish(EmitStatus::InvalidHandle);
+    }
+
+    const auto schemas   = hub.schemas.load(std::memory_order_acquire);
+    const auto schema_it = schemas->find(_schema.hash);
+    if (schema_it == schemas->end()) {
+        return finish(EmitStatus::InvalidHandle);
+    }
+
+    const std::uint64_t sequence = admission->next_sequence.fetch_add(1, std::memory_order_relaxed);
+    const std::uint64_t attempted_value_bytes = EstimateValueBytes(_values);
+    Array<std::uint8_t> payload;
+    EncodeStatus        encode_status = EncodeStatus::InvalidSchema;
+    try {
+        encode_status = EncodeRecordPayload(
+            _schema.hash,
+            sequence,
+            schema_it->second->descriptor.fields,
+            _values,
+            admission->config.codec_limits,
+            payload
+        );
+    } catch (...) {
+        hub.stats.records_dropped_queue_full.fetch_add(1, std::memory_order_relaxed);
+        AccumulateLoss(
+            admission->generation, sequence, sequence, 1, attempted_value_bytes, LossReason::QueueFull
+        );
+        return finish(EmitStatus::QueueFull);
+    }
+    if (encode_status != EncodeStatus::Ok) {
+        if (encode_status == EncodeStatus::PayloadTooLarge || encode_status == EncodeStatus::StringTooLarge) {
+            hub.stats.records_dropped_oversized.fetch_add(1, std::memory_order_relaxed);
+            AccumulateLoss(
+                admission->generation, sequence, sequence, 1, attempted_value_bytes, LossReason::Oversized
+            );
+        }
+        return finish(MapEncodeStatus(encode_status));
+    }
+    if (payload.size() > admission->config.max_record_bytes ||
+        payload.size() > admission->config.tls_max_bytes) {
+        hub.stats.records_dropped_oversized.fetch_add(1, std::memory_order_relaxed);
+        AccumulateLoss(
+            admission->generation,
+            sequence,
+            sequence,
+            1,
+            EncodedRecordValueBytes(payload),
+            LossReason::Oversized
+        );
+        return finish(EmitStatus::RecordTooLarge);
+    }
+
+    if (g_tls_shard.generation != 0 && g_tls_shard.generation != admission->generation) {
+        (void)PublishTlsShard(g_tls_shard);
+    }
+    if (g_tls_shard.generation == 0) {
+        g_tls_shard.generation = admission->generation;
+    }
+
+    if (!g_tls_shard.records.empty() &&
+        (g_tls_shard.records.size() >= admission->config.tls_max_records ||
+         payload.size() > admission->config.tls_max_bytes - g_tls_shard.payload_bytes)) {
+        (void)PublishTlsShard(g_tls_shard);
+        g_tls_shard.generation = admission->generation;
+    }
+
+    const std::size_t record_bytes = payload.size();
+    try {
+        g_tls_shard.payload_bytes += record_bytes;
+        g_tls_shard.records.emplace_back(PendingRecord{
+            .schema_hash = _schema.hash,
+            .sequence    = sequence,
+            .payload     = std::move(payload),
+        });
+    } catch (...) {
+        g_tls_shard.payload_bytes -= record_bytes;
+        hub.stats.records_dropped_queue_full.fetch_add(1, std::memory_order_relaxed);
+        AccumulateLoss(
+            admission->generation, sequence, sequence, 1, attempted_value_bytes, LossReason::QueueFull
+        );
+        return finish(EmitStatus::QueueFull);
+    }
+    hub.stats.records_committed.fetch_add(1, std::memory_order_relaxed);
+
+    const bool publish = g_tls_shard.records.size() >= admission->config.tls_publish_records ||
+                         g_tls_shard.payload_bytes >= admission->config.tls_publish_bytes ||
+                         g_tls_shard.records.size() >= admission->config.tls_max_records ||
+                         g_tls_shard.payload_bytes >= admission->config.tls_max_bytes;
+    if (publish) {
+        const PublishResult result = PublishTlsShard(g_tls_shard);
+        if (result == PublishResult::QueueFull) {
+            return finish(EmitStatus::QueueFull);
+        }
+        if (result == PublishResult::Faulted) {
+            return finish(EmitStatus::SinkFault);
+        }
+        if (result != PublishResult::Accepted) {
+            return finish(EmitStatus::Disabled);
+        }
+    }
+    return finish(EmitStatus::Accepted);
+}
+
+FlushResult FlushThreadLocal() noexcept {
+    const PublishResult published      = PublishTlsShard(g_tls_shard);
+    const FlushResult   publish_result = PublishResultToFlush(published);
+    if (publish_result == FlushResult::Faulted) {
+        return FlushResult::Faulted;
+    }
+    if (publish_result == FlushResult::Rejected) {
+        return FlushResult::Rejected;
+    }
+
+    const FlushResult flush_result = FlushAll();
+    if (flush_result == FlushResult::Faulted) {
+        return flush_result;
+    }
+    if (published == PublishResult::Nothing && flush_result == FlushResult::NothingPending) {
+        return FlushResult::NothingPending;
+    }
+    return flush_result == FlushResult::NothingPending ? FlushResult::Completed : flush_result;
+}
+
+FlushResult FlushAll() noexcept {
+    Hub&                        hub = GetHub();
+    std::shared_ptr<FlushFence> fence;
+    {
+        std::lock_guard    lock(hub.mutex);
+        const RuntimeState state = hub.state.load(std::memory_order_acquire);
+        if (state == RuntimeState::Faulted) {
+            return FlushResult::Faulted;
+        }
+        if (state != RuntimeState::Running) {
+            return FlushResult::Rejected;
+        }
+        if (hub.stats.resident_chunks.load(std::memory_order_relaxed) == 0 && !hub.file_dirty &&
+            !hub.pending_loss.pending) {
+            return FlushResult::NothingPending;
+        }
+        if (!hub.messages.empty()) {
+            if (auto* tail_flush = std::get_if<FlushMessage>(&hub.messages.back())) {
+                fence = tail_flush->fence;
+            }
+        } else if (hub.active_flush_fence && !hub.pending_loss.pending) {
+            fence = hub.active_flush_fence;
+        }
+
+        if (!fence) {
+            try {
+                fence = std::make_shared<FlushFence>();
+                hub.messages.emplace_back(FlushMessage{.fence = fence});
+            } catch (...) {
+                return FlushResult::Rejected;
+            }
+        }
+    }
+    hub.work_cv.notify_one();
+    return WaitFence(fence);
+}
+
+ShutdownResult Shutdown() noexcept {
+    Hub&            hub = GetHub();
+    std::lock_guard lifecycle_lock(hub.lifecycle_mutex);
+
+    RuntimeState state = hub.state.load(std::memory_order_acquire);
+    if (state == RuntimeState::Stopped) {
+        ReapWorker(hub);
+        return ShutdownResult::AlreadyStopped;
+    }
+    if (state == RuntimeState::Starting) {
+        std::unique_lock lock(hub.mutex);
+        hub.start_cv.wait(lock, [&] {
+            return hub.start_complete;
+        });
+        state = hub.state.load(std::memory_order_acquire);
+    }
+    (void)PublishTlsShard(g_tls_shard);
+
+    std::shared_ptr<FlushFence> fence;
+    {
+        std::unique_lock lock(hub.mutex);
+        state = hub.state.load(std::memory_order_acquire);
+        if (state == RuntimeState::Faulted) {
+            // FailWriter retains and closes the last admission. Do not allow a
+            // new generation to start until every emitter admitted by that
+            // generation has left its critical section.
+            hub.emitter_cv.wait(lock, [&] {
+                return !hub.retired_admission || hub.retired_admission->active_emitters == 0;
+            });
+            hub.retired_admission.reset();
+        } else if (state == RuntimeState::Stopped) {
+            // Reap outside Hub::mutex below.
+        } else if (state == RuntimeState::Running) {
+            const auto closing_admission = hub.admission.load(std::memory_order_acquire);
+            if (closing_admission) {
+                closing_admission->closing = true;
+                hub.retired_admission      = closing_admission;
+            }
+            hub.admission.store({}, std::memory_order_release);
+
+            // Keep RuntimeState::Running while admitted emitters finish. Their
+            // exit path publishes the current TLS shard before decrementing
+            // active_emitters, so every such chunk is ordered before
+            // Finalize in the writer FIFO.
+            hub.emitter_cv.wait(lock, [&] {
+                return !closing_admission || closing_admission->active_emitters == 0;
+            });
+            hub.retired_admission.reset();
+
+            if (hub.state.load(std::memory_order_acquire) != RuntimeState::Faulted) {
+                hub.state.store(RuntimeState::Draining, std::memory_order_release);
+                try {
+                    fence              = std::make_shared<FlushFence>();
+                    hub.shutdown_fence = fence;
+                    hub.messages.emplace_back(FinalizeMessage{.fence = fence});
+                } catch (...) {
+                    hub.state.store(RuntimeState::Faulted, std::memory_order_release);
+                    hub.last_fault.store(RuntimeFault::WriterException, std::memory_order_release);
+                    hub.test_hooks.writer_resume = true;
+                }
+            }
+        } else if (state == RuntimeState::Draining) {
+            fence = hub.shutdown_fence;
+        }
+    }
+
+    if (state == RuntimeState::Stopped) {
+        ReapWorker(hub);
+        return ShutdownResult::AlreadyStopped;
+    }
+
+    if (hub.state.load(std::memory_order_acquire) == RuntimeState::Faulted) {
+        hub.work_cv.notify_all();
+        hub.test_cv.notify_all();
+        ReapWorker(hub);
+        hub.state.store(RuntimeState::Stopped, std::memory_order_release);
+        return ShutdownResult::Faulted;
+    }
+
+    hub.work_cv.notify_one();
+    hub.test_cv.notify_all();
+    const FlushResult result = WaitFence(fence);
+    ReapWorker(hub);
+    if (result == FlushResult::Completed) {
+        return ShutdownResult::Completed;
+    }
+    hub.state.store(RuntimeState::Stopped, std::memory_order_release);
+    return ShutdownResult::Faulted;
+}
+
+RuntimeState GetRuntimeState() noexcept {
+    return GetHub().state.load(std::memory_order_acquire);
+}
+
+RuntimeStats GetRuntimeStats() noexcept {
+    Hub&         hub = GetHub();
+    RuntimeStats stats{};
+    stats.state      = hub.state.load(std::memory_order_acquire);
+    stats.last_fault = hub.last_fault.load(std::memory_order_acquire);
+    stats.generation = hub.generation.load(std::memory_order_acquire);
+
+#define MOER_LOAD_PROFILE_STAT(Name) stats.Name = hub.stats.Name.load(std::memory_order_relaxed)
+    MOER_LOAD_PROFILE_STAT(records_committed);
+    MOER_LOAD_PROFILE_STAT(records_enqueued);
+    MOER_LOAD_PROFILE_STAT(records_written);
+    MOER_LOAD_PROFILE_STAT(records_dropped_stopped);
+    MOER_LOAD_PROFILE_STAT(records_dropped_stale_generation);
+    MOER_LOAD_PROFILE_STAT(records_dropped_oversized);
+    MOER_LOAD_PROFILE_STAT(records_dropped_queue_full);
+    MOER_LOAD_PROFILE_STAT(records_dropped_after_fault);
+    MOER_LOAD_PROFILE_STAT(chunks_enqueued);
+    MOER_LOAD_PROFILE_STAT(chunks_written);
+    MOER_LOAD_PROFILE_STAT(chunks_dropped);
+    MOER_LOAD_PROFILE_STAT(resident_chunks);
+    MOER_LOAD_PROFILE_STAT(resident_records);
+    MOER_LOAD_PROFILE_STAT(resident_bytes);
+    MOER_LOAD_PROFILE_STAT(high_water_chunks);
+    MOER_LOAD_PROFILE_STAT(high_water_records);
+    MOER_LOAD_PROFILE_STAT(high_water_bytes);
+    MOER_LOAD_PROFILE_STAT(file_bytes_written);
+    MOER_LOAD_PROFILE_STAT(flush_completed);
+    MOER_LOAD_PROFILE_STAT(flush_failed);
+    MOER_LOAD_PROFILE_STAT(io_faults);
+#undef MOER_LOAD_PROFILE_STAT
+    return stats;
+}
+
+namespace Testing {
+
+bool ConfigureFault(FaultPoint _point, std::uint64_t _trigger_hit) noexcept {
+    Hub&            hub = GetHub();
+    std::lock_guard lock(hub.mutex);
+    if (hub.state.load(std::memory_order_acquire) != RuntimeState::Stopped) {
+        return false;
+    }
+    hub.test_hooks.fault_point   = _point;
+    hub.test_hooks.trigger_hit   = std::max<std::uint64_t>(_trigger_hit, 1);
+    hub.test_hooks.matching_hits = 0;
+    hub.test_hooks.fault_fired   = false;
+    return true;
+}
+
+bool ConfigureWriterPauseAfterStart(bool _enabled) noexcept {
+    Hub&            hub = GetHub();
+    std::lock_guard lock(hub.mutex);
+    if (hub.state.load(std::memory_order_acquire) != RuntimeState::Stopped) {
+        return false;
+    }
+    hub.test_hooks.pause_after_start = _enabled;
+    hub.test_hooks.writer_paused     = false;
+    hub.test_hooks.writer_resume     = false;
+    return true;
+}
+
+bool ConfigureWriterPauseBeforeTempOpen(bool _enabled) noexcept {
+    Hub&            hub = GetHub();
+    std::lock_guard lock(hub.mutex);
+    if (hub.state.load(std::memory_order_acquire) != RuntimeState::Stopped) {
+        return false;
+    }
+    hub.test_hooks.pause_before_temp_open = _enabled;
+    hub.test_hooks.writer_paused          = false;
+    hub.test_hooks.writer_resume          = false;
+    return true;
+}
+
+bool WaitForWriterPaused(std::uint32_t _timeout_ms) noexcept {
+    Hub&             hub = GetHub();
+    std::unique_lock lock(hub.mutex);
+    return hub.test_cv.wait_for(lock, std::chrono::milliseconds(_timeout_ms), [&] {
+        return hub.test_hooks.writer_paused ||
+               hub.state.load(std::memory_order_acquire) == RuntimeState::Faulted;
+    }) && hub.test_hooks.writer_paused;
+}
+
+void ResumeWriter() noexcept {
+    Hub& hub = GetHub();
+    {
+        std::lock_guard lock(hub.mutex);
+        hub.test_hooks.writer_resume = true;
+    }
+    hub.test_cv.notify_all();
+}
+
+void ClearHooks() noexcept {
+    Hub&            hub = GetHub();
+    std::lock_guard lock(hub.mutex);
+    if (hub.state.load(std::memory_order_acquire) != RuntimeState::Stopped) {
+        return;
+    }
+    hub.test_hooks = {};
+}
+
+} // namespace Testing
+
+} // namespace Moer::ProfileDump

--- a/source/runtime/core/source/profile/ProfileDump.cpp
+++ b/source/runtime/core/source/profile/ProfileDump.cpp
@@ -40,6 +40,39 @@ namespace {
 
 using namespace std::chrono_literals;
 
+std::atomic<std::uint64_t> g_temp_path_nonce{1};
+
+[[nodiscard]] std::uint64_t CurrentProcessIdValue() noexcept {
+#if PLATFORM_WINDOWS
+    return static_cast<std::uint64_t>(::GetCurrentProcessId());
+#else
+    return static_cast<std::uint64_t>(::getpid());
+#endif
+}
+
+[[nodiscard]] std::filesystem::path MakeSessionTempPath(const std::filesystem::path& _output_path) {
+    const auto clock_tick =
+        static_cast<std::uint64_t>(std::chrono::steady_clock::now().time_since_epoch().count());
+    const std::uint64_t nonce = g_temp_path_nonce.fetch_add(1, std::memory_order_relaxed);
+
+    auto combine = [](std::uint64_t _seed, std::uint64_t _value) noexcept {
+        return _seed ^ (_value + 0x9e3779b97f4a7c15ULL + (_seed << 6U) + (_seed >> 2U));
+    };
+    std::uint64_t token = combine(CurrentProcessIdValue(), clock_tick);
+    token               = combine(token, nonce);
+    token ^= token >> 30U;
+    token *= 0xbf58476d1ce4e5b9ULL;
+    token ^= token >> 27U;
+    token *= 0x94d049bb133111ebULL;
+    token ^= token >> 31U;
+
+    char token_text[17]{};
+    static_cast<void>(
+        std::snprintf(token_text, sizeof(token_text), "%016llx", static_cast<unsigned long long>(token))
+    );
+    return _output_path.parent_path() / (std::string(".moer-profile-") + token_text + ".inprogress");
+}
+
 struct PendingRecord {
     std::uint64_t       schema_hash{0};
     std::uint64_t       sequence{0};
@@ -728,8 +761,20 @@ void RenameFinalChecked(Hub& _hub) {
     if (_hub.config.replace_existing) {
         flags |= MOVEFILE_REPLACE_EXISTING;
     }
-    if (!::MoveFileExW(_hub.temp_path.c_str(), _hub.config.output_path.c_str(), flags)) {
-        throw WriterFailure{RuntimeFault::RenameFinal};
+
+    constexpr std::uint32_t max_attempts = 8;
+    for (std::uint32_t attempt = 0; attempt < max_attempts; ++attempt) {
+        if (::MoveFileExW(_hub.temp_path.c_str(), _hub.config.output_path.c_str(), flags)) {
+            return;
+        }
+        const DWORD error = ::GetLastError();
+        const bool  transient =
+            error == ERROR_SHARING_VIOLATION || error == ERROR_LOCK_VIOLATION || error == ERROR_ACCESS_DENIED;
+        if (!transient || attempt + 1 == max_attempts) {
+            throw WriterFailure{RuntimeFault::RenameFinal};
+        }
+        const auto backoff = std::chrono::milliseconds(1U << std::min<std::uint32_t>(attempt, 5U));
+        std::this_thread::sleep_for(backoff);
     }
 #else
     if (_hub.config.replace_existing) {
@@ -1087,34 +1132,23 @@ StartResult Start(const RuntimeConfig& _config) noexcept {
         if (ShouldInject(Testing::FaultPoint::StartAllocation)) {
             throw std::bad_alloc{};
         }
-        RuntimeConfig         prepared_config = _config;
-        std::filesystem::path temp_path       = prepared_config.output_path;
-        temp_path += ".inprogress";
-        auto initial_schemas      = std::make_shared<const SchemaMap>();
-        auto session_admission    = std::make_shared<Admission>();
-        session_admission->config = prepared_config;
+        RuntimeConfig         prepared_config   = _config;
+        std::filesystem::path temp_path         = MakeSessionTempPath(prepared_config.output_path);
+        auto                  initial_schemas   = std::make_shared<const SchemaMap>();
+        auto                  session_admission = std::make_shared<Admission>();
+        session_admission->config               = prepared_config;
 
         std::error_code error;
         const bool      final_exists = std::filesystem::exists(prepared_config.output_path, error);
         if (error) {
             return StartResult::FileOpenFailed;
         }
-        const bool temp_exists = std::filesystem::exists(temp_path, error);
-        if (error) {
-            return StartResult::FileOpenFailed;
-        }
-        if (!prepared_config.replace_existing && (final_exists || temp_exists)) {
+        if (!prepared_config.replace_existing && final_exists) {
             return StartResult::OutputExists;
         }
-        // A stale/incomplete temp capture may be discarded for an explicit
-        // replacement. Keep the previous valid final until the new writer has
-        // closed successfully and can atomically publish over it.
-        if (prepared_config.replace_existing && temp_exists) {
-            std::filesystem::remove(temp_path, error);
-            if (error) {
-                return StartResult::FileOpenFailed;
-            }
-        }
+        // Every session exclusively creates and owns a unique temp path.
+        // Replacement applies only to the final output and must never unlink
+        // another process's live or forensic in-progress capture.
 
         {
             std::lock_guard lock(hub.mutex);
@@ -1600,6 +1634,23 @@ bool WaitForWriterPaused(std::uint32_t _timeout_ms) noexcept {
         return hub.test_hooks.writer_paused ||
                hub.state.load(std::memory_order_acquire) == RuntimeState::Faulted;
     }) && hub.test_hooks.writer_paused;
+}
+
+bool CreateActiveTempCollision(const std::uint8_t* _bytes, std::size_t _byte_count) noexcept {
+    Hub&            hub = GetHub();
+    std::lock_guard lock(hub.mutex);
+    if (hub.state.load(std::memory_order_acquire) != RuntimeState::Starting ||
+        !hub.test_hooks.pause_before_temp_open || !hub.test_hooks.writer_paused || hub.temp_path.empty() ||
+        (!_bytes && _byte_count != 0)) {
+        return false;
+    }
+
+    std::FILE* stream = OpenTempFileExclusive(hub.temp_path);
+    if (!stream) {
+        return false;
+    }
+    const bool wrote = _byte_count == 0 || std::fwrite(_bytes, 1, _byte_count, stream) == _byte_count;
+    return std::fclose(stream) == 0 && wrote;
 }
 
 void ResumeWriter() noexcept {

--- a/source/runtime/core/source/profile/ProfileDump.cpp
+++ b/source/runtime/core/source/profile/ProfileDump.cpp
@@ -398,19 +398,22 @@ bool IsIoFault(RuntimeFault _fault) noexcept {
            _fault == RuntimeFault::RenameFinal;
 }
 
+bool ShouldInjectLocked(TestHooks& _hooks, Testing::FaultPoint _point) noexcept {
+    if (_hooks.fault_point != _point || _hooks.fault_fired) {
+        return false;
+    }
+    ++_hooks.matching_hits;
+    if (_hooks.matching_hits != std::max<std::uint64_t>(_hooks.trigger_hit, 1)) {
+        return false;
+    }
+    _hooks.fault_fired = true;
+    return true;
+}
+
 bool ShouldInject(Testing::FaultPoint _point) noexcept {
     Hub&            hub = GetHub();
     std::lock_guard lock(hub.mutex);
-    TestHooks&      hooks = hub.test_hooks;
-    if (hooks.fault_point != _point || hooks.fault_fired) {
-        return false;
-    }
-    ++hooks.matching_hits;
-    if (hooks.matching_hits != std::max<std::uint64_t>(hooks.trigger_hit, 1)) {
-        return false;
-    }
-    hooks.fault_fired = true;
-    return true;
+    return ShouldInjectLocked(hub.test_hooks, _point);
 }
 
 struct WriterFailure {
@@ -921,6 +924,13 @@ void WriterMain(Hub& _hub, std::shared_ptr<Admission> _session_admission) noexce
                     return !_hub.messages.empty() || _hub.pending_loss.pending ||
                            _hub.state.load(std::memory_order_acquire) == RuntimeState::Faulted;
                 });
+                if (_hub.state.load(std::memory_order_acquire) == RuntimeState::Faulted) {
+                    RuntimeFault fault = _hub.last_fault.load(std::memory_order_acquire);
+                    if (fault == RuntimeFault::None) {
+                        fault = RuntimeFault::WriterException;
+                    }
+                    throw WriterFailure{fault};
+                }
                 if (_hub.messages.empty() && !_hub.pending_loss.pending) {
                     return;
                 }
@@ -1513,10 +1523,15 @@ ShutdownResult Shutdown() noexcept {
             if (hub.state.load(std::memory_order_acquire) != RuntimeState::Faulted) {
                 hub.state.store(RuntimeState::Draining, std::memory_order_release);
                 try {
+                    if (ShouldInjectLocked(hub.test_hooks, Testing::FaultPoint::ShutdownFinalizeAllocation)) {
+                        throw std::bad_alloc{};
+                    }
                     fence              = std::make_shared<FlushFence>();
                     hub.shutdown_fence = fence;
                     hub.messages.emplace_back(FinalizeMessage{.fence = fence});
                 } catch (...) {
+                    hub.shutdown_fence.reset();
+                    fence.reset();
                     hub.state.store(RuntimeState::Faulted, std::memory_order_release);
                     hub.last_fault.store(RuntimeFault::WriterException, std::memory_order_release);
                     hub.test_hooks.writer_resume = true;

--- a/source/runtime/core/source/profile/ProfileDumpCodec.cpp
+++ b/source/runtime/core/source/profile/ProfileDumpCodec.cpp
@@ -1,0 +1,891 @@
+#include "profile/ProfileDumpCodec.h"
+
+#include "misc/Crc32.h"
+
+#include <bit>
+#include <limits>
+#include <type_traits>
+#include <utility>
+
+namespace Moer::ProfileDump {
+
+namespace {
+
+constexpr std::uint64_t    kFnvOffsetBasis   = 14695981039346656037ull;
+constexpr std::uint64_t    kFnvPrime         = 1099511628211ull;
+constexpr std::string_view kSchemaHashDomain = "moer.profile.schema.v3";
+constexpr std::size_t      kHeaderCrcBytes   = kPacketHeaderBytes - sizeof(std::uint32_t);
+constexpr std::size_t      kRecordPrefixBytes =
+    sizeof(std::uint64_t) + sizeof(std::uint64_t) + sizeof(std::uint32_t);
+constexpr std::size_t kLossPayloadBytes         = sizeof(std::uint64_t) * 4 + sizeof(std::uint32_t);
+constexpr std::size_t kSessionBeginPayloadBytes = sizeof(std::uint64_t) * 2;
+constexpr std::size_t kSessionEndPayloadBytes   = sizeof(std::uint64_t) * 3;
+
+static_assert(kPacketHeaderBytes == 32);
+static_assert(kHeaderCrcBytes == 28);
+static_assert(sizeof(float) == sizeof(std::uint32_t));
+static_assert(sizeof(double) == sizeof(std::uint64_t));
+static_assert(std::numeric_limits<float>::is_iec559);
+static_assert(std::numeric_limits<double>::is_iec559);
+
+bool IsValidChannel(Channel _channel) noexcept {
+    return _channel == Channel::CpuThread || _channel == Channel::GpuQueue;
+}
+
+bool IsValidEventKind(EventKind _kind) noexcept {
+    return _kind == EventKind::Scope || _kind == EventKind::Counter || _kind == EventKind::Instant;
+}
+
+bool IsValidFieldType(FieldType _type) noexcept {
+    return _type == FieldType::Bool || _type == FieldType::Int32 || _type == FieldType::UInt32 ||
+           _type == FieldType::Int64 || _type == FieldType::UInt64 || _type == FieldType::Float32 ||
+           _type == FieldType::Float64 || _type == FieldType::String;
+}
+
+bool IsValidPacketType(PacketType _type) noexcept {
+    return _type == PacketType::SessionBegin || _type == PacketType::Schema || _type == PacketType::Record ||
+           _type == PacketType::Loss || _type == PacketType::SessionEnd;
+}
+
+template<typename T>
+    requires(std::is_unsigned_v<T>)
+void AppendLittleEndian(Array<std::uint8_t>& _output, T _value) {
+    for (std::size_t byte_index = 0; byte_index < sizeof(T); ++byte_index) {
+        _output.emplace_back(static_cast<std::uint8_t>(_value & T{0xff}));
+        _value >>= 8;
+    }
+}
+
+template<typename T>
+    requires(std::is_signed_v<T>)
+void AppendLittleEndian(Array<std::uint8_t>& _output, T _value) {
+    using UnsignedT = std::make_unsigned_t<T>;
+    AppendLittleEndian(_output, std::bit_cast<UnsignedT>(_value));
+}
+
+void AppendFloat(Array<std::uint8_t>& _output, float _value) {
+    AppendLittleEndian(_output, std::bit_cast<std::uint32_t>(_value));
+}
+
+void AppendFloat(Array<std::uint8_t>& _output, double _value) {
+    AppendLittleEndian(_output, std::bit_cast<std::uint64_t>(_value));
+}
+
+bool CanEncodeU32Length(std::size_t _size) noexcept {
+    return _size <= std::numeric_limits<std::uint32_t>::max();
+}
+
+bool CanGrowPayload(
+    std::size_t        _current_size,
+    std::size_t        _additional_size,
+    const CodecLimits& _limits
+) noexcept {
+    return _additional_size <= std::numeric_limits<std::size_t>::max() - _current_size &&
+           _current_size + _additional_size <= _limits.max_packet_payload_bytes &&
+           CanEncodeU32Length(_current_size + _additional_size);
+}
+
+void AppendString(Array<std::uint8_t>& _output, std::string_view _value) {
+    AppendLittleEndian(_output, static_cast<std::uint32_t>(_value.size()));
+    _output.insert(_output.end(), _value.begin(), _value.end());
+}
+
+class ByteReader {
+public:
+    explicit ByteReader(std::span<const std::uint8_t> _bytes) noexcept : m_bytes(_bytes) {}
+
+    template<typename T>
+        requires(std::is_unsigned_v<T>)
+    bool ReadLittleEndian(T& _value) noexcept {
+        if (Remaining() < sizeof(T)) {
+            return false;
+        }
+
+        T value = 0;
+        for (std::size_t byte_index = 0; byte_index < sizeof(T); ++byte_index) {
+            value |= static_cast<T>(m_bytes[m_offset + byte_index]) << (byte_index * 8);
+        }
+        m_offset += sizeof(T);
+        _value = value;
+        return true;
+    }
+
+    template<typename T>
+        requires(std::is_signed_v<T>)
+    bool ReadLittleEndian(T& _value) noexcept {
+        using UnsignedT   = std::make_unsigned_t<T>;
+        UnsignedT encoded = 0;
+        if (!ReadLittleEndian(encoded)) {
+            return false;
+        }
+        _value = std::bit_cast<T>(encoded);
+        return true;
+    }
+
+    bool ReadFloat(float& _value) noexcept {
+        std::uint32_t bits = 0;
+        if (!ReadLittleEndian(bits)) {
+            return false;
+        }
+        _value = std::bit_cast<float>(bits);
+        return true;
+    }
+
+    bool ReadFloat(double& _value) noexcept {
+        std::uint64_t bits = 0;
+        if (!ReadLittleEndian(bits)) {
+            return false;
+        }
+        _value = std::bit_cast<double>(bits);
+        return true;
+    }
+
+    DecodeStatus ReadString(ProfileString& _value, const CodecLimits& _limits) {
+        std::uint32_t length = 0;
+        if (!ReadLittleEndian(length)) {
+            return DecodeStatus::MalformedPayload;
+        }
+        if (length > _limits.max_string_bytes) {
+            return DecodeStatus::LimitExceeded;
+        }
+        if (static_cast<std::size_t>(length) > Remaining()) {
+            return DecodeStatus::MalformedPayload;
+        }
+
+        _value.assign(reinterpret_cast<const char*>(m_bytes.data() + m_offset), length);
+        m_offset += length;
+        return DecodeStatus::Ok;
+    }
+
+    bool ReadSpan(std::size_t _size, std::span<const std::uint8_t>& _value) noexcept {
+        if (_size > Remaining()) {
+            return false;
+        }
+        _value = m_bytes.subspan(m_offset, _size);
+        m_offset += _size;
+        return true;
+    }
+
+    [[nodiscard]] std::size_t Remaining() const noexcept {
+        return m_bytes.size() - m_offset;
+    }
+
+    [[nodiscard]] bool AtEnd() const noexcept {
+        return m_offset == m_bytes.size();
+    }
+
+private:
+    std::span<const std::uint8_t> m_bytes{};
+    std::size_t                   m_offset{0};
+};
+
+class StableHasher {
+public:
+    void AppendByte(std::uint8_t _value) noexcept {
+        m_hash ^= _value;
+        m_hash *= kFnvPrime;
+    }
+
+    template<typename T>
+        requires(std::is_unsigned_v<T>)
+    void AppendLittleEndian(T _value) noexcept {
+        for (std::size_t byte_index = 0; byte_index < sizeof(T); ++byte_index) {
+            AppendByte(static_cast<std::uint8_t>(_value & T{0xff}));
+            _value >>= 8;
+        }
+    }
+
+    void AppendString(std::string_view _value) noexcept {
+        AppendLittleEndian(static_cast<std::uint32_t>(_value.size()));
+        for (const char character : _value) {
+            AppendByte(static_cast<std::uint8_t>(static_cast<unsigned char>(character)));
+        }
+    }
+
+    [[nodiscard]] std::uint64_t Finish() const noexcept {
+        return m_hash;
+    }
+
+private:
+    std::uint64_t m_hash{kFnvOffsetBasis};
+};
+
+bool HasDuplicateFieldNames(const SchemaDescriptor& _schema) noexcept {
+    for (std::size_t field_index = 0; field_index < _schema.fields.size(); ++field_index) {
+        for (std::size_t other_index = field_index + 1; other_index < _schema.fields.size(); ++other_index) {
+            if (_schema.fields[field_index].name == _schema.fields[other_index].name) {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
+bool IsSchemaDescriptorHashable(const SchemaDescriptor& _schema) noexcept {
+    if (_schema.name.empty() || _schema.event_type.empty() || !IsValidEventKind(_schema.kind) ||
+        !IsValidChannel(_schema.channel) || !CanEncodeU32Length(_schema.name.size()) ||
+        !CanEncodeU32Length(_schema.event_type.size()) ||
+        _schema.fields.size() > std::numeric_limits<std::uint16_t>::max() ||
+        _schema.fields.size() > std::numeric_limits<std::uint32_t>::max()) {
+        return false;
+    }
+
+    for (const SchemaField& field : _schema.fields) {
+        if (field.name.empty() || !IsValidFieldType(field.type) || !CanEncodeU32Length(field.name.size())) {
+            return false;
+        }
+    }
+    return !HasDuplicateFieldNames(_schema);
+}
+
+EncodeStatus ValidateSchemaForEncoding(const SchemaDescriptor& _schema, const CodecLimits& _limits) noexcept {
+    if (_schema.name.empty() || _schema.event_type.empty() || !IsValidEventKind(_schema.kind) ||
+        !IsValidChannel(_schema.channel) || _schema.fields.size() > _limits.max_fields ||
+        _schema.fields.size() > std::numeric_limits<std::uint16_t>::max() ||
+        HasDuplicateFieldNames(_schema)) {
+        return EncodeStatus::InvalidSchema;
+    }
+    if (!CanEncodeU32Length(_schema.name.size()) || !CanEncodeU32Length(_schema.event_type.size()) ||
+        _schema.name.size() > _limits.max_string_bytes ||
+        _schema.event_type.size() > _limits.max_string_bytes) {
+        return EncodeStatus::StringTooLarge;
+    }
+
+    for (const SchemaField& field : _schema.fields) {
+        if (field.name.empty() || !IsValidFieldType(field.type)) {
+            return EncodeStatus::InvalidSchema;
+        }
+        if (!CanEncodeU32Length(field.name.size()) || field.name.size() > _limits.max_string_bytes) {
+            return EncodeStatus::StringTooLarge;
+        }
+    }
+
+    return EncodeStatus::Ok;
+}
+
+std::uint32_t ComputeCrc32(std::span<const std::uint8_t> _bytes) noexcept {
+    return crc32_fast(_bytes.data(), _bytes.size());
+}
+
+bool ValidatePayloadView(const PacketView& _packet, PacketType _expected_type) noexcept {
+    return _packet.header.type == _expected_type && _packet.header.payload_bytes == _packet.payload.size();
+}
+
+template<typename T>
+bool HoldsFieldValue(const FieldValueView& _value) noexcept {
+    return std::holds_alternative<T>(_value);
+}
+
+EncodeStatus AppendFieldValue(
+    Array<std::uint8_t>&  _encoded,
+    const SchemaField&    _field,
+    const FieldValueView& _value,
+    const CodecLimits&    _limits
+) {
+    switch (_field.type) {
+        case FieldType::Bool:
+            if (!HoldsFieldValue<bool>(_value)) {
+                return EncodeStatus::ValueTypeMismatch;
+            }
+            _encoded.emplace_back(std::get<bool>(_value) ? 1u : 0u);
+            return EncodeStatus::Ok;
+        case FieldType::Int32:
+            if (!HoldsFieldValue<std::int32_t>(_value)) {
+                return EncodeStatus::ValueTypeMismatch;
+            }
+            AppendLittleEndian(_encoded, std::get<std::int32_t>(_value));
+            return EncodeStatus::Ok;
+        case FieldType::UInt32:
+            if (!HoldsFieldValue<std::uint32_t>(_value)) {
+                return EncodeStatus::ValueTypeMismatch;
+            }
+            AppendLittleEndian(_encoded, std::get<std::uint32_t>(_value));
+            return EncodeStatus::Ok;
+        case FieldType::Int64:
+            if (!HoldsFieldValue<std::int64_t>(_value)) {
+                return EncodeStatus::ValueTypeMismatch;
+            }
+            AppendLittleEndian(_encoded, std::get<std::int64_t>(_value));
+            return EncodeStatus::Ok;
+        case FieldType::UInt64:
+            if (!HoldsFieldValue<std::uint64_t>(_value)) {
+                return EncodeStatus::ValueTypeMismatch;
+            }
+            AppendLittleEndian(_encoded, std::get<std::uint64_t>(_value));
+            return EncodeStatus::Ok;
+        case FieldType::Float32:
+            if (!HoldsFieldValue<float>(_value)) {
+                return EncodeStatus::ValueTypeMismatch;
+            }
+            AppendFloat(_encoded, std::get<float>(_value));
+            return EncodeStatus::Ok;
+        case FieldType::Float64:
+            if (!HoldsFieldValue<double>(_value)) {
+                return EncodeStatus::ValueTypeMismatch;
+            }
+            AppendFloat(_encoded, std::get<double>(_value));
+            return EncodeStatus::Ok;
+        case FieldType::String: {
+            if (!HoldsFieldValue<std::string_view>(_value)) {
+                return EncodeStatus::ValueTypeMismatch;
+            }
+            const std::string_view text = std::get<std::string_view>(_value);
+            if (!CanEncodeU32Length(text.size()) || text.size() > _limits.max_string_bytes) {
+                return EncodeStatus::StringTooLarge;
+            }
+            AppendString(_encoded, text);
+            return EncodeStatus::Ok;
+        }
+    }
+    return EncodeStatus::ValueTypeMismatch;
+}
+
+DecodeStatus DecodeFieldValue(
+    ByteReader&        _reader,
+    const SchemaField& _field,
+    const CodecLimits& _limits,
+    FieldValue&        _value
+) {
+    switch (_field.type) {
+        case FieldType::Bool: {
+            std::uint8_t value = 0;
+            if (!_reader.ReadLittleEndian(value) || value > 1) {
+                return DecodeStatus::MalformedPayload;
+            }
+            _value = value != 0;
+            return DecodeStatus::Ok;
+        }
+        case FieldType::Int32: {
+            std::int32_t value = 0;
+            if (!_reader.ReadLittleEndian(value)) {
+                return DecodeStatus::MalformedPayload;
+            }
+            _value = value;
+            return DecodeStatus::Ok;
+        }
+        case FieldType::UInt32: {
+            std::uint32_t value = 0;
+            if (!_reader.ReadLittleEndian(value)) {
+                return DecodeStatus::MalformedPayload;
+            }
+            _value = value;
+            return DecodeStatus::Ok;
+        }
+        case FieldType::Int64: {
+            std::int64_t value = 0;
+            if (!_reader.ReadLittleEndian(value)) {
+                return DecodeStatus::MalformedPayload;
+            }
+            _value = value;
+            return DecodeStatus::Ok;
+        }
+        case FieldType::UInt64: {
+            std::uint64_t value = 0;
+            if (!_reader.ReadLittleEndian(value)) {
+                return DecodeStatus::MalformedPayload;
+            }
+            _value = value;
+            return DecodeStatus::Ok;
+        }
+        case FieldType::Float32: {
+            float value = 0.0f;
+            if (!_reader.ReadFloat(value)) {
+                return DecodeStatus::MalformedPayload;
+            }
+            _value = value;
+            return DecodeStatus::Ok;
+        }
+        case FieldType::Float64: {
+            double value = 0.0;
+            if (!_reader.ReadFloat(value)) {
+                return DecodeStatus::MalformedPayload;
+            }
+            _value = value;
+            return DecodeStatus::Ok;
+        }
+        case FieldType::String: {
+            ProfileString      value;
+            const DecodeStatus status = _reader.ReadString(value, _limits);
+            if (status != DecodeStatus::Ok) {
+                return status;
+            }
+            _value = std::move(value);
+            return DecodeStatus::Ok;
+        }
+    }
+    return DecodeStatus::MalformedPayload;
+}
+
+} // namespace
+
+std::uint64_t ComputeSchemaHash(const SchemaDescriptor& _schema) noexcept {
+    if (!IsSchemaDescriptorHashable(_schema)) {
+        return 0;
+    }
+
+    StableHasher hasher;
+    hasher.AppendString(kSchemaHashDomain);
+    hasher.AppendString(_schema.name);
+    hasher.AppendString(_schema.event_type);
+    hasher.AppendByte(static_cast<std::uint8_t>(_schema.kind));
+    hasher.AppendByte(static_cast<std::uint8_t>(_schema.channel));
+    hasher.AppendLittleEndian(_schema.schema_version);
+    hasher.AppendLittleEndian(static_cast<std::uint32_t>(_schema.fields.size()));
+    for (const SchemaField& field : _schema.fields) {
+        hasher.AppendString(field.name);
+        hasher.AppendByte(static_cast<std::uint8_t>(field.type));
+    }
+    return hasher.Finish();
+}
+
+EncodeStatus EncodeSchemaPayload(
+    const SchemaDescriptor& _schema,
+    const CodecLimits&      _limits,
+    Array<std::uint8_t>&    _payload
+) {
+    _payload.clear();
+    const EncodeStatus validation = ValidateSchemaForEncoding(_schema, _limits);
+    if (validation != EncodeStatus::Ok) {
+        return validation;
+    }
+
+    std::size_t encoded_size =
+        sizeof(std::uint64_t) + sizeof(std::uint32_t) + sizeof(std::uint8_t) * 2 + sizeof(std::uint16_t);
+    const auto include_string = [&](std::string_view text) {
+        const std::size_t additional_size = sizeof(std::uint32_t) + text.size();
+        if (!CanGrowPayload(encoded_size, additional_size, _limits)) {
+            return false;
+        }
+        encoded_size += additional_size;
+        return true;
+    };
+    if (!include_string(_schema.name) || !include_string(_schema.event_type)) {
+        return EncodeStatus::PayloadTooLarge;
+    }
+    for (const SchemaField& field : _schema.fields) {
+        if (!CanGrowPayload(encoded_size, sizeof(std::uint8_t), _limits)) {
+            return EncodeStatus::PayloadTooLarge;
+        }
+        encoded_size += sizeof(std::uint8_t);
+        if (!include_string(field.name)) {
+            return EncodeStatus::PayloadTooLarge;
+        }
+    }
+
+    Array<std::uint8_t> encoded;
+    encoded.reserve(encoded_size);
+    AppendLittleEndian(encoded, ComputeSchemaHash(_schema));
+    AppendLittleEndian(encoded, _schema.schema_version);
+    encoded.emplace_back(static_cast<std::uint8_t>(_schema.kind));
+    encoded.emplace_back(static_cast<std::uint8_t>(_schema.channel));
+    AppendLittleEndian(encoded, static_cast<std::uint16_t>(_schema.fields.size()));
+    AppendString(encoded, _schema.name);
+    AppendString(encoded, _schema.event_type);
+    for (const SchemaField& field : _schema.fields) {
+        encoded.emplace_back(static_cast<std::uint8_t>(field.type));
+        AppendString(encoded, field.name);
+    }
+
+    if (encoded.size() > _limits.max_packet_payload_bytes || !CanEncodeU32Length(encoded.size())) {
+        return EncodeStatus::PayloadTooLarge;
+    }
+
+    _payload = std::move(encoded);
+    return EncodeStatus::Ok;
+}
+
+EncodeStatus EncodeRecordPayload(
+    std::uint64_t                   _schema_hash,
+    std::uint64_t                   _sequence,
+    std::span<const SchemaField>    _fields,
+    std::span<const FieldValueView> _values,
+    const CodecLimits&              _limits,
+    Array<std::uint8_t>&            _payload
+) {
+    _payload.clear();
+    if (_schema_hash == 0) {
+        return EncodeStatus::InvalidSchema;
+    }
+    if (_fields.size() != _values.size()) {
+        return EncodeStatus::ValueCountMismatch;
+    }
+    if (_fields.size() > _limits.max_fields) {
+        return EncodeStatus::PayloadTooLarge;
+    }
+
+    Array<std::uint8_t> encoded_values;
+    encoded_values.reserve(_limits.max_packet_payload_bytes < 128 ? _limits.max_packet_payload_bytes : 128);
+    for (std::size_t field_index = 0; field_index < _fields.size(); ++field_index) {
+        if (!IsValidFieldType(_fields[field_index].type)) {
+            return EncodeStatus::InvalidSchema;
+        }
+        std::size_t encoded_field_size = 0;
+        switch (_fields[field_index].type) {
+            case FieldType::Bool:
+                encoded_field_size = sizeof(std::uint8_t);
+                break;
+            case FieldType::Int32:
+            case FieldType::UInt32:
+            case FieldType::Float32:
+                encoded_field_size = sizeof(std::uint32_t);
+                break;
+            case FieldType::Int64:
+            case FieldType::UInt64:
+            case FieldType::Float64:
+                encoded_field_size = sizeof(std::uint64_t);
+                break;
+            case FieldType::String:
+                if (HoldsFieldValue<std::string_view>(_values[field_index])) {
+                    const std::string_view text = std::get<std::string_view>(_values[field_index]);
+                    if (!CanEncodeU32Length(text.size()) || text.size() > _limits.max_string_bytes) {
+                        return EncodeStatus::StringTooLarge;
+                    }
+                    encoded_field_size = sizeof(std::uint32_t) + text.size();
+                }
+                break;
+        }
+        if (encoded_field_size != 0 && !CanGrowPayload(encoded_values.size(), encoded_field_size, _limits)) {
+            return EncodeStatus::PayloadTooLarge;
+        }
+        const EncodeStatus status =
+            AppendFieldValue(encoded_values, _fields[field_index], _values[field_index], _limits);
+        if (status != EncodeStatus::Ok) {
+            return status;
+        }
+        if (encoded_values.size() > _limits.max_packet_payload_bytes ||
+            encoded_values.size() > std::numeric_limits<std::uint32_t>::max()) {
+            return EncodeStatus::PayloadTooLarge;
+        }
+    }
+
+    if (encoded_values.size() > std::numeric_limits<std::size_t>::max() - kRecordPrefixBytes ||
+        encoded_values.size() + kRecordPrefixBytes > _limits.max_packet_payload_bytes) {
+        return EncodeStatus::PayloadTooLarge;
+    }
+
+    Array<std::uint8_t> encoded;
+    encoded.reserve(kRecordPrefixBytes + encoded_values.size());
+    AppendLittleEndian(encoded, _schema_hash);
+    AppendLittleEndian(encoded, _sequence);
+    AppendLittleEndian(encoded, static_cast<std::uint32_t>(encoded_values.size()));
+    encoded.insert(encoded.end(), encoded_values.begin(), encoded_values.end());
+    _payload = std::move(encoded);
+    return EncodeStatus::Ok;
+}
+
+void EncodeLossPayload(const LossNotice& _loss, Array<std::uint8_t>& _payload) {
+    Array<std::uint8_t> encoded;
+    encoded.reserve(kLossPayloadBytes);
+    AppendLittleEndian(encoded, _loss.first_sequence);
+    AppendLittleEndian(encoded, _loss.last_sequence);
+    AppendLittleEndian(encoded, _loss.record_count);
+    AppendLittleEndian(encoded, _loss.value_bytes);
+    AppendLittleEndian(encoded, _loss.reason_mask);
+    _payload = std::move(encoded);
+}
+
+void EncodeSessionBeginPayload(const SessionBeginInfo& _session, Array<std::uint8_t>& _payload) {
+    Array<std::uint8_t> encoded;
+    encoded.reserve(kSessionBeginPayloadBytes);
+    AppendLittleEndian(encoded, _session.generation);
+    AppendLittleEndian(encoded, _session.started_unix_ns);
+    _payload = std::move(encoded);
+}
+
+void EncodeSessionEndPayload(const SessionEndInfo& _session, Array<std::uint8_t>& _payload) {
+    Array<std::uint8_t> encoded;
+    encoded.reserve(kSessionEndPayloadBytes);
+    AppendLittleEndian(encoded, _session.generation);
+    AppendLittleEndian(encoded, _session.records_written);
+    AppendLittleEndian(encoded, _session.records_dropped);
+    _payload = std::move(encoded);
+}
+
+EncodeStatus WrapPacket(
+    PacketType                    _type,
+    std::uint64_t                 _packet_index,
+    std::span<const std::uint8_t> _payload,
+    const CodecLimits&            _limits,
+    Array<std::uint8_t>&          _packet
+) {
+    if (!IsValidPacketType(_type)) {
+        _packet.clear();
+        return EncodeStatus::InvalidSchema;
+    }
+    if (_payload.size() > _limits.max_packet_payload_bytes || !CanEncodeU32Length(_payload.size())) {
+        _packet.clear();
+        return EncodeStatus::PayloadTooLarge;
+    }
+
+    Array<std::uint8_t> encoded;
+    encoded.reserve(kPacketHeaderBytes + _payload.size());
+    AppendLittleEndian(encoded, kPacketMagic);
+    AppendLittleEndian(encoded, kWireVersion);
+    AppendLittleEndian(encoded, kPacketHeaderBytes);
+    AppendLittleEndian(encoded, static_cast<std::uint16_t>(_type));
+    AppendLittleEndian(encoded, std::uint16_t{0});
+    AppendLittleEndian(encoded, static_cast<std::uint32_t>(_payload.size()));
+    AppendLittleEndian(encoded, _packet_index);
+    AppendLittleEndian(encoded, ComputeCrc32(_payload));
+    AppendLittleEndian(encoded, ComputeCrc32(std::span<const std::uint8_t>(encoded.data(), kHeaderCrcBytes)));
+    encoded.insert(encoded.end(), _payload.begin(), _payload.end());
+
+    _packet = std::move(encoded);
+    return EncodeStatus::Ok;
+}
+
+DecodeStatus DecodePacket(
+    std::span<const std::uint8_t> _input,
+    const CodecLimits&            _limits,
+    PacketView&                   _packet,
+    std::size_t&                  _consumed
+) noexcept {
+    _consumed = 0;
+    _packet   = {};
+
+    if (_input.size() < kPacketHeaderBytes) {
+        return DecodeStatus::NeedMoreData;
+    }
+
+    ByteReader    reader(_input.first(kPacketHeaderBytes));
+    PacketHeader  header{};
+    std::uint16_t packet_type = 0;
+    if (!reader.ReadLittleEndian(header.magic) || !reader.ReadLittleEndian(header.wire_version) ||
+        !reader.ReadLittleEndian(header.header_bytes) || !reader.ReadLittleEndian(packet_type) ||
+        !reader.ReadLittleEndian(header.flags) || !reader.ReadLittleEndian(header.payload_bytes) ||
+        !reader.ReadLittleEndian(header.packet_index) || !reader.ReadLittleEndian(header.payload_crc32) ||
+        !reader.ReadLittleEndian(header.header_crc32) || !reader.AtEnd()) {
+        return DecodeStatus::InvalidHeader;
+    }
+    header.type = static_cast<PacketType>(packet_type);
+
+    if (header.magic != kPacketMagic) {
+        return DecodeStatus::InvalidMagic;
+    }
+    if (header.wire_version != kWireVersion) {
+        return DecodeStatus::UnsupportedVersion;
+    }
+    if (header.header_bytes != kPacketHeaderBytes) {
+        return DecodeStatus::InvalidHeader;
+    }
+    if (ComputeCrc32(_input.first(kHeaderCrcBytes)) != header.header_crc32) {
+        return DecodeStatus::ChecksumMismatch;
+    }
+    if (!IsValidPacketType(header.type)) {
+        return DecodeStatus::UnknownPacketType;
+    }
+    if (header.flags != 0) {
+        return DecodeStatus::UnsupportedFlags;
+    }
+    if (header.payload_bytes > _limits.max_packet_payload_bytes) {
+        return DecodeStatus::PayloadTooLarge;
+    }
+
+    const std::size_t payload_size = header.payload_bytes;
+    if (payload_size > _input.size() - kPacketHeaderBytes) {
+        return DecodeStatus::NeedMoreData;
+    }
+
+    const std::span<const std::uint8_t> payload = _input.subspan(kPacketHeaderBytes, payload_size);
+    if (ComputeCrc32(payload) != header.payload_crc32) {
+        return DecodeStatus::ChecksumMismatch;
+    }
+
+    _packet.header  = header;
+    _packet.payload = payload;
+    _consumed       = kPacketHeaderBytes + payload_size;
+    return DecodeStatus::Ok;
+}
+
+DecodeStatus
+DecodeSchemaPayload(const PacketView& _packet, const CodecLimits& _limits, SchemaDescriptor& _schema) {
+    if (!ValidatePayloadView(_packet, PacketType::Schema)) {
+        return DecodeStatus::MalformedPayload;
+    }
+    if (_packet.payload.size() > _limits.max_packet_payload_bytes) {
+        return DecodeStatus::LimitExceeded;
+    }
+
+    ByteReader       reader(_packet.payload);
+    std::uint64_t    encoded_hash    = 0;
+    std::uint8_t     encoded_kind    = 0;
+    std::uint8_t     encoded_channel = 0;
+    std::uint16_t    field_count     = 0;
+    SchemaDescriptor decoded{};
+    if (!reader.ReadLittleEndian(encoded_hash) || !reader.ReadLittleEndian(decoded.schema_version) ||
+        !reader.ReadLittleEndian(encoded_kind) || !reader.ReadLittleEndian(encoded_channel) ||
+        !reader.ReadLittleEndian(field_count)) {
+        return DecodeStatus::MalformedPayload;
+    }
+    if (field_count > _limits.max_fields) {
+        return DecodeStatus::LimitExceeded;
+    }
+
+    decoded.kind    = static_cast<EventKind>(encoded_kind);
+    decoded.channel = static_cast<Channel>(encoded_channel);
+    if (!IsValidEventKind(decoded.kind) || !IsValidChannel(decoded.channel)) {
+        return DecodeStatus::MalformedPayload;
+    }
+
+    DecodeStatus status = reader.ReadString(decoded.name, _limits);
+    if (status != DecodeStatus::Ok) {
+        return status;
+    }
+    status = reader.ReadString(decoded.event_type, _limits);
+    if (status != DecodeStatus::Ok) {
+        return status;
+    }
+    if (decoded.name.empty() || decoded.event_type.empty()) {
+        return DecodeStatus::MalformedPayload;
+    }
+
+    decoded.fields.reserve(field_count);
+    for (std::uint16_t field_index = 0; field_index < field_count; ++field_index) {
+        std::uint8_t encoded_type = 0;
+        SchemaField  field{};
+        if (!reader.ReadLittleEndian(encoded_type)) {
+            return DecodeStatus::MalformedPayload;
+        }
+        field.type = static_cast<FieldType>(encoded_type);
+        if (!IsValidFieldType(field.type)) {
+            return DecodeStatus::MalformedPayload;
+        }
+        status = reader.ReadString(field.name, _limits);
+        if (status != DecodeStatus::Ok) {
+            return status;
+        }
+        if (field.name.empty()) {
+            return DecodeStatus::MalformedPayload;
+        }
+        for (const SchemaField& existing : decoded.fields) {
+            if (existing.name == field.name) {
+                return DecodeStatus::MalformedPayload;
+            }
+        }
+        decoded.fields.emplace_back(std::move(field));
+    }
+    if (!reader.AtEnd()) {
+        return DecodeStatus::MalformedPayload;
+    }
+    if (ComputeSchemaHash(decoded) != encoded_hash) {
+        return DecodeStatus::SchemaHashMismatch;
+    }
+
+    _schema = std::move(decoded);
+    return DecodeStatus::Ok;
+}
+
+DecodeStatus DecodeRecordPayload(
+    const PacketView&       _packet,
+    const SchemaDescriptor& _schema,
+    const CodecLimits&      _limits,
+    DecodedRecord&          _record
+) {
+    if (!ValidatePayloadView(_packet, PacketType::Record)) {
+        return DecodeStatus::MalformedPayload;
+    }
+    if (_packet.payload.size() > _limits.max_packet_payload_bytes ||
+        _schema.fields.size() > _limits.max_fields) {
+        return DecodeStatus::LimitExceeded;
+    }
+
+    ByteReader    reader(_packet.payload);
+    DecodedRecord decoded{};
+    std::uint32_t value_bytes = 0;
+    if (!reader.ReadLittleEndian(decoded.schema_hash) || !reader.ReadLittleEndian(decoded.sequence) ||
+        !reader.ReadLittleEndian(value_bytes)) {
+        return DecodeStatus::MalformedPayload;
+    }
+    if (decoded.schema_hash != ComputeSchemaHash(_schema)) {
+        return DecodeStatus::UnknownSchema;
+    }
+
+    std::span<const std::uint8_t> encoded_values;
+    if (!reader.ReadSpan(value_bytes, encoded_values) || !reader.AtEnd()) {
+        return DecodeStatus::MalformedPayload;
+    }
+
+    ByteReader value_reader(encoded_values);
+    decoded.values.reserve(_schema.fields.size());
+    for (const SchemaField& field : _schema.fields) {
+        if (!IsValidFieldType(field.type)) {
+            return DecodeStatus::MalformedPayload;
+        }
+        FieldValue         value{};
+        const DecodeStatus status = DecodeFieldValue(value_reader, field, _limits, value);
+        if (status != DecodeStatus::Ok) {
+            return status;
+        }
+        decoded.values.emplace_back(std::move(value));
+    }
+    if (!value_reader.AtEnd()) {
+        return DecodeStatus::MalformedPayload;
+    }
+
+    _record = std::move(decoded);
+    return DecodeStatus::Ok;
+}
+
+DecodeStatus DecodeLossPayload(const PacketView& _packet, LossNotice& _loss) noexcept {
+    if (!ValidatePayloadView(_packet, PacketType::Loss) || _packet.payload.size() != kLossPayloadBytes) {
+        return DecodeStatus::MalformedPayload;
+    }
+
+    ByteReader reader(_packet.payload);
+    LossNotice decoded{};
+    if (!reader.ReadLittleEndian(decoded.first_sequence) || !reader.ReadLittleEndian(decoded.last_sequence) ||
+        !reader.ReadLittleEndian(decoded.record_count) || !reader.ReadLittleEndian(decoded.value_bytes) ||
+        !reader.ReadLittleEndian(decoded.reason_mask) || !reader.AtEnd()) {
+        return DecodeStatus::MalformedPayload;
+    }
+
+    constexpr std::uint32_t known_reason_mask = static_cast<std::uint32_t>(LossReason::Oversized) |
+                                                static_cast<std::uint32_t>(LossReason::QueueFull) |
+                                                static_cast<std::uint32_t>(LossReason::StaleGeneration) |
+                                                static_cast<std::uint32_t>(LossReason::AfterShutdown) |
+                                                static_cast<std::uint32_t>(LossReason::SinkFault);
+    if (decoded.record_count == 0 || decoded.first_sequence > decoded.last_sequence ||
+        decoded.record_count - 1 > decoded.last_sequence - decoded.first_sequence ||
+        decoded.reason_mask == 0 || (decoded.reason_mask & ~known_reason_mask) != 0) {
+        return DecodeStatus::MalformedPayload;
+    }
+
+    _loss = decoded;
+    return DecodeStatus::Ok;
+}
+
+DecodeStatus DecodeSessionBeginPayload(const PacketView& _packet, SessionBeginInfo& _session) noexcept {
+    if (!ValidatePayloadView(_packet, PacketType::SessionBegin) ||
+        _packet.payload.size() != kSessionBeginPayloadBytes) {
+        return DecodeStatus::MalformedPayload;
+    }
+
+    ByteReader       reader(_packet.payload);
+    SessionBeginInfo decoded{};
+    if (!reader.ReadLittleEndian(decoded.generation) || !reader.ReadLittleEndian(decoded.started_unix_ns) ||
+        !reader.AtEnd()) {
+        return DecodeStatus::MalformedPayload;
+    }
+
+    _session = decoded;
+    return DecodeStatus::Ok;
+}
+
+DecodeStatus DecodeSessionEndPayload(const PacketView& _packet, SessionEndInfo& _session) noexcept {
+    if (!ValidatePayloadView(_packet, PacketType::SessionEnd) ||
+        _packet.payload.size() != kSessionEndPayloadBytes) {
+        return DecodeStatus::MalformedPayload;
+    }
+
+    ByteReader     reader(_packet.payload);
+    SessionEndInfo decoded{};
+    if (!reader.ReadLittleEndian(decoded.generation) || !reader.ReadLittleEndian(decoded.records_written) ||
+        !reader.ReadLittleEndian(decoded.records_dropped) || !reader.AtEnd()) {
+        return DecodeStatus::MalformedPayload;
+    }
+
+    _session = decoded;
+    return DecodeStatus::Ok;
+}
+
+} // namespace Moer::ProfileDump

--- a/source/runtime/core/source/profile/ProfileDumpTesting.h
+++ b/source/runtime/core/source/profile/ProfileDumpTesting.h
@@ -3,6 +3,7 @@
 
 #include "API_Macro.h"
 
+#include <cstddef>
 #include <cstdint>
 
 namespace Moer::ProfileDump::Testing {
@@ -26,6 +27,7 @@ CORE_API bool ConfigureFault(FaultPoint _point, std::uint64_t _trigger_hit = 1) 
 CORE_API bool ConfigureWriterPauseBeforeTempOpen(bool _enabled) noexcept;
 CORE_API bool ConfigureWriterPauseAfterStart(bool _enabled) noexcept;
 CORE_API bool WaitForWriterPaused(std::uint32_t _timeout_ms) noexcept;
+CORE_API bool CreateActiveTempCollision(const std::uint8_t* _bytes, std::size_t _byte_count) noexcept;
 CORE_API void ResumeWriter() noexcept;
 CORE_API void ClearHooks() noexcept;
 

--- a/source/runtime/core/source/profile/ProfileDumpTesting.h
+++ b/source/runtime/core/source/profile/ProfileDumpTesting.h
@@ -12,6 +12,7 @@ enum class FaultPoint : std::uint8_t {
     None = 0,
     StartAllocation,
     BeforeThreadCreate,
+    ShutdownFinalizeAllocation,
     OpenTempFile,
     WritePacket,
     FlushFile,

--- a/source/runtime/core/source/profile/ProfileDumpTesting.h
+++ b/source/runtime/core/source/profile/ProfileDumpTesting.h
@@ -1,0 +1,34 @@
+#ifndef MOER_ENGINE_PROFILE_DUMP_TESTING_H
+#define MOER_ENGINE_PROFILE_DUMP_TESTING_H
+
+#include "API_Macro.h"
+
+#include <cstdint>
+
+namespace Moer::ProfileDump::Testing {
+
+enum class FaultPoint : std::uint8_t {
+    None = 0,
+    StartAllocation,
+    BeforeThreadCreate,
+    OpenTempFile,
+    WritePacket,
+    FlushFile,
+    CloseFile,
+    RenameFinal,
+    WriterException,
+};
+
+// Hooks may only be changed while the runtime is stopped. The matching fault
+// is injected once, on the requested one-based hit.
+CORE_API bool ConfigureFault(FaultPoint _point, std::uint64_t _trigger_hit = 1) noexcept;
+
+CORE_API bool ConfigureWriterPauseBeforeTempOpen(bool _enabled) noexcept;
+CORE_API bool ConfigureWriterPauseAfterStart(bool _enabled) noexcept;
+CORE_API bool WaitForWriterPaused(std::uint32_t _timeout_ms) noexcept;
+CORE_API void ResumeWriter() noexcept;
+CORE_API void ClearHooks() noexcept;
+
+} // namespace Moer::ProfileDump::Testing
+
+#endif // MOER_ENGINE_PROFILE_DUMP_TESTING_H

--- a/source/test/CMakeLists.txt
+++ b/source/test/CMakeLists.txt
@@ -4,6 +4,18 @@ add_subdirectory(math)
 add_subdirectory(remote)
 add_subdirectory(scripting)
 
+set(test_target TestProfileDumpCore)
+add_executable(${test_target} "ProfileDumpCoreTest.cpp")
+target_include_directories(${test_target}
+    PRIVATE "${moer_source_dir}/runtime/core/source/profile"
+)
+target_link_libraries(${test_target}
+    PRIVATE Moer::Core
+)
+set_target_properties(${test_target} PROPERTIES FOLDER ${moer_test_folder})
+add_test(NAME ProfileDumpCoreContract COMMAND $<TARGET_FILE:${test_target}>)
+set_tests_properties(ProfileDumpCoreContract PROPERTIES TIMEOUT 60)
+
 set(test_target TestEngineOnly)
 add_executable(${test_target} "TestEngineOnly.cpp")
 target_link_libraries(${test_target}

--- a/source/test/ProfileDumpCoreTest.cpp
+++ b/source/test/ProfileDumpCoreTest.cpp
@@ -32,23 +32,59 @@ class ScopedOutput {
 public:
     explicit ScopedOutput(std::string_view _stem) {
         static std::atomic<std::uint64_t> next_id{0};
-        const auto                        now =
-            static_cast<std::uint64_t>(std::chrono::steady_clock::now().time_since_epoch().count());
-        path = std::filesystem::temp_directory_path() /
-               (std::string(_stem) + "-" + std::to_string(now) + "-" +
-                std::to_string(next_id.fetch_add(1, std::memory_order_relaxed)) + ".mpds");
+        for (std::uint32_t attempt = 0; attempt < 64; ++attempt) {
+            const auto now =
+                static_cast<std::uint64_t>(std::chrono::steady_clock::now().time_since_epoch().count());
+            const std::filesystem::path candidate =
+                std::filesystem::temp_directory_path() /
+                (std::string(_stem) + "-" + std::to_string(now) + "-" +
+                 std::to_string(next_id.fetch_add(1, std::memory_order_relaxed)));
+            std::error_code error;
+            if (std::filesystem::create_directory(candidate, error)) {
+                directory = candidate;
+                path      = directory / "capture.mpds";
+                return;
+            }
+            if (error && error != std::errc::file_exists) {
+                throw std::runtime_error("profile dump fixture directory could not be created");
+            }
+        }
+        throw std::runtime_error("profile dump fixture could not reserve a unique directory");
     }
 
     ~ScopedOutput() {
+        // Assertions can unwind while the singleton runtime is active. Reap
+        // its writer before removing the fixture-owned directory so cleanup
+        // never unlinks a live capture.
+        static_cast<void>(Shutdown());
         std::error_code error;
-        std::filesystem::remove(path, error);
-        std::filesystem::remove(InProgressPath(), error);
+        std::filesystem::remove_all(directory, error);
+    }
+
+    [[nodiscard]] std::vector<std::filesystem::path> InProgressPaths() const {
+        std::vector<std::filesystem::path>        candidates;
+        std::error_code                           error;
+        const std::string                         suffix = ".inprogress";
+        std::filesystem::directory_iterator       iterator(directory, error);
+        const std::filesystem::directory_iterator end;
+        while (!error && iterator != end) {
+            const std::string filename = iterator->path().filename().string();
+            if (filename.ends_with(suffix)) {
+                candidates.push_back(iterator->path());
+            }
+            iterator.increment(error);
+        }
+        std::ranges::sort(candidates);
+        return candidates;
     }
 
     [[nodiscard]] std::filesystem::path InProgressPath() const {
-        return std::filesystem::path(path.string() + ".inprogress");
+        const std::vector<std::filesystem::path> candidates = InProgressPaths();
+        Expect(candidates.size() == 1, "expected exactly one in-progress output");
+        return candidates.front();
     }
 
+    std::filesystem::path directory;
     std::filesystem::path path;
 };
 
@@ -498,6 +534,35 @@ private:
     bool active{true};
 };
 
+class FlushWaitersOnExit {
+public:
+    FlushWaitersOnExit(std::atomic<bool>& _release, std::vector<std::jthread>& _waiters) noexcept :
+        release(_release),
+        waiters(_waiters) {}
+
+    FlushWaitersOnExit(const FlushWaitersOnExit&)            = delete;
+    FlushWaitersOnExit& operator=(const FlushWaitersOnExit&) = delete;
+
+    ~FlushWaitersOnExit() {
+        Drain();
+    }
+
+    void Drain() noexcept {
+        if (!active) {
+            return;
+        }
+        release.store(true, std::memory_order_release);
+        Testing::ResumeWriter();
+        waiters.clear();
+        active = false;
+    }
+
+private:
+    std::atomic<bool>&         release;
+    std::vector<std::jthread>& waiters;
+    bool                       active{true};
+};
+
 void TestRuntimeLifecycleAndRestart() {
     Expect(Shutdown() == ShutdownResult::AlreadyStopped, "runtime did not begin in the stopped state");
 
@@ -534,9 +599,7 @@ void TestRuntimeLifecycleAndRestart() {
     Expect(Shutdown() == ShutdownResult::Completed, "runtime shutdown did not complete");
     Expect(GetRuntimeState() == RuntimeState::Stopped, "shutdown runtime is not stopped");
     Expect(std::filesystem::exists(first_output.path), "shutdown did not publish final output");
-    Expect(
-        !std::filesystem::exists(first_output.InProgressPath()), "shutdown left the in-progress file behind"
-    );
+    Expect(first_output.InProgressPaths().empty(), "shutdown left the in-progress file behind");
 
     const ParsedDump first_dump = ParseDump(first_output.path, first_config.codec_limits);
     Expect(first_dump.packet_types.front() == PacketType::SessionBegin, "session begin is not first");
@@ -606,7 +669,7 @@ void TestStartAllocationFailureIsContained() {
     );
     Expect(GetRuntimeState() == RuntimeState::Stopped, "start allocation failure changed runtime state");
     Expect(
-        !std::filesystem::exists(output.path) && !std::filesystem::exists(output.InProgressPath()),
+        !std::filesystem::exists(output.path) && output.InProgressPaths().empty(),
         "start allocation failure left an output artifact"
     );
     Expect(
@@ -641,15 +704,10 @@ void TestExclusiveTempCreateRace() {
         0x4c,
         0x21,
     };
-    {
-        std::ofstream stream(output.InProgressPath(), std::ios::binary | std::ios::trunc);
-        Expect(stream.is_open(), "competing temp fixture could not be opened");
-        stream.write(
-            reinterpret_cast<const char*>(competing_bytes.data()),
-            static_cast<std::streamsize>(competing_bytes.size())
-        );
-        Expect(stream.good(), "competing temp fixture could not be written");
-    }
+    Expect(
+        Testing::CreateActiveTempCollision(competing_bytes.data(), competing_bytes.size()),
+        "competing temp fixture could not be created"
+    );
 
     resume_guard.Resume();
     starter.join();
@@ -665,6 +723,135 @@ void TestExclusiveTempCreateRace() {
         "exclusive temp collision did not restore the stopped lifecycle"
     );
     Testing::ClearHooks();
+}
+
+void TestReplacementPreservesForeignTemp() {
+    Testing::ClearHooks();
+    ScopedOutput  output("moer-profile-replacement-foreign-temp");
+    RuntimeConfig config    = MakeRuntimeConfig(output);
+    config.replace_existing = true;
+
+    // Recreate the exact fixed path used by the old implementation. A
+    // replacement start must treat it as another session's live/forensic
+    // artifact instead of unlinking it.
+    std::filesystem::path foreign_temp = output.path;
+    foreign_temp += ".inprogress";
+    const std::array<std::uint8_t, 7> foreign_bytes = {
+        0x46,
+        0x4f,
+        0x52,
+        0x45,
+        0x49,
+        0x47,
+        0x4e,
+    };
+    {
+        std::ofstream stream(foreign_temp, std::ios::binary | std::ios::trunc);
+        Expect(stream.is_open(), "foreign temp fixture could not be opened");
+        stream.write(
+            reinterpret_cast<const char*>(foreign_bytes.data()),
+            static_cast<std::streamsize>(foreign_bytes.size())
+        );
+        Expect(stream.good(), "foreign temp fixture could not be written");
+    }
+
+    Expect(Start(config) == StartResult::Started, "replacement runtime failed to start");
+    Expect(
+        output.InProgressPaths().size() == 2,
+        "replacement runtime did not keep its temp separate from the foreign temp"
+    );
+    Expect(
+        ReadBinaryFile(foreign_temp) == std::vector<std::uint8_t>(foreign_bytes.begin(), foreign_bytes.end()),
+        "replacement startup modified the foreign temp"
+    );
+    Expect(Shutdown() == ShutdownResult::Completed, "replacement runtime did not shut down cleanly");
+    const std::vector<std::filesystem::path> remaining = output.InProgressPaths();
+    Expect(
+        remaining.size() == 1 && remaining.front() == foreign_temp,
+        "replacement finalization removed or retained the wrong temp"
+    );
+    Expect(
+        ReadBinaryFile(foreign_temp) == std::vector<std::uint8_t>(foreign_bytes.begin(), foreign_bytes.end()),
+        "replacement finalization modified the foreign temp"
+    );
+}
+
+void TestFinalPublicationRaces() {
+    Testing::ClearHooks();
+    const std::array<std::uint8_t, 8> competing_final = {
+        0x45,
+        0x58,
+        0x54,
+        0x45,
+        0x52,
+        0x4e,
+        0x41,
+        0x4c,
+    };
+
+    {
+        ScopedOutput        output("moer-profile-final-no-replace-race");
+        const RuntimeConfig config = MakeRuntimeConfig(output);
+        Expect(Start(config) == StartResult::Started, "no-replace race runtime failed to start");
+        const std::filesystem::path session_temp = output.InProgressPath();
+        {
+            std::ofstream stream(output.path, std::ios::binary | std::ios::trunc);
+            Expect(stream.is_open(), "competing final fixture could not be opened");
+            stream.write(
+                reinterpret_cast<const char*>(competing_final.data()),
+                static_cast<std::streamsize>(competing_final.size())
+            );
+            Expect(stream.good(), "competing final fixture could not be written");
+        }
+
+        Expect(
+            Shutdown() == ShutdownResult::Faulted,
+            "no-replace publication overwrote a final created after Start"
+        );
+        const RuntimeStats stats = GetRuntimeStats();
+        Expect(stats.last_fault == RuntimeFault::RenameFinal, "final-name race fault identity changed");
+        Expect(
+            ReadBinaryFile(output.path) ==
+                std::vector<std::uint8_t>(competing_final.begin(), competing_final.end()),
+            "no-replace publication modified the competing final"
+        );
+        Expect(
+            std::filesystem::exists(session_temp),
+            "no-replace publication race removed the forensic session temp"
+        );
+        Expect(
+            Shutdown() == ShutdownResult::AlreadyStopped,
+            "no-replace publication race did not restore the stopped lifecycle"
+        );
+    }
+
+    {
+        ScopedOutput  output("moer-profile-final-replace-race");
+        RuntimeConfig config    = MakeRuntimeConfig(output);
+        config.replace_existing = true;
+        Expect(Start(config) == StartResult::Started, "replace race runtime failed to start");
+        {
+            std::ofstream stream(output.path, std::ios::binary | std::ios::trunc);
+            Expect(stream.is_open(), "replace race final fixture could not be opened");
+            stream.write(
+                reinterpret_cast<const char*>(competing_final.data()),
+                static_cast<std::streamsize>(competing_final.size())
+            );
+            Expect(stream.good(), "replace race final fixture could not be written");
+        }
+
+        Expect(
+            Shutdown() == ShutdownResult::Completed,
+            "replacement publication did not atomically replace the competing final"
+        );
+        Expect(output.InProgressPaths().empty(), "replacement publication retained its session temp");
+        const ParsedDump dump = ParseDump(output.path, config.codec_limits);
+        Expect(
+            dump.packet_types.front() == PacketType::SessionBegin &&
+                dump.packet_types.back() == PacketType::SessionEnd,
+            "replacement publication exposed an incomplete capture"
+        );
+    }
 }
 
 void TestMultithreadedProducers() {
@@ -746,6 +933,7 @@ void TestMultithreadedProducers() {
 
 void TestBoundedQueueDropNewest() {
     Testing::ClearHooks();
+    ScopedOutput output("moer-profile-bounded");
     Expect(
         Testing::ConfigureWriterPauseAfterStart(true),
         "writer pause hook could not be configured while stopped"
@@ -774,7 +962,6 @@ void TestBoundedQueueDropNewest() {
     const std::size_t record_bytes = encoded_record.size();
     Expect(record_bytes > 0, "bounded queue test produced an empty record");
 
-    ScopedOutput  output("moer-profile-bounded");
     RuntimeConfig config       = MakeRuntimeConfig(output);
     config.max_record_bytes    = record_bytes * 2;
     config.tls_publish_records = 1;
@@ -878,13 +1065,13 @@ void TestBoundedQueueDropNewest() {
 
 void TestConcurrentFlushWaiters() {
     Testing::ClearHooks();
+    ScopedOutput output("moer-profile-concurrent-flush");
     Expect(
         Testing::ConfigureWriterPauseAfterStart(true),
         "flush waiter pause hook could not be configured while stopped"
     );
     ResumeWriterOnExit resume_guard;
 
-    ScopedOutput  output("moer-profile-concurrent-flush");
     RuntimeConfig config       = MakeRuntimeConfig(output);
     config.tls_publish_records = 1;
     Expect(Start(config) == StartResult::Started, "flush waiter runtime failed to start");
@@ -909,6 +1096,7 @@ void TestConcurrentFlushWaiters() {
     std::atomic<bool>         release{false};
     std::vector<std::jthread> waiters;
     waiters.reserve(waiter_count);
+    FlushWaitersOnExit waiters_guard(release, waiters);
     for (std::size_t index = 0; index < waiter_count; ++index) {
         waiters.emplace_back([&, index] {
             ready.fetch_add(1, std::memory_order_release);
@@ -928,8 +1116,8 @@ void TestConcurrentFlushWaiters() {
         std::this_thread::yield();
     }
 
+    waiters_guard.Drain();
     resume_guard.Resume();
-    waiters.clear();
     for (FlushResult result : results) {
         Expect(
             result == FlushResult::Completed || result == FlushResult::NothingPending,
@@ -1101,6 +1289,8 @@ int main() {
         TestRuntimeLifecycleAndRestart();
         TestStartAllocationFailureIsContained();
         TestExclusiveTempCreateRace();
+        TestReplacementPreservesForeignTemp();
+        TestFinalPublicationRaces();
         TestMultithreadedProducers();
         TestBoundedQueueDropNewest();
         TestConcurrentFlushWaiters();

--- a/source/test/ProfileDumpCoreTest.cpp
+++ b/source/test/ProfileDumpCoreTest.cpp
@@ -1,0 +1,1124 @@
+#include "ProfileDumpTesting.h"
+#include "profile/ProfileDump.h"
+#include "profile/ProfileDumpCodec.h"
+
+#include <algorithm>
+#include <array>
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <span>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <thread>
+#include <vector>
+
+namespace {
+
+using namespace Moer::ProfileDump;
+
+void Expect(bool _condition, std::string_view _message) {
+    if (!_condition) {
+        throw std::runtime_error(std::string(_message));
+    }
+}
+
+class ScopedOutput {
+public:
+    explicit ScopedOutput(std::string_view _stem) {
+        static std::atomic<std::uint64_t> next_id{0};
+        const auto                        now =
+            static_cast<std::uint64_t>(std::chrono::steady_clock::now().time_since_epoch().count());
+        path = std::filesystem::temp_directory_path() /
+               (std::string(_stem) + "-" + std::to_string(now) + "-" +
+                std::to_string(next_id.fetch_add(1, std::memory_order_relaxed)) + ".mpds");
+    }
+
+    ~ScopedOutput() {
+        std::error_code error;
+        std::filesystem::remove(path, error);
+        std::filesystem::remove(InProgressPath(), error);
+    }
+
+    [[nodiscard]] std::filesystem::path InProgressPath() const {
+        return std::filesystem::path(path.string() + ".inprogress");
+    }
+
+    std::filesystem::path path;
+};
+
+std::vector<std::uint8_t> ReadBinaryFile(const std::filesystem::path& _path) {
+    std::ifstream stream(_path, std::ios::binary | std::ios::ate);
+    Expect(stream.is_open(), "profile dump output could not be opened");
+    const std::streamoff size = stream.tellg();
+    Expect(size >= 0, "profile dump output size is invalid");
+    std::vector<std::uint8_t> bytes(static_cast<std::size_t>(size));
+    stream.seekg(0);
+    if (!bytes.empty()) {
+        stream.read(reinterpret_cast<char*>(bytes.data()), static_cast<std::streamsize>(bytes.size()));
+    }
+    Expect(stream.good() || stream.eof(), "profile dump output could not be read");
+    return bytes;
+}
+
+struct ParsedDump {
+    std::vector<PacketType>       packet_types;
+    std::vector<std::uint64_t>    packet_indices;
+    std::vector<SchemaDescriptor> schemas;
+    std::vector<DecodedRecord>    records;
+    std::vector<LossNotice>       losses;
+    std::vector<SessionBeginInfo> session_begins;
+    std::vector<SessionEndInfo>   session_ends;
+};
+
+ParsedDump ParseDump(const std::filesystem::path& _path, const CodecLimits& _limits) {
+    const std::vector<std::uint8_t> bytes = ReadBinaryFile(_path);
+    Expect(!bytes.empty(), "profile dump output is empty");
+
+    ParsedDump  parsed;
+    std::size_t offset = 0;
+    while (offset < bytes.size()) {
+        PacketView         packet{};
+        std::size_t        consumed = 0;
+        const DecodeStatus status =
+            DecodePacket(std::span<const std::uint8_t>(bytes).subspan(offset), _limits, packet, consumed);
+        Expect(status == DecodeStatus::Ok, "profile dump packet failed validation");
+        Expect(consumed > 0, "successful packet decode consumed no input");
+        parsed.packet_types.push_back(packet.header.type);
+        parsed.packet_indices.push_back(packet.header.packet_index);
+
+        switch (packet.header.type) {
+            case PacketType::SessionBegin: {
+                SessionBeginInfo session{};
+                Expect(
+                    DecodeSessionBeginPayload(packet, session) == DecodeStatus::Ok,
+                    "session begin payload failed to decode"
+                );
+                parsed.session_begins.push_back(session);
+                break;
+            }
+            case PacketType::Schema: {
+                SchemaDescriptor schema{};
+                Expect(
+                    DecodeSchemaPayload(packet, _limits, schema) == DecodeStatus::Ok,
+                    "schema payload failed to decode"
+                );
+                parsed.schemas.push_back(std::move(schema));
+                break;
+            }
+            case PacketType::Record: {
+                Expect(!parsed.schemas.empty(), "record packet preceded every schema packet");
+                DecodedRecord record{};
+                bool          decoded = false;
+                for (const SchemaDescriptor& schema : parsed.schemas) {
+                    if (DecodeRecordPayload(packet, schema, _limits, record) == DecodeStatus::Ok) {
+                        decoded = true;
+                        break;
+                    }
+                }
+                Expect(decoded, "record payload did not match any preceding schema");
+                parsed.records.push_back(std::move(record));
+                break;
+            }
+            case PacketType::Loss: {
+                LossNotice loss{};
+                Expect(DecodeLossPayload(packet, loss) == DecodeStatus::Ok, "loss payload failed to decode");
+                parsed.losses.push_back(loss);
+                break;
+            }
+            case PacketType::SessionEnd: {
+                SessionEndInfo session{};
+                Expect(
+                    DecodeSessionEndPayload(packet, session) == DecodeStatus::Ok,
+                    "session end payload failed to decode"
+                );
+                parsed.session_ends.push_back(session);
+                break;
+            }
+        }
+        offset += consumed;
+    }
+
+    Expect(offset == bytes.size(), "profile dump ended with trailing bytes");
+    for (std::size_t index = 0; index < parsed.packet_indices.size(); ++index) {
+        Expect(parsed.packet_indices[index] == index, "packet indices must be contiguous and start at zero");
+    }
+    return parsed;
+}
+
+SchemaDescriptor MakeAllTypesSchema() {
+    return {
+        .name           = "AllTypes",
+        .event_type     = "contract.all_types",
+        .kind           = EventKind::Instant,
+        .channel        = Channel::CpuThread,
+        .schema_version = 7,
+        .fields =
+            {
+                {"bool", FieldType::Bool},
+                {"int32", FieldType::Int32},
+                {"uint32", FieldType::UInt32},
+                {"int64", FieldType::Int64},
+                {"uint64", FieldType::UInt64},
+                {"float32", FieldType::Float32},
+                {"float64", FieldType::Float64},
+                {"string", FieldType::String},
+            },
+    };
+}
+
+SchemaDescriptor MakeRuntimeSchema() {
+    return {
+        .name           = "RuntimeRecord",
+        .event_type     = "contract.runtime_record",
+        .kind           = EventKind::Instant,
+        .channel        = Channel::CpuThread,
+        .schema_version = 1,
+        .fields =
+            {
+                {"producer", FieldType::UInt64},
+                {"sequence", FieldType::UInt64},
+                {"label", FieldType::String},
+            },
+    };
+}
+
+void TestV3LittleEndianGoldenVector() {
+    constexpr std::array<std::uint8_t, 16> expected_payload = {
+        0x08,
+        0x07,
+        0x06,
+        0x05,
+        0x04,
+        0x03,
+        0x02,
+        0x01,
+        0x18,
+        0x17,
+        0x16,
+        0x15,
+        0x14,
+        0x13,
+        0x12,
+        0x11,
+    };
+    // Fixed protocol vector. CRC32 constants were generated independently
+    // from the v3 wire specification, not decoded from codec output:
+    // payload_crc32 = 0xcbd946cf, header_crc32 = 0x782b1023.
+    constexpr std::array<std::uint8_t, 48> expected_packet = {
+        0x4d, 0x50, 0x44, 0x53, 0x03, 0x00, 0x20, 0x00, 0x01, 0x00, 0x00, 0x00, 0x10, 0x00, 0x00, 0x00,
+        0x28, 0x27, 0x26, 0x25, 0x24, 0x23, 0x22, 0x21, 0xcf, 0x46, 0xd9, 0xcb, 0x23, 0x10, 0x2b, 0x78,
+        0x08, 0x07, 0x06, 0x05, 0x04, 0x03, 0x02, 0x01, 0x18, 0x17, 0x16, 0x15, 0x14, 0x13, 0x12, 0x11,
+    };
+    const SessionBeginInfo source{
+        .generation      = 0x0102030405060708ull,
+        .started_unix_ns = 0x1112131415161718ull,
+    };
+
+    Moer::Array<std::uint8_t> payload;
+    EncodeSessionBeginPayload(source, payload);
+    Expect(
+        std::equal(payload.begin(), payload.end(), expected_payload.begin(), expected_payload.end()),
+        "session begin payload no longer uses the v3 explicit little-endian vector"
+    );
+
+    Moer::Array<std::uint8_t> packet;
+    Expect(
+        WrapPacket(PacketType::SessionBegin, 0x2122232425262728ull, payload, CodecLimits{}, packet) ==
+            EncodeStatus::Ok,
+        "golden session packet failed to wrap"
+    );
+    Expect(
+        std::equal(packet.begin(), packet.end(), expected_packet.begin(), expected_packet.end()),
+        "wrapped v3 header or CRC no longer matches the fixed golden vector"
+    );
+
+    PacketView  decoded{};
+    std::size_t consumed = 0;
+    Expect(
+        DecodePacket(expected_packet, CodecLimits{}, decoded, consumed) == DecodeStatus::Ok,
+        "fixed v3 golden vector failed to decode"
+    );
+    Expect(consumed == expected_packet.size(), "golden vector consumed the wrong byte count");
+    Expect(decoded.header.payload_crc32 == 0xcbd946cfu, "golden payload CRC decoded incorrectly");
+    Expect(decoded.header.header_crc32 == 0x782b1023u, "golden header CRC decoded incorrectly");
+    SessionBeginInfo round_trip{};
+    Expect(
+        DecodeSessionBeginPayload(decoded, round_trip) == DecodeStatus::Ok &&
+            round_trip.generation == source.generation &&
+            round_trip.started_unix_ns == source.started_unix_ns,
+        "golden session payload decoded with the wrong endianness"
+    );
+}
+
+void TestLossDecodeHardening() {
+    const LossNotice valid{
+        .first_sequence = 10,
+        .last_sequence  = 12,
+        .record_count   = 3,
+        .value_bytes    = 99,
+        .reason_mask    = static_cast<std::uint32_t>(LossReason::QueueFull),
+    };
+    Moer::Array<std::uint8_t> valid_payload;
+    EncodeLossPayload(valid, valid_payload);
+    Expect(valid_payload.size() == 36, "v3 loss payload size changed");
+
+    auto WriteU64 = [](Moer::Array<std::uint8_t>& _payload, std::size_t _offset, std::uint64_t _value) {
+        for (std::size_t byte = 0; byte < sizeof(_value); ++byte) {
+            _payload[_offset + byte] = static_cast<std::uint8_t>(_value >> (byte * 8));
+        }
+    };
+    auto WriteU32 = [](Moer::Array<std::uint8_t>& _payload, std::size_t _offset, std::uint32_t _value) {
+        for (std::size_t byte = 0; byte < sizeof(_value); ++byte) {
+            _payload[_offset + byte] = static_cast<std::uint8_t>(_value >> (byte * 8));
+        }
+    };
+    auto ExpectMalformed = [&](Moer::Array<std::uint8_t> _payload, std::string_view _message) {
+        const PacketView packet{
+            .header =
+                PacketHeader{
+                    .type          = PacketType::Loss,
+                    .payload_bytes = static_cast<std::uint32_t>(_payload.size()),
+                },
+            .payload = _payload,
+        };
+        LossNotice decoded{};
+        Expect(DecodeLossPayload(packet, decoded) == DecodeStatus::MalformedPayload, _message);
+    };
+
+    Moer::Array<std::uint8_t> malformed = valid_payload;
+    WriteU64(malformed, 16, 0);
+    ExpectMalformed(std::move(malformed), "zero-count loss notice was accepted");
+    malformed = valid_payload;
+    WriteU64(malformed, 0, 13);
+    ExpectMalformed(std::move(malformed), "reversed loss sequence interval was accepted");
+    malformed = valid_payload;
+    WriteU64(malformed, 8, 10);
+    WriteU64(malformed, 16, 2);
+    ExpectMalformed(std::move(malformed), "loss count larger than its sequence interval was accepted");
+    malformed = valid_payload;
+    WriteU32(malformed, 32, 0);
+    ExpectMalformed(std::move(malformed), "zero-reason loss notice was accepted");
+    malformed = valid_payload;
+    WriteU32(malformed, 32, 0x80000000u);
+    ExpectMalformed(std::move(malformed), "unknown loss reason bit was accepted");
+}
+
+void TestCodecRoundTripAndChecksums() {
+    const CodecLimits      limits{};
+    const SchemaDescriptor schema = MakeAllTypesSchema();
+
+    Moer::Array<std::uint8_t> schema_payload;
+    Expect(
+        EncodeSchemaPayload(schema, limits, schema_payload) == EncodeStatus::Ok,
+        "all-types schema failed to encode"
+    );
+    Moer::Array<std::uint8_t> schema_packet;
+    Expect(
+        WrapPacket(PacketType::Schema, 0, schema_payload, limits, schema_packet) == EncodeStatus::Ok,
+        "schema packet failed to wrap"
+    );
+
+    PacketView  decoded_schema_packet{};
+    std::size_t consumed = 0;
+    Expect(
+        DecodePacket(schema_packet, limits, decoded_schema_packet, consumed) == DecodeStatus::Ok,
+        "schema packet failed to decode"
+    );
+    Expect(consumed == schema_packet.size(), "schema packet consumed an unexpected byte count");
+    Expect(decoded_schema_packet.header.magic == kPacketMagic, "packet magic changed");
+    Expect(decoded_schema_packet.header.wire_version == kWireVersion, "wire version changed");
+    Expect(decoded_schema_packet.header.header_bytes == kPacketHeaderBytes, "wire header size changed");
+
+    SchemaDescriptor decoded_schema{};
+    Expect(
+        DecodeSchemaPayload(decoded_schema_packet, limits, decoded_schema) == DecodeStatus::Ok,
+        "schema payload failed to round-trip"
+    );
+    Expect(decoded_schema == schema, "schema round-trip changed a descriptor field");
+
+    const std::array<FieldValueView, 8> values = {
+        FieldValueView{true},
+        FieldValueView{std::int32_t{-17}},
+        FieldValueView{std::uint32_t{23}},
+        FieldValueView{std::int64_t{-1234567890123}},
+        FieldValueView{std::uint64_t{12345678901234}},
+        FieldValueView{1.25F},
+        FieldValueView{-9.5},
+        FieldValueView{std::string_view("round-trip-string")},
+    };
+    Moer::Array<std::uint8_t> record_payload;
+    const std::uint64_t       schema_hash = ComputeSchemaHash(schema);
+    Expect(schema_hash != 0, "valid schema produced the reserved zero hash");
+    Expect(
+        EncodeRecordPayload(0, 91, schema.fields, values, limits, record_payload) ==
+            EncodeStatus::InvalidSchema,
+        "reserved zero schema hash was accepted"
+    );
+    Expect(
+        EncodeRecordPayload(schema_hash, 91, schema.fields, values, limits, record_payload) ==
+            EncodeStatus::Ok,
+        "all-types record failed to encode"
+    );
+    Moer::Array<std::uint8_t> record_packet;
+    Expect(
+        WrapPacket(PacketType::Record, 1, record_payload, limits, record_packet) == EncodeStatus::Ok,
+        "record packet failed to wrap"
+    );
+
+    PacketView decoded_record_packet{};
+    consumed = 0;
+    Expect(
+        DecodePacket(record_packet, limits, decoded_record_packet, consumed) == DecodeStatus::Ok,
+        "record packet failed to decode"
+    );
+    DecodedRecord record{};
+    Expect(
+        DecodeRecordPayload(decoded_record_packet, schema, limits, record) == DecodeStatus::Ok,
+        "record payload failed to round-trip"
+    );
+    Expect(record.schema_hash == schema_hash, "record schema hash changed");
+    Expect(record.sequence == 91, "record sequence changed");
+    Expect(record.values.size() == values.size(), "record value count changed");
+    Expect(std::get<bool>(record.values[0]), "bool value changed");
+    Expect(std::get<std::int32_t>(record.values[1]) == -17, "int32 value changed");
+    Expect(std::get<std::uint32_t>(record.values[2]) == 23, "uint32 value changed");
+    Expect(std::get<std::int64_t>(record.values[3]) == -1234567890123, "int64 value changed");
+    Expect(std::get<std::uint64_t>(record.values[4]) == 12345678901234, "uint64 value changed");
+    Expect(std::get<float>(record.values[5]) == 1.25F, "float32 value changed");
+    Expect(std::get<double>(record.values[6]) == -9.5, "float64 value changed");
+    Expect(std::get<ProfileString>(record.values[7]) == "round-trip-string", "string value changed");
+
+    for (std::size_t prefix = 0; prefix < record_packet.size(); ++prefix) {
+        PacketView truncated_packet{};
+        consumed                  = 99;
+        const DecodeStatus status = DecodePacket(
+            std::span<const std::uint8_t>(record_packet).first(prefix), limits, truncated_packet, consumed
+        );
+        Expect(status == DecodeStatus::NeedMoreData, "truncated packet was not retryable");
+        Expect(consumed == 0, "truncated packet consumed input");
+    }
+
+    Moer::Array<std::uint8_t> damaged_header = record_packet;
+    damaged_header[kPacketHeaderBytes - 1] ^= 0x80;
+    PacketView damaged_packet{};
+    consumed = 99;
+    Expect(
+        DecodePacket(damaged_header, limits, damaged_packet, consumed) == DecodeStatus::ChecksumMismatch,
+        "header CRC corruption was not detected"
+    );
+    Expect(consumed == 0, "bad header CRC consumed input");
+
+    Moer::Array<std::uint8_t> damaged_payload = record_packet;
+    damaged_payload[kPacketHeaderBytes] ^= 0x80;
+    consumed = 99;
+    Expect(
+        DecodePacket(damaged_payload, limits, damaged_packet, consumed) == DecodeStatus::ChecksumMismatch,
+        "payload CRC corruption was not detected"
+    );
+    Expect(consumed == 0, "bad payload CRC consumed input");
+}
+
+void TestSchemaHashCoverage() {
+    const SchemaDescriptor baseline      = MakeAllTypesSchema();
+    const std::uint64_t    baseline_hash = ComputeSchemaHash(baseline);
+    auto                   ExpectChanged = [&](SchemaDescriptor _changed, std::string_view _message) {
+        Expect(ComputeSchemaHash(_changed) != baseline_hash, _message);
+    };
+
+    SchemaDescriptor changed = baseline;
+    changed.name += ".changed";
+    ExpectChanged(changed, "schema name is absent from the schema hash");
+    changed = baseline;
+    changed.event_type += ".changed";
+    ExpectChanged(changed, "event type is absent from the schema hash");
+    changed      = baseline;
+    changed.kind = EventKind::Counter;
+    ExpectChanged(changed, "event kind is absent from the schema hash");
+    changed         = baseline;
+    changed.channel = Channel::GpuQueue;
+    ExpectChanged(changed, "channel is absent from the schema hash");
+    changed = baseline;
+    ++changed.schema_version;
+    ExpectChanged(changed, "schema version is absent from the schema hash");
+    changed = baseline;
+    changed.fields[0].name += ".changed";
+    ExpectChanged(changed, "field name is absent from the schema hash");
+    changed                = baseline;
+    changed.fields[0].type = FieldType::UInt64;
+    ExpectChanged(changed, "field type is absent from the schema hash");
+    changed = baseline;
+    changed.fields.pop_back();
+    ExpectChanged(changed, "field count is absent from the schema hash");
+}
+
+RuntimeConfig MakeRuntimeConfig(const ScopedOutput& _output) {
+    RuntimeConfig config{};
+    config.output_path         = _output.path;
+    config.replace_existing    = false;
+    config.tls_publish_records = 8;
+    config.tls_publish_bytes   = 1024;
+    config.tls_max_records     = 64;
+    config.tls_max_bytes       = 64 * 1024;
+    config.queue_max_chunks    = 64;
+    config.queue_max_records   = 4096;
+    config.queue_max_bytes     = 4 * 1024 * 1024;
+    return config;
+}
+
+void ExpectFlushSucceeded(FlushResult _result, std::string_view _message) {
+    Expect(_result == FlushResult::Completed || _result == FlushResult::NothingPending, _message);
+}
+
+class ResumeWriterOnExit {
+public:
+    ResumeWriterOnExit()                                     = default;
+    ResumeWriterOnExit(const ResumeWriterOnExit&)            = delete;
+    ResumeWriterOnExit& operator=(const ResumeWriterOnExit&) = delete;
+
+    ~ResumeWriterOnExit() {
+        if (active) {
+            Testing::ResumeWriter();
+        }
+    }
+
+    void Resume() noexcept {
+        if (active) {
+            Testing::ResumeWriter();
+            active = false;
+        }
+    }
+
+private:
+    bool active{true};
+};
+
+void TestRuntimeLifecycleAndRestart() {
+    Expect(Shutdown() == ShutdownResult::AlreadyStopped, "runtime did not begin in the stopped state");
+
+    const SchemaDescriptor schema = MakeRuntimeSchema();
+    ScopedOutput           first_output("moer-profile-runtime");
+    const RuntimeConfig    first_config = MakeRuntimeConfig(first_output);
+    Expect(Start(first_config) == StartResult::Started, "runtime failed to start");
+    Expect(GetRuntimeState() == RuntimeState::Running, "started runtime is not running");
+    Expect(
+        std::filesystem::exists(first_output.InProgressPath()), "start did not create the in-progress file"
+    );
+    Expect(!std::filesystem::exists(first_output.path), "final output became visible before shutdown");
+
+    const SchemaRegistration registration = RegisterSchema(schema);
+    Expect(registration.status == SchemaStatus::Registered, "runtime schema was not registered");
+    Expect(static_cast<bool>(registration.handle), "registered schema returned an invalid handle");
+    const SchemaRegistration duplicate = RegisterSchema(schema);
+    Expect(
+        duplicate.status == SchemaStatus::AlreadyRegistered,
+        "duplicate schema registration was not idempotent"
+    );
+    Expect(duplicate.handle == registration.handle, "duplicate registration changed the handle");
+
+    const std::array<FieldValueView, 3> values = {
+        FieldValueView{std::uint64_t{3}},
+        FieldValueView{std::uint64_t{17}},
+        FieldValueView{std::string_view("single")},
+    };
+    Expect(Emit(registration.handle, values) == EmitStatus::Accepted, "runtime rejected a valid record");
+    ExpectFlushSucceeded(FlushThreadLocal(), "thread-local flush failed");
+    ExpectFlushSucceeded(FlushAll(), "global flush failed");
+    const RuntimeStats before_shutdown = GetRuntimeStats();
+    Expect(before_shutdown.generation == registration.handle.generation, "handle generation drifted");
+    Expect(Shutdown() == ShutdownResult::Completed, "runtime shutdown did not complete");
+    Expect(GetRuntimeState() == RuntimeState::Stopped, "shutdown runtime is not stopped");
+    Expect(std::filesystem::exists(first_output.path), "shutdown did not publish final output");
+    Expect(
+        !std::filesystem::exists(first_output.InProgressPath()), "shutdown left the in-progress file behind"
+    );
+
+    const ParsedDump first_dump = ParseDump(first_output.path, first_config.codec_limits);
+    Expect(first_dump.packet_types.front() == PacketType::SessionBegin, "session begin is not first");
+    Expect(first_dump.packet_types.back() == PacketType::SessionEnd, "session end is not last");
+    Expect(first_dump.schemas.size() == 1, "runtime wrote an unexpected schema count");
+    Expect(first_dump.schemas.front() == schema, "runtime schema changed on disk");
+    Expect(first_dump.records.size() == 1, "runtime wrote an unexpected record count");
+    Expect(first_dump.session_begins.size() == 1, "runtime wrote no unique session begin");
+    Expect(first_dump.session_ends.size() == 1, "runtime wrote no unique session end");
+    Expect(
+        first_dump.session_begins.front().generation == registration.handle.generation,
+        "session begin generation disagrees with the schema handle"
+    );
+    Expect(
+        first_dump.session_ends.front().generation == registration.handle.generation,
+        "session end generation disagrees with the schema handle"
+    );
+    auto schema_position =
+        std::find(first_dump.packet_types.begin(), first_dump.packet_types.end(), PacketType::Schema);
+    auto record_position =
+        std::find(first_dump.packet_types.begin(), first_dump.packet_types.end(), PacketType::Record);
+    Expect(schema_position < record_position, "runtime persisted a record before its schema");
+
+    ScopedOutput        second_output("moer-profile-restart");
+    const RuntimeConfig second_config = MakeRuntimeConfig(second_output);
+    Expect(Start(second_config) == StartResult::Started, "runtime failed to restart");
+    const RuntimeStats restarted_stats = GetRuntimeStats();
+    Expect(
+        restarted_stats.generation != registration.handle.generation,
+        "runtime restart reused the previous generation"
+    );
+    Expect(
+        Emit(registration.handle, values) == EmitStatus::InvalidHandle,
+        "runtime accepted a stale schema handle after restart"
+    );
+    const SchemaRegistration restarted_registration = RegisterSchema(schema);
+    Expect(
+        restarted_registration.status == SchemaStatus::Registered, "schema registration failed after restart"
+    );
+    Expect(
+        restarted_registration.handle.generation == restarted_stats.generation,
+        "restarted schema handle has the wrong generation"
+    );
+    Expect(
+        Emit(restarted_registration.handle, values) == EmitStatus::Accepted,
+        "runtime rejected a valid record after restart"
+    );
+    ExpectFlushSucceeded(FlushThreadLocal(), "restart thread-local flush failed");
+    Expect(Shutdown() == ShutdownResult::Completed, "restarted runtime did not shut down");
+    const ParsedDump second_dump = ParseDump(second_output.path, second_config.codec_limits);
+    Expect(second_dump.records.size() == 1, "restart output lost or duplicated its record");
+    Expect(Shutdown() == ShutdownResult::AlreadyStopped, "successful shutdown was not idempotent");
+}
+
+void TestStartAllocationFailureIsContained() {
+    Testing::ClearHooks();
+    Expect(
+        Testing::ConfigureFault(Testing::FaultPoint::StartAllocation),
+        "start allocation fault hook could not be configured while stopped"
+    );
+
+    ScopedOutput        output("moer-profile-start-allocation-fault");
+    const RuntimeConfig config = MakeRuntimeConfig(output);
+    Expect(
+        Start(config) == StartResult::ResourceExhausted,
+        "start allocation failure escaped the noexcept API boundary"
+    );
+    Expect(GetRuntimeState() == RuntimeState::Stopped, "start allocation failure changed runtime state");
+    Expect(
+        !std::filesystem::exists(output.path) && !std::filesystem::exists(output.InProgressPath()),
+        "start allocation failure left an output artifact"
+    );
+    Expect(
+        Shutdown() == ShutdownResult::AlreadyStopped, "start allocation failure broke shutdown idempotence"
+    );
+    Testing::ClearHooks();
+}
+
+void TestExclusiveTempCreateRace() {
+    Testing::ClearHooks();
+    Expect(
+        Testing::ConfigureWriterPauseBeforeTempOpen(true),
+        "pre-open pause hook could not be configured while stopped"
+    );
+    ScopedOutput        output("moer-profile-exclusive-temp");
+    const RuntimeConfig config       = MakeRuntimeConfig(output);
+    StartResult         start_result = StartResult::Busy;
+    std::jthread        starter([&] {
+        start_result = Start(config);
+    });
+    ResumeWriterOnExit  resume_guard;
+    Expect(Testing::WaitForWriterPaused(2000), "writer did not reach the deterministic pre-open pause");
+
+    const std::array<std::uint8_t, 9> competing_bytes = {
+        0x45,
+        0x58,
+        0x54,
+        0x45,
+        0x52,
+        0x4e,
+        0x41,
+        0x4c,
+        0x21,
+    };
+    {
+        std::ofstream stream(output.InProgressPath(), std::ios::binary | std::ios::trunc);
+        Expect(stream.is_open(), "competing temp fixture could not be opened");
+        stream.write(
+            reinterpret_cast<const char*>(competing_bytes.data()),
+            static_cast<std::streamsize>(competing_bytes.size())
+        );
+        Expect(stream.good(), "competing temp fixture could not be written");
+    }
+
+    resume_guard.Resume();
+    starter.join();
+    Expect(start_result == StartResult::FileOpenFailed, "exclusive temp collision did not fail startup");
+    Expect(
+        ReadBinaryFile(output.InProgressPath()) ==
+            std::vector<std::uint8_t>(competing_bytes.begin(), competing_bytes.end()),
+        "exclusive temp collision truncated or removed the competing file"
+    );
+    Expect(!std::filesystem::exists(output.path), "exclusive temp collision exposed a final output");
+    Expect(
+        GetRuntimeState() == RuntimeState::Stopped && Shutdown() == ShutdownResult::AlreadyStopped,
+        "exclusive temp collision did not restore the stopped lifecycle"
+    );
+    Testing::ClearHooks();
+}
+
+void TestMultithreadedProducers() {
+    ScopedOutput  output("moer-profile-multithread");
+    RuntimeConfig config       = MakeRuntimeConfig(output);
+    config.tls_publish_records = 7;
+    Expect(Start(config) == StartResult::Started, "multithread runtime failed to start");
+
+    const SchemaDescriptor   schema       = MakeRuntimeSchema();
+    const SchemaRegistration registration = RegisterSchema(schema);
+    Expect(registration.status == SchemaStatus::Registered, "multithread schema failed to register");
+
+    constexpr std::uint64_t    producer_count       = 6;
+    constexpr std::uint64_t    records_per_producer = 41;
+    std::atomic<std::uint64_t> accepted{0};
+    std::atomic<std::uint64_t> rejected{0};
+    std::atomic<std::uint64_t> producer_flushes{0};
+    std::vector<std::jthread>  producers;
+    producers.reserve(producer_count);
+    for (std::uint64_t producer = 0; producer < producer_count; ++producer) {
+        producers.emplace_back([&, producer] {
+            for (std::uint64_t sequence = 0; sequence < records_per_producer; ++sequence) {
+                const std::array<FieldValueView, 3> values = {
+                    FieldValueView{producer},
+                    FieldValueView{sequence},
+                    FieldValueView{std::string_view("parallel")},
+                };
+                if (Emit(registration.handle, values) == EmitStatus::Accepted) {
+                    accepted.fetch_add(1, std::memory_order_relaxed);
+                } else {
+                    rejected.fetch_add(1, std::memory_order_relaxed);
+                }
+            }
+            const FlushResult flush = FlushThreadLocal();
+            producer_flushes.fetch_add(1, std::memory_order_relaxed);
+            if (flush != FlushResult::Completed && flush != FlushResult::NothingPending) {
+                rejected.fetch_add(1, std::memory_order_relaxed);
+            }
+        });
+    }
+    producers.clear();
+
+    const std::uint64_t expected_records = producer_count * records_per_producer;
+    Expect(rejected.load(std::memory_order_relaxed) == 0, "a producer operation failed");
+    Expect(
+        producer_flushes.load(std::memory_order_relaxed) == producer_count,
+        "a producer exited without flushing its thread-local shard"
+    );
+    Expect(
+        accepted.load(std::memory_order_relaxed) == expected_records, "producers did not accept every record"
+    );
+    ExpectFlushSucceeded(FlushAll(), "multithread global flush failed");
+    Expect(Shutdown() == ShutdownResult::Completed, "multithread runtime did not shut down");
+
+    const ParsedDump dump = ParseDump(output.path, config.codec_limits);
+    Expect(dump.schemas.size() == 1, "multithread output duplicated its schema");
+    Expect(dump.records.size() == expected_records, "multithread output lost or duplicated records");
+    std::vector<bool> seen(expected_records, false);
+    for (const DecodedRecord& record : dump.records) {
+        Expect(record.values.size() == 3, "multithread record value count changed");
+        const std::uint64_t producer = std::get<std::uint64_t>(record.values[0]);
+        const std::uint64_t sequence = std::get<std::uint64_t>(record.values[1]);
+        Expect(producer < producer_count, "multithread record producer is out of range");
+        Expect(sequence < records_per_producer, "multithread record sequence is out of range");
+        const std::size_t key = static_cast<std::size_t>(producer * records_per_producer + sequence);
+        Expect(!seen[key], "multithread output duplicated a producer record");
+        seen[key] = true;
+    }
+    for (bool was_seen : seen) {
+        Expect(was_seen, "multithread output omitted a producer record");
+    }
+
+    const RuntimeStats stats = GetRuntimeStats();
+    Expect(stats.state == RuntimeState::Stopped, "multithread runtime remained active");
+    Expect(stats.records_written == expected_records, "runtime stats disagree with decoded record count");
+    Expect(stats.records_dropped_queue_full == 0, "bounded queue unexpectedly dropped records");
+    Expect(stats.records_dropped_oversized == 0, "valid records were treated as oversized");
+}
+
+void TestBoundedQueueDropNewest() {
+    Testing::ClearHooks();
+    Expect(
+        Testing::ConfigureWriterPauseAfterStart(true),
+        "writer pause hook could not be configured while stopped"
+    );
+    ResumeWriterOnExit resume_guard;
+
+    const SchemaDescriptor              schema = MakeRuntimeSchema();
+    const std::array<FieldValueView, 3> values = {
+        FieldValueView{std::uint64_t{7}},
+        FieldValueView{std::uint64_t{11}},
+        FieldValueView{std::string_view("bounded")},
+    };
+    const std::string                   oversized_label(80, 'x');
+    const std::array<FieldValueView, 3> oversized_values = {
+        FieldValueView{std::uint64_t{7}},
+        FieldValueView{std::uint64_t{12}},
+        FieldValueView{std::string_view(oversized_label)},
+    };
+    Moer::Array<std::uint8_t> encoded_record;
+    const CodecLimits         limits{};
+    Expect(
+        EncodeRecordPayload(ComputeSchemaHash(schema), 1, schema.fields, values, limits, encoded_record) ==
+            EncodeStatus::Ok,
+        "bounded queue test could not size its record"
+    );
+    const std::size_t record_bytes = encoded_record.size();
+    Expect(record_bytes > 0, "bounded queue test produced an empty record");
+
+    ScopedOutput  output("moer-profile-bounded");
+    RuntimeConfig config       = MakeRuntimeConfig(output);
+    config.max_record_bytes    = record_bytes * 2;
+    config.tls_publish_records = 1;
+    config.tls_publish_bytes   = record_bytes * 2;
+    config.tls_max_records     = 2;
+    config.tls_max_bytes       = record_bytes * 2;
+    config.queue_max_chunks    = 2;
+    config.queue_max_records   = 2;
+    config.queue_max_bytes     = record_bytes * 2;
+
+    Expect(Start(config) == StartResult::Started, "bounded queue runtime failed to start");
+    Expect(Testing::WaitForWriterPaused(2000), "writer did not reach the deterministic pause point");
+    const SchemaRegistration registration = RegisterSchema(schema);
+    Expect(registration.status == SchemaStatus::Registered, "bounded queue schema failed to register");
+
+    // The writer is paused, so completion of these calls proves producers do
+    // not wait for sink progress. The first two records fill all three queue
+    // budgets exactly; the limit+1 record must be rejected as the newest item.
+    Expect(
+        Emit(registration.handle, values) == EmitStatus::Accepted, "record below the queue limit was rejected"
+    );
+    Expect(
+        Emit(registration.handle, values) == EmitStatus::Accepted, "record at the queue limit was rejected"
+    );
+    Expect(
+        Emit(registration.handle, values) == EmitStatus::QueueFull,
+        "limit+1 record did not use drop-newest admission"
+    );
+    Expect(
+        Emit(registration.handle, oversized_values) == EmitStatus::RecordTooLarge,
+        "oversized record did not fail before queue admission"
+    );
+
+    const RuntimeStats paused_stats = GetRuntimeStats();
+    Expect(paused_stats.resident_chunks == 2, "resident chunk accounting missed queued work");
+    Expect(paused_stats.resident_records == 2, "resident record accounting missed queued work");
+    Expect(paused_stats.resident_bytes == record_bytes * 2, "resident byte accounting missed queued work");
+    Expect(
+        paused_stats.high_water_chunks == 2 && paused_stats.high_water_chunks <= config.queue_max_chunks,
+        "chunk high-water exceeded its hard limit"
+    );
+    Expect(
+        paused_stats.high_water_records == 2 && paused_stats.high_water_records <= config.queue_max_records,
+        "record high-water exceeded its hard limit"
+    );
+    Expect(
+        paused_stats.high_water_bytes == record_bytes * 2 &&
+            paused_stats.high_water_bytes <= config.queue_max_bytes,
+        "byte high-water exceeded its hard limit"
+    );
+    Expect(paused_stats.records_committed == 3, "committed record accounting changed");
+    Expect(paused_stats.records_enqueued == 2, "accepted queue record accounting changed");
+    Expect(paused_stats.records_dropped_queue_full == 1, "drop-newest rejection was not accounted");
+    Expect(paused_stats.records_dropped_oversized == 1, "oversized rejection was not accounted");
+    Expect(paused_stats.chunks_enqueued == 2, "accepted chunk accounting changed");
+    Expect(paused_stats.chunks_dropped == 1, "rejected chunk accounting changed");
+
+    resume_guard.Resume();
+    // Finalize itself is the drain fence here: queued records and the fixed
+    // loss slot must reach disk before SessionEnd and the final rename.
+    Expect(Shutdown() == ShutdownResult::Completed, "bounded queue runtime did not shut down");
+    const RuntimeStats drained_stats = GetRuntimeStats();
+    Expect(
+        drained_stats.resident_chunks == 0 && drained_stats.resident_records == 0 &&
+            drained_stats.resident_bytes == 0,
+        "resident accounting did not release drained and in-flight chunks"
+    );
+    const ParsedDump dump = ParseDump(output.path, config.codec_limits);
+    Expect(dump.records.size() == 2, "drop-newest persisted the rejected record");
+    Expect(dump.losses.size() == 1, "bounded losses were not coalesced into one disk notice");
+    const LossNotice& loss = dump.losses.front();
+    Expect(loss.first_sequence == 3, "loss aggregate has the wrong first sequence");
+    Expect(loss.last_sequence == 4, "loss aggregate has the wrong last sequence");
+    Expect(loss.record_count == 2, "loss aggregate has the wrong record count");
+    // Two uint64 values plus one length-prefixed string: 8 + 8 + 4 + N.
+    constexpr std::uint64_t queue_full_value_bytes = 8 + 8 + 4 + 7;
+    constexpr std::uint64_t oversized_value_bytes  = 8 + 8 + 4 + 80;
+    Expect(
+        loss.value_bytes == queue_full_value_bytes + oversized_value_bytes,
+        "loss aggregate has the wrong attempted value byte count"
+    );
+    const std::uint32_t required_reasons =
+        static_cast<std::uint32_t>(LossReason::QueueFull) | static_cast<std::uint32_t>(LossReason::Oversized);
+    Expect(
+        (loss.reason_mask & required_reasons) == required_reasons,
+        "loss aggregate omitted queue-full or oversized reason"
+    );
+    Expect(
+        dump.session_ends.size() == 1 && dump.session_ends.front().records_written == dump.records.size() &&
+            dump.session_ends.front().records_dropped == loss.record_count,
+        "SessionEnd totals disagree with persisted records and loss"
+    );
+    Expect(
+        drained_stats.records_written == dump.records.size() &&
+            drained_stats.records_dropped_queue_full + drained_stats.records_dropped_oversized ==
+                loss.record_count,
+        "runtime stats disagree with the persisted loss aggregate"
+    );
+    Testing::ClearHooks();
+}
+
+void TestConcurrentFlushWaiters() {
+    Testing::ClearHooks();
+    Expect(
+        Testing::ConfigureWriterPauseAfterStart(true),
+        "flush waiter pause hook could not be configured while stopped"
+    );
+    ResumeWriterOnExit resume_guard;
+
+    ScopedOutput  output("moer-profile-concurrent-flush");
+    RuntimeConfig config       = MakeRuntimeConfig(output);
+    config.tls_publish_records = 1;
+    Expect(Start(config) == StartResult::Started, "flush waiter runtime failed to start");
+    Expect(Testing::WaitForWriterPaused(2000), "flush waiter writer did not reach its pause point");
+
+    const SchemaDescriptor   schema       = MakeRuntimeSchema();
+    const SchemaRegistration registration = RegisterSchema(schema);
+    Expect(registration.status == SchemaStatus::Registered, "flush waiter schema failed to register");
+    const std::array<FieldValueView, 3> values = {
+        FieldValueView{std::uint64_t{34}},
+        FieldValueView{std::uint64_t{55}},
+        FieldValueView{std::string_view("flush-waiters")},
+    };
+    Expect(
+        Emit(registration.handle, values) == EmitStatus::Accepted, "flush waiter setup record was rejected"
+    );
+
+    constexpr std::size_t                 waiter_count = 12;
+    std::array<FlushResult, waiter_count> results{};
+    results.fill(FlushResult::Rejected);
+    std::atomic<std::size_t>  ready{0};
+    std::atomic<bool>         release{false};
+    std::vector<std::jthread> waiters;
+    waiters.reserve(waiter_count);
+    for (std::size_t index = 0; index < waiter_count; ++index) {
+        waiters.emplace_back([&, index] {
+            ready.fetch_add(1, std::memory_order_release);
+            while (!release.load(std::memory_order_acquire)) {
+                std::this_thread::yield();
+            }
+            results[index] = FlushAll();
+        });
+    }
+    while (ready.load(std::memory_order_acquire) != waiter_count) {
+        std::this_thread::yield();
+    }
+    release.store(true, std::memory_order_release);
+    // Give every released waiter a scheduling turn while sink progress is
+    // structurally impossible. This is not a wall-clock performance check.
+    for (std::size_t turn = 0; turn < 4096; ++turn) {
+        std::this_thread::yield();
+    }
+
+    resume_guard.Resume();
+    waiters.clear();
+    for (FlushResult result : results) {
+        Expect(
+            result == FlushResult::Completed || result == FlushResult::NothingPending,
+            "a concurrent flush waiter did not observe the shared drain"
+        );
+    }
+    Expect(
+        GetRuntimeStats().flush_completed == 1,
+        "concurrent waiters created more than one physical flush interval"
+    );
+    Expect(Shutdown() == ShutdownResult::Completed, "flush waiter runtime did not shut down");
+    const ParsedDump dump = ParseDump(output.path, config.codec_limits);
+    Expect(dump.records.size() == 1, "concurrent flush lost or duplicated queued data");
+    Expect(dump.losses.empty(), "concurrent flush fabricated a loss notice");
+    Testing::ClearHooks();
+}
+
+void RecoverAfterFault(const ScopedOutput& _output, RuntimeConfig _config, const SchemaDescriptor& _schema) {
+    Testing::ClearHooks();
+    _config.replace_existing = true;
+    Expect(Start(_config) == StartResult::Started, "runtime did not restart after sink fault");
+    const SchemaRegistration registration = RegisterSchema(_schema);
+    Expect(
+        registration.status == SchemaStatus::Registered, "schema did not register after sink-fault restart"
+    );
+    const std::array<FieldValueView, 3> values = {
+        FieldValueView{std::uint64_t{1}},
+        FieldValueView{std::uint64_t{2}},
+        FieldValueView{std::string_view("recovered")},
+    };
+    Expect(
+        Emit(registration.handle, values) == EmitStatus::Accepted, "producer did not recover after sink fault"
+    );
+    Expect(Shutdown() == ShutdownResult::Completed, "recovered runtime did not shut down");
+    const ParsedDump dump = ParseDump(_output.path, _config.codec_limits);
+    Expect(dump.records.size() == 1, "recovered output has the wrong record count");
+    Expect(Shutdown() == ShutdownResult::AlreadyStopped, "recovered shutdown was not idempotent");
+}
+
+void TestWriterFaultReleasesFlushWaiter(
+    Testing::FaultPoint _fault_point,
+    std::uint64_t       _trigger_hit,
+    RuntimeFault        _expected_fault,
+    std::string_view    _output_stem,
+    bool                _recover
+) {
+    Testing::ClearHooks();
+    Expect(
+        Testing::ConfigureFault(_fault_point, _trigger_hit),
+        "writer fault hook could not be configured while stopped"
+    );
+
+    ScopedOutput  output(_output_stem);
+    RuntimeConfig config          = MakeRuntimeConfig(output);
+    config.tls_publish_records    = 1;
+    const SchemaDescriptor schema = MakeRuntimeSchema();
+    Expect(Start(config) == StartResult::Started, "fault test runtime failed to start");
+    const SchemaRegistration registration = RegisterSchema(schema);
+    Expect(registration.status == SchemaStatus::Registered, "fault test schema failed to register");
+    const std::array<FieldValueView, 3> values = {
+        FieldValueView{std::uint64_t{5}},
+        FieldValueView{std::uint64_t{8}},
+        FieldValueView{std::string_view("fault")},
+    };
+    const EmitStatus initial_emit = Emit(registration.handle, values);
+    Expect(
+        initial_emit == EmitStatus::Accepted || initial_emit == EmitStatus::SinkFault,
+        "fault test producer returned an unrelated status"
+    );
+
+    // This call is also the waiter contract: the writer fault must signal the
+    // queued fence and return Faulted rather than leaving the caller blocked.
+    Expect(FlushAll() == FlushResult::Faulted, "writer fault did not release the flush waiter as faulted");
+    Expect(GetRuntimeState() == RuntimeState::Faulted, "writer fault did not latch state");
+    const RuntimeStats fault_stats = GetRuntimeStats();
+    Expect(fault_stats.last_fault == _expected_fault, "writer fault identity changed");
+    Expect(fault_stats.io_faults == 1, "I/O fault was not counted exactly once");
+    Expect(
+        fault_stats.resident_chunks == 0 && fault_stats.resident_records == 0 &&
+            fault_stats.resident_bytes == 0,
+        "faulted writer retained admitted or in-flight capacity"
+    );
+    Expect(
+        Emit(registration.handle, values) == EmitStatus::SinkFault,
+        "noexcept producer did not fail closed after sink fault"
+    );
+    Expect(
+        std::filesystem::exists(output.InProgressPath()), "sink fault removed forensic in-progress output"
+    );
+    Expect(!std::filesystem::exists(output.path), "sink fault published a partial final output");
+    Expect(Shutdown() == ShutdownResult::Faulted, "faulted runtime shutdown did not report the fault");
+    Expect(GetRuntimeState() == RuntimeState::Stopped, "fault shutdown was not reaped");
+    Expect(Shutdown() == ShutdownResult::AlreadyStopped, "fault shutdown was not idempotent");
+    if (_recover) {
+        RecoverAfterFault(output, config, schema);
+    } else {
+        Testing::ClearHooks();
+    }
+}
+
+void TestRenameFinalFault() {
+    Testing::ClearHooks();
+    Expect(
+        Testing::ConfigureFault(Testing::FaultPoint::RenameFinal),
+        "rename fault hook could not be configured while stopped"
+    );
+
+    ScopedOutput  output("moer-profile-rename-fault");
+    RuntimeConfig config                        = MakeRuntimeConfig(output);
+    config.replace_existing                     = true;
+    config.tls_publish_records                  = 1;
+    const std::array<std::uint8_t, 8> old_final = {
+        0x4d,
+        0x4f,
+        0x45,
+        0x52,
+        0x2d,
+        0x4f,
+        0x4c,
+        0x44,
+    };
+    {
+        std::ofstream stream(output.path, std::ios::binary | std::ios::trunc);
+        Expect(stream.is_open(), "old final fixture could not be opened");
+        stream.write(
+            reinterpret_cast<const char*>(old_final.data()), static_cast<std::streamsize>(old_final.size())
+        );
+        Expect(stream.good(), "old final fixture could not be written");
+    }
+    const SchemaDescriptor schema = MakeRuntimeSchema();
+    Expect(Start(config) == StartResult::Started, "rename fault runtime failed to start");
+    Expect(
+        ReadBinaryFile(output.path) == std::vector<std::uint8_t>(old_final.begin(), old_final.end()),
+        "replacement start removed the previous valid final"
+    );
+    const SchemaRegistration registration = RegisterSchema(schema);
+    Expect(registration.status == SchemaStatus::Registered, "rename fault schema failed to register");
+    const std::array<FieldValueView, 3> values = {
+        FieldValueView{std::uint64_t{13}},
+        FieldValueView{std::uint64_t{21}},
+        FieldValueView{std::string_view("rename")},
+    };
+    Expect(
+        Emit(registration.handle, values) == EmitStatus::Accepted, "rename fault setup record was rejected"
+    );
+    Expect(Shutdown() == ShutdownResult::Faulted, "rename failure did not fail finalization");
+    const RuntimeStats stats = GetRuntimeStats();
+    Expect(stats.last_fault == RuntimeFault::RenameFinal, "rename fault identity changed");
+    Expect(stats.io_faults == 1, "rename fault was not counted exactly once");
+    Expect(
+        std::filesystem::exists(output.InProgressPath()), "rename fault removed forensic in-progress output"
+    );
+    Expect(
+        ReadBinaryFile(output.path) == std::vector<std::uint8_t>(old_final.begin(), old_final.end()),
+        "rename fault destroyed the previous valid final"
+    );
+    Expect(Shutdown() == ShutdownResult::AlreadyStopped, "rename fault shutdown was not idempotent");
+    RecoverAfterFault(output, config, schema);
+}
+
+} // namespace
+
+int main() {
+    try {
+        TestV3LittleEndianGoldenVector();
+        TestLossDecodeHardening();
+        TestCodecRoundTripAndChecksums();
+        TestSchemaHashCoverage();
+        TestRuntimeLifecycleAndRestart();
+        TestStartAllocationFailureIsContained();
+        TestExclusiveTempCreateRace();
+        TestMultithreadedProducers();
+        TestBoundedQueueDropNewest();
+        TestConcurrentFlushWaiters();
+        TestWriterFaultReleasesFlushWaiter(
+            Testing::FaultPoint::WritePacket, 2, RuntimeFault::WritePacket, "moer-profile-write-fault", true
+        );
+        TestWriterFaultReleasesFlushWaiter(
+            Testing::FaultPoint::FlushFile, 1, RuntimeFault::FlushFile, "moer-profile-flush-fault", false
+        );
+        TestRenameFinalFault();
+        std::cout << "ProfileDump core contract tests passed." << std::endl;
+        return EXIT_SUCCESS;
+    } catch (const std::exception& error) {
+        const RuntimeState state = GetRuntimeState();
+        if (state != RuntimeState::Stopped) {
+            static_cast<void>(Shutdown());
+        }
+        std::cerr << "ProfileDump core contract test failed: " << error.what() << std::endl;
+        return EXIT_FAILURE;
+    }
+}

--- a/source/test/ProfileDumpCoreTest.cpp
+++ b/source/test/ProfileDumpCoreTest.cpp
@@ -678,6 +678,49 @@ void TestStartAllocationFailureIsContained() {
     Testing::ClearHooks();
 }
 
+void TestShutdownFinalizeAllocationFailureClosesWriter() {
+    Testing::ClearHooks();
+    Expect(
+        Testing::ConfigureFault(Testing::FaultPoint::ShutdownFinalizeAllocation),
+        "shutdown finalize allocation fault hook could not be configured while stopped"
+    );
+
+    ScopedOutput        output("moer-profile-shutdown-allocation-fault");
+    const RuntimeConfig config = MakeRuntimeConfig(output);
+    Expect(Start(config) == StartResult::Started, "shutdown allocation fault runtime failed to start");
+    Expect(
+        Shutdown() == ShutdownResult::Faulted, "shutdown finalize allocation failure did not report a fault"
+    );
+    const RuntimeStats stats = GetRuntimeStats();
+    Expect(stats.last_fault == RuntimeFault::WriterException, "shutdown allocation fault identity changed");
+    Expect(GetRuntimeState() == RuntimeState::Stopped, "shutdown allocation fault did not reap the runtime");
+    Expect(!std::filesystem::exists(output.path), "shutdown allocation fault published a partial final");
+
+    const std::filesystem::path session_temp = output.InProgressPath();
+    std::filesystem::path       moved_temp   = output.directory / "closed-writer-forensic.inprogress";
+    std::error_code             move_error;
+    for (std::uint32_t attempt = 0; attempt < 8; ++attempt) {
+        move_error.clear();
+        std::filesystem::rename(session_temp, moved_temp, move_error);
+        if (!move_error) {
+            break;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(1U << std::min<std::uint32_t>(attempt, 5U)));
+    }
+    Expect(!move_error, "shutdown allocation fault left the writer file handle open");
+    Expect(
+        Shutdown() == ShutdownResult::AlreadyStopped,
+        "shutdown allocation fault did not restore shutdown idempotence"
+    );
+
+    Testing::ClearHooks();
+    RuntimeConfig recovery_config    = config;
+    recovery_config.replace_existing = true;
+    Expect(Start(recovery_config) == StartResult::Started, "runtime did not restart after shutdown OOM");
+    Expect(Shutdown() == ShutdownResult::Completed, "shutdown OOM recovery did not publish a clean capture");
+    Expect(std::filesystem::exists(moved_temp), "shutdown OOM recovery removed the previous forensic temp");
+}
+
 void TestExclusiveTempCreateRace() {
     Testing::ClearHooks();
     Expect(
@@ -1288,6 +1331,7 @@ int main() {
         TestSchemaHashCoverage();
         TestRuntimeLifecycleAndRestart();
         TestStartAllocationFailureIsContained();
+        TestShutdownFinalizeAllocationFailureClosesWriter();
         TestExclusiveTempCreateRace();
         TestReplacementPreservesForeignTemp();
         TestFinalPublicationRaces();


### PR DESCRIPTION
## What changed

- adds a backend-neutral ProfileDump v3 codec with explicit little-endian packets, CRCs, stable schema hashes, and strict bounded decoding
- adds bounded TLS shards, global resident accounting, drop-newest loss aggregation, a single writer, lifecycle/fault/restart contracts, and CPU/GPU scope schema templates
- adds exclusive `.inprogress` creation and clean final publication with replace/no-replace semantics while preserving an older valid final on failure
- adds a comprehensive CPU contract suite for codec corruption, lifecycle, concurrency, capacity, loss accounting, file faults, OOM containment, and file replacement races

## Why

This is the Phase 21A persistence boundary needed before Completion-owned GPUEventStream integration. It absorbs the useful typed-schema/TLS packet-stream ideas from `dev_parallel_rhi` without carrying over its unbounded queues, synchronous producer I/O, TCP/Trace dual protocol, or global profiler runtime.

## Validation

- `TestProfileDumpCore` RelWithDebInfo: passed
- `TestProfileDumpCore` Debug: passed
- RelWithDebInfo stress: 100/100 passed
- default CTest: 23/23 passed
- `MoerEditor` RelWithDebInfo: built and linked
- Raytracing/Vulkan/RHI-thread/parallel-recording smoke: healthy for 25 seconds, stderr empty, no VUID/validation/error/fatal/device-lost/assert matches
- independent codec/API and concurrency reviews: P0=0, P1=0, P2=0
