### PR TITLE
Phase 21D.2a.1: harvest live ProfileDump TLS shards

### DIFF
--- a/source/runtime/core/include/profile/ProfileDump.h
+++ b/source/runtime/core/include/profile/ProfileDump.h
@@ -153,19 +153,19 @@ Emit(SchemaHandle _schema, std::span<const FieldValueView> _values) noexcept;
 // Producer-thread operation. Publishes only the calling thread's TLS shard,
 // then waits until the already-published writer interval has been flushed to
 // the in-progress stream. This is not an fsync/power-loss durability
-// guarantee. Each producer must call this before it exits, or exit and let its
-// TLS destructor publish, before the owner begins final shutdown.
+// guarantee.
 [[nodiscard]] CORE_API FlushResult FlushThreadLocal() noexcept;
 
-// Process-owner synchronization fence for chunks that producers have already
-// published to the global queue. It cannot discover another live thread's
-// sub-threshold TLS shard and therefore is not a substitute for producer
-// FlushThreadLocal/exit.
+// Process-owner synchronization fence. Harvests every currently registered
+// live TLS shard, then flushes that published writer interval. The harvest is
+// a per-shard cut rather than one global instantaneous snapshot: an Emit that
+// commits after its shard was visited can remain for the next interval.
 [[nodiscard]] CORE_API FlushResult FlushAll() noexcept;
 
-// Process-owner finalization. All producer threads must first FlushThreadLocal
-// or exit and be joined. The owner calls Shutdown last; it drains accepted
-// emitters, closes the writer, and publishes .inprogress as the final file.
+// Process-owner finalization. Closes admission, waits for already-accepted
+// Emit calls, harvests all registered live TLS shards, drains the writer, and
+// publishes .inprogress as the final file. Producers need not exit or flush
+// individually, but must not begin a new capture Emit after Shutdown starts.
 [[nodiscard]] CORE_API ShutdownResult Shutdown() noexcept;
 
 [[nodiscard]] CORE_API RuntimeState GetRuntimeState() noexcept;

