### PR TITLE
Core: add bounded console log sequence channel

### DIFF
--- a/source/runtime/core/include/log/LogSystem.h
+++ b/source/runtime/core/include/log/LogSystem.h
@@ -30,9 +30,12 @@ struct ConsoleLogPollResult {
 };
 
 // Views are borrowed only for the visitor invocation. Init installs a
-// process-lifetime forwarding default logger: the previous logger and its sink
-// storage remain untouched in their owning module, while admitted messages are
-// also copied into this channel. This avoids reallocating an owning STL
+// process-lifetime forwarding default logger: the previous logger's sink
+// storage remains untouched in its owning module, and the previous logger is
+// parked at level::off. Init transfers default-logger authority: callers must
+// discard previously acquired default_logger() references, must not re-enable
+// them, and must reacquire the installed default after Init. Admitted messages
+// are also copied into this channel. This avoids reallocating an owning STL
 // container across separate mimalloc heaps. Call Init again at a
 // logger-quiescent point after replacing the default logger; spdlog does not
 // synchronize default-logger replacement with concurrent producers. Configure

--- a/source/runtime/core/include/log/LogSystem.h
+++ b/source/runtime/core/include/log/LogSystem.h
@@ -3,6 +3,10 @@
 
 #include "API_Macro.h"
 
+#include <cstddef>
+#include <cstdint>
+#include <string_view>
+
 #if defined(NDEBUG)
 #define SPDLOG_ACTIVE_LEVEL SPDLOG_LEVEL_INFO
 #else
@@ -12,7 +16,46 @@
 #include "spdlog/spdlog.h"
 
 namespace Moer { namespace LogSystem {
+
+struct ConsoleLogEntryView {
+    std::uint64_t             sequence = 0;
+    spdlog::level::level_enum level    = spdlog::level::info;
+    std::string_view          message;
+};
+
+struct ConsoleLogPollResult {
+    std::uint64_t next_sequence = 1;
+    std::uint64_t dropped_count = 0;
+    std::size_t   visited_count = 0;
+};
+
+// Views are borrowed only for the visitor invocation. Init installs a
+// process-lifetime forwarding default logger: the previous logger and its sink
+// storage remain untouched in their owning module, while admitted messages are
+// also copied into this channel. This avoids reallocating an owning STL
+// container across separate mimalloc heaps. Call Init again at a
+// logger-quiescent point after replacing the default logger; spdlog does not
+// synchronize default-logger replacement with concurrent producers. Configure
+// non-virtual formatter and error-handler state before Init; runtime level and
+// flush-level changes remain synchronized to the forwarded logger. Backtrace
+// state is not introspectable through spdlog's public API, so enable backtrace
+// after Init; dumped entries are forwarded without a second logger-level filter.
+using ConsoleLogVisitor = void (*)(const ConsoleLogEntryView& _entry, void* _context);
+
 CORE_API void Init();
+
+// Sequence zero is normalized to one. Entries removed by bounded overwrite or
+// ClearConsoleLogs are reported through dropped_count. The visitor runs after
+// releasing channel locks and may re-enter logging, polling, or clearing.
+[[nodiscard]] CORE_API ConsoleLogPollResult VisitConsoleLogs(
+    std::uint64_t     _next_sequence,
+    std::size_t       _max_count,
+    ConsoleLogVisitor _visitor,
+    void*             _context
+);
+
+// Clear preserves sequence identity so existing cursors can observe the loss.
+CORE_API void ClearConsoleLogs();
 }} // namespace Moer::LogSystem
 
 // Active when in debug mode

--- a/source/runtime/core/source/log/LogSystem.cpp
+++ b/source/runtime/core/source/log/LogSystem.cpp
@@ -138,8 +138,14 @@ public:
         source_logger(std::move(_source_logger)),
         dispatch_logger(std::move(_dispatch_logger)),
         console_sink(std::move(_console_sink)) {
-        set_level(source_logger->level());
-        flush_on(source_logger->flush_level());
+        const spdlog::level::level_enum source_level       = source_logger->level();
+        const spdlog::level::level_enum source_flush_level = source_logger->flush_level();
+        set_level(source_level);
+        flush_on(source_flush_level);
+        source_logger->set_level(spdlog::level::off);
+        source_logger->flush_on(spdlog::level::off);
+        dispatch_logger->set_level(spdlog::level::trace);
+        dispatch_logger->flush_on(source_flush_level);
     }
 
 protected:
@@ -150,10 +156,8 @@ protected:
         // filter while still using the source logger's virtual dispatch (for
         // example an async queue or a custom sink_it_ override).
         SynchronizeConfiguration();
-        const std::shared_ptr<spdlog::logger>& target =
-            _message.level >= level() ? source_logger : dispatch_logger;
         SPDLOG_TRY {
-            target->log(_message.time, _message.source, _message.level, _message.payload);
+            dispatch_logger->log(_message.time, _message.source, _message.level, _message.payload);
         }
         SPDLOG_LOGGER_CATCH(_message.source)
 
@@ -190,10 +194,6 @@ protected:
     void flush_() override {
         SynchronizeConfiguration();
         SPDLOG_TRY {
-            source_logger->flush();
-        }
-        SPDLOG_LOGGER_CATCH(spdlog::source_loc())
-        SPDLOG_TRY {
             dispatch_logger->flush();
         }
         SPDLOG_LOGGER_CATCH(spdlog::source_loc())
@@ -215,13 +215,18 @@ public:
         // intentionally default-logger scoped; make a clone default and call
         // LogSystem::Init again if it also needs capture.
         SynchronizeConfiguration();
-        return source_logger->clone(std::move(_logger_name));
+        std::shared_ptr<spdlog::logger> cloned = source_logger->clone(std::move(_logger_name));
+        if (cloned) {
+            cloned->set_level(level());
+            cloned->flush_on(flush_level());
+        }
+        return cloned;
     }
 
 private:
     void SynchronizeConfiguration() {
-        source_logger->set_level(level());
-        source_logger->flush_on(flush_level());
+        source_logger->set_level(spdlog::level::off);
+        source_logger->flush_on(spdlog::level::off);
         dispatch_logger->set_level(spdlog::level::trace);
         dispatch_logger->flush_on(flush_level());
     }
