### PR TITLE
Phase 21D.1: add ProfileDump v3 session consumer

### DIFF
--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_subdirectory(profile)
 add_subdirectory(cuda)
 add_subdirectory(runtime)
+add_subdirectory(tool/profile_consumer)
 add_subdirectory(editor)
 
 if(${moer_build_test})

--- a/source/runtime/core/include/misc/MMemory.h
+++ b/source/runtime/core/include/misc/MMemory.h
@@ -4,6 +4,7 @@
 #include <assert.h>
 #include <cstddef>
 #include <cstdint>
+#include <new>
 #include <utility>
 
 #define USE_MIMALLOC 1
@@ -11,7 +12,10 @@ class CORE_API Memory {
 public:
     static void* Malloc(size_t size) noexcept;
     static void* MallocAligned(size_t size, size_t alignment) noexcept;
-    static void* MallocN(size_t count, size_t size) noexcept;
+    // Array allocation follows the standard allocator contract: overflow or
+    // allocation failure is reported with std::bad_alloc instead of escaping
+    // through a noexcept boundary.
+    static void* MallocN(size_t count, size_t size);
     static void* Calloc(size_t count, size_t size) noexcept;
     static void* CallocAligned(size_t count, size_t size, size_t alignment) noexcept;
     static void* ReAlloc(void* p, size_t newsize) noexcept;
@@ -103,18 +107,15 @@ struct MoerStlAllocator : public MoerStlAllocatorCommon<T> {
         Memory::Free(p);
     }
 
-#if (__cplusplus >= 201703L) // C++17
     MOER_NODISCARD T* allocate(size_type count) {
+        if (count > this->max_size()) {
+            throw std::bad_array_new_length();
+        }
         return static_cast<T*>(Memory::MallocN(count, sizeof(T)));
     }
     MOER_NODISCARD T* allocate(size_type count, const void*) {
         return allocate(count);
     }
-#else
-    MOER_NODISCARD pointer allocate(size_type count, const void* = 0) {
-        return static_cast<pointer>(Memory::MallocN(count, sizeof(value_type)));
-    }
-#endif
 
 #if ((__cplusplus >= 201103L) || (_MSC_VER > 1900)) // C++11
     using is_always_equal = std::true_type;

--- a/source/runtime/core/source/misc/Memory.cpp
+++ b/source/runtime/core/source/misc/Memory.cpp
@@ -3,7 +3,9 @@
 #include "mimalloc.h"
 #endif
 #include "platform/Platform.h"
+#include <limits>
 #include <memory>
+#include <new>
 
 #if USE_MIMALLOC
 #if PLATFORM_WINDOWS
@@ -62,11 +64,18 @@ void* Memory::MallocAligned(size_t size, size_t alignment) noexcept {
 #endif
 }
 
-void* Memory::MallocN(size_t count, size_t size) noexcept {
+void* Memory::MallocN(size_t count, size_t size) {
+    if (size != 0 && count > std::numeric_limits<size_t>::max() / size) {
+        throw std::bad_array_new_length();
+    }
 #if USE_MIMALLOC
     return mi_new_n(count, size);
 #else
-    return malloc(count * size);
+    void* allocation = malloc(count * size);
+    if (allocation == nullptr && count != 0 && size != 0) {
+        throw std::bad_alloc();
+    }
+    return allocation;
 #endif
 }
 void* Memory::CallocAligned(size_t count, size_t size, size_t alignment) noexcept {

--- a/source/test/CMakeLists.txt
+++ b/source/test/CMakeLists.txt
@@ -16,6 +16,31 @@ set_target_properties(${test_target} PROPERTIES FOLDER ${moer_test_folder})
 add_test(NAME ProfileDumpCoreContract COMMAND $<TARGET_FILE:${test_target}>)
 set_tests_properties(ProfileDumpCoreContract PROPERTIES TIMEOUT 60)
 
+set(test_target TestProfileDumpConsumer)
+add_executable(${test_target} "ProfileDumpConsumerTest.cpp")
+target_link_libraries(${test_target}
+    PRIVATE Moer::ProfileConsumer
+)
+set_target_properties(${test_target} PROPERTIES FOLDER ${moer_test_folder})
+add_test(NAME ProfileDumpConsumerContract COMMAND $<TARGET_FILE:${test_target}>)
+set_tests_properties(ProfileDumpConsumerContract PROPERTIES TIMEOUT 120)
+
+set(test_target TestProfileSummaryCli)
+add_executable(${test_target} "ProfileSummaryCliTest.cpp")
+target_link_libraries(${test_target}
+    PRIVATE
+        Moer::ProfileConsumer
+        Moer::Core
+        nlohmann_json::nlohmann_json
+)
+add_dependencies(${test_target} MoerProfileSummary)
+set_target_properties(${test_target} PROPERTIES FOLDER ${moer_test_folder})
+add_test(
+    NAME ProfileSummaryCliContract
+    COMMAND $<TARGET_FILE:${test_target}> $<TARGET_FILE:MoerProfileSummary>
+)
+set_tests_properties(ProfileSummaryCliContract PROPERTIES TIMEOUT 120)
+
 set(test_target TestProfileScopeProducer)
 add_executable(${test_target} "ProfileScopeProducerTest.cpp")
 target_include_directories(${test_target}

--- a/source/test/ProfileDumpConsumerTest.cpp
+++ b/source/test/ProfileDumpConsumerTest.cpp
@@ -4306,14 +4306,20 @@ void TestLimitsAndStickyFailure() {
         });
         builder.End();
 
-        SessionLoadOptions options{};
-        options.limits.max_topology_work_items = 2;
+        // One Loss scan + two extrema materializations + their sort/scan and
+        // record-collision searches consume 13 items before the two GPU source
+        // topology edges. The boundary verifies that all phases share one
+        // cumulative budget.
+        constexpr std::uint64_t loss_allocation_work = 13;
+        constexpr std::uint64_t gpu_topology_work    = 2;
+        SessionLoadOptions      options{};
+        options.limits.max_topology_work_items = loss_allocation_work + gpu_topology_work;
         Expect(
             LoadChunks(builder.bytes, {}, options).result.status == SessionLoadStatus::Complete,
             "exact global GPU topology work-item limit was rejected"
         );
-        options.limits.max_topology_work_items = 1;
-        const Loaded loaded                    = LoadChunks(builder.bytes, {}, options);
+        --options.limits.max_topology_work_items;
+        const Loaded loaded = LoadChunks(builder.bytes, {}, options);
         Expect(
             loaded.result.status == SessionLoadStatus::LimitExceeded &&
                 loaded.result.limit_kind == SessionLimitKind::TopologyWorkItems,
@@ -4324,6 +4330,38 @@ void TestLimitsAndStickyFailure() {
         SessionLoadOptions options{};
         options.limits.max_input_bytes = golden.bytes.size();
         expect_complete(options, "exact input byte limit was rejected");
+    }
+    {
+        SessionBuilder no_loss;
+        no_loss.Begin();
+        no_loss.Schema(Templates::CpuScope());
+        AddCpuScope(no_loss, 1, 1, "zero-budget-root", 0, 10, 0);
+        no_loss.End();
+
+        SessionLoadOptions zero_budget{};
+        zero_budget.limits.max_topology_work_items = 0;
+        Expect(
+            LoadChunks(no_loss.bytes, {}, zero_budget).result.status == SessionLoadStatus::Complete,
+            "loss-free session consumed Loss-allocation topology budget"
+        );
+
+        SessionBuilder with_loss;
+        with_loss.Begin();
+        with_loss.Loss({
+            .first_sequence = 1,
+            .last_sequence  = 1,
+            .record_count   = 1,
+            .value_bytes    = 8,
+            .reason_mask    = static_cast<std::uint32_t>(LossReason::QueueFull),
+        });
+        with_loss.End();
+        const Loaded limited = LoadChunks(with_loss.bytes, {}, zero_budget);
+        Expect(
+            limited.result.status == SessionLoadStatus::LimitExceeded &&
+                limited.result.limit_kind == SessionLimitKind::TopologyWorkItems &&
+                !limited.result.HasUsableSession(),
+            "Loss sequence allocation escaped the session topology work budget"
+        );
     }
     {
         SessionLoadOptions options{};

--- a/source/test/ProfileDumpConsumerTest.cpp
+++ b/source/test/ProfileDumpConsumerTest.cpp
@@ -1,3 +1,4 @@
+#include "misc/Crc32.h"
 #include "misc/MMemory.h"
 #include "profile/ProfileDump.h"
 #include "profile/ProfileDumpTemplates.h"
@@ -23,6 +24,18 @@
 namespace {
 
 using namespace Moer::ProfileDump;
+
+static_assert([] {
+    std::uint32_t wire_bytes = 0;
+    return Detail::TryPacketWireBytes(
+               std::numeric_limits<std::uint32_t>::max() - kPacketHeaderBytes, wire_bytes
+           ) &&
+           wire_bytes == std::numeric_limits<std::uint32_t>::max();
+}());
+static_assert([] {
+    std::uint32_t wire_bytes = 0;
+    return !Detail::TryPacketWireBytes(std::numeric_limits<std::uint32_t>::max(), wire_bytes);
+}());
 
 void Expect(bool _condition, std::string_view _message) {
     if (!_condition) {
@@ -304,7 +317,7 @@ SessionBuilder MakeGoldenSession() {
     );
     AddGpuScope(
         builder,
-        14,
+        13,
         100,
         1,
         0,
@@ -326,7 +339,7 @@ SessionBuilder MakeGoldenSession() {
     );
     AddGpuScope(
         builder,
-        16,
+        11,
         100,
         3,
         0,
@@ -348,7 +361,7 @@ SessionBuilder MakeGoldenSession() {
     );
     AddGpuScope(
         builder,
-        18,
+        6,
         100,
         4,
         0,
@@ -370,7 +383,7 @@ SessionBuilder MakeGoldenSession() {
     );
     AddGpuScope(
         builder,
-        20,
+        5,
         101,
         1,
         0,
@@ -394,7 +407,7 @@ SessionBuilder MakeGoldenSession() {
         std::uint64_t{99},
         std::string_view("future"),
     };
-    builder.Record(unknown, 22, unknown_values);
+    builder.Record(unknown, 1, unknown_values);
 
     // Emitted sequence values 4/7/8 are inside this observational interval;
     // count=2 means the interval is not an exact missing-sequence set.
@@ -435,8 +448,8 @@ void VerifyGolden(const Loaded& _loaded) {
     Expect(summary.unknown_record_count == 1, "unknown record count is wrong");
     Expect(
         summary.complete_gpu_frame_count == 1 && summary.invalid_gpu_frame_count == 1 &&
-            summary.incomplete_gpu_frame_count == 0 && summary.ready_gpu_scope_count == 4 &&
-            summary.error_gpu_scope_count == 1,
+            summary.degraded_complete_gpu_frame_count == 0 && summary.incomplete_gpu_frame_count == 0 &&
+            summary.ready_gpu_scope_count == 4 && summary.error_gpu_scope_count == 1,
         "GPU status summary is wrong"
     );
     Expect(summary.lost_record_count == 2, "loss count is wrong");
@@ -531,10 +544,12 @@ void VerifyGolden(const Loaded& _loaded) {
         complete_frame != _loaded.session.GpuFrames().end() &&
             complete_frame->status == ProfileGpuFrameStatus::Complete && complete_frame->valid &&
             complete_frame->admitted_scope_count == 4 && complete_frame->scope_count == 4 &&
-            complete_frame->error_scope_count == 0 && invalid_frame != _loaded.session.GpuFrames().end() &&
+            complete_frame->error_scope_count == 0 && complete_frame->materialization_complete &&
+            complete_frame->timing_topology_trusted && invalid_frame != _loaded.session.GpuFrames().end() &&
             invalid_frame->status == ProfileGpuFrameStatus::Invalid && !invalid_frame->valid &&
             invalid_frame->admitted_scope_count == 1 && invalid_frame->scope_count == 1 &&
-            invalid_frame->error_scope_count == 1 &&
+            invalid_frame->error_scope_count == 1 && invalid_frame->materialization_complete &&
+            !invalid_frame->timing_topology_trusted &&
             _loaded.session.String(invalid_frame->reason) == "query failed",
         "GPU frame counters or reason changed while materializing the session"
     );
@@ -542,8 +557,8 @@ void VerifyGolden(const Loaded& _loaded) {
     Expect(
         shared_domain.logical_queue_mask == (ProfileLogicalQueueBit(ProfileLogicalQueue::Graphics) |
                                              ProfileLogicalQueueBit(ProfileLogicalQueue::Compute)) &&
-            shared_domain.valid_bits == 64 && shared_domain.tick_period_ns == 1.0 &&
-            shared_domain.ready_scope_count == 3,
+            shared_domain.timing_capability_trusted && shared_domain.valid_bits == 64 &&
+            shared_domain.tick_period_ns == 1.0 && shared_domain.ready_scope_count == 3,
         "GPU physical-domain metadata is wrong"
     );
     Expect(
@@ -609,7 +624,7 @@ void TestEnvelopeSchemaAndSequenceContracts() {
             std::uint64_t{1},
             std::string_view("x"),
         };
-        builder.Record(unknown, 9, values);
+        builder.Record(unknown, 1, values);
         builder.End();
         const Loaded loaded = LoadChunks(builder.bytes);
         Expect(
@@ -858,6 +873,400 @@ void TestSemanticTopologyAndLossRecovery() {
     {
         SessionBuilder builder;
         builder.Begin();
+        builder.Schema(Templates::CpuScope());
+        AddCpuScope(builder, 1, 1, "crossing-a", 0, 10, 0);
+        AddCpuScope(builder, 2, 1, "crossing-b", 5, 15, 0);
+        builder.Loss({
+            .first_sequence = 3,
+            .last_sequence  = 3,
+            .record_count   = 1,
+            .value_bytes    = 8,
+            .reason_mask    = static_cast<std::uint32_t>(LossReason::QueueFull),
+        });
+        builder.End();
+        const Loaded loaded = LoadChunks(builder.bytes);
+        Expect(
+            loaded.result.status == SessionLoadStatus::ProtocolViolation &&
+                loaded.result.error_code == SessionErrorCode::CpuScopeTopologyInvalid,
+            "Loss downgraded crossing CPU intervals"
+        );
+    }
+    {
+        SessionBuilder builder;
+        builder.Begin();
+        builder.Schema(Templates::CpuScope());
+        AddCpuScope(builder, 1, 1, "same-depth-parent", 0, 20, 0);
+        AddCpuScope(builder, 2, 1, "same-depth-child", 5, 10, 0);
+        builder.End();
+        const Loaded loaded = LoadChunks(builder.bytes);
+        Expect(
+            loaded.result.status == SessionLoadStatus::ProtocolViolation &&
+                loaded.result.error_code == SessionErrorCode::CpuScopeTopologyInvalid,
+            "same-depth nested CPU intervals were accepted"
+        );
+    }
+    {
+        SessionBuilder builder;
+        builder.Begin();
+        builder.Schema(Templates::CpuScope());
+        AddCpuScope(builder, 1, 1, "adjacent-a", 0, 10, 0);
+        AddCpuScope(builder, 2, 1, "adjacent-b", 10, 20, 0);
+        AddCpuScope(builder, 4, 2, "zero-parent", 0, 10, 0);
+        AddCpuScope(builder, 3, 2, "zero-child", 10, 10, 1);
+        builder.End();
+        const Loaded loaded     = LoadChunks(builder.bytes);
+        const auto   zero_child = std::find_if(
+            loaded.session.CpuScopes().begin(),
+            loaded.session.CpuScopes().end(),
+            [&](const CpuScopeRecord& _scope) {
+                return loaded.session.String(_scope.name) == "zero-child";
+            }
+        );
+        Expect(
+            loaded.result.status == SessionLoadStatus::Complete &&
+                zero_child != loaded.session.CpuScopes().end() &&
+                zero_child->parent_index != kInvalidSessionIndex,
+            "adjacent roots or a zero-duration CPU child were rejected"
+        );
+    }
+    {
+        SessionBuilder builder;
+        builder.Begin();
+        builder.Schema(Templates::CpuScope());
+        AddCpuScope(builder, 2, 1, "ending-parent", 0, 10, 0);
+        AddCpuScope(builder, 1, 1, "boundary-child", 10, 10, 1);
+        AddCpuScope(builder, 3, 1, "starting-root", 10, 20, 0);
+        builder.End();
+        const Loaded loaded = LoadChunks(builder.bytes);
+        const auto   child  = std::find_if(
+            loaded.session.CpuScopes().begin(),
+            loaded.session.CpuScopes().end(),
+            [&](const CpuScopeRecord& _scope) {
+                return loaded.session.String(_scope.name) == "boundary-child";
+            }
+        );
+        Expect(
+            loaded.result.status == SessionLoadStatus::Complete &&
+                child != loaded.session.CpuScopes().end() && child->parent_index != kInvalidSessionIndex &&
+                loaded.session.String(loaded.session.CpuScopes()[child->parent_index].name) ==
+                    "ending-parent",
+            "CPU record sequence did not keep a zero-duration child with its ending parent"
+        );
+    }
+    {
+        SessionBuilder builder;
+        builder.Begin();
+        builder.Schema(Templates::CpuScope());
+        AddCpuScope(builder, 1, 1, "ending-root", 0, 10, 0);
+        AddCpuScope(builder, 2, 1, "boundary-child", 10, 10, 1);
+        AddCpuScope(builder, 3, 1, "starting-parent", 10, 20, 0);
+        builder.End();
+        const Loaded loaded = LoadChunks(builder.bytes);
+        const auto   child  = std::find_if(
+            loaded.session.CpuScopes().begin(),
+            loaded.session.CpuScopes().end(),
+            [&](const CpuScopeRecord& _scope) {
+                return loaded.session.String(_scope.name) == "boundary-child";
+            }
+        );
+        Expect(
+            loaded.result.status == SessionLoadStatus::Complete &&
+                child != loaded.session.CpuScopes().end() && child->parent_index != kInvalidSessionIndex &&
+                loaded.session.String(loaded.session.CpuScopes()[child->parent_index].name) ==
+                    "starting-parent",
+            "CPU record sequence did not attach a zero-duration child to its starting parent"
+        );
+    }
+    {
+        SessionBuilder builder;
+        builder.Begin();
+        builder.Schema(Templates::CpuScope());
+        AddCpuScope(builder, 4, 1, "root", 0, 100, 0);
+        AddCpuScope(builder, 1, 1, "ended-child", 0, 50, 1);
+        AddCpuScope(builder, 2, 1, "orphan-grandchild", 50, 60, 2);
+        builder.Loss({
+            .first_sequence = 3,
+            .last_sequence  = 3,
+            .record_count   = 1,
+            .value_bytes    = 8,
+            .reason_mask    = static_cast<std::uint32_t>(LossReason::QueueFull),
+        });
+        builder.End();
+        const Loaded loaded = LoadChunks(builder.bytes);
+        Expect(
+            loaded.result.status == SessionLoadStatus::Complete &&
+                loaded.session.Summary().orphan_cpu_scope_count == 1,
+            "a positive-duration CPU orphan after an adjacent ended scope was rejected"
+        );
+    }
+    {
+        SessionBuilder builder;
+        builder.Begin();
+        builder.Schema(Templates::CpuScope());
+        AddCpuScope(builder, 1, 1, "deep-orphan", 0, 10, 5);
+        builder.End();
+        const Loaded loaded = LoadChunks(builder.bytes);
+        Expect(
+            loaded.result.status == SessionLoadStatus::Complete &&
+                loaded.session.Summary().orphan_cpu_scope_count == 1,
+            "a lifecycle-tail CPU orphan was charged as a ProfileDump loss"
+        );
+    }
+    {
+        SessionBuilder builder;
+        builder.Begin();
+        builder.Schema(Templates::CpuScope());
+        AddCpuScope(builder, 1, 1, "thread-one-orphan", 0, 10, 1);
+        AddCpuScope(builder, 2, 2, "thread-two-orphan", 0, 10, 1);
+        builder.End();
+        const Loaded loaded = LoadChunks(builder.bytes);
+        Expect(
+            loaded.result.status == SessionLoadStatus::Complete &&
+                loaded.session.Summary().orphan_cpu_scope_count == 2,
+            "thread-local lifecycle-tail CPU orphans were rejected"
+        );
+    }
+    {
+        SessionBuilder builder;
+        builder.Begin();
+        builder.Schema(Templates::CpuScope());
+        AddCpuScope(builder, 3, 1, "root-one", 0, 10, 0);
+        AddCpuScope(builder, 1, 1, "root-one-orphan", 1, 2, 2);
+        AddCpuScope(builder, 6, 1, "root-two", 10, 20, 0);
+        AddCpuScope(builder, 4, 1, "root-two-orphan", 11, 12, 2);
+        builder.End(SessionEndInfo{
+            .generation      = builder.generation,
+            .records_written = builder.record_count,
+            .records_dropped = 1,
+        });
+        const Loaded loaded = LoadChunks(builder.bytes);
+        Expect(
+            loaded.result.status == SessionLoadStatus::ProtocolViolation &&
+                loaded.result.error_code == SessionErrorCode::RecordSequenceInvalid,
+            "one CPU drop fabricated sequence capacity for two independent observed ancestor subtrees"
+        );
+    }
+    {
+        SessionBuilder builder;
+        builder.Begin();
+        builder.Schema(Templates::CpuScope());
+        AddCpuScope(builder, 3, 1, "root-one", 0, 10, 0);
+        AddCpuScope(builder, 1, 1, "root-one-orphan", 1, 2, 2);
+        AddCpuScope(builder, 6, 1, "root-two", 10, 20, 0);
+        AddCpuScope(builder, 4, 1, "root-two-orphan", 11, 12, 2);
+        builder.End(SessionEndInfo{
+            .generation      = builder.generation,
+            .records_written = builder.record_count,
+            .records_dropped = 2,
+        });
+        const Loaded loaded = LoadChunks(builder.bytes);
+        Expect(
+            loaded.result.status == SessionLoadStatus::Complete &&
+                loaded.session.Summary().orphan_cpu_scope_count == 2,
+            "two CPU drops did not cover two independent observed parent subtrees"
+        );
+    }
+    {
+        SessionBuilder builder;
+        builder.Begin();
+        builder.Schema(Templates::CpuScope());
+        AddCpuScope(builder, 6, 1, "root", 0, 100, 0);
+        AddCpuScope(builder, 1, 1, "orphan-before-barrier", 0, 10, 2);
+        AddCpuScope(builder, 3, 1, "observed-depth-one-barrier", 10, 20, 1);
+        AddCpuScope(builder, 4, 1, "orphan-after-barrier", 20, 30, 2);
+        builder.End(SessionEndInfo{
+            .generation      = builder.generation,
+            .records_written = builder.record_count,
+            .records_dropped = 2,
+        });
+        const Loaded loaded = LoadChunks(builder.bytes);
+        Expect(
+            loaded.result.status == SessionLoadStatus::Complete &&
+                loaded.session.Summary().orphan_cpu_scope_count == 2,
+            "two CPU drops did not cover gap runs separated by an observed barrier"
+        );
+    }
+    {
+        SessionBuilder builder;
+        builder.Begin();
+        builder.Schema(Templates::CpuScope());
+        AddCpuScope(builder, 2, 1, "observed-root", 0, 20, 0);
+        AddCpuScope(builder, 1, 1, "unbudgeted-depth-two", 1, 2, 2);
+        builder.End();
+        const Loaded loaded = LoadChunks(builder.bytes);
+        Expect(
+            loaded.result.status == SessionLoadStatus::ProtocolViolation &&
+                loaded.result.error_code == SessionErrorCode::CpuScopeTopologyInvalid,
+            "an observed CPU ancestor gap was treated as a lifecycle-tail orphan"
+        );
+    }
+    {
+        SessionBuilder builder;
+        builder.Begin();
+        builder.Schema(Templates::CpuScope());
+        AddCpuScope(builder, 2, 1, "observed-root", 0, 20, 0);
+        AddCpuScope(builder, 1, 1, "slotless-depth-two", 1, 2, 2);
+        builder.Loss({
+            .first_sequence = 3,
+            .last_sequence  = 3,
+            .record_count   = 1,
+            .value_bytes    = 8,
+            .reason_mask    = static_cast<std::uint32_t>(LossReason::QueueFull),
+        });
+        builder.End();
+        const Loaded loaded = LoadChunks(builder.bytes);
+        Expect(
+            loaded.result.status == SessionLoadStatus::ProtocolViolation &&
+                loaded.result.error_code == SessionErrorCode::CpuScopeTopologyInvalid,
+            "a missing CPU parent had no sequence slot between child and ancestor"
+        );
+    }
+    {
+        SessionBuilder builder;
+        builder.Begin();
+        builder.Schema(Templates::CpuScope());
+        AddCpuScope(builder, 0, 1, "zero-sequence", 0, 10, 0);
+        builder.End();
+        const Loaded loaded = LoadChunks(builder.bytes);
+        Expect(
+            loaded.result.status == SessionLoadStatus::ProtocolViolation &&
+                loaded.result.error_code == SessionErrorCode::RecordSequenceInvalid,
+            "reserved record sequence zero was accepted"
+        );
+    }
+    {
+        SessionBuilder builder;
+        builder.Begin();
+        builder.Schema(Templates::CpuScope());
+        AddCpuScope(builder, 100, 1, "forged-sparse-root", 0, 20, 0);
+        AddCpuScope(builder, 1, 1, "forged-sparse-child", 1, 2, 2);
+        builder.Loss({
+            .first_sequence = 2,
+            .last_sequence  = 2,
+            .record_count   = 1,
+            .value_bytes    = 8,
+            .reason_mask    = static_cast<std::uint32_t>(LossReason::QueueFull),
+        });
+        builder.End();
+        const Loaded loaded = LoadChunks(builder.bytes);
+        Expect(
+            loaded.result.status == SessionLoadStatus::ProtocolViolation &&
+                loaded.result.error_code == SessionErrorCode::RecordSequenceInvalid,
+            "record sequence exceeded the producer's written-plus-dropped allocation bound"
+        );
+    }
+    {
+        SessionBuilder builder;
+        builder.Begin();
+        builder.Schema(Templates::CpuScope());
+        AddCpuScope(builder, 1, 1, "early-emitted-root", 0, 20, 0);
+        AddCpuScope(builder, 2, 1, "strictly-contained-zero", 10, 10, 1);
+        builder.End();
+        const Loaded loaded = LoadChunks(builder.bytes);
+        Expect(
+            loaded.result.status == SessionLoadStatus::ProtocolViolation &&
+                loaded.result.error_code == SessionErrorCode::CpuScopeTopologyInvalid,
+            "a strictly contained zero-duration CPU child outlived its observed parent"
+        );
+    }
+    {
+        SessionBuilder builder;
+        builder.Begin();
+        builder.Schema(Templates::CpuScope());
+        AddCpuScope(builder, 2, 1, "earlier-root", 0, 10, 0);
+        AddCpuScope(builder, 1, 1, "later-root", 10, 20, 0);
+        builder.End();
+        const Loaded loaded = LoadChunks(builder.bytes);
+        Expect(
+            loaded.result.status == SessionLoadStatus::ProtocolViolation &&
+                loaded.result.error_code == SessionErrorCode::CpuScopeTopologyInvalid,
+            "adjacent CPU roots moved backward in record sequence"
+        );
+    }
+    {
+        SessionBuilder builder;
+        builder.Begin();
+        builder.Schema(Templates::CpuScope());
+        AddCpuScope(builder, 3, 1, "root", 0, 30, 0);
+        AddCpuScope(builder, 2, 1, "earlier-sibling", 0, 10, 1);
+        AddCpuScope(builder, 1, 1, "later-sibling", 10, 20, 1);
+        builder.End();
+        const Loaded loaded = LoadChunks(builder.bytes);
+        Expect(
+            loaded.result.status == SessionLoadStatus::ProtocolViolation &&
+                loaded.result.error_code == SessionErrorCode::CpuScopeTopologyInvalid,
+            "CPU siblings moved backward in record sequence"
+        );
+    }
+    {
+        SessionBuilder builder;
+        builder.Begin();
+        builder.Schema(Templates::CpuScope());
+        AddCpuScope(builder, 4, 1, "ending-root", 0, 10, 0);
+        AddCpuScope(builder, 1, 1, "early-depth-two", 1, 2, 2);
+        AddCpuScope(builder, 2, 1, "boundary-depth-two", 10, 10, 2);
+        AddCpuScope(builder, 5, 1, "starting-root", 10, 20, 0);
+        builder.Loss({
+            .first_sequence = 3,
+            .last_sequence  = 3,
+            .record_count   = 1,
+            .value_bytes    = 8,
+            .reason_mask    = static_cast<std::uint32_t>(LossReason::QueueFull),
+        });
+        builder.End();
+        const Loaded loaded = LoadChunks(builder.bytes);
+        Expect(
+            loaded.result.status == SessionLoadStatus::Complete &&
+                loaded.session.Summary().orphan_cpu_scope_count == 2,
+            "zero-duration CPU boundary evidence failed to share its ending ancestor's missing parent"
+        );
+    }
+    {
+        SessionBuilder builder;
+        builder.Begin();
+        builder.Schema(Templates::CpuScope());
+        builder.Schema(Templates::GpuFrame());
+        AddCpuScope(builder, 3, 1, "cpu-root", 0, 20, 0);
+        AddCpuScope(builder, 1, 1, "cpu-depth-two", 1, 2, 2);
+        AddGpuFrame(builder, 4, 1, ProfileGpuFrameStatus::Complete, true, 1, 0, 0, "");
+        builder.End(SessionEndInfo{
+            .generation      = builder.generation,
+            .records_written = builder.record_count,
+            .records_dropped = 1,
+        });
+        const Loaded loaded = LoadChunks(builder.bytes);
+        Expect(
+            loaded.result.status == SessionLoadStatus::ProtocolViolation &&
+                loaded.result.error_code == SessionErrorCode::GpuFrameTotalsMismatch,
+            "one ProfileDump loss was reused by CPU and GPU topology deficits"
+        );
+    }
+    {
+        SessionBuilder builder;
+        builder.Begin();
+        builder.Schema(Templates::CpuScope());
+        builder.Schema(Templates::GpuFrame());
+        AddCpuScope(builder, 1, 1, "cpu-orphan", 0, 10, 1);
+        AddGpuFrame(builder, 2, 1, ProfileGpuFrameStatus::Complete, true, 1, 0, 0, "");
+        builder.Loss({
+            .first_sequence = 3,
+            .last_sequence  = 3,
+            .record_count   = 1,
+            .value_bytes    = 8,
+            .reason_mask    = static_cast<std::uint32_t>(LossReason::QueueFull),
+        });
+        builder.End();
+        const Loaded loaded = LoadChunks(builder.bytes);
+        Expect(
+            loaded.result.status == SessionLoadStatus::Complete &&
+                loaded.session.Summary().orphan_cpu_scope_count == 1 &&
+                loaded.session.Summary().degraded_complete_gpu_frame_count == 1,
+            "a lifecycle-tail CPU orphan consumed the GPU ProfileDump loss budget"
+        );
+    }
+    {
+        SessionBuilder builder;
+        builder.Begin();
         builder.Schema(Templates::GpuFrame());
         builder.Schema(Templates::GpuScope());
         AddGpuFrame(builder, 1, 1, ProfileGpuFrameStatus::Complete, true, 1, 0, 0, "");
@@ -895,7 +1304,7 @@ void TestSemanticTopologyAndLossRecovery() {
         builder.Begin();
         builder.Schema(Templates::GpuFrame());
         builder.Schema(Templates::GpuScope());
-        AddGpuFrame(builder, 1, 1, ProfileGpuFrameStatus::Complete, true, 1, 0, 0, "");
+        AddGpuFrame(builder, 1, 1, ProfileGpuFrameStatus::Complete, true, 2, 0, 0, "");
         AddGpuScope(
             builder,
             2,
@@ -938,7 +1347,180 @@ void TestSemanticTopologyAndLossRecovery() {
         builder.Begin();
         builder.Schema(Templates::GpuFrame());
         builder.Schema(Templates::GpuScope());
+        AddGpuFrame(builder, 1, 1, ProfileGpuFrameStatus::Complete, true, 3, 0, 0, "");
+        AddGpuScope(
+            builder,
+            2,
+            1,
+            2,
+            99,
+            0,
+            1,
+            0,
+            0,
+            0,
+            "orphan-a",
+            ProfileGpuScopeStatus::Ready,
+            1,
+            2,
+            64,
+            1.0,
+            1.0,
+            1.0,
+            1,
+            ""
+        );
+        AddGpuScope(
+            builder,
+            3,
+            1,
+            3,
+            99,
+            0,
+            1,
+            1,
+            1,
+            1,
+            "orphan-b",
+            ProfileGpuScopeStatus::Ready,
+            3,
+            4,
+            64,
+            1.0,
+            1.0,
+            1.0,
+            1,
+            ""
+        );
+        builder.Loss({
+            .first_sequence = 4,
+            .last_sequence  = 4,
+            .record_count   = 1,
+            .value_bytes    = 8,
+            .reason_mask    = static_cast<std::uint32_t>(LossReason::QueueFull),
+        });
+        builder.End();
+        const Loaded loaded = LoadChunks(builder.bytes);
+        Expect(
+            loaded.result.status == SessionLoadStatus::ProtocolViolation &&
+                loaded.result.error_code == SessionErrorCode::GpuScopeParentInvalid,
+            "one missing GPU parent was allowed to have incompatible child contracts"
+        );
+    }
+    {
+        SessionBuilder builder;
+        builder.Begin();
+        builder.Schema(Templates::GpuFrame());
+        builder.Schema(Templates::GpuScope());
         AddGpuFrame(builder, 1, 1, ProfileGpuFrameStatus::Complete, true, 2, 0, 0, "");
+        AddGpuScope(
+            builder,
+            2,
+            1,
+            2,
+            99,
+            0,
+            0,
+            0,
+            0,
+            0,
+            "local-zero-orphan",
+            ProfileGpuScopeStatus::Ready,
+            1,
+            2,
+            64,
+            1.0,
+            1.0,
+            1.0,
+            1,
+            ""
+        );
+        builder.Loss({
+            .first_sequence = 3,
+            .last_sequence  = 3,
+            .record_count   = 1,
+            .value_bytes    = 8,
+            .reason_mask    = static_cast<std::uint32_t>(LossReason::QueueFull),
+        });
+        builder.End();
+        const Loaded loaded = LoadChunks(builder.bytes);
+        Expect(
+            loaded.result.status == SessionLoadStatus::ProtocolViolation &&
+                loaded.result.error_code == SessionErrorCode::GpuScopeParentInvalid,
+            "a missing GPU parent was placed before child local order zero"
+        );
+    }
+    {
+        SessionBuilder builder;
+        builder.Begin();
+        builder.Schema(Templates::GpuFrame());
+        builder.Schema(Templates::GpuScope());
+        AddGpuFrame(builder, 1, 1, ProfileGpuFrameStatus::Complete, true, 4, 0, 0, "");
+        AddGpuScope(
+            builder,
+            2,
+            1,
+            3,
+            98,
+            0,
+            1,
+            0,
+            0,
+            0,
+            "deadline-one",
+            ProfileGpuScopeStatus::Ready,
+            1,
+            2,
+            64,
+            1.0,
+            1.0,
+            1.0,
+            1,
+            ""
+        );
+        AddGpuScope(
+            builder,
+            3,
+            1,
+            4,
+            99,
+            0,
+            2,
+            0,
+            0,
+            0,
+            "deadline-two",
+            ProfileGpuScopeStatus::Ready,
+            3,
+            4,
+            64,
+            1.0,
+            1.0,
+            1.0,
+            1,
+            ""
+        );
+        builder.Loss({
+            .first_sequence = 4,
+            .last_sequence  = 5,
+            .record_count   = 2,
+            .value_bytes    = 16,
+            .reason_mask    = static_cast<std::uint32_t>(LossReason::QueueFull),
+        });
+        builder.End();
+        const Loaded loaded = LoadChunks(builder.bytes);
+        Expect(
+            loaded.result.status == SessionLoadStatus::ProtocolViolation &&
+                loaded.result.error_code == SessionErrorCode::GpuScopeParentInvalid,
+            "two missing GPU parents reused one local-order slot"
+        );
+    }
+    {
+        SessionBuilder builder;
+        builder.Begin();
+        builder.Schema(Templates::GpuFrame());
+        builder.Schema(Templates::GpuScope());
+        AddGpuFrame(builder, 1, 1, ProfileGpuFrameStatus::Complete, true, 3, 0, 0, "");
         AddGpuScope(
             builder,
             2,
@@ -1061,6 +1643,699 @@ void TestSemanticTopologyAndLossRecovery() {
             loaded.result.status == SessionLoadStatus::ProtocolViolation &&
                 loaded.result.error_code == SessionErrorCode::GpuScopeTimingInvalid,
             "GpuScope raw ticks and duration contradiction was accepted"
+        );
+    }
+    {
+        SessionBuilder builder;
+        builder.Begin();
+        builder.Schema(Templates::GpuFrame());
+        builder.Schema(Templates::GpuScope());
+        AddGpuFrame(builder, 1, 1, ProfileGpuFrameStatus::Complete, true, 2, 0, 0, "");
+        AddGpuScope(
+            builder,
+            2,
+            1,
+            1,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            "parent",
+            ProfileGpuScopeStatus::Ready,
+            100,
+            200,
+            64,
+            1.0,
+            100.0,
+            90.0,
+            0,
+            ""
+        );
+        AddGpuScope(
+            builder,
+            3,
+            1,
+            2,
+            1,
+            0,
+            1,
+            0,
+            0,
+            0,
+            "outside-child",
+            ProfileGpuScopeStatus::Ready,
+            50,
+            60,
+            64,
+            1.0,
+            10.0,
+            10.0,
+            1,
+            ""
+        );
+        builder.End();
+        const Loaded loaded = LoadChunks(builder.bytes);
+        Expect(
+            loaded.result.status == SessionLoadStatus::ProtocolViolation &&
+                loaded.result.error_code == SessionErrorCode::GpuScopeTimingInvalid,
+            "complete GpuFrame accepted a child outside its parent interval"
+        );
+    }
+    {
+        SessionBuilder builder;
+        builder.Begin();
+        builder.Schema(Templates::GpuFrame());
+        builder.Schema(Templates::GpuScope());
+        AddGpuFrame(builder, 1, 1, ProfileGpuFrameStatus::Complete, true, 3, 0, 0, "");
+        AddGpuScope(
+            builder,
+            2,
+            1,
+            1,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            "parent",
+            ProfileGpuScopeStatus::Ready,
+            100,
+            200,
+            64,
+            1.0,
+            100.0,
+            30.0,
+            0,
+            ""
+        );
+        AddGpuScope(
+            builder,
+            3,
+            1,
+            2,
+            1,
+            0,
+            1,
+            0,
+            0,
+            0,
+            "child-a",
+            ProfileGpuScopeStatus::Ready,
+            110,
+            160,
+            64,
+            1.0,
+            50.0,
+            50.0,
+            1,
+            ""
+        );
+        AddGpuScope(
+            builder,
+            4,
+            1,
+            3,
+            1,
+            0,
+            2,
+            0,
+            0,
+            0,
+            "child-b",
+            ProfileGpuScopeStatus::Ready,
+            150,
+            170,
+            64,
+            1.0,
+            20.0,
+            20.0,
+            1,
+            ""
+        );
+        builder.End();
+        const Loaded loaded = LoadChunks(builder.bytes);
+        Expect(
+            loaded.result.status == SessionLoadStatus::ProtocolViolation &&
+                loaded.result.error_code == SessionErrorCode::GpuScopeTimingInvalid,
+            "complete GpuFrame accepted overlapping direct children"
+        );
+    }
+    {
+        SessionBuilder builder;
+        builder.Begin();
+        builder.Schema(Templates::GpuFrame());
+        builder.Schema(Templates::GpuScope());
+        AddGpuFrame(builder, 1, 1, ProfileGpuFrameStatus::Complete, true, 2, 0, 0, "");
+        AddGpuScope(
+            builder,
+            2,
+            1,
+            1,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            "root-a",
+            ProfileGpuScopeStatus::Ready,
+            100,
+            150,
+            64,
+            1.0,
+            50.0,
+            50.0,
+            0,
+            ""
+        );
+        AddGpuScope(
+            builder,
+            3,
+            1,
+            2,
+            0,
+            0,
+            1,
+            0,
+            0,
+            0,
+            "root-b",
+            ProfileGpuScopeStatus::Ready,
+            140,
+            160,
+            64,
+            1.0,
+            20.0,
+            20.0,
+            0,
+            ""
+        );
+        builder.End();
+        const Loaded loaded = LoadChunks(builder.bytes);
+        Expect(
+            loaded.result.status == SessionLoadStatus::ProtocolViolation &&
+                loaded.result.error_code == SessionErrorCode::GpuScopeTimingInvalid,
+            "complete GpuFrame accepted overlapping same-source roots"
+        );
+    }
+    {
+        SessionBuilder builder;
+        builder.Begin();
+        builder.Schema(Templates::GpuFrame());
+        builder.Schema(Templates::GpuScope());
+        AddGpuFrame(builder, 1, 1, ProfileGpuFrameStatus::Complete, true, 3, 0, 0, "");
+        AddGpuScope(
+            builder,
+            2,
+            1,
+            1,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            "wrapped-parent",
+            ProfileGpuScopeStatus::Ready,
+            250,
+            20,
+            8,
+            1.0,
+            26.0,
+            14.0,
+            0,
+            ""
+        );
+        AddGpuScope(
+            builder,
+            3,
+            1,
+            2,
+            1,
+            0,
+            1,
+            0,
+            0,
+            0,
+            "wrapped-child-a",
+            ProfileGpuScopeStatus::Ready,
+            254,
+            4,
+            8,
+            1.0,
+            6.0,
+            6.0,
+            1,
+            ""
+        );
+        AddGpuScope(
+            builder,
+            4,
+            1,
+            3,
+            1,
+            0,
+            2,
+            0,
+            0,
+            0,
+            "wrapped-child-b",
+            ProfileGpuScopeStatus::Ready,
+            4,
+            10,
+            8,
+            1.0,
+            6.0,
+            6.0,
+            1,
+            ""
+        );
+        builder.End();
+        const Loaded loaded = LoadChunks(builder.bytes);
+        Expect(
+            loaded.result.status == SessionLoadStatus::Complete &&
+                loaded.session.GpuFrames().front().timing_topology_trusted,
+            "valid wrapped GPU parent/child timing was rejected"
+        );
+    }
+    {
+        SessionBuilder builder;
+        builder.Begin();
+        builder.Schema(Templates::GpuFrame());
+        builder.Schema(Templates::GpuScope());
+        AddGpuFrame(builder, 1, 1, ProfileGpuFrameStatus::Complete, true, 3, 0, 0, "");
+        AddGpuScope(
+            builder,
+            2,
+            1,
+            1,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            "wrapped-root-a",
+            ProfileGpuScopeStatus::Ready,
+            250,
+            5,
+            8,
+            1.0,
+            11.0,
+            11.0,
+            0,
+            ""
+        );
+        AddGpuScope(
+            builder,
+            3,
+            1,
+            2,
+            0,
+            0,
+            1,
+            0,
+            0,
+            0,
+            "wrapped-root-b",
+            ProfileGpuScopeStatus::Ready,
+            5,
+            10,
+            8,
+            1.0,
+            5.0,
+            5.0,
+            0,
+            ""
+        );
+        AddGpuScope(
+            builder,
+            4,
+            1,
+            3,
+            0,
+            0,
+            2,
+            0,
+            0,
+            0,
+            "wrapped-root-c",
+            ProfileGpuScopeStatus::Ready,
+            10,
+            20,
+            8,
+            1.0,
+            10.0,
+            10.0,
+            0,
+            ""
+        );
+        builder.End();
+        const Loaded loaded = LoadChunks(builder.bytes);
+        Expect(
+            loaded.result.status == SessionLoadStatus::Complete &&
+                loaded.session.GpuFrames().front().timing_topology_trusted,
+            "adjacent same-source GPU roots across timestamp wrap were rejected"
+        );
+    }
+    {
+        SessionBuilder builder;
+        builder.Begin();
+        builder.Schema(Templates::GpuFrame());
+        builder.Schema(Templates::GpuScope());
+        AddGpuFrame(builder, 1, 1, ProfileGpuFrameStatus::Complete, true, 2, 0, 0, "");
+        AddGpuScope(
+            builder,
+            2,
+            1,
+            1,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            "wrapped-overlap-a",
+            ProfileGpuScopeStatus::Ready,
+            250,
+            5,
+            8,
+            1.0,
+            11.0,
+            11.0,
+            0,
+            ""
+        );
+        AddGpuScope(
+            builder,
+            3,
+            1,
+            2,
+            0,
+            0,
+            1,
+            0,
+            0,
+            0,
+            "wrapped-overlap-b",
+            ProfileGpuScopeStatus::Ready,
+            4,
+            10,
+            8,
+            1.0,
+            6.0,
+            6.0,
+            0,
+            ""
+        );
+        builder.End();
+        const Loaded loaded = LoadChunks(builder.bytes);
+        Expect(
+            loaded.result.status == SessionLoadStatus::ProtocolViolation &&
+                loaded.result.error_code == SessionErrorCode::GpuScopeTimingInvalid,
+            "overlapping same-source GPU roots across timestamp wrap were accepted"
+        );
+    }
+    {
+        SessionBuilder builder;
+        builder.Begin();
+        builder.Schema(Templates::GpuFrame());
+        builder.Schema(Templates::GpuScope());
+        AddGpuFrame(builder, 1, 1, ProfileGpuFrameStatus::Complete, true, 2, 0, 0, "");
+        AddGpuScope(
+            builder,
+            2,
+            1,
+            1,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            "tolerant-parent",
+            ProfileGpuScopeStatus::Ready,
+            0,
+            100,
+            64,
+            1.0,
+            100.0,
+            80.0,
+            0,
+            ""
+        );
+        AddGpuScope(
+            builder,
+            3,
+            1,
+            2,
+            1,
+            0,
+            1,
+            0,
+            0,
+            0,
+            "tolerant-child",
+            ProfileGpuScopeStatus::Ready,
+            10,
+            30,
+            64,
+            1.00000001,
+            20.0000002,
+            20.0000002,
+            1,
+            ""
+        );
+        builder.End();
+        const Loaded loaded = LoadChunks(builder.bytes);
+        Expect(
+            loaded.result.status == SessionLoadStatus::Complete &&
+                loaded.session.GpuFrames().front().timing_topology_trusted,
+            "producer-equivalent timestamp-period tolerance was rejected"
+        );
+    }
+    {
+        SessionBuilder builder;
+        builder.Begin();
+        builder.Schema(Templates::GpuFrame());
+        builder.Schema(Templates::GpuScope());
+        AddGpuFrame(builder, 1, 1, ProfileGpuFrameStatus::Complete, true, 1, 0, 0, "");
+        AddGpuScope(
+            builder,
+            2,
+            1,
+            1,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            "bad-exclusive",
+            ProfileGpuScopeStatus::Ready,
+            0,
+            10,
+            64,
+            1.0,
+            10.0,
+            9.0,
+            0,
+            ""
+        );
+        builder.End();
+        const Loaded loaded = LoadChunks(builder.bytes);
+        Expect(
+            loaded.result.status == SessionLoadStatus::ProtocolViolation &&
+                loaded.result.error_code == SessionErrorCode::GpuScopeTimingInvalid,
+            "complete GpuFrame accepted an exclusive duration that disagrees with its full child set"
+        );
+    }
+    {
+        SessionBuilder builder;
+        builder.Begin();
+        builder.Schema(Templates::GpuFrame());
+        builder.Schema(Templates::GpuScope());
+        AddGpuFrame(builder, 1, 1, ProfileGpuFrameStatus::Complete, true, 3, 0, 0, "");
+        AddGpuScope(
+            builder,
+            2,
+            1,
+            1,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            "partial-parent",
+            ProfileGpuScopeStatus::Ready,
+            0,
+            10,
+            64,
+            1.0,
+            10.0,
+            5.0,
+            0,
+            ""
+        );
+        AddGpuScope(
+            builder,
+            3,
+            1,
+            2,
+            1,
+            0,
+            1,
+            0,
+            0,
+            0,
+            "partial-child",
+            ProfileGpuScopeStatus::Ready,
+            0,
+            6,
+            64,
+            1.0,
+            6.0,
+            6.0,
+            1,
+            ""
+        );
+        builder.End(SessionEndInfo{
+            .generation      = builder.generation,
+            .records_written = builder.record_count,
+            .records_dropped = 1,
+        });
+        const Loaded loaded = LoadChunks(builder.bytes);
+        Expect(
+            loaded.result.status == SessionLoadStatus::ProtocolViolation &&
+                loaded.result.error_code == SessionErrorCode::GpuScopeTimingInvalid,
+            "partial GpuFrame accepted observed child plus exclusive time beyond its parent"
+        );
+    }
+    {
+        SessionBuilder builder;
+        builder.Begin();
+        builder.Schema(Templates::GpuFrame());
+        builder.Schema(Templates::GpuScope());
+        AddGpuFrame(builder, 1, 1, ProfileGpuFrameStatus::Invalid, false, 2, 0, 0, "topology invalid");
+        AddGpuScope(
+            builder,
+            2,
+            1,
+            1,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            "invalid-parent",
+            ProfileGpuScopeStatus::Ready,
+            100,
+            200,
+            64,
+            1.0,
+            100.0,
+            0.0,
+            0,
+            ""
+        );
+        AddGpuScope(
+            builder,
+            3,
+            1,
+            2,
+            1,
+            0,
+            1,
+            0,
+            0,
+            0,
+            "invalid-outside-child",
+            ProfileGpuScopeStatus::Ready,
+            50,
+            60,
+            32,
+            2.0,
+            20.0,
+            0.0,
+            1,
+            ""
+        );
+        builder.End();
+        const Loaded loaded = LoadChunks(builder.bytes);
+        Expect(
+            loaded.result.status == SessionLoadStatus::Complete &&
+                loaded.session.GpuFrames().front().materialization_complete &&
+                !loaded.session.GpuFrames().front().timing_topology_trusted &&
+                !loaded.session.GpuDomains().front().timing_capability_trusted,
+            "producer Invalid timing/domain evidence was rejected or marked trusted"
+        );
+    }
+    {
+        SessionBuilder builder;
+        builder.Begin();
+        builder.Schema(Templates::GpuFrame());
+        builder.Schema(Templates::GpuScope());
+        AddGpuFrame(builder, 1, 1, ProfileGpuFrameStatus::Complete, true, 3, 0, 0, "");
+        AddGpuScope(
+            builder,
+            2,
+            1,
+            1,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            "first-root",
+            ProfileGpuScopeStatus::Ready,
+            0,
+            10,
+            8,
+            1.0,
+            10.0,
+            10.0,
+            0,
+            ""
+        );
+        AddGpuScope(
+            builder,
+            3,
+            1,
+            3,
+            0,
+            0,
+            2,
+            0,
+            0,
+            0,
+            "third-root",
+            ProfileGpuScopeStatus::Ready,
+            200,
+            210,
+            8,
+            1.0,
+            10.0,
+            10.0,
+            0,
+            ""
+        );
+        builder.End(SessionEndInfo{
+            .generation      = builder.generation,
+            .records_written = builder.record_count,
+            .records_dropped = 1,
+        });
+        const Loaded loaded = LoadChunks(builder.bytes);
+        Expect(
+            loaded.result.status == SessionLoadStatus::Complete &&
+                loaded.session.Summary().degraded_complete_gpu_frame_count == 1 &&
+                !loaded.session.GpuFrames().front().timing_topology_trusted,
+            "missing middle root caused an unsound half-range comparison"
         );
     }
     {
@@ -1233,6 +2508,215 @@ void TestSemanticTopologyAndLossRecovery() {
         SessionBuilder builder;
         builder.Begin();
         builder.Schema(Templates::GpuFrame());
+        AddGpuFrame(builder, 1, 1, ProfileGpuFrameStatus::Complete, true, 100, 0, 0, "");
+        builder.Loss({
+            .first_sequence = 2,
+            .last_sequence  = 2,
+            .record_count   = 1,
+            .value_bytes    = 8,
+            .reason_mask    = static_cast<std::uint32_t>(LossReason::QueueFull),
+        });
+        builder.End();
+        const Loaded loaded = LoadChunks(builder.bytes);
+        Expect(
+            loaded.result.status == SessionLoadStatus::ProtocolViolation &&
+                loaded.result.error_code == SessionErrorCode::GpuFrameTotalsMismatch,
+            "one dropped record explained an unbounded complete-frame deficit"
+        );
+    }
+    {
+        SessionBuilder builder;
+        builder.Begin();
+        builder.Schema(Templates::GpuFrame());
+        AddGpuFrame(builder, 1, 1, ProfileGpuFrameStatus::Complete, true, 2, 0, 0, "");
+        AddGpuFrame(builder, 2, 2, ProfileGpuFrameStatus::Complete, true, 3, 0, 0, "");
+        builder.End(SessionEndInfo{
+            .generation      = builder.generation,
+            .records_written = builder.record_count,
+            .records_dropped = 4,
+        });
+        const Loaded loaded = LoadChunks(builder.bytes);
+        Expect(
+            loaded.result.status == SessionLoadStatus::ProtocolViolation &&
+                loaded.result.error_code == SessionErrorCode::GpuFrameTotalsMismatch,
+            "drop budget was reused independently by multiple complete frames"
+        );
+    }
+    {
+        SessionBuilder builder;
+        builder.Begin();
+        builder.Schema(Templates::GpuFrame());
+        AddGpuFrame(builder, 1, 1, ProfileGpuFrameStatus::Complete, true, 5, 0, 0, "");
+        builder.End(SessionEndInfo{
+            .generation      = builder.generation,
+            .records_written = builder.record_count,
+            .records_dropped = 5,
+        });
+        const Loaded loaded = LoadChunks(builder.bytes);
+        Expect(
+            loaded.result.status == SessionLoadStatus::Complete &&
+                loaded.session.Summary().degraded_complete_gpu_frame_count == 1 &&
+                loaded.session.GpuFrames().front().export_missing_scope_count == 5 &&
+                !loaded.session.GpuFrames().front().materialization_complete &&
+                !loaded.session.GpuFrames().front().timing_topology_trusted,
+            "a fully budgeted complete-frame deficit was not marked degraded"
+        );
+    }
+    {
+        SessionBuilder builder;
+        builder.Begin();
+        builder.Schema(Templates::GpuFrame());
+        builder.Schema(Templates::GpuScope());
+        AddGpuFrame(builder, 1, 1, ProfileGpuFrameStatus::Invalid, false, 1, 0, 1, "query failed");
+        AddGpuScope(
+            builder,
+            2,
+            1,
+            1,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            "undeclared-ready",
+            ProfileGpuScopeStatus::Ready,
+            10,
+            20,
+            64,
+            1.0,
+            10.0,
+            10.0,
+            0,
+            ""
+        );
+        builder.End(SessionEndInfo{
+            .generation      = builder.generation,
+            .records_written = builder.record_count,
+            .records_dropped = 100,
+        });
+        const Loaded loaded = LoadChunks(builder.bytes);
+        Expect(
+            loaded.result.status == SessionLoadStatus::ProtocolViolation &&
+                loaded.result.error_code == SessionErrorCode::GpuFrameTotalsMismatch,
+            "drop budget allowed more Ready scopes than the frame declared"
+        );
+    }
+    for (const ProfileGpuFrameStatus status :
+         {ProfileGpuFrameStatus::Incomplete, ProfileGpuFrameStatus::Invalid}) {
+        SessionBuilder builder;
+        builder.Begin();
+        builder.Schema(Templates::GpuFrame());
+        builder.Schema(Templates::GpuScope());
+        AddGpuFrame(
+            builder,
+            1,
+            1,
+            status,
+            false,
+            1,
+            status == ProfileGpuFrameStatus::Incomplete ? 1 : 0,
+            0,
+            "untrusted frame"
+        );
+        AddGpuScope(
+            builder,
+            2,
+            1,
+            2,
+            99,
+            0,
+            1,
+            0,
+            0,
+            0,
+            "impossible-orphan",
+            ProfileGpuScopeStatus::Ready,
+            10,
+            20,
+            64,
+            1.0,
+            10.0,
+            0.0,
+            1,
+            ""
+        );
+        builder.End(SessionEndInfo{
+            .generation      = builder.generation,
+            .records_written = builder.record_count,
+            .records_dropped = 1,
+        });
+        const Loaded loaded = LoadChunks(builder.bytes);
+        Expect(
+            loaded.result.status == SessionLoadStatus::ProtocolViolation &&
+                loaded.result.error_code == SessionErrorCode::GpuFrameTotalsMismatch,
+            "untrusted GpuFrame had more missing parents than missing admitted scopes"
+        );
+    }
+    {
+        SessionBuilder builder;
+        builder.Begin();
+        builder.Schema(Templates::GpuFrame());
+        builder.Schema(Templates::GpuScope());
+        AddGpuFrame(builder, 1, 1, ProfileGpuFrameStatus::Incomplete, false, 4, 1, 0, "RHI drops");
+        AddGpuScope(
+            builder,
+            2,
+            1,
+            1,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            "surviving-incomplete",
+            ProfileGpuScopeStatus::Ready,
+            10,
+            20,
+            64,
+            1.0,
+            10.0,
+            0.0,
+            0,
+            ""
+        );
+        AddGpuScope(
+            builder,
+            3,
+            1,
+            2,
+            0,
+            0,
+            1,
+            0,
+            0,
+            0,
+            "conflicting-incomplete",
+            ProfileGpuScopeStatus::Ready,
+            30,
+            35,
+            32,
+            2.0,
+            10.0,
+            0.0,
+            0,
+            ""
+        );
+        builder.End();
+        const Loaded loaded = LoadChunks(builder.bytes);
+        Expect(
+            loaded.result.status == SessionLoadStatus::Complete &&
+                loaded.session.GpuFrames().front().export_missing_scope_count == 2 &&
+                !loaded.session.GpuFrames().front().timing_topology_trusted &&
+                !loaded.session.GpuDomains().front().timing_capability_trusted,
+            "GpuFrame v1 Incomplete producer omissions/domain conflicts were rejected or trusted"
+        );
+    }
+    {
+        SessionBuilder builder;
+        builder.Begin();
+        builder.Schema(Templates::GpuFrame());
         builder.Schema(Templates::GpuScope());
         AddGpuFrame(builder, 1, 1, ProfileGpuFrameStatus::Complete, true, 2, 0, 0, "");
         AddGpuScope(
@@ -1265,8 +2749,906 @@ void TestSemanticTopologyAndLossRecovery() {
         const Loaded loaded = LoadChunks(builder.bytes);
         Expect(
             loaded.result.status == SessionLoadStatus::Complete &&
-                loaded.session.Summary().unnotified_drop_count == 1,
+                loaded.session.Summary().unnotified_drop_count == 1 &&
+                loaded.session.Summary().degraded_complete_gpu_frame_count == 1 &&
+                loaded.session.GpuFrames().front().export_missing_scope_count == 1,
             "unnotified SessionEnd drops did not explain an undersized GPU frame"
+        );
+    }
+    const auto add_ready_scope = [](SessionBuilder&  _builder,
+                                    std::uint64_t    _sequence,
+                                    std::uint64_t    _frame_id,
+                                    std::uint64_t    _scope_id,
+                                    std::uint64_t    _parent_scope_id,
+                                    std::uint64_t    _source_order,
+                                    std::uint64_t    _local_order,
+                                    std::string_view _name,
+                                    std::uint64_t    _begin_tick,
+                                    std::uint64_t    _end_tick,
+                                    std::uint32_t    _depth) {
+        AddGpuScope(
+            _builder,
+            _sequence,
+            _frame_id,
+            _scope_id,
+            _parent_scope_id,
+            _source_order,
+            _local_order,
+            0,
+            0,
+            0,
+            _name,
+            ProfileGpuScopeStatus::Ready,
+            _begin_tick,
+            _end_tick,
+            64,
+            1.0,
+            static_cast<double>(_end_tick - _begin_tick),
+            static_cast<double>(_end_tick - _begin_tick),
+            _depth,
+            ""
+        );
+    };
+    const auto add_ready_scope_bits = [](SessionBuilder&  _builder,
+                                         std::uint64_t    _sequence,
+                                         std::uint64_t    _frame_id,
+                                         std::uint64_t    _scope_id,
+                                         std::uint64_t    _parent_scope_id,
+                                         std::uint64_t    _source_order,
+                                         std::uint64_t    _local_order,
+                                         std::string_view _name,
+                                         std::uint64_t    _begin_tick,
+                                         std::uint64_t    _end_tick,
+                                         std::uint32_t    _valid_bits,
+                                         double           _total_duration,
+                                         double           _exclusive_duration,
+                                         std::uint32_t    _depth) {
+        AddGpuScope(
+            _builder,
+            _sequence,
+            _frame_id,
+            _scope_id,
+            _parent_scope_id,
+            _source_order,
+            _local_order,
+            0,
+            0,
+            0,
+            _name,
+            ProfileGpuScopeStatus::Ready,
+            _begin_tick,
+            _end_tick,
+            _valid_bits,
+            1.0,
+            _total_duration,
+            _exclusive_duration,
+            _depth,
+            ""
+        );
+    };
+    const auto add_queue_loss =
+        [](SessionBuilder& _builder, std::uint64_t _first_sequence, std::uint64_t _record_count) {
+            _builder.Loss({
+                .first_sequence = _first_sequence,
+                .last_sequence  = _first_sequence + _record_count - 1,
+                .record_count   = _record_count,
+                .value_bytes    = _record_count * 8,
+                .reason_mask    = static_cast<std::uint32_t>(LossReason::QueueFull),
+            });
+        };
+    {
+        SessionBuilder builder;
+        builder.Begin();
+        builder.Schema(Templates::GpuFrame());
+        builder.Schema(Templates::GpuScope());
+        AddGpuFrame(builder, 1, 1, ProfileGpuFrameStatus::Complete, true, 1, 0, 0, "");
+        add_ready_scope(builder, 2, 1, 1, 0, 0, 1, "root-after-hole", 10, 20, 0);
+        builder.End();
+        const Loaded loaded = LoadChunks(builder.bytes);
+        Expect(
+            loaded.result.status == SessionLoadStatus::ProtocolViolation &&
+                loaded.result.error_code == SessionErrorCode::GpuFrameTotalsMismatch,
+            "a Complete GPU source started after an unexplained local-order hole"
+        );
+    }
+    {
+        SessionBuilder builder;
+        builder.Begin();
+        builder.Schema(Templates::GpuFrame());
+        builder.Schema(Templates::GpuScope());
+        AddGpuFrame(builder, 1, 1, ProfileGpuFrameStatus::Complete, true, 3, 0, 0, "");
+        add_ready_scope(builder, 2, 1, 1, 0, 0, 1, "source-zero-root", 10, 20, 0);
+        add_ready_scope(builder, 3, 1, 2, 0, 1, 1, "source-one-root", 30, 40, 0);
+        builder.Loss({
+            .first_sequence = 4,
+            .last_sequence  = 4,
+            .record_count   = 1,
+            .value_bytes    = 8,
+            .reason_mask    = static_cast<std::uint32_t>(LossReason::QueueFull),
+        });
+        builder.End();
+        const Loaded loaded = LoadChunks(builder.bytes);
+        Expect(
+            loaded.result.status == SessionLoadStatus::ProtocolViolation &&
+                loaded.result.error_code == SessionErrorCode::GpuFrameTotalsMismatch,
+            "one frame-level deficit was reused by two GPU source local-order holes"
+        );
+    }
+    {
+        SessionBuilder builder;
+        builder.Begin();
+        builder.Schema(Templates::GpuFrame());
+        builder.Schema(Templates::GpuScope());
+        AddGpuFrame(builder, 1, 1, ProfileGpuFrameStatus::Complete, true, 2, 0, 0, "");
+        add_ready_scope(builder, 2, 1, 3, 99, 0, 2, "depth-two-orphan", 10, 20, 2);
+        builder.Loss({
+            .first_sequence = 3,
+            .last_sequence  = 3,
+            .record_count   = 1,
+            .value_bytes    = 8,
+            .reason_mask    = static_cast<std::uint32_t>(LossReason::QueueFull),
+        });
+        builder.End();
+        const Loaded loaded = LoadChunks(builder.bytes);
+        Expect(
+            loaded.result.status == SessionLoadStatus::ProtocolViolation &&
+                loaded.result.error_code == SessionErrorCode::GpuFrameTotalsMismatch,
+            "one missing GPU record explained both a parent and its hidden root"
+        );
+    }
+    {
+        SessionBuilder builder;
+        builder.Begin();
+        builder.Schema(Templates::GpuFrame());
+        builder.Schema(Templates::GpuScope());
+        AddGpuFrame(builder, 1, 1, ProfileGpuFrameStatus::Complete, true, 3, 0, 0, "");
+        add_ready_scope(builder, 2, 1, 3, 99, 0, 2, "budgeted-depth-two-orphan", 10, 20, 2);
+        builder.Loss({
+            .first_sequence = 3,
+            .last_sequence  = 4,
+            .record_count   = 2,
+            .value_bytes    = 16,
+            .reason_mask    = static_cast<std::uint32_t>(LossReason::QueueFull),
+        });
+        builder.End();
+        const Loaded loaded = LoadChunks(builder.bytes);
+        Expect(
+            loaded.result.status == SessionLoadStatus::Complete &&
+                loaded.session.Summary().degraded_complete_gpu_frame_count == 1 &&
+                loaded.session.GpuFrames().front().export_missing_scope_count == 2,
+            "a fully budgeted hidden GPU ancestor chain was rejected"
+        );
+    }
+    {
+        SessionBuilder builder;
+        builder.Begin();
+        builder.Schema(Templates::GpuFrame());
+        builder.Schema(Templates::GpuScope());
+        AddGpuFrame(builder, 1, 1, ProfileGpuFrameStatus::Complete, true, 3, 0, 0, "");
+        add_ready_scope(builder, 2, 1, 1, 0, 0, 0, "observed-root", 0, 100, 0);
+        add_ready_scope(builder, 3, 1, 3, 99, 0, 2, "orphan-with-observed-root", 10, 20, 2);
+        builder.Loss({
+            .first_sequence = 4,
+            .last_sequence  = 4,
+            .record_count   = 1,
+            .value_bytes    = 8,
+            .reason_mask    = static_cast<std::uint32_t>(LossReason::QueueFull),
+        });
+        builder.End();
+        const Loaded loaded = LoadChunks(builder.bytes);
+        Expect(
+            loaded.result.status == SessionLoadStatus::Complete &&
+                loaded.session.Summary().degraded_complete_gpu_frame_count == 1 &&
+                loaded.session.Summary().orphan_gpu_scope_count == 1,
+            "an observed GPU root was not reused by a missing parent chain"
+        );
+    }
+    {
+        SessionBuilder builder;
+        builder.Begin();
+        builder.Schema(Templates::GpuFrame());
+        builder.Schema(Templates::GpuScope());
+        AddGpuFrame(builder, 1, 1, ProfileGpuFrameStatus::Complete, true, 3, 0, 0, "");
+        add_ready_scope(builder, 2, 1, 1, 0, 0, 0, "expired-observed-root", 0, 10, 0);
+        add_ready_scope(builder, 3, 1, 3, 99, 0, 2, "orphan-after-root", 20, 30, 2);
+        builder.Loss({
+            .first_sequence = 4,
+            .last_sequence  = 4,
+            .record_count   = 1,
+            .value_bytes    = 8,
+            .reason_mask    = static_cast<std::uint32_t>(LossReason::QueueFull),
+        });
+        builder.End();
+        const Loaded loaded = LoadChunks(builder.bytes);
+        Expect(
+            loaded.result.status == SessionLoadStatus::ProtocolViolation &&
+                loaded.result.error_code == SessionErrorCode::GpuScopeParentInvalid,
+            "an expired observed GPU root was reused as an orphan subtree ancestor"
+        );
+    }
+    {
+        SessionBuilder builder;
+        builder.Begin();
+        builder.Schema(Templates::GpuFrame());
+        builder.Schema(Templates::GpuScope());
+        AddGpuFrame(builder, 1, 1, ProfileGpuFrameStatus::Incomplete, false, 4, 2, 0, "RHI drops");
+        add_ready_scope(builder, 2, 1, 1, 0, 0, 0, "early-root", 0, 100, 0);
+        add_ready_scope(builder, 3, 1, 2, 1, 0, 4, "late-depth-one", 10, 20, 1);
+        add_ready_scope(builder, 4, 1, 4, 99, 0, 5, "depth-three-orphan", 30, 40, 3);
+        builder.Loss({
+            .first_sequence = 5,
+            .last_sequence  = 5,
+            .record_count   = 1,
+            .value_bytes    = 8,
+            .reason_mask    = static_cast<std::uint32_t>(LossReason::QueueFull),
+        });
+        builder.End();
+        const Loaded loaded = LoadChunks(builder.bytes);
+        Expect(
+            loaded.result.status == SessionLoadStatus::ProtocolViolation &&
+                loaded.result.error_code == SessionErrorCode::GpuFrameTotalsMismatch,
+            "a late observed GPU ancestor was reused before a missing parent's latest slot"
+        );
+    }
+    {
+        SessionBuilder builder;
+        builder.Begin();
+        builder.Schema(Templates::GpuFrame());
+        builder.Schema(Templates::GpuScope());
+        AddGpuFrame(builder, 1, 1, ProfileGpuFrameStatus::Complete, true, 8, 0, 0, "");
+        add_ready_scope(builder, 2, 1, 1, 0, 0, 0, "prefix-root-zero", 0, 1, 0);
+        add_ready_scope(builder, 3, 1, 2, 0, 0, 1, "prefix-root-one", 2, 3, 0);
+        add_ready_scope(builder, 4, 1, 3, 0, 0, 2, "prefix-root-two", 4, 5, 0);
+        add_ready_scope(builder, 5, 1, 4, 0, 0, 3, "prefix-root-three", 6, 7, 0);
+        add_ready_scope(builder, 6, 1, 6, 99, 0, 5, "prefix-depth-three", 8, 9, 3);
+        add_ready_scope(builder, 7, 1, 7, 0, 0, 7, "post-child-hole-root", 10, 11, 0);
+        builder.Loss({
+            .first_sequence = 8,
+            .last_sequence  = 9,
+            .record_count   = 2,
+            .value_bytes    = 16,
+            .reason_mask    = static_cast<std::uint32_t>(LossReason::QueueFull),
+        });
+        builder.End();
+        const Loaded loaded = LoadChunks(builder.bytes);
+        Expect(
+            loaded.result.status == SessionLoadStatus::ProtocolViolation &&
+                loaded.result.error_code == SessionErrorCode::GpuScopeParentInvalid,
+            "a GPU child borrowed hidden-ancestor capacity from a later local-order hole"
+        );
+    }
+    {
+        SessionBuilder builder;
+        builder.Begin();
+        builder.Schema(Templates::GpuFrame());
+        builder.Schema(Templates::GpuScope());
+        AddGpuFrame(builder, 1, 1, ProfileGpuFrameStatus::Complete, true, 6, 0, 0, "");
+        add_ready_scope(builder, 2, 1, 1, 0, 0, 0, "deadline-root-zero", 0, 1, 0);
+        add_ready_scope(builder, 3, 1, 2, 0, 0, 1, "deadline-root-one", 2, 3, 0);
+        add_ready_scope(builder, 4, 1, 4, 99, 0, 3, "early-depth-three", 4, 5, 3);
+        add_ready_scope(builder, 5, 1, 6, 100, 0, 5, "late-depth-two", 6, 7, 2);
+        builder.Loss({
+            .first_sequence = 6,
+            .last_sequence  = 7,
+            .record_count   = 2,
+            .value_bytes    = 16,
+            .reason_mask    = static_cast<std::uint32_t>(LossReason::QueueFull),
+        });
+        builder.End();
+        const Loaded loaded = LoadChunks(builder.bytes);
+        Expect(
+            loaded.result.status == SessionLoadStatus::ProtocolViolation &&
+                loaded.result.error_code == SessionErrorCode::GpuScopeParentInvalid,
+            "a later missing GPU parent was reused before its own scheduling deadline"
+        );
+    }
+    {
+        SessionBuilder builder;
+        builder.Begin();
+        builder.Schema(Templates::GpuFrame());
+        builder.Schema(Templates::GpuScope());
+        AddGpuFrame(builder, 1, 1, ProfileGpuFrameStatus::Complete, true, 7, 0, 0, "");
+        add_ready_scope(builder, 2, 1, 1, 0, 0, 0, "release-root", 0, 200, 0);
+        add_ready_scope(builder, 3, 1, 2, 1, 0, 4, "release-anchor", 10, 100, 1);
+        add_ready_scope(builder, 4, 1, 3, 99, 0, 6, "release-orphan", 20, 30, 4);
+        builder.Loss({
+            .first_sequence = 5,
+            .last_sequence  = 8,
+            .record_count   = 4,
+            .value_bytes    = 32,
+            .reason_mask    = static_cast<std::uint32_t>(LossReason::QueueFull),
+        });
+        builder.End();
+        const Loaded loaded = LoadChunks(builder.bytes);
+        Expect(
+            loaded.result.status == SessionLoadStatus::ProtocolViolation &&
+                loaded.result.error_code == SessionErrorCode::GpuScopeParentInvalid,
+            "GPU ancestry borrowed local-order holes from before its observed anchor"
+        );
+    }
+    {
+        SessionBuilder builder;
+        builder.Begin();
+        builder.Schema(Templates::GpuFrame());
+        builder.Schema(Templates::GpuScope());
+        AddGpuFrame(builder, 1, 1, ProfileGpuFrameStatus::Complete, true, 7, 0, 0, "");
+        add_ready_scope(builder, 2, 1, 1, 0, 0, 0, "barrier-root", 0, 100, 0);
+        add_ready_scope(builder, 3, 1, 3, 101, 0, 3, "barrier-orphan-one", 10, 20, 3);
+        add_ready_scope(builder, 4, 1, 4, 1, 0, 4, "observed-depth-one-barrier", 40, 60, 1);
+        add_ready_scope(builder, 5, 1, 6, 102, 0, 6, "barrier-orphan-two", 80, 90, 3);
+        builder.Loss({
+            .first_sequence = 6,
+            .last_sequence  = 8,
+            .record_count   = 3,
+            .value_bytes    = 24,
+            .reason_mask    = static_cast<std::uint32_t>(LossReason::QueueFull),
+        });
+        builder.End();
+        const Loaded loaded = LoadChunks(builder.bytes);
+        Expect(
+            loaded.result.status == SessionLoadStatus::ProtocolViolation &&
+                loaded.result.error_code == SessionErrorCode::GpuScopeParentInvalid,
+            "GPU hidden ancestors were shared across an observed same-depth timing barrier"
+        );
+    }
+    {
+        SessionBuilder builder;
+        builder.Begin();
+        builder.Schema(Templates::GpuFrame());
+        builder.Schema(Templates::GpuScope());
+        AddGpuFrame(builder, 1, 1, ProfileGpuFrameStatus::Complete, true, 3, 0, 0, "");
+        add_ready_scope(builder, 2, 1, 1, 0, 0, 0, "crossing-before-hole", 0, 100, 0);
+        add_ready_scope(builder, 3, 1, 2, 0, 0, 2, "crossing-after-hole", 50, 150, 0);
+        builder.Loss({
+            .first_sequence = 4,
+            .last_sequence  = 4,
+            .record_count   = 1,
+            .value_bytes    = 8,
+            .reason_mask    = static_cast<std::uint32_t>(LossReason::QueueFull),
+        });
+        builder.End();
+        const Loaded loaded = LoadChunks(builder.bytes);
+        Expect(
+            loaded.result.status == SessionLoadStatus::ProtocolViolation &&
+                loaded.result.error_code == SessionErrorCode::GpuScopeTimingInvalid,
+            "a local-order hole concealed crossing Complete GPU roots"
+        );
+    }
+    {
+        SessionBuilder builder;
+        builder.Begin();
+        builder.Schema(Templates::GpuFrame());
+        builder.Schema(Templates::GpuScope());
+        AddGpuFrame(builder, 1, 1, ProfileGpuFrameStatus::Complete, true, 5, 0, 0, "");
+        add_ready_scope(builder, 2, 1, 1, 0, 0, 0, "replacement-root", 0, 100, 0);
+        add_ready_scope(builder, 3, 1, 3, 200, 0, 3, "child-of-missing-p", 10, 20, 3);
+        add_ready_scope(builder, 4, 1, 4, 100, 0, 4, "child-of-missing-q", 30, 40, 2);
+        builder.Loss({
+            .first_sequence = 5,
+            .last_sequence  = 6,
+            .record_count   = 2,
+            .value_bytes    = 16,
+            .reason_mask    = static_cast<std::uint32_t>(LossReason::QueueFull),
+        });
+        builder.End();
+        const Loaded loaded = LoadChunks(builder.bytes);
+        Expect(
+            loaded.result.status == SessionLoadStatus::Complete &&
+                loaded.session.Summary().orphan_gpu_scope_count == 2 &&
+                loaded.session.GpuFrames().front().export_missing_scope_count == 2,
+            "a later direct missing GPU parent did not replace an earlier anonymous ancestor demand"
+        );
+    }
+    for (const std::uint32_t timing_case : {0u, 1u, 2u}) {
+        SessionBuilder builder;
+        builder.Begin();
+        builder.Schema(Templates::GpuFrame());
+        builder.Schema(Templates::GpuScope());
+        AddGpuFrame(builder, 1, 1, ProfileGpuFrameStatus::Complete, true, 3, 0, 0, "");
+        add_ready_scope(builder, 2, 1, 2, 99, 0, 1, "missing-parent-child-a", 10, 20, 1);
+        const std::uint64_t second_begin = timing_case == 0 ? 20 : timing_case == 1 ? 15 : 5;
+        add_ready_scope(builder, 3, 1, 3, 99, 0, 2, "missing-parent-child-b", second_begin, 30, 1);
+        builder.Loss({
+            .first_sequence = 4,
+            .last_sequence  = 4,
+            .record_count   = 1,
+            .value_bytes    = 8,
+            .reason_mask    = static_cast<std::uint32_t>(LossReason::QueueFull),
+        });
+        builder.End();
+        const Loaded loaded       = LoadChunks(builder.bytes);
+        const bool   valid_timing = timing_case == 0;
+        Expect(
+            valid_timing ? loaded.result.status == SessionLoadStatus::Complete &&
+                               loaded.session.Summary().orphan_gpu_scope_count == 2 :
+                           loaded.result.status == SessionLoadStatus::ProtocolViolation &&
+                               loaded.result.error_code == SessionErrorCode::GpuScopeTimingInvalid,
+            valid_timing ? "adjacent observed children of one missing GPU parent were rejected" :
+                           "overlapping or backward observed children of one missing GPU parent were accepted"
+        );
+    }
+    {
+        SessionBuilder builder;
+        builder.Begin();
+        builder.Schema(Templates::GpuFrame());
+        builder.Schema(Templates::GpuScope());
+        AddGpuFrame(builder, 1, 1, ProfileGpuFrameStatus::Complete, true, 3, 0, 0, "");
+        add_ready_scope_bits(builder, 2, 1, 1, 0, 0, 0, "wide-root", 0, 220, 8, 220.0, 218.0, 0);
+        add_ready_scope_bits(builder, 3, 1, 2, 1, 0, 1, "wide-child-a", 0, 1, 8, 1.0, 1.0, 1);
+        add_ready_scope_bits(builder, 4, 1, 3, 1, 0, 2, "wide-child-b", 200, 201, 8, 1.0, 1.0, 1);
+        builder.End();
+        Expect(
+            LoadChunks(builder.bytes).result.status == SessionLoadStatus::Complete,
+            "internal GPU siblings were incorrectly subjected to the root half-range rule"
+        );
+    }
+    {
+        SessionBuilder builder;
+        builder.Begin();
+        builder.Schema(Templates::GpuFrame());
+        builder.Schema(Templates::GpuScope());
+        AddGpuFrame(builder, 1, 1, ProfileGpuFrameStatus::Complete, true, 3, 0, 0, "");
+        add_ready_scope_bits(builder, 2, 1, 2, 99, 0, 1, "wide-missing-child-a", 0, 1, 8, 1.0, 1.0, 1);
+        add_ready_scope_bits(builder, 3, 1, 3, 99, 0, 2, "wide-missing-child-b", 200, 201, 8, 1.0, 1.0, 1);
+        add_queue_loss(builder, 4, 1);
+        builder.End();
+        Expect(
+            LoadChunks(builder.bytes).result.status == SessionLoadStatus::Complete,
+            "a valid wide envelope under one missing GPU parent was rejected"
+        );
+    }
+    {
+        SessionBuilder builder;
+        builder.Begin();
+        builder.Schema(Templates::GpuFrame());
+        builder.Schema(Templates::GpuScope());
+        AddGpuFrame(builder, 1, 1, ProfileGpuFrameStatus::Complete, true, 5, 0, 0, "");
+        add_ready_scope_bits(builder, 2, 1, 2, 99, 0, 1, "cycle-child-a", 0, 1, 8, 1.0, 1.0, 1);
+        add_ready_scope_bits(builder, 3, 1, 3, 99, 0, 2, "cycle-child-b", 100, 101, 8, 1.0, 1.0, 1);
+        add_ready_scope_bits(builder, 4, 1, 4, 99, 0, 3, "cycle-child-c", 200, 201, 8, 1.0, 1.0, 1);
+        add_ready_scope_bits(builder, 5, 1, 5, 99, 0, 4, "cycle-child-d", 44, 45, 8, 1.0, 1.0, 1);
+        add_queue_loss(builder, 6, 1);
+        builder.End();
+        const Loaded loaded = LoadChunks(builder.bytes);
+        Expect(
+            loaded.result.status == SessionLoadStatus::ProtocolViolation &&
+                loaded.result.error_code == SessionErrorCode::GpuScopeTimingInvalid,
+            "children of one missing GPU parent spanned more than one timestamp cycle"
+        );
+    }
+    {
+        SessionBuilder builder;
+        builder.Begin();
+        builder.Schema(Templates::GpuFrame());
+        builder.Schema(Templates::GpuScope());
+        AddGpuFrame(builder, 1, 1, ProfileGpuFrameStatus::Complete, true, 3, 0, 0, "");
+        add_ready_scope_bits(builder, 2, 1, 2, 99, 0, 1, "wrapped-missing-child-a", 250, 5, 8, 11.0, 11.0, 1);
+        add_ready_scope_bits(builder, 3, 1, 3, 99, 0, 2, "wrapped-missing-child-b", 5, 10, 8, 5.0, 5.0, 1);
+        add_queue_loss(builder, 4, 1);
+        builder.End();
+        Expect(
+            LoadChunks(builder.bytes).result.status == SessionLoadStatus::Complete,
+            "a valid wrapped envelope under one missing GPU parent was rejected"
+        );
+    }
+    {
+        SessionBuilder builder;
+        builder.Begin();
+        builder.Schema(Templates::GpuFrame());
+        builder.Schema(Templates::GpuScope());
+        AddGpuFrame(builder, 1, 1, ProfileGpuFrameStatus::Complete, true, 3, 0, 0, "");
+        add_ready_scope_bits(builder, 2, 1, 1, 0, 0, 0, "bridge-root-a", 0, 1, 8, 1.0, 1.0, 0);
+        add_ready_scope_bits(builder, 3, 1, 2, 0, 0, 2, "bridge-root-b", 255, 0, 8, 1.0, 1.0, 0);
+        add_queue_loss(builder, 4, 1);
+        builder.End();
+        const Loaded loaded = LoadChunks(builder.bytes);
+        Expect(
+            loaded.result.status == SessionLoadStatus::ProtocolViolation &&
+                loaded.result.error_code == SessionErrorCode::GpuScopeTimingInvalid,
+            "one lost root bridged more than two legal half-range timestamp steps"
+        );
+    }
+    {
+        SessionBuilder builder;
+        builder.Begin();
+        builder.Schema(Templates::GpuFrame());
+        builder.Schema(Templates::GpuScope());
+        AddGpuFrame(builder, 1, 1, ProfileGpuFrameStatus::Complete, true, 4, 0, 0, "");
+        add_ready_scope_bits(builder, 2, 1, 1, 0, 0, 0, "three-step-root-a", 0, 100, 8, 100.0, 100.0, 0);
+        add_ready_scope_bits(builder, 3, 1, 2, 0, 0, 3, "three-step-root-b", 50, 60, 8, 10.0, 10.0, 0);
+        add_queue_loss(builder, 4, 2);
+        builder.End();
+        Expect(
+            LoadChunks(builder.bytes).result.status == SessionLoadStatus::Complete,
+            "two lost roots could not bridge a legal three-step timestamp wrap"
+        );
+    }
+    {
+        SessionBuilder builder;
+        builder.Begin();
+        builder.Schema(Templates::GpuFrame());
+        builder.Schema(Templates::GpuScope());
+        AddGpuFrame(builder, 1, 1, ProfileGpuFrameStatus::Complete, true, 4, 0, 0, "");
+        add_ready_scope_bits(builder, 2, 1, 1, 0, 0, 0, "endpoint-root", 0, 100, 64, 100.0, 50.0, 0);
+        add_ready_scope(builder, 3, 1, 2, 1, 0, 1, "endpoint-sibling-a", 0, 50, 1);
+        add_ready_scope(builder, 4, 1, 4, 99, 0, 3, "endpoint-orphan", 50, 50, 2);
+        add_queue_loss(builder, 5, 1);
+        builder.End();
+        Expect(
+            LoadChunks(builder.bytes).result.status == SessionLoadStatus::Complete,
+            "a zero-duration orphan at a completed sibling boundary chose that sibling as its parent"
+        );
+    }
+    {
+        SessionBuilder builder;
+        builder.Begin();
+        builder.Schema(Templates::GpuFrame());
+        builder.Schema(Templates::GpuScope());
+        AddGpuFrame(builder, 1, 1, ProfileGpuFrameStatus::Complete, true, 3, 0, 0, "");
+        add_ready_scope(builder, 2, 1, 1, 0, 0, 0, "endpoint-grandparent", 0, 50, 0);
+        add_ready_scope(builder, 3, 1, 3, 99, 0, 2, "endpoint-grandchild", 50, 50, 2);
+        add_queue_loss(builder, 4, 1);
+        builder.End();
+        Expect(
+            LoadChunks(builder.bytes).result.status == SessionLoadStatus::Complete,
+            "a genuine zero-duration grandchild at its observed ancestor endpoint was rejected"
+        );
+    }
+    {
+        SessionBuilder builder;
+        builder.Begin();
+        builder.Schema(Templates::GpuFrame());
+        builder.Schema(Templates::GpuScope());
+        AddGpuFrame(builder, 1, 1, ProfileGpuFrameStatus::Complete, true, 5, 0, 0, "");
+        add_ready_scope(builder, 2, 1, 1, 0, 0, 0, "contract-barrier-root", 0, 100, 0);
+        add_ready_scope(builder, 3, 1, 3, 99, 0, 2, "contract-child-a", 10, 20, 2);
+        add_ready_scope(builder, 4, 1, 4, 1, 0, 3, "contract-barrier", 30, 40, 1);
+        add_ready_scope(builder, 5, 1, 5, 99, 0, 4, "contract-child-b", 50, 60, 2);
+        add_queue_loss(builder, 6, 1);
+        builder.End();
+        const Loaded loaded = LoadChunks(builder.bytes);
+        Expect(
+            loaded.result.status == SessionLoadStatus::ProtocolViolation &&
+                loaded.result.error_code == SessionErrorCode::GpuScopeParentInvalid,
+            "one missing GPU parent crossed an observed same-depth hierarchy barrier"
+        );
+    }
+    for (const bool leave_sibling_hole : {false, true}) {
+        SessionBuilder builder;
+        builder.Begin();
+        builder.Schema(Templates::GpuFrame());
+        builder.Schema(Templates::GpuScope());
+        AddGpuFrame(builder, 1, 1, ProfileGpuFrameStatus::Complete, true, 5, 0, 0, "");
+        add_ready_scope(builder, 2, 1, 1, 0, 0, 0, "virtual-sibling-root", 0, 100, 0);
+        const std::uint64_t first_child_order  = leave_sibling_hole ? 2 : 3;
+        const std::uint64_t second_child_order = leave_sibling_hole ? 4 : 4;
+        add_ready_scope(builder, 3, 1, 3, 101, 0, first_child_order, "virtual-sibling-child-a", 10, 20, 2);
+        add_ready_scope(builder, 4, 1, 4, 102, 0, second_child_order, "virtual-sibling-child-b", 30, 40, 2);
+        add_queue_loss(builder, 5, 2);
+        builder.End();
+        const Loaded loaded = LoadChunks(builder.bytes);
+        Expect(
+            leave_sibling_hole ? loaded.result.status == SessionLoadStatus::Complete :
+                                 loaded.result.status == SessionLoadStatus::ProtocolViolation &&
+                                     loaded.result.error_code == SessionErrorCode::GpuScopeParentInvalid,
+            leave_sibling_hole ?
+                "distinct missing GPU siblings were rejected despite a hole between their subtrees" :
+                "distinct missing GPU siblings borrowed only pre-subtree holes"
+        );
+    }
+    {
+        SessionBuilder builder;
+        builder.Begin();
+        builder.Schema(Templates::GpuFrame());
+        builder.Schema(Templates::GpuScope());
+        AddGpuFrame(builder, 1, 1, ProfileGpuFrameStatus::Complete, true, 6, 0, 0, "");
+        add_ready_scope_bits(builder, 2, 1, 1, 0, 0, 0, "contract-lca-root", 0, 100, 64, 100.0, 50.0, 0);
+        add_ready_scope(builder, 3, 1, 2, 1, 0, 1, "contract-lca-sibling", 0, 50, 1);
+        add_ready_scope(builder, 4, 1, 4, 99, 0, 4, "contract-lca-zero-child", 50, 50, 3);
+        add_ready_scope(builder, 5, 1, 5, 99, 0, 5, "contract-lca-late-child", 60, 70, 3);
+        add_queue_loss(builder, 6, 2);
+        builder.End();
+        Expect(
+            LoadChunks(builder.bytes).result.status == SessionLoadStatus::Complete,
+            "a missing-parent envelope did not choose its deepest common observed ancestor"
+        );
+    }
+    {
+        SessionBuilder builder;
+        builder.Begin();
+        builder.Schema(Templates::GpuFrame());
+        builder.Schema(Templates::GpuScope());
+        AddGpuFrame(builder, 1, 1, ProfileGpuFrameStatus::Complete, true, 4, 0, 0, "");
+        add_ready_scope_bits(builder, 2, 1, 1, 0, 0, 0, "virtual-chain-root-a", 0, 127, 8, 127.0, 127.0, 0);
+        add_ready_scope_bits(builder, 3, 1, 3, 99, 0, 2, "virtual-chain-child", 200, 210, 8, 10.0, 10.0, 1);
+        add_ready_scope_bits(builder, 4, 1, 4, 0, 0, 3, "virtual-chain-root-b", 100, 110, 8, 10.0, 10.0, 0);
+        add_queue_loss(builder, 5, 1);
+        builder.End();
+        const Loaded loaded = LoadChunks(builder.bytes);
+        Expect(
+            loaded.result.status == SessionLoadStatus::ProtocolViolation &&
+                loaded.result.error_code == SessionErrorCode::GpuScopeTimingInvalid,
+            "a virtual root bypassed the serial root timestamp contract"
+        );
+    }
+    for (const std::uint64_t split_loss_count : {3ull, 4ull}) {
+        SessionBuilder builder;
+        builder.Begin();
+        builder.Schema(Templates::GpuFrame());
+        builder.Schema(Templates::GpuScope());
+        AddGpuFrame(builder, 1, 1, ProfileGpuFrameStatus::Complete, true, 2 + split_loss_count, 0, 0, "");
+        add_ready_scope_bits(builder, 2, 1, 3, 101, 0, 2, "split-root-child-a", 10, 30, 8, 20.0, 20.0, 2);
+        const std::uint64_t second_child_order = split_loss_count == 3 ? 4 : 5;
+        add_ready_scope_bits(
+            builder, 3, 1, 4, 102, 0, second_child_order, "split-root-child-b", 20, 40, 8, 20.0, 20.0, 2
+        );
+        add_queue_loss(builder, 4, split_loss_count);
+        builder.End();
+        const Loaded loaded = LoadChunks(builder.bytes);
+        Expect(
+            split_loss_count == 4 ? loaded.result.status == SessionLoadStatus::Complete :
+                                    loaded.result.status == SessionLoadStatus::ProtocolViolation,
+            split_loss_count == 4 ?
+                "overlapping virtual-root envelopes did not split despite spare ancestry holes" :
+                "overlapping virtual-root envelopes split without enough ancestry holes"
+        );
+    }
+    {
+        SessionBuilder builder;
+        builder.Begin();
+        builder.Schema(Templates::GpuFrame());
+        builder.Schema(Templates::GpuScope());
+        AddGpuFrame(builder, 1, 1, ProfileGpuFrameStatus::Complete, true, 7, 0, 0, "");
+        add_ready_scope_bits(builder, 2, 1, 3, 101, 0, 2, "wide-root-child-a", 10, 20, 8, 10.0, 10.0, 2);
+        add_ready_scope_bits(builder, 3, 1, 4, 102, 0, 5, "wide-root-child-b", 200, 210, 8, 10.0, 10.0, 2);
+        add_ready_scope_bits(builder, 4, 1, 5, 0, 0, 6, "wide-root-successor", 220, 230, 8, 10.0, 10.0, 0);
+        add_queue_loss(builder, 5, 4);
+        builder.End();
+        Expect(
+            LoadChunks(builder.bytes).result.status == SessionLoadStatus::Complete,
+            "a wide virtual envelope was not partitioned before a later observed root"
+        );
+    }
+    {
+        SessionBuilder builder;
+        builder.Begin();
+        builder.Schema(Templates::GpuFrame());
+        builder.Schema(Templates::GpuScope());
+        AddGpuFrame(builder, 1, 1, ProfileGpuFrameStatus::Complete, true, 7, 0, 0, "");
+        add_ready_scope_bits(builder, 2, 1, 3, 101, 0, 2, "partition-child-a", 0, 10, 8, 10.0, 10.0, 2);
+        add_ready_scope_bits(builder, 3, 1, 4, 102, 0, 5, "partition-child-b", 100, 110, 8, 10.0, 10.0, 2);
+        add_ready_scope_bits(builder, 4, 1, 5, 0, 0, 6, "partition-successor", 150, 160, 8, 10.0, 10.0, 0);
+        add_queue_loss(builder, 5, 4);
+        builder.End();
+        const Loaded loaded = LoadChunks(builder.bytes);
+        Expect(
+            loaded.result.status == SessionLoadStatus::Complete &&
+                !loaded.session.GpuFrames().front().materialization_complete &&
+                !loaded.session.GpuFrames().front().timing_topology_trusted,
+            "a timing-driven virtual-root partition with an internal spare hole was rejected or trusted"
+        );
+    }
+    {
+        SessionBuilder builder;
+        builder.Begin();
+        builder.Schema(Templates::GpuFrame());
+        builder.Schema(Templates::GpuScope());
+        AddGpuFrame(builder, 1, 1, ProfileGpuFrameStatus::Complete, true, 9, 0, 0, "");
+        add_ready_scope_bits(
+            builder, 2, 1, 2, 100, 0, 1, "future-shared-child-zero", 0, 10, 8, 10.0, 10.0, 1
+        );
+        add_ready_scope_bits(
+            builder, 3, 1, 3, 201, 0, 5, "future-shared-child-one", 100, 105, 8, 5.0, 5.0, 3
+        );
+        add_ready_scope_bits(
+            builder, 4, 1, 4, 202, 0, 7, "future-shared-child-two", 106, 110, 8, 4.0, 4.0, 3
+        );
+        add_ready_scope_bits(
+            builder, 5, 1, 5, 0, 0, 8, "future-shared-successor", 150, 160, 8, 10.0, 10.0, 0
+        );
+        add_queue_loss(builder, 6, 5);
+        builder.End();
+        const Loaded loaded = LoadChunks(builder.bytes);
+        Expect(
+            loaded.result.status == SessionLoadStatus::Complete &&
+                !loaded.session.GpuFrames().front().materialization_complete &&
+                !loaded.session.GpuFrames().front().timing_topology_trusted,
+            "a future-shared missing suffix inflated an earlier virtual-root partition cost"
+        );
+    }
+    {
+        SessionBuilder builder;
+        builder.Begin();
+        builder.Schema(Templates::GpuFrame());
+        builder.Schema(Templates::GpuScope());
+        AddGpuFrame(builder, 1, 1, ProfileGpuFrameStatus::Complete, true, 9, 0, 0, "");
+        add_ready_scope_bits(builder, 2, 1, 2, 100, 0, 1, "partial-split-child-zero", 0, 0, 8, 0.0, 0.0, 1);
+        add_ready_scope_bits(
+            builder, 3, 1, 3, 201, 0, 4, "partial-split-child-one", 100, 100, 8, 0.0, 0.0, 2
+        );
+        add_ready_scope_bits(
+            builder, 4, 1, 4, 202, 0, 6, "partial-split-child-two", 110, 110, 8, 0.0, 0.0, 2
+        );
+        add_ready_scope_bits(builder, 5, 1, 5, 0, 0, 8, "partial-split-successor", 50, 60, 8, 10.0, 10.0, 0);
+        add_queue_loss(builder, 6, 5);
+        builder.End();
+        const Loaded loaded = LoadChunks(builder.bytes);
+        Expect(
+            loaded.result.status == SessionLoadStatus::Complete &&
+                !loaded.session.GpuFrames().front().materialization_complete &&
+                !loaded.session.GpuFrames().front().timing_topology_trusted,
+            "a later infeasible cut rolled back an earlier valid virtual-root partition"
+        );
+    }
+    {
+        SessionBuilder builder;
+        builder.Begin();
+        builder.Schema(Templates::GpuFrame());
+        builder.Schema(Templates::GpuScope());
+        AddGpuFrame(builder, 1, 1, ProfileGpuFrameStatus::Complete, true, 5, 0, 0, "");
+        add_ready_scope_bits(builder, 2, 1, 1, 0, 0, 0, "occurrence-frontier-root-a", 0, 0, 8, 0.0, 0.0, 0);
+        add_ready_scope_bits(
+            builder, 3, 1, 3, 99, 0, 3, "occurrence-frontier-child", 125, 125, 8, 0.0, 0.0, 1
+        );
+        add_ready_scope_bits(
+            builder, 4, 1, 4, 0, 0, 4, "occurrence-frontier-root-b", 175, 180, 8, 5.0, 5.0, 0
+        );
+        add_queue_loss(builder, 5, 2);
+        builder.End();
+        const Loaded loaded = LoadChunks(builder.bytes);
+        Expect(
+            loaded.result.status == SessionLoadStatus::Complete &&
+                !loaded.session.GpuFrames().front().materialization_complete &&
+                !loaded.session.GpuFrames().front().timing_topology_trusted,
+            "a later flexible-envelope occurrence hid an earlier valid serial timestamp witness"
+        );
+    }
+    {
+        SessionBuilder builder;
+        builder.Begin();
+        builder.Schema(Templates::GpuFrame());
+        builder.Schema(Templates::GpuScope());
+        AddGpuFrame(builder, 1, 1, ProfileGpuFrameStatus::Complete, true, 8, 0, 0, "");
+        add_ready_scope_bits(
+            builder, 2, 1, 1, 0, 0, 0, "partition-soundness-root-a", 0, 127, 8, 127.0, 127.0, 0
+        );
+        add_ready_scope_bits(
+            builder, 3, 1, 3, 101, 0, 3, "partition-soundness-child-a", 255, 255, 8, 0.0, 0.0, 2
+        );
+        add_ready_scope_bits(
+            builder, 4, 1, 4, 102, 0, 6, "partition-soundness-child-b", 255, 255, 8, 0.0, 0.0, 2
+        );
+        add_ready_scope_bits(
+            builder, 5, 1, 5, 0, 0, 7, "partition-soundness-root-b", 150, 160, 8, 10.0, 10.0, 0
+        );
+        add_queue_loss(builder, 6, 4);
+        builder.End();
+        const Loaded loaded = LoadChunks(builder.bytes);
+        Expect(
+            loaded.result.status == SessionLoadStatus::ProtocolViolation &&
+                loaded.result.error_code == SessionErrorCode::GpuScopeTimingInvalid,
+            "a local-order virtual-root split erased its predecessor and successor timestamp constraints"
+        );
+    }
+    {
+        SessionBuilder builder;
+        builder.Begin();
+        builder.Schema(Templates::GpuFrame());
+        builder.Schema(Templates::GpuScope());
+        AddGpuFrame(builder, 1, 1, ProfileGpuFrameStatus::Complete, true, 7, 0, 0, "");
+        add_ready_scope_bits(
+            builder, 2, 1, 3, 101, 0, 3, "blocked-partition-child-a", 0, 10, 8, 10.0, 10.0, 2
+        );
+        add_ready_scope_bits(
+            builder, 3, 1, 4, 102, 0, 5, "blocked-partition-child-b", 100, 110, 8, 10.0, 10.0, 2
+        );
+        add_ready_scope_bits(
+            builder, 4, 1, 5, 0, 0, 6, "blocked-partition-successor", 150, 160, 8, 10.0, 10.0, 0
+        );
+        add_queue_loss(builder, 5, 4);
+        builder.End();
+        const Loaded loaded = LoadChunks(builder.bytes);
+        Expect(
+            loaded.result.status == SessionLoadStatus::ProtocolViolation &&
+                loaded.result.error_code == SessionErrorCode::GpuScopeTimingInvalid,
+            "a virtual-root partition borrowed a spare hole before its first subtree"
+        );
+    }
+    {
+        SessionBuilder builder;
+        builder.Begin();
+        builder.Schema(Templates::GpuFrame());
+        builder.Schema(Templates::GpuScope());
+        AddGpuFrame(builder, 1, 1, ProfileGpuFrameStatus::Complete, true, 4, 0, 0, "");
+        add_ready_scope_bits(
+            builder, 2, 1, 2, 99, 0, 1, "long-atomic-virtual-child", 0, 200, 8, 200.0, 200.0, 1
+        );
+        add_ready_scope_bits(builder, 3, 1, 3, 0, 0, 3, "long-atomic-successor", 210, 220, 8, 10.0, 10.0, 0);
+        add_queue_loss(builder, 4, 2);
+        builder.End();
+        const Loaded loaded = LoadChunks(builder.bytes);
+        Expect(
+            loaded.result.status == SessionLoadStatus::ProtocolViolation &&
+                loaded.result.error_code == SessionErrorCode::GpuScopeTimingInvalid,
+            "a long atomic virtual root borrowed an optional partition before its successor"
+        );
+    }
+    {
+        SessionBuilder builder;
+        builder.Begin();
+        builder.Schema(Templates::GpuFrame());
+        builder.Schema(Templates::GpuScope());
+        AddGpuFrame(builder, 1, 1, ProfileGpuFrameStatus::Complete, true, 5, 0, 0, "");
+        add_ready_scope_bits(builder, 2, 1, 1, 0, 0, 0, "late-root-a", 0, 100, 8, 100.0, 100.0, 0);
+        add_ready_scope_bits(builder, 3, 1, 3, 99, 0, 3, "late-root-child", 250, 0, 8, 6.0, 6.0, 1);
+        add_ready_scope_bits(builder, 4, 1, 4, 0, 0, 4, "late-root-b", 0, 10, 8, 10.0, 10.0, 0);
+        add_queue_loss(builder, 5, 2);
+        builder.End();
+        Expect(
+            LoadChunks(builder.bytes).result.status == SessionLoadStatus::Complete,
+            "a required virtual root was not scheduled after an optional bridge root"
+        );
+    }
+    {
+        SessionBuilder builder;
+        builder.Begin();
+        builder.Schema(Templates::GpuFrame());
+        builder.Schema(Templates::GpuScope());
+        AddGpuFrame(builder, 1, 1, ProfileGpuFrameStatus::Complete, true, 4, 0, 0, "");
+        add_ready_scope_bits(builder, 2, 1, 1, 0, 0, 0, "long-root", 0, 200, 8, 200.0, 200.0, 0);
+        add_ready_scope_bits(builder, 3, 1, 3, 99, 0, 3, "long-root-successor", 210, 220, 8, 10.0, 10.0, 1);
+        add_queue_loss(builder, 4, 2);
+        builder.End();
+        const Loaded loaded = LoadChunks(builder.bytes);
+        Expect(
+            loaded.result.status == SessionLoadStatus::ProtocolViolation &&
+                loaded.result.error_code == SessionErrorCode::GpuScopeTimingInvalid,
+            "a root longer than one legal serial step borrowed a later optional root"
+        );
+    }
+    {
+        SessionBuilder builder;
+        builder.Begin();
+        builder.Schema(Templates::GpuFrame());
+        builder.Schema(Templates::GpuScope());
+        AddGpuFrame(builder, 1, 1, ProfileGpuFrameStatus::Complete, true, 4, 0, 0, "");
+        add_ready_scope_bits(builder, 2, 1, 1, 0, 0, 0, "closed-parent-root", 0, 100, 64, 100.0, 50.0, 0);
+        add_ready_scope_bits(builder, 3, 1, 2, 1, 0, 1, "closed-parent", 0, 30, 64, 30.0, 20.0, 1);
+        add_ready_scope(builder, 4, 1, 3, 1, 0, 2, "closing-sibling", 40, 60, 1);
+        add_ready_scope(builder, 5, 1, 4, 2, 0, 3, "late-closed-child", 10, 20, 2);
+        builder.End();
+        const Loaded loaded = LoadChunks(builder.bytes);
+        Expect(
+            loaded.result.status == SessionLoadStatus::ProtocolViolation &&
+                loaded.result.error_code == SessionErrorCode::GpuScopeParentInvalid,
+            "a child reopened an observed parent after a later sibling closed it"
+        );
+    }
+    {
+        SessionBuilder builder;
+        builder.Begin();
+        builder.Schema(Templates::GpuFrame());
+        builder.Schema(Templates::GpuScope());
+        AddGpuFrame(builder, 1, 1, ProfileGpuFrameStatus::Complete, true, 1, 0, 0, "");
+        add_ready_scope(
+            builder,
+            2,
+            1,
+            1,
+            0,
+            0,
+            std::numeric_limits<std::uint64_t>::max(),
+            "overflow-local-order",
+            10,
+            20,
+            0
+        );
+        builder.End();
+        const Loaded loaded = LoadChunks(builder.bytes);
+        Expect(
+            loaded.result.status == SessionLoadStatus::ProtocolViolation &&
+                loaded.result.error_code == SessionErrorCode::GpuScopeIdentityInvalid,
+            "UINT64_MAX GPU local order overflowed its source span"
         );
     }
 }
@@ -1537,8 +3919,8 @@ void TestLimitsAndStickyFailure() {
         SessionBuilder builder;
         builder.Begin();
         builder.Schema(Templates::CpuScope());
-        AddCpuScope(builder, 1, 1, "parent", 0, 20, 0);
-        AddCpuScope(builder, 2, 1, "child", 5, 10, 1);
+        AddCpuScope(builder, 2, 1, "parent", 0, 20, 0);
+        AddCpuScope(builder, 1, 1, "child", 5, 10, 1);
         builder.End();
 
         SessionLoadOptions options{};
@@ -1622,6 +4004,79 @@ void TestLimitsAndStickyFailure() {
         );
     }
     {
+        SessionBuilder builder;
+        builder.Begin();
+        builder.Schema(Templates::GpuFrame());
+        builder.Schema(Templates::GpuScope());
+        AddGpuFrame(builder, 1, 1, ProfileGpuFrameStatus::Complete, true, 4, 0, 0, "");
+        AddGpuScope(
+            builder,
+            2,
+            1,
+            2,
+            101,
+            0,
+            1,
+            0,
+            0,
+            0,
+            "topology-source-zero-child",
+            ProfileGpuScopeStatus::Ready,
+            10,
+            20,
+            64,
+            1.0,
+            10.0,
+            10.0,
+            1,
+            ""
+        );
+        AddGpuScope(
+            builder,
+            3,
+            1,
+            4,
+            201,
+            1,
+            1,
+            0,
+            0,
+            0,
+            "topology-source-one-child",
+            ProfileGpuScopeStatus::Ready,
+            30,
+            40,
+            64,
+            1.0,
+            10.0,
+            10.0,
+            1,
+            ""
+        );
+        builder.Loss({
+            .first_sequence = 4,
+            .last_sequence  = 5,
+            .record_count   = 2,
+            .value_bytes    = 16,
+            .reason_mask    = static_cast<std::uint32_t>(LossReason::QueueFull),
+        });
+        builder.End();
+
+        SessionLoadOptions options{};
+        options.limits.max_topology_work_items = 2;
+        Expect(
+            LoadChunks(builder.bytes, {}, options).result.status == SessionLoadStatus::Complete,
+            "exact global GPU topology work-item limit was rejected"
+        );
+        options.limits.max_topology_work_items = 1;
+        const Loaded loaded                    = LoadChunks(builder.bytes, {}, options);
+        Expect(
+            loaded.result.status == SessionLoadStatus::LimitExceeded &&
+                loaded.result.limit_kind == SessionLimitKind::TopologyWorkItems,
+            "GPU topology work-item limit was not accumulated across recording sources"
+        );
+    }
+    {
         SessionLoadOptions options{};
         options.limits.max_input_bytes = golden.bytes.size();
         expect_complete(options, "exact input byte limit was rejected");
@@ -1635,6 +4090,51 @@ void TestLimitsAndStickyFailure() {
                 loaded.result.limit_kind == SessionLimitKind::InputBytes,
             "input byte limit was not enforced"
         );
+    }
+    {
+        SessionBuilder builder;
+        builder.Begin();
+
+        Moer::Array<std::uint8_t>       forged_header;
+        const Moer::Array<std::uint8_t> empty_payload;
+        Expect(
+            WrapPacket(
+                PacketType::Schema, builder.next_packet_index, empty_payload, builder.limits, forged_header
+            ) == EncodeStatus::Ok &&
+                forged_header.size() == kPacketHeaderBytes,
+            "could not build the packet-size boundary fixture"
+        );
+        const auto write_u32 = [](Moer::Array<std::uint8_t>& _bytes, std::size_t _offset, std::uint32_t _value
+                               ) {
+            for (std::size_t byte = 0; byte < sizeof(_value); ++byte) {
+                _bytes[_offset + byte] = static_cast<std::uint8_t>(_value >> (byte * 8));
+            }
+        };
+        write_u32(forged_header, 12, std::numeric_limits<std::uint32_t>::max());
+        const auto header_prefix = std::span<const std::uint8_t>(forged_header).first(28);
+        write_u32(forged_header, 28, crc32_fast(header_prefix.data(), header_prefix.size()));
+        builder.bytes.insert(builder.bytes.end(), forged_header.begin(), forged_header.end());
+
+        SessionLoadOptions options{};
+        options.limits.codec.max_packet_payload_bytes = std::numeric_limits<std::uint32_t>::max();
+        options.limits.max_input_bytes                = builder.bytes.size();
+        const Loaded loaded                           = LoadChunks(builder.bytes, {}, options);
+        Expect(
+            loaded.result.status == SessionLoadStatus::LimitExceeded,
+            "an unaddressable or input-impossible packet wire size was not rejected before reserve"
+        );
+        if constexpr (sizeof(std::size_t) == sizeof(std::uint32_t)) {
+            Expect(
+                loaded.result.limit_kind == SessionLimitKind::Codec &&
+                    loaded.result.codec_status == DecodeStatus::PayloadTooLarge,
+                "32-bit packet-size overflow did not use the stable codec limit contract"
+            );
+        } else {
+            Expect(
+                loaded.result.limit_kind == SessionLimitKind::InputBytes,
+                "declared packet size bypassed the configured input byte limit"
+            );
+        }
     }
     {
         SessionLoadOptions options{};

--- a/source/test/ProfileDumpConsumerTest.cpp
+++ b/source/test/ProfileDumpConsumerTest.cpp
@@ -4910,6 +4910,44 @@ void TestGpuProducerSequenceProofs() {
         builder.Begin();
         builder.Schema(Templates::CpuScope());
         builder.Schema(Templates::GpuFrame());
+        AddCpuScope(builder, 1, 77, "cpu-only-over-budget-child", 10, 20, 3);
+        AddCpuScope(builder, 5, 77, "cpu-only-over-budget-ancestor", 0, 30, 0);
+        AddGpuFrame(builder, 6, 1, ProfileGpuFrameStatus::Complete, true, 0, 0, 0, "");
+        add_loss(builder, 2, 2, 1);
+        builder.End();
+        expect_rejected(
+            LoadChunks(builder.bytes),
+            SessionErrorCode::CpuScopeParentMissing,
+            "zero-demand GPU data changed a CPU-only over-budget diagnostic",
+            "CPU hierarchy deficits exceed the noticed allocated-record loss budget"
+        );
+    }
+
+    {
+        SessionBuilder builder;
+        builder.Begin();
+        builder.Schema(Templates::CpuScope());
+        builder.Schema(Templates::GpuFrame());
+        builder.Schema(Templates::GpuScope());
+        AddCpuScope(builder, 1, 77, "mixed-over-budget-cpu-child", 10, 20, 3);
+        AddGpuFrame(builder, 2, 1, ProfileGpuFrameStatus::Incomplete, false, 2, 0, 0, "");
+        add_scope(builder, 4, 1, 2, 99, 0, 1, 1, "mixed-over-budget-gpu-child");
+        AddCpuScope(builder, 6, 77, "mixed-over-budget-cpu-ancestor", 0, 30, 0);
+        add_loss(builder, 3, 3, 1);
+        builder.End();
+        expect_rejected(
+            LoadChunks(builder.bytes),
+            SessionErrorCode::RecordSequenceInvalid,
+            "a CPU deficit already over budget hid a simultaneous nontrusted GPU deficit",
+            "CPU/GPU deficits exceed the noticed allocated-record loss budget"
+        );
+    }
+
+    {
+        SessionBuilder builder;
+        builder.Begin();
+        builder.Schema(Templates::CpuScope());
+        builder.Schema(Templates::GpuFrame());
         builder.Schema(Templates::GpuScope());
         AddCpuScope(builder, 1, 77, "mixed-virtual-cpu-child", 10, 20, 2);
         AddGpuFrame(builder, 2, 1, ProfileGpuFrameStatus::Incomplete, false, 2, 0, 0, "");
@@ -4922,6 +4960,46 @@ void TestGpuProducerSequenceProofs() {
             SessionErrorCode::RecordSequenceInvalid,
             "an insufficient mixed CPU/nontrusted-GPU Loss total was classified as a GPU-only failure",
             "CPU/GPU deficits exceed the noticed allocated-record loss budget"
+        );
+    }
+
+    {
+        SessionBuilder builder;
+        builder.Begin();
+        builder.Schema(Templates::CpuScope());
+        builder.Schema(Templates::GpuFrame());
+        builder.Schema(Templates::GpuScope());
+        AddCpuScope(builder, 1, 77, "mixed-slot-cpu-child", 10, 20, 2);
+        AddCpuScope(builder, 2, 88, "mixed-slot-occupied-record", 40, 50, 0);
+        AddCpuScope(builder, 3, 77, "mixed-slot-cpu-ancestor", 0, 30, 0);
+        AddGpuFrame(builder, 4, 1, ProfileGpuFrameStatus::Incomplete, false, 2, 0, 0, "");
+        add_scope(builder, 6, 1, 2, 99, 0, 1, 1, "mixed-slot-gpu-child");
+        add_loss(builder, 5, 7, 2);
+        builder.End();
+        expect_rejected(
+            LoadChunks(builder.bytes),
+            SessionErrorCode::RecordSequenceInvalid,
+            "a CPU sequence-slot failure ignored a simultaneous nontrusted GPU topology demand",
+            "missing CPU/GPU topology records cannot occupy distinct record-sequence holes"
+        );
+    }
+
+    {
+        SessionBuilder builder;
+        builder.Begin();
+        builder.Schema(Templates::CpuScope());
+        builder.Schema(Templates::GpuFrame());
+        AddCpuScope(builder, 1, 77, "cpu-only-slot-child", 10, 20, 2);
+        AddCpuScope(builder, 2, 88, "cpu-only-slot-occupied-record", 40, 50, 0);
+        AddCpuScope(builder, 3, 77, "cpu-only-slot-ancestor", 0, 30, 0);
+        AddGpuFrame(builder, 4, 1, ProfileGpuFrameStatus::Complete, true, 0, 0, 0, "");
+        add_loss(builder, 5, 5, 1);
+        builder.End();
+        expect_rejected(
+            LoadChunks(builder.bytes),
+            SessionErrorCode::CpuScopeTopologyInvalid,
+            "GPU records without a GPU topology demand changed a CPU-only sequence-slot failure",
+            "missing CPU/GPU topology records cannot occupy distinct record-sequence holes"
         );
     }
 

--- a/source/test/ProfileDumpConsumerTest.cpp
+++ b/source/test/ProfileDumpConsumerTest.cpp
@@ -351,6 +351,45 @@ std::uint64_t MinimumPassingTopologyBudget(std::span<const std::uint8_t> _bytes)
     return lower;
 }
 
+std::uint64_t
+MinimumPassingTopologyFlowEdges(std::span<const std::uint8_t> _bytes, SessionLoadOptions _base_options = {}) {
+    const auto completes_with_limit = [&](std::uint64_t _limit) {
+        SessionLoadOptions options             = _base_options;
+        options.limits.max_topology_flow_edges = _limit;
+        const Loaded loaded                    = LoadChunks(_bytes, {}, options);
+        if (loaded.result.HasUsableSession()) {
+            return true;
+        }
+        Expect(
+            loaded.result.status == SessionLoadStatus::LimitExceeded &&
+                loaded.result.limit_kind == SessionLimitKind::TopologyFlowEdges &&
+                !loaded.result.HasUsableSession() && !loaded.session.Valid(),
+            "topology flow-edge search observed a non-edge failure or a partially published session"
+        );
+        return false;
+    };
+
+    std::uint64_t lower = 0;
+    std::uint64_t upper = 1;
+    while (!completes_with_limit(upper)) {
+        Expect(
+            upper <= std::numeric_limits<std::uint64_t>::max() / 2,
+            "topology flow-edge search exceeded the uint64 range"
+        );
+        lower = upper + 1;
+        upper *= 2;
+    }
+    while (lower < upper) {
+        const std::uint64_t middle = lower + (upper - lower) / 2;
+        if (completes_with_limit(middle)) {
+            upper = middle;
+        } else {
+            lower = middle + 1;
+        }
+    }
+    return lower;
+}
+
 SessionBuilder MakeGoldenSession() {
     SessionBuilder         builder;
     const SchemaDescriptor unknown = UnknownSchema();
@@ -360,17 +399,18 @@ SessionBuilder MakeGoldenSession() {
     builder.Schema(Templates::GpuScope());
     builder.Schema(unknown);
 
-    // Record sequence and packet order are deliberately unrelated. CPU child
-    // and GPU child also precede their parents in the file.
+    // Record sequence and packet order are deliberately unrelated. CPU scope
+    // sequence is not a hierarchy key, while GPU sequences still preserve the
+    // producer's frame-first/pre-order emission contract.
     AddCpuScope(builder, 4, 11, "cpu-child", 120, 150, 1);
     AddCpuScope(builder, 7, 11, "cpu-parent", 100, 300, 0);
     AddCpuScope(builder, 2, 22, "cpu-other", 50, 60, 0);
 
     AddGpuFrame(builder, 10, 100, ProfileGpuFrameStatus::Complete, true, 4, 0, 0, "");
-    AddGpuFrame(builder, 12, 101, ProfileGpuFrameStatus::Invalid, false, 1, 0, 1, "query failed");
+    AddGpuFrame(builder, 15, 101, ProfileGpuFrameStatus::Invalid, false, 1, 0, 1, "query failed");
     AddGpuScope(
         builder,
-        8,
+        12,
         100,
         2,
         1,
@@ -392,7 +432,7 @@ SessionBuilder MakeGoldenSession() {
     );
     AddGpuScope(
         builder,
-        13,
+        11,
         100,
         1,
         0,
@@ -414,7 +454,7 @@ SessionBuilder MakeGoldenSession() {
     );
     AddGpuScope(
         builder,
-        11,
+        14,
         100,
         3,
         0,
@@ -436,7 +476,7 @@ SessionBuilder MakeGoldenSession() {
     );
     AddGpuScope(
         builder,
-        6,
+        13,
         100,
         4,
         0,
@@ -458,7 +498,7 @@ SessionBuilder MakeGoldenSession() {
     );
     AddGpuScope(
         builder,
-        5,
+        16,
         101,
         1,
         0,
@@ -510,7 +550,13 @@ const GpuScopeRecord& FindGpuScope(const ProfileSession& _session, std::string_v
 }
 
 void VerifyGolden(const Loaded& _loaded) {
-    Expect(_loaded.result.status == SessionLoadStatus::Complete, "golden session did not complete");
+    Expect(
+        _loaded.result.status == SessionLoadStatus::Complete,
+        "golden session did not complete (status=" +
+            std::to_string(static_cast<unsigned>(_loaded.result.status)) +
+            ", error=" + std::to_string(static_cast<unsigned>(_loaded.result.error_code)) +
+            ", diagnostic=" + _loaded.diagnostic + ")"
+    );
     Expect(_loaded.session.Valid(), "golden session model is invalid");
     const ProfileSessionSummary& summary = _loaded.session.Summary();
     Expect(summary.generation == 7, "session generation is wrong");
@@ -1071,7 +1117,7 @@ void TestChecksumAndForensicTruncation() {
         AddGpuFrame(builder, 1, 3, ProfileGpuFrameStatus::Complete, true, 2, 0, 0, "");
         AddGpuScope(
             builder,
-            2,
+            3,
             3,
             2,
             1,
@@ -1512,7 +1558,7 @@ void TestSemanticTopologyAndLossRecovery() {
         const Loaded loaded = LoadChunks(builder.bytes);
         Expect(
             loaded.result.status == SessionLoadStatus::ProtocolViolation &&
-                loaded.result.error_code == SessionErrorCode::GpuFrameTotalsMismatch,
+                loaded.result.error_code == SessionErrorCode::RecordSequenceInvalid,
             "one ProfileDump loss was reused by CPU and GPU topology deficits"
         );
     }
@@ -1547,7 +1593,7 @@ void TestSemanticTopologyAndLossRecovery() {
         AddGpuFrame(builder, 1, 1, ProfileGpuFrameStatus::Complete, true, 1, 0, 0, "");
         AddGpuScope(
             builder,
-            2,
+            3,
             1,
             2,
             99,
@@ -1582,7 +1628,7 @@ void TestSemanticTopologyAndLossRecovery() {
         AddGpuFrame(builder, 1, 1, ProfileGpuFrameStatus::Complete, true, 2, 0, 0, "");
         AddGpuScope(
             builder,
-            2,
+            3,
             1,
             2,
             99,
@@ -1603,8 +1649,8 @@ void TestSemanticTopologyAndLossRecovery() {
             ""
         );
         builder.Loss({
-            .first_sequence = 3,
-            .last_sequence  = 3,
+            .first_sequence = 2,
+            .last_sequence  = 2,
             .record_count   = 1,
             .value_bytes    = 8,
             .reason_mask    = static_cast<std::uint32_t>(LossReason::QueueFull),
@@ -1622,10 +1668,10 @@ void TestSemanticTopologyAndLossRecovery() {
         builder.Begin();
         builder.Schema(Templates::GpuFrame());
         builder.Schema(Templates::GpuScope());
-        AddGpuFrame(builder, 1, 1, ProfileGpuFrameStatus::Complete, true, 3, 0, 0, "");
+        AddGpuFrame(builder, 1, 1, ProfileGpuFrameStatus::Complete, true, 4, 0, 0, "");
         AddGpuScope(
             builder,
-            2,
+            3,
             1,
             2,
             99,
@@ -1647,7 +1693,7 @@ void TestSemanticTopologyAndLossRecovery() {
         );
         AddGpuScope(
             builder,
-            3,
+            5,
             1,
             3,
             99,
@@ -1668,10 +1714,10 @@ void TestSemanticTopologyAndLossRecovery() {
             ""
         );
         builder.Loss({
-            .first_sequence = 4,
+            .first_sequence = 2,
             .last_sequence  = 4,
-            .record_count   = 1,
-            .value_bytes    = 8,
+            .record_count   = 2,
+            .value_bytes    = 16,
             .reason_mask    = static_cast<std::uint32_t>(LossReason::QueueFull),
         });
         builder.End();
@@ -1679,7 +1725,10 @@ void TestSemanticTopologyAndLossRecovery() {
         Expect(
             loaded.result.status == SessionLoadStatus::ProtocolViolation &&
                 loaded.result.error_code == SessionErrorCode::GpuScopeParentInvalid,
-            "one missing GPU parent was allowed to have incompatible child contracts"
+            "one missing GPU parent was allowed to have incompatible child contracts (status=" +
+                std::to_string(static_cast<unsigned>(loaded.result.status)) +
+                ", error=" + std::to_string(static_cast<unsigned>(loaded.result.error_code)) +
+                ", diagnostic=" + loaded.diagnostic + ")"
         );
     }
     {
@@ -1733,7 +1782,7 @@ void TestSemanticTopologyAndLossRecovery() {
         AddGpuFrame(builder, 1, 1, ProfileGpuFrameStatus::Complete, true, 4, 0, 0, "");
         AddGpuScope(
             builder,
-            2,
+            3,
             1,
             3,
             98,
@@ -1755,7 +1804,7 @@ void TestSemanticTopologyAndLossRecovery() {
         );
         AddGpuScope(
             builder,
-            3,
+            4,
             1,
             4,
             99,
@@ -1776,7 +1825,7 @@ void TestSemanticTopologyAndLossRecovery() {
             ""
         );
         builder.Loss({
-            .first_sequence = 4,
+            .first_sequence = 2,
             .last_sequence  = 5,
             .record_count   = 2,
             .value_bytes    = 16,
@@ -2583,7 +2632,7 @@ void TestSemanticTopologyAndLossRecovery() {
         );
         AddGpuScope(
             builder,
-            3,
+            4,
             1,
             3,
             0,
@@ -2604,8 +2653,8 @@ void TestSemanticTopologyAndLossRecovery() {
             ""
         );
         builder.Loss({
-            .first_sequence = 4,
-            .last_sequence  = 4,
+            .first_sequence = 3,
+            .last_sequence  = 3,
             .record_count   = 1,
             .value_bytes    = 8,
             .reason_mask    = static_cast<std::uint32_t>(LossReason::QueueFull),
@@ -3142,11 +3191,11 @@ void TestSemanticTopologyAndLossRecovery() {
         builder.Schema(Templates::GpuFrame());
         builder.Schema(Templates::GpuScope());
         AddGpuFrame(builder, 1, 1, ProfileGpuFrameStatus::Complete, true, 3, 0, 0, "");
-        add_ready_scope(builder, 2, 1, 1, 0, 0, 1, "source-zero-root", 10, 20, 0);
-        add_ready_scope(builder, 3, 1, 2, 0, 1, 1, "source-one-root", 30, 40, 0);
+        add_ready_scope(builder, 3, 1, 1, 0, 0, 1, "source-zero-root", 10, 20, 0);
+        add_ready_scope(builder, 5, 1, 2, 0, 1, 1, "source-one-root", 30, 40, 0);
         builder.Loss({
-            .first_sequence = 4,
-            .last_sequence  = 4,
+            .first_sequence = 2,
+            .last_sequence  = 2,
             .record_count   = 1,
             .value_bytes    = 8,
             .reason_mask    = static_cast<std::uint32_t>(LossReason::QueueFull),
@@ -3165,10 +3214,10 @@ void TestSemanticTopologyAndLossRecovery() {
         builder.Schema(Templates::GpuFrame());
         builder.Schema(Templates::GpuScope());
         AddGpuFrame(builder, 1, 1, ProfileGpuFrameStatus::Complete, true, 2, 0, 0, "");
-        add_ready_scope(builder, 2, 1, 3, 99, 0, 2, "depth-two-orphan", 10, 20, 2);
+        add_ready_scope(builder, 4, 1, 3, 99, 0, 2, "depth-two-orphan", 10, 20, 2);
         builder.Loss({
-            .first_sequence = 3,
-            .last_sequence  = 3,
+            .first_sequence = 2,
+            .last_sequence  = 2,
             .record_count   = 1,
             .value_bytes    = 8,
             .reason_mask    = static_cast<std::uint32_t>(LossReason::QueueFull),
@@ -3187,10 +3236,10 @@ void TestSemanticTopologyAndLossRecovery() {
         builder.Schema(Templates::GpuFrame());
         builder.Schema(Templates::GpuScope());
         AddGpuFrame(builder, 1, 1, ProfileGpuFrameStatus::Complete, true, 3, 0, 0, "");
-        add_ready_scope(builder, 2, 1, 3, 99, 0, 2, "budgeted-depth-two-orphan", 10, 20, 2);
+        add_ready_scope(builder, 4, 1, 3, 99, 0, 2, "budgeted-depth-two-orphan", 10, 20, 2);
         builder.Loss({
-            .first_sequence = 3,
-            .last_sequence  = 4,
+            .first_sequence = 2,
+            .last_sequence  = 3,
             .record_count   = 2,
             .value_bytes    = 16,
             .reason_mask    = static_cast<std::uint32_t>(LossReason::QueueFull),
@@ -3211,10 +3260,10 @@ void TestSemanticTopologyAndLossRecovery() {
         builder.Schema(Templates::GpuScope());
         AddGpuFrame(builder, 1, 1, ProfileGpuFrameStatus::Complete, true, 3, 0, 0, "");
         add_ready_scope(builder, 2, 1, 1, 0, 0, 0, "observed-root", 0, 100, 0);
-        add_ready_scope(builder, 3, 1, 3, 99, 0, 2, "orphan-with-observed-root", 10, 20, 2);
+        add_ready_scope(builder, 4, 1, 3, 99, 0, 2, "orphan-with-observed-root", 10, 20, 2);
         builder.Loss({
-            .first_sequence = 4,
-            .last_sequence  = 4,
+            .first_sequence = 3,
+            .last_sequence  = 3,
             .record_count   = 1,
             .value_bytes    = 8,
             .reason_mask    = static_cast<std::uint32_t>(LossReason::QueueFull),
@@ -3235,10 +3284,10 @@ void TestSemanticTopologyAndLossRecovery() {
         builder.Schema(Templates::GpuScope());
         AddGpuFrame(builder, 1, 1, ProfileGpuFrameStatus::Complete, true, 3, 0, 0, "");
         add_ready_scope(builder, 2, 1, 1, 0, 0, 0, "expired-observed-root", 0, 10, 0);
-        add_ready_scope(builder, 3, 1, 3, 99, 0, 2, "orphan-after-root", 20, 30, 2);
+        add_ready_scope(builder, 4, 1, 3, 99, 0, 2, "orphan-after-root", 20, 30, 2);
         builder.Loss({
-            .first_sequence = 4,
-            .last_sequence  = 4,
+            .first_sequence = 3,
+            .last_sequence  = 3,
             .record_count   = 1,
             .value_bytes    = 8,
             .reason_mask    = static_cast<std::uint32_t>(LossReason::QueueFull),
@@ -3285,11 +3334,11 @@ void TestSemanticTopologyAndLossRecovery() {
         add_ready_scope(builder, 3, 1, 2, 0, 0, 1, "prefix-root-one", 2, 3, 0);
         add_ready_scope(builder, 4, 1, 3, 0, 0, 2, "prefix-root-two", 4, 5, 0);
         add_ready_scope(builder, 5, 1, 4, 0, 0, 3, "prefix-root-three", 6, 7, 0);
-        add_ready_scope(builder, 6, 1, 6, 99, 0, 5, "prefix-depth-three", 8, 9, 3);
-        add_ready_scope(builder, 7, 1, 7, 0, 0, 7, "post-child-hole-root", 10, 11, 0);
+        add_ready_scope(builder, 7, 1, 6, 99, 0, 5, "prefix-depth-three", 8, 9, 3);
+        add_ready_scope(builder, 9, 1, 7, 0, 0, 7, "post-child-hole-root", 10, 11, 0);
         builder.Loss({
-            .first_sequence = 8,
-            .last_sequence  = 9,
+            .first_sequence = 6,
+            .last_sequence  = 8,
             .record_count   = 2,
             .value_bytes    = 16,
             .reason_mask    = static_cast<std::uint32_t>(LossReason::QueueFull),
@@ -3310,11 +3359,11 @@ void TestSemanticTopologyAndLossRecovery() {
         AddGpuFrame(builder, 1, 1, ProfileGpuFrameStatus::Complete, true, 6, 0, 0, "");
         add_ready_scope(builder, 2, 1, 1, 0, 0, 0, "deadline-root-zero", 0, 1, 0);
         add_ready_scope(builder, 3, 1, 2, 0, 0, 1, "deadline-root-one", 2, 3, 0);
-        add_ready_scope(builder, 4, 1, 4, 99, 0, 3, "early-depth-three", 4, 5, 3);
-        add_ready_scope(builder, 5, 1, 6, 100, 0, 5, "late-depth-two", 6, 7, 2);
+        add_ready_scope(builder, 5, 1, 4, 99, 0, 3, "early-depth-three", 4, 5, 3);
+        add_ready_scope(builder, 7, 1, 6, 100, 0, 5, "late-depth-two", 6, 7, 2);
         builder.Loss({
-            .first_sequence = 6,
-            .last_sequence  = 7,
+            .first_sequence = 4,
+            .last_sequence  = 6,
             .record_count   = 2,
             .value_bytes    = 16,
             .reason_mask    = static_cast<std::uint32_t>(LossReason::QueueFull),
@@ -3334,11 +3383,11 @@ void TestSemanticTopologyAndLossRecovery() {
         builder.Schema(Templates::GpuScope());
         AddGpuFrame(builder, 1, 1, ProfileGpuFrameStatus::Complete, true, 7, 0, 0, "");
         add_ready_scope(builder, 2, 1, 1, 0, 0, 0, "release-root", 0, 200, 0);
-        add_ready_scope(builder, 3, 1, 2, 1, 0, 4, "release-anchor", 10, 100, 1);
-        add_ready_scope(builder, 4, 1, 3, 99, 0, 6, "release-orphan", 20, 30, 4);
+        add_ready_scope(builder, 6, 1, 2, 1, 0, 4, "release-anchor", 10, 100, 1);
+        add_ready_scope(builder, 8, 1, 3, 99, 0, 6, "release-orphan", 20, 30, 4);
         builder.Loss({
-            .first_sequence = 5,
-            .last_sequence  = 8,
+            .first_sequence = 3,
+            .last_sequence  = 7,
             .record_count   = 4,
             .value_bytes    = 32,
             .reason_mask    = static_cast<std::uint32_t>(LossReason::QueueFull),
@@ -3358,12 +3407,12 @@ void TestSemanticTopologyAndLossRecovery() {
         builder.Schema(Templates::GpuScope());
         AddGpuFrame(builder, 1, 1, ProfileGpuFrameStatus::Complete, true, 7, 0, 0, "");
         add_ready_scope(builder, 2, 1, 1, 0, 0, 0, "barrier-root", 0, 100, 0);
-        add_ready_scope(builder, 3, 1, 3, 101, 0, 3, "barrier-orphan-one", 10, 20, 3);
-        add_ready_scope(builder, 4, 1, 4, 1, 0, 4, "observed-depth-one-barrier", 40, 60, 1);
-        add_ready_scope(builder, 5, 1, 6, 102, 0, 6, "barrier-orphan-two", 80, 90, 3);
+        add_ready_scope(builder, 5, 1, 3, 101, 0, 3, "barrier-orphan-one", 10, 20, 3);
+        add_ready_scope(builder, 6, 1, 4, 1, 0, 4, "observed-depth-one-barrier", 40, 60, 1);
+        add_ready_scope(builder, 8, 1, 6, 102, 0, 6, "barrier-orphan-two", 80, 90, 3);
         builder.Loss({
-            .first_sequence = 6,
-            .last_sequence  = 8,
+            .first_sequence = 3,
+            .last_sequence  = 7,
             .record_count   = 3,
             .value_bytes    = 24,
             .reason_mask    = static_cast<std::uint32_t>(LossReason::QueueFull),
@@ -3383,10 +3432,10 @@ void TestSemanticTopologyAndLossRecovery() {
         builder.Schema(Templates::GpuScope());
         AddGpuFrame(builder, 1, 1, ProfileGpuFrameStatus::Complete, true, 3, 0, 0, "");
         add_ready_scope(builder, 2, 1, 1, 0, 0, 0, "crossing-before-hole", 0, 100, 0);
-        add_ready_scope(builder, 3, 1, 2, 0, 0, 2, "crossing-after-hole", 50, 150, 0);
+        add_ready_scope(builder, 4, 1, 2, 0, 0, 2, "crossing-after-hole", 50, 150, 0);
         builder.Loss({
-            .first_sequence = 4,
-            .last_sequence  = 4,
+            .first_sequence = 3,
+            .last_sequence  = 3,
             .record_count   = 1,
             .value_bytes    = 8,
             .reason_mask    = static_cast<std::uint32_t>(LossReason::QueueFull),
@@ -3406,11 +3455,11 @@ void TestSemanticTopologyAndLossRecovery() {
         builder.Schema(Templates::GpuScope());
         AddGpuFrame(builder, 1, 1, ProfileGpuFrameStatus::Complete, true, 5, 0, 0, "");
         add_ready_scope(builder, 2, 1, 1, 0, 0, 0, "replacement-root", 0, 100, 0);
-        add_ready_scope(builder, 3, 1, 3, 200, 0, 3, "child-of-missing-p", 10, 20, 3);
-        add_ready_scope(builder, 4, 1, 4, 100, 0, 4, "child-of-missing-q", 30, 40, 2);
+        add_ready_scope(builder, 5, 1, 3, 200, 0, 3, "child-of-missing-p", 10, 20, 3);
+        add_ready_scope(builder, 6, 1, 4, 100, 0, 4, "child-of-missing-q", 30, 40, 2);
         builder.Loss({
-            .first_sequence = 5,
-            .last_sequence  = 6,
+            .first_sequence = 3,
+            .last_sequence  = 4,
             .record_count   = 2,
             .value_bytes    = 16,
             .reason_mask    = static_cast<std::uint32_t>(LossReason::QueueFull),
@@ -3430,12 +3479,12 @@ void TestSemanticTopologyAndLossRecovery() {
         builder.Schema(Templates::GpuFrame());
         builder.Schema(Templates::GpuScope());
         AddGpuFrame(builder, 1, 1, ProfileGpuFrameStatus::Complete, true, 3, 0, 0, "");
-        add_ready_scope(builder, 2, 1, 2, 99, 0, 1, "missing-parent-child-a", 10, 20, 1);
+        add_ready_scope(builder, 3, 1, 2, 99, 0, 1, "missing-parent-child-a", 10, 20, 1);
         const std::uint64_t second_begin = timing_case == 0 ? 20 : timing_case == 1 ? 15 : 5;
-        add_ready_scope(builder, 3, 1, 3, 99, 0, 2, "missing-parent-child-b", second_begin, 30, 1);
+        add_ready_scope(builder, 4, 1, 3, 99, 0, 2, "missing-parent-child-b", second_begin, 30, 1);
         builder.Loss({
-            .first_sequence = 4,
-            .last_sequence  = 4,
+            .first_sequence = 2,
+            .last_sequence  = 2,
             .record_count   = 1,
             .value_bytes    = 8,
             .reason_mask    = static_cast<std::uint32_t>(LossReason::QueueFull),
@@ -3473,9 +3522,9 @@ void TestSemanticTopologyAndLossRecovery() {
         builder.Schema(Templates::GpuFrame());
         builder.Schema(Templates::GpuScope());
         AddGpuFrame(builder, 1, 1, ProfileGpuFrameStatus::Complete, true, 3, 0, 0, "");
-        add_ready_scope_bits(builder, 2, 1, 2, 99, 0, 1, "wide-missing-child-a", 0, 1, 8, 1.0, 1.0, 1);
-        add_ready_scope_bits(builder, 3, 1, 3, 99, 0, 2, "wide-missing-child-b", 200, 201, 8, 1.0, 1.0, 1);
-        add_queue_loss(builder, 4, 1);
+        add_ready_scope_bits(builder, 3, 1, 2, 99, 0, 1, "wide-missing-child-a", 0, 1, 8, 1.0, 1.0, 1);
+        add_ready_scope_bits(builder, 4, 1, 3, 99, 0, 2, "wide-missing-child-b", 200, 201, 8, 1.0, 1.0, 1);
+        add_queue_loss(builder, 2, 1);
         builder.End();
         Expect(
             LoadChunks(builder.bytes).result.status == SessionLoadStatus::Complete,
@@ -3488,11 +3537,11 @@ void TestSemanticTopologyAndLossRecovery() {
         builder.Schema(Templates::GpuFrame());
         builder.Schema(Templates::GpuScope());
         AddGpuFrame(builder, 1, 1, ProfileGpuFrameStatus::Complete, true, 5, 0, 0, "");
-        add_ready_scope_bits(builder, 2, 1, 2, 99, 0, 1, "cycle-child-a", 0, 1, 8, 1.0, 1.0, 1);
-        add_ready_scope_bits(builder, 3, 1, 3, 99, 0, 2, "cycle-child-b", 100, 101, 8, 1.0, 1.0, 1);
-        add_ready_scope_bits(builder, 4, 1, 4, 99, 0, 3, "cycle-child-c", 200, 201, 8, 1.0, 1.0, 1);
-        add_ready_scope_bits(builder, 5, 1, 5, 99, 0, 4, "cycle-child-d", 44, 45, 8, 1.0, 1.0, 1);
-        add_queue_loss(builder, 6, 1);
+        add_ready_scope_bits(builder, 3, 1, 2, 99, 0, 1, "cycle-child-a", 0, 1, 8, 1.0, 1.0, 1);
+        add_ready_scope_bits(builder, 4, 1, 3, 99, 0, 2, "cycle-child-b", 100, 101, 8, 1.0, 1.0, 1);
+        add_ready_scope_bits(builder, 5, 1, 4, 99, 0, 3, "cycle-child-c", 200, 201, 8, 1.0, 1.0, 1);
+        add_ready_scope_bits(builder, 6, 1, 5, 99, 0, 4, "cycle-child-d", 44, 45, 8, 1.0, 1.0, 1);
+        add_queue_loss(builder, 2, 1);
         builder.End();
         const Loaded loaded = LoadChunks(builder.bytes);
         Expect(
@@ -3507,9 +3556,9 @@ void TestSemanticTopologyAndLossRecovery() {
         builder.Schema(Templates::GpuFrame());
         builder.Schema(Templates::GpuScope());
         AddGpuFrame(builder, 1, 1, ProfileGpuFrameStatus::Complete, true, 3, 0, 0, "");
-        add_ready_scope_bits(builder, 2, 1, 2, 99, 0, 1, "wrapped-missing-child-a", 250, 5, 8, 11.0, 11.0, 1);
-        add_ready_scope_bits(builder, 3, 1, 3, 99, 0, 2, "wrapped-missing-child-b", 5, 10, 8, 5.0, 5.0, 1);
-        add_queue_loss(builder, 4, 1);
+        add_ready_scope_bits(builder, 3, 1, 2, 99, 0, 1, "wrapped-missing-child-a", 250, 5, 8, 11.0, 11.0, 1);
+        add_ready_scope_bits(builder, 4, 1, 3, 99, 0, 2, "wrapped-missing-child-b", 5, 10, 8, 5.0, 5.0, 1);
+        add_queue_loss(builder, 2, 1);
         builder.End();
         Expect(
             LoadChunks(builder.bytes).result.status == SessionLoadStatus::Complete,
@@ -3523,8 +3572,8 @@ void TestSemanticTopologyAndLossRecovery() {
         builder.Schema(Templates::GpuScope());
         AddGpuFrame(builder, 1, 1, ProfileGpuFrameStatus::Complete, true, 3, 0, 0, "");
         add_ready_scope_bits(builder, 2, 1, 1, 0, 0, 0, "bridge-root-a", 0, 1, 8, 1.0, 1.0, 0);
-        add_ready_scope_bits(builder, 3, 1, 2, 0, 0, 2, "bridge-root-b", 255, 0, 8, 1.0, 1.0, 0);
-        add_queue_loss(builder, 4, 1);
+        add_ready_scope_bits(builder, 4, 1, 2, 0, 0, 2, "bridge-root-b", 255, 0, 8, 1.0, 1.0, 0);
+        add_queue_loss(builder, 3, 1);
         builder.End();
         const Loaded loaded = LoadChunks(builder.bytes);
         Expect(
@@ -3540,8 +3589,8 @@ void TestSemanticTopologyAndLossRecovery() {
         builder.Schema(Templates::GpuScope());
         AddGpuFrame(builder, 1, 1, ProfileGpuFrameStatus::Complete, true, 4, 0, 0, "");
         add_ready_scope_bits(builder, 2, 1, 1, 0, 0, 0, "three-step-root-a", 0, 100, 8, 100.0, 100.0, 0);
-        add_ready_scope_bits(builder, 3, 1, 2, 0, 0, 3, "three-step-root-b", 50, 60, 8, 10.0, 10.0, 0);
-        add_queue_loss(builder, 4, 2);
+        add_ready_scope_bits(builder, 5, 1, 2, 0, 0, 3, "three-step-root-b", 50, 60, 8, 10.0, 10.0, 0);
+        add_queue_loss(builder, 3, 2);
         builder.End();
         Expect(
             LoadChunks(builder.bytes).result.status == SessionLoadStatus::Complete,
@@ -3556,8 +3605,8 @@ void TestSemanticTopologyAndLossRecovery() {
         AddGpuFrame(builder, 1, 1, ProfileGpuFrameStatus::Complete, true, 4, 0, 0, "");
         add_ready_scope_bits(builder, 2, 1, 1, 0, 0, 0, "endpoint-root", 0, 100, 64, 100.0, 50.0, 0);
         add_ready_scope(builder, 3, 1, 2, 1, 0, 1, "endpoint-sibling-a", 0, 50, 1);
-        add_ready_scope(builder, 4, 1, 4, 99, 0, 3, "endpoint-orphan", 50, 50, 2);
-        add_queue_loss(builder, 5, 1);
+        add_ready_scope(builder, 5, 1, 4, 99, 0, 3, "endpoint-orphan", 50, 50, 2);
+        add_queue_loss(builder, 4, 1);
         builder.End();
         Expect(
             LoadChunks(builder.bytes).result.status == SessionLoadStatus::Complete,
@@ -3571,8 +3620,8 @@ void TestSemanticTopologyAndLossRecovery() {
         builder.Schema(Templates::GpuScope());
         AddGpuFrame(builder, 1, 1, ProfileGpuFrameStatus::Complete, true, 3, 0, 0, "");
         add_ready_scope(builder, 2, 1, 1, 0, 0, 0, "endpoint-grandparent", 0, 50, 0);
-        add_ready_scope(builder, 3, 1, 3, 99, 0, 2, "endpoint-grandchild", 50, 50, 2);
-        add_queue_loss(builder, 4, 1);
+        add_ready_scope(builder, 4, 1, 3, 99, 0, 2, "endpoint-grandchild", 50, 50, 2);
+        add_queue_loss(builder, 3, 1);
         builder.End();
         Expect(
             LoadChunks(builder.bytes).result.status == SessionLoadStatus::Complete,
@@ -3586,10 +3635,10 @@ void TestSemanticTopologyAndLossRecovery() {
         builder.Schema(Templates::GpuScope());
         AddGpuFrame(builder, 1, 1, ProfileGpuFrameStatus::Complete, true, 5, 0, 0, "");
         add_ready_scope(builder, 2, 1, 1, 0, 0, 0, "contract-barrier-root", 0, 100, 0);
-        add_ready_scope(builder, 3, 1, 3, 99, 0, 2, "contract-child-a", 10, 20, 2);
-        add_ready_scope(builder, 4, 1, 4, 1, 0, 3, "contract-barrier", 30, 40, 1);
-        add_ready_scope(builder, 5, 1, 5, 99, 0, 4, "contract-child-b", 50, 60, 2);
-        add_queue_loss(builder, 6, 1);
+        add_ready_scope(builder, 4, 1, 3, 99, 0, 2, "contract-child-a", 10, 20, 2);
+        add_ready_scope(builder, 5, 1, 4, 1, 0, 3, "contract-barrier", 30, 40, 1);
+        add_ready_scope(builder, 6, 1, 5, 99, 0, 4, "contract-child-b", 50, 60, 2);
+        add_queue_loss(builder, 3, 1);
         builder.End();
         const Loaded loaded = LoadChunks(builder.bytes);
         Expect(
@@ -3605,11 +3654,43 @@ void TestSemanticTopologyAndLossRecovery() {
         builder.Schema(Templates::GpuScope());
         AddGpuFrame(builder, 1, 1, ProfileGpuFrameStatus::Complete, true, 5, 0, 0, "");
         add_ready_scope(builder, 2, 1, 1, 0, 0, 0, "virtual-sibling-root", 0, 100, 0);
-        const std::uint64_t first_child_order  = leave_sibling_hole ? 2 : 3;
-        const std::uint64_t second_child_order = leave_sibling_hole ? 4 : 4;
-        add_ready_scope(builder, 3, 1, 3, 101, 0, first_child_order, "virtual-sibling-child-a", 10, 20, 2);
-        add_ready_scope(builder, 4, 1, 4, 102, 0, second_child_order, "virtual-sibling-child-b", 30, 40, 2);
-        add_queue_loss(builder, 5, 2);
+        const std::uint64_t first_child_order     = leave_sibling_hole ? 2 : 3;
+        const std::uint64_t second_child_order    = leave_sibling_hole ? 4 : 4;
+        const std::uint64_t first_child_sequence  = leave_sibling_hole ? 4 : 5;
+        const std::uint64_t second_child_sequence = 6;
+        add_ready_scope(
+            builder,
+            first_child_sequence,
+            1,
+            3,
+            101,
+            0,
+            first_child_order,
+            "virtual-sibling-child-a",
+            10,
+            20,
+            2
+        );
+        add_ready_scope(
+            builder,
+            second_child_sequence,
+            1,
+            4,
+            102,
+            0,
+            second_child_order,
+            "virtual-sibling-child-b",
+            30,
+            40,
+            2
+        );
+        builder.Loss({
+            .first_sequence = 3,
+            .last_sequence  = leave_sibling_hole ? 5ull : 4ull,
+            .record_count   = 2,
+            .value_bytes    = 16,
+            .reason_mask    = static_cast<std::uint32_t>(LossReason::QueueFull),
+        });
         builder.End();
         const Loaded loaded = LoadChunks(builder.bytes);
         Expect(
@@ -3629,9 +3710,9 @@ void TestSemanticTopologyAndLossRecovery() {
         AddGpuFrame(builder, 1, 1, ProfileGpuFrameStatus::Complete, true, 6, 0, 0, "");
         add_ready_scope_bits(builder, 2, 1, 1, 0, 0, 0, "contract-lca-root", 0, 100, 64, 100.0, 50.0, 0);
         add_ready_scope(builder, 3, 1, 2, 1, 0, 1, "contract-lca-sibling", 0, 50, 1);
-        add_ready_scope(builder, 4, 1, 4, 99, 0, 4, "contract-lca-zero-child", 50, 50, 3);
-        add_ready_scope(builder, 5, 1, 5, 99, 0, 5, "contract-lca-late-child", 60, 70, 3);
-        add_queue_loss(builder, 6, 2);
+        add_ready_scope(builder, 6, 1, 4, 99, 0, 4, "contract-lca-zero-child", 50, 50, 3);
+        add_ready_scope(builder, 7, 1, 5, 99, 0, 5, "contract-lca-late-child", 60, 70, 3);
+        add_queue_loss(builder, 4, 2);
         builder.End();
         Expect(
             LoadChunks(builder.bytes).result.status == SessionLoadStatus::Complete,
@@ -3645,9 +3726,9 @@ void TestSemanticTopologyAndLossRecovery() {
         builder.Schema(Templates::GpuScope());
         AddGpuFrame(builder, 1, 1, ProfileGpuFrameStatus::Complete, true, 4, 0, 0, "");
         add_ready_scope_bits(builder, 2, 1, 1, 0, 0, 0, "virtual-chain-root-a", 0, 127, 8, 127.0, 127.0, 0);
-        add_ready_scope_bits(builder, 3, 1, 3, 99, 0, 2, "virtual-chain-child", 200, 210, 8, 10.0, 10.0, 1);
-        add_ready_scope_bits(builder, 4, 1, 4, 0, 0, 3, "virtual-chain-root-b", 100, 110, 8, 10.0, 10.0, 0);
-        add_queue_loss(builder, 5, 1);
+        add_ready_scope_bits(builder, 4, 1, 3, 99, 0, 2, "virtual-chain-child", 200, 210, 8, 10.0, 10.0, 1);
+        add_ready_scope_bits(builder, 5, 1, 4, 0, 0, 3, "virtual-chain-root-b", 100, 110, 8, 10.0, 10.0, 0);
+        add_queue_loss(builder, 3, 1);
         builder.End();
         const Loaded loaded = LoadChunks(builder.bytes);
         Expect(
@@ -3662,12 +3743,32 @@ void TestSemanticTopologyAndLossRecovery() {
         builder.Schema(Templates::GpuFrame());
         builder.Schema(Templates::GpuScope());
         AddGpuFrame(builder, 1, 1, ProfileGpuFrameStatus::Complete, true, 2 + split_loss_count, 0, 0, "");
-        add_ready_scope_bits(builder, 2, 1, 3, 101, 0, 2, "split-root-child-a", 10, 30, 8, 20.0, 20.0, 2);
-        const std::uint64_t second_child_order = split_loss_count == 3 ? 4 : 5;
+        add_ready_scope_bits(builder, 4, 1, 3, 101, 0, 2, "split-root-child-a", 10, 30, 8, 20.0, 20.0, 2);
+        const std::uint64_t second_child_order    = split_loss_count == 3 ? 4 : 5;
+        const std::uint64_t second_child_sequence = split_loss_count == 3 ? 6 : 7;
         add_ready_scope_bits(
-            builder, 3, 1, 4, 102, 0, second_child_order, "split-root-child-b", 20, 40, 8, 20.0, 20.0, 2
+            builder,
+            second_child_sequence,
+            1,
+            4,
+            102,
+            0,
+            second_child_order,
+            "split-root-child-b",
+            20,
+            40,
+            8,
+            20.0,
+            20.0,
+            2
         );
-        add_queue_loss(builder, 4, split_loss_count);
+        builder.Loss({
+            .first_sequence = 2,
+            .last_sequence  = split_loss_count == 3 ? 5ull : 6ull,
+            .record_count   = split_loss_count,
+            .value_bytes    = split_loss_count * 8,
+            .reason_mask    = static_cast<std::uint32_t>(LossReason::QueueFull),
+        });
         builder.End();
         const Loaded loaded = LoadChunks(builder.bytes);
         Expect(
@@ -3684,10 +3785,16 @@ void TestSemanticTopologyAndLossRecovery() {
         builder.Schema(Templates::GpuFrame());
         builder.Schema(Templates::GpuScope());
         AddGpuFrame(builder, 1, 1, ProfileGpuFrameStatus::Complete, true, 7, 0, 0, "");
-        add_ready_scope_bits(builder, 2, 1, 3, 101, 0, 2, "wide-root-child-a", 10, 20, 8, 10.0, 10.0, 2);
-        add_ready_scope_bits(builder, 3, 1, 4, 102, 0, 5, "wide-root-child-b", 200, 210, 8, 10.0, 10.0, 2);
-        add_ready_scope_bits(builder, 4, 1, 5, 0, 0, 6, "wide-root-successor", 220, 230, 8, 10.0, 10.0, 0);
-        add_queue_loss(builder, 5, 4);
+        add_ready_scope_bits(builder, 4, 1, 3, 101, 0, 2, "wide-root-child-a", 10, 20, 8, 10.0, 10.0, 2);
+        add_ready_scope_bits(builder, 7, 1, 4, 102, 0, 5, "wide-root-child-b", 200, 210, 8, 10.0, 10.0, 2);
+        add_ready_scope_bits(builder, 8, 1, 5, 0, 0, 6, "wide-root-successor", 220, 230, 8, 10.0, 10.0, 0);
+        builder.Loss({
+            .first_sequence = 2,
+            .last_sequence  = 6,
+            .record_count   = 4,
+            .value_bytes    = 32,
+            .reason_mask    = static_cast<std::uint32_t>(LossReason::QueueFull),
+        });
         builder.End();
         Expect(
             LoadChunks(builder.bytes).result.status == SessionLoadStatus::Complete,
@@ -3700,10 +3807,16 @@ void TestSemanticTopologyAndLossRecovery() {
         builder.Schema(Templates::GpuFrame());
         builder.Schema(Templates::GpuScope());
         AddGpuFrame(builder, 1, 1, ProfileGpuFrameStatus::Complete, true, 7, 0, 0, "");
-        add_ready_scope_bits(builder, 2, 1, 3, 101, 0, 2, "partition-child-a", 0, 10, 8, 10.0, 10.0, 2);
-        add_ready_scope_bits(builder, 3, 1, 4, 102, 0, 5, "partition-child-b", 100, 110, 8, 10.0, 10.0, 2);
-        add_ready_scope_bits(builder, 4, 1, 5, 0, 0, 6, "partition-successor", 150, 160, 8, 10.0, 10.0, 0);
-        add_queue_loss(builder, 5, 4);
+        add_ready_scope_bits(builder, 4, 1, 3, 101, 0, 2, "partition-child-a", 0, 10, 8, 10.0, 10.0, 2);
+        add_ready_scope_bits(builder, 7, 1, 4, 102, 0, 5, "partition-child-b", 100, 110, 8, 10.0, 10.0, 2);
+        add_ready_scope_bits(builder, 8, 1, 5, 0, 0, 6, "partition-successor", 150, 160, 8, 10.0, 10.0, 0);
+        builder.Loss({
+            .first_sequence = 2,
+            .last_sequence  = 6,
+            .record_count   = 4,
+            .value_bytes    = 32,
+            .reason_mask    = static_cast<std::uint32_t>(LossReason::QueueFull),
+        });
         builder.End();
         const Loaded loaded = LoadChunks(builder.bytes);
         Expect(
@@ -3720,18 +3833,24 @@ void TestSemanticTopologyAndLossRecovery() {
         builder.Schema(Templates::GpuScope());
         AddGpuFrame(builder, 1, 1, ProfileGpuFrameStatus::Complete, true, 9, 0, 0, "");
         add_ready_scope_bits(
-            builder, 2, 1, 2, 100, 0, 1, "future-shared-child-zero", 0, 10, 8, 10.0, 10.0, 1
+            builder, 3, 1, 2, 100, 0, 1, "future-shared-child-zero", 0, 10, 8, 10.0, 10.0, 1
         );
         add_ready_scope_bits(
-            builder, 3, 1, 3, 201, 0, 5, "future-shared-child-one", 100, 105, 8, 5.0, 5.0, 3
+            builder, 7, 1, 3, 201, 0, 5, "future-shared-child-one", 100, 105, 8, 5.0, 5.0, 3
         );
         add_ready_scope_bits(
-            builder, 4, 1, 4, 202, 0, 7, "future-shared-child-two", 106, 110, 8, 4.0, 4.0, 3
+            builder, 9, 1, 4, 202, 0, 7, "future-shared-child-two", 106, 110, 8, 4.0, 4.0, 3
         );
         add_ready_scope_bits(
-            builder, 5, 1, 5, 0, 0, 8, "future-shared-successor", 150, 160, 8, 10.0, 10.0, 0
+            builder, 10, 1, 5, 0, 0, 8, "future-shared-successor", 150, 160, 8, 10.0, 10.0, 0
         );
-        add_queue_loss(builder, 6, 5);
+        builder.Loss({
+            .first_sequence = 2,
+            .last_sequence  = 8,
+            .record_count   = 5,
+            .value_bytes    = 40,
+            .reason_mask    = static_cast<std::uint32_t>(LossReason::QueueFull),
+        });
         builder.End();
         const Loaded loaded = LoadChunks(builder.bytes);
         Expect(
@@ -3747,15 +3866,21 @@ void TestSemanticTopologyAndLossRecovery() {
         builder.Schema(Templates::GpuFrame());
         builder.Schema(Templates::GpuScope());
         AddGpuFrame(builder, 1, 1, ProfileGpuFrameStatus::Complete, true, 9, 0, 0, "");
-        add_ready_scope_bits(builder, 2, 1, 2, 100, 0, 1, "partial-split-child-zero", 0, 0, 8, 0.0, 0.0, 1);
+        add_ready_scope_bits(builder, 3, 1, 2, 100, 0, 1, "partial-split-child-zero", 0, 0, 8, 0.0, 0.0, 1);
         add_ready_scope_bits(
-            builder, 3, 1, 3, 201, 0, 4, "partial-split-child-one", 100, 100, 8, 0.0, 0.0, 2
+            builder, 6, 1, 3, 201, 0, 4, "partial-split-child-one", 100, 100, 8, 0.0, 0.0, 2
         );
         add_ready_scope_bits(
-            builder, 4, 1, 4, 202, 0, 6, "partial-split-child-two", 110, 110, 8, 0.0, 0.0, 2
+            builder, 8, 1, 4, 202, 0, 6, "partial-split-child-two", 110, 110, 8, 0.0, 0.0, 2
         );
-        add_ready_scope_bits(builder, 5, 1, 5, 0, 0, 8, "partial-split-successor", 50, 60, 8, 10.0, 10.0, 0);
-        add_queue_loss(builder, 6, 5);
+        add_ready_scope_bits(builder, 10, 1, 5, 0, 0, 8, "partial-split-successor", 50, 60, 8, 10.0, 10.0, 0);
+        builder.Loss({
+            .first_sequence = 2,
+            .last_sequence  = 9,
+            .record_count   = 5,
+            .value_bytes    = 40,
+            .reason_mask    = static_cast<std::uint32_t>(LossReason::QueueFull),
+        });
         builder.End();
         const Loaded loaded = LoadChunks(builder.bytes);
         Expect(
@@ -3773,12 +3898,12 @@ void TestSemanticTopologyAndLossRecovery() {
         AddGpuFrame(builder, 1, 1, ProfileGpuFrameStatus::Complete, true, 5, 0, 0, "");
         add_ready_scope_bits(builder, 2, 1, 1, 0, 0, 0, "occurrence-frontier-root-a", 0, 0, 8, 0.0, 0.0, 0);
         add_ready_scope_bits(
-            builder, 3, 1, 3, 99, 0, 3, "occurrence-frontier-child", 125, 125, 8, 0.0, 0.0, 1
+            builder, 5, 1, 3, 99, 0, 3, "occurrence-frontier-child", 125, 125, 8, 0.0, 0.0, 1
         );
         add_ready_scope_bits(
-            builder, 4, 1, 4, 0, 0, 4, "occurrence-frontier-root-b", 175, 180, 8, 5.0, 5.0, 0
+            builder, 6, 1, 4, 0, 0, 4, "occurrence-frontier-root-b", 175, 180, 8, 5.0, 5.0, 0
         );
-        add_queue_loss(builder, 5, 2);
+        add_queue_loss(builder, 3, 2);
         builder.End();
         const Loaded loaded = LoadChunks(builder.bytes);
         Expect(
@@ -3798,15 +3923,21 @@ void TestSemanticTopologyAndLossRecovery() {
             builder, 2, 1, 1, 0, 0, 0, "partition-soundness-root-a", 0, 127, 8, 127.0, 127.0, 0
         );
         add_ready_scope_bits(
-            builder, 3, 1, 3, 101, 0, 3, "partition-soundness-child-a", 255, 255, 8, 0.0, 0.0, 2
+            builder, 5, 1, 3, 101, 0, 3, "partition-soundness-child-a", 255, 255, 8, 0.0, 0.0, 2
         );
         add_ready_scope_bits(
-            builder, 4, 1, 4, 102, 0, 6, "partition-soundness-child-b", 255, 255, 8, 0.0, 0.0, 2
+            builder, 8, 1, 4, 102, 0, 6, "partition-soundness-child-b", 255, 255, 8, 0.0, 0.0, 2
         );
         add_ready_scope_bits(
-            builder, 5, 1, 5, 0, 0, 7, "partition-soundness-root-b", 150, 160, 8, 10.0, 10.0, 0
+            builder, 9, 1, 5, 0, 0, 7, "partition-soundness-root-b", 150, 160, 8, 10.0, 10.0, 0
         );
-        add_queue_loss(builder, 6, 4);
+        builder.Loss({
+            .first_sequence = 3,
+            .last_sequence  = 7,
+            .record_count   = 4,
+            .value_bytes    = 32,
+            .reason_mask    = static_cast<std::uint32_t>(LossReason::QueueFull),
+        });
         builder.End();
         const Loaded loaded = LoadChunks(builder.bytes);
         Expect(
@@ -3822,15 +3953,21 @@ void TestSemanticTopologyAndLossRecovery() {
         builder.Schema(Templates::GpuScope());
         AddGpuFrame(builder, 1, 1, ProfileGpuFrameStatus::Complete, true, 7, 0, 0, "");
         add_ready_scope_bits(
-            builder, 2, 1, 3, 101, 0, 3, "blocked-partition-child-a", 0, 10, 8, 10.0, 10.0, 2
+            builder, 5, 1, 3, 101, 0, 3, "blocked-partition-child-a", 0, 10, 8, 10.0, 10.0, 2
         );
         add_ready_scope_bits(
-            builder, 3, 1, 4, 102, 0, 5, "blocked-partition-child-b", 100, 110, 8, 10.0, 10.0, 2
+            builder, 7, 1, 4, 102, 0, 5, "blocked-partition-child-b", 100, 110, 8, 10.0, 10.0, 2
         );
         add_ready_scope_bits(
-            builder, 4, 1, 5, 0, 0, 6, "blocked-partition-successor", 150, 160, 8, 10.0, 10.0, 0
+            builder, 8, 1, 5, 0, 0, 6, "blocked-partition-successor", 150, 160, 8, 10.0, 10.0, 0
         );
-        add_queue_loss(builder, 5, 4);
+        builder.Loss({
+            .first_sequence = 2,
+            .last_sequence  = 6,
+            .record_count   = 4,
+            .value_bytes    = 32,
+            .reason_mask    = static_cast<std::uint32_t>(LossReason::QueueFull),
+        });
         builder.End();
         const Loaded loaded = LoadChunks(builder.bytes);
         Expect(
@@ -3846,10 +3983,16 @@ void TestSemanticTopologyAndLossRecovery() {
         builder.Schema(Templates::GpuScope());
         AddGpuFrame(builder, 1, 1, ProfileGpuFrameStatus::Complete, true, 4, 0, 0, "");
         add_ready_scope_bits(
-            builder, 2, 1, 2, 99, 0, 1, "long-atomic-virtual-child", 0, 200, 8, 200.0, 200.0, 1
+            builder, 3, 1, 2, 99, 0, 1, "long-atomic-virtual-child", 0, 200, 8, 200.0, 200.0, 1
         );
-        add_ready_scope_bits(builder, 3, 1, 3, 0, 0, 3, "long-atomic-successor", 210, 220, 8, 10.0, 10.0, 0);
-        add_queue_loss(builder, 4, 2);
+        add_ready_scope_bits(builder, 5, 1, 3, 0, 0, 3, "long-atomic-successor", 210, 220, 8, 10.0, 10.0, 0);
+        builder.Loss({
+            .first_sequence = 2,
+            .last_sequence  = 4,
+            .record_count   = 2,
+            .value_bytes    = 16,
+            .reason_mask    = static_cast<std::uint32_t>(LossReason::QueueFull),
+        });
         builder.End();
         const Loaded loaded = LoadChunks(builder.bytes);
         Expect(
@@ -3865,9 +4008,9 @@ void TestSemanticTopologyAndLossRecovery() {
         builder.Schema(Templates::GpuScope());
         AddGpuFrame(builder, 1, 1, ProfileGpuFrameStatus::Complete, true, 5, 0, 0, "");
         add_ready_scope_bits(builder, 2, 1, 1, 0, 0, 0, "late-root-a", 0, 100, 8, 100.0, 100.0, 0);
-        add_ready_scope_bits(builder, 3, 1, 3, 99, 0, 3, "late-root-child", 250, 0, 8, 6.0, 6.0, 1);
-        add_ready_scope_bits(builder, 4, 1, 4, 0, 0, 4, "late-root-b", 0, 10, 8, 10.0, 10.0, 0);
-        add_queue_loss(builder, 5, 2);
+        add_ready_scope_bits(builder, 5, 1, 3, 99, 0, 3, "late-root-child", 250, 0, 8, 6.0, 6.0, 1);
+        add_ready_scope_bits(builder, 6, 1, 4, 0, 0, 4, "late-root-b", 0, 10, 8, 10.0, 10.0, 0);
+        add_queue_loss(builder, 3, 2);
         builder.End();
         Expect(
             LoadChunks(builder.bytes).result.status == SessionLoadStatus::Complete,
@@ -3881,8 +4024,8 @@ void TestSemanticTopologyAndLossRecovery() {
         builder.Schema(Templates::GpuScope());
         AddGpuFrame(builder, 1, 1, ProfileGpuFrameStatus::Complete, true, 4, 0, 0, "");
         add_ready_scope_bits(builder, 2, 1, 1, 0, 0, 0, "long-root", 0, 200, 8, 200.0, 200.0, 0);
-        add_ready_scope_bits(builder, 3, 1, 3, 99, 0, 3, "long-root-successor", 210, 220, 8, 10.0, 10.0, 1);
-        add_queue_loss(builder, 4, 2);
+        add_ready_scope_bits(builder, 5, 1, 3, 99, 0, 3, "long-root-successor", 210, 220, 8, 10.0, 10.0, 1);
+        add_queue_loss(builder, 3, 2);
         builder.End();
         const Loaded loaded = LoadChunks(builder.bytes);
         Expect(
@@ -3997,6 +4140,947 @@ void TestSemanticTopologyAndLossRecovery() {
                 limited.result.limit_kind == SessionLimitKind::TopologyWorkItems &&
                 !limited.result.HasUsableSession() && !limited.session.Valid(),
             "CPU boundary-parent search escaped the session topology work budget"
+        );
+    }
+}
+
+void TestGpuProducerSequenceProofs() {
+    const auto add_scope = [](SessionBuilder&  _builder,
+                              std::uint64_t    _sequence,
+                              std::uint64_t    _frame_id,
+                              std::uint64_t    _scope_id,
+                              std::uint64_t    _parent_scope_id,
+                              std::uint64_t    _source_order,
+                              std::uint64_t    _local_order,
+                              std::uint32_t    _depth,
+                              std::string_view _name) {
+        AddGpuScope(
+            _builder,
+            _sequence,
+            _frame_id,
+            _scope_id,
+            _parent_scope_id,
+            _source_order,
+            _local_order,
+            0,
+            0,
+            0,
+            _name,
+            ProfileGpuScopeStatus::Ready,
+            10,
+            20,
+            64,
+            1.0,
+            10.0,
+            10.0,
+            _depth,
+            ""
+        );
+    };
+    const auto add_loss =
+        [](SessionBuilder& _builder, std::uint64_t _first, std::uint64_t _last, std::uint64_t _count) {
+            _builder.Loss({
+                .first_sequence = _first,
+                .last_sequence  = _last,
+                .record_count   = _count,
+                .value_bytes    = _count * 8,
+                .reason_mask    = static_cast<std::uint32_t>(LossReason::QueueFull),
+            });
+        };
+    const auto expect_rejected = [](const Loaded&    _loaded,
+                                    SessionErrorCode _error,
+                                    std::string_view _message,
+                                    std::string_view _diagnostic = {}) {
+        Expect(
+            _loaded.result.status == SessionLoadStatus::ProtocolViolation &&
+                _loaded.result.error_code == _error && !_loaded.result.HasUsableSession() &&
+                !_loaded.session.Valid() && (_diagnostic.empty() || _loaded.diagnostic == _diagnostic),
+            std::string(_message) + " (diagnostic=" + _loaded.diagnostic + ")"
+        );
+    };
+
+    {
+        SessionBuilder builder;
+        builder.Begin();
+        builder.Schema(Templates::GpuFrame());
+        builder.Schema(Templates::GpuScope());
+        AddGpuFrame(builder, 3, 1, ProfileGpuFrameStatus::Complete, true, 1, 0, 0, "");
+        add_scope(builder, 2, 1, 1, 0, 0, 0, 0, "scope-before-own-frame");
+        builder.End();
+        expect_rejected(
+            LoadChunks(builder.bytes),
+            SessionErrorCode::RecordSequenceInvalid,
+            "a GpuScope record preceded its owning GpuFrame record",
+            "GpuFrame record sequence does not precede its GpuScope records"
+        );
+
+        SessionBuilder control;
+        control.Begin();
+        control.Schema(Templates::GpuFrame());
+        control.Schema(Templates::GpuScope());
+        AddGpuFrame(control, 1, 1, ProfileGpuFrameStatus::Complete, true, 1, 0, 0, "");
+        add_scope(control, 2, 1, 1, 0, 0, 0, 0, "scope-after-own-frame");
+        control.End();
+        const Loaded loaded = LoadChunks(control.bytes);
+        Expect(
+            loaded.result.status == SessionLoadStatus::Complete && loaded.session.Valid(),
+            "a GpuScope record after its owning frame was rejected"
+        );
+    }
+    {
+        const auto add_parent_child =
+            [](SessionBuilder& _builder, std::uint64_t _parent_sequence, std::uint64_t _child_sequence) {
+                AddGpuScope(
+                    _builder,
+                    _parent_sequence,
+                    1,
+                    1,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    "observed-parent",
+                    ProfileGpuScopeStatus::Ready,
+                    10,
+                    30,
+                    64,
+                    1.0,
+                    20.0,
+                    10.0,
+                    0,
+                    ""
+                );
+                AddGpuScope(
+                    _builder,
+                    _child_sequence,
+                    1,
+                    2,
+                    1,
+                    0,
+                    1,
+                    0,
+                    0,
+                    0,
+                    "observed-child",
+                    ProfileGpuScopeStatus::Ready,
+                    15,
+                    25,
+                    64,
+                    1.0,
+                    10.0,
+                    10.0,
+                    1,
+                    ""
+                );
+            };
+
+        SessionBuilder builder;
+        builder.Begin();
+        builder.Schema(Templates::GpuFrame());
+        builder.Schema(Templates::GpuScope());
+        AddGpuFrame(builder, 1, 1, ProfileGpuFrameStatus::Complete, true, 2, 0, 0, "");
+        add_parent_child(builder, 3, 2);
+        builder.End();
+        expect_rejected(
+            LoadChunks(builder.bytes),
+            SessionErrorCode::RecordSequenceInvalid,
+            "an observed GPU parent was emitted after its child",
+            "GpuScope parent record sequence does not precede its child"
+        );
+
+        SessionBuilder control;
+        control.Begin();
+        control.Schema(Templates::GpuFrame());
+        control.Schema(Templates::GpuScope());
+        AddGpuFrame(control, 1, 1, ProfileGpuFrameStatus::Complete, true, 2, 0, 0, "");
+        add_parent_child(control, 2, 3);
+        control.End();
+        const Loaded loaded = LoadChunks(control.bytes);
+        Expect(
+            loaded.result.status == SessionLoadStatus::Complete && loaded.session.Valid(),
+            "an observed GPU parent before its child was rejected"
+        );
+    }
+    {
+        SessionBuilder builder;
+        builder.Begin();
+        builder.Schema(Templates::GpuFrame());
+        builder.Schema(Templates::GpuScope());
+        AddGpuFrame(builder, 1, 1, ProfileGpuFrameStatus::Complete, true, 2, 0, 0, "");
+        add_scope(builder, 3, 1, 1, 0, 0, 0, 0, "later-sequence-source-zero");
+        add_scope(builder, 2, 1, 2, 0, 1, 0, 0, "earlier-sequence-source-one");
+        builder.End();
+        expect_rejected(
+            LoadChunks(builder.bytes),
+            SessionErrorCode::RecordSequenceInvalid,
+            "GPU recording sources reversed producer emission order",
+            "GpuScope records reverse producer emission order"
+        );
+
+        SessionBuilder control;
+        control.Begin();
+        control.Schema(Templates::GpuFrame());
+        control.Schema(Templates::GpuScope());
+        AddGpuFrame(control, 1, 1, ProfileGpuFrameStatus::Complete, true, 2, 0, 0, "");
+        add_scope(control, 2, 1, 1, 0, 0, 0, 0, "ordered-source-zero");
+        add_scope(control, 3, 1, 2, 0, 1, 0, 0, "ordered-source-one");
+        control.End();
+        const Loaded loaded = LoadChunks(control.bytes);
+        Expect(
+            loaded.result.status == SessionLoadStatus::Complete && loaded.session.Valid(),
+            "producer-ordered GPU recording sources were rejected"
+        );
+    }
+    {
+        SessionBuilder builder;
+        builder.Begin();
+        builder.Schema(Templates::GpuFrame());
+        builder.Schema(Templates::GpuScope());
+        AddGpuFrame(builder, 1, 1, ProfileGpuFrameStatus::Complete, true, 1, 0, 0, "");
+        add_scope(builder, 4, 1, 1, 0, 0, 0, 0, "scope-after-next-frame");
+        AddGpuFrame(builder, 3, 2, ProfileGpuFrameStatus::Complete, true, 0, 0, 0, "");
+        builder.End();
+        expect_rejected(
+            LoadChunks(builder.bytes),
+            SessionErrorCode::RecordSequenceInvalid,
+            "a GpuScope crossed the next known frame boundary",
+            "GPU frame emission boundaries reverse producer frame order"
+        );
+
+        SessionBuilder control;
+        control.Begin();
+        control.Schema(Templates::GpuFrame());
+        control.Schema(Templates::GpuScope());
+        AddGpuFrame(control, 1, 1, ProfileGpuFrameStatus::Complete, true, 1, 0, 0, "");
+        add_scope(control, 2, 1, 1, 0, 0, 0, 0, "scope-before-next-frame");
+        AddGpuFrame(control, 3, 2, ProfileGpuFrameStatus::Complete, true, 0, 0, 0, "");
+        control.End();
+        const Loaded loaded = LoadChunks(control.bytes);
+        Expect(
+            loaded.result.status == SessionLoadStatus::Complete && loaded.session.Valid(),
+            "a GpuScope before the next known frame boundary was rejected"
+        );
+    }
+    {
+        SessionBuilder builder;
+        builder.Begin();
+        builder.Schema(Templates::GpuFrame());
+        builder.Schema(Templates::GpuScope());
+        AddGpuFrame(builder, 1, 1, ProfileGpuFrameStatus::Complete, true, 3, 0, 0, "");
+        add_scope(builder, 2, 1, 1, 0, 0, 0, 0, "source-a-root");
+        add_scope(builder, 4, 1, 3, 0, 1, 0, 0, "source-b-root");
+        add_loss(builder, 3, 3, 1);
+        builder.End();
+        const Loaded loaded = LoadChunks(builder.bytes);
+        Expect(
+            loaded.result.status == SessionLoadStatus::Complete && loaded.session.Valid() &&
+                loaded.session.Summary().degraded_complete_gpu_frame_count == 1,
+            "a Complete-frame source-tail loss between observed sources was rejected"
+        );
+    }
+
+    {
+        SessionBuilder builder;
+        builder.Begin();
+        builder.Schema(Templates::GpuFrame());
+        builder.Schema(Templates::GpuScope());
+        AddGpuFrame(builder, 1, 1, ProfileGpuFrameStatus::Complete, true, 0, 0, 0, "");
+        AddGpuFrame(builder, 3, 3, ProfileGpuFrameStatus::Complete, true, 0, 0, 0, "");
+        add_scope(builder, 4, 2, 1, 0, 0, 0, 0, "missing-frame-after-next-frame");
+        add_loss(builder, 2, 2, 1);
+        builder.End();
+        expect_rejected(
+            LoadChunks(builder.bytes),
+            SessionErrorCode::RecordSequenceInvalid,
+            "a missing frame emitted scopes after the next known frame record"
+        );
+
+        SessionBuilder control;
+        control.Begin();
+        control.Schema(Templates::GpuFrame());
+        control.Schema(Templates::GpuScope());
+        AddGpuFrame(control, 1, 1, ProfileGpuFrameStatus::Complete, true, 0, 0, 0, "");
+        AddGpuFrame(control, 4, 3, ProfileGpuFrameStatus::Complete, true, 0, 0, 0, "");
+        add_scope(control, 3, 2, 1, 0, 0, 0, 0, "ordered-missing-frame");
+        add_loss(control, 2, 2, 1);
+        control.End();
+        Expect(
+            LoadChunks(control.bytes).result.status == SessionLoadStatus::Complete,
+            "a producer-ordered missing frame was rejected"
+        );
+    }
+    {
+        SessionBuilder builder;
+        builder.Begin();
+        builder.Schema(Templates::GpuFrame());
+        builder.Schema(Templates::GpuScope());
+        AddGpuFrame(builder, 1, 1, ProfileGpuFrameStatus::Complete, true, 1, 0, 0, "");
+        add_scope(builder, 3, 2, 1, 0, 0, 0, 0, "missing-next-frame-root");
+        add_loss(builder, 2, 4, 2);
+        builder.End();
+        expect_rejected(
+            LoadChunks(builder.bytes),
+            SessionErrorCode::GpuFrameTotalsMismatch,
+            "a Complete-frame tail crossed the record of the next missing frame"
+        );
+
+        SessionBuilder control;
+        control.Begin();
+        control.Schema(Templates::GpuFrame());
+        control.Schema(Templates::GpuScope());
+        AddGpuFrame(control, 1, 1, ProfileGpuFrameStatus::Complete, true, 1, 0, 0, "");
+        add_scope(control, 4, 2, 1, 0, 0, 0, 0, "ordered-next-frame-root");
+        add_loss(control, 2, 3, 2);
+        control.End();
+        Expect(
+            LoadChunks(control.bytes).result.status == SessionLoadStatus::Complete,
+            "a Complete-frame tail and following missing frame did not fit valid ordered slots"
+        );
+    }
+    {
+        SessionBuilder builder;
+        builder.Begin();
+        builder.Schema(Templates::GpuFrame());
+        builder.Schema(Templates::GpuScope());
+        AddGpuFrame(builder, 1, 1, ProfileGpuFrameStatus::Incomplete, false, 3, 1, 0, "RHI drops");
+        add_scope(builder, 3, 1, 1, 0, 1, 0, 0, "observed-root-predecessor");
+        add_scope(builder, 4, 1, 3, 99, 1, 2, 1, "child-after-missing-root");
+        add_loss(builder, 2, 2, 1);
+        builder.End();
+        expect_rejected(
+            LoadChunks(builder.bytes),
+            SessionErrorCode::GpuFrameTotalsMismatch,
+            "a missing direct GPU parent was placed before its producer predecessor"
+        );
+
+        SessionBuilder control;
+        control.Begin();
+        control.Schema(Templates::GpuFrame());
+        control.Schema(Templates::GpuScope());
+        AddGpuFrame(control, 1, 1, ProfileGpuFrameStatus::Incomplete, false, 3, 1, 0, "RHI drops");
+        add_scope(control, 2, 1, 1, 0, 1, 0, 0, "ordered-root-predecessor");
+        add_scope(control, 4, 1, 3, 99, 1, 2, 1, "ordered-child-after-missing-root");
+        add_loss(control, 3, 3, 1);
+        control.End();
+        Expect(
+            LoadChunks(control.bytes).result.status == SessionLoadStatus::Complete,
+            "a direct GPU parent in its producer-valid slot was rejected"
+        );
+    }
+    {
+        SessionBuilder builder;
+        builder.Begin();
+        builder.Schema(Templates::GpuFrame());
+        builder.Schema(Templates::GpuScope());
+        AddGpuFrame(builder, 1, 1, ProfileGpuFrameStatus::Incomplete, false, 4, 1, 0, "RHI drops");
+        add_scope(builder, 3, 1, 3, 99, 1, 2, 2, "early-depth-two-child");
+        add_scope(builder, 6, 1, 4, 0, 2, 0, 0, "later-unrelated-root");
+        add_loss(builder, 2, 5, 2);
+        builder.End();
+        expect_rejected(
+            LoadChunks(builder.bytes),
+            SessionErrorCode::GpuFrameTotalsMismatch,
+            "a hidden GPU ancestor was placed after the child that requires it"
+        );
+
+        SessionBuilder control;
+        control.Begin();
+        control.Schema(Templates::GpuFrame());
+        control.Schema(Templates::GpuScope());
+        AddGpuFrame(control, 1, 1, ProfileGpuFrameStatus::Incomplete, false, 4, 1, 0, "RHI drops");
+        add_scope(control, 4, 1, 3, 99, 1, 2, 2, "ordered-depth-two-child");
+        add_scope(control, 6, 1, 4, 0, 2, 0, 0, "ordered-later-root");
+        add_loss(control, 2, 3, 2);
+        control.End();
+        Expect(
+            LoadChunks(control.bytes).result.status == SessionLoadStatus::Complete,
+            "a hidden GPU ancestor chain before its child was rejected"
+        );
+    }
+    {
+        SessionBuilder builder;
+        builder.Begin();
+        builder.Schema(Templates::GpuFrame());
+        builder.Schema(Templates::GpuScope());
+        AddGpuFrame(builder, 1, 1, ProfileGpuFrameStatus::Complete, true, 0, 0, 0, "");
+        add_scope(builder, 4, 2, 3, 99, 1, 2, 2, "missing-frame-depth-two-child");
+        add_scope(builder, 7, 2, 4, 0, 2, 0, 0, "missing-frame-later-root");
+        add_loss(builder, 2, 6, 3);
+        builder.End();
+        expect_rejected(
+            LoadChunks(builder.bytes),
+            SessionErrorCode::GpuFrameTotalsMismatch,
+            "a missing frame record and its parent chain reused too few pre-child slots"
+        );
+
+        SessionBuilder control;
+        control.Begin();
+        control.Schema(Templates::GpuFrame());
+        control.Schema(Templates::GpuScope());
+        AddGpuFrame(control, 1, 1, ProfileGpuFrameStatus::Complete, true, 0, 0, 0, "");
+        add_scope(control, 5, 2, 3, 99, 1, 2, 2, "ordered-missing-frame-child");
+        add_scope(control, 7, 2, 4, 0, 2, 0, 0, "ordered-missing-frame-root");
+        add_loss(control, 2, 4, 3);
+        control.End();
+        Expect(
+            LoadChunks(control.bytes).result.status == SessionLoadStatus::Complete,
+            "a missing frame record and parent chain in valid slots were rejected"
+        );
+    }
+    {
+        const auto make_distinct_parent_fixture =
+            [&](std::uint64_t _second_child_sequence, bool _with_loss, std::uint64_t _loss_last) {
+                SessionBuilder builder;
+                builder.Begin();
+                builder.Schema(Templates::GpuFrame());
+                builder.Schema(Templates::GpuScope());
+                AddGpuFrame(builder, 1, 1, ProfileGpuFrameStatus::Incomplete, false, 4, 0, 0, "");
+                add_scope(builder, 4, 1, 2, 99, 0, 1, 1, "first-missing-parent-child");
+                add_scope(builder, _second_child_sequence, 1, 3, 100, 0, 3, 1, "second-missing-parent-child");
+                if (_with_loss) {
+                    add_loss(builder, 2, _loss_last, 2);
+                    builder.End();
+                }
+                return builder;
+            };
+
+        SessionBuilder no_intervening_slot = make_distinct_parent_fixture(5, true, 3);
+        expect_rejected(
+            LoadChunks(no_intervening_slot.bytes),
+            SessionErrorCode::GpuFrameTotalsMismatch,
+            "distinct missing GPU parents crossed an observed child subtree"
+        );
+
+        SessionBuilder misplaced_loss = make_distinct_parent_fixture(6, true, 3);
+        expect_rejected(
+            LoadChunks(misplaced_loss.bytes),
+            SessionErrorCode::GpuFrameTotalsMismatch,
+            "noticed Loss before the first child was reused for its later sibling parent"
+        );
+
+        SessionBuilder complete_control = make_distinct_parent_fixture(6, true, 5);
+        const Loaded   complete_loaded  = LoadChunks(complete_control.bytes);
+        Expect(
+            complete_loaded.result.status == SessionLoadStatus::Complete && complete_loaded.session.Valid(),
+            "distinct missing GPU parents in producer-valid Loss slots were rejected"
+        );
+
+        SessionBuilder     forensic_control = make_distinct_parent_fixture(6, false, 0);
+        SessionLoadOptions forensic_options{};
+        forensic_options.allow_forensic_truncation = true;
+        const Loaded forensic_loaded               = LoadChunks(forensic_control.bytes, {}, forensic_options);
+        Expect(
+            forensic_loaded.result.status == SessionLoadStatus::ForensicTruncated &&
+                forensic_loaded.session.Valid(),
+            "forensic distinct missing GPU parents with producer-valid holes were rejected"
+        );
+    }
+    {
+        const auto make_hidden_depth_fixture = [&](std::uint64_t _second_child_sequence,
+                                                   std::uint64_t _loss_last) {
+            SessionBuilder builder;
+            builder.Begin();
+            builder.Schema(Templates::GpuFrame());
+            builder.Schema(Templates::GpuScope());
+            AddGpuFrame(builder, 1, 1, ProfileGpuFrameStatus::Incomplete, false, 4, 0, 0, "");
+            add_scope(builder, 4, 1, 2, 99, 0, 1, 1, "missing-root-child");
+            add_scope(builder, _second_child_sequence, 1, 3, 100, 0, 3, 2, "later-missing-depth-one-child");
+            add_loss(builder, 2, _loss_last, 2);
+            builder.End();
+            return builder;
+        };
+
+        SessionBuilder builder = make_hidden_depth_fixture(5, 3);
+        expect_rejected(
+            LoadChunks(builder.bytes),
+            SessionErrorCode::GpuFrameTotalsMismatch,
+            "a later virtual missing task crossed a completed observed subtree"
+        );
+
+        SessionBuilder control        = make_hidden_depth_fixture(6, 5);
+        const Loaded   control_loaded = LoadChunks(control.bytes);
+        Expect(
+            control_loaded.result.status == SessionLoadStatus::Complete && control_loaded.session.Valid(),
+            "a later virtual missing task in its producer-valid slot was rejected"
+        );
+    }
+    {
+        const auto make_structural_epoch_fixture = [&](std::uint64_t _orphan_sequence,
+                                                       std::uint64_t _admitted,
+                                                       std::uint64_t _loss_last,
+                                                       std::uint64_t _loss_count) {
+            SessionBuilder builder;
+            builder.Begin();
+            builder.Schema(Templates::GpuFrame());
+            builder.Schema(Templates::GpuScope());
+            AddGpuFrame(
+                builder, 1, 1, ProfileGpuFrameStatus::Incomplete, false, _admitted, 0, 0, "RHI drops"
+            );
+            add_scope(builder, 2, 1, 1, 0, 0, 0, 0, "first-root");
+            add_scope(builder, 3, 1, 2, 1, 0, 1, 1, "first-root-child");
+            add_scope(builder, 4, 1, 3, 0, 0, 2, 0, "second-root");
+            add_scope(builder, _orphan_sequence, 1, 6, 99, 0, 5, 3, "second-root-orphan");
+            add_loss(builder, 5, _loss_last, _loss_count);
+            builder.End();
+            return builder;
+        };
+
+        SessionBuilder builder = make_structural_epoch_fixture(6, 5, 5, 1);
+        expect_rejected(
+            LoadChunks(builder.bytes),
+            SessionErrorCode::GpuFrameTotalsMismatch,
+            "an observed depth from a completed root epoch hid a new hidden GPU ancestor"
+        );
+
+        SessionBuilder control        = make_structural_epoch_fixture(7, 6, 6, 2);
+        const Loaded   control_loaded = LoadChunks(control.bytes);
+        Expect(
+            control_loaded.result.status == SessionLoadStatus::Complete && control_loaded.session.Valid(),
+            "a hidden GPU ancestor after a new root epoch was rejected"
+        );
+    }
+    {
+        const auto make_local_assignment_fixture = [&](std::uint64_t _second_child_sequence,
+                                                       std::uint64_t _loss_last) {
+            SessionBuilder builder;
+            builder.Begin();
+            builder.Schema(Templates::GpuFrame());
+            builder.Schema(Templates::GpuScope());
+            AddGpuFrame(builder, 1, 1, ProfileGpuFrameStatus::Incomplete, false, 5, 0, 0, "RHI drops");
+            add_scope(builder, 2, 1, 1, 0, 0, 0, 0, "assignment-root");
+            add_scope(builder, 5, 1, 3, 99, 0, 2, 2, "assignment-orphan-a");
+            add_scope(builder, _second_child_sequence, 1, 5, 100, 0, 4, 1, "assignment-orphan-b");
+            add_loss(builder, 3, _loss_last, 2);
+            builder.End();
+            return builder;
+        };
+
+        SessionBuilder builder = make_local_assignment_fixture(6, 4);
+        expect_rejected(
+            LoadChunks(builder.bytes),
+            SessionErrorCode::GpuFrameTotalsMismatch,
+            "local EDF assignments reused a record-sequence predecessor from an earlier structural segment"
+        );
+
+        SessionBuilder control        = make_local_assignment_fixture(7, 6);
+        const Loaded   control_loaded = LoadChunks(control.bytes);
+        Expect(
+            control_loaded.result.status == SessionLoadStatus::Complete && control_loaded.session.Valid(),
+            "local EDF assignments with compatible record-sequence segments were rejected"
+        );
+
+        const std::uint64_t exact_budget = MinimumPassingTopologyBudget(control.bytes);
+        Expect(
+            exact_budget == 718,
+            "nontrusted virtual-task topology work disagreed with the independent oracle (actual=" +
+                std::to_string(exact_budget) + ")"
+        );
+        SessionLoadOptions exact{};
+        exact.limits.max_topology_work_items = exact_budget;
+        const Loaded exact_loaded            = LoadChunks(control.bytes, {}, exact);
+        Expect(
+            exact_loaded.result.status == SessionLoadStatus::Complete && exact_loaded.session.Valid(),
+            "the exact nontrusted virtual-task topology budget was rejected"
+        );
+        SessionLoadOptions short_by_one = exact;
+        --short_by_one.limits.max_topology_work_items;
+        const Loaded limited = LoadChunks(control.bytes, {}, short_by_one);
+        Expect(
+            limited.result.status == SessionLoadStatus::LimitExceeded &&
+                limited.result.limit_kind == SessionLimitKind::TopologyWorkItems &&
+                !limited.result.HasUsableSession() && !limited.session.Valid(),
+            "nontrusted virtual-task work escaped the topology budget"
+        );
+    }
+    {
+        const auto make_spare_hole_fixture = [&](std::uint64_t _second_child_sequence,
+                                                 std::uint64_t _loss_last) {
+            SessionBuilder builder;
+            builder.Begin();
+            builder.Schema(Templates::GpuFrame());
+            builder.Schema(Templates::GpuScope());
+            AddGpuFrame(builder, 1, 1, ProfileGpuFrameStatus::Incomplete, false, 4, 2, 0, "");
+            add_scope(builder, 5, 1, 2, 99, 0, 3, 1, "first-child-after-spare-holes");
+            add_scope(
+                builder, _second_child_sequence, 1, 3, 100, 0, 5, 1, "second-child-after-first-subtree"
+            );
+            add_loss(builder, 2, _loss_last, 2);
+            builder.End();
+            return builder;
+        };
+
+        SessionBuilder builder = make_spare_hole_fixture(6, 3);
+        expect_rejected(
+            LoadChunks(builder.bytes),
+            SessionErrorCode::GpuFrameTotalsMismatch,
+            "spare early local-order holes hid a later sibling-parent sequence violation"
+        );
+
+        SessionBuilder control        = make_spare_hole_fixture(7, 6);
+        const Loaded   control_loaded = LoadChunks(control.bytes);
+        Expect(
+            control_loaded.result.status == SessionLoadStatus::Complete && control_loaded.session.Valid(),
+            "a sibling parent after spare local-order holes was rejected"
+        );
+    }
+    {
+        const auto make_joint_local_sequence_fixture = [&](std::uint64_t _last_child_local_order,
+                                                           std::uint64_t _dropped_scope_count) {
+            SessionBuilder builder;
+            builder.Begin();
+            builder.Schema(Templates::GpuFrame());
+            builder.Schema(Templates::GpuScope());
+            AddGpuFrame(
+                builder,
+                1,
+                1,
+                ProfileGpuFrameStatus::Incomplete,
+                false,
+                7,
+                _dropped_scope_count,
+                0,
+                "RHI drops"
+            );
+            add_scope(builder, 2, 1, 1, 0, 0, 0, 0, "joint-root");
+            add_scope(builder, 4, 1, 2, 99, 0, 2, 1, "joint-child-b");
+            add_scope(builder, 6, 1, 3, 100, 0, 5, 2, "joint-child-c");
+            add_scope(builder, 8, 1, 4, 101, 0, _last_child_local_order, 1, "joint-child-d");
+            add_loss(builder, 3, 3, 1);
+            add_loss(builder, 5, 5, 1);
+            add_loss(builder, 7, 7, 1);
+            builder.End();
+            return builder;
+        };
+
+        SessionBuilder no_post_c_local_hole = make_joint_local_sequence_fixture(6, 0);
+        expect_rejected(
+            LoadChunks(no_post_c_local_hole.bytes),
+            SessionErrorCode::GpuFrameTotalsMismatch,
+            "two virtual GPU parents reused one pre-C sequence/Loss slot"
+        );
+
+        SessionBuilder joint_control        = make_joint_local_sequence_fixture(7, 1);
+        const Loaded   joint_control_loaded = LoadChunks(joint_control.bytes);
+        Expect(
+            joint_control_loaded.result.status == SessionLoadStatus::Complete &&
+                joint_control_loaded.session.Valid(),
+            "a virtual GPU parent in the post-C local/sequence cell was rejected"
+        );
+
+        const std::uint64_t exact_flow_edges = MinimumPassingTopologyFlowEdges(joint_control.bytes);
+        Expect(
+            exact_flow_edges == 22,
+            "joint topology flow-edge count disagreed with the independent oracle (actual=" +
+                std::to_string(exact_flow_edges) + ")"
+        );
+        SessionLoadOptions exact{};
+        exact.limits.max_topology_flow_edges = exact_flow_edges;
+        const Loaded exact_loaded            = LoadChunks(joint_control.bytes, {}, exact);
+        Expect(
+            exact_loaded.result.status == SessionLoadStatus::Complete && exact_loaded.session.Valid(),
+            "the exact joint topology flow-edge limit was rejected"
+        );
+        SessionLoadOptions short_by_one = exact;
+        --short_by_one.limits.max_topology_flow_edges;
+        const Loaded limited = LoadChunks(joint_control.bytes, {}, short_by_one);
+        Expect(
+            limited.result.status == SessionLoadStatus::LimitExceeded &&
+                limited.result.limit_kind == SessionLimitKind::TopologyFlowEdges &&
+                !limited.result.HasUsableSession() && !limited.session.Valid(),
+            "joint topology flow edges escaped their resource limit or published a partial session"
+        );
+        SessionLoadOptions zero_edges{};
+        zero_edges.limits.max_topology_flow_edges = 0;
+        const Loaded task_limited                 = LoadChunks(joint_control.bytes, {}, zero_edges);
+        Expect(
+            task_limited.result.status == SessionLoadStatus::LimitExceeded &&
+                task_limited.result.limit_kind == SessionLimitKind::TopologyFlowEdges &&
+                !task_limited.result.HasUsableSession() && !task_limited.session.Valid(),
+            "virtual GPU task allocation escaped the zero flow-edge limit"
+        );
+    }
+    {
+        SessionBuilder builder;
+        builder.Begin();
+        builder.Schema(Templates::GpuFrame());
+        builder.Schema(Templates::GpuScope());
+        AddGpuFrame(builder, 1, 1, ProfileGpuFrameStatus::Incomplete, false, 8, 2, 0, "optional empty cell");
+        add_scope(builder, 2, 1, 1, 0, 0, 0, 0, "empty-cell-root");
+        add_scope(builder, 4, 1, 2, 99, 0, 2, 1, "empty-cell-b");
+        add_scope(builder, 6, 1, 3, 100, 0, 5, 2, "empty-cell-c");
+        add_scope(builder, 7, 1, 4, 3, 0, 7, 3, "empty-cell-explicit-c-child");
+        add_scope(builder, 9, 1, 5, 101, 0, 9, 1, "empty-cell-d");
+        add_loss(builder, 3, 3, 1);
+        add_loss(builder, 5, 5, 1);
+        add_loss(builder, 8, 8, 1);
+        builder.End();
+        const Loaded loaded = LoadChunks(builder.bytes);
+        Expect(
+            loaded.result.status == SessionLoadStatus::Complete && loaded.session.Valid(),
+            "an optional empty local/sequence cell rejected a task with a later valid cell"
+        );
+        const std::uint64_t exact_flow_edges = MinimumPassingTopologyFlowEdges(builder.bytes);
+        Expect(
+            exact_flow_edges == 22,
+            "optional-cell topology flow-edge count disagreed with the independent oracle (actual=" +
+                std::to_string(exact_flow_edges) + ")"
+        );
+        SessionLoadOptions exact{};
+        exact.limits.max_topology_flow_edges = exact_flow_edges;
+        const Loaded exact_loaded            = LoadChunks(builder.bytes, {}, exact);
+        Expect(
+            exact_loaded.result.status == SessionLoadStatus::Complete && exact_loaded.session.Valid(),
+            "the exact optional-cell topology flow-edge limit was rejected"
+        );
+        SessionLoadOptions short_by_one = exact;
+        --short_by_one.limits.max_topology_flow_edges;
+        const Loaded limited = LoadChunks(builder.bytes, {}, short_by_one);
+        Expect(
+            limited.result.status == SessionLoadStatus::LimitExceeded &&
+                limited.result.limit_kind == SessionLimitKind::TopologyFlowEdges &&
+                !limited.result.HasUsableSession() && !limited.session.Valid(),
+            "a pruned optional cell polluted the exact flow-edge limit or published a partial session"
+        );
+    }
+    {
+        SessionBuilder builder;
+        builder.Begin();
+        builder.Schema(Templates::GpuFrame());
+        builder.Schema(Templates::GpuScope());
+        AddGpuFrame(
+            builder,
+            std::numeric_limits<std::uint64_t>::max() - 2,
+            1,
+            ProfileGpuFrameStatus::Incomplete,
+            false,
+            2,
+            0,
+            0,
+            ""
+        );
+        add_scope(
+            builder,
+            std::numeric_limits<std::uint64_t>::max(),
+            1,
+            2,
+            99,
+            0,
+            1,
+            1,
+            "forensic-upper-bound-joint-child"
+        );
+
+        SessionLoadOptions forensic{};
+        forensic.allow_forensic_truncation = true;
+        const Loaded loaded                = LoadChunks(builder.bytes, {}, forensic);
+        Expect(
+            loaded.result.status == SessionLoadStatus::ForensicTruncated && loaded.session.Valid(),
+            "forensic joint topology rejected the UINT64_MAX-adjacent sequence hole"
+        );
+
+        const std::uint64_t exact_flow_edges = MinimumPassingTopologyFlowEdges(builder.bytes, forensic);
+        Expect(
+            exact_flow_edges == 6,
+            "forensic joint topology flow-edge count disagreed with the independent oracle (actual=" +
+                std::to_string(exact_flow_edges) + ")"
+        );
+        SessionLoadOptions exact             = forensic;
+        exact.limits.max_topology_flow_edges = exact_flow_edges;
+        const Loaded exact_loaded            = LoadChunks(builder.bytes, {}, exact);
+        Expect(
+            exact_loaded.result.status == SessionLoadStatus::ForensicTruncated &&
+                exact_loaded.session.Valid(),
+            "the exact forensic joint topology flow-edge limit was rejected"
+        );
+        SessionLoadOptions short_by_one = exact;
+        --short_by_one.limits.max_topology_flow_edges;
+        const Loaded limited = LoadChunks(builder.bytes, {}, short_by_one);
+        Expect(
+            limited.result.status == SessionLoadStatus::LimitExceeded &&
+                limited.result.limit_kind == SessionLimitKind::TopologyFlowEdges &&
+                !limited.result.HasUsableSession() && !limited.session.Valid(),
+            "forensic joint topology edges escaped their limit or published a partial session"
+        );
+    }
+
+    {
+        SessionBuilder builder;
+        builder.Begin();
+        builder.Schema(Templates::CpuScope());
+        builder.Schema(Templates::GpuFrame());
+        builder.Schema(Templates::GpuScope());
+        AddCpuScope(builder, 1, 77, "mixed-virtual-cpu-child", 10, 20, 2);
+        AddGpuFrame(builder, 2, 1, ProfileGpuFrameStatus::Incomplete, false, 2, 0, 0, "");
+        add_scope(builder, 4, 1, 2, 99, 0, 1, 1, "mixed-virtual-gpu-child");
+        AddCpuScope(builder, 5, 77, "mixed-virtual-cpu-ancestor", 0, 30, 0);
+        add_loss(builder, 3, 3, 1);
+        builder.End();
+        expect_rejected(
+            LoadChunks(builder.bytes),
+            SessionErrorCode::RecordSequenceInvalid,
+            "an insufficient mixed CPU/nontrusted-GPU Loss total was classified as a GPU-only failure",
+            "CPU/GPU deficits exceed the noticed allocated-record loss budget"
+        );
+    }
+
+    const auto make_cpu_gpu_shared_hole = [&](std::uint64_t _cpu_ancestor_sequence) {
+        SessionBuilder builder;
+        builder.Begin();
+        builder.Schema(Templates::CpuScope());
+        builder.Schema(Templates::GpuFrame());
+        builder.Schema(Templates::GpuScope());
+        AddCpuScope(builder, 1, 77, "compressed-cpu-child", 10, 20, 2);
+        AddGpuFrame(builder, 2, 1, ProfileGpuFrameStatus::Complete, true, 2, 0, 0, "");
+        add_scope(builder, 4, 1, 2, 1, 0, 1, 1, "compressed-gpu-child");
+        AddCpuScope(builder, _cpu_ancestor_sequence, 77, "compressed-cpu-ancestor", 0, 30, 0);
+        return builder;
+    };
+    {
+        SessionBuilder builder = make_cpu_gpu_shared_hole(6);
+        add_loss(builder, 3, 3, 1);
+        builder.End();
+        expect_rejected(
+            LoadChunks(builder.bytes),
+            SessionErrorCode::RecordSequenceInvalid,
+            "an insufficient mixed CPU/GPU Loss total was classified as a GPU-only failure",
+            "CPU/GPU deficits exceed the noticed allocated-record loss budget"
+        );
+    }
+    {
+        SessionBuilder     builder = make_cpu_gpu_shared_hole(5);
+        SessionLoadOptions options{};
+        options.allow_forensic_truncation = true;
+        expect_rejected(
+            LoadChunks(builder.bytes, {}, options),
+            SessionErrorCode::RecordSequenceInvalid,
+            "forensic CPU/GPU topology demands reused one record-sequence hole"
+        );
+
+        SessionBuilder control        = make_cpu_gpu_shared_hole(6);
+        const Loaded   control_loaded = LoadChunks(control.bytes, {}, options);
+        Expect(
+            control_loaded.result.status == SessionLoadStatus::ForensicTruncated &&
+                control_loaded.session.Valid(),
+            "forensic CPU/GPU topology with distinct holes was rejected"
+        );
+    }
+    {
+        SessionBuilder builder = make_cpu_gpu_shared_hole(7);
+        add_loss(builder, 3, 8, 2);
+        builder.End();
+        expect_rejected(
+            LoadChunks(builder.bytes),
+            SessionErrorCode::RecordSequenceInvalid,
+            "structural sequence capacity bypassed incompatible noticed-Loss intervals"
+        );
+
+        SessionBuilder control = make_cpu_gpu_shared_hole(7);
+        add_loss(control, 3, 5, 2);
+        control.End();
+        const Loaded control_loaded = LoadChunks(control.bytes);
+        Expect(
+            control_loaded.result.status == SessionLoadStatus::Complete && control_loaded.session.Valid(),
+            "compatible CPU/GPU structural and noticed-Loss sequence proofs were rejected"
+        );
+
+        const std::uint64_t exact_budget = MinimumPassingTopologyBudget(control.bytes);
+        SessionLoadOptions  exact{};
+        exact.limits.max_topology_work_items = exact_budget;
+        const Loaded exact_loaded            = LoadChunks(control.bytes, {}, exact);
+        Expect(
+            exact_loaded.result.status == SessionLoadStatus::Complete && exact_loaded.session.Valid(),
+            "the exact combined CPU/GPU sequence/Loss topology budget was rejected"
+        );
+
+        SessionLoadOptions short_by_one = exact;
+        --short_by_one.limits.max_topology_work_items;
+        const Loaded limited = LoadChunks(control.bytes, {}, short_by_one);
+        Expect(
+            limited.result.status == SessionLoadStatus::LimitExceeded &&
+                limited.result.limit_kind == SessionLimitKind::TopologyWorkItems &&
+                !limited.result.HasUsableSession() && !limited.session.Valid(),
+            "combined CPU/GPU sequence/Loss work escaped the topology budget"
+        );
+    }
+    {
+        SessionBuilder builder;
+        builder.Begin();
+        builder.Schema(Templates::GpuFrame());
+        AddGpuFrame(
+            builder,
+            std::numeric_limits<std::uint64_t>::max() - 1,
+            1,
+            ProfileGpuFrameStatus::Complete,
+            true,
+            1,
+            0,
+            0,
+            ""
+        );
+        SessionLoadOptions options{};
+        options.allow_forensic_truncation = true;
+        const Loaded loaded               = LoadChunks(builder.bytes, {}, options);
+        Expect(
+            loaded.result.status == SessionLoadStatus::ForensicTruncated && loaded.session.Valid(),
+            "a forensic Complete-frame tail did not consume the inclusive UINT64_MAX sequence slot"
+        );
+
+        SessionBuilder exhausted;
+        exhausted.Begin();
+        exhausted.Schema(Templates::GpuFrame());
+        AddGpuFrame(
+            exhausted,
+            std::numeric_limits<std::uint64_t>::max(),
+            1,
+            ProfileGpuFrameStatus::Complete,
+            true,
+            1,
+            0,
+            0,
+            ""
+        );
+        expect_rejected(
+            LoadChunks(exhausted.bytes, {}, options),
+            SessionErrorCode::GpuFrameTotalsMismatch,
+            "a Complete-frame tail escaped an exhausted record-sequence domain"
+        );
+    }
+    {
+        const auto make_upper_bound_loss_fixture = [&](std::uint64_t _loss_first) {
+            SessionBuilder builder;
+            builder.Begin();
+            builder.Schema(Templates::GpuFrame());
+            AddGpuFrame(
+                builder,
+                std::numeric_limits<std::uint64_t>::max() - 2,
+                1,
+                ProfileGpuFrameStatus::Complete,
+                true,
+                2,
+                0,
+                0,
+                ""
+            );
+            add_loss(builder, _loss_first, std::numeric_limits<std::uint64_t>::max(), 2);
+            builder.End();
+            return builder;
+        };
+
+        SessionBuilder incompatible =
+            make_upper_bound_loss_fixture(std::numeric_limits<std::uint64_t>::max() - 3);
+        expect_rejected(
+            LoadChunks(incompatible.bytes),
+            SessionErrorCode::GpuFrameTotalsMismatch,
+            "Loss below a Complete frame was reused for a UINT64_MAX tail demand"
+        );
+
+        SessionBuilder control = make_upper_bound_loss_fixture(std::numeric_limits<std::uint64_t>::max() - 1);
+        const Loaded   loaded  = LoadChunks(control.bytes);
+        Expect(
+            loaded.result.status == SessionLoadStatus::Complete && loaded.session.Valid(),
+            "a non-forensic Complete-frame tail failed Loss flow at UINT64_MAX"
         );
     }
 }
@@ -4494,31 +5578,37 @@ void TestLimitsAndStickyFailure() {
                 (TopologyBinarySearchWorkOracle(frame_count) + TopologyBinarySearchWorkOracle(domain_count)) +
             TopologySortWorkOracle(gpu_scope_count) + TopologyLinearWorkOracle(gpu_scope_count) * 2;
         const auto gpu_topology_work = [&](std::uint64_t _source_count) {
-            return TopologyLinearWorkOracle(frame_count) * 2 + TopologyLinearWorkOracle(gpu_scope_count) +
+            return TopologyLinearWorkOracle(frame_count) * 3 + TopologyLinearWorkOracle(gpu_scope_count) +
                    TopologySortWorkOracle(gpu_scope_count) + TopologyLinearWorkOracle(gpu_scope_count) +
                    TopologyLinearWorkOracle(gpu_scope_count) * 10 +
-                   TopologyLinearWorkOracle(gpu_scope_count) * 2 +
+                   TopologyLinearWorkOracle(gpu_scope_count) + TopologySortWorkOracle(gpu_scope_count) +
+                   TopologyLinearWorkOracle(gpu_scope_count) + TopologyLinearWorkOracle(gpu_scope_count) * 2 +
                    gpu_scope_count * TopologyBinarySearchWorkOracle(frame_count) +
                    TopologyLinearWorkOracle(gpu_scope_count) + TopologyLinearWorkOracle(gpu_scope_count) * 4 +
                    TopologyLinearWorkOracle(gpu_scope_count) * 3 +
                    TopologyLinearWorkOracle(depth_tree_leaves * 2) +
                    TopologyLinearWorkOracle(gpu_scope_count) + TopologyLinearWorkOracle(depth_tree_leaves) +
                    TopologyLinearWorkOracle(gpu_scope_count) * 3 + TopologyLinearWorkOracle(_source_count) +
-                   TopologySortWorkOracle(_source_count) + TopologyLinearWorkOracle(_source_count) +
-                   TopologyLinearWorkOracle(frame_count) + TopologyBinarySearchWorkOracle(frame_count) +
-                   TopologyLinearWorkOracle(gpu_scope_count) * 2 + TopologyLinearWorkOracle(frame_count);
+                   TopologySortWorkOracle(_source_count) + TopologyLinearWorkOracle(_source_count) * 2 +
+                   TopologyLinearWorkOracle(_source_count) + TopologySortWorkOracle(_source_count) +
+                   TopologyLinearWorkOracle(gpu_scope_count) + TopologyLinearWorkOracle(frame_count) +
+                   TopologyBinarySearchWorkOracle(frame_count) +
+                   TopologyLinearWorkOracle(gpu_scope_count) * 2 + TopologyLinearWorkOracle(frame_count) +
+                   TopologyLinearWorkOracle(frame_count) * 3;
         };
         const std::uint64_t expected_two_source_budget =
             record_index_work + domain_track_work + gpu_topology_work(two_source_count);
         const std::uint64_t expected_one_source_budget =
             record_index_work + domain_track_work + gpu_topology_work(one_source_count);
         Expect(
-            gpu_only_budget == expected_two_source_budget && expected_two_source_budget == 106,
-            "two-source GPU base indexing disagreed with the independent work oracle"
+            gpu_only_budget == expected_two_source_budget && expected_two_source_budget == 124,
+            "two-source GPU base indexing disagreed with the independent work oracle (actual=" +
+                std::to_string(gpu_only_budget) + ", oracle=" + std::to_string(expected_two_source_budget) +
+                ")"
         );
         Expect(
-            one_source_budget == expected_one_source_budget && expected_one_source_budget == 102 &&
-                gpu_only_budget - one_source_budget == 4,
+            one_source_budget == expected_one_source_budget && expected_one_source_budget == 116 &&
+                gpu_only_budget - one_source_budget == 8,
             "GPU source-evidence indexing was not accumulated independently"
         );
         Expect(
@@ -4599,7 +5689,7 @@ void TestLimitsAndStickyFailure() {
             gpu_limited.result.status == SessionLoadStatus::LimitExceeded &&
                 gpu_limited.result.limit_kind == SessionLimitKind::TopologyWorkItems &&
                 !gpu_limited.result.HasUsableSession() && !gpu_limited.session.Valid() &&
-                MinimumPassingTopologyBudget(frame_only.bytes) == 9,
+                MinimumPassingTopologyBudget(frame_only.bytes) == 13,
             "GPU frame indexing escaped its GPU-specific topology budget"
         );
 
@@ -4904,6 +5994,7 @@ int main() {
         TestEnvelopeSchemaAndSequenceContracts();
         TestChecksumAndForensicTruncation();
         TestSemanticTopologyAndLossRecovery();
+        TestGpuProducerSequenceProofs();
         TestReaderPublicationAndAllocatorContracts();
         TestLimitsAndStickyFailure();
         TestFileWrapperAndMoveOwnership();

--- a/source/test/ProfileDumpConsumerTest.cpp
+++ b/source/test/ProfileDumpConsumerTest.cpp
@@ -1,0 +1,1840 @@
+#include "misc/MMemory.h"
+#include "profile/ProfileDump.h"
+#include "profile/ProfileDumpTemplates.h"
+#include "profile_consumer/ProfileSession.h"
+
+#include <algorithm>
+#include <array>
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <limits>
+#include <new>
+#include <optional>
+#include <span>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace {
+
+using namespace Moer::ProfileDump;
+
+void Expect(bool _condition, std::string_view _message) {
+    if (!_condition) {
+        throw std::runtime_error(std::string(_message));
+    }
+}
+
+struct PacketRange {
+    std::size_t offset{0};
+    std::size_t size{0};
+};
+
+class SessionBuilder {
+public:
+    explicit SessionBuilder(std::uint64_t _generation = 7) : generation(_generation) {}
+
+    void Begin() {
+        Moer::Array<std::uint8_t> payload;
+        EncodeSessionBeginPayload(
+            {
+                .generation      = generation,
+                .started_unix_ns = 123456789,
+            },
+            payload
+        );
+        Append(PacketType::SessionBegin, payload);
+    }
+
+    void Schema(const SchemaDescriptor& _schema) {
+        SchemaAt(_schema, next_packet_index);
+    }
+
+    void SchemaAt(const SchemaDescriptor& _schema, std::uint64_t _packet_index) {
+        Moer::Array<std::uint8_t> payload;
+        Expect(
+            EncodeSchemaPayload(_schema, limits, payload) == EncodeStatus::Ok,
+            "fixture schema failed to encode"
+        );
+        AppendAt(PacketType::Schema, payload, _packet_index);
+    }
+
+    void Record(
+        const SchemaDescriptor&         _schema,
+        std::uint64_t                   _sequence,
+        std::span<const FieldValueView> _values
+    ) {
+        Moer::Array<std::uint8_t> payload;
+        Expect(
+            EncodeRecordPayload(
+                ComputeSchemaHash(_schema), _sequence, _schema.fields, _values, limits, payload
+            ) == EncodeStatus::Ok,
+            "fixture record failed to encode"
+        );
+        Append(PacketType::Record, payload);
+        ++record_count;
+    }
+
+    void Loss(const LossNotice& _loss) {
+        Moer::Array<std::uint8_t> payload;
+        EncodeLossPayload(_loss, payload);
+        Append(PacketType::Loss, payload);
+        dropped_count += _loss.record_count;
+    }
+
+    void End(std::optional<SessionEndInfo> _override = std::nullopt) {
+        const SessionEndInfo      end = _override.value_or(SessionEndInfo{
+                 .generation      = generation,
+                 .records_written = record_count,
+                 .records_dropped = dropped_count,
+        });
+        Moer::Array<std::uint8_t> payload;
+        EncodeSessionEndPayload(end, payload);
+        Append(PacketType::SessionEnd, payload);
+    }
+
+    void Append(PacketType _type, std::span<const std::uint8_t> _payload) {
+        AppendAt(_type, _payload, next_packet_index);
+    }
+
+    void AppendAt(PacketType _type, std::span<const std::uint8_t> _payload, std::uint64_t _packet_index) {
+        Moer::Array<std::uint8_t> packet;
+        Expect(
+            WrapPacket(_type, _packet_index, _payload, limits, packet) == EncodeStatus::Ok,
+            "fixture packet failed to wrap"
+        );
+        ranges.push_back({bytes.size(), packet.size()});
+        bytes.insert(bytes.end(), packet.begin(), packet.end());
+        next_packet_index = _packet_index + 1;
+    }
+
+    CodecLimits               limits{};
+    std::uint64_t             generation{7};
+    std::uint64_t             next_packet_index{0};
+    std::uint64_t             record_count{0};
+    std::uint64_t             dropped_count{0};
+    std::vector<std::uint8_t> bytes{};
+    std::vector<PacketRange>  ranges{};
+};
+
+SchemaDescriptor UnknownSchema() {
+    return {
+        .name           = "FutureCounter",
+        .event_type     = "future.counter",
+        .kind           = EventKind::Counter,
+        .channel        = Channel::CpuThread,
+        .schema_version = 9,
+        .fields =
+            {
+                {"value", FieldType::UInt64},
+                {"label", FieldType::String},
+            },
+    };
+}
+
+void AddCpuScope(
+    SessionBuilder&  _builder,
+    std::uint64_t    _sequence,
+    std::uint64_t    _thread,
+    std::string_view _name,
+    std::uint64_t    _begin,
+    std::uint64_t    _end,
+    std::uint32_t    _depth
+) {
+    const std::array<FieldValueView, 5> values{
+        _thread,
+        _name,
+        _begin,
+        _end,
+        _depth,
+    };
+    _builder.Record(Templates::CpuScope(), _sequence, values);
+}
+
+void AddGpuFrame(
+    SessionBuilder&       _builder,
+    std::uint64_t         _sequence,
+    std::uint64_t         _frame_id,
+    ProfileGpuFrameStatus _status,
+    bool                  _valid,
+    std::uint64_t         _admitted,
+    std::uint64_t         _dropped,
+    std::uint64_t         _errors,
+    std::string_view      _reason
+) {
+    const std::array<FieldValueView, 7> values{
+        _frame_id,
+        static_cast<std::uint32_t>(_status),
+        _valid,
+        _admitted,
+        _dropped,
+        _errors,
+        _reason,
+    };
+    _builder.Record(Templates::GpuFrame(), _sequence, values);
+}
+
+void AddGpuScope(
+    SessionBuilder&       _builder,
+    std::uint64_t         _sequence,
+    std::uint64_t         _frame_id,
+    std::uint64_t         _scope_id,
+    std::uint64_t         _parent_scope_id,
+    std::uint64_t         _source_order,
+    std::uint64_t         _local_order,
+    std::uint32_t         _logical_queue,
+    std::uint32_t         _native_queue_id,
+    std::uint32_t         _family_id,
+    std::string_view      _name,
+    ProfileGpuScopeStatus _status,
+    std::uint64_t         _begin_tick,
+    std::uint64_t         _end_tick,
+    std::uint32_t         _valid_bits,
+    double                _tick_period_ns,
+    double                _total_duration_ns,
+    double                _exclusive_duration_ns,
+    std::uint32_t         _depth,
+    std::string_view      _error_reason
+) {
+    const std::array<FieldValueView, 18> values{
+        _frame_id,
+        _scope_id,
+        _parent_scope_id,
+        _source_order,
+        _local_order,
+        _logical_queue,
+        _native_queue_id,
+        _family_id,
+        _name,
+        static_cast<std::uint32_t>(_status),
+        _begin_tick,
+        _end_tick,
+        _valid_bits,
+        _tick_period_ns,
+        _total_duration_ns,
+        _exclusive_duration_ns,
+        _depth,
+        _error_reason,
+    };
+    _builder.Record(Templates::GpuScope(), _sequence, values);
+}
+
+struct Loaded {
+    SessionLoadResult result{};
+    ProfileSession    session{};
+    std::string       diagnostic{};
+};
+
+Loaded LoadChunks(
+    std::span<const std::uint8_t> _bytes,
+    std::span<const std::size_t>  _pattern = {},
+    const SessionLoadOptions&     _options = {}
+) {
+    ProfileSessionReader reader(_options);
+    std::size_t          offset        = 0;
+    std::size_t          pattern_index = 0;
+    while (offset < _bytes.size() && reader.Result().status == SessionLoadStatus::Reading) {
+        const std::size_t requested =
+            _pattern.empty() ? _bytes.size() - offset : _pattern[pattern_index++ % _pattern.size()];
+        const std::size_t       count = std::min(std::max<std::size_t>(requested, 1), _bytes.size() - offset);
+        const SessionLoadResult fed   = reader.Feed(_bytes.subspan(offset, count));
+        offset += count;
+        if (fed.status == SessionLoadStatus::Reading) {
+            Expect(!fed.IsTerminal(), "Reading result was incorrectly reported terminal");
+        }
+    }
+
+    SessionLoadResult result = reader.Result();
+    if (result.status == SessionLoadStatus::Reading) {
+        result = reader.Finish();
+    }
+    Loaded loaded{
+        .result     = result,
+        .diagnostic = std::string(reader.DiagnosticMessage()),
+    };
+    if (result.HasUsableSession()) {
+        loaded.session = reader.TakeSession();
+    }
+    return loaded;
+}
+
+SessionBuilder MakeGoldenSession() {
+    SessionBuilder         builder;
+    const SchemaDescriptor unknown = UnknownSchema();
+    builder.Begin();
+    builder.Schema(Templates::CpuScope());
+    builder.Schema(Templates::GpuFrame());
+    builder.Schema(Templates::GpuScope());
+    builder.Schema(unknown);
+
+    // Record sequence and packet order are deliberately unrelated. CPU child
+    // and GPU child also precede their parents in the file.
+    AddCpuScope(builder, 4, 11, "cpu-child", 120, 150, 1);
+    AddCpuScope(builder, 7, 11, "cpu-parent", 100, 300, 0);
+    AddCpuScope(builder, 2, 22, "cpu-other", 50, 60, 0);
+
+    AddGpuFrame(builder, 10, 100, ProfileGpuFrameStatus::Complete, true, 4, 0, 0, "");
+    AddGpuFrame(builder, 12, 101, ProfileGpuFrameStatus::Invalid, false, 1, 0, 1, "query failed");
+    AddGpuScope(
+        builder,
+        8,
+        100,
+        2,
+        1,
+        5,
+        1,
+        0,
+        3,
+        7,
+        "gfx-child",
+        ProfileGpuScopeStatus::Ready,
+        110,
+        140,
+        64,
+        1.0,
+        30.0,
+        30.0,
+        1,
+        ""
+    );
+    AddGpuScope(
+        builder,
+        14,
+        100,
+        1,
+        0,
+        5,
+        0,
+        0,
+        3,
+        7,
+        "gfx-root",
+        ProfileGpuScopeStatus::Ready,
+        100,
+        200,
+        64,
+        1.0,
+        100.0,
+        70.0,
+        0,
+        ""
+    );
+    AddGpuScope(
+        builder,
+        16,
+        100,
+        3,
+        0,
+        6,
+        0,
+        1,
+        3,
+        7,
+        "compute-root",
+        ProfileGpuScopeStatus::Ready,
+        300,
+        350,
+        64,
+        1.0,
+        50.0,
+        50.0,
+        0,
+        ""
+    );
+    AddGpuScope(
+        builder,
+        18,
+        100,
+        4,
+        0,
+        7,
+        0,
+        0,
+        4,
+        7,
+        "wrapped-root",
+        ProfileGpuScopeStatus::Ready,
+        0xfffffff0ull,
+        0x10ull,
+        32,
+        2.0,
+        64.0,
+        64.0,
+        0,
+        ""
+    );
+    AddGpuScope(
+        builder,
+        20,
+        101,
+        1,
+        0,
+        8,
+        0,
+        0,
+        3,
+        7,
+        "failed-root",
+        ProfileGpuScopeStatus::Error,
+        0,
+        0,
+        0,
+        0.0,
+        0.0,
+        0.0,
+        0,
+        "timestamp unavailable"
+    );
+    const std::array<FieldValueView, 2> unknown_values{
+        std::uint64_t{99},
+        std::string_view("future"),
+    };
+    builder.Record(unknown, 22, unknown_values);
+
+    // Emitted sequence values 4/7/8 are inside this observational interval;
+    // count=2 means the interval is not an exact missing-sequence set.
+    builder.Loss({
+        .first_sequence = 3,
+        .last_sequence  = 9,
+        .record_count   = 2,
+        .value_bytes    = 128,
+        .reason_mask    = static_cast<std::uint32_t>(LossReason::QueueFull),
+    });
+    builder.End();
+    return builder;
+}
+
+const GpuScopeRecord& FindGpuScope(const ProfileSession& _session, std::string_view _name) {
+    const auto found = std::find_if(
+        _session.GpuScopes().begin(),
+        _session.GpuScopes().end(),
+        [&](const GpuScopeRecord& _scope) {
+            return _session.String(_scope.name) == _name;
+        }
+    );
+    Expect(found != _session.GpuScopes().end(), "expected GPU scope was not found");
+    return *found;
+}
+
+void VerifyGolden(const Loaded& _loaded) {
+    Expect(_loaded.result.status == SessionLoadStatus::Complete, "golden session did not complete");
+    Expect(_loaded.session.Valid(), "golden session model is invalid");
+    const ProfileSessionSummary& summary = _loaded.session.Summary();
+    Expect(summary.generation == 7, "session generation is wrong");
+    Expect(summary.unique_schema_count == 4, "unique schema count is wrong");
+    Expect(summary.schema_packet_count == 4, "schema packet count is wrong");
+    Expect(summary.record_count == 11, "record count is wrong");
+    Expect(summary.cpu_scope_count == 3, "CPU scope count is wrong");
+    Expect(summary.gpu_frame_count == 2, "GPU frame count is wrong");
+    Expect(summary.gpu_scope_count == 5, "GPU scope count is wrong");
+    Expect(summary.unknown_record_count == 1, "unknown record count is wrong");
+    Expect(
+        summary.complete_gpu_frame_count == 1 && summary.invalid_gpu_frame_count == 1 &&
+            summary.incomplete_gpu_frame_count == 0 && summary.ready_gpu_scope_count == 4 &&
+            summary.error_gpu_scope_count == 1,
+        "GPU status summary is wrong"
+    );
+    Expect(summary.lost_record_count == 2, "loss count is wrong");
+    Expect(summary.loss_notice_count == 1, "loss notice count is wrong");
+    Expect(summary.orphan_cpu_scope_count == 0, "golden CPU scope became orphaned");
+    Expect(summary.orphan_gpu_scope_count == 0, "golden GPU scope became orphaned");
+    Expect(
+        _loaded.result.input_bytes == _loaded.result.valid_prefix_bytes,
+        "complete session did not consume its exact input"
+    );
+
+    Expect(_loaded.session.CpuTracks().size() == 2, "CPU track count is wrong");
+    const auto cpu_parent = std::find_if(
+        _loaded.session.CpuScopes().begin(),
+        _loaded.session.CpuScopes().end(),
+        [&](const CpuScopeRecord& _scope) {
+            return _loaded.session.String(_scope.name) == "cpu-parent";
+        }
+    );
+    const auto cpu_child = std::find_if(
+        _loaded.session.CpuScopes().begin(),
+        _loaded.session.CpuScopes().end(),
+        [&](const CpuScopeRecord& _scope) {
+            return _loaded.session.String(_scope.name) == "cpu-child";
+        }
+    );
+    Expect(
+        cpu_parent != _loaded.session.CpuScopes().end() && cpu_child != _loaded.session.CpuScopes().end(),
+        "CPU hierarchy records are missing"
+    );
+    Expect(
+        cpu_child->parent_index ==
+            static_cast<std::uint64_t>(cpu_parent - _loaded.session.CpuScopes().begin()),
+        "CPU hierarchy was not reconstructed"
+    );
+
+    Expect(_loaded.session.GpuTracks().size() == 3, "GPU track count is wrong");
+    Expect(_loaded.session.GpuDomains().size() == 2, "GPU domain count is wrong");
+    const GpuScopeRecord& graphics = FindGpuScope(_loaded.session, "gfx-root");
+    const GpuScopeRecord& compute  = FindGpuScope(_loaded.session, "compute-root");
+    const GpuScopeRecord& wrapped  = FindGpuScope(_loaded.session, "wrapped-root");
+    const GpuScopeRecord& child    = FindGpuScope(_loaded.session, "gfx-child");
+    Expect(
+        graphics.domain_index == compute.domain_index,
+        "aliased logical queues did not share their physical timestamp domain"
+    );
+    Expect(
+        graphics.track_index != compute.track_index, "distinct logical queues were merged into one GPU track"
+    );
+    Expect(
+        graphics.domain_index != wrapped.domain_index,
+        "independent native queues were merged into one timestamp domain"
+    );
+    Expect(
+        child.parent_index != kInvalidSessionIndex &&
+            _loaded.session.GpuScopes()[child.parent_index].scope_id == graphics.scope_id,
+        "GPU parent topology was not reconstructed"
+    );
+    Expect(
+        wrapped.begin_tick > wrapped.end_tick && wrapped.valid_bits == 32,
+        "wrapped raw GPU timestamps were rejected or rewritten"
+    );
+    Expect(
+        graphics.logical_queue == ProfileLogicalQueue::Graphics && graphics.source_order == 5 &&
+            graphics.local_order == 0 && graphics.begin_tick == 100 && graphics.end_tick == 200 &&
+            graphics.valid_bits == 64 && graphics.tick_period_ns == 1.0 &&
+            graphics.total_duration_ns == 100.0 && graphics.exclusive_duration_ns == 70.0 &&
+            graphics.depth == 0 && child.source_order == 5 && child.local_order == 1 && child.depth == 1 &&
+            child.total_duration_ns == 30.0 && compute.logical_queue == ProfileLogicalQueue::Compute &&
+            wrapped.native_queue_id == 4,
+        "GPU scope fields changed while materializing the session"
+    );
+    Expect(
+        FindGpuScope(_loaded.session, "failed-root").status == ProfileGpuScopeStatus::Error,
+        "GPU error scope was dropped"
+    );
+    const auto complete_frame = std::find_if(
+        _loaded.session.GpuFrames().begin(),
+        _loaded.session.GpuFrames().end(),
+        [](const GpuFrameRecord& _frame) {
+            return _frame.frame_id == 100;
+        }
+    );
+    const auto invalid_frame = std::find_if(
+        _loaded.session.GpuFrames().begin(),
+        _loaded.session.GpuFrames().end(),
+        [](const GpuFrameRecord& _frame) {
+            return _frame.frame_id == 101;
+        }
+    );
+    Expect(
+        complete_frame != _loaded.session.GpuFrames().end() &&
+            complete_frame->status == ProfileGpuFrameStatus::Complete && complete_frame->valid &&
+            complete_frame->admitted_scope_count == 4 && complete_frame->scope_count == 4 &&
+            complete_frame->error_scope_count == 0 && invalid_frame != _loaded.session.GpuFrames().end() &&
+            invalid_frame->status == ProfileGpuFrameStatus::Invalid && !invalid_frame->valid &&
+            invalid_frame->admitted_scope_count == 1 && invalid_frame->scope_count == 1 &&
+            invalid_frame->error_scope_count == 1 &&
+            _loaded.session.String(invalid_frame->reason) == "query failed",
+        "GPU frame counters or reason changed while materializing the session"
+    );
+    const GpuTimestampDomain& shared_domain = _loaded.session.GpuDomains()[graphics.domain_index];
+    Expect(
+        shared_domain.logical_queue_mask == (ProfileLogicalQueueBit(ProfileLogicalQueue::Graphics) |
+                                             ProfileLogicalQueueBit(ProfileLogicalQueue::Compute)) &&
+            shared_domain.valid_bits == 64 && shared_domain.tick_period_ns == 1.0 &&
+            shared_domain.ready_scope_count == 3,
+        "GPU physical-domain metadata is wrong"
+    );
+    Expect(
+        _loaded.session.Schemas().size() == 4 && _loaded.session.SchemaFields().size() == 32,
+        "schema descriptors were not retained"
+    );
+}
+
+void TestGoldenSessionAndArbitraryChunking() {
+    const SessionBuilder golden = MakeGoldenSession();
+    VerifyGolden(LoadChunks(golden.bytes));
+
+    const std::array<std::size_t, 1> one_byte{1};
+    VerifyGolden(LoadChunks(golden.bytes, one_byte));
+
+    const std::array<std::size_t, 8> mixed{
+        31,
+        1,
+        2,
+        3,
+        5,
+        17,
+        64,
+        257,
+    };
+    VerifyGolden(LoadChunks(golden.bytes, mixed));
+}
+
+void TestEnvelopeSchemaAndSequenceContracts() {
+    {
+        SessionBuilder builder = MakeGoldenSession();
+        builder.bytes.push_back(0xaa);
+        const Loaded loaded = LoadChunks(builder.bytes);
+        Expect(
+            loaded.result.status == SessionLoadStatus::ProtocolViolation,
+            "trailing byte after SessionEnd was accepted"
+        );
+    }
+    {
+        SessionBuilder builder;
+        builder.Begin();
+        builder.SchemaAt(UnknownSchema(), 3);
+        const Loaded loaded = LoadChunks(builder.bytes);
+        Expect(loaded.result.status == SessionLoadStatus::ProtocolViolation, "packet index gap was accepted");
+    }
+    {
+        SessionBuilder builder;
+        builder.Begin();
+        builder.Begin();
+        const Loaded loaded = LoadChunks(builder.bytes);
+        Expect(
+            loaded.result.status == SessionLoadStatus::ProtocolViolation,
+            "duplicate SessionBegin was accepted"
+        );
+    }
+    {
+        SessionBuilder         builder;
+        const SchemaDescriptor unknown = UnknownSchema();
+        builder.Begin();
+        builder.Schema(unknown);
+        builder.Schema(unknown);
+        const std::array<FieldValueView, 2> values{
+            std::uint64_t{1},
+            std::string_view("x"),
+        };
+        builder.Record(unknown, 9, values);
+        builder.End();
+        const Loaded loaded = LoadChunks(builder.bytes);
+        Expect(
+            loaded.result.status == SessionLoadStatus::Complete &&
+                loaded.session.Summary().schema_packet_count == 2 &&
+                loaded.session.Summary().unique_schema_count == 1,
+            "exact duplicate schema was not handled deterministically"
+        );
+    }
+    {
+        SessionBuilder         builder;
+        const SchemaDescriptor unknown = UnknownSchema();
+        builder.Begin();
+        const std::array<FieldValueView, 2> values{
+            std::uint64_t{1},
+            std::string_view("x"),
+        };
+        builder.Record(unknown, 1, values);
+        const Loaded loaded = LoadChunks(builder.bytes);
+        Expect(
+            loaded.result.status == SessionLoadStatus::ProtocolViolation &&
+                loaded.result.codec_status == DecodeStatus::UnknownSchema,
+            "record referencing an unregistered schema was accepted"
+        );
+    }
+    {
+        SessionBuilder         builder;
+        const SchemaDescriptor unknown = UnknownSchema();
+        builder.Begin();
+        builder.Schema(unknown);
+        const std::array<FieldValueView, 2> first{
+            std::uint64_t{1},
+            std::string_view("a"),
+        };
+        const std::array<FieldValueView, 2> second{
+            std::uint64_t{2},
+            std::string_view("b"),
+        };
+        builder.Record(unknown, 5, first);
+        builder.Record(unknown, 5, second);
+        builder.End();
+        const Loaded loaded = LoadChunks(builder.bytes);
+        Expect(
+            loaded.result.status == SessionLoadStatus::ProtocolViolation,
+            "duplicate record sequence was accepted"
+        );
+    }
+    {
+        SessionBuilder builder;
+        builder.Begin();
+        builder.End(SessionEndInfo{
+            .generation      = builder.generation,
+            .records_written = 1,
+            .records_dropped = 0,
+        });
+        const Loaded loaded = LoadChunks(builder.bytes);
+        Expect(
+            loaded.result.status == SessionLoadStatus::ProtocolViolation,
+            "incorrect SessionEnd totals were accepted"
+        );
+    }
+    {
+        SessionBuilder builder;
+        builder.Begin();
+        builder.End(SessionEndInfo{
+            .generation      = builder.generation,
+            .records_written = 0,
+            .records_dropped = 1,
+        });
+        const Loaded loaded = LoadChunks(builder.bytes);
+        Expect(
+            loaded.result.status == SessionLoadStatus::Complete &&
+                loaded.session.Summary().session_end_records_dropped == 1 &&
+                loaded.session.Summary().lost_record_count == 0 &&
+                loaded.session.Summary().unnotified_drop_count == 1,
+            "producer drops without Loss packets were rejected or misclassified"
+        );
+    }
+    {
+        SessionBuilder builder;
+        builder.Begin();
+        builder.Loss({
+            .first_sequence = 1,
+            .last_sequence  = 2,
+            .record_count   = 2,
+            .value_bytes    = 16,
+            .reason_mask    = static_cast<std::uint32_t>(LossReason::QueueFull),
+        });
+        builder.End(SessionEndInfo{
+            .generation      = builder.generation,
+            .records_written = 0,
+            .records_dropped = 1,
+        });
+        const Loaded loaded = LoadChunks(builder.bytes);
+        Expect(
+            loaded.result.status == SessionLoadStatus::ProtocolViolation &&
+                loaded.result.error_code == SessionErrorCode::SessionEndTotalsMismatch,
+            "SessionEnd drop total smaller than noticed losses was accepted"
+        );
+    }
+}
+
+void TestChecksumAndForensicTruncation() {
+    {
+        const SessionBuilder golden = MakeGoldenSession();
+        SessionLoadOptions   options{};
+        options.allow_forensic_truncation = true;
+        const Loaded loaded               = LoadChunks(golden.bytes, {}, options);
+        Expect(
+            loaded.result.status == SessionLoadStatus::Complete,
+            "forensic opt-in downgraded a complete session"
+        );
+    }
+    {
+        SessionBuilder    builder = MakeGoldenSession();
+        const PacketRange record  = builder.ranges[5];
+        builder.bytes[record.offset + kPacketHeaderBytes] ^= 0x80;
+        SessionLoadOptions options{};
+        options.allow_forensic_truncation = true;
+        const Loaded loaded               = LoadChunks(builder.bytes, {}, options);
+        Expect(
+            loaded.result.status == SessionLoadStatus::CorruptData &&
+                loaded.result.codec_status == DecodeStatus::ChecksumMismatch,
+            "payload CRC failure was downgraded to forensic data"
+        );
+    }
+    {
+        SessionBuilder builder;
+        builder.Begin();
+        SessionLoadOptions options{};
+        options.allow_forensic_truncation = true;
+        const Loaded loaded               = LoadChunks(builder.bytes, {}, options);
+        Expect(
+            loaded.result.status == SessionLoadStatus::ForensicTruncated &&
+                loaded.result.incomplete_reason == SessionIncompleteReason::MissingSessionEnd &&
+                loaded.session.Valid(),
+            "clean prefix without SessionEnd was not exposed for forensics"
+        );
+    }
+    {
+        SessionBuilder builder;
+        builder.Begin();
+        builder.Schema(UnknownSchema());
+        builder.bytes.resize(builder.ranges[1].offset + kPacketHeaderBytes - 1);
+        SessionLoadOptions options{};
+        options.allow_forensic_truncation = true;
+        const Loaded loaded               = LoadChunks(builder.bytes, {}, options);
+        Expect(
+            loaded.result.status == SessionLoadStatus::ForensicTruncated &&
+                loaded.result.incomplete_reason == SessionIncompleteReason::TruncatedHeader,
+            "truncated header was classified incorrectly"
+        );
+    }
+    {
+        SessionBuilder builder;
+        builder.Begin();
+        builder.Schema(UnknownSchema());
+        builder.bytes.resize(builder.bytes.size() - 1);
+        SessionLoadOptions options{};
+        options.allow_forensic_truncation = true;
+        const Loaded loaded               = LoadChunks(builder.bytes, {}, options);
+        Expect(
+            loaded.result.status == SessionLoadStatus::ForensicTruncated &&
+                loaded.result.incomplete_reason == SessionIncompleteReason::TruncatedPayload,
+            "truncated payload was classified incorrectly"
+        );
+    }
+    {
+        SessionLoadOptions options{};
+        options.allow_forensic_truncation = true;
+        const Loaded loaded               = LoadChunks({}, {}, options);
+        Expect(
+            loaded.result.status == SessionLoadStatus::CorruptData && !loaded.result.HasUsableSession(),
+            "empty input was exposed as a forensic session"
+        );
+    }
+    {
+        SessionBuilder builder;
+        builder.Begin();
+        builder.Schema(Templates::CpuScope());
+        AddCpuScope(builder, 1, 9, "forensic-child", 10, 20, 1);
+
+        SessionLoadOptions options{};
+        options.allow_forensic_truncation = true;
+        const Loaded loaded               = LoadChunks(builder.bytes, {}, options);
+        Expect(
+            loaded.result.status == SessionLoadStatus::ForensicTruncated &&
+                loaded.session.Summary().orphan_cpu_scope_count == 1 &&
+                loaded.result.incomplete_byte_offset == builder.bytes.size() &&
+                loaded.result.incomplete_packet_index == builder.next_packet_index,
+            "forensic CPU topology did not retain a clean orphaned prefix"
+        );
+    }
+    {
+        SessionBuilder builder;
+        builder.Begin();
+        builder.Schema(Templates::GpuFrame());
+        builder.Schema(Templates::GpuScope());
+        AddGpuFrame(builder, 1, 3, ProfileGpuFrameStatus::Complete, true, 2, 0, 0, "");
+        AddGpuScope(
+            builder,
+            2,
+            3,
+            2,
+            1,
+            0,
+            1,
+            0,
+            0,
+            0,
+            "forensic-gpu-child",
+            ProfileGpuScopeStatus::Ready,
+            10,
+            20,
+            64,
+            1.0,
+            10.0,
+            10.0,
+            1,
+            ""
+        );
+
+        SessionLoadOptions options{};
+        options.allow_forensic_truncation = true;
+        const Loaded loaded               = LoadChunks(builder.bytes, {}, options);
+        Expect(
+            loaded.result.status == SessionLoadStatus::ForensicTruncated &&
+                loaded.session.Summary().orphan_gpu_scope_count == 1,
+            "forensic GPU topology did not retain a clean partial frame"
+        );
+    }
+}
+
+void TestSemanticTopologyAndLossRecovery() {
+    {
+        SessionBuilder builder;
+        builder.Begin();
+        builder.Schema(Templates::CpuScope());
+        AddCpuScope(builder, 1, 1, "bad", 20, 10, 0);
+        builder.End();
+        const Loaded loaded = LoadChunks(builder.bytes);
+        Expect(
+            loaded.result.status == SessionLoadStatus::ProtocolViolation, "reversed CPU interval was accepted"
+        );
+    }
+    {
+        SessionBuilder builder;
+        builder.Begin();
+        builder.Schema(Templates::GpuFrame());
+        builder.Schema(Templates::GpuScope());
+        AddGpuFrame(builder, 1, 1, ProfileGpuFrameStatus::Complete, true, 1, 0, 0, "");
+        AddGpuScope(
+            builder,
+            2,
+            1,
+            2,
+            99,
+            0,
+            1,
+            0,
+            0,
+            0,
+            "orphan",
+            ProfileGpuScopeStatus::Ready,
+            1,
+            2,
+            64,
+            1.0,
+            1.0,
+            1.0,
+            1,
+            ""
+        );
+        builder.End();
+        const Loaded loaded = LoadChunks(builder.bytes);
+        Expect(
+            loaded.result.status == SessionLoadStatus::ProtocolViolation,
+            "missing GPU parent without loss was accepted"
+        );
+    }
+    {
+        SessionBuilder builder;
+        builder.Begin();
+        builder.Schema(Templates::GpuFrame());
+        builder.Schema(Templates::GpuScope());
+        AddGpuFrame(builder, 1, 1, ProfileGpuFrameStatus::Complete, true, 1, 0, 0, "");
+        AddGpuScope(
+            builder,
+            2,
+            1,
+            2,
+            99,
+            0,
+            1,
+            0,
+            0,
+            0,
+            "orphan",
+            ProfileGpuScopeStatus::Ready,
+            1,
+            2,
+            64,
+            1.0,
+            1.0,
+            1.0,
+            1,
+            ""
+        );
+        builder.Loss({
+            .first_sequence = 3,
+            .last_sequence  = 3,
+            .record_count   = 1,
+            .value_bytes    = 8,
+            .reason_mask    = static_cast<std::uint32_t>(LossReason::QueueFull),
+        });
+        builder.End();
+        const Loaded loaded = LoadChunks(builder.bytes);
+        Expect(
+            loaded.result.status == SessionLoadStatus::Complete &&
+                loaded.session.Summary().orphan_gpu_scope_count == 1,
+            "loss-tolerant GPU orphan was not retained"
+        );
+    }
+    {
+        SessionBuilder builder;
+        builder.Begin();
+        builder.Schema(Templates::GpuFrame());
+        builder.Schema(Templates::GpuScope());
+        AddGpuFrame(builder, 1, 1, ProfileGpuFrameStatus::Complete, true, 2, 0, 0, "");
+        AddGpuScope(
+            builder,
+            2,
+            1,
+            1,
+            0,
+            0,
+            0,
+            0,
+            1,
+            1,
+            "a",
+            ProfileGpuScopeStatus::Ready,
+            1,
+            2,
+            64,
+            1.0,
+            1.0,
+            1.0,
+            0,
+            ""
+        );
+        AddGpuScope(
+            builder,
+            3,
+            1,
+            2,
+            0,
+            1,
+            0,
+            1,
+            1,
+            1,
+            "b",
+            ProfileGpuScopeStatus::Ready,
+            1,
+            2,
+            32,
+            2.0,
+            2.0,
+            2.0,
+            0,
+            ""
+        );
+        builder.End();
+        const Loaded loaded = LoadChunks(builder.bytes);
+        Expect(
+            loaded.result.status == SessionLoadStatus::ProtocolViolation,
+            "conflicting capability metadata in one physical domain was accepted"
+        );
+    }
+    {
+        struct InvalidFrameCase {
+            ProfileGpuFrameStatus status;
+            bool                  valid;
+            std::uint64_t         admitted;
+            std::uint64_t         dropped;
+            std::uint64_t         errors;
+        };
+        const std::array<InvalidFrameCase, 3> cases{
+            InvalidFrameCase{ProfileGpuFrameStatus::Complete, true, 0, 1, 0},
+            InvalidFrameCase{ProfileGpuFrameStatus::Complete, true, 1, 0, 1},
+            InvalidFrameCase{ProfileGpuFrameStatus::Incomplete, false, 1, 0, 1},
+        };
+        for (const InvalidFrameCase& invalid : cases) {
+            SessionBuilder builder;
+            builder.Begin();
+            builder.Schema(Templates::GpuFrame());
+            AddGpuFrame(
+                builder,
+                1,
+                1,
+                invalid.status,
+                invalid.valid,
+                invalid.admitted,
+                invalid.dropped,
+                invalid.errors,
+                "invalid counters"
+            );
+            builder.End();
+            const Loaded loaded = LoadChunks(builder.bytes);
+            Expect(
+                loaded.result.status == SessionLoadStatus::ProtocolViolation &&
+                    loaded.result.error_code == SessionErrorCode::GpuFrameStatusInvalid,
+                "GpuFrame status/counter contradiction was accepted"
+            );
+        }
+    }
+    {
+        SessionBuilder builder;
+        builder.Begin();
+        builder.Schema(Templates::GpuFrame());
+        builder.Schema(Templates::GpuScope());
+        AddGpuFrame(builder, 1, 1, ProfileGpuFrameStatus::Complete, true, 1, 0, 0, "");
+        AddGpuScope(
+            builder,
+            2,
+            1,
+            1,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            "bad-duration",
+            ProfileGpuScopeStatus::Ready,
+            10,
+            20,
+            64,
+            2.0,
+            19.0,
+            19.0,
+            0,
+            ""
+        );
+        builder.End();
+        const Loaded loaded = LoadChunks(builder.bytes);
+        Expect(
+            loaded.result.status == SessionLoadStatus::ProtocolViolation &&
+                loaded.result.error_code == SessionErrorCode::GpuScopeTimingInvalid,
+            "GpuScope raw ticks and duration contradiction was accepted"
+        );
+    }
+    {
+        SessionBuilder builder;
+        builder.Begin();
+        builder.Schema(Templates::GpuFrame());
+        builder.Schema(Templates::GpuScope());
+        AddGpuFrame(builder, 1, 1, ProfileGpuFrameStatus::Complete, true, 1, 0, 0, "");
+        AddGpuScope(
+            builder,
+            2,
+            1,
+            2,
+            1,
+            0,
+            1,
+            0,
+            0,
+            0,
+            "zero-depth-child",
+            ProfileGpuScopeStatus::Ready,
+            10,
+            20,
+            64,
+            1.0,
+            10.0,
+            10.0,
+            0,
+            ""
+        );
+        builder.End();
+        const Loaded loaded = LoadChunks(builder.bytes);
+        Expect(
+            loaded.result.status == SessionLoadStatus::ProtocolViolation &&
+                loaded.result.error_code == SessionErrorCode::GpuScopeParentInvalid,
+            "non-root zero-depth GpuScope was accepted"
+        );
+    }
+    for (const bool forensic : {false, true}) {
+        SessionBuilder builder;
+        builder.Begin();
+        builder.Schema(Templates::GpuFrame());
+        builder.Schema(Templates::GpuScope());
+        AddGpuFrame(builder, 1, 1, ProfileGpuFrameStatus::Complete, true, 1, 0, 0, "");
+        AddGpuScope(
+            builder,
+            2,
+            1,
+            1,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            "bad-root-depth",
+            ProfileGpuScopeStatus::Ready,
+            10,
+            20,
+            64,
+            1.0,
+            10.0,
+            10.0,
+            1,
+            ""
+        );
+        SessionLoadOptions options{};
+        if (forensic) {
+            options.allow_forensic_truncation = true;
+        } else {
+            builder.Loss({
+                .first_sequence = 3,
+                .last_sequence  = 3,
+                .record_count   = 1,
+                .value_bytes    = 8,
+                .reason_mask    = static_cast<std::uint32_t>(LossReason::QueueFull),
+            });
+            builder.End();
+        }
+        const Loaded loaded = LoadChunks(builder.bytes, {}, options);
+        Expect(
+            loaded.result.status == SessionLoadStatus::ProtocolViolation &&
+                loaded.result.error_code == SessionErrorCode::GpuScopeRootDepthInvalid,
+            "GpuScope root/depth contradiction was downgraded by Loss or forensic mode"
+        );
+    }
+    {
+        SessionBuilder builder;
+        builder.Begin();
+        builder.Schema(Templates::GpuFrame());
+        builder.Schema(Templates::GpuScope());
+        AddGpuFrame(builder, 1, 1, ProfileGpuFrameStatus::Invalid, false, 2, 0, 0, "topology invalid");
+        AddGpuScope(
+            builder,
+            2,
+            1,
+            1,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            "surviving-root",
+            ProfileGpuScopeStatus::Ready,
+            10,
+            20,
+            64,
+            1.0,
+            10.0,
+            10.0,
+            0,
+            ""
+        );
+        builder.End();
+        const Loaded loaded = LoadChunks(builder.bytes);
+        Expect(
+            loaded.result.status == SessionLoadStatus::Complete &&
+                loaded.session.Summary().invalid_gpu_frame_count == 1 &&
+                loaded.session.GpuFrames().front().scope_count == 1,
+            "valid producer Invalid frame with omitted unreachable scopes was rejected"
+        );
+    }
+    {
+        SessionBuilder builder;
+        builder.Begin();
+        builder.Schema(Templates::GpuFrame());
+        builder.Schema(Templates::GpuScope());
+        AddGpuFrame(builder, 1, 1, ProfileGpuFrameStatus::Complete, true, 1, 0, 0, "");
+        for (std::uint64_t scope_id = 1; scope_id <= 2; ++scope_id) {
+            AddGpuScope(
+                builder,
+                1 + scope_id,
+                1,
+                scope_id,
+                0,
+                scope_id,
+                0,
+                0,
+                0,
+                0,
+                "extra-root",
+                ProfileGpuScopeStatus::Ready,
+                scope_id * 10,
+                scope_id * 10 + 1,
+                64,
+                1.0,
+                1.0,
+                1.0,
+                0,
+                ""
+            );
+        }
+        builder.Loss({
+            .first_sequence = 4,
+            .last_sequence  = 4,
+            .record_count   = 1,
+            .value_bytes    = 8,
+            .reason_mask    = static_cast<std::uint32_t>(LossReason::QueueFull),
+        });
+        builder.End();
+        const Loaded loaded = LoadChunks(builder.bytes);
+        Expect(
+            loaded.result.status == SessionLoadStatus::ProtocolViolation &&
+                loaded.result.error_code == SessionErrorCode::GpuFrameTotalsMismatch,
+            "Loss allowed more observed GPU scopes than the frame declared"
+        );
+    }
+    {
+        SessionBuilder builder;
+        builder.Begin();
+        builder.Schema(Templates::GpuFrame());
+        builder.Schema(Templates::GpuScope());
+        AddGpuFrame(builder, 1, 1, ProfileGpuFrameStatus::Complete, true, 2, 0, 0, "");
+        AddGpuScope(
+            builder,
+            2,
+            1,
+            1,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            "surviving-root",
+            ProfileGpuScopeStatus::Ready,
+            10,
+            20,
+            64,
+            1.0,
+            10.0,
+            10.0,
+            0,
+            ""
+        );
+        builder.End(SessionEndInfo{
+            .generation      = builder.generation,
+            .records_written = builder.record_count,
+            .records_dropped = 1,
+        });
+        const Loaded loaded = LoadChunks(builder.bytes);
+        Expect(
+            loaded.result.status == SessionLoadStatus::Complete &&
+                loaded.session.Summary().unnotified_drop_count == 1,
+            "unnotified SessionEnd drops did not explain an undersized GPU frame"
+        );
+    }
+}
+
+void TestReaderPublicationAndAllocatorContracts() {
+    const SessionBuilder    golden = MakeGoldenSession();
+    ProfileSessionReader    reader;
+    const PacketRange       begin = golden.ranges.front();
+    const SessionLoadResult first =
+        reader.Feed(std::span<const std::uint8_t>(golden.bytes).first(begin.size));
+    Expect(first.status == SessionLoadStatus::Reading, "reader did not remain active after SessionBegin");
+
+    const ProfileSession& unpublished        = reader.Session();
+    const auto            unpublished_scopes = unpublished.CpuScopes();
+    Expect(
+        !unpublished.Valid() && unpublished_scopes.empty() && unpublished.Schemas().empty(),
+        "reader exposed mutable session storage before Finish"
+    );
+
+    const SessionLoadResult rest =
+        reader.Feed(std::span<const std::uint8_t>(golden.bytes).subspan(begin.size));
+    Expect(rest.status == SessionLoadStatus::Reading, "reader published before EOF was established");
+    ProfileSession early_take = reader.TakeSession();
+    Expect(
+        !reader.Session().Valid() && reader.Session().CpuScopes().empty() && !early_take.Valid(),
+        "reader exposed or transferred the model after SessionEnd but before Finish"
+    );
+    const SessionLoadResult finished = reader.Finish();
+    Expect(
+        finished.status == SessionLoadStatus::Complete && reader.Session().Valid() &&
+            unpublished_scopes.empty(),
+        "reader did not atomically publish the immutable session at Finish"
+    );
+
+    bool malloc_n_overflow_threw = false;
+    try {
+        void* allocation = Memory::MallocN(std::numeric_limits<std::size_t>::max(), 2);
+        Memory::Free(allocation);
+    } catch (const std::bad_array_new_length&) {
+        malloc_n_overflow_threw = true;
+    }
+    Expect(malloc_n_overflow_threw, "Memory::MallocN overflow did not throw std::bad_array_new_length");
+
+    bool allocator_overflow_threw = false;
+    try {
+        MoerStlAllocator<std::uint64_t> allocator;
+        [[maybe_unused]] auto*          allocation = allocator.allocate(allocator.max_size() + 1);
+    } catch (const std::bad_alloc&) {
+        allocator_overflow_threw = true;
+    }
+    Expect(
+        allocator_overflow_threw, "MoerStlAllocator overflow did not follow the standard exception contract"
+    );
+}
+
+void TestLimitsAndStickyFailure() {
+    const SessionBuilder golden   = MakeGoldenSession();
+    const Loaded         baseline = LoadChunks(golden.bytes);
+    Expect(baseline.result.status == SessionLoadStatus::Complete, "limit baseline did not load");
+    const auto expect_complete = [&](const SessionLoadOptions& _options, std::string_view _message) {
+        Expect(LoadChunks(golden.bytes, {}, _options).result.status == SessionLoadStatus::Complete, _message);
+    };
+    {
+        SessionLoadOptions options{};
+        options.limits.max_packets = golden.ranges.size();
+        expect_complete(options, "exact packet limit was rejected");
+    }
+    {
+        SessionLoadOptions options{};
+        options.limits.max_schemas = baseline.session.Schemas().size();
+        expect_complete(options, "exact schema count limit was rejected");
+        --options.limits.max_schemas;
+        const Loaded loaded = LoadChunks(golden.bytes, {}, options);
+        Expect(
+            loaded.result.status == SessionLoadStatus::LimitExceeded &&
+                loaded.result.limit_kind == SessionLimitKind::Schemas,
+            "schema count boundary was not enforced"
+        );
+    }
+    {
+        std::uint64_t schema_payload_bytes = 0;
+        for (std::size_t index = 1; index <= 4; ++index) {
+            schema_payload_bytes += golden.ranges[index].size - kPacketHeaderBytes;
+        }
+        SessionLoadOptions options{};
+        options.limits.max_schema_bytes = schema_payload_bytes;
+        expect_complete(options, "exact schema byte limit was rejected");
+        --options.limits.max_schema_bytes;
+        const Loaded loaded = LoadChunks(golden.bytes, {}, options);
+        Expect(
+            loaded.result.status == SessionLoadStatus::LimitExceeded &&
+                loaded.result.limit_kind == SessionLimitKind::SchemaBytes,
+            "schema byte boundary was not enforced"
+        );
+    }
+    {
+        SessionLoadOptions options{};
+        options.limits.max_records = baseline.session.Summary().record_count;
+        expect_complete(options, "exact record limit was rejected");
+        --options.limits.max_records;
+        const Loaded loaded = LoadChunks(golden.bytes, {}, options);
+        Expect(
+            loaded.result.status == SessionLoadStatus::LimitExceeded &&
+                loaded.result.limit_kind == SessionLimitKind::Records,
+            "record boundary was not enforced"
+        );
+    }
+    {
+        SessionLoadOptions options{};
+        options.limits.max_loss_notices = baseline.session.Losses().size();
+        expect_complete(options, "exact Loss notice limit was rejected");
+        --options.limits.max_loss_notices;
+        const Loaded loaded = LoadChunks(golden.bytes, {}, options);
+        Expect(
+            loaded.result.status == SessionLoadStatus::LimitExceeded &&
+                loaded.result.limit_kind == SessionLimitKind::LossNotices,
+            "Loss notice boundary was not enforced"
+        );
+    }
+    {
+        SessionLoadOptions options{};
+        options.limits.max_cpu_scopes = baseline.session.CpuScopes().size();
+        expect_complete(options, "exact CPU scope limit was rejected");
+        --options.limits.max_cpu_scopes;
+        const Loaded loaded = LoadChunks(golden.bytes, {}, options);
+        Expect(
+            loaded.result.status == SessionLoadStatus::LimitExceeded &&
+                loaded.result.limit_kind == SessionLimitKind::CpuScopes,
+            "CPU scope boundary was not enforced"
+        );
+    }
+    {
+        SessionLoadOptions options{};
+        options.limits.max_gpu_frames = baseline.session.GpuFrames().size();
+        expect_complete(options, "exact GPU frame limit was rejected");
+        --options.limits.max_gpu_frames;
+        const Loaded loaded = LoadChunks(golden.bytes, {}, options);
+        Expect(
+            loaded.result.status == SessionLoadStatus::LimitExceeded &&
+                loaded.result.limit_kind == SessionLimitKind::GpuFrames,
+            "GPU frame boundary was not enforced"
+        );
+    }
+    {
+        SessionLoadOptions options{};
+        options.limits.max_gpu_scopes = baseline.session.GpuScopes().size();
+        expect_complete(options, "exact GPU scope limit was rejected");
+        --options.limits.max_gpu_scopes;
+        const Loaded loaded = LoadChunks(golden.bytes, {}, options);
+        Expect(
+            loaded.result.status == SessionLoadStatus::LimitExceeded &&
+                loaded.result.limit_kind == SessionLimitKind::GpuScopes,
+            "GPU scope boundary was not enforced"
+        );
+    }
+    {
+        SessionLoadOptions options{};
+        options.limits.max_cpu_tracks = baseline.session.CpuTracks().size();
+        expect_complete(options, "exact CPU track limit was rejected");
+        --options.limits.max_cpu_tracks;
+        const Loaded loaded = LoadChunks(golden.bytes, {}, options);
+        Expect(
+            loaded.result.status == SessionLoadStatus::LimitExceeded &&
+                loaded.result.limit_kind == SessionLimitKind::CpuTracks,
+            "CPU track boundary was not enforced"
+        );
+    }
+    {
+        SessionLoadOptions options{};
+        options.limits.max_gpu_tracks = baseline.session.GpuTracks().size();
+        expect_complete(options, "exact GPU track limit was rejected");
+        --options.limits.max_gpu_tracks;
+        const Loaded loaded = LoadChunks(golden.bytes, {}, options);
+        Expect(
+            loaded.result.status == SessionLoadStatus::LimitExceeded &&
+                loaded.result.limit_kind == SessionLimitKind::GpuTracks,
+            "GPU track boundary was not enforced"
+        );
+    }
+    {
+        SessionLoadOptions options{};
+        options.limits.max_gpu_domains = baseline.session.GpuDomains().size();
+        expect_complete(options, "exact GPU domain limit was rejected");
+    }
+    {
+        SessionLoadOptions options{};
+        options.limits.max_logical_model_bytes = baseline.session.Summary().logical_model_bytes;
+        expect_complete(options, "exact logical model byte limit was rejected");
+        --options.limits.max_logical_model_bytes;
+        const Loaded loaded = LoadChunks(golden.bytes, {}, options);
+        Expect(
+            loaded.result.status == SessionLoadStatus::LimitExceeded &&
+                loaded.result.limit_kind == SessionLimitKind::LogicalModelBytes,
+            "logical model byte boundary was not enforced"
+        );
+    }
+    {
+        const SchemaDescriptor compact_schema{
+            .name           = "a",
+            .event_type     = "bb",
+            .kind           = EventKind::Counter,
+            .channel        = Channel::CpuThread,
+            .schema_version = 1,
+            .fields         = {{"c", FieldType::UInt64}},
+        };
+        SessionBuilder compact;
+        compact.Begin();
+        compact.Schema(compact_schema);
+        compact.End();
+
+        SessionLoadOptions options{};
+        options.limits.max_unique_strings = 3;
+        Expect(
+            LoadChunks(compact.bytes, {}, options).result.status == SessionLoadStatus::Complete,
+            "exact unique string limit was rejected"
+        );
+        options.limits.max_unique_strings = 2;
+        Loaded loaded                     = LoadChunks(compact.bytes, {}, options);
+        Expect(
+            loaded.result.status == SessionLoadStatus::LimitExceeded &&
+                loaded.result.limit_kind == SessionLimitKind::UniqueStrings,
+            "unique string boundary was not enforced"
+        );
+
+        options                         = {};
+        options.limits.max_string_bytes = 4;
+        Expect(
+            LoadChunks(compact.bytes, {}, options).result.status == SessionLoadStatus::Complete,
+            "exact cumulative string byte limit was rejected"
+        );
+        options.limits.max_string_bytes = 3;
+        loaded                          = LoadChunks(compact.bytes, {}, options);
+        Expect(
+            loaded.result.status == SessionLoadStatus::LimitExceeded &&
+                loaded.result.limit_kind == SessionLimitKind::StringBytes,
+            "cumulative string byte boundary was not enforced"
+        );
+
+        options                         = {};
+        options.limits.codec.max_fields = 1;
+        Expect(
+            LoadChunks(compact.bytes, {}, options).result.status == SessionLoadStatus::Complete,
+            "exact codec field limit was rejected"
+        );
+        options.limits.codec.max_fields = 0;
+        loaded                          = LoadChunks(compact.bytes, {}, options);
+        Expect(
+            loaded.result.status == SessionLoadStatus::LimitExceeded &&
+                loaded.result.limit_kind == SessionLimitKind::Codec,
+            "codec field boundary was not enforced"
+        );
+
+        options                               = {};
+        options.limits.codec.max_string_bytes = 2;
+        Expect(
+            LoadChunks(compact.bytes, {}, options).result.status == SessionLoadStatus::Complete,
+            "exact codec string limit was rejected"
+        );
+        options.limits.codec.max_string_bytes = 1;
+        loaded                                = LoadChunks(compact.bytes, {}, options);
+        Expect(
+            loaded.result.status == SessionLoadStatus::LimitExceeded &&
+                loaded.result.limit_kind == SessionLimitKind::Codec,
+            "codec string boundary was not enforced"
+        );
+    }
+    {
+        SessionBuilder builder;
+        builder.Begin();
+        builder.Schema(Templates::CpuScope());
+        AddCpuScope(builder, 1, 1, "parent", 0, 20, 0);
+        AddCpuScope(builder, 2, 1, "child", 5, 10, 1);
+        builder.End();
+
+        SessionLoadOptions options{};
+        options.limits.max_scope_depth = 1;
+        Expect(
+            LoadChunks(builder.bytes, {}, options).result.status == SessionLoadStatus::Complete,
+            "exact scope depth limit was rejected"
+        );
+        options.limits.max_scope_depth = 0;
+        const Loaded loaded            = LoadChunks(builder.bytes, {}, options);
+        Expect(
+            loaded.result.status == SessionLoadStatus::LimitExceeded &&
+                loaded.result.limit_kind == SessionLimitKind::ScopeDepth,
+            "scope depth boundary was not enforced"
+        );
+    }
+    {
+        SessionBuilder builder;
+        builder.Begin();
+        builder.Schema(Templates::GpuFrame());
+        builder.Schema(Templates::GpuScope());
+        AddGpuFrame(builder, 1, 1, ProfileGpuFrameStatus::Complete, true, 2, 0, 0, "");
+        AddGpuScope(
+            builder,
+            2,
+            1,
+            1,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            "gpu-parent",
+            ProfileGpuScopeStatus::Ready,
+            10,
+            30,
+            64,
+            1.0,
+            20.0,
+            10.0,
+            0,
+            ""
+        );
+        AddGpuScope(
+            builder,
+            3,
+            1,
+            2,
+            1,
+            0,
+            1,
+            0,
+            0,
+            0,
+            "gpu-child",
+            ProfileGpuScopeStatus::Ready,
+            15,
+            25,
+            64,
+            1.0,
+            10.0,
+            10.0,
+            1,
+            ""
+        );
+        builder.End();
+
+        SessionLoadOptions options{};
+        options.limits.max_scope_depth = 1;
+        Expect(
+            LoadChunks(builder.bytes, {}, options).result.status == SessionLoadStatus::Complete,
+            "exact GPU scope depth limit was rejected"
+        );
+        options.limits.max_scope_depth = 0;
+        const Loaded loaded            = LoadChunks(builder.bytes, {}, options);
+        Expect(
+            loaded.result.status == SessionLoadStatus::LimitExceeded &&
+                loaded.result.limit_kind == SessionLimitKind::ScopeDepth,
+            "GPU scope depth boundary was not enforced"
+        );
+    }
+    {
+        SessionLoadOptions options{};
+        options.limits.max_input_bytes = golden.bytes.size();
+        expect_complete(options, "exact input byte limit was rejected");
+    }
+    {
+        SessionLoadOptions options{};
+        options.limits.max_input_bytes = golden.bytes.size() - 1;
+        const Loaded loaded            = LoadChunks(golden.bytes, {}, options);
+        Expect(
+            loaded.result.status == SessionLoadStatus::LimitExceeded &&
+                loaded.result.limit_kind == SessionLimitKind::InputBytes,
+            "input byte limit was not enforced"
+        );
+    }
+    {
+        SessionLoadOptions options{};
+        options.limits.max_packets = 1;
+        const Loaded loaded        = LoadChunks(golden.bytes, {}, options);
+        Expect(
+            loaded.result.status == SessionLoadStatus::LimitExceeded &&
+                loaded.result.limit_kind == SessionLimitKind::Packets,
+            "packet limit was not enforced"
+        );
+    }
+    {
+        SessionLoadOptions options{};
+        options.limits.max_records = 1;
+        const Loaded loaded        = LoadChunks(golden.bytes, {}, options);
+        Expect(
+            loaded.result.status == SessionLoadStatus::LimitExceeded &&
+                loaded.result.limit_kind == SessionLimitKind::Records,
+            "record limit was not enforced"
+        );
+    }
+    {
+        SessionLoadOptions options{};
+        options.limits.max_gpu_domains = 1;
+        const Loaded loaded            = LoadChunks(golden.bytes, {}, options);
+        Expect(
+            loaded.result.status == SessionLoadStatus::LimitExceeded &&
+                loaded.result.limit_kind == SessionLimitKind::GpuDomains,
+            "GPU domain limit was not enforced"
+        );
+    }
+    {
+        SessionLoadOptions options{};
+        options.limits.max_logical_model_bytes = 1;
+        const Loaded loaded                    = LoadChunks(golden.bytes, {}, options);
+        Expect(
+            loaded.result.status == SessionLoadStatus::LimitExceeded &&
+                loaded.result.limit_kind == SessionLimitKind::LogicalModelBytes,
+            "model byte limit was not enforced"
+        );
+    }
+    {
+        SessionBuilder builder;
+        builder.Begin();
+        builder.Schema(UnknownSchema());
+        const PacketRange  schema = builder.ranges[1];
+        SessionLoadOptions options{};
+        options.limits.codec.max_packet_payload_bytes = 16;
+        const std::size_t       header_end            = schema.offset + kPacketHeaderBytes;
+        ProfileSessionReader    reader(options);
+        const SessionLoadResult first =
+            reader.Feed(std::span<const std::uint8_t>(builder.bytes).first(header_end));
+        Expect(
+            first.status == SessionLoadStatus::LimitExceeded && first.limit_kind == SessionLimitKind::Codec,
+            "oversized declared payload was not rejected from its header"
+        );
+        const SessionLoadResult sticky = reader.Feed(builder.bytes);
+        Expect(
+            sticky.status == first.status && reader.Finish().status == first.status,
+            "fatal reader state was not sticky"
+        );
+    }
+}
+
+class ScopedTempDirectory {
+public:
+    ScopedTempDirectory() {
+        static std::atomic<std::uint64_t> next{0};
+        for (std::uint32_t attempt = 0; attempt < 32; ++attempt) {
+            const auto                  tick = std::chrono::steady_clock::now().time_since_epoch().count();
+            const std::filesystem::path candidate =
+                std::filesystem::temp_directory_path() /
+                ("profile-consumer-" + std::to_string(tick) + "-" + std::to_string(next.fetch_add(1)));
+            std::error_code error;
+            if (std::filesystem::create_directory(candidate, error)) {
+                path = candidate;
+                return;
+            }
+        }
+        throw std::runtime_error("could not create profile consumer temp directory");
+    }
+
+    ~ScopedTempDirectory() {
+        std::error_code error;
+        std::filesystem::remove_all(path, error);
+    }
+
+    std::filesystem::path path{};
+};
+
+void WriteBytes(const std::filesystem::path& _path, std::span<const std::uint8_t> _bytes) {
+    std::ofstream stream(_path, std::ios::binary | std::ios::trunc);
+    Expect(stream.is_open(), "could not create profile fixture file");
+    stream.write(reinterpret_cast<const char*>(_bytes.data()), static_cast<std::streamsize>(_bytes.size()));
+    Expect(stream.good(), "could not write profile fixture file");
+}
+
+void TestFileWrapperAndMoveOwnership() {
+    const SessionBuilder        golden = MakeGoldenSession();
+    ScopedTempDirectory         temporary;
+    const std::filesystem::path valid_path   = temporary.path / "valid.mpds";
+    const std::filesystem::path invalid_path = temporary.path / "invalid.mpds";
+    WriteBytes(valid_path, golden.bytes);
+    const std::array<std::uint8_t, 3> invalid{1, 2, 3};
+    WriteBytes(invalid_path, invalid);
+
+    ProfileSession          session;
+    const SessionLoadResult valid_result = LoadProfileSessionFile(valid_path, {}, session);
+    Expect(
+        valid_result.status == SessionLoadStatus::Complete && session.Valid() &&
+            session.Summary().generation == 7,
+        "file wrapper did not load a valid session"
+    );
+
+    const SessionLoadResult invalid_result = LoadProfileSessionFile(invalid_path, {}, session);
+    Expect(
+        invalid_result.status == SessionLoadStatus::CorruptData && session.Valid() &&
+            session.Summary().generation == 7,
+        "failed file load modified the caller's valid session"
+    );
+
+    ProfileSession moved = std::move(session);
+    Expect(
+        moved.Valid() && !session.Valid() && moved.String(moved.CpuScopes().front().name) == "cpu-parent",
+        "ProfileSession move did not preserve ownership"
+    );
+
+    ProfileSession          missing_output;
+    const SessionLoadResult missing =
+        LoadProfileSessionFile(temporary.path / "missing.mpds", {}, missing_output);
+    Expect(
+        missing.status == SessionLoadStatus::OpenFailed && !missing_output.Valid(),
+        "missing file was not reported as OpenFailed"
+    );
+
+    SessionLoadOptions constrained{};
+    constrained.limits.max_input_bytes = golden.bytes.size() - 1;
+    const SessionLoadResult preflight  = LoadProfileSessionFile(valid_path, constrained, moved);
+    Expect(
+        preflight.status == SessionLoadStatus::LimitExceeded &&
+            preflight.limit_kind == SessionLimitKind::InputBytes &&
+            preflight.input_bytes == golden.bytes.size() && moved.Valid() && moved.Summary().generation == 7,
+        "file-size preflight did not enforce the exact input limit atomically"
+    );
+}
+
+void TestProducerToConsumerUnnotifiedDrop() {
+    [[maybe_unused]] const ShutdownResult initial_shutdown = Shutdown();
+    ScopedTempDirectory                   temporary;
+    RuntimeConfig                         config{};
+    config.output_path      = temporary.path / "generation-a.mpd";
+    config.replace_existing = true;
+
+    Expect(Start(config) == StartResult::Started, "producer integration could not start generation A");
+    const SchemaDescriptor   unknown      = UnknownSchema();
+    const SchemaRegistration registration = RegisterSchema(unknown);
+    Expect(
+        registration.status == SchemaStatus::Registered,
+        "producer integration could not register generation A schema"
+    );
+    Expect(Shutdown() == ShutdownResult::Completed, "producer integration could not close generation A");
+
+    config.output_path = temporary.path / "generation-b.mpd";
+    Expect(Start(config) == StartResult::Started, "producer integration could not start generation B");
+    const std::array<FieldValueView, 2> stale_values{
+        std::uint64_t{1},
+        std::string_view("stale"),
+    };
+    Expect(
+        Emit(registration.handle, stale_values) == EmitStatus::InvalidHandle,
+        "producer integration did not exercise a stale-generation drop"
+    );
+    Expect(Shutdown() == ShutdownResult::Completed, "producer integration could not close generation B");
+
+    ProfileSession          session;
+    const SessionLoadResult loaded = LoadProfileSessionFile(config.output_path, {}, session);
+    Expect(
+        loaded.status == SessionLoadStatus::Complete && session.Valid() &&
+            session.Summary().session_end_records_dropped == 1 && session.Summary().lost_record_count == 0 &&
+            session.Summary().unnotified_drop_count == 1,
+        "consumer rejected a real producer dump containing an unnotified stale-handle drop"
+    );
+}
+
+} // namespace
+
+int main() {
+    try {
+        TestGoldenSessionAndArbitraryChunking();
+        TestEnvelopeSchemaAndSequenceContracts();
+        TestChecksumAndForensicTruncation();
+        TestSemanticTopologyAndLossRecovery();
+        TestReaderPublicationAndAllocatorContracts();
+        TestLimitsAndStickyFailure();
+        TestFileWrapperAndMoveOwnership();
+        TestProducerToConsumerUnnotifiedDrop();
+        std::cout << "ProfileDump consumer contract passed\n";
+        return 0;
+    } catch (const std::exception& error) {
+        std::cerr << "ProfileDump consumer contract failed: " << error.what() << '\n';
+        return 1;
+    }
+}

--- a/source/test/ProfileDumpConsumerTest.cpp
+++ b/source/test/ProfileDumpConsumerTest.cpp
@@ -725,6 +725,176 @@ void TestEnvelopeSchemaAndSequenceContracts() {
             "SessionEnd drop total smaller than noticed losses was accepted"
         );
     }
+    {
+        SessionBuilder         builder;
+        const SchemaDescriptor unknown = UnknownSchema();
+        builder.Begin();
+        builder.Schema(unknown);
+        const std::array<FieldValueView, 2> values{
+            std::uint64_t{1},
+            std::string_view("observed"),
+        };
+        builder.Record(unknown, 1, values);
+        builder.Loss({
+            .first_sequence = 1,
+            .last_sequence  = 1,
+            .record_count   = 1,
+            .value_bytes    = 8,
+            .reason_mask    = static_cast<std::uint32_t>(LossReason::QueueFull),
+        });
+        builder.End();
+        const Loaded loaded = LoadChunks(builder.bytes);
+        Expect(
+            loaded.result.status == SessionLoadStatus::ProtocolViolation &&
+                loaded.result.error_code == SessionErrorCode::RecordSequenceInvalid,
+            "a Loss notice reused an observed record sequence"
+        );
+    }
+    {
+        SessionBuilder builder;
+        builder.Begin();
+        builder.Loss({
+            .first_sequence = 1,
+            .last_sequence  = 5,
+            .record_count   = 3,
+            .value_bytes    = 24,
+            .reason_mask    = static_cast<std::uint32_t>(LossReason::QueueFull),
+        });
+        builder.Loss({
+            .first_sequence = 2,
+            .last_sequence  = 4,
+            .record_count   = 3,
+            .value_bytes    = 24,
+            .reason_mask    = static_cast<std::uint32_t>(LossReason::Oversized),
+        });
+        builder.End();
+        const Loaded loaded = LoadChunks(builder.bytes);
+        Expect(
+            loaded.result.status == SessionLoadStatus::ProtocolViolation &&
+                loaded.result.error_code == SessionErrorCode::RecordSequenceInvalid,
+            "overlapping Loss hulls reused their only residual sequence"
+        );
+    }
+    {
+        SessionBuilder         builder;
+        const SchemaDescriptor unknown = UnknownSchema();
+        builder.Begin();
+        builder.Schema(unknown);
+        builder.Loss({
+            .first_sequence = 1,
+            .last_sequence  = 3,
+            .record_count   = 2,
+            .value_bytes    = 16,
+            .reason_mask    = static_cast<std::uint32_t>(LossReason::QueueFull),
+        });
+        const std::array<FieldValueView, 2> values{
+            std::uint64_t{2},
+            std::string_view("inside-loss-hull"),
+        };
+        builder.Record(unknown, 2, values);
+        builder.End();
+        const Loaded loaded = LoadChunks(builder.bytes);
+        Expect(
+            loaded.result.status == SessionLoadStatus::Complete &&
+                loaded.session.Summary().lost_record_count == 2,
+            "an observed record inside a Loss hull was mistaken for a lost endpoint"
+        );
+    }
+    {
+        SessionBuilder builder;
+        builder.Begin();
+        builder.Loss({
+            .first_sequence = 1,
+            .last_sequence  = 3,
+            .record_count   = 2,
+            .value_bytes    = 16,
+            .reason_mask    = static_cast<std::uint32_t>(LossReason::QueueFull),
+        });
+        builder.Loss({
+            .first_sequence = 2,
+            .last_sequence  = 2,
+            .record_count   = 1,
+            .value_bytes    = 8,
+            .reason_mask    = static_cast<std::uint32_t>(LossReason::Oversized),
+        });
+        builder.End();
+        const Loaded loaded = LoadChunks(builder.bytes);
+        Expect(
+            loaded.result.status == SessionLoadStatus::Complete &&
+                loaded.session.Summary().lost_record_count == 3,
+            "distinct overlapping Loss notices were rejected"
+        );
+    }
+    {
+        SessionBuilder builder;
+        builder.Begin();
+        builder.Loss({
+            .first_sequence = 0,
+            .last_sequence  = 0,
+            .record_count   = 1,
+            .value_bytes    = 8,
+            .reason_mask    = static_cast<std::uint32_t>(LossReason::QueueFull),
+        });
+        builder.End();
+        const Loaded loaded = LoadChunks(builder.bytes);
+        Expect(
+            loaded.result.status == SessionLoadStatus::ProtocolViolation &&
+                loaded.result.error_code == SessionErrorCode::LossPayloadInvalid,
+            "Loss notice claimed reserved record sequence zero"
+        );
+    }
+    {
+        SessionBuilder builder;
+        builder.Begin();
+        builder.Loss({
+            .first_sequence = 1,
+            .last_sequence  = 3,
+            .record_count   = 1,
+            .value_bytes    = 8,
+            .reason_mask    = static_cast<std::uint32_t>(LossReason::QueueFull),
+        });
+        builder.End();
+        const Loaded loaded = LoadChunks(builder.bytes);
+        Expect(
+            loaded.result.status == SessionLoadStatus::ProtocolViolation &&
+                loaded.result.error_code == SessionErrorCode::LossPayloadInvalid,
+            "single-record Loss notice claimed different minimum and maximum sequences"
+        );
+    }
+    {
+        SessionBuilder builder;
+        builder.Begin();
+        builder.Loss({
+            .first_sequence = 100,
+            .last_sequence  = 100,
+            .record_count   = 1,
+            .value_bytes    = 8,
+            .reason_mask    = static_cast<std::uint32_t>(LossReason::Oversized),
+        });
+        builder.End();
+        const Loaded loaded = LoadChunks(builder.bytes);
+        Expect(
+            loaded.result.status == SessionLoadStatus::Complete,
+            "v3 consumer invented a finite sequence frontier absent from the wire"
+        );
+    }
+    {
+        SessionBuilder         builder;
+        const SchemaDescriptor unknown = UnknownSchema();
+        builder.Begin();
+        builder.Schema(unknown);
+        const std::array<FieldValueView, 2> values{
+            std::uint64_t{2},
+            std::string_view("post-validation-gap"),
+        };
+        builder.Record(unknown, 2, values);
+        builder.End();
+        const Loaded loaded = LoadChunks(builder.bytes);
+        Expect(
+            loaded.result.status == SessionLoadStatus::Complete,
+            "unreported post-reservation validation failure was treated as a sequence violation"
+        );
+    }
 }
 
 void TestChecksumAndForensicTruncation() {
@@ -1042,8 +1212,8 @@ void TestSemanticTopologyAndLossRecovery() {
         const Loaded loaded = LoadChunks(builder.bytes);
         Expect(
             loaded.result.status == SessionLoadStatus::ProtocolViolation &&
-                loaded.result.error_code == SessionErrorCode::RecordSequenceInvalid,
-            "one CPU drop fabricated sequence capacity for two independent observed ancestor subtrees"
+                loaded.result.error_code == SessionErrorCode::CpuScopeParentMissing,
+            "an unnotified drop fabricated sequence-backed CPU parent evidence"
         );
     }
     {
@@ -1054,11 +1224,14 @@ void TestSemanticTopologyAndLossRecovery() {
         AddCpuScope(builder, 1, 1, "root-one-orphan", 1, 2, 2);
         AddCpuScope(builder, 6, 1, "root-two", 10, 20, 0);
         AddCpuScope(builder, 4, 1, "root-two-orphan", 11, 12, 2);
-        builder.End(SessionEndInfo{
-            .generation      = builder.generation,
-            .records_written = builder.record_count,
-            .records_dropped = 2,
+        builder.Loss({
+            .first_sequence = 2,
+            .last_sequence  = 5,
+            .record_count   = 2,
+            .value_bytes    = 16,
+            .reason_mask    = static_cast<std::uint32_t>(LossReason::QueueFull),
         });
+        builder.End();
         const Loaded loaded = LoadChunks(builder.bytes);
         Expect(
             loaded.result.status == SessionLoadStatus::Complete &&
@@ -1074,11 +1247,14 @@ void TestSemanticTopologyAndLossRecovery() {
         AddCpuScope(builder, 1, 1, "orphan-before-barrier", 0, 10, 2);
         AddCpuScope(builder, 3, 1, "observed-depth-one-barrier", 10, 20, 1);
         AddCpuScope(builder, 4, 1, "orphan-after-barrier", 20, 30, 2);
-        builder.End(SessionEndInfo{
-            .generation      = builder.generation,
-            .records_written = builder.record_count,
-            .records_dropped = 2,
+        builder.Loss({
+            .first_sequence = 2,
+            .last_sequence  = 5,
+            .record_count   = 2,
+            .value_bytes    = 16,
+            .reason_mask    = static_cast<std::uint32_t>(LossReason::QueueFull),
         });
+        builder.End();
         const Loaded loaded = LoadChunks(builder.bytes);
         Expect(
             loaded.result.status == SessionLoadStatus::Complete &&
@@ -1125,6 +1301,27 @@ void TestSemanticTopologyAndLossRecovery() {
         SessionBuilder builder;
         builder.Begin();
         builder.Schema(Templates::CpuScope());
+        AddCpuScope(builder, 3, 1, "observed-root", 0, 20, 0);
+        AddCpuScope(builder, 1, 1, "depth-two", 1, 2, 2);
+        builder.Loss({
+            .first_sequence = 4,
+            .last_sequence  = 4,
+            .record_count   = 1,
+            .value_bytes    = 8,
+            .reason_mask    = static_cast<std::uint32_t>(LossReason::QueueFull),
+        });
+        builder.End();
+        const Loaded loaded = LoadChunks(builder.bytes);
+        Expect(
+            loaded.result.status == SessionLoadStatus::ProtocolViolation &&
+                loaded.result.error_code == SessionErrorCode::CpuScopeParentMissing,
+            "Loss outside the CPU parent sequence interval was reused as topology evidence"
+        );
+    }
+    {
+        SessionBuilder builder;
+        builder.Begin();
+        builder.Schema(Templates::CpuScope());
         AddCpuScope(builder, 0, 1, "zero-sequence", 0, 10, 0);
         builder.End();
         const Loaded loaded = LoadChunks(builder.bytes);
@@ -1150,9 +1347,9 @@ void TestSemanticTopologyAndLossRecovery() {
         builder.End();
         const Loaded loaded = LoadChunks(builder.bytes);
         Expect(
-            loaded.result.status == SessionLoadStatus::ProtocolViolation &&
-                loaded.result.error_code == SessionErrorCode::RecordSequenceInvalid,
-            "record sequence exceeded the producer's written-plus-dropped allocation bound"
+            loaded.result.status == SessionLoadStatus::Complete &&
+                loaded.session.Summary().orphan_cpu_scope_count == 1,
+            "unreported post-reservation failures were mistaken for an encoded sequence frontier"
         );
     }
     {
@@ -1229,11 +1426,14 @@ void TestSemanticTopologyAndLossRecovery() {
         AddCpuScope(builder, 3, 1, "cpu-root", 0, 20, 0);
         AddCpuScope(builder, 1, 1, "cpu-depth-two", 1, 2, 2);
         AddGpuFrame(builder, 4, 1, ProfileGpuFrameStatus::Complete, true, 1, 0, 0, "");
-        builder.End(SessionEndInfo{
-            .generation      = builder.generation,
-            .records_written = builder.record_count,
-            .records_dropped = 1,
+        builder.Loss({
+            .first_sequence = 2,
+            .last_sequence  = 2,
+            .record_count   = 1,
+            .value_bytes    = 8,
+            .reason_mask    = static_cast<std::uint32_t>(LossReason::QueueFull),
         });
+        builder.End();
         const Loaded loaded = LoadChunks(builder.bytes);
         Expect(
             loaded.result.status == SessionLoadStatus::ProtocolViolation &&
@@ -2203,11 +2403,14 @@ void TestSemanticTopologyAndLossRecovery() {
             1,
             ""
         );
-        builder.End(SessionEndInfo{
-            .generation      = builder.generation,
-            .records_written = builder.record_count,
-            .records_dropped = 1,
+        builder.Loss({
+            .first_sequence = 4,
+            .last_sequence  = 4,
+            .record_count   = 1,
+            .value_bytes    = 8,
+            .reason_mask    = static_cast<std::uint32_t>(LossReason::QueueFull),
         });
+        builder.End();
         const Loaded loaded = LoadChunks(builder.bytes);
         Expect(
             loaded.result.status == SessionLoadStatus::ProtocolViolation &&
@@ -2325,11 +2528,14 @@ void TestSemanticTopologyAndLossRecovery() {
             0,
             ""
         );
-        builder.End(SessionEndInfo{
-            .generation      = builder.generation,
-            .records_written = builder.record_count,
-            .records_dropped = 1,
+        builder.Loss({
+            .first_sequence = 4,
+            .last_sequence  = 4,
+            .record_count   = 1,
+            .value_bytes    = 8,
+            .reason_mask    = static_cast<std::uint32_t>(LossReason::QueueFull),
         });
+        builder.End();
         const Loaded loaded = LoadChunks(builder.bytes);
         Expect(
             loaded.result.status == SessionLoadStatus::Complete &&
@@ -2547,11 +2753,14 @@ void TestSemanticTopologyAndLossRecovery() {
         builder.Begin();
         builder.Schema(Templates::GpuFrame());
         AddGpuFrame(builder, 1, 1, ProfileGpuFrameStatus::Complete, true, 5, 0, 0, "");
-        builder.End(SessionEndInfo{
-            .generation      = builder.generation,
-            .records_written = builder.record_count,
-            .records_dropped = 5,
+        builder.Loss({
+            .first_sequence = 2,
+            .last_sequence  = 6,
+            .record_count   = 5,
+            .value_bytes    = 40,
+            .reason_mask    = static_cast<std::uint32_t>(LossReason::QueueFull),
         });
+        builder.End();
         const Loaded loaded = LoadChunks(builder.bytes);
         Expect(
             loaded.result.status == SessionLoadStatus::Complete &&
@@ -2641,11 +2850,14 @@ void TestSemanticTopologyAndLossRecovery() {
             1,
             ""
         );
-        builder.End(SessionEndInfo{
-            .generation      = builder.generation,
-            .records_written = builder.record_count,
-            .records_dropped = 1,
+        builder.Loss({
+            .first_sequence = 3,
+            .last_sequence  = 3,
+            .record_count   = 1,
+            .value_bytes    = 8,
+            .reason_mask    = static_cast<std::uint32_t>(LossReason::QueueFull),
         });
+        builder.End();
         const Loaded loaded = LoadChunks(builder.bytes);
         Expect(
             loaded.result.status == SessionLoadStatus::ProtocolViolation &&
@@ -2748,11 +2960,9 @@ void TestSemanticTopologyAndLossRecovery() {
         });
         const Loaded loaded = LoadChunks(builder.bytes);
         Expect(
-            loaded.result.status == SessionLoadStatus::Complete &&
-                loaded.session.Summary().unnotified_drop_count == 1 &&
-                loaded.session.Summary().degraded_complete_gpu_frame_count == 1 &&
-                loaded.session.GpuFrames().front().export_missing_scope_count == 1,
-            "unnotified SessionEnd drops did not explain an undersized GPU frame"
+            loaded.result.status == SessionLoadStatus::ProtocolViolation &&
+                loaded.result.error_code == SessionErrorCode::GpuFrameTotalsMismatch,
+            "an unnotified drop was treated as sequence-backed GPU deficit evidence"
         );
     }
     const auto add_ready_scope = [](SessionBuilder&  _builder,
@@ -3651,6 +3861,40 @@ void TestSemanticTopologyAndLossRecovery() {
             "UINT64_MAX GPU local order overflowed its source span"
         );
     }
+    {
+        constexpr std::uint64_t candidate_count = 32;
+        constexpr std::uint64_t child_count     = 32;
+
+        SessionBuilder builder;
+        builder.Begin();
+        builder.Schema(Templates::CpuScope());
+        for (std::uint64_t index = 0; index < candidate_count; ++index) {
+            AddCpuScope(builder, index + 1, 1, "ending-candidate", 10, 10, 1);
+        }
+        for (std::uint64_t index = 0; index < child_count; ++index) {
+            AddCpuScope(builder, candidate_count + index + 1, 1, "unmatched-boundary-child", 10, 10, 2);
+        }
+        builder.End();
+
+        SessionLoadOptions exact{};
+        exact.limits.max_topology_work_items = candidate_count * child_count;
+        const Loaded exact_loaded            = LoadChunks(builder.bytes, {}, exact);
+        Expect(
+            exact_loaded.result.status == SessionLoadStatus::Complete &&
+                exact_loaded.session.Summary().orphan_cpu_scope_count == candidate_count + child_count,
+            "exact CPU boundary-parent topology budget was rejected"
+        );
+
+        SessionLoadOptions short_by_one = exact;
+        --short_by_one.limits.max_topology_work_items;
+        const Loaded limited = LoadChunks(builder.bytes, {}, short_by_one);
+        Expect(
+            limited.result.status == SessionLoadStatus::LimitExceeded &&
+                limited.result.limit_kind == SessionLimitKind::TopologyWorkItems &&
+                !limited.result.HasUsableSession(),
+            "CPU boundary-parent search escaped the session topology work budget"
+        );
+    }
 }
 
 void TestReaderPublicationAndAllocatorContracts() {
@@ -4316,6 +4560,43 @@ void TestProducerToConsumerUnnotifiedDrop() {
             session.Summary().session_end_records_dropped == 1 && session.Summary().lost_record_count == 0 &&
             session.Summary().unnotified_drop_count == 1,
         "consumer rejected a real producer dump containing an unnotified stale-handle drop"
+    );
+
+    config.output_path = temporary.path / "generation-c.mpd";
+    Expect(Start(config) == StartResult::Started, "producer integration could not start generation C");
+    const SchemaRegistration current_registration = RegisterSchema(Templates::CpuScope());
+    Expect(
+        current_registration.status == SchemaStatus::Registered,
+        "producer integration could not register generation C schema"
+    );
+    const std::array<FieldValueView, 1> invalid_values{
+        std::uint64_t{1},
+    };
+    Expect(
+        Emit(current_registration.handle, invalid_values) == EmitStatus::ValueCountMismatch,
+        "producer integration did not reserve a sequence for a rejected value set"
+    );
+    const std::array<FieldValueView, 5> valid_values{
+        std::uint64_t{7},
+        std::string_view("sequence-two"),
+        std::uint64_t{10},
+        std::uint64_t{20},
+        std::uint32_t{0},
+    };
+    Expect(
+        Emit(current_registration.handle, valid_values) == EmitStatus::Accepted,
+        "producer integration could not emit the post-rejection record"
+    );
+    Expect(Shutdown() == ShutdownResult::Completed, "producer integration could not close generation C");
+
+    ProfileSession          sparse_session;
+    const SessionLoadResult sparse_loaded = LoadProfileSessionFile(config.output_path, {}, sparse_session);
+    Expect(
+        sparse_loaded.status == SessionLoadStatus::Complete && sparse_session.Valid() &&
+            sparse_session.Summary().record_count == 1 && sparse_session.CpuScopes().size() == 1 &&
+            sparse_session.CpuScopes().front().sequence == 2 &&
+            sparse_session.Summary().session_end_records_dropped == 0,
+        "consumer did not preserve the post-rejection sequence gap without inventing a v3 frontier"
     );
 }
 

--- a/source/test/ProfileDumpConsumerTest.cpp
+++ b/source/test/ProfileDumpConsumerTest.cpp
@@ -276,6 +276,81 @@ Loaded LoadChunks(
     return loaded;
 }
 
+constexpr std::uint64_t TopologyLinearWorkOracle(std::size_t _count) noexcept {
+    return static_cast<std::uint64_t>(_count);
+}
+
+constexpr std::uint64_t TopologySortWorkOracle(std::size_t _count) noexcept {
+    const std::uint64_t count = static_cast<std::uint64_t>(_count);
+    std::uint64_t       work  = 0;
+    std::size_t         width = 1;
+    while (width < _count) {
+        work += count;
+        if (width > std::numeric_limits<std::size_t>::max() / 2) {
+            break;
+        }
+        width *= 2;
+    }
+    return work;
+}
+
+constexpr std::uint64_t TopologyBinarySearchWorkOracle(std::size_t _count) noexcept {
+    std::uint64_t work = 0;
+    while (_count != 0) {
+        ++work;
+        _count /= 2;
+    }
+    return work;
+}
+
+constexpr std::uint64_t TopologyHeapWorkOracle(std::size_t _size) noexcept {
+    std::uint64_t work = 1;
+    while (_size > 1) {
+        ++work;
+        _size /= 2;
+    }
+    return work;
+}
+
+std::uint64_t MinimumPassingTopologyBudget(std::span<const std::uint8_t> _bytes) {
+    const auto completes_with_budget = [&](std::uint64_t _budget) {
+        SessionLoadOptions options{};
+        options.limits.max_topology_work_items = _budget;
+        const Loaded loaded                    = LoadChunks(_bytes, {}, options);
+        if (loaded.result.status == SessionLoadStatus::Complete) {
+            return true;
+        }
+        Expect(
+            loaded.result.status == SessionLoadStatus::LimitExceeded &&
+                loaded.result.limit_kind == SessionLimitKind::TopologyWorkItems &&
+                !loaded.result.HasUsableSession() && !loaded.session.Valid(),
+            "topology budget search observed a non-budget failure or a partially published session"
+        );
+        return false;
+    };
+
+    std::uint64_t lower = 0;
+    std::uint64_t upper = 1;
+    while (!completes_with_budget(upper)) {
+        Expect(
+            upper <= std::numeric_limits<std::uint64_t>::max() / 2,
+            "topology budget search exceeded the uint64 range"
+        );
+        lower = upper + 1;
+        upper *= 2;
+    }
+
+    while (lower < upper) {
+        const std::uint64_t middle = lower + (upper - lower) / 2;
+        if (completes_with_budget(middle)) {
+            upper = middle;
+        } else {
+            lower = middle + 1;
+        }
+    }
+    return lower;
+}
+
 SessionBuilder MakeGoldenSession() {
     SessionBuilder         builder;
     const SchemaDescriptor unknown = UnknownSchema();
@@ -3865,20 +3940,49 @@ void TestSemanticTopologyAndLossRecovery() {
         constexpr std::uint64_t candidate_count = 32;
         constexpr std::uint64_t child_count     = 32;
 
-        SessionBuilder builder;
-        builder.Begin();
-        builder.Schema(Templates::CpuScope());
-        for (std::uint64_t index = 0; index < candidate_count; ++index) {
-            AddCpuScope(builder, index + 1, 1, "ending-candidate", 10, 10, 1);
-        }
-        for (std::uint64_t index = 0; index < child_count; ++index) {
-            AddCpuScope(builder, candidate_count + index + 1, 1, "unmatched-boundary-child", 10, 10, 2);
-        }
-        builder.End();
+        const auto make_fixture = [](std::uint32_t _child_depth) {
+            SessionBuilder builder;
+            builder.Begin();
+            builder.Schema(Templates::CpuScope());
+            for (std::uint64_t index = 0; index < candidate_count; ++index) {
+                AddCpuScope(builder, index + 1, 1, "ending-candidate", 10, 10, 1);
+            }
+            for (std::uint64_t index = 0; index < child_count; ++index) {
+                AddCpuScope(
+                    builder, candidate_count + index + 1, 1, "unmatched-boundary-child", 10, 10, _child_depth
+                );
+            }
+            builder.End();
+            return builder;
+        };
 
+        const SessionBuilder    adversarial        = make_fixture(2);
+        const SessionBuilder    control            = make_fixture(1);
+        const std::uint64_t     adversarial_budget = MinimumPassingTopologyBudget(adversarial.bytes);
+        const std::uint64_t     control_budget     = MinimumPassingTopologyBudget(control.bytes);
+        constexpr std::uint64_t scope_count        = candidate_count + child_count;
+        const std::uint64_t     expected_index_work =
+            TopologySortWorkOracle(scope_count) * 2 + TopologyLinearWorkOracle(scope_count) * 4;
+        const std::uint64_t candidate_map_work = TopologyHeapWorkOracle(1) +
+                                                 (candidate_count - 2) * TopologyHeapWorkOracle(2) +
+                                                 (candidate_count - 1) * TopologyBinarySearchWorkOracle(1);
+        const std::uint64_t control_child_map_work =
+            child_count * (TopologyHeapWorkOracle(2) + TopologyBinarySearchWorkOracle(1));
+        const std::uint64_t expected_control_budget =
+            expected_index_work + candidate_map_work + control_child_map_work;
+        Expect(
+            control_budget == expected_control_budget,
+            "CPU boundary-parent control disagreed with the independent indexing/container oracle"
+        );
+        const std::uint64_t ordered_map_delta =
+            (child_count - 1) * (TopologyBinarySearchWorkOracle(2) - TopologyBinarySearchWorkOracle(1));
+        Expect(
+            adversarial_budget == control_budget + candidate_count * child_count + ordered_map_delta,
+            "CPU boundary-parent candidate/map work was under- or over-charged"
+        );
         SessionLoadOptions exact{};
-        exact.limits.max_topology_work_items = candidate_count * child_count;
-        const Loaded exact_loaded            = LoadChunks(builder.bytes, {}, exact);
+        exact.limits.max_topology_work_items = adversarial_budget;
+        const Loaded exact_loaded            = LoadChunks(adversarial.bytes, {}, exact);
         Expect(
             exact_loaded.result.status == SessionLoadStatus::Complete &&
                 exact_loaded.session.Summary().orphan_cpu_scope_count == candidate_count + child_count,
@@ -3887,11 +3991,11 @@ void TestSemanticTopologyAndLossRecovery() {
 
         SessionLoadOptions short_by_one = exact;
         --short_by_one.limits.max_topology_work_items;
-        const Loaded limited = LoadChunks(builder.bytes, {}, short_by_one);
+        const Loaded limited = LoadChunks(adversarial.bytes, {}, short_by_one);
         Expect(
             limited.result.status == SessionLoadStatus::LimitExceeded &&
                 limited.result.limit_kind == SessionLimitKind::TopologyWorkItems &&
-                !limited.result.HasUsableSession(),
+                !limited.result.HasUsableSession() && !limited.session.Valid(),
             "CPU boundary-parent search escaped the session topology work budget"
         );
     }
@@ -4248,81 +4352,192 @@ void TestLimitsAndStickyFailure() {
         );
     }
     {
-        SessionBuilder builder;
+        constexpr std::uint64_t scope_count = 5;
+        SessionBuilder          builder;
         builder.Begin();
-        builder.Schema(Templates::GpuFrame());
-        builder.Schema(Templates::GpuScope());
-        AddGpuFrame(builder, 1, 1, ProfileGpuFrameStatus::Complete, true, 4, 0, 0, "");
-        AddGpuScope(
-            builder,
-            2,
-            1,
-            2,
-            101,
-            0,
-            1,
-            0,
-            0,
-            0,
-            "topology-source-zero-child",
-            ProfileGpuScopeStatus::Ready,
-            10,
-            20,
-            64,
-            1.0,
-            10.0,
-            10.0,
-            1,
-            ""
-        );
-        AddGpuScope(
-            builder,
-            3,
-            1,
-            4,
-            201,
-            1,
-            1,
-            0,
-            0,
-            0,
-            "topology-source-one-child",
-            ProfileGpuScopeStatus::Ready,
-            30,
-            40,
-            64,
-            1.0,
-            10.0,
-            10.0,
-            1,
-            ""
-        );
-        builder.Loss({
-            .first_sequence = 4,
-            .last_sequence  = 5,
-            .record_count   = 2,
-            .value_bytes    = 16,
-            .reason_mask    = static_cast<std::uint32_t>(LossReason::QueueFull),
-        });
+        builder.Schema(Templates::CpuScope());
+        for (std::uint64_t index = 0; index < scope_count; ++index) {
+            AddCpuScope(builder, index + 1, 1, "oracle-root", index * 20, index * 20 + 10, 0);
+        }
         builder.End();
 
-        // One Loss scan + two extrema materializations + their sort/scan and
-        // record-collision searches consume 13 items before the two GPU source
-        // topology edges. The boundary verifies that all phases share one
-        // cumulative budget.
-        constexpr std::uint64_t loss_allocation_work = 13;
-        constexpr std::uint64_t gpu_topology_work    = 2;
-        SessionLoadOptions      options{};
-        options.limits.max_topology_work_items = loss_allocation_work + gpu_topology_work;
+        const std::uint64_t expected_budget =
+            TopologySortWorkOracle(scope_count) * 2 + TopologyLinearWorkOracle(scope_count) * 4;
         Expect(
-            LoadChunks(builder.bytes, {}, options).result.status == SessionLoadStatus::Complete,
+            MinimumPassingTopologyBudget(builder.bytes) == expected_budget,
+            "isolated CPU indexing disagreed with the independent sort/linear work oracle"
+        );
+    }
+    {
+        const auto add_loss = [](SessionBuilder& _builder) {
+            _builder.Loss({
+                .first_sequence = 4,
+                .last_sequence  = 5,
+                .record_count   = 2,
+                .value_bytes    = 16,
+                .reason_mask    = static_cast<std::uint32_t>(LossReason::QueueFull),
+            });
+        };
+        const auto make_gpu_fixture = [&](bool _with_loss, bool _two_sources = true) {
+            SessionBuilder builder;
+            builder.Begin();
+            builder.Schema(Templates::GpuFrame());
+            builder.Schema(Templates::GpuScope());
+            AddGpuFrame(builder, 1, 1, ProfileGpuFrameStatus::Complete, true, 2, 0, 0, "");
+            AddGpuScope(
+                builder,
+                2,
+                1,
+                2,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                "topology-source-zero-root",
+                ProfileGpuScopeStatus::Ready,
+                10,
+                20,
+                64,
+                1.0,
+                10.0,
+                10.0,
+                0,
+                ""
+            );
+            AddGpuScope(
+                builder,
+                3,
+                1,
+                4,
+                0,
+                _two_sources ? 1 : 0,
+                _two_sources ? 0 : 1,
+                0,
+                0,
+                0,
+                "topology-source-one-root",
+                ProfileGpuScopeStatus::Ready,
+                30,
+                40,
+                64,
+                1.0,
+                10.0,
+                10.0,
+                0,
+                ""
+            );
+            if (_with_loss) {
+                add_loss(builder);
+            }
+            builder.End();
+            return builder;
+        };
+        const auto make_no_gpu_fixture = [&](bool _with_loss) {
+            SessionBuilder         builder;
+            const SchemaDescriptor unknown = UnknownSchema();
+            builder.Begin();
+            builder.Schema(unknown);
+            for (std::uint64_t sequence = 1; sequence <= 3; ++sequence) {
+                const std::array<FieldValueView, 2> values{
+                    sequence,
+                    std::string_view("topology-budget-control"),
+                };
+                builder.Record(unknown, sequence, values);
+            }
+            if (_with_loss) {
+                add_loss(builder);
+            }
+            builder.End();
+            return builder;
+        };
+
+        const SessionBuilder combined           = make_gpu_fixture(true);
+        const SessionBuilder gpu_only           = make_gpu_fixture(false);
+        const SessionBuilder one_source_gpu     = make_gpu_fixture(false, false);
+        const SessionBuilder no_gpu             = make_no_gpu_fixture(false);
+        const SessionBuilder no_gpu_with_loss   = make_no_gpu_fixture(true);
+        const std::uint64_t  combined_budget    = MinimumPassingTopologyBudget(combined.bytes);
+        const std::uint64_t  gpu_only_budget    = MinimumPassingTopologyBudget(gpu_only.bytes);
+        const std::uint64_t  one_source_budget  = MinimumPassingTopologyBudget(one_source_gpu.bytes);
+        const std::uint64_t  no_gpu_budget      = MinimumPassingTopologyBudget(no_gpu.bytes);
+        const std::uint64_t  no_gpu_loss_budget = MinimumPassingTopologyBudget(no_gpu_with_loss.bytes);
+        Expect(
+            no_gpu_loss_budget >= no_gpu_budget,
+            "Loss topology work unexpectedly reduced the minimum passing budget"
+        );
+        const std::uint64_t     loss_delta               = no_gpu_loss_budget - no_gpu_budget;
+        constexpr std::uint64_t mandatory_sequence_count = 2;
+        constexpr std::uint64_t emitted_record_count     = 3;
+        const std::uint64_t     expected_loss_delta =
+            TopologyLinearWorkOracle(1) + TopologyLinearWorkOracle(mandatory_sequence_count) +
+            TopologySortWorkOracle(mandatory_sequence_count) +
+            TopologyLinearWorkOracle(mandatory_sequence_count) * 2 +
+            TopologyBinarySearchWorkOracle(emitted_record_count) * mandatory_sequence_count;
+        Expect(loss_delta == expected_loss_delta, "Loss topology work disagreed with the independent oracle");
+
+        constexpr std::uint64_t frame_count       = 1;
+        constexpr std::uint64_t gpu_scope_count   = 2;
+        constexpr std::uint64_t domain_count      = 1;
+        constexpr std::uint64_t depth_tree_leaves = 2;
+        constexpr std::uint64_t two_source_count  = 2;
+        constexpr std::uint64_t one_source_count  = 1;
+        const std::uint64_t     record_index_work =
+            TopologySortWorkOracle(emitted_record_count) + TopologyLinearWorkOracle(emitted_record_count);
+        const std::uint64_t domain_track_work =
+            TopologySortWorkOracle(frame_count) + TopologyLinearWorkOracle(frame_count) +
+            TopologyLinearWorkOracle(gpu_scope_count) + TopologySortWorkOracle(gpu_scope_count) +
+            TopologyLinearWorkOracle(gpu_scope_count) + TopologyLinearWorkOracle(domain_count) +
+            TopologyLinearWorkOracle(gpu_scope_count) +
+            gpu_scope_count *
+                (TopologyBinarySearchWorkOracle(frame_count) + TopologyBinarySearchWorkOracle(domain_count)) +
+            TopologySortWorkOracle(gpu_scope_count) + TopologyLinearWorkOracle(gpu_scope_count) * 2;
+        const auto gpu_topology_work = [&](std::uint64_t _source_count) {
+            return TopologyLinearWorkOracle(frame_count) * 2 + TopologyLinearWorkOracle(gpu_scope_count) +
+                   TopologySortWorkOracle(gpu_scope_count) + TopologyLinearWorkOracle(gpu_scope_count) +
+                   TopologyLinearWorkOracle(gpu_scope_count) * 10 +
+                   TopologyLinearWorkOracle(gpu_scope_count) * 2 +
+                   gpu_scope_count * TopologyBinarySearchWorkOracle(frame_count) +
+                   TopologyLinearWorkOracle(gpu_scope_count) + TopologyLinearWorkOracle(gpu_scope_count) * 4 +
+                   TopologyLinearWorkOracle(gpu_scope_count) * 3 +
+                   TopologyLinearWorkOracle(depth_tree_leaves * 2) +
+                   TopologyLinearWorkOracle(gpu_scope_count) + TopologyLinearWorkOracle(depth_tree_leaves) +
+                   TopologyLinearWorkOracle(gpu_scope_count) * 3 + TopologyLinearWorkOracle(_source_count) +
+                   TopologySortWorkOracle(_source_count) + TopologyLinearWorkOracle(_source_count) +
+                   TopologyLinearWorkOracle(frame_count) + TopologyBinarySearchWorkOracle(frame_count) +
+                   TopologyLinearWorkOracle(gpu_scope_count) * 2 + TopologyLinearWorkOracle(frame_count);
+        };
+        const std::uint64_t expected_two_source_budget =
+            record_index_work + domain_track_work + gpu_topology_work(two_source_count);
+        const std::uint64_t expected_one_source_budget =
+            record_index_work + domain_track_work + gpu_topology_work(one_source_count);
+        Expect(
+            gpu_only_budget == expected_two_source_budget && expected_two_source_budget == 106,
+            "two-source GPU base indexing disagreed with the independent work oracle"
+        );
+        Expect(
+            one_source_budget == expected_one_source_budget && expected_one_source_budget == 102 &&
+                gpu_only_budget - one_source_budget == 4,
+            "GPU source-evidence indexing was not accumulated independently"
+        );
+        Expect(
+            combined_budget == gpu_only_budget + loss_delta,
+            "Loss and GPU topology work were not additive across the unified budget"
+        );
+
+        SessionLoadOptions options{};
+        options.limits.max_topology_work_items = combined_budget;
+        Expect(
+            LoadChunks(combined.bytes, {}, options).result.status == SessionLoadStatus::Complete,
             "exact global GPU topology work-item limit was rejected"
         );
         --options.limits.max_topology_work_items;
-        const Loaded loaded = LoadChunks(builder.bytes, {}, options);
+        const Loaded loaded = LoadChunks(combined.bytes, {}, options);
         Expect(
             loaded.result.status == SessionLoadStatus::LimitExceeded &&
-                loaded.result.limit_kind == SessionLimitKind::TopologyWorkItems,
+                loaded.result.limit_kind == SessionLimitKind::TopologyWorkItems &&
+                !loaded.result.HasUsableSession() && !loaded.session.Valid(),
             "GPU topology work-item limit was not accumulated across recording sources"
         );
     }
@@ -4332,17 +4547,60 @@ void TestLimitsAndStickyFailure() {
         expect_complete(options, "exact input byte limit was rejected");
     }
     {
-        SessionBuilder no_loss;
-        no_loss.Begin();
-        no_loss.Schema(Templates::CpuScope());
-        AddCpuScope(no_loss, 1, 1, "zero-budget-root", 0, 10, 0);
-        no_loss.End();
-
         SessionLoadOptions zero_budget{};
         zero_budget.limits.max_topology_work_items = 0;
+
+        SessionBuilder empty;
+        empty.Begin();
+        empty.End();
         Expect(
-            LoadChunks(no_loss.bytes, {}, zero_budget).result.status == SessionLoadStatus::Complete,
-            "loss-free session consumed Loss-allocation topology budget"
+            LoadChunks(empty.bytes, {}, zero_budget).result.status == SessionLoadStatus::Complete,
+            "empty session consumed topology work budget"
+        );
+
+        SessionBuilder with_cpu;
+        with_cpu.Begin();
+        with_cpu.Schema(Templates::CpuScope());
+        AddCpuScope(with_cpu, 1, 1, "zero-budget-root", 0, 10, 0);
+        with_cpu.End();
+        const Loaded cpu_limited = LoadChunks(with_cpu.bytes, {}, zero_budget);
+        Expect(
+            cpu_limited.result.status == SessionLoadStatus::LimitExceeded &&
+                cpu_limited.result.limit_kind == SessionLimitKind::TopologyWorkItems &&
+                !cpu_limited.result.HasUsableSession() && !cpu_limited.session.Valid(),
+            "non-empty CPU indexing escaped the zero topology budget or published partial state"
+        );
+
+        SessionBuilder         record_only;
+        const SchemaDescriptor unknown = UnknownSchema();
+        record_only.Begin();
+        record_only.Schema(unknown);
+        const std::array<FieldValueView, 2> unknown_values{
+            std::uint64_t{1},
+            std::string_view("gpu-index-control"),
+        };
+        record_only.Record(unknown, 1, unknown_values);
+        record_only.End();
+
+        SessionBuilder frame_only;
+        frame_only.Begin();
+        frame_only.Schema(Templates::GpuFrame());
+        AddGpuFrame(frame_only, 1, 1, ProfileGpuFrameStatus::Complete, true, 0, 0, 0, "");
+        frame_only.End();
+
+        SessionLoadOptions record_budget{};
+        record_budget.limits.max_topology_work_items = 1;
+        Expect(
+            LoadChunks(record_only.bytes, {}, record_budget).result.status == SessionLoadStatus::Complete,
+            "single record did not fit its independent record-index budget"
+        );
+        const Loaded gpu_limited = LoadChunks(frame_only.bytes, {}, record_budget);
+        Expect(
+            gpu_limited.result.status == SessionLoadStatus::LimitExceeded &&
+                gpu_limited.result.limit_kind == SessionLimitKind::TopologyWorkItems &&
+                !gpu_limited.result.HasUsableSession() && !gpu_limited.session.Valid() &&
+                MinimumPassingTopologyBudget(frame_only.bytes) == 9,
+            "GPU frame indexing escaped its GPU-specific topology budget"
         );
 
         SessionBuilder with_loss;
@@ -4359,8 +4617,8 @@ void TestLimitsAndStickyFailure() {
         Expect(
             limited.result.status == SessionLoadStatus::LimitExceeded &&
                 limited.result.limit_kind == SessionLimitKind::TopologyWorkItems &&
-                !limited.result.HasUsableSession(),
-            "Loss sequence allocation escaped the session topology work budget"
+                !limited.result.HasUsableSession() && !limited.session.Valid(),
+            "Loss sequence allocation escaped the zero topology budget or published partial state"
         );
     }
     {

--- a/source/test/ProfileSummaryCliTest.cpp
+++ b/source/test/ProfileSummaryCliTest.cpp
@@ -1,0 +1,787 @@
+#include "profile/ProfileDumpCodec.h"
+#include "profile/ProfileDumpTemplates.h"
+#include "profile_consumer/ProfileSummaryContract.h"
+
+#include <nlohmann/json.hpp>
+
+#include <algorithm>
+#include <array>
+#include <atomic>
+#include <cctype>
+#include <chrono>
+#include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <iterator>
+#include <span>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+#if defined(_WIN32)
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#include <windows.h>
+#else
+#include <cerrno>
+#include <fcntl.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+#endif
+
+namespace {
+
+using Json = nlohmann::json;
+using namespace Moer::ProfileDump;
+using NativeProcessArgument = std::filesystem::path::string_type;
+
+static_assert(ProfileSummaryExitCode(SessionLoadStatus::Complete) == 0);
+static_assert(ProfileSummaryExitCode(SessionLoadStatus::ForensicTruncated) == 2);
+static_assert(ProfileSummaryExitCode(SessionLoadStatus::InvalidArgument) == 10);
+static_assert(ProfileSummaryExitCode(SessionLoadStatus::OpenFailed) == 11);
+static_assert(ProfileSummaryExitCode(SessionLoadStatus::ProtocolViolation) == 12);
+static_assert(ProfileSummaryExitCode(SessionLoadStatus::LimitExceeded) == 13);
+static_assert(ProfileSummaryExitCode(SessionLoadStatus::ResourceExhausted) == 14);
+
+void Expect(bool _condition, std::string_view _message) {
+    if (!_condition) {
+        throw std::runtime_error(std::string(_message));
+    }
+}
+
+class SessionBuilder {
+public:
+    void Begin() {
+        Moer::Array<std::uint8_t> payload;
+        EncodeSessionBeginPayload(
+            {
+                .generation      = generation,
+                .started_unix_ns = 123456789,
+            },
+            payload
+        );
+        Append(PacketType::SessionBegin, payload);
+    }
+
+    void End() {
+        Moer::Array<std::uint8_t> payload;
+        EncodeSessionEndPayload(
+            {
+                .generation      = generation,
+                .records_written = record_count,
+                .records_dropped = dropped_count,
+            },
+            payload
+        );
+        Append(PacketType::SessionEnd, payload);
+    }
+
+    void Schema(const SchemaDescriptor& _schema) {
+        Moer::Array<std::uint8_t> payload;
+        Expect(
+            EncodeSchemaPayload(_schema, {}, payload) == EncodeStatus::Ok, "fixture schema failed to encode"
+        );
+        Append(PacketType::Schema, payload);
+    }
+
+    void Record(
+        const SchemaDescriptor&         _schema,
+        std::uint64_t                   _sequence,
+        std::span<const FieldValueView> _values
+    ) {
+        Moer::Array<std::uint8_t> payload;
+        Expect(
+            EncodeRecordPayload(
+                ComputeSchemaHash(_schema), _sequence, _schema.fields, _values, {}, payload
+            ) == EncodeStatus::Ok,
+            "fixture record failed to encode"
+        );
+        Append(PacketType::Record, payload);
+        ++record_count;
+    }
+
+    void Loss(const LossNotice& _loss) {
+        Moer::Array<std::uint8_t> payload;
+        EncodeLossPayload(_loss, payload);
+        Append(PacketType::Loss, payload);
+        dropped_count += _loss.record_count;
+    }
+
+    std::vector<std::uint8_t> bytes{};
+
+private:
+    void Append(PacketType _type, std::span<const std::uint8_t> _payload) {
+        Moer::Array<std::uint8_t> packet;
+        Expect(
+            WrapPacket(_type, next_packet_index++, _payload, {}, packet) == EncodeStatus::Ok,
+            "fixture packet failed to encode"
+        );
+        bytes.insert(bytes.end(), packet.begin(), packet.end());
+    }
+
+    std::uint64_t generation{17};
+    std::uint64_t next_packet_index{0};
+    std::uint64_t record_count{0};
+    std::uint64_t dropped_count{0};
+};
+
+SchemaDescriptor UnknownSchema() {
+    return {
+        .name           = "CliCounter",
+        .event_type     = "cli.counter",
+        .kind           = EventKind::Counter,
+        .channel        = Channel::CpuThread,
+        .schema_version = 1,
+        .fields         = {{"value", FieldType::UInt64}},
+    };
+}
+
+void PopulateCompleteSession(SessionBuilder& _builder) {
+    const SchemaDescriptor unknown = UnknownSchema();
+    _builder.Begin();
+    _builder.Schema(Templates::CpuScope());
+    _builder.Schema(Templates::GpuFrame());
+    _builder.Schema(Templates::GpuScope());
+    _builder.Schema(unknown);
+
+    const std::array<FieldValueView, 5> cpu{
+        std::uint64_t{7},
+        std::string_view("cli-cpu"),
+        std::uint64_t{10},
+        std::uint64_t{20},
+        std::uint32_t{0},
+    };
+    _builder.Record(Templates::CpuScope(), 1, cpu);
+
+    const std::array<FieldValueView, 7> frame{
+        std::uint64_t{42},
+        std::uint32_t{0},
+        true,
+        std::uint64_t{1},
+        std::uint64_t{0},
+        std::uint64_t{0},
+        std::string_view{},
+    };
+    _builder.Record(Templates::GpuFrame(), 2, frame);
+
+    const std::array<FieldValueView, 18> scope{
+        std::uint64_t{42},
+        std::uint64_t{1},
+        std::uint64_t{0},
+        std::uint64_t{0},
+        std::uint64_t{0},
+        std::uint32_t{0},
+        std::uint32_t{5},
+        std::uint32_t{6},
+        std::string_view("cli-gpu"),
+        std::uint32_t{0},
+        std::uint64_t{100},
+        std::uint64_t{110},
+        std::uint32_t{64},
+        2.0,
+        20.0,
+        20.0,
+        std::uint32_t{0},
+        std::string_view{},
+    };
+    _builder.Record(Templates::GpuScope(), 3, scope);
+
+    const std::array<FieldValueView, 1> counter{std::uint64_t{9}};
+    _builder.Record(unknown, 4, counter);
+    _builder.Loss({
+        .first_sequence = 5,
+        .last_sequence  = 5,
+        .record_count   = 1,
+        .value_bytes    = 8,
+        .reason_mask    = static_cast<std::uint32_t>(LossReason::QueueFull),
+    });
+    _builder.End();
+}
+
+class ScopedTempDirectory {
+public:
+    ScopedTempDirectory() {
+        static std::atomic<std::uint64_t> next{0};
+        for (std::uint32_t attempt = 0; attempt < 32; ++attempt) {
+            const auto                  tick = std::chrono::steady_clock::now().time_since_epoch().count();
+            const std::filesystem::path candidate =
+                std::filesystem::temp_directory_path() /
+                ("profile-summary-cli-" + std::to_string(tick) + "-" + std::to_string(next.fetch_add(1)));
+            std::error_code error;
+            if (std::filesystem::create_directory(candidate, error)) {
+                path = candidate;
+                return;
+            }
+        }
+        throw std::runtime_error("could not create ProfileSummary CLI test directory");
+    }
+
+    ~ScopedTempDirectory() {
+        std::error_code error;
+        std::filesystem::remove_all(path, error);
+    }
+
+    std::filesystem::path path{};
+};
+
+void WriteBytes(const std::filesystem::path& _path, std::span<const std::uint8_t> _bytes) {
+    std::ofstream stream(_path, std::ios::binary | std::ios::trunc);
+    Expect(stream.is_open(), "could not create ProfileDump fixture");
+    stream.write(reinterpret_cast<const char*>(_bytes.data()), static_cast<std::streamsize>(_bytes.size()));
+    Expect(stream.good(), "could not write ProfileDump fixture");
+}
+
+std::string ReadText(const std::filesystem::path& _path) {
+    std::ifstream stream(_path, std::ios::binary);
+    Expect(stream.is_open(), "could not open child-process capture");
+    return {std::istreambuf_iterator<char>(stream), std::istreambuf_iterator<char>()};
+}
+
+struct ProcessResult {
+    int         exit_code{-1};
+    std::string standard_output{};
+    std::string standard_error{};
+};
+
+#if defined(_WIN32)
+
+class ScopedHandle {
+public:
+    explicit ScopedHandle(HANDLE _handle = INVALID_HANDLE_VALUE) noexcept : handle(_handle) {}
+
+    ~ScopedHandle() {
+        if (handle != INVALID_HANDLE_VALUE && handle != nullptr) {
+            CloseHandle(handle);
+        }
+    }
+
+    ScopedHandle(const ScopedHandle&)            = delete;
+    ScopedHandle& operator=(const ScopedHandle&) = delete;
+
+    ScopedHandle(ScopedHandle&& _other) noexcept : handle(_other.handle) {
+        _other.handle = INVALID_HANDLE_VALUE;
+    }
+
+    ScopedHandle& operator=(ScopedHandle&& _other) noexcept {
+        if (this != &_other) {
+            if (handle != INVALID_HANDLE_VALUE && handle != nullptr) {
+                CloseHandle(handle);
+            }
+            handle        = _other.handle;
+            _other.handle = INVALID_HANDLE_VALUE;
+        }
+        return *this;
+    }
+
+    HANDLE Get() const noexcept {
+        return handle;
+    }
+
+private:
+    HANDLE handle{INVALID_HANDLE_VALUE};
+};
+
+std::wstring QuoteWindowsArgument(std::wstring_view _argument) {
+    std::wstring quoted;
+    quoted.push_back(L'"');
+    std::size_t backslash_count = 0;
+    for (const wchar_t character : _argument) {
+        if (character == L'\\') {
+            ++backslash_count;
+            continue;
+        }
+        if (character == L'"') {
+            quoted.append(backslash_count * 2 + 1, L'\\');
+            quoted.push_back(L'"');
+        } else {
+            quoted.append(backslash_count, L'\\');
+            quoted.push_back(character);
+        }
+        backslash_count = 0;
+    }
+    quoted.append(backslash_count * 2, L'\\');
+    quoted.push_back(L'"');
+    return quoted;
+}
+
+ProcessResult RunProcess(
+    const std::filesystem::path&              _executable,
+    const std::vector<NativeProcessArgument>& _arguments,
+    const std::filesystem::path&              _working_directory,
+    const std::filesystem::path&              _stdout_path,
+    const std::filesystem::path&              _stderr_path
+) {
+    SECURITY_ATTRIBUTES security{};
+    security.nLength        = sizeof(security);
+    security.bInheritHandle = TRUE;
+
+    ScopedHandle stdout_handle(CreateFileW(
+        _stdout_path.c_str(),
+        GENERIC_WRITE,
+        FILE_SHARE_READ | FILE_SHARE_WRITE,
+        &security,
+        CREATE_ALWAYS,
+        FILE_ATTRIBUTE_NORMAL,
+        nullptr
+    ));
+    ScopedHandle stderr_handle(CreateFileW(
+        _stderr_path.c_str(),
+        GENERIC_WRITE,
+        FILE_SHARE_READ | FILE_SHARE_WRITE,
+        &security,
+        CREATE_ALWAYS,
+        FILE_ATTRIBUTE_NORMAL,
+        nullptr
+    ));
+    ScopedHandle stdin_handle(CreateFileW(
+        L"NUL",
+        GENERIC_READ,
+        FILE_SHARE_READ | FILE_SHARE_WRITE,
+        &security,
+        OPEN_EXISTING,
+        FILE_ATTRIBUTE_NORMAL,
+        nullptr
+    ));
+    Expect(
+        stdout_handle.Get() != INVALID_HANDLE_VALUE && stderr_handle.Get() != INVALID_HANDLE_VALUE &&
+            stdin_handle.Get() != INVALID_HANDLE_VALUE,
+        "could not create child-process handles"
+    );
+
+    std::wstring command_line = QuoteWindowsArgument(_executable.native());
+    for (const NativeProcessArgument& argument : _arguments) {
+        command_line.push_back(L' ');
+        command_line += QuoteWindowsArgument(argument);
+    }
+    std::vector<wchar_t> mutable_command(command_line.begin(), command_line.end());
+    mutable_command.push_back(L'\0');
+
+    STARTUPINFOW startup{};
+    startup.cb         = sizeof(startup);
+    startup.dwFlags    = STARTF_USESTDHANDLES;
+    startup.hStdInput  = stdin_handle.Get();
+    startup.hStdOutput = stdout_handle.Get();
+    startup.hStdError  = stderr_handle.Get();
+
+    PROCESS_INFORMATION process{};
+    const BOOL          created = CreateProcessW(
+        _executable.c_str(),
+        mutable_command.data(),
+        nullptr,
+        nullptr,
+        TRUE,
+        CREATE_NO_WINDOW,
+        nullptr,
+        _working_directory.c_str(),
+        &startup,
+        &process
+    );
+    if (!created) {
+        throw std::runtime_error(
+            "could not launch MoerProfileSummary, Win32 error " + std::to_string(GetLastError())
+        );
+    }
+
+    ScopedHandle process_handle(process.hProcess);
+    ScopedHandle thread_handle(process.hThread);
+    Expect(WaitForSingleObject(process_handle.Get(), INFINITE) == WAIT_OBJECT_0, "child process wait failed");
+
+    DWORD exit_code = 0;
+    Expect(GetExitCodeProcess(process_handle.Get(), &exit_code) != FALSE, "child process exit query failed");
+
+    stdout_handle = ScopedHandle{};
+    stderr_handle = ScopedHandle{};
+    return {
+        .exit_code       = static_cast<int>(exit_code),
+        .standard_output = ReadText(_stdout_path),
+        .standard_error  = ReadText(_stderr_path),
+    };
+}
+
+#else
+
+ProcessResult RunProcess(
+    const std::filesystem::path&              _executable,
+    const std::vector<NativeProcessArgument>& _arguments,
+    const std::filesystem::path&              _working_directory,
+    const std::filesystem::path&              _stdout_path,
+    const std::filesystem::path&              _stderr_path
+) {
+    std::vector<std::string> arguments;
+    arguments.reserve(_arguments.size() + 1);
+    arguments.push_back(_executable.native());
+    for (const NativeProcessArgument& argument : _arguments) {
+        arguments.push_back(argument);
+    }
+
+    const pid_t child = fork();
+    Expect(child >= 0, "could not fork MoerProfileSummary");
+    if (child == 0) {
+        const int stdout_fd = open(_stdout_path.c_str(), O_WRONLY | O_CREAT | O_TRUNC, 0600);
+        const int stderr_fd = open(_stderr_path.c_str(), O_WRONLY | O_CREAT | O_TRUNC, 0600);
+        if (stdout_fd < 0 || stderr_fd < 0 || chdir(_working_directory.c_str()) != 0 ||
+            dup2(stdout_fd, STDOUT_FILENO) < 0 || dup2(stderr_fd, STDERR_FILENO) < 0) {
+            _exit(127);
+        }
+        close(stdout_fd);
+        close(stderr_fd);
+
+        std::vector<char*> argument_pointers;
+        argument_pointers.reserve(arguments.size() + 1);
+        for (std::string& argument : arguments) {
+            argument_pointers.push_back(argument.data());
+        }
+        argument_pointers.push_back(nullptr);
+        execv(_executable.c_str(), argument_pointers.data());
+        _exit(127);
+    }
+
+    int status = 0;
+    while (waitpid(child, &status, 0) < 0) {
+        if (errno != EINTR) {
+            throw std::runtime_error("could not wait for MoerProfileSummary");
+        }
+    }
+    const int exit_code = WIFEXITED(status) ? WEXITSTATUS(status) : 128 + WTERMSIG(status);
+    return {
+        .exit_code       = exit_code,
+        .standard_output = ReadText(_stdout_path),
+        .standard_error  = ReadText(_stderr_path),
+    };
+}
+
+#endif
+
+class ProcessRunner {
+public:
+    ProcessRunner(std::filesystem::path _executable, std::filesystem::path _directory) :
+        executable(std::move(_executable)),
+        directory(std::move(_directory)) {}
+
+    ProcessResult Run(std::string_view _label, std::vector<NativeProcessArgument> _arguments) {
+        const std::filesystem::path stdout_path = directory / (std::string(_label) + ".stdout");
+        const std::filesystem::path stderr_path = directory / (std::string(_label) + ".stderr");
+        return RunProcess(executable, _arguments, directory, stdout_path, stderr_path);
+    }
+
+private:
+    std::filesystem::path executable{};
+    std::filesystem::path directory{};
+};
+
+Json ParseJson(const ProcessResult& _result, std::string_view _case_name) {
+    try {
+        return Json::parse(_result.standard_output);
+    } catch (const std::exception& error) {
+        throw std::runtime_error(
+            std::string(_case_name) + " did not emit valid JSON: " + error.what() +
+            "; stdout=" + _result.standard_output + "; stderr=" + _result.standard_error
+        );
+    }
+}
+
+bool IsDecimalString(const Json& _value) {
+    if (!_value.is_string()) {
+        return false;
+    }
+    const std::string& text = _value.get_ref<const std::string&>();
+    return !text.empty() && std::all_of(text.begin(), text.end(), [](unsigned char character) {
+        return std::isdigit(character) != 0;
+    });
+}
+
+void ExpectU64(const Json& _value, std::string_view _field_name) {
+    Expect(IsDecimalString(_value), std::string(_field_name) + " is not a decimal string");
+}
+
+void ExpectContractHeader(const Json& _document) {
+    Expect(_document.at("contract") == "moer.profile.summary", "summary contract changed");
+    Expect(_document.at("version") == 1, "summary contract version changed");
+}
+
+void ExpectLoadU64Fields(const Json& _document) {
+    const Json& load = _document.at("load");
+    ExpectU64(load.at("input_bytes"), "load.input_bytes");
+    ExpectU64(load.at("valid_prefix_bytes"), "load.valid_prefix_bytes");
+}
+
+void ExpectUsableSessionU64Fields(const Json& _document, bool _has_session_end) {
+    const Json& session = _document.at("session");
+    ExpectU64(session.at("generation"), "session.generation");
+    ExpectU64(session.at("started_unix_ns"), "session.started_unix_ns");
+    if (_has_session_end) {
+        ExpectU64(session.at("records_written"), "session.records_written");
+        ExpectU64(session.at("records_dropped"), "session.records_dropped");
+    } else {
+        Expect(session.at("records_written").is_null(), "forensic records_written is not null");
+        Expect(session.at("records_dropped").is_null(), "forensic records_dropped is not null");
+    }
+
+    const Json& packets = _document.at("packets");
+    for (const char* field : {"total", "schema_packets", "unique_schemas", "records", "loss_notices"}) {
+        ExpectU64(packets.at(field), std::string("packets.") + field);
+    }
+
+    const Json& records = _document.at("records");
+    for (const char* field : {"cpu_scopes", "gpu_frames", "gpu_scopes", "unknown"}) {
+        ExpectU64(records.at(field), std::string("records.") + field);
+    }
+
+    const Json& loss = _document.at("loss");
+    ExpectU64(loss.at("noticed_records"), "loss.noticed_records");
+    ExpectU64(loss.at("value_bytes"), "loss.value_bytes");
+    ExpectU64(loss.at("reason_mask"), "loss.reason_mask");
+    if (_has_session_end) {
+        ExpectU64(loss.at("unnotified_records"), "loss.unnotified_records");
+    } else {
+        Expect(loss.at("unnotified_records").is_null(), "forensic unnotified_records is not null");
+    }
+
+    const Json& cpu = _document.at("cpu");
+    for (const char* field : {"tracks", "scopes", "orphan_scopes", "begin_ns", "end_ns"}) {
+        ExpectU64(cpu.at(field), std::string("cpu.") + field);
+    }
+
+    const Json& gpu = _document.at("gpu");
+    for (const char* field : {"total", "complete", "incomplete", "invalid"}) {
+        ExpectU64(gpu.at("frames").at(field), std::string("gpu.frames.") + field);
+    }
+    for (const char* field : {"total", "ready", "error", "orphan"}) {
+        ExpectU64(gpu.at("scopes").at(field), std::string("gpu.scopes.") + field);
+    }
+    ExpectU64(gpu.at("tracks"), "gpu.tracks");
+    for (const Json& domain : gpu.at("domains")) {
+        ExpectU64(domain.at("ready_scopes"), "gpu.domains[].ready_scopes");
+        ExpectU64(domain.at("error_scopes"), "gpu.domains[].error_scopes");
+    }
+    ExpectU64(_document.at("logical_model_bytes"), "logical_model_bytes");
+}
+
+void TestComplete(ProcessRunner& _runner, const std::filesystem::path& _path) {
+    const ProcessResult result = _runner.Run("complete", {_path.native()});
+    Expect(result.exit_code == 0, "complete capture did not return exit code 0");
+
+    const Json document = ParseJson(result, "complete capture");
+    ExpectContractHeader(document);
+    ExpectLoadU64Fields(document);
+    Expect(document.at("load").at("status") == "complete", "complete status changed");
+    Expect(document.at("load").at("error_code") == "none", "complete error code changed");
+    Expect(document.at("load").at("codec_status") == "ok", "complete codec status changed");
+    Expect(document.at("load").at("error_byte_offset").is_null(), "complete error offset is not null");
+    Expect(document.at("load").at("error_packet_index").is_null(), "complete error packet is not null");
+    Expect(
+        document.at("load").at("incomplete_byte_offset").is_null(), "complete incomplete offset is not null"
+    );
+    Expect(
+        document.at("load").at("incomplete_packet_index").is_null(), "complete incomplete packet is not null"
+    );
+    Expect(document.at("session").at("has_session_end") == true, "complete session has no SessionEnd");
+    ExpectUsableSessionU64Fields(document, true);
+    Expect(document.at("session").at("generation") == "17", "complete generation changed");
+    Expect(document.at("session").at("records_written") == "4", "complete record total changed");
+    Expect(document.at("session").at("records_dropped") == "1", "complete drop total changed");
+    Expect(
+        document.at("packets") ==
+            Json{
+                {"total", "11"},
+                {"schema_packets", "4"},
+                {"unique_schemas", "4"},
+                {"records", "4"},
+                {"loss_notices", "1"},
+            },
+        "complete packet summary changed"
+    );
+    Expect(
+        document.at("records") ==
+            Json{
+                {"cpu_scopes", "1"},
+                {"gpu_frames", "1"},
+                {"gpu_scopes", "1"},
+                {"unknown", "1"},
+            },
+        "complete record summary changed"
+    );
+    const Json& loss = document.at("loss");
+    Expect(
+        loss.at("noticed_records") == "1" && loss.at("unnotified_records") == "0" &&
+            loss.at("value_bytes") == "8" &&
+            loss.at("reason_mask") == std::to_string(static_cast<std::uint32_t>(LossReason::QueueFull)),
+        "complete Loss summary changed"
+    );
+    const Json& cpu = document.at("cpu");
+    Expect(
+        cpu.at("clock") == "steady_clock_ns" && cpu.at("absolute_unix_anchor") == false &&
+            cpu.at("tracks") == "1" && cpu.at("scopes") == "1" && cpu.at("orphan_scopes") == "0" &&
+            cpu.at("has_range") == true && cpu.at("begin_ns") == "10" && cpu.at("end_ns") == "20",
+        "complete CPU summary changed"
+    );
+    const Json& gpu = document.at("gpu");
+    Expect(
+        gpu.at("clock") == "raw_device_ticks" && gpu.at("cross_cpu_alignment") == "none" &&
+            gpu.at("cross_domain_alignment") == "none" && gpu.at("tracks") == "1" &&
+            gpu.at("frames").at("total") == "1" && gpu.at("frames").at("complete") == "1" &&
+            gpu.at("frames").at("incomplete") == "0" && gpu.at("frames").at("invalid") == "0" &&
+            gpu.at("scopes").at("total") == "1" && gpu.at("scopes").at("ready") == "1" &&
+            gpu.at("scopes").at("error") == "0" && gpu.at("scopes").at("orphan") == "0",
+        "complete GPU summary changed"
+    );
+    Expect(gpu.at("domains").size() == 1, "complete GPU domain count changed");
+    const Json& domain = gpu.at("domains").front();
+    Expect(
+        domain.at("native_queue_id") == 5 && domain.at("family_id") == 6 &&
+            domain.at("logical_queues") == Json::array({"graphics"}) &&
+            domain.at("has_ready_timestamps") == true && domain.at("valid_bits") == 64 &&
+            domain.at("tick_period_ns") == 2.0 && domain.at("ready_scopes") == "1" &&
+            domain.at("error_scopes") == "0",
+        "complete GPU domain metadata changed"
+    );
+}
+
+void TestForensic(ProcessRunner& _runner, const std::filesystem::path& _path) {
+    const ProcessResult result =
+        _runner.Run("forensic", {_path.native(), std::filesystem::path("--allow-truncated").native()});
+    Expect(result.exit_code == 2, "forensic capture did not return exit code 2");
+
+    const Json document = ParseJson(result, "forensic capture");
+    ExpectContractHeader(document);
+    ExpectLoadU64Fields(document);
+    const Json& load = document.at("load");
+    Expect(load.at("status") == "forensic_truncated", "forensic status changed");
+    Expect(load.at("incomplete_reason") == "missing_session_end", "forensic reason changed");
+    Expect(load.at("error_code") == "none", "forensic result reported an error");
+    Expect(load.at("codec_status") == "ok", "forensic codec status changed");
+    Expect(load.at("error_byte_offset").is_null(), "forensic error offset is not null");
+    Expect(load.at("error_packet_index").is_null(), "forensic error packet is not null");
+    ExpectU64(load.at("incomplete_byte_offset"), "load.incomplete_byte_offset");
+    ExpectU64(load.at("incomplete_packet_index"), "load.incomplete_packet_index");
+    Expect(document.at("session").at("has_session_end") == false, "forensic session has SessionEnd");
+    ExpectUsableSessionU64Fields(document, false);
+}
+
+void TestProtocolViolation(ProcessRunner& _runner, const std::filesystem::path& _path) {
+    const ProcessResult result = _runner.Run("protocol", {_path.native()});
+    Expect(result.exit_code == 12, "protocol violation did not return exit code 12");
+
+    const Json document = ParseJson(result, "protocol violation");
+    ExpectContractHeader(document);
+    ExpectLoadU64Fields(document);
+    const Json& load = document.at("load");
+    Expect(load.at("status") == "protocol_violation", "protocol status changed");
+    Expect(load.at("error_code") == "session_begin_duplicate", "protocol error code changed");
+    Expect(load.at("codec_status") == "ok", "protocol codec status changed");
+    ExpectU64(load.at("error_byte_offset"), "load.error_byte_offset");
+    ExpectU64(load.at("error_packet_index"), "load.error_packet_index");
+    Expect(load.at("incomplete_byte_offset").is_null(), "protocol incomplete offset is not null");
+    Expect(load.at("incomplete_packet_index").is_null(), "protocol incomplete packet is not null");
+    Expect(!document.contains("session"), "failed protocol load exposed a session");
+}
+
+void TestMissingFile(ProcessRunner& _runner, const std::filesystem::path& _path) {
+    const ProcessResult result = _runner.Run("missing", {_path.native()});
+    Expect(result.exit_code == 11, "missing file did not return exit code 11");
+
+    const Json document = ParseJson(result, "missing file");
+    ExpectContractHeader(document);
+    ExpectLoadU64Fields(document);
+    const Json& load = document.at("load");
+    Expect(load.at("status") == "open_failed", "missing-file status changed");
+    Expect(load.at("error_code") == "file_open_failed", "missing-file error code changed");
+    Expect(load.at("codec_status") == "ok", "missing-file codec status changed");
+    Expect(load.at("error_byte_offset").is_null(), "missing-file error offset is not null");
+    Expect(load.at("error_packet_index").is_null(), "missing-file error packet is not null");
+    Expect(load.at("incomplete_byte_offset").is_null(), "missing-file incomplete offset is not null");
+    Expect(load.at("incomplete_packet_index").is_null(), "missing-file incomplete packet is not null");
+    Expect(!document.contains("session"), "missing-file load exposed a session");
+}
+
+void TestLimitExceeded(ProcessRunner& _runner, const std::filesystem::path& _path) {
+    const ProcessResult result = _runner.Run("limit", {_path.native()});
+    Expect(result.exit_code == 13, "codec limit failure did not return exit code 13");
+
+    const Json document = ParseJson(result, "codec limit failure");
+    ExpectContractHeader(document);
+    const Json& load = document.at("load");
+    Expect(load.at("status") == "limit_exceeded", "codec limit status changed");
+    Expect(load.at("error_code") == "codec_header_invalid", "codec limit error code changed");
+    Expect(load.at("limit") == "codec", "codec limit kind changed");
+    Expect(load.at("codec_status") == "payload_too_large", "codec limit codec status changed");
+    Expect(!document.contains("session"), "codec limit failure exposed a session");
+}
+
+void TestInvalidArguments(ProcessRunner& _runner, const std::filesystem::path& _valid_path) {
+    const ProcessResult missing_argument = _runner.Run("invalid-missing-argument", {});
+    Expect(missing_argument.exit_code == 10, "missing CLI argument did not return exit code 10");
+    Expect(missing_argument.standard_output.empty(), "missing CLI argument unexpectedly emitted JSON");
+    Expect(!missing_argument.standard_error.empty(), "missing CLI argument emitted no usage diagnostic");
+
+    const ProcessResult unknown_option = _runner.Run(
+        "invalid-option", {_valid_path.native(), std::filesystem::path("--unknown-option").native()}
+    );
+    Expect(unknown_option.exit_code == 10, "unknown CLI option did not return exit code 10");
+    Expect(unknown_option.standard_output.empty(), "unknown CLI option unexpectedly emitted JSON");
+    Expect(!unknown_option.standard_error.empty(), "unknown CLI option emitted no diagnostic");
+}
+
+} // namespace
+
+int main(int _argument_count, char** _arguments) {
+    try {
+        Expect(_argument_count == 2, "expected MoerProfileSummary path in argv[1]");
+        const std::filesystem::path executable = std::filesystem::absolute(_arguments[1]);
+        Expect(std::filesystem::is_regular_file(executable), "MoerProfileSummary executable does not exist");
+
+        ScopedTempDirectory         temporary;
+        const std::filesystem::path complete_path = temporary.path / std::filesystem::path(u8"完整 捕获.mpd");
+        const std::filesystem::path forensic_path = temporary.path / "forensic.mpd";
+        const std::filesystem::path protocol_path = temporary.path / "protocol.mpd";
+        const std::filesystem::path limit_path    = temporary.path / "limit.mpd";
+
+        SessionBuilder complete;
+        PopulateCompleteSession(complete);
+        WriteBytes(complete_path, complete.bytes);
+
+        SessionBuilder forensic;
+        forensic.Begin();
+        WriteBytes(forensic_path, forensic.bytes);
+
+        SessionBuilder protocol;
+        protocol.Begin();
+        protocol.Begin();
+        WriteBytes(protocol_path, protocol.bytes);
+
+        CodecLimits               oversized_limits{};
+        Moer::Array<std::uint8_t> oversized_payload(
+            oversized_limits.max_packet_payload_bytes + 1, std::uint8_t{0}
+        );
+        oversized_limits.max_packet_payload_bytes = oversized_payload.size();
+        Moer::Array<std::uint8_t> oversized_packet;
+        Expect(
+            WrapPacket(PacketType::Schema, 0, oversized_payload, oversized_limits, oversized_packet) ==
+                EncodeStatus::Ok,
+            "could not construct codec limit fixture"
+        );
+        WriteBytes(limit_path, oversized_packet);
+
+        ProcessRunner runner(executable, temporary.path);
+        TestComplete(runner, complete_path);
+        TestForensic(runner, forensic_path);
+        TestProtocolViolation(runner, protocol_path);
+        TestMissingFile(runner, temporary.path / "missing.mpd");
+        TestLimitExceeded(runner, limit_path);
+        TestInvalidArguments(runner, complete_path);
+
+        std::cout << "ProfileSummary CLI contract passed\n";
+        return 0;
+    } catch (const std::exception& error) {
+        std::cerr << "ProfileSummary CLI contract failed: " << error.what() << '\n';
+        return 1;
+    }
+}

--- a/source/test/ProfileSummaryCliTest.cpp
+++ b/source/test/ProfileSummaryCliTest.cpp
@@ -507,6 +507,58 @@ void ExpectContractHeader(const Json& _document) {
     Expect(_document.at("version") == 1, "summary contract version changed");
 }
 
+void TestCliBoundaryContract() {
+    SessionErrorCode emergency_error  = SessionErrorCode::None;
+    const auto       emergency_writer = [&](SessionErrorCode _error) noexcept {
+        emergency_error = _error;
+    };
+
+    Expect(
+        RunProfileSummaryCliBoundary(
+            [] {
+                return 2;
+            },
+            emergency_writer
+        ) == 2 &&
+            emergency_error == SessionErrorCode::None,
+        "CLI boundary changed a normal exit code"
+    );
+    Expect(
+        RunProfileSummaryCliBoundary(
+            []() -> int {
+                throw std::bad_alloc{};
+            },
+            emergency_writer
+        ) == 14 &&
+            emergency_error == SessionErrorCode::ResourceAllocationFailed,
+        "CLI boundary did not map bad_alloc to exit code 14"
+    );
+    Expect(
+        RunProfileSummaryCliBoundary(
+            []() -> int {
+                throw 7;
+            },
+            emergency_writer
+        ) == 14 &&
+            emergency_error == SessionErrorCode::UnexpectedFailure,
+        "CLI boundary did not map an unexpected exception to exit code 14"
+    );
+
+    for (const SessionErrorCode error :
+         {SessionErrorCode::ResourceAllocationFailed, SessionErrorCode::UnexpectedFailure}) {
+        const Json emergency = Json::parse(ProfileSummaryEmergencyJson(error));
+        ExpectContractHeader(emergency);
+        Expect(
+            emergency.at("load").at("status") == "resource_exhausted" &&
+                emergency.at("load").at("error_code") ==
+                    (error == SessionErrorCode::ResourceAllocationFailed ? "resource_allocation_failed" :
+                                                                           "unexpected_failure") &&
+                emergency.at("load").at("codec_status") == "ok" && !emergency.contains("session"),
+            "emergency JSON contract changed"
+        );
+    }
+}
+
 void ExpectLoadU64Fields(const Json& _document) {
     const Json& load = _document.at("load");
     ExpectU64(load.at("input_bytes"), "load.input_bytes");
@@ -551,7 +603,7 @@ void ExpectUsableSessionU64Fields(const Json& _document, bool _has_session_end) 
     }
 
     const Json& gpu = _document.at("gpu");
-    for (const char* field : {"total", "complete", "incomplete", "invalid"}) {
+    for (const char* field : {"total", "complete", "degraded_complete", "incomplete", "invalid"}) {
         ExpectU64(gpu.at("frames").at(field), std::string("gpu.frames.") + field);
     }
     for (const char* field : {"total", "ready", "error", "orphan"}) {
@@ -628,9 +680,10 @@ void TestComplete(ProcessRunner& _runner, const std::filesystem::path& _path) {
         gpu.at("clock") == "raw_device_ticks" && gpu.at("cross_cpu_alignment") == "none" &&
             gpu.at("cross_domain_alignment") == "none" && gpu.at("tracks") == "1" &&
             gpu.at("frames").at("total") == "1" && gpu.at("frames").at("complete") == "1" &&
-            gpu.at("frames").at("incomplete") == "0" && gpu.at("frames").at("invalid") == "0" &&
-            gpu.at("scopes").at("total") == "1" && gpu.at("scopes").at("ready") == "1" &&
-            gpu.at("scopes").at("error") == "0" && gpu.at("scopes").at("orphan") == "0",
+            gpu.at("frames").at("degraded_complete") == "0" && gpu.at("frames").at("incomplete") == "0" &&
+            gpu.at("frames").at("invalid") == "0" && gpu.at("scopes").at("total") == "1" &&
+            gpu.at("scopes").at("ready") == "1" && gpu.at("scopes").at("error") == "0" &&
+            gpu.at("scopes").at("orphan") == "0",
         "complete GPU summary changed"
     );
     Expect(gpu.at("domains").size() == 1, "complete GPU domain count changed");
@@ -638,9 +691,9 @@ void TestComplete(ProcessRunner& _runner, const std::filesystem::path& _path) {
     Expect(
         domain.at("native_queue_id") == 5 && domain.at("family_id") == 6 &&
             domain.at("logical_queues") == Json::array({"graphics"}) &&
-            domain.at("has_ready_timestamps") == true && domain.at("valid_bits") == 64 &&
-            domain.at("tick_period_ns") == 2.0 && domain.at("ready_scopes") == "1" &&
-            domain.at("error_scopes") == "0",
+            domain.at("has_ready_timestamps") == true && domain.at("timing_capability_trusted") == true &&
+            domain.at("valid_bits") == 64 && domain.at("tick_period_ns") == 2.0 &&
+            domain.at("ready_scopes") == "1" && domain.at("error_scopes") == "0",
         "complete GPU domain metadata changed"
     );
 }
@@ -734,6 +787,7 @@ void TestInvalidArguments(ProcessRunner& _runner, const std::filesystem::path& _
 
 int main(int _argument_count, char** _arguments) {
     try {
+        TestCliBoundaryContract();
         Expect(_argument_count == 2, "expected MoerProfileSummary path in argv[1]");
         const std::filesystem::path executable = std::filesystem::absolute(_arguments[1]);
         Expect(std::filesystem::is_regular_file(executable), "MoerProfileSummary executable does not exist");

--- a/source/tool/profile_consumer/CMakeLists.txt
+++ b/source/tool/profile_consumer/CMakeLists.txt
@@ -1,0 +1,41 @@
+set(target_name moer_profile_consumer)
+
+file(GLOB_RECURSE profile_consumer_headers CONFIGURE_DEPENDS "include/*.h")
+file(GLOB_RECURSE profile_consumer_sources CONFIGURE_DEPENDS "source/*.cpp")
+
+source_group(
+    TREE ${CMAKE_CURRENT_SOURCE_DIR}
+    FILES ${profile_consumer_headers} ${profile_consumer_sources}
+)
+
+add_library(
+    ${target_name}
+    STATIC
+    ${profile_consumer_headers}
+    ${profile_consumer_sources}
+)
+add_library(Moer::ProfileConsumer ALIAS ${target_name})
+
+target_include_directories(
+    ${target_name}
+    PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+)
+target_link_libraries(
+    ${target_name}
+    PUBLIC Moer::Core
+)
+
+set_target_properties(${target_name} PROPERTIES FOLDER "tool")
+set_target_properties(${target_name} PROPERTIES POSITION_INDEPENDENT_CODE ON)
+
+add_executable(
+    MoerProfileSummary
+    "app/ProfileSummaryMain.cpp"
+)
+target_link_libraries(
+    MoerProfileSummary
+    PRIVATE
+        Moer::ProfileConsumer
+        nlohmann_json::nlohmann_json
+)
+set_target_properties(MoerProfileSummary PROPERTIES FOLDER "tool")

--- a/source/tool/profile_consumer/app/ProfileSummaryMain.cpp
+++ b/source/tool/profile_consumer/app/ProfileSummaryMain.cpp
@@ -220,6 +220,8 @@ using Json = nlohmann::ordered_json;
             return "scope_depth";
         case SessionLimitKind::TopologyWorkItems:
             return "topology_work_items";
+        case SessionLimitKind::TopologyFlowEdges:
+            return "topology_flow_edges";
     }
     return "unknown";
 }

--- a/source/tool/profile_consumer/app/ProfileSummaryMain.cpp
+++ b/source/tool/profile_consumer/app/ProfileSummaryMain.cpp
@@ -1,0 +1,397 @@
+#include "profile_consumer/ProfileSession.h"
+#include "profile_consumer/ProfileSummaryContract.h"
+
+#include <nlohmann/json.hpp>
+
+#include <cstdint>
+#include <iostream>
+#include <string>
+#include <string_view>
+
+namespace {
+
+using namespace Moer::ProfileDump;
+using Json = nlohmann::ordered_json;
+
+[[nodiscard]] const char* StatusName(SessionLoadStatus _status) noexcept {
+    switch (_status) {
+        case SessionLoadStatus::Reading:
+            return "reading";
+        case SessionLoadStatus::Complete:
+            return "complete";
+        case SessionLoadStatus::ForensicTruncated:
+            return "forensic_truncated";
+        case SessionLoadStatus::InvalidArgument:
+            return "invalid_argument";
+        case SessionLoadStatus::OpenFailed:
+            return "open_failed";
+        case SessionLoadStatus::ReadFailed:
+            return "read_failed";
+        case SessionLoadStatus::UnsupportedVersion:
+            return "unsupported_version";
+        case SessionLoadStatus::CorruptData:
+            return "corrupt_data";
+        case SessionLoadStatus::ProtocolViolation:
+            return "protocol_violation";
+        case SessionLoadStatus::LimitExceeded:
+            return "limit_exceeded";
+        case SessionLoadStatus::ResourceExhausted:
+            return "resource_exhausted";
+    }
+    return "unknown";
+}
+
+[[nodiscard]] const char* IncompleteReasonName(SessionIncompleteReason _reason) noexcept {
+    switch (_reason) {
+        case SessionIncompleteReason::None:
+            return "none";
+        case SessionIncompleteReason::MissingSessionEnd:
+            return "missing_session_end";
+        case SessionIncompleteReason::TruncatedHeader:
+            return "truncated_header";
+        case SessionIncompleteReason::TruncatedPayload:
+            return "truncated_payload";
+    }
+    return "unknown";
+}
+
+[[nodiscard]] const char* ErrorCodeName(SessionErrorCode _code) noexcept {
+    switch (_code) {
+        case SessionErrorCode::None:
+            return "none";
+        case SessionErrorCode::InvalidArgument:
+            return "invalid_argument";
+        case SessionErrorCode::FileOpenFailed:
+            return "file_open_failed";
+        case SessionErrorCode::FileReadFailed:
+            return "file_read_failed";
+        case SessionErrorCode::ResourceAllocationFailed:
+            return "resource_allocation_failed";
+        case SessionErrorCode::UnexpectedFailure:
+            return "unexpected_failure";
+        case SessionErrorCode::LimitExceeded:
+            return "limit_exceeded";
+        case SessionErrorCode::CodecHeaderInvalid:
+            return "codec_header_invalid";
+        case SessionErrorCode::CodecPacketInvalid:
+            return "codec_packet_invalid";
+        case SessionErrorCode::SessionBeginMissing:
+            return "session_begin_missing";
+        case SessionErrorCode::SessionBeginDuplicate:
+            return "session_begin_duplicate";
+        case SessionErrorCode::SessionEndMissing:
+            return "session_end_missing";
+        case SessionErrorCode::SessionEndTotalsMismatch:
+            return "session_end_totals_mismatch";
+        case SessionErrorCode::PacketIndexMismatch:
+            return "packet_index_mismatch";
+        case SessionErrorCode::TrailingDataAfterSessionEnd:
+            return "trailing_data_after_session_end";
+        case SessionErrorCode::TruncatedPacket:
+            return "truncated_packet";
+        case SessionErrorCode::SchemaDecodeInvalid:
+            return "schema_decode_invalid";
+        case SessionErrorCode::SchemaConflict:
+            return "schema_conflict";
+        case SessionErrorCode::RecordPayloadInvalid:
+            return "record_payload_invalid";
+        case SessionErrorCode::RecordSchemaUnregistered:
+            return "record_schema_unregistered";
+        case SessionErrorCode::RecordSequenceDuplicate:
+            return "record_sequence_duplicate";
+        case SessionErrorCode::LossPayloadInvalid:
+            return "loss_payload_invalid";
+        case SessionErrorCode::LossTotalsOverflow:
+            return "loss_totals_overflow";
+        case SessionErrorCode::CpuScopePayloadInvalid:
+            return "cpu_scope_payload_invalid";
+        case SessionErrorCode::CpuScopeTimeInvalid:
+            return "cpu_scope_time_invalid";
+        case SessionErrorCode::CpuScopeParentMissing:
+            return "cpu_scope_parent_missing";
+        case SessionErrorCode::GpuFramePayloadInvalid:
+            return "gpu_frame_payload_invalid";
+        case SessionErrorCode::GpuFrameStatusInvalid:
+            return "gpu_frame_status_invalid";
+        case SessionErrorCode::GpuFrameDuplicate:
+            return "gpu_frame_duplicate";
+        case SessionErrorCode::GpuFrameTotalsMismatch:
+            return "gpu_frame_totals_mismatch";
+        case SessionErrorCode::GpuScopePayloadInvalid:
+            return "gpu_scope_payload_invalid";
+        case SessionErrorCode::GpuScopeIdentityInvalid:
+            return "gpu_scope_identity_invalid";
+        case SessionErrorCode::GpuScopeQueueInvalid:
+            return "gpu_scope_queue_invalid";
+        case SessionErrorCode::GpuScopeStatusInvalid:
+            return "gpu_scope_status_invalid";
+        case SessionErrorCode::GpuScopeTimingInvalid:
+            return "gpu_scope_timing_invalid";
+        case SessionErrorCode::GpuDomainConflict:
+            return "gpu_domain_conflict";
+        case SessionErrorCode::GpuScopeDuplicate:
+            return "gpu_scope_duplicate";
+        case SessionErrorCode::GpuScopeFrameMissing:
+            return "gpu_scope_frame_missing";
+        case SessionErrorCode::GpuScopeRootDepthInvalid:
+            return "gpu_scope_root_depth_invalid";
+        case SessionErrorCode::GpuScopeParentMissing:
+            return "gpu_scope_parent_missing";
+        case SessionErrorCode::GpuScopeParentInvalid:
+            return "gpu_scope_parent_invalid";
+    }
+    return "unknown";
+}
+
+[[nodiscard]] const char* CodecStatusName(DecodeStatus _status) noexcept {
+    switch (_status) {
+        case DecodeStatus::Ok:
+            return "ok";
+        case DecodeStatus::NeedMoreData:
+            return "need_more_data";
+        case DecodeStatus::InvalidMagic:
+            return "invalid_magic";
+        case DecodeStatus::UnsupportedVersion:
+            return "unsupported_version";
+        case DecodeStatus::InvalidHeader:
+            return "invalid_header";
+        case DecodeStatus::UnknownPacketType:
+            return "unknown_packet_type";
+        case DecodeStatus::UnsupportedFlags:
+            return "unsupported_flags";
+        case DecodeStatus::PayloadTooLarge:
+            return "payload_too_large";
+        case DecodeStatus::ChecksumMismatch:
+            return "checksum_mismatch";
+        case DecodeStatus::MalformedPayload:
+            return "malformed_payload";
+        case DecodeStatus::LimitExceeded:
+            return "limit_exceeded";
+        case DecodeStatus::SchemaHashMismatch:
+            return "schema_hash_mismatch";
+        case DecodeStatus::UnknownSchema:
+            return "unknown_schema";
+    }
+    return "unknown";
+}
+
+[[nodiscard]] const char* LimitName(SessionLimitKind _limit) noexcept {
+    switch (_limit) {
+        case SessionLimitKind::None:
+            return "none";
+        case SessionLimitKind::Codec:
+            return "codec";
+        case SessionLimitKind::InputBytes:
+            return "input_bytes";
+        case SessionLimitKind::Packets:
+            return "packets";
+        case SessionLimitKind::Schemas:
+            return "schemas";
+        case SessionLimitKind::SchemaBytes:
+            return "schema_bytes";
+        case SessionLimitKind::Records:
+            return "records";
+        case SessionLimitKind::LossNotices:
+            return "loss_notices";
+        case SessionLimitKind::CpuScopes:
+            return "cpu_scopes";
+        case SessionLimitKind::GpuFrames:
+            return "gpu_frames";
+        case SessionLimitKind::GpuScopes:
+            return "gpu_scopes";
+        case SessionLimitKind::CpuTracks:
+            return "cpu_tracks";
+        case SessionLimitKind::GpuTracks:
+            return "gpu_tracks";
+        case SessionLimitKind::GpuDomains:
+            return "gpu_domains";
+        case SessionLimitKind::UniqueStrings:
+            return "unique_strings";
+        case SessionLimitKind::StringBytes:
+            return "string_bytes";
+        case SessionLimitKind::LogicalModelBytes:
+            return "logical_model_bytes";
+        case SessionLimitKind::ScopeDepth:
+            return "scope_depth";
+    }
+    return "unknown";
+}
+
+[[nodiscard]] std::string U64(std::uint64_t _value) {
+    return std::to_string(_value);
+}
+
+[[nodiscard]] Json OptionalU64(std::uint64_t _value) {
+    return _value == kInvalidSessionIndex ? Json(nullptr) : Json(U64(_value));
+}
+
+[[nodiscard]] Json BuildJson(const SessionLoadResult& _result, const ProfileSession& _session) {
+    Json document{
+        {"contract", kProfileSummaryContractName},
+        {"version", kProfileSummaryContractVersion},
+        {
+            "load",
+            {
+                {"status", StatusName(_result.status)},
+                {"incomplete_reason", IncompleteReasonName(_result.incomplete_reason)},
+                {"error_code", ErrorCodeName(_result.error_code)},
+                {"limit", LimitName(_result.limit_kind)},
+                {"codec_status", CodecStatusName(_result.codec_status)},
+                {"input_bytes", U64(_result.input_bytes)},
+                {"valid_prefix_bytes", U64(_result.valid_prefix_bytes)},
+                {"error_byte_offset", OptionalU64(_result.error_byte_offset)},
+                {"error_packet_index", OptionalU64(_result.error_packet_index)},
+                {"incomplete_byte_offset", OptionalU64(_result.incomplete_byte_offset)},
+                {"incomplete_packet_index", OptionalU64(_result.incomplete_packet_index)},
+            },
+        },
+    };
+    if (!_result.HasUsableSession()) {
+        return document;
+    }
+
+    const ProfileSessionSummary& summary = _session.Summary();
+    document["session"]                  = {
+        {"generation", U64(summary.generation)},
+        {"started_unix_ns", U64(summary.started_unix_ns)},
+        {"has_session_end", summary.has_session_end},
+        {
+            "records_written",
+            summary.has_session_end ? Json(U64(summary.session_end_records_written)) : Json(nullptr),
+        },
+        {
+            "records_dropped",
+            summary.has_session_end ? Json(U64(summary.session_end_records_dropped)) : Json(nullptr),
+        },
+    };
+    document["packets"] = {
+        {"total", U64(summary.packet_count)},
+        {"schema_packets", U64(summary.schema_packet_count)},
+        {"unique_schemas", U64(summary.unique_schema_count)},
+        {"records", U64(summary.record_count)},
+        {"loss_notices", U64(summary.loss_notice_count)},
+    };
+    document["records"] = {
+        {"cpu_scopes", U64(summary.cpu_scope_count)},
+        {"gpu_frames", U64(summary.gpu_frame_count)},
+        {"gpu_scopes", U64(summary.gpu_scope_count)},
+        {"unknown", U64(summary.unknown_record_count)},
+    };
+    document["loss"] = {
+        {"noticed_records", U64(summary.lost_record_count)},
+        {
+            "unnotified_records",
+            summary.has_session_end ? Json(U64(summary.unnotified_drop_count)) : Json(nullptr),
+        },
+        {"value_bytes", U64(summary.lost_value_bytes)},
+        {"reason_mask", U64(summary.loss_reason_mask)},
+    };
+    document["cpu"] = {
+        {"clock", "steady_clock_ns"},
+        {"absolute_unix_anchor", false},
+        {"tracks", U64(_session.CpuTracks().size())},
+        {"scopes", U64(summary.cpu_scope_count)},
+        {"orphan_scopes", U64(summary.orphan_cpu_scope_count)},
+        {"has_range", summary.has_cpu_range},
+        {"begin_ns", U64(summary.cpu_begin_ns)},
+        {"end_ns", U64(summary.cpu_end_ns)},
+    };
+    document["gpu"] = {
+        {"clock", "raw_device_ticks"},
+        {"cross_cpu_alignment", "none"},
+        {"cross_domain_alignment", "none"},
+        {
+            "frames",
+            {
+                {"total", U64(summary.gpu_frame_count)},
+                {"complete", U64(summary.complete_gpu_frame_count)},
+                {"incomplete", U64(summary.incomplete_gpu_frame_count)},
+                {"invalid", U64(summary.invalid_gpu_frame_count)},
+            },
+        },
+        {
+            "scopes",
+            {
+                {"total", U64(summary.gpu_scope_count)},
+                {"ready", U64(summary.ready_gpu_scope_count)},
+                {"error", U64(summary.error_gpu_scope_count)},
+                {"orphan", U64(summary.orphan_gpu_scope_count)},
+            },
+        },
+        {"tracks", U64(_session.GpuTracks().size())},
+    };
+
+    Json domains = Json::array();
+    for (const GpuTimestampDomain& domain : _session.GpuDomains()) {
+        Json logical_queues = Json::array();
+        if ((domain.logical_queue_mask & ProfileLogicalQueueBit(ProfileLogicalQueue::Graphics)) != 0) {
+            logical_queues.push_back("graphics");
+        }
+        if ((domain.logical_queue_mask & ProfileLogicalQueueBit(ProfileLogicalQueue::Compute)) != 0) {
+            logical_queues.push_back("compute");
+        }
+        if ((domain.logical_queue_mask & ProfileLogicalQueueBit(ProfileLogicalQueue::Copy)) != 0) {
+            logical_queues.push_back("copy");
+        }
+        domains.push_back({
+            {"native_queue_id", domain.native_queue_id},
+            {"family_id", domain.family_id},
+            {"logical_queues", std::move(logical_queues)},
+            {"has_ready_timestamps", domain.has_ready_timestamps},
+            {"valid_bits", domain.valid_bits},
+            {"tick_period_ns", domain.tick_period_ns},
+            {"ready_scopes", U64(domain.ready_scope_count)},
+            {"error_scopes", U64(domain.error_scope_count)},
+        });
+    }
+    document["gpu"]["domains"]      = std::move(domains);
+    document["logical_model_bytes"] = U64(summary.logical_model_bytes);
+    return document;
+}
+
+int RunSummary(const std::filesystem::path& _path, const SessionLoadOptions& _options) {
+    ProfileSession          session;
+    const SessionLoadResult result = LoadProfileSessionFile(_path, _options, session);
+    std::cout << BuildJson(result, session).dump(2) << '\n';
+    return ProfileSummaryExitCode(result.status);
+}
+
+} // namespace
+
+#if defined(_WIN32)
+int wmain(int _argument_count, wchar_t** _arguments) {
+    if (_argument_count < 2 || _argument_count > 3) {
+        std::cerr << "usage: MoerProfileSummary <capture.mpd> [--allow-truncated]\n";
+        return 10;
+    }
+
+    SessionLoadOptions options{};
+    if (_argument_count == 3) {
+        if (std::wstring_view(_arguments[2]) != L"--allow-truncated") {
+            std::wcerr << L"unknown option: " << _arguments[2] << L'\n';
+            return 10;
+        }
+        options.allow_forensic_truncation = true;
+    }
+
+    return RunSummary(std::filesystem::path(_arguments[1]), options);
+}
+#else
+int main(int _argument_count, char** _arguments) {
+    if (_argument_count < 2 || _argument_count > 3) {
+        std::cerr << "usage: MoerProfileSummary <capture.mpd> [--allow-truncated]\n";
+        return 10;
+    }
+
+    SessionLoadOptions options{};
+    if (_argument_count == 3) {
+        if (std::string_view(_arguments[2]) != "--allow-truncated") {
+            std::cerr << "unknown option: " << _arguments[2] << '\n';
+            return 10;
+        }
+        options.allow_forensic_truncation = true;
+    }
+
+    return RunSummary(std::filesystem::path(_arguments[1]), options);
+}
+#endif

--- a/source/tool/profile_consumer/app/ProfileSummaryMain.cpp
+++ b/source/tool/profile_consumer/app/ProfileSummaryMain.cpp
@@ -4,6 +4,7 @@
 #include <nlohmann/json.hpp>
 
 #include <cstdint>
+#include <cstdio>
 #include <iostream>
 #include <string>
 #include <string_view>
@@ -99,6 +100,8 @@ using Json = nlohmann::ordered_json;
             return "record_schema_unregistered";
         case SessionErrorCode::RecordSequenceDuplicate:
             return "record_sequence_duplicate";
+        case SessionErrorCode::RecordSequenceInvalid:
+            return "record_sequence_invalid";
         case SessionErrorCode::LossPayloadInvalid:
             return "loss_payload_invalid";
         case SessionErrorCode::LossTotalsOverflow:
@@ -139,6 +142,8 @@ using Json = nlohmann::ordered_json;
             return "gpu_scope_parent_missing";
         case SessionErrorCode::GpuScopeParentInvalid:
             return "gpu_scope_parent_invalid";
+        case SessionErrorCode::CpuScopeTopologyInvalid:
+            return "cpu_scope_topology_invalid";
     }
     return "unknown";
 }
@@ -213,6 +218,8 @@ using Json = nlohmann::ordered_json;
             return "logical_model_bytes";
         case SessionLimitKind::ScopeDepth:
             return "scope_depth";
+        case SessionLimitKind::TopologyWorkItems:
+            return "topology_work_items";
     }
     return "unknown";
 }
@@ -305,6 +312,7 @@ using Json = nlohmann::ordered_json;
             {
                 {"total", U64(summary.gpu_frame_count)},
                 {"complete", U64(summary.complete_gpu_frame_count)},
+                {"degraded_complete", U64(summary.degraded_complete_gpu_frame_count)},
                 {"incomplete", U64(summary.incomplete_gpu_frame_count)},
                 {"invalid", U64(summary.invalid_gpu_frame_count)},
             },
@@ -338,6 +346,7 @@ using Json = nlohmann::ordered_json;
             {"family_id", domain.family_id},
             {"logical_queues", std::move(logical_queues)},
             {"has_ready_timestamps", domain.has_ready_timestamps},
+            {"timing_capability_trusted", domain.timing_capability_trusted},
             {"valid_bits", domain.valid_bits},
             {"tick_period_ns", domain.tick_period_ns},
             {"ready_scopes", U64(domain.ready_scope_count)},
@@ -352,46 +361,70 @@ using Json = nlohmann::ordered_json;
 int RunSummary(const std::filesystem::path& _path, const SessionLoadOptions& _options) {
     ProfileSession          session;
     const SessionLoadResult result = LoadProfileSessionFile(_path, _options, session);
-    std::cout << BuildJson(result, session).dump(2) << '\n';
+    std::string             output = BuildJson(result, session).dump(2);
+    output.push_back('\n');
+    if (std::fwrite(output.data(), 1, output.size(), stdout) != output.size()) {
+        return ProfileSummaryExitCode(SessionLoadStatus::ResourceExhausted);
+    }
     return ProfileSummaryExitCode(result.status);
+}
+
+void WriteEmergencySummary(SessionErrorCode _error) noexcept {
+    const std::string_view output = ProfileSummaryEmergencyJson(_error);
+    std::fwrite(output.data(), 1, output.size(), stdout);
+    std::fputc('\n', stdout);
 }
 
 } // namespace
 
 #if defined(_WIN32)
 int wmain(int _argument_count, wchar_t** _arguments) {
-    if (_argument_count < 2 || _argument_count > 3) {
-        std::cerr << "usage: MoerProfileSummary <capture.mpd> [--allow-truncated]\n";
-        return 10;
-    }
+    return RunProfileSummaryCliBoundary(
+        [&]() -> int {
+            if (_argument_count < 2 || _argument_count > 3) {
+                std::cerr << "usage: MoerProfileSummary <capture.mpd> [--allow-truncated]\n";
+                return 10;
+            }
 
-    SessionLoadOptions options{};
-    if (_argument_count == 3) {
-        if (std::wstring_view(_arguments[2]) != L"--allow-truncated") {
-            std::wcerr << L"unknown option: " << _arguments[2] << L'\n';
-            return 10;
+            SessionLoadOptions options{};
+            if (_argument_count == 3) {
+                if (std::wstring_view(_arguments[2]) != L"--allow-truncated") {
+                    std::wcerr << L"unknown option: " << _arguments[2] << L'\n';
+                    return 10;
+                }
+                options.allow_forensic_truncation = true;
+            }
+
+            return RunSummary(std::filesystem::path(_arguments[1]), options);
+        },
+        [](SessionErrorCode _error) noexcept {
+            WriteEmergencySummary(_error);
         }
-        options.allow_forensic_truncation = true;
-    }
-
-    return RunSummary(std::filesystem::path(_arguments[1]), options);
+    );
 }
 #else
 int main(int _argument_count, char** _arguments) {
-    if (_argument_count < 2 || _argument_count > 3) {
-        std::cerr << "usage: MoerProfileSummary <capture.mpd> [--allow-truncated]\n";
-        return 10;
-    }
+    return RunProfileSummaryCliBoundary(
+        [&]() -> int {
+            if (_argument_count < 2 || _argument_count > 3) {
+                std::cerr << "usage: MoerProfileSummary <capture.mpd> [--allow-truncated]\n";
+                return 10;
+            }
 
-    SessionLoadOptions options{};
-    if (_argument_count == 3) {
-        if (std::string_view(_arguments[2]) != "--allow-truncated") {
-            std::cerr << "unknown option: " << _arguments[2] << '\n';
-            return 10;
+            SessionLoadOptions options{};
+            if (_argument_count == 3) {
+                if (std::string_view(_arguments[2]) != "--allow-truncated") {
+                    std::cerr << "unknown option: " << _arguments[2] << '\n';
+                    return 10;
+                }
+                options.allow_forensic_truncation = true;
+            }
+
+            return RunSummary(std::filesystem::path(_arguments[1]), options);
+        },
+        [](SessionErrorCode _error) noexcept {
+            WriteEmergencySummary(_error);
         }
-        options.allow_forensic_truncation = true;
-    }
-
-    return RunSummary(std::filesystem::path(_arguments[1]), options);
+    );
 }
 #endif

--- a/source/tool/profile_consumer/include/profile_consumer/ProfileSession.h
+++ b/source/tool/profile_consumer/include/profile_consumer/ProfileSession.h
@@ -8,6 +8,7 @@
 #include <limits>
 #include <span>
 #include <string_view>
+#include <type_traits>
 
 namespace Moer::ProfileDump {
 
@@ -15,6 +16,26 @@ using SessionStringId = std::uint32_t;
 
 inline constexpr SessionStringId kInvalidSessionString = std::numeric_limits<SessionStringId>::max();
 inline constexpr std::uint64_t   kInvalidSessionIndex  = std::numeric_limits<std::uint64_t>::max();
+
+namespace Detail {
+
+// Compute the full wire size before converting the untrusted uint32 payload
+// length to the address-space-sized reader counter. The generic Size keeps the
+// 32-bit boundary independently testable on a 64-bit build.
+template<typename Size>
+[[nodiscard]] constexpr bool TryPacketWireBytes(std::uint32_t _payload_bytes, Size& _result) noexcept {
+    static_assert(std::is_unsigned_v<Size>);
+    constexpr std::uint64_t maximum = static_cast<std::uint64_t>(std::numeric_limits<Size>::max());
+    const std::uint64_t     total =
+        static_cast<std::uint64_t>(kPacketHeaderBytes) + static_cast<std::uint64_t>(_payload_bytes);
+    if (total > maximum) {
+        return false;
+    }
+    _result = static_cast<Size>(total);
+    return true;
+}
+
+} // namespace Detail
 
 enum class SessionLoadStatus : std::uint8_t {
     Reading = 0,
@@ -61,6 +82,7 @@ enum class SessionErrorCode : std::uint16_t {
     RecordPayloadInvalid,
     RecordSchemaUnregistered,
     RecordSequenceDuplicate,
+    RecordSequenceInvalid,
     LossPayloadInvalid,
     LossTotalsOverflow,
     CpuScopePayloadInvalid,
@@ -81,6 +103,7 @@ enum class SessionErrorCode : std::uint16_t {
     GpuScopeRootDepthInvalid,
     GpuScopeParentMissing,
     GpuScopeParentInvalid,
+    CpuScopeTopologyInvalid,
 };
 
 enum class SessionLimitKind : std::uint8_t {
@@ -102,6 +125,7 @@ enum class SessionLimitKind : std::uint8_t {
     StringBytes,
     LogicalModelBytes,
     ScopeDepth,
+    TopologyWorkItems,
 };
 
 enum class KnownProfileSchema : std::uint8_t {
@@ -149,6 +173,7 @@ struct SessionLimits {
     std::uint32_t max_gpu_tracks{1024};
     std::uint32_t max_gpu_domains{256};
     std::uint32_t max_scope_depth{1024};
+    std::uint64_t max_topology_work_items{1'000'000};
 
     std::uint32_t max_unique_strings{1'000'000};
     std::uint64_t max_string_bytes{256ull * 1024 * 1024};
@@ -245,6 +270,9 @@ struct GpuFrameRecord {
     std::uint64_t         error_scope_count{0};
     SessionStringId       reason{kInvalidSessionString};
     std::uint64_t         scope_count{0};
+    std::uint64_t         export_missing_scope_count{0};
+    bool                  materialization_complete{false};
+    bool                  timing_topology_trusted{false};
 };
 
 // One physical timestamp domain. Different logical roles may share it when
@@ -256,6 +284,7 @@ struct GpuTimestampDomain {
     // Bit positions are defined by ProfileLogicalQueue.
     std::uint32_t logical_queue_mask{0};
     bool          has_ready_timestamps{false};
+    bool          timing_capability_trusted{false};
     std::uint32_t valid_bits{0};
     double        tick_period_ns{0.0};
     std::uint64_t ready_scope_count{0};
@@ -319,6 +348,7 @@ struct ProfileSessionSummary {
     std::uint64_t unknown_record_count{0};
 
     std::uint64_t complete_gpu_frame_count{0};
+    std::uint64_t degraded_complete_gpu_frame_count{0};
     std::uint64_t incomplete_gpu_frame_count{0};
     std::uint64_t invalid_gpu_frame_count{0};
     std::uint64_t ready_gpu_scope_count{0};

--- a/source/tool/profile_consumer/include/profile_consumer/ProfileSession.h
+++ b/source/tool/profile_consumer/include/profile_consumer/ProfileSession.h
@@ -126,6 +126,7 @@ enum class SessionLimitKind : std::uint8_t {
     LogicalModelBytes,
     ScopeDepth,
     TopologyWorkItems,
+    TopologyFlowEdges,
 };
 
 enum class KnownProfileSchema : std::uint8_t {
@@ -179,6 +180,10 @@ struct SessionLimits {
     // independent record/scope count limits. Callers handling untrusted
     // captures should lower it to their latency budget.
     std::uint64_t max_topology_work_items{1'000'000'000};
+    // Counts forward residual-network edges before allocation. Reverse edges
+    // are checked separately for addressability and allocated as part of each
+    // admitted forward edge.
+    std::uint64_t max_topology_flow_edges{1'000'000};
 
     std::uint32_t max_unique_strings{1'000'000};
     std::uint64_t max_string_bytes{256ull * 1024 * 1024};

--- a/source/tool/profile_consumer/include/profile_consumer/ProfileSession.h
+++ b/source/tool/profile_consumer/include/profile_consumer/ProfileSession.h
@@ -173,7 +173,12 @@ struct SessionLimits {
     std::uint32_t max_gpu_tracks{1024};
     std::uint32_t max_gpu_domains{256};
     std::uint32_t max_scope_depth{1024};
-    std::uint64_t max_topology_work_items{1'000'000};
+    // Covers ordinary O(N log N) indexing as well as exceptional topology
+    // reconstruction. This default accommodates practical offline captures,
+    // but the shared work budget may reject adversarial inputs before the
+    // independent record/scope count limits. Callers handling untrusted
+    // captures should lower it to their latency budget.
+    std::uint64_t max_topology_work_items{1'000'000'000};
 
     std::uint32_t max_unique_strings{1'000'000};
     std::uint64_t max_string_bytes{256ull * 1024 * 1024};

--- a/source/tool/profile_consumer/include/profile_consumer/ProfileSession.h
+++ b/source/tool/profile_consumer/include/profile_consumer/ProfileSession.h
@@ -1,0 +1,410 @@
+#ifndef MOER_ENGINE_PROFILE_SESSION_H
+#define MOER_ENGINE_PROFILE_SESSION_H
+
+#include "profile/ProfileDumpCodec.h"
+
+#include <cstdint>
+#include <filesystem>
+#include <limits>
+#include <span>
+#include <string_view>
+
+namespace Moer::ProfileDump {
+
+using SessionStringId = std::uint32_t;
+
+inline constexpr SessionStringId kInvalidSessionString = std::numeric_limits<SessionStringId>::max();
+inline constexpr std::uint64_t   kInvalidSessionIndex  = std::numeric_limits<std::uint64_t>::max();
+
+enum class SessionLoadStatus : std::uint8_t {
+    Reading = 0,
+    Complete,
+    ForensicTruncated,
+    InvalidArgument,
+    OpenFailed,
+    ReadFailed,
+    UnsupportedVersion,
+    CorruptData,
+    ProtocolViolation,
+    LimitExceeded,
+    ResourceExhausted,
+};
+
+enum class SessionIncompleteReason : std::uint8_t {
+    None = 0,
+    MissingSessionEnd,
+    TruncatedHeader,
+    TruncatedPayload,
+};
+
+// Stable machine-readable reason for terminal load failures. A successful
+// Complete/ForensicTruncated result always reports None.
+enum class SessionErrorCode : std::uint16_t {
+    None = 0,
+    InvalidArgument,
+    FileOpenFailed,
+    FileReadFailed,
+    ResourceAllocationFailed,
+    UnexpectedFailure,
+    LimitExceeded,
+    CodecHeaderInvalid,
+    CodecPacketInvalid,
+    SessionBeginMissing,
+    SessionBeginDuplicate,
+    SessionEndMissing,
+    SessionEndTotalsMismatch,
+    PacketIndexMismatch,
+    TrailingDataAfterSessionEnd,
+    TruncatedPacket,
+    SchemaDecodeInvalid,
+    SchemaConflict,
+    RecordPayloadInvalid,
+    RecordSchemaUnregistered,
+    RecordSequenceDuplicate,
+    LossPayloadInvalid,
+    LossTotalsOverflow,
+    CpuScopePayloadInvalid,
+    CpuScopeTimeInvalid,
+    CpuScopeParentMissing,
+    GpuFramePayloadInvalid,
+    GpuFrameStatusInvalid,
+    GpuFrameDuplicate,
+    GpuFrameTotalsMismatch,
+    GpuScopePayloadInvalid,
+    GpuScopeIdentityInvalid,
+    GpuScopeQueueInvalid,
+    GpuScopeStatusInvalid,
+    GpuScopeTimingInvalid,
+    GpuDomainConflict,
+    GpuScopeDuplicate,
+    GpuScopeFrameMissing,
+    GpuScopeRootDepthInvalid,
+    GpuScopeParentMissing,
+    GpuScopeParentInvalid,
+};
+
+enum class SessionLimitKind : std::uint8_t {
+    None = 0,
+    Codec,
+    InputBytes,
+    Packets,
+    Schemas,
+    SchemaBytes,
+    Records,
+    LossNotices,
+    CpuScopes,
+    GpuFrames,
+    GpuScopes,
+    CpuTracks,
+    GpuTracks,
+    GpuDomains,
+    UniqueStrings,
+    StringBytes,
+    LogicalModelBytes,
+    ScopeDepth,
+};
+
+enum class KnownProfileSchema : std::uint8_t {
+    Unknown = 0,
+    CpuScopeV1,
+    GpuFrameV1,
+    GpuScopeV2,
+};
+
+enum class ProfileGpuFrameStatus : std::uint32_t {
+    Complete = 0,
+    Incomplete,
+    Invalid,
+};
+
+enum class ProfileGpuScopeStatus : std::uint32_t {
+    Ready = 0,
+    Error,
+};
+
+enum class ProfileLogicalQueue : std::uint32_t {
+    Graphics = 0,
+    Compute,
+    Copy,
+};
+
+[[nodiscard]] inline constexpr std::uint32_t ProfileLogicalQueueBit(ProfileLogicalQueue _queue) noexcept {
+    return std::uint32_t{1} << static_cast<std::uint32_t>(_queue);
+}
+
+struct SessionLimits {
+    CodecLimits codec{};
+
+    std::uint64_t max_input_bytes{16ull * 1024 * 1024 * 1024};
+    std::uint64_t max_packets{16'000'000};
+    std::uint32_t max_schemas{4096};
+    std::uint64_t max_schema_bytes{16ull * 1024 * 1024};
+    std::uint64_t max_records{8'000'000};
+    std::uint64_t max_loss_notices{1'000'000};
+
+    std::uint64_t max_cpu_scopes{4'000'000};
+    std::uint64_t max_gpu_frames{500'000};
+    std::uint64_t max_gpu_scopes{4'000'000};
+    std::uint32_t max_cpu_tracks{4096};
+    std::uint32_t max_gpu_tracks{1024};
+    std::uint32_t max_gpu_domains{256};
+    std::uint32_t max_scope_depth{1024};
+
+    std::uint32_t max_unique_strings{1'000'000};
+    std::uint64_t max_string_bytes{256ull * 1024 * 1024};
+    // Logical retained-model estimate, not a process RSS or allocator-capacity
+    // guarantee. Transient decode/index storage remains bounded by the count
+    // and codec limits above.
+    std::uint64_t max_logical_model_bytes{1024ull * 1024 * 1024};
+};
+
+struct SessionLoadOptions {
+    SessionLimits limits{};
+
+    // Only a clean prefix ending at the last complete packet may be exposed.
+    // CRC, schema, protocol, and semantic failures are never downgraded.
+    bool allow_forensic_truncation{false};
+};
+
+struct SessionLoadResult {
+    SessionLoadStatus       status{SessionLoadStatus::Reading};
+    SessionIncompleteReason incomplete_reason{SessionIncompleteReason::None};
+    SessionErrorCode        error_code{SessionErrorCode::None};
+    SessionLimitKind        limit_kind{SessionLimitKind::None};
+    DecodeStatus            codec_status{DecodeStatus::Ok};
+
+    std::uint64_t error_byte_offset{kInvalidSessionIndex};
+    std::uint64_t error_packet_index{kInvalidSessionIndex};
+    std::uint64_t incomplete_byte_offset{kInvalidSessionIndex};
+    std::uint64_t incomplete_packet_index{kInvalidSessionIndex};
+    std::uint64_t input_bytes{0};
+    std::uint64_t valid_prefix_bytes{0};
+    std::uint64_t packet_count{0};
+
+    [[nodiscard]] bool HasUsableSession() const noexcept {
+        return status == SessionLoadStatus::Complete || status == SessionLoadStatus::ForensicTruncated;
+    }
+
+    [[nodiscard]] bool IsTerminal() const noexcept {
+        return status != SessionLoadStatus::Reading;
+    }
+};
+
+struct ProfileSchemaFieldInfo {
+    SessionStringId name{kInvalidSessionString};
+    FieldType       type{FieldType::Bool};
+};
+
+struct ProfileSchemaInfo {
+    std::uint64_t      hash{0};
+    SessionStringId    name{kInvalidSessionString};
+    SessionStringId    event_type{kInvalidSessionString};
+    std::uint32_t      schema_version{0};
+    EventKind          kind{EventKind::Scope};
+    Channel            channel{Channel::CpuThread};
+    KnownProfileSchema known_schema{KnownProfileSchema::Unknown};
+    std::uint64_t      first_field{0};
+    std::uint32_t      field_count{0};
+    std::uint64_t      record_count{0};
+};
+
+struct ProfileLossRecord {
+    std::uint64_t first_sequence{0};
+    std::uint64_t last_sequence{0};
+    std::uint64_t record_count{0};
+    std::uint64_t value_bytes{0};
+    std::uint32_t reason_mask{0};
+};
+
+struct CpuScopeRecord {
+    std::uint64_t   sequence{0};
+    std::uint64_t   thread_id{0};
+    SessionStringId name{kInvalidSessionString};
+    std::uint64_t   begin_ns{0};
+    std::uint64_t   end_ns{0};
+    std::uint32_t   depth{0};
+    std::uint32_t   track_index{0};
+    std::uint64_t   parent_index{kInvalidSessionIndex};
+};
+
+// CPU scopes use the producer process's steady-clock nanosecond domain. The
+// SessionBegin Unix timestamp is metadata, not an absolute clock anchor.
+struct CpuTrack {
+    std::uint64_t thread_id{0};
+    std::uint64_t first_scope{0};
+    std::uint64_t scope_count{0};
+};
+
+struct GpuFrameRecord {
+    std::uint64_t         sequence{0};
+    std::uint64_t         frame_id{0};
+    ProfileGpuFrameStatus status{ProfileGpuFrameStatus::Invalid};
+    bool                  valid{false};
+    std::uint64_t         admitted_scope_count{0};
+    std::uint64_t         dropped_scope_count{0};
+    std::uint64_t         error_scope_count{0};
+    SessionStringId       reason{kInvalidSessionString};
+    std::uint64_t         scope_count{0};
+};
+
+// One physical timestamp domain. Different logical roles may share it when
+// they resolve to the same native queue/family; GpuTrack keeps those roles
+// distinct for presentation. No CPU/GPU or cross-domain calibration exists.
+struct GpuTimestampDomain {
+    std::uint32_t native_queue_id{0};
+    std::uint32_t family_id{0};
+    // Bit positions are defined by ProfileLogicalQueue.
+    std::uint32_t logical_queue_mask{0};
+    bool          has_ready_timestamps{false};
+    std::uint32_t valid_bits{0};
+    double        tick_period_ns{0.0};
+    std::uint64_t ready_scope_count{0};
+    std::uint64_t error_scope_count{0};
+};
+
+struct GpuTrack {
+    ProfileLogicalQueue logical_queue{ProfileLogicalQueue::Graphics};
+    std::uint32_t       native_queue_id{0};
+    std::uint32_t       family_id{0};
+    std::uint32_t       domain_index{0};
+    std::uint64_t       first_scope{0};
+    std::uint64_t       scope_count{0};
+};
+
+struct GpuScopeRecord {
+    std::uint64_t sequence{0};
+    std::uint64_t frame_id{0};
+    std::uint64_t scope_id{0};
+    std::uint64_t parent_scope_id{0};
+    std::uint64_t source_order{0};
+    std::uint64_t local_order{0};
+
+    ProfileLogicalQueue logical_queue{ProfileLogicalQueue::Graphics};
+    std::uint32_t       native_queue_id{0};
+    std::uint32_t       family_id{0};
+    std::uint32_t       domain_index{0};
+    std::uint32_t       track_index{0};
+    std::uint64_t       frame_index{kInvalidSessionIndex};
+    std::uint64_t       parent_index{kInvalidSessionIndex};
+
+    SessionStringId       name{kInvalidSessionString};
+    ProfileGpuScopeStatus status{ProfileGpuScopeStatus::Error};
+    std::uint64_t         begin_tick{0};
+    std::uint64_t         end_tick{0};
+    std::uint32_t         valid_bits{0};
+    double                tick_period_ns{0.0};
+    double                total_duration_ns{0.0};
+    double                exclusive_duration_ns{0.0};
+    std::uint32_t         depth{0};
+    SessionStringId       error_reason{kInvalidSessionString};
+};
+
+struct ProfileSessionSummary {
+    std::uint64_t generation{0};
+    std::uint64_t started_unix_ns{0};
+    bool          has_session_end{false};
+    std::uint64_t session_end_records_written{0};
+    std::uint64_t session_end_records_dropped{0};
+    std::uint64_t unnotified_drop_count{0};
+
+    std::uint64_t packet_count{0};
+    std::uint64_t schema_packet_count{0};
+    std::uint64_t unique_schema_count{0};
+    std::uint64_t record_count{0};
+    std::uint64_t loss_notice_count{0};
+
+    std::uint64_t cpu_scope_count{0};
+    std::uint64_t gpu_frame_count{0};
+    std::uint64_t gpu_scope_count{0};
+    std::uint64_t unknown_record_count{0};
+
+    std::uint64_t complete_gpu_frame_count{0};
+    std::uint64_t incomplete_gpu_frame_count{0};
+    std::uint64_t invalid_gpu_frame_count{0};
+    std::uint64_t ready_gpu_scope_count{0};
+    std::uint64_t error_gpu_scope_count{0};
+    std::uint64_t orphan_cpu_scope_count{0};
+    std::uint64_t orphan_gpu_scope_count{0};
+
+    std::uint64_t lost_record_count{0};
+    std::uint64_t lost_value_bytes{0};
+    std::uint32_t loss_reason_mask{0};
+
+    bool          has_cpu_range{false};
+    std::uint64_t cpu_begin_ns{0};
+    std::uint64_t cpu_end_ns{0};
+    // Estimated logical bytes retained by the immutable session model.
+    std::uint64_t logical_model_bytes{0};
+};
+
+class ProfileSession {
+public:
+    ProfileSession() noexcept = default;
+    ~ProfileSession();
+
+    ProfileSession(const ProfileSession&)            = delete;
+    ProfileSession& operator=(const ProfileSession&) = delete;
+    ProfileSession(ProfileSession&& _other) noexcept;
+    ProfileSession& operator=(ProfileSession&& _other) noexcept;
+
+    // Returned spans and string views remain valid until this session is
+    // destroyed or move-assigned. The model is immutable after a successful
+    // reader Finish/LoadProfileSessionFile call.
+    [[nodiscard]] bool                                    Valid() const noexcept;
+    [[nodiscard]] const ProfileSessionSummary&            Summary() const noexcept;
+    [[nodiscard]] std::span<const ProfileSchemaInfo>      Schemas() const noexcept;
+    [[nodiscard]] std::span<const ProfileSchemaFieldInfo> SchemaFields() const noexcept;
+    [[nodiscard]] std::span<const ProfileLossRecord>      Losses() const noexcept;
+    [[nodiscard]] std::span<const CpuScopeRecord>         CpuScopes() const noexcept;
+    [[nodiscard]] std::span<const CpuTrack>               CpuTracks() const noexcept;
+    [[nodiscard]] std::span<const GpuFrameRecord>         GpuFrames() const noexcept;
+    [[nodiscard]] std::span<const GpuScopeRecord>         GpuScopes() const noexcept;
+    [[nodiscard]] std::span<const GpuTrack>               GpuTracks() const noexcept;
+    [[nodiscard]] std::span<const GpuTimestampDomain>     GpuDomains() const noexcept;
+    [[nodiscard]] std::string_view                        String(SessionStringId _id) const noexcept;
+
+private:
+    struct Impl;
+    Impl* impl_{nullptr};
+
+    friend class ProfileSessionReader;
+};
+
+class ProfileSessionReader final {
+public:
+    explicit ProfileSessionReader(const SessionLoadOptions& _options = {}) noexcept;
+    ~ProfileSessionReader();
+
+    ProfileSessionReader(const ProfileSessionReader&)            = delete;
+    ProfileSessionReader& operator=(const ProfileSessionReader&) = delete;
+    ProfileSessionReader(ProfileSessionReader&& _other) noexcept;
+    ProfileSessionReader& operator=(ProfileSessionReader&& _other) noexcept;
+
+    // Feed accepts arbitrary chunk boundaries and retains at most one bounded
+    // wire packet in addition to the explicitly limited session model. Seeing
+    // SessionEnd does not publish Complete: only Finish establishes EOF, so a
+    // later chunk containing trailing bytes cannot be silently ignored.
+    [[nodiscard]] SessionLoadResult Feed(std::span<const std::uint8_t> _bytes) noexcept;
+    [[nodiscard]] SessionLoadResult Finish() noexcept;
+
+    [[nodiscard]] const SessionLoadResult& Result() const noexcept;
+    [[nodiscard]] std::string_view         DiagnosticMessage() const noexcept;
+    [[nodiscard]] const ProfileSession&    Session() const noexcept;
+    [[nodiscard]] ProfileSession           TakeSession() noexcept;
+
+private:
+    struct Impl;
+    Impl* impl_{nullptr};
+};
+
+// The file size is snapshotted once. Output is move-replaced only for a
+// Complete or explicitly accepted ForensicTruncated result.
+[[nodiscard]] SessionLoadResult LoadProfileSessionFile(
+    const std::filesystem::path& _path,
+    const SessionLoadOptions&    _options,
+    ProfileSession&              _output
+) noexcept;
+
+} // namespace Moer::ProfileDump
+
+#endif // MOER_ENGINE_PROFILE_SESSION_H

--- a/source/tool/profile_consumer/include/profile_consumer/ProfileSummaryContract.h
+++ b/source/tool/profile_consumer/include/profile_consumer/ProfileSummaryContract.h
@@ -3,12 +3,28 @@
 
 #include "profile_consumer/ProfileSession.h"
 
+#include <new>
 #include <string_view>
+#include <type_traits>
+#include <utility>
 
 namespace Moer::ProfileDump {
 
 inline constexpr std::string_view kProfileSummaryContractName{"moer.profile.summary"};
 inline constexpr std::uint32_t    kProfileSummaryContractVersion{1};
+
+inline constexpr std::string_view kProfileSummaryAllocationFailureJson{
+    R"json({"contract":"moer.profile.summary","version":1,"load":{"status":"resource_exhausted","incomplete_reason":"none","error_code":"resource_allocation_failed","limit":"none","codec_status":"ok","input_bytes":"0","valid_prefix_bytes":"0","error_byte_offset":null,"error_packet_index":null,"incomplete_byte_offset":null,"incomplete_packet_index":null}})json"
+};
+inline constexpr std::string_view kProfileSummaryUnexpectedFailureJson{
+    R"json({"contract":"moer.profile.summary","version":1,"load":{"status":"resource_exhausted","incomplete_reason":"none","error_code":"unexpected_failure","limit":"none","codec_status":"ok","input_bytes":"0","valid_prefix_bytes":"0","error_byte_offset":null,"error_packet_index":null,"incomplete_byte_offset":null,"incomplete_packet_index":null}})json"
+};
+
+[[nodiscard]] inline constexpr std::string_view ProfileSummaryEmergencyJson(SessionErrorCode _error
+) noexcept {
+    return _error == SessionErrorCode::ResourceAllocationFailed ? kProfileSummaryAllocationFailureJson :
+                                                                  kProfileSummaryUnexpectedFailureJson;
+}
 
 [[nodiscard]] inline constexpr int ProfileSummaryExitCode(SessionLoadStatus _status) noexcept {
     switch (_status) {
@@ -32,6 +48,20 @@ inline constexpr std::uint32_t    kProfileSummaryContractVersion{1};
             return 14;
     }
     return 12;
+}
+
+template<typename Operation, typename EmergencyWriter>
+[[nodiscard]] int
+RunProfileSummaryCliBoundary(Operation&& _operation, EmergencyWriter&& _emergency_writer) noexcept {
+    static_assert(std::is_nothrow_invocable_v<EmergencyWriter, SessionErrorCode>);
+    try {
+        return std::forward<Operation>(_operation)();
+    } catch (const std::bad_alloc&) {
+        std::forward<EmergencyWriter>(_emergency_writer)(SessionErrorCode::ResourceAllocationFailed);
+    } catch (...) {
+        std::forward<EmergencyWriter>(_emergency_writer)(SessionErrorCode::UnexpectedFailure);
+    }
+    return ProfileSummaryExitCode(SessionLoadStatus::ResourceExhausted);
 }
 
 } // namespace Moer::ProfileDump

--- a/source/tool/profile_consumer/include/profile_consumer/ProfileSummaryContract.h
+++ b/source/tool/profile_consumer/include/profile_consumer/ProfileSummaryContract.h
@@ -1,0 +1,39 @@
+#ifndef MOER_ENGINE_PROFILE_SUMMARY_CONTRACT_H
+#define MOER_ENGINE_PROFILE_SUMMARY_CONTRACT_H
+
+#include "profile_consumer/ProfileSession.h"
+
+#include <string_view>
+
+namespace Moer::ProfileDump {
+
+inline constexpr std::string_view kProfileSummaryContractName{"moer.profile.summary"};
+inline constexpr std::uint32_t    kProfileSummaryContractVersion{1};
+
+[[nodiscard]] inline constexpr int ProfileSummaryExitCode(SessionLoadStatus _status) noexcept {
+    switch (_status) {
+        case SessionLoadStatus::Complete:
+            return 0;
+        case SessionLoadStatus::ForensicTruncated:
+            return 2;
+        case SessionLoadStatus::InvalidArgument:
+        case SessionLoadStatus::Reading:
+            return 10;
+        case SessionLoadStatus::OpenFailed:
+        case SessionLoadStatus::ReadFailed:
+            return 11;
+        case SessionLoadStatus::UnsupportedVersion:
+        case SessionLoadStatus::CorruptData:
+        case SessionLoadStatus::ProtocolViolation:
+            return 12;
+        case SessionLoadStatus::LimitExceeded:
+            return 13;
+        case SessionLoadStatus::ResourceExhausted:
+            return 14;
+    }
+    return 12;
+}
+
+} // namespace Moer::ProfileDump
+
+#endif // MOER_ENGINE_PROFILE_SUMMARY_CONTRACT_H

--- a/source/tool/profile_consumer/source/ProfileSession.cpp
+++ b/source/tool/profile_consumer/source/ProfileSession.cpp
@@ -378,6 +378,22 @@ struct ProfileSessionReader::Impl {
         std::uint64_t count{0};
     };
 
+    struct JointVirtualTask {
+        std::uint64_t first_allowed_local{0};
+        std::uint64_t deadline_local{0};
+        std::uint64_t deadline_sequence{0};
+    };
+
+    struct JointLocalCell {
+        std::uint64_t            frame_id{0};
+        std::uint64_t            local_begin{0};
+        std::uint64_t            local_end{0};
+        std::uint64_t            release_sequence{0};
+        std::uint64_t            deadline_sequence{0};
+        std::uint64_t            local_capacity{0};
+        std::vector<std::size_t> task_indices{};
+    };
+
     explicit Impl(const SessionLoadOptions& _options) noexcept : options(_options) {
         session.impl_ = new (std::nothrow) ProfileSession::Impl();
         if (session.impl_ == nullptr) {
@@ -1770,6 +1786,14 @@ struct ProfileSessionReader::Impl {
             return false;
         }
 
+        return true;
+    }
+
+    [[nodiscard]] bool ValidateSequenceSlotCapacity(
+        std::vector<RecordSequenceDemand>& _sequence_demands,
+        bool                               _has_cpu_demands,
+        bool                               _has_gpu_demands
+    ) {
         if (!ChargeTopologySortWork(_sequence_demands.size())) {
             return false;
         }
@@ -1786,24 +1810,42 @@ struct ProfileSessionReader::Impl {
         if (_sequence_demands.empty()) {
             return true;
         }
-        struct PendingCpuSequenceDemand {
+
+        const auto capacity_error = [&]() {
+            if (_has_cpu_demands && _has_gpu_demands) {
+                return SessionErrorCode::RecordSequenceInvalid;
+            }
+            return _has_gpu_demands ? SessionErrorCode::GpuFrameTotalsMismatch :
+                                      SessionErrorCode::CpuScopeTopologyInvalid;
+        };
+        const auto fail_capacity = [&]() {
+            Fail(
+                SessionLoadStatus::ProtocolViolation,
+                capacity_error(),
+                "missing CPU/GPU topology records cannot occupy distinct record-sequence holes"
+            );
+            return false;
+        };
+
+        struct PendingSequenceDemand {
             std::uint64_t deadline_sequence{0};
             std::uint64_t remaining_count{0};
         };
-        const auto later_deadline = [](const PendingCpuSequenceDemand& _left,
-                                       const PendingCpuSequenceDemand& _right) {
+        const auto later_deadline = [](const PendingSequenceDemand& _left,
+                                       const PendingSequenceDemand& _right) {
             return _left.deadline_sequence > _right.deadline_sequence;
         };
-        std::vector<PendingCpuSequenceDemand> pending_storage;
+        std::vector<PendingSequenceDemand> pending_storage;
         pending_storage.reserve(_sequence_demands.size());
         std::priority_queue<
-            PendingCpuSequenceDemand,
-            std::vector<PendingCpuSequenceDemand>,
+            PendingSequenceDemand,
+            std::vector<PendingSequenceDemand>,
             decltype(later_deadline)>
             pending_demands(later_deadline, std::move(pending_storage));
         if (!ChargeTopologyLinearWork(record_sequences.size())) {
             return false;
         }
+
         std::size_t   demand_index   = 0;
         std::size_t   observed_index = 0;
         std::uint64_t position       = _sequence_demands.front().release_sequence;
@@ -1827,18 +1869,16 @@ struct ProfileSessionReader::Impl {
                 continue;
             }
             if (pending_demands.top().deadline_sequence < position) {
-                Fail(
-                    SessionLoadStatus::ProtocolViolation,
-                    SessionErrorCode::CpuScopeTopologyInvalid,
-                    "missing CpuScope parents cannot occupy distinct record-sequence holes"
-                );
-                return false;
+                return fail_capacity();
             }
 
             while (observed_index < record_sequences.size() && record_sequences[observed_index] < position) {
                 ++observed_index;
             }
             if (observed_index < record_sequences.size() && record_sequences[observed_index] == position) {
+                if (position == std::numeric_limits<std::uint64_t>::max()) {
+                    return fail_capacity();
+                }
                 ++position;
                 ++observed_index;
                 continue;
@@ -1847,19 +1887,35 @@ struct ProfileSessionReader::Impl {
             if (!ChargeTopologyHeapWork(pending_demands.size())) {
                 return false;
             }
-            PendingCpuSequenceDemand demand = pending_demands.top();
+            PendingSequenceDemand demand = pending_demands.top();
             pending_demands.pop();
-            std::uint64_t batch_end = demand.deadline_sequence + 1;
-            if (observed_index < record_sequences.size()) {
-                batch_end = std::min(batch_end, record_sequences[observed_index]);
+
+            std::uint64_t available = demand.remaining_count;
+            if (demand.deadline_sequence != std::numeric_limits<std::uint64_t>::max() || position != 0) {
+                available = std::min(available, demand.deadline_sequence - position + std::uint64_t{1});
             }
-            if (demand_index < _sequence_demands.size()) {
-                batch_end = std::min(batch_end, _sequence_demands[demand_index].release_sequence);
+            if (observed_index < record_sequences.size() && record_sequences[observed_index] >= position) {
+                available = std::min(available, record_sequences[observed_index] - position);
             }
-            const std::uint64_t available = batch_end - position;
-            const std::uint64_t assigned  = std::min(available, demand.remaining_count);
-            position += assigned;
-            demand.remaining_count -= assigned;
+            if (demand_index < _sequence_demands.size() &&
+                _sequence_demands[demand_index].release_sequence > position) {
+                available = std::min(available, _sequence_demands[demand_index].release_sequence - position);
+            }
+            if (available == 0) {
+                return fail_capacity();
+            }
+
+            demand.remaining_count -= available;
+            const bool exhausts_sequence_domain =
+                available > std::numeric_limits<std::uint64_t>::max() - position;
+            if (exhausts_sequence_domain) {
+                if (demand.remaining_count != 0 || demand_index != _sequence_demands.size() ||
+                    !pending_demands.empty()) {
+                    return fail_capacity();
+                }
+                return true;
+            }
+            position += available;
             if (demand.remaining_count != 0) {
                 if (!ChargeTopologyHeapWork(pending_demands.size() + 1)) {
                     return false;
@@ -1870,11 +1926,22 @@ struct ProfileSessionReader::Impl {
         return true;
     }
 
-    [[nodiscard]] bool
-    ValidateCpuLossCompatibility(std::span<const RecordSequenceDemand> _cpu_sequence_demands) {
-        if (_cpu_sequence_demands.empty()) {
+    [[nodiscard]] bool ValidateTopologyLossCompatibility(
+        std::span<const RecordSequenceDemand> _sequence_demands,
+        bool                                  _has_cpu_demands,
+        bool                                  _has_gpu_demands,
+        bool                                  _forensic
+    ) {
+        if (_sequence_demands.empty() && joint_virtual_tasks.empty()) {
             return true;
         }
+        _has_gpu_demands               = _has_gpu_demands || !joint_virtual_tasks.empty();
+        const auto compatibility_error = [&](SessionErrorCode _cpu_error, SessionErrorCode _gpu_error) {
+            if (_has_cpu_demands && _has_gpu_demands) {
+                return SessionErrorCode::RecordSequenceInvalid;
+            }
+            return _has_gpu_demands ? _gpu_error : _cpu_error;
+        };
 
         struct LossBucket {
             std::uint64_t release_sequence{0};
@@ -1882,12 +1949,14 @@ struct ProfileSessionReader::Impl {
             std::uint64_t count{0};
         };
 
-        std::uint64_t input_work = static_cast<std::uint64_t>(session.impl_->losses.size());
-        if (AddOverflow(input_work, static_cast<std::uint64_t>(_cpu_sequence_demands.size()), input_work)) {
+        std::uint64_t input_work = _forensic ? 0 : static_cast<std::uint64_t>(session.impl_->losses.size());
+        if (AddOverflow(input_work, static_cast<std::uint64_t>(_sequence_demands.size()), input_work) ||
+            AddOverflow(input_work, static_cast<std::uint64_t>(joint_virtual_tasks.size()), input_work) ||
+            AddOverflow(input_work, static_cast<std::uint64_t>(joint_local_cells.size()), input_work)) {
             Fail(
                 SessionLoadStatus::LimitExceeded,
                 SessionErrorCode::LimitExceeded,
-                "CPU/Loss topology input count overflows",
+                "profile topology/Loss input count overflows",
                 DecodeStatus::LimitExceeded,
                 SessionLimitKind::TopologyWorkItems
             );
@@ -1899,63 +1968,120 @@ struct ProfileSessionReader::Impl {
 
         std::uint64_t loss_bucket_count = 0;
         std::uint64_t loss_bucket_total = 0;
-        for (const ProfileLossRecord& loss : session.impl_->losses) {
-            std::uint64_t buckets_for_loss = 1;
-            if (loss.record_count != 1) {
-                ++buckets_for_loss;
+        if (!_forensic) {
+            for (const ProfileLossRecord& loss : session.impl_->losses) {
+                std::uint64_t buckets_for_loss = 1;
+                if (loss.record_count != 1) {
+                    ++buckets_for_loss;
+                }
+                if (loss.record_count > 2) {
+                    ++buckets_for_loss;
+                }
+                if (AddOverflow(loss_bucket_count, buckets_for_loss, loss_bucket_count) ||
+                    AddOverflow(loss_bucket_total, loss.record_count, loss_bucket_total)) {
+                    Fail(
+                        SessionLoadStatus::ProtocolViolation,
+                        SessionErrorCode::LossTotalsOverflow,
+                        "profile noticed-loss bucket total overflows"
+                    );
+                    return false;
+                }
             }
-            if (loss.record_count > 2) {
-                ++buckets_for_loss;
-            }
-            if (AddOverflow(loss_bucket_count, buckets_for_loss, loss_bucket_count) ||
-                AddOverflow(loss_bucket_total, loss.record_count, loss_bucket_total)) {
+        }
+        std::uint64_t demand_total = 0;
+        for (const RecordSequenceDemand& demand : _sequence_demands) {
+            if (AddOverflow(demand_total, demand.count, demand_total)) {
                 Fail(
                     SessionLoadStatus::ProtocolViolation,
-                    SessionErrorCode::LossTotalsOverflow,
-                    "profile noticed-loss bucket total overflows"
+                    compatibility_error(
+                        SessionErrorCode::CpuScopeTopologyInvalid, SessionErrorCode::GpuFrameTotalsMismatch
+                    ),
+                    "profile sequence-backed topology demand overflows"
                 );
                 return false;
             }
         }
-        std::uint64_t cpu_demand_total = 0;
-        for (const RecordSequenceDemand& demand : _cpu_sequence_demands) {
-            if (AddOverflow(cpu_demand_total, demand.count, cpu_demand_total)) {
-                Fail(
-                    SessionLoadStatus::ProtocolViolation,
-                    SessionErrorCode::CpuScopeTopologyInvalid,
-                    "CPU sequence-backed loss demand overflows"
-                );
-                return false;
-            }
-        }
-        if (loss_bucket_total != session.impl_->summary.lost_record_count ||
-            cpu_demand_total > loss_bucket_total) {
+        std::uint64_t required_topology_total = 0;
+        if (AddOverflow(
+                demand_total, static_cast<std::uint64_t>(joint_virtual_tasks.size()), required_topology_total
+            )) {
             Fail(
                 SessionLoadStatus::ProtocolViolation,
-                SessionErrorCode::CpuScopeParentMissing,
-                "CPU hierarchy deficits exceed noticed allocated-record losses"
+                compatibility_error(
+                    SessionErrorCode::CpuScopeTopologyInvalid, SessionErrorCode::GpuFrameTotalsMismatch
+                ),
+                "joint profile topology demand overflows"
+            );
+            return false;
+        }
+        if (!_forensic && (loss_bucket_total != session.impl_->summary.lost_record_count ||
+                           required_topology_total > loss_bucket_total)) {
+            Fail(
+                SessionLoadStatus::ProtocolViolation,
+                compatibility_error(
+                    SessionErrorCode::CpuScopeParentMissing, SessionErrorCode::GpuFrameTotalsMismatch
+                ),
+                "CPU/GPU topology deficits exceed noticed allocated-record losses"
+            );
+            return false;
+        }
+
+        std::uint64_t       early_edge_lower_bound = _forensic ? 0 : loss_bucket_count;
+        const std::uint64_t early_dummy_edge =
+            !_forensic && loss_bucket_total != required_topology_total ? 1 : 0;
+        if (AddOverflow(
+                early_edge_lower_bound,
+                static_cast<std::uint64_t>(_sequence_demands.size()),
+                early_edge_lower_bound
+            ) ||
+            AddOverflow(
+                early_edge_lower_bound,
+                static_cast<std::uint64_t>(joint_local_cells.size()),
+                early_edge_lower_bound
+            ) ||
+            AddOverflow(
+                early_edge_lower_bound,
+                static_cast<std::uint64_t>(joint_virtual_tasks.size()),
+                early_edge_lower_bound
+            ) ||
+            AddOverflow(early_edge_lower_bound, joint_cell_task_edge_count, early_edge_lower_bound) ||
+            AddOverflow(early_edge_lower_bound, early_dummy_edge, early_edge_lower_bound) ||
+            early_edge_lower_bound > options.limits.max_topology_flow_edges) {
+            Fail(
+                SessionLoadStatus::LimitExceeded,
+                SessionErrorCode::LimitExceeded,
+                "profile topology flow-edge lower bound exceeds the configured limit",
+                DecodeStatus::LimitExceeded,
+                SessionLimitKind::TopologyFlowEdges
             );
             return false;
         }
 
         std::uint64_t loss_critical_count   = 0;
         std::uint64_t demand_critical_count = 0;
+        std::uint64_t cell_critical_count   = 0;
         std::uint64_t critical_point_count  = 0;
         std::uint64_t construction_work     = 0;
         if (AddOverflow(loss_bucket_count, loss_bucket_count, loss_critical_count) ||
             AddOverflow(
-                static_cast<std::uint64_t>(_cpu_sequence_demands.size()),
-                static_cast<std::uint64_t>(_cpu_sequence_demands.size()),
+                static_cast<std::uint64_t>(_sequence_demands.size()),
+                static_cast<std::uint64_t>(_sequence_demands.size()),
                 demand_critical_count
             ) ||
+            AddOverflow(
+                static_cast<std::uint64_t>(joint_local_cells.size()),
+                static_cast<std::uint64_t>(joint_local_cells.size()),
+                cell_critical_count
+            ) ||
             AddOverflow(loss_critical_count, demand_critical_count, critical_point_count) ||
+            AddOverflow(critical_point_count, cell_critical_count, critical_point_count) ||
             AddOverflow(loss_bucket_count, critical_point_count, construction_work) ||
             loss_bucket_count > static_cast<std::uint64_t>(std::numeric_limits<std::size_t>::max()) ||
             critical_point_count > static_cast<std::uint64_t>(std::numeric_limits<std::size_t>::max())) {
             Fail(
                 SessionLoadStatus::LimitExceeded,
                 SessionErrorCode::LimitExceeded,
-                "CPU/Loss topology preprocessing exceeds the addressable range",
+                "profile topology/Loss preprocessing exceeds the addressable range",
                 DecodeStatus::LimitExceeded,
                 SessionLimitKind::TopologyWorkItems
             );
@@ -1983,19 +2109,36 @@ struct ProfileSessionReader::Impl {
             critical_points.push_back(_release);
             critical_points.push_back(_deadline);
         };
-        for (const ProfileLossRecord& loss : session.impl_->losses) {
-            add_loss_bucket(loss.first_sequence, loss.first_sequence, 1);
-            if (loss.record_count != 1) {
-                add_loss_bucket(loss.last_sequence, loss.last_sequence, 1);
-            }
-            if (loss.record_count > 2) {
-                add_loss_bucket(loss.first_sequence + 1, loss.last_sequence - 1, loss.record_count - 2);
+        if (!_forensic) {
+            for (const ProfileLossRecord& loss : session.impl_->losses) {
+                add_loss_bucket(loss.first_sequence, loss.first_sequence, 1);
+                if (loss.record_count != 1) {
+                    add_loss_bucket(loss.last_sequence, loss.last_sequence, 1);
+                }
+                if (loss.record_count > 2) {
+                    add_loss_bucket(loss.first_sequence + 1, loss.last_sequence - 1, loss.record_count - 2);
+                }
             }
         }
-        for (const RecordSequenceDemand& demand : _cpu_sequence_demands) {
+        for (const RecordSequenceDemand& demand : _sequence_demands) {
             critical_points.push_back(demand.release_sequence);
             critical_points.push_back(demand.deadline_sequence);
         }
+        for (const JointLocalCell& cell : joint_local_cells) {
+            critical_points.push_back(cell.release_sequence);
+            critical_points.push_back(cell.deadline_sequence);
+        }
+        if (!ChargeTopologySortWork(loss_buckets.size())) {
+            return false;
+        }
+        std::sort(
+            loss_buckets.begin(),
+            loss_buckets.end(),
+            [](const LossBucket& _left, const LossBucket& _right) {
+                return std::tie(_left.release_sequence, _left.deadline_sequence) <
+                       std::tie(_right.release_sequence, _right.deadline_sequence);
+            }
+        );
 
         // std::sort is introspective O(N log N). Charge one abstract work item
         // per element and merge level before invoking it so preprocessing cannot
@@ -2033,7 +2176,7 @@ struct ProfileSessionReader::Impl {
                 Fail(
                     SessionLoadStatus::LimitExceeded,
                     SessionErrorCode::LimitExceeded,
-                    "CPU/Loss sequence segmentation overflows",
+                    "profile topology/Loss sequence segmentation overflows",
                     DecodeStatus::LimitExceeded,
                     SessionLimitKind::TopologyWorkItems
                 );
@@ -2049,7 +2192,7 @@ struct ProfileSessionReader::Impl {
             Fail(
                 SessionLoadStatus::LimitExceeded,
                 SessionErrorCode::LimitExceeded,
-                "CPU/Loss sequence segmentation exceeds the addressable range",
+                "profile topology/Loss sequence segmentation exceeds the addressable range",
                 DecodeStatus::LimitExceeded,
                 SessionLimitKind::TopologyWorkItems
             );
@@ -2059,10 +2202,38 @@ struct ProfileSessionReader::Impl {
             return false;
         }
 
+        struct LossCoverage {
+            std::uint64_t begin{0};
+            std::uint64_t end{0};
+        };
+        std::vector<LossCoverage> loss_coverage;
+        if (!_forensic) {
+            if (!ChargeTopologyLinearWork(loss_buckets.size())) {
+                return false;
+            }
+            loss_coverage.reserve(loss_buckets.size());
+            for (const LossBucket& bucket : loss_buckets) {
+                if (loss_coverage.empty() ||
+                    (loss_coverage.back().end != std::numeric_limits<std::uint64_t>::max() &&
+                     bucket.release_sequence > loss_coverage.back().end + 1)) {
+                    loss_coverage.push_back({
+                        .begin = bucket.release_sequence,
+                        .end   = bucket.deadline_sequence,
+                    });
+                } else {
+                    loss_coverage.back().end = std::max(loss_coverage.back().end, bucket.deadline_sequence);
+                }
+            }
+        }
+
         std::vector<SequenceSegment> segments;
-        segments.reserve(static_cast<std::size_t>(maximum_segment_count));
-        std::size_t observed_index = 0;
-        const auto  add_segment    = [&](std::uint64_t _begin, std::uint64_t _end) {
+        const std::uint64_t          segment_edge_capacity = options.limits.max_topology_flow_edges / 2;
+        segments.reserve(static_cast<std::size_t>(std::min(maximum_segment_count, segment_edge_capacity)));
+        std::size_t         observed_index       = 0;
+        std::size_t         loss_coverage_index  = 0;
+        bool                segment_build_failed = false;
+        const std::uint64_t flow_target          = _forensic ? required_topology_total : loss_bucket_total;
+        const auto          add_segment          = [&](std::uint64_t _begin, std::uint64_t _end) {
             while (observed_index < record_sequences.size() && record_sequences[observed_index] < _begin) {
                 ++observed_index;
             }
@@ -2079,28 +2250,120 @@ struct ProfileSessionReader::Impl {
                 // excluding any observed sequence, or can be capped directly
                 // by the total flow when none are observed.
                 available = observed_count == 0 ?
-                                    loss_bucket_total :
-                                    std::numeric_limits<std::uint64_t>::max() - (observed_count - 1);
+                                                  flow_target :
+                                                  std::numeric_limits<std::uint64_t>::max() - (observed_count - 1);
             } else {
                 const std::uint64_t span = span_minus_one + 1;
                 available                = observed_count < span ? span - observed_count : 0;
             }
-            const std::uint64_t capacity = std::min(available, loss_bucket_total);
-            if (capacity != 0) {
-                segments.push_back({
-                        .begin    = _begin,
-                        .end      = _end,
-                        .capacity = capacity,
-                });
+            const std::uint64_t capacity = std::min(available, flow_target);
+            if (capacity == 0) {
+                return;
             }
+            if (!_forensic) {
+                while (loss_coverage_index < loss_coverage.size() &&
+                       loss_coverage[loss_coverage_index].end < _begin) {
+                    ++loss_coverage_index;
+                }
+                if (loss_coverage_index == loss_coverage.size() ||
+                    loss_coverage[loss_coverage_index].begin > _begin ||
+                    loss_coverage[loss_coverage_index].end < _end) {
+                    return;
+                }
+            }
+            if (static_cast<std::uint64_t>(segments.size()) >= segment_edge_capacity) {
+                Fail(
+                    SessionLoadStatus::LimitExceeded,
+                    SessionErrorCode::LimitExceeded,
+                    "profile sequence segments exceed the topology flow-edge limit",
+                    DecodeStatus::LimitExceeded,
+                    SessionLimitKind::TopologyFlowEdges
+                );
+                segment_build_failed = true;
+                return;
+            }
+            segments.push_back({
+                                  .begin    = _begin,
+                                  .end      = _end,
+                                  .capacity = capacity,
+            });
         };
         for (std::size_t index = 0; index < critical_points.size(); ++index) {
+            if (segment_build_failed) {
+                return false;
+            }
             const std::uint64_t point = critical_points[index];
             add_segment(point, point);
             if (index + 1 < critical_points.size() && point != std::numeric_limits<std::uint64_t>::max() &&
                 critical_points[index + 1] > point + 1) {
                 add_segment(point + 1, critical_points[index + 1] - 1);
             }
+        }
+        if (segment_build_failed) {
+            return false;
+        }
+
+        struct SegmentRange {
+            std::size_t begin{0};
+            std::size_t end{0};
+        };
+        const auto find_segment_range = [&](std::uint64_t _release, std::uint64_t _deadline) {
+            const auto begin = std::lower_bound(
+                segments.begin(),
+                segments.end(),
+                _release,
+                [](const SequenceSegment& _segment, std::uint64_t _sequence) {
+                    return _segment.end < _sequence;
+                }
+            );
+            const auto end = std::upper_bound(
+                begin,
+                segments.end(),
+                _deadline,
+                [](std::uint64_t _sequence, const SequenceSegment& _segment) {
+                    return _sequence < _segment.begin;
+                }
+            );
+            return SegmentRange{
+                .begin = static_cast<std::size_t>(begin - segments.begin()),
+                .end   = static_cast<std::size_t>(end - segments.begin()),
+            };
+        };
+        if (!ChargeTopologyLinearWork(loss_buckets.size()) ||
+            !ChargeTopologyLinearWork(_sequence_demands.size()) ||
+            !ChargeTopologyLinearWork(joint_local_cells.size())) {
+            return false;
+        }
+        std::vector<SegmentRange> loss_segment_ranges;
+        std::vector<SegmentRange> demand_segment_ranges;
+        std::vector<SegmentRange> cell_segment_ranges;
+        loss_segment_ranges.reserve(loss_buckets.size());
+        demand_segment_ranges.reserve(_sequence_demands.size());
+        cell_segment_ranges.reserve(joint_local_cells.size());
+        for (const LossBucket& bucket : loss_buckets) {
+            if (!ChargeTopologyBinarySearchWork(segments.size()) ||
+                !ChargeTopologyBinarySearchWork(segments.size())) {
+                return false;
+            }
+            loss_segment_ranges.push_back(
+                find_segment_range(bucket.release_sequence, bucket.deadline_sequence)
+            );
+        }
+        for (const RecordSequenceDemand& demand : _sequence_demands) {
+            if (!ChargeTopologyBinarySearchWork(segments.size()) ||
+                !ChargeTopologyBinarySearchWork(segments.size())) {
+                return false;
+            }
+            demand_segment_ranges.push_back(
+                find_segment_range(demand.release_sequence, demand.deadline_sequence)
+            );
+        }
+        for (const JointLocalCell& cell : joint_local_cells) {
+            if (!ChargeTopologyBinarySearchWork(segments.size()) ||
+                !ChargeTopologyBinarySearchWork(segments.size())) {
+                return false;
+            }
+            cell_segment_ranges.push_back(find_segment_range(cell.release_sequence, cell.deadline_sequence));
         }
 
         std::uint64_t graph_node_work = 3;
@@ -2110,18 +2373,34 @@ struct ProfileSessionReader::Impl {
         if (!add_node_work(static_cast<std::uint64_t>(loss_buckets.size())) ||
             !add_node_work(static_cast<std::uint64_t>(segments.size())) ||
             !add_node_work(static_cast<std::uint64_t>(segments.size())) ||
-            !add_node_work(static_cast<std::uint64_t>(_cpu_sequence_demands.size())) ||
+            !add_node_work(static_cast<std::uint64_t>(_sequence_demands.size())) ||
+            !add_node_work(static_cast<std::uint64_t>(joint_local_cells.size())) ||
+            !add_node_work(static_cast<std::uint64_t>(joint_local_cells.size())) ||
+            !add_node_work(static_cast<std::uint64_t>(joint_virtual_tasks.size())) ||
             graph_node_work > static_cast<std::uint64_t>(std::numeric_limits<std::size_t>::max())) {
             Fail(
                 SessionLoadStatus::LimitExceeded,
                 SessionErrorCode::LimitExceeded,
-                "CPU/Loss topology graph exceeds the addressable node range",
+                "profile topology/Loss graph exceeds the addressable node range",
                 DecodeStatus::LimitExceeded,
                 SessionLimitKind::TopologyWorkItems
             );
             return false;
         }
-        if (!ChargeTopologyWork(graph_node_work)) {
+        std::uint64_t graph_storage_work = 0;
+        if (AddOverflow(graph_node_work, graph_node_work, graph_storage_work) ||
+            AddOverflow(graph_storage_work, graph_node_work, graph_storage_work) ||
+            AddOverflow(graph_storage_work, graph_node_work, graph_storage_work)) {
+            Fail(
+                SessionLoadStatus::LimitExceeded,
+                SessionErrorCode::LimitExceeded,
+                "profile topology/Loss graph storage work overflows",
+                DecodeStatus::LimitExceeded,
+                SessionLimitKind::TopologyWorkItems
+            );
+            return false;
+        }
+        if (!ChargeTopologyWork(graph_storage_work)) {
             return false;
         }
 
@@ -2218,25 +2497,138 @@ struct ProfileSessionReader::Impl {
             std::vector<std::size_t>       pending_nodes;
         };
 
-        const std::size_t source_node       = 0;
-        const std::size_t loss_base         = 1;
-        const std::size_t segment_in_base   = loss_base + loss_buckets.size();
-        const std::size_t segment_out_base  = segment_in_base + segments.size();
-        const std::size_t cpu_demand_base   = segment_out_base + segments.size();
-        const std::size_t dummy_demand_node = cpu_demand_base + _cpu_sequence_demands.size();
-        const std::size_t sink_node         = dummy_demand_node + 1;
-        FlowNetwork       network(*this, sink_node + 1);
-        const auto        add_edge = [&](std::size_t _source, std::size_t _target, std::uint64_t _capacity) {
+        const std::size_t   source_node         = 0;
+        const std::size_t   loss_base           = 1;
+        const std::size_t   segment_in_base     = loss_base + loss_buckets.size();
+        const std::size_t   segment_out_base    = segment_in_base + segments.size();
+        const std::size_t   demand_base         = segment_out_base + segments.size();
+        const std::size_t   cell_in_base        = demand_base + _sequence_demands.size();
+        const std::size_t   cell_out_base       = cell_in_base + joint_local_cells.size();
+        const std::size_t   task_base           = cell_out_base + joint_local_cells.size();
+        const std::size_t   dummy_demand_node   = task_base + joint_virtual_tasks.size();
+        const std::size_t   sink_node           = dummy_demand_node + 1;
+        const std::uint64_t dummy_capacity      = _forensic ? 0 : loss_bucket_total - required_topology_total;
+        std::uint64_t       forward_edge_count  = 0;
+        const auto          count_forward_edges = [&](std::uint64_t _count) {
+            std::uint64_t next = 0;
+            if (AddOverflow(forward_edge_count, _count, next) ||
+                next > options.limits.max_topology_flow_edges) {
+                Fail(
+                    SessionLoadStatus::LimitExceeded,
+                    SessionErrorCode::LimitExceeded,
+                    "profile topology flow-edge limit exceeded",
+                    DecodeStatus::LimitExceeded,
+                    SessionLimitKind::TopologyFlowEdges
+                );
+                return false;
+            }
+            if (!ChargeTopologyWork(_count)) {
+                return false;
+            }
+            forward_edge_count = next;
+            return true;
+        };
+        std::uint64_t fixed_edge_count = static_cast<std::uint64_t>(segments.size());
+        if (AddOverflow(
+                fixed_edge_count,
+                static_cast<std::uint64_t>(_forensic ? segments.size() : loss_buckets.size()),
+                fixed_edge_count
+            ) ||
+            AddOverflow(
+                fixed_edge_count, static_cast<std::uint64_t>(_sequence_demands.size()), fixed_edge_count
+            ) ||
+            AddOverflow(
+                fixed_edge_count, static_cast<std::uint64_t>(joint_local_cells.size()), fixed_edge_count
+            ) ||
+            AddOverflow(
+                fixed_edge_count, static_cast<std::uint64_t>(joint_virtual_tasks.size()), fixed_edge_count
+            ) ||
+            AddOverflow(
+                fixed_edge_count, dummy_capacity == 0 ? std::uint64_t{0} : std::uint64_t{1}, fixed_edge_count
+            )) {
+            Fail(
+                SessionLoadStatus::LimitExceeded,
+                SessionErrorCode::LimitExceeded,
+                "profile topology flow-edge count overflows",
+                DecodeStatus::LimitExceeded,
+                SessionLimitKind::TopologyFlowEdges
+            );
+            return false;
+        }
+        if (!count_forward_edges(fixed_edge_count)) {
+            return false;
+        }
+        const auto count_segment_range_edges = [&](const SegmentRange& _range) {
+            const std::uint64_t count = static_cast<std::uint64_t>(_range.end - _range.begin);
+            return count_forward_edges(count);
+        };
+        for (const SegmentRange& range : loss_segment_ranges) {
+            if (!count_segment_range_edges(range)) {
+                return false;
+            }
+        }
+        for (const SegmentRange& range : demand_segment_ranges) {
+            if (!count_segment_range_edges(range)) {
+                return false;
+            }
+        }
+        for (const SegmentRange& range : cell_segment_ranges) {
+            if (!count_segment_range_edges(range)) {
+                return false;
+            }
+        }
+        if (dummy_capacity != 0) {
+            if (!count_forward_edges(static_cast<std::uint64_t>(segments.size()))) {
+                return false;
+            }
+        }
+        for (const JointLocalCell& cell : joint_local_cells) {
+            if (!count_forward_edges(static_cast<std::uint64_t>(cell.task_indices.size()))) {
+                return false;
+            }
+            for (const std::size_t task_index : cell.task_indices) {
+                if (task_index >= joint_virtual_tasks.size()) {
+                    Fail(
+                        SessionLoadStatus::ProtocolViolation,
+                        SessionErrorCode::GpuFrameTotalsMismatch,
+                        "joint GPU local cell references an invalid virtual task"
+                    );
+                    return false;
+                }
+            }
+        }
+        if (forward_edge_count > static_cast<std::uint64_t>(std::numeric_limits<std::size_t>::max() / 2)) {
+            Fail(
+                SessionLoadStatus::LimitExceeded,
+                SessionErrorCode::LimitExceeded,
+                "profile topology residual edges exceed the addressable range",
+                DecodeStatus::LimitExceeded,
+                SessionLimitKind::TopologyFlowEdges
+            );
+            return false;
+        }
+        FlowNetwork   network(*this, sink_node + 1);
+        std::uint64_t built_forward_edges = 0;
+        const auto    add_edge = [&](std::size_t _source, std::size_t _target, std::uint64_t _capacity) {
             if (!ChargeTopologyWork(1)) {
                 return false;
             }
             network.AddEdge(_source, _target, _capacity);
+            ++built_forward_edges;
             return true;
         };
 
-        for (std::size_t index = 0; index < loss_buckets.size(); ++index) {
-            if (!add_edge(source_node, loss_base + index, loss_buckets[index].count)) {
-                return false;
+        if (_forensic) {
+            for (std::size_t index = 0; index < segments.size(); ++index) {
+                if (!add_edge(source_node, segment_in_base + index, segments[index].capacity)) {
+                    return false;
+                }
+            }
+        } else {
+            for (std::size_t index = 0; index < loss_buckets.size(); ++index) {
+                if (!add_edge(source_node, loss_base + index, loss_buckets[index].count)) {
+                    return false;
+                }
             }
         }
         for (std::size_t index = 0; index < segments.size(); ++index) {
@@ -2244,101 +2636,106 @@ struct ProfileSessionReader::Impl {
                 return false;
             }
         }
-        for (std::size_t index = 0; index < _cpu_sequence_demands.size(); ++index) {
-            if (!add_edge(cpu_demand_base + index, sink_node, _cpu_sequence_demands[index].count)) {
+        for (std::size_t index = 0; index < _sequence_demands.size(); ++index) {
+            if (!add_edge(demand_base + index, sink_node, _sequence_demands[index].count)) {
                 return false;
             }
         }
-        if (!add_edge(dummy_demand_node, sink_node, loss_bucket_total - cpu_demand_total)) {
+        for (std::size_t index = 0; index < joint_local_cells.size(); ++index) {
+            if (!add_edge(
+                    cell_in_base + index, cell_out_base + index, joint_local_cells[index].local_capacity
+                )) {
+                return false;
+            }
+        }
+        for (std::size_t index = 0; index < joint_virtual_tasks.size(); ++index) {
+            if (!add_edge(task_base + index, sink_node, 1)) {
+                return false;
+            }
+        }
+        if (dummy_capacity != 0 && !add_edge(dummy_demand_node, sink_node, dummy_capacity)) {
             return false;
         }
 
-        const auto charge_segment_search = [&]() {
-            std::uint64_t remaining = static_cast<std::uint64_t>(segments.size());
-            std::uint64_t work      = 0;
-            while (remaining != 0) {
-                ++work;
-                remaining /= 2;
-            }
-            return ChargeTopologyWork(work);
-        };
-        for (std::size_t loss_index = 0; loss_index < loss_buckets.size(); ++loss_index) {
-            const LossBucket& bucket = loss_buckets[loss_index];
-            if (!charge_segment_search()) {
-                return false;
-            }
-            auto segment_it = std::lower_bound(
-                segments.begin(),
-                segments.end(),
-                bucket.release_sequence,
-                [](const SequenceSegment& _segment, std::uint64_t _sequence) {
-                    return _segment.end < _sequence;
+        if (!_forensic) {
+            for (std::size_t loss_index = 0; loss_index < loss_buckets.size(); ++loss_index) {
+                const LossBucket&   bucket = loss_buckets[loss_index];
+                const SegmentRange& range  = loss_segment_ranges[loss_index];
+                for (std::size_t segment_index = range.begin; segment_index < range.end; ++segment_index) {
+                    const SequenceSegment& segment = segments[segment_index];
+                    if (!add_edge(
+                            loss_base + loss_index,
+                            segment_in_base + segment_index,
+                            std::min(bucket.count, segment.capacity)
+                        )) {
+                        return false;
+                    }
                 }
-            );
-            for (; segment_it != segments.end() && segment_it->begin <= bucket.deadline_sequence;
-                 ++segment_it) {
-                if (!ChargeTopologyWork(1)) {
-                    return false;
-                }
-                const std::size_t segment_index = static_cast<std::size_t>(segment_it - segments.begin());
-                const SequenceSegment& segment  = segments[segment_index];
-                if (segment.begin >= bucket.release_sequence && segment.end <= bucket.deadline_sequence &&
-                    !add_edge(
-                        loss_base + loss_index,
-                        segment_in_base + segment_index,
-                        std::min(bucket.count, segment.capacity)
+            }
+        }
+        if (dummy_capacity != 0) {
+            for (std::size_t segment_index = 0; segment_index < segments.size(); ++segment_index) {
+                if (!add_edge(
+                        segment_out_base + segment_index, dummy_demand_node, segments[segment_index].capacity
                     )) {
                     return false;
                 }
             }
         }
-        for (std::size_t segment_index = 0; segment_index < segments.size(); ++segment_index) {
-            if (!add_edge(
-                    segment_out_base + segment_index, dummy_demand_node, segments[segment_index].capacity
-                )) {
-                return false;
-            }
-        }
-        for (std::size_t demand_index = 0; demand_index < _cpu_sequence_demands.size(); ++demand_index) {
-            const RecordSequenceDemand& demand = _cpu_sequence_demands[demand_index];
-            if (!charge_segment_search()) {
-                return false;
-            }
-            auto segment_it = std::lower_bound(
-                segments.begin(),
-                segments.end(),
-                demand.release_sequence,
-                [](const SequenceSegment& _segment, std::uint64_t _sequence) {
-                    return _segment.end < _sequence;
-                }
-            );
-            for (; segment_it != segments.end() && segment_it->begin <= demand.deadline_sequence;
-                 ++segment_it) {
-                if (!ChargeTopologyWork(1)) {
-                    return false;
-                }
-                const std::size_t segment_index = static_cast<std::size_t>(segment_it - segments.begin());
-                const SequenceSegment& segment  = segments[segment_index];
-                if (segment.begin >= demand.release_sequence && segment.end <= demand.deadline_sequence &&
-                    !add_edge(
+        for (std::size_t demand_index = 0; demand_index < _sequence_demands.size(); ++demand_index) {
+            const RecordSequenceDemand& demand = _sequence_demands[demand_index];
+            const SegmentRange&         range  = demand_segment_ranges[demand_index];
+            for (std::size_t segment_index = range.begin; segment_index < range.end; ++segment_index) {
+                const SequenceSegment& segment = segments[segment_index];
+                if (!add_edge(
                         segment_out_base + segment_index,
-                        cpu_demand_base + demand_index,
+                        demand_base + demand_index,
                         std::min(segment.capacity, demand.count)
                     )) {
                     return false;
                 }
             }
         }
+        for (std::size_t cell_index = 0; cell_index < joint_local_cells.size(); ++cell_index) {
+            const JointLocalCell& cell  = joint_local_cells[cell_index];
+            const SegmentRange&   range = cell_segment_ranges[cell_index];
+            for (std::size_t segment_index = range.begin; segment_index < range.end; ++segment_index) {
+                const SequenceSegment& segment = segments[segment_index];
+                if (!add_edge(
+                        segment_out_base + segment_index,
+                        cell_in_base + cell_index,
+                        std::min(segment.capacity, cell.local_capacity)
+                    )) {
+                    return false;
+                }
+            }
+            for (const std::size_t task_index : cell.task_indices) {
+                if (!add_edge(cell_out_base + cell_index, task_base + task_index, 1)) {
+                    return false;
+                }
+            }
+        }
 
-        std::uint64_t allocated_loss_count = 0;
-        if (!network.MaxFlow(source_node, sink_node, loss_bucket_total, allocated_loss_count)) {
+        if (built_forward_edges != forward_edge_count) {
+            Fail(
+                SessionLoadStatus::ResourceExhausted,
+                SessionErrorCode::UnexpectedFailure,
+                "profile topology flow-edge preflight disagrees with construction"
+            );
             return false;
         }
-        if (allocated_loss_count != loss_bucket_total) {
+        std::uint64_t allocated_flow = 0;
+        if (!network.MaxFlow(source_node, sink_node, flow_target, allocated_flow)) {
+            return false;
+        }
+        if (allocated_flow != flow_target) {
             Fail(
                 SessionLoadStatus::ProtocolViolation,
-                SessionErrorCode::CpuScopeParentMissing,
-                "noticed Loss intervals cannot jointly explain missing CPU parent sequences"
+                compatibility_error(
+                    SessionErrorCode::CpuScopeParentMissing, SessionErrorCode::GpuFrameTotalsMismatch
+                ),
+                _forensic ? "raw record-sequence holes cannot jointly explain missing CPU/GPU topology" :
+                            "noticed Loss intervals cannot jointly explain missing CPU/GPU topology sequences"
             );
             return false;
         }
@@ -2369,6 +2766,14 @@ struct ProfileSessionReader::Impl {
                     SessionLoadStatus::ProtocolViolation,
                     SessionErrorCode::GpuFrameDuplicate,
                     "duplicate GpuFrame identity"
+                );
+                return false;
+            }
+            if (frames[index - 1].sequence >= frames[index].sequence) {
+                Fail(
+                    SessionLoadStatus::ProtocolViolation,
+                    SessionErrorCode::RecordSequenceInvalid,
+                    "GpuFrame records reverse producer FIFO order"
                 );
                 return false;
             }
@@ -2538,9 +2943,17 @@ struct ProfileSessionReader::Impl {
         return true;
     }
 
-    [[nodiscard]] bool BuildGpuTopology(bool _allow_missing, std::uint64_t _required_cpu_drops) {
-        auto& frames = session.impl_->gpu_frames;
-        auto& scopes = session.impl_->gpu_scopes;
+    [[nodiscard]] bool BuildGpuTopology(
+        bool                               _allow_missing,
+        std::uint64_t                      _required_cpu_drops,
+        std::vector<RecordSequenceDemand>& _sequence_demands
+    ) {
+        _sequence_demands.clear();
+        joint_virtual_tasks.clear();
+        joint_local_cells.clear();
+        joint_cell_task_edge_count = 0;
+        auto& frames               = session.impl_->gpu_frames;
+        auto& scopes               = session.impl_->gpu_scopes;
         if (frames.empty() && scopes.empty()) {
             return true;
         }
@@ -2548,12 +2961,43 @@ struct ProfileSessionReader::Impl {
         const auto charge_topology_work = [&](std::uint64_t _count) {
             return ChargeTopologyWork(_count);
         };
-        if (!ChargeTopologyLinearWork(frames.size()) || !ChargeTopologyLinearWork(frames.size())) {
+        if (!ChargeTopologyLinearWork(frames.size()) || !ChargeTopologyLinearWork(frames.size()) ||
+            !ChargeTopologyLinearWork(frames.size())) {
             return false;
         }
         std::vector<std::uint64_t> frame_error_counts(frames.size(), 0);
         std::vector<std::uint8_t>  frame_root_partition_ambiguous(frames.size(), 0);
-        std::vector<ScopeLookup>   lookup;
+        struct FrameSequenceEvidence {
+            std::uint64_t earliest_scope_sequence{0};
+            std::uint64_t latest_scope_sequence{0};
+            std::uint64_t constrained_missing_scope_count{0};
+        };
+        std::vector<FrameSequenceEvidence> frame_sequence_evidence(frames.size());
+        const auto                         add_sequence_demand =
+            [&](std::uint64_t _release, std::uint64_t _deadline, std::uint64_t _count, const char* _diagnostic
+            ) {
+                if (_count == 0) {
+                    return true;
+                }
+                if (_release == 0 || _release > _deadline || _deadline - _release + 1 < _count) {
+                    Fail(
+                        SessionLoadStatus::ProtocolViolation,
+                        SessionErrorCode::GpuFrameTotalsMismatch,
+                        _diagnostic
+                    );
+                    return false;
+                }
+                if (!ChargeTopologyWork(1)) {
+                    return false;
+                }
+                _sequence_demands.push_back({
+                    .release_sequence  = _release,
+                    .deadline_sequence = _deadline,
+                    .count             = _count,
+                });
+                return true;
+            };
+        std::vector<ScopeLookup> lookup;
         if (!ChargeTopologyLinearWork(scopes.size())) {
             return false;
         }
@@ -2604,7 +3048,12 @@ struct ProfileSessionReader::Impl {
         std::vector<std::uint8_t>  has_previous_child(scopes.size(), 0);
         std::vector<double>        direct_child_duration(scopes.size(), 0.0);
         std::vector<ScopeLookup>   missing_parent_keys;
-        std::vector<std::uint64_t> missing_frame_ids;
+        struct MissingFrameEvidence {
+            std::uint64_t frame_id{0};
+            std::uint64_t earliest_scope_sequence{0};
+            std::uint64_t latest_scope_sequence{0};
+        };
+        std::vector<MissingFrameEvidence> missing_frame_evidence;
         struct MissingParentEvidence {
             std::uint64_t       frame_id{0};
             std::uint64_t       parent_scope_id{0};
@@ -2631,7 +3080,7 @@ struct ProfileSessionReader::Impl {
         }
         missing_parent_keys.reserve(scopes.size());
         missing_parent_evidence.reserve(scopes.size());
-        missing_frame_ids.reserve(scopes.size());
+        missing_frame_evidence.reserve(scopes.size());
 
         if (!ChargeTopologyLinearWork(scopes.size())) {
             return false;
@@ -2663,6 +3112,15 @@ struct ProfileSessionReader::Impl {
             GpuScopeRecord& scope  = scopes[index];
             bool            orphan = false;
 
+            if (scope.local_order == std::numeric_limits<std::uint64_t>::max()) {
+                Fail(
+                    SessionLoadStatus::ProtocolViolation,
+                    SessionErrorCode::GpuScopeIdentityInvalid,
+                    "GpuScope source local-order span overflows"
+                );
+                return false;
+            }
+
             if (!ChargeTopologyBinarySearchWork(frames.size())) {
                 return false;
             }
@@ -2677,7 +3135,11 @@ struct ProfileSessionReader::Impl {
             bool validate_timing = false;
             if (frame == frames.end() || frame->frame_id != scope.frame_id) {
                 orphan = true;
-                missing_frame_ids.push_back(scope.frame_id);
+                missing_frame_evidence.push_back({
+                    .frame_id                = scope.frame_id,
+                    .earliest_scope_sequence = scope.sequence,
+                    .latest_scope_sequence   = scope.sequence,
+                });
                 if (!_allow_missing) {
                     Fail(
                         SessionLoadStatus::ProtocolViolation,
@@ -2689,6 +3151,21 @@ struct ProfileSessionReader::Impl {
             } else {
                 const std::size_t frame_index = static_cast<std::size_t>(frame - frames.begin());
                 scope.frame_index             = frame_index;
+                if (frame->sequence >= scope.sequence) {
+                    Fail(
+                        SessionLoadStatus::ProtocolViolation,
+                        SessionErrorCode::RecordSequenceInvalid,
+                        "GpuFrame record sequence does not precede its GpuScope records"
+                    );
+                    return false;
+                }
+                FrameSequenceEvidence& sequence_evidence = frame_sequence_evidence[frame_index];
+                sequence_evidence.earliest_scope_sequence =
+                    sequence_evidence.earliest_scope_sequence == 0 ?
+                        scope.sequence :
+                        std::min(sequence_evidence.earliest_scope_sequence, scope.sequence);
+                sequence_evidence.latest_scope_sequence =
+                    std::max(sequence_evidence.latest_scope_sequence, scope.sequence);
                 // GpuFrame v1 only proves that producer-side topology was
                 // valid for Complete. Incomplete can also represent a
                 // structurally invalid frame accompanied by RHI drops.
@@ -2770,6 +3247,14 @@ struct ProfileSessionReader::Impl {
                         );
                         return false;
                     }
+                    if (parent.sequence >= scope.sequence) {
+                        Fail(
+                            SessionLoadStatus::ProtocolViolation,
+                            SessionErrorCode::RecordSequenceInvalid,
+                            "GpuScope parent record sequence does not precede its child"
+                        );
+                        return false;
+                    }
                     scope.parent_index = parent_index;
                     if (validate_timing) {
                         if (parent.status != ProfileGpuScopeStatus::Ready ||
@@ -2811,6 +3296,115 @@ struct ProfileSessionReader::Impl {
             if (orphan) {
                 ++session.impl_->summary.orphan_gpu_scope_count;
             }
+        }
+
+        if (!ChargeTopologyLinearWork(scopes.size()) || !ChargeTopologySortWork(scopes.size()) ||
+            !ChargeTopologyLinearWork(scopes.size())) {
+            return false;
+        }
+        std::vector<std::size_t> emission_order;
+        emission_order.reserve(scopes.size());
+        for (std::size_t index = 0; index < scopes.size(); ++index) {
+            emission_order.push_back(index);
+        }
+        std::sort(
+            emission_order.begin(),
+            emission_order.end(),
+            [&](std::size_t _left_index, std::size_t _right_index) {
+                const GpuScopeRecord& left  = scopes[_left_index];
+                const GpuScopeRecord& right = scopes[_right_index];
+                return std::tie(
+                           left.frame_id,
+                           left.logical_queue,
+                           left.native_queue_id,
+                           left.family_id,
+                           left.source_order,
+                           left.local_order,
+                           left.scope_id
+                       ) <
+                       std::tie(
+                           right.frame_id,
+                           right.logical_queue,
+                           right.native_queue_id,
+                           right.family_id,
+                           right.source_order,
+                           right.local_order,
+                           right.scope_id
+                       );
+            }
+        );
+        std::size_t emission_begin = 0;
+        while (emission_begin < emission_order.size()) {
+            std::size_t emission_end = emission_begin + 1;
+            while (emission_end < emission_order.size() && scopes[emission_order[emission_end]].frame_id ==
+                                                               scopes[emission_order[emission_begin]].frame_id
+            ) {
+                ++emission_end;
+            }
+
+            const GpuScopeRecord& first_scope     = scopes[emission_order[emission_begin]];
+            const bool            has_known_frame = first_scope.frame_index != kInvalidSessionIndex;
+            const std::size_t     frame_index =
+                has_known_frame ? static_cast<std::size_t>(first_scope.frame_index) : 0;
+            const bool complete_frame =
+                has_known_frame && frames[frame_index].status == ProfileGpuFrameStatus::Complete;
+            std::uint64_t previous_sequence =
+                has_known_frame ? frames[frame_index].sequence : std::uint64_t{0};
+            std::uint64_t constrained_missing_scope_count = 0;
+            bool          has_previous_record             = has_known_frame;
+            bool          has_previous_scope              = false;
+            for (std::size_t order_index = emission_begin; order_index < emission_end; ++order_index) {
+                const GpuScopeRecord& scope = scopes[emission_order[order_index]];
+                if (has_previous_record && scope.sequence <= previous_sequence) {
+                    Fail(
+                        SessionLoadStatus::ProtocolViolation,
+                        SessionErrorCode::RecordSequenceInvalid,
+                        "GpuScope records reverse producer emission order"
+                    );
+                    return false;
+                }
+
+                if (complete_frame) {
+                    std::uint64_t gap_count = scope.local_order;
+                    if (has_previous_scope) {
+                        const GpuScopeRecord& previous    = scopes[emission_order[order_index - 1]];
+                        const bool            same_source = previous.logical_queue == scope.logical_queue &&
+                                                 previous.native_queue_id == scope.native_queue_id &&
+                                                 previous.family_id == scope.family_id &&
+                                                 previous.source_order == scope.source_order;
+                        if (same_source) {
+                            gap_count = scope.local_order - previous.local_order - 1;
+                        }
+                    }
+                    if (gap_count != 0 &&
+                        !add_sequence_demand(
+                            previous_sequence + 1,
+                            scope.sequence - 1,
+                            gap_count,
+                            "missing Complete GpuFrame scopes have no compatible record-sequence slots"
+                        )) {
+                        return false;
+                    }
+                    if (AddOverflow(
+                            constrained_missing_scope_count, gap_count, constrained_missing_scope_count
+                        )) {
+                        Fail(
+                            SessionLoadStatus::ProtocolViolation,
+                            SessionErrorCode::GpuFrameTotalsMismatch,
+                            "Complete GpuFrame sequence-constrained deficit count overflows"
+                        );
+                        return false;
+                    }
+                }
+                previous_sequence   = scope.sequence;
+                has_previous_record = true;
+                has_previous_scope  = true;
+            }
+            if (complete_frame) {
+                frame_sequence_evidence[frame_index].constrained_missing_scope_count =
+                    constrained_missing_scope_count;
+            }
+            emission_begin = emission_end;
         }
 
         if (!ChargeTopologySortWork(missing_parent_evidence.size())) {
@@ -3148,19 +3742,29 @@ struct ProfileSessionReader::Impl {
             timing_source_begin = timing_source_end;
         }
         if (!ChargeTopologyLinearWork(scopes.size()) || !ChargeTopologyLinearWork(scopes.size()) ||
-            !ChargeTopologyLinearWork(scopes.size())) {
+            !ChargeTopologyLinearWork(scopes.size()) || !ChargeTopologyLinearWork(scopes.size())) {
             return false;
         }
         std::vector<std::uint64_t> timing_subtree_end_local(scopes.size(), 0);
+        std::vector<std::uint64_t> structural_subtree_end_local(scopes.size(), 0);
         for (std::size_t index = 0; index < scopes.size(); ++index) {
-            timing_subtree_end_local[index] = scopes[index].local_order;
+            timing_subtree_end_local[index]     = scopes[index].local_order;
+            structural_subtree_end_local[index] = scopes[index].local_order;
         }
         for (std::size_t index = scopes.size(); index != 0; --index) {
-            const std::size_t   scope_index  = index - 1;
-            const std::uint64_t parent_index = nearest_observed_timing_ancestor[scope_index];
-            if (parent_index != kInvalidSessionIndex) {
-                timing_subtree_end_local[parent_index] =
-                    std::max(timing_subtree_end_local[parent_index], timing_subtree_end_local[scope_index]);
+            const std::size_t   scope_index         = index - 1;
+            const std::uint64_t timing_parent_index = nearest_observed_timing_ancestor[scope_index];
+            if (timing_parent_index != kInvalidSessionIndex) {
+                timing_subtree_end_local[timing_parent_index] = std::max(
+                    timing_subtree_end_local[timing_parent_index], timing_subtree_end_local[scope_index]
+                );
+            }
+            const std::uint64_t structural_parent_index = scopes[scope_index].parent_index;
+            if (structural_parent_index != kInvalidSessionIndex) {
+                structural_subtree_end_local[structural_parent_index] = std::max(
+                    structural_subtree_end_local[structural_parent_index],
+                    structural_subtree_end_local[scope_index]
+                );
             }
         }
         std::size_t depth_range_leaf_count = 1;
@@ -3206,6 +3810,7 @@ struct ProfileSessionReader::Impl {
             std::uint64_t       source_order{0};
             std::uint32_t       parent_depth{0};
             std::uint64_t       child_local_order_deadline{0};
+            std::uint64_t       earliest_child_sequence{0};
             std::uint64_t       latest_parent_local_order{0};
             std::uint64_t       observed_local_orders_before_deadline{0};
             bool                timing_topology_trusted{false};
@@ -3233,8 +3838,12 @@ struct ProfileSessionReader::Impl {
             }
 
             const MissingParentEvidence& contract = missing_parent_evidence[evidence_begin];
-            std::uint64_t                last_child_subtree_end_local =
+            std::uint64_t                last_child_timing_subtree_end_local =
                 timing_subtree_end_local[static_cast<std::size_t>(contract.child_index)];
+            std::uint64_t last_child_structural_subtree_end_local =
+                structural_subtree_end_local[static_cast<std::size_t>(contract.child_index)];
+            std::uint64_t earliest_child_sequence =
+                scopes[static_cast<std::size_t>(contract.child_index)].sequence;
             for (std::size_t index = evidence_begin + 1; index < evidence_end; ++index) {
                 const MissingParentEvidence& evidence = missing_parent_evidence[index];
                 if (evidence.logical_queue != contract.logical_queue ||
@@ -3249,9 +3858,16 @@ struct ProfileSessionReader::Impl {
                     );
                     return false;
                 }
-                last_child_subtree_end_local = std::max(
-                    last_child_subtree_end_local,
+                last_child_timing_subtree_end_local = std::max(
+                    last_child_timing_subtree_end_local,
                     timing_subtree_end_local[static_cast<std::size_t>(evidence.child_index)]
+                );
+                last_child_structural_subtree_end_local = std::max(
+                    last_child_structural_subtree_end_local,
+                    structural_subtree_end_local[static_cast<std::size_t>(evidence.child_index)]
+                );
+                earliest_child_sequence = std::min(
+                    earliest_child_sequence, scopes[static_cast<std::size_t>(evidence.child_index)].sequence
                 );
             }
 
@@ -3431,11 +4047,14 @@ struct ProfileSessionReader::Impl {
                 .source_order                          = contract.source_order,
                 .parent_depth                          = contract.parent_depth,
                 .child_local_order_deadline            = contract.child_local_order,
+                .earliest_child_sequence               = earliest_child_sequence,
                 .latest_parent_local_order             = latest_parent_local_order,
                 .observed_local_orders_before_deadline = observed_before,
                 .timing_topology_trusted               = timing_topology_trusted,
                 .observed_ancestor_index               = observed_ancestor_index,
-                .last_child_subtree_end_local          = last_child_subtree_end_local,
+                .last_child_subtree_end_local          = timing_topology_trusted ?
+                                                             last_child_timing_subtree_end_local :
+                                                             last_child_structural_subtree_end_local,
                 .timing_envelope_begin_tick            = envelope_begin_tick,
                 .timing_envelope_duration              = envelope_end_offset,
             });
@@ -3468,6 +4087,135 @@ struct ProfileSessionReader::Impl {
             }
         );
 
+        if (!ChargeTopologySortWork(missing_frame_evidence.size()) ||
+            !ChargeTopologyLinearWork(missing_frame_evidence.size())) {
+            return false;
+        }
+        std::sort(
+            missing_frame_evidence.begin(),
+            missing_frame_evidence.end(),
+            [](const MissingFrameEvidence& _left, const MissingFrameEvidence& _right) {
+                if (_left.frame_id != _right.frame_id) {
+                    return _left.frame_id < _right.frame_id;
+                }
+                return _left.earliest_scope_sequence < _right.earliest_scope_sequence;
+            }
+        );
+        std::size_t missing_frame_count = 0;
+        for (const MissingFrameEvidence& evidence : missing_frame_evidence) {
+            if (missing_frame_count == 0 ||
+                missing_frame_evidence[missing_frame_count - 1].frame_id != evidence.frame_id) {
+                missing_frame_evidence[missing_frame_count++] = evidence;
+            } else {
+                missing_frame_evidence[missing_frame_count - 1].earliest_scope_sequence = std::min(
+                    missing_frame_evidence[missing_frame_count - 1].earliest_scope_sequence,
+                    evidence.earliest_scope_sequence
+                );
+                missing_frame_evidence[missing_frame_count - 1].latest_scope_sequence = std::max(
+                    missing_frame_evidence[missing_frame_count - 1].latest_scope_sequence,
+                    evidence.latest_scope_sequence
+                );
+            }
+        }
+        missing_frame_evidence.resize(missing_frame_count);
+
+        struct FrameEmissionBoundary {
+            std::uint64_t frame_id{0};
+            std::uint64_t earliest_scope_sequence{0};
+            std::uint64_t latest_observed_sequence{0};
+            std::size_t   source_index{0};
+            bool          known{false};
+        };
+        if (frames.size() > std::numeric_limits<std::size_t>::max() - missing_frame_evidence.size()) {
+            Fail(
+                SessionLoadStatus::LimitExceeded,
+                SessionErrorCode::LimitExceeded,
+                "GPU frame emission boundary count exceeds the addressable range",
+                DecodeStatus::LimitExceeded,
+                SessionLimitKind::TopologyWorkItems
+            );
+            return false;
+        }
+        const std::size_t boundary_count = frames.size() + missing_frame_evidence.size();
+        if (!ChargeTopologyWork(static_cast<std::uint64_t>(boundary_count)) ||
+            !ChargeTopologyLinearWork(boundary_count) || !ChargeTopologyLinearWork(boundary_count)) {
+            return false;
+        }
+        std::vector<FrameEmissionBoundary> frame_boundaries;
+        frame_boundaries.reserve(boundary_count);
+        std::size_t known_index   = 0;
+        std::size_t missing_index = 0;
+        while (known_index < frames.size() || missing_index < missing_frame_evidence.size()) {
+            const bool take_known =
+                missing_index == missing_frame_evidence.size() ||
+                (known_index < frames.size() &&
+                 frames[known_index].frame_id < missing_frame_evidence[missing_index].frame_id);
+            if (take_known) {
+                frame_boundaries.push_back({
+                    .frame_id                 = frames[known_index].frame_id,
+                    .earliest_scope_sequence  = frame_sequence_evidence[known_index].earliest_scope_sequence,
+                    .latest_observed_sequence = std::max(
+                        frames[known_index].sequence,
+                        frame_sequence_evidence[known_index].latest_scope_sequence
+                    ),
+                    .source_index = known_index,
+                    .known        = true,
+                });
+                ++known_index;
+            } else {
+                frame_boundaries.push_back({
+                    .frame_id                 = missing_frame_evidence[missing_index].frame_id,
+                    .earliest_scope_sequence  = missing_frame_evidence[missing_index].earliest_scope_sequence,
+                    .latest_observed_sequence = missing_frame_evidence[missing_index].latest_scope_sequence,
+                    .source_index             = missing_index,
+                    .known                    = false,
+                });
+                ++missing_index;
+            }
+        }
+
+        std::vector<std::uint64_t> known_frame_tail_deadlines(
+            frames.size(), std::numeric_limits<std::uint64_t>::max()
+        );
+        std::vector<std::uint64_t> missing_frame_record_releases(missing_frame_evidence.size(), 1);
+        std::uint64_t              previous_observed_end = 0;
+        bool                       has_previous_boundary = false;
+        for (std::size_t index = 0; index < frame_boundaries.size(); ++index) {
+            FrameEmissionBoundary& boundary = frame_boundaries[index];
+            if (boundary.known) {
+                const GpuFrameRecord& frame = frames[boundary.source_index];
+                if (has_previous_boundary && previous_observed_end >= frame.sequence) {
+                    Fail(
+                        SessionLoadStatus::ProtocolViolation,
+                        SessionErrorCode::RecordSequenceInvalid,
+                        "GPU frame emission boundaries reverse producer frame order"
+                    );
+                    return false;
+                }
+            } else {
+                if (boundary.earliest_scope_sequence == 0 ||
+                    (has_previous_boundary && previous_observed_end >= boundary.earliest_scope_sequence)) {
+                    Fail(
+                        SessionLoadStatus::ProtocolViolation,
+                        SessionErrorCode::RecordSequenceInvalid,
+                        "GpuScopes of a missing frame reverse producer frame order"
+                    );
+                    return false;
+                }
+                const std::uint64_t release =
+                    has_previous_boundary ? previous_observed_end + 1 : std::uint64_t{1};
+                missing_frame_record_releases[boundary.source_index] = release;
+            }
+
+            previous_observed_end = boundary.latest_observed_sequence;
+            has_previous_boundary = true;
+            if (boundary.known && index + 1 < frame_boundaries.size()) {
+                const FrameEmissionBoundary& next = frame_boundaries[index + 1];
+                known_frame_tail_deadlines[boundary.source_index] =
+                    next.known ? frames[next.source_index].sequence - 1 : next.earliest_scope_sequence - 1;
+            }
+        }
+
         struct SourceLossEvidence {
             std::uint64_t       frame_id{0};
             ProfileLogicalQueue logical_queue{ProfileLogicalQueue::Graphics};
@@ -3478,6 +4226,7 @@ struct ProfileSessionReader::Impl {
             std::uint64_t       scope_count{0};
             std::uint64_t       local_hole_count{0};
             std::uint64_t       required_parent_record_count{0};
+            std::uint64_t       producer_predecessor_sequence{0};
         };
         std::vector<SourceLossEvidence> source_loss_evidence;
         if (!ChargeTopologyLinearWork(scopes.size()) || !ChargeTopologyLinearWork(scopes.size()) ||
@@ -3521,17 +4270,68 @@ struct ProfileSessionReader::Impl {
             }
             const std::uint64_t observed_count = static_cast<std::uint64_t>(source_end - source_begin);
             source_loss_evidence.push_back({
-                .frame_id                     = scopes[source_begin].frame_id,
-                .logical_queue                = scopes[source_begin].logical_queue,
-                .native_queue_id              = scopes[source_begin].native_queue_id,
-                .family_id                    = scopes[source_begin].family_id,
-                .source_order                 = scopes[source_begin].source_order,
-                .first_scope                  = source_begin,
-                .scope_count                  = observed_count,
-                .local_hole_count             = local_span - observed_count,
-                .required_parent_record_count = 0,
+                .frame_id                      = scopes[source_begin].frame_id,
+                .logical_queue                 = scopes[source_begin].logical_queue,
+                .native_queue_id               = scopes[source_begin].native_queue_id,
+                .family_id                     = scopes[source_begin].family_id,
+                .source_order                  = scopes[source_begin].source_order,
+                .first_scope                   = source_begin,
+                .scope_count                   = observed_count,
+                .local_hole_count              = local_span - observed_count,
+                .required_parent_record_count  = 0,
+                .producer_predecessor_sequence = 0,
             });
             source_begin = source_end;
+        }
+
+        if (!ChargeTopologyLinearWork(source_loss_evidence.size()) ||
+            !ChargeTopologySortWork(source_loss_evidence.size())) {
+            return false;
+        }
+        std::vector<std::size_t> source_emission_order;
+        source_emission_order.reserve(source_loss_evidence.size());
+        for (std::size_t index = 0; index < source_loss_evidence.size(); ++index) {
+            source_emission_order.push_back(index);
+        }
+        std::sort(
+            source_emission_order.begin(),
+            source_emission_order.end(),
+            [&](std::size_t _left_index, std::size_t _right_index) {
+                const SourceLossEvidence& left  = source_loss_evidence[_left_index];
+                const SourceLossEvidence& right = source_loss_evidence[_right_index];
+                return std::tie(
+                           left.frame_id,
+                           left.logical_queue,
+                           left.native_queue_id,
+                           left.family_id,
+                           left.source_order
+                       ) <
+                       std::tie(
+                           right.frame_id,
+                           right.logical_queue,
+                           right.native_queue_id,
+                           right.family_id,
+                           right.source_order
+                       );
+            }
+        );
+        std::uint64_t previous_source_frame_id = 0;
+        std::uint64_t previous_source_sequence = 0;
+        bool          has_previous_source      = false;
+        if (!ChargeTopologyLinearWork(source_emission_order.size())) {
+            return false;
+        }
+        for (const std::size_t source_index : source_emission_order) {
+            SourceLossEvidence& source = source_loss_evidence[source_index];
+            std::uint64_t predecessor  = has_previous_source && previous_source_frame_id == source.frame_id ?
+                                             previous_source_sequence :
+                                             std::uint64_t{0};
+            source.producer_predecessor_sequence = predecessor;
+            const std::size_t source_end_index =
+                static_cast<std::size_t>(source.first_scope + source.scope_count);
+            previous_source_frame_id = source.frame_id;
+            previous_source_sequence = scopes[source_end_index - 1].sequence;
+            has_previous_source      = true;
         }
 
         const auto same_contract_source = [](const MissingParentContract& _contract,
@@ -3598,6 +4398,40 @@ struct ProfileSessionReader::Impl {
                 );
                 return false;
             }
+            if (!ChargeTopologyBinarySearchWork(frame_boundaries.size())) {
+                return false;
+            }
+            const auto frame_boundary = std::lower_bound(
+                frame_boundaries.begin(),
+                frame_boundaries.end(),
+                source->frame_id,
+                [](const FrameEmissionBoundary& _boundary, std::uint64_t _frame_id) {
+                    return _boundary.frame_id < _frame_id;
+                }
+            );
+            if (frame_boundary == frame_boundaries.end() || frame_boundary->frame_id != source->frame_id) {
+                Fail(
+                    SessionLoadStatus::ProtocolViolation,
+                    SessionErrorCode::GpuScopeFrameMissing,
+                    "joint GPU topology has no frame emission boundary"
+                );
+                return false;
+            }
+            std::uint64_t source_frame_release = 0;
+            if (frame_boundary->known) {
+                const GpuFrameRecord& frame = frames[frame_boundary->source_index];
+                if (frame.sequence == std::numeric_limits<std::uint64_t>::max()) {
+                    Fail(
+                        SessionLoadStatus::ProtocolViolation,
+                        SessionErrorCode::GpuFrameTotalsMismatch,
+                        "joint GPU topology has no sequence after its frame record"
+                    );
+                    return false;
+                }
+                source_frame_release = frame.sequence + 1;
+            } else {
+                source_frame_release = missing_frame_record_releases[frame_boundary->source_index];
+            }
 
             std::vector<std::uint32_t> depth_coordinates;
             const std::size_t          source_scope_count = static_cast<std::size_t>(source->scope_count);
@@ -3633,6 +4467,8 @@ struct ProfileSessionReader::Impl {
             if (!ChargeTopologyLinearWork(depth_coordinates.size()) ||
                 !ChargeTopologyLinearWork(depth_coordinates.size()) ||
                 !ChargeTopologyLinearWork(depth_coordinates.size()) ||
+                !ChargeTopologyLinearWork(depth_coordinates.size()) ||
+                !ChargeTopologyLinearWork(depth_coordinates.size()) ||
                 !ChargeTopologyLinearWork(depth_coordinates.size())) {
                 return false;
             }
@@ -3640,7 +4476,10 @@ struct ProfileSessionReader::Impl {
             std::vector<std::uint64_t> prefix_covered_depth_tree(depth_coordinates.size() + 1, 0);
             std::vector<std::uint8_t>  depth_covered(depth_coordinates.size(), 0);
             std::vector<std::uint8_t>  prefix_depth_covered(depth_coordinates.size(), 0);
-            const auto                 cover_depth = [&](std::uint32_t               _depth,
+            std::vector<std::uint8_t>  active_observed_depth(depth_coordinates.size(), 0);
+            std::vector<std::size_t>   active_observed_depth_stack;
+            active_observed_depth_stack.reserve(depth_coordinates.size());
+            const auto cover_depth = [&](std::uint32_t               _depth,
                                          std::vector<std::uint64_t>& _tree,
                                          std::vector<std::uint8_t>&  _covered) {
                 const std::size_t coordinate = static_cast<std::size_t>(
@@ -4840,6 +5679,209 @@ struct ProfileSessionReader::Impl {
                 if (!ChargeTopologyLinearWork(contract_count)) {
                     return false;
                 }
+                struct VirtualSequenceTaskState {
+                    std::uint64_t canonical_task_index{kInvalidSessionIndex};
+                    bool          canonical_is_direct{false};
+                };
+                struct VirtualSequenceTaskKey {
+                    std::uint32_t depth{0};
+                    std::uint64_t first_allowed_slot{0};
+
+                    [[nodiscard]] bool operator<(const VirtualSequenceTaskKey& _right) const noexcept {
+                        return std::tie(depth, first_allowed_slot) <
+                               std::tie(_right.depth, _right.first_allowed_slot);
+                    }
+                };
+                struct VirtualSequenceTask {
+                    std::uint64_t first_allowed_slot{0};
+                    std::uint64_t deadline_slot{0};
+                    std::uint64_t deadline_sequence{0};
+                    std::uint32_t depth{0};
+                };
+
+                if (!ChargeTopologyLinearWork(depth_coordinates.size()) ||
+                    !ChargeTopologyLinearWork(source_scope_count)) {
+                    return false;
+                }
+                std::vector<std::uint64_t> structural_barrier_tree(depth_coordinates.size() + 1, 0);
+                const auto                 observe_structural_barrier = [&](std::size_t _scope_index) {
+                    const GpuScopeRecord& scope      = scopes[_scope_index];
+                    const std::size_t     coordinate = static_cast<std::size_t>(
+                        std::lower_bound(depth_coordinates.begin(), depth_coordinates.end(), scope.depth) -
+                        depth_coordinates.begin()
+                    );
+                    std::uint64_t local_order_after = 0;
+                    if (AddOverflow(
+                            structural_subtree_end_local[_scope_index], std::uint64_t{1}, local_order_after
+                        )) {
+                        Fail(
+                            SessionLoadStatus::ProtocolViolation,
+                            SessionErrorCode::GpuScopeIdentityInvalid,
+                            "observed GPU structural subtree overflows local-order space"
+                        );
+                        return false;
+                    }
+                    for (std::size_t tree_index = coordinate + 1; tree_index < structural_barrier_tree.size();
+                         tree_index += tree_index & (~tree_index + 1)) {
+                        structural_barrier_tree[tree_index] =
+                            std::max(structural_barrier_tree[tree_index], local_order_after);
+                    }
+                    return true;
+                };
+                const auto latest_structural_barrier_after = [&](std::uint32_t _depth) {
+                    std::size_t tree_index = static_cast<std::size_t>(
+                        std::upper_bound(depth_coordinates.begin(), depth_coordinates.end(), _depth) -
+                        depth_coordinates.begin()
+                    );
+                    std::uint64_t latest = 0;
+                    while (tree_index != 0) {
+                        latest = std::max(latest, structural_barrier_tree[tree_index]);
+                        tree_index &= tree_index - 1;
+                    }
+                    return latest;
+                };
+
+                std::vector<std::size_t> structural_completion_order;
+                structural_completion_order.reserve(source_scope_count);
+                for (std::size_t index = static_cast<std::size_t>(source->first_scope);
+                     index < source_end_index;
+                     ++index) {
+                    structural_completion_order.push_back(index);
+                }
+                if (!ChargeTopologySortWork(structural_completion_order.size())) {
+                    return false;
+                }
+                std::sort(
+                    structural_completion_order.begin(),
+                    structural_completion_order.end(),
+                    [&](std::size_t _left, std::size_t _right) {
+                        return std::tie(structural_subtree_end_local[_left], scopes[_left].local_order) <
+                               std::tie(structural_subtree_end_local[_right], scopes[_right].local_order);
+                    }
+                );
+
+                std::map<VirtualSequenceTaskKey, VirtualSequenceTaskState> virtual_task_states;
+                std::map<std::uint32_t, std::uint64_t>                     previous_missing_direct_end;
+                std::vector<VirtualSequenceTask>                           virtual_sequence_tasks;
+                std::size_t                                                completed_structural_index = 0;
+                const auto add_virtual_sequence_task = [&](std::uint32_t                _depth,
+                                                           const MissingParentContract& _contract,
+                                                           bool                         _direct) {
+                    if (_contract.earliest_child_sequence == 0) {
+                        Fail(
+                            SessionLoadStatus::ProtocolViolation,
+                            SessionErrorCode::GpuScopeParentInvalid,
+                            "missing GpuScope sequence obligation has no child deadline"
+                        );
+                        return false;
+                    }
+                    if (!ChargeTopologyBinarySearchWork(depth_coordinates.size()) ||
+                        !ChargeTopologyBinarySearchWork(depth_coordinates.size())) {
+                        return false;
+                    }
+                    std::uint64_t first_allowed_slot = latest_structural_barrier_after(_depth);
+                    if (_direct) {
+                        if (!ChargeTopologyBinarySearchWork(previous_missing_direct_end.size())) {
+                            return false;
+                        }
+                        const auto previous_direct = previous_missing_direct_end.find(_depth);
+                        if (previous_direct != previous_missing_direct_end.end()) {
+                            std::uint64_t direct_epoch = 0;
+                            if (AddOverflow(previous_direct->second, std::uint64_t{1}, direct_epoch)) {
+                                Fail(
+                                    SessionLoadStatus::ProtocolViolation,
+                                    SessionErrorCode::GpuScopeIdentityInvalid,
+                                    "missing GPU parent subtree overflows local-order space"
+                                );
+                                return false;
+                            }
+                            first_allowed_slot = std::max(first_allowed_slot, direct_epoch);
+                        }
+                    }
+                    if (first_allowed_slot >= _contract.child_local_order_deadline) {
+                        Fail(
+                            SessionLoadStatus::ProtocolViolation,
+                            SessionErrorCode::GpuFrameTotalsMismatch,
+                            "missing GPU ancestry has no slot after its structural barrier"
+                        );
+                        return false;
+                    }
+
+                    const VirtualSequenceTaskKey key{
+                        .depth              = _depth,
+                        .first_allowed_slot = first_allowed_slot,
+                    };
+                    if (!ChargeTopologyBinarySearchWork(virtual_task_states.size())) {
+                        return false;
+                    }
+                    auto       state            = virtual_task_states.find(key);
+                    const bool shares_canonical = state != virtual_task_states.end() &&
+                                                  (!_direct || !state->second.canonical_is_direct);
+                    if (shares_canonical) {
+                        VirtualSequenceTask& task =
+                            virtual_sequence_tasks[static_cast<std::size_t>(state->second.canonical_task_index
+                            )];
+                        task.deadline_slot =
+                            std::min(task.deadline_slot, _contract.child_local_order_deadline);
+                        task.deadline_sequence =
+                            std::min(task.deadline_sequence, _contract.earliest_child_sequence - 1);
+                        if (task.first_allowed_slot >= task.deadline_slot) {
+                            Fail(
+                                SessionLoadStatus::ProtocolViolation,
+                                SessionErrorCode::GpuFrameTotalsMismatch,
+                                "shared missing GPU ancestry crosses its structural local-order barrier"
+                            );
+                            return false;
+                        }
+                        if (_direct) {
+                            state->second.canonical_is_direct = true;
+                        }
+                        return true;
+                    }
+
+                    std::uint64_t next_task_edge_count = 0;
+                    if (AddOverflow(
+                            static_cast<std::uint64_t>(joint_virtual_tasks.size()),
+                            static_cast<std::uint64_t>(virtual_sequence_tasks.size()),
+                            next_task_edge_count
+                        ) ||
+                        AddOverflow(next_task_edge_count, std::uint64_t{1}, next_task_edge_count) ||
+                        next_task_edge_count > options.limits.max_topology_flow_edges) {
+                        Fail(
+                            SessionLoadStatus::LimitExceeded,
+                            SessionErrorCode::LimitExceeded,
+                            "joint GPU virtual tasks exceed the topology flow-edge limit",
+                            DecodeStatus::LimitExceeded,
+                            SessionLimitKind::TopologyFlowEdges
+                        );
+                        return false;
+                    }
+                    if (!ChargeTopologyWork(1)) {
+                        return false;
+                    }
+                    const std::uint64_t task_index =
+                        static_cast<std::uint64_t>(virtual_sequence_tasks.size());
+                    virtual_sequence_tasks.push_back({
+                        .first_allowed_slot = first_allowed_slot,
+                        .deadline_slot      = _contract.child_local_order_deadline,
+                        .deadline_sequence  = _contract.earliest_child_sequence - 1,
+                        .depth              = _depth,
+                    });
+                    if (state == virtual_task_states.end()) {
+                        if (!ChargeTopologyHeapWork(virtual_task_states.size() + 1)) {
+                            return false;
+                        }
+                        virtual_task_states.emplace(
+                            key,
+                            VirtualSequenceTaskState{
+                                .canonical_task_index = task_index,
+                                .canonical_is_direct  = _direct,
+                            }
+                        );
+                    }
+                    return true;
+                };
+
                 std::size_t   observed_index              = static_cast<std::size_t>(source->first_scope);
                 std::uint64_t hidden_ancestor_lower_bound = 0;
                 std::map<std::uint32_t, std::uint32_t> required_prefix_depth_intervals;
@@ -4944,6 +5986,22 @@ struct ProfileSessionReader::Impl {
                 ));
                 for (std::size_t index = contract_begin; index < contract_end; ++index) {
                     const MissingParentContract& contract = missing_parent_contracts[index];
+                    while (completed_structural_index < structural_completion_order.size() &&
+                           structural_subtree_end_local
+                                   [structural_completion_order[completed_structural_index]] <
+                               contract.child_local_order_deadline) {
+                        if (!ChargeTopologyBinarySearchWork(depth_coordinates.size()) ||
+                            !ChargeTopologyBinarySearchWork(depth_coordinates.size()) ||
+                            !observe_structural_barrier(
+                                structural_completion_order[completed_structural_index]
+                            )) {
+                            return false;
+                        }
+                        ++completed_structural_index;
+                    }
+                    if (!add_virtual_sequence_task(contract.parent_depth, contract, true)) {
+                        return false;
+                    }
                     if (!ChargeTopologyBinarySearchWork(depth_coordinates.size())) {
                         return false;
                     }
@@ -4988,6 +6046,7 @@ struct ProfileSessionReader::Impl {
                             if (!ChargeTopologyBinarySearchWork(depth_coordinates.size()) ||
                                 !ChargeTopologyBinarySearchWork(depth_coordinates.size()) ||
                                 !ChargeTopologyBinarySearchWork(depth_coordinates.size()) ||
+                                !ChargeTopologyBinarySearchWork(depth_coordinates.size()) ||
                                 !ChargeTopologyBinarySearchWork(depth_coordinates.size())) {
                                 return false;
                             }
@@ -4995,7 +6054,48 @@ struct ProfileSessionReader::Impl {
                             cover_depth(
                                 scopes[observed_index].depth, prefix_covered_depth_tree, prefix_depth_covered
                             );
+                            const std::size_t observed_depth_coordinate = static_cast<std::size_t>(
+                                std::lower_bound(
+                                    depth_coordinates.begin(),
+                                    depth_coordinates.end(),
+                                    scopes[observed_index].depth
+                                ) -
+                                depth_coordinates.begin()
+                            );
+                            while (!active_observed_depth_stack.empty() &&
+                                   depth_coordinates[active_observed_depth_stack.back()] >=
+                                       scopes[observed_index].depth) {
+                                if (!ChargeTopologyWork(1)) {
+                                    return false;
+                                }
+                                active_observed_depth[active_observed_depth_stack.back()] = 0;
+                                active_observed_depth_stack.pop_back();
+                            }
+                            if (!ChargeTopologyWork(1)) {
+                                return false;
+                            }
+                            active_observed_depth[observed_depth_coordinate] = 1;
+                            active_observed_depth_stack.push_back(observed_depth_coordinate);
                             ++observed_index;
+                        }
+                    }
+
+                    if (!ChargeTopologyWork(static_cast<std::uint64_t>(contract.parent_depth))) {
+                        return false;
+                    }
+                    for (std::uint32_t depth = 0; depth < contract.parent_depth; ++depth) {
+                        if (!ChargeTopologyBinarySearchWork(depth_coordinates.size())) {
+                            return false;
+                        }
+                        const auto coordinate =
+                            std::lower_bound(depth_coordinates.begin(), depth_coordinates.end(), depth);
+                        const bool observed_depth = coordinate != depth_coordinates.end() &&
+                                                    *coordinate == depth &&
+                                                    active_observed_depth[static_cast<std::size_t>(
+                                                        coordinate - depth_coordinates.begin()
+                                                    )] != 0;
+                        if (!observed_depth && !add_virtual_sequence_task(depth, contract, false)) {
+                            return false;
                         }
                     }
 
@@ -5080,6 +6180,12 @@ struct ProfileSessionReader::Impl {
                         );
                         return false;
                     }
+
+                    if (!ChargeTopologyHeapWork(previous_missing_direct_end.size() + 1)) {
+                        return false;
+                    }
+                    previous_missing_direct_end[contract.parent_depth] =
+                        contract.last_child_subtree_end_local;
                 }
 
                 const std::uint64_t direct_parent_count =
@@ -5099,12 +6205,236 @@ struct ProfileSessionReader::Impl {
                     );
                     return false;
                 }
-                source->required_parent_record_count = depth_required_parent_records;
-                if (source->required_parent_record_count > source->local_hole_count) {
+                if (depth_required_parent_records > source->local_hole_count) {
                     Fail(
                         SessionLoadStatus::ProtocolViolation,
                         SessionErrorCode::GpuScopeParentInvalid,
                         "missing GpuScope ancestry exceeds its source local-order holes"
+                    );
+                    return false;
+                }
+                const std::uint64_t sequence_required_parent_records =
+                    static_cast<std::uint64_t>(virtual_sequence_tasks.size());
+                if (sequence_required_parent_records < depth_required_parent_records) {
+                    Fail(
+                        SessionLoadStatus::ProtocolViolation,
+                        SessionErrorCode::GpuScopeParentInvalid,
+                        "missing GpuScope sequence obligations disagree with the topology lower bound"
+                    );
+                    return false;
+                }
+                depth_required_parent_records        = sequence_required_parent_records;
+                source->required_parent_record_count = depth_required_parent_records;
+                if (source->required_parent_record_count > source->local_hole_count) {
+                    Fail(
+                        SessionLoadStatus::ProtocolViolation,
+                        SessionErrorCode::GpuFrameTotalsMismatch,
+                        "structural GPU ancestry generations exceed source local-order holes"
+                    );
+                    return false;
+                }
+
+                const auto source_scope_begin =
+                    scopes.begin() + static_cast<std::ptrdiff_t>(source->first_scope);
+                const auto source_scope_end = scopes.begin() + static_cast<std::ptrdiff_t>(source_end_index);
+                const std::size_t global_task_begin = joint_virtual_tasks.size();
+                if (virtual_sequence_tasks.size() > joint_virtual_tasks.max_size() - global_task_begin ||
+                    !ChargeTopologyLinearWork(virtual_sequence_tasks.size())) {
+                    Fail(
+                        SessionLoadStatus::LimitExceeded,
+                        SessionErrorCode::LimitExceeded,
+                        "joint GPU topology task count exceeds the addressable range",
+                        DecodeStatus::LimitExceeded,
+                        SessionLimitKind::TopologyWorkItems
+                    );
+                    return false;
+                }
+                std::uint64_t task_edge_lower_bound = 0;
+                if (AddOverflow(
+                        static_cast<std::uint64_t>(joint_virtual_tasks.size()),
+                        static_cast<std::uint64_t>(virtual_sequence_tasks.size()),
+                        task_edge_lower_bound
+                    ) ||
+                    task_edge_lower_bound > options.limits.max_topology_flow_edges) {
+                    Fail(
+                        SessionLoadStatus::LimitExceeded,
+                        SessionErrorCode::LimitExceeded,
+                        "joint GPU task edges exceed the topology flow-edge limit",
+                        DecodeStatus::LimitExceeded,
+                        SessionLimitKind::TopologyFlowEdges
+                    );
+                    return false;
+                }
+                for (std::size_t task_index = 0; task_index < virtual_sequence_tasks.size(); ++task_index) {
+                    const VirtualSequenceTask& task = virtual_sequence_tasks[task_index];
+                    joint_virtual_tasks.push_back({
+                        .first_allowed_local = task.first_allowed_slot,
+                        .deadline_local      = task.deadline_slot,
+                        .deadline_sequence   = task.deadline_sequence,
+                    });
+                }
+
+                std::uint64_t       boundary_capacity = 1;
+                const std::uint64_t task_count = static_cast<std::uint64_t>(virtual_sequence_tasks.size());
+                if (AddOverflow(boundary_capacity, task_count, boundary_capacity) ||
+                    AddOverflow(boundary_capacity, task_count, boundary_capacity) ||
+                    AddOverflow(boundary_capacity, source_scope_count, boundary_capacity) ||
+                    AddOverflow(boundary_capacity, source_scope_count, boundary_capacity) ||
+                    boundary_capacity > static_cast<std::uint64_t>(std::numeric_limits<std::size_t>::max()) ||
+                    !ChargeTopologyWork(boundary_capacity)) {
+                    Fail(
+                        SessionLoadStatus::LimitExceeded,
+                        SessionErrorCode::LimitExceeded,
+                        "joint GPU local-cell boundaries exceed the addressable range",
+                        DecodeStatus::LimitExceeded,
+                        SessionLimitKind::TopologyWorkItems
+                    );
+                    return false;
+                }
+                std::vector<std::uint64_t> local_boundaries;
+                local_boundaries.reserve(static_cast<std::size_t>(boundary_capacity));
+                local_boundaries.push_back(0);
+                for (const VirtualSequenceTask& task : virtual_sequence_tasks) {
+                    local_boundaries.push_back(task.first_allowed_slot);
+                    local_boundaries.push_back(task.deadline_slot);
+                }
+                for (auto scope = source_scope_begin; scope != source_scope_end; ++scope) {
+                    local_boundaries.push_back(scope->local_order);
+                    local_boundaries.push_back(scope->local_order + 1);
+                }
+                if (!ChargeTopologySortWork(local_boundaries.size()) ||
+                    !ChargeTopologyLinearWork(local_boundaries.size())) {
+                    return false;
+                }
+                std::sort(local_boundaries.begin(), local_boundaries.end());
+                local_boundaries.erase(
+                    std::unique(local_boundaries.begin(), local_boundaries.end()), local_boundaries.end()
+                );
+
+                std::vector<std::uint8_t> task_has_cell(virtual_sequence_tasks.size(), 0);
+                for (std::size_t boundary_index = 0; boundary_index + 1 < local_boundaries.size();
+                     ++boundary_index) {
+                    const std::uint64_t cell_begin = local_boundaries[boundary_index];
+                    const std::uint64_t cell_end   = local_boundaries[boundary_index + 1];
+                    if (cell_begin >= cell_end) {
+                        continue;
+                    }
+                    if (!ChargeTopologyBinarySearchWork(source_scope_count)) {
+                        return false;
+                    }
+                    const auto successor = std::lower_bound(
+                        source_scope_begin,
+                        source_scope_end,
+                        cell_begin,
+                        [](const GpuScopeRecord& _scope, std::uint64_t _local_order) {
+                            return _scope.local_order < _local_order;
+                        }
+                    );
+                    if (successor != source_scope_end && successor->local_order == cell_begin) {
+                        continue;
+                    }
+                    if (successor == source_scope_end || successor->local_order < cell_end ||
+                        successor->sequence == 0) {
+                        continue;
+                    }
+
+                    std::uint64_t predecessor_sequence = source->producer_predecessor_sequence;
+                    if (successor != source_scope_begin) {
+                        predecessor_sequence = std::prev(successor)->sequence;
+                    }
+                    if (predecessor_sequence == std::numeric_limits<std::uint64_t>::max()) {
+                        Fail(
+                            SessionLoadStatus::ProtocolViolation,
+                            SessionErrorCode::GpuFrameTotalsMismatch,
+                            "joint GPU local cell has no sequence after its producer predecessor"
+                        );
+                        return false;
+                    }
+                    const std::uint64_t release_sequence =
+                        std::max(predecessor_sequence + 1, source_frame_release);
+                    const std::uint64_t deadline_sequence = successor->sequence - 1;
+                    if (release_sequence > deadline_sequence) {
+                        continue;
+                    }
+
+                    JointLocalCell cell{
+                        .frame_id          = source->frame_id,
+                        .local_begin       = cell_begin,
+                        .local_end         = cell_end,
+                        .release_sequence  = release_sequence,
+                        .deadline_sequence = deadline_sequence,
+                    };
+                    std::uint64_t accepted_task_count = 0;
+                    if (!ChargeTopologyLinearWork(virtual_sequence_tasks.size())) {
+                        return false;
+                    }
+                    for (std::size_t task_index = 0; task_index < virtual_sequence_tasks.size();
+                         ++task_index) {
+                        const VirtualSequenceTask& task = virtual_sequence_tasks[task_index];
+                        if (task.first_allowed_slot <= cell_begin && cell_end <= task.deadline_slot) {
+                            if (successor->sequence - 1 > task.deadline_sequence) {
+                                Fail(
+                                    SessionLoadStatus::ProtocolViolation,
+                                    SessionErrorCode::GpuFrameTotalsMismatch,
+                                    "joint GPU local cell crosses its task sequence deadline"
+                                );
+                                return false;
+                            }
+                            std::uint64_t next_accepted_task_count = 0;
+                            std::uint64_t proposed_task_edge_count = 0;
+                            std::uint64_t proposed_cell_count      = 0;
+                            std::uint64_t flow_edge_lower_bound    = 0;
+                            if (AddOverflow(
+                                    accepted_task_count, std::uint64_t{1}, next_accepted_task_count
+                                ) ||
+                                AddOverflow(
+                                    joint_cell_task_edge_count,
+                                    next_accepted_task_count,
+                                    proposed_task_edge_count
+                                ) ||
+                                AddOverflow(
+                                    static_cast<std::uint64_t>(joint_local_cells.size()),
+                                    std::uint64_t{1},
+                                    proposed_cell_count
+                                ) ||
+                                AddOverflow(
+                                    static_cast<std::uint64_t>(joint_virtual_tasks.size()),
+                                    proposed_cell_count,
+                                    flow_edge_lower_bound
+                                ) ||
+                                AddOverflow(
+                                    flow_edge_lower_bound, proposed_task_edge_count, flow_edge_lower_bound
+                                ) ||
+                                flow_edge_lower_bound > options.limits.max_topology_flow_edges) {
+                                Fail(
+                                    SessionLoadStatus::LimitExceeded,
+                                    SessionErrorCode::LimitExceeded,
+                                    "joint GPU local-cell edges exceed the topology flow-edge limit",
+                                    DecodeStatus::LimitExceeded,
+                                    SessionLimitKind::TopologyFlowEdges
+                                );
+                                return false;
+                            }
+                            accepted_task_count = next_accepted_task_count;
+                            cell.task_indices.push_back(global_task_begin + task_index);
+                            task_has_cell[task_index] = 1;
+                        }
+                    }
+                    if (accepted_task_count == 0) {
+                        continue;
+                    }
+                    cell.local_capacity = std::min<std::uint64_t>(cell_end - cell_begin, accepted_task_count);
+                    joint_cell_task_edge_count += accepted_task_count;
+                    joint_local_cells.push_back(std::move(cell));
+                }
+                if (!ChargeTopologyLinearWork(task_has_cell.size())) {
+                    return false;
+                }
+                if (std::ranges::find(task_has_cell, std::uint8_t{0}) != task_has_cell.end()) {
+                    Fail(
+                        SessionLoadStatus::ProtocolViolation,
+                        SessionErrorCode::GpuFrameTotalsMismatch,
+                        "missing GPU ancestry has no joint local-order cell"
                     );
                     return false;
                 }
@@ -5200,14 +6530,6 @@ struct ProfileSessionReader::Impl {
             ),
             missing_parent_keys.end()
         );
-        if (!ChargeTopologySortWork(missing_frame_ids.size()) ||
-            !ChargeTopologyLinearWork(missing_frame_ids.size())) {
-            return false;
-        }
-        std::sort(missing_frame_ids.begin(), missing_frame_ids.end());
-        missing_frame_ids.erase(
-            std::unique(missing_frame_ids.begin(), missing_frame_ids.end()), missing_frame_ids.end()
-        );
 
         const auto missing_parent_count = [&](std::uint64_t _frame_id) {
             const ScopeLookup first{
@@ -5293,44 +6615,105 @@ struct ProfileSessionReader::Impl {
             frame.export_missing_scope_count = missing_scopes;
             frame.materialization_complete   = missing_scopes == 0;
             if (frame.status == ProfileGpuFrameStatus::Complete) {
+                const std::uint64_t constrained_missing =
+                    frame_sequence_evidence[index].constrained_missing_scope_count;
+                if (constrained_missing > missing_scopes) {
+                    Fail(
+                        SessionLoadStatus::ProtocolViolation,
+                        SessionErrorCode::GpuFrameTotalsMismatch,
+                        "GpuFrame sequence-constrained deficits exceed its missing scope count"
+                    );
+                    return false;
+                }
+                const std::uint64_t unconstrained_missing = missing_scopes - constrained_missing;
+                if (unconstrained_missing != 0) {
+                    if (frame.sequence == std::numeric_limits<std::uint64_t>::max()) {
+                        Fail(
+                            SessionLoadStatus::ProtocolViolation,
+                            SessionErrorCode::GpuFrameTotalsMismatch,
+                            "missing Complete GpuFrame scopes have no record-sequence capacity after the "
+                            "frame"
+                        );
+                        return false;
+                    }
+                    if (!add_sequence_demand(
+                            frame.sequence + 1,
+                            known_frame_tail_deadlines[index],
+                            unconstrained_missing,
+                            "missing Complete GpuFrame scopes have no record-sequence capacity after the "
+                            "frame"
+                        )) {
+                        return false;
+                    }
+                }
                 if (!add_required_gpu_drops(missing_scopes)) {
                     return false;
                 }
                 if (missing_scopes != 0) {
                     ++session.impl_->summary.degraded_complete_gpu_frame_count;
                 }
-            } else if (!add_required_gpu_drops(required_parent_records)) {
-                return false;
+            } else {
+                if (!add_required_gpu_drops(required_parent_records)) {
+                    return false;
+                }
             }
         }
 
-        if (!add_required_gpu_drops(static_cast<std::uint64_t>(missing_frame_ids.size()))) {
+        if (!ChargeTopologyLinearWork(missing_frame_evidence.size())) {
             return false;
         }
-        if (!ChargeTopologyLinearWork(missing_frame_ids.size())) {
-            return false;
-        }
-        for (const std::uint64_t frame_id : missing_frame_ids) {
+        for (std::size_t missing_frame_index = 0; missing_frame_index < missing_frame_evidence.size();
+             ++missing_frame_index) {
+            const MissingFrameEvidence& missing_frame = missing_frame_evidence[missing_frame_index];
             if (!ChargeTopologyBinarySearchWork(frame_loss_evidence.size()) ||
                 !ChargeTopologyBinarySearchWork(missing_parent_keys.size()) ||
                 !ChargeTopologyBinarySearchWork(missing_parent_keys.size())) {
                 return false;
             }
-            const FrameLossEvidence* loss_evidence           = find_frame_loss_evidence(frame_id);
+            const FrameLossEvidence* loss_evidence = find_frame_loss_evidence(missing_frame.frame_id);
             const std::uint64_t      required_parent_records = std::max(
-                missing_parent_count(frame_id),
+                missing_parent_count(missing_frame.frame_id),
                 loss_evidence != nullptr ? loss_evidence->required_parent_record_count : 0
             );
-            if (!add_required_gpu_drops(required_parent_records)) {
+            std::uint64_t required_frame_records = 0;
+            if (AddOverflow(required_parent_records, std::uint64_t{1}, required_frame_records)) {
+                Fail(
+                    SessionLoadStatus::ProtocolViolation,
+                    SessionErrorCode::GpuFrameTotalsMismatch,
+                    "missing GpuFrame topology record count overflows"
+                );
+                return false;
+            }
+            if (missing_frame.earliest_scope_sequence <= 1) {
+                Fail(
+                    SessionLoadStatus::ProtocolViolation,
+                    SessionErrorCode::GpuFrameTotalsMismatch,
+                    "missing GpuFrame topology has no compatible record-sequence slots"
+                );
+                return false;
+            }
+            if (!add_sequence_demand(
+                    missing_frame_record_releases[missing_frame_index],
+                    missing_frame.earliest_scope_sequence - 1,
+                    1,
+                    "missing GpuFrame topology has no compatible record-sequence slots"
+                )) {
+                return false;
+            }
+            if (!add_required_gpu_drops(required_frame_records)) {
                 return false;
             }
         }
         if (session.impl_->summary.has_session_end) {
             const std::uint64_t total_drop_budget = session.impl_->summary.lost_record_count;
             if (required_gpu_drops > total_drop_budget) {
+                const bool has_cpu_drop_requirement = _required_cpu_drops != 0;
+                const bool has_gpu_drop_requirement = required_gpu_drops > _required_cpu_drops;
                 Fail(
                     SessionLoadStatus::ProtocolViolation,
-                    SessionErrorCode::GpuFrameTotalsMismatch,
+                    has_cpu_drop_requirement && has_gpu_drop_requirement ?
+                        SessionErrorCode::RecordSequenceInvalid :
+                        SessionErrorCode::GpuFrameTotalsMismatch,
                     "CPU/GPU deficits exceed the noticed allocated-record loss budget"
                 );
                 return false;
@@ -5486,6 +6869,7 @@ struct ProfileSessionReader::Impl {
         if (!BuildCpuTracks(allow_missing, required_cpu_drops, cpu_sequence_demands)) {
             return false;
         }
+        const bool has_cpu_sequence_demands = !cpu_sequence_demands.empty();
         if (session.impl_->summary.has_session_end &&
             required_cpu_drops > session.impl_->summary.lost_record_count) {
             Fail(
@@ -5495,10 +6879,42 @@ struct ProfileSessionReader::Impl {
             );
             return false;
         }
-        if (!_forensic && !ValidateCpuLossCompatibility(cpu_sequence_demands)) {
+        std::vector<RecordSequenceDemand> gpu_sequence_demands;
+        if (!BuildGpuDomainsAndTracks() ||
+            !BuildGpuTopology(allow_missing, required_cpu_drops, gpu_sequence_demands)) {
             return false;
         }
-        if (!BuildGpuDomainsAndTracks() || !BuildGpuTopology(allow_missing, required_cpu_drops)) {
+        const bool has_gpu_sequence_demands = !gpu_sequence_demands.empty();
+        if (has_gpu_sequence_demands) {
+            if (gpu_sequence_demands.size() > cpu_sequence_demands.max_size() - cpu_sequence_demands.size()) {
+                Fail(
+                    SessionLoadStatus::LimitExceeded,
+                    SessionErrorCode::LimitExceeded,
+                    "combined CPU/GPU sequence demand count exceeds the addressable range",
+                    DecodeStatus::LimitExceeded,
+                    SessionLimitKind::TopologyWorkItems
+                );
+                return false;
+            }
+            const std::size_t combined_demand_count =
+                cpu_sequence_demands.size() + gpu_sequence_demands.size();
+            if (!ChargeTopologyLinearWork(combined_demand_count)) {
+                return false;
+            }
+            cpu_sequence_demands.reserve(combined_demand_count);
+            cpu_sequence_demands.insert(
+                cpu_sequence_demands.end(), gpu_sequence_demands.begin(), gpu_sequence_demands.end()
+            );
+        }
+        if (!ValidateSequenceSlotCapacity(
+                cpu_sequence_demands, has_cpu_sequence_demands, has_gpu_sequence_demands
+            )) {
+            return false;
+        }
+        if ((!_forensic || !joint_virtual_tasks.empty()) &&
+            !ValidateTopologyLossCompatibility(
+                cpu_sequence_demands, has_cpu_sequence_demands, has_gpu_sequence_demands, _forensic
+            )) {
             return false;
         }
         session.impl_->valid = true;
@@ -5510,6 +6926,9 @@ struct ProfileSessionReader::Impl {
         std::unordered_map<std::uint64_t, SchemaEntry>{}.swap(schemas);
         std::unordered_map<std::string_view, SessionStringId>{}.swap(interned_strings);
         std::vector<std::uint64_t>{}.swap(record_sequences);
+        std::vector<JointVirtualTask>{}.swap(joint_virtual_tasks);
+        std::vector<JointLocalCell>{}.swap(joint_local_cells);
+        joint_cell_task_edge_count = 0;
     }
 
     [[nodiscard]] SessionLoadResult Feed(std::span<const std::uint8_t> _bytes) noexcept {
@@ -5726,6 +7145,9 @@ struct ProfileSessionReader::Impl {
     std::unordered_map<std::uint64_t, SchemaEntry>        schemas{};
     std::unordered_map<std::string_view, SessionStringId> interned_strings{};
     std::vector<std::uint64_t>                            record_sequences{};
+    std::vector<JointVirtualTask>                         joint_virtual_tasks{};
+    std::vector<JointLocalCell>                           joint_local_cells{};
+    std::uint64_t                                         joint_cell_task_edge_count{0};
     std::uint64_t                                         schema_bytes{0};
     std::uint64_t                                         string_bytes{0};
     std::uint64_t                                         topology_work_items{0};

--- a/source/tool/profile_consumer/source/ProfileSession.cpp
+++ b/source/tool/profile_consumer/source/ProfileSession.cpp
@@ -9,8 +9,12 @@
 #include <cstring>
 #include <deque>
 #include <fstream>
+#include <iterator>
 #include <limits>
+#include <map>
 #include <new>
+#include <queue>
+#include <set>
 #include <string>
 #include <type_traits>
 #include <unordered_map>
@@ -76,6 +80,144 @@ TimestampDelta(std::uint64_t _begin_tick, std::uint64_t _end_tick, std::uint32_t
     }
     const double tolerance = std::max(1.0e-6, std::max(std::abs(_left), std::abs(_right)) * 1.0e-9);
     return std::abs(_left - _right) <= tolerance;
+}
+
+[[nodiscard]] bool CanBridgeSerialTimestampGap(
+    std::uint64_t _duration,
+    std::uint64_t _begin_offset,
+    std::uint32_t _valid_bits,
+    std::uint64_t _missing_local_orders
+) noexcept {
+    const std::uint64_t half_range =
+        _valid_bits == 64 ? (std::uint64_t{1} << 63) : (std::uint64_t{1} << (_valid_bits - 1));
+    const std::uint64_t maximum_step = half_range - 1;
+    if (_duration > maximum_step) {
+        return false;
+    }
+
+    std::uint64_t step_count = 0;
+    if (AddOverflow(_missing_local_orders, std::uint64_t{1}, step_count)) {
+        return true;
+    }
+    if (maximum_step == 0) {
+        return _begin_offset == 0 && _duration == 0;
+    }
+
+    if (_valid_bits != 64) {
+        const std::uint64_t modulus  = std::uint64_t{1} << _valid_bits;
+        const std::uint64_t distance = _begin_offset >= _duration ? _begin_offset : _begin_offset + modulus;
+        const std::uint64_t required_steps =
+            distance / maximum_step + static_cast<std::uint64_t>(distance % maximum_step != 0);
+        return required_steps <= step_count;
+    }
+
+    std::uint64_t required_steps = 0;
+    if (_begin_offset >= _duration) {
+        required_steps =
+            _begin_offset / maximum_step + static_cast<std::uint64_t>(_begin_offset % maximum_step != 0);
+    } else if (_begin_offset <= maximum_step - 2) {
+        required_steps = 3;
+    } else if (_begin_offset <= std::numeric_limits<std::uint64_t>::max() - 3) {
+        required_steps = 4;
+    } else {
+        required_steps = 5;
+    }
+    return required_steps <= step_count;
+}
+
+struct SerialTick {
+    std::uint64_t epoch{0};
+    std::uint64_t tick{0};
+
+    [[nodiscard]] bool operator<(const SerialTick& _right) const noexcept {
+        return std::tie(epoch, tick) < std::tie(_right.epoch, _right.tick);
+    }
+};
+
+[[nodiscard]] bool SerialTickLessEqual(const SerialTick& _left, const SerialTick& _right) noexcept {
+    return !(_right < _left);
+}
+
+[[nodiscard]] bool AddSerialTickDelta(
+    SerialTick    _base,
+    std::uint64_t _delta,
+    std::uint32_t _valid_bits,
+    SerialTick&   _result
+) noexcept {
+    if (_valid_bits == 64) {
+        const std::uint64_t tick  = _base.tick + _delta;
+        const std::uint64_t carry = static_cast<std::uint64_t>(tick < _base.tick);
+        if (carry != 0 && _base.epoch == std::numeric_limits<std::uint64_t>::max()) {
+            return false;
+        }
+        _result = {
+            .epoch = _base.epoch + carry,
+            .tick  = tick,
+        };
+        return true;
+    }
+
+    const std::uint64_t modulus = std::uint64_t{1} << _valid_bits;
+    const std::uint64_t sum     = _base.tick + _delta;
+    const std::uint64_t carry   = static_cast<std::uint64_t>(sum >= modulus);
+    if (carry != 0 && _base.epoch == std::numeric_limits<std::uint64_t>::max()) {
+        return false;
+    }
+    _result = {
+        .epoch = _base.epoch + carry,
+        .tick  = carry != 0 ? sum - modulus : sum,
+    };
+    return true;
+}
+
+[[nodiscard]] bool SubtractSerialTickDelta(
+    SerialTick    _base,
+    std::uint64_t _delta,
+    std::uint32_t _valid_bits,
+    SerialTick&   _result
+) noexcept {
+    if (_base.tick >= _delta) {
+        _result = {
+            .epoch = _base.epoch,
+            .tick  = _base.tick - _delta,
+        };
+        return true;
+    }
+    if (_base.epoch == 0) {
+        return false;
+    }
+    if (_valid_bits == 64) {
+        _result = {
+            .epoch = _base.epoch - 1,
+            .tick  = _base.tick - _delta,
+        };
+        return true;
+    }
+    const std::uint64_t modulus = std::uint64_t{1} << _valid_bits;
+    _result                     = {
+                            .epoch = _base.epoch - 1,
+                            .tick  = modulus - (_delta - _base.tick),
+    };
+    return true;
+}
+
+[[nodiscard]] bool NextSerialTickOccurrence(
+    std::uint64_t     _tick,
+    std::uint32_t     _valid_bits,
+    const SerialTick& _lower_bound,
+    SerialTick&       _result
+) noexcept {
+    _result = {
+        .epoch = _lower_bound.epoch,
+        .tick  = _tick & TimestampMask(_valid_bits),
+    };
+    if (_result < _lower_bound) {
+        if (_result.epoch == std::numeric_limits<std::uint64_t>::max()) {
+            return false;
+        }
+        ++_result.epoch;
+    }
+    return true;
 }
 
 [[nodiscard]] KnownProfileSchema IdentifyKnownSchema(const SchemaDescriptor& _schema) {
@@ -976,8 +1118,9 @@ struct ProfileSessionReader::Impl {
         return true;
     }
 
-    [[nodiscard]] bool BuildCpuTracks(bool _allow_missing) {
-        auto& scopes = session.impl_->cpu_scopes;
+    [[nodiscard]] bool BuildCpuTracks(bool _allow_missing, std::uint64_t& _required_cpu_drops) {
+        _required_cpu_drops = 0;
+        auto& scopes        = session.impl_->cpu_scopes;
         std::sort(
             scopes.begin(),
             scopes.end(),
@@ -998,6 +1141,13 @@ struct ProfileSessionReader::Impl {
             }
         );
 
+        struct CpuGapEvent {
+            std::uint64_t ancestor_index{0};
+            std::uint64_t scope_index{0};
+            std::uint32_t depth_gap{0};
+        };
+        std::vector<CpuGapEvent> gap_events;
+        gap_events.reserve(scopes.size());
         std::size_t track_begin = 0;
         while (track_begin < scopes.size()) {
             std::size_t track_end = track_begin + 1;
@@ -1025,51 +1175,320 @@ struct ProfileSessionReader::Impl {
             active.reserve(std::min<std::size_t>(
                 track_end - track_begin, static_cast<std::size_t>(options.limits.max_scope_depth) + 1
             ));
+            std::map<std::uint32_t, std::vector<std::uint64_t>> ending_parents_by_depth;
+            std::uint64_t                                       boundary_time     = 0;
+            bool                                                has_boundary_time = false;
             for (std::size_t index = track_begin; index < track_end; ++index) {
                 CpuScopeRecord& scope = scopes[index];
                 scope.track_index     = track_index;
 
+                if (!has_boundary_time || boundary_time != scope.begin_ns) {
+                    ending_parents_by_depth.clear();
+                    boundary_time     = scope.begin_ns;
+                    has_boundary_time = true;
+                }
                 while (!active.empty()) {
-                    const CpuScopeRecord& candidate = scopes[active.back()];
-                    if (candidate.end_ns >= scope.end_ns && candidate.begin_ns <= scope.begin_ns &&
-                        candidate.depth < scope.depth) {
+                    const std::uint64_t   candidate_index = active.back();
+                    const CpuScopeRecord& candidate       = scopes[candidate_index];
+                    const bool            zero_duration_child_at_end =
+                        candidate.end_ns == scope.begin_ns && scope.end_ns == scope.begin_ns &&
+                        scope.depth > candidate.depth && candidate.sequence > scope.sequence;
+                    if (candidate.end_ns > scope.begin_ns || zero_duration_child_at_end) {
                         break;
                     }
-                    active.pop_back();
-                }
-                while (!active.empty() && scopes[active.back()].depth >= scope.depth) {
+                    if (candidate.sequence >= scope.sequence) {
+                        Fail(
+                            SessionLoadStatus::ProtocolViolation,
+                            SessionErrorCode::CpuScopeTopologyInvalid,
+                            "non-overlapping CpuScopes move backward in record sequence"
+                        );
+                        return false;
+                    }
+                    if (candidate.end_ns == scope.begin_ns) {
+                        ending_parents_by_depth[candidate.depth].push_back(candidate_index);
+                    }
                     active.pop_back();
                 }
 
-                if (scope.depth != 0) {
-                    auto parent =
-                        std::find_if(active.rbegin(), active.rend(), [&](std::uint64_t _candidate_index) {
-                            const CpuScopeRecord& candidate = scopes[_candidate_index];
-                            return candidate.depth == scope.depth - 1 &&
-                                   candidate.begin_ns <= scope.begin_ns && candidate.end_ns >= scope.end_ns;
-                        });
-                    if (parent == active.rend()) {
-                        ++session.impl_->summary.orphan_cpu_scope_count;
-                        if (!_allow_missing) {
-                            Fail(
-                                SessionLoadStatus::ProtocolViolation,
-                                SessionErrorCode::CpuScopeParentMissing,
-                                "CpuScope hierarchy has a missing parent"
-                            );
-                            return false;
-                        }
-                    } else {
-                        scope.parent_index = *parent;
+                if (!active.empty()) {
+                    const CpuScopeRecord& candidate     = scopes[active.back()];
+                    const bool            crossing      = scope.end_ns > candidate.end_ns;
+                    const bool            invalid_depth = scope.depth <= candidate.depth;
+                    if (crossing || invalid_depth) {
+                        Fail(
+                            SessionLoadStatus::ProtocolViolation,
+                            SessionErrorCode::CpuScopeTopologyInvalid,
+                            "CpuScope intervals overlap without a valid nesting relation"
+                        );
+                        return false;
                     }
+                }
+
+                std::uint64_t ancestor_index = active.empty() ? kInvalidSessionIndex : active.back();
+                if (scope.begin_ns == scope.end_ns && scope.depth != 0) {
+                    std::uint64_t ending_ancestor_index = kInvalidSessionIndex;
+                    auto          ending_depth          = ending_parents_by_depth.lower_bound(scope.depth);
+                    while (ending_depth != ending_parents_by_depth.begin()) {
+                        --ending_depth;
+                        for (const std::uint64_t candidate_index : ending_depth->second) {
+                            const CpuScopeRecord& candidate = scopes[candidate_index];
+                            if (candidate.sequence > scope.sequence &&
+                                (ending_ancestor_index == kInvalidSessionIndex ||
+                                 candidate.sequence < scopes[ending_ancestor_index].sequence)) {
+                                ending_ancestor_index = candidate_index;
+                            }
+                        }
+                        if (ending_ancestor_index != kInvalidSessionIndex) {
+                            break;
+                        }
+                    }
+                    if (ending_ancestor_index != kInvalidSessionIndex &&
+                        (ancestor_index == kInvalidSessionIndex ||
+                         scopes[ending_ancestor_index].depth > scopes[ancestor_index].depth ||
+                         (scopes[ending_ancestor_index].depth == scopes[ancestor_index].depth &&
+                          scopes[ending_ancestor_index].sequence < scopes[ancestor_index].sequence))) {
+                        ancestor_index = ending_ancestor_index;
+                    }
+                }
+
+                std::uint64_t parent_index = kInvalidSessionIndex;
+                if (ancestor_index != kInvalidSessionIndex) {
+                    const CpuScopeRecord& ancestor = scopes[ancestor_index];
+                    if (ancestor.sequence <= scope.sequence) {
+                        Fail(
+                            SessionLoadStatus::ProtocolViolation,
+                            SessionErrorCode::CpuScopeTopologyInvalid,
+                            "CpuScope containing ancestor was emitted before its descendant"
+                        );
+                        return false;
+                    }
+                    const std::uint32_t depth_gap      = scope.depth - ancestor.depth - 1;
+                    const std::uint64_t sequence_slots = ancestor.sequence - scope.sequence - 1;
+                    if (sequence_slots < depth_gap) {
+                        Fail(
+                            SessionLoadStatus::ProtocolViolation,
+                            SessionErrorCode::CpuScopeTopologyInvalid,
+                            "CpuScope depth gap has too few intervening record sequences"
+                        );
+                        return false;
+                    }
+                    gap_events.push_back({
+                        .ancestor_index = ancestor_index,
+                        .scope_index    = index,
+                        .depth_gap      = depth_gap,
+                    });
+                    if (depth_gap == 0) {
+                        parent_index = ancestor_index;
+                    }
+                }
+
+                if (scope.depth != 0 && parent_index == kInvalidSessionIndex) {
+                    ++session.impl_->summary.orphan_cpu_scope_count;
+                } else if (parent_index != kInvalidSessionIndex) {
+                    scope.parent_index = parent_index;
                 }
                 active.push_back(index);
             }
             track_begin = track_end;
         }
+
+        struct CpuSequenceDemand {
+            std::uint64_t release_sequence{0};
+            std::uint64_t deadline_sequence{0};
+            std::uint64_t count{0};
+        };
+        std::vector<CpuSequenceDemand> sequence_demands;
+        sequence_demands.reserve(gap_events.size());
+        const auto add_sequence_demand =
+            [&](std::uint64_t _lower_sequence, std::uint64_t _upper_sequence, std::uint64_t _count) {
+                if (_count == 0) {
+                    return true;
+                }
+                if (_lower_sequence >= _upper_sequence || _upper_sequence - _lower_sequence - 1 < _count) {
+                    Fail(
+                        SessionLoadStatus::ProtocolViolation,
+                        SessionErrorCode::CpuScopeTopologyInvalid,
+                        "CpuScope hierarchy has too few record-sequence slots for missing parents"
+                    );
+                    return false;
+                }
+                std::uint64_t required_cpu_drops = 0;
+                if (AddOverflow(_required_cpu_drops, _count, required_cpu_drops)) {
+                    Fail(
+                        SessionLoadStatus::ProtocolViolation,
+                        SessionErrorCode::CpuScopeTopologyInvalid,
+                        "minimum CPU record loss count overflows"
+                    );
+                    return false;
+                }
+                _required_cpu_drops = required_cpu_drops;
+                sequence_demands.push_back({
+                    .release_sequence  = _lower_sequence + 1,
+                    .deadline_sequence = _upper_sequence - 1,
+                    .count             = _count,
+                });
+                return true;
+            };
+
+        std::sort(
+            gap_events.begin(),
+            gap_events.end(),
+            [](const CpuGapEvent& _left, const CpuGapEvent& _right) {
+                if (_left.ancestor_index != _right.ancestor_index) {
+                    return _left.ancestor_index < _right.ancestor_index;
+                }
+                return _left.scope_index < _right.scope_index;
+            }
+        );
+        std::size_t event_begin = 0;
+        while (event_begin < gap_events.size()) {
+            std::size_t event_end = event_begin + 1;
+            while (event_end < gap_events.size() &&
+                   gap_events[event_end].ancestor_index == gap_events[event_begin].ancestor_index) {
+                ++event_end;
+            }
+
+            std::uint32_t previous_gap      = gap_events[event_begin].depth_gap;
+            std::uint64_t previous_sequence = scopes[gap_events[event_begin].scope_index].sequence;
+            for (std::size_t index = event_begin + 1; index < event_end; ++index) {
+                const CpuGapEvent&  event          = gap_events[index];
+                const std::uint64_t event_sequence = scopes[event.scope_index].sequence;
+                if (event_sequence <= previous_sequence) {
+                    Fail(
+                        SessionLoadStatus::ProtocolViolation,
+                        SessionErrorCode::CpuScopeTopologyInvalid,
+                        "compressed CpuScope siblings move backward in record sequence"
+                    );
+                    return false;
+                }
+                if (event.depth_gap < previous_gap &&
+                    !add_sequence_demand(
+                        previous_sequence,
+                        event_sequence,
+                        static_cast<std::uint64_t>(previous_gap - event.depth_gap)
+                    )) {
+                    return false;
+                }
+                previous_gap      = event.depth_gap;
+                previous_sequence = event_sequence;
+            }
+
+            const std::uint64_t ancestor_sequence = scopes[gap_events[event_begin].ancestor_index].sequence;
+            if (!add_sequence_demand(previous_sequence, ancestor_sequence, previous_gap)) {
+                return false;
+            }
+            event_begin = event_end;
+        }
+
+        if (_required_cpu_drops != 0 && !_allow_missing) {
+            Fail(
+                SessionLoadStatus::ProtocolViolation,
+                SessionErrorCode::CpuScopeParentMissing,
+                "CpuScope hierarchy requires missing emitted parents"
+            );
+            return false;
+        }
+
+        std::sort(
+            sequence_demands.begin(),
+            sequence_demands.end(),
+            [](const CpuSequenceDemand& _left, const CpuSequenceDemand& _right) {
+                if (_left.release_sequence != _right.release_sequence) {
+                    return _left.release_sequence < _right.release_sequence;
+                }
+                return _left.deadline_sequence < _right.deadline_sequence;
+            }
+        );
+        struct PendingCpuSequenceDemand {
+            std::uint64_t deadline_sequence{0};
+            std::uint64_t remaining_count{0};
+        };
+        const auto later_deadline = [](const PendingCpuSequenceDemand& _left,
+                                       const PendingCpuSequenceDemand& _right) {
+            return _left.deadline_sequence > _right.deadline_sequence;
+        };
+        std::priority_queue<
+            PendingCpuSequenceDemand,
+            std::vector<PendingCpuSequenceDemand>,
+            decltype(later_deadline)>
+                      pending_demands(later_deadline);
+        std::size_t   demand_index   = 0;
+        std::size_t   observed_index = 0;
+        std::uint64_t position = sequence_demands.empty() ? 0 : sequence_demands.front().release_sequence;
+        while (demand_index < sequence_demands.size() || !pending_demands.empty()) {
+            while (demand_index < sequence_demands.size() &&
+                   sequence_demands[demand_index].release_sequence <= position) {
+                pending_demands.push({
+                    .deadline_sequence = sequence_demands[demand_index].deadline_sequence,
+                    .remaining_count   = sequence_demands[demand_index].count,
+                });
+                ++demand_index;
+            }
+            if (pending_demands.empty()) {
+                position = sequence_demands[demand_index].release_sequence;
+                continue;
+            }
+            if (pending_demands.top().deadline_sequence < position) {
+                Fail(
+                    SessionLoadStatus::ProtocolViolation,
+                    SessionErrorCode::CpuScopeTopologyInvalid,
+                    "missing CpuScope parents cannot occupy distinct record-sequence holes"
+                );
+                return false;
+            }
+
+            while (observed_index < record_sequences.size() && record_sequences[observed_index] < position) {
+                ++observed_index;
+            }
+            if (observed_index < record_sequences.size() && record_sequences[observed_index] == position) {
+                ++position;
+                ++observed_index;
+                continue;
+            }
+
+            PendingCpuSequenceDemand demand = pending_demands.top();
+            pending_demands.pop();
+            std::uint64_t batch_end = demand.deadline_sequence + 1;
+            if (observed_index < record_sequences.size()) {
+                batch_end = std::min(batch_end, record_sequences[observed_index]);
+            }
+            if (demand_index < sequence_demands.size()) {
+                batch_end = std::min(batch_end, sequence_demands[demand_index].release_sequence);
+            }
+            const std::uint64_t available = batch_end - position;
+            const std::uint64_t assigned  = std::min(available, demand.remaining_count);
+            position += assigned;
+            demand.remaining_count -= assigned;
+            if (demand.remaining_count != 0) {
+                pending_demands.push(demand);
+            }
+        }
         return true;
     }
 
     [[nodiscard]] bool BuildGpuDomainsAndTracks() {
+        auto& frames = session.impl_->gpu_frames;
+        std::sort(
+            frames.begin(),
+            frames.end(),
+            [](const GpuFrameRecord& _left, const GpuFrameRecord& _right) {
+                if (_left.frame_id != _right.frame_id) {
+                    return _left.frame_id < _right.frame_id;
+                }
+                return _left.sequence < _right.sequence;
+            }
+        );
+        for (std::size_t index = 1; index < frames.size(); ++index) {
+            if (frames[index - 1].frame_id == frames[index].frame_id) {
+                Fail(
+                    SessionLoadStatus::ProtocolViolation,
+                    SessionErrorCode::GpuFrameDuplicate,
+                    "duplicate GpuFrame identity"
+                );
+                return false;
+            }
+        }
+
         auto&                  scopes = session.impl_->gpu_scopes;
         std::vector<DomainKey> keys;
         keys.reserve(scopes.size());
@@ -1102,6 +1521,17 @@ struct ProfileSessionReader::Impl {
         }
 
         for (GpuScopeRecord& scope : scopes) {
+            const auto frame = std::lower_bound(
+                frames.begin(),
+                frames.end(),
+                scope.frame_id,
+                [](const GpuFrameRecord& _frame, std::uint64_t _frame_id) {
+                    return _frame.frame_id < _frame_id;
+                }
+            );
+            const bool timing_capability_trusted = frame != frames.end() &&
+                                                   frame->frame_id == scope.frame_id &&
+                                                   frame->status == ProfileGpuFrameStatus::Complete;
             const DomainKey key{
                 .native_queue_id = scope.native_queue_id,
                 .family_id       = scope.family_id,
@@ -1113,18 +1543,24 @@ struct ProfileSessionReader::Impl {
             domain.logical_queue_mask |= ProfileLogicalQueueBit(scope.logical_queue);
             if (scope.status == ProfileGpuScopeStatus::Ready) {
                 ++domain.ready_scope_count;
-                if (!domain.has_ready_timestamps) {
-                    domain.has_ready_timestamps = true;
-                    domain.valid_bits           = scope.valid_bits;
-                    domain.tick_period_ns       = scope.tick_period_ns;
-                } else if (domain.valid_bits != scope.valid_bits ||
-                           domain.tick_period_ns != scope.tick_period_ns) {
+                if (timing_capability_trusted && !domain.timing_capability_trusted) {
+                    domain.has_ready_timestamps      = true;
+                    domain.timing_capability_trusted = true;
+                    domain.valid_bits                = scope.valid_bits;
+                    domain.tick_period_ns            = scope.tick_period_ns;
+                } else if (timing_capability_trusted &&
+                           (domain.valid_bits != scope.valid_bits ||
+                            !NearlyEqualDuration(domain.tick_period_ns, scope.tick_period_ns))) {
                     Fail(
                         SessionLoadStatus::ProtocolViolation,
                         SessionErrorCode::GpuDomainConflict,
-                        "one GPU timestamp domain reports conflicting timing capabilities"
+                        "trusted GPU scopes report conflicting timing capabilities"
                     );
                     return false;
+                } else if (!domain.has_ready_timestamps) {
+                    domain.has_ready_timestamps = true;
+                    domain.valid_bits           = scope.valid_bits;
+                    domain.tick_period_ns       = scope.tick_period_ns;
                 }
             } else {
                 ++domain.error_scope_count;
@@ -1192,31 +1628,29 @@ struct ProfileSessionReader::Impl {
         return true;
     }
 
-    [[nodiscard]] bool BuildGpuTopology(bool _allow_missing) {
+    [[nodiscard]] bool BuildGpuTopology(bool _allow_missing, std::uint64_t _required_cpu_drops) {
         auto& frames = session.impl_->gpu_frames;
         auto& scopes = session.impl_->gpu_scopes;
-        std::sort(
-            frames.begin(),
-            frames.end(),
-            [](const GpuFrameRecord& _left, const GpuFrameRecord& _right) {
-                if (_left.frame_id != _right.frame_id) {
-                    return _left.frame_id < _right.frame_id;
-                }
-                return _left.sequence < _right.sequence;
-            }
-        );
-        for (std::size_t index = 1; index < frames.size(); ++index) {
-            if (frames[index - 1].frame_id == frames[index].frame_id) {
+
+        std::uint64_t topology_work_items  = 0;
+        const auto    charge_topology_work = [&](std::uint64_t _count) {
+            std::uint64_t next_topology_work_items = 0;
+            if (AddOverflow(topology_work_items, _count, next_topology_work_items) ||
+                next_topology_work_items > options.limits.max_topology_work_items) {
                 Fail(
-                    SessionLoadStatus::ProtocolViolation,
-                    SessionErrorCode::GpuFrameDuplicate,
-                    "duplicate GpuFrame identity"
+                    SessionLoadStatus::LimitExceeded,
+                    SessionErrorCode::LimitExceeded,
+                    "GPU topology work-item limit exceeded",
+                    DecodeStatus::LimitExceeded,
+                    SessionLimitKind::TopologyWorkItems
                 );
                 return false;
             }
-        }
-
+            topology_work_items = next_topology_work_items;
+            return true;
+        };
         std::vector<std::uint64_t> frame_error_counts(frames.size(), 0);
+        std::vector<std::uint8_t>  frame_root_partition_ambiguous(frames.size(), 0);
         std::vector<ScopeLookup>   lookup;
         lookup.reserve(scopes.size());
         for (std::size_t index = 0; index < scopes.size(); ++index) {
@@ -1251,6 +1685,51 @@ struct ProfileSessionReader::Impl {
                        kInvalidSessionIndex;
         };
 
+        std::vector<std::uint64_t> previous_child_end(scopes.size(), 0);
+        std::vector<std::uint8_t>  has_previous_child(scopes.size(), 0);
+        std::vector<double>        direct_child_duration(scopes.size(), 0.0);
+        std::vector<ScopeLookup>   missing_parent_keys;
+        std::vector<std::uint64_t> missing_frame_ids;
+        struct MissingParentEvidence {
+            std::uint64_t       frame_id{0};
+            std::uint64_t       parent_scope_id{0};
+            ProfileLogicalQueue logical_queue{ProfileLogicalQueue::Graphics};
+            std::uint32_t       native_queue_id{0};
+            std::uint32_t       family_id{0};
+            std::uint64_t       source_order{0};
+            std::uint32_t       parent_depth{0};
+            std::uint64_t       child_local_order{0};
+            std::uint64_t       child_index{0};
+        };
+        std::vector<MissingParentEvidence> missing_parent_evidence;
+        std::vector<std::uint64_t>         source_local_rank(scopes.size(), 0);
+        std::vector<std::uint64_t> nearest_observed_timing_ancestor(scopes.size(), kInvalidSessionIndex);
+        std::vector<std::uint64_t> completed_observed_child_end(scopes.size(), 0);
+        std::vector<std::uint64_t> active_timing_stack_position(scopes.size(), kInvalidSessionIndex);
+        missing_parent_keys.reserve(scopes.size());
+        missing_parent_evidence.reserve(scopes.size());
+        missing_frame_ids.reserve(scopes.size());
+
+        for (std::size_t index = 1; index < scopes.size(); ++index) {
+            const GpuScopeRecord& previous = scopes[index - 1];
+            const GpuScopeRecord& scope    = scopes[index];
+            const bool            same_source =
+                previous.logical_queue == scope.logical_queue &&
+                previous.native_queue_id == scope.native_queue_id && previous.family_id == scope.family_id &&
+                previous.frame_id == scope.frame_id && previous.source_order == scope.source_order;
+            if (same_source && previous.local_order == scope.local_order) {
+                Fail(
+                    SessionLoadStatus::ProtocolViolation,
+                    SessionErrorCode::GpuScopeIdentityInvalid,
+                    "GpuScope local order is duplicated within one recording source"
+                );
+                return false;
+            }
+            if (same_source) {
+                source_local_rank[index] = source_local_rank[index - 1] + 1;
+            }
+        }
+
         for (std::size_t index = 0; index < scopes.size(); ++index) {
             GpuScopeRecord& scope  = scopes[index];
             bool            orphan = false;
@@ -1263,8 +1742,10 @@ struct ProfileSessionReader::Impl {
                     return _frame.frame_id < _frame_id;
                 }
             );
+            bool validate_timing = false;
             if (frame == frames.end() || frame->frame_id != scope.frame_id) {
                 orphan = true;
+                missing_frame_ids.push_back(scope.frame_id);
                 if (!_allow_missing) {
                     Fail(
                         SessionLoadStatus::ProtocolViolation,
@@ -1276,6 +1757,10 @@ struct ProfileSessionReader::Impl {
             } else {
                 const std::size_t frame_index = static_cast<std::size_t>(frame - frames.begin());
                 scope.frame_index             = frame_index;
+                // GpuFrame v1 only proves that producer-side topology was
+                // valid for Complete. Incomplete can also represent a
+                // structurally invalid frame accompanied by RHI drops.
+                validate_timing = frame->status == ProfileGpuFrameStatus::Complete;
                 ++frame->scope_count;
                 if (scope.status == ProfileGpuScopeStatus::Error) {
                     ++frame_error_counts[frame_index];
@@ -1291,6 +1776,16 @@ struct ProfileSessionReader::Impl {
                     );
                     return false;
                 }
+                if (validate_timing) {
+                    if (scope.status != ProfileGpuScopeStatus::Ready) {
+                        Fail(
+                            SessionLoadStatus::ProtocolViolation,
+                            SessionErrorCode::GpuScopeTimingInvalid,
+                            "non-invalid GpuFrame contains a non-ready root scope"
+                        );
+                        return false;
+                    }
+                }
             } else {
                 if (scope.depth == 0) {
                     Fail(
@@ -1303,6 +1798,22 @@ struct ProfileSessionReader::Impl {
                 const std::uint64_t parent_index = find_scope(scope.frame_id, scope.parent_scope_id);
                 if (parent_index == kInvalidSessionIndex) {
                     orphan = true;
+                    missing_parent_keys.push_back({
+                        .frame_id    = scope.frame_id,
+                        .scope_id    = scope.parent_scope_id,
+                        .scope_index = 0,
+                    });
+                    missing_parent_evidence.push_back({
+                        .frame_id          = scope.frame_id,
+                        .parent_scope_id   = scope.parent_scope_id,
+                        .logical_queue     = scope.logical_queue,
+                        .native_queue_id   = scope.native_queue_id,
+                        .family_id         = scope.family_id,
+                        .source_order      = scope.source_order,
+                        .parent_depth      = scope.depth - 1,
+                        .child_local_order = scope.local_order,
+                        .child_index       = index,
+                    });
                     if (!_allow_missing) {
                         Fail(
                             SessionLoadStatus::ProtocolViolation,
@@ -1325,6 +1836,41 @@ struct ProfileSessionReader::Impl {
                         return false;
                     }
                     scope.parent_index = parent_index;
+                    if (validate_timing) {
+                        if (parent.status != ProfileGpuScopeStatus::Ready ||
+                            scope.status != ProfileGpuScopeStatus::Ready ||
+                            parent.valid_bits != scope.valid_bits ||
+                            !NearlyEqualDuration(parent.tick_period_ns, scope.tick_period_ns)) {
+                            Fail(
+                                SessionLoadStatus::ProtocolViolation,
+                                SessionErrorCode::GpuScopeTimingInvalid,
+                                "non-invalid GpuFrame has incompatible parent/child timing metadata"
+                            );
+                            return false;
+                        }
+
+                        const std::uint64_t parent_delta =
+                            TimestampDelta(parent.begin_tick, parent.end_tick, parent.valid_bits);
+                        const std::uint64_t child_begin_offset =
+                            (scope.begin_tick - parent.begin_tick) & TimestampMask(parent.valid_bits);
+                        const std::uint64_t child_delta =
+                            TimestampDelta(scope.begin_tick, scope.end_tick, scope.valid_bits);
+                        const bool contained = child_begin_offset <= parent_delta &&
+                                               child_delta <= parent_delta - child_begin_offset;
+                        const bool ordered = has_previous_child[parent_index] == 0 ||
+                                             child_begin_offset >= previous_child_end[parent_index];
+                        if (!contained || !ordered) {
+                            Fail(
+                                SessionLoadStatus::ProtocolViolation,
+                                SessionErrorCode::GpuScopeTimingInvalid,
+                                "GpuScope children are outside their parent or overlap"
+                            );
+                            return false;
+                        }
+                        previous_child_end[parent_index] = child_begin_offset + child_delta;
+                        has_previous_child[parent_index] = 1;
+                        direct_child_duration[parent_index] += scope.total_duration_ns;
+                    }
                 }
             }
             if (orphan) {
@@ -1332,28 +1878,2327 @@ struct ProfileSessionReader::Impl {
             }
         }
 
-        for (std::size_t index = 0; index < frames.size(); ++index) {
-            const GpuFrameRecord& frame             = frames[index];
-            const bool            observed_too_many = frame.scope_count > frame.admitted_scope_count ||
-                                           frame_error_counts[index] > frame.error_scope_count;
-            const bool intact_frame_mismatch = !_allow_missing &&
-                                               frame.status != ProfileGpuFrameStatus::Invalid &&
-                                               (frame.scope_count != frame.admitted_scope_count ||
-                                                frame_error_counts[index] != frame.error_scope_count);
-            if (observed_too_many || intact_frame_mismatch) {
+        std::sort(
+            missing_parent_evidence.begin(),
+            missing_parent_evidence.end(),
+            [](const MissingParentEvidence& _left, const MissingParentEvidence& _right) {
+                if (_left.frame_id != _right.frame_id) {
+                    return _left.frame_id < _right.frame_id;
+                }
+                if (_left.parent_scope_id != _right.parent_scope_id) {
+                    return _left.parent_scope_id < _right.parent_scope_id;
+                }
+                return _left.child_local_order < _right.child_local_order;
+            }
+        );
+        struct TimingContractEnvelope {
+            std::uint32_t parent_depth{0};
+            std::uint64_t begin_tick{0};
+            std::uint64_t duration{0};
+            bool          trusted{false};
+        };
+        std::vector<TimingContractEnvelope> timing_contract_envelopes;
+        std::vector<std::uint64_t>          timing_contract_for_child(scopes.size(), kInvalidSessionIndex);
+        timing_contract_envelopes.reserve(missing_parent_evidence.size());
+        std::size_t timing_evidence_begin = 0;
+        while (timing_evidence_begin < missing_parent_evidence.size()) {
+            std::size_t timing_evidence_end = timing_evidence_begin + 1;
+            while (timing_evidence_end < missing_parent_evidence.size() &&
+                   missing_parent_evidence[timing_evidence_end].frame_id ==
+                       missing_parent_evidence[timing_evidence_begin].frame_id &&
+                   missing_parent_evidence[timing_evidence_end].parent_scope_id ==
+                       missing_parent_evidence[timing_evidence_begin].parent_scope_id) {
+                ++timing_evidence_end;
+            }
+
+            const MissingParentEvidence& first_evidence = missing_parent_evidence[timing_evidence_begin];
+            const GpuScopeRecord& first_child = scopes[static_cast<std::size_t>(first_evidence.child_index)];
+            const auto            frame       = std::lower_bound(
+                frames.begin(),
+                frames.end(),
+                first_evidence.frame_id,
+                [](const GpuFrameRecord& _frame, std::uint64_t _frame_id) {
+                    return _frame.frame_id < _frame_id;
+                }
+            );
+            const bool trusted = frame != frames.end() && frame->frame_id == first_evidence.frame_id &&
+                                 frame->status == ProfileGpuFrameStatus::Complete;
+            std::uint64_t envelope_end_offset = 0;
+            for (std::size_t index = timing_evidence_begin; index < timing_evidence_end; ++index) {
+                const MissingParentEvidence& evidence = missing_parent_evidence[index];
+                const GpuScopeRecord&        child = scopes[static_cast<std::size_t>(evidence.child_index)];
+                if (evidence.logical_queue != first_evidence.logical_queue ||
+                    evidence.native_queue_id != first_evidence.native_queue_id ||
+                    evidence.family_id != first_evidence.family_id ||
+                    evidence.source_order != first_evidence.source_order ||
+                    evidence.parent_depth != first_evidence.parent_depth) {
+                    Fail(
+                        SessionLoadStatus::ProtocolViolation,
+                        SessionErrorCode::GpuScopeParentInvalid,
+                        "children disagree on the contract of one missing GpuScope parent"
+                    );
+                    return false;
+                }
+                if (trusted) {
+                    if (child.status != ProfileGpuScopeStatus::Ready ||
+                        child.valid_bits != first_child.valid_bits ||
+                        !NearlyEqualDuration(child.tick_period_ns, first_child.tick_period_ns)) {
+                        Fail(
+                            SessionLoadStatus::ProtocolViolation,
+                            SessionErrorCode::GpuScopeTimingInvalid,
+                            "children of one missing GPU parent disagree on timestamp metadata"
+                        );
+                        return false;
+                    }
+                    const std::uint64_t child_begin_offset =
+                        (child.begin_tick - first_child.begin_tick) & TimestampMask(first_child.valid_bits);
+                    const std::uint64_t child_duration =
+                        TimestampDelta(child.begin_tick, child.end_tick, child.valid_bits);
+                    const std::uint64_t timestamp_mask = TimestampMask(first_child.valid_bits);
+                    if (child_begin_offset < envelope_end_offset ||
+                        child_duration > timestamp_mask - child_begin_offset) {
+                        Fail(
+                            SessionLoadStatus::ProtocolViolation,
+                            SessionErrorCode::GpuScopeTimingInvalid,
+                            "children of one missing parent do not form one ordered timestamp envelope"
+                        );
+                        return false;
+                    }
+                    envelope_end_offset = child_begin_offset + child_duration;
+                }
+            }
+
+            const std::uint64_t contract_index = static_cast<std::uint64_t>(timing_contract_envelopes.size());
+            timing_contract_envelopes.push_back({
+                .parent_depth = first_evidence.parent_depth,
+                .begin_tick   = first_child.begin_tick,
+                .duration     = envelope_end_offset,
+                .trusted      = trusted,
+            });
+            for (std::size_t index = timing_evidence_begin; index < timing_evidence_end; ++index) {
+                timing_contract_for_child[static_cast<std::size_t>(missing_parent_evidence[index].child_index
+                )] = contract_index;
+            }
+            timing_evidence_begin = timing_evidence_end;
+        }
+
+        std::size_t timing_source_begin = 0;
+        while (timing_source_begin < scopes.size()) {
+            std::size_t timing_source_end = timing_source_begin + 1;
+            while (timing_source_end < scopes.size()) {
+                const GpuScopeRecord& first = scopes[timing_source_begin];
+                const GpuScopeRecord& next  = scopes[timing_source_end];
+                if (first.logical_queue != next.logical_queue ||
+                    first.native_queue_id != next.native_queue_id || first.family_id != next.family_id ||
+                    first.frame_id != next.frame_id || first.source_order != next.source_order) {
+                    break;
+                }
+                ++timing_source_end;
+            }
+
+            const GpuScopeRecord& first_scope = scopes[timing_source_begin];
+            const bool            timing_topology_trusted =
+                first_scope.frame_index != kInvalidSessionIndex &&
+                frames[first_scope.frame_index].status == ProfileGpuFrameStatus::Complete;
+            if (timing_topology_trusted) {
+                std::vector<std::uint64_t> timing_stack;
+                timing_stack.reserve(std::min<std::size_t>(
+                    timing_source_end - timing_source_begin,
+                    static_cast<std::size_t>(options.limits.max_scope_depth) + 1
+                ));
+                const auto close_observed_subtrees = [&](std::size_t _keep_count) {
+                    while (timing_stack.size() > _keep_count) {
+                        const std::size_t child_index = static_cast<std::size_t>(timing_stack.back());
+                        timing_stack.pop_back();
+                        active_timing_stack_position[child_index] = kInvalidSessionIndex;
+                        if (timing_stack.empty()) {
+                            continue;
+                        }
+                        const std::size_t     parent_index = static_cast<std::size_t>(timing_stack.back());
+                        const GpuScopeRecord& parent       = scopes[parent_index];
+                        const GpuScopeRecord& child        = scopes[child_index];
+                        const std::uint64_t   child_begin_offset =
+                            (child.begin_tick - parent.begin_tick) & TimestampMask(parent.valid_bits);
+                        const std::uint64_t child_duration =
+                            TimestampDelta(child.begin_tick, child.end_tick, child.valid_bits);
+                        completed_observed_child_end[parent_index] = std::max(
+                            completed_observed_child_end[parent_index], child_begin_offset + child_duration
+                        );
+                    }
+                };
+                for (std::size_t index = timing_source_begin; index < timing_source_end; ++index) {
+                    const GpuScopeRecord& scope = scopes[index];
+                    if (scope.status != ProfileGpuScopeStatus::Ready) {
+                        Fail(
+                            SessionLoadStatus::ProtocolViolation,
+                            SessionErrorCode::GpuScopeTimingInvalid,
+                            "Complete GpuFrame contains a non-ready scope"
+                        );
+                        return false;
+                    }
+                    if (first_scope.valid_bits != scope.valid_bits ||
+                        !NearlyEqualDuration(first_scope.tick_period_ns, scope.tick_period_ns)) {
+                        Fail(
+                            SessionLoadStatus::ProtocolViolation,
+                            SessionErrorCode::GpuScopeTimingInvalid,
+                            "Complete GPU source changes timestamp metadata"
+                        );
+                        return false;
+                    }
+
+                    std::size_t container_position = timing_stack.size();
+                    if (scope.parent_index != kInvalidSessionIndex) {
+                        const std::uint64_t active_position =
+                            active_timing_stack_position[scope.parent_index];
+                        if (active_position == kInvalidSessionIndex ||
+                            active_position >= timing_stack.size() ||
+                            timing_stack[static_cast<std::size_t>(active_position)] != scope.parent_index) {
+                            Fail(
+                                SessionLoadStatus::ProtocolViolation,
+                                SessionErrorCode::GpuScopeParentInvalid,
+                                "observed GPU parent was already closed by a later subtree"
+                            );
+                            return false;
+                        }
+                        container_position = static_cast<std::size_t>(active_position);
+                    } else if (scope.parent_scope_id != 0) {
+                        const std::uint64_t timing_contract_index = timing_contract_for_child[index];
+                        const TimingContractEnvelope* timing_contract =
+                            timing_contract_index == kInvalidSessionIndex ?
+                                nullptr :
+                                &timing_contract_envelopes[static_cast<std::size_t>(timing_contract_index)];
+                        const std::uint32_t required_parent_depth =
+                            timing_contract != nullptr ? timing_contract->parent_depth : scope.depth - 1;
+                        const std::uint64_t required_begin_tick =
+                            timing_contract != nullptr && timing_contract->trusted ?
+                                timing_contract->begin_tick :
+                                scope.begin_tick;
+                        const std::uint64_t required_duration =
+                            timing_contract != nullptr && timing_contract->trusted ?
+                                timing_contract->duration :
+                                TimestampDelta(scope.begin_tick, scope.end_tick, scope.valid_bits);
+                        for (std::size_t position = timing_stack.size(); position != 0; --position) {
+                            if (!charge_topology_work(1)) {
+                                return false;
+                            }
+                            const GpuScopeRecord& candidate = scopes[timing_stack[position - 1]];
+                            if (candidate.depth >= required_parent_depth) {
+                                continue;
+                            }
+                            const std::uint64_t candidate_duration = TimestampDelta(
+                                candidate.begin_tick, candidate.end_tick, candidate.valid_bits
+                            );
+                            const std::uint64_t required_begin_offset =
+                                (required_begin_tick - candidate.begin_tick) &
+                                TimestampMask(candidate.valid_bits);
+                            if (required_begin_offset <= candidate_duration &&
+                                required_duration <= candidate_duration - required_begin_offset) {
+                                container_position = position - 1;
+                                break;
+                            }
+                        }
+                    }
+
+                    if (container_position != timing_stack.size()) {
+                        close_observed_subtrees(container_position + 1);
+                        const std::size_t     container_index = static_cast<std::size_t>(timing_stack.back());
+                        const GpuScopeRecord& container       = scopes[container_index];
+                        const std::uint64_t   scope_begin_offset =
+                            (scope.begin_tick - container.begin_tick) & TimestampMask(container.valid_bits);
+                        const std::uint64_t scope_duration =
+                            TimestampDelta(scope.begin_tick, scope.end_tick, scope.valid_bits);
+                        const std::uint64_t container_duration =
+                            TimestampDelta(container.begin_tick, container.end_tick, container.valid_bits);
+                        if (scope_begin_offset > container_duration ||
+                            scope_duration > container_duration - scope_begin_offset ||
+                            scope_begin_offset < completed_observed_child_end[container_index]) {
+                            Fail(
+                                SessionLoadStatus::ProtocolViolation,
+                                SessionErrorCode::GpuScopeTimingInvalid,
+                                "Complete GPU source has crossing observed subtrees"
+                            );
+                            return false;
+                        }
+                        nearest_observed_timing_ancestor[index] = container_index;
+                    } else {
+                        if (scope.parent_index != kInvalidSessionIndex) {
+                            Fail(
+                                SessionLoadStatus::ProtocolViolation,
+                                SessionErrorCode::GpuScopeTimingInvalid,
+                                "observed GPU parent does not contain its child"
+                            );
+                            return false;
+                        }
+                        if (scope.parent_scope_id == 0 && !timing_stack.empty()) {
+                            const GpuScopeRecord& previous_root = scopes[timing_stack.front()];
+                            if (previous_root.parent_scope_id == 0) {
+                                const std::uint64_t previous_duration = TimestampDelta(
+                                    previous_root.begin_tick, previous_root.end_tick, previous_root.valid_bits
+                                );
+                                const std::uint64_t begin_offset =
+                                    (scope.begin_tick - previous_root.begin_tick) &
+                                    TimestampMask(scope.valid_bits);
+                                const std::uint64_t missing_local_orders =
+                                    index == timing_source_begin ?
+                                        0 :
+                                        scope.local_order - scopes[index - 1].local_order - 1;
+                                if (!CanBridgeSerialTimestampGap(
+                                        previous_duration,
+                                        begin_offset,
+                                        scope.valid_bits,
+                                        missing_local_orders
+                                    )) {
+                                    Fail(
+                                        SessionLoadStatus::ProtocolViolation,
+                                        SessionErrorCode::GpuScopeTimingInvalid,
+                                        "Complete GPU roots overlap or move backward"
+                                    );
+                                    return false;
+                                }
+                            }
+                        }
+                        close_observed_subtrees(0);
+                    }
+
+                    const std::uint64_t timing_parent = nearest_observed_timing_ancestor[index];
+                    if (scope.parent_index != kInvalidSessionIndex && timing_parent != scope.parent_index) {
+                        Fail(
+                            SessionLoadStatus::ProtocolViolation,
+                            SessionErrorCode::GpuScopeTimingInvalid,
+                            "observed GPU parent does not match the timing hierarchy"
+                        );
+                        return false;
+                    }
+                    if (scope.parent_scope_id == 0 && timing_parent != kInvalidSessionIndex) {
+                        Fail(
+                            SessionLoadStatus::ProtocolViolation,
+                            SessionErrorCode::GpuScopeTimingInvalid,
+                            "GPU root is nested inside an observed interval"
+                        );
+                        return false;
+                    }
+                    if (scope.parent_scope_id != 0 && scope.parent_index == kInvalidSessionIndex &&
+                        timing_parent != kInvalidSessionIndex &&
+                        scopes[timing_parent].depth >= scope.depth - 1) {
+                        Fail(
+                            SessionLoadStatus::ProtocolViolation,
+                            SessionErrorCode::GpuScopeParentInvalid,
+                            "missing GPU parent conflicts with an observed timing ancestor"
+                        );
+                        return false;
+                    }
+                    timing_stack.push_back(index);
+                    active_timing_stack_position[index] = timing_stack.size() - 1;
+                }
+                close_observed_subtrees(0);
+            }
+            timing_source_begin = timing_source_end;
+        }
+        std::vector<std::uint64_t> timing_subtree_end_local(scopes.size(), 0);
+        for (std::size_t index = 0; index < scopes.size(); ++index) {
+            timing_subtree_end_local[index] = scopes[index].local_order;
+        }
+        for (std::size_t index = scopes.size(); index != 0; --index) {
+            const std::size_t   scope_index  = index - 1;
+            const std::uint64_t parent_index = nearest_observed_timing_ancestor[scope_index];
+            if (parent_index != kInvalidSessionIndex) {
+                timing_subtree_end_local[parent_index] =
+                    std::max(timing_subtree_end_local[parent_index], timing_subtree_end_local[scope_index]);
+            }
+        }
+        std::size_t depth_range_leaf_count = 1;
+        while (depth_range_leaf_count < scopes.size()) {
+            depth_range_leaf_count *= 2;
+        }
+        std::vector<std::uint32_t> depth_range_tree(
+            depth_range_leaf_count * 2, std::numeric_limits<std::uint32_t>::max()
+        );
+        for (std::size_t index = 0; index < scopes.size(); ++index) {
+            depth_range_tree[depth_range_leaf_count + index] = scopes[index].depth;
+        }
+        for (std::size_t index = depth_range_leaf_count; index != 1; --index) {
+            const std::size_t parent = index - 1;
+            depth_range_tree[parent] =
+                std::min(depth_range_tree[parent * 2], depth_range_tree[parent * 2 + 1]);
+        }
+        const auto minimum_depth_in_range = [&](std::size_t _begin, std::size_t _end) {
+            std::uint32_t minimum = std::numeric_limits<std::uint32_t>::max();
+            std::size_t   begin   = depth_range_leaf_count + _begin;
+            std::size_t   end     = depth_range_leaf_count + _end;
+            while (begin < end) {
+                if ((begin & 1) != 0) {
+                    minimum = std::min(minimum, depth_range_tree[begin++]);
+                }
+                if ((end & 1) != 0) {
+                    minimum = std::min(minimum, depth_range_tree[--end]);
+                }
+                begin /= 2;
+                end /= 2;
+            }
+            return minimum;
+        };
+
+        std::sort(
+            missing_parent_evidence.begin(),
+            missing_parent_evidence.end(),
+            [](const MissingParentEvidence& _left, const MissingParentEvidence& _right) {
+                if (_left.frame_id != _right.frame_id) {
+                    return _left.frame_id < _right.frame_id;
+                }
+                if (_left.parent_scope_id != _right.parent_scope_id) {
+                    return _left.parent_scope_id < _right.parent_scope_id;
+                }
+                return _left.child_local_order < _right.child_local_order;
+            }
+        );
+        struct MissingParentContract {
+            std::uint64_t       frame_id{0};
+            ProfileLogicalQueue logical_queue{ProfileLogicalQueue::Graphics};
+            std::uint32_t       native_queue_id{0};
+            std::uint32_t       family_id{0};
+            std::uint64_t       source_order{0};
+            std::uint32_t       parent_depth{0};
+            std::uint64_t       child_local_order_deadline{0};
+            std::uint64_t       latest_parent_local_order{0};
+            std::uint64_t       observed_local_orders_before_deadline{0};
+            bool                timing_topology_trusted{false};
+            std::uint64_t       observed_ancestor_index{kInvalidSessionIndex};
+            std::uint64_t       last_child_subtree_end_local{0};
+            std::uint64_t       timing_envelope_begin_tick{0};
+            std::uint64_t       timing_envelope_duration{0};
+        };
+        std::vector<MissingParentContract> missing_parent_contracts;
+        missing_parent_contracts.reserve(missing_parent_evidence.size());
+
+        std::size_t evidence_begin = 0;
+        while (evidence_begin < missing_parent_evidence.size()) {
+            std::size_t evidence_end = evidence_begin + 1;
+            while (evidence_end < missing_parent_evidence.size() &&
+                   missing_parent_evidence[evidence_end].frame_id ==
+                       missing_parent_evidence[evidence_begin].frame_id &&
+                   missing_parent_evidence[evidence_end].parent_scope_id ==
+                       missing_parent_evidence[evidence_begin].parent_scope_id) {
+                ++evidence_end;
+            }
+
+            const MissingParentEvidence& contract = missing_parent_evidence[evidence_begin];
+            std::uint64_t                last_child_subtree_end_local =
+                timing_subtree_end_local[static_cast<std::size_t>(contract.child_index)];
+            for (std::size_t index = evidence_begin + 1; index < evidence_end; ++index) {
+                const MissingParentEvidence& evidence = missing_parent_evidence[index];
+                if (evidence.logical_queue != contract.logical_queue ||
+                    evidence.native_queue_id != contract.native_queue_id ||
+                    evidence.family_id != contract.family_id ||
+                    evidence.source_order != contract.source_order ||
+                    evidence.parent_depth != contract.parent_depth) {
+                    Fail(
+                        SessionLoadStatus::ProtocolViolation,
+                        SessionErrorCode::GpuScopeParentInvalid,
+                        "children disagree on the contract of one missing GpuScope parent"
+                    );
+                    return false;
+                }
+                last_child_subtree_end_local = std::max(
+                    last_child_subtree_end_local,
+                    timing_subtree_end_local[static_cast<std::size_t>(evidence.child_index)]
+                );
+            }
+
+            const std::size_t   first_child_index = static_cast<std::size_t>(contract.child_index);
+            const std::uint64_t observed_before   = source_local_rank[first_child_index];
+            if (contract.child_local_order == 0 || contract.child_local_order <= observed_before) {
                 Fail(
                     SessionLoadStatus::ProtocolViolation,
-                    SessionErrorCode::GpuFrameTotalsMismatch,
-                    "GpuFrame scope totals do not match its records"
+                    SessionErrorCode::GpuScopeParentInvalid,
+                    "a missing GpuScope parent has no earlier local-order slot"
                 );
                 return false;
             }
+            std::uint64_t latest_parent_local_order = contract.child_local_order - 1;
+            if (observed_before != 0) {
+                const std::size_t last_observed_index = first_child_index - 1;
+                if (scopes[last_observed_index].local_order == latest_parent_local_order) {
+                    const std::size_t source_begin_index =
+                        first_child_index - static_cast<std::size_t>(observed_before);
+                    const std::uint64_t contiguous_run_key =
+                        scopes[last_observed_index].local_order - (observed_before - 1);
+                    std::size_t low  = source_begin_index;
+                    std::size_t high = first_child_index;
+                    while (low < high) {
+                        const std::size_t   mid = low + (high - low) / 2;
+                        const std::uint64_t order_without_rank =
+                            scopes[mid].local_order - static_cast<std::uint64_t>(mid - source_begin_index);
+                        if (order_without_rank < contiguous_run_key) {
+                            low = mid + 1;
+                        } else {
+                            high = mid;
+                        }
+                    }
+                    if (low == first_child_index || scopes[low].local_order == 0) {
+                        Fail(
+                            SessionLoadStatus::ProtocolViolation,
+                            SessionErrorCode::GpuScopeParentInvalid,
+                            "a missing GpuScope parent has no unobserved local-order slot"
+                        );
+                        return false;
+                    }
+                    latest_parent_local_order = scopes[low].local_order - 1;
+                }
+            }
+
+            const auto frame = std::lower_bound(
+                frames.begin(),
+                frames.end(),
+                contract.frame_id,
+                [](const GpuFrameRecord& _frame, std::uint64_t _frame_id) {
+                    return _frame.frame_id < _frame_id;
+                }
+            );
+            const bool timing_topology_trusted = frame != frames.end() &&
+                                                 frame->frame_id == contract.frame_id &&
+                                                 frame->status == ProfileGpuFrameStatus::Complete;
+            std::uint64_t       observed_ancestor_index = kInvalidSessionIndex;
+            const std::uint64_t timing_contract_index   = timing_contract_for_child[first_child_index];
+            const TimingContractEnvelope* timing_contract =
+                timing_contract_index == kInvalidSessionIndex ?
+                    nullptr :
+                    &timing_contract_envelopes[static_cast<std::size_t>(timing_contract_index)];
+            std::uint64_t envelope_begin_tick = timing_contract != nullptr ?
+                                                    timing_contract->begin_tick :
+                                                    scopes[first_child_index].begin_tick;
+            std::uint64_t envelope_end_offset = timing_contract != nullptr ?
+                                                    timing_contract->duration :
+                                                    TimestampDelta(
+                                                        scopes[first_child_index].begin_tick,
+                                                        scopes[first_child_index].end_tick,
+                                                        scopes[first_child_index].valid_bits
+                                                    );
+            if (timing_topology_trusted) {
+                const GpuScopeRecord& first_child =
+                    scopes[missing_parent_evidence[evidence_begin].child_index];
+                envelope_end_offset = 0;
+                for (std::size_t index = evidence_begin; index < evidence_end; ++index) {
+                    const GpuScopeRecord& child = scopes[missing_parent_evidence[index].child_index];
+                    if (child.status != ProfileGpuScopeStatus::Ready) {
+                        Fail(
+                            SessionLoadStatus::ProtocolViolation,
+                            SessionErrorCode::GpuScopeTimingInvalid,
+                            "Complete GpuFrame has a non-ready child of a missing parent"
+                        );
+                        return false;
+                    }
+                    if (first_child.valid_bits != child.valid_bits ||
+                        !NearlyEqualDuration(first_child.tick_period_ns, child.tick_period_ns)) {
+                        Fail(
+                            SessionLoadStatus::ProtocolViolation,
+                            SessionErrorCode::GpuScopeTimingInvalid,
+                            "children of one missing parent disagree on timestamp metadata"
+                        );
+                        return false;
+                    }
+                    const std::uint64_t child_begin_offset =
+                        (child.begin_tick - envelope_begin_tick) & TimestampMask(child.valid_bits);
+                    const std::uint64_t child_duration =
+                        TimestampDelta(child.begin_tick, child.end_tick, child.valid_bits);
+                    const std::uint64_t timestamp_mask = TimestampMask(child.valid_bits);
+                    if (child_begin_offset < envelope_end_offset ||
+                        child_duration > timestamp_mask - child_begin_offset) {
+                        Fail(
+                            SessionLoadStatus::ProtocolViolation,
+                            SessionErrorCode::GpuScopeTimingInvalid,
+                            "children of one missing parent do not form one ordered timestamp envelope"
+                        );
+                        return false;
+                    }
+                    envelope_end_offset = child_begin_offset + child_duration;
+                    const std::uint64_t child_observed_ancestor =
+                        nearest_observed_timing_ancestor[missing_parent_evidence[index].child_index];
+                    if (index == evidence_begin) {
+                        observed_ancestor_index = child_observed_ancestor;
+                    } else if (child_observed_ancestor != observed_ancestor_index) {
+                        Fail(
+                            SessionLoadStatus::ProtocolViolation,
+                            SessionErrorCode::GpuScopeParentInvalid,
+                            "children of one missing GPU parent disagree on their observed timing ancestor"
+                        );
+                        return false;
+                    }
+                }
+                if (observed_ancestor_index != kInvalidSessionIndex &&
+                    scopes[observed_ancestor_index].local_order >= latest_parent_local_order) {
+                    Fail(
+                        SessionLoadStatus::ProtocolViolation,
+                        SessionErrorCode::GpuScopeParentInvalid,
+                        "a missing GPU parent has no slot after its observed timing ancestor"
+                    );
+                    return false;
+                }
+                if (observed_ancestor_index != kInvalidSessionIndex) {
+                    const GpuScopeRecord& ancestor = scopes[observed_ancestor_index];
+                    const std::uint64_t   ancestor_duration =
+                        TimestampDelta(ancestor.begin_tick, ancestor.end_tick, ancestor.valid_bits);
+                    const std::uint64_t envelope_begin_offset =
+                        (envelope_begin_tick - ancestor.begin_tick) & TimestampMask(ancestor.valid_bits);
+                    if (envelope_begin_offset > ancestor_duration ||
+                        envelope_end_offset > ancestor_duration - envelope_begin_offset) {
+                        Fail(
+                            SessionLoadStatus::ProtocolViolation,
+                            SessionErrorCode::GpuScopeTimingInvalid,
+                            "observed GPU ancestor does not contain the missing-parent child envelope"
+                        );
+                        return false;
+                    }
+                }
+                const std::size_t last_child_index =
+                    static_cast<std::size_t>(missing_parent_evidence[evidence_end - 1].child_index);
+                if (minimum_depth_in_range(first_child_index, last_child_index + 1) <=
+                    contract.parent_depth) {
+                    Fail(
+                        SessionLoadStatus::ProtocolViolation,
+                        SessionErrorCode::GpuScopeParentInvalid,
+                        "children of one missing GPU parent cross an observed hierarchy barrier"
+                    );
+                    return false;
+                }
+            }
+
+            missing_parent_contracts.push_back({
+                .frame_id                              = contract.frame_id,
+                .logical_queue                         = contract.logical_queue,
+                .native_queue_id                       = contract.native_queue_id,
+                .family_id                             = contract.family_id,
+                .source_order                          = contract.source_order,
+                .parent_depth                          = contract.parent_depth,
+                .child_local_order_deadline            = contract.child_local_order,
+                .latest_parent_local_order             = latest_parent_local_order,
+                .observed_local_orders_before_deadline = observed_before,
+                .timing_topology_trusted               = timing_topology_trusted,
+                .observed_ancestor_index               = observed_ancestor_index,
+                .last_child_subtree_end_local          = last_child_subtree_end_local,
+                .timing_envelope_begin_tick            = envelope_begin_tick,
+                .timing_envelope_duration              = envelope_end_offset,
+            });
+            evidence_begin = evidence_end;
+        }
+
+        std::sort(
+            missing_parent_contracts.begin(),
+            missing_parent_contracts.end(),
+            [](const MissingParentContract& _left, const MissingParentContract& _right) {
+                if (_left.logical_queue != _right.logical_queue) {
+                    return _left.logical_queue < _right.logical_queue;
+                }
+                if (_left.native_queue_id != _right.native_queue_id) {
+                    return _left.native_queue_id < _right.native_queue_id;
+                }
+                if (_left.family_id != _right.family_id) {
+                    return _left.family_id < _right.family_id;
+                }
+                if (_left.frame_id != _right.frame_id) {
+                    return _left.frame_id < _right.frame_id;
+                }
+                if (_left.source_order != _right.source_order) {
+                    return _left.source_order < _right.source_order;
+                }
+                return _left.child_local_order_deadline < _right.child_local_order_deadline;
+            }
+        );
+
+        struct SourceLossEvidence {
+            std::uint64_t       frame_id{0};
+            ProfileLogicalQueue logical_queue{ProfileLogicalQueue::Graphics};
+            std::uint32_t       native_queue_id{0};
+            std::uint32_t       family_id{0};
+            std::uint64_t       source_order{0};
+            std::uint64_t       first_scope{0};
+            std::uint64_t       scope_count{0};
+            std::uint64_t       local_hole_count{0};
+            std::uint64_t       required_parent_record_count{0};
+        };
+        std::vector<SourceLossEvidence> source_loss_evidence;
+        source_loss_evidence.reserve(scopes.size());
+        std::size_t source_begin = 0;
+        while (source_begin < scopes.size()) {
+            std::size_t source_end = source_begin + 1;
+            while (source_end < scopes.size()) {
+                const GpuScopeRecord& first = scopes[source_begin];
+                const GpuScopeRecord& next  = scopes[source_end];
+                if (first.logical_queue != next.logical_queue ||
+                    first.native_queue_id != next.native_queue_id || first.family_id != next.family_id ||
+                    first.frame_id != next.frame_id || first.source_order != next.source_order) {
+                    break;
+                }
+                ++source_end;
+            }
+
+            for (std::size_t index = source_begin; index < source_end; ++index) {
+                if (scopes[index].depth > scopes[index].local_order) {
+                    Fail(
+                        SessionLoadStatus::ProtocolViolation,
+                        SessionErrorCode::GpuScopeParentInvalid,
+                        "GpuScope depth cannot be reached by its source local order"
+                    );
+                    return false;
+                }
+            }
+
+            std::uint64_t local_span = 0;
+            if (AddOverflow(scopes[source_end - 1].local_order, std::uint64_t{1}, local_span)) {
+                Fail(
+                    SessionLoadStatus::ProtocolViolation,
+                    SessionErrorCode::GpuScopeIdentityInvalid,
+                    "GpuScope source local-order span overflows"
+                );
+                return false;
+            }
+            const std::uint64_t observed_count = static_cast<std::uint64_t>(source_end - source_begin);
+            source_loss_evidence.push_back({
+                .frame_id                     = scopes[source_begin].frame_id,
+                .logical_queue                = scopes[source_begin].logical_queue,
+                .native_queue_id              = scopes[source_begin].native_queue_id,
+                .family_id                    = scopes[source_begin].family_id,
+                .source_order                 = scopes[source_begin].source_order,
+                .first_scope                  = source_begin,
+                .scope_count                  = observed_count,
+                .local_hole_count             = local_span - observed_count,
+                .required_parent_record_count = 0,
+            });
+            source_begin = source_end;
+        }
+
+        const auto same_contract_source = [](const MissingParentContract& _contract,
+                                             const SourceLossEvidence&    _source) {
+            return _contract.logical_queue == _source.logical_queue &&
+                   _contract.native_queue_id == _source.native_queue_id &&
+                   _contract.family_id == _source.family_id && _contract.frame_id == _source.frame_id &&
+                   _contract.source_order == _source.source_order;
+        };
+        const auto source_less_than_contract = [](const SourceLossEvidence&    _source,
+                                                  const MissingParentContract& _contract) {
+            return std::tie(
+                       _source.logical_queue,
+                       _source.native_queue_id,
+                       _source.family_id,
+                       _source.frame_id,
+                       _source.source_order
+                   ) <
+                   std::tie(
+                       _contract.logical_queue,
+                       _contract.native_queue_id,
+                       _contract.family_id,
+                       _contract.frame_id,
+                       _contract.source_order
+                   );
+        };
+
+        std::size_t contract_begin = 0;
+        while (contract_begin < missing_parent_contracts.size()) {
+            std::size_t contract_end = contract_begin + 1;
+            while (contract_end < missing_parent_contracts.size()) {
+                const MissingParentContract& first = missing_parent_contracts[contract_begin];
+                const MissingParentContract& next  = missing_parent_contracts[contract_end];
+                if (first.logical_queue != next.logical_queue ||
+                    first.native_queue_id != next.native_queue_id || first.family_id != next.family_id ||
+                    first.frame_id != next.frame_id || first.source_order != next.source_order) {
+                    break;
+                }
+                ++contract_end;
+            }
+
+            SourceLossEvidence* source    = nullptr;
+            const auto          source_it = std::lower_bound(
+                source_loss_evidence.begin(),
+                source_loss_evidence.end(),
+                missing_parent_contracts[contract_begin],
+                source_less_than_contract
+            );
+            if (source_it != source_loss_evidence.end() &&
+                same_contract_source(missing_parent_contracts[contract_begin], *source_it)) {
+                source = &*source_it;
+            }
+            if (source == nullptr) {
+                Fail(
+                    SessionLoadStatus::ProtocolViolation,
+                    SessionErrorCode::GpuScopeParentInvalid,
+                    "missing GpuScope parent has no recording source"
+                );
+                return false;
+            }
+
+            std::vector<std::uint32_t> depth_coordinates;
+            depth_coordinates.reserve(
+                static_cast<std::size_t>(source->scope_count) + contract_end - contract_begin
+            );
+            const std::size_t source_end_index =
+                static_cast<std::size_t>(source->first_scope + source->scope_count);
+            std::uint64_t last_observed_root_local_order = 0;
+            bool          has_observed_root              = false;
+            for (std::size_t index = static_cast<std::size_t>(source->first_scope); index < source_end_index;
+                 ++index) {
+                depth_coordinates.push_back(scopes[index].depth);
+                if (scopes[index].parent_scope_id == 0) {
+                    last_observed_root_local_order = scopes[index].local_order;
+                    has_observed_root              = true;
+                }
+            }
+            for (std::size_t index = contract_begin; index < contract_end; ++index) {
+                depth_coordinates.push_back(missing_parent_contracts[index].parent_depth);
+            }
+            std::sort(depth_coordinates.begin(), depth_coordinates.end());
+            depth_coordinates.erase(
+                std::unique(depth_coordinates.begin(), depth_coordinates.end()), depth_coordinates.end()
+            );
+
+            std::vector<std::uint64_t> covered_depth_tree(depth_coordinates.size() + 1, 0);
+            std::vector<std::uint64_t> prefix_covered_depth_tree(depth_coordinates.size() + 1, 0);
+            std::vector<std::uint8_t>  depth_covered(depth_coordinates.size(), 0);
+            std::vector<std::uint8_t>  prefix_depth_covered(depth_coordinates.size(), 0);
+            const auto                 cover_depth = [&](std::uint32_t               _depth,
+                                         std::vector<std::uint64_t>& _tree,
+                                         std::vector<std::uint8_t>&  _covered) {
+                const std::size_t coordinate = static_cast<std::size_t>(
+                    std::lower_bound(depth_coordinates.begin(), depth_coordinates.end(), _depth) -
+                    depth_coordinates.begin()
+                );
+                if (_covered[coordinate] != 0) {
+                    return;
+                }
+                _covered[coordinate] = 1;
+                for (std::size_t tree_index = coordinate + 1; tree_index < _tree.size();
+                     tree_index += tree_index & (~tree_index + 1)) {
+                    ++_tree[tree_index];
+                }
+            };
+            const auto covered_depth_count_before = [&](std::uint32_t                     _depth,
+                                                        const std::vector<std::uint64_t>& _tree) {
+                std::size_t tree_index = static_cast<std::size_t>(
+                    std::lower_bound(depth_coordinates.begin(), depth_coordinates.end(), _depth) -
+                    depth_coordinates.begin()
+                );
+                std::uint64_t covered_count = 0;
+                while (tree_index != 0) {
+                    covered_count += _tree[tree_index];
+                    tree_index &= tree_index - 1;
+                }
+                return covered_count;
+            };
+
+            for (std::size_t index = contract_begin; index < contract_end; ++index) {
+                cover_depth(missing_parent_contracts[index].parent_depth, covered_depth_tree, depth_covered);
+            }
+            const bool timing_topology_trusted =
+                missing_parent_contracts[contract_begin].timing_topology_trusted;
+            if (timing_topology_trusted) {
+                struct MissingTaskKey {
+                    std::uint64_t anchor_index{kInvalidSessionIndex};
+                    std::uint32_t depth{0};
+                    std::uint64_t first_allowed_slot{0};
+
+                    [[nodiscard]] bool operator<(const MissingTaskKey& _right) const noexcept {
+                        return std::tie(anchor_index, depth, first_allowed_slot) <
+                               std::tie(_right.anchor_index, _right.depth, _right.first_allowed_slot);
+                    }
+                };
+                struct MissingTaskState {
+                    std::uint64_t canonical_task_index{kInvalidSessionIndex};
+                    bool          canonical_is_direct{false};
+                };
+                struct MissingTask {
+                    std::uint64_t first_allowed_slot{0};
+                    std::uint64_t deadline_slot{0};
+                    std::uint64_t assigned_slot{kInvalidSessionIndex};
+                    std::uint32_t depth{0};
+                    bool          has_timing_envelope{false};
+                    std::uint64_t timing_envelope_begin_tick{0};
+                    std::uint64_t timing_envelope_duration{0};
+                    std::uint64_t timing_envelope_member_count{0};
+                    std::uint64_t maximum_member_duration{0};
+                    std::uint64_t first_member_duration{0};
+                    std::uint64_t first_member_subtree_end_local{0};
+                    std::uint64_t timing_subtree_end_local{0};
+                };
+                struct RootPartitionCandidate {
+                    std::uint64_t root_task_index{kInvalidSessionIndex};
+                    std::uint64_t previous_subtree_end_local{0};
+                    std::uint64_t child_local_order_deadline{0};
+                    std::uint64_t member_begin_tick{0};
+                    std::uint64_t member_duration{0};
+                    std::uint64_t member_subtree_end_local{0};
+                    std::size_t   chain_begin{0};
+                    std::size_t   chain_end{0};
+                };
+
+                std::vector<std::uint64_t> latest_barrier_tree(depth_coordinates.size() + 1, 0);
+                const auto                 observe_barrier = [&](std::size_t _scope_index) {
+                    const GpuScopeRecord& scope      = scopes[_scope_index];
+                    const std::size_t     coordinate = static_cast<std::size_t>(
+                        std::lower_bound(depth_coordinates.begin(), depth_coordinates.end(), scope.depth) -
+                        depth_coordinates.begin()
+                    );
+                    const std::uint64_t local_order_after = timing_subtree_end_local[_scope_index] + 1;
+                    for (std::size_t tree_index = coordinate + 1; tree_index < latest_barrier_tree.size();
+                         tree_index += tree_index & (~tree_index + 1)) {
+                        latest_barrier_tree[tree_index] =
+                            std::max(latest_barrier_tree[tree_index], local_order_after);
+                    }
+                };
+                const auto latest_barrier_after = [&](std::uint32_t _depth) {
+                    std::size_t tree_index = static_cast<std::size_t>(
+                        std::upper_bound(depth_coordinates.begin(), depth_coordinates.end(), _depth) -
+                        depth_coordinates.begin()
+                    );
+                    std::uint64_t latest = 0;
+                    while (tree_index != 0) {
+                        latest = std::max(latest, latest_barrier_tree[tree_index]);
+                        tree_index &= tree_index - 1;
+                    }
+                    return latest;
+                };
+
+                std::map<MissingTaskKey, MissingTaskState> task_states;
+                std::vector<MissingTask>                   tasks;
+                std::vector<std::uint64_t>                 chain_task_indices;
+                std::vector<std::uint8_t>                  chain_task_shared_with_prior;
+                std::vector<std::uint64_t>                 chain_ends;
+                std::vector<RootPartitionCandidate>        root_partition_candidates;
+                std::map<std::uint32_t, std::uint64_t>     previous_missing_direct_end;
+                std::map<std::uint32_t, std::uint64_t>     virtual_epoch_floor;
+                std::vector<std::size_t>                   completion_order;
+                completion_order.reserve(static_cast<std::size_t>(source->scope_count));
+                for (std::size_t index = static_cast<std::size_t>(source->first_scope);
+                     index < source_end_index;
+                     ++index) {
+                    completion_order.push_back(index);
+                }
+                std::sort(
+                    completion_order.begin(),
+                    completion_order.end(),
+                    [&](std::size_t _left, std::size_t _right) {
+                        return std::tie(timing_subtree_end_local[_left], scopes[_left].local_order) <
+                               std::tie(timing_subtree_end_local[_right], scopes[_right].local_order);
+                    }
+                );
+                std::size_t completed_observed_index = 0;
+                for (std::size_t index = contract_begin; index < contract_end; ++index) {
+                    const MissingParentContract& contract = missing_parent_contracts[index];
+                    while (completed_observed_index < completion_order.size() &&
+                           timing_subtree_end_local[completion_order[completed_observed_index]] <
+                               contract.child_local_order_deadline) {
+                        observe_barrier(completion_order[completed_observed_index]);
+                        ++completed_observed_index;
+                    }
+
+                    const std::uint64_t anchor_index = contract.observed_ancestor_index;
+                    const std::uint32_t base_depth =
+                        anchor_index == kInvalidSessionIndex ? 0 : scopes[anchor_index].depth + 1;
+                    const std::uint64_t chain_item_count =
+                        static_cast<std::uint64_t>(contract.parent_depth - base_depth) + 1;
+                    if (!charge_topology_work(chain_item_count)) {
+                        return false;
+                    }
+
+                    const std::uint64_t anchor_first_allowed =
+                        anchor_index == kInvalidSessionIndex ? 0 : scopes[anchor_index].local_order + 1;
+                    const auto previous_direct = previous_missing_direct_end.find(contract.parent_depth);
+                    if (previous_direct != previous_missing_direct_end.end()) {
+                        std::uint64_t sibling_after = 0;
+                        if (AddOverflow(previous_direct->second, std::uint64_t{1}, sibling_after)) {
+                            Fail(
+                                SessionLoadStatus::ProtocolViolation,
+                                SessionErrorCode::GpuScopeIdentityInvalid,
+                                "missing GPU parent subtree overflows local-order space"
+                            );
+                            return false;
+                        }
+                        if (sibling_after >= contract.child_local_order_deadline) {
+                            Fail(
+                                SessionLoadStatus::ProtocolViolation,
+                                SessionErrorCode::GpuScopeParentInvalid,
+                                "distinct missing GPU parents at one depth have interleaved subtrees"
+                            );
+                            return false;
+                        }
+                        virtual_epoch_floor[contract.parent_depth] = sibling_after;
+                    }
+                    const std::size_t current_chain_begin = chain_task_indices.size();
+                    for (std::uint32_t depth = base_depth;; ++depth) {
+                        std::uint64_t first_allowed_slot =
+                            std::max(anchor_first_allowed, latest_barrier_after(depth));
+                        const auto epoch = virtual_epoch_floor.find(depth);
+                        if (epoch != virtual_epoch_floor.end()) {
+                            first_allowed_slot = std::max(first_allowed_slot, epoch->second);
+                        }
+                        const bool direct = depth == contract.parent_depth;
+                        if (first_allowed_slot >= contract.child_local_order_deadline) {
+                            Fail(
+                                SessionLoadStatus::ProtocolViolation,
+                                SessionErrorCode::GpuScopeParentInvalid,
+                                "missing GPU ancestry has no slot after its timing barrier"
+                            );
+                            return false;
+                        }
+
+                        const MissingTaskKey key{
+                            .anchor_index       = anchor_index,
+                            .depth              = depth,
+                            .first_allowed_slot = first_allowed_slot,
+                        };
+                        auto [state_it, state_inserted]          = task_states.try_emplace(key);
+                        MissingTaskState& state                  = state_it->second;
+                        std::uint64_t     task_index             = state.canonical_task_index;
+                        bool              task_shared_with_prior = false;
+                        if (state_inserted) {
+                            task_index = static_cast<std::uint64_t>(tasks.size());
+                            tasks.push_back({
+                                .first_allowed_slot = first_allowed_slot,
+                                .deadline_slot      = contract.child_local_order_deadline,
+                                .depth              = depth,
+                            });
+                            state.canonical_task_index = task_index;
+                            state.canonical_is_direct  = direct;
+                        } else if (direct && state.canonical_is_direct) {
+                            task_index = static_cast<std::uint64_t>(tasks.size());
+                            tasks.push_back({
+                                .first_allowed_slot = first_allowed_slot,
+                                .deadline_slot      = contract.child_local_order_deadline,
+                                .depth              = depth,
+                            });
+                        } else {
+                            task_shared_with_prior = true;
+                            MissingTask& task      = tasks[task_index];
+                            task.deadline_slot =
+                                std::min(task.deadline_slot, contract.child_local_order_deadline);
+                            if (direct) {
+                                state.canonical_is_direct = true;
+                            }
+                        }
+                        chain_task_indices.push_back(task_index);
+                        chain_task_shared_with_prior.push_back(
+                            static_cast<std::uint8_t>(task_shared_with_prior)
+                        );
+                        if (depth == contract.parent_depth) {
+                            break;
+                        }
+                    }
+                    if (base_depth == 0) {
+                        const std::uint64_t root_task_index = chain_task_indices[current_chain_begin];
+                        MissingTask&        root_task       = tasks[root_task_index];
+                        if (!root_task.has_timing_envelope) {
+                            root_task.has_timing_envelope            = true;
+                            root_task.timing_envelope_begin_tick     = contract.timing_envelope_begin_tick;
+                            root_task.timing_envelope_duration       = contract.timing_envelope_duration;
+                            root_task.timing_envelope_member_count   = 1;
+                            root_task.maximum_member_duration        = contract.timing_envelope_duration;
+                            root_task.first_member_duration          = contract.timing_envelope_duration;
+                            root_task.first_member_subtree_end_local = contract.last_child_subtree_end_local;
+                            root_task.timing_subtree_end_local       = contract.last_child_subtree_end_local;
+                        } else {
+                            const std::uint32_t valid_bits =
+                                scopes[static_cast<std::size_t>(source->first_scope)].valid_bits;
+                            const std::uint64_t envelope_begin_offset =
+                                (contract.timing_envelope_begin_tick - root_task.timing_envelope_begin_tick) &
+                                TimestampMask(valid_bits);
+                            const std::uint64_t timestamp_mask = TimestampMask(valid_bits);
+                            const bool          envelope_invalid =
+                                envelope_begin_offset < root_task.timing_envelope_duration ||
+                                contract.timing_envelope_duration > timestamp_mask - envelope_begin_offset;
+                            const std::uint64_t merged_envelope_duration =
+                                envelope_invalid ? 0 :
+                                                   envelope_begin_offset + contract.timing_envelope_duration;
+                            const std::uint64_t maximum_root_step =
+                                valid_bits == 64 ? (std::uint64_t{1} << 63) - 1 :
+                                                   (std::uint64_t{1} << (valid_bits - 1)) - 1;
+                            const bool has_later_observed_root =
+                                has_observed_root &&
+                                last_observed_root_local_order > contract.last_child_subtree_end_local;
+                            if (envelope_invalid ||
+                                (has_later_observed_root && merged_envelope_duration > maximum_root_step)) {
+                                const std::size_t chain_count =
+                                    chain_task_indices.size() - current_chain_begin;
+                                if (!charge_topology_work(static_cast<std::uint64_t>(chain_count))) {
+                                    return false;
+                                }
+                                std::uint64_t split_first_allowed = 0;
+                                if (AddOverflow(
+                                        root_task.timing_subtree_end_local,
+                                        std::uint64_t{1},
+                                        split_first_allowed
+                                    ) ||
+                                    split_first_allowed >= contract.child_local_order_deadline) {
+                                    Fail(
+                                        SessionLoadStatus::ProtocolViolation,
+                                        SessionErrorCode::GpuScopeParentInvalid,
+                                        "a virtual GPU root cannot split before the next child subtree"
+                                    );
+                                    return false;
+                                }
+                                for (std::size_t chain_index = current_chain_begin;
+                                     chain_index < chain_task_indices.size();
+                                     ++chain_index) {
+                                    MissingTask clone = tasks[chain_task_indices[chain_index]];
+                                    clone.first_allowed_slot =
+                                        std::max(clone.first_allowed_slot, split_first_allowed);
+                                    clone.deadline_slot                = contract.child_local_order_deadline;
+                                    clone.assigned_slot                = kInvalidSessionIndex;
+                                    clone.has_timing_envelope          = false;
+                                    clone.timing_envelope_begin_tick   = 0;
+                                    clone.timing_envelope_duration     = 0;
+                                    clone.timing_envelope_member_count = 0;
+                                    clone.maximum_member_duration      = 0;
+                                    clone.first_member_duration        = 0;
+                                    clone.first_member_subtree_end_local = 0;
+                                    clone.timing_subtree_end_local       = 0;
+                                    const std::uint64_t clone_index =
+                                        static_cast<std::uint64_t>(tasks.size());
+                                    tasks.push_back(clone);
+                                    chain_task_indices[chain_index]           = clone_index;
+                                    chain_task_shared_with_prior[chain_index] = 0;
+                                    const MissingTaskKey clone_key{
+                                        .anchor_index       = anchor_index,
+                                        .depth              = clone.depth,
+                                        .first_allowed_slot = clone.first_allowed_slot,
+                                    };
+                                    MissingTaskState& clone_state    = task_states[clone_key];
+                                    clone_state.canonical_task_index = clone_index;
+                                    clone_state.canonical_is_direct  = clone.depth == contract.parent_depth;
+                                }
+                                MissingTask& split_root = tasks[chain_task_indices[current_chain_begin]];
+                                split_root.has_timing_envelope          = true;
+                                split_root.timing_envelope_begin_tick   = contract.timing_envelope_begin_tick;
+                                split_root.timing_envelope_duration     = contract.timing_envelope_duration;
+                                split_root.timing_envelope_member_count = 1;
+                                split_root.maximum_member_duration      = contract.timing_envelope_duration;
+                                split_root.first_member_duration        = contract.timing_envelope_duration;
+                                split_root.first_member_subtree_end_local =
+                                    contract.last_child_subtree_end_local;
+                                split_root.timing_subtree_end_local = contract.last_child_subtree_end_local;
+                            } else {
+                                root_partition_candidates.push_back({
+                                    .root_task_index            = root_task_index,
+                                    .previous_subtree_end_local = root_task.timing_subtree_end_local,
+                                    .child_local_order_deadline = contract.child_local_order_deadline,
+                                    .member_begin_tick          = contract.timing_envelope_begin_tick,
+                                    .member_duration            = contract.timing_envelope_duration,
+                                    .member_subtree_end_local   = contract.last_child_subtree_end_local,
+                                    .chain_begin                = current_chain_begin,
+                                    .chain_end                  = chain_task_indices.size(),
+                                });
+                                root_task.timing_envelope_duration = merged_envelope_duration;
+                                ++root_task.timing_envelope_member_count;
+                                root_task.maximum_member_duration = std::max(
+                                    root_task.maximum_member_duration, contract.timing_envelope_duration
+                                );
+                                root_task.timing_subtree_end_local = std::max(
+                                    root_task.timing_subtree_end_local, contract.last_child_subtree_end_local
+                                );
+                            }
+                        }
+                    }
+                    chain_ends.push_back(static_cast<std::uint64_t>(chain_task_indices.size()));
+                    previous_missing_direct_end[contract.parent_depth] =
+                        contract.last_child_subtree_end_local;
+                }
+
+                std::vector<std::uint8_t> task_active(tasks.size(), 0);
+                std::uint64_t             active_task_count = 0;
+                for (const std::uint64_t task_index : chain_task_indices) {
+                    if (task_active[static_cast<std::size_t>(task_index)] == 0) {
+                        task_active[static_cast<std::size_t>(task_index)] = 1;
+                        ++active_task_count;
+                    }
+                }
+                source->required_parent_record_count = active_task_count;
+                if (source->required_parent_record_count > source->local_hole_count) {
+                    Fail(
+                        SessionLoadStatus::ProtocolViolation,
+                        SessionErrorCode::GpuScopeParentInvalid,
+                        "missing GPU ancestry exceeds its source local-order holes"
+                    );
+                    return false;
+                }
+                const bool has_spare_local_holes =
+                    source->required_parent_record_count < source->local_hole_count;
+                std::vector<std::uint64_t> task_order;
+                task_order.reserve(static_cast<std::size_t>(active_task_count));
+                for (std::size_t index = 0; index < tasks.size(); ++index) {
+                    if (task_active[index] != 0) {
+                        task_order.push_back(static_cast<std::uint64_t>(index));
+                    }
+                }
+                std::sort(
+                    task_order.begin(),
+                    task_order.end(),
+                    [&](std::uint64_t _left, std::uint64_t _right) {
+                        const MissingTask& left  = tasks[_left];
+                        const MissingTask& right = tasks[_right];
+                        return std::tie(left.deadline_slot, left.first_allowed_slot, left.depth, _left) >
+                               std::tie(right.deadline_slot, right.first_allowed_slot, right.depth, _right);
+                    }
+                );
+                const auto earlier_release = [&](std::uint64_t _left, std::uint64_t _right) {
+                    const MissingTask& left  = tasks[_left];
+                    const MissingTask& right = tasks[_right];
+                    return std::tie(left.first_allowed_slot, left.depth, _left) <
+                           std::tie(right.first_allowed_slot, right.depth, _right);
+                };
+                std::priority_queue<std::uint64_t, std::vector<std::uint64_t>, decltype(earlier_release)>
+                              ready_tasks(earlier_release);
+                std::size_t   ordered_task_index  = 0;
+                std::size_t   observed_slot_index = source_end_index;
+                bool          has_slot            = !task_order.empty();
+                std::uint64_t slot = task_order.empty() ? 0 : tasks[task_order.front()].deadline_slot - 1;
+                const auto    move_to_previous_slot = [&]() {
+                    if (slot == 0) {
+                        has_slot = false;
+                    } else {
+                        --slot;
+                    }
+                };
+                while (ordered_task_index < task_order.size() || !ready_tasks.empty()) {
+                    if (!has_slot) {
+                        Fail(
+                            SessionLoadStatus::ProtocolViolation,
+                            SessionErrorCode::GpuScopeParentInvalid,
+                            "missing GPU ancestry cannot fit its sparse local-order holes"
+                        );
+                        return false;
+                    }
+                    while (ordered_task_index < task_order.size() &&
+                           tasks[task_order[ordered_task_index]].deadline_slot > slot) {
+                        ready_tasks.push(task_order[ordered_task_index]);
+                        ++ordered_task_index;
+                    }
+                    if (ready_tasks.empty()) {
+                        slot = tasks[task_order[ordered_task_index]].deadline_slot - 1;
+                        continue;
+                    }
+                    while (observed_slot_index > static_cast<std::size_t>(source->first_scope) &&
+                           scopes[observed_slot_index - 1].local_order > slot) {
+                        --observed_slot_index;
+                    }
+                    if (observed_slot_index > static_cast<std::size_t>(source->first_scope) &&
+                        scopes[observed_slot_index - 1].local_order == slot) {
+                        --observed_slot_index;
+                        move_to_previous_slot();
+                        continue;
+                    }
+                    const std::uint64_t task_index = ready_tasks.top();
+                    if (tasks[task_index].first_allowed_slot > slot) {
+                        Fail(
+                            SessionLoadStatus::ProtocolViolation,
+                            SessionErrorCode::GpuScopeParentInvalid,
+                            "missing GPU ancestry cannot fit its sparse local-order holes"
+                        );
+                        return false;
+                    }
+                    ready_tasks.pop();
+                    tasks[task_index].assigned_slot = slot;
+                    move_to_previous_slot();
+                }
+
+                std::size_t chain_begin = 0;
+                for (const std::uint64_t chain_end_value : chain_ends) {
+                    const std::size_t chain_end = static_cast<std::size_t>(chain_end_value);
+                    for (std::size_t index = chain_begin + 1; index < chain_end; ++index) {
+                        if (tasks[chain_task_indices[index - 1]].assigned_slot >=
+                            tasks[chain_task_indices[index]].assigned_slot) {
+                            Fail(
+                                SessionLoadStatus::ProtocolViolation,
+                                SessionErrorCode::GpuScopeParentInvalid,
+                                "missing GPU ancestry cannot preserve parent-before-child order"
+                            );
+                            return false;
+                        }
+                    }
+                    chain_begin = chain_end;
+                }
+
+                std::vector<std::uint64_t> occupied_local_orders;
+                occupied_local_orders.reserve(
+                    static_cast<std::size_t>(source->scope_count) +
+                    static_cast<std::size_t>(active_task_count)
+                );
+                for (std::size_t index = static_cast<std::size_t>(source->first_scope);
+                     index < source_end_index;
+                     ++index) {
+                    occupied_local_orders.push_back(scopes[index].local_order);
+                }
+                for (std::size_t task_index = 0; task_index < tasks.size(); ++task_index) {
+                    if (task_active[task_index] != 0) {
+                        occupied_local_orders.push_back(tasks[task_index].assigned_slot);
+                    }
+                }
+                std::sort(occupied_local_orders.begin(), occupied_local_orders.end());
+
+                std::vector<std::uint64_t> candidate_split_root_slot(
+                    root_partition_candidates.size(), kInvalidSessionIndex
+                );
+                std::vector<std::size_t>   candidate_reserved_slot_begin(root_partition_candidates.size(), 0);
+                std::vector<std::size_t>   candidate_reserved_slot_end(root_partition_candidates.size(), 0);
+                std::vector<std::uint64_t> candidate_reserved_slot_storage;
+                std::vector<std::uint8_t>  task_has_concrete_split(tasks.size(), 0);
+                std::set<std::uint64_t>    reserved_split_slots;
+                std::vector<std::size_t>   candidate_order;
+                candidate_order.reserve(root_partition_candidates.size());
+                for (std::size_t index = 0; index < root_partition_candidates.size(); ++index) {
+                    candidate_order.push_back(index);
+                }
+                std::sort(
+                    candidate_order.begin(),
+                    candidate_order.end(),
+                    [&](std::size_t _left, std::size_t _right) {
+                        return std::tie(root_partition_candidates[_left].root_task_index, _left) <
+                               std::tie(root_partition_candidates[_right].root_task_index, _right);
+                    }
+                );
+                if (has_spare_local_holes) {
+
+                    std::size_t group_begin = 0;
+                    while (group_begin < candidate_order.size()) {
+                        std::size_t       group_end       = group_begin + 1;
+                        const std::size_t root_task_index = static_cast<std::size_t>(
+                            root_partition_candidates[candidate_order[group_begin]].root_task_index
+                        );
+                        while (group_end < candidate_order.size() &&
+                               root_partition_candidates[candidate_order[group_end]].root_task_index ==
+                                   root_partition_candidates[candidate_order[group_begin]].root_task_index) {
+                            ++group_end;
+                        }
+                        if (task_active[root_task_index] == 0 ||
+                            tasks[root_task_index].timing_envelope_member_count !=
+                                static_cast<std::uint64_t>(group_end - group_begin + 1)) {
+                            group_begin = group_end;
+                            continue;
+                        }
+
+                        for (std::size_t order_index = group_begin; order_index < group_end; ++order_index) {
+                            const std::size_t             candidate_index = candidate_order[order_index];
+                            const RootPartitionCandidate& candidate =
+                                root_partition_candidates[candidate_index];
+                            const std::uint64_t chain_item_count =
+                                static_cast<std::uint64_t>(candidate.chain_end - candidate.chain_begin);
+                            if (!charge_topology_work(chain_item_count)) {
+                                return false;
+                            }
+
+                            std::uint64_t required_split_records = 0;
+                            std::uint64_t first_unshared_slot    = candidate.child_local_order_deadline;
+                            bool          reached_unshared_task  = false;
+                            bool          candidate_feasible     = true;
+                            for (std::size_t chain_index = candidate.chain_begin;
+                                 chain_index < candidate.chain_end;
+                                 ++chain_index) {
+                                const std::size_t task_index =
+                                    static_cast<std::size_t>(chain_task_indices[chain_index]);
+                                if (chain_task_shared_with_prior[chain_index] != 0) {
+                                    if (reached_unshared_task) {
+                                        candidate_feasible = false;
+                                        break;
+                                    }
+                                    ++required_split_records;
+                                } else {
+                                    reached_unshared_task = true;
+                                    first_unshared_slot =
+                                        std::min(first_unshared_slot, tasks[task_index].assigned_slot);
+                                }
+                            }
+                            if (!candidate_feasible || required_split_records == 0 ||
+                                candidate.previous_subtree_end_local >= first_unshared_slot) {
+                                continue;
+                            }
+
+                            std::vector<std::uint64_t> candidate_reserved_slots;
+                            std::uint64_t              cursor    = first_unshared_slot;
+                            std::uint64_t              root_slot = kInvalidSessionIndex;
+                            for (std::uint64_t record = 0; record < required_split_records; ++record) {
+                                bool found = false;
+                                while (cursor != 0) {
+                                    --cursor;
+                                    if (cursor <= candidate.previous_subtree_end_local) {
+                                        break;
+                                    }
+                                    if (!charge_topology_work(1)) {
+                                        return false;
+                                    }
+                                    if (!std::binary_search(
+                                            occupied_local_orders.begin(), occupied_local_orders.end(), cursor
+                                        ) &&
+                                        !reserved_split_slots.contains(cursor)) {
+                                        found = true;
+                                        break;
+                                    }
+                                }
+                                if (!found) {
+                                    candidate_feasible = false;
+                                    break;
+                                }
+                                reserved_split_slots.insert(cursor);
+                                candidate_reserved_slots.push_back(cursor);
+                                root_slot = cursor;
+                            }
+                            if (candidate_feasible) {
+                                candidate_reserved_slot_begin[candidate_index] =
+                                    candidate_reserved_slot_storage.size();
+                                candidate_reserved_slot_storage.insert(
+                                    candidate_reserved_slot_storage.end(),
+                                    candidate_reserved_slots.begin(),
+                                    candidate_reserved_slots.end()
+                                );
+                                candidate_reserved_slot_end[candidate_index] =
+                                    candidate_reserved_slot_storage.size();
+                                candidate_split_root_slot[candidate_index] = root_slot;
+                                task_has_concrete_split[root_task_index]   = 1;
+                            } else {
+                                for (const std::uint64_t slot : candidate_reserved_slots) {
+                                    reserved_split_slots.erase(slot);
+                                }
+                            }
+                        }
+                        group_begin = group_end;
+                    }
+                }
+
+                struct RootComponent {
+                    std::uint64_t local_order{0};
+                    std::uint64_t subtree_end_local{0};
+                    bool          flexible{false};
+                    std::uint64_t begin_tick{0};
+                    std::uint64_t duration{0};
+                    std::uint64_t atomic_duration{0};
+                };
+                std::vector<RootComponent> root_components;
+                std::vector<RootComponent> split_root_components;
+                std::set<std::uint64_t>    used_split_slots;
+                root_components.reserve(static_cast<std::size_t>(source->scope_count) + tasks.size());
+                split_root_components.reserve(
+                    static_cast<std::size_t>(source->scope_count) + tasks.size() +
+                    root_partition_candidates.size()
+                );
+                for (std::size_t index = static_cast<std::size_t>(source->first_scope);
+                     index < source_end_index;
+                     ++index) {
+                    const GpuScopeRecord& scope = scopes[index];
+                    if (scope.parent_scope_id == 0) {
+                        const RootComponent component{
+                            .local_order       = scope.local_order,
+                            .subtree_end_local = timing_subtree_end_local[index],
+                            .flexible          = false,
+                            .begin_tick        = scope.begin_tick,
+                            .duration = TimestampDelta(scope.begin_tick, scope.end_tick, scope.valid_bits),
+                            .atomic_duration =
+                                TimestampDelta(scope.begin_tick, scope.end_tick, scope.valid_bits),
+                        };
+                        root_components.push_back(component);
+                        split_root_components.push_back(component);
+                    }
+                }
+                std::size_t         candidate_order_index = 0;
+                bool                has_split_plan        = false;
+                const std::uint32_t source_valid_bits =
+                    scopes[static_cast<std::size_t>(source->first_scope)].valid_bits;
+                const std::uint64_t source_timestamp_mask    = TimestampMask(source_valid_bits);
+                const std::uint64_t source_half_range        = source_valid_bits == 64 ?
+                                                                   (std::uint64_t{1} << 63) :
+                                                                   (std::uint64_t{1} << (source_valid_bits - 1));
+                const std::uint64_t source_maximum_root_step = source_half_range - 1;
+                for (std::size_t task_index = 0; task_index < tasks.size(); ++task_index) {
+                    while (candidate_order_index < candidate_order.size() &&
+                           root_partition_candidates[candidate_order[candidate_order_index]].root_task_index <
+                               task_index) {
+                        ++candidate_order_index;
+                    }
+                    const std::size_t task_candidate_begin = candidate_order_index;
+                    while (
+                        candidate_order_index < candidate_order.size() &&
+                        root_partition_candidates[candidate_order[candidate_order_index]].root_task_index ==
+                            task_index
+                    ) {
+                        ++candidate_order_index;
+                    }
+                    const std::size_t task_candidate_end = candidate_order_index;
+                    if (task_active[task_index] == 0) {
+                        continue;
+                    }
+                    const MissingTask& task = tasks[task_index];
+                    if (task.depth != 0) {
+                        continue;
+                    }
+                    if (!task.has_timing_envelope || task.assigned_slot == kInvalidSessionIndex) {
+                        Fail(
+                            SessionLoadStatus::ProtocolViolation,
+                            SessionErrorCode::GpuScopeTimingInvalid,
+                            "virtual GPU root has no assigned timing envelope"
+                        );
+                        return false;
+                    }
+                    const RootComponent merged_component{
+                        .local_order       = task.assigned_slot,
+                        .subtree_end_local = task.timing_subtree_end_local,
+                        .flexible          = true,
+                        .begin_tick        = task.timing_envelope_begin_tick,
+                        .duration          = task.timing_envelope_duration,
+                        .atomic_duration   = task.maximum_member_duration,
+                    };
+                    root_components.push_back(merged_component);
+                    if (task_has_concrete_split[task_index] == 0) {
+                        split_root_components.push_back(merged_component);
+                        continue;
+                    }
+
+                    RootComponent split_component{
+                        .local_order       = task.assigned_slot,
+                        .subtree_end_local = task.first_member_subtree_end_local,
+                        .flexible          = true,
+                        .begin_tick        = task.timing_envelope_begin_tick,
+                        .duration          = task.first_member_duration,
+                        .atomic_duration   = task.first_member_duration,
+                    };
+                    for (std::size_t order_index = task_candidate_begin; order_index < task_candidate_end;
+                         ++order_index) {
+                        const std::size_t             candidate_index = candidate_order[order_index];
+                        const RootPartitionCandidate& candidate = root_partition_candidates[candidate_index];
+                        const std::uint64_t split_root_slot     = candidate_split_root_slot[candidate_index];
+                        if (split_root_slot != kInvalidSessionIndex &&
+                            split_component.duration <= source_maximum_root_step) {
+                            has_split_plan = true;
+                            for (std::size_t slot_index = candidate_reserved_slot_begin[candidate_index];
+                                 slot_index < candidate_reserved_slot_end[candidate_index];
+                                 ++slot_index) {
+                                used_split_slots.insert(candidate_reserved_slot_storage[slot_index]);
+                            }
+                            split_root_components.push_back(split_component);
+                            split_component = {
+                                .local_order       = split_root_slot,
+                                .subtree_end_local = candidate.member_subtree_end_local,
+                                .flexible          = true,
+                                .begin_tick        = candidate.member_begin_tick,
+                                .duration          = candidate.member_duration,
+                                .atomic_duration   = candidate.member_duration,
+                            };
+                            continue;
+                        }
+
+                        const std::uint64_t member_begin_offset =
+                            (candidate.member_begin_tick - split_component.begin_tick) &
+                            source_timestamp_mask;
+                        if (member_begin_offset < split_component.duration ||
+                            candidate.member_duration > source_timestamp_mask - member_begin_offset) {
+                            Fail(
+                                SessionLoadStatus::ProtocolViolation,
+                                SessionErrorCode::GpuScopeTimingInvalid,
+                                "concrete GPU root partition has a non-serial member envelope"
+                            );
+                            return false;
+                        }
+                        split_component.duration = member_begin_offset + candidate.member_duration;
+                        split_component.atomic_duration =
+                            std::max(split_component.atomic_duration, candidate.member_duration);
+                        split_component.subtree_end_local =
+                            std::max(split_component.subtree_end_local, candidate.member_subtree_end_local);
+                    }
+                    split_root_components.push_back(split_component);
+                }
+                const auto sort_root_components = [](std::vector<RootComponent>& _components) {
+                    std::sort(
+                        _components.begin(),
+                        _components.end(),
+                        [](const RootComponent& _left, const RootComponent& _right) {
+                            return std::tie(_left.local_order, _left.flexible) <
+                                   std::tie(_right.local_order, _right.flexible);
+                        }
+                    );
+                };
+                sort_root_components(root_components);
+                sort_root_components(split_root_components);
+                const auto duplicate_root_slot = [](const std::vector<RootComponent>& _components) {
+                    return std::adjacent_find(
+                               _components.begin(),
+                               _components.end(),
+                               [](const RootComponent& _left, const RootComponent& _right) {
+                                   return _left.local_order == _right.local_order;
+                               }
+                           ) != _components.end();
+                };
+                if (duplicate_root_slot(root_components) ||
+                    (has_split_plan && duplicate_root_slot(split_root_components))) {
+                    Fail(
+                        SessionLoadStatus::ProtocolViolation,
+                        SessionErrorCode::GpuScopeParentInvalid,
+                        "observed and virtual GPU roots occupy one local-order slot"
+                    );
+                    return false;
+                }
+                if (!root_components.empty()) {
+                    const std::uint32_t valid_bits =
+                        scopes[static_cast<std::size_t>(source->first_scope)].valid_bits;
+                    const std::uint64_t timestamp_mask = TimestampMask(valid_bits);
+                    const std::uint64_t half_range =
+                        valid_bits == 64 ? (std::uint64_t{1} << 63) : (std::uint64_t{1} << (valid_bits - 1));
+                    const std::uint64_t maximum_root_step  = half_range - 1;
+                    const auto          fail_root_sequence = [&]() {
+                        Fail(
+                            SessionLoadStatus::ProtocolViolation,
+                            SessionErrorCode::GpuScopeTimingInvalid,
+                            "observed and virtual GPU roots have no legal serial timestamp order"
+                        );
+                        return false;
+                    };
+                    bool       topology_limit_failed  = false;
+                    const auto validate_root_sequence = [&](const std::vector<RootComponent>& _components,
+                                                            const std::vector<std::uint64_t>&
+                                                                _occupied_local_orders) {
+                        if (_components.empty()) {
+                            return true;
+                        }
+                        for (std::size_t index = 0; index < _components.size(); ++index) {
+                            const RootComponent& component = _components[index];
+                            if (index + 1 < _components.size() &&
+                                component.atomic_duration > maximum_root_step) {
+                                return false;
+                            }
+                            if (index != 0 &&
+                                _components[index - 1].subtree_end_local >= component.local_order) {
+                                return false;
+                            }
+                        }
+
+                        struct RootSerialState {
+                            SerialTick begin{};
+                            SerialTick end{};
+                        };
+                        const RootComponent& first_component = _components.front();
+                        RootSerialState      initial_state{
+                                 .begin =
+                                     {
+                                         .epoch = 1,
+                                         .tick  = first_component.begin_tick & timestamp_mask,
+                                },
+                        };
+                        if (first_component.flexible) {
+                            const std::uint64_t maximum_duration =
+                                _components.size() == 1 ? timestamp_mask : maximum_root_step;
+                            if (first_component.duration > maximum_duration || !AddSerialTickDelta(
+                                                                                   initial_state.begin,
+                                                                                   first_component.duration,
+                                                                                   valid_bits,
+                                                                                   initial_state.end
+                                                                               )) {
+                                return false;
+                            }
+                        } else if (!AddSerialTickDelta(
+                                       initial_state.begin,
+                                       first_component.duration,
+                                       valid_bits,
+                                       initial_state.end
+                                   )) {
+                            return false;
+                        }
+                        std::vector<RootSerialState> frontier{initial_state};
+
+                        for (std::size_t index = 1; index < _components.size(); ++index) {
+                            const RootComponent& previous_component = _components[index - 1];
+                            const RootComponent& component          = _components[index];
+                            const auto           occupied_begin     = std::upper_bound(
+                                _occupied_local_orders.begin(),
+                                _occupied_local_orders.end(),
+                                previous_component.subtree_end_local
+                            );
+                            const auto occupied_end = std::lower_bound(
+                                occupied_begin, _occupied_local_orders.end(), component.local_order
+                            );
+                            const std::uint64_t span =
+                                component.local_order - previous_component.subtree_end_local - 1;
+                            const std::uint64_t occupied_count =
+                                static_cast<std::uint64_t>(occupied_end - occupied_begin);
+                            if (occupied_count > span) {
+                                return false;
+                            }
+                            const std::uint64_t free_root_count = span - occupied_count;
+                            const bool          final_component = index + 1 == _components.size();
+                            const std::uint64_t maximum_duration =
+                                final_component ? timestamp_mask : maximum_root_step;
+                            if (component.flexible && component.duration > maximum_duration) {
+                                return false;
+                            }
+
+                            std::vector<RootSerialState> next_frontier;
+                            for (const RootSerialState& state : frontier) {
+                                if (!charge_topology_work(free_root_count)) {
+                                    topology_limit_failed = true;
+                                    return false;
+                                }
+                                SerialTick window_upper{};
+                                if (!AddSerialTickDelta(
+                                        state.begin, maximum_root_step, valid_bits, window_upper
+                                    ) ||
+                                    !SerialTickLessEqual(state.end, window_upper)) {
+                                    continue;
+                                }
+                                bool window_overflow = false;
+                                for (std::uint64_t step = 0; step < free_root_count; ++step) {
+                                    SerialTick next_upper{};
+                                    if (!AddSerialTickDelta(
+                                            window_upper, maximum_root_step, valid_bits, next_upper
+                                        )) {
+                                        window_overflow = true;
+                                        break;
+                                    }
+                                    window_upper = next_upper;
+                                }
+                                if (window_overflow) {
+                                    continue;
+                                }
+
+                                if (!component.flexible) {
+                                    SerialTick occurrence{};
+                                    if (!NextSerialTickOccurrence(
+                                            component.begin_tick, valid_bits, state.end, occurrence
+                                        )) {
+                                        continue;
+                                    }
+                                    while (SerialTickLessEqual(occurrence, window_upper)) {
+                                        if (!charge_topology_work(1)) {
+                                            topology_limit_failed = true;
+                                            return false;
+                                        }
+                                        SerialTick occurrence_end{};
+                                        if (!AddSerialTickDelta(
+                                                occurrence, component.duration, valid_bits, occurrence_end
+                                            )) {
+                                            break;
+                                        }
+                                        next_frontier.push_back({
+                                            .begin = occurrence,
+                                            .end   = occurrence_end,
+                                        });
+                                        if (occurrence.epoch == std::numeric_limits<std::uint64_t>::max()) {
+                                            break;
+                                        }
+                                        ++occurrence.epoch;
+                                    }
+                                    continue;
+                                }
+
+                                const std::uint64_t begin_slack = maximum_duration - component.duration;
+                                SerialTick          latest_envelope{};
+                                if (!AddSerialTickDelta(
+                                        window_upper, begin_slack, valid_bits, latest_envelope
+                                    )) {
+                                    continue;
+                                }
+                                SerialTick envelope_occurrence{};
+                                if (!NextSerialTickOccurrence(
+                                        component.begin_tick, valid_bits, state.end, envelope_occurrence
+                                    )) {
+                                    continue;
+                                }
+                                while (SerialTickLessEqual(envelope_occurrence, latest_envelope)) {
+                                    if (!charge_topology_work(1)) {
+                                        topology_limit_failed = true;
+                                        return false;
+                                    }
+                                    SerialTick envelope_begin_floor{};
+                                    if (SubtractSerialTickDelta(
+                                            envelope_occurrence, begin_slack, valid_bits, envelope_begin_floor
+                                        )) {
+                                        const SerialTick feasible_begin = envelope_begin_floor < state.end ?
+                                                                              state.end :
+                                                                              envelope_begin_floor;
+                                        const SerialTick feasible_end   = window_upper < envelope_occurrence ?
+                                                                              window_upper :
+                                                                              envelope_occurrence;
+                                        SerialTick       next_end{};
+                                        if (SerialTickLessEqual(feasible_begin, feasible_end) &&
+                                            AddSerialTickDelta(
+                                                envelope_occurrence, component.duration, valid_bits, next_end
+                                            )) {
+                                            next_frontier.push_back({
+                                                .begin = feasible_end,
+                                                .end   = next_end,
+                                            });
+                                        }
+                                    }
+                                    if (envelope_occurrence.epoch ==
+                                        std::numeric_limits<std::uint64_t>::max()) {
+                                        break;
+                                    }
+                                    ++envelope_occurrence.epoch;
+                                }
+                            }
+                            if (next_frontier.empty()) {
+                                return false;
+                            }
+                            std::sort(
+                                next_frontier.begin(),
+                                next_frontier.end(),
+                                [](const RootSerialState& _left, const RootSerialState& _right) {
+                                    if (_left.begin < _right.begin) {
+                                        return false;
+                                    }
+                                    if (_right.begin < _left.begin) {
+                                        return true;
+                                    }
+                                    return _left.end < _right.end;
+                                }
+                            );
+                            std::vector<RootSerialState> pruned_frontier;
+                            pruned_frontier.reserve(next_frontier.size());
+                            for (const RootSerialState& state : next_frontier) {
+                                if (!pruned_frontier.empty() && !((state.end) < pruned_frontier.back().end)) {
+                                    continue;
+                                }
+                                pruned_frontier.push_back(state);
+                            }
+                            frontier = std::move(pruned_frontier);
+                        }
+                        return !frontier.empty();
+                    };
+
+                    bool used_split_plan     = false;
+                    bool root_sequence_valid = validate_root_sequence(root_components, occupied_local_orders);
+                    if (!root_sequence_valid && !topology_limit_failed && has_split_plan) {
+                        std::vector<std::uint64_t> split_occupied_local_orders = occupied_local_orders;
+                        split_occupied_local_orders.insert(
+                            split_occupied_local_orders.end(),
+                            used_split_slots.begin(),
+                            used_split_slots.end()
+                        );
+                        std::sort(split_occupied_local_orders.begin(), split_occupied_local_orders.end());
+                        root_sequence_valid =
+                            validate_root_sequence(split_root_components, split_occupied_local_orders);
+                        used_split_plan = root_sequence_valid;
+                    }
+                    if (topology_limit_failed) {
+                        return false;
+                    }
+                    if (!root_sequence_valid) {
+                        return fail_root_sequence();
+                    }
+                    if (used_split_plan) {
+                        std::uint64_t required_parent_record_count = 0;
+                        if (AddOverflow(
+                                source->required_parent_record_count,
+                                static_cast<std::uint64_t>(used_split_slots.size()),
+                                required_parent_record_count
+                            ) ||
+                            required_parent_record_count > source->local_hole_count) {
+                            Fail(
+                                SessionLoadStatus::ProtocolViolation,
+                                SessionErrorCode::GpuScopeParentInvalid,
+                                "concrete GPU root partition exceeds its source local-order holes"
+                            );
+                            return false;
+                        }
+                        source->required_parent_record_count = required_parent_record_count;
+                        const std::uint64_t frame_index =
+                            scopes[static_cast<std::size_t>(source->first_scope)].frame_index;
+                        if (frame_index == kInvalidSessionIndex || frame_index >= frames.size()) {
+                            Fail(
+                                SessionLoadStatus::ProtocolViolation,
+                                SessionErrorCode::GpuScopeIdentityInvalid,
+                                "partitioned GPU root has no owning frame"
+                            );
+                            return false;
+                        }
+                        frame_root_partition_ambiguous[static_cast<std::size_t>(frame_index)] = 1;
+                    }
+                }
+            }
+
+            if (!timing_topology_trusted) {
+                std::size_t   observed_index              = static_cast<std::size_t>(source->first_scope);
+                std::uint64_t hidden_ancestor_lower_bound = 0;
+                std::map<std::uint32_t, std::uint32_t> required_prefix_depth_intervals;
+                std::uint32_t                          exposed_prefix_depth                = 0;
+                std::uint64_t                          required_prefix_depth_count         = 0;
+                std::uint64_t                          matched_required_direct_depth_count = 0;
+                const auto                             prefix_depth_was_required = [&](std::uint32_t _depth) {
+                    const auto interval = required_prefix_depth_intervals.upper_bound(_depth);
+                    if (interval == required_prefix_depth_intervals.begin()) {
+                        return false;
+                    }
+                    const auto& candidate = *std::prev(interval);
+                    return _depth >= candidate.first && _depth < candidate.second;
+                };
+                const auto prefix_direct_depth_count_in_range = [&](std::uint32_t _begin,
+                                                                    std::uint32_t _end) {
+                    return covered_depth_count_before(_end, prefix_covered_depth_tree) -
+                           covered_depth_count_before(_begin, prefix_covered_depth_tree);
+                };
+                const auto add_required_prefix_range = [&](std::uint32_t _begin, std::uint32_t _end) {
+                    if (_begin >= _end) {
+                        return;
+                    }
+
+                    auto interval = required_prefix_depth_intervals.lower_bound(_begin);
+                    if (interval != required_prefix_depth_intervals.begin()) {
+                        auto previous = std::prev(interval);
+                        if (previous->second >= _begin) {
+                            interval = previous;
+                        }
+                    }
+
+                    std::uint32_t merged_begin = _begin;
+                    std::uint32_t merged_end   = _end;
+                    std::uint32_t cursor       = _begin;
+                    while (interval != required_prefix_depth_intervals.end() && interval->first <= merged_end
+                    ) {
+                        if (cursor < _end && cursor < interval->first) {
+                            const std::uint32_t uncovered_end = std::min(_end, interval->first);
+                            required_prefix_depth_count += static_cast<std::uint64_t>(uncovered_end - cursor);
+                            matched_required_direct_depth_count +=
+                                prefix_direct_depth_count_in_range(cursor, uncovered_end);
+                        }
+                        cursor       = std::max(cursor, interval->second);
+                        merged_begin = std::min(merged_begin, interval->first);
+                        merged_end   = std::max(merged_end, interval->second);
+                        interval     = required_prefix_depth_intervals.erase(interval);
+                    }
+                    if (cursor < _end) {
+                        required_prefix_depth_count += static_cast<std::uint64_t>(_end - cursor);
+                        matched_required_direct_depth_count +=
+                            prefix_direct_depth_count_in_range(cursor, _end);
+                    }
+                    required_prefix_depth_intervals.emplace(merged_begin, merged_end);
+                };
+
+                std::vector<std::uint32_t> observed_ancestor_depths;
+                observed_ancestor_depths.reserve(std::min<std::size_t>(
+                    static_cast<std::size_t>(options.limits.max_scope_depth),
+                    source_end_index - static_cast<std::size_t>(source->first_scope)
+                ));
+                for (std::size_t index = contract_begin; index < contract_end; ++index) {
+                    const MissingParentContract& contract                = missing_parent_contracts[index];
+                    const std::size_t            parent_depth_coordinate = static_cast<std::size_t>(
+                        std::lower_bound(
+                            depth_coordinates.begin(), depth_coordinates.end(), contract.parent_depth
+                        ) -
+                        depth_coordinates.begin()
+                    );
+                    if (prefix_depth_covered[parent_depth_coordinate] == 0 &&
+                        prefix_depth_was_required(contract.parent_depth)) {
+                        ++matched_required_direct_depth_count;
+                    }
+                    cover_depth(contract.parent_depth, prefix_covered_depth_tree, prefix_depth_covered);
+
+                    observed_ancestor_depths.clear();
+                    if (timing_topology_trusted) {
+                        std::uint64_t ancestor_index = contract.observed_ancestor_index;
+                        while (ancestor_index != kInvalidSessionIndex) {
+                            const GpuScopeRecord& ancestor = scopes[ancestor_index];
+                            if (ancestor.depth < contract.parent_depth) {
+                                observed_ancestor_depths.push_back(ancestor.depth);
+                            }
+                            ancestor_index = nearest_observed_timing_ancestor[ancestor_index];
+                        }
+                        std::sort(observed_ancestor_depths.begin(), observed_ancestor_depths.end());
+                        observed_ancestor_depths.erase(
+                            std::unique(observed_ancestor_depths.begin(), observed_ancestor_depths.end()),
+                            observed_ancestor_depths.end()
+                        );
+                    } else {
+                        while (observed_index < source_end_index &&
+                               scopes[observed_index].local_order < contract.latest_parent_local_order) {
+                            cover_depth(scopes[observed_index].depth, covered_depth_tree, depth_covered);
+                            cover_depth(
+                                scopes[observed_index].depth, prefix_covered_depth_tree, prefix_depth_covered
+                            );
+                            ++observed_index;
+                        }
+                    }
+
+                    std::uint64_t covered_ancestor_depths =
+                        covered_depth_count_before(contract.parent_depth, covered_depth_tree);
+                    if (timing_topology_trusted) {
+                        for (const std::uint32_t depth : observed_ancestor_depths) {
+                            const std::size_t coordinate = static_cast<std::size_t>(
+                                std::lower_bound(depth_coordinates.begin(), depth_coordinates.end(), depth) -
+                                depth_coordinates.begin()
+                            );
+                            if (depth_covered[coordinate] == 0) {
+                                ++covered_ancestor_depths;
+                            }
+                        }
+                    }
+                    const std::uint64_t hidden_ancestors =
+                        static_cast<std::uint64_t>(contract.parent_depth) - covered_ancestor_depths;
+                    hidden_ancestor_lower_bound = std::max(hidden_ancestor_lower_bound, hidden_ancestors);
+
+                    if (timing_topology_trusted) {
+                        std::uint32_t interval_begin = 0;
+                        for (const std::uint32_t depth : observed_ancestor_depths) {
+                            add_required_prefix_range(interval_begin, depth);
+                            interval_begin = depth + 1;
+                        }
+                        add_required_prefix_range(interval_begin, contract.parent_depth);
+                    } else if (contract.parent_depth > exposed_prefix_depth) {
+                        std::uint32_t interval_begin = exposed_prefix_depth;
+                        auto          coordinate     = std::lower_bound(
+                            depth_coordinates.begin(), depth_coordinates.end(), exposed_prefix_depth
+                        );
+                        while (coordinate != depth_coordinates.end() && *coordinate < contract.parent_depth) {
+                            const std::size_t coordinate_index =
+                                static_cast<std::size_t>(coordinate - depth_coordinates.begin());
+                            if (prefix_depth_covered[coordinate_index] != 0) {
+                                add_required_prefix_range(interval_begin, *coordinate);
+                                interval_begin = *coordinate + 1;
+                            }
+                            ++coordinate;
+                        }
+                        add_required_prefix_range(interval_begin, contract.parent_depth);
+                        exposed_prefix_depth = contract.parent_depth;
+                    }
+
+                    const std::uint64_t parent_ordinal =
+                        static_cast<std::uint64_t>(index - contract_begin + 1);
+                    const std::uint64_t unmatched_required_prefix_depths =
+                        required_prefix_depth_count - matched_required_direct_depth_count;
+                    std::uint64_t       required_prefix_slots = 0;
+                    const std::uint64_t available_local_order_slots =
+                        contract.child_local_order_deadline - contract.observed_local_orders_before_deadline;
+                    if (AddOverflow(
+                            parent_ordinal, unmatched_required_prefix_depths, required_prefix_slots
+                        ) ||
+                        required_prefix_slots > available_local_order_slots) {
+                        Fail(
+                            SessionLoadStatus::ProtocolViolation,
+                            SessionErrorCode::GpuScopeParentInvalid,
+                            "missing GpuScope ancestry exceeds its local-order deadline"
+                        );
+                        return false;
+                    }
+                }
+
+                const std::uint64_t direct_parent_count =
+                    static_cast<std::uint64_t>(contract_end - contract_begin);
+                hidden_ancestor_lower_bound = std::max(
+                    hidden_ancestor_lower_bound,
+                    required_prefix_depth_count - matched_required_direct_depth_count
+                );
+                std::uint64_t depth_required_parent_records = 0;
+                if (AddOverflow(
+                        direct_parent_count, hidden_ancestor_lower_bound, depth_required_parent_records
+                    )) {
+                    Fail(
+                        SessionLoadStatus::ProtocolViolation,
+                        SessionErrorCode::GpuScopeParentInvalid,
+                        "missing GpuScope ancestry count overflows"
+                    );
+                    return false;
+                }
+                source->required_parent_record_count = depth_required_parent_records;
+                if (source->required_parent_record_count > source->local_hole_count) {
+                    Fail(
+                        SessionLoadStatus::ProtocolViolation,
+                        SessionErrorCode::GpuScopeParentInvalid,
+                        "missing GpuScope ancestry exceeds its source local-order holes"
+                    );
+                    return false;
+                }
+            }
+            contract_begin = contract_end;
+        }
+
+        struct FrameLossEvidence {
+            std::uint64_t frame_id{0};
+            std::uint64_t local_hole_count{0};
+            std::uint64_t required_parent_record_count{0};
+        };
+        std::vector<FrameLossEvidence> frame_loss_evidence;
+        frame_loss_evidence.reserve(source_loss_evidence.size());
+        for (const SourceLossEvidence& source : source_loss_evidence) {
+            frame_loss_evidence.push_back({
+                .frame_id                     = source.frame_id,
+                .local_hole_count             = source.local_hole_count,
+                .required_parent_record_count = source.required_parent_record_count,
+            });
+        }
+        std::sort(
+            frame_loss_evidence.begin(),
+            frame_loss_evidence.end(),
+            [](const FrameLossEvidence& _left, const FrameLossEvidence& _right) {
+                return _left.frame_id < _right.frame_id;
+            }
+        );
+        std::size_t frame_evidence_count = 0;
+        for (std::size_t index = 0; index < frame_loss_evidence.size(); ++index) {
+            if (frame_evidence_count == 0 || frame_loss_evidence[frame_evidence_count - 1].frame_id !=
+                                                 frame_loss_evidence[index].frame_id) {
+                frame_loss_evidence[frame_evidence_count++] = frame_loss_evidence[index];
+                continue;
+            }
+            FrameLossEvidence& aggregate        = frame_loss_evidence[frame_evidence_count - 1];
+            std::uint64_t      local_holes      = 0;
+            std::uint64_t      required_parents = 0;
+            if (AddOverflow(
+                    aggregate.local_hole_count, frame_loss_evidence[index].local_hole_count, local_holes
+                ) ||
+                AddOverflow(
+                    aggregate.required_parent_record_count,
+                    frame_loss_evidence[index].required_parent_record_count,
+                    required_parents
+                )) {
+                Fail(
+                    SessionLoadStatus::ProtocolViolation,
+                    SessionErrorCode::GpuFrameTotalsMismatch,
+                    "GPU source loss lower bound overflows"
+                );
+                return false;
+            }
+            aggregate.local_hole_count             = local_holes;
+            aggregate.required_parent_record_count = required_parents;
+        }
+        frame_loss_evidence.resize(frame_evidence_count);
+        const auto find_frame_loss_evidence = [&](std::uint64_t _frame_id) {
+            const auto found = std::lower_bound(
+                frame_loss_evidence.begin(),
+                frame_loss_evidence.end(),
+                _frame_id,
+                [](const FrameLossEvidence& _evidence, std::uint64_t _value) {
+                    return _evidence.frame_id < _value;
+                }
+            );
+            return found != frame_loss_evidence.end() && found->frame_id == _frame_id ?
+                       &*found :
+                       static_cast<const FrameLossEvidence*>(nullptr);
+        };
+
+        std::sort(missing_parent_keys.begin(), missing_parent_keys.end());
+        missing_parent_keys.erase(
+            std::unique(
+                missing_parent_keys.begin(),
+                missing_parent_keys.end(),
+                [](const ScopeLookup& _left, const ScopeLookup& _right) {
+                    return _left.frame_id == _right.frame_id && _left.scope_id == _right.scope_id;
+                }
+            ),
+            missing_parent_keys.end()
+        );
+        std::sort(missing_frame_ids.begin(), missing_frame_ids.end());
+        missing_frame_ids.erase(
+            std::unique(missing_frame_ids.begin(), missing_frame_ids.end()), missing_frame_ids.end()
+        );
+
+        const auto missing_parent_count = [&](std::uint64_t _frame_id) {
+            const ScopeLookup first{
+                .frame_id    = _frame_id,
+                .scope_id    = 0,
+                .scope_index = 0,
+            };
+            const ScopeLookup last{
+                .frame_id    = _frame_id,
+                .scope_id    = std::numeric_limits<std::uint64_t>::max(),
+                .scope_index = std::numeric_limits<std::uint64_t>::max(),
+            };
+            const auto begin =
+                std::lower_bound(missing_parent_keys.begin(), missing_parent_keys.end(), first);
+            const auto end = std::upper_bound(missing_parent_keys.begin(), missing_parent_keys.end(), last);
+            return static_cast<std::uint64_t>(end - begin);
+        };
+
+        std::uint64_t required_gpu_drops     = _required_cpu_drops;
+        const auto    add_required_gpu_drops = [&](std::uint64_t _count) {
+            std::uint64_t next = 0;
+            if (AddOverflow(required_gpu_drops, _count, next)) {
+                Fail(
+                    SessionLoadStatus::ProtocolViolation,
+                    SessionErrorCode::GpuFrameTotalsMismatch,
+                    "minimum CPU/GPU record loss count overflows"
+                );
+                return false;
+            }
+            required_gpu_drops = next;
+            return true;
+        };
+
+        for (std::size_t index = 0; index < frames.size(); ++index) {
+            GpuFrameRecord&     frame  = frames[index];
+            const std::uint64_t errors = frame_error_counts[index];
+            const bool          observed_too_many =
+                frame.scope_count > frame.admitted_scope_count || errors > frame.error_scope_count;
+            const std::uint64_t observed_ready = errors <= frame.scope_count ? frame.scope_count - errors : 0;
+            const std::uint64_t declared_ready = frame.admitted_scope_count - frame.error_scope_count;
+            if (observed_too_many || observed_ready > declared_ready) {
+                Fail(
+                    SessionLoadStatus::ProtocolViolation,
+                    SessionErrorCode::GpuFrameTotalsMismatch,
+                    "GpuFrame Ready/Error totals exceed its declarations"
+                );
+                return false;
+            }
+
+            const std::uint64_t      missing_scopes          = frame.admitted_scope_count - frame.scope_count;
+            const std::uint64_t      missing_parents         = missing_parent_count(frame.frame_id);
+            const FrameLossEvidence* loss_evidence           = find_frame_loss_evidence(frame.frame_id);
+            const std::uint64_t      required_parent_records = std::max(
+                missing_parents, loss_evidence != nullptr ? loss_evidence->required_parent_record_count : 0
+            );
+            std::uint64_t explainable_local_holes = 0;
+            if (AddOverflow(missing_scopes, frame.dropped_scope_count, explainable_local_holes)) {
+                Fail(
+                    SessionLoadStatus::ProtocolViolation,
+                    SessionErrorCode::GpuFrameTotalsMismatch,
+                    "GpuFrame scope deficit accounting overflows"
+                );
+                return false;
+            }
+            if ((loss_evidence != nullptr && loss_evidence->local_hole_count > explainable_local_holes) ||
+                required_parent_records > missing_scopes) {
+                Fail(
+                    SessionLoadStatus::ProtocolViolation,
+                    SessionErrorCode::GpuFrameTotalsMismatch,
+                    "GpuFrame declarations cannot explain its source local-order holes"
+                );
+                return false;
+            }
+
+            frame.export_missing_scope_count = missing_scopes;
+            frame.materialization_complete   = missing_scopes == 0;
+            if (frame.status == ProfileGpuFrameStatus::Complete) {
+                if (!add_required_gpu_drops(missing_scopes)) {
+                    return false;
+                }
+                if (missing_scopes != 0) {
+                    ++session.impl_->summary.degraded_complete_gpu_frame_count;
+                }
+            } else if (!add_required_gpu_drops(required_parent_records)) {
+                return false;
+            }
+        }
+
+        if (!add_required_gpu_drops(static_cast<std::uint64_t>(missing_frame_ids.size()))) {
+            return false;
+        }
+        for (const std::uint64_t frame_id : missing_frame_ids) {
+            const FrameLossEvidence* loss_evidence           = find_frame_loss_evidence(frame_id);
+            const std::uint64_t      required_parent_records = std::max(
+                missing_parent_count(frame_id),
+                loss_evidence != nullptr ? loss_evidence->required_parent_record_count : 0
+            );
+            if (!add_required_gpu_drops(required_parent_records)) {
+                return false;
+            }
+        }
+        if (session.impl_->summary.has_session_end) {
+            const std::uint64_t total_drop_budget = session.impl_->summary.session_end_records_dropped;
+            if (required_gpu_drops > total_drop_budget) {
+                Fail(
+                    SessionLoadStatus::ProtocolViolation,
+                    SessionErrorCode::GpuFrameTotalsMismatch,
+                    "CPU/GPU deficits exceed the session record-loss budget"
+                );
+                return false;
+            }
+        }
+
+        std::uint64_t previous_root_index = kInvalidSessionIndex;
+        for (std::size_t index = 0; index < scopes.size(); ++index) {
+            const GpuScopeRecord& scope = scopes[index];
+            if (scope.parent_scope_id != 0 || scope.frame_index == kInvalidSessionIndex) {
+                continue;
+            }
+            const GpuFrameRecord& frame = frames[scope.frame_index];
+            if (frame.status != ProfileGpuFrameStatus::Complete || !frame.materialization_complete) {
+                previous_root_index = kInvalidSessionIndex;
+                continue;
+            }
+
+            if (previous_root_index != kInvalidSessionIndex) {
+                const GpuScopeRecord& previous = scopes[previous_root_index];
+                const bool            same_source =
+                    previous.frame_id == scope.frame_id && previous.logical_queue == scope.logical_queue &&
+                    previous.native_queue_id == scope.native_queue_id &&
+                    previous.family_id == scope.family_id && previous.source_order == scope.source_order;
+                if (same_source) {
+                    if (previous.valid_bits != scope.valid_bits ||
+                        !NearlyEqualDuration(previous.tick_period_ns, scope.tick_period_ns)) {
+                        Fail(
+                            SessionLoadStatus::ProtocolViolation,
+                            SessionErrorCode::GpuScopeTimingInvalid,
+                            "serial GPU roots disagree on their timestamp domain"
+                        );
+                        return false;
+                    }
+                    const std::uint64_t begin_distance =
+                        (scope.begin_tick - previous.begin_tick) & TimestampMask(scope.valid_bits);
+                    const std::uint64_t previous_duration =
+                        TimestampDelta(previous.begin_tick, previous.end_tick, previous.valid_bits);
+                    const std::uint64_t half_range = scope.valid_bits == 64 ?
+                                                         (std::uint64_t{1} << 63) :
+                                                         (std::uint64_t{1} << (scope.valid_bits - 1));
+                    if (begin_distance < previous_duration || begin_distance >= half_range) {
+                        Fail(
+                            SessionLoadStatus::ProtocolViolation,
+                            SessionErrorCode::GpuScopeTimingInvalid,
+                            "serial GPU roots overlap or move backward in their timestamp domain"
+                        );
+                        return false;
+                    }
+                }
+            }
+            previous_root_index = index;
+        }
+
+        for (std::size_t index = 0; index < scopes.size(); ++index) {
+            const GpuScopeRecord& scope = scopes[index];
+            if (scope.frame_index == kInvalidSessionIndex) {
+                continue;
+            }
+            GpuFrameRecord& frame = frames[scope.frame_index];
+            if (frame.status != ProfileGpuFrameStatus::Complete) {
+                continue;
+            }
+
+            const double child_duration = direct_child_duration[index];
+            if (!std::isfinite(child_duration) ||
+                !DurationContains(scope.total_duration_ns, child_duration)) {
+                Fail(
+                    SessionLoadStatus::ProtocolViolation,
+                    SessionErrorCode::GpuScopeTimingInvalid,
+                    "GpuScope direct-child durations exceed the parent duration"
+                );
+                return false;
+            }
+            if (frame.materialization_complete) {
+                const double expected_exclusive = std::max(0.0, scope.total_duration_ns - child_duration);
+                if (!NearlyEqualDuration(scope.exclusive_duration_ns, expected_exclusive)) {
+                    Fail(
+                        SessionLoadStatus::ProtocolViolation,
+                        SessionErrorCode::GpuScopeTimingInvalid,
+                        "GpuScope exclusive duration disagrees with its complete child set"
+                    );
+                    return false;
+                }
+            } else if (!DurationContains(
+                           scope.total_duration_ns, scope.exclusive_duration_ns + child_duration
+                       )) {
+                Fail(
+                    SessionLoadStatus::ProtocolViolation,
+                    SessionErrorCode::GpuScopeTimingInvalid,
+                    "partial GpuScope evidence already exceeds the parent duration"
+                );
+                return false;
+            }
+        }
+        for (std::size_t index = 0; index < frames.size(); ++index) {
+            GpuFrameRecord& frame         = frames[index];
+            frame.timing_topology_trusted = frame.status == ProfileGpuFrameStatus::Complete &&
+                                            frame.materialization_complete &&
+                                            frame_root_partition_ambiguous[index] == 0;
         }
         return true;
     }
 
     [[nodiscard]] bool BuildIndexes(bool _forensic) {
         std::sort(record_sequences.begin(), record_sequences.end());
+        if (!record_sequences.empty() && record_sequences.front() == 0) {
+            Fail(
+                SessionLoadStatus::ProtocolViolation,
+                SessionErrorCode::RecordSequenceInvalid,
+                "profile record sequence zero is reserved"
+            );
+            return false;
+        }
         if (std::adjacent_find(record_sequences.begin(), record_sequences.end()) != record_sequences.end()) {
             Fail(
                 SessionLoadStatus::ProtocolViolation,
@@ -1362,11 +4207,39 @@ struct ProfileSessionReader::Impl {
             );
             return false;
         }
+        if (session.impl_->summary.has_session_end) {
+            std::uint64_t maximum_assigned_sequence = 0;
+            if (AddOverflow(
+                    session.impl_->summary.session_end_records_written,
+                    session.impl_->summary.session_end_records_dropped,
+                    maximum_assigned_sequence
+                ) ||
+                (!record_sequences.empty() && record_sequences.back() > maximum_assigned_sequence)) {
+                Fail(
+                    SessionLoadStatus::ProtocolViolation,
+                    SessionErrorCode::RecordSequenceInvalid,
+                    "profile record sequence exceeds the producer allocation bound"
+                );
+                return false;
+            }
+        }
 
         const bool allow_missing = _forensic || session.impl_->summary.lost_record_count != 0 ||
                                    session.impl_->summary.unnotified_drop_count != 0;
-        if (!BuildCpuTracks(allow_missing) || !BuildGpuDomainsAndTracks() ||
-            !BuildGpuTopology(allow_missing)) {
+        std::uint64_t required_cpu_drops = 0;
+        if (!BuildCpuTracks(allow_missing, required_cpu_drops)) {
+            return false;
+        }
+        if (session.impl_->summary.has_session_end &&
+            required_cpu_drops > session.impl_->summary.session_end_records_dropped) {
+            Fail(
+                SessionLoadStatus::ProtocolViolation,
+                SessionErrorCode::CpuScopeParentMissing,
+                "CPU hierarchy deficits exceed the session record-loss budget"
+            );
+            return false;
+        }
+        if (!BuildGpuDomainsAndTracks() || !BuildGpuTopology(allow_missing, required_cpu_drops)) {
             return false;
         }
         session.impl_->valid = true;
@@ -1440,8 +4313,27 @@ struct ProfileSessionReader::Impl {
                         );
                         break;
                     }
-                    const std::uint32_t payload_bytes = ReadU32LittleEndian(packet_bytes, 12);
-                    expected_packet_bytes = kPacketHeaderBytes + static_cast<std::size_t>(payload_bytes);
+                    const std::uint32_t payload_bytes     = ReadU32LittleEndian(packet_bytes, 12);
+                    std::size_t         packet_wire_bytes = 0;
+                    if (!Detail::TryPacketWireBytes(payload_bytes, packet_wire_bytes)) {
+                        FailCodec(
+                            DecodeStatus::PayloadTooLarge,
+                            SessionErrorCode::CodecHeaderInvalid,
+                            "profile packet size exceeds the addressable range"
+                        );
+                        break;
+                    }
+                    if (static_cast<std::uint64_t>(packet_wire_bytes) > options.limits.max_input_bytes) {
+                        Fail(
+                            SessionLoadStatus::LimitExceeded,
+                            SessionErrorCode::LimitExceeded,
+                            "profile packet cannot fit within the input byte limit",
+                            DecodeStatus::Ok,
+                            SessionLimitKind::InputBytes
+                        );
+                        break;
+                    }
+                    expected_packet_bytes = packet_wire_bytes;
                     packet_bytes.reserve(expected_packet_bytes);
                 }
 

--- a/source/tool/profile_consumer/source/ProfileSession.cpp
+++ b/source/tool/profile_consumer/source/ProfileSession.cpp
@@ -1,0 +1,1723 @@
+#include "profile_consumer/ProfileSession.h"
+
+#include "profile/ProfileDumpTemplates.h"
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <cstddef>
+#include <cstring>
+#include <deque>
+#include <fstream>
+#include <limits>
+#include <new>
+#include <string>
+#include <type_traits>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+namespace Moer::ProfileDump {
+
+namespace {
+
+constexpr std::size_t kReadBlockBytes = 256 * 1024;
+
+template<typename T>
+[[nodiscard]] bool AddOverflow(T _left, T _right, T& _result) noexcept {
+    static_assert(std::is_unsigned_v<T>);
+    if (_right > std::numeric_limits<T>::max() - _left) {
+        return true;
+    }
+    _result = _left + _right;
+    return false;
+}
+
+[[nodiscard]] std::uint32_t
+ReadU32LittleEndian(std::span<const std::uint8_t> _bytes, std::size_t _offset) noexcept {
+    std::uint32_t value = 0;
+    for (std::size_t byte = 0; byte < sizeof(value); ++byte) {
+        value |= static_cast<std::uint32_t>(_bytes[_offset + byte]) << (byte * 8);
+    }
+    return value;
+}
+
+[[nodiscard]] std::uint64_t
+ReadU64LittleEndian(std::span<const std::uint8_t> _bytes, std::size_t _offset) noexcept {
+    std::uint64_t value = 0;
+    for (std::size_t byte = 0; byte < sizeof(value); ++byte) {
+        value |= static_cast<std::uint64_t>(_bytes[_offset + byte]) << (byte * 8);
+    }
+    return value;
+}
+
+[[nodiscard]] bool IsFiniteNonnegative(double _value) noexcept {
+    return std::isfinite(_value) && _value >= 0.0;
+}
+
+[[nodiscard]] bool DurationContains(double _outer, double _inner) noexcept {
+    const double tolerance = std::max(1e-9, std::abs(_outer) * 1e-9);
+    return _inner <= _outer + tolerance;
+}
+
+[[nodiscard]] std::uint64_t TimestampMask(std::uint32_t _valid_bits) noexcept {
+    return _valid_bits == 64 ? std::numeric_limits<std::uint64_t>::max() :
+                               (std::uint64_t{1} << _valid_bits) - 1;
+}
+
+[[nodiscard]] std::uint64_t
+TimestampDelta(std::uint64_t _begin_tick, std::uint64_t _end_tick, std::uint32_t _valid_bits) noexcept {
+    return (_end_tick - _begin_tick) & TimestampMask(_valid_bits);
+}
+
+[[nodiscard]] bool NearlyEqualDuration(double _left, double _right) noexcept {
+    if (!std::isfinite(_left) || !std::isfinite(_right)) {
+        return false;
+    }
+    const double tolerance = std::max(1.0e-6, std::max(std::abs(_left), std::abs(_right)) * 1.0e-9);
+    return std::abs(_left - _right) <= tolerance;
+}
+
+[[nodiscard]] KnownProfileSchema IdentifyKnownSchema(const SchemaDescriptor& _schema) {
+    if (_schema == Templates::CpuScope()) {
+        return KnownProfileSchema::CpuScopeV1;
+    }
+    if (_schema == Templates::GpuFrame()) {
+        return KnownProfileSchema::GpuFrameV1;
+    }
+    if (_schema == Templates::GpuScope()) {
+        return KnownProfileSchema::GpuScopeV2;
+    }
+    return KnownProfileSchema::Unknown;
+}
+
+template<typename T>
+[[nodiscard]] const T* RecordField(const DecodedRecord& _record, std::size_t _index) noexcept {
+    if (_index >= _record.values.size()) {
+        return nullptr;
+    }
+    return std::get_if<T>(&_record.values[_index]);
+}
+
+[[nodiscard]] SessionLoadResult ResourceExhaustedResult() noexcept {
+    SessionLoadResult result{};
+    result.status     = SessionLoadStatus::ResourceExhausted;
+    result.error_code = SessionErrorCode::ResourceAllocationFailed;
+    return result;
+}
+
+} // namespace
+
+struct ProfileSession::Impl {
+    bool                  valid{false};
+    ProfileSessionSummary summary{};
+
+    std::vector<ProfileSchemaInfo>      schemas{};
+    std::vector<ProfileSchemaFieldInfo> schema_fields{};
+    std::vector<ProfileLossRecord>      losses{};
+    std::vector<CpuScopeRecord>         cpu_scopes{};
+    std::vector<CpuTrack>               cpu_tracks{};
+    std::vector<GpuFrameRecord>         gpu_frames{};
+    std::vector<GpuScopeRecord>         gpu_scopes{};
+    std::vector<GpuTrack>               gpu_tracks{};
+    std::vector<GpuTimestampDomain>     gpu_domains{};
+    std::deque<std::string>             strings{};
+};
+
+ProfileSession::~ProfileSession() {
+    delete impl_;
+}
+
+ProfileSession::ProfileSession(ProfileSession&& _other) noexcept :
+    impl_(std::exchange(_other.impl_, nullptr)) {}
+
+ProfileSession& ProfileSession::operator=(ProfileSession&& _other) noexcept {
+    if (this != &_other) {
+        delete impl_;
+        impl_ = std::exchange(_other.impl_, nullptr);
+    }
+    return *this;
+}
+
+bool ProfileSession::Valid() const noexcept {
+    return impl_ != nullptr && impl_->valid;
+}
+
+const ProfileSessionSummary& ProfileSession::Summary() const noexcept {
+    static const ProfileSessionSummary empty{};
+    return Valid() ? impl_->summary : empty;
+}
+
+std::span<const ProfileSchemaInfo> ProfileSession::Schemas() const noexcept {
+    return Valid() ? std::span<const ProfileSchemaInfo>(impl_->schemas) :
+                     std::span<const ProfileSchemaInfo>{};
+}
+
+std::span<const ProfileSchemaFieldInfo> ProfileSession::SchemaFields() const noexcept {
+    return Valid() ? std::span<const ProfileSchemaFieldInfo>(impl_->schema_fields) :
+                     std::span<const ProfileSchemaFieldInfo>{};
+}
+
+std::span<const ProfileLossRecord> ProfileSession::Losses() const noexcept {
+    return Valid() ? std::span<const ProfileLossRecord>(impl_->losses) : std::span<const ProfileLossRecord>{};
+}
+
+std::span<const CpuScopeRecord> ProfileSession::CpuScopes() const noexcept {
+    return Valid() ? std::span<const CpuScopeRecord>(impl_->cpu_scopes) : std::span<const CpuScopeRecord>{};
+}
+
+std::span<const CpuTrack> ProfileSession::CpuTracks() const noexcept {
+    return Valid() ? std::span<const CpuTrack>(impl_->cpu_tracks) : std::span<const CpuTrack>{};
+}
+
+std::span<const GpuFrameRecord> ProfileSession::GpuFrames() const noexcept {
+    return Valid() ? std::span<const GpuFrameRecord>(impl_->gpu_frames) : std::span<const GpuFrameRecord>{};
+}
+
+std::span<const GpuScopeRecord> ProfileSession::GpuScopes() const noexcept {
+    return Valid() ? std::span<const GpuScopeRecord>(impl_->gpu_scopes) : std::span<const GpuScopeRecord>{};
+}
+
+std::span<const GpuTrack> ProfileSession::GpuTracks() const noexcept {
+    return Valid() ? std::span<const GpuTrack>(impl_->gpu_tracks) : std::span<const GpuTrack>{};
+}
+
+std::span<const GpuTimestampDomain> ProfileSession::GpuDomains() const noexcept {
+    return Valid() ? std::span<const GpuTimestampDomain>(impl_->gpu_domains) :
+                     std::span<const GpuTimestampDomain>{};
+}
+
+std::string_view ProfileSession::String(SessionStringId _id) const noexcept {
+    if (!Valid() || _id == kInvalidSessionString || static_cast<std::size_t>(_id) >= impl_->strings.size()) {
+        return {};
+    }
+    return impl_->strings[_id];
+}
+
+struct ProfileSessionReader::Impl {
+    struct SchemaEntry {
+        SchemaDescriptor   descriptor{};
+        KnownProfileSchema known_schema{KnownProfileSchema::Unknown};
+        std::size_t        info_index{0};
+    };
+
+    struct DomainKey {
+        std::uint32_t native_queue_id{0};
+        std::uint32_t family_id{0};
+
+        friend bool operator==(const DomainKey&, const DomainKey&) = default;
+        friend bool operator<(const DomainKey& _left, const DomainKey& _right) noexcept {
+            if (_left.native_queue_id != _right.native_queue_id) {
+                return _left.native_queue_id < _right.native_queue_id;
+            }
+            return _left.family_id < _right.family_id;
+        }
+    };
+
+    struct ScopeLookup {
+        std::uint64_t frame_id{0};
+        std::uint64_t scope_id{0};
+        std::uint64_t scope_index{0};
+
+        friend bool operator<(const ScopeLookup& _left, const ScopeLookup& _right) noexcept {
+            if (_left.frame_id != _right.frame_id) {
+                return _left.frame_id < _right.frame_id;
+            }
+            if (_left.scope_id != _right.scope_id) {
+                return _left.scope_id < _right.scope_id;
+            }
+            return _left.scope_index < _right.scope_index;
+        }
+    };
+
+    explicit Impl(const SessionLoadOptions& _options) noexcept : options(_options) {
+        session.impl_ = new (std::nothrow) ProfileSession::Impl();
+        if (session.impl_ == nullptr) {
+            result.status     = SessionLoadStatus::ResourceExhausted;
+            result.error_code = SessionErrorCode::ResourceAllocationFailed;
+            diagnostic        = "profile session model allocation failed";
+        }
+    }
+
+    [[nodiscard]] bool IsReading() const noexcept {
+        return result.status == SessionLoadStatus::Reading;
+    }
+
+    void Fail(
+        SessionLoadStatus _status,
+        SessionErrorCode  _error_code,
+        const char*       _diagnostic,
+        DecodeStatus      _codec_status = DecodeStatus::Ok,
+        SessionLimitKind  _limit_kind   = SessionLimitKind::None,
+        std::uint64_t     _byte_offset  = kInvalidSessionIndex
+    ) noexcept {
+        if (!IsReading()) {
+            return;
+        }
+        result.status       = _status;
+        result.error_code   = _error_code;
+        result.codec_status = _codec_status;
+        result.limit_kind   = _limit_kind;
+        result.error_byte_offset =
+            _byte_offset == kInvalidSessionIndex ? result.valid_prefix_bytes : _byte_offset;
+        result.error_packet_index = expected_packet_index;
+        diagnostic                = _diagnostic;
+        if (session.impl_ != nullptr) {
+            session.impl_->valid = false;
+        }
+    }
+
+    [[nodiscard]] bool ChargeModel(std::uint64_t _bytes) noexcept {
+        std::uint64_t next = 0;
+        if (AddOverflow(session.impl_->summary.logical_model_bytes, _bytes, next) ||
+            next > options.limits.max_logical_model_bytes) {
+            Fail(
+                SessionLoadStatus::LimitExceeded,
+                SessionErrorCode::LimitExceeded,
+                "profile session model byte limit exceeded",
+                DecodeStatus::LimitExceeded,
+                SessionLimitKind::LogicalModelBytes
+            );
+            return false;
+        }
+        session.impl_->summary.logical_model_bytes = next;
+        return true;
+    }
+
+    [[nodiscard]] bool CheckCountLimit(
+        std::uint64_t    _current,
+        std::uint64_t    _maximum,
+        SessionLimitKind _kind,
+        const char*      _diagnostic
+    ) noexcept {
+        if (_current >= _maximum) {
+            Fail(
+                SessionLoadStatus::LimitExceeded,
+                SessionErrorCode::LimitExceeded,
+                _diagnostic,
+                DecodeStatus::LimitExceeded,
+                _kind
+            );
+            return false;
+        }
+        return true;
+    }
+
+    [[nodiscard]] bool InternString(std::string_view _value, SessionStringId& _id) {
+        const auto existing = interned_strings.find(_value);
+        if (existing != interned_strings.end()) {
+            _id = existing->second;
+            return true;
+        }
+
+        if (session.impl_->strings.size() >= options.limits.max_unique_strings ||
+            session.impl_->strings.size() >=
+                static_cast<std::size_t>(std::numeric_limits<SessionStringId>::max())) {
+            Fail(
+                SessionLoadStatus::LimitExceeded,
+                SessionErrorCode::LimitExceeded,
+                "profile session unique string limit exceeded",
+                DecodeStatus::LimitExceeded,
+                SessionLimitKind::UniqueStrings
+            );
+            return false;
+        }
+
+        std::uint64_t next_string_bytes = 0;
+        if (AddOverflow(string_bytes, static_cast<std::uint64_t>(_value.size()), next_string_bytes) ||
+            next_string_bytes > options.limits.max_string_bytes) {
+            Fail(
+                SessionLoadStatus::LimitExceeded,
+                SessionErrorCode::LimitExceeded,
+                "profile session string byte limit exceeded",
+                DecodeStatus::LimitExceeded,
+                SessionLimitKind::StringBytes
+            );
+            return false;
+        }
+        if (!ChargeModel(sizeof(std::string) + static_cast<std::uint64_t>(_value.size()))) {
+            return false;
+        }
+
+        session.impl_->strings.emplace_back(_value);
+        const SessionStringId  id     = static_cast<SessionStringId>(session.impl_->strings.size() - 1);
+        const std::string_view stored = session.impl_->strings.back();
+        interned_strings.emplace(stored, id);
+        string_bytes = next_string_bytes;
+        _id          = id;
+        return true;
+    }
+
+    void FailCodec(DecodeStatus _status, SessionErrorCode _error_code, const char* _context) noexcept {
+        SessionLoadStatus status = SessionLoadStatus::CorruptData;
+        SessionLimitKind  limit  = SessionLimitKind::None;
+        if (_status == DecodeStatus::UnsupportedVersion) {
+            status = SessionLoadStatus::UnsupportedVersion;
+        } else if (_status == DecodeStatus::PayloadTooLarge || _status == DecodeStatus::LimitExceeded) {
+            status = SessionLoadStatus::LimitExceeded;
+            limit  = SessionLimitKind::Codec;
+        } else if (_status == DecodeStatus::UnknownSchema) {
+            status = SessionLoadStatus::ProtocolViolation;
+        }
+        Fail(status, _error_code, _context, _status, limit);
+    }
+
+    [[nodiscard]] bool MaterializeCpuScope(const DecodedRecord& _record) {
+        const auto* thread_id = RecordField<std::uint64_t>(_record, 0);
+        const auto* name      = RecordField<ProfileString>(_record, 1);
+        const auto* begin_ns  = RecordField<std::uint64_t>(_record, 2);
+        const auto* end_ns    = RecordField<std::uint64_t>(_record, 3);
+        const auto* depth     = RecordField<std::uint32_t>(_record, 4);
+        if (thread_id == nullptr || name == nullptr || begin_ns == nullptr || end_ns == nullptr ||
+            depth == nullptr) {
+            Fail(
+                SessionLoadStatus::CorruptData,
+                SessionErrorCode::CpuScopePayloadInvalid,
+                "CpuScope record fields do not match the registered template",
+                DecodeStatus::MalformedPayload
+            );
+            return false;
+        }
+        if (*end_ns < *begin_ns) {
+            Fail(
+                SessionLoadStatus::ProtocolViolation,
+                SessionErrorCode::CpuScopeTimeInvalid,
+                "CpuScope end precedes begin"
+            );
+            return false;
+        }
+        if (*depth > options.limits.max_scope_depth) {
+            Fail(
+                SessionLoadStatus::LimitExceeded,
+                SessionErrorCode::LimitExceeded,
+                "CpuScope depth limit exceeded",
+                DecodeStatus::LimitExceeded,
+                SessionLimitKind::ScopeDepth
+            );
+            return false;
+        }
+        if (!CheckCountLimit(
+                session.impl_->cpu_scopes.size(),
+                options.limits.max_cpu_scopes,
+                SessionLimitKind::CpuScopes,
+                "CpuScope record limit exceeded"
+            ) ||
+            !ChargeModel(sizeof(CpuScopeRecord))) {
+            return false;
+        }
+
+        SessionStringId name_id = kInvalidSessionString;
+        if (!InternString(*name, name_id)) {
+            return false;
+        }
+        session.impl_->cpu_scopes.push_back({
+            .sequence  = _record.sequence,
+            .thread_id = *thread_id,
+            .name      = name_id,
+            .begin_ns  = *begin_ns,
+            .end_ns    = *end_ns,
+            .depth     = *depth,
+        });
+
+        ProfileSessionSummary& summary = session.impl_->summary;
+        ++summary.cpu_scope_count;
+        if (!summary.has_cpu_range) {
+            summary.has_cpu_range = true;
+            summary.cpu_begin_ns  = *begin_ns;
+            summary.cpu_end_ns    = *end_ns;
+        } else {
+            summary.cpu_begin_ns = std::min(summary.cpu_begin_ns, *begin_ns);
+            summary.cpu_end_ns   = std::max(summary.cpu_end_ns, *end_ns);
+        }
+        return true;
+    }
+
+    [[nodiscard]] bool MaterializeGpuFrame(const DecodedRecord& _record) {
+        const auto* frame_id       = RecordField<std::uint64_t>(_record, 0);
+        const auto* capture_status = RecordField<std::uint32_t>(_record, 1);
+        const auto* valid          = RecordField<bool>(_record, 2);
+        const auto* admitted       = RecordField<std::uint64_t>(_record, 3);
+        const auto* dropped        = RecordField<std::uint64_t>(_record, 4);
+        const auto* errors         = RecordField<std::uint64_t>(_record, 5);
+        const auto* reason         = RecordField<ProfileString>(_record, 6);
+        if (frame_id == nullptr || capture_status == nullptr || valid == nullptr || admitted == nullptr ||
+            dropped == nullptr || errors == nullptr || reason == nullptr) {
+            Fail(
+                SessionLoadStatus::CorruptData,
+                SessionErrorCode::GpuFramePayloadInvalid,
+                "GpuFrame record fields do not match the registered template",
+                DecodeStatus::MalformedPayload
+            );
+            return false;
+        }
+        if (*capture_status > static_cast<std::uint32_t>(ProfileGpuFrameStatus::Invalid)) {
+            Fail(
+                SessionLoadStatus::ProtocolViolation,
+                SessionErrorCode::GpuFrameStatusInvalid,
+                "GpuFrame capture status is invalid"
+            );
+            return false;
+        }
+        const ProfileGpuFrameStatus status = static_cast<ProfileGpuFrameStatus>(*capture_status);
+        if ((status == ProfileGpuFrameStatus::Complete) != *valid) {
+            Fail(
+                SessionLoadStatus::ProtocolViolation,
+                SessionErrorCode::GpuFrameStatusInvalid,
+                "GpuFrame validity disagrees with capture status"
+            );
+            return false;
+        }
+        const bool frame_status_consistent =
+            *errors <= *admitted &&
+            (status != ProfileGpuFrameStatus::Complete || (*dropped == 0 && *errors == 0)) &&
+            (status != ProfileGpuFrameStatus::Incomplete || *errors == 0);
+        if (!frame_status_consistent) {
+            Fail(
+                SessionLoadStatus::ProtocolViolation,
+                SessionErrorCode::GpuFrameStatusInvalid,
+                "GpuFrame counters disagree with capture status"
+            );
+            return false;
+        }
+        if (!CheckCountLimit(
+                session.impl_->gpu_frames.size(),
+                options.limits.max_gpu_frames,
+                SessionLimitKind::GpuFrames,
+                "GpuFrame record limit exceeded"
+            ) ||
+            !ChargeModel(sizeof(GpuFrameRecord))) {
+            return false;
+        }
+
+        SessionStringId reason_id = kInvalidSessionString;
+        if (!InternString(*reason, reason_id)) {
+            return false;
+        }
+        session.impl_->gpu_frames.push_back({
+            .sequence             = _record.sequence,
+            .frame_id             = *frame_id,
+            .status               = status,
+            .valid                = *valid,
+            .admitted_scope_count = *admitted,
+            .dropped_scope_count  = *dropped,
+            .error_scope_count    = *errors,
+            .reason               = reason_id,
+        });
+
+        ProfileSessionSummary& summary = session.impl_->summary;
+        ++summary.gpu_frame_count;
+        switch (status) {
+            case ProfileGpuFrameStatus::Complete:
+                ++summary.complete_gpu_frame_count;
+                break;
+            case ProfileGpuFrameStatus::Incomplete:
+                ++summary.incomplete_gpu_frame_count;
+                break;
+            case ProfileGpuFrameStatus::Invalid:
+                ++summary.invalid_gpu_frame_count;
+                break;
+        }
+        return true;
+    }
+
+    [[nodiscard]] bool MaterializeGpuScope(const DecodedRecord& _record) {
+        const auto* frame_id              = RecordField<std::uint64_t>(_record, 0);
+        const auto* scope_id              = RecordField<std::uint64_t>(_record, 1);
+        const auto* parent_scope_id       = RecordField<std::uint64_t>(_record, 2);
+        const auto* source_order          = RecordField<std::uint64_t>(_record, 3);
+        const auto* local_order           = RecordField<std::uint64_t>(_record, 4);
+        const auto* logical_queue         = RecordField<std::uint32_t>(_record, 5);
+        const auto* native_queue_id       = RecordField<std::uint32_t>(_record, 6);
+        const auto* family_id             = RecordField<std::uint32_t>(_record, 7);
+        const auto* name                  = RecordField<ProfileString>(_record, 8);
+        const auto* encoded_status        = RecordField<std::uint32_t>(_record, 9);
+        const auto* begin_tick            = RecordField<std::uint64_t>(_record, 10);
+        const auto* end_tick              = RecordField<std::uint64_t>(_record, 11);
+        const auto* valid_bits            = RecordField<std::uint32_t>(_record, 12);
+        const auto* tick_period_ns        = RecordField<double>(_record, 13);
+        const auto* total_duration_ns     = RecordField<double>(_record, 14);
+        const auto* exclusive_duration_ns = RecordField<double>(_record, 15);
+        const auto* depth                 = RecordField<std::uint32_t>(_record, 16);
+        const auto* error_reason          = RecordField<ProfileString>(_record, 17);
+        if (frame_id == nullptr || scope_id == nullptr || parent_scope_id == nullptr ||
+            source_order == nullptr || local_order == nullptr || logical_queue == nullptr ||
+            native_queue_id == nullptr || family_id == nullptr || name == nullptr ||
+            encoded_status == nullptr || begin_tick == nullptr || end_tick == nullptr ||
+            valid_bits == nullptr || tick_period_ns == nullptr || total_duration_ns == nullptr ||
+            exclusive_duration_ns == nullptr || depth == nullptr || error_reason == nullptr) {
+            Fail(
+                SessionLoadStatus::CorruptData,
+                SessionErrorCode::GpuScopePayloadInvalid,
+                "GpuScope record fields do not match the registered template",
+                DecodeStatus::MalformedPayload
+            );
+            return false;
+        }
+        if (*scope_id == 0 || *scope_id == *parent_scope_id) {
+            Fail(
+                SessionLoadStatus::ProtocolViolation,
+                SessionErrorCode::GpuScopeIdentityInvalid,
+                "GpuScope identity or parent identity is invalid"
+            );
+            return false;
+        }
+        if (*logical_queue > static_cast<std::uint32_t>(ProfileLogicalQueue::Copy)) {
+            Fail(
+                SessionLoadStatus::ProtocolViolation,
+                SessionErrorCode::GpuScopeQueueInvalid,
+                "GpuScope logical queue is invalid"
+            );
+            return false;
+        }
+        if (*encoded_status > static_cast<std::uint32_t>(ProfileGpuScopeStatus::Error)) {
+            Fail(
+                SessionLoadStatus::ProtocolViolation,
+                SessionErrorCode::GpuScopeStatusInvalid,
+                "GpuScope terminal status is invalid"
+            );
+            return false;
+        }
+        if (*depth > options.limits.max_scope_depth) {
+            Fail(
+                SessionLoadStatus::LimitExceeded,
+                SessionErrorCode::LimitExceeded,
+                "GpuScope depth limit exceeded",
+                DecodeStatus::LimitExceeded,
+                SessionLimitKind::ScopeDepth
+            );
+            return false;
+        }
+
+        const ProfileGpuScopeStatus status = static_cast<ProfileGpuScopeStatus>(*encoded_status);
+        if (status == ProfileGpuScopeStatus::Ready) {
+            bool timing_valid = *valid_bits != 0 && *valid_bits <= 64 && std::isfinite(*tick_period_ns) &&
+                                *tick_period_ns > 0.0 && IsFiniteNonnegative(*total_duration_ns) &&
+                                IsFiniteNonnegative(*exclusive_duration_ns) &&
+                                DurationContains(*total_duration_ns, *exclusive_duration_ns);
+            if (timing_valid) {
+                const double expected_duration_ns =
+                    static_cast<double>(TimestampDelta(*begin_tick, *end_tick, *valid_bits)) *
+                    *tick_period_ns;
+                timing_valid = NearlyEqualDuration(*total_duration_ns, expected_duration_ns);
+            }
+            if (!timing_valid) {
+                Fail(
+                    SessionLoadStatus::ProtocolViolation,
+                    SessionErrorCode::GpuScopeTimingInvalid,
+                    "ready GpuScope timing metadata is invalid"
+                );
+                return false;
+            }
+        }
+        if (!CheckCountLimit(
+                session.impl_->gpu_scopes.size(),
+                options.limits.max_gpu_scopes,
+                SessionLimitKind::GpuScopes,
+                "GpuScope record limit exceeded"
+            ) ||
+            !ChargeModel(sizeof(GpuScopeRecord))) {
+            return false;
+        }
+
+        SessionStringId name_id  = kInvalidSessionString;
+        SessionStringId error_id = kInvalidSessionString;
+        if (!InternString(*name, name_id) || !InternString(*error_reason, error_id)) {
+            return false;
+        }
+        session.impl_->gpu_scopes.push_back({
+            .sequence              = _record.sequence,
+            .frame_id              = *frame_id,
+            .scope_id              = *scope_id,
+            .parent_scope_id       = *parent_scope_id,
+            .source_order          = *source_order,
+            .local_order           = *local_order,
+            .logical_queue         = static_cast<ProfileLogicalQueue>(*logical_queue),
+            .native_queue_id       = *native_queue_id,
+            .family_id             = *family_id,
+            .name                  = name_id,
+            .status                = status,
+            .begin_tick            = *begin_tick,
+            .end_tick              = *end_tick,
+            .valid_bits            = *valid_bits,
+            .tick_period_ns        = *tick_period_ns,
+            .total_duration_ns     = *total_duration_ns,
+            .exclusive_duration_ns = *exclusive_duration_ns,
+            .depth                 = *depth,
+            .error_reason          = error_id,
+        });
+
+        ProfileSessionSummary& summary = session.impl_->summary;
+        ++summary.gpu_scope_count;
+        if (status == ProfileGpuScopeStatus::Ready) {
+            ++summary.ready_gpu_scope_count;
+        } else {
+            ++summary.error_gpu_scope_count;
+        }
+        return true;
+    }
+
+    [[nodiscard]] bool ProcessSchema(const PacketView& _packet) {
+        SchemaDescriptor   descriptor{};
+        const DecodeStatus decode = DecodeSchemaPayload(_packet, options.limits.codec, descriptor);
+        if (decode != DecodeStatus::Ok) {
+            FailCodec(
+                decode, SessionErrorCode::SchemaDecodeInvalid, "profile schema packet failed to decode"
+            );
+            return false;
+        }
+
+        const std::uint64_t hash     = ComputeSchemaHash(descriptor);
+        const auto          existing = schemas.find(hash);
+        ++session.impl_->summary.schema_packet_count;
+        if (existing != schemas.end()) {
+            if (existing->second.descriptor != descriptor) {
+                Fail(
+                    SessionLoadStatus::ProtocolViolation,
+                    SessionErrorCode::SchemaConflict,
+                    "conflicting profile schemas share one hash",
+                    DecodeStatus::SchemaHashMismatch
+                );
+                return false;
+            }
+            return true;
+        }
+
+        if (!CheckCountLimit(
+                schemas.size(),
+                options.limits.max_schemas,
+                SessionLimitKind::Schemas,
+                "profile schema count limit exceeded"
+            )) {
+            return false;
+        }
+        std::uint64_t next_schema_bytes = 0;
+        if (AddOverflow(
+                schema_bytes, static_cast<std::uint64_t>(_packet.payload.size()), next_schema_bytes
+            ) ||
+            next_schema_bytes > options.limits.max_schema_bytes) {
+            Fail(
+                SessionLoadStatus::LimitExceeded,
+                SessionErrorCode::LimitExceeded,
+                "profile schema byte limit exceeded",
+                DecodeStatus::LimitExceeded,
+                SessionLimitKind::SchemaBytes
+            );
+            return false;
+        }
+        if (!ChargeModel(sizeof(ProfileSchemaInfo) + static_cast<std::uint64_t>(_packet.payload.size()))) {
+            return false;
+        }
+
+        SessionStringId name       = kInvalidSessionString;
+        SessionStringId event_type = kInvalidSessionString;
+        if (!InternString(descriptor.name, name) || !InternString(descriptor.event_type, event_type)) {
+            return false;
+        }
+
+        const std::uint64_t first_field = session.impl_->schema_fields.size();
+        for (const SchemaField& field : descriptor.fields) {
+            if (!ChargeModel(sizeof(ProfileSchemaFieldInfo))) {
+                return false;
+            }
+            SessionStringId field_name = kInvalidSessionString;
+            if (!InternString(field.name, field_name)) {
+                return false;
+            }
+            session.impl_->schema_fields.push_back({
+                .name = field_name,
+                .type = field.type,
+            });
+        }
+
+        const KnownProfileSchema known      = IdentifyKnownSchema(descriptor);
+        const std::size_t        info_index = session.impl_->schemas.size();
+        session.impl_->schemas.push_back({
+            .hash           = hash,
+            .name           = name,
+            .event_type     = event_type,
+            .schema_version = descriptor.schema_version,
+            .kind           = descriptor.kind,
+            .channel        = descriptor.channel,
+            .known_schema   = known,
+            .first_field    = first_field,
+            .field_count    = static_cast<std::uint32_t>(descriptor.fields.size()),
+        });
+        schemas.emplace(
+            hash,
+            SchemaEntry{
+                .descriptor   = std::move(descriptor),
+                .known_schema = known,
+                .info_index   = info_index,
+            }
+        );
+        schema_bytes                               = next_schema_bytes;
+        session.impl_->summary.unique_schema_count = schemas.size();
+        return true;
+    }
+
+    [[nodiscard]] bool ProcessRecord(const PacketView& _packet) {
+        if (_packet.payload.size() < sizeof(std::uint64_t) * 2 + sizeof(std::uint32_t)) {
+            Fail(
+                SessionLoadStatus::CorruptData,
+                SessionErrorCode::RecordPayloadInvalid,
+                "profile record prefix is truncated",
+                DecodeStatus::MalformedPayload
+            );
+            return false;
+        }
+        if (!CheckCountLimit(
+                session.impl_->summary.record_count,
+                options.limits.max_records,
+                SessionLimitKind::Records,
+                "profile record limit exceeded"
+            )) {
+            return false;
+        }
+
+        const std::uint64_t schema_hash = ReadU64LittleEndian(_packet.payload, 0);
+        const auto          schema      = schemas.find(schema_hash);
+        if (schema == schemas.end()) {
+            Fail(
+                SessionLoadStatus::ProtocolViolation,
+                SessionErrorCode::RecordSchemaUnregistered,
+                "profile record references an unregistered schema",
+                DecodeStatus::UnknownSchema
+            );
+            return false;
+        }
+
+        DecodedRecord      record{};
+        const DecodeStatus decode =
+            DecodeRecordPayload(_packet, schema->second.descriptor, options.limits.codec, record);
+        if (decode != DecodeStatus::Ok) {
+            FailCodec(
+                decode, SessionErrorCode::RecordPayloadInvalid, "profile record packet failed to decode"
+            );
+            return false;
+        }
+
+        switch (schema->second.known_schema) {
+            case KnownProfileSchema::CpuScopeV1:
+                if (!MaterializeCpuScope(record)) {
+                    return false;
+                }
+                break;
+            case KnownProfileSchema::GpuFrameV1:
+                if (!MaterializeGpuFrame(record)) {
+                    return false;
+                }
+                break;
+            case KnownProfileSchema::GpuScopeV2:
+                if (!MaterializeGpuScope(record)) {
+                    return false;
+                }
+                break;
+            case KnownProfileSchema::Unknown:
+                ++session.impl_->summary.unknown_record_count;
+                break;
+        }
+
+        record_sequences.push_back(record.sequence);
+        ++session.impl_->summary.record_count;
+        ++session.impl_->schemas[schema->second.info_index].record_count;
+        return true;
+    }
+
+    [[nodiscard]] bool ProcessLoss(const PacketView& _packet) {
+        if (!CheckCountLimit(
+                session.impl_->losses.size(),
+                options.limits.max_loss_notices,
+                SessionLimitKind::LossNotices,
+                "profile loss notice limit exceeded"
+            ) ||
+            !ChargeModel(sizeof(ProfileLossRecord))) {
+            return false;
+        }
+
+        LossNotice         loss{};
+        const DecodeStatus decode = DecodeLossPayload(_packet, loss);
+        if (decode != DecodeStatus::Ok) {
+            FailCodec(decode, SessionErrorCode::LossPayloadInvalid, "profile loss packet failed to decode");
+            return false;
+        }
+
+        ProfileSessionSummary& summary      = session.impl_->summary;
+        std::uint64_t          lost_records = 0;
+        std::uint64_t          lost_bytes   = 0;
+        if (AddOverflow(summary.lost_record_count, loss.record_count, lost_records) ||
+            AddOverflow(summary.lost_value_bytes, loss.value_bytes, lost_bytes)) {
+            Fail(
+                SessionLoadStatus::ProtocolViolation,
+                SessionErrorCode::LossTotalsOverflow,
+                "profile loss totals overflow"
+            );
+            return false;
+        }
+        session.impl_->losses.push_back({
+            .first_sequence = loss.first_sequence,
+            .last_sequence  = loss.last_sequence,
+            .record_count   = loss.record_count,
+            .value_bytes    = loss.value_bytes,
+            .reason_mask    = loss.reason_mask,
+        });
+        summary.lost_record_count = lost_records;
+        summary.lost_value_bytes  = lost_bytes;
+        summary.loss_reason_mask |= loss.reason_mask;
+        ++summary.loss_notice_count;
+        return true;
+    }
+
+    [[nodiscard]] bool ProcessPacket(const PacketView& _packet) {
+        if (!CheckCountLimit(
+                session.impl_->summary.packet_count,
+                options.limits.max_packets,
+                SessionLimitKind::Packets,
+                "profile packet limit exceeded"
+            )) {
+            return false;
+        }
+        if (_packet.header.packet_index != expected_packet_index) {
+            Fail(
+                SessionLoadStatus::ProtocolViolation,
+                SessionErrorCode::PacketIndexMismatch,
+                "profile packet indices are not contiguous"
+            );
+            return false;
+        }
+        if (!saw_session_begin && _packet.header.type != PacketType::SessionBegin) {
+            Fail(
+                SessionLoadStatus::ProtocolViolation,
+                SessionErrorCode::SessionBeginMissing,
+                "profile session does not begin with SessionBegin"
+            );
+            return false;
+        }
+        if (saw_session_end) {
+            Fail(
+                SessionLoadStatus::ProtocolViolation,
+                SessionErrorCode::TrailingDataAfterSessionEnd,
+                "profile packet appears after SessionEnd"
+            );
+            return false;
+        }
+
+        switch (_packet.header.type) {
+            case PacketType::SessionBegin: {
+                if (saw_session_begin || _packet.header.packet_index != 0) {
+                    Fail(
+                        SessionLoadStatus::ProtocolViolation,
+                        SessionErrorCode::SessionBeginDuplicate,
+                        "profile session contains a duplicate SessionBegin"
+                    );
+                    return false;
+                }
+                SessionBeginInfo   begin{};
+                const DecodeStatus decode = DecodeSessionBeginPayload(_packet, begin);
+                if (decode != DecodeStatus::Ok) {
+                    FailCodec(
+                        decode, SessionErrorCode::SessionBeginMissing, "SessionBegin payload failed to decode"
+                    );
+                    return false;
+                }
+                saw_session_begin                      = true;
+                session.impl_->summary.generation      = begin.generation;
+                session.impl_->summary.started_unix_ns = begin.started_unix_ns;
+                break;
+            }
+            case PacketType::Schema:
+                if (!ProcessSchema(_packet)) {
+                    return false;
+                }
+                break;
+            case PacketType::Record:
+                if (!ProcessRecord(_packet)) {
+                    return false;
+                }
+                break;
+            case PacketType::Loss:
+                if (!ProcessLoss(_packet)) {
+                    return false;
+                }
+                break;
+            case PacketType::SessionEnd: {
+                SessionEndInfo     end{};
+                const DecodeStatus decode = DecodeSessionEndPayload(_packet, end);
+                if (decode != DecodeStatus::Ok) {
+                    FailCodec(
+                        decode,
+                        SessionErrorCode::SessionEndTotalsMismatch,
+                        "SessionEnd payload failed to decode"
+                    );
+                    return false;
+                }
+                const ProfileSessionSummary& summary = session.impl_->summary;
+                if (end.generation != summary.generation || end.records_written != summary.record_count ||
+                    end.records_dropped < summary.lost_record_count) {
+                    Fail(
+                        SessionLoadStatus::ProtocolViolation,
+                        SessionErrorCode::SessionEndTotalsMismatch,
+                        "SessionEnd totals do not match the decoded session"
+                    );
+                    return false;
+                }
+                saw_session_end                                    = true;
+                session.impl_->summary.has_session_end             = true;
+                session.impl_->summary.session_end_records_written = end.records_written;
+                session.impl_->summary.session_end_records_dropped = end.records_dropped;
+                session.impl_->summary.unnotified_drop_count =
+                    end.records_dropped - summary.lost_record_count;
+                break;
+            }
+        }
+
+        ++session.impl_->summary.packet_count;
+        ++expected_packet_index;
+        result.packet_count = session.impl_->summary.packet_count;
+        return true;
+    }
+
+    [[nodiscard]] bool BuildCpuTracks(bool _allow_missing) {
+        auto& scopes = session.impl_->cpu_scopes;
+        std::sort(
+            scopes.begin(),
+            scopes.end(),
+            [](const CpuScopeRecord& _left, const CpuScopeRecord& _right) {
+                if (_left.thread_id != _right.thread_id) {
+                    return _left.thread_id < _right.thread_id;
+                }
+                if (_left.begin_ns != _right.begin_ns) {
+                    return _left.begin_ns < _right.begin_ns;
+                }
+                if (_left.end_ns != _right.end_ns) {
+                    return _left.end_ns > _right.end_ns;
+                }
+                if (_left.depth != _right.depth) {
+                    return _left.depth < _right.depth;
+                }
+                return _left.sequence < _right.sequence;
+            }
+        );
+
+        std::size_t track_begin = 0;
+        while (track_begin < scopes.size()) {
+            std::size_t track_end = track_begin + 1;
+            while (track_end < scopes.size() && scopes[track_end].thread_id == scopes[track_begin].thread_id
+            ) {
+                ++track_end;
+            }
+            if (!CheckCountLimit(
+                    session.impl_->cpu_tracks.size(),
+                    options.limits.max_cpu_tracks,
+                    SessionLimitKind::CpuTracks,
+                    "CPU track limit exceeded"
+                ) ||
+                !ChargeModel(sizeof(CpuTrack))) {
+                return false;
+            }
+            const std::uint32_t track_index = static_cast<std::uint32_t>(session.impl_->cpu_tracks.size());
+            session.impl_->cpu_tracks.push_back({
+                .thread_id   = scopes[track_begin].thread_id,
+                .first_scope = track_begin,
+                .scope_count = track_end - track_begin,
+            });
+
+            std::vector<std::uint64_t> active;
+            active.reserve(std::min<std::size_t>(
+                track_end - track_begin, static_cast<std::size_t>(options.limits.max_scope_depth) + 1
+            ));
+            for (std::size_t index = track_begin; index < track_end; ++index) {
+                CpuScopeRecord& scope = scopes[index];
+                scope.track_index     = track_index;
+
+                while (!active.empty()) {
+                    const CpuScopeRecord& candidate = scopes[active.back()];
+                    if (candidate.end_ns >= scope.end_ns && candidate.begin_ns <= scope.begin_ns &&
+                        candidate.depth < scope.depth) {
+                        break;
+                    }
+                    active.pop_back();
+                }
+                while (!active.empty() && scopes[active.back()].depth >= scope.depth) {
+                    active.pop_back();
+                }
+
+                if (scope.depth != 0) {
+                    auto parent =
+                        std::find_if(active.rbegin(), active.rend(), [&](std::uint64_t _candidate_index) {
+                            const CpuScopeRecord& candidate = scopes[_candidate_index];
+                            return candidate.depth == scope.depth - 1 &&
+                                   candidate.begin_ns <= scope.begin_ns && candidate.end_ns >= scope.end_ns;
+                        });
+                    if (parent == active.rend()) {
+                        ++session.impl_->summary.orphan_cpu_scope_count;
+                        if (!_allow_missing) {
+                            Fail(
+                                SessionLoadStatus::ProtocolViolation,
+                                SessionErrorCode::CpuScopeParentMissing,
+                                "CpuScope hierarchy has a missing parent"
+                            );
+                            return false;
+                        }
+                    } else {
+                        scope.parent_index = *parent;
+                    }
+                }
+                active.push_back(index);
+            }
+            track_begin = track_end;
+        }
+        return true;
+    }
+
+    [[nodiscard]] bool BuildGpuDomainsAndTracks() {
+        auto&                  scopes = session.impl_->gpu_scopes;
+        std::vector<DomainKey> keys;
+        keys.reserve(scopes.size());
+        for (const GpuScopeRecord& scope : scopes) {
+            keys.push_back({
+                .native_queue_id = scope.native_queue_id,
+                .family_id       = scope.family_id,
+            });
+        }
+        std::sort(keys.begin(), keys.end());
+        keys.erase(std::unique(keys.begin(), keys.end()), keys.end());
+        if (keys.size() > options.limits.max_gpu_domains) {
+            Fail(
+                SessionLoadStatus::LimitExceeded,
+                SessionErrorCode::LimitExceeded,
+                "GPU timestamp domain limit exceeded",
+                DecodeStatus::LimitExceeded,
+                SessionLimitKind::GpuDomains
+            );
+            return false;
+        }
+        for (const DomainKey& key : keys) {
+            if (!ChargeModel(sizeof(GpuTimestampDomain))) {
+                return false;
+            }
+            session.impl_->gpu_domains.push_back({
+                .native_queue_id = key.native_queue_id,
+                .family_id       = key.family_id,
+            });
+        }
+
+        for (GpuScopeRecord& scope : scopes) {
+            const DomainKey key{
+                .native_queue_id = scope.native_queue_id,
+                .family_id       = scope.family_id,
+            };
+            const auto          domain_position = std::lower_bound(keys.begin(), keys.end(), key);
+            const std::uint32_t domain_index    = static_cast<std::uint32_t>(domain_position - keys.begin());
+            scope.domain_index                  = domain_index;
+            GpuTimestampDomain& domain          = session.impl_->gpu_domains[domain_index];
+            domain.logical_queue_mask |= ProfileLogicalQueueBit(scope.logical_queue);
+            if (scope.status == ProfileGpuScopeStatus::Ready) {
+                ++domain.ready_scope_count;
+                if (!domain.has_ready_timestamps) {
+                    domain.has_ready_timestamps = true;
+                    domain.valid_bits           = scope.valid_bits;
+                    domain.tick_period_ns       = scope.tick_period_ns;
+                } else if (domain.valid_bits != scope.valid_bits ||
+                           domain.tick_period_ns != scope.tick_period_ns) {
+                    Fail(
+                        SessionLoadStatus::ProtocolViolation,
+                        SessionErrorCode::GpuDomainConflict,
+                        "one GPU timestamp domain reports conflicting timing capabilities"
+                    );
+                    return false;
+                }
+            } else {
+                ++domain.error_scope_count;
+            }
+        }
+
+        std::sort(
+            scopes.begin(),
+            scopes.end(),
+            [](const GpuScopeRecord& _left, const GpuScopeRecord& _right) {
+                if (_left.logical_queue != _right.logical_queue) {
+                    return _left.logical_queue < _right.logical_queue;
+                }
+                if (_left.native_queue_id != _right.native_queue_id) {
+                    return _left.native_queue_id < _right.native_queue_id;
+                }
+                if (_left.family_id != _right.family_id) {
+                    return _left.family_id < _right.family_id;
+                }
+                if (_left.frame_id != _right.frame_id) {
+                    return _left.frame_id < _right.frame_id;
+                }
+                if (_left.source_order != _right.source_order) {
+                    return _left.source_order < _right.source_order;
+                }
+                if (_left.local_order != _right.local_order) {
+                    return _left.local_order < _right.local_order;
+                }
+                return _left.scope_id < _right.scope_id;
+            }
+        );
+
+        std::size_t track_begin = 0;
+        while (track_begin < scopes.size()) {
+            std::size_t track_end = track_begin + 1;
+            while (track_end < scopes.size() &&
+                   scopes[track_end].logical_queue == scopes[track_begin].logical_queue &&
+                   scopes[track_end].native_queue_id == scopes[track_begin].native_queue_id &&
+                   scopes[track_end].family_id == scopes[track_begin].family_id) {
+                ++track_end;
+            }
+            if (!CheckCountLimit(
+                    session.impl_->gpu_tracks.size(),
+                    options.limits.max_gpu_tracks,
+                    SessionLimitKind::GpuTracks,
+                    "GPU track limit exceeded"
+                ) ||
+                !ChargeModel(sizeof(GpuTrack))) {
+                return false;
+            }
+            const std::uint32_t track_index = static_cast<std::uint32_t>(session.impl_->gpu_tracks.size());
+            session.impl_->gpu_tracks.push_back({
+                .logical_queue   = scopes[track_begin].logical_queue,
+                .native_queue_id = scopes[track_begin].native_queue_id,
+                .family_id       = scopes[track_begin].family_id,
+                .domain_index    = scopes[track_begin].domain_index,
+                .first_scope     = track_begin,
+                .scope_count     = track_end - track_begin,
+            });
+            for (std::size_t index = track_begin; index < track_end; ++index) {
+                scopes[index].track_index = track_index;
+            }
+            track_begin = track_end;
+        }
+        return true;
+    }
+
+    [[nodiscard]] bool BuildGpuTopology(bool _allow_missing) {
+        auto& frames = session.impl_->gpu_frames;
+        auto& scopes = session.impl_->gpu_scopes;
+        std::sort(
+            frames.begin(),
+            frames.end(),
+            [](const GpuFrameRecord& _left, const GpuFrameRecord& _right) {
+                if (_left.frame_id != _right.frame_id) {
+                    return _left.frame_id < _right.frame_id;
+                }
+                return _left.sequence < _right.sequence;
+            }
+        );
+        for (std::size_t index = 1; index < frames.size(); ++index) {
+            if (frames[index - 1].frame_id == frames[index].frame_id) {
+                Fail(
+                    SessionLoadStatus::ProtocolViolation,
+                    SessionErrorCode::GpuFrameDuplicate,
+                    "duplicate GpuFrame identity"
+                );
+                return false;
+            }
+        }
+
+        std::vector<std::uint64_t> frame_error_counts(frames.size(), 0);
+        std::vector<ScopeLookup>   lookup;
+        lookup.reserve(scopes.size());
+        for (std::size_t index = 0; index < scopes.size(); ++index) {
+            lookup.push_back({
+                .frame_id    = scopes[index].frame_id,
+                .scope_id    = scopes[index].scope_id,
+                .scope_index = index,
+            });
+        }
+        std::sort(lookup.begin(), lookup.end());
+        for (std::size_t index = 1; index < lookup.size(); ++index) {
+            if (lookup[index - 1].frame_id == lookup[index].frame_id &&
+                lookup[index - 1].scope_id == lookup[index].scope_id) {
+                Fail(
+                    SessionLoadStatus::ProtocolViolation,
+                    SessionErrorCode::GpuScopeDuplicate,
+                    "duplicate GpuScope identity within one frame"
+                );
+                return false;
+            }
+        }
+
+        const auto find_scope = [&](std::uint64_t _frame_id, std::uint64_t _scope_id) {
+            const ScopeLookup key{
+                .frame_id    = _frame_id,
+                .scope_id    = _scope_id,
+                .scope_index = 0,
+            };
+            const auto found = std::lower_bound(lookup.begin(), lookup.end(), key);
+            return found != lookup.end() && found->frame_id == _frame_id && found->scope_id == _scope_id ?
+                       found->scope_index :
+                       kInvalidSessionIndex;
+        };
+
+        for (std::size_t index = 0; index < scopes.size(); ++index) {
+            GpuScopeRecord& scope  = scopes[index];
+            bool            orphan = false;
+
+            const auto frame = std::lower_bound(
+                frames.begin(),
+                frames.end(),
+                scope.frame_id,
+                [](const GpuFrameRecord& _frame, std::uint64_t _frame_id) {
+                    return _frame.frame_id < _frame_id;
+                }
+            );
+            if (frame == frames.end() || frame->frame_id != scope.frame_id) {
+                orphan = true;
+                if (!_allow_missing) {
+                    Fail(
+                        SessionLoadStatus::ProtocolViolation,
+                        SessionErrorCode::GpuScopeFrameMissing,
+                        "GpuScope references a missing GpuFrame"
+                    );
+                    return false;
+                }
+            } else {
+                const std::size_t frame_index = static_cast<std::size_t>(frame - frames.begin());
+                scope.frame_index             = frame_index;
+                ++frame->scope_count;
+                if (scope.status == ProfileGpuScopeStatus::Error) {
+                    ++frame_error_counts[frame_index];
+                }
+            }
+
+            if (scope.parent_scope_id == 0) {
+                if (scope.depth != 0) {
+                    Fail(
+                        SessionLoadStatus::ProtocolViolation,
+                        SessionErrorCode::GpuScopeRootDepthInvalid,
+                        "root GpuScope has a non-zero depth"
+                    );
+                    return false;
+                }
+            } else {
+                if (scope.depth == 0) {
+                    Fail(
+                        SessionLoadStatus::ProtocolViolation,
+                        SessionErrorCode::GpuScopeParentInvalid,
+                        "non-root GpuScope has zero depth"
+                    );
+                    return false;
+                }
+                const std::uint64_t parent_index = find_scope(scope.frame_id, scope.parent_scope_id);
+                if (parent_index == kInvalidSessionIndex) {
+                    orphan = true;
+                    if (!_allow_missing) {
+                        Fail(
+                            SessionLoadStatus::ProtocolViolation,
+                            SessionErrorCode::GpuScopeParentMissing,
+                            "GpuScope references a missing parent"
+                        );
+                        return false;
+                    }
+                } else {
+                    const GpuScopeRecord& parent = scopes[parent_index];
+                    if (parent.logical_queue != scope.logical_queue ||
+                        parent.native_queue_id != scope.native_queue_id ||
+                        parent.family_id != scope.family_id || parent.source_order != scope.source_order ||
+                        parent.depth != scope.depth - 1 || parent.local_order >= scope.local_order) {
+                        Fail(
+                            SessionLoadStatus::ProtocolViolation,
+                            SessionErrorCode::GpuScopeParentInvalid,
+                            "GpuScope parent topology is inconsistent"
+                        );
+                        return false;
+                    }
+                    scope.parent_index = parent_index;
+                }
+            }
+            if (orphan) {
+                ++session.impl_->summary.orphan_gpu_scope_count;
+            }
+        }
+
+        for (std::size_t index = 0; index < frames.size(); ++index) {
+            const GpuFrameRecord& frame             = frames[index];
+            const bool            observed_too_many = frame.scope_count > frame.admitted_scope_count ||
+                                           frame_error_counts[index] > frame.error_scope_count;
+            const bool intact_frame_mismatch = !_allow_missing &&
+                                               frame.status != ProfileGpuFrameStatus::Invalid &&
+                                               (frame.scope_count != frame.admitted_scope_count ||
+                                                frame_error_counts[index] != frame.error_scope_count);
+            if (observed_too_many || intact_frame_mismatch) {
+                Fail(
+                    SessionLoadStatus::ProtocolViolation,
+                    SessionErrorCode::GpuFrameTotalsMismatch,
+                    "GpuFrame scope totals do not match its records"
+                );
+                return false;
+            }
+        }
+        return true;
+    }
+
+    [[nodiscard]] bool BuildIndexes(bool _forensic) {
+        std::sort(record_sequences.begin(), record_sequences.end());
+        if (std::adjacent_find(record_sequences.begin(), record_sequences.end()) != record_sequences.end()) {
+            Fail(
+                SessionLoadStatus::ProtocolViolation,
+                SessionErrorCode::RecordSequenceDuplicate,
+                "profile record sequence is duplicated"
+            );
+            return false;
+        }
+
+        const bool allow_missing = _forensic || session.impl_->summary.lost_record_count != 0 ||
+                                   session.impl_->summary.unnotified_drop_count != 0;
+        if (!BuildCpuTracks(allow_missing) || !BuildGpuDomainsAndTracks() ||
+            !BuildGpuTopology(allow_missing)) {
+            return false;
+        }
+        session.impl_->valid = true;
+        return true;
+    }
+
+    void ReleaseWorkingState() noexcept {
+        std::vector<std::uint8_t>{}.swap(packet_bytes);
+        std::unordered_map<std::uint64_t, SchemaEntry>{}.swap(schemas);
+        std::unordered_map<std::string_view, SessionStringId>{}.swap(interned_strings);
+        std::vector<std::uint64_t>{}.swap(record_sequences);
+    }
+
+    [[nodiscard]] SessionLoadResult Feed(std::span<const std::uint8_t> _bytes) noexcept {
+        if (!IsReading() || _bytes.empty()) {
+            return result;
+        }
+        try {
+            std::uint64_t next_input_bytes = 0;
+            if (AddOverflow(
+                    result.input_bytes, static_cast<std::uint64_t>(_bytes.size()), next_input_bytes
+                ) ||
+                next_input_bytes > options.limits.max_input_bytes) {
+                Fail(
+                    SessionLoadStatus::LimitExceeded,
+                    SessionErrorCode::LimitExceeded,
+                    "profile input byte limit exceeded",
+                    DecodeStatus::LimitExceeded,
+                    SessionLimitKind::InputBytes,
+                    result.input_bytes
+                );
+                return result;
+            }
+            const std::uint64_t feed_begin_offset = result.input_bytes;
+            result.input_bytes                    = next_input_bytes;
+
+            std::size_t cursor = 0;
+            while (cursor < _bytes.size() && IsReading()) {
+                if (saw_session_end) {
+                    Fail(
+                        SessionLoadStatus::ProtocolViolation,
+                        SessionErrorCode::TrailingDataAfterSessionEnd,
+                        "bytes appear after SessionEnd",
+                        DecodeStatus::Ok,
+                        SessionLimitKind::None,
+                        feed_begin_offset + cursor
+                    );
+                    break;
+                }
+
+                if (expected_packet_bytes == 0) {
+                    const std::size_t header_remaining = kPacketHeaderBytes - packet_bytes.size();
+                    const std::size_t copy_bytes       = std::min(header_remaining, _bytes.size() - cursor);
+                    packet_bytes.insert(
+                        packet_bytes.end(), _bytes.begin() + cursor, _bytes.begin() + cursor + copy_bytes
+                    );
+                    cursor += copy_bytes;
+                    if (packet_bytes.size() < kPacketHeaderBytes) {
+                        continue;
+                    }
+
+                    PacketView         header_view{};
+                    std::size_t        consumed = 0;
+                    const DecodeStatus header_status =
+                        DecodePacket(packet_bytes, options.limits.codec, header_view, consumed);
+                    if (header_status != DecodeStatus::NeedMoreData && header_status != DecodeStatus::Ok) {
+                        FailCodec(
+                            header_status,
+                            SessionErrorCode::CodecHeaderInvalid,
+                            "profile packet header failed validation"
+                        );
+                        break;
+                    }
+                    const std::uint32_t payload_bytes = ReadU32LittleEndian(packet_bytes, 12);
+                    expected_packet_bytes = kPacketHeaderBytes + static_cast<std::size_t>(payload_bytes);
+                    packet_bytes.reserve(expected_packet_bytes);
+                }
+
+                const std::size_t packet_remaining = expected_packet_bytes - packet_bytes.size();
+                const std::size_t copy_bytes       = std::min(packet_remaining, _bytes.size() - cursor);
+                packet_bytes.insert(
+                    packet_bytes.end(), _bytes.begin() + cursor, _bytes.begin() + cursor + copy_bytes
+                );
+                cursor += copy_bytes;
+                if (packet_bytes.size() != expected_packet_bytes) {
+                    continue;
+                }
+
+                PacketView         packet{};
+                std::size_t        consumed = 0;
+                const DecodeStatus decode =
+                    DecodePacket(packet_bytes, options.limits.codec, packet, consumed);
+                if (decode != DecodeStatus::Ok || consumed != expected_packet_bytes) {
+                    FailCodec(
+                        decode == DecodeStatus::Ok ? DecodeStatus::MalformedPayload : decode,
+                        SessionErrorCode::CodecPacketInvalid,
+                        "profile packet failed validation"
+                    );
+                    break;
+                }
+                if (!ProcessPacket(packet)) {
+                    break;
+                }
+
+                result.valid_prefix_bytes += expected_packet_bytes;
+                packet_bytes.clear();
+                expected_packet_bytes = 0;
+            }
+        } catch (const std::bad_alloc&) {
+            Fail(
+                SessionLoadStatus::ResourceExhausted,
+                SessionErrorCode::ResourceAllocationFailed,
+                "profile consumer allocation failed"
+            );
+        } catch (...) {
+            Fail(
+                SessionLoadStatus::ResourceExhausted,
+                SessionErrorCode::UnexpectedFailure,
+                "profile consumer rejected an unexpected allocation failure"
+            );
+        }
+        return result;
+    }
+
+    [[nodiscard]] SessionLoadResult Finish() noexcept {
+        if (!IsReading()) {
+            return result;
+        }
+        try {
+            if (!saw_session_begin) {
+                Fail(
+                    SessionLoadStatus::CorruptData,
+                    SessionErrorCode::SessionBeginMissing,
+                    "profile input has no complete SessionBegin",
+                    DecodeStatus::NeedMoreData
+                );
+                return result;
+            }
+
+            bool forensic = false;
+            if (!packet_bytes.empty()) {
+                result.incomplete_reason = packet_bytes.size() < kPacketHeaderBytes ?
+                                               SessionIncompleteReason::TruncatedHeader :
+                                               SessionIncompleteReason::TruncatedPayload;
+                if (!options.allow_forensic_truncation) {
+                    Fail(
+                        SessionLoadStatus::CorruptData,
+                        SessionErrorCode::TruncatedPacket,
+                        "profile input ends inside a packet",
+                        DecodeStatus::NeedMoreData
+                    );
+                    return result;
+                }
+                forensic = true;
+            } else if (!saw_session_end) {
+                result.incomplete_reason = SessionIncompleteReason::MissingSessionEnd;
+                if (!options.allow_forensic_truncation) {
+                    Fail(
+                        SessionLoadStatus::ProtocolViolation,
+                        SessionErrorCode::SessionEndMissing,
+                        "profile input has no SessionEnd"
+                    );
+                    return result;
+                }
+                forensic = true;
+            }
+
+            if (!BuildIndexes(forensic)) {
+                return result;
+            }
+            if (forensic) {
+                result.incomplete_byte_offset  = result.valid_prefix_bytes;
+                result.incomplete_packet_index = expected_packet_index;
+            }
+            ReleaseWorkingState();
+            result.status = forensic ? SessionLoadStatus::ForensicTruncated : SessionLoadStatus::Complete;
+            diagnostic =
+                forensic ? "valid profile prefix materialized for forensic use" : "profile session loaded";
+        } catch (const std::bad_alloc&) {
+            Fail(
+                SessionLoadStatus::ResourceExhausted,
+                SessionErrorCode::ResourceAllocationFailed,
+                "profile index allocation failed"
+            );
+        } catch (...) {
+            Fail(
+                SessionLoadStatus::ResourceExhausted,
+                SessionErrorCode::UnexpectedFailure,
+                "profile index construction failed"
+            );
+        }
+        return result;
+    }
+
+    SessionLoadOptions options{};
+    SessionLoadResult  result{};
+    const char*        diagnostic{"profile session reader is accepting input"};
+    ProfileSession     session{};
+
+    std::vector<std::uint8_t> packet_bytes{};
+    std::size_t               expected_packet_bytes{0};
+    std::uint64_t             expected_packet_index{0};
+    bool                      saw_session_begin{false};
+    bool                      saw_session_end{false};
+
+    std::unordered_map<std::uint64_t, SchemaEntry>        schemas{};
+    std::unordered_map<std::string_view, SessionStringId> interned_strings{};
+    std::vector<std::uint64_t>                            record_sequences{};
+    std::uint64_t                                         schema_bytes{0};
+    std::uint64_t                                         string_bytes{0};
+};
+
+ProfileSessionReader::ProfileSessionReader(const SessionLoadOptions& _options) noexcept {
+    try {
+        impl_ = new (std::nothrow) Impl(_options);
+    } catch (...) {
+        impl_ = nullptr;
+    }
+}
+
+ProfileSessionReader::~ProfileSessionReader() {
+    delete impl_;
+}
+
+ProfileSessionReader::ProfileSessionReader(ProfileSessionReader&& _other) noexcept :
+    impl_(std::exchange(_other.impl_, nullptr)) {}
+
+ProfileSessionReader& ProfileSessionReader::operator=(ProfileSessionReader&& _other) noexcept {
+    if (this != &_other) {
+        delete impl_;
+        impl_ = std::exchange(_other.impl_, nullptr);
+    }
+    return *this;
+}
+
+SessionLoadResult ProfileSessionReader::Feed(std::span<const std::uint8_t> _bytes) noexcept {
+    return impl_ != nullptr ? impl_->Feed(_bytes) : ResourceExhaustedResult();
+}
+
+SessionLoadResult ProfileSessionReader::Finish() noexcept {
+    return impl_ != nullptr ? impl_->Finish() : ResourceExhaustedResult();
+}
+
+const SessionLoadResult& ProfileSessionReader::Result() const noexcept {
+    static const SessionLoadResult exhausted = ResourceExhaustedResult();
+    return impl_ != nullptr ? impl_->result : exhausted;
+}
+
+std::string_view ProfileSessionReader::DiagnosticMessage() const noexcept {
+    return impl_ != nullptr ? std::string_view(impl_->diagnostic) :
+                              std::string_view("profile session reader allocation failed");
+}
+
+const ProfileSession& ProfileSessionReader::Session() const noexcept {
+    static const ProfileSession empty{};
+    return impl_ != nullptr && impl_->result.HasUsableSession() ? impl_->session : empty;
+}
+
+ProfileSession ProfileSessionReader::TakeSession() noexcept {
+    if (impl_ == nullptr || !impl_->result.HasUsableSession()) {
+        return {};
+    }
+    return std::move(impl_->session);
+}
+
+SessionLoadResult LoadProfileSessionFile(
+    const std::filesystem::path& _path,
+    const SessionLoadOptions&    _options,
+    ProfileSession&              _output
+) noexcept {
+    if (_path.empty()) {
+        SessionLoadResult result{};
+        result.status     = SessionLoadStatus::InvalidArgument;
+        result.error_code = SessionErrorCode::InvalidArgument;
+        return result;
+    }
+
+    try {
+        std::ifstream stream(_path, std::ios::binary | std::ios::ate);
+        if (!stream.is_open()) {
+            SessionLoadResult result{};
+            result.status     = SessionLoadStatus::OpenFailed;
+            result.error_code = SessionErrorCode::FileOpenFailed;
+            return result;
+        }
+        const std::streamoff snapshot = stream.tellg();
+        if (snapshot < 0) {
+            SessionLoadResult result{};
+            result.status     = SessionLoadStatus::ReadFailed;
+            result.error_code = SessionErrorCode::FileReadFailed;
+            return result;
+        }
+        const std::uint64_t snapshot_bytes = static_cast<std::uint64_t>(snapshot);
+        if (snapshot_bytes > _options.limits.max_input_bytes) {
+            SessionLoadResult result{};
+            result.status      = SessionLoadStatus::LimitExceeded;
+            result.error_code  = SessionErrorCode::LimitExceeded;
+            result.limit_kind  = SessionLimitKind::InputBytes;
+            result.input_bytes = snapshot_bytes;
+            return result;
+        }
+        stream.seekg(0);
+        if (!stream.good()) {
+            SessionLoadResult result{};
+            result.status     = SessionLoadStatus::ReadFailed;
+            result.error_code = SessionErrorCode::FileReadFailed;
+            return result;
+        }
+
+        ProfileSessionReader reader(_options);
+        if (reader.Result().status != SessionLoadStatus::Reading) {
+            return reader.Result();
+        }
+
+        std::array<std::uint8_t, kReadBlockBytes> block{};
+        std::uint64_t                             remaining = snapshot_bytes;
+        while (remaining != 0) {
+            const std::size_t request =
+                static_cast<std::size_t>(std::min<std::uint64_t>(remaining, block.size()));
+            stream.read(reinterpret_cast<char*>(block.data()), static_cast<std::streamsize>(request));
+            const std::streamsize read = stream.gcount();
+            if (read != static_cast<std::streamsize>(request)) {
+                SessionLoadResult result = reader.Result();
+                result.status            = SessionLoadStatus::ReadFailed;
+                result.error_code        = SessionErrorCode::FileReadFailed;
+                result.input_bytes       = snapshot_bytes - remaining +
+                                     static_cast<std::uint64_t>(std::max<std::streamsize>(read, 0));
+                return result;
+            }
+
+            const SessionLoadResult fed =
+                reader.Feed(std::span<const std::uint8_t>(block.data(), static_cast<std::size_t>(read)));
+            if (fed.IsTerminal()) {
+                return fed;
+            }
+            remaining -= static_cast<std::uint64_t>(read);
+        }
+
+        const SessionLoadResult finished = reader.Finish();
+        if (finished.HasUsableSession()) {
+            _output = reader.TakeSession();
+        }
+        return finished;
+    } catch (const std::bad_alloc&) {
+        return ResourceExhaustedResult();
+    } catch (...) {
+        SessionLoadResult result{};
+        result.status     = SessionLoadStatus::ReadFailed;
+        result.error_code = SessionErrorCode::UnexpectedFailure;
+        return result;
+    }
+}
+
+} // namespace Moer::ProfileDump

--- a/source/tool/profile_consumer/source/ProfileSession.cpp
+++ b/source/tool/profile_consumer/source/ProfileSession.cpp
@@ -394,7 +394,10 @@ struct ProfileSessionReader::Impl {
         std::vector<std::size_t> task_indices{};
     };
 
-    explicit Impl(const SessionLoadOptions& _options) noexcept : options(_options) {
+    // ProfileSession::Impl owns standard containers whose constructors may
+    // throw. Let the public reader constructor's catch-all convert any such
+    // construction failure into the stable ResourceExhausted state.
+    explicit Impl(const SessionLoadOptions& _options) : options(_options) {
         session.impl_ = new (std::nothrow) ProfileSession::Impl();
         if (session.impl_ == nullptr) {
             result.status     = SessionLoadStatus::ResourceExhausted;
@@ -7160,6 +7163,10 @@ struct ProfileSessionReader::Impl {
 };
 
 ProfileSessionReader::ProfileSessionReader(const SessionLoadOptions& _options) noexcept {
+    static_assert(
+        !std::is_nothrow_constructible_v<Impl, const SessionLoadOptions&>,
+        "reader implementation construction must propagate to the public catch boundary"
+    );
     try {
         impl_ = new (std::nothrow) Impl(_options);
     } catch (...) {

--- a/source/tool/profile_consumer/source/ProfileSession.cpp
+++ b/source/tool/profile_consumer/source/ProfileSession.cpp
@@ -372,6 +372,12 @@ struct ProfileSessionReader::Impl {
         }
     };
 
+    struct RecordSequenceDemand {
+        std::uint64_t release_sequence{0};
+        std::uint64_t deadline_sequence{0};
+        std::uint64_t count{0};
+    };
+
     explicit Impl(const SessionLoadOptions& _options) noexcept : options(_options) {
         session.impl_ = new (std::nothrow) ProfileSession::Impl();
         if (session.impl_ == nullptr) {
@@ -442,6 +448,23 @@ struct ProfileSessionReader::Impl {
             );
             return false;
         }
+        return true;
+    }
+
+    [[nodiscard]] bool ChargeTopologyWork(std::uint64_t _count) noexcept {
+        std::uint64_t next_topology_work_items = 0;
+        if (AddOverflow(topology_work_items, _count, next_topology_work_items) ||
+            next_topology_work_items > options.limits.max_topology_work_items) {
+            Fail(
+                SessionLoadStatus::LimitExceeded,
+                SessionErrorCode::LimitExceeded,
+                "profile topology work-item limit exceeded",
+                DecodeStatus::LimitExceeded,
+                SessionLimitKind::TopologyWorkItems
+            );
+            return false;
+        }
+        topology_work_items = next_topology_work_items;
         return true;
     }
 
@@ -1009,6 +1032,155 @@ struct ProfileSessionReader::Impl {
         return true;
     }
 
+    [[nodiscard]] bool ValidateLossSequenceAllocation() {
+        struct SequenceDemand {
+            std::uint64_t release_sequence{0};
+            std::uint64_t deadline_sequence{0};
+            std::uint64_t count{0};
+        };
+        std::vector<std::uint64_t>  occupied_sequences = record_sequences;
+        std::vector<SequenceDemand> residual_demands;
+        residual_demands.reserve(session.impl_->losses.size());
+
+        for (const ProfileLossRecord& loss : session.impl_->losses) {
+            if (loss.first_sequence == 0 ||
+                (loss.record_count == 1 && loss.first_sequence != loss.last_sequence)) {
+                Fail(
+                    SessionLoadStatus::ProtocolViolation,
+                    SessionErrorCode::LossPayloadInvalid,
+                    "profile loss notice sequence extrema are not emitted-record sequences"
+                );
+                return false;
+            }
+
+            occupied_sequences.push_back(loss.first_sequence);
+            if (loss.record_count != 1) {
+                occupied_sequences.push_back(loss.last_sequence);
+            }
+            if (loss.record_count > 2) {
+                residual_demands.push_back({
+                    .release_sequence  = loss.first_sequence + 1,
+                    .deadline_sequence = loss.last_sequence - 1,
+                    .count             = loss.record_count - 2,
+                });
+            }
+        }
+
+        std::sort(occupied_sequences.begin(), occupied_sequences.end());
+        if (std::adjacent_find(occupied_sequences.begin(), occupied_sequences.end()) !=
+            occupied_sequences.end()) {
+            Fail(
+                SessionLoadStatus::ProtocolViolation,
+                SessionErrorCode::RecordSequenceInvalid,
+                "profile records and loss notices claim the same allocated sequence"
+            );
+            return false;
+        }
+
+        if (residual_demands.empty()) {
+            return true;
+        }
+        std::sort(
+            residual_demands.begin(),
+            residual_demands.end(),
+            [](const SequenceDemand& _left, const SequenceDemand& _right) {
+                if (_left.release_sequence != _right.release_sequence) {
+                    return _left.release_sequence < _right.release_sequence;
+                }
+                return _left.deadline_sequence < _right.deadline_sequence;
+            }
+        );
+
+        struct PendingDemand {
+            std::uint64_t deadline_sequence{0};
+            std::uint64_t remaining_count{0};
+        };
+        const auto later_deadline = [](const PendingDemand& _left, const PendingDemand& _right) {
+            return _left.deadline_sequence > _right.deadline_sequence;
+        };
+        std::priority_queue<PendingDemand, std::vector<PendingDemand>, decltype(later_deadline)>
+            pending_demands(later_deadline);
+
+        const auto fail_allocation = [&]() {
+            Fail(
+                SessionLoadStatus::ProtocolViolation,
+                SessionErrorCode::RecordSequenceInvalid,
+                "profile loss notices cannot claim distinct allocated record sequences"
+            );
+            return false;
+        };
+
+        std::size_t   demand_index             = 0;
+        std::size_t   occupied_index           = 0;
+        std::uint64_t position                 = residual_demands.front().release_sequence;
+        bool          sequence_space_exhausted = false;
+        while (demand_index < residual_demands.size() || !pending_demands.empty()) {
+            if (sequence_space_exhausted) {
+                return fail_allocation();
+            }
+            while (demand_index < residual_demands.size() &&
+                   residual_demands[demand_index].release_sequence <= position) {
+                pending_demands.push({
+                    .deadline_sequence = residual_demands[demand_index].deadline_sequence,
+                    .remaining_count   = residual_demands[demand_index].count,
+                });
+                ++demand_index;
+            }
+            if (pending_demands.empty()) {
+                position = residual_demands[demand_index].release_sequence;
+                continue;
+            }
+            if (pending_demands.top().deadline_sequence < position) {
+                return fail_allocation();
+            }
+
+            occupied_index = static_cast<std::size_t>(
+                std::lower_bound(
+                    occupied_sequences.begin() + occupied_index, occupied_sequences.end(), position
+                ) -
+                occupied_sequences.begin()
+            );
+            if (occupied_index < occupied_sequences.size() &&
+                occupied_sequences[occupied_index] == position) {
+                if (position == std::numeric_limits<std::uint64_t>::max()) {
+                    return fail_allocation();
+                }
+                ++position;
+                ++occupied_index;
+                continue;
+            }
+
+            PendingDemand demand = pending_demands.top();
+            pending_demands.pop();
+            std::uint64_t batch_end = demand.deadline_sequence;
+            if (occupied_index < occupied_sequences.size() && occupied_sequences[occupied_index] > position) {
+                batch_end = std::min(batch_end, occupied_sequences[occupied_index] - 1);
+            }
+            if (demand_index < residual_demands.size() &&
+                residual_demands[demand_index].release_sequence > position) {
+                batch_end = std::min(batch_end, residual_demands[demand_index].release_sequence - 1);
+            }
+            if (batch_end < position) {
+                return fail_allocation();
+            }
+
+            const std::uint64_t available = batch_end - position + 1;
+            const std::uint64_t assigned  = std::min(available, demand.remaining_count);
+            demand.remaining_count -= assigned;
+            if (assigned < available) {
+                position += assigned;
+            } else if (batch_end == std::numeric_limits<std::uint64_t>::max()) {
+                sequence_space_exhausted = true;
+            } else {
+                position = batch_end + 1;
+            }
+            if (demand.remaining_count != 0) {
+                pending_demands.push(demand);
+            }
+        }
+        return true;
+    }
+
     [[nodiscard]] bool ProcessPacket(const PacketView& _packet) {
         if (!CheckCountLimit(
                 session.impl_->summary.packet_count,
@@ -1118,9 +1290,14 @@ struct ProfileSessionReader::Impl {
         return true;
     }
 
-    [[nodiscard]] bool BuildCpuTracks(bool _allow_missing, std::uint64_t& _required_cpu_drops) {
+    [[nodiscard]] bool BuildCpuTracks(
+        bool                               _allow_missing,
+        std::uint64_t&                     _required_cpu_drops,
+        std::vector<RecordSequenceDemand>& _sequence_demands
+    ) {
         _required_cpu_drops = 0;
-        auto& scopes        = session.impl_->cpu_scopes;
+        _sequence_demands.clear();
+        auto& scopes = session.impl_->cpu_scopes;
         std::sort(
             scopes.begin(),
             scopes.end(),
@@ -1230,6 +1407,9 @@ struct ProfileSessionReader::Impl {
                     auto          ending_depth          = ending_parents_by_depth.lower_bound(scope.depth);
                     while (ending_depth != ending_parents_by_depth.begin()) {
                         --ending_depth;
+                        if (!ChargeTopologyWork(static_cast<std::uint64_t>(ending_depth->second.size()))) {
+                            return false;
+                        }
                         for (const std::uint64_t candidate_index : ending_depth->second) {
                             const CpuScopeRecord& candidate = scopes[candidate_index];
                             if (candidate.sequence > scope.sequence &&
@@ -1292,13 +1472,7 @@ struct ProfileSessionReader::Impl {
             track_begin = track_end;
         }
 
-        struct CpuSequenceDemand {
-            std::uint64_t release_sequence{0};
-            std::uint64_t deadline_sequence{0};
-            std::uint64_t count{0};
-        };
-        std::vector<CpuSequenceDemand> sequence_demands;
-        sequence_demands.reserve(gap_events.size());
+        _sequence_demands.reserve(gap_events.size());
         const auto add_sequence_demand =
             [&](std::uint64_t _lower_sequence, std::uint64_t _upper_sequence, std::uint64_t _count) {
                 if (_count == 0) {
@@ -1322,7 +1496,7 @@ struct ProfileSessionReader::Impl {
                     return false;
                 }
                 _required_cpu_drops = required_cpu_drops;
-                sequence_demands.push_back({
+                _sequence_demands.push_back({
                     .release_sequence  = _lower_sequence + 1,
                     .deadline_sequence = _upper_sequence - 1,
                     .count             = _count,
@@ -1390,9 +1564,9 @@ struct ProfileSessionReader::Impl {
         }
 
         std::sort(
-            sequence_demands.begin(),
-            sequence_demands.end(),
-            [](const CpuSequenceDemand& _left, const CpuSequenceDemand& _right) {
+            _sequence_demands.begin(),
+            _sequence_demands.end(),
+            [](const RecordSequenceDemand& _left, const RecordSequenceDemand& _right) {
                 if (_left.release_sequence != _right.release_sequence) {
                     return _left.release_sequence < _right.release_sequence;
                 }
@@ -1414,18 +1588,18 @@ struct ProfileSessionReader::Impl {
                       pending_demands(later_deadline);
         std::size_t   demand_index   = 0;
         std::size_t   observed_index = 0;
-        std::uint64_t position = sequence_demands.empty() ? 0 : sequence_demands.front().release_sequence;
-        while (demand_index < sequence_demands.size() || !pending_demands.empty()) {
-            while (demand_index < sequence_demands.size() &&
-                   sequence_demands[demand_index].release_sequence <= position) {
+        std::uint64_t position = _sequence_demands.empty() ? 0 : _sequence_demands.front().release_sequence;
+        while (demand_index < _sequence_demands.size() || !pending_demands.empty()) {
+            while (demand_index < _sequence_demands.size() &&
+                   _sequence_demands[demand_index].release_sequence <= position) {
                 pending_demands.push({
-                    .deadline_sequence = sequence_demands[demand_index].deadline_sequence,
-                    .remaining_count   = sequence_demands[demand_index].count,
+                    .deadline_sequence = _sequence_demands[demand_index].deadline_sequence,
+                    .remaining_count   = _sequence_demands[demand_index].count,
                 });
                 ++demand_index;
             }
             if (pending_demands.empty()) {
-                position = sequence_demands[demand_index].release_sequence;
+                position = _sequence_demands[demand_index].release_sequence;
                 continue;
             }
             if (pending_demands.top().deadline_sequence < position) {
@@ -1452,8 +1626,8 @@ struct ProfileSessionReader::Impl {
             if (observed_index < record_sequences.size()) {
                 batch_end = std::min(batch_end, record_sequences[observed_index]);
             }
-            if (demand_index < sequence_demands.size()) {
-                batch_end = std::min(batch_end, sequence_demands[demand_index].release_sequence);
+            if (demand_index < _sequence_demands.size()) {
+                batch_end = std::min(batch_end, _sequence_demands[demand_index].release_sequence);
             }
             const std::uint64_t available = batch_end - position;
             const std::uint64_t assigned  = std::min(available, demand.remaining_count);
@@ -1462,6 +1636,481 @@ struct ProfileSessionReader::Impl {
             if (demand.remaining_count != 0) {
                 pending_demands.push(demand);
             }
+        }
+        return true;
+    }
+
+    [[nodiscard]] bool
+    ValidateCpuLossCompatibility(std::span<const RecordSequenceDemand> _cpu_sequence_demands) {
+        if (_cpu_sequence_demands.empty()) {
+            return true;
+        }
+
+        struct LossBucket {
+            std::uint64_t release_sequence{0};
+            std::uint64_t deadline_sequence{0};
+            std::uint64_t count{0};
+        };
+
+        std::uint64_t input_work = static_cast<std::uint64_t>(session.impl_->losses.size());
+        if (AddOverflow(input_work, static_cast<std::uint64_t>(_cpu_sequence_demands.size()), input_work)) {
+            Fail(
+                SessionLoadStatus::LimitExceeded,
+                SessionErrorCode::LimitExceeded,
+                "CPU/Loss topology input count overflows",
+                DecodeStatus::LimitExceeded,
+                SessionLimitKind::TopologyWorkItems
+            );
+            return false;
+        }
+        if (!ChargeTopologyWork(input_work)) {
+            return false;
+        }
+
+        std::uint64_t loss_bucket_count = 0;
+        std::uint64_t loss_bucket_total = 0;
+        for (const ProfileLossRecord& loss : session.impl_->losses) {
+            std::uint64_t buckets_for_loss = 1;
+            if (loss.record_count != 1) {
+                ++buckets_for_loss;
+            }
+            if (loss.record_count > 2) {
+                ++buckets_for_loss;
+            }
+            if (AddOverflow(loss_bucket_count, buckets_for_loss, loss_bucket_count) ||
+                AddOverflow(loss_bucket_total, loss.record_count, loss_bucket_total)) {
+                Fail(
+                    SessionLoadStatus::ProtocolViolation,
+                    SessionErrorCode::LossTotalsOverflow,
+                    "profile noticed-loss bucket total overflows"
+                );
+                return false;
+            }
+        }
+        std::uint64_t cpu_demand_total = 0;
+        for (const RecordSequenceDemand& demand : _cpu_sequence_demands) {
+            if (AddOverflow(cpu_demand_total, demand.count, cpu_demand_total)) {
+                Fail(
+                    SessionLoadStatus::ProtocolViolation,
+                    SessionErrorCode::CpuScopeTopologyInvalid,
+                    "CPU sequence-backed loss demand overflows"
+                );
+                return false;
+            }
+        }
+        if (loss_bucket_total != session.impl_->summary.lost_record_count ||
+            cpu_demand_total > loss_bucket_total) {
+            Fail(
+                SessionLoadStatus::ProtocolViolation,
+                SessionErrorCode::CpuScopeParentMissing,
+                "CPU hierarchy deficits exceed noticed allocated-record losses"
+            );
+            return false;
+        }
+
+        std::uint64_t loss_critical_count   = 0;
+        std::uint64_t demand_critical_count = 0;
+        std::uint64_t critical_point_count  = 0;
+        std::uint64_t construction_work     = 0;
+        if (AddOverflow(loss_bucket_count, loss_bucket_count, loss_critical_count) ||
+            AddOverflow(
+                static_cast<std::uint64_t>(_cpu_sequence_demands.size()),
+                static_cast<std::uint64_t>(_cpu_sequence_demands.size()),
+                demand_critical_count
+            ) ||
+            AddOverflow(loss_critical_count, demand_critical_count, critical_point_count) ||
+            AddOverflow(loss_bucket_count, critical_point_count, construction_work) ||
+            loss_bucket_count > static_cast<std::uint64_t>(std::numeric_limits<std::size_t>::max()) ||
+            critical_point_count > static_cast<std::uint64_t>(std::numeric_limits<std::size_t>::max())) {
+            Fail(
+                SessionLoadStatus::LimitExceeded,
+                SessionErrorCode::LimitExceeded,
+                "CPU/Loss topology preprocessing exceeds the addressable range",
+                DecodeStatus::LimitExceeded,
+                SessionLimitKind::TopologyWorkItems
+            );
+            return false;
+        }
+        if (!ChargeTopologyWork(construction_work)) {
+            return false;
+        }
+
+        std::vector<LossBucket> loss_buckets;
+        loss_buckets.reserve(static_cast<std::size_t>(loss_bucket_count));
+        std::vector<std::uint64_t> critical_points;
+        critical_points.reserve(static_cast<std::size_t>(critical_point_count));
+
+        const auto add_loss_bucket = [&](std::uint64_t _release, std::uint64_t _deadline, std::uint64_t _count
+                                     ) {
+            if (_count == 0) {
+                return;
+            }
+            loss_buckets.push_back({
+                .release_sequence  = _release,
+                .deadline_sequence = _deadline,
+                .count             = _count,
+            });
+            critical_points.push_back(_release);
+            critical_points.push_back(_deadline);
+        };
+        for (const ProfileLossRecord& loss : session.impl_->losses) {
+            add_loss_bucket(loss.first_sequence, loss.first_sequence, 1);
+            if (loss.record_count != 1) {
+                add_loss_bucket(loss.last_sequence, loss.last_sequence, 1);
+            }
+            if (loss.record_count > 2) {
+                add_loss_bucket(loss.first_sequence + 1, loss.last_sequence - 1, loss.record_count - 2);
+            }
+        }
+        for (const RecordSequenceDemand& demand : _cpu_sequence_demands) {
+            critical_points.push_back(demand.release_sequence);
+            critical_points.push_back(demand.deadline_sequence);
+        }
+
+        // std::sort is introspective O(N log N). Charge one abstract work item
+        // per element and merge level before invoking it so preprocessing cannot
+        // escape the session-wide topology budget.
+        std::uint64_t sort_width = 1;
+        while (sort_width < critical_point_count) {
+            if (!ChargeTopologyWork(critical_point_count)) {
+                return false;
+            }
+            if (sort_width > std::numeric_limits<std::uint64_t>::max() / 2) {
+                break;
+            }
+            sort_width *= 2;
+        }
+        std::sort(critical_points.begin(), critical_points.end());
+        if (!ChargeTopologyWork(critical_point_count)) {
+            return false;
+        }
+        critical_points.erase(
+            std::unique(critical_points.begin(), critical_points.end()), critical_points.end()
+        );
+
+        struct SequenceSegment {
+            std::uint64_t begin{0};
+            std::uint64_t end{0};
+            std::uint64_t capacity{0};
+        };
+        std::uint64_t maximum_segment_count = 0;
+        if (!critical_points.empty()) {
+            if (AddOverflow(
+                    static_cast<std::uint64_t>(critical_points.size()),
+                    static_cast<std::uint64_t>(critical_points.size()),
+                    maximum_segment_count
+                )) {
+                Fail(
+                    SessionLoadStatus::LimitExceeded,
+                    SessionErrorCode::LimitExceeded,
+                    "CPU/Loss sequence segmentation overflows",
+                    DecodeStatus::LimitExceeded,
+                    SessionLimitKind::TopologyWorkItems
+                );
+                return false;
+            }
+            --maximum_segment_count;
+        }
+        std::uint64_t segmentation_work = maximum_segment_count;
+        if (AddOverflow(
+                segmentation_work, static_cast<std::uint64_t>(record_sequences.size()), segmentation_work
+            ) ||
+            maximum_segment_count > static_cast<std::uint64_t>(std::numeric_limits<std::size_t>::max())) {
+            Fail(
+                SessionLoadStatus::LimitExceeded,
+                SessionErrorCode::LimitExceeded,
+                "CPU/Loss sequence segmentation exceeds the addressable range",
+                DecodeStatus::LimitExceeded,
+                SessionLimitKind::TopologyWorkItems
+            );
+            return false;
+        }
+        if (!ChargeTopologyWork(segmentation_work)) {
+            return false;
+        }
+
+        std::vector<SequenceSegment> segments;
+        segments.reserve(static_cast<std::size_t>(maximum_segment_count));
+        std::size_t observed_index = 0;
+        const auto  add_segment    = [&](std::uint64_t _begin, std::uint64_t _end) {
+            while (observed_index < record_sequences.size() && record_sequences[observed_index] < _begin) {
+                ++observed_index;
+            }
+            const std::size_t observed_begin = observed_index;
+            while (observed_index < record_sequences.size() && record_sequences[observed_index] <= _end) {
+                ++observed_index;
+            }
+            const std::uint64_t observed_count = static_cast<std::uint64_t>(observed_index - observed_begin);
+            const std::uint64_t span_minus_one = _end - _begin;
+            std::uint64_t       available      = 0;
+            if (span_minus_one == std::numeric_limits<std::uint64_t>::max()) {
+                // The full uint64 domain has 2^64 values, which cannot itself
+                // be represented. The available count is representable after
+                // excluding any observed sequence, or can be capped directly
+                // by the total flow when none are observed.
+                available = observed_count == 0 ?
+                                    loss_bucket_total :
+                                    std::numeric_limits<std::uint64_t>::max() - (observed_count - 1);
+            } else {
+                const std::uint64_t span = span_minus_one + 1;
+                available                = observed_count < span ? span - observed_count : 0;
+            }
+            const std::uint64_t capacity = std::min(available, loss_bucket_total);
+            if (capacity != 0) {
+                segments.push_back({
+                        .begin    = _begin,
+                        .end      = _end,
+                        .capacity = capacity,
+                });
+            }
+        };
+        for (std::size_t index = 0; index < critical_points.size(); ++index) {
+            const std::uint64_t point = critical_points[index];
+            add_segment(point, point);
+            if (index + 1 < critical_points.size() && point != std::numeric_limits<std::uint64_t>::max() &&
+                critical_points[index + 1] > point + 1) {
+                add_segment(point + 1, critical_points[index + 1] - 1);
+            }
+        }
+
+        std::uint64_t graph_node_work = 3;
+        const auto    add_node_work   = [&](std::uint64_t _count) {
+            return !AddOverflow(graph_node_work, _count, graph_node_work);
+        };
+        if (!add_node_work(static_cast<std::uint64_t>(loss_buckets.size())) ||
+            !add_node_work(static_cast<std::uint64_t>(segments.size())) ||
+            !add_node_work(static_cast<std::uint64_t>(segments.size())) ||
+            !add_node_work(static_cast<std::uint64_t>(_cpu_sequence_demands.size())) ||
+            graph_node_work > static_cast<std::uint64_t>(std::numeric_limits<std::size_t>::max())) {
+            Fail(
+                SessionLoadStatus::LimitExceeded,
+                SessionErrorCode::LimitExceeded,
+                "CPU/Loss topology graph exceeds the addressable node range",
+                DecodeStatus::LimitExceeded,
+                SessionLimitKind::TopologyWorkItems
+            );
+            return false;
+        }
+        if (!ChargeTopologyWork(graph_node_work)) {
+            return false;
+        }
+
+        struct FlowNetwork {
+            struct Edge {
+                std::size_t   target{0};
+                std::size_t   reverse_index{0};
+                std::uint64_t capacity{0};
+            };
+
+            explicit FlowNetwork(Impl& _owner, std::size_t _node_count) :
+                owner(&_owner),
+                edges(_node_count),
+                parent_nodes(_node_count),
+                parent_edges(_node_count),
+                pending_nodes(_node_count) {}
+
+            void AddEdge(std::size_t _source, std::size_t _target, std::uint64_t _capacity) {
+                const std::size_t source_reverse = edges[_target].size();
+                const std::size_t target_reverse = edges[_source].size();
+                edges[_source].push_back({
+                    .target        = _target,
+                    .reverse_index = source_reverse,
+                    .capacity      = _capacity,
+                });
+                edges[_target].push_back({
+                    .target        = _source,
+                    .reverse_index = target_reverse,
+                    .capacity      = 0,
+                });
+            }
+
+            [[nodiscard]] bool
+            MaxFlow(std::size_t _source, std::size_t _sink, std::uint64_t _target, std::uint64_t& _flow) {
+                constexpr std::size_t unreached = std::numeric_limits<std::size_t>::max();
+                _flow                           = 0;
+                while (_flow < _target) {
+                    if (!owner->ChargeTopologyWork(static_cast<std::uint64_t>(parent_nodes.size()))) {
+                        return false;
+                    }
+                    std::fill(parent_nodes.begin(), parent_nodes.end(), unreached);
+                    parent_nodes[_source]        = _source;
+                    std::size_t pending_begin    = 0;
+                    std::size_t pending_end      = 0;
+                    pending_nodes[pending_end++] = _source;
+
+                    while (pending_begin < pending_end && parent_nodes[_sink] == unreached) {
+                        const std::size_t node = pending_nodes[pending_begin++];
+                        if (!owner->ChargeTopologyWork(static_cast<std::uint64_t>(edges[node].size()))) {
+                            return false;
+                        }
+                        for (std::size_t edge_index = 0; edge_index < edges[node].size(); ++edge_index) {
+                            const Edge& edge = edges[node][edge_index];
+                            if (edge.capacity != 0 && parent_nodes[edge.target] == unreached) {
+                                parent_nodes[edge.target]    = node;
+                                parent_edges[edge.target]    = edge_index;
+                                pending_nodes[pending_end++] = edge.target;
+                                if (edge.target == _sink) {
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                    if (parent_nodes[_sink] == unreached) {
+                        return true;
+                    }
+
+                    std::uint64_t augment = _target - _flow;
+                    for (std::size_t node = _sink; node != _source; node = parent_nodes[node]) {
+                        if (!owner->ChargeTopologyWork(1)) {
+                            return false;
+                        }
+                        const Edge& edge = edges[parent_nodes[node]][parent_edges[node]];
+                        augment          = std::min(augment, edge.capacity);
+                    }
+
+                    for (std::size_t node = _sink; node != _source; node = parent_nodes[node]) {
+                        if (!owner->ChargeTopologyWork(1)) {
+                            return false;
+                        }
+                        Edge& edge = edges[parent_nodes[node]][parent_edges[node]];
+                        edge.capacity -= augment;
+                        edges[node][edge.reverse_index].capacity += augment;
+                    }
+                    _flow += augment;
+                }
+                return true;
+            }
+
+            Impl*                          owner{nullptr};
+            std::vector<std::vector<Edge>> edges;
+            std::vector<std::size_t>       parent_nodes;
+            std::vector<std::size_t>       parent_edges;
+            std::vector<std::size_t>       pending_nodes;
+        };
+
+        const std::size_t source_node       = 0;
+        const std::size_t loss_base         = 1;
+        const std::size_t segment_in_base   = loss_base + loss_buckets.size();
+        const std::size_t segment_out_base  = segment_in_base + segments.size();
+        const std::size_t cpu_demand_base   = segment_out_base + segments.size();
+        const std::size_t dummy_demand_node = cpu_demand_base + _cpu_sequence_demands.size();
+        const std::size_t sink_node         = dummy_demand_node + 1;
+        FlowNetwork       network(*this, sink_node + 1);
+        const auto        add_edge = [&](std::size_t _source, std::size_t _target, std::uint64_t _capacity) {
+            if (!ChargeTopologyWork(1)) {
+                return false;
+            }
+            network.AddEdge(_source, _target, _capacity);
+            return true;
+        };
+
+        for (std::size_t index = 0; index < loss_buckets.size(); ++index) {
+            if (!add_edge(source_node, loss_base + index, loss_buckets[index].count)) {
+                return false;
+            }
+        }
+        for (std::size_t index = 0; index < segments.size(); ++index) {
+            if (!add_edge(segment_in_base + index, segment_out_base + index, segments[index].capacity)) {
+                return false;
+            }
+        }
+        for (std::size_t index = 0; index < _cpu_sequence_demands.size(); ++index) {
+            if (!add_edge(cpu_demand_base + index, sink_node, _cpu_sequence_demands[index].count)) {
+                return false;
+            }
+        }
+        if (!add_edge(dummy_demand_node, sink_node, loss_bucket_total - cpu_demand_total)) {
+            return false;
+        }
+
+        const auto charge_segment_search = [&]() {
+            std::uint64_t remaining = static_cast<std::uint64_t>(segments.size());
+            std::uint64_t work      = 0;
+            while (remaining != 0) {
+                ++work;
+                remaining /= 2;
+            }
+            return ChargeTopologyWork(work);
+        };
+        for (std::size_t loss_index = 0; loss_index < loss_buckets.size(); ++loss_index) {
+            const LossBucket& bucket = loss_buckets[loss_index];
+            if (!charge_segment_search()) {
+                return false;
+            }
+            auto segment_it = std::lower_bound(
+                segments.begin(),
+                segments.end(),
+                bucket.release_sequence,
+                [](const SequenceSegment& _segment, std::uint64_t _sequence) {
+                    return _segment.end < _sequence;
+                }
+            );
+            for (; segment_it != segments.end() && segment_it->begin <= bucket.deadline_sequence;
+                 ++segment_it) {
+                if (!ChargeTopologyWork(1)) {
+                    return false;
+                }
+                const std::size_t segment_index = static_cast<std::size_t>(segment_it - segments.begin());
+                const SequenceSegment& segment  = segments[segment_index];
+                if (segment.begin >= bucket.release_sequence && segment.end <= bucket.deadline_sequence &&
+                    !add_edge(
+                        loss_base + loss_index,
+                        segment_in_base + segment_index,
+                        std::min(bucket.count, segment.capacity)
+                    )) {
+                    return false;
+                }
+            }
+        }
+        for (std::size_t segment_index = 0; segment_index < segments.size(); ++segment_index) {
+            if (!add_edge(
+                    segment_out_base + segment_index, dummy_demand_node, segments[segment_index].capacity
+                )) {
+                return false;
+            }
+        }
+        for (std::size_t demand_index = 0; demand_index < _cpu_sequence_demands.size(); ++demand_index) {
+            const RecordSequenceDemand& demand = _cpu_sequence_demands[demand_index];
+            if (!charge_segment_search()) {
+                return false;
+            }
+            auto segment_it = std::lower_bound(
+                segments.begin(),
+                segments.end(),
+                demand.release_sequence,
+                [](const SequenceSegment& _segment, std::uint64_t _sequence) {
+                    return _segment.end < _sequence;
+                }
+            );
+            for (; segment_it != segments.end() && segment_it->begin <= demand.deadline_sequence;
+                 ++segment_it) {
+                if (!ChargeTopologyWork(1)) {
+                    return false;
+                }
+                const std::size_t segment_index = static_cast<std::size_t>(segment_it - segments.begin());
+                const SequenceSegment& segment  = segments[segment_index];
+                if (segment.begin >= demand.release_sequence && segment.end <= demand.deadline_sequence &&
+                    !add_edge(
+                        segment_out_base + segment_index,
+                        cpu_demand_base + demand_index,
+                        std::min(segment.capacity, demand.count)
+                    )) {
+                    return false;
+                }
+            }
+        }
+
+        std::uint64_t allocated_loss_count = 0;
+        if (!network.MaxFlow(source_node, sink_node, loss_bucket_total, allocated_loss_count)) {
+            return false;
+        }
+        if (allocated_loss_count != loss_bucket_total) {
+            Fail(
+                SessionLoadStatus::ProtocolViolation,
+                SessionErrorCode::CpuScopeParentMissing,
+                "noticed Loss intervals cannot jointly explain missing CPU parent sequences"
+            );
+            return false;
         }
         return true;
     }
@@ -1632,22 +2281,8 @@ struct ProfileSessionReader::Impl {
         auto& frames = session.impl_->gpu_frames;
         auto& scopes = session.impl_->gpu_scopes;
 
-        std::uint64_t topology_work_items  = 0;
-        const auto    charge_topology_work = [&](std::uint64_t _count) {
-            std::uint64_t next_topology_work_items = 0;
-            if (AddOverflow(topology_work_items, _count, next_topology_work_items) ||
-                next_topology_work_items > options.limits.max_topology_work_items) {
-                Fail(
-                    SessionLoadStatus::LimitExceeded,
-                    SessionErrorCode::LimitExceeded,
-                    "GPU topology work-item limit exceeded",
-                    DecodeStatus::LimitExceeded,
-                    SessionLimitKind::TopologyWorkItems
-                );
-                return false;
-            }
-            topology_work_items = next_topology_work_items;
-            return true;
+        const auto charge_topology_work = [&](std::uint64_t _count) {
+            return ChargeTopologyWork(_count);
         };
         std::vector<std::uint64_t> frame_error_counts(frames.size(), 0);
         std::vector<std::uint8_t>  frame_root_partition_ambiguous(frames.size(), 0);
@@ -4080,12 +4715,12 @@ struct ProfileSessionReader::Impl {
             }
         }
         if (session.impl_->summary.has_session_end) {
-            const std::uint64_t total_drop_budget = session.impl_->summary.session_end_records_dropped;
+            const std::uint64_t total_drop_budget = session.impl_->summary.lost_record_count;
             if (required_gpu_drops > total_drop_budget) {
                 Fail(
                     SessionLoadStatus::ProtocolViolation,
                     SessionErrorCode::GpuFrameTotalsMismatch,
-                    "CPU/GPU deficits exceed the session record-loss budget"
+                    "CPU/GPU deficits exceed the noticed allocated-record loss budget"
                 );
                 return false;
             }
@@ -4207,36 +4842,34 @@ struct ProfileSessionReader::Impl {
             );
             return false;
         }
-        if (session.impl_->summary.has_session_end) {
-            std::uint64_t maximum_assigned_sequence = 0;
-            if (AddOverflow(
-                    session.impl_->summary.session_end_records_written,
-                    session.impl_->summary.session_end_records_dropped,
-                    maximum_assigned_sequence
-                ) ||
-                (!record_sequences.empty() && record_sequences.back() > maximum_assigned_sequence)) {
-                Fail(
-                    SessionLoadStatus::ProtocolViolation,
-                    SessionErrorCode::RecordSequenceInvalid,
-                    "profile record sequence exceeds the producer allocation bound"
-                );
-                return false;
-            }
+        // ProfileDump v3 does not encode the last reserved sequence.
+        // SessionEnd::records_dropped mixes pre-reservation attempts with
+        // sequence-backed losses, while value validation/encoding can consume a
+        // sequence without incrementing that aggregate. Therefore neither
+        // written+dropped nor written+noticed is a valid sequence frontier.
+        if (!ValidateLossSequenceAllocation()) {
+            return false;
         }
 
-        const bool allow_missing = _forensic || session.impl_->summary.lost_record_count != 0 ||
-                                   session.impl_->summary.unnotified_drop_count != 0;
+        // Only a Loss notice proves that an allocated record sequence was
+        // dropped. Unnotified SessionEnd attempts remain useful telemetry, but
+        // cannot justify a missing CPU/GPU record.
+        const bool    allow_missing      = _forensic || session.impl_->summary.lost_record_count != 0;
         std::uint64_t required_cpu_drops = 0;
-        if (!BuildCpuTracks(allow_missing, required_cpu_drops)) {
+        std::vector<RecordSequenceDemand> cpu_sequence_demands;
+        if (!BuildCpuTracks(allow_missing, required_cpu_drops, cpu_sequence_demands)) {
             return false;
         }
         if (session.impl_->summary.has_session_end &&
-            required_cpu_drops > session.impl_->summary.session_end_records_dropped) {
+            required_cpu_drops > session.impl_->summary.lost_record_count) {
             Fail(
                 SessionLoadStatus::ProtocolViolation,
                 SessionErrorCode::CpuScopeParentMissing,
-                "CPU hierarchy deficits exceed the session record-loss budget"
+                "CPU hierarchy deficits exceed the noticed allocated-record loss budget"
             );
+            return false;
+        }
+        if (!_forensic && !ValidateCpuLossCompatibility(cpu_sequence_demands)) {
             return false;
         }
         if (!BuildGpuDomainsAndTracks() || !BuildGpuTopology(allow_missing, required_cpu_drops)) {
@@ -4469,6 +5102,7 @@ struct ProfileSessionReader::Impl {
     std::vector<std::uint64_t>                            record_sequences{};
     std::uint64_t                                         schema_bytes{0};
     std::uint64_t                                         string_bytes{0};
+    std::uint64_t                                         topology_work_items{0};
 };
 
 ProfileSessionReader::ProfileSessionReader(const SessionLoadOptions& _options) noexcept {

--- a/source/tool/profile_consumer/source/ProfileSession.cpp
+++ b/source/tool/profile_consumer/source/ProfileSession.cpp
@@ -6705,15 +6705,16 @@ struct ProfileSessionReader::Impl {
             }
         }
         if (session.impl_->summary.has_session_end) {
-            const std::uint64_t total_drop_budget = session.impl_->summary.lost_record_count;
-            if (required_gpu_drops > total_drop_budget) {
-                const bool has_cpu_drop_requirement = _required_cpu_drops != 0;
-                const bool has_gpu_drop_requirement = required_gpu_drops > _required_cpu_drops;
+            const std::uint64_t total_drop_budget        = session.impl_->summary.lost_record_count;
+            const bool          has_cpu_drop_requirement = _required_cpu_drops != 0;
+            const bool          has_gpu_drop_requirement = required_gpu_drops > _required_cpu_drops;
+            if (has_gpu_drop_requirement && required_gpu_drops > total_drop_budget) {
+                const SessionErrorCode deficit_error = has_cpu_drop_requirement ?
+                                                           SessionErrorCode::RecordSequenceInvalid :
+                                                           SessionErrorCode::GpuFrameTotalsMismatch;
                 Fail(
                     SessionLoadStatus::ProtocolViolation,
-                    has_cpu_drop_requirement && has_gpu_drop_requirement ?
-                        SessionErrorCode::RecordSequenceInvalid :
-                        SessionErrorCode::GpuFrameTotalsMismatch,
+                    deficit_error,
                     "CPU/GPU deficits exceed the noticed allocated-record loss budget"
                 );
                 return false;
@@ -6869,7 +6870,16 @@ struct ProfileSessionReader::Impl {
         if (!BuildCpuTracks(allow_missing, required_cpu_drops, cpu_sequence_demands)) {
             return false;
         }
-        const bool has_cpu_sequence_demands = !cpu_sequence_demands.empty();
+        const bool                        has_cpu_sequence_demands = !cpu_sequence_demands.empty();
+        std::vector<RecordSequenceDemand> gpu_sequence_demands;
+        if (!BuildGpuDomainsAndTracks() ||
+            !BuildGpuTopology(allow_missing, required_cpu_drops, gpu_sequence_demands)) {
+            return false;
+        }
+        // BuildGpuTopology rejects aggregate failures only when GPU topology
+        // adds a drop requirement. Preserve the CPU-only diagnostic here for
+        // both its empty-GPU fast path and valid zero-deficit GPU data, without
+        // returning before GPU topology is known.
         if (session.impl_->summary.has_session_end &&
             required_cpu_drops > session.impl_->summary.lost_record_count) {
             Fail(
@@ -6879,12 +6889,8 @@ struct ProfileSessionReader::Impl {
             );
             return false;
         }
-        std::vector<RecordSequenceDemand> gpu_sequence_demands;
-        if (!BuildGpuDomainsAndTracks() ||
-            !BuildGpuTopology(allow_missing, required_cpu_drops, gpu_sequence_demands)) {
-            return false;
-        }
         const bool has_gpu_sequence_demands = !gpu_sequence_demands.empty();
+        const bool has_gpu_topology_demands = has_gpu_sequence_demands || !joint_virtual_tasks.empty();
         if (has_gpu_sequence_demands) {
             if (gpu_sequence_demands.size() > cpu_sequence_demands.max_size() - cpu_sequence_demands.size()) {
                 Fail(
@@ -6907,13 +6913,13 @@ struct ProfileSessionReader::Impl {
             );
         }
         if (!ValidateSequenceSlotCapacity(
-                cpu_sequence_demands, has_cpu_sequence_demands, has_gpu_sequence_demands
+                cpu_sequence_demands, has_cpu_sequence_demands, has_gpu_topology_demands
             )) {
             return false;
         }
         if ((!_forensic || !joint_virtual_tasks.empty()) &&
             !ValidateTopologyLossCompatibility(
-                cpu_sequence_demands, has_cpu_sequence_demands, has_gpu_sequence_demands, _forensic
+                cpu_sequence_demands, has_cpu_sequence_demands, has_gpu_topology_demands, _forensic
             )) {
             return false;
         }

--- a/source/tool/profile_consumer/source/ProfileSession.cpp
+++ b/source/tool/profile_consumer/source/ProfileSession.cpp
@@ -468,6 +468,43 @@ struct ProfileSessionReader::Impl {
         return true;
     }
 
+    [[nodiscard]] bool ChargeTopologyLinearWork(std::size_t _count) noexcept {
+        return ChargeTopologyWork(static_cast<std::uint64_t>(_count));
+    }
+
+    [[nodiscard]] bool ChargeTopologySortWork(std::size_t _count) noexcept {
+        const std::uint64_t count = static_cast<std::uint64_t>(_count);
+        std::size_t         width = 1;
+        while (width < _count) {
+            if (!ChargeTopologyWork(count)) {
+                return false;
+            }
+            if (width > std::numeric_limits<std::size_t>::max() / 2) {
+                break;
+            }
+            width *= 2;
+        }
+        return true;
+    }
+
+    [[nodiscard]] bool ChargeTopologyBinarySearchWork(std::size_t _count) noexcept {
+        std::uint64_t work = 0;
+        while (_count != 0) {
+            ++work;
+            _count /= 2;
+        }
+        return ChargeTopologyWork(work);
+    }
+
+    [[nodiscard]] bool ChargeTopologyHeapWork(std::size_t _size) noexcept {
+        std::uint64_t work = 1;
+        while (_size > 1) {
+            ++work;
+            _size /= 2;
+        }
+        return ChargeTopologyWork(work);
+    }
+
     [[nodiscard]] bool InternString(std::string_view _value, SessionStringId& _id) {
         const auto existing = interned_strings.find(_value);
         if (existing != interned_strings.end()) {
@@ -1443,6 +1480,9 @@ struct ProfileSessionReader::Impl {
         _required_cpu_drops = 0;
         _sequence_demands.clear();
         auto& scopes = session.impl_->cpu_scopes;
+        if (!ChargeTopologySortWork(scopes.size())) {
+            return false;
+        }
         std::sort(
             scopes.begin(),
             scopes.end(),
@@ -1462,6 +1502,13 @@ struct ProfileSessionReader::Impl {
                 return _left.sequence < _right.sequence;
             }
         );
+        // One pass partitions tracks, one visits every scope, and active-stack
+        // retirement visits each scope at most once. Boundary candidate scans
+        // are charged separately where they occur.
+        if (!ChargeTopologyLinearWork(scopes.size()) || !ChargeTopologyLinearWork(scopes.size()) ||
+            !ChargeTopologyLinearWork(scopes.size())) {
+            return false;
+        }
 
         struct CpuGapEvent {
             std::uint64_t ancestor_index{0};
@@ -1505,6 +1552,9 @@ struct ProfileSessionReader::Impl {
                 scope.track_index     = track_index;
 
                 if (!has_boundary_time || boundary_time != scope.begin_ns) {
+                    if (!ChargeTopologyLinearWork(ending_parents_by_depth.size())) {
+                        return false;
+                    }
                     ending_parents_by_depth.clear();
                     boundary_time     = scope.begin_ns;
                     has_boundary_time = true;
@@ -1527,6 +1577,9 @@ struct ProfileSessionReader::Impl {
                         return false;
                     }
                     if (candidate.end_ns == scope.begin_ns) {
+                        if (!ChargeTopologyHeapWork(ending_parents_by_depth.size() + 1)) {
+                            return false;
+                        }
                         ending_parents_by_depth[candidate.depth].push_back(candidate_index);
                     }
                     active.pop_back();
@@ -1549,7 +1602,10 @@ struct ProfileSessionReader::Impl {
                 std::uint64_t ancestor_index = active.empty() ? kInvalidSessionIndex : active.back();
                 if (scope.begin_ns == scope.end_ns && scope.depth != 0) {
                     std::uint64_t ending_ancestor_index = kInvalidSessionIndex;
-                    auto          ending_depth          = ending_parents_by_depth.lower_bound(scope.depth);
+                    if (!ChargeTopologyBinarySearchWork(ending_parents_by_depth.size())) {
+                        return false;
+                    }
+                    auto ending_depth = ending_parents_by_depth.lower_bound(scope.depth);
                     while (ending_depth != ending_parents_by_depth.begin()) {
                         --ending_depth;
                         if (!ChargeTopologyWork(static_cast<std::uint64_t>(ending_depth->second.size()))) {
@@ -1649,6 +1705,9 @@ struct ProfileSessionReader::Impl {
                 return true;
             };
 
+        if (!ChargeTopologySortWork(gap_events.size())) {
+            return false;
+        }
         std::sort(
             gap_events.begin(),
             gap_events.end(),
@@ -1659,6 +1718,9 @@ struct ProfileSessionReader::Impl {
                 return _left.scope_index < _right.scope_index;
             }
         );
+        if (!ChargeTopologyLinearWork(gap_events.size())) {
+            return false;
+        }
         std::size_t event_begin = 0;
         while (event_begin < gap_events.size()) {
             std::size_t event_end = event_begin + 1;
@@ -1708,6 +1770,9 @@ struct ProfileSessionReader::Impl {
             return false;
         }
 
+        if (!ChargeTopologySortWork(_sequence_demands.size())) {
+            return false;
+        }
         std::sort(
             _sequence_demands.begin(),
             _sequence_demands.end(),
@@ -1718,6 +1783,9 @@ struct ProfileSessionReader::Impl {
                 return _left.deadline_sequence < _right.deadline_sequence;
             }
         );
+        if (_sequence_demands.empty()) {
+            return true;
+        }
         struct PendingCpuSequenceDemand {
             std::uint64_t deadline_sequence{0};
             std::uint64_t remaining_count{0};
@@ -1726,17 +1794,28 @@ struct ProfileSessionReader::Impl {
                                        const PendingCpuSequenceDemand& _right) {
             return _left.deadline_sequence > _right.deadline_sequence;
         };
+        std::vector<PendingCpuSequenceDemand> pending_storage;
+        pending_storage.reserve(_sequence_demands.size());
         std::priority_queue<
             PendingCpuSequenceDemand,
             std::vector<PendingCpuSequenceDemand>,
             decltype(later_deadline)>
-                      pending_demands(later_deadline);
+            pending_demands(later_deadline, std::move(pending_storage));
+        if (!ChargeTopologyLinearWork(record_sequences.size())) {
+            return false;
+        }
         std::size_t   demand_index   = 0;
         std::size_t   observed_index = 0;
-        std::uint64_t position = _sequence_demands.empty() ? 0 : _sequence_demands.front().release_sequence;
+        std::uint64_t position       = _sequence_demands.front().release_sequence;
         while (demand_index < _sequence_demands.size() || !pending_demands.empty()) {
+            if (!ChargeTopologyWork(1)) {
+                return false;
+            }
             while (demand_index < _sequence_demands.size() &&
                    _sequence_demands[demand_index].release_sequence <= position) {
+                if (!ChargeTopologyHeapWork(pending_demands.size() + 1)) {
+                    return false;
+                }
                 pending_demands.push({
                     .deadline_sequence = _sequence_demands[demand_index].deadline_sequence,
                     .remaining_count   = _sequence_demands[demand_index].count,
@@ -1765,6 +1844,9 @@ struct ProfileSessionReader::Impl {
                 continue;
             }
 
+            if (!ChargeTopologyHeapWork(pending_demands.size())) {
+                return false;
+            }
             PendingCpuSequenceDemand demand = pending_demands.top();
             pending_demands.pop();
             std::uint64_t batch_end = demand.deadline_sequence + 1;
@@ -1779,6 +1861,9 @@ struct ProfileSessionReader::Impl {
             position += assigned;
             demand.remaining_count -= assigned;
             if (demand.remaining_count != 0) {
+                if (!ChargeTopologyHeapWork(pending_demands.size() + 1)) {
+                    return false;
+                }
                 pending_demands.push(demand);
             }
         }
@@ -2262,6 +2347,9 @@ struct ProfileSessionReader::Impl {
 
     [[nodiscard]] bool BuildGpuDomainsAndTracks() {
         auto& frames = session.impl_->gpu_frames;
+        if (!ChargeTopologySortWork(frames.size())) {
+            return false;
+        }
         std::sort(
             frames.begin(),
             frames.end(),
@@ -2272,6 +2360,9 @@ struct ProfileSessionReader::Impl {
                 return _left.sequence < _right.sequence;
             }
         );
+        if (!ChargeTopologyLinearWork(frames.size())) {
+            return false;
+        }
         for (std::size_t index = 1; index < frames.size(); ++index) {
             if (frames[index - 1].frame_id == frames[index].frame_id) {
                 Fail(
@@ -2285,6 +2376,9 @@ struct ProfileSessionReader::Impl {
 
         auto&                  scopes = session.impl_->gpu_scopes;
         std::vector<DomainKey> keys;
+        if (!ChargeTopologyLinearWork(scopes.size())) {
+            return false;
+        }
         keys.reserve(scopes.size());
         for (const GpuScopeRecord& scope : scopes) {
             keys.push_back({
@@ -2292,7 +2386,13 @@ struct ProfileSessionReader::Impl {
                 .family_id       = scope.family_id,
             });
         }
+        if (!ChargeTopologySortWork(keys.size())) {
+            return false;
+        }
         std::sort(keys.begin(), keys.end());
+        if (!ChargeTopologyLinearWork(keys.size())) {
+            return false;
+        }
         keys.erase(std::unique(keys.begin(), keys.end()), keys.end());
         if (keys.size() > options.limits.max_gpu_domains) {
             Fail(
@@ -2302,6 +2402,9 @@ struct ProfileSessionReader::Impl {
                 DecodeStatus::LimitExceeded,
                 SessionLimitKind::GpuDomains
             );
+            return false;
+        }
+        if (!ChargeTopologyLinearWork(keys.size())) {
             return false;
         }
         for (const DomainKey& key : keys) {
@@ -2314,7 +2417,14 @@ struct ProfileSessionReader::Impl {
             });
         }
 
+        if (!ChargeTopologyLinearWork(scopes.size())) {
+            return false;
+        }
         for (GpuScopeRecord& scope : scopes) {
+            if (!ChargeTopologyBinarySearchWork(frames.size()) ||
+                !ChargeTopologyBinarySearchWork(keys.size())) {
+                return false;
+            }
             const auto frame = std::lower_bound(
                 frames.begin(),
                 frames.end(),
@@ -2361,6 +2471,9 @@ struct ProfileSessionReader::Impl {
             }
         }
 
+        if (!ChargeTopologySortWork(scopes.size())) {
+            return false;
+        }
         std::sort(
             scopes.begin(),
             scopes.end(),
@@ -2386,6 +2499,9 @@ struct ProfileSessionReader::Impl {
                 return _left.scope_id < _right.scope_id;
             }
         );
+        if (!ChargeTopologyLinearWork(scopes.size()) || !ChargeTopologyLinearWork(scopes.size())) {
+            return false;
+        }
 
         std::size_t track_begin = 0;
         while (track_begin < scopes.size()) {
@@ -2425,13 +2541,22 @@ struct ProfileSessionReader::Impl {
     [[nodiscard]] bool BuildGpuTopology(bool _allow_missing, std::uint64_t _required_cpu_drops) {
         auto& frames = session.impl_->gpu_frames;
         auto& scopes = session.impl_->gpu_scopes;
+        if (frames.empty() && scopes.empty()) {
+            return true;
+        }
 
         const auto charge_topology_work = [&](std::uint64_t _count) {
             return ChargeTopologyWork(_count);
         };
+        if (!ChargeTopologyLinearWork(frames.size()) || !ChargeTopologyLinearWork(frames.size())) {
+            return false;
+        }
         std::vector<std::uint64_t> frame_error_counts(frames.size(), 0);
         std::vector<std::uint8_t>  frame_root_partition_ambiguous(frames.size(), 0);
         std::vector<ScopeLookup>   lookup;
+        if (!ChargeTopologyLinearWork(scopes.size())) {
+            return false;
+        }
         lookup.reserve(scopes.size());
         for (std::size_t index = 0; index < scopes.size(); ++index) {
             lookup.push_back({
@@ -2440,7 +2565,13 @@ struct ProfileSessionReader::Impl {
                 .scope_index = index,
             });
         }
+        if (!ChargeTopologySortWork(lookup.size())) {
+            return false;
+        }
         std::sort(lookup.begin(), lookup.end());
+        if (!ChargeTopologyLinearWork(lookup.size())) {
+            return false;
+        }
         for (std::size_t index = 1; index < lookup.size(); ++index) {
             if (lookup[index - 1].frame_id == lookup[index].frame_id &&
                 lookup[index - 1].scope_id == lookup[index].scope_id) {
@@ -2465,6 +2596,10 @@ struct ProfileSessionReader::Impl {
                        kInvalidSessionIndex;
         };
 
+        if (!ChargeTopologyLinearWork(scopes.size()) || !ChargeTopologyLinearWork(scopes.size()) ||
+            !ChargeTopologyLinearWork(scopes.size())) {
+            return false;
+        }
         std::vector<std::uint64_t> previous_child_end(scopes.size(), 0);
         std::vector<std::uint8_t>  has_previous_child(scopes.size(), 0);
         std::vector<double>        direct_child_duration(scopes.size(), 0.0);
@@ -2482,14 +2617,25 @@ struct ProfileSessionReader::Impl {
             std::uint64_t       child_index{0};
         };
         std::vector<MissingParentEvidence> missing_parent_evidence;
-        std::vector<std::uint64_t>         source_local_rank(scopes.size(), 0);
+        if (!ChargeTopologyLinearWork(scopes.size()) || !ChargeTopologyLinearWork(scopes.size()) ||
+            !ChargeTopologyLinearWork(scopes.size()) || !ChargeTopologyLinearWork(scopes.size())) {
+            return false;
+        }
+        std::vector<std::uint64_t> source_local_rank(scopes.size(), 0);
         std::vector<std::uint64_t> nearest_observed_timing_ancestor(scopes.size(), kInvalidSessionIndex);
         std::vector<std::uint64_t> completed_observed_child_end(scopes.size(), 0);
         std::vector<std::uint64_t> active_timing_stack_position(scopes.size(), kInvalidSessionIndex);
+        if (!ChargeTopologyLinearWork(scopes.size()) || !ChargeTopologyLinearWork(scopes.size()) ||
+            !ChargeTopologyLinearWork(scopes.size())) {
+            return false;
+        }
         missing_parent_keys.reserve(scopes.size());
         missing_parent_evidence.reserve(scopes.size());
         missing_frame_ids.reserve(scopes.size());
 
+        if (!ChargeTopologyLinearWork(scopes.size())) {
+            return false;
+        }
         for (std::size_t index = 1; index < scopes.size(); ++index) {
             const GpuScopeRecord& previous = scopes[index - 1];
             const GpuScopeRecord& scope    = scopes[index];
@@ -2510,10 +2656,16 @@ struct ProfileSessionReader::Impl {
             }
         }
 
+        if (!ChargeTopologyLinearWork(scopes.size())) {
+            return false;
+        }
         for (std::size_t index = 0; index < scopes.size(); ++index) {
             GpuScopeRecord& scope  = scopes[index];
             bool            orphan = false;
 
+            if (!ChargeTopologyBinarySearchWork(frames.size())) {
+                return false;
+            }
             const auto frame = std::lower_bound(
                 frames.begin(),
                 frames.end(),
@@ -2573,6 +2725,9 @@ struct ProfileSessionReader::Impl {
                         SessionErrorCode::GpuScopeParentInvalid,
                         "non-root GpuScope has zero depth"
                     );
+                    return false;
+                }
+                if (!ChargeTopologyBinarySearchWork(lookup.size())) {
                     return false;
                 }
                 const std::uint64_t parent_index = find_scope(scope.frame_id, scope.parent_scope_id);
@@ -2658,6 +2813,9 @@ struct ProfileSessionReader::Impl {
             }
         }
 
+        if (!ChargeTopologySortWork(missing_parent_evidence.size())) {
+            return false;
+        }
         std::sort(
             missing_parent_evidence.begin(),
             missing_parent_evidence.end(),
@@ -2678,7 +2836,12 @@ struct ProfileSessionReader::Impl {
             bool          trusted{false};
         };
         std::vector<TimingContractEnvelope> timing_contract_envelopes;
-        std::vector<std::uint64_t>          timing_contract_for_child(scopes.size(), kInvalidSessionIndex);
+        if (!ChargeTopologyLinearWork(scopes.size()) ||
+            !ChargeTopologyLinearWork(missing_parent_evidence.size()) ||
+            !ChargeTopologyLinearWork(missing_parent_evidence.size())) {
+            return false;
+        }
+        std::vector<std::uint64_t> timing_contract_for_child(scopes.size(), kInvalidSessionIndex);
         timing_contract_envelopes.reserve(missing_parent_evidence.size());
         std::size_t timing_evidence_begin = 0;
         while (timing_evidence_begin < missing_parent_evidence.size()) {
@@ -2693,7 +2856,10 @@ struct ProfileSessionReader::Impl {
 
             const MissingParentEvidence& first_evidence = missing_parent_evidence[timing_evidence_begin];
             const GpuScopeRecord& first_child = scopes[static_cast<std::size_t>(first_evidence.child_index)];
-            const auto            frame       = std::lower_bound(
+            if (!ChargeTopologyBinarySearchWork(frames.size())) {
+                return false;
+            }
+            const auto frame = std::lower_bound(
                 frames.begin(),
                 frames.end(),
                 first_evidence.frame_id,
@@ -2762,6 +2928,13 @@ struct ProfileSessionReader::Impl {
             timing_evidence_begin = timing_evidence_end;
         }
 
+        // Source partitioning, per-scope validation, and stack retirement are
+        // each monotonic over the scope array. Candidate ancestry scans remain
+        // separately charged at their point of use.
+        if (!ChargeTopologyLinearWork(scopes.size()) || !ChargeTopologyLinearWork(scopes.size()) ||
+            !ChargeTopologyLinearWork(scopes.size()) || !ChargeTopologyLinearWork(scopes.size())) {
+            return false;
+        }
         std::size_t timing_source_begin = 0;
         while (timing_source_begin < scopes.size()) {
             std::size_t timing_source_end = timing_source_begin + 1;
@@ -2974,6 +3147,10 @@ struct ProfileSessionReader::Impl {
             }
             timing_source_begin = timing_source_end;
         }
+        if (!ChargeTopologyLinearWork(scopes.size()) || !ChargeTopologyLinearWork(scopes.size()) ||
+            !ChargeTopologyLinearWork(scopes.size())) {
+            return false;
+        }
         std::vector<std::uint64_t> timing_subtree_end_local(scopes.size(), 0);
         for (std::size_t index = 0; index < scopes.size(); ++index) {
             timing_subtree_end_local[index] = scopes[index].local_order;
@@ -2989,6 +3166,10 @@ struct ProfileSessionReader::Impl {
         std::size_t depth_range_leaf_count = 1;
         while (depth_range_leaf_count < scopes.size()) {
             depth_range_leaf_count *= 2;
+        }
+        if (!ChargeTopologyLinearWork(depth_range_leaf_count * 2) ||
+            !ChargeTopologyLinearWork(scopes.size()) || !ChargeTopologyLinearWork(depth_range_leaf_count)) {
+            return false;
         }
         std::vector<std::uint32_t> depth_range_tree(
             depth_range_leaf_count * 2, std::numeric_limits<std::uint32_t>::max()
@@ -3017,20 +3198,6 @@ struct ProfileSessionReader::Impl {
             }
             return minimum;
         };
-
-        std::sort(
-            missing_parent_evidence.begin(),
-            missing_parent_evidence.end(),
-            [](const MissingParentEvidence& _left, const MissingParentEvidence& _right) {
-                if (_left.frame_id != _right.frame_id) {
-                    return _left.frame_id < _right.frame_id;
-                }
-                if (_left.parent_scope_id != _right.parent_scope_id) {
-                    return _left.parent_scope_id < _right.parent_scope_id;
-                }
-                return _left.child_local_order < _right.child_local_order;
-            }
-        );
         struct MissingParentContract {
             std::uint64_t       frame_id{0};
             ProfileLogicalQueue logical_queue{ProfileLogicalQueue::Graphics};
@@ -3048,6 +3215,10 @@ struct ProfileSessionReader::Impl {
             std::uint64_t       timing_envelope_duration{0};
         };
         std::vector<MissingParentContract> missing_parent_contracts;
+        if (!ChargeTopologyLinearWork(missing_parent_evidence.size()) ||
+            !ChargeTopologyLinearWork(missing_parent_evidence.size())) {
+            return false;
+        }
         missing_parent_contracts.reserve(missing_parent_evidence.size());
 
         std::size_t evidence_begin = 0;
@@ -3104,6 +3275,9 @@ struct ProfileSessionReader::Impl {
                         scopes[last_observed_index].local_order - (observed_before - 1);
                     std::size_t low  = source_begin_index;
                     std::size_t high = first_child_index;
+                    if (!ChargeTopologyBinarySearchWork(high - low)) {
+                        return false;
+                    }
                     while (low < high) {
                         const std::size_t   mid = low + (high - low) / 2;
                         const std::uint64_t order_without_rank =
@@ -3126,6 +3300,9 @@ struct ProfileSessionReader::Impl {
                 }
             }
 
+            if (!ChargeTopologyBinarySearchWork(frames.size())) {
+                return false;
+            }
             const auto frame = std::lower_bound(
                 frames.begin(),
                 frames.end(),
@@ -3231,6 +3408,10 @@ struct ProfileSessionReader::Impl {
                 }
                 const std::size_t last_child_index =
                     static_cast<std::size_t>(missing_parent_evidence[evidence_end - 1].child_index);
+                if (!ChargeTopologyBinarySearchWork(depth_range_leaf_count) ||
+                    !ChargeTopologyBinarySearchWork(depth_range_leaf_count)) {
+                    return false;
+                }
                 if (minimum_depth_in_range(first_child_index, last_child_index + 1) <=
                     contract.parent_depth) {
                     Fail(
@@ -3261,6 +3442,9 @@ struct ProfileSessionReader::Impl {
             evidence_begin = evidence_end;
         }
 
+        if (!ChargeTopologySortWork(missing_parent_contracts.size())) {
+            return false;
+        }
         std::sort(
             missing_parent_contracts.begin(),
             missing_parent_contracts.end(),
@@ -3296,6 +3480,10 @@ struct ProfileSessionReader::Impl {
             std::uint64_t       required_parent_record_count{0};
         };
         std::vector<SourceLossEvidence> source_loss_evidence;
+        if (!ChargeTopologyLinearWork(scopes.size()) || !ChargeTopologyLinearWork(scopes.size()) ||
+            !ChargeTopologyLinearWork(scopes.size())) {
+            return false;
+        }
         source_loss_evidence.reserve(scopes.size());
         std::size_t source_begin = 0;
         while (source_begin < scopes.size()) {
@@ -3372,6 +3560,9 @@ struct ProfileSessionReader::Impl {
         };
 
         std::size_t contract_begin = 0;
+        if (!ChargeTopologyLinearWork(missing_parent_contracts.size())) {
+            return false;
+        }
         while (contract_begin < missing_parent_contracts.size()) {
             std::size_t contract_end = contract_begin + 1;
             while (contract_end < missing_parent_contracts.size()) {
@@ -3385,8 +3576,11 @@ struct ProfileSessionReader::Impl {
                 ++contract_end;
             }
 
-            SourceLossEvidence* source    = nullptr;
-            const auto          source_it = std::lower_bound(
+            SourceLossEvidence* source = nullptr;
+            if (!ChargeTopologyBinarySearchWork(source_loss_evidence.size())) {
+                return false;
+            }
+            const auto source_it = std::lower_bound(
                 source_loss_evidence.begin(),
                 source_loss_evidence.end(),
                 missing_parent_contracts[contract_begin],
@@ -3406,9 +3600,12 @@ struct ProfileSessionReader::Impl {
             }
 
             std::vector<std::uint32_t> depth_coordinates;
-            depth_coordinates.reserve(
-                static_cast<std::size_t>(source->scope_count) + contract_end - contract_begin
-            );
+            const std::size_t          source_scope_count = static_cast<std::size_t>(source->scope_count);
+            const std::size_t          contract_count     = contract_end - contract_begin;
+            if (!ChargeTopologyLinearWork(source_scope_count) || !ChargeTopologyLinearWork(contract_count)) {
+                return false;
+            }
+            depth_coordinates.reserve(source_scope_count + contract_count);
             const std::size_t source_end_index =
                 static_cast<std::size_t>(source->first_scope + source->scope_count);
             std::uint64_t last_observed_root_local_order = 0;
@@ -3424,11 +3621,21 @@ struct ProfileSessionReader::Impl {
             for (std::size_t index = contract_begin; index < contract_end; ++index) {
                 depth_coordinates.push_back(missing_parent_contracts[index].parent_depth);
             }
+            if (!ChargeTopologySortWork(depth_coordinates.size()) ||
+                !ChargeTopologyLinearWork(depth_coordinates.size())) {
+                return false;
+            }
             std::sort(depth_coordinates.begin(), depth_coordinates.end());
             depth_coordinates.erase(
                 std::unique(depth_coordinates.begin(), depth_coordinates.end()), depth_coordinates.end()
             );
 
+            if (!ChargeTopologyLinearWork(depth_coordinates.size()) ||
+                !ChargeTopologyLinearWork(depth_coordinates.size()) ||
+                !ChargeTopologyLinearWork(depth_coordinates.size()) ||
+                !ChargeTopologyLinearWork(depth_coordinates.size())) {
+                return false;
+            }
             std::vector<std::uint64_t> covered_depth_tree(depth_coordinates.size() + 1, 0);
             std::vector<std::uint64_t> prefix_covered_depth_tree(depth_coordinates.size() + 1, 0);
             std::vector<std::uint8_t>  depth_covered(depth_coordinates.size(), 0);
@@ -3464,6 +3671,10 @@ struct ProfileSessionReader::Impl {
             };
 
             for (std::size_t index = contract_begin; index < contract_end; ++index) {
+                if (!ChargeTopologyBinarySearchWork(depth_coordinates.size()) ||
+                    !ChargeTopologyBinarySearchWork(depth_coordinates.size())) {
+                    return false;
+                }
                 cover_depth(missing_parent_contracts[index].parent_depth, covered_depth_tree, depth_covered);
             }
             const bool timing_topology_trusted =
@@ -3508,6 +3719,9 @@ struct ProfileSessionReader::Impl {
                     std::size_t   chain_end{0};
                 };
 
+                if (!ChargeTopologyLinearWork(depth_coordinates.size())) {
+                    return false;
+                }
                 std::vector<std::uint64_t> latest_barrier_tree(depth_coordinates.size() + 1, 0);
                 const auto                 observe_barrier = [&](std::size_t _scope_index) {
                     const GpuScopeRecord& scope      = scopes[_scope_index];
@@ -3544,11 +3758,17 @@ struct ProfileSessionReader::Impl {
                 std::map<std::uint32_t, std::uint64_t>     previous_missing_direct_end;
                 std::map<std::uint32_t, std::uint64_t>     virtual_epoch_floor;
                 std::vector<std::size_t>                   completion_order;
+                if (!ChargeTopologyLinearWork(source_scope_count)) {
+                    return false;
+                }
                 completion_order.reserve(static_cast<std::size_t>(source->scope_count));
                 for (std::size_t index = static_cast<std::size_t>(source->first_scope);
                      index < source_end_index;
                      ++index) {
                     completion_order.push_back(index);
+                }
+                if (!ChargeTopologySortWork(completion_order.size())) {
+                    return false;
                 }
                 std::sort(
                     completion_order.begin(),
@@ -3564,6 +3784,10 @@ struct ProfileSessionReader::Impl {
                     while (completed_observed_index < completion_order.size() &&
                            timing_subtree_end_local[completion_order[completed_observed_index]] <
                                contract.child_local_order_deadline) {
+                        if (!ChargeTopologyBinarySearchWork(depth_coordinates.size()) ||
+                            !ChargeTopologyBinarySearchWork(depth_coordinates.size())) {
+                            return false;
+                        }
                         observe_barrier(completion_order[completed_observed_index]);
                         ++completed_observed_index;
                     }
@@ -3579,6 +3803,9 @@ struct ProfileSessionReader::Impl {
 
                     const std::uint64_t anchor_first_allowed =
                         anchor_index == kInvalidSessionIndex ? 0 : scopes[anchor_index].local_order + 1;
+                    if (!ChargeTopologyBinarySearchWork(previous_missing_direct_end.size())) {
+                        return false;
+                    }
                     const auto previous_direct = previous_missing_direct_end.find(contract.parent_depth);
                     if (previous_direct != previous_missing_direct_end.end()) {
                         std::uint64_t sibling_after = 0;
@@ -3598,12 +3825,22 @@ struct ProfileSessionReader::Impl {
                             );
                             return false;
                         }
+                        if (!ChargeTopologyHeapWork(virtual_epoch_floor.size() + 1)) {
+                            return false;
+                        }
                         virtual_epoch_floor[contract.parent_depth] = sibling_after;
                     }
                     const std::size_t current_chain_begin = chain_task_indices.size();
                     for (std::uint32_t depth = base_depth;; ++depth) {
+                        if (!ChargeTopologyBinarySearchWork(depth_coordinates.size()) ||
+                            !ChargeTopologyBinarySearchWork(depth_coordinates.size())) {
+                            return false;
+                        }
                         std::uint64_t first_allowed_slot =
                             std::max(anchor_first_allowed, latest_barrier_after(depth));
+                        if (!ChargeTopologyBinarySearchWork(virtual_epoch_floor.size())) {
+                            return false;
+                        }
                         const auto epoch = virtual_epoch_floor.find(depth);
                         if (epoch != virtual_epoch_floor.end()) {
                             first_allowed_slot = std::max(first_allowed_slot, epoch->second);
@@ -3623,6 +3860,9 @@ struct ProfileSessionReader::Impl {
                             .depth              = depth,
                             .first_allowed_slot = first_allowed_slot,
                         };
+                        if (!ChargeTopologyHeapWork(task_states.size() + 1)) {
+                            return false;
+                        }
                         auto [state_it, state_inserted]          = task_states.try_emplace(key);
                         MissingTaskState& state                  = state_it->second;
                         std::uint64_t     task_index             = state.canonical_task_index;
@@ -3738,6 +3978,9 @@ struct ProfileSessionReader::Impl {
                                         .depth              = clone.depth,
                                         .first_allowed_slot = clone.first_allowed_slot,
                                     };
+                                    if (!ChargeTopologyHeapWork(task_states.size() + 1)) {
+                                        return false;
+                                    }
                                     MissingTaskState& clone_state    = task_states[clone_key];
                                     clone_state.canonical_task_index = clone_index;
                                     clone_state.canonical_is_direct  = clone.depth == contract.parent_depth;
@@ -3775,10 +4018,17 @@ struct ProfileSessionReader::Impl {
                         }
                     }
                     chain_ends.push_back(static_cast<std::uint64_t>(chain_task_indices.size()));
+                    if (!ChargeTopologyHeapWork(previous_missing_direct_end.size() + 1)) {
+                        return false;
+                    }
                     previous_missing_direct_end[contract.parent_depth] =
                         contract.last_child_subtree_end_local;
                 }
 
+                if (!ChargeTopologyLinearWork(tasks.size()) ||
+                    !ChargeTopologyLinearWork(chain_task_indices.size())) {
+                    return false;
+                }
                 std::vector<std::uint8_t> task_active(tasks.size(), 0);
                 std::uint64_t             active_task_count = 0;
                 for (const std::uint64_t task_index : chain_task_indices) {
@@ -3799,11 +4049,17 @@ struct ProfileSessionReader::Impl {
                 const bool has_spare_local_holes =
                     source->required_parent_record_count < source->local_hole_count;
                 std::vector<std::uint64_t> task_order;
+                if (!ChargeTopologyLinearWork(tasks.size())) {
+                    return false;
+                }
                 task_order.reserve(static_cast<std::size_t>(active_task_count));
                 for (std::size_t index = 0; index < tasks.size(); ++index) {
                     if (task_active[index] != 0) {
                         task_order.push_back(static_cast<std::uint64_t>(index));
                     }
+                }
+                if (!ChargeTopologySortWork(task_order.size())) {
+                    return false;
                 }
                 std::sort(
                     task_order.begin(),
@@ -3834,6 +4090,10 @@ struct ProfileSessionReader::Impl {
                         --slot;
                     }
                 };
+                if (!ChargeTopologyLinearWork(task_order.size()) ||
+                    !ChargeTopologyLinearWork(source_scope_count)) {
+                    return false;
+                }
                 while (ordered_task_index < task_order.size() || !ready_tasks.empty()) {
                     if (!has_slot) {
                         Fail(
@@ -3845,6 +4105,9 @@ struct ProfileSessionReader::Impl {
                     }
                     while (ordered_task_index < task_order.size() &&
                            tasks[task_order[ordered_task_index]].deadline_slot > slot) {
+                        if (!ChargeTopologyHeapWork(ready_tasks.size() + 1)) {
+                            return false;
+                        }
                         ready_tasks.push(task_order[ordered_task_index]);
                         ++ordered_task_index;
                     }
@@ -3871,12 +4134,18 @@ struct ProfileSessionReader::Impl {
                         );
                         return false;
                     }
+                    if (!ChargeTopologyHeapWork(ready_tasks.size())) {
+                        return false;
+                    }
                     ready_tasks.pop();
                     tasks[task_index].assigned_slot = slot;
                     move_to_previous_slot();
                 }
 
                 std::size_t chain_begin = 0;
+                if (!ChargeTopologyLinearWork(chain_task_indices.size())) {
+                    return false;
+                }
                 for (const std::uint64_t chain_end_value : chain_ends) {
                     const std::size_t chain_end = static_cast<std::size_t>(chain_end_value);
                     for (std::size_t index = chain_begin + 1; index < chain_end; ++index) {
@@ -3894,6 +4163,10 @@ struct ProfileSessionReader::Impl {
                 }
 
                 std::vector<std::uint64_t> occupied_local_orders;
+                if (!ChargeTopologyLinearWork(source_scope_count) ||
+                    !ChargeTopologyLinearWork(tasks.size())) {
+                    return false;
+                }
                 occupied_local_orders.reserve(
                     static_cast<std::size_t>(source->scope_count) +
                     static_cast<std::size_t>(active_task_count)
@@ -3908,8 +4181,17 @@ struct ProfileSessionReader::Impl {
                         occupied_local_orders.push_back(tasks[task_index].assigned_slot);
                     }
                 }
+                if (!ChargeTopologySortWork(occupied_local_orders.size())) {
+                    return false;
+                }
                 std::sort(occupied_local_orders.begin(), occupied_local_orders.end());
 
+                if (!ChargeTopologyLinearWork(root_partition_candidates.size()) ||
+                    !ChargeTopologyLinearWork(root_partition_candidates.size()) ||
+                    !ChargeTopologyLinearWork(root_partition_candidates.size()) ||
+                    !ChargeTopologyLinearWork(tasks.size())) {
+                    return false;
+                }
                 std::vector<std::uint64_t> candidate_split_root_slot(
                     root_partition_candidates.size(), kInvalidSessionIndex
                 );
@@ -3919,9 +4201,15 @@ struct ProfileSessionReader::Impl {
                 std::vector<std::uint8_t>  task_has_concrete_split(tasks.size(), 0);
                 std::set<std::uint64_t>    reserved_split_slots;
                 std::vector<std::size_t>   candidate_order;
+                if (!ChargeTopologyLinearWork(root_partition_candidates.size())) {
+                    return false;
+                }
                 candidate_order.reserve(root_partition_candidates.size());
                 for (std::size_t index = 0; index < root_partition_candidates.size(); ++index) {
                     candidate_order.push_back(index);
+                }
+                if (!ChargeTopologySortWork(candidate_order.size())) {
+                    return false;
                 }
                 std::sort(
                     candidate_order.begin(),
@@ -4000,10 +4288,17 @@ struct ProfileSessionReader::Impl {
                                     if (!charge_topology_work(1)) {
                                         return false;
                                     }
-                                    if (!std::binary_search(
-                                            occupied_local_orders.begin(), occupied_local_orders.end(), cursor
-                                        ) &&
-                                        !reserved_split_slots.contains(cursor)) {
+                                    if (!ChargeTopologyBinarySearchWork(occupied_local_orders.size())) {
+                                        return false;
+                                    }
+                                    const bool occupied = std::binary_search(
+                                        occupied_local_orders.begin(), occupied_local_orders.end(), cursor
+                                    );
+                                    if (!occupied &&
+                                        !ChargeTopologyBinarySearchWork(reserved_split_slots.size())) {
+                                        return false;
+                                    }
+                                    if (!occupied && !reserved_split_slots.contains(cursor)) {
                                         found = true;
                                         break;
                                     }
@@ -4012,6 +4307,9 @@ struct ProfileSessionReader::Impl {
                                     candidate_feasible = false;
                                     break;
                                 }
+                                if (!ChargeTopologyHeapWork(reserved_split_slots.size() + 1)) {
+                                    return false;
+                                }
                                 reserved_split_slots.insert(cursor);
                                 candidate_reserved_slots.push_back(cursor);
                                 root_slot = cursor;
@@ -4019,6 +4317,9 @@ struct ProfileSessionReader::Impl {
                             if (candidate_feasible) {
                                 candidate_reserved_slot_begin[candidate_index] =
                                     candidate_reserved_slot_storage.size();
+                                if (!ChargeTopologyLinearWork(candidate_reserved_slots.size())) {
+                                    return false;
+                                }
                                 candidate_reserved_slot_storage.insert(
                                     candidate_reserved_slot_storage.end(),
                                     candidate_reserved_slots.begin(),
@@ -4030,6 +4331,9 @@ struct ProfileSessionReader::Impl {
                                 task_has_concrete_split[root_task_index]   = 1;
                             } else {
                                 for (const std::uint64_t slot : candidate_reserved_slots) {
+                                    if (!ChargeTopologyBinarySearchWork(reserved_split_slots.size())) {
+                                        return false;
+                                    }
                                     reserved_split_slots.erase(slot);
                                 }
                             }
@@ -4054,6 +4358,9 @@ struct ProfileSessionReader::Impl {
                     static_cast<std::size_t>(source->scope_count) + tasks.size() +
                     root_partition_candidates.size()
                 );
+                if (!ChargeTopologyLinearWork(source_scope_count)) {
+                    return false;
+                }
                 for (std::size_t index = static_cast<std::size_t>(source->first_scope);
                      index < source_end_index;
                      ++index) {
@@ -4081,6 +4388,10 @@ struct ProfileSessionReader::Impl {
                                                                    (std::uint64_t{1} << 63) :
                                                                    (std::uint64_t{1} << (source_valid_bits - 1));
                 const std::uint64_t source_maximum_root_step = source_half_range - 1;
+                if (!ChargeTopologyLinearWork(tasks.size()) ||
+                    !ChargeTopologyLinearWork(root_partition_candidates.size())) {
+                    return false;
+                }
                 for (std::size_t task_index = 0; task_index < tasks.size(); ++task_index) {
                     while (candidate_order_index < candidate_order.size() &&
                            root_partition_candidates[candidate_order[candidate_order_index]].root_task_index <
@@ -4144,6 +4455,9 @@ struct ProfileSessionReader::Impl {
                             for (std::size_t slot_index = candidate_reserved_slot_begin[candidate_index];
                                  slot_index < candidate_reserved_slot_end[candidate_index];
                                  ++slot_index) {
+                                if (!ChargeTopologyHeapWork(used_split_slots.size() + 1)) {
+                                    return false;
+                                }
                                 used_split_slots.insert(candidate_reserved_slot_storage[slot_index]);
                             }
                             split_root_components.push_back(split_component);
@@ -4178,6 +4492,10 @@ struct ProfileSessionReader::Impl {
                     }
                     split_root_components.push_back(split_component);
                 }
+                if (!ChargeTopologySortWork(root_components.size()) ||
+                    !ChargeTopologySortWork(split_root_components.size())) {
+                    return false;
+                }
                 const auto sort_root_components = [](std::vector<RootComponent>& _components) {
                     std::sort(
                         _components.begin(),
@@ -4190,6 +4508,10 @@ struct ProfileSessionReader::Impl {
                 };
                 sort_root_components(root_components);
                 sort_root_components(split_root_components);
+                if (!ChargeTopologyLinearWork(root_components.size()) ||
+                    !ChargeTopologyLinearWork(split_root_components.size())) {
+                    return false;
+                }
                 const auto duplicate_root_slot = [](const std::vector<RootComponent>& _components) {
                     return std::adjacent_find(
                                _components.begin(),
@@ -4229,6 +4551,10 @@ struct ProfileSessionReader::Impl {
                                                                 _occupied_local_orders) {
                         if (_components.empty()) {
                             return true;
+                        }
+                        if (!ChargeTopologyLinearWork(_components.size())) {
+                            topology_limit_failed = true;
+                            return false;
                         }
                         for (std::size_t index = 0; index < _components.size(); ++index) {
                             const RootComponent& component = _components[index];
@@ -4278,11 +4604,21 @@ struct ProfileSessionReader::Impl {
                         for (std::size_t index = 1; index < _components.size(); ++index) {
                             const RootComponent& previous_component = _components[index - 1];
                             const RootComponent& component          = _components[index];
-                            const auto           occupied_begin     = std::upper_bound(
+                            if (!ChargeTopologyBinarySearchWork(_occupied_local_orders.size())) {
+                                topology_limit_failed = true;
+                                return false;
+                            }
+                            const auto occupied_begin = std::upper_bound(
                                 _occupied_local_orders.begin(),
                                 _occupied_local_orders.end(),
                                 previous_component.subtree_end_local
                             );
+                            if (!ChargeTopologyBinarySearchWork(
+                                    static_cast<std::size_t>(_occupied_local_orders.end() - occupied_begin)
+                                )) {
+                                topology_limit_failed = true;
+                                return false;
+                            }
                             const auto occupied_end = std::lower_bound(
                                 occupied_begin, _occupied_local_orders.end(), component.local_order
                             );
@@ -4408,6 +4744,10 @@ struct ProfileSessionReader::Impl {
                             if (next_frontier.empty()) {
                                 return false;
                             }
+                            if (!ChargeTopologySortWork(next_frontier.size())) {
+                                topology_limit_failed = true;
+                                return false;
+                            }
                             std::sort(
                                 next_frontier.begin(),
                                 next_frontier.end(),
@@ -4422,6 +4762,10 @@ struct ProfileSessionReader::Impl {
                                 }
                             );
                             std::vector<RootSerialState> pruned_frontier;
+                            if (!ChargeTopologyLinearWork(next_frontier.size())) {
+                                topology_limit_failed = true;
+                                return false;
+                            }
                             pruned_frontier.reserve(next_frontier.size());
                             for (const RootSerialState& state : next_frontier) {
                                 if (!pruned_frontier.empty() && !((state.end) < pruned_frontier.back().end)) {
@@ -4437,12 +4781,19 @@ struct ProfileSessionReader::Impl {
                     bool used_split_plan     = false;
                     bool root_sequence_valid = validate_root_sequence(root_components, occupied_local_orders);
                     if (!root_sequence_valid && !topology_limit_failed && has_split_plan) {
+                        if (!ChargeTopologyLinearWork(occupied_local_orders.size()) ||
+                            !ChargeTopologyLinearWork(used_split_slots.size())) {
+                            return false;
+                        }
                         std::vector<std::uint64_t> split_occupied_local_orders = occupied_local_orders;
                         split_occupied_local_orders.insert(
                             split_occupied_local_orders.end(),
                             used_split_slots.begin(),
                             used_split_slots.end()
                         );
+                        if (!ChargeTopologySortWork(split_occupied_local_orders.size())) {
+                            return false;
+                        }
                         std::sort(split_occupied_local_orders.begin(), split_occupied_local_orders.end());
                         root_sequence_valid =
                             validate_root_sequence(split_root_components, split_occupied_local_orders);
@@ -4486,13 +4837,21 @@ struct ProfileSessionReader::Impl {
             }
 
             if (!timing_topology_trusted) {
+                if (!ChargeTopologyLinearWork(contract_count)) {
+                    return false;
+                }
                 std::size_t   observed_index              = static_cast<std::size_t>(source->first_scope);
                 std::uint64_t hidden_ancestor_lower_bound = 0;
                 std::map<std::uint32_t, std::uint32_t> required_prefix_depth_intervals;
                 std::uint32_t                          exposed_prefix_depth                = 0;
                 std::uint64_t                          required_prefix_depth_count         = 0;
                 std::uint64_t                          matched_required_direct_depth_count = 0;
+                bool                                   prefix_budget_failed                = false;
                 const auto                             prefix_depth_was_required = [&](std::uint32_t _depth) {
+                    if (!ChargeTopologyBinarySearchWork(required_prefix_depth_intervals.size())) {
+                        prefix_budget_failed = true;
+                        return false;
+                    }
                     const auto interval = required_prefix_depth_intervals.upper_bound(_depth);
                     if (interval == required_prefix_depth_intervals.begin()) {
                         return false;
@@ -4502,6 +4861,13 @@ struct ProfileSessionReader::Impl {
                 };
                 const auto prefix_direct_depth_count_in_range = [&](std::uint32_t _begin,
                                                                     std::uint32_t _end) {
+                    if (!ChargeTopologyBinarySearchWork(depth_coordinates.size()) ||
+                        !ChargeTopologyBinarySearchWork(depth_coordinates.size()) ||
+                        !ChargeTopologyBinarySearchWork(depth_coordinates.size()) ||
+                        !ChargeTopologyBinarySearchWork(depth_coordinates.size())) {
+                        prefix_budget_failed = true;
+                        return std::uint64_t{0};
+                    }
                     return covered_depth_count_before(_end, prefix_covered_depth_tree) -
                            covered_depth_count_before(_begin, prefix_covered_depth_tree);
                 };
@@ -4510,6 +4876,10 @@ struct ProfileSessionReader::Impl {
                         return;
                     }
 
+                    if (!ChargeTopologyBinarySearchWork(required_prefix_depth_intervals.size())) {
+                        prefix_budget_failed = true;
+                        return;
+                    }
                     auto interval = required_prefix_depth_intervals.lower_bound(_begin);
                     if (interval != required_prefix_depth_intervals.begin()) {
                         auto previous = std::prev(interval);
@@ -4523,11 +4893,19 @@ struct ProfileSessionReader::Impl {
                     std::uint32_t cursor       = _begin;
                     while (interval != required_prefix_depth_intervals.end() && interval->first <= merged_end
                     ) {
+                        if (!ChargeTopologyWork(1)) {
+                            prefix_budget_failed = true;
+                            return;
+                        }
                         if (cursor < _end && cursor < interval->first) {
                             const std::uint32_t uncovered_end = std::min(_end, interval->first);
                             required_prefix_depth_count += static_cast<std::uint64_t>(uncovered_end - cursor);
-                            matched_required_direct_depth_count +=
+                            const std::uint64_t direct_depth_count =
                                 prefix_direct_depth_count_in_range(cursor, uncovered_end);
+                            if (prefix_budget_failed) {
+                                return;
+                            }
+                            matched_required_direct_depth_count += direct_depth_count;
                         }
                         cursor       = std::max(cursor, interval->second);
                         merged_begin = std::min(merged_begin, interval->first);
@@ -4536,10 +4914,27 @@ struct ProfileSessionReader::Impl {
                     }
                     if (cursor < _end) {
                         required_prefix_depth_count += static_cast<std::uint64_t>(_end - cursor);
-                        matched_required_direct_depth_count +=
+                        const std::uint64_t direct_depth_count =
                             prefix_direct_depth_count_in_range(cursor, _end);
+                        if (prefix_budget_failed) {
+                            return;
+                        }
+                        matched_required_direct_depth_count += direct_depth_count;
+                    }
+                    if (prefix_budget_failed ||
+                        !ChargeTopologyHeapWork(required_prefix_depth_intervals.size() + 1)) {
+                        prefix_budget_failed = true;
+                        return;
                     }
                     required_prefix_depth_intervals.emplace(merged_begin, merged_end);
+                };
+                const auto charge_and_add_required_prefix_range = [&](std::uint32_t _begin,
+                                                                      std::uint32_t _end) {
+                    if (_begin >= _end) {
+                        return true;
+                    }
+                    add_required_prefix_range(_begin, _end);
+                    return !prefix_budget_failed;
                 };
 
                 std::vector<std::uint32_t> observed_ancestor_depths;
@@ -4548,8 +4943,11 @@ struct ProfileSessionReader::Impl {
                     source_end_index - static_cast<std::size_t>(source->first_scope)
                 ));
                 for (std::size_t index = contract_begin; index < contract_end; ++index) {
-                    const MissingParentContract& contract                = missing_parent_contracts[index];
-                    const std::size_t            parent_depth_coordinate = static_cast<std::size_t>(
+                    const MissingParentContract& contract = missing_parent_contracts[index];
+                    if (!ChargeTopologyBinarySearchWork(depth_coordinates.size())) {
+                        return false;
+                    }
+                    const std::size_t parent_depth_coordinate = static_cast<std::size_t>(
                         std::lower_bound(
                             depth_coordinates.begin(), depth_coordinates.end(), contract.parent_depth
                         ) -
@@ -4558,6 +4956,10 @@ struct ProfileSessionReader::Impl {
                     if (prefix_depth_covered[parent_depth_coordinate] == 0 &&
                         prefix_depth_was_required(contract.parent_depth)) {
                         ++matched_required_direct_depth_count;
+                    }
+                    if (prefix_budget_failed || !ChargeTopologyBinarySearchWork(depth_coordinates.size()) ||
+                        !ChargeTopologyBinarySearchWork(depth_coordinates.size())) {
+                        return false;
                     }
                     cover_depth(contract.parent_depth, prefix_covered_depth_tree, prefix_depth_covered);
 
@@ -4571,6 +4973,10 @@ struct ProfileSessionReader::Impl {
                             }
                             ancestor_index = nearest_observed_timing_ancestor[ancestor_index];
                         }
+                        if (!ChargeTopologySortWork(observed_ancestor_depths.size()) ||
+                            !ChargeTopologyLinearWork(observed_ancestor_depths.size())) {
+                            return false;
+                        }
                         std::sort(observed_ancestor_depths.begin(), observed_ancestor_depths.end());
                         observed_ancestor_depths.erase(
                             std::unique(observed_ancestor_depths.begin(), observed_ancestor_depths.end()),
@@ -4579,6 +4985,12 @@ struct ProfileSessionReader::Impl {
                     } else {
                         while (observed_index < source_end_index &&
                                scopes[observed_index].local_order < contract.latest_parent_local_order) {
+                            if (!ChargeTopologyBinarySearchWork(depth_coordinates.size()) ||
+                                !ChargeTopologyBinarySearchWork(depth_coordinates.size()) ||
+                                !ChargeTopologyBinarySearchWork(depth_coordinates.size()) ||
+                                !ChargeTopologyBinarySearchWork(depth_coordinates.size())) {
+                                return false;
+                            }
                             cover_depth(scopes[observed_index].depth, covered_depth_tree, depth_covered);
                             cover_depth(
                                 scopes[observed_index].depth, prefix_covered_depth_tree, prefix_depth_covered
@@ -4587,10 +4999,17 @@ struct ProfileSessionReader::Impl {
                         }
                     }
 
+                    if (!ChargeTopologyBinarySearchWork(depth_coordinates.size()) ||
+                        !ChargeTopologyBinarySearchWork(depth_coordinates.size())) {
+                        return false;
+                    }
                     std::uint64_t covered_ancestor_depths =
                         covered_depth_count_before(contract.parent_depth, covered_depth_tree);
                     if (timing_topology_trusted) {
                         for (const std::uint32_t depth : observed_ancestor_depths) {
+                            if (!ChargeTopologyBinarySearchWork(depth_coordinates.size())) {
+                                return false;
+                            }
                             const std::size_t coordinate = static_cast<std::size_t>(
                                 std::lower_bound(depth_coordinates.begin(), depth_coordinates.end(), depth) -
                                 depth_coordinates.begin()
@@ -4607,25 +5026,39 @@ struct ProfileSessionReader::Impl {
                     if (timing_topology_trusted) {
                         std::uint32_t interval_begin = 0;
                         for (const std::uint32_t depth : observed_ancestor_depths) {
-                            add_required_prefix_range(interval_begin, depth);
+                            if (!charge_and_add_required_prefix_range(interval_begin, depth)) {
+                                return false;
+                            }
                             interval_begin = depth + 1;
                         }
-                        add_required_prefix_range(interval_begin, contract.parent_depth);
+                        if (!charge_and_add_required_prefix_range(interval_begin, contract.parent_depth)) {
+                            return false;
+                        }
                     } else if (contract.parent_depth > exposed_prefix_depth) {
                         std::uint32_t interval_begin = exposed_prefix_depth;
-                        auto          coordinate     = std::lower_bound(
+                        if (!ChargeTopologyBinarySearchWork(depth_coordinates.size())) {
+                            return false;
+                        }
+                        auto coordinate = std::lower_bound(
                             depth_coordinates.begin(), depth_coordinates.end(), exposed_prefix_depth
                         );
                         while (coordinate != depth_coordinates.end() && *coordinate < contract.parent_depth) {
                             const std::size_t coordinate_index =
                                 static_cast<std::size_t>(coordinate - depth_coordinates.begin());
                             if (prefix_depth_covered[coordinate_index] != 0) {
-                                add_required_prefix_range(interval_begin, *coordinate);
+                                if (!charge_and_add_required_prefix_range(interval_begin, *coordinate)) {
+                                    return false;
+                                }
                                 interval_begin = *coordinate + 1;
+                            }
+                            if (!ChargeTopologyWork(1)) {
+                                return false;
                             }
                             ++coordinate;
                         }
-                        add_required_prefix_range(interval_begin, contract.parent_depth);
+                        if (!charge_and_add_required_prefix_range(interval_begin, contract.parent_depth)) {
+                            return false;
+                        }
                         exposed_prefix_depth = contract.parent_depth;
                     }
 
@@ -4685,6 +5118,9 @@ struct ProfileSessionReader::Impl {
             std::uint64_t required_parent_record_count{0};
         };
         std::vector<FrameLossEvidence> frame_loss_evidence;
+        if (!ChargeTopologyLinearWork(source_loss_evidence.size())) {
+            return false;
+        }
         frame_loss_evidence.reserve(source_loss_evidence.size());
         for (const SourceLossEvidence& source : source_loss_evidence) {
             frame_loss_evidence.push_back({
@@ -4692,6 +5128,9 @@ struct ProfileSessionReader::Impl {
                 .local_hole_count             = source.local_hole_count,
                 .required_parent_record_count = source.required_parent_record_count,
             });
+        }
+        if (!ChargeTopologySortWork(frame_loss_evidence.size())) {
+            return false;
         }
         std::sort(
             frame_loss_evidence.begin(),
@@ -4701,6 +5140,9 @@ struct ProfileSessionReader::Impl {
             }
         );
         std::size_t frame_evidence_count = 0;
+        if (!ChargeTopologyLinearWork(frame_loss_evidence.size())) {
+            return false;
+        }
         for (std::size_t index = 0; index < frame_loss_evidence.size(); ++index) {
             if (frame_evidence_count == 0 || frame_loss_evidence[frame_evidence_count - 1].frame_id !=
                                                  frame_loss_evidence[index].frame_id) {
@@ -4743,6 +5185,10 @@ struct ProfileSessionReader::Impl {
                        static_cast<const FrameLossEvidence*>(nullptr);
         };
 
+        if (!ChargeTopologySortWork(missing_parent_keys.size()) ||
+            !ChargeTopologyLinearWork(missing_parent_keys.size())) {
+            return false;
+        }
         std::sort(missing_parent_keys.begin(), missing_parent_keys.end());
         missing_parent_keys.erase(
             std::unique(
@@ -4754,6 +5200,10 @@ struct ProfileSessionReader::Impl {
             ),
             missing_parent_keys.end()
         );
+        if (!ChargeTopologySortWork(missing_frame_ids.size()) ||
+            !ChargeTopologyLinearWork(missing_frame_ids.size())) {
+            return false;
+        }
         std::sort(missing_frame_ids.begin(), missing_frame_ids.end());
         missing_frame_ids.erase(
             std::unique(missing_frame_ids.begin(), missing_frame_ids.end()), missing_frame_ids.end()
@@ -4791,6 +5241,9 @@ struct ProfileSessionReader::Impl {
             return true;
         };
 
+        if (!ChargeTopologyLinearWork(frames.size())) {
+            return false;
+        }
         for (std::size_t index = 0; index < frames.size(); ++index) {
             GpuFrameRecord&     frame  = frames[index];
             const std::uint64_t errors = frame_error_counts[index];
@@ -4807,7 +5260,12 @@ struct ProfileSessionReader::Impl {
                 return false;
             }
 
-            const std::uint64_t      missing_scopes          = frame.admitted_scope_count - frame.scope_count;
+            const std::uint64_t missing_scopes = frame.admitted_scope_count - frame.scope_count;
+            if (!ChargeTopologyBinarySearchWork(missing_parent_keys.size()) ||
+                !ChargeTopologyBinarySearchWork(missing_parent_keys.size()) ||
+                !ChargeTopologyBinarySearchWork(frame_loss_evidence.size())) {
+                return false;
+            }
             const std::uint64_t      missing_parents         = missing_parent_count(frame.frame_id);
             const FrameLossEvidence* loss_evidence           = find_frame_loss_evidence(frame.frame_id);
             const std::uint64_t      required_parent_records = std::max(
@@ -4849,7 +5307,15 @@ struct ProfileSessionReader::Impl {
         if (!add_required_gpu_drops(static_cast<std::uint64_t>(missing_frame_ids.size()))) {
             return false;
         }
+        if (!ChargeTopologyLinearWork(missing_frame_ids.size())) {
+            return false;
+        }
         for (const std::uint64_t frame_id : missing_frame_ids) {
+            if (!ChargeTopologyBinarySearchWork(frame_loss_evidence.size()) ||
+                !ChargeTopologyBinarySearchWork(missing_parent_keys.size()) ||
+                !ChargeTopologyBinarySearchWork(missing_parent_keys.size())) {
+                return false;
+            }
             const FrameLossEvidence* loss_evidence           = find_frame_loss_evidence(frame_id);
             const std::uint64_t      required_parent_records = std::max(
                 missing_parent_count(frame_id),
@@ -4872,6 +5338,9 @@ struct ProfileSessionReader::Impl {
         }
 
         std::uint64_t previous_root_index = kInvalidSessionIndex;
+        if (!ChargeTopologyLinearWork(scopes.size())) {
+            return false;
+        }
         for (std::size_t index = 0; index < scopes.size(); ++index) {
             const GpuScopeRecord& scope = scopes[index];
             if (scope.parent_scope_id != 0 || scope.frame_index == kInvalidSessionIndex) {
@@ -4919,6 +5388,9 @@ struct ProfileSessionReader::Impl {
             previous_root_index = index;
         }
 
+        if (!ChargeTopologyLinearWork(scopes.size())) {
+            return false;
+        }
         for (std::size_t index = 0; index < scopes.size(); ++index) {
             const GpuScopeRecord& scope = scopes[index];
             if (scope.frame_index == kInvalidSessionIndex) {
@@ -4960,6 +5432,9 @@ struct ProfileSessionReader::Impl {
                 return false;
             }
         }
+        if (!ChargeTopologyLinearWork(frames.size())) {
+            return false;
+        }
         for (std::size_t index = 0; index < frames.size(); ++index) {
             GpuFrameRecord& frame         = frames[index];
             frame.timing_topology_trusted = frame.status == ProfileGpuFrameStatus::Complete &&
@@ -4970,7 +5445,13 @@ struct ProfileSessionReader::Impl {
     }
 
     [[nodiscard]] bool BuildIndexes(bool _forensic) {
+        if (!ChargeTopologySortWork(record_sequences.size())) {
+            return false;
+        }
         std::sort(record_sequences.begin(), record_sequences.end());
+        if (!ChargeTopologyLinearWork(record_sequences.size())) {
+            return false;
+        }
         if (!record_sequences.empty() && record_sequences.front() == 0) {
             Fail(
                 SessionLoadStatus::ProtocolViolation,

--- a/source/tool/profile_consumer/source/ProfileSession.cpp
+++ b/source/tool/profile_consumer/source/ProfileSession.cpp
@@ -1033,15 +1033,23 @@ struct ProfileSessionReader::Impl {
     }
 
     [[nodiscard]] bool ValidateLossSequenceAllocation() {
+        if (session.impl_->losses.empty()) {
+            return true;
+        }
+
         struct SequenceDemand {
             std::uint64_t release_sequence{0};
             std::uint64_t deadline_sequence{0};
             std::uint64_t count{0};
         };
-        std::vector<std::uint64_t>  occupied_sequences = record_sequences;
-        std::vector<SequenceDemand> residual_demands;
-        residual_demands.reserve(session.impl_->losses.size());
 
+        const std::uint64_t loss_notice_count = static_cast<std::uint64_t>(session.impl_->losses.size());
+        if (!ChargeTopologyWork(loss_notice_count)) {
+            return false;
+        }
+
+        std::uint64_t mandatory_sequence_count = 0;
+        std::uint64_t residual_demand_count    = 0;
         for (const ProfileLossRecord& loss : session.impl_->losses) {
             if (loss.first_sequence == 0 ||
                 (loss.record_count == 1 && loss.first_sequence != loss.last_sequence)) {
@@ -1053,9 +1061,50 @@ struct ProfileSessionReader::Impl {
                 return false;
             }
 
-            occupied_sequences.push_back(loss.first_sequence);
+            std::uint64_t mandatory_for_loss = 1;
             if (loss.record_count != 1) {
-                occupied_sequences.push_back(loss.last_sequence);
+                ++mandatory_for_loss;
+            }
+            if (loss.record_count > 2) {
+                ++residual_demand_count;
+            }
+            if (AddOverflow(mandatory_sequence_count, mandatory_for_loss, mandatory_sequence_count)) {
+                Fail(
+                    SessionLoadStatus::LimitExceeded,
+                    SessionErrorCode::LimitExceeded,
+                    "profile loss allocation preprocessing overflows",
+                    DecodeStatus::LimitExceeded,
+                    SessionLimitKind::TopologyWorkItems
+                );
+                return false;
+            }
+        }
+
+        std::uint64_t construction_work = 0;
+        if (AddOverflow(mandatory_sequence_count, residual_demand_count, construction_work) ||
+            mandatory_sequence_count > static_cast<std::uint64_t>(std::numeric_limits<std::size_t>::max()) ||
+            residual_demand_count > static_cast<std::uint64_t>(std::numeric_limits<std::size_t>::max())) {
+            Fail(
+                SessionLoadStatus::LimitExceeded,
+                SessionErrorCode::LimitExceeded,
+                "profile loss allocation model exceeds the addressable range",
+                DecodeStatus::LimitExceeded,
+                SessionLimitKind::TopologyWorkItems
+            );
+            return false;
+        }
+        if (!ChargeTopologyWork(construction_work)) {
+            return false;
+        }
+
+        std::vector<std::uint64_t> mandatory_sequences;
+        mandatory_sequences.reserve(static_cast<std::size_t>(mandatory_sequence_count));
+        std::vector<SequenceDemand> residual_demands;
+        residual_demands.reserve(static_cast<std::size_t>(residual_demand_count));
+        for (const ProfileLossRecord& loss : session.impl_->losses) {
+            mandatory_sequences.push_back(loss.first_sequence);
+            if (loss.record_count != 1) {
+                mandatory_sequences.push_back(loss.last_sequence);
             }
             if (loss.record_count > 2) {
                 residual_demands.push_back({
@@ -1066,9 +1115,38 @@ struct ProfileSessionReader::Impl {
             }
         }
 
-        std::sort(occupied_sequences.begin(), occupied_sequences.end());
-        if (std::adjacent_find(occupied_sequences.begin(), occupied_sequences.end()) !=
-            occupied_sequences.end()) {
+        const auto charge_sort_work = [&](std::uint64_t _count) {
+            std::uint64_t width = 1;
+            while (width < _count) {
+                if (!ChargeTopologyWork(_count)) {
+                    return false;
+                }
+                if (width > std::numeric_limits<std::uint64_t>::max() / 2) {
+                    break;
+                }
+                width *= 2;
+            }
+            return true;
+        };
+        const auto charge_binary_search = [&](std::size_t _count) {
+            std::uint64_t work      = 0;
+            std::size_t   remaining = _count;
+            while (remaining != 0) {
+                ++work;
+                remaining /= 2;
+            }
+            return ChargeTopologyWork(work);
+        };
+
+        if (!charge_sort_work(mandatory_sequence_count)) {
+            return false;
+        }
+        std::sort(mandatory_sequences.begin(), mandatory_sequences.end());
+        if (!ChargeTopologyWork(mandatory_sequence_count)) {
+            return false;
+        }
+        if (std::adjacent_find(mandatory_sequences.begin(), mandatory_sequences.end()) !=
+            mandatory_sequences.end()) {
             Fail(
                 SessionLoadStatus::ProtocolViolation,
                 SessionErrorCode::RecordSequenceInvalid,
@@ -1076,9 +1154,29 @@ struct ProfileSessionReader::Impl {
             );
             return false;
         }
+        if (!ChargeTopologyWork(mandatory_sequence_count)) {
+            return false;
+        }
+        for (const std::uint64_t sequence : mandatory_sequences) {
+            if (!charge_binary_search(record_sequences.size())) {
+                return false;
+            }
+            const auto record = std::lower_bound(record_sequences.begin(), record_sequences.end(), sequence);
+            if (record != record_sequences.end() && *record == sequence) {
+                Fail(
+                    SessionLoadStatus::ProtocolViolation,
+                    SessionErrorCode::RecordSequenceInvalid,
+                    "profile records and loss notices claim the same allocated sequence"
+                );
+                return false;
+            }
+        }
 
         if (residual_demands.empty()) {
             return true;
+        }
+        if (!charge_sort_work(residual_demand_count)) {
+            return false;
         }
         std::sort(
             residual_demands.begin(),
@@ -1098,8 +1196,18 @@ struct ProfileSessionReader::Impl {
         const auto later_deadline = [](const PendingDemand& _left, const PendingDemand& _right) {
             return _left.deadline_sequence > _right.deadline_sequence;
         };
+        std::vector<PendingDemand> pending_storage;
+        pending_storage.reserve(residual_demands.size());
         std::priority_queue<PendingDemand, std::vector<PendingDemand>, decltype(later_deadline)>
-            pending_demands(later_deadline);
+                   pending_demands(later_deadline, std::move(pending_storage));
+        const auto charge_heap_work = [&](std::size_t _size) {
+            std::uint64_t work = 1;
+            while (_size > 1) {
+                ++work;
+                _size /= 2;
+            }
+            return ChargeTopologyWork(work);
+        };
 
         const auto fail_allocation = [&]() {
             Fail(
@@ -1111,15 +1219,22 @@ struct ProfileSessionReader::Impl {
         };
 
         std::size_t   demand_index             = 0;
-        std::size_t   occupied_index           = 0;
+        std::size_t   record_index             = 0;
+        std::size_t   mandatory_index          = 0;
         std::uint64_t position                 = residual_demands.front().release_sequence;
         bool          sequence_space_exhausted = false;
         while (demand_index < residual_demands.size() || !pending_demands.empty()) {
+            if (!ChargeTopologyWork(1)) {
+                return false;
+            }
             if (sequence_space_exhausted) {
                 return fail_allocation();
             }
             while (demand_index < residual_demands.size() &&
                    residual_demands[demand_index].release_sequence <= position) {
+                if (!charge_heap_work(pending_demands.size() + 1)) {
+                    return false;
+                }
                 pending_demands.push({
                     .deadline_sequence = residual_demands[demand_index].deadline_sequence,
                     .remaining_count   = residual_demands[demand_index].count,
@@ -1134,27 +1249,54 @@ struct ProfileSessionReader::Impl {
                 return fail_allocation();
             }
 
-            occupied_index = static_cast<std::size_t>(
-                std::lower_bound(
-                    occupied_sequences.begin() + occupied_index, occupied_sequences.end(), position
-                ) -
-                occupied_sequences.begin()
-            );
-            if (occupied_index < occupied_sequences.size() &&
-                occupied_sequences[occupied_index] == position) {
+            if (record_index < record_sequences.size() && record_sequences[record_index] < position) {
+                if (!charge_binary_search(record_sequences.size() - record_index)) {
+                    return false;
+                }
+                record_index = static_cast<std::size_t>(
+                    std::lower_bound(
+                        record_sequences.begin() + record_index, record_sequences.end(), position
+                    ) -
+                    record_sequences.begin()
+                );
+            }
+            while (mandatory_index < mandatory_sequences.size() &&
+                   mandatory_sequences[mandatory_index] < position) {
+                if (!ChargeTopologyWork(1)) {
+                    return false;
+                }
+                ++mandatory_index;
+            }
+
+            const bool          has_record    = record_index < record_sequences.size();
+            const bool          has_mandatory = mandatory_index < mandatory_sequences.size();
+            const std::uint64_t next_record =
+                has_record ? record_sequences[record_index] : std::numeric_limits<std::uint64_t>::max();
+            const std::uint64_t next_mandatory = has_mandatory ? mandatory_sequences[mandatory_index] :
+                                                                 std::numeric_limits<std::uint64_t>::max();
+            const bool          has_occupied   = has_record || has_mandatory;
+            const std::uint64_t next_occupied  = std::min(next_record, next_mandatory);
+            if (has_occupied && next_occupied == position) {
                 if (position == std::numeric_limits<std::uint64_t>::max()) {
                     return fail_allocation();
                 }
+                if (has_record && next_record == position) {
+                    ++record_index;
+                } else {
+                    ++mandatory_index;
+                }
                 ++position;
-                ++occupied_index;
                 continue;
             }
 
+            if (!charge_heap_work(pending_demands.size())) {
+                return false;
+            }
             PendingDemand demand = pending_demands.top();
             pending_demands.pop();
             std::uint64_t batch_end = demand.deadline_sequence;
-            if (occupied_index < occupied_sequences.size() && occupied_sequences[occupied_index] > position) {
-                batch_end = std::min(batch_end, occupied_sequences[occupied_index] - 1);
+            if (has_occupied && next_occupied > position) {
+                batch_end = std::min(batch_end, next_occupied - 1);
             }
             if (demand_index < residual_demands.size() &&
                 residual_demands[demand_index].release_sequence > position) {
@@ -1175,6 +1317,9 @@ struct ProfileSessionReader::Impl {
                 position = batch_end + 1;
             }
             if (demand.remaining_count != 0) {
+                if (!charge_heap_work(pending_demands.size() + 1)) {
+                    return false;
+                }
                 pending_demands.push(demand);
             }
         }


### PR DESCRIPTION
## What changed

- add a bounded, arbitrary-chunk ProfileDump v3 reader that atomically publishes an immutable session model at EOF
- materialize CPU tracks, GPU logical tracks/physical timestamp domains, schemas, Loss evidence, and forensic truncated captures
- add `MoerProfileSummary` with a stable `moer.profile.summary` v1 JSON/exit-code contract and Windows Unicode-path support
- harden `Memory::MallocN`/`MoerStlAllocator` overflow and allocation-failure behavior so consumer OOM paths cannot terminate through `noexcept`
- add exhaustive consumer and child-process CLI contract tests

## Why

The current main branch already produces the modern ProfileDump v3 stream, but lacked the dev_parallel-style offline consumer/session layer needed to inspect captures safely. This ports that product capability onto main's current protocol without reviving the obsolete Trace/MRTC/TCP schema or changing renderer execution.

## Contract and safety

- strict SessionBegin/Schema/Record/Loss/SessionEnd validation
- bounded packet/model/count/codec limits and stable error codes
- forensic mode only publishes a validated prefix; CRC/schema/semantic contradictions remain hard failures
- CPU steady-clock and GPU raw device timestamp domains remain explicitly uncalibrated
- logical queue roles remain distinct even when they share a physical queue domain
- unknown schemas retain descriptors/counts without unsafe materialization

## Validation

- Debug full build; CTest 28/28
- RelWithDebInfo full build; CTest 28/28
- Release consumer/CLI targets; focused CTest 2/2
- real 166,745,345-byte RT export capture: Complete, 1,065,685 records, zero drops
- real 403,193,856-byte `.inprogress` capture: ForensicTruncated/exit 2 with validated prefix
- multiple independent pre-PR audits; all reported P0-P2 findings addressed and re-reviewed clean

No Editor/renderer runtime path was changed, so runtime validation used real Editor-produced MPD captures rather than launching the Editor.