### PR TITLE
Phase 24A: add modern CVar and command control plane

### DIFF
--- a/source/runtime/core/include/command/EngineCommandProcessor.h
+++ b/source/runtime/core/include/command/EngineCommandProcessor.h
@@ -1,0 +1,156 @@
+#pragma once
+
+#include "API_Macro.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace Moer::Command {
+
+struct EngineCommandProcessorLimits {
+    // Zero is normalized to one so every constructed processor remains usable.
+    std::size_t pending_capacity = 256;
+    std::size_t output_capacity  = 2048;
+};
+
+enum class ESubmitStatus : std::uint8_t {
+    Accepted,
+    Empty,
+    QueueFull,
+};
+
+enum class EProcessStatus : std::uint8_t {
+    Processed,
+    Empty,
+    Busy,
+    MaxCommandsZero,
+};
+
+struct ProcessPendingResult {
+    EProcessStatus status    = EProcessStatus::Empty;
+    std::size_t    processed = 0;
+};
+
+struct CommandOutputLineView {
+    std::uint64_t    sequence = 0;
+    std::string_view text;
+};
+
+struct CommandOutputLine {
+    std::uint64_t sequence = 0;
+    std::string   text;
+};
+
+struct CommandOutputPollResult {
+    std::uint64_t next_sequence = 1;
+    std::uint64_t dropped_count = 0;
+    std::size_t   visited_count = 0;
+};
+
+struct CommandOutputBatch {
+    std::vector<CommandOutputLine> lines;
+    std::uint64_t                  next_sequence = 1;
+    std::uint64_t                  dropped_count = 0;
+};
+
+struct CommandCandidateView {
+    std::string_view text;
+    std::string_view helper;
+    bool             is_command = false;
+};
+
+struct CommandCandidate {
+    std::string text;
+    std::string helper;
+    bool        is_command = false;
+};
+
+// View strings are borrowed only for the visitor invocation. Callers that need
+// to retain them must copy, as PollOutput/GetCandidates do.
+using CommandOutputVisitor    = void (*)(const CommandOutputLineView& _line, void* _context);
+using CommandCandidateVisitor = void (*)(const CommandCandidateView& _candidate, void* _context);
+
+// SubmitText is multi-producer safe. ProcessPending is a serialized consumer:
+// a concurrent or callback-reentrant drain returns Busy instead of blocking.
+class EngineCommandProcessor {
+public:
+    CORE_API explicit EngineCommandProcessor(EngineCommandProcessorLimits _limits = {});
+    CORE_API ~EngineCommandProcessor();
+
+    EngineCommandProcessor(const EngineCommandProcessor&)            = delete;
+    EngineCommandProcessor& operator=(const EngineCommandProcessor&) = delete;
+    EngineCommandProcessor(EngineCommandProcessor&&)                 = delete;
+    EngineCommandProcessor& operator=(EngineCommandProcessor&&)      = delete;
+
+    [[nodiscard]] CORE_API ESubmitStatus        SubmitText(std::string_view _text);
+    [[nodiscard]] CORE_API ProcessPendingResult ProcessPending(std::size_t _max_commands = 64);
+
+    // Raw visitors are invoked after releasing processor locks. The owning
+    // convenience wrappers below copy in the caller's allocation domain.
+    [[nodiscard]] CORE_API CommandOutputPollResult VisitOutput(
+        std::uint64_t        _next_sequence,
+        std::size_t          _max_count,
+        CommandOutputVisitor _visitor,
+        void*                _context
+    ) const;
+    [[nodiscard]] CORE_API std::size_t VisitCandidates(
+        std::string_view        _input,
+        std::size_t             _max_count,
+        CommandCandidateVisitor _visitor,
+        void*                   _context
+    ) const;
+
+    [[nodiscard]] CommandOutputBatch
+    PollOutput(std::uint64_t _next_sequence = 1, std::size_t _max_count = 256) const {
+        CommandOutputBatch            batch;
+        const CommandOutputPollResult result = VisitOutput(
+            _next_sequence,
+            _max_count,
+            [](const CommandOutputLineView& _line, void* _context) {
+                static_cast<CommandOutputBatch*>(_context)->lines.push_back({
+                    .sequence = _line.sequence,
+                    .text     = std::string(_line.text),
+                });
+            },
+            &batch
+        );
+        batch.next_sequence = result.next_sequence;
+        batch.dropped_count = result.dropped_count;
+        return batch;
+    }
+
+    [[nodiscard]] std::vector<CommandCandidate>
+    GetCandidates(std::string_view _input, std::size_t _max_count = 64) const {
+        std::vector<CommandCandidate> candidates;
+        static_cast<void>(VisitCandidates(
+            _input,
+            _max_count,
+            [](const CommandCandidateView& _candidate, void* _context) {
+                static_cast<std::vector<CommandCandidate>*>(_context)->push_back({
+                    .text       = std::string(_candidate.text),
+                    .helper     = std::string(_candidate.helper),
+                    .is_command = _candidate.is_command,
+                });
+            },
+            &candidates
+        ));
+        return candidates;
+    }
+
+    CORE_API void ClearOutput();
+
+private:
+    void ProcessCommand(std::string_view _text);
+    void ProcessSlashCommand(std::string_view _text);
+    void ProcessDefaultCVar(std::string_view _text);
+    void AppendOutput(std::string_view _text);
+
+    struct Impl;
+    std::unique_ptr<Impl> impl;
+};
+
+} // namespace Moer::Command

--- a/source/runtime/core/include/config/CVarSystem.h
+++ b/source/runtime/core/include/config/CVarSystem.h
@@ -1,0 +1,420 @@
+#pragma once
+
+#include "API_Macro.h"
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+namespace Moer::CVar {
+
+enum class EType : std::uint8_t {
+    Bool,
+    Int,
+    Float,
+    String,
+};
+
+enum class EFlags : std::uint32_t {
+    None        = 0,
+    ReadOnly    = 1u << 0,
+    StartupOnly = 1u << 1,
+};
+
+constexpr EFlags operator|(EFlags _lhs, EFlags _rhs) noexcept {
+    return static_cast<EFlags>(static_cast<std::uint32_t>(_lhs) | static_cast<std::uint32_t>(_rhs));
+}
+
+constexpr bool HasFlag(EFlags _flags, EFlags _flag) noexcept {
+    return (static_cast<std::uint32_t>(_flags) & static_cast<std::uint32_t>(_flag)) != 0;
+}
+
+enum class ESetSource : std::uint8_t {
+    Runtime,
+    StartupConfig,
+};
+
+enum class ESetStatus : std::uint8_t {
+    Changed,
+    Unchanged,
+    NotFound,
+    TypeMismatch,
+    OutOfRange,
+    ReadOnly,
+    StartupSealed,
+    InvalidRegistration,
+};
+
+struct CVarSetResult {
+    ESetStatus  status            = ESetStatus::NotFound;
+    bool        callback_failed   = false;
+    bool        callback_deferred = false;
+    bool        callback_canceled = false;
+    const char* detail            = nullptr;
+
+    [[nodiscard]] bool Succeeded() const noexcept {
+        return status == ESetStatus::Changed || status == ESetStatus::Unchanged;
+    }
+};
+
+struct CVarDescriptor {
+    std::string           name;
+    std::string           helper;
+    std::string           true_helper;
+    std::string           false_helper;
+    EFlags                flags = EFlags::None;
+    std::optional<double> min_value;
+    std::optional<double> max_value;
+};
+
+struct CVarDescriptorView {
+    std::string_view      name;
+    std::string_view      helper;
+    std::string_view      true_helper;
+    std::string_view      false_helper;
+    EFlags                flags = EFlags::None;
+    std::optional<double> min_value;
+    std::optional<double> max_value;
+};
+
+struct CVarSnapshotView {
+    std::uint64_t         id = 0;
+    std::string_view      name;
+    std::string_view      helper;
+    std::string_view      true_helper;
+    std::string_view      false_helper;
+    std::string_view      value;
+    EType                 type  = EType::String;
+    EFlags                flags = EFlags::None;
+    std::optional<double> min_value;
+    std::optional<double> max_value;
+    bool                  startup_sealed = false;
+};
+
+struct CVarSnapshot {
+    std::uint64_t         id = 0;
+    std::string           name;
+    std::string           helper;
+    std::string           true_helper;
+    std::string           false_helper;
+    std::string           value;
+    EType                 type  = EType::String;
+    EFlags                flags = EFlags::None;
+    std::optional<double> min_value;
+    std::optional<double> max_value;
+    bool                  startup_sealed = false;
+};
+
+enum class ERegistrationStatus : std::uint8_t {
+    Registered,
+    InvalidDescriptor,
+    DuplicateName,
+};
+
+class Registration;
+
+namespace Detail {
+struct RegistrationAccess {
+    static Registration Create(std::uint64_t _id) noexcept;
+};
+} // namespace Detail
+
+// Each cvar serializes its own commits and callback FIFO. User callbacks and
+// caller-side destroy thunks run without registry or entry locks. A concurrent
+// mutation may commit while an earlier callback is running; it returns with
+// callback_deferred instead of waiting. The active dispatcher considers that
+// callback later in commit order, but Reset may cancel it first. A deferred
+// result has no completion query in this phase, so its eventual callback
+// success/failure/cancellation is intentionally not reported to that caller.
+// Callbacks may re-enter the registry.
+class Registration {
+public:
+    Registration() noexcept = default;
+    CORE_API ~Registration();
+
+    Registration(const Registration&)                     = delete;
+    Registration&          operator=(const Registration&) = delete;
+    CORE_API               Registration(Registration&& _other) noexcept;
+    CORE_API Registration& operator=(Registration&& _other) noexcept;
+
+    [[nodiscard]] bool IsValid() const noexcept {
+        return id != 0;
+    }
+    [[nodiscard]] std::uint64_t GetId() const noexcept {
+        return id;
+    }
+    [[nodiscard]] std::optional<CVarSnapshot> GetSnapshot() const;
+
+    CORE_API CVarSetResult SynchronizeOwnerValue(bool _value);
+    CORE_API CVarSetResult SynchronizeOwnerValue(std::int64_t _value);
+    CORE_API CVarSetResult SynchronizeOwnerValue(double _value);
+    CORE_API CVarSetResult SynchronizeOwnerValue(std::string_view _value);
+
+    // Reset removes the name first and retires the caller callback thunk.
+    // Calls made outside cvar callbacks and callback-capture destruction wait
+    // for in-flight work. Any Reset made from either chain is non-blocking to
+    // avoid cross-entry wait cycles; the last active dispatcher retires the
+    // thunk after returning from user code.
+    CORE_API void Reset() noexcept;
+
+private:
+    explicit Registration(std::uint64_t _id) noexcept;
+
+    std::uint64_t id = 0;
+
+    friend struct Detail::RegistrationAccess;
+};
+
+struct RegistrationResult {
+    ERegistrationStatus status = ERegistrationStatus::InvalidDescriptor;
+    Registration        registration;
+    const char*         detail = nullptr;
+
+    [[nodiscard]] bool Succeeded() const noexcept {
+        return status == ERegistrationStatus::Registered && registration.IsValid();
+    }
+};
+
+// Every string_view in CVarSnapshotView is valid only for the duration of the
+// visitor call. Copy it inside the callback; never retain the view.
+using SnapshotVisitor = void (*)(const CVarSnapshotView& _snapshot, void* _context);
+
+namespace Detail {
+
+using DestroyCallback = void (*)(void* _context) noexcept;
+using BoolCallback    = bool (*)(void* _context, bool _old_value, bool _new_value) noexcept;
+using IntCallback     = bool (*)(void* _context, std::int64_t _old_value, std::int64_t _new_value) noexcept;
+using FloatCallback   = bool (*)(void* _context, double _old_value, double _new_value) noexcept;
+using StringCallback =
+    bool (*)(void* _context, std::string_view _old_value, std::string_view _new_value) noexcept;
+
+// Raw registration takes ownership after validating a complete callback
+// binding, including later invalid/duplicate/error paths. An incomplete
+// binding is rejected without taking ownership; a valid binding is either
+// entirely empty or provides callback, context, and destroy together.
+CORE_API RegistrationResult RegisterBoolRaw(
+    CVarDescriptorView _descriptor,
+    bool               _default_value,
+    BoolCallback       _callback,
+    void*              _context,
+    DestroyCallback    _destroy
+);
+CORE_API RegistrationResult RegisterIntRaw(
+    CVarDescriptorView _descriptor,
+    std::int64_t       _default_value,
+    IntCallback        _callback,
+    void*              _context,
+    DestroyCallback    _destroy
+);
+CORE_API RegistrationResult RegisterFloatRaw(
+    CVarDescriptorView _descriptor,
+    double             _default_value,
+    FloatCallback      _callback,
+    void*              _context,
+    DestroyCallback    _destroy
+);
+CORE_API RegistrationResult RegisterStringRaw(
+    CVarDescriptorView _descriptor,
+    std::string_view   _default_value,
+    StringCallback     _callback,
+    void*              _context,
+    DestroyCallback    _destroy
+);
+
+CORE_API bool VisitSnapshotRaw(std::string_view _name, SnapshotVisitor _visitor, void* _context);
+CORE_API bool VisitSnapshotByIdRaw(std::uint64_t _id, SnapshotVisitor _visitor, void* _context);
+CORE_API std::size_t VisitAllSnapshotsRaw(std::string_view _prefix, SnapshotVisitor _visitor, void* _context);
+
+inline CVarDescriptorView ViewOf(const CVarDescriptor& _descriptor) noexcept {
+    return {
+        .name         = _descriptor.name,
+        .helper       = _descriptor.helper,
+        .true_helper  = _descriptor.true_helper,
+        .false_helper = _descriptor.false_helper,
+        .flags        = _descriptor.flags,
+        .min_value    = _descriptor.min_value,
+        .max_value    = _descriptor.max_value,
+    };
+}
+
+template<typename Callback>
+void DestroyOwnedCallback(void* _context) noexcept {
+    delete static_cast<Callback*>(_context);
+}
+
+template<typename Callback>
+bool InvokeBoolCallback(void* _context, bool _old_value, bool _new_value) noexcept {
+    try {
+        std::invoke(*static_cast<Callback*>(_context), _old_value, _new_value);
+        return true;
+    } catch (...) {
+        return false;
+    }
+}
+
+template<typename Callback>
+bool InvokeIntCallback(void* _context, std::int64_t _old_value, std::int64_t _new_value) noexcept {
+    try {
+        std::invoke(*static_cast<Callback*>(_context), _old_value, _new_value);
+        return true;
+    } catch (...) {
+        return false;
+    }
+}
+
+template<typename Callback>
+bool InvokeFloatCallback(void* _context, double _old_value, double _new_value) noexcept {
+    try {
+        std::invoke(*static_cast<Callback*>(_context), _old_value, _new_value);
+        return true;
+    } catch (...) {
+        return false;
+    }
+}
+
+template<typename Callback>
+bool InvokeStringCallback(void* _context, std::string_view _old_value, std::string_view _new_value) noexcept {
+    try {
+        std::invoke(*static_cast<Callback*>(_context), _old_value, _new_value);
+        return true;
+    } catch (...) {
+        return false;
+    }
+}
+
+inline CVarSnapshot CopySnapshot(const CVarSnapshotView& _view) {
+    return {
+        .id             = _view.id,
+        .name           = std::string(_view.name),
+        .helper         = std::string(_view.helper),
+        .true_helper    = std::string(_view.true_helper),
+        .false_helper   = std::string(_view.false_helper),
+        .value          = std::string(_view.value),
+        .type           = _view.type,
+        .flags          = _view.flags,
+        .min_value      = _view.min_value,
+        .max_value      = _view.max_value,
+        .startup_sealed = _view.startup_sealed,
+    };
+}
+
+} // namespace Detail
+
+inline RegistrationResult RegisterBool(const CVarDescriptor& _descriptor, bool _default_value) {
+    return Detail::RegisterBoolRaw(Detail::ViewOf(_descriptor), _default_value, nullptr, nullptr, nullptr);
+}
+
+template<typename Callback>
+RegistrationResult
+RegisterBool(const CVarDescriptor& _descriptor, bool _default_value, Callback&& _callback) {
+    using StoredCallback = std::decay_t<Callback>;
+    auto* context        = new StoredCallback(std::forward<Callback>(_callback));
+    return Detail::
+        RegisterBoolRaw(Detail::ViewOf(_descriptor), _default_value, &Detail::InvokeBoolCallback<StoredCallback>, context, &Detail::DestroyOwnedCallback<StoredCallback>);
+}
+
+inline RegistrationResult RegisterInt(const CVarDescriptor& _descriptor, std::int64_t _default_value) {
+    return Detail::RegisterIntRaw(Detail::ViewOf(_descriptor), _default_value, nullptr, nullptr, nullptr);
+}
+
+template<typename Callback>
+RegistrationResult
+RegisterInt(const CVarDescriptor& _descriptor, std::int64_t _default_value, Callback&& _callback) {
+    using StoredCallback = std::decay_t<Callback>;
+    auto* context        = new StoredCallback(std::forward<Callback>(_callback));
+    return Detail::
+        RegisterIntRaw(Detail::ViewOf(_descriptor), _default_value, &Detail::InvokeIntCallback<StoredCallback>, context, &Detail::DestroyOwnedCallback<StoredCallback>);
+}
+
+inline RegistrationResult RegisterFloat(const CVarDescriptor& _descriptor, double _default_value) {
+    return Detail::RegisterFloatRaw(Detail::ViewOf(_descriptor), _default_value, nullptr, nullptr, nullptr);
+}
+
+template<typename Callback>
+RegistrationResult
+RegisterFloat(const CVarDescriptor& _descriptor, double _default_value, Callback&& _callback) {
+    using StoredCallback = std::decay_t<Callback>;
+    auto* context        = new StoredCallback(std::forward<Callback>(_callback));
+    return Detail::
+        RegisterFloatRaw(Detail::ViewOf(_descriptor), _default_value, &Detail::InvokeFloatCallback<StoredCallback>, context, &Detail::DestroyOwnedCallback<StoredCallback>);
+}
+
+inline RegistrationResult RegisterString(const CVarDescriptor& _descriptor, std::string_view _default_value) {
+    return Detail::RegisterStringRaw(Detail::ViewOf(_descriptor), _default_value, nullptr, nullptr, nullptr);
+}
+
+template<typename Callback>
+RegistrationResult
+RegisterString(const CVarDescriptor& _descriptor, std::string_view _default_value, Callback&& _callback) {
+    using StoredCallback = std::decay_t<Callback>;
+    auto* context        = new StoredCallback(std::forward<Callback>(_callback));
+    return Detail::
+        RegisterStringRaw(Detail::ViewOf(_descriptor), _default_value, &Detail::InvokeStringCallback<StoredCallback>, context, &Detail::DestroyOwnedCallback<StoredCallback>);
+}
+
+inline std::optional<CVarSnapshot> Find(std::string_view _name) {
+    std::optional<CVarSnapshot> snapshot;
+    Detail::VisitSnapshotRaw(
+        _name,
+        [](const CVarSnapshotView& _view, void* _context) {
+            *static_cast<std::optional<CVarSnapshot>*>(_context) = Detail::CopySnapshot(_view);
+        },
+        &snapshot
+    );
+    return snapshot;
+}
+
+inline std::optional<CVarSnapshot> FindById(std::uint64_t _id) {
+    std::optional<CVarSnapshot> snapshot;
+    Detail::VisitSnapshotByIdRaw(
+        _id,
+        [](const CVarSnapshotView& _view, void* _context) {
+            *static_cast<std::optional<CVarSnapshot>*>(_context) = Detail::CopySnapshot(_view);
+        },
+        &snapshot
+    );
+    return snapshot;
+}
+
+inline std::vector<CVarSnapshot> List(std::string_view _prefix = {}) {
+    std::vector<CVarSnapshot> snapshots;
+    Detail::VisitAllSnapshotsRaw(
+        _prefix,
+        [](const CVarSnapshotView& _view, void* _context) {
+            static_cast<std::vector<CVarSnapshot>*>(_context)->push_back(Detail::CopySnapshot(_view));
+        },
+        &snapshots
+    );
+    std::ranges::sort(snapshots, [](const CVarSnapshot& _lhs, const CVarSnapshot& _rhs) {
+        const auto less_insensitive = [](char _left, char _right) {
+            const char left = _left >= 'A' && _left <= 'Z' ? static_cast<char>(_left + ('a' - 'A')) : _left;
+            const char right =
+                _right >= 'A' && _right <= 'Z' ? static_cast<char>(_right + ('a' - 'A')) : _right;
+            return left < right;
+        };
+        return std::lexicographical_compare(
+            _lhs.name.begin(), _lhs.name.end(), _rhs.name.begin(), _rhs.name.end(), less_insensitive
+        );
+    });
+    return snapshots;
+}
+
+CORE_API CVarSetResult
+SetValueFromString(std::string_view _name, std::string_view _value, ESetSource _source = ESetSource::Runtime);
+
+CORE_API void SealStartupOnlyCVars();
+CORE_API bool IsStartupConfigurationSealed() noexcept;
+
+inline std::optional<CVarSnapshot> Registration::GetSnapshot() const {
+    return FindById(id);
+}
+
+} // namespace Moer::CVar

