### PR TITLE
RHI: add backend-neutral thread heartbeat watchdog

### DIFF
--- a/source/runtime/Engine.cpp
+++ b/source/runtime/Engine.cpp
@@ -1305,7 +1305,9 @@ void Engine::Init(
         "[Threading] render_thread={}, rhi_thread={}, rhi_bypass={}, max_frame_lag={}, "
         "profile_logging={}, parallel_recording={}, parallel_record_workers={}, "
         "parallel_record_verify={}, parallel_record_profile={}, "
-        "parallel_record_min_work_units_per_job={}, submission_batch_window={}",
+        "parallel_record_min_work_units_per_job={}, submission_batch_window={}, "
+        "rhi_heartbeat_enabled={}, rhi_heartbeat_stall_timeout_ms={}, "
+        "rhi_heartbeat_poll_interval_ms={}",
         config.engine.threading.render_thread,
         config.engine.threading.rhi_thread,
         config.engine.threading.rhi_bypass,
@@ -1316,7 +1318,10 @@ void Engine::Init(
         config.engine.threading.parallel_record_verify,
         config.engine.threading.parallel_record_profile,
         config.engine.threading.parallel_record_min_work_units_per_job,
-        submission_batch_window
+        submission_batch_window,
+        config.engine.threading.rhi_heartbeat_enabled,
+        config.engine.threading.rhi_heartbeat_stall_timeout_ms,
+        config.engine.threading.rhi_heartbeat_poll_interval_ms
     );
 
     if (config.engine.threading.render_thread) {
@@ -1378,6 +1383,12 @@ void Engine::Init(
                 .parallel_record_min_work_units_per_job =
                     config.engine.threading.parallel_record_min_work_units_per_job,
                 .submission_batch_window = submission_batch_window,
+                .rhi_heartbeat_enabled =
+                    config.engine.threading.rhi_heartbeat_enabled,
+                .rhi_heartbeat_stall_timeout_ms =
+                    config.engine.threading.rhi_heartbeat_stall_timeout_ms,
+                .rhi_heartbeat_poll_interval_ms =
+                    config.engine.threading.rhi_heartbeat_poll_interval_ms,
                 .parallel_record_worker_throw_trigger =
                     parallel_record_worker_throw_trigger,
                 .vulkan_present_submit_fault_trigger = vulkan_present_submit_fault_trigger,

--- a/source/runtime/core/include/config/GlobalConfig.h
+++ b/source/runtime/core/include/config/GlobalConfig.h
@@ -42,6 +42,9 @@ struct CORE_API GlobalConfig {
             bool parallel_record_profile = false;
             uint parallel_record_min_work_units_per_job = 64;
             uint submission_batch_window = 2;
+            bool rhi_heartbeat_enabled = false;
+            uint rhi_heartbeat_stall_timeout_ms = 5000;
+            uint rhi_heartbeat_poll_interval_ms = 1000;
             uint max_frame_lag           = 0;
         } threading;
 

--- a/source/runtime/core/source/config/GlobalConfig.cpp
+++ b/source/runtime/core/source/config/GlobalConfig.cpp
@@ -51,6 +51,14 @@ GlobalConfig GlobalConfig::LoadConfigFromTomlFile(const std::string_view& toml_p
             .value_or(uint{64});
     loaded_config.engine.threading.submission_batch_window =
         toml_config.at_path("engine.threading.submission_batch_window").value_or(uint{2});
+    loaded_config.engine.threading.rhi_heartbeat_enabled =
+        toml_config.at_path("engine.threading.rhi_heartbeat_enabled").value_or(false);
+    loaded_config.engine.threading.rhi_heartbeat_stall_timeout_ms =
+        toml_config.at_path("engine.threading.rhi_heartbeat_stall_timeout_ms")
+            .value_or(uint{5000});
+    loaded_config.engine.threading.rhi_heartbeat_poll_interval_ms =
+        toml_config.at_path("engine.threading.rhi_heartbeat_poll_interval_ms")
+            .value_or(uint{1000});
     loaded_config.engine.threading.max_frame_lag =
         toml_config.at_path("engine.threading.max_frame_lag").value_or(uint{0});
 

--- a/source/runtime/render/rhi/RHI.cpp
+++ b/source/runtime/render/rhi/RHI.cpp
@@ -9,11 +9,35 @@
 #include "rhi/RHICommon.h"
 #include "rhi/RHIExecutor.h"
 #include "rhi/RHIResource.h"
+#include "rhi/RHIThreadHeartbeat.h"
 #include "shader/ShaderResourceManager.h"
 #include "vulkan/VulkanDevice.h"
 #include <cassert>
 
 namespace Moer::Render {
+namespace {
+
+class RHIHeartbeatStopGuard final {
+public:
+    explicit RHIHeartbeatStopGuard(RHIThreadHeartbeat& _heartbeat) noexcept :
+        heartbeat(_heartbeat) {}
+
+    ~RHIHeartbeatStopGuard() noexcept {
+        if (armed) {
+            heartbeat.Stop();
+        }
+    }
+
+    void Dismiss() noexcept {
+        armed = false;
+    }
+
+private:
+    RHIThreadHeartbeat& heartbeat;
+    bool                armed{true};
+};
+
+} // namespace
 
 template<>
 VulkanRHIConfig ResolveConfigAs(const DeviceInitInfo& _info) {
@@ -72,22 +96,41 @@ bool RenderDevice::IsInitialized() {
     return Get().impl != nullptr;
 }
 void RenderDevice::Init(DeviceInitInfo&& _info) {
-    switch (_info.rhi_type) {
-        case ERHIType::Vulkan:
-            Get().impl =
-                std::move(UniquePtr<Impl>(MoerNew(VulkanDevice)(ResolveConfigAs<VulkanRHIConfig>(_info))));
-            break;
-        case ERHIType::D3D12:
-            Get().impl =
-                std::move(UniquePtr<Impl>(MoerNew(D3D12Device)(ResolveConfigAs<D3D12RHIConfig>(_info))));
-            //LOG_ERROR("D3D12 is not supported yet");
-            break;
+    RHIThreadHeartbeat& heartbeat = RHIThreadHeartbeat::Get();
+    heartbeat.Start(
+        RHIThreadHeartbeatConfig{
+            .enabled = _info.rhi_heartbeat_enabled,
+            .stall_timeout_ms = _info.rhi_heartbeat_stall_timeout_ms,
+            .poll_interval_ms = _info.rhi_heartbeat_poll_interval_ms,
+        }
+    );
+    RHIHeartbeatStopGuard heartbeat_stop_guard(heartbeat);
+    try {
+        switch (_info.rhi_type) {
+            case ERHIType::Vulkan:
+                Get().impl =
+                    std::move(UniquePtr<Impl>(MoerNew(VulkanDevice)(ResolveConfigAs<VulkanRHIConfig>(_info))));
+                break;
+            case ERHIType::D3D12:
+                Get().impl =
+                    std::move(UniquePtr<Impl>(MoerNew(D3D12Device)(ResolveConfigAs<D3D12RHIConfig>(_info))));
+                //LOG_ERROR("D3D12 is not supported yet");
+                break;
+        }
+        Get().rhi_type = _info.rhi_type;
+        RHIExecutor::StartUp(_info.submission_batch_window);
+        Get().impl->PostInit();
+        heartbeat_stop_guard.Dismiss();
+    } catch (...) {
+        RHIExecutor::ShutDown();
+        Get().impl.reset();
+        throw;
     }
-    Get().rhi_type = _info.rhi_type;
-    RHIExecutor::StartUp(_info.submission_batch_window);
-    Get().impl->PostInit();
 }
 void RenderDevice::Dispose() {
+    RHIHeartbeatStopGuard heartbeat_stop_guard(
+        RHIThreadHeartbeat::Get()
+    );
     RHIExecutor::ShutDown();
     // Pooled RHI objects must die while the backend implementation and its
     // allocators are still alive. In-flight owners have already drained with

--- a/source/runtime/render/rhi/RHI.h
+++ b/source/runtime/render/rhi/RHI.h
@@ -48,6 +48,9 @@ struct DeviceInitInfo {
     uint32_t         parallel_record_min_work_units_per_job = 64;
     uint32_t         submission_batch_window =
         Moer::Render::RHISubmissionPipelinePolicy::DefaultBatchWindow;
+    bool             rhi_heartbeat_enabled               = false;
+    uint32_t         rhi_heartbeat_stall_timeout_ms       = 5000;
+    uint32_t         rhi_heartbeat_poll_interval_ms       = 1000;
     uint64_t         parallel_record_worker_throw_trigger = 0;
     uint64_t         vulkan_present_submit_fault_trigger = 0;
 };

--- a/source/runtime/render/rhi/RHIExecutorRecordingHandoff.cpp
+++ b/source/runtime/render/rhi/RHIExecutorRecordingHandoff.cpp
@@ -147,15 +147,18 @@ void RHIExecutorRecordingHandoffQueue::Run(std::stop_token _stop_token) noexcept
     RHIThreadHeartbeatScope heartbeat(
         ERHIThreadRole::Executor,
         ERHIHeartbeatDomain::General,
-        ERHIHeartbeatStage::WaitingForWork
+        ERHIHeartbeatStage::Dispatch
     );
 
     for (;;) {
         RHIExecutorRecordingHandoffWork work{};
         {
-            heartbeat.Pulse(ERHIHeartbeatStage::WaitingForWork);
+            heartbeat.Pulse(ERHIHeartbeatStage::Dispatch);
             std::unique_lock lock(mutex);
-            work_cv.wait(lock, _stop_token, [this] { return !pending.empty(); });
+            RHIThreadHeartbeatWaitLock wait_lock(
+                lock, heartbeat, ERHIHeartbeatStage::Dispatch
+            );
+            work_cv.wait(wait_lock, _stop_token, [this] { return !pending.empty(); });
             if (pending.empty()) {
                 assert(_stop_token.stop_requested());
                 heartbeat.Pulse(ERHIHeartbeatStage::Shutdown);

--- a/source/runtime/render/rhi/RHIExecutorRecordingHandoff.cpp
+++ b/source/runtime/render/rhi/RHIExecutorRecordingHandoff.cpp
@@ -2,6 +2,7 @@
 
 #include "log/LogSystem.h"
 #include "platform/Platform.h"
+#include "rhi/RHIThreadHeartbeat.h"
 #include "rhi/RHIThreadOwnership.h"
 
 #include <cassert>
@@ -143,14 +144,21 @@ bool RHIExecutorRecordingHandoffQueue::IsIdle() const noexcept {
 void RHIExecutorRecordingHandoffQueue::Run(std::stop_token _stop_token) noexcept {
     Platform::SetCurrentThreadName("Moer RHI Executor");
     RHIThreadRoleScope owner_scope(ERHIThreadRole::Executor);
+    RHIThreadHeartbeatScope heartbeat(
+        ERHIThreadRole::Executor,
+        ERHIHeartbeatDomain::General,
+        ERHIHeartbeatStage::WaitingForWork
+    );
 
     for (;;) {
         RHIExecutorRecordingHandoffWork work{};
         {
+            heartbeat.Pulse(ERHIHeartbeatStage::WaitingForWork);
             std::unique_lock lock(mutex);
             work_cv.wait(lock, _stop_token, [this] { return !pending.empty(); });
             if (pending.empty()) {
                 assert(_stop_token.stop_requested());
+                heartbeat.Pulse(ERHIHeartbeatStage::Shutdown);
                 break;
             }
             work = std::move(pending.front());
@@ -160,6 +168,7 @@ void RHIExecutorRecordingHandoffQueue::Run(std::stop_token _stop_token) noexcept
 
         bool ready = true;
         bool cancelled = false;
+        heartbeat.Pulse(ERHIHeartbeatStage::Dispatch);
         for (const RHIRecordingGateRef& prerequisite : work.prerequisites) {
             if (!prerequisite) {
                 ready = false;
@@ -167,7 +176,9 @@ void RHIExecutorRecordingHandoffQueue::Run(std::stop_token _stop_token) noexcept
             }
             ERHIRecordingStatus status = prerequisite->Status();
             if (status == ERHIRecordingStatus::Pending) {
+                heartbeat.Pulse(ERHIHeartbeatStage::WaitForDependency);
                 status = prerequisite->Wait(_stop_token);
+                heartbeat.Pulse(ERHIHeartbeatStage::Dispatch);
             }
             if (status != ERHIRecordingStatus::Succeeded) {
                 ready = false;
@@ -195,6 +206,7 @@ void RHIExecutorRecordingHandoffQueue::Run(std::stop_token _stop_token) noexcept
         idle_cv.notify_all();
 
         if (cancelled) {
+            heartbeat.Pulse(ERHIHeartbeatStage::Shutdown);
             break;
         }
     }
@@ -210,6 +222,7 @@ void RHIExecutorRecordingHandoffQueue::Run(std::stop_token _stop_token) noexcept
     for (RHIExecutorRecordingHandoffWork& work : rejected) {
         ResolveNoThrow(work, ERHIRecordingHandoffResult::Cancel);
     }
+    heartbeat.Pulse(ERHIHeartbeatStage::Shutdown);
 }
 
 void RHIExecutorRecordingHandoffQueue::ResolveNoThrow(

--- a/source/runtime/render/rhi/RHIThreadHeartbeat.cpp
+++ b/source/runtime/render/rhi/RHIThreadHeartbeat.cpp
@@ -1,0 +1,665 @@
+#include "rhi/RHIThreadHeartbeat.h"
+
+#include "log/LogSystem.h"
+#include "platform/Platform.h"
+
+#include <algorithm>
+#include <array>
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <cstddef>
+#include <mutex>
+#include <new>
+#include <thread>
+#include <utility>
+
+namespace Moer::Render {
+namespace {
+
+constexpr std::size_t   kMaxHeartbeatSlots = 128;
+constexpr std::uint64_t kWritingBit        = 1;
+
+thread_local RHIThreadHeartbeatHandle g_current_heartbeat{};
+
+template<typename F>
+class ScopeExit final {
+public:
+    explicit ScopeExit(F&& _callback) noexcept : callback(std::forward<F>(_callback)) {}
+
+    ~ScopeExit() noexcept {
+        callback();
+    }
+
+    ScopeExit(const ScopeExit&)            = delete;
+    ScopeExit& operator=(const ScopeExit&) = delete;
+
+private:
+    F callback;
+};
+
+[[nodiscard]] std::uint64_t ActiveToken(std::uint64_t _generation) noexcept {
+    return _generation << 1;
+}
+
+[[nodiscard]] std::uint64_t TokenGeneration(std::uint64_t _token) noexcept {
+    return _token >> 1;
+}
+
+[[nodiscard]] std::uint64_t ProductionNow(void*) noexcept {
+    return static_cast<std::uint64_t>(std::chrono::duration_cast<std::chrono::nanoseconds>(
+                                          std::chrono::steady_clock::now().time_since_epoch()
+    )
+                                          .count());
+}
+
+void ProductionSink(const RHIThreadHeartbeatEvent& _event, void*) noexcept {
+    try {
+        if (_event.kind == ERHIHeartbeatEventKind::Stalled) {
+            LOG_WARNING(
+                "[RHIHeartbeat] stalled role={} domain={} thread={} slot={} "
+                "generation={} stale_ms={} stage={} progress={}",
+                RHIThreadRoleName(_event.role),
+                RHIHeartbeatDomainName(_event.domain),
+                _event.thread_id,
+                _event.slot_index,
+                _event.generation,
+                _event.stale_ms,
+                RHIHeartbeatStageName(_event.stage),
+                _event.progress_sequence
+            );
+        } else {
+            LOG_INFO(
+                "[RHIHeartbeat] recovered role={} domain={} thread={} slot={} "
+                "generation={} previous_stale_ms={} stage={} progress={}",
+                RHIThreadRoleName(_event.role),
+                RHIHeartbeatDomainName(_event.domain),
+                _event.thread_id,
+                _event.slot_index,
+                _event.generation,
+                _event.stale_ms,
+                RHIHeartbeatStageName(_event.stage),
+                _event.progress_sequence
+            );
+        }
+    } catch (...) {
+        // Diagnostics must never destabilize the ownership pipeline.
+    }
+}
+
+} // namespace
+
+struct RHIThreadHeartbeat::Impl {
+    struct Slot {
+        // 0 = inactive, generation<<1 = active, generation<<1|1 = writer.
+        std::atomic<std::uint64_t> state{0};
+        std::atomic<std::uint64_t> last_pulse_ns{0};
+        std::atomic<std::uint64_t> progress_sequence{0};
+        std::atomic<std::uint32_t> thread_id{0};
+        std::atomic<std::uint8_t>  role{static_cast<std::uint8_t>(ERHIThreadRole::Unknown)};
+        std::atomic<std::uint8_t>  domain{static_cast<std::uint8_t>(ERHIHeartbeatDomain::General)};
+        std::atomic<std::uint8_t>  stage{static_cast<std::uint8_t>(ERHIHeartbeatStage::Registered)};
+    };
+
+    struct MonitorSlot {
+        std::uint64_t generation{0};
+        std::uint64_t progress_sequence{0};
+        std::uint64_t reported_stale_ms{0};
+        bool          stalled{false};
+    };
+
+    RHIThreadHeartbeatConfig                    config{};
+    RHIThreadHeartbeatTestingHooks              hooks{};
+    std::array<Slot, kMaxHeartbeatSlots>        slots{};
+    std::array<MonitorSlot, kMaxHeartbeatSlots> monitor_slots{};
+    mutable std::mutex                          registry_mutex{};
+    std::mutex                                  wait_mutex{};
+    std::condition_variable                     wait_cv{};
+    bool                                        monitor_running{false};
+    std::thread                                 monitor_thread{};
+
+    [[nodiscard]] std::uint64_t Now() const noexcept {
+        const RHIHeartbeatNowFunction now = hooks.now != nullptr ? hooks.now : ProductionNow;
+        return now(hooks.context);
+    }
+
+    void Emit(const RHIThreadHeartbeatEvent& _event) const noexcept {
+        const RHIHeartbeatEventSink sink = hooks.sink != nullptr ? hooks.sink : ProductionSink;
+        sink(_event, hooks.context);
+    }
+};
+
+const char* RHIHeartbeatDomainName(ERHIHeartbeatDomain _domain) noexcept {
+    switch (_domain) {
+        case ERHIHeartbeatDomain::General:
+            return "General";
+        case ERHIHeartbeatDomain::Graphics:
+            return "Graphics";
+        case ERHIHeartbeatDomain::Compute:
+            return "Compute";
+        case ERHIHeartbeatDomain::Copy:
+            return "Copy";
+        case ERHIHeartbeatDomain::Present:
+            return "Present";
+    }
+    return "Invalid";
+}
+
+const char* RHIHeartbeatStageName(ERHIHeartbeatStage _stage) noexcept {
+    switch (_stage) {
+        case ERHIHeartbeatStage::Registered:
+            return "Registered";
+        case ERHIHeartbeatStage::WaitingForWork:
+            return "WaitingForWork";
+        case ERHIHeartbeatStage::Dispatch:
+            return "Dispatch";
+        case ERHIHeartbeatStage::WaitForDependency:
+            return "WaitForDependency";
+        case ERHIHeartbeatStage::RecordCommands:
+            return "RecordCommands";
+        case ERHIHeartbeatStage::Translate:
+            return "Translate";
+        case ERHIHeartbeatStage::WaitForPipelineCapacity:
+            return "WaitForPipelineCapacity";
+        case ERHIHeartbeatStage::Submit:
+            return "Submit";
+        case ERHIHeartbeatStage::NativeSubmit:
+            return "NativeSubmit";
+        case ERHIHeartbeatStage::Present:
+            return "Present";
+        case ERHIHeartbeatStage::PollCompletion:
+            return "PollCompletion";
+        case ERHIHeartbeatStage::AwaitCompletion:
+            return "AwaitCompletion";
+        case ERHIHeartbeatStage::Shutdown:
+            return "Shutdown";
+    }
+    return "Invalid";
+}
+
+bool IsRHIHeartbeatParkedStage(ERHIHeartbeatStage _stage) noexcept {
+    return _stage == ERHIHeartbeatStage::WaitingForWork || _stage == ERHIHeartbeatStage::Shutdown;
+}
+
+RHIThreadHeartbeat& RHIThreadHeartbeat::Get() {
+    static RHIThreadHeartbeat heartbeat{};
+    return heartbeat;
+}
+
+RHIThreadHeartbeat::~RHIThreadHeartbeat() {
+    Stop();
+}
+
+void RHIThreadHeartbeat::Start(RHIThreadHeartbeatConfig _config) noexcept {
+    StartInternal(_config, {}, true);
+}
+
+void RHIThreadHeartbeat::StartForTesting(
+    RHIThreadHeartbeatConfig       _config,
+    RHIThreadHeartbeatTestingHooks _hooks
+) {
+    StartInternal(_config, _hooks, false);
+}
+
+void RHIThreadHeartbeat::StartInternal(
+    RHIThreadHeartbeatConfig       _config,
+    RHIThreadHeartbeatTestingHooks _hooks,
+    bool                           _spawn_monitor
+) noexcept {
+    std::lock_guard lifecycle_lock(lifecycle_mutex);
+    if (enabled.load(std::memory_order_acquire) || impl.load(std::memory_order_acquire) != nullptr) {
+        return;
+    }
+    if (!_config.enabled) {
+        return;
+    }
+
+    _config.stall_timeout_ms = std::max<std::uint32_t>(1000, _config.stall_timeout_ms);
+    _config.poll_interval_ms =
+        std::clamp<std::uint32_t>(_config.poll_interval_ms, 50, _config.stall_timeout_ms);
+
+    Impl* created = new (std::nothrow) Impl{};
+    if (created == nullptr) {
+        return;
+    }
+    created->config = _config;
+    created->hooks  = _hooks;
+    before_reader_gate_hook.store(_hooks.before_reader_gate, std::memory_order_release);
+    impl.store(created, std::memory_order_release);
+    impl_reader_state.store(0, std::memory_order_release);
+    enabled.store(true, std::memory_order_release);
+
+    if (_spawn_monitor) {
+        try {
+            {
+                std::lock_guard lock(created->wait_mutex);
+                created->monitor_running = true;
+            }
+            created->monitor_thread = std::thread([this] {
+                MonitorLoop();
+            });
+        } catch (...) {
+            enabled.store(false, std::memory_order_release);
+            impl_reader_state.fetch_or(kImplReadersStoppingBit, std::memory_order_acq_rel);
+            impl.store(nullptr, std::memory_order_release);
+            WaitForImplReaders();
+            delete created;
+            return;
+        }
+        try {
+            LOG_INFO(
+                "[RHIHeartbeat] enabled timeout_ms={} poll_ms={} slots={}",
+                _config.stall_timeout_ms,
+                _config.poll_interval_ms,
+                kMaxHeartbeatSlots
+            );
+        } catch (...) {
+        }
+    }
+}
+
+void RHIThreadHeartbeat::Stop() noexcept {
+    std::lock_guard lifecycle_lock(lifecycle_mutex);
+    enabled.store(false, std::memory_order_release);
+    impl_reader_state.fetch_or(kImplReadersStoppingBit, std::memory_order_acq_rel);
+    Impl* stopping = impl.exchange(nullptr, std::memory_order_acq_rel);
+    if (stopping == nullptr) {
+        WaitForImplReaders();
+        g_current_heartbeat = {};
+        return;
+    }
+
+    // Stop new registrations/pulses before waking the monitor. RenderDevice
+    // calls this only after backend-owned threads have joined.
+    {
+        std::lock_guard lock(stopping->wait_mutex);
+        stopping->monitor_running = false;
+    }
+    stopping->wait_cv.notify_all();
+    if (stopping->monitor_thread.joinable()) {
+        stopping->monitor_thread.join();
+    }
+
+    WaitForImplReaders();
+    delete stopping;
+    g_current_heartbeat = {};
+}
+
+bool RHIThreadHeartbeat::IsEnabled() const noexcept {
+    return enabled.load(std::memory_order_acquire);
+}
+
+RHIThreadHeartbeat::Impl* RHIThreadHeartbeat::AcquireImplRead() const noexcept {
+    if (!enabled.load(std::memory_order_acquire)) {
+        return nullptr;
+    }
+
+    const RHIHeartbeatReaderAcquireHook before_gate = before_reader_gate_hook.load(std::memory_order_acquire);
+    if (before_gate != nullptr) {
+        before_gate();
+    }
+
+    std::uint64_t state = impl_reader_state.load(std::memory_order_acquire);
+    for (;;) {
+        if ((state & kImplReadersStoppingBit) != 0) {
+            return nullptr;
+        }
+        if ((state & kImplReaderCountMask) == kImplReaderCountMask) {
+            return nullptr;
+        }
+        if (impl_reader_state.compare_exchange_weak(
+                state, state + 1, std::memory_order_acq_rel, std::memory_order_acquire
+            )) {
+            break;
+        }
+    }
+
+    Impl* active = impl.load(std::memory_order_acquire);
+    if (active == nullptr) {
+        ReleaseImplRead();
+        return nullptr;
+    }
+    return active;
+}
+
+void RHIThreadHeartbeat::ReleaseImplRead() const noexcept {
+    const std::uint64_t previous = impl_reader_state.fetch_sub(1, std::memory_order_acq_rel);
+    if ((previous & kImplReaderCountMask) == 1) {
+        impl_reader_state.notify_all();
+    }
+}
+
+void RHIThreadHeartbeat::WaitForImplReaders() noexcept {
+    std::uint64_t state = impl_reader_state.load(std::memory_order_acquire);
+    while ((state & kImplReaderCountMask) != 0) {
+        impl_reader_state.wait(state, std::memory_order_acquire);
+        state = impl_reader_state.load(std::memory_order_acquire);
+    }
+}
+
+RHIThreadHeartbeatHandle RHIThreadHeartbeat::Register(
+    ERHIThreadRole      _role,
+    ERHIHeartbeatDomain _domain,
+    ERHIHeartbeatStage  _stage
+) noexcept {
+    Impl* active = AcquireImplRead();
+    if (active == nullptr) {
+        return {};
+    }
+    ScopeExit release_reader([this]() noexcept {
+        ReleaseImplRead();
+    });
+
+    try {
+        std::lock_guard lock(active->registry_mutex);
+        if (!enabled.load(std::memory_order_acquire) || impl.load(std::memory_order_acquire) != active) {
+            return {};
+        }
+
+        for (std::uint32_t index = 0; index < static_cast<std::uint32_t>(active->slots.size()); ++index) {
+            Impl::Slot& slot = active->slots[index];
+            if (slot.state.load(std::memory_order_acquire) != 0) {
+                continue;
+            }
+
+            std::uint64_t generation = next_generation.fetch_add(1, std::memory_order_relaxed);
+            if (generation == 0) {
+                generation = next_generation.fetch_add(1, std::memory_order_relaxed);
+            }
+
+            slot.thread_id.store(Platform::GetCurrentThreadID(), std::memory_order_relaxed);
+            slot.role.store(static_cast<std::uint8_t>(_role), std::memory_order_relaxed);
+            slot.domain.store(static_cast<std::uint8_t>(_domain), std::memory_order_relaxed);
+            slot.stage.store(static_cast<std::uint8_t>(_stage), std::memory_order_relaxed);
+            slot.last_pulse_ns.store(active->Now(), std::memory_order_relaxed);
+            slot.progress_sequence.store(1, std::memory_order_relaxed);
+            slot.state.store(ActiveToken(generation), std::memory_order_release);
+
+            g_current_heartbeat = {
+                .slot_index = index,
+                .generation = generation,
+            };
+            return g_current_heartbeat;
+        }
+    } catch (...) {
+        // Registration is diagnostics-only and must not escape into an owner
+        // thread, including allocation or platform-query failures.
+    }
+    return {};
+}
+
+void RHIThreadHeartbeat::Pulse(RHIThreadHeartbeatHandle _handle, ERHIHeartbeatStage _stage) noexcept {
+    if (!_handle.IsValid()) {
+        return;
+    }
+
+    Impl* active = AcquireImplRead();
+    if (active == nullptr) {
+        return;
+    }
+    ScopeExit release_reader([this]() noexcept {
+        ReleaseImplRead();
+    });
+    if (_handle.slot_index >= active->slots.size()) {
+        return;
+    }
+
+    Impl::Slot&   slot     = active->slots[_handle.slot_index];
+    std::uint64_t expected = ActiveToken(_handle.generation);
+    if (!slot.state.compare_exchange_strong(
+            expected, expected | kWritingBit, std::memory_order_acquire, std::memory_order_relaxed
+        )) {
+        return;
+    }
+
+    try {
+        slot.thread_id.store(Platform::GetCurrentThreadID(), std::memory_order_relaxed);
+        slot.stage.store(static_cast<std::uint8_t>(_stage), std::memory_order_relaxed);
+        slot.last_pulse_ns.store(active->Now(), std::memory_order_relaxed);
+        slot.progress_sequence.store(
+            slot.progress_sequence.load(std::memory_order_relaxed) + 1, std::memory_order_release
+        );
+    } catch (...) {
+        // Restore a readable token even if a platform diagnostic query fails.
+        // Heartbeat instrumentation must not terminate an owner thread.
+    }
+    slot.state.store(ActiveToken(_handle.generation), std::memory_order_release);
+}
+
+void RHIThreadHeartbeat::PulseCurrent(ERHIHeartbeatStage _stage) noexcept {
+    Pulse(g_current_heartbeat, _stage);
+}
+
+void RHIThreadHeartbeat::Unregister(RHIThreadHeartbeatHandle& _handle) noexcept {
+    if (!_handle.IsValid()) {
+        return;
+    }
+
+    const RHIThreadHeartbeatHandle retiring = _handle;
+    _handle                                 = {};
+    if (g_current_heartbeat.slot_index == retiring.slot_index &&
+        g_current_heartbeat.generation == retiring.generation) {
+        g_current_heartbeat = {};
+    }
+
+    Impl* active = AcquireImplRead();
+    if (active == nullptr) {
+        return;
+    }
+    ScopeExit release_reader([this]() noexcept {
+        ReleaseImplRead();
+    });
+    if (retiring.slot_index >= active->slots.size()) {
+        return;
+    }
+
+    try {
+        std::lock_guard     lock(active->registry_mutex);
+        Impl::Slot&         slot  = active->slots[retiring.slot_index];
+        const std::uint64_t token = ActiveToken(retiring.generation);
+        for (;;) {
+            std::uint64_t expected = slot.state.load(std::memory_order_acquire);
+            if (expected == 0 || TokenGeneration(expected) != retiring.generation) {
+                return;
+            }
+            if ((expected & kWritingBit) != 0) {
+                std::this_thread::yield();
+                continue;
+            }
+            if (!slot.state.compare_exchange_weak(
+                    expected, token | kWritingBit, std::memory_order_acquire, std::memory_order_relaxed
+                )) {
+                continue;
+            }
+            slot.state.store(0, std::memory_order_release);
+            return;
+        }
+    } catch (...) {
+    }
+}
+
+void RHIThreadHeartbeat::MonitorLoop() noexcept {
+    try {
+        Platform::SetCurrentThreadName("Moer RHI Heartbeat");
+    } catch (...) {
+    }
+
+    Impl* active = impl.load(std::memory_order_acquire);
+    if (active == nullptr) {
+        return;
+    }
+
+    for (;;) {
+        {
+            std::unique_lock lock(active->wait_mutex);
+            active->wait_cv
+                .wait_for(lock, std::chrono::milliseconds(active->config.poll_interval_ms), [active] {
+                    return !active->monitor_running;
+                });
+            if (!active->monitor_running) {
+                return;
+            }
+        }
+        PollOnce();
+    }
+}
+
+void RHIThreadHeartbeat::PollOnceForTesting() noexcept {
+    if (!IsMonitorRunningForTesting()) {
+        PollOnce();
+    }
+}
+
+bool RHIThreadHeartbeat::IsMonitorRunningForTesting() const noexcept {
+    Impl* active = AcquireImplRead();
+    if (active == nullptr) {
+        return false;
+    }
+    ScopeExit       release_reader([this]() noexcept {
+        ReleaseImplRead();
+    });
+    std::lock_guard lock(active->wait_mutex);
+    return active->monitor_running;
+}
+
+std::uint32_t RHIThreadHeartbeat::ActiveSlotCountForTesting() const noexcept {
+    Impl* active = AcquireImplRead();
+    if (active == nullptr) {
+        return 0;
+    }
+    ScopeExit     release_reader([this]() noexcept {
+        ReleaseImplRead();
+    });
+    std::uint32_t count = 0;
+    for (const Impl::Slot& slot : active->slots) {
+        const std::uint64_t token = slot.state.load(std::memory_order_acquire);
+        if (token != 0 && (token & kWritingBit) == 0) {
+            ++count;
+        }
+    }
+    return count;
+}
+
+void RHIThreadHeartbeat::PollOnce() noexcept {
+    Impl* active = AcquireImplRead();
+    if (active == nullptr) {
+        return;
+    }
+    ScopeExit release_reader([this]() noexcept {
+        ReleaseImplRead();
+    });
+
+    std::array<RHIThreadHeartbeatEvent, kMaxHeartbeatSlots * 2> events{};
+    std::size_t                                                 event_count = 0;
+    const std::uint64_t                                         now         = active->Now();
+    const std::uint64_t                                         timeout_ns =
+        static_cast<std::uint64_t>(active->config.stall_timeout_ms) * 1'000'000ull;
+
+    for (std::uint32_t index = 0; index < static_cast<std::uint32_t>(active->slots.size()); ++index) {
+        Impl::Slot&        slot    = active->slots[index];
+        Impl::MonitorSlot& monitor = active->monitor_slots[index];
+
+        const std::uint64_t state_before = slot.state.load(std::memory_order_acquire);
+        if (state_before == 0) {
+            monitor = {};
+            continue;
+        }
+        if ((state_before & kWritingBit) != 0) {
+            continue;
+        }
+
+        const std::uint64_t generation = TokenGeneration(state_before);
+        // Progress is also the snapshot sequence. Reading it on both sides of
+        // the payload closes the active->writing->active ABA window where the
+        // state token intentionally returns to the same generation.
+        const std::uint64_t progress_before = slot.progress_sequence.load(std::memory_order_acquire);
+        const std::uint64_t last_pulse_ns   = slot.last_pulse_ns.load(std::memory_order_relaxed);
+        const std::uint32_t thread_id       = slot.thread_id.load(std::memory_order_relaxed);
+        const auto          role = static_cast<ERHIThreadRole>(slot.role.load(std::memory_order_relaxed));
+        const auto domain = static_cast<ERHIHeartbeatDomain>(slot.domain.load(std::memory_order_relaxed));
+        const auto stage  = static_cast<ERHIHeartbeatStage>(slot.stage.load(std::memory_order_relaxed));
+        if (active->hooks.after_snapshot_payload != nullptr) {
+            active->hooks.after_snapshot_payload(index, active->hooks.context);
+        }
+
+        const std::uint64_t state_after    = slot.state.load(std::memory_order_acquire);
+        const std::uint64_t progress_after = slot.progress_sequence.load(std::memory_order_acquire);
+        if (state_before != state_after || progress_before != progress_after) {
+            continue;
+        }
+        const std::uint64_t progress = progress_after;
+
+        if (monitor.generation != generation) {
+            monitor = {
+                .generation        = generation,
+                .progress_sequence = progress,
+            };
+        } else if (monitor.progress_sequence != progress) {
+            if (monitor.stalled && event_count < events.size()) {
+                events[event_count++] = {
+                    .kind              = ERHIHeartbeatEventKind::Recovered,
+                    .role              = role,
+                    .domain            = domain,
+                    .stage             = stage,
+                    .thread_id         = thread_id,
+                    .slot_index        = index,
+                    .generation        = generation,
+                    .progress_sequence = progress,
+                    .stale_ms          = monitor.reported_stale_ms,
+                };
+            }
+            monitor.progress_sequence = progress;
+            monitor.reported_stale_ms = 0;
+            monitor.stalled           = false;
+        }
+
+        if (IsRHIHeartbeatParkedStage(stage)) {
+            continue;
+        }
+
+        const std::uint64_t stale_ns = now >= last_pulse_ns ? now - last_pulse_ns : 0;
+        if (stale_ns < timeout_ns || monitor.stalled) {
+            continue;
+        }
+
+        const std::uint64_t stale_ms = stale_ns / 1'000'000ull;
+        monitor.stalled              = true;
+        monitor.reported_stale_ms    = stale_ms;
+        if (event_count < events.size()) {
+            events[event_count++] = {
+                .kind              = ERHIHeartbeatEventKind::Stalled,
+                .role              = role,
+                .domain            = domain,
+                .stage             = stage,
+                .thread_id         = thread_id,
+                .slot_index        = index,
+                .generation        = generation,
+                .progress_sequence = progress,
+                .stale_ms          = stale_ms,
+            };
+        }
+    }
+
+    for (std::size_t index = 0; index < event_count; ++index) {
+        active->Emit(events[index]);
+    }
+}
+
+RHIThreadHeartbeatScope::RHIThreadHeartbeatScope(
+    ERHIThreadRole      _role,
+    ERHIHeartbeatDomain _domain,
+    ERHIHeartbeatStage  _stage
+) noexcept :
+    previous_handle(g_current_heartbeat),
+    handle(RHIThreadHeartbeat::Get().Register(_role, _domain, _stage)) {}
+
+RHIThreadHeartbeatScope::~RHIThreadHeartbeatScope() {
+    RHIThreadHeartbeat::Get().Unregister(handle);
+    g_current_heartbeat = previous_handle;
+}
+
+void RHIThreadHeartbeatScope::Pulse(ERHIHeartbeatStage _stage) noexcept {
+    RHIThreadHeartbeat::Get().Pulse(handle, _stage);
+}
+
+} // namespace Moer::Render

--- a/source/runtime/render/rhi/RHIThreadHeartbeat.h
+++ b/source/runtime/render/rhi/RHIThreadHeartbeat.h
@@ -170,4 +170,42 @@ private:
     RHIThreadHeartbeatHandle handle{};
 };
 
+// Pass this BasicLockable adapter to condition_variable_any after the initial
+// queue-mutex acquisition. The condition variable parks the heartbeat exactly
+// when it unlocks for a wait and restores the active stage before it attempts
+// to reacquire the mutex, so both initial and post-wake lock contention remain
+// visible to the watchdog.
+template<typename Mutex>
+class RHIThreadHeartbeatWaitLock final {
+public:
+    RHIThreadHeartbeatWaitLock(
+        std::unique_lock<Mutex>& _lock,
+        RHIThreadHeartbeatScope& _heartbeat,
+        ERHIHeartbeatStage       _resume_stage
+    ) noexcept :
+        lock_ref(_lock),
+        heartbeat(_heartbeat),
+        resume_stage(_resume_stage) {}
+
+    RHIThreadHeartbeatWaitLock(const RHIThreadHeartbeatWaitLock&)            = delete;
+    RHIThreadHeartbeatWaitLock& operator=(const RHIThreadHeartbeatWaitLock&) = delete;
+    RHIThreadHeartbeatWaitLock(RHIThreadHeartbeatWaitLock&&)                 = delete;
+    RHIThreadHeartbeatWaitLock& operator=(RHIThreadHeartbeatWaitLock&&)      = delete;
+
+    void lock() {
+        heartbeat.Pulse(resume_stage);
+        lock_ref.lock();
+    }
+
+    void unlock() {
+        heartbeat.Pulse(ERHIHeartbeatStage::WaitingForWork);
+        lock_ref.unlock();
+    }
+
+private:
+    std::unique_lock<Mutex>& lock_ref;
+    RHIThreadHeartbeatScope& heartbeat;
+    ERHIHeartbeatStage       resume_stage;
+};
+
 } // namespace Moer::Render

--- a/source/runtime/render/rhi/RHIThreadHeartbeat.h
+++ b/source/runtime/render/rhi/RHIThreadHeartbeat.h
@@ -1,0 +1,173 @@
+#pragma once
+
+#include "RenderAPI.h"
+#include "rhi/RHIThreadOwnership.h"
+
+#include <atomic>
+#include <cstdint>
+#include <mutex>
+
+namespace Moer::Render {
+
+// Backend-neutral queue/lifecycle domain attached to a heartbeat participant.
+// Keep this set fixed: worker hot paths publish compact IDs and the monitor
+// resolves them to text only when it emits a diagnostic.
+enum class ERHIHeartbeatDomain : std::uint8_t {
+    General,
+    Graphics,
+    Compute,
+    Copy,
+    Present,
+};
+
+// A stage describes the last boundary crossed by an RHI owner. WaitingForWork
+// and Shutdown are deliberately parked states: an idle service thread is
+// healthy even when it does not pulse for longer than the stall timeout.
+enum class ERHIHeartbeatStage : std::uint8_t {
+    Registered,
+    WaitingForWork,
+    Dispatch,
+    WaitForDependency,
+    RecordCommands,
+    Translate,
+    WaitForPipelineCapacity,
+    Submit,
+    NativeSubmit,
+    Present,
+    PollCompletion,
+    AwaitCompletion,
+    Shutdown,
+};
+
+enum class ERHIHeartbeatEventKind : std::uint8_t {
+    Stalled,
+    Recovered,
+};
+
+struct RHIThreadHeartbeatConfig {
+    bool          enabled{false};
+    std::uint32_t stall_timeout_ms{5000};
+    std::uint32_t poll_interval_ms{1000};
+};
+
+struct RHIThreadHeartbeatHandle {
+    std::uint32_t slot_index{UINT32_MAX};
+    std::uint64_t generation{0};
+
+    [[nodiscard]] bool IsValid() const noexcept {
+        return slot_index != UINT32_MAX && generation != 0;
+    }
+};
+
+struct RHIThreadHeartbeatEvent {
+    ERHIHeartbeatEventKind kind{ERHIHeartbeatEventKind::Stalled};
+    ERHIThreadRole         role{ERHIThreadRole::Unknown};
+    ERHIHeartbeatDomain    domain{ERHIHeartbeatDomain::General};
+    ERHIHeartbeatStage     stage{ERHIHeartbeatStage::Registered};
+    std::uint32_t          thread_id{0};
+    std::uint32_t          slot_index{UINT32_MAX};
+    std::uint64_t          generation{0};
+    std::uint64_t          progress_sequence{0};
+    std::uint64_t          stale_ms{0};
+};
+
+using RHIHeartbeatNowFunction = std::uint64_t (*)(void* _context) noexcept;
+using RHIHeartbeatEventSink   = void (*)(const RHIThreadHeartbeatEvent& _event, void* _context) noexcept;
+using RHIHeartbeatReaderAcquireHook = void (*)() noexcept;
+using RHIHeartbeatSnapshotHook      = void (*)(std::uint32_t _slot_index, void* _context) noexcept;
+
+struct RHIThreadHeartbeatTestingHooks {
+    RHIHeartbeatNowFunction       now{nullptr};
+    RHIHeartbeatEventSink         sink{nullptr};
+    RHIHeartbeatReaderAcquireHook before_reader_gate{nullptr};
+    RHIHeartbeatSnapshotHook      after_snapshot_payload{nullptr};
+    void*                         context{nullptr};
+};
+
+RENDER_API const char* RHIHeartbeatDomainName(ERHIHeartbeatDomain _domain) noexcept;
+RENDER_API const char* RHIHeartbeatStageName(ERHIHeartbeatStage _stage) noexcept;
+RENDER_API bool        IsRHIHeartbeatParkedStage(ERHIHeartbeatStage _stage) noexcept;
+
+// Fixed-capacity RHI watchdog. Disabled is the production default: no Impl is
+// allocated, no monitor thread is created, and Register/Pulse return before
+// taking a lock or querying the clock. Enabled Pulse uses a per-slot atomic
+// writer token; registration/reuse alone takes the registry mutex.
+class RENDER_API RHIThreadHeartbeat final {
+public:
+    static RHIThreadHeartbeat& Get();
+
+    void Start(RHIThreadHeartbeatConfig _config) noexcept;
+    void Stop() noexcept;
+
+    [[nodiscard]] bool IsEnabled() const noexcept;
+
+    [[nodiscard]] RHIThreadHeartbeatHandle Register(
+        ERHIThreadRole      _role,
+        ERHIHeartbeatDomain _domain,
+        ERHIHeartbeatStage  _stage = ERHIHeartbeatStage::Registered
+    ) noexcept;
+    void Pulse(RHIThreadHeartbeatHandle _handle, ERHIHeartbeatStage _stage) noexcept;
+    void PulseCurrent(ERHIHeartbeatStage _stage) noexcept;
+    void Unregister(RHIThreadHeartbeatHandle& _handle) noexcept;
+
+    // Deterministic CPU-only contract seam. This starts the same reducer and
+    // slot implementation without a monitor thread; the caller advances its
+    // injected clock and invokes PollOnceForTesting explicitly.
+    void StartForTesting(RHIThreadHeartbeatConfig _config, RHIThreadHeartbeatTestingHooks _hooks);
+    void PollOnceForTesting() noexcept;
+    [[nodiscard]] bool          IsMonitorRunningForTesting() const noexcept;
+    [[nodiscard]] std::uint32_t ActiveSlotCountForTesting() const noexcept;
+
+private:
+    RHIThreadHeartbeat() = default;
+    ~RHIThreadHeartbeat();
+
+    RHIThreadHeartbeat(const RHIThreadHeartbeat&)            = delete;
+    RHIThreadHeartbeat& operator=(const RHIThreadHeartbeat&) = delete;
+
+    void StartInternal(
+        RHIThreadHeartbeatConfig       _config,
+        RHIThreadHeartbeatTestingHooks _hooks,
+        bool                           _spawn_monitor
+    ) noexcept;
+    void MonitorLoop() noexcept;
+    void PollOnce() noexcept;
+
+    struct Impl;
+    [[nodiscard]] Impl* AcquireImplRead() const noexcept;
+    void                ReleaseImplRead() const noexcept;
+    void                WaitForImplReaders() noexcept;
+
+    static constexpr std::uint64_t kImplReadersStoppingBit = std::uint64_t{1} << 63;
+    static constexpr std::uint64_t kImplReaderCountMask    = ~kImplReadersStoppingBit;
+
+    std::atomic<Impl*>                         impl{nullptr};
+    std::atomic_bool                           enabled{false};
+    mutable std::atomic<std::uint64_t>         impl_reader_state{kImplReadersStoppingBit};
+    std::atomic<RHIHeartbeatReaderAcquireHook> before_reader_gate_hook{nullptr};
+    std::atomic<std::uint64_t>                 next_generation{1};
+    std::mutex                                 lifecycle_mutex{};
+};
+
+class RENDER_API RHIThreadHeartbeatScope final {
+public:
+    explicit RHIThreadHeartbeatScope(
+        ERHIThreadRole      _role,
+        ERHIHeartbeatDomain _domain = ERHIHeartbeatDomain::General,
+        ERHIHeartbeatStage  _stage  = ERHIHeartbeatStage::Registered
+    ) noexcept;
+    ~RHIThreadHeartbeatScope();
+
+    RHIThreadHeartbeatScope(const RHIThreadHeartbeatScope&)            = delete;
+    RHIThreadHeartbeatScope& operator=(const RHIThreadHeartbeatScope&) = delete;
+    RHIThreadHeartbeatScope(RHIThreadHeartbeatScope&&)                 = delete;
+    RHIThreadHeartbeatScope& operator=(RHIThreadHeartbeatScope&&)      = delete;
+
+    void Pulse(ERHIHeartbeatStage _stage) noexcept;
+
+private:
+    RHIThreadHeartbeatHandle previous_handle{};
+    RHIThreadHeartbeatHandle handle{};
+};
+
+} // namespace Moer::Render

--- a/source/runtime/render/rhi/d3d12/D3D12Device.cpp
+++ b/source/runtime/render/rhi/d3d12/D3D12Device.cpp
@@ -987,15 +987,19 @@ void D3D12GraphicsCommandQueue::ExecuteThread(std::stop_token _st) {
     RHIThreadHeartbeatScope heartbeat(
         ERHIThreadRole::Completion,
         ERHIHeartbeatDomain::Graphics,
-        ERHIHeartbeatStage::WaitingForWork
+        ERHIHeartbeatStage::PollCompletion
     );
     do {
         {
-            heartbeat.Pulse(ERHIHeartbeatStage::WaitingForWork);
+            heartbeat.Pulse(ERHIHeartbeatStage::PollCompletion);
             std::unique_lock lck(mtx);
-            if (!cv.wait(lck, _st, [&]() {
-                    return !event_queue.empty();
-                })) {
+            RHIThreadHeartbeatWaitLock wait_lock(
+                lck, heartbeat, ERHIHeartbeatStage::PollCompletion
+            );
+            const bool work_ready = cv.wait(wait_lock, _st, [&]() {
+                return !event_queue.empty();
+            });
+            if (!work_ready) {
                 continue;
             }
         }

--- a/source/runtime/render/rhi/d3d12/D3D12Device.cpp
+++ b/source/runtime/render/rhi/d3d12/D3D12Device.cpp
@@ -4,6 +4,7 @@
 
 #include "log/LogSystem.h"
 #include "rhi/RHIResourceInitilizer.h"
+#include "rhi/RHIThreadHeartbeat.h"
 #include "rhi/RHIThreadOwnership.h"
 
 #include "Core.h"
@@ -983,8 +984,14 @@ Allocation D3D12GpuGlobalAllocator::AllocateTextureHeap(
 
 void D3D12GraphicsCommandQueue::ExecuteThread(std::stop_token _st) {
     RHIThreadRoleScope completion_owner(ERHIThreadRole::Completion);
+    RHIThreadHeartbeatScope heartbeat(
+        ERHIThreadRole::Completion,
+        ERHIHeartbeatDomain::Graphics,
+        ERHIHeartbeatStage::WaitingForWork
+    );
     do {
         {
+            heartbeat.Pulse(ERHIHeartbeatStage::WaitingForWork);
             std::unique_lock lck(mtx);
             if (!cv.wait(lck, _st, [&]() {
                     return !event_queue.empty();
@@ -995,6 +1002,7 @@ void D3D12GraphicsCommandQueue::ExecuteThread(std::stop_token _st) {
 
         uint64 fence_value; // local state
 
+        heartbeat.Pulse(ERHIHeartbeatStage::AwaitCompletion);
         is_second_thread_busy = true;
         while (true) {
             std::optional<QueueEvent> evt;
@@ -1042,6 +1050,7 @@ void D3D12GraphicsCommandQueue::ExecuteThread(std::stop_token _st) {
         is_second_thread_busy = false;
 
     } while (!_st.stop_requested());
+    heartbeat.Pulse(ERHIHeartbeatStage::Shutdown);
 }
 
 struct D3D12CommandPreprocessVisitor {
@@ -1502,6 +1511,11 @@ void D3D12GraphicsCommandQueue::Wait(WaitEvent _event) {
 }
 
 WaitEvent D3D12GraphicsCommandQueue::Execute(CmdSubmit&& _submit) {
+    RHIThreadHeartbeatScope heartbeat(
+        ERHIThreadRole::Submission,
+        ERHIHeartbeatDomain::Graphics,
+        ERHIHeartbeatStage::Translate
+    );
     struct SignalFailureGuard {
         CmdSubmit* submit{nullptr};
         bool       armed{true};
@@ -1789,7 +1803,9 @@ WaitEvent D3D12GraphicsCommandQueue::Execute(CmdSubmit&& _submit) {
     try {
         {
             ID3D12CommandList* ppCommandLists[]{cmd_list->Native()};
+            heartbeat.Pulse(ERHIHeartbeatStage::NativeSubmit);
             queue->ExecuteCommandLists(1, ppCommandLists);
+            heartbeat.Pulse(ERHIHeartbeatStage::Submit);
             native_commands_published = true;
         }
         DX_CHECK_HRESULT(queue->Signal(queue_fence.Native(), next_fence_value));

--- a/source/runtime/render/rhi/vulkan/VulkanDevice.cpp
+++ b/source/runtime/render/rhi/vulkan/VulkanDevice.cpp
@@ -22,6 +22,7 @@
 #include "misc/STL.h"
 #include "rhi/RHICommand.h"
 #include "rhi/RHICommon.h"
+#include "rhi/RHIThreadHeartbeat.h"
 #include "rhi/RHIResource.h"
 #include "rhi/RHIResourceInitilizer.h"
 
@@ -1185,7 +1186,13 @@ VulkanOperationResult VulkanDevice::SubmitOnQueue(
     }
 
     native_submit_call_count.fetch_add(1, std::memory_order_relaxed);
+    RHIThreadHeartbeat::Get().PulseCurrent(
+        ERHIHeartbeatStage::NativeSubmit
+    );
     const VkResult result = vkQueueSubmit2(_queue, 1, &_submit_info, _fence);
+    RHIThreadHeartbeat::Get().PulseCurrent(
+        ERHIHeartbeatStage::Submit
+    );
     if (result == VK_SUCCESS) {
         return {};
     }
@@ -1215,7 +1222,13 @@ VulkanOperationResult VulkanDevice::PresentOnQueue(
     }
 
     native_present_call_count.fetch_add(1, std::memory_order_relaxed);
+    RHIThreadHeartbeat::Get().PulseCurrent(
+        ERHIHeartbeatStage::Present
+    );
     const VkResult result = vkQueuePresentKHR(_queue, &_present_info);
+    RHIThreadHeartbeat::Get().PulseCurrent(
+        ERHIHeartbeatStage::Submit
+    );
     if (result == VK_SUCCESS) {
         return {};
     }

--- a/source/runtime/render/rhi/vulkan/VulkanQueue.cpp
+++ b/source/runtime/render/rhi/vulkan/VulkanQueue.cpp
@@ -21,6 +21,7 @@
 #include "rhi/RHIExecutorBackend.h"
 #include "rhi/RHIIO.h"
 #include "rhi/RHIResource.h"
+#include "rhi/RHIThreadHeartbeat.h"
 
 #include "VulkanCustomCommand.h"
 #include "shader/ShaderPipeline.h"
@@ -36,6 +37,19 @@
 #include <variant>
 namespace Moer::Render {
 namespace {
+
+ERHIHeartbeatDomain HeartbeatDomainForQueue(EQueueType _type) noexcept {
+    switch (_type) {
+        case EQueueType::Graphics:
+            return ERHIHeartbeatDomain::Graphics;
+        case EQueueType::Compute:
+            return ERHIHeartbeatDomain::Compute;
+        case EQueueType::Copy:
+            return ERHIHeartbeatDomain::Copy;
+        default:
+            return ERHIHeartbeatDomain::General;
+    }
+}
 
 std::atomic<const VulkanNativeSubmissionObserver*>
     g_native_submission_observer{nullptr};
@@ -5573,6 +5587,11 @@ WaitEvent VkCommandQueue::Execute(CmdSubmit&& _submit) {
     RHIThreadRoleScope submission_owner(
         ERHIThreadRole::Submission
     );
+    RHIThreadHeartbeatScope heartbeat(
+        ERHIThreadRole::Submission,
+        HeartbeatDomainForQueue(queue.GetType()),
+        ERHIHeartbeatStage::Translate
+    );
     std::unique_lock<std::mutex> lock(exec_mtx);
     const uint64 current_timeline = last_frame.fetch_add(1, std::memory_order_relaxed) + 1;
     if (thread_profile) {
@@ -6702,6 +6721,11 @@ bool VkCommandQueue::TryExecuteParallel(
             for (size_t chunk_index = 0; chunk_index < runtime.chunks.size(); ++chunk_index) {
                 wave_jobs.emplace_back([&, layer_index, chunk_index] {
                     RHIThreadRoleScope owner_scope(ERHIThreadRole::RecordWorker);
+                    RHIThreadHeartbeatScope heartbeat(
+                        ERHIThreadRole::RecordWorker,
+                        HeartbeatDomainForQueue(queue.GetType()),
+                        ERHIHeartbeatStage::RecordCommands
+                    );
                     ParallelLayerRuntime& job_layer = runtime_layers[layer_index];
                     ParallelChunkRuntime& chunk     = job_layer.chunks[chunk_index];
                     const uint32 now_active =
@@ -8226,6 +8250,11 @@ void VkCommandQueue::Present(SwapchainRef _sc, TextureView _view, PresentReceipt
     RHIThreadRoleScope submission_owner(
         ERHIThreadRole::Submission
     );
+    RHIThreadHeartbeatScope heartbeat(
+        ERHIThreadRole::Submission,
+        HeartbeatDomainForQueue(queue.GetType()),
+        ERHIHeartbeatStage::Present
+    );
     std::unique_lock<std::mutex> lock(exec_mtx);
     const uint64 current_timeline = last_frame.fetch_add(1, std::memory_order_relaxed) + 1;
     if (thread_profile) {
@@ -9438,6 +9467,11 @@ void VkCommandQueue::RhiThreadMain() {
         queue.GetType() == EQueueType::Graphics ? "Moer RHI Thread" : "Moer Compute RHI"
     );
     RHIThreadRoleScope owner_scope(ERHIThreadRole::Submission);
+    RHIThreadHeartbeatScope heartbeat(
+        ERHIThreadRole::Submission,
+        HeartbeatDomainForQueue(queue.GetType()),
+        ERHIHeartbeatStage::WaitingForWork
+    );
     rhi_thread_id.store(Platform::GetCurrentThreadID(), std::memory_order_release);
     LOG_INFO(
         "[Threading] RHIThread id = {}, queue = {}",
@@ -9448,11 +9482,13 @@ void VkCommandQueue::RhiThreadMain() {
     while (true) {
         std::optional<RhiWork> work;
         {
+            heartbeat.Pulse(ERHIHeartbeatStage::WaitingForWork);
             std::unique_lock<std::mutex> lock(rhi_work_mutex);
             rhi_work_cv.wait(lock, [this]() {
                 return !rhi_worker_running || !rhi_work_queue.empty();
             });
             if (!rhi_worker_running && rhi_work_queue.empty()) {
+                heartbeat.Pulse(ERHIHeartbeatStage::Shutdown);
                 break;
             }
 
@@ -9461,6 +9497,11 @@ void VkCommandQueue::RhiThreadMain() {
         }
 
         const uint64 serial = std::visit([](const auto& _work) { return _work.serial; }, *work);
+        heartbeat.Pulse(
+            std::holds_alternative<RhiExecuteWork>(*work) ?
+                ERHIHeartbeatStage::Translate :
+                ERHIHeartbeatStage::Present
+        );
         {
             std::unique_lock<std::mutex> lock(exec_mtx);
             auto execute_work = [&] {
@@ -9516,6 +9557,7 @@ void VkCommandQueue::RhiThreadMain() {
         rhi_work_done_cv.notify_all();
     }
 
+    heartbeat.Pulse(ERHIHeartbeatStage::Shutdown);
     LOG_INFO("[Threading] RHIThread id = {} stopped", Platform::GetCurrentThreadID());
 }
 
@@ -9705,11 +9747,17 @@ void VkCommandQueue::CompletionThreadMain() {
         queue.GetType() == EQueueType::Graphics ? "Vulkan Gfx Completion" : "Vulkan Compute Completion"
     );
     RHIThreadRoleScope owner_scope(ERHIThreadRole::Completion);
+    RHIThreadHeartbeatScope heartbeat(
+        ERHIThreadRole::Completion,
+        HeartbeatDomainForQueue(queue.GetType()),
+        ERHIHeartbeatStage::WaitingForWork
+    );
 
     bool batch_gpu_success = false;
     bool batch_release_safe = false;
     Array<PendingPresentRetirement> pending_present_retirements{};
     while (true) {
+        heartbeat.Pulse(ERHIHeartbeatStage::PollCompletion);
         for (auto pending = pending_present_retirements.begin();
              pending != pending_present_retirements.end();) {
             if (TryPollPresentRetirement(*pending)) {
@@ -9722,6 +9770,7 @@ void VkCommandQueue::CompletionThreadMain() {
 
         std::optional<QueueEvent> evt;
         {
+            heartbeat.Pulse(ERHIHeartbeatStage::WaitingForWork);
             std::unique_lock<std::mutex> lock(event_mutex);
             if (pending_present_retirements.empty()) {
                 queue_cv.wait(lock, [this]() {
@@ -9737,6 +9786,7 @@ void VkCommandQueue::CompletionThreadMain() {
             }
             if (!completion_worker_running && event_queue.empty() &&
                 pending_present_retirements.empty()) {
+                heartbeat.Pulse(ERHIHeartbeatStage::Shutdown);
                 break;
             }
             if (event_queue.empty()) {
@@ -9747,6 +9797,7 @@ void VkCommandQueue::CompletionThreadMain() {
             event_queue.pop_front();
         }
 
+        heartbeat.Pulse(ERHIHeartbeatStage::AwaitCompletion);
         const uint64 event_timeline = evt->timeline;
         std::visit(
             Overload{
@@ -11309,21 +11360,29 @@ FenceRef VkCopyQueue::GetFenceHandle() {
 void VkCopyQueue::ExecuteThread() {
     Platform::SetCurrentThreadName("Vulkan Copy Completion");
     RHIThreadRoleScope owner_scope(ERHIThreadRole::Completion);
+    RHIThreadHeartbeatScope heartbeat(
+        ERHIThreadRole::Completion,
+        ERHIHeartbeatDomain::Copy,
+        ERHIHeartbeatStage::WaitingForWork
+    );
     bool batch_gpu_success = false;
     while (true) {
         std::optional<IOEvent> evt;
         {
+            heartbeat.Pulse(ERHIHeartbeatStage::WaitingForWork);
             std::unique_lock<std::mutex> lock(event_mutex);
             queue_cv.wait(lock, [this]() {
                 return !enabled.load(std::memory_order_acquire) || !event_queue.empty();
             });
             if (!enabled.load(std::memory_order_acquire) && event_queue.empty()) {
+                heartbeat.Pulse(ERHIHeartbeatStage::Shutdown);
                 break;
             }
             evt.emplace(std::move(event_queue.front()));
             event_queue.pop_front();
         }
 
+        heartbeat.Pulse(ERHIHeartbeatStage::AwaitCompletion);
         const uint64 event_timeline = evt->timeline;
         std::visit(
             Overload{

--- a/source/runtime/render/rhi/vulkan/VulkanQueue.cpp
+++ b/source/runtime/render/rhi/vulkan/VulkanQueue.cpp
@@ -9470,7 +9470,7 @@ void VkCommandQueue::RhiThreadMain() {
     RHIThreadHeartbeatScope heartbeat(
         ERHIThreadRole::Submission,
         HeartbeatDomainForQueue(queue.GetType()),
-        ERHIHeartbeatStage::WaitingForWork
+        ERHIHeartbeatStage::Dispatch
     );
     rhi_thread_id.store(Platform::GetCurrentThreadID(), std::memory_order_release);
     LOG_INFO(
@@ -9482,9 +9482,12 @@ void VkCommandQueue::RhiThreadMain() {
     while (true) {
         std::optional<RhiWork> work;
         {
-            heartbeat.Pulse(ERHIHeartbeatStage::WaitingForWork);
+            heartbeat.Pulse(ERHIHeartbeatStage::Dispatch);
             std::unique_lock<std::mutex> lock(rhi_work_mutex);
-            rhi_work_cv.wait(lock, [this]() {
+            RHIThreadHeartbeatWaitLock wait_lock(
+                lock, heartbeat, ERHIHeartbeatStage::Dispatch
+            );
+            rhi_work_cv.wait(wait_lock, [this]() {
                 return !rhi_worker_running || !rhi_work_queue.empty();
             });
             if (!rhi_worker_running && rhi_work_queue.empty()) {
@@ -9750,7 +9753,7 @@ void VkCommandQueue::CompletionThreadMain() {
     RHIThreadHeartbeatScope heartbeat(
         ERHIThreadRole::Completion,
         HeartbeatDomainForQueue(queue.GetType()),
-        ERHIHeartbeatStage::WaitingForWork
+        ERHIHeartbeatStage::PollCompletion
     );
 
     bool batch_gpu_success = false;
@@ -9770,16 +9773,18 @@ void VkCommandQueue::CompletionThreadMain() {
 
         std::optional<QueueEvent> evt;
         {
-            heartbeat.Pulse(ERHIHeartbeatStage::WaitingForWork);
             std::unique_lock<std::mutex> lock(event_mutex);
+            RHIThreadHeartbeatWaitLock wait_lock(
+                lock, heartbeat, ERHIHeartbeatStage::PollCompletion
+            );
             if (pending_present_retirements.empty()) {
-                queue_cv.wait(lock, [this]() {
+                queue_cv.wait(wait_lock, [this]() {
                     return !completion_worker_running ||
                            !event_queue.empty();
                 });
             } else {
                 queue_cv.wait_for(
-                    lock,
+                    wait_lock,
                     std::chrono::milliseconds(1),
                     [this]() { return !event_queue.empty(); }
                 );
@@ -11363,15 +11368,18 @@ void VkCopyQueue::ExecuteThread() {
     RHIThreadHeartbeatScope heartbeat(
         ERHIThreadRole::Completion,
         ERHIHeartbeatDomain::Copy,
-        ERHIHeartbeatStage::WaitingForWork
+        ERHIHeartbeatStage::PollCompletion
     );
     bool batch_gpu_success = false;
     while (true) {
         std::optional<IOEvent> evt;
         {
-            heartbeat.Pulse(ERHIHeartbeatStage::WaitingForWork);
+            heartbeat.Pulse(ERHIHeartbeatStage::PollCompletion);
             std::unique_lock<std::mutex> lock(event_mutex);
-            queue_cv.wait(lock, [this]() {
+            RHIThreadHeartbeatWaitLock wait_lock(
+                lock, heartbeat, ERHIHeartbeatStage::PollCompletion
+            );
+            queue_cv.wait(wait_lock, [this]() {
                 return !enabled.load(std::memory_order_acquire) || !event_queue.empty();
             });
             if (!enabled.load(std::memory_order_acquire) && event_queue.empty()) {

--- a/source/runtime/render/rhi/vulkan/VulkanQueue.h
+++ b/source/runtime/render/rhi/vulkan/VulkanQueue.h
@@ -1002,7 +1002,7 @@ private:
     VulkanFence*                                       timeline = nullptr;
     std::mutex                                         event_mutex;
     bool                                               completion_worker_running{false};
-    std::condition_variable                            queue_cv;
+    std::condition_variable_any                        queue_cv;
     VkNativeQueue                                      queue;
     VkNativeQueryPool                                  timestamp_pool;
     ProfilerStorage                                    profiler_storage;
@@ -1034,7 +1034,7 @@ private:
     uint64                  completed_rhi_work{0};
     DEQueue<RhiWork>        rhi_work_queue;
     std::mutex              rhi_work_mutex;
-    std::condition_variable rhi_work_cv;
+    std::condition_variable_any rhi_work_cv;
     std::condition_variable rhi_work_done_cv;
 
     std::mutex   exec_mtx;
@@ -1244,7 +1244,7 @@ private:
     VulkanFenceRef          timeline       = nullptr;
     std::mutex              event_mutex;
     std::atomic_bool        enabled{false};
-    std::condition_variable queue_cv; // wake up execute thread from sleeping
+    std::condition_variable_any queue_cv; // wake up execute thread from sleeping
     std::condition_variable settled_cv;
     VkNativeQueue           queue;
     std::jthread            thread;

--- a/source/runtime/render/rhi/vulkan/VulkanSubmissionExecutor.cpp
+++ b/source/runtime/render/rhi/vulkan/VulkanSubmissionExecutor.cpp
@@ -4,6 +4,7 @@
 #include "platform/Platform.h"
 #include "rhi/RHI.h"
 #include "rhi/RHISubmissionPipelinePolicy.h"
+#include "rhi/RHIThreadHeartbeat.h"
 #include "rhi/RHIThreadOwnership.h"
 #include "taskgraph/TaskGraph.h"
 #include "VulkanDevice.h"
@@ -1759,20 +1760,32 @@ void VulkanSubmissionExecutor::ShutDown() {
 void VulkanSubmissionExecutor::RunExecutor() {
     Platform::SetCurrentThreadName("Moer Vulkan Translate");
     RHIThreadRoleScope owner_scope(ERHIThreadRole::Translate);
+    RHIThreadHeartbeatScope heartbeat(
+        ERHIThreadRole::Translate,
+        ERHIHeartbeatDomain::General,
+        ERHIHeartbeatStage::WaitingForWork
+    );
     while (true) {
         Request request{};
         {
+            heartbeat.Pulse(ERHIHeartbeatStage::WaitingForWork);
             std::unique_lock lock(mutex);
             cv.wait(lock, [this] {
                 return constructor_abort || !requests.empty();
             });
             if (constructor_abort && requests.empty()) {
+                heartbeat.Pulse(ERHIHeartbeatStage::Shutdown);
                 break;
             }
             request = std::move(requests.front());
             requests.pop_front();
         }
 
+        heartbeat.Pulse(
+            request.kind == ERequestKind::Submit ?
+                ERHIHeartbeatStage::Translate :
+                ERHIHeartbeatStage::AwaitCompletion
+        );
         BatchExceptionState exception_state{};
         std::exception_ptr  request_failure{};
         const VulkanSubmissionDetail::WorkerRequestDispatchResult dispatch_result =
@@ -1851,9 +1864,11 @@ void VulkanSubmissionExecutor::RunExecutor() {
                 }
             );
         if (dispatch_result.stop) {
+            heartbeat.Pulse(ERHIHeartbeatStage::Shutdown);
             break;
         }
     }
+    heartbeat.Pulse(ERHIHeartbeatStage::Shutdown);
     StopSubmissionThread();
 }
 
@@ -1872,20 +1887,28 @@ bool VulkanSubmissionExecutor::EnqueueSubmissionWork(SubmissionWork&& _work) {
 void VulkanSubmissionExecutor::RunSubmission() {
     Platform::SetCurrentThreadName("Moer Vulkan Submission");
     RHIThreadRoleScope owner_scope(ERHIThreadRole::Submission);
+    RHIThreadHeartbeatScope heartbeat(
+        ERHIThreadRole::Submission,
+        ERHIHeartbeatDomain::General,
+        ERHIHeartbeatStage::WaitingForWork
+    );
     for (;;) {
         SubmissionWork work{};
         {
+            heartbeat.Pulse(ERHIHeartbeatStage::WaitingForWork);
             std::unique_lock lock(submission_mutex);
             submission_cv.wait(lock, [this] {
                 return !submission_accepting || !submission_work.empty();
             });
             if (submission_work.empty()) {
                 assert(!submission_accepting);
+                heartbeat.Pulse(ERHIHeartbeatStage::Shutdown);
                 break;
             }
             work = std::move(submission_work.front());
             submission_work.pop_front();
         }
+        heartbeat.Pulse(ERHIHeartbeatStage::Submit);
         if (work.execute.valid()) {
             // packaged_task captures exceptions and publishes them to the
             // waiting Translate owner; none may escape this service thread.
@@ -1907,10 +1930,16 @@ void VulkanSubmissionExecutor::StopSubmissionThread() {
 
 void VulkanSubmissionExecutor::WaitForPipelineCapacity() {
     while (in_flight_batches.size() >= batch_window) {
+        RHIThreadHeartbeat::Get().PulseCurrent(
+            ERHIHeartbeatStage::WaitForPipelineCapacity
+        );
         std::shared_ptr<Completion> completion =
             std::move(in_flight_batches.front());
         in_flight_batches.pop_front();
         completion->Wait();
+        RHIThreadHeartbeat::Get().PulseCurrent(
+            ERHIHeartbeatStage::Translate
+        );
     }
 }
 
@@ -3485,9 +3514,15 @@ void VulkanSubmissionExecutor::ProcessBatch(
                         (void)LambdaTask::Dispatch(
                             [slot, entry, &completed, &translate_slot] {
                                 RHIThreadRoleScope translate_worker(ERHIThreadRole::Translate);
+                                RHIThreadHeartbeatScope heartbeat(
+                                    ERHIThreadRole::Translate,
+                                    ERHIHeartbeatDomain::General,
+                                    ERHIHeartbeatStage::Translate
+                                );
                                 translate_slot(
                                     *slot, std::move(entry->submit)
                                 );
+                                heartbeat.Pulse(ERHIHeartbeatStage::Shutdown);
                                 completed.count_down();
                             },
                             EThread::AnyThread_NormalPri

--- a/source/runtime/render/rhi/vulkan/VulkanSubmissionExecutor.cpp
+++ b/source/runtime/render/rhi/vulkan/VulkanSubmissionExecutor.cpp
@@ -1763,14 +1763,17 @@ void VulkanSubmissionExecutor::RunExecutor() {
     RHIThreadHeartbeatScope heartbeat(
         ERHIThreadRole::Translate,
         ERHIHeartbeatDomain::General,
-        ERHIHeartbeatStage::WaitingForWork
+        ERHIHeartbeatStage::Dispatch
     );
     while (true) {
         Request request{};
         {
-            heartbeat.Pulse(ERHIHeartbeatStage::WaitingForWork);
+            heartbeat.Pulse(ERHIHeartbeatStage::Dispatch);
             std::unique_lock lock(mutex);
-            cv.wait(lock, [this] {
+            RHIThreadHeartbeatWaitLock wait_lock(
+                lock, heartbeat, ERHIHeartbeatStage::Dispatch
+            );
+            cv.wait(wait_lock, [this] {
                 return constructor_abort || !requests.empty();
             });
             if (constructor_abort && requests.empty()) {
@@ -1890,14 +1893,17 @@ void VulkanSubmissionExecutor::RunSubmission() {
     RHIThreadHeartbeatScope heartbeat(
         ERHIThreadRole::Submission,
         ERHIHeartbeatDomain::General,
-        ERHIHeartbeatStage::WaitingForWork
+        ERHIHeartbeatStage::Dispatch
     );
     for (;;) {
         SubmissionWork work{};
         {
-            heartbeat.Pulse(ERHIHeartbeatStage::WaitingForWork);
+            heartbeat.Pulse(ERHIHeartbeatStage::Dispatch);
             std::unique_lock lock(submission_mutex);
-            submission_cv.wait(lock, [this] {
+            RHIThreadHeartbeatWaitLock wait_lock(
+                lock, heartbeat, ERHIHeartbeatStage::Dispatch
+            );
+            submission_cv.wait(wait_lock, [this] {
                 return !submission_accepting || !submission_work.empty();
             });
             if (submission_work.empty()) {

--- a/source/runtime/render/rhi/vulkan/VulkanSubmissionExecutor.h
+++ b/source/runtime/render/rhi/vulkan/VulkanSubmissionExecutor.h
@@ -294,7 +294,7 @@ private:
     ) noexcept;
 
     std::mutex                 mutex{};
-    std::condition_variable    cv{};
+    std::condition_variable_any cv{};
     std::deque<Request>        requests{};
     std::jthread               executor_thread{};
     bool                       accepting{true};
@@ -328,7 +328,7 @@ private:
         async_scope_seen_queues{};
 
     std::mutex                 submission_mutex{};
-    std::condition_variable    submission_cv{};
+    std::condition_variable_any submission_cv{};
     std::deque<SubmissionWork> submission_work{};
     std::jthread               submission_thread{};
     bool                       submission_accepting{true};

--- a/source/test/CMakeLists.txt
+++ b/source/test/CMakeLists.txt
@@ -380,6 +380,17 @@ target_link_libraries(${test_target}
 set_target_properties(${test_target} PROPERTIES FOLDER ${moer_test_folder})
 add_test(NAME RHIThreadOwnershipContract COMMAND $<TARGET_FILE:${test_target}>)
 
+# CPU-only deterministic watchdog contract. It uses an injected clock/sink to
+# verify stall suppression, recovery, parked stages, slot reuse and teardown.
+set(test_target TestRHIThreadHeartbeat)
+add_executable(${test_target} "RHIThreadHeartbeatTest.cpp")
+target_link_libraries(${test_target}
+    PRIVATE Moer::Render
+)
+set_target_properties(${test_target} PROPERTIES FOLDER ${moer_test_folder})
+add_test(NAME RHIThreadHeartbeatContract COMMAND $<TARGET_FILE:${test_target}>)
+set_tests_properties(RHIThreadHeartbeatContract PROPERTIES TIMEOUT 60)
+
 # CPU-only contract for the bounded cross-batch submission policy. It verifies
 # the configured window clamp and the correctness-critical Graphics/Compute
 # native-queue alias fallback without requiring alias-capable Vulkan hardware.

--- a/source/test/RHIThreadHeartbeatTest.cpp
+++ b/source/test/RHIThreadHeartbeatTest.cpp
@@ -1,0 +1,570 @@
+#include "rhi/RHIThreadHeartbeat.h"
+
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+#include <cstdlib>
+#include <iostream>
+#include <thread>
+#include <vector>
+
+namespace {
+
+using namespace Moer::Render;
+
+struct TestContext {
+    std::uint64_t                        now_ns{0};
+    std::uint32_t                        clock_queries{0};
+    std::vector<RHIThreadHeartbeatEvent> events{};
+};
+
+struct SnapshotRaceContext {
+    std::atomic<std::uint64_t> now_ns{0};
+    std::atomic<std::uint32_t> event_count{0};
+    std::atomic_bool           snapshot_observed{false};
+    std::atomic_bool           pulse_completed{false};
+};
+
+struct StopRaceContext {
+    std::atomic<std::uint64_t> now_ns{0};
+    std::atomic_bool           block_next_clock{false};
+    std::atomic_bool           pulse_entered{false};
+    std::atomic_bool           release_pulse{false};
+};
+
+struct PreGateRaceContext {
+    std::atomic_bool block_next_acquire{false};
+    std::atomic_bool acquire_entered{false};
+    std::atomic_bool release_acquire{false};
+};
+
+PreGateRaceContext g_pre_gate_race{};
+
+std::uint64_t ReadFakeClock(void* _context) noexcept {
+    auto& context = *static_cast<TestContext*>(_context);
+    ++context.clock_queries;
+    return context.now_ns;
+}
+
+void CaptureEvent(const RHIThreadHeartbeatEvent& _event, void* _context) noexcept {
+    static_cast<TestContext*>(_context)->events.emplace_back(_event);
+}
+
+std::uint64_t ReadRaceClock(void* _context) noexcept {
+    return static_cast<SnapshotRaceContext*>(_context)->now_ns.load(std::memory_order_acquire);
+}
+
+void CountRaceEvent(const RHIThreadHeartbeatEvent&, void* _context) noexcept {
+    static_cast<SnapshotRaceContext*>(_context)->event_count.fetch_add(1, std::memory_order_relaxed);
+}
+
+void PauseAfterSnapshotPayload(std::uint32_t, void* _context) noexcept {
+    auto& context = *static_cast<SnapshotRaceContext*>(_context);
+    context.snapshot_observed.store(true, std::memory_order_release);
+    while (!context.pulse_completed.load(std::memory_order_acquire)) {
+        std::this_thread::yield();
+    }
+}
+
+std::uint64_t ReadStopRaceClock(void* _context) noexcept {
+    auto& context = *static_cast<StopRaceContext*>(_context);
+    if (context.block_next_clock.exchange(false, std::memory_order_acq_rel)) {
+        context.pulse_entered.store(true, std::memory_order_release);
+        while (!context.release_pulse.load(std::memory_order_acquire)) {
+            std::this_thread::yield();
+        }
+    }
+    return context.now_ns.load(std::memory_order_acquire);
+}
+
+void PauseBeforeReaderGate() noexcept {
+    if (!g_pre_gate_race.block_next_acquire.exchange(false, std::memory_order_acq_rel)) {
+        return;
+    }
+    g_pre_gate_race.acquire_entered.store(true, std::memory_order_release);
+    while (!g_pre_gate_race.release_acquire.load(std::memory_order_acquire)) {
+        std::this_thread::yield();
+    }
+}
+
+bool WaitForTrue(const std::atomic_bool& _value) {
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds{2};
+    while (!_value.load(std::memory_order_acquire)) {
+        if (std::chrono::steady_clock::now() >= deadline) {
+            return false;
+        }
+        std::this_thread::yield();
+    }
+    return true;
+}
+
+bool Expect(bool _condition, const char* _message) {
+    if (_condition) {
+        return true;
+    }
+    std::cerr << "RHIThreadHeartbeatContract: " << _message << '\n';
+    return false;
+}
+
+RHIThreadHeartbeatConfig EnabledConfig() {
+    return {
+        .enabled          = true,
+        .stall_timeout_ms = 1000,
+        .poll_interval_ms = 100,
+    };
+}
+
+RHIThreadHeartbeatTestingHooks Hooks(TestContext& _context) {
+    return {
+        .now     = ReadFakeClock,
+        .sink    = CaptureEvent,
+        .context = &_context,
+    };
+}
+
+bool DisabledIsAZeroServiceFastPath() {
+    RHIThreadHeartbeat& heartbeat = RHIThreadHeartbeat::Get();
+    heartbeat.Stop();
+
+    TestContext context{};
+    heartbeat.StartForTesting(RHIThreadHeartbeatConfig{.enabled = false}, Hooks(context));
+    RHIThreadHeartbeatHandle handle = heartbeat.Register(
+        ERHIThreadRole::Executor, ERHIHeartbeatDomain::General, ERHIHeartbeatStage::Dispatch
+    );
+    heartbeat.Pulse(handle, ERHIHeartbeatStage::NativeSubmit);
+    heartbeat.PollOnceForTesting();
+
+    const bool okay = Expect(!heartbeat.IsEnabled(), "disabled config started the service") &&
+                      Expect(!heartbeat.IsMonitorRunningForTesting(), "disabled config started a monitor") &&
+                      Expect(!handle.IsValid(), "disabled Register returned a live handle") &&
+                      Expect(context.clock_queries == 0, "disabled hot path queried the clock") &&
+                      Expect(context.events.empty(), "disabled service emitted an event");
+    heartbeat.Stop();
+    return okay;
+}
+
+bool ReportsOneStallThenOneRecovery() {
+    RHIThreadHeartbeat& heartbeat = RHIThreadHeartbeat::Get();
+    heartbeat.Stop();
+
+    TestContext context{.now_ns = 10'000'000'000ull};
+    heartbeat.StartForTesting(EnabledConfig(), Hooks(context));
+    RHIThreadHeartbeatHandle handle = heartbeat.Register(
+        ERHIThreadRole::Translate, ERHIHeartbeatDomain::Graphics, ERHIHeartbeatStage::Translate
+    );
+
+    context.now_ns += 999'000'000ull;
+    heartbeat.PollOnceForTesting();
+    bool okay = Expect(context.events.empty(), "stall reported before timeout");
+
+    context.now_ns += 1'000'000ull;
+    heartbeat.PollOnceForTesting();
+    okay &= Expect(context.events.size() == 1, "first stall was not reported once");
+    if (context.events.size() == 1) {
+        const auto& event = context.events.front();
+        okay &= Expect(event.kind == ERHIHeartbeatEventKind::Stalled, "first event was not a stall");
+        okay &= Expect(
+            event.role == ERHIThreadRole::Translate && event.domain == ERHIHeartbeatDomain::Graphics &&
+                event.stage == ERHIHeartbeatStage::Translate,
+            "stall identity did not preserve role/domain/stage"
+        );
+        okay &= Expect(event.stale_ms == 1000, "stall duration was not deterministic");
+    }
+
+    context.now_ns += 5'000'000'000ull;
+    heartbeat.PollOnceForTesting();
+    okay &= Expect(context.events.size() == 1, "unchanged stall was reported repeatedly");
+
+    heartbeat.Pulse(handle, ERHIHeartbeatStage::NativeSubmit);
+    heartbeat.PollOnceForTesting();
+    okay &= Expect(context.events.size() == 2, "progress did not emit recovery");
+    if (context.events.size() == 2) {
+        const auto& event = context.events.back();
+        okay &= Expect(event.kind == ERHIHeartbeatEventKind::Recovered, "progress event was not recovery");
+        okay &= Expect(
+            event.stage == ERHIHeartbeatStage::NativeSubmit && event.stale_ms == 1000,
+            "recovery did not preserve the new stage and reported stall age"
+        );
+    }
+
+    heartbeat.Unregister(handle);
+    okay &= Expect(heartbeat.ActiveSlotCountForTesting() == 0, "Unregister left a live slot");
+    heartbeat.Stop();
+    return okay;
+}
+
+bool ParkedStagesDoNotReportFalseStalls() {
+    RHIThreadHeartbeat& heartbeat = RHIThreadHeartbeat::Get();
+    heartbeat.Stop();
+
+    TestContext context{.now_ns = 20'000'000'000ull};
+    heartbeat.StartForTesting(EnabledConfig(), Hooks(context));
+    RHIThreadHeartbeatHandle handle = heartbeat.Register(
+        ERHIThreadRole::Completion, ERHIHeartbeatDomain::Copy, ERHIHeartbeatStage::WaitingForWork
+    );
+
+    context.now_ns += 60'000'000'000ull;
+    heartbeat.PollOnceForTesting();
+    bool okay = Expect(context.events.empty(), "idle service thread was reported as stalled");
+
+    heartbeat.Pulse(handle, ERHIHeartbeatStage::Shutdown);
+    context.now_ns += 60'000'000'000ull;
+    heartbeat.PollOnceForTesting();
+    okay &= Expect(context.events.empty(), "shutdown parked state was reported as stalled");
+
+    heartbeat.Unregister(handle);
+    heartbeat.Stop();
+    return okay;
+}
+
+bool GenerationRejectsStaleHandlesAfterReuse() {
+    RHIThreadHeartbeat& heartbeat = RHIThreadHeartbeat::Get();
+    heartbeat.Stop();
+
+    TestContext context{.now_ns = 30'000'000'000ull};
+    heartbeat.StartForTesting(EnabledConfig(), Hooks(context));
+
+    RHIThreadHeartbeatHandle first = heartbeat.Register(
+        ERHIThreadRole::Executor, ERHIHeartbeatDomain::General, ERHIHeartbeatStage::Dispatch
+    );
+    const RHIThreadHeartbeatHandle stale = first;
+    heartbeat.Unregister(first);
+    RHIThreadHeartbeatHandle second = heartbeat.Register(
+        ERHIThreadRole::Submission, ERHIHeartbeatDomain::Compute, ERHIHeartbeatStage::Submit
+    );
+
+    bool okay = Expect(second.slot_index == stale.slot_index, "freed slot was not reused") &&
+                Expect(second.generation != stale.generation, "slot generation did not advance");
+
+    heartbeat.Pulse(stale, ERHIHeartbeatStage::Present);
+    context.now_ns += 1'000'000'000ull;
+    heartbeat.PollOnceForTesting();
+    okay &= Expect(context.events.size() == 1, "reused live slot did not stall");
+    if (context.events.size() == 1) {
+        const auto& event = context.events.front();
+        okay &= Expect(
+            event.generation == second.generation && event.role == ERHIThreadRole::Submission &&
+                event.domain == ERHIHeartbeatDomain::Compute && event.stage == ERHIHeartbeatStage::Submit,
+            "stale handle mutated the reused slot"
+        );
+    }
+
+    heartbeat.Unregister(second);
+    heartbeat.PollOnceForTesting();
+    okay &= Expect(context.events.size() == 1, "Unregister synthesized a recovery event");
+    heartbeat.Stop();
+    return okay;
+}
+
+bool GenerationRejectsStaleHandlesAfterRestart() {
+    RHIThreadHeartbeat& heartbeat = RHIThreadHeartbeat::Get();
+    heartbeat.Stop();
+
+    TestContext first_context{.now_ns = 35'000'000'000ull};
+    heartbeat.StartForTesting(EnabledConfig(), Hooks(first_context));
+    RHIThreadHeartbeatHandle first = heartbeat.Register(
+        ERHIThreadRole::Executor, ERHIHeartbeatDomain::General, ERHIHeartbeatStage::Dispatch
+    );
+    const RHIThreadHeartbeatHandle stale = first;
+    heartbeat.Stop();
+
+    TestContext second_context{.now_ns = 40'000'000'000ull};
+    heartbeat.StartForTesting(EnabledConfig(), Hooks(second_context));
+    RHIThreadHeartbeatHandle second = heartbeat.Register(
+        ERHIThreadRole::Submission, ERHIHeartbeatDomain::Graphics, ERHIHeartbeatStage::Submit
+    );
+
+    bool okay = Expect(second.slot_index == stale.slot_index, "restart did not reuse the first slot") &&
+                Expect(second.generation != stale.generation, "restart reset the slot generation");
+
+    heartbeat.Pulse(stale, ERHIHeartbeatStage::Present);
+    RHIThreadHeartbeatHandle retiring_stale = stale;
+    heartbeat.Unregister(retiring_stale);
+    okay &= Expect(
+        heartbeat.ActiveSlotCountForTesting() == 1, "stale pre-restart handle retired the new participant"
+    );
+
+    second_context.now_ns += 1'000'000'000ull;
+    heartbeat.PollOnceForTesting();
+    okay &= Expect(second_context.events.size() == 1, "restarted live slot did not stall");
+    if (second_context.events.size() == 1) {
+        const auto& event = second_context.events.front();
+        okay &= Expect(
+            event.generation == second.generation && event.role == ERHIThreadRole::Submission &&
+                event.domain == ERHIHeartbeatDomain::Graphics && event.stage == ERHIHeartbeatStage::Submit,
+            "stale pre-restart handle mutated the new participant"
+        );
+    }
+
+    heartbeat.Unregister(second);
+    heartbeat.Stop();
+    return okay;
+}
+
+bool ScopeOwnsRegistrationLifetime() {
+    RHIThreadHeartbeat& heartbeat = RHIThreadHeartbeat::Get();
+    heartbeat.Stop();
+
+    TestContext context{.now_ns = 40'000'000'000ull};
+    heartbeat.StartForTesting(EnabledConfig(), Hooks(context));
+    {
+        RHIThreadHeartbeatScope outer(
+            ERHIThreadRole::RecordWorker, ERHIHeartbeatDomain::Graphics, ERHIHeartbeatStage::RecordCommands
+        );
+        if (!Expect(heartbeat.ActiveSlotCountForTesting() == 1, "scope did not register its participant")) {
+            heartbeat.Stop();
+            return false;
+        }
+        {
+            RHIThreadHeartbeatScope inner(
+                ERHIThreadRole::Submission, ERHIHeartbeatDomain::Graphics, ERHIHeartbeatStage::Submit
+            );
+            if (!Expect(
+                    heartbeat.ActiveSlotCountForTesting() == 2, "nested scope did not register independently"
+                )) {
+                heartbeat.Stop();
+                return false;
+            }
+            heartbeat.PulseCurrent(ERHIHeartbeatStage::NativeSubmit);
+        }
+        if (!Expect(
+                heartbeat.ActiveSlotCountForTesting() == 1, "nested scope did not retire only its own slot"
+            )) {
+            heartbeat.Stop();
+            return false;
+        }
+        heartbeat.PulseCurrent(ERHIHeartbeatStage::Dispatch);
+        context.now_ns += 1'000'000'000ull;
+        heartbeat.PollOnceForTesting();
+        if (!Expect(
+                context.events.size() == 1 && context.events.front().role == ERHIThreadRole::RecordWorker &&
+                    context.events.front().stage == ERHIHeartbeatStage::Dispatch,
+                "nested scope teardown did not restore PulseCurrent"
+            )) {
+            heartbeat.Stop();
+            return false;
+        }
+    }
+
+    const bool okay = Expect(
+        heartbeat.ActiveSlotCountForTesting() == 0, "scope destructor did not unregister its participant"
+    );
+    heartbeat.Stop();
+    return okay;
+}
+
+bool MonitorThreadStopsWithoutWaitingForPollTimeout() {
+    using namespace std::chrono;
+
+    RHIThreadHeartbeat& heartbeat = RHIThreadHeartbeat::Get();
+    heartbeat.Stop();
+    heartbeat.Start(RHIThreadHeartbeatConfig{
+        .enabled          = true,
+        .stall_timeout_ms = 5000,
+        .poll_interval_ms = 5000,
+    });
+    bool okay =
+        Expect(heartbeat.IsMonitorRunningForTesting(), "production Start did not create the monitor thread");
+    RHIThreadHeartbeatHandle handle = heartbeat.Register(
+        ERHIThreadRole::Completion, ERHIHeartbeatDomain::Graphics, ERHIHeartbeatStage::WaitingForWork
+    );
+    const auto begin = steady_clock::now();
+    heartbeat.Stop();
+    const auto elapsed = duration_cast<milliseconds>(steady_clock::now() - begin);
+    okay &= Expect(elapsed < milliseconds{1000}, "Stop waited for the configured poll timeout");
+    heartbeat.Unregister(handle);
+    return okay;
+}
+
+bool ConcurrentRegisterPulseAndReuseLeavesNoSlots() {
+    RHIThreadHeartbeat& heartbeat = RHIThreadHeartbeat::Get();
+    heartbeat.Stop();
+    heartbeat.StartForTesting(EnabledConfig(), {});
+
+    std::atomic<std::uint32_t> failures{0};
+    std::vector<std::jthread>  workers{};
+    workers.reserve(24);
+    for (std::uint32_t worker_index = 0; worker_index < 24; ++worker_index) {
+        workers.emplace_back([&heartbeat, &failures, worker_index] {
+            for (std::uint32_t iteration = 0; iteration < 200; ++iteration) {
+                RHIThreadHeartbeatHandle handle = heartbeat.Register(
+                    ERHIThreadRole::Translate,
+                    (worker_index & 1u) == 0u ? ERHIHeartbeatDomain::Graphics : ERHIHeartbeatDomain::Compute,
+                    ERHIHeartbeatStage::Translate
+                );
+                if (!handle.IsValid()) {
+                    failures.fetch_add(1, std::memory_order_relaxed);
+                    continue;
+                }
+                heartbeat.Pulse(handle, ERHIHeartbeatStage::Dispatch);
+                heartbeat.Pulse(handle, ERHIHeartbeatStage::Translate);
+                heartbeat.Unregister(handle);
+            }
+        });
+    }
+    workers.clear();
+
+    const bool okay =
+        Expect(
+            failures.load(std::memory_order_acquire) == 0, "concurrent registration exhausted or lost a slot"
+        ) &&
+        Expect(heartbeat.ActiveSlotCountForTesting() == 0, "concurrent reuse left an active slot");
+    heartbeat.Stop();
+    return okay;
+}
+
+bool ConcurrentStopWaitsForActivePulseReader() {
+    RHIThreadHeartbeat& heartbeat = RHIThreadHeartbeat::Get();
+    heartbeat.Stop();
+
+    StopRaceContext context{};
+    context.now_ns.store(50'000'000'000ull, std::memory_order_release);
+    heartbeat.StartForTesting(
+        EnabledConfig(),
+        RHIThreadHeartbeatTestingHooks{
+            .now     = ReadStopRaceClock,
+            .context = &context,
+        }
+    );
+    RHIThreadHeartbeatHandle handle = heartbeat.Register(
+        ERHIThreadRole::Submission, ERHIHeartbeatDomain::Graphics, ERHIHeartbeatStage::Submit
+    );
+
+    context.block_next_clock.store(true, std::memory_order_release);
+    std::jthread pulser([&] {
+        heartbeat.Pulse(handle, ERHIHeartbeatStage::NativeSubmit);
+    });
+    bool         okay =
+        Expect(WaitForTrue(context.pulse_entered), "pulse did not enter the blocked diagnostic clock");
+
+    std::atomic_bool stop_returned{false};
+    std::jthread     stopper([&] {
+        heartbeat.Stop();
+        stop_returned.store(true, std::memory_order_release);
+    });
+    const auto       disable_deadline = std::chrono::steady_clock::now() + std::chrono::seconds{2};
+    while (heartbeat.IsEnabled() && std::chrono::steady_clock::now() < disable_deadline) {
+        std::this_thread::yield();
+    }
+    okay &= Expect(!heartbeat.IsEnabled(), "concurrent Stop did not disable new readers");
+    okay &= Expect(
+        !stop_returned.load(std::memory_order_acquire),
+        "Stop deleted the service while Pulse still held a reader"
+    );
+
+    context.release_pulse.store(true, std::memory_order_release);
+    pulser.join();
+    stopper.join();
+    okay &= Expect(
+        stop_returned.load(std::memory_order_acquire),
+        "Stop did not finish after the active Pulse reader drained"
+    );
+    heartbeat.Stop();
+    return okay;
+}
+
+bool StopClosesReaderGateAgainstLateAcquire() {
+    RHIThreadHeartbeat& heartbeat = RHIThreadHeartbeat::Get();
+    heartbeat.Stop();
+
+    g_pre_gate_race.block_next_acquire.store(false, std::memory_order_release);
+    g_pre_gate_race.acquire_entered.store(false, std::memory_order_release);
+    g_pre_gate_race.release_acquire.store(false, std::memory_order_release);
+
+    TestContext context{.now_ns = 60'000'000'000ull};
+    heartbeat.StartForTesting(
+        EnabledConfig(),
+        RHIThreadHeartbeatTestingHooks{
+            .now                = ReadFakeClock,
+            .sink               = CaptureEvent,
+            .before_reader_gate = PauseBeforeReaderGate,
+            .context            = &context,
+        }
+    );
+    RHIThreadHeartbeatHandle handle = heartbeat.Register(
+        ERHIThreadRole::Submission, ERHIHeartbeatDomain::Graphics, ERHIHeartbeatStage::Submit
+    );
+
+    g_pre_gate_race.block_next_acquire.store(true, std::memory_order_release);
+    std::jthread pulser([&] {
+        heartbeat.Pulse(handle, ERHIHeartbeatStage::NativeSubmit);
+    });
+    bool         okay =
+        Expect(WaitForTrue(g_pre_gate_race.acquire_entered), "pulse did not pause before the reader gate");
+
+    std::atomic_bool stop_returned{false};
+    std::jthread     stopper([&] {
+        heartbeat.Stop();
+        stop_returned.store(true, std::memory_order_release);
+    });
+    okay &= Expect(WaitForTrue(stop_returned), "Stop treated a pre-gate caller as an acquired reader");
+    okay &= Expect(!heartbeat.IsEnabled(), "Stop left the reader gate enabled");
+
+    g_pre_gate_race.release_acquire.store(true, std::memory_order_release);
+    pulser.join();
+    stopper.join();
+    heartbeat.Stop();
+    return okay;
+}
+
+bool MonitorSnapshotDoesNotMixPulseGenerations() {
+    RHIThreadHeartbeat& heartbeat = RHIThreadHeartbeat::Get();
+    heartbeat.Stop();
+
+    SnapshotRaceContext context{};
+    context.now_ns.store(10'000'000'000ull, std::memory_order_release);
+    heartbeat.StartForTesting(
+        EnabledConfig(),
+        RHIThreadHeartbeatTestingHooks{
+            .now                    = ReadRaceClock,
+            .sink                   = CountRaceEvent,
+            .after_snapshot_payload = PauseAfterSnapshotPayload,
+            .context                = &context,
+        }
+    );
+    RHIThreadHeartbeatHandle handle = heartbeat.Register(
+        ERHIThreadRole::Submission, ERHIHeartbeatDomain::Graphics, ERHIHeartbeatStage::Submit
+    );
+
+    context.now_ns.store(20'000'000'000ull, std::memory_order_release);
+    std::jthread pulser([&] {
+        while (!context.snapshot_observed.load(std::memory_order_acquire)) {
+            std::this_thread::yield();
+        }
+        heartbeat.Pulse(handle, ERHIHeartbeatStage::NativeSubmit);
+        context.pulse_completed.store(true, std::memory_order_release);
+    });
+    heartbeat.PollOnceForTesting();
+    pulser.join();
+
+    const bool okay =
+        Expect(
+            context.snapshot_observed.load(std::memory_order_acquire), "snapshot race hook was not reached"
+        ) &&
+        Expect(
+            context.pulse_completed.load(std::memory_order_acquire), "snapshot race pulse did not complete"
+        ) &&
+        Expect(
+            context.event_count.load(std::memory_order_acquire) == 0,
+            "monitor mixed old and new pulse payloads into a false stall"
+        );
+    heartbeat.Unregister(handle);
+    heartbeat.Stop();
+    return okay;
+}
+
+} // namespace
+
+int main() {
+    if (!DisabledIsAZeroServiceFastPath() || !ReportsOneStallThenOneRecovery() ||
+        !ParkedStagesDoNotReportFalseStalls() || !GenerationRejectsStaleHandlesAfterReuse() ||
+        !GenerationRejectsStaleHandlesAfterRestart() || !ScopeOwnsRegistrationLifetime() ||
+        !MonitorThreadStopsWithoutWaitingForPollTimeout() ||
+        !ConcurrentRegisterPulseAndReuseLeavesNoSlots() || !ConcurrentStopWaitsForActivePulseReader() ||
+        !StopClosesReaderGateAgainstLateAcquire() || !MonitorSnapshotDoesNotMixPulseGenerations()) {
+        return EXIT_FAILURE;
+    }
+
+    std::cout << "RHI thread heartbeat contract passed\n";
+    return EXIT_SUCCESS;
+}

--- a/source/test/RHIThreadHeartbeatTest.cpp
+++ b/source/test/RHIThreadHeartbeatTest.cpp
@@ -217,6 +217,42 @@ bool ParkedStagesDoNotReportFalseStalls() {
     return okay;
 }
 
+bool WaitLockParksOnlyWhileTheQueueMutexIsReleased() {
+    RHIThreadHeartbeat& heartbeat = RHIThreadHeartbeat::Get();
+    heartbeat.Stop();
+
+    TestContext context{.now_ns = 25'000'000'000ull};
+    heartbeat.StartForTesting(EnabledConfig(), Hooks(context));
+    bool okay = true;
+    {
+        RHIThreadHeartbeatScope owner(
+            ERHIThreadRole::Executor, ERHIHeartbeatDomain::General, ERHIHeartbeatStage::Dispatch
+        );
+        std::mutex                 queue_mutex;
+        std::unique_lock           queue_lock(queue_mutex);
+        RHIThreadHeartbeatWaitLock wait_lock(queue_lock, owner, ERHIHeartbeatStage::Dispatch);
+
+        wait_lock.unlock();
+        okay &= Expect(!queue_lock.owns_lock(), "wait lock did not release the queue mutex");
+        context.now_ns += 60'000'000'000ull;
+        heartbeat.PollOnceForTesting();
+        okay &= Expect(context.events.empty(), "intentional wait was reported as stalled");
+
+        wait_lock.lock();
+        okay &= Expect(queue_lock.owns_lock(), "wait lock did not reacquire the queue mutex");
+        context.now_ns += 1'000'000'000ull;
+        heartbeat.PollOnceForTesting();
+        okay &= Expect(
+            context.events.size() == 1 && context.events.front().kind == ERHIHeartbeatEventKind::Stalled &&
+                context.events.front().stage == ERHIHeartbeatStage::Dispatch,
+            "wait lock did not restore active wake-up processing"
+        );
+    }
+
+    heartbeat.Stop();
+    return okay;
+}
+
 bool GenerationRejectsStaleHandlesAfterReuse() {
     RHIThreadHeartbeat& heartbeat = RHIThreadHeartbeat::Get();
     heartbeat.Stop();
@@ -557,9 +593,9 @@ bool MonitorSnapshotDoesNotMixPulseGenerations() {
 
 int main() {
     if (!DisabledIsAZeroServiceFastPath() || !ReportsOneStallThenOneRecovery() ||
-        !ParkedStagesDoNotReportFalseStalls() || !GenerationRejectsStaleHandlesAfterReuse() ||
-        !GenerationRejectsStaleHandlesAfterRestart() || !ScopeOwnsRegistrationLifetime() ||
-        !MonitorThreadStopsWithoutWaitingForPollTimeout() ||
+        !ParkedStagesDoNotReportFalseStalls() || !WaitLockParksOnlyWhileTheQueueMutexIsReleased() ||
+        !GenerationRejectsStaleHandlesAfterReuse() || !GenerationRejectsStaleHandlesAfterRestart() ||
+        !ScopeOwnsRegistrationLifetime() || !MonitorThreadStopsWithoutWaitingForPollTimeout() ||
         !ConcurrentRegisterPulseAndReuseLeavesNoSlots() || !ConcurrentStopWaitsForActivePulseReader() ||
         !StopClosesReaderGateAgainstLateAcquire() || !MonitorSnapshotDoesNotMixPulseGenerations()) {
         return EXIT_FAILURE;

--- a/template.MoerEngine.toml
+++ b/template.MoerEngine.toml
@@ -30,6 +30,11 @@ parallel_record_min_work_units_per_job = 64
 # Runtime clamps this value to the supported range [1, 8].
 # If Graphics and Compute alias the same native queue, the effective window is 1.
 submission_batch_window = 2
+# Backend-neutral watchdog for Executor/Translate/Submission/Completion owners.
+# Disabled creates no monitor thread and adds only a fast false check.
+rhi_heartbeat_enabled = false
+rhi_heartbeat_stall_timeout_ms = 5000
+rhi_heartbeat_poll_interval_ms = 1000
 
 [engine.profile_dump]
 # Enqueues the initial capture session during Engine startup. The Engine-owned


### PR DESCRIPTION
## Summary

- adds a backend-neutral heartbeat/watchdog for Executor, Translate, Submission, Completion, native submit, and present ownership stages
- keeps the feature default-off with no implementation allocation, monitor thread, or clock queries on the disabled path
- hardens lifecycle safety with generation-tagged handles, race-safe snapshots, and a single atomic stopping/reader gate
- wires Vulkan and D3D12 paths and adds configuration plus deterministic concurrency tests

This is a behavioral reimplementation of the useful `dev_parallel_rhi` heartbeat architecture on top of the current `main` ownership topology; it is not a source-level cherry-pick.

## Validation

- Debug full build
- Debug CTest: 39/39
- Release full build
- Release CTest: 39/39
- GUI runtime with heartbeat enabled: 116 seconds, 0 stall/recovery/Vulkan validation errors, clean shutdown
- `git diff --check`

Known build output contains only the pre-existing `VulkanQueue` uint64-to-uint C4244 warning.