### PR TITLE
Phase 22D.2: add continuous WSI presentation recovery

### DIFF
--- a/source/runtime/render/renderer/Renderer.cpp
+++ b/source/runtime/render/renderer/Renderer.cpp
@@ -71,8 +71,11 @@ Renderer::Renderer(
 
 Renderer::~Renderer() = default;
 
-PresentReceiptRef Renderer::CreateMainPresentReceipt(bool scene_content_ready) {
-    if (first_main_present_confirmed.load(std::memory_order_acquire)) {
+PresentReceiptRef Renderer::SelectMainPresentReceipt(
+    bool                     scene_content_ready,
+    const PresentReceiptRef& candidate
+) {
+    if (!candidate || first_main_present_confirmed.load(std::memory_order_acquire)) {
         return {};
     }
 
@@ -101,7 +104,7 @@ PresentReceiptRef Renderer::CreateMainPresentReceipt(bool scene_content_ready) {
             );
         }
     }
-    return MakeShared<PresentReceipt>();
+    return candidate;
 }
 
 void Renderer::ApplyMainPresentReceipt(const PresentReceiptRef& receipt, const EngineHooks& hooks) {
@@ -118,10 +121,12 @@ void Renderer::ApplyMainPresentReceipt(const PresentReceiptRef& receipt, const E
         );
         return;
     }
-    if (result.recreate_swapchain) {
-        main_swapchain_recreate_requested.store(true, std::memory_order_release);
+    if (PresentStatusRequiresRefresh(result.status)) {
         LOG_INFO(
-            "[Startup][Renderer] Main swapchain requested recreation before the startup handoff."
+            "[Startup][Renderer] Main Present requested presentation recovery before the startup "
+            "handoff (status={}, stage={}).",
+            static_cast<uint32>(result.status),
+            static_cast<uint32>(result.stage)
         );
     }
     if (!result.submitted) {
@@ -176,8 +181,6 @@ bool Renderer::PrepareRenderFrame(const WindowFrameSnapshot& window_frame) {
     }
     RenderGraphResourcePool::Global().Tick();
 
-    const bool recreate_requested =
-        main_swapchain_recreate_requested.exchange(false, std::memory_order_acq_rel);
     if (!main_presentation_surface) {
         return false;
     }
@@ -185,8 +188,7 @@ bool Renderer::PrepareRenderFrame(const WindowFrameSnapshot& window_frame) {
     const EPresentationSurfaceEnsureResult result =
         main_presentation_surface->EnsureCurrent(
             main_window_surface,
-            window_frame,
-            recreate_requested
+            window_frame
         );
     if (!IsPresentationSurfaceReady(result)) {
         return false;

--- a/source/runtime/render/renderer/Renderer.h
+++ b/source/runtime/render/renderer/Renderer.h
@@ -88,7 +88,10 @@ public:
 
 protected:
     [[nodiscard]] bool PrepareRenderFrame(const WindowFrameSnapshot& window_frame);
-    PresentReceiptRef  CreateMainPresentReceipt(bool scene_content_ready);
+    PresentReceiptRef  SelectMainPresentReceipt(
+        bool                     scene_content_ready,
+        const PresentReceiptRef& candidate
+    );
     void ApplyMainPresentReceipt(const PresentReceiptRef& receipt, const EngineHooks& hooks);
     [[nodiscard]] PresentationSurface& GetMainPresentationSurface() noexcept {
         return *main_presentation_surface;
@@ -134,7 +137,6 @@ protected:
     bool     first_load;
     bool     resources_released = false;
     mutable std::atomic<bool> first_main_present_confirmed{false};
-    std::atomic<bool> main_swapchain_recreate_requested{false};
     std::optional<std::chrono::steady_clock::time_point> first_present_candidate_started_at;
     bool first_present_receipt_logged = false;
     uint     max_frame_in_flight;

--- a/source/runtime/render/renderer/common/PresentationSurface.cpp
+++ b/source/runtime/render/renderer/common/PresentationSurface.cpp
@@ -63,7 +63,22 @@ bool PresentationSurfaceState::Commit(
         .capture_sequence       = window_frame.capture_sequence,
         .drawable_generation    = window_frame.drawable_generation,
     };
+    committed_epoch_ = next_epoch_++;
+    if (next_epoch_ == 0) {
+        next_epoch_ = 1;
+    }
     refresh_pending_ = false;
+    return true;
+}
+
+bool PresentationSurfaceState::ApplyPresentFeedback(const PresentReceiptResult& feedback) noexcept {
+    if (!feedback.resolved || !PresentStatusRequiresRefresh(feedback.status) ||
+        feedback.context.presentation_epoch == 0 ||
+        feedback.context.presentation_epoch != committed_epoch_ ||
+        feedback.context.drawable_generation != committed_.drawable_generation) {
+        return false;
+    }
+    refresh_pending_ = true;
     return true;
 }
 
@@ -108,7 +123,11 @@ bool PresentationSurfaceState::IsCurrent(const WindowFrameSnapshot& window_frame
 
 PresentationSurface::PresentationSurface(RenderDevice& device, PresentationSurfaceDesc desc) :
     device_(device),
-    desc_(std::move(desc)) {
+    desc_(std::move(desc)),
+    feedback_mailbox_(
+        desc_.feedback_mailbox ? desc_.feedback_mailbox :
+                                 MakeShared<PresentFeedbackMailbox>()
+    ) {
     AssertRenderOwner();
 }
 
@@ -126,6 +145,14 @@ EPresentationSurfaceEnsureResult PresentationSurface::EnsureCurrent(
     bool                        force_refresh
 ) {
     AssertRenderOwner();
+    if (feedback_mailbox_) {
+        if (const auto feedback = feedback_mailbox_->ConsumeLatestRecovery();
+            feedback.has_value() && state_.ApplyPresentFeedback(*feedback)) {
+            force_surface_recreate_pending_ =
+                force_surface_recreate_pending_ ||
+                PresentStatusRequiresNativeSurfaceRefresh(feedback->status);
+        }
+    }
     if (force_refresh) {
         state_.RequestRefresh();
     }
@@ -153,6 +180,7 @@ EPresentationSurfaceEnsureResult PresentationSurface::EnsureCurrent(
         .size             = window_frame.drawable_extent,
         .back_buffer_sz   = desc_.back_buffer_count,
         .preferred_format = desc_.preferred_format,
+        .force_surface_recreate = force_surface_recreate_pending_,
     };
 
     if (!swapchain_) {
@@ -191,6 +219,7 @@ EPresentationSurfaceEnsureResult PresentationSurface::EnsureCurrent(
     if (!state_.Commit(window_frame, actual_extent)) {
         return EPresentationSurfaceEnsureResult::RetryPending;
     }
+    force_surface_recreate_pending_ = false;
     frame_buffer_ = std::move(committed_frame_buffer);
     return EPresentationSurfaceEnsureResult::Committed;
 }
@@ -198,9 +227,12 @@ EPresentationSurfaceEnsureResult PresentationSurface::EnsureCurrent(
 std::optional<RHIPresentRequest> PresentationSurface::CreatePresentRequest(
     const WindowFrameSnapshot& window_frame,
     TextureView                source,
-    PresentReceiptRef          receipt
-) const {
+    PresentReceiptRef*         out_receipt
+) {
     AssertRenderOwner();
+    if (out_receipt != nullptr) {
+        *out_receipt = {};
+    }
     if (!IsCurrent(window_frame) || source.GetTexture() == nullptr) {
         return std::nullopt;
     }
@@ -208,6 +240,21 @@ std::optional<RHIPresentRequest> PresentationSurface::CreatePresentRequest(
     const Extent2D committed_extent = state_.GetCommittedSnapshot().drawable_extent;
     if (source.extent.x != committed_extent.x || source.extent.y != committed_extent.y) {
         return std::nullopt;
+    }
+    uint64 request_serial = next_present_request_serial_++;
+    if (request_serial == 0) {
+        request_serial = next_present_request_serial_++;
+    }
+    PresentReceiptRef receipt = MakeShared<PresentReceipt>(
+        PresentReceiptContext{
+            .presentation_epoch  = state_.GetCommittedEpoch(),
+            .drawable_generation = state_.GetCommittedSnapshot().drawable_generation,
+            .request_serial      = request_serial,
+        },
+        feedback_mailbox_
+    );
+    if (out_receipt != nullptr) {
+        *out_receipt = receipt;
     }
     return RHIPresentRequest(swapchain_, source, std::move(receipt));
 }
@@ -230,6 +277,10 @@ void PresentationSurface::Release() {
     }
     swapchain_    = nullptr;
     frame_buffer_ = nullptr;
+    force_surface_recreate_pending_ = false;
+    if (feedback_mailbox_) {
+        feedback_mailbox_->Reset();
+    }
     state_.Reset();
 }
 

--- a/source/runtime/render/renderer/common/PresentationSurface.h
+++ b/source/runtime/render/renderer/common/PresentationSurface.h
@@ -47,14 +47,17 @@ public:
 
     [[nodiscard]] bool Commit(const WindowFrameSnapshot& window_frame, Extent2D actual_extent) noexcept;
 
+    [[nodiscard]] bool ApplyPresentFeedback(const PresentReceiptResult& feedback) noexcept;
+
     void Reject() noexcept {
         refresh_pending_ = true;
     }
 
     void Reset() noexcept {
-        committed_       = {};
-        last_observed_   = {};
-        refresh_pending_ = true;
+        committed_        = {};
+        last_observed_    = {};
+        committed_epoch_  = 0;
+        refresh_pending_  = true;
     }
 
     [[nodiscard]] bool
@@ -68,12 +71,18 @@ public:
         return refresh_pending_;
     }
 
+    [[nodiscard]] uint64 GetCommittedEpoch() const noexcept {
+        return committed_epoch_;
+    }
+
 private:
     [[nodiscard]] bool CanObserve(const WindowFrameSnapshot& window_frame) const noexcept;
     void               Observe(const WindowFrameSnapshot& window_frame) noexcept;
 
     PresentationSurfaceSnapshot committed_{};
     WindowFrameSnapshot         last_observed_{};
+    uint64                      committed_epoch_{0};
+    uint64                      next_epoch_{1};
     bool                        refresh_pending_{true};
 };
 
@@ -87,6 +96,7 @@ struct PresentationSurfaceDesc {
     EPixelFormat                                      preferred_format{PF_R8G8B8A8_SRGB};
     std::string                                       debug_name{"PresentationSurface"};
     std::optional<PresentationSurfaceFrameBufferDesc> frame_buffer{};
+    PresentFeedbackMailboxRef                         feedback_mailbox{};
 };
 
 enum class EPresentationSurfaceEnsureResult : uint8_t {
@@ -124,8 +134,8 @@ public:
     [[nodiscard]] std::optional<RHIPresentRequest> CreatePresentRequest(
         const WindowFrameSnapshot& window_frame,
         TextureView                source,
-        PresentReceiptRef          receipt = {}
-    ) const;
+        PresentReceiptRef*         out_receipt = nullptr
+    );
 
     void Quiesce();
     void Release();
@@ -168,9 +178,12 @@ private:
 
     RenderDevice&            device_;
     PresentationSurfaceDesc  desc_;
-    PresentationSurfaceState state_{};
-    SwapchainRef             swapchain_{};
-    TextureRef               frame_buffer_{};
+    PresentationSurfaceState  state_{};
+    SwapchainRef              swapchain_{};
+    TextureRef                frame_buffer_{};
+    PresentFeedbackMailboxRef feedback_mailbox_{};
+    uint64                     next_present_request_serial_{1};
+    bool                       force_surface_recreate_pending_{false};
 };
 
 } // namespace Moer::Render

--- a/source/runtime/render/renderer/common/UIRenderer.h
+++ b/source/runtime/render/renderer/common/UIRenderer.h
@@ -32,6 +32,31 @@ public:
     virtual ~UiViewportRenderResources() = default;
 
     /**
+     * Creates a Present request without transferring ownership out of the
+     * copied viewport packet. Backends that own a PresentationSurface may
+     * attach continuous feedback while the packet keeps its framebuffer,
+     * swapchain, and resource-owner references alive.
+     */
+    [[nodiscard]] virtual std::optional<RHIPresentRequest>
+    CreatePresentRequest(
+        const WindowFrameSnapshot& window_frame,
+        TextureView                source
+    ) {
+        static_cast<void>(window_frame);
+        static_cast<void>(source);
+        return std::nullopt;
+    }
+
+    /**
+     * Game-Thread scheduling hint only. The Render owner remains responsible
+     * for consuming and validating recovery feedback in PresentationSurface.
+     */
+    [[nodiscard]] virtual bool
+    HasPendingPresentationRecovery() const noexcept {
+        return false;
+    }
+
+    /**
      * UI upload-ring selection is speculative until the command source is
      * accepted by the native queue. The renderer records one frame at a time,
      * so a read-only token can be frozen in the copied packet and committed

--- a/source/runtime/render/renderer/common/ui/DearImGuiRenderer.cpp
+++ b/source/runtime/render/renderer/common/ui/DearImGuiRenderer.cpp
@@ -111,13 +111,35 @@ struct GuiFrameRenderBuffers {
     Moer::Render::BufferRef argument_buffer;
 };
 struct GuiViewportRenderResources final : UiViewportRenderResources {
-    UniquePtr<PresentationSurface> presentation_surface;
+    PresentFeedbackMailboxRef          presentation_feedback_mailbox;
+    UniquePtr<PresentationSurface>     presentation_surface;
 
     Array<GuiFrameRenderBuffers> render_buffers;
 
     uint64_t frame_index = 0;
 
-    explicit GuiViewportRenderResources(uint32_t _frame_in_flight) : render_buffers(_frame_in_flight) {}
+    explicit GuiViewportRenderResources(uint32_t _frame_in_flight) :
+        presentation_feedback_mailbox(
+            MakeShared<PresentFeedbackMailbox>()
+        ),
+        render_buffers(_frame_in_flight) {}
+
+    std::optional<RHIPresentRequest> CreatePresentRequest(
+        const WindowFrameSnapshot& window_frame,
+        TextureView                source
+    ) override {
+        if (!presentation_surface) {
+            return std::nullopt;
+        }
+        return presentation_surface->CreatePresentRequest(
+            window_frame, source
+        );
+    }
+
+    bool HasPendingPresentationRecovery() const noexcept override {
+        return presentation_feedback_mailbox &&
+               presentation_feedback_mailbox->HasPendingRecovery();
+    }
 
     uint64_t GetPendingRecordingSlot() const noexcept override {
         return frame_index;
@@ -646,11 +668,18 @@ void ImGuiRenderBackend::PresentWindows(
         (_execution_thread == EUiDrawExecutionThread::Render && IsCurrentlyRenderThread())
     );
     for (const auto& viewport : _frame.platform_viewports) {
-        if (IsUiViewportPresentationCurrent(viewport)) {
+        if (IsUiViewportPresentationCurrent(viewport) &&
+            viewport.render_resources) {
             const auto framebuffer_view = viewport.framebuffer->GetView();
-            RHIExecutor::Get().Present(
-                RHIPresentRequest(viewport.swapchain, framebuffer_view), true
-            );
+            auto present_request =
+                viewport.render_resources->CreatePresentRequest(
+                    viewport.window_frame, framebuffer_view
+                );
+            if (present_request.has_value()) {
+                RHIExecutor::Get().Present(
+                    std::move(*present_request), true
+                );
+            }
         }
     }
 }
@@ -920,6 +949,8 @@ bool CreateOrResizeViewportResources(
                             ETextureUsageFlags::TRANSFER_SRC |
                             ETextureUsageFlags::TRANSFER_DST,
                     },
+                    .feedback_mailbox =
+                        _resources->presentation_feedback_mailbox,
                 }
             );
     }
@@ -1048,8 +1079,14 @@ bool RefreshGuiViewportPresentation(
         transition == EWindowFrameTransition::DrawableResized ||
         transition == EWindowFrameTransition::Restored ||
         transition == EWindowFrameTransition::Replaced;
+    const bool presentation_recovery_pending =
+        viewport_data.render_resources &&
+        viewport_data.render_resources
+            ->HasPendingPresentationRecovery();
     viewport_data.presentation_refresh_pending =
-        viewport_data.presentation_refresh_pending || presentation_changed;
+        viewport_data.presentation_refresh_pending ||
+        presentation_changed ||
+        presentation_recovery_pending;
     if (!viewport_data.latest_window_frame.IsDrawable()) {
         return false;
     }

--- a/source/runtime/render/renderer/raster/RasterRenderer.cpp
+++ b/source/runtime/render/renderer/raster/RasterRenderer.cpp
@@ -1813,12 +1813,11 @@ RasterFrameFeedback RasterRenderer::RenderFrame(RasterFramePacket frame_packet) 
                 frame_packet.ui_draw_frame.platform_viewports.size()
             );
         }
-        main_present_receipt =
-            CreateMainPresentReceipt(frame_packet.scene_updates.scene_ready);
+        PresentReceiptRef continuous_present_receipt{};
         present_request = main_presentation_surface.CreatePresentRequest(
             frame_packet.window,
             output_view,
-            main_present_receipt
+            &continuous_present_receipt
         );
         if (!present_request.has_value()) {
             main_present_receipt = {};
@@ -1828,6 +1827,11 @@ RasterFrameFeedback RasterRenderer::RenderFrame(RasterFramePacket frame_packet) 
                 output_view.extent.y,
                 presentation_extent.x,
                 presentation_extent.y
+            );
+        } else {
+            main_present_receipt = SelectMainPresentReceipt(
+                frame_packet.scene_updates.scene_ready,
+                continuous_present_receipt
             );
         }
     }

--- a/source/runtime/render/renderer/raytracing/RaytracingRenderer.cpp
+++ b/source/runtime/render/renderer/raytracing/RaytracingRenderer.cpp
@@ -1959,14 +1959,11 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
                 prepared_ui->GetDrawFrame().platform_viewports.size()
             );
         }
-        feedback.main_present_receipt = CreateMainPresentReceipt(
-            frame_packet.scene_updates.scene_ready &&
-            frame_packet.runtime_assets_ready
-        );
+        PresentReceiptRef continuous_present_receipt{};
         present_request = main_presentation_surface.CreatePresentRequest(
             frame_packet.window,
             output_view,
-            feedback.main_present_receipt
+            &continuous_present_receipt
         );
         if (!present_request.has_value()) {
             feedback.main_present_receipt = {};
@@ -1976,6 +1973,12 @@ RaytracingFrameFeedback RaytracingRenderer::RenderFrame(RaytracingFramePacket fr
                 output_view.extent.y,
                 presentation_extent.x,
                 presentation_extent.y
+            );
+        } else {
+            feedback.main_present_receipt = SelectMainPresentReceipt(
+                frame_packet.scene_updates.scene_ready &&
+                    frame_packet.runtime_assets_ready,
+                continuous_present_receipt
             );
         }
     }

--- a/source/runtime/render/rhi/RHICommand.h
+++ b/source/runtime/render/rhi/RHICommand.h
@@ -16,6 +16,7 @@
 #include "rhi/RHIResource.h"
 #include "rhi/RHISubmissionTopology.h"
 #include "shader/ShaderPipeline.h"
+#include <atomic>
 #include <array>
 #include <chrono>
 #include <condition_variable>
@@ -2196,15 +2197,167 @@ struct ProfileData {
     Array<ProfileResultEntry> cpu_entries;
 };
 
-struct PresentReceiptResult {
-    bool resolved              = false;
-    bool submitted            = false;
-    bool recreate_swapchain   = false;
+enum class EPresentStatus : uint8_t {
+    Unresolved,
+    Success,
+    Suboptimal,
+    Retry,
+    OutOfDate,
+    SurfaceLost,
+    Rejected,
+    Faulted,
 };
+
+enum class EPresentStage : uint8_t {
+    None,
+    Validation,
+    Acquire,
+    Submit,
+    Present,
+};
+
+[[nodiscard]] constexpr bool
+PresentStatusRequiresRefresh(EPresentStatus status) noexcept {
+    return status == EPresentStatus::Suboptimal ||
+           status == EPresentStatus::OutOfDate ||
+           status == EPresentStatus::SurfaceLost;
+}
+
+[[nodiscard]] constexpr bool
+PresentStatusRequiresNativeSurfaceRefresh(EPresentStatus status) noexcept {
+    return status == EPresentStatus::SurfaceLost;
+}
+
+[[nodiscard]] constexpr uint8_t PresentRecoveryPriority(EPresentStatus status) noexcept {
+    switch (status) {
+        case EPresentStatus::SurfaceLost:
+            return 3;
+        case EPresentStatus::OutOfDate:
+            return 2;
+        case EPresentStatus::Suboptimal:
+            return 1;
+        default:
+            return 0;
+    }
+}
+
+struct PresentReceiptContext {
+    uint64 presentation_epoch  = 0;
+    uint64 drawable_generation = 0;
+    uint64 request_serial      = 0;
+};
+
+struct PresentReceiptResult {
+    bool                  resolved            = false;
+    bool                  submitted           = false;
+    bool                  recreate_swapchain  = false;
+    EPresentStatus        status              = EPresentStatus::Unresolved;
+    EPresentStage         stage               = EPresentStage::None;
+    PresentReceiptContext context{};
+};
+
+// Cross-thread, bounded recovery mailbox. Submission publishes only the latest
+// refresh-requiring result. The Render owner consumes it; the Game Thread may
+// only inspect the atomic pending bit to schedule detached-viewport control.
+class PresentFeedbackMailbox {
+public:
+    void Publish(const PresentReceiptResult& result) noexcept {
+        if (!result.resolved ||
+            !PresentStatusRequiresRefresh(result.status) ||
+            result.context.presentation_epoch == 0 ||
+            result.context.drawable_generation == 0 ||
+            result.context.request_serial == 0) {
+            return;
+        }
+        try {
+            std::unique_lock<std::mutex> lock(mutex);
+            const bool replace =
+                !latest_recovery.has_value() ||
+                result.context.presentation_epoch >
+                    latest_recovery->context.presentation_epoch ||
+                (result.context.presentation_epoch ==
+                     latest_recovery->context.presentation_epoch &&
+                 (PresentRecoveryPriority(result.status) >
+                      PresentRecoveryPriority(latest_recovery->status) ||
+                  (PresentRecoveryPriority(result.status) ==
+                       PresentRecoveryPriority(latest_recovery->status) &&
+                   result.context.request_serial >=
+                       latest_recovery->context.request_serial)));
+            if (replace) {
+                latest_recovery = result;
+                recovery_pending.store(true, std::memory_order_release);
+            }
+        } catch (...) {
+        }
+    }
+
+    [[nodiscard]] std::optional<PresentReceiptResult>
+    ConsumeLatestRecovery() noexcept {
+        try {
+            std::unique_lock<std::mutex> lock(mutex);
+            if (!latest_recovery.has_value()) {
+                recovery_pending.store(false, std::memory_order_release);
+                return std::nullopt;
+            }
+            std::optional<PresentReceiptResult> result =
+                std::move(latest_recovery);
+            latest_recovery.reset();
+            recovery_pending.store(false, std::memory_order_release);
+            return result;
+        } catch (...) {
+            return std::nullopt;
+        }
+    }
+
+    [[nodiscard]] bool HasPendingRecovery() const noexcept {
+        return recovery_pending.load(std::memory_order_acquire);
+    }
+
+    void Reset() noexcept {
+        try {
+            std::unique_lock<std::mutex> lock(mutex);
+            latest_recovery.reset();
+            recovery_pending.store(false, std::memory_order_release);
+        } catch (...) {
+        }
+    }
+
+private:
+    mutable std::mutex                  mutex;
+    std::optional<PresentReceiptResult> latest_recovery{};
+    std::atomic_bool                    recovery_pending{false};
+};
+
+using PresentFeedbackMailboxRef = SharedPtr<PresentFeedbackMailbox>;
 
 class PresentReceipt {
 public:
+    PresentReceipt() = default;
+
+    explicit PresentReceipt(
+        PresentReceiptContext     _context,
+        PresentFeedbackMailboxRef _feedback_mailbox = {}
+    ) :
+        context(_context),
+        feedback_mailbox(std::move(_feedback_mailbox)) {}
+
     void Resolve(bool _submitted, bool _recreate_swapchain = false) {
+        Resolve(
+            _submitted,
+            _recreate_swapchain ?
+                (_submitted ? EPresentStatus::Suboptimal :
+                              EPresentStatus::OutOfDate) :
+                (_submitted ? EPresentStatus::Success :
+                              EPresentStatus::Rejected),
+            EPresentStage::None
+        );
+    }
+
+    void Resolve(
+        bool           _submitted,
+        EPresentStatus _status,
+        EPresentStage  _stage
+    ) {
         {
             std::unique_lock<std::mutex> lock(mutex);
             ++resolution_attempts;
@@ -2213,7 +2366,14 @@ public:
             }
             result.resolved            = true;
             result.submitted           = _submitted;
-            result.recreate_swapchain  = _recreate_swapchain;
+            result.recreate_swapchain  =
+                PresentStatusRequiresRefresh(_status);
+            result.status              = _status;
+            result.stage               = _stage;
+            result.context             = context;
+            if (feedback_mailbox) {
+                feedback_mailbox->Publish(result);
+            }
             resolved                   = true;
         }
         cv.notify_all();
@@ -2229,17 +2389,28 @@ public:
         return result;
     }
 
+    [[nodiscard]] std::optional<PresentReceiptResult>
+    TryGetResult() const {
+        std::unique_lock<std::mutex> lock(mutex);
+        if (!resolved) {
+            return std::nullopt;
+        }
+        return result;
+    }
+
     [[nodiscard]] uint32 ResolutionAttemptCount() const noexcept {
         std::unique_lock<std::mutex> lock(mutex);
         return resolution_attempts;
     }
 
 private:
-    mutable std::mutex       mutex;
-    std::condition_variable  cv;
-    PresentReceiptResult     result{};
-    bool                     resolved{false};
-    uint32                   resolution_attempts{0};
+    mutable std::mutex        mutex;
+    std::condition_variable   cv;
+    PresentReceiptResult      result{};
+    PresentReceiptContext     context{};
+    PresentFeedbackMailboxRef feedback_mailbox{};
+    bool                      resolved{false};
+    uint32                    resolution_attempts{0};
 };
 
 using PresentReceiptRef = SharedPtr<PresentReceipt>;

--- a/source/runtime/render/rhi/RHIResource.h
+++ b/source/runtime/render/rhi/RHIResource.h
@@ -1386,8 +1386,9 @@ struct RenderPassInfo {
 struct SwapchainCreateInfo {
     SwapchainSurfaceInfo surface;
     Extent2D             size;
-    uint                 back_buffer_sz   = 2;
-    EPixelFormat         preferred_format = PF_R8G8B8A8_SRGB;
+    uint                 back_buffer_sz         = 2;
+    EPixelFormat         preferred_format       = PF_R8G8B8A8_SRGB;
+    bool                 force_surface_recreate = false;
 };
 
 class RENDER_API Swapchain : public RHIResource {

--- a/source/runtime/render/rhi/vulkan/VulkanDevice.cpp
+++ b/source/runtime/render/rhi/vulkan/VulkanDevice.cpp
@@ -1180,7 +1180,7 @@ VulkanOperationResult VulkanDevice::PresentOnQueue(
         return {EVulkanOperationStatus::Retry, result};
     }
     if (result == VK_SUBOPTIMAL_KHR || result == VK_ERROR_OUT_OF_DATE_KHR ||
-        result == VK_ERROR_FULL_SCREEN_EXCLUSIVE_MODE_LOST_EXT) {
+        result == VK_ERROR_SURFACE_LOST_KHR || result == VK_ERROR_FULL_SCREEN_EXCLUSIVE_MODE_LOST_EXT) {
         return {EVulkanOperationStatus::Recreate, result};
     }
 
@@ -1209,9 +1209,8 @@ VulkanOperationResult VulkanDevice::AcquireNextImage(
         return {EVulkanOperationStatus::Rejected, GetFirstFaultResult()};
     }
 
-    const VkResult result = vkAcquireNextImageKHR(
-        m_device, _swapchain, _timeout, _semaphore, _fence, _image_index
-    );
+    const VkResult result =
+        vkAcquireNextImageKHR(m_device, _swapchain, _timeout, _semaphore, _fence, _image_index);
     if (result == VK_SUCCESS) {
         return {};
     }
@@ -1219,7 +1218,7 @@ VulkanOperationResult VulkanDevice::AcquireNextImage(
         return {EVulkanOperationStatus::Retry, result};
     }
     if (result == VK_SUBOPTIMAL_KHR || result == VK_ERROR_OUT_OF_DATE_KHR ||
-        result == VK_ERROR_FULL_SCREEN_EXCLUSIVE_MODE_LOST_EXT) {
+        result == VK_ERROR_SURFACE_LOST_KHR || result == VK_ERROR_FULL_SCREEN_EXCLUSIVE_MODE_LOST_EXT) {
         return {EVulkanOperationStatus::Recreate, result};
     }
 
@@ -1372,10 +1371,12 @@ bool VulkanDevice::TryLatchFirstFault(
     if (_result == VK_SUCCESS) {
         return false;
     }
+    if (_result == VK_ERROR_SURFACE_LOST_KHR) {
+        return false;
+    }
     if (!_force_terminal &&
-        (_result == VK_NOT_READY || _result == VK_TIMEOUT ||
-         _result == VK_SUBOPTIMAL_KHR || _result == VK_ERROR_OUT_OF_DATE_KHR ||
-         _result == VK_ERROR_FULL_SCREEN_EXCLUSIVE_MODE_LOST_EXT)) {
+        (_result == VK_NOT_READY || _result == VK_TIMEOUT || _result == VK_SUBOPTIMAL_KHR ||
+         _result == VK_ERROR_OUT_OF_DATE_KHR || _result == VK_ERROR_FULL_SCREEN_EXCLUSIVE_MODE_LOST_EXT)) {
         return false;
     }
     if (!TryBeginFirstFault(_result)) {

--- a/source/runtime/render/rhi/vulkan/VulkanQueue.cpp
+++ b/source/runtime/render/rhi/vulkan/VulkanQueue.cpp
@@ -824,16 +824,89 @@ void VulkanBatchCompletionGroup::WaitUntilSettled() {
     });
 }
 
+static EPresentStatus PresentStatusFromVulkanOutcome(const VulkanOperationResult& _outcome) noexcept {
+    switch (_outcome.result) {
+        case VK_SUCCESS:
+            return EPresentStatus::Success;
+        case VK_SUBOPTIMAL_KHR:
+            return EPresentStatus::Suboptimal;
+        case VK_NOT_READY:
+        case VK_TIMEOUT:
+            return EPresentStatus::Retry;
+        case VK_ERROR_OUT_OF_DATE_KHR:
+        case VK_ERROR_FULL_SCREEN_EXCLUSIVE_MODE_LOST_EXT:
+            return EPresentStatus::OutOfDate;
+        case VK_ERROR_SURFACE_LOST_KHR:
+            return EPresentStatus::SurfaceLost;
+        case VK_ERROR_DEVICE_LOST:
+        case VK_ERROR_OUT_OF_HOST_MEMORY:
+        case VK_ERROR_OUT_OF_DEVICE_MEMORY:
+            return EPresentStatus::Faulted;
+        default:
+            break;
+    }
+
+    switch (_outcome.status) {
+        case EVulkanOperationStatus::Success:
+            return EPresentStatus::Success;
+        case EVulkanOperationStatus::Retry:
+            return EPresentStatus::Retry;
+        case EVulkanOperationStatus::Recreate:
+            return EPresentStatus::OutOfDate;
+        case EVulkanOperationStatus::Faulted:
+            return EPresentStatus::Faulted;
+        case EVulkanOperationStatus::Rejected:
+        default:
+            return EPresentStatus::Rejected;
+    }
+}
+
+static uint8_t PresentStatusPriority(EPresentStatus _status) noexcept {
+    switch (_status) {
+        case EPresentStatus::Success:
+            return 1;
+        case EPresentStatus::Retry:
+            return 2;
+        case EPresentStatus::Rejected:
+            return 3;
+        case EPresentStatus::Suboptimal:
+            return 4;
+        case EPresentStatus::OutOfDate:
+            return 5;
+        case EPresentStatus::SurfaceLost:
+            return 6;
+        case EPresentStatus::Faulted:
+            return 7;
+        case EPresentStatus::Unresolved:
+        default:
+            return 0;
+    }
+}
+
+static void AccumulatePresentReceiptOutcome(
+    EPresentStatus&              _status,
+    EPresentStage&               _stage,
+    const VulkanOperationResult& _outcome,
+    EPresentStage                _outcome_stage
+) noexcept {
+    const EPresentStatus outcome_status = PresentStatusFromVulkanOutcome(_outcome);
+    if (PresentStatusPriority(outcome_status) >= PresentStatusPriority(_status)) {
+        _status = outcome_status;
+        _stage  = _outcome_stage;
+    }
+}
+
 static void ResolvePresentReceiptNoexcept(
     const PresentReceiptRef& _receipt,
     bool                     _submitted,
-    bool                     _recreate_swapchain
+    EPresentStatus           _status,
+    EPresentStage            _stage
 ) noexcept {
     if (!_receipt) {
         return;
     }
     try {
-        _receipt->Resolve(_submitted, _recreate_swapchain);
+        _receipt->Resolve(_submitted, _status, _stage);
     } catch (...) {
         try {
             LOG_ERROR("[RHIExecutor][Vulkan] failed to resolve Present receipt");
@@ -845,9 +918,7 @@ static void ResolvePresentReceiptNoexcept(
 class StaleBindlessUpdateBatch final : public std::runtime_error {
 public:
     StaleBindlessUpdateBatch() :
-        std::runtime_error(
-            "stale bindless update batch cannot be submitted with dependent commands"
-        ) {}
+        std::runtime_error("stale bindless update batch cannot be submitted with dependent commands") {}
 };
 
 #pragma endregion
@@ -5662,13 +5733,12 @@ void VkCommandQueue::RejectForRuntime(
 }
 
 VulkanRuntimeSubmissionResult VkCommandQueue::PresentForRuntime(
-    SwapchainRef _swapchain,
-    TextureView _source,
+    SwapchainRef      _swapchain,
+    TextureView       _source,
     PresentReceiptRef _receipt
 ) noexcept {
     assert(
-        execution_ownership_mode.load(std::memory_order_acquire) ==
-            EExecutionOwnershipMode::Runtime &&
+        execution_ownership_mode.load(std::memory_order_acquire) == EExecutionOwnershipMode::Runtime &&
         "runtime Present requires an exclusively claimed queue"
     );
     assert(
@@ -5678,36 +5748,28 @@ VulkanRuntimeSubmissionResult VkCommandQueue::PresentForRuntime(
     try {
         if (vk_device.IsFaulted()) {
             vk_device.RecordRejectedPresent();
-            ResolvePresentReceiptNoexcept(_receipt, false, false);
-            return {
-                .outcome = {
-                    EVulkanOperationStatus::Rejected,
-                    vk_device.GetFirstFaultResult()
-                }
-            };
+            ResolvePresentReceiptNoexcept(
+                _receipt, false, EPresentStatus::Faulted, EPresentStage::Validation
+            );
+            return {.outcome = {EVulkanOperationStatus::Rejected, vk_device.GetFirstFaultResult()}};
         }
-        TextureRef source_texture{_source.texture};
+        TextureRef                                     source_texture{_source.texture};
         const VulkanScriptedPresentOverrideForTesting* scripted_override =
             g_scripted_present_override.load(std::memory_order_acquire);
         const VulkanPresentSourceContract source_contract =
-            ValidatePresentSourceContract(
-                _source, _swapchain.Get()
-            );
+            ValidatePresentSourceContract(_source, _swapchain.Get());
         if (!source_contract.valid) {
-            InvokePresentSourceRejectionCallbackForTesting(
-                scripted_override
-            );
-            bool recoverable_rejection = false;
+            InvokePresentSourceRejectionCallbackForTesting(scripted_override);
+            bool                        recoverable_rejection = false;
             const VulkanOperationResult rejection =
-                ClassifyPresentSourceRejection(
-                    vk_device, recoverable_rejection
-                );
+                ClassifyPresentSourceRejection(vk_device, recoverable_rejection);
             vk_device.RecordRejectedPresent();
-            ResolvePresentReceiptNoexcept(_receipt, false, false);
+            ResolvePresentReceiptNoexcept(
+                _receipt, false, PresentStatusFromVulkanOutcome(rejection), EPresentStage::Validation
+            );
             try {
                 LOG_ERROR(
-                    "[RHIExecutor][Vulkan] rejected Present source contract: {}",
-                    source_contract.reason
+                    "[RHIExecutor][Vulkan] rejected Present source contract: {}", source_contract.reason
                 );
             } catch (...) {
             }
@@ -5716,26 +5778,20 @@ VulkanRuntimeSubmissionResult VkCommandQueue::PresentForRuntime(
                 .recoverable_rejection = recoverable_rejection,
             };
         }
-        auto* vk_source_texture =
-            static_cast<VulkanTexture*>(_source.texture);
+        auto* vk_source_texture = static_cast<VulkanTexture*>(_source.texture);
         if (!vk_source_texture->IsPresentationSourceReady() &&
-            (scripted_override == nullptr ||
-             scripted_override->require_present_source_ready)) {
-            InvokePresentSourceRejectionCallbackForTesting(
-                scripted_override
-            );
-            bool recoverable_rejection = false;
+            (scripted_override == nullptr || scripted_override->require_present_source_ready)) {
+            InvokePresentSourceRejectionCallbackForTesting(scripted_override);
+            bool                        recoverable_rejection = false;
             const VulkanOperationResult rejection =
-                ClassifyPresentSourceRejection(
-                    vk_device, recoverable_rejection
-                );
+                ClassifyPresentSourceRejection(vk_device, recoverable_rejection);
             vk_device.RecordRejectedPresent();
-            ResolvePresentReceiptNoexcept(_receipt, false, false);
+            ResolvePresentReceiptNoexcept(
+                _receipt, false, PresentStatusFromVulkanOutcome(rejection), EPresentStage::Validation
+            );
             try {
-                LOG_ERROR(
-                    "[RHIExecutor][Vulkan] rejected Present source before an "
-                    "accepted producer export published GENERAL / TRANSFER_READ"
-                );
+                LOG_ERROR("[RHIExecutor][Vulkan] rejected Present source before an "
+                          "accepted producer export published GENERAL / TRANSFER_READ");
             } catch (...) {
             }
             return {
@@ -5744,16 +5800,12 @@ VulkanRuntimeSubmissionResult VkCommandQueue::PresentForRuntime(
             };
         }
 
-        auto execution_lease = runtime_execution_gate.Acquire();
+        auto                         execution_lease = runtime_execution_gate.Acquire();
         std::unique_lock<std::mutex> execution_lock(exec_mtx);
-        const uint64 current_timeline =
-            last_frame.fetch_add(1, std::memory_order_relaxed) + 1;
+        const uint64 current_timeline = last_frame.fetch_add(1, std::memory_order_relaxed) + 1;
         if (scripted_override != nullptr) {
             VulkanScriptedPresentResult scripted =
-                scripted_override->callback(
-                    scripted_override->context,
-                    current_timeline
-                );
+                scripted_override->callback(scripted_override->context, current_timeline);
             switch (scripted.outcome.status) {
                 case EVulkanOperationStatus::Retry:
                 case EVulkanOperationStatus::Recreate:
@@ -5766,8 +5818,7 @@ VulkanRuntimeSubmissionResult VkCommandQueue::PresentForRuntime(
                 default:
                     // A headless test hook must never claim native success or
                     // mutate VulkanDevice fault state.
-                    scripted.outcome.status =
-                        EVulkanOperationStatus::Rejected;
+                    scripted.outcome.status = EVulkanOperationStatus::Rejected;
                     if (scripted.outcome.result == VK_SUCCESS) {
                         scripted.outcome.result = VK_ERROR_UNKNOWN;
                     }
@@ -5795,10 +5846,7 @@ VulkanRuntimeSubmissionResult VkCommandQueue::PresentForRuntime(
                 current_timeline
             );
             ResolvePresentReceiptNoexcept(
-                _receipt,
-                false,
-                scripted.outcome.status ==
-                    EVulkanOperationStatus::Recreate
+                _receipt, false, PresentStatusFromVulkanOutcome(scripted.outcome), EPresentStage::Present
             );
             return {
                 .outcome               = scripted.outcome,
@@ -5817,20 +5865,20 @@ VulkanRuntimeSubmissionResult VkCommandQueue::PresentForRuntime(
         );
     } catch (...) {
         vk_device.RecordRejectedPresent();
-        ResolvePresentReceiptNoexcept(_receipt, false, false);
+        ResolvePresentReceiptNoexcept(
+            _receipt,
+            false,
+            vk_device.IsFaulted() ? EPresentStatus::Faulted : EPresentStatus::Rejected,
+            EPresentStage::Validation
+        );
         try {
-            LOG_ERROR(
-                "[RHIExecutor][Vulkan] Present owner setup threw before timeline reservation"
-            );
+            LOG_ERROR("[RHIExecutor][Vulkan] Present owner setup threw before timeline reservation");
         } catch (...) {
         }
         return {
-            .outcome = {
-                EVulkanOperationStatus::Rejected,
-                vk_device.IsFaulted() ?
-                    vk_device.GetFirstFaultResult() :
-                    VK_ERROR_UNKNOWN
-            }
+            .outcome =
+                {EVulkanOperationStatus::Rejected,
+                 vk_device.IsFaulted() ? vk_device.GetFirstFaultResult() : VK_ERROR_UNKNOWN}
         };
     }
 }
@@ -8002,8 +8050,7 @@ void VkCommandQueue::ExecuteNow(
         );
         profiler_storage.AdvanceFrame();
     } else if (has_cmd && emits_profiling_queries) {
-        const bool submission_accepted =
-            _out_recorded != nullptr || submit_result.outcome.WasSubmitted();
+        const bool submission_accepted = _out_recorded != nullptr || submit_result.outcome.WasSubmitted();
         if (!submission_accepted) {
             ResetSplitProfilingCpuFrame();
         } else {
@@ -8015,24 +8062,16 @@ void VkCommandQueue::ExecuteNow(
     }
 }
 
-void VkCommandQueue::Present(
-    SwapchainRef      _sc,
-    TextureView       _view,
-    PresentReceiptRef _receipt
-) {
+void VkCommandQueue::Present(SwapchainRef _sc, TextureView _view, PresentReceiptRef _receipt) {
     TextureRef source_texture{_view.texture};
 
     if (!ClaimLegacyOwnership("Present")) {
-        if (_receipt) {
-            _receipt->Resolve(false);
-        }
+        ResolvePresentReceiptNoexcept(_receipt, false, EPresentStatus::Rejected, EPresentStage::Validation);
         return;
     }
     if (vk_device.IsFaulted()) {
         vk_device.RecordRejectedPresent();
-        if (_receipt) {
-            _receipt->Resolve(false);
-        }
+        ResolvePresentReceiptNoexcept(_receipt, false, EPresentStatus::Faulted, EPresentStage::Validation);
         return;
     }
 
@@ -8096,13 +8135,13 @@ void VkCommandQueue::Present(
 }
 
 VulkanRuntimeSubmissionResult VkCommandQueue::PresentNow(
-    SwapchainRef&& _sc,
-    TextureRef&&   _source_texture,
-    TextureView    _view,
+    SwapchainRef&&    _sc,
+    TextureRef&&      _source_texture,
+    TextureView       _view,
     PresentReceiptRef _receipt,
-    uint64         _timeline,
-    uint64         _serial,
-    bool           _runtime_owner
+    uint64            _timeline,
+    uint64            _serial,
+    bool              _runtime_owner
 ) noexcept {
     assert(
         _runtime_owner || !rhi_thread_enabled ||
@@ -8117,93 +8156,78 @@ VulkanRuntimeSubmissionResult VkCommandQueue::PresentNow(
         .work_serial = _serial,
     };
 
-    VulkanOperationResult final_outcome{
-        EVulkanOperationStatus::Rejected, VK_ERROR_UNKNOWN
-    };
-    bool                            gpu_submitted = false;
-    bool                            present_accepted = false;
-    bool                            recreate_swapchain = false;
+    VulkanOperationResult           final_outcome{EVulkanOperationStatus::Rejected, VK_ERROR_UNKNOWN};
+    bool                            gpu_submitted         = false;
+    bool                            present_accepted      = false;
     bool                            recoverable_rejection = false;
-    EVulkanPresentorRetirementState presentor_state =
-        EVulkanPresentorRetirementState::Unused;
-    UniquePtr<VulkanPresentor> presentor{};
-    Array<RHIResource*>        deferred_releases{};
+    EPresentStatus                  receipt_status        = EPresentStatus::Unresolved;
+    EPresentStage                   receipt_stage         = EPresentStage::None;
+    EVulkanPresentorRetirementState presentor_state       = EVulkanPresentorRetirementState::Unused;
+    UniquePtr<VulkanPresentor>      presentor{};
+    Array<RHIResource*>             deferred_releases{};
 
     try {
-        const VulkanScriptedPresentOverrideForTesting*
-            scripted_override = g_scripted_present_override.load(
-                std::memory_order_acquire
-            );
+        const VulkanScriptedPresentOverrideForTesting* scripted_override =
+            g_scripted_present_override.load(std::memory_order_acquire);
         if (vk_device.IsFaulted()) {
             vk_device.RecordRejectedPresent();
-            final_outcome = {
-                EVulkanOperationStatus::Rejected,
-                vk_device.GetFirstFaultResult()
-            };
+            final_outcome = {EVulkanOperationStatus::Rejected, vk_device.GetFirstFaultResult()};
+            AccumulatePresentReceiptOutcome(
+                receipt_status, receipt_stage, final_outcome, EPresentStage::Validation
+            );
         } else if (const VulkanPresentSourceContract source_contract =
                        ValidatePresentSourceContract(_view, _sc.Get());
                    !source_contract.valid) {
-            InvokePresentSourceRejectionCallbackForTesting(
-                scripted_override
-            );
-            final_outcome = ClassifyPresentSourceRejection(
-                vk_device, recoverable_rejection
+            InvokePresentSourceRejectionCallbackForTesting(scripted_override);
+            final_outcome = ClassifyPresentSourceRejection(vk_device, recoverable_rejection);
+            AccumulatePresentReceiptOutcome(
+                receipt_status, receipt_stage, final_outcome, EPresentStage::Validation
             );
             vk_device.RecordRejectedPresent();
             try {
                 LOG_ERROR(
-                    "[RHIExecutor][Vulkan] rejected Present source contract: {}",
-                    source_contract.reason
+                    "[RHIExecutor][Vulkan] rejected Present source contract: {}", source_contract.reason
                 );
             } catch (...) {
             }
-        } else if (!static_cast<VulkanTexture*>(_view.texture)
-                        ->IsPresentationSourceReady()) {
-            InvokePresentSourceRejectionCallbackForTesting(
-                scripted_override
-            );
-            final_outcome = ClassifyPresentSourceRejection(
-                vk_device, recoverable_rejection
+        } else if (!static_cast<VulkanTexture*>(_view.texture)->IsPresentationSourceReady()) {
+            InvokePresentSourceRejectionCallbackForTesting(scripted_override);
+            final_outcome = ClassifyPresentSourceRejection(vk_device, recoverable_rejection);
+            AccumulatePresentReceiptOutcome(
+                receipt_status, receipt_stage, final_outcome, EPresentStage::Validation
             );
             vk_device.RecordRejectedPresent();
         } else {
-            auto* vk_source_texture =
-                static_cast<VulkanTexture*>(_view.texture);
-            VkSwapchain* sc = ResourceCast(_sc.Get());
-            presentor       = GetPresentor();
+            auto*        vk_source_texture = static_cast<VulkanTexture*>(_view.texture);
+            VkSwapchain* sc                = ResourceCast(_sc.Get());
+            presentor                      = GetPresentor();
             if (!sc->WaitFrameInFlight()) {
                 vk_device.RecordRejectedPresent();
-                final_outcome = {
-                    EVulkanOperationStatus::Rejected,
-                    GetRejectedSubmitResult(vk_device)
-                };
+                final_outcome = {EVulkanOperationStatus::Rejected, GetRejectedSubmitResult(vk_device)};
+                AccumulatePresentReceiptOutcome(
+                    receipt_status, receipt_stage, final_outcome, EPresentStage::Submit
+                );
             } else {
-                const VkSwapchain::AcquireResult acquire =
-                    sc->AquireNextImage(
-                        presentor->GetImageReadySemaphore(),
-                        rhi_thread_enabled ? 0 : 50'000'000
-                    );
-                final_outcome      = acquire.outcome;
-                recreate_swapchain =
-                    acquire.outcome.status == EVulkanOperationStatus::Recreate;
+                const VkSwapchain::AcquireResult acquire = sc->AquireNextImage(
+                    presentor->GetImageReadySemaphore(), rhi_thread_enabled ? 0 : 50'000'000
+                );
+                final_outcome = acquire.outcome;
+                AccumulatePresentReceiptOutcome(
+                    receipt_status, receipt_stage, acquire.outcome, EPresentStage::Acquire
+                );
 
                 if (acquire.HasImage()) {
-                    presentor_state =
-                        EVulkanPresentorRetirementState::RecordedNotSubmitted;
-                    auto& vk_allocator = *presentor;
-                    auto& vk_cmd_list  = vk_allocator.GetCmdList();
-                    auto& vk_tracker   = vk_allocator.GetTracker();
-                    auto* vk_src_tex   = vk_source_texture;
-                    const uint idx     = acquire.image_index;
-                    auto* swapchain_tex =
-                        ResourceCast(sc->GetSwapchainImage(idx).texture);
+                    presentor_state          = EVulkanPresentorRetirementState::RecordedNotSubmitted;
+                    auto&      vk_allocator  = *presentor;
+                    auto&      vk_cmd_list   = vk_allocator.GetCmdList();
+                    auto&      vk_tracker    = vk_allocator.GetTracker();
+                    auto*      vk_src_tex    = vk_source_texture;
+                    const uint idx           = acquire.image_index;
+                    auto*      swapchain_tex = ResourceCast(sc->GetSwapchainImage(idx).texture);
 
                     VK_CHECK_RESULT(vk_cmd_list.Begin());
-                    const std::string present_label =
-                        std::format("Present: {}", vk_src_tex->GetName());
-                    vk_cmd_list.BeginLabel(
-                        present_label, {0.0f, 0.85f, 0.95f, 1.0f}
-                    );
+                    const std::string present_label = std::format("Present: {}", vk_src_tex->GetName());
+                    vk_cmd_list.BeginLabel(present_label, {0.0f, 0.85f, 0.95f, 1.0f});
                     vk_tracker.SetPassType(EPassType::Graphics);
                     // PRESENTATION_SOURCE is a producer-side terminal
                     // contract. The active graph exports GENERAL with
@@ -8215,9 +8239,7 @@ VulkanRuntimeSubmissionResult VkCommandQueue::PresentNow(
                     // accepted producer writes to this copy.
                     vk_tracker.EmitExplicitBarrier(
                         vk_src_tex,
-                        VulkanEnumTranslator::METoVKImageAspectFlags(
-                            vk_src_tex->GetAspectFlags()
-                        ),
+                        VulkanEnumTranslator::METoVKImageAspectFlags(vk_src_tex->GetAspectFlags()),
                         0,
                         1,
                         0,
@@ -8233,16 +8255,11 @@ VulkanRuntimeSubmissionResult VkCommandQueue::PresentNow(
                         VK_IMAGE_LAYOUT_GENERAL
                     );
                     vk_tracker.RecordState(
-                        swapchain_tex,
-                        vk_tracker.WriteTexture(
-                            swapchain_tex, ETextureState::TRANSFER
-                        )
+                        swapchain_tex, vk_tracker.WriteTexture(swapchain_tex, ETextureState::TRANSFER)
                     );
                     vk_tracker.ResolveBarriers();
                     vk_tracker.DispatchBarriers(vk_cmd_list);
-                    vk_cmd_list.InsertLabel(
-                        "Copy Present Image", GpuMarkerPalette::Transfer()
-                    );
+                    vk_cmd_list.InsertLabel("Copy Present Image", GpuMarkerPalette::Transfer());
                     vk_cmd_list.CopyTexture(
                         vk_src_tex,
                         swapchain_tex,
@@ -8267,37 +8284,27 @@ VulkanRuntimeSubmissionResult VkCommandQueue::PresentNow(
                     vk_tracker.Reset();
 
                     deferred_releases = TakeDeferredReleases();
-                    queue.Signal(
-                        timeline, _timeline, VK_PIPELINE_STAGE_2_COPY_BIT
-                    );
-                    queue.Wait(
-                        acquire.ready_semaphore,
-                        VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT
-                    );
-                    queue.Signal(
-                        sc->GetRenderFinishedFence(idx),
-                        VK_PIPELINE_STAGE_2_COPY_BIT
-                    );
+                    queue.Signal(timeline, _timeline, VK_PIPELINE_STAGE_2_COPY_BIT);
+                    queue.Wait(acquire.ready_semaphore, VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT);
+                    queue.Signal(sc->GetRenderFinishedFence(idx), VK_PIPELINE_STAGE_2_COPY_BIT);
                     const VulkanOperationResult submit_outcome =
                         queue.Submit(vk_allocator.GetCmdList(), context);
                     final_outcome = submit_outcome;
                     gpu_submitted = submit_outcome.WasSubmitted();
+                    AccumulatePresentReceiptOutcome(
+                        receipt_status, receipt_stage, submit_outcome, EPresentStage::Submit
+                    );
                     if (gpu_submitted) {
-                        presentor_state =
-                            EVulkanPresentorRetirementState::Submitted;
+                        presentor_state = EVulkanPresentorRetirementState::Submitted;
                         timeline->MarkSubmitted(_timeline);
 
                         const VulkanOperationResult present_outcome =
-                            sc->Present(
-                                queue.GetHandle(), idx, _timeline, _serial
-                            );
-                        present_accepted =
-                            present_outcome.result == VK_SUCCESS ||
-                            present_outcome.result == VK_SUBOPTIMAL_KHR;
-                        recreate_swapchain =
-                            recreate_swapchain ||
-                            present_outcome.status ==
-                                EVulkanOperationStatus::Recreate;
+                            sc->Present(queue.GetHandle(), idx, _timeline, _serial);
+                        present_accepted = present_outcome.result == VK_SUCCESS ||
+                                           present_outcome.result == VK_SUBOPTIMAL_KHR;
+                        AccumulatePresentReceiptOutcome(
+                            receipt_status, receipt_stage, present_outcome, EPresentStage::Present
+                        );
                         if (!present_outcome.Succeeded()) {
                             final_outcome = present_outcome;
                         }
@@ -8310,22 +8317,17 @@ VulkanRuntimeSubmissionResult VkCommandQueue::PresentNow(
     } catch (const std::exception& error) {
         queue.DiscardPendingSubmitState();
         vk_device.RecordRejectedPresent();
-        final_outcome = {
-            EVulkanOperationStatus::Rejected, VK_ERROR_UNKNOWN
-        };
+        final_outcome = {EVulkanOperationStatus::Rejected, VK_ERROR_UNKNOWN};
+        AccumulatePresentReceiptOutcome(receipt_status, receipt_stage, final_outcome, EPresentStage::Submit);
         try {
-            LOG_ERROR(
-                "[RHIExecutor][Vulkan] Present threw before retirement: {}",
-                error.what()
-            );
+            LOG_ERROR("[RHIExecutor][Vulkan] Present threw before retirement: {}", error.what());
         } catch (...) {
         }
     } catch (...) {
         queue.DiscardPendingSubmitState();
         vk_device.RecordRejectedPresent();
-        final_outcome = {
-            EVulkanOperationStatus::Rejected, VK_ERROR_UNKNOWN
-        };
+        final_outcome = {EVulkanOperationStatus::Rejected, VK_ERROR_UNKNOWN};
+        AccumulatePresentReceiptOutcome(receipt_status, receipt_stage, final_outcome, EPresentStage::Submit);
         try {
             LOG_ERROR("[RHIExecutor][Vulkan] Present threw before retirement");
         } catch (...) {
@@ -8344,12 +8346,13 @@ VulkanRuntimeSubmissionResult VkCommandQueue::PresentNow(
         _timeline
     );
 
-    ResolvePresentReceiptNoexcept(
-        _receipt, present_accepted, recreate_swapchain
-    );
+    if (receipt_status == EPresentStatus::Unresolved) {
+        AccumulatePresentReceiptOutcome(receipt_status, receipt_stage, final_outcome, EPresentStage::Submit);
+    }
+    ResolvePresentReceiptNoexcept(_receipt, present_accepted, receipt_status, receipt_stage);
 
     VulkanRuntimeSubmissionResult runtime_result{
-        .outcome = final_outcome,
+        .outcome               = final_outcome,
         .recoverable_rejection = recoverable_rejection,
     };
     if (gpu_submitted) {

--- a/source/runtime/render/rhi/vulkan/VulkanSubmissionExecutor.cpp
+++ b/source/runtime/render/rhi/vulkan/VulkanSubmissionExecutor.cpp
@@ -898,7 +898,7 @@ const char* TopologyErrorName(ERHISubmissionTopologyError _error) {
 
 void ResolveRejectedPresent(std::optional<RHIPresentRequest>& _present) {
     if (_present && _present->receipt) {
-        _present->receipt->Resolve(false);
+        _present->receipt->Resolve(false, EPresentStatus::Rejected, EPresentStage::Validation);
     }
 }
 

--- a/source/runtime/render/rhi/vulkan/VulkanSwapChain.cpp
+++ b/source/runtime/render/rhi/vulkan/VulkanSwapChain.cpp
@@ -81,6 +81,44 @@ VkCompositeAlphaFlagBitsKHR ChooseCompositeAlpha(const VkSurfaceCapabilitiesKHR&
     return VK_COMPOSITE_ALPHA_OPAQUE_BIT_KHR;
 }
 
+[[nodiscard]] bool IsDeviceWideTerminalSwapchainResult(VkResult result) noexcept {
+    return result == VK_ERROR_DEVICE_LOST || result == VK_ERROR_OUT_OF_HOST_MEMORY ||
+           result == VK_ERROR_OUT_OF_DEVICE_MEMORY;
+}
+
+[[nodiscard]] bool IsPresentationLocalSwapchainResult(VkResult result) noexcept {
+    // These failures invalidate or temporarily block presentation state, not
+    // the logical device. Keep recovery pending so a later frame can retry.
+    return result == VK_SUBOPTIMAL_KHR || result == VK_INCOMPLETE ||
+           result == VK_ERROR_OUT_OF_DATE_KHR || result == VK_ERROR_SURFACE_LOST_KHR ||
+           result == VK_ERROR_NATIVE_WINDOW_IN_USE_KHR ||
+           result == VK_ERROR_INCOMPATIBLE_DISPLAY_KHR ||
+           result == VK_ERROR_FULL_SCREEN_EXCLUSIVE_MODE_LOST_EXT ||
+           result == VK_ERROR_FORMAT_NOT_SUPPORTED;
+}
+
+[[nodiscard]] bool ShouldLatchSwapchainFailure(
+    bool                  force_surface_recreate,
+    EVulkanFaultOperation operation,
+    VkResult              result
+) noexcept {
+    if (IsPresentationLocalSwapchainResult(result)) {
+        return false;
+    }
+    if (!force_surface_recreate || IsDeviceWideTerminalSwapchainResult(result)) {
+        return true;
+    }
+    switch (operation) {
+        case EVulkanFaultOperation::SwapchainSurfaceCreate:
+        case EVulkanFaultOperation::SwapchainSurfaceQuery:
+        case EVulkanFaultOperation::SwapchainCreate:
+        case EVulkanFaultOperation::SwapchainGetImages:
+            return false;
+        default:
+            return true;
+    }
+}
+
 } // namespace
 
 VkSurfaceFormatKHR ChooseSwapSurfaceFormat(
@@ -211,29 +249,51 @@ bool VkSwapchain::Recreate(const SwapchainCreateInfo& _info) {
     //FIXME: this is not a good way to do it, and it may have issue in multi-threaded env
     //best do sync in a separate thread, and give sync op to user
     // vkQueueWaitIdle(device.GetPresentQueue());
-    return CreateOrRecreate(_info);
+    return CreateOrRecreate(_info, _info.force_surface_recreate);
 }
 bool VkSwapchain::CreateOrRecreate(const SwapchainCreateInfo& _info, bool _force_recreate) {
-    (void)_force_recreate;
     if (device.IsFaulted()) {
         return false;
     }
+    native_surface_recreate_pending_ =
+        native_surface_recreate_pending_ || _force_recreate;
+    const bool effective_force_surface_recreate =
+        native_surface_recreate_pending_;
     if (_info.size.x == 0 || _info.size.y == 0) {
         LOG_WARNING("Swapchain recreate skipped due to zero window size.");
         return false;
     }
 
-    const ESwapchainSurfaceTransition surface_transition =
+    const auto observe_setup_result = [this](VkResult result) {
+        if (result == VK_ERROR_SURFACE_LOST_KHR) {
+            native_surface_recreate_pending_ = true;
+        }
+    };
+
+    ESwapchainSurfaceTransition surface_transition =
         ClassifySwapchainSurfaceTransition(surface_info, surface != VK_NULL_HANDLE, _info.surface);
+    if (effective_force_surface_recreate &&
+        surface_transition == ESwapchainSurfaceTransition::Reuse) {
+        // Surface loss invalidates the native VkSurfaceKHR without changing
+        // the window-system identity. Force the destructive recovery path,
+        // which keeps oldSwapchain null for the replacement surface.
+        surface_transition = ESwapchainSurfaceTransition::Replace;
+    }
     if (surface_transition == ESwapchainSurfaceTransition::Invalid) {
         LOG_ERROR("Vulkan swapchain creation requires a valid window surface source.");
-        device.TryLatchFirstFault(
-            VulkanOperationContext{.operation = EVulkanFaultOperation::SwapchainSurfaceCreate},
-            VK_ERROR_INITIALIZATION_FAILED,
-            false,
-            false,
-            true
-        );
+        if (ShouldLatchSwapchainFailure(
+                effective_force_surface_recreate,
+                EVulkanFaultOperation::SwapchainSurfaceCreate,
+                VK_ERROR_INITIALIZATION_FAILED
+            )) {
+            device.TryLatchFirstFault(
+                VulkanOperationContext{.operation = EVulkanFaultOperation::SwapchainSurfaceCreate},
+                VK_ERROR_INITIALIZATION_FAILED,
+                false,
+                false,
+                true
+            );
+        }
         return false;
     }
 
@@ -242,9 +302,42 @@ bool VkSwapchain::CreateOrRecreate(const SwapchainCreateInfo& _info, bool _force
         return false;
     }
 
-    const VkSwapchainKHR committed_old_sc       = handle;
-    VkSurfaceKHR         candidate_surface      = surface;
-    const bool           candidate_owns_surface = surface_transition != ESwapchainSurfaceTransition::Reuse;
+    if (effective_force_surface_recreate) {
+        // A lost native surface is no longer a usable transactional fallback.
+        // Some window systems also reject a second surface for the same
+        // native window while the old one exists, so retire in Vulkan order
+        // before asking the platform to create its replacement.
+        for (auto* texture : swapchain_textures) {
+            MoerDelete(texture);
+        }
+        swapchain_textures.clear();
+        swapchain_views.clear();
+        for (VkSemaphore semaphore : render_finished_fences) {
+            if (semaphore != VK_NULL_HANDLE) {
+                vkDestroySemaphore(
+                    device.GetDevice(), semaphore, VK_NULL_HANDLE
+                );
+            }
+        }
+        render_finished_fences.clear();
+        if (handle != VK_NULL_HANDLE) {
+            vkDestroySwapchainKHR(
+                device.GetDevice(), handle, VK_NULL_HANDLE
+            );
+            handle = VK_NULL_HANDLE;
+        }
+        if (surface != VK_NULL_HANDLE) {
+            vkDestroySurfaceKHR(
+                device.GetInstance(), surface, VK_NULL_HANDLE
+            );
+            surface = VK_NULL_HANDLE;
+        }
+        surface_info = {};
+    }
+
+    const VkSwapchainKHR   committed_old_sc       = handle;
+    VkSurfaceKHR           candidate_surface      = surface;
+    const bool             candidate_owns_surface = surface_transition != ESwapchainSurfaceTransition::Reuse;
     ScopedSurfaceCandidate candidate_surface_guard(device.GetInstance());
     if (candidate_owns_surface) {
         candidate_surface                              = VK_NULL_HANDLE;
@@ -257,18 +350,25 @@ bool VkSwapchain::CreateOrRecreate(const SwapchainCreateInfo& _info, bool _force
             if (surface_result.native_error_code != 0) {
                 native_result = static_cast<VkResult>(static_cast<int32_t>(surface_result.native_error_code));
             }
+            observe_setup_result(native_result);
             LOG_ERROR(
                 "Window surface creation failed: status={}, native_result={}.",
                 static_cast<uint32_t>(surface_result.status),
                 static_cast<int32_t>(native_result)
             );
-            device.TryLatchFirstFault(
-                VulkanOperationContext{.operation = EVulkanFaultOperation::SwapchainSurfaceCreate},
-                native_result,
-                false,
-                false,
-                true
-            );
+            if (ShouldLatchSwapchainFailure(
+                    effective_force_surface_recreate,
+                    EVulkanFaultOperation::SwapchainSurfaceCreate,
+                    native_result
+                )) {
+                device.TryLatchFirstFault(
+                    VulkanOperationContext{.operation = EVulkanFaultOperation::SwapchainSurfaceCreate},
+                    native_result,
+                    false,
+                    false,
+                    true
+                );
+            }
             return false;
         }
     }
@@ -286,23 +386,29 @@ bool VkSwapchain::CreateOrRecreate(const SwapchainCreateInfo& _info, bool _force
         return false;
     }
 
-    const VkUtil::SwapChainSupportQueryResult support_query = VkUtil::QuerySwapChainSupport(
-        device.GetGpu(), candidate_surface, queue_families.present.value()
-    );
+    const VkUtil::SwapChainSupportQueryResult support_query =
+        VkUtil::QuerySwapChainSupport(device.GetGpu(), candidate_surface, queue_families.present.value());
     if (!support_query.Succeeded()) {
+        observe_setup_result(support_query.native_result);
         LOG_ERROR(
             "Swapchain surface query failed: status={}, native_result={}, present_queue_family={}.",
             static_cast<uint32_t>(support_query.status),
             static_cast<int32_t>(support_query.native_result),
             queue_families.present.value()
         );
-        device.TryLatchFirstFault(
-            VulkanOperationContext{.operation = EVulkanFaultOperation::SwapchainSurfaceQuery},
-            support_query.native_result,
-            false,
-            false,
-            true
-        );
+        if (ShouldLatchSwapchainFailure(
+                effective_force_surface_recreate,
+                EVulkanFaultOperation::SwapchainSurfaceQuery,
+                support_query.native_result
+            )) {
+            device.TryLatchFirstFault(
+                VulkanOperationContext{.operation = EVulkanFaultOperation::SwapchainSurfaceQuery},
+                support_query.native_result,
+                false,
+                false,
+                true
+            );
+        }
         return false;
     }
 
@@ -314,9 +420,9 @@ bool VkSwapchain::CreateOrRecreate(const SwapchainCreateInfo& _info, bool _force
         LOG_WARNING("Swapchain recreate skipped due to zero swapchain extent.");
         return false;
     }
-    VkPresentModeKHR   present_mode = ChooseSwapPresentMode(details.present_modes, false);
-    const EPixelFormat new_format   = (EPixelFormat)new_fmt.format;
-    const uint32_t queue_family_indices[] = {
+    VkPresentModeKHR   present_mode           = ChooseSwapPresentMode(details.present_modes, false);
+    const EPixelFormat new_format             = (EPixelFormat)new_fmt.format;
+    const uint32_t     queue_family_indices[] = {
         queue_families.graphics.value(),
         queue_families.present.value(),
     };
@@ -328,18 +434,17 @@ bool VkSwapchain::CreateOrRecreate(const SwapchainCreateInfo& _info, bool _force
     const VkSwapchainKHR old_sc_for_create =
         surface_transition == ESwapchainSurfaceTransition::Reuse ? committed_old_sc : VK_NULL_HANDLE;
     VkSwapchainCreateInfoKHR create_info{
-        .sType                 = VK_STRUCTURE_TYPE_SWAPCHAIN_CREATE_INFO_KHR,
-        .pNext                 = nullptr,
-        .flags                 = 0,
-        .surface               = candidate_surface,
-        .minImageCount         = image_count,
-        .imageFormat           = new_fmt.format,
-        .imageColorSpace       = new_fmt.colorSpace,
-        .imageExtent           = {new_size.x, new_size.y},
-        .imageArrayLayers      = 1,
-        .imageUsage            = VK_IMAGE_USAGE_TRANSFER_DST_BIT,
-        .imageSharingMode      = use_concurrent_sharing ? VK_SHARING_MODE_CONCURRENT :
-                                                         VK_SHARING_MODE_EXCLUSIVE,
+        .sType            = VK_STRUCTURE_TYPE_SWAPCHAIN_CREATE_INFO_KHR,
+        .pNext            = nullptr,
+        .flags            = 0,
+        .surface          = candidate_surface,
+        .minImageCount    = image_count,
+        .imageFormat      = new_fmt.format,
+        .imageColorSpace  = new_fmt.colorSpace,
+        .imageExtent      = {new_size.x, new_size.y},
+        .imageArrayLayers = 1,
+        .imageUsage       = VK_IMAGE_USAGE_TRANSFER_DST_BIT,
+        .imageSharingMode = use_concurrent_sharing ? VK_SHARING_MODE_CONCURRENT : VK_SHARING_MODE_EXCLUSIVE,
         .queueFamilyIndexCount = use_concurrent_sharing ? 2u : 0u,
         .pQueueFamilyIndices   = use_concurrent_sharing ? queue_family_indices : nullptr,
         .preTransform          = details.capabilities.currentTransform,
@@ -396,10 +501,11 @@ bool VkSwapchain::CreateOrRecreate(const SwapchainCreateInfo& _info, bool _force
         }
         render_finished_fences.clear();
         vkDestroySwapchainKHR(device.GetDevice(), committed_old_sc, VK_NULL_HANDLE);
-        handle = VK_NULL_HANDLE;
+        handle                = VK_NULL_HANDLE;
         old_resources_retired = true;
     };
     auto check_device_result = [&](VkResult _result, EVulkanFaultOperation _operation) {
+        observe_setup_result(_result);
         if (_result == VK_SUCCESS && !device.IsFaulted()) {
             return true;
         }
@@ -407,9 +513,15 @@ bool VkSwapchain::CreateOrRecreate(const SwapchainCreateInfo& _info, bool _force
             fault_admission.unlock();
         }
         if (_result != VK_SUCCESS) {
-            device.TryLatchFirstFault(
-                VulkanOperationContext{.operation = _operation}, _result, false, false, true
-            );
+            if (ShouldLatchSwapchainFailure(
+                    effective_force_surface_recreate,
+                    _operation,
+                    _result
+                )) {
+                device.TryLatchFirstFault(
+                    VulkanOperationContext{.operation = _operation}, _result, false, false, true
+                );
+            }
         }
         return false;
     };
@@ -545,9 +657,9 @@ bool VkSwapchain::CreateOrRecreate(const SwapchainCreateInfo& _info, bool _force
         return false;
     }
 
-    // A replacement surface uses oldSwapchain = VK_NULL_HANDLE, so the old
-    // presentation bundle remains valid until every candidate resource is
-    // ready. Commit retires the old bundle and surface only at this point.
+    // Ordinary identity replacement remains transactional. Forced recovery
+    // has already retired its unusable native bundle, so this is a no-op for
+    // that path.
     retire_old_resources();
 
     if (recreate_fences) {
@@ -577,7 +689,11 @@ bool VkSwapchain::CreateOrRecreate(const SwapchainCreateInfo& _info, bool _force
         in_flight_fences = std::move(new_in_flight_fences);
     }
     image_idx = 0;
-    return IsPresentationReady();
+    const bool presentation_ready = IsPresentationReady();
+    if (presentation_ready) {
+        native_surface_recreate_pending_ = false;
+    }
+    return presentation_ready;
 }
 VkSwapchain::~VkSwapchain() {
     Sync();
@@ -687,9 +803,7 @@ VulkanOperationResult VkSwapchain::Present(
             .work_serial = _work_serial,
         }
     );
-    if (use_present_fence &&
-        (outcome.status == EVulkanOperationStatus::Success ||
-         outcome.status == EVulkanOperationStatus::Recreate)) {
+    if (use_present_fence && (outcome.result == VK_SUCCESS || outcome.result == VK_SUBOPTIMAL_KHR)) {
         // 仅在使用 present fence 的情况下异步等待 in_flight_fences
         EnqueuePresent(image_idx);
     }

--- a/source/runtime/render/rhi/vulkan/VulkanSwapChain.h
+++ b/source/runtime/render/rhi/vulkan/VulkanSwapChain.h
@@ -97,7 +97,8 @@ private:
 
 private:
     Array<std::jthread> present_threads;
-    std::atomic<uint>   cur_present_cnt = 0;
+    std::atomic<uint>   cur_present_cnt                  = 0;
+    bool                native_surface_recreate_pending_ = false;
 };
 } // namespace Moer::Render
 

--- a/source/test/PresentationSurfaceContractTest.cpp
+++ b/source/test/PresentationSurfaceContractTest.cpp
@@ -159,6 +159,126 @@ int main() {
     Require(retry_state.Plan(surface_a, delayed_stable, true) == EPresentationSurfacePlan::Invalid);
     Require(retry_state.Plan(surface_a, failed_resize, true) == EPresentationSurfacePlan::Refresh);
 
+    {
+        PresentationSurfaceState   feedback_state;
+        WindowFrameSnapshotTracker feedback_tracker;
+        const WindowFrameSnapshot  feedback_frame =
+            feedback_tracker.Advance(identity_a, MakeMetrics({800, 600}, {800, 600}));
+        Require(feedback_state.Plan(surface_a, feedback_frame, false) == EPresentationSurfacePlan::Refresh);
+        Require(feedback_state.Commit(feedback_frame, {800, 600}));
+        const uint64_t initial_epoch = feedback_state.GetCommittedEpoch();
+        Require(initial_epoch != 0);
+
+        PresentReceiptResult success{
+            .resolved = true,
+            .submitted = true,
+            .status = EPresentStatus::Success,
+            .stage = EPresentStage::Present,
+            .context = {
+                .presentation_epoch = initial_epoch,
+                .drawable_generation = feedback_frame.drawable_generation,
+                .request_serial = 1,
+            },
+        };
+        Require(!feedback_state.ApplyPresentFeedback(success));
+        Require(!feedback_state.HasRefreshPending());
+
+        PresentReceiptResult stale_generation = success;
+        stale_generation.status = EPresentStatus::OutOfDate;
+        stale_generation.context.drawable_generation++;
+        Require(!feedback_state.ApplyPresentFeedback(stale_generation));
+        Require(!feedback_state.HasRefreshPending());
+
+        PresentReceiptResult current_out_of_date = success;
+        current_out_of_date.submitted = false;
+        current_out_of_date.status = EPresentStatus::OutOfDate;
+        current_out_of_date.context.request_serial = 2;
+        Require(feedback_state.ApplyPresentFeedback(current_out_of_date));
+        Require(feedback_state.HasRefreshPending());
+        Require(
+            feedback_state.Plan(surface_a, feedback_frame, true) ==
+            EPresentationSurfacePlan::Refresh
+        );
+        Require(feedback_state.Commit(feedback_frame, {800, 600}));
+        const uint64_t replacement_epoch = feedback_state.GetCommittedEpoch();
+        Require(replacement_epoch > initial_epoch);
+        Require(!feedback_state.ApplyPresentFeedback(current_out_of_date));
+        Require(!feedback_state.HasRefreshPending());
+
+        PresentReceiptResult current_surface_lost = current_out_of_date;
+        current_surface_lost.status = EPresentStatus::SurfaceLost;
+        current_surface_lost.context.presentation_epoch = replacement_epoch;
+        current_surface_lost.context.request_serial = 3;
+        Require(feedback_state.ApplyPresentFeedback(current_surface_lost));
+        Require(feedback_state.HasRefreshPending());
+    }
+
+    {
+        const PresentReceiptContext context{
+            .presentation_epoch = 7,
+            .drawable_generation = 11,
+            .request_serial = 1,
+        };
+        const PresentFeedbackMailboxRef mailbox = std::make_shared<PresentFeedbackMailbox>();
+        const PresentReceiptRef success_receipt = std::make_shared<PresentReceipt>(context, mailbox);
+        Require(!success_receipt->TryGetResult().has_value());
+        success_receipt->Resolve(true, EPresentStatus::Success, EPresentStage::Present);
+        const auto success_result = success_receipt->TryGetResult();
+        Require(success_result.has_value());
+        Require(success_result->submitted);
+        Require(success_result->status == EPresentStatus::Success);
+        Require(success_result->context.request_serial == 1);
+        Require(!mailbox->HasPendingRecovery());
+        success_receipt->Resolve(false, EPresentStatus::SurfaceLost, EPresentStage::Present);
+        Require(success_receipt->ResolutionAttemptCount() == 2);
+        Require(success_receipt->TryGetResult()->status == EPresentStatus::Success);
+        Require(!mailbox->HasPendingRecovery());
+
+        PresentReceiptResult out_of_date{
+            .resolved = true,
+            .submitted = false,
+            .status = EPresentStatus::OutOfDate,
+            .stage = EPresentStage::Acquire,
+            .context = {
+                .presentation_epoch = 7,
+                .drawable_generation = 11,
+                .request_serial = 2,
+            },
+        };
+        mailbox->Publish(out_of_date);
+        Require(mailbox->HasPendingRecovery());
+
+        PresentReceiptResult surface_lost = out_of_date;
+        surface_lost.status = EPresentStatus::SurfaceLost;
+        surface_lost.stage = EPresentStage::Present;
+        surface_lost.context.request_serial = 3;
+        mailbox->Publish(surface_lost);
+
+        PresentReceiptResult later_suboptimal = out_of_date;
+        later_suboptimal.submitted = true;
+        later_suboptimal.status = EPresentStatus::Suboptimal;
+        later_suboptimal.context.request_serial = 4;
+        mailbox->Publish(later_suboptimal);
+
+        const auto coalesced = mailbox->ConsumeLatestRecovery();
+        Require(coalesced.has_value());
+        Require(coalesced->status == EPresentStatus::SurfaceLost);
+        Require(coalesced->context.request_serial == 3);
+        Require(!mailbox->HasPendingRecovery());
+        Require(!mailbox->ConsumeLatestRecovery().has_value());
+
+        PresentReceiptResult old_epoch_surface_lost = surface_lost;
+        mailbox->Publish(old_epoch_surface_lost);
+        PresentReceiptResult new_epoch_suboptimal = later_suboptimal;
+        new_epoch_suboptimal.context.presentation_epoch = 8;
+        new_epoch_suboptimal.context.request_serial = 1;
+        mailbox->Publish(new_epoch_suboptimal);
+        const auto new_epoch_recovery = mailbox->ConsumeLatestRecovery();
+        Require(new_epoch_recovery.has_value());
+        Require(new_epoch_recovery->status == EPresentStatus::Suboptimal);
+        Require(new_epoch_recovery->context.presentation_epoch == 8);
+    }
+
     state.Reset();
     Require(state.HasRefreshPending());
     Require(!state.GetCommittedSnapshot().IsValid());

--- a/source/test/RHIParallelRecordVulkanTest.cpp
+++ b/source/test/RHIParallelRecordVulkanTest.cpp
@@ -10750,7 +10750,9 @@ void RunPresentPipelineBoundary() {
             receipt->WaitForSubmission(5s);
         if (!receipt_result.resolved ||
             receipt_result.submitted ||
-            !receipt_result.recreate_swapchain) {
+            !receipt_result.recreate_swapchain ||
+            receipt_result.status != EPresentStatus::OutOfDate ||
+            receipt_result.stage != EPresentStage::Present) {
             throw std::runtime_error(
                 "scripted Recreate Present resolved the wrong receipt state"
             );
@@ -10938,7 +10940,9 @@ void RunPresentPipelineBoundary() {
             present_only_receipt->WaitForSubmission(5s);
         if (!present_only_result.resolved ||
             present_only_result.submitted ||
-            !present_only_result.recreate_swapchain) {
+            !present_only_result.recreate_swapchain ||
+            present_only_result.status != EPresentStatus::OutOfDate ||
+            present_only_result.stage != EPresentStage::Present) {
             throw std::runtime_error(
                 "Present-only batch resolved the wrong receipt state"
             );
@@ -10976,12 +10980,126 @@ void RunPresentPipelineBoundary() {
             );
         }
 
+        const size_t surface_lost_boundary_index =
+            boundary_capture.Count();
+        scripted_capture.result = VulkanScriptedPresentResult{
+            .outcome = {
+                EVulkanOperationStatus::Recreate,
+                VK_ERROR_SURFACE_LOST_KHR,
+            },
+        };
+        PresentReceiptRef surface_lost_receipt =
+            MakeShared<PresentReceipt>();
+        RHIExecutor::Get().Present(
+            RHIPresentRequest(
+                scripted_swapchain,
+                present_source->GetView(),
+                surface_lost_receipt
+            ),
+            true
+        );
+        const PresentReceiptResult surface_lost_result =
+            surface_lost_receipt->WaitForSubmission(5s);
+        if (!surface_lost_result.resolved ||
+            surface_lost_result.submitted ||
+            !surface_lost_result.recreate_swapchain ||
+            surface_lost_result.status !=
+                EPresentStatus::SurfaceLost ||
+            surface_lost_result.stage != EPresentStage::Present) {
+            throw std::runtime_error(
+                "scripted SurfaceLost Present lost its typed receipt"
+            );
+        }
+        RHIExecutor::Get().Sync(ERHISyncDepth::Present);
+        if (surface_lost_receipt->ResolutionAttemptCount() != 1 ||
+            scripted_capture.count.load(std::memory_order_acquire) != 3 ||
+            boundary_capture.Count() !=
+                surface_lost_boundary_index + 2 ||
+            native_capture.Count() != expected_native_count) {
+            throw std::runtime_error(
+                "scripted SurfaceLost Present was replayed or submitted "
+                "native work"
+            );
+        }
+        expect_pair(
+            surface_lost_boundary_index,
+            present_batch_sequence + 3,
+            1,
+            EVulkanSubmissionBoundaryKind::Present,
+            0
+        );
+        const VulkanSubmissionBoundaryEvent&
+            surface_lost_terminal =
+                boundary_capture.Event(surface_lost_boundary_index + 1);
+        if (surface_lost_terminal.outcome.status !=
+                EVulkanOperationStatus::Recreate ||
+            surface_lost_terminal.outcome.result !=
+                VK_ERROR_SURFACE_LOST_KHR) {
+            throw std::runtime_error(
+                "SurfaceLost terminal diagnostics lost the native result"
+            );
+        }
+
+        // A faulted device would reject before reaching the scripted
+        // callback. A typed Retry on the following request therefore proves
+        // that SurfaceLost did not poison VulkanDevice fault state.
+        scripted_capture.result = VulkanScriptedPresentResult{
+            .outcome = {
+                EVulkanOperationStatus::Retry,
+                VK_NOT_READY,
+            },
+        };
+        PresentReceiptRef post_surface_lost_receipt =
+            MakeShared<PresentReceipt>();
+        RHIExecutor::Get().Present(
+            RHIPresentRequest(
+                scripted_swapchain,
+                present_source->GetView(),
+                post_surface_lost_receipt
+            ),
+            true
+        );
+        const PresentReceiptResult post_surface_lost_result =
+            post_surface_lost_receipt->WaitForSubmission(5s);
+        if (!post_surface_lost_result.resolved ||
+            post_surface_lost_result.submitted ||
+            post_surface_lost_result.recreate_swapchain ||
+            post_surface_lost_result.status !=
+                EPresentStatus::Retry ||
+            post_surface_lost_result.stage != EPresentStage::Present) {
+            throw std::runtime_error(
+                "SurfaceLost polluted VulkanDevice fault state"
+            );
+        }
+        RHIExecutor::Get().Sync(ERHISyncDepth::Present);
+        if (post_surface_lost_receipt->ResolutionAttemptCount() != 1 ||
+            scripted_capture.count.load(std::memory_order_acquire) != 4 ||
+            boundary_capture.Count() !=
+                surface_lost_boundary_index + 4 ||
+            native_capture.Count() != expected_native_count ||
+            scripted_capture.wrong_owner.load(
+                std::memory_order_acquire
+            )) {
+            throw std::runtime_error(
+                "post-SurfaceLost Retry did not remain on the Submission "
+                "owner exactly once"
+            );
+        }
+        expect_pair(
+            surface_lost_boundary_index + 2,
+            present_batch_sequence + 4,
+            1,
+            EVulkanSubmissionBoundaryKind::Present,
+            0
+        );
+
         LOG_INFO(
             "[TESTCASE][PASS] name=PresentPipelineBoundary "
             "outcome=Recreate order=Prefix,Bridge?,Present,Later "
             "owner=Submission receipt_attempts=1 submitted=false "
             "recreate=true completion=drained later_batch=success "
-            "present_only=verified bridge={} graphics_native={} "
+            "present_only=verified surface_lost=typed "
+            "device_healthy=verified bridge={} graphics_native={} "
             "prefix_native={} readback=verified replay=0",
             bridge_required ? "required" : "elided",
             topology.graphics.native_queue_id,


### PR DESCRIPTION
## Summary

- add backend-neutral typed Present status/stage plus epoch, drawable-generation, and request-serial context
- publish refresh-requiring results through a bounded per-surface mailbox and reject stale feedback on the Render owner
- keep every main and detached viewport Present observable without adding per-frame Game Thread waits
- classify Vulkan `SUBOPTIMAL`, `OUT_OF_DATE`, and `SURFACE_LOST` precisely; keep WSI-local failures from poisoning the device
- recover `SURFACE_LOST` by quiescing and rebuilding the native surface/swapchain in Vulkan lifetime order
- prevent failed Present calls from entering unsignaled present-fence retirement
- extend PresentationSurface and Vulkan boundary contracts, including exactly-once and post-SurfaceLost device-health checks

## Relation to `dev_parallel_rhi`

This preserves the branch's Submission/Completion ownership direction, but implements the missing continuous WSI feedback loop on top of current `main` (`PresentReceipt`, `PresentationSurface`, and the newer executor topology). The old branch does not contain a directly portable typed recovery implementation.

## Validation

- Debug full build
- Debug CTest: 37/37
- Release full build
- Release CTest: 37/37
- `TestPresentationSurface`
- `TestRHIParallelRecordVulkan --present-boundary` (`surface_lost=typed device_healthy=verified`)
- independent diff audit: P0=0, P1=0
- Raytracing GUI smoke: first Present, maximize resize, minimize/restore, detached viewport create/close/recreate/retire, clean Render/RHI/Vulkan shutdown

## Known test gap

A deterministic real GLFW/Win32 injection of `VK_ERROR_SURFACE_LOST_KHR` is not currently available. Scripted tests cover typed feedback, exactly-once resolution, recovery intent, device health, and fence-retirement behavior; native destructive replacement and sticky retry remain a platform fault-injection follow-up.