### PR TITLE
Phase 21B.2: add bounded GPU scope transport

### DIFF
--- a/source/runtime/render/rhi/RHICommand.h
+++ b/source/runtime/render/rhi/RHICommand.h
@@ -1701,7 +1701,8 @@ public:
     // Binds one stable topology source for this recording generation before
     // any timed scope is recorded. Submit/rejection clears the recorder so
     // frame metadata cannot leak into a later generation. The recorder queue
-    // must match this CommandList.
+    // must match this CommandList. Passing an empty recorder is an admission
+    // error; omit this call entirely to retain the legacy profiling path.
     RENDER_API CommandList& SetGpuScopeRecorder(
         GpuScopeRecorder _recorder
     );

--- a/source/runtime/render/rhi/RHICommand.h
+++ b/source/runtime/render/rhi/RHICommand.h
@@ -10,6 +10,7 @@
 #include "misc/Traits.h"
 #include "rhi/RHICommon.h"
 #include "rhi/RHICompletion.h"
+#include "rhi/RHIGpuScope.h"
 #include "rhi/RHIQuery.h"
 #include "rhi/RHIReadback.h"
 #include "rhi/RHIResource.h"
@@ -1697,6 +1698,17 @@ public:
     RENDER_API QueryToken BeginOcclusionQuery(std::string_view _name = "OcclusionQuery");
     RENDER_API void EndOcclusionQuery(const QueryToken& _token);
 
+    // Binds one stable topology source for this recording generation before
+    // any timed scope is recorded. Submit/rejection clears the recorder so
+    // frame metadata cannot leak into a later generation. The recorder queue
+    // must match this CommandList.
+    RENDER_API CommandList& SetGpuScopeRecorder(
+        GpuScopeRecorder _recorder
+    );
+    [[nodiscard]] bool HasGpuScopeRecorder() const noexcept {
+        return gpu_scope_recorder.IsBound();
+    }
+
     template<typename T, typename... Args>
     struct CountType;
 
@@ -2057,6 +2069,10 @@ private:
     RENDER_API void RejectPendingGpuCompletions(
         std::string_view _reason
     ) noexcept;
+    RENDER_API QueryToken BeginTimestampQueryWithCallback(
+        std::string_view       _name,
+        QueryFuture::Callback  _callback
+    );
 
 #pragma region[ raytracing ]
     RENDER_API void TraceRays(PipelineHandle _pipeline, ArrayArguments&& _args, uint3 _extent);
@@ -2092,11 +2108,22 @@ private:
     struct ScopeState {
         std::string name;
         float4      color;
-        bool        query_timestamp = false;
+        bool        timed_scope = false;
+        bool        legacy_timestamp = false;
+        QueryToken  timestamp_query{};
+        GpuScopeCompletionTicket gpu_scope_ticket{};
+        uint64      previous_gpu_scope_id{0};
+        uint32      previous_gpu_scope_depth{0};
+        bool        suppresses_modern_children{false};
     };
 
     Stack<ScopeState>            scope_stack;
     UnorderedSet<std::string>    timestamp_scope_names;
+    GpuScopeRecorder             gpu_scope_recorder{};
+    uint64                       active_gpu_scope_id{0};
+    uint32                       active_gpu_scope_depth{0};
+    uint32                       gpu_scope_suppression_depth{0};
+    bool                         gpu_scope_recorder_bound_this_generation{false};
 };
 
 // Non-copyable, non-movable RAII wrapper used by high-level render code. It guarantees that a

--- a/source/runtime/render/rhi/RHICommandList.cpp
+++ b/source/runtime/render/rhi/RHICommandList.cpp
@@ -190,6 +190,11 @@ CommandList::~CommandList() {
         scope_stack.pop();
     }
     timestamp_scope_names.clear();
+    gpu_scope_recorder = {};
+    active_gpu_scope_id = 0;
+    active_gpu_scope_depth = 0;
+    gpu_scope_suppression_depth = 0;
+    gpu_scope_recorder_bound_this_generation = false;
 
     // No externally observable rejection may run while the dying object still
     // exposes an extractable command generation.
@@ -282,6 +287,11 @@ CommandList& CommandList::operator=(CommandList&& _other) {
         scope_stack.pop();
     }
     timestamp_scope_names.clear();
+    gpu_scope_recorder = {};
+    active_gpu_scope_id = 0;
+    active_gpu_scope_depth = 0;
+    gpu_scope_suppression_depth = 0;
+    gpu_scope_recorder_bound_this_generation = false;
 
     commands                    = std::move(_other.commands);
     current_barriers            = _other.current_barriers;
@@ -308,6 +318,14 @@ CommandList& CommandList::operator=(CommandList&& _other) {
     );
     scope_stack.swap(_other.scope_stack);
     timestamp_scope_names.swap(_other.timestamp_scope_names);
+    gpu_scope_recorder          =
+        std::move(_other.gpu_scope_recorder);
+    active_gpu_scope_id         = _other.active_gpu_scope_id;
+    active_gpu_scope_depth      = _other.active_gpu_scope_depth;
+    gpu_scope_suppression_depth =
+        _other.gpu_scope_suppression_depth;
+    gpu_scope_recorder_bound_this_generation =
+        _other.gpu_scope_recorder_bound_this_generation;
     query_owner_id              = _other.query_owner_id;
 
     _other.current_barriers          = nullptr;
@@ -333,6 +351,11 @@ CommandList& CommandList::operator=(CommandList&& _other) {
         _other.scope_stack.pop();
     }
     _other.timestamp_scope_names.clear();
+    _other.gpu_scope_recorder = {};
+    _other.active_gpu_scope_id = 0;
+    _other.active_gpu_scope_depth = 0;
+    _other.gpu_scope_suppression_depth = 0;
+    _other.gpu_scope_recorder_bound_this_generation = false;
 
     // Install the complete incoming generation before rejecting a Fence,
     // publishing a terminal Future (which wakes Wait/Get), or releasing a
