### PR TITLE
Phase 21C.2a: add Engine-owned GPU profile bridge

### DIFF
--- a/source/runtime/Engine.cpp
+++ b/source/runtime/Engine.cpp
@@ -5,6 +5,7 @@
 #include "misc/ScopedLogTimer.h"
 #include "profile/ProfileDump.h"
 #include "profile/ProfileDumpTemplates.h"
+#include "profile/RenderProfileCapture.h"
 #include "profile/ProfileScope.h"
 #include "remote/RemoteConfig.h"
 #include "remote/RemoteModule.h"
@@ -613,6 +614,8 @@ void Engine::InitializeProfileDump() noexcept {
             return;
         }
 
+        InitializeRenderProfileCapture();
+
         LOG_INFO(
             "[ProfileDump] Capture started: output='{}', replace_existing={}.",
             output_path.generic_string(),
@@ -636,7 +639,141 @@ void Engine::InitializeProfileDump() noexcept {
     }
 }
 
+void Engine::InitializeRenderProfileCapture() noexcept {
+    if (!m_profile_dump_owned || m_render_profile_capture) {
+        return;
+    }
+
+    try {
+        const ProfileDump::SchemaRegistration gpu_frame =
+            ProfileDump::RegisterSchema(
+                ProfileDump::Templates::GpuFrame()
+            );
+        if ((gpu_frame.status !=
+                 ProfileDump::SchemaStatus::Registered &&
+             gpu_frame.status !=
+                 ProfileDump::SchemaStatus::AlreadyRegistered) ||
+            !gpu_frame.handle) {
+            LOG_WARNING(
+                "[ProfileDump] GpuFrame schema registration failed "
+                "(status={}); GPU capture disabled.",
+                static_cast<unsigned int>(gpu_frame.status)
+            );
+            return;
+        }
+
+        const ProfileDump::SchemaRegistration gpu_scope =
+            ProfileDump::RegisterSchema(
+                ProfileDump::Templates::GpuScope()
+            );
+        if ((gpu_scope.status !=
+                 ProfileDump::SchemaStatus::Registered &&
+             gpu_scope.status !=
+                 ProfileDump::SchemaStatus::AlreadyRegistered) ||
+            !gpu_scope.handle) {
+            LOG_WARNING(
+                "[ProfileDump] GpuScope schema registration failed "
+                "(status={}); GPU capture disabled.",
+                static_cast<unsigned int>(gpu_scope.status)
+            );
+            return;
+        }
+
+        auto capture =
+            MakeUnique<Render::RenderProfileCapture>(
+                gpu_frame.handle, gpu_scope.handle
+            );
+        if (!capture->Valid()) {
+            LOG_WARNING(
+                "[ProfileDump] GPU capture bridge rejected the current "
+                "schema generation; GPU capture disabled."
+            );
+            return;
+        }
+        m_render_profile_capture = std::move(capture);
+        LOG_INFO(
+            "[ProfileDump] GPU capture bridge initialized "
+            "(generation={}).",
+            gpu_frame.handle.generation
+        );
+    } catch (const std::exception& error) {
+        m_render_profile_capture.reset();
+        try {
+            LOG_WARNING(
+                "[ProfileDump] GPU capture bridge initialization failed: "
+                "{}; CPU capture remains enabled.",
+                error.what()
+            );
+        } catch (...) {
+        }
+    } catch (...) {
+        m_render_profile_capture.reset();
+        try {
+            LOG_WARNING(
+                "[ProfileDump] GPU capture bridge initialization failed; "
+                "CPU capture remains enabled."
+            );
+        } catch (...) {
+        }
+    }
+}
+
+void Engine::ShutdownRenderProfileCapture(
+    bool _rhi_drained
+) noexcept {
+    UniquePtr<Render::RenderProfileCapture> capture =
+        std::move(m_render_profile_capture);
+    if (!capture) {
+        return;
+    }
+
+    if (_rhi_drained) {
+        capture->ShutdownAfterRhiDrain();
+    } else {
+        capture->Abort();
+    }
+    const Render::RenderProfileCaptureStats stats =
+        capture->GetStats();
+
+    try {
+        if (!_rhi_drained ||
+            stats.shutdown_abandoned_frames != 0 ||
+            stats.terminal_faults != 0 ||
+            stats.frames_admission_rejected != 0 ||
+            stats.frame_records_dropped != 0 ||
+            stats.scope_records_dropped != 0) {
+            LOG_WARNING(
+                "[ProfileDump] GPU capture bridge stopped "
+                "(rhi_drained={}, emitted_frames={}, emitted_scopes={}, "
+                "admission_rejects={}, frame_drops={}, scope_drops={}, "
+                "abandoned_frames={}, terminal_faults={}).",
+                _rhi_drained,
+                stats.frames_emitted,
+                stats.scopes_emitted,
+                stats.frames_admission_rejected,
+                stats.frame_records_dropped,
+                stats.scope_records_dropped,
+                stats.shutdown_abandoned_frames,
+                stats.terminal_faults
+            );
+        } else {
+            LOG_INFO(
+                "[ProfileDump] GPU capture bridge drained "
+                "(frames={}, scopes={}, frame_drops={}, scope_drops={}).",
+                stats.frames_emitted,
+                stats.scopes_emitted,
+                stats.frame_records_dropped,
+                stats.scope_records_dropped
+            );
+        }
+    } catch (...) {
+    }
+}
+
 void Engine::ShutdownProfileDump() noexcept {
+    // Defensive rollback path. Normal shutdown has already drained and reset
+    // the bridge after RHI Completion joined.
+    ShutdownRenderProfileCapture(false);
     if (!m_profile_dump_owned) {
         return;
     }
@@ -1334,10 +1471,17 @@ void Engine::ShutDown() noexcept {
         m_shader_manager_initialized = false;
         cleanup([]() { ShaderManager::ShutDown(); });
     }
+    bool rhi_drained = !m_render_device_initialized;
     if (m_render_device_initialized) {
         m_render_device_initialized = false;
-        cleanup([]() { RenderDevice::Dispose(); });
+        try {
+            RenderDevice::Dispose();
+            rhi_drained = true;
+        } catch (...) {
+            rhi_drained = false;
+        }
     }
+    ShutdownRenderProfileCapture(rhi_drained);
     if (m_task_system_initialized) {
         m_task_system_initialized = false;
         cleanup([]() { TaskSystem::ShutDown(); });

--- a/source/runtime/Engine.h
+++ b/source/runtime/Engine.h
@@ -20,6 +20,9 @@ namespace Moer {
 class EditorUI;
 class RuntimeAssets;
 class RenderThreadService;
+namespace Render {
+class RenderProfileCapture;
+}
 
 class RENDER_API Engine {
 public:
@@ -68,6 +71,8 @@ private:
     void Init3rdParty();
     void ShutDown3rdParty();
     void InitializeProfileDump() noexcept;
+    void InitializeRenderProfileCapture() noexcept;
+    void ShutdownRenderProfileCapture(bool rhi_drained) noexcept;
     void ShutdownProfileDump() noexcept;
 
     void TickRendererSwitchValidation(Scene& scene);
@@ -81,6 +86,7 @@ private:
     UniquePtr<remote::RemoteModule>  m_remote_module;
     UniquePtr<Render::Renderer>      m_renderer;
     UniquePtr<RenderThreadService>   m_render_thread_service;
+    UniquePtr<Render::RenderProfileCapture> m_render_profile_capture;
 
     uint m_max_frame_lag = 0;
     bool m_has_shutdown = false;

--- a/source/runtime/core/include/profile/ProfileDumpTemplates.h
+++ b/source/runtime/core/include/profile/ProfileDumpTemplates.h
@@ -27,22 +27,54 @@ inline const SchemaDescriptor& CpuScope() {
     return schema;
 }
 
+inline const SchemaDescriptor& GpuFrame() {
+    static const SchemaDescriptor schema{
+        .name           = "GpuFrame",
+        .event_type     = "timing.gpu_frame",
+        .kind           = EventKind::Instant,
+        .channel        = Channel::GpuQueue,
+        .schema_version = 1,
+        .fields =
+            {
+                {"frame_id", FieldType::UInt64},
+                {"capture_status", FieldType::UInt32},
+                {"valid", FieldType::Bool},
+                {"admitted_scope_count", FieldType::UInt64},
+                {"dropped_scope_count", FieldType::UInt64},
+                {"error_scope_count", FieldType::UInt64},
+                {"reason", FieldType::String},
+            },
+    };
+    return schema;
+}
+
 inline const SchemaDescriptor& GpuScope() {
     static const SchemaDescriptor schema{
         .name           = "GpuScope",
         .event_type     = "timing.gpu_scope",
         .kind           = EventKind::Scope,
         .channel        = Channel::GpuQueue,
-        .schema_version = 1,
+        .schema_version = 2,
         .fields =
             {
                 {"frame_id", FieldType::UInt64},
-                {"queue_domain", FieldType::UInt64},
+                {"scope_id", FieldType::UInt64},
+                {"parent_scope_id", FieldType::UInt64},
+                {"source_order", FieldType::UInt64},
+                {"local_order", FieldType::UInt64},
+                {"logical_queue", FieldType::UInt32},
+                {"native_queue_id", FieldType::UInt32},
+                {"family_id", FieldType::UInt32},
                 {"name", FieldType::String},
+                {"status", FieldType::UInt32},
                 {"begin_tick", FieldType::UInt64},
                 {"end_tick", FieldType::UInt64},
+                {"valid_bits", FieldType::UInt32},
                 {"tick_period_ns", FieldType::Float64},
+                {"total_duration_ns", FieldType::Float64},
+                {"exclusive_duration_ns", FieldType::Float64},
                 {"depth", FieldType::UInt32},
+                {"error_reason", FieldType::String},
             },
     };
     return schema;

--- a/source/runtime/render/profile/RenderProfileCapture.cpp
+++ b/source/runtime/render/profile/RenderProfileCapture.cpp
@@ -1,0 +1,631 @@
+#include "profile/RenderProfileCapture.h"
+
+#include "profile/ProfileDumpTemplates.h"
+#include "rhi/RHICommand.h"
+
+#include <array>
+#include <limits>
+#include <mutex>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+namespace Moer::Render {
+
+namespace {
+
+enum class EmitDisposition : std::uint8_t {
+    Accepted,
+    Dropped,
+    Fatal,
+};
+
+bool IsManagedQueue(const RHIQueueBinding& _binding) noexcept {
+    return _binding.available &&
+           (_binding.queue == EQueueType::Graphics ||
+            _binding.queue == EQueueType::Compute ||
+            _binding.queue == EQueueType::Copy);
+}
+
+} // namespace
+
+namespace RenderProfileDetail {
+
+struct FrameMetadata {
+    std::uint64_t frame_id{0};
+    std::uint64_t source_bind_failures{0};
+};
+
+struct CaptureState {
+    CaptureState(
+        ProfileDump::SchemaHandle   _gpu_frame_schema,
+        ProfileDump::SchemaHandle   _gpu_scope_schema,
+        const GpuScopeStreamConfig& _stream_config
+    ) :
+        gpu_frame_schema(_gpu_frame_schema),
+        gpu_scope_schema(_gpu_scope_schema),
+        generation(_gpu_frame_schema.generation),
+        stream(_stream_config),
+        frame_metadata(_stream_config.max_resident_frames) {}
+
+    [[nodiscard]] bool RuntimeWritableUnlocked() const noexcept {
+        return generation != 0 &&
+               ProfileDump::GetRuntimeGeneration() == generation &&
+               ProfileDump::GetRuntimeState() ==
+                   ProfileDump::RuntimeState::Running;
+    }
+
+    void ClearMetadataUnlocked() noexcept {
+        for (FrameMetadata& metadata : frame_metadata) {
+            metadata = {};
+        }
+    }
+
+    void CloseUnlocked(bool _terminal_fault) noexcept {
+        if (closed) {
+            return;
+        }
+        accepting = false;
+        closed = true;
+        if (_terminal_fault) {
+            ++terminal_faults;
+        }
+        const GpuScopeStreamStats before_close = stream.GetStats();
+        shutdown_abandoned_frames += before_close.resident_frames;
+        stream.Close();
+        ClearMetadataUnlocked();
+    }
+
+    [[nodiscard]] bool ReserveMetadataUnlocked(
+        std::uint64_t _frame_id
+    ) noexcept {
+        for (FrameMetadata& metadata : frame_metadata) {
+            if (metadata.frame_id == 0) {
+                metadata.frame_id = _frame_id;
+                return true;
+            }
+        }
+        return false;
+    }
+
+    void ReleaseMetadataUnlocked(std::uint64_t _frame_id) noexcept {
+        for (FrameMetadata& metadata : frame_metadata) {
+            if (metadata.frame_id == _frame_id) {
+                metadata = {};
+                return;
+            }
+        }
+    }
+
+    [[nodiscard]] FrameMetadata TakeMetadataUnlocked(
+        std::uint64_t _frame_id
+    ) noexcept {
+        for (FrameMetadata& metadata : frame_metadata) {
+            if (metadata.frame_id == _frame_id) {
+                const FrameMetadata result = metadata;
+                metadata = {};
+                return result;
+            }
+        }
+        return {};
+    }
+
+    void MarkSourceFailureUnlocked(std::uint64_t _frame_id) noexcept {
+        ++sources_rejected;
+        for (FrameMetadata& metadata : frame_metadata) {
+            if (metadata.frame_id == _frame_id) {
+                ++metadata.source_bind_failures;
+                return;
+            }
+        }
+    }
+
+    [[nodiscard]] EmitDisposition HandleEmitUnlocked(
+        ProfileDump::EmitStatus _status,
+        bool                    _frame_record
+    ) noexcept {
+        switch (_status) {
+            case ProfileDump::EmitStatus::Accepted:
+                if (_frame_record) {
+                    ++frames_emitted;
+                } else {
+                    ++scopes_emitted;
+                }
+                return EmitDisposition::Accepted;
+            case ProfileDump::EmitStatus::QueueFull:
+                if (_frame_record) {
+                    ++frame_records_dropped;
+                } else {
+                    ++scope_records_dropped;
+                }
+                return EmitDisposition::Dropped;
+            case ProfileDump::EmitStatus::Disabled:
+            case ProfileDump::EmitStatus::InvalidHandle:
+            case ProfileDump::EmitStatus::ValueCountMismatch:
+            case ProfileDump::EmitStatus::ValueTypeMismatch:
+            case ProfileDump::EmitStatus::StringTooLarge:
+            case ProfileDump::EmitStatus::RecordTooLarge:
+            case ProfileDump::EmitStatus::SinkFault:
+                CloseUnlocked(true);
+                return EmitDisposition::Fatal;
+        }
+        CloseUnlocked(true);
+        return EmitDisposition::Fatal;
+    }
+
+    [[nodiscard]] EmitDisposition EmitFrameRecordUnlocked(
+        std::uint64_t            _frame_id,
+        GpuFrameCaptureStatus    _status,
+        bool                     _valid,
+        std::uint64_t            _admitted_scope_count,
+        std::uint64_t            _dropped_scope_count,
+        std::uint64_t            _error_scope_count,
+        std::string_view         _reason
+    ) noexcept {
+        const std::array<ProfileDump::FieldValueView, 7> values{
+            _frame_id,
+            static_cast<std::uint32_t>(_status),
+            _valid,
+            _admitted_scope_count,
+            _dropped_scope_count,
+            _error_scope_count,
+            _reason,
+        };
+        return HandleEmitUnlocked(
+            ProfileDump::Emit(gpu_frame_schema, values),
+            true
+        );
+    }
+
+    [[nodiscard]] EmitDisposition EmitScopeRecordUnlocked(
+        std::uint64_t       _frame_id,
+        const GpuScopeNode& _scope
+    ) noexcept {
+        const std::array<ProfileDump::FieldValueView, 18> values{
+            _frame_id,
+            _scope.scope_id,
+            _scope.parent_scope_id,
+            _scope.source_order,
+            _scope.local_order,
+            static_cast<std::uint32_t>(_scope.queue_binding.queue),
+            _scope.queue_binding.native_queue_id,
+            _scope.queue_binding.family_id,
+            std::string_view(_scope.name),
+            static_cast<std::uint32_t>(_scope.status),
+            _scope.begin_tick,
+            _scope.end_tick,
+            _scope.valid_bits,
+            _scope.tick_period_ns,
+            _scope.total_duration_ns,
+            _scope.exclusive_duration_ns,
+            _scope.depth,
+            std::string_view(_scope.error_reason),
+        };
+        return HandleEmitUnlocked(
+            ProfileDump::Emit(gpu_scope_schema, values),
+            false
+        );
+    }
+
+    [[nodiscard]] bool EmitScopeTreeUnlocked(
+        std::uint64_t       _frame_id,
+        const GpuScopeNode& _scope
+    ) noexcept {
+        if (EmitScopeRecordUnlocked(_frame_id, _scope) ==
+            EmitDisposition::Fatal) {
+            return false;
+        }
+        for (const GpuScopeNode& child : _scope.children) {
+            if (!EmitScopeTreeUnlocked(_frame_id, child)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    [[nodiscard]] bool EmitResolvedFrameUnlocked(
+        const ResolvedGpuScopeFrame& _frame
+    ) noexcept {
+        const FrameMetadata metadata =
+            TakeMetadataUnlocked(_frame.frame_id);
+        const bool bridge_incomplete =
+            metadata.source_bind_failures != 0;
+        const bool valid = _frame.valid && !bridge_incomplete;
+
+        GpuFrameCaptureStatus capture_status =
+            GpuFrameCaptureStatus::Complete;
+        std::string_view reason{};
+        if (!valid) {
+            ++frames_invalid;
+            const bool has_errors = _frame.error_scope_count != 0;
+            const bool has_drops =
+                _frame.dropped_scope_count != 0 || bridge_incomplete;
+            if (has_errors || (!has_drops && !_frame.valid)) {
+                capture_status = GpuFrameCaptureStatus::Invalid;
+            } else {
+                capture_status = GpuFrameCaptureStatus::Incomplete;
+            }
+
+            if (has_errors && has_drops) {
+                reason = "GPU frame capture contains failed and dropped scopes";
+            } else if (has_errors) {
+                reason = "one or more GPU scopes failed";
+            } else if (bridge_incomplete &&
+                       _frame.dropped_scope_count != 0) {
+                reason = "GPU recording sources and scopes were dropped";
+            } else if (bridge_incomplete) {
+                reason = "one or more GPU recording sources were rejected";
+            } else if (_frame.dropped_scope_count != 0) {
+                reason = "one or more GPU scopes were dropped";
+            } else {
+                reason = "GPU scope topology validation failed";
+            }
+        }
+
+        if (EmitFrameRecordUnlocked(
+                _frame.frame_id,
+                capture_status,
+                valid,
+                _frame.admitted_scope_count,
+                _frame.dropped_scope_count,
+                _frame.error_scope_count,
+                reason
+            ) == EmitDisposition::Fatal) {
+            return false;
+        }
+
+        for (const auto& queue_roots : _frame.queue_roots) {
+            for (const GpuScopeNode& root : queue_roots) {
+                if (!EmitScopeTreeUnlocked(_frame.frame_id, root)) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
+    [[nodiscard]] std::size_t DrainUnlocked() noexcept {
+        if (closed || !RuntimeWritableUnlocked()) {
+            if (!closed) {
+                CloseUnlocked(true);
+            }
+            return 0;
+        }
+
+        std::size_t drained = 0;
+        try {
+            ResolvedGpuScopeFrame frame{};
+            while (!closed && stream.TryPopFrame(frame)) {
+                ++drained;
+                if (!EmitResolvedFrameUnlocked(frame)) {
+                    break;
+                }
+                frame = {};
+            }
+        } catch (...) {
+            CloseUnlocked(true);
+        }
+        return drained;
+    }
+
+    ProfileDump::SchemaHandle gpu_frame_schema{};
+    ProfileDump::SchemaHandle gpu_scope_schema{};
+    std::uint64_t             generation{0};
+    GpuScopeStream            stream;
+    std::vector<FrameMetadata> frame_metadata{};
+
+    mutable std::mutex mutex{};
+    std::uint64_t next_frame_id{1};
+    bool          accepting{true};
+    bool          closed{false};
+
+    std::uint64_t frames_attempted{0};
+    std::uint64_t frames_admitted{0};
+    std::uint64_t frames_admission_rejected{0};
+    std::uint64_t frames_sealed{0};
+    std::uint64_t frames_emitted{0};
+    std::uint64_t frames_invalid{0};
+    std::uint64_t frame_records_dropped{0};
+    std::uint64_t sources_bound{0};
+    std::uint64_t sources_rejected{0};
+    std::uint64_t scopes_emitted{0};
+    std::uint64_t scope_records_dropped{0};
+    std::uint64_t terminal_faults{0};
+    std::uint64_t shutdown_abandoned_frames{0};
+};
+
+} // namespace RenderProfileDetail
+
+RenderProfileFrameToken::RenderProfileFrameToken(
+    std::shared_ptr<RenderProfileDetail::CaptureState> _state,
+    GpuScopeFrameHandle                                _frame,
+    std::uint64_t                                      _frame_id
+) noexcept :
+    state_(std::move(_state)),
+    frame_(std::move(_frame)),
+    frame_id_(_frame_id) {}
+
+RenderProfileFrameToken::~RenderProfileFrameToken() {
+    SealIfNeeded();
+}
+
+RenderProfileFrameToken::RenderProfileFrameToken(
+    RenderProfileFrameToken&& _other
+) noexcept :
+    state_(std::move(_other.state_)),
+    frame_(std::move(_other.frame_)),
+    frame_id_(_other.frame_id_),
+    sealed_(_other.sealed_) {
+    _other.frame_id_ = 0;
+    _other.sealed_ = true;
+}
+
+RenderProfileFrameToken& RenderProfileFrameToken::operator=(
+    RenderProfileFrameToken&& _other
+) noexcept {
+    if (this == &_other) {
+        return *this;
+    }
+    SealIfNeeded();
+    state_ = std::move(_other.state_);
+    frame_ = std::move(_other.frame_);
+    frame_id_ = _other.frame_id_;
+    sealed_ = _other.sealed_;
+    _other.frame_id_ = 0;
+    _other.sealed_ = true;
+    return *this;
+}
+
+bool RenderProfileFrameToken::Valid() const noexcept {
+    if (sealed_ || !state_ || !frame_.Valid()) {
+        return false;
+    }
+    std::scoped_lock lock(state_->mutex);
+    return state_->accepting && !state_->closed &&
+           state_->RuntimeWritableUnlocked() && frame_.Valid();
+}
+
+std::uint64_t RenderProfileFrameToken::FrameId() const noexcept {
+    return frame_id_;
+}
+
+void RenderProfileFrameToken::SealIfNeeded() noexcept {
+    if (sealed_) {
+        return;
+    }
+    sealed_ = true;
+    if (state_ && frame_.Valid()) {
+        std::scoped_lock lock(state_->mutex);
+        if (!state_->closed && state_->stream.SealFrame(frame_)) {
+            ++state_->frames_sealed;
+        }
+    }
+    frame_ = {};
+    state_.reset();
+}
+
+RenderProfileCapture::RenderProfileCapture(
+    ProfileDump::SchemaHandle   _gpu_frame_schema,
+    ProfileDump::SchemaHandle   _gpu_scope_schema,
+    const GpuScopeStreamConfig& _stream_config
+) {
+    const std::uint64_t generation =
+        ProfileDump::GetRuntimeGeneration();
+    if (!_gpu_frame_schema || !_gpu_scope_schema ||
+        generation == 0 ||
+        ProfileDump::GetRuntimeState() !=
+            ProfileDump::RuntimeState::Running ||
+        _gpu_frame_schema.generation != generation ||
+        _gpu_scope_schema.generation != generation ||
+        _gpu_frame_schema.hash != ProfileDump::ComputeSchemaHash(
+                                      ProfileDump::Templates::GpuFrame()
+                                  ) ||
+        _gpu_scope_schema.hash != ProfileDump::ComputeSchemaHash(
+                                      ProfileDump::Templates::GpuScope()
+                                  )) {
+        return;
+    }
+
+    state_ = std::make_shared<RenderProfileDetail::CaptureState>(
+        _gpu_frame_schema,
+        _gpu_scope_schema,
+        _stream_config
+    );
+}
+
+RenderProfileCapture::~RenderProfileCapture() {
+    Abort();
+}
+
+bool RenderProfileCapture::Valid() const noexcept {
+    const auto state = state_;
+    if (!state) {
+        return false;
+    }
+    std::scoped_lock lock(state->mutex);
+    return state->accepting && !state->closed &&
+           state->RuntimeWritableUnlocked();
+}
+
+RenderProfileFrameToken RenderProfileCapture::BeginFrame() noexcept {
+    const auto state = state_;
+    if (!state) {
+        return {};
+    }
+
+    std::scoped_lock lock(state->mutex);
+    if (!state->accepting || state->closed ||
+        !state->RuntimeWritableUnlocked()) {
+        if (!state->closed) {
+            state->CloseUnlocked(true);
+        }
+        return {};
+    }
+
+    const std::uint64_t frame_id = state->next_frame_id++;
+    ++state->frames_attempted;
+    if (frame_id == 0 ||
+        state->next_frame_id == 0) {
+        state->CloseUnlocked(true);
+        return {};
+    }
+
+    GpuScopeFrameHandle frame = state->stream.BeginFrame(frame_id);
+    if (!frame.Valid()) {
+        ++state->frames_admission_rejected;
+        // Rejected frames do not enter GpuScopeStream's ordered frame FIFO.
+        // Emitting them here would allow frame N to appear before an older
+        // pending frame N-1. Keep the rejection in bounded bridge statistics;
+        // admitted frame records remain strictly materialized in FIFO order.
+        return RenderProfileFrameToken(state, {}, frame_id);
+    }
+
+    if (!state->ReserveMetadataUnlocked(frame_id)) {
+        static_cast<void>(state->stream.SealFrame(frame));
+        state->CloseUnlocked(true);
+        return {};
+    }
+    ++state->frames_admitted;
+    return RenderProfileFrameToken(
+        state, std::move(frame), frame_id
+    );
+}
+
+RenderProfileBindResult RenderProfileCapture::BindSource(
+    RenderProfileFrameToken& _frame,
+    CommandList&             _command_list,
+    RHIQueueBinding          _queue_binding,
+    std::uint64_t            _source_order
+) noexcept {
+    const auto state = state_;
+    if (!state || _frame.state_.get() != state.get() ||
+        _frame.sealed_ || !_frame.frame_.Valid()) {
+        return RenderProfileBindResult::InvalidFrame;
+    }
+
+    std::scoped_lock lock(state->mutex);
+    if (!state->accepting || state->closed ||
+        !state->RuntimeWritableUnlocked()) {
+        if (!state->closed) {
+            state->CloseUnlocked(true);
+        }
+        return RenderProfileBindResult::Inactive;
+    }
+    if (!IsManagedQueue(_queue_binding)) {
+        state->MarkSourceFailureUnlocked(_frame.frame_id_);
+        return RenderProfileBindResult::InvalidQueue;
+    }
+
+    GpuScopeRecorder recorder =
+        _frame.frame_.CreateRecorder(_queue_binding, _source_order);
+    if (!recorder.Valid()) {
+        state->MarkSourceFailureUnlocked(_frame.frame_id_);
+        return RenderProfileBindResult::SourceRejected;
+    }
+
+    try {
+        _command_list.SetGpuScopeRecorder(std::move(recorder));
+    } catch (...) {
+        state->MarkSourceFailureUnlocked(_frame.frame_id_);
+        return RenderProfileBindResult::CommandListRejected;
+    }
+    ++state->sources_bound;
+    return RenderProfileBindResult::Bound;
+}
+
+bool RenderProfileCapture::Seal(
+    RenderProfileFrameToken& _frame
+) noexcept {
+    const auto state = state_;
+    if (!state || _frame.state_.get() != state.get() ||
+        _frame.sealed_) {
+        return false;
+    }
+
+    std::scoped_lock lock(state->mutex);
+    const bool sealed =
+        !state->closed && _frame.frame_.Valid() &&
+        state->stream.SealFrame(_frame.frame_);
+    if (sealed) {
+        ++state->frames_sealed;
+    }
+    _frame.sealed_ = true;
+    _frame.frame_ = {};
+    _frame.state_.reset();
+    return sealed;
+}
+
+std::size_t RenderProfileCapture::DrainReadyFrames() noexcept {
+    const auto state = state_;
+    if (!state) {
+        return 0;
+    }
+    std::scoped_lock lock(state->mutex);
+    return state->DrainUnlocked();
+}
+
+void RenderProfileCapture::ShutdownAfterRhiDrain() noexcept {
+    const auto state = state_;
+    if (!state) {
+        return;
+    }
+    std::scoped_lock lock(state->mutex);
+    if (state->closed) {
+        return;
+    }
+    state->accepting = false;
+    static_cast<void>(state->DrainUnlocked());
+    if (!state->closed) {
+        state->closed = true;
+        const GpuScopeStreamStats before_close =
+            state->stream.GetStats();
+        state->shutdown_abandoned_frames +=
+            before_close.resident_frames;
+        state->stream.Close();
+        state->ClearMetadataUnlocked();
+    }
+}
+
+void RenderProfileCapture::Abort() noexcept {
+    const auto state = state_;
+    if (!state) {
+        return;
+    }
+    std::scoped_lock lock(state->mutex);
+    state->CloseUnlocked(false);
+}
+
+RenderProfileCaptureStats
+RenderProfileCapture::GetStats() const noexcept {
+    RenderProfileCaptureStats result{};
+    const auto state = state_;
+    if (!state) {
+        return result;
+    }
+
+    std::scoped_lock lock(state->mutex);
+    result.accepting = state->accepting;
+    result.closed = state->closed;
+    result.generation = state->generation;
+    result.frames_attempted = state->frames_attempted;
+    result.frames_admitted = state->frames_admitted;
+    result.frames_admission_rejected =
+        state->frames_admission_rejected;
+    result.frames_sealed = state->frames_sealed;
+    result.frames_emitted = state->frames_emitted;
+    result.frames_invalid = state->frames_invalid;
+    result.frame_records_dropped =
+        state->frame_records_dropped;
+    result.sources_bound = state->sources_bound;
+    result.sources_rejected = state->sources_rejected;
+    result.scopes_emitted = state->scopes_emitted;
+    result.scope_records_dropped =
+        state->scope_records_dropped;
+    result.terminal_faults = state->terminal_faults;
+    result.shutdown_abandoned_frames =
+        state->shutdown_abandoned_frames;
+    result.stream = state->stream.GetStats();
+    return result;
+}
+
+} // namespace Moer::Render

--- a/source/runtime/render/profile/RenderProfileCapture.h
+++ b/source/runtime/render/profile/RenderProfileCapture.h
@@ -1,0 +1,136 @@
+#ifndef MOER_ENGINE_RENDER_PROFILE_CAPTURE_H
+#define MOER_ENGINE_RENDER_PROFILE_CAPTURE_H
+
+#include "RenderAPI.h"
+#include "profile/ProfileDump.h"
+#include "rhi/RHIGpuScope.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+
+namespace Moer::Render {
+
+class CommandList;
+
+namespace RenderProfileDetail {
+struct CaptureState;
+}
+
+enum class GpuFrameCaptureStatus : std::uint32_t {
+    Complete = 0,
+    Incomplete,
+    Invalid,
+};
+
+enum class RenderProfileBindResult : std::uint8_t {
+    Bound = 0,
+    Inactive,
+    InvalidFrame,
+    InvalidQueue,
+    SourceRejected,
+    CommandListRejected,
+};
+
+struct RenderProfileCaptureStats {
+    bool          accepting{false};
+    bool          closed{false};
+    std::uint64_t generation{0};
+
+    std::uint64_t frames_attempted{0};
+    std::uint64_t frames_admitted{0};
+    std::uint64_t frames_admission_rejected{0};
+    std::uint64_t frames_sealed{0};
+    std::uint64_t frames_emitted{0};
+    std::uint64_t frames_invalid{0};
+    std::uint64_t frame_records_dropped{0};
+
+    std::uint64_t sources_bound{0};
+    std::uint64_t sources_rejected{0};
+    std::uint64_t scopes_emitted{0};
+    std::uint64_t scope_records_dropped{0};
+    std::uint64_t terminal_faults{0};
+    std::uint64_t shutdown_abandoned_frames{0};
+
+    GpuScopeStreamStats stream{};
+};
+
+class RENDER_API RenderProfileFrameToken {
+public:
+    RenderProfileFrameToken() = default;
+    ~RenderProfileFrameToken();
+
+    RenderProfileFrameToken(const RenderProfileFrameToken&) = delete;
+    RenderProfileFrameToken& operator=(const RenderProfileFrameToken&) = delete;
+    RenderProfileFrameToken(RenderProfileFrameToken&& _other) noexcept;
+    RenderProfileFrameToken&
+    operator=(RenderProfileFrameToken&& _other) noexcept;
+
+    [[nodiscard]] bool Valid() const noexcept;
+    [[nodiscard]] std::uint64_t FrameId() const noexcept;
+
+private:
+    RenderProfileFrameToken(
+        std::shared_ptr<RenderProfileDetail::CaptureState> _state,
+        GpuScopeFrameHandle                                _frame,
+        std::uint64_t                                      _frame_id
+    ) noexcept;
+
+    void SealIfNeeded() noexcept;
+
+    std::shared_ptr<RenderProfileDetail::CaptureState> state_{};
+    GpuScopeFrameHandle                                frame_{};
+    std::uint64_t                                      frame_id_{0};
+    bool                                               sealed_{false};
+
+    friend class RenderProfileCapture;
+};
+
+class RENDER_API RenderProfileCapture final {
+public:
+    RenderProfileCapture(
+        ProfileDump::SchemaHandle     _gpu_frame_schema,
+        ProfileDump::SchemaHandle     _gpu_scope_schema,
+        const GpuScopeStreamConfig&   _stream_config = {}
+    );
+    ~RenderProfileCapture();
+
+    RenderProfileCapture(const RenderProfileCapture&) = delete;
+    RenderProfileCapture& operator=(const RenderProfileCapture&) = delete;
+    RenderProfileCapture(RenderProfileCapture&&) = delete;
+    RenderProfileCapture& operator=(RenderProfileCapture&&) = delete;
+
+    [[nodiscard]] bool Valid() const noexcept;
+    [[nodiscard]] RenderProfileFrameToken BeginFrame() noexcept;
+    [[nodiscard]] RenderProfileBindResult BindSource(
+        RenderProfileFrameToken& _frame,
+        CommandList&             _command_list,
+        RHIQueueBinding          _queue_binding,
+        std::uint64_t            _source_order
+    ) noexcept;
+    [[nodiscard]] bool Seal(
+        RenderProfileFrameToken& _frame
+    ) noexcept;
+
+    // Consumer-only operation. It materializes ready frames in BeginFrame
+    // order and emits ProfileDump records on the calling thread. Completion
+    // callbacks never enter this path.
+    [[nodiscard]] std::size_t DrainReadyFrames() noexcept;
+
+    // Normal terminal boundary. Call only after RHI Executor/Submission/
+    // Completion have stopped and joined.
+    void ShutdownAfterRhiDrain() noexcept;
+
+    // Exceptional terminal boundary. It is non-blocking and never presents
+    // pending frames as completed.
+    void Abort() noexcept;
+
+    [[nodiscard]] RenderProfileCaptureStats GetStats() const noexcept;
+
+private:
+    std::shared_ptr<RenderProfileDetail::CaptureState> state_{};
+};
+
+} // namespace Moer::Render
+
+#endif // MOER_ENGINE_RENDER_PROFILE_CAPTURE_H

--- a/source/test/CMakeLists.txt
+++ b/source/test/CMakeLists.txt
@@ -132,6 +132,18 @@ set_target_properties(${test_target} PROPERTIES FOLDER ${moer_test_folder})
 add_test(NAME RHIGpuScopeContract COMMAND $<TARGET_FILE:${test_target}>)
 set_tests_properties(RHIGpuScopeContract PROPERTIES TIMEOUT 60)
 
+set(test_target TestRenderProfileCapture)
+add_executable(${test_target} "RenderProfileCaptureTest.cpp")
+target_include_directories(${test_target}
+    PRIVATE "${moer_source_dir}/runtime/core/source/profile"
+)
+target_link_libraries(${test_target}
+    PRIVATE Moer::Render
+)
+set_target_properties(${test_target} PROPERTIES FOLDER ${moer_test_folder})
+add_test(NAME RenderProfileCaptureContract COMMAND $<TARGET_FILE:${test_target}>)
+set_tests_properties(RenderProfileCaptureContract PROPERTIES TIMEOUT 60)
+
 set(test_target TestRHIGpuCompletion)
 add_executable(${test_target} "RHIGpuCompletionContractTest.cpp")
 target_link_libraries(${test_target}

--- a/source/test/RenderProfileCaptureTest.cpp
+++ b/source/test/RenderProfileCaptureTest.cpp
@@ -1,0 +1,951 @@
+#include "ProfileDumpTesting.h"
+#include "profile/ProfileDump.h"
+#include "profile/ProfileDumpCodec.h"
+#include "profile/ProfileDumpTemplates.h"
+#include "profile/RenderProfileCapture.h"
+#include "rhi/RHICommand.h"
+#include "rhi/RHIImpl.h"
+#include "rhi/RHIQuery.h"
+
+#include <algorithm>
+#include <array>
+#include <atomic>
+#include <chrono>
+#include <cmath>
+#include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <span>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+namespace {
+
+using namespace Moer;
+using namespace Moer::ProfileDump;
+using namespace Moer::Render;
+
+void Expect(bool _condition, std::string_view _message) {
+    if (!_condition) {
+        throw std::runtime_error(std::string(_message));
+    }
+}
+
+void ExpectNear(
+    double           _actual,
+    double           _expected,
+    std::string_view _message
+) {
+    if (std::abs(_actual - _expected) > 1.0e-9) {
+        throw std::runtime_error(std::string(_message));
+    }
+}
+
+class ScopedOutput {
+public:
+    explicit ScopedOutput(std::string_view _stem) {
+        static std::atomic<std::uint64_t> next_id{0};
+        for (std::uint32_t attempt = 0; attempt < 64; ++attempt) {
+            const auto now = static_cast<std::uint64_t>(
+                std::chrono::steady_clock::now().
+                    time_since_epoch().count()
+            );
+            directory = std::filesystem::temp_directory_path() /
+                        (std::string(_stem) + "-" +
+                         std::to_string(now) + "-" +
+                         std::to_string(next_id.fetch_add(
+                             1, std::memory_order_relaxed
+                         )));
+            std::error_code error;
+            if (std::filesystem::create_directory(directory, error)) {
+                path = directory / "capture.mpd";
+                return;
+            }
+            if (error && error != std::errc::file_exists) {
+                break;
+            }
+        }
+        throw std::runtime_error(
+            "RenderProfileCapture test could not reserve a temp directory"
+        );
+    }
+
+    ~ScopedOutput() {
+        static_cast<void>(ProfileDump::Shutdown());
+        std::error_code error;
+        std::filesystem::remove_all(directory, error);
+    }
+
+    [[nodiscard]] bool HasInProgressFile() const {
+        std::error_code error;
+        for (std::filesystem::directory_iterator it(directory, error), end;
+             !error && it != end;
+             it.increment(error)) {
+            if (it->path().filename().string().ends_with(
+                    ".inprogress"
+                )) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    std::filesystem::path directory{};
+    std::filesystem::path path{};
+};
+
+struct ParsedDump {
+    std::vector<PacketType>       packet_types{};
+    std::vector<SchemaDescriptor> schemas{};
+    std::vector<DecodedRecord>    records{};
+};
+
+std::vector<std::uint8_t> ReadBinary(
+    const std::filesystem::path& _path
+) {
+    std::ifstream file(_path, std::ios::binary | std::ios::ate);
+    Expect(file.is_open(), "capture output could not be opened");
+    const std::streamoff size = file.tellg();
+    Expect(size >= 0, "capture output size is invalid");
+    std::vector<std::uint8_t> bytes(
+        static_cast<std::size_t>(size)
+    );
+    file.seekg(0);
+    if (!bytes.empty()) {
+        file.read(
+            reinterpret_cast<char*>(bytes.data()),
+            static_cast<std::streamsize>(bytes.size())
+        );
+    }
+    Expect(file.good() || file.eof(), "capture output read failed");
+    return bytes;
+}
+
+ParsedDump ParseDump(const std::filesystem::path& _path) {
+    const std::vector<std::uint8_t> bytes = ReadBinary(_path);
+    Expect(!bytes.empty(), "capture output is empty");
+
+    ParsedDump parsed{};
+    CodecLimits limits{};
+    std::size_t offset = 0;
+    std::uint64_t expected_packet_index = 0;
+    while (offset < bytes.size()) {
+        PacketView packet{};
+        std::size_t consumed = 0;
+        Expect(
+            DecodePacket(
+                std::span<const std::uint8_t>(bytes).subspan(
+                    offset
+                ),
+                limits,
+                packet,
+                consumed
+            ) == DecodeStatus::Ok,
+            "capture packet decode failed"
+        );
+        Expect(
+            consumed != 0 &&
+                packet.header.packet_index ==
+                    expected_packet_index++,
+            "capture packet order is not contiguous"
+        );
+        parsed.packet_types.push_back(packet.header.type);
+
+        if (packet.header.type == PacketType::Schema) {
+            SchemaDescriptor schema{};
+            Expect(
+                DecodeSchemaPayload(packet, limits, schema) ==
+                    DecodeStatus::Ok,
+                "capture schema decode failed"
+            );
+            parsed.schemas.push_back(std::move(schema));
+        } else if (packet.header.type == PacketType::Record) {
+            DecodedRecord record{};
+            bool decoded = false;
+            for (const SchemaDescriptor& schema : parsed.schemas) {
+                if (DecodeRecordPayload(
+                        packet, schema, limits, record
+                    ) == DecodeStatus::Ok) {
+                    decoded = true;
+                    break;
+                }
+            }
+            Expect(
+                decoded,
+                "record appeared before its schema or did not match it"
+            );
+            parsed.records.push_back(std::move(record));
+        }
+        offset += consumed;
+    }
+    Expect(offset == bytes.size(), "capture has trailing bytes");
+    return parsed;
+}
+
+const SchemaDescriptor& FindSchema(
+    const ParsedDump& _dump,
+    std::string_view  _name
+) {
+    const auto it = std::ranges::find_if(
+        _dump.schemas,
+        [&](const SchemaDescriptor& _schema) {
+            return std::string_view(_schema.name) == _name;
+        }
+    );
+    Expect(it != _dump.schemas.end(), "expected schema is missing");
+    return *it;
+}
+
+std::vector<const DecodedRecord*> RecordsFor(
+    const ParsedDump& _dump,
+    const SchemaDescriptor& _schema
+) {
+    const std::uint64_t hash = ComputeSchemaHash(_schema);
+    std::vector<const DecodedRecord*> result{};
+    for (const DecodedRecord& record : _dump.records) {
+        if (record.schema_hash == hash) {
+            result.push_back(&record);
+        }
+    }
+    return result;
+}
+
+template<typename T>
+const T& ValueAt(
+    const DecodedRecord& _record,
+    std::size_t          _index
+) {
+    Expect(
+        _index < _record.values.size(),
+        "decoded record field index is out of range"
+    );
+    return std::get<T>(_record.values[_index]);
+}
+
+std::string_view StringAt(
+    const DecodedRecord& _record,
+    std::size_t          _index
+) {
+    return std::string_view(
+        ValueAt<ProfileString>(_record, _index)
+    );
+}
+
+RHIQueueBinding Binding(
+    EQueueType   _queue,
+    std::uint32_t _native_queue_id,
+    std::uint32_t _family_id
+) {
+    return {
+        .queue = _queue,
+        .native_queue_id = _native_queue_id,
+        .family_id = _family_id,
+        .available = true,
+    };
+}
+
+TimestampQueryResult Timestamp(
+    std::uint64_t _begin,
+    std::uint64_t _end,
+    double        _period = 1.0
+) {
+    return {
+        .begin_tick = _begin,
+        .end_tick = _end,
+        .valid_bits = 64,
+        .tick_period_ns = _period,
+        .duration_ns =
+            static_cast<double>(_end - _begin) * _period,
+    };
+}
+
+void ResolveTimestampAt(
+    CmdSubmit&                  _submit,
+    std::size_t                 _index,
+    const TimestampQueryResult& _timestamp
+) {
+    Expect(
+        _index < _submit.query_tokens.size(),
+        "test timestamp token index is out of range"
+    );
+    Expect(
+        QueryBackendAccess::ResolveTimestamp(
+            _submit.query_tokens[_index], _timestamp
+        ),
+        "test timestamp did not win terminal publication"
+    );
+}
+
+void ReleaseSubmit(CmdSubmit& _submit) {
+    _submit.callbacks.clear();
+    _submit.query_tokens.clear();
+}
+
+struct RegisteredGpuSchemas {
+    SchemaHandle frame{};
+    SchemaHandle scope{};
+};
+
+RegisteredGpuSchemas RegisterGpuSchemas() {
+    const SchemaRegistration frame =
+        RegisterSchema(Templates::GpuFrame());
+    const SchemaRegistration scope =
+        RegisterSchema(Templates::GpuScope());
+    Expect(
+        (frame.status == SchemaStatus::Registered ||
+         frame.status == SchemaStatus::AlreadyRegistered) &&
+            frame.handle,
+        "GpuFrame schema registration failed"
+    );
+    Expect(
+        (scope.status == SchemaStatus::Registered ||
+         scope.status == SchemaStatus::AlreadyRegistered) &&
+            scope.handle,
+        "GpuScope schema registration failed"
+    );
+    return {frame.handle, scope.handle};
+}
+
+void StartRuntime(
+    const ScopedOutput& _output,
+    RuntimeConfig       _config = {}
+) {
+    RuntimeConfig config = std::move(_config);
+    config.output_path = _output.path;
+    config.replace_existing = true;
+    const StartResult result = Start(config);
+    if (result != StartResult::Started) {
+        throw std::runtime_error(
+            "ProfileDump runtime did not start (result=" +
+            std::to_string(static_cast<unsigned int>(result)) + ")"
+        );
+    }
+}
+
+class WriterResumeGuard {
+public:
+    ~WriterResumeGuard() {
+        if (active_) {
+            Testing::ResumeWriter();
+        }
+    }
+
+    void Resume() noexcept {
+        if (active_) {
+            Testing::ResumeWriter();
+            active_ = false;
+        }
+    }
+
+private:
+    bool active_{true};
+};
+
+void FinishRuntime(const ScopedOutput& _output) {
+    const FlushResult flush = FlushThreadLocal();
+    Expect(
+        flush == FlushResult::Completed ||
+            flush == FlushResult::NothingPending,
+        "ProfileDump producer flush failed"
+    );
+    Expect(
+        Shutdown() == ShutdownResult::Completed,
+        "ProfileDump runtime did not shut down cleanly"
+    );
+    Expect(
+        std::filesystem::is_regular_file(_output.path),
+        "ProfileDump final file is missing"
+    );
+    Expect(
+        !_output.HasInProgressFile(),
+        "ProfileDump left an in-progress file"
+    );
+}
+
+void HappyPathPreservesTopologyAndRawTimestampDomains() {
+    ScopedOutput output("moer-render-profile-happy");
+    StartRuntime(output);
+    const RegisteredGpuSchemas schemas = RegisterGpuSchemas();
+    RenderProfileCapture capture(schemas.frame, schemas.scope);
+    Expect(capture.Valid(), "GPU capture bridge is not valid");
+
+    RenderProfileFrameToken frame = capture.BeginFrame();
+    Expect(
+        frame.Valid() && frame.FrameId() == 1,
+        "first GPU frame admission failed"
+    );
+
+    CommandList graphics(EQueueType::Graphics);
+    Expect(
+        capture.BindSource(
+            frame,
+            graphics,
+            Binding(EQueueType::Graphics, 3, 7),
+            7
+        ) == RenderProfileBindResult::Bound,
+        "first Graphics source bind failed"
+    );
+    graphics.PushScopeWithTimeScope("Outer");
+    graphics.PushScopeWithTimeScope("Child");
+    graphics.PopScopeWithTimeScope();
+    graphics.PopScopeWithTimeScope();
+    CmdSubmit first_graphics = graphics.Submit();
+    Expect(
+        !graphics.HasGpuScopeRecorder(),
+        "Submit did not consume the first recording generation"
+    );
+
+    Expect(
+        capture.BindSource(
+            frame,
+            graphics,
+            Binding(EQueueType::Graphics, 3, 7),
+            8
+        ) == RenderProfileBindResult::Bound,
+        "persistent Graphics CommandList could not rebind"
+    );
+    graphics.PushScopeWithTimeScope("Tail");
+    graphics.PopScopeWithTimeScope();
+    CmdSubmit second_graphics = graphics.Submit();
+
+    CommandList compute(EQueueType::Compute);
+    Expect(
+        capture.BindSource(
+            frame,
+            compute,
+            Binding(EQueueType::Compute, 4, 9),
+            9
+        ) == RenderProfileBindResult::Bound,
+        "Compute source bind failed"
+    );
+    compute.PushScopeWithTimeScope("Compute");
+    compute.PopScopeWithTimeScope();
+    CmdSubmit compute_submit = compute.Submit();
+
+    Expect(capture.Seal(frame), "first GPU frame seal failed");
+    Expect(
+        capture.DrainReadyFrames() == 0,
+        "frame became visible before query completion"
+    );
+
+    ResolveTimestampAt(first_graphics, 1, Timestamp(120, 150));
+    ResolveTimestampAt(first_graphics, 0, Timestamp(100, 200));
+    ResolveTimestampAt(second_graphics, 0, Timestamp(210, 240));
+    ResolveTimestampAt(compute_submit, 0, Timestamp(1000, 1020, 2.0));
+    Expect(
+        capture.DrainReadyFrames() == 1,
+        "completed first frame did not drain"
+    );
+
+    {
+        RenderProfileFrameToken raii_frame = capture.BeginFrame();
+        Expect(
+            raii_frame.Valid() && raii_frame.FrameId() == 2,
+            "RAII frame admission failed"
+        );
+    }
+    Expect(
+        capture.DrainReadyFrames() == 1,
+        "FrameToken destructor did not seal an empty frame"
+    );
+
+    RenderProfileFrameToken error_frame = capture.BeginFrame();
+    Expect(
+        error_frame.Valid() && error_frame.FrameId() == 3,
+        "error frame admission failed"
+    );
+    CommandList error_list(EQueueType::Graphics);
+    Expect(
+        capture.BindSource(
+            error_frame,
+            error_list,
+            Binding(EQueueType::Graphics, 3, 7),
+            0
+        ) == RenderProfileBindResult::Bound,
+        "error source bind failed"
+    );
+    error_list.PushScopeWithTimeScope("ErrorScope");
+    error_list.PopScopeWithTimeScope();
+    CmdSubmit error_submit = error_list.Submit();
+    Expect(capture.Seal(error_frame), "error frame seal failed");
+    Expect(
+        QueryBackendAccess::ResolveErrorIfPending(
+            error_submit.query_tokens.front(),
+            "injected GPU completion failure"
+        ),
+        "error query did not reach its terminal state"
+    );
+    Expect(
+        capture.DrainReadyFrames() == 1,
+        "error frame did not drain"
+    );
+
+    capture.ShutdownAfterRhiDrain();
+    const RenderProfileCaptureStats stats = capture.GetStats();
+    Expect(
+        stats.closed && !stats.accepting &&
+            stats.frames_attempted == 3 &&
+            stats.frames_admitted == 3 &&
+            stats.frames_sealed == 3 &&
+            stats.frames_emitted == 3 &&
+            stats.frames_invalid == 1 &&
+            stats.sources_bound == 4 &&
+            stats.scopes_emitted == 5 &&
+            stats.shutdown_abandoned_frames == 0 &&
+            stats.terminal_faults == 0,
+        "GPU capture bridge stats are inconsistent"
+    );
+
+    ReleaseSubmit(first_graphics);
+    ReleaseSubmit(second_graphics);
+    ReleaseSubmit(compute_submit);
+    ReleaseSubmit(error_submit);
+    FinishRuntime(output);
+
+    const ParsedDump dump = ParseDump(output.path);
+    const SchemaDescriptor& frame_schema =
+        FindSchema(dump, "GpuFrame");
+    const SchemaDescriptor& scope_schema =
+        FindSchema(dump, "GpuScope");
+    Expect(
+        frame_schema.schema_version == 1 &&
+            frame_schema.fields.size() == 7,
+        "GpuFrame schema contract changed"
+    );
+    Expect(
+        scope_schema.schema_version == 2 &&
+            scope_schema.fields.size() == 18,
+        "GpuScope v2 schema contract changed"
+    );
+
+    const auto frame_records = RecordsFor(dump, frame_schema);
+    const auto scope_records = RecordsFor(dump, scope_schema);
+    Expect(
+        frame_records.size() == 3 && scope_records.size() == 5,
+        "decoded GPU record counts are incorrect"
+    );
+    Expect(
+        ValueAt<std::uint64_t>(*frame_records[0], 0) == 1 &&
+            ValueAt<std::uint32_t>(*frame_records[0], 1) ==
+                static_cast<std::uint32_t>(
+                    GpuFrameCaptureStatus::Complete
+                ) &&
+            ValueAt<bool>(*frame_records[0], 2) &&
+            ValueAt<std::uint64_t>(*frame_records[0], 3) == 4 &&
+            StringAt(*frame_records[0], 6).empty(),
+        "first GpuFrame payload is incorrect"
+    );
+    Expect(
+        ValueAt<std::uint64_t>(*frame_records[2], 0) == 3 &&
+            ValueAt<std::uint32_t>(*frame_records[2], 1) ==
+                static_cast<std::uint32_t>(
+                    GpuFrameCaptureStatus::Invalid
+                ) &&
+            !ValueAt<bool>(*frame_records[2], 2) &&
+            ValueAt<std::uint64_t>(*frame_records[2], 5) == 1,
+        "error GpuFrame payload is incorrect"
+    );
+
+    const std::array<std::string_view, 5> expected_names{
+        "Outer", "Child", "Tail", "Compute", "ErrorScope"
+    };
+    for (std::size_t index = 0;
+         index < expected_names.size();
+         ++index) {
+        Expect(
+            StringAt(*scope_records[index], 8) ==
+                expected_names[index],
+            "GpuScope preorder/name is incorrect"
+        );
+    }
+    Expect(
+        ValueAt<std::uint64_t>(*scope_records[0], 0) == 1 &&
+            ValueAt<std::uint64_t>(*scope_records[0], 3) == 7 &&
+            ValueAt<std::uint32_t>(*scope_records[0], 5) ==
+                static_cast<std::uint32_t>(EQueueType::Graphics) &&
+            ValueAt<std::uint32_t>(*scope_records[0], 6) == 3 &&
+            ValueAt<std::uint32_t>(*scope_records[0], 7) == 7 &&
+            ValueAt<std::uint32_t>(*scope_records[0], 16) == 0,
+        "outer scope topology/domain payload is incorrect"
+    );
+    Expect(
+        ValueAt<std::uint64_t>(*scope_records[1], 2) ==
+                ValueAt<std::uint64_t>(*scope_records[0], 1) &&
+            ValueAt<std::uint32_t>(*scope_records[1], 16) == 1,
+        "child parent/depth payload is incorrect"
+    );
+    ExpectNear(
+        ValueAt<double>(*scope_records[0], 14),
+        100.0,
+        "outer total duration is incorrect"
+    );
+    ExpectNear(
+        ValueAt<double>(*scope_records[0], 15),
+        70.0,
+        "outer exclusive duration is incorrect"
+    );
+    Expect(
+        ValueAt<std::uint64_t>(*scope_records[3], 3) == 9 &&
+            ValueAt<std::uint32_t>(*scope_records[3], 5) ==
+                static_cast<std::uint32_t>(EQueueType::Compute) &&
+            ValueAt<std::uint32_t>(*scope_records[3], 6) == 4 &&
+            ValueAt<std::uint32_t>(*scope_records[3], 7) == 9,
+        "Compute queue domain/source order is incorrect"
+    );
+    ExpectNear(
+        ValueAt<double>(*scope_records[3], 13),
+        2.0,
+        "Compute tick period was not preserved"
+    );
+    ExpectNear(
+        ValueAt<double>(*scope_records[3], 14),
+        40.0,
+        "Compute duration was not preserved"
+    );
+    Expect(
+        ValueAt<std::uint32_t>(*scope_records[4], 9) ==
+                static_cast<std::uint32_t>(
+                    GpuScopeTerminalStatus::Error
+                ) &&
+            StringAt(*scope_records[4], 17) ==
+                "injected GPU completion failure",
+        "error scope diagnostic payload is incorrect"
+    );
+}
+
+void AbortDetachesPendingCompletionWithoutBlocking() {
+    ScopedOutput output("moer-render-profile-abort");
+    StartRuntime(output);
+    const RegisteredGpuSchemas schemas = RegisterGpuSchemas();
+    RenderProfileCapture capture(schemas.frame, schemas.scope);
+
+    RenderProfileFrameToken frame = capture.BeginFrame();
+    CommandList list(EQueueType::Graphics);
+    Expect(
+        capture.BindSource(
+            frame,
+            list,
+            Binding(EQueueType::Graphics, 0, 0),
+            0
+        ) == RenderProfileBindResult::Bound,
+        "abort source bind failed"
+    );
+    list.PushScopeWithTimeScope("PendingAtAbort");
+    list.PopScopeWithTimeScope();
+    CmdSubmit submit = list.Submit();
+    Expect(capture.Seal(frame), "abort frame seal failed");
+
+    capture.Abort();
+    const RenderProfileCaptureStats stats = capture.GetStats();
+    Expect(
+        stats.closed && !stats.accepting &&
+            stats.shutdown_abandoned_frames == 1 &&
+            stats.stream.resident_frames == 0,
+        "Abort did not detach its pending frame"
+    );
+    Expect(
+        QueryBackendAccess::ResolveTimestamp(
+            submit.query_tokens.front(), Timestamp(1, 2)
+        ),
+        "outliving Completion ticket was not safe after Abort"
+    );
+    ReleaseSubmit(submit);
+    FinishRuntime(output);
+}
+
+void ShutdownAfterRhiDrainPerformsFinalDrain() {
+    ScopedOutput output("moer-render-profile-final-drain");
+    StartRuntime(output);
+    const RegisteredGpuSchemas schemas = RegisterGpuSchemas();
+    RenderProfileCapture capture(schemas.frame, schemas.scope);
+
+    RenderProfileFrameToken frame = capture.BeginFrame();
+    CommandList list(EQueueType::Graphics);
+    Expect(
+        capture.BindSource(
+            frame,
+            list,
+            Binding(EQueueType::Graphics, 2, 5),
+            11
+        ) == RenderProfileBindResult::Bound,
+        "final-drain source bind failed"
+    );
+    list.PushScopeWithTimeScope("FinalDrain.Scope");
+    list.PopScopeWithTimeScope();
+    CmdSubmit submit = list.Submit();
+    Expect(capture.Seal(frame), "final-drain frame seal failed");
+    ResolveTimestampAt(submit, 0, Timestamp(20, 30));
+
+    // Engine relies on this terminal path after RHI Completion joins; no
+    // ordinary per-frame drain is performed first.
+    capture.ShutdownAfterRhiDrain();
+    const RenderProfileCaptureStats stats = capture.GetStats();
+    Expect(
+        stats.closed && !stats.accepting &&
+            stats.frames_emitted == 1 &&
+            stats.scopes_emitted == 1 &&
+            stats.shutdown_abandoned_frames == 0 &&
+            stats.terminal_faults == 0,
+        "ShutdownAfterRhiDrain did not perform a clean final drain"
+    );
+    ReleaseSubmit(submit);
+    FinishRuntime(output);
+
+    const ParsedDump dump = ParseDump(output.path);
+    Expect(
+        RecordsFor(dump, FindSchema(dump, "GpuFrame")).size() == 1 &&
+            RecordsFor(dump, FindSchema(dump, "GpuScope")).size() == 1,
+        "final drain did not persist its frame and scope records"
+    );
+}
+
+void StaleGenerationFailsClosed() {
+    ScopedOutput first_output("moer-render-profile-stale-a");
+    StartRuntime(first_output);
+    const RegisteredGpuSchemas old_schemas = RegisterGpuSchemas();
+    RenderProfileCapture old_capture(
+        old_schemas.frame, old_schemas.scope
+    );
+    Expect(old_capture.Valid(), "old capture was not valid");
+    FinishRuntime(first_output);
+
+    ScopedOutput second_output("moer-render-profile-stale-b");
+    StartRuntime(second_output);
+    Expect(
+        !old_capture.Valid() &&
+            !old_capture.BeginFrame().Valid(),
+        "old capture crossed a ProfileDump generation"
+    );
+    RenderProfileCapture stale_handles(
+        old_schemas.frame, old_schemas.scope
+    );
+    Expect(
+        !stale_handles.Valid(),
+        "stale schema handles constructed a live bridge"
+    );
+
+    const RegisteredGpuSchemas new_schemas = RegisterGpuSchemas();
+    RenderProfileCapture new_capture(
+        new_schemas.frame, new_schemas.scope
+    );
+    Expect(
+        new_capture.Valid(),
+        "current-generation schema handles were rejected"
+    );
+    new_capture.Abort();
+    old_capture.Abort();
+    FinishRuntime(second_output);
+}
+
+void QueueFullDropsRecordsWithoutDisablingCapture() {
+    Testing::ClearHooks();
+    Expect(
+        Testing::ConfigureWriterPauseAfterStart(true),
+        "writer pause hook could not be configured"
+    );
+    WriterResumeGuard resume_guard;
+
+    ScopedOutput output("moer-render-profile-queue-full");
+    RuntimeConfig config{};
+    config.max_record_bytes = 4096;
+    config.tls_publish_records = 1;
+    config.tls_publish_bytes = 4096;
+    config.tls_max_records = 1;
+    config.tls_max_bytes = 4096;
+    config.queue_max_chunks = 1;
+    config.queue_max_records = 1;
+    config.queue_max_bytes = 4096;
+    StartRuntime(output, config);
+    Expect(
+        Testing::WaitForWriterPaused(2000),
+        "writer did not reach the deterministic pause"
+    );
+
+    const RegisteredGpuSchemas schemas = RegisterGpuSchemas();
+    RenderProfileCapture capture(schemas.frame, schemas.scope);
+    RenderProfileFrameToken frame = capture.BeginFrame();
+    CommandList list(EQueueType::Graphics);
+    Expect(
+        capture.BindSource(
+            frame,
+            list,
+            Binding(EQueueType::Graphics, 0, 0),
+            0
+        ) == RenderProfileBindResult::Bound,
+        "queue-full source bind failed"
+    );
+    list.PushScopeWithTimeScope("QueueFull.Scope");
+    list.PopScopeWithTimeScope();
+    CmdSubmit submit = list.Submit();
+    Expect(capture.Seal(frame), "queue-full frame seal failed");
+    ResolveTimestampAt(submit, 0, Timestamp(1, 2));
+    Expect(
+        capture.DrainReadyFrames() == 1,
+        "queue-full frame did not materialize"
+    );
+    RenderProfileCaptureStats pressured = capture.GetStats();
+    Expect(
+        capture.Valid() &&
+            pressured.frames_emitted == 1 &&
+            pressured.scope_records_dropped == 1 &&
+            pressured.terminal_faults == 0,
+        "QueueFull disabled capture or changed drop accounting"
+    );
+
+    resume_guard.Resume();
+    const FlushResult drained = FlushAll();
+    Expect(
+        drained == FlushResult::Completed ||
+            drained == FlushResult::NothingPending,
+        "queue-full recovery did not drain accepted work"
+    );
+    {
+        RenderProfileFrameToken recovered = capture.BeginFrame();
+        Expect(recovered.Valid(), "capture did not recover after QueueFull");
+    }
+    Expect(
+        capture.DrainReadyFrames() == 1,
+        "recovered empty frame did not drain"
+    );
+    const RenderProfileCaptureStats recovered = capture.GetStats();
+    Expect(
+        capture.Valid() &&
+            recovered.frames_emitted == 2 &&
+            recovered.terminal_faults == 0,
+        "capture did not remain active after QueueFull recovery"
+    );
+
+    capture.ShutdownAfterRhiDrain();
+    ReleaseSubmit(submit);
+    FinishRuntime(output);
+    Testing::ClearHooks();
+}
+
+void WriterFaultFailsCaptureClosed() {
+    Testing::ClearHooks();
+    Expect(
+        Testing::ConfigureFault(
+            Testing::FaultPoint::WritePacket, 2
+        ),
+        "writer fault hook could not be configured"
+    );
+
+    ScopedOutput output("moer-render-profile-writer-fault");
+    RuntimeConfig config{};
+    config.tls_publish_records = 1;
+    StartRuntime(output, config);
+    const RegisteredGpuSchemas schemas = RegisterGpuSchemas();
+    RenderProfileCapture capture(schemas.frame, schemas.scope);
+
+    {
+        RenderProfileFrameToken frame = capture.BeginFrame();
+        Expect(frame.Valid(), "fault trigger frame admission failed");
+    }
+    static_cast<void>(capture.DrainReadyFrames());
+    Expect(
+        FlushAll() == FlushResult::Faulted,
+        "injected writer fault did not become observable"
+    );
+    Expect(
+        !capture.BeginFrame().Valid() && !capture.Valid(),
+        "faulted ProfileDump runtime did not close the GPU bridge"
+    );
+    const RenderProfileCaptureStats stats = capture.GetStats();
+    Expect(
+        stats.closed && stats.terminal_faults == 1,
+        "writer fault did not latch one terminal bridge fault"
+    );
+    capture.Abort();
+    Expect(
+        Shutdown() == ShutdownResult::Faulted,
+        "faulted ProfileDump shutdown reported success"
+    );
+    Testing::ClearHooks();
+}
+
+void AdmissionRejectDoesNotOvertakeOrderedFrames() {
+    ScopedOutput output("moer-render-profile-admission-order");
+    StartRuntime(output);
+    const RegisteredGpuSchemas schemas = RegisterGpuSchemas();
+    GpuScopeStreamConfig stream_config{};
+    stream_config.max_resident_frames = 2;
+    stream_config.max_pending_frames = 1;
+    RenderProfileCapture capture(
+        schemas.frame, schemas.scope, stream_config
+    );
+
+    RenderProfileFrameToken first = capture.BeginFrame();
+    Expect(
+        first.Valid() && first.FrameId() == 1,
+        "ordered admission first frame failed"
+    );
+    RenderProfileFrameToken rejected = capture.BeginFrame();
+    Expect(
+        !rejected.Valid() && rejected.FrameId() == 2,
+        "pending-frame limit did not reject frame 2"
+    );
+    Expect(
+        capture.Seal(first) &&
+            capture.DrainReadyFrames() == 1,
+        "ordered admission first frame did not drain"
+    );
+
+    {
+        RenderProfileFrameToken recovered = capture.BeginFrame();
+        Expect(
+            recovered.Valid() && recovered.FrameId() == 3,
+            "capture did not recover after admission rejection"
+        );
+    }
+    Expect(
+        capture.DrainReadyFrames() == 1,
+        "ordered admission recovered frame did not drain"
+    );
+    capture.ShutdownAfterRhiDrain();
+    const RenderProfileCaptureStats stats = capture.GetStats();
+    Expect(
+        stats.frames_attempted == 3 &&
+            stats.frames_admitted == 2 &&
+            stats.frames_admission_rejected == 1 &&
+            stats.frames_emitted == 2 &&
+            stats.shutdown_abandoned_frames == 0,
+        "admission rejection accounting is incorrect"
+    );
+    FinishRuntime(output);
+
+    const ParsedDump dump = ParseDump(output.path);
+    const auto frames = RecordsFor(
+        dump, FindSchema(dump, "GpuFrame")
+    );
+    Expect(
+        frames.size() == 2 &&
+            ValueAt<std::uint64_t>(*frames[0], 0) == 1 &&
+            ValueAt<std::uint64_t>(*frames[1], 0) == 3,
+        "rejected frame overtook or polluted ordered frame output"
+    );
+}
+
+} // namespace
+
+int main() {
+    try {
+        HappyPathPreservesTopologyAndRawTimestampDomains();
+        AbortDetachesPendingCompletionWithoutBlocking();
+        ShutdownAfterRhiDrainPerformsFinalDrain();
+        StaleGenerationFailsClosed();
+        QueueFullDropsRecordsWithoutDisablingCapture();
+        WriterFaultFailsCaptureClosed();
+        AdmissionRejectDoesNotOvertakeOrderedFrames();
+    } catch (const std::exception& error) {
+        std::cerr << "RenderProfileCaptureContract: "
+                  << error.what() << '\n';
+        return 1;
+    }
+    std::cout
+        << "RenderProfileCaptureContract: all checks passed\n";
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add Engine-owned RenderProfileCapture over the bounded GpuScopeStream
- register GpuFrame v1 and GpuScope v2 schemas with generation/hash validation
- preserve FIFO materialization, raw GPU clock domains, RAII frame sealing, and fail-closed shutdown semantics
- keep production Raster/Raytracing/RenderGraph wiring intentionally inert for Phase 21C.2b

## Validation
- Debug full build and CTest: 26/26
- RelWithDebInfo full build and CTest: 26/26
- threading Python contracts: 146/146
- Vulkan renderer-switch smoke: Raster -> Raytracing -> Raster, clean shutdown, no validation/device-loss errors, no .inprogress
- ProfileDump-disabled Editor smoke: clean shutdown and no output
- three independent pre-commit audits: P0/P1/P2 = 0

## Follow-up
Phase 21C.2b will bind ordered recording sources in Raster, Raytracing, and RenderGraph and drain completed GPU frames from the production owner loop.