### PR TITLE
Phase 22B: add immutable window frame snapshots

### DIFF
--- a/source/runtime/render/renderer/Renderer.cpp
+++ b/source/runtime/render/renderer/Renderer.cpp
@@ -159,27 +159,15 @@ void Renderer::ReleaseResources() {
     RenderGraphResourcePool::Global().Reset();
 }
 
-Renderer::WindowFrameState Renderer::TickWindowContext(uint2 current_resolution) {
+WindowFrameSnapshot Renderer::TickWindowContext() {
     WindowContext::Tick();
-
-    int w_width, w_height;
-    WindowContext::GetWindowSize(WindowContext::GetMainWindow(), &w_width, &w_height);
-    if (w_width == 0 || w_height == 0) {
-        return WindowFrameState{EWindowState::Hiding, current_resolution};
-    }
-
-    if (w_width != current_resolution.x || w_height != current_resolution.y) {
-        return WindowFrameState{
-            EWindowState::SizeChanged, uint2(static_cast<uint32>(w_width), static_cast<uint32>(w_height))
-        };
-    }
-
-    return WindowFrameState{EWindowState::Default, current_resolution};
+    return main_window_frame_tracker.Advance(
+        swapchain_create_info.surface.GetIdentity(),
+        WindowContext::CaptureWindowFrameMetrics(*WindowContext::GetMainWindow())
+    );
 }
 
-void Renderer::PrepareRenderFrame(const WindowFrameState& window_frame) {
-    resolution = window_frame.resolution;
-
+bool Renderer::PrepareRenderFrame(const WindowFrameSnapshot& window_frame) {
     if (time >= max_frame_in_flight) {
         timeline->Wait(time - max_frame_in_flight);
     }
@@ -187,23 +175,45 @@ void Renderer::PrepareRenderFrame(const WindowFrameState& window_frame) {
 
     const bool recreate_requested =
         main_swapchain_recreate_requested.exchange(false, std::memory_order_acq_rel);
-    if (window_frame.state == EWindowState::Hiding) {
-        if (recreate_requested) {
+    const bool presentation_ready =
+        swapchain && swapchain->IsPresentationReady();
+    if (!window_frame.IsDrawable()) {
+        if (recreate_requested || !presentation_ready) {
             // A zero-extent swapchain cannot be recreated. Preserve the WSI
             // recovery request until the window has a drawable extent again.
             main_swapchain_recreate_requested.store(true, std::memory_order_release);
         }
-        return;
+        return false;
+    }
+    if (!swapchain) {
+        main_swapchain_recreate_requested.store(true, std::memory_order_release);
+        return false;
     }
 
-    if (window_frame.state != EWindowState::SizeChanged && !recreate_requested) {
-        return;
+    const Extent2D drawable_extent = window_frame.drawable_extent;
+    const bool request_matches =
+        presentation_ready &&
+        committed_main_surface_identity == window_frame.surface_identity &&
+        committed_main_drawable_generation == window_frame.drawable_generation;
+    if (request_matches && !recreate_requested) {
+        resolution = uint2(swapchain->size.x, swapchain->size.y);
+        return true;
     }
 
     RHIExecutor::Get().Sync(ERHISyncDepth::Present);
-    swapchain_create_info.size = {resolution.x, resolution.y};
+    swapchain_create_info.size = drawable_extent;
     swapchain->Sync();
-    swapchain->Recreate(swapchain_create_info);
+    const bool recreated = swapchain->Recreate(swapchain_create_info);
+    if (!recreated ||
+        !swapchain->IsPresentationReady() ||
+        swapchain->GetCommittedSurfaceIdentity() != window_frame.surface_identity) {
+        main_swapchain_recreate_requested.store(true, std::memory_order_release);
+        return false;
+    }
+    committed_main_surface_identity       = window_frame.surface_identity;
+    committed_main_drawable_generation   = window_frame.drawable_generation;
+    resolution = uint2(swapchain->size.x, swapchain->size.y);
+    return true;
 }
 
 void Renderer::LogSceneLoadStatus(const EditorConfig& config) const {

--- a/source/runtime/render/renderer/Renderer.h
+++ b/source/runtime/render/renderer/Renderer.h
@@ -9,6 +9,7 @@
 #include "scene/RenderScene.h"
 #include "scene/Scene.h"
 #include "shader/ShaderResourceManager.h"
+#include "window/WindowFrameSnapshot.h"
 
 #include "common/UIRenderer.h"
 #include "common/UiCombinePass.h"
@@ -55,18 +56,6 @@ struct EngineHooks {
 class RENDER_API Renderer {
 
 public:
-    enum class EWindowState {
-        Default = 0,
-        Hiding,
-        SizeChanged,
-        Num,
-    };
-
-    struct WindowFrameState {
-        EWindowState state      = EWindowState::Default;
-        uint2        resolution = uint2(0u, 0u);
-    };
-
     Renderer(
         uint2                         initial_resolution,
         const SharedPtr<EditorConfig> config,
@@ -78,8 +67,8 @@ public:
 
     void ReleaseResources();
 
-    WindowFrameState TickWindowContext(uint2 current_resolution);
-    void             LogSceneLoadStatus(const EditorConfig& config) const;
+    WindowFrameSnapshot TickWindowContext();
+    void                LogSceneLoadStatus(const EditorConfig& config) const;
 
     Renderer(const Renderer&)            = delete;
     Renderer& operator=(const Renderer&) = delete;
@@ -95,7 +84,7 @@ public:
     }
 
 protected:
-    void               PrepareRenderFrame(const WindowFrameState& window_frame);
+    [[nodiscard]] bool PrepareRenderFrame(const WindowFrameSnapshot& window_frame);
     PresentReceiptRef  CreateMainPresentReceipt(bool scene_content_ready);
     void ApplyMainPresentReceipt(const PresentReceiptRef& receipt, const EngineHooks& hooks);
     [[nodiscard]] bool IsFramePrepareProfilingEnabled() const {
@@ -121,10 +110,13 @@ protected:
     SwapchainRef     swapchain;
     BindlessArrayRef bindless_array;
 
-    SwapchainCreateInfo    swapchain_create_info;
-    Scene                  scene;
-    UniquePtr<RenderScene> render_scene;
-    CommandList            cmd_list;
+    SwapchainCreateInfo        swapchain_create_info;
+    WindowFrameSnapshotTracker main_window_frame_tracker;
+    WindowSurfaceIdentity       committed_main_surface_identity{};
+    uint64_t                    committed_main_drawable_generation = 0;
+    Scene                       scene;
+    UniquePtr<RenderScene>      render_scene;
+    CommandList                 cmd_list;
 
     UniquePtr<UiCombinePass> ui_combine_pass;
 

--- a/source/runtime/render/renderer/common/UIRenderer.h
+++ b/source/runtime/render/renderer/common/UIRenderer.h
@@ -6,6 +6,7 @@
 #include "RenderAPI.h"
 #include "misc/STL.h"
 #include "rhi/RHI.h"
+#include "window/WindowFrameSnapshot.h"
 #include <atomic>
 #include <cstdint>
 #include <limits>
@@ -15,8 +16,9 @@ namespace Moer::Render {
 class UiDrawFrameBackend;
 
 struct UiCompositionFrameData {
-    bool       enabled         = false;
-    bool       separate_window = false;
+    bool       enabled               = false;
+    bool       separate_window       = false;
+    bool       scene_extent_resolved = false;
     uint2      output_resolution{};
     float2     scene_color_position{};
     float2     scene_color_resolution{};
@@ -53,12 +55,32 @@ struct UiDrawVertex {
 using UiDrawIndex = uint16;
 
 struct UiDrawCommand {
+    // Viewport-local logical coordinates. The execution target's immutable
+    // framebuffer scale is applied only when the RT builds the native batch.
     float2 clip_min{};
     float2 clip_max{};
     uint32 texture_handle = 0;
     uint32 element_count  = 0;
     uint32 vertex_offset  = 0;
     uint32 index_offset   = 0;
+};
+
+struct UiClipRect {
+    float2 min{};
+    float2 max{};
+};
+
+struct UiViewportPresentationSnapshot {
+    WindowSurfaceIdentity surface_identity{};
+    Extent2D              drawable_extent{};
+    uint64_t              drawable_generation = 0;
+
+    [[nodiscard]] bool IsValid() const noexcept {
+        return surface_identity.IsValid() &&
+               drawable_extent.x != 0 &&
+               drawable_extent.y != 0 &&
+               drawable_generation != 0;
+    }
 };
 
 struct UiViewportDrawPacket {
@@ -77,6 +99,9 @@ struct UiViewportDrawPacket {
     SharedPtr<UiViewportRenderResources> render_resources;
     TextureRef                           framebuffer;
     SwapchainRef                         swapchain;
+    WindowFrameSnapshot                  window_frame;
+    UiViewportPresentationSnapshot       presentation;
+    bool                                 presentation_metadata_only = false;
 };
 
 struct UiDrawFramePacket {
@@ -94,6 +119,39 @@ struct UiDrawFramePacket {
 
 static_assert(std::is_move_constructible_v<UiDrawFramePacket>);
 static_assert(!std::is_copy_constructible_v<UiDrawFramePacket>);
+
+// Converts editor/ImGui logical coordinates to the drawable pixel domain used
+// by the selected main or detached presentation target.
+[[nodiscard]] RENDER_API bool ResolveUiCompositionDrawableMetrics(
+    UiCompositionFrameData&      composition,
+    const WindowFrameSnapshot&   main_window_frame,
+    const UiDrawFramePacket&     draw_frame
+) noexcept;
+RENDER_API void BindUiViewportWindowFrame(
+    UiViewportDrawPacket&      viewport,
+    const WindowFrameSnapshot& window_frame
+) noexcept;
+RENDER_API void BindUiViewportPresentation(
+    UiViewportDrawPacket&                 viewport,
+    const UiViewportPresentationSnapshot& presentation
+) noexcept;
+// Finalizes the main-window presentation scale and retargets composition
+// metrics from the captured raw drawable domain to the RT-committed extent.
+[[nodiscard]] RENDER_API bool RetargetMainUiPresentation(
+    UiViewportDrawPacket&      main_viewport,
+    UiCompositionFrameData&    composition,
+    const WindowFrameSnapshot& window_frame,
+    Extent2D                   committed_extent
+) noexcept;
+[[nodiscard]] RENDER_API bool ConvertUiClipRectToDrawable(
+    UiClipRect&   clip_rect,
+    const float2& display_position,
+    const float2& framebuffer_scale
+) noexcept;
+[[nodiscard]] RENDER_API bool
+IsUiViewportPresentationCommitted(const UiViewportDrawPacket& viewport) noexcept;
+[[nodiscard]] RENDER_API bool
+IsUiViewportPresentationCurrent(const UiViewportDrawPacket& viewport) noexcept;
 
 /**
  * Freezes the speculative upload-ring slots used by one copied UI frame.

--- a/source/runtime/render/renderer/common/UiFrameGraphPass.cpp
+++ b/source/runtime/render/renderer/common/UiFrameGraphPass.cpp
@@ -71,7 +71,9 @@ Array<TextureRef> CollectPresentationTargets(
         AddUniqueTarget(targets, composition.window_frame_buffer);
     }
     for (const auto& viewport : draw_frame.platform_viewports) {
-        AddUniqueTarget(targets, viewport.framebuffer);
+        if (!viewport.presentation_metadata_only) {
+            AddUniqueTarget(targets, viewport.framebuffer);
+        }
     }
     return targets;
 }

--- a/source/runtime/render/renderer/common/UiFrameGraphPass.h
+++ b/source/runtime/render/renderer/common/UiFrameGraphPass.h
@@ -13,8 +13,9 @@ class UiFrameGraphPassTestAccess;
 
 /**
  * Owns the copied editor draw packet across RenderGraph recording and the
- * Executor-owned Present epilogue. The packet is immutable after capture; the
- * one-shot state protects the mutable ImGui GPU upload-ring backend.
+ * Executor-owned Present epilogue. The packet becomes immutable after RT
+ * presentation finalization and Prepare; the one-shot state protects the
+ * mutable ImGui GPU upload-ring backend.
  */
 class RENDER_API UiFrameGraphPass {
 public:

--- a/source/runtime/render/renderer/common/ui/DearImGuiRenderer.cpp
+++ b/source/runtime/render/renderer/common/ui/DearImGuiRenderer.cpp
@@ -42,9 +42,16 @@ using namespace Moer;
 
 namespace Moer::Render {
 struct ImGuiData;
+struct GuiViewportData;
 }
 
 void InitializeGuiPlatformInterface();
+bool RefreshGuiViewportPresentation(
+    ImGuiViewport*                      viewport,
+    Moer::Render::GuiViewportData&      viewport_data,
+    Moer::Render::RenderDevice&         device,
+    uint32_t                            frames_in_flight
+);
 void RenderGuiDrawPacket(
     const UiViewportDrawPacket& _draw_packet,
     const TextureView&    _framebuffer,
@@ -108,6 +115,7 @@ struct GuiViewportRenderResources final : UiViewportRenderResources {
 
     Array<GuiFrameRenderBuffers> render_buffers;
     TextureRef                   framebuffer;
+    UiViewportPresentationSnapshot committed_presentation{};
 
     uint64_t frame_index = 0;
 
@@ -132,6 +140,9 @@ struct GuiViewportRenderResources final : UiViewportRenderResources {
 struct GuiViewportData {
     SharedPtr<GuiViewportRenderResources> render_resources;
     SwapchainSurfaceInfo                  surface_info;
+    WindowFrameSnapshotTracker            window_frame_tracker;
+    WindowFrameSnapshot                   latest_window_frame;
+    bool                                  presentation_refresh_pending = true;
 
     uint32_t        viewport_index = 0;
     static uint32_t viewport_count;
@@ -408,7 +419,19 @@ void ImGuiRenderBackend::UnregisterImage(Texture* _texture) {
 static UiViewportDrawPacket
 CaptureViewportDrawPacket(ImDrawData* _draw_data, GuiViewportData* _viewport_data) {
     UiViewportDrawPacket packet{};
-    if (!_draw_data || !_viewport_data || !_viewport_data->render_resources) {
+    if (!_viewport_data || !_viewport_data->render_resources) {
+        return packet;
+    }
+
+    packet.render_resources = _viewport_data->render_resources;
+    packet.framebuffer      = _viewport_data->render_resources->framebuffer;
+    packet.swapchain        = _viewport_data->render_resources->swapchain;
+    BindUiViewportWindowFrame(packet, _viewport_data->latest_window_frame);
+    BindUiViewportPresentation(
+        packet,
+        _viewport_data->render_resources->committed_presentation
+    );
+    if (!_draw_data) {
         return packet;
     }
 
@@ -420,10 +443,15 @@ CaptureViewportDrawPacket(ImDrawData* _draw_data, GuiViewportData* _viewport_dat
 
     packet.display_position  = {_draw_data->DisplayPos.x, _draw_data->DisplayPos.y};
     packet.display_size      = {_draw_data->DisplaySize.x, _draw_data->DisplaySize.y};
-    packet.framebuffer_scale = {_draw_data->FramebufferScale.x, _draw_data->FramebufferScale.y};
-    packet.render_resources  = _viewport_data->render_resources;
-    packet.framebuffer       = _viewport_data->render_resources->framebuffer;
-    packet.swapchain         = _viewport_data->render_resources->swapchain;
+    if (!packet.window_frame.IsValid()) {
+        // ImGui's main viewport does not use the detached-window refresh path.
+        // Preserve its platform backend scale until the renderer binds the
+        // immutable main-window snapshot to the copied packet.
+        packet.framebuffer_scale = {
+            _draw_data->FramebufferScale.x,
+            _draw_data->FramebufferScale.y
+        };
+    }
 
     if (_draw_data->DisplaySize.x <= 0.f || _draw_data->DisplaySize.y <= 0.f) {
         return packet;
@@ -468,21 +496,21 @@ CaptureViewportDrawPacket(ImDrawData* _draw_data, GuiViewportData* _viewport_dat
                 continue;
             }
 
-            const float clip_min_x =
-                (draw_command.ClipRect.x - _draw_data->DisplayPos.x) * _draw_data->FramebufferScale.x;
-            const float clip_min_y =
-                (draw_command.ClipRect.y - _draw_data->DisplayPos.y) * _draw_data->FramebufferScale.y;
-            const float clip_max_x =
-                (draw_command.ClipRect.z - _draw_data->DisplayPos.x) * _draw_data->FramebufferScale.x;
-            const float clip_max_y =
-                (draw_command.ClipRect.w - _draw_data->DisplayPos.y) * _draw_data->FramebufferScale.y;
-            if (clip_max_x <= clip_min_x || clip_max_y <= clip_min_y) {
+            UiClipRect clip_rect{
+                .min = {draw_command.ClipRect.x, draw_command.ClipRect.y},
+                .max = {draw_command.ClipRect.z, draw_command.ClipRect.w},
+            };
+            if (!ConvertUiClipRectToDrawable(
+                    clip_rect,
+                    packet.display_position,
+                    float2(1.f, 1.f)
+                )) {
                 continue;
             }
 
             packet.commands.emplace_back(UiDrawCommand{
-                .clip_min       = {clip_min_x, clip_min_y},
-                .clip_max       = {clip_max_x, clip_max_y},
+                .clip_min       = clip_rect.min,
+                .clip_max       = clip_rect.max,
                 .texture_handle = static_cast<uint32>(draw_command.TextureId),
                 .element_count  = draw_command.ElemCount,
                 .vertex_offset  = draw_command.VtxOffset + global_vertex_offset,
@@ -514,12 +542,35 @@ UiDrawFramePacket ImGuiRenderBackend::CaptureDrawFrame() {
         }
         for (int viewport_index = 1; viewport_index < platform_io.Viewports.Size; ++viewport_index) {
             ImGuiViewport* viewport = platform_io.Viewports[viewport_index];
-            if ((viewport->Flags & ImGuiViewportFlags_IsMinimized) != 0 || !viewport->DrawData) {
+            auto* viewport_data =
+                static_cast<GuiViewportData*>(viewport->RendererUserData);
+            if (viewport_data != nullptr) {
+                static_cast<void>(RefreshGuiViewportPresentation(
+                    viewport,
+                    *viewport_data,
+                    device,
+                    static_cast<ImGuiData*>(backend_data)->frames_in_flight
+                ));
+            }
+            const bool drawable =
+                viewport_data != nullptr &&
+                viewport_data->latest_window_frame.IsDrawable();
+            if (!drawable ||
+                (viewport->Flags & ImGuiViewportFlags_IsMinimized) != 0 ||
+                !viewport->DrawData) {
+                auto retained_packet =
+                    CaptureViewportDrawPacket(nullptr, viewport_data);
+                if (!drawable &&
+                    IsUiViewportPresentationCommitted(retained_packet)) {
+                    retained_packet.presentation_metadata_only = true;
+                    frame.platform_viewports.emplace_back(
+                        std::move(retained_packet)
+                    );
+                }
                 continue;
             }
-            auto* viewport_data   = static_cast<GuiViewportData*>(viewport->RendererUserData);
             auto  viewport_packet = CaptureViewportDrawPacket(viewport->DrawData, viewport_data);
-            if (viewport_packet.framebuffer && viewport_packet.swapchain) {
+            if (IsUiViewportPresentationCurrent(viewport_packet)) {
                 frame.platform_viewports.emplace_back(std::move(viewport_packet));
             }
         }
@@ -550,7 +601,7 @@ void ImGuiRenderBackend::RenderGUI(
     }
     for (size_t viewport_index = 0; viewport_index < _frame.platform_viewports.size(); ++viewport_index) {
         const auto& viewport = _frame.platform_viewports[viewport_index];
-        if (viewport.framebuffer && !viewport.commands.empty()) {
+        if (IsUiViewportPresentationCurrent(viewport) && !viewport.commands.empty()) {
             ScopedGpuMarker viewport_marker(
                 _cmd_list,
                 std::format("Platform Viewport {}", viewport_index),
@@ -580,19 +631,8 @@ void ImGuiRenderBackend::PresentWindows(
         (_execution_thread == EUiDrawExecutionThread::Render && IsCurrentlyRenderThread())
     );
     for (const auto& viewport : _frame.platform_viewports) {
-        if (viewport.swapchain && viewport.framebuffer) {
+        if (IsUiViewportPresentationCurrent(viewport)) {
             const auto framebuffer_view = viewport.framebuffer->GetView();
-            if (framebuffer_view.extent.x != viewport.swapchain->size.x ||
-                framebuffer_view.extent.y != viewport.swapchain->size.y) {
-                LOG_WARNING(
-                    "Skipping stale ImGui viewport present: source={}x{}, swapchain={}x{}.",
-                    framebuffer_view.extent.x,
-                    framebuffer_view.extent.y,
-                    viewport.swapchain->size.x,
-                    viewport.swapchain->size.y
-                );
-                continue;
-            }
             RHIExecutor::Get().Present(
                 RHIPresentRequest(viewport.swapchain, framebuffer_view), true
             );
@@ -661,9 +701,20 @@ static void BuildGuiDrawBatch(
 
     uint32 command_offset = 0;
     for (const UiDrawCommand& command : _draw_packet.commands) {
+        UiClipRect clip_rect{
+            .min = command.clip_min,
+            .max = command.clip_max,
+        };
+        if (!ConvertUiClipRectToDrawable(
+                clip_rect,
+                float2(0.f, 0.f),
+                _draw_packet.framebuffer_scale
+            )) {
+            continue;
+        }
         _arguments.emplace_back(
-            ImVec2{command.clip_min.x, command.clip_min.y},
-            ImVec2{command.clip_max.x, command.clip_max.y},
+            ImVec2{clip_rect.min.x, clip_rect.min.y},
+            ImVec2{clip_rect.max.x, clip_rect.max.y},
             command.texture_handle
         );
         batch.EmplaceDrawIndexed(
@@ -812,29 +863,42 @@ void DestroyRenderBuffers(GuiFrameRenderBuffers* _render_buffers) {
     _render_buffers->argument_buffer = nullptr;
 }
 
-void CreateOrResizeViewportResources(
-    RenderDevice&                                       _device,
-    const SharedPtr<GuiViewportRenderResources>&        _resources,
-    SwapchainSurfaceInfo                                _surface_info,
-    uint2                                               _extent,
-    uint32_t                                            _frame_in_flight,
-    uint32_t                                            _viewport_index
+bool CreateOrResizeViewportResources(
+    RenderDevice&                                _device,
+    const SharedPtr<GuiViewportRenderResources>& _resources,
+    SwapchainSurfaceInfo                         _surface_info,
+    WindowFrameSnapshot                          _window_frame,
+    uint32_t                                     _frame_in_flight,
+    uint32_t                                     _viewport_index
 ) {
     assert(_resources);
     assert(!IsRenderThreadRunning() || IsCurrentlyRenderThread());
+    if (!_surface_info.IsValid() || !_window_frame.IsDrawable() ||
+        _surface_info.GetIdentity() != _window_frame.surface_identity) {
+        return false;
+    }
 
     const bool has_swapchain = _resources->swapchain.IsValid();
-    const bool surface_matches =
-        has_swapchain && _surface_info.IsValid() &&
-        _resources->swapchain->GetCommittedSurfaceIdentity() == _surface_info.GetIdentity();
-    const bool swapchain_matches =
-        surface_matches && _resources->swapchain->size.x == _extent.x &&
-        _resources->swapchain->size.y == _extent.y;
+    const bool request_matches =
+        _resources->committed_presentation.IsValid() &&
+        _resources->committed_presentation.surface_identity == _window_frame.surface_identity &&
+        _resources->committed_presentation.drawable_generation ==
+            _window_frame.drawable_generation;
+    const bool swapchain_matches_commit =
+        has_swapchain &&
+        _resources->swapchain->IsPresentationReady() &&
+        _resources->swapchain->GetCommittedSurfaceIdentity() ==
+            _resources->committed_presentation.surface_identity &&
+        _resources->swapchain->size ==
+            _resources->committed_presentation.drawable_extent;
     const bool framebuffer_matches =
-        _resources->framebuffer && _resources->framebuffer->GetExtent().x == _extent.x &&
-        _resources->framebuffer->GetExtent().y == _extent.y;
-    if (swapchain_matches && framebuffer_matches) {
-        return;
+        _resources->framebuffer &&
+        _resources->framebuffer->GetExtent().x ==
+            _resources->committed_presentation.drawable_extent.x &&
+        _resources->framebuffer->GetExtent().y ==
+            _resources->committed_presentation.drawable_extent.y;
+    if (request_matches && swapchain_matches_commit && framebuffer_matches) {
+        return true;
     }
 
     if (has_swapchain || _resources->framebuffer) {
@@ -843,37 +907,67 @@ void CreateOrResizeViewportResources(
 
     SwapchainCreateInfo swapchain_info{
         .surface          = _surface_info,
-        .size             = _extent,
+        .size             = _window_frame.drawable_extent,
         .back_buffer_sz   = _frame_in_flight,
         .preferred_format = PF_R8G8B8A8_SRGB
     };
 
+    bool native_commit_succeeded = false;
     if (!has_swapchain) {
         _resources->swapchain = _device.CreateSwapchain(swapchain_info);
-    } else if (!swapchain_matches) {
+        native_commit_succeeded =
+            _resources->swapchain && _resources->swapchain->IsPresentationReady();
+    } else if (!request_matches || !swapchain_matches_commit) {
         _resources->swapchain->Sync();
-        _resources->swapchain->Recreate(swapchain_info);
+        native_commit_succeeded = _resources->swapchain->Recreate(swapchain_info);
+    } else {
+        native_commit_succeeded = true;
     }
 
-    _resources->framebuffer = _device.CreateTexture(
-        Extent2D(_extent.x, _extent.y),
-        PF_R8G8B8A8_SRGB,
-        ETextureUsageFlags::COLOR_ATTACHMENT |
-            ETextureUsageFlags::SAMPLED |
-            ETextureUsageFlags::PRESENTATION_SOURCE |
-            ETextureUsageFlags::TRANSFER_SRC |
-            ETextureUsageFlags::TRANSFER_DST
-    );
-    _resources->framebuffer->SetName(std::format("ImGui Window {}", _viewport_index));
+    if (!native_commit_succeeded ||
+        !_resources->swapchain ||
+        !_resources->swapchain->IsPresentationReady() ||
+        _resources->swapchain->GetCommittedSurfaceIdentity() != _window_frame.surface_identity ||
+        _resources->swapchain->size.x == 0 ||
+        _resources->swapchain->size.y == 0) {
+        return false;
+    }
+
+    const Extent2D actual_extent = _resources->swapchain->size;
+    const bool framebuffer_matches_actual =
+        _resources->framebuffer &&
+        _resources->framebuffer->GetExtent().x == actual_extent.x &&
+        _resources->framebuffer->GetExtent().y == actual_extent.y;
+    if (!framebuffer_matches_actual) {
+        _resources->framebuffer = _device.CreateTexture(
+            actual_extent,
+            PF_R8G8B8A8_SRGB,
+            ETextureUsageFlags::COLOR_ATTACHMENT |
+                ETextureUsageFlags::SAMPLED |
+                ETextureUsageFlags::PRESENTATION_SOURCE |
+                ETextureUsageFlags::TRANSFER_SRC |
+                ETextureUsageFlags::TRANSFER_DST
+        );
+        if (!_resources->framebuffer) {
+            return false;
+        }
+        _resources->framebuffer->SetName(std::format("ImGui Window {}", _viewport_index));
+    }
+    _resources->committed_presentation = UiViewportPresentationSnapshot{
+        .surface_identity     = _window_frame.surface_identity,
+        .drawable_extent      = actual_extent,
+        .drawable_generation  = _window_frame.drawable_generation,
+    };
 
     LOG_INFO(
         "[Threading][UI] {} ImGui viewport {} resources at {}x{} on {} Thread.",
         has_swapchain ? "Updated" : "Created",
         _viewport_index,
-        _extent.x,
-        _extent.y,
+        actual_extent.x,
+        actual_extent.y,
         IsCurrentlyRenderThread() ? "Render" : "Game"
     );
+    return true;
 }
 
 void ReleaseViewportResources(
@@ -890,8 +984,9 @@ void ReleaseViewportResources(
     if (_resources->swapchain) {
         _resources->swapchain->Sync();
     }
-    _resources->swapchain   = nullptr;
-    _resources->framebuffer = nullptr;
+    _resources->swapchain              = nullptr;
+    _resources->framebuffer            = nullptr;
+    _resources->committed_presentation = {};
     for (auto& render_buffers : _resources->render_buffers) {
         DestroyRenderBuffers(&render_buffers);
     }
@@ -942,51 +1037,88 @@ ImGuiRenderBackend::~ImGuiRenderBackend() {
     backend_data = nullptr;
 }
 
-void GuiCreateWindow(ImGuiViewport* _viewport) {
-    ImGuiData&       backend_data  = *GetImGuiBackendData();
-    GuiViewportData* viewport_data = MoerNew(GuiViewportData)(backend_data.frames_in_flight);
-    using namespace Moer::Render;
-    ImGuiRenderBackend& render_backend = *backend_data.render_backend;
-    RenderDevice&       rd_device      = render_backend.device;
-
-    _viewport->RendererUserData = viewport_data;
+bool RefreshGuiViewportPresentation(
+    ImGuiViewport*    viewport,
+    GuiViewportData&  viewport_data,
+    RenderDevice&     device,
+    uint32_t          frames_in_flight
+) {
+    assert(!IsRenderThreadInitialized() || IsCurrentlyGameThread());
 
     void* platform_window =
-        _viewport->PlatformHandle ? _viewport->PlatformHandle : _viewport->PlatformHandleRaw;
-    if (!platform_window) {
-        return;
-    }
-    Moer::WindowHandle handle{static_cast<Moer::WindowType*>(platform_window)};
-    using namespace Moer::Render;
-    using namespace Moer;
-
-    int width, height;
-    WindowContext::GetWindowSize(&handle, &width, &height);
-    viewport_data->surface_info = WindowContext::CreateSwapchainSurfaceInfo(handle);
-    const uint2 extent{static_cast<uint>(_viewport->Size.x), static_cast<uint>(_viewport->Size.y)};
-    if (!viewport_data->surface_info.IsValid() ||
-        width == 0 ||
-        height == 0 ||
-        extent.x == 0 ||
-        extent.y == 0) {
-        return;
+        viewport->PlatformHandle ? viewport->PlatformHandle : viewport->PlatformHandleRaw;
+    if (platform_window == nullptr) {
+        viewport_data.latest_window_frame =
+            viewport_data.window_frame_tracker.Advance({}, {});
+        viewport_data.presentation_refresh_pending = true;
+        return false;
     }
 
-    const auto render_resources = viewport_data->render_resources;
-    const auto surface_info     = viewport_data->surface_info;
-    const auto viewport_index   = viewport_data->viewport_index;
+    const WindowHandle handle{static_cast<WindowType*>(platform_window)};
+    const SwapchainSurfaceInfo incoming_surface =
+        WindowContext::CreateSwapchainSurfaceInfo(handle);
+    if (incoming_surface.IsValid()) {
+        viewport_data.surface_info = incoming_surface;
+    }
+    viewport_data.latest_window_frame = viewport_data.window_frame_tracker.Advance(
+        incoming_surface.GetIdentity(),
+        WindowContext::CaptureWindowFrameMetrics(handle)
+    );
+
+    const auto transition = viewport_data.latest_window_frame.transition;
+    const bool presentation_changed =
+        transition == EWindowFrameTransition::Initial ||
+        transition == EWindowFrameTransition::DrawableResized ||
+        transition == EWindowFrameTransition::Restored ||
+        transition == EWindowFrameTransition::Replaced;
+    viewport_data.presentation_refresh_pending =
+        viewport_data.presentation_refresh_pending || presentation_changed;
+    if (!viewport_data.latest_window_frame.IsDrawable()) {
+        return false;
+    }
+    if (!viewport_data.presentation_refresh_pending) {
+        return true;
+    }
+
+    const auto render_resources = viewport_data.render_resources;
+    const auto surface_info     = viewport_data.surface_info;
+    const auto window_frame     = viewport_data.latest_window_frame;
+    const auto viewport_index   = viewport_data.viewport_index;
+    bool       committed        = false;
     RunRenderThreadControlAndWait(
-        [&rd_device,
+        [&device,
          render_resources,
          surface_info,
-         extent,
-         frame_in_flight = backend_data.frames_in_flight,
-         viewport_index]() {
-            CreateOrResizeViewportResources(
-                rd_device, render_resources, surface_info, extent, frame_in_flight, viewport_index
+         window_frame,
+         frames_in_flight,
+         viewport_index,
+         &committed]() {
+            committed = CreateOrResizeViewportResources(
+                device,
+                render_resources,
+                surface_info,
+                window_frame,
+                frames_in_flight,
+                viewport_index
             );
         }
     );
+    viewport_data.presentation_refresh_pending = !committed;
+    return committed;
+}
+
+void GuiCreateWindow(ImGuiViewport* _viewport) {
+    ImGuiData&       backend_data  = *GetImGuiBackendData();
+    GuiViewportData* viewport_data = MoerNew(GuiViewportData)(backend_data.frames_in_flight);
+    ImGuiRenderBackend& render_backend = *backend_data.render_backend;
+
+    _viewport->RendererUserData = viewport_data;
+    static_cast<void>(RefreshGuiViewportPresentation(
+        _viewport,
+        *viewport_data,
+        render_backend.device,
+        backend_data.frames_in_flight
+    ));
 }
 
 void GuiDestroyWindow(ImGuiViewport* _viewport) {
@@ -1011,41 +1143,20 @@ void GuiDestroyWindow(ImGuiViewport* _viewport) {
 }
 void GuiSetWindowSize(ImGuiViewport* _viewport, ImVec2 _size) {
     auto* viewport_data = static_cast<GuiViewportData*>(_viewport->RendererUserData);
-    if (!viewport_data || !viewport_data->render_resources || _size.x == 0 || _size.y == 0) {
+    if (!viewport_data || !viewport_data->render_resources) {
         return;
     }
-
-    void* platform_window =
-        _viewport->PlatformHandle ? _viewport->PlatformHandle : _viewport->PlatformHandleRaw;
-    if (!platform_window) {
-        return;
-    }
-
+    static_cast<void>(_size);
     ImGuiData* backend_data = GetImGuiBackendData();
-    auto&      rd_device    = backend_data->render_backend->device;
-    if (!viewport_data->surface_info.IsValid()) {
-        Moer::WindowHandle handle{static_cast<Moer::WindowType*>(platform_window)};
-        viewport_data->surface_info = WindowContext::CreateSwapchainSurfaceInfo(handle);
-    }
-    if (!viewport_data->surface_info.IsValid()) {
+    if (backend_data == nullptr) {
         return;
     }
-    const auto render_resources = viewport_data->render_resources;
-    const auto surface_info     = viewport_data->surface_info;
-    const auto viewport_index   = viewport_data->viewport_index;
-    const uint2 extent{static_cast<uint>(_size.x), static_cast<uint>(_size.y)};
-    RunRenderThreadControlAndWait(
-        [&rd_device,
-         render_resources,
-         surface_info,
-         extent,
-         frame_in_flight = backend_data->frames_in_flight,
-         viewport_index]() {
-            CreateOrResizeViewportResources(
-                rd_device, render_resources, surface_info, extent, frame_in_flight, viewport_index
-            );
-        }
-    );
+    static_cast<void>(RefreshGuiViewportPresentation(
+        _viewport,
+        *viewport_data,
+        backend_data->render_backend->device,
+        backend_data->frames_in_flight
+    ));
 }
 void GuiRenderWindow(ImGuiViewport* _viewport, void* _cmd_list) {
     auto* viewport_data = static_cast<GuiViewportData*>(_viewport->RendererUserData);
@@ -1056,6 +1167,9 @@ void GuiRenderWindow(ImGuiViewport* _viewport, void* _cmd_list) {
 
     ImGuiData& backend_data = *GetImGuiBackendData();
     auto       draw_packet  = CaptureViewportDrawPacket(_viewport->DrawData, viewport_data);
+    if (!IsUiViewportPresentationCurrent(draw_packet)) {
+        return;
+    }
     draw_packet.recording_slot =
         draw_packet.render_resources->GetPendingRecordingSlot();
     RenderGuiDrawPacket(
@@ -1080,10 +1194,22 @@ void GuiSwapBuffers(ImGuiViewport* _viewport, void*) {
     if (!viewport_data || !viewport_data->render_resources) {
         return;
     }
+    UiViewportDrawPacket present_packet{
+        .framebuffer = viewport_data->render_resources->framebuffer,
+        .swapchain   = viewport_data->render_resources->swapchain,
+    };
+    BindUiViewportWindowFrame(present_packet, viewport_data->latest_window_frame);
+    BindUiViewportPresentation(
+        present_packet,
+        viewport_data->render_resources->committed_presentation
+    );
+    if (!IsUiViewportPresentationCurrent(present_packet)) {
+        return;
+    }
     RHIExecutor::Get().Present(
         RHIPresentRequest(
-            viewport_data->render_resources->swapchain,
-            viewport_data->render_resources->framebuffer->GetView()
+            present_packet.swapchain,
+            present_packet.framebuffer->GetView()
         ),
         true
     );

--- a/source/runtime/render/renderer/common/ui/UIRenderer.cpp
+++ b/source/runtime/render/renderer/common/ui/UIRenderer.cpp
@@ -5,6 +5,193 @@
 #include "rhi/RHI.h"
 
 namespace Moer::Render {
+void BindUiViewportWindowFrame(
+    UiViewportDrawPacket&      viewport,
+    const WindowFrameSnapshot& window_frame
+) noexcept {
+    viewport.window_frame = window_frame;
+    if (!window_frame.IsDrawable() ||
+        window_frame.logical_extent.x == 0 ||
+        window_frame.logical_extent.y == 0) {
+        return;
+    }
+    viewport.framebuffer_scale = float2(
+        static_cast<float>(window_frame.drawable_extent.x) /
+            static_cast<float>(window_frame.logical_extent.x),
+        static_cast<float>(window_frame.drawable_extent.y) /
+            static_cast<float>(window_frame.logical_extent.y)
+    );
+}
+
+void BindUiViewportPresentation(
+    UiViewportDrawPacket&                 viewport,
+    const UiViewportPresentationSnapshot& presentation
+) noexcept {
+    viewport.presentation = presentation;
+    if (!presentation.IsValid() ||
+        !viewport.window_frame.IsValid() ||
+        presentation.surface_identity != viewport.window_frame.surface_identity ||
+        presentation.drawable_generation != viewport.window_frame.drawable_generation ||
+        viewport.window_frame.logical_extent.x == 0 ||
+        viewport.window_frame.logical_extent.y == 0) {
+        return;
+    }
+    viewport.framebuffer_scale = float2(
+        static_cast<float>(presentation.drawable_extent.x) /
+            static_cast<float>(viewport.window_frame.logical_extent.x),
+        static_cast<float>(presentation.drawable_extent.y) /
+            static_cast<float>(viewport.window_frame.logical_extent.y)
+    );
+}
+
+bool RetargetMainUiPresentation(
+    UiViewportDrawPacket&      main_viewport,
+    UiCompositionFrameData&    composition,
+    const WindowFrameSnapshot& window_frame,
+    Extent2D                   committed_extent
+) noexcept {
+    if (!window_frame.IsDrawable() ||
+        window_frame.logical_extent.x == 0 ||
+        window_frame.logical_extent.y == 0 ||
+        committed_extent.x == 0 ||
+        committed_extent.y == 0 ||
+        window_frame.drawable_generation == 0) {
+        return false;
+    }
+    if (main_viewport.presentation.IsValid() &&
+        main_viewport.presentation.surface_identity == window_frame.surface_identity &&
+        main_viewport.presentation.drawable_generation == window_frame.drawable_generation &&
+        main_viewport.presentation.drawable_extent == committed_extent) {
+        return true;
+    }
+
+    const float2 committed_to_raw_scale(
+        static_cast<float>(committed_extent.x) /
+            static_cast<float>(window_frame.drawable_extent.x),
+        static_cast<float>(committed_extent.y) /
+            static_cast<float>(window_frame.drawable_extent.y)
+    );
+
+    BindUiViewportWindowFrame(main_viewport, window_frame);
+    BindUiViewportPresentation(
+        main_viewport,
+        UiViewportPresentationSnapshot{
+            .surface_identity    = window_frame.surface_identity,
+            .drawable_extent     = committed_extent,
+            .drawable_generation = window_frame.drawable_generation,
+        }
+    );
+
+    if (composition.scene_extent_resolved && !composition.separate_window) {
+        composition.output_resolution = uint2(committed_extent.x, committed_extent.y);
+        composition.scene_color_position.x *= committed_to_raw_scale.x;
+        composition.scene_color_position.y *= committed_to_raw_scale.y;
+        composition.scene_color_resolution.x *= committed_to_raw_scale.x;
+        composition.scene_color_resolution.y *= committed_to_raw_scale.y;
+    }
+    return true;
+}
+
+bool ConvertUiClipRectToDrawable(
+    UiClipRect&   clip_rect,
+    const float2& display_position,
+    const float2& framebuffer_scale
+) noexcept {
+    if (framebuffer_scale.x <= 0.f || framebuffer_scale.y <= 0.f) {
+        return false;
+    }
+    clip_rect.min.x = (clip_rect.min.x - display_position.x) * framebuffer_scale.x;
+    clip_rect.min.y = (clip_rect.min.y - display_position.y) * framebuffer_scale.y;
+    clip_rect.max.x = (clip_rect.max.x - display_position.x) * framebuffer_scale.x;
+    clip_rect.max.y = (clip_rect.max.y - display_position.y) * framebuffer_scale.y;
+    return clip_rect.max.x > clip_rect.min.x && clip_rect.max.y > clip_rect.min.y;
+}
+
+bool IsUiViewportPresentationCommitted(const UiViewportDrawPacket& viewport) noexcept {
+    if (!viewport.window_frame.IsValid() ||
+        !viewport.presentation.IsValid() ||
+        !viewport.framebuffer ||
+        !viewport.swapchain ||
+        !viewport.swapchain->IsPresentationReady()) {
+        return false;
+    }
+    const auto framebuffer_extent = viewport.framebuffer->GetExtent();
+    return viewport.presentation.surface_identity == viewport.window_frame.surface_identity &&
+           viewport.presentation.drawable_generation ==
+               viewport.window_frame.drawable_generation &&
+           viewport.swapchain->GetCommittedSurfaceIdentity() ==
+               viewport.presentation.surface_identity &&
+           viewport.swapchain->size == viewport.presentation.drawable_extent &&
+           framebuffer_extent.x == viewport.presentation.drawable_extent.x &&
+           framebuffer_extent.y == viewport.presentation.drawable_extent.y;
+}
+
+bool IsUiViewportPresentationCurrent(const UiViewportDrawPacket& viewport) noexcept {
+    return !viewport.presentation_metadata_only &&
+           viewport.window_frame.IsDrawable() &&
+           IsUiViewportPresentationCommitted(viewport);
+}
+
+bool ResolveUiCompositionDrawableMetrics(
+    UiCompositionFrameData&    composition,
+    const WindowFrameSnapshot& main_window_frame,
+    const UiDrawFramePacket&   draw_frame
+) noexcept {
+    composition.scene_extent_resolved = false;
+    if (!composition.enabled) {
+        return true;
+    }
+
+    const WindowFrameSnapshot* target_frame        = &main_window_frame;
+    Extent2D                   target_extent       = main_window_frame.drawable_extent;
+    float2                     drawable_scale{};
+    bool                       target_metadata_only = false;
+    if (composition.separate_window) {
+        target_frame = nullptr;
+        if (!composition.window_frame_buffer) {
+            return false;
+        }
+        for (const UiViewportDrawPacket& viewport : draw_frame.platform_viewports) {
+            if (viewport.framebuffer.Get() == composition.window_frame_buffer.Get()) {
+                if (!IsUiViewportPresentationCommitted(viewport)) {
+                    return false;
+                }
+                target_frame = &viewport.window_frame;
+                target_extent = viewport.presentation.drawable_extent;
+                drawable_scale = viewport.framebuffer_scale;
+                target_metadata_only = viewport.presentation_metadata_only;
+                break;
+            }
+        }
+    }
+
+    if (target_frame == nullptr || !target_frame->IsValid() ||
+        (!composition.separate_window && !target_frame->IsDrawable()) ||
+        target_frame->logical_extent.x == 0 || target_frame->logical_extent.y == 0) {
+        return false;
+    }
+
+    if (!composition.separate_window) {
+        drawable_scale = float2(
+            static_cast<float>(target_extent.x) /
+                static_cast<float>(target_frame->logical_extent.x),
+            static_cast<float>(target_extent.y) /
+                static_cast<float>(target_frame->logical_extent.y)
+        );
+    }
+    composition.output_resolution = uint2(target_extent.x, target_extent.y);
+    composition.scene_color_position.x *= drawable_scale.x;
+    composition.scene_color_position.y *= drawable_scale.y;
+    composition.scene_color_resolution.x *= drawable_scale.x;
+    composition.scene_color_resolution.y *= drawable_scale.y;
+    composition.scene_extent_resolved = true;
+    if (target_metadata_only) {
+        composition.enabled             = false;
+        composition.window_frame_buffer = nullptr;
+    }
+    return true;
+}
+
 UiDrawFrameSlotClaim::UiDrawFrameSlotClaim(UiDrawFramePacket& frame) {
     slots.reserve(frame.platform_viewports.size() + 1);
     Freeze(frame.main_viewport);

--- a/source/runtime/render/renderer/raster/RasterFramePacket.h
+++ b/source/runtime/render/renderer/raster/RasterFramePacket.h
@@ -15,7 +15,7 @@ namespace Moer::Render::Raster {
 
 struct RasterFramePacket {
     uint64_t                   frame_id = 0;
-    Renderer::WindowFrameState window{};
+    WindowFrameSnapshot window{};
     RasterConfig               raster_config{};
     std::string                validation_selected_frame_buffer_name;
     EEditorViewportMode        active_viewport_mode = EEditorViewportMode::Game;

--- a/source/runtime/render/renderer/raster/RasterRenderer.cpp
+++ b/source/runtime/render/renderer/raster/RasterRenderer.cpp
@@ -333,8 +333,12 @@ RasterRenderer::PrepareFrame(const SharedPtr<EditorConfig> editor_config, const 
     {
         ScopedFramePrepareProfileTimer timer(profile_logging, prepare_profile.window_ms);
         LogSceneLoadStatus(*editor_config);
-        frame_packet.window = TickWindowContext(editor_config->GetResolution());
-        editor_config->SetResolution(frame_packet.window.resolution);
+        frame_packet.window = TickWindowContext();
+        const uint2 stable_drawable_resolution =
+            frame_packet.window.GetStableDrawableResolution();
+        if (stable_drawable_resolution.x != 0 && stable_drawable_resolution.y != 0) {
+            editor_config->SetResolution(stable_drawable_resolution);
+        }
     }
 
     {
@@ -428,30 +432,42 @@ RasterRenderer::PrepareFrame(const SharedPtr<EditorConfig> editor_config, const 
     }
 
     {
-        ScopedFramePrepareProfileTimer timer(profile_logging, prepare_profile.ui_composition_ms);
-        if (hooks.on_capture_ui_composition) {
-            frame_packet.ui_composition = hooks.on_capture_ui_composition();
-        }
-        frame_packet.scene_render_extent = CaptureSceneRenderExtentRequest(
-            frame_packet.ui_composition.enabled,
-            frame_packet.ui_composition.scene_color_resolution,
-            frame_packet.window.resolution
-        );
-    }
-    {
         ScopedFramePrepareProfileTimer timer(profile_logging, prepare_profile.ui_draw_packet_ms);
         if (hooks.on_capture_ui_draw_frame) {
             frame_packet.ui_draw_frame = hooks.on_capture_ui_draw_frame();
         }
+        BindUiViewportWindowFrame(
+            frame_packet.ui_draw_frame.main_viewport,
+            frame_packet.window
+        );
         CaptureFramePrepareUiWorkload(prepare_workload, frame_packet.ui_draw_frame);
+    }
+    {
+        ScopedFramePrepareProfileTimer timer(profile_logging, prepare_profile.ui_composition_ms);
+        if (hooks.on_capture_ui_composition) {
+            frame_packet.ui_composition = hooks.on_capture_ui_composition();
+        }
+        if (!ResolveUiCompositionDrawableMetrics(
+                frame_packet.ui_composition,
+                frame_packet.window,
+                frame_packet.ui_draw_frame
+            )) {
+            frame_packet.ui_composition.enabled             = false;
+            frame_packet.ui_composition.window_frame_buffer = nullptr;
+        }
+        frame_packet.scene_render_extent = CaptureSceneRenderExtentRequest(
+            frame_packet.ui_composition.scene_extent_resolved,
+            frame_packet.ui_composition.scene_color_resolution,
+            frame_packet.window.GetStableDrawableResolution()
+        );
     }
 
     if (frame_packet.frame_id == 0) {
         LOG_INFO(
             "[Threading] RasterFramePacket boundary active; resolution={}x{}, UI main vertices={}, "
             "platform viewports={}.",
-            frame_packet.window.resolution.x,
-            frame_packet.window.resolution.y,
+            frame_packet.window.GetStableDrawableResolution().x,
+            frame_packet.window.GetStableDrawableResolution().y,
             frame_packet.ui_draw_frame.main_viewport.vertices.size(),
             frame_packet.ui_draw_frame.platform_viewports.size()
         );
@@ -519,16 +535,33 @@ RasterFrameFeedback RasterRenderer::RenderFrame(RasterFramePacket frame_packet) 
     uint64 tail_source_order         = 1;
 
     auto& raster_context = *raster_context_ptr;
+    bool  main_presentation_current =
+        PrepareRenderFrame(frame_packet.window);
+    if (main_presentation_current) {
+        main_presentation_current = RetargetMainUiPresentation(
+            frame_packet.ui_draw_frame.main_viewport,
+            frame_packet.ui_composition,
+            frame_packet.window,
+            Extent2D(resolution.x, resolution.y)
+        );
+        frame_packet.scene_render_extent = CaptureSceneRenderExtentRequest(
+            frame_packet.ui_composition.scene_extent_resolved,
+            frame_packet.ui_composition.scene_color_resolution,
+            resolution
+        );
+    }
     auto scene_extent_request = frame_packet.scene_render_extent;
     // An OS-window resize already requires a presentation rebuild. Accept the
     // matching SceneColor layout immediately so the two resource domains move
     // together; dock-only drags retain the two-observation debounce.
-    if (frame_packet.window.state == EWindowState::SizeChanged && scene_extent_request.valid) {
+    if (frame_packet.window.IsDrawable() &&
+        frame_packet.window.transition != EWindowFrameTransition::Stable &&
+        frame_packet.window.transition != EWindowFrameTransition::LogicalResized &&
+        scene_extent_request.valid) {
         scene_extent_request.immediate = true;
     }
     (void)scene_render_extent_tracker.Observe(scene_extent_request);
     raster_context.BeginSceneFrame(frame_packet.scene_updates);
-    PrepareRenderFrame(frame_packet.window);
 
     if (time == 0) {
         const uint32_t frame_thread_id = IsCurrentlyRenderThread() ? GetRenderThreadId() : GetGameThreadId();
@@ -542,22 +575,21 @@ RasterFrameFeedback RasterRenderer::RenderFrame(RasterFramePacket frame_packet) 
     bool              skip_present = false;
     bool              split_graph_profiling_frame = false;
     PresentReceiptRef main_present_receipt{};
-    if (frame_packet.window.state == EWindowState::Hiding) {
+    if (!main_presentation_current ||
+        !frame_packet.window.IsDrawable() ||
+        !swapchain ||
+        !swapchain->IsPresentationReady()) {
         // 窗口最小化后无法 present，此处主动让出线程，避免高频空转。
         std::this_thread::yield();
         skip_present = true;
-    } else {
-        assert(
-            frame_packet.window.state == EWindowState::Default ||
-            frame_packet.window.state == EWindowState::SizeChanged
-        );
     }
 
-    const uint2 active_scene_extent = scene_render_extent_tracker.GetActiveExtent();
+    const uint2 active_scene_extent      = scene_render_extent_tracker.GetActiveExtent();
+    const uint2 presentation_resolution = resolution;
     const bool  recreate_scene_resources =
         !EqualRenderExtent(raster_context.GetResolution(), active_scene_extent);
     const bool recreate_output_resources =
-        !EqualRenderExtent(raster_context.GetOutputResolution(), frame_packet.window.resolution);
+        !EqualRenderExtent(raster_context.GetOutputResolution(), presentation_resolution);
 
     const bool recreate_frame_resources =
         !skip_present && (recreate_scene_resources || recreate_output_resources);
@@ -570,7 +602,7 @@ RasterFrameFeedback RasterRenderer::RenderFrame(RasterFramePacket frame_packet) 
         );
         raster_context.CreateFrameBuffers(
             active_scene_extent,
-            frame_packet.window.resolution,
+            presentation_resolution,
             recreate_scene_resources,
             recreate_output_resources
         );
@@ -1288,11 +1320,11 @@ RasterFrameFeedback RasterRenderer::RenderFrame(RasterFramePacket frame_packet) 
                         default_output_texture = ui_combine_pass->Process(
                             cmd_list,
                             true,
-                            frame_packet.window.resolution,
+                            presentation_resolution,
                             float2(0.f, 0.f),
                             float2(
-                                static_cast<float>(frame_packet.window.resolution.x),
-                                static_cast<float>(frame_packet.window.resolution.y)
+                                static_cast<float>(presentation_resolution.x),
+                                static_cast<float>(presentation_resolution.y)
                             ),
                             TextureView(raster_context.textures.output.tex),
                             processing_image.tex,
@@ -1766,7 +1798,8 @@ RasterFrameFeedback RasterRenderer::RenderFrame(RasterFramePacket frame_packet) 
 
     if (!skip_present) {
         const auto output_view = default_output_texture->GetView();
-        if (frame_packet.window.state == EWindowState::SizeChanged) {
+        if (frame_packet.window.transition != EWindowFrameTransition::Stable &&
+            frame_packet.window.transition != EWindowFrameTransition::LogicalResized) {
             LOG_INFO(
                 "[Threading][Resize] Main present source={}x{}, swapchain={}x{}, UI platform viewports={}.",
                 output_view.extent.x,

--- a/source/runtime/render/renderer/raytracing/RaytracingFramePacket.h
+++ b/source/runtime/render/renderer/raytracing/RaytracingFramePacket.h
@@ -25,7 +25,7 @@ struct RaytracingFramePacket {
 
     uint64 frame_id = 0;
 
-    Renderer::WindowFrameState   window{};
+    WindowFrameSnapshot          window{};
     RaytracingConfig             config{};
     SceneUpdateBatch             scene_updates{};
     RaytracingSceneFrameSnapshot scene_snapshot{};

--- a/source/runtime/render/renderer/raytracing/RaytracingRenderer.cpp
+++ b/source/runtime/render/renderer/raytracing/RaytracingRenderer.cpp
@@ -504,8 +504,12 @@ RaytracingRenderer::PrepareFrame(const SharedPtr<EditorConfig> editor_config, co
     {
         ScopedFramePrepareProfileTimer timer(profile_logging, prepare_profile.window_ms);
         LogSceneLoadStatus(*editor_config);
-        frame_packet.window = TickWindowContext(editor_config->GetResolution());
-        editor_config->SetResolution(frame_packet.window.resolution);
+        frame_packet.window = TickWindowContext();
+        const uint2 stable_drawable_resolution =
+            frame_packet.window.GetStableDrawableResolution();
+        if (stable_drawable_resolution.x != 0 && stable_drawable_resolution.y != 0) {
+            editor_config->SetResolution(stable_drawable_resolution);
+        }
     }
 
     {
@@ -611,30 +615,42 @@ RaytracingRenderer::PrepareFrame(const SharedPtr<EditorConfig> editor_config, co
     }
 
     {
-        ScopedFramePrepareProfileTimer timer(profile_logging, prepare_profile.ui_composition_ms);
-        if (hooks.on_capture_ui_composition) {
-            frame_packet.ui_composition = hooks.on_capture_ui_composition();
-        }
-        frame_packet.scene_render_extent = CaptureSceneRenderExtentRequest(
-            frame_packet.ui_composition.enabled,
-            frame_packet.ui_composition.scene_color_resolution,
-            frame_packet.window.resolution
-        );
-    }
-    {
         ScopedFramePrepareProfileTimer timer(profile_logging, prepare_profile.ui_draw_packet_ms);
         if (hooks.on_capture_ui_draw_frame) {
             frame_packet.ui_draw_frame = hooks.on_capture_ui_draw_frame();
         }
+        BindUiViewportWindowFrame(
+            frame_packet.ui_draw_frame.main_viewport,
+            frame_packet.window
+        );
         CaptureFramePrepareUiWorkload(prepare_workload, frame_packet.ui_draw_frame);
+    }
+    {
+        ScopedFramePrepareProfileTimer timer(profile_logging, prepare_profile.ui_composition_ms);
+        if (hooks.on_capture_ui_composition) {
+            frame_packet.ui_composition = hooks.on_capture_ui_composition();
+        }
+        if (!ResolveUiCompositionDrawableMetrics(
+                frame_packet.ui_composition,
+                frame_packet.window,
+                frame_packet.ui_draw_frame
+            )) {
+            frame_packet.ui_composition.enabled             = false;
+            frame_packet.ui_composition.window_frame_buffer = nullptr;
+        }
+        frame_packet.scene_render_extent = CaptureSceneRenderExtentRequest(
+            frame_packet.ui_composition.scene_extent_resolved,
+            frame_packet.ui_composition.scene_color_resolution,
+            frame_packet.window.GetStableDrawableResolution()
+        );
     }
 
     if (frame_packet.frame_id == 0) {
         LOG_INFO(
             "[Threading] RaytracingFramePacket boundary active on Game Thread; resolution={}x{}, "
             "UI main vertices={}, platform viewports={}.",
-            frame_packet.window.resolution.x,
-            frame_packet.window.resolution.y,
+            frame_packet.window.GetStableDrawableResolution().x,
+            frame_packet.window.GetStableDrawableResolution().y,
             frame_packet.ui_draw_frame.main_viewport.vertices.size(),
             frame_packet.ui_draw_frame.platform_viewports.size()
         );
@@ -725,10 +741,28 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
 
     auto& state     = *runtime_state;
     auto& ui_config = frame_packet.config;
+    bool  main_presentation_current =
+        PrepareRenderFrame(frame_packet.window);
+    if (main_presentation_current) {
+        main_presentation_current = RetargetMainUiPresentation(
+            frame_packet.ui_draw_frame.main_viewport,
+            frame_packet.ui_composition,
+            frame_packet.window,
+            Extent2D(resolution.x, resolution.y)
+        );
+        frame_packet.scene_render_extent = CaptureSceneRenderExtentRequest(
+            frame_packet.ui_composition.scene_extent_resolved,
+            frame_packet.ui_composition.scene_color_resolution,
+            resolution
+        );
+    }
     auto  scene_extent_request = frame_packet.scene_render_extent;
     // Keep dock-only changes debounced, but accept a matching OS-window
     // change immediately because presentation resources already have to move.
-    if (frame_packet.window.state == EWindowState::SizeChanged && scene_extent_request.valid) {
+    if (frame_packet.window.IsDrawable() &&
+        frame_packet.window.transition != EWindowFrameTransition::Stable &&
+        frame_packet.window.transition != EWindowFrameTransition::LogicalResized &&
+        scene_extent_request.valid) {
         scene_extent_request.immediate = true;
     }
     const bool scene_extent_advanced =
@@ -753,7 +787,6 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
         );
     }
 
-    PrepareRenderFrame(frame_packet.window);
     bool  skip_present                    = false;
     bool  split_graph_profiling_frame     = false;
     bool  frame_setup_graph_recorded      = false;
@@ -797,20 +830,15 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
     uint64                                           graph_submission_value_count = 0;
     UiFrameGraphPass::GraphPasses                    ui_graph_passes{};
 
-    switch (frame_packet.window.state) {
-        case EWindowState::Hiding:
-            std::this_thread::yield();
-            skip_present = true;
-            break;
-        case EWindowState::SizeChanged:
-            break;
-        case EWindowState::Default:
-            break;
-        default:
-            assert(false);
-            break;
+    if (!main_presentation_current ||
+        !frame_packet.window.IsDrawable() ||
+        !swapchain ||
+        !swapchain->IsPresentationReady()) {
+        std::this_thread::yield();
+        skip_present = true;
     }
 
+    const uint2 presentation_resolution = resolution;
     const uint3 current_scene_extent_3d  = state.rt_ctx->frame_rt.ldr_color->GetExtent();
     const uint3 current_output_extent_3d = state.output->GetExtent();
     const bool recreate_scene_resources = !EqualRenderExtent(
@@ -818,12 +846,12 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
     );
     const bool recreate_output_resources = !EqualRenderExtent(
         uint2(current_output_extent_3d.x, current_output_extent_3d.y),
-        frame_packet.window.resolution
+        presentation_resolution
     );
 
     if (!skip_present && (recreate_scene_resources || recreate_output_resources)) {
         if (recreate_output_resources) {
-            RecreateOutputResources(frame_packet.window.resolution);
+            RecreateOutputResources(presentation_resolution);
             output_resources_recreated = true;
         }
         if (recreate_scene_resources) {
@@ -855,8 +883,8 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
                 frame_packet.scene_render_extent.valid,
                 active_scene_extent.x,
                 active_scene_extent.y,
-                frame_packet.window.resolution.x,
-                frame_packet.window.resolution.y,
+                presentation_resolution.x,
+                presentation_resolution.y,
                 swapchain->size.x,
                 swapchain->size.y,
                 scene_resources_recreated,
@@ -1912,7 +1940,8 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
     std::optional<RHIPresentRequest> present_request{};
     if (!skip_present) {
         const auto output_view = state.output->GetView();
-        if (frame_packet.window.state == EWindowState::SizeChanged) {
+        if (frame_packet.window.transition != EWindowFrameTransition::Stable &&
+            frame_packet.window.transition != EWindowFrameTransition::LogicalResized) {
             LOG_INFO(
                 "[Threading][Resize] Raytracing main present source={}x{}, swapchain={}x{}, UI platform "
                 "viewports={}.",

--- a/source/runtime/render/rhi/RHIResource.h
+++ b/source/runtime/render/rhi/RHIResource.h
@@ -1395,9 +1395,10 @@ protected:
     Swapchain() : RHIResource(RRT_SWAPCHAIN) {};
 
 public:
-    virtual void Recreate(const SwapchainCreateInfo&) = 0;
-    virtual ~Swapchain()                              = default;
-    virtual void Sync()                               = 0;
+    [[nodiscard]] virtual bool Recreate(const SwapchainCreateInfo&) = 0;
+    virtual ~Swapchain()                                            = default;
+    virtual void Sync()                                             = 0;
+    [[nodiscard]] virtual bool IsPresentationReady() const noexcept = 0;
     [[nodiscard]] virtual WindowSurfaceIdentity GetCommittedSurfaceIdentity() const noexcept = 0;
 
 public:

--- a/source/runtime/render/rhi/d3d12/D3D12Device.cpp
+++ b/source/runtime/render/rhi/d3d12/D3D12Device.cpp
@@ -756,12 +756,13 @@ D3D12Device::PushSamplerDescriptor(std::span<const DescriptorIndex> _index_in_cp
 }
 
 D3D12Swapchain::D3D12Swapchain(D3D12Device& device, const SwapchainCreateInfo& info) : device(device) {
-    Recreate(info);
+    static_cast<void>(Recreate(info));
 }
 
-void D3D12Swapchain::Recreate(const SwapchainCreateInfo& _info) {
+bool D3D12Swapchain::Recreate(const SwapchainCreateInfo& _info) {
     (void)_info;
     FATAL("not implemented");
+    return false;
 }
 
 void D3D12Swapchain::Sync() {

--- a/source/runtime/render/rhi/d3d12/D3D12Device.h
+++ b/source/runtime/render/rhi/d3d12/D3D12Device.h
@@ -1065,8 +1065,11 @@ public:
     D3D12Swapchain(D3D12Device& device, const SwapchainCreateInfo& info);
     ~D3D12Swapchain() = default;
 
-    void Recreate(const SwapchainCreateInfo&) override;
+    [[nodiscard]] bool Recreate(const SwapchainCreateInfo&) override;
     void Sync() override;
+    [[nodiscard]] bool IsPresentationReady() const noexcept override {
+        return false;
+    }
     [[nodiscard]] WindowSurfaceIdentity GetCommittedSurfaceIdentity() const noexcept override {
         return {};
     }

--- a/source/runtime/render/rhi/vulkan/VulkanSwapChain.cpp
+++ b/source/runtime/render/rhi/vulkan/VulkanSwapChain.cpp
@@ -145,7 +145,7 @@ VkSwapchain::VkSwapchain(RenderDevice::Impl& _device, const SwapchainCreateInfo&
     Swapchain(),
     device(*static_cast<VulkanDevice*>(&_device)) {
     present_threads.resize(max_frames_in_flight);
-    CreateOrRecreate(_info);
+    static_cast<void>(CreateOrRecreate(_info));
 }
 bool VkSwapchain::WaitFrameInFlight() {
     // if (image_idx < max_frames_in_flight) {
@@ -207,20 +207,20 @@ VkFence VkSwapchain::GetInFlightFence(uint64 _index) {
     return in_flight_fences[_index % in_flight_fences.size()];
 }
 
-void VkSwapchain::Recreate(const SwapchainCreateInfo& _info) {
+bool VkSwapchain::Recreate(const SwapchainCreateInfo& _info) {
     //FIXME: this is not a good way to do it, and it may have issue in multi-threaded env
     //best do sync in a separate thread, and give sync op to user
     // vkQueueWaitIdle(device.GetPresentQueue());
-    CreateOrRecreate(_info);
+    return CreateOrRecreate(_info);
 }
-void VkSwapchain::CreateOrRecreate(const SwapchainCreateInfo& _info, bool _force_recreate) {
+bool VkSwapchain::CreateOrRecreate(const SwapchainCreateInfo& _info, bool _force_recreate) {
     (void)_force_recreate;
     if (device.IsFaulted()) {
-        return;
+        return false;
     }
     if (_info.size.x == 0 || _info.size.y == 0) {
         LOG_WARNING("Swapchain recreate skipped due to zero window size.");
-        return;
+        return false;
     }
 
     const ESwapchainSurfaceTransition surface_transition =
@@ -234,12 +234,12 @@ void VkSwapchain::CreateOrRecreate(const SwapchainCreateInfo& _info, bool _force
             false,
             true
         );
-        return;
+        return false;
     }
 
     Sync();
     if (device.IsFaulted()) {
-        return;
+        return false;
     }
 
     const VkSwapchainKHR committed_old_sc       = handle;
@@ -269,7 +269,7 @@ void VkSwapchain::CreateOrRecreate(const SwapchainCreateInfo& _info, bool _force
                 false,
                 true
             );
-            return;
+            return false;
         }
     }
 
@@ -283,7 +283,7 @@ void VkSwapchain::CreateOrRecreate(const SwapchainCreateInfo& _info, bool _force
             false,
             true
         );
-        return;
+        return false;
     }
 
     const VkUtil::SwapChainSupportQueryResult support_query = VkUtil::QuerySwapChainSupport(
@@ -303,7 +303,7 @@ void VkSwapchain::CreateOrRecreate(const SwapchainCreateInfo& _info, bool _force
             false,
             true
         );
-        return;
+        return false;
     }
 
     const auto&        details = support_query.details;
@@ -312,7 +312,7 @@ void VkSwapchain::CreateOrRecreate(const SwapchainCreateInfo& _info, bool _force
     ChooseSwapExtent(&new_size.x, &new_size.y, details.capabilities);
     if (new_size.x == 0 || new_size.y == 0) {
         LOG_WARNING("Swapchain recreate skipped due to zero swapchain extent.");
-        return;
+        return false;
     }
     VkPresentModeKHR   present_mode = ChooseSwapPresentMode(details.present_modes, false);
     const EPixelFormat new_format   = (EPixelFormat)new_fmt.format;
@@ -351,7 +351,7 @@ void VkSwapchain::CreateOrRecreate(const SwapchainCreateInfo& _info, bool _force
 
     auto fault_admission = device.AcquireFaultAdmission();
     if (device.IsFaulted()) {
-        return;
+        return false;
     }
 
     VkSwapchainKHR        new_sc = VK_NULL_HANDLE;
@@ -427,7 +427,7 @@ void VkSwapchain::CreateOrRecreate(const SwapchainCreateInfo& _info, bool _force
     }
     if (!check_device_result(result, EVulkanFaultOperation::SwapchainCreate)) {
         abort_transaction();
-        return;
+        return false;
     }
 
     uint32_t       image_cnt = 0;
@@ -437,14 +437,14 @@ void VkSwapchain::CreateOrRecreate(const SwapchainCreateInfo& _info, bool _force
         result = vkGetSwapchainImagesKHR(device.GetDevice(), new_sc, &image_cnt, nullptr);
         if (!check_device_result(result, EVulkanFaultOperation::SwapchainGetImages)) {
             abort_transaction();
-            return;
+            return false;
         }
         if (image_cnt == 0) {
             check_device_result(
                 VK_ERROR_INITIALIZATION_FAILED, EVulkanFaultOperation::SwapchainGetImages
             );
             abort_transaction();
-            return;
+            return false;
         }
 
         images.assign(image_cnt, VK_NULL_HANDLE);
@@ -457,14 +457,14 @@ void VkSwapchain::CreateOrRecreate(const SwapchainCreateInfo& _info, bool _force
         }
         if (!check_device_result(result, EVulkanFaultOperation::SwapchainGetImages)) {
             abort_transaction();
-            return;
+            return false;
         }
         if (fetched_image_cnt == 0) {
             check_device_result(
                 VK_ERROR_INITIALIZATION_FAILED, EVulkanFaultOperation::SwapchainGetImages
             );
             abort_transaction();
-            return;
+            return false;
         }
         image_cnt = fetched_image_cnt;
         images.resize(image_cnt);
@@ -477,7 +477,7 @@ void VkSwapchain::CreateOrRecreate(const SwapchainCreateInfo& _info, bool _force
             VK_ERROR_INITIALIZATION_FAILED, EVulkanFaultOperation::SwapchainGetImages
         );
         abort_transaction();
-        return;
+        return false;
     }
 
     const uint new_max_frames_in_flight = std::min(max_frames_in_flight, uint(image_cnt));
@@ -493,7 +493,7 @@ void VkSwapchain::CreateOrRecreate(const SwapchainCreateInfo& _info, bool _force
         }
         if (!check_device_result(result, EVulkanFaultOperation::SwapchainSemaphoreCreate)) {
             abort_transaction();
-            return;
+            return false;
         }
         device.SetResourceName(
             uint64(new_render_finished_fences[i]),
@@ -514,7 +514,7 @@ void VkSwapchain::CreateOrRecreate(const SwapchainCreateInfo& _info, bool _force
             }
             if (!check_device_result(result, EVulkanFaultOperation::SwapchainFenceCreate)) {
                 abort_transaction();
-                return;
+                return false;
             }
             device.SetResourceName(
                 uint64(new_in_flight_fences[i]),
@@ -542,7 +542,7 @@ void VkSwapchain::CreateOrRecreate(const SwapchainCreateInfo& _info, bool _force
     }
     if (!check_device_result(VK_SUCCESS, EVulkanFaultOperation::SwapchainCreate)) {
         abort_transaction();
-        return;
+        return false;
     }
 
     // A replacement surface uses oldSwapchain = VK_NULL_HANDLE, so the old
@@ -577,6 +577,7 @@ void VkSwapchain::CreateOrRecreate(const SwapchainCreateInfo& _info, bool _force
         in_flight_fences = std::move(new_in_flight_fences);
     }
     image_idx = 0;
+    return IsPresentationReady();
 }
 VkSwapchain::~VkSwapchain() {
     Sync();

--- a/source/runtime/render/rhi/vulkan/VulkanSwapChain.h
+++ b/source/runtime/render/rhi/vulkan/VulkanSwapChain.h
@@ -40,8 +40,9 @@ public:
     friend VkCommandQueue;
     VkSwapchain(RenderDevice::Impl& _device, const SwapchainCreateInfo& _info);
     ~VkSwapchain();
-    void Recreate(const SwapchainCreateInfo& _info) override;
-    void CreateOrRecreate(const SwapchainCreateInfo& _info, bool _force_recreate = false);
+    [[nodiscard]] bool Recreate(const SwapchainCreateInfo& _info) override;
+    [[nodiscard]] bool
+    CreateOrRecreate(const SwapchainCreateInfo& _info, bool _force_recreate = false);
     AcquireResult AquireNextImage(
         VkSemaphore _ready_semaphore,
         uint64      _timeout = UINT64_MAX
@@ -55,6 +56,14 @@ public:
         uint64  _work_serial
     );
     void                                Sync() override;
+    [[nodiscard]] bool IsPresentationReady() const noexcept override {
+        return handle != VK_NULL_HANDLE &&
+               surface != VK_NULL_HANDLE &&
+               surface_info.IsValid() &&
+               surface_info.GetIdentity().IsValid() &&
+               size.x != 0 &&
+               size.y != 0;
+    }
     [[nodiscard]] WindowSurfaceIdentity GetCommittedSurfaceIdentity() const noexcept override {
         return surface_info.GetIdentity();
     }

--- a/source/runtime/render/window/WindowContext.cpp
+++ b/source/runtime/render/window/WindowContext.cpp
@@ -19,9 +19,9 @@ void WindowContext::SetFocusMode(WindowHandle* window, bool focused) {
     WindowImpl::GetInstance().SetFocusMode(window, focused);
 };
 
-void WindowContext::GetWindowSize(WindowHandle* window, int* width, int* height) {
-    WindowImpl::GetInstance().GetWindowSize(window, width, height);
-};
+Render::WindowFrameMetrics WindowContext::CaptureWindowFrameMetrics(const WindowHandle& window) {
+    return WindowImpl::GetInstance().CaptureWindowFrameMetrics(window);
+}
 
 void WindowContext::SetTitle(WindowHandle* window, const char* newTitle) {
     WindowImpl::GetInstance().SetTitle(window, newTitle);

--- a/source/runtime/render/window/WindowContext.h
+++ b/source/runtime/render/window/WindowContext.h
@@ -4,6 +4,7 @@
 #include "RenderAPI.h"
 
 #include "rhi/RHIWindowSurface.h"
+#include "window/WindowFrameSnapshot.h"
 #include <functional>
 
 namespace Moer {
@@ -69,7 +70,9 @@ public:
     static void Tick();
     static void ShutDown();
     //new support for multi window
-    static void          GetWindowSize(WindowHandle*, int* width, int* height);
+    // Captures logical and drawable extents together on the Game Thread.
+    // Render/RHI code consumes the returned value and never queries GLFW.
+    static Render::WindowFrameMetrics CaptureWindowFrameMetrics(const WindowHandle&);
     static void          SetFocusMode(WindowHandle*, bool focused);
     static bool          GetFocusMode(WindowHandle*);
     static WindowHandle* GetMainWindow();

--- a/source/runtime/render/window/WindowContextImpl.h
+++ b/source/runtime/render/window/WindowContextImpl.h
@@ -12,12 +12,13 @@ public:
     virtual void Tick()     = 0;
 
     //for multi-window support
-    virtual void SetFocusMode(WindowHandle*, bool _focused)                          = 0;
-    virtual void GetWindowSize(WindowHandle*, int32_t* width, int32_t* height) const = 0;
-    virtual void SetTitle(WindowHandle*, const char* _new_title)                     = 0;
-    virtual void RequestClose(WindowHandle*)                                          = 0;
-    virtual bool ShouldClose(WindowHandle*) const                                    = 0;
-    virtual void ShowMainWindow()                                                    = 0;
+    virtual void SetFocusMode(WindowHandle*, bool _focused) = 0;
+    virtual Render::WindowFrameMetrics
+    CaptureWindowFrameMetrics(const WindowHandle&) const      = 0;
+    virtual void SetTitle(WindowHandle*, const char* _new_title) = 0;
+    virtual void RequestClose(WindowHandle*)                     = 0;
+    virtual bool ShouldClose(WindowHandle*) const                 = 0;
+    virtual void ShowMainWindow()                                 = 0;
 
     virtual Render::SwapchainSurfaceInfo CreateSwapchainSurfaceInfo(const WindowHandle&) const = 0;
 

--- a/source/runtime/render/window/WindowFrameSnapshot.h
+++ b/source/runtime/render/window/WindowFrameSnapshot.h
@@ -1,0 +1,132 @@
+#pragma once
+
+#include "rhi/RHIWindowSurface.h"
+
+#include <cstdint>
+
+namespace Moer::Render {
+
+struct WindowFrameMetrics {
+    Extent2D logical_extent{};
+    Extent2D drawable_extent{};
+    bool     valid{false};
+};
+
+enum class EWindowFrameTransition : uint8_t {
+    Invalid,
+    Initial,
+    Stable,
+    LogicalResized,
+    DrawableResized,
+    Minimized,
+    Restored,
+    Replaced,
+};
+
+struct WindowFrameSnapshot {
+    WindowSurfaceIdentity   surface_identity{};
+    Extent2D                logical_extent{};
+    Extent2D                drawable_extent{};
+    Extent2D                last_drawable_extent{};
+    uint64_t                capture_sequence{0};
+    uint64_t                drawable_generation{0};
+    EWindowFrameTransition  transition{EWindowFrameTransition::Invalid};
+
+    [[nodiscard]] bool IsValid() const noexcept {
+        return transition != EWindowFrameTransition::Invalid && surface_identity.IsValid();
+    }
+
+    [[nodiscard]] bool IsDrawable() const noexcept {
+        return IsValid() && drawable_extent.width != 0 && drawable_extent.height != 0;
+    }
+
+    [[nodiscard]] Extent2D GetStableDrawableExtent() const noexcept {
+        return last_drawable_extent;
+    }
+
+    [[nodiscard]] Moer::uint2 GetStableDrawableResolution() const noexcept {
+        return {last_drawable_extent.x, last_drawable_extent.y};
+    }
+};
+
+// Pure state machine for turning GT-captured window metrics into immutable
+// frame values. Invalid captures advance sequencing but never replace the last
+// valid state used to classify the next capture.
+class WindowFrameSnapshotTracker {
+public:
+    [[nodiscard]] WindowFrameSnapshot
+    Advance(const WindowSurfaceIdentity& surface_identity, const WindowFrameMetrics& metrics) noexcept {
+        const uint64_t capture_sequence = ++capture_sequence_;
+        if (!surface_identity.IsValid() || !metrics.valid) {
+            WindowFrameSnapshot invalid_snapshot = last_valid_snapshot_;
+            invalid_snapshot.capture_sequence    = capture_sequence;
+            invalid_snapshot.transition          = EWindowFrameTransition::Invalid;
+            return invalid_snapshot;
+        }
+
+        const bool has_drawable =
+            metrics.drawable_extent.width != 0 && metrics.drawable_extent.height != 0;
+
+        WindowFrameSnapshot snapshot{
+            .surface_identity     = surface_identity,
+            .logical_extent       = metrics.logical_extent,
+            .drawable_extent      = metrics.drawable_extent,
+            .capture_sequence     = capture_sequence,
+        };
+
+        if (!has_valid_snapshot_) {
+            snapshot.last_drawable_extent = has_drawable ? metrics.drawable_extent : Extent2D{};
+            snapshot.drawable_generation  = has_drawable ? 1 : 0;
+            snapshot.transition =
+                has_drawable ? EWindowFrameTransition::Initial : EWindowFrameTransition::Minimized;
+            Commit(snapshot);
+            return snapshot;
+        }
+
+        if (surface_identity != last_valid_snapshot_.surface_identity) {
+            snapshot.last_drawable_extent = has_drawable ? metrics.drawable_extent : Extent2D{};
+            snapshot.drawable_generation  = last_valid_snapshot_.drawable_generation + 1;
+            snapshot.transition           = EWindowFrameTransition::Replaced;
+            Commit(snapshot);
+            return snapshot;
+        }
+
+        const bool had_drawable = last_valid_snapshot_.IsDrawable();
+        snapshot.last_drawable_extent = last_valid_snapshot_.last_drawable_extent;
+        snapshot.drawable_generation  = last_valid_snapshot_.drawable_generation;
+
+        if (!has_drawable) {
+            snapshot.transition =
+                had_drawable ? EWindowFrameTransition::Minimized : EWindowFrameTransition::Stable;
+        } else if (!had_drawable) {
+            snapshot.last_drawable_extent = metrics.drawable_extent;
+            ++snapshot.drawable_generation;
+            snapshot.transition = EWindowFrameTransition::Restored;
+        } else if (metrics.drawable_extent != last_valid_snapshot_.drawable_extent) {
+            snapshot.last_drawable_extent = metrics.drawable_extent;
+            ++snapshot.drawable_generation;
+            snapshot.transition = EWindowFrameTransition::DrawableResized;
+        } else if (metrics.logical_extent != last_valid_snapshot_.logical_extent) {
+            snapshot.last_drawable_extent = metrics.drawable_extent;
+            snapshot.transition           = EWindowFrameTransition::LogicalResized;
+        } else {
+            snapshot.last_drawable_extent = metrics.drawable_extent;
+            snapshot.transition           = EWindowFrameTransition::Stable;
+        }
+
+        Commit(snapshot);
+        return snapshot;
+    }
+
+private:
+    void Commit(const WindowFrameSnapshot& snapshot) noexcept {
+        last_valid_snapshot_ = snapshot;
+        has_valid_snapshot_  = true;
+    }
+
+    WindowFrameSnapshot last_valid_snapshot_{};
+    uint64_t            capture_sequence_{0};
+    bool                has_valid_snapshot_{false};
+};
+
+} // namespace Moer::Render

--- a/source/runtime/render/window/glfw/GLFWWindowImpl.cpp
+++ b/source/runtime/render/window/glfw/GLFWWindowImpl.cpp
@@ -447,8 +447,43 @@ void GLFWWindowImpl::SetFocusMode(WindowHandle* _window, bool _focused) {
     );
 }
 
-void GLFWWindowImpl::GetWindowSize(WindowHandle* _window, int32_t* width, int32_t* height) const {
-    glfwGetWindowSize((GLFWwindow*)_window->window, width, height);
+Render::WindowFrameMetrics
+GLFWWindowImpl::CaptureWindowFrameMetrics(const WindowHandle& window) const {
+    if (!IsCurrentlyGameThread()) {
+        LOG_ERROR("Window frame metrics may only be captured on the Game Thread.");
+        return {};
+    }
+
+    auto* glfw_window = static_cast<GLFWwindow*>(window.window);
+    if (glfw_window == nullptr) {
+        return {};
+    }
+
+    int logical_width   = 0;
+    int logical_height  = 0;
+    int drawable_width  = 0;
+    int drawable_height = 0;
+    glfwGetWindowSize(glfw_window, &logical_width, &logical_height);
+    glfwGetFramebufferSize(glfw_window, &drawable_width, &drawable_height);
+    if (logical_width < 0 || logical_height < 0 || drawable_width < 0 || drawable_height < 0) {
+        LOG_ERROR(
+            "GLFW returned invalid window metrics: logical={}x{}, drawable={}x{}.",
+            logical_width,
+            logical_height,
+            drawable_width,
+            drawable_height
+        );
+        return {};
+    }
+
+    return Render::WindowFrameMetrics{
+        .logical_extent =
+            Extent2D(static_cast<uint32_t>(logical_width), static_cast<uint32_t>(logical_height)),
+        .drawable_extent = Extent2D(
+            static_cast<uint32_t>(drawable_width), static_cast<uint32_t>(drawable_height)
+        ),
+        .valid = true
+    };
 }
 
 void GLFWWindowImpl::SetTitle(WindowHandle* _window, const char* _new_title) {

--- a/source/runtime/render/window/glfw/GLFWWindowImpl.h
+++ b/source/runtime/render/window/glfw/GLFWWindowImpl.h
@@ -21,12 +21,13 @@ public:
     virtual void ShutDown() override;
 
     //for multi-window support
-    virtual void  SetFocusMode(WindowHandle*, bool _focused) override;
-    virtual void  GetWindowSize(WindowHandle*, int32_t* width, int32_t* height) const override;
-    virtual void  SetTitle(WindowHandle*, const char* _new_title) override;
-    virtual void  RequestClose(WindowHandle*) override;
-    virtual bool  ShouldClose(WindowHandle*) const override;
-    virtual void  ShowMainWindow() override;
+    virtual void SetFocusMode(WindowHandle*, bool _focused) override;
+    virtual Render::WindowFrameMetrics
+    CaptureWindowFrameMetrics(const WindowHandle&) const override;
+    virtual void SetTitle(WindowHandle*, const char* _new_title) override;
+    virtual void RequestClose(WindowHandle*) override;
+    virtual bool ShouldClose(WindowHandle*) const override;
+    virtual void ShowMainWindow() override;
     virtual Render::SwapchainSurfaceInfo CreateSwapchainSurfaceInfo(const WindowHandle&) const override;
 
 private:

--- a/source/test/CMakeLists.txt
+++ b/source/test/CMakeLists.txt
@@ -166,6 +166,15 @@ set_target_properties(${test_target} PROPERTIES FOLDER ${moer_test_folder})
 add_test(NAME WindowSurfaceSourceContract COMMAND $<TARGET_FILE:${test_target}>)
 set_tests_properties(WindowSurfaceSourceContract PROPERTIES TIMEOUT 60)
 
+set(test_target TestWindowFrameSnapshot)
+add_executable(${test_target} "WindowFrameSnapshotContractTest.cpp")
+target_link_libraries(${test_target}
+    PRIVATE Moer::Render
+)
+set_target_properties(${test_target} PROPERTIES FOLDER ${moer_test_folder})
+add_test(NAME WindowFrameSnapshotContract COMMAND $<TARGET_FILE:${test_target}>)
+set_tests_properties(WindowFrameSnapshotContract PROPERTIES TIMEOUT 60)
+
 set(test_target TestRHICmdReorderer)
 add_executable(${test_target} "RHICmdReordererTest.cpp")
 target_link_libraries(${test_target}

--- a/source/test/RHIParallelRecordVulkanTest.cpp
+++ b/source/test/RHIParallelRecordVulkanTest.cpp
@@ -274,8 +274,17 @@ public:
         size   = Extent2D(4, 4);
     }
 
-    void Recreate(const SwapchainCreateInfo&) override {}
+    [[nodiscard]] bool Recreate(const SwapchainCreateInfo& info) override {
+        if (info.size.x == 0 || info.size.y == 0) {
+            return false;
+        }
+        size = info.size;
+        return IsPresentationReady();
+    }
     void Sync() override {}
+    [[nodiscard]] bool IsPresentationReady() const noexcept override {
+        return size.x != 0 && size.y != 0;
+    }
     [[nodiscard]] WindowSurfaceIdentity GetCommittedSurfaceIdentity() const noexcept override {
         return {};
     }

--- a/source/test/RenderGraphTest.cpp
+++ b/source/test/RenderGraphTest.cpp
@@ -4060,9 +4060,10 @@ public:
             ETextureUsageFlags::PRESENTATION_SOURCE |
             ETextureUsageFlags::TRANSFER_SRC |
             ETextureUsageFlags::TRANSFER_DST,
-        ETextureAspectFlags aspects = ETextureAspectFlags::COLOR
+        ETextureAspectFlags aspects = ETextureAspectFlags::COLOR,
+        Extent2D            extent  = Extent2D(64, 64)
     ) :
-        Texture(MakeInfo(usage, aspects)) {
+        Texture(MakeInfo(usage, aspects, extent)) {
         SetName(name);
     }
 
@@ -4077,18 +4078,51 @@ public:
 private:
     static Moer::Render::TextureInfo MakeInfo(
         ETextureUsageFlags  usage,
-        ETextureAspectFlags aspects
+        ETextureAspectFlags aspects,
+        Extent2D            extent
     ) {
         using namespace Moer::Render;
         TextureInfo info{};
         info.usage        = usage;
-        info.extent       = {64, 64};
+        info.extent       = extent;
         info.num_mips     = 1;
         info.array_size   = 1;
         info.format       = PF_R8G8B8A8_UNORM;
         info.aspect_flags = aspects;
         return info;
     }
+};
+
+class FakeUiSwapchain final : public Moer::Render::Swapchain {
+public:
+    FakeUiSwapchain(
+        Moer::Render::WindowSurfaceIdentity identity,
+        Extent2D                             extent,
+        bool                                 presentation_ready = true
+    ) :
+        identity(identity),
+        presentation_ready(presentation_ready) {
+        format = PF_R8G8B8A8_UNORM;
+        size   = extent;
+    }
+
+    [[nodiscard]] bool Recreate(const Moer::Render::SwapchainCreateInfo&) override {
+        return presentation_ready;
+    }
+    void Sync() override {}
+
+    [[nodiscard]] bool IsPresentationReady() const noexcept override {
+        return presentation_ready;
+    }
+
+    [[nodiscard]] Moer::Render::WindowSurfaceIdentity
+    GetCommittedSurfaceIdentity() const noexcept override {
+        return identity;
+    }
+
+private:
+    Moer::Render::WindowSurfaceIdentity identity{};
+    bool                                presentation_ready{true};
 };
 
 Moer::Render::UiDrawFramePacket MakeUiDrawPacket(
@@ -4107,6 +4141,300 @@ Moer::Render::UiDrawFramePacket MakeUiDrawPacket(
         packet.platform_viewports.emplace_back(std::move(platform));
     }
     return packet;
+}
+
+void TestUiDrawablePresentationContracts(TestSuite& suite) {
+    using namespace Moer;
+    using namespace Moer::Render;
+    constexpr std::string_view test_name =
+        "UI drawable presentation snapshot contract";
+
+    const WindowSurfaceIdentity identity{
+        .window_system          = EWindowSystemType::GLFW,
+        .window_system_handle   = 0x1000u,
+        .platform_window_handle = 0x2000u,
+        .generation             = 1,
+    };
+    const WindowSurfaceIdentity other_identity{
+        .window_system          = EWindowSystemType::GLFW,
+        .window_system_handle   = 0x3000u,
+        .platform_window_handle = 0x4000u,
+        .generation             = 1,
+    };
+    const WindowFrameSnapshot detached_frame{
+        .surface_identity     = identity,
+        .logical_extent       = {32, 32},
+        .drawable_extent      = {80, 80},
+        .last_drawable_extent = {80, 80},
+        .capture_sequence     = 1,
+        .drawable_generation  = 1,
+        .transition           = EWindowFrameTransition::Initial,
+    };
+    const UiViewportPresentationSnapshot committed_presentation{
+        .surface_identity    = identity,
+        .drawable_extent     = {64, 64},
+        .drawable_generation = 1,
+    };
+
+    TextureRef   framebuffer{MoerNew(FakeUiTexture)("DetachedFramebuffer")};
+    SwapchainRef matching_swapchain{
+        MoerNew(FakeUiSwapchain)(identity, Extent2D(64, 64))
+    };
+    UiViewportDrawPacket viewport{
+        .framebuffer  = framebuffer,
+        .swapchain    = matching_swapchain,
+        .window_frame = detached_frame,
+    };
+    BindUiViewportWindowFrame(viewport, detached_frame);
+    BindUiViewportPresentation(viewport, committed_presentation);
+    suite.Check(
+        IsUiViewportPresentationCurrent(viewport) &&
+            viewport.framebuffer_scale == float2(2.f, 2.f),
+        test_name,
+        "a committed 64x64 presentation for a raw 80x80 request was rejected or used raw scaling"
+    );
+
+    viewport.presentation.surface_identity = other_identity;
+    suite.Check(
+        !IsUiViewportPresentationCurrent(viewport),
+        test_name,
+        "a committed presentation with a different surface identity was accepted"
+    );
+
+    viewport.presentation = committed_presentation;
+    viewport.swapchain =
+        SwapchainRef{MoerNew(FakeUiSwapchain)(other_identity, Extent2D(64, 64))};
+    suite.Check(
+        !IsUiViewportPresentationCurrent(viewport),
+        test_name,
+        "a native swapchain with a different committed surface identity was accepted"
+    );
+
+    viewport.swapchain                         = matching_swapchain;
+    viewport.presentation                      = committed_presentation;
+    viewport.presentation.drawable_generation = 2;
+    suite.Check(
+        !IsUiViewportPresentationCurrent(viewport),
+        test_name,
+        "a committed presentation from a different drawable generation was accepted"
+    );
+
+    viewport.presentation = committed_presentation;
+    viewport.swapchain =
+        SwapchainRef{MoerNew(FakeUiSwapchain)(identity, Extent2D(64, 64), false)};
+    suite.Check(
+        !IsUiViewportPresentationCurrent(viewport),
+        test_name,
+        "a swapchain without a ready committed presentation was accepted"
+    );
+
+    viewport.swapchain = matching_swapchain;
+    viewport.presentation.drawable_extent = {32, 32};
+    suite.Check(
+        !IsUiViewportPresentationCurrent(viewport),
+        test_name,
+        "a committed drawable extent that differs from the native swapchain was accepted"
+    );
+
+    viewport.presentation = committed_presentation;
+    viewport.swapchain =
+        SwapchainRef{MoerNew(FakeUiSwapchain)(identity, Extent2D(32, 32))};
+    suite.Check(
+        !IsUiViewportPresentationCurrent(viewport),
+        test_name,
+        "a swapchain extent that differs from the drawable snapshot was accepted"
+    );
+
+    TextureRef small_framebuffer{MoerNew(FakeUiTexture)(
+        "SmallDetachedFramebuffer",
+        ETextureUsageFlags::SAMPLED |
+            ETextureUsageFlags::COLOR_ATTACHMENT |
+            ETextureUsageFlags::PRESENTATION_SOURCE |
+            ETextureUsageFlags::TRANSFER_SRC |
+            ETextureUsageFlags::TRANSFER_DST,
+        ETextureAspectFlags::COLOR,
+        Extent2D(32, 32)
+    )};
+    viewport.swapchain   = matching_swapchain;
+    viewport.framebuffer = small_framebuffer;
+    suite.Check(
+        !IsUiViewportPresentationCurrent(viewport),
+        test_name,
+        "a framebuffer extent that differs from the committed swapchain was accepted"
+    );
+
+    viewport.framebuffer  = framebuffer;
+    viewport.presentation = committed_presentation;
+    UiDrawFramePacket draw_frame{};
+    draw_frame.platform_viewports.emplace_back(std::move(viewport));
+    UiCompositionFrameData composition{
+        .enabled                = true,
+        .separate_window        = true,
+        .output_resolution      = {32, 32},
+        .scene_color_position   = {3.f, 5.f},
+        .scene_color_resolution = {10.f, 12.f},
+        .window_frame_buffer    = framebuffer,
+    };
+    suite.Check(
+        ResolveUiCompositionDrawableMetrics(
+            composition,
+            {},
+            draw_frame
+        ) &&
+            composition.output_resolution == uint2(64, 64) &&
+            composition.scene_color_position == float2(6.f, 10.f) &&
+            composition.scene_color_resolution == float2(20.f, 24.f),
+        test_name,
+        "detached composition did not use the committed actual extent and 2x drawable scale"
+    );
+
+    UiClipRect detached_clip{
+        .min = {11.f, 21.f},
+        .max = {21.f, 31.f},
+    };
+    suite.Check(
+        ConvertUiClipRectToDrawable(
+            detached_clip,
+            float2(10.f, 20.f),
+            draw_frame.platform_viewports.front().framebuffer_scale
+        ) &&
+            detached_clip.min == float2(2.f, 2.f) &&
+            detached_clip.max == float2(22.f, 22.f),
+        test_name,
+        "detached clip conversion used an assumed main-window 1x scale instead of its 2x scale"
+    );
+
+    UiViewportDrawPacket main_viewport{};
+    main_viewport.commands.emplace_back(UiDrawCommand{
+        .clip_min = {4.f, 8.f},
+        .clip_max = {12.f, 16.f},
+    });
+    BindUiViewportWindowFrame(main_viewport, detached_frame);
+    UiCompositionFrameData main_composition{
+        .enabled                = true,
+        .separate_window        = false,
+        .scene_extent_resolved  = true,
+        .output_resolution      = {80, 80},
+        .scene_color_position   = {10.f, 20.f},
+        .scene_color_resolution = {40.f, 20.f},
+    };
+    const bool main_retargeted = RetargetMainUiPresentation(
+        main_viewport,
+        main_composition,
+        detached_frame,
+        Extent2D(64, 64)
+    );
+    UiClipRect main_committed_clip{
+        .min = main_viewport.commands.front().clip_min,
+        .max = main_viewport.commands.front().clip_max,
+    };
+    const bool main_clip_resolved = ConvertUiClipRectToDrawable(
+        main_committed_clip,
+        float2(0.f, 0.f),
+        main_viewport.framebuffer_scale
+    );
+    suite.Check(
+        main_retargeted &&
+            main_clip_resolved &&
+            main_viewport.presentation.drawable_extent == Extent2D(64, 64) &&
+            main_viewport.framebuffer_scale == float2(2.f, 2.f) &&
+            main_viewport.commands.front().clip_min == float2(4.f, 8.f) &&
+            main_viewport.commands.front().clip_max == float2(12.f, 16.f) &&
+            main_committed_clip.min == float2(8.f, 16.f) &&
+            main_committed_clip.max == float2(24.f, 32.f) &&
+            main_composition.output_resolution == uint2(64, 64) &&
+            main_composition.scene_color_position == float2(8.f, 16.f) &&
+            main_composition.scene_color_resolution == float2(32.f, 16.f),
+        test_name,
+        "main UI was not retargeted from raw 80x80 into the committed 64x64 presentation domain"
+    );
+
+    auto& minimized_viewport = draw_frame.platform_viewports.front();
+    WindowFrameSnapshot minimized_frame = detached_frame;
+    minimized_frame.drawable_extent      = {0, 0};
+    minimized_frame.last_drawable_extent = detached_frame.last_drawable_extent;
+    minimized_frame.capture_sequence     = 2;
+    minimized_frame.transition           = EWindowFrameTransition::Minimized;
+    BindUiViewportWindowFrame(minimized_viewport, minimized_frame);
+    BindUiViewportPresentation(minimized_viewport, committed_presentation);
+    minimized_viewport.presentation_metadata_only = true;
+    suite.Check(
+        minimized_viewport.window_frame.GetStableDrawableExtent() ==
+                detached_frame.last_drawable_extent &&
+            IsUiViewportPresentationCommitted(minimized_viewport) &&
+            !IsUiViewportPresentationCurrent(minimized_viewport),
+        test_name,
+        "a minimized snapshot did not retain its committed detached presentation"
+    );
+
+    UiCompositionFrameData minimized_composition{
+        .enabled                = true,
+        .separate_window        = true,
+        .output_resolution      = {80, 80},
+        .scene_color_position   = {3.f, 5.f},
+        .scene_color_resolution = {10.f, 12.f},
+        .window_frame_buffer    = framebuffer,
+    };
+    suite.Check(
+        ResolveUiCompositionDrawableMetrics(
+            minimized_composition,
+            {},
+            draw_frame
+        ) &&
+            !minimized_composition.enabled &&
+            minimized_composition.scene_extent_resolved &&
+            !minimized_composition.window_frame_buffer &&
+            minimized_composition.output_resolution == uint2(64, 64) &&
+            minimized_composition.scene_color_position == float2(6.f, 10.f) &&
+            minimized_composition.scene_color_resolution == float2(20.f, 24.f),
+        test_name,
+        "minimization did not preserve scene extent as metadata-only composition state"
+    );
+
+    WindowFrameSnapshot invalid_frame = minimized_frame;
+    invalid_frame.capture_sequence     = 3;
+    invalid_frame.transition           = EWindowFrameTransition::Invalid;
+    BindUiViewportWindowFrame(minimized_viewport, invalid_frame);
+    BindUiViewportPresentation(minimized_viewport, committed_presentation);
+    UiCompositionFrameData invalid_composition{
+        .enabled             = true,
+        .separate_window     = true,
+        .window_frame_buffer = framebuffer,
+    };
+    suite.Check(
+        !IsUiViewportPresentationCommitted(minimized_viewport) &&
+            !IsUiViewportPresentationCurrent(minimized_viewport) &&
+            !ResolveUiCompositionDrawableMetrics(
+                invalid_composition,
+                {},
+                draw_frame
+            ),
+        test_name,
+        "an invalid detached snapshot reused a committed presentation"
+    );
+
+    WindowFrameSnapshot replaced_generation_frame = detached_frame;
+    replaced_generation_frame.capture_sequence     = 4;
+    replaced_generation_frame.drawable_generation  = 2;
+    replaced_generation_frame.transition           = EWindowFrameTransition::Replaced;
+    BindUiViewportWindowFrame(minimized_viewport, replaced_generation_frame);
+    BindUiViewportPresentation(minimized_viewport, committed_presentation);
+    UiCompositionFrameData replaced_composition{
+        .enabled             = true,
+        .separate_window     = true,
+        .window_frame_buffer = framebuffer,
+    };
+    suite.Check(
+        !IsUiViewportPresentationCommitted(minimized_viewport) &&
+            !IsUiViewportPresentationCurrent(minimized_viewport) &&
+            !ResolveUiCompositionDrawableMetrics(
+                replaced_composition,
+                {},
+                draw_frame
+            ),
+        test_name,
+        "a replaced detached generation reused the prior committed presentation"
+    );
 }
 
 void TestRasterStyleUiSlotClaimTracksNativeAcceptance(TestSuite& suite) {
@@ -4402,6 +4730,7 @@ void TestUiFrameGraphTailContract(TestSuite& suite) {
     TextureRef main_output(MoerNew(FakeUiTexture)("MainOutput"));
     TextureRef window_output(MoerNew(FakeUiTexture)("SceneWindow"));
     TextureRef platform_output(MoerNew(FakeUiTexture)("PlatformOutput"));
+    TextureRef metadata_output(MoerNew(FakeUiTexture)("MetadataOnlyOutput"));
 
     auto shared_slots = Moer::MakeShared<FakeUiViewportResources>(5);
     auto platform_slots = Moer::MakeShared<FakeUiViewportResources>(9);
@@ -4411,17 +4740,22 @@ void TestUiFrameGraphTailContract(TestSuite& suite) {
     draw_frame.main_viewport.render_resources = shared_slots;
     draw_frame.main_viewport.commands.emplace_back();
 
-    const auto append_platform = [&](TextureRef framebuffer,
-                                     Moer::SharedPtr<FakeUiViewportResources> slots) {
+    const auto append_platform = [&](
+                                     TextureRef framebuffer,
+                                     Moer::SharedPtr<FakeUiViewportResources> slots,
+                                     bool metadata_only = false
+                                 ) {
         UiViewportDrawPacket viewport{};
-        viewport.framebuffer      = std::move(framebuffer);
-        viewport.render_resources = std::move(slots);
+        viewport.framebuffer                 = std::move(framebuffer);
+        viewport.render_resources            = std::move(slots);
+        viewport.presentation_metadata_only  = metadata_only;
         viewport.commands.emplace_back();
         draw_frame.platform_viewports.emplace_back(std::move(viewport));
     };
     append_platform(main_output, shared_slots);
     append_platform(window_output, shared_slots);
     append_platform(platform_output, platform_slots);
+    append_platform(metadata_output, platform_slots, true);
 
     UiCompositionFrameData composition{
         .enabled                 = true,
@@ -4448,11 +4782,15 @@ void TestUiFrameGraphTailContract(TestSuite& suite) {
         linear_shared_slots;
     linear_draw_frame.main_viewport.commands.emplace_back();
     const auto append_linear_platform =
-        [&](TextureRef framebuffer,
-            Moer::SharedPtr<FakeUiViewportResources> slots) {
+        [&](
+            TextureRef framebuffer,
+            Moer::SharedPtr<FakeUiViewportResources> slots,
+            bool metadata_only = false
+        ) {
             UiViewportDrawPacket viewport{};
-            viewport.framebuffer      = std::move(framebuffer);
-            viewport.render_resources = std::move(slots);
+            viewport.framebuffer                = std::move(framebuffer);
+            viewport.render_resources           = std::move(slots);
+            viewport.presentation_metadata_only = metadata_only;
             viewport.commands.emplace_back();
             linear_draw_frame.platform_viewports.emplace_back(
                 std::move(viewport)
@@ -4461,6 +4799,7 @@ void TestUiFrameGraphTailContract(TestSuite& suite) {
     append_linear_platform(main_output, linear_shared_slots);
     append_linear_platform(window_output, linear_shared_slots);
     append_linear_platform(platform_output, linear_platform_slots);
+    append_linear_platform(metadata_output, linear_platform_slots, true);
     auto linear_prepared = UiFrameGraphPass::Prepare(
         UiCompositionFrameData{
             .enabled                = true,
@@ -7083,6 +7422,7 @@ int main() {
     TestSuite suite;
     TestStableSerialCallbackOrder(suite);
     TestPassCompletionObserverRunsAfterEachCallback(suite);
+    TestUiDrawablePresentationContracts(suite);
     TestRasterStyleUiSlotClaimTracksNativeAcceptance(suite);
     TestUiPreparedFrameLifecycleIsOneShot(suite);
     TestUiFrameGraphTailContract(suite);

--- a/source/test/VulkanHeaderContractTest.cpp
+++ b/source/test/VulkanHeaderContractTest.cpp
@@ -11,6 +11,7 @@
 #endif
 
 #include "rhi/RHIWindowSurface.h"
+#include "window/WindowFrameSnapshot.h"
 #include "rhi/vulkan/VulkanDebugCallback.h"
 #include "rhi/vulkan/VulkanFault.h"
 #include "rhi/vulkan/VulkanMemoryAllocator.h"

--- a/source/test/WindowFrameSnapshotContractTest.cpp
+++ b/source/test/WindowFrameSnapshotContractTest.cpp
@@ -1,0 +1,266 @@
+#include "renderer/common/UIRenderer.h"
+#include "window/WindowFrameSnapshot.h"
+
+#include <cstdlib>
+
+using namespace Moer::Render;
+
+namespace {
+
+void Require(bool condition) {
+    if (!condition) {
+        std::abort();
+    }
+}
+
+WindowSurfaceIdentity MakeIdentity(
+    uintptr_t window_system_handle,
+    uintptr_t platform_window_handle,
+    uint64_t  generation
+) {
+    return {
+        .window_system          = EWindowSystemType::GLFW,
+        .window_system_handle   = window_system_handle,
+        .platform_window_handle = platform_window_handle,
+        .generation             = generation,
+    };
+}
+
+WindowFrameMetrics MakeMetrics(Extent2D logical_extent, Extent2D drawable_extent) {
+    return {
+        .logical_extent  = logical_extent,
+        .drawable_extent = drawable_extent,
+        .valid           = true,
+    };
+}
+
+void RequireExtent(Extent2D actual, Extent2D expected) {
+    Require(actual == expected);
+}
+
+} // namespace
+
+int main() {
+    const WindowSurfaceIdentity identity_a = MakeIdentity(0x1000u, 0x2000u, 1u);
+
+    WindowFrameSnapshotTracker tracker;
+    const WindowFrameSnapshot invalid_first = tracker.Advance({}, MakeMetrics({800, 600}, {800, 600}));
+    Require(invalid_first.transition == EWindowFrameTransition::Invalid);
+    Require(invalid_first.capture_sequence == 1);
+    Require(!invalid_first.IsValid());
+    Require(!invalid_first.IsDrawable());
+
+    const WindowFrameSnapshot initial = tracker.Advance(identity_a, MakeMetrics({800, 600}, {800, 600}));
+    Require(initial.transition == EWindowFrameTransition::Initial);
+    Require(initial.capture_sequence == 2);
+    Require(initial.drawable_generation == 1);
+    Require(initial.IsValid());
+    Require(initial.IsDrawable());
+    RequireExtent(initial.GetStableDrawableExtent(), {800, 600});
+    const Moer::uint2 initial_stable_resolution = initial.GetStableDrawableResolution();
+    Require(initial_stable_resolution.x == 800);
+    Require(initial_stable_resolution.y == 600);
+
+    const WindowFrameSnapshot immutable_copy = initial;
+    const WindowFrameSnapshot stable = tracker.Advance(identity_a, MakeMetrics({800, 600}, {800, 600}));
+    Require(stable.transition == EWindowFrameTransition::Stable);
+    Require(stable.capture_sequence == 3);
+    Require(stable.drawable_generation == 1);
+    Require(immutable_copy.transition == EWindowFrameTransition::Initial);
+    Require(immutable_copy.capture_sequence == 2);
+    RequireExtent(immutable_copy.drawable_extent, {800, 600});
+
+    const WindowFrameSnapshot logical_resized =
+        tracker.Advance(identity_a, MakeMetrics({640, 480}, {800, 600}));
+    Require(logical_resized.transition == EWindowFrameTransition::LogicalResized);
+    Require(logical_resized.capture_sequence == 4);
+    Require(logical_resized.drawable_generation == 1);
+    RequireExtent(logical_resized.logical_extent, {640, 480});
+    RequireExtent(logical_resized.drawable_extent, {800, 600});
+
+    // A DPI/content-scale change can leave the logical extent untouched while
+    // changing the framebuffer extent.
+    const WindowFrameSnapshot dpi_resized =
+        tracker.Advance(identity_a, MakeMetrics({640, 480}, {1280, 960}));
+    Require(dpi_resized.transition == EWindowFrameTransition::DrawableResized);
+    Require(dpi_resized.capture_sequence == 5);
+    Require(dpi_resized.drawable_generation == 2);
+    RequireExtent(dpi_resized.GetStableDrawableExtent(), {1280, 960});
+
+    const WindowFrameSnapshot minimized = tracker.Advance(identity_a, MakeMetrics({640, 480}, {0, 0}));
+    Require(minimized.transition == EWindowFrameTransition::Minimized);
+    Require(minimized.capture_sequence == 6);
+    Require(minimized.drawable_generation == 2);
+    Require(minimized.IsValid());
+    Require(!minimized.IsDrawable());
+    RequireExtent(minimized.GetStableDrawableExtent(), {1280, 960});
+
+    const WindowFrameSnapshot repeated_zero =
+        tracker.Advance(identity_a, MakeMetrics({320, 240}, {0, 0}));
+    Require(repeated_zero.transition == EWindowFrameTransition::Stable);
+    Require(repeated_zero.capture_sequence == 7);
+    Require(repeated_zero.drawable_generation == 2);
+    RequireExtent(repeated_zero.logical_extent, {320, 240});
+    RequireExtent(repeated_zero.GetStableDrawableExtent(), {1280, 960});
+
+    const WindowFrameSnapshot restored_same =
+        tracker.Advance(identity_a, MakeMetrics({1280, 960}, {1280, 960}));
+    Require(restored_same.transition == EWindowFrameTransition::Restored);
+    Require(restored_same.capture_sequence == 8);
+    Require(restored_same.drawable_generation == 3);
+    Require(restored_same.IsDrawable());
+    RequireExtent(restored_same.GetStableDrawableExtent(), {1280, 960});
+
+    const WindowFrameSnapshot minimized_again =
+        tracker.Advance(identity_a, MakeMetrics({1280, 960}, {0, 0}));
+    Require(minimized_again.transition == EWindowFrameTransition::Minimized);
+    Require(minimized_again.drawable_generation == 3);
+
+    const WindowFrameSnapshot restored_different =
+        tracker.Advance(identity_a, MakeMetrics({1024, 768}, {1024, 768}));
+    Require(restored_different.transition == EWindowFrameTransition::Restored);
+    Require(restored_different.capture_sequence == 10);
+    Require(restored_different.drawable_generation == 4);
+    RequireExtent(restored_different.GetStableDrawableExtent(), {1024, 768});
+
+    const WindowFrameSnapshot drawable_resized =
+        tracker.Advance(identity_a, MakeMetrics({1024, 768}, {1600, 1200}));
+    Require(drawable_resized.transition == EWindowFrameTransition::DrawableResized);
+    Require(drawable_resized.capture_sequence == 11);
+    Require(drawable_resized.drawable_generation == 5);
+
+    const WindowFrameSnapshot invalid_metrics = tracker.Advance(
+        MakeIdentity(0x3000u, 0x4000u, 1u),
+        {
+            .logical_extent  = {1, 1},
+            .drawable_extent = {1, 1},
+            .valid           = false,
+        }
+    );
+    Require(invalid_metrics.transition == EWindowFrameTransition::Invalid);
+    Require(invalid_metrics.capture_sequence == 12);
+    Require(invalid_metrics.surface_identity == identity_a);
+    Require(invalid_metrics.drawable_generation == 5);
+    RequireExtent(invalid_metrics.GetStableDrawableExtent(), {1600, 1200});
+
+    // The invalid capture did not replace the last valid identity or metrics.
+    const WindowFrameSnapshot stable_after_invalid =
+        tracker.Advance(identity_a, MakeMetrics({1024, 768}, {1600, 1200}));
+    Require(stable_after_invalid.transition == EWindowFrameTransition::Stable);
+    Require(stable_after_invalid.capture_sequence == 13);
+    Require(stable_after_invalid.drawable_generation == 5);
+
+    const WindowSurfaceIdentity identity_b = MakeIdentity(0x3000u, 0x4000u, 1u);
+    const WindowFrameSnapshot replaced = tracker.Advance(identity_b, MakeMetrics({900, 700}, {1800, 1400}));
+    Require(replaced.transition == EWindowFrameTransition::Replaced);
+    Require(replaced.capture_sequence == 14);
+    Require(replaced.drawable_generation == 6);
+    Require(replaced.surface_identity == identity_b);
+    RequireExtent(replaced.GetStableDrawableExtent(), {1800, 1400});
+
+    const WindowSurfaceIdentity identity_b_recreated = MakeIdentity(0x3000u, 0x4000u, 2u);
+    const WindowFrameSnapshot replaced_zero =
+        tracker.Advance(identity_b_recreated, MakeMetrics({900, 700}, {0, 0}));
+    Require(replaced_zero.transition == EWindowFrameTransition::Replaced);
+    Require(replaced_zero.capture_sequence == 15);
+    Require(replaced_zero.drawable_generation == 7);
+    Require(!replaced_zero.IsDrawable());
+    RequireExtent(replaced_zero.GetStableDrawableExtent(), {0, 0});
+
+    const WindowFrameSnapshot replacement_zero_stable =
+        tracker.Advance(identity_b_recreated, MakeMetrics({900, 700}, {0, 0}));
+    Require(replacement_zero_stable.transition == EWindowFrameTransition::Stable);
+    Require(replacement_zero_stable.drawable_generation == 7);
+
+    const WindowFrameSnapshot replacement_restored =
+        tracker.Advance(identity_b_recreated, MakeMetrics({900, 700}, {900, 700}));
+    Require(replacement_restored.transition == EWindowFrameTransition::Restored);
+    Require(replacement_restored.capture_sequence == 17);
+    Require(replacement_restored.drawable_generation == 8);
+    RequireExtent(replacement_restored.GetStableDrawableExtent(), {900, 700});
+
+    // Same native handles returning after another identity are still a
+    // replacement when the native-window generation changes (ABA defense).
+    const WindowSurfaceIdentity identity_a_recreated = MakeIdentity(0x1000u, 0x2000u, 2u);
+    const WindowFrameSnapshot aba_replaced =
+        tracker.Advance(identity_a_recreated, MakeMetrics({800, 600}, {800, 600}));
+    Require(aba_replaced.transition == EWindowFrameTransition::Replaced);
+    Require(aba_replaced.capture_sequence == 18);
+    Require(aba_replaced.drawable_generation == 9);
+    Require(aba_replaced.surface_identity == identity_a_recreated);
+
+    // Mutating a returned value cannot mutate the tracker's internal state.
+    WindowFrameSnapshot mutable_copy = aba_replaced;
+    mutable_copy.drawable_extent     = {1, 1};
+    mutable_copy.drawable_generation = 0;
+    const WindowFrameSnapshot stable_after_copy_mutation =
+        tracker.Advance(identity_a_recreated, MakeMetrics({800, 600}, {800, 600}));
+    Require(stable_after_copy_mutation.transition == EWindowFrameTransition::Stable);
+    Require(stable_after_copy_mutation.capture_sequence == 19);
+    Require(stable_after_copy_mutation.drawable_generation == 9);
+    RequireExtent(stable_after_copy_mutation.drawable_extent, {800, 600});
+
+    WindowFrameSnapshotTracker zero_first_tracker;
+    const WindowFrameSnapshot zero_first =
+        zero_first_tracker.Advance(identity_a, MakeMetrics({800, 600}, {0, 0}));
+    Require(zero_first.transition == EWindowFrameTransition::Minimized);
+    Require(zero_first.capture_sequence == 1);
+    Require(zero_first.drawable_generation == 0);
+    Require(zero_first.IsValid());
+    Require(!zero_first.IsDrawable());
+    RequireExtent(zero_first.GetStableDrawableExtent(), {0, 0});
+
+    const WindowFrameSnapshot zero_first_repeated =
+        zero_first_tracker.Advance(identity_a, MakeMetrics({800, 600}, {0, 0}));
+    Require(zero_first_repeated.transition == EWindowFrameTransition::Stable);
+    Require(zero_first_repeated.capture_sequence == 2);
+    Require(zero_first_repeated.drawable_generation == 0);
+
+    const WindowFrameSnapshot zero_first_restored =
+        zero_first_tracker.Advance(identity_a, MakeMetrics({800, 600}, {800, 600}));
+    Require(zero_first_restored.transition == EWindowFrameTransition::Restored);
+    Require(zero_first_restored.capture_sequence == 3);
+    Require(zero_first_restored.drawable_generation == 1);
+    RequireExtent(zero_first_restored.GetStableDrawableExtent(), {800, 600});
+
+    WindowFrameSnapshot high_dpi_frame{
+        .surface_identity     = identity_a,
+        .logical_extent       = {800, 600},
+        .drawable_extent      = {1600, 1200},
+        .last_drawable_extent = {1600, 1200},
+        .capture_sequence     = 1,
+        .drawable_generation  = 1,
+        .transition           = EWindowFrameTransition::Initial,
+    };
+    UiDrawFramePacket high_dpi_draw_frame{};
+    BindUiViewportWindowFrame(high_dpi_draw_frame.main_viewport, high_dpi_frame);
+    Require(high_dpi_draw_frame.main_viewport.framebuffer_scale == Moer::float2(2.f, 2.f));
+
+    UiCompositionFrameData high_dpi_composition{
+        .enabled                = true,
+        .separate_window        = false,
+        .output_resolution      = {800, 600},
+        .scene_color_position   = {10.f, 20.f},
+        .scene_color_resolution = {320.f, 180.f},
+    };
+    Require(ResolveUiCompositionDrawableMetrics(
+        high_dpi_composition,
+        high_dpi_frame,
+        high_dpi_draw_frame
+    ));
+    Require(high_dpi_composition.output_resolution == Moer::uint2(1600, 1200));
+    Require(high_dpi_composition.scene_color_position == Moer::float2(20.f, 40.f));
+    Require(high_dpi_composition.scene_color_resolution == Moer::float2(640.f, 360.f));
+
+    UiCompositionFrameData unresolved_detached{
+        .enabled         = true,
+        .separate_window = true,
+    };
+    Require(!ResolveUiCompositionDrawableMetrics(
+        unresolved_detached,
+        high_dpi_frame,
+        high_dpi_draw_frame
+    ));
+
+    return 0;
+}


### PR DESCRIPTION
## Summary

- capture logical and drawable window metrics on the Game Thread and pass immutable `WindowFrameSnapshot` values to Raster, Raytracing, and copied ImGui packets
- track drawable generations across resize, minimize/restore, surface replacement, and native-handle ABA
- make swapchain recreate success explicit and gate main/detached recording and Present on committed identity, generation, readiness, framebuffer, and backend actual extent
- preserve ImGui clip rectangles in logical coordinates until RT presentation finalization, including mixed-DPI and Vulkan extent-clamp paths
- retain minimized detached viewports as metadata-only scene-extent sources while excluding them from graph recording and Present

## Why

Phase 22A established immutable window surface identity. Phase 22B extends that contract to per-frame window state so Render/RHI threads no longer read live GLFW dimensions and presentation state is derived from what the backend actually committed rather than the latest request.

This is a semantic port of the `dev_parallel_rhi` window/presentation direction onto main's current RenderGraph, Executor, Submission, Completion, and DeviceFault ownership model.

## Validation

- Debug full build: passed
- Debug CTest: 35/35 passed
- Release full build: passed
- Release CTest: 35/35 passed
- final affected Debug/Release rebuilds and focused contracts: passed
- Release runtime: Raytracing Sponza first frame, maximize/restore, minimize/restore, Raster↔Raytracing, detached viewport creation/release, and clean shutdown passed
- independent local reviews: P0/P1/P2 = 0/0/0
- `git diff --check`: clean (line-ending notices only)

## Compatibility

This intentionally changes C++ interfaces/layouts for `WindowContext`, renderer frame packets, copied UI packets, and `Swapchain::Recreate`. In-tree Vulkan, D3D12, and test fakes are updated; out-of-tree subclasses/plugins require a clean rebuild and source migration.

## Follow-up

- Phase 22C: GT-owned input/ImGui snapshot and single-owner GLFW callback chaining
- Phase 22D: RT-owned presentation wrapper and typed persistent Present recovery