@@ -533,7 +556,13 @@ CmdSubmit CommandList::Submit() {
         while (!scope_stack.empty()) {
             const ScopeState& scope = scope_stack.top();
             commands.push_back(
-                MakeUnique<ScopeCmd>(scope.name, false, scope.query_timestamp, scope.color)
+                MakeUnique<ScopeCmd>(
+                    scope.name,
+                    false,
+                    scope.legacy_timestamp,
+                    scope.color,
+                    queue_type
+                )
             );
             scope_stack.pop();
         }
@@ -608,6 +637,11 @@ CmdSubmit CommandList::Submit() {
     signal_events.clear();
     signal_rejection_keepalives.clear();
     timestamp_scope_names.clear();
+    gpu_scope_recorder = {};
+    active_gpu_scope_id = 0;
+    active_gpu_scope_depth = 0;
+    gpu_scope_suppression_depth = 0;
+    gpu_scope_recorder_bound_this_generation = false;
     translate_execution_class = ERHITranslateExecutionClass::Parallel;
     resource_state_ownership  = ERHIResourceStateOwnership::BackendTracked;
     return std::move(submit);
@@ -736,6 +770,11 @@ CmdSubmit CommandList::PrepareRecordingRejectionDrain(
         scope_stack.pop();
     }
     timestamp_scope_names.clear();
+    gpu_scope_recorder = {};
+    active_gpu_scope_id = 0;
+    active_gpu_scope_depth = 0;
+    gpu_scope_suppression_depth = 0;
+    gpu_scope_recorder_bound_this_generation = false;
     translate_execution_class =
         ERHITranslateExecutionClass::Parallel;
     resource_state_ownership =
@@ -1073,23 +1112,120 @@ void CommandList::ClearResource(TextureView _texture, uint _value) {
 void CommandList::PushScope(std::string_view _name, float4 _color) {
     assert(!_name.empty() && "GPU marker scope name must not be empty");
     const std::string scope_name = _name.empty() ? "Unnamed GPU Scope" : std::string(_name);
-    commands.push_back(MakeUnique<ScopeCmd>(scope_name, true, false, _color));
-    scope_stack.emplace(ScopeState{scope_name, _color, false});
+    commands.push_back(
+        MakeUnique<ScopeCmd>(
+            scope_name, true, false, _color, queue_type
+        )
+    );
+    scope_stack.emplace(ScopeState{
+        .name = scope_name,
+        .color = _color,
+        .timed_scope = false,
+        .legacy_timestamp = false,
+        .previous_gpu_scope_id = active_gpu_scope_id,
+        .previous_gpu_scope_depth = active_gpu_scope_depth,
+    });
 }
 
 void CommandList::PushScopeWithTimeScope(std::string_view _name, float4 _color) {
     assert(!_name.empty() && "GPU timestamp scope name must not be empty");
     const std::string scope_name = _name.empty() ? "Unnamed GPU Timestamp Scope" : std::string(_name);
-    const bool unique_timestamp_name = timestamp_scope_names.emplace(scope_name).second;
-    assert(
-        unique_timestamp_name &&
-        "GPU timestamp scope names must be unique within a CommandList submission"
-    );
+    // Once a recording generation is explicitly bound to the modern sink it
+    // must never fall back to the legacy profiler. A stream may close while
+    // producers are still recording; that becomes a bounded dropped subtree,
+    // not a mixed modern/legacy query stream.
+    const bool modern_scope = gpu_scope_recorder.IsBound();
+    bool       legacy_timestamp = false;
+    if (!modern_scope) {
+        legacy_timestamp =
+            timestamp_scope_names.emplace(scope_name).second;
+        assert(
+            legacy_timestamp &&
+            "GPU timestamp scope names must be unique within a legacy profiled submission"
+        );
+    }
 
-    // In release builds, a duplicate remains useful as a visual marker but
-    // deliberately does not allocate/reuse an ambiguous profiler query pair.
-    commands.push_back(MakeUnique<ScopeCmd>(scope_name, true, unique_timestamp_name, _color));
-    scope_stack.emplace(ScopeState{scope_name, _color, unique_timestamp_name});
+    // Allocate all visual-marker storage before reserving a bounded modern
+    // scope. Once admission succeeds, no later marker allocation can strand
+    // the reservation.
+    auto marker = MakeUnique<ScopeCmd>(
+        scope_name,
+        true,
+        legacy_timestamp,
+        _color,
+        queue_type
+    );
+    commands.reserve(commands.size() + (modern_scope ? 2 : 1));
+
+    GpuScopeCompletionTicket scope_ticket{};
+    if (modern_scope) {
+        if (gpu_scope_suppression_depth != 0) {
+            gpu_scope_recorder.RecordSuppressedScope();
+        } else {
+            scope_ticket = gpu_scope_recorder.TryBeginScope(
+                scope_name,
+                active_gpu_scope_id,
+                active_gpu_scope_depth
+            );
+        }
+    }
+    const bool suppresses_modern_children =
+        modern_scope && !scope_ticket.Valid();
+
+    ScopeState scope{
+        .name = scope_name,
+        .color = _color,
+        .timed_scope = true,
+        .legacy_timestamp = legacy_timestamp,
+        .gpu_scope_ticket = scope_ticket,
+        .previous_gpu_scope_id = active_gpu_scope_id,
+        .previous_gpu_scope_depth = active_gpu_scope_depth,
+        .suppresses_modern_children =
+            suppresses_modern_children,
+    };
+    bool scope_state_installed = false;
+    try {
+        scope_stack.emplace(std::move(scope));
+        scope_state_installed = true;
+        commands.emplace_back(std::move(marker));
+    } catch (...) {
+        if (scope_state_installed) {
+            scope_stack.pop();
+        }
+        scope_ticket.Fail(
+            "GPU scope marker allocation failed before query recording"
+        );
+        if (legacy_timestamp) {
+            timestamp_scope_names.erase(scope_name);
+        }
+        throw;
+    }
+
+    if (!scope_ticket.Valid()) {
+        if (suppresses_modern_children) {
+            ++gpu_scope_suppression_depth;
+        }
+        return;
+    }
+
+    try {
+        QueryToken query = BeginTimestampQueryWithCallback(
+            scope_name,
+            [scope_ticket](const QueryResult& _result) noexcept {
+                scope_ticket.Resolve(_result);
+            }
+        );
+        scope_stack.top().timestamp_query = std::move(query);
+        active_gpu_scope_id = scope_ticket.ScopeId();
+        ++active_gpu_scope_depth;
+    } catch (...) {
+        commands.pop_back();
+        scope_stack.pop();
+        scope_ticket.Fail(
+            "GPU scope query recording failed before submission"
+        );
+        throw;
+    }
 }
 
 void CommandList::PopScope() {
@@ -1098,9 +1234,18 @@ void CommandList::PopScope() {
         return;
     }
     const ScopeState& scope = scope_stack.top();
-    assert(!scope.query_timestamp && "PopScope must match PushScope, not PushScopeWithTimeScope");
+    assert(
+        !scope.timed_scope &&
+        "PopScope must match PushScope, not PushScopeWithTimeScope"
+    );
     commands.push_back(
-        MakeUnique<ScopeCmd>(scope.name, false, scope.query_timestamp, scope.color)
+        MakeUnique<ScopeCmd>(
+            scope.name,
+            false,
+            scope.legacy_timestamp,
+            scope.color,
+            queue_type
+        )
     );
     scope_stack.pop();
 }
@@ -1112,13 +1257,66 @@ void CommandList::PopScopeWithTimeScope() {
     }
     const ScopeState& scope = scope_stack.top();
     assert(
-        scope.query_timestamp &&
+        scope.timed_scope &&
         "PopScopeWithTimeScope must match PushScopeWithTimeScope, not PushScope"
     );
-    commands.push_back(
-        MakeUnique<ScopeCmd>(scope.name, false, scope.query_timestamp, scope.color)
+    auto marker = MakeUnique<ScopeCmd>(
+        scope.name,
+        false,
+        scope.legacy_timestamp,
+        scope.color,
+        queue_type
     );
+    commands.reserve(
+        commands.size() +
+        (scope.gpu_scope_ticket.Valid() ? 2 : 1)
+    );
+    if (scope.gpu_scope_ticket.Valid()) {
+        EndTimestampQuery(scope.timestamp_query);
+        active_gpu_scope_id = scope.previous_gpu_scope_id;
+        active_gpu_scope_depth =
+            scope.previous_gpu_scope_depth;
+    } else if (scope.suppresses_modern_children) {
+        assert(gpu_scope_suppression_depth != 0);
+        if (gpu_scope_suppression_depth != 0) {
+            --gpu_scope_suppression_depth;
+        }
+    }
+    commands.emplace_back(std::move(marker));
     scope_stack.pop();
+}
+
+CommandList& CommandList::SetGpuScopeRecorder(
+    GpuScopeRecorder _recorder
+) {
+    if (!scope_stack.empty() || HasOpenQueries()) {
+        throw std::logic_error(
+            "GPU scope recorder cannot change while a marker or query is open"
+        );
+    }
+    if (gpu_scope_recorder_bound_this_generation) {
+        throw std::logic_error(
+            "GPU scope recorder is immutable for one CommandList recording generation"
+        );
+    }
+    if (_recorder.IsBound() &&
+        _recorder.BoundQueueBinding().queue != queue_type) {
+        throw std::invalid_argument(
+            "GPU scope recorder queue must match its CommandList"
+        );
+    }
+    if (_recorder.IsBound() && !timestamp_scope_names.empty()) {
+        throw std::logic_error(
+            "GPU scope recorder must be bound before any legacy timed scope in a CommandList recording generation"
+        );
+    }
+    gpu_scope_recorder = std::move(_recorder);
+    active_gpu_scope_id = 0;
+    active_gpu_scope_depth = 0;
+    gpu_scope_suppression_depth = 0;
+    gpu_scope_recorder_bound_this_generation =
+        gpu_scope_recorder.IsBound();
+    return *this;
 }
 #pragma region[ raytracing ]
 
@@ -1304,37 +1502,48 @@ GpuCompletionFuture CommandList::TrackGpuCompletion(
 }
 
 QueryToken CommandList::BeginTimestampQuery(std::string_view _name) {
+    return BeginTimestampQueryWithCallback(_name, {});
+}
+
+QueryToken CommandList::BeginTimestampQueryWithCallback(
+    std::string_view      _name,
+    QueryFuture::Callback _callback
+) {
     QueryToken token(
         NextNonZeroId(g_query_token_id),
         QueryKind::Timestamp,
         query_owner_id,
         _name
     );
-    query_cancellation_domain.Register(token);
-
-    auto command = MakeUnique<QueryCmd>(
-        token,
-        QueryCmd::EOp::BeginTimestamp,
-        queue_type,
-        token.Name()
-    );
-    std::function<void()> rejection_fallback = [token] {
-        QueryBackendAccess::ResolveErrorIfPending(
-            token,
-            "timestamp query submission did not reach GPU completion"
-        );
-    };
-
-    commands.reserve(commands.size() + 1);
-    callbacks.reserve(callbacks.size() + 1);
-    query_tokens.reserve(query_tokens.size() + 1);
-    active_query_stack.reserve(active_query_stack.size() + 1);
 
     const size_t command_count  = commands.size();
     const size_t callback_count = callbacks.size();
     const size_t query_count    = query_tokens.size();
     const size_t stack_depth    = active_query_stack.size();
     try {
+        // Register observer storage before mutating the CommandList. If the
+        // callback array allocation fails, no open native query has been
+        // recorded and the caller can release its bounded admission directly.
+        token.Then(std::move(_callback));
+        query_cancellation_domain.Register(token);
+
+        auto command = MakeUnique<QueryCmd>(
+            token,
+            QueryCmd::EOp::BeginTimestamp,
+            queue_type,
+            token.Name()
+        );
+        std::function<void()> rejection_fallback = [token] {
+            QueryBackendAccess::ResolveErrorIfPending(
+                token,
+                "timestamp query submission did not reach GPU completion"
+            );
+        };
+
+        commands.reserve(commands.size() + 1);
+        callbacks.reserve(callbacks.size() + 1);
+        query_tokens.reserve(query_tokens.size() + 1);
+        active_query_stack.reserve(active_query_stack.size() + 1);
         commands.emplace_back(std::move(command));
         callbacks.emplace_back(std::move(rejection_fallback));
         query_tokens.emplace_back(token);
@@ -1346,7 +1555,7 @@ QueryToken CommandList::BeginTimestampQuery(std::string_view _name) {
         active_query_stack.resize(stack_depth);
         QueryBackendAccess::ResolveErrorIfPending(
             token,
-            "timestamp query recording failed before Begin was published"
+            "timestamp query recording failed before Begin was committed"
         );
         throw;
     }

--- a/source/runtime/render/rhi/RHICommandList.cpp
+++ b/source/runtime/render/rhi/RHICommandList.cpp
@@ -1299,13 +1299,21 @@ CommandList& CommandList::SetGpuScopeRecorder(
             "GPU scope recorder is immutable for one CommandList recording generation"
         );
     }
-    if (_recorder.IsBound() &&
-        _recorder.BoundQueueBinding().queue != queue_type) {
+    // An empty recorder is an admission failure, not an opt-out signal.
+    // Callers that do not want modern profiling simply never call this API.
+    // A once-bound recorder whose stream later closes remains accepted and
+    // fail-closed through IsBound(), preventing silent legacy fallback.
+    if (!_recorder.IsBound()) {
+        throw std::invalid_argument(
+            "GPU scope recorder must own an admitted recording source"
+        );
+    }
+    if (_recorder.BoundQueueBinding().queue != queue_type) {
         throw std::invalid_argument(
             "GPU scope recorder queue must match its CommandList"
         );
     }
-    if (_recorder.IsBound() && !timestamp_scope_names.empty()) {
+    if (!timestamp_scope_names.empty()) {
         throw std::logic_error(
             "GPU scope recorder must be bound before any legacy timed scope in a CommandList recording generation"
         );

--- a/source/runtime/render/rhi/RHIGpuScope.cpp
+++ b/source/runtime/render/rhi/RHIGpuScope.cpp
@@ -1,0 +1,1631 @@
+#include "rhi/RHIGpuScope.h"
+
+#include <algorithm>
+#include <cassert>
+#include <atomic>
+#include <cmath>
+#include <limits>
+#include <mutex>
+#include <numeric>
+#include <stdexcept>
+#if defined(MOER_RHI_GPU_SCOPE_TEST_HOOKS)
+#include <thread>
+#endif
+#include <tuple>
+#include <utility>
+
+namespace Moer::Render {
+namespace GpuScopeDetail {
+
+namespace {
+
+constexpr std::size_t kInvalidStreamSlot =
+    std::numeric_limits<std::size_t>::max();
+
+#if defined(MOER_RHI_GPU_SCOPE_TEST_HOOKS)
+std::atomic<std::atomic_uint32_t*> g_admission_pause_entered{nullptr};
+std::atomic<std::atomic_bool*>     g_admission_pause_release{nullptr};
+
+void PauseScopeAdmissionForTesting() noexcept {
+    std::atomic_uint32_t* entered =
+        g_admission_pause_entered.load(std::memory_order_acquire);
+    if (entered == nullptr) {
+        return;
+    }
+    entered->fetch_add(1, std::memory_order_acq_rel);
+    std::atomic_bool* release =
+        g_admission_pause_release.load(std::memory_order_acquire);
+    while (release != nullptr &&
+           !release->load(std::memory_order_acquire)) {
+        std::this_thread::yield();
+    }
+}
+#endif
+
+bool IsManagedQueue(EQueueType _queue) noexcept {
+    return _queue == EQueueType::Graphics ||
+           _queue == EQueueType::Compute ||
+           _queue == EQueueType::Copy;
+}
+
+std::size_t QueueIndex(EQueueType _queue) noexcept {
+    switch (_queue) {
+        case EQueueType::Graphics:
+            return 0;
+        case EQueueType::Compute:
+            return 1;
+        case EQueueType::Copy:
+            return 2;
+        case EQueueType::Num:
+        case EQueueType::Ignore:
+        default:
+            return 0;
+    }
+}
+
+bool SameTimestampDomain(
+    const RHIQueueBinding& _lhs,
+    const RHIQueueBinding& _rhs
+) noexcept {
+    return _lhs.available && _rhs.available &&
+           _lhs.native_queue_id == _rhs.native_queue_id &&
+           _lhs.family_id == _rhs.family_id;
+}
+
+std::uint64_t TimestampMask(std::uint32_t _valid_bits) noexcept {
+    return _valid_bits == 64 ?
+        std::numeric_limits<std::uint64_t>::max() :
+        (std::uint64_t{1} << _valid_bits) - 1;
+}
+
+std::uint64_t TimestampDelta(
+    std::uint64_t _begin_tick,
+    std::uint64_t _end_tick,
+    std::uint32_t _valid_bits
+) noexcept {
+    return (_end_tick - _begin_tick) & TimestampMask(_valid_bits);
+}
+
+bool NearlyEqualDuration(double _lhs, double _rhs) noexcept {
+    if (!std::isfinite(_lhs) || !std::isfinite(_rhs)) {
+        return false;
+    }
+    const double tolerance = std::max(
+        1.0e-6,
+        std::max(std::abs(_lhs), std::abs(_rhs)) * 1.0e-9
+    );
+    return std::abs(_lhs - _rhs) <= tolerance;
+}
+
+void UpdateHighWater(
+    std::atomic<std::uint64_t>& _high_water,
+    std::uint64_t               _value
+) noexcept {
+    std::uint64_t observed = _high_water.load(std::memory_order_relaxed);
+    while (observed < _value &&
+           !_high_water.compare_exchange_weak(
+               observed,
+               _value,
+               std::memory_order_relaxed,
+               std::memory_order_relaxed
+           )) {
+    }
+}
+
+void AssignBoundedNoexcept(
+    std::string&      _destination,
+    std::string_view  _source,
+    std::size_t       _max_bytes
+) noexcept {
+    try {
+        _destination.assign(
+            _source.data(),
+            std::min(_source.size(), _max_bytes)
+        );
+    } catch (...) {
+        _destination.clear();
+    }
+}
+
+} // namespace
+
+struct ScopeSlot {
+    std::uint64_t scope_id{0};
+    std::uint64_t parent_scope_id{0};
+    std::uint64_t source_order{0};
+    std::uint64_t local_order{0};
+    std::uint32_t depth{0};
+    RHIQueueBinding queue_binding{};
+    std::string     name{};
+
+    bool                   terminal{false};
+    GpuScopeTerminalStatus status{GpuScopeTerminalStatus::Error};
+    std::uint64_t          query_id{0};
+    std::uint64_t          begin_tick{0};
+    std::uint64_t          end_tick{0};
+    std::uint32_t          valid_bits{0};
+    double                 tick_period_ns{0.0};
+    double                 duration_ns{0.0};
+    std::string            error_reason{};
+};
+
+struct SourceKey {
+    RHIQueueBinding queue_binding{};
+    std::uint64_t   source_order{0};
+};
+
+struct StreamCounters {
+    std::atomic<std::uint64_t> frames_opened{0};
+    std::atomic<std::uint64_t> frames_sealed{0};
+    std::atomic<std::uint64_t> frames_ready{0};
+    std::atomic<std::uint64_t> frames_popped{0};
+    std::atomic<std::uint64_t> frames_dropped_resident_full{0};
+    std::atomic<std::uint64_t> frames_dropped_pending_full{0};
+    std::atomic<std::uint64_t> frames_dropped_duplicate_id{0};
+    std::atomic<std::uint64_t> frames_dropped_resource_exhaustion{0};
+    std::atomic<std::uint64_t> frames_abandoned_on_close{0};
+
+    std::atomic<std::uint64_t> sources_opened{0};
+    std::atomic<std::uint64_t> sources_dropped_capacity{0};
+    std::atomic<std::uint64_t> sources_dropped_duplicate_order{0};
+    std::atomic<std::uint64_t> sources_dropped_after_seal{0};
+
+    std::atomic<std::uint64_t> scopes_attempted{0};
+    std::atomic<std::uint64_t> scopes_admitted{0};
+    std::atomic<std::uint64_t> scopes_ready{0};
+    std::atomic<std::uint64_t> scopes_error{0};
+    std::atomic<std::uint64_t> scopes_dropped_resident_full{0};
+    std::atomic<std::uint64_t> scopes_dropped_frame_full{0};
+    std::atomic<std::uint64_t> scopes_dropped_name_too_large{0};
+    std::atomic<std::uint64_t> scopes_dropped_invalid_hierarchy{0};
+    std::atomic<std::uint64_t> scopes_dropped_suppressed_subtree{0};
+    std::atomic<std::uint64_t> scopes_dropped_after_seal{0};
+    std::atomic<std::uint64_t> scopes_dropped_resource_exhaustion{0};
+
+    std::atomic<std::uint64_t> high_water_frames{0};
+    std::atomic<std::uint64_t> high_water_pending_frames{0};
+    std::atomic<std::uint64_t> high_water_ready_frames{0};
+    std::atomic<std::uint64_t> high_water_scopes{0};
+};
+
+struct FrameState;
+
+struct StreamState : std::enable_shared_from_this<StreamState> {
+    explicit StreamState(const GpuScopeStreamConfig& _config) :
+        config(_config),
+        frame_slots(_config.max_resident_frames),
+        frame_reservations(_config.max_resident_frames, false),
+        reserved_frame_ids(_config.max_resident_frames, 0),
+        ready_flags(_config.max_resident_frames, false),
+        frame_order(_config.max_resident_frames, 0) {}
+
+    bool TryReserveScope(
+        const std::shared_ptr<FrameState>& _frame
+    ) noexcept;
+    bool ContainsFrame(
+        const std::shared_ptr<FrameState>& _frame
+    ) const noexcept;
+    void ReleaseScopeReservation() noexcept;
+    void MarkFrameReady(
+        const std::shared_ptr<FrameState>& _frame
+    ) noexcept;
+    void CancelFrameReservation(
+        std::size_t   _slot,
+        std::uint64_t _frame_id
+    ) noexcept;
+
+    GpuScopeStreamConfig config{};
+    mutable std::mutex   mutex{};
+    bool                 accepting{true};
+    bool                 pop_in_progress{false};
+    std::size_t          pop_slot{kInvalidStreamSlot};
+
+    Array<std::shared_ptr<FrameState>> frame_slots{};
+    Array<bool>                        frame_reservations{};
+    Array<std::uint64_t>               reserved_frame_ids{};
+    Array<bool>                        ready_flags{};
+    Array<std::size_t>                 frame_order{};
+    std::size_t                        order_head{0};
+    std::size_t                        order_tail{0};
+    std::size_t                        order_count{0};
+    std::size_t                        pending_count{0};
+    std::size_t                        ready_count{0};
+    std::size_t                        resident_scope_count{0};
+    StreamCounters                     counters{};
+};
+
+struct FrameState : std::enable_shared_from_this<FrameState> {
+    FrameState(
+        std::weak_ptr<StreamState> _stream,
+        std::uint64_t              _frame_id,
+        const GpuScopeStreamConfig& _config
+    ) :
+        stream(std::move(_stream)),
+        frame_id(_frame_id),
+        max_scopes(_config.max_scopes_per_frame),
+        max_sources(_config.max_sources_per_frame),
+        max_scope_depth(_config.max_scope_depth),
+        max_scope_name_bytes(_config.max_scope_name_bytes),
+        max_error_reason_bytes(_config.max_error_reason_bytes) {
+        scopes.reserve(max_scopes);
+        sources.reserve(max_sources);
+    }
+
+    GpuScopeCompletionTicket TryBeginScope(
+        const std::shared_ptr<RecorderState>& _recorder,
+        std::string_view                      _name,
+        std::uint64_t                         _parent_scope_id,
+        std::uint32_t                         _depth
+    ) noexcept;
+    void ResolveScope(
+        std::uint32_t       _slot,
+        std::uint64_t       _scope_id,
+        const QueryResult*  _result,
+        std::string_view    _forced_error
+    ) noexcept;
+    bool Seal() noexcept;
+    ResolvedGpuScopeFrame Materialize() const;
+    std::size_t AdmittedScopeCount() const noexcept;
+
+    [[nodiscard]] bool TryStartAdmission() noexcept {
+        std::scoped_lock lock(mutex);
+        if (sealed) {
+            return false;
+        }
+        ++in_flight_admission_count;
+        return true;
+    }
+
+    void FinishAdmission() noexcept;
+
+    void RecordDroppedScopeDuringAdmission() noexcept {
+        std::scoped_lock lock(mutex);
+        assert(in_flight_admission_count != 0);
+        ++dropped_scope_count;
+    }
+
+    std::weak_ptr<StreamState> stream{};
+    std::size_t                stream_slot{kInvalidStreamSlot};
+    const std::uint64_t        frame_id{0};
+    const std::size_t          max_scopes{0};
+    const std::size_t          max_sources{0};
+    const std::uint32_t        max_scope_depth{0};
+    const std::size_t          max_scope_name_bytes{0};
+    const std::size_t          max_error_reason_bytes{0};
+
+    mutable std::mutex mutex{};
+    Array<ScopeSlot>   scopes{};
+    Array<SourceKey>   sources{};
+    std::uint64_t      next_scope_id{1};
+    std::uint64_t      terminal_scope_count{0};
+    std::uint64_t      error_scope_count{0};
+    std::uint64_t      dropped_scope_count{0};
+    std::uint64_t      in_flight_admission_count{0};
+    bool               sealed{false};
+    bool               ready_notified{false};
+};
+
+struct RecorderState {
+    RecorderState(
+        std::shared_ptr<FrameState> _frame,
+        RHIQueueBinding             _queue_binding,
+        std::uint64_t               _source_order
+    ) :
+        frame(std::move(_frame)),
+        queue_binding(_queue_binding),
+        source_order(_source_order) {}
+
+    std::shared_ptr<FrameState> frame{};
+    RHIQueueBinding             queue_binding{};
+    std::uint64_t               source_order{0};
+    std::atomic<std::uint64_t>  next_local_order{0};
+};
+
+bool StreamState::TryReserveScope(
+    const std::shared_ptr<FrameState>& _frame
+) noexcept {
+    std::scoped_lock lock(mutex);
+    if (!accepting || !_frame ||
+        _frame->stream_slot >= frame_slots.size() ||
+        frame_slots[_frame->stream_slot].get() != _frame.get() ||
+        resident_scope_count >= config.max_resident_scopes) {
+        counters.scopes_dropped_resident_full.fetch_add(
+            1, std::memory_order_relaxed
+        );
+        return false;
+    }
+    ++resident_scope_count;
+    UpdateHighWater(
+        counters.high_water_scopes,
+        static_cast<std::uint64_t>(resident_scope_count)
+    );
+    return true;
+}
+
+bool StreamState::ContainsFrame(
+    const std::shared_ptr<FrameState>& _frame
+) const noexcept {
+    std::scoped_lock lock(mutex);
+    return accepting && _frame &&
+           _frame->stream_slot < frame_slots.size() &&
+           frame_slots[_frame->stream_slot].get() == _frame.get();
+}
+
+void StreamState::ReleaseScopeReservation() noexcept {
+    std::scoped_lock lock(mutex);
+    if (resident_scope_count != 0) {
+        --resident_scope_count;
+    }
+}
+
+void StreamState::MarkFrameReady(
+    const std::shared_ptr<FrameState>& _frame
+) noexcept {
+    std::scoped_lock lock(mutex);
+    if (!accepting || !_frame ||
+        _frame->stream_slot >= frame_slots.size() ||
+        frame_slots[_frame->stream_slot].get() != _frame.get() ||
+        ready_flags[_frame->stream_slot]) {
+        return;
+    }
+
+    ready_flags[_frame->stream_slot] = true;
+    if (pending_count != 0) {
+        --pending_count;
+    }
+    ++ready_count;
+    counters.frames_ready.fetch_add(1, std::memory_order_relaxed);
+    UpdateHighWater(
+        counters.high_water_ready_frames,
+        static_cast<std::uint64_t>(ready_count)
+    );
+}
+
+void StreamState::CancelFrameReservation(
+    std::size_t   _slot,
+    std::uint64_t _frame_id
+) noexcept {
+    std::scoped_lock lock(mutex);
+    if (_slot >= frame_reservations.size() ||
+        !frame_reservations[_slot] ||
+        reserved_frame_ids[_slot] != _frame_id) {
+        return;
+    }
+
+    std::size_t order_offset = order_count;
+    for (std::size_t offset = 0; offset < order_count; ++offset) {
+        const std::size_t order_index =
+            (order_head + offset) % frame_order.size();
+        if (frame_order[order_index] == _slot) {
+            order_offset = offset;
+            break;
+        }
+    }
+    if (order_offset == order_count) {
+        return;
+    }
+
+    for (std::size_t offset = order_offset;
+         offset + 1 < order_count;
+         ++offset) {
+        const std::size_t destination =
+            (order_head + offset) % frame_order.size();
+        const std::size_t source =
+            (order_head + offset + 1) % frame_order.size();
+        frame_order[destination] = frame_order[source];
+    }
+
+    frame_reservations[_slot] = false;
+    reserved_frame_ids[_slot] = 0;
+    ready_flags[_slot] = false;
+    --order_count;
+    order_tail = (order_head + order_count) % frame_order.size();
+    if (pending_count != 0) {
+        --pending_count;
+    }
+}
+
+GpuScopeCompletionTicket FrameState::TryBeginScope(
+    const std::shared_ptr<RecorderState>& _recorder,
+    std::string_view                      _name,
+    std::uint64_t                         _parent_scope_id,
+    std::uint32_t                         _depth
+) noexcept {
+    const std::shared_ptr<StreamState> owner = stream.lock();
+    if (!owner || !_recorder || _recorder->frame.get() != this) {
+        return {};
+    }
+
+    owner->counters.scopes_attempted.fetch_add(
+        1, std::memory_order_relaxed
+    );
+    if (!TryStartAdmission()) {
+        owner->counters.scopes_dropped_after_seal.fetch_add(
+            1, std::memory_order_relaxed
+        );
+        return {};
+    }
+    struct AdmissionGuard {
+        FrameState* frame{nullptr};
+        ~AdmissionGuard() {
+            frame->FinishAdmission();
+        }
+    } admission_guard{this};
+
+    if (_name.size() > max_scope_name_bytes) {
+        owner->counters.scopes_dropped_name_too_large.fetch_add(
+            1, std::memory_order_relaxed
+        );
+        RecordDroppedScopeDuringAdmission();
+        return {};
+    }
+    if (_depth > max_scope_depth) {
+        owner->counters.scopes_dropped_invalid_hierarchy.fetch_add(
+            1, std::memory_order_relaxed
+        );
+        RecordDroppedScopeDuringAdmission();
+        return {};
+    }
+    if (!owner->TryReserveScope(shared_from_this())) {
+        RecordDroppedScopeDuringAdmission();
+        return {};
+    }
+
+#if defined(MOER_RHI_GPU_SCOPE_TEST_HOOKS)
+    PauseScopeAdmissionForTesting();
+#endif
+
+    ScopeSlot candidate{};
+    try {
+        candidate.name.assign(_name);
+    } catch (...) {
+        owner->ReleaseScopeReservation();
+        owner->counters.scopes_dropped_resource_exhaustion.fetch_add(
+            1, std::memory_order_relaxed
+        );
+        RecordDroppedScopeDuringAdmission();
+        return {};
+    }
+
+    bool             release_reservation = false;
+    std::uint32_t    slot_index = 0;
+    std::uint64_t    scope_id = 0;
+    {
+        std::scoped_lock lock(mutex);
+        // TryStartAdmission linearizes before Seal. Once admitted here, Seal
+        // may already have set sealed=true, but readiness must wait for this
+        // in-flight producer and the scope remains part of the frozen frame.
+        if (scopes.size() >= max_scopes) {
+            ++dropped_scope_count;
+            release_reservation = true;
+            owner->counters.scopes_dropped_frame_full.fetch_add(
+                1, std::memory_order_relaxed
+            );
+        } else {
+            const ScopeSlot* parent = nullptr;
+            if (_parent_scope_id != 0) {
+                const auto parent_it = std::find_if(
+                    scopes.begin(),
+                    scopes.end(),
+                    [_parent_scope_id](const ScopeSlot& _slot) {
+                        return _slot.scope_id == _parent_scope_id;
+                    }
+                );
+                if (parent_it != scopes.end()) {
+                    parent = &*parent_it;
+                }
+            }
+
+            const bool root_shape =
+                _parent_scope_id == 0 && _depth == 0;
+            const bool child_shape =
+                parent != nullptr &&
+                parent->queue_binding == _recorder->queue_binding &&
+                parent->source_order == _recorder->source_order &&
+                _depth == parent->depth + 1;
+            if (!root_shape && !child_shape) {
+                ++dropped_scope_count;
+                release_reservation = true;
+                owner->counters.scopes_dropped_invalid_hierarchy.fetch_add(
+                    1, std::memory_order_relaxed
+                );
+            } else {
+                scope_id = next_scope_id++;
+                if (scope_id == 0) {
+                    scope_id = next_scope_id++;
+                }
+                candidate.scope_id = scope_id;
+                candidate.parent_scope_id = _parent_scope_id;
+                candidate.source_order = _recorder->source_order;
+                candidate.local_order =
+                    _recorder->next_local_order.fetch_add(
+                        1, std::memory_order_relaxed
+                    );
+                candidate.depth = _depth;
+                candidate.queue_binding = _recorder->queue_binding;
+                slot_index = static_cast<std::uint32_t>(scopes.size());
+                try {
+                    scopes.emplace_back(std::move(candidate));
+                } catch (...) {
+                    ++dropped_scope_count;
+                    release_reservation = true;
+                    scope_id = 0;
+                    owner->counters.
+                        scopes_dropped_resource_exhaustion.fetch_add(
+                            1, std::memory_order_relaxed
+                        );
+                }
+            }
+        }
+    }
+
+    if (release_reservation) {
+        owner->ReleaseScopeReservation();
+        return {};
+    }
+    owner->counters.scopes_admitted.fetch_add(
+        1, std::memory_order_relaxed
+    );
+    return GpuScopeCompletionTicket(
+        shared_from_this(), slot_index, scope_id
+    );
+}
+
+void FrameState::FinishAdmission() noexcept {
+    bool ready_frame = false;
+    {
+        std::scoped_lock lock(mutex);
+        assert(in_flight_admission_count != 0);
+        if (in_flight_admission_count != 0) {
+            --in_flight_admission_count;
+        }
+        if (sealed && in_flight_admission_count == 0 &&
+            terminal_scope_count == scopes.size() &&
+            !ready_notified) {
+            ready_notified = true;
+            ready_frame = true;
+        }
+    }
+
+    if (ready_frame) {
+        if (const std::shared_ptr<StreamState> owner = stream.lock()) {
+            owner->MarkFrameReady(shared_from_this());
+        }
+    }
+}
+
+void FrameState::ResolveScope(
+    std::uint32_t      _slot,
+    std::uint64_t      _scope_id,
+    const QueryResult* _result,
+    std::string_view   _forced_error
+) noexcept {
+    bool ready_frame = false;
+    bool ready_scope = false;
+    {
+        std::scoped_lock lock(mutex);
+        if (_slot >= scopes.size()) {
+            return;
+        }
+        ScopeSlot& slot = scopes[_slot];
+        if (slot.scope_id != _scope_id || slot.terminal) {
+            return;
+        }
+
+        slot.terminal = true;
+        ++terminal_scope_count;
+        if (_result != nullptr) {
+            slot.query_id = _result->query_id;
+        }
+
+        const auto set_error = [&](std::string_view _reason) {
+            slot.status = GpuScopeTerminalStatus::Error;
+            AssignBoundedNoexcept(
+                slot.error_reason,
+                _reason,
+                max_error_reason_bytes
+            );
+            ++error_scope_count;
+        };
+
+        if (!_forced_error.empty()) {
+            set_error(_forced_error);
+        } else if (_result == nullptr ||
+                   _result->status != QueryStatus::Ready ||
+                   _result->kind != QueryKind::Timestamp) {
+            const std::string_view reason =
+                _result != nullptr && !_result->error_reason.empty() ?
+                    std::string_view(_result->error_reason) :
+                    std::string_view("GPU scope query did not resolve Ready");
+            set_error(reason);
+        } else {
+            const auto* timestamp =
+                std::get_if<TimestampQueryResult>(&_result->payload);
+            bool payload_valid =
+                timestamp != nullptr &&
+                timestamp->valid_bits != 0 &&
+                timestamp->valid_bits <= 64 &&
+                std::isfinite(timestamp->tick_period_ns) &&
+                timestamp->tick_period_ns > 0.0 &&
+                std::isfinite(timestamp->duration_ns) &&
+                timestamp->duration_ns >= 0.0;
+            if (payload_valid) {
+                const std::uint64_t delta_tick = TimestampDelta(
+                    timestamp->begin_tick,
+                    timestamp->end_tick,
+                    timestamp->valid_bits
+                );
+                const double expected_duration_ns =
+                    static_cast<double>(delta_tick) *
+                    timestamp->tick_period_ns;
+                payload_valid = NearlyEqualDuration(
+                    timestamp->duration_ns,
+                    expected_duration_ns
+                );
+            }
+            if (!payload_valid) {
+                set_error("GPU scope timestamp payload is invalid");
+            } else {
+                slot.status = GpuScopeTerminalStatus::Ready;
+                slot.query_id = _result->query_id;
+                slot.begin_tick = timestamp->begin_tick;
+                slot.end_tick = timestamp->end_tick;
+                slot.valid_bits = timestamp->valid_bits;
+                slot.tick_period_ns = timestamp->tick_period_ns;
+                slot.duration_ns = timestamp->duration_ns;
+                slot.error_reason.clear();
+                ready_scope = true;
+            }
+        }
+
+        if (sealed && in_flight_admission_count == 0 &&
+            terminal_scope_count == scopes.size() && !ready_notified) {
+            ready_notified = true;
+            ready_frame = true;
+        }
+    }
+
+    if (const std::shared_ptr<StreamState> owner = stream.lock()) {
+        if (ready_scope) {
+            owner->counters.scopes_ready.fetch_add(
+                1, std::memory_order_relaxed
+            );
+        } else {
+            owner->counters.scopes_error.fetch_add(
+                1, std::memory_order_relaxed
+            );
+        }
+        if (ready_frame) {
+            owner->MarkFrameReady(shared_from_this());
+        }
+    }
+}
+
+bool FrameState::Seal() noexcept {
+    bool ready_frame = false;
+    {
+        std::scoped_lock lock(mutex);
+        if (sealed) {
+            return false;
+        }
+        sealed = true;
+        if (in_flight_admission_count == 0 &&
+            terminal_scope_count == scopes.size() && !ready_notified) {
+            ready_notified = true;
+            ready_frame = true;
+        }
+    }
+
+    if (const std::shared_ptr<StreamState> owner = stream.lock()) {
+        owner->counters.frames_sealed.fetch_add(
+            1, std::memory_order_relaxed
+        );
+        if (ready_frame) {
+            owner->MarkFrameReady(shared_from_this());
+        }
+    }
+    return true;
+}
+
+std::size_t FrameState::AdmittedScopeCount() const noexcept {
+    std::scoped_lock lock(mutex);
+    return scopes.size();
+}
+
+ResolvedGpuScopeFrame FrameState::Materialize() const {
+    Array<ScopeSlot> slots{};
+    std::uint64_t dropped = 0;
+    std::uint64_t errors = 0;
+    {
+        std::scoped_lock lock(mutex);
+        slots = scopes;
+        dropped = dropped_scope_count;
+        errors = error_scope_count;
+    }
+
+    ResolvedGpuScopeFrame result{};
+    result.frame_id = frame_id;
+    result.admitted_scope_count =
+        static_cast<std::uint64_t>(slots.size());
+    result.dropped_scope_count = dropped;
+    result.error_scope_count = errors;
+
+    Array<std::size_t> order(slots.size());
+    std::iota(order.begin(), order.end(), std::size_t{0});
+    std::stable_sort(
+        order.begin(),
+        order.end(),
+        [&](std::size_t _lhs, std::size_t _rhs) {
+            const ScopeSlot& lhs = slots[_lhs];
+            const ScopeSlot& rhs = slots[_rhs];
+            return std::tie(
+                       lhs.queue_binding.queue,
+                       lhs.queue_binding.native_queue_id,
+                       lhs.queue_binding.family_id,
+                       lhs.source_order,
+                       lhs.local_order,
+                       lhs.scope_id
+                   ) <
+                   std::tie(
+                       rhs.queue_binding.queue,
+                       rhs.queue_binding.native_queue_id,
+                       rhs.queue_binding.family_id,
+                       rhs.source_order,
+                       rhs.local_order,
+                       rhs.scope_id
+                   );
+        }
+    );
+
+    struct BuildNode {
+        GpuScopeNode      node{};
+        Array<std::size_t> children{};
+    };
+
+    Array<BuildNode> arena{};
+    arena.reserve(slots.size());
+    UnorderedMap<std::uint64_t, std::size_t> scope_to_arena{};
+    scope_to_arena.reserve(slots.size());
+    std::array<Array<std::size_t>, 3> root_indices{};
+    bool structure_valid = true;
+
+    for (std::size_t source_index : order) {
+        const ScopeSlot& slot = slots[source_index];
+        if (!slot.terminal || !IsManagedQueue(slot.queue_binding.queue)) {
+            structure_valid = false;
+            continue;
+        }
+
+        BuildNode build{};
+        build.node.scope_id = slot.scope_id;
+        build.node.parent_scope_id = slot.parent_scope_id;
+        build.node.source_order = slot.source_order;
+        build.node.local_order = slot.local_order;
+        build.node.depth = slot.depth;
+        build.node.queue_binding = slot.queue_binding;
+        build.node.name = slot.name;
+        build.node.status = slot.status;
+        build.node.query_id = slot.query_id;
+        build.node.begin_tick = slot.begin_tick;
+        build.node.end_tick = slot.end_tick;
+        build.node.valid_bits = slot.valid_bits;
+        build.node.tick_period_ns = slot.tick_period_ns;
+        build.node.total_duration_ns = slot.duration_ns;
+        build.node.error_reason = slot.error_reason;
+
+        const std::size_t arena_index = arena.size();
+        arena.emplace_back(std::move(build));
+        const bool inserted =
+            scope_to_arena.emplace(slot.scope_id, arena_index).second;
+        if (!inserted) {
+            structure_valid = false;
+            continue;
+        }
+
+        if (slot.parent_scope_id == 0) {
+            if (slot.depth != 0) {
+                structure_valid = false;
+                continue;
+            }
+            root_indices[QueueIndex(slot.queue_binding.queue)].
+                emplace_back(arena_index);
+            continue;
+        }
+
+        const auto parent_it =
+            scope_to_arena.find(slot.parent_scope_id);
+        if (parent_it == scope_to_arena.end()) {
+            structure_valid = false;
+            continue;
+        }
+        BuildNode& parent = arena[parent_it->second];
+        if (slot.depth != parent.node.depth + 1 ||
+            slot.source_order != parent.node.source_order ||
+            slot.queue_binding != parent.node.queue_binding) {
+            structure_valid = false;
+            continue;
+        }
+        parent.children.emplace_back(arena_index);
+    }
+
+    // A Ready query payload is not sufficient on its own: direct children
+    // recorded by one source must lie inside the parent interval and siblings
+    // must not overlap. Fail the whole frame closed if backend data violates
+    // that topology instead of silently clamping an impossible exclusive
+    // duration to zero.
+    for (const BuildNode& parent : arena) {
+        if (parent.node.status != GpuScopeTerminalStatus::Ready) {
+            continue;
+        }
+        if (parent.node.valid_bits == 0 ||
+            parent.node.valid_bits > 64) {
+            structure_valid = false;
+            continue;
+        }
+
+        const std::uint64_t parent_delta = TimestampDelta(
+            parent.node.begin_tick,
+            parent.node.end_tick,
+            parent.node.valid_bits
+        );
+        std::uint64_t previous_child_end = 0;
+        bool          has_previous_child = false;
+        for (std::size_t child_index : parent.children) {
+            const GpuScopeNode& child = arena[child_index].node;
+            if (child.status != GpuScopeTerminalStatus::Ready ||
+                !SameTimestampDomain(
+                    parent.node.queue_binding,
+                    child.queue_binding
+                ) ||
+                child.valid_bits != parent.node.valid_bits ||
+                !NearlyEqualDuration(
+                    child.tick_period_ns,
+                    parent.node.tick_period_ns
+                )) {
+                structure_valid = false;
+                continue;
+            }
+
+            const std::uint64_t child_begin_offset =
+                (child.begin_tick - parent.node.begin_tick) &
+                TimestampMask(parent.node.valid_bits);
+            const std::uint64_t child_delta = TimestampDelta(
+                child.begin_tick,
+                child.end_tick,
+                child.valid_bits
+            );
+            const bool contained =
+                child_begin_offset <= parent_delta &&
+                child_delta <= parent_delta - child_begin_offset;
+            const bool ordered =
+                !has_previous_child ||
+                child_begin_offset >= previous_child_end;
+            if (!contained || !ordered) {
+                structure_valid = false;
+                continue;
+            }
+            previous_child_end = child_begin_offset + child_delta;
+            has_previous_child = true;
+        }
+    }
+
+    // Root scopes from different recording sources may overlap, but roots
+    // emitted by one source are a serial command stream just like siblings
+    // under a parent. Validate each contiguous (queue binding, source order)
+    // group in local-order order. The half-range rule disambiguates forward
+    // timestamp wrap from an impossible backward/overlapping interval.
+    for (const Array<std::size_t>& roots : root_indices) {
+        const GpuScopeNode* previous_root = nullptr;
+        for (std::size_t root_index : roots) {
+            const GpuScopeNode& root = arena[root_index].node;
+            const bool same_source =
+                previous_root != nullptr &&
+                root.queue_binding == previous_root->queue_binding &&
+                root.source_order == previous_root->source_order;
+            if (!same_source) {
+                previous_root = &root;
+                continue;
+            }
+
+            if (root.status != GpuScopeTerminalStatus::Ready ||
+                previous_root->status !=
+                    GpuScopeTerminalStatus::Ready ||
+                root.valid_bits == 0 ||
+                root.valid_bits != previous_root->valid_bits ||
+                !NearlyEqualDuration(
+                    root.tick_period_ns,
+                    previous_root->tick_period_ns
+                )) {
+                structure_valid = false;
+                previous_root = &root;
+                continue;
+            }
+
+            const std::uint64_t begin_distance =
+                (root.begin_tick - previous_root->begin_tick) &
+                TimestampMask(root.valid_bits);
+            const std::uint64_t previous_duration = TimestampDelta(
+                previous_root->begin_tick,
+                previous_root->end_tick,
+                previous_root->valid_bits
+            );
+            const std::uint64_t half_range =
+                root.valid_bits == 64 ?
+                    (std::uint64_t{1} << 63) :
+                    (std::uint64_t{1} <<
+                     (root.valid_bits - 1));
+            if (begin_distance < previous_duration ||
+                begin_distance >= half_range) {
+                structure_valid = false;
+            }
+            previous_root = &root;
+        }
+    }
+
+    const bool exclusive_trustworthy =
+        structure_valid && dropped == 0 && errors == 0;
+    const auto materialize =
+        [&](const auto& self, std::size_t _node_index) -> GpuScopeNode {
+        GpuScopeNode node = arena[_node_index].node;
+        node.children.reserve(arena[_node_index].children.size());
+        double child_duration = 0.0;
+        for (std::size_t child_index :
+             arena[_node_index].children) {
+            GpuScopeNode child = self(self, child_index);
+            if (exclusive_trustworthy &&
+                child.status == GpuScopeTerminalStatus::Ready &&
+                SameTimestampDomain(
+                    node.queue_binding, child.queue_binding
+                )) {
+                child_duration += child.total_duration_ns;
+            }
+            node.children.emplace_back(std::move(child));
+        }
+        node.exclusive_duration_ns =
+            exclusive_trustworthy &&
+                    node.status == GpuScopeTerminalStatus::Ready ?
+                std::max(0.0, node.total_duration_ns - child_duration) :
+                0.0;
+        return node;
+    };
+
+    for (std::size_t queue_index = 0;
+         queue_index < root_indices.size();
+         ++queue_index) {
+        Array<GpuScopeNode>& roots = result.queue_roots[queue_index];
+        roots.reserve(root_indices[queue_index].size());
+        for (std::size_t root_index : root_indices[queue_index]) {
+            roots.emplace_back(materialize(materialize, root_index));
+        }
+    }
+
+    result.valid =
+        structure_valid && dropped == 0 && errors == 0;
+    return result;
+}
+
+} // namespace GpuScopeDetail
+
+GpuScopeCompletionTicket::GpuScopeCompletionTicket(
+    std::shared_ptr<GpuScopeDetail::FrameState> _frame,
+    std::uint32_t                               _slot,
+    std::uint64_t                               _scope_id
+) noexcept :
+    frame_(std::move(_frame)),
+    slot_(_slot),
+    scope_id_(_scope_id) {}
+
+bool GpuScopeCompletionTicket::Valid() const noexcept {
+    return frame_ != nullptr && scope_id_ != 0;
+}
+
+std::uint64_t GpuScopeCompletionTicket::ScopeId() const noexcept {
+    return scope_id_;
+}
+
+void GpuScopeCompletionTicket::Resolve(
+    const QueryResult& _result
+) const noexcept {
+    if (frame_) {
+        frame_->ResolveScope(slot_, scope_id_, &_result, {});
+    }
+}
+
+void GpuScopeCompletionTicket::Fail(
+    std::string_view _reason
+) const noexcept {
+    if (frame_) {
+        frame_->ResolveScope(
+            slot_,
+            scope_id_,
+            nullptr,
+            _reason.empty() ?
+                std::string_view("GPU scope recording failed") :
+                _reason
+        );
+    }
+}
+
+GpuScopeRecorder::GpuScopeRecorder(
+    std::shared_ptr<GpuScopeDetail::RecorderState> _state
+) noexcept :
+    state_(std::move(_state)) {}
+
+bool GpuScopeRecorder::Valid() const noexcept {
+    if (state_ == nullptr || state_->frame == nullptr) {
+        return false;
+    }
+    const std::shared_ptr<GpuScopeDetail::StreamState> owner =
+        state_->frame->stream.lock();
+    return owner && owner->ContainsFrame(state_->frame);
+}
+
+std::uint64_t GpuScopeRecorder::FrameId() const noexcept {
+    return Valid() ? state_->frame->frame_id : 0;
+}
+
+std::uint64_t GpuScopeRecorder::SourceOrder() const noexcept {
+    return Valid() ? state_->source_order : 0;
+}
+
+RHIQueueBinding GpuScopeRecorder::QueueBinding() const noexcept {
+    return Valid() ?
+        state_->queue_binding :
+        RHIQueueBinding{
+            .queue = EQueueType::Ignore,
+            .native_queue_id = 0,
+            .family_id = 0,
+            .available = false,
+        };
+}
+
+bool GpuScopeRecorder::IsBound() const noexcept {
+    return state_ != nullptr;
+}
+
+RHIQueueBinding GpuScopeRecorder::BoundQueueBinding() const noexcept {
+    return state_ ?
+        state_->queue_binding :
+        RHIQueueBinding{
+            .queue = EQueueType::Ignore,
+            .native_queue_id = 0,
+            .family_id = 0,
+            .available = false,
+        };
+}
+
+GpuScopeCompletionTicket GpuScopeRecorder::TryBeginScope(
+    std::string_view _name,
+    std::uint64_t    _parent_scope_id,
+    std::uint32_t    _depth
+) const noexcept {
+    if (!Valid()) {
+        return {};
+    }
+    return state_->frame->TryBeginScope(
+        state_, _name, _parent_scope_id, _depth
+    );
+}
+
+void GpuScopeRecorder::RecordSuppressedScope() const noexcept {
+    if (!Valid()) {
+        return;
+    }
+    if (const std::shared_ptr<GpuScopeDetail::StreamState> owner =
+            state_->frame->stream.lock()) {
+        owner->counters.scopes_attempted.fetch_add(
+            1, std::memory_order_relaxed
+        );
+        if (!state_->frame->TryStartAdmission()) {
+            owner->counters.scopes_dropped_after_seal.fetch_add(
+                1, std::memory_order_relaxed
+            );
+            return;
+        }
+        struct AdmissionGuard {
+            GpuScopeDetail::FrameState* frame{nullptr};
+            ~AdmissionGuard() {
+                frame->FinishAdmission();
+            }
+        } admission_guard{state_->frame.get()};
+        owner->counters.scopes_dropped_suppressed_subtree.fetch_add(
+            1, std::memory_order_relaxed
+        );
+        state_->frame->RecordDroppedScopeDuringAdmission();
+    }
+}
+
+GpuScopeFrameHandle::GpuScopeFrameHandle(
+    std::shared_ptr<GpuScopeDetail::FrameState> _state
+) noexcept :
+    state_(std::move(_state)) {}
+
+bool GpuScopeFrameHandle::Valid() const noexcept {
+    if (!state_) {
+        return false;
+    }
+    const std::shared_ptr<GpuScopeDetail::StreamState> owner =
+        state_->stream.lock();
+    return owner && owner->ContainsFrame(state_);
+}
+
+std::uint64_t GpuScopeFrameHandle::FrameId() const noexcept {
+    return state_ ? state_->frame_id : 0;
+}
+
+GpuScopeRecorder GpuScopeFrameHandle::CreateRecorder(
+    RHIQueueBinding _queue_binding,
+    std::uint64_t   _source_order
+) const noexcept {
+    if (!state_ ||
+        !GpuScopeDetail::IsManagedQueue(_queue_binding.queue) ||
+        !_queue_binding.available) {
+        return {};
+    }
+    const std::shared_ptr<GpuScopeDetail::StreamState> owner =
+        state_->stream.lock();
+    if (!owner) {
+        return {};
+    }
+    if (!owner->ContainsFrame(state_)) {
+        return {};
+    }
+
+    std::shared_ptr<GpuScopeDetail::RecorderState> recorder{};
+    try {
+        recorder = std::make_shared<GpuScopeDetail::RecorderState>(
+            state_, _queue_binding, _source_order
+        );
+    } catch (...) {
+        owner->counters.sources_dropped_capacity.fetch_add(
+            1, std::memory_order_relaxed
+        );
+        return {};
+    }
+
+    {
+        std::scoped_lock lock(state_->mutex);
+        if (state_->sealed) {
+            owner->counters.sources_dropped_after_seal.fetch_add(
+                1, std::memory_order_relaxed
+            );
+            return {};
+        }
+        if (state_->sources.size() >= state_->max_sources) {
+            owner->counters.sources_dropped_capacity.fetch_add(
+                1, std::memory_order_relaxed
+            );
+            return {};
+        }
+        const bool duplicate = std::any_of(
+            state_->sources.begin(),
+            state_->sources.end(),
+            [&](const GpuScopeDetail::SourceKey& _source) {
+                return _source.queue_binding == _queue_binding &&
+                       _source.source_order == _source_order;
+            }
+        );
+        if (duplicate) {
+            owner->counters.sources_dropped_duplicate_order.fetch_add(
+                1, std::memory_order_relaxed
+            );
+            return {};
+        }
+        try {
+            state_->sources.emplace_back(
+                GpuScopeDetail::SourceKey{
+                    .queue_binding = _queue_binding,
+                    .source_order = _source_order,
+                }
+            );
+        } catch (...) {
+            owner->counters.sources_dropped_capacity.fetch_add(
+                1, std::memory_order_relaxed
+            );
+            return {};
+        }
+    }
+
+    owner->counters.sources_opened.fetch_add(
+        1, std::memory_order_relaxed
+    );
+    return GpuScopeRecorder(std::move(recorder));
+}
+
+GpuScopeStream::GpuScopeStream(
+    const GpuScopeStreamConfig& _config
+) {
+    if (_config.max_resident_frames == 0 ||
+        _config.max_pending_frames == 0 ||
+        _config.max_pending_frames > _config.max_resident_frames ||
+        _config.max_resident_scopes == 0 ||
+        _config.max_scopes_per_frame == 0 ||
+        _config.max_scopes_per_frame >
+            _config.max_resident_scopes ||
+        _config.max_sources_per_frame == 0 ||
+        _config.max_scope_depth == 0 ||
+        _config.max_scope_name_bytes == 0 ||
+        _config.max_error_reason_bytes == 0) {
+        throw std::invalid_argument(
+            "GpuScopeStreamConfig contains an invalid zero or capacity relationship"
+        );
+    }
+    state_ =
+        std::make_shared<GpuScopeDetail::StreamState>(_config);
+}
+
+GpuScopeStream::~GpuScopeStream() {
+    Close();
+}
+
+GpuScopeStream::GpuScopeStream(
+    GpuScopeStream&& _other
+) noexcept :
+    state_(std::move(_other.state_)) {}
+
+GpuScopeStream& GpuScopeStream::operator=(
+    GpuScopeStream&& _other
+) noexcept {
+    if (this != &_other) {
+        Close();
+        state_ = std::move(_other.state_);
+    }
+    return *this;
+}
+
+bool GpuScopeStream::Valid() const noexcept {
+    return state_ != nullptr;
+}
+
+GpuScopeFrameHandle GpuScopeStream::BeginFrame(
+    std::uint64_t _frame_id
+) noexcept {
+    const std::shared_ptr<GpuScopeDetail::StreamState> owner = state_;
+    if (!owner) {
+        return {};
+    }
+
+    std::size_t reserved_slot = GpuScopeDetail::kInvalidStreamSlot;
+    {
+        std::scoped_lock lock(owner->mutex);
+        if (!owner->accepting) {
+            return {};
+        }
+        if (owner->order_count >= owner->config.max_resident_frames) {
+            owner->counters.frames_dropped_resident_full.fetch_add(
+                1, std::memory_order_relaxed
+            );
+            return {};
+        }
+        if (owner->pending_count >= owner->config.max_pending_frames) {
+            owner->counters.frames_dropped_pending_full.fetch_add(
+                1, std::memory_order_relaxed
+            );
+            return {};
+        }
+        bool duplicate = false;
+        for (std::size_t slot = 0;
+             slot < owner->frame_slots.size();
+             ++slot) {
+            if ((owner->frame_slots[slot] &&
+                 owner->frame_slots[slot]->frame_id == _frame_id) ||
+                (owner->frame_reservations[slot] &&
+                 owner->reserved_frame_ids[slot] == _frame_id)) {
+                duplicate = true;
+                break;
+            }
+        }
+        if (duplicate) {
+            owner->counters.frames_dropped_duplicate_id.fetch_add(
+                1, std::memory_order_relaxed
+            );
+            return {};
+        }
+
+        for (std::size_t slot = 0;
+             slot < owner->frame_slots.size();
+             ++slot) {
+            if (!owner->frame_slots[slot] &&
+                !owner->frame_reservations[slot]) {
+                reserved_slot = slot;
+                break;
+            }
+        }
+        if (reserved_slot == GpuScopeDetail::kInvalidStreamSlot) {
+            owner->counters.frames_dropped_resident_full.fetch_add(
+                1, std::memory_order_relaxed
+            );
+            return {};
+        }
+
+        // Reserve the fixed slot and FIFO position before allocating the
+        // frame's configured scope/source payload. The permit bounds all
+        // concurrent heavy allocations without holding the stream mutex, so
+        // Completion can still terminalize unrelated resident frames.
+        owner->frame_reservations[reserved_slot] = true;
+        owner->reserved_frame_ids[reserved_slot] = _frame_id;
+        owner->ready_flags[reserved_slot] = false;
+        owner->frame_order[owner->order_tail] = reserved_slot;
+        owner->order_tail =
+            (owner->order_tail + 1) %
+            owner->frame_order.size();
+        ++owner->order_count;
+        ++owner->pending_count;
+        GpuScopeDetail::UpdateHighWater(
+            owner->counters.high_water_frames,
+            static_cast<std::uint64_t>(owner->order_count)
+        );
+        GpuScopeDetail::UpdateHighWater(
+            owner->counters.high_water_pending_frames,
+            static_cast<std::uint64_t>(owner->pending_count)
+        );
+    }
+
+    std::shared_ptr<GpuScopeDetail::FrameState> frame{};
+    try {
+        frame = std::make_shared<GpuScopeDetail::FrameState>(
+            owner, _frame_id, owner->config
+        );
+    } catch (...) {
+        owner->counters.frames_dropped_resource_exhaustion.fetch_add(
+            1, std::memory_order_relaxed
+        );
+        owner->CancelFrameReservation(reserved_slot, _frame_id);
+        return {};
+    }
+
+    {
+        std::scoped_lock lock(owner->mutex);
+        if (!owner->accepting ||
+            reserved_slot >= owner->frame_slots.size() ||
+            !owner->frame_reservations[reserved_slot] ||
+            owner->reserved_frame_ids[reserved_slot] != _frame_id ||
+            owner->frame_slots[reserved_slot]) {
+            return {};
+        }
+        frame->stream_slot = reserved_slot;
+        owner->frame_slots[reserved_slot] = frame;
+        owner->frame_reservations[reserved_slot] = false;
+        owner->reserved_frame_ids[reserved_slot] = 0;
+        owner->counters.frames_opened.fetch_add(
+            1, std::memory_order_relaxed
+        );
+    }
+    return GpuScopeFrameHandle(std::move(frame));
+}
+
+bool GpuScopeStream::SealFrame(
+    const GpuScopeFrameHandle& _frame
+) noexcept {
+    if (!state_ || !_frame.state_) {
+        return false;
+    }
+    const std::shared_ptr<GpuScopeDetail::StreamState> frame_owner =
+        _frame.state_->stream.lock();
+    if (frame_owner.get() != state_.get()) {
+        return false;
+    }
+    if (!state_->ContainsFrame(_frame.state_)) {
+        return false;
+    }
+    return _frame.state_->Seal();
+}
+
+bool GpuScopeStream::TryPopFrame(
+    ResolvedGpuScopeFrame& _frame
+) {
+    const std::shared_ptr<GpuScopeDetail::StreamState> owner = state_;
+    if (!owner) {
+        return false;
+    }
+
+    std::shared_ptr<GpuScopeDetail::FrameState> frame{};
+    std::size_t slot = GpuScopeDetail::kInvalidStreamSlot;
+    {
+        std::scoped_lock lock(owner->mutex);
+        if (owner->pop_in_progress || owner->order_count == 0) {
+            return false;
+        }
+        slot = owner->frame_order[owner->order_head];
+        if (slot >= owner->frame_slots.size() ||
+            !owner->frame_slots[slot] ||
+            !owner->ready_flags[slot]) {
+            return false;
+        }
+        owner->pop_in_progress = true;
+        owner->pop_slot = slot;
+        frame = owner->frame_slots[slot];
+    }
+
+    ResolvedGpuScopeFrame resolved{};
+    try {
+        resolved = frame->Materialize();
+    } catch (...) {
+        std::scoped_lock lock(owner->mutex);
+        if (owner->pop_in_progress && owner->pop_slot == slot) {
+            owner->pop_in_progress = false;
+            owner->pop_slot = GpuScopeDetail::kInvalidStreamSlot;
+        }
+        throw;
+    }
+
+    const std::size_t released_scopes =
+        frame->AdmittedScopeCount();
+    {
+        std::scoped_lock lock(owner->mutex);
+        if (!owner->pop_in_progress ||
+            owner->pop_slot != slot ||
+            owner->order_count == 0 ||
+            owner->frame_order[owner->order_head] != slot ||
+            owner->frame_slots[slot].get() != frame.get() ||
+            !owner->ready_flags[slot]) {
+            owner->pop_in_progress = false;
+            owner->pop_slot = GpuScopeDetail::kInvalidStreamSlot;
+            return false;
+        }
+
+        owner->frame_slots[slot].reset();
+        owner->ready_flags[slot] = false;
+        owner->order_head =
+            (owner->order_head + 1) %
+            owner->frame_order.size();
+        --owner->order_count;
+        if (owner->ready_count != 0) {
+            --owner->ready_count;
+        }
+        owner->resident_scope_count =
+            released_scopes <= owner->resident_scope_count ?
+                owner->resident_scope_count - released_scopes :
+                0;
+        owner->pop_in_progress = false;
+        owner->pop_slot = GpuScopeDetail::kInvalidStreamSlot;
+        owner->counters.frames_popped.fetch_add(
+            1, std::memory_order_relaxed
+        );
+    }
+
+    _frame = std::move(resolved);
+    return true;
+}
+
+GpuScopeStreamStats GpuScopeStream::GetStats() const noexcept {
+    GpuScopeStreamStats stats{};
+    const std::shared_ptr<GpuScopeDetail::StreamState> owner = state_;
+    if (!owner) {
+        return stats;
+    }
+
+#define MOER_LOAD_GPU_SCOPE_COUNTER(name) \
+    stats.name = owner->counters.name.load(std::memory_order_relaxed)
+    MOER_LOAD_GPU_SCOPE_COUNTER(frames_opened);
+    MOER_LOAD_GPU_SCOPE_COUNTER(frames_sealed);
+    MOER_LOAD_GPU_SCOPE_COUNTER(frames_ready);
+    MOER_LOAD_GPU_SCOPE_COUNTER(frames_popped);
+    MOER_LOAD_GPU_SCOPE_COUNTER(frames_dropped_resident_full);
+    MOER_LOAD_GPU_SCOPE_COUNTER(frames_dropped_pending_full);
+    MOER_LOAD_GPU_SCOPE_COUNTER(frames_dropped_duplicate_id);
+    MOER_LOAD_GPU_SCOPE_COUNTER(frames_dropped_resource_exhaustion);
+    MOER_LOAD_GPU_SCOPE_COUNTER(frames_abandoned_on_close);
+    MOER_LOAD_GPU_SCOPE_COUNTER(sources_opened);
+    MOER_LOAD_GPU_SCOPE_COUNTER(sources_dropped_capacity);
+    MOER_LOAD_GPU_SCOPE_COUNTER(sources_dropped_duplicate_order);
+    MOER_LOAD_GPU_SCOPE_COUNTER(sources_dropped_after_seal);
+    MOER_LOAD_GPU_SCOPE_COUNTER(scopes_attempted);
+    MOER_LOAD_GPU_SCOPE_COUNTER(scopes_admitted);
+    MOER_LOAD_GPU_SCOPE_COUNTER(scopes_ready);
+    MOER_LOAD_GPU_SCOPE_COUNTER(scopes_error);
+    MOER_LOAD_GPU_SCOPE_COUNTER(scopes_dropped_resident_full);
+    MOER_LOAD_GPU_SCOPE_COUNTER(scopes_dropped_frame_full);
+    MOER_LOAD_GPU_SCOPE_COUNTER(scopes_dropped_name_too_large);
+    MOER_LOAD_GPU_SCOPE_COUNTER(scopes_dropped_invalid_hierarchy);
+    MOER_LOAD_GPU_SCOPE_COUNTER(scopes_dropped_suppressed_subtree);
+    MOER_LOAD_GPU_SCOPE_COUNTER(scopes_dropped_after_seal);
+    MOER_LOAD_GPU_SCOPE_COUNTER(scopes_dropped_resource_exhaustion);
+    MOER_LOAD_GPU_SCOPE_COUNTER(high_water_frames);
+    MOER_LOAD_GPU_SCOPE_COUNTER(high_water_pending_frames);
+    MOER_LOAD_GPU_SCOPE_COUNTER(high_water_ready_frames);
+    MOER_LOAD_GPU_SCOPE_COUNTER(high_water_scopes);
+#undef MOER_LOAD_GPU_SCOPE_COUNTER
+
+    {
+        std::scoped_lock lock(owner->mutex);
+        stats.accepting = owner->accepting;
+        stats.resident_frames =
+            static_cast<std::uint64_t>(owner->order_count);
+        stats.resident_pending_frames =
+            static_cast<std::uint64_t>(owner->pending_count);
+        stats.resident_ready_frames =
+            static_cast<std::uint64_t>(owner->ready_count);
+        stats.resident_scopes =
+            static_cast<std::uint64_t>(
+                owner->resident_scope_count
+            );
+    }
+    return stats;
+}
+
+void GpuScopeStream::Close() noexcept {
+    const std::shared_ptr<GpuScopeDetail::StreamState> owner = state_;
+    if (!owner) {
+        return;
+    }
+
+    Array<std::shared_ptr<GpuScopeDetail::FrameState>> detached_frames{};
+    {
+        std::scoped_lock lock(owner->mutex);
+        if (!owner->accepting && owner->order_count == 0) {
+            return;
+        }
+        owner->accepting = false;
+        const std::uint64_t opened_frames_abandoned =
+            static_cast<std::uint64_t>(std::count_if(
+                owner->frame_slots.begin(),
+                owner->frame_slots.end(),
+                [](const auto& _frame) {
+                    return _frame != nullptr;
+                }
+            ));
+        owner->counters.frames_abandoned_on_close.fetch_add(
+            opened_frames_abandoned,
+            std::memory_order_relaxed
+        );
+
+        // Detach ownership in O(1) while holding the state lock. Destroying a
+        // full frame releases thousands of names/slots and must happen after
+        // Completion can reacquire the mutex.
+        detached_frames.swap(owner->frame_slots);
+        std::fill(
+            owner->frame_reservations.begin(),
+            owner->frame_reservations.end(),
+            false
+        );
+        std::fill(
+            owner->reserved_frame_ids.begin(),
+            owner->reserved_frame_ids.end(),
+            0
+        );
+        std::fill(
+            owner->ready_flags.begin(),
+            owner->ready_flags.end(),
+            false
+        );
+        owner->order_head = 0;
+        owner->order_tail = 0;
+        owner->order_count = 0;
+        owner->pending_count = 0;
+        owner->ready_count = 0;
+        owner->resident_scope_count = 0;
+        owner->pop_in_progress = false;
+        owner->pop_slot = GpuScopeDetail::kInvalidStreamSlot;
+    }
+    // detached_frames releases its payload outside StreamState::mutex.
+}
+
+#if defined(MOER_RHI_GPU_SCOPE_TEST_HOOKS)
+namespace GpuScopeTesting {
+
+void InstallAdmissionPause(
+    std::atomic_uint32_t& _entered_count,
+    std::atomic_bool&     _release
+) noexcept {
+    GpuScopeDetail::g_admission_pause_release.store(
+        &_release, std::memory_order_release
+    );
+    GpuScopeDetail::g_admission_pause_entered.store(
+        &_entered_count, std::memory_order_release
+    );
+}
+
+void ClearAdmissionPause() noexcept {
+    GpuScopeDetail::g_admission_pause_entered.store(
+        nullptr, std::memory_order_release
+    );
+    GpuScopeDetail::g_admission_pause_release.store(
+        nullptr, std::memory_order_release
+    );
+}
+
+} // namespace GpuScopeTesting
+#endif
+
+} // namespace Moer::Render

--- a/source/runtime/render/rhi/RHIGpuScope.h
+++ b/source/runtime/render/rhi/RHIGpuScope.h
@@ -1,0 +1,257 @@
+#ifndef MOER_ENGINE_RHI_GPU_SCOPE_H
+#define MOER_ENGINE_RHI_GPU_SCOPE_H
+
+#include "RenderAPI.h"
+#include "misc/STL.h"
+#include "rhi/RHICommon.h"
+#include "rhi/RHIQuery.h"
+
+#include <array>
+#if defined(MOER_RHI_GPU_SCOPE_TEST_HOOKS)
+#include <atomic>
+#endif
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <string_view>
+
+namespace Moer::Render {
+
+namespace GpuScopeDetail {
+struct FrameState;
+struct RecorderState;
+struct StreamState;
+} // namespace GpuScopeDetail
+
+enum class GpuScopeTerminalStatus : std::uint8_t {
+    Ready = 0,
+    Error,
+};
+
+struct GpuScopeStreamConfig {
+    // Frames remain resident from BeginFrame until the consumer pops them.
+    // Reserving that slot at BeginFrame guarantees Completion never discovers
+    // a full ready queue after a frame has already been admitted.
+    std::size_t max_resident_frames{8};
+    std::size_t max_pending_frames{4};
+    std::size_t max_resident_scopes{16384};
+    std::size_t max_scopes_per_frame{4096};
+    std::size_t max_sources_per_frame{1024};
+    std::uint32_t max_scope_depth{64};
+    std::size_t max_scope_name_bytes{256};
+    std::size_t max_error_reason_bytes{512};
+};
+
+struct GpuScopeStreamStats {
+    bool          accepting{false};
+    std::uint64_t frames_opened{0};
+    std::uint64_t frames_sealed{0};
+    std::uint64_t frames_ready{0};
+    std::uint64_t frames_popped{0};
+    std::uint64_t frames_dropped_resident_full{0};
+    std::uint64_t frames_dropped_pending_full{0};
+    std::uint64_t frames_dropped_duplicate_id{0};
+    std::uint64_t frames_dropped_resource_exhaustion{0};
+    std::uint64_t frames_abandoned_on_close{0};
+
+    std::uint64_t sources_opened{0};
+    std::uint64_t sources_dropped_capacity{0};
+    std::uint64_t sources_dropped_duplicate_order{0};
+    std::uint64_t sources_dropped_after_seal{0};
+
+    std::uint64_t scopes_attempted{0};
+    std::uint64_t scopes_admitted{0};
+    std::uint64_t scopes_ready{0};
+    std::uint64_t scopes_error{0};
+    std::uint64_t scopes_dropped_resident_full{0};
+    std::uint64_t scopes_dropped_frame_full{0};
+    std::uint64_t scopes_dropped_name_too_large{0};
+    std::uint64_t scopes_dropped_invalid_hierarchy{0};
+    std::uint64_t scopes_dropped_suppressed_subtree{0};
+    std::uint64_t scopes_dropped_after_seal{0};
+    std::uint64_t scopes_dropped_resource_exhaustion{0};
+
+    std::uint64_t resident_frames{0};
+    std::uint64_t resident_pending_frames{0};
+    std::uint64_t resident_ready_frames{0};
+    std::uint64_t resident_scopes{0};
+    std::uint64_t high_water_frames{0};
+    std::uint64_t high_water_pending_frames{0};
+    std::uint64_t high_water_ready_frames{0};
+    std::uint64_t high_water_scopes{0};
+};
+
+struct GpuScopeNode {
+    std::uint64_t scope_id{0};
+    std::uint64_t parent_scope_id{0};
+    std::uint64_t source_order{0};
+    std::uint64_t local_order{0};
+    std::uint32_t depth{0};
+    RHIQueueBinding queue_binding{};
+    std::string     name{};
+
+    GpuScopeTerminalStatus status{GpuScopeTerminalStatus::Error};
+    std::uint64_t          query_id{0};
+    std::uint64_t          begin_tick{0};
+    std::uint64_t          end_tick{0};
+    std::uint32_t          valid_bits{0};
+    double                 tick_period_ns{0.0};
+    double                 total_duration_ns{0.0};
+    double                 exclusive_duration_ns{0.0};
+    std::string            error_reason{};
+
+    Array<GpuScopeNode> children{};
+};
+
+struct ResolvedGpuScopeFrame {
+    std::uint64_t frame_id{0};
+    bool          valid{false};
+    std::uint64_t admitted_scope_count{0};
+    std::uint64_t dropped_scope_count{0};
+    std::uint64_t error_scope_count{0};
+    std::array<Array<GpuScopeNode>, 3> queue_roots{};
+};
+
+// Copyable, internal completion ticket. It intentionally owns only the
+// bounded frame slot and never captures QueryToken/QueryFuture, avoiding a
+// Future -> callback -> Future reference cycle.
+class RENDER_API GpuScopeCompletionTicket {
+public:
+    GpuScopeCompletionTicket() = default;
+
+    [[nodiscard]] bool Valid() const noexcept;
+    [[nodiscard]] std::uint64_t ScopeId() const noexcept;
+
+    void Resolve(const QueryResult& _result) const noexcept;
+    void Fail(std::string_view _reason) const noexcept;
+
+private:
+    GpuScopeCompletionTicket(
+        std::shared_ptr<GpuScopeDetail::FrameState> _frame,
+        std::uint32_t                               _slot,
+        std::uint64_t                               _scope_id
+    ) noexcept;
+
+    std::shared_ptr<GpuScopeDetail::FrameState> frame_{};
+    std::uint32_t                               slot_{0};
+    std::uint64_t                               scope_id_{0};
+
+    friend class GpuScopeRecorder;
+    friend struct GpuScopeDetail::FrameState;
+};
+
+// One stable topology source inside a frame. Recorders are move-only so a
+// source_order cannot accidentally acquire multiple local-order counters.
+class RENDER_API GpuScopeRecorder {
+public:
+    GpuScopeRecorder() = default;
+    GpuScopeRecorder(const GpuScopeRecorder&) = delete;
+    GpuScopeRecorder& operator=(const GpuScopeRecorder&) = delete;
+    GpuScopeRecorder(GpuScopeRecorder&&) noexcept = default;
+    GpuScopeRecorder& operator=(GpuScopeRecorder&&) noexcept = default;
+
+    [[nodiscard]] bool Valid() const noexcept;
+    [[nodiscard]] std::uint64_t FrameId() const noexcept;
+    [[nodiscard]] std::uint64_t SourceOrder() const noexcept;
+    [[nodiscard]] RHIQueueBinding QueueBinding() const noexcept;
+
+private:
+    explicit GpuScopeRecorder(
+        std::shared_ptr<GpuScopeDetail::RecorderState> _state
+    ) noexcept;
+
+    [[nodiscard]] GpuScopeCompletionTicket TryBeginScope(
+        std::string_view _name,
+        std::uint64_t    _parent_scope_id,
+        std::uint32_t    _depth
+    ) const noexcept;
+    void RecordSuppressedScope() const noexcept;
+    [[nodiscard]] bool IsBound() const noexcept;
+    [[nodiscard]] RHIQueueBinding BoundQueueBinding() const noexcept;
+
+    std::shared_ptr<GpuScopeDetail::RecorderState> state_{};
+
+    friend class CommandList;
+    friend class GpuScopeFrameHandle;
+};
+
+class RENDER_API GpuScopeFrameHandle {
+public:
+    GpuScopeFrameHandle() = default;
+
+    [[nodiscard]] bool Valid() const noexcept;
+    [[nodiscard]] std::uint64_t FrameId() const noexcept;
+
+    [[nodiscard]] GpuScopeRecorder CreateRecorder(
+        RHIQueueBinding _queue_binding,
+        std::uint64_t   _source_order
+    ) const noexcept;
+
+private:
+    explicit GpuScopeFrameHandle(
+        std::shared_ptr<GpuScopeDetail::FrameState> _state
+    ) noexcept;
+
+    std::shared_ptr<GpuScopeDetail::FrameState> state_{};
+
+    friend class GpuScopeStream;
+};
+
+class RENDER_API GpuScopeStream {
+public:
+    explicit GpuScopeStream(
+        const GpuScopeStreamConfig& _config = {}
+    );
+    ~GpuScopeStream();
+
+    GpuScopeStream(const GpuScopeStream&) = delete;
+    GpuScopeStream& operator=(const GpuScopeStream&) = delete;
+    GpuScopeStream(GpuScopeStream&& _other) noexcept;
+    GpuScopeStream& operator=(GpuScopeStream&& _other) noexcept;
+
+    [[nodiscard]] bool Valid() const noexcept;
+    [[nodiscard]] GpuScopeFrameHandle BeginFrame(
+        std::uint64_t _frame_id
+    ) noexcept;
+    [[nodiscard]] bool SealFrame(
+        const GpuScopeFrameHandle& _frame
+    ) noexcept;
+
+    // Seal is a linearizable producer boundary: admissions that started
+    // before it are included, while later attempts are rejected. The frame
+    // cannot become visible until all pre-Seal admissions and their queries
+    // have reached a terminal state.
+    // Frames are consumed in BeginFrame order, never callback arrival order.
+    // Hierarchy construction and exclusive-time calculation happen here on
+    // the consumer, not on Completion/rejection owners.
+    [[nodiscard]] bool TryPopFrame(
+        ResolvedGpuScopeFrame& _frame
+    );
+
+    [[nodiscard]] GpuScopeStreamStats GetStats() const noexcept;
+
+    // Non-blocking terminal lifecycle boundary. It rejects new admission and
+    // detaches resident frames; outstanding Query callbacks may safely finish
+    // against their bounded frame state without touching this stream.
+    void Close() noexcept;
+
+private:
+    std::shared_ptr<GpuScopeDetail::StreamState> state_{};
+};
+
+#if defined(MOER_RHI_GPU_SCOPE_TEST_HOOKS)
+// Deterministic contract-test seam. Production builds do not declare or
+// compile this gate.
+namespace GpuScopeTesting {
+RENDER_API void InstallAdmissionPause(
+    std::atomic_uint32_t& _entered_count,
+    std::atomic_bool&     _release
+) noexcept;
+RENDER_API void ClearAdmissionPause() noexcept;
+} // namespace GpuScopeTesting
+#endif
+
+} // namespace Moer::Render
+
+#endif // MOER_ENGINE_RHI_GPU_SCOPE_H

--- a/source/runtime/render/rhi/RHIImpl.h
+++ b/source/runtime/render/rhi/RHIImpl.h
@@ -1811,17 +1811,19 @@ public:
         std::string_view _name,
         bool             _push,
         bool             _query_timestamp,
-        float4           _color = GpuMarkerPalette::Scope()
+        float4           _color = GpuMarkerPalette::Scope(),
+        EQueueType       _queue_type = EQueueType::Graphics
     ) :
         Command(EType::Scope, _name),
         b_push(_push),
         scope_name(_name),
         b_query_timestamp(_query_timestamp),
-        color(_color) {}
+        color(_color),
+        queue_type(_queue_type) {}
 
 public:
     EQueueType GetQueueType() const override {
-        return EQueueType::Graphics;
+        return queue_type;
     }
     bool IsPush() const {
         return b_push;
@@ -1844,6 +1846,7 @@ private:
     bool        b_query_timestamp = false;
     std::string scope_name;
     float4      color = GpuMarkerPalette::Scope();
+    EQueueType  queue_type = EQueueType::Graphics;
 };
 
 struct CustomCmd : public Command {

--- a/source/test/CMakeLists.txt
+++ b/source/test/CMakeLists.txt
@@ -102,6 +102,24 @@ target_link_libraries(${test_target}
 set_target_properties(${test_target} PROPERTIES FOLDER ${moer_test_folder})
 add_test(NAME RHIQueryContract COMMAND $<TARGET_FILE:${test_target}>)
 
+# CPU-only contract for the bounded, Completion-fed GPU scope stream. It
+# validates queue-domain hierarchy, ordered frame visibility, capacity
+# recovery, rejection ownership, and move/close lifetime without a GPU.
+set(test_target TestRHIGpuScope)
+add_executable(${test_target} "RHIGpuScopeContractTest.cpp")
+target_compile_definitions(moer_render
+    PRIVATE MOER_RHI_GPU_SCOPE_TEST_HOOKS=1
+)
+target_compile_definitions(${test_target}
+    PRIVATE MOER_RHI_GPU_SCOPE_TEST_HOOKS=1
+)
+target_link_libraries(${test_target}
+    PRIVATE Moer::Render
+)
+set_target_properties(${test_target} PROPERTIES FOLDER ${moer_test_folder})
+add_test(NAME RHIGpuScopeContract COMMAND $<TARGET_FILE:${test_target}>)
+set_tests_properties(RHIGpuScopeContract PROPERTIES TIMEOUT 60)
+
 set(test_target TestRHIGpuCompletion)
 add_executable(${test_target} "RHIGpuCompletionContractTest.cpp")
 target_link_libraries(${test_target}

--- a/source/test/RHICommandMarkerTest.cpp
+++ b/source/test/RHICommandMarkerTest.cpp
@@ -182,6 +182,29 @@ void ProfilingPhasesPreserveOneLogicalFrame() {
     );
 }
 
+void ScopeCommandsPreserveCommandListQueueAffinity() {
+    for (EQueueType queue :
+         {EQueueType::Graphics, EQueueType::Compute, EQueueType::Copy}) {
+        CommandList cmd_list(queue);
+        cmd_list.PushScope("QueueLabel");
+        cmd_list.PopScope();
+        cmd_list.PushScopeWithTimeScope("QueueTimed");
+        cmd_list.PopScopeWithTimeScope();
+
+        CmdSubmit submit = cmd_list.Submit();
+        Expect(
+            submit.cmds.size() == 4,
+            "queue-affinity marker test emitted an unexpected command count"
+        );
+        for (std::size_t index = 0; index < submit.cmds.size(); ++index) {
+            Expect(
+                ScopeAt(submit, index).GetQueueType() == queue,
+                "ScopeCmd lost its originating CommandList queue"
+            );
+        }
+    }
+}
+
 void ConstSpanUploadsOwnImmutableSnapshots() {
     BufferRef target_buffer(MoerNew(RetainedTestBuffer)());
     const Array<byte> expected{
@@ -376,6 +399,7 @@ int main() {
     try {
         MarkerScopesAreBalancedColoredAndImmobile();
         ProfilingPhasesPreserveOneLogicalFrame();
+        ScopeCommandsPreserveCommandListQueueAffinity();
         ConstSpanUploadsOwnImmutableSnapshots();
         PointAndCsmMarkerNamesAreCompleteAndDisjoint();
         PreparedRaytracingUpdatesAreNullSafeAndOneShot();

--- a/source/test/RHIGpuScopeContractTest.cpp
+++ b/source/test/RHIGpuScopeContractTest.cpp
@@ -805,6 +805,36 @@ void ClosedModernStreamNeverFallsBackToLegacyProfiling() {
 }
 
 void RecorderBindingIsImmutableUntilGenerationReset() {
+    {
+        GpuScopeStream rejected_stream(SmallConfig());
+        GpuScopeFrameHandle sealed_frame =
+            rejected_stream.BeginFrame(4700);
+        Expect(
+            rejected_stream.SealFrame(sealed_frame),
+            "empty-recorder frame could not be sealed"
+        );
+        CommandList rejected_list(EQueueType::Graphics);
+        bool invalid_recorder_rejected = false;
+        try {
+            rejected_list.SetGpuScopeRecorder(
+                sealed_frame.CreateRecorder(
+                    QueueBinding(EQueueType::Graphics, 0, 0), 0
+                )
+            );
+        } catch (const std::invalid_argument&) {
+            invalid_recorder_rejected = true;
+        }
+        ResolvedGpuScopeFrame rejected_frame{};
+        Expect(
+            invalid_recorder_rejected &&
+                !rejected_list.HasGpuScopeRecorder() &&
+                rejected_stream.TryPopFrame(rejected_frame) &&
+                rejected_frame.valid &&
+                rejected_frame.admitted_scope_count == 0,
+            "failed recorder creation silently selected legacy profiling"
+        );
+    }
+
     GpuScopeStream stream(SmallConfig());
     GpuScopeFrameHandle first_frame = stream.BeginFrame(4701);
     CommandList list(EQueueType::Graphics);

--- a/source/test/RHIGpuScopeContractTest.cpp
+++ b/source/test/RHIGpuScopeContractTest.cpp
@@ -1,0 +1,1777 @@
+#include "rhi/RHICommand.h"
+#include "rhi/RHIGpuScope.h"
+#include "rhi/RHIImpl.h"
+#include "rhi/RHIQuery.h"
+
+#include <array>
+#include <atomic>
+#include <cmath>
+#include <exception>
+#include <iostream>
+#include <memory>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <thread>
+#include <type_traits>
+#include <utility>
+
+namespace {
+
+using namespace Moer::Render;
+
+void Expect(bool _condition, std::string_view _message) {
+    if (!_condition) {
+        throw std::runtime_error(std::string(_message));
+    }
+}
+
+void ExpectNear(
+    double           _actual,
+    double           _expected,
+    std::string_view _message
+) {
+    if (std::abs(_actual - _expected) > 1.0e-9) {
+        throw std::runtime_error(std::string(_message));
+    }
+}
+
+RHIQueueBinding QueueBinding(
+    EQueueType   _queue,
+    std::uint32_t _native_queue_id,
+    std::uint32_t _family_id
+) {
+    return RHIQueueBinding{
+        .queue = _queue,
+        .native_queue_id = _native_queue_id,
+        .family_id = _family_id,
+        .available = true,
+    };
+}
+
+TimestampQueryResult Timestamp(
+    std::uint64_t _begin_tick,
+    std::uint64_t _end_tick,
+    double        _tick_period_ns = 1.0
+) {
+    Expect(
+        _end_tick >= _begin_tick,
+        "test timestamp end precedes begin"
+    );
+    return TimestampQueryResult{
+        .begin_tick = _begin_tick,
+        .end_tick = _end_tick,
+        .valid_bits = 64,
+        .tick_period_ns = _tick_period_ns,
+        .duration_ns =
+            static_cast<double>(_end_tick - _begin_tick) *
+            _tick_period_ns,
+    };
+}
+
+void ResolveTimestampAt(
+    CmdSubmit&                  _submit,
+    std::size_t                 _index,
+    const TimestampQueryResult& _timestamp
+) {
+    Expect(
+        _index < _submit.query_tokens.size(),
+        "test query token index is out of range"
+    );
+    Expect(
+        QueryBackendAccess::ResolveTimestamp(
+            _submit.query_tokens[_index], _timestamp
+        ),
+        "timestamp query did not win its terminal transition"
+    );
+}
+
+void ReleaseTerminalSubmit(CmdSubmit& _submit) {
+    _submit.callbacks.clear();
+    _submit.query_tokens.clear();
+}
+
+void RecordTimedScope(CommandList& _list, std::string_view _name) {
+    _list.PushScopeWithTimeScope(_name);
+    _list.PopScopeWithTimeScope();
+}
+
+GpuScopeStreamConfig SmallConfig() {
+    return GpuScopeStreamConfig{
+        .max_resident_frames = 8,
+        .max_pending_frames = 8,
+        .max_resident_scopes = 64,
+        .max_scopes_per_frame = 16,
+        .max_sources_per_frame = 8,
+        .max_scope_name_bytes = 64,
+        .max_error_reason_bytes = 128,
+    };
+}
+
+void ReverseTerminalOrderBuildsNestedHierarchyAndExclusiveTime() {
+    GpuScopeStream stream(SmallConfig());
+    GpuScopeFrameHandle frame = stream.BeginFrame(1001);
+    Expect(frame.Valid(), "nested frame admission failed");
+
+    CommandList list(EQueueType::Graphics);
+    list.SetGpuScopeRecorder(
+        frame.CreateRecorder(
+            QueueBinding(EQueueType::Graphics, 3, 7), 19
+        )
+    );
+    Expect(
+        list.HasGpuScopeRecorder(),
+        "nested CommandList did not retain its recorder"
+    );
+
+    list.PushScopeWithTimeScope("Outer");
+    list.PushScopeWithTimeScope("Child");
+    list.PushScopeWithTimeScope("Grandchild");
+    list.PopScopeWithTimeScope();
+    list.PopScopeWithTimeScope();
+    list.PopScopeWithTimeScope();
+    CmdSubmit submit = list.Submit();
+
+    Expect(
+        submit.query_tokens.size() == 3,
+        "nested scopes did not emit one query pair apiece"
+    );
+    Expect(
+        stream.SealFrame(frame),
+        "nested frame could not be sealed"
+    );
+
+    ResolvedGpuScopeFrame resolved{};
+    ResolveTimestampAt(submit, 1, Timestamp(120, 180));
+    ResolveTimestampAt(submit, 2, Timestamp(130, 150));
+    Expect(
+        !stream.TryPopFrame(resolved),
+        "partially terminal nested frame became visible"
+    );
+    ResolveTimestampAt(submit, 0, Timestamp(100, 200));
+    Expect(
+        stream.TryPopFrame(resolved),
+        "reverse-terminal nested frame never became visible"
+    );
+
+    Expect(
+        resolved.valid && resolved.frame_id == 1001 &&
+            resolved.admitted_scope_count == 3 &&
+            resolved.dropped_scope_count == 0 &&
+            resolved.error_scope_count == 0,
+        "nested frame lost its validity or accounting"
+    );
+    Expect(
+        resolved.queue_roots[0].size() == 1 &&
+            resolved.queue_roots[1].empty() &&
+            resolved.queue_roots[2].empty(),
+        "nested frame was materialized in the wrong queue"
+    );
+
+    const GpuScopeNode& outer = resolved.queue_roots[0].front();
+    Expect(
+        outer.name == "Outer" && outer.depth == 0 &&
+            outer.parent_scope_id == 0 &&
+            outer.children.size() == 1,
+        "outer scope topology is incorrect"
+    );
+    const GpuScopeNode& child = outer.children.front();
+    Expect(
+        child.name == "Child" && child.depth == 1 &&
+            child.parent_scope_id == outer.scope_id &&
+            child.children.size() == 1,
+        "child scope topology is incorrect"
+    );
+    const GpuScopeNode& grandchild = child.children.front();
+    Expect(
+        grandchild.name == "Grandchild" &&
+            grandchild.depth == 2 &&
+            grandchild.parent_scope_id == child.scope_id &&
+            grandchild.children.empty(),
+        "grandchild scope topology is incorrect"
+    );
+    Expect(
+        outer.scope_id != child.scope_id &&
+            child.scope_id != grandchild.scope_id,
+        "nested scopes reused a scope identity"
+    );
+    ExpectNear(outer.total_duration_ns, 100.0, "outer total duration changed");
+    ExpectNear(outer.exclusive_duration_ns, 40.0, "outer exclusive duration is wrong");
+    ExpectNear(child.total_duration_ns, 60.0, "child total duration changed");
+    ExpectNear(child.exclusive_duration_ns, 40.0, "child exclusive duration is wrong");
+    ExpectNear(grandchild.total_duration_ns, 20.0, "grandchild total duration changed");
+    ExpectNear(
+        grandchild.exclusive_duration_ns,
+        20.0,
+        "leaf exclusive duration is wrong"
+    );
+    Expect(
+        outer.local_order < child.local_order &&
+            child.local_order < grandchild.local_order &&
+            outer.source_order == 19 &&
+            child.source_order == 19,
+        "source/local topology order was not stable"
+    );
+
+    const GpuScopeStreamStats stats = stream.GetStats();
+    Expect(
+        stats.frames_opened == 1 && stats.frames_sealed == 1 &&
+            stats.frames_ready == 1 && stats.frames_popped == 1 &&
+            stats.scopes_attempted == 3 &&
+            stats.scopes_admitted == 3 &&
+            stats.scopes_ready == 3 &&
+            stats.resident_frames == 0 &&
+            stats.resident_scopes == 0,
+        "nested scope stream counters are inconsistent"
+    );
+    ReleaseTerminalSubmit(submit);
+}
+
+void FramesPopInBeginOrderAndSealIsOneShot() {
+    GpuScopeStream stream(SmallConfig());
+    GpuScopeFrameHandle first = stream.BeginFrame(2001);
+    GpuScopeFrameHandle second = stream.BeginFrame(2002);
+    Expect(first.Valid() && second.Valid(), "ordered frames were not admitted");
+    Expect(
+        !stream.BeginFrame(2001).Valid(),
+        "duplicate resident frame id was admitted"
+    );
+
+    CommandList first_list(EQueueType::Graphics);
+    first_list.SetGpuScopeRecorder(
+        first.CreateRecorder(
+            QueueBinding(EQueueType::Graphics, 0, 0), 0
+        )
+    );
+    RecordTimedScope(first_list, "FirstFrame");
+    CmdSubmit first_submit = first_list.Submit();
+
+    CommandList second_list(EQueueType::Graphics);
+    second_list.SetGpuScopeRecorder(
+        second.CreateRecorder(
+            QueueBinding(EQueueType::Graphics, 0, 0), 0
+        )
+    );
+    RecordTimedScope(second_list, "SecondFrame");
+    CmdSubmit second_submit = second_list.Submit();
+
+    Expect(
+        stream.SealFrame(first) && stream.SealFrame(second),
+        "ordered frames could not be sealed"
+    );
+    Expect(
+        !stream.SealFrame(first),
+        "a frame was sealed more than once"
+    );
+
+    ResolveTimestampAt(second_submit, 0, Timestamp(20, 30));
+    ResolvedGpuScopeFrame resolved{};
+    Expect(
+        !stream.TryPopFrame(resolved),
+        "later frame bypassed an unresolved earlier frame"
+    );
+    ResolveTimestampAt(first_submit, 0, Timestamp(10, 15));
+    Expect(
+        stream.TryPopFrame(resolved) &&
+            resolved.frame_id == 2001,
+        "first admitted frame was not popped first"
+    );
+    Expect(
+        stream.TryPopFrame(resolved) &&
+            resolved.frame_id == 2002,
+        "second admitted frame did not follow the first"
+    );
+    Expect(
+        !stream.TryPopFrame(resolved),
+        "empty stream produced a frame"
+    );
+
+    GpuScopeStream foreign_stream(SmallConfig());
+    GpuScopeFrameHandle foreign = foreign_stream.BeginFrame(2003);
+    Expect(
+        !stream.SealFrame(foreign),
+        "stream sealed a frame owned by another stream"
+    );
+    Expect(
+        foreign_stream.SealFrame(foreign),
+        "foreign empty frame could not be sealed by its owner"
+    );
+    Expect(
+        foreign_stream.TryPopFrame(resolved) &&
+            resolved.frame_id == 2003 && resolved.valid,
+        "sealed empty frame did not preserve ordered visibility"
+    );
+
+    const GpuScopeStreamStats stats = stream.GetStats();
+    Expect(
+        stats.frames_dropped_duplicate_id == 1 &&
+            stats.frames_opened == 2 &&
+            stats.frames_ready == 2 &&
+            stats.frames_popped == 2,
+        "frame ordering counters are inconsistent"
+    );
+    ReleaseTerminalSubmit(first_submit);
+    ReleaseTerminalSubmit(second_submit);
+}
+
+void GraphicsAndComputeRemainIndependentTimestampDomains() {
+    GpuScopeStream stream(SmallConfig());
+    GpuScopeFrameHandle frame = stream.BeginFrame(3001);
+
+    const RHIQueueBinding graphics_binding =
+        QueueBinding(EQueueType::Graphics, 11, 2);
+    const RHIQueueBinding compute_binding =
+        QueueBinding(EQueueType::Compute, 22, 5);
+
+    CommandList graphics(EQueueType::Graphics);
+    graphics.SetGpuScopeRecorder(
+        frame.CreateRecorder(graphics_binding, 7)
+    );
+    RecordTimedScope(graphics, "GraphicsRoot");
+    CmdSubmit graphics_submit = graphics.Submit();
+
+    CommandList compute(EQueueType::Compute);
+    compute.SetGpuScopeRecorder(
+        frame.CreateRecorder(compute_binding, 7)
+    );
+    RecordTimedScope(compute, "ComputeRoot");
+    CmdSubmit compute_submit = compute.Submit();
+
+    Expect(
+        stream.SealFrame(frame),
+        "multi-domain frame could not be sealed"
+    );
+    ResolveTimestampAt(compute_submit, 0, Timestamp(100, 110, 3.0));
+    ResolveTimestampAt(graphics_submit, 0, Timestamp(100, 120, 2.0));
+
+    ResolvedGpuScopeFrame resolved{};
+    Expect(
+        stream.TryPopFrame(resolved) && resolved.valid,
+        "multi-domain frame did not resolve"
+    );
+    Expect(
+        resolved.queue_roots[0].size() == 1 &&
+            resolved.queue_roots[1].size() == 1 &&
+            resolved.queue_roots[2].empty(),
+        "Graphics/Compute roots were not independently partitioned"
+    );
+    const GpuScopeNode& graphics_node =
+        resolved.queue_roots[0].front();
+    const GpuScopeNode& compute_node =
+        resolved.queue_roots[1].front();
+    Expect(
+        graphics_node.queue_binding == graphics_binding &&
+            compute_node.queue_binding == compute_binding &&
+            graphics_node.source_order == 7 &&
+            compute_node.source_order == 7,
+        "queue-domain identity or per-domain source order was lost"
+    );
+    ExpectNear(
+        graphics_node.total_duration_ns,
+        40.0,
+        "Graphics duration was converted through another domain"
+    );
+    ExpectNear(
+        compute_node.total_duration_ns,
+        30.0,
+        "Compute duration was converted through another domain"
+    );
+    ExpectNear(
+        graphics_node.exclusive_duration_ns,
+        40.0,
+        "Graphics root exclusive duration is wrong"
+    );
+    ExpectNear(
+        compute_node.exclusive_duration_ns,
+        30.0,
+        "Compute root exclusive duration is wrong"
+    );
+
+    ReleaseTerminalSubmit(graphics_submit);
+    ReleaseTerminalSubmit(compute_submit);
+}
+
+void ErrorCancelAndRejectAreExactlyOnce() {
+    {
+        GpuScopeStream stream(SmallConfig());
+        GpuScopeFrameHandle frame = stream.BeginFrame(4001);
+        CommandList list(EQueueType::Graphics);
+        list.SetGpuScopeRecorder(
+            frame.CreateRecorder(
+                QueueBinding(EQueueType::Graphics, 0, 0), 0
+            )
+        );
+        RecordTimedScope(list, "DirectError");
+        CmdSubmit submit = list.Submit();
+        QueryToken token = submit.query_tokens.front();
+        Expect(stream.SealFrame(frame), "error frame seal failed");
+
+        Expect(
+            QueryBackendAccess::ResolveErrorIfPending(
+                token, "injected direct query error"
+            ),
+            "direct query error did not win"
+        );
+        Expect(
+            !QueryBackendAccess::ResolveTimestamp(
+                token, Timestamp(1, 2)
+            ) &&
+                !QueryBackendAccess::ResolveErrorIfPending(
+                    token, "duplicate error"
+                ),
+            "direct error was overwritten by a later terminal"
+        );
+        for (auto& callback : submit.callbacks) {
+            callback();
+            callback();
+        }
+        submit.callbacks.clear();
+
+        ResolvedGpuScopeFrame resolved{};
+        Expect(
+            stream.TryPopFrame(resolved) &&
+                !resolved.valid &&
+                resolved.error_scope_count == 1 &&
+                resolved.queue_roots[0].size() == 1 &&
+                resolved.queue_roots[0].front().status ==
+                    GpuScopeTerminalStatus::Error &&
+                resolved.queue_roots[0].front().error_reason ==
+                    "injected direct query error",
+            "direct Error was not materialized exactly once"
+        );
+        const GpuScopeStreamStats stats = stream.GetStats();
+        Expect(
+            stats.scopes_error == 1 && stats.scopes_ready == 0,
+            "direct Error changed stream counters more than once"
+        );
+        submit.query_tokens.clear();
+    }
+
+    {
+        GpuScopeStream stream(SmallConfig());
+        GpuScopeFrameHandle frame = stream.BeginFrame(4002);
+        CommandList list(EQueueType::Graphics);
+        list.SetGpuScopeRecorder(
+            frame.CreateRecorder(
+                QueueBinding(EQueueType::Graphics, 0, 0), 0
+            )
+        );
+        QueryCancellationView cancellation =
+            list.GetQueryCancellationView();
+        RecordTimedScope(list, "Cancelled");
+        Expect(
+            cancellation.Cancel("injected generation cancellation"),
+            "query generation cancellation did not win"
+        );
+        Expect(
+            !cancellation.Cancel("duplicate cancellation"),
+            "query cancellation was not one-shot"
+        );
+        CmdSubmit submit = list.Submit();
+        QueryToken token = submit.query_tokens.front();
+        Expect(stream.SealFrame(frame), "cancelled frame seal failed");
+
+        ResolvedGpuScopeFrame resolved{};
+        Expect(
+            !stream.TryPopFrame(resolved),
+            "cancelled callback escaped before ownership handoff"
+        );
+        submit.RejectPendingQueries("late submit rejection");
+        Expect(
+            !QueryBackendAccess::ResolveErrorIfPending(
+                token, "late duplicate cancellation"
+            ),
+            "cancelled query accepted another terminal transition"
+        );
+        Expect(
+            stream.TryPopFrame(resolved) &&
+                resolved.error_scope_count == 1 &&
+                resolved.queue_roots[0].front().error_reason ==
+                    "injected generation cancellation",
+            "deferred cancellation did not resolve exactly once"
+        );
+        Expect(
+            stream.GetStats().scopes_error == 1,
+            "cancelled scope incremented Error more than once"
+        );
+        submit.callbacks.clear();
+    }
+
+    {
+        GpuScopeStream stream(SmallConfig());
+        GpuScopeFrameHandle frame = stream.BeginFrame(4003);
+        CommandList list(EQueueType::Graphics);
+        list.SetGpuScopeRecorder(
+            frame.CreateRecorder(
+                QueueBinding(EQueueType::Graphics, 0, 0), 0
+            )
+        );
+        RecordTimedScope(list, "Rejected");
+        CmdSubmit submit = list.Submit();
+        QueryToken token = submit.query_tokens.front();
+        Expect(stream.SealFrame(frame), "rejected frame seal failed");
+
+        submit.RejectPendingQueries("injected submit rejection");
+        submit.RejectPendingQueries("duplicate submit rejection");
+        for (auto& callback : submit.callbacks) {
+            callback();
+        }
+        submit.callbacks.clear();
+        Expect(
+            !QueryBackendAccess::ResolveTimestamp(
+                token, Timestamp(10, 20)
+            ),
+            "rejected query accepted a late Ready result"
+        );
+
+        ResolvedGpuScopeFrame resolved{};
+        Expect(
+            stream.TryPopFrame(resolved) &&
+                resolved.error_scope_count == 1 &&
+                resolved.queue_roots[0].front().error_reason ==
+                    "injected submit rejection" &&
+                stream.GetStats().scopes_error == 1,
+            "submit rejection did not resolve exactly once"
+        );
+    }
+}
+
+void MalformedTimestampPayloadAndTopologyFailClosed() {
+    {
+        GpuScopeStream stream(SmallConfig());
+        GpuScopeFrameHandle frame = stream.BeginFrame(4501);
+        CommandList list(EQueueType::Graphics);
+        list.SetGpuScopeRecorder(
+            frame.CreateRecorder(
+                QueueBinding(EQueueType::Graphics, 0, 0), 0
+            )
+        );
+        RecordTimedScope(list, "MalformedDuration");
+        CmdSubmit submit = list.Submit();
+        Expect(stream.SealFrame(frame), "malformed-duration frame seal failed");
+
+        TimestampQueryResult malformed = Timestamp(0, 10);
+        malformed.duration_ns = 999.0;
+        ResolveTimestampAt(submit, 0, malformed);
+
+        ResolvedGpuScopeFrame resolved{};
+        Expect(
+            stream.TryPopFrame(resolved) &&
+                !resolved.valid &&
+                resolved.error_scope_count == 1 &&
+                resolved.queue_roots[0].front().status ==
+                    GpuScopeTerminalStatus::Error &&
+                resolved.queue_roots[0].front().error_reason ==
+                    "GPU scope timestamp payload is invalid",
+            "duration/raw-tick mismatch was accepted as a valid GPU scope"
+        );
+        ReleaseTerminalSubmit(submit);
+    }
+
+    {
+        GpuScopeStream stream(SmallConfig());
+        GpuScopeFrameHandle frame = stream.BeginFrame(4502);
+        CommandList list(EQueueType::Graphics);
+        list.SetGpuScopeRecorder(
+            frame.CreateRecorder(
+                QueueBinding(EQueueType::Graphics, 0, 0), 0
+            )
+        );
+        list.PushScopeWithTimeScope("Parent");
+        RecordTimedScope(list, "OversizedChild");
+        list.PopScopeWithTimeScope();
+        CmdSubmit submit = list.Submit();
+        Expect(stream.SealFrame(frame), "invalid-topology frame seal failed");
+
+        ResolveTimestampAt(submit, 0, Timestamp(0, 10));
+        ResolveTimestampAt(submit, 1, Timestamp(0, 20));
+
+        ResolvedGpuScopeFrame resolved{};
+        Expect(
+            stream.TryPopFrame(resolved) &&
+                !resolved.valid &&
+                resolved.error_scope_count == 0 &&
+                resolved.queue_roots[0].size() == 1 &&
+                resolved.queue_roots[0].front().
+                    exclusive_duration_ns == 0.0,
+            "child interval outside its parent was not failed closed"
+        );
+        ReleaseTerminalSubmit(submit);
+    }
+
+    {
+        GpuScopeStream stream(SmallConfig());
+        GpuScopeFrameHandle frame = stream.BeginFrame(4503);
+        CommandList list(EQueueType::Graphics);
+        list.SetGpuScopeRecorder(
+            frame.CreateRecorder(
+                QueueBinding(EQueueType::Graphics, 0, 0), 0
+            )
+        );
+        list.PushScopeWithTimeScope("Parent");
+        RecordTimedScope(list, "FirstChild");
+        RecordTimedScope(list, "OverlappingChild");
+        list.PopScopeWithTimeScope();
+        CmdSubmit submit = list.Submit();
+        Expect(stream.SealFrame(frame), "overlap frame seal failed");
+
+        ResolveTimestampAt(submit, 0, Timestamp(0, 100));
+        ResolveTimestampAt(submit, 1, Timestamp(10, 60));
+        ResolveTimestampAt(submit, 2, Timestamp(50, 80));
+
+        ResolvedGpuScopeFrame resolved{};
+        Expect(
+            stream.TryPopFrame(resolved) &&
+                !resolved.valid &&
+                resolved.error_scope_count == 0 &&
+                resolved.queue_roots[0].front().
+                    exclusive_duration_ns == 0.0,
+            "overlapping sibling intervals were not failed closed"
+        );
+        ReleaseTerminalSubmit(submit);
+    }
+
+    {
+        GpuScopeStream stream(SmallConfig());
+        GpuScopeFrameHandle frame = stream.BeginFrame(4504);
+        CommandList list(EQueueType::Graphics);
+        list.SetGpuScopeRecorder(
+            frame.CreateRecorder(
+                QueueBinding(EQueueType::Graphics, 0, 0), 0
+            )
+        );
+        RecordTimedScope(list, "RootA");
+        RecordTimedScope(list, "OverlappingRootB");
+        CmdSubmit submit = list.Submit();
+        Expect(stream.SealFrame(frame), "root-overlap frame seal failed");
+
+        ResolveTimestampAt(submit, 0, Timestamp(0, 100));
+        ResolveTimestampAt(submit, 1, Timestamp(50, 80));
+
+        ResolvedGpuScopeFrame resolved{};
+        Expect(
+            stream.TryPopFrame(resolved) &&
+                !resolved.valid &&
+                resolved.queue_roots[0].size() == 2 &&
+                resolved.queue_roots[0][0].
+                    exclusive_duration_ns == 0.0 &&
+                resolved.queue_roots[0][1].
+                    exclusive_duration_ns == 0.0,
+            "overlapping roots from one source were not failed closed"
+        );
+        ReleaseTerminalSubmit(submit);
+    }
+
+    {
+        GpuScopeStream stream(SmallConfig());
+        GpuScopeFrameHandle frame = stream.BeginFrame(4505);
+        CommandList list(EQueueType::Graphics);
+        list.SetGpuScopeRecorder(
+            frame.CreateRecorder(
+                QueueBinding(EQueueType::Graphics, 0, 0), 0
+            )
+        );
+        RecordTimedScope(list, "WrappedRootA");
+        RecordTimedScope(list, "WrappedRootB");
+        CmdSubmit submit = list.Submit();
+        Expect(stream.SealFrame(frame), "wrapped-root frame seal failed");
+
+        ResolveTimestampAt(
+            submit,
+            0,
+            TimestampQueryResult{
+                .begin_tick = 250,
+                .end_tick = 5,
+                .valid_bits = 8,
+                .tick_period_ns = 1.0,
+                .duration_ns = 11.0,
+            }
+        );
+        ResolveTimestampAt(
+            submit,
+            1,
+            TimestampQueryResult{
+                .begin_tick = 10,
+                .end_tick = 20,
+                .valid_bits = 8,
+                .tick_period_ns = 1.0,
+                .duration_ns = 10.0,
+            }
+        );
+
+        ResolvedGpuScopeFrame resolved{};
+        Expect(
+            stream.TryPopFrame(resolved) &&
+                resolved.valid &&
+                resolved.queue_roots[0].size() == 2 &&
+                resolved.queue_roots[0][0].
+                    exclusive_duration_ns == 11.0 &&
+                resolved.queue_roots[0][1].
+                    exclusive_duration_ns == 10.0,
+            "valid wrapped roots from one source were rejected"
+        );
+        ReleaseTerminalSubmit(submit);
+    }
+
+    {
+        GpuScopeStream stream(SmallConfig());
+        GpuScopeFrameHandle frame = stream.BeginFrame(4506);
+        CommandList list(EQueueType::Graphics);
+        list.SetGpuScopeRecorder(
+            frame.CreateRecorder(
+                QueueBinding(EQueueType::Graphics, 0, 0), 0
+            )
+        );
+        list.PushScopeWithTimeScope("WrappedParent");
+        RecordTimedScope(list, "WrappedChild");
+        list.PopScopeWithTimeScope();
+        CmdSubmit submit = list.Submit();
+        Expect(stream.SealFrame(frame), "wrapped frame seal failed");
+
+        ResolveTimestampAt(
+            submit,
+            0,
+            TimestampQueryResult{
+                .begin_tick = 250,
+                .end_tick = 20,
+                .valid_bits = 8,
+                .tick_period_ns = 1.0,
+                .duration_ns = 26.0,
+            }
+        );
+        ResolveTimestampAt(
+            submit,
+            1,
+            TimestampQueryResult{
+                .begin_tick = 255,
+                .end_tick = 5,
+                .valid_bits = 8,
+                .tick_period_ns = 1.0,
+                .duration_ns = 6.0,
+            }
+        );
+
+        ResolvedGpuScopeFrame resolved{};
+        Expect(
+            stream.TryPopFrame(resolved) &&
+                resolved.valid &&
+                resolved.queue_roots[0].front().
+                    exclusive_duration_ns == 20.0,
+            "valid wrapped timestamp topology was rejected"
+        );
+        ReleaseTerminalSubmit(submit);
+    }
+}
+
+void ClosedModernStreamNeverFallsBackToLegacyProfiling() {
+    GpuScopeStream stream(SmallConfig());
+    GpuScopeFrameHandle frame = stream.BeginFrame(4601);
+    CommandList list(EQueueType::Graphics);
+    list.SetGpuScopeRecorder(
+        frame.CreateRecorder(
+            QueueBinding(EQueueType::Graphics, 0, 0), 0
+        )
+    );
+    RecordTimedScope(list, "BeforeClose");
+    stream.Close();
+    Expect(
+        list.HasGpuScopeRecorder(),
+        "closed stream erased the explicit modern recorder binding"
+    );
+    RecordTimedScope(list, "AfterClose");
+
+    CmdSubmit submit = list.Submit();
+    Expect(
+        submit.query_tokens.size() == 1,
+        "closed modern stream recorded another native query"
+    );
+    std::size_t legacy_timestamp_markers = 0;
+    for (const auto& command : submit.cmds) {
+        if (command->Type() != Command::EType::Scope) {
+            continue;
+        }
+        const auto& scope = *static_cast<const ScopeCmd*>(command.get());
+        if (scope.QueryTimestamp()) {
+            ++legacy_timestamp_markers;
+        }
+    }
+    Expect(
+        legacy_timestamp_markers == 0,
+        "closed modern stream silently fell back to legacy profiling"
+    );
+    submit.RejectPendingQueries("closed stream test cleanup");
+    submit.callbacks.clear();
+}
+
+void RecorderBindingIsImmutableUntilGenerationReset() {
+    GpuScopeStream stream(SmallConfig());
+    GpuScopeFrameHandle first_frame = stream.BeginFrame(4701);
+    CommandList list(EQueueType::Graphics);
+    const RHIQueueBinding binding =
+        QueueBinding(EQueueType::Graphics, 0, 0);
+    list.SetGpuScopeRecorder(first_frame.CreateRecorder(binding, 0));
+    RecordTimedScope(list, "FirstSource");
+
+    bool clear_rejected = false;
+    try {
+        list.SetGpuScopeRecorder({});
+    } catch (const std::logic_error&) {
+        clear_rejected = true;
+    }
+    bool rebind_rejected = false;
+    try {
+        list.SetGpuScopeRecorder(
+            first_frame.CreateRecorder(binding, 1)
+        );
+    } catch (const std::logic_error&) {
+        rebind_rejected = true;
+    }
+    Expect(
+        clear_rejected && rebind_rejected &&
+            list.HasGpuScopeRecorder(),
+        "one CommandList generation changed its stable GPU scope source"
+    );
+
+    CmdSubmit first_submit = list.Submit();
+    Expect(
+        stream.SealFrame(first_frame),
+        "immutable-binding first frame seal failed"
+    );
+    ResolveTimestampAt(first_submit, 0, Timestamp(0, 10));
+    ResolvedGpuScopeFrame resolved{};
+    Expect(
+        stream.TryPopFrame(resolved) && resolved.valid,
+        "immutable-binding first frame did not drain"
+    );
+    ReleaseTerminalSubmit(first_submit);
+
+    GpuScopeFrameHandle second_frame = stream.BeginFrame(4702);
+    list.SetGpuScopeRecorder(
+        second_frame.CreateRecorder(binding, 0)
+    );
+    RecordTimedScope(list, "NextGeneration");
+    CmdSubmit second_submit = list.Submit();
+    Expect(
+        stream.SealFrame(second_frame),
+        "immutable-binding next frame seal failed"
+    );
+    ResolveTimestampAt(second_submit, 0, Timestamp(10, 20));
+    Expect(
+        stream.TryPopFrame(resolved) && resolved.valid &&
+            resolved.frame_id == 4702,
+        "Submit did not reset the recorder-binding generation"
+    );
+    ReleaseTerminalSubmit(second_submit);
+
+    GpuScopeFrameHandle legacy_mixing_frame =
+        stream.BeginFrame(4703);
+    CommandList legacy_first(EQueueType::Graphics);
+    RecordTimedScope(legacy_first, "LegacyBeforeModernBinding");
+    bool legacy_to_modern_rejected = false;
+    try {
+        legacy_first.SetGpuScopeRecorder(
+            legacy_mixing_frame.CreateRecorder(binding, 0)
+        );
+    } catch (const std::logic_error&) {
+        legacy_to_modern_rejected = true;
+    }
+    Expect(
+        legacy_to_modern_rejected &&
+            !legacy_first.HasGpuScopeRecorder(),
+        "a CommandList generation mixed legacy and modern timed scopes"
+    );
+    CmdSubmit legacy_submit = legacy_first.Submit();
+    std::size_t legacy_timestamp_markers = 0;
+    for (const auto& command : legacy_submit.cmds) {
+        if (command->Type() == Command::EType::Scope &&
+            static_cast<const ScopeCmd*>(command.get())->
+                QueryTimestamp()) {
+            ++legacy_timestamp_markers;
+        }
+    }
+    Expect(
+        legacy_timestamp_markers == 2 &&
+            stream.SealFrame(legacy_mixing_frame) &&
+            stream.TryPopFrame(resolved) && resolved.valid &&
+            resolved.admitted_scope_count == 0,
+        "legacy-to-modern rejection corrupted either profiling path"
+    );
+    ReleaseTerminalSubmit(legacy_submit);
+}
+
+void SealWaitsForAdmissionsThatAlreadyStarted() {
+    constexpr std::size_t producer_count = 4;
+
+    GpuScopeStreamConfig config = SmallConfig();
+    config.max_resident_scopes = producer_count;
+    config.max_scopes_per_frame = producer_count;
+    config.max_sources_per_frame = producer_count;
+    GpuScopeStream stream(config);
+    GpuScopeFrameHandle frame = stream.BeginFrame(4801);
+    Expect(frame.Valid(), "concurrent-admission frame was rejected");
+
+    std::array<std::unique_ptr<CommandList>, producer_count> lists{};
+    for (std::size_t index = 0; index < producer_count; ++index) {
+        lists[index] = std::make_unique<CommandList>(
+            EQueueType::Graphics
+        );
+        lists[index]->SetGpuScopeRecorder(
+            frame.CreateRecorder(
+                QueueBinding(EQueueType::Graphics, 0, 0),
+                static_cast<std::uint64_t>(index)
+            )
+        );
+    }
+
+    std::array<std::exception_ptr, producer_count> errors{};
+    std::array<std::thread, producer_count> producers{};
+    std::atomic_bool start{false};
+    std::atomic_uint32_t admission_pause_count{0};
+    std::atomic_bool     release_admissions{false};
+    GpuScopeTesting::InstallAdmissionPause(
+        admission_pause_count, release_admissions
+    );
+    for (std::size_t index = 0; index < producer_count; ++index) {
+        producers[index] = std::thread([&, index] {
+            while (!start.load(std::memory_order_acquire)) {
+                std::this_thread::yield();
+            }
+            try {
+                RecordTimedScope(
+                    *lists[index], "ConcurrentPreSealScope"
+                );
+            } catch (...) {
+                errors[index] = std::current_exception();
+            }
+        });
+    }
+
+    ResolvedGpuScopeFrame resolved{};
+    std::atomic_bool      popped{false};
+    std::atomic_bool      stop_consumer{false};
+    std::thread consumer([&] {
+        while (!stop_consumer.load(std::memory_order_acquire)) {
+            if (stream.TryPopFrame(resolved)) {
+                popped.store(true, std::memory_order_release);
+                return;
+            }
+            std::this_thread::yield();
+        }
+    });
+
+    start.store(true, std::memory_order_release);
+    bool all_paused = false;
+    for (std::size_t spin = 0; spin < 2'000'000; ++spin) {
+        if (admission_pause_count.load(std::memory_order_acquire) ==
+            producer_count) {
+            all_paused = true;
+            break;
+        }
+        std::this_thread::yield();
+    }
+    const bool sealed = stream.SealFrame(frame);
+    release_admissions.store(true, std::memory_order_release);
+
+    for (std::thread& producer : producers) {
+        producer.join();
+    }
+    GpuScopeTesting::ClearAdmissionPause();
+    std::exception_ptr producer_error{};
+    for (const std::exception_ptr& error : errors) {
+        if (error && !producer_error) {
+            producer_error = error;
+        }
+    }
+    if (!all_paused || !sealed || producer_error) {
+        stop_consumer.store(true, std::memory_order_release);
+        consumer.join();
+        stream.Close();
+        if (producer_error) {
+            std::rethrow_exception(producer_error);
+        }
+    }
+    Expect(
+        all_paused,
+        "scope producers did not reach the deterministic admission pause"
+    );
+    Expect(
+        sealed,
+        "concurrent-admission frame could not be sealed"
+    );
+    std::array<std::optional<CmdSubmit>, producer_count> submits{};
+    bool all_queries_recorded = true;
+    for (std::size_t index = 0; index < producer_count; ++index) {
+        submits[index].emplace(lists[index]->Submit());
+        if (submits[index]->query_tokens.size() != 1) {
+            all_queries_recorded = false;
+            continue;
+        }
+        all_queries_recorded &=
+            QueryBackendAccess::ResolveTimestamp(
+                submits[index]->query_tokens.front(),
+                Timestamp(
+                    static_cast<std::uint64_t>(index * 10),
+                    static_cast<std::uint64_t>(index * 10 + 5)
+                )
+            );
+    }
+
+    for (std::size_t spin = 0; spin < 2'000'000; ++spin) {
+        if (popped.load(std::memory_order_acquire)) {
+            break;
+        }
+        std::this_thread::yield();
+    }
+    stop_consumer.store(true, std::memory_order_release);
+    consumer.join();
+    Expect(
+        all_queries_recorded &&
+            popped.load(std::memory_order_acquire) && resolved.valid &&
+            resolved.admitted_scope_count == producer_count &&
+            resolved.dropped_scope_count == 0,
+        "Seal rejected or exposed a frame before its pre-Seal admissions completed"
+    );
+    for (auto& submit : submits) {
+        ReleaseTerminalSubmit(*submit);
+    }
+}
+
+void FrameAdmissionCapacityIsBoundedAndRecovers() {
+    GpuScopeStreamConfig config = SmallConfig();
+    config.max_resident_frames = 2;
+    config.max_pending_frames = 1;
+    GpuScopeStream stream(config);
+
+    GpuScopeFrameHandle first = stream.BeginFrame(5001);
+    Expect(first.Valid(), "first bounded frame was rejected");
+    Expect(
+        !stream.BeginFrame(5002).Valid(),
+        "pending-frame capacity was exceeded"
+    );
+    Expect(
+        stream.SealFrame(first),
+        "empty bounded frame could not be sealed"
+    );
+
+    GpuScopeFrameHandle second = stream.BeginFrame(5002);
+    Expect(
+        second.Valid(),
+        "pending-frame capacity did not recover after seal"
+    );
+    Expect(
+        !stream.BeginFrame(5003).Valid(),
+        "resident-frame capacity was exceeded"
+    );
+
+    ResolvedGpuScopeFrame resolved{};
+    Expect(
+        stream.TryPopFrame(resolved) && resolved.frame_id == 5001,
+        "first bounded frame did not release its resident slot"
+    );
+    Expect(
+        stream.SealFrame(second),
+        "second bounded frame could not be sealed"
+    );
+    GpuScopeFrameHandle third = stream.BeginFrame(5003);
+    Expect(
+        third.Valid(),
+        "resident/pending frame capacity did not recover after pop/seal"
+    );
+
+    Expect(
+        stream.TryPopFrame(resolved) && resolved.frame_id == 5002,
+        "second bounded frame did not pop"
+    );
+    Expect(
+        stream.SealFrame(third),
+        "third bounded frame could not be sealed"
+    );
+    Expect(
+        stream.TryPopFrame(resolved) && resolved.frame_id == 5003,
+        "third bounded frame did not pop"
+    );
+
+    const GpuScopeStreamStats stats = stream.GetStats();
+    Expect(
+        stats.frames_dropped_pending_full == 1 &&
+            stats.frames_dropped_resident_full == 1 &&
+            stats.frames_opened == 3 &&
+            stats.frames_popped == 3 &&
+            stats.high_water_frames == 2 &&
+            stats.high_water_pending_frames == 1,
+        "frame admission capacity counters are inconsistent"
+    );
+}
+
+void ConcurrentDuplicateFrameAdmissionReservesExactlyOneSlot() {
+    GpuScopeStreamConfig config = SmallConfig();
+    config.max_resident_frames = 32;
+    config.max_pending_frames = 32;
+    config.max_resident_scopes = 32;
+    config.max_scopes_per_frame = 1;
+    config.max_sources_per_frame = 1;
+
+    GpuScopeStream stream(config);
+    constexpr std::size_t contender_count = 32;
+    Moer::Array<GpuScopeFrameHandle> handles(contender_count);
+    Moer::Array<std::thread> threads{};
+    threads.reserve(contender_count);
+    std::atomic<std::size_t> arrived{0};
+    std::atomic<bool> start{false};
+
+    for (std::size_t index = 0; index < contender_count; ++index) {
+        threads.emplace_back([&, index] {
+            arrived.fetch_add(1, std::memory_order_release);
+            while (!start.load(std::memory_order_acquire)) {
+                std::this_thread::yield();
+            }
+            handles[index] = stream.BeginFrame(5050);
+        });
+    }
+    while (arrived.load(std::memory_order_acquire) != contender_count) {
+        std::this_thread::yield();
+    }
+    start.store(true, std::memory_order_release);
+    for (std::thread& thread : threads) {
+        thread.join();
+    }
+
+    std::size_t admitted = 0;
+    GpuScopeFrameHandle admitted_frame{};
+    for (const GpuScopeFrameHandle& handle : handles) {
+        if (handle.Valid()) {
+            ++admitted;
+            admitted_frame = handle;
+        }
+    }
+    Expect(
+        admitted == 1 && admitted_frame.Valid(),
+        "concurrent duplicate BeginFrame admitted more than one reservation"
+    );
+
+    const GpuScopeStreamStats admitted_stats = stream.GetStats();
+    Expect(
+        admitted_stats.frames_opened == 1 &&
+            admitted_stats.frames_dropped_duplicate_id ==
+                contender_count - 1 &&
+            admitted_stats.resident_frames == 1 &&
+            admitted_stats.resident_pending_frames == 1,
+        "concurrent duplicate frame-reservation counters are inconsistent"
+    );
+
+    Expect(
+        stream.SealFrame(admitted_frame),
+        "concurrent duplicate admitted frame seal failed"
+    );
+    ResolvedGpuScopeFrame resolved{};
+    Expect(
+        stream.TryPopFrame(resolved) &&
+            resolved.frame_id == 5050 &&
+            resolved.valid,
+        "concurrent duplicate admitted frame did not drain"
+    );
+}
+
+void PerFrameAndGlobalScopeCapacityAreBoundedAndRecover() {
+    {
+        GpuScopeStreamConfig config = SmallConfig();
+        config.max_resident_scopes = 4;
+        config.max_scopes_per_frame = 2;
+        GpuScopeStream stream(config);
+        GpuScopeFrameHandle frame = stream.BeginFrame(5101);
+        CommandList list(EQueueType::Graphics);
+        list.SetGpuScopeRecorder(
+            frame.CreateRecorder(
+                QueueBinding(EQueueType::Graphics, 0, 0), 0
+            )
+        );
+        RecordTimedScope(list, "FrameA");
+        RecordTimedScope(list, "FrameB");
+        RecordTimedScope(list, "FrameOverflow");
+        CmdSubmit submit = list.Submit();
+        Expect(
+            submit.query_tokens.size() == 2,
+            "per-frame overflow emitted an unbounded query"
+        );
+        Expect(stream.SealFrame(frame), "per-frame capacity frame seal failed");
+        ResolveTimestampAt(submit, 0, Timestamp(0, 4));
+        ResolveTimestampAt(submit, 1, Timestamp(5, 9));
+
+        ResolvedGpuScopeFrame resolved{};
+        Expect(
+            stream.TryPopFrame(resolved) &&
+                !resolved.valid &&
+                resolved.admitted_scope_count == 2 &&
+                resolved.dropped_scope_count == 1 &&
+                resolved.queue_roots[0].size() == 2,
+            "per-frame overflow accounting is incorrect"
+        );
+        ExpectNear(
+            resolved.queue_roots[0][0].exclusive_duration_ns,
+            0.0,
+            "partial frame exposed trustworthy exclusive time"
+        );
+        const GpuScopeStreamStats stats = stream.GetStats();
+        Expect(
+            stats.scopes_attempted == 3 &&
+                stats.scopes_admitted == 2 &&
+                stats.scopes_dropped_frame_full == 1 &&
+                stats.scopes_dropped_suppressed_subtree == 0 &&
+                stats.resident_scopes == 0,
+            "per-frame scope capacity counters are inconsistent"
+        );
+        ReleaseTerminalSubmit(submit);
+
+        GpuScopeFrameHandle recovered = stream.BeginFrame(5102);
+        CommandList recovered_list(EQueueType::Graphics);
+        recovered_list.SetGpuScopeRecorder(
+            recovered.CreateRecorder(
+                QueueBinding(EQueueType::Graphics, 0, 0), 0
+            )
+        );
+        RecordTimedScope(recovered_list, "RecoveredFrameScope");
+        CmdSubmit recovered_submit = recovered_list.Submit();
+        Expect(
+            recovered_submit.query_tokens.size() == 1,
+            "per-frame capacity did not recover in the next frame"
+        );
+        Expect(stream.SealFrame(recovered), "recovered frame seal failed");
+        ResolveTimestampAt(
+            recovered_submit, 0, Timestamp(10, 11)
+        );
+        Expect(
+            stream.TryPopFrame(resolved) && resolved.valid,
+            "scope admission did not recover after a bounded frame"
+        );
+        ReleaseTerminalSubmit(recovered_submit);
+    }
+
+    {
+        GpuScopeStreamConfig config = SmallConfig();
+        config.max_resident_scopes = 2;
+        config.max_scopes_per_frame = 2;
+        GpuScopeStream stream(config);
+        GpuScopeFrameHandle first = stream.BeginFrame(5201);
+        GpuScopeFrameHandle second = stream.BeginFrame(5202);
+
+        CommandList first_list(EQueueType::Graphics);
+        first_list.SetGpuScopeRecorder(
+            first.CreateRecorder(
+                QueueBinding(EQueueType::Graphics, 0, 0), 0
+            )
+        );
+        RecordTimedScope(first_list, "GlobalA");
+        RecordTimedScope(first_list, "GlobalB");
+        CmdSubmit first_submit = first_list.Submit();
+
+        CommandList second_list(EQueueType::Graphics);
+        second_list.SetGpuScopeRecorder(
+            second.CreateRecorder(
+                QueueBinding(EQueueType::Graphics, 0, 0), 0
+            )
+        );
+        RecordTimedScope(second_list, "GlobalOverflow");
+        Expect(
+            second_list.IsEmpty() == false,
+            "overflow visual markers unexpectedly disappeared"
+        );
+
+        Expect(stream.SealFrame(first), "global-capacity first seal failed");
+        ResolveTimestampAt(first_submit, 0, Timestamp(0, 1));
+        ResolveTimestampAt(first_submit, 1, Timestamp(1, 2));
+        ResolvedGpuScopeFrame resolved{};
+        Expect(
+            stream.TryPopFrame(resolved) && resolved.valid,
+            "first global-capacity frame did not release scopes"
+        );
+        ReleaseTerminalSubmit(first_submit);
+
+        RecordTimedScope(second_list, "GlobalRecovered");
+        CmdSubmit second_submit = second_list.Submit();
+        Expect(
+            second_submit.query_tokens.size() == 1,
+            "global scope capacity did not recover after pop"
+        );
+        Expect(stream.SealFrame(second), "global-capacity second seal failed");
+        ResolveTimestampAt(second_submit, 0, Timestamp(2, 4));
+        Expect(
+            stream.TryPopFrame(resolved) &&
+                !resolved.valid &&
+                resolved.admitted_scope_count == 1 &&
+                resolved.dropped_scope_count == 1,
+            "global overflow/recovery accounting is incorrect"
+        );
+        const GpuScopeStreamStats stats = stream.GetStats();
+        Expect(
+            stats.scopes_dropped_resident_full == 1 &&
+                stats.scopes_admitted == 3 &&
+                stats.resident_scopes == 0,
+            "global scope capacity counters are inconsistent"
+        );
+        ReleaseTerminalSubmit(second_submit);
+    }
+}
+
+void CapacityFailureSuppressesTheWholeNestedSubtree() {
+    GpuScopeStreamConfig config = SmallConfig();
+    config.max_resident_scopes = 4;
+    config.max_scopes_per_frame = 1;
+    GpuScopeStream stream(config);
+    GpuScopeFrameHandle frame = stream.BeginFrame(5301);
+
+    CommandList list(EQueueType::Graphics);
+    list.SetGpuScopeRecorder(
+        frame.CreateRecorder(
+            QueueBinding(EQueueType::Graphics, 0, 0), 0
+        )
+    );
+    RecordTimedScope(list, "Admitted");
+    list.PushScopeWithTimeScope("OverflowParent");
+    list.PushScopeWithTimeScope("SuppressedChild");
+    list.PushScopeWithTimeScope("SuppressedGrandchild");
+    list.PopScopeWithTimeScope();
+    list.PopScopeWithTimeScope();
+    list.PopScopeWithTimeScope();
+    CmdSubmit submit = list.Submit();
+
+    Expect(
+        submit.query_tokens.size() == 1,
+        "suppressed subtree emitted hidden query pairs"
+    );
+    Expect(
+        stream.SealFrame(frame),
+        "suppressed-subtree frame could not be sealed"
+    );
+    ResolveTimestampAt(submit, 0, Timestamp(0, 1));
+
+    ResolvedGpuScopeFrame resolved{};
+    Expect(
+        stream.TryPopFrame(resolved) &&
+            !resolved.valid &&
+            resolved.admitted_scope_count == 1 &&
+            resolved.dropped_scope_count == 3 &&
+            resolved.queue_roots[0].size() == 1 &&
+            resolved.queue_roots[0].front().name == "Admitted",
+        "suppressed subtree leaked partial hierarchy into the frame"
+    );
+    const GpuScopeStreamStats stats = stream.GetStats();
+    Expect(
+        stats.scopes_attempted == 4 &&
+            stats.scopes_admitted == 1 &&
+            stats.scopes_dropped_frame_full == 1 &&
+            stats.scopes_dropped_suppressed_subtree == 2 &&
+            stats.resident_scopes == 0,
+        "suppressed-subtree accounting or permits are inconsistent"
+    );
+    ReleaseTerminalSubmit(submit);
+}
+
+void DuplicateNamesAndSourceCapacityRemainUnambiguous() {
+    GpuScopeStreamConfig config = SmallConfig();
+    config.max_sources_per_frame = 2;
+    GpuScopeStream stream(config);
+    GpuScopeFrameHandle frame = stream.BeginFrame(6001);
+    const RHIQueueBinding graphics =
+        QueueBinding(EQueueType::Graphics, 0, 0);
+
+    GpuScopeRecorder recorder = frame.CreateRecorder(graphics, 4);
+    Expect(recorder.Valid(), "primary source recorder was rejected");
+    Expect(
+        !frame.CreateRecorder(graphics, 4).Valid(),
+        "duplicate queue/source-order recorder was admitted"
+    );
+    Expect(
+        frame.CreateRecorder(graphics, 5).Valid(),
+        "second unique source recorder was rejected"
+    );
+    Expect(
+        !frame.CreateRecorder(graphics, 6).Valid(),
+        "source capacity was exceeded"
+    );
+
+    CommandList list(EQueueType::Graphics);
+    list.SetGpuScopeRecorder(std::move(recorder));
+    RecordTimedScope(list, "DuplicateName");
+    RecordTimedScope(list, "DuplicateName");
+    CmdSubmit submit = list.Submit();
+    Expect(
+        submit.query_tokens.size() == 2 &&
+            submit.query_tokens[0].Name() == "DuplicateName" &&
+            submit.query_tokens[1].Name() == "DuplicateName",
+        "modern duplicate names were rejected or aliased"
+    );
+    Expect(stream.SealFrame(frame), "duplicate-name frame seal failed");
+    ResolveTimestampAt(submit, 1, Timestamp(20, 22));
+    ResolveTimestampAt(submit, 0, Timestamp(10, 11));
+
+    ResolvedGpuScopeFrame resolved{};
+    Expect(
+        stream.TryPopFrame(resolved) && resolved.valid &&
+            resolved.queue_roots[0].size() == 2,
+        "duplicate-name roots did not materialize independently"
+    );
+    const GpuScopeNode& first = resolved.queue_roots[0][0];
+    const GpuScopeNode& second = resolved.queue_roots[0][1];
+    Expect(
+        first.name == "DuplicateName" &&
+            second.name == "DuplicateName" &&
+            first.scope_id != second.scope_id &&
+            first.local_order < second.local_order,
+        "duplicate names lost independent identity/order"
+    );
+    const GpuScopeStreamStats stats = stream.GetStats();
+    Expect(
+        stats.sources_opened == 2 &&
+            stats.sources_dropped_duplicate_order == 1 &&
+            stats.sources_dropped_capacity == 1,
+        "source capacity/duplicate counters are inconsistent"
+    );
+    ReleaseTerminalSubmit(submit);
+}
+
+void CommandListMoveAndReplacementPreserveTerminalOwnership() {
+    GpuScopeStream stream(SmallConfig());
+    GpuScopeFrameHandle replaced_frame = stream.BeginFrame(7001);
+    GpuScopeFrameHandle incoming_frame = stream.BeginFrame(7002);
+
+    CommandList destination(EQueueType::Graphics);
+    destination.SetGpuScopeRecorder(
+        replaced_frame.CreateRecorder(
+            QueueBinding(EQueueType::Graphics, 0, 0), 0
+        )
+    );
+    destination.PushScopeWithTimeScope("ReplacedListScope");
+
+    CommandList source(EQueueType::Graphics);
+    source.SetGpuScopeRecorder(
+        incoming_frame.CreateRecorder(
+            QueueBinding(EQueueType::Graphics, 0, 0), 0
+        )
+    );
+    source.PushScopeWithTimeScope("MovedOpenScope");
+
+    destination = std::move(source);
+    Expect(
+        destination.HasGpuScopeRecorder() &&
+            !source.HasGpuScopeRecorder(),
+        "CommandList move assignment lost or duplicated its recorder"
+    );
+    destination.PopScopeWithTimeScope();
+    CmdSubmit incoming_submit = destination.Submit();
+
+    Expect(
+        stream.SealFrame(replaced_frame) &&
+            stream.SealFrame(incoming_frame),
+        "CommandList move frames could not be sealed"
+    );
+    ResolveTimestampAt(
+        incoming_submit, 0, Timestamp(100, 110)
+    );
+
+    ResolvedGpuScopeFrame resolved{};
+    Expect(
+        stream.TryPopFrame(resolved) &&
+            resolved.frame_id == 7001 &&
+            resolved.error_scope_count == 1 &&
+            resolved.queue_roots[0].front().error_reason.find(
+                "replaced before submission"
+            ) != std::string::npos,
+        "replaced CommandList scope was not terminally rejected"
+    );
+    Expect(
+        stream.TryPopFrame(resolved) &&
+            resolved.frame_id == 7002 && resolved.valid &&
+            resolved.queue_roots[0].front().name ==
+                "MovedOpenScope",
+        "moved open CommandList scope did not retain its topology"
+    );
+    ReleaseTerminalSubmit(incoming_submit);
+
+    GpuScopeFrameHandle constructed_frame = stream.BeginFrame(7003);
+    CommandList constructed_source(EQueueType::Compute);
+    constructed_source.SetGpuScopeRecorder(
+        constructed_frame.CreateRecorder(
+            QueueBinding(EQueueType::Compute, 8, 3), 1
+        )
+    );
+    constructed_source.PushScopeWithTimeScope("MoveConstructed");
+    CommandList constructed(std::move(constructed_source));
+    constructed.PopScopeWithTimeScope();
+    CmdSubmit constructed_submit = constructed.Submit();
+    Expect(
+        stream.SealFrame(constructed_frame),
+        "move-constructed frame seal failed"
+    );
+    ResolveTimestampAt(
+        constructed_submit, 0, Timestamp(0, 5)
+    );
+    Expect(
+        stream.TryPopFrame(resolved) &&
+            resolved.valid &&
+            resolved.queue_roots[1].front().name ==
+                "MoveConstructed",
+        "CommandList move construction lost its scope"
+    );
+    ReleaseTerminalSubmit(constructed_submit);
+}
+
+void CmdSubmitMoveAndReplacementAreTerminalAndOneShot() {
+    GpuScopeStream stream(SmallConfig());
+    GpuScopeFrameHandle moved_frame = stream.BeginFrame(7101);
+    CommandList moved_list(EQueueType::Graphics);
+    moved_list.SetGpuScopeRecorder(
+        moved_frame.CreateRecorder(
+            QueueBinding(EQueueType::Graphics, 0, 0), 0
+        )
+    );
+    RecordTimedScope(moved_list, "MovedSubmitScope");
+    CmdSubmit source_submit = moved_list.Submit();
+    CmdSubmit moved_submit(std::move(source_submit));
+    Expect(
+        source_submit.query_tokens.empty() &&
+            moved_submit.query_tokens.size() == 1,
+        "CmdSubmit move construction duplicated query ownership"
+    );
+    Expect(stream.SealFrame(moved_frame), "moved submit frame seal failed");
+    ResolveTimestampAt(moved_submit, 0, Timestamp(1, 3));
+
+    ResolvedGpuScopeFrame resolved{};
+    Expect(
+        stream.TryPopFrame(resolved) && resolved.valid &&
+            resolved.queue_roots[0].front().name ==
+                "MovedSubmitScope",
+        "moved CmdSubmit did not retain its completion callback"
+    );
+    ReleaseTerminalSubmit(moved_submit);
+
+    GpuScopeFrameHandle replaced_frame = stream.BeginFrame(7102);
+    CommandList replaced_list(EQueueType::Graphics);
+    replaced_list.SetGpuScopeRecorder(
+        replaced_frame.CreateRecorder(
+            QueueBinding(EQueueType::Graphics, 0, 0), 0
+        )
+    );
+    RecordTimedScope(replaced_list, "ReplacedSubmitScope");
+    CmdSubmit replaced_submit = replaced_list.Submit();
+    QueryToken replaced_token =
+        replaced_submit.query_tokens.front();
+
+    GpuScopeFrameHandle incoming_frame = stream.BeginFrame(7103);
+    CommandList incoming_list(EQueueType::Graphics);
+    incoming_list.SetGpuScopeRecorder(
+        incoming_frame.CreateRecorder(
+            QueueBinding(EQueueType::Graphics, 0, 0), 0
+        )
+    );
+    RecordTimedScope(incoming_list, "IncomingSubmitScope");
+    CmdSubmit incoming_submit = incoming_list.Submit();
+
+    CmdSubmit destination = CommandList(EQueueType::Graphics).Submit();
+    destination = std::move(replaced_submit);
+    destination = std::move(incoming_submit);
+    Expect(
+        stream.SealFrame(replaced_frame) &&
+            stream.SealFrame(incoming_frame),
+        "submit replacement frames could not be sealed"
+    );
+    Expect(
+        !QueryBackendAccess::ResolveTimestamp(
+            replaced_token, Timestamp(0, 1)
+        ),
+        "replaced CmdSubmit query accepted a late Ready"
+    );
+    ResolveTimestampAt(destination, 0, Timestamp(2, 7));
+
+    Expect(
+        stream.TryPopFrame(resolved) &&
+            resolved.frame_id == 7102 &&
+            resolved.error_scope_count == 1 &&
+            resolved.queue_roots[0].front().error_reason.find(
+                "replaced before completion"
+            ) != std::string::npos,
+        "replaced CmdSubmit did not reject exactly once"
+    );
+    Expect(
+        stream.TryPopFrame(resolved) &&
+            resolved.frame_id == 7103 && resolved.valid,
+        "incoming CmdSubmit lost ownership during replacement"
+    );
+    Expect(
+        stream.GetStats().scopes_error == 1,
+        "CmdSubmit replacement counted more than one Error"
+    );
+    ReleaseTerminalSubmit(destination);
+}
+
+void StreamCloseAndDestructionDoNotInvalidateOutstandingCallbacks() {
+    {
+        GpuScopeStream stream(SmallConfig());
+        GpuScopeFrameHandle frame = stream.BeginFrame(8001);
+        CommandList list(EQueueType::Graphics);
+        list.SetGpuScopeRecorder(
+            frame.CreateRecorder(
+                QueueBinding(EQueueType::Graphics, 0, 0), 0
+            )
+        );
+        RecordTimedScope(list, "CloseLifetime");
+        CmdSubmit submit = list.Submit();
+        Expect(stream.SealFrame(frame), "close-lifetime frame seal failed");
+
+        stream.Close();
+        const GpuScopeStreamStats closed = stream.GetStats();
+        Expect(
+            !closed.accepting &&
+                closed.frames_abandoned_on_close == 1 &&
+                closed.resident_frames == 0 &&
+                closed.resident_scopes == 0 &&
+                !stream.BeginFrame(8002).Valid(),
+            "Close did not detach and reject admission"
+        );
+        stream.Close();
+        ResolveTimestampAt(submit, 0, Timestamp(10, 12));
+        ResolvedGpuScopeFrame resolved{};
+        Expect(
+            !stream.TryPopFrame(resolved),
+            "closed stream resurrected an abandoned frame"
+        );
+        ReleaseTerminalSubmit(submit);
+    }
+
+    std::optional<CmdSubmit> outliving_submit{};
+    {
+        GpuScopeStream stream(SmallConfig());
+        GpuScopeFrameHandle frame = stream.BeginFrame(8003);
+        CommandList list(EQueueType::Compute);
+        list.SetGpuScopeRecorder(
+            frame.CreateRecorder(
+                QueueBinding(EQueueType::Compute, 4, 4), 0
+            )
+        );
+        RecordTimedScope(list, "DestroyedStreamLifetime");
+        outliving_submit.emplace(list.Submit());
+        Expect(
+            stream.SealFrame(frame),
+            "destroyed-stream lifetime frame seal failed"
+        );
+    }
+    ResolveTimestampAt(
+        *outliving_submit, 0, Timestamp(20, 25)
+    );
+    ReleaseTerminalSubmit(*outliving_submit);
+    outliving_submit.reset();
+
+    GpuScopeStream move_source(SmallConfig());
+    GpuScopeFrameHandle moved_frame = move_source.BeginFrame(8004);
+    GpuScopeStream move_destination(std::move(move_source));
+    Expect(
+        !move_source.Valid() && move_destination.Valid() &&
+            move_destination.SealFrame(moved_frame),
+        "GpuScopeStream move lost its resident frame"
+    );
+    ResolvedGpuScopeFrame resolved{};
+    Expect(
+        move_destination.TryPopFrame(resolved) &&
+            resolved.frame_id == 8004,
+        "moved GpuScopeStream could not pop its frame"
+    );
+}
+
+void CloseRacesCompletionWithoutResurrectingFrames() {
+    constexpr int race_iterations = 128;
+    for (int iteration = 0; iteration < race_iterations; ++iteration) {
+        GpuScopeStream stream(SmallConfig());
+        GpuScopeFrameHandle frame =
+            stream.BeginFrame(9000 + iteration);
+        CommandList list(EQueueType::Graphics);
+        list.SetGpuScopeRecorder(
+            frame.CreateRecorder(
+                QueueBinding(EQueueType::Graphics, 0, 0), 0
+            )
+        );
+        RecordTimedScope(list, "CloseRace");
+        CmdSubmit submit = list.Submit();
+        QueryToken token = submit.query_tokens.front();
+        Expect(stream.SealFrame(frame), "close-race frame seal failed");
+
+        std::atomic_bool start{false};
+        bool             resolved = false;
+        std::thread close_thread([&] {
+            while (!start.load(std::memory_order_acquire)) {
+                std::this_thread::yield();
+            }
+            stream.Close();
+        });
+        std::thread completion_thread([&] {
+            while (!start.load(std::memory_order_acquire)) {
+                std::this_thread::yield();
+            }
+            resolved = QueryBackendAccess::ResolveTimestamp(
+                token, Timestamp(10, 11)
+            );
+        });
+        start.store(true, std::memory_order_release);
+        close_thread.join();
+        completion_thread.join();
+
+        Expect(
+            resolved &&
+                token.GetFuture().Get().status == QueryStatus::Ready,
+            "Close race prevented the query terminal transition"
+        );
+        const GpuScopeStreamStats stats = stream.GetStats();
+        Expect(
+            !stats.accepting &&
+                stats.resident_frames == 0 &&
+                stats.resident_pending_frames == 0 &&
+                stats.resident_ready_frames == 0 &&
+                stats.resident_scopes == 0 &&
+                stats.frames_abandoned_on_close <= 1,
+            "Close race retained or resurrected bounded state"
+        );
+        ResolvedGpuScopeFrame resolved_frame{};
+        Expect(
+            !stream.TryPopFrame(resolved_frame),
+            "Close race exposed an abandoned frame"
+        );
+        ReleaseTerminalSubmit(submit);
+    }
+}
+
+} // namespace
+
+int main() {
+    static_assert(!std::is_copy_constructible_v<GpuScopeStream>);
+    static_assert(std::is_nothrow_move_constructible_v<GpuScopeStream>);
+    static_assert(std::is_nothrow_move_assignable_v<GpuScopeStream>);
+    static_assert(!std::is_copy_constructible_v<GpuScopeRecorder>);
+    static_assert(std::is_nothrow_move_constructible_v<GpuScopeRecorder>);
+    static_assert(std::is_copy_constructible_v<GpuScopeCompletionTicket>);
+
+    try {
+        ReverseTerminalOrderBuildsNestedHierarchyAndExclusiveTime();
+        FramesPopInBeginOrderAndSealIsOneShot();
+        GraphicsAndComputeRemainIndependentTimestampDomains();
+        ErrorCancelAndRejectAreExactlyOnce();
+        MalformedTimestampPayloadAndTopologyFailClosed();
+        ClosedModernStreamNeverFallsBackToLegacyProfiling();
+        RecorderBindingIsImmutableUntilGenerationReset();
+        SealWaitsForAdmissionsThatAlreadyStarted();
+        FrameAdmissionCapacityIsBoundedAndRecovers();
+        ConcurrentDuplicateFrameAdmissionReservesExactlyOneSlot();
+        PerFrameAndGlobalScopeCapacityAreBoundedAndRecover();
+        CapacityFailureSuppressesTheWholeNestedSubtree();
+        DuplicateNamesAndSourceCapacityRemainUnambiguous();
+        CommandListMoveAndReplacementPreserveTerminalOwnership();
+        CmdSubmitMoveAndReplacementAreTerminalAndOneShot();
+        StreamCloseAndDestructionDoNotInvalidateOutstandingCallbacks();
+        CloseRacesCompletionWithoutResurrectingFrames();
+    } catch (const std::exception& exception) {
+        std::cerr << "RHIGpuScopeContract: "
+                  << exception.what() << '\n';
+        return 1;
+    }
+
+    std::cout << "RHIGpuScopeContract: all checks passed\n";
+    return 0;
+}

--- a/source/test/RHIParallelRecordVulkanTest.cpp
+++ b/source/test/RHIParallelRecordVulkanTest.cpp
@@ -7,6 +7,7 @@
 #include "rhi/RHI.h"
 #include "rhi/RHICommand.h"
 #include "rhi/RHIExecutor.h"
+#include "rhi/RHIGpuScope.h"
 #include "rhi/RHISubmissionPipelinePolicy.h"
 #include "rhi/RHIThreadOwnership.h"
 #include "rhi/vulkan/VulkanCustomCommand.h"
@@ -22,6 +23,7 @@
 #include <atomic>
 #include <array>
 #include <chrono>
+#include <cmath>
 #include <cstddef>
 #include <cstdint>
 #include <cstring>
@@ -1345,7 +1347,8 @@ void ValidateArguments(int _argc, const char** _argv) {
             argument != "--timestamp-query" &&
             argument != "--timestamp-query-success-batch" &&
             argument != "--timestamp-query-mid-failure" &&
-            argument != "--timestamp-query-record-failure") {
+            argument != "--timestamp-query-record-failure" &&
+            argument != "--gpu-scope-stream") {
             throw std::invalid_argument("unsupported argument: " + std::string(argument));
         }
     }
@@ -11383,6 +11386,676 @@ void PrimeGlobalTransientPoolForDispose() {
     }
 }
 
+void RunGpuScopeStreamCompletionAndParallelIsolation() {
+    auto& device = RenderDevice::Get();
+    const RHIQueueTopology topology = device.GetQueueTopology();
+    if (!topology.graphics.available) {
+        LOG_INFO(
+            "[TESTCASE][SKIP] "
+            "name=GpuScopeStreamCompletionAndParallelIsolation "
+            "reason=graphics_queue_unavailable"
+        );
+        return;
+    }
+
+    constexpr uint64 frame_id = 0x5048323142324652ull;
+    constexpr uint64 async_queue_scope = 0x5048323142325343ull;
+    constexpr size_t sibling_copy_count = 8;
+    constexpr uint32 inner_copy_count = 128;
+    constexpr uint32 outer_copy_count = 16;
+    const EBufferUsageFlags usage =
+        EBufferUsageFlags::TRANSFER_SRC |
+        EBufferUsageFlags::TRANSFER_DST;
+
+    std::array<uint32, kElementCount> values{};
+    std::array<uint32, kElementCount> scope_readback{};
+    std::array<
+        std::array<uint32, kElementCount>,
+        sibling_copy_count
+    > sibling_readbacks{};
+    for (uint32 index = 0; index < values.size(); ++index) {
+        values[index] = 0x21B20000u + index * 37u;
+    }
+
+    BufferRef scope_ping = device.CreateBuffer<uint32>(
+        "gpu_scope_stream_ping", kElementCount, usage
+    );
+    BufferRef scope_pong = device.CreateBuffer<uint32>(
+        "gpu_scope_stream_pong", kElementCount, usage
+    );
+    std::array<BufferRef, sibling_copy_count> sibling_sources{};
+    std::array<BufferRef, sibling_copy_count>
+        sibling_destinations{};
+    for (size_t index = 0; index < sibling_copy_count; ++index) {
+        sibling_sources[index] = device.CreateBuffer<uint32>(
+            "gpu_scope_parallel_source_" +
+                std::to_string(index),
+            kElementCount,
+            usage
+        );
+        sibling_destinations[index] =
+            device.CreateBuffer<uint32>(
+                "gpu_scope_parallel_destination_" +
+                    std::to_string(index),
+                kElementCount,
+                usage
+            );
+    }
+    if (!scope_ping || !scope_pong ||
+        std::any_of(
+            sibling_sources.begin(),
+            sibling_sources.end(),
+            [](const BufferRef& _buffer) {
+                return !_buffer;
+            }
+        ) ||
+        std::any_of(
+            sibling_destinations.begin(),
+            sibling_destinations.end(),
+            [](const BufferRef& _buffer) {
+                return !_buffer;
+            }
+        )) {
+        throw std::runtime_error(
+            "failed to allocate GPU scope focused-test buffers"
+        );
+    }
+
+    // Initialize every source outside the observed batch. The query-free
+    // sibling can then consist solely of independent GPU copies, which is the
+    // smallest real workload that proves it remains parallel-record eligible.
+    CommandList initialize(EQueueType::Graphics);
+    initialize.CopyFrom(
+        OwnedBytes(values),
+        scope_ping->GetView(),
+        "GpuScopeInitializePing"
+    );
+    for (size_t index = 0; index < sibling_copy_count; ++index) {
+        initialize.CopyFrom(
+            OwnedBytes(values),
+            sibling_sources[index]->GetView(),
+            "GpuScopeInitializeParallelSource"
+        );
+    }
+    RHIExecutor::Get().Submit(
+        EQueueType::Graphics,
+        initialize.Submit(),
+        ERHIExecSubmitFlags::FlushGPU
+    );
+    RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
+
+    GpuScopeStream stream(GpuScopeStreamConfig{
+        .max_resident_frames = 2,
+        .max_pending_frames = 2,
+        .max_resident_scopes = 16,
+        .max_scopes_per_frame = 8,
+        .max_sources_per_frame = 4,
+        .max_scope_name_bytes = 128,
+        .max_error_reason_bytes = 256,
+    });
+    GpuScopeFrameHandle frame = stream.BeginFrame(frame_id);
+    if (!frame.Valid()) {
+        throw std::runtime_error(
+            "GPU scope focused frame was not admitted"
+        );
+    }
+
+    std::atomic<uint32> callback_errors{0};
+    std::atomic<uint32> completion_callbacks{0};
+    std::array<std::atomic<uint32>, 2> query_callbacks{};
+    std::array<std::atomic<uint32>, 2> ordinary_callbacks{};
+    std::array<std::atomic<uint32>, 2> success_callbacks{};
+    std::array<QueryFuture, 2> scope_futures{};
+
+    CommandList scoped(EQueueType::Graphics);
+    scoped.SetResourceStateOwnership(
+        ERHIResourceStateOwnership::Explicit
+    );
+    scoped.SetGpuScopeRecorder(
+        frame.CreateRecorder(topology.graphics, 0)
+    );
+    GpuCompletionFuture gpu_completion =
+        scoped.TrackGpuCompletion(
+            "Phase21B2GpuScopeCompletion"
+        );
+    gpu_completion.Then(
+        [&](const GpuCompletionResult& _result) {
+            if (GetCurrentRHIThreadRole() !=
+                    ERHIThreadRole::Completion ||
+                _result.status !=
+                    GpuCompletionStatus::Ready) {
+                callback_errors.fetch_add(
+                    1, std::memory_order_relaxed
+                );
+            }
+            completion_callbacks.fetch_add(
+                1, std::memory_order_release
+            );
+        }
+    );
+
+    auto record_ping_pong =
+        [&](CommandList& _commands, uint32 _count) {
+            for (uint32 copy = 0; copy < _count; ++copy) {
+                if ((copy & 1u) == 0) {
+                    _commands.CopyFrom(
+                        scope_ping->GetView(),
+                        scope_pong->GetView(),
+                        "GpuScopePingToPong"
+                    );
+                } else {
+                    _commands.CopyFrom(
+                        scope_pong->GetView(),
+                        scope_ping->GetView(),
+                        "GpuScopePongToPing"
+                    );
+                }
+            }
+        };
+
+    scoped.PushScopeWithTimeScope("Phase21B2Outer");
+    record_ping_pong(scoped, outer_copy_count);
+    scoped.PushScopeWithTimeScope("Phase21B2Inner");
+    record_ping_pong(scoped, inner_copy_count);
+    scoped.PopScopeWithTimeScope();
+    record_ping_pong(scoped, outer_copy_count);
+    scoped.PopScopeWithTimeScope();
+    scoped.CopyFrom(
+        scope_ping->GetView(),
+        WritableBytes(scope_readback),
+        "GpuScopeFocusedReadback"
+    );
+    scoped.AddCallback([&] {
+        const GpuScopeStreamStats stats =
+            stream.GetStats();
+        if (GetCurrentRHIThreadRole() !=
+                ERHIThreadRole::Completion ||
+            completion_callbacks.load(
+                std::memory_order_acquire
+            ) != 1 ||
+            query_callbacks[0].load(
+                std::memory_order_acquire
+            ) != 1 ||
+            query_callbacks[1].load(
+                std::memory_order_acquire
+            ) != 1 ||
+            stats.frames_ready != 1 ||
+            stats.scopes_ready != 2) {
+            callback_errors.fetch_add(
+                1, std::memory_order_relaxed
+            );
+        }
+        ordinary_callbacks[0].fetch_add(
+            1, std::memory_order_release
+        );
+    });
+    scoped.AddSuccessCallback([&] {
+        if (GetCurrentRHIThreadRole() !=
+                ERHIThreadRole::Completion ||
+            ordinary_callbacks[0].load(
+                std::memory_order_acquire
+            ) != 1 ||
+            ordinary_callbacks[1].load(
+                std::memory_order_acquire
+            ) != 1) {
+            callback_errors.fetch_add(
+                1, std::memory_order_relaxed
+            );
+        }
+        success_callbacks[0].fetch_add(
+            1, std::memory_order_release
+        );
+    });
+
+    CmdSubmit scoped_submit = scoped.Submit();
+    if (scoped_submit.query_tokens.size() != 2) {
+        throw std::runtime_error(
+            "nested GPU scopes did not emit two timestamp queries"
+        );
+    }
+    const size_t query_command_count = std::count_if(
+        scoped_submit.cmds.begin(),
+        scoped_submit.cmds.end(),
+        [](const UniquePtr<Command>& _command) {
+            return _command &&
+                   _command->Type() == Command::EType::Query;
+        }
+    );
+    if (query_command_count != 4) {
+        throw std::runtime_error(
+            "nested GPU scopes did not emit two complete query pairs"
+        );
+    }
+
+    scope_futures[0] =
+        scoped_submit.query_tokens[0].GetFuture();
+    scope_futures[1] =
+        scoped_submit.query_tokens[1].GetFuture();
+    for (size_t index = 0; index < scope_futures.size();
+         ++index) {
+        scope_futures[index].Then(
+            [&, index](const QueryResult& _result) {
+                if (GetCurrentRHIThreadRole() !=
+                        ERHIThreadRole::Completion ||
+                    _result.status != QueryStatus::Ready ||
+                    _result.kind != QueryKind::Timestamp ||
+                    std::get_if<TimestampQueryResult>(
+                        &_result.payload
+                    ) == nullptr) {
+                    callback_errors.fetch_add(
+                        1, std::memory_order_relaxed
+                    );
+                }
+                query_callbacks[index].fetch_add(
+                    1, std::memory_order_release
+                );
+            }
+        );
+    }
+    FenceRef scoped_done = device.CreateFence();
+    scoped_submit.SetTranslateExecutionClass(
+        ERHITranslateExecutionClass::Parallel
+    );
+    scoped_submit.SetResourceStateOwnership(
+        ERHIResourceStateOwnership::Explicit
+    );
+    scoped_submit.async_queue_scope = async_queue_scope;
+    scoped_submit.Signal(scoped_done.Get(), 1);
+
+    CommandList sibling(EQueueType::Graphics);
+    sibling.SetResourceStateOwnership(
+        ERHIResourceStateOwnership::Explicit
+    );
+    for (size_t index = 0; index < sibling_copy_count; ++index) {
+        sibling.CopyFrom(
+            sibling_sources[index]->GetView(),
+            sibling_destinations[index]->GetView(),
+            "GpuScopeQueryFreeParallelCopy"
+        );
+    }
+    sibling.AddCallback([&] {
+        if (GetCurrentRHIThreadRole() !=
+            ERHIThreadRole::Completion) {
+            callback_errors.fetch_add(
+                1, std::memory_order_relaxed
+            );
+        }
+        ordinary_callbacks[1].fetch_add(
+            1, std::memory_order_release
+        );
+    });
+    sibling.AddSuccessCallback([&] {
+        if (GetCurrentRHIThreadRole() !=
+                ERHIThreadRole::Completion ||
+            ordinary_callbacks[0].load(
+                std::memory_order_acquire
+            ) != 1 ||
+            ordinary_callbacks[1].load(
+                std::memory_order_acquire
+            ) != 1) {
+            callback_errors.fetch_add(
+                1, std::memory_order_relaxed
+            );
+        }
+        success_callbacks[1].fetch_add(
+            1, std::memory_order_release
+        );
+    });
+    CmdSubmit sibling_submit = sibling.Submit();
+    FenceRef sibling_done = device.CreateFence();
+    sibling_submit.SetTranslateExecutionClass(
+        ERHITranslateExecutionClass::Parallel
+    );
+    sibling_submit.SetResourceStateOwnership(
+        ERHIResourceStateOwnership::Explicit
+    );
+    sibling_submit.async_queue_scope = async_queue_scope;
+    sibling_submit.Signal(sibling_done.Get(), 1);
+
+    if (!stream.SealFrame(frame)) {
+        throw std::runtime_error(
+            "GPU scope focused frame could not be sealed"
+        );
+    }
+    ResolvedGpuScopeFrame premature{};
+    if (stream.TryPopFrame(premature)) {
+        throw std::runtime_error(
+            "GPU scope frame became visible before GPU Completion"
+        );
+    }
+
+    SourceTranslationCapture translation_capture(
+        async_queue_scope, EQueueType::Graphics
+    );
+    ScopedSourceTranslationObserver translation_observer(
+        translation_capture
+    );
+
+    Array<RHIBackendSubmissionBatchEntry> batch{};
+    batch.emplace_back(
+        EQueueType::Graphics, std::move(scoped_submit)
+    );
+    batch.emplace_back(
+        EQueueType::Graphics, std::move(sibling_submit)
+    );
+    RHIExecutor::Get().Submit(
+        std::move(batch), ERHIExecSubmitFlags::FlushGPU
+    );
+    RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
+
+    // Verify the query-free source's actual GPU writes with a separate
+    // SerialControl submission. Keeping readback out of the observed source
+    // preserves the topology under test while preventing planner diagnostics
+    // alone from masking dropped parallel-recorded copies.
+    CommandList verify_sibling_copies(EQueueType::Graphics);
+    verify_sibling_copies.SetTranslateExecutionClass(
+        ERHITranslateExecutionClass::SerialControl
+    );
+    for (size_t index = 0; index < sibling_copy_count; ++index) {
+        verify_sibling_copies.CopyFrom(
+            sibling_destinations[index]->GetView(),
+            WritableBytes(sibling_readbacks[index]),
+            "GpuScopeParallelSiblingReadback"
+        );
+    }
+    RHIExecutor::Get().Submit(
+        EQueueType::Graphics,
+        verify_sibling_copies.Submit(),
+        ERHIExecSubmitFlags::FlushGPU
+    );
+    RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
+
+    const GpuCompletionResult completion_result =
+        gpu_completion.Get();
+    std::array<QueryResult, 2> query_results{
+        scope_futures[0].Get(),
+        scope_futures[1].Get(),
+    };
+    std::array<const TimestampQueryResult*, 2> timestamps{
+        std::get_if<TimestampQueryResult>(
+            &query_results[0].payload
+        ),
+        std::get_if<TimestampQueryResult>(
+            &query_results[1].payload
+        ),
+    };
+    if (completion_result.status !=
+            GpuCompletionStatus::Ready ||
+        timestamps[0] == nullptr ||
+        timestamps[1] == nullptr ||
+        query_results[0].status != QueryStatus::Ready ||
+        query_results[1].status != QueryStatus::Ready ||
+        timestamps[0]->valid_bits == 0 ||
+        timestamps[0]->valid_bits > 64 ||
+        timestamps[1]->valid_bits == 0 ||
+        timestamps[1]->valid_bits > 64 ||
+        timestamps[0]->tick_period_ns <= 0.0 ||
+        timestamps[1]->tick_period_ns <= 0.0 ||
+        timestamps[0]->duration_ns <= 0.0 ||
+        timestamps[1]->duration_ns <= 0.0) {
+        throw std::runtime_error(
+            "real nested GPU scope queries did not resolve valid raw timestamps"
+        );
+    }
+
+    auto signal_succeeded = [](const FenceRef& _fence) {
+        auto* vk_fence = ResourceCast(_fence.Get());
+        return vk_fence != nullptr &&
+               vk_fence->WaitSubmitted(1) &&
+               !_fence->IsRejected(1) &&
+               !vk_fence->IsFailed();
+    };
+    if (!signal_succeeded(scoped_done) ||
+        !signal_succeeded(sibling_done) ||
+        scope_readback != values ||
+        !std::all_of(
+            sibling_readbacks.begin(),
+            sibling_readbacks.end(),
+            [&](const auto& _readback) {
+                return _readback == values;
+            }
+        )) {
+        throw std::runtime_error(
+            "GPU scope focused batch signal, scope readback, or parallel sibling readback failed"
+        );
+    }
+
+    ResolvedGpuScopeFrame resolved{};
+    if (!stream.TryPopFrame(resolved) || !resolved.valid ||
+        resolved.frame_id != frame_id ||
+        resolved.admitted_scope_count != 2 ||
+        resolved.dropped_scope_count != 0 ||
+        resolved.error_scope_count != 0 ||
+        resolved.queue_roots[0].size() != 1 ||
+        !resolved.queue_roots[1].empty() ||
+        !resolved.queue_roots[2].empty()) {
+        throw std::runtime_error(
+            "real GPU scope frame lost readiness, accounting, or queue topology"
+        );
+    }
+
+    const GpuScopeNode& outer =
+        resolved.queue_roots[0].front();
+    if (outer.name != "Phase21B2Outer" ||
+        outer.depth != 0 ||
+        outer.parent_scope_id != 0 ||
+        outer.children.size() != 1) {
+        throw std::runtime_error(
+            "real GPU scope outer hierarchy is invalid"
+        );
+    }
+    const GpuScopeNode& inner = outer.children.front();
+    if (inner.name != "Phase21B2Inner" ||
+        inner.depth != 1 ||
+        inner.parent_scope_id != outer.scope_id ||
+        !inner.children.empty() ||
+        outer.queue_binding != topology.graphics ||
+        inner.queue_binding != topology.graphics ||
+        outer.source_order != 0 ||
+        inner.source_order != 0 ||
+        outer.local_order >= inner.local_order ||
+        outer.status != GpuScopeTerminalStatus::Ready ||
+        inner.status != GpuScopeTerminalStatus::Ready) {
+        throw std::runtime_error(
+            "real GPU scope child hierarchy or timestamp domain is invalid"
+        );
+    }
+
+    auto approximately_equal =
+        [](double _actual, double _expected) {
+        const double scale =
+            std::max(1.0, std::abs(_expected));
+        return std::abs(_actual - _expected) <=
+               scale * 1.0e-9;
+        };
+    auto matches_timestamp =
+        [&](const GpuScopeNode& _node,
+            const QueryResult& _query,
+            const TimestampQueryResult& _timestamp) {
+            return _node.query_id == _query.query_id &&
+                   _node.begin_tick == _timestamp.begin_tick &&
+                   _node.end_tick == _timestamp.end_tick &&
+                   _node.valid_bits == _timestamp.valid_bits &&
+                   approximately_equal(
+                       _node.tick_period_ns,
+                       _timestamp.tick_period_ns
+                   ) &&
+                   approximately_equal(
+                       _node.total_duration_ns,
+                       _timestamp.duration_ns
+                   );
+        };
+    if (!matches_timestamp(
+            outer, query_results[0], *timestamps[0]
+        ) ||
+        !matches_timestamp(
+            inner, query_results[1], *timestamps[1]
+        ) ||
+        !approximately_equal(
+            inner.exclusive_duration_ns,
+            inner.total_duration_ns
+        ) ||
+        !approximately_equal(
+            outer.exclusive_duration_ns,
+            std::max(
+                0.0,
+                outer.total_duration_ns -
+                    inner.total_duration_ns
+            )
+        )) {
+        throw std::runtime_error(
+            "GPU scope raw ticks, duration, or exclusive time changed during materialization"
+        );
+    }
+
+    if (!translation_capture.IsValid() ||
+        !translation_capture.Seen(
+            0, EVulkanSourceTranslationPhase::Begin
+        ) ||
+        !translation_capture.Seen(
+            0, EVulkanSourceTranslationPhase::Recorded
+        ) ||
+        !translation_capture.Seen(
+            1, EVulkanSourceTranslationPhase::Begin
+        ) ||
+        !translation_capture.Seen(
+            1, EVulkanSourceTranslationPhase::Recorded
+        ) ||
+        translation_capture.Seen(
+            0, EVulkanSourceTranslationPhase::Failed
+        ) ||
+        translation_capture.Seen(
+            1, EVulkanSourceTranslationPhase::Failed
+        )) {
+        throw std::runtime_error(
+            "GPU scope focused batch lost source translation diagnostics"
+        );
+    }
+    const VulkanSourceTranslationEvent& query_source =
+        translation_capture.Event(
+            0, EVulkanSourceTranslationPhase::Recorded
+        );
+    const VulkanSourceTranslationEvent& parallel_sibling =
+        translation_capture.Event(
+            1, EVulkanSourceTranslationPhase::Recorded
+        );
+    if (query_source.batch_sequence == 0 ||
+        query_source.batch_sequence !=
+            parallel_sibling.batch_sequence ||
+        query_source.source_index != 0 ||
+        query_source.original_source_index != 0 ||
+        query_source.source_segment_index != 0 ||
+        query_source.source_segment_count != 1 ||
+        query_source.queue != EQueueType::Graphics ||
+        query_source.native_queue_id !=
+            topology.graphics.native_queue_id ||
+        query_source.async_queue_scope !=
+            async_queue_scope ||
+        !query_source.parallel_record_requested ||
+        query_source.parallel_record_planned ||
+        query_source.parallel_record_effective) {
+        throw std::runtime_error(
+            "timestamp-bearing GPU scope source did not remain a query serial island"
+        );
+    }
+    if (parallel_sibling.source_index != 1 ||
+        parallel_sibling.original_source_index != 1 ||
+        parallel_sibling.source_segment_index != 0 ||
+        parallel_sibling.source_segment_count != 1 ||
+        parallel_sibling.queue != EQueueType::Graphics ||
+        parallel_sibling.native_queue_id !=
+            topology.graphics.native_queue_id ||
+        parallel_sibling.async_queue_scope !=
+            async_queue_scope ||
+        !parallel_sibling.parallel_record_requested ||
+        !parallel_sibling.parallel_record_planned ||
+        !parallel_sibling.parallel_record_effective) {
+        throw std::runtime_error(
+            "query-free sibling lost effective parallel recording"
+        );
+    }
+
+    if (callback_errors.load(std::memory_order_acquire) != 0 ||
+        completion_callbacks.load(
+            std::memory_order_acquire
+        ) != 1 ||
+        query_callbacks[0].load(
+            std::memory_order_acquire
+        ) != 1 ||
+        query_callbacks[1].load(
+            std::memory_order_acquire
+        ) != 1 ||
+        ordinary_callbacks[0].load(
+            std::memory_order_acquire
+        ) != 1 ||
+        ordinary_callbacks[1].load(
+            std::memory_order_acquire
+        ) != 1 ||
+        success_callbacks[0].load(
+            std::memory_order_acquire
+        ) != 1 ||
+        success_callbacks[1].load(
+            std::memory_order_acquire
+        ) != 1) {
+        throw std::runtime_error(
+            "GPU scope focused callbacks violated Completion ownership or exactly-once delivery"
+        );
+    }
+
+    RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
+    ResolvedGpuScopeFrame replay{};
+    const GpuScopeStreamStats stats = stream.GetStats();
+    if (stream.TryPopFrame(replay) ||
+        !translation_capture.IsValid() ||
+        callback_errors.load(std::memory_order_acquire) != 0 ||
+        completion_callbacks.load(
+            std::memory_order_acquire
+        ) != 1 ||
+        query_callbacks[0].load(
+            std::memory_order_acquire
+        ) != 1 ||
+        query_callbacks[1].load(
+            std::memory_order_acquire
+        ) != 1 ||
+        ordinary_callbacks[0].load(
+            std::memory_order_acquire
+        ) != 1 ||
+        ordinary_callbacks[1].load(
+            std::memory_order_acquire
+        ) != 1 ||
+        success_callbacks[0].load(
+            std::memory_order_acquire
+        ) != 1 ||
+        success_callbacks[1].load(
+            std::memory_order_acquire
+        ) != 1 ||
+        stats.frames_ready != 1 ||
+        stats.frames_popped != 1 ||
+        stats.scopes_ready != 2 ||
+        stats.resident_frames != 0 ||
+        stats.resident_scopes != 0) {
+        throw std::runtime_error(
+            "a second RHI Sync replayed GPU scope publication or callbacks"
+        );
+    }
+
+    LOG_INFO(
+        "[TESTCASE][PASS] "
+        "name=GpuScopeStreamCompletionAndParallelIsolation "
+        "frame_id={} queue=Graphics scopes=2 hierarchy=nested "
+        "query_source=query-serial-island "
+        "query_free_sibling=parallel-effective "
+        "raw_ticks=verified duration_ns={},{} "
+        "exclusive_ns={},{} owner=Completion "
+        "readback=verified sibling_readbacks=8/8 replay=0",
+        frame_id,
+        outer.total_duration_ns,
+        inner.total_duration_ns,
+        outer.exclusive_duration_ns,
+        inner.exclusive_duration_ns
+    );
+}
+
 void RunTimestampQueryCompletionOwnership() {
     auto& device = RenderDevice::Get();
     const EBufferUsageFlags usage =
@@ -14897,6 +15570,8 @@ int main(int argc, const char** argv) {
             HasArgument(
                 argc, argv, "--timestamp-query-record-failure"
             );
+        const bool gpu_scope_stream_mode =
+            HasArgument(argc, argv, "--gpu-scope-stream");
         const uint32 submission_batch_window =
             pipeline_window1 ? 1u : 2u;
 
@@ -14918,7 +15593,8 @@ int main(int argc, const char** argv) {
                 timestamp_query_mode ||
                 timestamp_query_success_batch_mode ||
                 timestamp_query_mid_failure_mode ||
-                timestamp_query_record_failure_mode,
+                timestamp_query_record_failure_mode ||
+                gpu_scope_stream_mode,
             .parallel_record_workers = 4,
             .parallel_record_verify =
                 parallel || pipeline_window_mode || present_mode ||
@@ -14927,7 +15603,8 @@ int main(int argc, const char** argv) {
                 timestamp_query_mode ||
                 timestamp_query_success_batch_mode ||
                 timestamp_query_mid_failure_mode ||
-                timestamp_query_record_failure_mode,
+                timestamp_query_record_failure_mode ||
+                gpu_scope_stream_mode,
             .parallel_record_min_work_units_per_job = production_gate ? 64u : 1u,
             .submission_batch_window = submission_batch_window,
             .parallel_record_worker_throw_trigger = inject_worker_failure ? 1u : 0u,
@@ -14945,6 +15622,15 @@ int main(int argc, const char** argv) {
 
         if (occlusion_query_mode) {
             RunOcclusionQueryCompletionOwnership();
+            RenderDevice::Dispose();
+            render_device_initialized = false;
+            TaskSystem::ShutDown();
+            task_system_initialized = false;
+            return 0;
+        }
+
+        if (gpu_scope_stream_mode) {
+            RunGpuScopeStreamCompletionAndParallelIsolation();
             RenderDevice::Dispose();
             render_device_initialized = false;
             TaskSystem::ShutDown();


### PR DESCRIPTION
## Summary

- add an explicit, bounded `GpuScopeStream` with fixed frame/FIFO reservations, stable queue/source/local topology, and consumer-side hierarchy materialization
- feed GPU scope terminal state from the existing Query/Completion ownership path without polling, synchronous I/O, or a second terminalization ledger
- integrate modern timed scopes into `CommandList` while preserving legacy profiling when unbound and rejecting legacy/modern mixing within one recording generation
- preserve raw backend timestamp ticks, valid bits, period, total time, and same-domain exclusive time with fail-closed wrap/containment/overlap validation
- add CPU contract coverage plus a real Vulkan focused path proving query serial islands, query-free sibling parallelism, Completion delivery, and eight independent GPU readbacks

## Why

This ports the useful GPU event/scope semantics from `dev_parallel_rhi` onto main's newer QueryFuture, Executor, Submission, and Completion ownership model. It deliberately avoids the old singleton, unbounded queues, query polling, fake CPU/GPU clock mapping, and Completion-thread file I/O.

## Validation

- Debug full CTest: 24/24
- RelWithDebInfo full build and CTest: 24/24
- Python Vulkan runner contract: 134/134
- rebuilt RelWithDebInfo Vulkan matrix: 15/15 modes, 169 PASS, 0 SKIP, 0 FAIL, 0 VUID/Validation Error
- Debug and RelWithDebInfo real Vulkan focused GPU-scope test passed
- Raytracing/Vulkan editor rendered for 70 seconds with RHI thread + parallel recording/verify enabled and no VUID, validation error, device lost, assertion, or crash; the harness later failed to close because it retained a renderer-lifecycle-old HWND

## Integration boundary

A source containing Query commands remains a serial translate island; query-free siblings still translate in parallel. The upper-layer RenderGraph recorder binding after topology split, including multi-segment handling, is intentionally carried into Phase 21C.