### PR TITLE
Phase 21D.3a: add bounded profile timeline index

### DIFF
--- a/source/test/CMakeLists.txt
+++ b/source/test/CMakeLists.txt
@@ -41,6 +41,20 @@ add_test(
 )
 set_tests_properties(ProfileSummaryCliContract PROPERTIES TIMEOUT 120)
 
+set(test_target TestProfileTimelineIndex)
+add_executable(${test_target} "ProfileTimelineIndexTest.cpp")
+target_link_libraries(${test_target}
+    PRIVATE
+        Moer::ProfileConsumer
+        Moer::Core
+)
+set_target_properties(${test_target} PROPERTIES FOLDER ${moer_test_folder})
+add_test(
+    NAME ProfileTimelineIndexContract
+    COMMAND $<TARGET_FILE:${test_target}>
+)
+set_tests_properties(ProfileTimelineIndexContract PROPERTIES TIMEOUT 60)
+
 set(test_target TestProfileScopeProducer)
 add_executable(${test_target} "ProfileScopeProducerTest.cpp")
 target_include_directories(${test_target}

--- a/source/test/ProfileTimelineIndexTest.cpp
+++ b/source/test/ProfileTimelineIndexTest.cpp
@@ -1,0 +1,1301 @@
+#include "profile_consumer/ProfileTimelineIndex.h"
+#include "profile/ProfileDump.h"
+#include "profile/ProfileDumpCodec.h"
+#include "profile/ProfileDumpTemplates.h"
+#include "profile_consumer/ProfileSession.h"
+
+#include <algorithm>
+#include <array>
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <span>
+#include <stdexcept>
+#include <stop_token>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace {
+
+using namespace Moer::ProfileDump;
+
+void Expect(bool _condition, std::string_view _message) {
+    if (!_condition) {
+        throw std::runtime_error(std::string(_message));
+    }
+}
+
+class ScopedTimelineCapture final {
+public:
+    ScopedTimelineCapture() {
+        static std::atomic_uint64_t next_id{0};
+        for (std::uint32_t attempt = 0; attempt < 64; ++attempt) {
+            const auto now =
+                static_cast<std::uint64_t>(std::chrono::steady_clock::now().time_since_epoch().count());
+            directory_ = std::filesystem::temp_directory_path() /
+                         ("moer-profile-timeline-index-" + std::to_string(now) + "-" +
+                          std::to_string(next_id.fetch_add(1, std::memory_order_relaxed)));
+            std::error_code error;
+            if (std::filesystem::create_directory(directory_, error)) {
+                path_ = directory_ / "timeline.mpd";
+                return;
+            }
+            if (error && error != std::errc::file_exists) {
+                break;
+            }
+        }
+        throw std::runtime_error("timeline index test could not reserve a temp directory");
+    }
+
+    ~ScopedTimelineCapture() {
+        static_cast<void>(Shutdown());
+        std::error_code error;
+        std::filesystem::remove_all(directory_, error);
+    }
+
+    [[nodiscard]] const std::filesystem::path& Path() const noexcept {
+        return path_;
+    }
+
+private:
+    std::filesystem::path directory_{};
+    std::filesystem::path path_{};
+};
+
+void EmitCpuScope(
+    SchemaHandle     _schema,
+    std::uint64_t    _thread_id,
+    std::string_view _name,
+    std::uint64_t    _begin_ns,
+    std::uint64_t    _end_ns,
+    std::uint32_t    _depth
+) {
+    const std::array<FieldValueView, 5> values{
+        _thread_id,
+        _name,
+        _begin_ns,
+        _end_ns,
+        _depth,
+    };
+    Expect(Emit(_schema, values) == EmitStatus::Accepted, "CPU scope fixture emission failed");
+}
+
+void EmitGpuFrame(
+    SchemaHandle          _schema,
+    std::uint64_t         _frame_id,
+    ProfileGpuFrameStatus _status,
+    bool                  _valid,
+    std::uint64_t         _admitted,
+    std::uint64_t         _dropped,
+    std::uint64_t         _errors,
+    std::string_view      _reason
+) {
+    const std::array<FieldValueView, 7> values{
+        _frame_id,
+        static_cast<std::uint32_t>(_status),
+        _valid,
+        _admitted,
+        _dropped,
+        _errors,
+        _reason,
+    };
+    Expect(Emit(_schema, values) == EmitStatus::Accepted, "GPU frame fixture emission failed");
+}
+
+void EmitGpuScope(
+    SchemaHandle          _schema,
+    std::uint64_t         _frame_id,
+    std::uint64_t         _scope_id,
+    std::uint64_t         _parent_scope_id,
+    std::uint64_t         _source_order,
+    std::uint64_t         _local_order,
+    ProfileLogicalQueue   _logical_queue,
+    std::uint32_t         _native_queue_id,
+    std::uint32_t         _family_id,
+    std::string_view      _name,
+    ProfileGpuScopeStatus _status,
+    std::uint64_t         _begin_tick,
+    std::uint64_t         _end_tick,
+    std::uint32_t         _valid_bits,
+    double                _tick_period_ns,
+    double                _total_duration_ns,
+    double                _exclusive_duration_ns,
+    std::uint32_t         _depth,
+    std::string_view      _error_reason
+) {
+    const std::array<FieldValueView, 18> values{
+        _frame_id,
+        _scope_id,
+        _parent_scope_id,
+        _source_order,
+        _local_order,
+        static_cast<std::uint32_t>(_logical_queue),
+        _native_queue_id,
+        _family_id,
+        _name,
+        static_cast<std::uint32_t>(_status),
+        _begin_tick,
+        _end_tick,
+        _valid_bits,
+        _tick_period_ns,
+        _total_duration_ns,
+        _exclusive_duration_ns,
+        _depth,
+        _error_reason,
+    };
+    Expect(Emit(_schema, values) == EmitStatus::Accepted, "GPU scope fixture emission failed");
+}
+
+void WriteTimelineCapture(const std::filesystem::path& _path) {
+    static_cast<void>(Shutdown());
+    RuntimeConfig config;
+    config.output_path      = _path;
+    config.replace_existing = true;
+    Expect(Start(config) == StartResult::Started, "fixture capture did not start");
+
+    const SchemaRegistration cpu       = RegisterSchema(Templates::CpuScope());
+    const SchemaRegistration gpu_frame = RegisterSchema(Templates::GpuFrame());
+    const SchemaRegistration gpu_scope = RegisterSchema(Templates::GpuScope());
+    Expect(
+        cpu.status == SchemaStatus::Registered && gpu_frame.status == SchemaStatus::Registered &&
+            gpu_scope.status == SchemaStatus::Registered,
+        "fixture schemas did not register"
+    );
+
+    constexpr std::uint64_t cpu_origin = (std::uint64_t{1} << 54) + 1000;
+    // CPU parents are emitted after their children; the consumer reconstructs
+    // topology from interval/depth plus producer record order.
+    EmitCpuScope(cpu.handle, 11, "point", cpu_origin + 500, cpu_origin + 500, 2);
+    EmitCpuScope(cpu.handle, 11, "child", cpu_origin + 100, cpu_origin + 900, 1);
+    EmitCpuScope(cpu.handle, 11, "parent", cpu_origin, cpu_origin + 1000, 0);
+
+    EmitCpuScope(cpu.handle, 11, "equal-leaf", cpu_origin + 1200, cpu_origin + 1300, 2);
+    EmitCpuScope(cpu.handle, 11, "equal-child", cpu_origin + 1100, cpu_origin + 1800, 1);
+    EmitCpuScope(cpu.handle, 11, "equal-parent", cpu_origin + 1100, cpu_origin + 2000, 0);
+
+    EmitCpuScope(cpu.handle, 11, "sibling-a", cpu_origin + 2100, cpu_origin + 2300, 0);
+    EmitCpuScope(cpu.handle, 11, "sibling-b", cpu_origin + 2300, cpu_origin + 2400, 0);
+
+    EmitCpuScope(cpu.handle, 11, "deep-point", cpu_origin + 4000, cpu_origin + 4000, 6);
+    EmitCpuScope(cpu.handle, 11, "deep-5", cpu_origin + 3500, cpu_origin + 4500, 5);
+    EmitCpuScope(cpu.handle, 11, "deep-4", cpu_origin + 3400, cpu_origin + 4600, 4);
+    EmitCpuScope(cpu.handle, 11, "deep-3", cpu_origin + 3300, cpu_origin + 4700, 3);
+    EmitCpuScope(cpu.handle, 11, "deep-2", cpu_origin + 3200, cpu_origin + 4800, 2);
+    EmitCpuScope(cpu.handle, 11, "deep-1", cpu_origin + 3100, cpu_origin + 4900, 1);
+    EmitCpuScope(cpu.handle, 11, "deep-parent", cpu_origin + 3000, cpu_origin + 5000, 0);
+
+    EmitCpuScope(cpu.handle, 22, "other-thread", cpu_origin + 200, cpu_origin + 300, 0);
+
+    EmitGpuFrame(gpu_frame.handle, 100, ProfileGpuFrameStatus::Complete, true, 4, 0, 0, "");
+    EmitGpuScope(
+        gpu_scope.handle,
+        100,
+        1,
+        0,
+        5,
+        0,
+        ProfileLogicalQueue::Graphics,
+        3,
+        7,
+        "gfx-root",
+        ProfileGpuScopeStatus::Ready,
+        100,
+        200,
+        64,
+        1.0,
+        100.0,
+        70.0,
+        0,
+        ""
+    );
+    EmitGpuScope(
+        gpu_scope.handle,
+        100,
+        2,
+        1,
+        5,
+        1,
+        ProfileLogicalQueue::Graphics,
+        3,
+        7,
+        "gfx-child",
+        ProfileGpuScopeStatus::Ready,
+        110,
+        140,
+        64,
+        1.0,
+        30.0,
+        30.0,
+        1,
+        ""
+    );
+    EmitGpuScope(
+        gpu_scope.handle,
+        100,
+        4,
+        0,
+        7,
+        0,
+        ProfileLogicalQueue::Graphics,
+        4,
+        7,
+        "wrapped-root",
+        ProfileGpuScopeStatus::Ready,
+        0xfffffff0ull,
+        0x10ull,
+        32,
+        2.0,
+        64.0,
+        64.0,
+        0,
+        ""
+    );
+    EmitGpuScope(
+        gpu_scope.handle,
+        100,
+        3,
+        0,
+        6,
+        0,
+        ProfileLogicalQueue::Compute,
+        3,
+        7,
+        "compute-root",
+        ProfileGpuScopeStatus::Ready,
+        300,
+        350,
+        64,
+        1.0,
+        50.0,
+        50.0,
+        0,
+        ""
+    );
+
+    EmitGpuFrame(
+        gpu_frame.handle, 101, ProfileGpuFrameStatus::Invalid, false, 1, 0, 1, "timestamp unavailable"
+    );
+    EmitGpuScope(
+        gpu_scope.handle,
+        101,
+        1,
+        0,
+        8,
+        0,
+        ProfileLogicalQueue::Graphics,
+        5,
+        9,
+        "failed-root",
+        ProfileGpuScopeStatus::Error,
+        0,
+        0,
+        0,
+        0.0,
+        0.0,
+        0.0,
+        0,
+        "timestamp unavailable"
+    );
+
+    EmitGpuFrame(gpu_frame.handle, 102, ProfileGpuFrameStatus::Incomplete, false, 1, 1, 0, "scope dropped");
+    EmitGpuScope(
+        gpu_scope.handle,
+        102,
+        1,
+        0,
+        9,
+        0,
+        ProfileLogicalQueue::Copy,
+        6,
+        10,
+        "incomplete-root",
+        ProfileGpuScopeStatus::Ready,
+        500,
+        550,
+        64,
+        1.0,
+        50.0,
+        50.0,
+        0,
+        ""
+    );
+
+    EmitGpuFrame(gpu_frame.handle, 103, ProfileGpuFrameStatus::Complete, true, 1, 0, 0, "");
+    EmitGpuScope(
+        gpu_scope.handle,
+        103,
+        1,
+        0,
+        10,
+        0,
+        ProfileLogicalQueue::Graphics,
+        3,
+        7,
+        "gfx-next-frame",
+        ProfileGpuScopeStatus::Ready,
+        1000,
+        1025,
+        64,
+        1.0,
+        25.0,
+        25.0,
+        0,
+        ""
+    );
+    EmitGpuFrame(gpu_frame.handle, 104, ProfileGpuFrameStatus::Complete, true, 0, 0, 0, "");
+
+    Expect(Shutdown() == ShutdownResult::Completed, "fixture capture did not close cleanly");
+}
+
+void WriteEmptyCapture(const std::filesystem::path& _path) {
+    static_cast<void>(Shutdown());
+    RuntimeConfig config;
+    config.output_path      = _path;
+    config.replace_existing = true;
+    Expect(Start(config) == StartResult::Started, "empty fixture capture did not start");
+    Expect(Shutdown() == ShutdownResult::Completed, "empty fixture capture did not close cleanly");
+}
+
+struct LoadedTimeline {
+    SessionLoadResult result{};
+    ProfileSession    session{};
+};
+
+std::vector<std::uint8_t> ReadFile(const std::filesystem::path& _path);
+
+LoadedTimeline LoadComplete(const std::filesystem::path& _path) {
+    LoadedTimeline loaded;
+    loaded.result = LoadProfileSessionFile(_path, {}, loaded.session);
+    if (loaded.result.status != SessionLoadStatus::Complete || !loaded.session.Valid()) {
+        ProfileSessionReader            diagnostic_reader;
+        const std::vector<std::uint8_t> bytes = ReadFile(_path);
+        static_cast<void>(diagnostic_reader.Feed(bytes));
+        static_cast<void>(diagnostic_reader.Finish());
+        throw std::runtime_error(
+            "timeline fixture did not load as a complete session (status=" +
+            std::to_string(static_cast<unsigned>(loaded.result.status)) +
+            ", error=" + std::to_string(static_cast<unsigned>(loaded.result.error_code)) +
+            ", packet=" + std::to_string(loaded.result.error_packet_index) +
+            ", diagnostic=" + std::string(diagnostic_reader.DiagnosticMessage()) + ")"
+        );
+    }
+    return loaded;
+}
+
+std::vector<std::uint8_t> ReadFile(const std::filesystem::path& _path) {
+    std::ifstream file(_path, std::ios::binary | std::ios::ate);
+    Expect(file.is_open(), "timeline fixture file did not open");
+    const std::streamoff end = file.tellg();
+    Expect(end > 0, "timeline fixture file is empty");
+    std::vector<std::uint8_t> bytes(static_cast<std::size_t>(end));
+    file.seekg(0, std::ios::beg);
+    file.read(reinterpret_cast<char*>(bytes.data()), static_cast<std::streamsize>(bytes.size()));
+    Expect(file.good(), "timeline fixture file read failed");
+    return bytes;
+}
+
+LoadedTimeline LoadForensicPrefix(const std::filesystem::path& _path) {
+    const std::vector<std::uint8_t> bytes              = ReadFile(_path);
+    std::size_t                     offset             = 0;
+    std::size_t                     session_end_offset = bytes.size();
+    CodecLimits                     codec_limits;
+    while (offset < bytes.size()) {
+        PacketView  packet;
+        std::size_t consumed = 0;
+        Expect(
+            DecodePacket(
+                std::span<const std::uint8_t>(bytes).subspan(offset), codec_limits, packet, consumed
+            ) == DecodeStatus::Ok,
+            "timeline fixture packet decode failed"
+        );
+        if (packet.header.type == PacketType::SessionEnd) {
+            session_end_offset = offset;
+            break;
+        }
+        offset += consumed;
+    }
+    Expect(session_end_offset < bytes.size(), "timeline fixture did not contain SessionEnd");
+
+    SessionLoadOptions options;
+    options.allow_forensic_truncation = true;
+    ProfileSessionReader reader(options);
+    Expect(
+        reader.Feed(std::span<const std::uint8_t>(bytes).first(session_end_offset)).status ==
+            SessionLoadStatus::Reading,
+        "forensic prefix became terminal before EOF"
+    );
+    LoadedTimeline loaded;
+    loaded.result  = reader.Finish();
+    loaded.session = reader.TakeSession();
+    Expect(
+        loaded.result.status == SessionLoadStatus::ForensicTruncated && loaded.session.Valid(),
+        "missing SessionEnd was not exposed as a forensic session"
+    );
+    return loaded;
+}
+
+std::uint32_t
+FindCpuTrack(const ProfileTimelineIndex& _index, const ProfileSession& _session, std::uint64_t _thread_id) {
+    for (std::size_t index = 0; index < _index.CpuTracks().size(); ++index) {
+        const CpuTimelineTrackIndex& track = _index.CpuTracks()[index];
+        if (_session.CpuTracks()[track.source_track_index].thread_id == _thread_id) {
+            return static_cast<std::uint32_t>(index);
+        }
+    }
+    throw std::runtime_error("expected CPU timeline track was not found");
+}
+
+std::uint32_t FindGpuTrack(
+    const ProfileTimelineIndex& _index,
+    const ProfileSession&       _session,
+    ProfileLogicalQueue         _queue,
+    std::uint32_t               _native_queue
+) {
+    for (std::size_t index = 0; index < _index.GpuTracks().size(); ++index) {
+        const GpuTimelineTrackIndex& indexed = _index.GpuTracks()[index];
+        const GpuTrack&              source  = _session.GpuTracks()[indexed.source_track_index];
+        if (source.logical_queue == _queue && source.native_queue_id == _native_queue) {
+            return static_cast<std::uint32_t>(index);
+        }
+    }
+    throw std::runtime_error("expected GPU timeline track was not found");
+}
+
+void VerifyCpuQueries(const ProfileTimelineIndex& _index, const ProfileSession& _session) {
+    const std::uint32_t          thread = FindCpuTrack(_index, _session, 11);
+    const CpuTimelineTrackIndex& track  = _index.CpuTracks()[thread];
+    Expect(
+        track.axis_index == 0 && track.begin_ns == 0 && track.end_ns == 5000 && track.max_depth == 6 &&
+            track.scope_count == 15,
+        "CPU relative axis or track range is wrong"
+    );
+
+    std::array<std::uint64_t, 64> results{};
+    TimelineOverlapQueryResult    query = _index.QueryCpuOverlaps(thread, 700, 800, results);
+    Expect(
+        query.valid && !query.truncated && query.written == 2,
+        "long CPU ancestors were omitted from a visible-range query"
+    );
+    Expect(
+        _session.String(_session.CpuScopes()[results[0]].name) == "parent" &&
+            _session.String(_session.CpuScopes()[results[1]].name) == "child",
+        "CPU query order is not deterministic begin-time order"
+    );
+    std::array<std::uint64_t, 2> exact_results{};
+    query = _index.QueryCpuOverlaps(thread, 700, 800, exact_results);
+    Expect(
+        query.valid && !query.truncated && query.written == exact_results.size(),
+        "exact-fit CPU query was reported as truncated"
+    );
+
+    query = _index.QueryCpuOverlaps(thread, 500, 501, results);
+    Expect(
+        query.valid && !query.truncated && query.written == 3,
+        "zero-duration CPU scope was omitted at its visible point"
+    );
+
+    query = _index.QueryCpuOverlaps(thread, 500, 501, std::span<std::uint64_t>(results).first(1));
+    Expect(
+        query.valid && query.truncated && query.written == 1,
+        "CPU query did not stop at its caller-provided output bound"
+    );
+    query = _index.QueryCpuOverlaps(thread, 500, 501, {});
+    Expect(
+        query.valid && query.truncated && query.written == 0,
+        "CPU query with an empty output span did not report truncation"
+    );
+
+    query = _index.QueryCpuOverlaps(thread, 1000, 1001, results);
+    Expect(
+        query.valid && !query.truncated && query.written == 0,
+        "half-open CPU query included a scope ending at the view boundary"
+    );
+    Expect(
+        !_index.QueryCpuOverlaps(thread, 500, 500, results).valid,
+        "empty CPU view was reported as a valid range query"
+    );
+    Expect(
+        !_index.QueryCpuOverlaps(static_cast<std::uint32_t>(_index.CpuTracks().size()), 0, 1, results).valid,
+        "invalid CPU track query was reported as valid"
+    );
+
+    const auto expect_oracle = [&](std::uint64_t _begin, std::uint64_t _end) {
+        std::array<std::uint64_t, 64> expected{};
+        std::size_t                   expected_count = 0;
+        for (std::uint64_t local_index = 0; local_index < track.scope_count; ++local_index) {
+            const CpuTimelineScopeRef& scope    = _index.CpuScopes()[track.first_scope + local_index];
+            const bool                 overlaps = scope.end_ns > scope.begin_ns ?
+                                                      scope.end_ns > _begin && scope.begin_ns < _end :
+                                                      scope.begin_ns >= _begin && scope.begin_ns < _end;
+            if (overlaps) {
+                expected[expected_count++] = scope.source_scope_index;
+            }
+        }
+
+        std::array<std::uint64_t, 64>    actual{};
+        const TimelineOverlapQueryResult actual_query = _index.QueryCpuOverlaps(thread, _begin, _end, actual);
+        Expect(
+            actual_query.valid && !actual_query.truncated && actual_query.written == expected_count &&
+                std::equal(
+                    expected.begin(),
+                    expected.begin() + static_cast<std::ptrdiff_t>(expected_count),
+                    actual.begin()
+                ),
+            "CPU interval index disagreed with the brute-force overlap oracle"
+        );
+    };
+
+    constexpr std::array<std::uint64_t, 5> widths{1, 17, 211, 997, 2048};
+    for (std::uint64_t begin = 0; begin < 5200; begin += 137) {
+        for (const std::uint64_t width : widths) {
+            expect_oracle(begin, begin + width);
+        }
+    }
+    expect_oracle(1100, 1101);
+    expect_oracle(2300, 2301);
+    expect_oracle(4000, 4001);
+}
+
+void VerifyGpuDomainsAndSlices(const ProfileTimelineIndex& _index, const ProfileSession& _session) {
+    Expect(
+        _index.Axes().size() == 1 + _session.GpuDomains().size(),
+        "timeline axes did not preserve every physical GPU domain"
+    );
+    Expect(
+        _index.Axes().front().kind == TimelineAxisKind::CpuSteadyClock &&
+            _index.Axes().front().source_domain_index == kInvalidTimelineAxis &&
+            _index.Axes().front().unit_period_ns == 1.0 && _index.Axes().front().timing_available &&
+            _index.Axes().front().timing_capability_trusted && _index.Axes().front().calibrated_to_cpu &&
+            !_index.Axes().front().calibrated_to_other_gpu_domains,
+        "CPU steady-clock axis metadata is wrong"
+    );
+    for (std::size_t index = 1; index < _index.Axes().size(); ++index) {
+        Expect(
+            _index.Axes()[index].kind == TimelineAxisKind::GpuPhysicalTimestampDomain &&
+                !_index.Axes()[index].calibrated_to_cpu &&
+                !_index.Axes()[index].calibrated_to_other_gpu_domains,
+            "GPU axis incorrectly claims CPU or cross-domain calibration"
+        );
+    }
+
+    const std::uint32_t graphics   = FindGpuTrack(_index, _session, ProfileLogicalQueue::Graphics, 3);
+    const std::uint32_t compute    = FindGpuTrack(_index, _session, ProfileLogicalQueue::Compute, 3);
+    const std::uint32_t wrapped    = FindGpuTrack(_index, _session, ProfileLogicalQueue::Graphics, 4);
+    const std::uint32_t failed     = FindGpuTrack(_index, _session, ProfileLogicalQueue::Graphics, 5);
+    const std::uint32_t incomplete = FindGpuTrack(_index, _session, ProfileLogicalQueue::Copy, 6);
+    Expect(
+        _index.GpuTracks()[graphics].axis_index == _index.GpuTracks()[compute].axis_index &&
+            _index.GpuTracks()[graphics].axis_index != _index.GpuTracks()[wrapped].axis_index,
+        "logical queue aliasing did not preserve physical-domain identity"
+    );
+
+    const GpuTimelineFrameRef* frame = _index.FindGpuFrame(100);
+    Expect(
+        frame != nullptr && _session.GpuFrames()[frame->source_frame_index].frame_id == 100,
+        "GPU frame lookup did not retain its source identity"
+    );
+    const GpuTimelineFrameSlice* graphics_slice      = _index.FindGpuFrameSlice(graphics, 100);
+    const GpuTimelineFrameSlice* next_graphics_slice = _index.FindGpuFrameSlice(graphics, 103);
+    const GpuTimelineFrameSlice* failed_slice        = _index.FindGpuFrameSlice(failed, 101);
+    const GpuTimelineFrameSlice* incomplete_slice    = _index.FindGpuFrameSlice(incomplete, 102);
+    const GpuTimelineFrameSlice* compute_slice       = _index.FindGpuFrameSlice(compute, 100);
+    const GpuTimelineFrameSlice* wrapped_slice       = _index.FindGpuFrameSlice(wrapped, 100);
+    Expect(
+        graphics_slice != nullptr && graphics_slice->scope_count == 2 && graphics_slice->has_frame_record &&
+            graphics_slice->materialization_complete && graphics_slice->timing_topology_trusted &&
+            next_graphics_slice != nullptr && next_graphics_slice->scope_count == 1 &&
+            next_graphics_slice->timing_topology_trusted && compute_slice != nullptr &&
+            compute_slice->scope_count == 1 && compute_slice->timing_topology_trusted &&
+            wrapped_slice != nullptr && wrapped_slice->scope_count == 1 &&
+            wrapped_slice->timing_topology_trusted,
+        "trusted GPU frame slices are wrong"
+    );
+    Expect(
+        failed_slice != nullptr && failed_slice->scope_count == 1 && failed_slice->error_scope_count == 1 &&
+            failed_slice->frame_status == ProfileGpuFrameStatus::Invalid &&
+            !failed_slice->timing_topology_trusted,
+        "invalid/error GPU frame slice was hidden or marked trusted"
+    );
+    Expect(
+        incomplete_slice != nullptr && incomplete_slice->scope_count == 1 &&
+            incomplete_slice->error_scope_count == 0 &&
+            incomplete_slice->frame_status == ProfileGpuFrameStatus::Incomplete &&
+            !incomplete_slice->timing_topology_trusted,
+        "incomplete GPU frame slice was hidden or marked trusted"
+    );
+
+    const std::uint32_t         shared_axis       = _index.GpuTracks()[graphics].axis_index;
+    const GpuTimelineAxisFrame* shared_frame      = _index.FindGpuAxisFrame(shared_axis, 100);
+    const GpuTimelineAxisFrame* next_shared_frame = _index.FindGpuAxisFrame(shared_axis, 103);
+    const GpuTimelineAxisFrame* wrapped_frame =
+        _index.FindGpuAxisFrame(_index.GpuTracks()[wrapped].axis_index, 100);
+    const GpuTimelineAxisFrame* failed_frame =
+        _index.FindGpuAxisFrame(_index.GpuTracks()[failed].axis_index, 101);
+    const GpuTimelineAxisFrame* incomplete_frame =
+        _index.FindGpuAxisFrame(_index.GpuTracks()[incomplete].axis_index, 102);
+    Expect(
+        shared_frame != nullptr && shared_frame->origin_tick == 100 && shared_frame->extent_ticks == 250 &&
+            shared_frame->ready_scope_count == 3 && shared_frame->error_scope_count == 0 &&
+            shared_frame->timing_available && shared_frame->timing_capability_trusted &&
+            shared_frame->timing_topology_trusted && next_shared_frame != nullptr &&
+            next_shared_frame->origin_tick == 1000 && next_shared_frame->extent_ticks == 25,
+        "shared physical GPU axis did not get frame-local timing extents"
+    );
+    Expect(
+        wrapped_frame != nullptr && wrapped_frame->origin_tick == 0xfffffff0ull &&
+            wrapped_frame->extent_ticks == 32 && wrapped_frame->timing_available &&
+            wrapped_frame->timing_topology_trusted,
+        "wrapped GPU timestamps were not normalized to a local axis"
+    );
+    Expect(
+        failed_frame != nullptr && failed_frame->ready_scope_count == 0 &&
+            failed_frame->error_scope_count == 1 && !failed_frame->timing_available &&
+            !failed_frame->timing_topology_trusted && incomplete_frame != nullptr &&
+            incomplete_frame->origin_tick == 500 && incomplete_frame->extent_ticks == 50 &&
+            incomplete_frame->timing_available && !incomplete_frame->timing_capability_trusted &&
+            !incomplete_frame->timing_topology_trusted,
+        "untrusted GPU frame timing diagnostics are wrong"
+    );
+
+    Expect(
+        graphics_slice->axis_frame_index == compute_slice->axis_frame_index &&
+            graphics_slice->axis_frame_index != next_graphics_slice->axis_frame_index &&
+            graphics_slice->timeline_scope_count == 2 && compute_slice->timeline_scope_count == 1 &&
+            wrapped_slice->timeline_scope_count == 1 && failed_slice->timeline_scope_count == 0 &&
+            incomplete_slice->timeline_scope_count == 1,
+        "GPU track slices do not reference the expected frame-local timing data"
+    );
+
+    std::array<std::uint64_t, 8> query_results{};
+    TimelineOverlapQueryResult   query = _index.QueryGpuOverlaps(graphics, 100, 20, 30, query_results);
+    Expect(
+        query.valid && !query.truncated && query.written == 2 &&
+            _session.String(_session.GpuScopes()[query_results[0]].name) == "gfx-root" &&
+            _session.String(_session.GpuScopes()[query_results[1]].name) == "gfx-child",
+        "GPU visible-range query lost nested scopes or deterministic order"
+    );
+    std::array<std::uint64_t, 2> exact_gpu_results{};
+    query = _index.QueryGpuOverlaps(graphics, 100, 20, 30, exact_gpu_results);
+    Expect(
+        query.valid && !query.truncated && query.written == exact_gpu_results.size(),
+        "exact-fit GPU query was reported as truncated"
+    );
+    query = _index.QueryGpuOverlaps(compute, 100, 210, 220, query_results);
+    Expect(
+        query.valid && !query.truncated && query.written == 1 &&
+            _session.String(_session.GpuScopes()[query_results[0]].name) == "compute-root",
+        "logical queues sharing one GPU axis did not share its local origin"
+    );
+    query = _index.QueryGpuOverlaps(wrapped, 100, 0, 32, query_results);
+    Expect(
+        query.valid && !query.truncated && query.written == 1,
+        "wrapped GPU scope was not queryable on its normalized range"
+    );
+    query = _index.QueryGpuOverlaps(graphics, 100, 20, 30, std::span<std::uint64_t>(query_results).first(1));
+    Expect(
+        query.valid && query.truncated && query.written == 1,
+        "GPU query did not honor its caller-provided output bound"
+    );
+    Expect(
+        !_index.QueryGpuOverlaps(failed, 101, 0, 1, query_results).valid &&
+            !_index.QueryGpuOverlaps(graphics, 999, 0, 1, query_results).valid,
+        "GPU timing query accepted an error-only or missing frame"
+    );
+
+    const TimelineAxis& failed_axis = _index.Axes()[_index.GpuTracks()[failed].axis_index];
+    Expect(
+        failed_axis.native_queue_id == 5 && failed_axis.family_id == 9 && !failed_axis.timing_available &&
+            !failed_axis.timing_capability_trusted && failed_axis.valid_bits == 0 &&
+            failed_axis.unit_period_ns == 0.0,
+        "error-only physical GPU domain advertised usable timing"
+    );
+    Expect(_index.FindGpuFrameSlice(compute, 101) == nullptr, "GPU track lookup invented a frame slice");
+    Expect(
+        _index.FindGpuFrame(999) == nullptr && _index.FindGpuFrame(104) != nullptr &&
+            _index.FindGpuFrameSlice(graphics, 104) == nullptr &&
+            _index.FindGpuAxisFrame(shared_axis, 999) == nullptr &&
+            _index.FindGpuFrameSlice(static_cast<std::uint32_t>(_index.GpuTracks().size()), 100) == nullptr,
+        "missing GPU frame or invalid track lookup returned a result"
+    );
+}
+
+void VerifyPublicRangeIntegrity(const ProfileTimelineIndex& _index, const ProfileSession& _session) {
+    Expect(
+        _index.CpuTracks().size() == _session.CpuTracks().size() &&
+            _index.CpuScopes().size() == _session.CpuScopes().size() &&
+            _index.GpuFrames().size() == _session.GpuFrames().size() &&
+            _index.GpuTracks().size() == _session.GpuTracks().size(),
+        "timeline index omitted a public source track or record"
+    );
+
+    std::uint64_t cpu_scope_cursor = 0;
+    for (const CpuTimelineTrackIndex& indexed : _index.CpuTracks()) {
+        Expect(
+            indexed.source_track_index < _session.CpuTracks().size() &&
+                indexed.first_scope == cpu_scope_cursor && indexed.first_scope <= _index.CpuScopes().size() &&
+                indexed.scope_count <= _index.CpuScopes().size() - indexed.first_scope,
+            "CPU timeline track exposes an invalid retained range"
+        );
+        const CpuTrack& source_track = _session.CpuTracks()[indexed.source_track_index];
+        Expect(
+            indexed.scope_count == source_track.scope_count,
+            "CPU timeline track count disagrees with its source track"
+        );
+        for (std::uint64_t local_index = 0; local_index < indexed.scope_count; ++local_index) {
+            const CpuTimelineScopeRef& retained = _index.CpuScopes()[indexed.first_scope + local_index];
+            const std::uint64_t        expected_source = source_track.first_scope + local_index;
+            Expect(
+                retained.source_scope_index == expected_source &&
+                    expected_source < _session.CpuScopes().size(),
+                "CPU timeline scope points outside its source track"
+            );
+            const CpuScopeRecord& source = _session.CpuScopes()[expected_source];
+            Expect(
+                source.track_index == indexed.source_track_index &&
+                    retained.begin_ns == source.begin_ns - _session.Summary().cpu_begin_ns &&
+                    retained.end_ns == source.end_ns - _session.Summary().cpu_begin_ns,
+                "CPU timeline scope payload disagrees with its source record"
+            );
+        }
+        cpu_scope_cursor += indexed.scope_count;
+    }
+    Expect(
+        cpu_scope_cursor == _index.CpuScopes().size(),
+        "CPU timeline tracks did not cover every retained scope exactly once"
+    );
+
+    for (const GpuTimelineFrameRef& indexed : _index.GpuFrames()) {
+        Expect(
+            indexed.source_frame_index < _session.GpuFrames().size() &&
+                _session.GpuFrames()[indexed.source_frame_index].frame_id == indexed.frame_id,
+            "GPU frame lookup index points outside its source records"
+        );
+    }
+
+    std::uint64_t gpu_slice_cursor    = 0;
+    std::uint64_t gpu_timeline_cursor = 0;
+    for (const GpuTimelineTrackIndex& indexed : _index.GpuTracks()) {
+        Expect(
+            indexed.source_track_index < _session.GpuTracks().size() &&
+                indexed.axis_index < _index.Axes().size() && indexed.first_frame_slice == gpu_slice_cursor &&
+                indexed.first_frame_slice <= _index.GpuFrameSlices().size() &&
+                indexed.frame_slice_count <= _index.GpuFrameSlices().size() - indexed.first_frame_slice,
+            "GPU timeline track exposes an invalid retained range"
+        );
+        const GpuTrack&           source_track = _session.GpuTracks()[indexed.source_track_index];
+        const GpuTimestampDomain& domain       = _session.GpuDomains()[source_track.domain_index];
+        const TimelineAxis&       axis         = _index.Axes()[indexed.axis_index];
+        Expect(
+            axis.source_domain_index == source_track.domain_index &&
+                axis.native_queue_id == domain.native_queue_id && axis.family_id == domain.family_id &&
+                axis.logical_queue_mask == domain.logical_queue_mask &&
+                axis.valid_bits == domain.valid_bits && axis.unit_period_ns == domain.tick_period_ns &&
+                axis.timing_available == domain.has_ready_timestamps &&
+                axis.timing_capability_trusted == domain.timing_capability_trusted,
+            "GPU timeline axis disagrees with its physical source domain"
+        );
+
+        std::uint64_t previous_frame = 0;
+        bool          has_frame      = false;
+        std::uint64_t source_cursor  = source_track.first_scope;
+        for (std::uint64_t local_index = 0; local_index < indexed.frame_slice_count; ++local_index) {
+            const GpuTimelineFrameSlice& slice =
+                _index.GpuFrameSlices()[indexed.first_frame_slice + local_index];
+            Expect(
+                (!has_frame || previous_frame < slice.frame_id) && slice.scope_count != 0 &&
+                    slice.first_scope == source_cursor &&
+                    slice.first_scope <= source_track.first_scope + source_track.scope_count &&
+                    slice.scope_count <=
+                        source_track.first_scope + source_track.scope_count - slice.first_scope &&
+                    slice.axis_frame_index < _index.GpuAxisFrames().size() &&
+                    slice.first_timeline_scope == gpu_timeline_cursor &&
+                    slice.first_timeline_scope <= _index.GpuTimelineScopes().size() &&
+                    slice.timeline_scope_count <=
+                        _index.GpuTimelineScopes().size() - slice.first_timeline_scope,
+                "GPU frame slices are unsorted or escape their source track"
+            );
+            previous_frame = slice.frame_id;
+            has_frame      = true;
+            source_cursor += slice.scope_count;
+
+            std::uint64_t ready_scope_count = 0;
+            for (std::uint64_t scope_offset = 0; scope_offset < slice.scope_count; ++scope_offset) {
+                const GpuScopeRecord& scope = _session.GpuScopes()[slice.first_scope + scope_offset];
+                Expect(
+                    scope.track_index == indexed.source_track_index &&
+                        scope.domain_index == source_track.domain_index && scope.frame_id == slice.frame_id &&
+                        scope.frame_index == slice.source_frame_index,
+                    "GPU frame slice disagrees with one of its source scopes"
+                );
+                ready_scope_count += static_cast<std::uint64_t>(scope.status == ProfileGpuScopeStatus::Ready);
+            }
+            const GpuTimelineAxisFrame& axis_frame = _index.GpuAxisFrames()[slice.axis_frame_index];
+            Expect(
+                axis_frame.axis_index == indexed.axis_index && axis_frame.frame_id == slice.frame_id &&
+                    axis_frame.source_frame_index == slice.source_frame_index &&
+                    slice.timeline_scope_count == (axis_frame.timing_available ? ready_scope_count : 0),
+                "GPU frame slice disagrees with its physical axis-frame metadata"
+            );
+            for (std::uint64_t timeline_offset = 0; timeline_offset < slice.timeline_scope_count;
+                 ++timeline_offset) {
+                const GpuTimelineScopeRef& retained =
+                    _index.GpuTimelineScopes()[slice.first_timeline_scope + timeline_offset];
+                Expect(
+                    retained.source_scope_index >= slice.first_scope &&
+                        retained.source_scope_index < slice.first_scope + slice.scope_count &&
+                        _session.GpuScopes()[retained.source_scope_index].status ==
+                            ProfileGpuScopeStatus::Ready &&
+                        retained.begin_tick_offset <= retained.end_tick_offset &&
+                        retained.end_tick_offset <= axis_frame.extent_ticks,
+                    "GPU timeline scope escaped its source slice or frame-local extent"
+                );
+            }
+            gpu_timeline_cursor += slice.timeline_scope_count;
+        }
+        Expect(
+            source_cursor == source_track.first_scope + source_track.scope_count,
+            "GPU frame slices did not cover their source track exactly once"
+        );
+        gpu_slice_cursor += indexed.frame_slice_count;
+    }
+    Expect(
+        gpu_slice_cursor == _index.GpuFrameSlices().size() &&
+            gpu_timeline_cursor == _index.GpuTimelineScopes().size(),
+        "GPU tracks did not cover every retained slice or timeline scope"
+    );
+
+    std::vector<std::pair<std::uint32_t, std::uint64_t>> expected_axis_frames;
+    expected_axis_frames.reserve(_session.GpuScopes().size());
+    for (const GpuScopeRecord& scope : _session.GpuScopes()) {
+        expected_axis_frames.emplace_back(scope.domain_index, scope.frame_id);
+    }
+    std::sort(expected_axis_frames.begin(), expected_axis_frames.end());
+    expected_axis_frames.erase(
+        std::unique(expected_axis_frames.begin(), expected_axis_frames.end()), expected_axis_frames.end()
+    );
+    Expect(
+        _index.GpuAxisFrames().size() == expected_axis_frames.size(),
+        "GPU physical axis-frame index omitted a source domain/frame pair"
+    );
+    for (std::size_t index = 0; index < _index.GpuAxisFrames().size(); ++index) {
+        const GpuTimelineAxisFrame& axis_frame = _index.GpuAxisFrames()[index];
+        Expect(
+            axis_frame.axis_index == 1 + expected_axis_frames[index].first &&
+                axis_frame.frame_id == expected_axis_frames[index].second &&
+                _index.FindGpuAxisFrame(axis_frame.axis_index, axis_frame.frame_id) == &axis_frame,
+            "GPU physical axis-frame order or lookup is inconsistent"
+        );
+    }
+}
+
+template<typename T>
+std::vector<T> CopySpan(std::span<const T> _values) {
+    return std::vector<T>(_values.begin(), _values.end());
+}
+
+struct TimelineIndexSnapshot {
+    TimelineIndexBuildResult           result{};
+    ProfileTimelineQuality             quality{};
+    std::vector<TimelineAxis>          axes{};
+    std::vector<CpuTimelineTrackIndex> cpu_tracks{};
+    std::vector<CpuTimelineScopeRef>   cpu_scopes{};
+    std::vector<GpuTimelineFrameRef>   gpu_frames{};
+    std::vector<GpuTimelineTrackIndex> gpu_tracks{};
+    std::vector<GpuTimelineFrameSlice> gpu_slices{};
+    std::vector<GpuTimelineAxisFrame>  gpu_axis_frames{};
+    std::vector<GpuTimelineScopeRef>   gpu_scopes{};
+};
+
+TimelineIndexSnapshot CaptureIndex(const ProfileTimelineIndex& _index) {
+    return {
+        .result          = _index.BuildResult(),
+        .quality         = _index.Quality(),
+        .axes            = CopySpan(_index.Axes()),
+        .cpu_tracks      = CopySpan(_index.CpuTracks()),
+        .cpu_scopes      = CopySpan(_index.CpuScopes()),
+        .gpu_frames      = CopySpan(_index.GpuFrames()),
+        .gpu_tracks      = CopySpan(_index.GpuTracks()),
+        .gpu_slices      = CopySpan(_index.GpuFrameSlices()),
+        .gpu_axis_frames = CopySpan(_index.GpuAxisFrames()),
+        .gpu_scopes      = CopySpan(_index.GpuTimelineScopes()),
+    };
+}
+
+bool MatchesSnapshot(const ProfileTimelineIndex& _index, const TimelineIndexSnapshot& _snapshot) {
+    const auto equals = []<typename T>(std::span<const T> _actual, const std::vector<T>& _expected) {
+        return _actual.size() == _expected.size() &&
+               std::equal(_actual.begin(), _actual.end(), _expected.begin());
+    };
+    return _index.BuildResult() == _snapshot.result && _index.Quality() == _snapshot.quality &&
+           equals(_index.Axes(), _snapshot.axes) && equals(_index.CpuTracks(), _snapshot.cpu_tracks) &&
+           equals(_index.CpuScopes(), _snapshot.cpu_scopes) &&
+           equals(_index.GpuFrames(), _snapshot.gpu_frames) &&
+           equals(_index.GpuTracks(), _snapshot.gpu_tracks) &&
+           equals(_index.GpuFrameSlices(), _snapshot.gpu_slices) &&
+           equals(_index.GpuAxisFrames(), _snapshot.gpu_axis_frames) &&
+           equals(_index.GpuTimelineScopes(), _snapshot.gpu_scopes);
+}
+
+std::uint64_t TreeValueCount(std::uint64_t _scope_count) {
+    std::uint64_t leaves = 1;
+    while (leaves < _scope_count) {
+        leaves *= 2;
+    }
+    return leaves * 2;
+}
+
+std::uint64_t ExpectedLogicalBytes(const ProfileTimelineIndex& _index) {
+    std::uint64_t cpu_tree_values = 0;
+    for (const CpuTimelineTrackIndex& track : _index.CpuTracks()) {
+        cpu_tree_values += TreeValueCount(track.scope_count);
+    }
+    std::uint64_t gpu_tree_values = 0;
+    for (const GpuTimelineFrameSlice& slice : _index.GpuFrameSlices()) {
+        const GpuTimelineAxisFrame& axis_frame = _index.GpuAxisFrames()[slice.axis_frame_index];
+        if (axis_frame.timing_available) {
+            gpu_tree_values += TreeValueCount(slice.timeline_scope_count);
+        }
+    }
+    constexpr std::uint64_t interval_tree_bytes = sizeof(std::uint64_t) * 2;
+    return _index.Axes().size() * sizeof(TimelineAxis) +
+           _index.CpuTracks().size() * sizeof(CpuTimelineTrackIndex) +
+           _index.CpuScopes().size() * sizeof(CpuTimelineScopeRef) +
+           _index.CpuTracks().size() * interval_tree_bytes + cpu_tree_values * sizeof(std::uint64_t) +
+           _index.GpuFrames().size() * sizeof(GpuTimelineFrameRef) +
+           _index.GpuTracks().size() * sizeof(GpuTimelineTrackIndex) +
+           _index.GpuFrameSlices().size() * sizeof(GpuTimelineFrameSlice) +
+           _index.GpuAxisFrames().size() * sizeof(GpuTimelineAxisFrame) +
+           _index.GpuTimelineScopes().size() * sizeof(GpuTimelineScopeRef) +
+           _index.GpuFrameSlices().size() * interval_tree_bytes + gpu_tree_values * sizeof(std::uint64_t);
+}
+
+void VerifyQualityAndAtomicLimits(LoadedTimeline& _complete, const LoadedTimeline& _forensic) {
+    ProfileTimelineIndex           index;
+    const TimelineIndexBuildResult built =
+        BuildProfileTimelineIndex(_complete.session, _complete.result, {}, index);
+    Expect(
+        built.Succeeded() && index.Valid() && index.Matches(_complete.session),
+        "complete timeline index did not build"
+    );
+    Expect(
+        !index.Matches(_forensic.session),
+        "timeline index matched a different immutable session with the same shape"
+    );
+    const ProfileTimelineQuality& quality = index.Quality();
+    const std::uint32_t           expected_quality_flags =
+        TimelineQualityBit(TimelineQualityFlag::IncompleteGpuFrames) |
+        TimelineQualityBit(TimelineQualityFlag::InvalidGpuFrames) |
+        TimelineQualityBit(TimelineQualityFlag::GpuScopeErrors) |
+        TimelineQualityBit(TimelineQualityFlag::UntrustedGpuTiming);
+    const ProfileTimelineQuality expected_quality{
+        .flags                      = expected_quality_flags,
+        .incomplete_gpu_frame_count = 1,
+        .invalid_gpu_frame_count    = 1,
+        .error_gpu_scope_count      = 1,
+        .untrusted_gpu_frame_count  = 2,
+    };
+    Expect(quality == expected_quality, "complete session quality flags are wrong");
+
+    ProfileTimelineIndex forensic_index;
+    Expect(
+        BuildProfileTimelineIndex(_forensic.session, _forensic.result, {}, forensic_index).Succeeded() &&
+            forensic_index.Quality() ==
+                ProfileTimelineQuality{
+                    .flags =
+                        expected_quality_flags | TimelineQualityBit(TimelineQualityFlag::ForensicTruncated),
+                    .incomplete_gpu_frame_count = 1,
+                    .invalid_gpu_frame_count    = 1,
+                    .error_gpu_scope_count      = 1,
+                    .untrusted_gpu_frame_count  = 2,
+                },
+        "forensic session quality was not retained"
+    );
+
+    const std::uint64_t retained_bytes = index.BuildResult().logical_bytes;
+    Expect(
+        retained_bytes != 0 && retained_bytes == ExpectedLogicalBytes(index),
+        "timeline index logical bytes do not cover every retained vector"
+    );
+
+    TimelineIndexLimits exact;
+    exact.max_logical_bytes = retained_bytes;
+    ProfileTimelineIndex exact_index;
+    Expect(
+        BuildProfileTimelineIndex(_complete.session, _complete.result, exact, exact_index).Succeeded(),
+        "exact timeline logical-byte limit was rejected"
+    );
+    const TimelineIndexSnapshot exact_snapshot = CaptureIndex(exact_index);
+
+    TimelineIndexLimits one_less = exact;
+    one_less.max_logical_bytes   = retained_bytes - 1;
+    const TimelineIndexBuildResult rejected =
+        BuildProfileTimelineIndex(_complete.session, _complete.result, one_less, exact_index);
+    Expect(
+        rejected.status == TimelineIndexBuildStatus::LimitExceeded &&
+            rejected.limit_kind == TimelineIndexLimitKind::LogicalBytes && exact_index.Valid() &&
+            exact_index.Matches(_complete.session) && MatchesSnapshot(exact_index, exact_snapshot),
+        "failed timeline rebuild replaced the previous usable index"
+    );
+
+    TimelineIndexLimits zero_bytes = exact;
+    zero_bytes.max_logical_bytes   = 0;
+    const TimelineIndexBuildResult zero_rejected =
+        BuildProfileTimelineIndex(_complete.session, _complete.result, zero_bytes, exact_index);
+    Expect(
+        zero_rejected.status == TimelineIndexBuildStatus::LimitExceeded &&
+            zero_rejected.limit_kind == TimelineIndexLimitKind::LogicalBytes &&
+            MatchesSnapshot(exact_index, exact_snapshot),
+        "zero logical-byte limit was not reported as a bounded rejection"
+    );
+
+    TimelineIndexLimits exact_counts;
+    exact_counts.max_cpu_scopes          = _complete.session.CpuScopes().size();
+    exact_counts.max_gpu_frame_slices    = index.GpuFrameSlices().size();
+    exact_counts.max_gpu_timeline_scopes = index.GpuTimelineScopes().size();
+    ProfileTimelineIndex count_limited;
+    Expect(
+        BuildProfileTimelineIndex(_complete.session, _complete.result, exact_counts, count_limited)
+            .Succeeded(),
+        "exact timeline count limits were rejected"
+    );
+    const TimelineIndexSnapshot count_snapshot = CaptureIndex(count_limited);
+
+    TimelineIndexLimits one_less_cpu = exact_counts;
+    one_less_cpu.max_cpu_scopes -= 1;
+    const TimelineIndexBuildResult cpu_rejected =
+        BuildProfileTimelineIndex(_complete.session, _complete.result, one_less_cpu, count_limited);
+    Expect(
+        cpu_rejected.status == TimelineIndexBuildStatus::LimitExceeded &&
+            cpu_rejected.limit_kind == TimelineIndexLimitKind::CpuScopes &&
+            MatchesSnapshot(count_limited, count_snapshot),
+        "CPU scope limit rejection replaced the prior timeline index"
+    );
+
+    TimelineIndexLimits one_less_gpu = exact_counts;
+    one_less_gpu.max_gpu_frame_slices -= 1;
+    const TimelineIndexBuildResult gpu_rejected =
+        BuildProfileTimelineIndex(_complete.session, _complete.result, one_less_gpu, count_limited);
+    Expect(
+        gpu_rejected.status == TimelineIndexBuildStatus::LimitExceeded &&
+            gpu_rejected.limit_kind == TimelineIndexLimitKind::GpuFrameSlices &&
+            MatchesSnapshot(count_limited, count_snapshot),
+        "GPU frame-slice limit rejection replaced the prior timeline index"
+    );
+
+    TimelineIndexLimits one_less_gpu_scope = exact_counts;
+    one_less_gpu_scope.max_gpu_timeline_scopes -= 1;
+    const TimelineIndexBuildResult gpu_scope_rejected =
+        BuildProfileTimelineIndex(_complete.session, _complete.result, one_less_gpu_scope, count_limited);
+    Expect(
+        gpu_scope_rejected.status == TimelineIndexBuildStatus::LimitExceeded &&
+            gpu_scope_rejected.limit_kind == TimelineIndexLimitKind::GpuTimelineScopes &&
+            MatchesSnapshot(count_limited, count_snapshot),
+        "GPU timeline-scope limit rejection replaced the prior index"
+    );
+
+    TimelineIndexLimits zero_transient       = exact_counts;
+    zero_transient.max_transient_build_bytes = 0;
+    const TimelineIndexBuildResult transient_rejected =
+        BuildProfileTimelineIndex(_complete.session, _complete.result, zero_transient, count_limited);
+    Expect(
+        transient_rejected.status == TimelineIndexBuildStatus::LimitExceeded &&
+            transient_rejected.limit_kind == TimelineIndexLimitKind::TransientBuildBytes &&
+            MatchesSnapshot(count_limited, count_snapshot),
+        "transient build-byte rejection replaced the prior timeline index"
+    );
+
+    SessionLoadResult unusable = _complete.result;
+    unusable.status            = SessionLoadStatus::Reading;
+    const TimelineIndexBuildResult unusable_rejected =
+        BuildProfileTimelineIndex(_complete.session, unusable, exact_counts, count_limited);
+    Expect(
+        unusable_rejected.status == TimelineIndexBuildStatus::InvalidArgument &&
+            MatchesSnapshot(count_limited, count_snapshot),
+        "unusable session result replaced the prior timeline index"
+    );
+
+    const TimelineIndexBuildResult mismatched_rejected =
+        BuildProfileTimelineIndex(_complete.session, _forensic.result, exact_counts, count_limited);
+    Expect(
+        mismatched_rejected.status == TimelineIndexBuildStatus::InvalidArgument &&
+            MatchesSnapshot(count_limited, count_snapshot),
+        "load result from a different session was accepted by the index builder"
+    );
+
+    std::stop_source stop_source;
+    stop_source.request_stop();
+    const TimelineIndexBuildControl cancelled_control{
+        .stop_token                  = stop_source.get_token(),
+        .cancellation_check_interval = 1,
+    };
+    const TimelineIndexBuildResult cancelled = BuildProfileTimelineIndex(
+        _complete.session, _complete.result, exact_counts, count_limited, cancelled_control
+    );
+    Expect(
+        cancelled.status == TimelineIndexBuildStatus::Cancelled &&
+            MatchesSnapshot(count_limited, count_snapshot),
+        "cancelled timeline build replaced the prior usable index"
+    );
+
+    std::stop_source                passive_stop_source;
+    const TimelineIndexBuildControl zero_interval_control{
+        .stop_token                  = passive_stop_source.get_token(),
+        .cancellation_check_interval = 0,
+    };
+    ProfileTimelineIndex zero_interval_index;
+    Expect(
+        BuildProfileTimelineIndex(
+            _complete.session, _complete.result, exact_counts, zero_interval_index, zero_interval_control
+        )
+            .Succeeded(),
+        "zero cancellation interval or a non-requested live stop token rejected a valid build"
+    );
+
+    const auto build_with_budget = [&](std::uint64_t _budget, ProfileTimelineIndex& _output) {
+        return BuildProfileTimelineIndex(
+            _complete.session,
+            _complete.result,
+            exact_counts,
+            _output,
+            TimelineIndexBuildControl{
+                .cancellation_check_interval  = 1,
+                .max_work_items_before_cancel = _budget,
+            }
+        );
+    };
+    std::uint64_t minimum_success_budget = 1;
+    for (;;) {
+        ProfileTimelineIndex           probe;
+        const TimelineIndexBuildResult probe_result = build_with_budget(minimum_success_budget, probe);
+        if (probe_result.Succeeded()) {
+            break;
+        }
+        Expect(
+            probe_result.status == TimelineIndexBuildStatus::Cancelled,
+            "cooperative work budget produced a non-cancellation failure"
+        );
+        Expect(
+            minimum_success_budget <= (std::uint64_t{1} << 20),
+            "cooperative cancellation checkpoint count exceeded the test bound"
+        );
+        minimum_success_budget *= 2;
+    }
+    std::uint64_t cancelled_budget = minimum_success_budget / 2;
+    while (cancelled_budget + 1 < minimum_success_budget) {
+        const std::uint64_t  middle = cancelled_budget + (minimum_success_budget - cancelled_budget) / 2;
+        ProfileTimelineIndex probe;
+        if (build_with_budget(middle, probe).Succeeded()) {
+            minimum_success_budget = middle;
+        } else {
+            cancelled_budget = middle;
+        }
+    }
+    const TimelineIndexBuildResult deep_cancelled = build_with_budget(cancelled_budget, count_limited);
+    Expect(
+        deep_cancelled.status == TimelineIndexBuildStatus::Cancelled &&
+            MatchesSnapshot(count_limited, count_snapshot),
+        "late cooperative cancellation replaced the prior usable index"
+    );
+    VerifyCpuQueries(count_limited, _complete.session);
+    VerifyGpuDomainsAndSlices(count_limited, _complete.session);
+
+    ProfileTimelineIndex moved = std::move(exact_index);
+    Expect(
+        moved.Valid() && moved.Matches(_complete.session) && !exact_index.Valid(),
+        "timeline index move invalidated its retained source indices"
+    );
+    ProfileSession moved_session = std::move(_complete.session);
+    Expect(
+        moved.Matches(moved_session) && !moved.Matches(_complete.session),
+        "timeline index identity did not survive a ProfileSession move"
+    );
+}
+
+void VerifyEmptySession(const LoadedTimeline& _empty) {
+    ProfileTimelineIndex           index;
+    const TimelineIndexBuildResult built =
+        BuildProfileTimelineIndex(_empty.session, _empty.result, {}, index);
+    Expect(
+        built.Succeeded() && index.Valid() && index.Matches(_empty.session) && index.Axes().size() == 1 &&
+            index.Axes().front().kind == TimelineAxisKind::CpuSteadyClock &&
+            !index.Axes().front().timing_available && !index.Axes().front().timing_capability_trusted &&
+            index.CpuTracks().empty() && index.CpuScopes().empty() && index.GpuFrames().empty() &&
+            index.GpuTracks().empty() && index.GpuFrameSlices().empty() && index.GpuAxisFrames().empty() &&
+            index.GpuTimelineScopes().empty() &&
+            index.BuildResult().logical_bytes == ExpectedLogicalBytes(index) && index.Quality().Clean(),
+        "empty profile session did not produce a valid empty timeline index"
+    );
+
+    std::array<std::uint64_t, 1> output{};
+    Expect(
+        !index.QueryCpuOverlaps(0, 0, 1, output).valid && index.FindGpuFrame(0) == nullptr &&
+            index.FindGpuFrameSlice(0, 0) == nullptr && index.FindGpuAxisFrame(0, 0) == nullptr &&
+            !index.QueryGpuOverlaps(0, 0, 0, 1, output).valid,
+        "empty timeline index exposed invented CPU or GPU entries"
+    );
+
+    ProfileTimelineIndex invalid;
+    Expect(
+        !invalid.Valid() && invalid.BuildResult().status == TimelineIndexBuildStatus::InvalidArgument &&
+            invalid.Axes().empty() && invalid.CpuTracks().empty() && invalid.CpuScopes().empty() &&
+            invalid.GpuFrames().empty() && invalid.GpuTracks().empty() && invalid.GpuFrameSlices().empty() &&
+            invalid.GpuAxisFrames().empty() && invalid.GpuTimelineScopes().empty() &&
+            !invalid.QueryCpuOverlaps(0, 0, 1, output).valid && invalid.FindGpuFrame(0) == nullptr &&
+            invalid.FindGpuFrameSlice(0, 0) == nullptr && invalid.FindGpuAxisFrame(0, 0) == nullptr &&
+            !invalid.QueryGpuOverlaps(0, 0, 0, 1, output).valid,
+        "default timeline index did not remain safely invalid"
+    );
+}
+
+} // namespace
+
+int main(int _argc, char** _argv) {
+    try {
+        if (_argc == 2) {
+            const LoadedTimeline external = LoadComplete(std::filesystem::path(_argv[1]));
+            ProfileTimelineIndex external_index;
+            Expect(
+                BuildProfileTimelineIndex(external.session, external.result, {}, external_index).Succeeded(),
+                "external capture timeline index did not build"
+            );
+            VerifyPublicRangeIntegrity(external_index, external.session);
+            std::cout << "ProfileTimelineIndex external capture passed (cpu_scopes="
+                      << external_index.CpuScopes().size()
+                      << ", gpu_frames=" << external_index.GpuFrames().size()
+                      << ", gpu_slices=" << external_index.GpuFrameSlices().size()
+                      << ", logical_bytes=" << external_index.BuildResult().logical_bytes << ")\n";
+            return 0;
+        }
+        Expect(_argc == 1, "usage: TestProfileTimelineIndex [capture.mpd]");
+
+        ScopedTimelineCapture capture;
+        WriteTimelineCapture(capture.Path());
+        LoadedTimeline       complete = LoadComplete(capture.Path());
+        const LoadedTimeline forensic = LoadForensicPrefix(capture.Path());
+
+        ProfileTimelineIndex index;
+        Expect(
+            BuildProfileTimelineIndex(complete.session, complete.result, {}, index).Succeeded(),
+            "timeline index fixture did not build"
+        );
+        VerifyCpuQueries(index, complete.session);
+        VerifyGpuDomainsAndSlices(index, complete.session);
+        VerifyPublicRangeIntegrity(index, complete.session);
+        VerifyQualityAndAtomicLimits(complete, forensic);
+
+        ScopedTimelineCapture empty_capture;
+        WriteEmptyCapture(empty_capture.Path());
+        const LoadedTimeline empty = LoadComplete(empty_capture.Path());
+        VerifyEmptySession(empty);
+    } catch (const std::exception& error) {
+        std::cerr << "ProfileTimelineIndex contract failed: " << error.what() << '\n';
+        return 1;
+    }
+
+    std::cout << "ProfileTimelineIndex contract passed\n";
+    return 0;
+}

