### PR TITLE
Phase 21D.3c: add embedded profile viewer

### DIFF
--- a/source/editor/CMakeLists.txt
+++ b/source/editor/CMakeLists.txt
@@ -27,6 +27,7 @@ set_target_properties(${editor_library_target} PROPERTIES FOLDER "editor")
 
 target_link_libraries(${editor_library_target}
     PUBLIC Moer::Runtime
+    PRIVATE Moer::ProfileConsumer
     PRIVATE nfd
 )
 

--- a/source/editor/Editor.cpp
+++ b/source/editor/Editor.cpp
@@ -1,9 +1,17 @@
 #include "Editor.h"
 
+#include "Core.h"
 #include "Engine.h"
+#include "profile_consumer/ProfileDocument.h"
 
 #include "EditorUI.h"
 #include "window/WindowContext.h"
+
+#include <nfd.hpp>
+
+#include <cassert>
+#include <stdexcept>
+#include <string>
 
 using namespace Moer::Render;
 
@@ -24,12 +32,7 @@ void Editor::Init(int argc, const char** argv, StartupHooks startup_hooks) {
     ReportStartupProgress("Starting MoerEditor", "Initializing the engine core");
     m_engine = MakeUnique<Engine>();
     try {
-        m_engine->Init(
-            argc,
-            argv,
-            m_startup_hooks.main_window_visible,
-            m_startup_hooks.on_progress
-        );
+        m_engine->Init(argc, argv, m_startup_hooks.main_window_visible, m_startup_hooks.on_progress);
     } catch (...) {
         m_engine->ShutDown();
         m_engine.reset();
@@ -42,17 +45,32 @@ void Editor::Run() {
 }
 
 void Editor::Run(const ExtraHooks& extra_hooks) {
-    // UI 的生命周期限定在 Engine::Run 内，因为其渲染器资源依赖当前运行的 Engine。
-    ReportStartupProgress("Preparing editor interface", "Building ImGui fonts and GPU resources");
-    m_editor_ui = MakeUnique<EditorUI>(
-        MakeUnique<Render::UIRenderer>(RenderDevice::Get()),
-        m_engine->GetEditorConfig(),
-        m_engine->GetRemoteModuleController(),
-        *m_engine
-    );
+    try {
+        if (!m_engine) {
+            throw std::logic_error("Editor::Run requires a successfully initialized Engine.");
+        }
+        if (!IsCurrentlyGameThread()) {
+            throw std::runtime_error(
+                "Editor::Run and native file dialog initialization must run on the Game Thread."
+            );
+        }
 
-    m_engine->Run(
-        EngineHooks{
+        InitializeNativeFileDialog();
+        if (!m_profile_document_loader) {
+            m_profile_document_loader = MakeUnique<ProfileDump::ProfileDocumentLoader>();
+        }
+
+        // UI 的生命周期限定在 Engine::Run 内，因为其渲染器资源依赖当前运行的 Engine。
+        ReportStartupProgress("Preparing editor interface", "Building ImGui fonts and GPU resources");
+        m_editor_ui = MakeUnique<EditorUI>(
+            MakeUnique<Render::UIRenderer>(RenderDevice::Get()),
+            m_engine->GetEditorConfig(),
+            m_engine->GetRemoteModuleController(),
+            *m_engine,
+            *m_profile_document_loader
+        );
+
+        m_engine->Run(EngineHooks{
             // Common
             .on_tick_test = extra_hooks.on_tick_test,
             .on_tick_ui =
@@ -116,10 +134,16 @@ void Editor::Run(const ExtraHooks& extra_hooks) {
                 [this](const Array<std::string>& names) {
                     m_editor_ui->m_raster_ui.RegisterFrameBufferNames(names);
                 }
-        }
-    );
+        });
 
-    m_editor_ui.reset();
+        m_editor_ui.reset();
+    } catch (...) {
+        // Keep failure rollback identical to explicit shutdown: UI resources
+        // cannot outlive the loader, and NFD must leave the Game Thread before
+        // the Engine tears down its window and worker services.
+        ShutDown();
+        throw;
+    }
 }
 
 void Editor::ReportStartupProgress(std::string_view title, std::string_view detail) const noexcept {
@@ -134,10 +158,44 @@ void Editor::ReportStartupProgress(std::string_view title, std::string_view deta
 
 void Editor::ShutDown() noexcept {
     m_editor_ui.reset();
+    if (m_profile_document_loader) {
+        m_profile_document_loader->Shutdown();
+        m_profile_document_loader.reset();
+    }
+    ShutDownNativeFileDialog();
     if (m_engine) {
         m_engine->ShutDown();
         m_engine.reset();
     }
+}
+
+void Editor::InitializeNativeFileDialog() {
+    if (m_nfd_initialized) {
+        return;
+    }
+
+    assert(IsCurrentlyGameThread());
+    const nfdresult_t result = NFD::Init();
+    if (result == NFD_OKAY) {
+        m_nfd_initialized = true;
+        return;
+    }
+
+    const char* error = NFD_GetError();
+    throw std::runtime_error(
+        std::string("Failed to initialize the native file dialog on the Game Thread: ") +
+        (error != nullptr && error[0] != '\0' ? error : "unknown NFD initialization error")
+    );
+}
+
+void Editor::ShutDownNativeFileDialog() noexcept {
+    if (!m_nfd_initialized) {
+        return;
+    }
+
+    assert(IsCurrentlyGameThread());
+    NFD::Quit();
+    m_nfd_initialized = false;
 }
 
 Engine& Editor::GetEngine() {

--- a/source/editor/Editor.h
+++ b/source/editor/Editor.h
@@ -13,12 +13,16 @@ class EditorUI;
 class Engine;
 class Scene;
 
+namespace ProfileDump {
+class ProfileDocumentLoader;
+}
+
 class Editor {
 public:
     struct StartupHooks {
-        bool main_window_visible = true;
+        bool                                                                 main_window_visible = true;
         std::function<void(std::string_view title, std::string_view detail)> on_progress;
-        std::function<void()> on_first_main_present;
+        std::function<void()>                                                on_first_main_present;
     };
 
     struct ExtraHooks {
@@ -32,6 +36,8 @@ public:
     void Init(int argc, const char** argv, StartupHooks startup_hooks);
     void Run();
     void Run(const ExtraHooks& extra_hooks);
+    // Run and ShutDown are Game Thread operations. Native file-dialog
+    // initialization and teardown must remain on that owning thread.
     void ShutDown() noexcept;
 
     Engine&       GetEngine();
@@ -39,10 +45,14 @@ public:
 
 private:
     void ReportStartupProgress(std::string_view title, std::string_view detail) const noexcept;
+    void InitializeNativeFileDialog();
+    void ShutDownNativeFileDialog() noexcept;
 
-    UniquePtr<Engine>   m_engine;
-    UniquePtr<EditorUI> m_editor_ui;
-    StartupHooks        m_startup_hooks;
+    UniquePtr<Engine>                             m_engine;
+    UniquePtr<ProfileDump::ProfileDocumentLoader> m_profile_document_loader;
+    UniquePtr<EditorUI>                           m_editor_ui;
+    StartupHooks                                  m_startup_hooks;
+    bool                                          m_nfd_initialized = false;
 };
 
 } // namespace Moer

--- a/source/editor/EditorUI.cpp
+++ b/source/editor/EditorUI.cpp
@@ -64,12 +64,14 @@ EditorUI::EditorUI(
     UniquePtr<Render::UIRenderer>         renderer,
     SharedPtr<EditorConfig>               editor_config,
     const remote::RemoteModuleController& remote_controller,
-    Engine&                               engine
+    Engine&                               engine,
+    ProfileDump::ProfileDocumentLoader&   profile_document_loader
 ) :
     m_raster_ui(editor_config->raster_config),
     m_raytracing_ui(editor_config->raytracing_config),
     m_scene_editing_ui(editor_config->scene_test_case_config),
     m_profile_capture_ui(engine),
+    m_profile_viewer_ui(profile_document_loader),
     m_config(editor_config),
     m_remote_controller(remote_controller),
     m_ui_renderer(std::move(renderer)) {
@@ -90,6 +92,7 @@ EditorUI::EditorUI(
         m_b_show_scene_editing = window_visibility_settings.scene_editing;
         m_b_show_profile_capture =
             window_visibility_settings.profile_capture;
+        m_b_show_profile_viewer = window_visibility_settings.profile_viewer;
 #if WITH_PROFILE
         m_b_show_memory_profiler = window_visibility_settings.memory_profiler;
 #endif
@@ -102,6 +105,7 @@ EditorUI::EditorUI(
         m_b_show_scene_editing = has_saved_window_settings("Scene Editing");
         m_b_show_profile_capture =
             has_saved_window_settings("Profile Capture");
+        m_b_show_profile_viewer = has_saved_window_settings("Profile Viewer");
 #if WITH_PROFILE
         m_b_show_memory_profiler = has_saved_window_settings("Memory Profiler");
 #endif
@@ -374,6 +378,7 @@ void EditorUI::TickUI(Scene& scene) {
                 nullptr,
                 &m_b_show_profile_capture
             );
+            ImGui::MenuItem("Profile Viewer", nullptr, &m_b_show_profile_viewer);
             // ImGui::MenuItem("Demo", nullptr, &m_b_show_demo);
 #if WITH_PROFILE
             ImGui::MenuItem("Memory Profiler", nullptr, &m_b_show_memory_profiler);
@@ -385,6 +390,9 @@ void EditorUI::TickUI(Scene& scene) {
     ImGui::End();
     if (m_b_show_profile_capture) {
         m_profile_capture_ui.ShowWindow(&m_b_show_profile_capture);
+    }
+    if (m_b_show_profile_viewer) {
+        m_profile_viewer_ui.ShowWindow(&m_b_show_profile_viewer);
     }
 #if WITH_PROFILE
     if (m_b_show_memory_profiler) {
@@ -944,6 +952,7 @@ void EditorUI::SyncWindowVisibilitySettings() {
     settings.config        = m_b_show_config;
     settings.scene_editing = m_b_show_scene_editing;
     settings.profile_capture = m_b_show_profile_capture;
+    settings.profile_viewer = m_b_show_profile_viewer;
 #if WITH_PROFILE
     settings.memory_profiler = m_b_show_memory_profiler;
 #else

--- a/source/editor/EditorUI.h
+++ b/source/editor/EditorUI.h
@@ -10,6 +10,7 @@
 
 #include "inspector_ui/InspectorUI.h"
 #include "profile_capture_ui/ProfileCaptureUI.h"
+#include "profile_viewer_ui/ProfileViewerUI.h"
 #include "raster_ui/RasterUI.h"
 #include "raytracing_ui/RaytracingUI.h"
 #include "scene_editing_ui/SceneEditingUI.h"
@@ -51,7 +52,8 @@ public:
         UniquePtr<Render::UIRenderer>         renderer,
         SharedPtr<EditorConfig>               editor_config,
         const remote::RemoteModuleController& remote_controller,
-        Engine&                               engine
+        Engine&                               engine,
+        ProfileDump::ProfileDocumentLoader&   profile_document_loader
     );
     ~EditorUI() = default;
     void TickUI(Scene& scene);
@@ -89,6 +91,7 @@ public: // Sub UI
     SceneEditingUI m_scene_editing_ui;
     RemoteExamplesUI m_remote_examples_ui;
     ProfileCaptureUI m_profile_capture_ui;
+    ProfileViewerUI  m_profile_viewer_ui;
 
 private:
     void ResetFrameState();
@@ -117,6 +120,7 @@ private:
     bool   m_b_show_config                = true;
     bool   m_b_show_scene_editing         = true;
     bool   m_b_show_profile_capture       = false;
+    bool   m_b_show_profile_viewer        = false;
     bool   m_b_scene_color_mouse_captured = false;
     bool   m_b_active_viewport_window_seen = false;
     // ImGui 窗口几何信息使用浮点屏幕坐标表示。

--- a/source/editor/EditorUISettings.cpp
+++ b/source/editor/EditorUISettings.cpp
@@ -55,6 +55,7 @@ void ParseEditorWindowVisibilityLine(EditorWindowVisibilitySettings& settings, s
             "ProfileCapture",
             settings.profile_capture
         ) ||
+        TryParseBoolSetting(line, "ProfileViewer", settings.profile_viewer) ||
         TryParseBoolSetting(line, "MemoryProfiler", settings.memory_profiler)) {
         settings.loaded = true;
     }
@@ -96,6 +97,7 @@ void EditorWindowVisibilitySettingsWriteAll(ImGuiContext*, ImGuiSettingsHandler*
         "ProfileCapture=%d\n",
         settings.profile_capture ? 1 : 0
     );
+    out_buf->appendf("ProfileViewer=%d\n", settings.profile_viewer ? 1 : 0);
     out_buf->appendf("MemoryProfiler=%d\n\n", settings.memory_profiler ? 1 : 0);
 }
 
@@ -163,6 +165,7 @@ bool IsSameWindowVisibilitySettings(
            lhs.inspector == rhs.inspector && lhs.config == rhs.config &&
            lhs.scene_editing == rhs.scene_editing &&
            lhs.profile_capture == rhs.profile_capture &&
+           lhs.profile_viewer == rhs.profile_viewer &&
            lhs.memory_profiler == rhs.memory_profiler;
 }
 

--- a/source/editor/EditorUISettings.h
+++ b/source/editor/EditorUISettings.h
@@ -20,6 +20,7 @@ struct EditorWindowVisibilitySettings {
     bool config          = true;
     bool scene_editing   = true;
     bool profile_capture = false;
+    bool profile_viewer  = false;
     bool memory_profiler = false;
 };
 

--- a/source/editor/profile_viewer_ui/ProfileViewerModel.cpp
+++ b/source/editor/profile_viewer_ui/ProfileViewerModel.cpp
@@ -1,6 +1,7 @@
 #include "profile_viewer_ui/ProfileViewerModel.h"
 
 #include <algorithm>
+#include <iterator>
 #include <limits>
 
 namespace Moer {
@@ -40,6 +41,142 @@ ScaleCeilSaturated(std::uint64_t _value, std::uint32_t _numerator, std::uint32_t
     return static_cast<std::uint64_t>(-(_value + 1)) + 1;
 }
 
+enum class EGpuFrameChoiceSearch : std::uint8_t {
+    AtOrAfter = 0,
+    After,
+    Before,
+    AtOrBefore,
+};
+
+template<typename Iterator>
+[[nodiscard]] Iterator FindFrameInSortedRange(
+    Iterator              _begin,
+    Iterator              _end,
+    std::uint64_t         _frame_id,
+    EGpuFrameChoiceSearch _search
+) noexcept {
+    const auto less = [](const auto& _frame, std::uint64_t _value) {
+        return _frame.frame_id < _value;
+    };
+    const auto reverse_less = [](std::uint64_t _value, const auto& _frame) {
+        return _value < _frame.frame_id;
+    };
+
+    switch (_search) {
+        case EGpuFrameChoiceSearch::AtOrAfter:
+            return std::lower_bound(_begin, _end, _frame_id, less);
+        case EGpuFrameChoiceSearch::After:
+            return std::upper_bound(_begin, _end, _frame_id, reverse_less);
+        case EGpuFrameChoiceSearch::Before: {
+            const Iterator found = std::lower_bound(_begin, _end, _frame_id, less);
+            return found == _begin ? _end : std::prev(found);
+        }
+        case EGpuFrameChoiceSearch::AtOrBefore: {
+            const Iterator found = std::upper_bound(_begin, _end, _frame_id, reverse_less);
+            return found == _begin ? _end : std::prev(found);
+        }
+    }
+    return _end;
+}
+
+void MergeGpuFrameChoice(
+    std::optional<ProfileViewerGpuFrameChoice>& _best,
+    ProfileViewerGpuFrameChoice                 _candidate,
+    EGpuFrameChoiceSearch                       _search
+) noexcept {
+    if (!_best) {
+        _best = _candidate;
+        return;
+    }
+    if (_candidate.frame_id == _best->frame_id) {
+        _best->has_frame_record = _best->has_frame_record || _candidate.has_frame_record;
+        return;
+    }
+
+    const bool prefer_lower =
+        _search == EGpuFrameChoiceSearch::AtOrAfter || _search == EGpuFrameChoiceSearch::After;
+    if ((prefer_lower && _candidate.frame_id < _best->frame_id) ||
+        (!prefer_lower && _candidate.frame_id > _best->frame_id)) {
+        _best = _candidate;
+    }
+}
+
+template<typename Iterator, typename HasFrameRecord>
+void ConsiderGpuFrameRange(
+    Iterator                                    _begin,
+    Iterator                                    _end,
+    std::uint64_t                               _frame_id,
+    EGpuFrameChoiceSearch                       _search,
+    HasFrameRecord                              _has_frame_record,
+    std::optional<ProfileViewerGpuFrameChoice>& _best
+) noexcept {
+    const Iterator found = FindFrameInSortedRange(_begin, _end, _frame_id, _search);
+    if (found != _end) {
+        MergeGpuFrameChoice(
+            _best,
+            ProfileViewerGpuFrameChoice{
+                .frame_id         = found->frame_id,
+                .has_frame_record = _has_frame_record(*found),
+            },
+            _search
+        );
+    }
+}
+
+[[nodiscard]] std::optional<ProfileViewerGpuFrameChoice> FindProfileViewerGpuFrame(
+    std::span<const ProfileDump::GpuTimelineFrameRef>  _recorded_frames,
+    std::span<const ProfileDump::GpuTimelineAxisFrame> _axis_frames,
+    std::uint64_t                                      _frame_id,
+    EGpuFrameChoiceSearch                              _search
+) noexcept {
+    std::optional<ProfileViewerGpuFrameChoice> best;
+    ConsiderGpuFrameRange(
+        _recorded_frames.begin(),
+        _recorded_frames.end(),
+        _frame_id,
+        _search,
+        [](const ProfileDump::GpuTimelineFrameRef&) {
+            return true;
+        },
+        best
+    );
+
+    // GpuAxisFrames are sorted by (axis_index, frame_id). Binary-search each
+    // physical-axis group that the UI can render (indices 1..256). This keeps
+    // chooser and tab discovery on the same contract. Work is
+    // O(renderable_axis_count * log(frame_count)) with no allocation and no
+    // scan proportional to the scope/axis-frame count.
+    auto group_begin = _axis_frames.begin();
+    while (group_begin != _axis_frames.end()) {
+        const std::uint32_t axis_index = group_begin->axis_index;
+        const auto          group_end  = std::upper_bound(
+            group_begin,
+            _axis_frames.end(),
+            axis_index,
+            [](std::uint32_t _value, const ProfileDump::GpuTimelineAxisFrame& _frame) {
+                return _value < _frame.axis_index;
+            }
+        );
+        if (axis_index > kProfileViewerGpuRenderableAxisMax) {
+            break;
+        }
+        if (axis_index != 0) {
+            ConsiderGpuFrameRange(
+                group_begin,
+                group_end,
+                _frame_id,
+                _search,
+                [](const ProfileDump::GpuTimelineAxisFrame& _frame) {
+                    return _frame.has_frame_record;
+                },
+                best
+            );
+        }
+        group_begin = group_end;
+    }
+    return best;
+}
+
 } // namespace
 
 std::uint64_t ProfileViewerMapFraction(
@@ -58,6 +195,44 @@ std::uint64_t ProfileViewerMapFraction(
     return _begin + MulDivFloor(_end - _begin, _numerator, _denominator);
 }
 
+std::optional<ProfileViewerGpuFrameChoice> FindProfileViewerGpuFrameAtOrAfter(
+    std::span<const ProfileDump::GpuTimelineFrameRef>  _recorded_frames,
+    std::span<const ProfileDump::GpuTimelineAxisFrame> _axis_frames,
+    std::uint64_t                                      _frame_id
+) noexcept {
+    return FindProfileViewerGpuFrame(
+        _recorded_frames, _axis_frames, _frame_id, EGpuFrameChoiceSearch::AtOrAfter
+    );
+}
+
+std::optional<ProfileViewerGpuFrameChoice> FindProfileViewerGpuFrameAfter(
+    std::span<const ProfileDump::GpuTimelineFrameRef>  _recorded_frames,
+    std::span<const ProfileDump::GpuTimelineAxisFrame> _axis_frames,
+    std::uint64_t                                      _frame_id
+) noexcept {
+    return FindProfileViewerGpuFrame(_recorded_frames, _axis_frames, _frame_id, EGpuFrameChoiceSearch::After);
+}
+
+std::optional<ProfileViewerGpuFrameChoice> FindProfileViewerGpuFrameBefore(
+    std::span<const ProfileDump::GpuTimelineFrameRef>  _recorded_frames,
+    std::span<const ProfileDump::GpuTimelineAxisFrame> _axis_frames,
+    std::uint64_t                                      _frame_id
+) noexcept {
+    return FindProfileViewerGpuFrame(
+        _recorded_frames, _axis_frames, _frame_id, EGpuFrameChoiceSearch::Before
+    );
+}
+
+std::optional<ProfileViewerGpuFrameChoice> FindProfileViewerGpuFrameAtOrBefore(
+    std::span<const ProfileDump::GpuTimelineFrameRef>  _recorded_frames,
+    std::span<const ProfileDump::GpuTimelineAxisFrame> _axis_frames,
+    std::uint64_t                                      _frame_id
+) noexcept {
+    return FindProfileViewerGpuFrame(
+        _recorded_frames, _axis_frames, _frame_id, EGpuFrameChoiceSearch::AtOrBefore
+    );
+}
+
 bool ProfileViewerSelection::Valid() const noexcept {
     if (kind == EProfileViewerSelectionKind::None ||
         published_generation == ProfileDump::kInvalidProfileDocumentGeneration ||
@@ -73,7 +248,8 @@ bool ProfileViewerSelection::Valid() const noexcept {
 }
 
 EProfileViewerPublicationUpdate
-ProfileViewerModel::ObserveSnapshot(const ProfileDump::ProfileDocumentLoaderSnapshot& _snapshot) noexcept {
+ProfileViewerModel::InspectSnapshot(const ProfileDump::ProfileDocumentLoaderSnapshot& _snapshot
+) const noexcept {
     const std::uint64_t observed_generation = _snapshot.published_generation;
     if (observed_generation == ProfileDump::kInvalidProfileDocumentGeneration) {
         if (_snapshot.document) {
@@ -87,10 +263,19 @@ ProfileViewerModel::ObserveSnapshot(const ProfileDump::ProfileDocumentLoaderSnap
     if (observed_generation == published_generation_) {
         return EProfileViewerPublicationUpdate::Unchanged;
     }
-
-    published_generation_ = observed_generation;
-    ResetPublicationState();
     return EProfileViewerPublicationUpdate::Changed;
+}
+
+EProfileViewerPublicationUpdate
+ProfileViewerModel::ObserveSnapshot(const ProfileDump::ProfileDocumentLoaderSnapshot& _snapshot) noexcept {
+    const EProfileViewerPublicationUpdate update = InspectSnapshot(_snapshot);
+    if (update != EProfileViewerPublicationUpdate::Changed) {
+        return update;
+    }
+    const std::uint64_t observed_generation = _snapshot.published_generation;
+    published_generation_                   = observed_generation;
+    ResetPublicationState();
+    return update;
 }
 
 std::uint64_t ProfileViewerModel::PublishedGeneration() const noexcept {

--- a/source/editor/profile_viewer_ui/ProfileViewerModel.cpp
+++ b/source/editor/profile_viewer_ui/ProfileViewerModel.cpp
@@ -1,0 +1,410 @@
+#include "profile_viewer_ui/ProfileViewerModel.h"
+
+#include <algorithm>
+#include <limits>
+
+namespace Moer {
+namespace {
+
+[[nodiscard]] std::uint64_t
+MulDivFloor(std::uint64_t _value, std::uint32_t _numerator, std::uint32_t _denominator) noexcept {
+    const std::uint64_t quotient  = _value / _denominator;
+    const std::uint64_t remainder = _value % _denominator;
+    return quotient * _numerator + (remainder * _numerator) / _denominator;
+}
+
+[[nodiscard]] std::uint64_t
+ScaleCeilSaturated(std::uint64_t _value, std::uint32_t _numerator, std::uint32_t _denominator) noexcept {
+    constexpr std::uint64_t maximum = std::numeric_limits<std::uint64_t>::max();
+
+    const std::uint64_t quotient  = _value / _denominator;
+    const std::uint64_t remainder = _value % _denominator;
+    if (quotient > maximum / _numerator) {
+        return maximum;
+    }
+
+    const std::uint64_t whole             = quotient * _numerator;
+    const std::uint64_t remainder_product = remainder * _numerator;
+    const std::uint64_t partial =
+        remainder_product / _denominator + (remainder_product % _denominator != 0 ? 1 : 0);
+    if (partial > maximum - whole) {
+        return maximum;
+    }
+    return whole + partial;
+}
+
+[[nodiscard]] std::uint64_t SignedMagnitude(std::int64_t _value) noexcept {
+    if (_value >= 0) {
+        return static_cast<std::uint64_t>(_value);
+    }
+    return static_cast<std::uint64_t>(-(_value + 1)) + 1;
+}
+
+} // namespace
+
+std::uint64_t ProfileViewerMapFraction(
+    std::uint64_t _begin,
+    std::uint64_t _end,
+    std::uint32_t _numerator,
+    std::uint32_t _denominator
+) noexcept {
+    if (_end <= _begin || _denominator == 0 || _numerator > _denominator || _numerator == 0) {
+        return _begin;
+    }
+    if (_numerator == _denominator) {
+        return _end;
+    }
+
+    return _begin + MulDivFloor(_end - _begin, _numerator, _denominator);
+}
+
+bool ProfileViewerSelection::Valid() const noexcept {
+    if (kind == EProfileViewerSelectionKind::None ||
+        published_generation == ProfileDump::kInvalidProfileDocumentGeneration ||
+        source_scope_index == ProfileDump::kInvalidSessionIndex ||
+        timeline_track_index == ProfileDump::kInvalidSessionIndex || begin > end) {
+        return false;
+    }
+    if (kind == EProfileViewerSelectionKind::CpuScope) {
+        return axis_index == 0 && frame_id == 0;
+    }
+    return kind == EProfileViewerSelectionKind::GpuScope && axis_index != 0 &&
+           axis_index != ProfileDump::kInvalidTimelineAxis;
+}
+
+EProfileViewerPublicationUpdate
+ProfileViewerModel::ObserveSnapshot(const ProfileDump::ProfileDocumentLoaderSnapshot& _snapshot) noexcept {
+    const std::uint64_t observed_generation = _snapshot.published_generation;
+    if (observed_generation == ProfileDump::kInvalidProfileDocumentGeneration) {
+        if (_snapshot.document) {
+            return EProfileViewerPublicationUpdate::Invalid;
+        }
+    } else if (!_snapshot.document || _snapshot.document->request_generation != observed_generation ||
+               !_snapshot.document->Valid()) {
+        return EProfileViewerPublicationUpdate::Invalid;
+    }
+
+    if (observed_generation == published_generation_) {
+        return EProfileViewerPublicationUpdate::Unchanged;
+    }
+
+    published_generation_ = observed_generation;
+    ResetPublicationState();
+    return EProfileViewerPublicationUpdate::Changed;
+}
+
+std::uint64_t ProfileViewerModel::PublishedGeneration() const noexcept {
+    return published_generation_;
+}
+
+ProfileViewerViewport ProfileViewerModel::CpuViewport() const noexcept {
+    return cpu_viewport_;
+}
+
+bool ProfileViewerModel::FitCpu(std::uint64_t _domain_end) noexcept {
+    return published_generation_ != ProfileDump::kInvalidProfileDocumentGeneration &&
+           FitViewport(cpu_viewport_, _domain_end);
+}
+
+bool ProfileViewerModel::ZoomCpu(
+    std::uint32_t _anchor_numerator,
+    std::uint32_t _anchor_denominator,
+    std::uint32_t _scale_numerator,
+    std::uint32_t _scale_denominator
+) noexcept {
+    return ZoomViewport(
+        cpu_viewport_, _anchor_numerator, _anchor_denominator, _scale_numerator, _scale_denominator
+    );
+}
+
+bool ProfileViewerModel::PanCpu(std::int64_t _delta) noexcept {
+    return PanViewport(cpu_viewport_, _delta);
+}
+
+bool ProfileViewerModel::FocusCpu(std::uint64_t _begin, std::uint64_t _end, std::uint64_t _margin) noexcept {
+    return FocusViewport(cpu_viewport_, _begin, _end, _margin);
+}
+
+std::optional<ProfileViewerViewport> ProfileViewerModel::FindGpuViewport(ProfileViewerGpuViewportKey _key
+) const noexcept {
+    const GpuViewportSlot* slot = FindGpuViewportSlot(_key);
+    if (slot == nullptr) {
+        return std::nullopt;
+    }
+    return slot->viewport;
+}
+
+bool ProfileViewerModel::FitGpu(ProfileViewerGpuViewportKey _key, std::uint64_t _domain_end) noexcept {
+    if (published_generation_ == ProfileDump::kInvalidProfileDocumentGeneration || !IsValidGpuKey(_key) ||
+        _domain_end == 0) {
+        return false;
+    }
+
+    GpuViewportSlot* slot = AcquireGpuViewportSlot(_key);
+    return slot != nullptr && FitViewport(slot->viewport, _domain_end);
+}
+
+bool ProfileViewerModel::ZoomGpu(
+    ProfileViewerGpuViewportKey _key,
+    std::uint32_t               _anchor_numerator,
+    std::uint32_t               _anchor_denominator,
+    std::uint32_t               _scale_numerator,
+    std::uint32_t               _scale_denominator
+) noexcept {
+    GpuViewportSlot* slot = FindGpuViewportSlot(_key);
+    return slot != nullptr &&
+           ZoomViewport(
+               slot->viewport, _anchor_numerator, _anchor_denominator, _scale_numerator, _scale_denominator
+           );
+}
+
+bool ProfileViewerModel::PanGpu(ProfileViewerGpuViewportKey _key, std::int64_t _delta) noexcept {
+    GpuViewportSlot* slot = FindGpuViewportSlot(_key);
+    return slot != nullptr && PanViewport(slot->viewport, _delta);
+}
+
+bool ProfileViewerModel::FocusGpu(
+    ProfileViewerGpuViewportKey _key,
+    std::uint64_t               _begin,
+    std::uint64_t               _end,
+    std::uint64_t               _margin
+) noexcept {
+    GpuViewportSlot* slot = FindGpuViewportSlot(_key);
+    return slot != nullptr && FocusViewport(slot->viewport, _begin, _end, _margin);
+}
+
+bool ProfileViewerModel::SelectCpu(
+    std::uint64_t _timeline_track_index,
+    std::uint64_t _source_scope_index,
+    std::uint64_t _begin,
+    std::uint64_t _end
+) noexcept {
+    if (published_generation_ == ProfileDump::kInvalidProfileDocumentGeneration ||
+        _timeline_track_index == ProfileDump::kInvalidSessionIndex ||
+        _source_scope_index == ProfileDump::kInvalidSessionIndex ||
+        !ContainsInterval(cpu_viewport_, _begin, _end)) {
+        return false;
+    }
+
+    selection_ = {
+        .kind                 = EProfileViewerSelectionKind::CpuScope,
+        .published_generation = published_generation_,
+        .source_scope_index   = _source_scope_index,
+        .timeline_track_index = _timeline_track_index,
+        .axis_index           = 0,
+        .frame_id             = 0,
+        .begin                = _begin,
+        .end                  = _end,
+    };
+    return true;
+}
+
+bool ProfileViewerModel::SelectGpu(
+    ProfileViewerGpuViewportKey _key,
+    std::uint64_t               _timeline_track_index,
+    std::uint64_t               _source_scope_index,
+    std::uint64_t               _begin,
+    std::uint64_t               _end
+) noexcept {
+    const GpuViewportSlot* slot = FindGpuViewportSlot(_key);
+    if (published_generation_ == ProfileDump::kInvalidProfileDocumentGeneration ||
+        _timeline_track_index == ProfileDump::kInvalidSessionIndex ||
+        _source_scope_index == ProfileDump::kInvalidSessionIndex || slot == nullptr ||
+        !ContainsInterval(slot->viewport, _begin, _end)) {
+        return false;
+    }
+
+    selection_ = {
+        .kind                 = EProfileViewerSelectionKind::GpuScope,
+        .published_generation = published_generation_,
+        .source_scope_index   = _source_scope_index,
+        .timeline_track_index = _timeline_track_index,
+        .axis_index           = _key.axis_index,
+        .frame_id             = _key.frame_id,
+        .begin                = _begin,
+        .end                  = _end,
+    };
+    return true;
+}
+
+ProfileViewerSelection ProfileViewerModel::Selection() const noexcept {
+    return selection_;
+}
+
+void ProfileViewerModel::ClearSelection() noexcept {
+    selection_ = {};
+}
+
+std::size_t ProfileViewerModel::ActiveGpuViewportCount() const noexcept {
+    return active_gpu_viewport_count_;
+}
+
+bool ProfileViewerModel::IsValidGpuKey(ProfileViewerGpuViewportKey _key) noexcept {
+    return _key.axis_index != 0 && _key.axis_index != ProfileDump::kInvalidTimelineAxis;
+}
+
+bool ProfileViewerModel::FitViewport(ProfileViewerViewport& _viewport, std::uint64_t _domain_end) noexcept {
+    if (_domain_end == 0) {
+        return false;
+    }
+    _viewport = {
+        .valid      = true,
+        .domain_end = _domain_end,
+        .view_begin = 0,
+        .view_end   = _domain_end,
+    };
+    return true;
+}
+
+bool ProfileViewerModel::ZoomViewport(
+    ProfileViewerViewport& _viewport,
+    std::uint32_t          _anchor_numerator,
+    std::uint32_t          _anchor_denominator,
+    std::uint32_t          _scale_numerator,
+    std::uint32_t          _scale_denominator
+) noexcept {
+    if (!_viewport.valid || _viewport.domain_end == 0 || _viewport.view_begin >= _viewport.view_end ||
+        _viewport.view_end > _viewport.domain_end || _anchor_denominator == 0 ||
+        _anchor_numerator > _anchor_denominator || _scale_numerator == 0 || _scale_denominator == 0) {
+        return false;
+    }
+
+    const std::uint64_t old_span = _viewport.view_end - _viewport.view_begin;
+    const std::uint64_t new_span = std::clamp(
+        ScaleCeilSaturated(old_span, _scale_numerator, _scale_denominator),
+        std::uint64_t{1},
+        _viewport.domain_end
+    );
+    const std::uint64_t old_anchor_offset = MulDivFloor(old_span, _anchor_numerator, _anchor_denominator);
+    const std::uint64_t anchor            = _viewport.view_begin + old_anchor_offset;
+    const std::uint64_t new_anchor_offset = MulDivFloor(new_span, _anchor_numerator, _anchor_denominator);
+
+    std::uint64_t       new_begin     = anchor >= new_anchor_offset ? anchor - new_anchor_offset : 0;
+    const std::uint64_t maximum_begin = _viewport.domain_end - new_span;
+    new_begin                         = std::min(new_begin, maximum_begin);
+    _viewport.view_begin              = new_begin;
+    _viewport.view_end                = new_begin + new_span;
+    return true;
+}
+
+bool ProfileViewerModel::PanViewport(ProfileViewerViewport& _viewport, std::int64_t _delta) noexcept {
+    if (!_viewport.valid || _viewport.domain_end == 0 || _viewport.view_begin >= _viewport.view_end ||
+        _viewport.view_end > _viewport.domain_end) {
+        return false;
+    }
+
+    const std::uint64_t span          = _viewport.view_end - _viewport.view_begin;
+    const std::uint64_t maximum_begin = _viewport.domain_end - span;
+    const std::uint64_t magnitude     = SignedMagnitude(_delta);
+    std::uint64_t       new_begin     = _viewport.view_begin;
+    if (_delta >= 0) {
+        new_begin = magnitude >= maximum_begin - new_begin ? maximum_begin : new_begin + magnitude;
+    } else {
+        new_begin = magnitude >= new_begin ? 0 : new_begin - magnitude;
+    }
+
+    _viewport.view_begin = new_begin;
+    _viewport.view_end   = new_begin + span;
+    return true;
+}
+
+bool ProfileViewerModel::FocusViewport(
+    ProfileViewerViewport& _viewport,
+    std::uint64_t          _begin,
+    std::uint64_t          _end,
+    std::uint64_t          _margin
+) noexcept {
+    if (!_viewport.valid || _viewport.domain_end == 0 || _viewport.view_begin >= _viewport.view_end ||
+        _viewport.view_end > _viewport.domain_end) {
+        return false;
+    }
+
+    const std::uint64_t focus_begin = std::min(_begin, _viewport.domain_end - 1);
+    std::uint64_t       focus_end   = std::min(_end, _viewport.domain_end);
+    if (focus_end <= focus_begin) {
+        focus_end = focus_begin + 1;
+    }
+
+    const std::uint64_t view_begin = _margin > focus_begin ? 0 : focus_begin - _margin;
+    const std::uint64_t remaining  = _viewport.domain_end - focus_end;
+    const std::uint64_t view_end   = _margin >= remaining ? _viewport.domain_end : focus_end + _margin;
+    _viewport.view_begin           = view_begin;
+    _viewport.view_end             = view_end;
+    return true;
+}
+
+bool ProfileViewerModel::ContainsInterval(
+    const ProfileViewerViewport& _viewport,
+    std::uint64_t                _begin,
+    std::uint64_t                _end
+) noexcept {
+    return _viewport.valid && _viewport.domain_end != 0 && _viewport.view_begin < _viewport.view_end &&
+           _viewport.view_end <= _viewport.domain_end && _begin <= _end && _begin < _viewport.domain_end &&
+           _end <= _viewport.domain_end;
+}
+
+ProfileViewerModel::GpuViewportSlot* ProfileViewerModel::FindGpuViewportSlot(ProfileViewerGpuViewportKey _key
+) noexcept {
+    if (!IsValidGpuKey(_key)) {
+        return nullptr;
+    }
+    for (GpuViewportSlot& slot : gpu_viewports_) {
+        if (slot.occupied && slot.key == _key) {
+            return &slot;
+        }
+    }
+    return nullptr;
+}
+
+const ProfileViewerModel::GpuViewportSlot*
+ProfileViewerModel::FindGpuViewportSlot(ProfileViewerGpuViewportKey _key) const noexcept {
+    if (!IsValidGpuKey(_key)) {
+        return nullptr;
+    }
+    for (const GpuViewportSlot& slot : gpu_viewports_) {
+        if (slot.occupied && slot.key == _key) {
+            return &slot;
+        }
+    }
+    return nullptr;
+}
+
+ProfileViewerModel::GpuViewportSlot*
+ProfileViewerModel::AcquireGpuViewportSlot(ProfileViewerGpuViewportKey _key) noexcept {
+    if (GpuViewportSlot* existing = FindGpuViewportSlot(_key)) {
+        return existing;
+    }
+
+    for (GpuViewportSlot& slot : gpu_viewports_) {
+        if (!slot.occupied) {
+            slot = {
+                .occupied = true,
+                .key      = _key,
+                .viewport = {},
+            };
+            ++active_gpu_viewport_count_;
+            return &slot;
+        }
+    }
+
+    GpuViewportSlot& slot = gpu_viewports_[next_gpu_eviction_];
+    next_gpu_eviction_    = (next_gpu_eviction_ + 1) % gpu_viewports_.size();
+    slot                  = {
+                         .occupied = true,
+                         .key      = _key,
+                         .viewport = {},
+    };
+    return &slot;
+}
+
+void ProfileViewerModel::ResetPublicationState() noexcept {
+    cpu_viewport_ = {};
+    for (GpuViewportSlot& slot : gpu_viewports_) {
+        slot = {};
+    }
+    active_gpu_viewport_count_ = 0;
+    next_gpu_eviction_         = 0;
+    selection_                 = {};
+}
+
+} // namespace Moer

--- a/source/editor/profile_viewer_ui/ProfileViewerModel.h
+++ b/source/editor/profile_viewer_ui/ProfileViewerModel.h
@@ -1,0 +1,167 @@
+#pragma once
+
+#include "profile_consumer/ProfileDocument.h"
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <optional>
+
+namespace Moer {
+
+inline constexpr std::size_t kProfileViewerGpuViewportCapacity = 256;
+
+// Maps a bounded rational position onto [begin, end] without converting the
+// uint64_t domain to floating point. Invalid fractions map to begin.
+[[nodiscard]] std::uint64_t ProfileViewerMapFraction(
+    std::uint64_t _begin,
+    std::uint64_t _end,
+    std::uint32_t _numerator,
+    std::uint32_t _denominator
+) noexcept;
+
+struct ProfileViewerViewport {
+    bool          valid{false};
+    std::uint64_t domain_end{0};
+    std::uint64_t view_begin{0};
+    std::uint64_t view_end{0};
+
+    friend bool operator==(const ProfileViewerViewport&, const ProfileViewerViewport&) = default;
+};
+
+struct ProfileViewerGpuViewportKey {
+    std::uint32_t axis_index{ProfileDump::kInvalidTimelineAxis};
+    std::uint64_t frame_id{0};
+
+    friend bool operator==(const ProfileViewerGpuViewportKey&, const ProfileViewerGpuViewportKey&) = default;
+};
+
+enum class EProfileViewerSelectionKind : std::uint8_t {
+    None = 0,
+    CpuScope,
+    GpuScope,
+};
+
+struct ProfileViewerSelection {
+    EProfileViewerSelectionKind kind{EProfileViewerSelectionKind::None};
+    std::uint64_t               published_generation{ProfileDump::kInvalidProfileDocumentGeneration};
+    std::uint64_t               source_scope_index{ProfileDump::kInvalidSessionIndex};
+    std::uint64_t               timeline_track_index{ProfileDump::kInvalidSessionIndex};
+    std::uint32_t               axis_index{ProfileDump::kInvalidTimelineAxis};
+    std::uint64_t               frame_id{0};
+    std::uint64_t               begin{0};
+    std::uint64_t               end{0};
+
+    [[nodiscard]] bool Valid() const noexcept;
+
+    friend bool operator==(const ProfileViewerSelection&, const ProfileViewerSelection&) = default;
+};
+
+enum class EProfileViewerPublicationUpdate : std::uint8_t {
+    Unchanged = 0,
+    Changed,
+    Invalid,
+};
+
+// Pure editor-side navigation state for immutable ProfileDocument publications.
+// It deliberately retains no document pointer, span, string_view, or source
+// address. The caller resolves stored integer identities against the current
+// publication each frame.
+class ProfileViewerModel final {
+public:
+    [[nodiscard]] EProfileViewerPublicationUpdate
+    ObserveSnapshot(const ProfileDump::ProfileDocumentLoaderSnapshot& _snapshot) noexcept;
+
+    [[nodiscard]] std::uint64_t PublishedGeneration() const noexcept;
+
+    [[nodiscard]] ProfileViewerViewport CpuViewport() const noexcept;
+    [[nodiscard]] bool                  FitCpu(std::uint64_t _domain_end) noexcept;
+    [[nodiscard]] bool                  ZoomCpu(
+                         std::uint32_t _anchor_numerator,
+                         std::uint32_t _anchor_denominator,
+                         std::uint32_t _scale_numerator,
+                         std::uint32_t _scale_denominator
+                     ) noexcept;
+    [[nodiscard]] bool PanCpu(std::int64_t _delta) noexcept;
+    [[nodiscard]] bool FocusCpu(std::uint64_t _begin, std::uint64_t _end, std::uint64_t _margin) noexcept;
+
+    [[nodiscard]] std::optional<ProfileViewerViewport> FindGpuViewport(ProfileViewerGpuViewportKey _key
+    ) const noexcept;
+    [[nodiscard]] bool FitGpu(ProfileViewerGpuViewportKey _key, std::uint64_t _domain_end) noexcept;
+    [[nodiscard]] bool ZoomGpu(
+        ProfileViewerGpuViewportKey _key,
+        std::uint32_t               _anchor_numerator,
+        std::uint32_t               _anchor_denominator,
+        std::uint32_t               _scale_numerator,
+        std::uint32_t               _scale_denominator
+    ) noexcept;
+    [[nodiscard]] bool PanGpu(ProfileViewerGpuViewportKey _key, std::int64_t _delta) noexcept;
+    [[nodiscard]] bool FocusGpu(
+        ProfileViewerGpuViewportKey _key,
+        std::uint64_t               _begin,
+        std::uint64_t               _end,
+        std::uint64_t               _margin
+    ) noexcept;
+
+    [[nodiscard]] bool SelectCpu(
+        std::uint64_t _timeline_track_index,
+        std::uint64_t _source_scope_index,
+        std::uint64_t _begin,
+        std::uint64_t _end
+    ) noexcept;
+    [[nodiscard]] bool SelectGpu(
+        ProfileViewerGpuViewportKey _key,
+        std::uint64_t               _timeline_track_index,
+        std::uint64_t               _source_scope_index,
+        std::uint64_t               _begin,
+        std::uint64_t               _end
+    ) noexcept;
+    [[nodiscard]] ProfileViewerSelection Selection() const noexcept;
+    void                                 ClearSelection() noexcept;
+
+    [[nodiscard]] std::size_t ActiveGpuViewportCount() const noexcept;
+
+private:
+    struct GpuViewportSlot {
+        bool                        occupied{false};
+        ProfileViewerGpuViewportKey key{};
+        ProfileViewerViewport       viewport{};
+    };
+
+    [[nodiscard]] static bool IsValidGpuKey(ProfileViewerGpuViewportKey _key) noexcept;
+    [[nodiscard]] static bool
+    FitViewport(ProfileViewerViewport& _viewport, std::uint64_t _domain_end) noexcept;
+    [[nodiscard]] static bool ZoomViewport(
+        ProfileViewerViewport& _viewport,
+        std::uint32_t          _anchor_numerator,
+        std::uint32_t          _anchor_denominator,
+        std::uint32_t          _scale_numerator,
+        std::uint32_t          _scale_denominator
+    ) noexcept;
+    [[nodiscard]] static bool PanViewport(ProfileViewerViewport& _viewport, std::int64_t _delta) noexcept;
+    [[nodiscard]] static bool FocusViewport(
+        ProfileViewerViewport& _viewport,
+        std::uint64_t          _begin,
+        std::uint64_t          _end,
+        std::uint64_t          _margin
+    ) noexcept;
+    [[nodiscard]] static bool ContainsInterval(
+        const ProfileViewerViewport& _viewport,
+        std::uint64_t                _begin,
+        std::uint64_t                _end
+    ) noexcept;
+
+    [[nodiscard]] GpuViewportSlot*       FindGpuViewportSlot(ProfileViewerGpuViewportKey _key) noexcept;
+    [[nodiscard]] const GpuViewportSlot* FindGpuViewportSlot(ProfileViewerGpuViewportKey _key) const noexcept;
+    [[nodiscard]] GpuViewportSlot*       AcquireGpuViewportSlot(ProfileViewerGpuViewportKey _key) noexcept;
+    void                                 ResetPublicationState() noexcept;
+
+    std::uint64_t         published_generation_{ProfileDump::kInvalidProfileDocumentGeneration};
+    ProfileViewerViewport cpu_viewport_{};
+    std::array<GpuViewportSlot, kProfileViewerGpuViewportCapacity> gpu_viewports_{};
+    std::size_t                                                    active_gpu_viewport_count_{0};
+    std::size_t                                                    next_gpu_eviction_{0};
+    ProfileViewerSelection                                         selection_{};
+};
+
+} // namespace Moer

--- a/source/editor/profile_viewer_ui/ProfileViewerModel.h
+++ b/source/editor/profile_viewer_ui/ProfileViewerModel.h
@@ -6,10 +6,12 @@
 #include <cstddef>
 #include <cstdint>
 #include <optional>
+#include <span>
 
 namespace Moer {
 
-inline constexpr std::size_t kProfileViewerGpuViewportCapacity = 256;
+inline constexpr std::size_t   kProfileViewerGpuViewportCapacity  = 256;
+inline constexpr std::uint32_t kProfileViewerGpuRenderableAxisMax = 256;
 
 // Maps a bounded rational position onto [begin, end] without converting the
 // uint64_t domain to floating point. Invalid fractions map to begin.
@@ -18,6 +20,39 @@ inline constexpr std::size_t kProfileViewerGpuViewportCapacity = 256;
     std::uint64_t _end,
     std::uint32_t _numerator,
     std::uint32_t _denominator
+) noexcept;
+
+struct ProfileViewerGpuFrameChoice {
+    std::uint64_t frame_id{0};
+    bool          has_frame_record{false};
+
+    friend bool operator==(const ProfileViewerGpuFrameChoice&, const ProfileViewerGpuFrameChoice&) = default;
+};
+
+// The timeline index stores GpuFrame records by frame ID and physical-axis
+// frames by (axis, frame). These allocation-free searches expose the sorted
+// union of every recorded frame plus orphan timelines on viewer-renderable
+// physical axes [1, kProfileViewerGpuRenderableAxisMax], without materializing
+// or sorting a second large catalog.
+[[nodiscard]] std::optional<ProfileViewerGpuFrameChoice> FindProfileViewerGpuFrameAtOrAfter(
+    std::span<const ProfileDump::GpuTimelineFrameRef>  _recorded_frames,
+    std::span<const ProfileDump::GpuTimelineAxisFrame> _axis_frames,
+    std::uint64_t                                      _frame_id
+) noexcept;
+[[nodiscard]] std::optional<ProfileViewerGpuFrameChoice> FindProfileViewerGpuFrameAfter(
+    std::span<const ProfileDump::GpuTimelineFrameRef>  _recorded_frames,
+    std::span<const ProfileDump::GpuTimelineAxisFrame> _axis_frames,
+    std::uint64_t                                      _frame_id
+) noexcept;
+[[nodiscard]] std::optional<ProfileViewerGpuFrameChoice> FindProfileViewerGpuFrameBefore(
+    std::span<const ProfileDump::GpuTimelineFrameRef>  _recorded_frames,
+    std::span<const ProfileDump::GpuTimelineAxisFrame> _axis_frames,
+    std::uint64_t                                      _frame_id
+) noexcept;
+[[nodiscard]] std::optional<ProfileViewerGpuFrameChoice> FindProfileViewerGpuFrameAtOrBefore(
+    std::span<const ProfileDump::GpuTimelineFrameRef>  _recorded_frames,
+    std::span<const ProfileDump::GpuTimelineAxisFrame> _axis_frames,
+    std::uint64_t                                      _frame_id
 ) noexcept;
 
 struct ProfileViewerViewport {
@@ -69,6 +104,8 @@ enum class EProfileViewerPublicationUpdate : std::uint8_t {
 // publication each frame.
 class ProfileViewerModel final {
 public:
+    [[nodiscard]] EProfileViewerPublicationUpdate
+    InspectSnapshot(const ProfileDump::ProfileDocumentLoaderSnapshot& _snapshot) const noexcept;
     [[nodiscard]] EProfileViewerPublicationUpdate
     ObserveSnapshot(const ProfileDump::ProfileDocumentLoaderSnapshot& _snapshot) noexcept;
 

--- a/source/editor/profile_viewer_ui/ProfileViewerUI.cpp
+++ b/source/editor/profile_viewer_ui/ProfileViewerUI.cpp
@@ -1,0 +1,1760 @@
+#include "profile_viewer_ui/ProfileViewerUI.h"
+
+#include "profile_viewer_ui/ProfileViewerModel.h"
+
+#include "log/LogSystem.h"
+#include "profile_consumer/ProfileDocument.h"
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <exception>
+#include <filesystem>
+#include <limits>
+#include <optional>
+#include <span>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include <imgui.h>
+#include <nfd.hpp>
+
+namespace Moer {
+namespace {
+
+using namespace ProfileDump;
+
+constexpr std::size_t   k_query_capacity         = 4096;
+constexpr std::size_t   k_frame_event_budget     = 16384;
+constexpr std::size_t   k_filter_capacity        = 128;
+constexpr std::size_t   k_filter_name_byte_limit = 1024;
+constexpr std::size_t   k_draw_name_byte_limit   = 256;
+constexpr std::size_t   k_track_scan_budget      = 4096;
+constexpr std::size_t   k_axis_scan_budget       = 256;
+constexpr float         k_track_label_width      = 248.0f;
+constexpr float         k_lane_height            = 18.0f;
+constexpr std::uint32_t k_direct_depth_lanes     = 3;
+constexpr std::uint32_t k_overflow_depth_lane    = k_direct_depth_lanes;
+constexpr float k_track_row_height = (static_cast<float>(k_direct_depth_lanes) + 1.0f) * k_lane_height + 8.0f;
+
+enum class ERangeDomain : std::uint8_t {
+    None = 0,
+    Cpu,
+    Gpu,
+};
+
+struct RangeSelection {
+    ERangeDomain                domain{ERangeDomain::None};
+    ProfileViewerGpuViewportKey gpu_key{};
+    bool                        dragging{false};
+    bool                        committed{false};
+    std::uint64_t               anchor{0};
+    std::uint64_t               begin{0};
+    std::uint64_t               end{0};
+
+    void Clear() noexcept {
+        *this = {};
+    }
+
+    [[nodiscard]] bool ActiveForCpu() const noexcept {
+        return domain == ERangeDomain::Cpu && (dragging || committed) && begin < end;
+    }
+
+    [[nodiscard]] bool ActiveForGpu(ProfileViewerGpuViewportKey _key) const noexcept {
+        return domain == ERangeDomain::Gpu && gpu_key == _key && (dragging || committed) && begin < end;
+    }
+};
+
+[[nodiscard]] const char* LoadPhaseText(ProfileDocumentLoadPhase _phase) noexcept {
+    switch (_phase) {
+        case ProfileDocumentLoadPhase::Idle:
+            return "Idle";
+        case ProfileDocumentLoadPhase::Opening:
+            return "Opening";
+        case ProfileDocumentLoadPhase::Reading:
+            return "Reading (indeterminate)";
+        case ProfileDocumentLoadPhase::MaterializingSession:
+            return "Materializing session";
+        case ProfileDocumentLoadPhase::BuildingTimeline:
+            return "Building timeline";
+        case ProfileDocumentLoadPhase::Ready:
+            return "Ready";
+        case ProfileDocumentLoadPhase::Failed:
+            return "Failed";
+        case ProfileDocumentLoadPhase::Cancelled:
+            return "Cancelled";
+        case ProfileDocumentLoadPhase::Shutdown:
+            return "Shutdown";
+    }
+    return "Unknown";
+}
+
+[[nodiscard]] const char* LoadDiagnosticText(ProfileDocumentLoadDiagnostic _diagnostic) noexcept {
+    switch (_diagnostic) {
+        case ProfileDocumentLoadDiagnostic::None:
+            return "None";
+        case ProfileDocumentLoadDiagnostic::WorkerUnavailable:
+            return "Loader worker unavailable";
+        case ProfileDocumentLoadDiagnostic::Cancelled:
+            return "Load cancelled";
+        case ProfileDocumentLoadDiagnostic::SessionLoadFailed:
+            return "Profile session load failed";
+        case ProfileDocumentLoadDiagnostic::TimelineBuildFailed:
+            return "Timeline index build failed";
+        case ProfileDocumentLoadDiagnostic::DocumentAllocationFailed:
+            return "Profile document allocation failed";
+    }
+    return "Unknown";
+}
+
+[[nodiscard]] const char* LogicalQueueText(ProfileLogicalQueue _queue) noexcept {
+    switch (_queue) {
+        case ProfileLogicalQueue::Graphics:
+            return "Graphics";
+        case ProfileLogicalQueue::Compute:
+            return "Compute";
+        case ProfileLogicalQueue::Copy:
+            return "Copy";
+    }
+    return "Unknown";
+}
+
+[[nodiscard]] const char* GpuFrameStatusText(ProfileGpuFrameStatus _status) noexcept {
+    switch (_status) {
+        case ProfileGpuFrameStatus::Complete:
+            return "Complete";
+        case ProfileGpuFrameStatus::Incomplete:
+            return "Incomplete";
+        case ProfileGpuFrameStatus::Invalid:
+            return "Invalid";
+    }
+    return "Unknown";
+}
+
+[[nodiscard]] std::string PathForDisplay(const std::filesystem::path& _path) noexcept {
+    try {
+        const std::u8string utf8 = _path.generic_u8string();
+        return std::string(reinterpret_cast<const char*>(utf8.data()), utf8.size());
+    } catch (...) {
+        return "<path unavailable>";
+    }
+}
+
+[[nodiscard]] std::string_view
+BoundedUtf8Prefix(std::string_view _text, std::size_t _maximum_bytes) noexcept {
+    if (_text.size() <= _maximum_bytes) {
+        return _text;
+    }
+
+    std::size_t end = _maximum_bytes;
+    while (end > 0 && end < _text.size() && (static_cast<unsigned char>(_text[end]) & 0xc0u) == 0x80u) {
+        --end;
+    }
+    return _text.substr(0, end);
+}
+
+void DrawBoundedText(std::string_view _text, std::size_t _maximum_bytes = k_draw_name_byte_limit) {
+    const std::string_view bounded = BoundedUtf8Prefix(_text, _maximum_bytes);
+    ImGui::TextUnformatted(bounded.data(), bounded.data() + bounded.size());
+    if (bounded.size() < _text.size()) {
+        ImGui::SameLine(0.0f, 0.0f);
+        ImGui::TextUnformatted("...");
+    }
+}
+
+[[nodiscard]] char FoldAscii(char _value) noexcept {
+    const unsigned char byte = static_cast<unsigned char>(_value);
+    return byte >= static_cast<unsigned char>('A') && byte <= static_cast<unsigned char>('Z') ?
+               static_cast<char>(byte + static_cast<unsigned char>('a' - 'A')) :
+               _value;
+}
+
+class NameFilterMatcher final {
+public:
+    void Compile(std::string_view _filter) noexcept {
+        _filter         = BoundedUtf8Prefix(_filter, k_filter_capacity - 1);
+        pattern_length_ = _filter.size();
+        for (std::size_t index = 0; index < pattern_length_; ++index) {
+            pattern_[index] = FoldAscii(_filter[index]);
+        }
+
+        prefix_.fill(0);
+        for (std::size_t index = 1, matched = 0; index < pattern_length_; ++index) {
+            while (matched > 0 && pattern_[index] != pattern_[matched]) {
+                matched = prefix_[matched - 1];
+            }
+            if (pattern_[index] == pattern_[matched]) {
+                ++matched;
+            }
+            prefix_[index] = matched;
+        }
+    }
+
+    [[nodiscard]] bool Empty() const noexcept {
+        return pattern_length_ == 0;
+    }
+
+    // KMP keeps each bounded name check linear even for adversarial repetitive
+    // names and filters. Non-ASCII UTF-8 bytes remain exact-match bytes.
+    [[nodiscard]] bool Matches(std::string_view _name) const noexcept {
+        if (Empty()) {
+            return true;
+        }
+
+        _name = BoundedUtf8Prefix(_name, k_filter_name_byte_limit);
+        for (std::size_t index = 0, matched = 0; index < _name.size(); ++index) {
+            const char value = FoldAscii(_name[index]);
+            while (matched > 0 && value != pattern_[matched]) {
+                matched = prefix_[matched - 1];
+            }
+            if (value == pattern_[matched]) {
+                ++matched;
+            }
+            if (matched == pattern_length_) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+private:
+    std::array<char, k_filter_capacity>        pattern_{};
+    std::array<std::size_t, k_filter_capacity> prefix_{};
+    std::size_t                                pattern_length_{0};
+};
+
+[[nodiscard]] ImU32 EventColor(std::string_view _name) noexcept {
+    std::uint32_t hash    = 2166136261u;
+    const auto    bounded = BoundedUtf8Prefix(_name, k_filter_name_byte_limit);
+    for (const char value : bounded) {
+        hash ^= static_cast<std::uint8_t>(value);
+        hash *= 16777619u;
+    }
+
+    const float hue   = static_cast<float>(hash % 360u) / 360.0f;
+    float       red   = 0.0f;
+    float       green = 0.0f;
+    float       blue  = 0.0f;
+    ImGui::ColorConvertHSVtoRGB(hue, 0.48f, 0.78f, red, green, blue);
+    return ImGui::ColorConvertFloat4ToU32(ImVec4(red, green, blue, 0.92f));
+}
+
+[[nodiscard]] std::uint64_t SaturatingIncrement(std::uint64_t _value) noexcept {
+    return _value == std::numeric_limits<std::uint64_t>::max() ? _value : _value + 1;
+}
+
+[[nodiscard]] std::uint64_t IntervalExtent(std::uint64_t _begin, std::uint64_t _end) noexcept {
+    return _end >= _begin ? _end - _begin : 0;
+}
+
+[[nodiscard]] std::uint64_t CpuDomainEnd(const ProfileSessionSummary& _summary) noexcept {
+    if (!_summary.has_cpu_range || _summary.cpu_end_ns < _summary.cpu_begin_ns) {
+        return 0;
+    }
+    return SaturatingIncrement(_summary.cpu_end_ns - _summary.cpu_begin_ns);
+}
+
+[[nodiscard]] std::uint64_t GpuDomainEnd(const GpuTimelineAxisFrame& _frame) noexcept {
+    return _frame.timing_available ? SaturatingIncrement(_frame.extent_ticks) : 0;
+}
+
+[[nodiscard]] float
+TimeToX(const ProfileViewerViewport& _viewport, std::uint64_t _time, float _x0, float _width) noexcept {
+    if (!_viewport.valid || _viewport.view_end <= _viewport.view_begin || _width <= 0.0f) {
+        return _x0;
+    }
+    const std::uint64_t clamped = std::clamp(_time, _viewport.view_begin, _viewport.view_end);
+    const double        ratio   = static_cast<double>(clamped - _viewport.view_begin) /
+                         static_cast<double>(_viewport.view_end - _viewport.view_begin);
+    return _x0 + static_cast<float>(ratio) * _width;
+}
+
+[[nodiscard]] std::uint32_t AnchorNumerator(float _mouse_x, float _x0, float _width) noexcept;
+
+[[nodiscard]] std::uint64_t
+XToTime(const ProfileViewerViewport& _viewport, float _x, float _x0, float _width) noexcept {
+    if (!_viewport.valid || _viewport.view_end <= _viewport.view_begin || _width <= 0.0f) {
+        return _viewport.view_begin;
+    }
+    constexpr std::uint32_t denominator = 1'000'000;
+    return ProfileViewerMapFraction(
+        _viewport.view_begin, _viewport.view_end, AnchorNumerator(_x, _x0, _width), denominator
+    );
+}
+
+[[nodiscard]] std::int64_t
+PixelPanDelta(const ProfileViewerViewport& _viewport, float _pixel_delta, float _width) noexcept {
+    if (!_viewport.valid || _viewport.view_end <= _viewport.view_begin || !std::isfinite(_pixel_delta) ||
+        !std::isfinite(_width) || _width <= 0.0f) {
+        return 0;
+    }
+
+    const long double span = static_cast<long double>(_viewport.view_end - _viewport.view_begin);
+    const long double value =
+        -static_cast<long double>(_pixel_delta) * span / static_cast<long double>(_width);
+    if (!std::isfinite(value)) {
+        return 0;
+    }
+    const long double minimum = static_cast<long double>(std::numeric_limits<std::int64_t>::min());
+    const long double maximum = static_cast<long double>(std::numeric_limits<std::int64_t>::max());
+    return static_cast<std::int64_t>(std::clamp(value, minimum, maximum));
+}
+
+[[nodiscard]] std::int64_t
+KeyboardPanDelta(const ProfileViewerViewport& _viewport, bool _toward_end) noexcept {
+    if (!_viewport.valid || _viewport.view_end <= _viewport.view_begin) {
+        return 0;
+    }
+
+    const std::uint64_t span      = _viewport.view_end - _viewport.view_begin;
+    const std::uint64_t magnitude = std::min<std::uint64_t>(
+        std::max<std::uint64_t>(span / 10, 1),
+        static_cast<std::uint64_t>(std::numeric_limits<std::int64_t>::max())
+    );
+    const std::int64_t signed_magnitude = static_cast<std::int64_t>(magnitude);
+    return _toward_end ? signed_magnitude : -signed_magnitude;
+}
+
+[[nodiscard]] std::uint32_t AnchorNumerator(float _mouse_x, float _x0, float _width) noexcept {
+    constexpr std::uint32_t denominator = 1'000'000;
+    if (!std::isfinite(_mouse_x) || !std::isfinite(_x0) || !std::isfinite(_width) || _width <= 0.0f) {
+        return denominator / 2;
+    }
+
+    const double ratio = std::clamp(
+        (static_cast<double>(_mouse_x) - static_cast<double>(_x0)) / static_cast<double>(_width), 0.0, 1.0
+    );
+    return static_cast<std::uint32_t>(ratio * denominator);
+}
+
+void DrawTimeRuler(
+    const ProfileViewerViewport& _viewport,
+    float                        _x0,
+    float                        _width,
+    float                        _y,
+    double                       _unit_ns
+) {
+    ImDrawList* draw_list = ImGui::GetWindowDrawList();
+    draw_list->AddLine(ImVec2(_x0, _y), ImVec2(_x0 + _width, _y), IM_COL32(170, 170, 170, 255));
+
+    const float bounded_tick_count = std::isfinite(_width) ? std::clamp(_width / 130.0f, 3.0f, 10.0f) : 3.0f;
+    const int   tick_count         = static_cast<int>(bounded_tick_count);
+    for (int tick = 0; tick <= tick_count; ++tick) {
+        const double        ratio    = static_cast<double>(tick) / static_cast<double>(tick_count);
+        const float         x        = _x0 + static_cast<float>(ratio) * _width;
+        const std::uint64_t position = ProfileViewerMapFraction(
+            _viewport.view_begin,
+            _viewport.view_end,
+            static_cast<std::uint32_t>(tick),
+            static_cast<std::uint32_t>(tick_count)
+        );
+        const double value_ns = static_cast<double>(position) * _unit_ns;
+
+        char label[48]{};
+        if (value_ns >= 1.0e9) {
+            std::snprintf(label, sizeof(label), "%.3fs", value_ns / 1.0e9);
+        } else if (value_ns >= 1.0e6) {
+            std::snprintf(label, sizeof(label), "%.3fms", value_ns / 1.0e6);
+        } else if (value_ns >= 1.0e3) {
+            std::snprintf(label, sizeof(label), "%.3fus", value_ns / 1.0e3);
+        } else {
+            std::snprintf(label, sizeof(label), "%.0fns", value_ns);
+        }
+        draw_list->AddLine(ImVec2(x, _y), ImVec2(x, _y + 6.0f), IM_COL32(190, 190, 190, 255));
+        draw_list->AddText(ImVec2(x + 2.0f, _y + 7.0f), IM_COL32(205, 205, 205, 255), label);
+    }
+}
+
+void DrawOverview(const ProfileViewerViewport& _viewport, float _x0, float _width, float _height) {
+    ImDrawList*  draw_list = ImGui::GetWindowDrawList();
+    const ImVec2 origin    = ImGui::GetCursorScreenPos();
+    ImGui::InvisibleButton("##ProfileOverview", ImVec2(_x0 + _width - origin.x, _height));
+
+    const float y0 = origin.y + 7.0f;
+    const float y1 = y0 + 16.0f;
+    draw_list->AddRectFilled(ImVec2(_x0, y0), ImVec2(_x0 + _width, y1), IM_COL32(28, 28, 31, 255), 3.0f);
+    if (_viewport.valid && _viewport.domain_end > 0) {
+        const double begin_ratio =
+            static_cast<double>(_viewport.view_begin) / static_cast<double>(_viewport.domain_end);
+        const double end_ratio =
+            static_cast<double>(_viewport.view_end) / static_cast<double>(_viewport.domain_end);
+        const float view_x0 = _x0 + static_cast<float>(std::clamp(begin_ratio, 0.0, 1.0)) * _width;
+        const float view_x1 = _x0 + static_cast<float>(std::clamp(end_ratio, 0.0, 1.0)) * _width;
+        draw_list->AddRectFilled(
+            ImVec2(view_x0, y0 - 2.0f), ImVec2(view_x1, y1 + 2.0f), IM_COL32(225, 179, 72, 62), 3.0f
+        );
+        draw_list->AddRect(
+            ImVec2(view_x0, y0 - 2.0f), ImVec2(view_x1, y1 + 2.0f), IM_COL32(225, 179, 72, 230), 3.0f
+        );
+    }
+}
+
+void DrawQuality(const ProfileTimelineQuality& _quality) {
+    if (_quality.Clean()) {
+        ImGui::TextColored(ImVec4(0.45f, 0.85f, 0.52f, 1.0f), "Capture quality: clean");
+        return;
+    }
+
+    ImGui::TextColored(ImVec4(1.0f, 0.68f, 0.22f, 1.0f), "Capture quality warnings:");
+    if (_quality.Has(TimelineQualityFlag::ForensicTruncated)) {
+        ImGui::BulletText("Forensic/truncated input");
+    }
+    if (_quality.Has(TimelineQualityFlag::LostRecords)) {
+        ImGui::BulletText(
+            "Notified lost records: %llu", static_cast<unsigned long long>(_quality.lost_record_count)
+        );
+    }
+    if (_quality.Has(TimelineQualityFlag::UnnotifiedDrops)) {
+        ImGui::BulletText(
+            "Unnotified drops: %llu", static_cast<unsigned long long>(_quality.unnotified_drop_count)
+        );
+    }
+    if (_quality.Has(TimelineQualityFlag::CpuOrphans)) {
+        ImGui::BulletText(
+            "CPU orphan scopes: %llu", static_cast<unsigned long long>(_quality.orphan_cpu_scope_count)
+        );
+    }
+    if (_quality.Has(TimelineQualityFlag::GpuOrphans)) {
+        ImGui::BulletText(
+            "GPU orphan scopes: %llu", static_cast<unsigned long long>(_quality.orphan_gpu_scope_count)
+        );
+    }
+    if (_quality.Has(TimelineQualityFlag::DegradedGpuFrames)) {
+        ImGui::BulletText(
+            "Degraded complete GPU frames: %llu",
+            static_cast<unsigned long long>(_quality.degraded_complete_gpu_frame_count)
+        );
+    }
+    if (_quality.Has(TimelineQualityFlag::IncompleteGpuFrames)) {
+        ImGui::BulletText(
+            "Incomplete GPU frames: %llu",
+            static_cast<unsigned long long>(_quality.incomplete_gpu_frame_count)
+        );
+    }
+    if (_quality.Has(TimelineQualityFlag::InvalidGpuFrames)) {
+        ImGui::BulletText(
+            "Invalid GPU frames: %llu", static_cast<unsigned long long>(_quality.invalid_gpu_frame_count)
+        );
+    }
+    if (_quality.Has(TimelineQualityFlag::GpuScopeErrors)) {
+        ImGui::BulletText(
+            "GPU scope errors: %llu", static_cast<unsigned long long>(_quality.error_gpu_scope_count)
+        );
+    }
+    if (_quality.Has(TimelineQualityFlag::UntrustedGpuTiming)) {
+        ImGui::BulletText(
+            "Untrusted GPU frames: %llu", static_cast<unsigned long long>(_quality.untrusted_gpu_frame_count)
+        );
+    }
+    if (_quality.Has(TimelineQualityFlag::UnknownRecords)) {
+        ImGui::BulletText(
+            "Unknown records: %llu", static_cast<unsigned long long>(_quality.unknown_record_count)
+        );
+    }
+}
+
+void DrawParentName(const ProfileSession& _session, const CpuScopeRecord& _scope) {
+    ImGui::TextUnformatted("Parent:");
+    ImGui::SameLine();
+    if (_scope.parent_index != kInvalidSessionIndex && _scope.parent_index < _session.CpuScopes().size()) {
+        DrawBoundedText(_session.String(_session.CpuScopes()[_scope.parent_index].name));
+    } else {
+        ImGui::TextUnformatted("None");
+    }
+}
+
+void DrawParentName(const ProfileSession& _session, const GpuScopeRecord& _scope) {
+    ImGui::TextUnformatted("Parent:");
+    ImGui::SameLine();
+    if (_scope.parent_index != kInvalidSessionIndex && _scope.parent_index < _session.GpuScopes().size()) {
+        DrawBoundedText(_session.String(_session.GpuScopes()[_scope.parent_index].name));
+    } else {
+        ImGui::TextUnformatted("None");
+    }
+}
+
+[[nodiscard]] bool OpenProfileDump(std::filesystem::path& _selected_path, std::string& _status) {
+    NFD::UniquePath                      selected_path = nullptr;
+    const std::array<nfdfilteritem_t, 1> filters       = {{
+        {"Moer Profile Dump", "mpd"},
+    }};
+    const nfdresult_t result = NFD::OpenDialog(selected_path, filters.data(), filters.size());
+    if (result == NFD_CANCEL) {
+        _status = "Open cancelled.";
+        return false;
+    }
+    if (result != NFD_OKAY || !selected_path) {
+        const char* error = NFD_GetError();
+        _status           = error ? error : "Native file dialog failed.";
+        LOG_ERROR("[ProfileViewerUI] NFD error: {}", _status);
+        return false;
+    }
+
+    try {
+        _selected_path = std::filesystem::u8path(selected_path.get());
+        _status        = "Load requested.";
+        return true;
+    } catch (...) {
+        _status = "Selected profile path is invalid.";
+        return false;
+    }
+}
+
+[[nodiscard]] bool IsTerminalPhase(ProfileDocumentLoadPhase _phase) noexcept {
+    return _phase == ProfileDocumentLoadPhase::Ready || _phase == ProfileDocumentLoadPhase::Failed ||
+           _phase == ProfileDocumentLoadPhase::Cancelled || _phase == ProfileDocumentLoadPhase::Shutdown;
+}
+
+} // namespace
+
+struct ProfileViewerUI::Impl {
+    explicit Impl(ProfileDocumentLoader& _loader) : loader(_loader) {}
+
+    ProfileDocumentLoader& loader;
+    ProfileViewerModel     model{};
+
+    std::shared_ptr<const ProfileDocument> displayed_document{};
+    std::uint64_t                          publication_generation{kInvalidProfileDocumentGeneration};
+    std::vector<std::uint8_t>              cpu_track_visibility{};
+    std::vector<std::uint8_t>              gpu_track_visibility{};
+    std::vector<std::uint32_t>             cpu_visible_tracks{};
+    std::vector<std::uint32_t>             gpu_visible_tracks{};
+    std::array<char, k_filter_capacity>    filter{};
+    NameFilterMatcher                      name_filter{};
+    std::array<CpuTimelineScopeRef, k_query_capacity> cpu_query_output{};
+    std::array<GpuTimelineScopeRef, k_query_capacity> gpu_query_output{};
+    RangeSelection                                    range{};
+    std::uint64_t                                     selected_gpu_frame{0};
+    std::string                                       dialog_status{};
+
+    void ResetForPublication(const ProfileDocument& _document) {
+        publication_generation = _document.request_generation;
+        cpu_track_visibility.assign(
+            std::min(_document.timeline_index.CpuTracks().size(), k_track_scan_budget), 1
+        );
+        gpu_track_visibility.assign(
+            std::min(_document.timeline_index.GpuTracks().size(), k_track_scan_budget), 1
+        );
+        cpu_visible_tracks.clear();
+        cpu_visible_tracks.reserve(cpu_track_visibility.size());
+        gpu_visible_tracks.clear();
+        gpu_visible_tracks.reserve(gpu_track_visibility.size());
+        filter.fill('\0');
+        name_filter.Compile({});
+        range.Clear();
+
+        const auto gpu_frames = _document.timeline_index.GpuFrames();
+        selected_gpu_frame    = gpu_frames.empty() ? 0 : gpu_frames.front().frame_id;
+    }
+
+    void ClearPublication() {
+        displayed_document.reset();
+        publication_generation = kInvalidProfileDocumentGeneration;
+        cpu_track_visibility.clear();
+        gpu_track_visibility.clear();
+        cpu_visible_tracks.clear();
+        gpu_visible_tracks.clear();
+        filter.fill('\0');
+        name_filter.Compile({});
+        range.Clear();
+        selected_gpu_frame = 0;
+    }
+
+    void ReportLoadRequestFailure(const char* _detail) noexcept {
+        try {
+            dialog_status = "Load request failed";
+            if (_detail != nullptr && _detail[0] != '\0') {
+                dialog_status.append(": ");
+                dialog_status.append(_detail);
+            }
+        } catch (...) {
+            dialog_status.clear();
+        }
+        try {
+            LOG_ERROR(
+                "[ProfileViewerUI] Load request failed: {}",
+                _detail != nullptr && _detail[0] != '\0' ? _detail : "unknown error"
+            );
+        } catch (...) {
+        }
+    }
+
+    void DrawLoadStatus(const ProfileDocumentLoaderSnapshot& _snapshot) {
+        if (ImGui::Button("Open .mpd...")) {
+            std::filesystem::path selected_path;
+            if (OpenProfileDump(selected_path, dialog_status)) {
+                try {
+                    const std::uint64_t generation = loader.RequestLoad(selected_path);
+                    if (generation == kInvalidProfileDocumentGeneration) {
+                        dialog_status = "Loader rejected the request.";
+                    }
+                } catch (const std::exception& error) {
+                    ReportLoadRequestFailure(error.what());
+                } catch (...) {
+                    ReportLoadRequestFailure("unknown exception");
+                }
+            }
+        }
+
+        const bool cancellable = _snapshot.accepting_requests && !IsTerminalPhase(_snapshot.phase) &&
+                                 _snapshot.request_generation != kInvalidProfileDocumentGeneration;
+        ImGui::SameLine();
+        if (!cancellable) {
+            ImGui::BeginDisabled();
+        }
+        if (ImGui::Button("Cancel load")) {
+            dialog_status = loader.CancelLatest() ? "Cancellation requested." : "No cancellable request.";
+        }
+        if (!cancellable) {
+            ImGui::EndDisabled();
+        }
+
+        ImGui::SameLine();
+        ImGui::Text(
+            "Phase: %s | request %llu | published %llu",
+            LoadPhaseText(_snapshot.phase),
+            static_cast<unsigned long long>(_snapshot.request_generation),
+            static_cast<unsigned long long>(_snapshot.published_generation)
+        );
+
+        if (!_snapshot.latest_attempt_path.empty()) {
+            ImGui::TextUnformatted("Latest attempt:");
+            ImGui::SameLine();
+            const std::string path = PathForDisplay(_snapshot.latest_attempt_path);
+            DrawBoundedText(path, 2048);
+        }
+        if (_snapshot.phase == ProfileDocumentLoadPhase::Reading) {
+            ImGui::TextDisabled("Reading progress is indeterminate; observed file size is metadata only.");
+        } else if (_snapshot.reported_input_bytes_final) {
+            ImGui::Text("Input bytes: %llu", static_cast<unsigned long long>(_snapshot.reported_input_bytes));
+        }
+        if (_snapshot.diagnostic != ProfileDocumentLoadDiagnostic::None) {
+            ImGui::TextColored(
+                ImVec4(1.0f, 0.42f, 0.32f, 1.0f),
+                "Latest attempt: %s",
+                LoadDiagnosticText(_snapshot.diagnostic)
+            );
+        }
+        if (!dialog_status.empty()) {
+            ImGui::TextDisabled("%s", dialog_status.c_str());
+        }
+    }
+
+    void DrawDocumentHeader(const ProfileDocument& _document) {
+        const std::string path = PathForDisplay(_document.source_path);
+        ImGui::TextUnformatted("Displayed document:");
+        ImGui::SameLine();
+        DrawBoundedText(path, 2048);
+
+        const ProfileSessionSummary& summary = _document.session.Summary();
+        ImGui::Text(
+            "CPU scopes %llu | GPU frames %llu | GPU scopes %llu | model %llu bytes | index %llu bytes",
+            static_cast<unsigned long long>(summary.cpu_scope_count),
+            static_cast<unsigned long long>(summary.gpu_frame_count),
+            static_cast<unsigned long long>(summary.gpu_scope_count),
+            static_cast<unsigned long long>(summary.logical_model_bytes),
+            static_cast<unsigned long long>(_document.timeline_index.BuildResult().logical_bytes)
+        );
+        if (ImGui::CollapsingHeader("Capture quality")) {
+            DrawQuality(_document.timeline_index.Quality());
+        }
+    }
+
+    void
+    DrawFilterAndVisibility(std::span<const CpuTimelineTrackIndex> _tracks, const ProfileSession& _session) {
+        ImGui::SetNextItemWidth(240.0f);
+        if (ImGui::InputTextWithHint(
+                "##CpuProfileFilter", "Filter scope name", filter.data(), filter.size()
+            )) {
+            name_filter.Compile(filter.data());
+        }
+        ImGui::SameLine();
+        if (ImGui::Button("CPU tracks")) {
+            ImGui::OpenPopup("CpuProfileTrackVisibility");
+        }
+        if (ImGui::BeginPopup("CpuProfileTrackVisibility")) {
+            const std::size_t track_count = std::min(_tracks.size(), cpu_track_visibility.size());
+            for (std::size_t index = 0; index < track_count; ++index) {
+                const CpuTimelineTrackIndex& timeline_track = _tracks[index];
+                const CpuTrack& source_track = _session.CpuTracks()[timeline_track.source_track_index];
+                bool visible = index < cpu_track_visibility.size() && cpu_track_visibility[index] != 0;
+                char label[96]{};
+                std::snprintf(
+                    label,
+                    sizeof(label),
+                    "Thread %llu##CpuTrack%llu",
+                    static_cast<unsigned long long>(source_track.thread_id),
+                    static_cast<unsigned long long>(index)
+                );
+                if (ImGui::Checkbox(label, &visible) && index < cpu_track_visibility.size()) {
+                    cpu_track_visibility[index] = visible ? 1 : 0;
+                }
+            }
+            if (_tracks.size() > track_count) {
+                ImGui::TextDisabled("Track list truncated to the fixed 4096-track viewer budget.");
+            }
+            ImGui::EndPopup();
+        }
+    }
+
+    void DrawFilterAndVisibility(
+        std::span<const GpuTimelineTrackIndex> _tracks,
+        const ProfileSession&                  _session,
+        const ProfileTimelineIndex&            _index,
+        std::uint32_t                          _axis_index,
+        std::uint64_t                          _frame_id
+    ) {
+        ImGui::SetNextItemWidth(240.0f);
+        if (ImGui::InputTextWithHint(
+                "##GpuProfileFilter", "Filter scope name", filter.data(), filter.size()
+            )) {
+            name_filter.Compile(filter.data());
+        }
+        ImGui::SameLine();
+        if (ImGui::Button("GPU tracks")) {
+            ImGui::OpenPopup("GpuProfileTrackVisibility");
+        }
+        if (ImGui::BeginPopup("GpuProfileTrackVisibility")) {
+            const std::size_t track_count = std::min(_tracks.size(), gpu_track_visibility.size());
+            for (std::size_t index = 0; index < track_count; ++index) {
+                if (_tracks[index].axis_index != _axis_index ||
+                    _index.FindGpuFrameSlice(static_cast<std::uint32_t>(index), _frame_id) == nullptr) {
+                    continue;
+                }
+                const GpuTrack& source_track = _session.GpuTracks()[_tracks[index].source_track_index];
+                bool visible = index < gpu_track_visibility.size() && gpu_track_visibility[index] != 0;
+                char label[128]{};
+                std::snprintf(
+                    label,
+                    sizeof(label),
+                    "%s native %u##GpuTrack%llu",
+                    LogicalQueueText(source_track.logical_queue),
+                    source_track.native_queue_id,
+                    static_cast<unsigned long long>(index)
+                );
+                if (ImGui::Checkbox(label, &visible) && index < gpu_track_visibility.size()) {
+                    gpu_track_visibility[index] = visible ? 1 : 0;
+                }
+            }
+            if (_tracks.size() > track_count) {
+                ImGui::TextDisabled("Track list truncated to the fixed 4096-track viewer budget.");
+            }
+            ImGui::EndPopup();
+        }
+    }
+
+    void DrawCpuTooltip(
+        const ProfileSession& _session,
+        const CpuScopeRecord& _scope,
+        std::uint64_t         _relative_begin,
+        std::uint64_t         _relative_end
+    ) {
+        ImGui::BeginTooltip();
+        DrawBoundedText(_session.String(_scope.name));
+        ImGui::Separator();
+        ImGui::Text("Depth: %u", _scope.depth);
+        ImGui::Text(
+            "Range: %llu - %llu ns",
+            static_cast<unsigned long long>(_relative_begin),
+            static_cast<unsigned long long>(_relative_end)
+        );
+        ImGui::Text(
+            "Duration: %.3f us", static_cast<double>(IntervalExtent(_relative_begin, _relative_end)) / 1000.0
+        );
+        DrawParentName(_session, _scope);
+        ImGui::EndTooltip();
+    }
+
+    void DrawGpuTooltip(
+        const ProfileSession& _session,
+        const GpuScopeRecord& _scope,
+        std::uint64_t         _frame_id,
+        std::uint64_t         _relative_begin,
+        std::uint64_t         _relative_end,
+        double                _unit_period_ns
+    ) {
+        ImGui::BeginTooltip();
+        DrawBoundedText(_session.String(_scope.name));
+        ImGui::Separator();
+        ImGui::Text("Depth: %u", _scope.depth);
+        ImGui::Text("Frame: %llu", static_cast<unsigned long long>(_frame_id));
+        ImGui::Text(
+            "Tick offsets: %llu - %llu",
+            static_cast<unsigned long long>(_relative_begin),
+            static_cast<unsigned long long>(_relative_end)
+        );
+        ImGui::Text(
+            "Duration: %.3f us",
+            static_cast<double>(IntervalExtent(_relative_begin, _relative_end)) * _unit_period_ns / 1000.0
+        );
+        DrawParentName(_session, _scope);
+        ImGui::EndTooltip();
+    }
+
+    void DrawSelectionDetails(const ProfileDocument& _document) {
+        if (!ImGui::CollapsingHeader("Selection details", ImGuiTreeNodeFlags_DefaultOpen)) {
+            return;
+        }
+
+        const ProfileViewerSelection selection = model.Selection();
+        if (!selection.Valid() || selection.published_generation != publication_generation ||
+            selection.published_generation != _document.request_generation) {
+            ImGui::TextDisabled("No scope selected. Click a scope to keep its details here.");
+            return;
+        }
+
+        if (ImGui::SmallButton("Clear selection")) {
+            model.ClearSelection();
+            return;
+        }
+        ImGui::SameLine();
+        ImGui::Text(
+            "%s scope | timeline track %llu",
+            selection.kind == EProfileViewerSelectionKind::CpuScope ? "CPU" : "GPU",
+            static_cast<unsigned long long>(selection.timeline_track_index)
+        );
+
+        const ProfileSession& session = _document.session;
+        if (selection.kind == EProfileViewerSelectionKind::CpuScope) {
+            if (selection.source_scope_index >= session.CpuScopes().size()) {
+                ImGui::TextColored(ImVec4(1.0f, 0.45f, 0.35f, 1.0f), "Selected CPU scope is unavailable.");
+                return;
+            }
+
+            const CpuScopeRecord& scope = session.CpuScopes()[selection.source_scope_index];
+            ImGui::TextUnformatted("Name:");
+            ImGui::SameLine();
+            DrawBoundedText(session.String(scope.name));
+            ImGui::Text(
+                "Range: %llu - %llu ns | duration %.3f us",
+                static_cast<unsigned long long>(selection.begin),
+                static_cast<unsigned long long>(selection.end),
+                static_cast<double>(IntervalExtent(selection.begin, selection.end)) / 1000.0
+            );
+            ImGui::Text("Depth: %u", scope.depth);
+            DrawParentName(session, scope);
+            return;
+        }
+
+        if (selection.kind != EProfileViewerSelectionKind::GpuScope ||
+            selection.source_scope_index >= session.GpuScopes().size()) {
+            ImGui::TextColored(ImVec4(1.0f, 0.45f, 0.35f, 1.0f), "Selected GPU scope is unavailable.");
+            return;
+        }
+
+        const GpuScopeRecord& scope = session.GpuScopes()[selection.source_scope_index];
+        ImGui::TextUnformatted("Name:");
+        ImGui::SameLine();
+        DrawBoundedText(session.String(scope.name));
+        ImGui::Text(
+            "Frame %llu | physical axis %u | tick offsets %llu - %llu",
+            static_cast<unsigned long long>(selection.frame_id),
+            selection.axis_index,
+            static_cast<unsigned long long>(selection.begin),
+            static_cast<unsigned long long>(selection.end)
+        );
+        if (selection.axis_index < _document.timeline_index.Axes().size()) {
+            const double unit_period_ns =
+                _document.timeline_index.Axes()[selection.axis_index].unit_period_ns;
+            ImGui::Text(
+                "Duration: %.3f us",
+                static_cast<double>(IntervalExtent(selection.begin, selection.end)) * unit_period_ns / 1000.0
+            );
+        }
+        ImGui::Text("Depth: %u", scope.depth);
+        DrawParentName(session, scope);
+    }
+
+    void HandleCpuNavigation(
+        const ProfileViewerViewport& _viewport,
+        float                        _timeline_x0,
+        float                        _timeline_width,
+        bool                         _hovered
+    ) {
+        if (!_hovered || !_viewport.valid) {
+            return;
+        }
+        const ImGuiIO& io = ImGui::GetIO();
+        if (io.MouseWheel != 0.0f && !io.KeyShift) {
+            constexpr std::uint32_t denominator = 1'000'000;
+            const std::uint32_t     anchor = AnchorNumerator(io.MousePos.x, _timeline_x0, _timeline_width);
+            if (io.MouseWheel > 0.0f) {
+                static_cast<void>(model.ZoomCpu(anchor, denominator, 4, 5));
+            } else {
+                static_cast<void>(model.ZoomCpu(anchor, denominator, 5, 4));
+            }
+        }
+        if (ImGui::IsMouseDragging(ImGuiMouseButton_Middle)) {
+            static_cast<void>(model.PanCpu(PixelPanDelta(_viewport, io.MouseDelta.x, _timeline_width)));
+        } else if (io.MouseWheel != 0.0f && io.KeyShift) {
+            const float pixels = io.MouseWheel * _timeline_width * 0.12f;
+            static_cast<void>(model.PanCpu(PixelPanDelta(_viewport, pixels, _timeline_width)));
+        }
+        if (!ImGui::IsAnyItemActive()) {
+            if (ImGui::IsKeyPressed(ImGuiKey_LeftArrow)) {
+                static_cast<void>(model.PanCpu(KeyboardPanDelta(_viewport, false)));
+            } else if (ImGui::IsKeyPressed(ImGuiKey_RightArrow)) {
+                static_cast<void>(model.PanCpu(KeyboardPanDelta(_viewport, true)));
+            }
+        }
+    }
+
+    void HandleGpuNavigation(
+        ProfileViewerGpuViewportKey  _key,
+        const ProfileViewerViewport& _viewport,
+        float                        _timeline_x0,
+        float                        _timeline_width,
+        bool                         _hovered
+    ) {
+        if (!_hovered || !_viewport.valid) {
+            return;
+        }
+        const ImGuiIO& io = ImGui::GetIO();
+        if (io.MouseWheel != 0.0f && !io.KeyShift) {
+            constexpr std::uint32_t denominator = 1'000'000;
+            const std::uint32_t     anchor = AnchorNumerator(io.MousePos.x, _timeline_x0, _timeline_width);
+            if (io.MouseWheel > 0.0f) {
+                static_cast<void>(model.ZoomGpu(_key, anchor, denominator, 4, 5));
+            } else {
+                static_cast<void>(model.ZoomGpu(_key, anchor, denominator, 5, 4));
+            }
+        }
+        if (ImGui::IsMouseDragging(ImGuiMouseButton_Middle)) {
+            static_cast<void>(model.PanGpu(_key, PixelPanDelta(_viewport, io.MouseDelta.x, _timeline_width)));
+        } else if (io.MouseWheel != 0.0f && io.KeyShift) {
+            const float pixels = io.MouseWheel * _timeline_width * 0.12f;
+            static_cast<void>(model.PanGpu(_key, PixelPanDelta(_viewport, pixels, _timeline_width)));
+        }
+        if (!ImGui::IsAnyItemActive()) {
+            if (ImGui::IsKeyPressed(ImGuiKey_LeftArrow)) {
+                static_cast<void>(model.PanGpu(_key, KeyboardPanDelta(_viewport, false)));
+            } else if (ImGui::IsKeyPressed(ImGuiKey_RightArrow)) {
+                static_cast<void>(model.PanGpu(_key, KeyboardPanDelta(_viewport, true)));
+            }
+        }
+    }
+
+    void HandleRangeSelection(
+        ERangeDomain                 _domain,
+        ProfileViewerGpuViewportKey  _gpu_key,
+        const ProfileViewerViewport& _viewport,
+        float                        _timeline_x0,
+        float                        _timeline_width,
+        bool                         _body_hovered,
+        bool                         _event_hovered
+    ) {
+        if (!_viewport.valid) {
+            return;
+        }
+
+        const ImGuiIO& io = ImGui::GetIO();
+        if (_body_hovered && ImGui::IsMouseClicked(ImGuiMouseButton_Right)) {
+            range.Clear();
+            model.ClearSelection();
+            return;
+        }
+        if (_body_hovered && !_event_hovered && ImGui::IsMouseClicked(ImGuiMouseButton_Left)) {
+            range.domain    = _domain;
+            range.gpu_key   = _gpu_key;
+            range.dragging  = true;
+            range.committed = false;
+            range.anchor    = XToTime(_viewport, io.MousePos.x, _timeline_x0, _timeline_width);
+            range.begin     = range.anchor;
+            range.end       = range.anchor;
+        }
+
+        const bool same_domain =
+            range.domain == _domain && (_domain == ERangeDomain::Cpu || range.gpu_key == _gpu_key);
+        if (same_domain && range.dragging && ImGui::IsMouseDown(ImGuiMouseButton_Left)) {
+            const std::uint64_t current = XToTime(_viewport, io.MousePos.x, _timeline_x0, _timeline_width);
+            range.begin                 = std::min(range.anchor, current);
+            range.end                   = std::max(range.anchor, current);
+        }
+        // A release can happen while this tab/window is not drawn. Finishing on
+        // the first observed mouse-up prevents a permanently dragging range.
+        if (same_domain && range.dragging && !ImGui::IsMouseDown(ImGuiMouseButton_Left)) {
+            range.dragging  = false;
+            range.committed = range.begin < range.end;
+        }
+    }
+
+    void DrawRangeOverlay(
+        const ProfileViewerViewport& _viewport,
+        bool                         _active,
+        float                        _x0,
+        float                        _width,
+        float                        _y0,
+        float                        _y1
+    ) const {
+        if (!_active || _y1 <= _y0) {
+            return;
+        }
+        const float x0        = TimeToX(_viewport, range.begin, _x0, _width);
+        const float x1        = TimeToX(_viewport, range.end, _x0, _width);
+        ImDrawList* draw_list = ImGui::GetWindowDrawList();
+        draw_list->AddRectFilled(ImVec2(x0, _y0), ImVec2(x1, _y1), IM_COL32(92, 156, 206, 38));
+        draw_list->AddRect(ImVec2(x0, _y0), ImVec2(x1, _y1), IM_COL32(132, 202, 245, 190));
+    }
+
+    void DrawCpu(const ProfileDocument& _document) {
+        const ProfileSession&       session    = _document.session;
+        const ProfileTimelineIndex& index      = _document.timeline_index;
+        const auto                  tracks     = index.CpuTracks();
+        const std::uint64_t         domain_end = CpuDomainEnd(session.Summary());
+
+        ProfileViewerViewport viewport = model.CpuViewport();
+        if ((!viewport.valid || viewport.domain_end != domain_end) && domain_end > 0) {
+            static_cast<void>(model.FitCpu(domain_end));
+            viewport = model.CpuViewport();
+        }
+
+        if (ImGui::Button("Fit CPU")) {
+            static_cast<void>(model.FitCpu(domain_end));
+            viewport = model.CpuViewport();
+        }
+        ImGui::SameLine();
+        ImGui::TextDisabled("CPU steady-clock axis; never aligned to GPU.");
+        DrawFilterAndVisibility(tracks, session);
+        if (tracks.size() > cpu_track_visibility.size()) {
+            ImGui::TextColored(
+                ImVec4(1.0f, 0.66f, 0.22f, 1.0f),
+                "CPU track discovery truncated to the fixed 4096-track viewer budget."
+            );
+        }
+
+        if (!viewport.valid || tracks.empty()) {
+            ImGui::TextDisabled("No CPU timeline data.");
+            return;
+        }
+
+        const ProfileViewerSelection selection = model.Selection();
+        if (selection.kind == EProfileViewerSelectionKind::CpuScope &&
+            selection.published_generation == publication_generation &&
+            ImGui::IsWindowFocused(ImGuiFocusedFlags_RootAndChildWindows) && !ImGui::IsAnyItemActive() &&
+            ImGui::IsKeyPressed(ImGuiKey_F)) {
+            const std::uint64_t margin =
+                std::max<std::uint64_t>(IntervalExtent(selection.begin, selection.end) / 5, 1);
+            static_cast<void>(model.FocusCpu(selection.begin, selection.end, margin));
+            viewport = model.CpuViewport();
+        }
+
+        const float available_width = std::max(ImGui::GetContentRegionAvail().x, 360.0f);
+        const float timeline_x0     = ImGui::GetCursorScreenPos().x + k_track_label_width;
+        const float timeline_width  = std::max(100.0f, available_width - k_track_label_width);
+        DrawTimeRuler(viewport, timeline_x0, timeline_width, ImGui::GetCursorScreenPos().y, 1.0);
+        ImGui::Dummy(ImVec2(available_width, 30.0f));
+
+        DrawOverview(viewport, timeline_x0, timeline_width, 32.0f);
+        if (ImGui::IsItemHovered() && ImGui::IsMouseClicked(ImGuiMouseButton_Left)) {
+            constexpr std::uint32_t denominator = 1'000'000;
+            const std::uint64_t     target      = ProfileViewerMapFraction(
+                0,
+                viewport.domain_end,
+                AnchorNumerator(ImGui::GetIO().MousePos.x, timeline_x0, timeline_width),
+                denominator
+            );
+            const std::uint64_t span = viewport.view_end - viewport.view_begin;
+            static_cast<void>(
+                model.FocusCpu(target, SaturatingIncrement(target), std::max(span / 2, std::uint64_t{1}))
+            );
+            viewport = model.CpuViewport();
+        }
+
+        cpu_visible_tracks.clear();
+        const std::size_t cpu_track_count = std::min(tracks.size(), cpu_track_visibility.size());
+        for (std::size_t index_value = 0; index_value < cpu_track_count; ++index_value) {
+            if (cpu_track_visibility[index_value] != 0) {
+                cpu_visible_tracks.emplace_back(static_cast<std::uint32_t>(index_value));
+            }
+        }
+
+        ImGui::BeginChild(
+            "CpuProfileTimelineRows", ImVec2(0.0f, std::max(180.0f, ImGui::GetContentRegionAvail().y)), true
+        );
+        const ImVec2 body_origin               = ImGui::GetCursorScreenPos();
+        const float  body_width                = std::max(ImGui::GetContentRegionAvail().x, 360.0f);
+        const float  body_x0                   = body_origin.x + k_track_label_width;
+        const float  body_timeline_width       = std::max(100.0f, body_width - k_track_label_width);
+        bool         event_hovered             = false;
+        bool         query_truncated           = false;
+        bool         filter_results_incomplete = false;
+        std::size_t  remaining_budget          = k_frame_event_budget;
+
+        ImGuiListClipper clipper;
+        clipper.Begin(static_cast<int>(cpu_visible_tracks.size()), k_track_row_height);
+        while (clipper.Step()) {
+            for (int row_index = clipper.DisplayStart; row_index < clipper.DisplayEnd; ++row_index) {
+                const std::uint32_t timeline_track_index =
+                    cpu_visible_tracks[static_cast<std::size_t>(row_index)];
+                const CpuTimelineTrackIndex& track        = tracks[timeline_track_index];
+                const CpuTrack&              source_track = session.CpuTracks()[track.source_track_index];
+                const ImVec2                 row_origin   = ImGui::GetCursorScreenPos();
+                ImGui::Dummy(ImVec2(body_width, k_track_row_height));
+
+                ImDrawList* draw_list = ImGui::GetWindowDrawList();
+                draw_list->AddRectFilled(
+                    row_origin,
+                    ImVec2(row_origin.x + k_track_label_width, row_origin.y + k_track_row_height),
+                    IM_COL32(31, 31, 34, 255)
+                );
+                draw_list->AddRectFilled(
+                    ImVec2(body_x0, row_origin.y),
+                    ImVec2(body_x0 + body_timeline_width, row_origin.y + k_track_row_height),
+                    IM_COL32(24, 24, 27, 255)
+                );
+                draw_list->AddLine(
+                    ImVec2(row_origin.x, row_origin.y + k_track_row_height),
+                    ImVec2(row_origin.x + body_width, row_origin.y + k_track_row_height),
+                    IM_COL32(70, 70, 74, 255)
+                );
+                char track_label[128]{};
+                std::snprintf(
+                    track_label,
+                    sizeof(track_label),
+                    "CPU thread %llu | depth %u%s",
+                    static_cast<unsigned long long>(source_track.thread_id),
+                    track.max_depth,
+                    track.max_depth >= k_direct_depth_lanes ? " (overflow lane)" : ""
+                );
+                draw_list->AddText(
+                    ImVec2(row_origin.x + 7.0f, row_origin.y + 4.0f),
+                    IM_COL32(220, 220, 220, 255),
+                    track_label
+                );
+
+                if (remaining_budget == 0) {
+                    query_truncated           = true;
+                    filter_results_incomplete = filter_results_incomplete || !name_filter.Empty();
+                    continue;
+                }
+                const std::size_t output_capacity =
+                    std::min<std::size_t>(remaining_budget, cpu_query_output.size());
+                const TimelineOverlapQueryResult query = index.QueryCpuTimelineOverlaps(
+                    timeline_track_index,
+                    viewport.view_begin,
+                    viewport.view_end,
+                    std::span<CpuTimelineScopeRef>(cpu_query_output).first(output_capacity)
+                );
+                if (!query.valid) {
+                    continue;
+                }
+                query_truncated = query_truncated || query.truncated;
+                filter_results_incomplete =
+                    filter_results_incomplete || (query.truncated && !name_filter.Empty());
+                remaining_budget -= static_cast<std::size_t>(query.written);
+
+                for (std::uint64_t result_index = 0; result_index < query.written; ++result_index) {
+                    const CpuTimelineScopeRef& timeline_scope =
+                        cpu_query_output[static_cast<std::size_t>(result_index)];
+                    const std::uint64_t source_index = timeline_scope.source_scope_index;
+                    if (source_index >= session.CpuScopes().size()) {
+                        continue;
+                    }
+                    const CpuScopeRecord&  scope = session.CpuScopes()[source_index];
+                    const std::string_view name  = session.String(scope.name);
+                    filter_results_incomplete =
+                        filter_results_incomplete ||
+                        (!name_filter.Empty() && name.size() > k_filter_name_byte_limit);
+                    if (!name_filter.Matches(name)) {
+                        continue;
+                    }
+                    const std::uint64_t begin = timeline_scope.begin_ns;
+                    const std::uint64_t end   = timeline_scope.end_ns;
+                    float               x0    = TimeToX(viewport, begin, body_x0, body_timeline_width);
+                    float               x1    = TimeToX(viewport, end, body_x0, body_timeline_width);
+                    if (x1 - x0 < 2.0f) {
+                        x1 = std::min(body_x0 + body_timeline_width, x0 + 2.0f);
+                    }
+                    const std::uint32_t lane = std::min(scope.depth, k_overflow_depth_lane);
+                    const float         y0   = row_origin.y + 3.0f + lane * k_lane_height;
+                    const float         y1   = y0 + k_lane_height - 2.0f;
+                    if (x1 <= body_x0 || x0 >= body_x0 + body_timeline_width) {
+                        continue;
+                    }
+
+                    const ImVec2 rect_min(std::max(x0, body_x0), y0);
+                    const ImVec2 rect_max(std::min(x1, body_x0 + body_timeline_width), y1);
+                    draw_list->AddRectFilled(rect_min, rect_max, EventColor(name), 2.0f);
+                    const bool selected = selection.kind == EProfileViewerSelectionKind::CpuScope &&
+                                          selection.published_generation == publication_generation &&
+                                          selection.source_scope_index == source_index;
+                    if (selected) {
+                        draw_list->AddRect(rect_min, rect_max, IM_COL32(255, 232, 80, 255), 2.0f, 0, 2.0f);
+                    }
+                    if (rect_max.x - rect_min.x >= 28.0f) {
+                        const std::string_view bounded = BoundedUtf8Prefix(name, k_draw_name_byte_limit);
+                        draw_list->PushClipRect(rect_min, rect_max, true);
+                        draw_list->AddText(
+                            ImVec2(rect_min.x + 3.0f, rect_min.y + 1.0f),
+                            IM_COL32(238, 238, 238, 255),
+                            bounded.data(),
+                            bounded.data() + bounded.size()
+                        );
+                        draw_list->PopClipRect();
+                    }
+
+                    if (ImGui::IsMouseHoveringRect(rect_min, rect_max, true)) {
+                        event_hovered = true;
+                        DrawCpuTooltip(session, scope, begin, end);
+                        if (ImGui::IsMouseClicked(ImGuiMouseButton_Left)) {
+                            static_cast<void>(model.SelectCpu(
+                                timeline_track_index, source_index, begin, std::max(begin, end)
+                            ));
+                        }
+                    }
+                }
+            }
+        }
+
+        const bool body_hovered = ImGui::IsWindowHovered() && ImGui::GetIO().MousePos.x >= body_x0 &&
+                                  ImGui::GetIO().MousePos.x <= body_x0 + body_timeline_width;
+        HandleCpuNavigation(viewport, body_x0, body_timeline_width, body_hovered);
+        HandleRangeSelection(
+            ERangeDomain::Cpu, {}, viewport, body_x0, body_timeline_width, body_hovered, event_hovered
+        );
+        DrawRangeOverlay(
+            viewport,
+            range.ActiveForCpu(),
+            body_x0,
+            body_timeline_width,
+            body_origin.y,
+            ImGui::GetWindowPos().y + ImGui::GetWindowHeight()
+        );
+        ImGui::EndChild();
+
+        if (filter_results_incomplete) {
+            ImGui::TextColored(
+                ImVec4(1.0f, 0.66f, 0.22f, 1.0f),
+                "Filter results are incomplete: the query budget was exhausted or a scope name exceeded the "
+                "1024-byte filter scan limit."
+            );
+        } else if (query_truncated || remaining_budget == 0) {
+            ImGui::TextColored(
+                ImVec4(1.0f, 0.66f, 0.22f, 1.0f),
+                "Visible CPU scopes truncated (4096 per track / 16384 per frame budget)."
+            );
+        }
+    }
+
+    [[nodiscard]] std::size_t FindGpuFramePosition(
+        std::span<const GpuTimelineFrameRef> _frames,
+        std::uint64_t                        _frame_id
+    ) const noexcept {
+        const auto found = std::lower_bound(
+            _frames.begin(),
+            _frames.end(),
+            _frame_id,
+            [](const GpuTimelineFrameRef& _frame, std::uint64_t _value) {
+                return _frame.frame_id < _value;
+            }
+        );
+        if (found == _frames.end()) {
+            return _frames.empty() ? 0 : _frames.size() - 1;
+        }
+        return static_cast<std::size_t>(found - _frames.begin());
+    }
+
+    void DrawGpuFrameChooser(
+        std::span<const GpuTimelineFrameRef> _frames,
+        const ProfileSession&                _session,
+        const ProfileTimelineIndex&          _index
+    ) {
+        if (_frames.empty()) {
+            return;
+        }
+        std::size_t position = FindGpuFramePosition(_frames, selected_gpu_frame);
+        if (_frames[position].frame_id != selected_gpu_frame) {
+            selected_gpu_frame = _frames[position].frame_id;
+        }
+
+        if (ImGui::Button("<##GpuFrame")) {
+            if (position > 0) {
+                --position;
+                selected_gpu_frame = _frames[position].frame_id;
+                range.Clear();
+            }
+        }
+        ImGui::SameLine();
+        if (ImGui::Button(">##GpuFrame")) {
+            if (position + 1 < _frames.size()) {
+                ++position;
+                selected_gpu_frame = _frames[position].frame_id;
+                range.Clear();
+            }
+        }
+        ImGui::SameLine();
+        ImGui::SetNextItemWidth(180.0f);
+        std::uint64_t requested_frame = selected_gpu_frame;
+        if (ImGui::InputScalar(
+                "GPU frame",
+                ImGuiDataType_U64,
+                &requested_frame,
+                nullptr,
+                nullptr,
+                "%llu",
+                ImGuiInputTextFlags_EnterReturnsTrue
+            )) {
+            position           = FindGpuFramePosition(_frames, requested_frame);
+            selected_gpu_frame = _frames[position].frame_id;
+            range.Clear();
+        }
+
+        const GpuTimelineFrameRef* frame_ref = _index.FindGpuFrame(selected_gpu_frame);
+        if (frame_ref != nullptr && frame_ref->source_frame_index < _session.GpuFrames().size()) {
+            const GpuFrameRecord& frame = _session.GpuFrames()[frame_ref->source_frame_index];
+            ImGui::SameLine();
+            ImGui::Text(
+                "%s | scopes %llu | dropped %llu | errors %llu",
+                GpuFrameStatusText(frame.status),
+                static_cast<unsigned long long>(frame.scope_count),
+                static_cast<unsigned long long>(frame.dropped_scope_count),
+                static_cast<unsigned long long>(frame.error_scope_count)
+            );
+            if (!frame.materialization_complete || !frame.timing_topology_trusted) {
+                ImGui::TextColored(
+                    ImVec4(1.0f, 0.66f, 0.22f, 1.0f), "Frame timing is incomplete or topology-untrusted."
+                );
+            }
+        }
+    }
+
+    void DrawGpuAxis(
+        const ProfileDocument&      _document,
+        std::uint32_t               _axis_index,
+        const GpuTimelineAxisFrame& _axis_frame
+    ) {
+        const ProfileSession&             session = _document.session;
+        const ProfileTimelineIndex&       index   = _document.timeline_index;
+        const TimelineAxis&               axis    = index.Axes()[_axis_index];
+        const ProfileViewerGpuViewportKey key{
+            .axis_index = _axis_index,
+            .frame_id   = selected_gpu_frame,
+        };
+        const std::uint64_t domain_end = GpuDomainEnd(_axis_frame);
+
+        ImGui::Text(
+            "Physical domain: native queue %u, family %u, valid bits %u, %.6f ns/tick",
+            axis.native_queue_id,
+            axis.family_id,
+            axis.valid_bits,
+            axis.unit_period_ns
+        );
+        ImGui::SameLine();
+        ImGui::TextDisabled("| frame-local only; not calibrated to CPU, other domains, or other frames");
+        if (!_axis_frame.timing_available || domain_end == 0) {
+            ImGui::TextColored(
+                ImVec4(1.0f, 0.50f, 0.30f, 1.0f),
+                "No valid timing for this physical axis/frame; error-only scopes are not drawn."
+            );
+            ImGui::Text(
+                "Ready scopes %llu | error scopes %llu | capability trusted: %s | topology trusted: %s",
+                static_cast<unsigned long long>(_axis_frame.ready_scope_count),
+                static_cast<unsigned long long>(_axis_frame.error_scope_count),
+                _axis_frame.timing_capability_trusted ? "yes" : "no",
+                _axis_frame.timing_topology_trusted ? "yes" : "no"
+            );
+            return;
+        }
+
+        std::optional<ProfileViewerViewport> viewport = model.FindGpuViewport(key);
+        if (!viewport || !viewport->valid || viewport->domain_end != domain_end) {
+            static_cast<void>(model.FitGpu(key, domain_end));
+            viewport = model.FindGpuViewport(key);
+        }
+        if (!viewport) {
+            ImGui::TextColored(ImVec4(1.0f, 0.45f, 0.35f, 1.0f), "GPU viewport capacity exhausted.");
+            return;
+        }
+
+        if (ImGui::Button("Fit GPU axis/frame")) {
+            static_cast<void>(model.FitGpu(key, domain_end));
+            viewport = model.FindGpuViewport(key);
+        }
+        ImGui::SameLine();
+        ImGui::Text(
+            "Ready %llu | errors %llu | materialized %s | topology trusted %s",
+            static_cast<unsigned long long>(_axis_frame.ready_scope_count),
+            static_cast<unsigned long long>(_axis_frame.error_scope_count),
+            _axis_frame.materialization_complete ? "yes" : "no",
+            _axis_frame.timing_topology_trusted ? "yes" : "no"
+        );
+        DrawFilterAndVisibility(index.GpuTracks(), session, index, _axis_index, selected_gpu_frame);
+        if (index.GpuTracks().size() > gpu_track_visibility.size()) {
+            ImGui::TextColored(
+                ImVec4(1.0f, 0.66f, 0.22f, 1.0f),
+                "GPU track discovery truncated to the fixed 4096-track viewer budget."
+            );
+        }
+
+        const ProfileViewerSelection selection = model.Selection();
+        if (selection.kind == EProfileViewerSelectionKind::GpuScope &&
+            selection.published_generation == publication_generation && selection.axis_index == _axis_index &&
+            selection.frame_id == selected_gpu_frame &&
+            ImGui::IsWindowFocused(ImGuiFocusedFlags_RootAndChildWindows) && !ImGui::IsAnyItemActive() &&
+            ImGui::IsKeyPressed(ImGuiKey_F)) {
+            const std::uint64_t margin =
+                std::max<std::uint64_t>(IntervalExtent(selection.begin, selection.end) / 5, 1);
+            static_cast<void>(model.FocusGpu(key, selection.begin, selection.end, margin));
+            viewport = model.FindGpuViewport(key);
+        }
+        if (!viewport) {
+            return;
+        }
+
+        const float available_width = std::max(ImGui::GetContentRegionAvail().x, 360.0f);
+        const float timeline_x0     = ImGui::GetCursorScreenPos().x + k_track_label_width;
+        const float timeline_width  = std::max(100.0f, available_width - k_track_label_width);
+        DrawTimeRuler(
+            *viewport, timeline_x0, timeline_width, ImGui::GetCursorScreenPos().y, axis.unit_period_ns
+        );
+        ImGui::Dummy(ImVec2(available_width, 30.0f));
+        DrawOverview(*viewport, timeline_x0, timeline_width, 32.0f);
+        if (ImGui::IsItemHovered() && ImGui::IsMouseClicked(ImGuiMouseButton_Left)) {
+            constexpr std::uint32_t denominator = 1'000'000;
+            const std::uint64_t     target      = ProfileViewerMapFraction(
+                0,
+                viewport->domain_end,
+                AnchorNumerator(ImGui::GetIO().MousePos.x, timeline_x0, timeline_width),
+                denominator
+            );
+            const std::uint64_t span = viewport->view_end - viewport->view_begin;
+            static_cast<void>(
+                model.FocusGpu(key, target, SaturatingIncrement(target), std::max(span / 2, std::uint64_t{1}))
+            );
+            viewport = model.FindGpuViewport(key);
+        }
+        if (!viewport) {
+            return;
+        }
+
+        const auto gpu_tracks = index.GpuTracks();
+        gpu_visible_tracks.clear();
+        const std::size_t gpu_track_count = std::min(gpu_tracks.size(), gpu_track_visibility.size());
+        for (std::size_t track_index = 0; track_index < gpu_track_count; ++track_index) {
+            if (gpu_tracks[track_index].axis_index == _axis_index && gpu_track_visibility[track_index] != 0 &&
+                index.FindGpuFrameSlice(static_cast<std::uint32_t>(track_index), selected_gpu_frame) !=
+                    nullptr) {
+                gpu_visible_tracks.emplace_back(static_cast<std::uint32_t>(track_index));
+            }
+        }
+
+        char child_name[96]{};
+        std::snprintf(
+            child_name,
+            sizeof(child_name),
+            "GpuProfileTimelineRows##%u_%llu",
+            _axis_index,
+            static_cast<unsigned long long>(selected_gpu_frame)
+        );
+        ImGui::BeginChild(child_name, ImVec2(0.0f, std::max(180.0f, ImGui::GetContentRegionAvail().y)), true);
+        const ImVec2 body_origin               = ImGui::GetCursorScreenPos();
+        const float  body_width                = std::max(ImGui::GetContentRegionAvail().x, 360.0f);
+        const float  body_x0                   = body_origin.x + k_track_label_width;
+        const float  body_timeline_width       = std::max(100.0f, body_width - k_track_label_width);
+        bool         event_hovered             = false;
+        bool         query_truncated           = false;
+        bool         filter_results_incomplete = false;
+        std::size_t  remaining_budget          = k_frame_event_budget;
+
+        ImGuiListClipper clipper;
+        clipper.Begin(static_cast<int>(gpu_visible_tracks.size()), k_track_row_height);
+        while (clipper.Step()) {
+            for (int row_index = clipper.DisplayStart; row_index < clipper.DisplayEnd; ++row_index) {
+                const std::uint32_t timeline_track_index =
+                    gpu_visible_tracks[static_cast<std::size_t>(row_index)];
+                const GpuTimelineTrackIndex& track        = gpu_tracks[timeline_track_index];
+                const GpuTrack&              source_track = session.GpuTracks()[track.source_track_index];
+                const GpuTimelineFrameSlice* slice =
+                    index.FindGpuFrameSlice(timeline_track_index, selected_gpu_frame);
+                const ImVec2 row_origin = ImGui::GetCursorScreenPos();
+                ImGui::Dummy(ImVec2(body_width, k_track_row_height));
+
+                ImDrawList* draw_list = ImGui::GetWindowDrawList();
+                draw_list->AddRectFilled(
+                    row_origin,
+                    ImVec2(row_origin.x + k_track_label_width, row_origin.y + k_track_row_height),
+                    IM_COL32(31, 31, 34, 255)
+                );
+                draw_list->AddRectFilled(
+                    ImVec2(body_x0, row_origin.y),
+                    ImVec2(body_x0 + body_timeline_width, row_origin.y + k_track_row_height),
+                    IM_COL32(24, 24, 27, 255)
+                );
+                draw_list->AddLine(
+                    ImVec2(row_origin.x, row_origin.y + k_track_row_height),
+                    ImVec2(row_origin.x + body_width, row_origin.y + k_track_row_height),
+                    IM_COL32(70, 70, 74, 255)
+                );
+                char track_label[160]{};
+                std::snprintf(
+                    track_label,
+                    sizeof(track_label),
+                    "%s | native %u/family %u | errors %llu",
+                    LogicalQueueText(source_track.logical_queue),
+                    source_track.native_queue_id,
+                    source_track.family_id,
+                    static_cast<unsigned long long>(slice ? slice->error_scope_count : 0)
+                );
+                draw_list->AddText(
+                    ImVec2(row_origin.x + 7.0f, row_origin.y + 4.0f),
+                    IM_COL32(220, 220, 220, 255),
+                    track_label
+                );
+
+                if (remaining_budget == 0) {
+                    query_truncated           = true;
+                    filter_results_incomplete = filter_results_incomplete || !name_filter.Empty();
+                    continue;
+                }
+                const std::size_t output_capacity =
+                    std::min<std::size_t>(remaining_budget, gpu_query_output.size());
+                const TimelineOverlapQueryResult query = index.QueryGpuTimelineOverlaps(
+                    timeline_track_index,
+                    selected_gpu_frame,
+                    viewport->view_begin,
+                    viewport->view_end,
+                    std::span<GpuTimelineScopeRef>(gpu_query_output).first(output_capacity)
+                );
+                if (!query.valid) {
+                    continue;
+                }
+                query_truncated = query_truncated || query.truncated;
+                filter_results_incomplete =
+                    filter_results_incomplete || (query.truncated && !name_filter.Empty());
+                remaining_budget -= static_cast<std::size_t>(query.written);
+
+                for (std::uint64_t result_index = 0; result_index < query.written; ++result_index) {
+                    const GpuTimelineScopeRef& timeline_scope =
+                        gpu_query_output[static_cast<std::size_t>(result_index)];
+                    const std::uint64_t source_index = timeline_scope.source_scope_index;
+                    if (source_index >= session.GpuScopes().size()) {
+                        continue;
+                    }
+                    const GpuScopeRecord&  scope = session.GpuScopes()[source_index];
+                    const std::string_view name  = session.String(scope.name);
+                    filter_results_incomplete =
+                        filter_results_incomplete ||
+                        (!name_filter.Empty() && name.size() > k_filter_name_byte_limit);
+                    if (!name_filter.Matches(name)) {
+                        continue;
+                    }
+                    const std::uint64_t begin = timeline_scope.begin_tick_offset;
+                    const std::uint64_t end   = timeline_scope.end_tick_offset;
+                    if (begin > _axis_frame.extent_ticks || end > _axis_frame.extent_ticks) {
+                        continue;
+                    }
+                    float x0 = TimeToX(*viewport, begin, body_x0, body_timeline_width);
+                    float x1 = TimeToX(*viewport, end, body_x0, body_timeline_width);
+                    if (x1 - x0 < 2.0f) {
+                        x1 = std::min(body_x0 + body_timeline_width, x0 + 2.0f);
+                    }
+                    const std::uint32_t lane = std::min(scope.depth, k_overflow_depth_lane);
+                    const float         y0   = row_origin.y + 3.0f + lane * k_lane_height;
+                    const float         y1   = y0 + k_lane_height - 2.0f;
+                    if (x1 <= body_x0 || x0 >= body_x0 + body_timeline_width) {
+                        continue;
+                    }
+
+                    const ImVec2 rect_min(std::max(x0, body_x0), y0);
+                    const ImVec2 rect_max(std::min(x1, body_x0 + body_timeline_width), y1);
+                    draw_list->AddRectFilled(rect_min, rect_max, EventColor(name), 2.0f);
+                    const bool selected = selection.kind == EProfileViewerSelectionKind::GpuScope &&
+                                          selection.published_generation == publication_generation &&
+                                          selection.axis_index == _axis_index &&
+                                          selection.frame_id == selected_gpu_frame &&
+                                          selection.source_scope_index == source_index;
+                    if (selected) {
+                        draw_list->AddRect(rect_min, rect_max, IM_COL32(255, 232, 80, 255), 2.0f, 0, 2.0f);
+                    }
+                    if (rect_max.x - rect_min.x >= 28.0f) {
+                        const std::string_view bounded = BoundedUtf8Prefix(name, k_draw_name_byte_limit);
+                        draw_list->PushClipRect(rect_min, rect_max, true);
+                        draw_list->AddText(
+                            ImVec2(rect_min.x + 3.0f, rect_min.y + 1.0f),
+                            IM_COL32(238, 238, 238, 255),
+                            bounded.data(),
+                            bounded.data() + bounded.size()
+                        );
+                        draw_list->PopClipRect();
+                    }
+                    if (ImGui::IsMouseHoveringRect(rect_min, rect_max, true)) {
+                        event_hovered = true;
+                        DrawGpuTooltip(session, scope, selected_gpu_frame, begin, end, axis.unit_period_ns);
+                        if (ImGui::IsMouseClicked(ImGuiMouseButton_Left)) {
+                            static_cast<void>(model.SelectGpu(
+                                key, timeline_track_index, source_index, begin, std::max(begin, end)
+                            ));
+                        }
+                    }
+                }
+            }
+        }
+
+        const bool body_hovered = ImGui::IsWindowHovered() && ImGui::GetIO().MousePos.x >= body_x0 &&
+                                  ImGui::GetIO().MousePos.x <= body_x0 + body_timeline_width;
+        HandleGpuNavigation(key, *viewport, body_x0, body_timeline_width, body_hovered);
+        HandleRangeSelection(
+            ERangeDomain::Gpu, key, *viewport, body_x0, body_timeline_width, body_hovered, event_hovered
+        );
+        DrawRangeOverlay(
+            *viewport,
+            range.ActiveForGpu(key),
+            body_x0,
+            body_timeline_width,
+            body_origin.y,
+            ImGui::GetWindowPos().y + ImGui::GetWindowHeight()
+        );
+        ImGui::EndChild();
+
+        if (filter_results_incomplete) {
+            ImGui::TextColored(
+                ImVec4(1.0f, 0.66f, 0.22f, 1.0f),
+                "Filter results are incomplete: the query budget was exhausted or a scope name exceeded the "
+                "1024-byte filter scan limit."
+            );
+        } else if (query_truncated || remaining_budget == 0) {
+            ImGui::TextColored(
+                ImVec4(1.0f, 0.66f, 0.22f, 1.0f),
+                "Visible GPU scopes truncated (4096 per track / 16384 per frame budget)."
+            );
+        }
+    }
+
+    void DrawGpu(const ProfileDocument& _document) {
+        const ProfileSession&       session = _document.session;
+        const ProfileTimelineIndex& index   = _document.timeline_index;
+        const auto                  frames  = index.GpuFrames();
+        if (frames.empty()) {
+            ImGui::TextDisabled("No GPU frames.");
+            return;
+        }
+
+        DrawGpuFrameChooser(frames, session, index);
+        ImGui::TextDisabled(
+            "Each tab is one physical timestamp domain in one frame; tabs never share a ruler."
+        );
+
+        bool axis_available = false;
+        if (ImGui::BeginTabBar("GpuPhysicalAxisTabs")) {
+            const std::size_t axis_count = std::min(index.Axes().size(), k_axis_scan_budget + std::size_t{1});
+            for (std::uint32_t axis_index = 1; axis_index < axis_count; ++axis_index) {
+                const GpuTimelineAxisFrame* axis_frame =
+                    index.FindGpuAxisFrame(axis_index, selected_gpu_frame);
+                if (axis_frame == nullptr) {
+                    continue;
+                }
+                axis_available           = true;
+                const TimelineAxis& axis = index.Axes()[axis_index];
+                char                label[128]{};
+                std::snprintf(
+                    label,
+                    sizeof(label),
+                    "Physical %u / family %u##Axis%u",
+                    axis.native_queue_id,
+                    axis.family_id,
+                    axis_index
+                );
+                if (ImGui::BeginTabItem(label)) {
+                    DrawGpuAxis(_document, axis_index, *axis_frame);
+                    ImGui::EndTabItem();
+                }
+            }
+            ImGui::EndTabBar();
+        }
+        if (index.Axes().size() > k_axis_scan_budget + std::size_t{1}) {
+            ImGui::TextColored(
+                ImVec4(1.0f, 0.66f, 0.22f, 1.0f),
+                "GPU physical-axis discovery truncated to the fixed 256-axis viewer budget."
+            );
+        }
+        if (!axis_available) {
+            ImGui::TextColored(
+                ImVec4(1.0f, 0.58f, 0.30f, 1.0f), "Selected frame has no physical GPU timestamp domain."
+            );
+        }
+    }
+
+    void ShowWindow(bool* _open) {
+        // Exactly one coherent loader snapshot is taken for this UI frame.
+        // Keep its shared document owner alive until this function returns.
+        std::optional<ProfileDocumentLoaderSnapshot> snapshot_storage;
+        try {
+            snapshot_storage.emplace(loader.Snapshot());
+        } catch (...) {
+            const bool visible = ImGui::Begin("Profile Viewer", _open);
+            if (visible) {
+                ImGui::TextColored(
+                    ImVec4(1.0f, 0.35f, 0.30f, 1.0f),
+                    "Profile snapshot unavailable this frame; the last-good viewer state was preserved."
+                );
+            }
+            ImGui::End();
+            return;
+        }
+
+        const ProfileDocumentLoaderSnapshot&  snapshot = *snapshot_storage;
+        const EProfileViewerPublicationUpdate update   = model.ObserveSnapshot(snapshot);
+
+        // Only a coherent snapshot can replace the UI-owned last-good
+        // publication. Invalid snapshot payloads remain diagnostic-only.
+        if (update != EProfileViewerPublicationUpdate::Invalid) {
+            if (snapshot.document) {
+                displayed_document = snapshot.document;
+                if (update == EProfileViewerPublicationUpdate::Changed) {
+                    ResetForPublication(*displayed_document);
+                }
+            } else if (update == EProfileViewerPublicationUpdate::Changed) {
+                ClearPublication();
+            }
+        }
+        const std::shared_ptr<const ProfileDocument> document = displayed_document;
+
+        if (!ImGui::Begin("Profile Viewer", _open)) {
+            ImGui::End();
+            return;
+        }
+
+        DrawLoadStatus(snapshot);
+        ImGui::Separator();
+        if (update == EProfileViewerPublicationUpdate::Invalid) {
+            ImGui::TextColored(
+                ImVec4(1.0f, 0.35f, 0.30f, 1.0f), "Loader snapshot/document identity is invalid."
+            );
+        }
+        if (!document || !document->Valid() || !document->timeline_index.Matches(document->session)) {
+            ImGui::TextDisabled("Open a valid .mpd capture to inspect its timeline.");
+            ImGui::End();
+            return;
+        }
+
+        DrawDocumentHeader(*document);
+        DrawSelectionDetails(*document);
+        ImGui::Separator();
+
+        if (ImGui::BeginTabBar("ProfileViewerDomainTabs")) {
+            if (ImGui::BeginTabItem("CPU")) {
+                DrawCpu(*document);
+                ImGui::EndTabItem();
+            }
+            if (ImGui::BeginTabItem("GPU")) {
+                DrawGpu(*document);
+                ImGui::EndTabItem();
+            }
+            ImGui::EndTabBar();
+        }
+        ImGui::End();
+    }
+};
+
+ProfileViewerUI::ProfileViewerUI(ProfileDocumentLoader& _loader) : impl_(std::make_unique<Impl>(_loader)) {}
+
+ProfileViewerUI::~ProfileViewerUI() = default;
+
+void ProfileViewerUI::ShowWindow(bool* _open) {
+    impl_->ShowWindow(_open);
+}
+
+} // namespace Moer

--- a/source/editor/profile_viewer_ui/ProfileViewerUI.cpp
+++ b/source/editor/profile_viewer_ui/ProfileViewerUI.cpp
@@ -17,6 +17,7 @@
 #include <span>
 #include <string>
 #include <string_view>
+#include <utility>
 #include <vector>
 
 #include <imgui.h>
@@ -33,7 +34,7 @@ constexpr std::size_t   k_filter_capacity        = 128;
 constexpr std::size_t   k_filter_name_byte_limit = 1024;
 constexpr std::size_t   k_draw_name_byte_limit   = 256;
 constexpr std::size_t   k_track_scan_budget      = 4096;
-constexpr std::size_t   k_axis_scan_budget       = 256;
+constexpr std::size_t   k_axis_scan_budget       = kProfileViewerGpuRenderableAxisMax;
 constexpr float         k_track_label_width      = 248.0f;
 constexpr float         k_lane_height            = 18.0f;
 constexpr std::uint32_t k_direct_depth_lanes     = 3;
@@ -516,8 +517,17 @@ struct ProfileViewerUI::Impl {
     ProfileDocumentLoader& loader;
     ProfileViewerModel     model{};
 
+    struct PublicationResetState {
+        std::vector<std::uint8_t>  cpu_track_visibility{};
+        std::vector<std::uint8_t>  gpu_track_visibility{};
+        std::vector<std::uint32_t> cpu_visible_tracks{};
+        std::vector<std::uint32_t> gpu_visible_tracks{};
+        std::uint64_t              selected_gpu_frame{0};
+    };
+
     std::shared_ptr<const ProfileDocument> displayed_document{};
     std::uint64_t                          publication_generation{kInvalidProfileDocumentGeneration};
+    std::uint64_t                          failed_publication_generation{kInvalidProfileDocumentGeneration};
     std::vector<std::uint8_t>              cpu_track_visibility{};
     std::vector<std::uint8_t>              gpu_track_visibility{};
     std::vector<std::uint32_t>             cpu_visible_tracks{};
@@ -530,24 +540,38 @@ struct ProfileViewerUI::Impl {
     std::uint64_t                                     selected_gpu_frame{0};
     std::string                                       dialog_status{};
 
-    void ResetForPublication(const ProfileDocument& _document) {
-        publication_generation = _document.request_generation;
-        cpu_track_visibility.assign(
+    [[nodiscard]] PublicationResetState PreparePublication(const ProfileDocument& _document) const {
+        PublicationResetState prepared;
+        prepared.cpu_track_visibility.assign(
             std::min(_document.timeline_index.CpuTracks().size(), k_track_scan_budget), 1
         );
-        gpu_track_visibility.assign(
+        prepared.gpu_track_visibility.assign(
             std::min(_document.timeline_index.GpuTracks().size(), k_track_scan_budget), 1
         );
-        cpu_visible_tracks.clear();
-        cpu_visible_tracks.reserve(cpu_track_visibility.size());
-        gpu_visible_tracks.clear();
-        gpu_visible_tracks.reserve(gpu_track_visibility.size());
+        prepared.cpu_visible_tracks.reserve(prepared.cpu_track_visibility.size());
+        prepared.gpu_visible_tracks.reserve(prepared.gpu_track_visibility.size());
+
+        const auto first_gpu_frame = FindProfileViewerGpuFrameAtOrAfter(
+            _document.timeline_index.GpuFrames(), _document.timeline_index.GpuAxisFrames(), 0
+        );
+        prepared.selected_gpu_frame = first_gpu_frame ? first_gpu_frame->frame_id : 0;
+        return prepared;
+    }
+
+    void CommitPublication(
+        const std::shared_ptr<const ProfileDocument>& _document,
+        PublicationResetState&&                       _prepared
+    ) noexcept {
+        displayed_document     = _document;
+        publication_generation = _document->request_generation;
+        cpu_track_visibility   = std::move(_prepared.cpu_track_visibility);
+        gpu_track_visibility   = std::move(_prepared.gpu_track_visibility);
+        cpu_visible_tracks     = std::move(_prepared.cpu_visible_tracks);
+        gpu_visible_tracks     = std::move(_prepared.gpu_visible_tracks);
+        selected_gpu_frame     = _prepared.selected_gpu_frame;
         filter.fill('\0');
         name_filter.Compile({});
         range.Clear();
-
-        const auto gpu_frames = _document.timeline_index.GpuFrames();
-        selected_gpu_frame    = gpu_frames.empty() ? 0 : gpu_frames.front().frame_id;
     }
 
     void ClearPublication() {
@@ -561,6 +585,16 @@ struct ProfileViewerUI::Impl {
         name_filter.Compile({});
         range.Clear();
         selected_gpu_frame = 0;
+    }
+
+    void ReportPublicationPreparationFailure(const char* _detail) noexcept {
+        try {
+            LOG_ERROR(
+                "[ProfileViewerUI] Publication preparation failed; preserving last-good state: {}",
+                _detail != nullptr && _detail[0] != '\0' ? _detail : "unknown error"
+            );
+        } catch (...) {
+        }
     }
 
     void ReportLoadRequestFailure(const char* _detail) noexcept {
@@ -1239,49 +1273,36 @@ struct ProfileViewerUI::Impl {
         }
     }
 
-    [[nodiscard]] std::size_t FindGpuFramePosition(
-        std::span<const GpuTimelineFrameRef> _frames,
-        std::uint64_t                        _frame_id
-    ) const noexcept {
-        const auto found = std::lower_bound(
-            _frames.begin(),
-            _frames.end(),
-            _frame_id,
-            [](const GpuTimelineFrameRef& _frame, std::uint64_t _value) {
-                return _frame.frame_id < _value;
-            }
-        );
-        if (found == _frames.end()) {
-            return _frames.empty() ? 0 : _frames.size() - 1;
+    void DrawGpuFrameChooser(const ProfileSession& _session, const ProfileTimelineIndex& _index) {
+        const auto recorded_frames = _index.GpuFrames();
+        const auto axis_frames     = _index.GpuAxisFrames();
+        auto current = FindProfileViewerGpuFrameAtOrAfter(recorded_frames, axis_frames, selected_gpu_frame);
+        if (!current) {
+            current = FindProfileViewerGpuFrameAtOrBefore(
+                recorded_frames, axis_frames, std::numeric_limits<std::uint64_t>::max()
+            );
         }
-        return static_cast<std::size_t>(found - _frames.begin());
-    }
-
-    void DrawGpuFrameChooser(
-        std::span<const GpuTimelineFrameRef> _frames,
-        const ProfileSession&                _session,
-        const ProfileTimelineIndex&          _index
-    ) {
-        if (_frames.empty()) {
+        if (!current) {
             return;
         }
-        std::size_t position = FindGpuFramePosition(_frames, selected_gpu_frame);
-        if (_frames[position].frame_id != selected_gpu_frame) {
-            selected_gpu_frame = _frames[position].frame_id;
+        if (current->frame_id != selected_gpu_frame) {
+            selected_gpu_frame = current->frame_id;
         }
 
         if (ImGui::Button("<##GpuFrame")) {
-            if (position > 0) {
-                --position;
-                selected_gpu_frame = _frames[position].frame_id;
+            const auto previous =
+                FindProfileViewerGpuFrameBefore(recorded_frames, axis_frames, selected_gpu_frame);
+            if (previous) {
+                selected_gpu_frame = previous->frame_id;
                 range.Clear();
             }
         }
         ImGui::SameLine();
         if (ImGui::Button(">##GpuFrame")) {
-            if (position + 1 < _frames.size()) {
-                ++position;
-                selected_gpu_frame = _frames[position].frame_id;
+            const auto next =
+                FindProfileViewerGpuFrameAfter(recorded_frames, axis_frames, selected_gpu_frame);
+            if (next) {
+                selected_gpu_frame = next->frame_id;
                 range.Clear();
             }
         }
@@ -1297,9 +1318,17 @@ struct ProfileViewerUI::Impl {
                 "%llu",
                 ImGuiInputTextFlags_EnterReturnsTrue
             )) {
-            position           = FindGpuFramePosition(_frames, requested_frame);
-            selected_gpu_frame = _frames[position].frame_id;
-            range.Clear();
+            auto requested =
+                FindProfileViewerGpuFrameAtOrAfter(recorded_frames, axis_frames, requested_frame);
+            if (!requested) {
+                requested = FindProfileViewerGpuFrameAtOrBefore(
+                    recorded_frames, axis_frames, std::numeric_limits<std::uint64_t>::max()
+                );
+            }
+            if (requested) {
+                selected_gpu_frame = requested->frame_id;
+                range.Clear();
+            }
         }
 
         const GpuTimelineFrameRef* frame_ref = _index.FindGpuFrame(selected_gpu_frame);
@@ -1318,6 +1347,12 @@ struct ProfileViewerUI::Impl {
                     ImVec4(1.0f, 0.66f, 0.22f, 1.0f), "Frame timing is incomplete or topology-untrusted."
                 );
             }
+        } else {
+            ImGui::SameLine();
+            ImGui::TextColored(
+                ImVec4(1.0f, 0.58f, 0.30f, 1.0f),
+                "Orphaned timeline | no GpuFrame record; metadata comes from indexed scopes only"
+            );
         }
     }
 
@@ -1626,13 +1661,12 @@ struct ProfileViewerUI::Impl {
     void DrawGpu(const ProfileDocument& _document) {
         const ProfileSession&       session = _document.session;
         const ProfileTimelineIndex& index   = _document.timeline_index;
-        const auto                  frames  = index.GpuFrames();
-        if (frames.empty()) {
-            ImGui::TextDisabled("No GPU frames.");
+        if (!FindProfileViewerGpuFrameAtOrAfter(index.GpuFrames(), index.GpuAxisFrames(), 0)) {
+            ImGui::TextDisabled("No GPU frames or indexed GPU timeline data.");
             return;
         }
 
-        DrawGpuFrameChooser(frames, session, index);
+        DrawGpuFrameChooser(session, index);
         ImGui::TextDisabled(
             "Each tab is one physical timestamp domain in one frame; tabs never share a ruler."
         );
@@ -1696,18 +1730,38 @@ struct ProfileViewerUI::Impl {
         }
 
         const ProfileDocumentLoaderSnapshot&  snapshot = *snapshot_storage;
-        const EProfileViewerPublicationUpdate update   = model.ObserveSnapshot(snapshot);
+        const EProfileViewerPublicationUpdate update   = model.InspectSnapshot(snapshot);
+        bool publication_prepare_failed                = update == EProfileViewerPublicationUpdate::Changed &&
+                                          snapshot.document &&
+                                          failed_publication_generation == snapshot.published_generation;
 
-        // Only a coherent snapshot can replace the UI-owned last-good
-        // publication. Invalid snapshot payloads remain diagnostic-only.
-        if (update != EProfileViewerPublicationUpdate::Invalid) {
+        // Publication is two-phase: all allocating UI state is prepared while
+        // the model and displayed document still describe the last-good
+        // generation. Only no-throw moves and model reset happen at commit.
+        if (update == EProfileViewerPublicationUpdate::Changed && !publication_prepare_failed) {
             if (snapshot.document) {
-                displayed_document = snapshot.document;
-                if (update == EProfileViewerPublicationUpdate::Changed) {
-                    ResetForPublication(*displayed_document);
+                try {
+                    PublicationResetState prepared = PreparePublication(*snapshot.document);
+                    if (model.ObserveSnapshot(snapshot) == EProfileViewerPublicationUpdate::Changed) {
+                        CommitPublication(snapshot.document, std::move(prepared));
+                        failed_publication_generation = kInvalidProfileDocumentGeneration;
+                    } else {
+                        failed_publication_generation = snapshot.published_generation;
+                        publication_prepare_failed    = true;
+                        ReportPublicationPreparationFailure("snapshot changed before commit");
+                    }
+                } catch (const std::exception& error) {
+                    failed_publication_generation = snapshot.published_generation;
+                    publication_prepare_failed    = true;
+                    ReportPublicationPreparationFailure(error.what());
+                } catch (...) {
+                    failed_publication_generation = snapshot.published_generation;
+                    publication_prepare_failed    = true;
+                    ReportPublicationPreparationFailure("unexpected allocation failure");
                 }
-            } else if (update == EProfileViewerPublicationUpdate::Changed) {
+            } else if (model.ObserveSnapshot(snapshot) == EProfileViewerPublicationUpdate::Changed) {
                 ClearPublication();
+                failed_publication_generation = kInvalidProfileDocumentGeneration;
             }
         }
         const std::shared_ptr<const ProfileDocument> document = displayed_document;
@@ -1723,6 +1777,16 @@ struct ProfileViewerUI::Impl {
             ImGui::TextColored(
                 ImVec4(1.0f, 0.35f, 0.30f, 1.0f), "Loader snapshot/document identity is invalid."
             );
+        }
+        if (publication_prepare_failed) {
+            ImGui::TextColored(
+                ImVec4(1.0f, 0.35f, 0.30f, 1.0f),
+                "New profile publication could not be prepared; the last-good viewer state was preserved."
+            );
+            ImGui::SameLine();
+            if (ImGui::Button("Retry publication preparation")) {
+                failed_publication_generation = kInvalidProfileDocumentGeneration;
+            }
         }
         if (!document || !document->Valid() || !document->timeline_index.Matches(document->session)) {
             ImGui::TextDisabled("Open a valid .mpd capture to inspect its timeline.");

--- a/source/editor/profile_viewer_ui/ProfileViewerUI.h
+++ b/source/editor/profile_viewer_ui/ProfileViewerUI.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <memory>
+
+namespace Moer::ProfileDump {
+class ProfileDocumentLoader;
+}
+
+namespace Moer {
+
+// Editor-embedded, offline viewer for immutable ProfileDump documents. The
+// implementation is hidden so ProfileConsumer does not leak through public
+// Editor headers.
+class ProfileViewerUI final {
+public:
+    explicit ProfileViewerUI(ProfileDump::ProfileDocumentLoader& _loader);
+    ~ProfileViewerUI();
+
+    ProfileViewerUI(const ProfileViewerUI&)            = delete;
+    ProfileViewerUI& operator=(const ProfileViewerUI&) = delete;
+    ProfileViewerUI(ProfileViewerUI&&)                 = delete;
+    ProfileViewerUI& operator=(ProfileViewerUI&&)      = delete;
+
+    void ShowWindow(bool* _open);
+
+private:
+    struct Impl;
+    std::unique_ptr<Impl> impl_{};
+};
+
+} // namespace Moer

--- a/source/runtime/Engine.cpp
+++ b/source/runtime/Engine.cpp
@@ -28,7 +28,6 @@
 #include <filesystem>
 #include <iterator>
 #include <mutex>
-#include <nfd.hpp>
 #include <optional>
 #include <stdexcept>
 #include <string>
@@ -40,8 +39,6 @@
 using namespace Moer::Render;
 
 namespace Moer {
-
-static UniquePtr<NFD::Guard> nfd_guard = nullptr;
 
 static bool ContainsNonAscii(const std::filesystem::path& p);
 
@@ -2059,14 +2056,6 @@ void Engine::ShutDown() noexcept {
         }
     }
     m_editor_config.reset();
-}
-
-void Engine::Init3rdParty() {
-    nfd_guard = MakeUnique<NFD::Guard>();
-}
-
-void Engine::ShutDown3rdParty() {
-    nfd_guard.release();
 }
 
 // 检测路径中是否包含非ASCII字符（包括中文）

--- a/source/runtime/Engine.h
+++ b/source/runtime/Engine.h
@@ -87,8 +87,6 @@ private:
         Failed,
     };
 
-    void Init3rdParty();
-    void ShutDown3rdParty();
     void InitializeProfileDump() noexcept;
     void InitializeProfileCaptureLifecycleValidation() noexcept;
     void TickProfileCaptureLifecycleValidation(

--- a/source/runtime/render/CMakeLists.txt
+++ b/source/runtime/render/CMakeLists.txt
@@ -82,7 +82,6 @@ target_link_libraries(${target_name}
     PUBLIC dxguid
     PUBLIC D3D12MemoryAllocator
     PUBLIC winpixeventruntime
-    PUBLIC nfd
     PUBLIC AssetLoad
 )
 

--- a/source/test/CMakeLists.txt
+++ b/source/test/CMakeLists.txt
@@ -69,6 +69,28 @@ add_test(
 )
 set_tests_properties(ProfileDocumentLoaderContract PROPERTIES TIMEOUT 120)
 
+set(test_target TestProfileViewerModel)
+add_executable(
+    ${test_target}
+    "ProfileViewerModelTest.cpp"
+    "${moer_source_dir}/editor/profile_viewer_ui/ProfileViewerModel.cpp"
+)
+target_include_directories(
+    ${test_target}
+    PRIVATE "${moer_source_dir}/editor"
+)
+target_link_libraries(${test_target}
+    PRIVATE
+        Moer::ProfileConsumer
+        Moer::Core
+)
+set_target_properties(${test_target} PROPERTIES FOLDER ${moer_test_folder})
+add_test(
+    NAME ProfileViewerModelContract
+    COMMAND $<TARGET_FILE:${test_target}>
+)
+set_tests_properties(ProfileViewerModelContract PROPERTIES TIMEOUT 60)
+
 set(test_target TestProfileScopeProducer)
 add_executable(${test_target} "ProfileScopeProducerTest.cpp")
 target_include_directories(${test_target}

--- a/source/test/ProfileTimelineIndexTest.cpp
+++ b/source/test/ProfileTimelineIndexTest.cpp
@@ -360,6 +360,55 @@ void WriteEmptyCapture(const std::filesystem::path& _path) {
     Expect(Shutdown() == ShutdownResult::Completed, "empty fixture capture did not close cleanly");
 }
 
+void WriteOrphanGpuScopeCapture(const std::filesystem::path& _path) {
+    static_cast<void>(Shutdown());
+    RuntimeConfig config;
+    config.output_path      = _path;
+    config.replace_existing = true;
+    Expect(Start(config) == StartResult::Started, "orphan GPU fixture capture did not start");
+
+    const SchemaRegistration gpu_frame = RegisterSchema(Templates::GpuFrame());
+    const SchemaRegistration gpu_scope = RegisterSchema(Templates::GpuScope());
+    Expect(
+        gpu_frame.status == SchemaStatus::Registered && gpu_scope.status == SchemaStatus::Registered,
+        "orphan GPU fixture schemas did not register"
+    );
+
+    // Reserve the missing GpuFrame's producer sequence without writing a
+    // record. Forensic loading can then prove that the orphan scope has a
+    // compatible earlier record-sequence slot.
+    const std::array<FieldValueView, 1> rejected_frame_values{
+        std::uint64_t{42},
+    };
+    Expect(
+        Emit(gpu_frame.handle, rejected_frame_values) == EmitStatus::ValueCountMismatch,
+        "orphan GPU fixture did not reserve its missing frame sequence"
+    );
+    EmitGpuScope(
+        gpu_scope.handle,
+        42,
+        1,
+        0,
+        0,
+        0,
+        ProfileLogicalQueue::Graphics,
+        11,
+        3,
+        "orphan-root",
+        ProfileGpuScopeStatus::Ready,
+        100,
+        150,
+        64,
+        1.0,
+        50.0,
+        50.0,
+        0,
+        ""
+    );
+
+    Expect(Shutdown() == ShutdownResult::Completed, "orphan GPU fixture capture did not close cleanly");
+}
+
 struct LoadedTimeline {
     SessionLoadResult result{};
     ProfileSession    session{};
@@ -431,10 +480,14 @@ LoadedTimeline LoadForensicPrefix(const std::filesystem::path& _path) {
     LoadedTimeline loaded;
     loaded.result  = reader.Finish();
     loaded.session = reader.TakeSession();
-    Expect(
-        loaded.result.status == SessionLoadStatus::ForensicTruncated && loaded.session.Valid(),
-        "missing SessionEnd was not exposed as a forensic session"
-    );
+    if (loaded.result.status != SessionLoadStatus::ForensicTruncated || !loaded.session.Valid()) {
+        throw std::runtime_error(
+            "missing SessionEnd was not exposed as a forensic session (status=" +
+            std::to_string(static_cast<unsigned>(loaded.result.status)) +
+            ", error=" + std::to_string(static_cast<unsigned>(loaded.result.error_code)) +
+            ", diagnostic=" + std::string(reader.DiagnosticMessage()) + ")"
+        );
+    }
     return loaded;
 }
 
@@ -1320,6 +1373,48 @@ void VerifyEmptySession(const LoadedTimeline& _empty) {
     );
 }
 
+void VerifyOrphanGpuTimeline(const LoadedTimeline& _forensic) {
+    Expect(
+        _forensic.result.status == SessionLoadStatus::ForensicTruncated &&
+            _forensic.session.GpuFrames().empty() && _forensic.session.GpuScopes().size() == 1,
+        "orphan GPU fixture did not retain only its forensic scope"
+    );
+
+    ProfileTimelineIndex index;
+    Expect(
+        BuildProfileTimelineIndex(_forensic.session, _forensic.result, {}, index).Succeeded(),
+        "orphan GPU timeline index did not build"
+    );
+    Expect(
+        index.GpuFrames().empty() && index.GpuTracks().size() == 1 && index.GpuFrameSlices().size() == 1 &&
+            index.GpuAxisFrames().size() == 1 && index.GpuTimelineScopes().size() == 1,
+        "orphan GPU scope did not materialize without inventing a frame record"
+    );
+
+    const GpuTimelineAxisFrame& axis_frame = index.GpuAxisFrames().front();
+    Expect(
+        axis_frame.frame_id == 42 && axis_frame.source_frame_index == kInvalidSessionIndex &&
+            !axis_frame.has_frame_record && axis_frame.timing_available && axis_frame.origin_tick == 100 &&
+            axis_frame.extent_ticks == 50,
+        "orphan GPU axis-frame metadata is inconsistent"
+    );
+    const GpuTimelineFrameSlice& slice = index.GpuFrameSlices().front();
+    Expect(
+        slice.frame_id == 42 && slice.source_frame_index == kInvalidSessionIndex && !slice.has_frame_record &&
+            slice.axis_frame_index == 0 && slice.timeline_scope_count == 1,
+        "orphan GPU frame slice is inconsistent"
+    );
+
+    std::array<GpuTimelineScopeRef, 1> output{};
+    const TimelineOverlapQueryResult   query =
+        index.QueryGpuTimelineOverlaps(0, 42, 0, axis_frame.extent_ticks, output);
+    Expect(
+        query.valid && !query.truncated && query.written == 1 && output.front().source_scope_index == 0 &&
+            output.front().begin_tick_offset == 0 && output.front().end_tick_offset == 50,
+        "typed GPU query could not reach an orphan frame timeline"
+    );
+}
+
 } // namespace
 
 int main(int _argc, char** _argv) {
@@ -1355,6 +1450,10 @@ int main(int _argc, char** _argv) {
         VerifyGpuDomainsAndSlices(index, complete.session);
         VerifyPublicRangeIntegrity(index, complete.session);
         VerifyQualityAndAtomicLimits(complete, forensic);
+
+        ScopedTimelineCapture orphan_capture;
+        WriteOrphanGpuScopeCapture(orphan_capture.Path());
+        VerifyOrphanGpuTimeline(LoadForensicPrefix(orphan_capture.Path()));
 
         ScopedTimelineCapture empty_capture;
         WriteEmptyCapture(empty_capture.Path());

--- a/source/test/ProfileTimelineIndexTest.cpp
+++ b/source/test/ProfileTimelineIndexTest.cpp
@@ -491,11 +491,28 @@ void VerifyCpuQueries(const ProfileTimelineIndex& _index, const ProfileSession& 
         query.valid && !query.truncated && query.written == exact_results.size(),
         "exact-fit CPU query was reported as truncated"
     );
+    std::array<CpuTimelineScopeRef, 2> exact_timeline_results{};
+    query = _index.QueryCpuTimelineOverlaps(thread, 700, 800, exact_timeline_results);
+    Expect(
+        query.valid && !query.truncated && query.written == exact_timeline_results.size() &&
+            exact_timeline_results[0] == _index.CpuScopes()[track.first_scope] &&
+            exact_timeline_results[1] == _index.CpuScopes()[track.first_scope + 1] &&
+            exact_timeline_results[0].source_scope_index == exact_results[0] &&
+            exact_timeline_results[1].source_scope_index == exact_results[1],
+        "typed CPU query did not preserve normalized timing or source identity"
+    );
 
     query = _index.QueryCpuOverlaps(thread, 500, 501, results);
     Expect(
         query.valid && !query.truncated && query.written == 3,
         "zero-duration CPU scope was omitted at its visible point"
+    );
+    std::array<CpuTimelineScopeRef, 4> point_timeline_results{};
+    query = _index.QueryCpuTimelineOverlaps(thread, 500, 501, point_timeline_results);
+    Expect(
+        query.valid && !query.truncated && query.written == 3 && point_timeline_results[2].begin_ns == 500 &&
+            point_timeline_results[2].end_ns == 500,
+        "typed CPU query lost a zero-duration scope or its normalized point"
     );
 
     query = _index.QueryCpuOverlaps(thread, 500, 501, std::span<std::uint64_t>(results).first(1));
@@ -507,6 +524,18 @@ void VerifyCpuQueries(const ProfileTimelineIndex& _index, const ProfileSession& 
     Expect(
         query.valid && query.truncated && query.written == 0,
         "CPU query with an empty output span did not report truncation"
+    );
+    query = _index.QueryCpuTimelineOverlaps(
+        thread, 500, 501, std::span<CpuTimelineScopeRef>(point_timeline_results).first(1)
+    );
+    Expect(
+        query.valid && query.truncated && query.written == 1,
+        "typed CPU query did not honor its caller-provided output bound"
+    );
+    query = _index.QueryCpuTimelineOverlaps(thread, 500, 501, {});
+    Expect(
+        query.valid && query.truncated && query.written == 0,
+        "typed CPU query with an empty output span did not report truncation"
     );
 
     query = _index.QueryCpuOverlaps(thread, 1000, 1001, results);
@@ -521,6 +550,15 @@ void VerifyCpuQueries(const ProfileTimelineIndex& _index, const ProfileSession& 
     Expect(
         !_index.QueryCpuOverlaps(static_cast<std::uint32_t>(_index.CpuTracks().size()), 0, 1, results).valid,
         "invalid CPU track query was reported as valid"
+    );
+    Expect(
+        !_index.QueryCpuTimelineOverlaps(thread, 500, 500, point_timeline_results).valid &&
+            !_index
+                 .QueryCpuTimelineOverlaps(
+                     static_cast<std::uint32_t>(_index.CpuTracks().size()), 0, 1, point_timeline_results
+                 )
+                 .valid,
+        "typed CPU query accepted an empty range or invalid track"
     );
 
     const auto expect_oracle = [&](std::uint64_t _begin, std::uint64_t _end) {
@@ -684,6 +722,18 @@ void VerifyGpuDomainsAndSlices(const ProfileTimelineIndex& _index, const Profile
         query.valid && !query.truncated && query.written == exact_gpu_results.size(),
         "exact-fit GPU query was reported as truncated"
     );
+    std::array<GpuTimelineScopeRef, 2> exact_gpu_timeline_results{};
+    query = _index.QueryGpuTimelineOverlaps(graphics, 100, 20, 30, exact_gpu_timeline_results);
+    Expect(
+        query.valid && !query.truncated && query.written == exact_gpu_timeline_results.size() &&
+            exact_gpu_timeline_results[0].source_scope_index == exact_gpu_results[0] &&
+            exact_gpu_timeline_results[1].source_scope_index == exact_gpu_results[1] &&
+            exact_gpu_timeline_results[0].begin_tick_offset == 0 &&
+            exact_gpu_timeline_results[0].end_tick_offset == 100 &&
+            exact_gpu_timeline_results[1].begin_tick_offset == 10 &&
+            exact_gpu_timeline_results[1].end_tick_offset == 40,
+        "typed GPU query did not preserve normalized frame-local timing or source identity"
+    );
     query = _index.QueryGpuOverlaps(compute, 100, 210, 220, query_results);
     Expect(
         query.valid && !query.truncated && query.written == 1 &&
@@ -695,15 +745,34 @@ void VerifyGpuDomainsAndSlices(const ProfileTimelineIndex& _index, const Profile
         query.valid && !query.truncated && query.written == 1,
         "wrapped GPU scope was not queryable on its normalized range"
     );
+    std::array<GpuTimelineScopeRef, 1> wrapped_timeline_result{};
+    query = _index.QueryGpuTimelineOverlaps(wrapped, 100, 0, 32, wrapped_timeline_result);
+    Expect(
+        query.valid && !query.truncated && query.written == 1 &&
+            wrapped_timeline_result[0].source_scope_index == query_results[0] &&
+            wrapped_timeline_result[0].begin_tick_offset == 0 &&
+            wrapped_timeline_result[0].end_tick_offset == 32,
+        "typed GPU query did not preserve timestamp-wrap normalization"
+    );
     query = _index.QueryGpuOverlaps(graphics, 100, 20, 30, std::span<std::uint64_t>(query_results).first(1));
     Expect(
         query.valid && query.truncated && query.written == 1,
         "GPU query did not honor its caller-provided output bound"
     );
+    query = _index.QueryGpuTimelineOverlaps(graphics, 100, 20, 30, wrapped_timeline_result);
+    Expect(
+        query.valid && query.truncated && query.written == 1,
+        "typed GPU query did not honor its caller-provided output bound"
+    );
     Expect(
         !_index.QueryGpuOverlaps(failed, 101, 0, 1, query_results).valid &&
             !_index.QueryGpuOverlaps(graphics, 999, 0, 1, query_results).valid,
         "GPU timing query accepted an error-only or missing frame"
+    );
+    Expect(
+        !_index.QueryGpuTimelineOverlaps(failed, 101, 0, 1, wrapped_timeline_result).valid &&
+            !_index.QueryGpuTimelineOverlaps(graphics, 999, 0, 1, wrapped_timeline_result).valid,
+        "typed GPU timing query accepted an error-only or missing frame"
     );
 
     const TimelineAxis& failed_axis = _index.Axes()[_index.GpuTracks()[failed].axis_index];

--- a/source/test/ProfileViewerModelTest.cpp
+++ b/source/test/ProfileViewerModelTest.cpp
@@ -62,6 +62,185 @@ void TestOverflowSafeFractionMapping() {
     Expect(ProfileViewerMapFraction(99, 11, 1, 2) == 99, "reversed interval did not map to begin");
 }
 
+void ExpectGpuFrameChoice(
+    std::optional<ProfileViewerGpuFrameChoice> _choice,
+    std::uint64_t                              _frame_id,
+    bool                                       _has_frame_record,
+    std::string_view                           _message
+) {
+    Expect(
+        _choice && _choice->frame_id == _frame_id && _choice->has_frame_record == _has_frame_record, _message
+    );
+}
+
+void TestGpuFrameChoiceUnionNavigation() {
+    const std::array<GpuTimelineFrameRef, 2>  recorded_frames{{
+        {
+             .frame_id           = 10,
+             .source_frame_index = 0,
+        },
+        {
+             .frame_id           = 30,
+             .source_frame_index = 1,
+        },
+    }};
+    const std::array<GpuTimelineAxisFrame, 4> axis_frames{{
+        {
+            .frame_id         = 20,
+            .axis_index       = 1,
+            .has_frame_record = false,
+        },
+        {
+            .frame_id         = 30,
+            .axis_index       = 1,
+            .has_frame_record = true,
+        },
+        {
+            .frame_id         = 5,
+            .axis_index       = 2,
+            .has_frame_record = false,
+        },
+        {
+            .frame_id         = 20,
+            .axis_index       = 2,
+            .has_frame_record = false,
+        },
+    }};
+
+    ExpectGpuFrameChoice(
+        FindProfileViewerGpuFrameAtOrAfter(recorded_frames, axis_frames, 0),
+        5,
+        false,
+        "GPU frame union did not expose its orphan first frame"
+    );
+    ExpectGpuFrameChoice(
+        FindProfileViewerGpuFrameAtOrAfter(recorded_frames, axis_frames, 6),
+        10,
+        true,
+        "GPU frame union did not advance to a source-only frame"
+    );
+    ExpectGpuFrameChoice(
+        FindProfileViewerGpuFrameAtOrAfter(recorded_frames, axis_frames, 20),
+        20,
+        false,
+        "GPU frame union did not collapse a duplicate orphan frame across axes"
+    );
+    ExpectGpuFrameChoice(
+        FindProfileViewerGpuFrameAtOrAfter(recorded_frames, axis_frames, 30),
+        30,
+        true,
+        "GPU frame union did not retain source-record identity"
+    );
+    Expect(
+        !FindProfileViewerGpuFrameAtOrAfter(recorded_frames, axis_frames, 31),
+        "GPU frame at-or-after search advanced beyond the union"
+    );
+
+    ExpectGpuFrameChoice(
+        FindProfileViewerGpuFrameAfter(recorded_frames, axis_frames, 20),
+        30,
+        true,
+        "GPU next-frame navigation did not cross source/axis sets"
+    );
+    Expect(
+        !FindProfileViewerGpuFrameAfter(recorded_frames, axis_frames, 30),
+        "GPU next-frame navigation advanced past the final frame"
+    );
+    ExpectGpuFrameChoice(
+        FindProfileViewerGpuFrameBefore(recorded_frames, axis_frames, 20),
+        10,
+        true,
+        "GPU previous-frame navigation did not cross source/axis sets"
+    );
+    Expect(
+        !FindProfileViewerGpuFrameBefore(recorded_frames, axis_frames, 5),
+        "GPU previous-frame navigation moved before the first frame"
+    );
+    ExpectGpuFrameChoice(
+        FindProfileViewerGpuFrameAtOrBefore(recorded_frames, axis_frames, 19),
+        10,
+        true,
+        "GPU at-or-before navigation did not clamp to the preceding frame"
+    );
+    ExpectGpuFrameChoice(
+        FindProfileViewerGpuFrameAtOrBefore(recorded_frames, axis_frames, 20),
+        20,
+        false,
+        "GPU at-or-before navigation skipped an exact orphan frame"
+    );
+    Expect(
+        !FindProfileViewerGpuFrameAtOrBefore(recorded_frames, axis_frames, 4),
+        "GPU at-or-before navigation moved before the union"
+    );
+
+    const std::array<GpuTimelineAxisFrame, 1> orphan_only{{
+        {
+            .frame_id         = 42,
+            .axis_index       = 7,
+            .has_frame_record = false,
+        },
+    }};
+    ExpectGpuFrameChoice(
+        FindProfileViewerGpuFrameAtOrAfter({}, orphan_only, 0),
+        42,
+        false,
+        "axis-only orphan GPU frame was not selectable"
+    );
+    ExpectGpuFrameChoice(
+        FindProfileViewerGpuFrameAtOrAfter(recorded_frames, {}, 11),
+        30,
+        true,
+        "source-only GPU frames were dropped from the chooser"
+    );
+
+    const std::array<GpuTimelineAxisFrame, 2> axis_budget_boundary{{
+        {
+            .frame_id         = 60,
+            .axis_index       = kProfileViewerGpuRenderableAxisMax,
+            .has_frame_record = false,
+        },
+        {
+            .frame_id         = 1,
+            .axis_index       = kProfileViewerGpuRenderableAxisMax + 1,
+            .has_frame_record = false,
+        },
+    }};
+    ExpectGpuFrameChoice(
+        FindProfileViewerGpuFrameAtOrAfter({}, axis_budget_boundary, 0),
+        60,
+        false,
+        "GPU chooser did not retain the final viewer-renderable physical axis"
+    );
+    Expect(
+        !FindProfileViewerGpuFrameAfter({}, axis_budget_boundary, 60),
+        "GPU chooser exposed an orphan timeline beyond the viewer axis budget"
+    );
+
+    Expect(
+        !FindProfileViewerGpuFrameAtOrAfter({}, {}, 0) && !FindProfileViewerGpuFrameAfter({}, {}, 0) &&
+            !FindProfileViewerGpuFrameBefore({}, {}, 0) && !FindProfileViewerGpuFrameAtOrBefore({}, {}, 0),
+        "empty GPU frame sources produced a navigation result"
+    );
+
+    constexpr std::uint64_t                  maximum = std::numeric_limits<std::uint64_t>::max();
+    const std::array<GpuTimelineFrameRef, 1> maximum_frame{{
+        {
+            .frame_id           = maximum,
+            .source_frame_index = 0,
+        },
+    }};
+    ExpectGpuFrameChoice(
+        FindProfileViewerGpuFrameAtOrBefore(maximum_frame, {}, maximum),
+        maximum,
+        true,
+        "GPU frame navigation lost UINT64_MAX"
+    );
+    Expect(
+        !FindProfileViewerGpuFrameAfter(maximum_frame, {}, maximum),
+        "GPU next-frame navigation wrapped UINT64_MAX"
+    );
+}
+
 class ScopedFixtures final {
 public:
     ScopedFixtures() {
@@ -184,6 +363,11 @@ void TestPublicationAndIndependentNavigation(
     const auto ready_a = WaitForGeneration(_loader, generation_a);
     ExpectReady(ready_a, generation_a);
     Expect(
+        model.InspectSnapshot(ready_a) == EProfileViewerPublicationUpdate::Changed &&
+            model.PublishedGeneration() == kInvalidProfileDocumentGeneration,
+        "publication inspection mutated the unpublished model"
+    );
+    Expect(
         model.ObserveSnapshot(ready_a) == EProfileViewerPublicationUpdate::Changed,
         "first publication did not reset the model"
     );
@@ -297,6 +481,11 @@ void TestPublicationAndIndependentNavigation(
     const auto ready_b = WaitForGeneration(_loader, generation_b);
     ExpectReady(ready_b, generation_b);
     Expect(
+        model.InspectSnapshot(ready_b) == EProfileViewerPublicationUpdate::Changed &&
+            model.PublishedGeneration() == generation_a && model.Selection() == selection_a,
+        "publication inspection changed last-good navigation state"
+    );
+    Expect(
         model.ObserveSnapshot(ready_b) == EProfileViewerPublicationUpdate::Changed,
         "new publication did not reset the model"
     );
@@ -405,6 +594,7 @@ void TestPublicationAndIndependentNavigation(
 int main() {
     try {
         TestOverflowSafeFractionMapping();
+        TestGpuFrameChoiceUnionNavigation();
 
         ScopedFixtures fixtures;
         const auto     path_a = fixtures.Path("a");

--- a/source/test/ProfileViewerModelTest.cpp
+++ b/source/test/ProfileViewerModelTest.cpp
@@ -1,0 +1,425 @@
+#include "profile_viewer_ui/ProfileViewerModel.h"
+#include "profile/ProfileDump.h"
+#include "profile/ProfileDumpTemplates.h"
+#include "profile_consumer/ProfileDocument.h"
+
+#include <array>
+#include <chrono>
+#include <cstdint>
+#include <filesystem>
+#include <iostream>
+#include <limits>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <thread>
+#include <type_traits>
+#include <utility>
+
+namespace {
+
+using namespace Moer;
+using namespace Moer::ProfileDump;
+using namespace std::chrono_literals;
+
+static_assert(std::is_same_v<
+              decltype(std::declval<const ProfileViewerModel&>().FindGpuViewport({1, 1})),
+              std::optional<ProfileViewerViewport>>);
+static_assert(sizeof(ProfileViewerModel) < 64 * 1024);
+
+void Expect(bool _condition, std::string_view _message) {
+    if (!_condition) {
+        throw std::runtime_error(std::string(_message));
+    }
+}
+
+void ExpectValidViewport(const ProfileViewerViewport& _viewport, std::string_view _message) {
+    Expect(
+        _viewport.valid && _viewport.domain_end != 0 && _viewport.view_begin < _viewport.view_end &&
+            _viewport.view_end <= _viewport.domain_end,
+        _message
+    );
+}
+
+void TestOverflowSafeFractionMapping() {
+    constexpr std::uint64_t maximum = std::numeric_limits<std::uint64_t>::max();
+
+    Expect(ProfileViewerMapFraction(0, maximum, 0, 10) == 0, "fraction zero did not map to begin");
+    Expect(
+        ProfileViewerMapFraction(0, maximum, 10, 10) == maximum,
+        "fraction endpoint did not map exactly to uint64 max"
+    );
+    Expect(
+        ProfileViewerMapFraction(maximum - 10, maximum, 1, 2) == maximum - 5,
+        "fraction mapping overflowed a high-offset domain"
+    );
+    Expect(
+        ProfileViewerMapFraction(0, maximum, 1, 2) == maximum / 2,
+        "fraction midpoint did not use integer floor semantics"
+    );
+    Expect(ProfileViewerMapFraction(11, 99, 1, 0) == 11, "invalid fraction denominator did not map to begin");
+    Expect(ProfileViewerMapFraction(11, 99, 3, 2) == 11, "out-of-range fraction did not map to begin");
+    Expect(ProfileViewerMapFraction(99, 11, 1, 2) == 99, "reversed interval did not map to begin");
+}
+
+class ScopedFixtures final {
+public:
+    ScopedFixtures() {
+        static std::uint64_t next_id = 0;
+        for (std::uint32_t attempt = 0; attempt < 64; ++attempt) {
+            const auto now =
+                static_cast<std::uint64_t>(std::chrono::steady_clock::now().time_since_epoch().count());
+            directory_ =
+                std::filesystem::temp_directory_path() /
+                ("moer-profile-viewer-model-" + std::to_string(now) + "-" + std::to_string(next_id++));
+            std::error_code error;
+            if (std::filesystem::create_directory(directory_, error)) {
+                return;
+            }
+            if (error && error != std::errc::file_exists) {
+                break;
+            }
+        }
+        throw std::runtime_error("profile viewer model test could not reserve a temp directory");
+    }
+
+    ~ScopedFixtures() {
+        static_cast<void>(Moer::ProfileDump::Shutdown());
+        std::error_code error;
+        std::filesystem::remove_all(directory_, error);
+    }
+
+    [[nodiscard]] std::filesystem::path Path(std::string_view _name) const {
+        return directory_ / (std::string(_name) + ".mpd");
+    }
+
+private:
+    std::filesystem::path directory_{};
+};
+
+void WriteCapture(const std::filesystem::path& _path, std::string_view _scope_name) {
+    static_cast<void>(Moer::ProfileDump::Shutdown());
+
+    RuntimeConfig config;
+    config.output_path      = _path;
+    config.replace_existing = true;
+    Expect(Start(config) == StartResult::Started, "fixture capture did not start");
+
+    const SchemaRegistration cpu = RegisterSchema(Templates::CpuScope());
+    Expect(cpu.status == SchemaStatus::Registered, "fixture CPU schema did not register");
+
+    for (std::uint32_t index = 0; index < 4; ++index) {
+        const std::uint64_t                 begin = static_cast<std::uint64_t>(index) * 4;
+        const std::array<FieldValueView, 5> values{
+            std::uint64_t{17},
+            _scope_name,
+            begin,
+            begin + 2,
+            std::uint32_t{0},
+        };
+        Expect(Emit(cpu.handle, values) == EmitStatus::Accepted, "fixture CPU scope emission failed");
+    }
+
+    Expect(Moer::ProfileDump::Shutdown() == ShutdownResult::Completed, "fixture capture did not close");
+}
+
+[[nodiscard]] bool IsTerminal(ProfileDocumentLoadPhase _phase) noexcept {
+    return _phase == ProfileDocumentLoadPhase::Ready || _phase == ProfileDocumentLoadPhase::Failed ||
+           _phase == ProfileDocumentLoadPhase::Cancelled || _phase == ProfileDocumentLoadPhase::Shutdown;
+}
+
+ProfileDocumentLoaderSnapshot
+WaitForGeneration(const ProfileDocumentLoader& _loader, std::uint64_t _generation) {
+    const auto deadline = std::chrono::steady_clock::now() + 10s;
+    for (;;) {
+        auto snapshot = _loader.Snapshot();
+        Expect(
+            snapshot.request_generation == _generation,
+            "loader snapshot did not describe the requested generation"
+        );
+        if (IsTerminal(snapshot.phase)) {
+            return snapshot;
+        }
+        if (std::chrono::steady_clock::now() >= deadline) {
+            throw std::runtime_error("profile document load timed out");
+        }
+        std::this_thread::sleep_for(1ms);
+    }
+}
+
+void ExpectReady(const ProfileDocumentLoaderSnapshot& _snapshot, std::uint64_t _generation) {
+    Expect(_snapshot.phase == ProfileDocumentLoadPhase::Ready, "fixture document was not ready");
+    Expect(_snapshot.published_generation == _generation, "fixture publication generation mismatch");
+    Expect(_snapshot.document != nullptr, "ready fixture had no document");
+    Expect(_snapshot.document->Valid(), "ready fixture document was invalid");
+}
+
+void ExpectViewerState(
+    const ProfileViewerModel&     _model,
+    const ProfileViewerViewport&  _cpu,
+    ProfileViewerGpuViewportKey   _gpu_key,
+    const ProfileViewerViewport&  _gpu,
+    const ProfileViewerSelection& _selection,
+    std::size_t                   _gpu_count,
+    std::string_view              _message
+) {
+    const auto observed_gpu = _model.FindGpuViewport(_gpu_key);
+    Expect(
+        _model.CpuViewport() == _cpu && observed_gpu && *observed_gpu == _gpu &&
+            _model.Selection() == _selection && _model.ActiveGpuViewportCount() == _gpu_count,
+        _message
+    );
+}
+
+void TestPublicationAndIndependentNavigation(
+    ProfileDocumentLoader&       _loader,
+    const std::filesystem::path& _path_a,
+    const std::filesystem::path& _path_b
+) {
+    ProfileViewerModel model;
+    Expect(!model.FitCpu(10), "unpublished model accepted CPU navigation");
+
+    const std::uint64_t generation_a = _loader.RequestLoad(_path_a);
+    Expect(generation_a != 0, "first fixture load was rejected");
+    const auto ready_a = WaitForGeneration(_loader, generation_a);
+    ExpectReady(ready_a, generation_a);
+    Expect(
+        model.ObserveSnapshot(ready_a) == EProfileViewerPublicationUpdate::Changed,
+        "first publication did not reset the model"
+    );
+    Expect(model.PublishedGeneration() == generation_a, "model generation did not publish");
+
+    constexpr ProfileViewerGpuViewportKey gpu_a{1, 42};
+    constexpr ProfileViewerGpuViewportKey gpu_b{1, 43};
+    constexpr ProfileViewerGpuViewportKey gpu_c{2, 42};
+    Expect(model.FitCpu(1'000), "CPU fit failed");
+    Expect(model.ZoomCpu(1, 2, 1, 2), "CPU zoom failed");
+    Expect(model.PanCpu(100), "CPU pan failed");
+    Expect(model.FitGpu(gpu_a, 100), "first GPU fit failed");
+    Expect(model.ZoomGpu(gpu_a, 1, 2, 1, 2), "first GPU zoom failed");
+    Expect(model.FitGpu(gpu_b, 200), "second GPU fit failed");
+    Expect(model.FocusGpu(gpu_b, 20, 40, 5), "second GPU focus failed");
+    Expect(model.FitGpu(gpu_c, 300), "third GPU fit failed");
+
+    const auto cpu_before_gpu_pan = model.CpuViewport();
+    const auto gpu_a_before       = model.FindGpuViewport(gpu_a);
+    const auto gpu_c_before       = model.FindGpuViewport(gpu_c);
+    Expect(gpu_a_before && gpu_c_before, "GPU key lookup failed");
+    Expect(model.PanGpu(gpu_b, 10), "GPU pan failed");
+    Expect(model.CpuViewport() == cpu_before_gpu_pan, "GPU pan changed the CPU viewport");
+    Expect(model.FindGpuViewport(gpu_a) == gpu_a_before, "GPU frame key leaked into another frame");
+    Expect(model.FindGpuViewport(gpu_c) == gpu_c_before, "GPU axis key leaked into another axis");
+
+    Expect(model.SelectCpu(0, 1, 999, 999), "CPU point-scope selection failed");
+    const auto cpu_point_selection = model.Selection();
+    Expect(!model.SelectCpu(0, 1, 1'000, 1'000), "point scope at the exclusive CPU domain end was accepted");
+    Expect(model.Selection() == cpu_point_selection, "rejected exclusive-end CPU point mutated selection");
+    Expect(model.SelectCpu(0, 1, 400, 410), "CPU selection failed");
+    const ProfileViewerSelection selection_a = model.Selection();
+    Expect(selection_a.Valid(), "CPU selection was not valid");
+    const auto cpu_a       = model.CpuViewport();
+    const auto gpu_a_state = *model.FindGpuViewport(gpu_a);
+    const auto gpu_count_a = model.ActiveGpuViewportCount();
+
+    auto loading_b                = ready_a;
+    loading_b.request_generation  = generation_a + 1;
+    loading_b.phase               = ProfileDocumentLoadPhase::Reading;
+    loading_b.latest_attempt_path = _path_b;
+    Expect(
+        model.ObserveSnapshot(loading_b) == EProfileViewerPublicationUpdate::Unchanged,
+        "latest request generation reset last-good publication state"
+    );
+    ExpectViewerState(
+        model,
+        cpu_a,
+        gpu_a,
+        gpu_a_state,
+        selection_a,
+        gpu_count_a,
+        "in-progress attempt changed last-good view state"
+    );
+
+    auto failed_b  = loading_b;
+    failed_b.phase = ProfileDocumentLoadPhase::Failed;
+    Expect(
+        model.ObserveSnapshot(failed_b) == EProfileViewerPublicationUpdate::Unchanged,
+        "failed latest request reset last-good publication state"
+    );
+    auto cancelled_b  = loading_b;
+    cancelled_b.phase = ProfileDocumentLoadPhase::Cancelled;
+    Expect(
+        model.ObserveSnapshot(cancelled_b) == EProfileViewerPublicationUpdate::Unchanged,
+        "cancelled latest request reset last-good publication state"
+    );
+    ExpectViewerState(
+        model,
+        cpu_a,
+        gpu_a,
+        gpu_a_state,
+        selection_a,
+        gpu_count_a,
+        "failed or cancelled attempt changed last-good view state"
+    );
+
+    auto malformed                 = ready_a;
+    malformed.published_generation = generation_a + 1;
+    Expect(
+        model.ObserveSnapshot(malformed) == EProfileViewerPublicationUpdate::Invalid,
+        "mismatched publication and document generation was accepted"
+    );
+    ExpectViewerState(
+        model,
+        cpu_a,
+        gpu_a,
+        gpu_a_state,
+        selection_a,
+        gpu_count_a,
+        "invalid snapshot changed current view state"
+    );
+    Expect(
+        model.PublishedGeneration() == generation_a,
+        "invalid snapshot changed the last-good publication generation"
+    );
+
+    auto missing_document = ready_a;
+    missing_document.document.reset();
+    Expect(
+        model.ObserveSnapshot(missing_document) == EProfileViewerPublicationUpdate::Invalid,
+        "non-empty publication without a document was accepted"
+    );
+    Expect(
+        model.PublishedGeneration() == generation_a && model.Selection() == selection_a,
+        "missing-document snapshot cleared last-good publication state"
+    );
+
+    const std::uint64_t generation_b = _loader.RequestLoad(_path_b);
+    Expect(generation_b == generation_a + 1, "second fixture generation was not monotonic");
+    const auto ready_b = WaitForGeneration(_loader, generation_b);
+    ExpectReady(ready_b, generation_b);
+    Expect(
+        model.ObserveSnapshot(ready_b) == EProfileViewerPublicationUpdate::Changed,
+        "new publication did not reset the model"
+    );
+    Expect(!model.CpuViewport().valid, "new publication retained CPU viewport state");
+    Expect(model.ActiveGpuViewportCount() == 0, "new publication retained GPU viewport state");
+    Expect(!model.Selection().Valid(), "new publication retained selection state");
+    Expect(
+        model.ObserveSnapshot(ready_b) == EProfileViewerPublicationUpdate::Unchanged,
+        "same publication reset the model twice"
+    );
+
+    Expect(model.FitCpu(std::numeric_limits<std::uint64_t>::max()), "maximum CPU domain fit failed");
+    Expect(model.ZoomCpu(1, 2, std::numeric_limits<std::uint32_t>::max(), 1), "saturating zoom failed");
+    ExpectValidViewport(model.CpuViewport(), "saturating zoom broke CPU viewport invariants");
+    Expect(model.ZoomCpu(1, 2, 1, std::numeric_limits<std::uint32_t>::max()), "maximum-ratio zoom-in failed");
+    ExpectValidViewport(model.CpuViewport(), "maximum-ratio zoom-in broke CPU viewport invariants");
+    Expect(
+        model.FocusCpu(
+            std::numeric_limits<std::uint64_t>::max(), 0, std::numeric_limits<std::uint64_t>::max()
+        ),
+        "overflow-edge focus failed"
+    );
+    Expect(
+        model.CpuViewport().view_begin == 0 &&
+            model.CpuViewport().view_end == std::numeric_limits<std::uint64_t>::max(),
+        "maximum focus margin did not clamp to the domain"
+    );
+    Expect(model.FocusCpu(10, 20, 0), "small focus failed");
+    Expect(model.PanCpu(std::numeric_limits<std::int64_t>::min()), "minimum pan failed");
+    Expect(model.CpuViewport().view_begin == 0, "minimum pan did not clamp left");
+    Expect(model.PanCpu(std::numeric_limits<std::int64_t>::max()), "maximum pan failed");
+    ExpectValidViewport(model.CpuViewport(), "maximum pan broke CPU viewport invariants");
+
+    const auto before_invalid_zoom = model.CpuViewport();
+    Expect(!model.ZoomCpu(1, 0, 1, 1), "zero anchor denominator was accepted");
+    Expect(!model.ZoomCpu(2, 1, 1, 1), "out-of-range anchor was accepted");
+    Expect(!model.ZoomCpu(1, 2, 0, 1), "zero zoom numerator was accepted");
+    Expect(model.CpuViewport() == before_invalid_zoom, "invalid zoom mutated viewport state");
+
+    constexpr ProfileViewerGpuViewportKey same_frame_axis_a{1, 77};
+    constexpr ProfileViewerGpuViewportKey same_frame_axis_b{2, 77};
+    constexpr ProfileViewerGpuViewportKey same_axis_frame_b{1, 78};
+    Expect(model.FitGpu(same_frame_axis_a, 101), "GPU identity fit A failed");
+    Expect(model.FitGpu(same_frame_axis_b, 202), "GPU identity fit B failed");
+    Expect(model.FitGpu(same_axis_frame_b, 303), "GPU identity fit C failed");
+    Expect(
+        model.FindGpuViewport(same_frame_axis_a)->domain_end == 101 &&
+            model.FindGpuViewport(same_frame_axis_b)->domain_end == 202 &&
+            model.FindGpuViewport(same_axis_frame_b)->domain_end == 303,
+        "GPU viewports were not keyed by both axis and frame"
+    );
+
+    Expect(model.SelectGpu(same_frame_axis_a, 4, 9, 10, 20), "GPU selection failed");
+    Expect(model.Selection().Valid(), "GPU selection was invalid");
+    const auto selected_gpu = model.Selection();
+    Expect(model.SelectGpu(same_frame_axis_a, 4, 9, 100, 100), "GPU point-scope selection failed");
+    const auto selected_gpu_point = model.Selection();
+    Expect(
+        !model.SelectGpu(same_frame_axis_a, 4, 9, 101, 101),
+        "point scope at the exclusive GPU domain end was accepted"
+    );
+    Expect(model.Selection() == selected_gpu_point, "rejected exclusive-end GPU point mutated selection");
+    Expect(model.SelectGpu(same_frame_axis_a, 4, 9, 10, 20), "GPU reselection failed");
+    Expect(
+        !model.SelectGpu(same_frame_axis_a, ProfileDump::kInvalidSessionIndex, 9, 10, 20),
+        "invalid GPU track selection was accepted"
+    );
+    Expect(model.Selection() == selected_gpu, "rejected selection mutated current selection");
+
+    model.ClearSelection();
+    Expect(!model.Selection().Valid(), "selection clear failed");
+
+    const auto cpu_before_capacity = model.CpuViewport();
+    for (std::uint64_t frame = 1'000; frame < 1'000 + kProfileViewerGpuViewportCapacity; ++frame) {
+        Expect(model.FitGpu({3, frame}, frame + 1), "fixed GPU viewport table fill failed");
+    }
+    for (std::uint64_t frame = 10'000; frame < 14'096; ++frame) {
+        Expect(model.FitGpu({4, frame}, frame + 1), "fixed GPU viewport table eviction failed");
+    }
+    Expect(
+        model.ActiveGpuViewportCount() == kProfileViewerGpuViewportCapacity,
+        "GPU viewport state grew beyond its fixed capacity"
+    );
+    Expect(model.FindGpuViewport({4, 14'095}).has_value(), "newest evicted-table key was not retained");
+    Expect(model.CpuViewport() == cpu_before_capacity, "GPU table eviction changed CPU state");
+
+    ProfileDocumentLoaderSnapshot empty;
+    Expect(
+        model.ObserveSnapshot(empty) == EProfileViewerPublicationUpdate::Changed,
+        "empty publication did not reset a published model"
+    );
+    Expect(model.PublishedGeneration() == 0, "empty publication did not clear generation");
+    Expect(!model.CpuViewport().valid, "empty publication retained CPU state");
+    Expect(model.ActiveGpuViewportCount() == 0, "empty publication retained GPU state");
+
+    auto malformed_empty     = empty;
+    malformed_empty.document = ready_b.document;
+    Expect(
+        model.ObserveSnapshot(malformed_empty) == EProfileViewerPublicationUpdate::Invalid,
+        "empty generation with a document was accepted"
+    );
+}
+
+} // namespace
+
+int main() {
+    try {
+        TestOverflowSafeFractionMapping();
+
+        ScopedFixtures fixtures;
+        const auto     path_a = fixtures.Path("a");
+        const auto     path_b = fixtures.Path("b");
+        WriteCapture(path_a, "ViewerA");
+        WriteCapture(path_b, "ViewerB");
+
+        ProfileDocumentLoader loader;
+        TestPublicationAndIndependentNavigation(loader, path_a, path_b);
+        loader.Shutdown();
+
+        std::cout << "ProfileViewerModel contract passed\n";
+        return 0;
+    } catch (const std::exception& error) {
+        std::cerr << "ProfileViewerModel contract failed: " << error.what() << '\n';
+        return 1;
+    }
+}

--- a/source/tool/profile_consumer/include/profile_consumer/ProfileTimelineIndex.h
+++ b/source/tool/profile_consumer/include/profile_consumer/ProfileTimelineIndex.h
@@ -268,6 +268,17 @@ public:
         std::span<std::uint64_t> _output
     ) const noexcept;
 
+    // Viewer-oriented variant that returns the already-normalized timeline
+    // references as well as their source indices. This remains output-bounded
+    // and avoids rescanning a track or reconstructing relative timing in UI
+    // code.
+    [[nodiscard]] TimelineOverlapQueryResult QueryCpuTimelineOverlaps(
+        std::uint32_t                  _track_index,
+        std::uint64_t                  _view_begin_ns,
+        std::uint64_t                  _view_end_ns,
+        std::span<CpuTimelineScopeRef> _output
+    ) const noexcept;
+
     [[nodiscard]] const GpuTimelineFrameRef* FindGpuFrame(std::uint64_t _frame_id) const noexcept;
     [[nodiscard]] const GpuTimelineFrameSlice*
     FindGpuFrameSlice(std::uint32_t _track_index, std::uint64_t _frame_id) const noexcept;
@@ -283,6 +294,17 @@ public:
         std::uint64_t            _view_begin_ticks,
         std::uint64_t            _view_end_ticks,
         std::span<std::uint64_t> _output
+    ) const noexcept;
+
+    // Returns frame-local, wrap-normalized timing references. Distinct
+    // axis/frame records remain incomparable; callers must pair these offsets
+    // with the exact GpuTimelineAxisFrame selected for the query.
+    [[nodiscard]] TimelineOverlapQueryResult QueryGpuTimelineOverlaps(
+        std::uint32_t                  _track_index,
+        std::uint64_t                  _frame_id,
+        std::uint64_t                  _view_begin_ticks,
+        std::uint64_t                  _view_end_ticks,
+        std::span<GpuTimelineScopeRef> _output
     ) const noexcept;
 
 private:

--- a/source/tool/profile_consumer/source/ProfileTimelineIndex.cpp
+++ b/source/tool/profile_consumer/source/ProfileTimelineIndex.cpp
@@ -7,6 +7,7 @@
 #include <limits>
 #include <new>
 #include <tuple>
+#include <type_traits>
 #include <utility>
 #include <vector>
 
@@ -258,6 +259,100 @@ Overlaps(const GpuTimelineScopeRef& _scope, std::uint64_t _view_begin, std::uint
         return _scope.end_tick_offset > _view_begin && _scope.begin_tick_offset < _view_end;
     }
     return _scope.begin_tick_offset >= _view_begin && _scope.begin_tick_offset < _view_end;
+}
+
+template<typename ScopeRef, typename Output, typename Project>
+[[nodiscard]] TimelineOverlapQueryResult QueryTimelineOverlaps(
+    std::span<const ScopeRef>      _scopes,
+    std::uint64_t                  _first_scope,
+    std::uint64_t                  _scope_count,
+    const TimelineIntervalTree&    _tree,
+    std::span<const std::uint64_t> _tree_max_end,
+    std::uint64_t                  _view_begin,
+    std::uint64_t                  _view_end,
+    std::span<Output>              _output,
+    Project                        _project
+) noexcept {
+    TimelineOverlapQueryResult query{};
+    if (_view_end <= _view_begin || _first_scope > _scopes.size() ||
+        _scope_count > _scopes.size() - _first_scope) {
+        return query;
+    }
+
+    query.valid = true;
+    if (_scope_count == 0) {
+        return query;
+    }
+    if (_tree.leaf_count == 0 || _tree.tree_offset > _tree_max_end.size() ||
+        _tree.leaf_count > (_tree_max_end.size() - _tree.tree_offset) / 2) {
+        query.valid = false;
+        return query;
+    }
+
+    struct StackNode {
+        std::uint64_t node{0};
+        std::uint64_t begin{0};
+        std::uint64_t end{0};
+    };
+    std::array<StackNode, 128> stack{};
+    std::size_t                stack_size = 0;
+    stack[stack_size++]                   = {
+                          .node  = 1,
+                          .begin = 0,
+                          .end   = _tree.leaf_count,
+    };
+
+    while (stack_size != 0) {
+        const StackNode current = stack[--stack_size];
+        if (current.begin >= _scope_count) {
+            continue;
+        }
+        const std::uint64_t tree_value = _tree_max_end[_tree.tree_offset + current.node];
+        if (tree_value <= _view_begin) {
+            continue;
+        }
+
+        const ScopeRef& first = _scopes[_first_scope + current.begin];
+        if constexpr (std::is_same_v<ScopeRef, CpuTimelineScopeRef>) {
+            if (first.begin_ns >= _view_end) {
+                continue;
+            }
+        } else {
+            if (first.begin_tick_offset >= _view_end) {
+                continue;
+            }
+        }
+
+        if (current.end - current.begin == 1) {
+            if (!Overlaps(first, _view_begin, _view_end)) {
+                continue;
+            }
+            if (query.written < _output.size()) {
+                _output[query.written++] = _project(first);
+                continue;
+            }
+            query.truncated = true;
+            break;
+        }
+
+        const std::uint64_t middle = current.begin + (current.end - current.begin) / 2;
+        if (stack_size + 2 > stack.size()) {
+            query.valid = false;
+            return query;
+        }
+        // Push right first so the left/begin-time half is visited first.
+        stack[stack_size++] = {
+            .node  = current.node * 2 + 1,
+            .begin = middle,
+            .end   = current.end,
+        };
+        stack[stack_size++] = {
+            .node  = current.node * 2,
+            .begin = current.begin,
+            .end   = middle,
+        };
+    }
+    return query;
 }
 
 void AddQualityFlag(ProfileTimelineQuality& _quality, TimelineQualityFlag _flag) noexcept {
@@ -897,76 +992,52 @@ TimelineOverlapQueryResult ProfileTimelineIndex::QueryCpuOverlaps(
     std::uint64_t            _view_end_ns,
     std::span<std::uint64_t> _output
 ) const noexcept {
-    TimelineOverlapQueryResult query{};
     if (!Valid() || _track_index >= impl_->cpu_tracks.size() || _view_end_ns <= _view_begin_ns) {
-        return query;
+        return {};
     }
 
-    query.valid                        = true;
     const CpuTimelineTrackIndex& track = impl_->cpu_tracks[_track_index];
     const TimelineIntervalTree&  tree  = impl_->cpu_trees[_track_index];
-    if (track.scope_count == 0) {
-        return query;
+    return QueryTimelineOverlaps(
+        std::span<const CpuTimelineScopeRef>(impl_->cpu_scopes),
+        track.first_scope,
+        track.scope_count,
+        tree,
+        std::span<const std::uint64_t>(impl_->cpu_tree_max_end),
+        _view_begin_ns,
+        _view_end_ns,
+        _output,
+        [](const CpuTimelineScopeRef& _scope) noexcept {
+            return _scope.source_scope_index;
+        }
+    );
+}
+
+TimelineOverlapQueryResult ProfileTimelineIndex::QueryCpuTimelineOverlaps(
+    std::uint32_t                  _track_index,
+    std::uint64_t                  _view_begin_ns,
+    std::uint64_t                  _view_end_ns,
+    std::span<CpuTimelineScopeRef> _output
+) const noexcept {
+    if (!Valid() || _track_index >= impl_->cpu_tracks.size() || _view_end_ns <= _view_begin_ns) {
+        return {};
     }
 
-    struct StackNode {
-        std::uint64_t node{0};
-        std::uint64_t begin{0};
-        std::uint64_t end{0};
-    };
-    std::array<StackNode, 128> stack{};
-    std::size_t                stack_size = 0;
-    stack[stack_size++]                   = {
-                          .node  = 1,
-                          .begin = 0,
-                          .end   = tree.leaf_count,
-    };
-
-    while (stack_size != 0) {
-        const StackNode current = stack[--stack_size];
-        if (current.begin >= track.scope_count) {
-            continue;
+    const CpuTimelineTrackIndex& track = impl_->cpu_tracks[_track_index];
+    const TimelineIntervalTree&  tree  = impl_->cpu_trees[_track_index];
+    return QueryTimelineOverlaps(
+        std::span<const CpuTimelineScopeRef>(impl_->cpu_scopes),
+        track.first_scope,
+        track.scope_count,
+        tree,
+        std::span<const std::uint64_t>(impl_->cpu_tree_max_end),
+        _view_begin_ns,
+        _view_end_ns,
+        _output,
+        [](const CpuTimelineScopeRef& _scope) noexcept {
+            return _scope;
         }
-        const std::uint64_t tree_value = impl_->cpu_tree_max_end[tree.tree_offset + current.node];
-        if (tree_value <= _view_begin_ns) {
-            continue;
-        }
-
-        const CpuTimelineScopeRef& first = impl_->cpu_scopes[track.first_scope + current.begin];
-        if (first.begin_ns >= _view_end_ns) {
-            continue;
-        }
-
-        if (current.end - current.begin == 1) {
-            if (!Overlaps(first, _view_begin_ns, _view_end_ns)) {
-                continue;
-            }
-            if (query.written < _output.size()) {
-                _output[query.written++] = first.source_scope_index;
-                continue;
-            }
-            query.truncated = true;
-            break;
-        }
-
-        const std::uint64_t middle = current.begin + (current.end - current.begin) / 2;
-        if (stack_size + 2 > stack.size()) {
-            query.valid = false;
-            return query;
-        }
-        // Push right first so the left/begin-time half is visited first.
-        stack[stack_size++] = {
-            .node  = current.node * 2 + 1,
-            .begin = middle,
-            .end   = current.end,
-        };
-        stack[stack_size++] = {
-            .node  = current.node * 2,
-            .begin = current.begin,
-            .end   = middle,
-        };
-    }
-    return query;
+    );
 }
 
 const GpuTimelineFrameRef* ProfileTimelineIndex::FindGpuFrame(std::uint64_t _frame_id) const noexcept {
@@ -1026,88 +1097,67 @@ TimelineOverlapQueryResult ProfileTimelineIndex::QueryGpuOverlaps(
     std::uint64_t            _view_end_ticks,
     std::span<std::uint64_t> _output
 ) const noexcept {
-    TimelineOverlapQueryResult query{};
     if (!Valid() || _track_index >= impl_->gpu_tracks.size() || _view_end_ticks <= _view_begin_ticks) {
-        return query;
+        return {};
     }
     const GpuTimelineFrameSlice* slice = FindGpuFrameSlice(_track_index, _frame_id);
     if (slice == nullptr || slice->axis_frame_index >= impl_->gpu_axis_frames.size() ||
         !impl_->gpu_axis_frames[slice->axis_frame_index].timing_available) {
-        return query;
-    }
-
-    query.valid = true;
-    if (slice->timeline_scope_count == 0) {
-        return query;
+        return {};
     }
     const std::size_t slice_index = static_cast<std::size_t>(slice - impl_->gpu_frame_slices.data());
     if (slice_index >= impl_->gpu_trees.size()) {
-        query.valid = false;
-        return query;
+        return {};
     }
     const TimelineIntervalTree& tree = impl_->gpu_trees[slice_index];
-    if (tree.leaf_count == 0) {
-        query.valid = false;
-        return query;
+    return QueryTimelineOverlaps(
+        std::span<const GpuTimelineScopeRef>(impl_->gpu_timeline_scopes),
+        slice->first_timeline_scope,
+        slice->timeline_scope_count,
+        tree,
+        std::span<const std::uint64_t>(impl_->gpu_tree_max_end),
+        _view_begin_ticks,
+        _view_end_ticks,
+        _output,
+        [](const GpuTimelineScopeRef& _scope) noexcept {
+            return _scope.source_scope_index;
+        }
+    );
+}
+
+TimelineOverlapQueryResult ProfileTimelineIndex::QueryGpuTimelineOverlaps(
+    std::uint32_t                  _track_index,
+    std::uint64_t                  _frame_id,
+    std::uint64_t                  _view_begin_ticks,
+    std::uint64_t                  _view_end_ticks,
+    std::span<GpuTimelineScopeRef> _output
+) const noexcept {
+    if (!Valid() || _track_index >= impl_->gpu_tracks.size() || _view_end_ticks <= _view_begin_ticks) {
+        return {};
     }
-
-    struct StackNode {
-        std::uint64_t node{0};
-        std::uint64_t begin{0};
-        std::uint64_t end{0};
-    };
-    std::array<StackNode, 128> stack{};
-    std::size_t                stack_size = 0;
-    stack[stack_size++]                   = {
-                          .node  = 1,
-                          .begin = 0,
-                          .end   = tree.leaf_count,
-    };
-
-    while (stack_size != 0) {
-        const StackNode current = stack[--stack_size];
-        if (current.begin >= slice->timeline_scope_count) {
-            continue;
-        }
-        const std::uint64_t tree_value = impl_->gpu_tree_max_end[tree.tree_offset + current.node];
-        if (tree_value <= _view_begin_ticks) {
-            continue;
-        }
-
-        const GpuTimelineScopeRef& first =
-            impl_->gpu_timeline_scopes[slice->first_timeline_scope + current.begin];
-        if (first.begin_tick_offset >= _view_end_ticks) {
-            continue;
-        }
-        if (current.end - current.begin == 1) {
-            if (!Overlaps(first, _view_begin_ticks, _view_end_ticks)) {
-                continue;
-            }
-            if (query.written < _output.size()) {
-                _output[query.written++] = first.source_scope_index;
-                continue;
-            }
-            query.truncated = true;
-            break;
-        }
-
-        const std::uint64_t middle = current.begin + (current.end - current.begin) / 2;
-        if (stack_size + 2 > stack.size()) {
-            query.valid = false;
-            return query;
-        }
-        stack[stack_size++] = {
-            .node  = current.node * 2 + 1,
-            .begin = middle,
-            .end   = current.end,
-        };
-        stack[stack_size++] = {
-            .node  = current.node * 2,
-            .begin = current.begin,
-            .end   = middle,
-        };
+    const GpuTimelineFrameSlice* slice = FindGpuFrameSlice(_track_index, _frame_id);
+    if (slice == nullptr || slice->axis_frame_index >= impl_->gpu_axis_frames.size() ||
+        !impl_->gpu_axis_frames[slice->axis_frame_index].timing_available) {
+        return {};
     }
-    return query;
+    const std::size_t slice_index = static_cast<std::size_t>(slice - impl_->gpu_frame_slices.data());
+    if (slice_index >= impl_->gpu_trees.size()) {
+        return {};
+    }
+    const TimelineIntervalTree& tree = impl_->gpu_trees[slice_index];
+    return QueryTimelineOverlaps(
+        std::span<const GpuTimelineScopeRef>(impl_->gpu_timeline_scopes),
+        slice->first_timeline_scope,
+        slice->timeline_scope_count,
+        tree,
+        std::span<const std::uint64_t>(impl_->gpu_tree_max_end),
+        _view_begin_ticks,
+        _view_end_ticks,
+        _output,
+        [](const GpuTimelineScopeRef& _scope) noexcept {
+            return _scope;
+        }
+    );
 }
 
 TimelineIndexBuildResult BuildProfileTimelineIndex(


### PR DESCRIPTION
## Summary

- add typed, bounded CPU/GPU timeline overlap queries to `ProfileTimelineIndex`
- add a pure `ProfileViewerModel` with overflow-safe fit/zoom/pan/focus, generation reset semantics, and bounded per-axis GPU viewport state
- embed an asynchronous `.mpd` Profile Viewer in MoerEditor with CPU and physical GPU-domain timelines, filtering, selection, range navigation, and explicit truncation budgets
- move NFD and `ProfileDocumentLoader` ownership to `Editor`, with ordered UI teardown, loader cancel/join, NFD shutdown, then Engine shutdown
- retain the last coherent document across failed, cancelled, stale, or invalid load attempts

## Architecture

This absorbs the useful Profile Viewer intent from `dev_parallel_rhi` without restoring its mutable `ProfileStore`, UI-thread file parsing, global CPU/GPU timestamp normalization, Trace/TCP ingest, or standalone profiler shell.

CPU scopes remain in the CPU steady-clock domain. GPU rulers are keyed by exact `(physical axis, frame)` and use native tick offsets plus the axis period; unrelated domains are never compared or visually calibrated.

Viewer work is bounded per frame: 4096 tracks, 256 physical axes, 4096 query refs per track, 16384 GPU scopes per frame, fixed filter buffers, and 256 GPU viewport slots.

## Validation

- Debug targeted Editor/model/index/loader build passed
- Debug focused profile contracts: 3/3
- Debug full CTest: 33/33
- RelWithDebInfo full build and CTest: 33/33
- Release full build and CTest: 33/33
- real 44,583,497-byte capture: 136,578 CPU scopes, 3,906 GPU frames, 144,445 GPU scopes
- real 166,745,345-byte capture: 510,905 CPU scopes, 14,602 GPU frames, 540,178 GPU scopes
- GUI verified CPU/GPU zoom, filtering, scope selection, GPU frame and physical-axis switching
- invalid load preserved the 166 MB last-good document
- filter text input no longer triggers timeline keyboard shortcuts
- closing Debug Editor while the 166 MB capture was in `Reading (indeterminate)` cancelled/joined the worker and exited cleanly
- independent final review: P0/P1/P2 = 0
- `git diff --check` passed