### PR TITLE
Phase 22D.1: centralize PresentationSurface ownership

### DIFF
--- a/source/runtime/render/renderer/Renderer.cpp
+++ b/source/runtime/render/renderer/Renderer.cpp
@@ -22,7 +22,7 @@ namespace Moer::Render {
 Renderer::Renderer(
     uint2                         initial_resolution,
     const SharedPtr<EditorConfig> config,
-    SwapchainSurfaceInfo          main_window_surface,
+    SwapchainSurfaceInfo          _main_window_surface,
     RenderProfileCapture*         _render_profile_capture
 ) :
     device(RenderDevice::Get()),
@@ -30,17 +30,19 @@ Renderer::Renderer(
     gfx_queue(device.GetCommandQueue(EQueueType::Graphics)),
     resolution(initial_resolution),
     render_profile_capture(_render_profile_capture),
+    main_window_surface(std::move(_main_window_surface)),
     scene(),
     cmd_list() {
 
     {
-        swapchain_create_info = SwapchainCreateInfo{
-            .surface          = std::move(main_window_surface),
-            .size             = {resolution.x, resolution.y},
-            .back_buffer_sz   = 2,
-            .preferred_format = PF_R8G8B8A8_SRGB
-        };
-        swapchain = device.CreateSwapchain(swapchain_create_info);
+        main_presentation_surface = MakeUnique<PresentationSurface>(
+            device,
+            PresentationSurfaceDesc{
+                .back_buffer_count = 2,
+                .preferred_format  = PF_R8G8B8A8_SRGB,
+                .debug_name        = "Main Presentation Surface",
+            }
+        );
     }
     {
         bindless_array = device.CreateBindlessArray();
@@ -142,8 +144,9 @@ void Renderer::ReleaseResources() {
     resources_released = true;
 
     timeline->Wait(time);
-    RHIExecutor::Get().Sync(ERHISyncDepth::Present);
-    swapchain->Sync();
+    if (main_presentation_surface) {
+        main_presentation_surface->Release();
+    }
     device.WaitIdle();
 
     render_scene.reset();
@@ -162,7 +165,7 @@ void Renderer::ReleaseResources() {
 WindowFrameSnapshot Renderer::TickWindowContext() {
     WindowContext::Tick();
     return main_window_frame_tracker.Advance(
-        swapchain_create_info.surface.GetIdentity(),
+        main_window_surface.GetIdentity(),
         WindowContext::CaptureWindowFrameMetrics(*WindowContext::GetMainWindow())
     );
 }
@@ -175,45 +178,24 @@ bool Renderer::PrepareRenderFrame(const WindowFrameSnapshot& window_frame) {
 
     const bool recreate_requested =
         main_swapchain_recreate_requested.exchange(false, std::memory_order_acq_rel);
-    const bool presentation_ready =
-        swapchain && swapchain->IsPresentationReady();
-    if (!window_frame.IsDrawable()) {
-        if (recreate_requested || !presentation_ready) {
-            // A zero-extent swapchain cannot be recreated. Preserve the WSI
-            // recovery request until the window has a drawable extent again.
-            main_swapchain_recreate_requested.store(true, std::memory_order_release);
-        }
-        return false;
-    }
-    if (!swapchain) {
-        main_swapchain_recreate_requested.store(true, std::memory_order_release);
+    if (!main_presentation_surface) {
         return false;
     }
 
-    const Extent2D drawable_extent = window_frame.drawable_extent;
-    const bool request_matches =
-        presentation_ready &&
-        committed_main_surface_identity == window_frame.surface_identity &&
-        committed_main_drawable_generation == window_frame.drawable_generation;
-    if (request_matches && !recreate_requested) {
-        resolution = uint2(swapchain->size.x, swapchain->size.y);
-        return true;
-    }
-
-    RHIExecutor::Get().Sync(ERHISyncDepth::Present);
-    swapchain_create_info.size = drawable_extent;
-    swapchain->Sync();
-    const bool recreated = swapchain->Recreate(swapchain_create_info);
-    if (!recreated ||
-        !swapchain->IsPresentationReady() ||
-        swapchain->GetCommittedSurfaceIdentity() != window_frame.surface_identity) {
-        main_swapchain_recreate_requested.store(true, std::memory_order_release);
+    const EPresentationSurfaceEnsureResult result =
+        main_presentation_surface->EnsureCurrent(
+            main_window_surface,
+            window_frame,
+            recreate_requested
+        );
+    if (!IsPresentationSurfaceReady(result)) {
         return false;
     }
-    committed_main_surface_identity       = window_frame.surface_identity;
-    committed_main_drawable_generation   = window_frame.drawable_generation;
-    resolution = uint2(swapchain->size.x, swapchain->size.y);
-    return true;
+
+    const Extent2D committed_extent =
+        main_presentation_surface->GetExtent();
+    resolution = uint2(committed_extent.x, committed_extent.y);
+    return main_presentation_surface->IsCurrent(window_frame);
 }
 
 void Renderer::LogSceneLoadStatus(const EditorConfig& config) const {

--- a/source/runtime/render/renderer/Renderer.h
+++ b/source/runtime/render/renderer/Renderer.h
@@ -12,6 +12,7 @@
 #include "window/WindowFrameSnapshot.h"
 #include "window/WindowInput.h"
 
+#include "common/PresentationSurface.h"
 #include "common/UIRenderer.h"
 #include "common/UiCombinePass.h"
 
@@ -61,7 +62,7 @@ public:
     Renderer(
         uint2                         initial_resolution,
         const SharedPtr<EditorConfig> config,
-        SwapchainSurfaceInfo          main_window_surface,
+        SwapchainSurfaceInfo          _main_window_surface,
         RenderProfileCapture*         render_profile_capture = nullptr
     );
 
@@ -89,6 +90,13 @@ protected:
     [[nodiscard]] bool PrepareRenderFrame(const WindowFrameSnapshot& window_frame);
     PresentReceiptRef  CreateMainPresentReceipt(bool scene_content_ready);
     void ApplyMainPresentReceipt(const PresentReceiptRef& receipt, const EngineHooks& hooks);
+    [[nodiscard]] PresentationSurface& GetMainPresentationSurface() noexcept {
+        return *main_presentation_surface;
+    }
+    [[nodiscard]] const PresentationSurface&
+    GetMainPresentationSurface() const noexcept {
+        return *main_presentation_surface;
+    }
     [[nodiscard]] bool IsFramePrepareProfilingEnabled() const {
         return frame_prepare_profile_state != nullptr;
     }
@@ -109,13 +117,11 @@ protected:
     // Engine owns the capture bridge and outlives every renderer instance.
     RenderProfileCapture* render_profile_capture = nullptr;
 
-    SwapchainRef     swapchain;
     BindlessArrayRef bindless_array;
 
-    SwapchainCreateInfo        swapchain_create_info;
+    SwapchainSurfaceInfo       main_window_surface;
+    UniquePtr<PresentationSurface> main_presentation_surface;
     WindowFrameSnapshotTracker main_window_frame_tracker;
-    WindowSurfaceIdentity       committed_main_surface_identity{};
-    uint64_t                    committed_main_drawable_generation = 0;
     Scene                       scene;
     UniquePtr<RenderScene>      render_scene;
     CommandList                 cmd_list;

--- a/source/runtime/render/renderer/common/PresentationSurface.cpp
+++ b/source/runtime/render/renderer/common/PresentationSurface.cpp
@@ -1,0 +1,269 @@
+#include "renderer/common/PresentationSurface.h"
+
+#include "RenderThread.h"
+#include "rhi/RHIExecutor.h"
+
+#include <cassert>
+
+namespace Moer::Render {
+
+EPresentationSurfacePlan PresentationSurfaceState::Plan(
+    const SwapchainSurfaceInfo& surface,
+    const WindowFrameSnapshot&  window_frame,
+    bool                        native_commit_current
+) noexcept {
+    if (!surface.IsValid() || !window_frame.IsValid() ||
+        surface.GetIdentity() != window_frame.surface_identity || window_frame.capture_sequence == 0) {
+        return EPresentationSurfacePlan::Invalid;
+    }
+    if (!CanObserve(window_frame)) {
+        return EPresentationSurfacePlan::Invalid;
+    }
+    if (committed_.IsValid()) {
+        if (window_frame.capture_sequence < committed_.capture_sequence ||
+            window_frame.drawable_generation < committed_.drawable_generation) {
+            return EPresentationSurfacePlan::Invalid;
+        }
+    }
+    if (!window_frame.IsDrawable()) {
+        Observe(window_frame);
+        return EPresentationSurfacePlan::MetadataOnly;
+    }
+    if (window_frame.drawable_generation == 0) {
+        return EPresentationSurfacePlan::Invalid;
+    }
+    if (committed_.IsValid()) {
+        if (committed_.surface_identity == window_frame.surface_identity &&
+            committed_.drawable_generation == window_frame.drawable_generation &&
+            committed_.source_drawable_extent != window_frame.drawable_extent) {
+            return EPresentationSurfacePlan::Invalid;
+        }
+    }
+    Observe(window_frame);
+    return IsCurrent(window_frame, native_commit_current) ? EPresentationSurfacePlan::Reuse :
+                                                            EPresentationSurfacePlan::Refresh;
+}
+
+bool PresentationSurfaceState::Commit(
+    const WindowFrameSnapshot& window_frame,
+    Extent2D                   actual_extent
+) noexcept {
+    if (!window_frame.IsDrawable() || window_frame.capture_sequence == 0 ||
+        window_frame.drawable_generation == 0 || actual_extent.x == 0 || actual_extent.y == 0 ||
+        !CanObserve(window_frame)) {
+        Reject();
+        return false;
+    }
+
+    Observe(window_frame);
+    committed_ = PresentationSurfaceSnapshot{
+        .surface_identity       = window_frame.surface_identity,
+        .source_drawable_extent = window_frame.drawable_extent,
+        .drawable_extent        = actual_extent,
+        .capture_sequence       = window_frame.capture_sequence,
+        .drawable_generation    = window_frame.drawable_generation,
+    };
+    refresh_pending_ = false;
+    return true;
+}
+
+bool PresentationSurfaceState::CanObserve(const WindowFrameSnapshot& window_frame) const noexcept {
+    if (!last_observed_.IsValid()) {
+        return true;
+    }
+    if (window_frame.capture_sequence < last_observed_.capture_sequence ||
+        window_frame.drawable_generation < last_observed_.drawable_generation) {
+        return false;
+    }
+    if (window_frame.capture_sequence == last_observed_.capture_sequence) {
+        return window_frame.surface_identity == last_observed_.surface_identity &&
+               window_frame.logical_extent == last_observed_.logical_extent &&
+               window_frame.drawable_extent == last_observed_.drawable_extent &&
+               window_frame.last_drawable_extent == last_observed_.last_drawable_extent &&
+               window_frame.drawable_generation == last_observed_.drawable_generation &&
+               window_frame.transition == last_observed_.transition;
+    }
+    if (window_frame.surface_identity != last_observed_.surface_identity &&
+        window_frame.drawable_generation <= last_observed_.drawable_generation) {
+        return false;
+    }
+    return window_frame.surface_identity != last_observed_.surface_identity ||
+           window_frame.drawable_generation != last_observed_.drawable_generation ||
+           !window_frame.IsDrawable() || !last_observed_.IsDrawable() ||
+           window_frame.drawable_extent == last_observed_.drawable_extent;
+}
+
+void PresentationSurfaceState::Observe(const WindowFrameSnapshot& window_frame) noexcept {
+    last_observed_ = window_frame;
+}
+
+bool PresentationSurfaceState::IsCurrent(const WindowFrameSnapshot& window_frame, bool native_commit_current)
+    const noexcept {
+    return !refresh_pending_ && native_commit_current && committed_.IsValid() && window_frame.IsDrawable() &&
+           window_frame.capture_sequence >= committed_.capture_sequence &&
+           committed_.surface_identity == window_frame.surface_identity &&
+           committed_.source_drawable_extent == window_frame.drawable_extent &&
+           committed_.drawable_generation == window_frame.drawable_generation;
+}
+
+PresentationSurface::PresentationSurface(RenderDevice& device, PresentationSurfaceDesc desc) :
+    device_(device),
+    desc_(std::move(desc)) {
+    AssertRenderOwner();
+}
+
+PresentationSurface::~PresentationSurface() {
+    // Explicit Release() is the normal shutdown path; keep RAII cleanup as an
+    // exception-safe fallback for partially constructed renderer owners.
+    if (swapchain_ || frame_buffer_) {
+        Release();
+    }
+}
+
+EPresentationSurfaceEnsureResult PresentationSurface::EnsureCurrent(
+    const SwapchainSurfaceInfo& surface,
+    const WindowFrameSnapshot&  window_frame,
+    bool                        force_refresh
+) {
+    AssertRenderOwner();
+    if (force_refresh) {
+        state_.RequestRefresh();
+    }
+
+    const bool                     native_commit_current = NativeCommitCurrent();
+    const EPresentationSurfacePlan plan = state_.Plan(surface, window_frame, native_commit_current);
+    if (plan == EPresentationSurfacePlan::Invalid) {
+        return EPresentationSurfaceEnsureResult::Invalid;
+    }
+    if (plan == EPresentationSurfacePlan::MetadataOnly) {
+        if (!native_commit_current) {
+            state_.RequestRefresh();
+        }
+        return EPresentationSurfaceEnsureResult::MetadataOnly;
+    }
+    if (plan == EPresentationSurfacePlan::Reuse) {
+        return EPresentationSurfaceEnsureResult::Current;
+    }
+
+    state_.RequestRefresh();
+    Quiesce();
+
+    const SwapchainCreateInfo create_info{
+        .surface          = surface,
+        .size             = window_frame.drawable_extent,
+        .back_buffer_sz   = desc_.back_buffer_count,
+        .preferred_format = desc_.preferred_format,
+    };
+
+    if (!swapchain_) {
+        SwapchainRef candidate = device_.CreateSwapchain(create_info);
+        if (!candidate || !candidate->IsPresentationReady() ||
+            candidate->GetCommittedSurfaceIdentity() != window_frame.surface_identity) {
+            state_.Reject();
+            return EPresentationSurfaceEnsureResult::RetryPending;
+        }
+        swapchain_ = std::move(candidate);
+    } else if (!swapchain_->Recreate(create_info)) {
+        state_.Reject();
+        return EPresentationSurfaceEnsureResult::RetryPending;
+    }
+
+    if (!swapchain_ || !swapchain_->IsPresentationReady() ||
+        swapchain_->GetCommittedSurfaceIdentity() != window_frame.surface_identity ||
+        swapchain_->size.x == 0 || swapchain_->size.y == 0) {
+        state_.Reject();
+        return EPresentationSurfaceEnsureResult::RetryPending;
+    }
+
+    const Extent2D actual_extent          = swapchain_->size;
+    TextureRef     committed_frame_buffer = frame_buffer_;
+    if (desc_.frame_buffer.has_value() && !FrameBufferMatches(actual_extent)) {
+        const auto& frame_buffer_desc = *desc_.frame_buffer;
+        committed_frame_buffer =
+            device_.CreateTexture(actual_extent, frame_buffer_desc.format, frame_buffer_desc.usage);
+        if (!committed_frame_buffer) {
+            state_.Reject();
+            return EPresentationSurfaceEnsureResult::RetryPending;
+        }
+        committed_frame_buffer->SetName(desc_.debug_name);
+    }
+
+    if (!state_.Commit(window_frame, actual_extent)) {
+        return EPresentationSurfaceEnsureResult::RetryPending;
+    }
+    frame_buffer_ = std::move(committed_frame_buffer);
+    return EPresentationSurfaceEnsureResult::Committed;
+}
+
+std::optional<RHIPresentRequest> PresentationSurface::CreatePresentRequest(
+    const WindowFrameSnapshot& window_frame,
+    TextureView                source,
+    PresentReceiptRef          receipt
+) const {
+    AssertRenderOwner();
+    if (!IsCurrent(window_frame) || source.GetTexture() == nullptr) {
+        return std::nullopt;
+    }
+
+    const Extent2D committed_extent = state_.GetCommittedSnapshot().drawable_extent;
+    if (source.extent.x != committed_extent.x || source.extent.y != committed_extent.y) {
+        return std::nullopt;
+    }
+    return RHIPresentRequest(swapchain_, source, std::move(receipt));
+}
+
+void PresentationSurface::Quiesce() {
+    AssertRenderOwner();
+    if (!swapchain_ && !frame_buffer_) {
+        return;
+    }
+    RHIExecutor::Get().Sync(ERHISyncDepth::Present);
+    if (swapchain_) {
+        swapchain_->Sync();
+    }
+}
+
+void PresentationSurface::Release() {
+    AssertRenderOwner();
+    if (swapchain_ || frame_buffer_) {
+        Quiesce();
+    }
+    swapchain_    = nullptr;
+    frame_buffer_ = nullptr;
+    state_.Reset();
+}
+
+bool PresentationSurface::IsCurrent(const WindowFrameSnapshot& window_frame) const noexcept {
+    return state_.IsCurrent(window_frame, NativeCommitCurrent());
+}
+
+bool PresentationSurface::IsPresentable() const noexcept {
+    return !state_.HasRefreshPending() && NativeCommitCurrent();
+}
+
+bool PresentationSurface::NativeCommitCurrent() const noexcept {
+    const PresentationSurfaceSnapshot& committed = state_.GetCommittedSnapshot();
+    if (!committed.IsValid() || !swapchain_ || !swapchain_->IsPresentationReady() ||
+        swapchain_->GetCommittedSurfaceIdentity() != committed.surface_identity ||
+        swapchain_->size != committed.drawable_extent) {
+        return false;
+    }
+    return !desc_.frame_buffer.has_value() || FrameBufferMatches(committed.drawable_extent);
+}
+
+bool PresentationSurface::FrameBufferMatches(Extent2D extent) const noexcept {
+    if (!desc_.frame_buffer.has_value()) {
+        return !frame_buffer_;
+    }
+    if (!frame_buffer_ || frame_buffer_->GetFormat() != desc_.frame_buffer->format) {
+        return false;
+    }
+    const uint3 frame_buffer_extent = frame_buffer_->GetExtent();
+    return frame_buffer_extent.x == extent.x && frame_buffer_extent.y == extent.y;
+}
+
+void PresentationSurface::AssertRenderOwner() const noexcept {
+    assert(!IsRenderThreadRunning() || IsCurrentlyRenderThread());
+}
+
+} // namespace Moer::Render

--- a/source/runtime/render/renderer/common/PresentationSurface.h
+++ b/source/runtime/render/renderer/common/PresentationSurface.h
@@ -1,0 +1,176 @@
+#pragma once
+
+#include "RenderAPI.h"
+#include "rhi/RHI.h"
+#include "rhi/RHIExecutorBackend.h"
+#include "window/WindowFrameSnapshot.h"
+
+#include <optional>
+#include <string>
+
+namespace Moer::Render {
+
+struct PresentationSurfaceSnapshot {
+    WindowSurfaceIdentity surface_identity{};
+    Extent2D              source_drawable_extent{};
+    Extent2D              drawable_extent{};
+    uint64_t              capture_sequence    = 0;
+    uint64_t              drawable_generation = 0;
+
+    [[nodiscard]] bool IsValid() const noexcept {
+        return surface_identity.IsValid() && drawable_extent.x != 0 && drawable_extent.y != 0 &&
+               drawable_generation != 0;
+    }
+};
+
+enum class EPresentationSurfacePlan : uint8_t {
+    Invalid,
+    MetadataOnly,
+    Reuse,
+    Refresh,
+};
+
+// Pure reducer for the presentation transaction. Native swapchain and
+// framebuffer work is performed by PresentationSurface, while this state
+// freezes the identity/generation that was committed successfully.
+class RENDER_API PresentationSurfaceState {
+public:
+    [[nodiscard]] EPresentationSurfacePlan Plan(
+        const SwapchainSurfaceInfo& surface,
+        const WindowFrameSnapshot&  window_frame,
+        bool                        native_commit_current
+    ) noexcept;
+
+    void RequestRefresh() noexcept {
+        refresh_pending_ = true;
+    }
+
+    [[nodiscard]] bool Commit(const WindowFrameSnapshot& window_frame, Extent2D actual_extent) noexcept;
+
+    void Reject() noexcept {
+        refresh_pending_ = true;
+    }
+
+    void Reset() noexcept {
+        committed_       = {};
+        last_observed_   = {};
+        refresh_pending_ = true;
+    }
+
+    [[nodiscard]] bool
+    IsCurrent(const WindowFrameSnapshot& window_frame, bool native_commit_current) const noexcept;
+
+    [[nodiscard]] const PresentationSurfaceSnapshot& GetCommittedSnapshot() const noexcept {
+        return committed_;
+    }
+
+    [[nodiscard]] bool HasRefreshPending() const noexcept {
+        return refresh_pending_;
+    }
+
+private:
+    [[nodiscard]] bool CanObserve(const WindowFrameSnapshot& window_frame) const noexcept;
+    void               Observe(const WindowFrameSnapshot& window_frame) noexcept;
+
+    PresentationSurfaceSnapshot committed_{};
+    WindowFrameSnapshot         last_observed_{};
+    bool                        refresh_pending_{true};
+};
+
+struct PresentationSurfaceFrameBufferDesc {
+    EPixelFormat       format{PF_R8G8B8A8_SRGB};
+    ETextureUsageFlags usage{ETextureUsageFlags::COLOR_ATTACHMENT};
+};
+
+struct PresentationSurfaceDesc {
+    uint                                              back_buffer_count{2};
+    EPixelFormat                                      preferred_format{PF_R8G8B8A8_SRGB};
+    std::string                                       debug_name{"PresentationSurface"};
+    std::optional<PresentationSurfaceFrameBufferDesc> frame_buffer{};
+};
+
+enum class EPresentationSurfaceEnsureResult : uint8_t {
+    Invalid,
+    MetadataOnly,
+    Current,
+    Committed,
+    RetryPending,
+};
+
+[[nodiscard]] constexpr bool IsPresentationSurfaceReady(EPresentationSurfaceEnsureResult result) noexcept {
+    return result == EPresentationSurfaceEnsureResult::Current ||
+           result == EPresentationSurfaceEnsureResult::Committed;
+}
+
+// Render-owner presentation object. The Game Thread supplies immutable surface
+// and window snapshots; all native creation, recreation, quiesce and release
+// work remains on the Render owner.
+class RENDER_API PresentationSurface final {
+public:
+    PresentationSurface(RenderDevice& device, PresentationSurfaceDesc desc);
+    ~PresentationSurface();
+
+    PresentationSurface(const PresentationSurface&)            = delete;
+    PresentationSurface& operator=(const PresentationSurface&) = delete;
+    PresentationSurface(PresentationSurface&&)                 = delete;
+    PresentationSurface& operator=(PresentationSurface&&)      = delete;
+
+    [[nodiscard]] EPresentationSurfaceEnsureResult EnsureCurrent(
+        const SwapchainSurfaceInfo& surface,
+        const WindowFrameSnapshot&  window_frame,
+        bool                        force_refresh = false
+    );
+
+    [[nodiscard]] std::optional<RHIPresentRequest> CreatePresentRequest(
+        const WindowFrameSnapshot& window_frame,
+        TextureView                source,
+        PresentReceiptRef          receipt = {}
+    ) const;
+
+    void Quiesce();
+    void Release();
+
+    [[nodiscard]] bool IsCurrent(const WindowFrameSnapshot& window_frame) const noexcept;
+    [[nodiscard]] bool IsPresentable() const noexcept;
+
+    [[nodiscard]] SwapchainRef GetSwapchain() const {
+        return swapchain_;
+    }
+
+    [[nodiscard]] TextureRef GetFrameBuffer() const {
+        return frame_buffer_;
+    }
+
+    [[nodiscard]] TextureView GetFrameBufferView() const {
+        return frame_buffer_ ? frame_buffer_->GetView() : TextureView{};
+    }
+
+    [[nodiscard]] EPixelFormat GetFormat() const noexcept {
+        return swapchain_ ? swapchain_->format : desc_.preferred_format;
+    }
+
+    [[nodiscard]] Extent2D GetExtent() const noexcept {
+        return state_.GetCommittedSnapshot().drawable_extent;
+    }
+
+    [[nodiscard]] const PresentationSurfaceSnapshot& GetCommittedSnapshot() const noexcept {
+        return state_.GetCommittedSnapshot();
+    }
+
+    [[nodiscard]] bool HasRefreshPending() const noexcept {
+        return state_.HasRefreshPending();
+    }
+
+private:
+    [[nodiscard]] bool NativeCommitCurrent() const noexcept;
+    [[nodiscard]] bool FrameBufferMatches(Extent2D extent) const noexcept;
+    void               AssertRenderOwner() const noexcept;
+
+    RenderDevice&            device_;
+    PresentationSurfaceDesc  desc_;
+    PresentationSurfaceState state_{};
+    SwapchainRef             swapchain_{};
+    TextureRef               frame_buffer_{};
+};
+
+} // namespace Moer::Render

--- a/source/runtime/render/renderer/common/UIRenderer.h
+++ b/source/runtime/render/renderer/common/UIRenderer.h
@@ -5,6 +5,7 @@
 
 #include "RenderAPI.h"
 #include "misc/STL.h"
+#include "renderer/common/PresentationSurface.h"
 #include "rhi/RHI.h"
 #include "window/WindowFrameSnapshot.h"
 #include "window/WindowInput.h"
@@ -71,18 +72,7 @@ struct UiClipRect {
     float2 max{};
 };
 
-struct UiViewportPresentationSnapshot {
-    WindowSurfaceIdentity surface_identity{};
-    Extent2D              drawable_extent{};
-    uint64_t              drawable_generation = 0;
-
-    [[nodiscard]] bool IsValid() const noexcept {
-        return surface_identity.IsValid() &&
-               drawable_extent.x != 0 &&
-               drawable_extent.y != 0 &&
-               drawable_generation != 0;
-    }
-};
+using UiViewportPresentationSnapshot = PresentationSurfaceSnapshot;
 
 struct UiViewportDrawPacket {
     static constexpr uint64_t InvalidRecordingSlot =

--- a/source/runtime/render/renderer/common/ui/DearImGuiRenderer.cpp
+++ b/source/runtime/render/renderer/common/ui/DearImGuiRenderer.cpp
@@ -111,11 +111,9 @@ struct GuiFrameRenderBuffers {
     Moer::Render::BufferRef argument_buffer;
 };
 struct GuiViewportRenderResources final : UiViewportRenderResources {
-    SwapchainRef swapchain;
+    UniquePtr<PresentationSurface> presentation_surface;
 
     Array<GuiFrameRenderBuffers> render_buffers;
-    TextureRef                   framebuffer;
-    UiViewportPresentationSnapshot committed_presentation{};
 
     uint64_t frame_index = 0;
 
@@ -434,14 +432,20 @@ CaptureViewportDrawPacket(ImDrawData* _draw_data, GuiViewportData* _viewport_dat
         return packet;
     }
 
+    const PresentationSurface* presentation_surface =
+        _viewport_data->render_resources->presentation_surface.get();
     packet.render_resources = _viewport_data->render_resources;
-    packet.framebuffer      = _viewport_data->render_resources->framebuffer;
-    packet.swapchain        = _viewport_data->render_resources->swapchain;
+    if (presentation_surface) {
+        packet.framebuffer = presentation_surface->GetFrameBuffer();
+        packet.swapchain   = presentation_surface->GetSwapchain();
+    }
     BindUiViewportWindowFrame(packet, _viewport_data->latest_window_frame);
-    BindUiViewportPresentation(
-        packet,
-        _viewport_data->render_resources->committed_presentation
-    );
+    if (presentation_surface) {
+        BindUiViewportPresentation(
+            packet,
+            presentation_surface->GetCommittedSnapshot()
+        );
+    }
     if (!_draw_data) {
         return packet;
     }
@@ -655,9 +659,12 @@ TextureRef ImGuiRenderBackend::GetWindowFrameBuffer(void* _window) {
     auto* viewport      = static_cast<ImGuiViewport*>(_window);
     auto* viewport_data = static_cast<GuiViewportData*>(viewport->RendererUserData);
 
-    return viewport_data && viewport_data->render_resources && viewport_data->render_resources->framebuffer ?
-               viewport_data->render_resources->framebuffer :
-               TextureRef();
+    return viewport_data &&
+                   viewport_data->render_resources &&
+                   viewport_data->render_resources->presentation_surface ?
+               viewport_data->render_resources->presentation_surface
+                   ->GetFrameBuffer() :
+               TextureRef{};
 }
 
 } // namespace Moer::Render
@@ -856,16 +863,18 @@ void RenderGuiDrawPacket(
 void GuiCreateWindow(ImGuiViewport* _viewport);
 void GuiDestroyWindow(ImGuiViewport* _viewport);
 void GuiSetWindowSize(ImGuiViewport* _viewport, ImVec2 _size);
-void GuiRenderWindow(ImGuiViewport* _viewport, void*);
-void GuiSwapBuffers(ImGuiViewport* _viewport, void*);
 
 void InitializeGuiPlatformInterface() {
     ImGuiPlatformIO& platform_io       = ImGui::GetPlatformIO();
     platform_io.Renderer_CreateWindow  = GuiCreateWindow;
     platform_io.Renderer_DestroyWindow = GuiDestroyWindow;
     platform_io.Renderer_SetWindowSize = GuiSetWindowSize;
-    platform_io.Renderer_RenderWindow  = GuiRenderWindow;
-    platform_io.Renderer_SwapBuffers   = GuiSwapBuffers;
+    // Rendering and Present are consumed from immutable UI frame packets on
+    // the Render owner. Do not advertise the legacy GT callbacks used by
+    // RenderPlatformWindowsDefault(); they cannot carry our CommandList or
+    // presentation ownership contract.
+    platform_io.Renderer_RenderWindow = nullptr;
+    platform_io.Renderer_SwapBuffers  = nullptr;
 }
 
 void DestroyRenderBuffers(GuiFrameRenderBuffers* _render_buffers) {
@@ -889,90 +898,50 @@ bool CreateOrResizeViewportResources(
         return false;
     }
 
-    const bool has_swapchain = _resources->swapchain.IsValid();
-    const bool request_matches =
-        _resources->committed_presentation.IsValid() &&
-        _resources->committed_presentation.surface_identity == _window_frame.surface_identity &&
-        _resources->committed_presentation.drawable_generation ==
-            _window_frame.drawable_generation;
-    const bool swapchain_matches_commit =
-        has_swapchain &&
-        _resources->swapchain->IsPresentationReady() &&
-        _resources->swapchain->GetCommittedSurfaceIdentity() ==
-            _resources->committed_presentation.surface_identity &&
-        _resources->swapchain->size ==
-            _resources->committed_presentation.drawable_extent;
-    const bool framebuffer_matches =
-        _resources->framebuffer &&
-        _resources->framebuffer->GetExtent().x ==
-            _resources->committed_presentation.drawable_extent.x &&
-        _resources->framebuffer->GetExtent().y ==
-            _resources->committed_presentation.drawable_extent.y;
-    if (request_matches && swapchain_matches_commit && framebuffer_matches) {
+    const bool had_committed_surface =
+        _resources->presentation_surface &&
+        _resources->presentation_surface->GetCommittedSnapshot().IsValid();
+    if (!_resources->presentation_surface) {
+        _resources->presentation_surface =
+            MakeUnique<PresentationSurface>(
+                _device,
+                PresentationSurfaceDesc{
+                    .back_buffer_count = _frame_in_flight,
+                    .preferred_format  = PF_R8G8B8A8_SRGB,
+                    .debug_name = std::format(
+                        "ImGui Window {}", _viewport_index
+                    ),
+                    .frame_buffer = PresentationSurfaceFrameBufferDesc{
+                        .format = PF_R8G8B8A8_SRGB,
+                        .usage =
+                            ETextureUsageFlags::COLOR_ATTACHMENT |
+                            ETextureUsageFlags::SAMPLED |
+                            ETextureUsageFlags::PRESENTATION_SOURCE |
+                            ETextureUsageFlags::TRANSFER_SRC |
+                            ETextureUsageFlags::TRANSFER_DST,
+                    },
+                }
+            );
+    }
+
+    const EPresentationSurfaceEnsureResult result =
+        _resources->presentation_surface->EnsureCurrent(
+            _surface_info,
+            _window_frame
+        );
+    if (!IsPresentationSurfaceReady(result)) {
+        return false;
+    }
+    if (result == EPresentationSurfaceEnsureResult::Current) {
         return true;
     }
 
-    if (has_swapchain || _resources->framebuffer) {
-        RHIExecutor::Get().Sync(ERHISyncDepth::Present);
-    }
-
-    SwapchainCreateInfo swapchain_info{
-        .surface          = _surface_info,
-        .size             = _window_frame.drawable_extent,
-        .back_buffer_sz   = _frame_in_flight,
-        .preferred_format = PF_R8G8B8A8_SRGB
-    };
-
-    bool native_commit_succeeded = false;
-    if (!has_swapchain) {
-        _resources->swapchain = _device.CreateSwapchain(swapchain_info);
-        native_commit_succeeded =
-            _resources->swapchain && _resources->swapchain->IsPresentationReady();
-    } else if (!request_matches || !swapchain_matches_commit) {
-        _resources->swapchain->Sync();
-        native_commit_succeeded = _resources->swapchain->Recreate(swapchain_info);
-    } else {
-        native_commit_succeeded = true;
-    }
-
-    if (!native_commit_succeeded ||
-        !_resources->swapchain ||
-        !_resources->swapchain->IsPresentationReady() ||
-        _resources->swapchain->GetCommittedSurfaceIdentity() != _window_frame.surface_identity ||
-        _resources->swapchain->size.x == 0 ||
-        _resources->swapchain->size.y == 0) {
-        return false;
-    }
-
-    const Extent2D actual_extent = _resources->swapchain->size;
-    const bool framebuffer_matches_actual =
-        _resources->framebuffer &&
-        _resources->framebuffer->GetExtent().x == actual_extent.x &&
-        _resources->framebuffer->GetExtent().y == actual_extent.y;
-    if (!framebuffer_matches_actual) {
-        _resources->framebuffer = _device.CreateTexture(
-            actual_extent,
-            PF_R8G8B8A8_SRGB,
-            ETextureUsageFlags::COLOR_ATTACHMENT |
-                ETextureUsageFlags::SAMPLED |
-                ETextureUsageFlags::PRESENTATION_SOURCE |
-                ETextureUsageFlags::TRANSFER_SRC |
-                ETextureUsageFlags::TRANSFER_DST
-        );
-        if (!_resources->framebuffer) {
-            return false;
-        }
-        _resources->framebuffer->SetName(std::format("ImGui Window {}", _viewport_index));
-    }
-    _resources->committed_presentation = UiViewportPresentationSnapshot{
-        .surface_identity     = _window_frame.surface_identity,
-        .drawable_extent      = actual_extent,
-        .drawable_generation  = _window_frame.drawable_generation,
-    };
+    const Extent2D actual_extent =
+        _resources->presentation_surface->GetExtent();
 
     LOG_INFO(
         "[Threading][UI] {} ImGui viewport {} resources at {}x{} on {} Thread.",
-        has_swapchain ? "Updated" : "Created",
+        had_committed_surface ? "Updated" : "Created",
         _viewport_index,
         actual_extent.x,
         actual_extent.y,
@@ -991,13 +960,10 @@ void ReleaseViewportResources(
     }
     assert(!IsRenderThreadRunning() || IsCurrentlyRenderThread());
 
-    RHIExecutor::Get().Sync(ERHISyncDepth::Present);
-    if (_resources->swapchain) {
-        _resources->swapchain->Sync();
+    if (_resources->presentation_surface) {
+        _resources->presentation_surface->Release();
+        _resources->presentation_surface.reset();
     }
-    _resources->swapchain              = nullptr;
-    _resources->framebuffer            = nullptr;
-    _resources->committed_presentation = {};
     for (auto& render_buffers : _resources->render_buffers) {
         DestroyRenderBuffers(&render_buffers);
     }
@@ -1168,60 +1134,4 @@ void GuiSetWindowSize(ImGuiViewport* _viewport, ImVec2 _size) {
         backend_data->render_backend->device,
         backend_data->frames_in_flight
     ));
-}
-void GuiRenderWindow(ImGuiViewport* _viewport, void* _cmd_list) {
-    auto* viewport_data = static_cast<GuiViewportData*>(_viewport->RendererUserData);
-    if (!viewport_data || !viewport_data->render_resources || !viewport_data->render_resources->swapchain ||
-        !viewport_data->render_resources->framebuffer) {
-        return;
-    }
-
-    ImGuiData& backend_data = *GetImGuiBackendData();
-    auto       draw_packet  = CaptureViewportDrawPacket(_viewport->DrawData, viewport_data);
-    if (!IsUiViewportPresentationCurrent(draw_packet)) {
-        return;
-    }
-    draw_packet.recording_slot =
-        draw_packet.render_resources->GetPendingRecordingSlot();
-    RenderGuiDrawPacket(
-        draw_packet,
-        viewport_data->render_resources->framebuffer->GetView(),
-        *static_cast<CommandList*>(_cmd_list),
-        backend_data,
-        *backend_data.render_backend
-    );
-    if (draw_packet.render_resources->IsPendingRecordingSlot(
-            draw_packet.recording_slot
-        )) {
-        draw_packet.render_resources->CommitRecordingSlot(
-            draw_packet.recording_slot
-        );
-    }
-}
-
-void GuiSwapBuffers(ImGuiViewport* _viewport, void*) {
-    ImGuiData&       backend_data  = *GetImGuiBackendData();
-    auto* viewport_data = static_cast<GuiViewportData*>(_viewport->RendererUserData);
-    if (!viewport_data || !viewport_data->render_resources) {
-        return;
-    }
-    UiViewportDrawPacket present_packet{
-        .framebuffer = viewport_data->render_resources->framebuffer,
-        .swapchain   = viewport_data->render_resources->swapchain,
-    };
-    BindUiViewportWindowFrame(present_packet, viewport_data->latest_window_frame);
-    BindUiViewportPresentation(
-        present_packet,
-        viewport_data->render_resources->committed_presentation
-    );
-    if (!IsUiViewportPresentationCurrent(present_packet)) {
-        return;
-    }
-    RHIExecutor::Get().Present(
-        RHIPresentRequest(
-            present_packet.swapchain,
-            present_packet.framebuffer->GetView()
-        ),
-        true
-    );
 }

--- a/source/runtime/render/renderer/raster/RasterRenderer.cpp
+++ b/source/runtime/render/renderer/raster/RasterRenderer.cpp
@@ -536,7 +536,8 @@ RasterFrameFeedback RasterRenderer::RenderFrame(RasterFramePacket frame_packet) 
     uint64 linear_source_order       = 1;
     uint64 tail_source_order         = 1;
 
-    auto& raster_context = *raster_context_ptr;
+    auto& raster_context            = *raster_context_ptr;
+    auto& main_presentation_surface = GetMainPresentationSurface();
     bool  main_presentation_current =
         PrepareRenderFrame(frame_packet.window);
     if (main_presentation_current) {
@@ -579,8 +580,7 @@ RasterFrameFeedback RasterRenderer::RenderFrame(RasterFramePacket frame_packet) 
     PresentReceiptRef main_present_receipt{};
     if (!main_presentation_current ||
         !frame_packet.window.IsDrawable() ||
-        !swapchain ||
-        !swapchain->IsPresentationReady()) {
+        !main_presentation_surface.IsCurrent(frame_packet.window)) {
         // 窗口最小化后无法 present，此处主动让出线程，避免高频空转。
         std::this_thread::yield();
         skip_present = true;
@@ -657,8 +657,8 @@ RasterFrameFeedback RasterRenderer::RenderFrame(RasterFramePacket frame_packet) 
             raster_context.GetResolution().y,
             raster_context.GetOutputResolution().x,
             raster_context.GetOutputResolution().y,
-            swapchain->size.x,
-            swapchain->size.y,
+            main_presentation_surface.GetExtent().x,
+            main_presentation_surface.GetExtent().y,
             recreate_scene_resources,
             recreate_output_resources,
             recreate_scene_resources
@@ -1800,28 +1800,34 @@ RasterFrameFeedback RasterRenderer::RenderFrame(RasterFramePacket frame_packet) 
 
     if (!skip_present) {
         const auto output_view = default_output_texture->GetView();
+        const Extent2D presentation_extent =
+            main_presentation_surface.GetExtent();
         if (frame_packet.window.transition != EWindowFrameTransition::Stable &&
             frame_packet.window.transition != EWindowFrameTransition::LogicalResized) {
             LOG_INFO(
                 "[Threading][Resize] Main present source={}x{}, swapchain={}x{}, UI platform viewports={}.",
                 output_view.extent.x,
                 output_view.extent.y,
-                swapchain->size.x,
-                swapchain->size.y,
+                presentation_extent.x,
+                presentation_extent.y,
                 frame_packet.ui_draw_frame.platform_viewports.size()
             );
         }
-        if (output_view.extent.x == swapchain->size.x && output_view.extent.y == swapchain->size.y) {
-            main_present_receipt =
-                CreateMainPresentReceipt(frame_packet.scene_updates.scene_ready);
-            present_request.emplace(swapchain, output_view, main_present_receipt);
-        } else {
+        main_present_receipt =
+            CreateMainPresentReceipt(frame_packet.scene_updates.scene_ready);
+        present_request = main_presentation_surface.CreatePresentRequest(
+            frame_packet.window,
+            output_view,
+            main_present_receipt
+        );
+        if (!present_request.has_value()) {
+            main_present_receipt = {};
             LOG_WARNING(
                 "Skipping stale main-window present: source={}x{}, swapchain={}x{}.",
                 output_view.extent.x,
                 output_view.extent.y,
-                swapchain->size.x,
-                swapchain->size.y
+                presentation_extent.x,
+                presentation_extent.y
             );
         }
     }

--- a/source/runtime/render/renderer/raytracing/RaytracingRenderer.cpp
+++ b/source/runtime/render/renderer/raytracing/RaytracingRenderer.cpp
@@ -393,7 +393,7 @@ struct RaytracingRenderer::RuntimeState {
         importance_sampling_context(importance_sampling_params),
         output(renderer.device.CreateTexture(
             Extent2D(renderer.resolution.x, renderer.resolution.y),
-            renderer.swapchain->format,
+            renderer.GetMainPresentationSurface().GetFormat(),
             ETextureUsageFlags::COLOR_ATTACHMENT |
                 ETextureUsageFlags::PRESENTATION_SOURCE |
                 ETextureUsageFlags::TRANSFER_SRC |
@@ -741,8 +741,9 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
                    EGpuMarkerMode::Label;
     };
 
-    auto& state     = *runtime_state;
-    auto& ui_config = frame_packet.config;
+    auto& state                     = *runtime_state;
+    auto& ui_config                 = frame_packet.config;
+    auto& main_presentation_surface = GetMainPresentationSurface();
     bool  main_presentation_current =
         PrepareRenderFrame(frame_packet.window);
     if (main_presentation_current) {
@@ -834,8 +835,7 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
 
     if (!main_presentation_current ||
         !frame_packet.window.IsDrawable() ||
-        !swapchain ||
-        !swapchain->IsPresentationReady()) {
+        !main_presentation_surface.IsCurrent(frame_packet.window)) {
         std::this_thread::yield();
         skip_present = true;
     }
@@ -846,10 +846,13 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
     const bool recreate_scene_resources = !EqualRenderExtent(
         uint2(current_scene_extent_3d.x, current_scene_extent_3d.y), active_scene_extent
     );
-    const bool recreate_output_resources = !EqualRenderExtent(
-        uint2(current_output_extent_3d.x, current_output_extent_3d.y),
-        presentation_resolution
-    );
+    const bool recreate_output_resources =
+        !EqualRenderExtent(
+            uint2(current_output_extent_3d.x, current_output_extent_3d.y),
+            presentation_resolution
+        ) ||
+        state.output->GetFormat() !=
+            main_presentation_surface.GetFormat();
 
     if (!skip_present && (recreate_scene_resources || recreate_output_resources)) {
         if (recreate_output_resources) {
@@ -887,8 +890,8 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
                 active_scene_extent.y,
                 presentation_resolution.x,
                 presentation_resolution.y,
-                swapchain->size.x,
-                swapchain->size.y,
+                main_presentation_surface.GetExtent().x,
+                main_presentation_surface.GetExtent().y,
                 scene_resources_recreated,
                 output_resources_recreated,
                 scene_resources_recreated
@@ -1942,6 +1945,8 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
     std::optional<RHIPresentRequest> present_request{};
     if (!skip_present) {
         const auto output_view = state.output->GetView();
+        const Extent2D presentation_extent =
+            main_presentation_surface.GetExtent();
         if (frame_packet.window.transition != EWindowFrameTransition::Stable &&
             frame_packet.window.transition != EWindowFrameTransition::LogicalResized) {
             LOG_INFO(
@@ -1949,23 +1954,28 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
                 "viewports={}.",
                 output_view.extent.x,
                 output_view.extent.y,
-                swapchain->size.x,
-                swapchain->size.y,
+                presentation_extent.x,
+                presentation_extent.y,
                 prepared_ui->GetDrawFrame().platform_viewports.size()
             );
         }
-        if (output_view.extent.x == swapchain->size.x && output_view.extent.y == swapchain->size.y) {
-            feedback.main_present_receipt = CreateMainPresentReceipt(
-                frame_packet.scene_updates.scene_ready && frame_packet.runtime_assets_ready
-            );
-            present_request.emplace(swapchain, output_view, feedback.main_present_receipt);
-        } else {
+        feedback.main_present_receipt = CreateMainPresentReceipt(
+            frame_packet.scene_updates.scene_ready &&
+            frame_packet.runtime_assets_ready
+        );
+        present_request = main_presentation_surface.CreatePresentRequest(
+            frame_packet.window,
+            output_view,
+            feedback.main_present_receipt
+        );
+        if (!present_request.has_value()) {
+            feedback.main_present_receipt = {};
             LOG_WARNING(
                 "Skipping stale raytracing main-window present: source={}x{}, swapchain={}x{}.",
                 output_view.extent.x,
                 output_view.extent.y,
-                swapchain->size.x,
-                swapchain->size.y
+                presentation_extent.x,
+                presentation_extent.y
             );
         }
     }
@@ -2434,7 +2444,7 @@ void RaytracingRenderer::RecreateOutputResources(uint2 new_extent) {
     state.output = device.CreateTexture(
         "output",
         Extent2D(new_extent.x, new_extent.y),
-        swapchain->format,
+        GetMainPresentationSurface().GetFormat(),
         ETextureUsageFlags::COLOR_ATTACHMENT |
             ETextureUsageFlags::PRESENTATION_SOURCE |
             ETextureUsageFlags::TRANSFER_SRC |

--- a/source/test/CMakeLists.txt
+++ b/source/test/CMakeLists.txt
@@ -175,6 +175,15 @@ set_target_properties(${test_target} PROPERTIES FOLDER ${moer_test_folder})
 add_test(NAME WindowFrameSnapshotContract COMMAND $<TARGET_FILE:${test_target}>)
 set_tests_properties(WindowFrameSnapshotContract PROPERTIES TIMEOUT 60)
 
+set(test_target TestPresentationSurface)
+add_executable(${test_target} "PresentationSurfaceContractTest.cpp")
+target_link_libraries(${test_target}
+    PRIVATE Moer::Render
+)
+set_target_properties(${test_target} PROPERTIES FOLDER ${moer_test_folder})
+add_test(NAME PresentationSurfaceContract COMMAND $<TARGET_FILE:${test_target}>)
+set_tests_properties(PresentationSurfaceContract PROPERTIES TIMEOUT 60)
+
 set(test_target TestWindowInputSnapshot)
 add_executable(${test_target} "WindowInputSnapshotContractTest.cpp")
 target_link_libraries(${test_target}

--- a/source/test/PresentationSurfaceContractTest.cpp
+++ b/source/test/PresentationSurfaceContractTest.cpp
@@ -1,0 +1,168 @@
+#include "renderer/common/PresentationSurface.h"
+
+#include <cstdio>
+#include <cstdlib>
+#include <memory>
+
+using namespace Moer::Render;
+
+namespace {
+
+void RequireAt(bool condition, int line) {
+    if (!condition) {
+        std::fprintf(stderr, "PresentationSurfaceContract failed at line %d\n", line);
+        std::_Exit(EXIT_FAILURE);
+    }
+}
+
+#define Require(condition) RequireAt((condition), __LINE__)
+
+class FakeWindowSurfaceSource final : public WindowSurfaceSource {
+public:
+    explicit FakeWindowSurfaceSource(WindowSurfaceIdentity identity) : identity_(identity) {}
+
+    [[nodiscard]] WindowSurfaceIdentity GetIdentity() const noexcept override {
+        return identity_;
+    }
+
+    [[nodiscard]] WindowSurfaceCreateResult
+    CreateSurface(ERHIType, void*, const void*, void*) const noexcept override {
+        return {
+            .status = EWindowSurfaceCreateStatus::UnsupportedRHI,
+        };
+    }
+
+private:
+    WindowSurfaceIdentity identity_{};
+};
+
+WindowSurfaceIdentity
+MakeIdentity(uintptr_t window_system_handle, uintptr_t platform_window_handle, uint64_t generation) {
+    return {
+        .window_system          = EWindowSystemType::GLFW,
+        .window_system_handle   = window_system_handle,
+        .platform_window_handle = platform_window_handle,
+        .generation             = generation,
+    };
+}
+
+SwapchainSurfaceInfo MakeSurface(WindowSurfaceIdentity identity) {
+    return {
+        std::make_shared<FakeWindowSurfaceSource>(identity),
+    };
+}
+
+WindowFrameMetrics MakeMetrics(Extent2D logical_extent, Extent2D drawable_extent) {
+    return {
+        .logical_extent  = logical_extent,
+        .drawable_extent = drawable_extent,
+        .valid           = true,
+    };
+}
+
+} // namespace
+
+int main() {
+    const WindowSurfaceIdentity identity_a = MakeIdentity(0x1000u, 0x2000u, 1u);
+    const SwapchainSurfaceInfo  surface_a  = MakeSurface(identity_a);
+
+    PresentationSurfaceState   state;
+    WindowFrameSnapshotTracker tracker;
+    const WindowFrameSnapshot  initial = tracker.Advance(identity_a, MakeMetrics({800, 600}, {800, 600}));
+
+    Require(state.Plan({}, initial, false) == EPresentationSurfacePlan::Invalid);
+    Require(state.Plan(surface_a, initial, false) == EPresentationSurfacePlan::Refresh);
+    Require(state.HasRefreshPending());
+    Require(state.Commit(initial, {1024, 768}));
+    Require(!state.HasRefreshPending());
+    Require(state.GetCommittedSnapshot().IsValid());
+    Require(state.GetCommittedSnapshot().source_drawable_extent == Extent2D(800, 600));
+    Require(state.GetCommittedSnapshot().drawable_extent == Extent2D(1024, 768));
+    Require(state.Plan(surface_a, initial, true) == EPresentationSurfacePlan::Reuse);
+
+    const WindowFrameSnapshot stable = tracker.Advance(identity_a, MakeMetrics({800, 600}, {800, 600}));
+    Require(state.IsCurrent(stable, true));
+    Require(state.Plan(surface_a, stable, true) == EPresentationSurfacePlan::Reuse);
+
+    const WindowFrameSnapshot logical_resized =
+        tracker.Advance(identity_a, MakeMetrics({640, 480}, {800, 600}));
+    Require(state.IsCurrent(logical_resized, true));
+    Require(state.Plan(surface_a, logical_resized, true) == EPresentationSurfacePlan::Reuse);
+
+    WindowFrameSnapshot inconsistent_extent = logical_resized;
+    inconsistent_extent.drawable_extent     = {801, 600};
+    Require(state.Plan(surface_a, inconsistent_extent, true) == EPresentationSurfacePlan::Invalid);
+    Require(state.Plan(surface_a, logical_resized, false) == EPresentationSurfacePlan::Refresh);
+
+    state.RequestRefresh();
+    Require(state.HasRefreshPending());
+    Require(state.Plan(surface_a, logical_resized, true) == EPresentationSurfacePlan::Refresh);
+
+    const WindowFrameSnapshot minimized = tracker.Advance(identity_a, MakeMetrics({640, 480}, {0, 0}));
+    Require(state.Plan(surface_a, minimized, true) == EPresentationSurfacePlan::MetadataOnly);
+    Require(state.HasRefreshPending());
+
+    const WindowFrameSnapshot restored = tracker.Advance(identity_a, MakeMetrics({640, 480}, {800, 600}));
+    Require(restored.drawable_generation > initial.drawable_generation);
+    Require(state.Plan(surface_a, restored, true) == EPresentationSurfacePlan::Refresh);
+    Require(state.Commit(restored, {800, 600}));
+    Require(state.IsCurrent(restored, true));
+    Require(state.Plan(surface_a, initial, true) == EPresentationSurfacePlan::Invalid);
+
+    const WindowFrameSnapshot drawable_resized =
+        tracker.Advance(identity_a, MakeMetrics({640, 480}, {1280, 960}));
+    Require(state.Plan(surface_a, drawable_resized, true) == EPresentationSurfacePlan::Refresh);
+    state.Reject();
+    Require(state.HasRefreshPending());
+    Require(state.GetCommittedSnapshot().drawable_generation == restored.drawable_generation);
+    Require(state.Plan(surface_a, drawable_resized, true) == EPresentationSurfacePlan::Refresh);
+    Require(state.Commit(drawable_resized, {1278, 958}));
+    Require(state.GetCommittedSnapshot().drawable_extent == Extent2D(1278, 958));
+
+    const WindowSurfaceIdentity identity_b = MakeIdentity(0x3000u, 0x4000u, 1u);
+    const SwapchainSurfaceInfo  surface_b  = MakeSurface(identity_b);
+    const WindowFrameSnapshot   replaced = tracker.Advance(identity_b, MakeMetrics({900, 700}, {1800, 1400}));
+    Require(state.Plan(surface_b, replaced, false) == EPresentationSurfacePlan::Refresh);
+    Require(state.Commit(replaced, {1800, 1400}));
+    Require(state.Plan(surface_a, replaced, true) == EPresentationSurfacePlan::Invalid);
+
+    const WindowSurfaceIdentity identity_a2 = MakeIdentity(0x1000u, 0x2000u, 2u);
+    const SwapchainSurfaceInfo  surface_a2  = MakeSurface(identity_a2);
+    const WindowFrameSnapshot   aba_replaced =
+        tracker.Advance(identity_a2, MakeMetrics({800, 600}, {800, 600}));
+    Require(state.Plan(surface_a2, aba_replaced, false) == EPresentationSurfacePlan::Refresh);
+
+    PresentationSurfaceState   zero_first_state;
+    WindowFrameSnapshotTracker zero_first_tracker;
+    const WindowFrameSnapshot  zero_first =
+        zero_first_tracker.Advance(identity_a2, MakeMetrics({800, 600}, {0, 0}));
+    Require(zero_first.drawable_generation == 0);
+    Require(zero_first_state.Plan(surface_a2, zero_first, false) == EPresentationSurfacePlan::MetadataOnly);
+    const WindowFrameSnapshot zero_first_restored =
+        zero_first_tracker.Advance(identity_a2, MakeMetrics({800, 600}, {800, 600}));
+    Require(
+        zero_first_state.Plan(surface_a2, zero_first_restored, false) == EPresentationSurfacePlan::Refresh
+    );
+
+    PresentationSurfaceState   retry_state;
+    WindowFrameSnapshotTracker retry_tracker;
+    const WindowFrameSnapshot  retry_initial =
+        retry_tracker.Advance(identity_a, MakeMetrics({800, 600}, {800, 600}));
+    Require(retry_state.Plan(surface_a, retry_initial, false) == EPresentationSurfacePlan::Refresh);
+    Require(retry_state.Commit(retry_initial, {800, 600}));
+    const WindowFrameSnapshot delayed_stable =
+        retry_tracker.Advance(identity_a, MakeMetrics({800, 600}, {800, 600}));
+    const WindowFrameSnapshot failed_resize =
+        retry_tracker.Advance(identity_a, MakeMetrics({960, 720}, {960, 720}));
+    Require(retry_state.Plan(surface_a, failed_resize, true) == EPresentationSurfacePlan::Refresh);
+    retry_state.Reject();
+    Require(retry_state.Plan(surface_a, delayed_stable, true) == EPresentationSurfacePlan::Invalid);
+    Require(retry_state.Plan(surface_a, failed_resize, true) == EPresentationSurfacePlan::Refresh);
+
+    state.Reset();
+    Require(state.HasRefreshPending());
+    Require(!state.GetCommittedSnapshot().IsValid());
+    Require(state.Plan(surface_a2, aba_replaced, false) == EPresentationSurfacePlan::Refresh);
+
+    return 0;
+}


### PR DESCRIPTION
## Summary

- add an RT-owned `PresentationSurface` transaction for lazy swapchain/framebuffer creation, refresh, quiesce, and release
- migrate main Raster/Raytracing presentation and detached ImGui viewport resources to the shared abstraction
- preserve immutable window identity/generation, negotiated actual extent, retry high-watermark, and copied-packet strong ownership
- disable legacy ImGui render/swap callbacks that cannot satisfy the copied-frame RT ownership contract
- add `PresentationSurfaceState` contract coverage

## `dev_parallel_rhi` parity

This ports the presentation-surface ownership direction from `dev_parallel_rhi` while adapting it to main's immutable `WindowSurfaceSource` / `WindowFrameSnapshot`, RenderGraph UI packets, and Executor-owned Present path. It additionally keeps true lazy creation, zero-extent metadata-only behavior, negotiated RT output format handling, transactional retry, and explicit Present/swapchain quiesce.

## Validation

- Debug full build
- Debug CTest: 37/37
- Release full build
- Release CTest: 37/37
- runtime GUI/WSI smoke: Raytracing scene, detached Game create/render/resize/restore/close, main window remains responsive, clean application exit
- local independent review: P0/P1/P2 = 0/0/0

## Deferred to Phase 22D.2

Typed continuous WSI results and persistent recovery receipts (`OUT_OF_DATE`, `SUBOPTIMAL`, `SURFACE_LOST`) remain intentionally out of this PR.