### PR TITLE
Phase 21D.2a.2: add restartable GPU capture sessions

### DIFF
--- a/source/runtime/Engine.cpp
+++ b/source/runtime/Engine.cpp
@@ -640,19 +640,15 @@ void Engine::InitializeProfileDump() noexcept {
 }
 
 void Engine::InitializeRenderProfileCapture() noexcept {
-    if (!m_profile_dump_owned || m_render_profile_capture) {
+    if (!m_profile_dump_owned || !m_render_profile_capture || m_render_profile_capture->Valid()) {
         return;
     }
 
     try {
         const ProfileDump::SchemaRegistration gpu_frame =
-            ProfileDump::RegisterSchema(
-                ProfileDump::Templates::GpuFrame()
-            );
-        if ((gpu_frame.status !=
-                 ProfileDump::SchemaStatus::Registered &&
-             gpu_frame.status !=
-                 ProfileDump::SchemaStatus::AlreadyRegistered) ||
+            ProfileDump::RegisterSchema(ProfileDump::Templates::GpuFrame());
+        if ((gpu_frame.status != ProfileDump::SchemaStatus::Registered &&
+             gpu_frame.status != ProfileDump::SchemaStatus::AlreadyRegistered) ||
             !gpu_frame.handle) {
             LOG_WARNING(
                 "[ProfileDump] GpuFrame schema registration failed "
@@ -663,13 +659,9 @@ void Engine::InitializeRenderProfileCapture() noexcept {
         }
 
         const ProfileDump::SchemaRegistration gpu_scope =
-            ProfileDump::RegisterSchema(
-                ProfileDump::Templates::GpuScope()
-            );
-        if ((gpu_scope.status !=
-                 ProfileDump::SchemaStatus::Registered &&
-             gpu_scope.status !=
-                 ProfileDump::SchemaStatus::AlreadyRegistered) ||
+            ProfileDump::RegisterSchema(ProfileDump::Templates::GpuScope());
+        if ((gpu_scope.status != ProfileDump::SchemaStatus::Registered &&
+             gpu_scope.status != ProfileDump::SchemaStatus::AlreadyRegistered) ||
             !gpu_scope.handle) {
             LOG_WARNING(
                 "[ProfileDump] GpuScope schema registration failed "
@@ -679,25 +671,22 @@ void Engine::InitializeRenderProfileCapture() noexcept {
             return;
         }
 
-        auto capture =
-            MakeUnique<Render::RenderProfileCapture>(
-                gpu_frame.handle, gpu_scope.handle
-            );
-        if (!capture->Valid()) {
+        const Render::RenderProfileSessionStartResult start_result =
+            m_render_profile_capture->StartSession(gpu_frame.handle, gpu_scope.handle);
+        if (start_result != Render::RenderProfileSessionStartResult::Started) {
             LOG_WARNING(
                 "[ProfileDump] GPU capture bridge rejected the current "
-                "schema generation; GPU capture disabled."
+                "schema generation (result={}); GPU capture disabled.",
+                static_cast<unsigned int>(start_result)
             );
             return;
         }
-        m_render_profile_capture = std::move(capture);
         LOG_INFO(
             "[ProfileDump] GPU capture bridge initialized "
             "(generation={}).",
             gpu_frame.handle.generation
         );
     } catch (const std::exception& error) {
-        m_render_profile_capture.reset();
         try {
             LOG_WARNING(
                 "[ProfileDump] GPU capture bridge initialization failed: "
@@ -707,23 +696,21 @@ void Engine::InitializeRenderProfileCapture() noexcept {
         } catch (...) {
         }
     } catch (...) {
-        m_render_profile_capture.reset();
         try {
-            LOG_WARNING(
-                "[ProfileDump] GPU capture bridge initialization failed; "
-                "CPU capture remains enabled."
-            );
+            LOG_WARNING("[ProfileDump] GPU capture bridge initialization failed; "
+                        "CPU capture remains enabled.");
         } catch (...) {
         }
     }
 }
 
-void Engine::ShutdownRenderProfileCapture(
-    bool _rhi_drained
-) noexcept {
-    UniquePtr<Render::RenderProfileCapture> capture =
-        std::move(m_render_profile_capture);
-    if (!capture) {
+void Engine::ShutdownRenderProfileCapture(bool _rhi_drained) noexcept {
+    Render::RenderProfileCapture* capture = m_render_profile_capture.get();
+    if (capture == nullptr) {
+        return;
+    }
+    const Render::RenderProfileCaptureStats before_shutdown = capture->GetStats();
+    if (before_shutdown.generation == 0) {
         return;
     }
 
@@ -732,15 +719,11 @@ void Engine::ShutdownRenderProfileCapture(
     } else {
         capture->Abort();
     }
-    const Render::RenderProfileCaptureStats stats =
-        capture->GetStats();
+    const Render::RenderProfileCaptureStats stats = capture->GetStats();
 
     try {
-        if (!_rhi_drained ||
-            stats.shutdown_abandoned_frames != 0 ||
-            stats.terminal_faults != 0 ||
-            stats.frames_admission_rejected != 0 ||
-            stats.frame_records_dropped != 0 ||
+        if (!_rhi_drained || stats.shutdown_abandoned_frames != 0 || stats.terminal_faults != 0 ||
+            stats.frames_admission_rejected != 0 || stats.frame_records_dropped != 0 ||
             stats.scope_records_dropped != 0) {
             LOG_WARNING(
                 "[ProfileDump] GPU capture bridge stopped "
@@ -771,19 +754,22 @@ void Engine::ShutdownRenderProfileCapture(
 }
 
 void Engine::ShutdownProfileDump() noexcept {
-    // Defensive rollback path. Normal shutdown has already drained and reset
-    // the bridge after RHI Completion joined.
-    ShutdownRenderProfileCapture(false);
+    // Defensive rollback path. Normal shutdown has already drained and closed
+    // the facade's current session after RHI Completion joined.
+    if (m_render_profile_capture) {
+        const Render::RenderProfileCaptureStats bridge_stats = m_render_profile_capture->GetStats();
+        if (bridge_stats.generation != 0 && !bridge_stats.closed) {
+            ShutdownRenderProfileCapture(false);
+        }
+    }
     if (!m_profile_dump_owned) {
         return;
     }
     m_profile_dump_owned = false;
 
     ProfileDump::CpuScopeProducer::Deactivate();
-    const ProfileDump::FlushResult flush_result =
-        ProfileDump::FlushThreadLocal();
-    const ProfileDump::ShutdownResult shutdown_result =
-        ProfileDump::Shutdown();
+    const ProfileDump::FlushResult    flush_result    = ProfileDump::FlushThreadLocal();
+    const ProfileDump::ShutdownResult shutdown_result = ProfileDump::Shutdown();
 
     if (shutdown_result == ProfileDump::ShutdownResult::Faulted) {
         const ProfileDump::RuntimeStats stats = ProfileDump::GetRuntimeStats();
@@ -894,6 +880,19 @@ void Engine::Init(
         );
     }
 
+    try {
+        // Renderers retain this facade pointer for their whole lifetime.
+        // Individual ProfileDump generations bind and unbind session state
+        // inside the facade; the pointer itself never changes.
+        m_render_profile_capture = MakeUnique<Render::RenderProfileCapture>();
+    } catch (...) {
+        m_render_profile_capture.reset();
+        try {
+            LOG_WARNING("[ProfileDump] Failed to allocate the stable GPU capture "
+                        "facade; GPU capture will remain disabled.");
+        } catch (...) {
+        }
+    }
     InitializeProfileDump();
 
     // Init TaskSystem

--- a/source/runtime/render/profile/RenderProfileCapture.cpp
+++ b/source/runtime/render/profile/RenderProfileCapture.cpp
@@ -76,6 +76,10 @@ RenderProfileSessionStartResult ValidateSessionStart(
     ProfileDump::SchemaHandle _gpu_frame_schema,
     ProfileDump::SchemaHandle _gpu_scope_schema
 ) noexcept {
+    if (!_gpu_frame_schema || !_gpu_scope_schema) {
+        return RenderProfileSessionStartResult::InvalidSchema;
+    }
+
     try {
 #if defined(MOER_RENDER_PROFILE_CAPTURE_TEST_HOOKS)
         ThrowInjectedStartValidationExceptionForTesting();
@@ -87,8 +91,7 @@ RenderProfileSessionStartResult ValidateSessionStart(
             ProfileDump::ComputeSchemaHash(ProfileDump::Templates::GpuFrame());
         const std::uint64_t expected_scope_hash =
             ProfileDump::ComputeSchemaHash(ProfileDump::Templates::GpuScope());
-        if (!_gpu_frame_schema || !_gpu_scope_schema ||
-            _gpu_frame_schema.hash != expected_frame_hash ||
+        if (_gpu_frame_schema.hash != expected_frame_hash ||
             _gpu_scope_schema.hash != expected_scope_hash) {
             return RenderProfileSessionStartResult::InvalidSchema;
         }

--- a/source/runtime/render/profile/RenderProfileCapture.cpp
+++ b/source/runtime/render/profile/RenderProfileCapture.cpp
@@ -6,7 +6,10 @@
 #include <array>
 #include <limits>
 #include <mutex>
+#include <new>
+#include <stdexcept>
 #include <string_view>
+#include <thread>
 #include <utility>
 #include <vector>
 
@@ -20,16 +23,65 @@ enum class EmitDisposition : std::uint8_t {
     Fatal,
 };
 
+#if defined(MOER_RENDER_PROFILE_CAPTURE_TEST_HOOKS)
+std::atomic<std::atomic_uint32_t*> g_start_publish_pause_entered{nullptr};
+std::atomic<std::atomic_bool*>     g_start_publish_pause_release{nullptr};
+
+void PauseBeforeStartPublishForTesting() noexcept {
+    std::atomic_uint32_t* entered =
+        g_start_publish_pause_entered.exchange(nullptr, std::memory_order_acq_rel);
+    if (entered == nullptr) {
+        return;
+    }
+    entered->fetch_add(1, std::memory_order_release);
+    std::atomic_bool* release = g_start_publish_pause_release.load(std::memory_order_acquire);
+    while (release != nullptr && !release->load(std::memory_order_acquire)) {
+        std::this_thread::yield();
+    }
+}
+#endif
+
 bool IsManagedQueue(const RHIQueueBinding& _binding) noexcept {
     return _binding.available &&
-           (_binding.queue == EQueueType::Graphics ||
-            _binding.queue == EQueueType::Compute ||
+           (_binding.queue == EQueueType::Graphics || _binding.queue == EQueueType::Compute ||
             _binding.queue == EQueueType::Copy);
+}
+
+RenderProfileSessionStartResult ValidateSessionStart(
+    ProfileDump::SchemaHandle _gpu_frame_schema,
+    ProfileDump::SchemaHandle _gpu_scope_schema
+) noexcept {
+    if (!_gpu_frame_schema || !_gpu_scope_schema ||
+        _gpu_frame_schema.hash != ProfileDump::ComputeSchemaHash(ProfileDump::Templates::GpuFrame()) ||
+        _gpu_scope_schema.hash != ProfileDump::ComputeSchemaHash(ProfileDump::Templates::GpuScope())) {
+        return RenderProfileSessionStartResult::InvalidSchema;
+    }
+
+    const std::uint64_t             generation_before = ProfileDump::GetRuntimeGeneration();
+    const ProfileDump::RuntimeState runtime_state     = ProfileDump::GetRuntimeState();
+    const std::uint64_t             generation_after  = ProfileDump::GetRuntimeGeneration();
+    if (runtime_state != ProfileDump::RuntimeState::Running || generation_before == 0 ||
+        generation_before != generation_after) {
+        return RenderProfileSessionStartResult::RuntimeUnavailable;
+    }
+    if (_gpu_frame_schema.generation != generation_after ||
+        _gpu_scope_schema.generation != generation_after) {
+        return RenderProfileSessionStartResult::StaleGeneration;
+    }
+    return RenderProfileSessionStartResult::Started;
 }
 
 } // namespace
 
 namespace RenderProfileDetail {
+
+enum class SessionTerminal : std::uint8_t {
+    None = 0,
+    Closed,
+    ClosedWithLoss,
+    Faulted,
+    Aborted,
+};
 
 struct FrameMetadata {
     std::uint64_t frame_id{0};
@@ -49,10 +101,27 @@ struct CaptureState {
         frame_metadata(_stream_config.max_resident_frames) {}
 
     [[nodiscard]] bool RuntimeWritableUnlocked() const noexcept {
-        return generation != 0 &&
-               ProfileDump::GetRuntimeGeneration() == generation &&
-               ProfileDump::GetRuntimeState() ==
-                   ProfileDump::RuntimeState::Running;
+        const std::uint64_t             generation_before = ProfileDump::GetRuntimeGeneration();
+        const ProfileDump::RuntimeState runtime_state     = ProfileDump::GetRuntimeState();
+        const std::uint64_t             generation_after  = ProfileDump::GetRuntimeGeneration();
+        return generation != 0 && generation_before == generation && generation_after == generation &&
+               runtime_state == ProfileDump::RuntimeState::Running;
+    }
+
+    [[nodiscard]] bool HasLossUnlocked() const noexcept {
+        const GpuScopeStreamStats stream_stats = stream.GetStats();
+        return frames_admission_rejected != 0 || sources_rejected != 0 ||
+               frame_records_dropped != 0 || scope_records_dropped != 0 ||
+               stream_stats.sources_dropped_capacity != 0 ||
+               stream_stats.sources_dropped_duplicate_order != 0 ||
+               stream_stats.sources_dropped_after_seal != 0 ||
+               stream_stats.scopes_dropped_resident_full != 0 ||
+               stream_stats.scopes_dropped_frame_full != 0 ||
+               stream_stats.scopes_dropped_name_too_large != 0 ||
+               stream_stats.scopes_dropped_invalid_hierarchy != 0 ||
+               stream_stats.scopes_dropped_suppressed_subtree != 0 ||
+               stream_stats.scopes_dropped_after_seal != 0 ||
+               stream_stats.scopes_dropped_resource_exhaustion != 0;
     }
 
     void ClearMetadataUnlocked() noexcept {
@@ -61,13 +130,23 @@ struct CaptureState {
         }
     }
 
-    void CloseUnlocked(bool _terminal_fault) noexcept {
+    [[nodiscard]] bool MetadataEmptyUnlocked() const noexcept {
+        for (const FrameMetadata& metadata : frame_metadata) {
+            if (metadata.frame_id != 0) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    void CloseUnlocked(SessionTerminal _terminal) noexcept {
         if (closed) {
             return;
         }
         accepting = false;
-        closed = true;
-        if (_terminal_fault) {
+        closed    = true;
+        terminal  = _terminal;
+        if (_terminal == SessionTerminal::Faulted) {
             ++terminal_faults;
         }
         const GpuScopeStreamStats before_close = stream.GetStats();
@@ -76,9 +155,7 @@ struct CaptureState {
         ClearMetadataUnlocked();
     }
 
-    [[nodiscard]] bool ReserveMetadataUnlocked(
-        std::uint64_t _frame_id
-    ) noexcept {
+    [[nodiscard]] bool ReserveMetadataUnlocked(std::uint64_t _frame_id) noexcept {
         for (FrameMetadata& metadata : frame_metadata) {
             if (metadata.frame_id == 0) {
                 metadata.frame_id = _frame_id;
@@ -97,13 +174,11 @@ struct CaptureState {
         }
     }
 
-    [[nodiscard]] FrameMetadata TakeMetadataUnlocked(
-        std::uint64_t _frame_id
-    ) noexcept {
+    [[nodiscard]] FrameMetadata TakeMetadataUnlocked(std::uint64_t _frame_id) noexcept {
         for (FrameMetadata& metadata : frame_metadata) {
             if (metadata.frame_id == _frame_id) {
                 const FrameMetadata result = metadata;
-                metadata = {};
+                metadata                   = {};
                 return result;
             }
         }
@@ -120,10 +195,8 @@ struct CaptureState {
         }
     }
 
-    [[nodiscard]] EmitDisposition HandleEmitUnlocked(
-        ProfileDump::EmitStatus _status,
-        bool                    _frame_record
-    ) noexcept {
+    [[nodiscard]] EmitDisposition
+    HandleEmitUnlocked(ProfileDump::EmitStatus _status, bool _frame_record) noexcept {
         switch (_status) {
             case ProfileDump::EmitStatus::Accepted:
                 if (_frame_record) {
@@ -146,21 +219,21 @@ struct CaptureState {
             case ProfileDump::EmitStatus::StringTooLarge:
             case ProfileDump::EmitStatus::RecordTooLarge:
             case ProfileDump::EmitStatus::SinkFault:
-                CloseUnlocked(true);
+                CloseUnlocked(SessionTerminal::Faulted);
                 return EmitDisposition::Fatal;
         }
-        CloseUnlocked(true);
+        CloseUnlocked(SessionTerminal::Faulted);
         return EmitDisposition::Fatal;
     }
 
     [[nodiscard]] EmitDisposition EmitFrameRecordUnlocked(
-        std::uint64_t            _frame_id,
-        GpuFrameCaptureStatus    _status,
-        bool                     _valid,
-        std::uint64_t            _admitted_scope_count,
-        std::uint64_t            _dropped_scope_count,
-        std::uint64_t            _error_scope_count,
-        std::string_view         _reason
+        std::uint64_t         _frame_id,
+        GpuFrameCaptureStatus _status,
+        bool                  _valid,
+        std::uint64_t         _admitted_scope_count,
+        std::uint64_t         _dropped_scope_count,
+        std::uint64_t         _error_scope_count,
+        std::string_view      _reason
     ) noexcept {
         const std::array<ProfileDump::FieldValueView, 7> values{
             _frame_id,
@@ -171,16 +244,11 @@ struct CaptureState {
             _error_scope_count,
             _reason,
         };
-        return HandleEmitUnlocked(
-            ProfileDump::Emit(gpu_frame_schema, values),
-            true
-        );
+        return HandleEmitUnlocked(ProfileDump::Emit(gpu_frame_schema, values), true);
     }
 
-    [[nodiscard]] EmitDisposition EmitScopeRecordUnlocked(
-        std::uint64_t       _frame_id,
-        const GpuScopeNode& _scope
-    ) noexcept {
+    [[nodiscard]] EmitDisposition
+    EmitScopeRecordUnlocked(std::uint64_t _frame_id, const GpuScopeNode& _scope) noexcept {
         const std::array<ProfileDump::FieldValueView, 18> values{
             _frame_id,
             _scope.scope_id,
@@ -201,18 +269,11 @@ struct CaptureState {
             _scope.depth,
             std::string_view(_scope.error_reason),
         };
-        return HandleEmitUnlocked(
-            ProfileDump::Emit(gpu_scope_schema, values),
-            false
-        );
+        return HandleEmitUnlocked(ProfileDump::Emit(gpu_scope_schema, values), false);
     }
 
-    [[nodiscard]] bool EmitScopeTreeUnlocked(
-        std::uint64_t       _frame_id,
-        const GpuScopeNode& _scope
-    ) noexcept {
-        if (EmitScopeRecordUnlocked(_frame_id, _scope) ==
-            EmitDisposition::Fatal) {
+    [[nodiscard]] bool EmitScopeTreeUnlocked(std::uint64_t _frame_id, const GpuScopeNode& _scope) noexcept {
+        if (EmitScopeRecordUnlocked(_frame_id, _scope) == EmitDisposition::Fatal) {
             return false;
         }
         for (const GpuScopeNode& child : _scope.children) {
@@ -223,23 +284,17 @@ struct CaptureState {
         return true;
     }
 
-    [[nodiscard]] bool EmitResolvedFrameUnlocked(
-        const ResolvedGpuScopeFrame& _frame
-    ) noexcept {
-        const FrameMetadata metadata =
-            TakeMetadataUnlocked(_frame.frame_id);
-        const bool bridge_incomplete =
-            metadata.source_bind_failures != 0;
-        const bool valid = _frame.valid && !bridge_incomplete;
+    [[nodiscard]] bool EmitResolvedFrameUnlocked(const ResolvedGpuScopeFrame& _frame) noexcept {
+        const FrameMetadata metadata          = TakeMetadataUnlocked(_frame.frame_id);
+        const bool          bridge_incomplete = metadata.source_bind_failures != 0;
+        const bool          valid             = _frame.valid && !bridge_incomplete;
 
-        GpuFrameCaptureStatus capture_status =
-            GpuFrameCaptureStatus::Complete;
-        std::string_view reason{};
+        GpuFrameCaptureStatus capture_status = GpuFrameCaptureStatus::Complete;
+        std::string_view      reason{};
         if (!valid) {
             ++frames_invalid;
             const bool has_errors = _frame.error_scope_count != 0;
-            const bool has_drops =
-                _frame.dropped_scope_count != 0 || bridge_incomplete;
+            const bool has_drops  = _frame.dropped_scope_count != 0 || bridge_incomplete;
             if (has_errors || (!has_drops && !_frame.valid)) {
                 capture_status = GpuFrameCaptureStatus::Invalid;
             } else {
@@ -250,8 +305,7 @@ struct CaptureState {
                 reason = "GPU frame capture contains failed and dropped scopes";
             } else if (has_errors) {
                 reason = "one or more GPU scopes failed";
-            } else if (bridge_incomplete &&
-                       _frame.dropped_scope_count != 0) {
+            } else if (bridge_incomplete && _frame.dropped_scope_count != 0) {
                 reason = "GPU recording sources and scopes were dropped";
             } else if (bridge_incomplete) {
                 reason = "one or more GPU recording sources were rejected";
@@ -287,7 +341,7 @@ struct CaptureState {
     [[nodiscard]] std::size_t DrainUnlocked() noexcept {
         if (closed || !RuntimeWritableUnlocked()) {
             if (!closed) {
-                CloseUnlocked(true);
+                CloseUnlocked(SessionTerminal::Faulted);
             }
             return 0;
         }
@@ -303,21 +357,23 @@ struct CaptureState {
                 frame = {};
             }
         } catch (...) {
-            CloseUnlocked(true);
+            CloseUnlocked(SessionTerminal::Faulted);
         }
         return drained;
     }
 
-    ProfileDump::SchemaHandle gpu_frame_schema{};
-    ProfileDump::SchemaHandle gpu_scope_schema{};
-    std::uint64_t             generation{0};
-    GpuScopeStream            stream;
+    ProfileDump::SchemaHandle  gpu_frame_schema{};
+    ProfileDump::SchemaHandle  gpu_scope_schema{};
+    std::uint64_t              generation{0};
+    GpuScopeStream             stream;
     std::vector<FrameMetadata> frame_metadata{};
 
     mutable std::mutex mutex{};
-    std::uint64_t next_frame_id{1};
-    bool          accepting{true};
-    bool          closed{false};
+    std::uint64_t      next_frame_id{1};
+    bool               accepting{true};
+    bool               stop_requested{false};
+    bool               closed{false};
+    SessionTerminal    terminal{SessionTerminal::None};
 
     std::uint64_t frames_attempted{0};
     std::uint64_t frames_admitted{0};
@@ -349,30 +405,26 @@ RenderProfileFrameToken::~RenderProfileFrameToken() {
     SealIfNeeded();
 }
 
-RenderProfileFrameToken::RenderProfileFrameToken(
-    RenderProfileFrameToken&& _other
-) noexcept :
+RenderProfileFrameToken::RenderProfileFrameToken(RenderProfileFrameToken&& _other) noexcept :
     state_(std::move(_other.state_)),
     frame_(std::move(_other.frame_)),
     frame_id_(_other.frame_id_),
     sealed_(_other.sealed_) {
     _other.frame_id_ = 0;
-    _other.sealed_ = true;
+    _other.sealed_   = true;
 }
 
-RenderProfileFrameToken& RenderProfileFrameToken::operator=(
-    RenderProfileFrameToken&& _other
-) noexcept {
+RenderProfileFrameToken& RenderProfileFrameToken::operator=(RenderProfileFrameToken&& _other) noexcept {
     if (this == &_other) {
         return *this;
     }
     SealIfNeeded();
-    state_ = std::move(_other.state_);
-    frame_ = std::move(_other.frame_);
-    frame_id_ = _other.frame_id_;
-    sealed_ = _other.sealed_;
+    state_           = std::move(_other.state_);
+    frame_           = std::move(_other.frame_);
+    frame_id_        = _other.frame_id_;
+    sealed_          = _other.sealed_;
     _other.frame_id_ = 0;
-    _other.sealed_ = true;
+    _other.sealed_   = true;
     return *this;
 }
 
@@ -381,8 +433,14 @@ bool RenderProfileFrameToken::Valid() const noexcept {
         return false;
     }
     std::scoped_lock lock(state_->mutex);
-    return state_->accepting && !state_->closed &&
-           state_->RuntimeWritableUnlocked() && frame_.Valid();
+    if (state_->closed) {
+        return false;
+    }
+    if (!state_->RuntimeWritableUnlocked()) {
+        state_->CloseUnlocked(RenderProfileDetail::SessionTerminal::Faulted);
+        return false;
+    }
+    return frame_.Valid();
 }
 
 std::uint64_t RenderProfileFrameToken::FrameId() const noexcept {
@@ -396,8 +454,12 @@ void RenderProfileFrameToken::SealIfNeeded() noexcept {
     sealed_ = true;
     if (state_ && frame_.Valid()) {
         std::scoped_lock lock(state_->mutex);
-        if (!state_->closed && state_->stream.SealFrame(frame_)) {
-            ++state_->frames_sealed;
+        if (!state_->closed) {
+            if (!state_->RuntimeWritableUnlocked()) {
+                state_->CloseUnlocked(RenderProfileDetail::SessionTerminal::Faulted);
+            } else if (state_->stream.SealFrame(frame_)) {
+                ++state_->frames_sealed;
+            }
         }
     }
     frame_ = {};
@@ -409,64 +471,216 @@ RenderProfileCapture::RenderProfileCapture(
     ProfileDump::SchemaHandle   _gpu_scope_schema,
     const GpuScopeStreamConfig& _stream_config
 ) {
-    const std::uint64_t generation =
-        ProfileDump::GetRuntimeGeneration();
-    if (!_gpu_frame_schema || !_gpu_scope_schema ||
-        generation == 0 ||
-        ProfileDump::GetRuntimeState() !=
-            ProfileDump::RuntimeState::Running ||
-        _gpu_frame_schema.generation != generation ||
-        _gpu_scope_schema.generation != generation ||
-        _gpu_frame_schema.hash != ProfileDump::ComputeSchemaHash(
-                                      ProfileDump::Templates::GpuFrame()
-                                  ) ||
-        _gpu_scope_schema.hash != ProfileDump::ComputeSchemaHash(
-                                      ProfileDump::Templates::GpuScope()
-                                  )) {
-        return;
+    const RenderProfileSessionStartResult result =
+        StartSession(_gpu_frame_schema, _gpu_scope_schema, _stream_config);
+    if (result == RenderProfileSessionStartResult::InvalidConfiguration) {
+        throw std::invalid_argument("GpuScopeStreamConfig is invalid");
     }
-
-    state_ = std::make_shared<RenderProfileDetail::CaptureState>(
-        _gpu_frame_schema,
-        _gpu_scope_schema,
-        _stream_config
-    );
+    if (result == RenderProfileSessionStartResult::ResourceExhausted) {
+        throw std::bad_alloc{};
+    }
 }
 
 RenderProfileCapture::~RenderProfileCapture() {
     Abort();
 }
 
+RenderProfileSessionStartResult RenderProfileCapture::StartSession(
+    ProfileDump::SchemaHandle   _gpu_frame_schema,
+    ProfileDump::SchemaHandle   _gpu_scope_schema,
+    const GpuScopeStreamConfig& _stream_config
+) noexcept {
+    RenderProfileSessionStartResult validation = ValidateSessionStart(_gpu_frame_schema, _gpu_scope_schema);
+    if (validation != RenderProfileSessionStartResult::Started) {
+        return validation;
+    }
+
+    std::shared_ptr<RenderProfileDetail::CaptureState> replacement;
+    try {
+        replacement = std::make_shared<RenderProfileDetail::CaptureState>(
+            _gpu_frame_schema, _gpu_scope_schema, _stream_config
+        );
+        if (!replacement->stream.Valid()) {
+            return RenderProfileSessionStartResult::ResourceExhausted;
+        }
+    } catch (const std::invalid_argument&) {
+        return RenderProfileSessionStartResult::InvalidConfiguration;
+    } catch (...) {
+        return RenderProfileSessionStartResult::ResourceExhausted;
+    }
+
+    auto observed = state_.load(std::memory_order_acquire);
+    for (;;) {
+        // A request can be delayed while ProfileDump advances and another
+        // caller publishes the new generation. Revalidate before inspecting
+        // or retiring the currently published state so a stale request can
+        // never poison a newer live session.
+        validation = ValidateSessionStart(_gpu_frame_schema, _gpu_scope_schema);
+        if (validation != RenderProfileSessionStartResult::Started) {
+            return validation;
+        }
+
+        if (observed) {
+            std::scoped_lock lock(observed->mutex);
+            if (observed->generation == _gpu_frame_schema.generation) {
+                return observed->closed ? RenderProfileSessionStartResult::GenerationAlreadyUsed :
+                                          RenderProfileSessionStartResult::AlreadyActive;
+            }
+        }
+
+        // The ProfileDump runtime may have stopped or restarted while the
+        // replacement state was being allocated. Never publish a facade
+        // state whose schema handles no longer name the live generation.
+        validation = ValidateSessionStart(_gpu_frame_schema, _gpu_scope_schema);
+        if (validation != RenderProfileSessionStartResult::Started) {
+            return validation;
+        }
+
+#if defined(MOER_RENDER_PROFILE_CAPTURE_TEST_HOOKS)
+        PauseBeforeStartPublishForTesting();
+#endif
+
+        const auto retired = observed;
+        if (state_.compare_exchange_weak(
+                observed, replacement, std::memory_order_acq_rel, std::memory_order_acquire
+            )) {
+            // This is the publication linearization check. If ProfileDump
+            // changed after the pre-CAS validation, fail only this candidate;
+            // never mutate a state another caller may already have published.
+            validation = ValidateSessionStart(_gpu_frame_schema, _gpu_scope_schema);
+            if (validation != RenderProfileSessionStartResult::Started) {
+                std::scoped_lock lock(replacement->mutex);
+                replacement->CloseUnlocked(RenderProfileDetail::SessionTerminal::Faulted);
+                return validation;
+            }
+            if (retired) {
+                std::scoped_lock lock(retired->mutex);
+                if (!retired->closed && !retired->RuntimeWritableUnlocked()) {
+                    retired->CloseUnlocked(RenderProfileDetail::SessionTerminal::Faulted);
+                }
+            }
+            return RenderProfileSessionStartResult::Started;
+        }
+    }
+}
+
+RenderProfileSessionStopResult RenderProfileCapture::RequestStop() noexcept {
+    const auto state = state_.load(std::memory_order_acquire);
+    if (!state) {
+        return RenderProfileSessionStopResult::Inactive;
+    }
+
+    std::scoped_lock lock(state->mutex);
+    if (state->closed) {
+        return RenderProfileSessionStopResult::Inactive;
+    }
+    if (!state->RuntimeWritableUnlocked()) {
+        state->CloseUnlocked(RenderProfileDetail::SessionTerminal::Faulted);
+        return RenderProfileSessionStopResult::Inactive;
+    }
+    if (state->stop_requested) {
+        return RenderProfileSessionStopResult::AlreadyStopping;
+    }
+    state->stop_requested = true;
+    state->accepting      = false;
+    return RenderProfileSessionStopResult::StopRequested;
+}
+
+RenderProfileSessionFinishResult RenderProfileCapture::TryFinishSession() noexcept {
+    const auto state = state_.load(std::memory_order_acquire);
+    if (!state) {
+        return RenderProfileSessionFinishResult::Inactive;
+    }
+
+    std::scoped_lock lock(state->mutex);
+    if (state->closed) {
+        switch (state->terminal) {
+            case RenderProfileDetail::SessionTerminal::Closed:
+                return RenderProfileSessionFinishResult::Closed;
+            case RenderProfileDetail::SessionTerminal::ClosedWithLoss:
+                return RenderProfileSessionFinishResult::ClosedWithLoss;
+            case RenderProfileDetail::SessionTerminal::Aborted:
+                return RenderProfileSessionFinishResult::Aborted;
+            case RenderProfileDetail::SessionTerminal::Faulted:
+                return RenderProfileSessionFinishResult::Faulted;
+            case RenderProfileDetail::SessionTerminal::None:
+                break;
+        }
+        return RenderProfileSessionFinishResult::Faulted;
+    }
+
+    // Make the finish attempt self-contained if an owner omitted the
+    // separate RequestStop call. Already-admitted tokens remain operational.
+    state->stop_requested = true;
+    state->accepting      = false;
+    if (!state->RuntimeWritableUnlocked()) {
+        state->CloseUnlocked(RenderProfileDetail::SessionTerminal::Faulted);
+        return RenderProfileSessionFinishResult::Faulted;
+    }
+
+    static_cast<void>(state->DrainUnlocked());
+    if (state->closed) {
+        return RenderProfileSessionFinishResult::Faulted;
+    }
+
+    const GpuScopeStreamStats stream_stats = state->stream.GetStats();
+    if (stream_stats.resident_frames != 0) {
+        return RenderProfileSessionFinishResult::Pending;
+    }
+    if (stream_stats.resident_pending_frames != 0 || stream_stats.resident_ready_frames != 0 ||
+        stream_stats.resident_scopes != 0 || !state->MetadataEmptyUnlocked()) {
+        state->CloseUnlocked(RenderProfileDetail::SessionTerminal::Faulted);
+        return RenderProfileSessionFinishResult::Faulted;
+    }
+
+    if (state->HasLossUnlocked()) {
+        state->CloseUnlocked(RenderProfileDetail::SessionTerminal::ClosedWithLoss);
+        return RenderProfileSessionFinishResult::ClosedWithLoss;
+    }
+    state->CloseUnlocked(RenderProfileDetail::SessionTerminal::Closed);
+    return RenderProfileSessionFinishResult::Closed;
+}
+
 bool RenderProfileCapture::Valid() const noexcept {
-    const auto state = state_;
+    const auto state = state_.load(std::memory_order_acquire);
     if (!state) {
         return false;
     }
     std::scoped_lock lock(state->mutex);
-    return state->accepting && !state->closed &&
-           state->RuntimeWritableUnlocked();
+    if (state->closed) {
+        return false;
+    }
+    if (!state->RuntimeWritableUnlocked()) {
+        state->CloseUnlocked(RenderProfileDetail::SessionTerminal::Faulted);
+        return false;
+    }
+    return state->accepting;
 }
 
 RenderProfileFrameToken RenderProfileCapture::BeginFrame() noexcept {
-    const auto state = state_;
+    const auto state = state_.load(std::memory_order_acquire);
     if (!state) {
         return {};
     }
 
     std::scoped_lock lock(state->mutex);
-    if (!state->accepting || state->closed ||
-        !state->RuntimeWritableUnlocked()) {
+    if (state->closed) {
+        return {};
+    }
+    if (!state->RuntimeWritableUnlocked()) {
         if (!state->closed) {
-            state->CloseUnlocked(true);
+            state->CloseUnlocked(RenderProfileDetail::SessionTerminal::Faulted);
         }
+        return {};
+    }
+    if (!state->accepting) {
         return {};
     }
 
     const std::uint64_t frame_id = state->next_frame_id++;
     ++state->frames_attempted;
-    if (frame_id == 0 ||
-        state->next_frame_id == 0) {
-        state->CloseUnlocked(true);
+    if (frame_id == 0 || state->next_frame_id == 0) {
+        state->CloseUnlocked(RenderProfileDetail::SessionTerminal::Faulted);
         return {};
     }
 
@@ -482,13 +696,11 @@ RenderProfileFrameToken RenderProfileCapture::BeginFrame() noexcept {
 
     if (!state->ReserveMetadataUnlocked(frame_id)) {
         static_cast<void>(state->stream.SealFrame(frame));
-        state->CloseUnlocked(true);
+        state->CloseUnlocked(RenderProfileDetail::SessionTerminal::Faulted);
         return {};
     }
     ++state->frames_admitted;
-    return RenderProfileFrameToken(
-        state, std::move(frame), frame_id
-    );
+    return RenderProfileFrameToken(state, std::move(frame), frame_id);
 }
 
 RenderProfileBindResult RenderProfileCapture::BindSource(
@@ -497,17 +709,15 @@ RenderProfileBindResult RenderProfileCapture::BindSource(
     RHIQueueBinding          _queue_binding,
     std::uint64_t            _source_order
 ) noexcept {
-    const auto state = state_;
-    if (!state || _frame.state_.get() != state.get() ||
-        _frame.sealed_ || !_frame.frame_.Valid()) {
+    const auto state = state_.load(std::memory_order_acquire);
+    if (!state || _frame.state_.get() != state.get() || _frame.sealed_ || !_frame.frame_.Valid()) {
         return RenderProfileBindResult::InvalidFrame;
     }
 
     std::scoped_lock lock(state->mutex);
-    if (!state->accepting || state->closed ||
-        !state->RuntimeWritableUnlocked()) {
+    if (state->closed || !state->RuntimeWritableUnlocked()) {
         if (!state->closed) {
-            state->CloseUnlocked(true);
+            state->CloseUnlocked(RenderProfileDetail::SessionTerminal::Faulted);
         }
         return RenderProfileBindResult::Inactive;
     }
@@ -516,8 +726,7 @@ RenderProfileBindResult RenderProfileCapture::BindSource(
         return RenderProfileBindResult::InvalidQueue;
     }
 
-    GpuScopeRecorder recorder =
-        _frame.frame_.CreateRecorder(_queue_binding, _source_order);
+    GpuScopeRecorder recorder = _frame.frame_.CreateRecorder(_queue_binding, _source_order);
     if (!recorder.Valid()) {
         state->MarkSourceFailureUnlocked(_frame.frame_id_);
         return RenderProfileBindResult::SourceRejected;
@@ -533,30 +742,30 @@ RenderProfileBindResult RenderProfileCapture::BindSource(
     return RenderProfileBindResult::Bound;
 }
 
-bool RenderProfileCapture::Seal(
-    RenderProfileFrameToken& _frame
-) noexcept {
-    const auto state = state_;
-    if (!state || _frame.state_.get() != state.get() ||
-        _frame.sealed_) {
+bool RenderProfileCapture::Seal(RenderProfileFrameToken& _frame) noexcept {
+    const auto state = state_.load(std::memory_order_acquire);
+    if (!state || _frame.state_.get() != state.get() || _frame.sealed_) {
         return false;
     }
 
     std::scoped_lock lock(state->mutex);
-    const bool sealed =
-        !state->closed && _frame.frame_.Valid() &&
-        state->stream.SealFrame(_frame.frame_);
+    bool             sealed = false;
+    if (!state->closed && state->RuntimeWritableUnlocked()) {
+        sealed = _frame.frame_.Valid() && state->stream.SealFrame(_frame.frame_);
+    } else if (!state->closed) {
+        state->CloseUnlocked(RenderProfileDetail::SessionTerminal::Faulted);
+    }
     if (sealed) {
         ++state->frames_sealed;
     }
     _frame.sealed_ = true;
-    _frame.frame_ = {};
+    _frame.frame_  = {};
     _frame.state_.reset();
     return sealed;
 }
 
 std::size_t RenderProfileCapture::DrainReadyFrames() noexcept {
-    const auto state = state_;
+    const auto state = state_.load(std::memory_order_acquire);
     if (!state) {
         return 0;
     }
@@ -565,7 +774,7 @@ std::size_t RenderProfileCapture::DrainReadyFrames() noexcept {
 }
 
 void RenderProfileCapture::ShutdownAfterRhiDrain() noexcept {
-    const auto state = state_;
+    const auto state = state_.load(std::memory_order_acquire);
     if (!state) {
         return;
     }
@@ -573,59 +782,79 @@ void RenderProfileCapture::ShutdownAfterRhiDrain() noexcept {
     if (state->closed) {
         return;
     }
-    state->accepting = false;
+    state->stop_requested = true;
+    state->accepting      = false;
     static_cast<void>(state->DrainUnlocked());
     if (!state->closed) {
-        state->closed = true;
-        const GpuScopeStreamStats before_close =
-            state->stream.GetStats();
-        state->shutdown_abandoned_frames +=
-            before_close.resident_frames;
-        state->stream.Close();
-        state->ClearMetadataUnlocked();
+        const GpuScopeStreamStats before_close = state->stream.GetStats();
+        if (before_close.resident_frames != 0) {
+            state->CloseUnlocked(RenderProfileDetail::SessionTerminal::Aborted);
+        } else if (before_close.resident_pending_frames != 0 || before_close.resident_ready_frames != 0 ||
+                   before_close.resident_scopes != 0 || !state->MetadataEmptyUnlocked()) {
+            state->CloseUnlocked(RenderProfileDetail::SessionTerminal::Faulted);
+        } else {
+            state->CloseUnlocked(
+                state->HasLossUnlocked() ? RenderProfileDetail::SessionTerminal::ClosedWithLoss :
+                                           RenderProfileDetail::SessionTerminal::Closed
+            );
+        }
     }
 }
 
 void RenderProfileCapture::Abort() noexcept {
-    const auto state = state_;
+    const auto state = state_.load(std::memory_order_acquire);
     if (!state) {
         return;
     }
     std::scoped_lock lock(state->mutex);
-    state->CloseUnlocked(false);
+    state->CloseUnlocked(RenderProfileDetail::SessionTerminal::Aborted);
 }
 
-RenderProfileCaptureStats
-RenderProfileCapture::GetStats() const noexcept {
+RenderProfileCaptureStats RenderProfileCapture::GetStats() const noexcept {
     RenderProfileCaptureStats result{};
-    const auto state = state_;
+    const auto                state = state_.load(std::memory_order_acquire);
     if (!state) {
         return result;
     }
 
     std::scoped_lock lock(state->mutex);
-    result.accepting = state->accepting;
-    result.closed = state->closed;
-    result.generation = state->generation;
-    result.frames_attempted = state->frames_attempted;
-    result.frames_admitted = state->frames_admitted;
-    result.frames_admission_rejected =
-        state->frames_admission_rejected;
-    result.frames_sealed = state->frames_sealed;
-    result.frames_emitted = state->frames_emitted;
-    result.frames_invalid = state->frames_invalid;
-    result.frame_records_dropped =
-        state->frame_records_dropped;
-    result.sources_bound = state->sources_bound;
-    result.sources_rejected = state->sources_rejected;
-    result.scopes_emitted = state->scopes_emitted;
-    result.scope_records_dropped =
-        state->scope_records_dropped;
-    result.terminal_faults = state->terminal_faults;
-    result.shutdown_abandoned_frames =
-        state->shutdown_abandoned_frames;
-    result.stream = state->stream.GetStats();
+    if (!state->closed && !state->RuntimeWritableUnlocked()) {
+        state->CloseUnlocked(RenderProfileDetail::SessionTerminal::Faulted);
+    }
+    result.accepting                 = state->accepting;
+    result.closed                    = state->closed;
+    result.generation                = state->generation;
+    result.frames_attempted          = state->frames_attempted;
+    result.frames_admitted           = state->frames_admitted;
+    result.frames_admission_rejected = state->frames_admission_rejected;
+    result.frames_sealed             = state->frames_sealed;
+    result.frames_emitted            = state->frames_emitted;
+    result.frames_invalid            = state->frames_invalid;
+    result.frame_records_dropped     = state->frame_records_dropped;
+    result.sources_bound             = state->sources_bound;
+    result.sources_rejected          = state->sources_rejected;
+    result.scopes_emitted            = state->scopes_emitted;
+    result.scope_records_dropped     = state->scope_records_dropped;
+    result.terminal_faults           = state->terminal_faults;
+    result.shutdown_abandoned_frames = state->shutdown_abandoned_frames;
+    result.stream                    = state->stream.GetStats();
     return result;
 }
+
+#if defined(MOER_RENDER_PROFILE_CAPTURE_TEST_HOOKS)
+namespace RenderProfileTesting {
+
+void InstallStartPublishPause(std::atomic_uint32_t& _entered_count, std::atomic_bool& _release) noexcept {
+    g_start_publish_pause_release.store(&_release, std::memory_order_release);
+    g_start_publish_pause_entered.store(&_entered_count, std::memory_order_release);
+}
+
+void ClearStartPublishPause() noexcept {
+    g_start_publish_pause_entered.store(nullptr, std::memory_order_release);
+    g_start_publish_pause_release.store(nullptr, std::memory_order_release);
+}
+
+} // namespace RenderProfileTesting
+#endif
 
 } // namespace Moer::Render

--- a/source/runtime/render/profile/RenderProfileCapture.cpp
+++ b/source/runtime/render/profile/RenderProfileCapture.cpp
@@ -24,8 +24,33 @@ enum class EmitDisposition : std::uint8_t {
 };
 
 #if defined(MOER_RENDER_PROFILE_CAPTURE_TEST_HOOKS)
+enum class InjectedStartValidationException : std::uint8_t {
+    None = 0,
+    BadAlloc,
+    Other,
+};
+
+struct StartValidationExceptionForTesting final {};
+
+std::atomic<InjectedStartValidationException> g_start_validation_exception{
+    InjectedStartValidationException::None
+};
 std::atomic<std::atomic_uint32_t*> g_start_publish_pause_entered{nullptr};
 std::atomic<std::atomic_bool*>     g_start_publish_pause_release{nullptr};
+
+void ThrowInjectedStartValidationExceptionForTesting() {
+    switch (g_start_validation_exception.exchange(
+        InjectedStartValidationException::None,
+        std::memory_order_acq_rel
+    )) {
+        case InjectedStartValidationException::BadAlloc:
+            throw std::bad_alloc{};
+        case InjectedStartValidationException::Other:
+            throw StartValidationExceptionForTesting{};
+        case InjectedStartValidationException::None:
+            return;
+    }
+}
 
 void PauseBeforeStartPublishForTesting() noexcept {
     std::atomic_uint32_t* entered =
@@ -51,24 +76,44 @@ RenderProfileSessionStartResult ValidateSessionStart(
     ProfileDump::SchemaHandle _gpu_frame_schema,
     ProfileDump::SchemaHandle _gpu_scope_schema
 ) noexcept {
-    if (!_gpu_frame_schema || !_gpu_scope_schema ||
-        _gpu_frame_schema.hash != ProfileDump::ComputeSchemaHash(ProfileDump::Templates::GpuFrame()) ||
-        _gpu_scope_schema.hash != ProfileDump::ComputeSchemaHash(ProfileDump::Templates::GpuScope())) {
-        return RenderProfileSessionStartResult::InvalidSchema;
-    }
+    try {
+#if defined(MOER_RENDER_PROFILE_CAPTURE_TEST_HOOKS)
+        ThrowInjectedStartValidationExceptionForTesting();
+#endif
+        // GpuFrame()/GpuScope() use function-local static descriptors whose
+        // first construction allocates strings and field arrays. Keep that
+        // lazy initialization inside this noexcept translation boundary.
+        const std::uint64_t expected_frame_hash =
+            ProfileDump::ComputeSchemaHash(ProfileDump::Templates::GpuFrame());
+        const std::uint64_t expected_scope_hash =
+            ProfileDump::ComputeSchemaHash(ProfileDump::Templates::GpuScope());
+        if (!_gpu_frame_schema || !_gpu_scope_schema ||
+            _gpu_frame_schema.hash != expected_frame_hash ||
+            _gpu_scope_schema.hash != expected_scope_hash) {
+            return RenderProfileSessionStartResult::InvalidSchema;
+        }
 
-    const std::uint64_t             generation_before = ProfileDump::GetRuntimeGeneration();
-    const ProfileDump::RuntimeState runtime_state     = ProfileDump::GetRuntimeState();
-    const std::uint64_t             generation_after  = ProfileDump::GetRuntimeGeneration();
-    if (runtime_state != ProfileDump::RuntimeState::Running || generation_before == 0 ||
-        generation_before != generation_after) {
-        return RenderProfileSessionStartResult::RuntimeUnavailable;
+        const std::uint64_t generation_before =
+            ProfileDump::GetRuntimeGeneration();
+        const ProfileDump::RuntimeState runtime_state =
+            ProfileDump::GetRuntimeState();
+        const std::uint64_t generation_after =
+            ProfileDump::GetRuntimeGeneration();
+        if (runtime_state != ProfileDump::RuntimeState::Running ||
+            generation_before == 0 ||
+            generation_before != generation_after) {
+            return RenderProfileSessionStartResult::RuntimeUnavailable;
+        }
+        if (_gpu_frame_schema.generation != generation_after ||
+            _gpu_scope_schema.generation != generation_after) {
+            return RenderProfileSessionStartResult::StaleGeneration;
+        }
+        return RenderProfileSessionStartResult::Started;
+    } catch (const std::bad_alloc&) {
+        return RenderProfileSessionStartResult::ResourceExhausted;
+    } catch (...) {
+        return RenderProfileSessionStartResult::InvalidConfiguration;
     }
-    if (_gpu_frame_schema.generation != generation_after ||
-        _gpu_scope_schema.generation != generation_after) {
-        return RenderProfileSessionStartResult::StaleGeneration;
-    }
-    return RenderProfileSessionStartResult::Started;
 }
 
 } // namespace
@@ -843,6 +888,27 @@ RenderProfileCaptureStats RenderProfileCapture::GetStats() const noexcept {
 
 #if defined(MOER_RENDER_PROFILE_CAPTURE_TEST_HOOKS)
 namespace RenderProfileTesting {
+
+void InjectNextStartValidationBadAlloc() noexcept {
+    g_start_validation_exception.store(
+        InjectedStartValidationException::BadAlloc,
+        std::memory_order_release
+    );
+}
+
+void InjectNextStartValidationException() noexcept {
+    g_start_validation_exception.store(
+        InjectedStartValidationException::Other,
+        std::memory_order_release
+    );
+}
+
+void ClearStartValidationException() noexcept {
+    g_start_validation_exception.store(
+        InjectedStartValidationException::None,
+        std::memory_order_release
+    );
+}
 
 void InstallStartPublishPause(std::atomic_uint32_t& _entered_count, std::atomic_bool& _release) noexcept {
     g_start_publish_pause_release.store(&_release, std::memory_order_release);

--- a/source/runtime/render/profile/RenderProfileCapture.h
+++ b/source/runtime/render/profile/RenderProfileCapture.h
@@ -5,6 +5,7 @@
 #include "profile/ProfileDump.h"
 #include "rhi/RHIGpuScope.h"
 
+#include <atomic>
 #include <cstddef>
 #include <cstdint>
 #include <memory>
@@ -30,6 +31,34 @@ enum class RenderProfileBindResult : std::uint8_t {
     InvalidQueue,
     SourceRejected,
     CommandListRejected,
+};
+
+enum class RenderProfileSessionStartResult : std::uint8_t {
+    Started = 0,
+    AlreadyActive,
+    GenerationAlreadyUsed,
+    InvalidSchema,
+    RuntimeUnavailable,
+    StaleGeneration,
+    InvalidConfiguration,
+    ResourceExhausted,
+};
+
+enum class RenderProfileSessionStopResult : std::uint8_t {
+    StopRequested = 0,
+    AlreadyStopping,
+    Inactive,
+};
+
+enum class RenderProfileSessionFinishResult : std::uint8_t {
+    Pending = 0,
+    Closed,
+    // The session drained and closed, but at least one frame, source, scope,
+    // or serialized record was rejected or dropped.
+    ClosedWithLoss,
+    Faulted,
+    Aborted,
+    Inactive,
 };
 
 struct RenderProfileCaptureStats {
@@ -60,13 +89,12 @@ public:
     RenderProfileFrameToken() = default;
     ~RenderProfileFrameToken();
 
-    RenderProfileFrameToken(const RenderProfileFrameToken&) = delete;
+    RenderProfileFrameToken(const RenderProfileFrameToken&)            = delete;
     RenderProfileFrameToken& operator=(const RenderProfileFrameToken&) = delete;
     RenderProfileFrameToken(RenderProfileFrameToken&& _other) noexcept;
-    RenderProfileFrameToken&
-    operator=(RenderProfileFrameToken&& _other) noexcept;
+    RenderProfileFrameToken& operator=(RenderProfileFrameToken&& _other) noexcept;
 
-    [[nodiscard]] bool Valid() const noexcept;
+    [[nodiscard]] bool          Valid() const noexcept;
     [[nodiscard]] std::uint64_t FrameId() const noexcept;
 
 private:
@@ -88,19 +116,39 @@ private:
 
 class RENDER_API RenderProfileCapture final {
 public:
+    // Stable facade. One instance may bind to successive ProfileDump
+    // generations, but never to two sessions in the same generation.
+    RenderProfileCapture() noexcept = default;
+    // Compatibility constructor: invalid stream configuration and allocation
+    // failure retain the throwing behavior of the original one-shot facade.
     RenderProfileCapture(
-        ProfileDump::SchemaHandle     _gpu_frame_schema,
-        ProfileDump::SchemaHandle     _gpu_scope_schema,
-        const GpuScopeStreamConfig&   _stream_config = {}
+        ProfileDump::SchemaHandle   _gpu_frame_schema,
+        ProfileDump::SchemaHandle   _gpu_scope_schema,
+        const GpuScopeStreamConfig& _stream_config = {}
     );
     ~RenderProfileCapture();
 
-    RenderProfileCapture(const RenderProfileCapture&) = delete;
+    RenderProfileCapture(const RenderProfileCapture&)            = delete;
     RenderProfileCapture& operator=(const RenderProfileCapture&) = delete;
-    RenderProfileCapture(RenderProfileCapture&&) = delete;
-    RenderProfileCapture& operator=(RenderProfileCapture&&) = delete;
+    RenderProfileCapture(RenderProfileCapture&&)                 = delete;
+    RenderProfileCapture& operator=(RenderProfileCapture&&)      = delete;
 
-    [[nodiscard]] bool Valid() const noexcept;
+    [[nodiscard]] RenderProfileSessionStartResult StartSession(
+        ProfileDump::SchemaHandle   _gpu_frame_schema,
+        ProfileDump::SchemaHandle   _gpu_scope_schema,
+        const GpuScopeStreamConfig& _stream_config = {}
+    ) noexcept;
+
+    // Stops only future BeginFrame admission. Tokens admitted before the
+    // boundary remain valid and may still bind sources and seal.
+    [[nodiscard]] RenderProfileSessionStopResult RequestStop() noexcept;
+
+    // Stops admission, drains ready frames, and closes only after every
+    // admitted frame has left the resident stream. Pending callbacks retain
+    // the old session state and can never enter a later generation.
+    [[nodiscard]] RenderProfileSessionFinishResult TryFinishSession() noexcept;
+
+    [[nodiscard]] bool                    Valid() const noexcept;
     [[nodiscard]] RenderProfileFrameToken BeginFrame() noexcept;
     [[nodiscard]] RenderProfileBindResult BindSource(
         RenderProfileFrameToken& _frame,
@@ -108,9 +156,7 @@ public:
         RHIQueueBinding          _queue_binding,
         std::uint64_t            _source_order
     ) noexcept;
-    [[nodiscard]] bool Seal(
-        RenderProfileFrameToken& _frame
-    ) noexcept;
+    [[nodiscard]] bool Seal(RenderProfileFrameToken& _frame) noexcept;
 
     // Consumer-only operation. It materializes ready frames in BeginFrame
     // order and emits ProfileDump records on the calling thread. Completion
@@ -128,8 +174,16 @@ public:
     [[nodiscard]] RenderProfileCaptureStats GetStats() const noexcept;
 
 private:
-    std::shared_ptr<RenderProfileDetail::CaptureState> state_{};
+    std::atomic<std::shared_ptr<RenderProfileDetail::CaptureState>> state_{};
 };
+
+#if defined(MOER_RENDER_PROFILE_CAPTURE_TEST_HOOKS)
+namespace RenderProfileTesting {
+RENDER_API void
+InstallStartPublishPause(std::atomic_uint32_t& _entered_count, std::atomic_bool& _release) noexcept;
+RENDER_API void ClearStartPublishPause() noexcept;
+} // namespace RenderProfileTesting
+#endif
 
 } // namespace Moer::Render
 

--- a/source/runtime/render/profile/RenderProfileCapture.h
+++ b/source/runtime/render/profile/RenderProfileCapture.h
@@ -179,6 +179,13 @@ private:
 
 #if defined(MOER_RENDER_PROFILE_CAPTURE_TEST_HOOKS)
 namespace RenderProfileTesting {
+// Deterministic seams for exceptions that can escape first-use construction
+// of the lazy ProfileDump schema descriptors. Production builds do not
+// declare or compile these injectors.
+RENDER_API void InjectNextStartValidationBadAlloc() noexcept;
+RENDER_API void InjectNextStartValidationException() noexcept;
+RENDER_API void ClearStartValidationException() noexcept;
+
 RENDER_API void
 InstallStartPublishPause(std::atomic_uint32_t& _entered_count, std::atomic_bool& _release) noexcept;
 RENDER_API void ClearStartPublishPause() noexcept;

--- a/source/runtime/render/rhi/vulkan/RHICmdReorderer.h
+++ b/source/runtime/render/rhi/vulkan/RHICmdReorderer.h
@@ -955,19 +955,21 @@ public:
                 const Range range(
                     handle.mip_level, handle.num_mips, handle.array_layer, handle.num_array
                 );
-                const int64 prior_write_layer =
-                    range_handle->GetMaxWriteLayer(range);
+                const int64 prior_access_layer = std::max(
+                    range_handle->GetMaxReadLayer(range),
+                    range_handle->GetMaxWriteLayer(range)
+                );
                 assert(
-                    prior_write_layer < 0 &&
+                    prior_access_layer < 0 &&
                     std::format(
-                        "Import Texture {} should precede its first resource write",
+                        "Import Texture {} should precede its first resource access",
                         handle.GetTexture()->GetName()
                     )
                         .c_str()
                 );
                 layer = std::max(
                     layer,
-                    GetLayerWithOffset(prior_write_layer + 1)
+                    GetLayerWithOffset(prior_access_layer + 1)
                 );
             }
 
@@ -976,19 +978,21 @@ public:
                     GetHandle(uint64(handle.GetBuffer()), ResourceType::Texture_Buffer)
                 );
                 const Range range(handle.GetByteOffset(), handle.GetByteSize());
-                const int64 prior_write_layer =
-                    range_handle->GetMaxWriteLayer(range);
+                const int64 prior_access_layer = std::max(
+                    range_handle->GetMaxReadLayer(range),
+                    range_handle->GetMaxWriteLayer(range)
+                );
                 assert(
-                    prior_write_layer < 0 &&
+                    prior_access_layer < 0 &&
                     std::format(
-                        "Import Buffer {} should precede its first resource write",
+                        "Import Buffer {} should precede its first resource access",
                         handle.GetBuffer()->GetName()
                     )
                         .c_str()
                 );
                 layer = std::max(
                     layer,
-                    GetLayerWithOffset(prior_write_layer + 1)
+                    GetLayerWithOffset(prior_access_layer + 1)
                 );
             }
 

--- a/source/runtime/render/rhi/vulkan/RHICmdReorderer.h
+++ b/source/runtime/render/rhi/vulkan/RHICmdReorderer.h
@@ -229,14 +229,53 @@ public:
             ArenaAllocatorWrapper<std::pair<const Range, ResourceView>>>;
 
     private:
+        struct ExactAccess {
+            Range        range;
+            int64        layer{-1};
+            ExactAccess* next{nullptr};
+        };
+
+        ArenaAllocator&       exact_access_allocator;
+        ExactAccess*          exact_access_history{nullptr};
+        uint                  exact_access_count{0};
+        bool                  exact_access_complete{true};
         ResourceView          max_view{-1, -1};
         Range                 read_range;
         Range                 write_range;
         Map                   range2view;
         static constexpr uint max_range_size = 16;
+        static constexpr uint max_exact_access_size = 64;
+
+        void RecordExactAccess(const Range& _range, int64 _layer) {
+            for (ExactAccess* access = exact_access_history;
+                 access != nullptr;
+                 access = access->next) {
+                if (access->range == _range) {
+                    access->layer = std::max(access->layer, _layer);
+                    return;
+                }
+            }
+            if (!exact_access_complete) {
+                return;
+            }
+            if (exact_access_count >= max_exact_access_size) {
+                exact_access_complete = false;
+                return;
+            }
+            ExactAccess* access = exact_access_allocator.Malloc<ExactAccess>();
+            new (access) ExactAccess{_range, _layer, exact_access_history};
+            exact_access_history = access;
+            ++exact_access_count;
+        }
 
     public:
+        struct ExactAccessQuery {
+            int64 layer{-1};
+            bool  complete{true};
+        };
+
         RangeHandle(const ArenaAllocatorWrapper<ResourceView>& _alloc) :
+            exact_access_allocator(_alloc.allocator()),
             read_range(
                 std::numeric_limits<int64>::max(),
                 std::numeric_limits<int64>::min(),
@@ -251,13 +290,29 @@ public:
             ),
             range2view(max_range_size, _alloc) {}
 
-        int64 GetMaxReadLayer(const Range& _range) {
+        ExactAccessQuery GetMaxExactAccess(const Range& _range) const {
+            int64 layer = -1;
+            for (const ExactAccess* access = exact_access_history;
+                 access != nullptr;
+                 access = access->next) {
+                if (access->range.Colide(_range)) {
+                    layer = std::max(layer, access->layer);
+                }
+            }
+            return ExactAccessQuery{layer, exact_access_complete};
+        }
+
+        uint GetExactAccessCount() const {
+            return exact_access_count;
+        }
+
+        int64 GetMaxReadLayer(const Range& _range) const {
 
             int64 max_layer = -1;
             if (!_range.Colide(read_range)) {
                 return max_layer;
             }
-            for (auto& [range, view] : range2view) {
+            for (const auto& [range, view] : range2view) {
                 if (range.Colide(_range)) {
                     max_layer = std::max(max_layer, view.read_layer);
                     if (max_layer >= max_view.read_layer) {
@@ -268,12 +323,12 @@ public:
             return max_layer;
         }
 
-        int64 GetMaxWriteLayer(const Range& _range) {
+        int64 GetMaxWriteLayer(const Range& _range) const {
             int64 max_layer = -1;
             if (!_range.Colide(write_range)) {
                 return max_layer;
             }
-            for (auto& [range, view] : range2view) {
+            for (const auto& [range, view] : range2view) {
                 if (range.Colide(_range)) {
                     max_layer = std::max(max_layer, view.write_layer);
                     if (max_layer >= max_view.write_layer) {
@@ -292,7 +347,10 @@ public:
             value.write_layer = max_view.write_layer;
         }
 
-        void EmplaceReadLayer(const Range& _range, int64 _layer) {
+        void EmplaceReadLayer(const Range& _range, int64 _layer, bool _record_exact = true) {
+            if (_record_exact) {
+                RecordExactAccess(_range, _layer);
+            }
 
             read_range.primary_min = std::min(read_range.primary_min, _range.primary_min);
             read_range.primary_max = std::max(read_range.primary_max, _range.primary_max);
@@ -314,6 +372,8 @@ public:
         }
 
         void EmplaceWriteLayer(const Range& _range, int64 _layer) {
+            RecordExactAccess(_range, _layer);
+
             read_range.primary_min  = std::min(read_range.primary_min, _range.primary_min);
             read_range.primary_max  = std::max(read_range.primary_max, _range.primary_max);
             read_range.layer_min    = std::min(read_range.layer_min, _range.layer_min);
@@ -347,6 +407,16 @@ public:
     struct BindlessHandle : public ResourceHandle {
         ResourceView view{-1, -1};
     };
+    struct PriorResourceAccess {
+        int64 direct_exact_layer{-1};
+        int64 conservative_layer{-1};
+        bool  direct_exact_complete{true};
+    };
+    struct ArgReadResource {
+        Range           range;
+        ResourceHandle* handle{nullptr};
+        bool            record_exact{true};
+    };
     struct CommandListNode {
         Command const*         cmd;
         CommandListNode const* next;
@@ -365,7 +435,7 @@ public:
     UnorderedSet<uint64> m_writed_geometry;
 
     //temporal resources
-    Array<std::tuple<Range, ResourceHandle*>> m_arg_read_resources;
+    Array<ArgReadResource>                    m_arg_read_resources;
     Array<std::tuple<Range, ResourceHandle*>> m_arg_write_resources;
     UnorderedSet<uint64>                      temp_writed_resources;
 
@@ -418,8 +488,8 @@ public:
         return std::max(_layer, (int64)layer_offset);
     }
 
-    int64 GetLastLayerWrite(RangeHandle* _handle, const Range& _range) {
-        int64 layer = _handle->GetMaxReadLayer(_range);
+    int64 GetMaxBindlessAliasAccessLayer(RangeHandle* _handle, int64 _layer) {
+        int64 layer = _layer;
         if (m_max_bdls_layer >= layer) {
             //check contains certain resource
             for (auto&& i : m_bindless_handles) {
@@ -430,6 +500,40 @@ public:
                 m_funcs.unlock_bdls_array(i.first);
             }
         }
+        return layer;
+    }
+
+    PriorResourceAccess GetPriorResourceAccess(
+        RangeHandle* _handle,
+        const Range& _range
+    ) const {
+        const RangeHandle::ExactAccessQuery exact_access =
+            _handle->GetMaxExactAccess(_range);
+        int64 conservative_layer = exact_access.layer;
+        if (!exact_access.complete) {
+            conservative_layer = std::max(
+                conservative_layer,
+                std::max(
+                    _handle->GetMaxReadLayer(_range),
+                    _handle->GetMaxWriteLayer(_range)
+                )
+            );
+        }
+        // Bindless membership is mutable and the function table exposes only
+        // its current value, not a historical snapshot. It therefore cannot
+        // prove that a particular resource was accessed by an earlier
+        // bindless dispatch. Conservatively wait for the latest opaque
+        // bindless access while keeping Debug validation exact.
+        return PriorResourceAccess{
+            exact_access.layer,
+            std::max(conservative_layer, m_max_bdls_layer),
+            exact_access.complete
+        };
+    }
+
+    int64 GetLastLayerWrite(RangeHandle* _handle, const Range& _range) {
+        const int64 layer =
+            GetMaxBindlessAliasAccessLayer(_handle, _handle->GetMaxReadLayer(_range));
         return GetLayerWithOffset(layer + 1);
     }
 
@@ -503,7 +607,12 @@ public:
         return SetRead(handle, _range);
     }
 
-    void RecordRead(ResourceHandle* _handle, Range _range, int64 _layer) {
+    void RecordRead(
+        ResourceHandle* _handle,
+        Range           _range,
+        int64           _layer,
+        bool            _record_exact = true
+    ) {
         switch (_handle->type) {
 
             case ResourceType::Mesh:
@@ -520,8 +629,19 @@ public:
             default: {
 
                 auto* range_handle = static_cast<RangeHandle*>(_handle);
-                range_handle->EmplaceReadLayer(_range, _layer);
+                range_handle->EmplaceReadLayer(_range, _layer, _record_exact);
             }
+        }
+    }
+
+    void RecordArgReads(int64 _layer) {
+        for (const ArgReadResource& read_resource : m_arg_read_resources) {
+            RecordRead(
+                read_resource.handle,
+                read_resource.range,
+                _layer,
+                read_resource.record_exact
+            );
         }
     }
 
@@ -648,7 +768,13 @@ public:
         return layer;
     }
 
-    void EmplaceArg(uint64 _handle, ResourceType _type, const Range& _range, bool _b_write) {
+    void EmplaceArg(
+        uint64       _handle,
+        ResourceType _type,
+        const Range& _range,
+        bool         _b_write,
+        bool         _record_exact = true
+    ) {
         ResourceHandle* handle = GetHandle(_handle, _type);
         if (_b_write) {
             switch (_type) {
@@ -690,7 +816,9 @@ public:
                     );
                 }
             }
-            m_arg_read_resources.emplace_back(_range, handle);
+            m_arg_read_resources.emplace_back(
+                ArgReadResource{_range, handle, _record_exact}
+            );
         }
     }
 
@@ -745,17 +873,33 @@ public:
         );
     }
 
-    void VisitBindlessArg(BindlessArrayRef _bdls, const UnorderedSet<uint64>& _temp_write_resources) {
-        m_funcs.lock_bdls_array((uint64)(_bdls.Get()));
+    void VisitBindlessArg(uint64 _bindless_handle, const UnorderedSet<uint64>& _temp_write_resources) {
+        m_funcs.lock_bdls_array(_bindless_handle);
         for (auto&& res : m_write_resources) {
             if (!_temp_write_resources.contains(res) &&
-                m_funcs.is_resource_in_bindless(res, (uint64)(_bdls.Get()))) {
-                EmplaceArg(res, ResourceType::Texture_Buffer, Range{}, false);
+                m_funcs.is_resource_in_bindless(res, _bindless_handle)) {
+                EmplaceArg(
+                    res,
+                    ResourceType::Texture_Buffer,
+                    Range{},
+                    false,
+                    false
+                );
             }
         }
-        m_funcs.unlock_bdls_array((uint64)(_bdls.Get()));
+        m_funcs.unlock_bdls_array(_bindless_handle);
         //emplace self
-        EmplaceArg((uint64)(_bdls.Get()), ResourceType::Bindless, Range{}, false);
+        EmplaceArg(
+            _bindless_handle,
+            ResourceType::Bindless,
+            Range{},
+            false,
+            false
+        );
+    }
+
+    void VisitBindlessArg(BindlessArrayRef _bdls, const UnorderedSet<uint64>& _temp_write_resources) {
+        VisitBindlessArg(uint64(_bdls.Get()), _temp_write_resources);
     }
 
     void VisitCmd(const UploadBufferCmd* _cmd) {
@@ -955,12 +1099,10 @@ public:
                 const Range range(
                     handle.mip_level, handle.num_mips, handle.array_layer, handle.num_array
                 );
-                const int64 prior_access_layer = std::max(
-                    range_handle->GetMaxReadLayer(range),
-                    range_handle->GetMaxWriteLayer(range)
-                );
+                const PriorResourceAccess prior_access =
+                    GetPriorResourceAccess(range_handle, range);
                 assert(
-                    prior_access_layer < 0 &&
+                    prior_access.direct_exact_layer < 0 &&
                     std::format(
                         "Import Texture {} should precede its first resource access",
                         handle.GetTexture()->GetName()
@@ -969,7 +1111,7 @@ public:
                 );
                 layer = std::max(
                     layer,
-                    GetLayerWithOffset(prior_access_layer + 1)
+                    GetLayerWithOffset(prior_access.conservative_layer + 1)
                 );
             }
 
@@ -978,12 +1120,10 @@ public:
                     GetHandle(uint64(handle.GetBuffer()), ResourceType::Texture_Buffer)
                 );
                 const Range range(handle.GetByteOffset(), handle.GetByteSize());
-                const int64 prior_access_layer = std::max(
-                    range_handle->GetMaxReadLayer(range),
-                    range_handle->GetMaxWriteLayer(range)
-                );
+                const PriorResourceAccess prior_access =
+                    GetPriorResourceAccess(range_handle, range);
                 assert(
-                    prior_access_layer < 0 &&
+                    prior_access.direct_exact_layer < 0 &&
                     std::format(
                         "Import Buffer {} should precede its first resource access",
                         handle.GetBuffer()->GetName()
@@ -992,7 +1132,7 @@ public:
                 );
                 layer = std::max(
                     layer,
-                    GetLayerWithOffset(prior_access_layer + 1)
+                    GetLayerWithOffset(prior_access.conservative_layer + 1)
                 );
             }
 
@@ -1003,6 +1143,7 @@ public:
                 range_handle->EmplaceWriteLayer(
                     Range(handle.mip_level, handle.num_mips, handle.array_layer, handle.num_array), layer
                 );
+                m_write_resources.emplace(range_handle->handle);
             }
 
             for (const auto& [handle, state] : _cmd->ImportBuffers()) {
@@ -1010,6 +1151,7 @@ public:
                     GetHandle(uint64(handle.GetBuffer()), ResourceType::Texture_Buffer)
                 );
                 range_handle->EmplaceWriteLayer(Range(handle.GetByteOffset(), handle.GetByteSize()), layer);
+                m_write_resources.emplace(range_handle->handle);
             }
         } else {
             barrier_resources.reserve(_cmd->ExportTextures().size());
@@ -1046,6 +1188,7 @@ public:
                 range_handle->EmplaceWriteLayer(
                     Range(handle.mip_level, handle.num_mips, handle.array_layer, handle.num_array), layer
                 );
+                m_write_resources.emplace(range_handle->handle);
             }
 
             for (const auto& [handle, state] : _cmd->ExportBuffers()) {
@@ -1053,6 +1196,7 @@ public:
                     GetHandle(uint64(handle.GetBuffer()), ResourceType::Texture_Buffer)
                 );
                 range_handle->EmplaceWriteLayer(Range(handle.GetByteOffset(), handle.GetByteSize()), layer);
+                m_write_resources.emplace(range_handle->handle);
             }
         }
 
@@ -1165,9 +1309,7 @@ public:
             RecordWrite(std::get<1>(write_res), std::get<0>(write_res), m_dispatch_layer);
         }
 
-        for (const auto& read_res : m_arg_read_resources) {
-            RecordRead(std::get<1>(read_res), std::get<0>(read_res), m_dispatch_layer);
-        }
+        RecordArgReads(m_dispatch_layer);
 
         if (b_use_bdls) {
             m_max_bdls_layer = std::max(m_max_bdls_layer, m_dispatch_layer);
@@ -1282,9 +1424,7 @@ public:
         for (const auto& write_res : m_arg_write_resources) {
             RecordWrite(std::get<1>(write_res), std::get<0>(write_res), m_dispatch_layer);
         }
-        for (const auto& read_res : m_arg_read_resources) {
-            RecordRead(std::get<1>(read_res), std::get<0>(read_res), m_dispatch_layer);
-        }
+        RecordArgReads(m_dispatch_layer);
         if (b_use_bdls) {
             m_max_bdls_layer = std::max(m_max_bdls_layer, m_dispatch_layer);
         }
@@ -1406,9 +1546,7 @@ public:
         for (const auto& write_res : m_arg_write_resources) {
             RecordWrite(std::get<1>(write_res), std::get<0>(write_res), m_dispatch_layer);
         }
-        for (const auto& read_res : m_arg_read_resources) {
-            RecordRead(std::get<1>(read_res), std::get<0>(read_res), m_dispatch_layer);
-        }
+        RecordArgReads(m_dispatch_layer);
         if (b_use_bdls) {
             m_max_bdls_layer = std::max(m_max_bdls_layer, m_dispatch_layer);
         }
@@ -1561,9 +1699,7 @@ public:
         for (const auto& write_res : m_arg_write_resources) {
             RecordWrite(std::get<1>(write_res), std::get<0>(write_res), m_dispatch_layer);
         }
-        for (const auto& read_res : m_arg_read_resources) {
-            RecordRead(std::get<1>(read_res), std::get<0>(read_res), m_dispatch_layer);
-        }
+        RecordArgReads(m_dispatch_layer);
         if (!bindless_arrays.empty()) {
             m_max_bdls_layer =
                 std::max(m_max_bdls_layer, m_dispatch_layer);

--- a/source/runtime/render/rhi/vulkan/RHICmdReorderer.h
+++ b/source/runtime/render/rhi/vulkan/RHICmdReorderer.h
@@ -952,19 +952,22 @@ public:
                 RangeHandle* range_handle = static_cast<RangeHandle*>(
                     GetHandle(uint64(handle.GetTexture()), ResourceType::Texture_Buffer)
                 );
-                layer = std::max(
-                    layer,
-                    GetLastLayerRead(
-                        range_handle,
-                        Range(handle.mip_level, handle.num_mips, handle.array_layer, handle.num_array)
-                    )
+                const Range range(
+                    handle.mip_level, handle.num_mips, handle.array_layer, handle.num_array
                 );
+                const int64 prior_write_layer =
+                    range_handle->GetMaxWriteLayer(range);
                 assert(
-                    layer == 0 &&
+                    prior_write_layer < 0 &&
                     std::format(
-                        "Import Texture {} should be the first command", handle.GetTexture()->GetName()
+                        "Import Texture {} should precede its first resource write",
+                        handle.GetTexture()->GetName()
                     )
                         .c_str()
+                );
+                layer = std::max(
+                    layer,
+                    GetLayerWithOffset(prior_write_layer + 1)
                 );
             }
 
@@ -972,14 +975,20 @@ public:
                 RangeHandle* range_handle = static_cast<RangeHandle*>(
                     GetHandle(uint64(handle.GetBuffer()), ResourceType::Texture_Buffer)
                 );
+                const Range range(handle.GetByteOffset(), handle.GetByteSize());
+                const int64 prior_write_layer =
+                    range_handle->GetMaxWriteLayer(range);
+                assert(
+                    prior_write_layer < 0 &&
+                    std::format(
+                        "Import Buffer {} should precede its first resource write",
+                        handle.GetBuffer()->GetName()
+                    )
+                        .c_str()
+                );
                 layer = std::max(
                     layer,
-                    GetLastLayerRead(range_handle, Range(handle.GetByteOffset(), handle.GetByteSize()))
-                );
-                assert(
-                    layer == 0 &&
-                    std::format("Import Buffer {} should be the first command", handle.GetBuffer()->GetName())
-                        .c_str()
+                    GetLayerWithOffset(prior_write_layer + 1)
                 );
             }
 

--- a/source/test/CMakeLists.txt
+++ b/source/test/CMakeLists.txt
@@ -159,6 +159,12 @@ set_tests_properties(RHIGpuScopeContract PROPERTIES TIMEOUT 60)
 
 set(test_target TestRenderProfileCapture)
 add_executable(${test_target} "RenderProfileCaptureTest.cpp")
+target_compile_definitions(moer_render
+    PRIVATE MOER_RENDER_PROFILE_CAPTURE_TEST_HOOKS=1
+)
+target_compile_definitions(${test_target}
+    PRIVATE MOER_RENDER_PROFILE_CAPTURE_TEST_HOOKS=1
+)
 target_include_directories(${test_target}
     PRIVATE "${moer_source_dir}/runtime/core/source/profile"
 )

--- a/source/test/RHICmdReordererTest.cpp
+++ b/source/test/RHICmdReordererTest.cpp
@@ -27,7 +27,8 @@ public:
 
 class TestTexture final : public Texture {
 public:
-    TestTexture() : Texture(MakeInfo()) {}
+    explicit TestTexture(uint16_t _array_size = 1, uint8_t _num_mips = 1) :
+        Texture(MakeInfo(_array_size, _num_mips)) {}
 
     uint GetMipByteSize(uint) const override {
         return 4;
@@ -36,14 +37,14 @@ public:
     void SetName(const std::string_view) override {}
 
 private:
-    static TextureInfo MakeInfo() {
+    static TextureInfo MakeInfo(uint16_t _array_size, uint8_t _num_mips) {
         TextureInfo info{};
         info.usage =
             ETextureUsageFlags::SAMPLED |
             ETextureUsageFlags::TRANSFER_DST;
         info.extent       = {4, 4};
-        info.num_mips     = 1;
-        info.array_size   = 1;
+        info.num_mips     = _num_mips;
+        info.array_size   = _array_size;
         info.aspect_flags = ETextureAspectFlags::COLOR;
         return info;
     }
@@ -68,6 +69,38 @@ bool FalseBindlessMembership(uint64, uint64) {
     return false;
 }
 
+uint64 aliased_texture_resource = 0;
+uint64 aliased_buffer_resource  = 0;
+uint64 aliasing_bindless_handle = 0;
+
+bool SelectedBindlessMembership(uint64 _resource, uint64 _bindless_handle) {
+    return _bindless_handle == aliasing_bindless_handle &&
+           (_resource == aliased_texture_resource ||
+            _resource == aliased_buffer_resource);
+}
+
+class ScopedBindlessMembership final {
+public:
+    ScopedBindlessMembership(
+        uint64 _texture_resource,
+        uint64 _buffer_resource,
+        uint64 _bindless_handle
+    ) {
+        aliased_texture_resource = _texture_resource;
+        aliased_buffer_resource  = _buffer_resource;
+        aliasing_bindless_handle = _bindless_handle;
+    }
+
+    ~ScopedBindlessMembership() {
+        aliased_texture_resource = 0;
+        aliased_buffer_resource  = 0;
+        aliasing_bindless_handle = 0;
+    }
+
+    ScopedBindlessMembership(const ScopedBindlessMembership&) = delete;
+    ScopedBindlessMembership& operator=(const ScopedBindlessMembership&) = delete;
+};
+
 void NoopBindlessLock(uint64) {}
 
 FunctionTable MakeFunctionTable() {
@@ -79,6 +112,12 @@ FunctionTable MakeFunctionTable() {
         .lock_bdls_array         = &NoopBindlessLock,
         .unlock_bdls_array       = &NoopBindlessLock,
     };
+}
+
+FunctionTable MakeAliasingFunctionTable() {
+    FunctionTable functions           = MakeFunctionTable();
+    functions.is_resource_in_bindless = &SelectedBindlessMembership;
+    return functions;
 }
 
 template<typename FirstAccess, typename SecondAccess>
@@ -412,6 +451,20 @@ void ResourceImportsDetectPriorTextureAndBufferReads() {
             buffer_handle->GetMaxWriteLayer(buffer_range) < 0,
         "buffer prior read was not distinguishable from a fresh import range"
     );
+    const CmdReorderer::PriorResourceAccess texture_prior =
+        reorderer.GetPriorResourceAccess(texture_handle, texture_range);
+    const CmdReorderer::PriorResourceAccess buffer_prior =
+        reorderer.GetPriorResourceAccess(buffer_handle, buffer_range);
+    Expect(
+        texture_prior.direct_exact_layer == 2 &&
+            texture_prior.conservative_layer == 2,
+        "texture prior read was missing from the exact import history"
+    );
+    Expect(
+        buffer_prior.direct_exact_layer == 2 &&
+            buffer_prior.conservative_layer == 2,
+        "buffer prior read was missing from the exact import history"
+    );
 
 #if defined(NDEBUG)
     // Debug deliberately rejects this invalid ownership order with an
@@ -443,6 +496,618 @@ void ResourceImportsDetectPriorTextureAndBufferReads() {
 
     QueryBackendAccess::ResolveErrorIfPending(
         timestamp, "reorderer prior-read test cleanup"
+    );
+}
+
+void ResourceImportsDetectPriorTextureAndBufferWrites() {
+    TCachedArgArray cached_args;
+    CmdReorderer   reorderer(MakeFunctionTable(), cached_args);
+
+    TestTexture texture;
+    TestBuffer  buffer(
+        16,
+        4,
+        EBufferUsageFlags::UNORDERED_ACCESS |
+            EBufferUsageFlags::TRANSFER_DST
+    );
+    auto* texture_handle = static_cast<CmdReorderer::RangeHandle*>(
+        reorderer.GetHandle(
+            uint64(&texture),
+            CmdReorderer::ResourceType::Texture_Buffer
+        )
+    );
+    auto* buffer_handle = static_cast<CmdReorderer::RangeHandle*>(
+        reorderer.GetHandle(
+            uint64(&buffer),
+            CmdReorderer::ResourceType::Texture_Buffer
+        )
+    );
+    const CmdReorderer::Range texture_range(0, 1, 0, 1);
+    const CmdReorderer::Range buffer_range(0, buffer.GetByteSize());
+
+    Expect(
+        reorderer.SetWrite(texture_handle, texture_range) == 0,
+        "texture prior write did not enter the first resource layer"
+    );
+    Expect(
+        reorderer.SetWrite(buffer_handle, buffer_range) == 0,
+        "buffer prior write did not enter the first resource layer"
+    );
+    const CmdReorderer::PriorResourceAccess texture_prior =
+        reorderer.GetPriorResourceAccess(texture_handle, texture_range);
+    const CmdReorderer::PriorResourceAccess buffer_prior =
+        reorderer.GetPriorResourceAccess(buffer_handle, buffer_range);
+    Expect(
+        texture_prior.direct_exact_layer == 0 &&
+            texture_prior.conservative_layer == 0,
+        "texture prior write was missing from the exact import history"
+    );
+    Expect(
+        buffer_prior.direct_exact_layer == 0 &&
+            buffer_prior.conservative_layer == 0,
+        "buffer prior write was missing from the exact import history"
+    );
+
+#if defined(NDEBUG)
+    QueueTransferCmd import(
+        EQueueType::Copy,
+        Array<ImportTexture>{
+            ImportTexture(texture.GetView(), ETextureState::SAMPLE)
+        },
+        Array<ImportBuffer>{
+            ImportBuffer(buffer.GetView(), EBufferState::UNORDERED_ACCESS)
+        }
+    );
+    reorderer.AcceptCmd(&import);
+    Expect(
+        FindCommandLayer(reorderer, &import) == 1,
+        "release import fallback did not wait for prior writes"
+    );
+    Expect(
+        reorderer.SetRead(texture_handle, texture_range) == 2,
+        "texture use did not wait for the prior-write import fallback"
+    );
+    Expect(
+        reorderer.SetRead(buffer_handle, buffer_range) == 2,
+        "buffer use did not wait for the prior-write import fallback"
+    );
+#endif
+}
+
+void VerifyOpaqueBindlessImportWait(
+    bool   _current_membership,
+    uint64 _bindless_handle
+) {
+    TCachedArgArray cached_args;
+    TestTexture texture;
+    TestBuffer  buffer(
+        16,
+        4,
+        EBufferUsageFlags::UNORDERED_ACCESS |
+            EBufferUsageFlags::TRANSFER_DST
+    );
+    ScopedBindlessMembership membership(
+        _current_membership ? uint64(&texture) : 0,
+        _current_membership ? uint64(&buffer) : 0,
+        _current_membership ? _bindless_handle : 0
+    );
+    CmdReorderer reorderer(MakeAliasingFunctionTable(), cached_args);
+    ScopeCmd root_scope(
+        "Opaque Bindless Prior Access",
+        true,
+        false,
+        GpuMarkerPalette::Renderer(),
+        EQueueType::Graphics
+    );
+    reorderer.AcceptCmd(&root_scope);
+
+    auto* texture_handle = static_cast<CmdReorderer::RangeHandle*>(
+        reorderer.GetHandle(
+            uint64(&texture),
+            CmdReorderer::ResourceType::Texture_Buffer
+        )
+    );
+    auto* buffer_handle = static_cast<CmdReorderer::RangeHandle*>(
+        reorderer.GetHandle(
+            uint64(&buffer),
+            CmdReorderer::ResourceType::Texture_Buffer
+        )
+    );
+    const CmdReorderer::Range texture_range(0, 1, 0, 1);
+    const CmdReorderer::Range buffer_range(0, buffer.GetByteSize());
+
+    UnorderedSet<uint64> no_current_writes;
+    reorderer.VisitBindlessArg(_bindless_handle, no_current_writes);
+    const int64 bindless_layer = reorderer.m_dispatch_layer;
+    reorderer.RecordArgReads(bindless_layer);
+    reorderer.m_max_bdls_layer =
+        std::max(reorderer.m_max_bdls_layer, bindless_layer);
+    Expect(
+        bindless_layer == 1,
+        "bindless access did not follow the profiling prefix"
+    );
+    Expect(
+        texture_handle->GetMaxExactAccess(texture_range).layer < 0 &&
+            buffer_handle->GetMaxExactAccess(buffer_range).layer < 0 &&
+            texture_handle->GetExactAccessCount() == 0 &&
+            buffer_handle->GetExactAccessCount() == 0,
+        "bindless alias test unexpectedly created a direct resource access"
+    );
+    const CmdReorderer::PriorResourceAccess texture_prior =
+        reorderer.GetPriorResourceAccess(texture_handle, texture_range);
+    const CmdReorderer::PriorResourceAccess buffer_prior =
+        reorderer.GetPriorResourceAccess(buffer_handle, buffer_range);
+    Expect(
+        texture_prior.direct_exact_layer < 0 &&
+            texture_prior.conservative_layer == bindless_layer,
+        "texture import did not conservatively wait for opaque bindless access"
+    );
+    Expect(
+        buffer_prior.direct_exact_layer < 0 &&
+            buffer_prior.conservative_layer == bindless_layer,
+        "buffer import did not conservatively wait for opaque bindless access"
+    );
+
+    QueueTransferCmd import(
+        EQueueType::Copy,
+        Array<ImportTexture>{
+            ImportTexture(texture.GetView(), ETextureState::SAMPLE)
+        },
+        Array<ImportBuffer>{
+            ImportBuffer(buffer.GetView(), EBufferState::UNORDERED_ACCESS)
+        }
+    );
+    reorderer.AcceptCmd(&import);
+    Expect(
+        FindCommandLayer(reorderer, &import) == bindless_layer + 1,
+        "import moved before an opaque bindless access"
+    );
+    Expect(
+        reorderer.SetRead(texture_handle, texture_range) ==
+            bindless_layer + 2,
+        "texture use did not wait for the bindless import fallback"
+    );
+    Expect(
+        reorderer.SetRead(buffer_handle, buffer_range) ==
+            bindless_layer + 2,
+        "buffer use did not wait for the conservative bindless import"
+    );
+
+}
+
+void ResourceImportsConservativelyWaitForOpaqueBindlessAccess() {
+    // Current membership cannot describe historical membership. Both values
+    // must therefore produce the same conservative ordering and neither may
+    // turn into a Debug assertion without a direct resource access.
+    VerifyOpaqueBindlessImportWait(true, 0xB1AD1E55);
+    VerifyOpaqueBindlessImportWait(false, 0xB1AD1E56);
+}
+
+void QueueTransferWritesFeedBindlessAliasOrderingWithoutExactPollution() {
+    TCachedArgArray cached_args;
+    TestTexture texture;
+    TestBuffer  buffer(
+        16,
+        4,
+        EBufferUsageFlags::UNORDERED_ACCESS |
+            EBufferUsageFlags::TRANSFER_DST
+    );
+    constexpr uint64 bindless_handle = 0xB1AD1E57;
+    ScopedBindlessMembership membership(
+        uint64(&texture),
+        uint64(&buffer),
+        bindless_handle
+    );
+    CmdReorderer reorderer(MakeAliasingFunctionTable(), cached_args);
+
+    QueueTransferCmd import(
+        EQueueType::Copy,
+        Array<ImportTexture>{
+            ImportTexture(texture.GetView(), ETextureState::SAMPLE)
+        },
+        Array<ImportBuffer>{
+            ImportBuffer(buffer.GetView(), EBufferState::UNORDERED_ACCESS)
+        }
+    );
+    reorderer.AcceptCmd(&import);
+    Expect(
+        reorderer.m_write_resources.contains(uint64(&texture)) &&
+            reorderer.m_write_resources.contains(uint64(&buffer)),
+        "QueueTransfer import did not publish texture and buffer writes for bindless tracking"
+    );
+
+    auto* texture_handle = static_cast<CmdReorderer::RangeHandle*>(
+        reorderer.GetHandle(
+            uint64(&texture),
+            CmdReorderer::ResourceType::Texture_Buffer
+        )
+    );
+    auto* buffer_handle = static_cast<CmdReorderer::RangeHandle*>(
+        reorderer.GetHandle(
+            uint64(&buffer),
+            CmdReorderer::ResourceType::Texture_Buffer
+        )
+    );
+    const CmdReorderer::Range texture_range(0, 1, 0, 1);
+    const CmdReorderer::Range buffer_range(0, buffer.GetByteSize());
+    Expect(
+        texture_handle->GetExactAccessCount() == 1 &&
+            buffer_handle->GetExactAccessCount() == 1,
+        "QueueTransfer import did not create its exact write provenance"
+    );
+
+    reorderer.m_dispatch_layer = -1;
+    reorderer.m_arg_read_resources.clear();
+    reorderer.m_arg_write_resources.clear();
+    reorderer.temp_writed_resources.clear();
+    reorderer.VisitBindlessArg(
+        bindless_handle,
+        reorderer.temp_writed_resources
+    );
+    Expect(
+        reorderer.m_dispatch_layer == 1,
+        "bindless alias read did not wait for QueueTransfer import"
+    );
+    reorderer.RecordArgReads(reorderer.m_dispatch_layer);
+    reorderer.m_max_bdls_layer = std::max(
+        reorderer.m_max_bdls_layer,
+        reorderer.m_dispatch_layer
+    );
+
+    Expect(
+        texture_handle->GetMaxReadLayer(texture_range) == 1 &&
+            buffer_handle->GetMaxReadLayer(buffer_range) == 1,
+        "bindless membership read did not reach the conservative resource map"
+    );
+    Expect(
+        texture_handle->GetMaxExactAccess(texture_range).layer == 0 &&
+            buffer_handle->GetMaxExactAccess(buffer_range).layer == 0 &&
+            texture_handle->GetExactAccessCount() == 1 &&
+            buffer_handle->GetExactAccessCount() == 1,
+        "frontend bindless membership polluted exact import provenance"
+    );
+}
+
+void ExactImportHistoryIsBoundedAndMergesDuplicateRanges() {
+    TCachedArgArray cached_args;
+    CmdReorderer   reorderer(MakeFunctionTable(), cached_args);
+
+    TestBuffer buffer(
+        300,
+        4,
+        EBufferUsageFlags::UNORDERED_ACCESS |
+            EBufferUsageFlags::TRANSFER_DST
+    );
+    TestTexture texture(132);
+    auto* buffer_handle = static_cast<CmdReorderer::RangeHandle*>(
+        reorderer.GetHandle(
+            uint64(&buffer),
+            CmdReorderer::ResourceType::Texture_Buffer
+        )
+    );
+    auto* texture_handle = static_cast<CmdReorderer::RangeHandle*>(
+        reorderer.GetHandle(
+            uint64(&texture),
+            CmdReorderer::ResourceType::Texture_Buffer
+        )
+    );
+    const CmdReorderer::Range repeated_buffer_range(0, 4);
+    const CmdReorderer::Range repeated_texture_range(0, 1, 0, 1);
+    for (uint repeat = 0; repeat < 128; ++repeat) {
+        reorderer.RecordRead(buffer_handle, repeated_buffer_range, 0);
+        reorderer.RecordRead(texture_handle, repeated_texture_range, 0);
+    }
+    Expect(
+        buffer_handle->GetExactAccessCount() == 1 &&
+            texture_handle->GetExactAccessCount() == 1,
+        "repeated exact ranges allocated duplicate history entries"
+    );
+
+    for (int64 index = 1; index < 64; ++index) {
+        reorderer.RecordRead(
+            buffer_handle,
+            CmdReorderer::Range(index * 8, 4),
+            0
+        );
+        reorderer.RecordRead(
+            texture_handle,
+            CmdReorderer::Range(0, 1, index * 2, 1),
+            0
+        );
+    }
+    Expect(
+        buffer_handle->GetExactAccessCount() == 64 &&
+            texture_handle->GetExactAccessCount() == 64 &&
+            buffer_handle->GetMaxExactAccess(repeated_buffer_range).complete &&
+            texture_handle->GetMaxExactAccess(repeated_texture_range).complete,
+        "exact history became incomplete before reaching 64 unique ranges"
+    );
+
+    const CmdReorderer::Range overflow_buffer_range(64 * 8, 4);
+    const CmdReorderer::Range overflow_texture_range(0, 1, 64 * 2, 1);
+    reorderer.RecordRead(buffer_handle, overflow_buffer_range, 0);
+    reorderer.RecordRead(texture_handle, overflow_texture_range, 0);
+    reorderer.RecordRead(
+        buffer_handle,
+        CmdReorderer::Range(65 * 8, 4),
+        0
+    );
+    reorderer.RecordRead(
+        texture_handle,
+        CmdReorderer::Range(0, 1, 65 * 2, 1),
+        0
+    );
+    reorderer.RecordRead(buffer_handle, repeated_buffer_range, 7);
+    reorderer.RecordRead(texture_handle, repeated_texture_range, 7);
+
+    const CmdReorderer::RangeHandle::ExactAccessQuery buffer_overflow =
+        buffer_handle->GetMaxExactAccess(overflow_buffer_range);
+    const CmdReorderer::RangeHandle::ExactAccessQuery texture_overflow =
+        texture_handle->GetMaxExactAccess(overflow_texture_range);
+    Expect(
+        buffer_handle->GetExactAccessCount() == 64 &&
+            texture_handle->GetExactAccessCount() == 64 &&
+            buffer_overflow.layer < 0 && !buffer_overflow.complete &&
+            texture_overflow.layer < 0 && !texture_overflow.complete,
+        "overflowing exact history allocated beyond its 64-range bound"
+    );
+    Expect(
+        buffer_handle->GetMaxExactAccess(repeated_buffer_range).layer == 7 &&
+            texture_handle->GetMaxExactAccess(repeated_texture_range).layer == 7,
+        "incomplete exact history stopped merging a previously known range"
+    );
+
+    const CmdReorderer::PriorResourceAccess buffer_prior =
+        reorderer.GetPriorResourceAccess(buffer_handle, overflow_buffer_range);
+    const CmdReorderer::PriorResourceAccess texture_prior =
+        reorderer.GetPriorResourceAccess(texture_handle, overflow_texture_range);
+    Expect(
+        buffer_prior.direct_exact_layer < 0 &&
+            !buffer_prior.direct_exact_complete &&
+            buffer_prior.conservative_layer == 0,
+        "incomplete buffer history did not fall back to conservative ordering"
+    );
+    Expect(
+        texture_prior.direct_exact_layer < 0 &&
+            !texture_prior.direct_exact_complete &&
+            texture_prior.conservative_layer == 0,
+        "incomplete texture history did not fall back to conservative ordering"
+    );
+
+    QueueTransferCmd import(
+        EQueueType::Copy,
+        Array<ImportTexture>{
+            ImportTexture(
+                texture.GetView().Slice(128, 1),
+                ETextureState::SAMPLE
+            )
+        },
+        Array<ImportBuffer>{
+            ImportBuffer(
+                BufferView(&buffer, 64 * 8, 1, 4),
+                EBufferState::UNORDERED_ACCESS
+            )
+        }
+    );
+    reorderer.AcceptCmd(&import);
+    Expect(
+        FindCommandLayer(reorderer, &import) == 1,
+        "unknown overflow import ignored the bounded-history fallback"
+    );
+    Expect(
+        buffer_handle->GetExactAccessCount() == 64 &&
+            texture_handle->GetExactAccessCount() == 64,
+        "overflow import allocated new exact-history entries"
+    );
+}
+
+void ResourceImportExactHistorySurvivesReadWriteAndTwoDimensionalCompression() {
+    TCachedArgArray cached_args;
+    CmdReorderer   reorderer(MakeFunctionTable(), cached_args);
+
+    TestBuffer read_buffer(
+        64,
+        4,
+        EBufferUsageFlags::UNORDERED_ACCESS |
+            EBufferUsageFlags::TRANSFER_DST
+    );
+    TestBuffer write_buffer(
+        64,
+        4,
+        EBufferUsageFlags::UNORDERED_ACCESS |
+            EBufferUsageFlags::TRANSFER_DST
+    );
+    TestTexture read_texture(34, 2);
+    TestTexture write_texture(34, 2);
+
+    auto* read_buffer_handle = static_cast<CmdReorderer::RangeHandle*>(
+        reorderer.GetHandle(
+            uint64(&read_buffer),
+            CmdReorderer::ResourceType::Texture_Buffer
+        )
+    );
+    auto* write_buffer_handle = static_cast<CmdReorderer::RangeHandle*>(
+        reorderer.GetHandle(
+            uint64(&write_buffer),
+            CmdReorderer::ResourceType::Texture_Buffer
+        )
+    );
+    auto* read_texture_handle = static_cast<CmdReorderer::RangeHandle*>(
+        reorderer.GetHandle(
+            uint64(&read_texture),
+            CmdReorderer::ResourceType::Texture_Buffer
+        )
+    );
+    auto* write_texture_handle = static_cast<CmdReorderer::RangeHandle*>(
+        reorderer.GetHandle(
+            uint64(&write_texture),
+            CmdReorderer::ResourceType::Texture_Buffer
+        )
+    );
+
+    constexpr int64 accessed_range_count = 17;
+    for (int64 index = 0; index < accessed_range_count; ++index) {
+        const CmdReorderer::Range buffer_range(index * 8, 4);
+        const CmdReorderer::Range texture_range(
+            index % 2,
+            1,
+            index * 2 + index % 2,
+            1
+        );
+        Expect(
+            reorderer.SetRead(read_buffer_handle, buffer_range) == 0 &&
+                reorderer.SetRead(read_texture_handle, texture_range) == 0,
+            "disjoint direct reads unexpectedly depended on each other"
+        );
+        Expect(
+            reorderer.SetWrite(write_buffer_handle, buffer_range) == 0 &&
+                reorderer.SetWrite(write_texture_handle, texture_range) == 0,
+            "disjoint direct writes unexpectedly depended on each other"
+        );
+    }
+
+    const CmdReorderer::Range touched_buffer_range(8, 4);
+    const CmdReorderer::Range touched_texture_range(1, 1, 3, 1);
+    const CmdReorderer::Range buffer_gap(4, 4);
+    const CmdReorderer::Range texture_cross_gap(0, 1, 3, 1);
+    Expect(
+        read_buffer_handle->GetMaxReadLayer(buffer_gap) == 0 &&
+            write_buffer_handle->GetMaxWriteLayer(buffer_gap) == 0 &&
+            read_texture_handle->GetMaxReadLayer(texture_cross_gap) == 0 &&
+            write_texture_handle->GetMaxWriteLayer(texture_cross_gap) == 0,
+        "test did not trigger conservative read/write range compression"
+    );
+
+    const auto expect_touched = [&](CmdReorderer::RangeHandle* _handle,
+                                    const CmdReorderer::Range& _range,
+                                    const char* _message) {
+        const auto exact = _handle->GetMaxExactAccess(_range);
+        Expect(
+            exact.layer == 0 && exact.complete &&
+                _handle->GetExactAccessCount() == accessed_range_count,
+            _message
+        );
+    };
+    expect_touched(
+        read_buffer_handle,
+        touched_buffer_range,
+        "compressed buffer read lost a touched exact range"
+    );
+    expect_touched(
+        write_buffer_handle,
+        touched_buffer_range,
+        "compressed buffer write lost a touched exact range"
+    );
+    expect_touched(
+        read_texture_handle,
+        touched_texture_range,
+        "compressed texture read lost a touched exact range"
+    );
+    expect_touched(
+        write_texture_handle,
+        touched_texture_range,
+        "compressed texture write lost a touched exact range"
+    );
+
+    const auto expect_gap = [&](CmdReorderer::RangeHandle* _handle,
+                                const CmdReorderer::Range& _range,
+                                const char* _message) {
+        const auto exact = _handle->GetMaxExactAccess(_range);
+        const auto prior = reorderer.GetPriorResourceAccess(_handle, _range);
+        Expect(
+            exact.layer < 0 && exact.complete &&
+                prior.direct_exact_layer < 0 &&
+                prior.direct_exact_complete &&
+                prior.conservative_layer < 0,
+            _message
+        );
+    };
+    expect_gap(
+        read_buffer_handle,
+        buffer_gap,
+        "exact history falsely marked a compressed buffer-read gap"
+    );
+    expect_gap(
+        write_buffer_handle,
+        buffer_gap,
+        "exact history falsely marked a compressed buffer-write gap"
+    );
+    expect_gap(
+        read_texture_handle,
+        texture_cross_gap,
+        "exact history falsely marked a texture-read mip-array cross-gap"
+    );
+    expect_gap(
+        write_texture_handle,
+        texture_cross_gap,
+        "exact history falsely marked a texture-write mip-array cross-gap"
+    );
+
+#if defined(NDEBUG)
+    QueueTransferCmd touched_import(
+        EQueueType::Copy,
+        Array<ImportTexture>{
+            ImportTexture(
+                read_texture.GetView(1, 1).Slice(3, 1),
+                ETextureState::SAMPLE
+            ),
+            ImportTexture(
+                write_texture.GetView(1, 1).Slice(3, 1),
+                ETextureState::SAMPLE
+            )
+        },
+        Array<ImportBuffer>{
+            ImportBuffer(
+                read_buffer.GetView(8, 4),
+                EBufferState::UNORDERED_ACCESS
+            ),
+            ImportBuffer(
+                write_buffer.GetView(8, 4),
+                EBufferState::UNORDERED_ACCESS
+            )
+        }
+    );
+    reorderer.AcceptCmd(&touched_import);
+    Expect(
+        FindCommandLayer(reorderer, &touched_import) == 1,
+        "NDEBUG touched-range import missed its exact fallback"
+    );
+#endif
+
+    QueueTransferCmd gap_import(
+        EQueueType::Copy,
+        Array<ImportTexture>{
+            ImportTexture(
+                read_texture.GetView(0, 1).Slice(3, 1),
+                ETextureState::SAMPLE
+            ),
+            ImportTexture(
+                write_texture.GetView(0, 1).Slice(3, 1),
+                ETextureState::SAMPLE
+            )
+        },
+        Array<ImportBuffer>{
+            ImportBuffer(
+                read_buffer.GetView(4, 4),
+                EBufferState::UNORDERED_ACCESS
+            ),
+            ImportBuffer(
+                write_buffer.GetView(4, 4),
+                EBufferState::UNORDERED_ACCESS
+            )
+        }
+    );
+    reorderer.AcceptCmd(&gap_import);
+    Expect(
+        FindCommandLayer(reorderer, &gap_import) == 0,
+        "untouched compressed gap import gained a false dependency"
+    );
+    Expect(
+        reorderer.SetRead(read_buffer_handle, buffer_gap) == 1 &&
+            reorderer.SetRead(write_buffer_handle, buffer_gap) == 1 &&
+            reorderer.SetRead(read_texture_handle, texture_cross_gap) == 1 &&
+            reorderer.SetRead(write_texture_handle, texture_cross_gap) == 1,
+        "gap resource use did not wait for its successful import"
     );
 }
 
@@ -590,6 +1255,11 @@ int main() {
         ScopeCommandsOwnExclusiveLayers();
         ResourceImportsMayFollowNonResourceOrderingBoundaries();
         ResourceImportsDetectPriorTextureAndBufferReads();
+        ResourceImportsDetectPriorTextureAndBufferWrites();
+        ResourceImportsConservativelyWaitForOpaqueBindlessAccess();
+        QueueTransferWritesFeedBindlessAliasOrderingWithoutExactPollution();
+        ExactImportHistoryIsBoundedAndMergesDuplicateRanges();
+        ResourceImportExactHistorySurvivesReadWriteAndTwoDimensionalCompression();
         CommandResourcePreprocessingIsTaskGraphIndependent();
         std::cout << "RHI command reorderer tests passed\n";
         return 0;

--- a/source/test/RHICmdReordererTest.cpp
+++ b/source/test/RHICmdReordererTest.cpp
@@ -348,6 +348,104 @@ void ResourceImportsMayFollowNonResourceOrderingBoundaries() {
     );
 }
 
+void ResourceImportsDetectPriorTextureAndBufferReads() {
+    TCachedArgArray cached_args;
+    CmdReorderer   reorderer(MakeFunctionTable(), cached_args);
+
+    ScopeCmd root_scope(
+        "Profiled Prior Read",
+        true,
+        false,
+        GpuMarkerPalette::Renderer(),
+        EQueueType::Graphics
+    );
+    CommandList query_source(EQueueType::Graphics);
+    QueryToken  timestamp =
+        query_source.BeginTimestampQuery("Profiled Prior Read");
+    query_source.EndTimestampQuery(timestamp);
+    CmdSubmit query_submit = query_source.Submit();
+    Expect(
+        query_submit.cmds.size() == 2 &&
+            query_submit.cmds.front()->Type() == Command::EType::Query,
+        "prior-read timestamp source did not emit its query pair"
+    );
+
+    TestTexture texture;
+    TestBuffer  buffer(
+        16,
+        4,
+        EBufferUsageFlags::UNORDERED_ACCESS |
+            EBufferUsageFlags::TRANSFER_DST
+    );
+    auto* texture_handle = static_cast<CmdReorderer::RangeHandle*>(
+        reorderer.GetHandle(
+            uint64(&texture),
+            CmdReorderer::ResourceType::Texture_Buffer
+        )
+    );
+    auto* buffer_handle = static_cast<CmdReorderer::RangeHandle*>(
+        reorderer.GetHandle(
+            uint64(&buffer),
+            CmdReorderer::ResourceType::Texture_Buffer
+        )
+    );
+    const CmdReorderer::Range texture_range(0, 1, 0, 1);
+    const CmdReorderer::Range buffer_range(0, buffer.GetByteSize());
+
+    reorderer.AcceptCmd(&root_scope);
+    reorderer.AcceptCmd(query_submit.cmds.front().get());
+    Expect(
+        reorderer.SetRead(texture_handle, texture_range) == 2,
+        "texture prior read did not follow the profiling prefix"
+    );
+    Expect(
+        reorderer.SetRead(buffer_handle, buffer_range) == 2,
+        "buffer prior read did not follow the profiling prefix"
+    );
+    Expect(
+        texture_handle->GetMaxReadLayer(texture_range) == 2 &&
+            texture_handle->GetMaxWriteLayer(texture_range) < 0,
+        "texture prior read was not distinguishable from a fresh import range"
+    );
+    Expect(
+        buffer_handle->GetMaxReadLayer(buffer_range) == 2 &&
+            buffer_handle->GetMaxWriteLayer(buffer_range) < 0,
+        "buffer prior read was not distinguishable from a fresh import range"
+    );
+
+#if defined(NDEBUG)
+    // Debug deliberately rejects this invalid ownership order with an
+    // assertion. Release keeps a fail-safe dependency so the transfer can
+    // never move before the already-recorded resource reads.
+    QueueTransferCmd import(
+        EQueueType::Copy,
+        Array<ImportTexture>{
+            ImportTexture(texture.GetView(), ETextureState::SAMPLE)
+        },
+        Array<ImportBuffer>{
+            ImportBuffer(buffer.GetView(), EBufferState::UNORDERED_ACCESS)
+        }
+    );
+    reorderer.AcceptCmd(&import);
+    Expect(
+        FindCommandLayer(reorderer, &import) == 3,
+        "release import fallback did not wait for prior texture and buffer reads"
+    );
+    Expect(
+        reorderer.SetRead(texture_handle, texture_range) == 4,
+        "texture use did not wait for the release import fallback"
+    );
+    Expect(
+        reorderer.SetRead(buffer_handle, buffer_range) == 4,
+        "buffer use did not wait for the release import fallback"
+    );
+#endif
+
+    QueryBackendAccess::ResolveErrorIfPending(
+        timestamp, "reorderer prior-read test cleanup"
+    );
+}
+
 void CommandResourcePreprocessingIsTaskGraphIndependent() {
     std::exception_ptr worker_error;
     std::jthread worker([&] {
@@ -491,6 +589,7 @@ int main() {
         WriteBarrierWaitsForPriorRead();
         ScopeCommandsOwnExclusiveLayers();
         ResourceImportsMayFollowNonResourceOrderingBoundaries();
+        ResourceImportsDetectPriorTextureAndBufferReads();
         CommandResourcePreprocessingIsTaskGraphIndependent();
         std::cout << "RHI command reorderer tests passed\n";
         return 0;

--- a/source/test/RHICmdReordererTest.cpp
+++ b/source/test/RHICmdReordererTest.cpp
@@ -25,6 +25,30 @@ public:
     void SetName(const std::string_view) override {}
 };
 
+class TestTexture final : public Texture {
+public:
+    TestTexture() : Texture(MakeInfo()) {}
+
+    uint GetMipByteSize(uint) const override {
+        return 4;
+    }
+
+    void SetName(const std::string_view) override {}
+
+private:
+    static TextureInfo MakeInfo() {
+        TextureInfo info{};
+        info.usage =
+            ETextureUsageFlags::SAMPLED |
+            ETextureUsageFlags::TRANSFER_DST;
+        info.extent       = {4, 4};
+        info.num_mips     = 1;
+        info.array_size   = 1;
+        info.aspect_flags = ETextureAspectFlags::COLOR;
+        return info;
+    }
+};
+
 void ExpectRange(
     const UnorderedMap<Buffer*, BufferRange>& _ranges,
     Buffer*                                   _buffer,
@@ -236,6 +260,94 @@ void ScopeCommandsOwnExclusiveLayers() {
     Expect(FindCommandLayer(reorderer, &renderer_pop) == 5, "renderer pop did not own the final layer");
 }
 
+void ResourceImportsMayFollowNonResourceOrderingBoundaries() {
+    TCachedArgArray cached_args;
+    CmdReorderer   reorderer(MakeFunctionTable(), cached_args);
+
+    ScopeCmd root_scope(
+        "Profiled Import",
+        true,
+        false,
+        GpuMarkerPalette::Renderer(),
+        EQueueType::Graphics
+    );
+    CommandList query_source(EQueueType::Graphics);
+    QueryToken  timestamp =
+        query_source.BeginTimestampQuery("Profiled Import");
+    query_source.EndTimestampQuery(timestamp);
+    CmdSubmit query_submit = query_source.Submit();
+    Expect(
+        query_submit.cmds.size() == 2 &&
+            query_submit.cmds.front()->Type() == Command::EType::Query,
+        "timestamp source did not emit its query pair"
+    );
+
+    TestTexture texture;
+    TestBuffer  buffer(
+        16,
+        4,
+        EBufferUsageFlags::UNORDERED_ACCESS |
+            EBufferUsageFlags::TRANSFER_DST
+    );
+    QueueTransferCmd import(
+        EQueueType::Copy,
+        Array<ImportTexture>{
+            ImportTexture(texture.GetView(), ETextureState::SAMPLE)
+        },
+        Array<ImportBuffer>{
+            ImportBuffer(buffer.GetView(), EBufferState::UNORDERED_ACCESS)
+        }
+    );
+
+    reorderer.AcceptCmd(&root_scope);
+    reorderer.AcceptCmd(query_submit.cmds.front().get());
+    reorderer.AcceptCmd(&import);
+
+    Expect(
+        FindCommandLayer(reorderer, &root_scope) == 0,
+        "profile root did not retain its ordering boundary"
+    );
+    Expect(
+        FindCommandLayer(reorderer, query_submit.cmds.front().get()) == 1,
+        "timestamp begin did not retain its ordering boundary"
+    );
+    Expect(
+        FindCommandLayer(reorderer, &import) == 2,
+        "fresh resource import did not follow the profiling prefix"
+    );
+
+    auto* texture_handle = static_cast<CmdReorderer::RangeHandle*>(
+        reorderer.GetHandle(
+            uint64(&texture),
+            CmdReorderer::ResourceType::Texture_Buffer
+        )
+    );
+    auto* buffer_handle = static_cast<CmdReorderer::RangeHandle*>(
+        reorderer.GetHandle(
+            uint64(&buffer),
+            CmdReorderer::ResourceType::Texture_Buffer
+        )
+    );
+    Expect(
+        reorderer.SetRead(
+            texture_handle,
+            CmdReorderer::Range(0, 1, 0, 1)
+        ) == 3,
+        "texture use did not wait for its profiled import"
+    );
+    Expect(
+        reorderer.SetRead(
+            buffer_handle,
+            CmdReorderer::Range(0, buffer.GetByteSize())
+        ) == 3,
+        "buffer use did not wait for its profiled import"
+    );
+
+    QueryBackendAccess::ResolveErrorIfPending(
+        timestamp, "reorderer import-prefix test cleanup"
+    );
+}
+
 void CommandResourcePreprocessingIsTaskGraphIndependent() {
     std::exception_ptr worker_error;
     std::jthread worker([&] {
@@ -378,6 +490,7 @@ int main() {
         MultiResourceBarrierPublishesEveryAccessAtItsFinalLayer();
         WriteBarrierWaitsForPriorRead();
         ScopeCommandsOwnExclusiveLayers();
+        ResourceImportsMayFollowNonResourceOrderingBoundaries();
         CommandResourcePreprocessingIsTaskGraphIndependent();
         std::cout << "RHI command reorderer tests passed\n";
         return 0;

--- a/source/test/RenderProfileCaptureTest.cpp
+++ b/source/test/RenderProfileCaptureTest.cpp
@@ -404,6 +404,48 @@ void LegacyConstructorRejectsInvalidStreamConfiguration() {
     FinishRuntime(output);
 }
 
+void StartValidationExceptionsReturnStableResults() {
+    ScopedOutput output("moer-render-profile-start-validation-exception");
+    StartRuntime(output);
+    const RegisteredGpuSchemas schemas = RegisterGpuSchemas();
+    RenderProfileCapture       capture;
+
+    RenderProfileTesting::InjectNextStartValidationBadAlloc();
+    Expect(
+        capture.StartSession(schemas.frame, schemas.scope) ==
+            RenderProfileSessionStartResult::ResourceExhausted,
+        "schema descriptor allocation failure escaped the noexcept start boundary"
+    );
+    Expect(
+        !capture.Valid() && capture.GetStats().generation == 0,
+        "schema descriptor allocation failure published session state"
+    );
+
+    RenderProfileTesting::InjectNextStartValidationException();
+    Expect(
+        capture.StartSession(schemas.frame, schemas.scope) ==
+            RenderProfileSessionStartResult::InvalidConfiguration,
+        "schema descriptor exception escaped the noexcept start boundary"
+    );
+    Expect(
+        !capture.Valid() && capture.GetStats().generation == 0,
+        "schema descriptor exception published session state"
+    );
+
+    Expect(
+        capture.StartSession(schemas.frame, schemas.scope) ==
+            RenderProfileSessionStartResult::Started,
+        "capture did not recover after translated start-validation exceptions"
+    );
+    Expect(
+        capture.TryFinishSession() ==
+            RenderProfileSessionFinishResult::Closed,
+        "recovered capture session did not close cleanly"
+    );
+    RenderProfileTesting::ClearStartValidationException();
+    FinishRuntime(output);
+}
+
 void FinishSessionOwnsStopAndTokenDestructorSeal() {
     RenderProfileCapture capture;
 
@@ -1839,6 +1881,7 @@ int main() {
     try {
         DefaultSessionFacadeIsInactive();
         LegacyConstructorRejectsInvalidStreamConfiguration();
+        StartValidationExceptionsReturnStableResults();
         FinishSessionOwnsStopAndTokenDestructorSeal();
         SessionGateStopsAdmissionDrainsAndRestartsNextGeneration();
         AbortedPendingQueryCannotPolluteNextRuntimeGeneration();

--- a/source/test/RenderProfileCaptureTest.cpp
+++ b/source/test/RenderProfileCaptureTest.cpp
@@ -412,6 +412,14 @@ void StartValidationExceptionsReturnStableResults() {
 
     RenderProfileTesting::InjectNextStartValidationBadAlloc();
     Expect(
+        capture.StartSession({}, {}) ==
+            RenderProfileSessionStartResult::InvalidSchema,
+        "invalid handles did not retain precedence over lazy schema initialization"
+    );
+    RenderProfileTesting::ClearStartValidationException();
+
+    RenderProfileTesting::InjectNextStartValidationBadAlloc();
+    Expect(
         capture.StartSession(schemas.frame, schemas.scope) ==
             RenderProfileSessionStartResult::ResourceExhausted,
         "schema descriptor allocation failure escaped the noexcept start boundary"

--- a/source/test/RenderProfileCaptureTest.cpp
+++ b/source/test/RenderProfileCaptureTest.cpp
@@ -10,6 +10,7 @@
 #include <algorithm>
 #include <array>
 #include <atomic>
+#include <barrier>
 #include <chrono>
 #include <cmath>
 #include <cstdint>
@@ -20,6 +21,7 @@
 #include <stdexcept>
 #include <string>
 #include <string_view>
+#include <thread>
 #include <utility>
 #include <vector>
 
@@ -364,6 +366,649 @@ void FinishRuntime(const ScopedOutput& _output) {
         !_output.HasInProgressFile(),
         "ProfileDump left an in-progress file"
     );
+}
+
+void DefaultSessionFacadeIsInactive() {
+    RenderProfileCapture            capture;
+    const RenderProfileCaptureStats stats = capture.GetStats();
+
+    Expect(!capture.Valid() && !capture.BeginFrame().Valid(), "default GPU capture facade admitted work");
+    Expect(
+        capture.RequestStop() == RenderProfileSessionStopResult::Inactive,
+        "default GPU capture facade accepted a stop request"
+    );
+    Expect(
+        capture.TryFinishSession() == RenderProfileSessionFinishResult::Inactive,
+        "default GPU capture facade reported a terminal session"
+    );
+    Expect(
+        !stats.accepting && !stats.closed && stats.generation == 0,
+        "default GPU capture facade exposed non-empty state"
+    );
+}
+
+void LegacyConstructorRejectsInvalidStreamConfiguration() {
+    ScopedOutput output("moer-render-profile-invalid-config");
+    StartRuntime(output);
+    const RegisteredGpuSchemas schemas = RegisterGpuSchemas();
+    GpuScopeStreamConfig       invalid_config{};
+    invalid_config.max_resident_frames = 0;
+
+    bool rejected = false;
+    try {
+        RenderProfileCapture capture(schemas.frame, schemas.scope, invalid_config);
+    } catch (const std::invalid_argument&) {
+        rejected = true;
+    }
+    Expect(rejected, "legacy GPU capture constructor silently accepted invalid stream configuration");
+    FinishRuntime(output);
+}
+
+void FinishSessionOwnsStopAndTokenDestructorSeal() {
+    RenderProfileCapture capture;
+
+    {
+        ScopedOutput output("moer-render-profile-finish-owned-stop");
+        StartRuntime(output);
+        const RegisteredGpuSchemas schemas = RegisterGpuSchemas();
+        Expect(
+            capture.StartSession(schemas.frame, schemas.scope) == RenderProfileSessionStartResult::Started,
+            "self-stopping GPU capture session did not start"
+        );
+        RenderProfileFrameToken frame = capture.BeginFrame();
+        Expect(frame.Valid() && capture.Seal(frame), "self-stopping session frame did not seal");
+        Expect(
+            capture.TryFinishSession() == RenderProfileSessionFinishResult::Closed,
+            "TryFinishSession did not own its admission-stop boundary"
+        );
+        const RenderProfileCaptureStats stats = capture.GetStats();
+        Expect(
+            stats.closed && stats.frames_sealed == 1 && stats.frames_emitted == 1 &&
+                stats.shutdown_abandoned_frames == 0,
+            "self-stopping session did not drain cleanly"
+        );
+        FinishRuntime(output);
+    }
+
+    {
+        ScopedOutput output("moer-render-profile-token-auto-seal");
+        StartRuntime(output);
+        const RegisteredGpuSchemas schemas = RegisterGpuSchemas();
+        Expect(
+            capture.StartSession(schemas.frame, schemas.scope) == RenderProfileSessionStartResult::Started,
+            "token auto-seal GPU capture session did not start"
+        );
+        {
+            RenderProfileFrameToken frame = capture.BeginFrame();
+            Expect(frame.Valid(), "token auto-seal frame admission failed");
+            Expect(
+                capture.RequestStop() == RenderProfileSessionStopResult::StopRequested,
+                "token auto-seal session stop request failed"
+            );
+            Expect(frame.Valid(), "stop invalidated the token before its destructor");
+        }
+        Expect(
+            capture.TryFinishSession() == RenderProfileSessionFinishResult::Closed,
+            "stopped token destructor did not auto-seal and drain"
+        );
+        const RenderProfileCaptureStats stats = capture.GetStats();
+        Expect(
+            stats.frames_sealed == 1 && stats.frames_emitted == 1 && stats.shutdown_abandoned_frames == 0,
+            "token destructor auto-seal accounting is inconsistent"
+        );
+        FinishRuntime(output);
+    }
+}
+
+void SessionGateStopsAdmissionDrainsAndRestartsNextGeneration() {
+    RenderProfileCapture capture;
+    std::uint64_t        first_generation = 0;
+
+    {
+        ScopedOutput output("moer-render-profile-session-a");
+        StartRuntime(output);
+        const RegisteredGpuSchemas schemas = RegisterGpuSchemas();
+        Expect(
+            capture.StartSession(schemas.frame, schemas.scope) == RenderProfileSessionStartResult::Started,
+            "first GPU capture session did not start"
+        );
+        first_generation = capture.GetStats().generation;
+        Expect(first_generation != 0 && capture.Valid(), "first GPU capture session has no live generation");
+
+        RenderProfileFrameToken frame = capture.BeginFrame();
+        Expect(frame.Valid() && frame.FrameId() == 1, "first session frame admission failed");
+        Expect(
+            capture.RequestStop() == RenderProfileSessionStopResult::StopRequested,
+            "first session stop request was not accepted"
+        );
+        Expect(
+            capture.RequestStop() == RenderProfileSessionStopResult::AlreadyStopping,
+            "repeated session stop did not report an existing stop"
+        );
+        Expect(
+            !capture.Valid() && !capture.BeginFrame().Valid(),
+            "stopping session continued to admit new frames"
+        );
+        Expect(frame.Valid(), "stopping session invalidated an admitted frame token");
+        Expect(
+            capture.TryFinishSession() == RenderProfileSessionFinishResult::Pending,
+            "session closed while an admitted frame was still unsealed"
+        );
+
+        CommandList list(EQueueType::Graphics);
+        Expect(
+            capture.BindSource(frame, list, Binding(EQueueType::Graphics, 6, 12), 4) ==
+                RenderProfileBindResult::Bound,
+            "stopping session rejected an admitted frame source"
+        );
+        list.PushScopeWithTimeScope("SessionA.AcceptedBeforeStop");
+        list.PopScopeWithTimeScope();
+        CmdSubmit submit = list.Submit();
+        Expect(capture.Seal(frame), "stopping session could not seal an admitted frame");
+        Expect(
+            capture.TryFinishSession() == RenderProfileSessionFinishResult::Pending,
+            "session closed before its admitted query completed"
+        );
+
+        ResolveTimestampAt(submit, 0, Timestamp(40, 55));
+        Expect(
+            capture.GetStats().stream.resident_ready_frames == 1,
+            "completed query did not publish a ready frame before owner polling"
+        );
+        Expect(
+            capture.TryFinishSession() == RenderProfileSessionFinishResult::Closed,
+            "finish did not drain the ready frame and close cleanly"
+        );
+        const RenderProfileCaptureStats closed = capture.GetStats();
+        Expect(
+            closed.closed && !closed.accepting && closed.frames_admitted == 1 && closed.frames_emitted == 1 &&
+                closed.scopes_emitted == 1 && closed.shutdown_abandoned_frames == 0 &&
+                closed.terminal_faults == 0,
+            "clean session close statistics are inconsistent"
+        );
+        Expect(
+            capture.TryFinishSession() == RenderProfileSessionFinishResult::Closed,
+            "clean session finish was not idempotent"
+        );
+        Expect(
+            capture.StartSession(schemas.frame, schemas.scope) ==
+                RenderProfileSessionStartResult::GenerationAlreadyUsed,
+            "closed session rebound inside one ProfileDump generation"
+        );
+
+        ReleaseSubmit(submit);
+        FinishRuntime(output);
+        const ParsedDump dump = ParseDump(output.path);
+        Expect(
+            RecordsFor(dump, FindSchema(dump, "GpuFrame")).size() == 1 &&
+                RecordsFor(dump, FindSchema(dump, "GpuScope")).size() == 1,
+            "first session did not persist its clean drain"
+        );
+    }
+
+    {
+        ScopedOutput output("moer-render-profile-session-b");
+        StartRuntime(output);
+        const RegisteredGpuSchemas schemas = RegisterGpuSchemas();
+        Expect(
+            capture.StartSession(schemas.frame, schemas.scope) == RenderProfileSessionStartResult::Started,
+            "stable facade did not start in the next runtime generation"
+        );
+        Expect(
+            capture.GetStats().generation != first_generation,
+            "stable facade retained the previous runtime generation"
+        );
+
+        RenderProfileFrameToken frame = capture.BeginFrame();
+        Expect(
+            frame.Valid() && frame.FrameId() == 1 && capture.Seal(frame),
+            "second session did not reset and seal frame identity"
+        );
+        Expect(
+            capture.RequestStop() == RenderProfileSessionStopResult::StopRequested &&
+                capture.TryFinishSession() == RenderProfileSessionFinishResult::Closed,
+            "second session did not close cleanly"
+        );
+        const RenderProfileCaptureStats closed = capture.GetStats();
+        Expect(
+            closed.frames_emitted == 1 && closed.scopes_emitted == 0 && closed.shutdown_abandoned_frames == 0,
+            "second session inherited first-generation accounting"
+        );
+
+        FinishRuntime(output);
+        const ParsedDump dump = ParseDump(output.path);
+        Expect(
+            RecordsFor(dump, FindSchema(dump, "GpuFrame")).size() == 1 && dump.records.size() == 1,
+            "second session output contains cross-generation records"
+        );
+    }
+}
+
+void AbortedPendingQueryCannotPolluteNextRuntimeGeneration() {
+    RenderProfileCapture     capture;
+    CommandList              persistent(EQueueType::Graphics);
+    std::optional<CmdSubmit> old_submit{};
+    RenderProfileFrameToken  stale_token{};
+
+    {
+        ScopedOutput output("moer-render-profile-session-abort-old");
+        StartRuntime(output);
+        const RegisteredGpuSchemas schemas = RegisterGpuSchemas();
+        Expect(
+            capture.StartSession(schemas.frame, schemas.scope) == RenderProfileSessionStartResult::Started,
+            "old GPU capture session did not start"
+        );
+
+        RenderProfileFrameToken frame = capture.BeginFrame();
+        Expect(
+            capture.BindSource(frame, persistent, Binding(EQueueType::Graphics, 7, 13), 1) ==
+                RenderProfileBindResult::Bound,
+            "old pending source bind failed"
+        );
+        persistent.PushScopeWithTimeScope("OldGeneration.Pending");
+        persistent.PopScopeWithTimeScope();
+        old_submit.emplace(persistent.Submit());
+        Expect(capture.Seal(frame), "old pending frame seal failed");
+        stale_token = capture.BeginFrame();
+        Expect(
+            stale_token.Valid() && stale_token.FrameId() == 2,
+            "old generation stale-token frame admission failed"
+        );
+
+        capture.Abort();
+        const RenderProfileCaptureStats aborted = capture.GetStats();
+        Expect(
+            aborted.closed && !aborted.accepting && aborted.shutdown_abandoned_frames == 2 &&
+                capture.TryFinishSession() == RenderProfileSessionFinishResult::Aborted,
+            "abort did not detach the old pending session"
+        );
+        Expect(
+            capture.StartSession(schemas.frame, schemas.scope) ==
+                RenderProfileSessionStartResult::GenerationAlreadyUsed,
+            "aborted session rebound inside one ProfileDump generation"
+        );
+        FinishRuntime(output);
+    }
+
+    {
+        ScopedOutput output("moer-render-profile-session-abort-new");
+        StartRuntime(output);
+        const RegisteredGpuSchemas schemas = RegisterGpuSchemas();
+        Expect(
+            capture.StartSession(schemas.frame, schemas.scope) == RenderProfileSessionStartResult::Started,
+            "new GPU capture generation did not rebind"
+        );
+        CommandList stale_list(EQueueType::Graphics);
+        Expect(
+            !stale_token.Valid() &&
+                capture.BindSource(stale_token, stale_list, Binding(EQueueType::Graphics, 8, 14), 0) ==
+                    RenderProfileBindResult::InvalidFrame &&
+                !capture.Seal(stale_token) && capture.Valid() && capture.GetStats().frames_attempted == 0,
+            "old generation frame token entered or replaced the new session"
+        );
+
+        RenderProfileFrameToken frame = capture.BeginFrame();
+        Expect(
+            capture.BindSource(frame, persistent, Binding(EQueueType::Graphics, 8, 14), 2) ==
+                RenderProfileBindResult::Bound,
+            "persistent CommandList did not bind to the new session"
+        );
+        persistent.PushScopeWithTimeScope("NewGeneration.Current");
+        persistent.PopScopeWithTimeScope();
+        CmdSubmit current_submit = persistent.Submit();
+        Expect(capture.Seal(frame), "new generation frame seal failed");
+        const RenderProfileCaptureStats before_old_completion = capture.GetStats();
+        Expect(
+            before_old_completion.stream.resident_frames == 1 &&
+                before_old_completion.stream.resident_pending_frames == 1 &&
+                before_old_completion.frames_emitted == 0,
+            "new generation did not retain its same-id frame while the old callback was pending"
+        );
+
+        Expect(
+            QueryBackendAccess::ResolveTimestamp(old_submit->query_tokens.front(), Timestamp(1, 2)),
+            "old generation query could not complete safely"
+        );
+        Expect(capture.DrainReadyFrames() == 0, "old generation completion became a current frame");
+        const RenderProfileCaptureStats after_old_completion = capture.GetStats();
+        Expect(
+            after_old_completion.frames_emitted == before_old_completion.frames_emitted &&
+                after_old_completion.scopes_emitted == before_old_completion.scopes_emitted &&
+                after_old_completion.frames_invalid == before_old_completion.frames_invalid &&
+                after_old_completion.stream.resident_frames == before_old_completion.stream.resident_frames,
+            "old generation completion mutated the current session"
+        );
+
+        ResolveTimestampAt(current_submit, 0, Timestamp(100, 125));
+        Expect(capture.DrainReadyFrames() == 1, "new generation frame did not drain");
+        Expect(
+            capture.RequestStop() == RenderProfileSessionStopResult::StopRequested &&
+                capture.TryFinishSession() == RenderProfileSessionFinishResult::Closed,
+            "new generation did not close after old completion"
+        );
+        ReleaseSubmit(current_submit);
+        ReleaseSubmit(*old_submit);
+        FinishRuntime(output);
+
+        const ParsedDump dump   = ParseDump(output.path);
+        const auto       frames = RecordsFor(dump, FindSchema(dump, "GpuFrame"));
+        const auto       scopes = RecordsFor(dump, FindSchema(dump, "GpuScope"));
+        Expect(
+            frames.size() == 1 && scopes.size() == 1 &&
+                StringAt(*scopes.front(), 8) == "NewGeneration.Current",
+            "old generation callback polluted the new dump"
+        );
+    }
+}
+
+void DelayedStaleStartCannotFaultNewGeneration() {
+    RenderProfileCapture            capture;
+    RegisteredGpuSchemas            stale_schemas{};
+    std::atomic_uint32_t            pause_entered{0};
+    std::atomic_bool                pause_release{false};
+    RenderProfileSessionStartResult stale_result = RenderProfileSessionStartResult::InvalidSchema;
+
+    ScopedOutput stale_output("moer-render-profile-delayed-start-old");
+    StartRuntime(stale_output);
+    stale_schemas = RegisterGpuSchemas();
+    RenderProfileTesting::InstallStartPublishPause(pause_entered, pause_release);
+
+    std::optional<std::jthread> stale_starter;
+    try {
+        stale_starter.emplace([&] {
+            stale_result = capture.StartSession(stale_schemas.frame, stale_schemas.scope);
+        });
+    } catch (...) {
+        RenderProfileTesting::ClearStartPublishPause();
+        throw;
+    }
+
+    struct PauseCleanup {
+        std::atomic_bool& release;
+        bool              active{true};
+
+        ~PauseCleanup() {
+            if (active) {
+                release.store(true, std::memory_order_release);
+                RenderProfileTesting::ClearStartPublishPause();
+            }
+        }
+
+        void Finish() noexcept {
+            release.store(true, std::memory_order_release);
+            RenderProfileTesting::ClearStartPublishPause();
+            active = false;
+        }
+    } pause_cleanup{pause_release};
+
+    const auto pause_deadline = std::chrono::steady_clock::now() + std::chrono::seconds(2);
+    while (pause_entered.load(std::memory_order_acquire) == 0 &&
+           std::chrono::steady_clock::now() < pause_deadline) {
+        std::this_thread::yield();
+    }
+    if (pause_entered.load(std::memory_order_acquire) == 0) {
+        pause_cleanup.Finish();
+        stale_starter->join();
+        Expect(false, "delayed StartSession did not reach its deterministic publish boundary");
+    }
+
+    FinishRuntime(stale_output);
+
+    ScopedOutput current_output("moer-render-profile-delayed-start-current");
+    StartRuntime(current_output);
+    const RegisteredGpuSchemas            current_schemas = RegisterGpuSchemas();
+    const RenderProfileSessionStartResult current_result =
+        capture.StartSession(current_schemas.frame, current_schemas.scope);
+
+    pause_cleanup.Finish();
+    stale_starter->join();
+    Expect(
+        current_result == RenderProfileSessionStartResult::Started &&
+            stale_result == RenderProfileSessionStartResult::StaleGeneration,
+        "delayed stale StartSession did not lose to the current generation"
+    );
+    const RenderProfileCaptureStats current_stats = capture.GetStats();
+    Expect(
+        capture.Valid() && current_stats.generation == current_schemas.frame.generation &&
+            current_stats.terminal_faults == 0,
+        "delayed stale StartSession faulted or replaced the current session"
+    );
+
+    RenderProfileFrameToken frame = capture.BeginFrame();
+    Expect(frame.Valid() && capture.Seal(frame), "current session failed after delayed stale start");
+    Expect(
+        capture.RequestStop() == RenderProfileSessionStopResult::StopRequested &&
+            capture.TryFinishSession() == RenderProfileSessionFinishResult::Closed,
+        "current session did not close after delayed stale start"
+    );
+    FinishRuntime(current_output);
+}
+
+void DelayedStartCannotPublishStaleCandidate() {
+    RenderProfileCapture       capture;
+    std::atomic_uint32_t       pause_entered{0};
+    std::atomic_bool           pause_release{false};
+    RenderProfileSessionStartResult stale_result =
+        RenderProfileSessionStartResult::InvalidSchema;
+
+    ScopedOutput stale_output("moer-render-profile-publish-race-old");
+    StartRuntime(stale_output);
+    const RegisteredGpuSchemas stale_schemas = RegisterGpuSchemas();
+    RenderProfileTesting::InstallStartPublishPause(pause_entered, pause_release);
+
+    std::optional<std::jthread> stale_starter;
+    try {
+        stale_starter.emplace([&] {
+            stale_result = capture.StartSession(stale_schemas.frame, stale_schemas.scope);
+        });
+    } catch (...) {
+        RenderProfileTesting::ClearStartPublishPause();
+        throw;
+    }
+
+    struct PauseCleanup {
+        std::atomic_bool& release;
+        bool              active{true};
+
+        ~PauseCleanup() {
+            if (active) {
+                release.store(true, std::memory_order_release);
+                RenderProfileTesting::ClearStartPublishPause();
+            }
+        }
+
+        void Finish() noexcept {
+            release.store(true, std::memory_order_release);
+            RenderProfileTesting::ClearStartPublishPause();
+            active = false;
+        }
+    } pause_cleanup{pause_release};
+
+    const auto pause_deadline = std::chrono::steady_clock::now() + std::chrono::seconds(2);
+    while (pause_entered.load(std::memory_order_acquire) == 0 &&
+           std::chrono::steady_clock::now() < pause_deadline) {
+        std::this_thread::yield();
+    }
+    if (pause_entered.load(std::memory_order_acquire) == 0) {
+        pause_cleanup.Finish();
+        stale_starter->join();
+        Expect(false, "StartSession did not pause immediately before publication");
+    }
+
+    FinishRuntime(stale_output);
+
+    ScopedOutput current_output("moer-render-profile-publish-race-current");
+    StartRuntime(current_output);
+    const RegisteredGpuSchemas current_schemas = RegisterGpuSchemas();
+
+    // No current session is published yet, so the delayed compare-exchange
+    // succeeds. The post-CAS generation check must still reject and close
+    // only that stale candidate instead of reporting Started.
+    pause_cleanup.Finish();
+    stale_starter->join();
+    const RenderProfileCaptureStats stale_stats = capture.GetStats();
+    Expect(
+        stale_result == RenderProfileSessionStartResult::StaleGeneration &&
+            stale_stats.closed && stale_stats.generation == stale_schemas.frame.generation &&
+            stale_stats.terminal_faults == 1,
+        "post-publication generation check accepted a stale candidate"
+    );
+
+    Expect(
+        capture.StartSession(current_schemas.frame, current_schemas.scope) ==
+            RenderProfileSessionStartResult::Started,
+        "current generation could not replace the rejected stale candidate"
+    );
+    const RenderProfileCaptureStats current_stats = capture.GetStats();
+    Expect(
+        capture.Valid() && current_stats.generation == current_schemas.frame.generation &&
+            current_stats.terminal_faults == 0,
+        "current generation inherited the stale candidate's terminal state"
+    );
+    RenderProfileFrameToken frame = capture.BeginFrame();
+    Expect(frame.Valid() && capture.Seal(frame), "current frame failed after stale publication rejection");
+    Expect(
+        capture.RequestStop() == RenderProfileSessionStopResult::StopRequested &&
+            capture.TryFinishSession() == RenderProfileSessionFinishResult::Closed,
+        "current session did not close after stale publication rejection"
+    );
+    FinishRuntime(current_output);
+}
+
+void ConcurrentSessionStartHasOneWinner() {
+    ScopedOutput output("moer-render-profile-concurrent-start");
+    StartRuntime(output);
+    const RegisteredGpuSchemas schemas = RegisterGpuSchemas();
+    RenderProfileCapture       capture;
+
+    constexpr std::size_t thread_count = 16;
+    std::barrier          start_line(static_cast<std::ptrdiff_t>(thread_count + 1));
+    std::array<RenderProfileSessionStartResult, thread_count> results{};
+    results.fill(RenderProfileSessionStartResult::InvalidSchema);
+    std::vector<std::jthread> starters;
+    starters.reserve(thread_count);
+    for (std::size_t index = 0; index < thread_count; ++index) {
+        starters.emplace_back([&, index] {
+            start_line.arrive_and_wait();
+            results[index] = capture.StartSession(schemas.frame, schemas.scope);
+        });
+    }
+    start_line.arrive_and_wait();
+    starters.clear();
+
+    const std::size_t started =
+        static_cast<std::size_t>(std::ranges::count(results, RenderProfileSessionStartResult::Started));
+    const std::size_t already_active =
+        static_cast<std::size_t>(std::ranges::count(results, RenderProfileSessionStartResult::AlreadyActive));
+    Expect(
+        started == 1 && already_active == thread_count - 1 && capture.Valid(),
+        "concurrent session start did not elect exactly one winner"
+    );
+
+    Expect(
+        capture.RequestStop() == RenderProfileSessionStopResult::StopRequested &&
+            capture.TryFinishSession() == RenderProfileSessionFinishResult::Closed,
+        "concurrently started session did not close cleanly"
+    );
+    FinishRuntime(output);
+}
+
+void StaleSchemaHandlesCannotReplaceCurrentSession() {
+    RegisteredGpuSchemas stale_schemas{};
+    {
+        ScopedOutput output("moer-render-profile-stale-session");
+        StartRuntime(output);
+        stale_schemas = RegisterGpuSchemas();
+        FinishRuntime(output);
+    }
+
+    ScopedOutput output("moer-render-profile-current-session");
+    StartRuntime(output);
+    const RegisteredGpuSchemas current_schemas = RegisterGpuSchemas();
+    RenderProfileCapture       capture;
+    Expect(
+        capture.StartSession(current_schemas.frame, current_schemas.scope) ==
+            RenderProfileSessionStartResult::Started,
+        "current GPU capture session did not start"
+    );
+    const std::uint64_t current_generation = capture.GetStats().generation;
+    Expect(
+        capture.StartSession(stale_schemas.frame, stale_schemas.scope) ==
+            RenderProfileSessionStartResult::StaleGeneration,
+        "stale schema handles were not explicitly rejected"
+    );
+    Expect(
+        capture.Valid() && capture.GetStats().generation == current_generation,
+        "stale schema handles replaced the current session"
+    );
+
+    RenderProfileFrameToken frame = capture.BeginFrame();
+    Expect(
+        frame.Valid() && frame.FrameId() == 1 && capture.Seal(frame),
+        "current session did not survive the stale start attempt"
+    );
+    Expect(
+        capture.RequestStop() == RenderProfileSessionStopResult::StopRequested &&
+            capture.TryFinishSession() == RenderProfileSessionFinishResult::Closed,
+        "current session did not close after stale-handle rejection"
+    );
+    FinishRuntime(output);
+
+    const ParsedDump dump = ParseDump(output.path);
+    Expect(
+        RecordsFor(dump, FindSchema(dump, "GpuFrame")).size() == 1,
+        "stale-handle rejection lost the current frame"
+    );
+}
+
+void SourceAndScopeDropsCloseWithLoss() {
+    ScopedOutput output("moer-render-profile-source-scope-loss");
+    StartRuntime(output);
+    const RegisteredGpuSchemas schemas = RegisterGpuSchemas();
+    GpuScopeStreamConfig       stream_config{};
+    stream_config.max_scope_name_bytes = 4;
+    RenderProfileCapture capture(schemas.frame, schemas.scope, stream_config);
+
+    RenderProfileFrameToken frame = capture.BeginFrame();
+    Expect(frame.Valid(), "loss-classification frame admission failed");
+
+    CommandList rejected_source(EQueueType::Graphics);
+    Expect(
+        capture.BindSource(frame, rejected_source, RHIQueueBinding{}, 0) ==
+            RenderProfileBindResult::InvalidQueue,
+        "invalid source did not reach the bridge rejection path"
+    );
+
+    CommandList dropped_scope(EQueueType::Graphics);
+    Expect(
+        capture.BindSource(
+            frame,
+            dropped_scope,
+            Binding(EQueueType::Graphics, 9, 15),
+            1
+        ) == RenderProfileBindResult::Bound,
+        "scope-drop source bind failed"
+    );
+    dropped_scope.PushScopeWithTimeScope("TooLong");
+    dropped_scope.PopScopeWithTimeScope();
+    CmdSubmit submit = dropped_scope.Submit();
+    Expect(capture.Seal(frame), "loss-classification frame seal failed");
+
+    Expect(
+        capture.RequestStop() == RenderProfileSessionStopResult::StopRequested &&
+            capture.TryFinishSession() == RenderProfileSessionFinishResult::ClosedWithLoss,
+        "source/scope drops did not produce a lossy terminal state"
+    );
+    const RenderProfileCaptureStats stats = capture.GetStats();
+    Expect(
+        stats.closed && stats.sources_rejected == 1 && stats.frames_invalid == 1 &&
+            stats.stream.scopes_dropped_name_too_large == 1 &&
+            stats.frames_emitted == 1 && stats.terminal_faults == 0,
+        "source/scope loss accounting is inconsistent"
+    );
+
+    ReleaseSubmit(submit);
+    FinishRuntime(output);
 }
 
 void HappyPathPreservesTopologyAndRawTimestampDomains() {
@@ -1040,39 +1685,29 @@ void StaleGenerationFailsClosed() {
 
 void QueueFullDropsRecordsWithoutDisablingCapture() {
     Testing::ClearHooks();
-    Expect(
-        Testing::ConfigureWriterPauseAfterStart(true),
-        "writer pause hook could not be configured"
-    );
+    Expect(Testing::ConfigureWriterPauseAfterStart(true), "writer pause hook could not be configured");
     WriterResumeGuard resume_guard;
 
-    ScopedOutput output("moer-render-profile-queue-full");
+    ScopedOutput  output("moer-render-profile-queue-full");
     RuntimeConfig config{};
-    config.max_record_bytes = 4096;
+    config.max_record_bytes    = 4096;
     config.tls_publish_records = 1;
-    config.tls_publish_bytes = 4096;
-    config.tls_max_records = 1;
-    config.tls_max_bytes = 4096;
-    config.queue_max_chunks = 1;
-    config.queue_max_records = 1;
-    config.queue_max_bytes = 4096;
+    config.tls_publish_bytes   = 4096;
+    config.tls_max_records     = 1;
+    config.tls_max_bytes       = 4096;
+    config.queue_max_chunks    = 1;
+    config.queue_max_records   = 1;
+    config.queue_max_bytes     = 4096;
     StartRuntime(output, config);
-    Expect(
-        Testing::WaitForWriterPaused(2000),
-        "writer did not reach the deterministic pause"
-    );
+    Expect(Testing::WaitForWriterPaused(2000), "writer did not reach the deterministic pause");
 
     const RegisteredGpuSchemas schemas = RegisterGpuSchemas();
-    RenderProfileCapture capture(schemas.frame, schemas.scope);
-    RenderProfileFrameToken frame = capture.BeginFrame();
-    CommandList list(EQueueType::Graphics);
+    RenderProfileCapture       capture(schemas.frame, schemas.scope);
+    RenderProfileFrameToken    frame = capture.BeginFrame();
+    CommandList                list(EQueueType::Graphics);
     Expect(
-        capture.BindSource(
-            frame,
-            list,
-            Binding(EQueueType::Graphics, 0, 0),
-            0
-        ) == RenderProfileBindResult::Bound,
+        capture.BindSource(frame, list, Binding(EQueueType::Graphics, 0, 0), 0) ==
+            RenderProfileBindResult::Bound,
         "queue-full source bind failed"
     );
     list.PushScopeWithTimeScope("QueueFull.Scope");
@@ -1080,15 +1715,10 @@ void QueueFullDropsRecordsWithoutDisablingCapture() {
     CmdSubmit submit = list.Submit();
     Expect(capture.Seal(frame), "queue-full frame seal failed");
     ResolveTimestampAt(submit, 0, Timestamp(1, 2));
-    Expect(
-        capture.DrainReadyFrames() == 1,
-        "queue-full frame did not materialize"
-    );
+    Expect(capture.DrainReadyFrames() == 1, "queue-full frame did not materialize");
     RenderProfileCaptureStats pressured = capture.GetStats();
     Expect(
-        capture.Valid() &&
-            pressured.frames_emitted == 1 &&
-            pressured.scope_records_dropped == 1 &&
+        capture.Valid() && pressured.frames_emitted == 1 && pressured.scope_records_dropped == 1 &&
             pressured.terminal_faults == 0,
         "QueueFull disabled capture or changed drop accounting"
     );
@@ -1096,27 +1726,25 @@ void QueueFullDropsRecordsWithoutDisablingCapture() {
     resume_guard.Resume();
     const FlushResult drained = FlushAll();
     Expect(
-        drained == FlushResult::Completed ||
-            drained == FlushResult::NothingPending,
+        drained == FlushResult::Completed || drained == FlushResult::NothingPending,
         "queue-full recovery did not drain accepted work"
     );
     {
         RenderProfileFrameToken recovered = capture.BeginFrame();
         Expect(recovered.Valid(), "capture did not recover after QueueFull");
     }
-    Expect(
-        capture.DrainReadyFrames() == 1,
-        "recovered empty frame did not drain"
-    );
+    Expect(capture.DrainReadyFrames() == 1, "recovered empty frame did not drain");
     const RenderProfileCaptureStats recovered = capture.GetStats();
     Expect(
-        capture.Valid() &&
-            recovered.frames_emitted == 2 &&
-            recovered.terminal_faults == 0,
+        capture.Valid() && recovered.frames_emitted == 2 && recovered.terminal_faults == 0,
         "capture did not remain active after QueueFull recovery"
     );
 
     capture.ShutdownAfterRhiDrain();
+    Expect(
+        capture.TryFinishSession() == RenderProfileSessionFinishResult::ClosedWithLoss,
+        "QueueFull session did not expose its lossy terminal state"
+    );
     ReleaseSubmit(submit);
     FinishRuntime(output);
     Testing::ClearHooks();
@@ -1125,42 +1753,37 @@ void QueueFullDropsRecordsWithoutDisablingCapture() {
 void WriterFaultFailsCaptureClosed() {
     Testing::ClearHooks();
     Expect(
-        Testing::ConfigureFault(
-            Testing::FaultPoint::WritePacket, 2
-        ),
+        Testing::ConfigureFault(Testing::FaultPoint::WritePacket, 2),
         "writer fault hook could not be configured"
     );
 
-    ScopedOutput output("moer-render-profile-writer-fault");
+    ScopedOutput  output("moer-render-profile-writer-fault");
     RuntimeConfig config{};
     config.tls_publish_records = 1;
     StartRuntime(output, config);
     const RegisteredGpuSchemas schemas = RegisterGpuSchemas();
-    RenderProfileCapture capture(schemas.frame, schemas.scope);
+    RenderProfileCapture       capture(schemas.frame, schemas.scope);
 
     {
         RenderProfileFrameToken frame = capture.BeginFrame();
         Expect(frame.Valid(), "fault trigger frame admission failed");
     }
     static_cast<void>(capture.DrainReadyFrames());
-    Expect(
-        FlushAll() == FlushResult::Faulted,
-        "injected writer fault did not become observable"
-    );
+    Expect(FlushAll() == FlushResult::Faulted, "injected writer fault did not become observable");
     Expect(
         !capture.BeginFrame().Valid() && !capture.Valid(),
         "faulted ProfileDump runtime did not close the GPU bridge"
     );
     const RenderProfileCaptureStats stats = capture.GetStats();
     Expect(
-        stats.closed && stats.terminal_faults == 1,
-        "writer fault did not latch one terminal bridge fault"
+        stats.closed && stats.terminal_faults == 1, "writer fault did not latch one terminal bridge fault"
+    );
+    Expect(
+        capture.TryFinishSession() == RenderProfileSessionFinishResult::Faulted,
+        "writer fault did not expose the faulted terminal state"
     );
     capture.Abort();
-    Expect(
-        Shutdown() == ShutdownResult::Faulted,
-        "faulted ProfileDump shutdown reported success"
-    );
+    Expect(Shutdown() == ShutdownResult::Faulted, "faulted ProfileDump shutdown reported success");
     Testing::ClearHooks();
 }
 
@@ -1168,59 +1791,43 @@ void AdmissionRejectDoesNotOvertakeOrderedFrames() {
     ScopedOutput output("moer-render-profile-admission-order");
     StartRuntime(output);
     const RegisteredGpuSchemas schemas = RegisterGpuSchemas();
-    GpuScopeStreamConfig stream_config{};
+    GpuScopeStreamConfig       stream_config{};
     stream_config.max_resident_frames = 2;
-    stream_config.max_pending_frames = 1;
-    RenderProfileCapture capture(
-        schemas.frame, schemas.scope, stream_config
-    );
+    stream_config.max_pending_frames  = 1;
+    RenderProfileCapture capture(schemas.frame, schemas.scope, stream_config);
 
     RenderProfileFrameToken first = capture.BeginFrame();
-    Expect(
-        first.Valid() && first.FrameId() == 1,
-        "ordered admission first frame failed"
-    );
+    Expect(first.Valid() && first.FrameId() == 1, "ordered admission first frame failed");
     RenderProfileFrameToken rejected = capture.BeginFrame();
+    Expect(!rejected.Valid() && rejected.FrameId() == 2, "pending-frame limit did not reject frame 2");
     Expect(
-        !rejected.Valid() && rejected.FrameId() == 2,
-        "pending-frame limit did not reject frame 2"
-    );
-    Expect(
-        capture.Seal(first) &&
-            capture.DrainReadyFrames() == 1,
-        "ordered admission first frame did not drain"
+        capture.Seal(first) && capture.DrainReadyFrames() == 1, "ordered admission first frame did not drain"
     );
 
     {
         RenderProfileFrameToken recovered = capture.BeginFrame();
         Expect(
-            recovered.Valid() && recovered.FrameId() == 3,
-            "capture did not recover after admission rejection"
+            recovered.Valid() && recovered.FrameId() == 3, "capture did not recover after admission rejection"
         );
     }
+    Expect(capture.DrainReadyFrames() == 1, "ordered admission recovered frame did not drain");
     Expect(
-        capture.DrainReadyFrames() == 1,
-        "ordered admission recovered frame did not drain"
+        capture.RequestStop() == RenderProfileSessionStopResult::StopRequested &&
+            capture.TryFinishSession() == RenderProfileSessionFinishResult::ClosedWithLoss,
+        "frame admission rejection did not close through the dynamic lossy finish path"
     );
-    capture.ShutdownAfterRhiDrain();
     const RenderProfileCaptureStats stats = capture.GetStats();
     Expect(
-        stats.frames_attempted == 3 &&
-            stats.frames_admitted == 2 &&
-            stats.frames_admission_rejected == 1 &&
-            stats.frames_emitted == 2 &&
-            stats.shutdown_abandoned_frames == 0,
+        stats.frames_attempted == 3 && stats.frames_admitted == 2 && stats.frames_admission_rejected == 1 &&
+            stats.frames_emitted == 2 && stats.shutdown_abandoned_frames == 0,
         "admission rejection accounting is incorrect"
     );
     FinishRuntime(output);
 
-    const ParsedDump dump = ParseDump(output.path);
-    const auto frames = RecordsFor(
-        dump, FindSchema(dump, "GpuFrame")
-    );
+    const ParsedDump dump   = ParseDump(output.path);
+    const auto       frames = RecordsFor(dump, FindSchema(dump, "GpuFrame"));
     Expect(
-        frames.size() == 2 &&
-            ValueAt<std::uint64_t>(*frames[0], 0) == 1 &&
+        frames.size() == 2 && ValueAt<std::uint64_t>(*frames[0], 0) == 1 &&
             ValueAt<std::uint64_t>(*frames[1], 0) == 3,
         "rejected frame overtook or polluted ordered frame output"
     );
@@ -1230,6 +1837,16 @@ void AdmissionRejectDoesNotOvertakeOrderedFrames() {
 
 int main() {
     try {
+        DefaultSessionFacadeIsInactive();
+        LegacyConstructorRejectsInvalidStreamConfiguration();
+        FinishSessionOwnsStopAndTokenDestructorSeal();
+        SessionGateStopsAdmissionDrainsAndRestartsNextGeneration();
+        AbortedPendingQueryCannotPolluteNextRuntimeGeneration();
+        DelayedStaleStartCannotFaultNewGeneration();
+        DelayedStartCannotPublishStaleCandidate();
+        ConcurrentSessionStartHasOneWinner();
+        StaleSchemaHandlesCannotReplaceCurrentSession();
+        SourceAndScopeDropsCloseWithLoss();
         HappyPathPreservesTopologyAndRawTimestampDomains();
         RaytracingCaptureAggregationWaitsForReverseCompletionAndRecovers();
         AbortDetachesPendingCompletionWithoutBlocking();
@@ -1239,11 +1856,9 @@ int main() {
         WriterFaultFailsCaptureClosed();
         AdmissionRejectDoesNotOvertakeOrderedFrames();
     } catch (const std::exception& error) {
-        std::cerr << "RenderProfileCaptureContract: "
-                  << error.what() << '\n';
+        std::cerr << "RenderProfileCaptureContract: " << error.what() << '\n';
         return 1;
     }
-    std::cout
-        << "RenderProfileCaptureContract: all checks passed\n";
+    std::cout << "RenderProfileCaptureContract: all checks passed\n";
     return 0;
 }


### PR DESCRIPTION
## Summary
- add a stable `RenderProfileCapture` facade with generation-bound restartable sessions
- define explicit admission, stop, owner-polled drain, terminal loss/fault, and safe generation rebind semantics
- preserve already-admitted frame tokens across stop while isolating stale callbacks from newer generations
- allow resource imports after non-resource GPU profiling Scope/Query ordering prefixes without weakening prior-write validation
- add deterministic concurrency, restart, drain, loss/fault, and reorderer regression coverage

## Relationship to dev_parallel
This ports the restartable GPU capture admission/drain/rebind primitive needed before the dynamic Engine capture controller. The renderer keeps one facade address for its lifetime; each ProfileDump runtime generation binds a separate state object. UI/TCP control and expected-generation request serialization remain for Phase 21D.2a.3.

## Validation
- Debug full build + CTest: 28/28
- RelWithDebInfo full build + CTest: 28/28
- Release full build + CTest: 28/28
- RenderProfileCapture stress: Debug 100/100, Release 50/50
- Debug profile-enabled RT runtime: 248/248 GPU frames, 9,099/9,099 scopes, zero drops/errors/orphans
- RelWithDebInfo profile-enabled RT runtime: 3,906/3,906 GPU frames, 144,445/144,445 scopes, zero drops/errors/orphans
- three independent pre-PR reviews: no P0/P1/P2 findings