### PR TITLE
Phase 22D.3: track presentation completion and targeted drains

### DIFF
--- a/source/runtime/render/renderer/common/PresentationSurface.cpp
+++ b/source/runtime/render/renderer/common/PresentationSurface.cpp
@@ -4,6 +4,7 @@
 #include "rhi/RHIExecutor.h"
 
 #include <cassert>
+#include <exception>
 
 namespace Moer::Render {
 
@@ -173,7 +174,22 @@ EPresentationSurfaceEnsureResult PresentationSurface::EnsureCurrent(
     }
 
     state_.RequestRefresh();
-    Quiesce();
+    try {
+        Quiesce();
+    } catch (const std::exception& error) {
+        LOG_ERROR(
+            "[Presentation] targeted drain failed before recreate: {}",
+            error.what()
+        );
+        state_.Reject();
+        return EPresentationSurfaceEnsureResult::RetryPending;
+    } catch (...) {
+        LOG_ERROR(
+            "[Presentation] targeted drain failed before recreate"
+        );
+        state_.Reject();
+        return EPresentationSurfaceEnsureResult::RetryPending;
+    }
 
     const SwapchainCreateInfo create_info{
         .surface          = surface,
@@ -264,9 +280,21 @@ void PresentationSurface::Quiesce() {
     if (!swapchain_ && !frame_buffer_) {
         return;
     }
-    RHIExecutor::Get().Sync(ERHISyncDepth::Present);
     if (swapchain_) {
-        swapchain_->Sync();
+        const PresentationSurfaceSnapshot& committed =
+            state_.GetCommittedSnapshot();
+        RHIExecutor::Get().DrainPresentation(
+            RHIPresentationDrainTarget{
+                swapchain_,
+                state_.GetCommittedEpoch(),
+                committed.drawable_generation,
+            }
+        );
+    } else {
+        // Defensive partial-construction fallback. A committed presentation
+        // surface always owns a swapchain; only a failed setup path can retain
+        // a framebuffer without one.
+        RHIExecutor::Get().Sync(ERHISyncDepth::RHI);
     }
 }
 

--- a/source/runtime/render/renderer/common/PresentationSurface.cpp
+++ b/source/runtime/render/renderer/common/PresentationSurface.cpp
@@ -132,7 +132,7 @@ PresentationSurface::PresentationSurface(RenderDevice& device, PresentationSurfa
     AssertRenderOwner();
 }
 
-PresentationSurface::~PresentationSurface() {
+PresentationSurface::~PresentationSurface() noexcept {
     // Explicit Release() is the normal shutdown path; keep RAII cleanup as an
     // exception-safe fallback for partially constructed renderer owners.
     if (swapchain_ || frame_buffer_) {
@@ -298,10 +298,42 @@ void PresentationSurface::Quiesce() {
     }
 }
 
-void PresentationSurface::Release() {
+void PresentationSurface::Release() noexcept {
     AssertRenderOwner();
+    const auto fallback_to_device_idle =
+        [this](const char* _reason) noexcept {
+            // Recreate must reject an unsafe transition, but teardown cannot
+            // let a cancelled/faulted executor escape an owner destructor.
+            // Device idle is the final lifetime-safe fallback because it
+            // serializes directly with every native queue operation.
+            try {
+                LOG_ERROR(
+                    "[Presentation] targeted drain failed during release; "
+                    "falling back to device idle: {}",
+                    _reason
+                );
+            } catch (...) {
+            }
+            try {
+                device_.WaitIdle();
+            } catch (...) {
+                try {
+                    LOG_ERROR(
+                        "[Presentation] device-idle fallback failed during release"
+                    );
+                } catch (...) {
+                }
+            }
+        };
+
     if (swapchain_ || frame_buffer_) {
-        Quiesce();
+        try {
+            Quiesce();
+        } catch (const std::exception& error) {
+            fallback_to_device_idle(error.what());
+        } catch (...) {
+            fallback_to_device_idle("unknown exception");
+        }
     }
     swapchain_    = nullptr;
     frame_buffer_ = nullptr;

--- a/source/runtime/render/renderer/common/PresentationSurface.h
+++ b/source/runtime/render/renderer/common/PresentationSurface.h
@@ -118,7 +118,7 @@ enum class EPresentationSurfaceEnsureResult : uint8_t {
 class RENDER_API PresentationSurface final {
 public:
     PresentationSurface(RenderDevice& device, PresentationSurfaceDesc desc);
-    ~PresentationSurface();
+    ~PresentationSurface() noexcept;
 
     PresentationSurface(const PresentationSurface&)            = delete;
     PresentationSurface& operator=(const PresentationSurface&) = delete;
@@ -138,7 +138,7 @@ public:
     );
 
     void Quiesce();
-    void Release();
+    void Release() noexcept;
 
     [[nodiscard]] bool IsCurrent(const WindowFrameSnapshot& window_frame) const noexcept;
     [[nodiscard]] bool IsPresentable() const noexcept;

--- a/source/runtime/render/rhi/RHICommand.h
+++ b/source/runtime/render/rhi/RHICommand.h
@@ -2403,6 +2403,10 @@ public:
         return resolution_attempts;
     }
 
+    [[nodiscard]] PresentReceiptContext GetContext() const noexcept {
+        return context;
+    }
+
 private:
     mutable std::mutex        mutex;
     std::condition_variable   cv;

--- a/source/runtime/render/rhi/RHIExecutor.cpp
+++ b/source/runtime/render/rhi/RHIExecutor.cpp
@@ -1028,22 +1028,30 @@ struct RecordingSubmissionPayload {
 
 class HandoffSyncCompletion final {
 public:
-    void Signal() noexcept {
+    void Signal(std::exception_ptr _failure = {}) noexcept {
         {
             std::lock_guard lock(mutex);
+            failure  = std::move(_failure);
             complete = true;
         }
         cv.notify_all();
     }
 
-    void Wait() noexcept {
+    void Wait() {
+        std::exception_ptr wait_failure{};
         std::unique_lock lock(mutex);
         cv.wait(lock, [this] { return complete; });
+        wait_failure = failure;
+        lock.unlock();
+        if (wait_failure) {
+            std::rethrow_exception(wait_failure);
+        }
     }
 
 private:
     std::mutex              mutex;
     std::condition_variable cv;
+    std::exception_ptr      failure{};
     bool                    complete{false};
 };
 
@@ -1210,6 +1218,17 @@ public:
             RenderDevice::Get().GetCopyQueue().Sync(copy_timeline);
         }
         return MakeCompletedBackendEvent();
+    }
+
+    GraphEventRef DrainPresentation(
+        RHIPresentationDrainTarget _target
+    ) override {
+        // The legacy backend has no independent WSI completion lane. Preserve
+        // correctness by degrading the scoped lifecycle boundary to its
+        // existing graphics Present sync. Vulkan overrides this with a
+        // generation-aware per-surface frontier.
+        (void)_target;
+        return Sync(ERHISyncDepth::Present);
     }
 
     void Flush(ERHIFlushDepth) override {
@@ -2269,10 +2288,72 @@ void RHIExecutor::Sync(ERHISyncDepth _depth) {
     completion->Wait();
 }
 
+void RHIExecutor::DrainPresentation(
+    RHIPresentationDrainTarget _target
+) {
+    if (RejectOwnedThreadBlockingCall("DrainPresentation")) {
+        throw std::logic_error(
+            "Presentation drain cannot block on an RHI owner thread"
+        );
+    }
+    if (!_target.IsValid()) {
+        LOG_ERROR(
+            "[RHIExecutor] rejected an invalid Presentation drain target"
+        );
+        throw std::invalid_argument(
+            "invalid Presentation drain target"
+        );
+    }
+
+    auto completion = std::make_shared<HandoffSyncCompletion>();
+    recording_handoff.RouteReady(RHIExecutorRecordingHandoffWork{
+        .prerequisites = {},
+        .resolve =
+            [this, target = std::move(_target), completion](
+                ERHIRecordingHandoffResult _result
+            ) mutable {
+                try {
+                    if (_result !=
+                        ERHIRecordingHandoffResult::Consume) {
+                        throw std::runtime_error(
+                            "Presentation drain was cancelled before backend publication"
+                        );
+                    }
+                    DrainPresentationReady(std::move(target));
+                    completion->Signal();
+                } catch (...) {
+                    completion->Signal(std::current_exception());
+                }
+            },
+    });
+    completion->Wait();
+}
+
 void RHIExecutor::SyncReady(ERHISyncDepth _depth) {
+    SyncOrDrainReady(_depth, std::nullopt);
+}
+
+void RHIExecutor::DrainPresentationReady(
+    RHIPresentationDrainTarget _target
+) {
+    SyncOrDrainReady(
+        ERHISyncDepth::Present,
+        std::optional<RHIPresentationDrainTarget>(std::move(_target))
+    );
+}
+
+void RHIExecutor::SyncOrDrainReady(
+    ERHISyncDepth _depth,
+    std::optional<RHIPresentationDrainTarget> _presentation_target
+) {
     {
         std::lock_guard lock(submit_mutex);
         if (lifecycle_state != ELifecycleState::Running) {
+            if (_presentation_target) {
+                throw std::runtime_error(
+                    "Presentation drain rejected while RHIExecutor is not running"
+                );
+            }
             return;
         }
     }
@@ -2340,25 +2421,48 @@ void RHIExecutor::SyncReady(ERHISyncDepth _depth) {
     }
 
     if (backend_creation_failure) {
-        ReportBackendCreationFailure("Sync", backend_creation_failure);
+        ReportBackendCreationFailure(
+            _presentation_target ? "DrainPresentation" : "Sync",
+            backend_creation_failure
+        );
         FinalizeRejectedBackendBatch(
             std::move(failed_batch), "backend creation failed while synchronizing"
         );
+        if (_presentation_target) {
+            std::rethrow_exception(backend_creation_failure);
+        }
         return;
     }
     if (backend_publication_failure) {
         ReportBackendPublicationFailure(
-            "Sync",
+            _presentation_target ? "DrainPresentation" : "Sync",
             backend_publication_failure
         );
         FinalizeRejectedBackendBatch(
             std::move(failed_batch),
             "backend publication failed while synchronizing"
         );
+        if (_presentation_target) {
+            std::rethrow_exception(backend_publication_failure);
+        }
         return;
     }
 
-    GraphEventRef completion = backend ? backend->Sync(_depth) : GraphEventRef{};
+    GraphEventRef completion{};
+    if (backend) {
+        completion = _presentation_target ?
+                         backend->DrainPresentation(
+                             std::move(*_presentation_target)
+                         ) :
+                         backend->Sync(_depth);
+    } else if (
+        _presentation_target &&
+        _presentation_target->completion_state->HasOutstanding()
+    ) {
+        throw std::runtime_error(
+            "Presentation drain has outstanding WSI work but no published backend"
+        );
+    }
     if (completion) {
         completion->Wait(EThread::UNKNOWN_THREAD);
     }

--- a/source/runtime/render/rhi/RHIExecutor.h
+++ b/source/runtime/render/rhi/RHIExecutor.h
@@ -136,6 +136,7 @@ public:
     // Blocking lifecycle boundaries must not be called recursively from an
     // RHI completion callback whose completion they are waiting for.
     void Sync(ERHISyncDepth _depth = ERHISyncDepth::RHI);
+    void DrainPresentation(RHIPresentationDrainTarget _target);
     static void ShutDown();
 
 private:
@@ -154,6 +155,11 @@ private:
     );
     void FlushReady(ERHIFlushDepth _depth);
     void SyncReady(ERHISyncDepth _depth);
+    void DrainPresentationReady(RHIPresentationDrainTarget _target);
+    void SyncOrDrainReady(
+        ERHISyncDepth _depth,
+        std::optional<RHIPresentationDrainTarget> _presentation_target
+    );
 
     std::mutex                              submit_mutex;
     std::condition_variable                 lifecycle_cv;

--- a/source/runtime/render/rhi/RHIExecutorBackend.h
+++ b/source/runtime/render/rhi/RHIExecutorBackend.h
@@ -74,6 +74,43 @@ struct RHIPresentRequest {
         receipt(std::move(_receipt)) {}
 };
 
+// Strong, generation-aware lifecycle target for one PresentationSurface.
+// The Render owner publishes this control request after all older Present
+// packets. The backend freezes the matching completion frontier only when the
+// sole Submission owner consumes it, so later frames and unrelated surfaces
+// cannot extend the drain.
+struct RHIPresentationDrainTarget {
+    SwapchainRef                   swapchain{};
+    PresentationCompletionStateRef completion_state{};
+    uint64                         state_instance_id{0};
+    uint64                         presentation_epoch{0};
+    uint64                         drawable_generation{0};
+
+    RHIPresentationDrainTarget() = default;
+
+    RHIPresentationDrainTarget(
+        SwapchainRef _swapchain,
+        uint64       _presentation_epoch,
+        uint64       _drawable_generation
+    ) :
+        swapchain(std::move(_swapchain)),
+        completion_state(
+            swapchain ? swapchain->GetPresentationCompletionState() :
+                        PresentationCompletionStateRef{}
+        ),
+        state_instance_id(
+            completion_state ? completion_state->GetInstanceId() : 0
+        ),
+        presentation_epoch(_presentation_epoch),
+        drawable_generation(_drawable_generation) {}
+
+    [[nodiscard]] bool IsValid() const noexcept {
+        return swapchain && completion_state &&
+               state_instance_id != 0 &&
+               completion_state->GetInstanceId() == state_instance_id;
+    }
+};
+
 struct RHIBackendSubmissionBatchEntry {
     EQueueType queue{EQueueType::Ignore};
     CmdSubmit  submit;
@@ -117,6 +154,9 @@ public:
     // backend must safely linearize Sync against later Enqueue/Flush calls.
     virtual void          Enqueue(RHIBackendSubmissionBatch&& _batch) = 0;
     virtual GraphEventRef Sync(ERHISyncDepth _depth = ERHISyncDepth::RHI) = 0;
+    virtual GraphEventRef DrainPresentation(
+        RHIPresentationDrainTarget _target
+    ) = 0;
     virtual void          Flush(ERHIFlushDepth _depth = ERHIFlushDepth::SubmitGPU) = 0;
     // Publish non-blocking cancellation before RHIExecutor waits for
     // concurrent Sync callers. Backends without cancellable host waits may

--- a/source/runtime/render/rhi/RHIPresentationCompletion.cpp
+++ b/source/runtime/render/rhi/RHIPresentationCompletion.cpp
@@ -1,0 +1,634 @@
+#include "rhi/RHIPresentationCompletion.h"
+
+#include <atomic>
+#include <condition_variable>
+#include <map>
+#include <mutex>
+#include <optional>
+#include <utility>
+
+namespace Moer::Render {
+namespace {
+
+std::atomic<std::uint64_t> g_presentation_completion_state_id{1};
+
+std::uint64_t NextStateInstanceId() noexcept {
+    std::uint64_t id = g_presentation_completion_state_id.fetch_add(
+        1, std::memory_order_relaxed
+    );
+    while (id == 0) {
+        id = g_presentation_completion_state_id.fetch_add(
+            1, std::memory_order_relaxed
+        );
+    }
+    return id;
+}
+
+} // namespace
+
+struct PresentationCompletionState::Impl {
+    struct Record {
+        PresentationCompletionIdentity            identity{};
+        std::uint64_t                              issue_sequence{0};
+        std::uint32_t                              fence_slot{0};
+        std::uint64_t                              slot_generation{0};
+        SharedPtr<
+            std::atomic<EPresentationWsiCompletionOutcome>>
+            wsi_outcome{};
+        std::optional<EPresentationWsiCompletionMode> wsi_mode{};
+        bool                                       gpu_complete{false};
+        bool                                       wsi_complete{false};
+
+        [[nodiscard]] bool IsTerminal() const noexcept {
+            return wsi_mode.has_value() &&
+                   gpu_complete &&
+                   wsi_complete;
+        }
+    };
+
+    mutable std::mutex              mutex{};
+    mutable std::condition_variable wsi_cv{};
+    mutable std::condition_variable retired_cv{};
+    std::map<std::uint64_t, Record> records{};
+    std::uint64_t                   next_issue_sequence{1};
+    std::uint64_t                   last_issue_sequence{0};
+};
+
+struct PresentationCompletionStateAccess {
+    using Record = PresentationCompletionState::Impl::Record;
+    using RecordIterator =
+        std::map<std::uint64_t, Record>::iterator;
+    using ConstRecordIterator =
+        std::map<std::uint64_t, Record>::const_iterator;
+
+    static bool TicketStructurallyBelongs(
+        const PresentationCompletionState&  _state,
+        const PresentationCompletionTicket& _ticket
+    ) noexcept {
+        return _ticket.state_.get() == &_state &&
+               _ticket.issue_sequence_ != 0 &&
+               _ticket.identity_.state_instance_id ==
+                   _state.GetStateInstanceId();
+    }
+
+    static RecordIterator FindExactRecord(
+        PresentationCompletionState::Impl&  _impl,
+        const PresentationCompletionState&  _state,
+        const PresentationCompletionTicket& _ticket
+    ) noexcept {
+        if (!TicketStructurallyBelongs(_state, _ticket)) {
+            return _impl.records.end();
+        }
+        const auto record =
+            _impl.records.find(_ticket.issue_sequence_);
+        if (record == _impl.records.end()) {
+            return record;
+        }
+        if (record->second.identity != _ticket.identity_ ||
+            record->second.issue_sequence !=
+                _ticket.issue_sequence_ ||
+            record->second.fence_slot != _ticket.fence_slot_ ||
+            record->second.slot_generation !=
+                _ticket.slot_generation_) {
+            return _impl.records.end();
+        }
+        return record;
+    }
+
+    static ConstRecordIterator FindExactRecord(
+        const PresentationCompletionState::Impl& _impl,
+        const PresentationCompletionState&       _state,
+        const PresentationCompletionTicket&      _ticket
+    ) noexcept {
+        if (!TicketStructurallyBelongs(_state, _ticket)) {
+            return _impl.records.end();
+        }
+        const auto record =
+            _impl.records.find(_ticket.issue_sequence_);
+        if (record == _impl.records.end()) {
+            return record;
+        }
+        if (record->second.identity != _ticket.identity_ ||
+            record->second.issue_sequence !=
+                _ticket.issue_sequence_ ||
+            record->second.fence_slot != _ticket.fence_slot_ ||
+            record->second.slot_generation !=
+                _ticket.slot_generation_) {
+            return _impl.records.end();
+        }
+        return record;
+    }
+
+    static bool DrainPointBelongs(
+        const PresentationCompletionState& _state,
+        const PresentationDrainPoint&       _point
+    ) noexcept {
+        return _point.state_.get() == &_state &&
+               _point.state_instance_id_ != 0 &&
+               _point.state_instance_id_ ==
+                   _state.GetStateInstanceId() &&
+               (_point.all_identities_ ||
+                (_point.presentation_epoch_ != 0 ||
+                 _point.drawable_generation_ != 0));
+    }
+
+    static bool RecordMatchesDrainPoint(
+        const Record&                 _record,
+        const PresentationDrainPoint& _point
+    ) noexcept {
+        if (_record.issue_sequence >
+            _point.through_issue_sequence_) {
+            return false;
+        }
+        return _point.all_identities_ ||
+               (_record.identity.presentation_epoch ==
+                    _point.presentation_epoch_ &&
+                _record.identity.drawable_generation ==
+                    _point.drawable_generation_);
+    }
+
+    static bool HasOutstandingAtPoint(
+        const PresentationCompletionState::Impl& _impl,
+        const PresentationDrainPoint&             _point
+    ) noexcept {
+        for (const auto& [issue_sequence, record] :
+             _impl.records) {
+            if (issue_sequence >
+                _point.through_issue_sequence_) {
+                break;
+            }
+            if (RecordMatchesDrainPoint(record, _point)) {
+                return true;
+            }
+        }
+        return false;
+    }
+};
+
+PresentationCompletionTicket::PresentationCompletionTicket(
+    PresentationCompletionStateRef _state,
+    PresentationCompletionIdentity _identity,
+    std::uint64_t                  _issue_sequence,
+    std::uint32_t                  _fence_slot,
+    std::uint64_t                  _slot_generation,
+    SharedPtr<std::atomic<EPresentationWsiCompletionOutcome>>
+        _wsi_outcome
+) noexcept :
+    state_(std::move(_state)),
+    identity_(_identity),
+    issue_sequence_(_issue_sequence),
+    fence_slot_(_fence_slot),
+    slot_generation_(_slot_generation),
+    wsi_outcome_(std::move(_wsi_outcome)) {}
+
+bool PresentationCompletionTicket::IsValid() const noexcept {
+    return state_ &&
+           identity_.state_instance_id != 0 &&
+           identity_.state_instance_id ==
+               state_->GetStateInstanceId() &&
+           issue_sequence_ != 0 &&
+           wsi_outcome_;
+}
+
+const PresentationCompletionIdentity&
+PresentationCompletionTicket::GetIdentity() const noexcept {
+    return identity_;
+}
+
+std::uint64_t
+PresentationCompletionTicket::GetIssueSequence() const noexcept {
+    return issue_sequence_;
+}
+
+std::uint32_t
+PresentationCompletionTicket::GetFenceSlot() const noexcept {
+    return fence_slot_;
+}
+
+std::uint64_t
+PresentationCompletionTicket::GetSlotGeneration() const noexcept {
+    return slot_generation_;
+}
+
+EPresentationWsiCompletionOutcome
+PresentationCompletionTicket::GetWsiOutcome() const noexcept {
+    return wsi_outcome_ ?
+               wsi_outcome_->load(std::memory_order_acquire) :
+               EPresentationWsiCompletionOutcome::Pending;
+}
+
+bool PresentationDrainPoint::IsValid() const noexcept {
+    return state_ &&
+           state_instance_id_ != 0 &&
+           state_instance_id_ == state_->GetStateInstanceId();
+}
+
+std::uint64_t
+PresentationDrainPoint::GetStateInstanceId() const noexcept {
+    return state_instance_id_;
+}
+
+std::uint64_t
+PresentationDrainPoint::GetThroughIssueSequence() const noexcept {
+    return through_issue_sequence_;
+}
+
+std::uint64_t
+PresentationDrainPoint::GetPresentationEpoch() const noexcept {
+    return presentation_epoch_;
+}
+
+std::uint64_t
+PresentationDrainPoint::GetDrawableGeneration() const noexcept {
+    return drawable_generation_;
+}
+
+bool PresentationDrainPoint::IncludesAllIdentities() const noexcept {
+    return all_identities_;
+}
+
+const PresentationCompletionStateRef&
+PresentationDrainPoint::GetState() const noexcept {
+    return state_;
+}
+
+PresentationCompletionStateRef PresentationCompletionState::Create() {
+    return PresentationCompletionStateRef(
+        new PresentationCompletionState(NextStateInstanceId())
+    );
+}
+
+PresentationCompletionState::PresentationCompletionState(
+    std::uint64_t _state_instance_id
+) :
+    state_instance_id_(_state_instance_id),
+    impl_(std::make_shared<Impl>()) {}
+
+PresentationCompletionState::~PresentationCompletionState() = default;
+
+std::uint64_t
+PresentationCompletionState::GetInstanceId() const noexcept {
+    return state_instance_id_;
+}
+
+PresentationCompletionTicket PresentationCompletionState::Reserve(
+    PresentationCompletionIdentity _identity,
+    std::uint32_t                   _fence_slot,
+    std::uint64_t                   _slot_generation
+) {
+    if (_identity.state_instance_id != state_instance_id_) {
+        return {};
+    }
+
+    std::uint64_t issue_sequence = 0;
+    auto wsi_outcome = MakeShared<
+        std::atomic<EPresentationWsiCompletionOutcome>>(
+        EPresentationWsiCompletionOutcome::Pending
+    );
+    {
+        std::scoped_lock lock(impl_->mutex);
+        do {
+            issue_sequence = impl_->next_issue_sequence++;
+        } while (issue_sequence == 0 ||
+                 impl_->records.contains(issue_sequence));
+
+        Impl::Record record{};
+        record.identity        = _identity;
+        record.issue_sequence  = issue_sequence;
+        record.fence_slot      = _fence_slot;
+        record.slot_generation = _slot_generation;
+        record.wsi_outcome     = wsi_outcome;
+        impl_->records.emplace(issue_sequence, std::move(record));
+        impl_->last_issue_sequence = issue_sequence;
+    }
+
+    return PresentationCompletionTicket(
+        shared_from_this(),
+        _identity,
+        issue_sequence,
+        _fence_slot,
+        _slot_generation,
+        std::move(wsi_outcome)
+    );
+}
+
+bool PresentationCompletionState::SetWsiMode(
+    const PresentationCompletionTicket& _ticket,
+    EPresentationWsiCompletionMode      _mode
+) noexcept {
+    bool notify_wsi = false;
+    {
+        std::scoped_lock lock(impl_->mutex);
+        const auto record =
+            PresentationCompletionStateAccess::FindExactRecord(
+                *impl_, *this, _ticket
+            );
+        if (record == impl_->records.end()) {
+            return false;
+        }
+        if (record->second.wsi_mode.has_value()) {
+            return record->second.wsi_mode.value() == _mode;
+        }
+        record->second.wsi_mode = _mode;
+        if (_mode == EPresentationWsiCompletionMode::Immediate ||
+            _mode == EPresentationWsiCompletionMode::Failed) {
+            record->second.wsi_complete = true;
+            record->second.wsi_outcome->store(
+                _mode == EPresentationWsiCompletionMode::Immediate ?
+                    EPresentationWsiCompletionOutcome::Succeeded :
+                    EPresentationWsiCompletionOutcome::Failed,
+                std::memory_order_release
+            );
+            notify_wsi                  = true;
+        }
+    }
+    if (notify_wsi) {
+        impl_->wsi_cv.notify_all();
+    }
+    return true;
+}
+
+bool PresentationCompletionState::MarkGpuComplete(
+    const PresentationCompletionTicket& _ticket
+) noexcept {
+    std::scoped_lock lock(impl_->mutex);
+    const auto record =
+        PresentationCompletionStateAccess::FindExactRecord(
+            *impl_, *this, _ticket
+        );
+    if (record == impl_->records.end()) {
+        return false;
+    }
+    record->second.gpu_complete = true;
+    return true;
+}
+
+bool PresentationCompletionState::MarkWsiComplete(
+    const PresentationCompletionTicket& _ticket
+) noexcept {
+    {
+        std::scoped_lock lock(impl_->mutex);
+        const auto record =
+            PresentationCompletionStateAccess::FindExactRecord(
+                *impl_, *this, _ticket
+            );
+        if (record == impl_->records.end() ||
+            !record->second.wsi_mode.has_value()) {
+            return false;
+        }
+        switch (record->second.wsi_mode.value()) {
+            case EPresentationWsiCompletionMode::PresentFence:
+                record->second.wsi_complete = true;
+                record->second.wsi_outcome->store(
+                    EPresentationWsiCompletionOutcome::Succeeded,
+                    std::memory_order_release
+                );
+                break;
+            case EPresentationWsiCompletionMode::Immediate:
+            case EPresentationWsiCompletionMode::Failed:
+                return true;
+            case EPresentationWsiCompletionMode::QueueIdleFallback:
+                return false;
+        }
+    }
+    impl_->wsi_cv.notify_all();
+    return true;
+}
+
+bool PresentationCompletionState::MarkWsiFailed(
+    const PresentationCompletionTicket& _ticket
+) noexcept {
+    {
+        std::scoped_lock lock(impl_->mutex);
+        const auto record =
+            PresentationCompletionStateAccess::FindExactRecord(
+                *impl_, *this, _ticket
+            );
+        if (record == impl_->records.end()) {
+            return false;
+        }
+        record->second.wsi_mode =
+            EPresentationWsiCompletionMode::Failed;
+        record->second.wsi_complete = true;
+        record->second.wsi_outcome->store(
+            EPresentationWsiCompletionOutcome::Failed,
+            std::memory_order_release
+        );
+    }
+    impl_->wsi_cv.notify_all();
+    return true;
+}
+
+bool PresentationCompletionState::PublishRetired(
+    const PresentationCompletionTicket& _ticket
+) noexcept {
+    {
+        std::scoped_lock lock(impl_->mutex);
+        const auto record =
+            PresentationCompletionStateAccess::FindExactRecord(
+                *impl_, *this, _ticket
+            );
+        if (record == impl_->records.end() ||
+            !record->second.IsTerminal()) {
+            return false;
+        }
+        impl_->records.erase(record);
+    }
+    impl_->wsi_cv.notify_all();
+    impl_->retired_cv.notify_all();
+    return true;
+}
+
+std::size_t PresentationCompletionState::PublishRetired() noexcept {
+    std::size_t retired_count = 0;
+    {
+        std::scoped_lock lock(impl_->mutex);
+        for (auto record = impl_->records.begin();
+             record != impl_->records.end();) {
+            if (record->second.IsTerminal()) {
+                record = impl_->records.erase(record);
+                ++retired_count;
+            } else {
+                ++record;
+            }
+        }
+    }
+    if (retired_count != 0) {
+        impl_->wsi_cv.notify_all();
+        impl_->retired_cv.notify_all();
+    }
+    return retired_count;
+}
+
+void PresentationCompletionState::WaitForWsi(
+    const PresentationCompletionTicket& _ticket
+) const {
+    std::unique_lock lock(impl_->mutex);
+    if (!PresentationCompletionStateAccess::
+            TicketStructurallyBelongs(*this, _ticket)) {
+        return;
+    }
+    impl_->wsi_cv.wait(lock, [&] {
+        const auto record =
+            PresentationCompletionStateAccess::FindExactRecord(
+                *impl_, *this, _ticket
+            );
+        return record == impl_->records.end() ||
+               record->second.wsi_complete;
+    });
+}
+
+bool PresentationCompletionState::WaitForWsi(
+    const PresentationCompletionTicket& _ticket,
+    std::chrono::nanoseconds             _timeout
+) const {
+    std::unique_lock lock(impl_->mutex);
+    if (!PresentationCompletionStateAccess::
+            TicketStructurallyBelongs(*this, _ticket)) {
+        return false;
+    }
+    const bool reached_terminal = impl_->wsi_cv.wait_for(
+        lock,
+        _timeout,
+        [&] {
+            const auto record =
+                PresentationCompletionStateAccess::FindExactRecord(
+                    *impl_, *this, _ticket
+                );
+            return record == impl_->records.end() ||
+                   record->second.wsi_complete;
+        }
+    );
+    if (!reached_terminal) {
+        return false;
+    }
+    const auto record =
+        PresentationCompletionStateAccess::FindExactRecord(
+            *impl_, *this, _ticket
+        );
+    return record == impl_->records.end() ||
+           record->second.wsi_complete;
+}
+
+PresentationDrainPoint PresentationCompletionState::Freeze(
+    std::uint64_t _presentation_epoch,
+    std::uint64_t _drawable_generation
+) {
+    PresentationDrainPoint point{};
+    point.state_               = shared_from_this();
+    point.state_instance_id_   = state_instance_id_;
+    point.presentation_epoch_  = _presentation_epoch;
+    point.drawable_generation_ = _drawable_generation;
+    point.all_identities_ =
+        _presentation_epoch == 0 && _drawable_generation == 0;
+    {
+        std::scoped_lock lock(impl_->mutex);
+        point.through_issue_sequence_ =
+            impl_->last_issue_sequence;
+    }
+    return point;
+}
+
+bool PresentationCompletionState::RequiresQueueIdle(
+    const PresentationDrainPoint& _point
+) const noexcept {
+    if (!PresentationCompletionStateAccess::DrainPointBelongs(
+            *this, _point
+        )) {
+        return false;
+    }
+    std::scoped_lock lock(impl_->mutex);
+    for (const auto& [issue_sequence, record] : impl_->records) {
+        if (issue_sequence > _point.through_issue_sequence_) {
+            break;
+        }
+        if (PresentationCompletionStateAccess::
+                RecordMatchesDrainPoint(record, _point) &&
+            record.wsi_mode ==
+                EPresentationWsiCompletionMode::QueueIdleFallback &&
+            !record.wsi_complete) {
+            return true;
+        }
+    }
+    return false;
+}
+
+bool PresentationCompletionState::ResolveQueueIdle(
+    const PresentationDrainPoint& _point
+) noexcept {
+    if (!PresentationCompletionStateAccess::DrainPointBelongs(
+            *this, _point
+        )) {
+        return false;
+    }
+
+    bool resolved_any = false;
+    {
+        std::scoped_lock lock(impl_->mutex);
+        for (auto& [issue_sequence, record] : impl_->records) {
+            if (issue_sequence > _point.through_issue_sequence_) {
+                break;
+            }
+            if (PresentationCompletionStateAccess::
+                    RecordMatchesDrainPoint(record, _point) &&
+                record.wsi_mode ==
+                    EPresentationWsiCompletionMode::QueueIdleFallback &&
+                !record.wsi_complete) {
+                record.wsi_complete = true;
+                record.wsi_outcome->store(
+                    EPresentationWsiCompletionOutcome::Succeeded,
+                    std::memory_order_release
+                );
+                resolved_any        = true;
+            }
+        }
+    }
+    if (resolved_any) {
+        impl_->wsi_cv.notify_all();
+    }
+    return resolved_any;
+}
+
+void PresentationCompletionState::WaitRetired(
+    const PresentationDrainPoint& _point
+) const {
+    if (!PresentationCompletionStateAccess::DrainPointBelongs(
+            *this, _point
+        )) {
+        return;
+    }
+    std::unique_lock lock(impl_->mutex);
+    impl_->retired_cv.wait(lock, [&] {
+        return !PresentationCompletionStateAccess::
+            HasOutstandingAtPoint(*impl_, _point);
+    });
+}
+
+bool PresentationCompletionState::WaitRetired(
+    const PresentationDrainPoint& _point,
+    std::chrono::nanoseconds       _timeout
+) const {
+    if (!PresentationCompletionStateAccess::DrainPointBelongs(
+            *this, _point
+        )) {
+        return false;
+    }
+    std::unique_lock lock(impl_->mutex);
+    return impl_->retired_cv.wait_for(lock, _timeout, [&] {
+        return !PresentationCompletionStateAccess::
+            HasOutstandingAtPoint(*impl_, _point);
+    });
+}
+
+bool PresentationCompletionState::HasOutstanding() const noexcept {
+    std::scoped_lock lock(impl_->mutex);
+    return !impl_->records.empty();
+}
+
+std::size_t
+PresentationCompletionState::OutstandingCount() const noexcept {
+    std::scoped_lock lock(impl_->mutex);
+    return impl_->records.size();
+}
+
+} // namespace Moer::Render

--- a/source/runtime/render/rhi/RHIPresentationCompletion.h
+++ b/source/runtime/render/rhi/RHIPresentationCompletion.h
@@ -1,0 +1,239 @@
+#ifndef MOER_ENGINE_RHI_PRESENTATION_COMPLETION_H
+#define MOER_ENGINE_RHI_PRESENTATION_COMPLETION_H
+
+#include "RenderAPI.h"
+#include "misc/STL.h"
+
+#include <atomic>
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+
+namespace Moer::Render {
+
+struct PresentationCompletionStateAccess;
+
+// WSI completion is deliberately separate from GPU queue completion. A
+// backend selects exactly one mode after attempting Present:
+// - Immediate/Failed have no outstanding native WSI wait.
+// - PresentFence is completed by the Completion owner.
+// - QueueIdleFallback is resolved only after the Submission owner performs
+//   the backend's queue-idle fallback.
+enum class EPresentationWsiCompletionMode : std::uint8_t {
+    Immediate = 0,
+    PresentFence,
+    QueueIdleFallback,
+    Failed,
+};
+
+enum class EPresentationWsiCompletionOutcome : std::uint8_t {
+    Pending = 0,
+    Succeeded,
+    Failed,
+};
+
+struct PresentationCompletionIdentity {
+    std::uint64_t state_instance_id{0};
+    std::uint64_t presentation_epoch{0};
+    std::uint64_t drawable_generation{0};
+    std::uint64_t request_serial{0};
+
+    [[nodiscard]] friend constexpr bool operator==(
+        const PresentationCompletionIdentity&,
+        const PresentationCompletionIdentity&
+    ) noexcept = default;
+};
+
+class PresentationCompletionState;
+using PresentationCompletionStateRef =
+    SharedPtr<PresentationCompletionState>;
+
+// Strong producer/completion identity. issue_sequence is assigned by the
+// reducer and therefore does not inherit ordering, reuse, or wrap assumptions
+// from a caller-owned Present receipt serial.
+class RENDER_API PresentationCompletionTicket {
+public:
+    PresentationCompletionTicket() = default;
+
+    [[nodiscard]] bool IsValid() const noexcept;
+    [[nodiscard]] const PresentationCompletionIdentity&
+    GetIdentity() const noexcept;
+    [[nodiscard]] std::uint64_t GetIssueSequence() const noexcept;
+    [[nodiscard]] std::uint32_t GetFenceSlot() const noexcept;
+    [[nodiscard]] std::uint64_t GetSlotGeneration() const noexcept;
+    [[nodiscard]] EPresentationWsiCompletionOutcome
+    GetWsiOutcome() const noexcept;
+
+private:
+    PresentationCompletionTicket(
+        PresentationCompletionStateRef _state,
+        PresentationCompletionIdentity _identity,
+        std::uint64_t                  _issue_sequence,
+        std::uint32_t                  _fence_slot,
+        std::uint64_t                  _slot_generation,
+        SharedPtr<std::atomic<EPresentationWsiCompletionOutcome>>
+            _wsi_outcome
+    ) noexcept;
+
+    PresentationCompletionStateRef state_{};
+    PresentationCompletionIdentity identity_{};
+    std::uint64_t                   issue_sequence_{0};
+    std::uint32_t                   fence_slot_{0};
+    std::uint64_t                   slot_generation_{0};
+    SharedPtr<std::atomic<EPresentationWsiCompletionOutcome>>
+        wsi_outcome_{};
+
+    friend class PresentationCompletionState;
+    friend struct PresentationCompletionStateAccess;
+};
+
+// A strong, immutable snapshot of the records that a targeted drain may wait
+// for. Records issued after this point never extend the wait. epoch/generation
+// zero/zero selects every identity owned by this state.
+struct RENDER_API PresentationDrainPoint {
+public:
+    PresentationDrainPoint() = default;
+
+    [[nodiscard]] bool IsValid() const noexcept;
+    [[nodiscard]] std::uint64_t GetStateInstanceId() const noexcept;
+    [[nodiscard]] std::uint64_t GetThroughIssueSequence() const noexcept;
+    [[nodiscard]] std::uint64_t GetPresentationEpoch() const noexcept;
+    [[nodiscard]] std::uint64_t GetDrawableGeneration() const noexcept;
+    [[nodiscard]] bool IncludesAllIdentities() const noexcept;
+    [[nodiscard]] const PresentationCompletionStateRef&
+    GetState() const noexcept;
+
+private:
+    PresentationCompletionStateRef state_{};
+    std::uint64_t                   state_instance_id_{0};
+    std::uint64_t                   through_issue_sequence_{0};
+    std::uint64_t                   presentation_epoch_{0};
+    std::uint64_t                   drawable_generation_{0};
+    bool                            all_identities_{false};
+
+    friend class PresentationCompletionState;
+    friend struct PresentationCompletionStateAccess;
+};
+
+// Pure CPU reducer for one strongly-owned PresentationSurface lifetime.
+// Native objects and raw-pointer keys never enter this type. A record is
+// reclaimable only after both its GPU and WSI components are complete, and is
+// erased only when its retirement is explicitly published.
+class RENDER_API PresentationCompletionState final :
+    public std::enable_shared_from_this<PresentationCompletionState> {
+public:
+    [[nodiscard]] static PresentationCompletionStateRef Create();
+    ~PresentationCompletionState();
+
+    PresentationCompletionState(const PresentationCompletionState&) = delete;
+    PresentationCompletionState& operator=(
+        const PresentationCompletionState&
+    ) = delete;
+
+    [[nodiscard]] std::uint64_t GetInstanceId() const noexcept;
+    [[nodiscard]] std::uint64_t GetStateInstanceId() const noexcept {
+        return GetInstanceId();
+    }
+
+    [[nodiscard]] PresentationCompletionTicket Reserve(
+        PresentationCompletionIdentity _identity,
+        std::uint32_t                   _fence_slot,
+        std::uint64_t                   _slot_generation
+    );
+
+    // Every mutation performs an exact ticket lookup. A late callback from a
+    // retired state/epoch/generation/slot generation returns false and cannot
+    // mutate a newer record.
+    bool SetWsiMode(
+        const PresentationCompletionTicket& _ticket,
+        EPresentationWsiCompletionMode      _mode
+    ) noexcept;
+    bool MarkGpuComplete(
+        const PresentationCompletionTicket& _ticket
+    ) noexcept;
+    bool MarkWsiComplete(
+        const PresentationCompletionTicket& _ticket
+    ) noexcept;
+    bool MarkWsiFailed(
+        const PresentationCompletionTicket& _ticket
+    ) noexcept;
+
+    // Publish one terminal record, or all currently terminal records. Unlike a
+    // prefix watermark, publication can retire a fast failure behind an older
+    // accepted Present without falsely retiring that older operation.
+    bool PublishRetired(
+        const PresentationCompletionTicket& _ticket
+    ) noexcept;
+    [[nodiscard]] std::size_t PublishRetired() noexcept;
+
+    void WaitForWsi(
+        const PresentationCompletionTicket& _ticket
+    ) const;
+    [[nodiscard]] bool WaitForWsi(
+        const PresentationCompletionTicket& _ticket,
+        std::chrono::nanoseconds             _timeout
+    ) const;
+
+    template<typename Rep, typename Period>
+    [[nodiscard]] bool WaitForWsi(
+        const PresentationCompletionTicket&       _ticket,
+        std::chrono::duration<Rep, Period>         _timeout
+    ) const {
+        return WaitForWsi(
+            _ticket,
+            std::chrono::duration_cast<std::chrono::nanoseconds>(
+                _timeout
+            )
+        );
+    }
+
+    [[nodiscard]] PresentationDrainPoint Freeze(
+        std::uint64_t _presentation_epoch = 0,
+        std::uint64_t _drawable_generation = 0
+    );
+    [[nodiscard]] bool RequiresQueueIdle(
+        const PresentationDrainPoint& _point
+    ) const noexcept;
+    bool ResolveQueueIdle(
+        const PresentationDrainPoint& _point
+    ) noexcept;
+
+    void WaitRetired(const PresentationDrainPoint& _point) const;
+    [[nodiscard]] bool WaitRetired(
+        const PresentationDrainPoint& _point,
+        std::chrono::nanoseconds       _timeout
+    ) const;
+
+    template<typename Rep, typename Period>
+    [[nodiscard]] bool WaitRetired(
+        const PresentationDrainPoint&          _point,
+        std::chrono::duration<Rep, Period>      _timeout
+    ) const {
+        return WaitRetired(
+            _point,
+            std::chrono::duration_cast<std::chrono::nanoseconds>(
+                _timeout
+            )
+        );
+    }
+
+    [[nodiscard]] bool HasOutstanding() const noexcept;
+    [[nodiscard]] std::size_t OutstandingCount() const noexcept;
+
+private:
+    struct Impl;
+
+    explicit PresentationCompletionState(
+        std::uint64_t _state_instance_id
+    );
+
+    const std::uint64_t state_instance_id_{0};
+    SharedPtr<Impl>     impl_{};
+
+    friend struct PresentationCompletionStateAccess;
+};
+
+} // namespace Moer::Render
+
+#endif

--- a/source/runtime/render/rhi/RHIResource.h
+++ b/source/runtime/render/rhi/RHIResource.h
@@ -11,6 +11,7 @@
 #include "misc/STL.h"
 #include "misc/Traits.h"
 #include "rhi/RHICommon.h"
+#include "rhi/RHIPresentationCompletion.h"
 #include "rhi/RHIResourceInitilizer.h"
 #include "rhi/RHIWindowSurface.h"
 
@@ -1393,18 +1394,27 @@ struct SwapchainCreateInfo {
 
 class RENDER_API Swapchain : public RHIResource {
 protected:
-    Swapchain() : RHIResource(RRT_SWAPCHAIN) {};
+    Swapchain() :
+        RHIResource(RRT_SWAPCHAIN),
+        presentation_completion_state_(PresentationCompletionState::Create()) {};
 
 public:
     [[nodiscard]] virtual bool Recreate(const SwapchainCreateInfo&) = 0;
     virtual ~Swapchain()                                            = default;
-    virtual void Sync()                                             = 0;
     [[nodiscard]] virtual bool IsPresentationReady() const noexcept = 0;
     [[nodiscard]] virtual WindowSurfaceIdentity GetCommittedSurfaceIdentity() const noexcept = 0;
+
+    [[nodiscard]] const PresentationCompletionStateRef&
+    GetPresentationCompletionState() const noexcept {
+        return presentation_completion_state_;
+    }
 
 public:
     EPixelFormat format;
     Extent2D     size;
+
+private:
+    PresentationCompletionStateRef presentation_completion_state_{};
 };
 } // namespace Moer::Render
 

--- a/source/runtime/render/rhi/d3d12/D3D12Device.cpp
+++ b/source/runtime/render/rhi/d3d12/D3D12Device.cpp
@@ -765,10 +765,6 @@ bool D3D12Swapchain::Recreate(const SwapchainCreateInfo& _info) {
     return false;
 }
 
-void D3D12Swapchain::Sync() {
-    FATAL("not implemented");
-}
-
 void D3D12Swapchain::Present() {}
 
 void D3D12Swapchain::CreateSizeDependentResources() {

--- a/source/runtime/render/rhi/d3d12/D3D12Device.h
+++ b/source/runtime/render/rhi/d3d12/D3D12Device.h
@@ -1066,7 +1066,6 @@ public:
     ~D3D12Swapchain() = default;
 
     [[nodiscard]] bool Recreate(const SwapchainCreateInfo&) override;
-    void Sync() override;
     [[nodiscard]] bool IsPresentationReady() const noexcept override {
         return false;
     }

--- a/source/runtime/render/rhi/vulkan/VulkanDevice.cpp
+++ b/source/runtime/render/rhi/vulkan/VulkanDevice.cpp
@@ -10,6 +10,7 @@
 #include "VulkanPlatform.h"
 #include "VulkanQueue.h"
 #include "VulkanRHIResource.h"
+#include "VulkanSubmissionDiagnostics.h"
 #include "VulkanUtil.h"
 #include "plugin/VulkanCooperativeSupport.h"
 #include "plugin/VulkanNrdPlugin.h"
@@ -205,6 +206,17 @@ void VulkanDevice::InitVulkanInstance(uint32 _api_version) {
     };
 
     const auto instance_extensions_required = VulkanInstanceExtension::GetMERequiredInstanceExtensions();
+    const auto instance_extensions_optional =
+        VulkanInstanceExtension::GetMEOptionalInstanceExtensions();
+    const bool can_enable_surface_maintenance1 =
+        CanEnableVulkanSurfaceMaintenance1(
+            instance_extensions.contains(
+                VK_EXT_SURFACE_MAINTENANCE_1_EXTENSION_NAME
+            ),
+            instance_extensions.contains(
+                VK_KHR_GET_SURFACE_CAPABILITIES_2_EXTENSION_NAME
+            )
+        );
 
     Array<const char*> instance_extensions_loaded;
     bool               b_instance_extensions_fully_supported = true;
@@ -213,6 +225,22 @@ void VulkanDevice::InitVulkanInstance(uint32 _api_version) {
             instance_extensions_loaded.emplace_back(ext.data());
         else
             b_instance_extensions_fully_supported = false;
+    }
+    for (const auto& ext : instance_extensions_optional) {
+        if (!instance_extensions.contains(ext.data())) {
+            continue;
+        }
+        if (ext == VK_EXT_SURFACE_MAINTENANCE_1_EXTENSION_NAME &&
+            !can_enable_surface_maintenance1) {
+            // VK_EXT_surface_maintenance1 has an explicit instance-extension
+            // dependency. Do not enable a capability that the loader cannot
+            // legally satisfy on non-Windows platforms.
+            continue;
+        }
+        instance_extensions_loaded.emplace_back(ext.data());
+        if (ext == VK_EXT_SURFACE_MAINTENANCE_1_EXTENSION_NAME) {
+            surface_maintenance1_enabled = true;
+        }
     }
     CHECK_ASSERT(
         b_instance_extensions_fully_supported, "Not all required instance extensions are supported."
@@ -372,6 +400,21 @@ void VulkanDevice::InitGpu(uint32 _api_version) {
     auto gpu_extensions = VulkanDevice::GetGpuExtensions(m_gpu);
 
     m_device_info.enabled_extensions = VulkanDeviceExtension::GetMEEnabledDeviceExtensions(gpu_extensions);
+    if (!CanEnableVulkanSwapchainMaintenance1(
+            surface_maintenance1_enabled,
+            gpu_extensions.contains(
+                VK_EXT_SWAPCHAIN_MAINTENANCE_1_EXTENSION_NAME
+            )
+        )) {
+        std::erase_if(
+            m_device_info.enabled_extensions,
+            [](const std::shared_ptr<VulkanDeviceExtension>& extension) {
+                return extension &&
+                       extension->GetExtensionName() ==
+                           VK_EXT_SWAPCHAIN_MAINTENANCE_1_EXTENSION_NAME;
+            }
+        );
+    }
 
     // Query core features
     m_device_info.core_features = VulkanDeviceFeatures::GetGpuFeatures(m_gpu, _api_version);
@@ -1244,6 +1287,7 @@ VkResult VulkanDevice::WaitQueueIdle(
         return VK_ERROR_DEVICE_LOST;
     }
 
+    NotifyVulkanQueueIdleWait(_context);
     const VkResult result = vkQueueWaitIdle(_queue);
     if (result == VK_SUCCESS) {
         return result;
@@ -1281,6 +1325,34 @@ VkResult VulkanDevice::ResetCommandPool(
     if (publish_fault) {
         std::unique_lock<std::shared_mutex> publish_gate(native_queue_gate);
         PublishFirstFaultLocked(_context, result, false, false);
+    }
+    return result;
+}
+
+VkResult VulkanDevice::GetFenceStatus(
+    VkFence _fence,
+    const VulkanOperationContext& _context
+) {
+    std::shared_lock<std::shared_mutex> gate(native_queue_gate);
+    if (IsFaulted()) {
+        gate.unlock();
+        return GetFirstFaultResult();
+    }
+
+    const VkResult result = vkGetFenceStatus(m_device, _fence);
+    if (result == VK_SUCCESS || result == VK_NOT_READY) {
+        return result;
+    }
+
+    const bool publish_fault = TryBeginFirstFault(result);
+    gate.unlock();
+    if (publish_fault) {
+        std::unique_lock<std::shared_mutex> publish_gate(
+            native_queue_gate
+        );
+        PublishFirstFaultLocked(
+            _context, result, false, false
+        );
     }
     return result;
 }

--- a/source/runtime/render/rhi/vulkan/VulkanDevice.h
+++ b/source/runtime/render/rhi/vulkan/VulkanDevice.h
@@ -296,6 +296,10 @@ public:
         const VulkanOperationContext& _context
     );
     VkResult WaitQueueIdle(VkQueue _queue, const VulkanOperationContext& _context);
+    VkResult GetFenceStatus(
+        VkFence _fence,
+        const VulkanOperationContext& _context
+    );
     VkResult ResetCommandPool(VkCommandPool _pool, const VulkanOperationContext& _context);
     VkResult ResetFence(VkFence _fence, const VulkanOperationContext& _context);
     using FaultAdmissionLock = std::unique_lock<std::shared_mutex>;
@@ -367,6 +371,7 @@ private:
     uint32                    parallel_record_min_work_units_per_job = 64;
     uint64                    parallel_record_worker_throw_trigger = 0;
     uint64                    present_submit_fault_trigger = 0;
+    bool                      surface_maintenance1_enabled = false;
     std::atomic<uint64>       present_submit_attempts{0};
 
     std::atomic<EVulkanFaultPublishState> fault_state{EVulkanFaultPublishState::Healthy};

--- a/source/runtime/render/rhi/vulkan/VulkanQueue.cpp
+++ b/source/runtime/render/rhi/vulkan/VulkanQueue.cpp
@@ -18,6 +18,7 @@
 #include "platform/Platform.h"
 #include "rhi/RHICommand.h"
 #include "rhi/RHICommon.h"
+#include "rhi/RHIExecutorBackend.h"
 #include "rhi/RHIIO.h"
 #include "rhi/RHIResource.h"
 
@@ -44,6 +45,11 @@ std::atomic<const VulkanBackendSyncWaitObserver*>
     g_backend_sync_wait_observer{nullptr};
 std::atomic<const VulkanQueueLocalSyncWaitObserver*>
     g_queue_local_sync_wait_observer{nullptr};
+std::atomic<const VulkanQueueIdleWaitObserver*>
+    g_queue_idle_wait_observer{nullptr};
+std::atomic<
+    const VulkanScriptedPresentFenceStatusOverrideForTesting*>
+    g_scripted_present_fence_status_override{nullptr};
 std::atomic<const VulkanScriptedQueryPreparationOverrideForTesting*>
     g_scripted_query_preparation_override{nullptr};
 std::atomic<const VulkanScriptedTimestampValidBitsOverrideForTesting*>
@@ -253,6 +259,26 @@ void NotifyQueueLocalSyncWait(
 }
 
 } // namespace
+
+void NotifyVulkanQueueIdleWait(
+    const VulkanOperationContext& _context
+) noexcept {
+    const VulkanQueueIdleWaitObserver* observer =
+        g_queue_idle_wait_observer.load(std::memory_order_acquire);
+    if (observer == nullptr) {
+        return;
+    }
+    observer->callback(
+        observer->context,
+        VulkanQueueIdleWaitEvent{
+            .context             = _context,
+            .native_queue_handle =
+                reinterpret_cast<uint64>(_context.queue),
+            .thread_id           = Platform::GetCurrentThreadID(),
+            .thread_role         = GetCurrentRHIThreadRole(),
+        }
+    );
+}
 
 void NotifyVulkanSubmissionDependencyWaitBlocked(
     EQueueType _queue,
@@ -524,6 +550,70 @@ bool RemoveVulkanQueueLocalSyncWaitObserver(
         std::memory_order_acq_rel,
         std::memory_order_acquire
     );
+}
+
+bool TryInstallVulkanQueueIdleWaitObserver(
+    const VulkanQueueIdleWaitObserver* _observer
+) noexcept {
+    if (_observer == nullptr || _observer->callback == nullptr) {
+        return false;
+    }
+    const VulkanQueueIdleWaitObserver* expected = nullptr;
+    return g_queue_idle_wait_observer.compare_exchange_strong(
+        expected,
+        _observer,
+        std::memory_order_release,
+        std::memory_order_relaxed
+    );
+}
+
+bool RemoveVulkanQueueIdleWaitObserver(
+    const VulkanQueueIdleWaitObserver* _observer
+) noexcept {
+    if (_observer == nullptr) {
+        return false;
+    }
+    const VulkanQueueIdleWaitObserver* expected = _observer;
+    return g_queue_idle_wait_observer.compare_exchange_strong(
+        expected,
+        nullptr,
+        std::memory_order_acq_rel,
+        std::memory_order_acquire
+    );
+}
+
+bool TryInstallVulkanScriptedPresentFenceStatusOverrideForTesting(
+    const VulkanScriptedPresentFenceStatusOverrideForTesting* _override
+) noexcept {
+    if (_override == nullptr || _override->callback == nullptr) {
+        return false;
+    }
+    const VulkanScriptedPresentFenceStatusOverrideForTesting* expected =
+        nullptr;
+    return g_scripted_present_fence_status_override.
+        compare_exchange_strong(
+            expected,
+            _override,
+            std::memory_order_release,
+            std::memory_order_relaxed
+        );
+}
+
+bool RemoveVulkanScriptedPresentFenceStatusOverrideForTesting(
+    const VulkanScriptedPresentFenceStatusOverrideForTesting* _override
+) noexcept {
+    if (_override == nullptr) {
+        return false;
+    }
+    const VulkanScriptedPresentFenceStatusOverrideForTesting* expected =
+        _override;
+    return g_scripted_present_fence_status_override.
+        compare_exchange_strong(
+            expected,
+            nullptr,
+            std::memory_order_acq_rel,
+            std::memory_order_acquire
+        );
 }
 
 #pragma region[ utils ]
@@ -5304,6 +5394,25 @@ VkCommandQueue::~VkCommandQueue() {
         parallel_record_pool.reset();
     }
 
+    Array<PresentationDrainPoint> shutdown_presentation_points{};
+    {
+        // The runtime backend normally performs this Present-depth drain
+        // before queue destruction. Legacy/direct and exceptional teardown
+        // paths still need a final owner handoff so a queue-idle fallback
+        // cannot leave the Completion worker polling forever during join.
+        RHIThreadRoleScope submission_owner(
+            ERHIThreadRole::Submission
+        );
+        shutdown_presentation_points =
+            FreezeAllPresentationDrains();
+    }
+    for (const PresentationDrainPoint& point :
+         shutdown_presentation_points) {
+        if (point.IsValid()) {
+            point.GetState()->WaitRetired(point);
+        }
+    }
+
     {
         std::unique_lock<std::mutex> lock(event_mutex);
         completion_worker_running = false;
@@ -5461,6 +5570,9 @@ WaitEvent VkCommandQueue::Execute(CmdSubmit&& _submit) {
         return {uint64(timeline), current_timeline};
     }
 
+    RHIThreadRoleScope submission_owner(
+        ERHIThreadRole::Submission
+    );
     std::unique_lock<std::mutex> lock(exec_mtx);
     const uint64 current_timeline = last_frame.fetch_add(1, std::memory_order_relaxed) + 1;
     if (thread_profile) {
@@ -5843,7 +5955,11 @@ VulkanRuntimeSubmissionResult VkCommandQueue::PresentForRuntime(
                 std::move(_swapchain),
                 std::move(source_texture),
                 std::move(deferred_releases),
-                current_timeline
+                current_timeline,
+                {},
+                VK_NULL_HANDLE,
+                false,
+                false
             );
             ResolvePresentReceiptNoexcept(
                 _receipt, false, PresentStatusFromVulkanOutcome(scripted.outcome), EPresentStage::Present
@@ -8099,14 +8215,17 @@ void VkCommandQueue::Present(SwapchainRef _sc, TextureView _view, PresentReceipt
                 enqueue_depth
             );
             if (thread_profile) {
-                std::get<RhiPresentWork>(rhi_work_queue.back()).caller_ms =
-                    RhiThreadProfileMilliseconds(caller_started, std::chrono::steady_clock::now());
+            std::get<RhiPresentWork>(rhi_work_queue.back()).caller_ms =
+                RhiThreadProfileMilliseconds(caller_started, std::chrono::steady_clock::now());
             }
         }
         rhi_work_cv.notify_one();
         return;
     }
 
+    RHIThreadRoleScope submission_owner(
+        ERHIThreadRole::Submission
+    );
     std::unique_lock<std::mutex> lock(exec_mtx);
     const uint64 current_timeline = last_frame.fetch_add(1, std::memory_order_relaxed) + 1;
     if (thread_profile) {
@@ -8165,6 +8284,11 @@ VulkanRuntimeSubmissionResult VkCommandQueue::PresentNow(
     EVulkanPresentorRetirementState presentor_state       = EVulkanPresentorRetirementState::Unused;
     UniquePtr<VulkanPresentor>      presentor{};
     Array<RHIResource*>             deferred_releases{};
+    PresentationCompletionTicket    presentation_completion{};
+    VkFence                         wsi_completion_fence{VK_NULL_HANDLE};
+    bool                            wsi_enqueued{false};
+    bool                            uses_present_fence{false};
+    bool                            presentation_wsi_classified{false};
 
     try {
         const VulkanScriptedPresentOverrideForTesting* scripted_override =
@@ -8284,6 +8408,34 @@ VulkanRuntimeSubmissionResult VkCommandQueue::PresentNow(
                     vk_tracker.Reset();
 
                     deferred_releases = TakeDeferredReleases();
+                    PresentReceiptContext receipt_context =
+                        _receipt ? _receipt->GetContext() :
+                                   PresentReceiptContext{};
+                    if (receipt_context.presentation_epoch == 0) {
+                        receipt_context.presentation_epoch = 1;
+                    }
+                    if (receipt_context.drawable_generation == 0) {
+                        receipt_context.drawable_generation = 1;
+                    }
+                    presentation_completion =
+                        sc->ReservePresentCompletion(
+                            PresentationCompletionIdentity{
+                                .presentation_epoch =
+                                    receipt_context.presentation_epoch,
+                                .drawable_generation =
+                                    receipt_context.drawable_generation,
+                                .request_serial =
+                                    receipt_context.request_serial,
+                            }
+                        );
+                    if (!presentation_completion.IsValid()) {
+                        throw std::runtime_error(
+                            "failed to reserve Presentation completion ticket"
+                        );
+                    }
+                    RegisterPresentationCompletionState(
+                        sc->GetPresentationCompletionState()
+                    );
                     queue.Signal(timeline, _timeline, VK_PIPELINE_STAGE_2_COPY_BIT);
                     queue.Wait(acquire.ready_semaphore, VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT);
                     queue.Signal(sc->GetRenderFinishedFence(idx), VK_PIPELINE_STAGE_2_COPY_BIT);
@@ -8298,10 +8450,45 @@ VulkanRuntimeSubmissionResult VkCommandQueue::PresentNow(
                         presentor_state = EVulkanPresentorRetirementState::Submitted;
                         timeline->MarkSubmitted(_timeline);
 
-                        const VulkanOperationResult present_outcome =
-                            sc->Present(queue.GetHandle(), idx, _timeline, _serial);
-                        present_accepted = present_outcome.result == VK_SUCCESS ||
-                                           present_outcome.result == VK_SUBOPTIMAL_KHR;
+                        const VkSwapchain::PresentResult present_result =
+                            sc->Present(
+                                queue.GetHandle(),
+                                idx,
+                                _timeline,
+                                _serial,
+                                presentation_completion
+                            );
+                        presentation_wsi_classified = true;
+                        const VulkanOperationResult& present_outcome =
+                            present_result.outcome;
+                        present_accepted =
+                            present_result.accepted;
+                        wsi_enqueued =
+                            present_result.wsi_enqueued;
+                        wsi_completion_fence =
+                            present_result.completion_fence;
+                        uses_present_fence =
+                            present_result.uses_present_fence;
+                        if (present_result.wsi_enqueued &&
+                            !present_result.uses_present_fence) {
+                            // Without swapchain-maintenance fences, leaving one
+                            // unresolved fallback record per frame would retain
+                            // command pools, semaphores, and swapchain resources
+                            // without bound until a resize. Performance is
+                            // secondary on this compatibility path: the sole
+                            // Submission owner resolves the current surface
+                            // frontier immediately with queue idle.
+                            const PresentationCompletionIdentity&
+                                identity =
+                                    presentation_completion.GetIdentity();
+                            ResolvePresentationQueueIdleFallback(
+                                _sc->GetPresentationCompletionState()->
+                                    Freeze(
+                                        identity.presentation_epoch,
+                                        identity.drawable_generation
+                                    )
+                            );
+                        }
                         AccumulatePresentReceiptOutcome(
                             receipt_status, receipt_stage, present_outcome, EPresentStage::Present
                         );
@@ -8334,6 +8521,20 @@ VulkanRuntimeSubmissionResult VkCommandQueue::PresentNow(
         }
     }
 
+    if (presentation_completion.IsValid() &&
+        !presentation_wsi_classified && _sc) {
+        // Close only the exceptional interval after reservation but before
+        // VkSwapchain::Present classified the WSI result. A completed Present
+        // call owns its classification even when it returned
+        // OUT_OF_DATE/SURFACE_LOST as non-accepted but enqueued operations.
+        if (!_sc->GetPresentationCompletionState()->SetWsiMode(
+                presentation_completion,
+                EPresentationWsiCompletionMode::Failed
+            )) {
+            std::terminate();
+        }
+    }
+
     CommitPresentCompletion(
         final_outcome,
         context,
@@ -8343,7 +8544,11 @@ VulkanRuntimeSubmissionResult VkCommandQueue::PresentNow(
         std::move(_sc),
         std::move(_source_texture),
         std::move(deferred_releases),
-        _timeline
+        _timeline,
+        std::move(presentation_completion),
+        wsi_completion_fence,
+        wsi_enqueued,
+        uses_present_fence
     );
 
     if (receipt_status == EPresentStatus::Unresolved) {
@@ -8370,7 +8575,11 @@ void VkCommandQueue::CommitPresentCompletion(
     SwapchainRef&&                  _swapchain,
     TextureRef&&                    _source_texture,
     Array<RHIResource*>&&           _deferred_releases,
-    uint64                          _timeline
+    uint64                          _timeline,
+    PresentationCompletionTicket    _presentation_completion,
+    VkFence                         _wsi_completion_fence,
+    bool                            _wsi_enqueued,
+    bool                            _uses_present_fence
 ) noexcept {
     try {
         if (!_gpu_submitted &&
@@ -8395,7 +8604,11 @@ void VkCommandQueue::CommitPresentCompletion(
             std::move(_presentor),
             std::move(_swapchain),
             std::move(_source_texture),
-            std::move(_deferred_releases)
+            std::move(_deferred_releases),
+            std::move(_presentation_completion),
+            _wsi_completion_fence,
+            _wsi_enqueued,
+            _uses_present_fence
         );
         retirement_enqueued_serial = retirement_serial;
     } catch (...) {
@@ -8403,6 +8616,202 @@ void VkCommandQueue::CommitPresentCompletion(
         std::terminate();
     }
     queue_cv.notify_one();
+}
+
+bool VkCommandQueue::EnqueuePresentationCompletionProbeForTesting(
+    SwapchainRef                 _swapchain,
+    PresentationCompletionTicket _completion,
+    bool                         _uses_present_fence
+) {
+    if (queue.GetType() != EQueueType::Graphics ||
+        !_swapchain || !_completion.IsValid()) {
+        return false;
+    }
+    const PresentationCompletionStateRef state =
+        _swapchain->GetPresentationCompletionState();
+    if (!state ||
+        state->GetStateInstanceId() !=
+            _completion.GetIdentity().state_instance_id ||
+        (_uses_present_fence &&
+         g_scripted_present_fence_status_override.load(
+             std::memory_order_acquire
+         ) == nullptr)) {
+        return false;
+    }
+
+    try {
+        std::unique_lock<std::mutex> lock(event_mutex);
+        const uint64 retirement_serial =
+            retirement_enqueued_serial + 1;
+        event_queue.emplace_back(
+            std::in_place_type<
+                VulkanPresentationCompletionProbeForTesting>,
+            _completion.GetIssueSequence(),
+            true,
+            retirement_serial,
+            std::move(_swapchain),
+            std::move(_completion),
+            _uses_present_fence
+        );
+        retirement_enqueued_serial = retirement_serial;
+    } catch (...) {
+        return false;
+    }
+    queue_cv.notify_one();
+    return true;
+}
+
+bool VkCommandQueue::
+RegisterPresentationCompletionStateForShutdownProbeForTesting(
+    const PresentationCompletionStateRef& _state
+) {
+    if (queue.GetType() != EQueueType::Graphics || !_state ||
+        rhi_thread_enabled ||
+        !ClaimLegacyOwnership(
+            "RegisterPresentationCompletionStateForShutdownProbeForTesting"
+        )) {
+        return false;
+    }
+
+    RHIThreadRoleScope submission_owner(
+        ERHIThreadRole::Submission
+    );
+    std::unique_lock<std::mutex> lock(exec_mtx);
+    RegisterPresentationCompletionState(_state);
+    return true;
+}
+
+void VkCommandQueue::RegisterPresentationCompletionState(
+    const PresentationCompletionStateRef& _state
+) {
+    if (!_state) {
+        return;
+    }
+    assert(
+        GetCurrentRHIThreadRole() == ERHIThreadRole::Submission &&
+        "Presentation state registration belongs to the Submission owner"
+    );
+
+    std::erase_if(
+        active_presentation_completion_states,
+        [](const std::weak_ptr<PresentationCompletionState>& weak_state) {
+            const PresentationCompletionStateRef state =
+                weak_state.lock();
+            return !state || !state->HasOutstanding();
+        }
+    );
+    const bool already_registered = std::ranges::any_of(
+        active_presentation_completion_states,
+        [&_state](
+            const std::weak_ptr<PresentationCompletionState>& weak_state
+        ) {
+            return weak_state.lock() == _state;
+        }
+    );
+    if (!already_registered) {
+        active_presentation_completion_states.emplace_back(_state);
+    }
+}
+
+PresentationDrainPoint VkCommandQueue::FreezePresentationDrain(
+    const RHIPresentationDrainTarget& _target
+) {
+    assert(
+        GetCurrentRHIThreadRole() == ERHIThreadRole::Submission &&
+        "Presentation drain frontier belongs to the Submission owner"
+    );
+    if (!_target.IsValid() ||
+        _target.swapchain->GetPresentationCompletionState() !=
+            _target.completion_state) {
+        return {};
+    }
+
+    PresentationDrainPoint point = _target.completion_state->Freeze(
+        _target.presentation_epoch,
+        _target.drawable_generation
+    );
+    ResolvePresentationQueueIdleFallback(point);
+    return point;
+}
+
+Array<PresentationDrainPoint>
+VkCommandQueue::FreezeAllPresentationDrains() {
+    assert(
+        GetCurrentRHIThreadRole() == ERHIThreadRole::Submission &&
+        "Global Presentation frontier belongs to the Submission owner"
+    );
+    std::erase_if(
+        active_presentation_completion_states,
+        [](const std::weak_ptr<PresentationCompletionState>& weak_state) {
+            const PresentationCompletionStateRef state =
+                weak_state.lock();
+            return !state || !state->HasOutstanding();
+        }
+    );
+
+    Array<PresentationDrainPoint> points{};
+    points.reserve(active_presentation_completion_states.size());
+    bool requires_queue_idle = false;
+    for (const std::weak_ptr<PresentationCompletionState>& weak_state :
+         active_presentation_completion_states) {
+        const PresentationCompletionStateRef state =
+            weak_state.lock();
+        if (!state) {
+            continue;
+        }
+        PresentationDrainPoint point = state->Freeze();
+        requires_queue_idle =
+            state->RequiresQueueIdle(point) || requires_queue_idle;
+        points.emplace_back(std::move(point));
+    }
+
+    if (requires_queue_idle && !vk_device.IsFaulted()) {
+        const VkQueue present_queue = vk_device.GetPresentQueue();
+        const VkResult result = vk_device.WaitQueueIdle(
+            present_queue,
+            VulkanOperationContext{
+                .operation  = EVulkanFaultOperation::QueueWaitIdle,
+                .queue_type = EQueueType::Graphics,
+                .queue      = present_queue,
+            }
+        );
+        if (result == VK_SUCCESS) {
+            for (const PresentationDrainPoint& point : points) {
+                if (point.IsValid()) {
+                    point.GetState()->ResolveQueueIdle(point);
+                }
+            }
+        }
+    }
+    return points;
+}
+
+void VkCommandQueue::ResolvePresentationQueueIdleFallback(
+    const PresentationDrainPoint& _point
+) {
+    if (!_point.IsValid() ||
+        !_point.GetState()->RequiresQueueIdle(_point) ||
+        vk_device.IsFaulted()) {
+        return;
+    }
+    assert(
+        GetCurrentRHIThreadRole() == ERHIThreadRole::Submission &&
+        "WSI queue-idle fallback belongs to the Submission owner"
+    );
+
+    const VkQueue present_queue = vk_device.GetPresentQueue();
+    const VkResult result = vk_device.WaitQueueIdle(
+        present_queue,
+        VulkanOperationContext{
+            .operation  = EVulkanFaultOperation::QueueWaitIdle,
+            .queue_type = EQueueType::Graphics,
+            .queue      = present_queue,
+            .timeline   = _point.GetThroughIssueSequence(),
+        }
+    );
+    if (result == VK_SUCCESS) {
+        _point.GetState()->ResolveQueueIdle(_point);
+    }
 }
 
 void VkCommandQueue::Sync() {
@@ -9110,6 +9519,187 @@ void VkCommandQueue::RhiThreadMain() {
     LOG_INFO("[Threading] RHIThread id = {} stopped", Platform::GetCurrentThreadID());
 }
 
+void VkCommandQueue::FinalizePresentRetirement(
+    VulkanPresentCompletionBatch& _batch,
+    bool                          _gpu_success,
+    bool                          _release_safe
+) noexcept {
+    assert(
+        GetCurrentRHIThreadRole() == ERHIThreadRole::Completion &&
+        "Present retirement belongs to the Completion owner"
+    );
+
+    PresentationCompletionStateRef completion_state{};
+    if (_batch.swapchain) {
+        completion_state =
+            _batch.swapchain->GetPresentationCompletionState();
+    }
+    PresentationCompletionTicket completion_ticket =
+        _batch.presentation_completion;
+
+    if (_batch.presentor) {
+        bool recycle_presentor = false;
+        if (_batch.presentor_state ==
+                EVulkanPresentorRetirementState::Submitted &&
+            _gpu_success && !vk_device.IsFaulted()) {
+            recycle_presentor =
+                _batch.presentor->CompleteSuccess() &&
+                _batch.presentor->Reset();
+        } else if (
+            _batch.presentor_state ==
+                EVulkanPresentorRetirementState::Unused &&
+            _release_safe && !vk_device.IsFaulted()
+        ) {
+            // No native command buffer was begun.
+            recycle_presentor = true;
+        }
+
+        if (recycle_presentor && !vk_device.IsFaulted()) {
+            presentors.Push(_batch.presentor.release());
+        } else {
+            vk_device.RecordAllocatorQuarantine();
+            vk_device.RecordSkippedCommandPoolReset();
+            presentor_quarantine.emplace_back(
+                std::move(_batch.presentor)
+            );
+        }
+    }
+
+    if (_gpu_success || _release_safe) {
+        for (auto* resource : _batch.deferred_releases) {
+            MoerDelete(resource);
+        }
+    } else {
+        for (auto* resource : _batch.deferred_releases) {
+            vk_device.EnqueueDeferredRelease(resource);
+        }
+    }
+    _batch.deferred_releases.clear();
+
+    // No code below this point may observe the native Present fence or touch
+    // retained Present resources. Drop strong resource ownership before
+    // publishing the task-local retirement point to the Render owner.
+    _batch.source_texture        = nullptr;
+    _batch.swapchain             = nullptr;
+    _batch.wsi_completion_fence  = VK_NULL_HANDLE;
+    _batch.wsi_enqueued          = false;
+    _batch.uses_present_fence    = false;
+
+    if (completion_ticket.IsValid()) {
+        if (!completion_state ||
+            !completion_state->PublishRetired(completion_ticket)) {
+            std::terminate();
+        }
+        _batch.presentation_completion = {};
+    }
+}
+
+bool VkCommandQueue::TryPollPresentRetirement(
+    PendingPresentRetirement& _pending
+) noexcept {
+    assert(
+        GetCurrentRHIThreadRole() == ERHIThreadRole::Completion &&
+        "Present fence observation belongs to the Completion owner"
+    );
+
+    VulkanPresentCompletionBatch& batch = _pending.batch;
+    if (!batch.presentation_completion.IsValid() ||
+        !batch.swapchain) {
+        std::terminate();
+    }
+    const PresentationCompletionStateRef completion_state =
+        batch.swapchain->GetPresentationCompletionState();
+    if (!completion_state) {
+        std::terminate();
+    }
+
+    const auto fail_wsi = [&](VkResult _result) {
+        VulkanOperationContext fault_context = batch.context;
+        fault_context.operation = EVulkanFaultOperation::PresentFenceWait;
+        fault_context.queue     = vk_device.GetPresentQueue();
+        fault_context.timeline =
+            batch.presentation_completion.GetIssueSequence();
+        if (_result == VK_SUCCESS) {
+            _result = VK_ERROR_UNKNOWN;
+        }
+        vk_device.TryLatchFirstFault(
+            fault_context, _result, false, false, true
+        );
+        if (!completion_state->MarkWsiFailed(
+                batch.presentation_completion
+            )) {
+            std::terminate();
+        }
+        FinalizePresentRetirement(batch, false, false);
+    };
+
+    if (vk_device.IsFaulted()) {
+        const VkResult fault_result =
+            vk_device.GetFirstFaultResult() == VK_SUCCESS ?
+                VK_ERROR_DEVICE_LOST :
+                vk_device.GetFirstFaultResult();
+        fail_wsi(fault_result);
+        return true;
+    }
+
+    if (!batch.uses_present_fence) {
+        if (!completion_state->WaitForWsi(
+                batch.presentation_completion,
+                std::chrono::nanoseconds::zero()
+            )) {
+            return false;
+        }
+        FinalizePresentRetirement(
+            batch, _pending.gpu_success, _pending.release_safe
+        );
+        return true;
+    }
+
+    const VulkanScriptedPresentFenceStatusOverrideForTesting*
+        scripted_fence_status =
+            g_scripted_present_fence_status_override.load(
+                std::memory_order_acquire
+            );
+    VkResult fence_status = VK_ERROR_UNKNOWN;
+    if (batch.scripted_fence_status_allowed &&
+        scripted_fence_status != nullptr) {
+        fence_status = scripted_fence_status->callback(
+            scripted_fence_status->context,
+            batch.presentation_completion.GetIssueSequence()
+        );
+    } else {
+        if (batch.wsi_completion_fence == VK_NULL_HANDLE) {
+            fail_wsi(VK_ERROR_UNKNOWN);
+            return true;
+        }
+        VulkanOperationContext fence_context = batch.context;
+        fence_context.operation =
+            EVulkanFaultOperation::PresentFenceWait;
+        fence_context.queue = vk_device.GetPresentQueue();
+        fence_context.timeline =
+            batch.presentation_completion.GetIssueSequence();
+        fence_status = vk_device.GetFenceStatus(
+            batch.wsi_completion_fence, fence_context
+        );
+    }
+    if (fence_status == VK_NOT_READY) {
+        return false;
+    }
+    if (fence_status != VK_SUCCESS) {
+        fail_wsi(fence_status);
+        return true;
+    }
+    if (!completion_state->MarkWsiComplete(
+            batch.presentation_completion
+        )) {
+        std::terminate();
+    }
+    FinalizePresentRetirement(
+        batch, _pending.gpu_success, _pending.release_safe
+    );
+    return true;
+}
+
 void VkCommandQueue::CompletionThreadMain() {
     Platform::SetCurrentThreadName(
         queue.GetType() == EQueueType::Graphics ? "Vulkan Gfx Completion" : "Vulkan Compute Completion"
@@ -9118,15 +9708,39 @@ void VkCommandQueue::CompletionThreadMain() {
 
     bool batch_gpu_success = false;
     bool batch_release_safe = false;
+    Array<PendingPresentRetirement> pending_present_retirements{};
     while (true) {
+        for (auto pending = pending_present_retirements.begin();
+             pending != pending_present_retirements.end();) {
+            if (TryPollPresentRetirement(*pending)) {
+                pending =
+                    pending_present_retirements.erase(pending);
+            } else {
+                ++pending;
+            }
+        }
+
         std::optional<QueueEvent> evt;
         {
             std::unique_lock<std::mutex> lock(event_mutex);
-            queue_cv.wait(lock, [this]() {
-                return !completion_worker_running || !event_queue.empty();
-            });
-            if (!completion_worker_running && event_queue.empty()) {
+            if (pending_present_retirements.empty()) {
+                queue_cv.wait(lock, [this]() {
+                    return !completion_worker_running ||
+                           !event_queue.empty();
+                });
+            } else {
+                queue_cv.wait_for(
+                    lock,
+                    std::chrono::milliseconds(1),
+                    [this]() { return !event_queue.empty(); }
+                );
+            }
+            if (!completion_worker_running && event_queue.empty() &&
+                pending_present_retirements.empty()) {
                 break;
+            }
+            if (event_queue.empty()) {
+                continue;
             }
 
             evt.emplace(std::move(event_queue.front()));
@@ -9440,7 +10054,11 @@ void VkCommandQueue::CompletionThreadMain() {
                     }
                     _batch.deferred_releases.clear();
                 },
-                [this, event_timeline, &batch_gpu_success, &batch_release_safe](
+                [this,
+                 event_timeline,
+                 &batch_gpu_success,
+                 &batch_release_safe,
+                 &pending_present_retirements](
                     VulkanPresentCompletionBatch& _batch
                 ) {
                     batch_gpu_success = false;
@@ -9493,45 +10111,123 @@ void VkCommandQueue::CompletionThreadMain() {
                         timeline->Reject(event_timeline);
                     }
 
-                    if (_batch.presentor) {
-                        bool recycle_presentor = false;
-                        if (_batch.presentor_state ==
-                                EVulkanPresentorRetirementState::Submitted &&
-                            batch_gpu_success && !vk_device.IsFaulted()) {
-                            recycle_presentor =
-                                _batch.presentor->CompleteSuccess() &&
-                                _batch.presentor->Reset();
-                        } else if (
-                            _batch.presentor_state ==
-                                EVulkanPresentorRetirementState::Unused &&
-                            batch_release_safe && !vk_device.IsFaulted()
-                        ) {
-                            // No command buffer was begun, matching the
-                            // previous acquire-retry fast recycle path.
-                            recycle_presentor = true;
+                    PresentationCompletionStateRef completion_state{};
+                    if (_batch.presentation_completion.IsValid()) {
+                        if (!_batch.swapchain) {
+                            std::terminate();
                         }
+                        completion_state =
+                            _batch.swapchain->
+                                GetPresentationCompletionState();
+                        if (!completion_state ||
+                            !completion_state->MarkGpuComplete(
+                                _batch.presentation_completion
+                            )) {
+                            std::terminate();
+                        }
+                    }
 
-                        if (recycle_presentor && !vk_device.IsFaulted()) {
-                            presentors.Push(_batch.presentor.release());
-                        } else {
-                            vk_device.RecordAllocatorQuarantine();
-                            vk_device.RecordSkippedCommandPoolReset();
-                            presentor_quarantine.emplace_back(
-                                std::move(_batch.presentor)
+                    if (!batch_gpu_success &&
+                        _batch.presentation_completion.IsValid()) {
+                        if (_batch.wsi_enqueued &&
+                            _batch.uses_present_fence &&
+                            !vk_device.IsFaulted()) {
+                            VulkanOperationContext fault_context =
+                                _batch.context;
+                            fault_context.operation =
+                                EVulkanFaultOperation::
+                                    TimelineHostWait;
+                            vk_device.TryLatchFirstFault(
+                                fault_context,
+                                completion_result == VK_SUCCESS ?
+                                    VK_ERROR_UNKNOWN :
+                                    completion_result,
+                                false,
+                                false,
+                                true
                             );
                         }
+                        if (!completion_state->MarkWsiFailed(
+                                _batch.presentation_completion
+                            )) {
+                            std::terminate();
+                        }
+                        FinalizePresentRetirement(
+                            _batch, false, false
+                        );
+                        return;
                     }
 
-                    if (batch_gpu_success || batch_release_safe) {
-                        for (auto* resource : _batch.deferred_releases) {
-                            MoerDelete(resource);
-                        }
-                    } else {
-                        for (auto* resource : _batch.deferred_releases) {
-                            vk_device.EnqueueDeferredRelease(resource);
+                    if (_batch.presentation_completion.IsValid() &&
+                        _batch.wsi_enqueued) {
+                        if (_batch.uses_present_fence ||
+                            !completion_state->WaitForWsi(
+                                _batch.presentation_completion,
+                                std::chrono::nanoseconds::zero()
+                            )) {
+                            pending_present_retirements.emplace_back(
+                                std::move(_batch),
+                                batch_gpu_success,
+                                batch_release_safe
+                            );
+                            return;
                         }
                     }
-                    _batch.deferred_releases.clear();
+
+                    FinalizePresentRetirement(
+                        _batch,
+                        batch_gpu_success,
+                        batch_release_safe
+                    );
+                },
+                [this, &pending_present_retirements](
+                    VulkanPresentationCompletionProbeForTesting& _probe
+                ) {
+                    if (!_probe.swapchain ||
+                        !_probe.completion.IsValid()) {
+                        std::terminate();
+                    }
+                    const PresentationCompletionStateRef state =
+                        _probe.swapchain->
+                            GetPresentationCompletionState();
+                    if (!state ||
+                        !state->MarkGpuComplete(
+                            _probe.completion
+                        )) {
+                        std::terminate();
+                    }
+
+                    const uint64 issue_sequence =
+                        _probe.completion.GetIssueSequence();
+                    VulkanPresentCompletionBatch completion_batch{
+                        VulkanOperationResult{},
+                        VulkanOperationContext{
+                            .operation =
+                                EVulkanFaultOperation::
+                                    PresentFenceWait,
+                            .queue_type = EQueueType::Graphics,
+                            .queue = vk_device.GetPresentQueue(),
+                            .timeline = issue_sequence,
+                            .work_serial = issue_sequence,
+                        },
+                        false,
+                        false,
+                        EVulkanPresentorRetirementState::Unused,
+                        UniquePtr<VulkanPresentor>{},
+                        std::move(_probe.swapchain),
+                        TextureRef{},
+                        Array<RHIResource*>{},
+                        std::move(_probe.completion),
+                        VK_NULL_HANDLE,
+                        true,
+                        _probe.uses_present_fence,
+                        true
+                    };
+                    pending_present_retirements.emplace_back(
+                        std::move(completion_batch),
+                        true,
+                        true
+                    );
                 },
                 [this, &batch_gpu_success](UniquePtr<VulkanAllocator>& _allocator) {
                     if (batch_gpu_success && !vk_device.IsFaulted()) {

--- a/source/runtime/render/rhi/vulkan/VulkanQueue.h
+++ b/source/runtime/render/rhi/vulkan/VulkanQueue.h
@@ -28,6 +28,7 @@
 namespace Moer::Render {
 class CmdReorderer;
 struct FunctionTable;
+struct RHIPresentationDrainTarget;
 
 static constexpr uint s_queue_max_frame_in_flight = 3;
 static constexpr uint s_query_max_storage         = 8 * 64;
@@ -423,7 +424,12 @@ struct VulkanPresentCompletionBatch {
         UniquePtr<VulkanPresentor>&&       _presentor,
         SwapchainRef&&                     _swapchain,
         TextureRef&&                       _source_texture,
-        Array<RHIResource*>&&              _deferred_releases
+        Array<RHIResource*>&&              _deferred_releases,
+        PresentationCompletionTicket       _presentation_completion,
+        VkFence                            _wsi_completion_fence,
+        bool                               _wsi_enqueued,
+        bool                               _uses_present_fence,
+        bool _scripted_fence_status_allowed = false
     ) noexcept :
         outcome(_outcome),
         context(_context),
@@ -433,7 +439,16 @@ struct VulkanPresentCompletionBatch {
         presentor(std::move(_presentor)),
         swapchain(std::move(_swapchain)),
         source_texture(std::move(_source_texture)),
-        deferred_releases(std::move(_deferred_releases)) {}
+        deferred_releases(std::move(_deferred_releases)),
+        presentation_completion(
+            std::move(_presentation_completion)
+        ),
+        wsi_completion_fence(_wsi_completion_fence),
+        wsi_enqueued(_wsi_enqueued),
+        uses_present_fence(_uses_present_fence),
+        scripted_fence_status_allowed(
+            _scripted_fence_status_allowed
+        ) {}
 
     VulkanPresentCompletionBatch(const VulkanPresentCompletionBatch&) = delete;
     VulkanPresentCompletionBatch& operator=(const VulkanPresentCompletionBatch&) = delete;
@@ -451,6 +466,26 @@ struct VulkanPresentCompletionBatch {
     SwapchainRef                    swapchain;
     TextureRef                      source_texture;
     Array<RHIResource*>             deferred_releases;
+    PresentationCompletionTicket    presentation_completion{};
+    VkFence                         wsi_completion_fence{VK_NULL_HANDLE};
+    bool                            wsi_enqueued{false};
+    bool                            uses_present_fence{false};
+    bool                            scripted_fence_status_allowed{false};
+};
+
+struct VulkanPresentationCompletionProbeForTesting {
+    VulkanPresentationCompletionProbeForTesting(
+        SwapchainRef                 _swapchain,
+        PresentationCompletionTicket _completion,
+        bool                         _uses_present_fence
+    ) noexcept :
+        swapchain(std::move(_swapchain)),
+        completion(std::move(_completion)),
+        uses_present_fence(_uses_present_fence) {}
+
+    SwapchainRef                 swapchain{};
+    PresentationCompletionTicket completion{};
+    bool                         uses_present_fence{false};
 };
 
 struct VulkanCompletionMarker {};
@@ -461,6 +496,7 @@ public:
         VulkanSubmissionEvent,
         VulkanSubmitCompletionBatch,
         VulkanPresentCompletionBatch,
+        VulkanPresentationCompletionProbeForTesting,
         UniquePtr<VulkanAllocator>,
         VulkanAllocatorBatch,
         VulkanDescriptorPushLease,
@@ -596,6 +632,16 @@ public:
     ) override;
     void        Sync() override;
     ProfileData GetProfilerEntry() override;
+    [[nodiscard]] RENDER_API bool
+    EnqueuePresentationCompletionProbeForTesting(
+        SwapchainRef                 _swapchain,
+        PresentationCompletionTicket _completion,
+        bool                         _uses_present_fence
+    );
+    [[nodiscard]] RENDER_API bool
+    RegisterPresentationCompletionStateForShutdownProbeForTesting(
+        const PresentationCompletionStateRef& _state
+    );
 
     void SetQueueSubmitMutex(std::mutex* _mutex) { queue.SetSubmitMutex(_mutex); }
 
@@ -875,7 +921,46 @@ private:
         SwapchainRef&&                     _swapchain,
         TextureRef&&                       _source_texture,
         Array<RHIResource*>&&              _deferred_releases,
-        uint64                             _timeline
+        uint64                             _timeline,
+        PresentationCompletionTicket       _presentation_completion,
+        VkFence                            _wsi_completion_fence,
+        bool                               _wsi_enqueued,
+        bool                               _uses_present_fence
+    ) noexcept;
+    void                       RegisterPresentationCompletionState(
+        const PresentationCompletionStateRef& _state
+    );
+    [[nodiscard]] PresentationDrainPoint FreezePresentationDrain(
+        const RHIPresentationDrainTarget& _target
+    );
+    [[nodiscard]] Array<PresentationDrainPoint>
+    FreezeAllPresentationDrains();
+    void                       ResolvePresentationQueueIdleFallback(
+        const PresentationDrainPoint& _point
+    );
+
+    struct PendingPresentRetirement {
+        VulkanPresentCompletionBatch batch;
+        bool                         gpu_success{false};
+        bool                         release_safe{false};
+
+        PendingPresentRetirement(
+            VulkanPresentCompletionBatch&& _batch,
+            bool                            _gpu_success,
+            bool                            _release_safe
+        ) noexcept :
+            batch(std::move(_batch)),
+            gpu_success(_gpu_success),
+            release_safe(_release_safe) {}
+    };
+
+    [[nodiscard]] bool TryPollPresentRetirement(
+        PendingPresentRetirement& _pending
+    ) noexcept;
+    void                       FinalizePresentRetirement(
+        VulkanPresentCompletionBatch& _batch,
+        bool                          _gpu_success,
+        bool                          _release_safe
     ) noexcept;
     UniquePtr<VulkanAllocator> GetAllocator();
     UniquePtr<VulkanPresentor> GetPresentor();
@@ -958,6 +1043,8 @@ private:
         EExecutionOwnershipMode::Unclaimed
     };
     std::atomic_bool runtime_dependency_waits_enabled{true};
+    Array<std::weak_ptr<PresentationCompletionState>>
+                       active_presentation_completion_states{};
     std::jthread completion_thread;
     std::jthread rhi_thread;
     Array<UniquePtr<VulkanAllocator>> allocator_quarantine;

--- a/source/runtime/render/rhi/vulkan/VulkanSubmissionDiagnostics.h
+++ b/source/runtime/render/rhi/vulkan/VulkanSubmissionDiagnostics.h
@@ -317,6 +317,57 @@ RemoveVulkanQueueLocalSyncWaitObserver(
     const VulkanQueueLocalSyncWaitObserver* _observer
 ) noexcept;
 
+struct VulkanQueueIdleWaitEvent {
+    VulkanOperationContext context{};
+    uint64                 native_queue_handle{0};
+    uint32                 thread_id{0};
+    ERHIThreadRole         thread_role{ERHIThreadRole::Unknown};
+};
+
+using VulkanQueueIdleWaitCallback =
+    void (*)(void*, const VulkanQueueIdleWaitEvent&) noexcept;
+
+struct VulkanQueueIdleWaitObserver {
+    void*                       context{nullptr};
+    VulkanQueueIdleWaitCallback callback{nullptr};
+};
+
+// Fires after Vulkan queue synchronization has been acquired and immediately
+// before vkQueueWaitIdle. Presentation fallback tests use this seam to prove
+// the native wait remains owned by the sole Submission thread.
+[[nodiscard]] RENDER_API bool
+TryInstallVulkanQueueIdleWaitObserver(
+    const VulkanQueueIdleWaitObserver* _observer
+) noexcept;
+[[nodiscard]] RENDER_API bool
+RemoveVulkanQueueIdleWaitObserver(
+    const VulkanQueueIdleWaitObserver* _observer
+) noexcept;
+
+void NotifyVulkanQueueIdleWait(
+    const VulkanOperationContext& _context
+) noexcept;
+
+using VulkanScriptedPresentFenceStatusCallback =
+    VkResult (*)(void*, uint64) noexcept;
+
+struct VulkanScriptedPresentFenceStatusOverrideForTesting {
+    void*                                    context{nullptr};
+    VulkanScriptedPresentFenceStatusCallback callback{nullptr};
+};
+
+// Deterministic WSI-fence observation seam. It is valid only for synthetic
+// Presentation completion probes; production Present batches always query
+// their native VkFence when no override is installed.
+[[nodiscard]] RENDER_API bool
+TryInstallVulkanScriptedPresentFenceStatusOverrideForTesting(
+    const VulkanScriptedPresentFenceStatusOverrideForTesting* _override
+) noexcept;
+[[nodiscard]] RENDER_API bool
+RemoveVulkanScriptedPresentFenceStatusOverrideForTesting(
+    const VulkanScriptedPresentFenceStatusOverrideForTesting* _override
+) noexcept;
+
 using VulkanScriptedQueryPreparationCallback =
     VkResult (*)(void*, EQueueType, uint64, uint32) noexcept;
 

--- a/source/runtime/render/rhi/vulkan/VulkanSubmissionExecutor.cpp
+++ b/source/runtime/render/rhi/vulkan/VulkanSubmissionExecutor.cpp
@@ -1273,17 +1273,26 @@ VulkanSubmissionExecutor::~VulkanSubmissionExecutor() {
     }
 }
 
-void VulkanSubmissionExecutor::Completion::Signal() {
+void VulkanSubmissionExecutor::Completion::Signal(
+    std::exception_ptr _failure
+) {
     {
         std::lock_guard lock(mutex);
+        failure = std::move(_failure);
         done = true;
     }
     cv.notify_all();
 }
 
 void VulkanSubmissionExecutor::Completion::Wait() {
+    std::exception_ptr wait_failure{};
     std::unique_lock lock(mutex);
     cv.wait(lock, [this] { return done; });
+    wait_failure = failure;
+    lock.unlock();
+    if (wait_failure) {
+        std::rethrow_exception(wait_failure);
+    }
 }
 
 VulkanSubmissionExecutor::BatchRejectionPublication::
@@ -1627,6 +1636,39 @@ GraphEventRef VulkanSubmissionExecutor::Sync(ERHISyncDepth _depth) {
     return MakeCompletedEvent();
 }
 
+GraphEventRef VulkanSubmissionExecutor::DrainPresentation(
+    RHIPresentationDrainTarget _target
+) {
+    if (!_target.IsValid()) {
+        throw std::invalid_argument(
+            "invalid Vulkan Presentation drain target"
+        );
+    }
+
+    auto completion = std::make_shared<Completion>();
+    {
+        std::lock_guard lock(mutex);
+        if (!accepting) {
+            throw std::runtime_error(
+                "Vulkan Presentation drain rejected during shutdown"
+            );
+        }
+        requests.emplace_back(Request{
+            .kind                = ERequestKind::PresentationDrain,
+            .sync_depth          = ERHISyncDepth::Present,
+            .presentation_target =
+                std::optional<RHIPresentationDrainTarget>(
+                    std::move(_target)
+                ),
+            .completion          = completion,
+        });
+    }
+    cv.notify_one();
+    NotifyVulkanBackendSyncWait();
+    completion->Wait();
+    return MakeCompletedEvent();
+}
+
 void VulkanSubmissionExecutor::Flush(ERHIFlushDepth) {
     // Enqueue publishes directly to the runtime FIFO and wakes its owner.
     // SubmitGPU intentionally does not wait; Sync is the explicit host boundary.
@@ -1732,6 +1774,7 @@ void VulkanSubmissionExecutor::RunExecutor() {
         }
 
         BatchExceptionState exception_state{};
+        std::exception_ptr  request_failure{};
         const VulkanSubmissionDetail::WorkerRequestDispatchResult dispatch_result =
             VulkanSubmissionDetail::DispatchWorkerRequestNoexcept(
                 request.kind,
@@ -1740,7 +1783,19 @@ void VulkanSubmissionExecutor::RunExecutor() {
                         ProcessBatch(request.batch, exception_state);
                     } else {
                         DrainPipelineBatches();
-                        ProcessSync(request.sync_depth);
+                        if (request.kind ==
+                            ERequestKind::PresentationDrain) {
+                            if (!request.presentation_target.has_value()) {
+                                throw std::runtime_error(
+                                    "Presentation drain request lost its target"
+                                );
+                            }
+                            ProcessPresentationDrain(
+                                std::move(*request.presentation_target)
+                            );
+                        } else {
+                            ProcessSync(request.sync_depth);
+                        }
                     }
                 },
                 [&] {
@@ -1766,9 +1821,25 @@ void VulkanSubmissionExecutor::RunExecutor() {
                         exception_state.rejection_publication
                     );
                 },
-                [&] { CompleteRequest(request.completion); },
+                [&] {
+                    CompleteRequest(
+                        request.completion,
+                        request.kind ==
+                                ERequestKind::PresentationDrain ?
+                            request_failure :
+                            std::exception_ptr{}
+                    );
+                },
                 [&](VulkanSubmissionDetail::EWorkerRequestFailurePhase _phase,
                     const std::exception_ptr& _exception) {
+                    if (request.kind ==
+                            ERequestKind::PresentationDrain &&
+                        _phase ==
+                            VulkanSubmissionDetail::
+                                EWorkerRequestFailurePhase::Process &&
+                        !request_failure) {
+                        request_failure = _exception;
+                    }
                     LatchHardFailure(
                         StreamPosition{
                             request.batch.sequence,
@@ -2464,6 +2535,9 @@ void VulkanSubmissionExecutor::ReportRequestFailure(
             break;
         case ERequestKind::Sync:
             kind_name = "Sync";
+            break;
+        case ERequestKind::PresentationDrain:
+            kind_name = "PresentationDrain";
             break;
         case ERequestKind::Stop:
             kind_name = "Stop";
@@ -4228,7 +4302,8 @@ void VulkanSubmissionExecutor::ProcessBatch(
 }
 
 void VulkanSubmissionExecutor::ProcessSync(ERHISyncDepth _depth) {
-    ExecuteOnSubmissionThread([this, _depth] {
+    Array<PresentationDrainPoint> presentation_points =
+        ExecuteOnSubmissionThread([this, _depth] {
         LOG_INFO(
             "[RHIExecutor][Vulkan] sync begin depth={} gfx={} compute={} copy_timeline={}",
             static_cast<uint32>(_depth),
@@ -4242,7 +4317,21 @@ void VulkanSubmissionExecutor::ProcessSync(ERHISyncDepth _depth) {
         RenderDevice::Get().GetCommandQueue(EQueueType::Graphics).Sync();
         RenderDevice::Get().GetCommandQueue(EQueueType::Compute).Sync();
         RenderDevice::Get().GetCopyQueue().Sync(last_copy_timeline);
+        if (_depth == ERHISyncDepth::Present) {
+            auto& graphics_queue = static_cast<VkCommandQueue&>(
+                RenderDevice::Get().GetCommandQueue(
+                    EQueueType::Graphics
+                )
+            );
+            return graphics_queue.FreezeAllPresentationDrains();
+        }
+        return Array<PresentationDrainPoint>{};
     });
+    for (const PresentationDrainPoint& point : presentation_points) {
+        if (point.IsValid()) {
+            point.GetState()->WaitRetired(point);
+        }
+    }
     gpu_frontier.fill(std::nullopt);
     async_scope_entry_frontier.fill(std::nullopt);
     async_scope_seen_queues.fill(false);
@@ -4252,11 +4341,33 @@ void VulkanSubmissionExecutor::ProcessSync(ERHISyncDepth _depth) {
     LOG_INFO("[RHIExecutor][Vulkan] sync complete depth={}", static_cast<uint32>(_depth));
 }
 
+void VulkanSubmissionExecutor::ProcessPresentationDrain(
+    RHIPresentationDrainTarget _target
+) {
+    PresentationDrainPoint point = ExecuteOnSubmissionThread(
+        [target = std::move(_target)]() mutable {
+            auto& graphics_queue = static_cast<VkCommandQueue&>(
+                RenderDevice::Get().GetCommandQueue(
+                    EQueueType::Graphics
+                )
+            );
+            return graphics_queue.FreezePresentationDrain(target);
+        }
+    );
+    if (!point.IsValid()) {
+        throw std::runtime_error(
+            "Submission owner could not freeze the requested Presentation frontier"
+        );
+    }
+    point.GetState()->WaitRetired(point);
+}
+
 void VulkanSubmissionExecutor::CompleteRequest(
-    const std::shared_ptr<Completion>& _completion
+    const std::shared_ptr<Completion>& _completion,
+    std::exception_ptr                 _failure
 ) {
     if (_completion) {
-        _completion->Signal();
+        _completion->Signal(std::move(_failure));
     }
 }
 

--- a/source/runtime/render/rhi/vulkan/VulkanSubmissionExecutor.h
+++ b/source/runtime/render/rhi/vulkan/VulkanSubmissionExecutor.h
@@ -35,17 +35,21 @@ public:
 
     void          Enqueue(RHIBackendSubmissionBatch&& _batch) override;
     GraphEventRef Sync(ERHISyncDepth _depth = ERHISyncDepth::RHI) override;
+    GraphEventRef DrainPresentation(
+        RHIPresentationDrainTarget _target
+    ) override;
     void          Flush(ERHIFlushDepth _depth = ERHIFlushDepth::SubmitGPU) override;
     void          BeginShutdown() noexcept override;
     void          ShutDown() override;
 
 private:
     struct Completion {
-        void Signal();
+        void Signal(std::exception_ptr _failure = {});
         void Wait();
 
         std::mutex              mutex{};
         std::condition_variable cv{};
+        std::exception_ptr      failure{};
         bool                    done{false};
     };
 
@@ -57,6 +61,8 @@ private:
         ERequestKind                kind{ERequestKind::Submit};
         RHIBackendSubmissionBatch   batch{};
         ERHISyncDepth               sync_depth{ERHISyncDepth::RHI};
+        std::optional<RHIPresentationDrainTarget>
+                                    presentation_target{};
         std::shared_ptr<Completion> completion{};
     };
 
@@ -264,6 +270,9 @@ private:
         int32*         _result = nullptr
     ) const noexcept;
     void ProcessSync(ERHISyncDepth _depth);
+    void ProcessPresentationDrain(
+        RHIPresentationDrainTarget _target
+    );
     void RejectBatch(
         RHIBackendSubmissionBatch&& _batch,
         int32                       _result,
@@ -274,7 +283,10 @@ private:
         std::shared_ptr<BatchRejectionPublication>
             _rejection_publication = {}
     );
-    void CompleteRequest(const std::shared_ptr<Completion>& _completion);
+    void CompleteRequest(
+        const std::shared_ptr<Completion>& _completion,
+        std::exception_ptr                 _failure = {}
+    );
     void ReportRequestFailure(
         ERequestKind                                  _kind,
         VulkanSubmissionDetail::EWorkerRequestFailurePhase _phase,

--- a/source/runtime/render/rhi/vulkan/VulkanSubmissionRequestDispatch.h
+++ b/source/runtime/render/rhi/vulkan/VulkanSubmissionRequestDispatch.h
@@ -9,6 +9,7 @@ namespace Moer::Render::VulkanSubmissionDetail {
 enum class EWorkerRequestKind : uint8_t {
     Submit,
     Sync,
+    PresentationDrain,
     Stop,
 };
 

--- a/source/runtime/render/rhi/vulkan/VulkanSwapChain.cpp
+++ b/source/runtime/render/rhi/vulkan/VulkanSwapChain.cpp
@@ -182,63 +182,40 @@ ChooseSwapExtent(uint32_t* width, uint32_t* height, const VkSurfaceCapabilitiesK
 VkSwapchain::VkSwapchain(RenderDevice::Impl& _device, const SwapchainCreateInfo& _info) :
     Swapchain(),
     device(*static_cast<VulkanDevice*>(&_device)) {
-    present_threads.resize(max_frames_in_flight);
     static_cast<void>(CreateOrRecreate(_info));
 }
 bool VkSwapchain::WaitFrameInFlight() {
-    // if (image_idx < max_frames_in_flight) {
-    //     return;
-    // }
-    // auto frame_offset = image_idx % max_frames_in_flight;
-    // vkWaitForFences(device.GetDevice(), 1, &in_flight_fences[frame_offset], VK_TRUE, UINT64_MAX);
-    // vkResetFences(device.GetDevice(), 1, &in_flight_fences[frame_offset]);
-    while (!device.IsFaulted() &&
-           cur_present_cnt.load(std::memory_order_relaxed) >= max_frames_in_flight) {
-        std::this_thread::yield();
+    if (!device.HasDeviceExtension(
+            VK_EXT_SWAPCHAIN_MAINTENANCE_1_EXTENSION_NAME
+        )) {
+        return !device.IsFaulted();
     }
-    return !device.IsFaulted();
+    return PreparePresentFence(image_idx);
 }
 
-bool VkSwapchain::WaitFrameInFlight(uint64 _image_idx) {
-    // if (_image_idx < max_frames_in_flight) {
-    //     return;
-    // }
-    auto frame_offset = _image_idx % max_frames_in_flight;
-    while (!device.IsFaulted()) {
-        const VulkanOperationContext context{
-            .operation  = EVulkanFaultOperation::PresentFenceWait,
-            .queue_type = EQueueType::Graphics,
-            .queue      = device.GetPresentQueue(),
-            .timeline   = _image_idx,
-        };
-        const VkResult result = vkWaitForFences(
-            device.GetDevice(), 1, &in_flight_fences[frame_offset], VK_TRUE, 50'000'000
-        );
-        if (result == VK_TIMEOUT) {
-            continue;
-        }
-        if (result != VK_SUCCESS) {
-            device.TryLatchFirstFault(context, result);
-            if (result != VK_ERROR_DEVICE_LOST) {
-                device.EmergencyExitWithoutVulkanCleanup(context, result);
-            }
-            return false;
-        }
-        if (device.IsDeviceLost()) {
-            return false;
-        }
-        const VkResult reset_result = device.ResetFence(
-            in_flight_fences[frame_offset],
-            VulkanOperationContext{
-                .operation  = EVulkanFaultOperation::PresentFenceReset,
-                .queue_type = EQueueType::Graphics,
-                .queue      = device.GetPresentQueue(),
-                .timeline   = _image_idx,
-            }
-        );
-        return reset_result == VK_SUCCESS && !device.IsFaulted();
+PresentationCompletionTicket VkSwapchain::ReservePresentCompletion(
+    PresentationCompletionIdentity _identity
+) {
+    const PresentationCompletionStateRef& state =
+        GetPresentationCompletionState();
+    if (!state || max_frames_in_flight == 0 ||
+        present_fence_slots.empty()) {
+        return {};
     }
-    return false;
+
+    const uint32 slot_index =
+        static_cast<uint32>(image_idx % max_frames_in_flight);
+    PresentFenceSlot& slot = present_fence_slots[slot_index];
+    ++slot.generation;
+    if (slot.generation == 0) {
+        ++slot.generation;
+    }
+    _identity.state_instance_id = state->GetInstanceId();
+    return state->Reserve(
+        _identity,
+        slot_index,
+        slot.generation
+    );
 }
 
 VkFence VkSwapchain::GetInFlightFence(uint64 _index) {
@@ -297,7 +274,12 @@ bool VkSwapchain::CreateOrRecreate(const SwapchainCreateInfo& _info, bool _force
         return false;
     }
 
-    Sync();
+    // PresentationSurface owns this destructive lifecycle boundary and must
+    // complete its targeted Presentation drain before native recreation.
+    assert(
+        !GetPresentationCompletionState()->HasOutstanding() &&
+        "Swapchain recreate requires a completed targeted Presentation drain"
+    );
     if (device.IsFaulted()) {
         return false;
     }
@@ -593,7 +575,11 @@ bool VkSwapchain::CreateOrRecreate(const SwapchainCreateInfo& _info, bool _force
     }
 
     const uint new_max_frames_in_flight = std::min(max_frames_in_flight, uint(image_cnt));
-    const bool recreate_fences = in_flight_fences.size() != new_max_frames_in_flight;
+    // Every successful lifecycle transaction receives fresh unsignalled Present
+    // fences. Completion owns observation, Submission owns slot reset, and the
+    // Render owner may destroy the retired set only after its targeted drain;
+    // no caller-side reset is therefore required or allowed.
+    const bool recreate_fences = true;
     new_render_finished_fences.resize(image_cnt, VK_NULL_HANDLE);
     VkSemaphoreCreateInfo semaphore_info{VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO};
     for (uint i = 0; i < image_cnt; i++) {
@@ -688,6 +674,8 @@ bool VkSwapchain::CreateOrRecreate(const SwapchainCreateInfo& _info, bool _force
     if (recreate_fences) {
         in_flight_fences = std::move(new_in_flight_fences);
     }
+    present_fence_slots.clear();
+    present_fence_slots.resize(new_max_frames_in_flight);
     image_idx = 0;
     const bool presentation_ready = IsPresentationReady();
     if (presentation_ready) {
@@ -696,8 +684,6 @@ bool VkSwapchain::CreateOrRecreate(const SwapchainCreateInfo& _info, bool _force
     return presentation_ready;
 }
 VkSwapchain::~VkSwapchain() {
-    Sync();
-
     for (VulkanTexture* texture : swapchain_textures) {
         MoerDelete(texture);
     }
@@ -761,23 +747,35 @@ VkSwapchain::AcquireResult VkSwapchain::AquireNextImage(
     return {outcome, VK_NULL_HANDLE, UINT32_MAX, image_idx};
 }
 
-VulkanOperationResult VkSwapchain::Present(
+VkSwapchain::PresentResult VkSwapchain::Present(
     VkQueue _queue,
     uint    _index,
     uint64  _timeline,
-    uint64  _work_serial
+    uint64  _work_serial,
+    const PresentationCompletionTicket& _completion
 ) {
+    PresentResult present_result{};
+    const auto set_wsi_mode =
+        [this, &_completion](EPresentationWsiCompletionMode _mode) {
+            if (_completion.IsValid() &&
+                !GetPresentationCompletionState()->SetWsiMode(
+                    _completion, _mode
+                )) {
+                std::terminate();
+            }
+        };
     if (_index == UINT32_MAX) {
-        return {EVulkanOperationStatus::Retry, VK_NOT_READY};
+        present_result.outcome = {
+            EVulkanOperationStatus::Retry, VK_NOT_READY
+        };
+        set_wsi_mode(EPresentationWsiCompletionMode::Immediate);
+        return present_result;
     }
     VkSemaphore finished_semaphores[] = {GetRenderFinishedFence(_index)};
     // 如果启用了 VK_EXT_swapchain_maintenance1，则使用 present fence 优化队列同步；
     // 否则退回到兼容路径，不挂 VkSwapchainPresentFenceInfoEXT，避免验证层报扩展未启用。
     const bool use_present_fence =
         device.HasDeviceExtension(VK_EXT_SWAPCHAIN_MAINTENANCE_1_EXTENSION_NAME);
-    if (use_present_fence && !PreparePresentFence(image_idx)) {
-        return {EVulkanOperationStatus::Rejected, device.GetFirstFaultResult()};
-    }
 
     VkSwapchainPresentFenceInfoEXT present_fence_info{VK_STRUCTURE_TYPE_SWAPCHAIN_PRESENT_FENCE_INFO_EXT};
     if (use_present_fence) {
@@ -792,7 +790,7 @@ VulkanOperationResult VkSwapchain::Present(
     present_info.swapchainCount     = 1;
     present_info.pSwapchains        = &handle;
     present_info.pImageIndices      = &_index;
-    const VulkanOperationResult outcome = device.PresentOnQueue(
+    present_result.outcome = device.PresentOnQueue(
         _queue,
         present_info,
         VulkanOperationContext{
@@ -803,122 +801,93 @@ VulkanOperationResult VkSwapchain::Present(
             .work_serial = _work_serial,
         }
     );
-    if (use_present_fence && (outcome.result == VK_SUCCESS || outcome.result == VK_SUBOPTIMAL_KHR)) {
-        // 仅在使用 present fence 的情况下异步等待 in_flight_fences
-        EnqueuePresent(image_idx);
+    present_result.accepted =
+        present_result.outcome.result == VK_SUCCESS ||
+        present_result.outcome.result == VK_SUBOPTIMAL_KHR;
+    // Recoverable WSI errors reject the presentation request, but Vulkan
+    // still considers the associated queue operations enqueued. Keep that
+    // lifetime fact separate from the receipt-facing success bit.
+    present_result.wsi_enqueued =
+        present_result.accepted ||
+        present_result.outcome.result == VK_ERROR_OUT_OF_DATE_KHR ||
+        present_result.outcome.result == VK_ERROR_SURFACE_LOST_KHR ||
+        present_result.outcome.result ==
+            VK_ERROR_FULL_SCREEN_EXCLUSIVE_MODE_LOST_EXT;
+    present_result.uses_present_fence =
+        present_result.wsi_enqueued && use_present_fence;
+
+    if (_completion.IsValid()) {
+        // Present fences cover both accepted presentation and the queue
+        // operations retained after recoverable WSI errors.
+        if (present_result.wsi_enqueued && use_present_fence) {
+            set_wsi_mode(
+                EPresentationWsiCompletionMode::PresentFence
+            );
+            const uint32 slot_index = _completion.GetFenceSlot();
+            if (slot_index >= present_fence_slots.size() ||
+                present_fence_slots[slot_index].generation !=
+                    _completion.GetSlotGeneration()) {
+                // The native Present is already accepted. Continuing without
+                // the exact slot generation could race reset/destruction.
+                std::terminate();
+            }
+            present_fence_slots[slot_index].completion = _completion;
+            present_result.completion_fence =
+                in_flight_fences[slot_index];
+        } else if (present_result.wsi_enqueued) {
+            set_wsi_mode(
+                EPresentationWsiCompletionMode::QueueIdleFallback
+            );
+        } else {
+            set_wsi_mode(
+                present_result.outcome.status ==
+                        EVulkanOperationStatus::Faulted ?
+                    EPresentationWsiCompletionMode::Failed :
+                    EPresentationWsiCompletionMode::Immediate
+            );
+        }
     }
     ++image_idx;
-    return outcome;
-}
-
-void VkSwapchain::OnFinishPresent(uint64 _image_idx) {
-    cur_present_cnt.fetch_sub(1, std::memory_order_acq_rel);
+    return present_result;
 }
 
 bool VkSwapchain::PreparePresentFence(uint64 _present_idx) {
-    auto& thread = present_threads[_present_idx % max_frames_in_flight];
-    if (thread.joinable()) {
-        thread.join();
+    if (in_flight_fences.empty() || present_fence_slots.empty()) {
+        return false;
     }
+    const uint32 slot_index =
+        static_cast<uint32>(_present_idx % present_fence_slots.size());
+    PresentFenceSlot& slot = present_fence_slots[slot_index];
+    if (!slot.completion.IsValid()) {
+        return !device.IsFaulted();
+    }
+
+    const PresentationCompletionStateRef& state =
+        GetPresentationCompletionState();
+    if (!state) {
+        return false;
+    }
+    state->WaitForWsi(slot.completion);
+    if (device.IsFaulted() ||
+        slot.completion.GetWsiOutcome() !=
+            EPresentationWsiCompletionOutcome::Succeeded) {
+        return false;
+    }
+
+    const VkResult result = device.ResetFence(
+        in_flight_fences[slot_index],
+        VulkanOperationContext{
+            .operation  = EVulkanFaultOperation::PresentFenceReset,
+            .queue_type = EQueueType::Graphics,
+            .queue      = device.GetPresentQueue(),
+            .timeline   = _present_idx,
+        }
+    );
+    if (result != VK_SUCCESS) {
+        return false;
+    }
+    slot.completion = {};
     return !device.IsFaulted();
 }
 
-void VkSwapchain::EnqueuePresent(uint64 _present_idx) {
-
-    cur_present_cnt.fetch_add(1, std::memory_order_acq_rel);
-    auto& thread = present_threads[_present_idx % max_frames_in_flight];
-    assert(!thread.joinable() && "Present fence slot must be retired before reuse");
-    try {
-        thread = std::jthread([this, _present_idx]() {
-            RHIThreadRoleScope owner_scope(ERHIThreadRole::Completion);
-            const uint64 frame_index = _present_idx % max_frames_in_flight;
-            while (!device.IsDeviceLost()) {
-                const VulkanOperationContext wait_context{
-                    .operation  = EVulkanFaultOperation::PresentFenceWait,
-                    .queue_type = EQueueType::Graphics,
-                    .queue      = device.GetPresentQueue(),
-                    .timeline   = _present_idx,
-                };
-                const VkResult result = vkWaitForFences(
-                    device.GetDevice(),
-                    1,
-                    &in_flight_fences[frame_index],
-                    VK_TRUE,
-                    50'000'000
-                );
-                if (result == VK_TIMEOUT) {
-                    continue;
-                }
-                if (result == VK_SUCCESS && !device.IsDeviceLost()) {
-                    const VkResult reset_result = device.ResetFence(
-                        in_flight_fences[frame_index],
-                        VulkanOperationContext{
-                            .operation  =
-                                EVulkanFaultOperation::PresentFenceReset,
-                            .queue_type = EQueueType::Graphics,
-                            .queue      = device.GetPresentQueue(),
-                            .timeline   = _present_idx,
-                        }
-                    );
-                    if (reset_result != VK_SUCCESS) {
-                        break;
-                    }
-                } else if (result != VK_SUCCESS) {
-                    device.TryLatchFirstFault(wait_context, result);
-                    if (result != VK_ERROR_DEVICE_LOST) {
-                        device.EmergencyExitWithoutVulkanCleanup(
-                            wait_context, result
-                        );
-                    }
-                }
-                break;
-            }
-            OnFinishPresent(_present_idx);
-        });
-    } catch (...) {
-        // vkQueuePresentKHR has already accepted this frame and incremented
-        // cur_present_cnt. Continuing without a waiter would make Sync hang
-        // forever and allow an in-flight present fence to be reused.
-        cur_present_cnt.fetch_sub(1, std::memory_order_acq_rel);
-        std::terminate();
-    }
-}
-
-void VkSwapchain::Sync() {
-    //wait for present copy
-    while (!device.IsDeviceLost() && cur_present_cnt.load(std::memory_order_relaxed) > 0) {
-        std::this_thread::yield();
-    }
-    for (auto& thread : present_threads) {
-        if (thread.joinable()) {
-            thread.join();
-        }
-    }
-    if (device.IsDeviceLost()) {
-        return;
-    }
-    VkQueue graphics_queue = device.GetGraphicsQueue();
-    VkQueue present_queue  = device.GetPresentQueue();
-    VkResult result        = device.WaitQueueIdle(
-        graphics_queue,
-        VulkanOperationContext{
-            .operation  = EVulkanFaultOperation::QueueWaitIdle,
-            .queue_type = EQueueType::Graphics,
-            .queue      = graphics_queue,
-        }
-    );
-    if (result != VK_SUCCESS && device.IsDeviceLost()) {
-        return;
-    }
-    if (present_queue != graphics_queue) {
-        (void)device.WaitQueueIdle(
-            present_queue,
-            VulkanOperationContext{
-                .operation  = EVulkanFaultOperation::QueueWaitIdle,
-                .queue_type = EQueueType::Graphics,
-                .queue      = present_queue,
-            }
-        );
-    }
-}
 } // namespace Moer::Render

--- a/source/runtime/render/rhi/vulkan/VulkanSwapChain.h
+++ b/source/runtime/render/rhi/vulkan/VulkanSwapChain.h
@@ -12,8 +12,6 @@
 #include "VulkanFault.h"
 #include "VulkanPlatform.h"
 #include <atomic>
-#include <mutex>
-#include <thread>
 namespace Moer::Render {
 VkSurfaceFormatKHR      ChooseSwapSurfaceFormat(
          const Array<VkSurfaceFormatKHR>& _available_formats,
@@ -37,6 +35,13 @@ public:
             return image_index != UINT32_MAX;
         }
     };
+    struct PresentResult {
+        VulkanOperationResult outcome{};
+        VkFence               completion_fence{VK_NULL_HANDLE};
+        bool                  accepted{false};
+        bool                  wsi_enqueued{false};
+        bool                  uses_present_fence{false};
+    };
     friend VkCommandQueue;
     VkSwapchain(RenderDevice::Impl& _device, const SwapchainCreateInfo& _info);
     ~VkSwapchain();
@@ -49,13 +54,13 @@ public:
     );
     TextureView                         GetSwapchainImage(uint _index);
     VkSemaphore                         GetRenderFinishedFence(uint _image_index);
-    VulkanOperationResult Present(
+    PresentResult Present(
         VkQueue _queue,
         uint    _image_index,
         uint64  _timeline,
-        uint64  _work_serial
+        uint64  _work_serial,
+        const PresentationCompletionTicket& _completion
     );
-    void                                Sync() override;
     [[nodiscard]] bool IsPresentationReady() const noexcept override {
         return handle != VK_NULL_HANDLE &&
                surface != VK_NULL_HANDLE &&
@@ -69,7 +74,9 @@ public:
     }
 
     bool               WaitFrameInFlight();
-    bool               WaitFrameInFlight(uint64 _image_idx);
+    PresentationCompletionTicket ReservePresentCompletion(
+        PresentationCompletionIdentity _identity
+    );
     VkFence            GetInFlightFence(uint64 _image_idx);
     VkSurfaceFormatKHR GetSurfaceFormat() const {
         return fmt;
@@ -92,13 +99,15 @@ public:
 
 private:
     bool PreparePresentFence(uint64 _present_idx);
-    void OnFinishPresent(uint64 _image_idx);
-    void EnqueuePresent(uint64 _present_idx);
+
+    struct PresentFenceSlot {
+        PresentationCompletionTicket completion{};
+        uint64                       generation{0};
+    };
 
 private:
-    Array<std::jthread> present_threads;
-    std::atomic<uint>   cur_present_cnt                  = 0;
-    bool                native_surface_recreate_pending_ = false;
+    Array<PresentFenceSlot> present_fence_slots{};
+    bool                    native_surface_recreate_pending_ = false;
 };
 } // namespace Moer::Render
 

--- a/source/runtime/render/rhi/vulkan/vulkanextension/VulkanExtension.cpp
+++ b/source/runtime/render/rhi/vulkan/vulkanextension/VulkanExtension.cpp
@@ -27,8 +27,23 @@ std::shared_ptr<VulkanDeviceExtension> CreateDeviceExtension(const VulkanExtensi
 TExtensionArray VulkanInstanceExtension::GetMERequiredInstanceExtensions() {
     TExtensionArray extensions;
     ForEachExtensionDesc(EVulkanExtensionKind::Instance, [&](const VulkanExtensionDesc& _desc) {
-        extensions.emplace_back(_desc.name);
+        if (!_desc.optional) {
+            extensions.emplace_back(_desc.name);
+        }
     });
+    return extensions;
+}
+
+TExtensionArray VulkanInstanceExtension::GetMEOptionalInstanceExtensions() {
+    TExtensionArray extensions;
+    ForEachExtensionDesc(
+        EVulkanExtensionKind::Instance,
+        [&](const VulkanExtensionDesc& _desc) {
+            if (_desc.optional) {
+                extensions.emplace_back(_desc.name);
+            }
+        }
+    );
     return extensions;
 }
 

--- a/source/runtime/render/rhi/vulkan/vulkanextension/VulkanExtension.h
+++ b/source/runtime/render/rhi/vulkan/vulkanextension/VulkanExtension.h
@@ -45,6 +45,22 @@ struct VulkanExtensionDesc {
     TVulkanDeviceExtensionFactory factory  = nullptr;
 };
 
+[[nodiscard]] constexpr bool CanEnableVulkanSurfaceMaintenance1(
+    bool _surface_maintenance1_supported,
+    bool _surface_capabilities2_supported
+) noexcept {
+    return _surface_maintenance1_supported &&
+           _surface_capabilities2_supported;
+}
+
+[[nodiscard]] constexpr bool CanEnableVulkanSwapchainMaintenance1(
+    bool _surface_maintenance1_enabled,
+    bool _swapchain_maintenance1_supported
+) noexcept {
+    return _surface_maintenance1_enabled &&
+           _swapchain_maintenance1_supported;
+}
+
 class VulkanExtensionBase {
 public:
     VulkanExtensionBase(std::string_view _ext_name) : m_extension_name(_ext_name), m_is_enabled(false) {}
@@ -75,6 +91,7 @@ public:
     virtual ~VulkanInstanceExtension() = default;
 
     static TExtensionArray GetMERequiredInstanceExtensions();
+    static TExtensionArray GetMEOptionalInstanceExtensions();
 };
 
 class VulkanDeviceExtension : public VulkanExtensionBase {
@@ -171,6 +188,7 @@ public:
 
     // optional extensions
     bool m_has_ext_descriptor_buffer                       = false;
+    bool m_has_ext_swapchain_maintenance1                  = false;
     bool m_has_khr_acceleration_structure                  = false;
     bool m_has_khr_ray_tracing_pipeline                    = false;
     bool m_has_khr_ray_query                               = false;

--- a/source/runtime/render/rhi/vulkan/vulkanextension/VulkanExtensionFactories.cpp
+++ b/source/runtime/render/rhi/vulkan/vulkanextension/VulkanExtensionFactories.cpp
@@ -22,6 +22,16 @@ public:
         AddToPNext(_gpu_features2, m_swapchain_maintenance1_features);
     }
 
+    void PostGpuFeatures(
+        VulkanOptionalDeviceExtensions& _gpu_extensions
+    ) override {
+        m_is_usable =
+            m_swapchain_maintenance1_features.swapchainMaintenance1 ==
+            VK_TRUE;
+        _gpu_extensions.m_has_ext_swapchain_maintenance1 =
+            m_is_usable;
+    }
+
     void PreCreateDevice(VkDeviceCreateInfo& _device_create_info) override {
         if (m_is_usable && m_is_enabled) {
             AddToPNext(_device_create_info, m_swapchain_maintenance1_features);

--- a/source/runtime/render/rhi/vulkan/vulkanextension/VulkanExtensionFactories.h
+++ b/source/runtime/render/rhi/vulkan/vulkanextension/VulkanExtensionFactories.h
@@ -1,11 +1,13 @@
 #ifndef VULKAN_EXTENSION_FACTORIES_H
 #define VULKAN_EXTENSION_FACTORIES_H
 
+#include "RenderAPI.h"
 #include "VulkanExtension.h"
 
 namespace Moer::Render {
 
-std::shared_ptr<VulkanDeviceExtension> CreateVulkanEXTSwapchainMaintenance1Extension(bool _optional);
+RENDER_API std::shared_ptr<VulkanDeviceExtension>
+CreateVulkanEXTSwapchainMaintenance1Extension(bool _optional);
 std::shared_ptr<VulkanDeviceExtension> CreateVulkanKHRAccelerationStructureExtension(bool _optional);
 std::shared_ptr<VulkanDeviceExtension> CreateVulkanKHRRayTracingPipelineExtension(bool _optional);
 std::shared_ptr<VulkanDeviceExtension> CreateVulkanKHRRayQueryExtension(bool _optional);

--- a/source/runtime/render/rhi/vulkan/vulkanextension/VulkanExtensionRegistry.cpp
+++ b/source/runtime/render/rhi/vulkan/vulkanextension/VulkanExtensionRegistry.cpp
@@ -24,17 +24,29 @@ static constexpr VulkanExtensionDesc vulkan_extension_descs[] = {
         .factory  = nullptr,
     },
     {
+        .kind     = EVulkanExtensionKind::Instance,
+        .name     = VK_KHR_GET_SURFACE_CAPABILITIES_2_EXTENSION_NAME,
+        .optional = true,
+        .factory  = nullptr,
+    },
+    {
+        .kind     = EVulkanExtensionKind::Instance,
+        .name     = VK_EXT_SURFACE_MAINTENANCE_1_EXTENSION_NAME,
+        .optional = true,
+        .factory  = nullptr,
+    },
+    {
         .kind     = EVulkanExtensionKind::Device,
         .name     = VK_KHR_SWAPCHAIN_EXTENSION_NAME,
         .optional = false,
         .factory  = nullptr,
     },
-    // {
-    //     .kind     = EVulkanExtensionKind::Device,
-    //     .name     = VK_EXT_SWAPCHAIN_MAINTENANCE_1_EXTENSION_NAME,
-    //     .optional = false,
-    //     .factory  = &CreateVulkanEXTSwapchainMaintenance1Extension,
-    // },
+    {
+        .kind     = EVulkanExtensionKind::Device,
+        .name     = VK_EXT_SWAPCHAIN_MAINTENANCE_1_EXTENSION_NAME,
+        .optional = true,
+        .factory  = &CreateVulkanEXTSwapchainMaintenance1Extension,
+    },
     {
         .kind     = EVulkanExtensionKind::Device,
         .name     = VK_EXT_DESCRIPTOR_BUFFER_EXTENSION_NAME,
@@ -113,12 +125,6 @@ static constexpr VulkanExtensionDesc vulkan_extension_descs[] = {
     {
         .kind     = EVulkanExtensionKind::Instance,
         .name     = VK_KHR_WIN32_SURFACE_EXTENSION_NAME,
-        .optional = false,
-        .factory  = nullptr,
-    },
-    {
-        .kind     = EVulkanExtensionKind::Instance,
-        .name     = VK_KHR_GET_SURFACE_CAPABILITIES_2_EXTENSION_NAME,
         .optional = false,
         .factory  = nullptr,
     },

--- a/source/runtime/render/rhi/vulkan/vulkanextension/VulkanExtensionRegistry.h
+++ b/source/runtime/render/rhi/vulkan/vulkanextension/VulkanExtensionRegistry.h
@@ -3,11 +3,13 @@
 
 #include <span>
 
+#include "RenderAPI.h"
 #include "VulkanExtension.h"
 
 namespace Moer::Render {
 
-std::span<const VulkanExtensionDesc> GetVulkanExtensionDescs();
+RENDER_API std::span<const VulkanExtensionDesc>
+GetVulkanExtensionDescs();
 
 } // namespace Moer::Render
 

--- a/source/test/CMakeLists.txt
+++ b/source/test/CMakeLists.txt
@@ -299,6 +299,24 @@ set_target_properties(${test_target} PROPERTIES FOLDER ${moer_test_folder})
 add_test(NAME RHIGpuCompletionContract COMMAND $<TARGET_FILE:${test_target}>)
 set_tests_properties(RHIGpuCompletionContract PROPERTIES TIMEOUT 60)
 
+set(test_target TestRHIPresentationCompletion)
+add_executable(
+    ${test_target}
+    "RHIPresentationCompletionContractTest.cpp"
+)
+target_link_libraries(${test_target}
+    PRIVATE Moer::Render
+)
+set_target_properties(${test_target} PROPERTIES FOLDER ${moer_test_folder})
+add_test(
+    NAME RHIPresentationCompletionContract
+    COMMAND $<TARGET_FILE:${test_target}>
+)
+set_tests_properties(
+    RHIPresentationCompletionContract
+    PROPERTIES TIMEOUT 60
+)
+
 set(test_target TestRHIReadback)
 add_executable(${test_target} "RHIReadbackContractTest.cpp")
 target_link_libraries(${test_target}

--- a/source/test/PresentationSurfaceContractTest.cpp
+++ b/source/test/PresentationSurfaceContractTest.cpp
@@ -3,8 +3,13 @@
 #include <cstdio>
 #include <cstdlib>
 #include <memory>
+#include <type_traits>
+#include <utility>
 
 using namespace Moer::Render;
+
+static_assert(std::is_nothrow_destructible_v<PresentationSurface>);
+static_assert(noexcept(std::declval<PresentationSurface&>().Release()));
 
 namespace {
 

--- a/source/test/RHIParallelRecordVulkanTest.cpp
+++ b/source/test/RHIParallelRecordVulkanTest.cpp
@@ -281,7 +281,6 @@ public:
         size = info.size;
         return IsPresentationReady();
     }
-    void Sync() override {}
     [[nodiscard]] bool IsPresentationReady() const noexcept override {
         return size.x != 0 && size.y != 0;
     }
@@ -825,13 +824,31 @@ public:
     ) noexcept {
         auto& capture =
             *static_cast<ScriptedPresentCapture*>(_context);
-        capture.source_rejection_hook_count.fetch_add(
-            1, std::memory_order_acq_rel
-        );
+        ObserveSourceRejectionOwner(_context);
         if (!TryLatchVulkanDeviceFaultForTesting(
                 VK_ERROR_DEVICE_LOST
             )) {
             capture.source_rejection_hook_failed.store(
+                true, std::memory_order_release
+            );
+        }
+    }
+
+    static void ObserveSourceRejectionOwner(
+        void* _context
+    ) noexcept {
+        auto& capture =
+            *static_cast<ScriptedPresentCapture*>(_context);
+        capture.source_rejection_hook_count.fetch_add(
+            1, std::memory_order_acq_rel
+        );
+        capture.thread_id.store(
+            Platform::GetCurrentThreadID(),
+            std::memory_order_release
+        );
+        if (GetCurrentRHIThreadRole() !=
+            ERHIThreadRole::Submission) {
+            capture.wrong_owner.store(
                 true, std::memory_order_release
             );
         }
@@ -851,7 +868,8 @@ public:
     explicit ScopedScriptedPresentOverride(
         ScriptedPresentCapture& _capture,
         bool _require_present_source_ready = false,
-        bool _latch_fault_before_source_rejection = false
+        bool _latch_fault_before_source_rejection = false,
+        bool _observe_source_rejection_owner = false
     ) :
         scripted_override{
             .context  = &_capture,
@@ -862,6 +880,9 @@ public:
                 _latch_fault_before_source_rejection ?
                     &ScriptedPresentCapture::
                         LatchDeviceFaultBeforeSourceRejection :
+                _observe_source_rejection_owner ?
+                    &ScriptedPresentCapture::
+                        ObserveSourceRejectionOwner :
                     nullptr,
         } {
         if (!TryInstallVulkanScriptedPresentOverrideForTesting(
@@ -1246,6 +1267,179 @@ private:
     bool                             installed{false};
 };
 
+class PresentFenceStatusCapture final {
+public:
+    PresentFenceStatusCapture(
+        uint64 _blocked_issue,
+        uint64 _ready_issue
+    ) :
+        blocked_issue(_blocked_issue),
+        ready_issue(_ready_issue) {}
+
+    static VkResult Observe(void* _context, uint64 _issue) noexcept {
+        auto& capture =
+            *static_cast<PresentFenceStatusCapture*>(_context);
+        const uint32 current_thread =
+            Platform::GetCurrentThreadID();
+        uint32 expected_thread = 0;
+        if (!capture.completion_thread.compare_exchange_strong(
+                expected_thread,
+                current_thread,
+                std::memory_order_acq_rel,
+                std::memory_order_acquire
+            ) &&
+            expected_thread != current_thread) {
+            capture.invalid.store(true, std::memory_order_release);
+        }
+        if (GetCurrentRHIThreadRole() !=
+            ERHIThreadRole::Completion) {
+            capture.invalid.store(true, std::memory_order_release);
+        }
+        capture.poll_count.fetch_add(
+            1, std::memory_order_acq_rel
+        );
+        if (_issue == capture.blocked_issue) {
+            capture.blocked_poll_count.fetch_add(
+                1, std::memory_order_acq_rel
+            );
+            return capture.release_blocked.load(
+                       std::memory_order_acquire
+                   ) ?
+                       VK_SUCCESS :
+                       VK_NOT_READY;
+        }
+        if (_issue == capture.ready_issue) {
+            capture.ready_poll_count.fetch_add(
+                1, std::memory_order_acq_rel
+            );
+            return VK_SUCCESS;
+        }
+        capture.invalid.store(true, std::memory_order_release);
+        return VK_ERROR_UNKNOWN;
+    }
+
+    std::atomic_bool   release_blocked{false};
+    std::atomic<uint32> completion_thread{0};
+    std::atomic<uint32> poll_count{0};
+    std::atomic<uint32> blocked_poll_count{0};
+    std::atomic<uint32> ready_poll_count{0};
+    std::atomic_bool   invalid{false};
+
+private:
+    uint64 blocked_issue{0};
+    uint64 ready_issue{0};
+};
+
+class ScopedPresentFenceStatusOverride final {
+public:
+    explicit ScopedPresentFenceStatusOverride(
+        PresentFenceStatusCapture& _capture
+    ) :
+        scripted_override{
+            .context  = &_capture,
+            .callback = &PresentFenceStatusCapture::Observe,
+        } {
+        if (!TryInstallVulkanScriptedPresentFenceStatusOverrideForTesting(
+                &scripted_override
+            )) {
+            throw std::runtime_error(
+                "Vulkan Present-fence status override was already installed"
+            );
+        }
+        installed = true;
+    }
+
+    ~ScopedPresentFenceStatusOverride() noexcept {
+        if (installed &&
+            !RemoveVulkanScriptedPresentFenceStatusOverrideForTesting(
+                &scripted_override
+            )) {
+            std::terminate();
+        }
+    }
+
+    ScopedPresentFenceStatusOverride(
+        const ScopedPresentFenceStatusOverride&
+    ) = delete;
+    ScopedPresentFenceStatusOverride& operator=(
+        const ScopedPresentFenceStatusOverride&
+    ) = delete;
+
+private:
+    VulkanScriptedPresentFenceStatusOverrideForTesting
+        scripted_override{};
+    bool installed{false};
+};
+
+class QueueIdleWaitCapture final {
+public:
+    static void Observe(
+        void*                             _context,
+        const VulkanQueueIdleWaitEvent& _event
+    ) noexcept {
+        auto& capture =
+            *static_cast<QueueIdleWaitCapture*>(_context);
+        if (_event.thread_role != ERHIThreadRole::Submission ||
+            _event.context.operation !=
+                EVulkanFaultOperation::QueueWaitIdle ||
+            _event.native_queue_handle == 0) {
+            capture.invalid.store(true, std::memory_order_release);
+        }
+        const uint32 current_thread = _event.thread_id;
+        uint32 expected_thread = 0;
+        if (!capture.submission_thread.compare_exchange_strong(
+                expected_thread,
+                current_thread,
+                std::memory_order_acq_rel,
+                std::memory_order_acquire
+            ) &&
+            expected_thread != current_thread) {
+            capture.invalid.store(true, std::memory_order_release);
+        }
+        capture.count.fetch_add(1, std::memory_order_acq_rel);
+    }
+
+    std::atomic<uint32> count{0};
+    std::atomic<uint32> submission_thread{0};
+    std::atomic_bool    invalid{false};
+};
+
+class ScopedQueueIdleWaitObserver final {
+public:
+    explicit ScopedQueueIdleWaitObserver(
+        QueueIdleWaitCapture& _capture
+    ) :
+        observer{
+            .context  = &_capture,
+            .callback = &QueueIdleWaitCapture::Observe,
+        } {
+        if (!TryInstallVulkanQueueIdleWaitObserver(&observer)) {
+            throw std::runtime_error(
+                "Vulkan queue-idle observer was already installed"
+            );
+        }
+        installed = true;
+    }
+
+    ~ScopedQueueIdleWaitObserver() noexcept {
+        if (installed &&
+            !RemoveVulkanQueueIdleWaitObserver(&observer)) {
+            std::terminate();
+        }
+    }
+
+    ScopedQueueIdleWaitObserver(
+        const ScopedQueueIdleWaitObserver&
+    ) = delete;
+    ScopedQueueIdleWaitObserver& operator=(
+        const ScopedQueueIdleWaitObserver&
+    ) = delete;
+
+private:
+    VulkanQueueIdleWaitObserver observer{};
+    bool                        installed{false};
+};
+
 class BatchPreflightRejectionCapture final {
 public:
     static void Observe(
@@ -1353,6 +1547,8 @@ void ValidateArguments(int _argc, const char** _argv) {
             argument != "--pipeline-window2" &&
             argument != "--present-boundary" &&
             argument != "--present-hard" &&
+            argument != "--present-legacy-owner" &&
+            argument != "--present-completion-shutdown" &&
             argument != "--rt-export-rejection" &&
             argument != "--readback-future" &&
             argument != "--occlusion-query" &&
@@ -11112,6 +11308,247 @@ void RunPresentPipelineBoundary() {
     }
 }
 
+void RunLegacyDirectPresentOwnerBoundary() {
+    using namespace std::chrono_literals;
+
+    auto& device = RenderDevice::Get();
+    auto& graphics_queue = static_cast<VkCommandQueue&>(
+        device.GetCommandQueue(EQueueType::Graphics)
+    );
+    const uint32 caller_thread =
+        Platform::GetCurrentThreadID();
+    SwapchainRef swapchain{
+        MoerNew(HeadlessScriptedSwapchain)()
+    };
+    ScriptedPresentCapture capture(
+        VulkanScriptedPresentResult{
+            .outcome = {
+                EVulkanOperationStatus::Rejected,
+                VK_ERROR_UNKNOWN,
+            },
+        }
+    );
+    ScopedScriptedPresentOverride scripted_override(
+        capture,
+        false,
+        false,
+        true
+    );
+    PresentReceiptRef receipt = MakeShared<PresentReceipt>();
+
+    graphics_queue.Present(
+        swapchain,
+        TextureView{},
+        receipt
+    );
+    const PresentReceiptResult result =
+        receipt->WaitForSubmission(5s);
+    graphics_queue.Sync();
+
+    if (!result.resolved || result.submitted ||
+        result.recreate_swapchain ||
+        receipt->ResolutionAttemptCount() != 1 ||
+        capture.source_rejection_hook_count.load(
+            std::memory_order_acquire
+        ) != 1 ||
+        capture.thread_id.load(std::memory_order_acquire) !=
+            caller_thread ||
+        capture.wrong_owner.load(std::memory_order_acquire) ||
+        capture.count.load(std::memory_order_acquire) != 0) {
+        throw std::runtime_error(
+            "legacy direct Present did not execute on the caller-side Submission owner"
+        );
+    }
+    LOG_INFO(
+        "[TESTCASE][PASS] "
+        "name=LegacyDirectPresentOwnerBoundary "
+        "rhi_thread=false owner=Submission thread=caller "
+        "receipt=exactly_once native_present=0"
+    );
+}
+
+void RunPresentationCompletionIntegrationBoundary() {
+    using namespace std::chrono_literals;
+
+    auto& device = RenderDevice::Get();
+    auto& graphics_queue = static_cast<VkCommandQueue&>(
+        device.GetCommandQueue(EQueueType::Graphics)
+    );
+    SwapchainRef swapchain{
+        MoerNew(HeadlessScriptedSwapchain)()
+    };
+    const PresentationCompletionStateRef state =
+        swapchain->GetPresentationCompletionState();
+    if (!state) {
+        throw std::runtime_error(
+            "headless Presentation completion state was not created"
+        );
+    }
+
+    const auto reserve =
+        [&](uint64 _epoch, uint64 _request, uint32 _slot) {
+            return state->Reserve(
+                PresentationCompletionIdentity{
+                    .state_instance_id =
+                        state->GetStateInstanceId(),
+                    .presentation_epoch = _epoch,
+                    .drawable_generation = 1,
+                    .request_serial = _request,
+                },
+                _slot,
+                1
+            );
+        };
+
+    const PresentationCompletionTicket blocked =
+        reserve(401, 1, 0);
+    const PresentationCompletionTicket ready =
+        reserve(402, 2, 1);
+    if (!blocked.IsValid() || !ready.IsValid() ||
+        !state->SetWsiMode(
+            blocked,
+            EPresentationWsiCompletionMode::PresentFence
+        ) ||
+        !state->SetWsiMode(
+            ready,
+            EPresentationWsiCompletionMode::PresentFence
+        )) {
+        throw std::runtime_error(
+            "Present-fence integration setup failed"
+        );
+    }
+
+    PresentFenceStatusCapture fence_status(
+        blocked.GetIssueSequence(),
+        ready.GetIssueSequence()
+    );
+    {
+        ScopedPresentFenceStatusOverride status_override(
+            fence_status
+        );
+        if (!graphics_queue.
+                EnqueuePresentationCompletionProbeForTesting(
+                    swapchain, blocked, true
+                ) ||
+            !graphics_queue.
+                EnqueuePresentationCompletionProbeForTesting(
+                    swapchain, ready, true
+                )) {
+            throw std::runtime_error(
+                "could not enqueue synthetic Present completions"
+            );
+        }
+
+        std::binary_semaphore ready_drain_finished{0};
+        std::jthread ready_drain([&] {
+            RHIExecutor::Get().DrainPresentation(
+                RHIPresentationDrainTarget{
+                    swapchain, 402, 1
+                }
+            );
+            ready_drain_finished.release();
+        });
+        if (!ready_drain_finished.try_acquire_for(5s)) {
+            fence_status.release_blocked.store(
+                true, std::memory_order_release
+            );
+            ready_drain.join();
+            throw std::runtime_error(
+                "ready Present was blocked behind an older unsignalled fence"
+            );
+        }
+        ready_drain.join();
+
+        const PresentationDrainPoint blocked_point =
+            state->Freeze(401, 1);
+        const PresentationDrainPoint ready_point =
+            state->Freeze(402, 1);
+        if (state->OutstandingCount() != 1 ||
+            state->WaitRetired(blocked_point, 1ms) ||
+            !state->WaitRetired(ready_point, 20ms) ||
+            fence_status.ready_poll_count.load(
+                std::memory_order_acquire
+            ) == 0) {
+            throw std::runtime_error(
+                "targeted Present drain retired the wrong identity"
+            );
+        }
+
+        fence_status.release_blocked.store(
+            true, std::memory_order_release
+        );
+        RHIExecutor::Get().DrainPresentation(
+            RHIPresentationDrainTarget{
+                swapchain, 401, 1
+            }
+        );
+        if (state->HasOutstanding() ||
+            fence_status.blocked_poll_count.load(
+                std::memory_order_acquire
+            ) == 0 ||
+            fence_status.invalid.load(
+                std::memory_order_acquire
+            ) ||
+            fence_status.completion_thread.load(
+                std::memory_order_acquire
+            ) == 0) {
+            throw std::runtime_error(
+                "Present-fence polling escaped the sole Completion owner"
+            );
+        }
+    }
+
+    const PresentationCompletionTicket fallback =
+        reserve(403, 3, 2);
+    if (!fallback.IsValid() ||
+        !state->SetWsiMode(
+            fallback,
+            EPresentationWsiCompletionMode::QueueIdleFallback
+        ) ||
+        !graphics_queue.
+            EnqueuePresentationCompletionProbeForTesting(
+                swapchain, fallback, false
+            )) {
+        throw std::runtime_error(
+            "queue-idle fallback integration setup failed"
+        );
+    }
+
+    QueueIdleWaitCapture queue_idle{};
+    {
+        ScopedQueueIdleWaitObserver queue_idle_observer(
+            queue_idle
+        );
+        RHIExecutor::Get().DrainPresentation(
+            RHIPresentationDrainTarget{
+                swapchain, 403, 1
+            }
+        );
+    }
+    if (state->HasOutstanding() ||
+        queue_idle.count.load(std::memory_order_acquire) == 0 ||
+        queue_idle.invalid.load(std::memory_order_acquire) ||
+        queue_idle.submission_thread.load(
+            std::memory_order_acquire
+        ) == 0 ||
+        queue_idle.submission_thread.load(
+            std::memory_order_acquire
+        ) == Platform::GetCurrentThreadID()) {
+        throw std::runtime_error(
+            "queue-idle fallback escaped the sole Submission owner"
+        );
+    }
+
+    LOG_INFO(
+        "[TESTCASE][PASS] "
+        "name=PresentationCompletionIntegrationBoundary "
+        "present_fence=nonblocking_targeted "
+        "fence_owner=Completion completion_threads=1 "
+        "queue_idle_fallback=targeted "
+        "queue_idle_owner=Submission outstanding=0"
+    );
+}
+
 void RunQueuedPresentShutdownBoundary() {
     using namespace std::chrono_literals;
 
@@ -11324,6 +11761,127 @@ void RunQueuedPresentShutdownBoundary() {
         stop_runtime();
         std::rethrow_exception(failure);
     }
+}
+
+void RunPresentationCompletionShutdownDrainBoundary() {
+    using namespace std::chrono_literals;
+
+    auto& device = RenderDevice::Get();
+    auto& graphics_queue = static_cast<VkCommandQueue&>(
+        device.GetCommandQueue(EQueueType::Graphics)
+    );
+    SwapchainRef swapchain{
+        MoerNew(HeadlessScriptedSwapchain)()
+    };
+    const PresentationCompletionStateRef state =
+        swapchain->GetPresentationCompletionState();
+    const auto reserve =
+        [&](uint64 _epoch, uint64 _request, uint32 _slot) {
+            return state->Reserve(
+                PresentationCompletionIdentity{
+                    .state_instance_id =
+                        state->GetStateInstanceId(),
+                    .presentation_epoch = _epoch,
+                    .drawable_generation = 1,
+                    .request_serial = _request,
+                },
+                _slot,
+                1
+            );
+        };
+    const PresentationCompletionTicket fence_ticket =
+        reserve(501, 1, 0);
+    const PresentationCompletionTicket fallback_ticket =
+        reserve(502, 2, 1);
+    if (!fence_ticket.IsValid() ||
+        !fallback_ticket.IsValid() ||
+        !state->SetWsiMode(
+            fence_ticket,
+            EPresentationWsiCompletionMode::PresentFence
+        ) ||
+        !state->SetWsiMode(
+            fallback_ticket,
+            EPresentationWsiCompletionMode::QueueIdleFallback
+        ) ||
+        !graphics_queue.
+            RegisterPresentationCompletionStateForShutdownProbeForTesting(
+                state
+            )) {
+        throw std::runtime_error(
+            "shutdown Presentation completion setup failed"
+        );
+    }
+
+    PresentFenceStatusCapture fence_status(
+        fence_ticket.GetIssueSequence(),
+        UINT64_MAX
+    );
+    QueueIdleWaitCapture queue_idle{};
+    ScopedPresentFenceStatusOverride fence_override(
+        fence_status
+    );
+    ScopedQueueIdleWaitObserver queue_idle_observer(
+        queue_idle
+    );
+    if (!graphics_queue.
+            EnqueuePresentationCompletionProbeForTesting(
+                swapchain, fence_ticket, true
+            ) ||
+        !graphics_queue.
+            EnqueuePresentationCompletionProbeForTesting(
+                swapchain, fallback_ticket, false
+            )) {
+        throw std::runtime_error(
+            "shutdown Presentation completion probes were not enqueued"
+        );
+    }
+
+    const auto poll_deadline =
+        std::chrono::steady_clock::now() + 2s;
+    while (fence_status.blocked_poll_count.load(
+               std::memory_order_acquire
+           ) == 0 &&
+           std::chrono::steady_clock::now() < poll_deadline) {
+        std::this_thread::sleep_for(1ms);
+    }
+    if (fence_status.blocked_poll_count.load(
+            std::memory_order_acquire
+        ) == 0) {
+        throw std::runtime_error(
+            "shutdown Present fence never reached Completion polling"
+        );
+    }
+
+    std::jthread release_fence([&] {
+        std::this_thread::sleep_for(100ms);
+        fence_status.release_blocked.store(
+            true, std::memory_order_release
+        );
+    });
+    RenderDevice::Dispose();
+    release_fence.join();
+
+    if (state->HasOutstanding() ||
+        fence_status.invalid.load(std::memory_order_acquire) ||
+        fence_status.completion_thread.load(
+            std::memory_order_acquire
+        ) == 0 ||
+        queue_idle.count.load(std::memory_order_acquire) == 0 ||
+        queue_idle.invalid.load(std::memory_order_acquire) ||
+        queue_idle.submission_thread.load(
+            std::memory_order_acquire
+        ) == 0) {
+        throw std::runtime_error(
+            "queue destruction did not perform the final owned Presentation drain"
+        );
+    }
+
+    LOG_INFO(
+        "[TESTCASE][PASS] "
+        "name=PresentationCompletionShutdownDrainBoundary "
+        "pending=fence+fallback fence_owner=Completion "
+        "queue_idle_owner=Submission outstanding=0 dispose=returned"
+    );
 }
 
 void RunPresentHardFailureBoundary() {
@@ -15700,6 +16258,22 @@ int main(int argc, const char** argv) {
             HasArgument(argc, argv, "--present-boundary");
         const bool present_hard =
             HasArgument(argc, argv, "--present-hard");
+        const bool present_legacy_owner =
+            HasArgument(argc, argv, "--present-legacy-owner");
+        const bool present_completion_shutdown =
+            HasArgument(
+                argc, argv, "--present-completion-shutdown"
+            );
+        const uint32 focused_present_mode_count =
+            static_cast<uint32>(present_boundary) +
+            static_cast<uint32>(present_hard) +
+            static_cast<uint32>(present_legacy_owner) +
+            static_cast<uint32>(present_completion_shutdown);
+        if (focused_present_mode_count > 1) {
+            throw std::invalid_argument(
+                "focused Present modes are mutually exclusive"
+            );
+        }
         const bool present_mode =
             present_boundary || present_hard;
         const bool rt_export_rejection =
@@ -15734,7 +16308,9 @@ int main(int argc, const char** argv) {
             .rhi_type         = ERHIType::Vulkan,
             .name             = "RHIParallelRecordVulkanTest",
             .rhi_api_version  = "1.3",
-            .rhi_thread       = true,
+            .rhi_thread       =
+                !present_legacy_owner &&
+                !present_completion_shutdown,
             .rhi_bypass       = false,
             .parallel_recording =
                 parallel || pipeline_window_mode || present_mode ||
@@ -15760,6 +16336,23 @@ int main(int argc, const char** argv) {
             .parallel_record_worker_throw_trigger = inject_worker_failure ? 1u : 0u,
         });
         render_device_initialized = true;
+
+        if (present_legacy_owner) {
+            RunLegacyDirectPresentOwnerBoundary();
+            RenderDevice::Dispose();
+            render_device_initialized = false;
+            TaskSystem::ShutDown();
+            task_system_initialized = false;
+            return 0;
+        }
+
+        if (present_completion_shutdown) {
+            RunPresentationCompletionShutdownDrainBoundary();
+            render_device_initialized = false;
+            TaskSystem::ShutDown();
+            task_system_initialized = false;
+            return 0;
+        }
 
         if (readback_future_mode) {
             RunOwningReadbackFuture();
@@ -15836,11 +16429,17 @@ int main(int argc, const char** argv) {
 
         if (present_mode) {
             if (present_boundary) {
+                LOG_INFO("[TESTCASE][BEGIN] name=PresentSourceContractRejection");
                 RunPresentSourceContractRejection();
+                LOG_INFO("[TESTCASE][BEGIN] name=SerialControlPipelineBoundary");
                 RunSerialControlPipelineBoundary();
+                LOG_INFO("[TESTCASE][BEGIN] name=PresentPipelineBoundary");
                 RunPresentPipelineBoundary();
+                LOG_INFO("[TESTCASE][BEGIN] name=PresentationCompletionIntegrationBoundary");
+                RunPresentationCompletionIntegrationBoundary();
                 // This is the terminal focused lifecycle test: it stops and
                 // joins the RHI runtime before returning.
+                LOG_INFO("[TESTCASE][BEGIN] name=QueuedPresentShutdownBoundary");
                 RunQueuedPresentShutdownBoundary();
             } else {
                 RunPresentHardFailureBoundary();

--- a/source/test/RHIPresentationCompletionContractTest.cpp
+++ b/source/test/RHIPresentationCompletionContractTest.cpp
@@ -1,0 +1,477 @@
+#include "rhi/RHIPresentationCompletion.h"
+#include "rhi/vulkan/vulkanextension/VulkanExtensionFactories.h"
+#include "rhi/vulkan/vulkanextension/VulkanExtensionRegistry.h"
+
+#include <atomic>
+#include <chrono>
+#include <iostream>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <thread>
+#include <type_traits>
+
+namespace {
+
+using namespace Moer::Render;
+using namespace std::chrono_literals;
+
+void Expect(bool _condition, std::string_view _message) {
+    if (!_condition) {
+        throw std::runtime_error(std::string(_message));
+    }
+}
+
+PresentationCompletionIdentity Identity(
+    const PresentationCompletionStateRef& _state,
+    std::uint64_t _epoch,
+    std::uint64_t _generation,
+    std::uint64_t _request_serial
+) {
+    return PresentationCompletionIdentity{
+        .state_instance_id = _state->GetStateInstanceId(),
+        .presentation_epoch = _epoch,
+        .drawable_generation = _generation,
+        .request_serial = _request_serial,
+    };
+}
+
+void CompletePresentFence(
+    const PresentationCompletionStateRef& _state,
+    const PresentationCompletionTicket&   _ticket
+) {
+    Expect(
+        _state->SetWsiMode(
+            _ticket,
+            EPresentationWsiCompletionMode::PresentFence
+        ),
+        "could not select PresentFence mode"
+    );
+    Expect(
+        _state->MarkGpuComplete(_ticket),
+        "could not mark GPU completion"
+    );
+    Expect(
+        _state->MarkWsiComplete(_ticket),
+        "could not mark WSI completion"
+    );
+}
+
+void SeparateStatesRejectCrossMutation() {
+    const auto state_a = PresentationCompletionState::Create();
+    const auto state_b = PresentationCompletionState::Create();
+    Expect(
+        state_a->GetStateInstanceId() !=
+            state_b->GetStateInstanceId(),
+        "separate states reused an instance identity"
+    );
+
+    const auto ticket_a =
+        state_a->Reserve(Identity(state_a, 1, 1, 7), 0, 1);
+    Expect(ticket_a.IsValid(), "state A returned an invalid ticket");
+    Expect(
+        !state_b->SetWsiMode(
+            ticket_a,
+            EPresentationWsiCompletionMode::Immediate
+        ) &&
+            !state_b->MarkGpuComplete(ticket_a) &&
+            !state_b->MarkWsiComplete(ticket_a) &&
+            !state_b->MarkWsiFailed(ticket_a) &&
+            !state_b->PublishRetired(ticket_a),
+        "state B accepted state A's strong ticket"
+    );
+    Expect(
+        state_a->OutstandingCount() == 1 &&
+            state_b->OutstandingCount() == 0,
+        "cross-state rejection changed outstanding records"
+    );
+
+    Expect(
+        state_a->SetWsiMode(
+            ticket_a,
+            EPresentationWsiCompletionMode::Immediate
+        ) &&
+            state_a->MarkGpuComplete(ticket_a) &&
+            state_a->PublishRetired(ticket_a),
+        "state A could not retire its own ticket"
+    );
+}
+
+void EpochDrainDoesNotCaptureNewGeneration() {
+    const auto state = PresentationCompletionState::Create();
+    const auto old_ticket =
+        state->Reserve(Identity(state, 10, 20, 1), 0, 1);
+    const auto new_ticket =
+        state->Reserve(Identity(state, 11, 21, 2), 1, 1);
+    const auto old_point = state->Freeze(10, 20);
+    const auto all_point = state->Freeze();
+
+    CompletePresentFence(state, old_ticket);
+    Expect(
+        state->PublishRetired(old_ticket),
+        "old epoch did not retire"
+    );
+    Expect(
+        state->WaitRetired(old_point, 20ms),
+        "old epoch drain waited on a newer generation"
+    );
+    Expect(
+        !state->WaitRetired(all_point, 2ms),
+        "all-identity drain ignored the newer generation"
+    );
+
+    CompletePresentFence(state, new_ticket);
+    Expect(
+        state->PublishRetired(new_ticket) &&
+            state->WaitRetired(all_point, 20ms),
+        "all-identity drain did not finish after both generations retired"
+    );
+}
+
+void OutOfOrderRetirementUsesInternalIssueSequence() {
+    const auto state = PresentationCompletionState::Create();
+    const auto first =
+        state->Reserve(Identity(state, 30, 40, 900), 0, 1);
+    const auto second =
+        state->Reserve(Identity(state, 30, 40, 1), 1, 1);
+    Expect(
+        first.GetIssueSequence() != first.GetIdentity().request_serial &&
+            second.GetIssueSequence() ==
+                first.GetIssueSequence() + 1,
+        "internal issue ordering inherited receipt serials"
+    );
+    const auto point = state->Freeze();
+
+    CompletePresentFence(state, second);
+    Expect(
+        state->PublishRetired(second),
+        "later issue could not retire out of order"
+    );
+    Expect(
+        state->OutstandingCount() == 1 &&
+            !state->WaitRetired(point, 2ms),
+        "out-of-order retirement falsely advanced past an older issue"
+    );
+
+    CompletePresentFence(state, first);
+    Expect(
+        state->PublishRetired(first) &&
+            state->WaitRetired(point, 20ms),
+        "drain did not finish after the older issue retired"
+    );
+}
+
+void FastFailureIsNotHeldBehindAcceptedPresent() {
+    const auto state = PresentationCompletionState::Create();
+    const auto accepted =
+        state->Reserve(Identity(state, 50, 60, 1), 0, 1);
+    const auto failed =
+        state->Reserve(Identity(state, 50, 60, 2), 1, 1);
+    Expect(
+        state->SetWsiMode(
+            accepted,
+            EPresentationWsiCompletionMode::PresentFence
+        ),
+        "accepted Present could not select its WSI mode"
+    );
+    Expect(
+        state->SetWsiMode(
+            failed,
+            EPresentationWsiCompletionMode::Failed
+        ) &&
+            state->MarkGpuComplete(failed) &&
+            state->PublishRetired(failed),
+        "fast failure could not retire behind an accepted Present"
+    );
+    Expect(
+        state->WaitForWsi(failed, 2ms) &&
+            !state->WaitForWsi(accepted, 2ms) &&
+            state->OutstandingCount() == 1,
+        "fast failure publication changed the accepted Present"
+    );
+
+    Expect(
+        state->MarkGpuComplete(accepted) &&
+            state->MarkWsiComplete(accepted) &&
+            state->PublishRetired(accepted),
+        "accepted Present cleanup failed"
+    );
+}
+
+void FailedPresentFenceOutcomeSurvivesRetirement() {
+    const auto state = PresentationCompletionState::Create();
+    const auto ticket =
+        state->Reserve(Identity(state, 61, 62, 1), 2, 7);
+    Expect(
+        state->SetWsiMode(
+            ticket,
+            EPresentationWsiCompletionMode::PresentFence
+        ) &&
+            state->MarkGpuComplete(ticket) &&
+            state->MarkWsiFailed(ticket),
+        "failed Present-fence setup did not become terminal"
+    );
+    Expect(
+        ticket.GetWsiOutcome() ==
+                EPresentationWsiCompletionOutcome::Failed &&
+            state->WaitForWsi(ticket, 20ms),
+        "failed Present fence reported successful or pending"
+    );
+    Expect(
+        state->PublishRetired(ticket) &&
+            ticket.GetWsiOutcome() ==
+                EPresentationWsiCompletionOutcome::Failed,
+        "retirement erased the slot-visible failure outcome"
+    );
+}
+
+void RetiredSlotGenerationRejectsLateCallbacks() {
+    const auto state = PresentationCompletionState::Create();
+    const auto old_ticket =
+        state->Reserve(Identity(state, 70, 80, 1), 4, 12);
+    CompletePresentFence(state, old_ticket);
+    Expect(
+        state->PublishRetired(old_ticket),
+        "old slot generation did not retire"
+    );
+
+    const auto new_ticket =
+        state->Reserve(Identity(state, 71, 81, 2), 4, 13);
+    Expect(
+        new_ticket.GetFenceSlot() == old_ticket.GetFenceSlot() &&
+            new_ticket.GetSlotGeneration() !=
+                old_ticket.GetSlotGeneration(),
+        "slot generation setup was invalid"
+    );
+    Expect(
+        !state->MarkGpuComplete(old_ticket) &&
+            !state->MarkWsiComplete(old_ticket) &&
+            !state->SetWsiMode(
+                old_ticket,
+                EPresentationWsiCompletionMode::Immediate
+            ) &&
+            !state->PublishRetired(old_ticket),
+        "late old-slot callback remained mutable after retirement"
+    );
+    Expect(
+        !state->WaitForWsi(new_ticket, 2ms),
+        "old-slot callback completed the reused slot"
+    );
+
+    CompletePresentFence(state, new_ticket);
+    Expect(
+        state->PublishRetired(new_ticket),
+        "new slot generation did not retire independently"
+    );
+}
+
+void QueueIdleFallbackIsTargetedAndOwnerResolved() {
+    const auto state = PresentationCompletionState::Create();
+    const auto fallback =
+        state->Reserve(Identity(state, 90, 100, 1), 0, 1);
+    Expect(
+        state->SetWsiMode(
+            fallback,
+            EPresentationWsiCompletionMode::QueueIdleFallback
+        ) &&
+            state->MarkGpuComplete(fallback),
+        "fallback Present setup failed"
+    );
+    Expect(
+        !state->MarkWsiComplete(fallback),
+        "Completion owner bypassed the queue-idle fallback owner"
+    );
+    const auto point = state->Freeze(90, 100);
+    Expect(
+        point.IsValid() &&
+            state->RequiresQueueIdle(point) &&
+            !state->WaitForWsi(fallback, 2ms),
+        "fallback drain did not expose its queue-idle requirement"
+    );
+    Expect(
+        state->ResolveQueueIdle(point) &&
+            !state->RequiresQueueIdle(point) &&
+            state->WaitForWsi(fallback, 20ms),
+        "queue-idle resolution did not publish WSI completion"
+    );
+    Expect(
+        state->PublishRetired() == 1 &&
+            state->WaitRetired(point, 20ms),
+        "resolved fallback did not retire"
+    );
+}
+
+void WaitersWakeAndStrongOwnersReleaseBoundedly() {
+    auto state = PresentationCompletionState::Create();
+    std::weak_ptr<PresentationCompletionState> weak_state = state;
+    auto ticket =
+        state->Reserve(Identity(state, 110, 120, 1), 0, 1);
+    auto point = state->Freeze();
+    Expect(
+        state->SetWsiMode(
+            ticket,
+            EPresentationWsiCompletionMode::PresentFence
+        ),
+        "bounded-wait setup failed"
+    );
+    Expect(
+        !state->WaitForWsi(ticket, 2ms) &&
+            !state->WaitRetired(point, 2ms),
+        "pending waits did not honor their timeout"
+    );
+
+    std::atomic_bool resolver_succeeded{false};
+    std::jthread resolver([state, ticket, &resolver_succeeded] {
+        std::this_thread::sleep_for(5ms);
+        resolver_succeeded.store(
+            state->MarkWsiComplete(ticket) &&
+                state->MarkGpuComplete(ticket) &&
+                state->PublishRetired(ticket),
+            std::memory_order_release
+        );
+    });
+    const bool wsi_released =
+        state->WaitForWsi(ticket, 2s);
+    const bool retirement_released =
+        state->WaitRetired(point, 2s);
+    resolver.join();
+    Expect(
+        wsi_released &&
+            retirement_released &&
+            resolver_succeeded.load(std::memory_order_acquire) &&
+            !state->HasOutstanding() &&
+            state->OutstandingCount() == 0,
+        "waiter/resolver failed or terminal records were retained"
+    );
+
+    state.reset();
+    Expect(
+        !weak_state.expired(),
+        "ticket/drain point did not strongly own their state"
+    );
+    ticket = {};
+    point  = {};
+    Expect(
+        weak_state.expired(),
+        "strong presentation completion owners did not release"
+    );
+}
+
+void Maintenance1CapabilityGateIsExplicitAndOptional() {
+    bool found_surface_dependency = false;
+    bool found_surface_maintenance = false;
+    bool found_swapchain_maintenance = false;
+    for (const VulkanExtensionDesc& desc :
+         GetVulkanExtensionDescs()) {
+        if (desc.name ==
+            VK_KHR_GET_SURFACE_CAPABILITIES_2_EXTENSION_NAME) {
+            found_surface_dependency =
+                desc.kind == EVulkanExtensionKind::Instance &&
+                desc.optional;
+        } else if (
+            desc.name ==
+            VK_EXT_SURFACE_MAINTENANCE_1_EXTENSION_NAME
+        ) {
+            found_surface_maintenance =
+                desc.kind == EVulkanExtensionKind::Instance &&
+                desc.optional;
+        } else if (
+            desc.name ==
+            VK_EXT_SWAPCHAIN_MAINTENANCE_1_EXTENSION_NAME
+        ) {
+            found_swapchain_maintenance =
+                desc.kind == EVulkanExtensionKind::Device &&
+                desc.optional && desc.factory != nullptr;
+        }
+    }
+    Expect(
+        found_surface_dependency &&
+            found_surface_maintenance &&
+            found_swapchain_maintenance,
+        "maintenance1 registry dependencies are not optional and explicit"
+    );
+
+    Expect(
+        !CanEnableVulkanSurfaceMaintenance1(false, false) &&
+            !CanEnableVulkanSurfaceMaintenance1(true, false) &&
+            !CanEnableVulkanSurfaceMaintenance1(false, true) &&
+            CanEnableVulkanSurfaceMaintenance1(true, true),
+        "surface maintenance1 dependency truth table is wrong"
+    );
+    Expect(
+        !CanEnableVulkanSwapchainMaintenance1(false, false) &&
+            !CanEnableVulkanSwapchainMaintenance1(true, false) &&
+            !CanEnableVulkanSwapchainMaintenance1(false, true) &&
+            CanEnableVulkanSwapchainMaintenance1(true, true),
+        "swapchain maintenance1 dependency truth table is wrong"
+    );
+
+    const auto verify_feature =
+        [](VkBool32 _feature_value, bool _expected_enabled) {
+            auto extension =
+                CreateVulkanEXTSwapchainMaintenance1Extension(true);
+            extension->Enable();
+            VkPhysicalDeviceFeatures2 features{
+                VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2
+            };
+            extension->PreGpuFeatures(features);
+            auto* maintenance_features =
+                static_cast<
+                    VkPhysicalDeviceSwapchainMaintenance1FeaturesEXT*>(
+                    features.pNext
+                );
+            Expect(
+                maintenance_features != nullptr &&
+                    maintenance_features->sType ==
+                        VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SWAPCHAIN_MAINTENANCE_1_FEATURES_EXT,
+                "maintenance1 feature query was not chained"
+            );
+            maintenance_features->swapchainMaintenance1 =
+                _feature_value;
+            VulkanOptionalDeviceExtensions optional_extensions{};
+            extension->PostGpuFeatures(optional_extensions);
+            Expect(
+                extension->ShouldEnableDeviceCreate() ==
+                        _expected_enabled &&
+                    optional_extensions.
+                            m_has_ext_swapchain_maintenance1 ==
+                        _expected_enabled,
+                "maintenance1 feature bit did not gate device enablement"
+            );
+        };
+    verify_feature(VK_FALSE, false);
+    verify_feature(VK_TRUE, true);
+}
+
+} // namespace
+
+int main() {
+    static_assert(
+        std::is_copy_constructible_v<PresentationCompletionTicket>
+    );
+    static_assert(
+        std::is_copy_constructible_v<PresentationDrainPoint>
+    );
+
+    try {
+        SeparateStatesRejectCrossMutation();
+        EpochDrainDoesNotCaptureNewGeneration();
+        OutOfOrderRetirementUsesInternalIssueSequence();
+        FastFailureIsNotHeldBehindAcceptedPresent();
+        FailedPresentFenceOutcomeSurvivesRetirement();
+        RetiredSlotGenerationRejectsLateCallbacks();
+        QueueIdleFallbackIsTargetedAndOwnerResolved();
+        WaitersWakeAndStrongOwnersReleaseBoundedly();
+        Maintenance1CapabilityGateIsExplicitAndOptional();
+    } catch (const std::exception& exception) {
+        std::cerr
+            << "RHIPresentationCompletionContract: "
+            << exception.what() << '\n';
+        return 1;
+    }
+
+    std::cout
+        << "RHIPresentationCompletionContract: all checks passed\n";
+    return 0;
+}

--- a/source/test/RenderGraphTest.cpp
+++ b/source/test/RenderGraphTest.cpp
@@ -4109,7 +4109,6 @@ public:
     [[nodiscard]] bool Recreate(const Moer::Render::SwapchainCreateInfo&) override {
         return presentation_ready;
     }
-    void Sync() override {}
 
     [[nodiscard]] bool IsPresentationReady() const noexcept override {
         return presentation_ready;

--- a/source/test/VulkanSubmissionRequestDispatchTest.cpp
+++ b/source/test/VulkanSubmissionRequestDispatchTest.cpp
@@ -2,6 +2,7 @@
 
 #include <iostream>
 #include <stdexcept>
+#include <string_view>
 #include <vector>
 
 using namespace Moer::Render::VulkanSubmissionDetail;
@@ -114,6 +115,69 @@ void SyncExceptionAlwaysCompletes() {
     Expect(complete_count == 1, "Sync exception did not release its waiter");
 }
 
+void PresentationDrainExceptionReachesCompletion() {
+    uint32_t           complete_count = 0;
+    uint32_t           reject_count   = 0;
+    std::exception_ptr propagated_failure{};
+    std::vector<EWorkerRequestFailurePhase> failures;
+
+    const WorkerRequestDispatchResult result =
+        DispatchWorkerRequestNoexcept(
+            EWorkerRequestKind::PresentationDrain,
+            [] {
+                throw std::runtime_error(
+                    "injected Presentation drain failure"
+                );
+            },
+            [&] { ++reject_count; },
+            [&] {
+                ++complete_count;
+                Expect(
+                    propagated_failure != nullptr,
+                    "Presentation drain completion ran before failure publication"
+                );
+            },
+            [&](EWorkerRequestFailurePhase _phase,
+                const std::exception_ptr& _failure) {
+                failures.push_back(_phase);
+                if (_phase == EWorkerRequestFailurePhase::Process) {
+                    propagated_failure = _failure;
+                }
+            }
+        );
+
+    Expect(
+        result.failed,
+        "Presentation drain exception was not reported as failed"
+    );
+    Expect(
+        !result.stop,
+        "Presentation drain exception incorrectly stopped the worker"
+    );
+    Expect(
+        reject_count == 0,
+        "Presentation drain exception incorrectly rejected a Submit"
+    );
+    Expect(
+        complete_count == 1,
+        "Presentation drain exception did not release its waiter exactly once"
+    );
+    Expect(
+        failures.size() == 1 &&
+            failures.front() == EWorkerRequestFailurePhase::Process,
+        "Presentation drain process failure was not diagnosed exactly once"
+    );
+    try {
+        std::rethrow_exception(propagated_failure);
+    } catch (const std::runtime_error& error) {
+        Expect(
+            std::string_view(error.what()) ==
+                "injected Presentation drain failure",
+            "Presentation drain completion lost the process exception"
+        );
+    }
+}
+
 void StopExceptionsAlwaysCompleteAndExit() {
     uint32_t complete_count = 0;
     std::vector<EWorkerRequestFailurePhase> failures;
@@ -167,6 +231,7 @@ int main() {
         SubmitExceptionRejectsEveryOutstandingObligation();
         SubmitExceptionPreservesTerminalizedPrefix();
         SyncExceptionAlwaysCompletes();
+        PresentationDrainExceptionReachesCompletion();
         StopExceptionsAlwaysCompleteAndExit();
         FailureReportingCannotEscapeOrSkipRejection();
         std::cout << "Vulkan submission request dispatch tests passed\n";


### PR DESCRIPTION
## What changed

- Add an RHI-level presentation completion reducer keyed by swapchain state instance, presentation epoch, drawable generation, request serial, issue sequence, fence slot, and slot generation.
- Retire presentation resources only after both GPU completion and the WSI completion mode are resolved; support out-of-order completion and reject stale callbacks after reuse/recreation.
- Add Submission-owned, epoch/generation-targeted presentation drains and propagate drain exceptions through the recording handoff/backend completion path.
- Integrate `VK_EXT_swapchain_maintenance1` present fences when the instance/device dependency and feature gate are actually enabled.
- Keep `accepted` separate from `wsi_enqueued`, including OUT_OF_DATE/SURFACE_LOST/FULL_SCREEN_LOST semantics.
- Provide a bounded compatibility path without maintenance1: Submission-owned queue-idle resolution, using the same graphics/present queue handle selected by the current Vulkan queue topology.
- Make Completion polling non-blocking and head-of-line-safe, and finish shutdown with a frozen presentation frontier before the Completion worker stops.
- Add CPU reducer contracts, Vulkan fallback/owner/shutdown/boundary tests, and drain exception propagation coverage.

## Why

Submission completion alone is not sufficient to prove that WSI has finished consuming present inputs. Swapchain recreation and shutdown therefore need an explicit presentation lifetime model and a targeted drain boundary instead of the old coarse `Swapchain::Sync()` contract.

This follows the ownership/synchronization direction of the staged `dev_parallel_rhi` migration while keeping MoerEngine's current RHI executor and Vulkan extension architecture.

## Validation

- Debug full build: pass
- Release full build: pass
- Debug CTest: 38/38 pass
- Release CTest: 38/38 pass
- Focused presentation completion, request dispatch, legacy-owner, shutdown, and present-boundary tests: pass
- Present-boundary stress: 8/8 pass
- Real Debug MoerEditor smoke with Raytracing + RHI thread + parallel recording: run > 1 minute, maximize/minimize/restore/resize/close cleanly
- Filtered runtime output: no VUID, validation error, device/surface loss, or presentation-drain error; Render and RHI threads stopped cleanly; exit code 0
- `git diff --check`: pass

## Conditional gaps

- Real platform SurfaceLost fault injection remains future validation work.
- D3D12/legacy backends do not yet have Vulkan-maintenance1-equivalent native present-fence parity.
- The no-maintenance1 fallback intentionally prioritizes bounded lifetime/correctness over performance.
- Presentation completion proves WSI resource-consumption completion, not physical scanout time.