### PR TITLE
Phase 21C.2b.1: wire Raster GPU profile topology

### DIFF
--- a/source/runtime/Engine.cpp
+++ b/source/runtime/Engine.cpp
@@ -1127,7 +1127,9 @@ void Engine::Run(const EngineHooks& hooks) {
         auto create_renderer = [this, runtime_hooks, selected_render_method]() {
             if (selected_render_method == ERenderMethod::Raster) {
                 m_renderer = MakeUnique<Raster::RasterRenderer>(
-                    m_editor_config->GetResolution(), m_editor_config
+                    m_editor_config->GetResolution(),
+                    m_editor_config,
+                    m_render_profile_capture.get()
                 );
 
             } else if (selected_render_method == ERenderMethod::Raytracing) {

--- a/source/runtime/render/renderer/Renderer.cpp
+++ b/source/runtime/render/renderer/Renderer.cpp
@@ -19,11 +19,16 @@
 
 namespace Moer::Render {
 
-Renderer::Renderer(uint2 initial_resolution, const SharedPtr<EditorConfig> config) :
+Renderer::Renderer(
+    uint2                         initial_resolution,
+    const SharedPtr<EditorConfig> config,
+    RenderProfileCapture*         _render_profile_capture
+) :
     device(RenderDevice::Get()),
     manager(ShaderManager::Get()),
     gfx_queue(device.GetCommandQueue(EQueueType::Graphics)),
     resolution(initial_resolution),
+    render_profile_capture(_render_profile_capture),
     scene(),
     cmd_list() {
 

--- a/source/runtime/render/renderer/Renderer.h
+++ b/source/runtime/render/renderer/Renderer.h
@@ -20,6 +20,8 @@
 
 namespace Moer::Render {
 
+class RenderProfileCapture;
+
 struct EngineHooks {
     // Common
     std::function<void(Scene&)> on_tick_scripting;
@@ -62,7 +64,11 @@ public:
         uint2        resolution = uint2(0u, 0u);
     };
 
-    Renderer(uint2 initial_resolution, const SharedPtr<EditorConfig> config);
+    Renderer(
+        uint2                         initial_resolution,
+        const SharedPtr<EditorConfig> config,
+        RenderProfileCapture*         render_profile_capture = nullptr
+    );
 
     virtual ~Renderer();
 
@@ -105,6 +111,8 @@ protected:
     ShaderManager& manager;
     CommandQueue&  gfx_queue;
     uint2          resolution;
+    // Engine owns the capture bridge and outlives every renderer instance.
+    RenderProfileCapture* render_profile_capture = nullptr;
 
     SwapchainRef     swapchain;
     BindlessArrayRef bindless_array;

--- a/source/runtime/render/renderer/raster/RasterRenderer.cpp
+++ b/source/runtime/render/renderer/raster/RasterRenderer.cpp
@@ -27,6 +27,7 @@
 #include "debug/RenderDocApi.h"
 #include "misc/ScopedLogTimer.h"
 #include "profile/ProfileScope.h"
+#include "profile/RenderProfileCapture.h"
 #include "renderer/common/UiFrameGraphPass.h"
 #include "rendergraph/RenderGraph.h"
 #include "rhi/RHIExecutor.h"
@@ -58,10 +59,11 @@ float GetElapsedTimeSeconds() {
 } // namespace
 
 RasterRenderer::RasterRenderer(
-    uint2                   initial_resolution,
-    SharedPtr<EditorConfig> config
+    uint2                         initial_resolution,
+    SharedPtr<EditorConfig>       config,
+    RenderProfileCapture*         render_profile_capture
 ) :
-    Renderer(initial_resolution, config),
+    Renderer(initial_resolution, config, render_profile_capture),
     scene_render_extent_tracker(initial_resolution) {
     ScopedLogTimer startup_timer("[Startup][RasterRenderer] RasterRenderer::Constructor() total");
 
@@ -459,6 +461,59 @@ RasterFrameFeedback RasterRenderer::RenderFrame(RasterFramePacket frame_packet) 
     assert(!IsRenderThreadInitialized() || IsCurrentlyRenderThread());
     MOER_PROFILE_SCOPE("Raster.RenderFrame");
 
+    RenderProfileFrameToken gpu_profile_frame{};
+    if (render_profile_capture != nullptr) {
+        static_cast<void>(render_profile_capture->DrainReadyFrames());
+        gpu_profile_frame = render_profile_capture->BeginFrame();
+    }
+    const RHIQueueBinding graphics_profile_binding =
+        device.GetQueueTopology().Resolve(EQueueType::Graphics);
+    const RHIQueueBinding copy_profile_binding =
+        device.GetQueueTopology().Resolve(EQueueType::Copy);
+    auto try_bind_profile_source =
+        [&](CommandList&    command_list,
+            RHIQueueBinding queue_binding,
+            uint64          source_order) noexcept {
+            if (render_profile_capture == nullptr || !gpu_profile_frame.Valid()) {
+                return false;
+            }
+            return render_profile_capture->BindSource(
+                       gpu_profile_frame,
+                       command_list,
+                       queue_binding,
+                       source_order
+                   ) == RenderProfileBindResult::Bound;
+        };
+    auto ensure_profile_source =
+        [&](CommandList&    command_list,
+            RHIQueueBinding queue_binding,
+            uint64          source_order) noexcept {
+            if (command_list.HasGpuScopeRecorder()) {
+                return true;
+            }
+            if (!gpu_profile_frame.Valid() ||
+                command_list.IsLegacyGpuProfilingSuppressedForGeneration()) {
+                return false;
+            }
+            if (try_bind_profile_source(
+                    command_list, queue_binding, source_order
+                )) {
+                return true;
+            }
+            try {
+                command_list.SuppressLegacyGpuProfilingForGeneration();
+            } catch (...) {
+                // Profiling degradation must not change the render path.
+            }
+            return false;
+        };
+    // Order zero is reserved for work already resident in the persistent
+    // Raster CommandList (resize/bindless prefix). Scene-update generations
+    // advance this cursor before RDG/linear recording chooses its base.
+    uint64 next_profile_source_order = 1;
+    uint64 linear_source_order       = 1;
+    uint64 tail_source_order         = 1;
+
     auto& raster_context = *raster_context_ptr;
     auto scene_extent_request = frame_packet.scene_render_extent;
     // An OS-window resize already requires a presentation rebuild. Accept the
@@ -500,7 +555,12 @@ RasterFrameFeedback RasterRenderer::RenderFrame(RasterFramePacket frame_packet) 
     const bool recreate_output_resources =
         !EqualRenderExtent(raster_context.GetOutputResolution(), frame_packet.window.resolution);
 
-    if (!skip_present && (recreate_scene_resources || recreate_output_resources)) {
+    const bool recreate_frame_resources =
+        !skip_present && (recreate_scene_resources || recreate_output_resources);
+    const bool resize_prefix_profile_bound =
+        recreate_frame_resources &&
+        ensure_profile_source(cmd_list, graphics_profile_binding, 0);
+    if (recreate_frame_resources) {
         raster_context.FreeFrameBuffers(
             false, recreate_scene_resources, recreate_output_resources
         );
@@ -512,9 +572,21 @@ RasterFrameFeedback RasterRenderer::RenderFrame(RasterFramePacket frame_packet) 
         );
         // External assets are resolution-independent and retain their bindless
         // handles. Only the selected resource domains are allocated again.
-        raster_context.AllocateFrameBuffers(
-            recreate_scene_resources, recreate_output_resources
-        );
+        if (resize_prefix_profile_bound) {
+            ScopedGpuMarker resize_marker(
+                cmd_list,
+                "Raster Resource Resize",
+                GpuMarkerPalette::Transfer(),
+                EGpuMarkerMode::Timestamp
+            );
+            raster_context.AllocateFrameBuffers(
+                recreate_scene_resources, recreate_output_resources
+            );
+        } else {
+            raster_context.AllocateFrameBuffers(
+                recreate_scene_resources, recreate_output_resources
+            );
+        }
 
         if (recreate_scene_resources) {
             raster_context.csm_data.shadow_cache_config_snapshot_valid = false;
@@ -555,6 +627,21 @@ RasterFrameFeedback RasterRenderer::RenderFrame(RasterFramePacket frame_packet) 
         );
     }
 
+    // Modern RDG/source binding requires an empty caller-thread list. Publish
+    // any already-recorded resize prefix before scene-update Copy/Graphics
+    // sources so source_order remains consistent with execution order.
+    if (gpu_profile_frame.Valid() && !cmd_list.IsEmpty()) {
+        CmdSubmit prefix_submit = cmd_list.Submit().DebugLabel(
+            std::format("Raster Frame {}/Prefix", frame_packet.frame_id),
+            GpuMarkerPalette::Transfer()
+        );
+        RHIExecutor::Get().Submit(
+            EQueueType::Graphics,
+            std::move(prefix_submit),
+            ERHIExecSubmitFlags::None
+        );
+    }
+
     TextureRef default_output_texture = raster_context.textures.output.tex;
 
     // 窗口资源就绪后再使用已准备好的场景快照。
@@ -562,8 +649,31 @@ RasterFrameFeedback RasterRenderer::RenderFrame(RasterFramePacket frame_packet) 
     if (frame_packet.scene_updates.scene_ready) {
         // 处理场景加载过程中遗留的命令
         auto& scene_updates = frame_packet.scene_updates;
+        const auto setup_scene_update_profiling =
+            [&](GpuScene::PendingCommandList& commands,
+                bool                          full_rebuild) {
+                if (full_rebuild) {
+                    const uint64 copy_source_order =
+                        next_profile_source_order++;
+                    static_cast<void>(ensure_profile_source(
+                        commands.copy_queue_cmd_list,
+                        copy_profile_binding,
+                        copy_source_order
+                    ));
+                }
+                const uint64 graphics_source_order =
+                    next_profile_source_order++;
+                static_cast<void>(ensure_profile_source(
+                    commands.gfx_queue_cmd_list,
+                    graphics_profile_binding,
+                    graphics_source_order
+                ));
+            };
         if (scene_updates.initial_gpu_update) {
-            auto commands = render_scene->ApplyUpdate(std::move(*scene_updates.initial_gpu_update));
+            auto commands = render_scene->ApplyUpdate(
+                std::move(*scene_updates.initial_gpu_update),
+                setup_scene_update_profiling
+            );
             RasterTool::ExecuteScenePendingCommands(
                 std::move(commands), device, gfx_queue
             );
@@ -573,7 +683,24 @@ RasterFrameFeedback RasterRenderer::RenderFrame(RasterFramePacket frame_packet) 
             first_load = false;
 
             // 第一个 Raster Pass 执行前，先发布首次场景上传创建的 descriptor。
-            cmd_list.UpdateBindlessArray(bindless_array);
+            const uint64 descriptor_source_order =
+                next_profile_source_order++;
+            const bool descriptor_profile_bound = ensure_profile_source(
+                cmd_list,
+                graphics_profile_binding,
+                descriptor_source_order
+            );
+            if (descriptor_profile_bound) {
+                ScopedGpuMarker prefix_marker(
+                    cmd_list,
+                    "Raster First Load Descriptor",
+                    GpuMarkerPalette::Transfer(),
+                    EGpuMarkerMode::Timestamp
+                );
+                cmd_list.UpdateBindlessArray(bindless_array);
+            } else {
+                cmd_list.UpdateBindlessArray(bindless_array);
+            }
             RHIExecutor::Get().Submit(
                 EQueueType::Graphics, cmd_list.Submit(), ERHIExecSubmitFlags::FlushGPU
             );
@@ -584,15 +711,24 @@ RasterFrameFeedback RasterRenderer::RenderFrame(RasterFramePacket frame_packet) 
 
         const auto& scene_tick_state = scene_updates.tick_state;
         if (scene_updates.update_gpu_update) {
-            auto commands = render_scene->ApplyUpdate(std::move(*scene_updates.update_gpu_update));
+            auto commands = render_scene->ApplyUpdate(
+                std::move(*scene_updates.update_gpu_update),
+                setup_scene_update_profiling
+            );
             RasterTool::ExecuteScenePendingCommands(
                 std::move(commands), device, gfx_queue
             );
         }
 
-        ScopedGpuMarker renderer_marker(
-            cmd_list, "Raster Renderer", GpuMarkerPalette::Renderer()
-        );
+        // ExecuteRecording owns modern per-source binding and requires the
+        // caller-thread list to be empty at graph entry. Preserve the legacy
+        // renderer label only when no modern frame was admitted.
+        std::optional<ScopedGpuMarker> renderer_marker{};
+        if (!gpu_profile_frame.Valid()) {
+            renderer_marker.emplace(
+                cmd_list, "Raster Renderer", GpuMarkerPalette::Renderer()
+            );
+        }
 
         const Camera& main_camera = scene_updates.main_camera;
         Camera        camera      = frame_packet.render_camera;
@@ -1163,10 +1299,18 @@ RasterFrameFeedback RasterRenderer::RenderFrame(RasterFramePacket frame_packet) 
             );
         };
 
+        linear_source_order = next_profile_source_order;
+        tail_source_order   = next_profile_source_order;
         auto execute_linear = [&]() {
-            ScopedGpuMarker pipeline_marker(
-                cmd_list, "Raster Linear Pipeline", GpuMarkerPalette::RenderGraph()
-            );
+            // A visual pipeline marker may not cross ExternalControl's explicit
+            // Submit boundary. Modern capture instead uses closed per-pass
+            // timestamp roots and rebinds the next recording generation.
+            std::optional<ScopedGpuMarker> pipeline_marker{};
+            if (!gpu_profile_frame.Valid()) {
+                pipeline_marker.emplace(
+                    cmd_list, "Raster Linear Pipeline", GpuMarkerPalette::RenderGraph()
+                );
+            }
             auto linear_schedule =
                 [&](std::string_view                name,
                     auto&&,
@@ -1175,19 +1319,40 @@ RasterFrameFeedback RasterRenderer::RenderFrame(RasterFramePacket frame_packet) 
                 if (execution_class == RenderGraph::PassExecutionClass::CpuPrepare ||
                     execution_class == RenderGraph::PassExecutionClass::ExternalControl) {
                     std::forward<decltype(execute)>(execute)(cmd_list);
+                    if (execution_class == RenderGraph::PassExecutionClass::ExternalControl &&
+                        gpu_profile_frame.Valid()) {
+                        ++linear_source_order;
+                    }
                     return;
                 }
+                static_cast<void>(ensure_profile_source(
+                    cmd_list, graphics_profile_binding, linear_source_order
+                ));
                 const std::string marker_name = std::format("Pass: {}", name);
                 ScopedGpuMarker pass_marker(
-                    cmd_list, marker_name, GpuMarkerPalette::Pass()
+                    cmd_list,
+                    marker_name,
+                    GpuMarkerPalette::Pass(),
+                    cmd_list.HasGpuScopeRecorder() ?
+                        EGpuMarkerMode::Timestamp :
+                        EGpuMarkerMode::Label
                 );
                 std::forward<decltype(execute)>(execute)(cmd_list);
             };
             define_raster_passes(linear_schedule);
+            // ExternalControl may seal the current CommandList generation.
+            // The tail either reuses the post-boundary generation or binds
+            // this next unique order when no later GPU pass was recorded.
+            tail_source_order = linear_source_order;
         };
 
         if (render_graph_enabled && !render_graph_fallback_latched) {
-            RenderGraph graph("RasterFrame");
+            // Profile sources and RDG barriers must use the initialized RHI's
+            // physical queue identity rather than the test-only single-queue
+            // default (native/family zero).
+            RenderGraph graph(
+                "RasterFrame", RenderGraph::QueueTopology::FromRHI()
+            );
             auto import_physical_texture = [&](std::string_view name, Texture* physical_texture) {
                 assert(physical_texture != nullptr);
                 RenderGraph::TextureAspect aspects = RenderGraph::TextureAspect::None;
@@ -1379,7 +1544,16 @@ RasterFrameFeedback RasterRenderer::RenderFrame(RasterFramePacket frame_packet) 
                     // A long-lived renderer/graph marker cannot cross the per-pass Submit boundaries.
                     // Every pass still owns its own marker and the immutable source packet carries a
                     // stable frame/pass debug label.
-                    renderer_marker.Close();
+                    if (renderer_marker) {
+                        renderer_marker->Close();
+                    }
+                    const uint64 graph_source_order_base =
+                        next_profile_source_order;
+                    tail_source_order =
+                        graph_source_order_base +
+                        static_cast<uint64>(
+                            graph.GetCompiledPlan().execution_order.size()
+                        );
                     const auto submit_main_thread_pass =
                         [&](const RenderGraph::ExecutedPassInfo& pass) {
                             assert(
@@ -1445,11 +1619,43 @@ RasterFrameFeedback RasterRenderer::RenderFrame(RasterFramePacket frame_packet) 
                             source.submit_metadata.translate_execution_class =
                                 ERHITranslateExecutionClass::SerialControl;
                         };
+                    RenderGraph::GpuProfilingOptions gpu_profiling{};
+                    if (gpu_profile_frame.Valid()) {
+                        gpu_profiling.try_bind_source =
+                            [&](const RenderGraph::ExecutedPassInfo&,
+                                CommandList&    recording_cmd_list,
+                                RHIQueueBinding queue_binding,
+                                uint64          source_order) noexcept {
+                                return try_bind_profile_source(
+                                    recording_cmd_list,
+                                    queue_binding,
+                                    source_order
+                                );
+                            };
+                        gpu_profiling.main_thread_command_list = &cmd_list;
+                        gpu_profiling.source_order_base =
+                            graph_source_order_base;
+                    }
                     if (!graph.ExecuteRecording(
                             submit_main_thread_pass,
                             configure_recording_source,
-                            parallel_recording_enabled
+                            parallel_recording_enabled,
+                            {},
+                            {},
+                            gpu_profiling
                         )) {
+                        if (gpu_profile_frame.Valid() &&
+                            (cmd_list.HasGpuScopeRecorder() ||
+                             cmd_list
+                                 .IsLegacyGpuProfilingSuppressedForGeneration())) {
+                            // A failed caller-thread pass never reaches the
+                            // observer Submit boundary. Rotate and reject that
+                            // partial generation so the frame tail cannot be
+                            // attributed to the failed pass source.
+                            CmdSubmit rejected_graph_generation =
+                                cmd_list.Submit();
+                            static_cast<void>(rejected_graph_generation);
+                        }
                         render_graph_fallback_latched = true;
                         LOG_ERROR(
                             "[RenderGraph][Fallback] Raster graph recording failed after execution began: {}. "
@@ -1488,36 +1694,52 @@ RasterFrameFeedback RasterRenderer::RenderFrame(RasterFramePacket frame_packet) 
     UiDrawFrameSlotClaim ui_slot_claim(frame_packet.ui_draw_frame);
     const bool ui_recording_claimed =
         ui_slot_claim.IsReadyForRecording();
-    if (ui_recording_claimed) {
-        RenderUiDrawFrame(
-            cmd_list,
-            default_output_texture->GetView(),
-            frame_packet.ui_draw_frame,
-            ui_execution_thread
-        );
-    } else {
-        ui_slot_claim.Reject();
-        skip_present = true;
-        LOG_CRITICAL(
-            "[Threading][UI] Raster copied-frame upload slots could not be "
-            "claimed; preserving the slots and skipping this frame's presents."
-        );
-    }
+    const auto record_frame_tail = [&]() {
+        if (ui_recording_claimed) {
+            RenderUiDrawFrame(
+                cmd_list,
+                default_output_texture->GetView(),
+                frame_packet.ui_draw_frame,
+                ui_execution_thread
+            );
+        } else {
+            ui_slot_claim.Reject();
+            skip_present = true;
+            LOG_CRITICAL(
+                "[Threading][UI] Raster copied-frame upload slots could not be "
+                "claimed; preserving the slots and skipping this frame's presents."
+            );
+        }
 
-    raster_context.probe_volume.TrackFrameSubmission(cmd_list, time);
-    if (!skip_present && ui_recording_claimed &&
-        !UiFrameGraphPass::RecordPresentationBoundary(
+        raster_context.probe_volume.TrackFrameSubmission(cmd_list, time);
+        if (!skip_present && ui_recording_claimed &&
+            !UiFrameGraphPass::RecordPresentationBoundary(
+                cmd_list,
+                frame_packet.ui_composition,
+                frame_packet.ui_draw_frame,
+                default_output_texture
+            )) {
+            skip_present = true;
+            LOG_CRITICAL(
+                "[Presentation] Raster UI frame tail did not satisfy the "
+                "presentation-source resource contract; skipping this frame's "
+                "main and platform-window presents."
+            );
+        }
+    };
+    const bool tail_profile_bound = ensure_profile_source(
+        cmd_list, graphics_profile_binding, tail_source_order
+    );
+    if (tail_profile_bound) {
+        ScopedGpuMarker tail_marker(
             cmd_list,
-            frame_packet.ui_composition,
-            frame_packet.ui_draw_frame,
-            default_output_texture
-        )) {
-        skip_present = true;
-        LOG_CRITICAL(
-            "[Presentation] Raster UI frame tail did not satisfy the "
-            "presentation-source resource contract; skipping this frame's "
-            "main and platform-window presents."
+            "Raster Frame Tail",
+            GpuMarkerPalette::Ui(),
+            EGpuMarkerMode::Timestamp
         );
+        record_frame_tail();
+    } else {
+        record_frame_tail();
     }
     time++;
     // Host 同步的 copy 操作已经完成。此处触发 timeline，向 validation layer 传递执行顺序，
@@ -1571,6 +1793,10 @@ RasterFrameFeedback RasterRenderer::RenderFrame(RasterFramePacket frame_packet) 
         ERHIExecSubmitFlags::FlushGPU,
         present_request ? &*present_request : nullptr
     );
+    if (render_profile_capture != nullptr && gpu_profile_frame.Valid()) {
+        static_cast<void>(render_profile_capture->Seal(gpu_profile_frame));
+        static_cast<void>(render_profile_capture->DrainReadyFrames());
+    }
 
     const bool frame_native_accepted = timeline->WaitSubmitted(time);
     bool       ui_source_accepted    = false;

--- a/source/runtime/render/renderer/raster/RasterRenderer.h
+++ b/source/runtime/render/renderer/raster/RasterRenderer.h
@@ -43,7 +43,11 @@ class TensorRTPass;
 class RENDER_API RasterRenderer : public Renderer {
 
 public:
-    RasterRenderer(uint2 initial_resolution, SharedPtr<EditorConfig> config);
+    RasterRenderer(
+        uint2                         initial_resolution,
+        SharedPtr<EditorConfig>       config,
+        RenderProfileCapture*         render_profile_capture
+    );
 
     ~RasterRenderer() override;
 

--- a/source/runtime/render/renderer/raster/RasterTool.cpp
+++ b/source/runtime/render/renderer/raster/RasterTool.cpp
@@ -244,11 +244,19 @@ void RasterTool::ExecuteScenePendingCommands(
     (void)gfx_queue;
 
     (void)device;
+    const bool modern_graphics_profiling =
+        commands.gfx_queue_cmd_list.HasGpuScopeRecorder() ||
+        commands.gfx_queue_cmd_list
+            .IsLegacyGpuProfilingSuppressedForGeneration();
     Array<RHIBackendSubmissionBatchEntry> submissions{};
     submissions.emplace_back(EQueueType::Copy, commands.copy_queue_cmd_list.Submit());
+    CmdSubmit graphics_submit =
+        commands.gfx_queue_cmd_list.Submit();
+    if (!modern_graphics_profiling) {
+        graphics_submit.TickProfiling();
+    }
     submissions.emplace_back(
-        EQueueType::Graphics,
-        commands.gfx_queue_cmd_list.Submit().TickProfiling()
+        EQueueType::Graphics, std::move(graphics_submit)
     );
     RHIExecutor::Get().Submit(
         std::move(submissions),

--- a/source/runtime/render/rendergraph/RenderGraph.cpp
+++ b/source/runtime/render/rendergraph/RenderGraph.cpp
@@ -591,6 +591,17 @@ RenderGraph::PassBuilder::ExecuteOn(QueueRole queue, PipelineType pipeline) {
     return EQueueType::Ignore;
 }
 
+[[nodiscard]] RHIQueueBinding ToRHIQueueBinding(
+    const RenderGraph::QueueBinding& binding
+) {
+    return RHIQueueBinding{
+        .queue           = ToRHIQueue(binding.role),
+        .native_queue_id = binding.native_queue_id,
+        .family_id       = binding.family_id,
+        .available       = binding.available,
+    };
+}
+
 [[nodiscard]] RenderGraph::TextureAspect
 RaiseTextureAspects(ETextureAspectFlags aspects) {
     RenderGraph::TextureAspect result = RenderGraph::TextureAspect::None;
@@ -1306,7 +1317,8 @@ bool RenderGraph::ExecuteRecording(
     const RecordingSourceSetupCallback& configure_recording_source,
     bool                                parallel_recording_enabled,
     const RecordingBatchPublisher&      publish_recording_batch,
-    const ActiveRecordingOptions&       active_recording
+    const ActiveRecordingOptions&       active_recording,
+    const GpuProfilingOptions&          gpu_profiling
 ) {
     if (!compiled) {
         compile_error = "ExecuteRecording called before a successful Compile";
@@ -1317,6 +1329,67 @@ bool RenderGraph::ExecuteRecording(
         return false;
     }
     MOER_PROFILE_SCOPE("RenderGraph.ExecuteRecording");
+
+    if (gpu_profiling.try_bind_source) {
+        bool has_main_thread_pass = false;
+        for (const CompiledRecordingBatch& batch :
+             compiled_plan.recording_batches) {
+            if (batch.passes.size() != 1) {
+                compile_error =
+                    "GPU profiling requires one pass per compiled recording batch";
+                return false;
+            }
+            if (batch.id >= compiled_plan.execution_order.size() ||
+                compiled_plan.execution_order[batch.id] !=
+                    batch.passes.front()) {
+                compile_error =
+                    "GPU profiling recording batch order does not match "
+                    "compiled execution order";
+                return false;
+            }
+            if (gpu_profiling.source_order_base >
+                std::numeric_limits<uint64>::max() -
+                    static_cast<uint64>(batch.id)) {
+                compile_error = "GPU profiling source order overflow";
+                return false;
+            }
+            if (batch.execution == PassExecutionClass::MainThread) {
+                has_main_thread_pass = true;
+                if (gpu_profiling.main_thread_command_list == nullptr) {
+                    compile_error =
+                        "GPU profiling requires a caller-owned CommandList for "
+                        "MainThread passes";
+                    return false;
+                }
+                if (gpu_profiling.main_thread_command_list->GetQueueType() !=
+                    ToRHIQueue(batch.queue.role)) {
+                    compile_error =
+                        "GPU profiling MainThread CommandList queue does not "
+                        "match compiled pass queue";
+                    return false;
+                }
+            }
+        }
+        if (has_main_thread_pass &&
+            (!gpu_profiling.main_thread_command_list->IsEmpty() ||
+             gpu_profiling.main_thread_command_list
+                 ->HasGpuScopeRecorder() ||
+             gpu_profiling.main_thread_command_list
+                 ->IsLegacyGpuProfilingSuppressedForGeneration())) {
+            compile_error =
+                "GPU profiling requires an empty, unbound, unsuppressed MainThread "
+                "CommandList at graph entry";
+            return false;
+        }
+        if (has_main_thread_pass && active_recording.enabled &&
+            active_recording.main_thread_command_list !=
+                gpu_profiling.main_thread_command_list) {
+            compile_error =
+                "GPU profiling and active recording must use the same "
+                "MainThread CommandList";
+            return false;
+        }
+    }
 
     struct TransientBindingReleaseGuard {
         RenderGraphTransientAllocator* allocator{nullptr};
@@ -1620,6 +1693,10 @@ bool RenderGraph::ExecuteRecording(
         RecordCallback      record{};
         SharedPtr<CommandList> command_list{};
         RHIRecordingGateRef completion{};
+        RHIQueueBinding     gpu_profile_queue_binding{};
+        uint64              gpu_profile_source_order{0};
+        bool                gpu_profile_requested{false};
+        bool                gpu_profile_bound{false};
         ERHITranslateExecutionClass translate_execution_class{
             ERHITranslateExecutionClass::Parallel
         };
@@ -1835,6 +1912,103 @@ bool RenderGraph::ExecuteRecording(
         };
     };
 
+    enum class GpuProfileBindOutcome : uint8 {
+        Bound,
+        Dropped,
+        Failed,
+    };
+    auto bind_gpu_profile_source =
+        [&](const ExecutedPassInfo& pass_info,
+            CommandList&            command_list,
+            RHIQueueBinding         queue_binding,
+            uint64                  source_order) {
+            if (!gpu_profiling.try_bind_source) {
+                return GpuProfileBindOutcome::Dropped;
+            }
+            if (!command_list.IsEmpty() ||
+                command_list.HasGpuScopeRecorder() ||
+                command_list
+                    .IsLegacyGpuProfilingSuppressedForGeneration()) {
+                compile_error =
+                    "GPU profiling source binding requires an empty, unbound, "
+                    "unsuppressed "
+                    "CommandList for pass '" +
+                    std::string(pass_info.name) + "'";
+                return GpuProfileBindOutcome::Failed;
+            }
+
+            const uint64 seal_generation =
+                command_list.GetSealGeneration();
+            const bool explicit_resource_state =
+                command_list.HasExplicitResourceStateOwnership();
+            const ERHITranslateExecutionClass translate_execution =
+                command_list.GetTranslateExecutionClass();
+            const bool legacy_profiling_suppressed =
+                command_list
+                    .IsLegacyGpuProfilingSuppressedForGeneration();
+
+            bool bound = false;
+            try {
+                RHIThreadRoleScope configuration_owner(
+                    ERHIThreadRole::RecordWorker
+                );
+                bound = gpu_profiling.try_bind_source(
+                    pass_info,
+                    command_list,
+                    queue_binding,
+                    source_order
+                );
+            } catch (const std::exception& exception) {
+                compile_error =
+                    "GPU profiling source binding failed for pass '" +
+                    std::string(pass_info.name) + "': " + exception.what();
+                return GpuProfileBindOutcome::Failed;
+            } catch (...) {
+                compile_error =
+                    "GPU profiling source binding failed for pass '" +
+                    std::string(pass_info.name) + "'";
+                return GpuProfileBindOutcome::Failed;
+            }
+
+            if (!command_list.IsEmpty() ||
+                command_list.GetSealGeneration() != seal_generation ||
+                command_list.HasExplicitResourceStateOwnership() !=
+                    explicit_resource_state ||
+                command_list.GetTranslateExecutionClass() !=
+                    translate_execution ||
+                command_list
+                        .IsLegacyGpuProfilingSuppressedForGeneration() !=
+                    legacy_profiling_suppressed ||
+                command_list.HasGpuScopeRecorder() != bound) {
+                compile_error =
+                    "GPU profiling source binding illegally mutated "
+                    "CommandList state for pass '" +
+                    std::string(pass_info.name) + "'";
+                return GpuProfileBindOutcome::Failed;
+            }
+            if (bound) {
+                return GpuProfileBindOutcome::Bound;
+            }
+            try {
+                command_list
+                    .SuppressLegacyGpuProfilingForGeneration();
+            } catch (const std::exception& exception) {
+                compile_error =
+                    "GPU profiling source drop suppression failed for pass '" +
+                    std::string(pass_info.name) + "': " + exception.what();
+                return GpuProfileBindOutcome::Failed;
+            } catch (...) {
+                compile_error =
+                    "GPU profiling source drop suppression failed for pass '" +
+                    std::string(pass_info.name) + "'";
+                return GpuProfileBindOutcome::Failed;
+            }
+            return GpuProfileBindOutcome::Dropped;
+        };
+    std::optional<uint64> gpu_profile_main_thread_generation{};
+    bool                  gpu_profile_main_thread_bound{false};
+    bool gpu_profile_managed_source_since_main_thread{false};
+
     auto store_error = [](const std::shared_ptr<RecordingError>& error, std::string message) {
         std::lock_guard lock(error->mutex);
         if (error->message.empty()) {
@@ -1951,6 +2125,59 @@ bool RenderGraph::ExecuteRecording(
                 };
 
             try {
+                bool gpu_profile_bound = false;
+                if (first_batch.execution ==
+                        PassExecutionClass::MainThread &&
+                    gpu_profiling.try_bind_source) {
+                    CommandList& profiling_list =
+                        *gpu_profiling.main_thread_command_list;
+                    const uint64 generation =
+                        profiling_list.GetSealGeneration();
+                    if (!gpu_profile_main_thread_generation ||
+                        *gpu_profile_main_thread_generation != generation) {
+                        const uint64 source_order =
+                            gpu_profiling.source_order_base +
+                            static_cast<uint64>(first_batch.id);
+                        const GpuProfileBindOutcome bind_outcome =
+                            bind_gpu_profile_source(
+                                make_pass_info(first_handle),
+                                profiling_list,
+                                ToRHIQueueBinding(first_batch.queue),
+                                source_order
+                            );
+                        if (bind_outcome == GpuProfileBindOutcome::Failed) {
+                            return reject_main_thread(
+                                std::move(compile_error)
+                            );
+                        }
+                        gpu_profile_main_thread_generation = generation;
+                        gpu_profile_main_thread_bound =
+                            bind_outcome == GpuProfileBindOutcome::Bound;
+                        gpu_profile_managed_source_since_main_thread = false;
+                    } else if (
+                        gpu_profile_managed_source_since_main_thread
+                    ) {
+                        return reject_main_thread(
+                            "GPU profiling MainThread CommandList must rotate "
+                            "its recording generation after an intervening "
+                            "managed GPU source"
+                        );
+                    } else if (
+                        profiling_list.HasGpuScopeRecorder() !=
+                            gpu_profile_main_thread_bound ||
+                        profiling_list
+                                .IsLegacyGpuProfilingSuppressedForGeneration() ==
+                            gpu_profile_main_thread_bound
+                    ) {
+                        return reject_main_thread(
+                            "GPU profiling MainThread CommandList changed "
+                            "recorder state within one recording generation"
+                        );
+                    }
+                    gpu_profile_bound =
+                        gpu_profile_main_thread_bound;
+                }
+
                 if (active_physical_main_thread) {
                     auto& command_list =
                         *active_recording.main_thread_command_list;
@@ -1972,7 +2199,21 @@ bool RenderGraph::ExecuteRecording(
                         active_recording.main_thread_command_list
                             ->GetSealGeneration() :
                         0;
-                first_pass.execute();
+                if (first_batch.execution ==
+                        PassExecutionClass::MainThread &&
+                    gpu_profiling.try_bind_source) {
+                    ScopedGpuMarker pass_marker(
+                        *gpu_profiling.main_thread_command_list,
+                        first_pass.name,
+                        GpuMarkerPalette::Pass(),
+                        gpu_profile_bound ?
+                            EGpuMarkerMode::Timestamp :
+                            EGpuMarkerMode::Label
+                    );
+                    first_pass.execute();
+                } else {
+                    first_pass.execute();
+                }
 
                 if (active_physical_main_thread &&
                     active_recording.main_thread_command_list
@@ -2017,6 +2258,30 @@ bool RenderGraph::ExecuteRecording(
             continue;
         }
 
+        if (gpu_profiling.try_bind_source &&
+            gpu_profile_main_thread_generation) {
+            const CommandList& profiling_list =
+                *gpu_profiling.main_thread_command_list;
+            if (profiling_list.GetSealGeneration() ==
+                *gpu_profile_main_thread_generation) {
+                compile_error =
+                    "GPU profiling MainThread CommandList must rotate its "
+                    "recording generation before a managed GPU source is "
+                    "bound or published";
+                return false;
+            }
+            if (!profiling_list.IsEmpty() ||
+                profiling_list.HasGpuScopeRecorder() ||
+                profiling_list
+                    .IsLegacyGpuProfilingSuppressedForGeneration()) {
+                compile_error =
+                    "GPU profiling MainThread observer must leave its "
+                    "replacement recording generation empty and unbound "
+                    "before a managed GPU source is bound or published";
+                return false;
+            }
+        }
+
         size_t group_end = batch_index + 1;
         if (first_batch.execution == PassExecutionClass::ParallelRecordEligible) {
             while (group_end < compiled_plan.recording_batches.size()) {
@@ -2056,6 +2321,15 @@ bool RenderGraph::ExecuteRecording(
                 .record       = pass.record,
                 .command_list = MakeShared<CommandList>(queue),
                 .completion   = RHIRecordingGate::Create(),
+                .gpu_profile_queue_binding =
+                    ToRHIQueueBinding(batch.queue),
+                .gpu_profile_source_order =
+                    gpu_profiling.try_bind_source ?
+                        gpu_profiling.source_order_base +
+                            static_cast<uint64>(batch.id) :
+                        0,
+                .gpu_profile_requested =
+                    static_cast<bool>(gpu_profiling.try_bind_source),
                 .translate_execution_class =
                     batch.translate_execution_class,
             };
@@ -2160,6 +2434,9 @@ bool RenderGraph::ExecuteRecording(
                     return false;
                 }
                 if (!source.command_list->IsEmpty() ||
+                    source.command_list->HasGpuScopeRecorder() ||
+                    source.command_list
+                        ->IsLegacyGpuProfilingSuppressedForGeneration() ||
                     source.command_list->HasExplicitResourceStateOwnership() ||
                     source.command_list->GetTranslateExecutionClass() !=
                         batch.translate_execution_class) {
@@ -2173,6 +2450,23 @@ bool RenderGraph::ExecuteRecording(
             group_gates.emplace_back(job.completion);
             jobs.emplace_back(std::move(job));
             sources.emplace_back(std::move(source));
+        }
+
+        if (gpu_profiling.try_bind_source) {
+            for (RecordingJob& job : jobs) {
+                const GpuProfileBindOutcome bind_outcome =
+                    bind_gpu_profile_source(
+                        make_pass_info(job.pass),
+                        *job.command_list,
+                        job.gpu_profile_queue_binding,
+                        job.gpu_profile_source_order
+                    );
+                if (bind_outcome == GpuProfileBindOutcome::Failed) {
+                    return false;
+                }
+                job.gpu_profile_bound =
+                    bind_outcome == GpuProfileBindOutcome::Bound;
+            }
         }
 
         PendingGateGuard pending_gate_guard{.gates = &group_gates};
@@ -2239,7 +2533,19 @@ bool RenderGraph::ExecuteRecording(
                 }
                 const uint64 seal_generation =
                     job.command_list->GetSealGeneration();
-                job.record(*job.command_list);
+                if (job.gpu_profile_requested) {
+                    ScopedGpuMarker pass_marker(
+                        *job.command_list,
+                        job.pass_name,
+                        GpuMarkerPalette::Pass(),
+                        job.gpu_profile_bound ?
+                            EGpuMarkerMode::Timestamp :
+                            EGpuMarkerMode::Label
+                    );
+                    job.record(*job.command_list);
+                } else {
+                    job.record(*job.command_list);
+                }
                 if (job.command_list->GetSealGeneration() != seal_generation) {
                     throw std::logic_error(
                         "record callback sealed its managed CommandList"
@@ -2309,10 +2615,21 @@ bool RenderGraph::ExecuteRecording(
         }
         for (size_t index = 0; index < jobs.size(); ++index) {
             const auto& job = jobs[index];
+            const bool expected_gpu_profile_recorder =
+                job.gpu_profile_requested &&
+                job.gpu_profile_bound;
+            const bool expected_legacy_profile_suppression =
+                job.gpu_profile_requested &&
+                !job.gpu_profile_bound;
             if (job.completion->Status() != ERHIRecordingStatus::Pending ||
                 job.command_list->GetSealGeneration() !=
                     publication_generations[index] ||
                 !job.command_list->IsEmpty() ||
+                job.command_list->HasGpuScopeRecorder() !=
+                    expected_gpu_profile_recorder ||
+                job.command_list
+                        ->IsLegacyGpuProfilingSuppressedForGeneration() !=
+                    expected_legacy_profile_suppression ||
                 job.command_list->HasExplicitResourceStateOwnership() ||
                 job.command_list->GetTranslateExecutionClass() !=
                     job.translate_execution_class ||
@@ -2413,6 +2730,10 @@ bool RenderGraph::ExecuteRecording(
             }
         }
         pending_gate_guard.Disarm();
+        if (gpu_profiling.try_bind_source &&
+            gpu_profile_main_thread_generation) {
+            gpu_profile_managed_source_since_main_thread = true;
+        }
         batch_index = group_end;
     }
     if (!active_transaction_guard.Commit()) {

--- a/source/runtime/render/rendergraph/RenderGraph.h
+++ b/source/runtime/render/rendergraph/RenderGraph.h
@@ -777,6 +777,38 @@ public:
         RenderGraphTransientAllocator* transient_allocator = nullptr;
     };
 
+    /**
+     * Optional modern GPU profiling seam for ExecuteRecording.
+     *
+     * The graph assigns source_order from the immutable compiled execution
+     * schedule before any managed producer is dispatched. A false callback
+     * result is a bounded profiling drop: it suppresses legacy timing for that
+     * CommandList generation and does not fail graph execution.
+     * Throwing, changing CommandList recording state, or returning a value that
+     * disagrees with HasGpuScopeRecorder() fails before source publication.
+     * MainThread passes reuse one binding while the caller-owned CommandList
+     * seal generation is unchanged and no managed GPU source intervenes.
+     * Before any managed GPU source is bound or published after a MainThread
+     * source, the completion observer must rotate the caller-owned generation
+     * and leave its replacement empty, unbound, and unsuppressed. The first
+     * pass of each new generation binds a new source. If a MainThread callback
+     * fails after recording begins, the caller still owns that partial
+     * generation and must reject/rotate it before recording an unrelated tail.
+     */
+    struct GpuProfilingOptions {
+        using TryBindSource = std::function<bool(
+            const ExecutedPassInfo&,
+            CommandList&,
+            RHIQueueBinding,
+            uint64 source_order
+        )>;
+
+        TryBindSource try_bind_source{};
+        /** Required for MainThread passes when try_bind_source is present. */
+        CommandList*  main_thread_command_list = nullptr;
+        uint64        source_order_base         = 0;
+    };
+
     explicit RenderGraph(std::string_view name = "RenderGraph");
     RenderGraph(std::string_view name, QueueTopology topology);
     ~RenderGraph();
@@ -909,7 +941,8 @@ public:
         const RecordingSourceSetupCallback& configure_recording_source = {},
         bool                                parallel_recording_enabled = true,
         const RecordingBatchPublisher&      publish_recording_batch = {},
-        const ActiveRecordingOptions&        active_recording = {}
+        const ActiveRecordingOptions&        active_recording = {},
+        const GpuProfilingOptions&            gpu_profiling = {}
     );
 
     [[nodiscard]] bool IsCompiled() const {

--- a/source/runtime/render/rhi/RHICommand.h
+++ b/source/runtime/render/rhi/RHICommand.h
@@ -1706,8 +1706,17 @@ public:
     RENDER_API CommandList& SetGpuScopeRecorder(
         GpuScopeRecorder _recorder
     );
+    // Selects the modern profiling path for this recording generation even
+    // when bounded source admission failed. Timed scopes remain visual
+    // markers but must not fall back to the unrelated legacy query stream.
+    RENDER_API CommandList&
+    SuppressLegacyGpuProfilingForGeneration();
     [[nodiscard]] bool HasGpuScopeRecorder() const noexcept {
         return gpu_scope_recorder.IsBound();
+    }
+    [[nodiscard]] bool
+    IsLegacyGpuProfilingSuppressedForGeneration() const noexcept {
+        return suppress_legacy_gpu_profiling_this_generation;
     }
 
     template<typename T, typename... Args>
@@ -2125,6 +2134,7 @@ private:
     uint32                       active_gpu_scope_depth{0};
     uint32                       gpu_scope_suppression_depth{0};
     bool                         gpu_scope_recorder_bound_this_generation{false};
+    bool suppress_legacy_gpu_profiling_this_generation{false};
 };
 
 // Non-copyable, non-movable RAII wrapper used by high-level render code. It guarantees that a

--- a/source/runtime/render/rhi/RHICommandList.cpp
+++ b/source/runtime/render/rhi/RHICommandList.cpp
@@ -195,6 +195,7 @@ CommandList::~CommandList() {
     active_gpu_scope_depth = 0;
     gpu_scope_suppression_depth = 0;
     gpu_scope_recorder_bound_this_generation = false;
+    suppress_legacy_gpu_profiling_this_generation = false;
 
     // No externally observable rejection may run while the dying object still
     // exposes an extractable command generation.
@@ -292,6 +293,7 @@ CommandList& CommandList::operator=(CommandList&& _other) {
     active_gpu_scope_depth = 0;
     gpu_scope_suppression_depth = 0;
     gpu_scope_recorder_bound_this_generation = false;
+    suppress_legacy_gpu_profiling_this_generation = false;
 
     commands                    = std::move(_other.commands);
     current_barriers            = _other.current_barriers;
@@ -326,6 +328,8 @@ CommandList& CommandList::operator=(CommandList&& _other) {
         _other.gpu_scope_suppression_depth;
     gpu_scope_recorder_bound_this_generation =
         _other.gpu_scope_recorder_bound_this_generation;
+    suppress_legacy_gpu_profiling_this_generation =
+        _other.suppress_legacy_gpu_profiling_this_generation;
     query_owner_id              = _other.query_owner_id;
 
     _other.current_barriers          = nullptr;
@@ -356,6 +360,7 @@ CommandList& CommandList::operator=(CommandList&& _other) {
     _other.active_gpu_scope_depth = 0;
     _other.gpu_scope_suppression_depth = 0;
     _other.gpu_scope_recorder_bound_this_generation = false;
+    _other.suppress_legacy_gpu_profiling_this_generation = false;
 
     // Install the complete incoming generation before rejecting a Fence,
     // publishing a terminal Future (which wakes Wait/Get), or releasing a
@@ -642,6 +647,7 @@ CmdSubmit CommandList::Submit() {
     active_gpu_scope_depth = 0;
     gpu_scope_suppression_depth = 0;
     gpu_scope_recorder_bound_this_generation = false;
+    suppress_legacy_gpu_profiling_this_generation = false;
     translate_execution_class = ERHITranslateExecutionClass::Parallel;
     resource_state_ownership  = ERHIResourceStateOwnership::BackendTracked;
     return std::move(submit);
@@ -775,6 +781,7 @@ CmdSubmit CommandList::PrepareRecordingRejectionDrain(
     active_gpu_scope_depth = 0;
     gpu_scope_suppression_depth = 0;
     gpu_scope_recorder_bound_this_generation = false;
+    suppress_legacy_gpu_profiling_this_generation = false;
     translate_execution_class =
         ERHITranslateExecutionClass::Parallel;
     resource_state_ownership =
@@ -1135,8 +1142,10 @@ void CommandList::PushScopeWithTimeScope(std::string_view _name, float4 _color) 
     // producers are still recording; that becomes a bounded dropped subtree,
     // not a mixed modern/legacy query stream.
     const bool modern_scope = gpu_scope_recorder.IsBound();
+    const bool legacy_timestamp_allowed =
+        !suppress_legacy_gpu_profiling_this_generation;
     bool       legacy_timestamp = false;
-    if (!modern_scope) {
+    if (!modern_scope && legacy_timestamp_allowed) {
         legacy_timestamp =
             timestamp_scope_names.emplace(scope_name).second;
         assert(
@@ -1299,6 +1308,11 @@ CommandList& CommandList::SetGpuScopeRecorder(
             "GPU scope recorder is immutable for one CommandList recording generation"
         );
     }
+    if (suppress_legacy_gpu_profiling_this_generation) {
+        throw std::logic_error(
+            "GPU profiling mode is immutable for one CommandList recording generation"
+        );
+    }
     // An empty recorder is an admission failure, not an opt-out signal.
     // Callers that do not want modern profiling simply never call this API.
     // A once-bound recorder whose stream later closes remains accepted and
@@ -1326,6 +1340,32 @@ CommandList& CommandList::SetGpuScopeRecorder(
         gpu_scope_recorder.IsBound();
     return *this;
 }
+
+CommandList&
+CommandList::SuppressLegacyGpuProfilingForGeneration() {
+    if (!scope_stack.empty() || HasOpenQueries()) {
+        throw std::logic_error(
+            "GPU profiling mode cannot change while a marker or query is open"
+        );
+    }
+    if (gpu_scope_recorder_bound_this_generation ||
+        gpu_scope_recorder.IsBound()) {
+        throw std::logic_error(
+            "GPU profiling mode is immutable for one CommandList recording generation"
+        );
+    }
+    if (!timestamp_scope_names.empty()) {
+        throw std::logic_error(
+            "legacy GPU profiling can only be suppressed before any timed scope"
+        );
+    }
+    suppress_legacy_gpu_profiling_this_generation = true;
+    active_gpu_scope_id = 0;
+    active_gpu_scope_depth = 0;
+    gpu_scope_suppression_depth = 0;
+    return *this;
+}
+
 #pragma region[ raytracing ]
 
 void CommandList::BuildAccelerationStructures(Array<AccelerationStructureBuildParam>&& _geometries) {

--- a/source/runtime/render/rhi/vulkan/VulkanSubmissionExecutor.cpp
+++ b/source/runtime/render/rhi/vulkan/VulkanSubmissionExecutor.cpp
@@ -258,6 +258,11 @@ bool IsCopyCommand(Command::EType _type) {
         case Command::EType::CopyBackTexture:
         case Command::EType::Barrier:
         case Command::EType::QueueTransfer:
+        // Scope commands are queue-agnostic debug-label boundaries. Modern
+        // GPU scopes lower to Scope + Query pairs; VkCopyQueue already routes
+        // both through CmdReorderer/VkCmdVisitor, so rejecting the label half
+        // would reject an otherwise legal Copy timestamp source.
+        case Command::EType::Scope:
         // Timestamp Query commands are legal ordering boundaries inside one
         // Copy segment. Multi-segment sources still reject all queries above,
         // and VkCopyQueue performs token/queue/LIFO preflight before native

--- a/source/runtime/render/scene/GpuScene.cpp
+++ b/source/runtime/render/scene/GpuScene.cpp
@@ -73,11 +73,55 @@ static constexpr std::string_view s_rt_scene_update_tlas_scope_name = "RTScene U
 
 GpuScene::GpuScene(BindlessArrayRef bindless_array) : m_bindless_array(std::move(bindless_array)) {}
 
-void GpuScene::ApplyUpdate(GpuSceneUpdate&& update) {
+void GpuScene::ApplyUpdate(
+    GpuSceneUpdate&&                       update,
+    const PendingCommandListSetupCallback& setup_command_lists
+) {
     assert(IsCurrentlyGameThread() || IsCurrentlyRenderThread());
     assert(update.HasWork());
 
     m_pending_cmd_lists = PendingCommandList{};
+    if (setup_command_lists) {
+        setup_command_lists(
+            m_pending_cmd_lists, update.full_rebuild
+        );
+    }
+
+    auto begin_profile_root =
+        [](CommandList& command_list,
+           std::string_view name,
+           float4 color) -> UniquePtr<ScopedGpuMarker> {
+            const bool modern_generation =
+                command_list.HasGpuScopeRecorder() ||
+                command_list
+                    .IsLegacyGpuProfilingSuppressedForGeneration();
+            if (!modern_generation) {
+                return {};
+            }
+            return MakeUnique<ScopedGpuMarker>(
+                command_list,
+                name,
+                color,
+                command_list.HasGpuScopeRecorder() ?
+                    EGpuMarkerMode::Timestamp :
+                    EGpuMarkerMode::Label
+            );
+        };
+    auto copy_profile_root = begin_profile_root(
+        m_pending_cmd_lists.copy_queue_cmd_list,
+        update.full_rebuild ?
+            "GpuScene Initial Copy Update" :
+            "GpuScene Copy Update",
+        GpuMarkerPalette::Transfer()
+    );
+    auto graphics_profile_root = begin_profile_root(
+        m_pending_cmd_lists.gfx_queue_cmd_list,
+        update.full_rebuild ?
+            "GpuScene Initial Graphics Update" :
+            "GpuScene Graphics Update",
+        GpuMarkerPalette::Renderer()
+    );
+
     auto update_data = MakeShared<GpuSceneUpdate>(std::move(update));
     auto& pending_update = *update_data;
 
@@ -122,6 +166,13 @@ void GpuScene::ApplyUpdate(GpuSceneUpdate&& update) {
                 );
                 break;
         }
+    }
+
+    if (copy_profile_root) {
+        copy_profile_root->Close();
+    }
+    if (graphics_profile_root) {
+        graphics_profile_root->Close();
     }
 
     // CopyFrom(span) stores a non-owning pointer. Keep the snapshot alive through each relevant submit.

--- a/source/runtime/render/scene/GpuScene.h
+++ b/source/runtime/render/scene/GpuScene.h
@@ -5,6 +5,8 @@
 #include "rhi/RHICommand.h"
 #include "rhi/RHIResource.h"
 
+#include <functional>
+
 namespace Moer::Render {
 
 /**
@@ -27,13 +29,20 @@ namespace Moer::Render {
 class RENDER_API GpuScene {
 
 public:
+    struct PendingCommandList;
+    using PendingCommandListSetupCallback =
+        std::function<void(PendingCommandList&, bool full_rebuild)>;
+
     explicit GpuScene(BindlessArrayRef bindless_array);
     ~GpuScene() noexcept;
 
     GpuScene(const GpuScene&)            = delete;
     GpuScene& operator=(const GpuScene&) = delete;
 
-    void ApplyUpdate(GpuSceneUpdate&& update);
+    void ApplyUpdate(
+        GpuSceneUpdate&&                       update,
+        const PendingCommandListSetupCallback& setup_command_lists = {}
+    );
 
 private:
     /**

--- a/source/runtime/render/scene/RenderScene.cpp
+++ b/source/runtime/render/scene/RenderScene.cpp
@@ -11,7 +11,10 @@ RenderScene::RenderScene(BindlessArrayRef bindless_array) : m_bindless_array(std
 
 RenderScene::~RenderScene() = default;
 
-GpuScene::PendingCommandList RenderScene::ApplyUpdate(GpuSceneUpdate&& update) {
+GpuScene::PendingCommandList RenderScene::ApplyUpdate(
+    GpuSceneUpdate&&                                  update,
+    const GpuScene::PendingCommandListSetupCallback& setup_command_lists
+) {
     assert(IsCurrentlyGameThread() || IsCurrentlyRenderThread());
     assert(update.HasWork());
 
@@ -36,7 +39,9 @@ GpuScene::PendingCommandList RenderScene::ApplyUpdate(GpuSceneUpdate&& update) {
     }
 
     assert(m_gpu_scene && "The first RenderScene update must be a full rebuild.");
-    m_gpu_scene->ApplyUpdate(std::move(update));
+    m_gpu_scene->ApplyUpdate(
+        std::move(update), setup_command_lists
+    );
     return m_gpu_scene->PopPendingCommandList();
 }
 

--- a/source/runtime/render/scene/RenderScene.h
+++ b/source/runtime/render/scene/RenderScene.h
@@ -13,7 +13,10 @@ public:
     RenderScene(const RenderScene&)            = delete;
     RenderScene& operator=(const RenderScene&) = delete;
 
-    GpuScene::PendingCommandList ApplyUpdate(GpuSceneUpdate&& update);
+    GpuScene::PendingCommandList ApplyUpdate(
+        GpuSceneUpdate&&                                  update,
+        const GpuScene::PendingCommandListSetupCallback& setup_command_lists = {}
+    );
 
     bool IsReady() const {
         return m_gpu_scene != nullptr;

--- a/source/test/RHIGpuScopeContractTest.cpp
+++ b/source/test/RHIGpuScopeContractTest.cpp
@@ -315,7 +315,7 @@ void FramesPopInBeginOrderAndSealIsOneShot() {
     ReleaseTerminalSubmit(second_submit);
 }
 
-void GraphicsAndComputeRemainIndependentTimestampDomains() {
+void ManagedQueuesRemainIndependentTimestampDomains() {
     GpuScopeStream stream(SmallConfig());
     GpuScopeFrameHandle frame = stream.BeginFrame(3001);
 
@@ -323,6 +323,8 @@ void GraphicsAndComputeRemainIndependentTimestampDomains() {
         QueueBinding(EQueueType::Graphics, 11, 2);
     const RHIQueueBinding compute_binding =
         QueueBinding(EQueueType::Compute, 22, 5);
+    const RHIQueueBinding copy_binding =
+        QueueBinding(EQueueType::Copy, 33, 7);
 
     CommandList graphics(EQueueType::Graphics);
     graphics.SetGpuScopeRecorder(
@@ -338,10 +340,18 @@ void GraphicsAndComputeRemainIndependentTimestampDomains() {
     RecordTimedScope(compute, "ComputeRoot");
     CmdSubmit compute_submit = compute.Submit();
 
+    CommandList copy(EQueueType::Copy);
+    copy.SetGpuScopeRecorder(
+        frame.CreateRecorder(copy_binding, 7)
+    );
+    RecordTimedScope(copy, "CopyRoot");
+    CmdSubmit copy_submit = copy.Submit();
+
     Expect(
         stream.SealFrame(frame),
         "multi-domain frame could not be sealed"
     );
+    ResolveTimestampAt(copy_submit, 0, Timestamp(100, 108, 4.0));
     ResolveTimestampAt(compute_submit, 0, Timestamp(100, 110, 3.0));
     ResolveTimestampAt(graphics_submit, 0, Timestamp(100, 120, 2.0));
 
@@ -353,18 +363,22 @@ void GraphicsAndComputeRemainIndependentTimestampDomains() {
     Expect(
         resolved.queue_roots[0].size() == 1 &&
             resolved.queue_roots[1].size() == 1 &&
-            resolved.queue_roots[2].empty(),
-        "Graphics/Compute roots were not independently partitioned"
+            resolved.queue_roots[2].size() == 1,
+        "managed-queue roots were not independently partitioned"
     );
     const GpuScopeNode& graphics_node =
         resolved.queue_roots[0].front();
     const GpuScopeNode& compute_node =
         resolved.queue_roots[1].front();
+    const GpuScopeNode& copy_node =
+        resolved.queue_roots[2].front();
     Expect(
         graphics_node.queue_binding == graphics_binding &&
             compute_node.queue_binding == compute_binding &&
+            copy_node.queue_binding == copy_binding &&
             graphics_node.source_order == 7 &&
-            compute_node.source_order == 7,
+            compute_node.source_order == 7 &&
+            copy_node.source_order == 7,
         "queue-domain identity or per-domain source order was lost"
     );
     ExpectNear(
@@ -378,6 +392,11 @@ void GraphicsAndComputeRemainIndependentTimestampDomains() {
         "Compute duration was converted through another domain"
     );
     ExpectNear(
+        copy_node.total_duration_ns,
+        32.0,
+        "Copy duration was converted through another domain"
+    );
+    ExpectNear(
         graphics_node.exclusive_duration_ns,
         40.0,
         "Graphics root exclusive duration is wrong"
@@ -387,9 +406,15 @@ void GraphicsAndComputeRemainIndependentTimestampDomains() {
         30.0,
         "Compute root exclusive duration is wrong"
     );
+    ExpectNear(
+        copy_node.exclusive_duration_ns,
+        32.0,
+        "Copy root exclusive duration is wrong"
+    );
 
     ReleaseTerminalSubmit(graphics_submit);
     ReleaseTerminalSubmit(compute_submit);
+    ReleaseTerminalSubmit(copy_submit);
 }
 
 void ErrorCancelAndRejectAreExactlyOnce() {
@@ -1781,7 +1806,7 @@ int main() {
     try {
         ReverseTerminalOrderBuildsNestedHierarchyAndExclusiveTime();
         FramesPopInBeginOrderAndSealIsOneShot();
-        GraphicsAndComputeRemainIndependentTimestampDomains();
+        ManagedQueuesRemainIndependentTimestampDomains();
         ErrorCancelAndRejectAreExactlyOnce();
         MalformedTimestampPayloadAndTopologyFailClosed();
         ClosedModernStreamNeverFallsBackToLegacyProfiling();

--- a/source/test/RHIParallelRecordVulkanTest.cpp
+++ b/source/test/RHIParallelRecordVulkanTest.cpp
@@ -13924,6 +13924,11 @@ void RunCopyTimestampQueryCapabilityAndIsolation() {
             source->GetView(),
             "CopyTimestampUpload"
         );
+        commands.PushScope(
+            _expect_ready ?
+                "Phase21BCopyTimestampScope" :
+                "Phase21BCopyTimestampUnsupportedScope"
+        );
         QueryToken query = commands.BeginTimestampQuery(
             _expect_ready ?
                 "Phase21BCopyTimestamp" :
@@ -13936,6 +13941,7 @@ void RunCopyTimestampQueryCapabilityAndIsolation() {
             "CopyTimestampMeasuredCopy"
         );
         commands.EndTimestampQuery(query);
+        commands.PopScope();
         commands.CopyFrom(
             destination->GetView(),
             WritableBytes(readback),
@@ -14003,6 +14009,19 @@ void RunCopyTimestampQueryCapabilityAndIsolation() {
         });
 
         CmdSubmit submit = commands.Submit();
+        const size_t scope_command_count = std::count_if(
+            submit.cmds.begin(),
+            submit.cmds.end(),
+            [](const UniquePtr<Command>& _command) {
+                return _command &&
+                       _command->Type() == Command::EType::Scope;
+            }
+        );
+        if (scope_command_count != 2) {
+            throw std::runtime_error(
+                "Copy timestamp source lost its balanced visual scope"
+            );
+        }
         submit.Signal(done.Get(), 1);
         RHIExecutor::Get().Submit(
             EQueueType::Copy,
@@ -14123,7 +14142,7 @@ void RunCopyTimestampQueryCapabilityAndIsolation() {
         LOG_INFO(
             "[TESTCASE][PASS] name=TimestampQueryCopySupported "
             "queue=Copy status=Ready valid_bits={} reset_mode={} "
-            "copy=verified "
+            "copy=verified scope=balanced "
             "gpu_completion=Ready order=signal->completion->query->ordinary->success "
             "owner=Completion callbacks=exactly_once "
             "allocator_reuse=verified native_owner=Submission replay=0",
@@ -14142,6 +14161,7 @@ void RunCopyTimestampQueryCapabilityAndIsolation() {
     LOG_INFO(
         "[TESTCASE][PASS] name=TimestampQueryCopyUnsupportedFallback "
         "queue=Copy injected_valid_bits=0 query=Error copy=verified "
+        "scope=balanced "
         "signal=success gpu_completion=Ready native_submit=accepted "
         "native_owner=Submission owner=Completion "
         "callbacks=exactly_once runtime=recovered replay=0"

--- a/source/test/RenderGraphTest.cpp
+++ b/source/test/RenderGraphTest.cpp
@@ -1,6 +1,8 @@
 #include "rendergraph/RenderGraph.h"
 #include "renderer/common/UiFrameGraphPass.h"
+#include "rhi/RHIGpuScope.h"
 #include "rhi/RHIImpl.h"
+#include "rhi/RHIQuery.h"
 #include "rhi/plugin/NrdPlugin.h"
 #include "taskgraph/TaskGraph.h"
 #include "taskgraph/TaskSystem.h"
@@ -13,6 +15,7 @@
 #include <cstdint>
 #include <cstdlib>
 #include <iostream>
+#include <limits>
 #include <mutex>
 #include <stdexcept>
 #include <string>
@@ -100,6 +103,47 @@ private:
 
 [[nodiscard]] bool Contains(std::string_view text, std::string_view fragment) {
     return text.find(fragment) != std::string_view::npos;
+}
+
+[[nodiscard]] Moer::Render::GpuScopeStreamConfig
+RenderGraphGpuScopeConfig() {
+    return Moer::Render::GpuScopeStreamConfig{
+        .max_resident_frames = 4,
+        .max_pending_frames = 4,
+        .max_resident_scopes = 32,
+        .max_scopes_per_frame = 16,
+        .max_sources_per_frame = 16,
+        .max_scope_name_bytes = 128,
+        .max_error_reason_bytes = 128,
+    };
+}
+
+[[nodiscard]] Moer::Render::TimestampQueryResult
+RenderGraphTimestamp(uint64_t begin_tick, uint64_t end_tick) {
+    return Moer::Render::TimestampQueryResult{
+        .begin_tick = begin_tick,
+        .end_tick = end_tick,
+        .valid_bits = 64,
+        .tick_period_ns = 1.0,
+        .duration_ns = static_cast<double>(end_tick - begin_tick),
+    };
+}
+
+[[nodiscard]] bool ResolveRenderGraphTimestamp(
+    Moer::Render::CmdSubmit& submit,
+    uint64_t                 begin_tick,
+    uint64_t                 end_tick
+) {
+    return submit.query_tokens.size() == 1 &&
+           Moer::Render::QueryBackendAccess::ResolveTimestamp(
+               submit.query_tokens.front(),
+               RenderGraphTimestamp(begin_tick, end_tick)
+           );
+}
+
+void ReleaseRenderGraphSubmit(Moer::Render::CmdSubmit& submit) {
+    submit.callbacks.clear();
+    submit.query_tokens.clear();
 }
 
 [[nodiscard]] bool HasEdgeReason(
@@ -5158,6 +5202,12 @@ void TestParallelRecordingDispatchAndJoin(TestSuite& suite) {
         std::vector<int>        completion_order{};
         GraphEventRef           deferred_named_task{};
     } rendezvous;
+    Moer::Render::GpuScopeStream gpu_scope_stream(
+        RenderGraphGpuScopeConfig()
+    );
+    auto gpu_scope_frame = gpu_scope_stream.BeginFrame(9101);
+    std::vector<uint64_t>    profiling_source_orders{};
+    std::vector<std::string> profiling_pass_names{};
 
     const auto make_record = [&](int id) {
         return [&, id](Moer::Render::CommandList&) {
@@ -5246,6 +5296,9 @@ void TestParallelRecordingDispatchAndJoin(TestSuite& suite) {
     Moer::Array<Moer::Array<Moer::Render::RHIRecordingSource>> published{};
     bool published_pending = false;
     bool distinct_command_lists = false;
+    Moer::Render::CommandList profiling_main_list(
+        Moer::Render::EQueueType::Graphics
+    );
     Moer::TaskSystem::Init();
     const bool executed = graph.ExecuteRecording(
         {},
@@ -5260,8 +5313,63 @@ void TestParallelRecordingDispatchAndJoin(TestSuite& suite) {
             distinct_command_lists = sources.size() == 2 &&
                                      sources[0].command_list != sources[1].command_list;
             published.emplace_back(std::move(sources));
+        },
+        {},
+        RenderGraph::GpuProfilingOptions{
+            .try_bind_source =
+                [&](const RenderGraph::ExecutedPassInfo& pass,
+                    Moer::Render::CommandList&            command_list,
+                    Moer::Render::RHIQueueBinding         queue_binding,
+                    Moer::uint64                          source_order) {
+                    if (pass.execution_class ==
+                        RenderGraph::PassExecutionClass::MainThread) {
+                        return false;
+                    }
+                    profiling_source_orders.emplace_back(source_order);
+                    profiling_pass_names.emplace_back(pass.name);
+                    auto recorder = gpu_scope_frame.CreateRecorder(
+                        queue_binding, source_order
+                    );
+                    if (!recorder.Valid()) {
+                        return false;
+                    }
+                    command_list.SetGpuScopeRecorder(std::move(recorder));
+                    return true;
+                },
+            .main_thread_command_list = &profiling_main_list,
+            .source_order_base = 73,
         }
     );
+    Moer::Array<Moer::Render::CmdSubmit> profiled_submits{};
+    Moer::Render::ResolvedGpuScopeFrame  resolved_gpu_frame{};
+    bool profiling_submit_contract = false;
+    bool profiling_resolution_contract = false;
+    if (published.size() == 1 && published.front().size() == 2) {
+        profiled_submits.reserve(2);
+        for (auto& source : published.front()) {
+            profiled_submits.emplace_back(source.command_list->Submit());
+        }
+        profiling_submit_contract =
+            profiled_submits.size() == 2 &&
+            profiled_submits[0].query_tokens.size() == 1 &&
+            profiled_submits[1].query_tokens.size() == 1 &&
+            !published.front()[0].command_list->HasGpuScopeRecorder() &&
+            !published.front()[1].command_list->HasGpuScopeRecorder() &&
+            gpu_scope_stream.SealFrame(gpu_scope_frame);
+        if (profiling_submit_contract) {
+            const bool reverse_resolved =
+                ResolveRenderGraphTimestamp(
+                    profiled_submits[1], 200, 240
+                ) &&
+                !gpu_scope_stream.TryPopFrame(resolved_gpu_frame) &&
+                ResolveRenderGraphTimestamp(
+                    profiled_submits[0], 100, 130
+                );
+            profiling_resolution_contract =
+                reverse_resolved &&
+                gpu_scope_stream.TryPopFrame(resolved_gpu_frame);
+        }
+    }
     const bool avoided_named_thread_reentry = !rendezvous.named_task_ran.load();
     GraphEventRef deferred_named_task{};
     {
@@ -5298,6 +5406,21 @@ void TestParallelRecordingDispatchAndJoin(TestSuite& suite) {
         "the test must exercise completion order different from source order"
     );
     suite.Check(
+        profiling_source_orders == std::vector<uint64_t>{73, 74} &&
+            profiling_pass_names ==
+                std::vector<std::string>{"FirstRecord", "SecondRecord"} &&
+            profiling_submit_contract &&
+            profiling_resolution_contract &&
+            resolved_gpu_frame.valid &&
+            resolved_gpu_frame.queue_roots[0].size() == 2 &&
+            resolved_gpu_frame.queue_roots[0][0].name == "FirstRecord" &&
+            resolved_gpu_frame.queue_roots[0][0].source_order == 73 &&
+            resolved_gpu_frame.queue_roots[0][1].name == "SecondRecord" &&
+            resolved_gpu_frame.queue_roots[0][1].source_order == 74,
+        test_name,
+        "GPU profiling roots must follow compiled source order despite reverse worker/query completion"
+    );
+    suite.Check(
         joined_before_main,
         test_name,
         "a caller-thread pass must not run until the recording wave has joined"
@@ -5316,6 +5439,914 @@ void TestParallelRecordingDispatchAndJoin(TestSuite& suite) {
         test_name,
         "every published source gate must reach a successful terminal state"
     );
+    for (auto& submit : profiled_submits) {
+        ReleaseRenderGraphSubmit(submit);
+    }
+}
+
+void TestGpuProfilingMainThreadSparseOrderAndRebind(TestSuite& suite) {
+    using namespace Moer::Render;
+    constexpr std::string_view test_name =
+        "GPU profiling MainThread sparse order and rebind";
+
+    GpuScopeStream gpu_scope_stream(RenderGraphGpuScopeConfig());
+    auto           gpu_scope_frame = gpu_scope_stream.BeginFrame(9102);
+    CommandList    main_command_list(EQueueType::Graphics);
+    RenderGraph    graph("GpuProfileMainThread");
+
+    int main_a_calls = 0;
+    int cpu_calls = 0;
+    int external_calls = 0;
+    int main_b_calls = 0;
+    graph.AddPass(
+        "MainA",
+        [](RenderGraph::PassBuilder& builder) {
+            builder.SideEffect().MainThread();
+        },
+        [&] { ++main_a_calls; }
+    );
+    graph.AddPass(
+        "CpuPrepare",
+        [](RenderGraph::PassBuilder& builder) {
+            builder.SideEffect().CpuPrepare();
+        },
+        [&] {
+            ++cpu_calls;
+            suite.Check(
+                !main_command_list.HasGpuScopeRecorder(),
+                test_name,
+                "CpuPrepare unexpectedly inherited a GPU profiling source"
+            );
+        }
+    );
+    graph.AddPass(
+        "ExternalControl",
+        [](RenderGraph::PassBuilder& builder) {
+            builder.SideEffect().ExternalControl();
+        },
+        [&] {
+            ++external_calls;
+            suite.Check(
+                !main_command_list.HasGpuScopeRecorder(),
+                test_name,
+                "ExternalControl unexpectedly inherited a GPU profiling source"
+            );
+        }
+    );
+    graph.AddPass(
+        "MainB",
+        [](RenderGraph::PassBuilder& builder) {
+            builder.SideEffect().MainThread();
+        },
+        [&] { ++main_b_calls; }
+    );
+
+    suite.Check(graph.Compile(), test_name, graph.GetCompileError());
+    std::vector<uint64_t> source_orders{};
+    std::vector<std::string> pass_names{};
+    Moer::Array<CmdSubmit> main_submits{};
+    bool recorder_cleared_after_submit = true;
+    int  observer_calls = 0;
+    int  publish_calls = 0;
+    const bool executed = graph.ExecuteRecording(
+        [&](const RenderGraph::ExecutedPassInfo&) {
+            ++observer_calls;
+            main_submits.emplace_back(main_command_list.Submit());
+            recorder_cleared_after_submit =
+                recorder_cleared_after_submit &&
+                !main_command_list.HasGpuScopeRecorder();
+        },
+        {},
+        false,
+        [&](Moer::Array<RHIRecordingSource>&&) { ++publish_calls; },
+        {},
+        RenderGraph::GpuProfilingOptions{
+            .try_bind_source =
+                [&](const RenderGraph::ExecutedPassInfo& pass,
+                    CommandList&                         command_list,
+                    RHIQueueBinding                      queue_binding,
+                    Moer::uint64                         source_order) {
+                    source_orders.emplace_back(source_order);
+                    pass_names.emplace_back(pass.name);
+                    auto recorder = gpu_scope_frame.CreateRecorder(
+                        queue_binding, source_order
+                    );
+                    if (!recorder.Valid()) {
+                        return false;
+                    }
+                    command_list.SetGpuScopeRecorder(std::move(recorder));
+                    return true;
+                },
+            .main_thread_command_list = &main_command_list,
+            .source_order_base = 100,
+        }
+    );
+
+    ResolvedGpuScopeFrame resolved{};
+    const bool submitted =
+        main_submits.size() == 2 &&
+        main_submits[0].query_tokens.size() == 1 &&
+        main_submits[1].query_tokens.size() == 1 &&
+        gpu_scope_stream.SealFrame(gpu_scope_frame);
+    bool resolved_ok = false;
+    if (submitted) {
+        resolved_ok =
+            ResolveRenderGraphTimestamp(main_submits[1], 300, 340) &&
+            !gpu_scope_stream.TryPopFrame(resolved) &&
+            ResolveRenderGraphTimestamp(main_submits[0], 200, 225) &&
+            gpu_scope_stream.TryPopFrame(resolved);
+    }
+
+    suite.Check(executed, test_name, graph.GetCompileError());
+    suite.Check(
+        main_a_calls == 1 && cpu_calls == 1 &&
+            external_calls == 1 && main_b_calls == 1 &&
+            observer_calls == 2 && publish_calls == 0,
+        test_name,
+        "MainThread/CPU/External callbacks did not retain their ownership classes"
+    );
+    suite.Check(
+        source_orders == std::vector<uint64_t>{100, 103} &&
+            pass_names == std::vector<std::string>{"MainA", "MainB"} &&
+            recorder_cleared_after_submit,
+        test_name,
+        "MainThread sources lost compiled-order gaps or Submit rebind semantics"
+    );
+    suite.Check(
+        resolved_ok && resolved.valid &&
+            resolved.queue_roots[0].size() == 2 &&
+            resolved.queue_roots[0][0].name == "MainA" &&
+            resolved.queue_roots[0][0].source_order == 100 &&
+            resolved.queue_roots[0][1].name == "MainB" &&
+            resolved.queue_roots[0][1].source_order == 103,
+        test_name,
+        "MainThread timestamp roots did not preserve sparse compiled order"
+    );
+    for (CmdSubmit& submit : main_submits) {
+        ReleaseRenderGraphSubmit(submit);
+    }
+}
+
+void TestGpuProfilingMainThreadGenerationReuse(TestSuite& suite) {
+    using namespace Moer::Render;
+    constexpr std::string_view test_name =
+        "GPU profiling MainThread generation reuse";
+
+    GpuScopeStream gpu_scope_stream(RenderGraphGpuScopeConfig());
+    auto           gpu_scope_frame = gpu_scope_stream.BeginFrame(9103);
+    CommandList    main_command_list(EQueueType::Graphics);
+    RenderGraph    graph("GpuProfileMainThreadGenerationReuse");
+
+    int pass_calls = 0;
+    for (std::string_view pass_name : {"MainA", "MainB"}) {
+        graph.AddPass(
+            pass_name,
+            [](RenderGraph::PassBuilder& builder) {
+                builder.SideEffect().MainThread();
+            },
+            [&] { ++pass_calls; }
+        );
+    }
+
+    suite.Check(graph.Compile(), test_name, graph.GetCompileError());
+    int                bind_calls = 0;
+    std::vector<uint64_t> source_orders{};
+    const bool executed = graph.ExecuteRecording(
+        {},
+        {},
+        false,
+        {},
+        {},
+        RenderGraph::GpuProfilingOptions{
+            .try_bind_source =
+                [&](const RenderGraph::ExecutedPassInfo&,
+                    CommandList&                         command_list,
+                    RHIQueueBinding                      queue_binding,
+                    Moer::uint64                         source_order) {
+                    ++bind_calls;
+                    source_orders.emplace_back(source_order);
+                    auto recorder = gpu_scope_frame.CreateRecorder(
+                        queue_binding, source_order
+                    );
+                    if (!recorder.Valid()) {
+                        return false;
+                    }
+                    command_list.SetGpuScopeRecorder(std::move(recorder));
+                    return true;
+                },
+            .main_thread_command_list = &main_command_list,
+            .source_order_base = 120,
+        }
+    );
+
+    CmdSubmit submit = main_command_list.Submit();
+    ResolvedGpuScopeFrame resolved{};
+    const bool submitted =
+        submit.query_tokens.size() == 2 &&
+        !main_command_list.HasGpuScopeRecorder() &&
+        gpu_scope_stream.SealFrame(gpu_scope_frame);
+    bool resolved_ok = false;
+    if (submitted) {
+        resolved_ok =
+            QueryBackendAccess::ResolveTimestamp(
+                submit.query_tokens[1],
+                RenderGraphTimestamp(400, 440)
+            ) &&
+            !gpu_scope_stream.TryPopFrame(resolved) &&
+            QueryBackendAccess::ResolveTimestamp(
+                submit.query_tokens[0],
+                RenderGraphTimestamp(300, 325)
+            ) &&
+            gpu_scope_stream.TryPopFrame(resolved);
+    }
+
+    suite.Check(executed, test_name, graph.GetCompileError());
+    suite.Check(
+        pass_calls == 2 && bind_calls == 1 &&
+            source_orders == std::vector<uint64_t>{120},
+        test_name,
+        "one MainThread recording generation must bind exactly one stable source"
+    );
+    suite.Check(
+        resolved_ok && resolved.valid &&
+            resolved.queue_roots[0].size() == 2 &&
+            resolved.queue_roots[0][0].name == "MainA" &&
+            resolved.queue_roots[0][0].source_order == 120 &&
+            resolved.queue_roots[0][0].local_order == 0 &&
+            resolved.queue_roots[0][1].name == "MainB" &&
+            resolved.queue_roots[0][1].source_order == 120 &&
+            resolved.queue_roots[0][1].local_order == 1,
+        test_name,
+        "every pass in a shared MainThread generation must retain a timestamp root"
+    );
+    ReleaseRenderGraphSubmit(submit);
+}
+
+void TestGpuProfilingMainThreadManagedBoundary(TestSuite& suite) {
+    using namespace Moer::Render;
+    constexpr std::string_view test_name =
+        "GPU profiling MainThread managed boundary";
+
+    const auto run_case = [&](bool rotate_main_generation) {
+        CommandList main_command_list(EQueueType::Graphics);
+        RenderGraph graph(
+            rotate_main_generation ?
+                "GpuProfileManagedBoundaryRotated" :
+                "GpuProfileManagedBoundaryUnrotated"
+        );
+
+        int main_a_calls = 0;
+        int managed_calls = 0;
+        int main_b_calls = 0;
+        const auto main_a = graph.AddPass(
+            "MainA",
+            [](RenderGraph::PassBuilder& builder) {
+                builder.SideEffect().MainThread();
+            },
+            [&] { ++main_a_calls; }
+        );
+        const auto managed = graph.AddRecordPass(
+            "Managed",
+            [=](RenderGraph::PassBuilder& builder) {
+                builder.DependsOn(main_a).SideEffect();
+            },
+            [&](CommandList&) { ++managed_calls; },
+            RenderGraph::PassExecutionClass::SerialRecord
+        );
+        graph.AddPass(
+            "MainB",
+            [=](RenderGraph::PassBuilder& builder) {
+                builder.DependsOn(managed).SideEffect().MainThread();
+            },
+            [&] { ++main_b_calls; }
+        );
+
+        suite.Check(graph.Compile(), test_name, graph.GetCompileError());
+        int                   observer_calls = 0;
+        int                   bind_calls = 0;
+        std::vector<uint64_t> source_orders{};
+        Moer::Array<CmdSubmit> main_submits{};
+        Moer::Array<RHIRecordingSource> published{};
+        const bool executed = graph.ExecuteRecording(
+            [&](const RenderGraph::ExecutedPassInfo&) {
+                ++observer_calls;
+                if (rotate_main_generation) {
+                    main_submits.emplace_back(main_command_list.Submit());
+                }
+            },
+            {},
+            false,
+            [&](Moer::Array<RHIRecordingSource>&& sources) {
+                published = std::move(sources);
+            },
+            {},
+            RenderGraph::GpuProfilingOptions{
+                .try_bind_source =
+                    [&](const RenderGraph::ExecutedPassInfo&,
+                        CommandList&,
+                        RHIQueueBinding,
+                        Moer::uint64 source_order) {
+                        ++bind_calls;
+                        source_orders.emplace_back(source_order);
+                        return false;
+                    },
+                .main_thread_command_list = &main_command_list,
+                .source_order_base = 200,
+            }
+        );
+
+        if (!main_command_list.IsEmpty() ||
+            main_command_list.HasGpuScopeRecorder() ||
+            main_command_list
+                .IsLegacyGpuProfilingSuppressedForGeneration()) {
+            main_submits.emplace_back(main_command_list.Submit());
+        }
+        for (RHIRecordingSource& source : published) {
+            CmdSubmit submit = source.command_list->Submit();
+            ReleaseRenderGraphSubmit(submit);
+        }
+        for (CmdSubmit& submit : main_submits) {
+            ReleaseRenderGraphSubmit(submit);
+        }
+
+        if (rotate_main_generation) {
+            suite.Check(
+                executed && main_a_calls == 1 && managed_calls == 1 &&
+                    main_b_calls == 1 && observer_calls == 2 &&
+                    bind_calls == 3 &&
+                    source_orders ==
+                        std::vector<uint64_t>{200, 201, 202},
+                test_name,
+                graph.GetCompileError()
+            );
+        } else {
+            suite.Check(
+                !executed && main_a_calls == 1 && managed_calls == 0 &&
+                    main_b_calls == 0 && observer_calls == 1 &&
+                    bind_calls == 1 && published.empty() &&
+                    source_orders == std::vector<uint64_t>{200} &&
+                    Contains(
+                        graph.GetCompileError(),
+                        "must rotate its recording generation"
+                    ),
+                test_name,
+                "an unrotated MainThread generation was not rejected before "
+                "the managed source was bound, published, or recorded"
+            );
+        }
+    };
+
+    run_case(false);
+    run_case(true);
+
+    {
+        CommandList main_command_list(EQueueType::Graphics);
+        RenderGraph graph("GpuProfileManagedBoundaryTerminal");
+        int main_calls = 0;
+        int managed_calls = 0;
+        const auto main = graph.AddPass(
+            "Main",
+            [](RenderGraph::PassBuilder& builder) {
+                builder.SideEffect().MainThread();
+            },
+            [&] { ++main_calls; }
+        );
+        graph.AddRecordPass(
+            "ManagedTerminal",
+            [=](RenderGraph::PassBuilder& builder) {
+                builder.DependsOn(main).SideEffect();
+            },
+            [&](CommandList&) { ++managed_calls; },
+            RenderGraph::PassExecutionClass::SerialRecord
+        );
+
+        suite.Check(graph.Compile(), test_name, graph.GetCompileError());
+        int                   bind_calls = 0;
+        int                   publish_calls = 0;
+        std::vector<uint64_t> source_orders{};
+        const bool executed = graph.ExecuteRecording(
+            {},
+            {},
+            false,
+            [&](Moer::Array<RHIRecordingSource>&&) {
+                ++publish_calls;
+            },
+            {},
+            RenderGraph::GpuProfilingOptions{
+                .try_bind_source =
+                    [&](const RenderGraph::ExecutedPassInfo&,
+                        CommandList&,
+                        RHIQueueBinding,
+                        Moer::uint64 source_order) {
+                        ++bind_calls;
+                        source_orders.emplace_back(source_order);
+                        return false;
+                    },
+                .main_thread_command_list = &main_command_list,
+                .source_order_base = 220,
+            }
+        );
+
+        CmdSubmit main_submit = main_command_list.Submit();
+        ReleaseRenderGraphSubmit(main_submit);
+        suite.Check(
+            !executed && main_calls == 1 && managed_calls == 0 &&
+                bind_calls == 1 && publish_calls == 0 &&
+                source_orders == std::vector<uint64_t>{220} &&
+                Contains(
+                    graph.GetCompileError(),
+                    "must rotate its recording generation"
+                ),
+            test_name,
+            "a terminal managed source escaped the pre-publication "
+            "MainThread generation boundary"
+        );
+    }
+
+    {
+        CommandList main_command_list(EQueueType::Graphics);
+        RenderGraph graph("GpuProfileManagedBoundaryDirtyReplacement");
+        int main_calls = 0;
+        int managed_calls = 0;
+        const auto main = graph.AddPass(
+            "Main",
+            [](RenderGraph::PassBuilder& builder) {
+                builder.SideEffect().MainThread();
+            },
+            [&] { ++main_calls; }
+        );
+        graph.AddRecordPass(
+            "Managed",
+            [=](RenderGraph::PassBuilder& builder) {
+                builder.DependsOn(main).SideEffect();
+            },
+            [&](CommandList&) { ++managed_calls; },
+            RenderGraph::PassExecutionClass::SerialRecord
+        );
+
+        suite.Check(graph.Compile(), test_name, graph.GetCompileError());
+        int                    observer_calls = 0;
+        int                    bind_calls = 0;
+        int                    publish_calls = 0;
+        Moer::Array<CmdSubmit> main_submits{};
+        const bool executed = graph.ExecuteRecording(
+            [&](const RenderGraph::ExecutedPassInfo&) {
+                ++observer_calls;
+                main_submits.emplace_back(main_command_list.Submit());
+                main_command_list.PushScope("DirtyReplacement");
+                main_command_list.PopScope();
+            },
+            {},
+            false,
+            [&](Moer::Array<RHIRecordingSource>&&) {
+                ++publish_calls;
+            },
+            {},
+            RenderGraph::GpuProfilingOptions{
+                .try_bind_source =
+                    [&](const RenderGraph::ExecutedPassInfo&,
+                        CommandList&,
+                        RHIQueueBinding,
+                        Moer::uint64) {
+                        ++bind_calls;
+                        return false;
+                    },
+                .main_thread_command_list = &main_command_list,
+                .source_order_base = 230,
+            }
+        );
+
+        main_submits.emplace_back(main_command_list.Submit());
+        for (CmdSubmit& submit : main_submits) {
+            ReleaseRenderGraphSubmit(submit);
+        }
+        suite.Check(
+            !executed && main_calls == 1 && managed_calls == 0 &&
+                observer_calls == 1 && bind_calls == 1 &&
+                publish_calls == 0 &&
+                Contains(
+                    graph.GetCompileError(),
+                    "replacement recording generation empty and unbound"
+                ),
+            test_name,
+            "a MainThread observer recorded into the replacement generation "
+            "before managed publication"
+        );
+    }
+
+    {
+        RenderGraph graph("GpuProfileManagedOnly");
+        int managed_calls = 0;
+        graph.AddRecordPass(
+            "ManagedOnly",
+            [](RenderGraph::PassBuilder& builder) {
+                builder.SideEffect();
+            },
+            [&](CommandList&) { ++managed_calls; },
+            RenderGraph::PassExecutionClass::SerialRecord
+        );
+
+        suite.Check(graph.Compile(), test_name, graph.GetCompileError());
+        int bind_calls = 0;
+        Moer::Array<RHIRecordingSource> published{};
+        const bool executed = graph.ExecuteRecording(
+            {},
+            {},
+            false,
+            [&](Moer::Array<RHIRecordingSource>&& sources) {
+                published = std::move(sources);
+            },
+            {},
+            RenderGraph::GpuProfilingOptions{
+                .try_bind_source =
+                    [&](const RenderGraph::ExecutedPassInfo&,
+                        CommandList&,
+                        RHIQueueBinding,
+                        Moer::uint64) {
+                        ++bind_calls;
+                        return false;
+                    },
+            }
+        );
+
+        const bool published_succeeded =
+            published.size() == 1 &&
+            published.front().completion.Status() ==
+                ERHIRecordingStatus::Succeeded;
+        for (RHIRecordingSource& source : published) {
+            CmdSubmit submit = source.command_list->Submit();
+            ReleaseRenderGraphSubmit(submit);
+        }
+        suite.Check(
+            executed && managed_calls == 1 && bind_calls == 1 &&
+                published_succeeded,
+            test_name,
+            "a managed-only graph incorrectly required a MainThread "
+            "CommandList"
+        );
+    }
+}
+
+void TestGpuProfilingBindingFailureContracts(TestSuite& suite) {
+    using namespace Moer::Render;
+    constexpr std::string_view test_name =
+        "GPU profiling binding failure contracts";
+
+    {
+        RenderGraph graph("GpuProfileDrop");
+        int record_calls = 0;
+        int bind_calls = 0;
+        int publish_calls = 0;
+        Moer::Array<RHIRecordingSource> published{};
+        graph.AddRecordPass(
+            "Dropped",
+            [](RenderGraph::PassBuilder& builder) {
+                builder.SideEffect().SerialRecord();
+            },
+            [&](CommandList& command_list) {
+                ++record_calls;
+                suite.Check(
+                    !command_list.HasGpuScopeRecorder() &&
+                        command_list
+                            .IsLegacyGpuProfilingSuppressedForGeneration(),
+                    test_name,
+                    "a rejected profiling source did not suppress legacy "
+                    "timing for its recording generation"
+                );
+                command_list.PushScopeWithTimeScope(
+                    "RejectedInnerTimedScope"
+                );
+                command_list.PopScopeWithTimeScope();
+            },
+            RenderGraph::PassExecutionClass::SerialRecord
+        );
+        suite.Check(graph.Compile(), test_name, graph.GetCompileError());
+        const bool executed = graph.ExecuteRecording(
+            {},
+            {},
+            false,
+            [&](Moer::Array<RHIRecordingSource>&& sources) {
+                ++publish_calls;
+                published = std::move(sources);
+            },
+            {},
+            RenderGraph::GpuProfilingOptions{
+                .try_bind_source =
+                    [&](const RenderGraph::ExecutedPassInfo&,
+                        CommandList&,
+                        RHIQueueBinding,
+                        Moer::uint64) {
+                        ++bind_calls;
+                        return false;
+                    },
+            }
+        );
+        bool no_fallback_query = false;
+        if (published.size() == 1) {
+            CmdSubmit submit = published.front().command_list->Submit();
+            no_fallback_query = submit.query_tokens.empty();
+            ReleaseRenderGraphSubmit(submit);
+        }
+        suite.Check(
+            executed && record_calls == 1 && bind_calls == 1 &&
+                publish_calls == 1 && no_fallback_query,
+            test_name,
+            "a false binder result failed the graph or created a legacy timestamp"
+        );
+    }
+
+    {
+        GpuScopeStream stream(RenderGraphGpuScopeConfig());
+        auto           frame = stream.BeginFrame(9104);
+        RenderGraph    graph("MetadataSetupCannotBindGpuRecorder");
+        int            record_calls = 0;
+        int            publish_calls = 0;
+        graph.AddRecordPass(
+            "Pass",
+            [](RenderGraph::PassBuilder& builder) {
+                builder.SideEffect().SerialRecord();
+            },
+            [&](CommandList&) { ++record_calls; },
+            RenderGraph::PassExecutionClass::SerialRecord
+        );
+        suite.Check(graph.Compile(), test_name, graph.GetCompileError());
+        const bool executed = graph.ExecuteRecording(
+            {},
+            [&](const RenderGraph::ExecutedPassInfo&,
+                RHIRecordingSource& source) {
+                source.command_list->SetGpuScopeRecorder(
+                    frame.CreateRecorder(
+                        RHIQueueBinding{
+                            .queue =
+                                source.command_list->GetQueueType(),
+                            .native_queue_id = 0,
+                            .family_id = 0,
+                            .available = true,
+                        },
+                        0
+                    )
+                );
+            },
+            false,
+            [&](Moer::Array<RHIRecordingSource>&&) {
+                ++publish_calls;
+            }
+        );
+        ResolvedGpuScopeFrame resolved{};
+        const bool drained =
+            stream.SealFrame(frame) && stream.TryPopFrame(resolved);
+        suite.Check(
+            !executed && record_calls == 0 && publish_calls == 0 &&
+                Contains(
+                    graph.GetCompileError(),
+                    "may only change submit metadata"
+                ) &&
+                drained && resolved.valid,
+            test_name,
+            "metadata-only source setup bypassed the independent GPU profiling seam"
+        );
+    }
+
+    const auto expect_pre_publish_failure =
+        [&](std::string_view graph_name,
+            RenderGraph::GpuProfilingOptions::TryBindSource binder,
+            std::string_view expected_error) {
+            RenderGraph graph(graph_name);
+            int record_calls = 0;
+            int publish_calls = 0;
+            graph.AddRecordPass(
+                "Pass",
+                [](RenderGraph::PassBuilder& builder) {
+                    builder.SideEffect().SerialRecord();
+                },
+                [&](CommandList&) { ++record_calls; },
+                RenderGraph::PassExecutionClass::SerialRecord
+            );
+            suite.Check(graph.Compile(), test_name, graph.GetCompileError());
+            const bool executed = graph.ExecuteRecording(
+                {},
+                {},
+                false,
+                [&](Moer::Array<RHIRecordingSource>&&) { ++publish_calls; },
+                {},
+                RenderGraph::GpuProfilingOptions{
+                    .try_bind_source = std::move(binder),
+                }
+            );
+            suite.Check(
+                !executed && record_calls == 0 && publish_calls == 0 &&
+                    Contains(graph.GetCompileError(), expected_error),
+                test_name,
+                graph.GetCompileError()
+            );
+        };
+
+    expect_pre_publish_failure(
+        "GpuProfileThrow",
+        [](const RenderGraph::ExecutedPassInfo&,
+           CommandList&,
+           RHIQueueBinding,
+           Moer::uint64) -> bool {
+            throw std::runtime_error("synthetic bind failure");
+        },
+        "synthetic bind failure"
+    );
+    expect_pre_publish_failure(
+        "GpuProfileMutation",
+        [](const RenderGraph::ExecutedPassInfo&,
+           CommandList& command_list,
+           RHIQueueBinding,
+           Moer::uint64) {
+            command_list.SetResourceStateOwnership(
+                ERHIResourceStateOwnership::Explicit
+            );
+            return false;
+        },
+        "illegally mutated"
+    );
+    expect_pre_publish_failure(
+        "GpuProfileResultMismatch",
+        [](const RenderGraph::ExecutedPassInfo&,
+           CommandList&,
+           RHIQueueBinding,
+           Moer::uint64) { return true; },
+        "illegally mutated"
+    );
+
+    for (const bool bind_source : {false, true}) {
+        GpuScopeStream stream(RenderGraphGpuScopeConfig());
+        auto frame = stream.BeginFrame(bind_source ? 9105 : 9106);
+        RenderGraph graph(
+            bind_source ?
+                "GpuProfilePublisherClearsRecorder" :
+                "GpuProfilePublisherClearsSuppression"
+        );
+        int record_calls = 0;
+        int publish_calls = 0;
+        graph.AddRecordPass(
+            "Pass",
+            [](RenderGraph::PassBuilder& builder) {
+                builder.SideEffect().SerialRecord();
+            },
+            [&](CommandList&) { ++record_calls; },
+            RenderGraph::PassExecutionClass::SerialRecord
+        );
+        suite.Check(graph.Compile(), test_name, graph.GetCompileError());
+        const bool executed = graph.ExecuteRecording(
+            {},
+            {},
+            false,
+            [&](Moer::Array<RHIRecordingSource>&& sources) {
+                ++publish_calls;
+                if (sources.size() == 1) {
+                    const EQueueType queue =
+                        sources.front().command_list->GetQueueType();
+                    *sources.front().command_list = CommandList(queue);
+                }
+            },
+            {},
+            RenderGraph::GpuProfilingOptions{
+                .try_bind_source =
+                    [&](const RenderGraph::ExecutedPassInfo&,
+                        CommandList& command_list,
+                        RHIQueueBinding queue_binding,
+                        Moer::uint64 source_order) {
+                        if (!bind_source) {
+                            return false;
+                        }
+                        auto recorder = frame.CreateRecorder(
+                            queue_binding, source_order
+                        );
+                        if (!recorder.Valid()) {
+                            return false;
+                        }
+                        command_list.SetGpuScopeRecorder(
+                            std::move(recorder)
+                        );
+                        return true;
+                    },
+            }
+        );
+        ResolvedGpuScopeFrame resolved{};
+        const bool drained =
+            stream.SealFrame(frame) && stream.TryPopFrame(resolved);
+        suite.Check(
+            !executed && record_calls == 0 && publish_calls == 1 &&
+                Contains(
+                    graph.GetCompileError(),
+                    "publisher mutated pending source state"
+                ) &&
+                drained && resolved.valid,
+            test_name,
+            "the publisher cleared an admitted recorder/suppression state "
+            "without failing before dispatch"
+        );
+    }
+
+    {
+        RenderGraph graph("GpuProfileOrderOverflow");
+        int bind_calls = 0;
+        int record_calls = 0;
+        int publish_calls = 0;
+        for (std::string_view name : {"First", "Second"}) {
+            graph.AddRecordPass(
+                name,
+                [](RenderGraph::PassBuilder& builder) {
+                    builder.SideEffect().SerialRecord();
+                },
+                [&](CommandList&) { ++record_calls; },
+                RenderGraph::PassExecutionClass::SerialRecord
+            );
+        }
+        suite.Check(graph.Compile(), test_name, graph.GetCompileError());
+        const bool executed = graph.ExecuteRecording(
+            {},
+            {},
+            false,
+            [&](Moer::Array<RHIRecordingSource>&&) { ++publish_calls; },
+            {},
+            RenderGraph::GpuProfilingOptions{
+                .try_bind_source =
+                    [&](const RenderGraph::ExecutedPassInfo&,
+                        CommandList&,
+                        RHIQueueBinding,
+                        Moer::uint64) {
+                        ++bind_calls;
+                        return false;
+                    },
+                .source_order_base = std::numeric_limits<Moer::uint64>::max(),
+            }
+        );
+        suite.Check(
+            !executed && bind_calls == 0 && record_calls == 0 &&
+                publish_calls == 0 &&
+                Contains(graph.GetCompileError(), "source order overflow"),
+            test_name,
+            "source-order overflow was not rejected before binding or publication"
+        );
+    }
+
+    {
+        RenderGraph graph("GpuProfileDisabledCompatibility");
+        int record_calls = 0;
+        Moer::Array<RHIRecordingSource> published{};
+        graph.AddRecordPass(
+            "Legacy",
+            [](RenderGraph::PassBuilder& builder) {
+                builder.SideEffect().SerialRecord();
+            },
+            [&](CommandList& command_list) {
+                ++record_calls;
+                suite.Check(
+                    !command_list.HasGpuScopeRecorder() &&
+                        !command_list
+                            .IsLegacyGpuProfilingSuppressedForGeneration(),
+                    test_name,
+                    "empty GPU profiling options changed the legacy path"
+                );
+                command_list.PushScopeWithTimeScope(
+                    "LegacyCompatibilityScope"
+                );
+                command_list.PopScopeWithTimeScope();
+            },
+            RenderGraph::PassExecutionClass::SerialRecord
+        );
+        suite.Check(graph.Compile(), test_name, graph.GetCompileError());
+        const bool executed = graph.ExecuteRecording(
+            {},
+            {},
+            false,
+            [&](Moer::Array<RHIRecordingSource>&& sources) {
+                published = std::move(sources);
+            }
+        );
+        bool legacy_query_preserved = false;
+        if (published.size() == 1) {
+            const bool suppression_disabled =
+                !published.front()
+                     .command_list
+                     ->IsLegacyGpuProfilingSuppressedForGeneration();
+            CmdSubmit submit = published.front().command_list->Submit();
+            const bool has_legacy_timestamp_markers =
+                submit.cmds.size() == 2 &&
+                submit.cmds[0]->Type() == Command::EType::Scope &&
+                submit.cmds[1]->Type() == Command::EType::Scope &&
+                static_cast<const ScopeCmd*>(submit.cmds[0].get())
+                    ->QueryTimestamp() &&
+                static_cast<const ScopeCmd*>(submit.cmds[1].get())
+                    ->QueryTimestamp();
+            legacy_query_preserved =
+                suppression_disabled &&
+                has_legacy_timestamp_markers &&
+                submit.query_tokens.empty();
+            ReleaseRenderGraphSubmit(submit);
+        }
+        suite.Check(
+            executed && record_calls == 1 && legacy_query_preserved,
+            test_name,
+            "empty GPU profiling options suppressed the legacy timed query"
+        );
+    }
 }
 
 void TestCpuRecordingDependenciesSplitParallelGroups(TestSuite& suite) {
@@ -6112,6 +7143,10 @@ int main() {
     TestCpuPrepareIsExcludedFromGpuQueuePlan(suite);
     TestParallelRecordingFallsBackWithoutTaskGraph(suite);
     TestParallelRecordingDispatchAndJoin(suite);
+    TestGpuProfilingMainThreadSparseOrderAndRebind(suite);
+    TestGpuProfilingMainThreadGenerationReuse(suite);
+    TestGpuProfilingMainThreadManagedBoundary(suite);
+    TestGpuProfilingBindingFailureContracts(suite);
     TestCpuRecordingDependenciesSplitParallelGroups(suite);
     TestRecordingPublicationFailureTerminatesGates(suite);
     TestFrameSetupTokenAndTlasBoundaryContract(suite);


### PR DESCRIPTION
## Summary

- add an independent RenderGraph GPU profiling seam that binds MainThread and managed CommandList generations from immutable compiled order before publication/dispatch
- make modern profiling admission generation-safe, including bounded drop suppression, Main-to-managed rotation checks, and fail-closed binder/publisher mutation contracts
- wire the Engine-owned capture bridge through Raster frames, scene Copy/Graphics updates, first-load descriptors, RDG/linear passes, and the UI/presentation tail using real physical queue bindings
- permit balanced queue-agnostic Scope labels around legal Copy timestamp queries while preserving Copy capability/error recovery behavior

## Safety and compatibility

- capture-disabled and empty profiling options preserve legacy behavior
- RDG submission remains ordered/serial while CPU CommandList recording overlaps
- unsupported Copy timestamp hardware keeps real Copy/completion behavior and reports the capture query as Error; backend-neutral label-only capability selection remains a documented conditional follow-up
- an independent pre-review found and fixed the terminal Main-to-managed generation-ordering gap before this PR; final code, backend/test, and docs/evidence audits are P0/P1/P2=0

## Validation

- Debug full build and CTest: 26/26
- RelWithDebInfo full build and CTest: 26/26
- threading Python contracts: 146/146
- real Vulkan timestamp-query batch, Copy supported, and injected `valid_bits=0` recovery paths: pass
- Raster RDG gate: 12 frames / 320 scopes / zero drops; strict MPD decoder pass; compiled source order and Graphics/Copy physical domains verified
- Raster linear gate: 12 frames / 320 scopes / zero drops; strict MPD decoder pass
- capture-disabled Raster RDG gate: normal exit, no ProfileDump output or residual file