### PR TITLE
Phase 21D.3b: add asynchronous profile document loader

### DIFF
--- a/source/test/CMakeLists.txt
+++ b/source/test/CMakeLists.txt
@@ -55,6 +55,20 @@ add_test(
 )
 set_tests_properties(ProfileTimelineIndexContract PROPERTIES TIMEOUT 60)
 
+set(test_target TestProfileDocumentLoader)
+add_executable(${test_target} "ProfileDocumentLoaderTest.cpp")
+target_link_libraries(${test_target}
+    PRIVATE
+        Moer::ProfileConsumer
+        Moer::Core
+)
+set_target_properties(${test_target} PROPERTIES FOLDER ${moer_test_folder})
+add_test(
+    NAME ProfileDocumentLoaderContract
+    COMMAND $<TARGET_FILE:${test_target}>
+)
+set_tests_properties(ProfileDocumentLoaderContract PROPERTIES TIMEOUT 120)
+
 set(test_target TestProfileScopeProducer)
 add_executable(${test_target} "ProfileScopeProducerTest.cpp")
 target_include_directories(${test_target}

--- a/source/test/ProfileDocumentLoaderTest.cpp
+++ b/source/test/ProfileDocumentLoaderTest.cpp
@@ -1,0 +1,491 @@
+#include "profile/ProfileDump.h"
+#include "profile/ProfileDumpTemplates.h"
+#include "profile_consumer/ProfileDocument.h"
+
+#include <array>
+#include <chrono>
+#include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <thread>
+
+namespace {
+
+using namespace Moer::ProfileDump;
+using namespace std::chrono_literals;
+
+void Expect(bool _condition, std::string_view _message) {
+    if (!_condition) {
+        throw std::runtime_error(std::string(_message));
+    }
+}
+
+class ScopedLoaderFixtures final {
+public:
+    ScopedLoaderFixtures() {
+        static std::uint64_t next_id = 0;
+        for (std::uint32_t attempt = 0; attempt < 64; ++attempt) {
+            const auto now =
+                static_cast<std::uint64_t>(std::chrono::steady_clock::now().time_since_epoch().count());
+            directory_ =
+                std::filesystem::temp_directory_path() /
+                ("moer-profile-document-loader-" + std::to_string(now) + "-" + std::to_string(next_id++));
+            std::error_code error;
+            if (std::filesystem::create_directory(directory_, error)) {
+                return;
+            }
+            if (error && error != std::errc::file_exists) {
+                break;
+            }
+        }
+        throw std::runtime_error("profile document loader test could not reserve a temp directory");
+    }
+
+    ~ScopedLoaderFixtures() {
+        static_cast<void>(Moer::ProfileDump::Shutdown());
+        std::error_code error;
+        std::filesystem::remove_all(directory_, error);
+    }
+
+    [[nodiscard]] std::filesystem::path Path(std::string_view _name) const {
+        return directory_ / (std::string(_name) + ".mpd");
+    }
+
+private:
+    std::filesystem::path directory_{};
+};
+
+void WriteCapture(
+    const std::filesystem::path& _path,
+    std::string_view             _scope_name,
+    std::uint32_t                _scope_count
+) {
+    static_cast<void>(Moer::ProfileDump::Shutdown());
+
+    RuntimeConfig config;
+    config.output_path      = _path;
+    config.replace_existing = true;
+    // The fixture is intentionally lossless. Optimized producers can outrun
+    // the writer while creating the two 131k-scope captures, so size the
+    // bounded queue for the complete synthetic burst instead of depending on
+    // scheduler timing.
+    config.queue_max_chunks  = 4096;
+    config.queue_max_records = 262144;
+    Expect(Start(config) == StartResult::Started, "fixture capture did not start");
+
+    const SchemaRegistration cpu = RegisterSchema(Templates::CpuScope());
+    Expect(cpu.status == SchemaStatus::Registered, "fixture CPU schema did not register");
+
+    for (std::uint32_t index = 0; index < _scope_count; ++index) {
+        const std::uint64_t                 begin = static_cast<std::uint64_t>(index) * 4;
+        const std::array<FieldValueView, 5> values{
+            std::uint64_t{17},
+            _scope_name,
+            begin,
+            begin + 2,
+            std::uint32_t{0},
+        };
+        Expect(Emit(cpu.handle, values) == EmitStatus::Accepted, "fixture CPU scope emission failed");
+    }
+
+    Expect(Moer::ProfileDump::Shutdown() == ShutdownResult::Completed, "fixture capture did not close");
+}
+
+[[nodiscard]] bool IsTerminal(ProfileDocumentLoadPhase _phase) noexcept {
+    return _phase == ProfileDocumentLoadPhase::Ready || _phase == ProfileDocumentLoadPhase::Failed ||
+           _phase == ProfileDocumentLoadPhase::Cancelled || _phase == ProfileDocumentLoadPhase::Shutdown;
+}
+
+ProfileDocumentLoaderSnapshot WaitForGeneration(
+    const ProfileDocumentLoader& _loader,
+    std::uint64_t                _generation,
+    std::chrono::milliseconds    _timeout = 10s
+) {
+    const auto deadline = std::chrono::steady_clock::now() + _timeout;
+    for (;;) {
+        auto snapshot = _loader.Snapshot();
+        Expect(
+            snapshot.request_generation == _generation,
+            "loader progress/result generation was not paired with the latest request"
+        );
+        if (IsTerminal(snapshot.phase)) {
+            Expect(
+                !snapshot.active_request || snapshot.active_generation != _generation,
+                "terminal latest generation remained active in the same snapshot"
+            );
+            return snapshot;
+        }
+        if (std::chrono::steady_clock::now() >= deadline) {
+            throw std::runtime_error("profile document loader timed out");
+        }
+        std::this_thread::sleep_for(1ms);
+    }
+}
+
+ProfileDocumentLoaderSnapshot WaitUntilActive(
+    const ProfileDocumentLoader& _loader,
+    std::uint64_t                _generation,
+    std::chrono::milliseconds    _timeout = 10s
+) {
+    const auto deadline = std::chrono::steady_clock::now() + _timeout;
+    for (;;) {
+        auto snapshot = _loader.Snapshot();
+        Expect(
+            snapshot.request_generation == _generation, "active wait observed a different latest generation"
+        );
+        if (snapshot.active_request && snapshot.active_generation == _generation) {
+            return snapshot;
+        }
+        if (IsTerminal(snapshot.phase)) {
+            throw std::runtime_error("request completed before active state was observed");
+        }
+        if (std::chrono::steady_clock::now() >= deadline) {
+            throw std::runtime_error("profile document loader did not activate the request");
+        }
+        std::this_thread::yield();
+    }
+}
+
+void ExpectReadyDocument(
+    const ProfileDocumentLoaderSnapshot& _snapshot,
+    std::uint64_t                        _generation,
+    const std::filesystem::path&         _path
+) {
+    Expect(_snapshot.phase == ProfileDocumentLoadPhase::Ready, "document load was not ready");
+    Expect(_snapshot.request_generation == _generation, "ready generation mismatch");
+    Expect(_snapshot.published_generation == _generation, "published generation mismatch");
+    Expect(_snapshot.latest_attempt_path == _path, "latest attempt path mismatch");
+    Expect(_snapshot.reported_input_bytes_final, "ready reader byte count was not final");
+    Expect(
+        _snapshot.observed_total_bytes_available,
+        "regular fixture did not expose a best-effort total-byte observation"
+    );
+    Expect(
+        _snapshot.observed_total_bytes == std::filesystem::file_size(_path),
+        "best-effort total-byte observation did not match the stable fixture"
+    );
+    Expect(
+        _snapshot.reported_input_bytes == _snapshot.session_result.input_bytes,
+        "final reported input byte count did not match the reader outcome"
+    );
+    Expect(_snapshot.document != nullptr, "ready snapshot had no document");
+    Expect(_snapshot.document->request_generation == _generation, "document generation mismatch");
+    Expect(_snapshot.document->source_path == _path, "document source path mismatch");
+    Expect(_snapshot.document->Valid(), "published document was internally inconsistent");
+    Expect(
+        _snapshot.document->timeline_index.Matches(_snapshot.document->session),
+        "published index did not match its owning session"
+    );
+}
+
+void TestSuccessReplacementAndFailurePreservation(
+    const std::filesystem::path& _a,
+    const std::filesystem::path& _b,
+    const std::filesystem::path& _missing
+) {
+    ProfileDocumentLoader loader;
+    const std::uint64_t   generation_a = loader.RequestLoad(_a);
+    Expect(generation_a != 0, "first load request was rejected");
+    auto ready_a = WaitForGeneration(loader, generation_a);
+    ExpectReadyDocument(ready_a, generation_a, _a);
+    const auto document_a = ready_a.document;
+
+    const std::uint64_t generation_b = loader.RequestLoad(_b);
+    Expect(generation_b == generation_a + 1, "request generation was not monotonic");
+    auto ready_b = WaitForGeneration(loader, generation_b);
+    ExpectReadyDocument(ready_b, generation_b, _b);
+    Expect(ready_b.document != document_a, "successful replacement reused the old document");
+    const auto document_b = ready_b.document;
+
+    const std::uint64_t failed_generation = loader.RequestLoad(_missing);
+    Expect(failed_generation == generation_b + 1, "failed request generation mismatch");
+    const auto failed = WaitForGeneration(loader, failed_generation);
+    Expect(failed.phase == ProfileDocumentLoadPhase::Failed, "missing file was not reported failed");
+    Expect(
+        failed.diagnostic == ProfileDocumentLoadDiagnostic::SessionLoadFailed,
+        "missing file failure diagnostic mismatch"
+    );
+    Expect(failed.latest_attempt_path == _missing, "failed attempt path mismatch");
+    Expect(failed.published_generation == generation_b, "failure changed published generation");
+    Expect(failed.document == document_b, "failure discarded the last-good document");
+    Expect(failed.document->Valid(), "last-good document became invalid after failure");
+}
+
+void TestCancellationPreservesLastGood(
+    const std::filesystem::path& _good,
+    const std::filesystem::path& _large
+) {
+    ProfileDocumentLoader loader;
+    const std::uint64_t   good_generation = loader.RequestLoad(_good);
+    const auto            ready           = WaitForGeneration(loader, good_generation);
+    ExpectReadyDocument(ready, good_generation, _good);
+    const auto last_good = ready.document;
+
+    ProfileDocumentLoadOptions index_cancel_options;
+    index_cancel_options.timeline_control.cancellation_check_interval  = 1;
+    index_cancel_options.timeline_control.max_work_items_before_cancel = 1;
+
+    const std::uint64_t index_cancel_generation = loader.RequestLoad(_large, index_cancel_options);
+    Expect(index_cancel_generation != 0, "index cancellation request was rejected");
+    const auto index_cancelled = WaitForGeneration(loader, index_cancel_generation);
+    Expect(
+        index_cancelled.phase == ProfileDocumentLoadPhase::Cancelled,
+        "index work-budget cancellation did not reach Cancelled"
+    );
+    Expect(
+        index_cancelled.session_result.HasUsableSession(),
+        "index cancellation did not complete session materialization first"
+    );
+    Expect(
+        index_cancelled.timeline_result.status == TimelineIndexBuildStatus::Cancelled,
+        "index cancellation did not report a cancelled timeline build"
+    );
+    Expect(index_cancelled.document == last_good, "index cancellation discarded the last-good document");
+
+    ProfileDocumentLoadOptions active_cancel_options;
+    active_cancel_options.session_control.cancellation_check_interval  = 1;
+    active_cancel_options.timeline_control.cancellation_check_interval = 1;
+    const std::uint64_t active_cancel_generation = loader.RequestLoad(_large, active_cancel_options);
+    Expect(active_cancel_generation != 0, "active cancellation request was rejected");
+    static_cast<void>(WaitUntilActive(loader, active_cancel_generation));
+    Expect(loader.CancelLatest(), "active request did not accept CancelLatest");
+    const auto active_cancelled = WaitForGeneration(loader, active_cancel_generation);
+    Expect(
+        active_cancelled.phase == ProfileDocumentLoadPhase::Cancelled,
+        "active CancelLatest did not reach Cancelled"
+    );
+    Expect(active_cancelled.document == last_good, "active CancelLatest discarded the last-good document");
+
+    ProfileDocumentLoadOptions options;
+    options.session_control.cancellation_check_interval  = 1;
+    options.session_control.max_work_items_before_cancel = 1;
+
+    const std::uint64_t cancelled_generation = loader.RequestLoad(_large, options);
+    Expect(cancelled_generation != 0, "cancellation fixture request was rejected");
+    static_cast<void>(loader.CancelLatest());
+    const auto cancelled = WaitForGeneration(loader, cancelled_generation);
+    Expect(
+        cancelled.phase == ProfileDocumentLoadPhase::Cancelled, "cancelled attempt did not reach Cancelled"
+    );
+    Expect(cancelled.diagnostic == ProfileDocumentLoadDiagnostic::Cancelled, "cancel diagnostic mismatch");
+    Expect(cancelled.document == last_good, "cancellation discarded the last-good document");
+    Expect(cancelled.published_generation == good_generation, "cancellation changed published generation");
+
+    std::stop_source external_stop;
+    external_stop.request_stop();
+    ProfileDocumentLoadOptions external_stop_options;
+    external_stop_options.session_control.stop_token = external_stop.get_token();
+
+    const std::uint64_t external_stop_generation = loader.RequestLoad(_large, external_stop_options);
+    Expect(external_stop_generation != 0, "external-stop request was rejected");
+    const auto external_stop_cancelled = WaitForGeneration(loader, external_stop_generation);
+    Expect(
+        external_stop_cancelled.phase == ProfileDocumentLoadPhase::Cancelled,
+        "external session stop_token was not forwarded"
+    );
+    Expect(
+        external_stop_cancelled.session_result.status == SessionLoadStatus::Cancelled,
+        "external session stop_token did not cancel the reader"
+    );
+    Expect(
+        external_stop_cancelled.document == last_good,
+        "external stop_token cancellation discarded the last-good document"
+    );
+}
+
+void TestTimelineFailurePreservesLastGood(
+    const std::filesystem::path& _good,
+    const std::filesystem::path& _candidate
+) {
+    ProfileDocumentLoader loader;
+    const std::uint64_t   good_generation = loader.RequestLoad(_good);
+    const auto            ready           = WaitForGeneration(loader, good_generation);
+    const auto            last_good       = ready.document;
+
+    ProfileDocumentLoadOptions options;
+    options.timeline_limits.max_cpu_scopes = 0;
+    const std::uint64_t failed_generation  = loader.RequestLoad(_candidate, options);
+    const auto          failed             = WaitForGeneration(loader, failed_generation);
+    Expect(failed.phase == ProfileDocumentLoadPhase::Failed, "timeline limit did not fail load");
+    Expect(
+        failed.diagnostic == ProfileDocumentLoadDiagnostic::TimelineBuildFailed,
+        "timeline failure diagnostic mismatch"
+    );
+    Expect(failed.session_result.HasUsableSession(), "timeline failure lost usable session outcome");
+    Expect(
+        failed.timeline_result.status == TimelineIndexBuildStatus::LimitExceeded,
+        "timeline failure did not report its limit outcome"
+    );
+    Expect(failed.document == last_good, "timeline failure discarded the last-good document");
+    Expect(failed.published_generation == good_generation, "timeline failure changed published generation");
+
+    ProfileDocumentLoadOptions preflight_options;
+    preflight_options.session.limits.max_input_bytes = 1;
+    const std::uint64_t preflight_generation         = loader.RequestLoad(_candidate, preflight_options);
+    const auto          preflight                    = WaitForGeneration(loader, preflight_generation);
+    Expect(preflight.phase == ProfileDocumentLoadPhase::Failed, "input preflight did not fail load");
+    Expect(
+        preflight.session_result.status == SessionLoadStatus::LimitExceeded &&
+            preflight.session_result.limit_kind == SessionLimitKind::InputBytes,
+        "input preflight did not preserve the reader limit outcome"
+    );
+    Expect(
+        preflight.reported_input_bytes == std::filesystem::file_size(_candidate) &&
+            preflight.reported_input_bytes == preflight.session_result.input_bytes,
+        "preflight file size was mislabeled or lost in the loader snapshot"
+    );
+    Expect(preflight.document == last_good, "input preflight discarded the last-good document");
+}
+
+void TestCancelReadyArbitration(const std::filesystem::path& _capture) {
+    ProfileDocumentLoader loader;
+    const std::uint64_t   initial_generation = loader.RequestLoad(_capture);
+    const auto            initial            = WaitForGeneration(loader, initial_generation);
+    ExpectReadyDocument(initial, initial_generation, _capture);
+    auto last_good = initial.document;
+
+    for (std::uint32_t iteration = 0; iteration < 256; ++iteration) {
+        const std::uint64_t generation = loader.RequestLoad(_capture);
+        Expect(generation != 0, "cancel/ready arbitration request was rejected");
+        const bool cancel_won = loader.CancelLatest();
+        const auto terminal   = WaitForGeneration(loader, generation);
+
+        if (cancel_won) {
+            Expect(
+                terminal.phase == ProfileDocumentLoadPhase::Cancelled,
+                "successful CancelLatest raced into Ready"
+            );
+            Expect(
+                terminal.published_generation == last_good->request_generation,
+                "successful cancellation published a new generation"
+            );
+            Expect(terminal.document == last_good, "successful cancellation replaced last-good");
+        } else {
+            Expect(
+                terminal.phase == ProfileDocumentLoadPhase::Ready,
+                "lost CancelLatest race did not observe Ready"
+            );
+            ExpectReadyDocument(terminal, generation, _capture);
+            last_good = terminal.document;
+        }
+    }
+}
+
+void TestRapidNewestWinsAndBoundedPending(
+    const std::filesystem::path& _a,
+    const std::filesystem::path& _b,
+    const std::filesystem::path& _c
+) {
+    ProfileDocumentLoader loader;
+
+    ProfileDocumentLoadOptions slow_options;
+    slow_options.session_control.cancellation_check_interval  = 1;
+    slow_options.timeline_control.cancellation_check_interval = 1;
+
+    const std::uint64_t generation_a = loader.RequestLoad(_a, slow_options);
+    const auto          after_a      = WaitUntilActive(loader, generation_a);
+    Expect(after_a.request_generation == generation_a, "A progress generation mismatch");
+    Expect(after_a.latest_attempt_path == _a, "A progress path mismatch");
+
+    const std::uint64_t generation_b = loader.RequestLoad(_b);
+    const auto          after_b      = loader.Snapshot();
+    Expect(after_b.request_generation == generation_b, "B progress generation mismatch");
+    Expect(after_b.latest_attempt_path == _b, "B progress path mismatch");
+
+    const std::uint64_t generation_c = loader.RequestLoad(_c);
+    const auto          after_c      = loader.Snapshot();
+    Expect(after_c.request_generation == generation_c, "C progress generation mismatch");
+    Expect(after_c.latest_attempt_path == _c, "C progress path mismatch");
+
+    const auto ready_c = WaitForGeneration(loader, generation_c);
+    ExpectReadyDocument(ready_c, generation_c, _c);
+    Expect(
+        ready_c.maximum_pending_request_count_observed == 1, "loader retained more than one pending request"
+    );
+    Expect(ready_c.pending_request_count == 0, "pending request remained after latest completion");
+    Expect(ready_c.superseded_request_count >= 2, "rapid supersession was not accounted");
+
+    // Give any stale active result time to reach its final publication gate.
+    std::this_thread::sleep_for(50ms);
+    const auto stable_c = loader.Snapshot();
+    Expect(stable_c.request_generation == generation_c, "stale result changed latest generation");
+    Expect(stable_c.published_generation == generation_c, "stale result replaced published generation");
+    Expect(stable_c.document == ready_c.document, "stale result replaced newest document");
+}
+
+void TestShutdownClosesAdmissionAndKeepsSnapshot(
+    const std::filesystem::path& _good,
+    const std::filesystem::path& _large
+) {
+    ProfileDocumentLoader loader;
+    const std::uint64_t   generation = loader.RequestLoad(_good);
+    const auto            ready      = WaitForGeneration(loader, generation);
+    const auto            last_good  = ready.document;
+
+    ProfileDocumentLoadOptions options;
+    options.session_control.cancellation_check_interval  = 1;
+    options.timeline_control.cancellation_check_interval = 1;
+    const std::uint64_t in_flight                        = loader.RequestLoad(_large, options);
+    Expect(in_flight != 0, "shutdown fixture request was rejected");
+    static_cast<void>(WaitUntilActive(loader, in_flight));
+
+    loader.Shutdown();
+    loader.Shutdown();
+    const auto shutdown = loader.Snapshot();
+    Expect(shutdown.phase == ProfileDocumentLoadPhase::Shutdown, "loader did not report Shutdown");
+    Expect(!shutdown.accepting_requests, "shutdown loader still accepted requests");
+    Expect(!shutdown.active_request, "shutdown returned before active work joined");
+    Expect(shutdown.pending_request_count == 0, "shutdown retained a pending request");
+    Expect(loader.RequestLoad(_good) == 0, "shutdown loader accepted a new request");
+    Expect(shutdown.document == last_good, "shutdown discarded or replaced last-good document");
+    Expect(last_good->Valid(), "shared last-good snapshot was invalid after shutdown");
+}
+
+} // namespace
+
+int main(int _argc, char** _argv) {
+    try {
+        if (_argc == 2) {
+            const std::filesystem::path capture = _argv[1];
+            ProfileDocumentLoader       loader;
+            const std::uint64_t         generation = loader.RequestLoad(capture);
+            Expect(generation != 0, "external capture request was rejected");
+            const auto ready = WaitForGeneration(loader, generation, 120s);
+            ExpectReadyDocument(ready, generation, capture);
+            std::cout << "Profile document loader external capture passed (cpu_scopes="
+                      << ready.document->session.CpuScopes().size()
+                      << ", gpu_scopes=" << ready.document->session.GpuScopes().size() << ")\n";
+            return 0;
+        }
+        Expect(_argc == 1, "usage: TestProfileDocumentLoader [capture.mpd]");
+
+        ScopedLoaderFixtures fixtures;
+        const auto           capture_a       = fixtures.Path("capture-a-large");
+        const auto           capture_b_large = fixtures.Path("capture-b-large");
+        const auto           capture_b       = fixtures.Path("capture-b");
+        const auto           capture_c       = fixtures.Path("capture-c");
+        const auto           missing         = fixtures.Path("missing");
+
+        WriteCapture(capture_a, "capture-a", 131'072);
+        WriteCapture(capture_b_large, "capture-b-large", 131'072);
+        WriteCapture(capture_b, "capture-b", 32);
+        WriteCapture(capture_c, "capture-c", 48);
+
+        TestSuccessReplacementAndFailurePreservation(capture_b, capture_c, missing);
+        TestCancellationPreservesLastGood(capture_b, capture_a);
+        TestTimelineFailurePreservesLastGood(capture_b, capture_c);
+        TestCancelReadyArbitration(capture_c);
+        TestRapidNewestWinsAndBoundedPending(capture_a, capture_b_large, capture_c);
+        TestShutdownClosesAdmissionAndKeepsSnapshot(capture_b, capture_a);
+
+        std::cout << "Profile document loader contract tests passed\n";
+        return 0;
+    } catch (const std::exception& error) {
+        std::cerr << "Profile document loader contract test failed: " << error.what() << '\n';
+        return 1;
+    }
+}

--- a/source/test/ProfileDumpConsumerTest.cpp
+++ b/source/test/ProfileDumpConsumerTest.cpp
@@ -19,6 +19,7 @@
 #include <stdexcept>
 #include <string>
 #include <string_view>
+#include <thread>
 #include <vector>
 
 namespace {
@@ -36,6 +37,10 @@ static_assert([] {
     std::uint32_t wire_bytes = 0;
     return !Detail::TryPacketWireBytes(std::numeric_limits<std::uint32_t>::max(), wire_bytes);
 }());
+static_assert(
+    SessionLimits{}.max_transient_materialization_bytes >= SessionLimits{}.max_logical_model_bytes,
+    "default transient materialization capacity must cover the retained-model default domain"
+);
 
 void Expect(bool _condition, std::string_view _message) {
     if (!_condition) {
@@ -246,9 +251,10 @@ struct Loaded {
 Loaded LoadChunks(
     std::span<const std::uint8_t> _bytes,
     std::span<const std::size_t>  _pattern = {},
-    const SessionLoadOptions&     _options = {}
+    const SessionLoadOptions&     _options = {},
+    const SessionLoadControl&     _control = {}
 ) {
-    ProfileSessionReader reader(_options);
+    ProfileSessionReader reader(_options, _control);
     std::size_t          offset        = 0;
     std::size_t          pattern_index = 0;
     while (offset < _bytes.size() && reader.Result().status == SessionLoadStatus::Reading) {
@@ -5214,6 +5220,247 @@ void TestReaderPublicationAndAllocatorContracts() {
     );
 }
 
+void ExpectCancelledResult(const SessionLoadResult& _result, std::string_view _context) {
+    Expect(
+        _result.status == SessionLoadStatus::Cancelled && _result.error_code == SessionErrorCode::Cancelled &&
+            _result.incomplete_reason == SessionIncompleteReason::None &&
+            _result.limit_kind == SessionLimitKind::None && _result.codec_status == DecodeStatus::Ok &&
+            _result.error_byte_offset == kInvalidSessionIndex &&
+            _result.error_packet_index == kInvalidSessionIndex &&
+            _result.incomplete_byte_offset == kInvalidSessionIndex &&
+            _result.incomplete_packet_index == kInvalidSessionIndex && _result.IsTerminal() &&
+            !_result.HasUsableSession(),
+        _context
+    );
+}
+
+void TestReaderCooperativeCancellation() {
+    const SessionBuilder golden = MakeGoldenSession();
+
+    {
+        std::stop_source source;
+        source.request_stop();
+        const SessionLoadControl control{
+            .stop_token = source.get_token(),
+        };
+        ProfileSessionReader reader({}, control);
+        ExpectCancelledResult(reader.Result(), "pre-cancelled reader did not start terminal");
+        ExpectCancelledResult(
+            reader.Feed(golden.bytes), "pre-cancelled reader Feed did not preserve sticky cancellation"
+        );
+        ExpectCancelledResult(
+            reader.Finish(), "pre-cancelled reader Finish did not preserve sticky cancellation"
+        );
+        Expect(
+            !reader.Session().Valid() && !reader.TakeSession().Valid(),
+            "pre-cancelled reader published a session"
+        );
+    }
+
+    {
+        std::stop_source         source;
+        const SessionLoadControl control{
+            .stop_token = source.get_token(),
+        };
+        ProfileSessionReader    reader({}, control);
+        const PacketRange&      begin = golden.ranges.front();
+        const SessionLoadResult fed =
+            reader.Feed(std::span<const std::uint8_t>(golden.bytes).first(begin.size));
+        Expect(
+            fed.status == SessionLoadStatus::Reading && fed.packet_count == 1 &&
+                fed.valid_prefix_bytes == begin.size,
+            "reader cancellation fixture did not admit its complete prefix"
+        );
+        source.request_stop();
+        const SessionLoadResult cancelled = reader.Feed({});
+        ExpectCancelledResult(cancelled, "empty Feed did not observe cancellation between chunks");
+        Expect(
+            cancelled.packet_count == 1 && cancelled.valid_prefix_bytes == begin.size &&
+                !reader.Session().Valid(),
+            "between-chunk cancellation damaged the valid-prefix counters or published the model"
+        );
+        ExpectCancelledResult(reader.Finish(), "between-chunk cancellation was not sticky");
+    }
+
+    {
+        const SessionLoadControl control{
+            .max_work_items_before_cancel = static_cast<std::uint64_t>(golden.ranges.size()),
+        };
+        ProfileSessionReader    reader({}, control);
+        const SessionLoadResult fed = reader.Feed(golden.bytes);
+        Expect(
+            fed.status == SessionLoadStatus::Reading && fed.packet_count == golden.ranges.size() &&
+                fed.valid_prefix_bytes == golden.bytes.size(),
+            "deterministic cancellation budget did not admit exactly N packet work items"
+        );
+        ExpectCancelledResult(
+            reader.Feed({}), "deterministic cancellation budget did not stop at the next checkpoint"
+        );
+    }
+
+    {
+        const SessionLoadControl control{
+            .max_work_items_before_cancel = static_cast<std::uint64_t>(golden.ranges.size()) + 1,
+        };
+        ProfileSessionReader    reader({}, control);
+        const SessionLoadResult fed = reader.Feed(golden.bytes);
+        Expect(
+            fed.status == SessionLoadStatus::Reading && fed.packet_count == golden.ranges.size(),
+            "Finish cancellation budget expired during Feed"
+        );
+        ExpectCancelledResult(reader.Finish(), "materialization budget did not cancel Finish");
+        Expect(
+            !reader.Session().Valid() && !reader.TakeSession().Valid(),
+            "cancelled Finish published a partially materialized session"
+        );
+    }
+
+    {
+        SessionLoadOptions options{};
+        options.allow_forensic_truncation = true;
+        const PacketRange& session_end    = golden.ranges.back();
+        const auto         prefix = std::span<const std::uint8_t>(golden.bytes).first(session_end.offset);
+        const SessionLoadControl control{
+            .max_work_items_before_cancel = static_cast<std::uint64_t>(golden.ranges.size()),
+        };
+        ProfileSessionReader    reader(options, control);
+        const SessionLoadResult fed = reader.Feed(prefix);
+        Expect(
+            fed.status == SessionLoadStatus::Reading && fed.packet_count == golden.ranges.size() - 1,
+            "forensic cancellation budget expired during Feed"
+        );
+        ExpectCancelledResult(
+            reader.Finish(), "cancelled forensic materialization was incorrectly exposed as usable"
+        );
+        Expect(!reader.Session().Valid(), "cancelled forensic materialization published a session");
+    }
+
+    {
+        std::stop_source         source;
+        const SessionLoadControl control{
+            .stop_token = source.get_token(),
+        };
+        ProfileSessionReader reader({}, control);
+        const PacketRange&   begin = golden.ranges.front();
+        Expect(
+            reader.Feed(std::span<const std::uint8_t>(golden.bytes).first(begin.size)).status ==
+                SessionLoadStatus::Reading,
+            "reader move cancellation fixture did not admit SessionBegin"
+        );
+        ProfileSessionReader moved(std::move(reader));
+        source.request_stop();
+        ExpectCancelledResult(moved.Feed({}), "moved reader lost its stop-state connection");
+        Expect(
+            reader.Result().status == SessionLoadStatus::ResourceExhausted,
+            "moved-from reader did not retain its documented empty state"
+        );
+    }
+
+    {
+        std::stop_source   source;
+        SessionLoadOptions options{};
+        options.limits.max_packets = 0;
+        const SessionLoadControl control{
+            .stop_token = source.get_token(),
+        };
+        ProfileSessionReader    reader(options, control);
+        const PacketRange&      begin = golden.ranges.front();
+        const SessionLoadResult limited =
+            reader.Feed(std::span<const std::uint8_t>(golden.bytes).first(begin.size));
+        Expect(
+            limited.status == SessionLoadStatus::LimitExceeded &&
+                limited.error_code == SessionErrorCode::LimitExceeded &&
+                limited.limit_kind == SessionLimitKind::Packets,
+            "sticky cancellation fixture did not reach LimitExceeded"
+        );
+        source.request_stop();
+        Expect(
+            reader.Feed({}).status == limited.status && reader.Finish().status == limited.status &&
+                reader.Result().error_code == limited.error_code,
+            "stop request overwrote an existing LimitExceeded terminal state"
+        );
+    }
+
+    {
+        std::vector<std::uint8_t> corrupt(
+            golden.bytes.begin(),
+            golden.bytes.begin() + static_cast<std::ptrdiff_t>(golden.ranges.front().size)
+        );
+        corrupt.back() ^= 0x80;
+        std::stop_source         source;
+        const SessionLoadControl control{
+            .stop_token = source.get_token(),
+        };
+        ProfileSessionReader    reader({}, control);
+        const SessionLoadResult rejected = reader.Feed(corrupt);
+        Expect(
+            rejected.status == SessionLoadStatus::CorruptData &&
+                rejected.error_code == SessionErrorCode::CodecPacketInvalid,
+            "sticky cancellation fixture did not reach CorruptData"
+        );
+        source.request_stop();
+        Expect(
+            reader.Feed({}).status == rejected.status && reader.Finish().status == rejected.status &&
+                reader.Result().error_code == rejected.error_code,
+            "stop request overwrote an existing CorruptData terminal state"
+        );
+    }
+}
+
+void TestConcurrentMidFinishCancellation() {
+    constexpr std::uint64_t kScopeCount = 200'000;
+
+    SessionBuilder builder(101);
+    builder.Begin();
+    builder.Schema(Templates::CpuScope());
+    for (std::uint64_t index = 0; index < kScopeCount; ++index) {
+        AddCpuScope(builder, index + 1, 77, "concurrent-cancel-root", index * 2, index * 2 + 1, 0);
+    }
+    builder.End();
+
+    std::stop_source         stop_source;
+    const SessionLoadControl control{
+        .stop_token                  = stop_source.get_token(),
+        .cancellation_check_interval = 64,
+    };
+    ProfileSessionReader    reader({}, control);
+    const SessionLoadResult fed = reader.Feed(builder.bytes);
+    Expect(
+        fed.status == SessionLoadStatus::Reading && fed.packet_count == builder.ranges.size(),
+        "concurrent cancellation fixture did not reach Finish"
+    );
+
+    std::atomic_bool  finish_started{false};
+    std::atomic_bool  finish_done{false};
+    SessionLoadResult finished{};
+    std::thread       worker([&] {
+        finish_started.store(true, std::memory_order_release);
+        finished = reader.Finish();
+        finish_done.store(true, std::memory_order_release);
+    });
+
+    while (!finish_started.load(std::memory_order_acquire)) {
+        std::this_thread::yield();
+    }
+    std::this_thread::sleep_for(std::chrono::milliseconds(2));
+    const bool request_was_mid_finish = !finish_done.load(std::memory_order_acquire);
+    const auto cancel_begin           = std::chrono::steady_clock::now();
+    stop_source.request_stop();
+    worker.join();
+    const auto cancel_latency = std::chrono::steady_clock::now() - cancel_begin;
+
+    Expect(request_was_mid_finish, "concurrent cancellation fixture completed before request_stop");
+    Expect(
+        cancel_latency < std::chrono::seconds(5),
+        "concurrent Finish cancellation exceeded the bounded-latency test threshold"
+    );
+    ExpectCancelledResult(finished, "concurrent request_stop did not cancel an active Finish");
+    Expect(
+        !reader.Session().Valid() && !reader.TakeSession().Valid(),
+        "concurrent cancellation published a partially materialized session"
+    );
+}
+
 void TestLimitsAndStickyFailure() {
     const SessionBuilder golden   = MakeGoldenSession();
     const Loaded         baseline = LoadChunks(golden.bytes);
@@ -5987,6 +6234,75 @@ void TestFileWrapperAndMoveOwnership() {
             preflight.input_bytes == golden.bytes.size() && moved.Valid() && moved.Summary().generation == 7,
         "file-size preflight did not enforce the exact input limit atomically"
     );
+
+    {
+        std::stop_source source;
+        source.request_stop();
+        const SessionLoadControl control{
+            .stop_token = source.get_token(),
+        };
+        const SessionLoadResult cancelled = LoadProfileSessionFile(valid_path, {}, moved, control);
+        ExpectCancelledResult(cancelled, "file wrapper did not report pre-cancellation");
+        Expect(
+            moved.Valid() && moved.Summary().generation == 7,
+            "pre-cancelled file load replaced the caller's valid output"
+        );
+    }
+
+    {
+        const SessionLoadControl control{
+            .max_work_items_before_cancel = static_cast<std::uint64_t>(golden.ranges.size()) + 1,
+        };
+        const SessionLoadResult cancelled = LoadProfileSessionFile(valid_path, {}, moved, control);
+        ExpectCancelledResult(cancelled, "file wrapper did not cancel Finish materialization");
+        Expect(
+            moved.Valid() && moved.Summary().generation == 7,
+            "Finish-cancelled file load replaced the caller's valid output"
+        );
+    }
+
+    SessionBuilder transient_fixture(99);
+    transient_fixture.Begin();
+    const SchemaDescriptor unknown = UnknownSchema();
+    transient_fixture.Schema(unknown);
+    const std::array<FieldValueView, 2> first_values{
+        std::uint64_t{1},
+        std::string_view("first"),
+    };
+    const std::array<FieldValueView, 2> second_values{
+        std::uint64_t{2},
+        std::string_view("second"),
+    };
+    transient_fixture.Record(unknown, 1, first_values);
+    transient_fixture.Record(unknown, 2, second_values);
+    transient_fixture.End();
+    const std::filesystem::path transient_path = temporary.path / "transient.mpds";
+    WriteBytes(transient_path, transient_fixture.bytes);
+
+    SessionLoadOptions transient_options{};
+    transient_options.limits.max_transient_materialization_bytes = sizeof(std::uint64_t) * 2;
+    const SessionLoadControl single_item_runs{
+        .cancellation_check_interval = 1,
+    };
+    ProfileSession          transient_session;
+    const SessionLoadResult exact_transient =
+        LoadProfileSessionFile(transient_path, transient_options, transient_session, single_item_runs);
+    Expect(
+        exact_transient.status == SessionLoadStatus::Complete && transient_session.Valid() &&
+            transient_session.Summary().generation == 99,
+        "exact transient materialization byte limit was rejected"
+    );
+
+    --transient_options.limits.max_transient_materialization_bytes;
+    const SessionLoadResult short_transient =
+        LoadProfileSessionFile(transient_path, transient_options, moved, single_item_runs);
+    Expect(
+        short_transient.status == SessionLoadStatus::LimitExceeded &&
+            short_transient.error_code == SessionErrorCode::LimitExceeded &&
+            short_transient.limit_kind == SessionLimitKind::TransientMaterializationBytes && moved.Valid() &&
+            moved.Summary().generation == 7,
+        "transient materialization byte limit was not enforced atomically"
+    );
 }
 
 void TestProducerToConsumerUnnotifiedDrop() {
@@ -6074,6 +6390,8 @@ int main() {
         TestSemanticTopologyAndLossRecovery();
         TestGpuProducerSequenceProofs();
         TestReaderPublicationAndAllocatorContracts();
+        TestReaderCooperativeCancellation();
+        TestConcurrentMidFinishCancellation();
         TestLimitsAndStickyFailure();
         TestFileWrapperAndMoveOwnership();
         TestProducerToConsumerUnnotifiedDrop();

--- a/source/test/ProfileSummaryCliTest.cpp
+++ b/source/test/ProfileSummaryCliTest.cpp
@@ -50,6 +50,7 @@ static_assert(ProfileSummaryExitCode(SessionLoadStatus::OpenFailed) == 11);
 static_assert(ProfileSummaryExitCode(SessionLoadStatus::ProtocolViolation) == 12);
 static_assert(ProfileSummaryExitCode(SessionLoadStatus::LimitExceeded) == 13);
 static_assert(ProfileSummaryExitCode(SessionLoadStatus::ResourceExhausted) == 14);
+static_assert(ProfileSummaryExitCode(SessionLoadStatus::Cancelled) == 15);
 
 void Expect(bool _condition, std::string_view _message) {
     if (!_condition) {

--- a/source/tool/profile_consumer/app/ProfileSummaryMain.cpp
+++ b/source/tool/profile_consumer/app/ProfileSummaryMain.cpp
@@ -38,6 +38,8 @@ using Json = nlohmann::ordered_json;
             return "limit_exceeded";
         case SessionLoadStatus::ResourceExhausted:
             return "resource_exhausted";
+        case SessionLoadStatus::Cancelled:
+            return "cancelled";
     }
     return "unknown";
 }
@@ -144,6 +146,8 @@ using Json = nlohmann::ordered_json;
             return "gpu_scope_parent_invalid";
         case SessionErrorCode::CpuScopeTopologyInvalid:
             return "cpu_scope_topology_invalid";
+        case SessionErrorCode::Cancelled:
+            return "cancelled";
     }
     return "unknown";
 }
@@ -222,6 +226,8 @@ using Json = nlohmann::ordered_json;
             return "topology_work_items";
         case SessionLimitKind::TopologyFlowEdges:
             return "topology_flow_edges";
+        case SessionLimitKind::TransientMaterializationBytes:
+            return "transient_materialization_bytes";
     }
     return "unknown";
 }

--- a/source/tool/profile_consumer/include/profile_consumer/ProfileDocument.h
+++ b/source/tool/profile_consumer/include/profile_consumer/ProfileDocument.h
@@ -1,0 +1,147 @@
+#ifndef MOER_ENGINE_PROFILE_DOCUMENT_H
+#define MOER_ENGINE_PROFILE_DOCUMENT_H
+
+#include "profile_consumer/ProfileSession.h"
+#include "profile_consumer/ProfileTimelineIndex.h"
+
+#include <cstdint>
+#include <filesystem>
+#include <memory>
+
+namespace Moer::ProfileDump {
+
+inline constexpr std::uint64_t kInvalidProfileDocumentGeneration = 0;
+
+// One immutable, self-contained publication unit. Field order is intentional:
+// timeline_index is destroyed before session, whose immutable model it indexes.
+struct ProfileDocument final {
+    std::filesystem::path source_path{};
+    std::uint64_t         request_generation{kInvalidProfileDocumentGeneration};
+    SessionLoadResult     load_result{};
+    ProfileSession        session{};
+    ProfileTimelineIndex  timeline_index{};
+
+    ProfileDocument(
+        std::filesystem::path _source_path,
+        std::uint64_t         _request_generation,
+        SessionLoadResult     _load_result,
+        ProfileSession        _session,
+        ProfileTimelineIndex  _timeline_index
+    ) noexcept;
+
+    ProfileDocument(const ProfileDocument&)            = delete;
+    ProfileDocument& operator=(const ProfileDocument&) = delete;
+    ProfileDocument(ProfileDocument&&)                 = delete;
+    ProfileDocument& operator=(ProfileDocument&&)      = delete;
+
+    [[nodiscard]] bool Valid() const noexcept;
+};
+
+enum class ProfileDocumentLoadPhase : std::uint8_t {
+    Idle = 0,
+    Opening,
+    Reading,
+    // Reserved for a future reader progress hook. The current whole-file API
+    // materializes during Reading, so the loader does not invent this phase.
+    MaterializingSession,
+    BuildingTimeline,
+    Ready,
+    Failed,
+    Cancelled,
+    Shutdown,
+};
+
+enum class ProfileDocumentLoadDiagnostic : std::uint8_t {
+    None = 0,
+    WorkerUnavailable,
+    Cancelled,
+    SessionLoadFailed,
+    TimelineBuildFailed,
+    DocumentAllocationFailed,
+};
+
+struct ProfileDocumentLoadOptions {
+    SessionLoadOptions        session{};
+    TimelineIndexLimits       timeline_limits{};
+    SessionLoadControl        session_control{};
+    TimelineIndexBuildControl timeline_control{};
+};
+
+struct ProfileDocumentLoaderSnapshot {
+    // Every progress/result field in this snapshot belongs to this generation.
+    // The last-good document may intentionally have an older generation after
+    // the latest attempt fails, is cancelled, or is still in progress.
+    std::uint64_t            request_generation{kInvalidProfileDocumentGeneration};
+    ProfileDocumentLoadPhase phase{ProfileDocumentLoadPhase::Idle};
+    std::filesystem::path    latest_attempt_path{};
+
+    // observed_total_bytes is a best-effort filesystem metadata observation
+    // made before the synchronous reader starts; it is not the reader's
+    // internal file-size snapshot. The reader currently has no streaming
+    // progress callback: while Reading, reported_input_bytes remains zero and
+    // reported_input_bytes_final is false. Once terminal, this is the exact
+    // SessionLoadResult::input_bytes field; for a file-size preflight rejection
+    // it therefore reports the snapshotted size, not bytes physically read.
+    // Consumers must render Reading as indeterminate rather than deriving a
+    // percentage from the observation.
+    bool          observed_total_bytes_available{false};
+    std::uint64_t observed_total_bytes{0};
+    std::uint64_t reported_input_bytes{0};
+    bool          reported_input_bytes_final{false};
+
+    // Worker/admission lifecycle only. Generation exhaustion is reported
+    // separately and never cancels an already accepted maximum generation.
+    bool          accepting_requests{false};
+    bool          generation_exhausted{false};
+    bool          cancel_requested{false};
+    bool          active_request{false};
+    std::uint64_t active_generation{kInvalidProfileDocumentGeneration};
+    std::uint32_t pending_request_count{0};
+    std::uint32_t maximum_pending_request_count_observed{0};
+    std::uint64_t superseded_request_count{0};
+
+    SessionLoadResult             session_result{};
+    TimelineIndexBuildResult      timeline_result{};
+    ProfileDocumentLoadDiagnostic diagnostic{ProfileDocumentLoadDiagnostic::None};
+
+    std::uint64_t                          published_generation{kInvalidProfileDocumentGeneration};
+    std::shared_ptr<const ProfileDocument> document{};
+};
+
+// A bounded latest-request-wins loader. It owns one persistent worker thread,
+// at most one pending request, and one active request. Publication and all
+// status fields are copied under the same mutex by Snapshot().
+class ProfileDocumentLoader final {
+public:
+    ProfileDocumentLoader() noexcept;
+    ~ProfileDocumentLoader();
+
+    ProfileDocumentLoader(const ProfileDocumentLoader&)            = delete;
+    ProfileDocumentLoader& operator=(const ProfileDocumentLoader&) = delete;
+    ProfileDocumentLoader(ProfileDocumentLoader&&)                 = delete;
+    ProfileDocumentLoader& operator=(ProfileDocumentLoader&&)      = delete;
+
+    // Returns zero after admission has closed or generation space is exhausted.
+    // A newer accepted request cooperatively cancels active work and replaces
+    // the single pending slot.
+    [[nodiscard]] std::uint64_t
+    RequestLoad(const std::filesystem::path& _path, const ProfileDocumentLoadOptions& _options = {});
+
+    // Requests cancellation of the latest non-terminal attempt. Cancellation
+    // never clears or mutates the last successfully published document.
+    [[nodiscard]] bool CancelLatest() noexcept;
+
+    [[nodiscard]] ProfileDocumentLoaderSnapshot Snapshot() const;
+
+    // Idempotent. Admission closes before pending/active work is cancelled.
+    // The worker is joined without holding the state mutex.
+    void Shutdown() noexcept;
+
+private:
+    struct Impl;
+    std::unique_ptr<Impl> impl_{};
+};
+
+} // namespace Moer::ProfileDump
+
+#endif // MOER_ENGINE_PROFILE_DOCUMENT_H

--- a/source/tool/profile_consumer/include/profile_consumer/ProfileSession.h
+++ b/source/tool/profile_consumer/include/profile_consumer/ProfileSession.h
@@ -7,6 +7,7 @@
 #include <filesystem>
 #include <limits>
 #include <span>
+#include <stop_token>
 #include <string_view>
 #include <type_traits>
 
@@ -49,6 +50,7 @@ enum class SessionLoadStatus : std::uint8_t {
     ProtocolViolation,
     LimitExceeded,
     ResourceExhausted,
+    Cancelled,
 };
 
 enum class SessionIncompleteReason : std::uint8_t {
@@ -104,6 +106,7 @@ enum class SessionErrorCode : std::uint16_t {
     GpuScopeParentMissing,
     GpuScopeParentInvalid,
     CpuScopeTopologyInvalid,
+    Cancelled,
 };
 
 enum class SessionLimitKind : std::uint8_t {
@@ -127,6 +130,7 @@ enum class SessionLimitKind : std::uint8_t {
     ScopeDepth,
     TopologyWorkItems,
     TopologyFlowEdges,
+    TransientMaterializationBytes,
 };
 
 enum class KnownProfileSchema : std::uint8_t {
@@ -191,6 +195,9 @@ struct SessionLimits {
     // guarantee. Transient decode/index storage remains bounded by the count
     // and codec limits above.
     std::uint64_t max_logical_model_bytes{1024ull * 1024 * 1024};
+    // Peak scratch payload admitted by one cancellable materialization sort.
+    // This is independent of retained logical_model_bytes.
+    std::uint64_t max_transient_materialization_bytes{1024ull * 1024 * 1024};
 };
 
 struct SessionLoadOptions {
@@ -199,6 +206,23 @@ struct SessionLoadOptions {
     // Only a clean prefix ending at the last complete packet may be exposed.
     // CRC, schema, protocol, and semantic failures are never downgraded.
     bool allow_forensic_truncation{false};
+};
+
+struct SessionLoadControl {
+    std::stop_token stop_token{};
+    // Linear decode/materialization loops sample cancellation at this
+    // interval. Potentially large sorts are split into bounded runs no larger
+    // than this interval (and an internal responsiveness cap), with
+    // cancellable merge passes. Zero is normalized to one. Decoding and
+    // processing one complete packet is an atomic, non-interruptible boundary;
+    // the default CodecLimits cap its payload at 1 MiB, while raising that
+    // limit also raises the worst-case cancellation tail latency.
+    std::uint64_t cancellation_check_interval{4096};
+    // Optional deterministic cooperative budget. Exactly N charged work
+    // items are admitted; cancellation occurs before the first item that
+    // would exceed N, or at the next zero-work checkpoint after exhaustion.
+    // Cancellation follows the same no-publication contract as stop_token.
+    std::uint64_t max_work_items_before_cancel{std::numeric_limits<std::uint64_t>::max()};
 };
 
 struct SessionLoadResult {
@@ -413,6 +437,7 @@ private:
 class ProfileSessionReader final {
 public:
     explicit ProfileSessionReader(const SessionLoadOptions& _options = {}) noexcept;
+    ProfileSessionReader(const SessionLoadOptions& _options, const SessionLoadControl& _control) noexcept;
     ~ProfileSessionReader();
 
     ProfileSessionReader(const ProfileSessionReader&)            = delete;
@@ -443,6 +468,13 @@ private:
     const std::filesystem::path& _path,
     const SessionLoadOptions&    _options,
     ProfileSession&              _output
+) noexcept;
+
+[[nodiscard]] SessionLoadResult LoadProfileSessionFile(
+    const std::filesystem::path& _path,
+    const SessionLoadOptions&    _options,
+    ProfileSession&              _output,
+    const SessionLoadControl&    _control
 ) noexcept;
 
 } // namespace Moer::ProfileDump

--- a/source/tool/profile_consumer/include/profile_consumer/ProfileSummaryContract.h
+++ b/source/tool/profile_consumer/include/profile_consumer/ProfileSummaryContract.h
@@ -46,6 +46,8 @@ inline constexpr std::string_view kProfileSummaryUnexpectedFailureJson{
             return 13;
         case SessionLoadStatus::ResourceExhausted:
             return 14;
+        case SessionLoadStatus::Cancelled:
+            return 15;
     }
     return 12;
 }

--- a/source/tool/profile_consumer/include/profile_consumer/ProfileTimelineIndex.h
+++ b/source/tool/profile_consumer/include/profile_consumer/ProfileTimelineIndex.h
@@ -85,9 +85,10 @@ struct TimelineIndexBuildControl {
     // Allocator and standard-library work inside one bounded run cannot be
     // interrupted. Zero is normalized to one.
     std::uint64_t cancellation_check_interval{4096};
-    // Optional deterministic cooperative budget. Exhaustion is reported as
-    // Cancelled and follows the same atomic-output contract as stop_token.
-    // This can cap background work even when the caller has no timer thread.
+    // Optional deterministic cooperative budget. Exactly this many charged
+    // work items may run; the next checkpoint reports Cancelled and follows
+    // the same atomic-output contract as stop_token. This can cap background
+    // work even when the caller has no timer thread.
     std::uint64_t max_work_items_before_cancel{std::numeric_limits<std::uint64_t>::max()};
 };
 

--- a/source/tool/profile_consumer/source/ProfileDocument.cpp
+++ b/source/tool/profile_consumer/source/ProfileDocument.cpp
@@ -1,0 +1,545 @@
+#include "profile_consumer/ProfileDocument.h"
+
+#include <condition_variable>
+#include <limits>
+#include <mutex>
+#include <new>
+#include <optional>
+#include <stop_token>
+#include <thread>
+#include <utility>
+
+namespace Moer::ProfileDump {
+
+ProfileDocument::ProfileDocument(
+    std::filesystem::path _source_path,
+    std::uint64_t         _request_generation,
+    SessionLoadResult     _load_result,
+    ProfileSession        _session,
+    ProfileTimelineIndex  _timeline_index
+) noexcept :
+    source_path(std::move(_source_path)),
+    request_generation(_request_generation),
+    load_result(_load_result),
+    session(std::move(_session)),
+    timeline_index(std::move(_timeline_index)) {}
+
+bool ProfileDocument::Valid() const noexcept {
+    return request_generation != kInvalidProfileDocumentGeneration && load_result.HasUsableSession() &&
+           session.Valid() && timeline_index.Valid() && timeline_index.Matches(session);
+}
+
+struct ProfileDocumentLoader::Impl final {
+    struct Request {
+        std::filesystem::path      path{};
+        ProfileDocumentLoadOptions options{};
+        std::uint64_t              generation{kInvalidProfileDocumentGeneration};
+    };
+
+    mutable std::mutex            mutex{};
+    std::mutex                    shutdown_mutex{};
+    std::condition_variable       work_available{};
+    std::optional<Request>        pending{};
+    std::stop_source              active_stop{};
+    bool                          active{false};
+    bool                          accepting{true};
+    std::uint64_t                 next_generation{kInvalidProfileDocumentGeneration};
+    ProfileDocumentLoaderSnapshot snapshot{};
+    std::jthread                  worker{};
+
+    Impl() {
+        snapshot.accepting_requests = true;
+        try {
+            worker = std::jthread([this](std::stop_token _worker_stop) noexcept {
+                WorkerMain(_worker_stop);
+            });
+        } catch (...) {
+            accepting                   = false;
+            snapshot.accepting_requests = false;
+            snapshot.phase              = ProfileDocumentLoadPhase::Failed;
+            snapshot.diagnostic         = ProfileDocumentLoadDiagnostic::WorkerUnavailable;
+        }
+    }
+
+    ~Impl() {
+        Shutdown();
+    }
+
+    void UpdatePendingCountLocked() noexcept {
+        snapshot.pending_request_count = pending.has_value() ? 1u : 0u;
+        if (snapshot.pending_request_count > snapshot.maximum_pending_request_count_observed) {
+            snapshot.maximum_pending_request_count_observed = snapshot.pending_request_count;
+        }
+    }
+
+    [[nodiscard]] bool IsLatestLocked(std::uint64_t _generation) const noexcept {
+        return accepting && snapshot.request_generation == _generation;
+    }
+
+    [[nodiscard]] static bool IsTerminalPhase(ProfileDocumentLoadPhase _phase) noexcept {
+        return _phase == ProfileDocumentLoadPhase::Ready || _phase == ProfileDocumentLoadPhase::Failed ||
+               _phase == ProfileDocumentLoadPhase::Cancelled || _phase == ProfileDocumentLoadPhase::Shutdown;
+    }
+
+    void CompleteActiveGenerationLocked(std::uint64_t _generation) noexcept {
+        if (snapshot.active_generation != _generation) {
+            return;
+        }
+        active                     = false;
+        snapshot.active_request    = false;
+        snapshot.active_generation = kInvalidProfileDocumentGeneration;
+    }
+
+    [[nodiscard]] bool CompleteCancellationIfRequestedLocked(
+        std::stop_token                 _request_stop,
+        const SessionLoadResult&        _session_result,
+        const TimelineIndexBuildResult& _timeline_result
+    ) noexcept {
+        if (!snapshot.cancel_requested && !_request_stop.stop_requested()) {
+            return false;
+        }
+        snapshot.phase                      = ProfileDocumentLoadPhase::Cancelled;
+        snapshot.session_result             = _session_result;
+        snapshot.timeline_result            = _timeline_result;
+        snapshot.reported_input_bytes       = _session_result.input_bytes;
+        snapshot.reported_input_bytes_final = true;
+        snapshot.diagnostic                 = ProfileDocumentLoadDiagnostic::Cancelled;
+        return true;
+    }
+
+    void BeginRequestLocked(std::uint64_t _generation, std::filesystem::path _latest_attempt_path) noexcept {
+        snapshot.request_generation             = _generation;
+        snapshot.phase                          = ProfileDocumentLoadPhase::Opening;
+        snapshot.latest_attempt_path            = std::move(_latest_attempt_path);
+        snapshot.observed_total_bytes_available = false;
+        snapshot.observed_total_bytes           = 0;
+        snapshot.reported_input_bytes           = 0;
+        snapshot.reported_input_bytes_final     = false;
+        snapshot.cancel_requested               = false;
+        snapshot.session_result                 = {};
+        snapshot.timeline_result                = {};
+        snapshot.diagnostic                     = ProfileDocumentLoadDiagnostic::None;
+    }
+
+    void PublishOpeningSnapshot(
+        const Request& _request,
+        bool           _total_available,
+        std::uint64_t  _total_bytes
+    ) noexcept {
+        std::lock_guard lock(mutex);
+        if (!IsLatestLocked(_request.generation)) {
+            return;
+        }
+        snapshot.phase                          = ProfileDocumentLoadPhase::Opening;
+        snapshot.observed_total_bytes_available = _total_available;
+        snapshot.observed_total_bytes           = _total_available ? _total_bytes : 0;
+    }
+
+    void PublishReadingSnapshot(const Request& _request) noexcept {
+        std::lock_guard lock(mutex);
+        if (!IsLatestLocked(_request.generation)) {
+            return;
+        }
+        snapshot.phase                      = ProfileDocumentLoadPhase::Reading;
+        snapshot.reported_input_bytes       = 0;
+        snapshot.reported_input_bytes_final = false;
+    }
+
+    void PublishSessionResult(const Request& _request, const SessionLoadResult& _result) noexcept {
+        std::lock_guard lock(mutex);
+        if (!IsLatestLocked(_request.generation)) {
+            return;
+        }
+        snapshot.session_result             = _result;
+        snapshot.reported_input_bytes       = _result.input_bytes;
+        snapshot.reported_input_bytes_final = true;
+        if (_result.HasUsableSession()) {
+            snapshot.phase = ProfileDocumentLoadPhase::BuildingTimeline;
+        }
+    }
+
+    void CompleteCancelled(
+        const Request&                  _request,
+        const SessionLoadResult&        _session_result,
+        const TimelineIndexBuildResult& _timeline_result
+    ) noexcept {
+        std::lock_guard lock(mutex);
+        if (!IsLatestLocked(_request.generation)) {
+            return;
+        }
+        snapshot.phase                      = ProfileDocumentLoadPhase::Cancelled;
+        snapshot.session_result             = _session_result;
+        snapshot.timeline_result            = _timeline_result;
+        snapshot.reported_input_bytes       = _session_result.input_bytes;
+        snapshot.reported_input_bytes_final = true;
+        snapshot.diagnostic                 = ProfileDocumentLoadDiagnostic::Cancelled;
+        CompleteActiveGenerationLocked(_request.generation);
+    }
+
+    void CompleteFailed(
+        const Request&                  _request,
+        const SessionLoadResult&        _session_result,
+        const TimelineIndexBuildResult& _timeline_result,
+        std::stop_token                 _request_stop
+    ) noexcept {
+        std::lock_guard lock(mutex);
+        if (!IsLatestLocked(_request.generation)) {
+            return;
+        }
+        if (CompleteCancellationIfRequestedLocked(_request_stop, _session_result, _timeline_result)) {
+            CompleteActiveGenerationLocked(_request.generation);
+            return;
+        }
+        snapshot.phase                      = ProfileDocumentLoadPhase::Failed;
+        snapshot.session_result             = _session_result;
+        snapshot.timeline_result            = _timeline_result;
+        snapshot.reported_input_bytes       = _session_result.input_bytes;
+        snapshot.reported_input_bytes_final = true;
+        snapshot.diagnostic                 = _session_result.HasUsableSession() ?
+                                                  ProfileDocumentLoadDiagnostic::TimelineBuildFailed :
+                                                  ProfileDocumentLoadDiagnostic::SessionLoadFailed;
+        CompleteActiveGenerationLocked(_request.generation);
+    }
+
+    void CompleteUnexpectedFailure(
+        const Request&                  _request,
+        const SessionLoadResult&        _session_result,
+        const TimelineIndexBuildResult& _timeline_result,
+        std::stop_token                 _request_stop
+    ) noexcept {
+        std::lock_guard lock(mutex);
+        if (!IsLatestLocked(_request.generation)) {
+            return;
+        }
+        if (CompleteCancellationIfRequestedLocked(_request_stop, _session_result, _timeline_result)) {
+            CompleteActiveGenerationLocked(_request.generation);
+            return;
+        }
+        snapshot.phase                      = ProfileDocumentLoadPhase::Failed;
+        snapshot.session_result             = _session_result;
+        snapshot.timeline_result            = _timeline_result;
+        snapshot.reported_input_bytes       = _session_result.input_bytes;
+        snapshot.reported_input_bytes_final = true;
+        snapshot.diagnostic                 = ProfileDocumentLoadDiagnostic::DocumentAllocationFailed;
+        CompleteActiveGenerationLocked(_request.generation);
+    }
+
+    void CompleteReady(
+        const Request&                         _request,
+        const SessionLoadResult&               _session_result,
+        const TimelineIndexBuildResult&        _timeline_result,
+        std::shared_ptr<const ProfileDocument> _document,
+        std::stop_token                        _request_stop
+    ) noexcept {
+        std::shared_ptr<const ProfileDocument> retired_document;
+        {
+            std::lock_guard lock(mutex);
+            if (!IsLatestLocked(_request.generation)) {
+                return;
+            }
+            if (CompleteCancellationIfRequestedLocked(_request_stop, _session_result, _timeline_result)) {
+                CompleteActiveGenerationLocked(_request.generation);
+                return;
+            }
+            snapshot.phase                      = ProfileDocumentLoadPhase::Ready;
+            snapshot.session_result             = _session_result;
+            snapshot.timeline_result            = _timeline_result;
+            snapshot.reported_input_bytes       = _session_result.input_bytes;
+            snapshot.reported_input_bytes_final = true;
+            snapshot.cancel_requested           = false;
+            snapshot.published_generation       = _request.generation;
+            // Publication is O(1) under the state mutex. The previous owning
+            // document is released after new coherent snapshots are visible.
+            retired_document    = std::exchange(snapshot.document, std::move(_document));
+            snapshot.diagnostic = ProfileDocumentLoadDiagnostic::None;
+            CompleteActiveGenerationLocked(_request.generation);
+        }
+    }
+
+    void
+    ProcessRequest(const Request& _request, std::stop_source _request_stop, std::stop_token _worker_stop) {
+        const auto forward_stop = [&_request_stop]() noexcept {
+            static_cast<void>(_request_stop.request_stop());
+        };
+        std::stop_callback worker_callback(_worker_stop, forward_stop);
+        std::stop_callback session_callback(_request.options.session_control.stop_token, forward_stop);
+        std::stop_callback timeline_callback(_request.options.timeline_control.stop_token, forward_stop);
+
+        if (_request_stop.stop_requested()) {
+            SessionLoadResult cancelled;
+            cancelled.status     = SessionLoadStatus::Cancelled;
+            cancelled.error_code = SessionErrorCode::Cancelled;
+            CompleteCancelled(_request, cancelled, {});
+            return;
+        }
+
+        std::error_code      file_size_error;
+        const std::uintmax_t file_size = std::filesystem::file_size(_request.path, file_size_error);
+        const bool           total_available =
+            !file_size_error &&
+            file_size <= static_cast<std::uintmax_t>(std::numeric_limits<std::uint64_t>::max());
+        PublishOpeningSnapshot(
+            _request, total_available, total_available ? static_cast<std::uint64_t>(file_size) : 0
+        );
+
+        PublishReadingSnapshot(_request);
+
+        ProfileSession session;
+        auto           session_control = _request.options.session_control;
+        session_control.stop_token     = _request_stop.get_token();
+        const SessionLoadResult session_result =
+            LoadProfileSessionFile(_request.path, _request.options.session, session, session_control);
+        PublishSessionResult(_request, session_result);
+
+        if (session_result.status == SessionLoadStatus::Cancelled || _request_stop.stop_requested()) {
+            auto cancelled_result = session_result;
+            if (cancelled_result.status != SessionLoadStatus::Cancelled) {
+                cancelled_result.status     = SessionLoadStatus::Cancelled;
+                cancelled_result.error_code = SessionErrorCode::Cancelled;
+            }
+            CompleteCancelled(_request, cancelled_result, {});
+            return;
+        }
+        if (!session_result.HasUsableSession()) {
+            CompleteFailed(_request, session_result, {}, _request_stop.get_token());
+            return;
+        }
+
+        ProfileTimelineIndex timeline_index;
+        auto                 timeline_control          = _request.options.timeline_control;
+        timeline_control.stop_token                    = _request_stop.get_token();
+        const TimelineIndexBuildResult timeline_result = BuildProfileTimelineIndex(
+            session, session_result, _request.options.timeline_limits, timeline_index, timeline_control
+        );
+
+        if (timeline_result.status == TimelineIndexBuildStatus::Cancelled || _request_stop.stop_requested()) {
+            CompleteCancelled(_request, session_result, timeline_result);
+            return;
+        }
+        if (!timeline_result.Succeeded()) {
+            CompleteFailed(_request, session_result, timeline_result, _request_stop.get_token());
+            return;
+        }
+
+        try {
+            auto document = std::make_shared<const ProfileDocument>(
+                _request.path,
+                _request.generation,
+                session_result,
+                std::move(session),
+                std::move(timeline_index)
+            );
+            CompleteReady(
+                _request, session_result, timeline_result, std::move(document), _request_stop.get_token()
+            );
+        } catch (...) {
+            CompleteUnexpectedFailure(_request, session_result, timeline_result, _request_stop.get_token());
+        }
+    }
+
+    void WorkerMainImpl(std::stop_token _worker_stop) {
+        for (;;) {
+            Request          request;
+            std::stop_source request_stop;
+            {
+                std::unique_lock lock(mutex);
+                work_available.wait(lock, [this, _worker_stop]() noexcept {
+                    return _worker_stop.stop_requested() || !accepting || pending.has_value();
+                });
+                if (_worker_stop.stop_requested() || !accepting) {
+                    active                     = false;
+                    snapshot.active_request    = false;
+                    snapshot.active_generation = kInvalidProfileDocumentGeneration;
+                    return;
+                }
+
+                request = std::move(*pending);
+                pending.reset();
+                UpdatePendingCountLocked();
+
+                active_stop                = request_stop;
+                active                     = true;
+                snapshot.active_request    = true;
+                snapshot.active_generation = request.generation;
+                if (snapshot.request_generation == request.generation) {
+                    snapshot.phase = ProfileDocumentLoadPhase::Opening;
+                }
+            }
+
+            ProcessRequest(request, request_stop, _worker_stop);
+
+            {
+                std::lock_guard lock(mutex);
+                if (snapshot.active_generation == request.generation) {
+                    active                     = false;
+                    snapshot.active_request    = false;
+                    snapshot.active_generation = kInvalidProfileDocumentGeneration;
+                }
+            }
+        }
+    }
+
+    void WorkerMain(std::stop_token _worker_stop) noexcept {
+        try {
+            WorkerMainImpl(_worker_stop);
+        } catch (...) {
+            // A worker-control allocation or wait failure must not escape the
+            // jthread entry point. Preserve the last-good document and close
+            // admission because this worker can no longer service requests.
+            try {
+                std::lock_guard lock(mutex);
+                if (!accepting) {
+                    return;
+                }
+                accepting                           = false;
+                snapshot.accepting_requests         = false;
+                snapshot.phase                      = ProfileDocumentLoadPhase::Failed;
+                snapshot.session_result             = {};
+                snapshot.session_result.status      = SessionLoadStatus::ResourceExhausted;
+                snapshot.session_result.error_code  = SessionErrorCode::ResourceAllocationFailed;
+                snapshot.timeline_result            = {};
+                snapshot.reported_input_bytes       = 0;
+                snapshot.reported_input_bytes_final = true;
+                snapshot.cancel_requested           = false;
+                snapshot.diagnostic                 = ProfileDocumentLoadDiagnostic::WorkerUnavailable;
+                pending.reset();
+                UpdatePendingCountLocked();
+                static_cast<void>(active_stop.request_stop());
+                active                     = false;
+                snapshot.active_request    = false;
+                snapshot.active_generation = kInvalidProfileDocumentGeneration;
+            } catch (...) {
+            }
+        }
+    }
+
+    void Shutdown() noexcept {
+        std::lock_guard shutdown_lock(shutdown_mutex);
+        {
+            std::lock_guard lock(mutex);
+            accepting                   = false;
+            snapshot.accepting_requests = false;
+            snapshot.phase              = ProfileDocumentLoadPhase::Shutdown;
+            pending.reset();
+            UpdatePendingCountLocked();
+            static_cast<void>(active_stop.request_stop());
+            if (worker.joinable()) {
+                worker.request_stop();
+            }
+        }
+        work_available.notify_all();
+        if (worker.joinable()) {
+            worker.join();
+        }
+        {
+            std::lock_guard lock(mutex);
+            active                     = false;
+            snapshot.active_request    = false;
+            snapshot.active_generation = kInvalidProfileDocumentGeneration;
+            snapshot.phase             = ProfileDocumentLoadPhase::Shutdown;
+        }
+    }
+};
+
+ProfileDocumentLoader::ProfileDocumentLoader() noexcept {
+    try {
+        impl_ = std::make_unique<Impl>();
+    } catch (...) {
+        impl_.reset();
+    }
+}
+
+ProfileDocumentLoader::~ProfileDocumentLoader() {
+    Shutdown();
+}
+
+std::uint64_t ProfileDocumentLoader::RequestLoad(
+    const std::filesystem::path&      _path,
+    const ProfileDocumentLoadOptions& _options
+) {
+    if (impl_ == nullptr) {
+        return kInvalidProfileDocumentGeneration;
+    }
+
+    Impl::Request request{
+        .path    = _path,
+        .options = _options,
+    };
+    std::filesystem::path latest_attempt_path = _path;
+
+    std::lock_guard lock(impl_->mutex);
+    if (!impl_->accepting) {
+        return kInvalidProfileDocumentGeneration;
+    }
+    if (impl_->next_generation == std::numeric_limits<std::uint64_t>::max()) {
+        impl_->snapshot.generation_exhausted = true;
+        return kInvalidProfileDocumentGeneration;
+    }
+
+    request.generation = impl_->next_generation + 1;
+    if (impl_->active || impl_->pending.has_value()) {
+        ++impl_->snapshot.superseded_request_count;
+    }
+    if (impl_->active) {
+        static_cast<void>(impl_->active_stop.request_stop());
+    }
+    impl_->pending         = std::move(request);
+    impl_->next_generation = impl_->pending->generation;
+    impl_->BeginRequestLocked(impl_->pending->generation, std::move(latest_attempt_path));
+    impl_->UpdatePendingCountLocked();
+    const std::uint64_t generation = impl_->next_generation;
+    impl_->work_available.notify_one();
+    return generation;
+}
+
+bool ProfileDocumentLoader::CancelLatest() noexcept {
+    if (impl_ == nullptr) {
+        return false;
+    }
+
+    std::lock_guard lock(impl_->mutex);
+    if (!impl_->accepting || impl_->snapshot.request_generation == kInvalidProfileDocumentGeneration) {
+        return false;
+    }
+
+    const std::uint64_t generation = impl_->snapshot.request_generation;
+    if (Impl::IsTerminalPhase(impl_->snapshot.phase)) {
+        return false;
+    }
+    if (impl_->pending.has_value() && impl_->pending->generation == generation) {
+        impl_->pending.reset();
+        impl_->UpdatePendingCountLocked();
+        impl_->snapshot.phase                      = ProfileDocumentLoadPhase::Cancelled;
+        impl_->snapshot.cancel_requested           = true;
+        impl_->snapshot.reported_input_bytes_final = true;
+        impl_->snapshot.session_result.status      = SessionLoadStatus::Cancelled;
+        impl_->snapshot.session_result.error_code  = SessionErrorCode::Cancelled;
+        impl_->snapshot.diagnostic                 = ProfileDocumentLoadDiagnostic::Cancelled;
+        return true;
+    }
+    if (impl_->active && impl_->snapshot.active_generation == generation) {
+        impl_->snapshot.cancel_requested = true;
+        static_cast<void>(impl_->active_stop.request_stop());
+        return true;
+    }
+    return false;
+}
+
+ProfileDocumentLoaderSnapshot ProfileDocumentLoader::Snapshot() const {
+    if (impl_ == nullptr) {
+        ProfileDocumentLoaderSnapshot unavailable;
+        unavailable.phase      = ProfileDocumentLoadPhase::Failed;
+        unavailable.diagnostic = ProfileDocumentLoadDiagnostic::WorkerUnavailable;
+        return unavailable;
+    }
+    std::lock_guard lock(impl_->mutex);
+    return impl_->snapshot;
+}
+
+void ProfileDocumentLoader::Shutdown() noexcept {
+    if (impl_ != nullptr) {
+        impl_->Shutdown();
+    }
+}
+
+} // namespace Moer::ProfileDump

--- a/source/tool/profile_consumer/source/ProfileSession.cpp
+++ b/source/tool/profile_consumer/source/ProfileSession.cpp
@@ -9,6 +9,7 @@
 #include <cstring>
 #include <deque>
 #include <fstream>
+#include <functional>
 #include <iterator>
 #include <limits>
 #include <map>
@@ -248,6 +249,50 @@ template<typename T>
     return result;
 }
 
+class CancellationProbe final {
+public:
+    explicit CancellationProbe(const SessionLoadControl& _control) noexcept :
+        stop_token_(_control.stop_token),
+        interval_(std::max<std::uint64_t>(std::uint64_t{1}, _control.cancellation_check_interval)),
+        remaining_budget_(_control.max_work_items_before_cancel) {}
+
+    [[nodiscard]] bool Requested(std::uint64_t _work_items = 1) noexcept {
+        if (_work_items > remaining_budget_) {
+            remaining_budget_ = 0;
+            return true;
+        }
+        remaining_budget_ -= _work_items;
+        return StopRequested(_work_items);
+    }
+
+    [[nodiscard]] bool RequestedNow() const noexcept {
+        return remaining_budget_ == 0 || stop_token_.stop_requested();
+    }
+
+    [[nodiscard]] bool StopRequested(std::uint64_t _actual_iterations = 1) noexcept {
+        if (!stop_token_.stop_possible()) {
+            return false;
+        }
+        if (_actual_iterations >= interval_ - pending_stop_iterations_) {
+            pending_stop_iterations_ = 0;
+            return stop_token_.stop_requested();
+        }
+        pending_stop_iterations_ += _actual_iterations;
+        return false;
+    }
+
+    [[nodiscard]] std::size_t SortRunSize() const noexcept {
+        constexpr std::uint64_t kMaximumSortRunSize = 4096;
+        return static_cast<std::size_t>(std::min(interval_, kMaximumSortRunSize));
+    }
+
+private:
+    std::stop_token stop_token_{};
+    std::uint64_t   interval_{1};
+    std::uint64_t   pending_stop_iterations_{0};
+    std::uint64_t   remaining_budget_{std::numeric_limits<std::uint64_t>::max()};
+};
+
 } // namespace
 
 struct ProfileSession::Impl {
@@ -397,17 +442,236 @@ struct ProfileSessionReader::Impl {
     // ProfileSession::Impl owns standard containers whose constructors may
     // throw. Let the public reader constructor's catch-all convert any such
     // construction failure into the stable ResourceExhausted state.
-    explicit Impl(const SessionLoadOptions& _options) : options(_options) {
+    Impl(const SessionLoadOptions& _options, const SessionLoadControl& _control) :
+        options(_options),
+        cancellation(_control) {
         session.impl_ = new (std::nothrow) ProfileSession::Impl();
         if (session.impl_ == nullptr) {
             result.status     = SessionLoadStatus::ResourceExhausted;
             result.error_code = SessionErrorCode::ResourceAllocationFailed;
             diagnostic        = "profile session model allocation failed";
+        } else if (cancellation.RequestedNow()) {
+            Cancel();
         }
     }
 
     [[nodiscard]] bool IsReading() const noexcept {
         return result.status == SessionLoadStatus::Reading;
+    }
+
+    void Cancel() noexcept {
+        if (!IsReading()) {
+            return;
+        }
+        result.status                  = SessionLoadStatus::Cancelled;
+        result.incomplete_reason       = SessionIncompleteReason::None;
+        result.error_code              = SessionErrorCode::Cancelled;
+        result.limit_kind              = SessionLimitKind::None;
+        result.codec_status            = DecodeStatus::Ok;
+        result.error_byte_offset       = kInvalidSessionIndex;
+        result.error_packet_index      = kInvalidSessionIndex;
+        result.incomplete_byte_offset  = kInvalidSessionIndex;
+        result.incomplete_packet_index = kInvalidSessionIndex;
+        diagnostic                     = "profile session load cancelled";
+        if (session.impl_ != nullptr) {
+            session.impl_->valid = false;
+        }
+    }
+
+    [[nodiscard]] bool CheckCancellation(std::uint64_t _work_items = 1) noexcept {
+        if (!IsReading() || !cancellation.Requested(_work_items)) {
+            return !IsReading();
+        }
+        Cancel();
+        return true;
+    }
+
+    [[nodiscard]] bool CheckCancellationNow() noexcept {
+        if (!IsReading() || !cancellation.RequestedNow()) {
+            return !IsReading();
+        }
+        Cancel();
+        return true;
+    }
+
+    [[nodiscard]] bool CheckStopOnly(std::uint64_t _actual_iterations = 1) noexcept {
+        if (!IsReading() || !cancellation.StopRequested(_actual_iterations)) {
+            return !IsReading();
+        }
+        Cancel();
+        return true;
+    }
+
+    template<typename Iterator, typename Compare>
+    [[nodiscard]] bool CancellableSort(Iterator _begin, Iterator _end, Compare _compare) {
+        using Value = typename std::iterator_traits<Iterator>::value_type;
+
+        const auto signed_count = std::distance(_begin, _end);
+        if (signed_count < 0) {
+            Fail(
+                SessionLoadStatus::ResourceExhausted,
+                SessionErrorCode::UnexpectedFailure,
+                "profile sort range is invalid"
+            );
+            return false;
+        }
+        const std::size_t count = static_cast<std::size_t>(signed_count);
+        if (count < 2) {
+            return !CheckCancellationNow();
+        }
+
+        const std::size_t run_size = std::min(count, cancellation.SortRunSize());
+        for (std::size_t run_begin = 0; run_begin < count;) {
+            const std::size_t run_count = std::min(run_size, count - run_begin);
+            if (CheckCancellation(static_cast<std::uint64_t>(run_count))) {
+                return false;
+            }
+            const Iterator begin = _begin + static_cast<std::ptrdiff_t>(run_begin);
+            std::sort(begin, begin + static_cast<std::ptrdiff_t>(run_count), _compare);
+            run_begin += run_count;
+        }
+
+        if (CheckCancellationNow()) {
+            return false;
+        }
+        if (run_size == count) {
+            return true;
+        }
+
+        std::uint64_t scratch_bytes = 0;
+        if (sizeof(Value) != 0 &&
+            static_cast<std::uint64_t>(count) >
+                std::numeric_limits<std::uint64_t>::max() / static_cast<std::uint64_t>(sizeof(Value))) {
+            Fail(
+                SessionLoadStatus::LimitExceeded,
+                SessionErrorCode::LimitExceeded,
+                "profile transient materialization sort size overflows",
+                DecodeStatus::LimitExceeded,
+                SessionLimitKind::TransientMaterializationBytes
+            );
+            return false;
+        }
+        scratch_bytes = static_cast<std::uint64_t>(count) * static_cast<std::uint64_t>(sizeof(Value));
+        if (scratch_bytes > options.limits.max_transient_materialization_bytes) {
+            Fail(
+                SessionLoadStatus::LimitExceeded,
+                SessionErrorCode::LimitExceeded,
+                "profile transient materialization byte limit exceeded",
+                DecodeStatus::LimitExceeded,
+                SessionLimitKind::TransientMaterializationBytes
+            );
+            return false;
+        }
+
+        std::vector<Value> scratch;
+        scratch.reserve(count);
+        for (std::size_t width = run_size; width < count;) {
+            scratch.clear();
+            std::size_t block_begin = 0;
+            while (block_begin < count) {
+                const std::size_t middle    = block_begin + std::min(width, count - block_begin);
+                const std::size_t block_end = middle + std::min(width, count - middle);
+                std::size_t       left      = block_begin;
+                std::size_t       right     = middle;
+                while (left < middle || right < block_end) {
+                    if (CheckCancellation()) {
+                        return false;
+                    }
+                    if (right == block_end ||
+                        (left < middle && !_compare(*(_begin + right), *(_begin + left)))) {
+                        scratch.push_back(std::move(*(_begin + left)));
+                        ++left;
+                    } else {
+                        scratch.push_back(std::move(*(_begin + right)));
+                        ++right;
+                    }
+                }
+                block_begin = block_end;
+            }
+            if (scratch.size() != count) {
+                Fail(
+                    SessionLoadStatus::ResourceExhausted,
+                    SessionErrorCode::UnexpectedFailure,
+                    "profile cancellable sort produced an invalid merge"
+                );
+                return false;
+            }
+            for (std::size_t index = 0; index < count; ++index) {
+                if (CheckCancellation()) {
+                    return false;
+                }
+                *(_begin + static_cast<std::ptrdiff_t>(index)) = std::move(scratch[index]);
+            }
+            width = width > count - width ? count : width * 2;
+        }
+        return !CheckCancellationNow();
+    }
+
+    template<typename Iterator>
+    [[nodiscard]] bool CancellableSort(Iterator _begin, Iterator _end) {
+        using Value = typename std::iterator_traits<Iterator>::value_type;
+        return CancellableSort(_begin, _end, std::less<Value>{});
+    }
+
+    template<typename Iterator, typename BinaryPredicate>
+    [[nodiscard]] bool
+    CancellableAdjacentMatch(Iterator _begin, Iterator _end, BinaryPredicate _predicate, bool& _matched) {
+        _matched = false;
+        if (_begin == _end) {
+            return !CheckCancellationNow();
+        }
+
+        Iterator previous = _begin;
+        Iterator current  = _begin;
+        ++current;
+        for (; current != _end; ++previous, ++current) {
+            if (CheckStopOnly()) {
+                return false;
+            }
+            if (_predicate(*previous, *current)) {
+                _matched = true;
+                return !CheckCancellationNow();
+            }
+        }
+        return !CheckCancellationNow();
+    }
+
+    template<typename Iterator>
+    [[nodiscard]] bool CancellableAdjacentMatch(Iterator _begin, Iterator _end, bool& _matched) {
+        using Value = typename std::iterator_traits<Iterator>::value_type;
+        return CancellableAdjacentMatch(_begin, _end, std::equal_to<Value>{}, _matched);
+    }
+
+    template<typename Iterator, typename BinaryPredicate>
+    [[nodiscard]] bool
+    CancellableUnique(Iterator _begin, Iterator _end, BinaryPredicate _predicate, Iterator& _new_end) {
+        _new_end = _begin;
+        if (_begin == _end) {
+            return !CheckCancellationNow();
+        }
+
+        Iterator result  = _begin;
+        Iterator current = _begin;
+        ++current;
+        for (; current != _end; ++current) {
+            if (CheckStopOnly()) {
+                return false;
+            }
+            if (!_predicate(*result, *current)) {
+                ++result;
+                if (result != current) {
+                    *result = std::move(*current);
+                }
+            }
+        }
+        _new_end = ++result;
+        return !CheckCancellationNow();
+    }
+
+    template<typename Iterator>
+    [[nodiscard]] bool CancellableUnique(Iterator _begin, Iterator _end, Iterator& _new_end) {
+        using Value = typename std::iterator_traits<Iterator>::value_type;
+        return CancellableUnique(_begin, _end, std::equal_to<Value>{}, _new_end);
     }
 
     void Fail(
@@ -471,6 +735,9 @@ struct ProfileSessionReader::Impl {
     }
 
     [[nodiscard]] bool ChargeTopologyWork(std::uint64_t _count) noexcept {
+        if ((_count == 0 && CheckCancellationNow()) || (_count != 0 && CheckCancellation(_count))) {
+            return false;
+        }
         std::uint64_t next_topology_work_items = 0;
         if (AddOverflow(topology_work_items, _count, next_topology_work_items) ||
             next_topology_work_items > options.limits.max_topology_work_items) {
@@ -937,6 +1204,9 @@ struct ProfileSessionReader::Impl {
 
         const std::uint64_t first_field = session.impl_->schema_fields.size();
         for (const SchemaField& field : descriptor.fields) {
+            if (CheckStopOnly()) {
+                return false;
+            }
             if (!ChargeModel(sizeof(ProfileSchemaFieldInfo))) {
                 return false;
             }
@@ -1107,6 +1377,9 @@ struct ProfileSessionReader::Impl {
         std::uint64_t mandatory_sequence_count = 0;
         std::uint64_t residual_demand_count    = 0;
         for (const ProfileLossRecord& loss : session.impl_->losses) {
+            if (CheckStopOnly()) {
+                return false;
+            }
             if (loss.first_sequence == 0 ||
                 (loss.record_count == 1 && loss.first_sequence != loss.last_sequence)) {
                 Fail(
@@ -1158,6 +1431,9 @@ struct ProfileSessionReader::Impl {
         std::vector<SequenceDemand> residual_demands;
         residual_demands.reserve(static_cast<std::size_t>(residual_demand_count));
         for (const ProfileLossRecord& loss : session.impl_->losses) {
+            if (CheckStopOnly()) {
+                return false;
+            }
             mandatory_sequences.push_back(loss.first_sequence);
             if (loss.record_count != 1) {
                 mandatory_sequences.push_back(loss.last_sequence);
@@ -1197,12 +1473,19 @@ struct ProfileSessionReader::Impl {
         if (!charge_sort_work(mandatory_sequence_count)) {
             return false;
         }
-        std::sort(mandatory_sequences.begin(), mandatory_sequences.end());
+        if (!CancellableSort(mandatory_sequences.begin(), mandatory_sequences.end())) {
+            return false;
+        }
         if (!ChargeTopologyWork(mandatory_sequence_count)) {
             return false;
         }
-        if (std::adjacent_find(mandatory_sequences.begin(), mandatory_sequences.end()) !=
-            mandatory_sequences.end()) {
+        bool duplicate_mandatory_sequence = false;
+        if (!CancellableAdjacentMatch(
+                mandatory_sequences.begin(), mandatory_sequences.end(), duplicate_mandatory_sequence
+            )) {
+            return false;
+        }
+        if (duplicate_mandatory_sequence) {
             Fail(
                 SessionLoadStatus::ProtocolViolation,
                 SessionErrorCode::RecordSequenceInvalid,
@@ -1214,6 +1497,9 @@ struct ProfileSessionReader::Impl {
             return false;
         }
         for (const std::uint64_t sequence : mandatory_sequences) {
+            if (CheckStopOnly()) {
+                return false;
+            }
             if (!charge_binary_search(record_sequences.size())) {
                 return false;
             }
@@ -1234,16 +1520,18 @@ struct ProfileSessionReader::Impl {
         if (!charge_sort_work(residual_demand_count)) {
             return false;
         }
-        std::sort(
-            residual_demands.begin(),
-            residual_demands.end(),
-            [](const SequenceDemand& _left, const SequenceDemand& _right) {
-                if (_left.release_sequence != _right.release_sequence) {
-                    return _left.release_sequence < _right.release_sequence;
+        if (!CancellableSort(
+                residual_demands.begin(),
+                residual_demands.end(),
+                [](const SequenceDemand& _left, const SequenceDemand& _right) {
+                    if (_left.release_sequence != _right.release_sequence) {
+                        return _left.release_sequence < _right.release_sequence;
+                    }
+                    return _left.deadline_sequence < _right.deadline_sequence;
                 }
-                return _left.deadline_sequence < _right.deadline_sequence;
-            }
-        );
+            )) {
+            return false;
+        }
 
         struct PendingDemand {
             std::uint64_t deadline_sequence{0};
@@ -1502,25 +1790,27 @@ struct ProfileSessionReader::Impl {
         if (!ChargeTopologySortWork(scopes.size())) {
             return false;
         }
-        std::sort(
-            scopes.begin(),
-            scopes.end(),
-            [](const CpuScopeRecord& _left, const CpuScopeRecord& _right) {
-                if (_left.thread_id != _right.thread_id) {
-                    return _left.thread_id < _right.thread_id;
+        if (!CancellableSort(
+                scopes.begin(),
+                scopes.end(),
+                [](const CpuScopeRecord& _left, const CpuScopeRecord& _right) {
+                    if (_left.thread_id != _right.thread_id) {
+                        return _left.thread_id < _right.thread_id;
+                    }
+                    if (_left.begin_ns != _right.begin_ns) {
+                        return _left.begin_ns < _right.begin_ns;
+                    }
+                    if (_left.end_ns != _right.end_ns) {
+                        return _left.end_ns > _right.end_ns;
+                    }
+                    if (_left.depth != _right.depth) {
+                        return _left.depth < _right.depth;
+                    }
+                    return _left.sequence < _right.sequence;
                 }
-                if (_left.begin_ns != _right.begin_ns) {
-                    return _left.begin_ns < _right.begin_ns;
-                }
-                if (_left.end_ns != _right.end_ns) {
-                    return _left.end_ns > _right.end_ns;
-                }
-                if (_left.depth != _right.depth) {
-                    return _left.depth < _right.depth;
-                }
-                return _left.sequence < _right.sequence;
-            }
-        );
+            )) {
+            return false;
+        }
         // One pass partitions tracks, one visits every scope, and active-stack
         // retirement visits each scope at most once. Boundary candidate scans
         // are charged separately where they occur.
@@ -1538,9 +1828,15 @@ struct ProfileSessionReader::Impl {
         gap_events.reserve(scopes.size());
         std::size_t track_begin = 0;
         while (track_begin < scopes.size()) {
+            if (CheckStopOnly()) {
+                return false;
+            }
             std::size_t track_end = track_begin + 1;
             while (track_end < scopes.size() && scopes[track_end].thread_id == scopes[track_begin].thread_id
             ) {
+                if (CheckStopOnly()) {
+                    return false;
+                }
                 ++track_end;
             }
             if (!CheckCountLimit(
@@ -1567,6 +1863,9 @@ struct ProfileSessionReader::Impl {
             std::uint64_t                                       boundary_time     = 0;
             bool                                                has_boundary_time = false;
             for (std::size_t index = track_begin; index < track_end; ++index) {
+                if (CheckStopOnly()) {
+                    return false;
+                }
                 CpuScopeRecord& scope = scopes[index];
                 scope.track_index     = track_index;
 
@@ -1579,6 +1878,9 @@ struct ProfileSessionReader::Impl {
                     has_boundary_time = true;
                 }
                 while (!active.empty()) {
+                    if (CheckStopOnly()) {
+                        return false;
+                    }
                     const std::uint64_t   candidate_index = active.back();
                     const CpuScopeRecord& candidate       = scopes[candidate_index];
                     const bool            zero_duration_child_at_end =
@@ -1631,6 +1933,9 @@ struct ProfileSessionReader::Impl {
                             return false;
                         }
                         for (const std::uint64_t candidate_index : ending_depth->second) {
+                            if (CheckStopOnly()) {
+                                return false;
+                            }
                             const CpuScopeRecord& candidate = scopes[candidate_index];
                             if (candidate.sequence > scope.sequence &&
                                 (ending_ancestor_index == kInvalidSessionIndex ||
@@ -1727,30 +2032,41 @@ struct ProfileSessionReader::Impl {
         if (!ChargeTopologySortWork(gap_events.size())) {
             return false;
         }
-        std::sort(
-            gap_events.begin(),
-            gap_events.end(),
-            [](const CpuGapEvent& _left, const CpuGapEvent& _right) {
-                if (_left.ancestor_index != _right.ancestor_index) {
-                    return _left.ancestor_index < _right.ancestor_index;
+        if (!CancellableSort(
+                gap_events.begin(),
+                gap_events.end(),
+                [](const CpuGapEvent& _left, const CpuGapEvent& _right) {
+                    if (_left.ancestor_index != _right.ancestor_index) {
+                        return _left.ancestor_index < _right.ancestor_index;
+                    }
+                    return _left.scope_index < _right.scope_index;
                 }
-                return _left.scope_index < _right.scope_index;
-            }
-        );
+            )) {
+            return false;
+        }
         if (!ChargeTopologyLinearWork(gap_events.size())) {
             return false;
         }
         std::size_t event_begin = 0;
         while (event_begin < gap_events.size()) {
+            if (CheckStopOnly()) {
+                return false;
+            }
             std::size_t event_end = event_begin + 1;
             while (event_end < gap_events.size() &&
                    gap_events[event_end].ancestor_index == gap_events[event_begin].ancestor_index) {
+                if (CheckStopOnly()) {
+                    return false;
+                }
                 ++event_end;
             }
 
             std::uint32_t previous_gap      = gap_events[event_begin].depth_gap;
             std::uint64_t previous_sequence = scopes[gap_events[event_begin].scope_index].sequence;
             for (std::size_t index = event_begin + 1; index < event_end; ++index) {
+                if (CheckStopOnly()) {
+                    return false;
+                }
                 const CpuGapEvent&  event          = gap_events[index];
                 const std::uint64_t event_sequence = scopes[event.scope_index].sequence;
                 if (event_sequence <= previous_sequence) {
@@ -1800,16 +2116,18 @@ struct ProfileSessionReader::Impl {
         if (!ChargeTopologySortWork(_sequence_demands.size())) {
             return false;
         }
-        std::sort(
-            _sequence_demands.begin(),
-            _sequence_demands.end(),
-            [](const RecordSequenceDemand& _left, const RecordSequenceDemand& _right) {
-                if (_left.release_sequence != _right.release_sequence) {
-                    return _left.release_sequence < _right.release_sequence;
+        if (!CancellableSort(
+                _sequence_demands.begin(),
+                _sequence_demands.end(),
+                [](const RecordSequenceDemand& _left, const RecordSequenceDemand& _right) {
+                    if (_left.release_sequence != _right.release_sequence) {
+                        return _left.release_sequence < _right.release_sequence;
+                    }
+                    return _left.deadline_sequence < _right.deadline_sequence;
                 }
-                return _left.deadline_sequence < _right.deadline_sequence;
-            }
-        );
+            )) {
+            return false;
+        }
         if (_sequence_demands.empty()) {
             return true;
         }
@@ -1876,6 +2194,9 @@ struct ProfileSessionReader::Impl {
             }
 
             while (observed_index < record_sequences.size() && record_sequences[observed_index] < position) {
+                if (CheckStopOnly()) {
+                    return false;
+                }
                 ++observed_index;
             }
             if (observed_index < record_sequences.size() && record_sequences[observed_index] == position) {
@@ -1973,6 +2294,9 @@ struct ProfileSessionReader::Impl {
         std::uint64_t loss_bucket_total = 0;
         if (!_forensic) {
             for (const ProfileLossRecord& loss : session.impl_->losses) {
+                if (CheckStopOnly()) {
+                    return false;
+                }
                 std::uint64_t buckets_for_loss = 1;
                 if (loss.record_count != 1) {
                     ++buckets_for_loss;
@@ -1993,6 +2317,9 @@ struct ProfileSessionReader::Impl {
         }
         std::uint64_t demand_total = 0;
         for (const RecordSequenceDemand& demand : _sequence_demands) {
+            if (CheckStopOnly()) {
+                return false;
+            }
             if (AddOverflow(demand_total, demand.count, demand_total)) {
                 Fail(
                     SessionLoadStatus::ProtocolViolation,
@@ -2114,6 +2441,9 @@ struct ProfileSessionReader::Impl {
         };
         if (!_forensic) {
             for (const ProfileLossRecord& loss : session.impl_->losses) {
+                if (CheckStopOnly()) {
+                    return false;
+                }
                 add_loss_bucket(loss.first_sequence, loss.first_sequence, 1);
                 if (loss.record_count != 1) {
                     add_loss_bucket(loss.last_sequence, loss.last_sequence, 1);
@@ -2124,27 +2454,35 @@ struct ProfileSessionReader::Impl {
             }
         }
         for (const RecordSequenceDemand& demand : _sequence_demands) {
+            if (CheckStopOnly()) {
+                return false;
+            }
             critical_points.push_back(demand.release_sequence);
             critical_points.push_back(demand.deadline_sequence);
         }
         for (const JointLocalCell& cell : joint_local_cells) {
+            if (CheckStopOnly()) {
+                return false;
+            }
             critical_points.push_back(cell.release_sequence);
             critical_points.push_back(cell.deadline_sequence);
         }
         if (!ChargeTopologySortWork(loss_buckets.size())) {
             return false;
         }
-        std::sort(
-            loss_buckets.begin(),
-            loss_buckets.end(),
-            [](const LossBucket& _left, const LossBucket& _right) {
-                return std::tie(_left.release_sequence, _left.deadline_sequence) <
-                       std::tie(_right.release_sequence, _right.deadline_sequence);
-            }
-        );
+        if (!CancellableSort(
+                loss_buckets.begin(),
+                loss_buckets.end(),
+                [](const LossBucket& _left, const LossBucket& _right) {
+                    return std::tie(_left.release_sequence, _left.deadline_sequence) <
+                           std::tie(_right.release_sequence, _right.deadline_sequence);
+                }
+            )) {
+            return false;
+        }
 
-        // std::sort is introspective O(N log N). Charge one abstract work item
-        // per element and merge level before invoking it so preprocessing cannot
+        // Charge one abstract work item per element and merge level before
+        // invoking the bounded-run cancellable sort so preprocessing cannot
         // escape the session-wide topology budget.
         std::uint64_t sort_width = 1;
         while (sort_width < critical_point_count) {
@@ -2156,13 +2494,17 @@ struct ProfileSessionReader::Impl {
             }
             sort_width *= 2;
         }
-        std::sort(critical_points.begin(), critical_points.end());
+        if (!CancellableSort(critical_points.begin(), critical_points.end())) {
+            return false;
+        }
         if (!ChargeTopologyWork(critical_point_count)) {
             return false;
         }
-        critical_points.erase(
-            std::unique(critical_points.begin(), critical_points.end()), critical_points.end()
-        );
+        auto critical_points_end = critical_points.begin();
+        if (!CancellableUnique(critical_points.begin(), critical_points.end(), critical_points_end)) {
+            return false;
+        }
+        critical_points.erase(critical_points_end, critical_points.end());
 
         struct SequenceSegment {
             std::uint64_t begin{0};
@@ -2216,6 +2558,9 @@ struct ProfileSessionReader::Impl {
             }
             loss_coverage.reserve(loss_buckets.size());
             for (const LossBucket& bucket : loss_buckets) {
+                if (CheckStopOnly()) {
+                    return false;
+                }
                 if (loss_coverage.empty() ||
                     (loss_coverage.back().end != std::numeric_limits<std::uint64_t>::max() &&
                      bucket.release_sequence > loss_coverage.back().end + 1)) {
@@ -2232,16 +2577,21 @@ struct ProfileSessionReader::Impl {
         std::vector<SequenceSegment> segments;
         const std::uint64_t          segment_edge_capacity = options.limits.max_topology_flow_edges / 2;
         segments.reserve(static_cast<std::size_t>(std::min(maximum_segment_count, segment_edge_capacity)));
-        std::size_t         observed_index       = 0;
-        std::size_t         loss_coverage_index  = 0;
-        bool                segment_build_failed = false;
-        const std::uint64_t flow_target          = _forensic ? required_topology_total : loss_bucket_total;
-        const auto          add_segment          = [&](std::uint64_t _begin, std::uint64_t _end) {
+        std::size_t         observed_index      = 0;
+        std::size_t         loss_coverage_index = 0;
+        const std::uint64_t flow_target         = _forensic ? required_topology_total : loss_bucket_total;
+        const auto          add_segment         = [&](std::uint64_t _begin, std::uint64_t _end) {
             while (observed_index < record_sequences.size() && record_sequences[observed_index] < _begin) {
+                if (CheckStopOnly()) {
+                    return false;
+                }
                 ++observed_index;
             }
             const std::size_t observed_begin = observed_index;
             while (observed_index < record_sequences.size() && record_sequences[observed_index] <= _end) {
+                if (CheckStopOnly()) {
+                    return false;
+                }
                 ++observed_index;
             }
             const std::uint64_t observed_count = static_cast<std::uint64_t>(observed_index - observed_begin);
@@ -2253,25 +2603,28 @@ struct ProfileSessionReader::Impl {
                 // excluding any observed sequence, or can be capped directly
                 // by the total flow when none are observed.
                 available = observed_count == 0 ?
-                                                  flow_target :
-                                                  std::numeric_limits<std::uint64_t>::max() - (observed_count - 1);
+                                                 flow_target :
+                                                 std::numeric_limits<std::uint64_t>::max() - (observed_count - 1);
             } else {
                 const std::uint64_t span = span_minus_one + 1;
                 available                = observed_count < span ? span - observed_count : 0;
             }
             const std::uint64_t capacity = std::min(available, flow_target);
             if (capacity == 0) {
-                return;
+                return true;
             }
             if (!_forensic) {
                 while (loss_coverage_index < loss_coverage.size() &&
                        loss_coverage[loss_coverage_index].end < _begin) {
+                    if (CheckStopOnly()) {
+                        return false;
+                    }
                     ++loss_coverage_index;
                 }
                 if (loss_coverage_index == loss_coverage.size() ||
                     loss_coverage[loss_coverage_index].begin > _begin ||
                     loss_coverage[loss_coverage_index].end < _end) {
-                    return;
+                    return true;
                 }
             }
             if (static_cast<std::uint64_t>(segments.size()) >= segment_edge_capacity) {
@@ -2282,28 +2635,29 @@ struct ProfileSessionReader::Impl {
                     DecodeStatus::LimitExceeded,
                     SessionLimitKind::TopologyFlowEdges
                 );
-                segment_build_failed = true;
-                return;
+                return false;
             }
             segments.push_back({
-                                  .begin    = _begin,
-                                  .end      = _end,
-                                  .capacity = capacity,
+                                 .begin    = _begin,
+                                 .end      = _end,
+                                 .capacity = capacity,
             });
+            return true;
         };
         for (std::size_t index = 0; index < critical_points.size(); ++index) {
-            if (segment_build_failed) {
+            if (CheckStopOnly()) {
                 return false;
             }
             const std::uint64_t point = critical_points[index];
-            add_segment(point, point);
+            if (!add_segment(point, point)) {
+                return false;
+            }
             if (index + 1 < critical_points.size() && point != std::numeric_limits<std::uint64_t>::max() &&
                 critical_points[index + 1] > point + 1) {
-                add_segment(point + 1, critical_points[index + 1] - 1);
+                if (!add_segment(point + 1, critical_points[index + 1] - 1)) {
+                    return false;
+                }
             }
-        }
-        if (segment_build_failed) {
-            return false;
         }
 
         struct SegmentRange {
@@ -2344,6 +2698,9 @@ struct ProfileSessionReader::Impl {
         demand_segment_ranges.reserve(_sequence_demands.size());
         cell_segment_ranges.reserve(joint_local_cells.size());
         for (const LossBucket& bucket : loss_buckets) {
+            if (CheckStopOnly()) {
+                return false;
+            }
             if (!ChargeTopologyBinarySearchWork(segments.size()) ||
                 !ChargeTopologyBinarySearchWork(segments.size())) {
                 return false;
@@ -2353,6 +2710,9 @@ struct ProfileSessionReader::Impl {
             );
         }
         for (const RecordSequenceDemand& demand : _sequence_demands) {
+            if (CheckStopOnly()) {
+                return false;
+            }
             if (!ChargeTopologyBinarySearchWork(segments.size()) ||
                 !ChargeTopologyBinarySearchWork(segments.size())) {
                 return false;
@@ -2362,6 +2722,9 @@ struct ProfileSessionReader::Impl {
             );
         }
         for (const JointLocalCell& cell : joint_local_cells) {
+            if (CheckStopOnly()) {
+                return false;
+            }
             if (!ChargeTopologyBinarySearchWork(segments.size()) ||
                 !ChargeTopologyBinarySearchWork(segments.size())) {
                 return false;
@@ -2444,7 +2807,12 @@ struct ProfileSessionReader::Impl {
                     if (!owner->ChargeTopologyWork(static_cast<std::uint64_t>(parent_nodes.size()))) {
                         return false;
                     }
-                    std::fill(parent_nodes.begin(), parent_nodes.end(), unreached);
+                    for (std::size_t& parent_node : parent_nodes) {
+                        if (owner->CheckStopOnly()) {
+                            return false;
+                        }
+                        parent_node = unreached;
+                    }
                     parent_nodes[_source]        = _source;
                     std::size_t pending_begin    = 0;
                     std::size_t pending_end      = 0;
@@ -2456,6 +2824,9 @@ struct ProfileSessionReader::Impl {
                             return false;
                         }
                         for (std::size_t edge_index = 0; edge_index < edges[node].size(); ++edge_index) {
+                            if (owner->CheckStopOnly()) {
+                                return false;
+                            }
                             const Edge& edge = edges[node][edge_index];
                             if (edge.capacity != 0 && parent_nodes[edge.target] == unreached) {
                                 parent_nodes[edge.target]    = node;
@@ -2566,16 +2937,25 @@ struct ProfileSessionReader::Impl {
             return count_forward_edges(count);
         };
         for (const SegmentRange& range : loss_segment_ranges) {
+            if (CheckStopOnly()) {
+                return false;
+            }
             if (!count_segment_range_edges(range)) {
                 return false;
             }
         }
         for (const SegmentRange& range : demand_segment_ranges) {
+            if (CheckStopOnly()) {
+                return false;
+            }
             if (!count_segment_range_edges(range)) {
                 return false;
             }
         }
         for (const SegmentRange& range : cell_segment_ranges) {
+            if (CheckStopOnly()) {
+                return false;
+            }
             if (!count_segment_range_edges(range)) {
                 return false;
             }
@@ -2586,10 +2966,16 @@ struct ProfileSessionReader::Impl {
             }
         }
         for (const JointLocalCell& cell : joint_local_cells) {
+            if (CheckStopOnly()) {
+                return false;
+            }
             if (!count_forward_edges(static_cast<std::uint64_t>(cell.task_indices.size()))) {
                 return false;
             }
             for (const std::size_t task_index : cell.task_indices) {
+                if (CheckStopOnly()) {
+                    return false;
+                }
                 if (task_index >= joint_virtual_tasks.size()) {
                     Fail(
                         SessionLoadStatus::ProtocolViolation,
@@ -2623,28 +3009,43 @@ struct ProfileSessionReader::Impl {
 
         if (_forensic) {
             for (std::size_t index = 0; index < segments.size(); ++index) {
+                if (CheckStopOnly()) {
+                    return false;
+                }
                 if (!add_edge(source_node, segment_in_base + index, segments[index].capacity)) {
                     return false;
                 }
             }
         } else {
             for (std::size_t index = 0; index < loss_buckets.size(); ++index) {
+                if (CheckStopOnly()) {
+                    return false;
+                }
                 if (!add_edge(source_node, loss_base + index, loss_buckets[index].count)) {
                     return false;
                 }
             }
         }
         for (std::size_t index = 0; index < segments.size(); ++index) {
+            if (CheckStopOnly()) {
+                return false;
+            }
             if (!add_edge(segment_in_base + index, segment_out_base + index, segments[index].capacity)) {
                 return false;
             }
         }
         for (std::size_t index = 0; index < _sequence_demands.size(); ++index) {
+            if (CheckStopOnly()) {
+                return false;
+            }
             if (!add_edge(demand_base + index, sink_node, _sequence_demands[index].count)) {
                 return false;
             }
         }
         for (std::size_t index = 0; index < joint_local_cells.size(); ++index) {
+            if (CheckStopOnly()) {
+                return false;
+            }
             if (!add_edge(
                     cell_in_base + index, cell_out_base + index, joint_local_cells[index].local_capacity
                 )) {
@@ -2652,6 +3053,9 @@ struct ProfileSessionReader::Impl {
             }
         }
         for (std::size_t index = 0; index < joint_virtual_tasks.size(); ++index) {
+            if (CheckStopOnly()) {
+                return false;
+            }
             if (!add_edge(task_base + index, sink_node, 1)) {
                 return false;
             }
@@ -2662,9 +3066,15 @@ struct ProfileSessionReader::Impl {
 
         if (!_forensic) {
             for (std::size_t loss_index = 0; loss_index < loss_buckets.size(); ++loss_index) {
+                if (CheckStopOnly()) {
+                    return false;
+                }
                 const LossBucket&   bucket = loss_buckets[loss_index];
                 const SegmentRange& range  = loss_segment_ranges[loss_index];
                 for (std::size_t segment_index = range.begin; segment_index < range.end; ++segment_index) {
+                    if (CheckStopOnly()) {
+                        return false;
+                    }
                     const SequenceSegment& segment = segments[segment_index];
                     if (!add_edge(
                             loss_base + loss_index,
@@ -2678,6 +3088,9 @@ struct ProfileSessionReader::Impl {
         }
         if (dummy_capacity != 0) {
             for (std::size_t segment_index = 0; segment_index < segments.size(); ++segment_index) {
+                if (CheckStopOnly()) {
+                    return false;
+                }
                 if (!add_edge(
                         segment_out_base + segment_index, dummy_demand_node, segments[segment_index].capacity
                     )) {
@@ -2686,9 +3099,15 @@ struct ProfileSessionReader::Impl {
             }
         }
         for (std::size_t demand_index = 0; demand_index < _sequence_demands.size(); ++demand_index) {
+            if (CheckStopOnly()) {
+                return false;
+            }
             const RecordSequenceDemand& demand = _sequence_demands[demand_index];
             const SegmentRange&         range  = demand_segment_ranges[demand_index];
             for (std::size_t segment_index = range.begin; segment_index < range.end; ++segment_index) {
+                if (CheckStopOnly()) {
+                    return false;
+                }
                 const SequenceSegment& segment = segments[segment_index];
                 if (!add_edge(
                         segment_out_base + segment_index,
@@ -2700,9 +3119,15 @@ struct ProfileSessionReader::Impl {
             }
         }
         for (std::size_t cell_index = 0; cell_index < joint_local_cells.size(); ++cell_index) {
+            if (CheckStopOnly()) {
+                return false;
+            }
             const JointLocalCell& cell  = joint_local_cells[cell_index];
             const SegmentRange&   range = cell_segment_ranges[cell_index];
             for (std::size_t segment_index = range.begin; segment_index < range.end; ++segment_index) {
+                if (CheckStopOnly()) {
+                    return false;
+                }
                 const SequenceSegment& segment = segments[segment_index];
                 if (!add_edge(
                         segment_out_base + segment_index,
@@ -2713,6 +3138,9 @@ struct ProfileSessionReader::Impl {
                 }
             }
             for (const std::size_t task_index : cell.task_indices) {
+                if (CheckStopOnly()) {
+                    return false;
+                }
                 if (!add_edge(cell_out_base + cell_index, task_base + task_index, 1)) {
                     return false;
                 }
@@ -2750,20 +3178,25 @@ struct ProfileSessionReader::Impl {
         if (!ChargeTopologySortWork(frames.size())) {
             return false;
         }
-        std::sort(
-            frames.begin(),
-            frames.end(),
-            [](const GpuFrameRecord& _left, const GpuFrameRecord& _right) {
-                if (_left.frame_id != _right.frame_id) {
-                    return _left.frame_id < _right.frame_id;
+        if (!CancellableSort(
+                frames.begin(),
+                frames.end(),
+                [](const GpuFrameRecord& _left, const GpuFrameRecord& _right) {
+                    if (_left.frame_id != _right.frame_id) {
+                        return _left.frame_id < _right.frame_id;
+                    }
+                    return _left.sequence < _right.sequence;
                 }
-                return _left.sequence < _right.sequence;
-            }
-        );
+            )) {
+            return false;
+        }
         if (!ChargeTopologyLinearWork(frames.size())) {
             return false;
         }
         for (std::size_t index = 1; index < frames.size(); ++index) {
+            if (CheckStopOnly()) {
+                return false;
+            }
             if (frames[index - 1].frame_id == frames[index].frame_id) {
                 Fail(
                     SessionLoadStatus::ProtocolViolation,
@@ -2789,6 +3222,9 @@ struct ProfileSessionReader::Impl {
         }
         keys.reserve(scopes.size());
         for (const GpuScopeRecord& scope : scopes) {
+            if (CheckStopOnly()) {
+                return false;
+            }
             keys.push_back({
                 .native_queue_id = scope.native_queue_id,
                 .family_id       = scope.family_id,
@@ -2797,11 +3233,17 @@ struct ProfileSessionReader::Impl {
         if (!ChargeTopologySortWork(keys.size())) {
             return false;
         }
-        std::sort(keys.begin(), keys.end());
+        if (!CancellableSort(keys.begin(), keys.end())) {
+            return false;
+        }
         if (!ChargeTopologyLinearWork(keys.size())) {
             return false;
         }
-        keys.erase(std::unique(keys.begin(), keys.end()), keys.end());
+        auto unique_keys_end = keys.begin();
+        if (!CancellableUnique(keys.begin(), keys.end(), unique_keys_end)) {
+            return false;
+        }
+        keys.erase(unique_keys_end, keys.end());
         if (keys.size() > options.limits.max_gpu_domains) {
             Fail(
                 SessionLoadStatus::LimitExceeded,
@@ -2816,6 +3258,9 @@ struct ProfileSessionReader::Impl {
             return false;
         }
         for (const DomainKey& key : keys) {
+            if (CheckStopOnly()) {
+                return false;
+            }
             if (!ChargeModel(sizeof(GpuTimestampDomain))) {
                 return false;
             }
@@ -2829,6 +3274,9 @@ struct ProfileSessionReader::Impl {
             return false;
         }
         for (GpuScopeRecord& scope : scopes) {
+            if (CheckStopOnly()) {
+                return false;
+            }
             if (!ChargeTopologyBinarySearchWork(frames.size()) ||
                 !ChargeTopologyBinarySearchWork(keys.size())) {
                 return false;
@@ -2882,42 +3330,50 @@ struct ProfileSessionReader::Impl {
         if (!ChargeTopologySortWork(scopes.size())) {
             return false;
         }
-        std::sort(
-            scopes.begin(),
-            scopes.end(),
-            [](const GpuScopeRecord& _left, const GpuScopeRecord& _right) {
-                if (_left.logical_queue != _right.logical_queue) {
-                    return _left.logical_queue < _right.logical_queue;
+        if (!CancellableSort(
+                scopes.begin(),
+                scopes.end(),
+                [](const GpuScopeRecord& _left, const GpuScopeRecord& _right) {
+                    if (_left.logical_queue != _right.logical_queue) {
+                        return _left.logical_queue < _right.logical_queue;
+                    }
+                    if (_left.native_queue_id != _right.native_queue_id) {
+                        return _left.native_queue_id < _right.native_queue_id;
+                    }
+                    if (_left.family_id != _right.family_id) {
+                        return _left.family_id < _right.family_id;
+                    }
+                    if (_left.frame_id != _right.frame_id) {
+                        return _left.frame_id < _right.frame_id;
+                    }
+                    if (_left.source_order != _right.source_order) {
+                        return _left.source_order < _right.source_order;
+                    }
+                    if (_left.local_order != _right.local_order) {
+                        return _left.local_order < _right.local_order;
+                    }
+                    return _left.scope_id < _right.scope_id;
                 }
-                if (_left.native_queue_id != _right.native_queue_id) {
-                    return _left.native_queue_id < _right.native_queue_id;
-                }
-                if (_left.family_id != _right.family_id) {
-                    return _left.family_id < _right.family_id;
-                }
-                if (_left.frame_id != _right.frame_id) {
-                    return _left.frame_id < _right.frame_id;
-                }
-                if (_left.source_order != _right.source_order) {
-                    return _left.source_order < _right.source_order;
-                }
-                if (_left.local_order != _right.local_order) {
-                    return _left.local_order < _right.local_order;
-                }
-                return _left.scope_id < _right.scope_id;
-            }
-        );
+            )) {
+            return false;
+        }
         if (!ChargeTopologyLinearWork(scopes.size()) || !ChargeTopologyLinearWork(scopes.size())) {
             return false;
         }
 
         std::size_t track_begin = 0;
         while (track_begin < scopes.size()) {
+            if (CheckStopOnly()) {
+                return false;
+            }
             std::size_t track_end = track_begin + 1;
             while (track_end < scopes.size() &&
                    scopes[track_end].logical_queue == scopes[track_begin].logical_queue &&
                    scopes[track_end].native_queue_id == scopes[track_begin].native_queue_id &&
                    scopes[track_end].family_id == scopes[track_begin].family_id) {
+                if (CheckStopOnly()) {
+                    return false;
+                }
                 ++track_end;
             }
             if (!CheckCountLimit(
@@ -2939,6 +3395,9 @@ struct ProfileSessionReader::Impl {
                 .scope_count     = track_end - track_begin,
             });
             for (std::size_t index = track_begin; index < track_end; ++index) {
+                if (CheckStopOnly()) {
+                    return false;
+                }
                 scopes[index].track_index = track_index;
             }
             track_begin = track_end;
@@ -3006,6 +3465,9 @@ struct ProfileSessionReader::Impl {
         }
         lookup.reserve(scopes.size());
         for (std::size_t index = 0; index < scopes.size(); ++index) {
+            if (CheckStopOnly()) {
+                return false;
+            }
             lookup.push_back({
                 .frame_id    = scopes[index].frame_id,
                 .scope_id    = scopes[index].scope_id,
@@ -3015,11 +3477,16 @@ struct ProfileSessionReader::Impl {
         if (!ChargeTopologySortWork(lookup.size())) {
             return false;
         }
-        std::sort(lookup.begin(), lookup.end());
+        if (!CancellableSort(lookup.begin(), lookup.end())) {
+            return false;
+        }
         if (!ChargeTopologyLinearWork(lookup.size())) {
             return false;
         }
         for (std::size_t index = 1; index < lookup.size(); ++index) {
+            if (CheckStopOnly()) {
+                return false;
+            }
             if (lookup[index - 1].frame_id == lookup[index].frame_id &&
                 lookup[index - 1].scope_id == lookup[index].scope_id) {
                 Fail(
@@ -3089,6 +3556,9 @@ struct ProfileSessionReader::Impl {
             return false;
         }
         for (std::size_t index = 1; index < scopes.size(); ++index) {
+            if (CheckStopOnly()) {
+                return false;
+            }
             const GpuScopeRecord& previous = scopes[index - 1];
             const GpuScopeRecord& scope    = scopes[index];
             const bool            same_source =
@@ -3112,6 +3582,9 @@ struct ProfileSessionReader::Impl {
             return false;
         }
         for (std::size_t index = 0; index < scopes.size(); ++index) {
+            if (CheckStopOnly()) {
+                return false;
+            }
             GpuScopeRecord& scope  = scopes[index];
             bool            orphan = false;
 
@@ -3308,40 +3781,51 @@ struct ProfileSessionReader::Impl {
         std::vector<std::size_t> emission_order;
         emission_order.reserve(scopes.size());
         for (std::size_t index = 0; index < scopes.size(); ++index) {
+            if (CheckStopOnly()) {
+                return false;
+            }
             emission_order.push_back(index);
         }
-        std::sort(
-            emission_order.begin(),
-            emission_order.end(),
-            [&](std::size_t _left_index, std::size_t _right_index) {
-                const GpuScopeRecord& left  = scopes[_left_index];
-                const GpuScopeRecord& right = scopes[_right_index];
-                return std::tie(
-                           left.frame_id,
-                           left.logical_queue,
-                           left.native_queue_id,
-                           left.family_id,
-                           left.source_order,
-                           left.local_order,
-                           left.scope_id
-                       ) <
-                       std::tie(
-                           right.frame_id,
-                           right.logical_queue,
-                           right.native_queue_id,
-                           right.family_id,
-                           right.source_order,
-                           right.local_order,
-                           right.scope_id
-                       );
-            }
-        );
+        if (!CancellableSort(
+                emission_order.begin(),
+                emission_order.end(),
+                [&](std::size_t _left_index, std::size_t _right_index) {
+                    const GpuScopeRecord& left  = scopes[_left_index];
+                    const GpuScopeRecord& right = scopes[_right_index];
+                    return std::tie(
+                               left.frame_id,
+                               left.logical_queue,
+                               left.native_queue_id,
+                               left.family_id,
+                               left.source_order,
+                               left.local_order,
+                               left.scope_id
+                           ) <
+                           std::tie(
+                               right.frame_id,
+                               right.logical_queue,
+                               right.native_queue_id,
+                               right.family_id,
+                               right.source_order,
+                               right.local_order,
+                               right.scope_id
+                           );
+                }
+            )) {
+            return false;
+        }
         std::size_t emission_begin = 0;
         while (emission_begin < emission_order.size()) {
+            if (CheckStopOnly()) {
+                return false;
+            }
             std::size_t emission_end = emission_begin + 1;
             while (emission_end < emission_order.size() && scopes[emission_order[emission_end]].frame_id ==
                                                                scopes[emission_order[emission_begin]].frame_id
             ) {
+                if (CheckStopOnly()) {
+                    return false;
+                }
                 ++emission_end;
             }
 
@@ -3357,6 +3841,9 @@ struct ProfileSessionReader::Impl {
             bool          has_previous_record             = has_known_frame;
             bool          has_previous_scope              = false;
             for (std::size_t order_index = emission_begin; order_index < emission_end; ++order_index) {
+                if (CheckStopOnly()) {
+                    return false;
+                }
                 const GpuScopeRecord& scope = scopes[emission_order[order_index]];
                 if (has_previous_record && scope.sequence <= previous_sequence) {
                     Fail(
@@ -3413,19 +3900,21 @@ struct ProfileSessionReader::Impl {
         if (!ChargeTopologySortWork(missing_parent_evidence.size())) {
             return false;
         }
-        std::sort(
-            missing_parent_evidence.begin(),
-            missing_parent_evidence.end(),
-            [](const MissingParentEvidence& _left, const MissingParentEvidence& _right) {
-                if (_left.frame_id != _right.frame_id) {
-                    return _left.frame_id < _right.frame_id;
+        if (!CancellableSort(
+                missing_parent_evidence.begin(),
+                missing_parent_evidence.end(),
+                [](const MissingParentEvidence& _left, const MissingParentEvidence& _right) {
+                    if (_left.frame_id != _right.frame_id) {
+                        return _left.frame_id < _right.frame_id;
+                    }
+                    if (_left.parent_scope_id != _right.parent_scope_id) {
+                        return _left.parent_scope_id < _right.parent_scope_id;
+                    }
+                    return _left.child_local_order < _right.child_local_order;
                 }
-                if (_left.parent_scope_id != _right.parent_scope_id) {
-                    return _left.parent_scope_id < _right.parent_scope_id;
-                }
-                return _left.child_local_order < _right.child_local_order;
-            }
-        );
+            )) {
+            return false;
+        }
         struct TimingContractEnvelope {
             std::uint32_t parent_depth{0};
             std::uint64_t begin_tick{0};
@@ -3442,12 +3931,18 @@ struct ProfileSessionReader::Impl {
         timing_contract_envelopes.reserve(missing_parent_evidence.size());
         std::size_t timing_evidence_begin = 0;
         while (timing_evidence_begin < missing_parent_evidence.size()) {
+            if (CheckStopOnly()) {
+                return false;
+            }
             std::size_t timing_evidence_end = timing_evidence_begin + 1;
             while (timing_evidence_end < missing_parent_evidence.size() &&
                    missing_parent_evidence[timing_evidence_end].frame_id ==
                        missing_parent_evidence[timing_evidence_begin].frame_id &&
                    missing_parent_evidence[timing_evidence_end].parent_scope_id ==
                        missing_parent_evidence[timing_evidence_begin].parent_scope_id) {
+                if (CheckStopOnly()) {
+                    return false;
+                }
                 ++timing_evidence_end;
             }
 
@@ -3468,6 +3963,9 @@ struct ProfileSessionReader::Impl {
                                  frame->status == ProfileGpuFrameStatus::Complete;
             std::uint64_t envelope_end_offset = 0;
             for (std::size_t index = timing_evidence_begin; index < timing_evidence_end; ++index) {
+                if (CheckStopOnly()) {
+                    return false;
+                }
                 const MissingParentEvidence& evidence = missing_parent_evidence[index];
                 const GpuScopeRecord&        child = scopes[static_cast<std::size_t>(evidence.child_index)];
                 if (evidence.logical_queue != first_evidence.logical_queue ||
@@ -3519,6 +4017,9 @@ struct ProfileSessionReader::Impl {
                 .trusted      = trusted,
             });
             for (std::size_t index = timing_evidence_begin; index < timing_evidence_end; ++index) {
+                if (CheckStopOnly()) {
+                    return false;
+                }
                 timing_contract_for_child[static_cast<std::size_t>(missing_parent_evidence[index].child_index
                 )] = contract_index;
             }
@@ -3534,8 +4035,14 @@ struct ProfileSessionReader::Impl {
         }
         std::size_t timing_source_begin = 0;
         while (timing_source_begin < scopes.size()) {
+            if (CheckStopOnly()) {
+                return false;
+            }
             std::size_t timing_source_end = timing_source_begin + 1;
             while (timing_source_end < scopes.size()) {
+                if (CheckStopOnly()) {
+                    return false;
+                }
                 const GpuScopeRecord& first = scopes[timing_source_begin];
                 const GpuScopeRecord& next  = scopes[timing_source_end];
                 if (first.logical_queue != next.logical_queue ||
@@ -3558,6 +4065,9 @@ struct ProfileSessionReader::Impl {
                 ));
                 const auto close_observed_subtrees = [&](std::size_t _keep_count) {
                     while (timing_stack.size() > _keep_count) {
+                        if (CheckStopOnly()) {
+                            return false;
+                        }
                         const std::size_t child_index = static_cast<std::size_t>(timing_stack.back());
                         timing_stack.pop_back();
                         active_timing_stack_position[child_index] = kInvalidSessionIndex;
@@ -3575,8 +4085,12 @@ struct ProfileSessionReader::Impl {
                             completed_observed_child_end[parent_index], child_begin_offset + child_duration
                         );
                     }
+                    return true;
                 };
                 for (std::size_t index = timing_source_begin; index < timing_source_end; ++index) {
+                    if (CheckStopOnly()) {
+                        return false;
+                    }
                     const GpuScopeRecord& scope = scopes[index];
                     if (scope.status != ProfileGpuScopeStatus::Ready) {
                         Fail(
@@ -3650,7 +4164,9 @@ struct ProfileSessionReader::Impl {
                     }
 
                     if (container_position != timing_stack.size()) {
-                        close_observed_subtrees(container_position + 1);
+                        if (!close_observed_subtrees(container_position + 1)) {
+                            return false;
+                        }
                         const std::size_t     container_index = static_cast<std::size_t>(timing_stack.back());
                         const GpuScopeRecord& container       = scopes[container_index];
                         const std::uint64_t   scope_begin_offset =
@@ -3707,7 +4223,9 @@ struct ProfileSessionReader::Impl {
                                 }
                             }
                         }
-                        close_observed_subtrees(0);
+                        if (!close_observed_subtrees(0)) {
+                            return false;
+                        }
                     }
 
                     const std::uint64_t timing_parent = nearest_observed_timing_ancestor[index];
@@ -3740,7 +4258,9 @@ struct ProfileSessionReader::Impl {
                     timing_stack.push_back(index);
                     active_timing_stack_position[index] = timing_stack.size() - 1;
                 }
-                close_observed_subtrees(0);
+                if (!close_observed_subtrees(0)) {
+                    return false;
+                }
             }
             timing_source_begin = timing_source_end;
         }
@@ -3751,10 +4271,16 @@ struct ProfileSessionReader::Impl {
         std::vector<std::uint64_t> timing_subtree_end_local(scopes.size(), 0);
         std::vector<std::uint64_t> structural_subtree_end_local(scopes.size(), 0);
         for (std::size_t index = 0; index < scopes.size(); ++index) {
+            if (CheckStopOnly()) {
+                return false;
+            }
             timing_subtree_end_local[index]     = scopes[index].local_order;
             structural_subtree_end_local[index] = scopes[index].local_order;
         }
         for (std::size_t index = scopes.size(); index != 0; --index) {
+            if (CheckStopOnly()) {
+                return false;
+            }
             const std::size_t   scope_index         = index - 1;
             const std::uint64_t timing_parent_index = nearest_observed_timing_ancestor[scope_index];
             if (timing_parent_index != kInvalidSessionIndex) {
@@ -3782,9 +4308,15 @@ struct ProfileSessionReader::Impl {
             depth_range_leaf_count * 2, std::numeric_limits<std::uint32_t>::max()
         );
         for (std::size_t index = 0; index < scopes.size(); ++index) {
+            if (CheckStopOnly()) {
+                return false;
+            }
             depth_range_tree[depth_range_leaf_count + index] = scopes[index].depth;
         }
         for (std::size_t index = depth_range_leaf_count; index != 1; --index) {
+            if (CheckStopOnly()) {
+                return false;
+            }
             const std::size_t parent = index - 1;
             depth_range_tree[parent] =
                 std::min(depth_range_tree[parent * 2], depth_range_tree[parent * 2 + 1]);
@@ -3831,12 +4363,18 @@ struct ProfileSessionReader::Impl {
 
         std::size_t evidence_begin = 0;
         while (evidence_begin < missing_parent_evidence.size()) {
+            if (CheckStopOnly()) {
+                return false;
+            }
             std::size_t evidence_end = evidence_begin + 1;
             while (evidence_end < missing_parent_evidence.size() &&
                    missing_parent_evidence[evidence_end].frame_id ==
                        missing_parent_evidence[evidence_begin].frame_id &&
                    missing_parent_evidence[evidence_end].parent_scope_id ==
                        missing_parent_evidence[evidence_begin].parent_scope_id) {
+                if (CheckStopOnly()) {
+                    return false;
+                }
                 ++evidence_end;
             }
 
@@ -3848,6 +4386,9 @@ struct ProfileSessionReader::Impl {
             std::uint64_t earliest_child_sequence =
                 scopes[static_cast<std::size_t>(contract.child_index)].sequence;
             for (std::size_t index = evidence_begin + 1; index < evidence_end; ++index) {
+                if (CheckStopOnly()) {
+                    return false;
+                }
                 const MissingParentEvidence& evidence = missing_parent_evidence[index];
                 if (evidence.logical_queue != contract.logical_queue ||
                     evidence.native_queue_id != contract.native_queue_id ||
@@ -3954,6 +4495,9 @@ struct ProfileSessionReader::Impl {
                     scopes[missing_parent_evidence[evidence_begin].child_index];
                 envelope_end_offset = 0;
                 for (std::size_t index = evidence_begin; index < evidence_end; ++index) {
+                    if (CheckStopOnly()) {
+                        return false;
+                    }
                     const GpuScopeRecord& child = scopes[missing_parent_evidence[index].child_index];
                     if (child.status != ProfileGpuScopeStatus::Ready) {
                         Fail(
@@ -4067,45 +4611,52 @@ struct ProfileSessionReader::Impl {
         if (!ChargeTopologySortWork(missing_parent_contracts.size())) {
             return false;
         }
-        std::sort(
-            missing_parent_contracts.begin(),
-            missing_parent_contracts.end(),
-            [](const MissingParentContract& _left, const MissingParentContract& _right) {
-                if (_left.logical_queue != _right.logical_queue) {
-                    return _left.logical_queue < _right.logical_queue;
+        if (!CancellableSort(
+                missing_parent_contracts.begin(),
+                missing_parent_contracts.end(),
+                [](const MissingParentContract& _left, const MissingParentContract& _right) {
+                    if (_left.logical_queue != _right.logical_queue) {
+                        return _left.logical_queue < _right.logical_queue;
+                    }
+                    if (_left.native_queue_id != _right.native_queue_id) {
+                        return _left.native_queue_id < _right.native_queue_id;
+                    }
+                    if (_left.family_id != _right.family_id) {
+                        return _left.family_id < _right.family_id;
+                    }
+                    if (_left.frame_id != _right.frame_id) {
+                        return _left.frame_id < _right.frame_id;
+                    }
+                    if (_left.source_order != _right.source_order) {
+                        return _left.source_order < _right.source_order;
+                    }
+                    return _left.child_local_order_deadline < _right.child_local_order_deadline;
                 }
-                if (_left.native_queue_id != _right.native_queue_id) {
-                    return _left.native_queue_id < _right.native_queue_id;
-                }
-                if (_left.family_id != _right.family_id) {
-                    return _left.family_id < _right.family_id;
-                }
-                if (_left.frame_id != _right.frame_id) {
-                    return _left.frame_id < _right.frame_id;
-                }
-                if (_left.source_order != _right.source_order) {
-                    return _left.source_order < _right.source_order;
-                }
-                return _left.child_local_order_deadline < _right.child_local_order_deadline;
-            }
-        );
+            )) {
+            return false;
+        }
 
         if (!ChargeTopologySortWork(missing_frame_evidence.size()) ||
             !ChargeTopologyLinearWork(missing_frame_evidence.size())) {
             return false;
         }
-        std::sort(
-            missing_frame_evidence.begin(),
-            missing_frame_evidence.end(),
-            [](const MissingFrameEvidence& _left, const MissingFrameEvidence& _right) {
-                if (_left.frame_id != _right.frame_id) {
-                    return _left.frame_id < _right.frame_id;
+        if (!CancellableSort(
+                missing_frame_evidence.begin(),
+                missing_frame_evidence.end(),
+                [](const MissingFrameEvidence& _left, const MissingFrameEvidence& _right) {
+                    if (_left.frame_id != _right.frame_id) {
+                        return _left.frame_id < _right.frame_id;
+                    }
+                    return _left.earliest_scope_sequence < _right.earliest_scope_sequence;
                 }
-                return _left.earliest_scope_sequence < _right.earliest_scope_sequence;
-            }
-        );
+            )) {
+            return false;
+        }
         std::size_t missing_frame_count = 0;
         for (const MissingFrameEvidence& evidence : missing_frame_evidence) {
+            if (CheckStopOnly()) {
+                return false;
+            }
             if (missing_frame_count == 0 ||
                 missing_frame_evidence[missing_frame_count - 1].frame_id != evidence.frame_id) {
                 missing_frame_evidence[missing_frame_count++] = evidence;
@@ -4149,6 +4700,9 @@ struct ProfileSessionReader::Impl {
         std::size_t known_index   = 0;
         std::size_t missing_index = 0;
         while (known_index < frames.size() || missing_index < missing_frame_evidence.size()) {
+            if (CheckStopOnly()) {
+                return false;
+            }
             const bool take_known =
                 missing_index == missing_frame_evidence.size() ||
                 (known_index < frames.size() &&
@@ -4184,6 +4738,9 @@ struct ProfileSessionReader::Impl {
         std::uint64_t              previous_observed_end = 0;
         bool                       has_previous_boundary = false;
         for (std::size_t index = 0; index < frame_boundaries.size(); ++index) {
+            if (CheckStopOnly()) {
+                return false;
+            }
             FrameEmissionBoundary& boundary = frame_boundaries[index];
             if (boundary.known) {
                 const GpuFrameRecord& frame = frames[boundary.source_index];
@@ -4239,8 +4796,14 @@ struct ProfileSessionReader::Impl {
         source_loss_evidence.reserve(scopes.size());
         std::size_t source_begin = 0;
         while (source_begin < scopes.size()) {
+            if (CheckStopOnly()) {
+                return false;
+            }
             std::size_t source_end = source_begin + 1;
             while (source_end < scopes.size()) {
+                if (CheckStopOnly()) {
+                    return false;
+                }
                 const GpuScopeRecord& first = scopes[source_begin];
                 const GpuScopeRecord& next  = scopes[source_end];
                 if (first.logical_queue != next.logical_queue ||
@@ -4252,6 +4815,9 @@ struct ProfileSessionReader::Impl {
             }
 
             for (std::size_t index = source_begin; index < source_end; ++index) {
+                if (CheckStopOnly()) {
+                    return false;
+                }
                 if (scopes[index].depth > scopes[index].local_order) {
                     Fail(
                         SessionLoadStatus::ProtocolViolation,
@@ -4294,30 +4860,35 @@ struct ProfileSessionReader::Impl {
         std::vector<std::size_t> source_emission_order;
         source_emission_order.reserve(source_loss_evidence.size());
         for (std::size_t index = 0; index < source_loss_evidence.size(); ++index) {
+            if (CheckStopOnly()) {
+                return false;
+            }
             source_emission_order.push_back(index);
         }
-        std::sort(
-            source_emission_order.begin(),
-            source_emission_order.end(),
-            [&](std::size_t _left_index, std::size_t _right_index) {
-                const SourceLossEvidence& left  = source_loss_evidence[_left_index];
-                const SourceLossEvidence& right = source_loss_evidence[_right_index];
-                return std::tie(
-                           left.frame_id,
-                           left.logical_queue,
-                           left.native_queue_id,
-                           left.family_id,
-                           left.source_order
-                       ) <
-                       std::tie(
-                           right.frame_id,
-                           right.logical_queue,
-                           right.native_queue_id,
-                           right.family_id,
-                           right.source_order
-                       );
-            }
-        );
+        if (!CancellableSort(
+                source_emission_order.begin(),
+                source_emission_order.end(),
+                [&](std::size_t _left_index, std::size_t _right_index) {
+                    const SourceLossEvidence& left  = source_loss_evidence[_left_index];
+                    const SourceLossEvidence& right = source_loss_evidence[_right_index];
+                    return std::tie(
+                               left.frame_id,
+                               left.logical_queue,
+                               left.native_queue_id,
+                               left.family_id,
+                               left.source_order
+                           ) <
+                           std::tie(
+                               right.frame_id,
+                               right.logical_queue,
+                               right.native_queue_id,
+                               right.family_id,
+                               right.source_order
+                           );
+                }
+            )) {
+            return false;
+        }
         std::uint64_t previous_source_frame_id = 0;
         std::uint64_t previous_source_sequence = 0;
         bool          has_previous_source      = false;
@@ -4325,6 +4896,9 @@ struct ProfileSessionReader::Impl {
             return false;
         }
         for (const std::size_t source_index : source_emission_order) {
+            if (CheckStopOnly()) {
+                return false;
+            }
             SourceLossEvidence& source = source_loss_evidence[source_index];
             std::uint64_t predecessor  = has_previous_source && previous_source_frame_id == source.frame_id ?
                                              previous_source_sequence :
@@ -4367,8 +4941,14 @@ struct ProfileSessionReader::Impl {
             return false;
         }
         while (contract_begin < missing_parent_contracts.size()) {
+            if (CheckStopOnly()) {
+                return false;
+            }
             std::size_t contract_end = contract_begin + 1;
             while (contract_end < missing_parent_contracts.size()) {
+                if (CheckStopOnly()) {
+                    return false;
+                }
                 const MissingParentContract& first = missing_parent_contracts[contract_begin];
                 const MissingParentContract& next  = missing_parent_contracts[contract_end];
                 if (first.logical_queue != next.logical_queue ||
@@ -4449,6 +5029,9 @@ struct ProfileSessionReader::Impl {
             bool          has_observed_root              = false;
             for (std::size_t index = static_cast<std::size_t>(source->first_scope); index < source_end_index;
                  ++index) {
+                if (CheckStopOnly()) {
+                    return false;
+                }
                 depth_coordinates.push_back(scopes[index].depth);
                 if (scopes[index].parent_scope_id == 0) {
                     last_observed_root_local_order = scopes[index].local_order;
@@ -4456,16 +5039,25 @@ struct ProfileSessionReader::Impl {
                 }
             }
             for (std::size_t index = contract_begin; index < contract_end; ++index) {
+                if (CheckStopOnly()) {
+                    return false;
+                }
                 depth_coordinates.push_back(missing_parent_contracts[index].parent_depth);
             }
             if (!ChargeTopologySortWork(depth_coordinates.size()) ||
                 !ChargeTopologyLinearWork(depth_coordinates.size())) {
                 return false;
             }
-            std::sort(depth_coordinates.begin(), depth_coordinates.end());
-            depth_coordinates.erase(
-                std::unique(depth_coordinates.begin(), depth_coordinates.end()), depth_coordinates.end()
-            );
+            if (!CancellableSort(depth_coordinates.begin(), depth_coordinates.end())) {
+                return false;
+            }
+            auto unique_depth_coordinates_end = depth_coordinates.begin();
+            if (!CancellableUnique(
+                    depth_coordinates.begin(), depth_coordinates.end(), unique_depth_coordinates_end
+                )) {
+                return false;
+            }
+            depth_coordinates.erase(unique_depth_coordinates_end, depth_coordinates.end());
 
             if (!ChargeTopologyLinearWork(depth_coordinates.size()) ||
                 !ChargeTopologyLinearWork(depth_coordinates.size()) ||
@@ -4513,6 +5105,9 @@ struct ProfileSessionReader::Impl {
             };
 
             for (std::size_t index = contract_begin; index < contract_end; ++index) {
+                if (CheckStopOnly()) {
+                    return false;
+                }
                 if (!ChargeTopologyBinarySearchWork(depth_coordinates.size()) ||
                     !ChargeTopologyBinarySearchWork(depth_coordinates.size())) {
                     return false;
@@ -4607,25 +5202,36 @@ struct ProfileSessionReader::Impl {
                 for (std::size_t index = static_cast<std::size_t>(source->first_scope);
                      index < source_end_index;
                      ++index) {
+                    if (CheckStopOnly()) {
+                        return false;
+                    }
                     completion_order.push_back(index);
                 }
                 if (!ChargeTopologySortWork(completion_order.size())) {
                     return false;
                 }
-                std::sort(
-                    completion_order.begin(),
-                    completion_order.end(),
-                    [&](std::size_t _left, std::size_t _right) {
-                        return std::tie(timing_subtree_end_local[_left], scopes[_left].local_order) <
-                               std::tie(timing_subtree_end_local[_right], scopes[_right].local_order);
-                    }
-                );
+                if (!CancellableSort(
+                        completion_order.begin(),
+                        completion_order.end(),
+                        [&](std::size_t _left, std::size_t _right) {
+                            return std::tie(timing_subtree_end_local[_left], scopes[_left].local_order) <
+                                   std::tie(timing_subtree_end_local[_right], scopes[_right].local_order);
+                        }
+                    )) {
+                    return false;
+                }
                 std::size_t completed_observed_index = 0;
                 for (std::size_t index = contract_begin; index < contract_end; ++index) {
+                    if (CheckStopOnly()) {
+                        return false;
+                    }
                     const MissingParentContract& contract = missing_parent_contracts[index];
                     while (completed_observed_index < completion_order.size() &&
                            timing_subtree_end_local[completion_order[completed_observed_index]] <
                                contract.child_local_order_deadline) {
+                        if (CheckStopOnly()) {
+                            return false;
+                        }
                         if (!ChargeTopologyBinarySearchWork(depth_coordinates.size()) ||
                             !ChargeTopologyBinarySearchWork(depth_coordinates.size())) {
                             return false;
@@ -4674,6 +5280,9 @@ struct ProfileSessionReader::Impl {
                     }
                     const std::size_t current_chain_begin = chain_task_indices.size();
                     for (std::uint32_t depth = base_depth;; ++depth) {
+                        if (CheckStopOnly()) {
+                            return false;
+                        }
                         if (!ChargeTopologyBinarySearchWork(depth_coordinates.size()) ||
                             !ChargeTopologyBinarySearchWork(depth_coordinates.size())) {
                             return false;
@@ -4797,6 +5406,9 @@ struct ProfileSessionReader::Impl {
                                 for (std::size_t chain_index = current_chain_begin;
                                      chain_index < chain_task_indices.size();
                                      ++chain_index) {
+                                    if (CheckStopOnly()) {
+                                        return false;
+                                    }
                                     MissingTask clone = tasks[chain_task_indices[chain_index]];
                                     clone.first_allowed_slot =
                                         std::max(clone.first_allowed_slot, split_first_allowed);
@@ -4874,6 +5486,9 @@ struct ProfileSessionReader::Impl {
                 std::vector<std::uint8_t> task_active(tasks.size(), 0);
                 std::uint64_t             active_task_count = 0;
                 for (const std::uint64_t task_index : chain_task_indices) {
+                    if (CheckStopOnly()) {
+                        return false;
+                    }
                     if (task_active[static_cast<std::size_t>(task_index)] == 0) {
                         task_active[static_cast<std::size_t>(task_index)] = 1;
                         ++active_task_count;
@@ -4896,6 +5511,9 @@ struct ProfileSessionReader::Impl {
                 }
                 task_order.reserve(static_cast<std::size_t>(active_task_count));
                 for (std::size_t index = 0; index < tasks.size(); ++index) {
+                    if (CheckStopOnly()) {
+                        return false;
+                    }
                     if (task_active[index] != 0) {
                         task_order.push_back(static_cast<std::uint64_t>(index));
                     }
@@ -4903,16 +5521,20 @@ struct ProfileSessionReader::Impl {
                 if (!ChargeTopologySortWork(task_order.size())) {
                     return false;
                 }
-                std::sort(
-                    task_order.begin(),
-                    task_order.end(),
-                    [&](std::uint64_t _left, std::uint64_t _right) {
-                        const MissingTask& left  = tasks[_left];
-                        const MissingTask& right = tasks[_right];
-                        return std::tie(left.deadline_slot, left.first_allowed_slot, left.depth, _left) >
-                               std::tie(right.deadline_slot, right.first_allowed_slot, right.depth, _right);
-                    }
-                );
+                if (!CancellableSort(
+                        task_order.begin(),
+                        task_order.end(),
+                        [&](std::uint64_t _left, std::uint64_t _right) {
+                            const MissingTask& left  = tasks[_left];
+                            const MissingTask& right = tasks[_right];
+                            return std::tie(left.deadline_slot, left.first_allowed_slot, left.depth, _left) >
+                                   std::tie(
+                                       right.deadline_slot, right.first_allowed_slot, right.depth, _right
+                                   );
+                        }
+                    )) {
+                    return false;
+                }
                 const auto earlier_release = [&](std::uint64_t _left, std::uint64_t _right) {
                     const MissingTask& left  = tasks[_left];
                     const MissingTask& right = tasks[_right];
@@ -4937,6 +5559,9 @@ struct ProfileSessionReader::Impl {
                     return false;
                 }
                 while (ordered_task_index < task_order.size() || !ready_tasks.empty()) {
+                    if (CheckStopOnly()) {
+                        return false;
+                    }
                     if (!has_slot) {
                         Fail(
                             SessionLoadStatus::ProtocolViolation,
@@ -4959,6 +5584,9 @@ struct ProfileSessionReader::Impl {
                     }
                     while (observed_slot_index > static_cast<std::size_t>(source->first_scope) &&
                            scopes[observed_slot_index - 1].local_order > slot) {
+                        if (CheckStopOnly()) {
+                            return false;
+                        }
                         --observed_slot_index;
                     }
                     if (observed_slot_index > static_cast<std::size_t>(source->first_scope) &&
@@ -4989,8 +5617,14 @@ struct ProfileSessionReader::Impl {
                     return false;
                 }
                 for (const std::uint64_t chain_end_value : chain_ends) {
+                    if (CheckStopOnly()) {
+                        return false;
+                    }
                     const std::size_t chain_end = static_cast<std::size_t>(chain_end_value);
                     for (std::size_t index = chain_begin + 1; index < chain_end; ++index) {
+                        if (CheckStopOnly()) {
+                            return false;
+                        }
                         if (tasks[chain_task_indices[index - 1]].assigned_slot >=
                             tasks[chain_task_indices[index]].assigned_slot) {
                             Fail(
@@ -5016,9 +5650,15 @@ struct ProfileSessionReader::Impl {
                 for (std::size_t index = static_cast<std::size_t>(source->first_scope);
                      index < source_end_index;
                      ++index) {
+                    if (CheckStopOnly()) {
+                        return false;
+                    }
                     occupied_local_orders.push_back(scopes[index].local_order);
                 }
                 for (std::size_t task_index = 0; task_index < tasks.size(); ++task_index) {
+                    if (CheckStopOnly()) {
+                        return false;
+                    }
                     if (task_active[task_index] != 0) {
                         occupied_local_orders.push_back(tasks[task_index].assigned_slot);
                     }
@@ -5026,7 +5666,9 @@ struct ProfileSessionReader::Impl {
                 if (!ChargeTopologySortWork(occupied_local_orders.size())) {
                     return false;
                 }
-                std::sort(occupied_local_orders.begin(), occupied_local_orders.end());
+                if (!CancellableSort(occupied_local_orders.begin(), occupied_local_orders.end())) {
+                    return false;
+                }
 
                 if (!ChargeTopologyLinearWork(root_partition_candidates.size()) ||
                     !ChargeTopologyLinearWork(root_partition_candidates.size()) ||
@@ -5048,23 +5690,31 @@ struct ProfileSessionReader::Impl {
                 }
                 candidate_order.reserve(root_partition_candidates.size());
                 for (std::size_t index = 0; index < root_partition_candidates.size(); ++index) {
+                    if (CheckStopOnly()) {
+                        return false;
+                    }
                     candidate_order.push_back(index);
                 }
                 if (!ChargeTopologySortWork(candidate_order.size())) {
                     return false;
                 }
-                std::sort(
-                    candidate_order.begin(),
-                    candidate_order.end(),
-                    [&](std::size_t _left, std::size_t _right) {
-                        return std::tie(root_partition_candidates[_left].root_task_index, _left) <
-                               std::tie(root_partition_candidates[_right].root_task_index, _right);
-                    }
-                );
+                if (!CancellableSort(
+                        candidate_order.begin(),
+                        candidate_order.end(),
+                        [&](std::size_t _left, std::size_t _right) {
+                            return std::tie(root_partition_candidates[_left].root_task_index, _left) <
+                                   std::tie(root_partition_candidates[_right].root_task_index, _right);
+                        }
+                    )) {
+                    return false;
+                }
                 if (has_spare_local_holes) {
 
                     std::size_t group_begin = 0;
                     while (group_begin < candidate_order.size()) {
+                        if (CheckStopOnly()) {
+                            return false;
+                        }
                         std::size_t       group_end       = group_begin + 1;
                         const std::size_t root_task_index = static_cast<std::size_t>(
                             root_partition_candidates[candidate_order[group_begin]].root_task_index
@@ -5072,6 +5722,9 @@ struct ProfileSessionReader::Impl {
                         while (group_end < candidate_order.size() &&
                                root_partition_candidates[candidate_order[group_end]].root_task_index ==
                                    root_partition_candidates[candidate_order[group_begin]].root_task_index) {
+                            if (CheckStopOnly()) {
+                                return false;
+                            }
                             ++group_end;
                         }
                         if (task_active[root_task_index] == 0 ||
@@ -5082,6 +5735,9 @@ struct ProfileSessionReader::Impl {
                         }
 
                         for (std::size_t order_index = group_begin; order_index < group_end; ++order_index) {
+                            if (CheckStopOnly()) {
+                                return false;
+                            }
                             const std::size_t             candidate_index = candidate_order[order_index];
                             const RootPartitionCandidate& candidate =
                                 root_partition_candidates[candidate_index];
@@ -5098,6 +5754,9 @@ struct ProfileSessionReader::Impl {
                             for (std::size_t chain_index = candidate.chain_begin;
                                  chain_index < candidate.chain_end;
                                  ++chain_index) {
+                                if (CheckStopOnly()) {
+                                    return false;
+                                }
                                 const std::size_t task_index =
                                     static_cast<std::size_t>(chain_task_indices[chain_index]);
                                 if (chain_task_shared_with_prior[chain_index] != 0) {
@@ -5121,6 +5780,9 @@ struct ProfileSessionReader::Impl {
                             std::uint64_t              cursor    = first_unshared_slot;
                             std::uint64_t              root_slot = kInvalidSessionIndex;
                             for (std::uint64_t record = 0; record < required_split_records; ++record) {
+                                if (CheckStopOnly()) {
+                                    return false;
+                                }
                                 bool found = false;
                                 while (cursor != 0) {
                                     --cursor;
@@ -5162,17 +5824,21 @@ struct ProfileSessionReader::Impl {
                                 if (!ChargeTopologyLinearWork(candidate_reserved_slots.size())) {
                                     return false;
                                 }
-                                candidate_reserved_slot_storage.insert(
-                                    candidate_reserved_slot_storage.end(),
-                                    candidate_reserved_slots.begin(),
-                                    candidate_reserved_slots.end()
-                                );
+                                for (const std::uint64_t slot : candidate_reserved_slots) {
+                                    if (CheckStopOnly()) {
+                                        return false;
+                                    }
+                                    candidate_reserved_slot_storage.push_back(slot);
+                                }
                                 candidate_reserved_slot_end[candidate_index] =
                                     candidate_reserved_slot_storage.size();
                                 candidate_split_root_slot[candidate_index] = root_slot;
                                 task_has_concrete_split[root_task_index]   = 1;
                             } else {
                                 for (const std::uint64_t slot : candidate_reserved_slots) {
+                                    if (CheckStopOnly()) {
+                                        return false;
+                                    }
                                     if (!ChargeTopologyBinarySearchWork(reserved_split_slots.size())) {
                                         return false;
                                     }
@@ -5206,6 +5872,9 @@ struct ProfileSessionReader::Impl {
                 for (std::size_t index = static_cast<std::size_t>(source->first_scope);
                      index < source_end_index;
                      ++index) {
+                    if (CheckStopOnly()) {
+                        return false;
+                    }
                     const GpuScopeRecord& scope = scopes[index];
                     if (scope.parent_scope_id == 0) {
                         const RootComponent component{
@@ -5235,9 +5904,15 @@ struct ProfileSessionReader::Impl {
                     return false;
                 }
                 for (std::size_t task_index = 0; task_index < tasks.size(); ++task_index) {
+                    if (CheckStopOnly()) {
+                        return false;
+                    }
                     while (candidate_order_index < candidate_order.size() &&
                            root_partition_candidates[candidate_order[candidate_order_index]].root_task_index <
                                task_index) {
+                        if (CheckStopOnly()) {
+                            return false;
+                        }
                         ++candidate_order_index;
                     }
                     const std::size_t task_candidate_begin = candidate_order_index;
@@ -5246,6 +5921,9 @@ struct ProfileSessionReader::Impl {
                         root_partition_candidates[candidate_order[candidate_order_index]].root_task_index ==
                             task_index
                     ) {
+                        if (CheckStopOnly()) {
+                            return false;
+                        }
                         ++candidate_order_index;
                     }
                     const std::size_t task_candidate_end = candidate_order_index;
@@ -5288,6 +5966,9 @@ struct ProfileSessionReader::Impl {
                     };
                     for (std::size_t order_index = task_candidate_begin; order_index < task_candidate_end;
                          ++order_index) {
+                        if (CheckStopOnly()) {
+                            return false;
+                        }
                         const std::size_t             candidate_index = candidate_order[order_index];
                         const RootPartitionCandidate& candidate = root_partition_candidates[candidate_index];
                         const std::uint64_t split_root_slot     = candidate_split_root_slot[candidate_index];
@@ -5297,6 +5978,9 @@ struct ProfileSessionReader::Impl {
                             for (std::size_t slot_index = candidate_reserved_slot_begin[candidate_index];
                                  slot_index < candidate_reserved_slot_end[candidate_index];
                                  ++slot_index) {
+                                if (CheckStopOnly()) {
+                                    return false;
+                                }
                                 if (!ChargeTopologyHeapWork(used_split_slots.size() + 1)) {
                                     return false;
                                 }
@@ -5338,8 +6022,8 @@ struct ProfileSessionReader::Impl {
                     !ChargeTopologySortWork(split_root_components.size())) {
                     return false;
                 }
-                const auto sort_root_components = [](std::vector<RootComponent>& _components) {
-                    std::sort(
+                const auto sort_root_components = [&](std::vector<RootComponent>& _components) {
+                    return CancellableSort(
                         _components.begin(),
                         _components.end(),
                         [](const RootComponent& _left, const RootComponent& _right) {
@@ -5348,23 +6032,33 @@ struct ProfileSessionReader::Impl {
                         }
                     );
                 };
-                sort_root_components(root_components);
-                sort_root_components(split_root_components);
+                if (!sort_root_components(root_components) || !sort_root_components(split_root_components)) {
+                    return false;
+                }
                 if (!ChargeTopologyLinearWork(root_components.size()) ||
                     !ChargeTopologyLinearWork(split_root_components.size())) {
                     return false;
                 }
-                const auto duplicate_root_slot = [](const std::vector<RootComponent>& _components) {
-                    return std::adjacent_find(
-                               _components.begin(),
-                               _components.end(),
-                               [](const RootComponent& _left, const RootComponent& _right) {
-                                   return _left.local_order == _right.local_order;
-                               }
-                           ) != _components.end();
+                const auto duplicate_root_slot = [&](const std::vector<RootComponent>& _components,
+                                                     bool&                             _duplicate) {
+                    return CancellableAdjacentMatch(
+                        _components.begin(),
+                        _components.end(),
+                        [](const RootComponent& _left, const RootComponent& _right) {
+                            return _left.local_order == _right.local_order;
+                        },
+                        _duplicate
+                    );
                 };
-                if (duplicate_root_slot(root_components) ||
-                    (has_split_plan && duplicate_root_slot(split_root_components))) {
+                bool has_duplicate_root_slot = false;
+                if (!duplicate_root_slot(root_components, has_duplicate_root_slot)) {
+                    return false;
+                }
+                if (!has_duplicate_root_slot && has_split_plan &&
+                    !duplicate_root_slot(split_root_components, has_duplicate_root_slot)) {
+                    return false;
+                }
+                if (has_duplicate_root_slot) {
                     Fail(
                         SessionLoadStatus::ProtocolViolation,
                         SessionErrorCode::GpuScopeParentInvalid,
@@ -5399,6 +6093,9 @@ struct ProfileSessionReader::Impl {
                             return false;
                         }
                         for (std::size_t index = 0; index < _components.size(); ++index) {
+                            if (CheckStopOnly()) {
+                                return false;
+                            }
                             const RootComponent& component = _components[index];
                             if (index + 1 < _components.size() &&
                                 component.atomic_duration > maximum_root_step) {
@@ -5444,6 +6141,9 @@ struct ProfileSessionReader::Impl {
                         std::vector<RootSerialState> frontier{initial_state};
 
                         for (std::size_t index = 1; index < _components.size(); ++index) {
+                            if (CheckStopOnly()) {
+                                return false;
+                            }
                             const RootComponent& previous_component = _components[index - 1];
                             const RootComponent& component          = _components[index];
                             if (!ChargeTopologyBinarySearchWork(_occupied_local_orders.size())) {
@@ -5481,6 +6181,9 @@ struct ProfileSessionReader::Impl {
 
                             std::vector<RootSerialState> next_frontier;
                             for (const RootSerialState& state : frontier) {
+                                if (CheckStopOnly()) {
+                                    return false;
+                                }
                                 if (!charge_topology_work(free_root_count)) {
                                     topology_limit_failed = true;
                                     return false;
@@ -5494,6 +6197,9 @@ struct ProfileSessionReader::Impl {
                                 }
                                 bool window_overflow = false;
                                 for (std::uint64_t step = 0; step < free_root_count; ++step) {
+                                    if (CheckStopOnly()) {
+                                        return false;
+                                    }
                                     SerialTick next_upper{};
                                     if (!AddSerialTickDelta(
                                             window_upper, maximum_root_step, valid_bits, next_upper
@@ -5590,19 +6296,22 @@ struct ProfileSessionReader::Impl {
                                 topology_limit_failed = true;
                                 return false;
                             }
-                            std::sort(
-                                next_frontier.begin(),
-                                next_frontier.end(),
-                                [](const RootSerialState& _left, const RootSerialState& _right) {
-                                    if (_left.begin < _right.begin) {
-                                        return false;
+                            if (!CancellableSort(
+                                    next_frontier.begin(),
+                                    next_frontier.end(),
+                                    [](const RootSerialState& _left, const RootSerialState& _right) {
+                                        if (_left.begin < _right.begin) {
+                                            return false;
+                                        }
+                                        if (_right.begin < _left.begin) {
+                                            return true;
+                                        }
+                                        return _left.end < _right.end;
                                     }
-                                    if (_right.begin < _left.begin) {
-                                        return true;
-                                    }
-                                    return _left.end < _right.end;
-                                }
-                            );
+                                )) {
+                                topology_limit_failed = true;
+                                return false;
+                            }
                             std::vector<RootSerialState> pruned_frontier;
                             if (!ChargeTopologyLinearWork(next_frontier.size())) {
                                 topology_limit_failed = true;
@@ -5610,6 +6319,9 @@ struct ProfileSessionReader::Impl {
                             }
                             pruned_frontier.reserve(next_frontier.size());
                             for (const RootSerialState& state : next_frontier) {
+                                if (CheckStopOnly()) {
+                                    return false;
+                                }
                                 if (!pruned_frontier.empty() && !((state.end) < pruned_frontier.back().end)) {
                                     continue;
                                 }
@@ -5627,16 +6339,30 @@ struct ProfileSessionReader::Impl {
                             !ChargeTopologyLinearWork(used_split_slots.size())) {
                             return false;
                         }
-                        std::vector<std::uint64_t> split_occupied_local_orders = occupied_local_orders;
-                        split_occupied_local_orders.insert(
-                            split_occupied_local_orders.end(),
-                            used_split_slots.begin(),
-                            used_split_slots.end()
+                        std::vector<std::uint64_t> split_occupied_local_orders;
+                        split_occupied_local_orders.reserve(
+                            occupied_local_orders.size() + used_split_slots.size()
                         );
+                        for (const std::uint64_t slot : occupied_local_orders) {
+                            if (CheckStopOnly()) {
+                                return false;
+                            }
+                            split_occupied_local_orders.push_back(slot);
+                        }
+                        for (const std::uint64_t slot : used_split_slots) {
+                            if (CheckStopOnly()) {
+                                return false;
+                            }
+                            split_occupied_local_orders.push_back(slot);
+                        }
                         if (!ChargeTopologySortWork(split_occupied_local_orders.size())) {
                             return false;
                         }
-                        std::sort(split_occupied_local_orders.begin(), split_occupied_local_orders.end());
+                        if (!CancellableSort(
+                                split_occupied_local_orders.begin(), split_occupied_local_orders.end()
+                            )) {
+                            return false;
+                        }
                         root_sequence_valid =
                             validate_root_sequence(split_root_components, split_occupied_local_orders);
                         used_split_plan = root_sequence_valid;
@@ -5749,19 +6475,24 @@ struct ProfileSessionReader::Impl {
                 for (std::size_t index = static_cast<std::size_t>(source->first_scope);
                      index < source_end_index;
                      ++index) {
+                    if (CheckStopOnly()) {
+                        return false;
+                    }
                     structural_completion_order.push_back(index);
                 }
                 if (!ChargeTopologySortWork(structural_completion_order.size())) {
                     return false;
                 }
-                std::sort(
-                    structural_completion_order.begin(),
-                    structural_completion_order.end(),
-                    [&](std::size_t _left, std::size_t _right) {
-                        return std::tie(structural_subtree_end_local[_left], scopes[_left].local_order) <
-                               std::tie(structural_subtree_end_local[_right], scopes[_right].local_order);
-                    }
-                );
+                if (!CancellableSort(
+                        structural_completion_order.begin(),
+                        structural_completion_order.end(),
+                        [&](std::size_t _left, std::size_t _right) {
+                            return std::tie(structural_subtree_end_local[_left], scopes[_left].local_order) <
+                                   std::tie(structural_subtree_end_local[_right], scopes[_right].local_order);
+                        }
+                    )) {
+                    return false;
+                }
 
                 std::map<VirtualSequenceTaskKey, VirtualSequenceTaskState> virtual_task_states;
                 std::map<std::uint32_t, std::uint64_t>                     previous_missing_direct_end;
@@ -5988,11 +6719,17 @@ struct ProfileSessionReader::Impl {
                     source_end_index - static_cast<std::size_t>(source->first_scope)
                 ));
                 for (std::size_t index = contract_begin; index < contract_end; ++index) {
+                    if (CheckStopOnly()) {
+                        return false;
+                    }
                     const MissingParentContract& contract = missing_parent_contracts[index];
                     while (completed_structural_index < structural_completion_order.size() &&
                            structural_subtree_end_local
                                    [structural_completion_order[completed_structural_index]] <
                                contract.child_local_order_deadline) {
+                        if (CheckStopOnly()) {
+                            return false;
+                        }
                         if (!ChargeTopologyBinarySearchWork(depth_coordinates.size()) ||
                             !ChargeTopologyBinarySearchWork(depth_coordinates.size()) ||
                             !observe_structural_barrier(
@@ -6028,6 +6765,9 @@ struct ProfileSessionReader::Impl {
                     if (timing_topology_trusted) {
                         std::uint64_t ancestor_index = contract.observed_ancestor_index;
                         while (ancestor_index != kInvalidSessionIndex) {
+                            if (CheckStopOnly()) {
+                                return false;
+                            }
                             const GpuScopeRecord& ancestor = scopes[ancestor_index];
                             if (ancestor.depth < contract.parent_depth) {
                                 observed_ancestor_depths.push_back(ancestor.depth);
@@ -6038,14 +6778,28 @@ struct ProfileSessionReader::Impl {
                             !ChargeTopologyLinearWork(observed_ancestor_depths.size())) {
                             return false;
                         }
-                        std::sort(observed_ancestor_depths.begin(), observed_ancestor_depths.end());
+                        if (!CancellableSort(
+                                observed_ancestor_depths.begin(), observed_ancestor_depths.end()
+                            )) {
+                            return false;
+                        }
+                        auto unique_observed_ancestor_depths_end = observed_ancestor_depths.begin();
+                        if (!CancellableUnique(
+                                observed_ancestor_depths.begin(),
+                                observed_ancestor_depths.end(),
+                                unique_observed_ancestor_depths_end
+                            )) {
+                            return false;
+                        }
                         observed_ancestor_depths.erase(
-                            std::unique(observed_ancestor_depths.begin(), observed_ancestor_depths.end()),
-                            observed_ancestor_depths.end()
+                            unique_observed_ancestor_depths_end, observed_ancestor_depths.end()
                         );
                     } else {
                         while (observed_index < source_end_index &&
                                scopes[observed_index].local_order < contract.latest_parent_local_order) {
+                            if (CheckStopOnly()) {
+                                return false;
+                            }
                             if (!ChargeTopologyBinarySearchWork(depth_coordinates.size()) ||
                                 !ChargeTopologyBinarySearchWork(depth_coordinates.size()) ||
                                 !ChargeTopologyBinarySearchWork(depth_coordinates.size()) ||
@@ -6087,6 +6841,9 @@ struct ProfileSessionReader::Impl {
                         return false;
                     }
                     for (std::uint32_t depth = 0; depth < contract.parent_depth; ++depth) {
+                        if (CheckStopOnly()) {
+                            return false;
+                        }
                         if (!ChargeTopologyBinarySearchWork(depth_coordinates.size())) {
                             return false;
                         }
@@ -6110,6 +6867,9 @@ struct ProfileSessionReader::Impl {
                         covered_depth_count_before(contract.parent_depth, covered_depth_tree);
                     if (timing_topology_trusted) {
                         for (const std::uint32_t depth : observed_ancestor_depths) {
+                            if (CheckStopOnly()) {
+                                return false;
+                            }
                             if (!ChargeTopologyBinarySearchWork(depth_coordinates.size())) {
                                 return false;
                             }
@@ -6129,6 +6889,9 @@ struct ProfileSessionReader::Impl {
                     if (timing_topology_trusted) {
                         std::uint32_t interval_begin = 0;
                         for (const std::uint32_t depth : observed_ancestor_depths) {
+                            if (CheckStopOnly()) {
+                                return false;
+                            }
                             if (!charge_and_add_required_prefix_range(interval_begin, depth)) {
                                 return false;
                             }
@@ -6269,6 +7032,9 @@ struct ProfileSessionReader::Impl {
                     return false;
                 }
                 for (std::size_t task_index = 0; task_index < virtual_sequence_tasks.size(); ++task_index) {
+                    if (CheckStopOnly()) {
+                        return false;
+                    }
                     const VirtualSequenceTask& task = virtual_sequence_tasks[task_index];
                     joint_virtual_tasks.push_back({
                         .first_allowed_local = task.first_allowed_slot,
@@ -6298,10 +7064,16 @@ struct ProfileSessionReader::Impl {
                 local_boundaries.reserve(static_cast<std::size_t>(boundary_capacity));
                 local_boundaries.push_back(0);
                 for (const VirtualSequenceTask& task : virtual_sequence_tasks) {
+                    if (CheckStopOnly()) {
+                        return false;
+                    }
                     local_boundaries.push_back(task.first_allowed_slot);
                     local_boundaries.push_back(task.deadline_slot);
                 }
                 for (auto scope = source_scope_begin; scope != source_scope_end; ++scope) {
+                    if (CheckStopOnly()) {
+                        return false;
+                    }
                     local_boundaries.push_back(scope->local_order);
                     local_boundaries.push_back(scope->local_order + 1);
                 }
@@ -6309,14 +7081,23 @@ struct ProfileSessionReader::Impl {
                     !ChargeTopologyLinearWork(local_boundaries.size())) {
                     return false;
                 }
-                std::sort(local_boundaries.begin(), local_boundaries.end());
-                local_boundaries.erase(
-                    std::unique(local_boundaries.begin(), local_boundaries.end()), local_boundaries.end()
-                );
+                if (!CancellableSort(local_boundaries.begin(), local_boundaries.end())) {
+                    return false;
+                }
+                auto unique_local_boundaries_end = local_boundaries.begin();
+                if (!CancellableUnique(
+                        local_boundaries.begin(), local_boundaries.end(), unique_local_boundaries_end
+                    )) {
+                    return false;
+                }
+                local_boundaries.erase(unique_local_boundaries_end, local_boundaries.end());
 
                 std::vector<std::uint8_t> task_has_cell(virtual_sequence_tasks.size(), 0);
                 for (std::size_t boundary_index = 0; boundary_index + 1 < local_boundaries.size();
                      ++boundary_index) {
+                    if (CheckStopOnly()) {
+                        return false;
+                    }
                     const std::uint64_t cell_begin = local_boundaries[boundary_index];
                     const std::uint64_t cell_end   = local_boundaries[boundary_index + 1];
                     if (cell_begin >= cell_end) {
@@ -6373,6 +7154,9 @@ struct ProfileSessionReader::Impl {
                     }
                     for (std::size_t task_index = 0; task_index < virtual_sequence_tasks.size();
                          ++task_index) {
+                        if (CheckStopOnly()) {
+                            return false;
+                        }
                         const VirtualSequenceTask& task = virtual_sequence_tasks[task_index];
                         if (task.first_allowed_slot <= cell_begin && cell_end <= task.deadline_slot) {
                             if (successor->sequence - 1 > task.deadline_sequence) {
@@ -6433,7 +7217,17 @@ struct ProfileSessionReader::Impl {
                 if (!ChargeTopologyLinearWork(task_has_cell.size())) {
                     return false;
                 }
-                if (std::ranges::find(task_has_cell, std::uint8_t{0}) != task_has_cell.end()) {
+                bool missing_task_cell = false;
+                for (const std::uint8_t has_cell : task_has_cell) {
+                    if (CheckStopOnly()) {
+                        return false;
+                    }
+                    if (has_cell == 0) {
+                        missing_task_cell = true;
+                        break;
+                    }
+                }
+                if (missing_task_cell) {
                     Fail(
                         SessionLoadStatus::ProtocolViolation,
                         SessionErrorCode::GpuFrameTotalsMismatch,
@@ -6456,6 +7250,9 @@ struct ProfileSessionReader::Impl {
         }
         frame_loss_evidence.reserve(source_loss_evidence.size());
         for (const SourceLossEvidence& source : source_loss_evidence) {
+            if (CheckStopOnly()) {
+                return false;
+            }
             frame_loss_evidence.push_back({
                 .frame_id                     = source.frame_id,
                 .local_hole_count             = source.local_hole_count,
@@ -6465,18 +7262,23 @@ struct ProfileSessionReader::Impl {
         if (!ChargeTopologySortWork(frame_loss_evidence.size())) {
             return false;
         }
-        std::sort(
-            frame_loss_evidence.begin(),
-            frame_loss_evidence.end(),
-            [](const FrameLossEvidence& _left, const FrameLossEvidence& _right) {
-                return _left.frame_id < _right.frame_id;
-            }
-        );
+        if (!CancellableSort(
+                frame_loss_evidence.begin(),
+                frame_loss_evidence.end(),
+                [](const FrameLossEvidence& _left, const FrameLossEvidence& _right) {
+                    return _left.frame_id < _right.frame_id;
+                }
+            )) {
+            return false;
+        }
         std::size_t frame_evidence_count = 0;
         if (!ChargeTopologyLinearWork(frame_loss_evidence.size())) {
             return false;
         }
         for (std::size_t index = 0; index < frame_loss_evidence.size(); ++index) {
+            if (CheckStopOnly()) {
+                return false;
+            }
             if (frame_evidence_count == 0 || frame_loss_evidence[frame_evidence_count - 1].frame_id !=
                                                  frame_loss_evidence[index].frame_id) {
                 frame_loss_evidence[frame_evidence_count++] = frame_loss_evidence[index];
@@ -6522,17 +7324,21 @@ struct ProfileSessionReader::Impl {
             !ChargeTopologyLinearWork(missing_parent_keys.size())) {
             return false;
         }
-        std::sort(missing_parent_keys.begin(), missing_parent_keys.end());
-        missing_parent_keys.erase(
-            std::unique(
+        if (!CancellableSort(missing_parent_keys.begin(), missing_parent_keys.end())) {
+            return false;
+        }
+        auto unique_missing_parent_keys_end = missing_parent_keys.begin();
+        if (!CancellableUnique(
                 missing_parent_keys.begin(),
                 missing_parent_keys.end(),
                 [](const ScopeLookup& _left, const ScopeLookup& _right) {
                     return _left.frame_id == _right.frame_id && _left.scope_id == _right.scope_id;
-                }
-            ),
-            missing_parent_keys.end()
-        );
+                },
+                unique_missing_parent_keys_end
+            )) {
+            return false;
+        }
+        missing_parent_keys.erase(unique_missing_parent_keys_end, missing_parent_keys.end());
 
         const auto missing_parent_count = [&](std::uint64_t _frame_id) {
             const ScopeLookup first{
@@ -6570,6 +7376,9 @@ struct ProfileSessionReader::Impl {
             return false;
         }
         for (std::size_t index = 0; index < frames.size(); ++index) {
+            if (CheckStopOnly()) {
+                return false;
+            }
             GpuFrameRecord&     frame  = frames[index];
             const std::uint64_t errors = frame_error_counts[index];
             const bool          observed_too_many =
@@ -6667,6 +7476,9 @@ struct ProfileSessionReader::Impl {
         }
         for (std::size_t missing_frame_index = 0; missing_frame_index < missing_frame_evidence.size();
              ++missing_frame_index) {
+            if (CheckStopOnly()) {
+                return false;
+            }
             const MissingFrameEvidence& missing_frame = missing_frame_evidence[missing_frame_index];
             if (!ChargeTopologyBinarySearchWork(frame_loss_evidence.size()) ||
                 !ChargeTopologyBinarySearchWork(missing_parent_keys.size()) ||
@@ -6729,6 +7541,9 @@ struct ProfileSessionReader::Impl {
             return false;
         }
         for (std::size_t index = 0; index < scopes.size(); ++index) {
+            if (CheckStopOnly()) {
+                return false;
+            }
             const GpuScopeRecord& scope = scopes[index];
             if (scope.parent_scope_id != 0 || scope.frame_index == kInvalidSessionIndex) {
                 continue;
@@ -6779,6 +7594,9 @@ struct ProfileSessionReader::Impl {
             return false;
         }
         for (std::size_t index = 0; index < scopes.size(); ++index) {
+            if (CheckStopOnly()) {
+                return false;
+            }
             const GpuScopeRecord& scope = scopes[index];
             if (scope.frame_index == kInvalidSessionIndex) {
                 continue;
@@ -6823,6 +7641,9 @@ struct ProfileSessionReader::Impl {
             return false;
         }
         for (std::size_t index = 0; index < frames.size(); ++index) {
+            if (CheckStopOnly()) {
+                return false;
+            }
             GpuFrameRecord& frame         = frames[index];
             frame.timing_topology_trusted = frame.status == ProfileGpuFrameStatus::Complete &&
                                             frame.materialization_complete &&
@@ -6835,7 +7656,9 @@ struct ProfileSessionReader::Impl {
         if (!ChargeTopologySortWork(record_sequences.size())) {
             return false;
         }
-        std::sort(record_sequences.begin(), record_sequences.end());
+        if (!CancellableSort(record_sequences.begin(), record_sequences.end())) {
+            return false;
+        }
         if (!ChargeTopologyLinearWork(record_sequences.size())) {
             return false;
         }
@@ -6847,7 +7670,13 @@ struct ProfileSessionReader::Impl {
             );
             return false;
         }
-        if (std::adjacent_find(record_sequences.begin(), record_sequences.end()) != record_sequences.end()) {
+        bool duplicate_record_sequence = false;
+        if (!CancellableAdjacentMatch(
+                record_sequences.begin(), record_sequences.end(), duplicate_record_sequence
+            )) {
+            return false;
+        }
+        if (duplicate_record_sequence) {
             Fail(
                 SessionLoadStatus::ProtocolViolation,
                 SessionErrorCode::RecordSequenceDuplicate,
@@ -6911,9 +7740,12 @@ struct ProfileSessionReader::Impl {
                 return false;
             }
             cpu_sequence_demands.reserve(combined_demand_count);
-            cpu_sequence_demands.insert(
-                cpu_sequence_demands.end(), gpu_sequence_demands.begin(), gpu_sequence_demands.end()
-            );
+            for (const RecordSequenceDemand& demand : gpu_sequence_demands) {
+                if (CheckStopOnly()) {
+                    return false;
+                }
+                cpu_sequence_demands.push_back(demand);
+            }
         }
         if (!ValidateSequenceSlotCapacity(
                 cpu_sequence_demands, has_cpu_sequence_demands, has_gpu_topology_demands
@@ -6941,7 +7773,7 @@ struct ProfileSessionReader::Impl {
     }
 
     [[nodiscard]] SessionLoadResult Feed(std::span<const std::uint8_t> _bytes) noexcept {
-        if (!IsReading() || _bytes.empty()) {
+        if (!IsReading() || CheckCancellationNow() || _bytes.empty()) {
             return result;
         }
         try {
@@ -6965,6 +7797,9 @@ struct ProfileSessionReader::Impl {
 
             std::size_t cursor = 0;
             while (cursor < _bytes.size() && IsReading()) {
+                if (CheckCancellation()) {
+                    break;
+                }
                 if (saw_session_end) {
                     Fail(
                         SessionLoadStatus::ProtocolViolation,
@@ -7071,7 +7906,7 @@ struct ProfileSessionReader::Impl {
     }
 
     [[nodiscard]] SessionLoadResult Finish() noexcept {
-        if (!IsReading()) {
+        if (!IsReading() || CheckCancellationNow()) {
             return result;
         }
         try {
@@ -7113,7 +7948,7 @@ struct ProfileSessionReader::Impl {
                 forensic = true;
             }
 
-            if (!BuildIndexes(forensic)) {
+            if (CheckCancellationNow() || !BuildIndexes(forensic) || CheckCancellationNow()) {
                 return result;
             }
             if (forensic) {
@@ -7141,6 +7976,7 @@ struct ProfileSessionReader::Impl {
     }
 
     SessionLoadOptions options{};
+    CancellationProbe  cancellation;
     SessionLoadResult  result{};
     const char*        diagnostic{"profile session reader is accepting input"};
     ProfileSession     session{};
@@ -7162,13 +7998,19 @@ struct ProfileSessionReader::Impl {
     std::uint64_t                                         topology_work_items{0};
 };
 
-ProfileSessionReader::ProfileSessionReader(const SessionLoadOptions& _options) noexcept {
+ProfileSessionReader::ProfileSessionReader(const SessionLoadOptions& _options) noexcept :
+    ProfileSessionReader(_options, SessionLoadControl{}) {}
+
+ProfileSessionReader::ProfileSessionReader(
+    const SessionLoadOptions& _options,
+    const SessionLoadControl& _control
+) noexcept {
     static_assert(
-        !std::is_nothrow_constructible_v<Impl, const SessionLoadOptions&>,
+        !std::is_nothrow_constructible_v<Impl, const SessionLoadOptions&, const SessionLoadControl&>,
         "reader implementation construction must propagate to the public catch boundary"
     );
     try {
-        impl_ = new (std::nothrow) Impl(_options);
+        impl_ = new (std::nothrow) Impl(_options, _control);
     } catch (...) {
         impl_ = nullptr;
     }
@@ -7224,6 +8066,15 @@ SessionLoadResult LoadProfileSessionFile(
     const SessionLoadOptions&    _options,
     ProfileSession&              _output
 ) noexcept {
+    return LoadProfileSessionFile(_path, _options, _output, SessionLoadControl{});
+}
+
+SessionLoadResult LoadProfileSessionFile(
+    const std::filesystem::path& _path,
+    const SessionLoadOptions&    _options,
+    ProfileSession&              _output,
+    const SessionLoadControl&    _control
+) noexcept {
     if (_path.empty()) {
         SessionLoadResult result{};
         result.status     = SessionLoadStatus::InvalidArgument;
@@ -7232,6 +8083,11 @@ SessionLoadResult LoadProfileSessionFile(
     }
 
     try {
+        ProfileSessionReader reader(_options, _control);
+        if (reader.Result().status != SessionLoadStatus::Reading) {
+            return reader.Result();
+        }
+
         std::ifstream stream(_path, std::ios::binary | std::ios::ate);
         if (!stream.is_open()) {
             SessionLoadResult result{};
@@ -7263,14 +8119,18 @@ SessionLoadResult LoadProfileSessionFile(
             return result;
         }
 
-        ProfileSessionReader reader(_options);
-        if (reader.Result().status != SessionLoadStatus::Reading) {
-            return reader.Result();
+        const SessionLoadResult before_read = reader.Feed({});
+        if (before_read.IsTerminal()) {
+            return before_read;
         }
 
         std::array<std::uint8_t, kReadBlockBytes> block{};
         std::uint64_t                             remaining = snapshot_bytes;
         while (remaining != 0) {
+            const SessionLoadResult before_block = reader.Feed({});
+            if (before_block.IsTerminal()) {
+                return before_block;
+            }
             const std::size_t request =
                 static_cast<std::size_t>(std::min<std::uint64_t>(remaining, block.size()));
             stream.read(reinterpret_cast<char*>(block.data()), static_cast<std::streamsize>(request));
@@ -7284,6 +8144,10 @@ SessionLoadResult LoadProfileSessionFile(
                 return result;
             }
 
+            const SessionLoadResult after_read = reader.Feed({});
+            if (after_read.IsTerminal()) {
+                return after_read;
+            }
             const SessionLoadResult fed =
                 reader.Feed(std::span<const std::uint8_t>(block.data(), static_cast<std::size_t>(read)));
             if (fed.IsTerminal()) {
@@ -7292,6 +8156,10 @@ SessionLoadResult LoadProfileSessionFile(
             remaining -= static_cast<std::uint64_t>(read);
         }
 
+        const SessionLoadResult before_finish = reader.Feed({});
+        if (before_finish.IsTerminal()) {
+            return before_finish;
+        }
         const SessionLoadResult finished = reader.Finish();
         if (finished.HasUsableSession()) {
             _output = reader.TakeSession();

--- a/source/tool/profile_consumer/source/ProfileTimelineIndex.cpp
+++ b/source/tool/profile_consumer/source/ProfileTimelineIndex.cpp
@@ -64,7 +64,7 @@ public:
         remaining_budget_(_control.max_work_items_before_cancel) {}
 
     [[nodiscard]] bool Requested(std::uint64_t _work_items = 1) noexcept {
-        if (_work_items >= remaining_budget_) {
+        if (_work_items > remaining_budget_) {
             remaining_budget_ = 0;
             return true;
         }


### PR DESCRIPTION
## Summary

- add an immutable `ProfileDocument` that owns one coherent `ProfileSession` + `ProfileTimelineIndex` publication
- add a persistent `std::jthread` loader with latest-request-wins, one bounded pending slot, generation pairing, last-good preservation, and joined shutdown
- extend `ProfileSessionReader`/file loading with cooperative cancellation, exact deterministic work budgets, bounded cancellable sort/merge, and a separate transient-materialization limit
- complete summary CLI mappings for the new cancellation/limit outcomes
- add loader concurrency, cancellation, failure, publication, shutdown, and real-capture contract coverage

## Ownership and cancellation contract

- worker constructs the complete candidate; only `shared_ptr<const ProfileDocument>` is published
- stale/failed/cancelled work cannot replace the last-good document
- terminal state and active-generation flags are completed under the same mutex
- accepted blocking OS I/O, one codec packet, one allocator/destructor operation, and one bounded sort run remain documented cooperative-cancellation atomic boundaries

## Validation

- Debug: full build + CTest `32/32`
- RelWithDebInfo: full build + CTest `32/32`
- Release: full build + CTest `32/32`
- RelWithDebInfo loader contract repeated `5/5`
- real 47,839,328-byte capture: `194861` CPU scopes / `97431` GPU scopes
- real 166,745,345-byte capture: `510905` CPU scopes / `540178` GPU scopes
- independent final architecture audit: P1 `0`, P2 `0`

## Scope

This is D.3b (consumer library + CPU-only contracts). Editor file dialog and timeline UI integration remain D.3c.