### PR TITLE
ProfileDump: add Engine-owned CPU scope capture

### DIFF
--- a/source/runtime/Engine.cpp
+++ b/source/runtime/Engine.cpp
@@ -3,6 +3,9 @@
 // Runtime
 #include "config/ConfigManager.h"
 #include "misc/ScopedLogTimer.h"
+#include "profile/ProfileDump.h"
+#include "profile/ProfileDumpTemplates.h"
+#include "profile/ProfileScope.h"
 #include "remote/RemoteConfig.h"
 #include "remote/RemoteModule.h"
 #include "RenderThread.h"
@@ -25,6 +28,7 @@
 #include <cassert>
 #include <chrono>
 #include <charconv>
+#include <filesystem>
 #include <iterator>
 #include <mutex>
 #include <nfd.hpp>
@@ -536,6 +540,137 @@ Engine::~Engine() {
     ShutDown();
 }
 
+void Engine::InitializeProfileDump() noexcept {
+    const auto& profile_config =
+        ConfigManager::GetInstance().GetConfig().engine.profile_dump;
+    if (!profile_config.enabled) {
+        return;
+    }
+
+    try {
+        std::filesystem::path output_path(profile_config.output_path);
+        if (output_path.empty()) {
+            LOG_WARNING("[ProfileDump] Capture is enabled but output_path is empty; capture disabled.");
+            return;
+        }
+
+        if (output_path.is_relative()) {
+            output_path = ConfigManager::GetInstance().GetWorkspacePath() / output_path;
+        }
+
+        std::error_code path_error;
+        output_path = std::filesystem::weakly_canonical(output_path, path_error);
+        if (path_error) {
+            LOG_WARNING(
+                "[ProfileDump] Failed to resolve output path '{}': {}; capture disabled.",
+                profile_config.output_path,
+                path_error.message()
+            );
+            return;
+        }
+
+        ProfileDump::RuntimeConfig runtime_config;
+        runtime_config.output_path      = output_path;
+        runtime_config.replace_existing = profile_config.replace_existing;
+
+        const ProfileDump::StartResult start_result =
+            ProfileDump::Start(runtime_config);
+        if (start_result != ProfileDump::StartResult::Started) {
+            LOG_WARNING(
+                "[ProfileDump] Start failed (result={}); capture disabled.",
+                static_cast<unsigned int>(start_result)
+            );
+            return;
+        }
+
+        // Ownership is acquired only for a session started by this Engine.
+        // In particular, AlreadyRunning must never adopt an external session.
+        m_profile_dump_owned = true;
+
+        const ProfileDump::SchemaRegistration cpu_scope =
+            ProfileDump::RegisterSchema(ProfileDump::Templates::CpuScope());
+        if ((cpu_scope.status != ProfileDump::SchemaStatus::Registered &&
+             cpu_scope.status != ProfileDump::SchemaStatus::AlreadyRegistered) ||
+            !cpu_scope.handle) {
+            LOG_WARNING(
+                "[ProfileDump] CpuScope schema registration failed (status={}); "
+                "rolling back capture.",
+                static_cast<unsigned int>(cpu_scope.status)
+            );
+            ShutdownProfileDump();
+            return;
+        }
+
+        const ProfileDump::CpuScopeActivationResult activation_result =
+            ProfileDump::CpuScopeProducer::Activate(cpu_scope.handle);
+        if (activation_result != ProfileDump::CpuScopeActivationResult::Activated) {
+            LOG_WARNING(
+                "[ProfileDump] CpuScope producer activation failed (result={}); "
+                "rolling back capture.",
+                static_cast<unsigned int>(activation_result)
+            );
+            ShutdownProfileDump();
+            return;
+        }
+
+        LOG_INFO(
+            "[ProfileDump] Capture started: output='{}', replace_existing={}.",
+            output_path.generic_string(),
+            profile_config.replace_existing
+        );
+    } catch (const std::exception& error) {
+        ShutdownProfileDump();
+        try {
+            LOG_WARNING(
+                "[ProfileDump] Capture initialization failed: {}; capture disabled.",
+                error.what()
+            );
+        } catch (...) {
+        }
+    } catch (...) {
+        ShutdownProfileDump();
+        try {
+            LOG_WARNING("[ProfileDump] Capture initialization failed; capture disabled.");
+        } catch (...) {
+        }
+    }
+}
+
+void Engine::ShutdownProfileDump() noexcept {
+    if (!m_profile_dump_owned) {
+        return;
+    }
+    m_profile_dump_owned = false;
+
+    ProfileDump::CpuScopeProducer::Deactivate();
+    const ProfileDump::FlushResult flush_result =
+        ProfileDump::FlushThreadLocal();
+    const ProfileDump::ShutdownResult shutdown_result =
+        ProfileDump::Shutdown();
+
+    if (shutdown_result == ProfileDump::ShutdownResult::Faulted) {
+        const ProfileDump::RuntimeStats stats = ProfileDump::GetRuntimeStats();
+        try {
+            LOG_WARNING(
+                "[ProfileDump] Capture shutdown faulted (fault={}, flush_result={}).",
+                static_cast<unsigned int>(stats.last_fault),
+                static_cast<unsigned int>(flush_result)
+            );
+        } catch (...) {
+        }
+        return;
+    }
+
+    try {
+        LOG_INFO(
+            "[ProfileDump] Capture stopped (shutdown_result={}, flush_result={}).",
+            static_cast<unsigned int>(shutdown_result),
+            static_cast<unsigned int>(flush_result)
+        );
+    } catch (...) {
+    }
+}
+
 void Engine::Init(
     int                            argc,
     const char**                   argv,
@@ -621,6 +756,8 @@ void Engine::Init(
             "engine.render.default_render_method = \"Raster\""
         );
     }
+
+    InitializeProfileDump();
 
     // Init TaskSystem
     report_startup("Starting worker services", "Creating task-graph worker threads");
@@ -1205,6 +1342,7 @@ void Engine::ShutDown() noexcept {
         m_task_system_initialized = false;
         cleanup([]() { TaskSystem::ShutDown(); });
     }
+    ShutdownProfileDump();
     m_editor_config.reset();
 }
 

--- a/source/runtime/Engine.h
+++ b/source/runtime/Engine.h
@@ -67,6 +67,8 @@ private:
 
     void Init3rdParty();
     void ShutDown3rdParty();
+    void InitializeProfileDump() noexcept;
+    void ShutdownProfileDump() noexcept;
 
     void TickRendererSwitchValidation(Scene& scene);
     void TickRasterLifecycleValidation(Scene& scene);
@@ -87,6 +89,7 @@ private:
     bool m_render_device_initialized   = false;
     bool m_shader_manager_initialized  = false;
     bool m_window_context_initialized  = false;
+    bool m_profile_dump_owned          = false;
 
     // Validation state is accessed only by Game Thread hooks. Render work is drained before reload.
     ERendererSwitchValidationStage m_renderer_switch_validation_stage =

--- a/source/runtime/core/include/config/GlobalConfig.h
+++ b/source/runtime/core/include/config/GlobalConfig.h
@@ -45,6 +45,12 @@ struct CORE_API GlobalConfig {
             uint max_frame_lag           = 0;
         } threading;
 