--- a/source/tool/profile_consumer/include/profile_consumer/ProfileTimelineIndex.h
+++ b/source/tool/profile_consumer/include/profile_consumer/ProfileTimelineIndex.h
@@ -1,0 +1,308 @@
+#ifndef MOER_ENGINE_PROFILE_TIMELINE_INDEX_H
+#define MOER_ENGINE_PROFILE_TIMELINE_INDEX_H
+
+#include "profile_consumer/ProfileSession.h"
+
+#include <cstdint>
+#include <limits>
+#include <span>
+#include <stop_token>
+
+namespace Moer::ProfileDump {
+
+inline constexpr std::uint32_t kInvalidTimelineAxis = std::numeric_limits<std::uint32_t>::max();
+
+enum class TimelineAxisKind : std::uint8_t {
+    CpuSteadyClock = 0,
+    GpuPhysicalTimestampDomain,
+};
+
+enum class TimelineIndexBuildStatus : std::uint8_t {
+    Ready = 0,
+    InvalidArgument,
+    LimitExceeded,
+    ProtocolViolation,
+    ResourceExhausted,
+    Cancelled,
+};
+
+enum class TimelineIndexLimitKind : std::uint8_t {
+    None = 0,
+    CpuScopes,
+    GpuFrameSlices,
+    GpuTimelineScopes,
+    LogicalBytes,
+    TransientBuildBytes,
+};
+
+enum class TimelineQualityFlag : std::uint32_t {
+    ForensicTruncated   = std::uint32_t{1} << 0,
+    LostRecords         = std::uint32_t{1} << 1,
+    UnnotifiedDrops     = std::uint32_t{1} << 2,
+    CpuOrphans          = std::uint32_t{1} << 3,
+    GpuOrphans          = std::uint32_t{1} << 4,
+    DegradedGpuFrames   = std::uint32_t{1} << 5,
+    IncompleteGpuFrames = std::uint32_t{1} << 6,
+    InvalidGpuFrames    = std::uint32_t{1} << 7,
+    GpuScopeErrors      = std::uint32_t{1} << 8,
+    UntrustedGpuTiming  = std::uint32_t{1} << 9,
+    UnknownRecords      = std::uint32_t{1} << 10,
+};
+
+[[nodiscard]] inline constexpr std::uint32_t TimelineQualityBit(TimelineQualityFlag _flag) noexcept {
+    return static_cast<std::uint32_t>(_flag);
+}
+
+struct TimelineIndexLimits {
+    std::uint64_t max_cpu_scopes{4'000'000};
+    std::uint64_t max_gpu_frame_slices{4'000'000};
+    std::uint64_t max_gpu_timeline_scopes{4'000'000};
+    // Retained index payload only. ProfileSession storage and transient build
+    // allocations have their own independent limits.
+    std::uint64_t max_logical_bytes{512ull * 1024 * 1024};
+    // Conservative peak for temporary GPU planning and cancellable sort
+    // workspaces. It excludes the immutable ProfileSession and retained index.
+    std::uint64_t max_transient_build_bytes{512ull * 1024 * 1024};
+};
+
+struct TimelineIndexBuildResult {
+    TimelineIndexBuildStatus status{TimelineIndexBuildStatus::InvalidArgument};
+    TimelineIndexLimitKind   limit_kind{TimelineIndexLimitKind::None};
+    std::uint64_t            logical_bytes{0};
+
+    [[nodiscard]] bool Succeeded() const noexcept {
+        return status == TimelineIndexBuildStatus::Ready;
+    }
+
+    friend bool operator==(const TimelineIndexBuildResult&, const TimelineIndexBuildResult&) = default;
+};
+
+struct TimelineIndexBuildControl {
+    std::stop_token stop_token{};
+    // Linear build loops sample cancellation at this interval. Potentially
+    // large sorts are split into bounded runs no larger than this interval
+    // (and an internal responsiveness cap), with cancellable merge passes.
+    // Allocator and standard-library work inside one bounded run cannot be
+    // interrupted. Zero is normalized to one.
+    std::uint64_t cancellation_check_interval{4096};
+    // Optional deterministic cooperative budget. Exhaustion is reported as
+    // Cancelled and follows the same atomic-output contract as stop_token.
+    // This can cap background work even when the caller has no timer thread.
+    std::uint64_t max_work_items_before_cancel{std::numeric_limits<std::uint64_t>::max()};
+};
+
+// CPU and every physical GPU timestamp domain are separate axes. ProfileDump
+// v3 contains no CPU/GPU or cross-GPU-domain calibration, so consumers must
+// never align distinct axis indices as if their zero points were comparable.
+struct TimelineAxis {
+    TimelineAxisKind kind{TimelineAxisKind::CpuSteadyClock};
+    std::uint32_t    source_domain_index{kInvalidTimelineAxis};
+    std::uint32_t    native_queue_id{0};
+    std::uint32_t    family_id{0};
+    std::uint32_t    logical_queue_mask{0};
+    std::uint32_t    valid_bits{0};
+    double           unit_period_ns{1.0};
+    bool             timing_available{false};
+    // This describes the physical domain's timestamp capability, not the
+    // topology trust of any particular frame.
+    bool timing_capability_trusted{false};
+    bool calibrated_to_cpu{false};
+    bool calibrated_to_other_gpu_domains{false};
+
+    friend bool operator==(const TimelineAxis&, const TimelineAxis&) = default;
+};
+
+struct CpuTimelineScopeRef {
+    std::uint64_t source_scope_index{kInvalidSessionIndex};
+    // Relative to ProfileSessionSummary::cpu_begin_ns. Integer subtraction is
+    // performed before presentation converts values to floating point.
+    std::uint64_t begin_ns{0};
+    std::uint64_t end_ns{0};
+
+    friend bool operator==(const CpuTimelineScopeRef&, const CpuTimelineScopeRef&) = default;
+};
+
+struct CpuTimelineTrackIndex {
+    std::uint32_t source_track_index{0};
+    std::uint32_t axis_index{0};
+    std::uint64_t first_scope{0};
+    std::uint64_t scope_count{0};
+    std::uint64_t begin_ns{0};
+    std::uint64_t end_ns{0};
+    std::uint32_t max_depth{0};
+
+    friend bool operator==(const CpuTimelineTrackIndex&, const CpuTimelineTrackIndex&) = default;
+};
+
+struct GpuTimelineFrameRef {
+    std::uint64_t frame_id{0};
+    std::uint64_t source_frame_index{kInvalidSessionIndex};
+
+    friend bool operator==(const GpuTimelineFrameRef&, const GpuTimelineFrameRef&) = default;
+};
+
+// One frame-local presentation domain for a physical GPU timestamp axis.
+// Offsets from distinct axis-frame records are intentionally incomparable,
+// including two frames on the same physical axis.
+struct GpuTimelineAxisFrame {
+    std::uint64_t         frame_id{0};
+    std::uint64_t         source_frame_index{kInvalidSessionIndex};
+    std::uint32_t         axis_index{kInvalidTimelineAxis};
+    std::uint64_t         origin_tick{0};
+    std::uint64_t         extent_ticks{0};
+    std::uint64_t         ready_scope_count{0};
+    std::uint64_t         error_scope_count{0};
+    ProfileGpuFrameStatus frame_status{ProfileGpuFrameStatus::Invalid};
+    bool                  has_frame_record{false};
+    bool                  timing_available{false};
+    bool                  timing_capability_trusted{false};
+    bool                  materialization_complete{false};
+    bool                  timing_topology_trusted{false};
+
+    friend bool operator==(const GpuTimelineAxisFrame&, const GpuTimelineAxisFrame&) = default;
+};
+
+struct GpuTimelineScopeRef {
+    std::uint64_t source_scope_index{kInvalidSessionIndex};
+    // Integer offsets from GpuTimelineAxisFrame::origin_tick. Multiply only
+    // after subtraction by TimelineAxis::unit_period_ns for presentation.
+    std::uint64_t begin_tick_offset{0};
+    std::uint64_t end_tick_offset{0};
+
+    friend bool operator==(const GpuTimelineScopeRef&, const GpuTimelineScopeRef&) = default;
+};
+
+struct GpuTimelineFrameSlice {
+    std::uint64_t         frame_id{0};
+    std::uint64_t         source_frame_index{kInvalidSessionIndex};
+    std::uint64_t         axis_frame_index{kInvalidSessionIndex};
+    std::uint64_t         first_scope{0};
+    std::uint64_t         scope_count{0};
+    std::uint64_t         first_timeline_scope{0};
+    std::uint64_t         timeline_scope_count{0};
+    std::uint64_t         error_scope_count{0};
+    ProfileGpuFrameStatus frame_status{ProfileGpuFrameStatus::Invalid};
+    bool                  has_frame_record{false};
+    bool                  materialization_complete{false};
+    bool                  timing_topology_trusted{false};
+
+    friend bool operator==(const GpuTimelineFrameSlice&, const GpuTimelineFrameSlice&) = default;
+};
+
+struct GpuTimelineTrackIndex {
+    std::uint32_t source_track_index{0};
+    std::uint32_t axis_index{kInvalidTimelineAxis};
+    std::uint64_t first_frame_slice{0};
+    std::uint64_t frame_slice_count{0};
+
+    friend bool operator==(const GpuTimelineTrackIndex&, const GpuTimelineTrackIndex&) = default;
+};
+
+struct ProfileTimelineQuality {
+    std::uint32_t flags{0};
+    std::uint64_t lost_record_count{0};
+    std::uint64_t unnotified_drop_count{0};
+    std::uint64_t orphan_cpu_scope_count{0};
+    std::uint64_t orphan_gpu_scope_count{0};
+    std::uint64_t degraded_complete_gpu_frame_count{0};
+    std::uint64_t incomplete_gpu_frame_count{0};
+    std::uint64_t invalid_gpu_frame_count{0};
+    std::uint64_t error_gpu_scope_count{0};
+    std::uint64_t untrusted_gpu_frame_count{0};
+    std::uint64_t unknown_record_count{0};
+
+    [[nodiscard]] bool Has(TimelineQualityFlag _flag) const noexcept {
+        return (flags & TimelineQualityBit(_flag)) != 0;
+    }
+
+    [[nodiscard]] bool Clean() const noexcept {
+        return flags == 0;
+    }
+
+    friend bool operator==(const ProfileTimelineQuality&, const ProfileTimelineQuality&) = default;
+};
+
+struct TimelineOverlapQueryResult {
+    std::uint64_t written{0};
+    bool          truncated{false};
+    bool          valid{false};
+};
+
+class ProfileTimelineIndex final {
+public:
+    ProfileTimelineIndex() noexcept = default;
+    ~ProfileTimelineIndex();
+
+    ProfileTimelineIndex(const ProfileTimelineIndex&)            = delete;
+    ProfileTimelineIndex& operator=(const ProfileTimelineIndex&) = delete;
+    ProfileTimelineIndex(ProfileTimelineIndex&& _other) noexcept;
+    ProfileTimelineIndex& operator=(ProfileTimelineIndex&& _other) noexcept;
+
+    // The index stores source indices rather than owning session strings or
+    // records. Keep the exact immutable ProfileSession alive while using it.
+    [[nodiscard]] bool Valid() const noexcept;
+    // Tests exact immutable-model identity and remains true if the owning
+    // ProfileSession object is moved (its model allocation stays stable).
+    [[nodiscard]] bool                            Matches(const ProfileSession& _session) const noexcept;
+    [[nodiscard]] const TimelineIndexBuildResult& BuildResult() const noexcept;
+    [[nodiscard]] const ProfileTimelineQuality&   Quality() const noexcept;
+
+    [[nodiscard]] std::span<const TimelineAxis>          Axes() const noexcept;
+    [[nodiscard]] std::span<const CpuTimelineTrackIndex> CpuTracks() const noexcept;
+    [[nodiscard]] std::span<const CpuTimelineScopeRef>   CpuScopes() const noexcept;
+    [[nodiscard]] std::span<const GpuTimelineFrameRef>   GpuFrames() const noexcept;
+    [[nodiscard]] std::span<const GpuTimelineTrackIndex> GpuTracks() const noexcept;
+    [[nodiscard]] std::span<const GpuTimelineFrameSlice> GpuFrameSlices() const noexcept;
+    [[nodiscard]] std::span<const GpuTimelineAxisFrame>  GpuAxisFrames() const noexcept;
+    [[nodiscard]] std::span<const GpuTimelineScopeRef>   GpuTimelineScopes() const noexcept;
+
+    // Returns source CpuScope indices in deterministic begin-time order.
+    // The query is output-bounded: it stops after finding the first match that
+    // does not fit in _output and reports truncated instead of scanning the
+    // remainder of a very large visible range.
+    [[nodiscard]] TimelineOverlapQueryResult QueryCpuOverlaps(
+        std::uint32_t            _track_index,
+        std::uint64_t            _view_begin_ns,
+        std::uint64_t            _view_end_ns,
+        std::span<std::uint64_t> _output
+    ) const noexcept;
+
+    [[nodiscard]] const GpuTimelineFrameRef* FindGpuFrame(std::uint64_t _frame_id) const noexcept;
+    [[nodiscard]] const GpuTimelineFrameSlice*
+    FindGpuFrameSlice(std::uint32_t _track_index, std::uint64_t _frame_id) const noexcept;
+    [[nodiscard]] const GpuTimelineAxisFrame*
+    FindGpuAxisFrame(std::uint32_t _axis_index, std::uint64_t _frame_id) const noexcept;
+
+    // Returns ready source GpuScope indices in frame-local tick-offset order.
+    // Error scopes remain discoverable through the source frame slice but do
+    // not participate in a timing query.
+    [[nodiscard]] TimelineOverlapQueryResult QueryGpuOverlaps(
+        std::uint32_t            _track_index,
+        std::uint64_t            _frame_id,
+        std::uint64_t            _view_begin_ticks,
+        std::uint64_t            _view_end_ticks,
+        std::span<std::uint64_t> _output
+    ) const noexcept;
+
+private:
+    struct Impl;
+    Impl* impl_{nullptr};
+
+    friend TimelineIndexBuildResult
+    BuildProfileTimelineIndex(const ProfileSession&, const SessionLoadResult&, const TimelineIndexLimits&, ProfileTimelineIndex&, const TimelineIndexBuildControl&) noexcept;
+};
+
+// _session and _load_result must be the paired outputs of the same load.
+// _output is move-replaced only after a complete, bounded index has been
+// constructed. A failed rebuild leaves the previous usable index untouched.
+[[nodiscard]] TimelineIndexBuildResult BuildProfileTimelineIndex(
+    const ProfileSession&            _session,
+    const SessionLoadResult&         _load_result,
+    const TimelineIndexLimits&       _limits,
+    ProfileTimelineIndex&            _output,
+    const TimelineIndexBuildControl& _control = {}
+) noexcept;
+
+} // namespace Moer::ProfileDump
+
+#endif // MOER_ENGINE_PROFILE_TIMELINE_INDEX_H

