### PR TITLE
RDG: add parameterized access declarations

### DIFF
--- a/source/runtime/render/renderer/raytracing/AntiAliasPass.cpp
+++ b/source/runtime/render/renderer/raytracing/AntiAliasPass.cpp
@@ -216,64 +216,66 @@ bool AntialiasPass::AddPasses(
         );
     }
 
+    UploadGraphParameters upload_parameters{};
+    upload_parameters.constants = constants;
+    upload_parameters.owner     = owner;
+    upload_parameters.command   = command;
     graph.AddRecordPass(
         "RT.AntiAlias.UploadConstants",
-        [=](RenderGraph::PassBuilder& builder) {
+        std::move(upload_parameters),
+        [](RenderGraph::PassBuilder& builder) {
             builder.ExecuteOn(
-                       RenderGraph::QueueRole::Graphics,
-                       RenderGraph::PipelineType::Copy
-                   )
-                .Write(constants, RenderGraph::BufferState::TransferDestination);
+                RenderGraph::QueueRole::Graphics,
+                RenderGraph::PipelineType::Copy
+            );
         },
-        [owner, command](CommandList& cmd_list) {
+        [](CommandList& cmd_list, const UploadGraphParameters& parameters) {
             ScopedGpuMarker marker(
                 cmd_list,
                 "Pass: RT AntiAlias Constants Upload",
                 GpuMarkerPalette::Transfer()
             );
-            RecordConstantsUpload(cmd_list, *owner, command);
+            RecordConstantsUpload(
+                cmd_list,
+                *parameters.owner,
+                parameters.command
+            );
         },
         RenderGraph::PassExecutionClass::ParallelRecordEligible
     );
 
+    DispatchGraphParameters dispatch_parameters{};
+    dispatch_parameters.constants      = constants;
+    dispatch_parameters.hdr_color      = graph_resources.hdr_color;
+    dispatch_parameters.motion         = graph_resources.motion;
+    dispatch_parameters.feedback_read  = feedback_read;
+    dispatch_parameters.resolved_color = graph_resources.resolved_color;
+    dispatch_parameters.feedback_write = feedback_write;
+    dispatch_parameters.owner          = owner;
+    dispatch_parameters.command        = command;
+    dispatch_parameters.resources      = resources;
     graph.AddRecordPass(
         "RT.AntiAlias.Dispatch",
-        [=](RenderGraph::PassBuilder& builder) {
-            builder
-                .ExecuteOn(
-                    RenderGraph::QueueRole::Graphics,
-                    RenderGraph::PipelineType::Compute
-                )
-                .Read(constants, RenderGraph::BufferState::ShaderResource)
-                .Read(
-                    graph_resources.hdr_color,
-                    RenderGraph::TextureState::Sampled
-                )
-                .Read(
-                    graph_resources.motion,
-                    RenderGraph::TextureState::Sampled
-                )
-                .Read(
-                    feedback_read,
-                    RenderGraph::TextureState::Sampled
-                )
-                .Write(
-                    graph_resources.resolved_color,
-                    RenderGraph::TextureState::UnorderedAccess
-                )
-                .Write(
-                    feedback_write,
-                    RenderGraph::TextureState::UnorderedAccess
-                );
+        std::move(dispatch_parameters),
+        [](RenderGraph::PassBuilder& builder) {
+            builder.ExecuteOn(
+                RenderGraph::QueueRole::Graphics,
+                RenderGraph::PipelineType::Compute
+            );
         },
-        [owner, command, resources](CommandList& cmd_list) {
+        [](CommandList& cmd_list, const DispatchGraphParameters& parameters) {
             ScopedGpuMarker marker(
                 cmd_list,
                 "AntiAliasPass",
                 GpuMarkerPalette::Pass(),
                 EGpuMarkerMode::Timestamp
             );
-            RecordTAA(cmd_list, *owner, command, resources);
+            RecordTAA(
+                cmd_list,
+                *parameters.owner,
+                parameters.command,
+                parameters.resources
+            );
         },
         RenderGraph::PassExecutionClass::ParallelRecordEligible
     );

--- a/source/runtime/render/renderer/raytracing/AntiAliasPass.h
+++ b/source/runtime/render/renderer/raytracing/AntiAliasPass.h
@@ -83,6 +83,63 @@ private:
         TAAPipeline pipeline{};
     };
 
+    struct UploadGraphParameters {
+        DEFINE_RG_BUFFER_ACCESS(
+            constants,
+            RenderGraph::AccessMode::Write,
+            RenderGraph::BufferState::TransferDestination
+        );
+        SharedPtr<RecordingOwner> owner{};
+        PreparedCommand           command{};
+
+        DEFINE_RG_PARAMETER_ACCESS(constants);
+    };
+
+    struct DispatchGraphParameters {
+        DEFINE_RG_BUFFER_ACCESS(
+            constants,
+            RenderGraph::AccessMode::Read,
+            RenderGraph::BufferState::ShaderResource
+        );
+        DEFINE_RG_TEXTURE_ACCESS(
+            hdr_color,
+            RenderGraph::AccessMode::Read,
+            RenderGraph::TextureState::Sampled
+        );
+        DEFINE_RG_TEXTURE_ACCESS(
+            motion,
+            RenderGraph::AccessMode::Read,
+            RenderGraph::TextureState::Sampled
+        );
+        DEFINE_RG_TEXTURE_ACCESS(
+            feedback_read,
+            RenderGraph::AccessMode::Read,
+            RenderGraph::TextureState::Sampled
+        );
+        DEFINE_RG_TEXTURE_ACCESS(
+            resolved_color,
+            RenderGraph::AccessMode::Write,
+            RenderGraph::TextureState::UnorderedAccess
+        );
+        DEFINE_RG_TEXTURE_ACCESS(
+            feedback_write,
+            RenderGraph::AccessMode::Write,
+            RenderGraph::TextureState::UnorderedAccess
+        );
+        SharedPtr<RecordingOwner> owner{};
+        PreparedCommand           command{};
+        RecordResources           resources{};
+
+        DEFINE_RG_PARAMETER_ACCESS(
+            constants,
+            hdr_color,
+            motion,
+            feedback_read,
+            resolved_color,
+            feedback_write
+        );
+    };
+
     PreparedCommand Prepare(
         Params            params,
         bool              prev_view_valid,

--- a/source/runtime/render/rendergraph/RenderGraph.h
+++ b/source/runtime/render/rendergraph/RenderGraph.h
@@ -4,18 +4,31 @@
 #include "rendergraph/RenderGraphResourcePool.h"
 #include "rhi/RHIExecutor.h"
 
+#include <concepts>
 #include <cstdint>
 #include <functional>
 #include <limits>
 #include <optional>
 #include <string>
 #include <string_view>
+#include <type_traits>
+#include <utility>
 #include <vector>
 
 namespace Moer::Render {
 
 class RenderGraphCompiler;
 class RenderGraphLowering;
+class RGParameterAccessCollector;
+
+template<typename T>
+concept RGParameterAccessProvider =
+    requires(
+        const std::remove_cvref_t<T>& value,
+        RGParameterAccessCollector&   collector
+    ) {
+        value.DeclareRGAccess(collector);
+    };
 
 /**
  * Typed RDG frontend with an opt-in command-recording schedule.
@@ -914,6 +927,26 @@ public:
         uint32_t             workload = 1
     );
 
+    /**
+     * Declares a command-recording pass from one graph-owned immutable
+     * parameter object. DeclareRGAccess() expands the typed access fields into
+     * this graph's existing PassBuilder contract; policy_setup remains the
+     * explicit home for queue, pipeline, side-effect and recording policy.
+     */
+    template<RGParameterAccessProvider Parameters, typename Record>
+        requires std::invocable<
+            Record&,
+            CommandList&,
+            const std::remove_cvref_t<Parameters>&>
+    PassHandle AddRecordPass(
+        std::string_view name,
+        Parameters&&     parameters,
+        SetupCallback    policy_setup,
+        Record&&         record,
+        PassExecutionClass execution = PassExecutionClass::SerialRecord,
+        uint32_t             workload = 1
+    );
+
     /** Compiles declarations without emitting barriers or recording RHI commands. */
     bool Compile();
 
@@ -1089,3 +1122,5 @@ private:
 };
 
 } // namespace Moer::Render
+
+#include "RenderGraphPassParameters.h"

--- a/source/runtime/render/rendergraph/RenderGraphPassParameters.h
+++ b/source/runtime/render/rendergraph/RenderGraphPassParameters.h
@@ -1,0 +1,492 @@
+#pragma once
+
+#include "RenderGraph.h"
+#include "misc/STL.h"
+
+#include <functional>
+#include <optional>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+namespace Moer::Render {
+
+namespace Detail {
+
+template<RenderGraph::AccessMode Mode>
+inline constexpr bool IsRGDeclarableAccessMode =
+    Mode == RenderGraph::AccessMode::Read ||
+    Mode == RenderGraph::AccessMode::Write ||
+    Mode == RenderGraph::AccessMode::ReadWrite;
+
+} // namespace Detail
+
+/** A required typed texture access. Invalid handles deliberately fail closed. */
+template<
+    RenderGraph::AccessMode   Mode,
+    RenderGraph::TextureState State = RenderGraph::TextureState::Automatic>
+struct RGTextureAccess {
+    static_assert(
+        Detail::IsRGDeclarableAccessMode<Mode>,
+        "RG texture access mode must be Read, Write, or ReadWrite"
+    );
+
+    RenderGraph::TextureHandle resource{};
+    RenderGraph::TextureRange  range = RenderGraph::TextureRange::Whole();
+
+    RGTextureAccess() = default;
+    RGTextureAccess(
+        RenderGraph::TextureHandle handle,
+        RenderGraph::TextureRange  access_range = RenderGraph::TextureRange::Whole()
+    ) : resource(handle), range(access_range) {}
+
+    RGTextureAccess& operator=(RenderGraph::TextureHandle handle) {
+        resource = handle;
+        return *this;
+    }
+};
+
+/** A required typed buffer access. Invalid handles deliberately fail closed. */
+template<
+    RenderGraph::AccessMode  Mode,
+    RenderGraph::BufferState State = RenderGraph::BufferState::Automatic>
+struct RGBufferAccess {
+    static_assert(
+        Detail::IsRGDeclarableAccessMode<Mode>,
+        "RG buffer access mode must be Read, Write, or ReadWrite"
+    );
+
+    RenderGraph::BufferHandle resource{};
+    RenderGraph::BufferRange  range = RenderGraph::BufferRange::Whole();
+
+    RGBufferAccess() = default;
+    RGBufferAccess(
+        RenderGraph::BufferHandle handle,
+        RenderGraph::BufferRange  access_range = RenderGraph::BufferRange::Whole()
+    ) : resource(handle), range(access_range) {}
+
+    RGBufferAccess& operator=(RenderGraph::BufferHandle handle) {
+        resource = handle;
+        return *this;
+    }
+};
+
+/** A required typed token access. */
+template<RenderGraph::AccessMode Mode>
+struct RGTokenAccess {
+    static_assert(
+        Detail::IsRGDeclarableAccessMode<Mode>,
+        "RG token access mode must be Read, Write, or ReadWrite"
+    );
+
+    RenderGraph::TokenHandle resource{};
+
+    RGTokenAccess() = default;
+    RGTokenAccess(RenderGraph::TokenHandle handle) : resource(handle) {}
+
+    RGTokenAccess& operator=(RenderGraph::TokenHandle handle) {
+        resource = handle;
+        return *this;
+    }
+};
+
+/** Explicitly optional access. A disengaged value is the only skipped access. */
+template<typename Access>
+using RGOptionalAccess = std::optional<Access>;
+
+/** Owning dynamic access list; no caller-owned pointer lifetime is retained. */
+template<typename Access>
+using RGAccessArray = std::vector<Access>;
+
+/** One heterogeneous texture-array element with explicit mode and state. */
+class RGTextureAccessElement {
+public:
+    [[nodiscard]] static RGTextureAccessElement Read(
+        RenderGraph::TextureHandle handle,
+        RenderGraph::TextureState  state = RenderGraph::TextureState::Automatic,
+        RenderGraph::TextureRange  range = RenderGraph::TextureRange::Whole()
+    ) {
+        return RGTextureAccessElement(
+            handle,
+            RenderGraph::AccessMode::Read,
+            state,
+            range
+        );
+    }
+
+    [[nodiscard]] static RGTextureAccessElement Write(
+        RenderGraph::TextureHandle handle,
+        RenderGraph::TextureState  state = RenderGraph::TextureState::Automatic,
+        RenderGraph::TextureRange  range = RenderGraph::TextureRange::Whole()
+    ) {
+        return RGTextureAccessElement(
+            handle,
+            RenderGraph::AccessMode::Write,
+            state,
+            range
+        );
+    }
+
+    [[nodiscard]] static RGTextureAccessElement ReadWrite(
+        RenderGraph::TextureHandle handle,
+        RenderGraph::TextureState  state = RenderGraph::TextureState::Automatic,
+        RenderGraph::TextureRange  range = RenderGraph::TextureRange::Whole()
+    ) {
+        return RGTextureAccessElement(
+            handle,
+            RenderGraph::AccessMode::ReadWrite,
+            state,
+            range
+        );
+    }
+
+    [[nodiscard]] RenderGraph::TextureHandle Resource() const {
+        return resource;
+    }
+    [[nodiscard]] RenderGraph::AccessMode Mode() const {
+        return mode;
+    }
+    [[nodiscard]] RenderGraph::TextureState State() const {
+        return state;
+    }
+    [[nodiscard]] RenderGraph::TextureRange Range() const {
+        return range;
+    }
+
+private:
+    RGTextureAccessElement(
+        RenderGraph::TextureHandle handle,
+        RenderGraph::AccessMode    mode,
+        RenderGraph::TextureState  state,
+        RenderGraph::TextureRange  range
+    ) : resource(handle), mode(mode), state(state), range(range) {}
+
+    RenderGraph::TextureHandle resource{};
+    RenderGraph::AccessMode    mode = RenderGraph::AccessMode::None;
+    RenderGraph::TextureState  state = RenderGraph::TextureState::Automatic;
+    RenderGraph::TextureRange  range = RenderGraph::TextureRange::Whole();
+};
+
+/** One heterogeneous buffer-array element with explicit mode and state. */
+class RGBufferAccessElement {
+public:
+    [[nodiscard]] static RGBufferAccessElement Read(
+        RenderGraph::BufferHandle handle,
+        RenderGraph::BufferState  state = RenderGraph::BufferState::Automatic,
+        RenderGraph::BufferRange  range = RenderGraph::BufferRange::Whole()
+    ) {
+        return RGBufferAccessElement(
+            handle,
+            RenderGraph::AccessMode::Read,
+            state,
+            range
+        );
+    }
+
+    [[nodiscard]] static RGBufferAccessElement Write(
+        RenderGraph::BufferHandle handle,
+        RenderGraph::BufferState  state = RenderGraph::BufferState::Automatic,
+        RenderGraph::BufferRange  range = RenderGraph::BufferRange::Whole()
+    ) {
+        return RGBufferAccessElement(
+            handle,
+            RenderGraph::AccessMode::Write,
+            state,
+            range
+        );
+    }
+
+    [[nodiscard]] static RGBufferAccessElement ReadWrite(
+        RenderGraph::BufferHandle handle,
+        RenderGraph::BufferState  state = RenderGraph::BufferState::Automatic,
+        RenderGraph::BufferRange  range = RenderGraph::BufferRange::Whole()
+    ) {
+        return RGBufferAccessElement(
+            handle,
+            RenderGraph::AccessMode::ReadWrite,
+            state,
+            range
+        );
+    }
+
+    [[nodiscard]] RenderGraph::BufferHandle Resource() const {
+        return resource;
+    }
+    [[nodiscard]] RenderGraph::AccessMode Mode() const {
+        return mode;
+    }
+    [[nodiscard]] RenderGraph::BufferState State() const {
+        return state;
+    }
+    [[nodiscard]] RenderGraph::BufferRange Range() const {
+        return range;
+    }
+
+private:
+    RGBufferAccessElement(
+        RenderGraph::BufferHandle handle,
+        RenderGraph::AccessMode   mode,
+        RenderGraph::BufferState  state,
+        RenderGraph::BufferRange  range
+    ) : resource(handle), mode(mode), state(state), range(range) {}
+
+    RenderGraph::BufferHandle resource{};
+    RenderGraph::AccessMode   mode = RenderGraph::AccessMode::None;
+    RenderGraph::BufferState  state = RenderGraph::BufferState::Automatic;
+    RenderGraph::BufferRange  range = RenderGraph::BufferRange::Whole();
+};
+
+using RGTextureAccessArray = RGAccessArray<RGTextureAccessElement>;
+using RGBufferAccessArray  = RGAccessArray<RGBufferAccessElement>;
+
+/**
+ * Adapts parameter declarations to the existing typed PassBuilder API. It
+ * intentionally owns no compiler state and performs no access inference.
+ */
+class RGParameterAccessCollector {
+public:
+    explicit RGParameterAccessCollector(RenderGraph::PassBuilder& builder) :
+        builder(builder) {}
+
+    template<RenderGraph::AccessMode Mode, RenderGraph::TextureState State>
+    void Add(const RGTextureAccess<Mode, State>& access) {
+        AddTexture(access.resource, Mode, State, access.range);
+    }
+
+    template<RenderGraph::AccessMode Mode, RenderGraph::BufferState State>
+    void Add(const RGBufferAccess<Mode, State>& access) {
+        AddBuffer(access.resource, Mode, State, access.range);
+    }
+
+    void Add(const RGTextureAccessElement& access) {
+        AddTexture(
+            access.Resource(),
+            access.Mode(),
+            access.State(),
+            access.Range()
+        );
+    }
+
+    void Add(const RGBufferAccessElement& access) {
+        AddBuffer(
+            access.Resource(),
+            access.Mode(),
+            access.State(),
+            access.Range()
+        );
+    }
+
+    template<RenderGraph::AccessMode Mode>
+    void Add(const RGTokenAccess<Mode>& access) {
+        if constexpr (Mode == RenderGraph::AccessMode::Read) {
+            builder.Read(access.resource);
+        } else if constexpr (Mode == RenderGraph::AccessMode::Write) {
+            builder.Write(access.resource);
+        } else {
+            builder.ReadWrite(access.resource);
+        }
+    }
+
+    template<RGParameterAccessProvider Parameters>
+    void Add(const Parameters& parameters) {
+        parameters.DeclareRGAccess(*this);
+    }
+
+    template<typename Access>
+    void Add(const std::optional<Access>& access) {
+        if (access.has_value()) {
+            Add(*access);
+        }
+    }
+
+    template<typename Access, typename Allocator>
+    void Add(const std::vector<Access, Allocator>& accesses) {
+        for (const Access& access : accesses) {
+            Add(access);
+        }
+    }
+
+private:
+    void AddTexture(
+        RenderGraph::TextureHandle handle,
+        RenderGraph::AccessMode    mode,
+        RenderGraph::TextureState  state,
+        RenderGraph::TextureRange  range
+    ) {
+        switch (mode) {
+            case RenderGraph::AccessMode::Read:
+                if (state == RenderGraph::TextureState::Automatic) {
+                    builder.Read(handle, range);
+                } else {
+                    builder.Read(handle, state, range);
+                }
+                return;
+            case RenderGraph::AccessMode::Write:
+                if (state == RenderGraph::TextureState::Automatic) {
+                    builder.Write(handle, range);
+                } else {
+                    builder.Write(handle, state, range);
+                }
+                return;
+            case RenderGraph::AccessMode::ReadWrite:
+                if (state == RenderGraph::TextureState::Automatic) {
+                    builder.ReadWrite(handle, range);
+                } else {
+                    builder.ReadWrite(handle, state, range);
+                }
+                return;
+            case RenderGraph::AccessMode::Unknown:
+            case RenderGraph::AccessMode::None:
+                builder.Read(RenderGraph::TextureHandle{}, range);
+                return;
+        }
+    }
+
+    void AddBuffer(
+        RenderGraph::BufferHandle handle,
+        RenderGraph::AccessMode   mode,
+        RenderGraph::BufferState  state,
+        RenderGraph::BufferRange  range
+    ) {
+        switch (mode) {
+            case RenderGraph::AccessMode::Read:
+                if (state == RenderGraph::BufferState::Automatic) {
+                    builder.Read(handle, range);
+                } else {
+                    builder.Read(handle, state, range);
+                }
+                return;
+            case RenderGraph::AccessMode::Write:
+                if (state == RenderGraph::BufferState::Automatic) {
+                    builder.Write(handle, range);
+                } else {
+                    builder.Write(handle, state, range);
+                }
+                return;
+            case RenderGraph::AccessMode::ReadWrite:
+                if (state == RenderGraph::BufferState::Automatic) {
+                    builder.ReadWrite(handle, range);
+                } else {
+                    builder.ReadWrite(handle, state, range);
+                }
+                return;
+            case RenderGraph::AccessMode::Unknown:
+            case RenderGraph::AccessMode::None:
+                builder.Read(RenderGraph::BufferHandle{}, range);
+                return;
+        }
+    }
+
+    RenderGraph::PassBuilder& builder;
+};
+
+template<typename... Accesses>
+void CollectRGParameterAccess(
+    RGParameterAccessCollector& collector,
+    const Accesses&...           accesses
+) {
+    (collector.Add(accesses), ...);
+}
+
+template<RGParameterAccessProvider Parameters, typename Record>
+    requires std::invocable<
+        Record&,
+        CommandList&,
+        const std::remove_cvref_t<Parameters>&>
+RenderGraph::PassHandle RenderGraph::AddRecordPass(
+    std::string_view name,
+    Parameters&&     parameters,
+    SetupCallback    policy_setup,
+    Record&&         record,
+    PassExecutionClass execution,
+    uint32_t             workload
+) {
+    using ParameterType = std::remove_cvref_t<Parameters>;
+    using RecordType    = std::decay_t<Record>;
+
+    if constexpr (std::is_pointer_v<RecordType>) {
+        if (record == nullptr) {
+            return AddRecordPass(
+                name,
+                policy_setup,
+                RecordCallback{},
+                execution,
+                workload
+            );
+        }
+    } else if constexpr (requires(const RecordType& candidate) {
+                             { candidate.operator bool() } -> std::same_as<bool>;
+                         }) {
+        if (!record.operator bool()) {
+            return AddRecordPass(
+                name,
+                policy_setup,
+                RecordCallback{},
+                execution,
+                workload
+            );
+        }
+    }
+
+    SharedPtr<const ParameterType> parameter_owner =
+        MakeShared<ParameterType>(std::forward<Parameters>(parameters));
+    auto record_owner = MakeShared<RecordType>(std::forward<Record>(record));
+
+    return AddRecordPass(
+        name,
+        [parameter_owner, policy_setup = std::move(policy_setup)](
+            PassBuilder& builder
+        ) {
+            if (policy_setup) {
+                policy_setup(builder);
+            }
+            RGParameterAccessCollector collector(builder);
+            parameter_owner->DeclareRGAccess(collector);
+        },
+        [parameter_owner, record_owner](CommandList& command_list) {
+            std::invoke(*record_owner, command_list, *parameter_owner);
+        },
+        execution,
+        workload
+    );
+}
+
+} // namespace Moer::Render
+
+#define DEFINE_RG_TEXTURE_ACCESS(name, mode, state) \
+    ::Moer::Render::RGTextureAccess<mode, state> name {}
+
+#define DEFINE_RG_BUFFER_ACCESS(name, mode, state) \
+    ::Moer::Render::RGBufferAccess<mode, state> name {}
+
+#define DEFINE_RG_TOKEN_ACCESS(name, mode) \
+    ::Moer::Render::RGTokenAccess<mode> name {}
+
+#define DEFINE_RG_NESTED_PARAMETER(type, name) type name {}
+
+#define DEFINE_RG_TEXTURE_ACCESS_ARRAY(name) \
+    ::Moer::Render::RGTextureAccessArray name {}
+
+#define DEFINE_RG_BUFFER_ACCESS_ARRAY(name) \
+    ::Moer::Render::RGBufferAccessArray name {}
+
+#define DEFINE_RG_OPTIONAL_TEXTURE_ACCESS(name, mode, state) \
+    ::Moer::Render::RGOptionalAccess<                      \
+        ::Moer::Render::RGTextureAccess<mode, state>> name {}
+
+#define DEFINE_RG_OPTIONAL_BUFFER_ACCESS(name, mode, state) \
+    ::Moer::Render::RGOptionalAccess<                     \
+        ::Moer::Render::RGBufferAccess<mode, state>> name {}
+
+#define DEFINE_RG_OPTIONAL_TOKEN_ACCESS(name, mode) \
+    ::Moer::Render::RGOptionalAccess<               \
+        ::Moer::Render::RGTokenAccess<mode>> name {}
+
+#define DEFINE_RG_PARAMETER_ACCESS(...)                                      \
+    void DeclareRGAccess(                                                     \
+        ::Moer::Render::RGParameterAccessCollector& collector                 \
+    ) const {                                                                 \
+        ::Moer::Render::CollectRGParameterAccess(                             \
+            collector __VA_OPT__(, ) __VA_ARGS__                              \
+        );                                                                    \
+    }

--- a/source/test/CMakeLists.txt
+++ b/source/test/CMakeLists.txt
@@ -203,6 +203,18 @@ target_link_libraries(${test_target}
 set_target_properties(${test_target} PROPERTIES FOLDER ${moer_test_folder})
 add_test(NAME RenderGraphContract COMMAND $<TARGET_FILE:${test_target}>)
 
+set(test_target TestRenderGraphParameterAccess)
+add_executable(${test_target} "RenderGraphParameterAccessTest.cpp")
+target_link_libraries(${test_target}
+    PRIVATE Moer::Render
+)
+set_target_properties(${test_target} PROPERTIES FOLDER ${moer_test_folder})
+add_test(
+    NAME RenderGraphParameterAccessContract
+    COMMAND $<TARGET_FILE:${test_target}>
+)
+set_tests_properties(RenderGraphParameterAccessContract PROPERTIES TIMEOUT 60)
+
 set(test_target TestRenderGraphLowering)
 add_executable(${test_target} "RenderGraphLoweringTest.cpp")
 target_link_libraries(${test_target}

--- a/source/test/RenderGraphParameterAccessTest.cpp
+++ b/source/test/RenderGraphParameterAccessTest.cpp
@@ -1,0 +1,630 @@
+#include "rendergraph/RenderGraphPassParameters.h"
+#include "rendergraph/RenderGraphLowering.h"
+#include "rhi/RHIResource.h"
+#include "taskgraph/TaskSystem.h"
+
+#include <atomic>
+#include <cstdlib>
+#include <functional>
+#include <iostream>
+#include <memory>
+#include <string>
+#include <string_view>
+#include <thread>
+
+namespace {
+
+using Moer::Render::Buffer;
+using Moer::Render::BufferInfo;
+using Moer::Render::BufferRef;
+using Moer::Render::CommandList;
+using Moer::Render::RenderGraph;
+using Moer::Render::RenderGraphLowering;
+using Moer::Render::Texture;
+using Moer::Render::TextureInfo;
+using Moer::Render::TextureRef;
+
+class TestSuite {
+public:
+    void Check(
+        bool             condition,
+        std::string_view test_name,
+        std::string_view expectation
+    ) {
+        if (condition) {
+            return;
+        }
+        ++failure_count;
+        std::cerr << "[FAIL] " << test_name << ": " << expectation << '\n';
+    }
+
+    [[nodiscard]] int FailureCount() const {
+        return failure_count;
+    }
+
+private:
+    int failure_count = 0;
+};
+
+[[nodiscard]] bool Contains(std::string_view text, std::string_view fragment) {
+    return text.find(fragment) != std::string_view::npos;
+}
+
+class FakeTexture final : public Texture {
+public:
+    FakeTexture(uint8_t mips, uint16_t layers) :
+        Texture(MakeInfo(mips, layers)) {}
+
+    Moer::uint GetMipByteSize(Moer::uint) const override {
+        return 4;
+    }
+
+    void SetName(std::string_view) override {}
+
+private:
+    static TextureInfo MakeInfo(uint8_t mips, uint16_t layers) {
+        TextureInfo info{};
+        info.usage = ETextureUsageFlags::SAMPLED |
+                     ETextureUsageFlags::UNORDERED_ACCESS |
+                     ETextureUsageFlags::COLOR_ATTACHMENT |
+                     ETextureUsageFlags::TRANSFER_SRC |
+                     ETextureUsageFlags::TRANSFER_DST;
+        info.extent       = {64, 64};
+        info.num_mips     = mips;
+        info.array_size   = layers;
+        info.aspect_flags = ETextureAspectFlags::COLOR;
+        return info;
+    }
+};
+
+class FakeBuffer final : public Buffer {
+public:
+    explicit FakeBuffer(uint64_t byte_size) :
+        Buffer(BufferInfo{
+            byte_size,
+            1,
+            EBufferUsageFlags::UNORDERED_ACCESS |
+                EBufferUsageFlags::TRANSFER_SRC |
+                EBufferUsageFlags::TRANSFER_DST
+        }) {}
+
+    void SetName(std::string_view) override {}
+};
+
+struct ProducerParameters {
+    DEFINE_RG_TEXTURE_ACCESS(
+        texture,
+        RenderGraph::AccessMode::Write,
+        RenderGraph::TextureState::TransferDestination
+    );
+    DEFINE_RG_BUFFER_ACCESS(
+        buffer,
+        RenderGraph::AccessMode::Write,
+        RenderGraph::BufferState::TransferDestination
+    );
+    DEFINE_RG_TOKEN_ACCESS(token, RenderGraph::AccessMode::Write);
+
+    DEFINE_RG_PARAMETER_ACCESS(texture, buffer, token);
+};
+
+struct NestedTextureParameters {
+    DEFINE_RG_TEXTURE_ACCESS(
+        texture,
+        RenderGraph::AccessMode::Read,
+        RenderGraph::TextureState::Sampled
+    );
+
+    DEFINE_RG_PARAMETER_ACCESS(texture);
+};
+
+struct ConsumerParameters {
+    DEFINE_RG_NESTED_PARAMETER(NestedTextureParameters, nested);
+    DEFINE_RG_BUFFER_ACCESS_ARRAY(buffers);
+    DEFINE_RG_OPTIONAL_TOKEN_ACCESS(token, RenderGraph::AccessMode::Read);
+    DEFINE_RG_OPTIONAL_TEXTURE_ACCESS(
+        absent_texture,
+        RenderGraph::AccessMode::Read,
+        RenderGraph::TextureState::Sampled
+    );
+
+    DEFINE_RG_PARAMETER_ACCESS(nested, buffers, token, absent_texture);
+};
+
+struct PlanResult {
+    bool        compiled = false;
+    bool        lowered  = false;
+    std::string error{};
+    std::string graph_dump{};
+    std::string lowered_dump{};
+    RenderGraph::PassExecutionClass consumer_execution =
+        RenderGraph::PassExecutionClass::MainThread;
+    Moer::Render::ERHITranslateExecutionClass consumer_translate =
+        Moer::Render::ERHITranslateExecutionClass::Parallel;
+    uint32_t               consumer_workload = 0;
+    RenderGraph::QueueRole consumer_queue = RenderGraph::QueueRole::None;
+};
+
+PlanResult BuildPlan(
+    bool              parameterized,
+    const TextureRef& physical_texture,
+    const BufferRef&  physical_buffer
+) {
+    RenderGraph graph(
+        "ParameterAccessEquivalence",
+        RenderGraph::QueueTopology::DedicatedQueues()
+    );
+    const auto texture = graph.ImportTexture(
+        "Texture",
+        physical_texture,
+        RenderGraph::TextureDesc{
+            .mip_count   = 4,
+            .layer_count = 2,
+            .aspects     = RenderGraph::TextureAspect::Color,
+        }
+    );
+    const auto buffer = graph.ImportBuffer(
+        "Buffer",
+        physical_buffer,
+        RenderGraph::BufferDesc{.byte_size = 256}
+    );
+    const auto token = graph.CreateTransientToken("Token");
+    const RenderGraph::TextureRange texture_range{
+        .aspects     = RenderGraph::TextureAspect::Color,
+        .mip_first   = 1,
+        .mip_count   = 2,
+        .layer_first = 1,
+        .layer_count = 1,
+    };
+    const RenderGraph::BufferRange buffer_range{.offset = 32, .size = 96};
+    const RenderGraph::BufferRange buffer_read_range{.offset = 32, .size = 48};
+    const RenderGraph::BufferRange buffer_read_write_range{
+        .offset = 80,
+        .size   = 48,
+    };
+
+    graph.SetInitialState(
+        texture,
+        RenderGraph::TextureState::Undefined,
+        RenderGraph::QueueRole::None,
+        RenderGraph::AccessMode::None,
+        texture_range
+    );
+    graph.SetInitialState(
+        buffer,
+        RenderGraph::BufferState::Undefined,
+        RenderGraph::QueueRole::None,
+        RenderGraph::AccessMode::None,
+        buffer_range
+    );
+
+    if (parameterized) {
+        ProducerParameters parameters{};
+        parameters.texture.resource = texture;
+        parameters.texture.range    = texture_range;
+        parameters.buffer.resource  = buffer;
+        parameters.buffer.range     = buffer_range;
+        parameters.token            = token;
+        graph.AddRecordPass(
+            "Producer",
+            std::move(parameters),
+            [](RenderGraph::PassBuilder& builder) {
+                builder.ExecuteOn(
+                           RenderGraph::QueueRole::Copy,
+                           RenderGraph::PipelineType::Copy
+                       )
+                    .SideEffect();
+            },
+            [](CommandList&, const ProducerParameters&) {},
+            RenderGraph::PassExecutionClass::ParallelRecordEligible,
+            3
+        );
+    } else {
+        graph.AddRecordPass(
+            "Producer",
+            [=](RenderGraph::PassBuilder& builder) {
+                builder.ExecuteOn(
+                           RenderGraph::QueueRole::Copy,
+                           RenderGraph::PipelineType::Copy
+                       )
+                    .SideEffect()
+                    .Write(
+                        texture,
+                        RenderGraph::TextureState::TransferDestination,
+                        texture_range
+                    )
+                    .Write(
+                        buffer,
+                        RenderGraph::BufferState::TransferDestination,
+                        buffer_range
+                    )
+                    .Write(token);
+            },
+            [](CommandList&) {},
+            RenderGraph::PassExecutionClass::ParallelRecordEligible,
+            3
+        );
+    }
+
+    if (parameterized) {
+        ConsumerParameters parameters{};
+        parameters.nested.texture.resource = texture;
+        parameters.nested.texture.range    = texture_range;
+        parameters.buffers.emplace_back(
+            Moer::Render::RGBufferAccessElement::Read(
+                buffer,
+                RenderGraph::BufferState::ShaderResource,
+                buffer_read_range
+            )
+        );
+        parameters.buffers.emplace_back(
+            Moer::Render::RGBufferAccessElement::ReadWrite(
+                buffer,
+                RenderGraph::BufferState::UnorderedAccess,
+                buffer_read_write_range
+            )
+        );
+        parameters.token.emplace(token);
+        graph.AddRecordPass(
+            "Consumer",
+            std::move(parameters),
+            [](RenderGraph::PassBuilder& builder) {
+                builder.ExecuteOn(
+                           RenderGraph::QueueRole::Compute,
+                           RenderGraph::PipelineType::Compute
+                       )
+                    .SideEffect()
+                    .TranslateSerialControl();
+            },
+            [](CommandList&, const ConsumerParameters&) {},
+            RenderGraph::PassExecutionClass::ParallelRecordEligible,
+            11
+        );
+    } else {
+        graph.AddRecordPass(
+            "Consumer",
+            [=](RenderGraph::PassBuilder& builder) {
+                builder.ExecuteOn(
+                           RenderGraph::QueueRole::Compute,
+                           RenderGraph::PipelineType::Compute
+                       )
+                    .SideEffect()
+                    .TranslateSerialControl()
+                    .Read(
+                        texture,
+                        RenderGraph::TextureState::Sampled,
+                        texture_range
+                    )
+                    .Read(
+                        buffer,
+                        RenderGraph::BufferState::ShaderResource,
+                        buffer_read_range
+                    )
+                    .ReadWrite(
+                        buffer,
+                        RenderGraph::BufferState::UnorderedAccess,
+                        buffer_read_write_range
+                    )
+                    .Read(token);
+            },
+            [](CommandList&) {},
+            RenderGraph::PassExecutionClass::ParallelRecordEligible,
+            11
+        );
+    }
+
+    graph.Export(
+        texture,
+        RenderGraph::TextureState::ShaderResource,
+        RenderGraph::QueueRole::Compute,
+        RenderGraph::AccessMode::Read,
+        texture_range
+    );
+    graph.Export(
+        buffer,
+        RenderGraph::BufferState::ShaderResource,
+        RenderGraph::QueueRole::Compute,
+        RenderGraph::AccessMode::Read,
+        buffer_range
+    );
+
+    PlanResult result{};
+    result.compiled = graph.Compile();
+    if (!result.compiled) {
+        result.error = graph.GetCompileError();
+        return result;
+    }
+    result.graph_dump = graph.Dump();
+    const auto& plan  = graph.GetCompiledPlan();
+    if (plan.recording_batches.size() == 2) {
+        result.consumer_execution = plan.recording_batches[1].execution;
+        result.consumer_translate =
+            plan.recording_batches[1].translate_execution_class;
+        result.consumer_workload = plan.recording_batches[1].workload;
+        result.consumer_queue    = plan.recording_batches[1].queue.role;
+    }
+
+    RenderGraphLowering::LoweredPlan lowered{};
+    result.lowered = RenderGraphLowering::Lower(graph, lowered, result.error);
+    if (result.lowered) {
+        result.lowered_dump = lowered.Dump();
+    }
+    return result;
+}
+
+void TestParameterizedAccessMatchesManualPlan(TestSuite& suite) {
+    constexpr std::string_view test_name =
+        "parameterized access matches manual plan";
+    TextureRef texture = MoerNew(FakeTexture)(4, 2);
+    BufferRef  buffer  = MoerNew(FakeBuffer)(256);
+
+    const PlanResult manual = BuildPlan(false, texture, buffer);
+    const PlanResult dsl    = BuildPlan(true, texture, buffer);
+
+    suite.Check(manual.compiled, test_name, manual.error);
+    suite.Check(dsl.compiled, test_name, dsl.error);
+    suite.Check(manual.lowered, test_name, manual.error);
+    suite.Check(dsl.lowered, test_name, dsl.error);
+    suite.Check(
+        manual.graph_dump == dsl.graph_dump,
+        test_name,
+        "typed accesses, edges, versions, barriers, waves and batches must be identical"
+    );
+    suite.Check(
+        manual.lowered_dump == dsl.lowered_dump,
+        test_name,
+        "partial-range and cross-queue lowering must be identical"
+    );
+    suite.Check(
+        dsl.consumer_execution ==
+                RenderGraph::PassExecutionClass::ParallelRecordEligible &&
+            dsl.consumer_translate ==
+                Moer::Render::ERHITranslateExecutionClass::SerialControl &&
+            dsl.consumer_workload == 11 &&
+            dsl.consumer_queue == RenderGraph::QueueRole::Compute,
+        test_name,
+        "parameter expansion must preserve explicit recording and queue policy"
+    );
+}
+
+struct RequiredTextureParameters {
+    DEFINE_RG_TEXTURE_ACCESS(
+        texture,
+        RenderGraph::AccessMode::Read,
+        RenderGraph::TextureState::Sampled
+    );
+    DEFINE_RG_PARAMETER_ACCESS(texture);
+};
+
+struct OptionalTextureParameters {
+    DEFINE_RG_OPTIONAL_TEXTURE_ACCESS(
+        texture,
+        RenderGraph::AccessMode::Read,
+        RenderGraph::TextureState::Sampled
+    );
+    DEFINE_RG_PARAMETER_ACCESS(texture);
+};
+
+void TestRequiredAndOptionalHandleContracts(TestSuite& suite) {
+    constexpr std::string_view test_name =
+        "required and optional parameter handles";
+
+    RenderGraph required("RequiredInvalid");
+    required.AddRecordPass(
+        "Required",
+        RequiredTextureParameters{},
+        [](RenderGraph::PassBuilder& builder) { builder.SideEffect(); },
+        [](CommandList&, const RequiredTextureParameters&) {}
+    );
+    suite.Check(
+        !required.Compile() &&
+            Contains(required.GetCompileError(), "declared an invalid resource"),
+        test_name,
+        "a required invalid handle must fail closed"
+    );
+
+    RenderGraph absent("OptionalAbsent");
+    absent.AddRecordPass(
+        "Absent",
+        OptionalTextureParameters{},
+        [](RenderGraph::PassBuilder& builder) { builder.SideEffect(); },
+        [](CommandList&, const OptionalTextureParameters&) {}
+    );
+    suite.Check(
+        absent.Compile(),
+        test_name,
+        absent.GetCompileError()
+    );
+
+    OptionalTextureParameters engaged_parameters{};
+    engaged_parameters.texture.emplace(RenderGraph::TextureHandle{});
+    RenderGraph engaged("OptionalEngagedInvalid");
+    engaged.AddRecordPass(
+        "Engaged",
+        std::move(engaged_parameters),
+        [](RenderGraph::PassBuilder& builder) { builder.SideEffect(); },
+        [](CommandList&, const OptionalTextureParameters&) {}
+    );
+    suite.Check(
+        !engaged.Compile() &&
+            Contains(engaged.GetCompileError(), "declared an invalid resource"),
+        test_name,
+        "an engaged optional access must retain required-handle validation"
+    );
+}
+
+void TestNullableRecordFailsAtDeclaration(TestSuite& suite) {
+    constexpr std::string_view test_name =
+        "nullable parameterized record callback";
+    using NullableRecord =
+        std::function<void(CommandList&, const OptionalTextureParameters&)>;
+
+    bool        setup_called = false;
+    RenderGraph empty_function("EmptyRecordFunction");
+    const auto empty_function_pass = empty_function.AddRecordPass(
+        "EmptyFunction",
+        OptionalTextureParameters{},
+        [&](RenderGraph::PassBuilder&) { setup_called = true; },
+        NullableRecord{}
+    );
+    suite.Check(
+        !empty_function_pass.IsValid() && !setup_called &&
+            !empty_function.Compile() &&
+            Contains(empty_function.GetCompileError(), "no record callback"),
+        test_name,
+        "an empty std::function must preserve the existing declaration-time rejection"
+    );
+
+    using NullableFunctionPointer =
+        void (*)(CommandList&, const OptionalTextureParameters&);
+    NullableFunctionPointer null_record = nullptr;
+    RenderGraph             null_function("NullRecordFunction");
+    const auto null_function_pass = null_function.AddRecordPass(
+        "NullFunction",
+        OptionalTextureParameters{},
+        [](RenderGraph::PassBuilder&) {},
+        null_record
+    );
+    suite.Check(
+        !null_function_pass.IsValid() && !null_function.Compile() &&
+            Contains(null_function.GetCompileError(), "no record callback"),
+        test_name,
+        "a null function pointer must fail before it can reach std::invoke"
+    );
+}
+
+struct LifetimeProbe {
+    explicit LifetimeProbe(std::atomic<int>& destruction_count) :
+        destruction_count(destruction_count) {}
+
+    ~LifetimeProbe() {
+        destruction_count.fetch_add(1, std::memory_order_relaxed);
+    }
+
+    std::atomic<int>& destruction_count;
+};
+
+struct MoveOnlyParameters {
+    Moer::Render::RGTokenAccess<RenderGraph::AccessMode::Write> token{};
+    std::unique_ptr<LifetimeProbe>                              probe{};
+    std::atomic<const void*>*                                  declared_address{};
+    int                                                        payload = 0;
+
+    MoveOnlyParameters() = default;
+    MoveOnlyParameters(const MoveOnlyParameters&) = delete;
+    MoveOnlyParameters& operator=(const MoveOnlyParameters&) = delete;
+    MoveOnlyParameters(MoveOnlyParameters&&) = default;
+    MoveOnlyParameters& operator=(MoveOnlyParameters&&) = default;
+
+    void DeclareRGAccess(
+        Moer::Render::RGParameterAccessCollector& collector
+    ) const {
+        declared_address->store(this, std::memory_order_release);
+        collector.Add(token);
+    }
+};
+
+void TestMoveOnlyParameterLifetimeAndParallelRecord(TestSuite& suite) {
+    constexpr std::string_view test_name =
+        "move-only parameter lifetime and parallel record";
+    std::atomic<int>         destruction_count{0};
+    std::atomic<const void*> declared_address{nullptr};
+    std::atomic<const void*> recorded_address{nullptr};
+    std::atomic<int>         record_count{0};
+    std::atomic<bool>        recorded_on_worker{false};
+    const std::thread::id    caller_thread = std::this_thread::get_id();
+
+    {
+        RenderGraph graph("MoveOnlyParameters");
+        const auto  token = graph.CreateTransientToken("Token");
+        MoveOnlyParameters parameters{};
+        parameters.token            = token;
+        parameters.probe            = std::make_unique<LifetimeProbe>(destruction_count);
+        parameters.declared_address = &declared_address;
+        parameters.payload          = 42;
+
+        graph.AddRecordPass(
+            "Record",
+            std::move(parameters),
+            [](RenderGraph::PassBuilder& builder) {
+                builder.SideEffect();
+            },
+            [&](CommandList&, const MoveOnlyParameters& immutable_parameters) {
+                recorded_on_worker.store(
+                    std::this_thread::get_id() != caller_thread,
+                    std::memory_order_release
+                );
+                recorded_address.store(
+                    &immutable_parameters,
+                    std::memory_order_release
+                );
+                if (immutable_parameters.payload == 42 &&
+                    immutable_parameters.probe != nullptr) {
+                    record_count.fetch_add(1, std::memory_order_relaxed);
+                }
+            },
+            RenderGraph::PassExecutionClass::ParallelRecordEligible,
+            7
+        );
+
+        suite.Check(graph.Compile(), test_name, graph.GetCompileError());
+        size_t published_source_count = 0;
+        Moer::TaskSystem::Init();
+        const bool executed = graph.ExecuteRecording(
+            {},
+            {},
+            true,
+            [&](Moer::Array<Moer::Render::RHIRecordingSource>&& sources) {
+                published_source_count += sources.size();
+            }
+        );
+        Moer::TaskSystem::ShutDown();
+
+        suite.Check(executed, test_name, graph.GetCompileError());
+        suite.Check(
+            record_count.load(std::memory_order_relaxed) == 1 &&
+                published_source_count == 1,
+            test_name,
+            "the graph-owned parameters must reach the managed record callback exactly once"
+        );
+        suite.Check(
+            recorded_on_worker.load(std::memory_order_acquire),
+            test_name,
+            "ParallelRecordEligible parameters must be consumed on a task worker"
+        );
+        suite.Check(
+            declared_address.load(std::memory_order_acquire) ==
+                recorded_address.load(std::memory_order_acquire),
+            test_name,
+            "declaration and recording must observe the same immutable parameter object"
+        );
+        suite.Check(
+            destruction_count.load(std::memory_order_relaxed) == 0,
+            test_name,
+            "the parameter payload must remain alive through recording"
+        );
+    }
+
+    suite.Check(
+        destruction_count.load(std::memory_order_relaxed) == 1,
+        test_name,
+        "the graph-owned move-only parameter payload must be destroyed exactly once"
+    );
+}
+
+} // namespace
+
+int main() {
+    TestSuite suite;
+    TestParameterizedAccessMatchesManualPlan(suite);
+    TestRequiredAndOptionalHandleContracts(suite);
+    TestNullableRecordFailsAtDeclaration(suite);
+    TestMoveOnlyParameterLifetimeAndParallelRecord(suite);
+
+    if (suite.FailureCount() != 0) {
+        std::cerr << "TestRenderGraphParameterAccess: "
+                  << suite.FailureCount() << " failure(s)\n";
+        return EXIT_FAILURE;
+    }
+    std::cout << "TestRenderGraphParameterAccess: all checks passed\n";
+    return EXIT_SUCCESS;
+}


### PR DESCRIPTION
## Summary

- add a graph-owned immutable RDG pass-parameter access DSL on top of the existing explicit `PassBuilder` compiler contract
- support required/optional texture, buffer and token accesses, nested parameters, partial ranges, and owning homogeneous/heterogeneous access arrays
- migrate the RT AntiAlias upload and dispatch passes as the first production caller without changing queue, pipeline, state, recording, or graph-boundary semantics
- add graph/lowering equivalence, fail-closed validation, nullable callback, move-only lifetime, and real worker-thread tests

## Validation

- Debug `MoerEditor` build: passed
- Debug CTest: 47/47 passed
- Release `RenderGraphParameterAccessContract`: passed
- Vulkan + Raytracing runtime smoke: 174 seconds; first present, RDG warmup, and upper submission topology healthy; no validation error, device lost, fatal, or stderr output
- local independent review: no remaining P0-P2

## Known limitations / excluded scope

- `DEFINE_RG_PARAMETER_ACCESS(...)` remains an explicit field list; C++ reflection does not diagnose an omitted field
- this phase does not change RDG compiler/lowering semantics and does not bulk-migrate unrelated passes
- the repository's third-party GKlib `ALL_BUILD` target has a pre-existing MSVC `/io.h` `C1083`; explicit editor and configured test targets pass