### PR TITLE
Phase 21B.1: add Copy timestamp queries

### DIFF
--- a/source/runtime/render/rhi/RHICommandList.cpp
+++ b/source/runtime/render/rhi/RHICommandList.cpp
@@ -1312,16 +1312,6 @@ QueryToken CommandList::BeginTimestampQuery(std::string_view _name) {
     );
     query_cancellation_domain.Register(token);
 
-    // Phase 17A does not translate timestamp queries on the Copy queue. Return
-    // a terminal token without manufacturing an untranslatable command.
-    if (queue_type == EQueueType::Copy) {
-        QueryBackendAccess::ResolveErrorIfPending(
-            token,
-            "timestamp queries are unsupported on Copy queues"
-        );
-        return token;
-    }
-
     auto command = MakeUnique<QueryCmd>(
         token,
         QueryCmd::EOp::BeginTimestamp,
@@ -1377,15 +1367,6 @@ void CommandList::EndTimestampQuery(const QueryToken& _token) {
     if (_token.Kind() != QueryKind::Timestamp) {
         throw std::invalid_argument(
             "EndTimestampQuery token has the wrong query kind"
-        );
-    }
-    if (queue_type == EQueueType::Copy) {
-        // BeginTimestampQuery on Copy intentionally records no Begin command.
-        if (_token.GetFuture().Status() == QueryStatus::Error) {
-            return;
-        }
-        throw std::logic_error(
-            "Copy queue timestamp token has no terminal capability result"
         );
     }
     if (active_query_stack.empty()) {

--- a/source/runtime/render/rhi/vulkan/VulkanAllocator.cpp
+++ b/source/runtime/render/rhi/vulkan/VulkanAllocator.cpp
@@ -262,6 +262,26 @@ VkResult VkNativeQueryPool::GetResults(
     );
 }
 
+void VkNativeQueryPool::ResetHost(
+    uint32 _first_query,
+    uint32 _query_count
+) {
+    if (_query_count == 0) {
+        return;
+    }
+    if (_first_query > count || _query_count > count - _first_query) {
+        throw std::out_of_range(
+            "Vulkan host query reset range exceeds the native pool"
+        );
+    }
+    vkResetQueryPool(
+        device.GetDevice(),
+        query_pool,
+        _first_query,
+        _query_count
+    );
+}
+
 void VkNativeQueryPool::EnsureCapacity(uint32 _required_count) {
     if (_required_count <= count) {
         return;
@@ -297,6 +317,9 @@ VulkanAllocator::VulkanAllocator(VulkanDevice* _device, EQueueType _type) :
     scratch_allocator(_device, &allocator),
     shader_buffer_allocator(_device, &allocator),
     timestamp_valid_bits(_device->GetTimestampValidBits(_type)),
+    timestamp_reset_mode(
+        _device->GetTimestampQueryResetMode(_type)
+    ),
     timestamp_period_ns(_device->GetCoreProperties().core_1_0.limits.timestampPeriod) {}
 
 VulkanAllocator::~VulkanAllocator() {
@@ -380,6 +403,28 @@ void VulkanAllocator::EnsureQueryCapacity(
     EnsureOcclusionQueryCapacity(_occlusion_pair_count);
 }
 
+void VulkanAllocator::ConfigureTimestampCapabilityForRecording(
+    uint32                         _valid_bits,
+    EVulkanTimestampQueryResetMode _reset_mode
+) {
+    if (next_timestamp_query != 0 || !timestamp_query_records.empty()) {
+        throw std::logic_error(
+            "Vulkan timestamp capability can change only before recording"
+        );
+    }
+    timestamp_valid_bits = std::min(_valid_bits, uint32{64});
+    const EVulkanTimestampQueryResetMode expected_mode =
+        m_device->GetTimestampQueryResetMode(
+            queue_type, timestamp_valid_bits
+        );
+    if (_reset_mode != expected_mode) {
+        throw std::invalid_argument(
+            "Vulkan timestamp reset mode does not match queue capability"
+        );
+    }
+    timestamp_reset_mode = _reset_mode;
+}
+
 void VulkanAllocator::EnsureTimestampQueryCapacity(size_t _required_count) {
     if (_required_count == 0) {
         return;
@@ -389,9 +434,10 @@ void VulkanAllocator::EnsureTimestampQueryCapacity(size_t _required_count) {
             "Vulkan timestamp query pool can grow only before recording"
         );
     }
-    if (timestamp_valid_bits == 0) {
+    if (timestamp_reset_mode ==
+        EVulkanTimestampQueryResetMode::Unsupported) {
         throw std::runtime_error(
-            "Vulkan queue family does not support timestamp queries"
+            "Vulkan queue family cannot safely reset timestamp queries"
         );
     }
     if (_required_count > std::numeric_limits<uint32>::max()) {
@@ -413,9 +459,13 @@ void VulkanAllocator::EnsureTimestampQueryCapacity(size_t _required_count) {
             required_count,
             queue_type
         );
-        return;
+    } else {
+        timestamp_pool->EnsureCapacity(required_count);
     }
-    timestamp_pool->EnsureCapacity(required_count);
+    if (timestamp_reset_mode ==
+        EVulkanTimestampQueryResetMode::Host) {
+        timestamp_pool->ResetHost(0, required_count);
+    }
 }
 
 void VulkanAllocator::EnsureOcclusionQueryCapacity(size_t _required_count) {
@@ -511,9 +561,15 @@ void VulkanAllocator::RecordTimestampQuery(
     if (!token.Valid() || token.Kind() != QueryKind::Timestamp) {
         throw std::runtime_error("invalid Vulkan timestamp query token");
     }
-    if (timestamp_valid_bits == 0) {
+    if (_cmd.GetQueueType() != queue_type) {
         throw std::runtime_error(
-            "Vulkan queue family does not support timestamp queries"
+            "Vulkan timestamp query command queue does not match allocator"
+        );
+    }
+    if (timestamp_reset_mode ==
+        EVulkanTimestampQueryResetMode::Unsupported) {
+        throw std::runtime_error(
+            "Vulkan timestamp query recording is unsupported on this queue"
         );
     }
 
@@ -523,7 +579,10 @@ void VulkanAllocator::RecordTimestampQuery(
             throw std::runtime_error("duplicate Vulkan timestamp query begin");
         }
         const uint32 slot = AllocateTimestampQuerySlot();
-        _cmd_list.ResetQueryPool(*timestamp_pool, slot, 1);
+        if (timestamp_reset_mode ==
+            EVulkanTimestampQueryResetMode::CommandBuffer) {
+            _cmd_list.ResetQueryPool(*timestamp_pool, slot, 1);
+        }
         _cmd_list.WriteTimeStamp(
             *timestamp_pool, slot, VK_PIPELINE_STAGE_2_TOP_OF_PIPE_BIT
         );
@@ -545,7 +604,10 @@ void VulkanAllocator::RecordTimestampQuery(
         throw std::runtime_error("duplicate Vulkan timestamp query end");
     }
     const uint32 slot = AllocateTimestampQuerySlot();
-    _cmd_list.ResetQueryPool(*timestamp_pool, slot, 1);
+    if (timestamp_reset_mode ==
+        EVulkanTimestampQueryResetMode::CommandBuffer) {
+        _cmd_list.ResetQueryPool(*timestamp_pool, slot, 1);
+    }
     _cmd_list.WriteTimeStamp(
         *timestamp_pool, slot, VK_PIPELINE_STAGE_2_BOTTOM_OF_PIPE_BIT
     );

--- a/source/runtime/render/rhi/vulkan/VulkanAllocator.h
+++ b/source/runtime/render/rhi/vulkan/VulkanAllocator.h
@@ -108,13 +108,16 @@ public:
     VulkanDevice& GetDevice() const {
         return device;
     }
-    // The owning allocator may grow an idle pool before command-buffer
-    // recording starts. Existing pools are never replaced while they are
-    // referenced by submitted work.
-    void EnsureCapacity(uint32 _required_count);
 
 private:
+    friend class VulkanAllocator;
+
     [[nodiscard]] VkQueryPool CreatePool(uint32 _query_count);
+    // The owning allocator may grow or host-reset an idle pool only before
+    // command-buffer recording starts. Keeping both operations private makes
+    // its single-owner synchronization contract explicit.
+    void EnsureCapacity(uint32 _required_count);
+    void ResetHost(uint32 _first_query, uint32 _query_count);
 
     VulkanDevice& device;
     VkQueryPool   query_pool{VK_NULL_HANDLE};
@@ -160,6 +163,14 @@ public:
     void EnsureQueryCapacity(
         size_t _timestamp_slot_count,
         size_t _occlusion_pair_count
+    );
+    // Queue-owned recording capability is refreshed before Copy recording so
+    // a recycled allocator can move between native and capability-degraded
+    // test paths without retaining stale state. This is legal only before any
+    // query boundary has been recorded for the current command buffer.
+    void ConfigureTimestampCapabilityForRecording(
+        uint32                         _valid_bits,
+        EVulkanTimestampQueryResetMode _reset_mode
     );
     void RecordQuery(VulkanCmdList& _cmd_list, const QueryCmd& _cmd);
     // GPU completion is a two-stage transaction. Prepare performs native
@@ -313,6 +324,9 @@ private:
     uint32                      next_timestamp_query{0};
     uint32                      next_occlusion_query{0};
     uint32                      timestamp_valid_bits{0};
+    EVulkanTimestampQueryResetMode timestamp_reset_mode{
+        EVulkanTimestampQueryResetMode::Unsupported
+    };
     double                      timestamp_period_ns{0.0};
     // Most allocators never record an explicit Query command. Lazily creating
     // this pool avoids adding a native driver object to every ordinary,

--- a/source/runtime/render/rhi/vulkan/VulkanCommon.h
+++ b/source/runtime/render/rhi/vulkan/VulkanCommon.h
@@ -21,4 +21,15 @@
 #define VK_NO_PROTOTYPES 1
 #endif
 
+#include <cstdint>
 #include <volk.h>
+
+namespace Moer::Render {
+
+enum class EVulkanTimestampQueryResetMode : std::uint8_t {
+    Unsupported,
+    CommandBuffer,
+    Host,
+};
+
+} // namespace Moer::Render

--- a/source/runtime/render/rhi/vulkan/VulkanDevice.cpp
+++ b/source/runtime/render/rhi/vulkan/VulkanDevice.cpp
@@ -823,6 +823,66 @@ uint VulkanDevice::GetQueueFamilyIndex(EQueueType _type) const {
     return VK_QUEUE_FAMILY_IGNORED;
 }
 
+uint32_t VulkanDevice::GetTimestampValidBits(
+    EQueueType _queue_type
+) const {
+    const uint32_t family_index = GetQueueFamilyIndex(_queue_type);
+    return family_index < m_device_info.queue_family_props.size() ?
+               m_device_info.queue_family_props[family_index].
+                   timestampValidBits :
+               0u;
+}
+
+VkQueueFlags VulkanDevice::GetQueueFamilyFlags(
+    EQueueType _queue_type
+) const {
+    const uint32_t family_index = GetQueueFamilyIndex(_queue_type);
+    return family_index < m_device_info.queue_family_props.size() ?
+               m_device_info.queue_family_props[family_index].queueFlags :
+               VkQueueFlags{0};
+}
+
+EVulkanTimestampQueryResetMode
+VulkanDevice::GetTimestampQueryResetMode(
+    EQueueType _queue_type,
+    uint32_t   _effective_valid_bits
+) const {
+    if (_effective_valid_bits == 0) {
+        return EVulkanTimestampQueryResetMode::Unsupported;
+    }
+    const VkQueueFlags queue_flags =
+        GetQueueFamilyFlags(_queue_type);
+    if ((queue_flags &
+         (VK_QUEUE_GRAPHICS_BIT | VK_QUEUE_COMPUTE_BIT)) != 0) {
+        return EVulkanTimestampQueryResetMode::CommandBuffer;
+    }
+    // VulkanDevice passes the queried Vulkan 1.2 feature chain unchanged to
+    // vkCreateDevice. A supported hostQueryReset value is therefore also the
+    // enabled value used by this native host-reset path.
+    if ((queue_flags & VK_QUEUE_TRANSFER_BIT) != 0 &&
+        m_device_info.core_features.core_1_2.hostQueryReset ==
+            VK_TRUE) {
+        return EVulkanTimestampQueryResetMode::Host;
+    }
+    return EVulkanTimestampQueryResetMode::Unsupported;
+}
+
+EVulkanTimestampQueryResetMode
+VulkanDevice::GetTimestampQueryResetMode(
+    EQueueType _queue_type
+) const {
+    return GetTimestampQueryResetMode(
+        _queue_type, GetTimestampValidBits(_queue_type)
+    );
+}
+
+bool VulkanDevice::SupportsTimestampQueries(
+    EQueueType _queue_type
+) const {
+    return GetTimestampQueryResetMode(_queue_type) !=
+           EVulkanTimestampQueryResetMode::Unsupported;
+}
+
 QueueFamilyIndices VulkanDevice::QueryQueueFamilyIndices(VkPhysicalDevice _gpu) const {
     QueueFamilyIndices indices;
 

--- a/source/runtime/render/rhi/vulkan/VulkanDevice.h
+++ b/source/runtime/render/rhi/vulkan/VulkanDevice.h
@@ -232,12 +232,24 @@ public:
     inline QueueFamilyIndices GetQueueFamilyIndices() const {
         return m_device_info.queue_family_indices;
     }
-    inline uint32_t GetTimestampValidBits(EQueueType _queue_type) const {
-        const uint32_t family_index = GetQueueFamilyIndex(_queue_type);
-        return family_index < m_device_info.queue_family_props.size() ?
-                   m_device_info.queue_family_props[family_index].timestampValidBits :
-                   0u;
-    }
+    [[nodiscard]] RENDER_API uint32_t GetTimestampValidBits(
+        EQueueType _queue_type
+    ) const;
+    [[nodiscard]] RENDER_API VkQueueFlags GetQueueFamilyFlags(
+        EQueueType _queue_type
+    ) const;
+    [[nodiscard]] RENDER_API EVulkanTimestampQueryResetMode
+    GetTimestampQueryResetMode(
+        EQueueType _queue_type,
+        uint32_t   _effective_valid_bits
+    ) const;
+    [[nodiscard]] RENDER_API EVulkanTimestampQueryResetMode
+    GetTimestampQueryResetMode(
+        EQueueType _queue_type
+    ) const;
+    [[nodiscard]] RENDER_API bool SupportsTimestampQueries(
+        EQueueType _queue_type
+    ) const;
     inline VkDescriptorSetLayout GetEmptyDescriptorSetLayout() const {
         return empty_descriptor_set_layout;
     }

--- a/source/runtime/render/rhi/vulkan/VulkanQueue.cpp
+++ b/source/runtime/render/rhi/vulkan/VulkanQueue.cpp
@@ -46,6 +46,8 @@ std::atomic<const VulkanQueueLocalSyncWaitObserver*>
     g_queue_local_sync_wait_observer{nullptr};
 std::atomic<const VulkanScriptedQueryPreparationOverrideForTesting*>
     g_scripted_query_preparation_override{nullptr};
+std::atomic<const VulkanScriptedTimestampValidBitsOverrideForTesting*>
+    g_scripted_timestamp_valid_bits_override{nullptr};
 std::atomic<const VulkanScriptedPresentOverrideForTesting*>
     g_scripted_present_override{nullptr};
 
@@ -344,6 +346,38 @@ bool RemoveVulkanScriptedQueryPreparationOverrideForTesting(
     const VulkanScriptedQueryPreparationOverrideForTesting* expected =
         _override;
     return g_scripted_query_preparation_override.compare_exchange_strong(
+        expected,
+        nullptr,
+        std::memory_order_acq_rel,
+        std::memory_order_acquire
+    );
+}
+
+bool TryInstallVulkanScriptedTimestampValidBitsOverrideForTesting(
+    const VulkanScriptedTimestampValidBitsOverrideForTesting* _override
+) noexcept {
+    if (_override == nullptr || _override->callback == nullptr) {
+        return false;
+    }
+    const VulkanScriptedTimestampValidBitsOverrideForTesting* expected =
+        nullptr;
+    return g_scripted_timestamp_valid_bits_override.compare_exchange_strong(
+        expected,
+        _override,
+        std::memory_order_release,
+        std::memory_order_relaxed
+    );
+}
+
+bool RemoveVulkanScriptedTimestampValidBitsOverrideForTesting(
+    const VulkanScriptedTimestampValidBitsOverrideForTesting* _override
+) noexcept {
+    if (_override == nullptr) {
+        return false;
+    }
+    const VulkanScriptedTimestampValidBitsOverrideForTesting* expected =
+        _override;
+    return g_scripted_timestamp_valid_bits_override.compare_exchange_strong(
         expected,
         nullptr,
         std::memory_order_acq_rel,
@@ -9887,6 +9921,134 @@ VkCopyQueue::TranslateForRuntime(CmdSubmit&& _evt) noexcept {
             return recorded;
         }
 
+        auto reject_before_native_record =
+            [&](const VulkanOperationResult& _outcome,
+                std::string_view             _reason,
+                UniquePtr<VulkanAllocator>*  _abandoned_allocator = nullptr) {
+                try {
+                    LOG_ERROR(
+                        "[RHIExecutor][Vulkan] Copy rejected before native "
+                        "record: timeline={} reason={} VkResult={}",
+                        recorded->logical_timeline,
+                        _reason,
+                        static_cast<int32_t>(_outcome.result)
+                    );
+                } catch (...) {
+                }
+                if (_abandoned_allocator != nullptr &&
+                    *_abandoned_allocator) {
+                    recorded->allocators.abandoned.reserve(
+                        recorded->allocators.abandoned.size() + 1
+                    );
+                    recorded->allocators.abandoned.emplace_back(
+                        std::move(*_abandoned_allocator)
+                    );
+                }
+                device.RecordRejectedSubmit();
+                recorded->retirement_outcome = _outcome;
+                recorded->recoverable_rejection =
+                    _outcome.status ==
+                        EVulkanOperationStatus::Rejected &&
+                    !device.IsFaulted() &&
+                    _outcome.result != VK_ERROR_DEVICE_LOST;
+                recorded->native_submit_resolved = true;
+            };
+
+        size_t               timestamp_query_slot_count = 0;
+        Array<uint64>         open_timestamp_queries{};
+        UnorderedSet<uint64>  seen_timestamp_queries{};
+        for (const UniquePtr<Command>& command :
+             recorded->submit.cmds) {
+            if (!command ||
+                command->Type() != Command::EType::Query) {
+                continue;
+            }
+            const auto& query =
+                *static_cast<const QueryCmd*>(command.get());
+            if (!query.IsTimestamp() ||
+                query.GetQueueType() != EQueueType::Copy ||
+                !query.Token().Valid() ||
+                query.Token().Kind() != QueryKind::Timestamp) {
+                reject_before_native_record(
+                    VulkanOperationResult{
+                        EVulkanOperationStatus::Rejected,
+                        VK_ERROR_FEATURE_NOT_PRESENT
+                    },
+                    "Copy payload contains a non-Copy timestamp query"
+                );
+                return recorded;
+            }
+            const bool token_owned_by_submit = std::any_of(
+                recorded->submit.query_tokens.begin(),
+                recorded->submit.query_tokens.end(),
+                [&query](const QueryToken& _token) {
+                    return _token.Valid() &&
+                           _token.Id() == query.Token().Id() &&
+                           _token.Kind() == QueryKind::Timestamp;
+                }
+            );
+            if (!token_owned_by_submit) {
+                reject_before_native_record(
+                    VulkanOperationResult{
+                        EVulkanOperationStatus::Rejected,
+                        VK_ERROR_FEATURE_NOT_PRESENT
+                    },
+                    "Copy timestamp query token is not owned by the submit"
+                );
+                return recorded;
+            }
+            if (query.IsBegin()) {
+                if (!seen_timestamp_queries.emplace(
+                        query.Token().Id()
+                    ).second) {
+                    reject_before_native_record(
+                        VulkanOperationResult{
+                            EVulkanOperationStatus::Rejected,
+                            VK_ERROR_FEATURE_NOT_PRESENT
+                        },
+                        "Copy timestamp query token is recorded more than once"
+                    );
+                    return recorded;
+                }
+                open_timestamp_queries.push_back(query.Token().Id());
+            } else if (open_timestamp_queries.empty() ||
+                       open_timestamp_queries.back() !=
+                           query.Token().Id()) {
+                reject_before_native_record(
+                    VulkanOperationResult{
+                        EVulkanOperationStatus::Rejected,
+                        VK_ERROR_FEATURE_NOT_PRESENT
+                    },
+                    "Copy timestamp query boundaries are malformed"
+                );
+                return recorded;
+            } else {
+                open_timestamp_queries.pop_back();
+            }
+            ++timestamp_query_slot_count;
+        }
+        if (!open_timestamp_queries.empty()) {
+            reject_before_native_record(
+                VulkanOperationResult{
+                    EVulkanOperationStatus::Rejected,
+                    VK_ERROR_FEATURE_NOT_PRESENT
+                },
+                "Copy timestamp query boundaries are incomplete"
+            );
+            return recorded;
+        }
+        if (timestamp_query_slot_count >
+            std::numeric_limits<uint32>::max()) {
+            reject_before_native_record(
+                VulkanOperationResult{
+                    EVulkanOperationStatus::Rejected,
+                    VK_ERROR_OUT_OF_POOL_MEMORY
+                },
+                "Copy timestamp query slot count exceeds uint32 capacity"
+            );
+            return recorded;
+        }
+
         FunctionTable function_table{
             .is_resource_write       = &IsBufferTextureWrite,
             .is_resource_read        = &IsBufferTextureRead,
@@ -9899,8 +10061,94 @@ VkCopyQueue::TranslateForRuntime(CmdSubmit&& _evt) noexcept {
             function_table, recorded->submit.cached_args
         };
 
+        uint32 effective_timestamp_valid_bits =
+            device.GetTimestampValidBits(EQueueType::Copy);
+        if (timestamp_query_slot_count != 0) {
+            const VulkanScriptedTimestampValidBitsOverrideForTesting*
+                scripted_override =
+                    g_scripted_timestamp_valid_bits_override.load(
+                        std::memory_order_acquire
+                    );
+            if (scripted_override != nullptr) {
+                effective_timestamp_valid_bits = std::min(
+                    effective_timestamp_valid_bits,
+                    scripted_override->callback(
+                        scripted_override->context,
+                        EQueueType::Copy,
+                        effective_timestamp_valid_bits
+                    )
+                );
+            }
+        }
+        const EVulkanTimestampQueryResetMode timestamp_reset_mode =
+            device.GetTimestampQueryResetMode(
+                EQueueType::Copy,
+                effective_timestamp_valid_bits
+            );
+        const bool suppress_timestamp_queries =
+            timestamp_query_slot_count != 0 &&
+            timestamp_reset_mode ==
+                EVulkanTimestampQueryResetMode::Unsupported;
+
         recorded->allocators.submitted.reserve(1);
-        recorded->allocators.submitted.emplace_back(GetAllocator());
+        recorded->allocators.abandoned.reserve(1);
+        auto allocator_ptr = GetAllocator();
+        try {
+            if (timestamp_query_slot_count != 0) {
+                allocator_ptr
+                    ->ConfigureTimestampCapabilityForRecording(
+                        effective_timestamp_valid_bits,
+                        timestamp_reset_mode
+                    );
+            }
+            allocator_ptr->EnsureQueryCapacity(
+                suppress_timestamp_queries ?
+                    0 :
+                    timestamp_query_slot_count,
+                0
+            );
+        } catch (const std::exception& error) {
+            try {
+                LOG_ERROR(
+                    "[RHIExecutor][Vulkan] Copy query pool preparation "
+                    "failed: {}",
+                    error.what()
+                );
+            } catch (...) {
+            }
+            const bool device_faulted = device.IsFaulted();
+            reject_before_native_record(
+                VulkanOperationResult{
+                    device_faulted ?
+                        EVulkanOperationStatus::Faulted :
+                        EVulkanOperationStatus::Rejected,
+                    device_faulted ?
+                        device.GetFirstFaultResult() :
+                        VK_ERROR_OUT_OF_POOL_MEMORY
+                },
+                "Copy query pool preparation failed",
+                &allocator_ptr
+            );
+            return recorded;
+        } catch (...) {
+            const bool device_faulted = device.IsFaulted();
+            reject_before_native_record(
+                VulkanOperationResult{
+                    device_faulted ?
+                        EVulkanOperationStatus::Faulted :
+                        EVulkanOperationStatus::Rejected,
+                    device_faulted ?
+                        device.GetFirstFaultResult() :
+                        VK_ERROR_OUT_OF_POOL_MEMORY
+                },
+                "Copy query pool preparation failed",
+                &allocator_ptr
+            );
+            return recorded;
+        }
+        recorded->allocators.submitted.emplace_back(
+            std::move(allocator_ptr)
+        );
         auto& vk_allocator =
             *recorded->allocators.submitted.front();
         auto& vk_cmd_list = vk_allocator.GetCmdList();
@@ -9923,6 +10171,10 @@ VkCopyQueue::TranslateForRuntime(CmdSubmit&& _evt) noexcept {
         );
 
         for (const auto& cmd : recorded->submit.cmds) {
+            if (suppress_timestamp_queries && cmd &&
+                cmd->Type() == Command::EType::Query) {
+                continue;
+            }
             reorderer.AcceptCmd(cmd.get());
         }
 

--- a/source/runtime/render/rhi/vulkan/VulkanSubmissionDiagnostics.h
+++ b/source/runtime/render/rhi/vulkan/VulkanSubmissionDiagnostics.h
@@ -343,6 +343,32 @@ RemoveVulkanScriptedQueryPreparationOverrideForTesting(
     const VulkanScriptedQueryPreparationOverrideForTesting* _override
 ) noexcept;
 
+using VulkanScriptedTimestampValidBitsCallback =
+    uint32 (*)(void*, EQueueType, uint32) noexcept;
+
+struct VulkanScriptedTimestampValidBitsOverrideForTesting {
+    void*                                    context{nullptr};
+    VulkanScriptedTimestampValidBitsCallback callback{nullptr};
+};
+
+// Narrow Copy-query capability seam. The callback receives the native queue
+// family value on the Translate owner and returns an upper bound for this
+// recording. The runtime clamps it to the native value, so a test can degrade
+// capability but can never manufacture unsupported hardware capability.
+// Production has no installed override. Tests use zero to prove that
+// timestamp observability degrades without rejecting real Copy work.
+//
+// Override storage and context are caller-owned and immutable while installed.
+// Quiesce the RHI runtime before removal and destroy them only after removal.
+[[nodiscard]] RENDER_API bool
+TryInstallVulkanScriptedTimestampValidBitsOverrideForTesting(
+    const VulkanScriptedTimestampValidBitsOverrideForTesting* _override
+) noexcept;
+[[nodiscard]] RENDER_API bool
+RemoveVulkanScriptedTimestampValidBitsOverrideForTesting(
+    const VulkanScriptedTimestampValidBitsOverrideForTesting* _override
+) noexcept;
+
 struct VulkanScriptedPresentResult {
     VulkanOperationResult outcome{
         EVulkanOperationStatus::Retry,

--- a/source/runtime/render/rhi/vulkan/VulkanSubmissionExecutor.cpp
+++ b/source/runtime/render/rhi/vulkan/VulkanSubmissionExecutor.cpp
@@ -258,6 +258,11 @@ bool IsCopyCommand(Command::EType _type) {
         case Command::EType::CopyBackTexture:
         case Command::EType::Barrier:
         case Command::EType::QueueTransfer:
+        // Timestamp Query commands are legal ordering boundaries inside one
+        // Copy segment. Multi-segment sources still reject all queries above,
+        // and VkCopyQueue performs token/queue/LIFO preflight before native
+        // command-buffer recording.
+        case Command::EType::Query:
             return true;
         default:
             return false;

--- a/source/test/RHIParallelRecordVulkanTest.cpp
+++ b/source/test/RHIParallelRecordVulkanTest.cpp
@@ -956,6 +956,78 @@ private:
     bool                                             installed{false};
 };
 
+class ScriptedTimestampValidBitsCapture final {
+public:
+    static uint32 ForceUnsupported(
+        void*      _context,
+        EQueueType _queue,
+        uint32     _native_valid_bits
+    ) noexcept {
+        auto& capture =
+            *static_cast<ScriptedTimestampValidBitsCapture*>(_context);
+        if (GetCurrentRHIThreadRole() != ERHIThreadRole::Translate) {
+            capture.wrong_owner.store(true, std::memory_order_relaxed);
+        }
+        capture.queue.store(
+            static_cast<uint32>(_queue), std::memory_order_relaxed
+        );
+        capture.native_valid_bits.store(
+            _native_valid_bits, std::memory_order_relaxed
+        );
+        capture.count.fetch_add(1, std::memory_order_release);
+        return 0;
+    }
+
+    std::atomic<uint32> count{0};
+    std::atomic<uint32> queue{
+        static_cast<uint32>(EQueueType::Ignore)
+    };
+    std::atomic<uint32> native_valid_bits{0};
+    std::atomic<bool>   wrong_owner{false};
+};
+
+class ScopedScriptedTimestampValidBitsOverride final {
+public:
+    explicit ScopedScriptedTimestampValidBitsOverride(
+        ScriptedTimestampValidBitsCapture& _capture
+    ) :
+        scripted_override{
+            .context  = &_capture,
+            .callback =
+                &ScriptedTimestampValidBitsCapture::ForceUnsupported,
+        } {
+        if (!TryInstallVulkanScriptedTimestampValidBitsOverrideForTesting(
+                &scripted_override
+            )) {
+            throw std::runtime_error(
+                "Vulkan scripted timestamp valid-bits override was already installed"
+            );
+        }
+        installed = true;
+    }
+
+    ~ScopedScriptedTimestampValidBitsOverride() noexcept {
+        if (installed &&
+            !RemoveVulkanScriptedTimestampValidBitsOverrideForTesting(
+                &scripted_override
+            )) {
+            std::terminate();
+        }
+    }
+
+    ScopedScriptedTimestampValidBitsOverride(
+        const ScopedScriptedTimestampValidBitsOverride&
+    ) = delete;
+    ScopedScriptedTimestampValidBitsOverride& operator=(
+        const ScopedScriptedTimestampValidBitsOverride&
+    ) = delete;
+
+private:
+    VulkanScriptedTimestampValidBitsOverrideForTesting
+        scripted_override{};
+    bool installed{false};
+};
+
 class DependencyWaitCapture final {
 public:
     explicit DependencyWaitCapture(EQueueType _queue) :
@@ -12857,10 +12929,9 @@ void RunTimestampQueryCopyOnlyPayloadArrival() {
     graphics_future = graphics_query.GetFuture();
     graphics.EndTimestampQuery(graphics_query);
 
-    // The public Copy API resolves timestamp capability as an immediate
-    // Error. Build the backend-internal query-only payload from a valid token
-    // and strip its native commands to exercise the executable-source
-    // contract that batch admission and rejection paths may still construct.
+    // Keep a backend-internal query-only payload alongside the real Copy query
+    // coverage below. Stripping its native commands exercises the executable
+    // source contract that batch admission and rejection paths may construct.
     CommandList copy_payload_builder(EQueueType::Graphics);
     copy_completion =
         copy_payload_builder.TrackGpuCompletion(
@@ -13084,6 +13155,323 @@ void RunTimestampQueryCopyOnlyPayloadArrival() {
         "copy_completion=Ready completion_only_copy=Ready "
         "group_arrival=verified owner=Completion "
         "callbacks=exactly_once native_submit=2 replay=0"
+    );
+}
+
+void RunCopyTimestampQueryCapabilityAndIsolation() {
+    auto& device = RenderDevice::Get();
+    auto* vk_device =
+        static_cast<VulkanDevice*>(device.GetImpl());
+    if (vk_device == nullptr) {
+        throw std::runtime_error(
+            "Copy timestamp test could not access the Vulkan device"
+        );
+    }
+
+    const uint32 native_valid_bits =
+        vk_device->GetTimestampValidBits(EQueueType::Copy);
+    const EVulkanTimestampQueryResetMode native_reset_mode =
+        vk_device->GetTimestampQueryResetMode(EQueueType::Copy);
+    const bool native_supported =
+        vk_device->SupportsTimestampQueries(EQueueType::Copy);
+    const char* native_reset_mode_name =
+        native_reset_mode ==
+                EVulkanTimestampQueryResetMode::CommandBuffer ?
+            "command_buffer" :
+        native_reset_mode == EVulkanTimestampQueryResetMode::Host ?
+            "host" :
+            "unsupported";
+    const EBufferUsageFlags usage =
+        EBufferUsageFlags::TRANSFER_SRC |
+        EBufferUsageFlags::TRANSFER_DST;
+    BufferRef source = device.CreateBuffer<uint32>(
+        "copy_timestamp_source", kElementCount, usage
+    );
+    BufferRef destination = device.CreateBuffer<uint32>(
+        "copy_timestamp_destination", kElementCount, usage
+    );
+
+    NativeSubmissionCapture        native_capture{};
+    ScopedNativeSubmissionObserver native_observer(native_capture);
+    size_t                          expected_native_submits = 0;
+
+    auto run_copy_submission =
+        [&](uint32 _seed, bool _expect_ready) -> QueryResult {
+        std::array<uint32, kElementCount> values{};
+        std::array<uint32, kElementCount> readback{};
+        for (uint32 index = 0; index < values.size(); ++index) {
+            values[index] = _seed + index * 37u;
+        }
+
+        std::atomic<uint32> callback_stage{0};
+        std::atomic<uint32> completion_callbacks{0};
+        std::atomic<uint32> query_callbacks{0};
+        std::atomic<uint32> ordinary_callbacks{0};
+        std::atomic<uint32> success_callbacks{0};
+        std::atomic<uint32> callback_errors{0};
+        FenceRef            done = device.CreateFence();
+
+        auto signal_succeeded = [&] {
+            auto* fence = static_cast<VulkanFence*>(
+                ResourceCast(done.Get())
+            );
+            return fence != nullptr && done->GetValue() >= 1 &&
+                   !fence->IsRejected(1) && !fence->IsFailed();
+        };
+        auto query_matches_expectation =
+            [&](const QueryResult& _result) {
+            const auto* timestamp =
+                std::get_if<TimestampQueryResult>(&_result.payload);
+            if (_expect_ready) {
+                return _result.status == QueryStatus::Ready &&
+                       _result.kind == QueryKind::Timestamp &&
+                       _result.error_reason.empty() &&
+                       timestamp != nullptr &&
+                       timestamp->valid_bits ==
+                           std::min(native_valid_bits, uint32{64}) &&
+                       timestamp->valid_bits != 0 &&
+                       timestamp->tick_period_ns > 0.0 &&
+                       timestamp->duration_ns >= 0.0;
+            }
+            return _result.status == QueryStatus::Error &&
+                   _result.kind == QueryKind::Timestamp &&
+                   !_result.error_reason.empty() &&
+                   timestamp == nullptr;
+        };
+
+        CommandList commands(EQueueType::Copy);
+        GpuCompletionFuture completion =
+            commands.TrackGpuCompletion(
+                _expect_ready ?
+                    "Phase21BCopyTimestampCompletion" :
+                    "Phase21BCopyTimestampUnsupportedCompletion"
+            );
+        commands.CopyFrom(
+            OwnedBytes(values),
+            source->GetView(),
+            "CopyTimestampUpload"
+        );
+        QueryToken query = commands.BeginTimestampQuery(
+            _expect_ready ?
+                "Phase21BCopyTimestamp" :
+                "Phase21BCopyTimestampUnsupported"
+        );
+        QueryFuture future = query.GetFuture();
+        commands.CopyFrom(
+            source->GetView(),
+            destination->GetView(),
+            "CopyTimestampMeasuredCopy"
+        );
+        commands.EndTimestampQuery(query);
+        commands.CopyFrom(
+            destination->GetView(),
+            WritableBytes(readback),
+            "CopyTimestampReadback"
+        );
+
+        completion.Then([&](const GpuCompletionResult& _result) {
+            const std::optional<QueryResult> query_result =
+                future.TryGet();
+            if (GetCurrentRHIThreadRole() !=
+                    ERHIThreadRole::Completion ||
+                _result.status != GpuCompletionStatus::Ready ||
+                !signal_succeeded() ||
+                !query_result.has_value() ||
+                !query_matches_expectation(*query_result) ||
+                callback_stage.load(std::memory_order_acquire) != 0) {
+                callback_errors.fetch_add(
+                    1, std::memory_order_relaxed
+                );
+            }
+            callback_stage.store(1, std::memory_order_release);
+            completion_callbacks.fetch_add(
+                1, std::memory_order_release
+            );
+        });
+        future.Then([&](const QueryResult& _result) {
+            if (GetCurrentRHIThreadRole() !=
+                    ERHIThreadRole::Completion ||
+                !query_matches_expectation(_result) ||
+                completion.Status() != GpuCompletionStatus::Ready ||
+                !signal_succeeded() ||
+                callback_stage.load(std::memory_order_acquire) != 1) {
+                callback_errors.fetch_add(
+                    1, std::memory_order_relaxed
+                );
+            }
+            callback_stage.store(2, std::memory_order_release);
+            query_callbacks.fetch_add(1, std::memory_order_release);
+        });
+        commands.AddCallback([&] {
+            if (GetCurrentRHIThreadRole() !=
+                    ERHIThreadRole::Completion ||
+                callback_stage.load(std::memory_order_acquire) != 2) {
+                callback_errors.fetch_add(
+                    1, std::memory_order_relaxed
+                );
+            }
+            callback_stage.store(3, std::memory_order_release);
+            ordinary_callbacks.fetch_add(
+                1, std::memory_order_release
+            );
+        });
+        commands.AddSuccessCallback([&] {
+            if (GetCurrentRHIThreadRole() !=
+                    ERHIThreadRole::Completion ||
+                callback_stage.load(std::memory_order_acquire) != 3) {
+                callback_errors.fetch_add(
+                    1, std::memory_order_relaxed
+                );
+            }
+            callback_stage.store(4, std::memory_order_release);
+            success_callbacks.fetch_add(
+                1, std::memory_order_release
+            );
+        });
+
+        CmdSubmit submit = commands.Submit();
+        submit.Signal(done.Get(), 1);
+        RHIExecutor::Get().Submit(
+            EQueueType::Copy,
+            std::move(submit),
+            ERHIExecSubmitFlags::FlushGPU
+        );
+        RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
+        ++expected_native_submits;
+
+        const GpuCompletionResult completion_result =
+            completion.Get();
+        const QueryResult result = future.Get();
+        if (!query_matches_expectation(result) ||
+            completion_result.status != GpuCompletionStatus::Ready ||
+            !signal_succeeded() ||
+            readback != values ||
+            callback_stage.load(std::memory_order_acquire) != 4 ||
+            completion_callbacks.load(std::memory_order_acquire) !=
+                1 ||
+            query_callbacks.load(std::memory_order_acquire) != 1 ||
+            ordinary_callbacks.load(std::memory_order_acquire) !=
+                1 ||
+            success_callbacks.load(std::memory_order_acquire) != 1 ||
+            callback_errors.load(std::memory_order_acquire) != 0) {
+            throw std::runtime_error(
+                _expect_ready ?
+                    "supported Copy timestamp submission violated its Completion contract" :
+                    "unsupported Copy timestamp profiling disrupted real Copy work"
+            );
+        }
+
+        RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
+        if (completion_callbacks.load(std::memory_order_acquire) !=
+                1 ||
+            query_callbacks.load(std::memory_order_acquire) != 1 ||
+            ordinary_callbacks.load(std::memory_order_acquire) !=
+                1 ||
+            success_callbacks.load(std::memory_order_acquire) != 1) {
+            throw std::runtime_error(
+                "Copy timestamp submission replayed Completion callbacks"
+            );
+        }
+        return result;
+    };
+
+    std::optional<QueryResult> first_supported_result{};
+    if (native_supported) {
+        first_supported_result.emplace(
+            run_copy_submission(0x21B10000u, true)
+        );
+    }
+
+    ScriptedTimestampValidBitsCapture unsupported_capture{};
+    QueryResult unsupported_result{};
+    {
+        ScopedScriptedTimestampValidBitsOverride
+            scripted_override(unsupported_capture);
+        unsupported_result =
+            run_copy_submission(0x21B20000u, false);
+    }
+    if (unsupported_capture.count.load(std::memory_order_acquire) !=
+            1 ||
+        unsupported_capture.queue.load(std::memory_order_acquire) !=
+            static_cast<uint32>(EQueueType::Copy) ||
+        unsupported_capture.native_valid_bits.load(
+            std::memory_order_acquire
+        ) != native_valid_bits ||
+        unsupported_capture.wrong_owner.load(
+            std::memory_order_acquire
+        ) ||
+        unsupported_result.status != QueryStatus::Error) {
+        throw std::runtime_error(
+            "scripted Copy timestamp capability override lost ownership or identity"
+        );
+    }
+
+    const QueryResult recovery_result =
+        run_copy_submission(
+            0x21B30000u,
+            native_supported
+        );
+
+    if (native_capture.Overflowed() ||
+        native_capture.Count() != expected_native_submits) {
+        throw std::runtime_error(
+            "Copy timestamp test observed the wrong native submission count"
+        );
+    }
+    for (size_t index = 0; index < native_capture.Count(); ++index) {
+        const VulkanNativeSubmissionEvent& event =
+            native_capture.Event(index);
+        if (event.queue != EQueueType::Copy ||
+            event.thread_role != ERHIThreadRole::Submission ||
+            !event.outcome.WasSubmitted()) {
+            throw std::runtime_error(
+                "Copy timestamp work did not retain native Submission ownership"
+            );
+        }
+    }
+
+    if (native_supported) {
+        const auto* first_timestamp =
+            std::get_if<TimestampQueryResult>(
+                &first_supported_result->payload
+            );
+        const auto* recovery_timestamp =
+            std::get_if<TimestampQueryResult>(
+                &recovery_result.payload
+            );
+        if (first_timestamp == nullptr ||
+            recovery_timestamp == nullptr ||
+            first_timestamp->valid_bits == 0 ||
+            recovery_timestamp->valid_bits == 0) {
+            throw std::runtime_error(
+                "Copy timestamp allocator reuse did not restore native capability"
+            );
+        }
+        LOG_INFO(
+            "[TESTCASE][PASS] name=TimestampQueryCopySupported "
+            "queue=Copy status=Ready valid_bits={} reset_mode={} "
+            "copy=verified "
+            "gpu_completion=Ready order=signal->completion->query->ordinary->success "
+            "owner=Completion callbacks=exactly_once "
+            "allocator_reuse=verified native_owner=Submission replay=0",
+            recovery_timestamp->valid_bits,
+            native_reset_mode_name
+        );
+    } else {
+        LOG_INFO(
+            "[TESTCASE][SKIP] name=TimestampQueryCopySupported "
+            "reason=timestamp_unsupported valid_bits={} "
+            "reset_mode=unsupported",
+            native_valid_bits
+        );
+    }
+
+    LOG_INFO(
+        "[TESTCASE][PASS] name=TimestampQueryCopyUnsupportedFallback "
+        "queue=Copy injected_valid_bits=0 query=Error copy=verified "
+        "signal=success gpu_completion=Ready native_submit=accepted "
+        "native_owner=Submission owner=Completion "
+        "callbacks=exactly_once runtime=recovered replay=0"
     );
 }
 
@@ -14569,6 +14957,7 @@ int main(int argc, const char** argv) {
             RunTimestampQueryCrossQueueBatchPublication();
             RunTimestampQueryMixedMultiSegmentCallbackTiers();
             RunTimestampQueryCopyOnlyPayloadArrival();
+            RunCopyTimestampQueryCapabilityAndIsolation();
             RenderDevice::Dispose();
             render_device_initialized = false;
             TaskSystem::ShutDown();
@@ -14597,6 +14986,7 @@ int main(int argc, const char** argv) {
             RunTimestampQueryCrossQueueBatchPublication();
             RunTimestampQueryMixedMultiSegmentCallbackTiers();
             RunTimestampQueryCopyOnlyPayloadArrival();
+            RunCopyTimestampQueryCapabilityAndIsolation();
             RunTimestampQueryPreparationRejection();
             // This malformed-batch rejection hard-latches the runtime, so the
             // mid-batch Translate failure has its own focused invocation.

--- a/source/test/RHIQueryContractTest.cpp
+++ b/source/test/RHIQueryContractTest.cpp
@@ -1039,13 +1039,43 @@ void InvalidSubmissionRejectionAndDestructionAreTerminal() {
     );
 
     CommandList copy(EQueueType::Copy);
-    QueryToken  copy_token = copy.BeginTimestampQuery("UnsupportedCopy");
+    QueryToken  copy_token = copy.BeginTimestampQuery("CopyTimestamp");
+    QueryFuture copy_future = copy_token.GetFuture();
     Expect(
-        copy_token.GetFuture().Get().status == QueryStatus::Error,
-        "Copy queue timestamp query did not fail closed"
+        copy_future.Status() == QueryStatus::Pending,
+        "Copy queue timestamp query was rejected before backend capability resolution"
     );
     copy.EndTimestampQuery(copy_token);
-    Expect(copy.IsEmpty(), "Copy queue capability failure emitted a QueryCmd");
+    CmdSubmit copy_submit = copy.Submit();
+    Expect(
+        copy_submit.cmds.size() == 2 &&
+            copy_submit.query_tokens.size() == 1 &&
+            QueryAt(copy_submit, 0).Op() == QueryCmd::EOp::BeginTimestamp &&
+            QueryAt(copy_submit, 1).Op() == QueryCmd::EOp::EndTimestamp &&
+            QueryAt(copy_submit, 0).IsTimestamp() &&
+            QueryAt(copy_submit, 1).IsTimestamp() &&
+            QueryAt(copy_submit, 0).GetQueueType() == EQueueType::Copy &&
+            QueryAt(copy_submit, 1).GetQueueType() == EQueueType::Copy &&
+            QueryAt(copy_submit, 0).Token().Id() == copy_token.Id() &&
+            QueryAt(copy_submit, 1).Token().Id() == copy_token.Id(),
+        "Copy timestamp query did not preserve its backend-resolved command pair"
+    );
+
+    std::atomic<int> copy_callback_count{0};
+    copy_future.Then([&](const QueryResult& _result) {
+        Expect(
+            _result.status == QueryStatus::Error,
+            "Copy timestamp rejection cleanup produced the wrong terminal state"
+        );
+        copy_callback_count.fetch_add(1, std::memory_order_relaxed);
+    });
+    copy_submit.RejectPendingQueries("Copy contract cleanup");
+    copy_submit.RejectPendingQueries("duplicate Copy contract cleanup");
+    Expect(
+        copy_future.Get().status == QueryStatus::Error &&
+            copy_callback_count.load(std::memory_order_relaxed) == 1,
+        "Copy timestamp rejection cleanup did not notify exactly once"
+    );
 }
 
 void SignalRejectionPrecedesQueryCallbacksAndPreservesReentrantState() {

--- a/tools/threading/run_parallel_record_vulkan_test.py
+++ b/tools/threading/run_parallel_record_vulkan_test.py
@@ -934,6 +934,71 @@ def _require_timestamp_query_success_batch(text: str) -> None:
         "timestamp-query-success-batch: incomplete Copy query-only arrival contract",
     )
 
+    copy_supported = _testcase_marker(
+        "TimestampQueryCopySupported", text
+    )
+    _require(
+        copy_supported is not None,
+        "timestamp-query-success-batch: missing Copy supported marker",
+    )
+    supported_status, supported_fields = copy_supported
+    if supported_status == "SKIP":
+        valid_bits = supported_fields.get("valid_bits")
+        _require(
+            supported_fields.get("reason") == "timestamp_unsupported"
+            and supported_fields.get("reset_mode") == "unsupported"
+            and valid_bits is not None
+            and valid_bits.isdigit()
+            and 0 <= int(valid_bits) <= 64,
+            "timestamp-query-success-batch: invalid Copy supported SKIP contract",
+        )
+    else:
+        valid_bits = supported_fields.get("valid_bits")
+        _require(
+            supported_status == "PASS"
+            and supported_fields.get("queue") == "Copy"
+            and supported_fields.get("status") == "Ready"
+            and valid_bits is not None
+            and valid_bits.isdigit()
+            and 0 < int(valid_bits) <= 64
+            and supported_fields.get("reset_mode")
+            in {"command_buffer", "host"}
+            and supported_fields.get("copy") == "verified"
+            and supported_fields.get("gpu_completion") == "Ready"
+            and supported_fields.get("order")
+            == "signal->completion->query->ordinary->success"
+            and supported_fields.get("owner") == "Completion"
+            and supported_fields.get("callbacks") == "exactly_once"
+            and supported_fields.get("allocator_reuse") == "verified"
+            and supported_fields.get("native_owner") == "Submission"
+            and supported_fields.get("replay") == "0",
+            "timestamp-query-success-batch: incomplete Copy supported contract",
+        )
+
+    copy_unsupported = _testcase_marker(
+        "TimestampQueryCopyUnsupportedFallback", text
+    )
+    _require(
+        copy_unsupported is not None and copy_unsupported[0] == "PASS",
+        "timestamp-query-success-batch: missing Copy unsupported fallback PASS marker",
+    )
+    _, unsupported_fields = copy_unsupported
+    _require(
+        unsupported_fields.get("queue") == "Copy"
+        and unsupported_fields.get("injected_valid_bits") == "0"
+        and unsupported_fields.get("query") == "Error"
+        and unsupported_fields.get("copy") == "verified"
+        and unsupported_fields.get("signal") == "success"
+        and unsupported_fields.get("gpu_completion") == "Ready"
+        and unsupported_fields.get("native_submit") == "accepted"
+        and unsupported_fields.get("native_owner") == "Submission"
+        and unsupported_fields.get("owner") == "Completion"
+        and unsupported_fields.get("callbacks") == "exactly_once"
+        and unsupported_fields.get("runtime") == "recovered"
+        and unsupported_fields.get("replay") == "0",
+        "timestamp-query-success-batch: incomplete Copy unsupported fallback contract",
+    )
+
 
 def _require_owning_readback_future(text: str) -> None:
     marker = _testcase_marker("OwningReadbackFuture", text)

--- a/tools/threading/test_run_parallel_record_vulkan_test.py
+++ b/tools/threading/test_run_parallel_record_vulkan_test.py
@@ -238,6 +238,20 @@ def timestamp_query_success_batch_line() -> str:
         "copy_payload=query_only copy_query=Error "
         "group_arrival=verified owner=Completion "
         "callbacks=exactly_once native_submit=2 replay=0\n"
+        "[TESTCASE][PASS] "
+        "name=TimestampQueryCopySupported "
+        "queue=Copy status=Ready valid_bits=64 reset_mode=host "
+        "copy=verified "
+        "gpu_completion=Ready "
+        "order=signal->completion->query->ordinary->success "
+        "owner=Completion callbacks=exactly_once "
+        "allocator_reuse=verified native_owner=Submission replay=0\n"
+        "[TESTCASE][PASS] "
+        "name=TimestampQueryCopyUnsupportedFallback "
+        "queue=Copy injected_valid_bits=0 query=Error copy=verified "
+        "signal=success gpu_completion=Ready native_submit=accepted "
+        "native_owner=Submission owner=Completion "
+        "callbacks=exactly_once runtime=recovered replay=0\n"
     )
 
 
@@ -1221,6 +1235,94 @@ class VulkanRunnerTests(unittest.TestCase):
                     "order=Query,SuccessInsideOrdinary",
                 ),
             )
+
+    def test_timestamp_query_success_batch_rejects_copy_isolation_failure(
+        self,
+    ) -> None:
+        with self.assertRaisesRegex(
+            runner.VulkanTestError,
+            "incomplete Copy unsupported fallback contract",
+        ):
+            runner.validate_log(
+                "timestamp-query-success-batch",
+                timestamp_query_success_batch_line().replace(
+                    "query=Error copy=verified signal=success",
+                    "query=Error copy=rejected signal=success",
+                ),
+            )
+
+    def test_timestamp_query_success_batch_rejects_copy_callback_owner(
+        self,
+    ) -> None:
+        with self.assertRaisesRegex(
+            runner.VulkanTestError,
+            "incomplete Copy unsupported fallback contract",
+        ):
+            runner.validate_log(
+                "timestamp-query-success-batch",
+                timestamp_query_success_batch_line().replace(
+                    "native_owner=Submission owner=Completion "
+                    "callbacks=exactly_once runtime=recovered",
+                    "native_owner=Submission owner=Translate "
+                    "callbacks=exactly_once runtime=recovered",
+                ),
+            )
+
+    def test_timestamp_query_success_batch_rejects_copy_allocator_reuse(
+        self,
+    ) -> None:
+        with self.assertRaisesRegex(
+            runner.VulkanTestError,
+            "incomplete Copy supported contract",
+        ):
+            runner.validate_log(
+                "timestamp-query-success-batch",
+                timestamp_query_success_batch_line().replace(
+                    "allocator_reuse=verified",
+                    "allocator_reuse=unverified",
+                ),
+            )
+
+    def test_timestamp_query_success_batch_rejects_copy_supported_reset_mode(
+        self,
+    ) -> None:
+        with self.assertRaisesRegex(
+            runner.VulkanTestError,
+            "incomplete Copy supported contract",
+        ):
+            runner.validate_log(
+                "timestamp-query-success-batch",
+                timestamp_query_success_batch_line().replace(
+                    "valid_bits=64 reset_mode=host",
+                    "valid_bits=64 reset_mode=unsupported",
+                ),
+            )
+
+    def test_timestamp_query_success_batch_accepts_copy_reset_unsupported_skip(
+        self,
+    ) -> None:
+        supported_marker = (
+            "[TESTCASE][PASS] "
+            "name=TimestampQueryCopySupported "
+            "queue=Copy status=Ready valid_bits=64 reset_mode=host "
+            "copy=verified gpu_completion=Ready "
+            "order=signal->completion->query->ordinary->success "
+            "owner=Completion callbacks=exactly_once "
+            "allocator_reuse=verified native_owner=Submission replay=0"
+        )
+        unsupported_marker = (
+            "[TESTCASE][SKIP] "
+            "name=TimestampQueryCopySupported "
+            "reason=timestamp_unsupported valid_bits=64 "
+            "reset_mode=unsupported"
+        )
+        runner.validate_log(
+            "timestamp-query-success-batch",
+            timestamp_query_success_batch_line().replace(
+                supported_marker,
+                unsupported_marker,
+            ),
+        )
 
     def test_rt_export_rejection_contract_is_accepted(self) -> None:
         runner.validate_log(


### PR DESCRIPTION
## Summary
- allow Copy command lists to carry strict Begin/End timestamp QueryCmd pairs
- add Vulkan timestamp reset capability modes: command-buffer, host, unsupported
- keep unsupported profiling isolated: real Copy work/signals/GPU completion/success callbacks still succeed while QueryFuture resolves Error on Completion
- preflight Copy query ownership/LIFO before native recording and admit Query boundaries in single Copy topology segments
- add real Copy/readback, allocator reuse, forced-unsupported recovery, owner/order, and runner gate coverage

## Validation
- RelWithDebInfo + Debug: TestRHIQuery and TestRHIParallelRecordVulkan build
- TestRHIQuery: pass in both configs
- Python runner tests: 134/134
- Vulkan --timestamp-query-success-batch: pass in both configs
- Vulkan full --timestamp-query: pass
- serial/parallel/fallback extended Vulkan matrix: pass
- CTest RelWithDebInfo: 23/23
- MoerEditor Raytracing/Vulkan/RHI-thread/parallel-record smoke: clean shutdown, stderr=0, VUID=0, Validation Error=0, [error]=0

## Architecture note
Unlike dev_parallel_rhi's global query runtime, query state remains allocator-local and moves through Submission -> Completion. Dedicated transfer queues use host reset only when Vulkan 1.2 hostQueryReset is enabled; otherwise timestamp observation degrades without rejecting the Copy source.