### PR TITLE
Phase 21D.2b: add Editor dynamic capture controls

### DIFF
--- a/source/editor/Editor.cpp
+++ b/source/editor/Editor.cpp
@@ -47,7 +47,8 @@ void Editor::Run(const ExtraHooks& extra_hooks) {
     m_editor_ui = MakeUnique<EditorUI>(
         MakeUnique<Render::UIRenderer>(RenderDevice::Get()),
         m_engine->GetEditorConfig(),
-        m_engine->GetRemoteModuleController()
+        m_engine->GetRemoteModuleController(),
+        *m_engine
     );
 
     m_engine->Run(

--- a/source/editor/EditorUI.cpp
+++ b/source/editor/EditorUI.cpp
@@ -63,14 +63,16 @@ std::string BuildRenderMethodMenuLabel(ERenderMethod render_method) {
 EditorUI::EditorUI(
     UniquePtr<Render::UIRenderer>         renderer,
     SharedPtr<EditorConfig>               editor_config,
-    const remote::RemoteModuleController& remote_controller
+    const remote::RemoteModuleController& remote_controller,
+    Engine&                               engine
 ) :
-    m_ui_renderer(std::move(renderer)),
-    m_config(editor_config),
-    m_remote_controller(remote_controller),
     m_raster_ui(editor_config->raster_config),
     m_raytracing_ui(editor_config->raytracing_config),
-    m_scene_editing_ui(editor_config->scene_test_case_config) {
+    m_scene_editing_ui(editor_config->scene_test_case_config),
+    m_profile_capture_ui(engine),
+    m_config(editor_config),
+    m_remote_controller(remote_controller),
+    m_ui_renderer(std::move(renderer)) {
 
     const EditorWindowVisibilitySettings& window_visibility_settings =
         EditorUISettings::LoadWindowVisibilitySettings();
@@ -86,6 +88,8 @@ EditorUI::EditorUI(
         m_b_show_inspector     = window_visibility_settings.inspector;
         m_b_show_config        = window_visibility_settings.config;
         m_b_show_scene_editing = window_visibility_settings.scene_editing;
+        m_b_show_profile_capture =
+            window_visibility_settings.profile_capture;
 #if WITH_PROFILE
         m_b_show_memory_profiler = window_visibility_settings.memory_profiler;
 #endif
@@ -96,6 +100,8 @@ EditorUI::EditorUI(
         m_b_show_inspector     = has_saved_window_settings("Inspector");
         m_b_show_config        = has_saved_window_settings("Configs");
         m_b_show_scene_editing = has_saved_window_settings("Scene Editing");
+        m_b_show_profile_capture =
+            has_saved_window_settings("Profile Capture");
 #if WITH_PROFILE
         m_b_show_memory_profiler = has_saved_window_settings("Memory Profiler");
 #endif
@@ -363,6 +369,11 @@ void EditorUI::TickUI(Scene& scene) {
             ImGui::MenuItem("Inspector", nullptr, &m_b_show_inspector);
             ImGui::MenuItem("Configs", nullptr, &m_b_show_config);
             ImGui::MenuItem("Scene Editing", nullptr, &m_b_show_scene_editing);
+            ImGui::MenuItem(
+                "Profile Capture",
+                nullptr,
+                &m_b_show_profile_capture
+            );
             // ImGui::MenuItem("Demo", nullptr, &m_b_show_demo);
 #if WITH_PROFILE
             ImGui::MenuItem("Memory Profiler", nullptr, &m_b_show_memory_profiler);
@@ -372,6 +383,9 @@ void EditorUI::TickUI(Scene& scene) {
         ImGui::EndMenuBar();
     }
     ImGui::End();
+    if (m_b_show_profile_capture) {
+        m_profile_capture_ui.ShowWindow(&m_b_show_profile_capture);
+    }
 #if WITH_PROFILE
     if (m_b_show_memory_profiler) {
         ShowMemoryProfiler(&m_b_show_memory_profiler);
@@ -929,6 +943,7 @@ void EditorUI::SyncWindowVisibilitySettings() {
     settings.inspector     = m_b_show_inspector;
     settings.config        = m_b_show_config;
     settings.scene_editing = m_b_show_scene_editing;
+    settings.profile_capture = m_b_show_profile_capture;
 #if WITH_PROFILE
     settings.memory_profiler = m_b_show_memory_profiler;
 #else

--- a/source/editor/EditorUI.h
+++ b/source/editor/EditorUI.h
@@ -9,6 +9,7 @@
 #include "rhi/RHIResource.h"
 
 #include "inspector_ui/InspectorUI.h"
+#include "profile_capture_ui/ProfileCaptureUI.h"
 #include "raster_ui/RasterUI.h"
 #include "raytracing_ui/RaytracingUI.h"
 #include "scene_editing_ui/SceneEditingUI.h"
@@ -20,6 +21,7 @@
 namespace Moer {
 
 class Scene;
+class Engine;
 
 /**
  * EditorUI 是编辑器主界面的窗口协调器。
@@ -48,7 +50,8 @@ public:
     EditorUI(
         UniquePtr<Render::UIRenderer>         renderer,
         SharedPtr<EditorConfig>               editor_config,
-        const remote::RemoteModuleController& remote_controller
+        const remote::RemoteModuleController& remote_controller,
+        Engine&                               engine
     );
     ~EditorUI() = default;
     void TickUI(Scene& scene);
@@ -85,6 +88,7 @@ public: // Sub UI
     RaytracingUI   m_raytracing_ui;
     SceneEditingUI m_scene_editing_ui;
     RemoteExamplesUI m_remote_examples_ui;
+    ProfileCaptureUI m_profile_capture_ui;
 
 private:
     void ResetFrameState();
@@ -112,6 +116,7 @@ private:
     bool   m_b_show_inspector             = true;
     bool   m_b_show_config                = true;
     bool   m_b_show_scene_editing         = true;
+    bool   m_b_show_profile_capture       = false;
     bool   m_b_scene_color_mouse_captured = false;
     bool   m_b_active_viewport_window_seen = false;
     // ImGui 窗口几何信息使用浮点屏幕坐标表示。

--- a/source/editor/EditorUISettings.cpp
+++ b/source/editor/EditorUISettings.cpp
@@ -50,6 +50,11 @@ void ParseEditorWindowVisibilityLine(EditorWindowVisibilitySettings& settings, s
         TryParseBoolSetting(line, "Inspector", settings.inspector) ||
         TryParseBoolSetting(line, "Configs", settings.config) ||
         TryParseBoolSetting(line, "SceneEditing", settings.scene_editing) ||
+        TryParseBoolSetting(
+            line,
+            "ProfileCapture",
+            settings.profile_capture
+        ) ||
         TryParseBoolSetting(line, "MemoryProfiler", settings.memory_profiler)) {
         settings.loaded = true;
     }
@@ -87,6 +92,10 @@ void EditorWindowVisibilitySettingsWriteAll(ImGuiContext*, ImGuiSettingsHandler*
     out_buf->appendf("Inspector=%d\n", settings.inspector ? 1 : 0);
     out_buf->appendf("Configs=%d\n", settings.config ? 1 : 0);
     out_buf->appendf("SceneEditing=%d\n", settings.scene_editing ? 1 : 0);
+    out_buf->appendf(
+        "ProfileCapture=%d\n",
+        settings.profile_capture ? 1 : 0
+    );
     out_buf->appendf("MemoryProfiler=%d\n\n", settings.memory_profiler ? 1 : 0);
 }
 
@@ -152,7 +161,9 @@ bool IsSameWindowVisibilitySettings(
     return lhs.loaded == rhs.loaded && lhs.scene_color == rhs.scene_color &&
            lhs.scene_view == rhs.scene_view && lhs.hierarchy == rhs.hierarchy &&
            lhs.inspector == rhs.inspector && lhs.config == rhs.config &&
-           lhs.scene_editing == rhs.scene_editing && lhs.memory_profiler == rhs.memory_profiler;
+           lhs.scene_editing == rhs.scene_editing &&
+           lhs.profile_capture == rhs.profile_capture &&
+           lhs.memory_profiler == rhs.memory_profiler;
 }
 
 } // namespace

--- a/source/editor/EditorUISettings.h
+++ b/source/editor/EditorUISettings.h
@@ -19,6 +19,7 @@ struct EditorWindowVisibilitySettings {
     bool inspector       = true;
     bool config          = true;
     bool scene_editing   = true;
+    bool profile_capture = false;
     bool memory_profiler = false;
 };
 

--- a/source/editor/profile_capture_ui/ProfileCaptureControlModel.cpp
+++ b/source/editor/profile_capture_ui/ProfileCaptureControlModel.cpp
@@ -3,6 +3,35 @@
 #include <utility>
 
 namespace Moer {
+namespace {
+
+[[nodiscard]] bool IsCoherentRejection(
+    Render::ProfileCaptureSubmitResult      result,
+    Render::ProfileCaptureCompletionStatus status
+) noexcept {
+    switch (result) {
+        case Render::ProfileCaptureSubmitResult::AdmissionClosed:
+            return status ==
+                   Render::ProfileCaptureCompletionStatus::
+                       RejectedAdmissionClosed;
+        case Render::ProfileCaptureSubmitResult::QueueFull:
+            return status ==
+                   Render::ProfileCaptureCompletionStatus::RejectedQueueFull;
+        case Render::ProfileCaptureSubmitResult::InvalidArgument:
+            return status ==
+                   Render::ProfileCaptureCompletionStatus::
+                       RejectedInvalidArgument;
+        case Render::ProfileCaptureSubmitResult::ResourceExhausted:
+            return status ==
+                   Render::ProfileCaptureCompletionStatus::
+                       RejectedResourceExhausted;
+        case Render::ProfileCaptureSubmitResult::Queued:
+            return false;
+    }
+    return false;
+}
+
+} // namespace
 
 ProfileCaptureControlModel::ProfileCaptureControlModel(
     ProfileCaptureControlCallbacks callbacks
@@ -200,16 +229,32 @@ ProfileCaptureControlModel::AcceptSubmission(
 ) noexcept {
     last_submit_result_ = submission.result;
     if (submission.result != Render::ProfileCaptureSubmitResult::Queued) {
-        if (submission.ticket.Valid()) {
-            Render::ProfileCaptureRequestCompletion completion;
-            if (!submission.ticket.TryGet(completion) ||
-                completion.kind != kind) {
+        last_completion_.reset();
+        if (!submission.ticket.Valid()) {
+            // Completion-state allocation and lock acquisition can fail
+            // before the controller has a request id to publish. That
+            // deliberately ticketless ResourceExhausted result is the only
+            // well-formed rejection without a terminal ticket.
+            if (submission.result ==
+                Render::ProfileCaptureSubmitResult::ResourceExhausted) {
+                last_action_result_ =
+                    EProfileCaptureControlActionResult::BackendRejected;
+            } else {
                 last_action_result_ =
                     EProfileCaptureControlActionResult::InvalidSubmission;
-                return last_action_result_;
             }
-            last_completion_ = completion;
+            return last_action_result_;
         }
+
+        Render::ProfileCaptureRequestCompletion completion;
+        if (!submission.ticket.TryGet(completion) ||
+            completion.kind != kind ||
+            !IsCoherentRejection(submission.result, completion.status)) {
+            last_action_result_ =
+                EProfileCaptureControlActionResult::InvalidSubmission;
+            return last_action_result_;
+        }
+        last_completion_ = completion;
         last_action_result_ =
             EProfileCaptureControlActionResult::BackendRejected;
         return last_action_result_;

--- a/source/editor/profile_capture_ui/ProfileCaptureControlModel.cpp
+++ b/source/editor/profile_capture_ui/ProfileCaptureControlModel.cpp
@@ -1,0 +1,232 @@
+#include "profile_capture_ui/ProfileCaptureControlModel.h"
+
+#include <utility>
+
+namespace Moer {
+
+ProfileCaptureControlModel::ProfileCaptureControlModel(
+    ProfileCaptureControlCallbacks callbacks
+) noexcept :
+    callbacks_(std::move(callbacks)) {
+    Refresh();
+}
+
+void ProfileCaptureControlModel::Refresh() noexcept {
+    if (has_pending_request_) {
+        Render::ProfileCaptureRequestCompletion completion;
+        if (pending_ticket_.TryGet(completion)) {
+            if (completion.kind == pending_kind_) {
+                last_completion_ = completion;
+                last_action_result_ =
+                    EProfileCaptureControlActionResult::Completed;
+            } else {
+                last_action_result_ =
+                    EProfileCaptureControlActionResult::InvalidSubmission;
+            }
+            pending_ticket_     = {};
+            pending_expected_generation_ = 0;
+            has_pending_request_ = false;
+        }
+    }
+
+    if (!callbacks_.get_snapshot) {
+        snapshot_ = {};
+        snapshot_.state = Render::ProfileCaptureControllerState::Shutdown;
+        snapshot_.accepting_requests = false;
+        snapshot_status_ = SnapshotStatus::CallbackUnavailable;
+        last_action_result_ =
+            EProfileCaptureControlActionResult::CallbackUnavailable;
+        return;
+    }
+
+    try {
+        snapshot_ = callbacks_.get_snapshot();
+        snapshot_status_ = SnapshotStatus::Available;
+    } catch (...) {
+        snapshot_ = {};
+        snapshot_.state = Render::ProfileCaptureControllerState::Shutdown;
+        snapshot_.accepting_requests = false;
+        snapshot_status_ = SnapshotStatus::CallbackFailed;
+        last_action_result_ =
+            EProfileCaptureControlActionResult::CallbackFailed;
+    }
+}
+
+EProfileCaptureControlActionResult ProfileCaptureControlModel::RequestStart(
+    Render::ProfileCaptureStartOptions options
+) noexcept {
+    Refresh();
+    if (has_pending_request_) {
+        last_action_result_ =
+            EProfileCaptureControlActionResult::PendingRequest;
+        return last_action_result_;
+    }
+    if (snapshot_status_ == SnapshotStatus::CallbackUnavailable) {
+        last_action_result_ =
+            EProfileCaptureControlActionResult::CallbackUnavailable;
+        return last_action_result_;
+    }
+    if (snapshot_status_ == SnapshotStatus::CallbackFailed) {
+        last_action_result_ =
+            EProfileCaptureControlActionResult::CallbackFailed;
+        return last_action_result_;
+    }
+    if (options.runtime.output_path.empty()) {
+        last_action_result_ =
+            EProfileCaptureControlActionResult::InvalidOutputPath;
+        return last_action_result_;
+    }
+    if (!CanRequestStart()) {
+        last_action_result_ =
+            EProfileCaptureControlActionResult::InvalidControllerState;
+        return last_action_result_;
+    }
+    if (!callbacks_.request_start) {
+        last_action_result_ =
+            EProfileCaptureControlActionResult::CallbackUnavailable;
+        return last_action_result_;
+    }
+
+    try {
+        return AcceptSubmission(
+            callbacks_.request_start(std::move(options)),
+            Render::ProfileCaptureRequestKind::Start,
+            0
+        );
+    } catch (...) {
+        last_action_result_ =
+            EProfileCaptureControlActionResult::CallbackFailed;
+        return last_action_result_;
+    }
+}
+
+EProfileCaptureControlActionResult
+ProfileCaptureControlModel::RequestStop() noexcept {
+    Refresh();
+    if (has_pending_request_) {
+        last_action_result_ =
+            EProfileCaptureControlActionResult::PendingRequest;
+        return last_action_result_;
+    }
+    if (snapshot_status_ == SnapshotStatus::CallbackUnavailable) {
+        last_action_result_ =
+            EProfileCaptureControlActionResult::CallbackUnavailable;
+        return last_action_result_;
+    }
+    if (snapshot_status_ == SnapshotStatus::CallbackFailed) {
+        last_action_result_ =
+            EProfileCaptureControlActionResult::CallbackFailed;
+        return last_action_result_;
+    }
+    if (!CanRequestStop()) {
+        last_action_result_ =
+            EProfileCaptureControlActionResult::InvalidControllerState;
+        return last_action_result_;
+    }
+    if (!callbacks_.request_stop) {
+        last_action_result_ =
+            EProfileCaptureControlActionResult::CallbackUnavailable;
+        return last_action_result_;
+    }
+
+    try {
+        const std::uint64_t expected_generation =
+            snapshot_.active_generation;
+        return AcceptSubmission(
+            callbacks_.request_stop(expected_generation),
+            Render::ProfileCaptureRequestKind::Stop,
+            expected_generation
+        );
+    } catch (...) {
+        last_action_result_ =
+            EProfileCaptureControlActionResult::CallbackFailed;
+        return last_action_result_;
+    }
+}
+
+bool ProfileCaptureControlModel::CanRequestStart() const noexcept {
+    return snapshot_status_ == SnapshotStatus::Available &&
+           !has_pending_request_ && snapshot_.accepting_requests &&
+           snapshot_.state == Render::ProfileCaptureControllerState::Idle &&
+           !snapshot_.owns_runtime && snapshot_.active_generation == 0;
+}
+
+bool ProfileCaptureControlModel::CanRequestStop() const noexcept {
+    return snapshot_status_ == SnapshotStatus::Available &&
+           !has_pending_request_ && snapshot_.accepting_requests &&
+           snapshot_.state == Render::ProfileCaptureControllerState::Running &&
+           snapshot_.owns_runtime && snapshot_.active_generation != 0;
+}
+
+bool ProfileCaptureControlModel::HasPendingRequest() const noexcept {
+    return has_pending_request_;
+}
+
+Render::ProfileCaptureRequestKind
+ProfileCaptureControlModel::PendingRequestKind() const noexcept {
+    return pending_kind_;
+}
+
+std::uint64_t
+ProfileCaptureControlModel::PendingExpectedGeneration() const noexcept {
+    return pending_expected_generation_;
+}
+
+const Render::ProfileCaptureControllerSnapshot&
+ProfileCaptureControlModel::Snapshot() const noexcept {
+    return snapshot_;
+}
+
+const std::optional<Render::ProfileCaptureRequestCompletion>&
+ProfileCaptureControlModel::LastCompletion() const noexcept {
+    return last_completion_;
+}
+
+EProfileCaptureControlActionResult
+ProfileCaptureControlModel::LastActionResult() const noexcept {
+    return last_action_result_;
+}
+
+Render::ProfileCaptureSubmitResult
+ProfileCaptureControlModel::LastSubmitResult() const noexcept {
+    return last_submit_result_;
+}
+
+EProfileCaptureControlActionResult
+ProfileCaptureControlModel::AcceptSubmission(
+    Render::ProfileCaptureRequestSubmission submission,
+    Render::ProfileCaptureRequestKind       kind,
+    std::uint64_t                           expected_generation
+) noexcept {
+    last_submit_result_ = submission.result;
+    if (submission.result != Render::ProfileCaptureSubmitResult::Queued) {
+        if (submission.ticket.Valid()) {
+            Render::ProfileCaptureRequestCompletion completion;
+            if (!submission.ticket.TryGet(completion) ||
+                completion.kind != kind) {
+                last_action_result_ =
+                    EProfileCaptureControlActionResult::InvalidSubmission;
+                return last_action_result_;
+            }
+            last_completion_ = completion;
+        }
+        last_action_result_ =
+            EProfileCaptureControlActionResult::BackendRejected;
+        return last_action_result_;
+    }
+    if (!submission.ticket.Valid()) {
+        last_action_result_ =
+            EProfileCaptureControlActionResult::InvalidSubmission;
+        return last_action_result_;
+    }
+
+    pending_ticket_              = std::move(submission.ticket);
+    pending_kind_                = kind;
+    pending_expected_generation_ = expected_generation;
+    has_pending_request_         = true;
+    last_action_result_          =
+        EProfileCaptureControlActionResult::Submitted;
+    return last_action_result_;
+}
+
+} // namespace Moer

--- a/source/editor/profile_capture_ui/ProfileCaptureControlModel.h
+++ b/source/editor/profile_capture_ui/ProfileCaptureControlModel.h
@@ -1,0 +1,99 @@
+#pragma once
+
+#include "ProfileCaptureController.h"
+
+#include <cstdint>
+#include <functional>
+#include <optional>
+
+namespace Moer {
+
+enum class EProfileCaptureControlActionResult : std::uint8_t {
+    None = 0,
+    Submitted,
+    Completed,
+    PendingRequest,
+    InvalidOutputPath,
+    InvalidControllerState,
+    CallbackUnavailable,
+    CallbackFailed,
+    BackendRejected,
+    InvalidSubmission,
+};
+
+struct ProfileCaptureControlCallbacks {
+    std::function<Render::ProfileCaptureRequestSubmission(
+        Render::ProfileCaptureStartOptions
+    )>
+        request_start;
+    std::function<Render::ProfileCaptureRequestSubmission(std::uint64_t)>
+        request_stop;
+    std::function<Render::ProfileCaptureControllerSnapshot()> get_snapshot;
+};
+
+// Editor-side intent model. It owns only a single UI request ticket and never
+// advances capture lifecycle state itself; Engine remains the Game Thread
+// owner and the sole caller of ProfileCaptureController::TickOwner().
+class ProfileCaptureControlModel final {
+public:
+    explicit ProfileCaptureControlModel(
+        ProfileCaptureControlCallbacks callbacks
+    ) noexcept;
+
+    void Refresh() noexcept;
+
+    [[nodiscard]] EProfileCaptureControlActionResult RequestStart(
+        Render::ProfileCaptureStartOptions options
+    ) noexcept;
+    [[nodiscard]] EProfileCaptureControlActionResult RequestStop() noexcept;
+
+    [[nodiscard]] bool CanRequestStart() const noexcept;
+    [[nodiscard]] bool CanRequestStop() const noexcept;
+    [[nodiscard]] bool HasPendingRequest() const noexcept;
+    [[nodiscard]] Render::ProfileCaptureRequestKind
+    PendingRequestKind() const noexcept;
+    [[nodiscard]] std::uint64_t
+    PendingExpectedGeneration() const noexcept;
+
+    [[nodiscard]] const Render::ProfileCaptureControllerSnapshot&
+    Snapshot() const noexcept;
+    [[nodiscard]] const std::optional<Render::ProfileCaptureRequestCompletion>&
+    LastCompletion() const noexcept;
+    [[nodiscard]] EProfileCaptureControlActionResult
+    LastActionResult() const noexcept;
+    [[nodiscard]] Render::ProfileCaptureSubmitResult
+    LastSubmitResult() const noexcept;
+
+private:
+    [[nodiscard]] EProfileCaptureControlActionResult AcceptSubmission(
+        Render::ProfileCaptureRequestSubmission submission,
+        Render::ProfileCaptureRequestKind       kind,
+        std::uint64_t                           expected_generation
+    ) noexcept;
+
+    enum class SnapshotStatus : std::uint8_t {
+        Available = 0,
+        CallbackUnavailable,
+        CallbackFailed,
+    };
+
+    ProfileCaptureControlCallbacks callbacks_{};
+    Render::ProfileCaptureControllerSnapshot snapshot_{};
+    Render::ProfileCaptureRequestTicket       pending_ticket_{};
+    Render::ProfileCaptureRequestKind pending_kind_{
+        Render::ProfileCaptureRequestKind::Start
+    };
+    std::uint64_t pending_expected_generation_{0};
+    bool has_pending_request_{false};
+    SnapshotStatus snapshot_status_{SnapshotStatus::CallbackUnavailable};
+
+    std::optional<Render::ProfileCaptureRequestCompletion> last_completion_{};
+    EProfileCaptureControlActionResult last_action_result_{
+        EProfileCaptureControlActionResult::None
+    };
+    Render::ProfileCaptureSubmitResult last_submit_result_{
+        Render::ProfileCaptureSubmitResult::ResourceExhausted
+    };
+};
+
+} // namespace Moer

--- a/source/editor/profile_capture_ui/ProfileCaptureUI.cpp
+++ b/source/editor/profile_capture_ui/ProfileCaptureUI.cpp
@@ -1,0 +1,415 @@
+#include "profile_capture_ui/ProfileCaptureUI.h"
+
+#include "Engine.h"
+#include "config/ConfigManager.h"
+#include "log/LogSystem.h"
+
+#include <array>
+#include <exception>
+#include <system_error>
+#include <utility>
+
+#include <imgui.h>
+#include <nfd.hpp>
+
+namespace Moer {
+namespace {
+
+const char* ControllerStateText(
+    Render::ProfileCaptureControllerState state
+) noexcept {
+    switch (state) {
+        case Render::ProfileCaptureControllerState::Idle:
+            return "Idle";
+        case Render::ProfileCaptureControllerState::Starting:
+            return "Starting";
+        case Render::ProfileCaptureControllerState::Running:
+            return "Running";
+        case Render::ProfileCaptureControllerState::StoppingGpu:
+            return "Stopping GPU";
+        case Render::ProfileCaptureControllerState::FinalizingRuntime:
+            return "Finalizing Runtime";
+        case Render::ProfileCaptureControllerState::AwaitingRhiDrain:
+            return "Awaiting RHI Drain";
+        case Render::ProfileCaptureControllerState::AwaitingWorkerShutdown:
+            return "Awaiting Worker Shutdown";
+        case Render::ProfileCaptureControllerState::Shutdown:
+            return "Shutdown";
+    }
+    return "Unknown";
+}
+
+const char* CompletionStatusText(
+    Render::ProfileCaptureCompletionStatus status
+) noexcept {
+    switch (status) {
+        case Render::ProfileCaptureCompletionStatus::Pending:
+            return "Pending";
+        case Render::ProfileCaptureCompletionStatus::Started:
+            return "Started";
+        case Render::ProfileCaptureCompletionStatus::StartedCpuOnly:
+            return "Started (CPU only)";
+        case Render::ProfileCaptureCompletionStatus::Stopped:
+            return "Stopped";
+        case Render::ProfileCaptureCompletionStatus::StoppedWithLoss:
+            return "Stopped with loss";
+        case Render::ProfileCaptureCompletionStatus::RejectedAdmissionClosed:
+            return "Rejected: admission closed";
+        case Render::ProfileCaptureCompletionStatus::RejectedQueueFull:
+            return "Rejected: queue full";
+        case Render::ProfileCaptureCompletionStatus::RejectedResourceExhausted:
+            return "Rejected: resource exhausted";
+        case Render::ProfileCaptureCompletionStatus::RejectedInvalidArgument:
+            return "Rejected: invalid argument";
+        case Render::ProfileCaptureCompletionStatus::RejectedAlreadyRunning:
+            return "Rejected: already running";
+        case Render::ProfileCaptureCompletionStatus::RejectedStaleGeneration:
+            return "Rejected: stale generation";
+        case Render::ProfileCaptureCompletionStatus::RejectedExternalRuntime:
+            return "Rejected: external runtime";
+        case Render::ProfileCaptureCompletionStatus::CancelledForShutdown:
+            return "Cancelled for shutdown";
+        case Render::ProfileCaptureCompletionStatus::RuntimeStartFailed:
+            return "Runtime start failed";
+        case Render::ProfileCaptureCompletionStatus::CpuSchemaFailed:
+            return "CPU schema failed";
+        case Render::ProfileCaptureCompletionStatus::GpuFrameSchemaFailed:
+            return "GPU frame schema failed";
+        case Render::ProfileCaptureCompletionStatus::GpuScopeSchemaFailed:
+            return "GPU scope schema failed";
+        case Render::ProfileCaptureCompletionStatus::CpuActivationFailed:
+            return "CPU producer activation failed";
+        case Render::ProfileCaptureCompletionStatus::GpuSessionStartFailed:
+            return "GPU session start failed";
+        case Render::ProfileCaptureCompletionStatus::RuntimeOwnershipLost:
+            return "Runtime ownership lost";
+        case Render::ProfileCaptureCompletionStatus::GpuSessionFaulted:
+            return "GPU session faulted";
+        case Render::ProfileCaptureCompletionStatus::GpuSessionAborted:
+            return "GPU session aborted";
+        case Render::ProfileCaptureCompletionStatus::RuntimeShutdownFaulted:
+            return "Runtime shutdown faulted";
+        case Render::ProfileCaptureCompletionStatus::ControllerDestroyed:
+            return "Controller destroyed";
+    }
+    return "Unknown";
+}
+
+const char* SubmitResultText(Render::ProfileCaptureSubmitResult result) noexcept {
+    switch (result) {
+        case Render::ProfileCaptureSubmitResult::Queued:
+            return "Queued";
+        case Render::ProfileCaptureSubmitResult::AdmissionClosed:
+            return "Admission closed";
+        case Render::ProfileCaptureSubmitResult::QueueFull:
+            return "Queue full";
+        case Render::ProfileCaptureSubmitResult::InvalidArgument:
+            return "Invalid argument";
+        case Render::ProfileCaptureSubmitResult::ResourceExhausted:
+            return "Resource exhausted";
+    }
+    return "Unknown";
+}
+
+const char* ActionResultText(EProfileCaptureControlActionResult result) noexcept {
+    switch (result) {
+        case EProfileCaptureControlActionResult::None:
+            return "No request submitted";
+        case EProfileCaptureControlActionResult::Submitted:
+            return "Request queued";
+        case EProfileCaptureControlActionResult::Completed:
+            return "Request reached a terminal completion";
+        case EProfileCaptureControlActionResult::PendingRequest:
+            return "A UI request is already pending";
+        case EProfileCaptureControlActionResult::InvalidOutputPath:
+            return "Choose a non-empty output path";
+        case EProfileCaptureControlActionResult::InvalidControllerState:
+            return "Action is not valid in the current controller state";
+        case EProfileCaptureControlActionResult::CallbackUnavailable:
+            return "Engine callback is unavailable";
+        case EProfileCaptureControlActionResult::CallbackFailed:
+            return "Engine callback failed";
+        case EProfileCaptureControlActionResult::BackendRejected:
+            return "Controller rejected the request";
+        case EProfileCaptureControlActionResult::InvalidSubmission:
+            return "Controller returned a malformed submission or ticket";
+    }
+    return "Unknown";
+}
+
+bool SelectCaptureOutput(
+    std::filesystem::path& output_path,
+    std::string&           status
+) {
+    NFD::UniquePath selected_path = nullptr;
+    const std::array<nfdfilteritem_t, 1> filters = {{
+        {"Moer Profile Dump", "mpd"},
+    }};
+
+    const nfdresult_t result = NFD::SaveDialog(
+        selected_path,
+        filters.data(),
+        filters.size(),
+        nullptr,
+        "MoerProfile.mpd"
+    );
+    if (result == NFD_CANCEL) {
+        status = "Output selection cancelled.";
+        return false;
+    }
+    if (result != NFD_OKAY || !selected_path) {
+        const char* error_message = NFD_GetError();
+        status = error_message ? error_message : "Native file dialog failed.";
+        LOG_ERROR("[ProfileCaptureUI] NFD error: {}", status);
+        return false;
+    }
+
+    try {
+        output_path = std::filesystem::u8path(selected_path.get());
+        if (output_path.extension() != ".mpd") {
+            output_path.replace_extension(".mpd");
+        }
+        status = "Output path selected.";
+        return true;
+    } catch (const std::exception& error) {
+        status = error.what();
+        LOG_ERROR(
+            "[ProfileCaptureUI] Invalid output path selected: {}",
+            error.what()
+        );
+        return false;
+    }
+}
+
+void DrawSnapshotTable(
+    const Render::ProfileCaptureControllerSnapshot& snapshot
+) {
+    if (!ImGui::BeginTable(
+            "ProfileCaptureControllerState",
+            2,
+            ImGuiTableFlags_Borders | ImGuiTableFlags_RowBg
+        )) {
+        return;
+    }
+
+    const auto row = [](const char* name, auto value) {
+        ImGui::TableNextRow();
+        ImGui::TableSetColumnIndex(0);
+        ImGui::TextUnformatted(name);
+        ImGui::TableSetColumnIndex(1);
+        ImGui::Text("%llu", static_cast<unsigned long long>(value));
+    };
+    const auto bool_row = [](const char* name, bool value) {
+        ImGui::TableNextRow();
+        ImGui::TableSetColumnIndex(0);
+        ImGui::TextUnformatted(name);
+        ImGui::TableSetColumnIndex(1);
+        ImGui::TextUnformatted(value ? "yes" : "no");
+    };
+
+    ImGui::TableNextRow();
+    ImGui::TableSetColumnIndex(0);
+    ImGui::TextUnformatted("State");
+    ImGui::TableSetColumnIndex(1);
+    ImGui::TextUnformatted(ControllerStateText(snapshot.state));
+
+    row("Generation", snapshot.active_generation);
+    bool_row("Owns runtime", snapshot.owns_runtime);
+    bool_row("CPU producer", snapshot.cpu_producer_active);
+    bool_row("GPU session", snapshot.gpu_session_active);
+    bool_row("Accepting requests", snapshot.accepting_requests);
+    row("Queued requests", snapshot.queued_requests);
+    row("Queue capacity", snapshot.queue_capacity);
+    row("Submitted", snapshot.requests_submitted);
+    row("Accepted", snapshot.requests_accepted);
+    row("Rejected", snapshot.requests_rejected);
+    row("Completed", snapshot.requests_completed);
+    row("Wrong-thread owner ticks", snapshot.wrong_thread_calls);
+    row("Last completed request", snapshot.last_completed_request_id);
+
+    ImGui::TableNextRow();
+    ImGui::TableSetColumnIndex(0);
+    ImGui::TextUnformatted("Last global completion");
+    ImGui::TableSetColumnIndex(1);
+    ImGui::TextUnformatted(
+        CompletionStatusText(snapshot.last_completion_status)
+    );
+
+    ImGui::EndTable();
+}
+
+} // namespace
+
+ProfileCaptureUI::ProfileCaptureUI(Engine& engine) :
+    control_(
+        ProfileCaptureControlCallbacks{
+            .request_start =
+                [&engine](Render::ProfileCaptureStartOptions options) {
+                    return engine.RequestProfileCaptureStart(
+                        std::move(options)
+                    );
+                },
+            .request_stop =
+                [&engine](std::uint64_t generation) {
+                    return engine.RequestProfileCaptureStop(generation);
+                },
+            .get_snapshot =
+                [&engine]() {
+                    return engine.GetProfileCaptureSnapshot();
+                },
+        }
+    ) {
+    try {
+        const ConfigManager& config_manager =
+            ConfigManager::GetInstance();
+        const auto& profile_config =
+            config_manager.GetConfig().engine.profile_dump;
+
+        output_path_ = profile_config.output_path.empty() ?
+            std::filesystem::path("profile/MoerProfile.mpd") :
+            std::filesystem::path(profile_config.output_path);
+        if (output_path_.is_relative()) {
+            output_path_ =
+                config_manager.GetWorkspacePath() / output_path_;
+        }
+
+        std::error_code path_error;
+        const std::filesystem::path canonical_output =
+            std::filesystem::weakly_canonical(output_path_, path_error);
+        if (!path_error) {
+            output_path_ = canonical_output;
+        } else {
+            output_path_ = output_path_.lexically_normal();
+        }
+    } catch (...) {
+        output_path_.clear();
+    }
+}
+
+void ProfileCaptureUI::ShowWindow(bool* open) {
+    control_.Refresh();
+
+    if (!ImGui::Begin("Profile Capture", open)) {
+        ImGui::End();
+        return;
+    }
+
+    const Render::ProfileCaptureControllerSnapshot& snapshot =
+        control_.Snapshot();
+    DrawSnapshotTable(snapshot);
+
+    ImGui::Spacing();
+    ImGui::SeparatorText("Capture Request");
+
+    const std::string output_text = output_path_.generic_string();
+    ImGui::TextWrapped(
+        "Next output: %s",
+        output_text.empty() ? "<not selected>" : output_text.c_str()
+    );
+    if (ImGui::Button("Choose Output...")) {
+        static_cast<void>(
+            SelectCaptureOutput(output_path_, dialog_status_)
+        );
+    }
+    if (!dialog_status_.empty()) {
+        ImGui::SameLine();
+        ImGui::TextDisabled("%s", dialog_status_.c_str());
+    }
+    ImGui::Checkbox("Replace existing file", &replace_existing_);
+
+    std::error_code output_exists_error;
+    const bool output_exists =
+        !output_path_.empty() &&
+        std::filesystem::exists(output_path_, output_exists_error);
+    if (!output_exists_error && output_exists && !replace_existing_) {
+        ImGui::TextColored(
+            ImVec4(1.0f, 0.75f, 0.2f, 1.0f),
+            "Output already exists. Choose another path or explicitly enable replacement."
+        );
+    }
+
+    const bool start_enabled =
+        control_.CanRequestStart() && !output_path_.empty() &&
+        !output_exists_error &&
+        (!output_exists || replace_existing_);
+    ImGui::BeginDisabled(!start_enabled);
+    if (ImGui::Button("Start Capture")) {
+        Render::ProfileCaptureStartOptions options;
+        options.runtime.output_path      = output_path_;
+        options.runtime.replace_existing = replace_existing_;
+        static_cast<void>(control_.RequestStart(std::move(options)));
+    }
+    ImGui::EndDisabled();
+
+    ImGui::SameLine();
+    const bool stop_enabled = control_.CanRequestStop();
+    ImGui::BeginDisabled(!stop_enabled);
+    if (ImGui::Button("Stop Capture")) {
+        static_cast<void>(control_.RequestStop());
+    }
+    ImGui::EndDisabled();
+
+    if (control_.HasPendingRequest()) {
+        const bool is_start =
+            control_.PendingRequestKind() ==
+            Render::ProfileCaptureRequestKind::Start;
+        ImGui::TextColored(
+            ImVec4(1.0f, 0.75f, 0.2f, 1.0f),
+            "%s request pending; Engine will process it at the next owner tick.",
+            is_start ? "Start" : "Stop"
+        );
+        if (!is_start) {
+            ImGui::Text(
+                "Protected generation requested by Stop: %llu",
+                static_cast<unsigned long long>(
+                    control_.PendingExpectedGeneration()
+                )
+            );
+        }
+    }
+
+    ImGui::Text(
+        "Last UI action: %s",
+        ActionResultText(control_.LastActionResult())
+    );
+    if (control_.LastActionResult() ==
+        EProfileCaptureControlActionResult::BackendRejected) {
+        ImGui::Text(
+            "Submit result: %s",
+            SubmitResultText(control_.LastSubmitResult())
+        );
+    }
+
+    if (const auto& completion = control_.LastCompletion();
+        completion.has_value()) {
+        ImGui::Spacing();
+        ImGui::SeparatorText("Last UI Completion");
+        ImGui::Text(
+            "Request %llu (%s), generation %llu",
+            static_cast<unsigned long long>(completion->request_id),
+            completion->kind == Render::ProfileCaptureRequestKind::Start ?
+                "Start" :
+                "Stop",
+            static_cast<unsigned long long>(completion->generation)
+        );
+        ImGui::Text(
+            "Status: %s",
+            CompletionStatusText(completion->status)
+        );
+        ImGui::Text(
+            "Subsystem detail: %u / %u",
+            completion->detail,
+            completion->secondary_detail
+        );
+    }
+
+    ImGui::Spacing();
+    ImGui::TextDisabled(
+        "The panel submits intent only. Engine owns lifecycle transitions, "
+        "GPU tail drain, ProfileDump shutdown, and generation checks."
+    );
+
+    ImGui::End();
+}
+
+} // namespace Moer

--- a/source/editor/profile_capture_ui/ProfileCaptureUI.h
+++ b/source/editor/profile_capture_ui/ProfileCaptureUI.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "profile_capture_ui/ProfileCaptureControlModel.h"
+
+#include <filesystem>
+#include <string>
+
+namespace Moer {
+
+class Engine;
+
+class ProfileCaptureUI final {
+public:
+    explicit ProfileCaptureUI(Engine& engine);
+
+    void ShowWindow(bool* open);
+
+private:
+    ProfileCaptureControlModel control_;
+    std::filesystem::path      output_path_{};
+    bool                       replace_existing_{false};
+    std::string                dialog_status_{};
+};
+
+} // namespace Moer

--- a/source/test/CMakeLists.txt
+++ b/source/test/CMakeLists.txt
@@ -184,6 +184,26 @@ set_target_properties(${test_target} PROPERTIES FOLDER ${moer_test_folder})
 add_test(NAME ProfileCaptureControllerContract COMMAND $<TARGET_FILE:${test_target}>)
 set_tests_properties(ProfileCaptureControllerContract PROPERTIES TIMEOUT 60)
 
+set(test_target TestProfileCaptureControlModel)
+add_executable(
+    ${test_target}
+    "ProfileCaptureControlModelTest.cpp"
+    "${moer_source_dir}/editor/profile_capture_ui/ProfileCaptureControlModel.cpp"
+)
+target_include_directories(
+    ${test_target}
+    PRIVATE "${moer_source_dir}/editor"
+)
+target_link_libraries(${test_target}
+    PRIVATE Moer::Runtime
+)
+set_target_properties(${test_target} PROPERTIES FOLDER ${moer_test_folder})
+add_test(
+    NAME ProfileCaptureControlModelContract
+    COMMAND $<TARGET_FILE:${test_target}>
+)
+set_tests_properties(ProfileCaptureControlModelContract PROPERTIES TIMEOUT 60)
+
 set(test_target TestRHIGpuCompletion)
 add_executable(${test_target} "RHIGpuCompletionContractTest.cpp")
 target_link_libraries(${test_target}

--- a/source/test/ProfileCaptureControlModelTest.cpp
+++ b/source/test/ProfileCaptureControlModelTest.cpp
@@ -1,0 +1,505 @@
+#include "profile_capture_ui/ProfileCaptureControlModel.h"
+
+#include "profile/ProfileDump.h"
+#include "profile/ProfileScope.h"
+
+#include <atomic>
+#include <chrono>
+#include <filesystem>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <utility>
+
+namespace {
+
+using namespace Moer;
+using namespace Moer::ProfileDump;
+using namespace Moer::Render;
+
+void Expect(bool condition, std::string_view message) {
+    if (!condition) {
+        throw std::runtime_error(std::string(message));
+    }
+}
+
+class ScopedCaptureOutput final {
+public:
+    ScopedCaptureOutput() {
+        static std::atomic_uint64_t next_id{0};
+        for (std::uint32_t attempt = 0; attempt < 64; ++attempt) {
+            const auto now = static_cast<std::uint64_t>(
+                std::chrono::steady_clock::now()
+                    .time_since_epoch()
+                    .count()
+            );
+            directory_ =
+                std::filesystem::temp_directory_path() /
+                ("moer-profile-control-model-" + std::to_string(now) + "-" +
+                 std::to_string(
+                     next_id.fetch_add(1, std::memory_order_relaxed)
+                 ));
+            std::error_code error;
+            if (std::filesystem::create_directory(directory_, error)) {
+                return;
+            }
+            if (error && error != std::errc::file_exists) {
+                break;
+            }
+        }
+        throw std::runtime_error(
+            "ProfileCaptureControlModel test could not reserve a temp directory"
+        );
+    }
+
+    ~ScopedCaptureOutput() {
+        CpuScopeProducer::Deactivate();
+        static_cast<void>(Shutdown());
+        std::error_code error;
+        std::filesystem::remove_all(directory_, error);
+    }
+
+    [[nodiscard]] std::filesystem::path File() const {
+        return directory_ / "capture.mpd";
+    }
+
+private:
+    std::filesystem::path directory_{};
+};
+
+ProfileCaptureControlModel MakeModel(
+    ProfileCaptureController& controller
+) {
+    return ProfileCaptureControlModel(
+        ProfileCaptureControlCallbacks{
+            .request_start =
+                [&controller](ProfileCaptureStartOptions options) {
+                    return controller.RequestStart(std::move(options));
+                },
+            .request_stop =
+                [&controller](std::uint64_t generation) {
+                    return controller.RequestStop(generation);
+                },
+            .get_snapshot =
+                [&controller]() {
+                    return controller.GetSnapshot();
+                },
+        }
+    );
+}
+
+void CpuOnlyStartStopUsesEngineOwnedTicketBoundary() {
+    ScopedCaptureOutput      output;
+    ProfileCaptureController controller(nullptr, 4);
+    ProfileCaptureControlModel model = MakeModel(controller);
+
+    Expect(
+        model.CanRequestStart() && !model.CanRequestStop(),
+        "idle control model did not expose only Start"
+    );
+
+    ProfileCaptureStartOptions options;
+    options.runtime.output_path      = output.File();
+    options.runtime.replace_existing = true;
+    Expect(
+        model.RequestStart(std::move(options)) ==
+                EProfileCaptureControlActionResult::Submitted &&
+            model.HasPendingRequest() &&
+            model.PendingRequestKind() == ProfileCaptureRequestKind::Start,
+        "control model did not retain the queued Start ticket"
+    );
+    Expect(
+        model.RequestStop() ==
+            EProfileCaptureControlActionResult::PendingRequest,
+        "control model admitted a second UI action while Start was pending"
+    );
+
+    model.Refresh();
+    Expect(
+        model.HasPendingRequest() &&
+            model.Snapshot().state == ProfileCaptureControllerState::Idle,
+        "control model advanced controller lifecycle from the UI refresh"
+    );
+
+    Expect(
+        controller.TickOwner() == ProfileCaptureTickResult::Progressed,
+        "Engine owner tick did not process the UI Start request"
+    );
+    model.Refresh();
+    Expect(
+        !model.HasPendingRequest() && model.CanRequestStop() &&
+            model.Snapshot().state ==
+                ProfileCaptureControllerState::Running &&
+            model.Snapshot().active_generation != 0 &&
+            model.LastCompletion().has_value() &&
+            model.LastCompletion()->status ==
+                ProfileCaptureCompletionStatus::StartedCpuOnly,
+        "control model did not observe the CPU-only Start completion"
+    );
+    const std::uint64_t generation =
+        model.Snapshot().active_generation;
+
+    Expect(
+        model.RequestStop() ==
+                EProfileCaptureControlActionResult::Submitted &&
+            model.HasPendingRequest() &&
+            model.PendingRequestKind() == ProfileCaptureRequestKind::Stop &&
+            model.PendingExpectedGeneration() == generation,
+        "control model did not submit exact-generation Stop"
+    );
+    Expect(
+        controller.TickOwner() == ProfileCaptureTickResult::Progressed,
+        "Engine owner tick did not process the UI Stop request"
+    );
+    model.Refresh();
+    Expect(
+        !model.HasPendingRequest() && model.CanRequestStart() &&
+            model.Snapshot().state == ProfileCaptureControllerState::Idle &&
+            model.LastActionResult() ==
+                EProfileCaptureControlActionResult::Completed &&
+            model.LastCompletion().has_value() &&
+            model.LastCompletion()->generation == generation &&
+            model.LastCompletion()->status ==
+                ProfileCaptureCompletionStatus::Stopped &&
+            model.PendingExpectedGeneration() == 0 &&
+            GetRuntimeState() == RuntimeState::Stopped,
+        "control model did not observe the exact-generation Stop completion"
+    );
+}
+
+void LocalValidationAndBackendRejectionStayBounded() {
+    std::uint64_t start_calls = 0;
+    ProfileCaptureControllerSnapshot snapshot;
+    snapshot.state              = ProfileCaptureControllerState::Idle;
+    snapshot.accepting_requests = true;
+    snapshot.queue_capacity     = 4;
+
+    ProfileCaptureControlModel model(
+        ProfileCaptureControlCallbacks{
+            .request_start =
+                [&start_calls](ProfileCaptureStartOptions) {
+                    ++start_calls;
+                    return ProfileCaptureRequestSubmission{
+                        .result = ProfileCaptureSubmitResult::QueueFull,
+                        .ticket = {},
+                    };
+                },
+            .request_stop = {},
+            .get_snapshot =
+                [&snapshot]() {
+                    return snapshot;
+                },
+        }
+    );
+
+    Expect(
+        model.RequestStart(ProfileCaptureStartOptions{}) ==
+                EProfileCaptureControlActionResult::InvalidOutputPath &&
+            start_calls == 0,
+        "empty output path reached the Engine callback"
+    );
+
+    ProfileCaptureStartOptions options;
+    options.runtime.output_path = "capture.mpd";
+    Expect(
+        model.RequestStart(std::move(options)) ==
+                EProfileCaptureControlActionResult::BackendRejected &&
+            model.LastSubmitResult() ==
+                ProfileCaptureSubmitResult::QueueFull &&
+            start_calls == 1 && !model.HasPendingRequest(),
+        "backend rejection did not remain a terminal bounded UI action"
+    );
+
+    snapshot.state              = ProfileCaptureControllerState::Running;
+    snapshot.owns_runtime       = true;
+    snapshot.active_generation  = 7;
+    model.Refresh();
+    Expect(
+        model.RequestStop() ==
+            EProfileCaptureControlActionResult::CallbackUnavailable,
+        "missing Stop callback was not reported without mutating state"
+    );
+}
+
+void SynchronousRejectionRetainsTerminalCompletion() {
+    ScopedCaptureOutput      output;
+    ProfileCaptureController controller(nullptr, 0);
+    ProfileCaptureControlModel model = MakeModel(controller);
+
+    ProfileCaptureStartOptions options;
+    options.runtime.output_path = output.File();
+    Expect(
+        model.RequestStart(std::move(options)) ==
+                EProfileCaptureControlActionResult::BackendRejected &&
+            model.LastSubmitResult() == ProfileCaptureSubmitResult::QueueFull &&
+            model.LastCompletion().has_value() &&
+            model.LastCompletion()->kind ==
+                ProfileCaptureRequestKind::Start &&
+            model.LastCompletion()->status ==
+                ProfileCaptureCompletionStatus::RejectedQueueFull &&
+            !model.HasPendingRequest(),
+        "synchronous rejection lost its terminal ticket payload"
+    );
+}
+
+void SnapshotFailuresStayDistinctFromControllerState() {
+    ProfileCaptureStartOptions options;
+    options.runtime.output_path = "capture.mpd";
+
+    ProfileCaptureControlModel missing_snapshot(
+        ProfileCaptureControlCallbacks{}
+    );
+    Expect(
+        missing_snapshot.RequestStart(options) ==
+            EProfileCaptureControlActionResult::CallbackUnavailable,
+        "missing snapshot callback was reported as a controller state error"
+    );
+
+    ProfileCaptureControlModel throwing_snapshot(
+        ProfileCaptureControlCallbacks{
+            .request_start =
+                [](ProfileCaptureStartOptions) {
+                    return ProfileCaptureRequestSubmission{};
+                },
+            .request_stop = {},
+            .get_snapshot =
+                []() -> ProfileCaptureControllerSnapshot {
+                    throw std::runtime_error("injected snapshot failure");
+                },
+        }
+    );
+    Expect(
+        throwing_snapshot.RequestStart(std::move(options)) ==
+            EProfileCaptureControlActionResult::CallbackFailed,
+        "throwing snapshot callback was reported as a controller state error"
+    );
+
+    ProfileCaptureControllerSnapshot idle_snapshot;
+    idle_snapshot.state              = ProfileCaptureControllerState::Idle;
+    idle_snapshot.accepting_requests = true;
+    ProfileCaptureControlModel throwing_request(
+        ProfileCaptureControlCallbacks{
+            .request_start =
+                [](ProfileCaptureStartOptions)
+                    -> ProfileCaptureRequestSubmission {
+                    throw std::runtime_error("injected request failure");
+                },
+            .request_stop = {},
+            .get_snapshot =
+                [&idle_snapshot]() {
+                    return idle_snapshot;
+                },
+        }
+    );
+    ProfileCaptureStartOptions throwing_options;
+    throwing_options.runtime.output_path = "capture.mpd";
+    Expect(
+        throwing_request.RequestStart(std::move(throwing_options)) ==
+            EProfileCaptureControlActionResult::CallbackFailed,
+        "throwing request callback escaped the control model"
+    );
+
+    ProfileCaptureControlModel missing_ticket(
+        ProfileCaptureControlCallbacks{
+            .request_start =
+                [](ProfileCaptureStartOptions) {
+                    return ProfileCaptureRequestSubmission{
+                        .result = ProfileCaptureSubmitResult::Queued,
+                        .ticket = {},
+                    };
+                },
+            .request_stop = {},
+            .get_snapshot =
+                [&idle_snapshot]() {
+                    return idle_snapshot;
+                },
+        }
+    );
+    ProfileCaptureStartOptions missing_ticket_options;
+    missing_ticket_options.runtime.output_path = "capture.mpd";
+    Expect(
+        missing_ticket.RequestStart(std::move(missing_ticket_options)) ==
+                EProfileCaptureControlActionResult::InvalidSubmission &&
+            !missing_ticket.HasPendingRequest(),
+        "queued submission without a ticket was not rejected"
+    );
+}
+
+void MismatchedTicketKindFailsClosed() {
+    ProfileCaptureController controller(nullptr, 4);
+    ProfileCaptureControllerSnapshot snapshot;
+    snapshot.state              = ProfileCaptureControllerState::Idle;
+    snapshot.accepting_requests = true;
+    snapshot.queue_capacity     = 4;
+
+    ProfileCaptureControlModel model(
+        ProfileCaptureControlCallbacks{
+            .request_start =
+                [&controller](ProfileCaptureStartOptions) {
+                    return controller.RequestStop(1);
+                },
+            .request_stop = {},
+            .get_snapshot =
+                [&snapshot]() {
+                    return snapshot;
+                },
+        }
+    );
+
+    ProfileCaptureStartOptions options;
+    options.runtime.output_path = "capture.mpd";
+    Expect(
+        model.RequestStart(std::move(options)) ==
+                EProfileCaptureControlActionResult::Submitted &&
+            model.HasPendingRequest(),
+        "mismatched-ticket fixture did not queue its request"
+    );
+    Expect(
+        controller.TickOwner() == ProfileCaptureTickResult::Progressed,
+        "mismatched-ticket fixture was not completed"
+    );
+    model.Refresh();
+    Expect(
+        !model.HasPendingRequest() &&
+            model.LastActionResult() ==
+                EProfileCaptureControlActionResult::InvalidSubmission &&
+            !model.LastCompletion().has_value(),
+        "mismatched ticket kind was accepted as a UI completion"
+    );
+}
+
+void StaleUiStopProtectsTheNewGeneration() {
+    ScopedCaptureOutput      output;
+    ProfileCaptureController controller(nullptr, 4);
+
+    ProfileCaptureStartOptions start_options;
+    start_options.runtime.output_path      = output.File();
+    start_options.runtime.replace_existing = true;
+    ProfileCaptureRequestSubmission start_a =
+        controller.RequestStart(start_options);
+    Expect(
+        start_a.result == ProfileCaptureSubmitResult::Queued &&
+            controller.TickOwner() == ProfileCaptureTickResult::Progressed,
+        "stale UI Stop fixture could not start generation A"
+    );
+    ProfileCaptureRequestCompletion start_a_completion;
+    Expect(
+        start_a.ticket.TryGet(start_a_completion) &&
+            start_a_completion.status ==
+                ProfileCaptureCompletionStatus::StartedCpuOnly,
+        "stale UI Stop fixture did not complete generation A Start"
+    );
+    const std::uint64_t generation_a = start_a_completion.generation;
+
+    ProfileCaptureRequestSubmission stop_a =
+        controller.RequestStop(generation_a);
+    Expect(
+        stop_a.result == ProfileCaptureSubmitResult::Queued &&
+            controller.TickOwner() == ProfileCaptureTickResult::Progressed,
+        "stale UI Stop fixture could not stop generation A"
+    );
+    ProfileCaptureRequestCompletion stop_a_completion;
+    Expect(
+        stop_a.ticket.TryGet(stop_a_completion) &&
+            stop_a_completion.status ==
+                ProfileCaptureCompletionStatus::Stopped,
+        "stale UI Stop fixture did not complete generation A Stop"
+    );
+
+    ProfileCaptureRequestSubmission start_b =
+        controller.RequestStart(std::move(start_options));
+    Expect(
+        start_b.result == ProfileCaptureSubmitResult::Queued &&
+            controller.TickOwner() == ProfileCaptureTickResult::Progressed,
+        "stale UI Stop fixture could not start generation B"
+    );
+    ProfileCaptureRequestCompletion start_b_completion;
+    Expect(
+        start_b.ticket.TryGet(start_b_completion) &&
+            start_b_completion.status ==
+                ProfileCaptureCompletionStatus::StartedCpuOnly &&
+            start_b_completion.generation > generation_a,
+        "stale UI Stop fixture did not publish a newer generation B"
+    );
+    const std::uint64_t generation_b = start_b_completion.generation;
+
+    ProfileCaptureControllerSnapshot stale_snapshot =
+        controller.GetSnapshot();
+    stale_snapshot.active_generation = generation_a;
+    ProfileCaptureControlModel model(
+        ProfileCaptureControlCallbacks{
+            .request_start = {},
+            .request_stop =
+                [&controller](std::uint64_t generation) {
+                    return controller.RequestStop(generation);
+                },
+            .get_snapshot =
+                [&stale_snapshot]() {
+                    return stale_snapshot;
+                },
+        }
+    );
+
+    Expect(
+        model.RequestStop() ==
+                EProfileCaptureControlActionResult::Submitted &&
+            model.PendingExpectedGeneration() == generation_a,
+        "UI did not retain the stale generation A Stop intent"
+    );
+    Expect(
+        controller.TickOwner() == ProfileCaptureTickResult::Progressed,
+        "controller did not complete the stale generation A Stop"
+    );
+    stale_snapshot = controller.GetSnapshot();
+    model.Refresh();
+    Expect(
+        !model.HasPendingRequest() &&
+            model.LastActionResult() ==
+                EProfileCaptureControlActionResult::Completed &&
+            model.LastCompletion().has_value() &&
+            model.LastCompletion()->status ==
+                ProfileCaptureCompletionStatus::RejectedStaleGeneration &&
+            model.LastCompletion()->generation == generation_b &&
+            model.Snapshot().state ==
+                ProfileCaptureControllerState::Running &&
+            model.Snapshot().active_generation == generation_b &&
+            model.CanRequestStop(),
+        "stale UI Stop did not preserve and expose running generation B"
+    );
+
+    ProfileCaptureRequestSubmission stop_b =
+        controller.RequestStop(generation_b);
+    Expect(
+        stop_b.result == ProfileCaptureSubmitResult::Queued &&
+            controller.TickOwner() == ProfileCaptureTickResult::Progressed,
+        "stale UI Stop fixture could not cleanly stop generation B"
+    );
+    ProfileCaptureRequestCompletion stop_b_completion;
+    Expect(
+        stop_b.ticket.TryGet(stop_b_completion) &&
+            stop_b_completion.status ==
+                ProfileCaptureCompletionStatus::Stopped,
+        "stale UI Stop fixture did not cleanly complete generation B"
+    );
+}
+
+} // namespace
+
+int main() {
+    try {
+        CpuOnlyStartStopUsesEngineOwnedTicketBoundary();
+        LocalValidationAndBackendRejectionStayBounded();
+        SynchronousRejectionRetainsTerminalCompletion();
+        SnapshotFailuresStayDistinctFromControllerState();
+        MismatchedTicketKindFailsClosed();
+        StaleUiStopProtectsTheNewGeneration();
+    } catch (const std::exception& error) {
+        std::cerr << "ProfileCaptureControlModel contract failed: "
+                  << error.what() << '\n';
+        return 1;
+    }
+
+    std::cout << "ProfileCaptureControlModel contract passed\n";
+    return 0;
+}

--- a/source/test/ProfileCaptureControlModelTest.cpp
+++ b/source/test/ProfileCaptureControlModelTest.cpp
@@ -168,7 +168,7 @@ void CpuOnlyStartStopUsesEngineOwnedTicketBoundary() {
     );
 }
 
-void LocalValidationAndBackendRejectionStayBounded() {
+void LocalValidationAndMalformedRejectionStayBounded() {
     std::uint64_t start_calls = 0;
     ProfileCaptureControllerSnapshot snapshot;
     snapshot.state              = ProfileCaptureControllerState::Idle;
@@ -204,11 +204,11 @@ void LocalValidationAndBackendRejectionStayBounded() {
     options.runtime.output_path = "capture.mpd";
     Expect(
         model.RequestStart(std::move(options)) ==
-                EProfileCaptureControlActionResult::BackendRejected &&
+                EProfileCaptureControlActionResult::InvalidSubmission &&
             model.LastSubmitResult() ==
                 ProfileCaptureSubmitResult::QueueFull &&
             start_calls == 1 && !model.HasPendingRequest(),
-        "backend rejection did not remain a terminal bounded UI action"
+        "ticketless QueueFull submission was not rejected as malformed"
     );
 
     snapshot.state              = ProfileCaptureControllerState::Running;
@@ -240,6 +240,99 @@ void SynchronousRejectionRetainsTerminalCompletion() {
                 ProfileCaptureCompletionStatus::RejectedQueueFull &&
             !model.HasPendingRequest(),
         "synchronous rejection lost its terminal ticket payload"
+    );
+}
+
+void SynchronousRejectionProtocolFailsClosed() {
+    ProfileCaptureControllerSnapshot idle_snapshot;
+    idle_snapshot.state              = ProfileCaptureControllerState::Idle;
+    idle_snapshot.accepting_requests = true;
+
+    ProfileCaptureControlModel allocation_failure(
+        ProfileCaptureControlCallbacks{
+            .request_start =
+                [](ProfileCaptureStartOptions) {
+                    return ProfileCaptureRequestSubmission{
+                        .result =
+                            ProfileCaptureSubmitResult::ResourceExhausted,
+                        .ticket = {},
+                    };
+                },
+            .request_stop = {},
+            .get_snapshot =
+                [&idle_snapshot]() {
+                    return idle_snapshot;
+                },
+        }
+    );
+    ProfileCaptureStartOptions allocation_options;
+    allocation_options.runtime.output_path = "capture.mpd";
+    Expect(
+        allocation_failure.RequestStart(std::move(allocation_options)) ==
+                EProfileCaptureControlActionResult::BackendRejected &&
+            allocation_failure.LastSubmitResult() ==
+                ProfileCaptureSubmitResult::ResourceExhausted &&
+            !allocation_failure.LastCompletion().has_value(),
+        "ticketless allocation failure was not retained as the explicit "
+        "ResourceExhausted exception"
+    );
+
+    ProfileCaptureController pending_controller(nullptr, 4);
+    ProfileCaptureControlModel non_terminal_rejection(
+        ProfileCaptureControlCallbacks{
+            .request_start =
+                [&pending_controller](ProfileCaptureStartOptions options) {
+                    ProfileCaptureRequestSubmission submission =
+                        pending_controller.RequestStart(std::move(options));
+                    submission.result = ProfileCaptureSubmitResult::QueueFull;
+                    return submission;
+                },
+            .request_stop = {},
+            .get_snapshot =
+                [&idle_snapshot]() {
+                    return idle_snapshot;
+                },
+        }
+    );
+    ProfileCaptureStartOptions pending_options;
+    pending_options.runtime.output_path = "capture.mpd";
+    Expect(
+        non_terminal_rejection.RequestStart(std::move(pending_options)) ==
+                EProfileCaptureControlActionResult::InvalidSubmission &&
+            !non_terminal_rejection.HasPendingRequest() &&
+            !non_terminal_rejection.LastCompletion().has_value(),
+        "non-terminal ticket attached to a synchronous rejection was accepted"
+    );
+
+    ProfileCaptureController mismatch_controller(nullptr, 4);
+    ProfileCaptureControllerSnapshot running_snapshot;
+    running_snapshot.state              =
+        ProfileCaptureControllerState::Running;
+    running_snapshot.accepting_requests = true;
+    running_snapshot.owns_runtime       = true;
+    running_snapshot.active_generation  = 7;
+    ProfileCaptureControlModel mismatched_status(
+        ProfileCaptureControlCallbacks{
+            .request_start = {},
+            .request_stop =
+                [&mismatch_controller](std::uint64_t) {
+                    ProfileCaptureRequestSubmission submission =
+                        mismatch_controller.RequestStop(0);
+                    submission.result = ProfileCaptureSubmitResult::QueueFull;
+                    return submission;
+                },
+            .get_snapshot =
+                [&running_snapshot]() {
+                    return running_snapshot;
+                },
+        }
+    );
+    Expect(
+        mismatched_status.RequestStop() ==
+                EProfileCaptureControlActionResult::InvalidSubmission &&
+            !mismatched_status.HasPendingRequest() &&
+            !mismatched_status.LastCompletion().has_value(),
+        "submit result and terminal completion status mismatch was accepted"
     );
 }
 
@@ -489,8 +582,9 @@ void StaleUiStopProtectsTheNewGeneration() {
 int main() {
     try {
         CpuOnlyStartStopUsesEngineOwnedTicketBoundary();
-        LocalValidationAndBackendRejectionStayBounded();
+        LocalValidationAndMalformedRejectionStayBounded();
         SynchronousRejectionRetainsTerminalCompletion();
+        SynchronousRejectionProtocolFailsClosed();
         SnapshotFailuresStayDistinctFromControllerState();
         MismatchedTicketKindFailsClosed();
         StaleUiStopProtectsTheNewGeneration();


### PR DESCRIPTION
## Scope

Phase 21D.2b adds an Editor control surface for the Engine-owned dynamic profile capture lifecycle.

- Adds a UI intent model that only calls Engine RequestStart / RequestStop / GetSnapshot callbacks.
- Keeps TickOwner, generation transitions, GPU tail drain, and shutdown ownership inside Engine.
- Adds exact-generation Stop, one-pending-ticket admission, fail-closed callback handling, and precise terminal completion reporting.
- Adds a Window > Profile Capture panel with persisted visibility, safe non-destructive replacement defaults, resolved workspace-relative output paths, and native .mpd path selection.
- Works independently of WITH_PROFILE.

## Validation

- ProfileCaptureControlModelContract: repeated 50/50 passes.
- Full CTest matrix: Debug 30/30, RelWithDebInfo 30/30, Release 30/30.
- MoerEditor built in Debug, RelWithDebInfo, and Release.
- Actual Vulkan RT lifecycle validation passed with Render Thread + RHI Thread + parallel recording, two capture generations, stale Stop rejection, and clean shutdown.
- Actual Editor UI Start/Stop flow passed; generated MPD parsed as complete with 389,723 records and zero dropped/loss/orphan/error records.
- Three independent read-only audits report P0=0 and P1=0; all identified P2 findings were addressed before publication.

Base: origin/main at 6b6529a76302ef2cf459bdb549d9b50b8ea971e4
Review target: 828159974a114b0236c8dfd1f7cf679dd9078082