### PR TITLE
Phase 21D.2a.3: add Engine-owned dynamic capture controller

### DIFF
--- a/source/runtime/Engine.cpp
+++ b/source/runtime/Engine.cpp
@@ -53,6 +53,20 @@ constexpr std::uint64_t kProfileCaptureValidationMinGpuFrames = 4;
 constexpr std::uint64_t kProfileCaptureValidationMaxGtTicks   = 60000;
 constexpr auto kProfileCaptureValidationTimeout = std::chrono::seconds(180);
 
+[[nodiscard]] bool ProfileDumpTerminalIsClean(
+    const ProfileDump::RuntimeStats& _stats,
+    std::uint64_t                    _generation
+) noexcept {
+    return _stats.state == ProfileDump::RuntimeState::Stopped &&
+           _stats.last_fault == ProfileDump::RuntimeFault::None &&
+           _stats.generation == _generation &&
+           _stats.records_dropped_stopped == 0 &&
+           _stats.records_dropped_stale_generation == 0 &&
+           _stats.records_dropped_oversized == 0 &&
+           _stats.records_dropped_queue_full == 0 &&
+           _stats.records_dropped_after_fault == 0;
+}
+
 double ThreadProfileMilliseconds(
     ThreadProfileClock::time_point begin,
     ThreadProfileClock::time_point end
@@ -922,6 +936,8 @@ void Engine::TickProfileCaptureLifecycleValidation(Render::ProfileCaptureTickRes
 
         const Render::ProfileCaptureControllerSnapshot snapshot = m_profile_capture_controller->GetSnapshot();
         const Render::RenderProfileCaptureStats        stats    = m_render_profile_capture->GetStats();
+        const ProfileDump::RuntimeStats runtime_stats =
+            ProfileDump::GetRuntimeStats();
         Render::ProfileCaptureRequestCompletion        completion{};
 
         switch (m_profile_capture_lifecycle_validation_stage) {
@@ -965,7 +981,11 @@ void Engine::TickProfileCaptureLifecycleValidation(Render::ProfileCaptureTickRes
                     completion.generation != m_profile_capture_validation_first_generation ||
                     snapshot.state != Render::ProfileCaptureControllerState::Idle || snapshot.owns_runtime ||
                     snapshot.gpu_session_active || !stats.closed ||
-                    stats.generation != m_profile_capture_validation_first_generation) {
+                    stats.generation != m_profile_capture_validation_first_generation ||
+                    !ProfileDumpTerminalIsClean(
+                        runtime_stats,
+                        m_profile_capture_validation_first_generation
+                    )) {
                     FailProfileCaptureLifecycleValidation(
                         "Stop(A) did not publish a clean terminal generation"
                     );
@@ -1100,7 +1120,11 @@ void Engine::TickProfileCaptureLifecycleValidation(Render::ProfileCaptureTickRes
                     snapshot.gpu_session_active || !stats.closed ||
                     stats.generation != m_profile_capture_validation_second_generation ||
                     stats.frames_emitted < kProfileCaptureValidationMinGpuFrames ||
-                    stats.scopes_emitted == 0) {
+                    stats.scopes_emitted == 0 ||
+                    !ProfileDumpTerminalIsClean(
+                        runtime_stats,
+                        m_profile_capture_validation_second_generation
+                    )) {
                     FailProfileCaptureLifecycleValidation(
                         "Stop(B) did not publish a clean terminal generation"
                     );

--- a/source/runtime/Engine.cpp
+++ b/source/runtime/Engine.cpp
@@ -3,10 +3,6 @@
 // Runtime
 #include "config/ConfigManager.h"
 #include "misc/ScopedLogTimer.h"
-#include "profile/ProfileDump.h"
-#include "profile/ProfileDumpTemplates.h"
-#include "profile/RenderProfileCapture.h"
-#include "profile/ProfileScope.h"
 #include "remote/RemoteConfig.h"
 #include "remote/RemoteModule.h"
 #include "RenderThread.h"
@@ -52,6 +48,10 @@ static bool ContainsNonAscii(const std::filesystem::path& p);
 namespace {
 
 using ThreadProfileClock = std::chrono::steady_clock;
+
+constexpr std::uint64_t kProfileCaptureValidationMinGpuFrames = 4;
+constexpr std::uint64_t kProfileCaptureValidationMaxGtTicks   = 60000;
+constexpr auto kProfileCaptureValidationTimeout = std::chrono::seconds(180);
 
 double ThreadProfileMilliseconds(
     ThreadProfileClock::time_point begin,
@@ -342,6 +342,34 @@ bool ParseThreadingRasterLifecycleValidation(int argc, const char** argv) {
     return enabled;
 }
 
+bool ParseProfileCaptureLifecycleValidation(int argc, const char** argv) {
+    constexpr std::string_view argument_name =
+        "--profile-capture-lifecycle-validation";
+    constexpr std::string_view value_prefix =
+        "--profile-capture-lifecycle-validation=";
+
+    bool enabled = false;
+    for (int index = 1; index < argc; ++index) {
+        const std::string_view argument = argv[index];
+        if (argument.starts_with(value_prefix)) {
+            throw std::invalid_argument(
+                "--profile-capture-lifecycle-validation is a flag and does not "
+                "accept a value"
+            );
+        }
+        if (argument != argument_name) {
+            continue;
+        }
+        if (enabled) {
+            throw std::invalid_argument(
+                "--profile-capture-lifecycle-validation may be specified only once"
+            );
+        }
+        enabled = true;
+    }
+    return enabled;
+}
+
 std::optional<std::string>
 ParseThreadingRasterFramebufferValidation(int argc, const char** argv) {
     constexpr std::string_view argument_name = "--threading-raster-framebuffer-validation";
@@ -505,13 +533,24 @@ void Engine::ValidateCommandLine(int argc, const char** argv) {
         ParseThreadingRasterLifecycleValidation(argc, argv);
     const auto raster_framebuffer_validation =
         ParseThreadingRasterFramebufferValidation(argc, argv);
+    const bool profile_capture_lifecycle_validation =
+        ParseProfileCaptureLifecycleValidation(argc, argv);
     if (renderer_switch_validation && raster_lifecycle_validation) {
         throw std::invalid_argument(
             "renderer-switch and Raster lifecycle validation modes are mutually exclusive"
         );
     }
+    if (profile_capture_lifecycle_validation &&
+        (renderer_switch_validation || raster_lifecycle_validation ||
+         raster_framebuffer_validation.has_value())) {
+        throw std::invalid_argument(
+            "profile-capture lifecycle validation is mutually exclusive with "
+            "threading Raster validation modes"
+        );
+    }
     if (!renderer_switch_validation && !raster_lifecycle_validation &&
-        !raster_framebuffer_validation.has_value()) {
+        !raster_framebuffer_validation.has_value() &&
+        !profile_capture_lifecycle_validation) {
         return;
     }
 
@@ -523,16 +562,32 @@ void Engine::ValidateCommandLine(int argc, const char** argv) {
         ParseConfigOverride(argc, argv).value_or(workspace_path / "MoerEngine.toml");
     if (!std::filesystem::is_regular_file(config_path)) {
         throw std::invalid_argument(
-            "threading validation config does not exist: " +
+            "validation config does not exist: " +
             config_path.generic_string()
         );
     }
     const auto validation_config =
         Config::GlobalConfig::LoadConfigFromTomlFile(config_path.generic_string());
-    if (validation_config.engine.render.default_render_method != "Raster") {
+    if ((renderer_switch_validation || raster_lifecycle_validation ||
+         raster_framebuffer_validation.has_value()) &&
+        validation_config.engine.render.default_render_method != "Raster") {
         throw std::invalid_argument(
             "threading Raster validation requires "
             "engine.render.default_render_method = \"Raster\""
+        );
+    }
+    if (profile_capture_lifecycle_validation &&
+        !validation_config.engine.profile_dump.enabled) {
+        throw std::invalid_argument(
+            "--profile-capture-lifecycle-validation requires "
+            "engine.profile_dump.enabled = true"
+        );
+    }
+    if (profile_capture_lifecycle_validation &&
+        validation_config.engine.profile_dump.output_path.empty()) {
+        throw std::invalid_argument(
+            "--profile-capture-lifecycle-validation requires a non-empty "
+            "engine.profile_dump.output_path"
         );
     }
 }
@@ -544,7 +599,7 @@ Engine::~Engine() {
 void Engine::InitializeProfileDump() noexcept {
     const auto& profile_config =
         ConfigManager::GetInstance().GetConfig().engine.profile_dump;
-    if (!profile_config.enabled) {
+    if (!profile_config.enabled || !m_profile_capture_controller) {
         return;
     }
 
@@ -570,59 +625,65 @@ void Engine::InitializeProfileDump() noexcept {
             return;
         }
 
-        ProfileDump::RuntimeConfig runtime_config;
-        runtime_config.output_path      = output_path;
-        runtime_config.replace_existing = profile_config.replace_existing;
+        Render::ProfileCaptureStartOptions options;
+        options.runtime.output_path      = output_path;
+        options.runtime.replace_existing = profile_config.replace_existing;
 
-        const ProfileDump::StartResult start_result =
-            ProfileDump::Start(runtime_config);
-        if (start_result != ProfileDump::StartResult::Started) {
+        Render::ProfileCaptureRequestSubmission submission =
+            m_profile_capture_controller->RequestStart(std::move(options));
+        if (submission.result != Render::ProfileCaptureSubmitResult::Queued) {
             LOG_WARNING(
-                "[ProfileDump] Start failed (result={}); capture disabled.",
-                static_cast<unsigned int>(start_result)
+                "[ProfileDump] Bootstrap request rejected (result={}); capture disabled.",
+                static_cast<unsigned int>(submission.result)
             );
             return;
         }
 
-        // Ownership is acquired only for a session started by this Engine.
-        // In particular, AlreadyRunning must never adopt an external session.
-        m_profile_dump_owned = true;
-
-        const ProfileDump::SchemaRegistration cpu_scope =
-            ProfileDump::RegisterSchema(ProfileDump::Templates::CpuScope());
-        if ((cpu_scope.status != ProfileDump::SchemaStatus::Registered &&
-             cpu_scope.status != ProfileDump::SchemaStatus::AlreadyRegistered) ||
-            !cpu_scope.handle) {
+        const Render::ProfileCaptureTickResult tick_result =
+            m_profile_capture_controller->TickOwner();
+        Render::ProfileCaptureRequestCompletion completion;
+        if (tick_result == Render::ProfileCaptureTickResult::WrongThread ||
+            !submission.ticket.TryGet(completion)) {
             LOG_WARNING(
-                "[ProfileDump] CpuScope schema registration failed (status={}); "
-                "rolling back capture.",
-                static_cast<unsigned int>(cpu_scope.status)
+                "[ProfileDump] Bootstrap request did not complete synchronously "
+                "(tick_result={}); capture disabled.",
+                static_cast<unsigned int>(tick_result)
             );
-            ShutdownProfileDump();
             return;
         }
 
-        const ProfileDump::CpuScopeActivationResult activation_result =
-            ProfileDump::CpuScopeProducer::Activate(cpu_scope.handle);
-        if (activation_result != ProfileDump::CpuScopeActivationResult::Activated) {
+        const bool cpu_only =
+            completion.status == Render::ProfileCaptureCompletionStatus::StartedCpuOnly;
+        if (completion.status != Render::ProfileCaptureCompletionStatus::Started &&
+            !cpu_only) {
             LOG_WARNING(
-                "[ProfileDump] CpuScope producer activation failed (result={}); "
-                "rolling back capture.",
-                static_cast<unsigned int>(activation_result)
+                "[ProfileDump] Bootstrap start failed "
+                "(status={}, detail={}, secondary_detail={}); capture disabled.",
+                static_cast<unsigned int>(completion.status),
+                completion.detail,
+                completion.secondary_detail
             );
-            ShutdownProfileDump();
             return;
         }
 
-        InitializeRenderProfileCapture();
-
-        LOG_INFO(
-            "[ProfileDump] Capture started: output='{}', replace_existing={}.",
-            output_path.generic_string(),
-            profile_config.replace_existing
-        );
+        if (cpu_only) {
+            LOG_WARNING(
+                "[ProfileDump] CPU-only capture started because the stable GPU facade "
+                "is unavailable: generation={}, output='{}', replace_existing={}.",
+                completion.generation,
+                output_path.generic_string(),
+                profile_config.replace_existing
+            );
+        } else {
+            LOG_INFO(
+                "[ProfileDump] Capture started: generation={}, output='{}', "
+                "replace_existing={}.",
+                completion.generation,
+                output_path.generic_string(),
+                profile_config.replace_existing
+            );
+        }
     } catch (const std::exception& error) {
-        ShutdownProfileDump();
         try {
             LOG_WARNING(
                 "[ProfileDump] Capture initialization failed: {}; capture disabled.",
@@ -631,7 +692,6 @@ void Engine::InitializeProfileDump() noexcept {
         } catch (...) {
         }
     } catch (...) {
-        ShutdownProfileDump();
         try {
             LOG_WARNING("[ProfileDump] Capture initialization failed; capture disabled.");
         } catch (...) {
@@ -639,158 +699,445 @@ void Engine::InitializeProfileDump() noexcept {
     }
 }
 
-void Engine::InitializeRenderProfileCapture() noexcept {
-    if (!m_profile_dump_owned || !m_render_profile_capture || m_render_profile_capture->Valid()) {
+void Engine::InitializeProfileCaptureLifecycleValidation() noexcept {
+    if (!m_profile_capture_lifecycle_validation_enabled) {
+        m_profile_capture_lifecycle_validation_stage =
+            EProfileCaptureLifecycleValidationStage::Disabled;
         return;
     }
 
     try {
-        const ProfileDump::SchemaRegistration gpu_frame =
-            ProfileDump::RegisterSchema(ProfileDump::Templates::GpuFrame());
-        if ((gpu_frame.status != ProfileDump::SchemaStatus::Registered &&
-             gpu_frame.status != ProfileDump::SchemaStatus::AlreadyRegistered) ||
-            !gpu_frame.handle) {
-            LOG_WARNING(
-                "[ProfileDump] GpuFrame schema registration failed "
-                "(status={}); GPU capture disabled.",
-                static_cast<unsigned int>(gpu_frame.status)
+        if (!m_profile_capture_controller || !m_render_profile_capture) {
+            FailProfileCaptureLifecycleValidation(
+                "Engine did not create both the capture controller and stable GPU facade"
             );
             return;
         }
 
-        const ProfileDump::SchemaRegistration gpu_scope =
-            ProfileDump::RegisterSchema(ProfileDump::Templates::GpuScope());
-        if ((gpu_scope.status != ProfileDump::SchemaStatus::Registered &&
-             gpu_scope.status != ProfileDump::SchemaStatus::AlreadyRegistered) ||
-            !gpu_scope.handle) {
-            LOG_WARNING(
-                "[ProfileDump] GpuScope schema registration failed "
-                "(status={}); GPU capture disabled.",
-                static_cast<unsigned int>(gpu_scope.status)
+        const Render::ProfileCaptureControllerSnapshot snapshot =
+            m_profile_capture_controller->GetSnapshot();
+        const Render::RenderProfileCaptureStats stats =
+            m_render_profile_capture->GetStats();
+        if (snapshot.state != Render::ProfileCaptureControllerState::Running ||
+            !snapshot.owns_runtime || !snapshot.cpu_producer_active ||
+            !snapshot.gpu_session_active || snapshot.active_generation == 0 ||
+            !m_render_profile_capture->Valid() || !stats.accepting ||
+            stats.generation != snapshot.active_generation) {
+            FailProfileCaptureLifecycleValidation(
+                "bootstrap did not produce a GPU-capable Running generation"
             );
             return;
         }
 
-        const Render::RenderProfileSessionStartResult start_result =
-            m_render_profile_capture->StartSession(gpu_frame.handle, gpu_scope.handle);
-        if (start_result != Render::RenderProfileSessionStartResult::Started) {
-            LOG_WARNING(
-                "[ProfileDump] GPU capture bridge rejected the current "
-                "schema generation (result={}); GPU capture disabled.",
-                static_cast<unsigned int>(start_result)
+        const auto& profile_config =
+            ConfigManager::GetInstance().GetConfig().engine.profile_dump;
+        std::filesystem::path output_path(profile_config.output_path);
+        if (output_path.is_relative()) {
+            output_path =
+                ConfigManager::GetInstance().GetWorkspacePath() / output_path;
+        }
+
+        std::error_code path_error;
+        output_path = std::filesystem::weakly_canonical(output_path, path_error);
+        if (path_error || output_path.empty()) {
+            FailProfileCaptureLifecycleValidation(
+                "bootstrap output path could not be resolved for restart"
             );
             return;
         }
-        LOG_INFO(
-            "[ProfileDump] GPU capture bridge initialized "
-            "(generation={}).",
-            gpu_frame.handle.generation
-        );
-    } catch (const std::exception& error) {
-        try {
-            LOG_WARNING(
-                "[ProfileDump] GPU capture bridge initialization failed: "
-                "{}; CPU capture remains enabled.",
-                error.what()
-            );
-        } catch (...) {
-        }
-    } catch (...) {
-        try {
-            LOG_WARNING("[ProfileDump] GPU capture bridge initialization failed; "
-                        "CPU capture remains enabled.");
-        } catch (...) {
-        }
-    }
-}
 
-void Engine::ShutdownRenderProfileCapture(bool _rhi_drained) noexcept {
-    Render::RenderProfileCapture* capture = m_render_profile_capture.get();
-    if (capture == nullptr) {
-        return;
-    }
-    const Render::RenderProfileCaptureStats before_shutdown = capture->GetStats();
-    if (before_shutdown.generation == 0) {
-        return;
-    }
-
-    if (_rhi_drained) {
-        capture->ShutdownAfterRhiDrain();
-    } else {
-        capture->Abort();
-    }
-    const Render::RenderProfileCaptureStats stats = capture->GetStats();
-
-    try {
-        if (!_rhi_drained || stats.shutdown_abandoned_frames != 0 || stats.terminal_faults != 0 ||
-            stats.frames_admission_rejected != 0 || stats.frame_records_dropped != 0 ||
-            stats.scope_records_dropped != 0) {
-            LOG_WARNING(
-                "[ProfileDump] GPU capture bridge stopped "
-                "(rhi_drained={}, emitted_frames={}, emitted_scopes={}, "
-                "admission_rejects={}, frame_drops={}, scope_drops={}, "
-                "abandoned_frames={}, terminal_faults={}).",
-                _rhi_drained,
-                stats.frames_emitted,
-                stats.scopes_emitted,
-                stats.frames_admission_rejected,
-                stats.frame_records_dropped,
-                stats.scope_records_dropped,
-                stats.shutdown_abandoned_frames,
-                stats.terminal_faults
-            );
+        const std::string extension = output_path.extension().string();
+        std::string       restart_filename;
+        if (extension.empty()) {
+            restart_filename = output_path.filename().string() + ".restart";
         } else {
-            LOG_INFO(
-                "[ProfileDump] GPU capture bridge drained "
-                "(frames={}, scopes={}, frame_drops={}, scope_drops={}).",
-                stats.frames_emitted,
-                stats.scopes_emitted,
-                stats.frame_records_dropped,
-                stats.scope_records_dropped
-            );
+            restart_filename =
+                output_path.stem().string() + ".restart" + extension;
         }
+        std::filesystem::path restart_path =
+            output_path.parent_path() / restart_filename;
+        if (restart_path == output_path) {
+            FailProfileCaptureLifecycleValidation(
+                "restart output path aliases the bootstrap output path"
+            );
+            return;
+        }
+
+        m_profile_capture_validation_restart_options = {};
+        m_profile_capture_validation_restart_options.runtime.output_path =
+            std::move(restart_path);
+        // Validation must be repeatable without requiring callers to clean a
+        // previous successful restart artifact.
+        m_profile_capture_validation_restart_options.runtime.replace_existing =
+            true;
+        m_profile_capture_validation_first_generation =
+            snapshot.active_generation;
+        m_profile_capture_validation_second_generation = 0;
+        m_profile_capture_validation_gt_ticks          = 0;
+        m_profile_capture_validation_ticket            = {};
+        m_profile_capture_validation_deadline =
+            std::chrono::steady_clock::now() +
+            kProfileCaptureValidationTimeout;
+        m_profile_capture_lifecycle_validation_stage =
+            EProfileCaptureLifecycleValidationStage::
+                WaitingForFirstGenerationFrames;
+
+        LOG_INFO(
+            "[ProfileCaptureValidation] Enabled on the Game Thread: "
+            "generation_a={}, restart_output='{}', required_gpu_frames={}, "
+            "timeout_seconds={}, max_gt_ticks={}, stable_facade={}.",
+            m_profile_capture_validation_first_generation,
+            m_profile_capture_validation_restart_options.runtime.output_path
+                .generic_string(),
+            kProfileCaptureValidationMinGpuFrames,
+            std::chrono::duration_cast<std::chrono::seconds>(
+                kProfileCaptureValidationTimeout
+            ).count(),
+            kProfileCaptureValidationMaxGtTicks,
+            static_cast<const void*>(m_render_profile_capture.get())
+        );
     } catch (...) {
+        FailProfileCaptureLifecycleValidation(
+            "unexpected exception while arming validation"
+        );
     }
 }
 
-void Engine::ShutdownProfileDump() noexcept {
-    // Defensive rollback path. Normal shutdown has already drained and closed
-    // the facade's current session after RHI Completion joined.
+void Engine::FailProfileCaptureLifecycleValidation(
+    std::string_view reason
+) noexcept {
+    if (!m_profile_capture_lifecycle_validation_enabled ||
+        m_profile_capture_lifecycle_validation_stage ==
+            EProfileCaptureLifecycleValidationStage::Complete ||
+        m_profile_capture_lifecycle_validation_stage ==
+            EProfileCaptureLifecycleValidationStage::Failed) {
+        return;
+    }
+
+    Render::ProfileCaptureControllerSnapshot snapshot{};
+    Render::RenderProfileCaptureStats         stats{};
+    if (m_profile_capture_controller) {
+        snapshot = m_profile_capture_controller->GetSnapshot();
+    }
     if (m_render_profile_capture) {
-        const Render::RenderProfileCaptureStats bridge_stats = m_render_profile_capture->GetStats();
-        if (bridge_stats.generation != 0 && !bridge_stats.closed) {
-            ShutdownRenderProfileCapture(false);
-        }
-    }
-    if (!m_profile_dump_owned) {
-        return;
-    }
-    m_profile_dump_owned = false;
-
-    ProfileDump::CpuScopeProducer::Deactivate();
-    const ProfileDump::FlushResult    flush_result    = ProfileDump::FlushThreadLocal();
-    const ProfileDump::ShutdownResult shutdown_result = ProfileDump::Shutdown();
-
-    if (shutdown_result == ProfileDump::ShutdownResult::Faulted) {
-        const ProfileDump::RuntimeStats stats = ProfileDump::GetRuntimeStats();
-        try {
-            LOG_WARNING(
-                "[ProfileDump] Capture shutdown faulted (fault={}, flush_result={}).",
-                static_cast<unsigned int>(stats.last_fault),
-                static_cast<unsigned int>(flush_result)
-            );
-        } catch (...) {
-        }
-        return;
+        stats = m_render_profile_capture->GetStats();
     }
 
     try {
-        LOG_INFO(
-            "[ProfileDump] Capture stopped (shutdown_result={}, flush_result={}).",
-            static_cast<unsigned int>(shutdown_result),
-            static_cast<unsigned int>(flush_result)
+        LOG_ERROR(
+            "[ProfileCaptureValidation][FAIL] reason='{}', stage={}, "
+            "gt_ticks={}, controller_state={}, generation={}, owns_runtime={}, "
+            "gpu_session_active={}, facade_generation={}, facade_accepting={}, "
+            "frames={}, scopes={}.",
+            reason,
+            static_cast<unsigned int>(
+                m_profile_capture_lifecycle_validation_stage
+            ),
+            m_profile_capture_validation_gt_ticks,
+            static_cast<unsigned int>(snapshot.state),
+            snapshot.active_generation,
+            snapshot.owns_runtime,
+            snapshot.gpu_session_active,
+            stats.generation,
+            stats.accepting,
+            stats.frames_emitted,
+            stats.scopes_emitted
         );
     } catch (...) {
+    }
+
+    m_profile_capture_lifecycle_validation_stage =
+        EProfileCaptureLifecycleValidationStage::Failed;
+    if (m_window_context_initialized &&
+        !m_profile_capture_validation_exit_requested) {
+        m_profile_capture_validation_exit_requested = true;
+        try {
+            RequestExit();
+        } catch (...) {
+        }
+    }
+}
+
+void Engine::TickProfileCaptureLifecycleValidation(Render::ProfileCaptureTickResult tick_result) noexcept {
+    assert(IsCurrentlyGameThread());
+    try {
+        if (!m_profile_capture_lifecycle_validation_enabled ||
+            m_profile_capture_lifecycle_validation_stage ==
+                EProfileCaptureLifecycleValidationStage::Disabled ||
+            m_profile_capture_lifecycle_validation_stage ==
+                EProfileCaptureLifecycleValidationStage::Complete) {
+            return;
+        }
+        if (m_profile_capture_lifecycle_validation_stage == EProfileCaptureLifecycleValidationStage::Failed) {
+            if (!m_profile_capture_validation_exit_requested) {
+                m_profile_capture_validation_exit_requested = true;
+                try {
+                    RequestExit();
+                } catch (...) {
+                }
+            }
+            return;
+        }
+
+        ++m_profile_capture_validation_gt_ticks;
+        if (tick_result == Render::ProfileCaptureTickResult::WrongThread) {
+            FailProfileCaptureLifecycleValidation("controller TickOwner did not run on its Game Thread owner"
+            );
+            return;
+        }
+        if (tick_result == Render::ProfileCaptureTickResult::Shutdown) {
+            FailProfileCaptureLifecycleValidation("controller shut down before validation completed");
+            return;
+        }
+        if (m_profile_capture_validation_gt_ticks > kProfileCaptureValidationMaxGtTicks ||
+            std::chrono::steady_clock::now() > m_profile_capture_validation_deadline) {
+            FailProfileCaptureLifecycleValidation("bounded Game Thread validation timeout expired");
+            return;
+        }
+        if (!m_profile_capture_controller || !m_render_profile_capture) {
+            FailProfileCaptureLifecycleValidation("controller or stable GPU facade disappeared");
+            return;
+        }
+
+        const auto live_generation_matches = [this](
+                                                 const Render::ProfileCaptureControllerSnapshot& snapshot,
+                                                 const Render::RenderProfileCaptureStats&        stats,
+                                                 std::uint64_t                                   generation
+                                             ) noexcept {
+            return generation != 0 && snapshot.state == Render::ProfileCaptureControllerState::Running &&
+                   snapshot.owns_runtime && snapshot.cpu_producer_active && snapshot.gpu_session_active &&
+                   snapshot.active_generation == generation && m_render_profile_capture->Valid() &&
+                   stats.accepting && !stats.closed && stats.generation == generation;
+        };
+        const auto accept_submission =
+            [this](Render::ProfileCaptureRequestSubmission&& submission, std::string_view failure) noexcept {
+                if (submission.result != Render::ProfileCaptureSubmitResult::Queued ||
+                    !submission.ticket.Valid()) {
+                    FailProfileCaptureLifecycleValidation(failure);
+                    return false;
+                }
+                m_profile_capture_validation_ticket = std::move(submission.ticket);
+                return true;
+            };
+
+        const Render::ProfileCaptureControllerSnapshot snapshot = m_profile_capture_controller->GetSnapshot();
+        const Render::RenderProfileCaptureStats        stats    = m_render_profile_capture->GetStats();
+        Render::ProfileCaptureRequestCompletion        completion{};
+
+        switch (m_profile_capture_lifecycle_validation_stage) {
+            case EProfileCaptureLifecycleValidationStage::WaitingForFirstGenerationFrames: {
+                if (!live_generation_matches(
+                        snapshot, stats, m_profile_capture_validation_first_generation
+                    )) {
+                    FailProfileCaptureLifecycleValidation("generation A left GPU-capable Running state");
+                    return;
+                }
+                if (!m_first_main_present_notified ||
+                    stats.frames_emitted < kProfileCaptureValidationMinGpuFrames ||
+                    stats.scopes_emitted == 0) {
+                    return;
+                }
+
+                if (!accept_submission(
+                        RequestProfileCaptureStop(m_profile_capture_validation_first_generation),
+                        "Stop(A) request was not admitted"
+                    )) {
+                    return;
+                }
+                m_profile_capture_lifecycle_validation_stage =
+                    EProfileCaptureLifecycleValidationStage::WaitingForFirstStop;
+                LOG_INFO(
+                    "[ProfileCaptureValidation] generation A ran on GPU "
+                    "(generation={}, frames={}, scopes={}); Stop(A) queued after "
+                    "the controller tick and must complete on a later GT tick.",
+                    m_profile_capture_validation_first_generation,
+                    stats.frames_emitted,
+                    stats.scopes_emitted
+                );
+                return;
+            }
+
+            case EProfileCaptureLifecycleValidationStage::WaitingForFirstStop: {
+                if (!m_profile_capture_validation_ticket.TryGet(completion)) {
+                    return;
+                }
+                if (completion.status != Render::ProfileCaptureCompletionStatus::Stopped ||
+                    completion.generation != m_profile_capture_validation_first_generation ||
+                    snapshot.state != Render::ProfileCaptureControllerState::Idle || snapshot.owns_runtime ||
+                    snapshot.gpu_session_active || !stats.closed ||
+                    stats.generation != m_profile_capture_validation_first_generation) {
+                    FailProfileCaptureLifecycleValidation(
+                        "Stop(A) did not publish a clean terminal generation"
+                    );
+                    return;
+                }
+
+                LOG_INFO(
+                    "[ProfileCaptureValidation] Stop(A) terminal on a later GT "
+                    "tick: generation={}, status={}, frames={}, scopes={}.",
+                    completion.generation,
+                    static_cast<unsigned int>(completion.status),
+                    stats.frames_emitted,
+                    stats.scopes_emitted
+                );
+                if (!accept_submission(
+                        RequestProfileCaptureStart(m_profile_capture_validation_restart_options),
+                        "Start(B) request was not admitted"
+                    )) {
+                    return;
+                }
+                m_profile_capture_lifecycle_validation_stage =
+                    EProfileCaptureLifecycleValidationStage::WaitingForRestart;
+                LOG_INFO(
+                    "[ProfileCaptureValidation] Start(B) queued after the "
+                    "controller tick: output='{}'.",
+                    m_profile_capture_validation_restart_options.runtime.output_path.generic_string()
+                );
+                return;
+            }
+
+            case EProfileCaptureLifecycleValidationStage::WaitingForRestart: {
+                if (!m_profile_capture_validation_ticket.TryGet(completion)) {
+                    return;
+                }
+                if (completion.status != Render::ProfileCaptureCompletionStatus::Started ||
+                    completion.generation <= m_profile_capture_validation_first_generation ||
+                    !live_generation_matches(snapshot, stats, completion.generation)) {
+                    FailProfileCaptureLifecycleValidation(
+                        "Start(B) did not bind a newer GPU-capable generation"
+                    );
+                    return;
+                }
+
+                m_profile_capture_validation_second_generation = completion.generation;
+                LOG_INFO(
+                    "[ProfileCaptureValidation] Start(B) completed on a later GT "
+                    "tick: generation_a={}, generation_b={}, status={}, "
+                    "stable_facade={}.",
+                    m_profile_capture_validation_first_generation,
+                    m_profile_capture_validation_second_generation,
+                    static_cast<unsigned int>(completion.status),
+                    static_cast<const void*>(m_render_profile_capture.get())
+                );
+                if (!accept_submission(
+                        RequestProfileCaptureStop(m_profile_capture_validation_first_generation),
+                        "stale Stop(A) request was not admitted"
+                    )) {
+                    return;
+                }
+                m_profile_capture_lifecycle_validation_stage =
+                    EProfileCaptureLifecycleValidationStage::WaitingForStaleStop;
+                LOG_INFO("[ProfileCaptureValidation] stale Stop(A) queued against "
+                         "running generation B; it must be rejected on a later GT tick.");
+                return;
+            }
+
+            case EProfileCaptureLifecycleValidationStage::WaitingForStaleStop: {
+                if (!m_profile_capture_validation_ticket.TryGet(completion)) {
+                    return;
+                }
+                if (completion.status != Render::ProfileCaptureCompletionStatus::RejectedStaleGeneration ||
+                    completion.generation != m_profile_capture_validation_second_generation ||
+                    !live_generation_matches(
+                        snapshot, stats, m_profile_capture_validation_second_generation
+                    )) {
+                    FailProfileCaptureLifecycleValidation(
+                        "stale Stop(A) mutated or failed to protect generation B"
+                    );
+                    return;
+                }
+
+                LOG_INFO(
+                    "[ProfileCaptureValidation] stale Stop(A) rejected on a later "
+                    "GT tick: protected_generation={}, status={}; generation B "
+                    "remains GPU-capable Running.",
+                    completion.generation,
+                    static_cast<unsigned int>(completion.status)
+                );
+                m_profile_capture_lifecycle_validation_stage =
+                    EProfileCaptureLifecycleValidationStage::WaitingForSecondGenerationFrames;
+                return;
+            }
+
+            case EProfileCaptureLifecycleValidationStage::WaitingForSecondGenerationFrames: {
+                if (!live_generation_matches(
+                        snapshot, stats, m_profile_capture_validation_second_generation
+                    )) {
+                    FailProfileCaptureLifecycleValidation("generation B left GPU-capable Running state");
+                    return;
+                }
+                if (stats.frames_emitted < kProfileCaptureValidationMinGpuFrames ||
+                    stats.scopes_emitted == 0) {
+                    return;
+                }
+
+                if (!accept_submission(
+                        RequestProfileCaptureStop(m_profile_capture_validation_second_generation),
+                        "Stop(B) request was not admitted"
+                    )) {
+                    return;
+                }
+                m_profile_capture_lifecycle_validation_stage =
+                    EProfileCaptureLifecycleValidationStage::WaitingForSecondStop;
+                LOG_INFO(
+                    "[ProfileCaptureValidation] generation B ran on GPU "
+                    "(generation={}, frames={}, scopes={}); Stop(B) queued after "
+                    "the controller tick.",
+                    m_profile_capture_validation_second_generation,
+                    stats.frames_emitted,
+                    stats.scopes_emitted
+                );
+                return;
+            }
+
+            case EProfileCaptureLifecycleValidationStage::WaitingForSecondStop: {
+                if (!m_profile_capture_validation_ticket.TryGet(completion)) {
+                    return;
+                }
+                if (completion.status != Render::ProfileCaptureCompletionStatus::Stopped ||
+                    completion.generation != m_profile_capture_validation_second_generation ||
+                    snapshot.state != Render::ProfileCaptureControllerState::Idle || snapshot.owns_runtime ||
+                    snapshot.gpu_session_active || !stats.closed ||
+                    stats.generation != m_profile_capture_validation_second_generation ||
+                    stats.frames_emitted < kProfileCaptureValidationMinGpuFrames ||
+                    stats.scopes_emitted == 0) {
+                    FailProfileCaptureLifecycleValidation(
+                        "Stop(B) did not publish a clean terminal generation"
+                    );
+                    return;
+                }
+
+                m_profile_capture_lifecycle_validation_stage =
+                    EProfileCaptureLifecycleValidationStage::Complete;
+                LOG_INFO(
+                    "[ProfileCaptureValidation][PASS] dynamic GPU capture "
+                    "lifecycle completed on the Game Thread: generation_a={}, "
+                    "generation_b={}, generation_b_frames={}, "
+                    "generation_b_scopes={}, gt_ticks={}, stable_facade={}.",
+                    m_profile_capture_validation_first_generation,
+                    m_profile_capture_validation_second_generation,
+                    stats.frames_emitted,
+                    stats.scopes_emitted,
+                    m_profile_capture_validation_gt_ticks,
+                    static_cast<const void*>(m_render_profile_capture.get())
+                );
+                if (!m_profile_capture_validation_exit_requested) {
+                    m_profile_capture_validation_exit_requested = true;
+                    try {
+                        RequestExit();
+                    } catch (...) {
+                    }
+                }
+                return;
+            }
+
+            case EProfileCaptureLifecycleValidationStage::Disabled:
+            case EProfileCaptureLifecycleValidationStage::Complete:
+            case EProfileCaptureLifecycleValidationStage::Failed:
+                return;
+        }
+    } catch (...) {
+        FailProfileCaptureLifecycleValidation("unexpected exception while advancing validation");
     }
 }
 
@@ -854,6 +1201,8 @@ void Engine::Init(
         ParseThreadingRasterLifecycleValidation(argc, argv);
     const auto raster_framebuffer_validation =
         ParseThreadingRasterFramebufferValidation(argc, argv);
+    m_profile_capture_lifecycle_validation_enabled =
+        ParseProfileCaptureLifecycleValidation(argc, argv);
     const uint submission_batch_window =
         RHISubmissionPipelinePolicy::ClampBatchWindow(
             config.engine.threading.submission_batch_window
@@ -871,12 +1220,28 @@ void Engine::Init(
             "renderer-switch and Raster lifecycle validation modes are mutually exclusive"
         );
     }
+    if (m_profile_capture_lifecycle_validation_enabled &&
+        (renderer_switch_validation_enabled ||
+         raster_lifecycle_validation_enabled ||
+         raster_framebuffer_validation.has_value())) {
+        throw std::invalid_argument(
+            "profile-capture lifecycle validation is mutually exclusive with "
+            "threading Raster validation modes"
+        );
+    }
     if ((renderer_switch_validation_enabled || raster_lifecycle_validation_enabled ||
          raster_framebuffer_validation.has_value()) &&
         config.engine.render.default_render_method != "Raster") {
         throw std::invalid_argument(
             "threading Raster validation requires "
             "engine.render.default_render_method = \"Raster\""
+        );
+    }
+    if (m_profile_capture_lifecycle_validation_enabled &&
+        !config.engine.profile_dump.enabled) {
+        throw std::invalid_argument(
+            "--profile-capture-lifecycle-validation requires "
+            "engine.profile_dump.enabled = true"
         );
     }
 
@@ -893,7 +1258,21 @@ void Engine::Init(
         } catch (...) {
         }
     }
+    try {
+        m_profile_capture_controller =
+            MakeUnique<Render::ProfileCaptureController>(m_render_profile_capture.get());
+    } catch (...) {
+        m_profile_capture_controller.reset();
+        try {
+            LOG_WARNING(
+                "[ProfileDump] Failed to allocate the Engine-owned capture controller; "
+                "dynamic capture will remain disabled."
+            );
+        } catch (...) {
+        }
+    }
     InitializeProfileDump();
+    InitializeProfileCaptureLifecycleValidation();
 
     // Init TaskSystem
     report_startup("Starting worker services", "Creating task-graph worker threads");
@@ -1081,6 +1460,22 @@ void Engine::Run(const EngineHooks& hooks) {
         };
     const bool thread_profile_logging =
         ConfigManager::GetInstance().GetConfig().engine.threading.profile_logging;
+    auto on_tick_engine_control = std::move(runtime_hooks.on_tick_engine_control);
+    runtime_hooks.on_tick_engine_control =
+        [this, callback = std::move(on_tick_engine_control)]() {
+            Render::ProfileCaptureTickResult capture_tick_result =
+                Render::ProfileCaptureTickResult::Shutdown;
+            if (m_profile_capture_controller) {
+                capture_tick_result =
+                    m_profile_capture_controller->TickOwner();
+            }
+            if (m_profile_capture_lifecycle_validation_enabled) {
+                TickProfileCaptureLifecycleValidation(capture_tick_result);
+            }
+            if (callback) {
+                callback();
+            }
+        };
     runtime_hooks.on_tick_scripting = [this](Scene& scene) {
         if (m_script_host) {
             m_script_host->ProcessMainThreadCommands(scene);
@@ -1417,9 +1812,52 @@ scripting::ScriptExecutionFuture Engine::SubmitScriptExecution(scripting::Script
     return scripting::ScriptExecutionFuture(promise.get_future());
 }
 
+Render::ProfileCaptureRequestSubmission
+Engine::RequestProfileCaptureStart(Render::ProfileCaptureStartOptions options) noexcept {
+    if (!m_profile_capture_controller) {
+        return {
+            .result = Render::ProfileCaptureSubmitResult::AdmissionClosed,
+            .ticket = {},
+        };
+    }
+    return m_profile_capture_controller->RequestStart(std::move(options));
+}
+
+Render::ProfileCaptureRequestSubmission
+Engine::RequestProfileCaptureStop(std::uint64_t expected_generation) noexcept {
+    if (!m_profile_capture_controller) {
+        return {
+            .result = Render::ProfileCaptureSubmitResult::AdmissionClosed,
+            .ticket = {},
+        };
+    }
+    return m_profile_capture_controller->RequestStop(expected_generation);
+}
+
+Render::ProfileCaptureControllerSnapshot Engine::GetProfileCaptureSnapshot() const noexcept {
+    if (m_profile_capture_controller) {
+        return m_profile_capture_controller->GetSnapshot();
+    }
+    Render::ProfileCaptureControllerSnapshot snapshot;
+    snapshot.state              = Render::ProfileCaptureControllerState::Shutdown;
+    snapshot.accepting_requests = false;
+    return snapshot;
+}
+
 void Engine::ShutDown() noexcept {
     if (m_has_shutdown) {
         return;
+    }
+    if (m_profile_capture_lifecycle_validation_enabled &&
+        m_profile_capture_lifecycle_validation_stage !=
+            EProfileCaptureLifecycleValidationStage::Complete &&
+        m_profile_capture_lifecycle_validation_stage !=
+            EProfileCaptureLifecycleValidationStage::Failed &&
+        m_profile_capture_lifecycle_validation_stage !=
+            EProfileCaptureLifecycleValidationStage::Disabled) {
+        FailProfileCaptureLifecycleValidation(
+            "Engine shutdown began before validation reached PASS"
+        );
     }
     m_has_shutdown = true;
 
@@ -1431,6 +1869,61 @@ void Engine::ShutDown() noexcept {
             // releasing later subsystems even if one cleanup operation fails.
         }
     };
+    bool capture_shutdown_trace_enabled =
+        m_profile_capture_lifecycle_validation_enabled;
+    if (m_profile_capture_controller) {
+        const Render::ProfileCaptureControllerSnapshot snapshot =
+            m_profile_capture_controller->GetSnapshot();
+        capture_shutdown_trace_enabled =
+            capture_shutdown_trace_enabled || snapshot.owns_runtime ||
+            snapshot.active_generation != 0;
+    }
+    const auto report_capture_boundary =
+        [this, capture_shutdown_trace_enabled](
+            std::string_view                     boundary,
+            Render::ProfileCaptureLifecycleResult result
+        ) noexcept {
+            if (result == Render::ProfileCaptureLifecycleResult::Advanced ||
+                result == Render::ProfileCaptureLifecycleResult::AlreadyAtBoundary) {
+                if (capture_shutdown_trace_enabled &&
+                    m_profile_capture_controller) {
+                    const Render::ProfileCaptureControllerSnapshot snapshot =
+                        m_profile_capture_controller->GetSnapshot();
+                    try {
+                        LOG_INFO(
+                            "[ProfileCapture][Shutdown] boundary='{}' complete "
+                            "(result={}, controller_state={}, generation={}, "
+                            "owns_runtime={}, gpu_session_active={}).",
+                            boundary,
+                            static_cast<unsigned int>(result),
+                            static_cast<unsigned int>(snapshot.state),
+                            snapshot.active_generation,
+                            snapshot.owns_runtime,
+                            snapshot.gpu_session_active
+                        );
+                    } catch (...) {
+                    }
+                }
+                return;
+            }
+            try {
+                LOG_WARNING(
+                    "[ProfileCapture][Shutdown] Capture controller failed the "
+                    "'{}' boundary "
+                    "(result={}); its generation-guarded destructor fallback will run.",
+                    boundary,
+                    static_cast<unsigned int>(result)
+                );
+            } catch (...) {
+            }
+        };
+
+    if (m_profile_capture_controller) {
+        report_capture_boundary(
+            "request-admission-before-renderer",
+            m_profile_capture_controller->BeginEngineShutdown()
+        );
+    }
 
     if (m_remote_module) {
         cleanup([this]() { m_remote_module->Stop(); });
@@ -1485,12 +1978,62 @@ void Engine::ShutDown() noexcept {
             rhi_drained = false;
         }
     }
-    ShutdownRenderProfileCapture(rhi_drained);
+    if (m_profile_capture_controller) {
+        report_capture_boundary(
+            rhi_drained ? "gpu-finalization-after-rhi-drain" :
+                          "gpu-abort-after-rhi-drain-failure",
+            m_profile_capture_controller->FinalizeGpuAfterRhiDrain(rhi_drained)
+        );
+    }
+    bool task_workers_joined = !m_task_system_initialized;
     if (m_task_system_initialized) {
         m_task_system_initialized = false;
-        cleanup([]() { TaskSystem::ShutDown(); });
+        if (capture_shutdown_trace_enabled) {
+            try {
+                LOG_INFO(
+                    "[ProfileCapture][Shutdown] TaskSystem worker shutdown "
+                    "begins after the GPU post-RHI boundary."
+                );
+            } catch (...) {
+            }
+        }
+        try {
+            TaskSystem::ShutDown();
+            task_workers_joined = true;
+        } catch (...) {
+            task_workers_joined = false;
+        }
     }
-    ShutdownProfileDump();
+    if (capture_shutdown_trace_enabled) {
+        try {
+            if (task_workers_joined) {
+                LOG_INFO(
+                    "[ProfileCapture][Shutdown] TaskSystem workers joined; "
+                    "ProfileDump runtime finalization may begin."
+                );
+            } else {
+                LOG_WARNING(
+                    "[ProfileCapture][Shutdown] TaskSystem worker shutdown "
+                    "failed before ProfileDump runtime finalization."
+                );
+            }
+        } catch (...) {
+        }
+    }
+    if (m_profile_capture_controller) {
+        if (task_workers_joined) {
+            report_capture_boundary(
+                "profiledump-finalization-after-workers",
+                m_profile_capture_controller->FinalizeRuntimeAfterWorkers()
+            );
+        } else {
+            report_capture_boundary(
+                "profiledump-abandoned-after-worker-failure",
+                m_profile_capture_controller
+                    ->AbandonRuntimeAfterWorkerShutdownFailure()
+            );
+        }
+    }
     m_editor_config.reset();
 }
 

--- a/source/runtime/Engine.h
+++ b/source/runtime/Engine.h
@@ -1,10 +1,14 @@
 #pragma once
 
+#include "ProfileCaptureController.h"
 #include "remote/RemoteModuleController.h"
 #include "renderer/Renderer.h"
 #include "scripting/ScriptExecutionFuture.h"
 #include "scripting/ScriptExecutionRequest.h"
 
+#include <chrono>
+#include <cstdint>
+#include <string>
 #include <string_view>
 
 namespace Moer::scripting {
@@ -20,9 +24,6 @@ namespace Moer {
 class EditorUI;
 class RuntimeAssets;
 class RenderThreadService;
-namespace Render {
-class RenderProfileCapture;
-}
 
 class RENDER_API Engine {
 public:
@@ -47,6 +48,12 @@ public:
     remote::RemoteModuleController GetRemoteModuleController() const;
 
     scripting::ScriptExecutionFuture SubmitScriptExecution(scripting::ScriptExecutionRequest request);
+    [[nodiscard]] Render::ProfileCaptureRequestSubmission
+    RequestProfileCaptureStart(Render::ProfileCaptureStartOptions options) noexcept;
+    [[nodiscard]] Render::ProfileCaptureRequestSubmission
+    RequestProfileCaptureStop(std::uint64_t expected_generation) noexcept;
+    [[nodiscard]] Render::ProfileCaptureControllerSnapshot
+    GetProfileCaptureSnapshot() const noexcept;
     void                             ShutDown() noexcept;
 
     uint2& GetResolution() {
@@ -68,12 +75,26 @@ private:
         Failed,
     };
 
+    enum class EProfileCaptureLifecycleValidationStage : uint8 {
+        Disabled,
+        WaitingForFirstGenerationFrames,
+        WaitingForFirstStop,
+        WaitingForRestart,
+        WaitingForStaleStop,
+        WaitingForSecondGenerationFrames,
+        WaitingForSecondStop,
+        Complete,
+        Failed,
+    };
+
     void Init3rdParty();
     void ShutDown3rdParty();
     void InitializeProfileDump() noexcept;
-    void InitializeRenderProfileCapture() noexcept;
-    void ShutdownRenderProfileCapture(bool rhi_drained) noexcept;
-    void ShutdownProfileDump() noexcept;
+    void InitializeProfileCaptureLifecycleValidation() noexcept;
+    void TickProfileCaptureLifecycleValidation(
+        Render::ProfileCaptureTickResult tick_result
+    ) noexcept;
+    void FailProfileCaptureLifecycleValidation(std::string_view reason) noexcept;
 
     void TickRendererSwitchValidation(Scene& scene);
     void TickRasterLifecycleValidation(Scene& scene);
@@ -87,6 +108,7 @@ private:
     UniquePtr<Render::Renderer>      m_renderer;
     UniquePtr<RenderThreadService>   m_render_thread_service;
     UniquePtr<Render::RenderProfileCapture> m_render_profile_capture;
+    UniquePtr<Render::ProfileCaptureController> m_profile_capture_controller;
 
     uint m_max_frame_lag = 0;
     bool m_has_shutdown = false;
@@ -95,7 +117,6 @@ private:
     bool m_render_device_initialized   = false;
     bool m_shader_manager_initialized  = false;
     bool m_window_context_initialized  = false;
-    bool m_profile_dump_owned          = false;
 
     // Validation state is accessed only by Game Thread hooks. Render work is drained before reload.
     ERendererSwitchValidationStage m_renderer_switch_validation_stage =
@@ -104,6 +125,19 @@ private:
     bool m_renderer_switch_validation_reload_requested = false;
     bool m_raster_lifecycle_validation_enabled = false;
     uint m_raster_lifecycle_validation_ready_frames = 0;
+
+    bool m_profile_capture_lifecycle_validation_enabled = false;
+    bool m_profile_capture_validation_exit_requested    = false;
+    EProfileCaptureLifecycleValidationStage
+        m_profile_capture_lifecycle_validation_stage =
+            EProfileCaptureLifecycleValidationStage::Disabled;
+    Render::ProfileCaptureRequestTicket m_profile_capture_validation_ticket;
+    Render::ProfileCaptureStartOptions  m_profile_capture_validation_restart_options;
+    std::uint64_t m_profile_capture_validation_first_generation  = 0;
+    std::uint64_t m_profile_capture_validation_second_generation = 0;
+    std::uint64_t m_profile_capture_validation_gt_ticks          = 0;
+    std::chrono::steady_clock::time_point
+        m_profile_capture_validation_deadline{};
 };
 
 } // namespace Moer

--- a/source/runtime/ProfileCaptureController.cpp
+++ b/source/runtime/ProfileCaptureController.cpp
@@ -63,6 +63,46 @@ StopCompletionStatus(RenderProfileSessionFinishResult _result) noexcept {
     return ProfileCaptureCompletionStatus::GpuSessionFaulted;
 }
 
+[[nodiscard]] bool
+RuntimeHasDroppedRecords(const ProfileDump::RuntimeStats& _stats) noexcept {
+    return _stats.records_dropped_stopped != 0 ||
+           _stats.records_dropped_stale_generation != 0 ||
+           _stats.records_dropped_oversized != 0 ||
+           _stats.records_dropped_queue_full != 0 ||
+           _stats.records_dropped_after_fault != 0;
+}
+
+[[nodiscard]] ProfileCaptureCompletionStatus AccountRuntimeFinalization(
+    ProfileCaptureCompletionStatus  _status,
+    ProfileDump::FlushResult         _flush_result,
+    ProfileDump::ShutdownResult      _shutdown_result,
+    const ProfileDump::RuntimeStats& _pre_shutdown_stats,
+    std::uint64_t                    _generation
+) noexcept {
+    const ProfileDump::RuntimeStats post_shutdown_stats =
+        ProfileDump::GetRuntimeStats();
+    if (_pre_shutdown_stats.generation != _generation ||
+        post_shutdown_stats.generation != _generation ||
+        _shutdown_result == ProfileDump::ShutdownResult::AlreadyStopped) {
+        return ProfileCaptureCompletionStatus::RuntimeOwnershipLost;
+    }
+    if (_flush_result == ProfileDump::FlushResult::Faulted ||
+        _shutdown_result == ProfileDump::ShutdownResult::Faulted ||
+        _pre_shutdown_stats.last_fault != ProfileDump::RuntimeFault::None ||
+        post_shutdown_stats.last_fault != ProfileDump::RuntimeFault::None ||
+        post_shutdown_stats.state != ProfileDump::RuntimeState::Stopped) {
+        return ProfileCaptureCompletionStatus::RuntimeShutdownFaulted;
+    }
+
+    const bool runtime_loss =
+        _flush_result == ProfileDump::FlushResult::Rejected ||
+        RuntimeHasDroppedRecords(post_shutdown_stats);
+    if (_status == ProfileCaptureCompletionStatus::Stopped && runtime_loss) {
+        return ProfileCaptureCompletionStatus::StoppedWithLoss;
+    }
+    return _status;
+}
+
 } // namespace
 
 ProfileCaptureRequestTicket::ProfileCaptureRequestTicket(
@@ -567,6 +607,7 @@ void ProfileCaptureController::FinalizeDynamicRuntime(
     ProfileDump::FlushResult flush_result = ProfileDump::FlushResult::Rejected;
     ProfileDump::ShutdownResult shutdown_result =
         ProfileDump::ShutdownResult::AlreadyStopped;
+    ProfileDump::RuntimeStats pre_shutdown_stats{};
 
     if (!OwnsPublishedGeneration()) {
         status = ProfileCaptureCompletionStatus::RuntimeOwnershipLost;
@@ -576,11 +617,15 @@ void ProfileCaptureController::FinalizeDynamicRuntime(
             cpu_producer_active_ = false;
         }
         flush_result    = ProfileDump::FlushAll();
+        pre_shutdown_stats = ProfileDump::GetRuntimeStats();
         shutdown_result = ProfileDump::Shutdown();
-        if (flush_result == ProfileDump::FlushResult::Faulted ||
-            shutdown_result == ProfileDump::ShutdownResult::Faulted) {
-            status = ProfileCaptureCompletionStatus::RuntimeShutdownFaulted;
-        }
+        status = AccountRuntimeFinalization(
+            status,
+            flush_result,
+            shutdown_result,
+            pre_shutdown_stats,
+            generation
+        );
     }
 
     owns_runtime_       = false;
@@ -698,8 +743,10 @@ ProfileCaptureController::FinalizeRuntimeAfterWorkers() noexcept {
 
     ProfileCaptureCompletionStatus stop_status =
         StopCompletionStatus(shutdown_gpu_result_);
+    ProfileDump::FlushResult flush_result = ProfileDump::FlushResult::NothingPending;
     ProfileDump::ShutdownResult shutdown_result =
         ProfileDump::ShutdownResult::AlreadyStopped;
+    ProfileDump::RuntimeStats pre_shutdown_stats{};
 
     if (owns_runtime_) {
         if (!OwnsPublishedGeneration()) {
@@ -709,13 +756,16 @@ ProfileCaptureController::FinalizeRuntimeAfterWorkers() noexcept {
                 ProfileDump::CpuScopeProducer::Deactivate();
                 cpu_producer_active_ = false;
             }
-            const ProfileDump::FlushResult flush_result = ProfileDump::FlushAll();
+            flush_result    = ProfileDump::FlushAll();
+            pre_shutdown_stats = ProfileDump::GetRuntimeStats();
             shutdown_result = ProfileDump::Shutdown();
-            if (flush_result == ProfileDump::FlushResult::Faulted ||
-                shutdown_result == ProfileDump::ShutdownResult::Faulted) {
-                stop_status =
-                    ProfileCaptureCompletionStatus::RuntimeShutdownFaulted;
-            }
+            stop_status = AccountRuntimeFinalization(
+                stop_status,
+                flush_result,
+                shutdown_result,
+                pre_shutdown_stats,
+                generation
+            );
         }
     }
 

--- a/source/runtime/ProfileCaptureController.cpp
+++ b/source/runtime/ProfileCaptureController.cpp
@@ -1,0 +1,901 @@
+#include "ProfileCaptureController.h"
+
+#include "profile/ProfileDumpTemplates.h"
+#include "profile/ProfileScope.h"
+
+#include <limits>
+#include <utility>
+
+namespace Moer::Render {
+
+namespace ProfileCaptureControllerDetail {
+
+struct CompletionState {
+    explicit CompletionState(ProfileCaptureRequestKind _kind) noexcept
+        : kind(_kind) {}
+
+    // Written once while request_mutex_ owns the submission linearization
+    // point, before either the queued request or rejected ticket is published.
+    std::uint64_t                   request_id{0};
+    const ProfileCaptureRequestKind kind{ProfileCaptureRequestKind::Start};
+    std::atomic_uint64_t            generation{0};
+    std::atomic_uint32_t            detail{0};
+    std::atomic_uint32_t            secondary_detail{0};
+    std::atomic_flag                completion_claimed = ATOMIC_FLAG_INIT;
+    std::atomic<ProfileCaptureCompletionStatus> status{
+        ProfileCaptureCompletionStatus::Pending
+    };
+};
+
+} // namespace ProfileCaptureControllerDetail
+
+namespace {
+
+template <typename Enum>
+[[nodiscard]] constexpr std::uint32_t Raw(Enum _value) noexcept {
+    return static_cast<std::uint32_t>(_value);
+}
+
+[[nodiscard]] bool RegistrationUsable(
+    const ProfileDump::SchemaRegistration& _registration,
+    std::uint64_t                           _generation
+) noexcept {
+    return (_registration.status == ProfileDump::SchemaStatus::Registered ||
+            _registration.status == ProfileDump::SchemaStatus::AlreadyRegistered) &&
+           static_cast<bool>(_registration.handle) &&
+           _registration.handle.generation == _generation;
+}
+
+[[nodiscard]] ProfileCaptureCompletionStatus
+StopCompletionStatus(RenderProfileSessionFinishResult _result) noexcept {
+    switch (_result) {
+        case RenderProfileSessionFinishResult::Closed:
+            return ProfileCaptureCompletionStatus::Stopped;
+        case RenderProfileSessionFinishResult::ClosedWithLoss:
+            return ProfileCaptureCompletionStatus::StoppedWithLoss;
+        case RenderProfileSessionFinishResult::Aborted:
+            return ProfileCaptureCompletionStatus::GpuSessionAborted;
+        case RenderProfileSessionFinishResult::Faulted:
+        case RenderProfileSessionFinishResult::Inactive:
+        case RenderProfileSessionFinishResult::Pending:
+            return ProfileCaptureCompletionStatus::GpuSessionFaulted;
+    }
+    return ProfileCaptureCompletionStatus::GpuSessionFaulted;
+}
+
+} // namespace
+
+ProfileCaptureRequestTicket::ProfileCaptureRequestTicket(
+    std::shared_ptr<ProfileCaptureControllerDetail::CompletionState> _state
+) noexcept
+    : state_(std::move(_state)) {}
+
+bool ProfileCaptureRequestTicket::Valid() const noexcept {
+    return static_cast<bool>(state_);
+}
+
+bool ProfileCaptureRequestTicket::Ready() const noexcept {
+    return state_ &&
+           state_->status.load(std::memory_order_acquire) !=
+               ProfileCaptureCompletionStatus::Pending;
+}
+
+bool ProfileCaptureRequestTicket::TryGet(
+    ProfileCaptureRequestCompletion& _completion
+) const noexcept {
+    if (!state_) {
+        return false;
+    }
+
+    const ProfileCaptureCompletionStatus status =
+        state_->status.load(std::memory_order_acquire);
+    if (status == ProfileCaptureCompletionStatus::Pending) {
+        return false;
+    }
+
+    _completion.request_id       = state_->request_id;
+    _completion.generation       = state_->generation.load(std::memory_order_relaxed);
+    _completion.kind             = state_->kind;
+    _completion.status           = status;
+    _completion.detail           = state_->detail.load(std::memory_order_relaxed);
+    _completion.secondary_detail =
+        state_->secondary_detail.load(std::memory_order_relaxed);
+    return true;
+}
+
+ProfileCaptureController::ProfileCaptureController(
+    RenderProfileCapture* _capture,
+    std::size_t           _request_capacity
+) noexcept
+    : capture_(_capture),
+      owner_thread_(std::this_thread::get_id()),
+      request_capacity_(_request_capacity) {
+    published_.state              = state_;
+    published_.accepting_requests = accepting_requests_;
+    published_.queue_capacity     = request_capacity_;
+}
+
+ProfileCaptureController::~ProfileCaptureController() noexcept {
+    {
+        std::lock_guard lock(request_mutex_);
+        accepting_requests_           = false;
+        published_.accepting_requests = false;
+    }
+
+    CancelQueued(ProfileCaptureCompletionStatus::ControllerDestroyed);
+    if (active_stop_completion_) {
+        Complete(
+            active_stop_completion_,
+            ProfileCaptureCompletionStatus::ControllerDestroyed,
+            active_generation_
+        );
+        active_stop_completion_.reset();
+    }
+
+    // Emergency fallback only. The normal Engine path must call the three
+    // owner-thread shutdown boundaries in order. If that path was skipped,
+    // retire only the exact generation acquired by this controller; never
+    // mutate a facade or ProfileDump runtime that has since been rebound.
+    if (owns_runtime_ && active_generation_ != 0) {
+        const std::uint64_t owned_generation = active_generation_;
+        if (gpu_session_active_ && capture_ != nullptr) {
+            const RenderProfileCaptureStats stats = capture_->GetStats();
+            if (stats.generation == owned_generation) {
+                capture_->Abort();
+            }
+        }
+
+        if (ProfileDump::GetRuntimeGeneration() == owned_generation) {
+            if (cpu_producer_active_) {
+                ProfileDump::CpuScopeProducer::Deactivate();
+            }
+            static_cast<void>(ProfileDump::FlushAll());
+            static_cast<void>(ProfileDump::Shutdown());
+        }
+    }
+
+    owns_runtime_        = false;
+    cpu_producer_active_ = false;
+    gpu_session_active_  = false;
+    active_generation_   = 0;
+    state_               = ProfileCaptureControllerState::Shutdown;
+    PublishOwnerState();
+}
+
+ProfileCaptureRequestSubmission ProfileCaptureController::RequestStart(
+    ProfileCaptureStartOptions _options
+) noexcept {
+    Request request{};
+    request.kind          = ProfileCaptureRequestKind::Start;
+    request.start_options = std::move(_options);
+    return Submit(std::move(request));
+}
+
+ProfileCaptureRequestSubmission
+ProfileCaptureController::RequestStop(std::uint64_t _expected_generation) noexcept {
+    Request request{};
+    request.kind                = ProfileCaptureRequestKind::Stop;
+    request.expected_generation = _expected_generation;
+    return Submit(std::move(request));
+}
+
+ProfileCaptureRequestSubmission
+ProfileCaptureController::Submit(Request&& _request) noexcept {
+    ProfileCaptureRequestSubmission submission{};
+
+    std::shared_ptr<ProfileCaptureControllerDetail::CompletionState> completion;
+    try {
+        completion =
+            std::make_shared<ProfileCaptureControllerDetail::CompletionState>(
+                _request.kind
+            );
+    } catch (...) {
+        submission.result = ProfileCaptureSubmitResult::ResourceExhausted;
+        return submission;
+    }
+
+    submission.ticket = ProfileCaptureRequestTicket(completion);
+    _request.completion = completion;
+
+    ProfileCaptureCompletionStatus rejected_status =
+        ProfileCaptureCompletionStatus::Pending;
+    try {
+        std::lock_guard lock(request_mutex_);
+        ++published_.requests_submitted;
+
+        // Id assignment is part of the same critical section as FIFO
+        // admission. A producer that enters this section first receives the
+        // lower id, and an accepted request is appended before the lock is
+        // released. Complete must remain outside this lock.
+        completion->request_id = next_request_id_++;
+        if (next_request_id_ == 0) {
+            next_request_id_ = 1;
+        }
+
+        if (_request.kind == ProfileCaptureRequestKind::Stop &&
+            _request.expected_generation == 0) {
+            submission.result = ProfileCaptureSubmitResult::InvalidArgument;
+            rejected_status =
+                ProfileCaptureCompletionStatus::RejectedInvalidArgument;
+        } else if (!accepting_requests_) {
+            submission.result = ProfileCaptureSubmitResult::AdmissionClosed;
+            rejected_status =
+                ProfileCaptureCompletionStatus::RejectedAdmissionClosed;
+        } else if (requests_.size() >= request_capacity_) {
+            submission.result = ProfileCaptureSubmitResult::QueueFull;
+            rejected_status = ProfileCaptureCompletionStatus::RejectedQueueFull;
+        } else {
+            try {
+                requests_.emplace_back(std::move(_request));
+                submission.result = ProfileCaptureSubmitResult::Queued;
+                ++published_.requests_accepted;
+                published_.queued_requests = requests_.size();
+                return submission;
+            } catch (...) {
+                submission.result = ProfileCaptureSubmitResult::ResourceExhausted;
+                rejected_status =
+                    ProfileCaptureCompletionStatus::RejectedResourceExhausted;
+            }
+        }
+        ++published_.requests_rejected;
+    } catch (...) {
+        submission.result = ProfileCaptureSubmitResult::ResourceExhausted;
+        // A lock acquisition failure has no valid linearization point and
+        // therefore cannot publish a well-formed non-zero ticket id.
+        submission.ticket = {};
+        return submission;
+    }
+
+    // Never call Complete while request_mutex_ is held: it publishes the
+    // controller's completion counters under that same mutex.
+    Complete(completion, rejected_status, 0);
+    return submission;
+}
+
+bool ProfileCaptureController::TryPopRequest(Request& _request) noexcept {
+    try {
+        std::lock_guard lock(request_mutex_);
+        if (requests_.empty()) {
+            return false;
+        }
+        _request = std::move(requests_.front());
+        requests_.pop_front();
+        published_.queued_requests = requests_.size();
+        return true;
+    } catch (...) {
+        return false;
+    }
+}
+
+ProfileCaptureTickResult ProfileCaptureController::TickOwner() noexcept {
+    if (!OnOwnerThread()) {
+        return ProfileCaptureTickResult::WrongThread;
+    }
+
+    switch (state_) {
+        case ProfileCaptureControllerState::Idle:
+        case ProfileCaptureControllerState::Running:
+            return ProcessQueuedRequests();
+        case ProfileCaptureControllerState::StoppingGpu:
+            return PollGpuStop();
+        case ProfileCaptureControllerState::Starting:
+        case ProfileCaptureControllerState::FinalizingRuntime:
+            return ProfileCaptureTickResult::Progressed;
+        case ProfileCaptureControllerState::AwaitingRhiDrain:
+        case ProfileCaptureControllerState::AwaitingWorkerShutdown:
+            return ProfileCaptureTickResult::WaitingForGpu;
+        case ProfileCaptureControllerState::Shutdown:
+            return ProfileCaptureTickResult::Shutdown;
+    }
+    return ProfileCaptureTickResult::Idle;
+}
+
+ProfileCaptureTickResult ProfileCaptureController::ProcessQueuedRequests() noexcept {
+    bool              progressed = false;
+    const std::size_t budget     = request_capacity_ == 0 ? 1 : request_capacity_;
+
+    for (std::size_t index = 0; index < budget; ++index) {
+        Request request{};
+        if (!TryPopRequest(request)) {
+            return progressed ? ProfileCaptureTickResult::Progressed :
+                                ProfileCaptureTickResult::Idle;
+        }
+        progressed = true;
+
+        if (state_ == ProfileCaptureControllerState::Idle) {
+            if (request.kind == ProfileCaptureRequestKind::Start) {
+                ProcessStart(std::move(request));
+            } else {
+                Complete(
+                    request.completion,
+                    ProfileCaptureCompletionStatus::RejectedStaleGeneration,
+                    0
+                );
+            }
+            continue;
+        }
+
+        if (state_ != ProfileCaptureControllerState::Running) {
+            // Only an asynchronous GPU stop may block FIFO consumption.
+            return ProfileCaptureTickResult::WaitingForGpu;
+        }
+
+        if (request.kind == ProfileCaptureRequestKind::Start) {
+            Complete(
+                request.completion,
+                ProfileCaptureCompletionStatus::RejectedAlreadyRunning,
+                active_generation_
+            );
+            continue;
+        }
+
+        if (!ProcessStop(std::move(request))) {
+            continue;
+        }
+
+        const ProfileCaptureTickResult stop_result = PollGpuStop();
+        if (stop_result == ProfileCaptureTickResult::WaitingForGpu) {
+            return stop_result;
+        }
+    }
+
+    return progressed ? ProfileCaptureTickResult::Progressed :
+                        ProfileCaptureTickResult::Idle;
+}
+
+void ProfileCaptureController::ProcessStart(Request&& _request) noexcept {
+    state_ = ProfileCaptureControllerState::Starting;
+    PublishOwnerState();
+
+    const ProfileDump::StartResult start_result =
+        ProfileDump::Start(_request.start_options.runtime);
+    if (start_result != ProfileDump::StartResult::Started) {
+        state_ = ProfileCaptureControllerState::Idle;
+        PublishOwnerState();
+        Complete(
+            _request.completion,
+            start_result == ProfileDump::StartResult::AlreadyRunning ?
+                ProfileCaptureCompletionStatus::RejectedExternalRuntime :
+                ProfileCaptureCompletionStatus::RuntimeStartFailed,
+            0,
+            Raw(start_result)
+        );
+        return;
+    }
+
+    owns_runtime_      = true;
+    active_generation_ = ProfileDump::GetRuntimeGeneration();
+    PublishOwnerState();
+
+    ProfileCaptureCompletionStatus failure_status =
+        ProfileCaptureCompletionStatus::CpuSchemaFailed;
+    std::uint32_t failure_detail = std::numeric_limits<std::uint32_t>::max();
+    const std::uint64_t started_generation = active_generation_;
+
+    try {
+        const ProfileDump::SchemaRegistration cpu_scope =
+            ProfileDump::RegisterSchema(ProfileDump::Templates::CpuScope());
+        if (!RegistrationUsable(cpu_scope, active_generation_)) {
+            failure_detail = Raw(cpu_scope.status);
+            RollbackOwnedStart();
+            Complete(
+                _request.completion,
+                ProfileCaptureCompletionStatus::CpuSchemaFailed,
+                started_generation,
+                failure_detail
+            );
+            return;
+        }
+
+        ProfileDump::SchemaRegistration gpu_frame{};
+        ProfileDump::SchemaRegistration gpu_scope{};
+        if (capture_ != nullptr) {
+            failure_status = ProfileCaptureCompletionStatus::GpuFrameSchemaFailed;
+            gpu_frame =
+                ProfileDump::RegisterSchema(ProfileDump::Templates::GpuFrame());
+            if (!RegistrationUsable(gpu_frame, active_generation_)) {
+                failure_detail = Raw(gpu_frame.status);
+                RollbackOwnedStart();
+                Complete(
+                    _request.completion,
+                    failure_status,
+                    started_generation,
+                    failure_detail
+                );
+                return;
+            }
+
+            failure_status = ProfileCaptureCompletionStatus::GpuScopeSchemaFailed;
+            gpu_scope =
+                ProfileDump::RegisterSchema(ProfileDump::Templates::GpuScope());
+            if (!RegistrationUsable(gpu_scope, active_generation_)) {
+                failure_detail = Raw(gpu_scope.status);
+                RollbackOwnedStart();
+                Complete(
+                    _request.completion,
+                    failure_status,
+                    started_generation,
+                    failure_detail
+                );
+                return;
+            }
+        }
+
+        failure_status = ProfileCaptureCompletionStatus::CpuActivationFailed;
+        const ProfileDump::CpuScopeActivationResult activation_result =
+            ProfileDump::CpuScopeProducer::Activate(cpu_scope.handle);
+        if (activation_result != ProfileDump::CpuScopeActivationResult::Activated) {
+            failure_detail = Raw(activation_result);
+            RollbackOwnedStart();
+            Complete(
+                _request.completion,
+                failure_status,
+                started_generation,
+                failure_detail
+            );
+            return;
+        }
+        cpu_producer_active_ = true;
+
+        if (capture_ != nullptr) {
+            // The bridge is the final transactional step. Any failure on a
+            // GPU-capable controller rolls back the whole owned generation;
+            // a null facade is an intentional CPU-only session instead.
+            failure_status = ProfileCaptureCompletionStatus::GpuSessionStartFailed;
+            const RenderProfileSessionStartResult gpu_start_result =
+                capture_->StartSession(
+                    gpu_frame.handle,
+                    gpu_scope.handle,
+                    _request.start_options.gpu_stream
+                );
+            if (gpu_start_result != RenderProfileSessionStartResult::Started) {
+                failure_detail = Raw(gpu_start_result);
+                RollbackOwnedStart();
+                Complete(
+                    _request.completion,
+                    failure_status,
+                    started_generation,
+                    failure_detail
+                );
+                return;
+            }
+            gpu_session_active_ = true;
+        }
+    } catch (...) {
+        RollbackOwnedStart();
+        Complete(
+            _request.completion,
+            failure_status,
+            started_generation,
+            failure_detail
+        );
+        return;
+    }
+
+    state_ = ProfileCaptureControllerState::Running;
+    PublishOwnerState();
+    Complete(
+        _request.completion,
+        capture_ != nullptr ? ProfileCaptureCompletionStatus::Started :
+                              ProfileCaptureCompletionStatus::StartedCpuOnly,
+        active_generation_
+    );
+}
+
+bool ProfileCaptureController::ProcessStop(Request&& _request) noexcept {
+    if (!owns_runtime_ || _request.expected_generation != active_generation_) {
+        Complete(
+            _request.completion,
+            ProfileCaptureCompletionStatus::RejectedStaleGeneration,
+            active_generation_
+        );
+        return false;
+    }
+
+    if (!OwnsPublishedGeneration()) {
+        if (capture_ != nullptr) {
+            const RenderProfileCaptureStats stats = capture_->GetStats();
+            if (stats.generation == active_generation_ && !stats.closed) {
+                static_cast<void>(capture_->RequestStop());
+            }
+        }
+
+        const std::uint64_t lost_generation = active_generation_;
+        owns_runtime_                       = false;
+        cpu_producer_active_                = false;
+        gpu_session_active_                 = false;
+        active_generation_                  = 0;
+        state_                              = ProfileCaptureControllerState::Idle;
+        PublishOwnerState();
+        Complete(
+            _request.completion,
+            ProfileCaptureCompletionStatus::RuntimeOwnershipLost,
+            lost_generation
+        );
+        return false;
+    }
+
+    if (cpu_producer_active_) {
+        ProfileDump::CpuScopeProducer::Deactivate();
+        cpu_producer_active_ = false;
+    }
+
+    if (capture_ != nullptr) {
+        const RenderProfileCaptureStats stats = capture_->GetStats();
+        if (stats.generation == active_generation_) {
+            static_cast<void>(capture_->RequestStop());
+        } else {
+            // The stable facade was rebound outside this controller. Never
+            // mutate the newer generation; owner-side runtime finalization
+            // below is still guarded independently by its exact generation.
+            gpu_session_active_ = false;
+        }
+    }
+    active_stop_completion_ = std::move(_request.completion);
+    state_                  = ProfileCaptureControllerState::StoppingGpu;
+    PublishOwnerState();
+    return true;
+}
+
+ProfileCaptureTickResult ProfileCaptureController::PollGpuStop() noexcept {
+    RenderProfileSessionFinishResult gpu_result = capture_ == nullptr ?
+        RenderProfileSessionFinishResult::Closed :
+        RenderProfileSessionFinishResult::Inactive;
+    if (capture_ != nullptr && gpu_session_active_) {
+        const RenderProfileCaptureStats stats = capture_->GetStats();
+        gpu_result = stats.generation == active_generation_ ?
+            capture_->TryFinishSession() :
+            RenderProfileSessionFinishResult::Faulted;
+    }
+    if (gpu_result == RenderProfileSessionFinishResult::Pending) {
+        return ProfileCaptureTickResult::WaitingForGpu;
+    }
+
+    FinalizeDynamicRuntime(gpu_result);
+    return ProfileCaptureTickResult::Progressed;
+}
+
+void ProfileCaptureController::FinalizeDynamicRuntime(
+    RenderProfileSessionFinishResult _gpu_result
+) noexcept {
+    const std::uint64_t generation = active_generation_;
+    state_                         = ProfileCaptureControllerState::FinalizingRuntime;
+    gpu_session_active_            = false;
+    PublishOwnerState();
+
+    ProfileCaptureCompletionStatus status = StopCompletionStatus(_gpu_result);
+    ProfileDump::FlushResult flush_result = ProfileDump::FlushResult::Rejected;
+    ProfileDump::ShutdownResult shutdown_result =
+        ProfileDump::ShutdownResult::AlreadyStopped;
+
+    if (!OwnsPublishedGeneration()) {
+        status = ProfileCaptureCompletionStatus::RuntimeOwnershipLost;
+    } else {
+        if (cpu_producer_active_) {
+            ProfileDump::CpuScopeProducer::Deactivate();
+            cpu_producer_active_ = false;
+        }
+        flush_result    = ProfileDump::FlushAll();
+        shutdown_result = ProfileDump::Shutdown();
+        if (flush_result == ProfileDump::FlushResult::Faulted ||
+            shutdown_result == ProfileDump::ShutdownResult::Faulted) {
+            status = ProfileCaptureCompletionStatus::RuntimeShutdownFaulted;
+        }
+    }
+
+    owns_runtime_       = false;
+    active_generation_  = 0;
+    cpu_producer_active_ = false;
+    state_               = ProfileCaptureControllerState::Idle;
+    PublishOwnerState();
+
+    Complete(
+        active_stop_completion_,
+        status,
+        generation,
+        Raw(_gpu_result),
+        Raw(shutdown_result)
+    );
+    active_stop_completion_.reset();
+}
+
+ProfileCaptureLifecycleResult
+ProfileCaptureController::BeginEngineShutdown() noexcept {
+    if (!OnOwnerThread()) {
+        return ProfileCaptureLifecycleResult::WrongThread;
+    }
+    if (state_ == ProfileCaptureControllerState::Shutdown) {
+        return ProfileCaptureLifecycleResult::AlreadyAtBoundary;
+    }
+    if (state_ == ProfileCaptureControllerState::AwaitingRhiDrain ||
+        state_ == ProfileCaptureControllerState::AwaitingWorkerShutdown) {
+        return ProfileCaptureLifecycleResult::AlreadyAtBoundary;
+    }
+    if (state_ == ProfileCaptureControllerState::Starting ||
+        state_ == ProfileCaptureControllerState::FinalizingRuntime) {
+        return ProfileCaptureLifecycleResult::InvalidState;
+    }
+
+    {
+        std::lock_guard lock(request_mutex_);
+        accepting_requests_           = false;
+        published_.accepting_requests = false;
+    }
+    CancelQueued(ProfileCaptureCompletionStatus::CancelledForShutdown);
+
+    if (OwnsPublishedGeneration()) {
+        if (cpu_producer_active_) {
+            ProfileDump::CpuScopeProducer::Deactivate();
+            cpu_producer_active_ = false;
+        }
+        if (gpu_session_active_ && capture_ != nullptr) {
+            const RenderProfileCaptureStats stats = capture_->GetStats();
+            if (stats.generation == active_generation_) {
+                static_cast<void>(capture_->RequestStop());
+            } else {
+                gpu_session_active_ = false;
+            }
+        }
+    }
+
+    state_ = ProfileCaptureControllerState::AwaitingRhiDrain;
+    PublishOwnerState();
+    return ProfileCaptureLifecycleResult::Advanced;
+}
+
+ProfileCaptureLifecycleResult
+ProfileCaptureController::FinalizeGpuAfterRhiDrain(bool _rhi_drained) noexcept {
+    if (!OnOwnerThread()) {
+        return ProfileCaptureLifecycleResult::WrongThread;
+    }
+    if (state_ == ProfileCaptureControllerState::AwaitingWorkerShutdown) {
+        return ProfileCaptureLifecycleResult::AlreadyAtBoundary;
+    }
+    if (state_ != ProfileCaptureControllerState::AwaitingRhiDrain) {
+        return state_ == ProfileCaptureControllerState::Shutdown ?
+            ProfileCaptureLifecycleResult::AlreadyAtBoundary :
+            ProfileCaptureLifecycleResult::InvalidState;
+    }
+
+    shutdown_gpu_result_ = capture_ == nullptr && owns_runtime_ ?
+        RenderProfileSessionFinishResult::Closed :
+        RenderProfileSessionFinishResult::Inactive;
+    if (gpu_session_active_ && capture_ != nullptr) {
+        const RenderProfileCaptureStats before = capture_->GetStats();
+        if (before.generation == active_generation_) {
+            if (_rhi_drained) {
+                capture_->ShutdownAfterRhiDrain();
+            } else {
+                capture_->Abort();
+            }
+            shutdown_gpu_result_ = capture_->TryFinishSession();
+        } else {
+            shutdown_gpu_result_ = RenderProfileSessionFinishResult::Faulted;
+        }
+    }
+    gpu_session_active_ = false;
+
+    state_ = ProfileCaptureControllerState::AwaitingWorkerShutdown;
+    PublishOwnerState();
+    return ProfileCaptureLifecycleResult::Advanced;
+}
+
+ProfileCaptureLifecycleResult
+ProfileCaptureController::FinalizeRuntimeAfterWorkers() noexcept {
+    if (!OnOwnerThread()) {
+        return ProfileCaptureLifecycleResult::WrongThread;
+    }
+    if (state_ == ProfileCaptureControllerState::Shutdown) {
+        return ProfileCaptureLifecycleResult::AlreadyAtBoundary;
+    }
+    if (state_ != ProfileCaptureControllerState::AwaitingWorkerShutdown) {
+        return ProfileCaptureLifecycleResult::InvalidState;
+    }
+
+    const std::uint64_t generation = active_generation_;
+    state_                         = ProfileCaptureControllerState::FinalizingRuntime;
+    PublishOwnerState();
+
+    ProfileCaptureCompletionStatus stop_status =
+        StopCompletionStatus(shutdown_gpu_result_);
+    ProfileDump::ShutdownResult shutdown_result =
+        ProfileDump::ShutdownResult::AlreadyStopped;
+
+    if (owns_runtime_) {
+        if (!OwnsPublishedGeneration()) {
+            stop_status = ProfileCaptureCompletionStatus::RuntimeOwnershipLost;
+        } else {
+            if (cpu_producer_active_) {
+                ProfileDump::CpuScopeProducer::Deactivate();
+                cpu_producer_active_ = false;
+            }
+            const ProfileDump::FlushResult flush_result = ProfileDump::FlushAll();
+            shutdown_result = ProfileDump::Shutdown();
+            if (flush_result == ProfileDump::FlushResult::Faulted ||
+                shutdown_result == ProfileDump::ShutdownResult::Faulted) {
+                stop_status =
+                    ProfileCaptureCompletionStatus::RuntimeShutdownFaulted;
+            }
+        }
+    }
+
+    owns_runtime_        = false;
+    cpu_producer_active_ = false;
+    gpu_session_active_  = false;
+    active_generation_   = 0;
+    state_               = ProfileCaptureControllerState::Shutdown;
+    PublishOwnerState();
+
+    if (active_stop_completion_) {
+        Complete(
+            active_stop_completion_,
+            stop_status,
+            generation,
+            Raw(shutdown_gpu_result_),
+            Raw(shutdown_result)
+        );
+        active_stop_completion_.reset();
+    }
+    return ProfileCaptureLifecycleResult::Advanced;
+}
+
+ProfileCaptureLifecycleResult
+ProfileCaptureController::AbandonRuntimeAfterWorkerShutdownFailure() noexcept {
+    if (!OnOwnerThread()) {
+        return ProfileCaptureLifecycleResult::WrongThread;
+    }
+    if (state_ == ProfileCaptureControllerState::Shutdown) {
+        return ProfileCaptureLifecycleResult::AlreadyAtBoundary;
+    }
+    if (state_ != ProfileCaptureControllerState::AwaitingWorkerShutdown) {
+        return ProfileCaptureLifecycleResult::InvalidState;
+    }
+
+    // Worker quiescence is unknown, so no ProfileDump, producer, or facade
+    // operation is safe here. Drop only the controller's bookkeeping and make
+    // the exceptional leak explicit. In particular, owns_runtime_ must be
+    // cleared so the destructor cannot race a still-running worker by trying
+    // the normal generation-guarded emergency finalization.
+    const std::uint64_t generation = active_generation_;
+    owns_runtime_                  = false;
+    cpu_producer_active_           = false;
+    gpu_session_active_            = false;
+    active_generation_             = 0;
+    state_                         = ProfileCaptureControllerState::Shutdown;
+    PublishOwnerState();
+
+    if (active_stop_completion_) {
+        Complete(
+            active_stop_completion_,
+            ProfileCaptureCompletionStatus::RuntimeShutdownFaulted,
+            generation,
+            Raw(shutdown_gpu_result_)
+        );
+        active_stop_completion_.reset();
+    }
+    return ProfileCaptureLifecycleResult::Advanced;
+}
+
+void ProfileCaptureController::RollbackOwnedStart() noexcept {
+    if (OwnsPublishedGeneration()) {
+        if (gpu_session_active_ && capture_ != nullptr) {
+            const RenderProfileCaptureStats stats = capture_->GetStats();
+            if (stats.generation == active_generation_ && !stats.closed) {
+                capture_->Abort();
+            }
+        }
+        if (cpu_producer_active_) {
+            ProfileDump::CpuScopeProducer::Deactivate();
+        }
+        static_cast<void>(ProfileDump::FlushAll());
+        static_cast<void>(ProfileDump::Shutdown());
+    }
+
+    owns_runtime_        = false;
+    cpu_producer_active_ = false;
+    gpu_session_active_  = false;
+    active_generation_   = 0;
+    state_               = ProfileCaptureControllerState::Idle;
+    PublishOwnerState();
+}
+
+bool ProfileCaptureController::OwnsPublishedGeneration() const noexcept {
+    return owns_runtime_ && active_generation_ != 0 &&
+           ProfileDump::GetRuntimeGeneration() == active_generation_;
+}
+
+bool ProfileCaptureController::OnOwnerThread() noexcept {
+    if (IsOwnerThread()) {
+        return true;
+    }
+    try {
+        std::lock_guard lock(request_mutex_);
+        ++published_.wrong_thread_calls;
+    } catch (...) {
+    }
+    return false;
+}
+
+bool ProfileCaptureController::IsOwnerThread() const noexcept {
+    return std::this_thread::get_id() == owner_thread_;
+}
+
+void ProfileCaptureController::PublishOwnerState() noexcept {
+    try {
+        std::lock_guard lock(request_mutex_);
+        published_.state               = state_;
+        published_.accepting_requests  = accepting_requests_;
+        published_.owns_runtime        = owns_runtime_;
+        published_.cpu_producer_active = cpu_producer_active_;
+        published_.gpu_session_active  = gpu_session_active_;
+        published_.queued_requests     = requests_.size();
+        published_.queue_capacity      = request_capacity_;
+        published_.active_generation  = active_generation_;
+    } catch (...) {
+    }
+}
+
+void ProfileCaptureController::Complete(
+    const std::shared_ptr<ProfileCaptureControllerDetail::CompletionState>& _completion,
+    ProfileCaptureCompletionStatus                                           _status,
+    std::uint64_t                                                            _generation,
+    std::uint32_t                                                            _detail,
+    std::uint32_t _secondary_detail
+) noexcept {
+    if (!_completion ||
+        _completion->completion_claimed.test_and_set(std::memory_order_acq_rel)) {
+        return;
+    }
+
+    _completion->generation.store(_generation, std::memory_order_relaxed);
+    _completion->detail.store(_detail, std::memory_order_relaxed);
+    _completion->secondary_detail.store(
+        _secondary_detail, std::memory_order_relaxed
+    );
+    try {
+        std::lock_guard lock(request_mutex_);
+        ++published_.requests_completed;
+        published_.last_completed_request_id = _completion->request_id;
+        published_.last_completion_status    = _status;
+    } catch (...) {
+    }
+
+    // Ready is the completion publication point. An acquiring ticket observer
+    // can now see both the immutable payload and the already-updated controller
+    // completion snapshot.
+    _completion->status.store(_status, std::memory_order_release);
+}
+
+void ProfileCaptureController::CancelQueued(
+    ProfileCaptureCompletionStatus _status
+) noexcept {
+    for (;;) {
+        Request request{};
+        if (!TryPopRequest(request)) {
+            return;
+        }
+        Complete(
+            request.completion,
+            _status,
+            request.kind == ProfileCaptureRequestKind::Stop ?
+                request.expected_generation :
+                active_generation_
+        );
+    }
+}
+
+ProfileCaptureControllerSnapshot
+ProfileCaptureController::GetSnapshot() const noexcept {
+    try {
+        std::lock_guard lock(request_mutex_);
+        return published_;
+    } catch (...) {
+        ProfileCaptureControllerSnapshot snapshot{};
+        snapshot.state              = state_;
+        snapshot.accepting_requests = false;
+        snapshot.queue_capacity     = request_capacity_;
+        return snapshot;
+    }
+}
+
+} // namespace Moer::Render

--- a/source/runtime/ProfileCaptureController.h
+++ b/source/runtime/ProfileCaptureController.h
@@ -1,0 +1,256 @@
+#pragma once
+
+#include "profile/ProfileDump.h"
+#include "profile/RenderProfileCapture.h"
+
+#include <atomic>
+#include <cstddef>
+#include <cstdint>
+#include <deque>
+#include <memory>
+#include <mutex>
+#include <thread>
+
+namespace Moer::Render {
+
+enum class ProfileCaptureControllerState : std::uint8_t {
+    Idle = 0,
+    Starting,
+    Running,
+    StoppingGpu,
+    FinalizingRuntime,
+    AwaitingRhiDrain,
+    AwaitingWorkerShutdown,
+    Shutdown,
+};
+
+enum class ProfileCaptureRequestKind : std::uint8_t {
+    Start = 0,
+    Stop,
+};
+
+enum class ProfileCaptureSubmitResult : std::uint8_t {
+    Queued = 0,
+    AdmissionClosed,
+    QueueFull,
+    InvalidArgument,
+    ResourceExhausted,
+};
+
+enum class ProfileCaptureCompletionStatus : std::uint8_t {
+    Pending = 0,
+    Started,
+    StartedCpuOnly,
+    Stopped,
+    StoppedWithLoss,
+    RejectedAdmissionClosed,
+    RejectedQueueFull,
+    RejectedResourceExhausted,
+    RejectedInvalidArgument,
+    RejectedAlreadyRunning,
+    RejectedStaleGeneration,
+    RejectedExternalRuntime,
+    CancelledForShutdown,
+    RuntimeStartFailed,
+    CpuSchemaFailed,
+    GpuFrameSchemaFailed,
+    GpuScopeSchemaFailed,
+    CpuActivationFailed,
+    GpuSessionStartFailed,
+    RuntimeOwnershipLost,
+    GpuSessionFaulted,
+    GpuSessionAborted,
+    RuntimeShutdownFaulted,
+    ControllerDestroyed,
+};
+
+enum class ProfileCaptureTickResult : std::uint8_t {
+    Idle = 0,
+    Progressed,
+    WaitingForGpu,
+    WrongThread,
+    Shutdown,
+};
+
+enum class ProfileCaptureLifecycleResult : std::uint8_t {
+    Advanced = 0,
+    AlreadyAtBoundary,
+    WrongThread,
+    InvalidState,
+};
+
+// The two detail fields retain the raw subsystem result values for telemetry.
+// Their interpretation is selected by status and remains optional to callers.
+struct ProfileCaptureRequestCompletion {
+    std::uint64_t                  request_id{0};
+    std::uint64_t                  generation{0};
+    ProfileCaptureRequestKind      kind{ProfileCaptureRequestKind::Start};
+    ProfileCaptureCompletionStatus status{ProfileCaptureCompletionStatus::Pending};
+    std::uint32_t                  detail{0};
+    std::uint32_t                  secondary_detail{0};
+};
+
+namespace ProfileCaptureControllerDetail {
+struct CompletionState;
+}
+
+class ProfileCaptureRequestTicket final {
+public:
+    ProfileCaptureRequestTicket() noexcept = default;
+
+    [[nodiscard]] bool Valid() const noexcept;
+    [[nodiscard]] bool Ready() const noexcept;
+
+    // Returns false while the request is pending or when this is an empty
+    // ticket. A terminal completion is immutable and may be polled from any
+    // thread.
+    [[nodiscard]] bool TryGet(ProfileCaptureRequestCompletion& _completion) const noexcept;
+
+private:
+    explicit ProfileCaptureRequestTicket(
+        std::shared_ptr<ProfileCaptureControllerDetail::CompletionState> _state
+    ) noexcept;
+
+    std::shared_ptr<ProfileCaptureControllerDetail::CompletionState> state_{};
+
+    friend class ProfileCaptureController;
+};
+
+struct ProfileCaptureRequestSubmission {
+    ProfileCaptureSubmitResult result{ProfileCaptureSubmitResult::ResourceExhausted};
+    ProfileCaptureRequestTicket ticket{};
+};
+
+struct ProfileCaptureStartOptions {
+    ProfileDump::RuntimeConfig runtime{};
+    GpuScopeStreamConfig       gpu_stream{};
+};
+
+struct ProfileCaptureControllerSnapshot {
+    ProfileCaptureControllerState state{ProfileCaptureControllerState::Idle};
+    bool                          accepting_requests{true};
+    bool                          owns_runtime{false};
+    bool                          cpu_producer_active{false};
+    bool                          gpu_session_active{false};
+    std::size_t                   queued_requests{0};
+    std::size_t                   queue_capacity{0};
+    std::uint64_t                 active_generation{0};
+    std::uint64_t                 last_completed_request_id{0};
+    ProfileCaptureCompletionStatus last_completion_status{
+        ProfileCaptureCompletionStatus::Pending
+    };
+    std::uint64_t requests_submitted{0};
+    std::uint64_t requests_accepted{0};
+    std::uint64_t requests_rejected{0};
+    std::uint64_t requests_completed{0};
+    std::uint64_t wrong_thread_calls{0};
+};
+
+// Game Thread owns all capture lifecycle transitions. RequestStart and
+// RequestStop are bounded MPSC admission points; tickets hold their own
+// completion state, so the controller never grows a result map.
+//
+// While this controller owns a ProfileDump generation, every ProfileDump and
+// CpuScopeProducer lifecycle operation must be serialized through it on the
+// Game Thread. External concurrent Shutdown/Deactivate calls violate the
+// process-owner contract; ProfileDump Core does not currently expose an owner
+// token that could enforce this boundary itself.
+class ProfileCaptureController final {
+public:
+    static constexpr std::size_t kDefaultRequestCapacity = 64;
+
+    explicit ProfileCaptureController(
+        RenderProfileCapture* _capture,
+        std::size_t           _request_capacity = kDefaultRequestCapacity
+    ) noexcept;
+    ~ProfileCaptureController() noexcept;
+
+    ProfileCaptureController(const ProfileCaptureController&)            = delete;
+    ProfileCaptureController& operator=(const ProfileCaptureController&) = delete;
+    ProfileCaptureController(ProfileCaptureController&&)                 = delete;
+    ProfileCaptureController& operator=(ProfileCaptureController&&)      = delete;
+
+    [[nodiscard]] ProfileCaptureRequestSubmission
+    RequestStart(ProfileCaptureStartOptions _options) noexcept;
+
+    // A zero generation is never a wildcard and is rejected at admission.
+    [[nodiscard]] ProfileCaptureRequestSubmission
+    RequestStop(std::uint64_t _expected_generation) noexcept;
+
+    [[nodiscard]] ProfileCaptureTickResult TickOwner() noexcept;
+
+    // Engine shutdown is intentionally split around the RHI and worker joins:
+    // Begin closes request/CPU/GPU admission only; it does not close the
+    // bridge or ProfileDump runtime.
+    [[nodiscard]] ProfileCaptureLifecycleResult BeginEngineShutdown() noexcept;
+    [[nodiscard]] ProfileCaptureLifecycleResult
+    FinalizeGpuAfterRhiDrain(bool _rhi_drained) noexcept;
+    [[nodiscard]] ProfileCaptureLifecycleResult FinalizeRuntimeAfterWorkers() noexcept;
+    // Last-resort Engine failure path. If worker quiescence cannot be proven,
+    // relinquish controller ownership without touching ProfileDump again.
+    // This intentionally leaves the process-global runtime alive so an
+    // in-flight worker scope cannot race an unsafe FlushAll/Shutdown, and it
+    // also prevents the controller destructor from retrying finalization.
+    [[nodiscard]] ProfileCaptureLifecycleResult
+    AbandonRuntimeAfterWorkerShutdownFailure() noexcept;
+
+    [[nodiscard]] ProfileCaptureControllerSnapshot GetSnapshot() const noexcept;
+    [[nodiscard]] bool                             IsOwnerThread() const noexcept;
+
+private:
+    struct Request {
+        ProfileCaptureRequestKind kind{ProfileCaptureRequestKind::Start};
+        ProfileCaptureStartOptions start_options{};
+        std::uint64_t expected_generation{0};
+        std::shared_ptr<ProfileCaptureControllerDetail::CompletionState> completion{};
+    };
+
+    [[nodiscard]] ProfileCaptureRequestSubmission Submit(Request&& _request) noexcept;
+    [[nodiscard]] bool                            TryPopRequest(Request& _request) noexcept;
+    [[nodiscard]] ProfileCaptureTickResult        ProcessQueuedRequests() noexcept;
+    void                                          ProcessStart(Request&& _request) noexcept;
+    [[nodiscard]] bool                            ProcessStop(Request&& _request) noexcept;
+    [[nodiscard]] ProfileCaptureTickResult        PollGpuStop() noexcept;
+    void                                          FinalizeDynamicRuntime(
+                                                 RenderProfileSessionFinishResult _gpu_result
+                                             ) noexcept;
+
+    void RollbackOwnedStart() noexcept;
+    [[nodiscard]] bool OwnsPublishedGeneration() const noexcept;
+    [[nodiscard]] bool OnOwnerThread() noexcept;
+    void PublishOwnerState() noexcept;
+    void Complete(
+        const std::shared_ptr<ProfileCaptureControllerDetail::CompletionState>& _completion,
+        ProfileCaptureCompletionStatus                                           _status,
+        std::uint64_t                                                            _generation,
+        std::uint32_t                                                            _detail = 0,
+        std::uint32_t _secondary_detail = 0
+    ) noexcept;
+    void CancelQueued(ProfileCaptureCompletionStatus _status) noexcept;
+
+    RenderProfileCapture* const capture_{nullptr};
+    const std::thread::id       owner_thread_;
+    const std::size_t           request_capacity_{0};
+    mutable std::mutex request_mutex_{};
+    // Protected by request_mutex_. Assigning the id and appending an accepted
+    // request share one linearization point, so accepted ids strictly follow
+    // FIFO order even when producers race.
+    std::uint64_t next_request_id_{1};
+    std::deque<Request> requests_{};
+    ProfileCaptureControllerSnapshot published_{};
+
+    ProfileCaptureControllerState state_{ProfileCaptureControllerState::Idle};
+    std::uint64_t                  active_generation_{0};
+    bool                           owns_runtime_{false};
+    bool                           cpu_producer_active_{false};
+    bool                           gpu_session_active_{false};
+    bool                           accepting_requests_{true};
+
+    std::shared_ptr<ProfileCaptureControllerDetail::CompletionState>
+        active_stop_completion_{};
+    RenderProfileSessionFinishResult shutdown_gpu_result_{
+        RenderProfileSessionFinishResult::Inactive
+    };
+};
+
+} // namespace Moer::Render

--- a/source/runtime/render/renderer/Renderer.h
+++ b/source/runtime/render/renderer/Renderer.h
@@ -24,6 +24,9 @@ class RenderProfileCapture;
 
 struct EngineHooks {
     // Common
+    // Engine-owned lifecycle controls run on the Game Thread before the
+    // frame's outer CPU profiling scope begins.
+    std::function<void()>        on_tick_engine_control;
     std::function<void(Scene&)> on_tick_scripting;
     std::function<void(Scene&)> on_tick_test;
     std::function<void(Scene&)> on_tick_ui;

--- a/source/runtime/render/renderer/raster/RasterRenderer.cpp
+++ b/source/runtime/render/renderer/raster/RasterRenderer.cpp
@@ -318,6 +318,9 @@ RasterFramePacket
 RasterRenderer::PrepareFrame(const SharedPtr<EditorConfig> editor_config, const EngineHooks& hooks) {
     assert(!IsRenderThreadInitialized() || IsCurrentlyGameThread());
     assert(editor_config);
+    if (hooks.on_tick_engine_control) {
+        hooks.on_tick_engine_control();
+    }
     MOER_PROFILE_SCOPE("Raster.PrepareFrame");
 
     const bool           profile_logging = IsFramePrepareProfilingEnabled();

--- a/source/runtime/render/renderer/raytracing/RaytracingRenderer.cpp
+++ b/source/runtime/render/renderer/raytracing/RaytracingRenderer.cpp
@@ -489,6 +489,9 @@ RaytracingFramePacket
 RaytracingRenderer::PrepareFrame(const SharedPtr<EditorConfig> editor_config, const EngineHooks& hooks) {
     assert(IsCurrentlyGameThread());
     assert(editor_config);
+    if (hooks.on_tick_engine_control) {
+        hooks.on_tick_engine_control();
+    }
     MOER_PROFILE_SCOPE("Raytracing.PrepareFrame");
 
     const bool            profile_logging = IsFramePrepareProfilingEnabled();

--- a/source/test/CMakeLists.txt
+++ b/source/test/CMakeLists.txt
@@ -175,6 +175,15 @@ set_target_properties(${test_target} PROPERTIES FOLDER ${moer_test_folder})
 add_test(NAME RenderProfileCaptureContract COMMAND $<TARGET_FILE:${test_target}>)
 set_tests_properties(RenderProfileCaptureContract PROPERTIES TIMEOUT 60)
 
+set(test_target TestProfileCaptureController)
+add_executable(${test_target} "ProfileCaptureControllerTest.cpp")
+target_link_libraries(${test_target}
+    PRIVATE Moer::Runtime
+)
+set_target_properties(${test_target} PROPERTIES FOLDER ${moer_test_folder})
+add_test(NAME ProfileCaptureControllerContract COMMAND $<TARGET_FILE:${test_target}>)
+set_tests_properties(ProfileCaptureControllerContract PROPERTIES TIMEOUT 60)
+
 set(test_target TestRHIGpuCompletion)
 add_executable(${test_target} "RHIGpuCompletionContractTest.cpp")
 target_link_libraries(${test_target}

--- a/source/test/ProfileCaptureControllerTest.cpp
+++ b/source/test/ProfileCaptureControllerTest.cpp
@@ -5,6 +5,7 @@
 #include "profile/RenderProfileCapture.h"
 
 #include <algorithm>
+#include <array>
 #include <atomic>
 #include <barrier>
 #include <chrono>
@@ -80,6 +81,50 @@ ProfileCaptureStartOptions StartOptions(
     options.runtime.output_path      = _output.Path(_filename);
     options.runtime.replace_existing = true;
     return options;
+}
+
+ProfileCaptureStartOptions LossyStartOptions(
+    const ScopedCaptureOutput& _output,
+    std::string_view           _filename
+) {
+    ProfileCaptureStartOptions options = StartOptions(_output, _filename);
+    options.runtime.max_record_bytes   = 64;
+    return options;
+}
+
+void EmitOversizedRuntimeRecord(std::uint64_t _generation) {
+    const SchemaDescriptor schema = {
+        .name           = "ControllerLossProbe",
+        .event_type     = "contract.controller_loss_probe",
+        .kind           = EventKind::Instant,
+        .channel        = Channel::CpuThread,
+        .schema_version = 1,
+        .fields =
+            {
+                {"payload", FieldType::String},
+            },
+    };
+    const SchemaRegistration registration = RegisterSchema(schema);
+    Expect(
+        registration.status == SchemaStatus::Registered &&
+            registration.handle.generation == _generation,
+        "loss probe schema did not bind the controller generation"
+    );
+
+    const std::string oversized_payload(256, 'x');
+    const std::array<FieldValueView, 1> values = {
+        FieldValueView{std::string_view(oversized_payload)},
+    };
+    Expect(
+        Emit(registration.handle, values) == EmitStatus::RecordTooLarge,
+        "loss probe did not deterministically reject an oversized record"
+    );
+    const RuntimeStats stats = GetRuntimeStats();
+    Expect(
+        stats.generation == _generation &&
+            stats.records_dropped_oversized == 1,
+        "loss probe rejection was not attributed to the controller generation"
+    );
 }
 
 ProfileCaptureRequestCompletion CompletionOf(
@@ -914,6 +959,91 @@ void EngineShutdownPreservesRhiAndWorkerOwnershipBoundaries() {
     );
 }
 
+void DynamicStopReportsProfileDumpRecordLoss() {
+    ScopedCaptureOutput      output("moer-profile-controller-dynamic-loss");
+    ProfileCaptureController controller(nullptr, 4);
+    const std::uint64_t generation = StartCpuOnlyCapture(
+        controller,
+        LossyStartOptions(output, "dynamic-loss.mpd")
+    );
+    EmitOversizedRuntimeRecord(generation);
+
+    const ProfileCaptureRequestCompletion completion =
+        StopCapture(controller, generation);
+    Expect(
+        completion.status ==
+                ProfileCaptureCompletionStatus::StoppedWithLoss &&
+            completion.generation == generation &&
+            GetRuntimeState() == RuntimeState::Stopped,
+        "dynamic Stop published a clean terminal status after ProfileDump loss"
+    );
+}
+
+void EngineShutdownReportsProfileDumpRecordLoss() {
+    ScopedCaptureOutput      output("moer-profile-controller-shutdown-loss");
+    RenderProfileCapture     capture;
+    ProfileCaptureController controller(&capture, 4);
+    const std::uint64_t generation = StartCapture(
+        controller,
+        LossyStartOptions(output, "shutdown-loss.mpd")
+    );
+    EmitOversizedRuntimeRecord(generation);
+
+    RenderProfileFrameToken frame = capture.BeginFrame();
+    Expect(frame.Valid(), "shutdown-loss setup did not admit a GPU frame");
+    ProfileCaptureRequestSubmission stop =
+        controller.RequestStop(generation);
+    Expect(
+        stop.result == ProfileCaptureSubmitResult::Queued &&
+            controller.TickOwner() == ProfileCaptureTickResult::WaitingForGpu &&
+            !stop.ticket.Ready(),
+        "shutdown-loss setup did not retain an active Stop ticket"
+    );
+
+    Expect(
+        controller.BeginEngineShutdown() ==
+            ProfileCaptureLifecycleResult::Advanced,
+        "shutdown-loss setup did not cross the admission boundary"
+    );
+    Expect(
+        capture.Seal(frame),
+        "shutdown-loss setup could not seal its admitted GPU frame"
+    );
+    Expect(
+        controller.FinalizeGpuAfterRhiDrain(true) ==
+            ProfileCaptureLifecycleResult::Advanced,
+        "shutdown-loss setup did not cross the post-RHI boundary"
+    );
+    const RenderProfileCaptureStats gpu_stats = capture.GetStats();
+    Expect(
+        gpu_stats.closed && gpu_stats.frames_emitted == 1 &&
+            gpu_stats.frame_records_dropped == 0 &&
+            gpu_stats.scope_records_dropped == 0 &&
+            gpu_stats.terminal_faults == 0 &&
+            gpu_stats.shutdown_abandoned_frames == 0 &&
+            !stop.ticket.Ready(),
+        "shutdown-loss setup introduced GPU loss instead of isolating ProfileDump loss"
+    );
+    Expect(
+        controller.FinalizeRuntimeAfterWorkers() ==
+            ProfileCaptureLifecycleResult::Advanced,
+        "shutdown-loss setup did not cross the post-worker boundary"
+    );
+
+    const ProfileCaptureRequestCompletion completion =
+        CompletionOf(
+            stop.ticket,
+            "Engine shutdown did not complete the active Stop ticket"
+        );
+    Expect(
+        completion.status ==
+                ProfileCaptureCompletionStatus::StoppedWithLoss &&
+            completion.generation == generation &&
+            GetRuntimeState() == RuntimeState::Stopped,
+        "post-worker finalization published a clean status after ProfileDump loss"
+    );
+}
+
 void WorkerShutdownFailureAbandonsRuntimeWithoutUnsafeFinalization() {
     ScopedCaptureOutput  output("moer-profile-controller-worker-failure");
     RenderProfileCapture capture;
@@ -1036,6 +1166,8 @@ int main() {
         RestartUsesStableFacadeAndRejectsStaleStop();
         AdmittedFrameKeepsDynamicStopPendingUntilSealed();
         EngineShutdownPreservesRhiAndWorkerOwnershipBoundaries();
+        DynamicStopReportsProfileDumpRecordLoss();
+        EngineShutdownReportsProfileDumpRecordLoss();
         WorkerShutdownFailureAbandonsRuntimeWithoutUnsafeFinalization();
         ClosingAdmissionCancelsQueuedTickets();
     } catch (const std::exception& error) {

--- a/source/test/ProfileCaptureControllerTest.cpp
+++ b/source/test/ProfileCaptureControllerTest.cpp
@@ -1,0 +1,1047 @@
+#include "ProfileCaptureController.h"
+
+#include "profile/ProfileDump.h"
+#include "profile/ProfileScope.h"
+#include "profile/RenderProfileCapture.h"
+
+#include <algorithm>
+#include <atomic>
+#include <barrier>
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <filesystem>
+#include <iostream>
+#include <memory>
+#include <set>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <thread>
+#include <utility>
+#include <vector>
+
+namespace {
+
+using namespace Moer;
+using namespace Moer::ProfileDump;
+using namespace Moer::Render;
+
+void Expect(bool _condition, std::string_view _message) {
+    if (!_condition) {
+        throw std::runtime_error(std::string(_message));
+    }
+}
+
+class ScopedCaptureOutput final {
+public:
+    explicit ScopedCaptureOutput(std::string_view _stem) {
+        static std::atomic_uint64_t next_id{0};
+        for (std::uint32_t attempt = 0; attempt < 64; ++attempt) {
+            const auto now = static_cast<std::uint64_t>(
+                std::chrono::steady_clock::now().time_since_epoch().count()
+            );
+            directory_ = std::filesystem::temp_directory_path() /
+                         (std::string(_stem) + "-" + std::to_string(now) + "-" +
+                          std::to_string(next_id.fetch_add(1, std::memory_order_relaxed)));
+            std::error_code error;
+            if (std::filesystem::create_directory(directory_, error)) {
+                return;
+            }
+            if (error && error != std::errc::file_exists) {
+                break;
+            }
+        }
+        throw std::runtime_error(
+            "ProfileCaptureController test could not reserve a temp directory"
+        );
+    }
+
+    ~ScopedCaptureOutput() {
+        CpuScopeProducer::Deactivate();
+        static_cast<void>(Shutdown());
+        std::error_code error;
+        std::filesystem::remove_all(directory_, error);
+    }
+
+    [[nodiscard]] std::filesystem::path Path(std::string_view _filename) const {
+        return directory_ / std::string(_filename);
+    }
+
+private:
+    std::filesystem::path directory_{};
+};
+
+ProfileCaptureStartOptions StartOptions(
+    const ScopedCaptureOutput& _output,
+    std::string_view           _filename
+) {
+    ProfileCaptureStartOptions options{};
+    options.runtime.output_path      = _output.Path(_filename);
+    options.runtime.replace_existing = true;
+    return options;
+}
+
+ProfileCaptureRequestCompletion CompletionOf(
+    const ProfileCaptureRequestTicket& _ticket,
+    std::string_view                    _message
+) {
+    ProfileCaptureRequestCompletion completion{};
+    Expect(_ticket.Valid(), "request did not return a valid completion ticket");
+    Expect(_ticket.Ready(), _message);
+    Expect(_ticket.TryGet(completion), "ready request ticket did not publish its completion");
+    Expect(
+        completion.request_id != 0,
+        "request completion did not preserve a non-zero request id"
+    );
+    return completion;
+}
+
+void TickUntilReady(
+    ProfileCaptureController&          _controller,
+    const ProfileCaptureRequestTicket& _ticket,
+    std::string_view                    _message,
+    std::size_t                         _max_ticks = 64
+) {
+    for (std::size_t tick = 0; tick < _max_ticks && !_ticket.Ready(); ++tick) {
+        const ProfileCaptureTickResult result = _controller.TickOwner();
+        Expect(
+            result != ProfileCaptureTickResult::WrongThread,
+            "owner-thread tick was rejected as a foreign-thread call"
+        );
+        Expect(
+            result != ProfileCaptureTickResult::Shutdown,
+            "controller reached shutdown before a request completed"
+        );
+    }
+    Expect(_ticket.Ready(), _message);
+}
+
+std::uint64_t StartCapture(
+    ProfileCaptureController& _controller,
+    ProfileCaptureStartOptions _options
+) {
+    ProfileCaptureRequestSubmission submission =
+        _controller.RequestStart(std::move(_options));
+    Expect(
+        submission.result == ProfileCaptureSubmitResult::Queued,
+        "valid capture start request was not queued"
+    );
+    TickUntilReady(
+        _controller,
+        submission.ticket,
+        "capture start request did not complete"
+    );
+    const ProfileCaptureRequestCompletion completion =
+        CompletionOf(submission.ticket, "capture start completion was not ready");
+    Expect(
+        completion.kind == ProfileCaptureRequestKind::Start &&
+            completion.status == ProfileCaptureCompletionStatus::Started &&
+            completion.generation != 0,
+        "capture start request did not publish a live generation"
+    );
+    return completion.generation;
+}
+
+std::uint64_t StartCpuOnlyCapture(
+    ProfileCaptureController& _controller,
+    ProfileCaptureStartOptions _options
+) {
+    ProfileCaptureRequestSubmission submission =
+        _controller.RequestStart(std::move(_options));
+    Expect(
+        submission.result == ProfileCaptureSubmitResult::Queued,
+        "valid CPU-only capture start request was not queued"
+    );
+    TickUntilReady(
+        _controller,
+        submission.ticket,
+        "CPU-only capture start request did not complete"
+    );
+    const ProfileCaptureRequestCompletion completion =
+        CompletionOf(
+            submission.ticket,
+            "CPU-only capture start completion was not ready"
+        );
+    Expect(
+        completion.kind == ProfileCaptureRequestKind::Start &&
+            completion.status ==
+                ProfileCaptureCompletionStatus::StartedCpuOnly &&
+            completion.generation != 0,
+        "null-facade controller did not publish a CPU-only generation"
+    );
+    return completion.generation;
+}
+
+ProfileCaptureRequestCompletion StopCapture(
+    ProfileCaptureController& _controller,
+    std::uint64_t             _generation
+) {
+    ProfileCaptureRequestSubmission submission =
+        _controller.RequestStop(_generation);
+    Expect(
+        submission.result == ProfileCaptureSubmitResult::Queued,
+        "valid capture stop request was not queued"
+    );
+    TickUntilReady(
+        _controller,
+        submission.ticket,
+        "capture stop request did not complete"
+    );
+    return CompletionOf(submission.ticket, "capture stop completion was not ready");
+}
+
+void FinishEngineShutdown(ProfileCaptureController& _controller) {
+    Expect(
+        _controller.FinalizeGpuAfterRhiDrain(true) ==
+            ProfileCaptureLifecycleResult::Advanced,
+        "engine shutdown did not cross the post-RHI GPU boundary"
+    );
+    Expect(
+        _controller.FinalizeRuntimeAfterWorkers() ==
+            ProfileCaptureLifecycleResult::Advanced,
+        "engine shutdown did not cross the post-worker runtime boundary"
+    );
+    Expect(
+        _controller.GetSnapshot().state == ProfileCaptureControllerState::Shutdown,
+        "engine shutdown did not publish the terminal controller state"
+    );
+}
+
+void AdmissionValidationQueueCapacityAndFifo() {
+    ScopedCaptureOutput    output("moer-profile-controller-fifo");
+    RenderProfileCapture   capture;
+    ProfileCaptureController controller(&capture, 2);
+
+    const ProfileCaptureRequestSubmission invalid_stop =
+        controller.RequestStop(0);
+    Expect(
+        invalid_stop.result == ProfileCaptureSubmitResult::InvalidArgument,
+        "Stop(0) was treated as a wildcard or queued request"
+    );
+    const ProfileCaptureRequestCompletion invalid_completion =
+        CompletionOf(invalid_stop.ticket, "Stop(0) did not complete synchronously");
+    Expect(
+        invalid_completion.kind == ProfileCaptureRequestKind::Stop &&
+            invalid_completion.status ==
+                ProfileCaptureCompletionStatus::RejectedInvalidArgument,
+        "Stop(0) completion did not retain its invalid-argument reason"
+    );
+
+    ProfileCaptureRequestSubmission first =
+        controller.RequestStart(StartOptions(output, "first.mpd"));
+    ProfileCaptureRequestSubmission second =
+        controller.RequestStart(StartOptions(output, "second.mpd"));
+    ProfileCaptureRequestSubmission overflow =
+        controller.RequestStart(StartOptions(output, "overflow.mpd"));
+    Expect(
+        first.result == ProfileCaptureSubmitResult::Queued &&
+            second.result == ProfileCaptureSubmitResult::Queued,
+        "bounded FIFO rejected work before reaching its capacity"
+    );
+    Expect(
+        overflow.result == ProfileCaptureSubmitResult::QueueFull,
+        "bounded FIFO silently exceeded its declared capacity"
+    );
+    const ProfileCaptureControllerSnapshot full = controller.GetSnapshot();
+    Expect(
+        full.queued_requests == 2 && full.queue_capacity == 2,
+        "bounded FIFO snapshot did not expose its exact resident capacity"
+    );
+    const ProfileCaptureRequestCompletion overflow_completion =
+        CompletionOf(overflow.ticket, "queue-full request did not complete synchronously");
+    Expect(
+        overflow_completion.status ==
+            ProfileCaptureCompletionStatus::RejectedQueueFull,
+        "queue-full ticket lost its rejection reason"
+    );
+
+    TickUntilReady(
+        controller,
+        first.ticket,
+        "front FIFO start request did not complete"
+    );
+    TickUntilReady(
+        controller,
+        second.ticket,
+        "second FIFO start request did not complete"
+    );
+    const ProfileCaptureRequestCompletion first_completion =
+        CompletionOf(first.ticket, "front FIFO completion was not ready");
+    const ProfileCaptureRequestCompletion second_completion =
+        CompletionOf(second.ticket, "second FIFO completion was not ready");
+    Expect(
+        first_completion.status == ProfileCaptureCompletionStatus::Started,
+        "bounded request queue did not process its front start first"
+    );
+    Expect(
+        second_completion.status ==
+            ProfileCaptureCompletionStatus::RejectedAlreadyRunning,
+        "second FIFO start did not observe the session opened by the first"
+    );
+    Expect(
+        first_completion.request_id < second_completion.request_id &&
+            second_completion.request_id < overflow_completion.request_id,
+        "single-thread request ids did not preserve admission order"
+    );
+
+    const ProfileCaptureRequestCompletion stopped =
+        StopCapture(controller, first_completion.generation);
+    Expect(
+        stopped.status == ProfileCaptureCompletionStatus::Stopped,
+        "empty FIFO-owned session did not stop cleanly"
+    );
+    Expect(
+        GetRuntimeState() == RuntimeState::Stopped,
+        "dynamic FIFO-owned stop left ProfileDump running"
+    );
+}
+
+void ConcurrentSubmissionIdsAreUniqueAndQueueIsBounded() {
+    constexpr std::size_t thread_count     = 8;
+    constexpr std::size_t requests_per_thread = 8;
+    constexpr std::size_t request_count    = thread_count * requests_per_thread;
+    constexpr std::size_t queue_capacity   = 17;
+
+    ScopedCaptureOutput      output("moer-profile-controller-mpsc");
+    RenderProfileCapture     capture;
+    ProfileCaptureController controller(&capture, queue_capacity);
+    std::barrier              start_gate(static_cast<std::ptrdiff_t>(thread_count + 1));
+    std::vector<std::vector<ProfileCaptureRequestSubmission>> submissions(thread_count);
+    std::vector<std::thread> workers;
+    workers.reserve(thread_count);
+
+    for (std::size_t thread_index = 0; thread_index < thread_count; ++thread_index) {
+        workers.emplace_back([&, thread_index] {
+            submissions[thread_index].reserve(requests_per_thread);
+            start_gate.arrive_and_wait();
+            for (std::size_t request_index = 0;
+                 request_index < requests_per_thread;
+                 ++request_index) {
+                submissions[thread_index].push_back(controller.RequestStart(
+                    StartOptions(output, "not-started.mpd")
+                ));
+            }
+        });
+    }
+    start_gate.arrive_and_wait();
+    for (std::thread& worker : workers) {
+        worker.join();
+    }
+
+    std::size_t accepted = 0;
+    std::size_t rejected = 0;
+    for (const auto& per_thread : submissions) {
+        for (const ProfileCaptureRequestSubmission& submission : per_thread) {
+            Expect(
+                submission.ticket.Valid(),
+                "concurrent submission lost its completion ticket"
+            );
+            if (submission.result == ProfileCaptureSubmitResult::Queued) {
+                ++accepted;
+            } else {
+                Expect(
+                    submission.result == ProfileCaptureSubmitResult::QueueFull,
+                    "concurrent bounded admission returned an unexpected result"
+                );
+                ++rejected;
+            }
+        }
+    }
+    Expect(
+        accepted == queue_capacity && rejected == request_count - queue_capacity,
+        "concurrent MPSC admission did not enforce its exact resident bound"
+    );
+    const ProfileCaptureControllerSnapshot admitted = controller.GetSnapshot();
+    Expect(
+        admitted.queued_requests == queue_capacity &&
+            admitted.requests_submitted == request_count &&
+            admitted.requests_accepted == queue_capacity &&
+            admitted.requests_rejected == request_count - queue_capacity,
+        "concurrent MPSC snapshot accounting is inconsistent"
+    );
+
+    Expect(
+        controller.BeginEngineShutdown() ==
+            ProfileCaptureLifecycleResult::Advanced,
+        "shutdown did not close concurrent request admission"
+    );
+    std::set<std::uint64_t> request_ids;
+    std::uint64_t           largest_accepted_request_id = 0;
+    for (const auto& per_thread : submissions) {
+        for (const ProfileCaptureRequestSubmission& submission : per_thread) {
+            const ProfileCaptureRequestCompletion completion =
+                CompletionOf(
+                    submission.ticket,
+                    "shutdown did not complete every concurrent request ticket"
+                );
+            Expect(
+                completion.status ==
+                        ProfileCaptureCompletionStatus::CancelledForShutdown ||
+                    completion.status ==
+                        ProfileCaptureCompletionStatus::RejectedQueueFull,
+                "concurrent ticket reached an unexpected terminal status"
+            );
+            if (submission.result == ProfileCaptureSubmitResult::Queued) {
+                Expect(
+                    completion.status ==
+                        ProfileCaptureCompletionStatus::CancelledForShutdown,
+                    "accepted concurrent request was not cancelled from the FIFO"
+                );
+                largest_accepted_request_id =
+                    std::max(largest_accepted_request_id, completion.request_id);
+            }
+            request_ids.insert(completion.request_id);
+        }
+    }
+    Expect(
+        request_ids.size() == request_count,
+        "concurrent request ids were duplicated"
+    );
+    Expect(
+        *request_ids.begin() != 0 &&
+            *request_ids.rbegin() - *request_ids.begin() + 1 == request_count,
+        "concurrent request ids were not allocated from one bounded contiguous interval"
+    );
+    const ProfileCaptureControllerSnapshot cancelled = controller.GetSnapshot();
+    Expect(
+        largest_accepted_request_id != 0 &&
+            cancelled.last_completed_request_id ==
+                largest_accepted_request_id &&
+            cancelled.last_completion_status ==
+                ProfileCaptureCompletionStatus::CancelledForShutdown,
+        "concurrent request ids did not remain monotonic with FIFO cancellation order"
+    );
+    FinishEngineShutdown(controller);
+}
+
+void ReadyTicketPublishesCompletionAccounting() {
+    constexpr std::size_t request_count = 512;
+
+    ScopedCaptureOutput      output("moer-profile-controller-ready-publication");
+    RenderProfileCapture     capture;
+    ProfileCaptureController controller(&capture, request_count);
+    std::vector<ProfileCaptureRequestSubmission> submissions;
+    submissions.reserve(request_count);
+    for (std::size_t index = 0; index < request_count; ++index) {
+        submissions.push_back(controller.RequestStart(
+            StartOptions(output, "never-started.mpd")
+        ));
+        Expect(
+            submissions.back().result == ProfileCaptureSubmitResult::Queued,
+            "ready-publication setup unexpectedly exceeded its queue"
+        );
+    }
+
+    std::barrier cancellation_gate(2);
+    std::atomic_bool publication_violation{false};
+    std::atomic_bool stop_observer{false};
+    std::thread observer([&] {
+        cancellation_gate.arrive_and_wait();
+        for (const ProfileCaptureRequestSubmission& submission : submissions) {
+            while (!submission.ticket.Ready()) {
+                if (stop_observer.load(std::memory_order_relaxed)) {
+                    publication_violation.store(true, std::memory_order_relaxed);
+                    return;
+                }
+                std::this_thread::yield();
+            }
+
+            ProfileCaptureRequestCompletion completion{};
+            if (!submission.ticket.TryGet(completion)) {
+                publication_violation.store(true, std::memory_order_relaxed);
+                return;
+            }
+
+            // Cancellation is FIFO and ids are assigned at that same
+            // linearization point. Once Ready is visible, the snapshot must
+            // already include this completion or a later one.
+            const ProfileCaptureControllerSnapshot snapshot =
+                controller.GetSnapshot();
+            if (snapshot.requests_completed < completion.request_id ||
+                snapshot.last_completed_request_id < completion.request_id) {
+                publication_violation.store(true, std::memory_order_relaxed);
+                return;
+            }
+        }
+    });
+
+    cancellation_gate.arrive_and_wait();
+    const ProfileCaptureLifecycleResult begin_result =
+        controller.BeginEngineShutdown();
+    if (begin_result != ProfileCaptureLifecycleResult::Advanced) {
+        stop_observer.store(true, std::memory_order_relaxed);
+    }
+    observer.join();
+    Expect(
+        begin_result == ProfileCaptureLifecycleResult::Advanced,
+        "ready-publication shutdown did not begin"
+    );
+    Expect(
+        !publication_violation.load(std::memory_order_relaxed),
+        "ticket Ready became visible before its snapshot completion accounting"
+    );
+    const ProfileCaptureControllerSnapshot completed = controller.GetSnapshot();
+    Expect(
+        completed.requests_completed == request_count &&
+            completed.last_completed_request_id == request_count &&
+            completed.last_completion_status ==
+                ProfileCaptureCompletionStatus::CancelledForShutdown,
+        "ready-publication final completion accounting is inconsistent"
+    );
+    FinishEngineShutdown(controller);
+}
+
+void ExternalRuntimeIsNeverAdoptedOrShutdown() {
+    ScopedCaptureOutput output("moer-profile-controller-external");
+    RuntimeConfig       external_config{};
+    external_config.output_path      = output.Path("external.mpd");
+    external_config.replace_existing = true;
+    Expect(
+        Start(external_config) == StartResult::Started,
+        "external ProfileDump test runtime did not start"
+    );
+    const std::uint64_t external_generation = GetRuntimeGeneration();
+
+    RenderProfileCapture capture;
+    {
+        ProfileCaptureController controller(&capture, 4);
+        ProfileCaptureRequestSubmission request =
+            controller.RequestStart(StartOptions(output, "controller.mpd"));
+        Expect(
+            request.result == ProfileCaptureSubmitResult::Queued,
+            "controller did not queue a start probe against an external runtime"
+        );
+        TickUntilReady(
+            controller,
+            request.ticket,
+            "external-runtime start probe did not complete"
+        );
+        const ProfileCaptureRequestCompletion completion =
+            CompletionOf(request.ticket, "external-runtime completion was not ready");
+        Expect(
+            completion.status ==
+                ProfileCaptureCompletionStatus::RejectedExternalRuntime,
+            "ProfileDump::AlreadyRunning was not exposed as external ownership"
+        );
+        const ProfileCaptureControllerSnapshot snapshot = controller.GetSnapshot();
+        Expect(
+            snapshot.state == ProfileCaptureControllerState::Idle &&
+                !snapshot.owns_runtime && snapshot.active_generation == 0 &&
+                !capture.Valid(),
+            "controller adopted state from an externally owned ProfileDump runtime"
+        );
+        Expect(
+            GetRuntimeState() == RuntimeState::Running &&
+                GetRuntimeGeneration() == external_generation,
+            "external ProfileDump runtime changed while the controller rejected adoption"
+        );
+    }
+    Expect(
+        GetRuntimeState() == RuntimeState::Running &&
+            GetRuntimeGeneration() == external_generation,
+        "controller destructor shut down or replaced the external runtime"
+    );
+    Expect(
+        Shutdown() == ShutdownResult::Completed,
+        "external owner could not shut down its untouched runtime"
+    );
+}
+
+void ControllerDestructorClosesOwnedRunningSession() {
+    ScopedCaptureOutput      output("moer-profile-controller-destroy-running");
+    RenderProfileCapture     capture;
+    std::uint64_t            generation = 0;
+    {
+        auto controller = std::make_unique<ProfileCaptureController>(&capture, 4);
+        generation = StartCapture(
+            *controller,
+            StartOptions(output, "destroy-running.mpd")
+        );
+        Expect(
+            capture.Valid() && GetRuntimeState() == RuntimeState::Running,
+            "running-destructor setup did not own a live capture session"
+        );
+    }
+
+    const RenderProfileCaptureStats stats = capture.GetStats();
+    Expect(
+        !capture.Valid() && stats.closed && stats.generation == generation &&
+            GetRuntimeState() == RuntimeState::Stopped &&
+            !CpuScopeProducer::IsActive(),
+        "controller destructor leaked its owned running generation"
+    );
+}
+
+void ControllerDestructorClosesOwnedStoppingSession() {
+    ScopedCaptureOutput      output("moer-profile-controller-destroy-stopping");
+    RenderProfileCapture     capture;
+    RenderProfileFrameToken frame;
+    ProfileCaptureRequestTicket stop_ticket;
+    std::uint64_t            generation = 0;
+    {
+        auto controller = std::make_unique<ProfileCaptureController>(&capture, 4);
+        generation = StartCapture(
+            *controller,
+            StartOptions(output, "destroy-stopping.mpd")
+        );
+        frame = capture.BeginFrame();
+        Expect(
+            frame.Valid(),
+            "stopping-destructor setup did not admit its pending GPU frame"
+        );
+        ProfileCaptureRequestSubmission stop =
+            controller->RequestStop(generation);
+        Expect(
+            stop.result == ProfileCaptureSubmitResult::Queued,
+            "stopping-destructor stop request was not queued"
+        );
+        stop_ticket = stop.ticket;
+        Expect(
+            controller->TickOwner() ==
+                    ProfileCaptureTickResult::WaitingForGpu &&
+                controller->GetSnapshot().state ==
+                    ProfileCaptureControllerState::StoppingGpu &&
+                !stop_ticket.Ready(),
+            "stopping-destructor setup did not retain its unsealed GPU tail"
+        );
+    }
+
+    const RenderProfileCaptureStats stats = capture.GetStats();
+    Expect(
+        !capture.Valid() && stats.closed && stats.generation == generation &&
+            stats.shutdown_abandoned_frames == 1 &&
+            GetRuntimeState() == RuntimeState::Stopped &&
+            !CpuScopeProducer::IsActive(),
+        "controller destructor leaked or presented its pending GPU tail as complete"
+    );
+    const ProfileCaptureRequestCompletion stop_completion =
+        CompletionOf(
+            stop_ticket,
+            "controller destructor left the active stop ticket pending"
+        );
+    Expect(
+        stop_completion.generation == generation &&
+            stop_completion.status ==
+                ProfileCaptureCompletionStatus::ControllerDestroyed,
+        "controller destructor published an invalid pending-stop terminal result"
+    );
+    frame = {};
+}
+
+void NullFacadeRunsAndStopsCpuOnlyCapture() {
+    ScopedCaptureOutput      output("moer-profile-controller-cpu-only-stop");
+    ProfileCaptureController controller(nullptr, 4);
+    const std::uint64_t generation = StartCpuOnlyCapture(
+        controller,
+        StartOptions(output, "cpu-only-stop.mpd")
+    );
+
+    ProfileCaptureControllerSnapshot snapshot = controller.GetSnapshot();
+    Expect(
+        snapshot.state == ProfileCaptureControllerState::Running &&
+            snapshot.owns_runtime && snapshot.cpu_producer_active &&
+            !snapshot.gpu_session_active &&
+            snapshot.active_generation == generation &&
+            GetRuntimeState() == RuntimeState::Running &&
+            GetRuntimeGeneration() == generation &&
+            CpuScopeProducer::IsActive(),
+        "CPU-only start did not publish its runtime and producer ownership"
+    );
+
+    const ProfileCaptureRequestCompletion stopped =
+        StopCapture(controller, generation);
+    snapshot = controller.GetSnapshot();
+    Expect(
+        stopped.status == ProfileCaptureCompletionStatus::Stopped &&
+            stopped.generation == generation &&
+            snapshot.state == ProfileCaptureControllerState::Idle &&
+            !snapshot.owns_runtime && !snapshot.cpu_producer_active &&
+            !snapshot.gpu_session_active &&
+            snapshot.active_generation == 0 &&
+            GetRuntimeState() == RuntimeState::Stopped &&
+            !CpuScopeProducer::IsActive(),
+        "exact-generation CPU-only stop leaked its owned runtime"
+    );
+}
+
+void NullFacadePreservesEngineShutdownSplit() {
+    ScopedCaptureOutput      output("moer-profile-controller-cpu-only-shutdown");
+    ProfileCaptureController controller(nullptr, 4);
+    const std::uint64_t generation = StartCpuOnlyCapture(
+        controller,
+        StartOptions(output, "cpu-only-shutdown.mpd")
+    );
+
+    Expect(
+        controller.BeginEngineShutdown() ==
+            ProfileCaptureLifecycleResult::Advanced,
+        "CPU-only Engine shutdown did not begin"
+    );
+    ProfileCaptureControllerSnapshot snapshot = controller.GetSnapshot();
+    Expect(
+        snapshot.state == ProfileCaptureControllerState::AwaitingRhiDrain &&
+            snapshot.owns_runtime && !snapshot.cpu_producer_active &&
+            !snapshot.gpu_session_active &&
+            snapshot.active_generation == generation &&
+            GetRuntimeState() == RuntimeState::Running &&
+            !CpuScopeProducer::IsActive(),
+        "CPU-only BeginEngineShutdown crossed the runtime finalization boundary"
+    );
+
+    Expect(
+        controller.FinalizeGpuAfterRhiDrain(true) ==
+            ProfileCaptureLifecycleResult::Advanced,
+        "CPU-only controller did not cross the post-RHI boundary"
+    );
+    snapshot = controller.GetSnapshot();
+    Expect(
+        snapshot.state ==
+                ProfileCaptureControllerState::AwaitingWorkerShutdown &&
+            snapshot.owns_runtime && !snapshot.gpu_session_active &&
+            snapshot.active_generation == generation &&
+            GetRuntimeState() == RuntimeState::Running,
+        "CPU-only post-RHI boundary shut down ProfileDump before workers joined"
+    );
+
+    Expect(
+        controller.FinalizeRuntimeAfterWorkers() ==
+            ProfileCaptureLifecycleResult::Advanced,
+        "CPU-only controller did not cross the post-worker boundary"
+    );
+    snapshot = controller.GetSnapshot();
+    Expect(
+        snapshot.state == ProfileCaptureControllerState::Shutdown &&
+            !snapshot.owns_runtime && !snapshot.cpu_producer_active &&
+            !snapshot.gpu_session_active &&
+            snapshot.active_generation == 0 &&
+            GetRuntimeState() == RuntimeState::Stopped,
+        "CPU-only post-worker boundary leaked its ProfileDump runtime"
+    );
+}
+
+void NullFacadeDestructorClosesOwnedCpuOnlyCapture() {
+    ScopedCaptureOutput output("moer-profile-controller-cpu-only-destructor");
+    std::uint64_t       generation = 0;
+    {
+        ProfileCaptureController controller(nullptr, 4);
+        generation = StartCpuOnlyCapture(
+            controller,
+            StartOptions(output, "cpu-only-destructor.mpd")
+        );
+        Expect(
+            GetRuntimeState() == RuntimeState::Running &&
+                GetRuntimeGeneration() == generation &&
+                CpuScopeProducer::IsActive(),
+            "CPU-only destructor setup did not own a live generation"
+        );
+    }
+
+    Expect(
+        generation != 0 && GetRuntimeState() == RuntimeState::Stopped &&
+            !CpuScopeProducer::IsActive(),
+        "null-facade controller destructor leaked its owned CPU-only generation"
+    );
+}
+
+void RestartUsesStableFacadeAndRejectsStaleStop() {
+    ScopedCaptureOutput      output("moer-profile-controller-restart");
+    RenderProfileCapture     capture;
+    RenderProfileCapture* const stable_facade = &capture;
+    ProfileCaptureController controller(stable_facade, 8);
+
+    const std::uint64_t first_generation =
+        StartCapture(controller, StartOptions(output, "first.mpd"));
+    Expect(
+        &capture == stable_facade && capture.Valid() &&
+            capture.GetStats().generation == first_generation,
+        "first generation was not published through the stable GPU facade"
+    );
+    const ProfileCaptureRequestCompletion first_stop =
+        StopCapture(controller, first_generation);
+    Expect(
+        first_stop.status == ProfileCaptureCompletionStatus::Stopped &&
+            first_stop.generation == first_generation &&
+            GetRuntimeState() == RuntimeState::Stopped,
+        "first dynamic generation did not close cleanly"
+    );
+
+    const std::uint64_t second_generation =
+        StartCapture(controller, StartOptions(output, "second.mpd"));
+    Expect(
+        second_generation > first_generation && &capture == stable_facade &&
+            capture.Valid() &&
+            capture.GetStats().generation == second_generation,
+        "restart did not rebind the stable GPU facade to a newer generation"
+    );
+
+    ProfileCaptureRequestSubmission stale_stop =
+        controller.RequestStop(first_generation);
+    Expect(
+        stale_stop.result == ProfileCaptureSubmitResult::Queued,
+        "non-zero stale stop was rejected before owner-side generation validation"
+    );
+    TickUntilReady(
+        controller,
+        stale_stop.ticket,
+        "stale stop request did not complete"
+    );
+    const ProfileCaptureRequestCompletion stale_completion =
+        CompletionOf(stale_stop.ticket, "stale stop completion was not ready");
+    Expect(
+        stale_completion.status ==
+                ProfileCaptureCompletionStatus::RejectedStaleGeneration &&
+            stale_completion.generation == second_generation,
+        "old-generation stop did not report the currently protected generation"
+    );
+    const ProfileCaptureControllerSnapshot after_stale = controller.GetSnapshot();
+    Expect(
+        after_stale.state == ProfileCaptureControllerState::Running &&
+            after_stale.active_generation == second_generation &&
+            after_stale.owns_runtime && capture.Valid() &&
+            GetRuntimeState() == RuntimeState::Running,
+        "stale stop mutated the restarted capture session"
+    );
+
+    const ProfileCaptureRequestCompletion second_stop =
+        StopCapture(controller, second_generation);
+    Expect(
+        second_stop.status == ProfileCaptureCompletionStatus::Stopped &&
+            GetRuntimeState() == RuntimeState::Stopped,
+        "current-generation stop did not close the restarted session"
+    );
+}
+
+void AdmittedFrameKeepsDynamicStopPendingUntilSealed() {
+    ScopedCaptureOutput      output("moer-profile-controller-pending-frame");
+    RenderProfileCapture     capture;
+    ProfileCaptureController controller(&capture, 4);
+    const std::uint64_t generation =
+        StartCapture(controller, StartOptions(output, "pending-frame.mpd"));
+
+    RenderProfileFrameToken frame = capture.BeginFrame();
+    Expect(frame.Valid(), "running controller did not admit a GPU frame token");
+    ProfileCaptureRequestSubmission stop = controller.RequestStop(generation);
+    Expect(
+        stop.result == ProfileCaptureSubmitResult::Queued,
+        "pending-frame stop request was not queued"
+    );
+    Expect(
+        controller.TickOwner() == ProfileCaptureTickResult::WaitingForGpu,
+        "owner did not expose the pending admitted GPU frame"
+    );
+    Expect(
+        !stop.ticket.Ready() &&
+            controller.GetSnapshot().state ==
+                ProfileCaptureControllerState::StoppingGpu &&
+            GetRuntimeState() == RuntimeState::Running,
+        "dynamic stop finalized while an admitted GPU frame remained unsealed"
+    );
+    Expect(
+        controller.TickOwner() == ProfileCaptureTickResult::WaitingForGpu &&
+            !stop.ticket.Ready(),
+        "repeated owner polling bypassed an admitted GPU frame"
+    );
+
+    Expect(capture.Seal(frame), "admitted GPU frame could not be sealed after stop");
+    TickUntilReady(
+        controller,
+        stop.ticket,
+        "sealed admitted GPU frame did not let stop finish"
+    );
+    const ProfileCaptureRequestCompletion completion =
+        CompletionOf(stop.ticket, "pending-frame stop completion was not ready");
+    Expect(
+        completion.status == ProfileCaptureCompletionStatus::Stopped &&
+            completion.generation == generation &&
+            controller.GetSnapshot().state ==
+                ProfileCaptureControllerState::Idle &&
+            GetRuntimeState() == RuntimeState::Stopped,
+        "sealed admitted GPU frame did not close the owned runtime cleanly"
+    );
+}
+
+void EngineShutdownPreservesRhiAndWorkerOwnershipBoundaries() {
+    ScopedCaptureOutput      output("moer-profile-controller-shutdown-split");
+    RenderProfileCapture     capture;
+    ProfileCaptureController controller(&capture, 4);
+    const std::uint64_t generation =
+        StartCapture(controller, StartOptions(output, "shutdown-split.mpd"));
+
+    Expect(
+        controller.BeginEngineShutdown() ==
+            ProfileCaptureLifecycleResult::Advanced,
+        "owned controller did not begin engine shutdown"
+    );
+    ProfileCaptureControllerSnapshot snapshot = controller.GetSnapshot();
+    Expect(
+        snapshot.state == ProfileCaptureControllerState::AwaitingRhiDrain &&
+            !snapshot.accepting_requests && snapshot.owns_runtime &&
+            snapshot.active_generation == generation &&
+            GetRuntimeState() == RuntimeState::Running,
+        "BeginEngineShutdown crossed the RHI or ProfileDump owner boundary"
+    );
+    Expect(
+        !capture.Valid(),
+        "BeginEngineShutdown did not close future GPU frame admission"
+    );
+
+    Expect(
+        controller.FinalizeGpuAfterRhiDrain(true) ==
+            ProfileCaptureLifecycleResult::Advanced,
+        "post-RHI GPU finalization did not advance"
+    );
+    snapshot = controller.GetSnapshot();
+    Expect(
+        snapshot.state ==
+                ProfileCaptureControllerState::AwaitingWorkerShutdown &&
+            snapshot.owns_runtime && !snapshot.gpu_session_active &&
+            GetRuntimeState() == RuntimeState::Running,
+        "GPU finalization shut down ProfileDump before worker producers joined"
+    );
+
+    Expect(
+        controller.FinalizeRuntimeAfterWorkers() ==
+            ProfileCaptureLifecycleResult::Advanced,
+        "post-worker ProfileDump finalization did not advance"
+    );
+    snapshot = controller.GetSnapshot();
+    Expect(
+        snapshot.state == ProfileCaptureControllerState::Shutdown &&
+            !snapshot.owns_runtime && snapshot.active_generation == 0 &&
+            GetRuntimeState() == RuntimeState::Stopped,
+        "post-worker finalization did not release the owned ProfileDump runtime"
+    );
+}
+
+void WorkerShutdownFailureAbandonsRuntimeWithoutUnsafeFinalization() {
+    ScopedCaptureOutput  output("moer-profile-controller-worker-failure");
+    RenderProfileCapture capture;
+    std::uint64_t        generation = 0;
+
+    {
+        ProfileCaptureController controller(&capture, 4);
+        generation = StartCapture(
+            controller,
+            StartOptions(output, "worker-failure.mpd")
+        );
+
+        Expect(
+            controller.BeginEngineShutdown() ==
+                ProfileCaptureLifecycleResult::Advanced,
+            "worker-failure setup did not begin engine shutdown"
+        );
+        Expect(
+            controller.FinalizeGpuAfterRhiDrain(true) ==
+                ProfileCaptureLifecycleResult::Advanced,
+            "worker-failure setup did not cross the post-RHI boundary"
+        );
+        Expect(
+            controller.AbandonRuntimeAfterWorkerShutdownFailure() ==
+                ProfileCaptureLifecycleResult::Advanced,
+            "worker-failure path did not abandon controller ownership"
+        );
+
+        const ProfileCaptureControllerSnapshot snapshot =
+            controller.GetSnapshot();
+        Expect(
+            snapshot.state == ProfileCaptureControllerState::Shutdown &&
+                !snapshot.owns_runtime &&
+                snapshot.active_generation == 0 &&
+                GetRuntimeState() == RuntimeState::Running &&
+                GetRuntimeGeneration() == generation,
+            "worker-failure path touched ProfileDump or retained destructor ownership"
+        );
+    }
+
+    Expect(
+        GetRuntimeState() == RuntimeState::Running &&
+            GetRuntimeGeneration() == generation,
+        "controller destructor retried unsafe runtime finalization after worker failure"
+    );
+}
+
+void ClosingAdmissionCancelsQueuedTickets() {
+    ScopedCaptureOutput      output("moer-profile-controller-cancel-queue");
+    RenderProfileCapture     capture;
+    ProfileCaptureController controller(&capture, 4);
+
+    ProfileCaptureRequestSubmission queued_start =
+        controller.RequestStart(StartOptions(output, "never-started.mpd"));
+    ProfileCaptureRequestSubmission queued_stop =
+        controller.RequestStop(42);
+    Expect(
+        queued_start.result == ProfileCaptureSubmitResult::Queued &&
+            queued_stop.result == ProfileCaptureSubmitResult::Queued &&
+            controller.GetSnapshot().queued_requests == 2,
+        "shutdown cancellation setup did not retain both queued requests"
+    );
+    Expect(
+        controller.BeginEngineShutdown() ==
+            ProfileCaptureLifecycleResult::Advanced,
+        "idle shutdown did not close request admission"
+    );
+    const ProfileCaptureRequestCompletion start_completion =
+        CompletionOf(
+            queued_start.ticket,
+            "shutdown did not cancel a queued start ticket"
+        );
+    const ProfileCaptureRequestCompletion stop_completion =
+        CompletionOf(
+            queued_stop.ticket,
+            "shutdown did not cancel a queued stop ticket"
+        );
+    Expect(
+        start_completion.status ==
+                ProfileCaptureCompletionStatus::CancelledForShutdown &&
+            stop_completion.status ==
+                ProfileCaptureCompletionStatus::CancelledForShutdown &&
+            controller.GetSnapshot().queued_requests == 0 &&
+            GetRuntimeState() == RuntimeState::Stopped,
+        "closing admission did not cancel the entire queued FIFO"
+    );
+
+    ProfileCaptureRequestSubmission rejected =
+        controller.RequestStart(StartOptions(output, "after-close.mpd"));
+    Expect(
+        rejected.result == ProfileCaptureSubmitResult::AdmissionClosed,
+        "closed controller admitted a new capture request"
+    );
+    const ProfileCaptureRequestCompletion rejected_completion =
+        CompletionOf(
+            rejected.ticket,
+            "closed-admission request did not complete synchronously"
+        );
+    Expect(
+        rejected_completion.status ==
+            ProfileCaptureCompletionStatus::RejectedAdmissionClosed,
+        "closed-admission ticket lost its rejection reason"
+    );
+    FinishEngineShutdown(controller);
+}
+
+} // namespace
+
+int main() {
+    try {
+        AdmissionValidationQueueCapacityAndFifo();
+        ConcurrentSubmissionIdsAreUniqueAndQueueIsBounded();
+        ReadyTicketPublishesCompletionAccounting();
+        ExternalRuntimeIsNeverAdoptedOrShutdown();
+        ControllerDestructorClosesOwnedRunningSession();
+        ControllerDestructorClosesOwnedStoppingSession();
+        NullFacadeRunsAndStopsCpuOnlyCapture();
+        NullFacadePreservesEngineShutdownSplit();
+        NullFacadeDestructorClosesOwnedCpuOnlyCapture();
+        RestartUsesStableFacadeAndRejectsStaleStop();
+        AdmittedFrameKeepsDynamicStopPendingUntilSealed();
+        EngineShutdownPreservesRhiAndWorkerOwnershipBoundaries();
+        WorkerShutdownFailureAbandonsRuntimeWithoutUnsafeFinalization();
+        ClosingAdmissionCancelsQueuedTickets();
+    } catch (const std::exception& error) {
+        std::cerr << "ProfileCaptureControllerContract: " << error.what() << '\n';
+        return 1;
+    }
+    std::cout << "ProfileCaptureControllerContract: all checks passed\n";
+    return 0;
+}

--- a/template.MoerEngine.toml
+++ b/template.MoerEngine.toml
@@ -32,6 +32,8 @@ parallel_record_min_work_units_per_job = 64
 submission_batch_window = 2
 
 [engine.profile_dump]
+# Enqueues the initial capture session during Engine startup. The Engine-owned
+# controller may stop this generation and start later generations at runtime.
 enabled = false
 output_path = "./profile/MoerProfile.mpd"
 # The previous final capture is replaced only after the new capture closes successfully.


### PR DESCRIPTION
## Summary

- add an Engine-owned, Game-Thread-driven `ProfileCaptureController`
- expose bounded MPSC Start/Stop requests, per-request completion tickets, exact generation checks, and a stable GPU capture facade across restarts
- preserve CPU-only capture when the GPU facade is unavailable; reject external runtimes instead of adopting them
- make dynamic Stop drain the GPU tail asynchronously before closing ProfileDump
- split Engine shutdown ownership across request admission, post-RHI GPU finalization, and post-worker ProfileDump finalization
- abandon active runtime bookkeeping without unsafe finalization when worker quiescence cannot be proven
- add `--profile-capture-lifecycle-validation`

## Architecture relation

This follows the useful `dev_parallel_rhi` ownership principle that GPU results are resolved by Completion and upper layers only express lifecycle intent. It is implemented on top of main's restartable ProfileDump and generation-scoped `RenderProfileCapture`, rather than porting the legacy Trace/CSV control path.

## Validation

- Debug / RelWithDebInfo / Release full build + CTest: 29/29 each
- real Debug Vulkan run with Render Thread, RHI Thread, and parallel recording enabled: PASS
  - generation A: 6 complete GPU frames, 145/145 ready GPU scopes
  - generation B: 6 complete GPU frames, 222/222 ready GPU scopes
  - stable facade reused; stale Stop(A) rejected without mutating B
  - both MPD files complete with SessionEnd and zero loss/error/orphan scopes
  - no `.inprogress` residue
- `git diff --check`: clean
- independent pre-PR P1/P2 reviews: clean after fixing the worker-shutdown failure path

## Test coverage

`ProfileCaptureControllerContract` covers bounded FIFO/MPSC admission, request-ID linearization, completion publication ordering, external ownership, restart/stale generation protection, pending GPU tails, CPU-only fallback, split Engine shutdown, worker-failure abandonment, and exact-generation destructor fallback.