### PR TITLE
Phase 22A: add immutable window surface sources

### DIFF
--- a/source/runtime/Engine.cpp
+++ b/source/runtime/Engine.cpp
@@ -1427,7 +1427,6 @@ void Engine::Init(
         main_window_visible ? "Preparing the main window" : "Keeping the main window hidden until its first frame"
     );
     WindowContext::Init(SurfaceInitInfo(
-        RenderDevice::Get().GetRHIType(),
         m_editor_config->GetResolution().x,
         m_editor_config->GetResolution().y,
         "MoerEditor",
@@ -1435,6 +1434,10 @@ void Engine::Init(
         main_window_visible
     ));
     m_window_context_initialized = true;
+    m_main_window_surface        = WindowContext::CreateSwapchainSurfaceInfo(*WindowContext::GetMainWindow());
+    if (!m_main_window_surface.IsValid()) {
+        throw std::runtime_error("Failed to capture the main window surface source");
+    }
 
     report_startup("Loading editor resources", "Uploading editor textures and environment assets");
     m_runtime_assets =
@@ -1544,6 +1547,7 @@ void Engine::Run(const EngineHooks& hooks) {
                 m_renderer = MakeUnique<Raster::RasterRenderer>(
                     m_editor_config->GetResolution(),
                     m_editor_config,
+                    m_main_window_surface,
                     m_render_profile_capture.get()
                 );
 
@@ -1551,6 +1555,7 @@ void Engine::Run(const EngineHooks& hooks) {
                 m_renderer = MakeUnique<Raytracing::RaytracingRenderer>(
                     m_editor_config->GetResolution(),
                     m_editor_config,
+                    m_main_window_surface,
                     *m_runtime_assets,
                     m_render_profile_capture.get()
                 );
@@ -1980,6 +1985,7 @@ void Engine::ShutDown() noexcept {
     }
 
     m_runtime_assets.reset(); // 释放RuntimeAssets资源
+    m_main_window_surface = {};
 
     if (m_window_context_initialized) {
         m_window_context_initialized = false;

--- a/source/runtime/Engine.h
+++ b/source/runtime/Engine.h
@@ -98,8 +98,9 @@ private:
     void TickRasterLifecycleValidation(Scene& scene);
     bool ConsumeRendererSwitchValidationReloadRequest();
 
-    SharedPtr<EditorConfig>  m_editor_config;
-    UniquePtr<RuntimeAssets> m_runtime_assets;
+    SharedPtr<EditorConfig>      m_editor_config;
+    Render::SwapchainSurfaceInfo m_main_window_surface;
+    UniquePtr<RuntimeAssets>     m_runtime_assets;
 
     UniquePtr<scripting::ScriptHost> m_script_host;
     UniquePtr<remote::RemoteModule>  m_remote_module;

--- a/source/runtime/render/renderer/Renderer.cpp
+++ b/source/runtime/render/renderer/Renderer.cpp
@@ -22,6 +22,7 @@ namespace Moer::Render {
 Renderer::Renderer(
     uint2                         initial_resolution,
     const SharedPtr<EditorConfig> config,
+    SwapchainSurfaceInfo          main_window_surface,
     RenderProfileCapture*         _render_profile_capture
 ) :
     device(RenderDevice::Get()),
@@ -34,7 +35,7 @@ Renderer::Renderer(
 
     {
         swapchain_create_info = SwapchainCreateInfo{
-            .window_handle    = (uintptr_t)WindowContext::GetMainWindow(),
+            .surface          = std::move(main_window_surface),
             .size             = {resolution.x, resolution.y},
             .back_buffer_sz   = 2,
             .preferred_format = PF_R8G8B8A8_SRGB

--- a/source/runtime/render/renderer/Renderer.h
+++ b/source/runtime/render/renderer/Renderer.h
@@ -70,6 +70,7 @@ public:
     Renderer(
         uint2                         initial_resolution,
         const SharedPtr<EditorConfig> config,
+        SwapchainSurfaceInfo          main_window_surface,
         RenderProfileCapture*         render_profile_capture = nullptr
     );
 

--- a/source/runtime/render/renderer/common/ui/DearImGuiRenderer.cpp
+++ b/source/runtime/render/renderer/common/ui/DearImGuiRenderer.cpp
@@ -131,6 +131,7 @@ struct GuiViewportRenderResources final : UiViewportRenderResources {
 
 struct GuiViewportData {
     SharedPtr<GuiViewportRenderResources> render_resources;
+    SwapchainSurfaceInfo                  surface_info;
 
     uint32_t        viewport_index = 0;
     static uint32_t viewport_count;
@@ -814,7 +815,7 @@ void DestroyRenderBuffers(GuiFrameRenderBuffers* _render_buffers) {
 void CreateOrResizeViewportResources(
     RenderDevice&                                       _device,
     const SharedPtr<GuiViewportRenderResources>&        _resources,
-    void*                                               _platform_window,
+    SwapchainSurfaceInfo                                _surface_info,
     uint2                                               _extent,
     uint32_t                                            _frame_in_flight,
     uint32_t                                            _viewport_index
@@ -823,8 +824,11 @@ void CreateOrResizeViewportResources(
     assert(!IsRenderThreadRunning() || IsCurrentlyRenderThread());
 
     const bool has_swapchain = _resources->swapchain.IsValid();
+    const bool surface_matches =
+        has_swapchain && _surface_info.IsValid() &&
+        _resources->swapchain->GetCommittedSurfaceIdentity() == _surface_info.GetIdentity();
     const bool swapchain_matches =
-        has_swapchain && _resources->swapchain->size.x == _extent.x &&
+        surface_matches && _resources->swapchain->size.x == _extent.x &&
         _resources->swapchain->size.y == _extent.y;
     const bool framebuffer_matches =
         _resources->framebuffer && _resources->framebuffer->GetExtent().x == _extent.x &&
@@ -837,9 +841,8 @@ void CreateOrResizeViewportResources(
         RHIExecutor::Get().Sync(ERHISyncDepth::Present);
     }
 
-    Moer::WindowHandle handle{static_cast<Moer::WindowType*>(_platform_window)};
     SwapchainCreateInfo swapchain_info{
-        .window_handle    = reinterpret_cast<uintptr_t>(&handle),
+        .surface          = _surface_info,
         .size             = _extent,
         .back_buffer_sz   = _frame_in_flight,
         .preferred_format = PF_R8G8B8A8_SRGB
@@ -959,22 +962,28 @@ void GuiCreateWindow(ImGuiViewport* _viewport) {
 
     int width, height;
     WindowContext::GetWindowSize(&handle, &width, &height);
+    viewport_data->surface_info = WindowContext::CreateSwapchainSurfaceInfo(handle);
     const uint2 extent{static_cast<uint>(_viewport->Size.x), static_cast<uint>(_viewport->Size.y)};
-    if (width == 0 || height == 0 || extent.x == 0 || extent.y == 0) {
+    if (!viewport_data->surface_info.IsValid() ||
+        width == 0 ||
+        height == 0 ||
+        extent.x == 0 ||
+        extent.y == 0) {
         return;
     }
 
     const auto render_resources = viewport_data->render_resources;
+    const auto surface_info     = viewport_data->surface_info;
     const auto viewport_index   = viewport_data->viewport_index;
     RunRenderThreadControlAndWait(
         [&rd_device,
          render_resources,
-         platform_window,
+         surface_info,
          extent,
          frame_in_flight = backend_data.frames_in_flight,
          viewport_index]() {
             CreateOrResizeViewportResources(
-                rd_device, render_resources, platform_window, extent, frame_in_flight, viewport_index
+                rd_device, render_resources, surface_info, extent, frame_in_flight, viewport_index
             );
         }
     );
@@ -1014,18 +1023,26 @@ void GuiSetWindowSize(ImGuiViewport* _viewport, ImVec2 _size) {
 
     ImGuiData* backend_data = GetImGuiBackendData();
     auto&      rd_device    = backend_data->render_backend->device;
+    if (!viewport_data->surface_info.IsValid()) {
+        Moer::WindowHandle handle{static_cast<Moer::WindowType*>(platform_window)};
+        viewport_data->surface_info = WindowContext::CreateSwapchainSurfaceInfo(handle);
+    }
+    if (!viewport_data->surface_info.IsValid()) {
+        return;
+    }
     const auto render_resources = viewport_data->render_resources;
+    const auto surface_info     = viewport_data->surface_info;
     const auto viewport_index   = viewport_data->viewport_index;
     const uint2 extent{static_cast<uint>(_size.x), static_cast<uint>(_size.y)};
     RunRenderThreadControlAndWait(
         [&rd_device,
          render_resources,
-         platform_window,
+         surface_info,
          extent,
          frame_in_flight = backend_data->frames_in_flight,
          viewport_index]() {
             CreateOrResizeViewportResources(
-                rd_device, render_resources, platform_window, extent, frame_in_flight, viewport_index
+                rd_device, render_resources, surface_info, extent, frame_in_flight, viewport_index
             );
         }
     );

--- a/source/runtime/render/renderer/raster/RasterRenderer.cpp
+++ b/source/runtime/render/renderer/raster/RasterRenderer.cpp
@@ -61,9 +61,10 @@ float GetElapsedTimeSeconds() {
 RasterRenderer::RasterRenderer(
     uint2                         initial_resolution,
     SharedPtr<EditorConfig>       config,
+    SwapchainSurfaceInfo          main_window_surface,
     RenderProfileCapture*         render_profile_capture
 ) :
-    Renderer(initial_resolution, config, render_profile_capture),
+    Renderer(initial_resolution, config, std::move(main_window_surface), render_profile_capture),
     scene_render_extent_tracker(initial_resolution) {
     ScopedLogTimer startup_timer("[Startup][RasterRenderer] RasterRenderer::Constructor() total");
 

--- a/source/runtime/render/renderer/raster/RasterRenderer.h
+++ b/source/runtime/render/renderer/raster/RasterRenderer.h
@@ -46,6 +46,7 @@ public:
     RasterRenderer(
         uint2                         initial_resolution,
         SharedPtr<EditorConfig>       config,
+        SwapchainSurfaceInfo          main_window_surface,
         RenderProfileCapture*         render_profile_capture
     );
 

--- a/source/runtime/render/renderer/raytracing/RaytracingRenderer.cpp
+++ b/source/runtime/render/renderer/raytracing/RaytracingRenderer.cpp
@@ -440,10 +440,11 @@ struct RaytracingRenderer::RuntimeState {
 RaytracingRenderer::RaytracingRenderer(
     uint2&                        resolution,
     const SharedPtr<EditorConfig> config,
+    SwapchainSurfaceInfo          main_window_surface,
     RuntimeAssets&                runtime_assets,
     RenderProfileCapture*         render_profile_capture
 ) :
-    Renderer(resolution, config, render_profile_capture),
+    Renderer(resolution, config, std::move(main_window_surface), render_profile_capture),
     runtime_assets(runtime_assets),
     scene_render_extent_tracker(resolution),
     runtime_state(MakeUnique<RuntimeState>(*this, scene_render_extent_tracker.GetActiveExtent())) {

--- a/source/runtime/render/renderer/raytracing/RaytracingRenderer.h
+++ b/source/runtime/render/renderer/raytracing/RaytracingRenderer.h
@@ -22,6 +22,7 @@ public:
     RaytracingRenderer(
         uint2&                        _resolution,
         const SharedPtr<EditorConfig> _config,
+        SwapchainSurfaceInfo          _main_window_surface,
         RuntimeAssets&                _runtime_assets,
         RenderProfileCapture*         _render_profile_capture
     );

--- a/source/runtime/render/rhi/RHIResource.h
+++ b/source/runtime/render/rhi/RHIResource.h
@@ -12,6 +12,7 @@
 #include "misc/Traits.h"
 #include "rhi/RHICommon.h"
 #include "rhi/RHIResourceInitilizer.h"
+#include "rhi/RHIWindowSurface.h"
 
 #include <atomic>
 #include <cassert>
@@ -1383,10 +1384,10 @@ struct RenderPassInfo {
 };
 
 struct SwapchainCreateInfo {
-    uintptr_t    window_handle;
-    Extent2D     size;
-    uint         back_buffer_sz   = 2;
-    EPixelFormat preferred_format = PF_R8G8B8A8_SRGB;
+    SwapchainSurfaceInfo surface;
+    Extent2D             size;
+    uint                 back_buffer_sz   = 2;
+    EPixelFormat         preferred_format = PF_R8G8B8A8_SRGB;
 };
 
 class RENDER_API Swapchain : public RHIResource {
@@ -1397,6 +1398,7 @@ public:
     virtual void Recreate(const SwapchainCreateInfo&) = 0;
     virtual ~Swapchain()                              = default;
     virtual void Sync()                               = 0;
+    [[nodiscard]] virtual WindowSurfaceIdentity GetCommittedSurfaceIdentity() const noexcept = 0;
 
 public:
     EPixelFormat format;

--- a/source/runtime/render/rhi/RHIWindowSurface.h
+++ b/source/runtime/render/rhi/RHIWindowSurface.h
@@ -1,0 +1,98 @@
+#pragma once
+
+#include "RenderAPI.h"
+#include "misc/STL.h"
+#include "rhi/RHICommon.h"
+
+#include <cstdint>
+
+namespace Moer::Render {
+
+enum class EWindowSystemType : uint8_t {
+    Unknown,
+    GLFW,
+};
+
+enum class EWindowSurfaceCreateStatus : uint8_t {
+    Success,
+    InvalidSource,
+    UnsupportedRHI,
+    NativeFailure,
+};
+
+struct WindowSurfaceCreateResult {
+    EWindowSurfaceCreateStatus status{EWindowSurfaceCreateStatus::InvalidSource};
+    int64_t                    native_error_code{0};
+
+    [[nodiscard]] bool Succeeded() const noexcept {
+        return status == EWindowSurfaceCreateStatus::Success;
+    }
+};
+
+struct WindowSurfaceIdentity {
+    EWindowSystemType window_system{EWindowSystemType::Unknown};
+    uintptr_t         window_system_handle{0};
+    uintptr_t         platform_window_handle{0};
+    uint64_t          generation{0};
+
+    [[nodiscard]] bool IsValid() const noexcept {
+        return window_system != EWindowSystemType::Unknown && window_system_handle != 0 && generation != 0;
+    }
+
+    friend bool operator==(const WindowSurfaceIdentity&, const WindowSurfaceIdentity&) = default;
+};
+
+// Immutable, non-owning lease over a native window. The platform window layer
+// owns native-window creation/destruction; swapchains retain this object only
+// to keep a stable identity and surface factory across render-thread work.
+class RENDER_API WindowSurfaceSource {
+public:
+    virtual ~WindowSurfaceSource() = default;
+
+    [[nodiscard]] virtual WindowSurfaceIdentity GetIdentity() const noexcept = 0;
+    [[nodiscard]] virtual WindowSurfaceCreateResult
+    CreateSurface(ERHIType rhi_type, void* instance, const void* allocation_callbacks, void* surface)
+        const noexcept = 0;
+};
+
+using WindowSurfaceSourceRef = SharedPtr<const WindowSurfaceSource>;
+
+struct SwapchainSurfaceInfo {
+    WindowSurfaceSourceRef source;
+
+    [[nodiscard]] WindowSurfaceIdentity GetIdentity() const noexcept {
+        return source ? source->GetIdentity() : WindowSurfaceIdentity{};
+    }
+
+    [[nodiscard]] bool IsValid() const noexcept {
+        return GetIdentity().IsValid();
+    }
+
+    [[nodiscard]] bool HasSameIdentity(const SwapchainSurfaceInfo& other) const noexcept {
+        return IsValid() && other.IsValid() && GetIdentity() == other.GetIdentity();
+    }
+};
+
+enum class ESwapchainSurfaceTransition : uint8_t {
+    Invalid,
+    Initialize,
+    Reuse,
+    Replace,
+};
+
+[[nodiscard]] inline ESwapchainSurfaceTransition ClassifySwapchainSurfaceTransition(
+    const SwapchainSurfaceInfo& committed,
+    bool                        has_committed_surface,
+    const SwapchainSurfaceInfo& incoming
+) noexcept {
+    if (!incoming.IsValid()) {
+        return ESwapchainSurfaceTransition::Invalid;
+    }
+    if (!has_committed_surface) {
+        return ESwapchainSurfaceTransition::Initialize;
+    }
+    return committed.HasSameIdentity(incoming) ? ESwapchainSurfaceTransition::Reuse :
+                                                 ESwapchainSurfaceTransition::Replace;
+}
+
+} // namespace Moer::Render

--- a/source/runtime/render/rhi/d3d12/D3D12Device.cpp
+++ b/source/runtime/render/rhi/d3d12/D3D12Device.cpp
@@ -760,48 +760,8 @@ D3D12Swapchain::D3D12Swapchain(D3D12Device& device, const SwapchainCreateInfo& i
 }
 
 void D3D12Swapchain::Recreate(const SwapchainCreateInfo& _info) {
+    (void)_info;
     FATAL("not implemented");
-    //if (width == _info.size.width && height == _info.size.height && window_handle == _info.window_handle && backbuffers.size() == _info.back_buffer_sz) {
-    //    return;
-    //}
-    //bool b_recreate = false;// false when create for first time
-    //if (window_handle != 0) {
-    //    ASSERT(window_handle == _info.window_handle);
-    //    b_recreate = true;
-    //}
-    //window_handle = _info.window_handle;
-    //width         = _info.size.width;
-    //height        = _info.size.height;
-    //backbuffers.resize(_info.back_buffer_sz);
-
-    //// note to sync before recreate
-    //DXGI_SWAP_CHAIN_DESC1 swapChainDesc;
-    //ZeroMemory(&swapChainDesc, sizeof(swapChainDesc));
-    //swapChainDesc.BufferCount        = backbuffers.size();
-    //swapChainDesc.Width              = width;
-    //swapChainDesc.Height             = height;
-    //swapChainDesc.Format             = desc.format;// TODO info.format
-    //swapChainDesc.BufferUsage        = DXGI_USAGE_RENDER_TARGET_OUTPUT;
-    //swapChainDesc.SwapEffect         = DXGI_SWAP_EFFECT_FLIP_DISCARD;
-    //swapChainDesc.SampleDesc.Count   = 1;
-    //swapChainDesc.SampleDesc.Quality = 0;
-    //swapChainDesc.Flags              = DXGI_SWAP_CHAIN_FLAG_ALLOW_TEARING;  // consider vsync?
-
-    //ComPtr<IDXGISwapChain1> swapchain1;
-    ////DX_CHECK_HRESULT(device->GetFactory()->CreateSwapChainForHwnd(
-    ////    m_device->GetGraphicsCommandContext().GetQueue(),// Swap chain needs the queue so that it can force a flush on it.
-    ////    windowHandle,
-    ////    &swapChainDesc,
-    ////    nullptr,
-    ////    nullptr,
-    ////    swapChain.put()));
-    //DX_CHECK_HRESULT(swapchain1.As(&swapchain));
-    //swapchain1 = nullptr;
-    //frame_index = swapchain->GetCurrentBackBufferIndex();
-
-    //DX_CHECK_HRESULT(device.GetFactory()->MakeWindowAssociation(reinterpret_cast<HWND>(window_handle), DXGI_MWA_NO_ALT_ENTER)); // maybe allow alt+enter to switch to full screen
-
-    //CreateSizeDependentResources();
 }
 
 void D3D12Swapchain::Sync() {

--- a/source/runtime/render/rhi/d3d12/D3D12Device.h
+++ b/source/runtime/render/rhi/d3d12/D3D12Device.h
@@ -1067,6 +1067,9 @@ public:
 
     void Recreate(const SwapchainCreateInfo&) override;
     void Sync() override;
+    [[nodiscard]] WindowSurfaceIdentity GetCommittedSurfaceIdentity() const noexcept override {
+        return {};
+    }
 
     uint GetBackbufferIndex() const {
         return frame_index;
@@ -1088,7 +1091,6 @@ private:
 
 private:
     D3D12Device&                  device;
-    uintptr_t                     window_handle;
     ComPtr<IDXGISwapChain3>       swapchain;
     Array<ComPtr<ID3D12Resource>> backbuffers;
     uint                          width;

--- a/source/runtime/render/rhi/vulkan/VulkanDevice.cpp
+++ b/source/runtime/render/rhi/vulkan/VulkanDevice.cpp
@@ -2474,17 +2474,4 @@ void VulkanDevice::LoadDefaultExtensions() {
     );
 #endif
 }
-
-// RHIViewportRef VulkanDevice::CreateViewport(const RHIViewportInitializer& _init) {
-//     VulkanSwapChain* swapchain = MoerNew(VulkanSwapChain)();
-//     uint32_t         width, height;
-//     VkSurfaceKHR     surface;
-//     Moer::WindowContext::CreateVulkanSurface(m_instance, _init.window_handle, nullptr, &surface);
-//     swapchain->Connect(m_instance, surface, this);
-//     swapchain->Init(&width, &height, _init.b_vsync);
-
-//     Moer::Render::VulkanRHIViewport* viewport = MoerNew(Moer::Render::VulkanRHIViewport)(swapchain, 2);
-
-//     return viewport;
-// }
 }; // namespace Moer::Render

--- a/source/runtime/render/rhi/vulkan/VulkanFault.h
+++ b/source/runtime/render/rhi/vulkan/VulkanFault.h
@@ -27,6 +27,8 @@ enum class EVulkanFaultOperation : uint8_t {
     CommandPoolReset,
     QueryPoolCreate,
     QueryPoolResults,
+    SwapchainSurfaceCreate,
+    SwapchainSurfaceQuery,
     SwapchainCreate,
     SwapchainGetImages,
     SwapchainSemaphoreCreate,
@@ -102,6 +104,10 @@ struct VulkanFaultRecord {
             return "QueryPoolCreate";
         case EVulkanFaultOperation::QueryPoolResults:
             return "QueryPoolResults";
+        case EVulkanFaultOperation::SwapchainSurfaceCreate:
+            return "SwapchainSurfaceCreate";
+        case EVulkanFaultOperation::SwapchainSurfaceQuery:
+            return "SwapchainSurfaceQuery";
         case EVulkanFaultOperation::SwapchainCreate:
             return "SwapchainCreate";
         case EVulkanFaultOperation::SwapchainGetImages:

--- a/source/runtime/render/rhi/vulkan/VulkanSwapChain.cpp
+++ b/source/runtime/render/rhi/vulkan/VulkanSwapChain.cpp
@@ -21,7 +21,6 @@
 #include "VulkanDevice.h"
 #include "VulkanMacroUtils.h"
 #include "VulkanRHIResource.h"
-#include "window/WindowContext.h"
 #include <atomic>
 #include <mutex>
 #include <thread>
@@ -31,31 +30,58 @@
 namespace VkUtil = Moer::RHI::Vulkan::Util;
 namespace Moer::Render {
 
-SwapChainSupportDetails QuerySwapChainSupport(VkPhysicalDevice _gpu, VkSurfaceKHR _surface) {
-    SwapChainSupportDetails details;
+namespace {
 
-    VK_CHECK_RESULT(vkGetPhysicalDeviceSurfaceCapabilitiesKHR(_gpu, _surface, &details.capabilities));
+class ScopedSurfaceCandidate {
+public:
+    explicit ScopedSurfaceCandidate(VkInstance instance) : instance(instance) {}
 
-    uint32_t format_count = 0;
-    VK_CHECK_RESULT(vkGetPhysicalDeviceSurfaceFormatsKHR(_gpu, _surface, &format_count, nullptr));
-    if (format_count > 0) {
-        details.formats.resize(format_count);
-        VK_CHECK_RESULT(
-            vkGetPhysicalDeviceSurfaceFormatsKHR(_gpu, _surface, &format_count, details.formats.data())
-        );
+    ~ScopedSurfaceCandidate() {
+        Reset();
     }
 
-    uint32_t present_mode_count = 0;
-    VK_CHECK_RESULT(vkGetPhysicalDeviceSurfacePresentModesKHR(_gpu, _surface, &present_mode_count, nullptr));
-    if (present_mode_count > 0) {
-        details.present_modes.resize(present_mode_count);
-        VK_CHECK_RESULT(vkGetPhysicalDeviceSurfacePresentModesKHR(
-            _gpu, _surface, &present_mode_count, details.present_modes.data()
-        ));
+    ScopedSurfaceCandidate(const ScopedSurfaceCandidate&)            = delete;
+    ScopedSurfaceCandidate& operator=(const ScopedSurfaceCandidate&) = delete;
+
+    void Adopt(VkSurfaceKHR new_surface) {
+        Reset();
+        surface = new_surface;
     }
 
-    return details;
+    [[nodiscard]] VkSurfaceKHR Release() noexcept {
+        const VkSurfaceKHR released = surface;
+        surface                     = VK_NULL_HANDLE;
+        return released;
+    }
+
+private:
+    void Reset() noexcept {
+        if (surface != VK_NULL_HANDLE) {
+            vkDestroySurfaceKHR(instance, surface, VK_NULL_HANDLE);
+            surface = VK_NULL_HANDLE;
+        }
+    }
+
+    VkInstance   instance{VK_NULL_HANDLE};
+    VkSurfaceKHR surface{VK_NULL_HANDLE};
+};
+
+VkCompositeAlphaFlagBitsKHR ChooseCompositeAlpha(const VkSurfaceCapabilitiesKHR& capabilities) {
+    constexpr VkCompositeAlphaFlagBitsKHR preferred_modes[] = {
+        VK_COMPOSITE_ALPHA_OPAQUE_BIT_KHR,
+        VK_COMPOSITE_ALPHA_PRE_MULTIPLIED_BIT_KHR,
+        VK_COMPOSITE_ALPHA_POST_MULTIPLIED_BIT_KHR,
+        VK_COMPOSITE_ALPHA_INHERIT_BIT_KHR,
+    };
+    for (const VkCompositeAlphaFlagBitsKHR mode : preferred_modes) {
+        if ((capabilities.supportedCompositeAlpha & mode) != 0) {
+            return mode;
+        }
+    }
+    return VK_COMPOSITE_ALPHA_OPAQUE_BIT_KHR;
 }
+
+} // namespace
 
 VkSurfaceFormatKHR ChooseSwapSurfaceFormat(
     const Moer::Array<VkSurfaceFormatKHR>& _available_formats,
@@ -64,6 +90,12 @@ VkSurfaceFormatKHR ChooseSwapSurfaceFormat(
 ) {
     VkFormat preferred_format = VulkanEnumTranslator::METoVKFormat(_preferred_format);
 
+    if (_available_formats.size() == 1 && _available_formats[0].format == VK_FORMAT_UNDEFINED) {
+        return {
+            .format     = preferred_format,
+            .colorSpace = _available_formats[0].colorSpace,
+        };
+    }
     for (const auto& format : _available_formats) {
         if (format.format == preferred_format && format.colorSpace == VK_COLOR_SPACE_SRGB_NONLINEAR_KHR) {
             return format;
@@ -102,6 +134,9 @@ ChooseSwapExtent(uint32_t* width, uint32_t* height, const VkSurfaceCapabilitiesK
         std::clamp(extent.width, _capabilities.minImageExtent.width, _capabilities.maxImageExtent.width);
     extent.height =
         std::clamp(extent.height, _capabilities.minImageExtent.height, _capabilities.maxImageExtent.height);
+
+    *width  = extent.width;
+    *height = extent.height;
 
     return extent;
 }
@@ -188,22 +223,90 @@ void VkSwapchain::CreateOrRecreate(const SwapchainCreateInfo& _info, bool _force
         return;
     }
 
+    const ESwapchainSurfaceTransition surface_transition =
+        ClassifySwapchainSurfaceTransition(surface_info, surface != VK_NULL_HANDLE, _info.surface);
+    if (surface_transition == ESwapchainSurfaceTransition::Invalid) {
+        LOG_ERROR("Vulkan swapchain creation requires a valid window surface source.");
+        device.TryLatchFirstFault(
+            VulkanOperationContext{.operation = EVulkanFaultOperation::SwapchainSurfaceCreate},
+            VK_ERROR_INITIALIZATION_FAILED,
+            false,
+            false,
+            true
+        );
+        return;
+    }
+
     Sync();
     if (device.IsFaulted()) {
         return;
     }
 
-    const VkSwapchainKHR old_sc     = handle;
-    VkInstance           instance   = device.GetInstance();
-    //create surface by window handle
-    assert(_info.window_handle != 0 && "Window handle is null when creating vulkan swapchain");
-    if (surface == VK_NULL_HANDLE) {
-        Moer::WindowContext::CreateVulkanSurface(
-            instance, (WindowHandle*)_info.window_handle, VK_NULL_HANDLE, &surface
+    const VkSwapchainKHR committed_old_sc       = handle;
+    VkSurfaceKHR         candidate_surface      = surface;
+    const bool           candidate_owns_surface = surface_transition != ESwapchainSurfaceTransition::Reuse;
+    ScopedSurfaceCandidate candidate_surface_guard(device.GetInstance());
+    if (candidate_owns_surface) {
+        candidate_surface                              = VK_NULL_HANDLE;
+        const WindowSurfaceCreateResult surface_result = _info.surface.source->CreateSurface(
+            ERHIType::Vulkan, device.GetInstance(), nullptr, &candidate_surface
         );
+        candidate_surface_guard.Adopt(candidate_surface);
+        if (!surface_result.Succeeded() || candidate_surface == VK_NULL_HANDLE) {
+            VkResult native_result = VK_ERROR_INITIALIZATION_FAILED;
+            if (surface_result.native_error_code != 0) {
+                native_result = static_cast<VkResult>(static_cast<int32_t>(surface_result.native_error_code));
+            }
+            LOG_ERROR(
+                "Window surface creation failed: status={}, native_result={}.",
+                static_cast<uint32_t>(surface_result.status),
+                static_cast<int32_t>(native_result)
+            );
+            device.TryLatchFirstFault(
+                VulkanOperationContext{.operation = EVulkanFaultOperation::SwapchainSurfaceCreate},
+                native_result,
+                false,
+                false,
+                true
+            );
+            return;
+        }
     }
-    //create swapchain
-    const auto         details = VkUtil::QuerySwapChainSupport(device.GetGpu(), surface);
+
+    const QueueFamilyIndices queue_families = device.GetQueueFamilyIndices();
+    if (!queue_families.graphics.has_value() || !queue_families.present.has_value()) {
+        LOG_ERROR("Vulkan swapchain creation requires initialized graphics and present queue families.");
+        device.TryLatchFirstFault(
+            VulkanOperationContext{.operation = EVulkanFaultOperation::SwapchainSurfaceQuery},
+            VK_ERROR_INITIALIZATION_FAILED,
+            false,
+            false,
+            true
+        );
+        return;
+    }
+
+    const VkUtil::SwapChainSupportQueryResult support_query = VkUtil::QuerySwapChainSupport(
+        device.GetGpu(), candidate_surface, queue_families.present.value()
+    );
+    if (!support_query.Succeeded()) {
+        LOG_ERROR(
+            "Swapchain surface query failed: status={}, native_result={}, present_queue_family={}.",
+            static_cast<uint32_t>(support_query.status),
+            static_cast<int32_t>(support_query.native_result),
+            queue_families.present.value()
+        );
+        device.TryLatchFirstFault(
+            VulkanOperationContext{.operation = EVulkanFaultOperation::SwapchainSurfaceQuery},
+            support_query.native_result,
+            false,
+            false,
+            true
+        );
+        return;
+    }
+
+    const auto&        details = support_query.details;
     VkSurfaceFormatKHR new_fmt = ChooseSwapSurfaceFormat(details.formats, _info.preferred_format);
     Extent2D           new_size{_info.size.x, _info.size.y};
     ChooseSwapExtent(&new_size.x, &new_size.y, details.capabilities);
@@ -211,32 +314,39 @@ void VkSwapchain::CreateOrRecreate(const SwapchainCreateInfo& _info, bool _force
         LOG_WARNING("Swapchain recreate skipped due to zero swapchain extent.");
         return;
     }
-    VkPresentModeKHR present_mode = ChooseSwapPresentMode(details.present_modes, false);
-    const EPixelFormat new_format = (EPixelFormat)new_fmt.format;
-    uint     queue_family_index   = device.GetQueueFamilyIndices().graphics.value();
-    uint32_t image_count          = details.capabilities.minImageCount + 1;
+    VkPresentModeKHR   present_mode = ChooseSwapPresentMode(details.present_modes, false);
+    const EPixelFormat new_format   = (EPixelFormat)new_fmt.format;
+    const uint32_t queue_family_indices[] = {
+        queue_families.graphics.value(),
+        queue_families.present.value(),
+    };
+    const bool use_concurrent_sharing = queue_family_indices[0] != queue_family_indices[1];
+    uint32_t   image_count            = details.capabilities.minImageCount + 1;
     if (details.capabilities.maxImageCount > 0 && image_count > details.capabilities.maxImageCount) {
         image_count = details.capabilities.maxImageCount;
     }
+    const VkSwapchainKHR old_sc_for_create =
+        surface_transition == ESwapchainSurfaceTransition::Reuse ? committed_old_sc : VK_NULL_HANDLE;
     VkSwapchainCreateInfoKHR create_info{
         .sType                 = VK_STRUCTURE_TYPE_SWAPCHAIN_CREATE_INFO_KHR,
         .pNext                 = nullptr,
         .flags                 = 0,
-        .surface               = surface,
+        .surface               = candidate_surface,
         .minImageCount         = image_count,
         .imageFormat           = new_fmt.format,
         .imageColorSpace       = new_fmt.colorSpace,
         .imageExtent           = {new_size.x, new_size.y},
         .imageArrayLayers      = 1,
         .imageUsage            = VK_IMAGE_USAGE_TRANSFER_DST_BIT,
-        .imageSharingMode      = VK_SHARING_MODE_EXCLUSIVE,
-        .queueFamilyIndexCount = 1,
-        .pQueueFamilyIndices   = &queue_family_index,
+        .imageSharingMode      = use_concurrent_sharing ? VK_SHARING_MODE_CONCURRENT :
+                                                         VK_SHARING_MODE_EXCLUSIVE,
+        .queueFamilyIndexCount = use_concurrent_sharing ? 2u : 0u,
+        .pQueueFamilyIndices   = use_concurrent_sharing ? queue_family_indices : nullptr,
         .preTransform          = details.capabilities.currentTransform,
-        .compositeAlpha        = VK_COMPOSITE_ALPHA_OPAQUE_BIT_KHR,
+        .compositeAlpha        = ChooseCompositeAlpha(details.capabilities),
         .presentMode           = present_mode,
         .clipped               = VK_TRUE,
-        .oldSwapchain          = old_sc
+        .oldSwapchain          = old_sc_for_create
     };
 
     auto fault_admission = device.AcquireFaultAdmission();
@@ -244,11 +354,12 @@ void VkSwapchain::CreateOrRecreate(const SwapchainCreateInfo& _info, bool _force
         return;
     }
 
-    VkSwapchainKHR          new_sc = VK_NULL_HANDLE;
-    Array<VkSemaphore>      new_render_finished_fences;
-    Array<VkFence>          new_in_flight_fences;
-    Array<VulkanTexture*>   new_swapchain_textures;
-    Array<TextureView>      new_swapchain_views;
+    VkSwapchainKHR        new_sc = VK_NULL_HANDLE;
+    Array<VkSemaphore>    new_render_finished_fences;
+    Array<VkFence>        new_in_flight_fences;
+    Array<VulkanTexture*> new_swapchain_textures;
+    Array<TextureView>    new_swapchain_views;
+    bool                  old_resources_retired = false;
 
     auto cleanup_new_resources = [&]() {
         for (auto* texture : new_swapchain_textures) {
@@ -272,7 +383,7 @@ void VkSwapchain::CreateOrRecreate(const SwapchainCreateInfo& _info, bool _force
         }
     };
     auto retire_old_resources = [&]() {
-        if (old_sc == VK_NULL_HANDLE) {
+        if (old_resources_retired || committed_old_sc == VK_NULL_HANDLE) {
             return;
         }
         for (auto* texture : swapchain_textures) {
@@ -284,8 +395,9 @@ void VkSwapchain::CreateOrRecreate(const SwapchainCreateInfo& _info, bool _force
             vkDestroySemaphore(device.GetDevice(), semaphore, VK_NULL_HANDLE);
         }
         render_finished_fences.clear();
-        vkDestroySwapchainKHR(device.GetDevice(), old_sc, VK_NULL_HANDLE);
+        vkDestroySwapchainKHR(device.GetDevice(), committed_old_sc, VK_NULL_HANDLE);
         handle = VK_NULL_HANDLE;
+        old_resources_retired = true;
     };
     auto check_device_result = [&](VkResult _result, EVulkanFaultOperation _operation) {
         if (_result == VK_SUCCESS && !device.IsFaulted()) {
@@ -307,7 +419,9 @@ void VkSwapchain::CreateOrRecreate(const SwapchainCreateInfo& _info, bool _force
 
     VkResult result = vkCreateSwapchainKHR(device.GetDevice(), &create_info, nullptr, &new_sc);
     // Passing a non-null oldSwapchain retires it even when creation fails.
-    retire_old_resources();
+    if (old_sc_for_create != VK_NULL_HANDLE) {
+        retire_old_resources();
+    }
     if (result != VK_SUCCESS) {
         new_sc = VK_NULL_HANDLE;
     }
@@ -431,21 +545,34 @@ void VkSwapchain::CreateOrRecreate(const SwapchainCreateInfo& _info, bool _force
         return;
     }
 
+    // A replacement surface uses oldSwapchain = VK_NULL_HANDLE, so the old
+    // presentation bundle remains valid until every candidate resource is
+    // ready. Commit retires the old bundle and surface only at this point.
+    retire_old_resources();
+
     if (recreate_fences) {
         for (VkFence fence : in_flight_fences) {
             vkDestroyFence(device.GetDevice(), fence, VK_NULL_HANDLE);
         }
     }
 
-    handle                    = new_sc;
-    new_sc                    = VK_NULL_HANDLE;
-    fmt                       = new_fmt;
-    size                      = new_size;
-    format                    = new_format;
-    max_frames_in_flight      = new_max_frames_in_flight;
-    render_finished_fences    = std::move(new_render_finished_fences);
-    swapchain_textures        = std::move(new_swapchain_textures);
-    swapchain_views           = std::move(new_swapchain_views);
+    if (candidate_owns_surface) {
+        const VkSurfaceKHR old_surface = surface;
+        surface                        = candidate_surface_guard.Release();
+        if (old_surface != VK_NULL_HANDLE) {
+            vkDestroySurfaceKHR(device.GetInstance(), old_surface, VK_NULL_HANDLE);
+        }
+    }
+    surface_info           = _info.surface;
+    handle                 = new_sc;
+    new_sc                 = VK_NULL_HANDLE;
+    fmt                    = new_fmt;
+    size                   = new_size;
+    format                 = new_format;
+    max_frames_in_flight   = new_max_frames_in_flight;
+    render_finished_fences = std::move(new_render_finished_fences);
+    swapchain_textures     = std::move(new_swapchain_textures);
+    swapchain_views        = std::move(new_swapchain_views);
     if (recreate_fences) {
         in_flight_fences = std::move(new_in_flight_fences);
     }
@@ -454,18 +581,30 @@ void VkSwapchain::CreateOrRecreate(const SwapchainCreateInfo& _info, bool _force
 VkSwapchain::~VkSwapchain() {
     Sync();
 
-    if (handle) {
+    for (VulkanTexture* texture : swapchain_textures) {
+        MoerDelete(texture);
+    }
+    swapchain_textures.clear();
+    swapchain_views.clear();
+    for (VkSemaphore semaphore : render_finished_fences) {
+        if (semaphore != VK_NULL_HANDLE) {
+            vkDestroySemaphore(device.GetDevice(), semaphore, VK_NULL_HANDLE);
+        }
+    }
+    render_finished_fences.clear();
+    for (VkFence fence : in_flight_fences) {
+        if (fence != VK_NULL_HANDLE) {
+            vkDestroyFence(device.GetDevice(), fence, VK_NULL_HANDLE);
+        }
+    }
+    in_flight_fences.clear();
+    if (handle != VK_NULL_HANDLE) {
         vkDestroySwapchainKHR(device.GetDevice(), handle, VK_NULL_HANDLE);
+        handle = VK_NULL_HANDLE;
     }
-    if (surface) {
+    if (surface != VK_NULL_HANDLE) {
         vkDestroySurfaceKHR(device.GetInstance(), surface, VK_NULL_HANDLE);
-    }
-    for (size_t i = 0; i < swapchain_textures.size(); ++i) {
-        MoerDelete(swapchain_textures[i]);
-        vkDestroySemaphore(device.GetDevice(), render_finished_fences[i], VK_NULL_HANDLE);
-    }
-    for (uint i = 0; i < in_flight_fences.size(); i++) {
-        vkDestroyFence(device.GetDevice(), in_flight_fences[i], VK_NULL_HANDLE);
+        surface = VK_NULL_HANDLE;
     }
 }
 VkSemaphore VkSwapchain::GetRenderFinishedFence(uint _image_index) {

--- a/source/runtime/render/rhi/vulkan/VulkanSwapChain.h
+++ b/source/runtime/render/rhi/vulkan/VulkanSwapChain.h
@@ -9,20 +9,12 @@
 #include "misc/CountableRef.h"
 #include "rhi/RHI.h"
 #include "rhi/RHIResource.h"
-#include "window/WindowContext.h"
-
-#include "VulkanPlatform.h"
 #include "VulkanFault.h"
+#include "VulkanPlatform.h"
 #include <atomic>
 #include <mutex>
 #include <thread>
 namespace Moer::Render {
-struct SwapChainSupportDetails {
-    VkSurfaceCapabilitiesKHR  capabilities;
-    Array<VkSurfaceFormatKHR> formats;
-    Array<VkPresentModeKHR>   present_modes;
-};
-SwapChainSupportDetails QuerySwapChainSupport(VkPhysicalDevice _gpu, VkSurfaceKHR _surface);
 VkSurfaceFormatKHR      ChooseSwapSurfaceFormat(
          const Array<VkSurfaceFormatKHR>& _available_formats,
          EPixelFormat                     _preferred_format,
@@ -63,6 +55,9 @@ public:
         uint64  _work_serial
     );
     void                                Sync() override;
+    [[nodiscard]] WindowSurfaceIdentity GetCommittedSurfaceIdentity() const noexcept override {
+        return surface_info.GetIdentity();
+    }
 
     bool               WaitFrameInFlight();
     bool               WaitFrameInFlight(uint64 _image_idx);
@@ -79,6 +74,7 @@ public:
 
     VkSwapchainKHR      handle  = VK_NULL_HANDLE;
     VkSurfaceKHR        surface = VK_NULL_HANDLE;
+    SwapchainSurfaceInfo surface_info{};
     class VulkanDevice& device;
     uint64              image_idx            = 0; // present queue timeline value
     uint                max_frames_in_flight = 3;

--- a/source/runtime/render/rhi/vulkan/VulkanUtil.cpp
+++ b/source/runtime/render/rhi/vulkan/VulkanUtil.cpp
@@ -4,36 +4,114 @@
 
 #include "misc/Crc32.h"
 
-#include "VulkanMacroUtils.h"
 #include "VulkanPlatform.h"
 #include "VulkanUtil.h"
 
 namespace Moer { namespace RHI { namespace Vulkan { namespace Util {
 
-SwapChainSupportDetails QuerySwapChainSupport(VkPhysicalDevice _gpu, VkSurfaceKHR _surface) {
-    SwapChainSupportDetails details;
+namespace {
 
-    VK_CHECK_RESULT(vkGetPhysicalDeviceSurfaceCapabilitiesKHR(_gpu, _surface, &details.capabilities));
+template<typename Value, typename Query>
+VkResult EnumerateSurfaceValues(Query&& query, Moer::Array<Value>& values) {
+    constexpr uint32_t max_attempts = 4;
+    for (uint32_t attempt = 0; attempt < max_attempts; ++attempt) {
+        uint32_t count  = 0;
+        VkResult result = query(&count, nullptr);
+        if (result != VK_SUCCESS && result != VK_INCOMPLETE) {
+            values.clear();
+            return result;
+        }
+        if (count == 0) {
+            values.clear();
+            return VK_SUCCESS;
+        }
 
-    uint32_t format_count = 0;
-    VK_CHECK_RESULT(vkGetPhysicalDeviceSurfaceFormatsKHR(_gpu, _surface, &format_count, nullptr));
-    if (format_count > 0) {
-        details.formats.resize(format_count);
-        VK_CHECK_RESULT(
-            vkGetPhysicalDeviceSurfaceFormatsKHR(_gpu, _surface, &format_count, details.formats.data())
-        );
+        values.resize(count);
+        uint32_t fetched_count = count;
+        result                 = query(&fetched_count, values.data());
+        if (result == VK_INCOMPLETE) {
+            continue;
+        }
+        if (result != VK_SUCCESS) {
+            values.clear();
+            return result;
+        }
+        values.resize(fetched_count);
+        return VK_SUCCESS;
+    }
+    values.clear();
+    return VK_INCOMPLETE;
+}
+
+} // namespace
+
+SwapChainSupportQueryResult
+QuerySwapChainSupport(VkPhysicalDevice _gpu, VkSurfaceKHR _surface, uint32_t _present_queue_family) {
+    SwapChainSupportQueryResult query_result{};
+
+    VkBool32 present_supported = VK_FALSE;
+    VkResult result            = vkGetPhysicalDeviceSurfaceSupportKHR(
+        _gpu, _present_queue_family, _surface, &present_supported
+    );
+    if (result != VK_SUCCESS) {
+        query_result.native_result = result;
+        return query_result;
+    }
+    if (present_supported != VK_TRUE) {
+        query_result.status        = ESwapChainSupportQueryStatus::PresentUnsupported;
+        query_result.native_result = VK_ERROR_INITIALIZATION_FAILED;
+        return query_result;
     }
 
-    uint32_t present_mode_count = 0;
-    VK_CHECK_RESULT(vkGetPhysicalDeviceSurfacePresentModesKHR(_gpu, _surface, &present_mode_count, nullptr));
-    if (present_mode_count > 0) {
-        details.present_modes.resize(present_mode_count);
-        VK_CHECK_RESULT(vkGetPhysicalDeviceSurfacePresentModesKHR(
-            _gpu, _surface, &present_mode_count, details.present_modes.data()
-        ));
+    result = vkGetPhysicalDeviceSurfaceCapabilitiesKHR(
+        _gpu, _surface, &query_result.details.capabilities
+    );
+    if (result != VK_SUCCESS) {
+        query_result.native_result = result;
+        return query_result;
     }
 
-    return details;
+    result = EnumerateSurfaceValues<VkSurfaceFormatKHR>(
+        [_gpu, _surface](uint32_t* count, VkSurfaceFormatKHR* values) {
+            return vkGetPhysicalDeviceSurfaceFormatsKHR(_gpu, _surface, count, values);
+        },
+        query_result.details.formats
+    );
+    if (result != VK_SUCCESS) {
+        query_result.status = result == VK_INCOMPLETE ?
+                                  ESwapChainSupportQueryStatus::EnumerationIncomplete :
+                                  ESwapChainSupportQueryStatus::NativeFailure;
+        query_result.native_result = result;
+        return query_result;
+    }
+    if (query_result.details.formats.empty()) {
+        query_result.status        = ESwapChainSupportQueryStatus::NoSurfaceFormats;
+        query_result.native_result = VK_ERROR_FORMAT_NOT_SUPPORTED;
+        return query_result;
+    }
+
+    result = EnumerateSurfaceValues<VkPresentModeKHR>(
+        [_gpu, _surface](uint32_t* count, VkPresentModeKHR* values) {
+            return vkGetPhysicalDeviceSurfacePresentModesKHR(_gpu, _surface, count, values);
+        },
+        query_result.details.present_modes
+    );
+    if (result != VK_SUCCESS) {
+        query_result.status = result == VK_INCOMPLETE ?
+                                  ESwapChainSupportQueryStatus::EnumerationIncomplete :
+                                  ESwapChainSupportQueryStatus::NativeFailure;
+        query_result.native_result = result;
+        return query_result;
+    }
+    if (query_result.details.present_modes.empty()) {
+        query_result.status        = ESwapChainSupportQueryStatus::NoPresentModes;
+        query_result.native_result = VK_ERROR_INITIALIZATION_FAILED;
+        return query_result;
+    }
+
+    query_result.status        = ESwapChainSupportQueryStatus::Success;
+    query_result.native_result = VK_SUCCESS;
+    return query_result;
 }
 
 uint32_t MemCrc32(const void* data, size_t data_size) {

--- a/source/runtime/render/rhi/vulkan/VulkanUtil.h
+++ b/source/runtime/render/rhi/vulkan/VulkanUtil.h
@@ -11,12 +11,34 @@
 
 namespace Moer { namespace RHI { namespace Vulkan { namespace Util {
 struct SwapChainSupportDetails {
-    VkSurfaceCapabilitiesKHR        capabilities;
+    VkSurfaceCapabilitiesKHR        capabilities{};
     Moer::Array<VkSurfaceFormatKHR> formats;
     Moer::Array<VkPresentModeKHR>   present_modes;
 };
 
-SwapChainSupportDetails QuerySwapChainSupport(VkPhysicalDevice _gpu, VkSurfaceKHR _surface);
+enum class ESwapChainSupportQueryStatus : uint8_t {
+    Success,
+    NativeFailure,
+    PresentUnsupported,
+    NoSurfaceFormats,
+    NoPresentModes,
+    EnumerationIncomplete,
+};
+
+struct SwapChainSupportQueryResult {
+    ESwapChainSupportQueryStatus status{ESwapChainSupportQueryStatus::NativeFailure};
+    VkResult                     native_result{VK_ERROR_INITIALIZATION_FAILED};
+    SwapChainSupportDetails      details{};
+
+    [[nodiscard]] bool Succeeded() const noexcept {
+        return status == ESwapChainSupportQueryStatus::Success && native_result == VK_SUCCESS;
+    }
+};
+
+// Vulkan backend-internal query contract. This is intentionally not exported
+// from moer_render; external RHI consumers use SwapchainCreateInfo instead.
+SwapChainSupportQueryResult
+QuerySwapChainSupport(VkPhysicalDevice _gpu, VkSurfaceKHR _surface, uint32_t _present_queue_family);
 
 uint32_t MemCrc32(const void* data, size_t data_size);
 }}}} // namespace Moer::RHI::Vulkan::Util

--- a/source/runtime/render/rhi/vulkan/platform/VulkanGenericPlatform.h
+++ b/source/runtime/render/rhi/vulkan/platform/VulkanGenericPlatform.h
@@ -16,8 +16,6 @@ class VulkanGenericPlatform {
 public:
     static void GetInstanceLayers(Moer::Array<std::string>& _layers) {}
     static void GetDeviceLayers(Moer::Array<std::string>& _layers) {}
-    // create the platform-specific surface object - required
-    static VkSurfaceKHR CreateSurface();
     // Allow the platform code to restrict the device features
     static void RestrictEnabledPhysicalDeviceFeatures(VulkanDeviceFeatures* _gpu_features);
 };

--- a/source/runtime/render/rhi/vulkan/platform/windows/VulkanWindowsPlatform.cpp
+++ b/source/runtime/render/rhi/vulkan/platform/windows/VulkanWindowsPlatform.cpp
@@ -2,24 +2,11 @@
 // Created by 74535 on 2023/10/1.
 //
 #include "VulkanWindowsPlatform.h"
-#include "../../VulkanMacroUtils.h"
 
 namespace Moer::Render {
 void VulkanWindowsPlatform::GetInstanceLayers(TLayerArray& _layers) {
 #ifndef NDEBUG
     _layers.emplace_back("VK_LAYER_KHRONOS_validation");
 #endif
-}
-
-void VulkanWindowsPlatform::CreateSurface(
-    void*         _window_handle,
-    VkInstance    _instance,
-    VkSurfaceKHR& _surface
-) {
-    VkWin32SurfaceCreateInfoKHR surface_create_info{};
-    surface_create_info.sType = VK_STRUCTURE_TYPE_WIN32_SURFACE_CREATE_INFO_KHR;
-    //surface_create_info.hinstance = GetModuleHandle(nullptr);
-    surface_create_info.hwnd = (HWND)_window_handle;
-    VK_CHECK_RESULT(vkCreateWin32SurfaceKHR(_instance, &surface_create_info, nullptr, &_surface));
 }
 } // namespace Moer::Render

--- a/source/runtime/render/rhi/vulkan/platform/windows/VulkanWindowsPlatform.h
+++ b/source/runtime/render/rhi/vulkan/platform/windows/VulkanWindowsPlatform.h
@@ -13,8 +13,6 @@ class VulkanWindowsPlatform : public VulkanGenericPlatform {
 public:
     static void GetInstanceLayers(TLayerArray& _layers);
     static void GetDeviceLayers(TLayerArray& _layers) {}
-    // create the platform-specific surface object - required
-    static void CreateSurface(void* _window_handle, VkInstance _instance, VkSurfaceKHR& _surface);
 };
 
 using VulkanPlatform = VulkanWindowsPlatform;

--- a/source/runtime/render/window/WindowContext.cpp
+++ b/source/runtime/render/window/WindowContext.cpp
@@ -35,10 +35,6 @@ bool WindowContext::ShouldClose(WindowHandle* window) {
     return WindowImpl::GetInstance().ShouldClose(window);
 };
 
-void* WindowContext::GetNativeWindow(WindowHandle* window) {
-    return WindowImpl::GetInstance().GetNativeWindow(window);
-};
-
 WindowHandle* WindowContext::GetMainWindow() {
     return &WindowImpl::GetInstance().main_window_handle;
 };
@@ -47,14 +43,9 @@ void WindowContext::ShowMainWindow() {
     WindowImpl::GetInstance().ShowMainWindow();
 }
 
-void WindowContext::CreateVulkanSurface(
-    void*         instance,
-    WindowHandle* window,
-    void*         allocation_callback,
-    void*         surface
-) {
-    WindowImpl::GetInstance().CreateVulkanSurface(instance, window, allocation_callback, surface);
-};
+Render::SwapchainSurfaceInfo WindowContext::CreateSwapchainSurfaceInfo(const WindowHandle& window) {
+    return WindowImpl::GetInstance().CreateSwapchainSurfaceInfo(window);
+}
 
 void WindowContext::RegisterOnCharFunc(WindowType* handle, OnCharFunc func) {
     WindowImpl::GetInstance().RegisterOnCharFunc(handle, func);

--- a/source/runtime/render/window/WindowContext.h
+++ b/source/runtime/render/window/WindowContext.h
@@ -3,7 +3,7 @@
 
 #include "RenderAPI.h"
 
-#include "rhi/RHI.h"
+#include "rhi/RHIWindowSurface.h"
 #include <functional>
 
 namespace Moer {
@@ -35,31 +35,22 @@ struct RENDER_API WindowHandle {
     WindowType* window{nullptr};
 };
 
-struct RENDER_API GuiWindowInitInfo {
-    WindowType* window;
-    bool        b_install_callbacks = true;
-    ERHIType    rhi_type;
-};
-
 struct RENDER_API SurfaceInitInfo {
     SurfaceInitInfo(
-        const ERHIType&    _rhi_type,
         uint32_t           _width,
         uint32_t           _height,
         const std::string& _title,
         bool               _full_screen,
         bool               _visible = true
     ) :
-        rhi_type(_rhi_type),
         width(_width),
         height(_height),
         title(_title),
         b_fullscreen(_full_screen),
         b_visible(_visible) {}
 
-    SurfaceInitInfo() : SurfaceInitInfo(ERHIType::Vulkan, 1920, 1080, "untitled", false) {}
+    SurfaceInitInfo() : SurfaceInitInfo(1920, 1080, "untitled", false) {}
 
-    ERHIType    rhi_type;
     int         width{1280};
     int         height{720};
     std::string title{"MoerEngine"};
@@ -86,11 +77,9 @@ public:
     static void          SetTitle(WindowHandle*, const char* newTitle);
     static void          RequestClose(WindowHandle*);
     static bool          ShouldClose(WindowHandle*);
-    //for dx12 win32 window
-    static void* GetNativeWindow(WindowHandle*);
-    //for vulkan surface creation
-    static void
-    CreateVulkanSurface(void* instance, WindowHandle* window, void* allocation_callback, void* surface);
+    // Captures an immutable native-window identity and surface factory. This
+    // is a Game Thread operation; the returned value can be retained by RT/RHI.
+    static Render::SwapchainSurfaceInfo CreateSwapchainSurfaceInfo(const WindowHandle&);
 
     typedef std::function<void(unsigned int)>                                OnCharFunc;
     typedef std::function<void(int entered)>                                 OnCursorEnterFunc;

--- a/source/runtime/render/window/WindowContextImpl.h
+++ b/source/runtime/render/window/WindowContextImpl.h
@@ -7,12 +7,7 @@ class WindowImpl {
 
 public:
     virtual ~WindowImpl() {}
-    // virtual void  SetFocusMode(bool _focused)                          = 0;
-    // virtual void  GetWindowSize(int32_t* width, int32_t* height) const = 0;
-    // virtual void  SetTitle(const char* _new_title)                     = 0;
-    // virtual bool  ShouldClose() const                                  = 0;
     virtual void PollEvents() const = 0;
-    // virtual void* GetNativeWindow() const                              = 0;
     virtual void ShutDown() = 0;
     virtual void Tick()     = 0;
 
@@ -24,7 +19,7 @@ public:
     virtual bool ShouldClose(WindowHandle*) const                                    = 0;
     virtual void ShowMainWindow()                                                    = 0;
 
-    virtual void* GetNativeWindow(WindowHandle*) const = 0;
+    virtual Render::SwapchainSurfaceInfo CreateSwapchainSurfaceInfo(const WindowHandle&) const = 0;
 
     static void OnCharCallback(WindowType* window, unsigned int codepoint);
     static void OnCursorEnterCallback(WindowType* window, int entered);
@@ -55,9 +50,7 @@ protected:
     virtual void       OnWindowContentScaleCallbackImpl(WindowType* window, float xscale, float yscale)   = 0;
     virtual void       OnWindowPosCallbackImpl(WindowType* window, int xpos, int ypos)                    = 0;
     virtual void       OnWindowSizeCallbackImpl(WindowType* window, int width, int height)                = 0;
-    virtual void       OnWindowFocusCallbackImpl(WindowType* window, int focused)                         = 0;
-    virtual void
-    CreateVulkanSurface(void* instance, WindowHandle* window, void* allocation_callback, void* surface) = 0;
+    virtual void       OnWindowFocusCallbackImpl(WindowType* window, int focused) = 0;
 
     void OnChar(WindowType* _type, unsigned int codepoint);
     void OnCursorEnter(WindowType* _type, int entered);

--- a/source/runtime/render/window/glfw/GLFWWindowImpl.cpp
+++ b/source/runtime/render/window/glfw/GLFWWindowImpl.cpp
@@ -4,11 +4,9 @@
 #include "misc/MMemory.h"
 #include "platform/Platform.h"
 #include "rhi/RHI.h"
+#include "rhi/vulkan/VulkanCommon.h"
 #include "window/WindowContext.h"
 
-// 1： define vulkan ahead of glfw
-#include "rhi/vulkan/VulkanPlatform.h"
-// 2
 #include "GLFW/glfw3.h"
 
 #include "IconsFontAwesome6.h"
@@ -22,11 +20,113 @@
 #include <imgui.h>
 
 #include "log/LogSystem.h"
+#include <exception>
+#include <stdexcept>
 #include <string.h>
 
 #include "window/WindowInput.h"
 
 namespace Moer {
+
+struct GLFWWindowSurfaceLeaseState {
+    std::atomic_uint32_t live_surface_leases{0};
+};
+
+namespace {
+
+class GLFWInitTransaction {
+public:
+    explicit GLFWInitTransaction(WindowType*& published_window) : published_window(published_window) {}
+
+    ~GLFWInitTransaction() {
+        if (committed) {
+            return;
+        }
+        if (window != nullptr) {
+            glfwDestroyWindow(window);
+        }
+        published_window = nullptr;
+        glfwTerminate();
+    }
+
+    GLFWInitTransaction(const GLFWInitTransaction&)            = delete;
+    GLFWInitTransaction& operator=(const GLFWInitTransaction&) = delete;
+
+    void Adopt(GLFWwindow* new_window) noexcept {
+        window = new_window;
+    }
+
+    void Commit() noexcept {
+        committed = true;
+    }
+
+private:
+    WindowType*& published_window;
+    GLFWwindow*  window{nullptr};
+    bool         committed{false};
+};
+
+class GLFWWindowSurfaceSource final : public Render::WindowSurfaceSource {
+public:
+    GLFWWindowSurfaceSource(
+        GLFWwindow*                            window,
+        uintptr_t                              platform_window_handle,
+        uint64_t                               generation,
+        SharedPtr<GLFWWindowSurfaceLeaseState> lease_state
+    ) :
+        identity{
+            .window_system          = Render::EWindowSystemType::GLFW,
+            .window_system_handle   = reinterpret_cast<uintptr_t>(window),
+            .platform_window_handle = platform_window_handle,
+            .generation             = generation,
+        },
+        window(window),
+        lease_state(std::move(lease_state)) {
+        this->lease_state->live_surface_leases.fetch_add(1, std::memory_order_relaxed);
+    }
+
+    ~GLFWWindowSurfaceSource() override {
+        lease_state->live_surface_leases.fetch_sub(1, std::memory_order_release);
+    }
+
+    [[nodiscard]] Render::WindowSurfaceIdentity GetIdentity() const noexcept override {
+        return identity;
+    }
+
+    [[nodiscard]] Render::WindowSurfaceCreateResult
+    CreateSurface(ERHIType rhi_type, void* instance, const void* allocation_callbacks, void* surface)
+        const noexcept override {
+        if (rhi_type != ERHIType::Vulkan) {
+            return {
+                .status = Render::EWindowSurfaceCreateStatus::UnsupportedRHI,
+            };
+        }
+        if (window == nullptr || instance == nullptr || surface == nullptr) {
+            return {
+                .status = Render::EWindowSurfaceCreateStatus::InvalidSource,
+            };
+        }
+
+        const VkResult result = glfwCreateWindowSurface(
+            static_cast<VkInstance>(instance),
+            window,
+            static_cast<const VkAllocationCallbacks*>(allocation_callbacks),
+            static_cast<VkSurfaceKHR*>(surface)
+        );
+        return {
+            .status            = result == VK_SUCCESS ? Render::EWindowSurfaceCreateStatus::Success :
+                                                        Render::EWindowSurfaceCreateStatus::NativeFailure,
+            .native_error_code = static_cast<int64_t>(result),
+        };
+    }
+
+private:
+    Render::WindowSurfaceIdentity          identity{};
+    GLFWwindow*                            window{nullptr};
+    SharedPtr<GLFWWindowSurfaceLeaseState> lease_state;
+};
+
+} // namespace
 
 //------------------------call back functions---------------------------
 static void UpdateKeyStateWithActionIsPress(bool& key_state, int action);                   // tool func
@@ -38,7 +138,7 @@ static void FrameBufferSizeCallbackFunc(GLFWwindow* window, int width, int heigh
 static void ScrollCallbackFunc(GLFWwindow* window, double xoffset, double yoffset);
 static void MouseButtonCallbackFunc(GLFWwindow* window, int button, int action, int mode);
 
-GLFWWindowImpl::GLFWWindowImpl() {}
+GLFWWindowImpl::GLFWWindowImpl() : surface_lease_state(MakeShared<GLFWWindowSurfaceLeaseState>()) {}
 GLFWWindowImpl::~GLFWWindowImpl() {}
 void GLFWWindowImpl::PollEvents() const {
     glfwPollEvents();
@@ -46,18 +146,12 @@ void GLFWWindowImpl::PollEvents() const {
 
 void GLFWWindowImpl::Init(const SurfaceInitInfo& info) {
     if (!glfwInit()) {
-        //error log and quit
         LOG_ERROR("Window init fail.");
-        assert(0 && "Window init fail.");
+        throw std::runtime_error("GLFW initialization failed");
     }
+    GLFWInitTransaction init_transaction(main_window_handle.window);
+
     glfwWindowHint(GLFW_CLIENT_API, GLFW_NO_API);
-    if (info.rhi_type == ERHIType::D3D12) {
-        InitD3D12();
-    } else if (info.rhi_type == ERHIType::Vulkan) {
-        InitVulkan();
-    } else {
-        assert(0 && "Unknown RHI type, code error.");
-    }
     glfwWindowHint(GLFW_VISIBLE, info.b_visible ? GLFW_TRUE : GLFW_FALSE);
 
     int          width   = info.width;
@@ -69,7 +163,13 @@ void GLFWWindowImpl::Init(const SurfaceInitInfo& info) {
     if (info.b_fullscreen) {
         // 全屏模式
         GLFWmonitor*       fullscreen_monitor = glfwGetPrimaryMonitor();
+        if (fullscreen_monitor == nullptr) {
+            throw std::runtime_error("No primary monitor is available for fullscreen window creation");
+        }
         const GLFWvidmode* mode               = glfwGetVideoMode(fullscreen_monitor);
+        if (mode == nullptr) {
+            throw std::runtime_error("Failed to query the primary monitor video mode");
+        }
         width                                 = mode->width;
         height                                = mode->height;
 
@@ -86,18 +186,28 @@ void GLFWWindowImpl::Init(const SurfaceInitInfo& info) {
     }
 
     GLFWwindow* window = glfwCreateWindow(width, height, info.title.c_str(), monitor, nullptr);
+    init_transaction.Adopt(window);
     // Window hints persist across creations. Restore the normal default so editor platform
     // windows are not accidentally created hidden after a hidden main-window bootstrap.
     glfwWindowHint(GLFW_VISIBLE, GLFW_TRUE);
+    if (window == nullptr) {
+        const char* description = nullptr;
+        const int   error       = glfwGetError(&description);
+        LOG_ERROR(
+            "Failed to create GLFW window: error={}, description={}",
+            error,
+            description ? description : "<none>"
+        );
+        throw std::runtime_error("Failed to create GLFW window");
+    }
 
     glfwSetWindowUserPointer(window, this);
 
     this->main_window_handle.window = window;
 
-    GuiWindowInitInfo window_info{.window = window, .b_install_callbacks = true, .rhi_type = info.rhi_type};
-
     //register engine io callbacks MARK.. remains problems
     InstallInterface(&main_window_handle);
+    init_transaction.Commit();
 
     //install imgui io callbacks
     // GuiInit(window_info);
@@ -262,8 +372,28 @@ void GLFWWindowImpl::Tick() {
     TickCursorState();
 }
 void GLFWWindowImpl::ShutDown() {
-    // GuiShutDown();
-    glfwDestroyWindow((GLFWwindow*)main_window_handle.window);
+    auto* window = static_cast<GLFWwindow*>(main_window_handle.window);
+    if (window == nullptr) {
+        return;
+    }
+
+    const uint32_t live_surface_leases =
+        surface_lease_state->live_surface_leases.load(std::memory_order_acquire);
+    if (live_surface_leases != 0) {
+        LOG_ERROR(
+            "Refusing to destroy the GLFW window while {} swapchain surface source lease(s) remain.",
+            live_surface_leases
+        );
+        std::terminate();
+    }
+
+    {
+        std::scoped_lock lock(surface_source_mutex);
+        surface_sources.clear();
+    }
+    glfwDestroyWindow(window);
+    main_window_handle.window = nullptr;
+    glfwTerminate();
 }
 
 void GLFWWindowImpl::TickCursorState() {
@@ -311,33 +441,6 @@ void GLFWWindowImpl::SetCursorNormal() {
     WindowInput::Get().cursor_delta_y   = 0.0f;
 }
 
-void GLFWWindowImpl::InitVulkan() {
-    if (!glfwVulkanSupported()) {
-        LOG_ERROR("Vulkan not supported by Winodw System");
-        exit(-1);
-    }
-}
-void GLFWWindowImpl::InitD3D12() {
-#if PLATFORM_WINDOWS
-
-#endif
-}
-// void GLFWWindowImpl::CreateVulkanSurface(void* instance, WindowType* window, void* allocation_callback, void* surface) {
-//     glfwCreateWindowSurface((VkInstance)instance, (GLFWwindow*)window, (const VkAllocationCallbacks*)allocation_callback, (VkSurfaceKHR*)surface);
-// }
-void GLFWWindowImpl::CreateVulkanSurface(
-    void*         instance,
-    WindowHandle* window,
-    void*         allocation_callback,
-    void*         surface
-) {
-    glfwCreateWindowSurface(
-        (VkInstance)instance,
-        (GLFWwindow*)window->window,
-        (const VkAllocationCallbacks*)allocation_callback,
-        (VkSurfaceKHR*)surface
-    );
-}
 void GLFWWindowImpl::SetFocusMode(WindowHandle* _window, bool _focused) {
     glfwSetInputMode(
         (GLFWwindow*)_window->window, GLFW_CURSOR, focused ? GLFW_CURSOR_DISABLED : GLFW_CURSOR_NORMAL
@@ -402,11 +505,33 @@ void GLFWWindowImpl::ShowMainWindow() {
     }
     glfwShowWindow(window);
 }
-void* GLFWWindowImpl::GetNativeWindow(WindowHandle* _window) const {
+Render::SwapchainSurfaceInfo GLFWWindowImpl::CreateSwapchainSurfaceInfo(const WindowHandle& window) const {
+    if (!IsCurrentlyGameThread()) {
+        LOG_ERROR("Window surface sources may only be captured on the Game Thread.");
+        return {};
+    }
+    auto* glfw_window = static_cast<GLFWwindow*>(window.window);
+    if (glfw_window == nullptr) {
+        return {};
+    }
+
+    std::scoped_lock lock(surface_source_mutex);
+    auto&            weak_source = surface_sources[window.window];
+    if (auto source = weak_source.lock()) {
+        return {.source = std::move(source)};
+    }
+
+    uintptr_t platform_window_handle = 0;
 #if PLATFORM_WINDOWS
-    return glfwGetWin32Window((GLFWwindow*)_window->window);
+    platform_window_handle = reinterpret_cast<uintptr_t>(glfwGetWin32Window(glfw_window));
 #endif
-    return nullptr;
+
+    const uint64_t generation = next_surface_generation.fetch_add(1, std::memory_order_relaxed);
+    auto           source     = MakeShared<GLFWWindowSurfaceSource>(
+        glfw_window, platform_window_handle, generation, surface_lease_state
+    );
+    weak_source = source;
+    return {.source = std::move(source)};
 }
 
 void GLFWWindowImpl::OnCursorEnterCallbackImpl(WindowType* window, int entered) {

--- a/source/runtime/render/window/glfw/GLFWWindowImpl.h
+++ b/source/runtime/render/window/glfw/GLFWWindowImpl.h
@@ -4,7 +4,12 @@
 #include "../WindowContextImpl.h"
 #include "window/WindowContext.h"
 
+#include <atomic>
+#include <mutex>
+
 namespace Moer {
+struct GLFWWindowSurfaceLeaseState;
+
 class GLFWWindowImpl final : public WindowImpl {
     friend WindowImpl;
 
@@ -12,9 +17,6 @@ public:
     virtual ~GLFWWindowImpl();
 
     virtual void PollEvents() const override;
-    virtual void
-    CreateVulkanSurface(void* instance, WindowHandle* window, void* allocation_callback, void* surface)
-        override;
     virtual void Tick() override;
     virtual void ShutDown() override;
 
@@ -25,7 +27,7 @@ public:
     virtual void  RequestClose(WindowHandle*) override;
     virtual bool  ShouldClose(WindowHandle*) const override;
     virtual void  ShowMainWindow() override;
-    virtual void* GetNativeWindow(WindowHandle*) const override;
+    virtual Render::SwapchainSurfaceInfo CreateSwapchainSurfaceInfo(const WindowHandle&) const override;
 
 private:
     void TickCursorState();
@@ -51,12 +53,14 @@ private:
     void InstallInterface(WindowHandle* _handle);
 
 private:
-    void InitVulkan();
-    void InitD3D12();
-
     bool m_deferred_fullscreen        = false;
     int  m_deferred_fullscreen_width  = 0;
     int  m_deferred_fullscreen_height = 0;
+
+    mutable std::mutex                                                                  surface_source_mutex;
+    mutable UnorderedMap<WindowType*, std::weak_ptr<const Render::WindowSurfaceSource>> surface_sources;
+    mutable std::atomic_uint64_t                                                        next_surface_generation{1};
+    SharedPtr<GLFWWindowSurfaceLeaseState>                                              surface_lease_state;
 };
 } // namespace Moer
 #endif

--- a/source/test/CMakeLists.txt
+++ b/source/test/CMakeLists.txt
@@ -157,6 +157,15 @@ target_link_libraries(${test_target}
 set_target_properties(${test_target} PROPERTIES FOLDER ${moer_test_folder})
 add_test(NAME SceneRenderExtentContract COMMAND $<TARGET_FILE:${test_target}>)
 
+set(test_target TestWindowSurfaceSource)
+add_executable(${test_target} "WindowSurfaceSourceContractTest.cpp")
+target_link_libraries(${test_target}
+    PRIVATE Moer::Render
+)
+set_target_properties(${test_target} PROPERTIES FOLDER ${moer_test_folder})
+add_test(NAME WindowSurfaceSourceContract COMMAND $<TARGET_FILE:${test_target}>)
+set_tests_properties(WindowSurfaceSourceContract PROPERTIES TIMEOUT 60)
+
 set(test_target TestRHICmdReorderer)
 add_executable(${test_target} "RHICmdReordererTest.cpp")
 target_link_libraries(${test_target}

--- a/source/test/RHIParallelRecordVulkanTest.cpp
+++ b/source/test/RHIParallelRecordVulkanTest.cpp
@@ -276,6 +276,9 @@ public:
 
     void Recreate(const SwapchainCreateInfo&) override {}
     void Sync() override {}
+    [[nodiscard]] WindowSurfaceIdentity GetCommittedSurfaceIdentity() const noexcept override {
+        return {};
+    }
 };
 
 class SourceSubmissionCapture final {

--- a/source/test/VulkanHeaderContractTest.cpp
+++ b/source/test/VulkanHeaderContractTest.cpp
@@ -1,12 +1,16 @@
 // This order is intentional: it reproduces the conflict that occurs when
 // vulkan_core.h declares function prototypes before Volk declares its entry
 // point variables.
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
 #include <vulkan/vulkan_core.h>
 
 #ifndef VK_NO_PROTOTYPES
 #error "Moer::Render must propagate VK_NO_PROTOTYPES to every consumer."
 #endif
 
+#include "rhi/RHIWindowSurface.h"
 #include "rhi/vulkan/VulkanDebugCallback.h"
 #include "rhi/vulkan/VulkanFault.h"
 #include "rhi/vulkan/VulkanMemoryAllocator.h"

--- a/source/test/WindowSurfaceSourceContractTest.cpp
+++ b/source/test/WindowSurfaceSourceContractTest.cpp
@@ -1,0 +1,150 @@
+#include "rhi/RHIResource.h"
+#include "rhi/RHIWindowSurface.h"
+
+#include <cstdint>
+#include <cstdlib>
+#include <memory>
+
+using namespace Moer::Render;
+
+namespace {
+
+void Require(bool condition) {
+    if (!condition) {
+        std::abort();
+    }
+}
+
+class FakeWindowSurfaceSource final : public WindowSurfaceSource {
+public:
+    WindowSurfaceIdentity     identity{};
+    WindowSurfaceCreateResult result{
+        .status = EWindowSurfaceCreateStatus::Success,
+    };
+    uintptr_t native_surface{0xabcdu};
+
+    mutable ERHIType    observed_rhi{ERHIType::Vulkan};
+    mutable void*       observed_instance{nullptr};
+    mutable const void* observed_allocator{nullptr};
+    mutable void*       observed_output{nullptr};
+    mutable uint32_t    create_calls{0};
+
+    [[nodiscard]] WindowSurfaceIdentity GetIdentity() const noexcept override {
+        return identity;
+    }
+
+    [[nodiscard]] WindowSurfaceCreateResult
+    CreateSurface(ERHIType rhi_type, void* instance, const void* allocation_callbacks, void* surface)
+        const noexcept override {
+        observed_rhi       = rhi_type;
+        observed_instance  = instance;
+        observed_allocator = allocation_callbacks;
+        observed_output    = surface;
+        ++create_calls;
+        if (result.Succeeded() && surface != nullptr) {
+            *static_cast<uintptr_t*>(surface) = native_surface;
+        }
+        return result;
+    }
+};
+
+std::shared_ptr<FakeWindowSurfaceSource>
+MakeSource(uintptr_t window_system_handle, uintptr_t platform_window_handle, uint64_t generation) {
+    auto source      = std::make_shared<FakeWindowSurfaceSource>();
+    source->identity = {
+        .window_system          = EWindowSystemType::GLFW,
+        .window_system_handle   = window_system_handle,
+        .platform_window_handle = platform_window_handle,
+        .generation             = generation,
+    };
+    return source;
+}
+
+} // namespace
+
+int main() {
+    const SwapchainSurfaceInfo invalid{};
+    Require(!invalid.IsValid());
+    Require(ClassifySwapchainSurfaceTransition({}, false, invalid) == ESwapchainSurfaceTransition::Invalid);
+
+    auto                 source_a = MakeSource(0x1000u, 0x2000u, 1u);
+    SwapchainSurfaceInfo surface_a{source_a};
+    Require(surface_a.IsValid());
+    Require(
+        ClassifySwapchainSurfaceTransition({}, false, surface_a) == ESwapchainSurfaceTransition::Initialize
+    );
+    const SwapchainSurfaceInfo platform_handle_optional{MakeSource(0x1002u, 0u, 1u)};
+    Require(platform_handle_optional.IsValid());
+
+    auto                 source_same_identity = MakeSource(0x1000u, 0x2000u, 1u);
+    SwapchainSurfaceInfo surface_same_identity{source_same_identity};
+    Require(source_a.get() != source_same_identity.get());
+    Require(surface_a.HasSameIdentity(surface_same_identity));
+    Require(
+        ClassifySwapchainSurfaceTransition(surface_a, true, surface_same_identity) ==
+        ESwapchainSurfaceTransition::Reuse
+    );
+
+    const SwapchainSurfaceInfo changed_window{MakeSource(0x1001u, 0x2000u, 1u)};
+    const SwapchainSurfaceInfo changed_platform{MakeSource(0x1000u, 0x2001u, 1u)};
+    const SwapchainSurfaceInfo changed_generation{MakeSource(0x1000u, 0x2000u, 2u)};
+    Require(!surface_a.HasSameIdentity(changed_window));
+    Require(!surface_a.HasSameIdentity(changed_platform));
+    Require(!surface_a.HasSameIdentity(changed_generation));
+    Require(
+        ClassifySwapchainSurfaceTransition(surface_a, true, changed_window) ==
+        ESwapchainSurfaceTransition::Replace
+    );
+    Require(
+        ClassifySwapchainSurfaceTransition(surface_a, true, changed_platform) ==
+        ESwapchainSurfaceTransition::Replace
+    );
+    Require(
+        ClassifySwapchainSurfaceTransition(surface_a, true, changed_generation) ==
+        ESwapchainSurfaceTransition::Replace
+    );
+
+    auto*                           instance  = reinterpret_cast<void*>(0x3000u);
+    auto*                           allocator = reinterpret_cast<const void*>(0x4000u);
+    uintptr_t                       output    = 0;
+    const WindowSurfaceCreateResult create_result =
+        source_a->CreateSurface(ERHIType::D3D12, instance, allocator, &output);
+    Require(create_result.Succeeded());
+    Require(output == source_a->native_surface);
+    Require(source_a->create_calls == 1);
+    Require(source_a->observed_rhi == ERHIType::D3D12);
+    Require(source_a->observed_instance == instance);
+    Require(source_a->observed_allocator == allocator);
+    Require(source_a->observed_output == &output);
+
+    auto failing_source    = MakeSource(0x5000u, 0x6000u, 1u);
+    failing_source->result = {
+        .status            = EWindowSurfaceCreateStatus::NativeFailure,
+        .native_error_code = -7,
+    };
+    output = 0;
+    const WindowSurfaceCreateResult failure =
+        failing_source->CreateSurface(ERHIType::Vulkan, instance, allocator, &output);
+    Require(!failure.Succeeded());
+    Require(failure.native_error_code == -7);
+    Require(output == 0);
+
+    std::weak_ptr<const WindowSurfaceSource> weak_source;
+    SwapchainCreateInfo                      copied_info;
+    {
+        auto lifetime_source = MakeSource(0x7000u, 0x8000u, 1u);
+        weak_source          = lifetime_source;
+        SwapchainCreateInfo original{
+            .surface = SwapchainSurfaceInfo{lifetime_source},
+            .size    = {1280, 720},
+        };
+        copied_info = original;
+        lifetime_source.reset();
+        Require(!weak_source.expired());
+    }
+    Require(!weak_source.expired());
+    copied_info.surface = {};
+    Require(weak_source.expired());
+
+    return 0;
+}


### PR DESCRIPTION
## Summary

- replace raw native window handles with immutable WindowSurfaceSource values captured on the Game Thread
- add identity/generation/lease semantics for main and detached ImGui windows
- harden Vulkan initialize/reuse/replace into typed, committed-state-aware surface/swapchain transactions
- remove obsolete raw Vulkan surface creation bypasses
- add WindowSurfaceSource contract coverage and update all in-tree swapchain implementations

## Architecture

This adapts the product intent from dev_parallel_rhi to the current main ownership model: GT capture -> immutable RT/RHI handoff -> backend committed identity as the single source of truth. Surface replacement fully materializes a candidate presentation bundle before retiring the last-good bundle; same-surface recreate follows Vulkan oldSwapchain retirement semantics.

## Compatibility

This intentionally changes the in-tree C++ RHI interface: SwapchainCreateInfo now carries a surface value and Swapchain adds GetCommittedSurfaceIdentity(). Out-of-tree Swapchain subclasses must rebuild and implement the new contract. D3D12 presentation remains unimplemented.

## Validation

- Debug full build: pass
- Debug CTest: 34/34 pass
- RelWithDebInfo full build + CTest: pass, 34/34
- Release full build + CTest: pass, 34/34
- post-cleanup Debug full rebuild + CTest: pass, 34/34
- post-cleanup Release affected-target rebuild + core contracts: pass, 3/3
- git diff --check: pass
- real Vulkan/GLFW GUI: RT first frame, main maximize/minimize/restore, two detached OS windows, detached resize/destroy/recreate, RT<->Raster switches, and shutdown with detached windows all pass
- runtime log scan: no VUID, surface fault/lost, device lost, native-window-in-use, or live-lease failure