+        struct ProfileDump {
+            bool        enabled          = false;
+            std::string output_path      = "./profile/MoerProfile.mpd";
+            bool        replace_existing = true;
+        } profile_dump;
+
         struct RHI {
             std::string type;
             std::string api_version;

--- a/source/runtime/core/include/profile/ProfileDump.h
+++ b/source/runtime/core/include/profile/ProfileDump.h
@@ -169,6 +169,7 @@ Emit(SchemaHandle _schema, std::span<const FieldValueView> _values) noexcept;
 [[nodiscard]] CORE_API ShutdownResult Shutdown() noexcept;
 
 [[nodiscard]] CORE_API RuntimeState GetRuntimeState() noexcept;
+[[nodiscard]] CORE_API std::uint64_t GetRuntimeGeneration() noexcept;
 [[nodiscard]] CORE_API RuntimeStats GetRuntimeStats() noexcept;
 
 } // namespace Moer::ProfileDump

--- a/source/runtime/core/include/profile/ProfileScope.h
+++ b/source/runtime/core/include/profile/ProfileScope.h
@@ -1,0 +1,64 @@
+#ifndef MOER_ENGINE_PROFILE_SCOPE_H
+#define MOER_ENGINE_PROFILE_SCOPE_H
+
+#include "API_Macro.h"
+#include "profile/ProfileDump.h"
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <string_view>
+
+namespace Moer::ProfileDump {
+
+enum class CpuScopeActivationResult : std::uint8_t {
+    Activated = 0,
+    AlreadyActive,
+    InvalidHandle,
+    RuntimeNotRunning,
+    StaleGeneration,
+    WrongSchema,
+};
+
+namespace CpuScopeProducer {
+
+[[nodiscard]] CORE_API CpuScopeActivationResult Activate(SchemaHandle _schema) noexcept;
+CORE_API void                                            Deactivate() noexcept;
+[[nodiscard]] CORE_API bool                             IsActive() noexcept;
+
+} // namespace CpuScopeProducer
+
+class CORE_API ScopedCpuProfile final {
+public:
+    static constexpr std::size_t kMaxNameBytes = 256;
+
+    explicit ScopedCpuProfile(std::string_view _name) noexcept;
+    ScopedCpuProfile(std::string_view _prefix, std::string_view _name) noexcept;
+    ~ScopedCpuProfile() noexcept;
+
+    ScopedCpuProfile(const ScopedCpuProfile&)            = delete;
+    ScopedCpuProfile& operator=(const ScopedCpuProfile&) = delete;
+    ScopedCpuProfile(ScopedCpuProfile&&)                 = delete;
+    ScopedCpuProfile& operator=(ScopedCpuProfile&&)      = delete;
+
+private:
+    void Begin(std::string_view _prefix, std::string_view _name, bool _join) noexcept;
+
+    std::array<char, kMaxNameBytes> name_{};
+    SchemaHandle                    schema_{};
+    std::uint64_t                   thread_id_{0};
+    std::uint64_t                   begin_ns_{0};
+    std::uint32_t                   depth_{0};
+    std::uint16_t                   name_bytes_{0};
+    bool                            active_{false};
+};
+
+} // namespace Moer::ProfileDump
+
+#define MOER_PROFILE_DETAIL_JOIN_INNER(Left, Right) Left##Right
+#define MOER_PROFILE_DETAIL_JOIN(Left, Right) MOER_PROFILE_DETAIL_JOIN_INNER(Left, Right)
+#define MOER_PROFILE_SCOPE(Name)                                                                    \
+    ::Moer::ProfileDump::ScopedCpuProfile MOER_PROFILE_DETAIL_JOIN(_moer_profile_scope_, __COUNTER__)(Name)
+#define MOER_PROFILE_FUNCTION() MOER_PROFILE_SCOPE(__func__)
+
+#endif // MOER_ENGINE_PROFILE_SCOPE_H