@@ -280,7 +285,8 @@ void Init() {
     const std::string_view downstream_name_view(downstream_name.data(), downstream_name.size());
     // The private clone only handles below-threshold backtrace replay and is
     // retained for process lifetime with its Core-owned, non-SSO name storage.
-    // Ordinary messages still use source_logger directly.
+    // All messages use the clone so explicit flush has exactly one downstream
+    // target and custom/async virtual dispatch remains intact.
     std::shared_ptr<spdlog::logger> dispatch_logger =
         logger->clone(MakeCoreOwnedLoggerName(downstream_name_view));
     if (!dispatch_logger) {

--- a/source/runtime/core/source/log/LogSystem.cpp
+++ b/source/runtime/core/source/log/LogSystem.cpp
@@ -126,6 +126,35 @@ private:
     std::uint64_t                      next_sequence = 1;
 };
 
+// spdlog exposes these operations to derived logger implementations. This
+// adapter is never instantiated; it only obtains public member pointers through
+// the derived access path, then invokes the base operations on the actual
+// logger. That preserves complete log_msg metadata and the configured error
+// handler without changing the vendored spdlog API or object layout.
+class LoggerDispatchAccess : public spdlog::logger {
+public:
+    using spdlog::logger::err_handler_;
+    using spdlog::logger::log_it_;
+
+    static void Log(spdlog::logger& _logger, const spdlog::details::log_msg& _message) {
+        const bool log_enabled       = _logger.should_log(_message.level);
+        const bool backtrace_enabled = _logger.should_backtrace();
+        if (!log_enabled && !backtrace_enabled) {
+            return;
+        }
+
+        using LogFunction = void (spdlog::logger::*)(const spdlog::details::log_msg&, bool, bool);
+        const LogFunction log_function = &LoggerDispatchAccess::log_it_;
+        (_logger.*log_function)(_message, log_enabled, backtrace_enabled);
+    }
+
+    static void ReportError(spdlog::logger& _logger, const std::string& _message) {
+        using ErrorFunction                = void (spdlog::logger::*)(const std::string&);
+        const ErrorFunction error_function = &LoggerDispatchAccess::err_handler_;
+        (_logger.*error_function)(_message);
+    }
+};
+
 class ConsoleForwardingLogger final : public spdlog::logger {
 public:
     ConsoleForwardingLogger(
@@ -146,6 +175,9 @@ public:
         source_logger->flush_on(spdlog::level::off);
         dispatch_logger->set_level(spdlog::level::trace);
         dispatch_logger->flush_on(source_flush_level);
+        set_error_handler([error_logger = dispatch_logger](const std::string& _message) {
+            LoggerDispatchAccess::ReportError(*error_logger, _message);
+        });
     }
 
 protected:
@@ -157,7 +189,7 @@ protected:
         // example an async queue or a custom sink_it_ override).
         SynchronizeConfiguration();
         SPDLOG_TRY {
-            dispatch_logger->log(_message.time, _message.source, _message.level, _message.payload);
+            LoggerDispatchAccess::Log(*dispatch_logger, _message);
         }
         SPDLOG_LOGGER_CATCH(_message.source)
 

--- a/source/runtime/core/source/log/LogSystem.cpp
+++ b/source/runtime/core/source/log/LogSystem.cpp
@@ -1,12 +1,316 @@
 #include "log/LogSystem.h"
 
+#include "spdlog/sinks/sink.h"
+
+#include <algorithm>
+#include <deque>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <vector>
+
 namespace Moer::LogSystem {
+
+namespace {
+
+namespace fmt_lib = spdlog::fmt_lib;
+
+constexpr std::size_t ConsoleLogCapacity        = 4096;
+constexpr std::size_t AbiSafeLoggerNameCapacity = 64;
+
+std::string MakeCoreOwnedLoggerName(std::string_view _name) {
+    std::string owned_name;
+    // An exported spdlog::logger can move this string across a Windows DLL
+    // boundary. Force owned storage even for an empty/short logger name so the
+    // move never carries MSVC's small-string representation across heaps.
+    owned_name.reserve((std::max)(AbiSafeLoggerNameCapacity, _name.size()));
+    if (!_name.empty()) {
+        owned_name.append(_name.data(), _name.size());
+    }
+    return owned_name;
+}
+
+struct ConsoleLogEntryStorage {
+    std::uint64_t             sequence = 0;
+    spdlog::level::level_enum level    = spdlog::level::info;
+    std::string               message;
+};
+
+class ConsoleLogSink final : public spdlog::sinks::sink {
+public:
+    void log(const spdlog::details::log_msg& _message) override {
+        std::string owned_message;
+        if (_message.payload.size() != 0) {
+            owned_message.assign(_message.payload.data(), _message.payload.size());
+        }
+
+        std::lock_guard lock(storage_mutex);
+        entries.push_back({
+            .sequence = next_sequence,
+            .level    = _message.level,
+            .message  = std::move(owned_message),
+        });
+        ++next_sequence;
+        if (entries.size() > ConsoleLogCapacity) {
+            entries.pop_front();
+        }
+    }
+
+    void flush() override {}
+
+    // The channel intentionally retains the formatted payload rather than a
+    // second sink-specific presentation of it.
+    void set_pattern(const std::string&) override {}
+    void set_formatter(std::unique_ptr<spdlog::formatter>) override {}
+
+    [[nodiscard]] ConsoleLogPollResult
+    Visit(std::uint64_t _next_sequence, std::size_t _max_count, ConsoleLogVisitor _visitor, void* _context) {
+        ConsoleLogPollResult result;
+        result.next_sequence = _next_sequence == 0 ? 1 : _next_sequence;
+
+        std::vector<ConsoleLogEntryStorage> copied_entries;
+        {
+            std::lock_guard lock(storage_mutex);
+            if (entries.empty()) {
+                if (result.next_sequence < next_sequence) {
+                    result.dropped_count = next_sequence - result.next_sequence;
+                    result.next_sequence = next_sequence;
+                }
+                return result;
+            }
+
+            const std::uint64_t first_sequence = entries.front().sequence;
+            if (result.next_sequence < first_sequence) {
+                result.dropped_count = first_sequence - result.next_sequence;
+                result.next_sequence = first_sequence;
+            }
+            if (_max_count == 0 || !_visitor) {
+                return result;
+            }
+
+            copied_entries.reserve((std::min)(_max_count, entries.size()));
+            for (const ConsoleLogEntryStorage& entry : entries) {
+                if (entry.sequence < result.next_sequence) {
+                    continue;
+                }
+                copied_entries.push_back(entry);
+                result.next_sequence = entry.sequence + 1;
+                if (copied_entries.size() == _max_count) {
+                    break;
+                }
+            }
+        }
+
+        for (const ConsoleLogEntryStorage& entry : copied_entries) {
+            _visitor(
+                {
+                    .sequence = entry.sequence,
+                    .level    = entry.level,
+                    .message  = entry.message,
+                },
+                _context
+            );
+        }
+        result.visited_count = copied_entries.size();
+        return result;
+    }
+
+    void Clear() {
+        std::lock_guard lock(storage_mutex);
+        entries.clear();
+    }
+
+private:
+    std::mutex                         storage_mutex;
+    std::deque<ConsoleLogEntryStorage> entries;
+    std::uint64_t                      next_sequence = 1;
+};
+
+class ConsoleForwardingLogger final : public spdlog::logger {
+public:
+    ConsoleForwardingLogger(
+        std::string                     _name,
+        std::shared_ptr<spdlog::logger> _source_logger,
+        std::shared_ptr<spdlog::logger> _dispatch_logger,
+        std::shared_ptr<ConsoleLogSink> _console_sink
+    ) :
+        spdlog::logger(std::move(_name)),
+        source_logger(std::move(_source_logger)),
+        dispatch_logger(std::move(_dispatch_logger)),
+        console_sink(std::move(_console_sink)) {
+        set_level(source_logger->level());
+        flush_on(source_logger->flush_level());
+    }
+
+protected:
+    void sink_it_(const spdlog::details::log_msg& _message) override {
+        // The forwarding logger is the registered default, so global level and
+        // flush-level changes land here. The private dispatch clone remains at
+        // trace level so dump_backtrace() entries bypass a second logger-level
+        // filter while still using the source logger's virtual dispatch (for
+        // example an async queue or a custom sink_it_ override).
+        SynchronizeConfiguration();
+        const std::shared_ptr<spdlog::logger>& target =
+            _message.level >= level() ? source_logger : dispatch_logger;
+        SPDLOG_TRY {
+            target->log(_message.time, _message.source, _message.level, _message.payload);
+        }
+        SPDLOG_LOGGER_CATCH(_message.source)
+
+        SPDLOG_TRY {
+            console_sink->log(_message);
+        }
+        SPDLOG_LOGGER_CATCH(_message.source)
+
+        // Keep the normal logger::sinks() extension point functional without
+        // placing the downstream sink vector in a different module's heap.
+        for (const spdlog::sink_ptr& sink : sinks_) {
+            if (sink->should_log(_message.level)) {
+                SPDLOG_TRY {
+                    sink->log(_message);
+                }
+                SPDLOG_LOGGER_CATCH(_message.source)
+            }
+        }
+
+        if (should_flush_(_message)) {
+            SPDLOG_TRY {
+                console_sink->flush();
+            }
+            SPDLOG_LOGGER_CATCH(_message.source)
+            for (const spdlog::sink_ptr& sink : sinks_) {
+                SPDLOG_TRY {
+                    sink->flush();
+                }
+                SPDLOG_LOGGER_CATCH(_message.source)
+            }
+        }
+    }
+
+    void flush_() override {
+        SynchronizeConfiguration();
+        SPDLOG_TRY {
+            source_logger->flush();
+        }
+        SPDLOG_LOGGER_CATCH(spdlog::source_loc())
+        SPDLOG_TRY {
+            dispatch_logger->flush();
+        }
+        SPDLOG_LOGGER_CATCH(spdlog::source_loc())
+        SPDLOG_TRY {
+            console_sink->flush();
+        }
+        SPDLOG_LOGGER_CATCH(spdlog::source_loc())
+        for (const spdlog::sink_ptr& sink : sinks_) {
+            SPDLOG_TRY {
+                sink->flush();
+            }
+            SPDLOG_LOGGER_CATCH(spdlog::source_loc())
+        }
+    }
+
+public:
+    std::shared_ptr<spdlog::logger> clone(std::string _logger_name) override {
+        // Clones preserve the original logger behavior. The console channel is
+        // intentionally default-logger scoped; make a clone default and call
+        // LogSystem::Init again if it also needs capture.
+        SynchronizeConfiguration();
+        return source_logger->clone(std::move(_logger_name));
+    }
+
+private:
+    void SynchronizeConfiguration() {
+        source_logger->set_level(level());
+        source_logger->flush_on(flush_level());
+        dispatch_logger->set_level(spdlog::level::trace);
+        dispatch_logger->flush_on(flush_level());
+    }
+
+    std::shared_ptr<spdlog::logger> source_logger;
+    std::shared_ptr<spdlog::logger> dispatch_logger;
+    std::shared_ptr<ConsoleLogSink> console_sink;
+};
+
+struct LogRuntime {
+    std::mutex                                   install_mutex;
+    std::shared_ptr<ConsoleLogSink>              console_sink = std::make_shared<ConsoleLogSink>();
+    std::vector<std::shared_ptr<spdlog::logger>> installed_loggers;
+};
+
+LogRuntime& GetLogRuntime() {
+    // spdlog owns its registry in a separate shared library. Keep the Core
+    // sink and its state alive until address-space reclamation so registry
+    // teardown cannot become the final release of a Core-defined vtable.
+    static LogRuntime* const runtime = new LogRuntime();
+    return *runtime;
+}
+
+} // namespace
 
 void Init() {
 
 #if !defined(NDEBUG)
     spdlog::set_level(spdlog::level::trace);
 #endif
+
+    LogRuntime&     runtime = GetLogRuntime();
+    std::lock_guard install_lock(runtime.install_mutex);
+
+    const std::shared_ptr<spdlog::logger> logger = spdlog::default_logger();
+    if (!logger) {
+        return;
+    }
+
+    const bool already_attached = std::ranges::any_of(
+        runtime.installed_loggers,
+        [&logger](const std::shared_ptr<spdlog::logger>& _installed) {
+            return _installed.get() == logger.get();
+        }
+    );
+    if (already_attached) {
+        return;
+    }
+
+    // logger::sinks() is an owning std::vector. Mutating or copying it into a
+    // logger owned by another DLL makes later reallocation/free depend on the
+    // wrong mimalloc heap. Leave the original logger untouched and forward to
+    // it instead. Runtime keeps every forwarding logger alive so spdlog
+    // shutdown cannot become the final release of Core-defined state.
+    const std::string&     downstream_name = logger->name();
+    const std::string_view downstream_name_view(downstream_name.data(), downstream_name.size());
+    // The private clone only handles below-threshold backtrace replay and is
+    // retained for process lifetime with its Core-owned, non-SSO name storage.
+    // Ordinary messages still use source_logger directly.
+    std::shared_ptr<spdlog::logger> dispatch_logger =
+        logger->clone(MakeCoreOwnedLoggerName(downstream_name_view));
+    if (!dispatch_logger) {
+        return;
+    }
+    dispatch_logger->disable_backtrace();
+    dispatch_logger->set_level(spdlog::level::trace);
+
+    auto replacement = std::make_shared<ConsoleForwardingLogger>(
+        MakeCoreOwnedLoggerName(downstream_name_view),
+        logger,
+        std::move(dispatch_logger),
+        runtime.console_sink
+    );
+
+    runtime.installed_loggers.push_back(replacement);
+    spdlog::set_default_logger(std::move(replacement));
+}
+
+ConsoleLogPollResult VisitConsoleLogs(
+    std::uint64_t     _next_sequence,
+    std::size_t       _max_count,
+    ConsoleLogVisitor _visitor,
+    void*             _context
+) {
+    return GetLogRuntime().console_sink->Visit(_next_sequence, _max_count, _visitor, _context);
+}
+
+void ClearConsoleLogs() {
+    GetLogRuntime().console_sink->Clear();
 }
 
 } // namespace Moer::LogSystem

--- a/source/test/CMakeLists.txt
+++ b/source/test/CMakeLists.txt
@@ -13,6 +13,15 @@ set_target_properties(${test_target} PROPERTIES FOLDER ${moer_test_folder})
 add_test(NAME CVarCommandCoreContract COMMAND $<TARGET_FILE:${test_target}>)
 set_tests_properties(CVarCommandCoreContract PROPERTIES TIMEOUT 60)
 
+set(test_target TestConsoleLogCore)
+add_executable(${test_target} "ConsoleLogCoreTest.cpp")
+target_link_libraries(${test_target}
+    PRIVATE Moer::Core
+)
+set_target_properties(${test_target} PROPERTIES FOLDER ${moer_test_folder})
+add_test(NAME ConsoleLogCoreContract COMMAND $<TARGET_FILE:${test_target}>)
+set_tests_properties(ConsoleLogCoreContract PROPERTIES TIMEOUT 60)
+
 set(test_target TestFatalDiagnostics)
 add_executable(${test_target} "FatalDiagnosticsTest.cpp")
 target_include_directories(${test_target}

--- a/source/test/ConsoleLogCoreTest.cpp
+++ b/source/test/ConsoleLogCoreTest.cpp
@@ -152,6 +152,7 @@ void TestInstallationAndCapture(
     const std::shared_ptr<spdlog::logger> original_logger     = _logger;
     const std::size_t                     original_sink_count = original_logger->sinks().size();
     const std::string                     original_name       = original_logger->name();
+    const spdlog::level::level_enum       original_level      = original_logger->level();
     original_logger->flush_on(spdlog::level::err);
     LogSystem::Init();
     const std::shared_ptr<spdlog::logger> installed_logger = spdlog::default_logger();
@@ -159,10 +160,11 @@ void TestInstallationAndCapture(
     Expect(
         installed_logger && installed_logger.get() != original_logger.get() &&
             spdlog::default_logger().get() == installed_logger.get() &&
-            installed_logger->name() == original_name &&
-            installed_logger->level() == original_logger->level() &&
-            installed_logger->flush_level() == original_logger->flush_level() &&
-            installed_logger->sinks().empty() && original_logger->sinks().size() == original_sink_count &&
+            installed_logger->name() == original_name && installed_logger->level() == original_level &&
+            installed_logger->flush_level() == spdlog::level::err &&
+            original_logger->level() == spdlog::level::off &&
+            original_logger->flush_level() == spdlog::level::off && installed_logger->sinks().empty() &&
+            original_logger->sinks().size() == original_sink_count &&
             std::ranges::any_of(
                 original_logger->sinks(),
                 [&_original_sink](const spdlog::sink_ptr& _sink) {
@@ -171,6 +173,20 @@ void TestInstallationAndCapture(
             ),
         "LogSystem::Init did not install one ABI-safe forwarding logger"
     );
+    const auto*       original_counting_sink = dynamic_cast<CountingSink*>(_original_sink.get());
+    const std::size_t retained_source_count =
+        original_counting_sink ? original_counting_sink->log_count.load() : 0;
+    spdlog::set_level(spdlog::level::warn);
+    Expect(
+        installed_logger->level() == spdlog::level::warn && original_logger->level() == spdlog::level::off,
+        "global level changes re-enabled a retained source logger"
+    );
+    original_logger->critical("console-log-retained-source-disabled");
+    Expect(
+        !original_counting_sink || original_counting_sink->log_count.load() == retained_source_count,
+        "a retained source logger bypassed the forwarding logger's level authority"
+    );
+    installed_logger->set_level(spdlog::level::trace);
     _logger = installed_logger;
 
     installed_logger->set_error_handler([](const std::string&) {});
@@ -195,9 +211,14 @@ void TestInstallationAndCapture(
             external_sink->log_count.load() == 2,
         "a throwing extra sink blocked forwarded/default/later sink paths"
     );
+    const std::size_t downstream_flush_count =
+        original_counting_sink ? original_counting_sink->flush_count.load() : 0;
     installed_logger->flush();
     Expect(
-        external_sink->flush_count.load() == 1, "a throwing extra sink blocked later explicit flush targets"
+        external_sink->flush_count.load() == 1 &&
+            (!original_counting_sink ||
+             original_counting_sink->flush_count.load() == downstream_flush_count + 1),
+        "explicit flush skipped or duplicated a downstream/extra flush target"
     );
 
     installed_logger->set_level(spdlog::level::err);

--- a/source/test/ConsoleLogCoreTest.cpp
+++ b/source/test/ConsoleLogCoreTest.cpp
@@ -1,0 +1,515 @@
+#include "log/LogSystem.h"
+
+#include "spdlog/sinks/null_sink.h"
+
+#include <algorithm>
+#include <atomic>
+#include <cstddef>
+#include <cstdint>
+#include <cstdlib>
+#include <iostream>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <thread>
+#include <unordered_set>
+#include <vector>
+
+namespace {
+
+using namespace Moer;
+
+constexpr std::size_t ConsoleLogCapacity = 4096;
+
+struct CapturedEntry {
+    std::uint64_t             sequence = 0;
+    spdlog::level::level_enum level    = spdlog::level::info;
+    std::string               message;
+};
+
+struct CapturedBatch {
+    std::vector<CapturedEntry>      entries;
+    LogSystem::ConsoleLogPollResult result;
+};
+
+void Expect(bool _condition, std::string_view _message) {
+    if (!_condition) {
+        throw std::runtime_error(std::string(_message));
+    }
+}
+
+CapturedBatch Poll(std::uint64_t _next_sequence, std::size_t _max_count) {
+    CapturedBatch batch;
+    batch.result = LogSystem::VisitConsoleLogs(
+        _next_sequence,
+        _max_count,
+        [](const LogSystem::ConsoleLogEntryView& _entry, void* _context) {
+            static_cast<CapturedBatch*>(_context)->entries.push_back({
+                .sequence = _entry.sequence,
+                .level    = _entry.level,
+                .message  = std::string(_entry.message),
+            });
+        },
+        &batch
+    );
+    return batch;
+}
+
+std::uint64_t ClearAndGetNextSequence() {
+    LogSystem::ClearConsoleLogs();
+    return LogSystem::VisitConsoleLogs(1, 0, nullptr, nullptr).next_sequence;
+}
+
+class DefaultLoggerRestore final {
+public:
+    DefaultLoggerRestore() : saved_logger(spdlog::default_logger()) {}
+
+    ~DefaultLoggerRestore() {
+        try {
+            spdlog::set_default_logger(saved_logger);
+            spdlog::drop("console-log-core-contract");
+            spdlog::drop("console-log-core-replacement");
+        } catch (...) {
+        }
+    }
+
+private:
+    std::shared_ptr<spdlog::logger> saved_logger;
+};
+
+class CountingSink final : public spdlog::sinks::sink {
+public:
+    void log(const spdlog::details::log_msg&) override {
+        ++log_count;
+    }
+
+    void flush() override {
+        ++flush_count;
+    }
+
+    void set_pattern(const std::string&) override {}
+    void set_formatter(std::unique_ptr<spdlog::formatter>) override {}
+
+    std::atomic<std::size_t> log_count{0};
+    std::atomic<std::size_t> flush_count{0};
+};
+
+class ThrowingSink final : public spdlog::sinks::sink {
+public:
+    void log(const spdlog::details::log_msg&) override {
+        throw std::runtime_error("intentional console log sink failure");
+    }
+
+    void flush() override {
+        throw std::runtime_error("intentional console log flush failure");
+    }
+
+    void set_pattern(const std::string&) override {}
+    void set_formatter(std::unique_ptr<spdlog::formatter>) override {}
+};
+
+struct VirtualDispatchState {
+    std::atomic<std::size_t> clone_count{0};
+    std::atomic<std::size_t> dispatch_count{0};
+};
+
+class VirtualDispatchLogger final : public spdlog::logger {
+public:
+    VirtualDispatchLogger(
+        std::string                           _name,
+        spdlog::sink_ptr                      _sink,
+        std::shared_ptr<VirtualDispatchState> _state
+    ) :
+        spdlog::logger(std::move(_name), std::move(_sink)),
+        state(std::move(_state)) {}
+
+    std::shared_ptr<spdlog::logger> clone(std::string _logger_name) override {
+        ++state->clone_count;
+        auto cloned =
+            std::make_shared<VirtualDispatchLogger>(std::move(_logger_name), sinks().front(), state);
+        cloned->set_level(level());
+        cloned->flush_on(flush_level());
+        return cloned;
+    }
+
+protected:
+    void sink_it_(const spdlog::details::log_msg& _message) override {
+        ++state->dispatch_count;
+        spdlog::logger::sink_it_(_message);
+    }
+
+private:
+    std::shared_ptr<VirtualDispatchState> state;
+};
+
+void TestInstallationAndCapture(
+    std::shared_ptr<spdlog::logger>&            _logger,
+    const std::shared_ptr<spdlog::sinks::sink>& _original_sink
+) {
+    LogSystem::ClearConsoleLogs();
+
+    const std::shared_ptr<spdlog::logger> original_logger     = _logger;
+    const std::size_t                     original_sink_count = original_logger->sinks().size();
+    const std::string                     original_name       = original_logger->name();
+    original_logger->flush_on(spdlog::level::err);
+    LogSystem::Init();
+    const std::shared_ptr<spdlog::logger> installed_logger = spdlog::default_logger();
+    LogSystem::Init();
+    Expect(
+        installed_logger && installed_logger.get() != original_logger.get() &&
+            spdlog::default_logger().get() == installed_logger.get() &&
+            installed_logger->name() == original_name &&
+            installed_logger->level() == original_logger->level() &&
+            installed_logger->flush_level() == original_logger->flush_level() &&
+            installed_logger->sinks().empty() && original_logger->sinks().size() == original_sink_count &&
+            std::ranges::any_of(
+                original_logger->sinks(),
+                [&_original_sink](const spdlog::sink_ptr& _sink) {
+                    return _sink.get() == _original_sink.get();
+                }
+            ),
+        "LogSystem::Init did not install one ABI-safe forwarding logger"
+    );
+    _logger = installed_logger;
+
+    installed_logger->set_error_handler([](const std::string&) {});
+    auto throwing_sink = std::make_shared<ThrowingSink>();
+    auto external_sink = std::make_shared<CountingSink>();
+    installed_logger->sinks().push_back(throwing_sink);
+    installed_logger->sinks().push_back(external_sink);
+    installed_logger->sinks().reserve(8);
+
+    const std::uint64_t cursor = ClearAndGetNextSequence();
+    LOG_INFO("console-log-contract-info");
+    spdlog::warn("console-log-contract-warning");
+
+    const CapturedBatch batch = Poll(cursor, 8);
+    Expect(
+        batch.result.dropped_count == 0 && batch.result.visited_count == 2 &&
+            batch.result.next_sequence == cursor + 2 && batch.entries.size() == 2 &&
+            batch.entries[0].sequence == cursor && batch.entries[0].level == spdlog::level::info &&
+            batch.entries[0].message == "console-log-contract-info" &&
+            batch.entries[1].sequence == cursor + 1 && batch.entries[1].level == spdlog::level::warn &&
+            batch.entries[1].message == "console-log-contract-warning" &&
+            external_sink->log_count.load() == 2,
+        "a throwing extra sink blocked forwarded/default/later sink paths"
+    );
+    installed_logger->flush();
+    Expect(
+        external_sink->flush_count.load() == 1, "a throwing extra sink blocked later explicit flush targets"
+    );
+
+    installed_logger->set_level(spdlog::level::err);
+    installed_logger->flush_on(spdlog::level::critical);
+    const std::shared_ptr<spdlog::logger> cloned_logger = installed_logger->clone("console-log-core-clone");
+    Expect(
+        cloned_logger && cloned_logger->name() == "console-log-core-clone" &&
+            cloned_logger->sinks().size() == original_sink_count &&
+            cloned_logger->level() == spdlog::level::err &&
+            cloned_logger->flush_level() == spdlog::level::critical,
+        "forwarding logger clone did not preserve current downstream logger behavior"
+    );
+    installed_logger->set_level(spdlog::level::trace);
+    installed_logger->flush_on(spdlog::level::err);
+}
+
+void TestBacktraceDump(
+    const std::shared_ptr<spdlog::logger>& _logger,
+    const std::shared_ptr<CountingSink>&   _downstream_sink
+) {
+    const std::uint64_t cursor               = ClearAndGetNextSequence();
+    const std::size_t   downstream_log_count = _downstream_sink->log_count.load();
+
+    _logger->set_level(spdlog::level::warn);
+    _logger->enable_backtrace(4);
+    _logger->debug("console-log-backtrace-debug");
+    _logger->dump_backtrace();
+    _logger->disable_backtrace();
+    _logger->set_level(spdlog::level::trace);
+
+    const CapturedBatch batch           = Poll(cursor, 8);
+    const bool          has_debug_entry = std::ranges::any_of(batch.entries, [](const CapturedEntry& _entry) {
+        return _entry.level == spdlog::level::debug && _entry.message == "console-log-backtrace-debug";
+    });
+    Expect(
+        batch.entries.size() == 3 && has_debug_entry &&
+            _downstream_sink->log_count.load() == downstream_log_count + 3,
+        "backtrace dump was filtered before reaching the console or downstream sinks"
+    );
+}
+
+void TestVirtualLoggerBacktraceDispatch(std::shared_ptr<spdlog::logger>& _logger) {
+    auto state         = std::make_shared<VirtualDispatchState>();
+    auto sink          = std::make_shared<CountingSink>();
+    auto source_logger = std::make_shared<VirtualDispatchLogger>("console-log-virtual-source", sink, state);
+    source_logger->set_level(spdlog::level::warn);
+    spdlog::set_default_logger(source_logger);
+
+    LogSystem::Init();
+    const std::shared_ptr<spdlog::logger> installed_logger = spdlog::default_logger();
+    Expect(
+        installed_logger && installed_logger.get() != source_logger.get() && state->clone_count.load() == 1,
+        "LogSystem::Init did not create a private virtual-dispatch clone"
+    );
+
+    const std::uint64_t cursor = ClearAndGetNextSequence();
+    installed_logger->set_level(spdlog::level::warn);
+    installed_logger->enable_backtrace(4);
+    installed_logger->debug("console-log-virtual-backtrace");
+    installed_logger->dump_backtrace();
+    installed_logger->disable_backtrace();
+
+    const CapturedBatch batch           = Poll(cursor, 8);
+    const bool          has_debug_entry = std::ranges::any_of(batch.entries, [](const CapturedEntry& _entry) {
+        return _entry.level == spdlog::level::debug && _entry.message == "console-log-virtual-backtrace";
+    });
+    Expect(
+        batch.entries.size() == 3 && has_debug_entry && state->dispatch_count.load() == 3 &&
+            sink->log_count.load() == 3,
+        "backtrace replay bypassed the source logger's virtual dispatch path"
+    );
+    _logger = installed_logger;
+}
+
+void TestRuntimeFiltering(const std::shared_ptr<spdlog::logger>& _logger) {
+    const std::uint64_t cursor = ClearAndGetNextSequence();
+    _logger->set_level(spdlog::level::warn);
+    spdlog::info("console-log-filtered-info");
+    spdlog::warn("console-log-admitted-warning");
+    _logger->set_level(spdlog::level::trace);
+
+    const CapturedBatch batch = Poll(cursor, 8);
+    Expect(
+        batch.entries.size() == 1 && batch.result.visited_count == 1 &&
+            batch.entries.front().level == spdlog::level::warn &&
+            batch.entries.front().message == "console-log-admitted-warning",
+        "console log channel bypassed the default logger's runtime level"
+    );
+}
+
+void TestPagingAndClear(const std::shared_ptr<spdlog::logger>& _logger) {
+    const std::uint64_t cursor = ClearAndGetNextSequence();
+    _logger->info("console-log-page-a");
+    _logger->info("console-log-page-b");
+    _logger->info("console-log-page-c");
+
+    const CapturedBatch first  = Poll(cursor, 2);
+    const CapturedBatch second = Poll(first.result.next_sequence, 2);
+    Expect(
+        first.entries.size() == 2 && first.result.visited_count == 2 &&
+            first.result.next_sequence == cursor + 2 && first.result.dropped_count == 0 &&
+            second.entries.size() == 1 && second.entries.front().sequence == cursor + 2 &&
+            second.result.next_sequence == cursor + 3 && second.result.dropped_count == 0,
+        "console log cursor paging skipped or duplicated retained entries"
+    );
+
+    const std::uint64_t stale_cursor = ClearAndGetNextSequence();
+    _logger->info("console-log-clear-a");
+    _logger->info("console-log-clear-b");
+    LogSystem::ClearConsoleLogs();
+    const LogSystem::ConsoleLogPollResult cleared =
+        LogSystem::VisitConsoleLogs(stale_cursor, 0, nullptr, nullptr);
+    Expect(
+        cleared.next_sequence == stale_cursor + 2 && cleared.dropped_count == 2 && cleared.visited_count == 0,
+        "clearing an empty-visible ring did not advance a stale cursor across removed entries"
+    );
+
+    _logger->info("console-log-after-clear");
+    const CapturedBatch after_clear = Poll(cleared.next_sequence, 4);
+    Expect(
+        after_clear.entries.size() == 1 && after_clear.entries.front().sequence == stale_cursor + 2 &&
+            after_clear.result.dropped_count == 0,
+        "ClearConsoleLogs reset sequence identity or lost the next entry"
+    );
+}
+
+void TestBoundedOverwrite(const std::shared_ptr<spdlog::logger>& _logger) {
+    constexpr std::size_t overflow_count = 17;
+    constexpr std::size_t produced_count = ConsoleLogCapacity + overflow_count;
+    const std::uint64_t   cursor         = ClearAndGetNextSequence();
+
+    for (std::size_t index = 0; index < produced_count; ++index) {
+        _logger->info("console-log-overflow-{}", index);
+    }
+
+    const CapturedBatch batch = Poll(cursor, produced_count);
+    Expect(
+        batch.entries.size() == ConsoleLogCapacity && batch.result.visited_count == ConsoleLogCapacity &&
+            batch.result.dropped_count == overflow_count &&
+            batch.entries.front().sequence == cursor + overflow_count &&
+            batch.entries.back().sequence == cursor + produced_count - 1 &&
+            batch.result.next_sequence == cursor + produced_count,
+        "bounded console log ring did not report overwritten cursor entries"
+    );
+}
+
+void TestConcurrentProducers(const std::shared_ptr<spdlog::logger>& _logger) {
+    constexpr std::size_t producer_count     = 8;
+    constexpr std::size_t entries_per_thread = 128;
+    constexpr std::size_t expected_count     = producer_count * entries_per_thread;
+    const std::uint64_t   cursor             = ClearAndGetNextSequence();
+
+    std::vector<std::jthread> producers;
+    producers.reserve(producer_count);
+    for (std::size_t producer = 0; producer < producer_count; ++producer) {
+        producers.emplace_back([_logger, producer] {
+            for (std::size_t index = 0; index < entries_per_thread; ++index) {
+                _logger->info("console-log-concurrent-{}-{}", producer, index);
+            }
+        });
+    }
+    producers.clear();
+
+    const CapturedBatch             batch = Poll(cursor, expected_count);
+    std::unordered_set<std::string> unique_messages;
+    unique_messages.reserve(expected_count);
+    bool sequences_are_contiguous = batch.entries.size() == expected_count;
+    for (std::size_t index = 0; index < batch.entries.size(); ++index) {
+        sequences_are_contiguous =
+            sequences_are_contiguous && batch.entries[index].sequence == cursor + index;
+        unique_messages.insert(batch.entries[index].message);
+    }
+    Expect(
+        batch.result.dropped_count == 0 && batch.result.visited_count == expected_count &&
+            batch.result.next_sequence == cursor + expected_count && sequences_are_contiguous &&
+            unique_messages.size() == expected_count,
+        "concurrent console log producers lost, duplicated, or mis-sequenced entries"
+    );
+}
+
+struct ReentrantVisitorContext {
+    std::shared_ptr<spdlog::logger> logger;
+    std::vector<CapturedEntry>      entries;
+    std::uint64_t                   new_entry_sequence = 0;
+    LogSystem::ConsoleLogPollResult nested_result;
+    bool                            reentered = false;
+};
+
+void ReentrantVisitor(const LogSystem::ConsoleLogEntryView& _entry, void* _context) {
+    auto& context = *static_cast<ReentrantVisitorContext*>(_context);
+    context.entries.push_back({
+        .sequence = _entry.sequence,
+        .level    = _entry.level,
+        .message  = std::string(_entry.message),
+    });
+    if (context.reentered) {
+        return;
+    }
+
+    context.reentered = true;
+    LogSystem::ClearConsoleLogs();
+    context.logger->warn("console-log-reentrant-new");
+    context.nested_result = LogSystem::VisitConsoleLogs(context.new_entry_sequence, 0, nullptr, nullptr);
+}
+
+void TestVisitorReentry(const std::shared_ptr<spdlog::logger>& _logger) {
+    const std::uint64_t cursor = ClearAndGetNextSequence();
+    _logger->info("console-log-reentrant-a");
+    _logger->info("console-log-reentrant-b");
+
+    ReentrantVisitorContext context{
+        .logger             = _logger,
+        .new_entry_sequence = cursor + 2,
+    };
+    const LogSystem::ConsoleLogPollResult outer =
+        LogSystem::VisitConsoleLogs(cursor, 2, &ReentrantVisitor, &context);
+    Expect(
+        outer.visited_count == 2 && outer.next_sequence == cursor + 2 && context.reentered &&
+            context.entries.size() == 2 && context.entries[0].message == "console-log-reentrant-a" &&
+            context.entries[1].message == "console-log-reentrant-b" &&
+            context.nested_result.next_sequence == cursor + 2 && context.nested_result.dropped_count == 0,
+        "console log visitor ran under the channel lock or lost its copied snapshot during reentry"
+    );
+
+    const CapturedBatch nested_entry = Poll(outer.next_sequence, 4);
+    Expect(
+        nested_entry.entries.size() == 1 && nested_entry.entries.front().sequence == cursor + 2 &&
+            nested_entry.entries.front().message == "console-log-reentrant-new",
+        "reentrant logging was not retained for the next cursor poll"
+    );
+}
+
+void TestSpdlogTeardownAndReattach(std::shared_ptr<spdlog::logger>& _logger) {
+    const std::uint64_t cursor = ClearAndGetNextSequence();
+    _logger->warn("console-log-before-spdlog-shutdown");
+    spdlog::shutdown();
+    _logger.reset();
+
+    const CapturedBatch retained = Poll(cursor, 4);
+    Expect(
+        retained.entries.size() == 1 &&
+            retained.entries.front().message == "console-log-before-spdlog-shutdown",
+        "spdlog logger teardown destroyed retained console log channel state"
+    );
+
+    auto replacement_sink = std::make_shared<spdlog::sinks::null_sink_mt>();
+    auto replacement_logger =
+        std::make_shared<spdlog::logger>("console-log-core-replacement", replacement_sink);
+    replacement_logger->set_level(spdlog::level::trace);
+    spdlog::set_default_logger(replacement_logger);
+    LogSystem::Init();
+    const std::shared_ptr<spdlog::logger> installed_replacement = spdlog::default_logger();
+    LogSystem::Init();
+    Expect(
+        installed_replacement && installed_replacement.get() != replacement_logger.get() &&
+            spdlog::default_logger().get() == installed_replacement.get() &&
+            installed_replacement->sinks().empty() && replacement_logger->sinks().size() == 1,
+        "LogSystem::Init did not install exactly one ABI-safe forwarding logger after replacement"
+    );
+
+    const std::uint64_t replacement_cursor = ClearAndGetNextSequence();
+    installed_replacement->error("console-log-after-reattach");
+    const CapturedBatch replacement_batch = Poll(replacement_cursor, 4);
+    Expect(
+        replacement_batch.entries.size() == 1 &&
+            replacement_batch.entries.front().message == "console-log-after-reattach",
+        "replacement default logger did not feed the existing console log channel"
+    );
+    _logger = installed_replacement;
+}
+
+} // namespace
+
+int main() {
+    DefaultLoggerRestore restore_default_logger;
+
+    const LogSystem::ConsoleLogPollResult initial = LogSystem::VisitConsoleLogs(0, 0, nullptr, nullptr);
+    Expect(
+        initial.next_sequence == 1 && initial.dropped_count == 0 && initial.visited_count == 0,
+        "empty console log channel did not normalize its initial cursor"
+    );
+
+    LogSystem::Init();
+    const std::uint64_t process_default_cursor = ClearAndGetNextSequence();
+    LOG_INFO("console-log-process-default-forwarding");
+    const CapturedBatch process_default_batch = Poll(process_default_cursor, 2);
+    Expect(
+        process_default_batch.entries.size() == 1 &&
+            process_default_batch.entries.front().message == "console-log-process-default-forwarding",
+        "the process default logger did not forward into the console channel"
+    );
+
+    auto                            original_sink = std::make_shared<CountingSink>();
+    std::shared_ptr<spdlog::logger> logger =
+        std::make_shared<spdlog::logger>("console-log-core-contract", original_sink);
+    logger->set_level(spdlog::level::trace);
+    spdlog::set_default_logger(logger);
+
+    try {
+        TestInstallationAndCapture(logger, original_sink);
+        TestBacktraceDump(logger, original_sink);
+        TestRuntimeFiltering(logger);
+        TestPagingAndClear(logger);
+        TestBoundedOverwrite(logger);
+        TestConcurrentProducers(logger);
+        TestVisitorReentry(logger);
+        TestVirtualLoggerBacktraceDispatch(logger);
+        TestSpdlogTeardownAndReattach(logger);
+        std::cout << "Console log core contract tests passed.\n";
+        return EXIT_SUCCESS;
+    } catch (const std::exception& error) {
+        std::cerr << "Console log core contract test failed: " << error.what() << '\n';
+        return EXIT_FAILURE;
+    }
+}

--- a/source/test/ConsoleLogCoreTest.cpp
+++ b/source/test/ConsoleLogCoreTest.cpp
@@ -1,5 +1,6 @@
 #include "log/LogSystem.h"
 
+#include "spdlog/details/os.h"
 #include "spdlog/sinks/null_sink.h"
 
 #include <algorithm>
@@ -9,6 +10,7 @@
 #include <cstdlib>
 #include <iostream>
 #include <memory>
+#include <mutex>
 #include <stdexcept>
 #include <string>
 #include <string_view>
@@ -109,6 +111,36 @@ public:
     void set_formatter(std::unique_ptr<spdlog::formatter>) override {}
 };
 
+class ThreadRecordingSink final : public spdlog::sinks::sink {
+    struct Record {
+        std::string message;
+        std::size_t thread_id = 0;
+    };
+
+public:
+    void log(const spdlog::details::log_msg& _message) override {
+        std::lock_guard lock(records_mutex);
+        records.push_back({
+            .message   = std::string(_message.payload.data(), _message.payload.size()),
+            .thread_id = _message.thread_id,
+        });
+    }
+
+    void flush() override {}
+    void set_pattern(const std::string&) override {}
+    void set_formatter(std::unique_ptr<spdlog::formatter>) override {}
+
+    [[nodiscard]] std::size_t FindThreadId(std::string_view _message) const {
+        std::lock_guard lock(records_mutex);
+        const auto      found = std::ranges::find(records, _message, &Record::message);
+        return found == records.end() ? 0 : found->thread_id;
+    }
+
+private:
+    mutable std::mutex  records_mutex;
+    std::vector<Record> records;
+};
+
 struct VirtualDispatchState {
     std::atomic<std::size_t> clone_count{0};
     std::atomic<std::size_t> dispatch_count{0};
@@ -153,6 +185,10 @@ void TestInstallationAndCapture(
     const std::size_t                     original_sink_count = original_logger->sinks().size();
     const std::string                     original_name       = original_logger->name();
     const spdlog::level::level_enum       original_level      = original_logger->level();
+    auto                                  source_error_count  = std::make_shared<std::atomic<std::size_t>>(0);
+    original_logger->set_error_handler([source_error_count](const std::string&) {
+        ++*source_error_count;
+    });
     original_logger->flush_on(spdlog::level::err);
     LogSystem::Init();
     const std::shared_ptr<spdlog::logger> installed_logger = spdlog::default_logger();
@@ -189,7 +225,6 @@ void TestInstallationAndCapture(
     installed_logger->set_level(spdlog::level::trace);
     _logger = installed_logger;
 
-    installed_logger->set_error_handler([](const std::string&) {});
     auto throwing_sink = std::make_shared<ThrowingSink>();
     auto external_sink = std::make_shared<CountingSink>();
     installed_logger->sinks().push_back(throwing_sink);
@@ -217,8 +252,9 @@ void TestInstallationAndCapture(
     Expect(
         external_sink->flush_count.load() == 1 &&
             (!original_counting_sink ||
-             original_counting_sink->flush_count.load() == downstream_flush_count + 1),
-        "explicit flush skipped or duplicated a downstream/extra flush target"
+             original_counting_sink->flush_count.load() == downstream_flush_count + 1) &&
+            source_error_count->load() == 3,
+        "explicit flush or the preconfigured error handler was not preserved exactly once"
     );
 
     installed_logger->set_level(spdlog::level::err);
@@ -289,6 +325,40 @@ void TestVirtualLoggerBacktraceDispatch(std::shared_ptr<spdlog::logger>& _logger
         batch.entries.size() == 3 && has_debug_entry && state->dispatch_count.load() == 3 &&
             sink->log_count.load() == 3,
         "backtrace replay bypassed the source logger's virtual dispatch path"
+    );
+    _logger = installed_logger;
+}
+
+void TestBacktraceThreadMetadata(std::shared_ptr<spdlog::logger>& _logger) {
+    auto sink          = std::make_shared<ThreadRecordingSink>();
+    auto source_logger = std::make_shared<spdlog::logger>("console-log-thread-metadata", sink);
+    source_logger->set_level(spdlog::level::warn);
+    spdlog::set_default_logger(source_logger);
+
+    LogSystem::Init();
+    const std::shared_ptr<spdlog::logger> installed_logger = spdlog::default_logger();
+    const std::uint64_t                   cursor           = ClearAndGetNextSequence();
+    installed_logger->set_level(spdlog::level::warn);
+    installed_logger->enable_backtrace(4);
+
+    std::atomic<std::size_t> producer_thread_id{0};
+    std::jthread             producer([installed_logger, &producer_thread_id] {
+        producer_thread_id.store(spdlog::details::os::thread_id());
+        installed_logger->debug("console-log-worker-backtrace");
+    });
+    producer.join();
+
+    installed_logger->dump_backtrace();
+    installed_logger->disable_backtrace();
+
+    const CapturedBatch batch           = Poll(cursor, 8);
+    const bool          has_debug_entry = std::ranges::any_of(batch.entries, [](const CapturedEntry& _entry) {
+        return _entry.message == "console-log-worker-backtrace";
+    });
+    Expect(
+        batch.entries.size() == 3 && has_debug_entry &&
+            sink->FindThreadId("console-log-worker-backtrace") == producer_thread_id.load(),
+        "backtrace forwarding replaced the producer thread metadata"
     );
     _logger = installed_logger;
 }
@@ -526,6 +596,7 @@ int main() {
         TestConcurrentProducers(logger);
         TestVisitorReentry(logger);
         TestVirtualLoggerBacktraceDispatch(logger);
+        TestBacktraceThreadMetadata(logger);
         TestSpdlogTeardownAndReattach(logger);
         std::cout << "Console log core contract tests passed.\n";
         return EXIT_SUCCESS;


### PR DESCRIPTION
## Summary
- add a 4096-entry sequence-based Core console log channel with cursor, dropped-count, clear, and reentrant visitor semantics
- install an ABI-safe forwarding default logger without mutating/copying the source logger sink vector across DLL heaps
- preserve normal, backtrace, clone, flush, exception-isolation, custom virtual logger, and replacement/reattach behavior
- add `ConsoleLogCoreContract` coverage for concurrency, overwrite, reentry, teardown, backtrace, and cross-DLL extension points

This is Phase 24B-A of the `dev_parallel_rhi` console/control-plane migration. Editor session/UI, command drain, and real CVar mappings remain separate follow-up work.

## Validation
- Debug full build: passed
- Release full build: passed
- Debug CTest: 43/43 passed
- Release CTest: 43/43 passed
- `ConsoleLogCoreContract`: Debug 50/50 and Release 50/50
- Raytracing GUI smoke: first main-window present submitted; 0 strict severe log matches
- local P0-P2 review loop: clean