--- a/source/runtime/core/source/profile/ProfileDump.cpp
+++ b/source/runtime/core/source/profile/ProfileDump.cpp
@@ -183,6 +183,9 @@ struct TestHooks {
     bool                pause_after_start{false};
     bool                writer_paused{false};
     bool                writer_resume{false};
+    bool                pause_emitter_after_admission{false};
+    bool                emitter_paused{false};
+    bool                emitter_resume{false};
 };
 
 struct PendingLossSlot {
@@ -191,9 +194,12 @@ struct PendingLossSlot {
     LossNotice    notice{};
 };
 
+struct ThreadLocalShardNode;
+
 struct Hub {
     std::mutex              lifecycle_mutex{};
     std::mutex              worker_join_mutex{};
+    std::mutex              tls_registry_mutex{};
     std::mutex              mutex{};
     std::condition_variable work_cv{};
     std::condition_variable start_cv{};
@@ -224,6 +230,11 @@ struct Hub {
     // unpublished so Shutdown can wait for every already-admitted Emit call.
     std::shared_ptr<Admission> retired_admission{};
 
+    // Protected by tls_registry_mutex. Nodes are owned by live producer
+    // threads and remain linked across capture generations until TLS
+    // destruction.
+    ThreadLocalShardNode* tls_shards_head{nullptr};
+
     AtomicStats stats{};
     TestHooks   test_hooks{};
 };
@@ -245,11 +256,21 @@ enum class PublishResult : std::uint8_t {
     Stale,
 };
 
-struct ThreadLocalShard {
+struct ThreadLocalShardNode {
+    std::mutex                 mutex{};
     std::uint64_t              generation{0};
     std::vector<PendingRecord> records{};
     std::size_t                payload_bytes{0};
+    ThreadLocalShardNode*      registry_previous{nullptr};
+    ThreadLocalShardNode*      registry_next{nullptr};
+    std::atomic<bool>          registered{false};
+};
 
+struct ThreadLocalShard {
+    // The registry points to this member rather than the TLS owner object.
+    // Its lifetime extends through the owner's destructor body, where the node
+    // is published and unlinked before member destruction begins.
+    ThreadLocalShardNode node{};
     ~ThreadLocalShard();
 };
 
@@ -426,103 +447,128 @@ void InjectOrContinue(Testing::FaultPoint _point, RuntimeFault _fault) {
     }
 }
 
-void ResetShard(ThreadLocalShard& _shard) noexcept {
-    _shard.records.clear();
-    _shard.records.shrink_to_fit();
-    _shard.payload_bytes = 0;
-    _shard.generation    = 0;
+void LinkTlsShardLocked(Hub& _hub, ThreadLocalShardNode& _shard) noexcept {
+    if (_shard.registered.load(std::memory_order_relaxed)) {
+        return;
+    }
+    _shard.registry_previous = nullptr;
+    _shard.registry_next     = _hub.tls_shards_head;
+    if (_hub.tls_shards_head) {
+        _hub.tls_shards_head->registry_previous = &_shard;
+    }
+    _hub.tls_shards_head = &_shard;
+    _shard.registered.store(true, std::memory_order_release);
 }
 
-void CountDroppedChunk(Hub& _hub, const ImmutableChunk& _chunk, PublishResult _reason) noexcept {
-    const std::uint64_t record_count = static_cast<std::uint64_t>(_chunk.records.size());
-    if (record_count == 0) {
+void UnlinkTlsShardLocked(Hub& _hub, ThreadLocalShardNode& _shard) noexcept {
+    if (!_shard.registered.load(std::memory_order_relaxed)) {
+        return;
+    }
+    if (_shard.registry_previous) {
+        _shard.registry_previous->registry_next = _shard.registry_next;
+    } else {
+        _hub.tls_shards_head = _shard.registry_next;
+    }
+    if (_shard.registry_next) {
+        _shard.registry_next->registry_previous = _shard.registry_previous;
+    }
+    _shard.registry_previous = nullptr;
+    _shard.registry_next     = nullptr;
+    _shard.registered.store(false, std::memory_order_release);
+}
+
+std::unique_lock<std::mutex> LockRegisteredTlsShard(ThreadLocalShardNode& _shard) {
+    if (_shard.registered.load(std::memory_order_acquire)) {
+        return std::unique_lock(_shard.mutex);
+    }
+
+    Hub&                         hub = GetHub();
+    std::unique_lock<std::mutex> registry_lock(hub.tls_registry_mutex);
+    std::unique_lock<std::mutex> shard_lock(_shard.mutex);
+    if (!_shard.registered.load(std::memory_order_relaxed)) {
+        LinkTlsShardLocked(hub, _shard);
+    }
+    registry_lock.unlock();
+    return shard_lock;
+}
+
+void CountDroppedChunk(Hub& _hub, std::uint64_t _record_count, PublishResult _reason) noexcept {
+    if (_record_count == 0) {
         return;
     }
     _hub.stats.chunks_dropped.fetch_add(1, std::memory_order_relaxed);
     switch (_reason) {
         case PublishResult::QueueFull:
-            _hub.stats.records_dropped_queue_full.fetch_add(record_count, std::memory_order_relaxed);
+            _hub.stats.records_dropped_queue_full.fetch_add(_record_count, std::memory_order_relaxed);
             break;
         case PublishResult::Faulted:
-            _hub.stats.records_dropped_after_fault.fetch_add(record_count, std::memory_order_relaxed);
+            _hub.stats.records_dropped_after_fault.fetch_add(_record_count, std::memory_order_relaxed);
             break;
         case PublishResult::Stale:
-            _hub.stats.records_dropped_stale_generation.fetch_add(record_count, std::memory_order_relaxed);
+            _hub.stats.records_dropped_stale_generation.fetch_add(_record_count, std::memory_order_relaxed);
             break;
         default:
-            _hub.stats.records_dropped_stopped.fetch_add(record_count, std::memory_order_relaxed);
+            _hub.stats.records_dropped_stopped.fetch_add(_record_count, std::memory_order_relaxed);
             break;
     }
 }
 
-PublishResult PublishTlsShard(ThreadLocalShard& _shard) noexcept {
-    if (_shard.records.empty()) {
+PublishResult PublishDetachedChunk(Hub& _hub, ImmutableChunk&& _chunk) noexcept {
+    const std::uint64_t record_count = static_cast<std::uint64_t>(_chunk.records.size());
+    if (record_count == 0) {
         return PublishResult::Nothing;
     }
 
-    ImmutableChunk chunk{
-        .generation    = _shard.generation,
-        .records       = std::move(_shard.records),
-        .payload_bytes = _shard.payload_bytes,
-    };
-    if (!chunk.records.empty()) {
-        chunk.first_sequence = chunk.records.front().sequence;
-        chunk.last_sequence  = chunk.records.front().sequence;
-        for (const PendingRecord& record : chunk.records) {
-            chunk.first_sequence = std::min(chunk.first_sequence, record.sequence);
-            chunk.last_sequence  = std::max(chunk.last_sequence, record.sequence);
-            chunk.value_bytes    = SaturatingAdd(chunk.value_bytes, RecordValueBytes(record));
-        }
-    }
-    _shard.records       = {};
-    _shard.payload_bytes = 0;
-    _shard.generation    = 0;
-
-    Hub&          hub    = GetHub();
-    PublishResult result = PublishResult::Rejected;
+    const std::uint64_t generation     = _chunk.generation;
+    const std::uint64_t payload_bytes  = static_cast<std::uint64_t>(_chunk.payload_bytes);
+    const std::uint64_t first_sequence = _chunk.first_sequence;
+    const std::uint64_t last_sequence  = _chunk.last_sequence;
+    const std::uint64_t value_bytes    = _chunk.value_bytes;
+    PublishResult       result         = PublishResult::Rejected;
     {
-        std::lock_guard     lock(hub.mutex);
-        const RuntimeState  state      = hub.state.load(std::memory_order_acquire);
-        const std::uint64_t generation = hub.generation.load(std::memory_order_acquire);
+        std::lock_guard     lock(_hub.mutex);
+        const RuntimeState  state             = _hub.state.load(std::memory_order_acquire);
+        const std::uint64_t active_generation = _hub.generation.load(std::memory_order_acquire);
 
         if (state == RuntimeState::Faulted) {
             result = PublishResult::Faulted;
-        } else if (chunk.generation != generation || chunk.generation == 0) {
+        } else if (generation != active_generation || generation == 0) {
             result = PublishResult::Stale;
         } else if (state != RuntimeState::Running) {
             result = PublishResult::Rejected;
         } else {
-            const std::uint64_t resident_chunks  = hub.stats.resident_chunks.load(std::memory_order_relaxed);
-            const std::uint64_t resident_records = hub.stats.resident_records.load(std::memory_order_relaxed);
-            const std::uint64_t resident_bytes   = hub.stats.resident_bytes.load(std::memory_order_relaxed);
-            const std::uint64_t chunk_records    = static_cast<std::uint64_t>(chunk.records.size());
-            const std::uint64_t chunk_bytes      = static_cast<std::uint64_t>(chunk.payload_bytes);
+            const std::uint64_t resident_chunks = _hub.stats.resident_chunks.load(std::memory_order_relaxed);
+            const std::uint64_t resident_records =
+                _hub.stats.resident_records.load(std::memory_order_relaxed);
+            const std::uint64_t resident_bytes = _hub.stats.resident_bytes.load(std::memory_order_relaxed);
 
             const bool full =
                 WouldExceedLimit(
-                    resident_chunks, 1, static_cast<std::uint64_t>(hub.config.queue_max_chunks)
+                    resident_chunks, 1, static_cast<std::uint64_t>(_hub.config.queue_max_chunks)
                 ) ||
                 WouldExceedLimit(
-                    resident_records, chunk_records, static_cast<std::uint64_t>(hub.config.queue_max_records)
+                    resident_records, record_count, static_cast<std::uint64_t>(_hub.config.queue_max_records)
                 ) ||
                 WouldExceedLimit(
-                    resident_bytes, chunk_bytes, static_cast<std::uint64_t>(hub.config.queue_max_bytes)
+                    resident_bytes, payload_bytes, static_cast<std::uint64_t>(_hub.config.queue_max_bytes)
                 );
             if (full) {
                 result = PublishResult::QueueFull;
             } else {
                 try {
-                    hub.messages.emplace_back(std::move(chunk));
-                    hub.stats.resident_chunks.store(resident_chunks + 1, std::memory_order_relaxed);
-                    hub.stats.resident_records.store(
-                        resident_records + chunk_records, std::memory_order_relaxed
+                    _hub.messages.emplace_back(std::move(_chunk));
+                    _hub.stats.resident_chunks.store(resident_chunks + 1, std::memory_order_relaxed);
+                    _hub.stats.resident_records.store(
+                        resident_records + record_count, std::memory_order_relaxed
                     );
-                    hub.stats.resident_bytes.store(resident_bytes + chunk_bytes, std::memory_order_relaxed);
-                    UpdateHighWater(hub.stats.high_water_chunks, resident_chunks + 1);
-                    UpdateHighWater(hub.stats.high_water_records, resident_records + chunk_records);
-                    UpdateHighWater(hub.stats.high_water_bytes, resident_bytes + chunk_bytes);
-                    hub.stats.records_enqueued.fetch_add(chunk_records, std::memory_order_relaxed);
-                    hub.stats.chunks_enqueued.fetch_add(1, std::memory_order_relaxed);
+                    _hub.stats.resident_bytes.store(
+                        resident_bytes + payload_bytes, std::memory_order_relaxed
+                    );
+                    UpdateHighWater(_hub.stats.high_water_chunks, resident_chunks + 1);
+                    UpdateHighWater(_hub.stats.high_water_records, resident_records + record_count);
+                    UpdateHighWater(_hub.stats.high_water_bytes, resident_bytes + payload_bytes);
+                    _hub.stats.records_enqueued.fetch_add(record_count, std::memory_order_relaxed);
+                    _hub.stats.chunks_enqueued.fetch_add(1, std::memory_order_relaxed);
                     result = PublishResult::Accepted;
                 } catch (...) {
                     result = PublishResult::QueueFull;
@@ -531,30 +577,95 @@ PublishResult PublishTlsShard(ThreadLocalShard& _shard) noexcept {
         }
         if (result == PublishResult::QueueFull) {
             AccumulateLossLocked(
-                hub,
-                chunk.generation,
-                chunk.first_sequence,
-                chunk.last_sequence,
-                static_cast<std::uint64_t>(chunk.records.size()),
-                chunk.value_bytes,
+                _hub,
+                generation,
+                first_sequence,
+                last_sequence,
+                record_count,
+                value_bytes,
                 LossReason::QueueFull
             );
         }
     }
 
     if (result == PublishResult::Accepted) {
-        hub.work_cv.notify_one();
+        _hub.work_cv.notify_one();
     } else {
-        CountDroppedChunk(hub, chunk, result);
+        CountDroppedChunk(_hub, record_count, result);
         if (result == PublishResult::QueueFull) {
-            hub.work_cv.notify_one();
+            _hub.work_cv.notify_one();
         }
     }
     return result;
 }
 
+PublishResult PublishTlsShardLocked(Hub& _hub, ThreadLocalShardNode& _shard) noexcept {
+    if (_shard.records.empty()) {
+        _shard.payload_bytes = 0;
+        _shard.generation    = 0;
+        return PublishResult::Nothing;
+    }
+
+    ImmutableChunk chunk{};
+    chunk.generation    = _shard.generation;
+    chunk.payload_bytes = _shard.payload_bytes;
+    chunk.records.swap(_shard.records);
+    _shard.payload_bytes = 0;
+    _shard.generation    = 0;
+
+    chunk.first_sequence = chunk.records.front().sequence;
+    chunk.last_sequence  = chunk.records.front().sequence;
+    for (const PendingRecord& record : chunk.records) {
+        chunk.first_sequence = std::min(chunk.first_sequence, record.sequence);
+        chunk.last_sequence  = std::max(chunk.last_sequence, record.sequence);
+        chunk.value_bytes    = SaturatingAdd(chunk.value_bytes, RecordValueBytes(record));
+    }
+    return PublishDetachedChunk(_hub, std::move(chunk));
+}
+
+PublishResult PublishTlsShard(ThreadLocalShardNode& _shard) noexcept {
+    Hub&            hub = GetHub();
+    std::lock_guard lock(_shard.mutex);
+    return PublishTlsShardLocked(hub, _shard);
+}
+
+int PublishResultPriority(PublishResult _result) noexcept {
+    switch (_result) {
+        case PublishResult::Faulted:
+            return 5;
+        case PublishResult::QueueFull:
+            return 4;
+        case PublishResult::Rejected:
+        case PublishResult::Stale:
+            return 3;
+        case PublishResult::Accepted:
+            return 2;
+        case PublishResult::Nothing:
+            return 1;
+    }
+    return 0;
+}
+
+PublishResult MergePublishResult(PublishResult _aggregate, PublishResult _next) noexcept {
+    return PublishResultPriority(_next) > PublishResultPriority(_aggregate) ? _next : _aggregate;
+}
+
+// The caller owns tls_registry_mutex for the entire raw-pointer traversal.
+PublishResult HarvestRegisteredTlsShardsLocked(Hub& _hub) noexcept {
+    PublishResult aggregate = PublishResult::Nothing;
+    for (ThreadLocalShardNode* shard = _hub.tls_shards_head; shard; shard = shard->registry_next) {
+        std::lock_guard shard_lock(shard->mutex);
+        aggregate = MergePublishResult(aggregate, PublishTlsShardLocked(_hub, *shard));
+    }
+    return aggregate;
+}
+
 ThreadLocalShard::~ThreadLocalShard() {
-    (void)PublishTlsShard(*this);
+    Hub&            hub = GetHub();
+    std::lock_guard registry_lock(hub.tls_registry_mutex);
+    std::lock_guard shard_lock(node.mutex);
+    (void)PublishTlsShardLocked(hub, node);
+    UnlinkTlsShardLocked(hub, node);
 }
 
 std::shared_ptr<Admission> AcquireEmitter(Hub& _hub) noexcept {
@@ -571,6 +682,20 @@ std::shared_ptr<Admission> AcquireEmitter(Hub& _hub) noexcept {
     }
     ++candidate->active_emitters;
     return candidate;
+}
+
+void PauseEmitterAfterAdmissionIfRequested(Hub& _hub) noexcept {
+    std::unique_lock lock(_hub.mutex);
+    if (!_hub.test_hooks.pause_emitter_after_admission) {
+        return;
+    }
+    _hub.test_hooks.emitter_paused = true;
+    _hub.test_cv.notify_all();
+    _hub.test_cv.wait(lock, [&] {
+        return _hub.test_hooks.emitter_resume ||
+               _hub.state.load(std::memory_order_acquire) == RuntimeState::Faulted;
+    });
+    _hub.test_hooks.emitter_paused = false;
 }
 
 EmitStatus ReleaseEmitter(const std::shared_ptr<Admission>& _admission, EmitStatus _result) noexcept {
@@ -595,7 +720,7 @@ EmitStatus ReleaseEmitter(const std::shared_ptr<Admission>& _admission, EmitStat
     }
 
     const PublishResult publish_result =
-        force_publish ? PublishTlsShard(g_tls_shard) : PublishResult::Nothing;
+        force_publish ? PublishTlsShard(g_tls_shard.node) : PublishResult::Nothing;
 
     {
         std::lock_guard lock(hub.mutex);
@@ -1106,17 +1231,79 @@ EmitStatus MapEncodeStatus(EncodeStatus _status) noexcept {
     }
 }
 
-FlushResult PublishResultToFlush(PublishResult _result) noexcept {
-    switch (_result) {
-        case PublishResult::Nothing:
-            return FlushResult::NothingPending;
-        case PublishResult::Accepted:
-            return FlushResult::Completed;
-        case PublishResult::Faulted:
-            return FlushResult::Faulted;
-        default:
-            return FlushResult::Rejected;
+std::shared_ptr<FlushFence> PrepareFlushLocked(Hub& _hub, FlushResult& _immediate_result) noexcept {
+    const RuntimeState state = _hub.state.load(std::memory_order_acquire);
+    if (state == RuntimeState::Faulted) {
+        _immediate_result = FlushResult::Faulted;
+        return {};
     }
+    if (state != RuntimeState::Running) {
+        _immediate_result = FlushResult::Rejected;
+        return {};
+    }
+    if (_hub.stats.resident_chunks.load(std::memory_order_relaxed) == 0 && !_hub.file_dirty &&
+        !_hub.pending_loss.pending) {
+        _immediate_result = FlushResult::NothingPending;
+        return {};
+    }
+
+    std::shared_ptr<FlushFence> fence;
+    if (!_hub.messages.empty()) {
+        if (auto* tail_flush = std::get_if<FlushMessage>(&_hub.messages.back())) {
+            fence = tail_flush->fence;
+        }
+    } else if (_hub.active_flush_fence && !_hub.pending_loss.pending) {
+        fence = _hub.active_flush_fence;
+    }
+
+    if (!fence) {
+        try {
+            fence = std::make_shared<FlushFence>();
+            _hub.messages.emplace_back(FlushMessage{.fence = fence});
+        } catch (...) {
+            _immediate_result = FlushResult::Rejected;
+            return {};
+        }
+    }
+    _immediate_result = FlushResult::Completed;
+    return fence;
+}
+
+FlushResult WaitPreparedFlush(
+    Hub&                               _hub,
+    const std::shared_ptr<FlushFence>& _fence,
+    FlushResult                        _immediate_result
+) noexcept {
+    if (!_fence) {
+        return _immediate_result;
+    }
+    _hub.work_cv.notify_one();
+    return WaitFence(_fence);
+}
+
+FlushResult FlushPublishedInterval() noexcept {
+    Hub&                        hub = GetHub();
+    std::shared_ptr<FlushFence> fence;
+    FlushResult                 immediate_result = FlushResult::Rejected;
+    {
+        std::lock_guard lock(hub.mutex);
+        fence = PrepareFlushLocked(hub, immediate_result);
+    }
+    return WaitPreparedFlush(hub, fence, immediate_result);
+}
+
+FlushResult ResolveHarvestedFlush(PublishResult _published, FlushResult _flushed) noexcept {
+    if (_published == PublishResult::Faulted || _flushed == FlushResult::Faulted) {
+        return FlushResult::Faulted;
+    }
+    if (_flushed == FlushResult::Rejected || _published == PublishResult::QueueFull ||
+        _published == PublishResult::Rejected || _published == PublishResult::Stale) {
+        return FlushResult::Rejected;
+    }
+    if (_published == PublishResult::Nothing && _flushed == FlushResult::NothingPending) {
+        return FlushResult::NothingPending;
+    }
+    return _flushed == FlushResult::NothingPending ? FlushResult::Completed : _flushed;
 }
 
 } // namespace
@@ -1160,6 +1347,14 @@ StartResult Start(const RuntimeConfig& _config) noexcept {
         // Replacement applies only to the final output and must never unlink
         // another process's live or forensic in-progress capture.
 
+        // A completed Shutdown normally leaves every live TLS node empty.
+        // Defensively discard any stopped-generation residue before resetting
+        // statistics and publishing the next generation.
+        {
+            std::lock_guard registry_lock(hub.tls_registry_mutex);
+            (void)HarvestRegisteredTlsShardsLocked(hub);
+        }
+
         {
             std::lock_guard lock(hub.mutex);
             hub.config    = std::move(prepared_config);
@@ -1180,10 +1375,12 @@ StartResult Start(const RuntimeConfig& _config) noexcept {
             hub.generation.store(generation, std::memory_order_release);
             hub.schemas.store(std::move(initial_schemas), std::memory_order_release);
             hub.admission.store({}, std::memory_order_release);
-            hub.test_hooks.matching_hits = 0;
-            hub.test_hooks.fault_fired   = false;
-            hub.test_hooks.writer_paused = false;
-            hub.test_hooks.writer_resume = false;
+            hub.test_hooks.matching_hits  = 0;
+            hub.test_hooks.fault_fired    = false;
+            hub.test_hooks.writer_paused  = false;
+            hub.test_hooks.writer_resume  = false;
+            hub.test_hooks.emitter_paused = false;
+            hub.test_hooks.emitter_resume = false;
             hub.state.store(RuntimeState::Starting, std::memory_order_release);
         }
 
@@ -1308,6 +1505,7 @@ EmitStatus Emit(SchemaHandle _schema, std::span<const FieldValueView> _values) n
     const auto finish = [&](EmitStatus _result) noexcept {
         return ReleaseEmitter(admission, _result);
     };
+    PauseEmitterAfterAdmissionIfRequested(hub);
 
     if (!_schema || _schema.generation != admission->generation) {
         hub.stats.records_dropped_stale_generation.fetch_add(1, std::memory_order_relaxed);
@@ -1363,112 +1561,97 @@ EmitStatus Emit(SchemaHandle _schema, std::span<const FieldValueView> _values) n
         return finish(EmitStatus::RecordTooLarge);
     }
 
-    if (g_tls_shard.generation != 0 && g_tls_shard.generation != admission->generation) {
-        (void)PublishTlsShard(g_tls_shard);
-    }
-    if (g_tls_shard.generation == 0) {
-        g_tls_shard.generation = admission->generation;
+    const std::size_t     record_bytes = payload.size();
+    PublishResult         current_publish_result{PublishResult::Nothing};
+    bool                  append_failed{false};
+    ThreadLocalShardNode& tls_shard = g_tls_shard.node;
+    {
+        // The first append links this TLS node while holding registry -> shard.
+        // Subsequent appends use only the shard lock. Publication may then
+        // acquire Hub::mutex, preserving the one-way lock order.
+        auto shard_lock = LockRegisteredTlsShard(tls_shard);
+
+        if (tls_shard.generation != 0 && tls_shard.generation != admission->generation) {
+            (void)PublishTlsShardLocked(hub, tls_shard);
+        }
+        if (tls_shard.generation == 0) {
+            tls_shard.generation = admission->generation;
+        }
+
+        if (!tls_shard.records.empty() &&
+            (tls_shard.records.size() >= admission->config.tls_max_records ||
+             payload.size() > admission->config.tls_max_bytes - tls_shard.payload_bytes)) {
+            (void)PublishTlsShardLocked(hub, tls_shard);
+            tls_shard.generation = admission->generation;
+        }
+
+        try {
+            tls_shard.records.emplace_back(PendingRecord{
+                .schema_hash = _schema.hash,
+                .sequence    = sequence,
+                .payload     = std::move(payload),
+            });
+            tls_shard.payload_bytes += record_bytes;
+        } catch (...) {
+            append_failed = true;
+        }
+
+        if (!append_failed) {
+            hub.stats.records_committed.fetch_add(1, std::memory_order_relaxed);
+            const bool publish = tls_shard.records.size() >= admission->config.tls_publish_records ||
+                                 tls_shard.payload_bytes >= admission->config.tls_publish_bytes ||
+                                 tls_shard.records.size() >= admission->config.tls_max_records ||
+                                 tls_shard.payload_bytes >= admission->config.tls_max_bytes;
+            if (publish) {
+                current_publish_result = PublishTlsShardLocked(hub, tls_shard);
+            }
+        }
     }
 
-    if (!g_tls_shard.records.empty() &&
-        (g_tls_shard.records.size() >= admission->config.tls_max_records ||
-         payload.size() > admission->config.tls_max_bytes - g_tls_shard.payload_bytes)) {
-        (void)PublishTlsShard(g_tls_shard);
-        g_tls_shard.generation = admission->generation;
-    }
-
-    const std::size_t record_bytes = payload.size();
-    try {
-        g_tls_shard.payload_bytes += record_bytes;
-        g_tls_shard.records.emplace_back(PendingRecord{
-            .schema_hash = _schema.hash,
-            .sequence    = sequence,
-            .payload     = std::move(payload),
-        });
-    } catch (...) {
-        g_tls_shard.payload_bytes -= record_bytes;
+    // Release shard ownership before any path reaches ReleaseEmitter(); a
+    // closing admission may publish this same TLS shard from that function.
+    if (append_failed) {
         hub.stats.records_dropped_queue_full.fetch_add(1, std::memory_order_relaxed);
         AccumulateLoss(
             admission->generation, sequence, sequence, 1, attempted_value_bytes, LossReason::QueueFull
         );
         return finish(EmitStatus::QueueFull);
     }
-    hub.stats.records_committed.fetch_add(1, std::memory_order_relaxed);
 
-    const bool publish = g_tls_shard.records.size() >= admission->config.tls_publish_records ||
-                         g_tls_shard.payload_bytes >= admission->config.tls_publish_bytes ||
-                         g_tls_shard.records.size() >= admission->config.tls_max_records ||
-                         g_tls_shard.payload_bytes >= admission->config.tls_max_bytes;
-    if (publish) {
-        const PublishResult result = PublishTlsShard(g_tls_shard);
-        if (result == PublishResult::QueueFull) {
-            return finish(EmitStatus::QueueFull);
-        }
-        if (result == PublishResult::Faulted) {
-            return finish(EmitStatus::SinkFault);
-        }
-        if (result != PublishResult::Accepted) {
-            return finish(EmitStatus::Disabled);
-        }
+    if (current_publish_result == PublishResult::QueueFull) {
+        return finish(EmitStatus::QueueFull);
+    }
+    if (current_publish_result == PublishResult::Faulted) {
+        return finish(EmitStatus::SinkFault);
+    }
+    if (current_publish_result != PublishResult::Nothing &&
+        current_publish_result != PublishResult::Accepted) {
+        return finish(EmitStatus::Disabled);
     }
     return finish(EmitStatus::Accepted);
 }
 
 FlushResult FlushThreadLocal() noexcept {
-    const PublishResult published      = PublishTlsShard(g_tls_shard);
-    const FlushResult   publish_result = PublishResultToFlush(published);
-    if (publish_result == FlushResult::Faulted) {
-        return FlushResult::Faulted;
-    }
-    if (publish_result == FlushResult::Rejected) {
-        return FlushResult::Rejected;
-    }
-
-    const FlushResult flush_result = FlushAll();
-    if (flush_result == FlushResult::Faulted) {
-        return flush_result;
-    }
-    if (published == PublishResult::Nothing && flush_result == FlushResult::NothingPending) {
-        return FlushResult::NothingPending;
-    }
-    return flush_result == FlushResult::NothingPending ? FlushResult::Completed : flush_result;
+    const PublishResult published = PublishTlsShard(g_tls_shard.node);
+    return ResolveHarvestedFlush(published, FlushPublishedInterval());
 }
 
 FlushResult FlushAll() noexcept {
     Hub&                        hub = GetHub();
     std::shared_ptr<FlushFence> fence;
+    FlushResult                 immediate_result = FlushResult::Rejected;
+    PublishResult               harvested        = PublishResult::Nothing;
     {
-        std::lock_guard    lock(hub.mutex);
-        const RuntimeState state = hub.state.load(std::memory_order_acquire);
-        if (state == RuntimeState::Faulted) {
-            return FlushResult::Faulted;
-        }
-        if (state != RuntimeState::Running) {
-            return FlushResult::Rejected;
-        }
-        if (hub.stats.resident_chunks.load(std::memory_order_relaxed) == 0 && !hub.file_dirty &&
-            !hub.pending_loss.pending) {
-            return FlushResult::NothingPending;
-        }
-        if (!hub.messages.empty()) {
-            if (auto* tail_flush = std::get_if<FlushMessage>(&hub.messages.back())) {
-                fence = tail_flush->fence;
-            }
-        } else if (hub.active_flush_fence && !hub.pending_loss.pending) {
-            fence = hub.active_flush_fence;
-        }
-
-        if (!fence) {
-            try {
-                fence = std::make_shared<FlushFence>();
-                hub.messages.emplace_back(FlushMessage{.fence = fence});
-            } catch (...) {
-                return FlushResult::Rejected;
-            }
-        }
+        // Pin every intrusive node through traversal and append the writer
+        // fence before a TLS destructor or first registration can cross the
+        // registry frontier.
+        std::lock_guard registry_lock(hub.tls_registry_mutex);
+        harvested = HarvestRegisteredTlsShardsLocked(hub);
+        std::lock_guard hub_lock(hub.mutex);
+        fence = PrepareFlushLocked(hub, immediate_result);
     }
-    hub.work_cv.notify_one();
-    return WaitFence(fence);
+    const FlushResult flushed = WaitPreparedFlush(hub, fence, immediate_result);
+    return ResolveHarvestedFlush(harvested, flushed);
 }
 
 ShutdownResult Shutdown() noexcept {
@@ -1487,9 +1670,9 @@ ShutdownResult Shutdown() noexcept {
         });
         state = hub.state.load(std::memory_order_acquire);
     }
-    (void)PublishTlsShard(g_tls_shard);
 
     std::shared_ptr<FlushFence> fence;
+    bool                        harvest_live_shards = false;
     {
         std::unique_lock lock(hub.mutex);
         state = hub.state.load(std::memory_order_acquire);
@@ -1501,6 +1684,7 @@ ShutdownResult Shutdown() noexcept {
                 return !hub.retired_admission || hub.retired_admission->active_emitters == 0;
             });
             hub.retired_admission.reset();
+            harvest_live_shards = true;
         } else if (state == RuntimeState::Stopped) {
             // Reap outside Hub::mutex below.
         } else if (state == RuntimeState::Running) {
@@ -1519,24 +1703,7 @@ ShutdownResult Shutdown() noexcept {
                 return !closing_admission || closing_admission->active_emitters == 0;
             });
             hub.retired_admission.reset();
-
-            if (hub.state.load(std::memory_order_acquire) != RuntimeState::Faulted) {
-                hub.state.store(RuntimeState::Draining, std::memory_order_release);
-                try {
-                    if (ShouldInjectLocked(hub.test_hooks, Testing::FaultPoint::ShutdownFinalizeAllocation)) {
-                        throw std::bad_alloc{};
-                    }
-                    fence              = std::make_shared<FlushFence>();
-                    hub.shutdown_fence = fence;
-                    hub.messages.emplace_back(FinalizeMessage{.fence = fence});
-                } catch (...) {
-                    hub.shutdown_fence.reset();
-                    fence.reset();
-                    hub.state.store(RuntimeState::Faulted, std::memory_order_release);
-                    hub.last_fault.store(RuntimeFault::WriterException, std::memory_order_release);
-                    hub.test_hooks.writer_resume = true;
-                }
-            }
+            harvest_live_shards = true;
         } else if (state == RuntimeState::Draining) {
             fence = hub.shutdown_fence;
         }
@@ -1545,6 +1712,36 @@ ShutdownResult Shutdown() noexcept {
     if (state == RuntimeState::Stopped) {
         ReapWorker(hub);
         return ShutdownResult::AlreadyStopped;
+    }
+
+    if (harvest_live_shards) {
+        // No admitted Emit remains. Keep Running while every parked live TLS
+        // shard is published, then append Finalize while the registry frontier
+        // is still pinned so no destructor can reorder an old chunk after it.
+        std::lock_guard registry_lock(hub.tls_registry_mutex);
+        (void)HarvestRegisteredTlsShardsLocked(hub);
+
+        std::lock_guard hub_lock(hub.mutex);
+        state = hub.state.load(std::memory_order_acquire);
+        if (state == RuntimeState::Running) {
+            hub.state.store(RuntimeState::Draining, std::memory_order_release);
+            try {
+                if (ShouldInjectLocked(hub.test_hooks, Testing::FaultPoint::ShutdownFinalizeAllocation)) {
+                    throw std::bad_alloc{};
+                }
+                fence              = std::make_shared<FlushFence>();
+                hub.shutdown_fence = fence;
+                hub.messages.emplace_back(FinalizeMessage{.fence = fence});
+            } catch (...) {
+                hub.shutdown_fence.reset();
+                fence.reset();
+                hub.state.store(RuntimeState::Faulted, std::memory_order_release);
+                hub.last_fault.store(RuntimeFault::WriterException, std::memory_order_release);
+                hub.test_hooks.writer_resume = true;
+            }
+        } else if (state == RuntimeState::Draining) {
+            fence = hub.shutdown_fence;
+        }
     }
 
     if (hub.state.load(std::memory_order_acquire) == RuntimeState::Faulted) {
@@ -1646,6 +1843,18 @@ bool ConfigureWriterPauseBeforeTempOpen(bool _enabled) noexcept {
     return true;
 }
 
+bool ConfigureEmitterPauseAfterAdmission(bool _enabled) noexcept {
+    Hub&            hub = GetHub();
+    std::lock_guard lock(hub.mutex);
+    if (hub.state.load(std::memory_order_acquire) != RuntimeState::Stopped) {
+        return false;
+    }
+    hub.test_hooks.pause_emitter_after_admission = _enabled;
+    hub.test_hooks.emitter_paused                = false;
+    hub.test_hooks.emitter_resume                = false;
+    return true;
+}
+
 bool WaitForWriterPaused(std::uint32_t _timeout_ms) noexcept {
     Hub&             hub = GetHub();
     std::unique_lock lock(hub.mutex);
@@ -1653,6 +1862,15 @@ bool WaitForWriterPaused(std::uint32_t _timeout_ms) noexcept {
         return hub.test_hooks.writer_paused ||
                hub.state.load(std::memory_order_acquire) == RuntimeState::Faulted;
     }) && hub.test_hooks.writer_paused;
+}
+
+bool WaitForEmitterPaused(std::uint32_t _timeout_ms) noexcept {
+    Hub&             hub = GetHub();
+    std::unique_lock lock(hub.mutex);
+    return hub.test_cv.wait_for(lock, std::chrono::milliseconds(_timeout_ms), [&] {
+        return hub.test_hooks.emitter_paused ||
+               hub.state.load(std::memory_order_acquire) == RuntimeState::Faulted;
+    }) && hub.test_hooks.emitter_paused;
 }
 
 bool CreateActiveTempCollision(const std::uint8_t* _bytes, std::size_t _byte_count) noexcept {
@@ -1677,6 +1895,15 @@ void ResumeWriter() noexcept {
     {
         std::lock_guard lock(hub.mutex);
         hub.test_hooks.writer_resume = true;
+    }
+    hub.test_cv.notify_all();
+}
+
+void ResumeEmitter() noexcept {
+    Hub& hub = GetHub();
+    {
+        std::lock_guard lock(hub.mutex);
+        hub.test_hooks.emitter_resume = true;
     }
     hub.test_cv.notify_all();
 }

--- a/source/runtime/core/source/profile/ProfileDumpTesting.h
+++ b/source/runtime/core/source/profile/ProfileDumpTesting.h
@@ -27,9 +27,12 @@ CORE_API bool ConfigureFault(FaultPoint _point, std::uint64_t _trigger_hit = 1) 
 
 CORE_API bool ConfigureWriterPauseBeforeTempOpen(bool _enabled) noexcept;
 CORE_API bool ConfigureWriterPauseAfterStart(bool _enabled) noexcept;
+CORE_API bool ConfigureEmitterPauseAfterAdmission(bool _enabled) noexcept;
 CORE_API bool WaitForWriterPaused(std::uint32_t _timeout_ms) noexcept;
+CORE_API bool WaitForEmitterPaused(std::uint32_t _timeout_ms) noexcept;
 CORE_API bool CreateActiveTempCollision(const std::uint8_t* _bytes, std::size_t _byte_count) noexcept;
 CORE_API void ResumeWriter() noexcept;
+CORE_API void ResumeEmitter() noexcept;
 CORE_API void ClearHooks() noexcept;
 
 } // namespace Moer::ProfileDump::Testing

--- a/source/test/ProfileDumpCoreTest.cpp
+++ b/source/test/ProfileDumpCoreTest.cpp
@@ -28,6 +28,15 @@ void Expect(bool _condition, std::string_view _message) {
     }
 }
 
+template<typename Predicate>
+bool WaitUntil(Predicate _predicate, std::uint32_t _timeout_ms = 2000) {
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(_timeout_ms);
+    while (!_predicate() && std::chrono::steady_clock::now() < deadline) {
+        std::this_thread::yield();
+    }
+    return _predicate();
+}
+
 class ScopedOutput {
 public:
     explicit ScopedOutput(std::string_view _stem) {
@@ -534,6 +543,29 @@ private:
     bool active{true};
 };
 
+class ResumeEmitterOnExit {
+public:
+    ResumeEmitterOnExit()                                      = default;
+    ResumeEmitterOnExit(const ResumeEmitterOnExit&)            = delete;
+    ResumeEmitterOnExit& operator=(const ResumeEmitterOnExit&) = delete;
+
+    ~ResumeEmitterOnExit() {
+        if (active) {
+            Testing::ResumeEmitter();
+        }
+    }
+
+    void Resume() noexcept {
+        if (active) {
+            Testing::ResumeEmitter();
+            active = false;
+        }
+    }
+
+private:
+    bool active{true};
+};
+
 class FlushWaitersOnExit {
 public:
     FlushWaitersOnExit(std::atomic<bool>& _release, std::vector<std::jthread>& _waiters) noexcept :
@@ -974,6 +1006,328 @@ void TestMultithreadedProducers() {
     Expect(stats.records_dropped_oversized == 0, "valid records were treated as oversized");
 }
 
+void TestFlushAllHarvestsParkedLiveShard() {
+    ScopedOutput  output("moer-profile-live-flush");
+    RuntimeConfig config = MakeRuntimeConfig(output);
+    Expect(Start(config) == StartResult::Started, "live-shard flush runtime failed to start");
+
+    const SchemaRegistration registration = RegisterSchema(MakeRuntimeSchema());
+    Expect(registration.status == SchemaStatus::Registered, "live-shard flush schema failed to register");
+
+    std::atomic<bool> ready{false};
+    std::atomic<bool> release{false};
+    EmitStatus        worker_status{EmitStatus::Disabled};
+    std::jthread      worker([&](std::stop_token _stop) {
+        const std::array<FieldValueView, 3> values = {
+            FieldValueView{std::uint64_t{71}},
+            FieldValueView{std::uint64_t{1}},
+            FieldValueView{std::string_view("parked-flush")},
+        };
+        worker_status = Emit(registration.handle, values);
+        ready.store(true, std::memory_order_release);
+        while (!release.load(std::memory_order_acquire) && !_stop.stop_requested()) {
+            std::this_thread::yield();
+        }
+    });
+
+    Expect(
+        WaitUntil([&] {
+            return ready.load(std::memory_order_acquire);
+        }),
+        "live-shard flush worker did not park"
+    );
+    Expect(worker_status == EmitStatus::Accepted, "live-shard flush worker record was rejected");
+    const RuntimeStats parked_stats = GetRuntimeStats();
+    Expect(parked_stats.records_committed == 1, "parked record was not committed");
+    Expect(parked_stats.records_enqueued == 0, "sub-threshold parked record published before harvest");
+
+    ExpectFlushSucceeded(FlushAll(), "owner FlushAll did not harvest a parked live shard");
+    const RuntimeStats flushed_stats = GetRuntimeStats();
+    Expect(
+        flushed_stats.records_enqueued == 1 && flushed_stats.records_written == 1,
+        "owner FlushAll did not write the parked live record"
+    );
+    Expect(!release.load(std::memory_order_acquire), "live-shard worker was released before verification");
+
+    release.store(true, std::memory_order_release);
+    worker.join();
+    Expect(Shutdown() == ShutdownResult::Completed, "live-shard flush runtime did not shut down");
+
+    const ParsedDump dump = ParseDump(output.path, config.codec_limits);
+    Expect(dump.records.size() == 1, "TLS destruction duplicated or lost the harvested live record");
+    Expect(dump.losses.empty(), "live-shard flush fabricated a loss notice");
+}
+
+void TestShutdownHarvestsParkedLiveShard() {
+    ScopedOutput  output("moer-profile-live-shutdown");
+    RuntimeConfig config = MakeRuntimeConfig(output);
+    Expect(Start(config) == StartResult::Started, "live-shard shutdown runtime failed to start");
+
+    const SchemaRegistration registration = RegisterSchema(MakeRuntimeSchema());
+    Expect(registration.status == SchemaStatus::Registered, "live-shard shutdown schema failed to register");
+
+    std::atomic<bool> ready{false};
+    std::atomic<bool> release{false};
+    EmitStatus        worker_status{EmitStatus::Disabled};
+    std::jthread      worker([&](std::stop_token _stop) {
+        const std::array<FieldValueView, 3> values = {
+            FieldValueView{std::uint64_t{72}},
+            FieldValueView{std::uint64_t{1}},
+            FieldValueView{std::string_view("parked-shutdown")},
+        };
+        worker_status = Emit(registration.handle, values);
+        ready.store(true, std::memory_order_release);
+        while (!release.load(std::memory_order_acquire) && !_stop.stop_requested()) {
+            std::this_thread::yield();
+        }
+    });
+
+    Expect(
+        WaitUntil([&] {
+            return ready.load(std::memory_order_acquire);
+        }),
+        "live-shard shutdown worker did not park"
+    );
+    Expect(worker_status == EmitStatus::Accepted, "live-shard shutdown worker record was rejected");
+    Expect(GetRuntimeStats().records_enqueued == 0, "parked shutdown record published too early");
+
+    Expect(
+        Shutdown() == ShutdownResult::Completed,
+        "owner Shutdown did not complete while the producer thread remained alive"
+    );
+    const ParsedDump dump = ParseDump(output.path, config.codec_limits);
+    Expect(dump.records.size() == 1, "owner Shutdown lost the parked live record");
+    const RuntimeStats before_worker_exit = GetRuntimeStats();
+
+    release.store(true, std::memory_order_release);
+    worker.join();
+    const RuntimeStats after_worker_exit = GetRuntimeStats();
+    Expect(
+        after_worker_exit.records_dropped_stopped == before_worker_exit.records_dropped_stopped,
+        "TLS destruction re-published an already harvested stopped-generation record"
+    );
+}
+
+void TestShutdownWaitsForAdmittedEmitterBeforeHarvest() {
+    Testing::ClearHooks();
+    ScopedOutput output("moer-profile-live-active-shutdown");
+    Expect(
+        Testing::ConfigureEmitterPauseAfterAdmission(true),
+        "active-emitter pause hook could not be configured while stopped"
+    );
+
+    std::jthread        worker;
+    std::jthread        shutdown_thread;
+    ResumeEmitterOnExit resume_guard;
+
+    RuntimeConfig config = MakeRuntimeConfig(output);
+    Expect(Start(config) == StartResult::Started, "active-emitter shutdown runtime failed to start");
+    const SchemaDescriptor   schema       = MakeRuntimeSchema();
+    const SchemaRegistration registration = RegisterSchema(schema);
+    Expect(
+        registration.status == SchemaStatus::Registered, "active-emitter shutdown schema failed to register"
+    );
+
+    EmitStatus        emit_status{EmitStatus::Disabled};
+    ShutdownResult    shutdown_result{ShutdownResult::Faulted};
+    std::atomic<bool> shutdown_done{false};
+    worker = std::jthread([&] {
+        const std::array<FieldValueView, 3> values = {
+            FieldValueView{std::uint64_t{74}},
+            FieldValueView{std::uint64_t{1}},
+            FieldValueView{std::string_view("active-shutdown")},
+        };
+        emit_status = Emit(registration.handle, values);
+    });
+    Expect(Testing::WaitForEmitterPaused(2000), "Emit did not pause after acquiring admission");
+
+    shutdown_thread = std::jthread([&] {
+        shutdown_result = Shutdown();
+        shutdown_done.store(true, std::memory_order_release);
+    });
+    Expect(
+        WaitUntil([&] {
+            return RegisterSchema(schema).status == SchemaStatus::NotRunning;
+        }),
+        "Shutdown did not close admission while the accepted Emit was paused"
+    );
+    Expect(
+        !shutdown_done.load(std::memory_order_acquire),
+        "Shutdown finalized before its already-admitted Emit completed"
+    );
+
+    resume_guard.Resume();
+    worker.join();
+    shutdown_thread.join();
+    Expect(emit_status == EmitStatus::Accepted, "already-admitted Emit failed during Shutdown");
+    Expect(shutdown_result == ShutdownResult::Completed, "active-emitter Shutdown did not complete");
+
+    const ParsedDump dump = ParseDump(output.path, config.codec_limits);
+    Expect(dump.records.size() == 1, "active-emitter Shutdown lost or duplicated its accepted record");
+    Expect(dump.losses.empty(), "active-emitter Shutdown fabricated a loss notice");
+    Testing::ClearHooks();
+}
+
+void TestParkedWorkerRebindsAcrossGenerations() {
+    ScopedOutput  first_output("moer-profile-live-generation-a");
+    ScopedOutput  second_output("moer-profile-live-generation-b");
+    RuntimeConfig first_config = MakeRuntimeConfig(first_output);
+    Expect(Start(first_config) == StartResult::Started, "first live generation failed to start");
+
+    const SchemaDescriptor   schema             = MakeRuntimeSchema();
+    const SchemaRegistration first_registration = RegisterSchema(schema);
+    Expect(
+        first_registration.status == SchemaStatus::Registered,
+        "first live generation schema failed to register"
+    );
+
+    std::array<SchemaHandle, 2> handles{};
+    handles[0] = first_registration.handle;
+    std::array<EmitStatus, 2>  statuses{EmitStatus::Disabled, EmitStatus::Disabled};
+    std::atomic<std::uint32_t> command{0};
+    std::atomic<std::uint32_t> completed{0};
+    std::atomic<bool>          release{false};
+    std::jthread               worker([&](std::stop_token _stop) {
+        for (std::uint32_t phase = 1; phase <= 2; ++phase) {
+            while (command.load(std::memory_order_acquire) < phase && !_stop.stop_requested()) {
+                std::this_thread::yield();
+            }
+            if (_stop.stop_requested()) {
+                return;
+            }
+            const std::array<FieldValueView, 3> values = {
+                FieldValueView{std::uint64_t{73}},
+                FieldValueView{std::uint64_t{phase}},
+                FieldValueView{std::string_view("parked-generation")},
+            };
+            statuses[phase - 1] = Emit(handles[phase - 1], values);
+            completed.store(phase, std::memory_order_release);
+        }
+        while (!release.load(std::memory_order_acquire) && !_stop.stop_requested()) {
+            std::this_thread::yield();
+        }
+    });
+
+    command.store(1, std::memory_order_release);
+    Expect(
+        WaitUntil([&] {
+            return completed.load(std::memory_order_acquire) >= 1;
+        }),
+        "parked worker did not emit in the first generation"
+    );
+    Expect(statuses[0] == EmitStatus::Accepted, "first parked-generation record was rejected");
+    Expect(Shutdown() == ShutdownResult::Completed, "first live generation did not shut down");
+    const ParsedDump first_dump = ParseDump(first_output.path, first_config.codec_limits);
+    Expect(first_dump.records.size() == 1, "first live generation lost or duplicated its record");
+
+    RuntimeConfig second_config = MakeRuntimeConfig(second_output);
+    Expect(Start(second_config) == StartResult::Started, "second live generation failed to start");
+    const SchemaRegistration second_registration = RegisterSchema(schema);
+    Expect(
+        second_registration.status == SchemaStatus::Registered,
+        "second live generation schema failed to register"
+    );
+    Expect(
+        second_registration.handle.generation != first_registration.handle.generation,
+        "parked worker restart reused a generation"
+    );
+    handles[1] = second_registration.handle;
+    command.store(2, std::memory_order_release);
+    Expect(
+        WaitUntil([&] {
+            return completed.load(std::memory_order_acquire) >= 2;
+        }),
+        "parked worker did not emit in the second generation"
+    );
+    Expect(statuses[1] == EmitStatus::Accepted, "second parked-generation record was rejected");
+    const RuntimeStats second_parked_stats = GetRuntimeStats();
+    Expect(second_parked_stats.records_committed == 1, "second generation inherited committed records");
+    Expect(second_parked_stats.records_enqueued == 0, "second parked record published before shutdown");
+    Expect(
+        second_parked_stats.records_dropped_stale_generation == 0,
+        "old parked data polluted second-generation stale accounting"
+    );
+
+    Expect(Shutdown() == ShutdownResult::Completed, "second live generation did not shut down");
+    const ParsedDump second_dump = ParseDump(second_output.path, second_config.codec_limits);
+    Expect(second_dump.records.size() == 1, "second live generation lost or duplicated its record");
+    Expect(
+        std::get<std::uint64_t>(first_dump.records.front().values[1]) == 1 &&
+            std::get<std::uint64_t>(second_dump.records.front().values[1]) == 2,
+        "parked worker records crossed generation boundaries"
+    );
+
+    release.store(true, std::memory_order_release);
+    worker.join();
+}
+
+void TestTlsDestructorRacesFlushAllExactlyOnce() {
+    ScopedOutput  output("moer-profile-live-destructor-race");
+    RuntimeConfig config       = MakeRuntimeConfig(output);
+    config.tls_publish_records = 64;
+    Expect(Start(config) == StartResult::Started, "TLS destructor race runtime failed to start");
+
+    const SchemaRegistration registration = RegisterSchema(MakeRuntimeSchema());
+    Expect(registration.status == SchemaStatus::Registered, "TLS destructor race schema failed to register");
+
+    constexpr std::size_t    worker_count = 96;
+    std::atomic<std::size_t> accepted{0};
+    std::atomic<bool>        workers_joined{false};
+    std::atomic<bool>        flush_failed{false};
+    std::jthread             flusher([&](std::stop_token _stop) {
+        while (!workers_joined.load(std::memory_order_acquire) && !_stop.stop_requested()) {
+            const FlushResult result = FlushAll();
+            if (result == FlushResult::Rejected || result == FlushResult::Faulted) {
+                flush_failed.store(true, std::memory_order_release);
+            }
+            std::this_thread::yield();
+        }
+    });
+
+    std::vector<std::jthread> workers;
+    workers.reserve(worker_count);
+    for (std::size_t index = 0; index < worker_count; ++index) {
+        workers.emplace_back([&, index] {
+            const std::array<FieldValueView, 3> values = {
+                FieldValueView{static_cast<std::uint64_t>(index)},
+                FieldValueView{std::uint64_t{1}},
+                FieldValueView{std::string_view("destructor-race")},
+            };
+            if (Emit(registration.handle, values) == EmitStatus::Accepted) {
+                accepted.fetch_add(1, std::memory_order_relaxed);
+            }
+        });
+    }
+    workers.clear();
+    workers_joined.store(true, std::memory_order_release);
+    flusher.join();
+
+    Expect(!flush_failed.load(std::memory_order_acquire), "TLS destructor race rejected a flush interval");
+    Expect(accepted.load(std::memory_order_relaxed) == worker_count, "TLS destructor race rejected a record");
+    ExpectFlushSucceeded(FlushAll(), "final TLS destructor race flush failed");
+    Expect(Shutdown() == ShutdownResult::Completed, "TLS destructor race runtime did not shut down");
+
+    const ParsedDump dump = ParseDump(output.path, config.codec_limits);
+    Expect(dump.records.size() == worker_count, "TLS destructor race lost or duplicated records");
+    std::vector<bool> seen(worker_count, false);
+    for (const DecodedRecord& record : dump.records) {
+        const std::uint64_t producer = std::get<std::uint64_t>(record.values[0]);
+        Expect(producer < worker_count, "TLS destructor race persisted an invalid producer");
+        Expect(!seen[producer], "TLS destructor race duplicated a producer record");
+        seen[producer] = true;
+    }
+    Expect(
+        std::ranges::all_of(
+            seen,
+            [](bool _seen) {
+                return _seen;
+            }
+        ),
+        "TLS destructor race omitted a producer record"
+    );
+    Expect(dump.losses.empty(), "TLS destructor race fabricated a loss notice");
+}
+
 void TestBoundedQueueDropNewest() {
     Testing::ClearHooks();
     ScopedOutput output("moer-profile-bounded");
@@ -1106,6 +1460,152 @@ void TestBoundedQueueDropNewest() {
     Testing::ClearHooks();
 }
 
+void TestMultiShardHarvestHonorsQueueLimitsAndLoss() {
+    Testing::ClearHooks();
+    ScopedOutput output("moer-profile-live-bounded-harvest");
+    Expect(
+        Testing::ConfigureWriterPauseAfterStart(true),
+        "multi-shard harvest pause hook could not be configured while stopped"
+    );
+
+    std::jthread       flusher;
+    ResumeWriterOnExit resume_guard;
+
+    const SchemaDescriptor              schema = MakeRuntimeSchema();
+    constexpr std::string_view          label{"multi-shard"};
+    const std::array<FieldValueView, 3> sizing_values = {
+        FieldValueView{std::uint64_t{1}},
+        FieldValueView{std::uint64_t{1}},
+        FieldValueView{label},
+    };
+    Moer::Array<std::uint8_t> encoded_record;
+    const CodecLimits         limits{};
+    Expect(
+        EncodeRecordPayload(
+            ComputeSchemaHash(schema), 1, schema.fields, sizing_values, limits, encoded_record
+        ) == EncodeStatus::Ok,
+        "multi-shard harvest could not size its record"
+    );
+    const std::size_t record_bytes = encoded_record.size();
+
+    RuntimeConfig config       = MakeRuntimeConfig(output);
+    config.max_record_bytes    = record_bytes * 2;
+    config.tls_publish_records = 2;
+    config.tls_publish_bytes   = record_bytes * 2;
+    config.tls_max_records     = 2;
+    config.tls_max_bytes       = record_bytes * 2;
+    config.queue_max_chunks    = 2;
+    config.queue_max_records   = 2;
+    config.queue_max_bytes     = record_bytes * 2;
+    Expect(Start(config) == StartResult::Started, "multi-shard harvest runtime failed to start");
+    Expect(Testing::WaitForWriterPaused(2000), "multi-shard harvest writer did not pause");
+
+    const SchemaRegistration registration = RegisterSchema(schema);
+    Expect(registration.status == SchemaStatus::Registered, "multi-shard harvest schema failed to register");
+
+    constexpr std::size_t     worker_count = 4;
+    std::atomic<std::size_t>  ready{0};
+    std::atomic<std::size_t>  accepted{0};
+    std::atomic<bool>         release{false};
+    std::vector<std::jthread> workers;
+    workers.reserve(worker_count);
+    for (std::size_t index = 0; index < worker_count; ++index) {
+        workers.emplace_back([&, index](std::stop_token _stop) {
+            const std::array<FieldValueView, 3> values = {
+                FieldValueView{static_cast<std::uint64_t>(index)},
+                FieldValueView{std::uint64_t{1}},
+                FieldValueView{label},
+            };
+            if (Emit(registration.handle, values) == EmitStatus::Accepted) {
+                accepted.fetch_add(1, std::memory_order_relaxed);
+            }
+            ready.fetch_add(1, std::memory_order_release);
+            while (!release.load(std::memory_order_acquire) && !_stop.stop_requested()) {
+                std::this_thread::yield();
+            }
+        });
+    }
+    Expect(
+        WaitUntil([&] {
+            return ready.load(std::memory_order_acquire) == worker_count;
+        }),
+        "multi-shard workers did not park"
+    );
+    Expect(accepted.load(std::memory_order_relaxed) == worker_count, "a multi-shard record was rejected");
+    Expect(GetRuntimeStats().records_enqueued == 0, "multi-shard records published before owner harvest");
+
+    FlushResult flush_result{FlushResult::NothingPending};
+    flusher = std::jthread([&] {
+        flush_result = FlushAll();
+    });
+    Expect(
+        WaitUntil([&] {
+            const RuntimeStats stats = GetRuntimeStats();
+            return stats.records_enqueued + stats.records_dropped_queue_full == worker_count;
+        }),
+        "multi-shard harvest did not account every parked record"
+    );
+
+    const RuntimeStats paused_stats = GetRuntimeStats();
+    Expect(
+        paused_stats.records_committed == worker_count,
+        "multi-shard harvest changed committed record accounting"
+    );
+    Expect(
+        paused_stats.resident_chunks == 2 && paused_stats.resident_records == 2,
+        "multi-shard harvest exceeded or underfilled the bounded queue"
+    );
+    Expect(
+        paused_stats.resident_bytes == record_bytes * 2,
+        "multi-shard harvest resident bytes disagree with the queue limit"
+    );
+    Expect(
+        paused_stats.records_enqueued == 2 && paused_stats.chunks_enqueued == 2,
+        "multi-shard harvest accepted the wrong number of chunks"
+    );
+    Expect(
+        paused_stats.records_dropped_queue_full == 2 && paused_stats.chunks_dropped == 2,
+        "multi-shard harvest did not drop-newest beyond the queue limit"
+    );
+    Expect(
+        paused_stats.high_water_chunks <= config.queue_max_chunks &&
+            paused_stats.high_water_records <= config.queue_max_records &&
+            paused_stats.high_water_bytes <= config.queue_max_bytes,
+        "multi-shard harvest exceeded a hard queue high-water limit"
+    );
+
+    release.store(true, std::memory_order_release);
+    workers.clear();
+    resume_guard.Resume();
+    flusher.join();
+    Expect(
+        flush_result == FlushResult::Rejected,
+        "partial multi-shard queue rejection was not surfaced after flushing accepted data"
+    );
+    Expect(Shutdown() == ShutdownResult::Completed, "multi-shard harvest runtime did not shut down");
+
+    const ParsedDump dump = ParseDump(output.path, config.codec_limits);
+    Expect(dump.records.size() == 2, "multi-shard harvest persisted the wrong record count");
+    Expect(dump.losses.size() == 1, "multi-shard queue losses were not coalesced");
+    const LossNotice& loss = dump.losses.front();
+    Expect(loss.record_count == 2, "multi-shard loss notice has the wrong record count");
+    Expect(
+        (loss.reason_mask & static_cast<std::uint32_t>(LossReason::QueueFull)) != 0,
+        "multi-shard loss notice omitted QueueFull"
+    );
+    constexpr std::uint64_t value_bytes_per_record = 8 + 8 + 4 + label.size();
+    Expect(
+        loss.value_bytes == value_bytes_per_record * 2,
+        "multi-shard loss notice has the wrong value byte count"
+    );
+    Expect(
+        dump.session_ends.size() == 1 && dump.session_ends.front().records_written == 2 &&
+            dump.session_ends.front().records_dropped == 2,
+        "multi-shard SessionEnd totals disagree with records and Loss"
+    );
+    Testing::ClearHooks();
+}
+
 void TestConcurrentFlushWaiters() {
     Testing::ClearHooks();
     ScopedOutput output("moer-profile-concurrent-flush");
@@ -1175,6 +1675,133 @@ void TestConcurrentFlushWaiters() {
     const ParsedDump dump = ParseDump(output.path, config.codec_limits);
     Expect(dump.records.size() == 1, "concurrent flush lost or duplicated queued data");
     Expect(dump.losses.empty(), "concurrent flush fabricated a loss notice");
+    Testing::ClearHooks();
+}
+
+void TestFaultedRestartDiscardsParkedStaleShard() {
+    Testing::ClearHooks();
+    ScopedOutput output("moer-profile-live-fault-restart");
+    Expect(
+        Testing::ConfigureFault(Testing::FaultPoint::WritePacket, 2),
+        "parked fault-restart hook could not be configured"
+    );
+
+    RuntimeConfig config       = MakeRuntimeConfig(output);
+    config.tls_publish_records = 2;
+    Expect(Start(config) == StartResult::Started, "parked fault generation failed to start");
+
+    const SchemaDescriptor   schema             = MakeRuntimeSchema();
+    const SchemaRegistration first_registration = RegisterSchema(schema);
+    Expect(
+        first_registration.status == SchemaStatus::Registered,
+        "parked fault generation schema failed to register"
+    );
+
+    std::array<SchemaHandle, 2> handles{};
+    handles[0] = first_registration.handle;
+    std::array<EmitStatus, 2>  statuses{EmitStatus::Disabled, EmitStatus::Disabled};
+    std::atomic<std::uint32_t> command{0};
+    std::atomic<std::uint32_t> completed{0};
+    std::atomic<bool>          release{false};
+    std::jthread               worker([&](std::stop_token _stop) {
+        for (std::uint32_t phase = 1; phase <= 2; ++phase) {
+            while (command.load(std::memory_order_acquire) < phase && !_stop.stop_requested()) {
+                std::this_thread::yield();
+            }
+            if (_stop.stop_requested()) {
+                return;
+            }
+            const std::array<FieldValueView, 3> values = {
+                FieldValueView{std::uint64_t{88}},
+                FieldValueView{std::uint64_t{phase}},
+                FieldValueView{std::string_view("fault-restart-worker")},
+            };
+            statuses[phase - 1] = Emit(handles[phase - 1], values);
+            completed.store(phase, std::memory_order_release);
+        }
+        while (!release.load(std::memory_order_acquire) && !_stop.stop_requested()) {
+            std::this_thread::yield();
+        }
+    });
+
+    command.store(1, std::memory_order_release);
+    Expect(
+        WaitUntil([&] {
+            return completed.load(std::memory_order_acquire) >= 1;
+        }),
+        "worker did not park data before the writer fault"
+    );
+    Expect(statuses[0] == EmitStatus::Accepted, "parked pre-fault record was rejected");
+    Expect(GetRuntimeStats().records_enqueued == 0, "parked pre-fault record published too early");
+
+    const std::array<FieldValueView, 3> trigger_values = {
+        FieldValueView{std::uint64_t{99}},
+        FieldValueView{std::uint64_t{1}},
+        FieldValueView{std::string_view("fault-trigger")},
+    };
+    const EmitStatus first_trigger  = Emit(first_registration.handle, trigger_values);
+    const EmitStatus second_trigger = Emit(first_registration.handle, trigger_values);
+    Expect(
+        first_trigger == EmitStatus::Accepted,
+        "first fault-trigger record failed before filling the main TLS shard"
+    );
+    Expect(
+        second_trigger == EmitStatus::Accepted || second_trigger == EmitStatus::SinkFault,
+        "second fault-trigger record returned an unexpected status"
+    );
+    Expect(
+        WaitUntil([] {
+            return GetRuntimeState() == RuntimeState::Faulted;
+        }),
+        "writer did not enter Faulted after the deterministic packet failure"
+    );
+    Expect(Shutdown() == ShutdownResult::Faulted, "faulted parked generation did not report failure");
+    Expect(GetRuntimeState() == RuntimeState::Stopped, "faulted parked generation did not stop");
+    const RuntimeStats faulted_stats = GetRuntimeStats();
+    Expect(
+        faulted_stats.records_dropped_after_fault == 3,
+        "faulted Shutdown did not account the queued chunk and parked live shard"
+    );
+    Expect(
+        faulted_stats.chunks_dropped == 2, "faulted Shutdown did not account both queued and parked chunks"
+    );
+
+    Testing::ClearHooks();
+    config.replace_existing = true;
+    Expect(Start(config) == StartResult::Started, "parked worker did not restart after writer fault");
+    const SchemaRegistration second_registration = RegisterSchema(schema);
+    Expect(
+        second_registration.status == SchemaStatus::Registered, "parked restart schema failed to register"
+    );
+    handles[1] = second_registration.handle;
+    command.store(2, std::memory_order_release);
+    Expect(
+        WaitUntil([&] {
+            return completed.load(std::memory_order_acquire) >= 2;
+        }),
+        "parked worker did not emit after fault restart"
+    );
+    Expect(statuses[1] == EmitStatus::Accepted, "parked post-fault record was rejected");
+    const RuntimeStats restarted_stats = GetRuntimeStats();
+    Expect(restarted_stats.records_committed == 1, "fault restart inherited old committed records");
+    Expect(restarted_stats.records_enqueued == 0, "post-fault parked record published before shutdown");
+    Expect(
+        restarted_stats.records_dropped_stale_generation == 0,
+        "old faulted shard polluted restarted stale-generation accounting"
+    );
+
+    Expect(Shutdown() == ShutdownResult::Completed, "parked fault restart did not shut down cleanly");
+    const ParsedDump dump = ParseDump(output.path, config.codec_limits);
+    Expect(dump.records.size() == 1, "fault restart output retained old or duplicated new parked data");
+    Expect(
+        std::get<std::uint64_t>(dump.records.front().values[0]) == 88 &&
+            std::get<std::uint64_t>(dump.records.front().values[1]) == 2,
+        "fault restart output contains the wrong worker generation"
+    );
+    Expect(dump.losses.empty(), "fault restart output inherited an old-generation Loss");
+
+    release.store(true, std::memory_order_release);
+    worker.join();
     Testing::ClearHooks();
 }
 
@@ -1336,8 +1963,15 @@ int main() {
         TestReplacementPreservesForeignTemp();
         TestFinalPublicationRaces();
         TestMultithreadedProducers();
+        TestFlushAllHarvestsParkedLiveShard();
+        TestShutdownHarvestsParkedLiveShard();
+        TestShutdownWaitsForAdmittedEmitterBeforeHarvest();
+        TestParkedWorkerRebindsAcrossGenerations();
+        TestTlsDestructorRacesFlushAllExactlyOnce();
         TestBoundedQueueDropNewest();
+        TestMultiShardHarvestHonorsQueueLimitsAndLoss();
         TestConcurrentFlushWaiters();
+        TestFaultedRestartDiscardsParkedStaleShard();
         TestWriterFaultReleasesFlushWaiter(
             Testing::FaultPoint::WritePacket, 2, RuntimeFault::WritePacket, "moer-profile-write-fault", true
         );

--- a/source/test/ProfileScopeProducerTest.cpp
+++ b/source/test/ProfileScopeProducerTest.cpp
@@ -104,10 +104,7 @@ SchemaHandle StartCpuProducer(const RuntimeConfig& _config) {
         );
     }
     const SchemaRegistration registration = RegisterSchema(Templates::CpuScope());
-    Expect(
-        registration.status == SchemaStatus::Registered,
-        "CpuScope schema failed to register"
-    );
+    Expect(registration.status == SchemaStatus::Registered, "CpuScope schema failed to register");
     Expect(
         CpuScopeProducer::Activate(registration.handle) == CpuScopeActivationResult::Activated,
         "CpuScope producer failed to activate"
@@ -181,11 +178,11 @@ ParsedDump ParseDump(const std::filesystem::path& _path, const CodecLimits& _lim
 }
 
 struct CpuRecordView {
-    std::uint64_t thread_id{0};
+    std::uint64_t    thread_id{0};
     std::string_view name{};
-    std::uint64_t begin_ns{0};
-    std::uint64_t end_ns{0};
-    std::uint32_t depth{0};
+    std::uint64_t    begin_ns{0};
+    std::uint64_t    end_ns{0};
+    std::uint32_t    depth{0};
 };
 
 CpuRecordView ViewCpuRecord(const DecodedRecord& _record) {
@@ -230,10 +227,7 @@ void TestProfileDumpConfigParsing() {
         defaults.engine.profile_dump.output_path == "./profile/MoerProfile.mpd",
         "profile dump default output path changed"
     );
-    Expect(
-        defaults.engine.profile_dump.replace_existing,
-        "profile dump default replacement policy changed"
-    );
+    Expect(defaults.engine.profile_dump.replace_existing, "profile dump default replacement policy changed");
 
     const std::filesystem::path explicit_path = output.directory / "explicit.toml";
     WriteTextFile(
@@ -263,7 +257,9 @@ void TestDisabledAndActivationValidation() {
 
     CpuScopeProducer::Deactivate();
     Expect(!CpuScopeProducer::IsActive(), "producer began active");
-    { MOER_PROFILE_SCOPE("Disabled.BeforeRuntime"); }
+    {
+        MOER_PROFILE_SCOPE("Disabled.BeforeRuntime");
+    }
     const SchemaHandle plausible{
         .hash       = ComputeSchemaHash(Templates::CpuScope()),
         .generation = 1,
@@ -280,16 +276,17 @@ void TestDisabledAndActivationValidation() {
     ScopedOutput        output("moer-profile-scope-activation");
     const RuntimeConfig config = MakeRuntimeConfig(output);
     Expect(Start(config) == StartResult::Started, "activation runtime failed to start");
-    { ScopedCpuProfile disabled("Disabled.WhileRunning"); }
+    {
+        ScopedCpuProfile disabled("Disabled.WhileRunning");
+    }
 
     const SchemaRegistration wrong = RegisterSchema(MakeWrongSchema());
     const SchemaRegistration cpu   = RegisterSchema(Templates::CpuScope());
     Expect(wrong.status == SchemaStatus::Registered, "wrong-schema fixture failed to register");
     Expect(cpu.status == SchemaStatus::Registered, "CpuScope fixture failed to register");
     Expect(
-        CpuScopeProducer::Activate(
-            {.hash = cpu.handle.hash, .generation = cpu.handle.generation + 1}
-        ) == CpuScopeActivationResult::StaleGeneration,
+        CpuScopeProducer::Activate({.hash = cpu.handle.hash, .generation = cpu.handle.generation + 1}) ==
+            CpuScopeActivationResult::StaleGeneration,
         "producer accepted a stale generation"
     );
     Expect(
@@ -305,7 +302,9 @@ void TestDisabledAndActivationValidation() {
         CpuScopeProducer::Activate(cpu.handle) == CpuScopeActivationResult::AlreadyActive,
         "duplicate activation was not idempotent"
     );
-    { ScopedCpuProfile valid("Enabled.AfterActivation"); }
+    {
+        ScopedCpuProfile valid("Enabled.AfterActivation");
+    }
     StopCpuProducer();
 
     const ParsedDump dump = ParseDump(output.path, config.codec_limits);
@@ -322,7 +321,9 @@ void TestNestedDecode() {
     static_cast<void>(StartCpuProducer(config));
     {
         MOER_PROFILE_SCOPE("Nested.Outer");
-        { ScopedCpuProfile inner("Nested", "Inner"); }
+        {
+            ScopedCpuProfile inner("Nested", "Inner");
+        }
     }
     StopCpuProducer();
 
@@ -347,14 +348,14 @@ void TestMultithreadedTlsDepth() {
     const RuntimeConfig config = MakeRuntimeConfig(output);
     static_cast<void>(StartCpuProducer(config));
 
-    constexpr std::size_t thread_count = 4;
+    constexpr std::size_t     thread_count = 4;
     std::vector<std::jthread> threads;
     threads.reserve(thread_count);
     for (std::size_t index = 0; index < thread_count; ++index) {
         threads.emplace_back([index] {
             const std::string suffix = std::to_string(index);
-            ScopedCpuProfile outer("Thread.Outer." + suffix);
-            ScopedCpuProfile inner("Thread.Inner." + suffix);
+            ScopedCpuProfile  outer("Thread.Outer." + suffix);
+            ScopedCpuProfile  inner("Thread.Inner." + suffix);
         });
     }
     threads.clear();
@@ -365,8 +366,8 @@ void TestMultithreadedTlsDepth() {
     std::unordered_set<std::uint64_t> thread_ids;
     for (std::size_t index = 0; index < thread_count; ++index) {
         const std::string   suffix = std::to_string(index);
-        const CpuRecordView outer = ViewCpuRecord(FindRecord(dump, "Thread.Outer." + suffix));
-        const CpuRecordView inner = ViewCpuRecord(FindRecord(dump, "Thread.Inner." + suffix));
+        const CpuRecordView outer  = ViewCpuRecord(FindRecord(dump, "Thread.Outer." + suffix));
+        const CpuRecordView inner  = ViewCpuRecord(FindRecord(dump, "Thread.Inner." + suffix));
         Expect(outer.thread_id == inner.thread_id, "one thread changed id between nested scopes");
         Expect(outer.depth == 0 && inner.depth == 1, "TLS depth leaked between producer threads");
         thread_ids.insert(outer.thread_id);
@@ -375,9 +376,9 @@ void TestMultithreadedTlsDepth() {
 }
 
 void TestRestartRejectsStaleScope() {
-    ScopedOutput        first_output("moer-profile-scope-stale-first");
-    const RuntimeConfig first_config = MakeRuntimeConfig(first_output);
-    const SchemaHandle  first_handle = StartCpuProducer(first_config);
+    ScopedOutput                    first_output("moer-profile-scope-stale-first");
+    const RuntimeConfig             first_config = MakeRuntimeConfig(first_output);
+    const SchemaHandle              first_handle = StartCpuProducer(first_config);
     std::optional<ScopedCpuProfile> stale_scope;
     stale_scope.emplace("Stale.OldSession");
     CpuScopeProducer::Deactivate();
@@ -390,17 +391,18 @@ void TestRestartRejectsStaleScope() {
         second_handle.generation != first_handle.generation,
         "ProfileDump restart reused a producer generation"
     );
-    { ScopedCpuProfile current("Fresh.BeforeStaleDestructor"); }
+    {
+        ScopedCpuProfile current("Fresh.BeforeStaleDestructor");
+    }
     stale_scope.reset();
-    Expect(
-        CpuScopeProducer::IsActive(),
-        "stale destructor disabled the restarted producer"
-    );
+    Expect(CpuScopeProducer::IsActive(), "stale destructor disabled the restarted producer");
     Expect(
         GetRuntimeStats().records_dropped_stale_generation == 0,
         "stale destructor charged the restarted session"
     );
-    { ScopedCpuProfile current("Fresh.AfterStaleDestructor"); }
+    {
+        ScopedCpuProfile current("Fresh.AfterStaleDestructor");
+    }
     StopCpuProducer();
 
     const ParsedDump dump = ParseDump(second_output.path, second_config.codec_limits);
@@ -410,19 +412,13 @@ void TestRestartRejectsStaleScope() {
 }
 
 void TestRestartReplacesStaleProducerPublication() {
-    ScopedOutput        first_output("moer-profile-scope-stale-publication-first");
-    const RuntimeConfig first_config = MakeRuntimeConfig(first_output);
-    const SchemaHandle  first_handle = StartCpuProducer(first_config);
+    ScopedOutput                    first_output("moer-profile-scope-stale-publication-first");
+    const RuntimeConfig             first_config = MakeRuntimeConfig(first_output);
+    const SchemaHandle              first_handle = StartCpuProducer(first_config);
     std::optional<ScopedCpuProfile> stale_scope;
     stale_scope.emplace("Stale.BeforeMissedDeactivate");
-    Expect(
-        Shutdown() == ShutdownResult::Completed,
-        "stale-publication first runtime failed to shut down"
-    );
-    Expect(
-        !CpuScopeProducer::IsActive(),
-        "producer reported an old stopped generation as active"
-    );
+    Expect(Shutdown() == ShutdownResult::Completed, "stale-publication first runtime failed to shut down");
+    Expect(!CpuScopeProducer::IsActive(), "producer reported an old stopped generation as active");
 
     ScopedOutput        second_output("moer-profile-scope-stale-publication-second");
     const RuntimeConfig second_config = MakeRuntimeConfig(second_output);
@@ -439,11 +435,12 @@ void TestRestartReplacesStaleProducerPublication() {
         "stale-publication restart did not create a new schema generation"
     );
     Expect(
-        CpuScopeProducer::Activate(second_schema.handle) ==
-            CpuScopeActivationResult::Activated,
+        CpuScopeProducer::Activate(second_schema.handle) == CpuScopeActivationResult::Activated,
         "new generation could not replace stale producer publication"
     );
-    { ScopedCpuProfile current("Fresh.AfterMissedDeactivate"); }
+    {
+        ScopedCpuProfile current("Fresh.AfterMissedDeactivate");
+    }
     StopCpuProducer();
 
     const ParsedDump dump = ParseDump(second_output.path, second_config.codec_limits);
@@ -458,7 +455,9 @@ void TestNameBoundariesAndDepthRecovery() {
 
     const std::string accepted(ScopedCpuProfile::kMaxNameBytes, 'a');
     const std::string rejected(ScopedCpuProfile::kMaxNameBytes + 1, 'b');
-    { ScopedCpuProfile scope(accepted); }
+    {
+        ScopedCpuProfile scope(accepted);
+    }
     {
         ScopedCpuProfile ignored(rejected);
         ScopedCpuProfile recovered("Name.AfterRejected");
@@ -484,13 +483,9 @@ void TestNameBoundariesAndDepthRecovery() {
     Expect(dump.records.size() == 5, "name validation accepted or rejected the wrong boundary");
     Expect(ViewCpuRecord(FindRecord(dump, accepted)).depth == 0, "256-byte name changed depth");
     Expect(
-        ViewCpuRecord(FindRecord(dump, "Name.AfterRejected")).depth == 0,
-        "257-byte name leaked TLS depth"
+        ViewCpuRecord(FindRecord(dump, "Name.AfterRejected")).depth == 0, "257-byte name leaked TLS depth"
     );
-    Expect(
-        ViewCpuRecord(FindRecord(dump, "Name.AfterEmpty")).depth == 0,
-        "empty name leaked TLS depth"
-    );
+    Expect(ViewCpuRecord(FindRecord(dump, "Name.AfterEmpty")).depth == 0, "empty name leaked TLS depth");
     Expect(
         ViewCpuRecord(FindRecord(dump, std::string(100, 'p') + "." + std::string(155, 'n'))).depth == 0,
         "256-byte joined name was rejected"
@@ -544,12 +539,12 @@ private:
 
 void TestTaskSystemShutdownPublishesWorkerTls() {
     ScopedOutput  output("moer-profile-scope-task-shutdown");
-    RuntimeConfig config = MakeRuntimeConfig(output);
+    RuntimeConfig config       = MakeRuntimeConfig(output);
     config.tls_publish_records = 64;
     static_cast<void>(StartCpuProducer(config));
 
     TaskSystemGuard task_system;
-    GraphEventRef event = LambdaTask::Dispatch([] {
+    GraphEventRef   event = LambdaTask::Dispatch([] {
         ScopedCpuProfile outer("Task.Worker.Outer");
         ScopedCpuProfile inner("Task.Worker.Inner");
     });
@@ -566,16 +561,49 @@ void TestTaskSystemShutdownPublishesWorkerTls() {
     );
 }
 
+void TestOwnerFlushHarvestsLiveTaskWorkerTls() {
+    ScopedOutput  output("moer-profile-scope-task-live-flush");
+    RuntimeConfig config       = MakeRuntimeConfig(output);
+    config.tls_publish_records = 64;
+    static_cast<void>(StartCpuProducer(config));
+
+    TaskSystemGuard task_system;
+    GraphEventRef   event = LambdaTask::Dispatch([] {
+        ScopedCpuProfile outer("Task.LiveFlush.Outer");
+        ScopedCpuProfile inner("Task.LiveFlush.Inner");
+    });
+    event->Wait();
+
+    const RuntimeStats parked_stats = GetRuntimeStats();
+    Expect(parked_stats.records_committed == 2, "live TaskSystem scopes were not committed");
+    Expect(
+        parked_stats.records_enqueued == 0,
+        "live TaskSystem worker published its sub-threshold TLS before owner harvest"
+    );
+    ExpectFlushSucceeded(FlushAll(), "owner FlushAll did not harvest a live TaskSystem worker");
+    Expect(GetRuntimeStats().records_written == 2, "owner FlushAll did not write live TaskSystem scopes");
+
+    // Finalize the capture while the TaskSystem and its worker TLS remain
+    // alive. Its later TLS destructor must see an empty harvested shard.
+    StopCpuProducer();
+    task_system.Shutdown();
+
+    const ParsedDump dump = ParseDump(output.path, config.codec_limits);
+    Expect(dump.records.size() == 2, "live TaskSystem harvest lost or duplicated worker scopes");
+    Expect(
+        ViewCpuRecord(FindRecord(dump, "Task.LiveFlush.Outer")).depth == 0 &&
+            ViewCpuRecord(FindRecord(dump, "Task.LiveFlush.Inner")).depth == 1,
+        "live TaskSystem harvest changed worker scope depth"
+    );
+}
+
 void TestQueueFullDoesNotDisableProducer() {
     Testing::ClearHooks();
-    Expect(
-        Testing::ConfigureWriterPauseAfterStart(true),
-        "writer pause hook could not be configured"
-    );
+    Expect(Testing::ConfigureWriterPauseAfterStart(true), "writer pause hook could not be configured");
     WriterResumeGuard resume_guard;
 
     ScopedOutput  output("moer-profile-scope-queue-full");
-    RuntimeConfig config = MakeRuntimeConfig(output);
+    RuntimeConfig config       = MakeRuntimeConfig(output);
     config.max_record_bytes    = 4096;
     config.tls_publish_records = 1;
     config.tls_publish_bytes   = 4096;
@@ -587,16 +615,19 @@ void TestQueueFullDoesNotDisableProducer() {
     static_cast<void>(StartCpuProducer(config));
     Expect(Testing::WaitForWriterPaused(2000), "writer did not reach the queue-full pause point");
 
-    { ScopedCpuProfile accepted("QueueFull.Accepted"); }
-    { ScopedCpuProfile dropped("QueueFull.Dropped"); }
-    Expect(
-        CpuScopeProducer::IsActive(),
-        "bounded queue pressure disabled the CPU producer"
-    );
+    {
+        ScopedCpuProfile accepted("QueueFull.Accepted");
+    }
+    {
+        ScopedCpuProfile dropped("QueueFull.Dropped");
+    }
+    Expect(CpuScopeProducer::IsActive(), "bounded queue pressure disabled the CPU producer");
 
     resume_guard.Resume();
     ExpectFlushSucceeded(FlushAll(), "queue-full recovery did not drain accepted work");
-    { ScopedCpuProfile recovered("QueueFull.Recovered"); }
+    {
+        ScopedCpuProfile recovered("QueueFull.Recovered");
+    }
     StopCpuProducer();
     Testing::ClearHooks();
 
@@ -614,15 +645,21 @@ void TestFaultSelfDisables() {
     );
 
     ScopedOutput  output("moer-profile-scope-fault");
-    RuntimeConfig config = MakeRuntimeConfig(output);
+    RuntimeConfig config       = MakeRuntimeConfig(output);
     config.tls_publish_records = 1;
     static_cast<void>(StartCpuProducer(config));
-    { ScopedCpuProfile first("Fault.Trigger"); }
+    {
+        ScopedCpuProfile first("Fault.Trigger");
+    }
     Expect(FlushAll() == FlushResult::Faulted, "writer fault did not become observable");
     Expect(CpuScopeProducer::IsActive(), "producer stopped before observing an Emit failure");
-    { ScopedCpuProfile second("Fault.Observe"); }
+    {
+        ScopedCpuProfile second("Fault.Observe");
+    }
     Expect(!CpuScopeProducer::IsActive(), "sink fault did not self-disable the producer");
-    { ScopedCpuProfile ignored("Fault.AfterDisable"); }
+    {
+        ScopedCpuProfile ignored("Fault.AfterDisable");
+    }
     Expect(Shutdown() == ShutdownResult::Faulted, "faulted writer shutdown reported success");
     Testing::ClearHooks();
 }
@@ -639,6 +676,7 @@ int main() {
         TestRestartReplacesStaleProducerPublication();
         TestNameBoundariesAndDepthRecovery();
         TestTaskSystemShutdownPublishesWorkerTls();
+        TestOwnerFlushHarvestsLiveTaskWorkerTls();
         TestQueueFullDoesNotDisableProducer();
         TestFaultSelfDisables();
         std::cout << "ProfileScope producer contract tests passed." << std::endl;


### PR DESCRIPTION
## Summary

- add an intrusive live TLS shard registry to ProfileDump
- let owner-side `FlushAll()` harvest sub-threshold records from still-live workers before fencing the writer
- make `Shutdown()` close admission, wait accepted emitters, harvest every live shard, then finalize
- preserve bounded queue, Loss packet, fault/restart, and generation semantics
- document the per-shard cut contract instead of claiming a global instantaneous snapshot

## Relationship to `dev_parallel_rhi`

This keeps the parallel branch's TLS-sharded producer direction, but closes a gap in that branch: its owner can only consume shards already published by the producing thread or its TLS destructor. The new registry lets main discover long-lived TaskSystem workers while retaining main's generation, admission, bounded queue, writer-fence, and restart model.

Base: `main@446b7d5653e630be0581f63262d74fd76847d5a7`  
Reference: `dev_parallel_rhi@2553e9afca2a84865f6c40b709f4b4a3e8900747`

## Concurrency contract

Lock order:

```text
lifecycle (Start/Shutdown only) -> registry -> node -> Hub
```

- registered hot-path emits take only the node lock
- registry traversal holds the registry lock, so a TLS destructor cannot unlink/destroy a node during owner harvest
- the TLS owner publishes and unlinks its member node in the owner destructor body, before member destruction begins
- no writer-fence wait or join happens under registry/node locks
- `Shutdown()` keeps the state Running while waiting already-admitted emitters, then harvests before appending Finalize

## Tests

- Debug full build and CTest: 28/28
- RelWithDebInfo full build and CTest: 28/28
- Release relevant targets and focused CTest: 4/4
- `ProfileDumpCoreContract`: 150 repeated Debug runs and 30 repeated Release runs
- Debug Raytracing editor smoke: stable for roughly 30–45 seconds; empty stderr and no fatal/validation/device-lost signatures

New tests cover:

- parked live-worker harvest from `FlushAll()` and `Shutdown()`
- an emitter paused after admission while `Shutdown()` closes new admission and waits
- generation rebind on a persistent worker
- concurrent TLS destruction versus `FlushAll()`
- queue-capacity/Loss accounting across multiple parked shards
- writer fault, exact parked-shard drop accounting, and restart
- real nested `ProfileScope` records on a live TaskSystem worker

## Release note

A fresh full Release solution build separately hits the existing third-party GKlib Windows `/io.h` include issue in `build-vs/3rdparty/gklib/GKlib.vcxproj`. It is outside this diff. The four directly relevant Release targets build and all focused Release contracts pass.