--- a/source/runtime/core/include/config/CVarSystem.h
+++ b/source/runtime/core/include/config/CVarSystem.h
@@ -172,7 +172,9 @@ public:
     // Calls made outside cvar callbacks and callback-capture destruction wait
     // for in-flight work. Any Reset made from either chain is non-blocking to
     // avoid cross-entry wait cycles; the last active dispatcher retires the
-    // thunk after returning from user code.
+    // thunk after returning from user code. Snapshot visitors are not in-flight
+    // operations after capture: Reset does not wait for them, and a visitor may
+    // finish with an old id/value after a same-name generation is registered.
     CORE_API void Reset() noexcept;
 
 private:
@@ -194,7 +196,9 @@ struct RegistrationResult {
 };
 
 // Every string_view in CVarSnapshotView is valid only for the duration of the
-// visitor call. Copy it inside the callback; never retain the view.
+// visitor call. Copy it inside the callback; never retain the view. The visitor
+// runs after snapshot capture has released its active Entry operation, so Reset
+// may complete concurrently while the immutable old snapshot remains valid.
 using SnapshotVisitor = void (*)(const CVarSnapshotView& _snapshot, void* _context);
 
 namespace Detail {

--- a/source/runtime/core/include/config/CVarSystem.h
+++ b/source/runtime/core/include/config/CVarSystem.h
@@ -169,12 +169,13 @@ public:
     CORE_API CVarSetResult SynchronizeOwnerValue(std::string_view _value);
 
     // Reset removes the name first and retires the caller callback thunk.
-    // Calls made outside cvar callbacks and callback-capture destruction wait
-    // for in-flight work. Any Reset made from either chain is non-blocking to
-    // avoid cross-entry wait cycles; the last active dispatcher retires the
-    // thunk after returning from user code. Snapshot visitors are not in-flight
-    // operations after capture: Reset does not wait for them, and a visitor may
-    // finish with an old id/value after a same-name generation is registered.
+    // Calls made outside cvar callbacks, callback-capture destruction, and
+    // snapshot visitors wait for in-flight work. Reset from any of those
+    // user-code chains is non-blocking to avoid cross-entry wait cycles; the
+    // last active dispatcher retires the thunk after returning from user code.
+    // Snapshot visitors are not in-flight operations after capture: Reset does
+    // not wait for them, and a visitor may finish with an old id/value after a
+    // same-name generation is registered.
     CORE_API void Reset() noexcept;
 
 private:
@@ -199,6 +200,8 @@ struct RegistrationResult {
 // visitor call. Copy it inside the callback; never retain the view. The visitor
 // runs after snapshot capture has released its active Entry operation, so Reset
 // may complete concurrently while the immutable old snapshot remains valid.
+// Reset called from visitor code is non-blocking with respect to other active
+// Entry operations to avoid user-code wait cycles.
 using SnapshotVisitor = void (*)(const CVarSnapshotView& _snapshot, void* _context);
 
 namespace Detail {

--- a/source/runtime/core/include/config/CVarSystem.h
+++ b/source/runtime/core/include/config/CVarSystem.h
@@ -335,9 +335,10 @@ template<typename Callback>
 RegistrationResult
 RegisterBool(const CVarDescriptor& _descriptor, bool _default_value, Callback&& _callback) {
     using StoredCallback = std::decay_t<Callback>;
-    auto* context        = new StoredCallback(std::forward<Callback>(_callback));
+    CVarDescriptor descriptor_snapshot = _descriptor;
+    auto*          context             = new StoredCallback(std::forward<Callback>(_callback));
     return Detail::
-        RegisterBoolRaw(Detail::ViewOf(_descriptor), _default_value, &Detail::InvokeBoolCallback<StoredCallback>, context, &Detail::DestroyOwnedCallback<StoredCallback>);
+        RegisterBoolRaw(Detail::ViewOf(descriptor_snapshot), _default_value, &Detail::InvokeBoolCallback<StoredCallback>, context, &Detail::DestroyOwnedCallback<StoredCallback>);
 }
 
 inline RegistrationResult RegisterInt(const CVarDescriptor& _descriptor, std::int64_t _default_value) {
@@ -348,9 +349,10 @@ template<typename Callback>
 RegistrationResult
 RegisterInt(const CVarDescriptor& _descriptor, std::int64_t _default_value, Callback&& _callback) {
     using StoredCallback = std::decay_t<Callback>;
-    auto* context        = new StoredCallback(std::forward<Callback>(_callback));
+    CVarDescriptor descriptor_snapshot = _descriptor;
+    auto*          context             = new StoredCallback(std::forward<Callback>(_callback));
     return Detail::
-        RegisterIntRaw(Detail::ViewOf(_descriptor), _default_value, &Detail::InvokeIntCallback<StoredCallback>, context, &Detail::DestroyOwnedCallback<StoredCallback>);
+        RegisterIntRaw(Detail::ViewOf(descriptor_snapshot), _default_value, &Detail::InvokeIntCallback<StoredCallback>, context, &Detail::DestroyOwnedCallback<StoredCallback>);
 }
 
 inline RegistrationResult RegisterFloat(const CVarDescriptor& _descriptor, double _default_value) {
@@ -361,9 +363,10 @@ template<typename Callback>
 RegistrationResult
 RegisterFloat(const CVarDescriptor& _descriptor, double _default_value, Callback&& _callback) {
     using StoredCallback = std::decay_t<Callback>;
-    auto* context        = new StoredCallback(std::forward<Callback>(_callback));
+    CVarDescriptor descriptor_snapshot = _descriptor;
+    auto*          context             = new StoredCallback(std::forward<Callback>(_callback));
     return Detail::
-        RegisterFloatRaw(Detail::ViewOf(_descriptor), _default_value, &Detail::InvokeFloatCallback<StoredCallback>, context, &Detail::DestroyOwnedCallback<StoredCallback>);
+        RegisterFloatRaw(Detail::ViewOf(descriptor_snapshot), _default_value, &Detail::InvokeFloatCallback<StoredCallback>, context, &Detail::DestroyOwnedCallback<StoredCallback>);
 }
 
 inline RegistrationResult RegisterString(const CVarDescriptor& _descriptor, std::string_view _default_value) {
@@ -374,9 +377,11 @@ template<typename Callback>
 RegistrationResult
 RegisterString(const CVarDescriptor& _descriptor, std::string_view _default_value, Callback&& _callback) {
     using StoredCallback = std::decay_t<Callback>;
-    auto* context        = new StoredCallback(std::forward<Callback>(_callback));
+    CVarDescriptor descriptor_snapshot = _descriptor;
+    std::string    default_snapshot(_default_value);
+    auto*          context = new StoredCallback(std::forward<Callback>(_callback));
     return Detail::
-        RegisterStringRaw(Detail::ViewOf(_descriptor), _default_value, &Detail::InvokeStringCallback<StoredCallback>, context, &Detail::DestroyOwnedCallback<StoredCallback>);
+        RegisterStringRaw(Detail::ViewOf(descriptor_snapshot), default_snapshot, &Detail::InvokeStringCallback<StoredCallback>, context, &Detail::DestroyOwnedCallback<StoredCallback>);
 }
 
 inline std::optional<CVarSnapshot> Find(std::string_view _name) {

--- a/source/runtime/core/include/config/CVarSystem.h
+++ b/source/runtime/core/include/config/CVarSystem.h
@@ -37,6 +37,9 @@ constexpr bool HasFlag(EFlags _flags, EFlags _flag) noexcept {
     return (static_cast<std::uint32_t>(_flags) & static_cast<std::uint32_t>(_flag)) != 0;
 }
 
+inline constexpr std::size_t DefaultCallbackDispatchBudget = 64;
+inline constexpr std::size_t MaxCallbackDispatchBudget     = 4096;
+
 enum class ESetSource : std::uint8_t {
     Runtime,
     StartupConfig,
@@ -50,6 +53,7 @@ enum class ESetStatus : std::uint8_t {
     OutOfRange,
     ReadOnly,
     StartupSealed,
+    CallbackQueueFull,
     InvalidRegistration,
 };
 
@@ -73,6 +77,7 @@ struct CVarDescriptor {
     EFlags                flags = EFlags::None;
     std::optional<double> min_value;
     std::optional<double> max_value;
+    std::size_t           callback_dispatch_budget = DefaultCallbackDispatchBudget;
 };
 
 struct CVarDescriptorView {
@@ -83,6 +88,7 @@ struct CVarDescriptorView {
     EFlags                flags = EFlags::None;
     std::optional<double> min_value;
     std::optional<double> max_value;
+    std::size_t           callback_dispatch_budget = DefaultCallbackDispatchBudget;
 };
 
 struct CVarSnapshotView {
@@ -96,7 +102,8 @@ struct CVarSnapshotView {
     EFlags                flags = EFlags::None;
     std::optional<double> min_value;
     std::optional<double> max_value;
-    bool                  startup_sealed = false;
+    std::size_t           callback_dispatch_budget = DefaultCallbackDispatchBudget;
+    bool                  startup_sealed           = false;
 };
 
 struct CVarSnapshot {
@@ -110,7 +117,8 @@ struct CVarSnapshot {
     EFlags                flags = EFlags::None;
     std::optional<double> min_value;
     std::optional<double> max_value;
-    bool                  startup_sealed = false;
+    std::size_t           callback_dispatch_budget = DefaultCallbackDispatchBudget;
+    bool                  startup_sealed           = false;
 };
 
 enum class ERegistrationStatus : std::uint8_t {
@@ -134,7 +142,9 @@ struct RegistrationAccess {
 // callback later in commit order, but Reset may cancel it first. A deferred
 // result has no completion query in this phase, so its eventual callback
 // success/failure/cancellation is intentionally not reported to that caller.
-// Callbacks may re-enter the registry.
+// Each dispatch epoch admits at most callback_dispatch_budget events; further
+// callback-producing mutations fail with CallbackQueueFull without committing
+// their value. Callbacks may re-enter the registry.
 class Registration {
 public:
     Registration() noexcept = default;
@@ -235,13 +245,14 @@ CORE_API std::size_t VisitAllSnapshotsRaw(std::string_view _prefix, SnapshotVisi
 
 inline CVarDescriptorView ViewOf(const CVarDescriptor& _descriptor) noexcept {
     return {
-        .name         = _descriptor.name,
-        .helper       = _descriptor.helper,
-        .true_helper  = _descriptor.true_helper,
-        .false_helper = _descriptor.false_helper,
-        .flags        = _descriptor.flags,
-        .min_value    = _descriptor.min_value,
-        .max_value    = _descriptor.max_value,
+        .name                     = _descriptor.name,
+        .helper                   = _descriptor.helper,
+        .true_helper              = _descriptor.true_helper,
+        .false_helper             = _descriptor.false_helper,
+        .flags                    = _descriptor.flags,
+        .min_value                = _descriptor.min_value,
+        .max_value                = _descriptor.max_value,
+        .callback_dispatch_budget = _descriptor.callback_dispatch_budget,
     };
 }
 
@@ -292,17 +303,18 @@ bool InvokeStringCallback(void* _context, std::string_view _old_value, std::stri
 
 inline CVarSnapshot CopySnapshot(const CVarSnapshotView& _view) {
     return {
-        .id             = _view.id,
-        .name           = std::string(_view.name),
-        .helper         = std::string(_view.helper),
-        .true_helper    = std::string(_view.true_helper),
-        .false_helper   = std::string(_view.false_helper),
-        .value          = std::string(_view.value),
-        .type           = _view.type,
-        .flags          = _view.flags,
-        .min_value      = _view.min_value,
-        .max_value      = _view.max_value,
-        .startup_sealed = _view.startup_sealed,
+        .id                       = _view.id,
+        .name                     = std::string(_view.name),
+        .helper                   = std::string(_view.helper),
+        .true_helper              = std::string(_view.true_helper),
+        .false_helper             = std::string(_view.false_helper),
+        .value                    = std::string(_view.value),
+        .type                     = _view.type,
+        .flags                    = _view.flags,
+        .min_value                = _view.min_value,
+        .max_value                = _view.max_value,
+        .callback_dispatch_budget = _view.callback_dispatch_budget,
+        .startup_sealed           = _view.startup_sealed,
     };
 }
 

--- a/source/runtime/core/source/command/EngineCommandProcessor.cpp
+++ b/source/runtime/core/source/command/EngineCommandProcessor.cpp
@@ -511,11 +511,13 @@ void EngineCommandProcessor::AppendOutput(std::string_view _text) {
         return;
     }
 
+    std::string owned_text(_text);
     std::lock_guard lock(impl->output_mutex);
     impl->output_lines.push_back({
-        .sequence = impl->next_output_sequence++,
-        .text     = std::string(_text),
+        .sequence = impl->next_output_sequence,
+        .text     = std::move(owned_text),
     });
+    ++impl->next_output_sequence;
     while (impl->output_lines.size() > impl->output_capacity) {
         impl->output_lines.pop_front();
     }

--- a/source/runtime/core/source/command/EngineCommandProcessor.cpp
+++ b/source/runtime/core/source/command/EngineCommandProcessor.cpp
@@ -1,0 +1,517 @@
+#include "command/EngineCommandProcessor.h"
+
+#include "config/CVarSystem.h"
+
+#include <algorithm>
+#include <cctype>
+#include <deque>
+#include <mutex>
+#include <utility>
+
+namespace Moer::Command {
+
+namespace {
+
+struct BuiltinCommand {
+    std::string_view name;
+    std::string_view helper;
+    std::string_view usage;
+};
+
+constexpr BuiltinCommand builtin_commands[] = {
+    {
+        "help",
+        "Show engine commands and the default cvar syntax.",
+        "/help",
+    },
+    {
+        "cvar.list",
+        "List registered cvars, optionally filtered by prefix.",
+        "/cvar.list [prefix]",
+    },
+};
+
+std::string_view TrimView(std::string_view _text) noexcept {
+    while (!_text.empty() && std::isspace(static_cast<unsigned char>(_text.front()))) {
+        _text.remove_prefix(1);
+    }
+    while (!_text.empty() && std::isspace(static_cast<unsigned char>(_text.back()))) {
+        _text.remove_suffix(1);
+    }
+    return _text;
+}
+
+constexpr char ToLowerAscii(char _character) noexcept {
+    return _character >= 'A' && _character <= 'Z' ? static_cast<char>(_character + ('a' - 'A')) : _character;
+}
+
+std::string Normalize(std::string_view _text) {
+    std::string normalized;
+    normalized.reserve(_text.size());
+    for (const char character : _text) {
+        normalized.push_back(ToLowerAscii(character));
+    }
+    return normalized;
+}
+
+bool StartsWithInsensitive(std::string_view _text, std::string_view _prefix) noexcept {
+    if (_prefix.size() > _text.size()) {
+        return false;
+    }
+    for (std::size_t index = 0; index < _prefix.size(); ++index) {
+        if (ToLowerAscii(_text[index]) != ToLowerAscii(_prefix[index])) {
+            return false;
+        }
+    }
+    return true;
+}
+
+const BuiltinCommand* FindBuiltin(std::string_view _name) {
+    for (const BuiltinCommand& command : builtin_commands) {
+        if (Normalize(_name) == command.name) {
+            return &command;
+        }
+    }
+    return nullptr;
+}
+
+std::string TypeName(CVar::EType _type) {
+    switch (_type) {
+        case CVar::EType::Bool:
+            return "bool";
+        case CVar::EType::Int:
+            return "int";
+        case CVar::EType::Float:
+            return "float";
+        case CVar::EType::String:
+            return "string";
+    }
+    return "unknown";
+}
+
+std::string FlagsText(CVar::EFlags _flags) {
+    std::string flags;
+    if (CVar::HasFlag(_flags, CVar::EFlags::ReadOnly)) {
+        flags = "read-only";
+    }
+    if (CVar::HasFlag(_flags, CVar::EFlags::StartupOnly)) {
+        if (!flags.empty()) {
+            flags += ", ";
+        }
+        flags += "startup-only";
+    }
+    return flags;
+}
+
+std::string SetErrorText(const CVar::CVarSetResult& _result) {
+    if (_result.detail && _result.detail[0] != '\0') {
+        return _result.detail;
+    }
+    switch (_result.status) {
+        case CVar::ESetStatus::NotFound:
+            return "unknown cvar";
+        case CVar::ESetStatus::TypeMismatch:
+            return "value type does not match";
+        case CVar::ESetStatus::OutOfRange:
+            return "value is outside the allowed range";
+        case CVar::ESetStatus::ReadOnly:
+            return "cvar is read-only";
+        case CVar::ESetStatus::StartupSealed:
+            return "cvar is sealed after startup";
+        case CVar::ESetStatus::InvalidRegistration:
+            return "cvar registration is no longer active";
+        case CVar::ESetStatus::Changed:
+        case CVar::ESetStatus::Unchanged:
+            return {};
+    }
+    return "cvar update failed";
+}
+
+} // namespace
+
+struct EngineCommandProcessor::Impl {
+    explicit Impl(EngineCommandProcessorLimits _limits) :
+        pending_capacity((std::max)(std::size_t{1}, _limits.pending_capacity)),
+        output_capacity((std::max)(std::size_t{1}, _limits.output_capacity)) {}
+
+    const std::size_t pending_capacity;
+    const std::size_t output_capacity;
+
+    mutable std::mutex      pending_mutex;
+    std::deque<std::string> pending_commands;
+    std::mutex              process_mutex;
+
+    mutable std::mutex            output_mutex;
+    std::deque<CommandOutputLine> output_lines;
+    std::uint64_t                 next_output_sequence = 1;
+};
+
+EngineCommandProcessor::EngineCommandProcessor(EngineCommandProcessorLimits _limits) :
+    impl(std::make_unique<Impl>(_limits)) {}
+
+EngineCommandProcessor::~EngineCommandProcessor() = default;
+
+ESubmitStatus EngineCommandProcessor::SubmitText(std::string_view _text) {
+    _text = TrimView(_text);
+    if (_text.empty()) {
+        return ESubmitStatus::Empty;
+    }
+
+    std::lock_guard lock(impl->pending_mutex);
+    if (impl->pending_commands.size() >= impl->pending_capacity) {
+        return ESubmitStatus::QueueFull;
+    }
+    impl->pending_commands.emplace_back(_text);
+    return ESubmitStatus::Accepted;
+}
+
+ProcessPendingResult EngineCommandProcessor::ProcessPending(std::size_t _max_commands) {
+    if (_max_commands == 0) {
+        return {.status = EProcessStatus::MaxCommandsZero};
+    }
+
+    std::unique_lock process_lock(impl->process_mutex, std::try_to_lock);
+    if (!process_lock.owns_lock()) {
+        return {.status = EProcessStatus::Busy};
+    }
+
+    std::size_t command_budget = 0;
+    {
+        std::lock_guard pending_lock(impl->pending_mutex);
+        command_budget = (std::min)(_max_commands, impl->pending_commands.size());
+    }
+    if (command_budget == 0) {
+        return {.status = EProcessStatus::Empty};
+    }
+
+    std::size_t processed_count = 0;
+    while (processed_count < command_budget) {
+        std::string command;
+        {
+            std::lock_guard pending_lock(impl->pending_mutex);
+            if (impl->pending_commands.empty()) {
+                break;
+            }
+            command = std::move(impl->pending_commands.front());
+            impl->pending_commands.pop_front();
+        }
+        ProcessCommand(command);
+        ++processed_count;
+    }
+    return {
+        .status    = processed_count == 0 ? EProcessStatus::Empty : EProcessStatus::Processed,
+        .processed = processed_count,
+    };
+}
+
+CommandOutputPollResult EngineCommandProcessor::VisitOutput(
+    std::uint64_t        _next_sequence,
+    std::size_t          _max_count,
+    CommandOutputVisitor _visitor,
+    void*                _context
+) const {
+    CommandOutputPollResult result;
+    result.next_sequence = _next_sequence == 0 ? 1 : _next_sequence;
+    std::vector<CommandOutputLine> copied_lines;
+    {
+        std::lock_guard lock(impl->output_mutex);
+        if (impl->output_lines.empty()) {
+            return result;
+        }
+
+        const std::uint64_t first_sequence = impl->output_lines.front().sequence;
+        if (result.next_sequence < first_sequence) {
+            result.dropped_count = first_sequence - result.next_sequence;
+            result.next_sequence = first_sequence;
+        }
+        if (_max_count == 0 || !_visitor) {
+            return result;
+        }
+
+        copied_lines.reserve((std::min)(_max_count, impl->output_lines.size()));
+        for (const CommandOutputLine& line : impl->output_lines) {
+            if (line.sequence < result.next_sequence) {
+                continue;
+            }
+            copied_lines.push_back(line);
+            result.next_sequence = line.sequence + 1;
+            if (copied_lines.size() == _max_count) {
+                break;
+            }
+        }
+    }
+
+    for (const CommandOutputLine& line : copied_lines) {
+        _visitor(
+            {
+                .sequence = line.sequence,
+                .text     = line.text,
+            },
+            _context
+        );
+    }
+    result.visited_count = copied_lines.size();
+    return result;
+}
+
+std::size_t EngineCommandProcessor::VisitCandidates(
+    std::string_view        _input,
+    std::size_t             _max_count,
+    CommandCandidateVisitor _visitor,
+    void*                   _context
+) const {
+    std::vector<CommandCandidate> candidates;
+    if (_max_count == 0 || !_visitor) {
+        return 0;
+    }
+
+    _input = TrimView(_input);
+    if (_input.empty()) {
+        return 0;
+    }
+
+    if (_input.front() == '/') {
+        std::string_view  token     = TrimView(_input.substr(1));
+        const std::size_t token_end = token.find_first_of(" \t?");
+        if (token_end != std::string_view::npos) {
+            token = token.substr(0, token_end);
+        }
+        for (const BuiltinCommand& command : builtin_commands) {
+            if (!token.empty() && !StartsWithInsensitive(command.name, token)) {
+                continue;
+            }
+            candidates.push_back({
+                .text       = "/" + std::string(command.name),
+                .helper     = std::string(command.helper),
+                .is_command = true,
+            });
+            if (candidates.size() == _max_count) {
+                break;
+            }
+        }
+    } else {
+        std::string_view  token     = _input;
+        const std::size_t token_end = token.find_first_of(" \t=?");
+        if (token_end != std::string_view::npos) {
+            token = token.substr(0, token_end);
+        }
+        if (token.empty()) {
+            return 0;
+        }
+
+        std::vector<CVar::CVarSnapshot> snapshots = CVar::List(token);
+        candidates.reserve((std::min)(_max_count, snapshots.size()));
+        for (const CVar::CVarSnapshot& snapshot : snapshots) {
+            candidates.push_back({
+                .text       = snapshot.name,
+                .helper     = snapshot.helper,
+                .is_command = false,
+            });
+            if (candidates.size() == _max_count) {
+                break;
+            }
+        }
+    }
+
+    for (const CommandCandidate& candidate : candidates) {
+        _visitor(
+            {
+                .text       = candidate.text,
+                .helper     = candidate.helper,
+                .is_command = candidate.is_command,
+            },
+            _context
+        );
+    }
+    return candidates.size();
+}
+
+void EngineCommandProcessor::ClearOutput() {
+    std::lock_guard lock(impl->output_mutex);
+    impl->output_lines.clear();
+}
+
+void EngineCommandProcessor::ProcessCommand(std::string_view _text) {
+    _text = TrimView(_text);
+    if (_text.empty()) {
+        return;
+    }
+    if (_text.front() == '/') {
+        ProcessSlashCommand(_text);
+    } else {
+        ProcessDefaultCVar(_text);
+    }
+}
+
+void EngineCommandProcessor::ProcessSlashCommand(std::string_view _text) {
+    std::string_view body       = TrimView(_text.substr(1));
+    bool             wants_help = false;
+    if (!body.empty() && body.back() == '?') {
+        wants_help = true;
+        body.remove_suffix(1);
+        body = TrimView(body);
+    }
+    if (body.empty()) {
+        AppendOutput("Error: missing command after '/'. Try /help");
+        return;
+    }
+
+    const std::size_t      name_end = body.find_first_of(" \t");
+    const std::string_view command_name =
+        name_end == std::string_view::npos ? body : body.substr(0, name_end);
+    const std::string_view arguments =
+        name_end == std::string_view::npos ? std::string_view{} : TrimView(body.substr(name_end + 1));
+    const BuiltinCommand* command = FindBuiltin(command_name);
+    if (!command) {
+        AppendOutput("Error: unknown command: /" + std::string(command_name));
+        return;
+    }
+
+    if (wants_help) {
+        AppendOutput("/" + std::string(command->name));
+        AppendOutput("  help: " + std::string(command->helper));
+        AppendOutput("  usage: " + std::string(command->usage));
+        return;
+    }
+
+    if (command->name == "help") {
+        AppendOutput("Commands:");
+        for (const BuiltinCommand& builtin : builtin_commands) {
+            AppendOutput("  /" + std::string(builtin.name) + " - " + std::string(builtin.helper));
+        }
+        AppendOutput("CVar syntax:");
+        AppendOutput("  <cvar>            show current value");
+        AppendOutput("  <cvar> <value>    set value");
+        AppendOutput("  <cvar> = <value>  set value");
+        AppendOutput("  <cvar> ?          show details");
+        return;
+    }
+
+    if (command->name == "cvar.list") {
+        const std::vector<CVar::CVarSnapshot> snapshots = CVar::List(arguments);
+        if (snapshots.empty()) {
+            AppendOutput(
+                arguments.empty() ? "No cvars registered." :
+                                    "No cvar matches prefix: " + std::string(arguments)
+            );
+            return;
+        }
+        for (const CVar::CVarSnapshot& snapshot : snapshots) {
+            std::string       line = snapshot.name + " (" + TypeName(snapshot.type) + ") = " + snapshot.value;
+            const std::string flags = FlagsText(snapshot.flags);
+            if (!flags.empty()) {
+                line += " [" + flags + "]";
+            }
+            AppendOutput(line);
+        }
+    }
+}
+
+void EngineCommandProcessor::ProcessDefaultCVar(std::string_view _text) {
+    _text                              = TrimView(_text);
+    const std::size_t initial_path_end = _text.find_first_of(" \t=");
+    bool wants_help = initial_path_end == std::string_view::npos && !_text.empty() && _text.back() == '?';
+    if (wants_help) {
+        _text.remove_suffix(1);
+        _text = TrimView(_text);
+    }
+
+    const std::size_t      path_end = _text.find_first_of(" \t=");
+    const std::string_view path     = path_end == std::string_view::npos ? _text : _text.substr(0, path_end);
+    if (path.empty()) {
+        AppendOutput("Error: missing cvar name.");
+        return;
+    }
+
+    if (!wants_help && path_end != std::string_view::npos) {
+        wants_help = TrimView(_text.substr(path_end)) == "?";
+    }
+
+    const std::optional<CVar::CVarSnapshot> current = CVar::Find(path);
+    if (!current) {
+        AppendOutput("Error: unknown cvar: " + std::string(path));
+        return;
+    }
+    if (wants_help) {
+        AppendOutput(current->name + " = " + current->value);
+        AppendOutput("  type: " + TypeName(current->type));
+        if (!current->helper.empty()) {
+            AppendOutput("  help: " + current->helper);
+        }
+        if (current->type == CVar::EType::Bool) {
+            if (!current->true_helper.empty()) {
+                AppendOutput("  true: " + current->true_helper);
+            }
+            if (!current->false_helper.empty()) {
+                AppendOutput("  false: " + current->false_helper);
+            }
+        }
+        if (current->min_value) {
+            AppendOutput("  minimum: " + std::to_string(*current->min_value));
+        }
+        if (current->max_value) {
+            AppendOutput("  maximum: " + std::to_string(*current->max_value));
+        }
+        const std::string flags = FlagsText(current->flags);
+        if (!flags.empty()) {
+            AppendOutput("  flags: " + flags);
+        }
+        return;
+    }
+    if (path_end == std::string_view::npos) {
+        AppendOutput(current->name + " = " + current->value);
+        return;
+    }
+
+    std::string_view argument        = TrimView(_text.substr(path_end));
+    bool             explicit_equals = false;
+    if (!argument.empty() && argument.front() == '=') {
+        explicit_equals = true;
+        argument.remove_prefix(1);
+        argument = TrimView(argument);
+    }
+    if (argument.empty() && !explicit_equals) {
+        AppendOutput(current->name + " = " + current->value);
+        return;
+    }
+
+    const CVar::CVarSetResult result = CVar::SetValueFromString(path, argument);
+    if (!result.Succeeded()) {
+        AppendOutput("Error: " + current->name + ": " + SetErrorText(result));
+        return;
+    }
+
+    const std::optional<CVar::CVarSnapshot> updated = CVar::Find(path);
+    if (updated) {
+        AppendOutput(updated->name + " = " + updated->value);
+    } else {
+        AppendOutput(current->name + " updated");
+    }
+    if (result.callback_failed) {
+        AppendOutput("Warning: " + current->name + ": on-change callback failed");
+    } else if (result.callback_canceled) {
+        AppendOutput("Notice: " + current->name + ": on-change callback canceled by unregistration");
+    } else if (result.callback_deferred) {
+        AppendOutput("Notice: " + current->name + ": on-change callback queued behind an active callback");
+    }
+}
+
+void EngineCommandProcessor::AppendOutput(std::string_view _text) {
+    while (!_text.empty() && (_text.back() == '\r' || _text.back() == '\n')) {
+        _text.remove_suffix(1);
+    }
+    if (_text.empty()) {
+        return;
+    }
+
+    std::lock_guard lock(impl->output_mutex);
+    impl->output_lines.push_back({
+        .sequence = impl->next_output_sequence++,
+        .text     = std::string(_text),
+    });
+    while (impl->output_lines.size() > impl->output_capacity) {
+        impl->output_lines.pop_front();
+    }
+}
+
+} // namespace Moer::Command

--- a/source/runtime/core/source/command/EngineCommandProcessor.cpp
+++ b/source/runtime/core/source/command/EngineCommandProcessor.cpp
@@ -118,6 +118,8 @@ std::string SetErrorText(const CVar::CVarSetResult& _result) {
             return "cvar is read-only";
         case CVar::ESetStatus::StartupSealed:
             return "cvar is sealed after startup";
+        case CVar::ESetStatus::CallbackQueueFull:
+            return "cvar callback dispatch budget is exhausted";
         case CVar::ESetStatus::InvalidRegistration:
             return "cvar registration is no longer active";
         case CVar::ESetStatus::Changed:
@@ -216,6 +218,10 @@ CommandOutputPollResult EngineCommandProcessor::VisitOutput(
     {
         std::lock_guard lock(impl->output_mutex);
         if (impl->output_lines.empty()) {
+            if (result.next_sequence < impl->next_output_sequence) {
+                result.dropped_count = impl->next_output_sequence - result.next_sequence;
+                result.next_sequence = impl->next_output_sequence;
+            }
             return result;
         }
 
@@ -452,6 +458,7 @@ void EngineCommandProcessor::ProcessDefaultCVar(std::string_view _text) {
         if (current->max_value) {
             AppendOutput("  maximum: " + std::to_string(*current->max_value));
         }
+        AppendOutput("  callback dispatch budget: " + std::to_string(current->callback_dispatch_budget));
         const std::string flags = FlagsText(current->flags);
         if (!flags.empty()) {
             AppendOutput("  flags: " + flags);

--- a/source/runtime/core/source/config/CVarSystem.cpp
+++ b/source/runtime/core/source/config/CVarSystem.cpp
@@ -946,13 +946,15 @@ bool VisitEntrySnapshot(const std::shared_ptr<EntryBase>& _entry, SnapshotVisito
         return false;
     }
 
-    EntryBase::Operation operation(*_entry);
-    if (!operation.IsValid()) {
-        return false;
-    }
-    const std::string value = _entry->CopyValueString();
-    _visitor(
-        {
+    std::string      value;
+    CVarSnapshotView snapshot;
+    {
+        EntryBase::Operation operation(*_entry);
+        if (!operation.IsValid()) {
+            return false;
+        }
+        value    = _entry->CopyValueString();
+        snapshot = {
             .id                       = _entry->id,
             .name                     = _entry->descriptor.name,
             .helper                   = _entry->descriptor.helper,
@@ -965,9 +967,13 @@ bool VisitEntrySnapshot(const std::shared_ptr<EntryBase>& _entry, SnapshotVisito
             .max_value                = _entry->descriptor.max_value,
             .callback_dispatch_budget = _entry->descriptor.callback_dispatch_budget,
             .startup_sealed           = _entry->startup_sealed.load(std::memory_order_acquire),
-        },
-        _context
-    );
+        };
+    }
+
+    // The shared_ptr keeps descriptor storage alive and value owns its copy.
+    // End the active operation before entering caller code so cross-entry
+    // Reset calls from concurrent visitors cannot form a quiescence wait cycle.
+    _visitor(snapshot, _context);
     return true;
 }
 

--- a/source/runtime/core/source/config/CVarSystem.cpp
+++ b/source/runtime/core/source/config/CVarSystem.cpp
@@ -571,17 +571,33 @@ private:
                 outcome.result.status = ESetStatus::Unchanged;
                 return outcome;
             }
+            const bool produces_callback = _invoke_callback && callback && callback_owner;
+            if (produces_callback && callback_dispatching && callback_admissions_remaining == 0) {
+                return {
+                    .result =
+                        {
+                            .status = ESetStatus::CallbackQueueFull,
+                            .detail = "callback dispatch budget is exhausted",
+                        },
+                };
+            }
+
             old_value = value;
-            if (_invoke_callback && callback && callback_owner) {
+            if (produces_callback) {
                 outcome.callback_event = std::make_shared<CallbackEvent>(old_value, _new_value);
                 callback_queue.push_back(outcome.callback_event);
             }
             value = std::move(_new_value);
         }
 
-        if (outcome.callback_event && !callback_dispatching) {
-            callback_dispatching  = true;
-            outcome.owns_dispatch = true;
+        if (outcome.callback_event) {
+            if (!callback_dispatching) {
+                callback_dispatching          = true;
+                callback_admissions_remaining = descriptor.callback_dispatch_budget - 1;
+                outcome.owns_dispatch         = true;
+            } else {
+                --callback_admissions_remaining;
+            }
         }
         return outcome;
     }
@@ -636,7 +652,8 @@ private:
             {
                 std::unique_lock lock(mutation_mutex);
                 if (IsRetired() || callback_queue.empty()) {
-                    callback_dispatching = false;
+                    callback_dispatching          = false;
+                    callback_admissions_remaining = 0;
                     if (IsRetired() && !callback_invoking) {
                         retired_callback_owner.reset(DetachCallbackOwnerLocked());
                     }
@@ -664,12 +681,14 @@ private:
                 callback_event->completed          = true;
                 if (IsRetired()) {
                     CancelQueuedCallbacksLocked();
-                    callback_dispatching = false;
+                    callback_dispatching          = false;
+                    callback_admissions_remaining = 0;
                     retired_callback_owner.reset(DetachCallbackOwnerLocked());
                     stop_dispatch = true;
                 } else if (callback_queue.empty()) {
-                    callback_dispatching = false;
-                    stop_dispatch        = true;
+                    callback_dispatching          = false;
+                    callback_admissions_remaining = 0;
+                    stop_dispatch                 = true;
                 }
             }
             retired_callback_owner.reset();
@@ -694,7 +713,8 @@ protected:
         if (callback_invoking) {
             return nullptr;
         }
-        callback_dispatching = false;
+        callback_dispatching          = false;
+        callback_admissions_remaining = 0;
         return callback_owner.release();
     }
 
@@ -704,6 +724,7 @@ protected:
         }
         callback = nullptr;
         CancelQueuedCallbacksLocked();
+        callback_admissions_remaining = 0;
         return callback_owner.release();
     }
 
@@ -713,8 +734,9 @@ private:
     Callback                                   callback = nullptr;
     std::unique_ptr<CallbackOwner>             callback_owner;
     std::deque<std::shared_ptr<CallbackEvent>> callback_queue;
-    bool                                       callback_dispatching = false;
-    bool                                       callback_invoking    = false;
+    std::size_t                                callback_admissions_remaining = 0;
+    bool                                       callback_dispatching          = false;
+    bool                                       callback_invoking             = false;
 };
 
 using BoolEntry   = Entry<bool, Detail::BoolCallback>;
@@ -777,13 +799,14 @@ void Unregister(std::uint64_t _id) noexcept {
 
 CVarDescriptor CopyDescriptor(CVarDescriptorView _view) {
     return {
-        .name         = std::string(_view.name),
-        .helper       = std::string(_view.helper),
-        .true_helper  = std::string(_view.true_helper),
-        .false_helper = std::string(_view.false_helper),
-        .flags        = _view.flags,
-        .min_value    = _view.min_value,
-        .max_value    = _view.max_value,
+        .name                     = std::string(_view.name),
+        .helper                   = std::string(_view.helper),
+        .true_helper              = std::string(_view.true_helper),
+        .false_helper             = std::string(_view.false_helper),
+        .flags                    = _view.flags,
+        .min_value                = _view.min_value,
+        .max_value                = _view.max_value,
+        .callback_dispatch_budget = _view.callback_dispatch_budget,
     };
 }
 
@@ -796,6 +819,8 @@ bool DescriptorIsInvalid(CVarDescriptorView _descriptor, const Value& _value) {
     const bool has_range_for_non_numeric = !std::is_same_v<Value, std::int64_t> &&
                                            !std::is_same_v<Value, double> &&
                                            (_descriptor.min_value || _descriptor.max_value);
+    const bool has_invalid_callback_budget = _descriptor.callback_dispatch_budget == 0 ||
+                                             _descriptor.callback_dispatch_budget > MaxCallbackDispatchBudget;
     bool default_is_invalid = false;
     if constexpr (std::is_same_v<Value, std::int64_t>) {
         default_is_invalid = (_descriptor.min_value && IntIsBelowMinimum(_value, *_descriptor.min_value)) ||
@@ -806,7 +831,7 @@ bool DescriptorIsInvalid(CVarDescriptorView _descriptor, const Value& _value) {
                              (_descriptor.max_value && _value > *_descriptor.max_value);
     }
     return !IsValidName(_descriptor.name) || has_non_finite_bound || has_inverted_range ||
-           has_range_for_non_numeric || default_is_invalid;
+           has_range_for_non_numeric || has_invalid_callback_budget || default_is_invalid;
 }
 
 template<typename EntryType, typename Value, typename Callback>
@@ -922,17 +947,18 @@ bool VisitEntrySnapshot(const std::shared_ptr<EntryBase>& _entry, SnapshotVisito
     const std::string value = _entry->CopyValueString();
     _visitor(
         {
-            .id             = _entry->id,
-            .name           = _entry->descriptor.name,
-            .helper         = _entry->descriptor.helper,
-            .true_helper    = _entry->descriptor.true_helper,
-            .false_helper   = _entry->descriptor.false_helper,
-            .value          = value,
-            .type           = _entry->type,
-            .flags          = _entry->descriptor.flags,
-            .min_value      = _entry->descriptor.min_value,
-            .max_value      = _entry->descriptor.max_value,
-            .startup_sealed = _entry->startup_sealed.load(std::memory_order_acquire),
+            .id                       = _entry->id,
+            .name                     = _entry->descriptor.name,
+            .helper                   = _entry->descriptor.helper,
+            .true_helper              = _entry->descriptor.true_helper,
+            .false_helper             = _entry->descriptor.false_helper,
+            .value                    = value,
+            .type                     = _entry->type,
+            .flags                    = _entry->descriptor.flags,
+            .min_value                = _entry->descriptor.min_value,
+            .max_value                = _entry->descriptor.max_value,
+            .callback_dispatch_budget = _entry->descriptor.callback_dispatch_budget,
+            .startup_sealed           = _entry->startup_sealed.load(std::memory_order_acquire),
         },
         _context
     );

--- a/source/runtime/core/source/config/CVarSystem.cpp
+++ b/source/runtime/core/source/config/CVarSystem.cpp
@@ -1,0 +1,1135 @@
+#include "config/CVarSystem.h"
+
+#include <atomic>
+#include <cctype>
+#include <charconv>
+#include <cmath>
+#include <condition_variable>
+#include <deque>
+#include <exception>
+#include <limits>
+#include <memory>
+#include <mutex>
+#include <shared_mutex>
+#include <system_error>
+#include <type_traits>
+#include <unordered_map>
+#include <utility>
+#include <variant>
+
+namespace Moer::CVar {
+
+namespace {
+
+using CVarValue = std::variant<bool, std::int64_t, double, std::string>;
+
+std::string_view TrimView(std::string_view _text) noexcept {
+    while (!_text.empty() && std::isspace(static_cast<unsigned char>(_text.front()))) {
+        _text.remove_prefix(1);
+    }
+    while (!_text.empty() && std::isspace(static_cast<unsigned char>(_text.back()))) {
+        _text.remove_suffix(1);
+    }
+    return _text;
+}
+
+constexpr char ToLowerAscii(char _character) noexcept {
+    return _character >= 'A' && _character <= 'Z' ? static_cast<char>(_character + ('a' - 'A')) : _character;
+}
+
+std::string NormalizeName(std::string_view _name) {
+    std::string normalized;
+    normalized.reserve(_name.size());
+    for (const char character : _name) {
+        normalized.push_back(ToLowerAscii(character));
+    }
+    return normalized;
+}
+
+bool IsValidName(std::string_view _name) noexcept {
+    if (_name.empty() || _name.front() == '/') {
+        return false;
+    }
+    for (const char character : _name) {
+        const bool is_ascii_alphanumeric = (character >= '0' && character <= '9') ||
+                                           (character >= 'A' && character <= 'Z') ||
+                                           (character >= 'a' && character <= 'z');
+        if (!(is_ascii_alphanumeric || character == '.' || character == '_' || character == '-')) {
+            return false;
+        }
+    }
+    return true;
+}
+
+bool StartsWithInsensitive(std::string_view _text, std::string_view _prefix) noexcept {
+    if (_prefix.size() > _text.size()) {
+        return false;
+    }
+    for (std::size_t index = 0; index < _prefix.size(); ++index) {
+        if (ToLowerAscii(_text[index]) != ToLowerAscii(_prefix[index])) {
+            return false;
+        }
+    }
+    return true;
+}
+
+template<typename T>
+constexpr EType TypeOf();
+
+template<>
+constexpr EType TypeOf<bool>() {
+    return EType::Bool;
+}
+
+template<>
+constexpr EType TypeOf<std::int64_t>() {
+    return EType::Int;
+}
+
+template<>
+constexpr EType TypeOf<double>() {
+    return EType::Float;
+}
+
+template<>
+constexpr EType TypeOf<std::string>() {
+    return EType::String;
+}
+
+std::string ValueToString(bool _value) {
+    return _value ? "true" : "false";
+}
+
+std::string ValueToString(std::int64_t _value) {
+    char buffer[32]{};
+    const auto [end, error] = std::to_chars(buffer, buffer + sizeof(buffer), _value);
+    return error == std::errc{} ? std::string(buffer, static_cast<std::size_t>(end - buffer)) : std::string{};
+}
+
+std::string ValueToString(double _value) {
+    char buffer[64]{};
+    const auto [end, error] = std::to_chars(
+        buffer,
+        buffer + sizeof(buffer),
+        _value,
+        std::chars_format::general,
+        std::numeric_limits<double>::max_digits10
+    );
+    return error == std::errc{} ? std::string(buffer, static_cast<std::size_t>(end - buffer)) : std::string{};
+}
+
+std::string ValueToString(const std::string& _value) {
+    return _value;
+}
+
+template<typename T>
+CVarSetResult ParseValue(std::string_view _text, T& _value);
+
+template<>
+CVarSetResult ParseValue<bool>(std::string_view _text, bool& _value) {
+    const std::string normalized = NormalizeName(TrimView(_text));
+    if (normalized == "1" || normalized == "true" || normalized == "on") {
+        _value = true;
+        return {.status = ESetStatus::Changed};
+    }
+    if (normalized == "0" || normalized == "false" || normalized == "off") {
+        _value = false;
+        return {.status = ESetStatus::Changed};
+    }
+    return {
+        .status = ESetStatus::TypeMismatch,
+        .detail = "expected bool (0/1, true/false, on/off)",
+    };
+}
+
+template<>
+CVarSetResult ParseValue<std::int64_t>(std::string_view _text, std::int64_t& _value) {
+    _text = TrimView(_text);
+    if (_text.empty()) {
+        return {
+            .status = ESetStatus::TypeMismatch,
+            .detail = "expected integer",
+        };
+    }
+    const auto [end, error] = std::from_chars(_text.data(), _text.data() + _text.size(), _value);
+    if (error != std::errc{} || end != _text.data() + _text.size()) {
+        return {
+            .status = ESetStatus::TypeMismatch,
+            .detail = "expected integer",
+        };
+    }
+    return {.status = ESetStatus::Changed};
+}
+
+template<>
+CVarSetResult ParseValue<double>(std::string_view _text, double& _value) {
+    _text = TrimView(_text);
+    if (_text.empty()) {
+        return {
+            .status = ESetStatus::TypeMismatch,
+            .detail = "expected finite floating-point value",
+        };
+    }
+    const auto [end, error] =
+        std::from_chars(_text.data(), _text.data() + _text.size(), _value, std::chars_format::general);
+    if (error != std::errc{} || end != _text.data() + _text.size() || !std::isfinite(_value)) {
+        return {
+            .status = ESetStatus::TypeMismatch,
+            .detail = "expected finite floating-point value",
+        };
+    }
+    return {.status = ESetStatus::Changed};
+}
+
+template<>
+CVarSetResult ParseValue<std::string>(std::string_view _text, std::string& _value) {
+    _value.assign(_text);
+    return {.status = ESetStatus::Changed};
+}
+
+bool IntIsBelowMinimum(std::int64_t _value, double _minimum) noexcept {
+    constexpr double minimum_int           = -9223372036854775808.0;
+    constexpr double maximum_int_exclusive = 9223372036854775808.0;
+    const double     threshold             = std::ceil(_minimum);
+    if (threshold <= minimum_int) {
+        return false;
+    }
+    if (threshold >= maximum_int_exclusive) {
+        return true;
+    }
+    return _value < static_cast<std::int64_t>(threshold);
+}
+
+bool IntIsAboveMaximum(std::int64_t _value, double _maximum) noexcept {
+    constexpr double minimum_int           = -9223372036854775808.0;
+    constexpr double maximum_int_exclusive = 9223372036854775808.0;
+    const double     threshold             = std::floor(_maximum);
+    if (threshold >= maximum_int_exclusive) {
+        return false;
+    }
+    if (threshold < minimum_int) {
+        return true;
+    }
+    return _value > static_cast<std::int64_t>(threshold);
+}
+
+thread_local std::uint32_t callback_destroy_depth = 0;
+
+struct CallbackOwner {
+    CallbackOwner(void* _context, Detail::DestroyCallback _destroy) noexcept :
+        context(_context),
+        destroy(_destroy) {}
+
+    ~CallbackOwner() {
+        Reset();
+    }
+
+    CallbackOwner(const CallbackOwner&)            = delete;
+    CallbackOwner& operator=(const CallbackOwner&) = delete;
+
+    CallbackOwner(CallbackOwner&& _other) noexcept :
+        context(std::exchange(_other.context, nullptr)),
+        destroy(std::exchange(_other.destroy, nullptr)) {}
+
+    CallbackOwner& operator=(CallbackOwner&& _other) noexcept {
+        if (this != &_other) {
+            Reset();
+            context = std::exchange(_other.context, nullptr);
+            destroy = std::exchange(_other.destroy, nullptr);
+        }
+        return *this;
+    }
+
+    void Reset() noexcept {
+        void*                   retired_context = std::exchange(context, nullptr);
+        Detail::DestroyCallback retired_destroy = std::exchange(destroy, nullptr);
+        if (retired_destroy) {
+            ++callback_destroy_depth;
+            retired_destroy(retired_context);
+            --callback_destroy_depth;
+        }
+    }
+
+    void*                   context = nullptr;
+    Detail::DestroyCallback destroy = nullptr;
+};
+
+class EntryBase;
+
+struct ActiveOperationNode {
+    EntryBase*           entry    = nullptr;
+    ActiveOperationNode* previous = nullptr;
+};
+
+struct ActiveCallbackNode {
+    EntryBase*          entry    = nullptr;
+    ActiveCallbackNode* previous = nullptr;
+};
+
+thread_local ActiveOperationNode* active_operation = nullptr;
+thread_local ActiveCallbackNode*  active_callback  = nullptr;
+
+bool IsInsideCallbackOrDestroy() noexcept {
+    return active_callback != nullptr || callback_destroy_depth != 0;
+}
+
+class EntryBase {
+public:
+    EntryBase(std::uint64_t _id, std::string _registry_key, CVarDescriptor _descriptor, EType _type) :
+        id(_id),
+        registry_key(std::move(_registry_key)),
+        descriptor(std::move(_descriptor)),
+        type(_type) {}
+
+    virtual ~EntryBase() = default;
+
+    EntryBase(const EntryBase&)            = delete;
+    EntryBase& operator=(const EntryBase&) = delete;
+
+    class Operation {
+    public:
+        explicit Operation(EntryBase& _entry) : entry(&_entry) {
+            valid = entry->TryBeginOperation(node);
+        }
+
+        ~Operation() {
+            if (valid) {
+                entry->EndOperation(node);
+            }
+        }
+
+        Operation(const Operation&)            = delete;
+        Operation& operator=(const Operation&) = delete;
+
+        [[nodiscard]] bool IsValid() const noexcept {
+            return valid;
+        }
+
+    private:
+        EntryBase*          entry = nullptr;
+        ActiveOperationNode node;
+        bool                valid = false;
+    };
+
+    virtual std::string   CopyValueString() const                                   = 0;
+    virtual CVarSetResult SetFromString(std::string_view _text, ESetSource _source) = 0;
+    virtual CVarSetResult SynchronizeOwnerValue(const CVarValue& _value)            = 0;
+
+    void SealStartup() noexcept {
+        if (HasFlag(descriptor.flags, EFlags::StartupOnly)) {
+            std::lock_guard lock(mutation_mutex);
+            startup_sealed.store(true, std::memory_order_release);
+        }
+    }
+
+    void RetireAndWait() noexcept {
+        std::unique_ptr<CallbackOwner> retired_callback_owner;
+        {
+            std::lock_guard lock(mutation_mutex);
+            retired.store(true, std::memory_order_release);
+            retired_callback_owner.reset(RetireCallbacksLocked());
+        }
+        retired_callback_owner.reset();
+
+        std::unique_lock lock(lifetime_mutex);
+        if (IsActiveOnCurrentThread() || IsInsideCallbackOrDestroy()) {
+            return;
+        }
+        lifetime_cv.wait(lock, [this] {
+            return active_operations == 0;
+        });
+        lock.unlock();
+
+        {
+            std::lock_guard mutation_lock(mutation_mutex);
+            retired_callback_owner.reset(DetachCallbackOwnerLocked());
+        }
+        retired_callback_owner.reset();
+    }
+
+    [[nodiscard]] bool IsRetired() const noexcept {
+        return retired.load(std::memory_order_acquire);
+    }
+
+    std::uint64_t    id = 0;
+    std::string      registry_key;
+    CVarDescriptor   descriptor;
+    EType            type = EType::String;
+    std::atomic_bool startup_sealed{false};
+
+protected:
+    virtual CallbackOwner* RetireCallbacksLocked() noexcept     = 0;
+    virtual CallbackOwner* DetachCallbackOwnerLocked() noexcept = 0;
+
+    std::mutex mutation_mutex;
+
+private:
+    bool TryBeginOperation(ActiveOperationNode& _node) noexcept {
+        {
+            std::lock_guard lock(lifetime_mutex);
+            if (retired.load(std::memory_order_acquire)) {
+                return false;
+            }
+            ++active_operations;
+        }
+        _node.entry      = this;
+        _node.previous   = active_operation;
+        active_operation = &_node;
+        return true;
+    }
+
+    void EndOperation(ActiveOperationNode& _node) noexcept {
+        active_operation = _node.previous;
+        std::lock_guard lock(lifetime_mutex);
+        --active_operations;
+        if (active_operations == 0) {
+            lifetime_cv.notify_all();
+        }
+    }
+
+    bool IsActiveOnCurrentThread() const noexcept {
+        for (ActiveOperationNode* node = active_operation; node != nullptr; node = node->previous) {
+            if (node->entry == this) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    std::mutex              lifetime_mutex;
+    std::condition_variable lifetime_cv;
+    std::size_t             active_operations = 0;
+    std::atomic_bool        retired{false};
+};
+
+template<typename T, typename Callback>
+class Entry final : public EntryBase {
+public:
+    Entry(
+        std::uint64_t  _id,
+        std::string    _registry_key,
+        CVarDescriptor _descriptor,
+        T              _value,
+        Callback       _callback,
+        CallbackOwner  _callback_owner
+    ) :
+        EntryBase(_id, std::move(_registry_key), std::move(_descriptor), TypeOf<T>()),
+        value(std::move(_value)),
+        callback(_callback),
+        callback_owner(
+            _callback_owner.context || _callback_owner.destroy ?
+                std::make_unique<CallbackOwner>(std::move(_callback_owner)) :
+                nullptr
+        ) {}
+
+    std::string CopyValueString() const override {
+        std::shared_lock lock(value_mutex);
+        return ValueToString(value);
+    }
+
+    CVarSetResult SetFromString(std::string_view _text, ESetSource _source) override {
+        Operation operation(*this);
+        if (!operation.IsValid()) {
+            return {
+                .status = ESetStatus::InvalidRegistration,
+                .detail = "cvar registration is no longer active",
+            };
+        }
+
+        MutationOutcome  outcome;
+        std::unique_lock mutation_lock(mutation_mutex);
+        if (IsRetired()) {
+            return {
+                .status = ESetStatus::InvalidRegistration,
+                .detail = "cvar registration is no longer active",
+            };
+        }
+        if (HasFlag(descriptor.flags, EFlags::ReadOnly)) {
+            return {
+                .status = ESetStatus::ReadOnly,
+                .detail = "cvar is read-only",
+            };
+        }
+        if (HasFlag(descriptor.flags, EFlags::StartupOnly)) {
+            if (_source != ESetSource::StartupConfig) {
+                return {
+                    .status = ESetStatus::StartupSealed,
+                    .detail = "cvar can only be changed by startup configuration",
+                };
+            }
+            if (startup_sealed.load(std::memory_order_acquire)) {
+                return {
+                    .status = ESetStatus::StartupSealed,
+                    .detail = "cvar is sealed after startup",
+                };
+            }
+        }
+
+        T             parsed{};
+        CVarSetResult result = ParseValue<T>(_text, parsed);
+        if (!result.Succeeded()) {
+            return result;
+        }
+        outcome = SetParsedValueLocked(std::move(parsed), true);
+        mutation_lock.unlock();
+        return CompleteMutation(std::move(outcome));
+    }
+
+    CVarSetResult SynchronizeOwnerValue(const CVarValue& _value) override {
+        Operation operation(*this);
+        if (!operation.IsValid()) {
+            return {
+                .status = ESetStatus::InvalidRegistration,
+                .detail = "cvar registration is no longer active",
+            };
+        }
+
+        const T* typed_value = std::get_if<T>(&_value);
+        if (!typed_value) {
+            return {
+                .status = ESetStatus::TypeMismatch,
+                .detail = "owner value type does not match cvar type",
+            };
+        }
+
+        MutationOutcome  outcome;
+        std::unique_lock mutation_lock(mutation_mutex);
+        if (IsRetired()) {
+            return {
+                .status = ESetStatus::InvalidRegistration,
+                .detail = "cvar registration is no longer active",
+            };
+        }
+        outcome = SetParsedValueLocked(*typed_value, false);
+        mutation_lock.unlock();
+        return CompleteMutation(std::move(outcome));
+    }
+
+private:
+    struct CallbackEvent {
+        CallbackEvent(const T& _old_value, const T& _new_value) :
+            old_value(_old_value),
+            new_value(_new_value) {}
+
+        T    old_value;
+        T    new_value;
+        bool completed          = false;
+        bool callback_succeeded = true;
+        bool callback_canceled  = false;
+    };
+
+    struct MutationOutcome {
+        CVarSetResult                  result;
+        std::shared_ptr<CallbackEvent> callback_event;
+        bool                           owns_dispatch = false;
+    };
+
+    CVarSetResult ValidateRange(const T& _value) const {
+        if constexpr (std::is_same_v<T, std::int64_t>) {
+            if (descriptor.min_value && IntIsBelowMinimum(_value, *descriptor.min_value)) {
+                return {
+                    .status = ESetStatus::OutOfRange,
+                    .detail = "value is below the allowed minimum",
+                };
+            }
+            if (descriptor.max_value && IntIsAboveMaximum(_value, *descriptor.max_value)) {
+                return {
+                    .status = ESetStatus::OutOfRange,
+                    .detail = "value is above the allowed maximum",
+                };
+            }
+        } else if constexpr (std::is_same_v<T, double>) {
+            if (descriptor.min_value && _value < *descriptor.min_value) {
+                return {
+                    .status = ESetStatus::OutOfRange,
+                    .detail = "value is below the allowed minimum",
+                };
+            }
+            if (descriptor.max_value && _value > *descriptor.max_value) {
+                return {
+                    .status = ESetStatus::OutOfRange,
+                    .detail = "value is above the allowed maximum",
+                };
+            }
+        }
+        return {.status = ESetStatus::Changed};
+    }
+
+    MutationOutcome SetParsedValueLocked(T _new_value, bool _invoke_callback) {
+        CVarSetResult range_result = ValidateRange(_new_value);
+        if (!range_result.Succeeded()) {
+            return {.result = range_result};
+        }
+
+        MutationOutcome outcome{
+            .result = {.status = ESetStatus::Changed},
+        };
+        T old_value;
+        {
+            std::unique_lock value_lock(value_mutex);
+            if (value == _new_value) {
+                outcome.result.status = ESetStatus::Unchanged;
+                return outcome;
+            }
+            old_value = value;
+            if (_invoke_callback && callback && callback_owner) {
+                outcome.callback_event = std::make_shared<CallbackEvent>(old_value, _new_value);
+                callback_queue.push_back(outcome.callback_event);
+            }
+            value = std::move(_new_value);
+        }
+
+        if (outcome.callback_event && !callback_dispatching) {
+            callback_dispatching  = true;
+            outcome.owns_dispatch = true;
+        }
+        return outcome;
+    }
+
+    CVarSetResult CompleteMutation(MutationOutcome _outcome) {
+        if (!_outcome.callback_event) {
+            return _outcome.result;
+        }
+        if (_outcome.owns_dispatch) {
+            DrainCallbacks();
+        }
+
+        std::lock_guard lock(mutation_mutex);
+        if (!_outcome.callback_event->completed) {
+            _outcome.result.callback_deferred = true;
+            _outcome.result.detail            = "value changed; callback completion was deferred";
+            return _outcome.result;
+        }
+        if (!_outcome.callback_event->callback_succeeded) {
+            _outcome.result.callback_failed = true;
+            _outcome.result.detail          = "value changed, but the on-change callback failed";
+        } else if (_outcome.callback_event->callback_canceled) {
+            _outcome.result.callback_canceled = true;
+            _outcome.result.detail            = "value changed; callback was canceled by unregistration";
+        }
+        return _outcome.result;
+    }
+
+    bool InvokeCallback(Callback _callback, void* _context, const CallbackEvent& _event) {
+        ActiveCallbackNode callback_node{
+            .entry    = this,
+            .previous = active_callback,
+        };
+        active_callback         = &callback_node;
+        bool callback_succeeded = false;
+        if constexpr (std::is_same_v<T, std::string>) {
+            callback_succeeded =
+                _callback(_context, std::string_view(_event.old_value), std::string_view(_event.new_value));
+        } else {
+            callback_succeeded = _callback(_context, _event.old_value, _event.new_value);
+        }
+        active_callback = callback_node.previous;
+        return callback_succeeded;
+    }
+
+    void DrainCallbacks() {
+        for (;;) {
+            std::shared_ptr<CallbackEvent> callback_event;
+            Callback                       callback_to_invoke = nullptr;
+            void*                          callback_context   = nullptr;
+            std::unique_ptr<CallbackOwner> retired_callback_owner;
+            {
+                std::unique_lock lock(mutation_mutex);
+                if (IsRetired() || callback_queue.empty()) {
+                    callback_dispatching = false;
+                    if (IsRetired() && !callback_invoking) {
+                        retired_callback_owner.reset(DetachCallbackOwnerLocked());
+                    }
+                    lock.unlock();
+                    retired_callback_owner.reset();
+                    return;
+                }
+
+                callback_event = std::move(callback_queue.front());
+                callback_queue.pop_front();
+                callback_to_invoke = callback;
+                callback_context   = callback_owner ? callback_owner->context : nullptr;
+                callback_invoking  = true;
+            }
+
+            const bool callback_succeeded =
+                callback_to_invoke && callback_context &&
+                InvokeCallback(callback_to_invoke, callback_context, *callback_event);
+
+            bool stop_dispatch = false;
+            {
+                std::unique_lock lock(mutation_mutex);
+                callback_invoking                  = false;
+                callback_event->callback_succeeded = callback_succeeded;
+                callback_event->completed          = true;
+                if (IsRetired()) {
+                    CancelQueuedCallbacksLocked();
+                    callback_dispatching = false;
+                    retired_callback_owner.reset(DetachCallbackOwnerLocked());
+                    stop_dispatch = true;
+                } else if (callback_queue.empty()) {
+                    callback_dispatching = false;
+                    stop_dispatch        = true;
+                }
+            }
+            retired_callback_owner.reset();
+            if (stop_dispatch) {
+                return;
+            }
+        }
+    }
+
+    void CancelQueuedCallbacksLocked() noexcept {
+        for (const std::shared_ptr<CallbackEvent>& event : callback_queue) {
+            event->callback_canceled = true;
+            event->completed         = true;
+        }
+        callback_queue.clear();
+    }
+
+protected:
+    CallbackOwner* RetireCallbacksLocked() noexcept override {
+        callback = nullptr;
+        CancelQueuedCallbacksLocked();
+        if (callback_invoking) {
+            return nullptr;
+        }
+        callback_dispatching = false;
+        return callback_owner.release();
+    }
+
+    CallbackOwner* DetachCallbackOwnerLocked() noexcept override {
+        if (callback_invoking) {
+            return nullptr;
+        }
+        callback = nullptr;
+        CancelQueuedCallbacksLocked();
+        return callback_owner.release();
+    }
+
+private:
+    mutable std::shared_mutex                  value_mutex;
+    T                                          value;
+    Callback                                   callback = nullptr;
+    std::unique_ptr<CallbackOwner>             callback_owner;
+    std::deque<std::shared_ptr<CallbackEvent>> callback_queue;
+    bool                                       callback_dispatching = false;
+    bool                                       callback_invoking    = false;
+};
+
+using BoolEntry   = Entry<bool, Detail::BoolCallback>;
+using IntEntry    = Entry<std::int64_t, Detail::IntCallback>;
+using FloatEntry  = Entry<double, Detail::FloatCallback>;
+using StringEntry = Entry<std::string, Detail::StringCallback>;
+
+struct RegistryData {
+    std::mutex                                                    registry_mutex;
+    std::unordered_map<std::string, std::shared_ptr<EntryBase>>   by_name;
+    std::unordered_map<std::uint64_t, std::shared_ptr<EntryBase>> by_id;
+    std::atomic<std::uint64_t>                                    next_id{1};
+    bool                                                          startup_sealed = false;
+};
+
+RegistryData& GetRegistry() {
+    static RegistryData registry;
+    return registry;
+}
+
+std::shared_ptr<EntryBase> FindEntryById(std::uint64_t _id) {
+    RegistryData&   registry = GetRegistry();
+    std::lock_guard lock(registry.registry_mutex);
+    const auto      found = registry.by_id.find(_id);
+    return found == registry.by_id.end() ? nullptr : found->second;
+}
+
+std::shared_ptr<EntryBase> FindEntryByName(std::string_view _name) {
+    RegistryData&   registry = GetRegistry();
+    std::lock_guard lock(registry.registry_mutex);
+    const auto      found = registry.by_name.find(NormalizeName(_name));
+    return found == registry.by_name.end() ? nullptr : found->second;
+}
+
+void Unregister(std::uint64_t _id) noexcept {
+    if (_id == 0) {
+        return;
+    }
+
+    std::shared_ptr<EntryBase> retired_entry;
+    RegistryData&              registry = GetRegistry();
+    {
+        std::lock_guard lock(registry.registry_mutex);
+        const auto      by_id = registry.by_id.find(_id);
+        if (by_id == registry.by_id.end()) {
+            return;
+        }
+
+        retired_entry      = by_id->second;
+        const auto by_name = registry.by_name.find(retired_entry->registry_key);
+        if (by_name != registry.by_name.end() && by_name->second.get() == retired_entry.get()) {
+            registry.by_name.erase(by_name);
+        }
+        registry.by_id.erase(by_id);
+    }
+
+    retired_entry->RetireAndWait();
+    retired_entry.reset();
+}
+
+CVarDescriptor CopyDescriptor(CVarDescriptorView _view) {
+    return {
+        .name         = std::string(_view.name),
+        .helper       = std::string(_view.helper),
+        .true_helper  = std::string(_view.true_helper),
+        .false_helper = std::string(_view.false_helper),
+        .flags        = _view.flags,
+        .min_value    = _view.min_value,
+        .max_value    = _view.max_value,
+    };
+}
+
+template<typename Value>
+bool DescriptorIsInvalid(CVarDescriptorView _descriptor, const Value& _value) {
+    const bool has_non_finite_bound = (_descriptor.min_value && !std::isfinite(*_descriptor.min_value)) ||
+                                      (_descriptor.max_value && !std::isfinite(*_descriptor.max_value));
+    const bool has_inverted_range =
+        _descriptor.min_value && _descriptor.max_value && *_descriptor.min_value > *_descriptor.max_value;
+    const bool has_range_for_non_numeric = !std::is_same_v<Value, std::int64_t> &&
+                                           !std::is_same_v<Value, double> &&
+                                           (_descriptor.min_value || _descriptor.max_value);
+    bool default_is_invalid = false;
+    if constexpr (std::is_same_v<Value, std::int64_t>) {
+        default_is_invalid = (_descriptor.min_value && IntIsBelowMinimum(_value, *_descriptor.min_value)) ||
+                             (_descriptor.max_value && IntIsAboveMaximum(_value, *_descriptor.max_value));
+    } else if constexpr (std::is_same_v<Value, double>) {
+        default_is_invalid = !std::isfinite(_value) ||
+                             (_descriptor.min_value && _value < *_descriptor.min_value) ||
+                             (_descriptor.max_value && _value > *_descriptor.max_value);
+    }
+    return !IsValidName(_descriptor.name) || has_non_finite_bound || has_inverted_range ||
+           has_range_for_non_numeric || default_is_invalid;
+}
+
+template<typename EntryType, typename Value, typename Callback>
+RegistrationResult RegisterEntry(
+    CVarDescriptorView _descriptor,
+    Value              _value,
+    Callback           _callback,
+    CallbackOwner      _callback_owner
+) {
+    const bool has_callback               = _callback != nullptr;
+    const bool has_callback_context       = _callback_owner.context != nullptr;
+    const bool has_callback_destroy       = _callback_owner.destroy != nullptr;
+    const bool has_empty_callback_binding = !has_callback && !has_callback_context && !has_callback_destroy;
+    const bool has_complete_callback_binding = has_callback && has_callback_context && has_callback_destroy;
+    if (DescriptorIsInvalid(_descriptor, _value) ||
+        (!has_empty_callback_binding && !has_complete_callback_binding)) {
+        return {
+            .status = ERegistrationStatus::InvalidDescriptor,
+            .detail = "invalid cvar descriptor, default, or callback binding",
+        };
+    }
+
+    RegistryData&       registry = GetRegistry();
+    const std::uint64_t id       = registry.next_id.fetch_add(1, std::memory_order_relaxed);
+    if (id == 0) {
+        return {
+            .status = ERegistrationStatus::InvalidDescriptor,
+            .detail = "cvar registration id space was exhausted",
+        };
+    }
+
+    std::string registry_key = NormalizeName(_descriptor.name);
+    auto        entry        = std::make_shared<EntryType>(
+        id,
+        registry_key,
+        CopyDescriptor(_descriptor),
+        std::move(_value),
+        _callback,
+        std::move(_callback_owner)
+    );
+
+    bool               duplicate    = false;
+    bool               id_collision = false;
+    std::exception_ptr insertion_failure;
+    {
+        std::lock_guard lock(registry.registry_mutex);
+        if (registry.by_name.contains(registry_key)) {
+            duplicate = true;
+        } else if (registry.by_id.contains(id)) {
+            id_collision = true;
+        } else {
+            if (registry.startup_sealed) {
+                entry->SealStartup();
+            }
+            try {
+                const bool name_inserted = registry.by_name.emplace(registry_key, entry).second;
+                const bool id_inserted   = registry.by_id.emplace(id, entry).second;
+                if (!name_inserted || !id_inserted) {
+                    if (name_inserted) {
+                        registry.by_name.erase(registry_key);
+                    }
+                    if (id_inserted) {
+                        registry.by_id.erase(id);
+                    }
+                    id_collision = true;
+                }
+            } catch (...) {
+                registry.by_name.erase(registry_key);
+                registry.by_id.erase(id);
+                insertion_failure = std::current_exception();
+            }
+        }
+    }
+
+    if (insertion_failure) {
+        entry.reset();
+        std::rethrow_exception(insertion_failure);
+    }
+    if (duplicate) {
+        return {
+            .status = ERegistrationStatus::DuplicateName,
+            .detail = "a cvar with the same case-insensitive name exists",
+        };
+    }
+    if (id_collision) {
+        return {
+            .status = ERegistrationStatus::InvalidDescriptor,
+            .detail = "cvar registration id space was exhausted",
+        };
+    }
+    return {
+        .status       = ERegistrationStatus::Registered,
+        .registration = Detail::RegistrationAccess::Create(id),
+    };
+}
+
+template<typename Callback>
+bool CallbackBindingIsValid(Callback _callback, void* _context, Detail::DestroyCallback _destroy) noexcept {
+    const bool empty    = _callback == nullptr && _context == nullptr && _destroy == nullptr;
+    const bool complete = _callback != nullptr && _context != nullptr && _destroy != nullptr;
+    return empty || complete;
+}
+
+bool VisitEntrySnapshot(const std::shared_ptr<EntryBase>& _entry, SnapshotVisitor _visitor, void* _context) {
+    if (!_entry || !_visitor) {
+        return false;
+    }
+
+    EntryBase::Operation operation(*_entry);
+    if (!operation.IsValid()) {
+        return false;
+    }
+    const std::string value = _entry->CopyValueString();
+    _visitor(
+        {
+            .id             = _entry->id,
+            .name           = _entry->descriptor.name,
+            .helper         = _entry->descriptor.helper,
+            .true_helper    = _entry->descriptor.true_helper,
+            .false_helper   = _entry->descriptor.false_helper,
+            .value          = value,
+            .type           = _entry->type,
+            .flags          = _entry->descriptor.flags,
+            .min_value      = _entry->descriptor.min_value,
+            .max_value      = _entry->descriptor.max_value,
+            .startup_sealed = _entry->startup_sealed.load(std::memory_order_acquire),
+        },
+        _context
+    );
+    return true;
+}
+
+} // namespace
+
+Registration Detail::RegistrationAccess::Create(std::uint64_t _id) noexcept {
+    return Registration(_id);
+}
+
+Registration::Registration(std::uint64_t _id) noexcept : id(_id) {}
+
+Registration::~Registration() {
+    Reset();
+}
+
+Registration::Registration(Registration&& _other) noexcept : id(std::exchange(_other.id, 0)) {}
+
+Registration& Registration::operator=(Registration&& _other) noexcept {
+    if (this != &_other) {
+        Reset();
+        id = std::exchange(_other.id, 0);
+    }
+    return *this;
+}
+
+CVarSetResult Registration::SynchronizeOwnerValue(bool _value) {
+    const std::shared_ptr<EntryBase> entry = FindEntryById(id);
+    return entry ? entry->SynchronizeOwnerValue(CVarValue(_value)) :
+                   CVarSetResult{
+                       .status = ESetStatus::InvalidRegistration,
+                       .detail = "registration is no longer active",
+                   };
+}
+
+CVarSetResult Registration::SynchronizeOwnerValue(std::int64_t _value) {
+    const std::shared_ptr<EntryBase> entry = FindEntryById(id);
+    return entry ? entry->SynchronizeOwnerValue(CVarValue(_value)) :
+                   CVarSetResult{
+                       .status = ESetStatus::InvalidRegistration,
+                       .detail = "registration is no longer active",
+                   };
+}
+
+CVarSetResult Registration::SynchronizeOwnerValue(double _value) {
+    const std::shared_ptr<EntryBase> entry = FindEntryById(id);
+    return entry ? entry->SynchronizeOwnerValue(CVarValue(_value)) :
+                   CVarSetResult{
+                       .status = ESetStatus::InvalidRegistration,
+                       .detail = "registration is no longer active",
+                   };
+}
+
+CVarSetResult Registration::SynchronizeOwnerValue(std::string_view _value) {
+    const std::shared_ptr<EntryBase> entry = FindEntryById(id);
+    return entry ? entry->SynchronizeOwnerValue(CVarValue(std::string(_value))) :
+                   CVarSetResult{
+                       .status = ESetStatus::InvalidRegistration,
+                       .detail = "registration is no longer active",
+                   };
+}
+
+void Registration::Reset() noexcept {
+    const std::uint64_t reset_id = std::exchange(id, 0);
+    Unregister(reset_id);
+}
+
+RegistrationResult Detail::RegisterBoolRaw(
+    CVarDescriptorView _descriptor,
+    bool               _default_value,
+    BoolCallback       _callback,
+    void*              _context,
+    DestroyCallback    _destroy
+) {
+    if (!CallbackBindingIsValid(_callback, _context, _destroy)) {
+        return {
+            .status = ERegistrationStatus::InvalidDescriptor,
+            .detail = "callback binding must be entirely empty or complete",
+        };
+    }
+    CallbackOwner owner(_context, _destroy);
+    return RegisterEntry<BoolEntry>(_descriptor, _default_value, _callback, std::move(owner));
+}
+
+RegistrationResult Detail::RegisterIntRaw(
+    CVarDescriptorView _descriptor,
+    std::int64_t       _default_value,
+    IntCallback        _callback,
+    void*              _context,
+    DestroyCallback    _destroy
+) {
+    if (!CallbackBindingIsValid(_callback, _context, _destroy)) {
+        return {
+            .status = ERegistrationStatus::InvalidDescriptor,
+            .detail = "callback binding must be entirely empty or complete",
+        };
+    }
+    CallbackOwner owner(_context, _destroy);
+    return RegisterEntry<IntEntry>(_descriptor, _default_value, _callback, std::move(owner));
+}
+
+RegistrationResult Detail::RegisterFloatRaw(
+    CVarDescriptorView _descriptor,
+    double             _default_value,
+    FloatCallback      _callback,
+    void*              _context,
+    DestroyCallback    _destroy
+) {
+    if (!CallbackBindingIsValid(_callback, _context, _destroy)) {
+        return {
+            .status = ERegistrationStatus::InvalidDescriptor,
+            .detail = "callback binding must be entirely empty or complete",
+        };
+    }
+    CallbackOwner owner(_context, _destroy);
+    return RegisterEntry<FloatEntry>(_descriptor, _default_value, _callback, std::move(owner));
+}
+
+RegistrationResult Detail::RegisterStringRaw(
+    CVarDescriptorView _descriptor,
+    std::string_view   _default_value,
+    StringCallback     _callback,
+    void*              _context,
+    DestroyCallback    _destroy
+) {
+    if (!CallbackBindingIsValid(_callback, _context, _destroy)) {
+        return {
+            .status = ERegistrationStatus::InvalidDescriptor,
+            .detail = "callback binding must be entirely empty or complete",
+        };
+    }
+    CallbackOwner owner(_context, _destroy);
+    return RegisterEntry<StringEntry>(_descriptor, std::string(_default_value), _callback, std::move(owner));
+}
+
+bool Detail::VisitSnapshotRaw(std::string_view _name, SnapshotVisitor _visitor, void* _context) {
+    return VisitEntrySnapshot(FindEntryByName(_name), _visitor, _context);
+}
+
+bool Detail::VisitSnapshotByIdRaw(std::uint64_t _id, SnapshotVisitor _visitor, void* _context) {
+    return VisitEntrySnapshot(FindEntryById(_id), _visitor, _context);
+}
+
+std::size_t Detail::VisitAllSnapshotsRaw(std::string_view _prefix, SnapshotVisitor _visitor, void* _context) {
+    if (!_visitor) {
+        return 0;
+    }
+
+    std::vector<std::shared_ptr<EntryBase>> entries;
+    {
+        RegistryData&   registry = GetRegistry();
+        std::lock_guard lock(registry.registry_mutex);
+        entries.reserve(registry.by_name.size());
+        for (const auto& [name, entry] : registry.by_name) {
+            (void)name;
+            if (_prefix.empty() || StartsWithInsensitive(entry->descriptor.name, _prefix)) {
+                entries.push_back(entry);
+            }
+        }
+    }
+
+    std::size_t visited_count = 0;
+    for (const std::shared_ptr<EntryBase>& entry : entries) {
+        if (VisitEntrySnapshot(entry, _visitor, _context)) {
+            ++visited_count;
+        }
+    }
+    return visited_count;
+}
+
+CVarSetResult SetValueFromString(std::string_view _name, std::string_view _value, ESetSource _source) {
+    const std::shared_ptr<EntryBase> entry = FindEntryByName(_name);
+    if (!entry) {
+        return {
+            .status = ESetStatus::NotFound,
+            .detail = "unknown cvar",
+        };
+    }
+    return entry->SetFromString(_value, _source);
+}
+
+void SealStartupOnlyCVars() {
+    RegistryData&   registry = GetRegistry();
+    std::lock_guard lock(registry.registry_mutex);
+    registry.startup_sealed = true;
+    for (const auto& [id, entry] : registry.by_id) {
+        (void)id;
+        entry->SealStartup();
+    }
+}
+
+bool IsStartupConfigurationSealed() noexcept {
+    RegistryData&   registry = GetRegistry();
+    std::lock_guard lock(registry.registry_mutex);
+    return registry.startup_sealed;
+}
+
+} // namespace Moer::CVar

--- a/source/runtime/core/source/config/CVarSystem.cpp
+++ b/source/runtime/core/source/config/CVarSystem.cpp
@@ -214,6 +214,7 @@ bool IntIsAboveMaximum(std::int64_t _value, double _maximum) noexcept {
 }
 
 thread_local std::uint32_t callback_destroy_depth = 0;
+thread_local std::uint32_t snapshot_visitor_depth = 0;
 
 struct CallbackOwner {
     CallbackOwner(void* _context, Detail::DestroyCallback _destroy) noexcept :
@@ -269,8 +270,29 @@ struct ActiveCallbackNode {
 thread_local ActiveOperationNode* active_operation = nullptr;
 thread_local ActiveCallbackNode*  active_callback  = nullptr;
 
-bool IsInsideCallbackOrDestroy() noexcept {
-    return active_callback != nullptr || callback_destroy_depth != 0;
+bool IsInsideNonblockingResetContext() noexcept {
+    return active_callback != nullptr || callback_destroy_depth != 0 || snapshot_visitor_depth != 0;
+}
+
+class SnapshotVisitorScope {
+public:
+    SnapshotVisitorScope() noexcept {
+        ++snapshot_visitor_depth;
+    }
+
+    ~SnapshotVisitorScope() {
+        --snapshot_visitor_depth;
+    }
+
+    SnapshotVisitorScope(const SnapshotVisitorScope&)            = delete;
+    SnapshotVisitorScope& operator=(const SnapshotVisitorScope&) = delete;
+};
+
+void InvokeSnapshotVisitor(
+    SnapshotVisitor _visitor, const CVarSnapshotView& _snapshot, void* _context
+) {
+    SnapshotVisitorScope scope;
+    _visitor(_snapshot, _context);
 }
 
 class EntryBase {
@@ -332,7 +354,7 @@ public:
         retired_callback_owner.reset();
 
         std::unique_lock lock(lifetime_mutex);
-        if (IsActiveOnCurrentThread() || IsInsideCallbackOrDestroy()) {
+        if (IsActiveOnCurrentThread() || IsInsideNonblockingResetContext()) {
             return;
         }
         lifetime_cv.wait(lock, [this] {
@@ -759,8 +781,12 @@ struct RegistryData {
 };
 
 RegistryData& GetRegistry() {
-    static RegistryData registry;
-    return registry;
+    // Registrations and their caller-owned destroy thunks may have static
+    // lifetime and re-enter this API during process teardown. Keep the
+    // registry alive until the process releases its address space instead of
+    // depending on cross-module static destruction order.
+    static RegistryData* const registry = new RegistryData();
+    return *registry;
 }
 
 std::shared_ptr<EntryBase> FindEntryById(std::uint64_t _id) {
@@ -973,7 +999,7 @@ bool VisitEntrySnapshot(const std::shared_ptr<EntryBase>& _entry, SnapshotVisito
     // The shared_ptr keeps descriptor storage alive and value owns its copy.
     // End the active operation before entering caller code so cross-entry
     // Reset calls from concurrent visitors cannot form a quiescence wait cycle.
-    _visitor(snapshot, _context);
+    InvokeSnapshotVisitor(_visitor, snapshot, _context);
     return true;
 }
 

--- a/source/runtime/core/source/config/CVarSystem.cpp
+++ b/source/runtime/core/source/config/CVarSystem.cpp
@@ -539,6 +539,12 @@ private:
                 };
             }
         } else if constexpr (std::is_same_v<T, double>) {
+            if (!std::isfinite(_value)) {
+                return {
+                    .status = ESetStatus::TypeMismatch,
+                    .detail = "expected finite floating-point value",
+                };
+            }
             if (descriptor.min_value && _value < *descriptor.min_value) {
                 return {
                     .status = ESetStatus::OutOfRange,

--- a/source/test/CMakeLists.txt
+++ b/source/test/CMakeLists.txt
@@ -4,6 +4,15 @@ add_subdirectory(math)
 add_subdirectory(remote)
 add_subdirectory(scripting)
 
+set(test_target TestCVarCommandCore)
+add_executable(${test_target} "CVarCommandCoreTest.cpp")
+target_link_libraries(${test_target}
+    PRIVATE Moer::Core
+)
+set_target_properties(${test_target} PROPERTIES FOLDER ${moer_test_folder})
+add_test(NAME CVarCommandCoreContract COMMAND $<TARGET_FILE:${test_target}>)
+set_tests_properties(CVarCommandCoreContract PROPERTIES TIMEOUT 60)
+
 set(test_target TestFatalDiagnostics)
 add_executable(${test_target} "FatalDiagnosticsTest.cpp")
 target_include_directories(${test_target}

--- a/source/test/CVarCommandCoreTest.cpp
+++ b/source/test/CVarCommandCoreTest.cpp
@@ -654,8 +654,6 @@ void TestFlagsOwnerSyncAndCallbacks() {
         "self-Reset allowed a queued mutation to invoke a late callback"
     );
 
-    CVar::RegistrationResult visitor_blocker =
-        CVar::RegisterBool(CVar::CVarDescriptor{.name = "Test.Visitor.Pin.Blocker"}, false);
     std::atomic_uint32_t            pinned_callback_destroyed{0};
     std::shared_ptr<CountOnDestroy> pinned_lifetime = std::make_shared<CountOnDestroy>();
     pinned_lifetime->count                          = &pinned_callback_destroyed;
@@ -664,22 +662,29 @@ void TestFlagsOwnerSyncAndCallbacks() {
     CVar::RegistrationResult visitor_target = CVar::RegisterInt(
         CVar::CVarDescriptor{.name = "Test.Visitor.Pin.Target"}, 0, std::move(pinned_callback)
     );
+    Expect(visitor_target.Succeeded(), "snapshot visitor lifetime fixture did not register");
     struct VisitorPinContext {
         std::atomic_bool entered{false};
         std::atomic_bool release{false};
-    } visitor_context;
+        std::atomic_bool view_remained_valid{false};
+        std::uint64_t    expected_id = 0;
+    } visitor_context{
+        .expected_id = visitor_target.registration.GetId(),
+    };
     std::jthread visitor([&] {
-        CVar::Detail::VisitAllSnapshotsRaw(
-            "Test.Visitor.Pin.",
+        CVar::Detail::VisitSnapshotRaw(
+            "Test.Visitor.Pin.Target",
             [](const CVar::CVarSnapshotView& _snapshot, void* _context) {
                 auto& context = *static_cast<VisitorPinContext*>(_context);
-                if (_snapshot.name != "Test.Visitor.Pin.Blocker") {
-                    return;
-                }
                 context.entered.store(true, std::memory_order_release);
                 while (!context.release.load(std::memory_order_acquire)) {
                     std::this_thread::yield();
                 }
+                context.view_remained_valid.store(
+                    _snapshot.id == context.expected_id &&
+                        _snapshot.name == "Test.Visitor.Pin.Target" && _snapshot.value == "0",
+                    std::memory_order_release
+                );
             },
             &visitor_context
         );
@@ -687,13 +692,91 @@ void TestFlagsOwnerSyncAndCallbacks() {
     while (!visitor_context.entered.load(std::memory_order_acquire)) {
         std::this_thread::yield();
     }
-    visitor_target.registration.Reset();
+    std::atomic_bool reset_during_visitor_returned{false};
+    std::jthread     reset_during_visitor([&] {
+        visitor_target.registration.Reset();
+        reset_during_visitor_returned.store(true, std::memory_order_release);
+    });
+    while (!reset_during_visitor_returned.load(std::memory_order_acquire)) {
+        std::this_thread::yield();
+    }
     Expect(
-        pinned_callback_destroyed.load(std::memory_order_acquire) == 1,
-        "Reset deferred caller callback destruction behind a snapshot pin"
+        pinned_callback_destroyed.load(std::memory_order_acquire) == 1 &&
+            !CVar::Find("Test.Visitor.Pin.Target"),
+        "Reset did not retire a cvar and its callback capture while its snapshot visitor was active"
+    );
+    CVar::RegistrationResult visitor_replacement =
+        CVar::RegisterInt(CVar::CVarDescriptor{.name = "Test.Visitor.Pin.Target"}, 7);
+    const std::optional<CVar::CVarSnapshot> replacement_snapshot =
+        CVar::Find("Test.Visitor.Pin.Target");
+    Expect(
+        visitor_replacement.Succeeded() &&
+            visitor_replacement.registration.GetId() != visitor_context.expected_id &&
+            replacement_snapshot &&
+            replacement_snapshot->id == visitor_replacement.registration.GetId(),
+        "same-name replacement did not establish a distinct snapshot generation"
     );
     visitor_context.release.store(true, std::memory_order_release);
     visitor.join();
+    reset_during_visitor.join();
+    Expect(
+        visitor_context.view_remained_valid.load(std::memory_order_acquire),
+        "Reset or same-name replacement invalidated the active visitor's old snapshot view"
+    );
+
+    CVar::RegistrationResult cross_visitor_a =
+        CVar::RegisterBool(CVar::CVarDescriptor{.name = "Test.Visitor.CrossResetA"}, false);
+    CVar::RegistrationResult cross_visitor_b =
+        CVar::RegisterBool(CVar::CVarDescriptor{.name = "Test.Visitor.CrossResetB"}, false);
+    Expect(
+        cross_visitor_a.Succeeded() && cross_visitor_b.Succeeded(),
+        "cross-reset snapshot visitor fixtures did not register"
+    );
+    struct CrossVisitorContext {
+        CVar::Registration*   target = nullptr;
+        std::atomic_uint32_t* entered = nullptr;
+        std::atomic_bool*     completed = nullptr;
+    };
+    std::atomic_uint32_t cross_visitor_entered{0};
+    std::atomic_bool     cross_visitor_a_completed{false};
+    std::atomic_bool     cross_visitor_b_completed{false};
+    CrossVisitorContext  cross_visitor_a_context{
+        .target    = &cross_visitor_b.registration,
+        .entered   = &cross_visitor_entered,
+        .completed = &cross_visitor_a_completed,
+    };
+    CrossVisitorContext cross_visitor_b_context{
+        .target    = &cross_visitor_a.registration,
+        .entered   = &cross_visitor_entered,
+        .completed = &cross_visitor_b_completed,
+    };
+    const auto cross_reset_visitor = [](const CVar::CVarSnapshotView&, void* _context) {
+        auto& context = *static_cast<CrossVisitorContext*>(_context);
+        context.entered->fetch_add(1, std::memory_order_acq_rel);
+        while (context.entered->load(std::memory_order_acquire) != 2) {
+            std::this_thread::yield();
+        }
+        context.target->Reset();
+        context.completed->store(true, std::memory_order_release);
+    };
+    std::jthread cross_visitor_a_thread([&] {
+        CVar::Detail::VisitSnapshotRaw(
+            "Test.Visitor.CrossResetA", cross_reset_visitor, &cross_visitor_a_context
+        );
+    });
+    std::jthread cross_visitor_b_thread([&] {
+        CVar::Detail::VisitAllSnapshotsRaw(
+            "Test.Visitor.CrossResetB", cross_reset_visitor, &cross_visitor_b_context
+        );
+    });
+    cross_visitor_a_thread.join();
+    cross_visitor_b_thread.join();
+    Expect(
+        cross_visitor_a_completed.load(std::memory_order_acquire) &&
+            cross_visitor_b_completed.load(std::memory_order_acquire) &&
+            !CVar::Find("Test.Visitor.CrossResetA") && !CVar::Find("Test.Visitor.CrossResetB"),
+        "cross-resetting snapshot visitors deadlocked or left a registration active"
+    );
 }
 
 void TestListingAndCandidates() {

--- a/source/test/CVarCommandCoreTest.cpp
+++ b/source/test/CVarCommandCoreTest.cpp
@@ -3,7 +3,9 @@
 
 #include <algorithm>
 #include <atomic>
+#include <chrono>
 #include <cmath>
+#include <condition_variable>
 #include <cstdint>
 #include <cstdlib>
 #include <iostream>
@@ -19,6 +21,10 @@
 namespace {
 
 using namespace Moer;
+
+std::atomic_bool   contract_body_succeeded{false};
+std::atomic_bool   exit_lifetime_destroy_reentered{false};
+CVar::Registration exit_lifetime_registration;
 
 void Expect(bool _condition, std::string_view _message) {
     if (!_condition) {
@@ -777,6 +783,73 @@ void TestFlagsOwnerSyncAndCallbacks() {
             !CVar::Find("Test.Visitor.CrossResetA") && !CVar::Find("Test.Visitor.CrossResetB"),
         "cross-resetting snapshot visitors deadlocked or left a registration active"
     );
+
+    std::atomic_bool        callback_wait_entered{false};
+    std::atomic_bool        reset_visitor_started{false};
+    std::atomic_bool        reset_returned_before_callback_release{false};
+    std::mutex              visitor_cycle_returned_mutex;
+    std::condition_variable visitor_cycle_returned_cv;
+    bool                    visitor_cycle_reset_returned = false;
+    CVar::RegistrationResult visitor_callback_cycle = CVar::RegisterInt(
+        CVar::CVarDescriptor{.name = "Test.Visitor.CallbackWaitCycle"},
+        0,
+        [&](std::int64_t, std::int64_t) {
+            callback_wait_entered.store(true, std::memory_order_release);
+            while (!reset_visitor_started.load(std::memory_order_acquire)) {
+                std::this_thread::yield();
+            }
+            std::unique_lock lock(visitor_cycle_returned_mutex);
+            reset_returned_before_callback_release.store(
+                visitor_cycle_returned_cv.wait_for(lock, std::chrono::seconds(2), [&] {
+                    return visitor_cycle_reset_returned;
+                }),
+                std::memory_order_release
+            );
+        }
+    );
+    Expect(visitor_callback_cycle.Succeeded(), "snapshot visitor callback-cycle fixture did not register");
+    struct VisitorCallbackCycleContext {
+        CVar::Registration*      registration    = nullptr;
+        std::atomic_bool*        visitor_started = nullptr;
+        std::mutex*              returned_mutex  = nullptr;
+        std::condition_variable* returned_cv = nullptr;
+        bool*                    reset_returned = nullptr;
+    } visitor_callback_cycle_context{
+        .registration    = &visitor_callback_cycle.registration,
+        .visitor_started = &reset_visitor_started,
+        .returned_mutex  = &visitor_cycle_returned_mutex,
+        .returned_cv     = &visitor_cycle_returned_cv,
+        .reset_returned  = &visitor_cycle_reset_returned,
+    };
+    std::jthread callback_wait_setter([&] {
+        CVar::SetValueFromString("Test.Visitor.CallbackWaitCycle", "1");
+    });
+    while (!callback_wait_entered.load(std::memory_order_acquire)) {
+        std::this_thread::yield();
+    }
+    std::jthread callback_wait_visitor([&] {
+        CVar::Detail::VisitSnapshotRaw(
+            "Test.Visitor.CallbackWaitCycle",
+            [](const CVar::CVarSnapshotView&, void* _context) {
+                auto& context = *static_cast<VisitorCallbackCycleContext*>(_context);
+                context.visitor_started->store(true, std::memory_order_release);
+                context.registration->Reset();
+                {
+                    std::lock_guard lock(*context.returned_mutex);
+                    *context.reset_returned = true;
+                }
+                context.returned_cv->notify_one();
+            },
+            &visitor_callback_cycle_context
+        );
+    });
+    callback_wait_visitor.join();
+    callback_wait_setter.join();
+    Expect(
+        reset_returned_before_callback_release.load(std::memory_order_acquire) &&
+            !CVar::Find("Test.Visitor.CallbackWaitCycle"),
+        "snapshot visitor Reset waited on an active callback that depended on the visitor"
+    );
 }
 
 void TestListingAndCandidates() {
@@ -1049,9 +1122,41 @@ void TestStartupSealLast() {
     );
 }
 
+void InstallExitLifetimeSmoke() {
+    std::shared_ptr<RegisterOnDestroy> destroy_capture = std::make_shared<RegisterOnDestroy>();
+    destroy_capture->destroyed                         = &exit_lifetime_destroy_reentered;
+    CVar::RegistrationResult result                   = CVar::RegisterBool(
+        CVar::CVarDescriptor{.name = "Test.Lifetime.ExitReentry"},
+        false,
+        [destroy_capture](bool, bool) {}
+    );
+    destroy_capture.reset();
+    Expect(result.Succeeded(), "process-lifetime registration fixture did not register");
+    exit_lifetime_registration = std::move(result.registration);
+}
+
+void VerifyExitLifetimeSmoke() noexcept {
+    bool succeeded = false;
+    try {
+        const std::optional<CVar::CVarSnapshot> before =
+            CVar::Find("Test.Lifetime.ExitReentry");
+        exit_lifetime_registration.Reset();
+        succeeded =
+            contract_body_succeeded.load(std::memory_order_acquire) && before &&
+            exit_lifetime_destroy_reentered.load(std::memory_order_acquire) &&
+            !CVar::Find("Test.Lifetime.ExitReentry");
+    } catch (...) {
+    }
+    std::_Exit(succeeded ? EXIT_SUCCESS : EXIT_FAILURE);
+}
+
 } // namespace
 
 int main() {
+    if (std::atexit(&VerifyExitLifetimeSmoke) != 0) {
+        std::cerr << "CVar/command core contract test could not install its exit-lifetime probe.\n";
+        return EXIT_FAILURE;
+    }
     try {
         TestRegistrationLifetimeAndDescriptors();
         TestTypedParsingAndRanges();
@@ -1060,7 +1165,9 @@ int main() {
         TestCommandProcessing();
         TestBoundedQueuesAndOutputCursor();
         TestStartupSealLast();
-        std::cout << "CVar/command core contract tests passed.\n";
+        InstallExitLifetimeSmoke();
+        std::cout << "CVar/command core contract tests passed.\n" << std::flush;
+        contract_body_succeeded.store(true, std::memory_order_release);
         return EXIT_SUCCESS;
     } catch (const std::exception& error) {
         std::cerr << "CVar/command core contract test failed: " << error.what() << '\n';

--- a/source/test/CVarCommandCoreTest.cpp
+++ b/source/test/CVarCommandCoreTest.cpp
@@ -1,0 +1,886 @@
+#include "command/EngineCommandProcessor.h"
+#include "config/CVarSystem.h"
+
+#include <algorithm>
+#include <atomic>
+#include <cmath>
+#include <cstdint>
+#include <cstdlib>
+#include <iostream>
+#include <limits>
+#include <memory>
+#include <mutex>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <thread>
+#include <vector>
+
+namespace {
+
+using namespace Moer;
+
+void Expect(bool _condition, std::string_view _message) {
+    if (!_condition) {
+        throw std::runtime_error(std::string(_message));
+    }
+}
+
+bool OutputContains(const Command::CommandOutputBatch& _batch, std::string_view _text) {
+    return std::ranges::any_of(_batch.lines, [_text](const Command::CommandOutputLine& _line) {
+        return _line.text.find(_text) != std::string::npos;
+    });
+}
+
+struct RegisterOnDestroy {
+    std::atomic_bool* destroyed = nullptr;
+
+    ~RegisterOnDestroy() {
+        CVar::RegistrationResult nested =
+            CVar::RegisterBool(CVar::CVarDescriptor{.name = "Test.Lifetime.DestructorReentry"}, false);
+        if (destroyed) {
+            destroyed->store(nested.Succeeded(), std::memory_order_release);
+        }
+    }
+};
+
+struct CountOnDestroy {
+    std::atomic_uint32_t* count = nullptr;
+
+    ~CountOnDestroy() {
+        if (count) {
+            count->fetch_add(1, std::memory_order_release);
+        }
+    }
+};
+
+void TestRegistrationLifetimeAndDescriptors() {
+    CVar::CVarDescriptor descriptor{
+        .name         = "Test.Lifetime.Toggle",
+        .helper       = "lifetime helper",
+        .true_helper  = "enabled",
+        .false_helper = "disabled",
+    };
+    CVar::RegistrationResult result = CVar::RegisterBool(descriptor, false);
+    Expect(result.Succeeded(), "valid bool cvar did not register");
+    Expect(CVar::Find("test.lifetime.toggle")->value == "false", "lookup was not case-insensitive");
+
+    CVar::RegistrationResult duplicate =
+        CVar::RegisterBool(CVar::CVarDescriptor{.name = "TEST.LIFETIME.TOGGLE"}, true);
+    Expect(
+        duplicate.status == CVar::ERegistrationStatus::DuplicateName,
+        "case-insensitive duplicate registration was accepted"
+    );
+
+    CVar::Registration moved = std::move(result.registration);
+    Expect(moved.IsValid() && !result.registration.IsValid(), "registration move did not transfer ownership");
+    moved.Reset();
+    Expect(!CVar::Find("Test.Lifetime.Toggle"), "registration reset did not unregister the cvar");
+    Expect(
+        moved.SynchronizeOwnerValue(true).status == CVar::ESetStatus::InvalidRegistration,
+        "stale registration accepted an owner update"
+    );
+
+    std::atomic_bool                   destructor_reentered{false};
+    std::shared_ptr<RegisterOnDestroy> destroy_capture = std::make_shared<RegisterOnDestroy>();
+    destroy_capture->destroyed                         = &destructor_reentered;
+    CVar::RegistrationResult destructor_cvar           = CVar::RegisterBool(
+        CVar::CVarDescriptor{.name = "Test.Lifetime.DestructorCapture"},
+        false,
+        [destroy_capture](bool, bool) {}
+    );
+    destroy_capture.reset();
+    destructor_cvar.registration.Reset();
+    Expect(
+        destructor_reentered.load(std::memory_order_acquire),
+        "callback capture was destroyed under the registry lock"
+    );
+
+    Expect(
+        CVar::RegisterInt(CVar::CVarDescriptor{.name = "bad name"}, 1).status ==
+            CVar::ERegistrationStatus::InvalidDescriptor,
+        "invalid cvar name was accepted"
+    );
+    Expect(
+        CVar::RegisterBool(
+            CVar::CVarDescriptor{
+                .name      = "Test.Invalid.BoolRange",
+                .min_value = 0.0,
+            },
+            false
+        )
+                .status == CVar::ERegistrationStatus::InvalidDescriptor,
+        "non-numeric cvar accepted a numeric range"
+    );
+    Expect(
+        CVar::RegisterInt(
+            CVar::CVarDescriptor{
+                .name      = "Test.Invalid.InvertedRange",
+                .min_value = 5.0,
+                .max_value = 1.0,
+            },
+            3
+        )
+                .status == CVar::ERegistrationStatus::InvalidDescriptor,
+        "inverted numeric range was accepted"
+    );
+    Expect(
+        CVar::RegisterFloat(
+            CVar::CVarDescriptor{
+                .name      = "Test.Invalid.NonFiniteRange",
+                .min_value = std::numeric_limits<double>::quiet_NaN(),
+            },
+            1.0
+        )
+                .status == CVar::ERegistrationStatus::InvalidDescriptor,
+        "non-finite numeric range was accepted"
+    );
+
+    int incomplete_context = 0;
+    Expect(
+        CVar::Detail::RegisterBoolRaw(
+            CVar::Detail::ViewOf(CVar::CVarDescriptor{
+                .name = "Test.Invalid.IncompleteCallback",
+            }),
+            false,
+            nullptr,
+            &incomplete_context,
+            nullptr
+        )
+                .status == CVar::ERegistrationStatus::InvalidDescriptor,
+        "incomplete raw callback binding was accepted"
+    );
+}
+
+void TestTypedParsingAndRanges() {
+    CVar::RegistrationResult bool_cvar =
+        CVar::RegisterBool(CVar::CVarDescriptor{.name = "Test.Types.Bool"}, false);
+    CVar::RegistrationResult int_cvar = CVar::RegisterInt(
+        CVar::CVarDescriptor{
+            .name      = "Test.Types.Int",
+            .min_value = -2.0,
+            .max_value = 4.0,
+        },
+        2
+    );
+    CVar::RegistrationResult float_cvar = CVar::RegisterFloat(
+        CVar::CVarDescriptor{
+            .name      = "Test.Types.Float",
+            .min_value = 0.0,
+            .max_value = 2.0,
+        },
+        1.0
+    );
+    CVar::RegistrationResult string_cvar =
+        CVar::RegisterString(CVar::CVarDescriptor{.name = "Test.Types.String"}, "initial");
+    Expect(
+        bool_cvar.Succeeded() && int_cvar.Succeeded() && float_cvar.Succeeded() && string_cvar.Succeeded(),
+        "typed cvar registration failed"
+    );
+
+    Expect(
+        CVar::SetValueFromString("TEST.TYPES.BOOL", " ON ").status == CVar::ESetStatus::Changed,
+        "bool parser rejected ON"
+    );
+    Expect(
+        CVar::SetValueFromString("Test.Types.Bool", "maybe").status == CVar::ESetStatus::TypeMismatch,
+        "bool parser accepted invalid text"
+    );
+    Expect(
+        CVar::SetValueFromString("Test.Types.Int", "4").Succeeded(),
+        "int parser rejected the inclusive maximum"
+    );
+    Expect(
+        CVar::SetValueFromString("Test.Types.Int", "5").status == CVar::ESetStatus::OutOfRange,
+        "int range accepted a value above maximum"
+    );
+    Expect(
+        CVar::SetValueFromString("Test.Types.Int", "4x").status == CVar::ESetStatus::TypeMismatch,
+        "int parser accepted trailing text"
+    );
+    CVar::RegistrationResult precise_int = CVar::RegisterInt(
+        CVar::CVarDescriptor{
+            .name      = "Test.Types.PreciseInt",
+            .max_value = 9007199254740992.0,
+        },
+        std::int64_t{9007199254740992}
+    );
+    Expect(
+        precise_int.Succeeded() &&
+            CVar::SetValueFromString("Test.Types.PreciseInt", "9007199254740993").status ==
+                CVar::ESetStatus::OutOfRange,
+        "int64 range comparison lost precision above 2^53"
+    );
+    Expect(
+        CVar::SetValueFromString("Test.Types.Float", "1.25").Succeeded(),
+        "float parser rejected a finite value"
+    );
+    Expect(
+        CVar::SetValueFromString("Test.Types.Float", "inf").status == CVar::ESetStatus::TypeMismatch,
+        "float parser accepted infinity"
+    );
+    Expect(
+        CVar::SetValueFromString("Test.Types.Float", "-0.1").status == CVar::ESetStatus::OutOfRange,
+        "float range accepted a value below minimum"
+    );
+    Expect(
+        CVar::SetValueFromString("Test.Types.String", "hello world").Succeeded(),
+        "string parser rejected spaces"
+    );
+    Expect(
+        CVar::Find("Test.Types.String")->value == "hello world", "string value snapshot changed its contents"
+    );
+    Expect(
+        CVar::SetValueFromString("missing.cvar", "1").status == CVar::ESetStatus::NotFound,
+        "unknown cvar did not report NotFound"
+    );
+
+    Expect(
+        CVar::RegisterInt(
+            CVar::CVarDescriptor{
+                .name      = "Test.Invalid.IntDefault",
+                .max_value = 3.0,
+            },
+            4
+        )
+                .status == CVar::ERegistrationStatus::InvalidDescriptor,
+        "out-of-range integer default was accepted"
+    );
+    Expect(
+        CVar::RegisterFloat(
+            CVar::CVarDescriptor{.name = "Test.Invalid.FloatDefault"}, std::numeric_limits<double>::infinity()
+        )
+                .status == CVar::ERegistrationStatus::InvalidDescriptor,
+        "non-finite float default was accepted"
+    );
+}
+
+void TestFlagsOwnerSyncAndCallbacks() {
+    std::atomic_uint32_t     read_only_callbacks{0};
+    CVar::RegistrationResult read_only = CVar::RegisterInt(
+        CVar::CVarDescriptor{
+            .name  = "Test.Flags.ReadOnly",
+            .flags = CVar::EFlags::ReadOnly,
+        },
+        1,
+        [&read_only_callbacks](std::int64_t, std::int64_t) {
+            read_only_callbacks.fetch_add(1, std::memory_order_relaxed);
+        }
+    );
+    Expect(read_only.Succeeded(), "read-only cvar did not register");
+    Expect(
+        CVar::SetValueFromString("Test.Flags.ReadOnly", "2").status == CVar::ESetStatus::ReadOnly,
+        "runtime update changed a read-only cvar"
+    );
+    Expect(
+        read_only.registration.SynchronizeOwnerValue(std::int64_t{2}).Succeeded(),
+        "owner could not synchronize a read-only cvar"
+    );
+    Expect(
+        read_only_callbacks.load(std::memory_order_relaxed) == 0,
+        "owner synchronization invoked the on-change callback"
+    );
+    Expect(
+        read_only.registration.SynchronizeOwnerValue(true).status == CVar::ESetStatus::TypeMismatch,
+        "owner synchronization accepted the wrong type"
+    );
+
+    CVar::RegistrationResult target =
+        CVar::RegisterInt(CVar::CVarDescriptor{.name = "Test.Callback.Target"}, 0);
+    std::atomic_uint32_t     callback_count{0};
+    CVar::RegistrationResult source = CVar::RegisterInt(
+        CVar::CVarDescriptor{.name = "Test.Callback.Source"},
+        0,
+        [&callback_count](std::int64_t, std::int64_t _new_value) {
+            Expect(
+                CVar::Find("Test.Callback.Source")->value == std::to_string(_new_value),
+                "callback ran before the new value became visible"
+            );
+            Expect(
+                CVar::SetValueFromString("Test.Callback.Target", std::to_string(_new_value)).Succeeded(),
+                "callback could not re-enter the registry"
+            );
+            callback_count.fetch_add(1, std::memory_order_relaxed);
+        }
+    );
+    Expect(target.Succeeded() && source.Succeeded(), "callback fixture did not register");
+    Expect(
+        CVar::SetValueFromString("Test.Callback.Source", "7").Succeeded(), "callback source update failed"
+    );
+    Expect(
+        callback_count.load(std::memory_order_relaxed) == 1 &&
+            CVar::Find("Test.Callback.Target")->value == "7",
+        "callback did not complete its re-entrant update"
+    );
+    Expect(
+        source.registration.SynchronizeOwnerValue(std::int64_t{8}).Succeeded() &&
+            callback_count.load(std::memory_order_relaxed) == 1,
+        "owner synchronization unexpectedly invoked a callback"
+    );
+
+    CVar::RegistrationResult throwing = CVar::RegisterInt(
+        CVar::CVarDescriptor{.name = "Test.Callback.Throwing"},
+        0,
+        [](std::int64_t, std::int64_t) {
+            throw std::runtime_error("injected callback failure");
+        }
+    );
+    const CVar::CVarSetResult throwing_result = CVar::SetValueFromString("Test.Callback.Throwing", "1");
+    Expect(
+        throwing_result.Succeeded() && throwing_result.callback_failed &&
+            CVar::Find("Test.Callback.Throwing")->value == "1",
+        "callback exception escaped or rolled back the committed value"
+    );
+
+    CVar::Registration*      self_registration = nullptr;
+    CVar::RegistrationResult self_removing     = CVar::RegisterInt(
+        CVar::CVarDescriptor{.name = "Test.Callback.SelfRemoving"},
+        0,
+        [&self_registration](std::int64_t, std::int64_t) {
+            self_registration->Reset();
+        }
+    );
+    self_registration = &self_removing.registration;
+    Expect(
+        CVar::SetValueFromString("Test.Callback.SelfRemoving", "1").Succeeded(),
+        "self-unregistering callback invalidated in-flight storage"
+    );
+    Expect(
+        !CVar::Find("Test.Callback.SelfRemoving"), "self-unregistering callback left the cvar discoverable"
+    );
+
+    std::atomic_uint32_t     cross_reset_entered{0};
+    CVar::Registration*      cross_a_registration = nullptr;
+    CVar::Registration*      cross_b_registration = nullptr;
+    CVar::RegistrationResult cross_a              = CVar::RegisterInt(
+        CVar::CVarDescriptor{.name = "Test.Callback.CrossResetA"},
+        0,
+        [&cross_reset_entered, &cross_b_registration](std::int64_t, std::int64_t) {
+            cross_reset_entered.fetch_add(1, std::memory_order_acq_rel);
+            while (cross_reset_entered.load(std::memory_order_acquire) != 2) {
+                std::this_thread::yield();
+            }
+            cross_b_registration->Reset();
+        }
+    );
+    CVar::RegistrationResult cross_b = CVar::RegisterInt(
+        CVar::CVarDescriptor{.name = "Test.Callback.CrossResetB"},
+        0,
+        [&cross_reset_entered, &cross_a_registration](std::int64_t, std::int64_t) {
+            cross_reset_entered.fetch_add(1, std::memory_order_acq_rel);
+            while (cross_reset_entered.load(std::memory_order_acquire) != 2) {
+                std::this_thread::yield();
+            }
+            cross_a_registration->Reset();
+        }
+    );
+    Expect(cross_a.Succeeded() && cross_b.Succeeded(), "cross-reset callback fixture did not register");
+    cross_a_registration = &cross_a.registration;
+    cross_b_registration = &cross_b.registration;
+    std::atomic_bool cross_a_succeeded{false};
+    std::atomic_bool cross_b_succeeded{false};
+    std::jthread     cross_a_setter([&] {
+        cross_a_succeeded.store(
+            CVar::SetValueFromString("Test.Callback.CrossResetA", "1").Succeeded(), std::memory_order_release
+        );
+    });
+    std::jthread     cross_b_setter([&] {
+        cross_b_succeeded.store(
+            CVar::SetValueFromString("Test.Callback.CrossResetB", "1").Succeeded(), std::memory_order_release
+        );
+    });
+    cross_a_setter.join();
+    cross_b_setter.join();
+    Expect(
+        cross_a.status == CVar::ERegistrationStatus::Registered &&
+            cross_b.status == CVar::ERegistrationStatus::Registered &&
+            cross_a_succeeded.load(std::memory_order_acquire) &&
+            cross_b_succeeded.load(std::memory_order_acquire) && !CVar::Find("Test.Callback.CrossResetA") &&
+            !CVar::Find("Test.Callback.CrossResetB"),
+        "cross-resetting callbacks deadlocked or left a registration active"
+    );
+
+    std::atomic_bool         blocking_entered{false};
+    std::atomic_bool         release_blocking{false};
+    std::atomic_bool         setter_succeeded{false};
+    std::atomic_bool         reset_returned{false};
+    CVar::RegistrationResult blocking = CVar::RegisterInt(
+        CVar::CVarDescriptor{.name = "Test.Callback.Quiescence"},
+        0,
+        [&blocking_entered, &release_blocking](std::int64_t, std::int64_t) {
+            blocking_entered.store(true, std::memory_order_release);
+            while (!release_blocking.load(std::memory_order_acquire)) {
+                std::this_thread::yield();
+            }
+        }
+    );
+    std::jthread setter([&] {
+        setter_succeeded.store(
+            CVar::SetValueFromString("Test.Callback.Quiescence", "1").Succeeded(), std::memory_order_release
+        );
+    });
+    while (!blocking_entered.load(std::memory_order_acquire)) {
+        std::this_thread::yield();
+    }
+    std::jthread resetter([&] {
+        blocking.registration.Reset();
+        reset_returned.store(true, std::memory_order_release);
+    });
+    while (CVar::Find("Test.Callback.Quiescence")) {
+        std::this_thread::yield();
+    }
+    Expect(
+        !reset_returned.load(std::memory_order_acquire),
+        "Reset returned before an in-flight callback quiesced"
+    );
+    release_blocking.store(true, std::memory_order_release);
+    setter.join();
+    resetter.join();
+    Expect(
+        setter_succeeded.load(std::memory_order_acquire) && reset_returned.load(std::memory_order_acquire),
+        "callback update or quiescent Reset did not finish"
+    );
+
+    std::atomic_bool          first_callback_entered{false};
+    std::atomic_bool          release_first_callback{false};
+    std::mutex                callback_order_mutex;
+    std::vector<std::int64_t> callback_order;
+    CVar::RegistrationResult  ordered = CVar::RegisterInt(
+        CVar::CVarDescriptor{.name = "Test.Callback.Ordered"},
+        0,
+        [&first_callback_entered, &release_first_callback, &callback_order_mutex, &callback_order](
+            std::int64_t, std::int64_t _new_value
+        ) {
+            if (_new_value == 1) {
+                first_callback_entered.store(true, std::memory_order_release);
+                while (!release_first_callback.load(std::memory_order_acquire)) {
+                    std::this_thread::yield();
+                }
+            }
+            std::lock_guard lock(callback_order_mutex);
+            callback_order.push_back(_new_value);
+        }
+    );
+    std::jthread first_setter([&] {
+        CVar::SetValueFromString("Test.Callback.Ordered", "1");
+    });
+    while (!first_callback_entered.load(std::memory_order_acquire)) {
+        std::this_thread::yield();
+    }
+    std::jthread second_setter([&] {
+        CVar::SetValueFromString("Test.Callback.Ordered", "2");
+    });
+    release_first_callback.store(true, std::memory_order_release);
+    first_setter.join();
+    second_setter.join();
+    Expect(
+        ordered.Succeeded() && callback_order == std::vector<std::int64_t>{1, 2} &&
+            CVar::Find("Test.Callback.Ordered")->value == "2",
+        "concurrent updates reordered callbacks relative to commits"
+    );
+
+    std::atomic_bool          joined_update_deferred{false};
+    std::mutex                joined_order_mutex;
+    std::vector<std::int64_t> joined_order;
+    CVar::RegistrationResult  joined = CVar::RegisterInt(
+        CVar::CVarDescriptor{.name = "Test.Callback.JoinedSetter"},
+        0,
+        [&joined_update_deferred, &joined_order_mutex, &joined_order](std::int64_t, std::int64_t _new_value) {
+            {
+                std::lock_guard lock(joined_order_mutex);
+                joined_order.push_back(_new_value);
+            }
+            if (_new_value != 1) {
+                return;
+            }
+            std::jthread concurrent_setter([&joined_update_deferred] {
+                const CVar::CVarSetResult result =
+                    CVar::SetValueFromString("Test.Callback.JoinedSetter", "2");
+                joined_update_deferred.store(
+                    result.Succeeded() && result.callback_deferred, std::memory_order_release
+                );
+            });
+            concurrent_setter.join();
+        }
+    );
+    const CVar::CVarSetResult joined_result = CVar::SetValueFromString("Test.Callback.JoinedSetter", "1");
+    Expect(
+        joined.Succeeded() && joined_result.Succeeded() && !joined_result.callback_deferred &&
+            joined_update_deferred.load(std::memory_order_acquire) &&
+            joined_order == std::vector<std::int64_t>{1, 2} &&
+            CVar::Find("Test.Callback.JoinedSetter")->value == "2",
+        "callback could not join a concurrent setter without deadlock or FIFO loss"
+    );
+
+    std::atomic_uint32_t     queued_callback_count{0};
+    std::atomic_bool         queued_first_entered{false};
+    std::atomic_bool         allow_self_reset{false};
+    std::atomic_bool         queued_second_deferred{false};
+    CVar::Registration*      queued_registration = nullptr;
+    CVar::RegistrationResult queued              = CVar::RegisterInt(
+        CVar::CVarDescriptor{.name = "Test.Callback.QueuedAfterReset"},
+        0,
+        [&queued_callback_count, &queued_first_entered, &allow_self_reset, &queued_registration](
+            std::int64_t, std::int64_t _new_value
+        ) {
+            queued_callback_count.fetch_add(1, std::memory_order_relaxed);
+            if (_new_value != 1) {
+                return;
+            }
+            queued_first_entered.store(true, std::memory_order_release);
+            while (!allow_self_reset.load(std::memory_order_acquire)) {
+                std::this_thread::yield();
+            }
+            queued_registration->Reset();
+        }
+    );
+    queued_registration = &queued.registration;
+    std::jthread queued_first([&] {
+        CVar::SetValueFromString("Test.Callback.QueuedAfterReset", "1");
+    });
+    while (!queued_first_entered.load(std::memory_order_acquire)) {
+        std::this_thread::yield();
+    }
+    std::jthread queued_second([&] {
+        const CVar::CVarSetResult result = CVar::SetValueFromString("Test.Callback.QueuedAfterReset", "2");
+        queued_second_deferred.store(
+            result.Succeeded() && result.callback_deferred, std::memory_order_release
+        );
+    });
+    while (!queued_second_deferred.load(std::memory_order_acquire)) {
+        std::this_thread::yield();
+    }
+    allow_self_reset.store(true, std::memory_order_release);
+    queued_first.join();
+    queued_second.join();
+    Expect(
+        queued_second_deferred.load(std::memory_order_acquire) &&
+            queued_callback_count.load(std::memory_order_acquire) == 1 &&
+            !CVar::Find("Test.Callback.QueuedAfterReset"),
+        "self-Reset allowed a queued mutation to invoke a late callback"
+    );
+
+    CVar::RegistrationResult visitor_blocker =
+        CVar::RegisterBool(CVar::CVarDescriptor{.name = "Test.Visitor.Pin.Blocker"}, false);
+    std::atomic_uint32_t            pinned_callback_destroyed{0};
+    std::shared_ptr<CountOnDestroy> pinned_lifetime = std::make_shared<CountOnDestroy>();
+    pinned_lifetime->count                          = &pinned_callback_destroyed;
+    auto pinned_callback                            = [pinned_lifetime](std::int64_t, std::int64_t) {};
+    pinned_lifetime.reset();
+    CVar::RegistrationResult visitor_target = CVar::RegisterInt(
+        CVar::CVarDescriptor{.name = "Test.Visitor.Pin.Target"}, 0, std::move(pinned_callback)
+    );
+    struct VisitorPinContext {
+        std::atomic_bool entered{false};
+        std::atomic_bool release{false};
+    } visitor_context;
+    std::jthread visitor([&] {
+        CVar::Detail::VisitAllSnapshotsRaw(
+            "Test.Visitor.Pin.",
+            [](const CVar::CVarSnapshotView& _snapshot, void* _context) {
+                auto& context = *static_cast<VisitorPinContext*>(_context);
+                if (_snapshot.name != "Test.Visitor.Pin.Blocker") {
+                    return;
+                }
+                context.entered.store(true, std::memory_order_release);
+                while (!context.release.load(std::memory_order_acquire)) {
+                    std::this_thread::yield();
+                }
+            },
+            &visitor_context
+        );
+    });
+    while (!visitor_context.entered.load(std::memory_order_acquire)) {
+        std::this_thread::yield();
+    }
+    visitor_target.registration.Reset();
+    Expect(
+        pinned_callback_destroyed.load(std::memory_order_acquire) == 1,
+        "Reset deferred caller callback destruction behind a snapshot pin"
+    );
+    visitor_context.release.store(true, std::memory_order_release);
+    visitor.join();
+}
+
+void TestListingAndCandidates() {
+    CVar::RegistrationResult z = CVar::RegisterBool(
+        CVar::CVarDescriptor{
+            .name   = "Test.List.zulu",
+            .helper = "z helper",
+        },
+        false
+    );
+    CVar::RegistrationResult a = CVar::RegisterInt(
+        CVar::CVarDescriptor{
+            .name   = "Test.List.Alpha",
+            .helper = "a helper",
+        },
+        1
+    );
+    CVar::RegistrationResult b = CVar::RegisterString(
+        CVar::CVarDescriptor{
+            .name   = "Test.List.bravo",
+            .helper = "b helper",
+        },
+        "value"
+    );
+    Expect(z.Succeeded() && a.Succeeded() && b.Succeeded(), "list fixtures did not register");
+
+    const std::vector<CVar::CVarSnapshot> listed = CVar::List("TEST.LIST.");
+    Expect(listed.size() == 3, "case-insensitive prefix list missed cvars");
+    Expect(
+        listed[0].name == "Test.List.Alpha" && listed[1].name == "Test.List.bravo" &&
+            listed[2].name == "Test.List.zulu",
+        "cvar list was not deterministically case-insensitive sorted"
+    );
+
+    Command::EngineCommandProcessor              processor;
+    const std::vector<Command::CommandCandidate> cvar_candidates = processor.GetCandidates("test.list.");
+    Expect(
+        cvar_candidates.size() == 3 && cvar_candidates.front().text == "Test.List.Alpha" &&
+            !cvar_candidates.front().is_command,
+        "cvar autocomplete was incomplete or unsorted"
+    );
+    const std::vector<Command::CommandCandidate> command_candidates = processor.GetCandidates("/CV");
+    Expect(
+        command_candidates.size() == 1 && command_candidates.front().text == "/cvar.list" &&
+            command_candidates.front().is_command,
+        "command autocomplete was not case-insensitive"
+    );
+    Expect(processor.GetCandidates("test.list.", 2).size() == 2, "autocomplete ignored its result bound");
+}
+
+void TestCommandProcessing() {
+    CVar::RegistrationResult toggle = CVar::RegisterBool(
+        CVar::CVarDescriptor{
+            .name         = "Cmd.Toggle",
+            .helper       = "toggle helper",
+            .true_helper  = "toggle on",
+            .false_helper = "toggle off",
+        },
+        false
+    );
+    CVar::RegistrationResult count = CVar::RegisterInt(
+        CVar::CVarDescriptor{
+            .name      = "Cmd.Count",
+            .helper    = "count helper",
+            .min_value = 0.0,
+            .max_value = 5.0,
+        },
+        1
+    );
+    CVar::RegistrationResult text = CVar::RegisterString(CVar::CVarDescriptor{.name = "Cmd.Text"}, "initial");
+    Command::EngineCommandProcessor*     reentrant_processor = nullptr;
+    std::atomic<Command::EProcessStatus> reentrant_process_status{Command::EProcessStatus::Empty};
+    CVar::RegistrationResult             reentrant = CVar::RegisterInt(
+        CVar::CVarDescriptor{.name = "Cmd.Reentrant"},
+        0,
+        [&reentrant_processor, &reentrant_process_status](std::int64_t, std::int64_t) {
+            Expect(
+                reentrant_processor->SubmitText("/help") == Command::ESubmitStatus::Accepted,
+                "callback could not submit a follow-up command"
+            );
+            reentrant_process_status.store(
+                reentrant_processor->ProcessPending().status, std::memory_order_release
+            );
+        }
+    );
+    Expect(
+        toggle.Succeeded() && count.Succeeded() && text.Succeeded() && reentrant.Succeeded(),
+        "command fixtures did not register"
+    );
+
+    Command::EngineCommandProcessor processor({.pending_capacity = 32, .output_capacity = 128});
+    reentrant_processor = &processor;
+    Expect(processor.SubmitText("   ") == Command::ESubmitStatus::Empty, "empty command was queued");
+    const std::vector<std::string_view> commands = {
+        "Cmd.Toggle on",
+        "Cmd.Toggle",
+        "Cmd.Toggle ?",
+        "Cmd.Count = 5",
+        "Cmd.Count 6",
+        "Cmd.Count nope",
+        "Cmd.Text hello world",
+        "Cmd.Text =",
+        "Cmd.Text question?",
+        "Cmd.Reentrant 1",
+        "/help",
+        "/cvar.list cmd.",
+        "/cvar.list absent.",
+        "/unknown",
+        "missing.cvar",
+    };
+    for (const std::string_view command : commands) {
+        Expect(
+            processor.SubmitText(command) == Command::ESubmitStatus::Accepted, "valid command was not queued"
+        );
+    }
+    const Command::ProcessPendingResult first_drain  = processor.ProcessPending(5);
+    const Command::ProcessPendingResult second_drain = processor.ProcessPending();
+    Expect(
+        first_drain.status == Command::EProcessStatus::Processed && first_drain.processed == 5 &&
+            second_drain.status == Command::EProcessStatus::Processed &&
+            second_drain.processed == commands.size() - 5,
+        "bounded command processing returned the wrong result"
+    );
+    Expect(
+        CVar::Find("Cmd.Toggle")->value == "true" && CVar::Find("Cmd.Count")->value == "5" &&
+            CVar::Find("Cmd.Text")->value == "question?",
+        "command execution produced the wrong cvar values"
+    );
+    Expect(
+        reentrant_process_status.load(std::memory_order_acquire) == Command::EProcessStatus::Busy,
+        "callback re-entry into ProcessPending deadlocked or consumed work"
+    );
+    Expect(
+        processor.ProcessPending().processed == 1,
+        "callback-submitted command was not retained for the next drain"
+    );
+    Expect(
+        processor.ProcessPending(0).status == Command::EProcessStatus::MaxCommandsZero,
+        "zero process budget was not distinguishable"
+    );
+
+    const Command::CommandOutputBatch output = processor.PollOutput();
+    Expect(
+        OutputContains(output, "Cmd.Toggle = true") && OutputContains(output, "toggle helper") &&
+            OutputContains(output, "Commands:") &&
+            OutputContains(output, "No cvar matches prefix: absent.") &&
+            OutputContains(output, "unknown command") && OutputContains(output, "unknown cvar") &&
+            OutputContains(output, "above the allowed maximum") && OutputContains(output, "expected integer"),
+        "command output missed query/help/list/error diagnostics"
+    );
+    Expect(
+        processor.PollOutput(output.next_sequence).lines.empty(),
+        "output cursor replayed already-consumed lines"
+    );
+}
+
+void TestBoundedQueuesAndOutputCursor() {
+    Command::EngineCommandProcessor processor({.pending_capacity = 32, .output_capacity = 3});
+    std::atomic_uint32_t            accepted{0};
+    std::atomic_uint32_t            full{0};
+    std::vector<std::jthread>       producers;
+    for (std::uint32_t thread_index = 0; thread_index < 8; ++thread_index) {
+        producers.emplace_back([&processor, &accepted, &full] {
+            for (std::uint32_t index = 0; index < 64; ++index) {
+                const Command::ESubmitStatus status = processor.SubmitText("/unknown");
+                if (status == Command::ESubmitStatus::Accepted) {
+                    accepted.fetch_add(1, std::memory_order_relaxed);
+                } else if (status == Command::ESubmitStatus::QueueFull) {
+                    full.fetch_add(1, std::memory_order_relaxed);
+                }
+            }
+        });
+    }
+    producers.clear();
+    Expect(
+        accepted.load(std::memory_order_relaxed) == 32 && full.load(std::memory_order_relaxed) == 480,
+        "concurrent producers exceeded or underfilled the pending bound"
+    );
+    Expect(processor.ProcessPending().processed == 32, "bounded pending queue lost accepted commands");
+
+    const Command::CommandOutputBatch retained = processor.PollOutput(1);
+    Expect(
+        retained.dropped_count == 29 && retained.lines.size() == 3 && retained.lines.front().sequence == 30 &&
+            retained.next_sequence == 33,
+        "output ring did not report overwritten cursor entries"
+    );
+    const Command::CommandOutputBatch limited = processor.PollOutput(30, 2);
+    Expect(
+        limited.lines.size() == 2 && limited.next_sequence == 32, "output polling ignored its result bound"
+    );
+
+    processor.ClearOutput();
+    Expect(
+        processor.SubmitText("/still-unknown") == Command::ESubmitStatus::Accepted &&
+            processor.ProcessPending().processed == 1,
+        "processor did not recover after clearing output"
+    );
+    const Command::CommandOutputBatch after_clear = processor.PollOutput(retained.next_sequence);
+    Expect(
+        after_clear.lines.size() == 1 && after_clear.lines.front().sequence == 33 &&
+            after_clear.dropped_count == 0,
+        "clear output reset sequence identity or lost new output"
+    );
+
+    Command::EngineCommandProcessor zero_limits({.pending_capacity = 0, .output_capacity = 0});
+    Expect(
+        zero_limits.SubmitText("/unknown") == Command::ESubmitStatus::Accepted &&
+            zero_limits.SubmitText("/unknown") == Command::ESubmitStatus::QueueFull &&
+            zero_limits.ProcessPending().processed == 1 && zero_limits.PollOutput().lines.size() == 1,
+        "documented zero-capacity normalization changed"
+    );
+}
+
+void TestStartupSealLast() {
+    CVar::RegistrationResult startup = CVar::RegisterInt(
+        CVar::CVarDescriptor{
+            .name  = "Test.Startup.BeforeSeal",
+            .flags = CVar::EFlags::StartupOnly,
+        },
+        1
+    );
+    Expect(startup.Succeeded(), "startup-only cvar did not register");
+    Expect(
+        CVar::SetValueFromString("Test.Startup.BeforeSeal", "2", CVar::ESetSource::Runtime).status ==
+            CVar::ESetStatus::StartupSealed,
+        "runtime source changed a startup-only cvar"
+    );
+    Expect(
+        CVar::SetValueFromString("Test.Startup.BeforeSeal", "2", CVar::ESetSource::StartupConfig).Succeeded(),
+        "startup config could not set an unsealed startup-only cvar"
+    );
+
+    CVar::SealStartupOnlyCVars();
+    Expect(
+        CVar::IsStartupConfigurationSealed() && CVar::Find("Test.Startup.BeforeSeal")->startup_sealed,
+        "global startup seal did not seal an existing cvar"
+    );
+    Expect(
+        CVar::SetValueFromString("Test.Startup.BeforeSeal", "3", CVar::ESetSource::StartupConfig).status ==
+            CVar::ESetStatus::StartupSealed,
+        "sealed startup-only cvar accepted a config update"
+    );
+
+    CVar::RegistrationResult late = CVar::RegisterBool(
+        CVar::CVarDescriptor{
+            .name  = "Test.Startup.Late",
+            .flags = CVar::EFlags::StartupOnly,
+        },
+        false
+    );
+    Expect(
+        late.Succeeded() && CVar::Find("Test.Startup.Late")->startup_sealed &&
+            CVar::SetValueFromString("Test.Startup.Late", "true", CVar::ESetSource::StartupConfig).status ==
+                CVar::ESetStatus::StartupSealed,
+        "late startup-only registration escaped the global seal"
+    );
+
+    CVar::RegistrationResult dynamic =
+        CVar::RegisterBool(CVar::CVarDescriptor{.name = "Test.Startup.Dynamic"}, false);
+    Expect(
+        dynamic.Succeeded() && !CVar::Find("Test.Startup.Dynamic")->startup_sealed &&
+            CVar::SetValueFromString("Test.Startup.Dynamic", "true").Succeeded(),
+        "global startup seal affected a dynamic cvar"
+    );
+}
+
+} // namespace
+
+int main() {
+    try {
+        TestRegistrationLifetimeAndDescriptors();
+        TestTypedParsingAndRanges();
+        TestFlagsOwnerSyncAndCallbacks();
+        TestListingAndCandidates();
+        TestCommandProcessing();
+        TestBoundedQueuesAndOutputCursor();
+        TestStartupSealLast();
+        std::cout << "CVar/command core contract tests passed.\n";
+        return EXIT_SUCCESS;
+    } catch (const std::exception& error) {
+        std::cerr << "CVar/command core contract test failed: " << error.what() << '\n';
+        return EXIT_FAILURE;
+    }
+}

--- a/source/test/CVarCommandCoreTest.cpp
+++ b/source/test/CVarCommandCoreTest.cpp
@@ -135,6 +135,28 @@ void TestRegistrationLifetimeAndDescriptors() {
                 .status == CVar::ERegistrationStatus::InvalidDescriptor,
         "non-finite numeric range was accepted"
     );
+    Expect(
+        CVar::RegisterBool(
+            CVar::CVarDescriptor{
+                .name                     = "Test.Invalid.ZeroCallbackBudget",
+                .callback_dispatch_budget = 0,
+            },
+            false
+        )
+                .status == CVar::ERegistrationStatus::InvalidDescriptor,
+        "zero callback dispatch budget was accepted"
+    );
+    Expect(
+        CVar::RegisterBool(
+            CVar::CVarDescriptor{
+                .name                     = "Test.Invalid.ExcessiveCallbackBudget",
+                .callback_dispatch_budget = CVar::MaxCallbackDispatchBudget + 1,
+            },
+            false
+        )
+                .status == CVar::ERegistrationStatus::InvalidDescriptor,
+        "excessive callback dispatch budget was accepted"
+    );
 
     int incomplete_context = 0;
     Expect(
@@ -512,6 +534,52 @@ void TestFlagsOwnerSyncAndCallbacks() {
         "callback could not join a concurrent setter without deadlock or FIFO loss"
     );
 
+    std::atomic_uint32_t     bounded_callback_count{0};
+    std::atomic_uint32_t     bounded_deferred_count{0};
+    std::atomic_uint32_t     bounded_rejected_count{0};
+    CVar::RegistrationResult bounded_callbacks = CVar::RegisterInt(
+        CVar::CVarDescriptor{
+            .name                     = "Test.Callback.BoundedDispatch",
+            .callback_dispatch_budget = 3,
+        },
+        0,
+        [&bounded_callback_count,
+         &bounded_deferred_count,
+         &bounded_rejected_count](std::int64_t, std::int64_t _new_value) {
+            bounded_callback_count.fetch_add(1, std::memory_order_relaxed);
+            if (_new_value >= 4) {
+                return;
+            }
+            const CVar::CVarSetResult result =
+                CVar::SetValueFromString("Test.Callback.BoundedDispatch", std::to_string(_new_value + 1));
+            if (result.callback_deferred) {
+                bounded_deferred_count.fetch_add(1, std::memory_order_relaxed);
+            }
+            if (result.status == CVar::ESetStatus::CallbackQueueFull) {
+                bounded_rejected_count.fetch_add(1, std::memory_order_relaxed);
+            }
+        }
+    );
+    const CVar::CVarSetResult bounded_result = CVar::SetValueFromString("Test.Callback.BoundedDispatch", "1");
+    const std::optional<CVar::CVarSnapshot> bounded_snapshot = CVar::Find("Test.Callback.BoundedDispatch");
+    Expect(
+        bounded_callbacks.Succeeded() && bounded_result.Succeeded() &&
+            bounded_callback_count.load(std::memory_order_acquire) == 3 &&
+            bounded_deferred_count.load(std::memory_order_acquire) == 2 &&
+            bounded_rejected_count.load(std::memory_order_acquire) == 1 && bounded_snapshot &&
+            bounded_snapshot->value == "3" && bounded_snapshot->callback_dispatch_budget == 3,
+        "callback dispatch budget did not bound queue growth and drainer lifetime"
+    );
+    const CVar::CVarSetResult bounded_next_epoch =
+        CVar::SetValueFromString("Test.Callback.BoundedDispatch", "10");
+    Expect(
+        bounded_next_epoch.Succeeded() && !bounded_next_epoch.callback_deferred &&
+            bounded_callback_count.load(std::memory_order_acquire) == 4 &&
+            bounded_rejected_count.load(std::memory_order_acquire) == 1 &&
+            CVar::Find("Test.Callback.BoundedDispatch")->value == "10",
+        "callback dispatch budget did not reset for the next idle-to-dispatch epoch"
+    );
+
     std::atomic_uint32_t     queued_callback_count{0};
     std::atomic_bool         queued_first_entered{false};
     std::atomic_bool         allow_self_reset{false};
@@ -792,6 +860,12 @@ void TestBoundedQueuesAndOutputCursor() {
     );
 
     processor.ClearOutput();
+    const Command::CommandOutputBatch cleared = processor.PollOutput(1);
+    Expect(
+        cleared.lines.empty() && cleared.dropped_count == 32 &&
+            cleared.next_sequence == retained.next_sequence,
+        "clearing output did not advance an older cursor across the removed sequence range"
+    );
     Expect(
         processor.SubmitText("/still-unknown") == Command::ESubmitStatus::Accepted &&
             processor.ProcessPending().processed == 1,

--- a/source/test/CVarCommandCoreTest.cpp
+++ b/source/test/CVarCommandCoreTest.cpp
@@ -193,10 +193,13 @@ void TestTypedParsingAndRanges() {
         },
         1.0
     );
+    CVar::RegistrationResult owner_float =
+        CVar::RegisterFloat(CVar::CVarDescriptor{.name = "Test.Types.OwnerFloat"}, 3.5);
     CVar::RegistrationResult string_cvar =
         CVar::RegisterString(CVar::CVarDescriptor{.name = "Test.Types.String"}, "initial");
     Expect(
-        bool_cvar.Succeeded() && int_cvar.Succeeded() && float_cvar.Succeeded() && string_cvar.Succeeded(),
+        bool_cvar.Succeeded() && int_cvar.Succeeded() && float_cvar.Succeeded() &&
+            owner_float.Succeeded() && string_cvar.Succeeded(),
         "typed cvar registration failed"
     );
 
@@ -244,6 +247,29 @@ void TestTypedParsingAndRanges() {
     Expect(
         CVar::SetValueFromString("Test.Types.Float", "-0.1").status == CVar::ESetStatus::OutOfRange,
         "float range accepted a value below minimum"
+    );
+    Expect(
+        owner_float.registration.SynchronizeOwnerValue(4.5).Succeeded(),
+        "owner synchronization rejected a finite float"
+    );
+    Expect(
+        owner_float.registration.SynchronizeOwnerValue(std::numeric_limits<double>::quiet_NaN()).status ==
+            CVar::ESetStatus::TypeMismatch,
+        "owner synchronization accepted NaN"
+    );
+    Expect(
+        owner_float.registration.SynchronizeOwnerValue(std::numeric_limits<double>::infinity()).status ==
+            CVar::ESetStatus::TypeMismatch,
+        "owner synchronization accepted positive infinity"
+    );
+    Expect(
+        owner_float.registration.SynchronizeOwnerValue(-std::numeric_limits<double>::infinity()).status ==
+            CVar::ESetStatus::TypeMismatch,
+        "owner synchronization accepted negative infinity"
+    );
+    Expect(
+        CVar::Find("Test.Types.OwnerFloat")->value == "4.5",
+        "rejected non-finite owner synchronization changed the float value"
     );
     Expect(
         CVar::SetValueFromString("Test.Types.String", "hello world").Succeeded(),

--- a/source/test/CVarCommandCoreTest.cpp
+++ b/source/test/CVarCommandCoreTest.cpp
@@ -60,6 +60,33 @@ struct CountOnDestroy {
     }
 };
 
+struct SelfOwnedRegistrationCallback {
+    CVar::CVarDescriptor descriptor;
+    std::string          default_value;
+
+    explicit SelfOwnedRegistrationCallback(std::string _name, std::string _default_value = {}) :
+        descriptor{
+            .name   = std::move(_name),
+            .helper = "self-owned helper",
+        },
+        default_value(std::move(_default_value)) {}
+
+    SelfOwnedRegistrationCallback(const SelfOwnedRegistrationCallback&) = delete;
+    SelfOwnedRegistrationCallback& operator=(const SelfOwnedRegistrationCallback&) = delete;
+
+    SelfOwnedRegistrationCallback(SelfOwnedRegistrationCallback&& _other) :
+        descriptor(std::move(_other.descriptor)),
+        default_value(_other.default_value) {
+        _other.descriptor.name.clear();
+        _other.descriptor.helper.clear();
+        std::ranges::fill(_other.default_value, '#');
+    }
+    SelfOwnedRegistrationCallback& operator=(SelfOwnedRegistrationCallback&&) = delete;
+
+    template<typename OldValue, typename NewValue>
+    void operator()(OldValue&&, NewValue&&) const {}
+};
+
 void TestRegistrationLifetimeAndDescriptors() {
     CVar::CVarDescriptor descriptor{
         .name         = "Test.Lifetime.Toggle",
@@ -100,6 +127,46 @@ void TestRegistrationLifetimeAndDescriptors() {
     Expect(
         destructor_reentered.load(std::memory_order_acquire),
         "callback capture was destroyed under the registry lock"
+    );
+
+    SelfOwnedRegistrationCallback bool_callback("Test.Lifetime.SelfOwnedBool");
+    SelfOwnedRegistrationCallback int_callback("Test.Lifetime.SelfOwnedInt");
+    SelfOwnedRegistrationCallback float_callback("Test.Lifetime.SelfOwnedFloat");
+    SelfOwnedRegistrationCallback string_callback("Test.Lifetime.SelfOwnedString", "owned default");
+    SelfOwnedRegistrationCallback string_default_callback("unused", "default-only value");
+    CVar::CVarDescriptor          external_string_descriptor{
+        .name   = "Test.Lifetime.SelfOwnedStringDefault",
+        .helper = "external helper",
+    };
+    CVar::RegistrationResult self_owned_bool =
+        CVar::RegisterBool(bool_callback.descriptor, false, std::move(bool_callback));
+    CVar::RegistrationResult self_owned_int =
+        CVar::RegisterInt(int_callback.descriptor, 3, std::move(int_callback));
+    CVar::RegistrationResult self_owned_float =
+        CVar::RegisterFloat(float_callback.descriptor, 1.5, std::move(float_callback));
+    CVar::RegistrationResult self_owned_string = CVar::RegisterString(
+        string_callback.descriptor, string_callback.default_value, std::move(string_callback)
+    );
+    CVar::RegistrationResult self_owned_string_default = CVar::RegisterString(
+        external_string_descriptor,
+        string_default_callback.default_value,
+        std::move(string_default_callback)
+    );
+    const std::optional<CVar::CVarSnapshot> self_owned_bool_snapshot =
+        CVar::Find("Test.Lifetime.SelfOwnedBool");
+    const std::optional<CVar::CVarSnapshot> self_owned_string_snapshot =
+        CVar::Find("Test.Lifetime.SelfOwnedString");
+    const std::optional<CVar::CVarSnapshot> self_owned_string_default_snapshot =
+        CVar::Find("Test.Lifetime.SelfOwnedStringDefault");
+    Expect(
+        self_owned_bool.Succeeded() && self_owned_int.Succeeded() &&
+            self_owned_float.Succeeded() && self_owned_string.Succeeded() &&
+            self_owned_string_default.Succeeded() && self_owned_bool_snapshot &&
+            self_owned_bool_snapshot->helper == "self-owned helper" &&
+            self_owned_string_snapshot && self_owned_string_snapshot->value == "owned default" &&
+            self_owned_string_default_snapshot &&
+            self_owned_string_default_snapshot->value == "default-only value",
+        "callback move invalidated borrowed registration inputs"
     );
 
     Expect(


### PR DESCRIPTION
## What changed

- add a typed, case-insensitive CVar registry for bool, int64, finite float and string values
- add descriptor validation, read-only/startup-only policy, owner synchronization, snapshots, listing and autocomplete
- add per-CVar FIFO callback dispatch with a fixed per-epoch admission budget, structured deferred/failed/canceled outcomes, re-entry and quiescent retirement
- keep cross-DLL ownership safe through raw view/visitor/thunk APIs and caller-side owning wrappers
- make snapshot visitors Reset-safe: capture under an active operation, invoke caller code after release, and retain immutable old-generation views through Reset/same-name replacement
- add a bounded multi-producer engine command processor with query/set/help/list commands, bounded output history and cursored polling across output clears
- add a focused `CVarCommandCoreContract` covering parsing, ranges, flags, callback ordering/reset races, dispatch saturation, visitor cross-reset/ABA lifetime, ABI ownership, bounded queues and command behavior

## Why

This is Phase 24A of the remaining `dev_parallel_rhi` capability migration. It ports the useful CVar/command-control-plane semantics onto the current main architecture without restoring the legacy standalone config authority, old logging mirror, or obsolete RHI toggle names. The Editor console UI and runtime wiring remain a separate Phase 24B.

## Concurrency / ownership contract

- commits and callbacks are FIFO per CVar; unrelated CVars do not share a global mutation lock
- each idle-to-dispatch epoch admits a fixed bounded number of callback-producing commits; saturation rejects without changing the value
- user callbacks and caller-side callback destruction run without registry or entry locks
- a mutation queued behind an active callback commits immediately and reports `callback_deferred`; Reset may cancel the queued callback
- external Reset quiesces active setters/callbacks; callback/capture-destruction chains are non-blocking to avoid cross-entry cycles
- snapshot visitor code is not an active Entry operation; Reset can return while an immutable old id/value view remains valid, and id identifies the generation
- process-lifetime registry storage outlives static handles and caller destroy-thunk re-entry during teardown
- exported raw APIs do not transfer STL-owned allocations across module heaps

## Validation

- Debug full build: passed
- Release full build: passed
- Debug CTest: 41/41 passed
- Release CTest: 41/41 passed
- focused contract stress: Debug 50 consecutive passes; Release 50 consecutive passes
- local P0-P2 review loop: closed with no remaining findings
- runtime GUI smoke intentionally not required in Phase 24A because no production runtime/editor wiring is added

Reviewed local head: `19dd6d3acc50518eac1989b614c0169ac01b42e5`