### PR TITLE
Phase24B: add Editor Console and runtime CVar control plane

### DIFF
--- a/source/editor/EditorUI.cpp
+++ b/source/editor/EditorUI.cpp
@@ -3,6 +3,7 @@
 // 构建编辑器 ImGui Dockspace，协调顶层工具，并跟踪当前活动的渲染视口。
 
 // Runtime
+#include "Engine.h"
 #include "log/LogSystem.h"
 #include "window/WindowInput.h"
 
@@ -67,6 +68,7 @@ EditorUI::EditorUI(
     Engine&                               engine,
     ProfileDump::ProfileDocumentLoader&   profile_document_loader
 ) :
+    m_console_panel(engine.GetCommandEndpoint()),
     m_raster_ui(editor_config->raster_config),
     m_raytracing_ui(editor_config->raytracing_config),
     m_scene_editing_ui(editor_config->scene_test_case_config),
@@ -90,6 +92,7 @@ EditorUI::EditorUI(
         m_b_show_inspector     = window_visibility_settings.inspector;
         m_b_show_config        = window_visibility_settings.config;
         m_b_show_scene_editing = window_visibility_settings.scene_editing;
+        m_b_show_console       = window_visibility_settings.console;
         m_b_show_profile_capture =
             window_visibility_settings.profile_capture;
         m_b_show_profile_viewer = window_visibility_settings.profile_viewer;
@@ -103,6 +106,7 @@ EditorUI::EditorUI(
         m_b_show_inspector     = has_saved_window_settings("Inspector");
         m_b_show_config        = has_saved_window_settings("Configs");
         m_b_show_scene_editing = has_saved_window_settings("Scene Editing");
+        m_b_show_console       = has_saved_window_settings("Console");
         m_b_show_profile_capture =
             has_saved_window_settings("Profile Capture");
         m_b_show_profile_viewer = has_saved_window_settings("Profile Viewer");
@@ -376,6 +380,7 @@ void EditorUI::TickUI(Scene& scene) {
             ImGui::MenuItem("Inspector", nullptr, &m_b_show_inspector);
             ImGui::MenuItem("Configs", nullptr, &m_b_show_config);
             ImGui::MenuItem("Scene Editing", nullptr, &m_b_show_scene_editing);
+            ImGui::MenuItem("Console", nullptr, &m_b_show_console);
             ImGui::MenuItem(
                 "Profile Capture",
                 nullptr,
@@ -391,6 +396,9 @@ void EditorUI::TickUI(Scene& scene) {
         ImGui::EndMenuBar();
     }
     ImGui::End();
+    if (m_b_show_console) {
+        m_console_panel.ShowWindow(&m_b_show_console);
+    }
     if (m_b_show_profile_capture) {
         m_profile_capture_ui.ShowWindow(&m_b_show_profile_capture);
     }
@@ -1029,6 +1037,7 @@ void EditorUI::SyncWindowVisibilitySettings() {
     settings.inspector     = m_b_show_inspector;
     settings.config        = m_b_show_config;
     settings.scene_editing = m_b_show_scene_editing;
+    settings.console       = m_b_show_console;
     settings.profile_capture = m_b_show_profile_capture;
     settings.profile_viewer = m_b_show_profile_viewer;
 #if WITH_PROFILE

--- a/source/editor/EditorUI.cpp
+++ b/source/editor/EditorUI.cpp
@@ -438,6 +438,8 @@ void EditorUI::TickUI(Scene& scene) {
     };
     const WindowInputSourceSnapshot& pending_input_source =
         m_window_input_tracker.GetPendingSource();
+    const bool console_input_active =
+        m_b_show_console && m_console_panel.IsInputActive();
     const bool any_mouse_button_down =
         pending_input_source.mouse_button_down[MouseButtons::Left] ||
         pending_input_source.mouse_button_down[MouseButtons::Middle] ||
@@ -483,12 +485,21 @@ void EditorUI::TickUI(Scene& scene) {
         // free-look request that activates later from hover alone.
         m_window_input_tracker.ClearKeyToggle(KeyButtons::F);
     }
+    if (console_input_active) {
+        // A docked Console shares the same platform viewport focus as the
+        // Scene/Game panel. Its text input nevertheless owns both keyboard and
+        // mouse for this frame, so revoke any latched scene capture explicitly.
+        m_window_input_tracker.ClearKeyToggle(KeyButtons::F);
+        m_mouse_capture_viewport_id     = 0;
+        m_free_look_capture_viewport_id = 0;
+    }
 
     m_window_input_snapshot = m_window_input_tracker.Finalize(WindowInputPolicy{
         .scene_active =
-            active_viewport_focused &&
+            !console_input_active && active_viewport_focused &&
             (m_mouse_capture_viewport_id != 0 || m_free_look_capture_viewport_id != 0),
-        .viewport_hovered = m_b_active_viewport_hovered,
+        .viewport_hovered     = !console_input_active && m_b_active_viewport_hovered,
+        .force_cursor_visible = console_input_active,
         .viewport_resolution = uint2(
             to_extent_component(m_scene_color_resolution.x),
             to_extent_component(m_scene_color_resolution.y)

--- a/source/editor/EditorUI.h
+++ b/source/editor/EditorUI.h
@@ -11,6 +11,7 @@
 #include "window/WindowInput.h"
 
 #include "inspector_ui/InspectorUI.h"
+#include "console/ConsolePanel.h"
 #include "profile_capture_ui/ProfileCaptureUI.h"
 #include "profile_viewer_ui/ProfileViewerUI.h"
 #include "raster_ui/RasterUI.h"
@@ -91,6 +92,7 @@ public:
     void UnregisterUIFunc(std::string name);
 
 public: // Sub UI
+    ConsolePanel    m_console_panel;
     RasterUI       m_raster_ui;
     RaytracingUI   m_raytracing_ui;
     SceneEditingUI m_scene_editing_ui;
@@ -124,6 +126,7 @@ private:
     bool   m_b_show_inspector             = true;
     bool   m_b_show_config                = true;
     bool   m_b_show_scene_editing         = true;
+    bool   m_b_show_console               = false;
     bool   m_b_show_profile_capture       = false;
     bool   m_b_show_profile_viewer          = false;
     bool   m_b_active_viewport_window_seen = false;

--- a/source/editor/EditorUISettings.cpp
+++ b/source/editor/EditorUISettings.cpp
@@ -50,6 +50,7 @@ void ParseEditorWindowVisibilityLine(EditorWindowVisibilitySettings& settings, s
         TryParseBoolSetting(line, "Inspector", settings.inspector) ||
         TryParseBoolSetting(line, "Configs", settings.config) ||
         TryParseBoolSetting(line, "SceneEditing", settings.scene_editing) ||
+        TryParseBoolSetting(line, "Console", settings.console) ||
         TryParseBoolSetting(
             line,
             "ProfileCapture",
@@ -93,6 +94,7 @@ void EditorWindowVisibilitySettingsWriteAll(ImGuiContext*, ImGuiSettingsHandler*
     out_buf->appendf("Inspector=%d\n", settings.inspector ? 1 : 0);
     out_buf->appendf("Configs=%d\n", settings.config ? 1 : 0);
     out_buf->appendf("SceneEditing=%d\n", settings.scene_editing ? 1 : 0);
+    out_buf->appendf("Console=%d\n", settings.console ? 1 : 0);
     out_buf->appendf(
         "ProfileCapture=%d\n",
         settings.profile_capture ? 1 : 0
@@ -164,6 +166,7 @@ bool IsSameWindowVisibilitySettings(
            lhs.scene_view == rhs.scene_view && lhs.hierarchy == rhs.hierarchy &&
            lhs.inspector == rhs.inspector && lhs.config == rhs.config &&
            lhs.scene_editing == rhs.scene_editing &&
+           lhs.console == rhs.console &&
            lhs.profile_capture == rhs.profile_capture &&
            lhs.profile_viewer == rhs.profile_viewer &&
            lhs.memory_profiler == rhs.memory_profiler;

--- a/source/editor/EditorUISettings.h
+++ b/source/editor/EditorUISettings.h
@@ -19,6 +19,7 @@ struct EditorWindowVisibilitySettings {
     bool inspector       = true;
     bool config          = true;
     bool scene_editing   = true;
+    bool console         = false;
     bool profile_capture = false;
     bool profile_viewer  = false;
     bool memory_profiler = false;

--- a/source/editor/console/ConsolePanel.cpp
+++ b/source/editor/console/ConsolePanel.cpp
@@ -53,6 +53,7 @@ void ConsolePanel::ShowWindow(bool* open) {
     ImGui::Checkbox("Auto-scroll", &auto_scroll);
     ImGui::SameLine();
     filter.Draw("Filter", 240.0f);
+    input_active = ImGui::IsItemActive() || ImGui::IsItemFocused();
     ImGui::Separator();
 
     const float footer_height =
@@ -120,7 +121,7 @@ void ConsolePanel::ShowWindow(bool* open) {
         &ConsolePanel::InputCallback,
         this
     );
-    input_active = ImGui::IsItemActive() || ImGui::IsItemFocused();
+    input_active = input_active || ImGui::IsItemActive() || ImGui::IsItemFocused();
     ImGui::PopItemWidth();
     if (submitted) {
         const Command::ESubmitStatus status = model.Submit(input_buffer.data());

--- a/source/editor/console/ConsolePanel.cpp
+++ b/source/editor/console/ConsolePanel.cpp
@@ -1,0 +1,263 @@
+#include "console/ConsolePanel.h"
+
+#include <algorithm>
+#include <cctype>
+#include <cstring>
+#include <string_view>
+#include <utility>
+
+namespace Moer {
+
+namespace {
+
+char FoldAscii(char value) noexcept {
+    if (value >= 'A' && value <= 'Z') {
+        return static_cast<char>(value + ('a' - 'A'));
+    }
+    return value;
+}
+
+std::size_t CommonPrefixLength(const std::vector<Command::CommandCandidate>& candidates) {
+    if (candidates.empty()) {
+        return 0;
+    }
+    std::size_t prefix_length = candidates.front().text.size();
+    for (std::size_t index = 1; index < candidates.size(); ++index) {
+        prefix_length       = (std::min)(prefix_length, candidates[index].text.size());
+        std::size_t matched = 0;
+        while (matched < prefix_length &&
+               FoldAscii(candidates.front().text[matched]) == FoldAscii(candidates[index].text[matched])) {
+            ++matched;
+        }
+        prefix_length = matched;
+    }
+    return prefix_length;
+}
+
+} // namespace
+
+ConsolePanel::ConsolePanel(std::shared_ptr<EngineCommandEndpoint> endpoint) : model(std::move(endpoint)) {}
+
+void ConsolePanel::ShowWindow(bool* open) {
+    static_cast<void>(model.Pump());
+    if (!ImGui::Begin("Console", open)) {
+        ImGui::End();
+        return;
+    }
+
+    if (ImGui::Button("Clear")) {
+        model.Clear();
+    }
+    ImGui::SameLine();
+    ImGui::Checkbox("Auto-scroll", &auto_scroll);
+    ImGui::SameLine();
+    filter.Draw("Filter", 240.0f);
+    ImGui::Separator();
+
+    const float footer_height =
+        ImGui::GetFrameHeightWithSpacing() +
+        (completion_candidates.empty() ? 0.0f : ImGui::GetTextLineHeightWithSpacing() * 3.0f);
+    if (ImGui::BeginChild(
+            "ConsoleOutput", ImVec2(0.0f, -footer_height), false, ImGuiWindowFlags_HorizontalScrollbar
+        )) {
+        const bool  was_at_bottom = ImGui::GetScrollY() >= ImGui::GetScrollMaxY() - 1.0f;
+        const auto& lines         = model.GetLines();
+        const auto  draw_line     = [](const ConsoleSessionLine& line) {
+            ImGui::PushStyleColor(ImGuiCol_Text, LineColor(line.level));
+            if (line.source_sequence != 0) {
+                ImGui::TextUnformatted(SourceLabel(line.source));
+                ImGui::SameLine();
+            }
+            ImGui::TextUnformatted(line.text.c_str());
+            ImGui::PopStyleColor();
+        };
+        if (filter.IsActive()) {
+            for (const ConsoleSessionLine& line : lines) {
+                if (filter.PassFilter(line.text.c_str())) {
+                    draw_line(line);
+                }
+            }
+        } else {
+            ImGuiListClipper clipper;
+            clipper.Begin(static_cast<int>(lines.size()));
+            while (clipper.Step()) {
+                for (int index = clipper.DisplayStart; index < clipper.DisplayEnd; ++index) {
+                    draw_line(lines[static_cast<std::size_t>(index)]);
+                }
+            }
+        }
+        if (auto_scroll && was_at_bottom) {
+            ImGui::SetScrollHereY(1.0f);
+        }
+    }
+    ImGui::EndChild();
+
+    if (!completion_candidates.empty()) {
+        ImGui::TextDisabled("Candidates:");
+        const std::size_t visible_count = (std::min)(completion_candidates.size(), std::size_t{8});
+        for (std::size_t index = 0; index < visible_count; ++index) {
+            if (index != 0) {
+                ImGui::SameLine();
+            }
+            ImGui::TextUnformatted(completion_candidates[index].text.c_str());
+        }
+        if (completion_candidates.size() > visible_count) {
+            ImGui::SameLine();
+            ImGui::TextDisabled("(+%zu)", completion_candidates.size() - visible_count);
+        }
+    }
+
+    const ImGuiInputTextFlags input_flags =
+        ImGuiInputTextFlags_EnterReturnsTrue | ImGuiInputTextFlags_CallbackCompletion |
+        ImGuiInputTextFlags_CallbackHistory | ImGuiInputTextFlags_CallbackEdit;
+    ImGui::PushItemWidth(-1.0f);
+    const bool submitted = ImGui::InputText(
+        "##ConsoleInput",
+        input_buffer.data(),
+        input_buffer.size(),
+        input_flags,
+        &ConsolePanel::InputCallback,
+        this
+    );
+    ImGui::PopItemWidth();
+    if (submitted) {
+        const Command::ESubmitStatus status = model.Submit(input_buffer.data());
+        if (status == Command::ESubmitStatus::Accepted || status == Command::ESubmitStatus::Empty) {
+            input_buffer[0]  = '\0';
+            history_position = -1;
+            history_draft.clear();
+            completion_candidates.clear();
+        }
+        reclaim_input_focus = true;
+    }
+    if (reclaim_input_focus) {
+        ImGui::SetKeyboardFocusHere(-1);
+        reclaim_input_focus = false;
+    }
+
+    ImGui::End();
+}
+
+int ConsolePanel::InputCallback(ImGuiInputTextCallbackData* data) {
+    return static_cast<ConsolePanel*>(data->UserData)->HandleInputCallback(*data);
+}
+
+int ConsolePanel::HandleInputCallback(ImGuiInputTextCallbackData& data) {
+    if (data.EventFlag == ImGuiInputTextFlags_CallbackCompletion) {
+        CompleteInput(data);
+    } else if (data.EventFlag == ImGuiInputTextFlags_CallbackHistory) {
+        NavigateHistory(data, data.EventKey == ImGuiKey_UpArrow);
+    } else if (data.EventFlag == ImGuiInputTextFlags_CallbackEdit) {
+        completion_candidates.clear();
+        history_position = -1;
+        history_draft.clear();
+    }
+    return 0;
+}
+
+void ConsolePanel::CompleteInput(ImGuiInputTextCallbackData& data) {
+    const std::string_view buffer(data.Buf, static_cast<std::size_t>(data.BufTextLen));
+    const std::size_t      cursor      = static_cast<std::size_t>(data.CursorPos);
+    std::size_t            token_begin = cursor;
+    while (token_begin > 0 && buffer[token_begin - 1] != ' ' && buffer[token_begin - 1] != '\t' &&
+           buffer[token_begin - 1] != '=') {
+        --token_begin;
+    }
+    std::size_t first_token_begin = 0;
+    while (first_token_begin < buffer.size() &&
+           (buffer[first_token_begin] == ' ' || buffer[first_token_begin] == '\t')) {
+        ++first_token_begin;
+    }
+    if (token_begin != first_token_begin) {
+        completion_candidates.clear();
+        return;
+    }
+
+    std::size_t token_end = cursor;
+    while (token_end < buffer.size() && buffer[token_end] != ' ' && buffer[token_end] != '\t' &&
+           buffer[token_end] != '=') {
+        ++token_end;
+    }
+    const std::string_view input_prefix = buffer.substr(token_begin, cursor - token_begin);
+    completion_candidates               = model.GetCandidates(input_prefix);
+    if (completion_candidates.empty()) {
+        return;
+    }
+
+    const std::size_t prefix_length = CommonPrefixLength(completion_candidates);
+    if (completion_candidates.size() == 1 || prefix_length > input_prefix.size()) {
+        const std::string_view replacement =
+            completion_candidates.size() == 1 ?
+                std::string_view(completion_candidates.front().text) :
+                std::string_view(completion_candidates.front().text).substr(0, prefix_length);
+        data.DeleteChars(static_cast<int>(token_begin), static_cast<int>(token_end - token_begin));
+        data.InsertChars(
+            static_cast<int>(token_begin), replacement.data(), replacement.data() + replacement.size()
+        );
+        if (completion_candidates.size() == 1) {
+            completion_candidates.clear();
+        }
+    }
+}
+
+void ConsolePanel::NavigateHistory(ImGuiInputTextCallbackData& data, bool previous) {
+    const auto& history = model.GetHistory();
+    if (history.empty()) {
+        return;
+    }
+
+    if (previous) {
+        if (history_position < 0) {
+            history_draft.assign(data.Buf, static_cast<std::size_t>(data.BufTextLen));
+            history_position = static_cast<int>(history.size()) - 1;
+        } else if (history_position > 0) {
+            --history_position;
+        }
+    } else if (history_position >= 0) {
+        ++history_position;
+        if (history_position >= static_cast<int>(history.size())) {
+            history_position = -1;
+        }
+    } else {
+        return;
+    }
+
+    const std::string_view replacement =
+        history_position >= 0 ? std::string_view(history[static_cast<std::size_t>(history_position)]) :
+                                std::string_view(history_draft);
+    data.DeleteChars(0, data.BufTextLen);
+    data.InsertChars(0, replacement.data(), replacement.data() + replacement.size());
+    completion_candidates.clear();
+}
+
+ImVec4 ConsolePanel::LineColor(EConsoleSessionLevel level) noexcept {
+    switch (level) {
+        case EConsoleSessionLevel::Trace:
+            return ImVec4(0.58f, 0.58f, 0.58f, 1.0f);
+        case EConsoleSessionLevel::Debug:
+            return ImVec4(0.65f, 0.72f, 0.82f, 1.0f);
+        case EConsoleSessionLevel::Warning:
+            return ImVec4(1.0f, 0.78f, 0.20f, 1.0f);
+        case EConsoleSessionLevel::Error:
+            return ImVec4(1.0f, 0.38f, 0.32f, 1.0f);
+        case EConsoleSessionLevel::Critical:
+            return ImVec4(1.0f, 0.18f, 0.18f, 1.0f);
+        case EConsoleSessionLevel::Info:
+            return ImGui::GetStyleColorVec4(ImGuiCol_Text);
+    }
+    return ImGui::GetStyleColorVec4(ImGuiCol_Text);
+}
+
+const char* ConsolePanel::SourceLabel(EConsoleSessionSource source) noexcept {
+    switch (source) {
+        case EConsoleSessionSource::Log:
+            return "[Log]";
+        case EConsoleSessionSource::Command:
+            return "[Cmd]";
+        case EConsoleSessionSource::Session:
+            return "[Session]";
+    }
+    return "[Console]";
+}
+
+} // namespace Moer

--- a/source/editor/console/ConsolePanel.cpp
+++ b/source/editor/console/ConsolePanel.cpp
@@ -39,6 +39,7 @@ std::size_t CommonPrefixLength(const std::vector<Command::CommandCandidate>& can
 ConsolePanel::ConsolePanel(std::shared_ptr<EngineCommandEndpoint> endpoint) : model(std::move(endpoint)) {}
 
 void ConsolePanel::ShowWindow(bool* open) {
+    input_active = false;
     static_cast<void>(model.Pump());
     if (!ImGui::Begin("Console", open)) {
         ImGui::End();
@@ -119,6 +120,7 @@ void ConsolePanel::ShowWindow(bool* open) {
         &ConsolePanel::InputCallback,
         this
     );
+    input_active = ImGui::IsItemActive() || ImGui::IsItemFocused();
     ImGui::PopItemWidth();
     if (submitted) {
         const Command::ESubmitStatus status = model.Submit(input_buffer.data());
@@ -132,6 +134,7 @@ void ConsolePanel::ShowWindow(bool* open) {
     }
     if (reclaim_input_focus) {
         ImGui::SetKeyboardFocusHere(-1);
+        input_active        = true;
         reclaim_input_focus = false;
     }
 

--- a/source/editor/console/ConsolePanel.h
+++ b/source/editor/console/ConsolePanel.h
@@ -17,6 +17,10 @@ public:
 
     void ShowWindow(bool* open);
 
+    [[nodiscard]] bool IsInputActive() const noexcept {
+        return input_active;
+    }
+
 private:
     static int InputCallback(ImGuiInputTextCallbackData* data);
     int        HandleInputCallback(ImGuiInputTextCallbackData& data);
@@ -34,6 +38,7 @@ private:
     std::string                            history_draft;
     bool                                   auto_scroll         = true;
     bool                                   reclaim_input_focus = false;
+    bool                                   input_active        = false;
 };
 
 } // namespace Moer

--- a/source/editor/console/ConsolePanel.h
+++ b/source/editor/console/ConsolePanel.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include "console/ConsoleSessionModel.h"
+
+#include <array>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include <imgui.h>
+
+namespace Moer {
+
+class ConsolePanel {
+public:
+    explicit ConsolePanel(std::shared_ptr<EngineCommandEndpoint> endpoint);
+
+    void ShowWindow(bool* open);
+
+private:
+    static int InputCallback(ImGuiInputTextCallbackData* data);
+    int        HandleInputCallback(ImGuiInputTextCallbackData& data);
+    void       CompleteInput(ImGuiInputTextCallbackData& data);
+    void       NavigateHistory(ImGuiInputTextCallbackData& data, bool previous);
+
+    static ImVec4      LineColor(EConsoleSessionLevel level) noexcept;
+    static const char* SourceLabel(EConsoleSessionSource source) noexcept;
+
+    ConsoleSessionModel                    model;
+    ImGuiTextFilter                        filter;
+    std::array<char, 1024>                 input_buffer{};
+    std::vector<Command::CommandCandidate> completion_candidates;
+    int                                    history_position = -1;
+    std::string                            history_draft;
+    bool                                   auto_scroll         = true;
+    bool                                   reclaim_input_focus = false;
+};
+
+} // namespace Moer

--- a/source/editor/console/ConsoleSessionModel.cpp
+++ b/source/editor/console/ConsoleSessionModel.cpp
@@ -1,0 +1,199 @@
+#include "console/ConsoleSessionModel.h"
+
+#include "log/LogSystem.h"
+
+#include <limits>
+#include <stdexcept>
+#include <utility>
+
+namespace Moer {
+
+namespace {
+
+EConsoleSessionLevel ToSessionLevel(spdlog::level::level_enum level) noexcept {
+    switch (level) {
+        case spdlog::level::trace:
+            return EConsoleSessionLevel::Trace;
+        case spdlog::level::debug:
+            return EConsoleSessionLevel::Debug;
+        case spdlog::level::warn:
+            return EConsoleSessionLevel::Warning;
+        case spdlog::level::err:
+            return EConsoleSessionLevel::Error;
+        case spdlog::level::critical:
+            return EConsoleSessionLevel::Critical;
+        case spdlog::level::info:
+        case spdlog::level::off:
+        case spdlog::level::n_levels:
+            return EConsoleSessionLevel::Info;
+    }
+    return EConsoleSessionLevel::Info;
+}
+
+void DiscardLogLine(const LogSystem::ConsoleLogEntryView&, void*) {}
+
+std::shared_ptr<EngineCommandEndpoint> RequireEndpoint(std::shared_ptr<EngineCommandEndpoint> endpoint) {
+    if (!endpoint) {
+        throw std::invalid_argument("ConsoleSessionModel requires a valid EngineCommandEndpoint.");
+    }
+    return endpoint;
+}
+
+} // namespace
+
+ConsoleSessionModel::ConsoleSessionModel(
+    std::shared_ptr<EngineCommandEndpoint> _endpoint,
+    ConsoleSessionLimits                   _limits
+) :
+    endpoint(RequireEndpoint(std::move(_endpoint))),
+    limits({
+        .display_capacity = _limits.display_capacity == 0 ? 1 : _limits.display_capacity,
+        .history_capacity = _limits.history_capacity == 0 ? 1 : _limits.history_capacity,
+    }) {}
+
+ConsoleSessionPumpResult ConsoleSessionModel::Pump(std::size_t max_log_lines, std::size_t max_command_lines) {
+    ConsoleSessionPumpResult pump_result;
+
+    struct LogVisitorContext {
+        struct Entry {
+            std::uint64_t        sequence = 0;
+            EConsoleSessionLevel level    = EConsoleSessionLevel::Info;
+            std::string          text;
+        };
+        std::vector<Entry> entries;
+    } log_context;
+    const LogSystem::ConsoleLogPollResult log_result = LogSystem::VisitConsoleLogs(
+        next_log_sequence,
+        max_log_lines,
+        [](const LogSystem::ConsoleLogEntryView& entry, void* context) {
+            auto& visitor_context = *static_cast<LogVisitorContext*>(context);
+            visitor_context.entries.push_back({
+                .sequence = entry.sequence,
+                .level    = ToSessionLevel(entry.level),
+                .text     = std::string(entry.message),
+            });
+        },
+        &log_context
+    );
+    next_log_sequence             = log_result.next_sequence;
+    pump_result.log_lines         = log_context.entries.size();
+    pump_result.dropped_log_lines = log_result.dropped_count;
+    if (log_result.dropped_count != 0) {
+        Append(
+            EConsoleSessionSource::Session,
+            EConsoleSessionLevel::Warning,
+            0,
+            "[console] " + std::to_string(log_result.dropped_count) +
+                " log line(s) were overwritten before this session could read them."
+        );
+    }
+    for (auto& entry : log_context.entries) {
+        Append(EConsoleSessionSource::Log, entry.level, entry.sequence, std::move(entry.text));
+    }
+
+    Command::CommandOutputBatch command_batch =
+        endpoint->PollOutput(next_command_sequence, max_command_lines);
+    next_command_sequence             = command_batch.next_sequence;
+    pump_result.command_lines         = command_batch.lines.size();
+    pump_result.dropped_command_lines = command_batch.dropped_count;
+    if (command_batch.dropped_count != 0) {
+        Append(
+            EConsoleSessionSource::Session,
+            EConsoleSessionLevel::Warning,
+            0,
+            "[console] " + std::to_string(command_batch.dropped_count) +
+                " command output line(s) were overwritten before this session could read them."
+        );
+    }
+    for (auto& entry : command_batch.lines) {
+        Append(
+            EConsoleSessionSource::Command, EConsoleSessionLevel::Info, entry.sequence, std::move(entry.text)
+        );
+    }
+
+    return pump_result;
+}
+
+Command::ESubmitStatus ConsoleSessionModel::Submit(std::string_view text) {
+    text = Trim(text);
+    if (text.empty()) {
+        return Command::ESubmitStatus::Empty;
+    }
+
+    const Command::ESubmitStatus status = endpoint->SubmitText(text);
+    if (status == Command::ESubmitStatus::Accepted) {
+        const std::string command(text);
+        if (history.empty() || history.back() != command) {
+            history.push_back(command);
+            while (history.size() > limits.history_capacity) {
+                history.pop_front();
+            }
+        }
+        Append(EConsoleSessionSource::Session, EConsoleSessionLevel::Info, 0, "> " + command);
+    } else if (status == Command::ESubmitStatus::QueueFull) {
+        Append(
+            EConsoleSessionSource::Session,
+            EConsoleSessionLevel::Error,
+            0,
+            "[console] Command queue is full; the command was not submitted."
+        );
+    } else if (status == Command::ESubmitStatus::Closed) {
+        Append(
+            EConsoleSessionSource::Session,
+            EConsoleSessionLevel::Error,
+            0,
+            "[console] Engine command admission is closed."
+        );
+    }
+    return status;
+}
+
+void ConsoleSessionModel::Clear() {
+    lines.clear();
+
+    const LogSystem::ConsoleLogPollResult log_result = LogSystem::VisitConsoleLogs(
+        next_log_sequence, (std::numeric_limits<std::size_t>::max)(), &DiscardLogLine, nullptr
+    );
+    next_log_sequence = log_result.next_sequence;
+
+    const Command::CommandOutputBatch command_batch =
+        endpoint->PollOutput(next_command_sequence, (std::numeric_limits<std::size_t>::max)());
+    next_command_sequence = command_batch.next_sequence;
+}
+
+std::vector<Command::CommandCandidate>
+ConsoleSessionModel::GetCandidates(std::string_view input, std::size_t max_count) const {
+    return endpoint->GetCandidates(input, max_count);
+}
+
+void ConsoleSessionModel::Append(
+    EConsoleSessionSource source,
+    EConsoleSessionLevel  level,
+    std::uint64_t         source_sequence,
+    std::string           text
+) {
+    lines.push_back({
+        .session_sequence = next_session_sequence++,
+        .source_sequence  = source_sequence,
+        .source           = source,
+        .level            = level,
+        .text             = std::move(text),
+    });
+    while (lines.size() > limits.display_capacity) {
+        lines.pop_front();
+    }
+}
+
+std::string_view ConsoleSessionModel::Trim(std::string_view text) noexcept {
+    while (!text.empty() &&
+           (text.front() == ' ' || text.front() == '\t' || text.front() == '\r' || text.front() == '\n')) {
+        text.remove_prefix(1);
+    }
+    while (!text.empty() &&
+           (text.back() == ' ' || text.back() == '\t' || text.back() == '\r' || text.back() == '\n')) {
+        text.remove_suffix(1);
+    }
+    return text;
+}
+
+} // namespace Moer

--- a/source/editor/console/ConsoleSessionModel.h
+++ b/source/editor/console/ConsoleSessionModel.h
@@ -1,0 +1,97 @@
+#pragma once
+
+#include "EngineConsoleControl.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <deque>
+#include <memory>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace Moer {
+
+enum class EConsoleSessionSource : std::uint8_t {
+    Session,
+    Log,
+    Command,
+};
+
+enum class EConsoleSessionLevel : std::uint8_t {
+    Trace,
+    Debug,
+    Info,
+    Warning,
+    Error,
+    Critical,
+};
+
+struct ConsoleSessionLine {
+    std::uint64_t         session_sequence = 0;
+    std::uint64_t         source_sequence  = 0;
+    EConsoleSessionSource source           = EConsoleSessionSource::Session;
+    EConsoleSessionLevel  level            = EConsoleSessionLevel::Info;
+    std::string           text;
+};
+
+struct ConsoleSessionLimits {
+    std::size_t display_capacity = 2048;
+    std::size_t history_capacity = 128;
+};
+
+struct ConsoleSessionPumpResult {
+    std::size_t   log_lines             = 0;
+    std::size_t   command_lines         = 0;
+    std::uint64_t dropped_log_lines     = 0;
+    std::uint64_t dropped_command_lines = 0;
+};
+
+// Editor-owned, Game-Thread session state. The Core log and command channels
+// retain independent sequence domains; session_sequence only records this
+// model's deterministic display order (logs first, then command output per
+// Pump call) and does not claim a cross-source global timeline.
+class ConsoleSessionModel {
+public:
+    explicit ConsoleSessionModel(
+        std::shared_ptr<EngineCommandEndpoint> endpoint,
+        ConsoleSessionLimits                   limits = {}
+    );
+
+    [[nodiscard]] ConsoleSessionPumpResult
+    Pump(std::size_t max_log_lines = 256, std::size_t max_command_lines = 256);
+    [[nodiscard]] Command::ESubmitStatus Submit(std::string_view text);
+
+    // Clear is local to this Editor session. It also advances both source
+    // cursors to their current tails without deleting globally retained data.
+    void Clear();
+
+    [[nodiscard]] std::vector<Command::CommandCandidate>
+    GetCandidates(std::string_view input, std::size_t max_count = 64) const;
+
+    [[nodiscard]] const std::deque<ConsoleSessionLine>& GetLines() const noexcept {
+        return lines;
+    }
+    [[nodiscard]] const std::deque<std::string>& GetHistory() const noexcept {
+        return history;
+    }
+
+private:
+    void Append(
+        EConsoleSessionSource source,
+        EConsoleSessionLevel  level,
+        std::uint64_t         source_sequence,
+        std::string           text
+    );
+    static std::string_view Trim(std::string_view text) noexcept;
+
+    std::shared_ptr<EngineCommandEndpoint> endpoint;
+    ConsoleSessionLimits                   limits;
+    std::deque<ConsoleSessionLine>         lines;
+    std::deque<std::string>                history;
+    std::uint64_t                          next_session_sequence = 1;
+    std::uint64_t                          next_log_sequence     = 1;
+    std::uint64_t                          next_command_sequence = 1;
+};
+
+} // namespace Moer

--- a/source/editor/raytracing_ui/RaytracingUI.cpp
+++ b/source/editor/raytracing_ui/RaytracingUI.cpp
@@ -270,7 +270,7 @@ void RaytracingUI::ShowConfig() {
     ImGui::Text("Directional Light Config");
     m_config.sun_direction = Normalizef(m_config.sun_direction);
     ImGui::SliderFloat3("Sun Direction", &m_config.sun_direction.x, -1.0f, 1.0f);
-    ImGui::SliderFloat("Exposure", &m_config.exposure, 0.0f, 10.0f);
+    ImGui::SliderFloat("Intensity", &m_config.directional_light_intensity, 0.0f, 10.0f);
 
     ImGui::Separator();
     ImGui::Text("Capture Settings");

--- a/source/runtime/Engine.cpp
+++ b/source/runtime/Engine.cpp
@@ -1,6 +1,8 @@
 #include "Engine.h"
+#include "EngineConsoleControl.h"
 
 // Runtime
+#include "config/CVarSystem.h"
 #include "config/ConfigManager.h"
 #include "misc/Assert.h"
 #include "misc/ScopedLogTimer.h"
@@ -1268,6 +1270,49 @@ void Engine::Init(
         );
     }
 
+    m_console_control = MakeUnique<EngineConsoleControl>(
+        EngineConsoleStartupConfig{
+            .render_thread = config.engine.threading.render_thread,
+            .rhi_thread = config.engine.threading.rhi_thread,
+            .rhi_bypass = config.engine.threading.rhi_bypass,
+            .profile_logging = config.engine.threading.profile_logging,
+            .parallel_recording =
+                config.engine.threading.parallel_recording,
+            .parallel_record_workers =
+                config.engine.threading.parallel_record_workers,
+            .parallel_record_verify =
+                config.engine.threading.parallel_record_verify,
+            .parallel_record_profile =
+                config.engine.threading.parallel_record_profile,
+            .parallel_record_min_work_units_per_job =
+                config.engine.threading.parallel_record_min_work_units_per_job,
+            .configured_submission_batch_window =
+                config.engine.threading.submission_batch_window,
+            .rhi_heartbeat_enabled =
+                config.engine.threading.rhi_heartbeat_enabled,
+            .rhi_heartbeat_stall_timeout_ms =
+                config.engine.threading.rhi_heartbeat_stall_timeout_ms,
+            .rhi_heartbeat_poll_interval_ms =
+                config.engine.threading.rhi_heartbeat_poll_interval_ms,
+            .max_frame_lag = config.engine.threading.max_frame_lag,
+            .max_frames_in_flight = config.engine.rhi.max_frame_in_flight,
+            .raster_rdg_enabled =
+                config.engine.render.raster.render_graph,
+            .raster_rdg_debug_dump =
+                config.engine.render.raster.render_graph_debug_dump,
+            .raster_rdg_parallel_recording =
+                config.engine.render.raster.render_graph_parallel_recording,
+            .raytracing_rdg_enabled =
+                config.engine.render.raytracing.render_graph,
+            .raytracing_rdg_debug_dump =
+                config.engine.render.raytracing.render_graph_debug_dump,
+            .raytracing_rdg_parallel_recording =
+                config.engine.render.raytracing.render_graph_parallel_recording,
+        },
+        submission_batch_window
+    );
+    CVar::SealStartupOnlyCVars();
+
     try {
         // Renderers retain this facade pointer for their whole lifetime.
         // Individual ProfileDump generations bind and unbind session state
@@ -1406,6 +1451,7 @@ void Engine::Init(
     m_editor_config->selected_render_method =
         ParseDefaultRenderMethod(config.engine.render.default_render_method);
     m_editor_config->scene_path = config.engine.scene.scene_path;
+    m_console_control->BindEditorConfig(*m_editor_config);
     if (raster_framebuffer_validation.has_value()) {
         m_editor_config->validation_selected_frame_buffer_name =
             *raster_framebuffer_validation;
@@ -1511,6 +1557,18 @@ void Engine::Run(const EngineHooks& hooks) {
             }
             if (callback) {
                 callback();
+            }
+        };
+    auto on_tick_ui = std::move(runtime_hooks.on_tick_ui);
+    runtime_hooks.on_tick_ui =
+        [this, callback = std::move(on_tick_ui)](Scene& scene) {
+            if (callback) {
+                callback(scene);
+            }
+            if (m_console_control && m_editor_config) {
+                static_cast<void>(
+                    m_console_control->TickGameThread(*m_editor_config)
+                );
             }
         };
     runtime_hooks.on_tick_scripting = [this](Scene& scene) {
@@ -1899,6 +1957,15 @@ Render::ProfileCaptureControllerSnapshot Engine::GetProfileCaptureSnapshot() con
     return snapshot;
 }
 
+SharedPtr<EngineCommandEndpoint> Engine::GetCommandEndpoint() const {
+    if (!m_console_control) {
+        throw std::logic_error(
+            "Engine command processor is unavailable before Engine::Init or after shutdown."
+        );
+    }
+    return m_console_control->GetCommandEndpoint();
+}
+
 void Engine::ShutDown() noexcept {
     if (m_has_shutdown) {
         return;
@@ -2090,6 +2157,7 @@ void Engine::ShutDown() noexcept {
             );
         }
     }
+    m_console_control.reset();
     m_editor_config.reset();
 }
 

--- a/source/runtime/Engine.h
+++ b/source/runtime/Engine.h
@@ -22,6 +22,8 @@ class RemoteModule;
 namespace Moer {
 
 class EditorUI;
+class EngineCommandEndpoint;
+class EngineConsoleControl;
 class RuntimeAssets;
 class RenderThreadService;
 
@@ -64,6 +66,8 @@ public:
         return m_editor_config;
     }
 
+    [[nodiscard]] SharedPtr<EngineCommandEndpoint> GetCommandEndpoint() const;
+
 private:
     enum class ERendererSwitchValidationStage : uint8 {
         Disabled,
@@ -98,9 +102,10 @@ private:
     void TickRasterLifecycleValidation(Scene& scene);
     bool ConsumeRendererSwitchValidationReloadRequest();
 
-    SharedPtr<EditorConfig>      m_editor_config;
-    Render::SwapchainSurfaceInfo m_main_window_surface;
-    UniquePtr<RuntimeAssets>     m_runtime_assets;
+    SharedPtr<EditorConfig>         m_editor_config;
+    UniquePtr<EngineConsoleControl> m_console_control;
+    Render::SwapchainSurfaceInfo    m_main_window_surface;
+    UniquePtr<RuntimeAssets>        m_runtime_assets;
 
     UniquePtr<scripting::ScriptHost> m_script_host;
     UniquePtr<remote::RemoteModule>  m_remote_module;

--- a/source/runtime/EngineConsoleControl.cpp
+++ b/source/runtime/EngineConsoleControl.cpp
@@ -261,7 +261,7 @@ struct EngineConsoleControl::Impl {
             std::scoped_lock lock(live_mutex);
             bloom.applied               = config.raster_config.bloom_enabled;
             raster_exposure.applied     = config.raster_config.tonemapping_exposure_ev;
-            raytracing_exposure.applied = config.raytracing_config.exposure;
+            raytracing_exposure.applied = config.raytracing_config.tone_mapping_cfg.exposure_bias;
         }
 
         auto bloom_result = CVar::RegisterBool(
@@ -299,13 +299,13 @@ struct EngineConsoleControl::Impl {
 
         auto raytracing_exposure_result = CVar::RegisterFloat(
             MakeDescriptor(
-                "Render.Raytracing.Exposure",
-                "Raytracing presentation exposure multiplier.",
+                "Render.Raytracing.Tonemapping.ExposureBiasEV",
+                "Raytracing tonemapping exposure bias in EV stops.",
                 CVar::EFlags::None,
-                0.0,
+                -10.0,
                 10.0
             ),
-            config.raytracing_config.exposure,
+            config.raytracing_config.tone_mapping_cfg.exposure_bias,
             [this](double, double new_value) {
                 std::scoped_lock lock(live_mutex);
                 raytracing_exposure.pending = new_value;
@@ -314,7 +314,7 @@ struct EngineConsoleControl::Impl {
         RequireLiveRegistration(
             raytracing_exposure_registration,
             std::move(raytracing_exposure_result),
-            "Render.Raytracing.Exposure"
+            "Render.Raytracing.Tonemapping.ExposureBiasEV"
         );
     }
 
@@ -359,7 +359,8 @@ struct EngineConsoleControl::Impl {
                 raster_exposure.applied = current_raster_exposure;
             }
         }
-        const double current_raytracing_exposure = static_cast<double>(config.raytracing_config.exposure);
+        const double current_raytracing_exposure =
+            static_cast<double>(config.raytracing_config.tone_mapping_cfg.exposure_bias);
         if (!raytracing_exposure.pending.has_value() &&
             current_raytracing_exposure != raytracing_exposure.applied) {
             const auto result =
@@ -386,8 +387,10 @@ struct EngineConsoleControl::Impl {
             raster_exposure.pending.reset();
         }
         if (raytracing_exposure.pending.has_value()) {
-            config.raytracing_config.exposure = static_cast<float>(*raytracing_exposure.pending);
-            const double applied              = static_cast<double>(config.raytracing_config.exposure);
+            config.raytracing_config.tone_mapping_cfg.exposure_bias =
+                static_cast<float>(*raytracing_exposure.pending);
+            const double applied =
+                static_cast<double>(config.raytracing_config.tone_mapping_cfg.exposure_bias);
             static_cast<void>(raytracing_exposure_registration.SynchronizeOwnerValue(applied));
             raytracing_exposure.applied = applied;
             raytracing_exposure.pending.reset();

--- a/source/runtime/EngineConsoleControl.cpp
+++ b/source/runtime/EngineConsoleControl.cpp
@@ -1,0 +1,439 @@
+#include "EngineConsoleControl.h"
+
+#include "command/EngineCommandProcessor.h"
+#include "config/CVarSystem.h"
+#include "renderer/EditorConfig.h"
+
+#include <cstdint>
+#include <mutex>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+namespace Moer {
+
+namespace {
+
+constexpr CVar::EFlags kStartupReadOnlyFlags = CVar::EFlags::ReadOnly | CVar::EFlags::StartupOnly;
+
+CVar::CVarDescriptor MakeDescriptor(
+    std::string           name,
+    std::string           helper,
+    CVar::EFlags          flags     = CVar::EFlags::None,
+    std::optional<double> min_value = std::nullopt,
+    std::optional<double> max_value = std::nullopt
+) {
+    return {
+        .name      = std::move(name),
+        .helper    = std::move(helper),
+        .flags     = flags,
+        .min_value = min_value,
+        .max_value = max_value,
+    };
+}
+
+void RequireRegistration(
+    std::vector<CVar::Registration>& registrations,
+    CVar::RegistrationResult         result,
+    std::string_view                 name
+) {
+    if (!result.Succeeded()) {
+        throw std::runtime_error(
+            "Failed to register console variable '" + std::string(name) +
+            "': " + (result.detail != nullptr ? result.detail : "unknown error")
+        );
+    }
+    registrations.push_back(std::move(result.registration));
+}
+
+template<typename Value>
+struct LiveValueState {
+    Value                applied{};
+    std::optional<Value> pending;
+};
+
+} // namespace
+
+struct EngineCommandEndpoint::Impl {
+    explicit Impl(Command::EngineCommandProcessorLimits limits) : processor(limits) {}
+
+    mutable std::recursive_mutex    mutex;
+    bool                            accepting = true;
+    Command::EngineCommandProcessor processor;
+};
+
+EngineCommandEndpoint::EngineCommandEndpoint(Command::EngineCommandProcessorLimits limits) :
+    impl(std::make_unique<Impl>(limits)) {}
+
+EngineCommandEndpoint::~EngineCommandEndpoint() = default;
+
+Command::ESubmitStatus EngineCommandEndpoint::SubmitText(std::string_view text) {
+    std::scoped_lock lock(impl->mutex);
+    if (!impl->accepting) {
+        return Command::ESubmitStatus::Closed;
+    }
+    return impl->processor.SubmitText(text);
+}
+
+Command::CommandOutputBatch
+EngineCommandEndpoint::PollOutput(std::uint64_t next_sequence, std::size_t max_count) const {
+    std::scoped_lock lock(impl->mutex);
+    return impl->processor.PollOutput(next_sequence, max_count);
+}
+
+std::vector<Command::CommandCandidate>
+EngineCommandEndpoint::GetCandidates(std::string_view input, std::size_t max_count) const {
+    std::scoped_lock lock(impl->mutex);
+    return impl->processor.GetCandidates(input, max_count);
+}
+
+bool EngineCommandEndpoint::IsAccepting() const noexcept {
+    std::scoped_lock lock(impl->mutex);
+    return impl->accepting;
+}
+
+Command::ProcessPendingResult EngineCommandEndpoint::ProcessPending(std::size_t max_commands) {
+    std::scoped_lock lock(impl->mutex);
+    return impl->processor.ProcessPending(max_commands);
+}
+
+void EngineCommandEndpoint::CloseAdmission() noexcept {
+    std::scoped_lock lock(impl->mutex);
+    impl->accepting = false;
+}
+
+struct EngineConsoleControl::Impl {
+    explicit Impl(
+        const EngineConsoleStartupConfig& config,
+        unsigned int                      policy_clamped_submission_batch_window
+    ) {
+        RegisterStartupVariables(config, policy_clamped_submission_batch_window);
+    }
+
+    void RegisterStartupVariables(
+        const EngineConsoleStartupConfig& config,
+        unsigned int                      policy_clamped_submission_batch_window
+    ) {
+        const auto register_bool = [this](std::string name, std::string helper, bool value) {
+            const std::string registered_name = name;
+            RequireRegistration(
+                startup_registrations,
+                CVar::RegisterBool(
+                    MakeDescriptor(std::move(name), std::move(helper), kStartupReadOnlyFlags), value
+                ),
+                registered_name
+            );
+        };
+        const auto register_int = [this](std::string name, std::string helper, std::int64_t value) {
+            const std::string registered_name = name;
+            RequireRegistration(
+                startup_registrations,
+                CVar::RegisterInt(
+                    MakeDescriptor(std::move(name), std::move(helper), kStartupReadOnlyFlags), value
+                ),
+                registered_name
+            );
+        };
+
+        register_bool(
+            "Engine.Threading.RenderThread.Configured",
+            "Configured request for a dedicated Render Thread.",
+            config.render_thread
+        );
+        register_bool(
+            "Engine.Threading.RHIThread.Configured",
+            "Configured request for a dedicated RHI thread; bypass and backend policy may disable it.",
+            config.rhi_thread
+        );
+        register_bool(
+            "Engine.Threading.RHIBypass.Configured",
+            "Configured request to bypass queued RHI translation.",
+            config.rhi_bypass
+        );
+        register_bool(
+            "Engine.Threading.ProfileLogging.Configured",
+            "Configured request for periodic threading profile diagnostics.",
+            config.profile_logging
+        );
+        register_int(
+            "Engine.Threading.MaxFrameLag.Configured",
+            "Configured maximum Render Thread frame lag; runtime policy may clamp it.",
+            config.max_frame_lag
+        );
+        register_bool(
+            "RHI.CommandRecording.Parallel.Configured",
+            "Configured request for parallel backend command-list translation/recording.",
+            config.parallel_recording
+        );
+        register_int(
+            "RHI.CommandRecording.Parallel.Workers.Configured",
+            "Configured parallel command-recording worker count; zero selects the runtime default.",
+            config.parallel_record_workers
+        );
+        register_bool(
+            "RHI.CommandRecording.Parallel.Verify.Configured",
+            "Whether parallel command recording runs verification checks.",
+            config.parallel_record_verify
+        );
+        register_bool(
+            "RHI.CommandRecording.Parallel.Profile.Configured",
+            "Whether parallel command recording emits profiling diagnostics.",
+            config.parallel_record_profile
+        );
+        register_int(
+            "RHI.CommandRecording.Parallel.MinWorkUnitsPerJob.Configured",
+            "Minimum estimated work units assigned to each parallel recording job.",
+            config.parallel_record_min_work_units_per_job
+        );
+        register_int(
+            "RHI.Submission.BatchWindow.Configured",
+            "Configured bounded submission batch window before policy clamping.",
+            config.configured_submission_batch_window
+        );
+        register_int(
+            "RHI.Submission.BatchWindow.PolicyClamped",
+            "Startup request after the generic [1, 8] policy clamp; native queue aliasing may reduce the "
+            "effective window further.",
+            policy_clamped_submission_batch_window
+        );
+        register_bool(
+            "RHI.Heartbeat.Enabled.Configured",
+            "Configured request for the RHI ownership heartbeat watchdog.",
+            config.rhi_heartbeat_enabled
+        );
+        register_int(
+            "RHI.Heartbeat.StallTimeoutMs.Configured",
+            "Configured RHI heartbeat stall timeout in milliseconds.",
+            config.rhi_heartbeat_stall_timeout_ms
+        );
+        register_int(
+            "RHI.Heartbeat.PollIntervalMs.Configured",
+            "Configured RHI heartbeat polling interval in milliseconds.",
+            config.rhi_heartbeat_poll_interval_ms
+        );
+        register_int(
+            "RHI.MaxFramesInFlight.Configured",
+            "Configured maximum frames in flight.",
+            config.max_frames_in_flight
+        );
+
+        const auto register_rdg =
+            [&register_bool](
+                std::string_view prefix, bool enabled, bool debug_dump, bool parallel_recording
+            ) {
+                register_bool(
+                    std::string(prefix) + ".Enabled.Configured",
+                    "Configured request for the compiled Render Dependency Graph path.",
+                    enabled
+                );
+                register_bool(
+                    std::string(prefix) + ".DebugDump.Configured",
+                    "Whether the renderer emits compiled RDG diagnostic dumps.",
+                    debug_dump
+                );
+                register_bool(
+                    std::string(prefix) + ".ParallelRecording.Configured",
+                    "Configured request to record eligible compiled RDG waves in parallel.",
+                    parallel_recording
+                );
+            };
+        register_rdg(
+            "Render.Raster.RDG",
+            config.raster_rdg_enabled,
+            config.raster_rdg_debug_dump,
+            config.raster_rdg_parallel_recording
+        );
+        register_rdg(
+            "Render.Raytracing.RDG",
+            config.raytracing_rdg_enabled,
+            config.raytracing_rdg_debug_dump,
+            config.raytracing_rdg_parallel_recording
+        );
+    }
+
+    void BindEditorConfig(EditorConfig& config) {
+        UnbindEditorConfig();
+
+        {
+            std::scoped_lock lock(live_mutex);
+            bloom.applied               = config.raster_config.bloom_enabled;
+            raster_exposure.applied     = config.raster_config.tonemapping_exposure_ev;
+            raytracing_exposure.applied = config.raytracing_config.exposure;
+        }
+
+        auto bloom_result = CVar::RegisterBool(
+            MakeDescriptor(
+                "Render.Raster.Bloom.Enabled",
+                "Enable or disable Raster bloom for subsequent frame snapshots."
+            ),
+            config.raster_config.bloom_enabled,
+            [this](bool, bool new_value) {
+                std::scoped_lock lock(live_mutex);
+                bloom.pending = new_value;
+            }
+        );
+        RequireLiveRegistration(bloom_registration, std::move(bloom_result), "Render.Raster.Bloom.Enabled");
+
+        auto raster_exposure_result = CVar::RegisterFloat(
+            MakeDescriptor(
+                "Render.Raster.Tonemapping.ExposureEV",
+                "Raster tonemapping exposure in EV stops.",
+                CVar::EFlags::None,
+                -15.0,
+                10.0
+            ),
+            config.raster_config.tonemapping_exposure_ev,
+            [this](double, double new_value) {
+                std::scoped_lock lock(live_mutex);
+                raster_exposure.pending = new_value;
+            }
+        );
+        RequireLiveRegistration(
+            raster_exposure_registration,
+            std::move(raster_exposure_result),
+            "Render.Raster.Tonemapping.ExposureEV"
+        );
+
+        auto raytracing_exposure_result = CVar::RegisterFloat(
+            MakeDescriptor(
+                "Render.Raytracing.Exposure",
+                "Raytracing presentation exposure multiplier.",
+                CVar::EFlags::None,
+                0.0,
+                10.0
+            ),
+            config.raytracing_config.exposure,
+            [this](double, double new_value) {
+                std::scoped_lock lock(live_mutex);
+                raytracing_exposure.pending = new_value;
+            }
+        );
+        RequireLiveRegistration(
+            raytracing_exposure_registration,
+            std::move(raytracing_exposure_result),
+            "Render.Raytracing.Exposure"
+        );
+    }
+
+    void RequireLiveRegistration(
+        CVar::Registration&      destination,
+        CVar::RegistrationResult result,
+        std::string_view         name
+    ) {
+        if (!result.Succeeded()) {
+            UnbindEditorConfig();
+            throw std::runtime_error(
+                "Failed to register live console variable '" + std::string(name) +
+                "': " + (result.detail != nullptr ? result.detail : "unknown error")
+            );
+        }
+        destination = std::move(result.registration);
+    }
+
+    void UnbindEditorConfig() noexcept {
+        raytracing_exposure_registration.Reset();
+        raster_exposure_registration.Reset();
+        bloom_registration.Reset();
+        std::scoped_lock lock(live_mutex);
+        bloom.pending.reset();
+        raster_exposure.pending.reset();
+        raytracing_exposure.pending.reset();
+    }
+
+    void SynchronizeOwners(EditorConfig& config) {
+        std::scoped_lock lock(live_mutex);
+        if (!bloom.pending.has_value() && config.raster_config.bloom_enabled != bloom.applied) {
+            const auto result = bloom_registration.SynchronizeOwnerValue(config.raster_config.bloom_enabled);
+            if (result.Succeeded()) {
+                bloom.applied = config.raster_config.bloom_enabled;
+            }
+        }
+        const double current_raster_exposure =
+            static_cast<double>(config.raster_config.tonemapping_exposure_ev);
+        if (!raster_exposure.pending.has_value() && current_raster_exposure != raster_exposure.applied) {
+            const auto result = raster_exposure_registration.SynchronizeOwnerValue(current_raster_exposure);
+            if (result.Succeeded()) {
+                raster_exposure.applied = current_raster_exposure;
+            }
+        }
+        const double current_raytracing_exposure = static_cast<double>(config.raytracing_config.exposure);
+        if (!raytracing_exposure.pending.has_value() &&
+            current_raytracing_exposure != raytracing_exposure.applied) {
+            const auto result =
+                raytracing_exposure_registration.SynchronizeOwnerValue(current_raytracing_exposure);
+            if (result.Succeeded()) {
+                raytracing_exposure.applied = current_raytracing_exposure;
+            }
+        }
+    }
+
+    void ApplyPending(EditorConfig& config) {
+        std::scoped_lock lock(live_mutex);
+        if (bloom.pending.has_value()) {
+            config.raster_config.bloom_enabled = *bloom.pending;
+            static_cast<void>(bloom_registration.SynchronizeOwnerValue(*bloom.pending));
+            bloom.applied = *bloom.pending;
+            bloom.pending.reset();
+        }
+        if (raster_exposure.pending.has_value()) {
+            config.raster_config.tonemapping_exposure_ev = static_cast<float>(*raster_exposure.pending);
+            const double applied = static_cast<double>(config.raster_config.tonemapping_exposure_ev);
+            static_cast<void>(raster_exposure_registration.SynchronizeOwnerValue(applied));
+            raster_exposure.applied = applied;
+            raster_exposure.pending.reset();
+        }
+        if (raytracing_exposure.pending.has_value()) {
+            config.raytracing_config.exposure = static_cast<float>(*raytracing_exposure.pending);
+            const double applied              = static_cast<double>(config.raytracing_config.exposure);
+            static_cast<void>(raytracing_exposure_registration.SynchronizeOwnerValue(applied));
+            raytracing_exposure.applied = applied;
+            raytracing_exposure.pending.reset();
+        }
+    }
+
+    std::shared_ptr<EngineCommandEndpoint> command_endpoint = std::make_shared<EngineCommandEndpoint>();
+    std::vector<CVar::Registration>        startup_registrations;
+
+    std::mutex             live_mutex;
+    LiveValueState<bool>   bloom;
+    LiveValueState<double> raster_exposure;
+    LiveValueState<double> raytracing_exposure;
+    CVar::Registration     bloom_registration;
+    CVar::Registration     raster_exposure_registration;
+    CVar::Registration     raytracing_exposure_registration;
+};
+
+EngineConsoleControl::EngineConsoleControl(
+    const EngineConsoleStartupConfig& config,
+    unsigned int                      policy_clamped_submission_batch_window
+) :
+    impl(std::make_unique<Impl>(config, policy_clamped_submission_batch_window)) {}
+
+EngineConsoleControl::~EngineConsoleControl() {
+    impl->command_endpoint->CloseAdmission();
+    impl->UnbindEditorConfig();
+}
+
+void EngineConsoleControl::BindEditorConfig(EditorConfig& config) {
+    impl->BindEditorConfig(config);
+}
+
+void EngineConsoleControl::UnbindEditorConfig() noexcept {
+    impl->UnbindEditorConfig();
+}
+
+std::size_t EngineConsoleControl::TickGameThread(EditorConfig& config, std::size_t max_commands) {
+    impl->SynchronizeOwners(config);
+    const Command::ProcessPendingResult result = impl->command_endpoint->ProcessPending(max_commands);
+    impl->ApplyPending(config);
+    return result.processed;
+}
+
+std::shared_ptr<EngineCommandEndpoint> EngineConsoleControl::GetCommandEndpoint() const noexcept {
+    return impl->command_endpoint;
+}
+
+} // namespace Moer

--- a/source/runtime/EngineConsoleControl.h
+++ b/source/runtime/EngineConsoleControl.h
@@ -1,0 +1,99 @@
+#pragma once
+
+#include "RenderAPI.h"
+#include "command/EngineCommandProcessor.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <string_view>
+#include <vector>
+
+namespace Moer {
+
+struct EditorConfig;
+
+struct EngineConsoleStartupConfig {
+    bool          render_thread                          = false;
+    bool          rhi_thread                             = false;
+    bool          rhi_bypass                             = true;
+    bool          profile_logging                        = false;
+    bool          parallel_recording                     = false;
+    std::uint32_t parallel_record_workers                = 0;
+    bool          parallel_record_verify                 = false;
+    bool          parallel_record_profile                = false;
+    std::uint32_t parallel_record_min_work_units_per_job = 64;
+    std::uint32_t configured_submission_batch_window     = 2;
+    bool          rhi_heartbeat_enabled                  = false;
+    std::uint32_t rhi_heartbeat_stall_timeout_ms         = 5000;
+    std::uint32_t rhi_heartbeat_poll_interval_ms         = 1000;
+    std::uint32_t max_frame_lag                          = 0;
+    std::uint32_t max_frames_in_flight                   = 0;
+
+    bool raster_rdg_enabled                = false;
+    bool raster_rdg_debug_dump             = false;
+    bool raster_rdg_parallel_recording     = false;
+    bool raytracing_rdg_enabled            = false;
+    bool raytracing_rdg_debug_dump         = false;
+    bool raytracing_rdg_parallel_recording = false;
+};
+
+// Stable producer/reader endpoint shared by Engine and Editor. Closing
+// admission is synchronized with in-flight calls, while the underlying Core
+// processor remains alive until the final endpoint owner releases it.
+class RENDER_API EngineCommandEndpoint {
+public:
+    explicit EngineCommandEndpoint(Command::EngineCommandProcessorLimits limits = {});
+    ~EngineCommandEndpoint();
+
+    EngineCommandEndpoint(const EngineCommandEndpoint&)            = delete;
+    EngineCommandEndpoint& operator=(const EngineCommandEndpoint&) = delete;
+    EngineCommandEndpoint(EngineCommandEndpoint&&)                 = delete;
+    EngineCommandEndpoint& operator=(EngineCommandEndpoint&&)      = delete;
+
+    [[nodiscard]] Command::ESubmitStatus SubmitText(std::string_view text);
+    [[nodiscard]] Command::CommandOutputBatch
+    PollOutput(std::uint64_t next_sequence = 1, std::size_t max_count = 256) const;
+    [[nodiscard]] std::vector<Command::CommandCandidate>
+                       GetCandidates(std::string_view input, std::size_t max_count = 64) const;
+    [[nodiscard]] bool IsAccepting() const noexcept;
+
+private:
+    [[nodiscard]] Command::ProcessPendingResult ProcessPending(std::size_t max_commands);
+    void                                        CloseAdmission() noexcept;
+
+    struct Impl;
+    std::unique_ptr<Impl> impl;
+
+    friend class EngineConsoleControl;
+};
+
+// Runtime-owned console endpoint. Command submission may come from any thread,
+// but command execution and EditorConfig mutation are serialized by
+// TickGameThread.
+class RENDER_API EngineConsoleControl {
+public:
+    EngineConsoleControl(
+        const EngineConsoleStartupConfig& config,
+        unsigned int                      policy_clamped_submission_batch_window
+    );
+    ~EngineConsoleControl();
+
+    EngineConsoleControl(const EngineConsoleControl&)            = delete;
+    EngineConsoleControl& operator=(const EngineConsoleControl&) = delete;
+    EngineConsoleControl(EngineConsoleControl&&)                 = delete;
+    EngineConsoleControl& operator=(EngineConsoleControl&&)      = delete;
+
+    void BindEditorConfig(EditorConfig& config);
+    void UnbindEditorConfig() noexcept;
+
+    [[nodiscard]] std::size_t TickGameThread(EditorConfig& config, std::size_t max_commands = 64);
+
+    [[nodiscard]] std::shared_ptr<EngineCommandEndpoint> GetCommandEndpoint() const noexcept;
+
+private:
+    struct Impl;
+    std::unique_ptr<Impl> impl;
+};
+
+} // namespace Moer

--- a/source/runtime/core/include/command/EngineCommandProcessor.h
+++ b/source/runtime/core/include/command/EngineCommandProcessor.h
@@ -21,6 +21,7 @@ enum class ESubmitStatus : std::uint8_t {
     Accepted,
     Empty,
     QueueFull,
+    Closed,
 };
 
 enum class EProcessStatus : std::uint8_t {

--- a/source/runtime/render/renderer/raytracing/RaytracingConfig.h
+++ b/source/runtime/render/renderer/raytracing/RaytracingConfig.h
@@ -121,10 +121,10 @@ struct RTProcessLightConfig {
     int  num_threads   = 4;
 };
 struct RaytracingConfig {
-    float3 sun_direction        = float3(0.f, 0.5f, 0.16f);
-    float  exposure             = 6.f;
-    float  sun_angular_diameter = 0.533f;
-    uint   max_bounce           = 4;
+    float3 sun_direction               = float3(0.f, 0.5f, 0.16f);
+    float  directional_light_intensity = 6.f;
+    float  sun_angular_diameter        = 0.533f;
+    uint   max_bounce                  = 4;
 
     GridConfig           grid_config{};
     ReSTIRDIConfig       restir_di_cfg{};

--- a/source/runtime/render/renderer/raytracing/RaytracingRenderer.cpp
+++ b/source/runtime/render/renderer/raytracing/RaytracingRenderer.cpp
@@ -564,10 +564,10 @@ RaytracingRenderer::PrepareFrame(const SharedPtr<EditorConfig> editor_config, co
                 // manufacture dirty scene work every frame.
                 const auto& light = scene.r().get<ecs::CLightDirectional>(light_entity);
                 if (!EqualFloat3(light.color, desired_color) ||
-                    light.intensity != frame_packet.config.exposure) {
+                    light.intensity != frame_packet.config.directional_light_intensity) {
                     scene.Patch<ecs::CLightDirectional>(light_entity, [&](auto& patched_light) {
                         patched_light.color     = desired_color;
-                        patched_light.intensity = frame_packet.config.exposure;
+                        patched_light.intensity = frame_packet.config.directional_light_intensity;
                     });
                 }
 

--- a/source/test/CMakeLists.txt
+++ b/source/test/CMakeLists.txt
@@ -22,6 +22,49 @@ set_target_properties(${test_target} PROPERTIES FOLDER ${moer_test_folder})
 add_test(NAME ConsoleLogCoreContract COMMAND $<TARGET_FILE:${test_target}>)
 set_tests_properties(ConsoleLogCoreContract PROPERTIES TIMEOUT 60)
 
+set(test_target TestConsoleSessionModel)
+add_executable(
+    ${test_target}
+    "ConsoleSessionModelTest.cpp"
+    "${moer_source_dir}/editor/console/ConsoleSessionModel.cpp"
+)
+target_include_directories(
+    ${test_target}
+    PRIVATE "${moer_source_dir}/editor"
+)
+target_link_libraries(${test_target}
+    PRIVATE Moer::Runtime
+)
+set_target_properties(${test_target} PROPERTIES FOLDER ${moer_test_folder})
+add_test(NAME ConsoleSessionModelContract COMMAND $<TARGET_FILE:${test_target}>)
+set_tests_properties(ConsoleSessionModelContract PROPERTIES TIMEOUT 60)
+
+set(test_target TestEngineConsoleControl)
+add_executable(${test_target} "EngineConsoleControlTest.cpp")
+target_link_libraries(${test_target}
+    PRIVATE Moer::Runtime
+)
+set_target_properties(${test_target} PROPERTIES FOLDER ${moer_test_folder})
+add_test(NAME EngineConsoleControlContract COMMAND $<TARGET_FILE:${test_target}>)
+set_tests_properties(EngineConsoleControlContract PROPERTIES TIMEOUT 60)
+
+set(test_target TestEditorUISettings)
+add_executable(
+    ${test_target}
+    "EditorUISettingsTest.cpp"
+    "${moer_source_dir}/editor/EditorUISettings.cpp"
+)
+target_include_directories(
+    ${test_target}
+    PRIVATE "${moer_source_dir}/editor"
+)
+target_link_libraries(${test_target}
+    PRIVATE ImGui::imgui
+)
+set_target_properties(${test_target} PROPERTIES FOLDER ${moer_test_folder})
+add_test(NAME EditorUISettingsContract COMMAND $<TARGET_FILE:${test_target}>)
+set_tests_properties(EditorUISettingsContract PROPERTIES TIMEOUT 60)
+
 set(test_target TestFatalDiagnostics)
 add_executable(${test_target} "FatalDiagnosticsTest.cpp")
 target_include_directories(${test_target}

--- a/source/test/ConsoleSessionModelTest.cpp
+++ b/source/test/ConsoleSessionModelTest.cpp
@@ -1,0 +1,148 @@
+#include "console/ConsoleSessionModel.h"
+
+#include "config/CVarSystem.h"
+#include "log/LogSystem.h"
+#include "renderer/EditorConfig.h"
+
+#include <cstdlib>
+#include <iostream>
+#include <string>
+#include <string_view>
+
+namespace {
+
+using namespace Moer;
+
+[[noreturn]] void Fail(const char* message) {
+    std::cerr << "ConsoleSessionModelContract failed: " << message << '\n';
+    std::exit(1);
+}
+
+void Expect(bool condition, const char* message) {
+    if (!condition) {
+        Fail(message);
+    }
+}
+
+const ConsoleSessionLine* FindLine(const ConsoleSessionModel& model, std::string_view text) {
+    for (const ConsoleSessionLine& line : model.GetLines()) {
+        if (line.text.find(text) != std::string::npos) {
+            return &line;
+        }
+    }
+    return nullptr;
+}
+
+} // namespace
+
+int main() {
+    LogSystem::Init();
+
+    EngineConsoleControl control(EngineConsoleStartupConfig{}, 2);
+    EditorConfig         editor_config{};
+    control.BindEditorConfig(editor_config);
+    auto endpoint = control.GetCommandEndpoint();
+
+    ConsoleSessionModel model(endpoint, {.display_capacity = 16, .history_capacity = 3});
+    model.Clear();
+
+    LOG_INFO("ConsoleSessionModel unique log line");
+    Expect(
+        endpoint->SubmitText("/help") == Command::ESubmitStatus::Accepted &&
+            control.TickGameThread(editor_config) == 1,
+        "command output fixture failed"
+    );
+    const ConsoleSessionPumpResult initial_pump = model.Pump();
+    const ConsoleSessionLine*      log_line     = FindLine(model, "ConsoleSessionModel unique log line");
+    const ConsoleSessionLine*      command_line = FindLine(model, "Commands:");
+    Expect(
+        initial_pump.log_lines >= 1 && initial_pump.command_lines >= 1 && log_line != nullptr &&
+            command_line != nullptr && log_line->source == EConsoleSessionSource::Log &&
+            command_line->source == EConsoleSessionSource::Command && log_line->source_sequence != 0 &&
+            command_line->source_sequence != 0 && log_line->session_sequence < command_line->session_sequence,
+        "two-source pump lost identity or deterministic logs-first display order"
+    );
+
+    Expect(
+        model.Submit("  First.Command  ") == Command::ESubmitStatus::Accepted &&
+            model.Submit("Second.Command") == Command::ESubmitStatus::Accepted &&
+            model.Submit("Second.Command") == Command::ESubmitStatus::Accepted &&
+            model.Submit("Third.Command") == Command::ESubmitStatus::Accepted &&
+            model.Submit("Fourth.Command") == Command::ESubmitStatus::Accepted,
+        "session submissions were rejected"
+    );
+    const auto& history = model.GetHistory();
+    Expect(
+        history.size() == 3 && history.front() == "Second.Command" && history.back() == "Fourth.Command",
+        "history did not trim, deduplicate adjacent entries, or enforce its bound"
+    );
+    Expect(
+        model.GetLines().size() <= 16 && FindLine(model, "> Fourth.Command") != nullptr,
+        "display ring did not retain the newest bounded session line"
+    );
+
+    CVar::RegistrationResult candidate = CVar::RegisterBool(
+        CVar::CVarDescriptor{
+            .name   = "Console.Model.Candidate",
+            .helper = "session autocomplete fixture",
+        },
+        false
+    );
+    const auto candidates = model.GetCandidates("console.model");
+    Expect(
+        candidate.Succeeded() && candidates.size() == 1 &&
+            candidates.front().text == "Console.Model.Candidate",
+        "session autocomplete did not use the Core command endpoint"
+    );
+
+    while (control.TickGameThread(editor_config, 64) != 0) {
+    }
+    ConsoleSessionModel bounded_model(endpoint, {.display_capacity = 8, .history_capacity = 2});
+    bounded_model.Clear();
+    for (int index = 0; index < 255; ++index) {
+        Expect(
+            endpoint->SubmitText("/queue-fill") == Command::ESubmitStatus::Accepted,
+            "queue saturation fixture filled early"
+        );
+    }
+    Expect(
+        bounded_model.Submit("/help") == Command::ESubmitStatus::Accepted &&
+            bounded_model.Submit("/help") == Command::ESubmitStatus::QueueFull &&
+            FindLine(bounded_model, "queue is full") != nullptr,
+        "queue saturation was not surfaced as a local session diagnostic"
+    );
+    while (control.TickGameThread(editor_config, 64) != 0) {
+    }
+    bounded_model.Clear();
+    Expect(bounded_model.GetLines().empty(), "local clear retained display lines");
+    LOG_WARNING("ConsoleSessionModel post-clear line");
+    static_cast<void>(bounded_model.Pump());
+    Expect(
+        FindLine(bounded_model, "ConsoleSessionModel post-clear line") != nullptr &&
+            FindLine(bounded_model, "Commands:") == nullptr,
+        "local clear replayed old global source data or skipped new data"
+    );
+
+    for (int batch = 0; batch < 9; ++batch) {
+        for (int index = 0; index < 256; ++index) {
+            Expect(
+                endpoint->SubmitText("/overwrite-fixture") == Command::ESubmitStatus::Accepted,
+                "command overwrite fixture overflowed before its bounded drain"
+            );
+        }
+        Expect(
+            control.TickGameThread(editor_config, 256) == 256,
+            "command overwrite fixture did not drain its batch"
+        );
+    }
+    ConsoleSessionModel overwritten_model(endpoint, {.display_capacity = 4096, .history_capacity = 2});
+    const ConsoleSessionPumpResult overwritten_pump = overwritten_model.Pump(0, 4096);
+    Expect(
+        overwritten_pump.dropped_command_lines > 0 &&
+            FindLine(overwritten_model, "command output line(s) were overwritten") != nullptr,
+        "source overwrite was not reported through a loss marker"
+    );
+
+    std::cout << "ConsoleSessionModelContract passed\n";
+    return 0;
+}

--- a/source/test/EditorUISettingsTest.cpp
+++ b/source/test/EditorUISettingsTest.cpp
@@ -1,0 +1,66 @@
+#include "EditorUISettings.h"
+
+#include <imgui.h>
+
+#include <cstdlib>
+#include <iostream>
+#include <string_view>
+
+namespace {
+
+using namespace Moer;
+
+[[noreturn]] void Fail(const char* message) {
+    std::cerr << "EditorUISettingsContract failed: " << message << '\n';
+    std::exit(1);
+}
+
+void Expect(bool condition, const char* message) {
+    if (!condition) {
+        Fail(message);
+    }
+}
+
+} // namespace
+
+int main() {
+    IMGUI_CHECKVERSION();
+    ImGui::CreateContext();
+
+    constexpr std::string_view ini = R"ini(
+[EditorWindowVisibility][Main]
+SceneColor=1
+SceneView=1
+Hierarchy=1
+Inspector=1
+Configs=1
+SceneEditing=1
+Console=1
+ProfileCapture=0
+ProfileViewer=0
+MemoryProfiler=0
+)ini";
+    ImGui::LoadIniSettingsFromMemory(ini.data(), ini.size());
+
+    const EditorWindowVisibilitySettings& loaded = EditorUISettings::LoadWindowVisibilitySettings();
+    Expect(
+        loaded.loaded && loaded.console, "Console visibility was not restored from the custom ini section"
+    );
+
+    EditorWindowVisibilitySettings stored = loaded;
+    stored.console                        = false;
+    EditorUISettings::StoreWindowVisibilitySettings(stored);
+
+    std::size_t            output_size = 0;
+    const char*            output      = ImGui::SaveIniSettingsToMemory(&output_size);
+    const std::string_view saved(output, output_size);
+    Expect(
+        saved.find("[EditorWindowVisibility][Main]") != std::string_view::npos &&
+            saved.find("Console=0") != std::string_view::npos,
+        "Console visibility was not written to the custom ini section"
+    );
+
+    ImGui::DestroyContext();
+    std::cout << "EditorUISettingsContract passed\n";
+    return 0;
+}

--- a/source/test/EngineConsoleControlTest.cpp
+++ b/source/test/EngineConsoleControlTest.cpp
@@ -1,0 +1,166 @@
+#include "EngineConsoleControl.h"
+
+#include "command/EngineCommandProcessor.h"
+#include "config/CVarSystem.h"
+#include "renderer/EditorConfig.h"
+
+#include <cmath>
+#include <cstdlib>
+#include <iostream>
+#include <string>
+#include <thread>
+
+namespace {
+
+using namespace Moer;
+
+[[noreturn]] void Fail(const char* message) {
+    std::cerr << "EngineConsoleControlContract failed: " << message << '\n';
+    std::exit(1);
+}
+
+void Expect(bool condition, const char* message) {
+    if (!condition) {
+        Fail(message);
+    }
+}
+
+double SnapshotFloat(std::string_view name) {
+    const auto snapshot = CVar::Find(name);
+    Expect(snapshot.has_value(), "expected cvar snapshot is missing");
+    return std::stod(snapshot->value);
+}
+
+} // namespace
+
+int main() {
+    EngineConsoleStartupConfig startup_config{
+        .render_thread                          = true,
+        .rhi_thread                             = true,
+        .rhi_bypass                             = false,
+        .parallel_recording                     = true,
+        .parallel_record_workers                = 3,
+        .parallel_record_verify                 = true,
+        .parallel_record_profile                = false,
+        .parallel_record_min_work_units_per_job = 96,
+        .configured_submission_batch_window     = 5,
+        .rhi_heartbeat_enabled                  = true,
+        .rhi_heartbeat_stall_timeout_ms         = 7000,
+        .rhi_heartbeat_poll_interval_ms         = 750,
+        .raster_rdg_enabled                     = true,
+        .raster_rdg_parallel_recording          = true,
+        .raytracing_rdg_enabled                 = true,
+        .raytracing_rdg_debug_dump              = true,
+    };
+
+    std::shared_ptr<EngineCommandEndpoint> retained_endpoint;
+    {
+        EngineConsoleControl control(startup_config, 4);
+        CVar::SealStartupOnlyCVars();
+
+        const auto submission = CVar::Find("RHI.Submission.BatchWindow.PolicyClamped");
+        Expect(
+            submission.has_value() && submission->value == "4" &&
+                CVar::HasFlag(submission->flags, CVar::EFlags::ReadOnly) &&
+                CVar::HasFlag(submission->flags, CVar::EFlags::StartupOnly) && submission->startup_sealed,
+            "policy-clamped startup topology was not exposed as read-only metadata"
+        );
+        Expect(
+            CVar::Find("RHI.CommandRecording.Parallel.Configured")->value == "true" &&
+                CVar::Find("Render.Raster.RDG.ParallelRecording.Configured")->value == "true" &&
+                CVar::Find("Render.Raytracing.RDG.DebugDump.Configured")->value == "true",
+            "startup topology cvars do not reflect GlobalConfig"
+        );
+
+        EditorConfig editor_config{};
+        editor_config.raster_config.bloom_enabled           = true;
+        editor_config.raster_config.tonemapping_exposure_ev = -2.0f;
+        editor_config.raytracing_config.exposure            = 6.0f;
+        control.BindEditorConfig(editor_config);
+        Expect(
+            !CVar::Find("Render.Raster.Bloom.Enabled")->startup_sealed,
+            "global startup seal incorrectly sealed a live cvar"
+        );
+
+        retained_endpoint = control.GetCommandEndpoint();
+        Expect(
+            retained_endpoint->SubmitText("Render.Raster.Bloom.Enabled false") ==
+                    Command::ESubmitStatus::Accepted &&
+                retained_endpoint->SubmitText("Render.Raster.Tonemapping.ExposureEV 1.5") ==
+                    Command::ESubmitStatus::Accepted &&
+                retained_endpoint->SubmitText("Render.Raytracing.Exposure 3.25") ==
+                    Command::ESubmitStatus::Accepted,
+            "live cvar commands were not admitted"
+        );
+        Expect(
+            control.TickGameThread(editor_config, 2) == 2 && !editor_config.raster_config.bloom_enabled &&
+                std::abs(editor_config.raster_config.tonemapping_exposure_ev - 1.5f) < 0.0001f &&
+                std::abs(editor_config.raytracing_config.exposure - 6.0f) < 0.0001f,
+            "bounded Game Thread drain did not apply exactly its first two commands"
+        );
+        Expect(
+            control.TickGameThread(editor_config, 2) == 1 &&
+                std::abs(editor_config.raytracing_config.exposure - 3.25f) < 0.0001f,
+            "second Game Thread drain did not apply the retained command"
+        );
+
+        editor_config.raster_config.tonemapping_exposure_ev = -4.5f;
+        Expect(
+            control.TickGameThread(editor_config, 0) == 0 &&
+                std::abs(SnapshotFloat("Render.Raster.Tonemapping.ExposureEV") + 4.5) < 0.0001,
+            "Editor-owned mutation did not synchronize back to the cvar registry"
+        );
+
+        CVar::CVarSetResult threaded_set;
+        std::jthread        producer([&threaded_set] {
+            threaded_set = CVar::SetValueFromString("Render.Raster.Bloom.Enabled", "true");
+        });
+        producer.join();
+        Expect(threaded_set.Succeeded(), "cross-thread cvar set was rejected");
+        Expect(
+            !editor_config.raster_config.bloom_enabled && control.TickGameThread(editor_config, 0) == 0 &&
+                editor_config.raster_config.bloom_enabled,
+            "cross-thread callback mutated EditorConfig outside the Game Thread handoff"
+        );
+
+        const CVar::CVarSetResult out_of_range =
+            CVar::SetValueFromString("Render.Raster.Tonemapping.ExposureEV", "20");
+        Expect(
+            out_of_range.status == CVar::ESetStatus::OutOfRange &&
+                control.TickGameThread(editor_config, 0) == 0 &&
+                std::abs(editor_config.raster_config.tonemapping_exposure_ev + 4.5f) < 0.0001f,
+            "range rejection changed the live owner"
+        );
+
+        for (int index = 0; index < 65; ++index) {
+            Expect(
+                retained_endpoint->SubmitText("/cvar.list No.Such.Prefix") ==
+                    Command::ESubmitStatus::Accepted,
+                "drain budget fixture overflowed the pending queue"
+            );
+        }
+        Expect(
+            control.TickGameThread(editor_config) == 64 && control.TickGameThread(editor_config) == 1,
+            "default Game Thread drain budget is not 64 commands"
+        );
+
+        control.UnbindEditorConfig();
+        Expect(
+            !CVar::Find("Render.Raster.Bloom.Enabled").has_value() &&
+                !CVar::Find("Render.Raster.Tonemapping.ExposureEV").has_value() &&
+                !CVar::Find("Render.Raytracing.Exposure").has_value(),
+            "live registrations outlived their EditorConfig binding"
+        );
+    }
+
+    const auto final_submission = CVar::Find("RHI.Submission.BatchWindow.PolicyClamped");
+    Expect(!final_submission.has_value(), "startup registrations outlived EngineConsoleControl");
+    Expect(
+        retained_endpoint && !retained_endpoint->IsAccepting() &&
+            retained_endpoint->SubmitText("/help") == Command::ESubmitStatus::Closed,
+        "retained async endpoint did not close admission safely at Engine teardown"
+    );
+    retained_endpoint.reset();
+    std::cout << "EngineConsoleControlContract passed\n";
+    return 0;
+}

--- a/source/test/EngineConsoleControlTest.cpp
+++ b/source/test/EngineConsoleControlTest.cpp
@@ -73,9 +73,10 @@ int main() {
         );
 
         EditorConfig editor_config{};
-        editor_config.raster_config.bloom_enabled           = true;
-        editor_config.raster_config.tonemapping_exposure_ev = -2.0f;
-        editor_config.raytracing_config.exposure            = 6.0f;
+        editor_config.raster_config.bloom_enabled                      = true;
+        editor_config.raster_config.tonemapping_exposure_ev            = -2.0f;
+        editor_config.raytracing_config.directional_light_intensity    = 6.0f;
+        editor_config.raytracing_config.tone_mapping_cfg.exposure_bias = -0.5f;
         control.BindEditorConfig(editor_config);
         Expect(
             !CVar::Find("Render.Raster.Bloom.Enabled")->startup_sealed,
@@ -88,20 +89,22 @@ int main() {
                     Command::ESubmitStatus::Accepted &&
                 retained_endpoint->SubmitText("Render.Raster.Tonemapping.ExposureEV 1.5") ==
                     Command::ESubmitStatus::Accepted &&
-                retained_endpoint->SubmitText("Render.Raytracing.Exposure 3.25") ==
+                retained_endpoint->SubmitText("Render.Raytracing.Tonemapping.ExposureBiasEV 3.25") ==
                     Command::ESubmitStatus::Accepted,
             "live cvar commands were not admitted"
         );
         Expect(
             control.TickGameThread(editor_config, 2) == 2 && !editor_config.raster_config.bloom_enabled &&
                 std::abs(editor_config.raster_config.tonemapping_exposure_ev - 1.5f) < 0.0001f &&
-                std::abs(editor_config.raytracing_config.exposure - 6.0f) < 0.0001f,
+                std::abs(editor_config.raytracing_config.tone_mapping_cfg.exposure_bias + 0.5f) < 0.0001f &&
+                std::abs(editor_config.raytracing_config.directional_light_intensity - 6.0f) < 0.0001f,
             "bounded Game Thread drain did not apply exactly its first two commands"
         );
         Expect(
             control.TickGameThread(editor_config, 2) == 1 &&
-                std::abs(editor_config.raytracing_config.exposure - 3.25f) < 0.0001f,
-            "second Game Thread drain did not apply the retained command"
+                std::abs(editor_config.raytracing_config.tone_mapping_cfg.exposure_bias - 3.25f) < 0.0001f &&
+                std::abs(editor_config.raytracing_config.directional_light_intensity - 6.0f) < 0.0001f,
+            "second Game Thread drain did not apply presentation exposure without changing light intensity"
         );
 
         editor_config.raster_config.tonemapping_exposure_ev = -4.5f;
@@ -109,6 +112,14 @@ int main() {
             control.TickGameThread(editor_config, 0) == 0 &&
                 std::abs(SnapshotFloat("Render.Raster.Tonemapping.ExposureEV") + 4.5) < 0.0001,
             "Editor-owned mutation did not synchronize back to the cvar registry"
+        );
+
+        editor_config.raytracing_config.tone_mapping_cfg.exposure_bias = -1.25f;
+        Expect(
+            control.TickGameThread(editor_config, 0) == 0 &&
+                std::abs(SnapshotFloat("Render.Raytracing.Tonemapping.ExposureBiasEV") + 1.25) < 0.0001 &&
+                std::abs(editor_config.raytracing_config.directional_light_intensity - 6.0f) < 0.0001f,
+            "Raytracing presentation exposure did not synchronize without changing light intensity"
         );
 
         CVar::CVarSetResult threaded_set;
@@ -148,7 +159,7 @@ int main() {
         Expect(
             !CVar::Find("Render.Raster.Bloom.Enabled").has_value() &&
                 !CVar::Find("Render.Raster.Tonemapping.ExposureEV").has_value() &&
-                !CVar::Find("Render.Raytracing.Exposure").has_value(),
+                !CVar::Find("Render.Raytracing.Tonemapping.ExposureBiasEV").has_value(),
             "live registrations outlived their EditorConfig binding"
         );
     }

--- a/source/test/WindowInputSnapshotContractTest.cpp
+++ b/source/test/WindowInputSnapshotContractTest.cpp
@@ -99,6 +99,50 @@ int main() {
     Require(!clear_toggle_frame.key_toggle[KeyButtons::F]);
     Require(!clear_toggle_frame.cursor_hidden);
 
+    // A text field in a docked Editor panel shares platform focus with the
+    // active Scene/Game viewport. The UI integration revokes its owners,
+    // clears free-look, suppresses viewport input, and forces a visible cursor.
+    WindowInputFrameTracker   text_input_tracker;
+    WindowInputSourceSnapshot text_input_free_look   = MakeSource(1);
+    text_input_free_look.key_released[KeyButtons::F] = true;
+    Require(text_input_tracker.BeginFrame(text_input_free_look));
+    const WindowInputFrameSnapshot text_input_captured = text_input_tracker.Finalize(active_policy);
+    Require(text_input_captured.cursor_hidden);
+    Require(text_input_captured.key_toggle[KeyButtons::F]);
+
+    WindowInputSourceSnapshot text_input_focus = MakeSource(2);
+    text_input_focus.want_capture_keyboard     = true;
+    text_input_focus.want_text_input           = true;
+    text_input_focus.mouse_delta               = float2(8.0f, -4.0f);
+    Require(text_input_tracker.BeginFrame(text_input_focus));
+    text_input_tracker.ClearKeyToggle(KeyButtons::F);
+    WindowInputPolicy text_input_policy             = active_policy;
+    text_input_policy.scene_active                  = false;
+    text_input_policy.viewport_hovered              = false;
+    text_input_policy.force_cursor_visible          = true;
+    const WindowInputFrameSnapshot text_input_frame = text_input_tracker.Finalize(text_input_policy);
+    Require(!text_input_frame.scene_active);
+    Require(!text_input_frame.mouse_input_allowed);
+    Require(!text_input_frame.keyboard_input_allowed);
+    Require(!text_input_frame.key_toggle[KeyButtons::F]);
+    Require(!text_input_frame.cursor_hidden);
+    Require(text_input_frame.cursor_mode_changed);
+    RequireFloat2(text_input_frame.cursor_delta, 0.0f, 0.0f);
+
+    WindowInputSourceSnapshot text_input_released = MakeSource(3);
+    Require(text_input_tracker.BeginFrame(text_input_released));
+    Require(!text_input_tracker.IsKeyToggled(KeyButtons::F));
+    const uint32_t resumed_free_look_owner = ResolveFreeLookCaptureViewportId(
+        text_input_released.focused_viewport_id, text_input_tracker.IsKeyToggled(KeyButtons::F), true, 17u, 0u
+    );
+    Require(resumed_free_look_owner == 0u);
+    WindowInputPolicy text_input_released_policy = active_policy;
+    text_input_released_policy.scene_active      = false;
+    const WindowInputFrameSnapshot text_input_released_frame =
+        text_input_tracker.Finalize(text_input_released_policy);
+    Require(!text_input_released_frame.cursor_hidden);
+    Require(!text_input_released_frame.key_toggle[KeyButtons::F]);
+
     // Releasing F away from active viewport content must not leave a latent
     // toggle that starts free-look on a later hover without another F edge.
     WindowInputFrameTracker latent_toggle_tracker;


### PR DESCRIPTION
## Summary
- add a Runtime-owned `EngineCommandEndpoint` with synchronized close/admission and bounded Game Thread command drain
- expose startup threading/RHI/RDG topology as sealed read-only CVars and wire three real per-frame renderer CVars
- add an Editor-owned bounded console session and dockable UI with log/command cursors, filtering, history, autocomplete, local clear, loss diagnostics, and visibility persistence
- add focused contracts for runtime control, session behavior, and Editor UI settings

## Ownership and ordering
- arbitrary threads may submit commands; only the Game Thread executes them
- per-frame order is Editor UI/owner sync -> bounded command drain -> pending CVar apply -> renderer frame snapshot
- retained Editor endpoints close admission safely after `EngineConsoleControl` teardown
- no `ConsoleVariable.toml` or obsolete `RHI.Translate.*` mappings are restored from `dev_parallel_rhi`

## Validation
- focused Debug build: `MoerEditor`, `TestEngineConsoleControl`, `TestConsoleSessionModel`, `TestEditorUISettings`
- `CVarCommandCoreContract` passed
- Debug CTest: 46/46 passed
- Release CTest: 46/46 passed
- Raster smoke: 60 s, graceful close, 0 severe log matches
- Raytracing smoke: 60 s, graceful close, 0 severe log matches
- local P1/P2 review: no remaining findings

## Environment note
The host lacks the repository's prescribed `just + Ninja + Clang` toolchain, so validation used Visual Studio 2022 as a fallback. Editor and all 46 test targets built and passed in Debug/Release. The default all-target build additionally visits the unrelated existing `GKlib` target and fails because its CMake passes Clang/GCC `-include io.h` to MSVC; this PR does not modify that third-party build script.