--- a/source/tool/profile_consumer/source/ProfileTimelineIndex.cpp
+++ b/source/tool/profile_consumer/source/ProfileTimelineIndex.cpp
@@ -1,0 +1,1600 @@
+#include "profile_consumer/ProfileTimelineIndex.h"
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <cstddef>
+#include <limits>
+#include <new>
+#include <tuple>
+#include <utility>
+#include <vector>
+
+namespace Moer::ProfileDump {
+namespace {
+
+struct TimelineIntervalTree {
+    std::uint64_t tree_offset{0};
+    std::uint64_t leaf_count{0};
+};
+
+struct GpuFrameSlicePlan {
+    std::uint32_t track_index{0};
+    std::uint32_t domain_index{0};
+    std::uint64_t frame_id{0};
+    std::uint64_t source_frame_index{kInvalidSessionIndex};
+    std::uint64_t first_scope{0};
+    std::uint64_t scope_count{0};
+    std::uint64_t ready_scope_count{0};
+    std::uint64_t error_scope_count{0};
+    std::uint64_t axis_frame_index{kInvalidSessionIndex};
+    std::uint64_t tree_offset{0};
+    std::uint64_t tree_leaf_count{0};
+};
+
+struct GpuAxisFramePlan {
+    std::uint32_t         domain_index{0};
+    std::uint64_t         frame_id{0};
+    std::uint64_t         source_frame_index{kInvalidSessionIndex};
+    std::uint64_t         origin_tick{0};
+    std::uint64_t         extent_ticks{0};
+    std::uint64_t         ready_scope_count{0};
+    std::uint64_t         error_scope_count{0};
+    ProfileGpuFrameStatus frame_status{ProfileGpuFrameStatus::Invalid};
+    bool                  has_frame_record{false};
+    bool                  timing_available{false};
+    bool                  materialization_complete{false};
+    bool                  timing_topology_trusted{false};
+};
+
+struct GpuBuildPlan {
+    std::vector<GpuFrameSlicePlan> slices{};
+    std::vector<GpuAxisFramePlan>  axis_frames{};
+    std::vector<std::uint64_t>     track_first_slice{};
+    std::vector<std::uint64_t>     track_slice_count{};
+    std::uint64_t                  timeline_scope_count{0};
+    std::uint64_t                  tree_value_count{0};
+};
+
+class CancellationProbe final {
+public:
+    explicit CancellationProbe(const TimelineIndexBuildControl& _control) noexcept :
+        control_(_control),
+        interval_(std::max<std::uint64_t>(std::uint64_t{1}, _control.cancellation_check_interval)),
+        remaining_budget_(_control.max_work_items_before_cancel) {}
+
+    [[nodiscard]] bool Requested(std::uint64_t _work_items = 1) noexcept {
+        if (_work_items >= remaining_budget_) {
+            remaining_budget_ = 0;
+            return true;
+        }
+        remaining_budget_ -= _work_items;
+        if (!control_.stop_token.stop_possible()) {
+            return false;
+        }
+        if (_work_items >= interval_ - pending_work_) {
+            pending_work_ = 0;
+            return control_.stop_token.stop_requested();
+        }
+        pending_work_ += _work_items;
+        return false;
+    }
+
+    [[nodiscard]] bool RequestedNow() const noexcept {
+        return remaining_budget_ == 0 || control_.stop_token.stop_requested();
+    }
+
+    [[nodiscard]] std::size_t SortRunSize() const noexcept {
+        constexpr std::uint64_t kMaximumSortRunSize = 4096;
+        return static_cast<std::size_t>(std::min(interval_, kMaximumSortRunSize));
+    }
+
+private:
+    const TimelineIndexBuildControl& control_;
+    std::uint64_t                    interval_{1};
+    std::uint64_t                    pending_work_{0};
+    std::uint64_t                    remaining_budget_{std::numeric_limits<std::uint64_t>::max()};
+};
+
+[[nodiscard]] bool MarkCancelled(
+    CancellationProbe&        _cancellation,
+    TimelineIndexBuildResult& _result,
+    std::uint64_t             _work_items = 1
+) noexcept;
+
+[[nodiscard]] bool
+MarkCancelledNow(const CancellationProbe& _cancellation, TimelineIndexBuildResult& _result) noexcept;
+
+template<typename T, typename Compare>
+[[nodiscard]] bool CancellableSort(
+    std::vector<T>&           _values,
+    std::size_t               _first,
+    std::size_t               _count,
+    Compare                   _compare,
+    CancellationProbe&        _cancellation,
+    TimelineIndexBuildResult& _result
+) {
+    if (_first > _values.size() || _count > _values.size() - _first) {
+        _result.status = TimelineIndexBuildStatus::ProtocolViolation;
+        return false;
+    }
+    if (_count < 2) {
+        return !MarkCancelledNow(_cancellation, _result);
+    }
+
+    const std::size_t run_size = std::min(_count, _cancellation.SortRunSize());
+    for (std::size_t run_begin = 0; run_begin < _count;) {
+        const std::size_t run_count = std::min(run_size, _count - run_begin);
+        if (MarkCancelled(_cancellation, _result, run_count)) {
+            return false;
+        }
+        const auto begin = _values.begin() + static_cast<std::ptrdiff_t>(_first + run_begin);
+        std::sort(begin, begin + static_cast<std::ptrdiff_t>(run_count), _compare);
+        run_begin += run_count;
+    }
+
+    if (MarkCancelledNow(_cancellation, _result) || run_size == _count) {
+        return _result.status != TimelineIndexBuildStatus::Cancelled;
+    }
+    std::vector<T> scratch;
+    scratch.reserve(_count);
+    for (std::size_t width = run_size; width < _count;) {
+        scratch.clear();
+        std::size_t block_begin = 0;
+        while (block_begin < _count) {
+            const std::size_t middle    = block_begin + std::min(width, _count - block_begin);
+            const std::size_t block_end = middle + std::min(width, _count - middle);
+            std::size_t       left      = block_begin;
+            std::size_t       right     = middle;
+            while (left < middle || right < block_end) {
+                if (MarkCancelled(_cancellation, _result)) {
+                    return false;
+                }
+                if (right == block_end ||
+                    (left < middle && !_compare(_values[_first + right], _values[_first + left]))) {
+                    scratch.push_back(_values[_first + left]);
+                    ++left;
+                } else {
+                    scratch.push_back(_values[_first + right]);
+                    ++right;
+                }
+            }
+            block_begin = block_end;
+        }
+        if (scratch.size() != _count) {
+            _result.status = TimelineIndexBuildStatus::ProtocolViolation;
+            return false;
+        }
+        for (std::size_t index = 0; index < _count; ++index) {
+            if (MarkCancelled(_cancellation, _result)) {
+                return false;
+            }
+            _values[_first + index] = std::move(scratch[index]);
+        }
+        width = width > _count - width ? _count : width * 2;
+    }
+    return !MarkCancelledNow(_cancellation, _result);
+}
+
+[[nodiscard]] bool AddOverflow(std::uint64_t _left, std::uint64_t _right, std::uint64_t& _result) noexcept {
+    if (_right > std::numeric_limits<std::uint64_t>::max() - _left) {
+        return true;
+    }
+    _result = _left + _right;
+    return false;
+}
+
+[[nodiscard]] bool
+MultiplyOverflow(std::uint64_t _left, std::uint64_t _right, std::uint64_t& _result) noexcept {
+    if (_left != 0 && _right > std::numeric_limits<std::uint64_t>::max() / _left) {
+        return true;
+    }
+    _result = _left * _right;
+    return false;
+}
+
+[[nodiscard]] bool NextPowerOfTwo(std::uint64_t _value, std::uint64_t& _result) noexcept {
+    if (_value == 0) {
+        _result = 1;
+        return true;
+    }
+    std::uint64_t power = 1;
+    while (power < _value) {
+        if (power > std::numeric_limits<std::uint64_t>::max() / 2) {
+            return false;
+        }
+        power *= 2;
+    }
+    _result = power;
+    return true;
+}
+
+[[nodiscard]] std::uint64_t TimestampMask(std::uint32_t _valid_bits) noexcept {
+    return _valid_bits == 64 ? std::numeric_limits<std::uint64_t>::max() :
+                               (std::uint64_t{1} << _valid_bits) - 1;
+}
+
+[[nodiscard]] std::uint64_t
+TimestampDelta(std::uint64_t _begin_tick, std::uint64_t _end_tick, std::uint32_t _valid_bits) noexcept {
+    return (_end_tick - _begin_tick) & TimestampMask(_valid_bits);
+}
+
+[[nodiscard]] bool NearlyEqual(double _left, double _right) noexcept {
+    if (!std::isfinite(_left) || !std::isfinite(_right)) {
+        return false;
+    }
+    const double tolerance = std::max(1.0e-6, std::max(std::abs(_left), std::abs(_right)) * 1.0e-9);
+    return std::abs(_left - _right) <= tolerance;
+}
+
+[[nodiscard]] std::uint64_t QueryEnd(const CpuTimelineScopeRef& _scope) noexcept {
+    if (_scope.end_ns > _scope.begin_ns) {
+        return _scope.end_ns;
+    }
+    return _scope.begin_ns == std::numeric_limits<std::uint64_t>::max() ? _scope.begin_ns :
+                                                                          _scope.begin_ns + 1;
+}
+
+[[nodiscard]] std::uint64_t QueryEnd(const GpuTimelineScopeRef& _scope) noexcept {
+    if (_scope.end_tick_offset > _scope.begin_tick_offset) {
+        return _scope.end_tick_offset;
+    }
+    return _scope.begin_tick_offset == std::numeric_limits<std::uint64_t>::max() ?
+               _scope.begin_tick_offset :
+               _scope.begin_tick_offset + 1;
+}
+
+[[nodiscard]] bool
+Overlaps(const CpuTimelineScopeRef& _scope, std::uint64_t _view_begin, std::uint64_t _view_end) noexcept {
+    if (_scope.end_ns > _scope.begin_ns) {
+        return _scope.end_ns > _view_begin && _scope.begin_ns < _view_end;
+    }
+    return _scope.begin_ns >= _view_begin && _scope.begin_ns < _view_end;
+}
+
+[[nodiscard]] bool
+Overlaps(const GpuTimelineScopeRef& _scope, std::uint64_t _view_begin, std::uint64_t _view_end) noexcept {
+    if (_scope.end_tick_offset > _scope.begin_tick_offset) {
+        return _scope.end_tick_offset > _view_begin && _scope.begin_tick_offset < _view_end;
+    }
+    return _scope.begin_tick_offset >= _view_begin && _scope.begin_tick_offset < _view_end;
+}
+
+void AddQualityFlag(ProfileTimelineQuality& _quality, TimelineQualityFlag _flag) noexcept {
+    _quality.flags |= TimelineQualityBit(_flag);
+}
+
+[[nodiscard]] bool MarkCancelled(
+    CancellationProbe&        _cancellation,
+    TimelineIndexBuildResult& _result,
+    std::uint64_t             _work_items
+) noexcept {
+    if (!_cancellation.Requested(_work_items)) {
+        return false;
+    }
+    _result.status = TimelineIndexBuildStatus::Cancelled;
+    return true;
+}
+
+[[nodiscard]] bool
+MarkCancelledNow(const CancellationProbe& _cancellation, TimelineIndexBuildResult& _result) noexcept {
+    if (!_cancellation.RequestedNow()) {
+        return false;
+    }
+    _result.status = TimelineIndexBuildStatus::Cancelled;
+    return true;
+}
+
+[[nodiscard]] bool ComputeGpuOffsets(
+    const GpuScopeRecord&     _scope,
+    const GpuTimestampDomain& _domain,
+    const GpuAxisFramePlan&   _axis_frame,
+    std::uint64_t&            _begin_offset,
+    std::uint64_t&            _end_offset
+) noexcept {
+    const std::uint64_t mask     = TimestampMask(_domain.valid_bits);
+    _begin_offset                = (_scope.begin_tick - _axis_frame.origin_tick) & mask;
+    const std::uint64_t duration = TimestampDelta(_scope.begin_tick, _scope.end_tick, _domain.valid_bits);
+    if (_begin_offset > _axis_frame.extent_ticks || duration > _axis_frame.extent_ticks - _begin_offset) {
+        return false;
+    }
+    _end_offset = _begin_offset + duration;
+    return true;
+}
+
+[[nodiscard]] bool PrepareGpuBuildPlan(
+    std::span<const GpuFrameRecord>     _gpu_frames,
+    std::span<const GpuScopeRecord>     _gpu_scopes,
+    std::span<const GpuTrack>           _gpu_tracks,
+    std::span<const GpuTimestampDomain> _gpu_domains,
+    const TimelineIndexLimits&          _limits,
+    CancellationProbe&                  _cancellation,
+    TimelineIndexBuildResult&           _result,
+    GpuBuildPlan&                       _plan
+) {
+    std::uint64_t planned_slice_count = 0;
+    std::uint64_t ready_scope_count   = 0;
+    for (std::size_t track_index = 0; track_index < _gpu_tracks.size(); ++track_index) {
+        if (MarkCancelled(_cancellation, _result)) {
+            return false;
+        }
+        const GpuTrack& track = _gpu_tracks[track_index];
+        if (track.domain_index >= _gpu_domains.size() || track.first_scope > _gpu_scopes.size() ||
+            track.scope_count > _gpu_scopes.size() - track.first_scope) {
+            _result.status = TimelineIndexBuildStatus::ProtocolViolation;
+            return false;
+        }
+
+        const std::size_t source_begin         = static_cast<std::size_t>(track.first_scope);
+        const std::size_t source_end           = source_begin + static_cast<std::size_t>(track.scope_count);
+        bool              has_frame            = false;
+        std::uint64_t     previous_frame_id    = 0;
+        std::uint64_t     previous_frame_index = kInvalidSessionIndex;
+        for (std::size_t scope_index = source_begin; scope_index < source_end; ++scope_index) {
+            if (MarkCancelled(_cancellation, _result)) {
+                return false;
+            }
+            const GpuScopeRecord& scope = _gpu_scopes[scope_index];
+            if (scope.track_index != track_index || scope.domain_index != track.domain_index) {
+                _result.status = TimelineIndexBuildStatus::ProtocolViolation;
+                return false;
+            }
+            if (scope.status == ProfileGpuScopeStatus::Ready &&
+                AddOverflow(ready_scope_count, std::uint64_t{1}, ready_scope_count)) {
+                _result.status = TimelineIndexBuildStatus::ResourceExhausted;
+                return false;
+            }
+            if (!has_frame || scope.frame_id != previous_frame_id) {
+                if (has_frame && previous_frame_id >= scope.frame_id) {
+                    _result.status = TimelineIndexBuildStatus::ProtocolViolation;
+                    return false;
+                }
+                if (planned_slice_count >= _limits.max_gpu_frame_slices) {
+                    _result.status     = TimelineIndexBuildStatus::LimitExceeded;
+                    _result.limit_kind = TimelineIndexLimitKind::GpuFrameSlices;
+                    return false;
+                }
+                ++planned_slice_count;
+                has_frame            = true;
+                previous_frame_id    = scope.frame_id;
+                previous_frame_index = scope.frame_index;
+                if (scope.frame_index != kInvalidSessionIndex &&
+                    (scope.frame_index >= _gpu_frames.size() ||
+                     _gpu_frames[scope.frame_index].frame_id != scope.frame_id)) {
+                    _result.status = TimelineIndexBuildStatus::ProtocolViolation;
+                    return false;
+                }
+            } else if (scope.frame_index != previous_frame_index) {
+                _result.status = TimelineIndexBuildStatus::ProtocolViolation;
+                return false;
+            }
+        }
+    }
+
+    const auto add_bytes = [](std::uint64_t& _total, std::uint64_t _count, std::uint64_t _size) {
+        std::uint64_t bytes = 0;
+        return !MultiplyOverflow(_count, _size, bytes) && !AddOverflow(_total, bytes, _total);
+    };
+    std::uint64_t initial_transient_bytes = 0;
+    if (!add_bytes(initial_transient_bytes, _gpu_tracks.size(), sizeof(std::uint64_t)) ||
+        !add_bytes(initial_transient_bytes, _gpu_tracks.size(), sizeof(std::uint64_t)) ||
+        !add_bytes(initial_transient_bytes, planned_slice_count, sizeof(GpuFrameSlicePlan)) ||
+        !add_bytes(initial_transient_bytes, planned_slice_count, sizeof(std::size_t)) ||
+        !add_bytes(initial_transient_bytes, planned_slice_count, sizeof(std::size_t))) {
+        _result.status = TimelineIndexBuildStatus::ResourceExhausted;
+        return false;
+    }
+    if (initial_transient_bytes > _limits.max_transient_build_bytes) {
+        _result.status     = TimelineIndexBuildStatus::LimitExceeded;
+        _result.limit_kind = TimelineIndexLimitKind::TransientBuildBytes;
+        return false;
+    }
+
+    _plan.track_first_slice.resize(_gpu_tracks.size(), 0);
+    _plan.track_slice_count.resize(_gpu_tracks.size(), 0);
+    _plan.slices.reserve(static_cast<std::size_t>(planned_slice_count));
+
+    for (std::size_t track_index = 0; track_index < _gpu_tracks.size(); ++track_index) {
+        if (MarkCancelled(_cancellation, _result)) {
+            return false;
+        }
+        const GpuTrack& track = _gpu_tracks[track_index];
+        if (track.domain_index >= _gpu_domains.size() || track.first_scope > _gpu_scopes.size() ||
+            track.scope_count > _gpu_scopes.size() - track.first_scope) {
+            _result.status = TimelineIndexBuildStatus::ProtocolViolation;
+            return false;
+        }
+
+        _plan.track_first_slice[track_index] = _plan.slices.size();
+        const std::size_t source_begin       = static_cast<std::size_t>(track.first_scope);
+        const std::size_t source_end         = source_begin + static_cast<std::size_t>(track.scope_count);
+        std::size_t       slice_begin        = source_begin;
+        while (slice_begin < source_end) {
+            if (MarkCancelled(_cancellation, _result)) {
+                return false;
+            }
+            std::size_t slice_end = slice_begin + 1;
+            while (slice_end < source_end &&
+                   _gpu_scopes[slice_end].frame_id == _gpu_scopes[slice_begin].frame_id) {
+                if (MarkCancelled(_cancellation, _result)) {
+                    return false;
+                }
+                ++slice_end;
+            }
+            if (slice_begin != source_begin &&
+                _gpu_scopes[slice_begin - 1].frame_id >= _gpu_scopes[slice_begin].frame_id) {
+                _result.status = TimelineIndexBuildStatus::ProtocolViolation;
+                return false;
+            }
+
+            const GpuScopeRecord& first = _gpu_scopes[slice_begin];
+            GpuFrameSlicePlan     slice{
+                    .track_index        = static_cast<std::uint32_t>(track_index),
+                    .domain_index       = track.domain_index,
+                    .frame_id           = first.frame_id,
+                    .source_frame_index = first.frame_index,
+                    .first_scope        = slice_begin,
+                    .scope_count        = slice_end - slice_begin,
+            };
+            for (std::size_t scope_index = slice_begin; scope_index < slice_end; ++scope_index) {
+                if (MarkCancelled(_cancellation, _result)) {
+                    return false;
+                }
+                const GpuScopeRecord& scope = _gpu_scopes[scope_index];
+                if (scope.track_index != track_index || scope.domain_index != track.domain_index ||
+                    scope.frame_id != slice.frame_id || scope.frame_index != slice.source_frame_index) {
+                    _result.status = TimelineIndexBuildStatus::ProtocolViolation;
+                    return false;
+                }
+                if (scope.status == ProfileGpuScopeStatus::Ready) {
+                    ++slice.ready_scope_count;
+                } else {
+                    ++slice.error_scope_count;
+                }
+            }
+            if (slice.source_frame_index != kInvalidSessionIndex) {
+                if (slice.source_frame_index >= _gpu_frames.size() ||
+                    _gpu_frames[slice.source_frame_index].frame_id != slice.frame_id) {
+                    _result.status = TimelineIndexBuildStatus::ProtocolViolation;
+                    return false;
+                }
+            }
+            if (_plan.slices.size() >= _limits.max_gpu_frame_slices) {
+                _result.status     = TimelineIndexBuildStatus::LimitExceeded;
+                _result.limit_kind = TimelineIndexLimitKind::GpuFrameSlices;
+                return false;
+            }
+            _plan.slices.push_back(slice);
+            slice_begin = slice_end;
+        }
+        _plan.track_slice_count[track_index] = _plan.slices.size() - _plan.track_first_slice[track_index];
+    }
+
+    if (MarkCancelled(_cancellation, _result)) {
+        return false;
+    }
+    std::vector<std::size_t> slice_order;
+    slice_order.reserve(_plan.slices.size());
+    for (std::size_t index = 0; index < _plan.slices.size(); ++index) {
+        if (MarkCancelled(_cancellation, _result)) {
+            return false;
+        }
+        slice_order.push_back(index);
+    }
+    if (!CancellableSort(
+            slice_order,
+            0,
+            slice_order.size(),
+            [&](std::size_t _left, std::size_t _right) {
+                const GpuFrameSlicePlan& left  = _plan.slices[_left];
+                const GpuFrameSlicePlan& right = _plan.slices[_right];
+                return std::tie(left.domain_index, left.frame_id, left.track_index) <
+                       std::tie(right.domain_index, right.frame_id, right.track_index);
+            },
+            _cancellation,
+            _result
+        )) {
+        return false;
+    }
+
+    std::uint64_t axis_frame_count = 0;
+    for (std::size_t index = 0; index < slice_order.size(); ++index) {
+        if (MarkCancelled(_cancellation, _result)) {
+            return false;
+        }
+        if (index == 0) {
+            axis_frame_count = 1;
+            continue;
+        }
+        const GpuFrameSlicePlan& previous = _plan.slices[slice_order[index - 1]];
+        const GpuFrameSlicePlan& current  = _plan.slices[slice_order[index]];
+        if (previous.domain_index != current.domain_index || previous.frame_id != current.frame_id) {
+            ++axis_frame_count;
+        }
+    }
+
+    std::uint64_t persistent_plan_bytes = 0;
+    std::uint64_t endpoint_peak_bytes   = 0;
+    std::uint64_t timeline_sort_bytes   = 0;
+    if (!add_bytes(persistent_plan_bytes, _gpu_tracks.size(), sizeof(std::uint64_t)) ||
+        !add_bytes(persistent_plan_bytes, _gpu_tracks.size(), sizeof(std::uint64_t)) ||
+        !add_bytes(persistent_plan_bytes, planned_slice_count, sizeof(GpuFrameSlicePlan)) ||
+        !add_bytes(persistent_plan_bytes, axis_frame_count, sizeof(GpuAxisFramePlan)) ||
+        !add_bytes(endpoint_peak_bytes, planned_slice_count, sizeof(std::size_t)) ||
+        !add_bytes(endpoint_peak_bytes, ready_scope_count, sizeof(std::uint64_t)) ||
+        !add_bytes(endpoint_peak_bytes, ready_scope_count, sizeof(std::uint64_t)) ||
+        !add_bytes(endpoint_peak_bytes, ready_scope_count, sizeof(std::uint64_t)) ||
+        !add_bytes(endpoint_peak_bytes, ready_scope_count, sizeof(std::uint64_t)) ||
+        !add_bytes(timeline_sort_bytes, ready_scope_count, sizeof(GpuTimelineScopeRef))) {
+        _result.status = TimelineIndexBuildStatus::ResourceExhausted;
+        return false;
+    }
+    std::uint64_t peak_transient_bytes = 0;
+    if (AddOverflow(
+            persistent_plan_bytes, std::max(endpoint_peak_bytes, timeline_sort_bytes), peak_transient_bytes
+        )) {
+        _result.status = TimelineIndexBuildStatus::ResourceExhausted;
+        return false;
+    }
+    if (peak_transient_bytes > _limits.max_transient_build_bytes) {
+        _result.status     = TimelineIndexBuildStatus::LimitExceeded;
+        _result.limit_kind = TimelineIndexLimitKind::TransientBuildBytes;
+        return false;
+    }
+    _plan.axis_frames.reserve(static_cast<std::size_t>(axis_frame_count));
+
+    std::vector<std::uint64_t> endpoints;
+    std::size_t                group_begin = 0;
+    while (group_begin < slice_order.size()) {
+        std::size_t              group_end   = group_begin + 1;
+        const GpuFrameSlicePlan& first_slice = _plan.slices[slice_order[group_begin]];
+        while (group_end < slice_order.size()) {
+            if (MarkCancelled(_cancellation, _result)) {
+                return false;
+            }
+            const GpuFrameSlicePlan& candidate = _plan.slices[slice_order[group_end]];
+            if (candidate.domain_index != first_slice.domain_index ||
+                candidate.frame_id != first_slice.frame_id) {
+                break;
+            }
+            ++group_end;
+        }
+
+        if (MarkCancelled(_cancellation, _result)) {
+            return false;
+        }
+        GpuAxisFramePlan axis_frame{
+            .domain_index       = first_slice.domain_index,
+            .frame_id           = first_slice.frame_id,
+            .source_frame_index = first_slice.source_frame_index,
+        };
+        if (axis_frame.source_frame_index != kInvalidSessionIndex) {
+            const GpuFrameRecord& frame         = _gpu_frames[axis_frame.source_frame_index];
+            axis_frame.frame_status             = frame.status;
+            axis_frame.has_frame_record         = true;
+            axis_frame.materialization_complete = frame.materialization_complete;
+            axis_frame.timing_topology_trusted  = frame.timing_topology_trusted;
+        }
+
+        endpoints.clear();
+        std::uint64_t group_ready_scope_count = 0;
+        for (std::size_t order_index = group_begin; order_index < group_end; ++order_index) {
+            if (MarkCancelled(_cancellation, _result) ||
+                AddOverflow(
+                    group_ready_scope_count,
+                    _plan.slices[slice_order[order_index]].ready_scope_count,
+                    group_ready_scope_count
+                )) {
+                if (_result.status != TimelineIndexBuildStatus::Cancelled) {
+                    _result.status = TimelineIndexBuildStatus::ResourceExhausted;
+                }
+                return false;
+            }
+        }
+        std::uint64_t endpoint_count = 0;
+        if (MultiplyOverflow(group_ready_scope_count, std::uint64_t{2}, endpoint_count) ||
+            endpoint_count > std::numeric_limits<std::size_t>::max()) {
+            _result.status = TimelineIndexBuildStatus::ResourceExhausted;
+            return false;
+        }
+        endpoints.reserve(static_cast<std::size_t>(endpoint_count));
+        bool                      timing_layout_valid = true;
+        const GpuTimestampDomain& domain              = _gpu_domains[axis_frame.domain_index];
+        for (std::size_t order_index = group_begin; order_index < group_end; ++order_index) {
+            GpuFrameSlicePlan& slice = _plan.slices[slice_order[order_index]];
+            if (slice.source_frame_index != axis_frame.source_frame_index) {
+                _result.status = TimelineIndexBuildStatus::ProtocolViolation;
+                return false;
+            }
+            axis_frame.ready_scope_count += slice.ready_scope_count;
+            axis_frame.error_scope_count += slice.error_scope_count;
+            for (std::uint64_t scope_offset = 0; scope_offset < slice.scope_count; ++scope_offset) {
+                if (MarkCancelled(_cancellation, _result)) {
+                    return false;
+                }
+                const GpuScopeRecord& scope = _gpu_scopes[slice.first_scope + scope_offset];
+                if (scope.status != ProfileGpuScopeStatus::Ready) {
+                    continue;
+                }
+                if (!domain.has_ready_timestamps || domain.valid_bits == 0 || domain.valid_bits > 64 ||
+                    scope.valid_bits != domain.valid_bits ||
+                    !NearlyEqual(scope.tick_period_ns, domain.tick_period_ns)) {
+                    timing_layout_valid = false;
+                    continue;
+                }
+                const std::uint64_t mask = TimestampMask(domain.valid_bits);
+                endpoints.push_back(scope.begin_tick & mask);
+                endpoints.push_back(scope.end_tick & mask);
+            }
+        }
+
+        if (timing_layout_valid && !endpoints.empty()) {
+            if (!CancellableSort(
+                    endpoints,
+                    0,
+                    endpoints.size(),
+                    [](std::uint64_t _left, std::uint64_t _right) {
+                        return _left < _right;
+                    },
+                    _cancellation,
+                    _result
+                )) {
+                return false;
+            }
+            std::size_t unique_count = 1;
+            for (std::size_t index = 1; index < endpoints.size(); ++index) {
+                if (MarkCancelled(_cancellation, _result)) {
+                    return false;
+                }
+                if (endpoints[index] != endpoints[unique_count - 1]) {
+                    endpoints[unique_count] = endpoints[index];
+                    ++unique_count;
+                }
+            }
+            endpoints.resize(unique_count);
+
+            if (endpoints.size() == 1) {
+                axis_frame.origin_tick  = endpoints.front();
+                axis_frame.extent_ticks = 0;
+            } else {
+                std::uint64_t largest_gap = 0;
+                std::uint64_t origin_tick = endpoints.front();
+                for (std::size_t index = 1; index < endpoints.size(); ++index) {
+                    if (MarkCancelled(_cancellation, _result)) {
+                        return false;
+                    }
+                    const std::uint64_t gap = endpoints[index] - endpoints[index - 1];
+                    if (gap > largest_gap) {
+                        largest_gap = gap;
+                        origin_tick = endpoints[index];
+                    }
+                }
+                const std::uint64_t wrap_gap =
+                    (endpoints.front() - endpoints.back()) & TimestampMask(domain.valid_bits);
+                if (wrap_gap > largest_gap) {
+                    largest_gap = wrap_gap;
+                    origin_tick = endpoints.front();
+                }
+                axis_frame.origin_tick = origin_tick;
+                if (domain.valid_bits == 64) {
+                    axis_frame.extent_ticks = std::uint64_t{0} - largest_gap;
+                } else {
+                    const std::uint64_t modulus = std::uint64_t{1} << domain.valid_bits;
+                    axis_frame.extent_ticks     = modulus - largest_gap;
+                }
+            }
+
+            const std::uint64_t half_range = domain.valid_bits == 64 ?
+                                                 (std::uint64_t{1} << 63) :
+                                                 (std::uint64_t{1} << (domain.valid_bits - 1));
+            timing_layout_valid            = axis_frame.extent_ticks < half_range;
+            if (timing_layout_valid) {
+                for (std::size_t order_index = group_begin; order_index < group_end && timing_layout_valid;
+                     ++order_index) {
+                    const GpuFrameSlicePlan& slice = _plan.slices[slice_order[order_index]];
+                    for (std::uint64_t scope_offset = 0; scope_offset < slice.scope_count; ++scope_offset) {
+                        if (MarkCancelled(_cancellation, _result)) {
+                            return false;
+                        }
+                        const GpuScopeRecord& scope = _gpu_scopes[slice.first_scope + scope_offset];
+                        if (scope.status != ProfileGpuScopeStatus::Ready) {
+                            continue;
+                        }
+                        std::uint64_t begin_offset = 0;
+                        std::uint64_t end_offset   = 0;
+                        timing_layout_valid =
+                            ComputeGpuOffsets(scope, domain, axis_frame, begin_offset, end_offset);
+                        if (!timing_layout_valid) {
+                            break;
+                        }
+                    }
+                }
+            }
+        } else {
+            timing_layout_valid = false;
+        }
+
+        axis_frame.timing_available          = timing_layout_valid && axis_frame.ready_scope_count != 0;
+        const std::uint64_t axis_frame_index = _plan.axis_frames.size();
+        for (std::size_t order_index = group_begin; order_index < group_end; ++order_index) {
+            if (MarkCancelled(_cancellation, _result)) {
+                return false;
+            }
+            GpuFrameSlicePlan& slice = _plan.slices[slice_order[order_index]];
+            slice.axis_frame_index   = axis_frame_index;
+            if (!axis_frame.timing_available) {
+                continue;
+            }
+            slice.tree_leaf_count = 0;
+            if (!NextPowerOfTwo(slice.ready_scope_count, slice.tree_leaf_count)) {
+                _result.status = TimelineIndexBuildStatus::ResourceExhausted;
+                return false;
+            }
+            std::uint64_t tree_values = 0;
+            if (MultiplyOverflow(slice.tree_leaf_count, std::uint64_t{2}, tree_values) ||
+                AddOverflow(_plan.tree_value_count, tree_values, _plan.tree_value_count) ||
+                AddOverflow(
+                    _plan.timeline_scope_count, slice.ready_scope_count, _plan.timeline_scope_count
+                )) {
+                _result.status = TimelineIndexBuildStatus::ResourceExhausted;
+                return false;
+            }
+            if (_plan.timeline_scope_count > _limits.max_gpu_timeline_scopes) {
+                _result.status     = TimelineIndexBuildStatus::LimitExceeded;
+                _result.limit_kind = TimelineIndexLimitKind::GpuTimelineScopes;
+                return false;
+            }
+        }
+        _plan.axis_frames.push_back(axis_frame);
+        group_begin = group_end;
+    }
+    if (_plan.axis_frames.size() != axis_frame_count) {
+        _result.status = TimelineIndexBuildStatus::ProtocolViolation;
+        return false;
+    }
+
+    if (_plan.timeline_scope_count > _limits.max_gpu_timeline_scopes) {
+        _result.status     = TimelineIndexBuildStatus::LimitExceeded;
+        _result.limit_kind = TimelineIndexLimitKind::GpuTimelineScopes;
+        return false;
+    }
+
+    std::uint64_t tree_offset = 0;
+    for (GpuFrameSlicePlan& slice : _plan.slices) {
+        if (MarkCancelled(_cancellation, _result)) {
+            return false;
+        }
+        slice.tree_offset         = tree_offset;
+        std::uint64_t tree_values = 0;
+        if (MultiplyOverflow(slice.tree_leaf_count, std::uint64_t{2}, tree_values) ||
+            AddOverflow(tree_offset, tree_values, tree_offset)) {
+            _result.status = TimelineIndexBuildStatus::ResourceExhausted;
+            return false;
+        }
+    }
+    if (tree_offset != _plan.tree_value_count) {
+        _result.status = TimelineIndexBuildStatus::ProtocolViolation;
+        return false;
+    }
+    return !MarkCancelledNow(_cancellation, _result);
+}
+
+} // namespace
+
+struct ProfileTimelineIndex::Impl {
+    TimelineIndexBuildResult result{
+        .status = TimelineIndexBuildStatus::Ready,
+    };
+    ProfileTimelineQuality       quality{};
+    const ProfileSessionSummary* session_identity{nullptr};
+    std::uint64_t                session_generation{0};
+    std::uint64_t                cpu_scope_count{0};
+    std::uint64_t                gpu_frame_count{0};
+    std::uint64_t                gpu_scope_count{0};
+    std::uint32_t                cpu_track_count{0};
+    std::uint32_t                gpu_track_count{0};
+    std::uint32_t                gpu_domain_count{0};
+
+    std::vector<TimelineAxis>          axes{};
+    std::vector<CpuTimelineTrackIndex> cpu_tracks{};
+    std::vector<CpuTimelineScopeRef>   cpu_scopes{};
+    std::vector<TimelineIntervalTree>  cpu_trees{};
+    std::vector<std::uint64_t>         cpu_tree_max_end{};
+    std::vector<GpuTimelineFrameRef>   gpu_frames{};
+    std::vector<GpuTimelineTrackIndex> gpu_tracks{};
+    std::vector<GpuTimelineFrameSlice> gpu_frame_slices{};
+    std::vector<GpuTimelineAxisFrame>  gpu_axis_frames{};
+    std::vector<GpuTimelineScopeRef>   gpu_timeline_scopes{};
+    std::vector<TimelineIntervalTree>  gpu_trees{};
+    std::vector<std::uint64_t>         gpu_tree_max_end{};
+};
+
+ProfileTimelineIndex::~ProfileTimelineIndex() {
+    delete impl_;
+}
+
+ProfileTimelineIndex::ProfileTimelineIndex(ProfileTimelineIndex&& _other) noexcept :
+    impl_(std::exchange(_other.impl_, nullptr)) {}
+
+ProfileTimelineIndex& ProfileTimelineIndex::operator=(ProfileTimelineIndex&& _other) noexcept {
+    if (this != &_other) {
+        delete impl_;
+        impl_ = std::exchange(_other.impl_, nullptr);
+    }
+    return *this;
+}
+
+bool ProfileTimelineIndex::Valid() const noexcept {
+    return impl_ != nullptr && impl_->result.status == TimelineIndexBuildStatus::Ready;
+}
+
+bool ProfileTimelineIndex::Matches(const ProfileSession& _session) const noexcept {
+    if (!Valid() || !_session.Valid()) {
+        return false;
+    }
+    const ProfileSessionSummary& summary = _session.Summary();
+    return impl_->session_identity == &summary && impl_->session_generation == summary.generation &&
+           impl_->cpu_scope_count == _session.CpuScopes().size() &&
+           impl_->gpu_frame_count == _session.GpuFrames().size() &&
+           impl_->gpu_scope_count == _session.GpuScopes().size() &&
+           impl_->cpu_track_count == _session.CpuTracks().size() &&
+           impl_->gpu_track_count == _session.GpuTracks().size() &&
+           impl_->gpu_domain_count == _session.GpuDomains().size();
+}
+
+const TimelineIndexBuildResult& ProfileTimelineIndex::BuildResult() const noexcept {
+    static const TimelineIndexBuildResult invalid{};
+    return impl_ != nullptr ? impl_->result : invalid;
+}
+
+const ProfileTimelineQuality& ProfileTimelineIndex::Quality() const noexcept {
+    static const ProfileTimelineQuality empty{};
+    return impl_ != nullptr ? impl_->quality : empty;
+}
+
+std::span<const TimelineAxis> ProfileTimelineIndex::Axes() const noexcept {
+    return Valid() ? std::span<const TimelineAxis>(impl_->axes) : std::span<const TimelineAxis>{};
+}
+
+std::span<const CpuTimelineTrackIndex> ProfileTimelineIndex::CpuTracks() const noexcept {
+    return Valid() ? std::span<const CpuTimelineTrackIndex>(impl_->cpu_tracks) :
+                     std::span<const CpuTimelineTrackIndex>{};
+}
+
+std::span<const CpuTimelineScopeRef> ProfileTimelineIndex::CpuScopes() const noexcept {
+    return Valid() ? std::span<const CpuTimelineScopeRef>(impl_->cpu_scopes) :
+                     std::span<const CpuTimelineScopeRef>{};
+}
+
+std::span<const GpuTimelineFrameRef> ProfileTimelineIndex::GpuFrames() const noexcept {
+    return Valid() ? std::span<const GpuTimelineFrameRef>(impl_->gpu_frames) :
+                     std::span<const GpuTimelineFrameRef>{};
+}
+
+std::span<const GpuTimelineTrackIndex> ProfileTimelineIndex::GpuTracks() const noexcept {
+    return Valid() ? std::span<const GpuTimelineTrackIndex>(impl_->gpu_tracks) :
+                     std::span<const GpuTimelineTrackIndex>{};
+}
+
+std::span<const GpuTimelineFrameSlice> ProfileTimelineIndex::GpuFrameSlices() const noexcept {
+    return Valid() ? std::span<const GpuTimelineFrameSlice>(impl_->gpu_frame_slices) :
+                     std::span<const GpuTimelineFrameSlice>{};
+}
+
+std::span<const GpuTimelineAxisFrame> ProfileTimelineIndex::GpuAxisFrames() const noexcept {
+    return Valid() ? std::span<const GpuTimelineAxisFrame>(impl_->gpu_axis_frames) :
+                     std::span<const GpuTimelineAxisFrame>{};
+}
+
+std::span<const GpuTimelineScopeRef> ProfileTimelineIndex::GpuTimelineScopes() const noexcept {
+    return Valid() ? std::span<const GpuTimelineScopeRef>(impl_->gpu_timeline_scopes) :
+                     std::span<const GpuTimelineScopeRef>{};
+}
+
+TimelineOverlapQueryResult ProfileTimelineIndex::QueryCpuOverlaps(
+    std::uint32_t            _track_index,
+    std::uint64_t            _view_begin_ns,
+    std::uint64_t            _view_end_ns,
+    std::span<std::uint64_t> _output
+) const noexcept {
+    TimelineOverlapQueryResult query{};
+    if (!Valid() || _track_index >= impl_->cpu_tracks.size() || _view_end_ns <= _view_begin_ns) {
+        return query;
+    }
+
+    query.valid                        = true;
+    const CpuTimelineTrackIndex& track = impl_->cpu_tracks[_track_index];
+    const TimelineIntervalTree&  tree  = impl_->cpu_trees[_track_index];
+    if (track.scope_count == 0) {
+        return query;
+    }
+
+    struct StackNode {
+        std::uint64_t node{0};
+        std::uint64_t begin{0};
+        std::uint64_t end{0};
+    };
+    std::array<StackNode, 128> stack{};
+    std::size_t                stack_size = 0;
+    stack[stack_size++]                   = {
+                          .node  = 1,
+                          .begin = 0,
+                          .end   = tree.leaf_count,
+    };
+
+    while (stack_size != 0) {
+        const StackNode current = stack[--stack_size];
+        if (current.begin >= track.scope_count) {
+            continue;
+        }
+        const std::uint64_t tree_value = impl_->cpu_tree_max_end[tree.tree_offset + current.node];
+        if (tree_value <= _view_begin_ns) {
+            continue;
+        }
+
+        const CpuTimelineScopeRef& first = impl_->cpu_scopes[track.first_scope + current.begin];
+        if (first.begin_ns >= _view_end_ns) {
+            continue;
+        }
+
+        if (current.end - current.begin == 1) {
+            if (!Overlaps(first, _view_begin_ns, _view_end_ns)) {
+                continue;
+            }
+            if (query.written < _output.size()) {
+                _output[query.written++] = first.source_scope_index;
+                continue;
+            }
+            query.truncated = true;
+            break;
+        }
+
+        const std::uint64_t middle = current.begin + (current.end - current.begin) / 2;
+        if (stack_size + 2 > stack.size()) {
+            query.valid = false;
+            return query;
+        }
+        // Push right first so the left/begin-time half is visited first.
+        stack[stack_size++] = {
+            .node  = current.node * 2 + 1,
+            .begin = middle,
+            .end   = current.end,
+        };
+        stack[stack_size++] = {
+            .node  = current.node * 2,
+            .begin = current.begin,
+            .end   = middle,
+        };
+    }
+    return query;
+}
+
+const GpuTimelineFrameRef* ProfileTimelineIndex::FindGpuFrame(std::uint64_t _frame_id) const noexcept {
+    if (!Valid()) {
+        return nullptr;
+    }
+    const auto found = std::lower_bound(
+        impl_->gpu_frames.begin(),
+        impl_->gpu_frames.end(),
+        _frame_id,
+        [](const GpuTimelineFrameRef& _frame, std::uint64_t _id) {
+            return _frame.frame_id < _id;
+        }
+    );
+    return found != impl_->gpu_frames.end() && found->frame_id == _frame_id ? &*found : nullptr;
+}
+
+const GpuTimelineFrameSlice*
+ProfileTimelineIndex::FindGpuFrameSlice(std::uint32_t _track_index, std::uint64_t _frame_id) const noexcept {
+    if (!Valid() || _track_index >= impl_->gpu_tracks.size()) {
+        return nullptr;
+    }
+    const GpuTimelineTrackIndex& track = impl_->gpu_tracks[_track_index];
+    const auto begin = impl_->gpu_frame_slices.begin() + static_cast<std::ptrdiff_t>(track.first_frame_slice);
+    const auto end   = begin + static_cast<std::ptrdiff_t>(track.frame_slice_count);
+    const auto found =
+        std::lower_bound(begin, end, _frame_id, [](const GpuTimelineFrameSlice& _slice, std::uint64_t _id) {
+            return _slice.frame_id < _id;
+        });
+    return found != end && found->frame_id == _frame_id ? &*found : nullptr;
+}
+
+const GpuTimelineAxisFrame*
+ProfileTimelineIndex::FindGpuAxisFrame(std::uint32_t _axis_index, std::uint64_t _frame_id) const noexcept {
+    if (!Valid() || _axis_index >= impl_->axes.size()) {
+        return nullptr;
+    }
+    const auto found = std::lower_bound(
+        impl_->gpu_axis_frames.begin(),
+        impl_->gpu_axis_frames.end(),
+        std::pair{_axis_index, _frame_id},
+        [](const GpuTimelineAxisFrame& _frame, const auto& _key) {
+            return _frame.axis_index < _key.first ||
+                   (_frame.axis_index == _key.first && _frame.frame_id < _key.second);
+        }
+    );
+    return found != impl_->gpu_axis_frames.end() && found->axis_index == _axis_index &&
+                   found->frame_id == _frame_id ?
+               &*found :
+               nullptr;
+}
+
+TimelineOverlapQueryResult ProfileTimelineIndex::QueryGpuOverlaps(
+    std::uint32_t            _track_index,
+    std::uint64_t            _frame_id,
+    std::uint64_t            _view_begin_ticks,
+    std::uint64_t            _view_end_ticks,
+    std::span<std::uint64_t> _output
+) const noexcept {
+    TimelineOverlapQueryResult query{};
+    if (!Valid() || _track_index >= impl_->gpu_tracks.size() || _view_end_ticks <= _view_begin_ticks) {
+        return query;
+    }
+    const GpuTimelineFrameSlice* slice = FindGpuFrameSlice(_track_index, _frame_id);
+    if (slice == nullptr || slice->axis_frame_index >= impl_->gpu_axis_frames.size() ||
+        !impl_->gpu_axis_frames[slice->axis_frame_index].timing_available) {
+        return query;
+    }
+
+    query.valid = true;
+    if (slice->timeline_scope_count == 0) {
+        return query;
+    }
+    const std::size_t slice_index = static_cast<std::size_t>(slice - impl_->gpu_frame_slices.data());
+    if (slice_index >= impl_->gpu_trees.size()) {
+        query.valid = false;
+        return query;
+    }
+    const TimelineIntervalTree& tree = impl_->gpu_trees[slice_index];
+    if (tree.leaf_count == 0) {
+        query.valid = false;
+        return query;
+    }
+
+    struct StackNode {
+        std::uint64_t node{0};
+        std::uint64_t begin{0};
+        std::uint64_t end{0};
+    };
+    std::array<StackNode, 128> stack{};
+    std::size_t                stack_size = 0;
+    stack[stack_size++]                   = {
+                          .node  = 1,
+                          .begin = 0,
+                          .end   = tree.leaf_count,
+    };
+
+    while (stack_size != 0) {
+        const StackNode current = stack[--stack_size];
+        if (current.begin >= slice->timeline_scope_count) {
+            continue;
+        }
+        const std::uint64_t tree_value = impl_->gpu_tree_max_end[tree.tree_offset + current.node];
+        if (tree_value <= _view_begin_ticks) {
+            continue;
+        }
+
+        const GpuTimelineScopeRef& first =
+            impl_->gpu_timeline_scopes[slice->first_timeline_scope + current.begin];
+        if (first.begin_tick_offset >= _view_end_ticks) {
+            continue;
+        }
+        if (current.end - current.begin == 1) {
+            if (!Overlaps(first, _view_begin_ticks, _view_end_ticks)) {
+                continue;
+            }
+            if (query.written < _output.size()) {
+                _output[query.written++] = first.source_scope_index;
+                continue;
+            }
+            query.truncated = true;
+            break;
+        }
+
+        const std::uint64_t middle = current.begin + (current.end - current.begin) / 2;
+        if (stack_size + 2 > stack.size()) {
+            query.valid = false;
+            return query;
+        }
+        stack[stack_size++] = {
+            .node  = current.node * 2 + 1,
+            .begin = middle,
+            .end   = current.end,
+        };
+        stack[stack_size++] = {
+            .node  = current.node * 2,
+            .begin = current.begin,
+            .end   = middle,
+        };
+    }
+    return query;
+}
+
+TimelineIndexBuildResult BuildProfileTimelineIndex(
+    const ProfileSession&            _session,
+    const SessionLoadResult&         _load_result,
+    const TimelineIndexLimits&       _limits,
+    ProfileTimelineIndex&            _output,
+    const TimelineIndexBuildControl& _control
+) noexcept {
+    TimelineIndexBuildResult result{};
+    if (!_session.Valid() || !_load_result.HasUsableSession()) {
+        return result;
+    }
+    const ProfileSessionSummary& input_summary = _session.Summary();
+    const bool                   result_matches_session =
+        _load_result.packet_count == input_summary.packet_count &&
+        ((_load_result.status == SessionLoadStatus::Complete) == input_summary.has_session_end);
+    if (!result_matches_session) {
+        return result;
+    }
+
+    CancellationProbe cancellation(_control);
+    if (MarkCancelledNow(cancellation, result)) {
+        return result;
+    }
+
+    try {
+        const auto cpu_scopes  = _session.CpuScopes();
+        const auto cpu_tracks  = _session.CpuTracks();
+        const auto gpu_frames  = _session.GpuFrames();
+        const auto gpu_scopes  = _session.GpuScopes();
+        const auto gpu_tracks  = _session.GpuTracks();
+        const auto gpu_domains = _session.GpuDomains();
+
+        if (cpu_scopes.size() > _limits.max_cpu_scopes) {
+            result.status     = TimelineIndexBuildStatus::LimitExceeded;
+            result.limit_kind = TimelineIndexLimitKind::CpuScopes;
+            return result;
+        }
+
+        std::uint64_t cpu_tree_value_count = 0;
+        for (const CpuTrack& track : cpu_tracks) {
+            if (MarkCancelled(cancellation, result)) {
+                return result;
+            }
+            std::uint64_t leaf_count = 0;
+            std::uint64_t tree_count = 0;
+            if (!NextPowerOfTwo(track.scope_count, leaf_count) ||
+                MultiplyOverflow(leaf_count, std::uint64_t{2}, tree_count) ||
+                AddOverflow(cpu_tree_value_count, tree_count, cpu_tree_value_count)) {
+                result.status = TimelineIndexBuildStatus::ResourceExhausted;
+                return result;
+            }
+        }
+
+        GpuBuildPlan gpu_plan;
+        if (!PrepareGpuBuildPlan(
+                gpu_frames, gpu_scopes, gpu_tracks, gpu_domains, _limits, cancellation, result, gpu_plan
+            )) {
+            return result;
+        }
+
+        const auto add_vector_bytes = [&](std::uint64_t _count, std::uint64_t _element_size) {
+            std::uint64_t bytes = 0;
+            return !MultiplyOverflow(_count, _element_size, bytes) &&
+                   !AddOverflow(result.logical_bytes, bytes, result.logical_bytes);
+        };
+        if (!add_vector_bytes(1 + gpu_domains.size(), sizeof(TimelineAxis)) ||
+            !add_vector_bytes(cpu_tracks.size(), sizeof(CpuTimelineTrackIndex)) ||
+            !add_vector_bytes(cpu_scopes.size(), sizeof(CpuTimelineScopeRef)) ||
+            !add_vector_bytes(cpu_tracks.size(), sizeof(TimelineIntervalTree)) ||
+            !add_vector_bytes(cpu_tree_value_count, sizeof(std::uint64_t)) ||
+            !add_vector_bytes(gpu_frames.size(), sizeof(GpuTimelineFrameRef)) ||
+            !add_vector_bytes(gpu_tracks.size(), sizeof(GpuTimelineTrackIndex)) ||
+            !add_vector_bytes(gpu_plan.slices.size(), sizeof(GpuTimelineFrameSlice)) ||
+            !add_vector_bytes(gpu_plan.axis_frames.size(), sizeof(GpuTimelineAxisFrame)) ||
+            !add_vector_bytes(gpu_plan.timeline_scope_count, sizeof(GpuTimelineScopeRef)) ||
+            !add_vector_bytes(gpu_plan.slices.size(), sizeof(TimelineIntervalTree)) ||
+            !add_vector_bytes(gpu_plan.tree_value_count, sizeof(std::uint64_t))) {
+            result.status = TimelineIndexBuildStatus::ResourceExhausted;
+            return result;
+        }
+        if (result.logical_bytes > _limits.max_logical_bytes) {
+            result.status     = TimelineIndexBuildStatus::LimitExceeded;
+            result.limit_kind = TimelineIndexLimitKind::LogicalBytes;
+            return result;
+        }
+        if (MarkCancelledNow(cancellation, result)) {
+            return result;
+        }
+
+        ProfileTimelineIndex candidate;
+        candidate.impl_ = new (std::nothrow) ProfileTimelineIndex::Impl;
+        if (candidate.impl_ == nullptr) {
+            result.status = TimelineIndexBuildStatus::ResourceExhausted;
+            return result;
+        }
+        ProfileTimelineIndex::Impl& impl = *candidate.impl_;
+        impl.result                      = result;
+        impl.result.status               = TimelineIndexBuildStatus::Ready;
+        impl.session_identity            = &_session.Summary();
+        impl.session_generation          = _session.Summary().generation;
+        impl.cpu_scope_count             = cpu_scopes.size();
+        impl.gpu_frame_count             = gpu_frames.size();
+        impl.gpu_scope_count             = gpu_scopes.size();
+        impl.cpu_track_count             = static_cast<std::uint32_t>(cpu_tracks.size());
+        impl.gpu_track_count             = static_cast<std::uint32_t>(gpu_tracks.size());
+        impl.gpu_domain_count            = static_cast<std::uint32_t>(gpu_domains.size());
+
+        impl.axes.reserve(1 + gpu_domains.size());
+        impl.cpu_tracks.reserve(cpu_tracks.size());
+        impl.cpu_scopes.reserve(cpu_scopes.size());
+        impl.cpu_trees.reserve(cpu_tracks.size());
+        impl.cpu_tree_max_end.resize(static_cast<std::size_t>(cpu_tree_value_count), 0);
+        impl.gpu_frames.reserve(gpu_frames.size());
+        impl.gpu_tracks.reserve(gpu_tracks.size());
+        impl.gpu_frame_slices.reserve(gpu_plan.slices.size());
+        impl.gpu_axis_frames.reserve(gpu_plan.axis_frames.size());
+        impl.gpu_timeline_scopes.reserve(static_cast<std::size_t>(gpu_plan.timeline_scope_count));
+        impl.gpu_trees.reserve(gpu_plan.slices.size());
+        impl.gpu_tree_max_end.resize(static_cast<std::size_t>(gpu_plan.tree_value_count), 0);
+
+        const ProfileSessionSummary& summary = input_summary;
+        impl.axes.push_back({
+            .kind                            = TimelineAxisKind::CpuSteadyClock,
+            .unit_period_ns                  = 1.0,
+            .timing_available                = summary.has_cpu_range,
+            .timing_capability_trusted       = summary.has_cpu_range,
+            .calibrated_to_cpu               = true,
+            .calibrated_to_other_gpu_domains = false,
+        });
+        for (std::size_t index = 0; index < gpu_domains.size(); ++index) {
+            if (MarkCancelled(cancellation, result)) {
+                return result;
+            }
+            const GpuTimestampDomain& domain = gpu_domains[index];
+            impl.axes.push_back({
+                .kind                            = TimelineAxisKind::GpuPhysicalTimestampDomain,
+                .source_domain_index             = static_cast<std::uint32_t>(index),
+                .native_queue_id                 = domain.native_queue_id,
+                .family_id                       = domain.family_id,
+                .logical_queue_mask              = domain.logical_queue_mask,
+                .valid_bits                      = domain.valid_bits,
+                .unit_period_ns                  = domain.tick_period_ns,
+                .timing_available                = domain.has_ready_timestamps,
+                .timing_capability_trusted       = domain.timing_capability_trusted,
+                .calibrated_to_cpu               = false,
+                .calibrated_to_other_gpu_domains = false,
+            });
+        }
+
+        std::uint64_t tree_offset = 0;
+        for (std::size_t track_index = 0; track_index < cpu_tracks.size(); ++track_index) {
+            if (MarkCancelled(cancellation, result)) {
+                return result;
+            }
+            const CpuTrack& track = cpu_tracks[track_index];
+            if (track.first_scope > cpu_scopes.size() ||
+                track.scope_count > cpu_scopes.size() - track.first_scope ||
+                (track.scope_count != 0 && !summary.has_cpu_range)) {
+                result.status = TimelineIndexBuildStatus::ProtocolViolation;
+                return result;
+            }
+
+            std::uint64_t leaf_count = 0;
+            if (!NextPowerOfTwo(track.scope_count, leaf_count)) {
+                result.status = TimelineIndexBuildStatus::ResourceExhausted;
+                return result;
+            }
+            impl.cpu_trees.push_back({
+                .tree_offset = tree_offset,
+                .leaf_count  = leaf_count,
+            });
+            CpuTimelineTrackIndex indexed_track{
+                .source_track_index = static_cast<std::uint32_t>(track_index),
+                .axis_index         = 0,
+                .first_scope        = impl.cpu_scopes.size(),
+                .scope_count        = track.scope_count,
+            };
+
+            std::uint64_t     previous_begin = 0;
+            bool              has_scope      = false;
+            const std::size_t source_begin   = static_cast<std::size_t>(track.first_scope);
+            const std::size_t source_end     = source_begin + static_cast<std::size_t>(track.scope_count);
+            for (std::size_t source_index = source_begin; source_index < source_end; ++source_index) {
+                if (MarkCancelled(cancellation, result)) {
+                    return result;
+                }
+                const CpuScopeRecord& scope = cpu_scopes[source_index];
+                if (scope.track_index != track_index || scope.thread_id != track.thread_id ||
+                    scope.begin_ns < summary.cpu_begin_ns || scope.end_ns < scope.begin_ns) {
+                    result.status = TimelineIndexBuildStatus::ProtocolViolation;
+                    return result;
+                }
+                const std::uint64_t begin_ns = scope.begin_ns - summary.cpu_begin_ns;
+                const std::uint64_t end_ns   = scope.end_ns - summary.cpu_begin_ns;
+                if (has_scope && begin_ns < previous_begin) {
+                    result.status = TimelineIndexBuildStatus::ProtocolViolation;
+                    return result;
+                }
+                previous_begin = begin_ns;
+                has_scope      = true;
+                impl.cpu_scopes.push_back({
+                    .source_scope_index = source_index,
+                    .begin_ns           = begin_ns,
+                    .end_ns             = end_ns,
+                });
+                indexed_track.max_depth = std::max(indexed_track.max_depth, scope.depth);
+                if (indexed_track.scope_count != 0) {
+                    if (source_index == source_begin) {
+                        indexed_track.begin_ns = begin_ns;
+                        indexed_track.end_ns   = end_ns;
+                    } else {
+                        indexed_track.end_ns = std::max(indexed_track.end_ns, end_ns);
+                    }
+                }
+            }
+            impl.cpu_tracks.push_back(indexed_track);
+
+            const std::uint64_t track_tree_offset = tree_offset;
+            for (std::uint64_t local_index = 0; local_index < track.scope_count; ++local_index) {
+                if (MarkCancelled(cancellation, result)) {
+                    return result;
+                }
+                const CpuTimelineScopeRef& scope = impl.cpu_scopes[indexed_track.first_scope + local_index];
+                impl.cpu_tree_max_end[track_tree_offset + leaf_count + local_index] = QueryEnd(scope);
+            }
+            for (std::uint64_t node = leaf_count; node > 1;) {
+                if (MarkCancelled(cancellation, result)) {
+                    return result;
+                }
+                --node;
+                impl.cpu_tree_max_end[track_tree_offset + node] = std::max(
+                    impl.cpu_tree_max_end[track_tree_offset + node * 2],
+                    impl.cpu_tree_max_end[track_tree_offset + node * 2 + 1]
+                );
+            }
+            tree_offset += leaf_count * 2;
+        }
+        if (tree_offset != cpu_tree_value_count) {
+            result.status = TimelineIndexBuildStatus::ProtocolViolation;
+            return result;
+        }
+
+        for (std::size_t index = 0; index < gpu_frames.size(); ++index) {
+            if (MarkCancelled(cancellation, result)) {
+                return result;
+            }
+            if (index != 0 && gpu_frames[index - 1].frame_id >= gpu_frames[index].frame_id) {
+                result.status = TimelineIndexBuildStatus::ProtocolViolation;
+                return result;
+            }
+            impl.gpu_frames.push_back({
+                .frame_id           = gpu_frames[index].frame_id,
+                .source_frame_index = index,
+            });
+        }
+
+        for (const GpuAxisFramePlan& planned : gpu_plan.axis_frames) {
+            if (MarkCancelled(cancellation, result) || planned.domain_index >= gpu_domains.size()) {
+                if (result.status != TimelineIndexBuildStatus::Cancelled) {
+                    result.status = TimelineIndexBuildStatus::ProtocolViolation;
+                }
+                return result;
+            }
+            const GpuTimestampDomain& domain = gpu_domains[planned.domain_index];
+            impl.gpu_axis_frames.push_back({
+                .frame_id                  = planned.frame_id,
+                .source_frame_index        = planned.source_frame_index,
+                .axis_index                = static_cast<std::uint32_t>(1 + planned.domain_index),
+                .origin_tick               = planned.origin_tick,
+                .extent_ticks              = planned.extent_ticks,
+                .ready_scope_count         = planned.ready_scope_count,
+                .error_scope_count         = planned.error_scope_count,
+                .frame_status              = planned.frame_status,
+                .has_frame_record          = planned.has_frame_record,
+                .timing_available          = planned.timing_available,
+                .timing_capability_trusted = domain.timing_capability_trusted,
+                .materialization_complete  = planned.materialization_complete,
+                .timing_topology_trusted   = planned.timing_topology_trusted,
+            });
+        }
+
+        for (std::size_t track_index = 0; track_index < gpu_tracks.size(); ++track_index) {
+            if (MarkCancelled(cancellation, result)) {
+                return result;
+            }
+            const GpuTrack& track = gpu_tracks[track_index];
+            if (track_index >= gpu_plan.track_first_slice.size() ||
+                track_index >= gpu_plan.track_slice_count.size() ||
+                track.domain_index >= gpu_domains.size()) {
+                result.status = TimelineIndexBuildStatus::ProtocolViolation;
+                return result;
+            }
+            GpuTimelineTrackIndex indexed_track{
+                .source_track_index = static_cast<std::uint32_t>(track_index),
+                .axis_index         = static_cast<std::uint32_t>(1 + track.domain_index),
+                .first_frame_slice  = impl.gpu_frame_slices.size(),
+                .frame_slice_count  = gpu_plan.track_slice_count[track_index],
+            };
+            const std::uint64_t plan_begin = gpu_plan.track_first_slice[track_index];
+            const std::uint64_t plan_end   = plan_begin + gpu_plan.track_slice_count[track_index];
+            if (plan_end > gpu_plan.slices.size()) {
+                result.status = TimelineIndexBuildStatus::ProtocolViolation;
+                return result;
+            }
+
+            for (std::uint64_t plan_index = plan_begin; plan_index < plan_end; ++plan_index) {
+                if (MarkCancelled(cancellation, result)) {
+                    return result;
+                }
+                const GpuFrameSlicePlan& planned = gpu_plan.slices[plan_index];
+                if (planned.track_index != track_index || planned.domain_index != track.domain_index ||
+                    planned.axis_frame_index >= impl.gpu_axis_frames.size()) {
+                    result.status = TimelineIndexBuildStatus::ProtocolViolation;
+                    return result;
+                }
+                const GpuTimelineAxisFrame& axis_frame = impl.gpu_axis_frames[planned.axis_frame_index];
+                const GpuAxisFramePlan&     axis_plan  = gpu_plan.axis_frames[planned.axis_frame_index];
+                GpuTimelineFrameSlice       slice{
+                          .frame_id             = planned.frame_id,
+                          .source_frame_index   = planned.source_frame_index,
+                          .axis_frame_index     = planned.axis_frame_index,
+                          .first_scope          = planned.first_scope,
+                          .scope_count          = planned.scope_count,
+                          .first_timeline_scope = impl.gpu_timeline_scopes.size(),
+                          .error_scope_count    = planned.error_scope_count,
+                };
+                if (planned.source_frame_index != kInvalidSessionIndex) {
+                    const GpuFrameRecord& frame    = gpu_frames[planned.source_frame_index];
+                    slice.frame_status             = frame.status;
+                    slice.has_frame_record         = true;
+                    slice.materialization_complete = frame.materialization_complete;
+                    slice.timing_topology_trusted  = frame.timing_topology_trusted;
+                }
+
+                if (axis_frame.timing_available) {
+                    const GpuTimestampDomain& domain = gpu_domains[planned.domain_index];
+                    for (std::uint64_t scope_offset = 0; scope_offset < planned.scope_count; ++scope_offset) {
+                        if (MarkCancelled(cancellation, result)) {
+                            return result;
+                        }
+                        const std::uint64_t   source_index = planned.first_scope + scope_offset;
+                        const GpuScopeRecord& scope        = gpu_scopes[source_index];
+                        if (scope.status != ProfileGpuScopeStatus::Ready) {
+                            continue;
+                        }
+                        std::uint64_t begin_offset = 0;
+                        std::uint64_t end_offset   = 0;
+                        if (!ComputeGpuOffsets(scope, domain, axis_plan, begin_offset, end_offset)) {
+                            result.status = TimelineIndexBuildStatus::ProtocolViolation;
+                            return result;
+                        }
+                        impl.gpu_timeline_scopes.push_back({
+                            .source_scope_index = source_index,
+                            .begin_tick_offset  = begin_offset,
+                            .end_tick_offset    = end_offset,
+                        });
+                    }
+                    slice.timeline_scope_count = impl.gpu_timeline_scopes.size() - slice.first_timeline_scope;
+                    if (slice.timeline_scope_count != planned.ready_scope_count) {
+                        result.status = TimelineIndexBuildStatus::ProtocolViolation;
+                        return result;
+                    }
+                    if (!CancellableSort(
+                            impl.gpu_timeline_scopes,
+                            static_cast<std::size_t>(slice.first_timeline_scope),
+                            static_cast<std::size_t>(slice.timeline_scope_count),
+                            [](const GpuTimelineScopeRef& _left, const GpuTimelineScopeRef& _right) {
+                                if (_left.begin_tick_offset != _right.begin_tick_offset) {
+                                    return _left.begin_tick_offset < _right.begin_tick_offset;
+                                }
+                                if (_left.end_tick_offset != _right.end_tick_offset) {
+                                    return _left.end_tick_offset > _right.end_tick_offset;
+                                }
+                                return _left.source_scope_index < _right.source_scope_index;
+                            },
+                            cancellation,
+                            result
+                        )) {
+                        return result;
+                    }
+                }
+
+                impl.gpu_trees.push_back({
+                    .tree_offset = planned.tree_offset,
+                    .leaf_count  = planned.tree_leaf_count,
+                });
+                if (planned.tree_leaf_count != 0) {
+                    for (std::uint64_t local_index = 0; local_index < slice.timeline_scope_count;
+                         ++local_index) {
+                        if (MarkCancelled(cancellation, result)) {
+                            return result;
+                        }
+                        const GpuTimelineScopeRef& scope =
+                            impl.gpu_timeline_scopes[slice.first_timeline_scope + local_index];
+                        impl.gpu_tree_max_end[planned.tree_offset + planned.tree_leaf_count + local_index] =
+                            QueryEnd(scope);
+                    }
+                    for (std::uint64_t node = planned.tree_leaf_count; node > 1;) {
+                        if (MarkCancelled(cancellation, result)) {
+                            return result;
+                        }
+                        --node;
+                        impl.gpu_tree_max_end[planned.tree_offset + node] = std::max(
+                            impl.gpu_tree_max_end[planned.tree_offset + node * 2],
+                            impl.gpu_tree_max_end[planned.tree_offset + node * 2 + 1]
+                        );
+                    }
+                }
+                impl.gpu_frame_slices.push_back(slice);
+            }
+            if (impl.gpu_frame_slices.size() - indexed_track.first_frame_slice !=
+                indexed_track.frame_slice_count) {
+                result.status = TimelineIndexBuildStatus::ProtocolViolation;
+                return result;
+            }
+            impl.gpu_tracks.push_back(indexed_track);
+        }
+
+        impl.quality.lost_record_count                 = summary.lost_record_count;
+        impl.quality.unnotified_drop_count             = summary.unnotified_drop_count;
+        impl.quality.orphan_cpu_scope_count            = summary.orphan_cpu_scope_count;
+        impl.quality.orphan_gpu_scope_count            = summary.orphan_gpu_scope_count;
+        impl.quality.degraded_complete_gpu_frame_count = summary.degraded_complete_gpu_frame_count;
+        impl.quality.incomplete_gpu_frame_count        = summary.incomplete_gpu_frame_count;
+        impl.quality.invalid_gpu_frame_count           = summary.invalid_gpu_frame_count;
+        impl.quality.error_gpu_scope_count             = summary.error_gpu_scope_count;
+        impl.quality.unknown_record_count              = summary.unknown_record_count;
+        for (const GpuFrameRecord& frame : gpu_frames) {
+            if (MarkCancelled(cancellation, result)) {
+                return result;
+            }
+            if (frame.scope_count != 0 && !frame.timing_topology_trusted) {
+                ++impl.quality.untrusted_gpu_frame_count;
+            }
+        }
+
+        if (_load_result.status == SessionLoadStatus::ForensicTruncated) {
+            AddQualityFlag(impl.quality, TimelineQualityFlag::ForensicTruncated);
+        }
+        if (impl.quality.lost_record_count != 0) {
+            AddQualityFlag(impl.quality, TimelineQualityFlag::LostRecords);
+        }
+        if (impl.quality.unnotified_drop_count != 0) {
+            AddQualityFlag(impl.quality, TimelineQualityFlag::UnnotifiedDrops);
+        }
+        if (impl.quality.orphan_cpu_scope_count != 0) {
+            AddQualityFlag(impl.quality, TimelineQualityFlag::CpuOrphans);
+        }
+        if (impl.quality.orphan_gpu_scope_count != 0) {
+            AddQualityFlag(impl.quality, TimelineQualityFlag::GpuOrphans);
+        }
+        if (impl.quality.degraded_complete_gpu_frame_count != 0) {
+            AddQualityFlag(impl.quality, TimelineQualityFlag::DegradedGpuFrames);
+        }
+        if (impl.quality.incomplete_gpu_frame_count != 0) {
+            AddQualityFlag(impl.quality, TimelineQualityFlag::IncompleteGpuFrames);
+        }
+        if (impl.quality.invalid_gpu_frame_count != 0) {
+            AddQualityFlag(impl.quality, TimelineQualityFlag::InvalidGpuFrames);
+        }
+        if (impl.quality.error_gpu_scope_count != 0) {
+            AddQualityFlag(impl.quality, TimelineQualityFlag::GpuScopeErrors);
+        }
+        if (impl.quality.untrusted_gpu_frame_count != 0) {
+            AddQualityFlag(impl.quality, TimelineQualityFlag::UntrustedGpuTiming);
+        }
+        if (impl.quality.unknown_record_count != 0) {
+            AddQualityFlag(impl.quality, TimelineQualityFlag::UnknownRecords);
+        }
+
+        if (MarkCancelledNow(cancellation, result)) {
+            return result;
+        }
+        impl.result        = result;
+        impl.result.status = TimelineIndexBuildStatus::Ready;
+        _output            = std::move(candidate);
+        result.status      = TimelineIndexBuildStatus::Ready;
+        return result;
+    } catch (const std::bad_alloc&) {
+        result.status = TimelineIndexBuildStatus::ResourceExhausted;
+        return result;
+    } catch (...) {
+        result.status = TimelineIndexBuildStatus::ResourceExhausted;
+        return result;
+    }
+}
+
+} // namespace Moer::ProfileDump