--- a/source/runtime/core/source/config/GlobalConfig.cpp
+++ b/source/runtime/core/source/config/GlobalConfig.cpp
@@ -54,6 +54,14 @@ GlobalConfig GlobalConfig::LoadConfigFromTomlFile(const std::string_view& toml_p
     loaded_config.engine.threading.max_frame_lag =
         toml_config.at_path("engine.threading.max_frame_lag").value_or(uint{0});
 
+    loaded_config.engine.profile_dump.enabled =
+        toml_config.at_path("engine.profile_dump.enabled").value_or(false);
+    loaded_config.engine.profile_dump.output_path =
+        toml_config.at_path("engine.profile_dump.output_path")
+            .value_or("./profile/MoerProfile.mpd");
+    loaded_config.engine.profile_dump.replace_existing =
+        toml_config.at_path("engine.profile_dump.replace_existing").value_or(true);
+
     loaded_config.engine.rhi.type = toml_config.at_path("engine.rhi.type").value_or("Not Specified");
     loaded_config.engine.rhi.max_frame_in_flight =
         toml_config.at_path("engine.rhi.max_frame_in_flight").value_or(3);

--- a/source/runtime/core/source/profile/ProfileDump.cpp
+++ b/source/runtime/core/source/profile/ProfileDump.cpp
@@ -1570,6 +1570,10 @@ RuntimeState GetRuntimeState() noexcept {
     return GetHub().state.load(std::memory_order_acquire);
 }
 
+std::uint64_t GetRuntimeGeneration() noexcept {
+    return GetHub().generation.load(std::memory_order_acquire);
+}
+
 RuntimeStats GetRuntimeStats() noexcept {
     Hub&         hub = GetHub();
     RuntimeStats stats{};

--- a/source/runtime/core/source/profile/ProfileScope.cpp
+++ b/source/runtime/core/source/profile/ProfileScope.cpp
@@ -1,0 +1,228 @@
+#include "profile/ProfileScope.h"
+
+#include "platform/Platform.h"
+#include "profile/ProfileDumpTemplates.h"
+
+#include <algorithm>
+#include <array>
+#include <atomic>
+#include <chrono>
+#include <cstring>
+#include <limits>
+#include <mutex>
+
+namespace Moer::ProfileDump {
+
+namespace {
+
+std::atomic<std::uint64_t> g_active_schema_hash{0};
+std::atomic<std::uint64_t> g_active_generation{0};
+std::mutex                 g_lifecycle_mutex{};
+
+struct ThreadScopeState {
+    std::uint64_t generation{0};
+    std::uint32_t depth{0};
+};
+
+thread_local ThreadScopeState g_thread_scope_state{};
+
+[[nodiscard]] std::uint64_t CurrentSteadyNanoseconds() noexcept {
+    const auto count =
+        std::chrono::duration_cast<std::chrono::nanoseconds>(
+            std::chrono::steady_clock::now().time_since_epoch()
+        )
+            .count();
+    return count > 0 ? static_cast<std::uint64_t>(count) : 0;
+}
+
+void DisableIfCurrent(std::uint64_t _generation) noexcept {
+    try {
+        std::lock_guard lock(g_lifecycle_mutex);
+        if (g_active_generation.load(std::memory_order_acquire) == _generation) {
+            g_active_generation.store(0, std::memory_order_release);
+            g_active_schema_hash.store(0, std::memory_order_relaxed);
+        }
+    } catch (...) {
+        // A producer failure must never escape a profiling scope destructor.
+        // The generation is the authoritative active flag, so clearing it is
+        // sufficient even if taking the cold-path lifecycle lock failed.
+        std::uint64_t expected = _generation;
+        static_cast<void>(g_active_generation.compare_exchange_strong(
+            expected, 0, std::memory_order_acq_rel, std::memory_order_acquire
+        ));
+    }
+}
+
+} // namespace
+
+namespace CpuScopeProducer {
+
+CpuScopeActivationResult Activate(SchemaHandle _schema) noexcept {
+    try {
+        if (!_schema) {
+            return CpuScopeActivationResult::InvalidHandle;
+        }
+
+        if (GetRuntimeState() != RuntimeState::Running) {
+            return CpuScopeActivationResult::RuntimeNotRunning;
+        }
+
+        if (_schema.generation != GetRuntimeGeneration()) {
+            return CpuScopeActivationResult::StaleGeneration;
+        }
+
+        const std::uint64_t expected_hash = ComputeSchemaHash(Templates::CpuScope());
+        if (_schema.hash != expected_hash) {
+            return CpuScopeActivationResult::WrongSchema;
+        }
+
+        std::lock_guard lock(g_lifecycle_mutex);
+        // Revalidate after serializing producer lifecycle publication. The
+        // ProfileDump runtime owns a separate lifecycle lock and can have
+        // stopped or restarted between the checks above and this cold path.
+        if (GetRuntimeState() != RuntimeState::Running) {
+            return CpuScopeActivationResult::RuntimeNotRunning;
+        }
+        if (_schema.generation != GetRuntimeGeneration()) {
+            return CpuScopeActivationResult::StaleGeneration;
+        }
+
+        const std::uint64_t active_generation =
+            g_active_generation.load(std::memory_order_acquire);
+        const std::uint64_t active_hash =
+            g_active_schema_hash.load(std::memory_order_relaxed);
+        if (active_generation == _schema.generation && active_hash == _schema.hash) {
+            return CpuScopeActivationResult::AlreadyActive;
+        }
+
+        // A runtime owner is expected to deactivate before shutdown, but
+        // replacing a publication from an older generation keeps the public
+        // producer API recoverable if that cleanup was missed.
+        g_active_schema_hash.store(_schema.hash, std::memory_order_relaxed);
+        g_active_generation.store(_schema.generation, std::memory_order_release);
+        return CpuScopeActivationResult::Activated;
+    } catch (...) {
+        return CpuScopeActivationResult::RuntimeNotRunning;
+    }
+}
+
+void Deactivate() noexcept {
+    try {
+        std::lock_guard lock(g_lifecycle_mutex);
+        g_active_generation.store(0, std::memory_order_release);
+        g_active_schema_hash.store(0, std::memory_order_relaxed);
+    } catch (...) {
+        g_active_generation.store(0, std::memory_order_release);
+    }
+}
+
+bool IsActive() noexcept {
+    const std::uint64_t generation = g_active_generation.load(std::memory_order_acquire);
+    const RuntimeState  state      = GetRuntimeState();
+    if (generation == 0 ||
+        (state != RuntimeState::Running && state != RuntimeState::Faulted)) {
+        return false;
+    }
+    return GetRuntimeGeneration() == generation &&
+           g_active_generation.load(std::memory_order_acquire) == generation;
+}
+
+} // namespace CpuScopeProducer
+
+ScopedCpuProfile::ScopedCpuProfile(std::string_view _name) noexcept {
+    Begin({}, _name, false);
+}
+
+ScopedCpuProfile::ScopedCpuProfile(std::string_view _prefix, std::string_view _name) noexcept {
+    Begin(_prefix, _name, true);
+}
+
+void ScopedCpuProfile::Begin(
+    std::string_view _prefix, std::string_view _name, bool _join
+) noexcept {
+    const std::uint64_t generation = g_active_generation.load(std::memory_order_acquire);
+    if (generation == 0) {
+        return;
+    }
+    const std::uint64_t schema_hash = g_active_schema_hash.load(std::memory_order_relaxed);
+    if (schema_hash == 0) {
+        return;
+    }
+
+    std::size_t joined_bytes = _name.size();
+    if (_name.empty()) {
+        return;
+    }
+    if (_join) {
+        if (_prefix.empty() || _prefix.size() >= kMaxNameBytes ||
+            _name.size() > kMaxNameBytes - _prefix.size() - 1) {
+            return;
+        }
+        joined_bytes = _prefix.size() + 1 + _name.size();
+    } else if (_name.size() > kMaxNameBytes) {
+        return;
+    }
+
+    if (g_thread_scope_state.generation != generation) {
+        g_thread_scope_state.generation = generation;
+        g_thread_scope_state.depth      = 0;
+    }
+    if (g_thread_scope_state.depth == std::numeric_limits<std::uint32_t>::max()) {
+        return;
+    }
+
+    if (_join) {
+        std::memcpy(name_.data(), _prefix.data(), _prefix.size());
+        name_[_prefix.size()] = '.';
+        std::memcpy(name_.data() + _prefix.size() + 1, _name.data(), _name.size());
+    } else {
+        std::memcpy(name_.data(), _name.data(), _name.size());
+    }
+
+    schema_      = {.hash = schema_hash, .generation = generation};
+    thread_id_   = static_cast<std::uint64_t>(Platform::GetCurrentThreadID());
+    begin_ns_    = CurrentSteadyNanoseconds();
+    depth_       = g_thread_scope_state.depth;
+    name_bytes_  = static_cast<std::uint16_t>(joined_bytes);
+    ++g_thread_scope_state.depth;
+    active_ = true;
+}
+
+ScopedCpuProfile::~ScopedCpuProfile() noexcept {
+    if (!active_) {
+        return;
+    }
+    active_ = false;
+
+    if (g_thread_scope_state.generation == schema_.generation && g_thread_scope_state.depth != 0) {
+        --g_thread_scope_state.depth;
+    }
+
+    // A scope may outlive the session in which it began. Do not route that
+    // stale handle through a restarted runtime: even a rejected Emit would
+    // charge the new session's dropped-record diagnostics.
+    if (g_active_generation.load(std::memory_order_acquire) != schema_.generation ||
+        GetRuntimeGeneration() != schema_.generation) {
+        return;
+    }
+
+    try {
+        const std::uint64_t end_ns = std::max(CurrentSteadyNanoseconds(), begin_ns_);
+        const std::array<FieldValueView, 5> values = {
+            thread_id_,
+            std::string_view(name_.data(), name_bytes_),
+            begin_ns_,
+            end_ns,
+            depth_,
+        };
+        const EmitStatus status = Emit(schema_, values);
+        if (status == EmitStatus::Disabled || status == EmitStatus::InvalidHandle ||
+            status == EmitStatus::SinkFault) {
+            DisableIfCurrent(schema_.generation);
+        }
+    } catch (...) {
+        DisableIfCurrent(schema_.generation);
+    }
+}
+
+} // namespace Moer::ProfileDump

--- a/source/runtime/render/renderer/raster/RasterRenderer.cpp
+++ b/source/runtime/render/renderer/raster/RasterRenderer.cpp
@@ -26,6 +26,7 @@
 #include "config/ConfigManager.h"
 #include "debug/RenderDocApi.h"
 #include "misc/ScopedLogTimer.h"
+#include "profile/ProfileScope.h"
 #include "renderer/common/UiFrameGraphPass.h"
 #include "rendergraph/RenderGraph.h"
 #include "rhi/RHIExecutor.h"
@@ -315,6 +316,7 @@ RasterFramePacket
 RasterRenderer::PrepareFrame(const SharedPtr<EditorConfig> editor_config, const EngineHooks& hooks) {
     assert(!IsRenderThreadInitialized() || IsCurrentlyGameThread());
     assert(editor_config);
+    MOER_PROFILE_SCOPE("Raster.PrepareFrame");
 
     const bool           profile_logging = IsFramePrepareProfilingEnabled();
     const auto           prepare_started = BeginFramePrepareProfile();
@@ -455,6 +457,7 @@ RasterRenderer::PrepareFrame(const SharedPtr<EditorConfig> editor_config, const 
 
 RasterFrameFeedback RasterRenderer::RenderFrame(RasterFramePacket frame_packet) {
     assert(!IsRenderThreadInitialized() || IsCurrentlyRenderThread());
+    MOER_PROFILE_SCOPE("Raster.RenderFrame");
 
     auto& raster_context = *raster_context_ptr;
     auto scene_extent_request = frame_packet.scene_render_extent;

--- a/source/runtime/render/renderer/raytracing/RaytracingRenderer.cpp
+++ b/source/runtime/render/renderer/raytracing/RaytracingRenderer.cpp
@@ -5,6 +5,7 @@
 #include "config/ConfigManager.h"
 #include "misc/BoundingBox.h"
 #include "misc/Timer.h"
+#include "profile/ProfileScope.h"
 #include "rhi/RHI.h"
 #include "rhi/RHICommand.h"
 #include "rhi/RHIExecutor.h"
@@ -475,6 +476,7 @@ RaytracingFramePacket
 RaytracingRenderer::PrepareFrame(const SharedPtr<EditorConfig> editor_config, const EngineHooks& hooks) {
     assert(IsCurrentlyGameThread());
     assert(editor_config);
+    MOER_PROFILE_SCOPE("Raytracing.PrepareFrame");
 
     const bool            profile_logging = IsFramePrepareProfilingEnabled();
     const auto            prepare_started = BeginFramePrepareProfile();
@@ -628,6 +630,7 @@ RaytracingRenderer::PrepareFrame(const SharedPtr<EditorConfig> editor_config, co
 RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket frame_packet) {
     assert(!IsRenderThreadInitialized() || IsCurrentlyRenderThread());
     assert(runtime_state);
+    MOER_PROFILE_SCOPE("Raytracing.RenderFrame");
 
     auto& state     = *runtime_state;
     auto& ui_config = frame_packet.config;

--- a/source/runtime/render/rendergraph/RenderGraph.cpp
+++ b/source/runtime/render/rendergraph/RenderGraph.cpp
@@ -1,6 +1,7 @@
 #include "rendergraph/RenderGraph.h"
 
 #include "log/LogSystem.h"
+#include "profile/ProfileScope.h"
 #include "rendergraph/RenderGraphCompiler.h"
 #include "rendergraph/RenderGraphLowering.h"
 #include "rhi/RHI.h"
@@ -1242,6 +1243,7 @@ bool RenderGraph::Compile() {
         compile_error = "graph has already executed and cannot be compiled again";
         return false;
     }
+    MOER_PROFILE_SCOPE("RenderGraph.Compile");
     return RenderGraphCompiler(*this).Compile();
 }
 
@@ -1314,6 +1316,7 @@ bool RenderGraph::ExecuteRecording(
         compile_error = "a per-frame RenderGraph can only be executed once";
         return false;
     }
+    MOER_PROFILE_SCOPE("RenderGraph.ExecuteRecording");
 
     struct TransientBindingReleaseGuard {
         RenderGraphTransientAllocator* allocator{nullptr};
@@ -2178,6 +2181,7 @@ bool RenderGraph::ExecuteRecording(
         auto run_job =
             [error, store_error, attach_recording_lifetime](RecordingJob job) mutable {
             RHIThreadRoleScope record_owner(ERHIThreadRole::RecordWorker);
+            ProfileDump::ScopedCpuProfile profile_scope("RenderGraph.Record", job.pass_name);
             ProducerGateGuard producer_gate_guard{.gate = job.completion};
             bool lifetime_attached = false;
             auto attach_lifetime = [&] {

--- a/source/test/CMakeLists.txt
+++ b/source/test/CMakeLists.txt
@@ -16,6 +16,18 @@ set_target_properties(${test_target} PROPERTIES FOLDER ${moer_test_folder})
 add_test(NAME ProfileDumpCoreContract COMMAND $<TARGET_FILE:${test_target}>)
 set_tests_properties(ProfileDumpCoreContract PROPERTIES TIMEOUT 60)
 
+set(test_target TestProfileScopeProducer)
+add_executable(${test_target} "ProfileScopeProducerTest.cpp")
+target_include_directories(${test_target}
+    PRIVATE "${moer_source_dir}/runtime/core/source/profile"
+)
+target_link_libraries(${test_target}
+    PRIVATE Moer::Core
+)
+set_target_properties(${test_target} PROPERTIES FOLDER ${moer_test_folder})
+add_test(NAME ProfileScopeProducerContract COMMAND $<TARGET_FILE:${test_target}>)
+set_tests_properties(ProfileScopeProducerContract PROPERTIES TIMEOUT 60)
+
 set(test_target TestEngineOnly)
 add_executable(${test_target} "TestEngineOnly.cpp")
 target_link_libraries(${test_target}

--- a/source/test/ProfileScopeProducerTest.cpp
+++ b/source/test/ProfileScopeProducerTest.cpp
@@ -1,0 +1,656 @@
+#include "ProfileDumpTesting.h"
+#include "config/GlobalConfig.h"
+#include "profile/ProfileDumpCodec.h"
+#include "profile/ProfileDumpTemplates.h"
+#include "profile/ProfileScope.h"
+#include "taskgraph/TaskSystem.h"
+
+#include <algorithm>
+#include <array>
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <optional>
+#include <span>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <thread>
+#include <type_traits>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+namespace {
+
+using namespace Moer::ProfileDump;
+
+void Expect(bool _condition, std::string_view _message) {
+    if (!_condition) {
+        throw std::runtime_error(std::string(_message));
+    }
+}
+
+class ScopedOutput {
+public:
+    explicit ScopedOutput(std::string_view _stem) {
+        static std::atomic<std::uint64_t> next_id{0};
+        for (std::uint32_t attempt = 0; attempt < 64; ++attempt) {
+            const auto now =
+                static_cast<std::uint64_t>(std::chrono::steady_clock::now().time_since_epoch().count());
+            const std::filesystem::path candidate =
+                std::filesystem::temp_directory_path() /
+                (std::string(_stem) + "-" + std::to_string(now) + "-" +
+                 std::to_string(next_id.fetch_add(1, std::memory_order_relaxed)));
+            std::error_code error;
+            if (std::filesystem::create_directory(candidate, error)) {
+                directory = candidate;
+                path      = directory / "capture.mpds";
+                return;
+            }
+            if (error && error != std::errc::file_exists) {
+                throw std::runtime_error("profile scope fixture directory could not be created");
+            }
+        }
+        throw std::runtime_error("profile scope fixture could not reserve a unique directory");
+    }
+
+    ~ScopedOutput() {
+        CpuScopeProducer::Deactivate();
+        static_cast<void>(Shutdown());
+        std::error_code error;
+        std::filesystem::remove_all(directory, error);
+    }
+
+    std::filesystem::path directory;
+    std::filesystem::path path;
+};
+
+RuntimeConfig MakeRuntimeConfig(const ScopedOutput& _output) {
+    RuntimeConfig config{};
+    config.output_path         = _output.path;
+    config.replace_existing    = false;
+    config.tls_publish_records = 64;
+    config.tls_publish_bytes   = 16 * 1024;
+    config.tls_max_records     = 128;
+    config.tls_max_bytes       = 128 * 1024;
+    config.queue_max_chunks    = 64;
+    config.queue_max_records   = 4096;
+    config.queue_max_bytes     = 4 * 1024 * 1024;
+    return config;
+}
+
+void WriteTextFile(const std::filesystem::path& _path, std::string_view _contents) {
+    std::ofstream stream(_path, std::ios::binary | std::ios::trunc);
+    Expect(stream.is_open(), "profile scope config fixture could not be opened");
+    stream.write(_contents.data(), static_cast<std::streamsize>(_contents.size()));
+    Expect(stream.good(), "profile scope config fixture could not be written");
+}
+
+void ExpectFlushSucceeded(FlushResult _result, std::string_view _message) {
+    Expect(_result == FlushResult::Completed || _result == FlushResult::NothingPending, _message);
+}
+
+SchemaHandle StartCpuProducer(const RuntimeConfig& _config) {
+    const StartResult start_result = Start(_config);
+    if (start_result != StartResult::Started) {
+        throw std::runtime_error(
+            "ProfileDump runtime failed to start (result=" +
+            std::to_string(static_cast<unsigned int>(start_result)) + ")"
+        );
+    }
+    const SchemaRegistration registration = RegisterSchema(Templates::CpuScope());
+    Expect(
+        registration.status == SchemaStatus::Registered,
+        "CpuScope schema failed to register"
+    );
+    Expect(
+        CpuScopeProducer::Activate(registration.handle) == CpuScopeActivationResult::Activated,
+        "CpuScope producer failed to activate"
+    );
+    return registration.handle;
+}
+
+void StopCpuProducer() {
+    CpuScopeProducer::Deactivate();
+    ExpectFlushSucceeded(FlushThreadLocal(), "producer TLS failed to flush");
+    Expect(Shutdown() == ShutdownResult::Completed, "ProfileDump runtime failed to shut down");
+}
+
+std::vector<std::uint8_t> ReadBinaryFile(const std::filesystem::path& _path) {
+    std::ifstream stream(_path, std::ios::binary | std::ios::ate);
+    Expect(stream.is_open(), "profile scope output could not be opened");
+    const std::streamoff size = stream.tellg();
+    Expect(size >= 0, "profile scope output size is invalid");
+    std::vector<std::uint8_t> bytes(static_cast<std::size_t>(size));
+    stream.seekg(0);
+    if (!bytes.empty()) {
+        stream.read(reinterpret_cast<char*>(bytes.data()), static_cast<std::streamsize>(bytes.size()));
+    }
+    Expect(stream.good() || stream.eof(), "profile scope output could not be read");
+    return bytes;
+}
+
+struct ParsedDump {
+    std::vector<SchemaDescriptor> schemas;
+    std::vector<DecodedRecord>    records;
+};
+
+ParsedDump ParseDump(const std::filesystem::path& _path, const CodecLimits& _limits) {
+    const std::vector<std::uint8_t> bytes = ReadBinaryFile(_path);
+    Expect(!bytes.empty(), "profile scope output is empty");
+
+    ParsedDump  parsed;
+    std::size_t offset = 0;
+    while (offset < bytes.size()) {
+        PacketView  packet{};
+        std::size_t consumed = 0;
+        Expect(
+            DecodePacket(std::span<const std::uint8_t>(bytes).subspan(offset), _limits, packet, consumed) ==
+                DecodeStatus::Ok,
+            "profile scope packet failed validation"
+        );
+        Expect(consumed != 0, "profile scope decoder made no progress");
+
+        if (packet.header.type == PacketType::Schema) {
+            SchemaDescriptor schema{};
+            Expect(
+                DecodeSchemaPayload(packet, _limits, schema) == DecodeStatus::Ok,
+                "profile scope schema failed to decode"
+            );
+            parsed.schemas.push_back(std::move(schema));
+        } else if (packet.header.type == PacketType::Record) {
+            DecodedRecord record{};
+            bool          decoded = false;
+            for (const SchemaDescriptor& schema : parsed.schemas) {
+                if (DecodeRecordPayload(packet, schema, _limits, record) == DecodeStatus::Ok) {
+                    decoded = true;
+                    break;
+                }
+            }
+            Expect(decoded, "profile scope record did not match a preceding schema");
+            parsed.records.push_back(std::move(record));
+        }
+        offset += consumed;
+    }
+    return parsed;
+}
+
+struct CpuRecordView {
+    std::uint64_t thread_id{0};
+    std::string_view name{};
+    std::uint64_t begin_ns{0};
+    std::uint64_t end_ns{0};
+    std::uint32_t depth{0};
+};
+
+CpuRecordView ViewCpuRecord(const DecodedRecord& _record) {
+    Expect(_record.values.size() == 5, "CpuScope record has the wrong field count");
+    return {
+        .thread_id = std::get<std::uint64_t>(_record.values[0]),
+        .name      = std::get<ProfileString>(_record.values[1]),
+        .begin_ns  = std::get<std::uint64_t>(_record.values[2]),
+        .end_ns    = std::get<std::uint64_t>(_record.values[3]),
+        .depth     = std::get<std::uint32_t>(_record.values[4]),
+    };
+}
+
+const DecodedRecord& FindRecord(const ParsedDump& _dump, std::string_view _name) {
+    const auto found = std::find_if(_dump.records.begin(), _dump.records.end(), [&](const auto& _record) {
+        return ViewCpuRecord(_record).name == _name;
+    });
+    Expect(found != _dump.records.end(), "expected CpuScope record was not found");
+    return *found;
+}
+
+SchemaDescriptor MakeWrongSchema() {
+    return {
+        .name           = "WrongCpuScope",
+        .event_type     = "contract.wrong_cpu_scope",
+        .kind           = EventKind::Instant,
+        .channel        = Channel::CpuThread,
+        .schema_version = 1,
+        .fields         = {{"value", FieldType::UInt64}},
+    };
+}
+
+void TestProfileDumpConfigParsing() {
+    ScopedOutput output("moer-profile-scope-config");
+
+    const std::filesystem::path defaults_path = output.directory / "defaults.toml";
+    WriteTextFile(defaults_path, "[engine]\n");
+    const Moer::Config::GlobalConfig defaults =
+        Moer::Config::GlobalConfig::LoadConfigFromTomlFile(defaults_path.generic_string());
+    Expect(!defaults.engine.profile_dump.enabled, "profile dump default must remain disabled");
+    Expect(
+        defaults.engine.profile_dump.output_path == "./profile/MoerProfile.mpd",
+        "profile dump default output path changed"
+    );
+    Expect(
+        defaults.engine.profile_dump.replace_existing,
+        "profile dump default replacement policy changed"
+    );
+
+    const std::filesystem::path explicit_path = output.directory / "explicit.toml";
+    WriteTextFile(
+        explicit_path,
+        "[engine.profile_dump]\n"
+        "enabled = true\n"
+        "output_path = \"./capture/custom.mpd\"\n"
+        "replace_existing = false\n"
+    );
+    const Moer::Config::GlobalConfig explicit_config =
+        Moer::Config::GlobalConfig::LoadConfigFromTomlFile(explicit_path.generic_string());
+    Expect(explicit_config.engine.profile_dump.enabled, "profile dump enabled flag was not parsed");
+    Expect(
+        explicit_config.engine.profile_dump.output_path == "./capture/custom.mpd",
+        "profile dump output path was not parsed"
+    );
+    Expect(
+        !explicit_config.engine.profile_dump.replace_existing,
+        "profile dump replacement policy was not parsed"
+    );
+}
+
+void TestDisabledAndActivationValidation() {
+    static_assert(!std::is_copy_constructible_v<ScopedCpuProfile>);
+    static_assert(!std::is_move_constructible_v<ScopedCpuProfile>);
+    static_assert(ScopedCpuProfile::kMaxNameBytes == 256);
+
+    CpuScopeProducer::Deactivate();
+    Expect(!CpuScopeProducer::IsActive(), "producer began active");
+    { MOER_PROFILE_SCOPE("Disabled.BeforeRuntime"); }
+    const SchemaHandle plausible{
+        .hash       = ComputeSchemaHash(Templates::CpuScope()),
+        .generation = 1,
+    };
+    Expect(
+        CpuScopeProducer::Activate({}) == CpuScopeActivationResult::InvalidHandle,
+        "producer accepted an empty handle"
+    );
+    Expect(
+        CpuScopeProducer::Activate(plausible) == CpuScopeActivationResult::RuntimeNotRunning,
+        "producer activated without a running runtime"
+    );
+
+    ScopedOutput        output("moer-profile-scope-activation");
+    const RuntimeConfig config = MakeRuntimeConfig(output);
+    Expect(Start(config) == StartResult::Started, "activation runtime failed to start");
+    { ScopedCpuProfile disabled("Disabled.WhileRunning"); }
+
+    const SchemaRegistration wrong = RegisterSchema(MakeWrongSchema());
+    const SchemaRegistration cpu   = RegisterSchema(Templates::CpuScope());
+    Expect(wrong.status == SchemaStatus::Registered, "wrong-schema fixture failed to register");
+    Expect(cpu.status == SchemaStatus::Registered, "CpuScope fixture failed to register");
+    Expect(
+        CpuScopeProducer::Activate(
+            {.hash = cpu.handle.hash, .generation = cpu.handle.generation + 1}
+        ) == CpuScopeActivationResult::StaleGeneration,
+        "producer accepted a stale generation"
+    );
+    Expect(
+        CpuScopeProducer::Activate(wrong.handle) == CpuScopeActivationResult::WrongSchema,
+        "producer accepted a different schema"
+    );
+    Expect(
+        CpuScopeProducer::Activate(cpu.handle) == CpuScopeActivationResult::Activated,
+        "valid CpuScope handle did not activate"
+    );
+    Expect(CpuScopeProducer::IsActive(), "producer did not publish active state");
+    Expect(
+        CpuScopeProducer::Activate(cpu.handle) == CpuScopeActivationResult::AlreadyActive,
+        "duplicate activation was not idempotent"
+    );
+    { ScopedCpuProfile valid("Enabled.AfterActivation"); }
+    StopCpuProducer();
+
+    const ParsedDump dump = ParseDump(output.path, config.codec_limits);
+    Expect(dump.records.size() == 1, "disabled scopes emitted records");
+    Expect(
+        ViewCpuRecord(dump.records.front()).name == "Enabled.AfterActivation",
+        "enabled scope emitted the wrong name"
+    );
+}
+
+void TestNestedDecode() {
+    ScopedOutput        output("moer-profile-scope-nested");
+    const RuntimeConfig config = MakeRuntimeConfig(output);
+    static_cast<void>(StartCpuProducer(config));
+    {
+        MOER_PROFILE_SCOPE("Nested.Outer");
+        { ScopedCpuProfile inner("Nested", "Inner"); }
+    }
+    StopCpuProducer();
+
+    const ParsedDump dump = ParseDump(output.path, config.codec_limits);
+    Expect(dump.schemas.size() == 1, "nested capture wrote the wrong schema count");
+    Expect(dump.schemas.front() == Templates::CpuScope(), "nested capture schema drifted");
+    Expect(dump.records.size() == 2, "nested capture wrote the wrong record count");
+
+    const CpuRecordView outer = ViewCpuRecord(FindRecord(dump, "Nested.Outer"));
+    const CpuRecordView inner = ViewCpuRecord(FindRecord(dump, "Nested.Inner"));
+    Expect(outer.thread_id != 0 && inner.thread_id == outer.thread_id, "nested thread id changed");
+    Expect(outer.depth == 0 && inner.depth == 1, "nested TLS depth is incorrect");
+    Expect(
+        outer.begin_ns <= inner.begin_ns && inner.end_ns <= outer.end_ns,
+        "nested timestamps are not contained"
+    );
+    Expect(outer.end_ns >= outer.begin_ns && inner.end_ns >= inner.begin_ns, "scope duration reversed");
+}
+
+void TestMultithreadedTlsDepth() {
+    ScopedOutput        output("moer-profile-scope-threads");
+    const RuntimeConfig config = MakeRuntimeConfig(output);
+    static_cast<void>(StartCpuProducer(config));
+
+    constexpr std::size_t thread_count = 4;
+    std::vector<std::jthread> threads;
+    threads.reserve(thread_count);
+    for (std::size_t index = 0; index < thread_count; ++index) {
+        threads.emplace_back([index] {
+            const std::string suffix = std::to_string(index);
+            ScopedCpuProfile outer("Thread.Outer." + suffix);
+            ScopedCpuProfile inner("Thread.Inner." + suffix);
+        });
+    }
+    threads.clear();
+    StopCpuProducer();
+
+    const ParsedDump dump = ParseDump(output.path, config.codec_limits);
+    Expect(dump.records.size() == thread_count * 2, "multithreaded capture lost a scope");
+    std::unordered_set<std::uint64_t> thread_ids;
+    for (std::size_t index = 0; index < thread_count; ++index) {
+        const std::string   suffix = std::to_string(index);
+        const CpuRecordView outer = ViewCpuRecord(FindRecord(dump, "Thread.Outer." + suffix));
+        const CpuRecordView inner = ViewCpuRecord(FindRecord(dump, "Thread.Inner." + suffix));
+        Expect(outer.thread_id == inner.thread_id, "one thread changed id between nested scopes");
+        Expect(outer.depth == 0 && inner.depth == 1, "TLS depth leaked between producer threads");
+        thread_ids.insert(outer.thread_id);
+    }
+    Expect(thread_ids.size() == thread_count, "worker scopes did not retain distinct thread ids");
+}
+
+void TestRestartRejectsStaleScope() {
+    ScopedOutput        first_output("moer-profile-scope-stale-first");
+    const RuntimeConfig first_config = MakeRuntimeConfig(first_output);
+    const SchemaHandle  first_handle = StartCpuProducer(first_config);
+    std::optional<ScopedCpuProfile> stale_scope;
+    stale_scope.emplace("Stale.OldSession");
+    CpuScopeProducer::Deactivate();
+    Expect(Shutdown() == ShutdownResult::Completed, "first stale-session shutdown failed");
+
+    ScopedOutput        second_output("moer-profile-scope-stale-second");
+    const RuntimeConfig second_config = MakeRuntimeConfig(second_output);
+    const SchemaHandle  second_handle = StartCpuProducer(second_config);
+    Expect(
+        second_handle.generation != first_handle.generation,
+        "ProfileDump restart reused a producer generation"
+    );
+    { ScopedCpuProfile current("Fresh.BeforeStaleDestructor"); }
+    stale_scope.reset();
+    Expect(
+        CpuScopeProducer::IsActive(),
+        "stale destructor disabled the restarted producer"
+    );
+    Expect(
+        GetRuntimeStats().records_dropped_stale_generation == 0,
+        "stale destructor charged the restarted session"
+    );
+    { ScopedCpuProfile current("Fresh.AfterStaleDestructor"); }
+    StopCpuProducer();
+
+    const ParsedDump dump = ParseDump(second_output.path, second_config.codec_limits);
+    Expect(dump.records.size() == 2, "stale generation polluted the restarted capture");
+    static_cast<void>(FindRecord(dump, "Fresh.BeforeStaleDestructor"));
+    static_cast<void>(FindRecord(dump, "Fresh.AfterStaleDestructor"));
+}
+
+void TestRestartReplacesStaleProducerPublication() {
+    ScopedOutput        first_output("moer-profile-scope-stale-publication-first");
+    const RuntimeConfig first_config = MakeRuntimeConfig(first_output);
+    const SchemaHandle  first_handle = StartCpuProducer(first_config);
+    std::optional<ScopedCpuProfile> stale_scope;
+    stale_scope.emplace("Stale.BeforeMissedDeactivate");
+    Expect(
+        Shutdown() == ShutdownResult::Completed,
+        "stale-publication first runtime failed to shut down"
+    );
+    Expect(
+        !CpuScopeProducer::IsActive(),
+        "producer reported an old stopped generation as active"
+    );
+
+    ScopedOutput        second_output("moer-profile-scope-stale-publication-second");
+    const RuntimeConfig second_config = MakeRuntimeConfig(second_output);
+    Expect(Start(second_config) == StartResult::Started, "stale-publication restart failed");
+    stale_scope.reset();
+    Expect(
+        GetRuntimeStats().records_dropped_stale_generation == 0,
+        "old scope charged the restarted runtime before producer activation"
+    );
+    const SchemaRegistration second_schema = RegisterSchema(Templates::CpuScope());
+    Expect(
+        second_schema.status == SchemaStatus::Registered &&
+            second_schema.handle.generation != first_handle.generation,
+        "stale-publication restart did not create a new schema generation"
+    );
+    Expect(
+        CpuScopeProducer::Activate(second_schema.handle) ==
+            CpuScopeActivationResult::Activated,
+        "new generation could not replace stale producer publication"
+    );
+    { ScopedCpuProfile current("Fresh.AfterMissedDeactivate"); }
+    StopCpuProducer();
+
+    const ParsedDump dump = ParseDump(second_output.path, second_config.codec_limits);
+    Expect(dump.records.size() == 1, "stale producer publication polluted the restarted session");
+    static_cast<void>(FindRecord(dump, "Fresh.AfterMissedDeactivate"));
+}
+
+void TestNameBoundariesAndDepthRecovery() {
+    ScopedOutput        output("moer-profile-scope-names");
+    const RuntimeConfig config = MakeRuntimeConfig(output);
+    static_cast<void>(StartCpuProducer(config));
+
+    const std::string accepted(ScopedCpuProfile::kMaxNameBytes, 'a');
+    const std::string rejected(ScopedCpuProfile::kMaxNameBytes + 1, 'b');
+    { ScopedCpuProfile scope(accepted); }
+    {
+        ScopedCpuProfile ignored(rejected);
+        ScopedCpuProfile recovered("Name.AfterRejected");
+    }
+    {
+        ScopedCpuProfile ignored("");
+        ScopedCpuProfile recovered("Name.AfterEmpty");
+    }
+    {
+        const std::string prefix(100, 'p');
+        const std::string name(155, 'n');
+        ScopedCpuProfile  joined(prefix, name);
+    }
+    {
+        const std::string prefix(100, 'q');
+        const std::string name(156, 'n');
+        ScopedCpuProfile  ignored(prefix, name);
+        ScopedCpuProfile  recovered("Name.AfterRejectedPrefix");
+    }
+    StopCpuProducer();
+
+    const ParsedDump dump = ParseDump(output.path, config.codec_limits);
+    Expect(dump.records.size() == 5, "name validation accepted or rejected the wrong boundary");
+    Expect(ViewCpuRecord(FindRecord(dump, accepted)).depth == 0, "256-byte name changed depth");
+    Expect(
+        ViewCpuRecord(FindRecord(dump, "Name.AfterRejected")).depth == 0,
+        "257-byte name leaked TLS depth"
+    );
+    Expect(
+        ViewCpuRecord(FindRecord(dump, "Name.AfterEmpty")).depth == 0,
+        "empty name leaked TLS depth"
+    );
+    Expect(
+        ViewCpuRecord(FindRecord(dump, std::string(100, 'p') + "." + std::string(155, 'n'))).depth == 0,
+        "256-byte joined name was rejected"
+    );
+    Expect(
+        ViewCpuRecord(FindRecord(dump, "Name.AfterRejectedPrefix")).depth == 0,
+        "oversized joined name leaked TLS depth"
+    );
+}
+
+class TaskSystemGuard {
+public:
+    TaskSystemGuard() {
+        Moer::TaskSystem::Init();
+        active_ = true;
+    }
+    ~TaskSystemGuard() {
+        if (active_) {
+            Moer::TaskSystem::ShutDown();
+        }
+    }
+    void Shutdown() {
+        if (active_) {
+            Moer::TaskSystem::ShutDown();
+            active_ = false;
+        }
+    }
+
+private:
+    bool active_{false};
+};
+
+class WriterResumeGuard {
+public:
+    ~WriterResumeGuard() {
+        if (active_) {
+            Testing::ResumeWriter();
+        }
+    }
+
+    void Resume() {
+        if (active_) {
+            Testing::ResumeWriter();
+            active_ = false;
+        }
+    }
+
+private:
+    bool active_{true};
+};
+
+void TestTaskSystemShutdownPublishesWorkerTls() {
+    ScopedOutput  output("moer-profile-scope-task-shutdown");
+    RuntimeConfig config = MakeRuntimeConfig(output);
+    config.tls_publish_records = 64;
+    static_cast<void>(StartCpuProducer(config));
+
+    TaskSystemGuard task_system;
+    GraphEventRef event = LambdaTask::Dispatch([] {
+        ScopedCpuProfile outer("Task.Worker.Outer");
+        ScopedCpuProfile inner("Task.Worker.Inner");
+    });
+    event->Wait();
+    task_system.Shutdown();
+
+    StopCpuProducer();
+    const ParsedDump dump = ParseDump(output.path, config.codec_limits);
+    Expect(dump.records.size() == 2, "TaskSystem shutdown did not publish worker TLS");
+    Expect(
+        ViewCpuRecord(FindRecord(dump, "Task.Worker.Outer")).depth == 0 &&
+            ViewCpuRecord(FindRecord(dump, "Task.Worker.Inner")).depth == 1,
+        "TaskSystem worker depth changed"
+    );
+}
+
+void TestQueueFullDoesNotDisableProducer() {
+    Testing::ClearHooks();
+    Expect(
+        Testing::ConfigureWriterPauseAfterStart(true),
+        "writer pause hook could not be configured"
+    );
+    WriterResumeGuard resume_guard;
+
+    ScopedOutput  output("moer-profile-scope-queue-full");
+    RuntimeConfig config = MakeRuntimeConfig(output);
+    config.max_record_bytes    = 4096;
+    config.tls_publish_records = 1;
+    config.tls_publish_bytes   = 4096;
+    config.tls_max_records     = 1;
+    config.tls_max_bytes       = 4096;
+    config.queue_max_chunks    = 1;
+    config.queue_max_records   = 1;
+    config.queue_max_bytes     = 4096;
+    static_cast<void>(StartCpuProducer(config));
+    Expect(Testing::WaitForWriterPaused(2000), "writer did not reach the queue-full pause point");
+
+    { ScopedCpuProfile accepted("QueueFull.Accepted"); }
+    { ScopedCpuProfile dropped("QueueFull.Dropped"); }
+    Expect(
+        CpuScopeProducer::IsActive(),
+        "bounded queue pressure disabled the CPU producer"
+    );
+
+    resume_guard.Resume();
+    ExpectFlushSucceeded(FlushAll(), "queue-full recovery did not drain accepted work");
+    { ScopedCpuProfile recovered("QueueFull.Recovered"); }
+    StopCpuProducer();
+    Testing::ClearHooks();
+
+    const ParsedDump dump = ParseDump(output.path, config.codec_limits);
+    Expect(dump.records.size() == 2, "queue-full recovery wrote the wrong record count");
+    static_cast<void>(FindRecord(dump, "QueueFull.Accepted"));
+    static_cast<void>(FindRecord(dump, "QueueFull.Recovered"));
+}
+
+void TestFaultSelfDisables() {
+    Testing::ClearHooks();
+    Expect(
+        Testing::ConfigureFault(Testing::FaultPoint::WritePacket, 2),
+        "writer fault hook could not be configured"
+    );
+
+    ScopedOutput  output("moer-profile-scope-fault");
+    RuntimeConfig config = MakeRuntimeConfig(output);
+    config.tls_publish_records = 1;
+    static_cast<void>(StartCpuProducer(config));
+    { ScopedCpuProfile first("Fault.Trigger"); }
+    Expect(FlushAll() == FlushResult::Faulted, "writer fault did not become observable");
+    Expect(CpuScopeProducer::IsActive(), "producer stopped before observing an Emit failure");
+    { ScopedCpuProfile second("Fault.Observe"); }
+    Expect(!CpuScopeProducer::IsActive(), "sink fault did not self-disable the producer");
+    { ScopedCpuProfile ignored("Fault.AfterDisable"); }
+    Expect(Shutdown() == ShutdownResult::Faulted, "faulted writer shutdown reported success");
+    Testing::ClearHooks();
+}
+
+} // namespace
+
+int main() {
+    try {
+        TestProfileDumpConfigParsing();
+        TestDisabledAndActivationValidation();
+        TestNestedDecode();
+        TestMultithreadedTlsDepth();
+        TestRestartRejectsStaleScope();
+        TestRestartReplacesStaleProducerPublication();
+        TestNameBoundariesAndDepthRecovery();
+        TestTaskSystemShutdownPublishesWorkerTls();
+        TestQueueFullDoesNotDisableProducer();
+        TestFaultSelfDisables();
+        std::cout << "ProfileScope producer contract tests passed." << std::endl;
+        return EXIT_SUCCESS;
+    } catch (const std::exception& error) {
+        CpuScopeProducer::Deactivate();
+        if (TaskGraph::IsInitialized()) {
+            Moer::TaskSystem::ShutDown();
+        }
+        static_cast<void>(Shutdown());
+        Testing::ClearHooks();
+        std::cerr << "ProfileScope producer contract test failed: " << error.what() << std::endl;
+        return EXIT_FAILURE;
+    }
+}

--- a/template.MoerEngine.toml
+++ b/template.MoerEngine.toml
@@ -31,6 +31,12 @@ parallel_record_min_work_units_per_job = 64
 # If Graphics and Compute alias the same native queue, the effective window is 1.
 submission_batch_window = 2
 
+[engine.profile_dump]
+enabled = false
+output_path = "./profile/MoerProfile.mpd"
+# The previous final capture is replaced only after the new capture closes successfully.
+replace_existing = true
+
 [engine.rhi]
 type = "Vulkan"
 api_version = "1.3"


### PR DESCRIPTION
## Summary
- add Engine-owned ProfileDump startup/shutdown with configurable fail-soft output handling
- add generation-aware, bounded CPU scope producer and instrument Raster, Raytracing, and RenderGraph paths
- add contract coverage for restart/stale scopes, worker TLS, queue pressure, writer faults, and config parsing

## Validation
- Debug build and CTest: 25/25
- RelWithDebInfo build and CTest: 25/25
- parallel-record Python contracts: 146/146
- enabled Vulkan/Raster Editor smoke: normal shutdown, final decodable MPD, 6744 CPU scopes, 0 drops, no inprogress residue
- disabled Editor smoke: normal shutdown and no capture artifact

## Scope note
TaskGraph partial-construction exception safety remains a separately documented conditional gap and is intentionally not bundled into this stage.