### PR DESCRIPTION
## Summary

- add an immutable-session `ProfileTimelineIndex` with exact source-model identity
- add precision-safe CPU track indexing and output-bounded interval queries
- add frame-local, physical-domain GPU presentation axes with timestamp-wrap normalization and bounded overlap queries
- preserve loss/error/incomplete/untrusted quality semantics without inventing CPU/GPU calibration
- add retained/transient resource limits, overflow checks, cooperative cancellation, and atomic candidate publication
- add a comprehensive `ProfileTimelineIndexContract` test target

## Architecture notes

This takes the timeline/index product intent from `dev_parallel_rhi` while keeping main's ProfileDump v3 immutable `ProfileSession` and quality model. It intentionally does not restore the legacy Trace/MRTC/CSV/TCP mutable profiler shell.

CPU and each physical GPU timestamp domain remain separate axes. GPU origins are local to `(physical domain, frame)` because the capture format has no CPU↔GPU, cross-domain, or cross-frame calibration.

The next loader phase must atomically publish one owning `shared_ptr<const ProfileDocument>` containing the load result, session, and index; session/index must never be published separately.

## Validation

- Debug full build + CTest: 31/31
- RelWithDebInfo full build + CTest: 31/31
- Release full build + CTest: 31/31
- focused Debug contract: 200/200 repeated runs
- real 47.8 MB MPD: 194,861 CPU scopes, 97,431 GPU frames/slices, 29,916,296 retained index bytes
- multiple independent architecture/index/cancellation/resource/test reviews: no remaining P1/P2/P3
