### PR TITLE
RDG: add asynchronous setup preparation

### DIFF
--- a/source/runtime/core/include/taskgraph/TaskGraph.h
+++ b/source/runtime/core/include/taskgraph/TaskGraph.h
@@ -41,10 +41,10 @@ public:
     inline uint32_t        GetWorkerThreadCount() const {
         return m_worker_thread_count;
     }
+    /** Returns the scheduler identity of the caller, or UNKNOWN for an external thread. */
+    CORE_API EThread::Type GetCurrentThread(bool localQueue = false);
 
 protected:
-    EThread::Type GetCurrentThread(bool localQueue = false);
-
     void TriggerEventWhenTasksComplete(
         Event*                 event,
         const GraphEventArray& task_events,

--- a/source/runtime/render/renderer/raytracing/AntiAliasPass.cpp
+++ b/source/runtime/render/renderer/raytracing/AntiAliasPass.cpp
@@ -29,38 +29,52 @@ AntialiasPass::AntialiasPass(RenderDevice& _device, ShaderManager& _manager, Cre
     recording_owner = std::move(owner);
 }
 
-AntialiasPass::PreparedCommand AntialiasPass::Prepare(
+AntialiasPass::SetupInput AntialiasPass::CaptureSetupInput(
     Params            params,
     bool              prev_view_valid,
     const TextureRef& input,
     const TextureRef& output
 ) const {
+    return SetupInput{
+        .params          = params,
+        .input_extent    = uint2(input->GetExtent().x, input->GetExtent().y),
+        .output_extent   = uint2(output->GetExtent().x, output->GetExtent().y),
+        .pixel_offset    = GetPixelOffset(),
+        .prev_view_valid = prev_view_valid,
+    };
+}
+
+AntialiasPass::PreparedCommand AntialiasPass::Prepare(
+    const SetupInput& input
+) {
     PreparedCommand command{};
     command.params.in_view_origin = float2(0.f);
     command.params.in_view_size =
-        float2(input->GetExtent().x, input->GetExtent().y);
+        float2(input.input_extent.x, input.input_extent.y);
     command.params.out_view_origin = float2(0.f);
     command.params.out_view_size =
-        float2(output->GetExtent().x, output->GetExtent().y);
-    command.params.in_pixel_offset      = GetPixelOffset();
+        float2(input.output_extent.x, input.output_extent.y);
+    command.params.in_pixel_offset      = input.pixel_offset;
     command.params.out_texture_size_inv = float2(
-        1.f / output->GetExtent().x,
-        1.f / output->GetExtent().y
+        1.f / input.output_extent.x,
+        1.f / input.output_extent.y
     );
     command.params.input_over_output_size =
         command.params.in_view_size / command.params.out_view_size;
     command.params.output_over_input_size =
         command.params.out_view_size / command.params.in_view_size;
     command.params.clamping_factor =
-        params.enable_history_clamp ? params.clamping_factor : -1.f;
+        input.params.enable_history_clamp ?
+            input.params.clamping_factor :
+            -1.f;
     command.params.new_frame_weight =
-        prev_view_valid ? params.new_frame_weight : 1.f;
+        input.prev_view_valid ? input.params.new_frame_weight : 1.f;
     command.params.pqc =
-        std::clamp(params.max_radiance, 1e-4f, 1e8f);
+        std::clamp(input.params.max_radiance, 1e-4f, 1e8f);
     command.params.inv_pqc = 1.f / command.params.pqc;
     command.dispatch_groups = uint3(
-        (output->GetExtent().x + 15) / 16,
-        (output->GetExtent().y + 15) / 16,
+        (input.output_extent.x + 15) / 16,
+        (input.output_extent.y + 15) / 16,
         1
     );
     return command;
@@ -121,8 +135,9 @@ void AntialiasPass::Process(
     TextureRef   input,
     TextureRef   output
 ) {
-    const PreparedCommand command =
-        Prepare(params, prev_view_valid, input, output);
+    const PreparedCommand command = Prepare(
+        CaptureSetupInput(params, prev_view_valid, input, output)
+    );
     const RecordResources resources =
         CaptureResources(std::move(input), std::move(output));
     const auto owner = recording_owner;
@@ -159,8 +174,8 @@ bool AntialiasPass::AddPasses(
         !feedback_color_ping || !feedback_color_pong) {
         return false;
     }
-    const PreparedCommand command =
-        Prepare(params, prev_view_valid, input, output);
+    SetupInput setup_input =
+        CaptureSetupInput(params, prev_view_valid, input, output);
     const RecordResources resources =
         CaptureResources(std::move(input), std::move(output));
     if (!resources.input || !resources.output || !resources.motion ||
@@ -216,6 +231,15 @@ bool AntialiasPass::AddPasses(
         );
     }
 
+    const auto command = graph.AddSetupPass(
+        "RT.AntiAlias.Prepare",
+        std::move(setup_input),
+        [](const SetupInput& input) { return Prepare(input); }
+    );
+    if (!command.IsValid()) {
+        return false;
+    }
+
     UploadGraphParameters upload_parameters{};
     upload_parameters.constants = constants;
     upload_parameters.owner     = owner;
@@ -238,7 +262,7 @@ bool AntialiasPass::AddPasses(
             RecordConstantsUpload(
                 cmd_list,
                 *parameters.owner,
-                parameters.command
+                parameters.command.Get()
             );
         },
         RenderGraph::PassExecutionClass::ParallelRecordEligible
@@ -273,7 +297,7 @@ bool AntialiasPass::AddPasses(
             RecordTAA(
                 cmd_list,
                 *parameters.owner,
-                parameters.command,
+                parameters.command.Get(),
                 parameters.resources
             );
         },

--- a/source/runtime/render/renderer/raytracing/AntiAliasPass.h
+++ b/source/runtime/render/renderer/raytracing/AntiAliasPass.h
@@ -78,6 +78,14 @@ public:
     bool   IsHistoryReadyForGraph() const;
 
 private:
+    struct SetupInput {
+        Params params{};
+        uint2  input_extent{};
+        uint2  output_extent{};
+        float2 pixel_offset{};
+        bool   prev_view_valid = false;
+    };
+
     struct RecordingOwner {
         BufferRef   constants{};
         TAAPipeline pipeline{};
@@ -90,7 +98,7 @@ private:
             RenderGraph::BufferState::TransferDestination
         );
         SharedPtr<RecordingOwner> owner{};
-        PreparedCommand           command{};
+        RGPreparedValue<PreparedCommand> command{};
 
         DEFINE_RG_PARAMETER_ACCESS(constants);
     };
@@ -127,7 +135,7 @@ private:
             RenderGraph::TextureState::UnorderedAccess
         );
         SharedPtr<RecordingOwner> owner{};
-        PreparedCommand           command{};
+        RGPreparedValue<PreparedCommand> command{};
         RecordResources           resources{};
 
         DEFINE_RG_PARAMETER_ACCESS(
@@ -140,12 +148,13 @@ private:
         );
     };
 
-    PreparedCommand Prepare(
+    SetupInput CaptureSetupInput(
         Params            params,
         bool              prev_view_valid,
         const TextureRef& input,
         const TextureRef& output
     ) const;
+    static PreparedCommand Prepare(const SetupInput& input);
     RecordResources CaptureResources(
         TextureRef input,
         TextureRef output

--- a/source/runtime/render/rendergraph/RenderGraph.cpp
+++ b/source/runtime/render/rendergraph/RenderGraph.cpp
@@ -23,6 +23,12 @@
 
 namespace Moer::Render {
 
+namespace {
+
+struct InjectedSetupDispatchFault {};
+
+} // namespace
+
 struct RenderGraph::SetupBatchState {
     enum class Status : uint8_t {
         Pending,
@@ -3687,16 +3693,15 @@ void RenderGraph::DispatchSetupPassesAsync() {
         return;
     }
 
-    // Build empty shared ownership before moving any declarations. The custom
-    // MakeShared performs object and control-block allocation separately; if
-    // either throws, setup_passes must still own every failure callback so no
-    // externally held RGPreparedValue can remain Pending.
+    // Establish throwing, single-allocation shared ownership before moving any
+    // declarations. If owner creation throws, setup_passes still owns every
+    // failure callback so no externally held RGPreparedValue remains Pending.
     try {
         if ((setup_faults_for_testing &
              static_cast<uint8_t>(SetupFaultForTesting::BatchOwnerCreate)) != 0) {
             throw std::bad_alloc{};
         }
-        auto candidate = MakeShared<SetupBatchState>();
+        auto candidate = std::make_shared<SetupBatchState>();
         candidate->AdoptJobs(std::move(setup_passes), setup_faults_for_testing);
         setup_batch      = std::move(candidate);
         setup_dispatched = true;
@@ -3724,8 +3729,8 @@ void RenderGraph::DispatchSetupPassesAsync() {
     const auto batch = setup_batch;
     try {
         if ((setup_faults_for_testing &
-             static_cast<uint8_t>(SetupFaultForTesting::TaskDispatch)) != 0) {
-            throw std::bad_alloc{};
+             static_cast<uint8_t>(SetupFaultForTesting::TaskDispatchThrows)) != 0) {
+            throw InjectedSetupDispatchFault{};
         }
         (void)LambdaTask::Dispatch([batch] { batch->Run(); });
     } catch (const std::exception& exception) {

--- a/source/runtime/render/rendergraph/RenderGraph.cpp
+++ b/source/runtime/render/rendergraph/RenderGraph.cpp
@@ -3726,6 +3726,23 @@ void RenderGraph::DispatchSetupPassesAsync() {
         return;
     }
 
+    // A Normal-priority worker cannot block waiting for work queued back to
+    // the same bounded pool. If every worker compiled a graph concurrently,
+    // asynchronous dispatch would otherwise starve all setup jobs. Main,
+    // render, external, and other-priority callers retain compile overlap.
+    const EThread::Type current_thread =
+        TaskGraph::GetInterface().GetCurrentThread();
+    const ThreadIndex current_index = EThread::GetThreadIndex(current_thread);
+    const bool current_is_normal_worker =
+        current_index >= EThread::NamedThreadCount &&
+        current_index != EThread::UNKNOWN_THREAD &&
+        EThread::GetThreadPriority(current_thread) ==
+            EThread::GetThreadPriority(EThread::AnyThread_NormalPri);
+    if (current_is_normal_worker) {
+        setup_batch->Run();
+        return;
+    }
+
     const auto batch = setup_batch;
     try {
         if ((setup_faults_for_testing &

--- a/source/runtime/render/rendergraph/RenderGraph.cpp
+++ b/source/runtime/render/rendergraph/RenderGraph.cpp
@@ -12,14 +12,287 @@
 #include <algorithm>
 #include <atomic>
 #include <cassert>
+#include <condition_variable>
 #include <exception>
 #include <limits>
 #include <mutex>
+#include <new>
 #include <sstream>
 #include <unordered_set>
 #include <utility>
 
 namespace Moer::Render {
+
+struct RenderGraph::SetupBatchState {
+    enum class Status : uint8_t {
+        Pending,
+        Succeeded,
+        Failed,
+    };
+
+    SetupBatchState() = default;
+
+    void AdoptJobs(
+        std::vector<SetupPassDeclaration>&& declarations,
+        uint8_t                             faults_for_testing
+    ) noexcept {
+        static_assert(std::is_nothrow_move_assignable_v<
+                      std::vector<SetupPassDeclaration>>);
+        jobs       = std::move(declarations);
+        fault_mask = faults_for_testing;
+    }
+
+    void Run() noexcept {
+        try {
+            for (size_t index = 0; index < jobs.size(); ++index) {
+                try {
+                    jobs[index].execute();
+                } catch (const std::exception& exception) {
+                    HandleExecutionFailure(index, exception.what());
+                    return;
+                } catch (...) {
+                    HandleExecutionFailure(index, nullptr);
+                    return;
+                }
+            }
+            CompleteSucceeded();
+        } catch (...) {
+            // This is deliberately allocation-free until every value and the
+            // aggregate gate have a terminal failure state. It is the final
+            // guard against an unexpected exception escaping a noexcept task.
+            TerminalizeAllPending(kCallbackFailed);
+            CompleteFailedWithoutDiagnostic(kCallbackFailed);
+        }
+    }
+
+    void FailBeforeDispatch(const char* reason) noexcept {
+        TerminalizeAllPending(kDispatchFailed);
+
+        std::string diagnostic{};
+        const bool diagnostic_available = TryBuildDispatchDiagnostic(
+            reason,
+            diagnostic
+        );
+        if (diagnostic_available) {
+            AnnotateAllFailed(diagnostic);
+        }
+        CompleteFailed(
+            kDispatchFailed,
+            std::move(diagnostic),
+            !diagnostic_available
+        );
+    }
+
+    [[nodiscard]] bool Wait(std::string& out_error) noexcept {
+        try {
+            std::unique_lock lock(mutex);
+            completion.wait(lock, [&] { return status != Status::Pending; });
+            if (status == Status::Succeeded) {
+                try {
+                    out_error.clear();
+                } catch (...) {
+                }
+                return true;
+            }
+
+            const char* fallback = diagnostic_storage_failed ?
+                                       kDiagnosticUnavailable :
+                                       fallback_error;
+            try {
+                out_error = error.empty() ? fallback : error;
+            } catch (...) {
+            }
+            return false;
+        } catch (...) {
+            return false;
+        }
+    }
+
+private:
+    static constexpr const char* kCallbackFailed =
+        "asynchronous RenderGraph setup failed";
+    static constexpr const char* kCallbackSkipped =
+        "asynchronous RenderGraph setup skipped after an earlier failure";
+    static constexpr const char* kDispatchFailed =
+        "failed to dispatch asynchronous RenderGraph setup";
+    static constexpr const char* kDiagnosticUnavailable =
+        "asynchronous RenderGraph setup failed (diagnostic unavailable)";
+
+    [[nodiscard]] bool HasFault(SetupFaultForTesting fault) const noexcept {
+        return (fault_mask & static_cast<uint8_t>(fault)) != 0;
+    }
+
+    void HandleExecutionFailure(size_t failed_index, const char* reason) noexcept {
+        // Publish fallback terminal states before attempting any detailed
+        // diagnostic allocation.
+        FailJob(jobs[failed_index], kCallbackFailed);
+        for (size_t index = failed_index + 1; index < jobs.size(); ++index) {
+            FailJob(jobs[index], kCallbackSkipped);
+        }
+
+        std::string diagnostic{};
+        const bool diagnostic_available = TryBuildCallbackDiagnostic(
+            failed_index,
+            reason,
+            diagnostic
+        );
+        if (diagnostic_available) {
+            AnnotateJob(jobs[failed_index], diagnostic);
+        }
+        CompleteFailed(
+            kCallbackFailed,
+            std::move(diagnostic),
+            !diagnostic_available
+        );
+    }
+
+    [[nodiscard]] bool TryBuildCallbackDiagnostic(
+        size_t       failed_index,
+        const char*  reason,
+        std::string& diagnostic
+    ) const noexcept {
+        if (HasFault(SetupFaultForTesting::FailureDiagnostic)) {
+            return false;
+        }
+        try {
+            diagnostic = "async setup pass '";
+            diagnostic += jobs[failed_index].name;
+            diagnostic += "' failed";
+            if (reason != nullptr && reason[0] != '\0') {
+                diagnostic += ": ";
+                diagnostic += reason;
+            } else {
+                diagnostic += " with an unknown exception";
+            }
+            return true;
+        } catch (...) {
+            diagnostic.clear();
+            return false;
+        }
+    }
+
+    [[nodiscard]] bool TryBuildDispatchDiagnostic(
+        const char*  reason,
+        std::string& diagnostic
+    ) const noexcept {
+        if (HasFault(SetupFaultForTesting::FailureDiagnostic)) {
+            return false;
+        }
+        try {
+            diagnostic = kDispatchFailed;
+            if (reason != nullptr && reason[0] != '\0') {
+                diagnostic += ": ";
+                diagnostic += reason;
+            }
+            return true;
+        } catch (...) {
+            diagnostic.clear();
+            return false;
+        }
+    }
+
+    void TerminalizeAllPending(std::string_view message) noexcept {
+        for (const auto& job : jobs) {
+            FailJob(job, message);
+        }
+    }
+
+    void AnnotateAllFailed(std::string_view message) noexcept {
+        for (const auto& job : jobs) {
+            AnnotateJob(job, message);
+        }
+    }
+
+    static void FailJob(
+        const SetupPassDeclaration& job,
+        std::string_view            message
+    ) noexcept {
+        try {
+            if (job.fail) {
+                job.fail(message);
+            }
+        } catch (...) {
+        }
+    }
+
+    static void AnnotateJob(
+        const SetupPassDeclaration& job,
+        std::string_view            message
+    ) noexcept {
+        try {
+            if (job.annotate_failure) {
+                job.annotate_failure(message);
+            }
+        } catch (...) {
+        }
+    }
+
+    void CompleteSucceeded() noexcept {
+        try {
+            {
+                std::lock_guard lock(mutex);
+                if (status != Status::Pending) {
+                    return;
+                }
+                status = Status::Succeeded;
+            }
+            completion.notify_all();
+        } catch (...) {
+        }
+    }
+
+    void CompleteFailed(
+        const char* fallback,
+        std::string diagnostic,
+        bool        diagnostic_unavailable
+    ) noexcept {
+        try {
+            {
+                std::lock_guard lock(mutex);
+                if (status != Status::Pending) {
+                    return;
+                }
+                // Aggregate failure is published before retaining diagnostics.
+                status                    = Status::Failed;
+                fallback_error            = fallback;
+                diagnostic_storage_failed = diagnostic_unavailable;
+                try {
+                    error = std::move(diagnostic);
+                } catch (...) {
+                    error.clear();
+                    diagnostic_storage_failed = true;
+                }
+            }
+            completion.notify_all();
+        } catch (...) {
+            CompleteFailedWithoutDiagnostic(fallback);
+        }
+    }
+
+    void CompleteFailedWithoutDiagnostic(const char* fallback) noexcept {
+        try {
+            {
+                std::lock_guard lock(mutex);
+                if (status == Status::Pending) {
+                    status         = Status::Failed;
+                    fallback_error = fallback;
+                    diagnostic_storage_failed = true;
+                }
+            }
+            completion.notify_all();
+        } catch (...) {
+        }
+    }
+
+    std::vector<SetupPassDeclaration> jobs{};
+    std::mutex                        mutex{};
+    std::condition_variable           completion{};
+    std::string                       error{};
+    const char*                       fallback_error = kCallbackFailed;
+    Status                            status = Status::Pending;
+    uint8_t                           fault_mask = 0;
+    bool                              diagnostic_storage_failed = false;
+};
 
 namespace {
 
@@ -298,7 +571,26 @@ RenderGraph::RenderGraph(std::string_view graph_name, QueueTopology topology) :
     assert(graph_id != 0 && "RenderGraph id counter wrapped.");
 }
 
-RenderGraph::~RenderGraph() = default;
+RenderGraph::~RenderGraph() {
+    if (!setup_dispatched) {
+        for (const auto& setup : setup_passes) {
+            try {
+                if (setup.fail) {
+                    setup.fail(
+                        "RenderGraph was destroyed before async setup ran"
+                    );
+                }
+            } catch (...) {
+            }
+        }
+        return;
+    }
+    try {
+        std::string ignored{};
+        (void)WaitSetupPasses(ignored);
+    } catch (...) {
+    }
+}
 
 RenderGraph::PassBuilder& RenderGraph::PassBuilder::Read(ResourceHandle resource, std::string_view range) {
     ResourceRange typed_range = ResourceRange::Token();
@@ -1255,7 +1547,32 @@ bool RenderGraph::Compile() {
         return false;
     }
     MOER_PROFILE_SCOPE("RenderGraph.Compile");
-    return RenderGraphCompiler(*this).Compile();
+    DispatchSetupPassesAsync();
+
+    bool compiler_succeeded = false;
+    try {
+        compiler_succeeded = RenderGraphCompiler(*this).Compile();
+    } catch (...) {
+        std::string ignored{};
+        (void)WaitSetupPasses(ignored);
+        throw;
+    }
+
+    std::string setup_error{};
+    const bool  setup_succeeded = WaitSetupPasses(setup_error);
+    if (setup_succeeded) {
+        return compiler_succeeded;
+    }
+
+    compiled = false;
+    if (compiler_succeeded || compile_error.empty()) {
+        compile_error = setup_error.empty() ?
+                            "asynchronous RenderGraph setup failed" :
+                            std::move(setup_error);
+    } else if (!setup_error.empty()) {
+        compile_error += "; " + setup_error;
+    }
+    return false;
 }
 
 bool RenderGraph::Execute() {
@@ -3323,9 +3640,146 @@ void RenderGraph::SetPassTranslateExecutionClass(
     passes[pass_index].translate_execution_class = execution_class;
 }
 
+bool RenderGraph::RegisterSetupPass(
+    std::string_view                         setup_name,
+    std::function<void()>                    execute,
+    std::function<void(std::string_view)>    fail,
+    std::function<void(std::string_view)>    annotate_failure
+) {
+    if (!InvalidateCompile()) {
+        return false;
+    }
+    if (setup_name.empty()) {
+        declaration_errors.emplace_back("setup pass name cannot be empty");
+        return false;
+    }
+    if (!execute || !fail || !annotate_failure) {
+        declaration_errors.emplace_back(
+            "setup pass has no prepare callback: " +
+            std::string(setup_name)
+        );
+        return false;
+    }
+    if (std::any_of(
+            setup_passes.begin(),
+            setup_passes.end(),
+            [&](const SetupPassDeclaration& setup) {
+                return setup.name == setup_name;
+            }
+        )) {
+        declaration_errors.emplace_back(
+            "duplicate setup pass name: " + std::string(setup_name)
+        );
+        return false;
+    }
+
+    setup_passes.emplace_back(SetupPassDeclaration{
+        .name    = std::string(setup_name),
+        .execute = std::move(execute),
+        .fail    = std::move(fail),
+        .annotate_failure = std::move(annotate_failure),
+    });
+    return true;
+}
+
+void RenderGraph::DispatchSetupPassesAsync() {
+    if (setup_dispatched || setup_passes.empty()) {
+        return;
+    }
+
+    // Build empty shared ownership before moving any declarations. The custom
+    // MakeShared performs object and control-block allocation separately; if
+    // either throws, setup_passes must still own every failure callback so no
+    // externally held RGPreparedValue can remain Pending.
+    try {
+        if ((setup_faults_for_testing &
+             static_cast<uint8_t>(SetupFaultForTesting::BatchOwnerCreate)) != 0) {
+            throw std::bad_alloc{};
+        }
+        auto candidate = MakeShared<SetupBatchState>();
+        candidate->AdoptJobs(std::move(setup_passes), setup_faults_for_testing);
+        setup_batch      = std::move(candidate);
+        setup_dispatched = true;
+        setup_passes.clear();
+    } catch (...) {
+        setup_failed_before_batch = true;
+        setup_dispatched          = true;
+        for (const auto& setup : setup_passes) {
+            try {
+                if (setup.fail) {
+                    setup.fail("RenderGraph async setup batch creation failed");
+                }
+            } catch (...) {
+            }
+        }
+        setup_passes.clear();
+        return;
+    }
+
+    if (!TaskGraph::IsInitialized()) {
+        setup_batch->Run();
+        return;
+    }
+
+    const auto batch = setup_batch;
+    try {
+        if ((setup_faults_for_testing &
+             static_cast<uint8_t>(SetupFaultForTesting::TaskDispatch)) != 0) {
+            throw std::bad_alloc{};
+        }
+        (void)LambdaTask::Dispatch([batch] { batch->Run(); });
+    } catch (const std::exception& exception) {
+        batch->FailBeforeDispatch(exception.what());
+    } catch (...) {
+        batch->FailBeforeDispatch(nullptr);
+    }
+}
+
+bool RenderGraph::WaitSetupPasses(std::string& error) noexcept {
+    if (setup_failed_before_batch) {
+        try {
+            error = "RenderGraph async setup batch creation failed";
+        } catch (...) {
+        }
+        return false;
+    }
+    if (!setup_batch) {
+        return true;
+    }
+    try {
+        return setup_batch->Wait(error);
+    } catch (const std::exception& exception) {
+        try {
+            error = std::string("failed to join asynchronous RenderGraph setup: ") +
+                    exception.what();
+        } catch (...) {
+        }
+    } catch (...) {
+        try {
+            error = "failed to join asynchronous RenderGraph setup";
+        } catch (...) {
+        }
+    }
+    return false;
+}
+
 bool RenderGraph::InvalidateCompile() {
     if (executed) {
         declaration_errors.emplace_back("graph declarations cannot be mutated after execution");
+        return false;
+    }
+    if (setup_dispatched) {
+        compiled = false;
+        compile_error.clear();
+        compiled_plan.Clear();
+        ReleaseNonExportedTransientBindings();
+        for (auto& resource : resources) {
+            resource.first_use = PassHandle::InvalidIndex;
+            resource.last_use  = PassHandle::InvalidIndex;
+        }
+        declaration_errors.emplace_back(
+            "graph declarations cannot be mutated after asynchronous setup dispatch"
+        );
         return false;
     }
     compiled = false;

--- a/source/runtime/render/rendergraph/RenderGraph.h
+++ b/source/runtime/render/rendergraph/RenderGraph.h
@@ -1037,10 +1037,10 @@ private:
     friend class RenderGraphAsyncSetupTestAccess;
 
     enum class SetupFaultForTesting : uint8_t {
-        None              = 0,
-        BatchOwnerCreate  = 1 << 0,
-        TaskDispatch      = 1 << 1,
-        FailureDiagnostic = 1 << 2,
+        None               = 0,
+        BatchOwnerCreate   = 1 << 0,
+        TaskDispatchThrows = 1 << 1,
+        FailureDiagnostic  = 1 << 2,
     };
 
     struct AccessDeclaration {

--- a/source/runtime/render/rendergraph/RenderGraph.h
+++ b/source/runtime/render/rendergraph/RenderGraph.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "RenderAPI.h"
+#include "misc/STL.h"
 #include "rendergraph/RenderGraphResourcePool.h"
 #include "rhi/RHIExecutor.h"
 
@@ -20,6 +21,14 @@ namespace Moer::Render {
 class RenderGraphCompiler;
 class RenderGraphLowering;
 class RGParameterAccessCollector;
+class RenderGraphAsyncSetupTestAccess;
+template<typename T>
+class RGPreparedValue;
+
+template<typename Input, typename Prepare>
+using RGSetupResult = std::remove_cvref_t<std::invoke_result_t<
+    std::decay_t<Prepare>&,
+    const std::decay_t<Input>&>>;
 
 template<typename T>
 concept RGParameterAccessProvider =
@@ -918,6 +927,29 @@ public:
         BufferRange  range       = BufferRange::Whole()
     );
 
+    /**
+     * Schedules one graph-owned, pure CPU preparation callback. Setup may run
+     * concurrently with compilation, is joined before Compile() returns, and
+     * publishes one immutable result for later recording callbacks.
+     */
+    template<typename Input, typename Prepare>
+        requires std::invocable<
+                     std::decay_t<Prepare>&,
+                     const std::decay_t<Input>&> &&
+                 (!std::is_void_v<RGSetupResult<Input, Prepare>>) &&
+                 (!std::is_reference_v<
+                     std::invoke_result_t<
+                         std::decay_t<Prepare>&,
+                         const std::decay_t<Input>&>>) &&
+                 std::move_constructible<RGSetupResult<Input, Prepare>> &&
+                 std::constructible_from<std::decay_t<Input>, Input&&> &&
+                 std::constructible_from<std::decay_t<Prepare>, Prepare&&>
+    auto AddSetupPass(
+        std::string_view name,
+        Input&&          immutable_input,
+        Prepare&&        prepare
+    ) -> RGPreparedValue<RGSetupResult<Input, Prepare>>;
+
     PassHandle AddPass(std::string_view name, const SetupCallback& setup, ExecuteCallback execute);
     PassHandle AddRecordPass(
         std::string_view     name,
@@ -1002,6 +1034,14 @@ private:
     friend class RenderGraphCompiler;
     friend class RenderGraphLowering;
     friend class RenderGraphTransientAllocator;
+    friend class RenderGraphAsyncSetupTestAccess;
+
+    enum class SetupFaultForTesting : uint8_t {
+        None              = 0,
+        BatchOwnerCreate  = 1 << 0,
+        TaskDispatch      = 1 << 1,
+        FailureDiagnostic = 1 << 2,
+    };
 
     struct AccessDeclaration {
         ResourceHandle resource{};
@@ -1057,6 +1097,15 @@ private:
         uint32_t                       workload = 1;
     };
 
+    struct SetupPassDeclaration {
+        std::string                              name{};
+        std::function<void()>                    execute{};
+        std::function<void(std::string_view)>    fail{};
+        std::function<void(std::string_view)>    annotate_failure{};
+    };
+
+    struct SetupBatchState;
+
     ResourceHandle ImportInternal(
         std::string_view   name,
         ResourceKind       kind,
@@ -1103,6 +1152,14 @@ private:
         uint32_t                    pass_index,
         ERHITranslateExecutionClass execution_class
     );
+    bool RegisterSetupPass(
+        std::string_view                         setup_name,
+        std::function<void()>                    execute,
+        std::function<void(std::string_view)>    fail,
+        std::function<void(std::string_view)>    annotate_failure
+    );
+    void DispatchSetupPassesAsync();
+    bool WaitSetupPasses(std::string& error) noexcept;
     bool InvalidateCompile();
     bool FailCompile(std::string message);
 
@@ -1112,6 +1169,8 @@ private:
     std::string                      name{};
     std::vector<ResourceDeclaration> resources{};
     std::vector<PassDeclaration>     passes{};
+    std::vector<SetupPassDeclaration> setup_passes{};
+    SharedPtr<SetupBatchState>        setup_batch{};
     CompiledPlan                     compiled_plan{};
     std::vector<std::string>         declaration_errors{};
     std::string                      compile_error{};
@@ -1119,8 +1178,12 @@ private:
     QueueTopology                    queue_topology{};
     bool                             compiled = false;
     bool                             executed = false;
+    bool                             setup_dispatched = false;
+    bool                             setup_failed_before_batch = false;
+    uint8_t                          setup_faults_for_testing = 0;
 };
 
 } // namespace Moer::Render
 
 #include "RenderGraphPassParameters.h"
+#include "RenderGraphSetup.h"

--- a/source/runtime/render/rendergraph/RenderGraphSetup.h
+++ b/source/runtime/render/rendergraph/RenderGraphSetup.h
@@ -194,11 +194,11 @@ auto RenderGraph::AddSetupPass(
         }
     }
 
-    auto state = MakeShared<StateType>();
-    SharedPtr<const InputType> input_owner = MakeShared<InputType>(
+    auto state = std::make_shared<StateType>();
+    SharedPtr<const InputType> input_owner = std::make_shared<InputType>(
         std::forward<Input>(immutable_input)
     );
-    auto prepare_owner = MakeShared<PrepareType>(
+    auto prepare_owner = std::make_shared<PrepareType>(
         std::forward<Prepare>(prepare)
     );
 

--- a/source/runtime/render/rendergraph/RenderGraphSetup.h
+++ b/source/runtime/render/rendergraph/RenderGraphSetup.h
@@ -1,0 +1,219 @@
+#pragma once
+
+#include "RenderGraph.h"
+#include "misc/STL.h"
+
+#include <mutex>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <type_traits>
+#include <utility>
+
+namespace Moer::Render {
+
+namespace Detail {
+
+enum class ERGSetupState : uint8_t {
+    Pending,
+    Succeeded,
+    Failed,
+};
+
+/** Write-once storage shared by one setup producer and immutable consumers. */
+template<typename T>
+class RGSetupState {
+public:
+    RGSetupState() = default;
+
+    RGSetupState(const RGSetupState&)            = delete;
+    RGSetupState& operator=(const RGSetupState&) = delete;
+
+    template<typename Value>
+        requires std::constructible_from<T, Value&&>
+    void Publish(Value&& published_value) {
+        std::lock_guard lock(mutex);
+        if (state != ERGSetupState::Pending) {
+            throw std::logic_error("RDG setup result was published more than once");
+        }
+        value.emplace(std::forward<Value>(published_value));
+        state = ERGSetupState::Succeeded;
+    }
+
+    void Fail(std::string_view message) noexcept {
+        try {
+            std::lock_guard lock(mutex);
+            if (state != ERGSetupState::Pending) {
+                return;
+            }
+            // Terminal state is independent from best-effort diagnostics. An
+            // allocation failure while retaining the message must never leave
+            // a prepared value Pending.
+            state = ERGSetupState::Failed;
+            try {
+                error.assign(message);
+            } catch (...) {
+                error.clear();
+            }
+        } catch (...) {
+        }
+    }
+
+    void AnnotateFailure(std::string_view message) noexcept {
+        try {
+            std::lock_guard lock(mutex);
+            if (state != ERGSetupState::Failed) {
+                return;
+            }
+            try {
+                error.assign(message);
+            } catch (...) {
+            }
+        } catch (...) {
+        }
+    }
+
+    [[nodiscard]] const T& Get() const {
+        std::lock_guard lock(mutex);
+        if (state == ERGSetupState::Pending) {
+            throw std::logic_error(
+                "RDG prepared value was read before setup completed"
+            );
+        }
+        if (state == ERGSetupState::Failed) {
+            throw std::runtime_error(
+                error.empty() ? "RDG setup failed" : error
+            );
+        }
+        return *value;
+    }
+
+    [[nodiscard]] bool IsReady() const {
+        std::lock_guard lock(mutex);
+        return state == ERGSetupState::Succeeded;
+    }
+
+    [[nodiscard]] bool HasFailed() const {
+        std::lock_guard lock(mutex);
+        return state == ERGSetupState::Failed;
+    }
+
+    [[nodiscard]] std::string GetError() const {
+        std::lock_guard lock(mutex);
+        return error;
+    }
+
+private:
+    mutable std::mutex mutex{};
+    std::optional<T>   value{};
+    std::string        error{};
+    ERGSetupState      state = ERGSetupState::Pending;
+};
+
+} // namespace Detail
+
+/**
+ * Immutable read capability for a graph-owned CPU setup result.
+ *
+ * A valid value becomes readable only after Compile() has joined setup work.
+ * Copies share ownership and may be consumed concurrently by recording tasks.
+ */
+template<typename T>
+class RGPreparedValue {
+public:
+    RGPreparedValue() = default;
+
+    [[nodiscard]] bool IsValid() const {
+        return static_cast<bool>(state);
+    }
+
+    [[nodiscard]] bool IsReady() const {
+        return state && state->IsReady();
+    }
+
+    [[nodiscard]] bool HasFailed() const {
+        return state && state->HasFailed();
+    }
+
+    [[nodiscard]] std::string GetError() const {
+        return state ? state->GetError() : "RDG prepared value is invalid";
+    }
+
+    [[nodiscard]] const T& Get() const & {
+        if (!state) {
+            throw std::logic_error("RDG prepared value is invalid");
+        }
+        return state->Get();
+    }
+    [[nodiscard]] const T& Get() const && = delete;
+
+private:
+    friend class RenderGraph;
+
+    explicit RGPreparedValue(
+        SharedPtr<const Detail::RGSetupState<T>> setup_state
+    ) : state(std::move(setup_state)) {}
+
+    SharedPtr<const Detail::RGSetupState<T>> state{};
+};
+
+template<typename Input, typename Prepare>
+    requires std::invocable<
+                 std::decay_t<Prepare>&,
+                 const std::decay_t<Input>&> &&
+             (!std::is_void_v<RGSetupResult<Input, Prepare>>) &&
+             (!std::is_reference_v<
+                 std::invoke_result_t<
+                     std::decay_t<Prepare>&,
+                     const std::decay_t<Input>&>>) &&
+             std::move_constructible<RGSetupResult<Input, Prepare>> &&
+             std::constructible_from<std::decay_t<Input>, Input&&> &&
+             std::constructible_from<std::decay_t<Prepare>, Prepare&&>
+auto RenderGraph::AddSetupPass(
+    std::string_view name,
+    Input&&          immutable_input,
+    Prepare&&        prepare
+) -> RGPreparedValue<RGSetupResult<Input, Prepare>> {
+    using InputType   = std::decay_t<Input>;
+    using PrepareType = std::decay_t<Prepare>;
+    using ResultType  = RGSetupResult<Input, Prepare>;
+    using StateType   = Detail::RGSetupState<ResultType>;
+
+    if constexpr (std::is_pointer_v<PrepareType>) {
+        if (prepare == nullptr) {
+            RegisterSetupPass(name, {}, {}, {});
+            return {};
+        }
+    } else if constexpr (requires(const PrepareType& candidate) {
+                             { candidate.operator bool() } -> std::same_as<bool>;
+                         }) {
+        if (!prepare.operator bool()) {
+            RegisterSetupPass(name, {}, {}, {});
+            return {};
+        }
+    }
+
+    auto state = MakeShared<StateType>();
+    SharedPtr<const InputType> input_owner = MakeShared<InputType>(
+        std::forward<Input>(immutable_input)
+    );
+    auto prepare_owner = MakeShared<PrepareType>(
+        std::forward<Prepare>(prepare)
+    );
+
+    const bool registered = RegisterSetupPass(
+        name,
+        [state, input_owner, prepare_owner] {
+            state->Publish(std::invoke(*prepare_owner, *input_owner));
+        },
+        [state](std::string_view error) { state->Fail(error); },
+        [state](std::string_view error) { state->AnnotateFailure(error); }
+    );
+    if (!registered) {
+        return {};
+    }
+    return RGPreparedValue<ResultType>(std::move(state));
+}
+
+} // namespace Moer::Render

--- a/source/test/CMakeLists.txt
+++ b/source/test/CMakeLists.txt
@@ -215,6 +215,18 @@ add_test(
 )
 set_tests_properties(RenderGraphParameterAccessContract PROPERTIES TIMEOUT 60)
 
+set(test_target TestRenderGraphAsyncSetup)
+add_executable(${test_target} "RenderGraphAsyncSetupTest.cpp")
+target_link_libraries(${test_target}
+    PRIVATE Moer::Render
+)
+set_target_properties(${test_target} PROPERTIES FOLDER ${moer_test_folder})
+add_test(
+    NAME RenderGraphAsyncSetupContract
+    COMMAND $<TARGET_FILE:${test_target}>
+)
+set_tests_properties(RenderGraphAsyncSetupContract PROPERTIES TIMEOUT 60)
+
 set(test_target TestRenderGraphLowering)
 add_executable(${test_target} "RenderGraphLoweringTest.cpp")
 target_link_libraries(${test_target}

--- a/source/test/RenderGraphAsyncSetupTest.cpp
+++ b/source/test/RenderGraphAsyncSetupTest.cpp
@@ -7,6 +7,7 @@
 #include <chrono>
 #include <condition_variable>
 #include <cstdlib>
+#include <filesystem>
 #include <functional>
 #include <iostream>
 #include <memory>
@@ -16,6 +17,22 @@
 #include <string_view>
 #include <thread>
 #include <vector>
+
+#if defined(_WIN32)
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#include <windows.h>
+#else
+#include <cerrno>
+#include <csignal>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+#endif
 
 namespace Moer::Render {
 
@@ -74,6 +91,115 @@ private:
 [[nodiscard]] bool Contains(std::string_view text, std::string_view fragment) {
     return text.find(fragment) != std::string_view::npos;
 }
+
+struct ChildProcessResult {
+    bool started   = false;
+    bool timed_out = false;
+    int  exit_code = -1;
+};
+
+#if defined(_WIN32)
+[[nodiscard]] std::wstring CurrentExecutablePath() {
+    std::vector<wchar_t> path(1024);
+    for (;;) {
+        const DWORD length =
+            ::GetModuleFileNameW(nullptr, path.data(), static_cast<DWORD>(path.size()));
+        if (length == 0) {
+            return {};
+        }
+        if (length < path.size() - 1) {
+            return std::wstring(path.data(), length);
+        }
+        path.resize(path.size() * 2);
+    }
+}
+
+[[nodiscard]] ChildProcessResult RunStarvationChild(const char*) {
+    const std::wstring executable = CurrentExecutablePath();
+    if (executable.empty()) {
+        return {};
+    }
+    std::wstring command =
+        L"\"" + executable + L"\" --worker-starvation-child";
+    std::vector<wchar_t> mutable_command(command.begin(), command.end());
+    mutable_command.push_back(L'\0');
+
+    STARTUPINFOW        startup{};
+    PROCESS_INFORMATION process{};
+    startup.cb = sizeof(startup);
+    if (::CreateProcessW(
+            executable.c_str(),
+            mutable_command.data(),
+            nullptr,
+            nullptr,
+            FALSE,
+            CREATE_NO_WINDOW,
+            nullptr,
+            nullptr,
+            &startup,
+            &process
+        ) == FALSE) {
+        return {};
+    }
+
+    ChildProcessResult result{.started = true};
+    const DWORD        wait_result = ::WaitForSingleObject(process.hProcess, 5000);
+    if (wait_result != WAIT_OBJECT_0) {
+        result.timed_out = wait_result == WAIT_TIMEOUT;
+        static_cast<void>(::TerminateProcess(process.hProcess, 0xEE));
+        static_cast<void>(::WaitForSingleObject(process.hProcess, 2000));
+    }
+    DWORD exit_code = 0;
+    if (::GetExitCodeProcess(process.hProcess, &exit_code) != FALSE) {
+        result.exit_code = static_cast<int>(exit_code);
+    }
+    ::CloseHandle(process.hThread);
+    ::CloseHandle(process.hProcess);
+    return result;
+}
+#else
+[[nodiscard]] ChildProcessResult RunStarvationChild(const char* argv0) {
+    const std::filesystem::path executable = std::filesystem::absolute(argv0);
+    const pid_t                 child      = ::fork();
+    if (child < 0) {
+        return {};
+    }
+    if (child == 0) {
+        ::execl(
+            executable.c_str(),
+            executable.c_str(),
+            "--worker-starvation-child",
+            static_cast<char*>(nullptr)
+        );
+        ::_exit(127);
+    }
+
+    ChildProcessResult result{.started = true};
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
+    int        status   = 0;
+    for (;;) {
+        const pid_t waited = ::waitpid(child, &status, WNOHANG);
+        if (waited == child) {
+            result.exit_code = WIFEXITED(status) ? WEXITSTATUS(status) :
+                                                   128 + WTERMSIG(status);
+            return result;
+        }
+        if (waited < 0 && errno != EINTR) {
+            static_cast<void>(::kill(child, SIGKILL));
+            static_cast<void>(::waitpid(child, &status, 0));
+            return result;
+        }
+        if (std::chrono::steady_clock::now() >= deadline) {
+            result.timed_out = true;
+            static_cast<void>(::kill(child, SIGKILL));
+            while (::waitpid(child, &status, 0) < 0 && errno == EINTR) {}
+            result.exit_code = 128 + SIGKILL;
+            return result;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+}
+#endif
 
 void AddNoOpPass(RenderGraph& graph, std::string_view name = "NoOp") {
     graph.AddPass(
@@ -311,6 +437,92 @@ void TestAsyncOrderJoinAndNamedThreadIsolation(TestSuite& suite) {
             named_task_ran.load(std::memory_order_acquire),
         test_name,
         "setup join pumped unrelated named-thread work or explicit drain failed"
+    );
+}
+
+int RunNormalWorkerStarvationChild() {
+    struct StartBarrier {
+        std::mutex              mutex{};
+        std::condition_variable cv{};
+        uint32_t                arrived = 0;
+        uint32_t                target  = 0;
+    };
+
+    Moer::TaskSystem::Init();
+    TaskGraph& task_graph = TaskGraph::GetInterface();
+    const uint32_t normal_worker_count =
+        (task_graph.GetWorkerThreadCount() + EThread::PriorityCount - 1) /
+        EThread::PriorityCount;
+    if (normal_worker_count == 0) {
+        Moer::TaskSystem::ShutDown();
+        std::cerr << "normal worker starvation child: no Normal workers\n";
+        return EXIT_FAILURE;
+    }
+
+    auto barrier    = std::make_shared<StartBarrier>();
+    barrier->target = normal_worker_count;
+    auto failures   = std::make_shared<std::atomic<uint32_t>>(0);
+    GraphEventArray compile_events;
+    compile_events.reserve(normal_worker_count);
+
+    for (uint32_t worker = 0; worker < normal_worker_count; ++worker) {
+        compile_events.emplace_back(LambdaTask::Dispatch(
+            [barrier, failures, worker] {
+                {
+                    std::unique_lock lock(barrier->mutex);
+                    ++barrier->arrived;
+                    if (barrier->arrived == barrier->target) {
+                        barrier->cv.notify_all();
+                    } else {
+                        barrier->cv.wait(
+                            lock,
+                            [&] { return barrier->arrived == barrier->target; }
+                        );
+                    }
+                }
+
+                try {
+                    RenderGraph graph("NormalWorkerSetupStarvation");
+                    const auto prepared = graph.AddSetupPass(
+                        "PrepareOnSaturatedPool",
+                        worker,
+                        [](const uint32_t& input) { return input + 1; }
+                    );
+                    AddNoOpPass(graph);
+                    if (!graph.Compile() || prepared.Get() != worker + 1) {
+                        failures->fetch_add(1, std::memory_order_relaxed);
+                    }
+                } catch (...) {
+                    failures->fetch_add(1, std::memory_order_relaxed);
+                }
+            },
+            EThread::AnyThread_NormalPri
+        ));
+    }
+
+    task_graph.WaitUntilTasksComplete(compile_events, EThread::EMainThread);
+    const uint32_t failure_count = failures->load(std::memory_order_relaxed);
+    Moer::TaskSystem::ShutDown();
+    if (failure_count != 0) {
+        std::cerr << "normal worker starvation child: " << failure_count
+                  << " compile failure(s)\n";
+        return EXIT_FAILURE;
+    }
+    std::cout << "normal worker starvation child: all workers completed\n";
+    return EXIT_SUCCESS;
+}
+
+void TestNormalWorkerStarvationSubprocess(TestSuite& suite, const char* argv0) {
+    constexpr std::string_view test_name =
+        "normal worker compile avoids setup pool starvation";
+    const ChildProcessResult result = RunStarvationChild(argv0);
+    suite.Check(result.started, test_name, "could not launch isolated child process");
+    suite.Check(
+        result.started && !result.timed_out && result.exit_code == EXIT_SUCCESS,
+        test_name,
+        result.timed_out ?
+            "all Normal workers blocked waiting for setup work queued to the same pool" :
+            "isolated worker-saturation child failed"
     );
 }
 
@@ -767,12 +979,17 @@ void TestDeclarationFreezeAfterDispatch(TestSuite& suite) {
 
 } // namespace
 
-int main() {
+int main(int argc, char** argv) {
+    if (argc == 2 && std::string_view(argv[1]) == "--worker-starvation-child") {
+        return RunNormalWorkerStarvationChild();
+    }
+
     TestSuite suite;
     TestSynchronousFallbackAndOneShot(suite);
     TestNullableSetupFailsClosed(suite);
     TestGraphDestructionTerminatesPendingValue(suite);
     TestBatchOwnerFailureTerminalizesValues(suite);
+    TestNormalWorkerStarvationSubprocess(suite, argv[0]);
 
     Moer::TaskSystem::Init();
     TestAsyncOrderJoinAndNamedThreadIsolation(suite);

--- a/source/test/RenderGraphAsyncSetupTest.cpp
+++ b/source/test/RenderGraphAsyncSetupTest.cpp
@@ -26,7 +26,7 @@ public:
     }
 
     static void InjectTaskDispatchFailure(RenderGraph& graph) noexcept {
-        AddFault(graph, RenderGraph::SetupFaultForTesting::TaskDispatch);
+        AddFault(graph, RenderGraph::SetupFaultForTesting::TaskDispatchThrows);
     }
 
     static void InjectFailureDiagnosticFailure(RenderGraph& graph) noexcept {
@@ -562,7 +562,7 @@ void TestFailureDiagnosticFaultIsTerminal(TestSuite& suite) {
 
 void TestTaskDispatchAndDiagnosticFaultsAreTerminal(TestSuite& suite) {
     constexpr std::string_view test_name =
-        "task dispatch plus diagnostic fault preserves terminal state";
+        "task dispatch exception plus diagnostic fault preserves terminal state";
 
     std::atomic<int> setup_calls{0};
     RenderGraph      graph("TaskDispatchDiagnosticFailure");

--- a/source/test/RenderGraphAsyncSetupTest.cpp
+++ b/source/test/RenderGraphAsyncSetupTest.cpp
@@ -1,0 +1,793 @@
+#include "rendergraph/RenderGraphPassParameters.h"
+#include "rendergraph/RenderGraphSetup.h"
+#include "taskgraph/TaskGraph.h"
+#include "taskgraph/TaskSystem.h"
+
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <cstdlib>
+#include <functional>
+#include <iostream>
+#include <memory>
+#include <mutex>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <thread>
+#include <vector>
+
+namespace Moer::Render {
+
+class RenderGraphAsyncSetupTestAccess {
+public:
+    static void InjectBatchOwnerFailure(RenderGraph& graph) noexcept {
+        AddFault(graph, RenderGraph::SetupFaultForTesting::BatchOwnerCreate);
+    }
+
+    static void InjectTaskDispatchFailure(RenderGraph& graph) noexcept {
+        AddFault(graph, RenderGraph::SetupFaultForTesting::TaskDispatch);
+    }
+
+    static void InjectFailureDiagnosticFailure(RenderGraph& graph) noexcept {
+        AddFault(graph, RenderGraph::SetupFaultForTesting::FailureDiagnostic);
+    }
+
+private:
+    static void AddFault(
+        RenderGraph&                      graph,
+        RenderGraph::SetupFaultForTesting fault
+    ) noexcept {
+        graph.setup_faults_for_testing |= static_cast<uint8_t>(fault);
+    }
+};
+
+} // namespace Moer::Render
+
+namespace {
+
+using Moer::Render::CommandList;
+using Moer::Render::RenderGraph;
+
+class TestSuite {
+public:
+    void Check(
+        bool             condition,
+        std::string_view test_name,
+        std::string_view expectation
+    ) {
+        if (condition) {
+            return;
+        }
+        ++failure_count;
+        std::cerr << "[FAIL] " << test_name << ": " << expectation << '\n';
+    }
+
+    [[nodiscard]] int FailureCount() const {
+        return failure_count;
+    }
+
+private:
+    int failure_count = 0;
+};
+
+[[nodiscard]] bool Contains(std::string_view text, std::string_view fragment) {
+    return text.find(fragment) != std::string_view::npos;
+}
+
+void AddNoOpPass(RenderGraph& graph, std::string_view name = "NoOp") {
+    graph.AddPass(
+        name,
+        [](RenderGraph::PassBuilder& builder) { builder.SideEffect(); },
+        [] {}
+    );
+}
+
+struct VoidPrepare {
+    void operator()(const int&) const {}
+};
+
+struct ReferencePrepare {
+    int& operator()(const int&) const;
+};
+
+struct GraphPrepare {
+    int operator()(const int&, RenderGraph&) const;
+};
+
+template<typename Prepare>
+concept AcceptsSetupPrepare = requires(RenderGraph& graph, Prepare prepare) {
+    graph.AddSetupPass("CompileContract", 1, std::move(prepare));
+};
+
+static_assert(!AcceptsSetupPrepare<VoidPrepare>);
+static_assert(!AcceptsSetupPrepare<ReferencePrepare>);
+static_assert(!AcceptsSetupPrepare<GraphPrepare>);
+
+struct MoveOnlyInput {
+    std::unique_ptr<int> value{};
+
+    MoveOnlyInput() = default;
+    MoveOnlyInput(const MoveOnlyInput&) = delete;
+    MoveOnlyInput& operator=(const MoveOnlyInput&) = delete;
+    MoveOnlyInput(MoveOnlyInput&&) = default;
+    MoveOnlyInput& operator=(MoveOnlyInput&&) = default;
+};
+
+struct MoveOnlyPrepare {
+    std::unique_ptr<int> offset{};
+    std::atomic<int>*    calls = nullptr;
+
+    MoveOnlyPrepare() = default;
+    MoveOnlyPrepare(const MoveOnlyPrepare&) = delete;
+    MoveOnlyPrepare& operator=(const MoveOnlyPrepare&) = delete;
+    MoveOnlyPrepare(MoveOnlyPrepare&&) = default;
+    MoveOnlyPrepare& operator=(MoveOnlyPrepare&&) = default;
+
+    int operator()(const MoveOnlyInput& input) {
+        calls->fetch_add(1, std::memory_order_relaxed);
+        return *input.value + *offset;
+    }
+};
+
+void TestSynchronousFallbackAndOneShot(TestSuite& suite) {
+    constexpr std::string_view test_name =
+        "synchronous setup fallback and one-shot result";
+
+    std::atomic<int> setup_calls{0};
+    RenderGraph      graph("SetupFallback");
+    MoveOnlyInput    input{};
+    input.value = std::make_unique<int>(40);
+    MoveOnlyPrepare prepare{};
+    prepare.offset = std::make_unique<int>(2);
+    prepare.calls  = &setup_calls;
+
+    auto value = graph.AddSetupPass(
+        "MoveOnly",
+        std::move(input),
+        std::move(prepare)
+    );
+    AddNoOpPass(graph);
+
+    bool read_before_compile_failed = false;
+    try {
+        (void)value.Get();
+    } catch (const std::logic_error&) {
+        read_before_compile_failed = true;
+    }
+
+    suite.Check(value.IsValid(), test_name, "setup registration returned an invalid value");
+    suite.Check(
+        read_before_compile_failed,
+        test_name,
+        "a pending setup result was readable before Compile"
+    );
+    suite.Check(graph.Compile(), test_name, graph.GetCompileError());
+    suite.Check(
+        value.IsReady() && value.Get() == 42,
+        test_name,
+        "move-only input/functor did not publish the expected result"
+    );
+
+    // A second compile is supported for diagnostics/re-lowering, but setup is
+    // deliberately write-once and must not run again.
+    suite.Check(
+        setup_calls.load(std::memory_order_relaxed) == 1,
+        test_name,
+        "setup did not execute exactly once during the first Compile"
+    );
+    suite.Check(graph.Compile(), test_name, graph.GetCompileError());
+    suite.Check(
+        setup_calls.load() == 1 && value.Get() == 42,
+        test_name,
+        "repeated Compile changed a write-once setup result"
+    );
+}
+
+void TestNullableSetupFailsClosed(TestSuite& suite) {
+    constexpr std::string_view test_name = "nullable setup callback";
+
+    using NullablePrepare = std::function<int(const int&)>;
+    RenderGraph empty_function("EmptySetupFunction");
+    const auto empty_value = empty_function.AddSetupPass(
+        "EmptyFunction",
+        1,
+        NullablePrepare{}
+    );
+    AddNoOpPass(empty_function);
+    suite.Check(
+        !empty_value.IsValid() && !empty_function.Compile() &&
+            Contains(empty_function.GetCompileError(), "no prepare callback"),
+        test_name,
+        "an empty std::function did not fail at declaration time"
+    );
+
+    using PreparePointer = int (*)(const int&);
+    PreparePointer null_prepare = nullptr;
+    RenderGraph    null_function("NullSetupFunction");
+    const auto null_value = null_function.AddSetupPass(
+        "NullFunction",
+        1,
+        null_prepare
+    );
+    AddNoOpPass(null_function);
+    suite.Check(
+        !null_value.IsValid() && !null_function.Compile() &&
+            Contains(null_function.GetCompileError(), "no prepare callback"),
+        test_name,
+        "a null function pointer did not fail at declaration time"
+    );
+}
+
+void TestAsyncOrderJoinAndNamedThreadIsolation(TestSuite& suite) {
+    constexpr std::string_view test_name =
+        "async setup order, join, and named-thread isolation";
+
+    std::mutex              mutex{};
+    std::condition_variable cv{};
+    bool                    first_started = false;
+    bool                    allow_finish  = false;
+    bool                    setup_finished = false;
+    std::vector<int>        order{};
+    std::thread::id         setup_thread{};
+    const std::thread::id   caller_thread = std::this_thread::get_id();
+    std::atomic<bool>       named_task_ran{false};
+    GraphEventRef           named_event{};
+
+    RenderGraph graph("AsyncSetupOrder");
+    const auto first = graph.AddSetupPass(
+        "First",
+        20,
+        [&](const int& input) {
+            setup_thread = std::this_thread::get_id();
+            auto event = LambdaTask::Dispatch(
+                [&] { named_task_ran.store(true, std::memory_order_release); },
+                EThread::EMainThread
+            );
+            {
+                std::unique_lock lock(mutex);
+                named_event   = std::move(event);
+                order.push_back(1);
+                first_started = true;
+                cv.notify_all();
+                cv.wait(lock, [&] { return allow_finish; });
+            }
+            return input + 1;
+        }
+    );
+    const auto second = graph.AddSetupPass(
+        "Second",
+        first,
+        [&](const Moer::Render::RGPreparedValue<int>& dependency) {
+            std::lock_guard lock(mutex);
+            order.push_back(2);
+            setup_finished = true;
+            return dependency.Get() * 2;
+        }
+    );
+    AddNoOpPass(graph);
+
+    std::thread releaser([&] {
+        std::unique_lock lock(mutex);
+        cv.wait(lock, [&] { return first_started; });
+        allow_finish = true;
+        cv.notify_all();
+    });
+    const bool compiled = graph.Compile();
+    releaser.join();
+
+    bool finished_at_return = false;
+    std::vector<int> observed_order{};
+    GraphEventRef event_to_drain{};
+    {
+        std::lock_guard lock(mutex);
+        finished_at_return = setup_finished;
+        observed_order     = order;
+        event_to_drain     = named_event;
+    }
+    const bool avoided_named_reentry =
+        !named_task_ran.load(std::memory_order_acquire);
+    if (event_to_drain) {
+        TaskGraph::GetInterface().WaitUntilTaskComplete(
+            event_to_drain,
+            EThread::EMainThread
+        );
+    }
+
+    suite.Check(compiled, test_name, graph.GetCompileError());
+    suite.Check(
+        setup_thread != caller_thread,
+        test_name,
+        "setup did not execute on a TaskGraph worker"
+    );
+    suite.Check(
+        finished_at_return && observed_order == std::vector<int>{1, 2} &&
+            first.Get() == 21 && second.Get() == 42,
+        test_name,
+        "Compile returned before ordered setup publication completed"
+    );
+    suite.Check(
+        avoided_named_reentry &&
+            named_task_ran.load(std::memory_order_acquire),
+        test_name,
+        "setup join pumped unrelated named-thread work or explicit drain failed"
+    );
+}
+
+void TestFailureJoinAndStableRetry(TestSuite& suite) {
+    constexpr std::string_view test_name =
+        "setup failure joins and remains stable across Compile retries";
+
+    std::mutex              mutex{};
+    std::condition_variable cv{};
+    bool                    started = false;
+    bool                    release = false;
+    bool                    finished = false;
+    std::atomic<int>        setup_calls{0};
+    std::atomic<int>        skipped_calls{0};
+    std::atomic<int>        record_calls{0};
+
+    RenderGraph graph("SetupAndCompilerFailure");
+    const auto failed = graph.AddSetupPass(
+        "FailingSetup",
+        1,
+        [&](const int&) -> int {
+            setup_calls.fetch_add(1, std::memory_order_relaxed);
+            {
+                std::unique_lock lock(mutex);
+                started = true;
+                cv.notify_all();
+                cv.wait(lock, [&] { return release; });
+                finished = true;
+            }
+            throw std::runtime_error("setup boom");
+        }
+    );
+    const auto skipped = graph.AddSetupPass(
+        "SkippedSetup",
+        2,
+        [&](const int& value) {
+            skipped_calls.fetch_add(1, std::memory_order_relaxed);
+            return value;
+        }
+    );
+    graph.AddRecordPass(
+        "InvalidRecord",
+        [](RenderGraph::PassBuilder& builder) {
+            builder.Read(RenderGraph::TokenHandle{}).SideEffect();
+        },
+        [&](CommandList&) {
+            record_calls.fetch_add(1, std::memory_order_relaxed);
+        },
+        RenderGraph::PassExecutionClass::ParallelRecordEligible
+    );
+
+    std::thread releaser([&] {
+        std::unique_lock lock(mutex);
+        cv.wait(lock, [&] { return started; });
+        release = true;
+        cv.notify_all();
+    });
+    const bool compiled = graph.Compile();
+    releaser.join();
+
+    bool failed_get_throws = false;
+    try {
+        (void)failed.Get();
+    } catch (const std::runtime_error& exception) {
+        failed_get_throws = Contains(exception.what(), "setup boom");
+    }
+
+    suite.Check(
+        !compiled && finished && !graph.IsCompiled(),
+        test_name,
+        "Compile did not join the throwing setup before returning failure"
+    );
+    suite.Check(
+        Contains(graph.GetCompileError(), "declared an invalid resource") &&
+            Contains(graph.GetCompileError(), "FailingSetup") &&
+            Contains(graph.GetCompileError(), "setup boom"),
+        test_name,
+        "compiler-primary and setup diagnostics were not preserved together"
+    );
+    suite.Check(
+        failed.HasFailed() && failed_get_throws && skipped.HasFailed() &&
+            Contains(skipped.GetError(), "skipped") &&
+            skipped_calls.load(std::memory_order_relaxed) == 0,
+        test_name,
+        "failed/skipped prepared values did not reach stable terminal states"
+    );
+
+    const bool retried = graph.Compile();
+    suite.Check(
+        !retried && setup_calls.load(std::memory_order_relaxed) == 1 &&
+            skipped_calls.load(std::memory_order_relaxed) == 0,
+        test_name,
+        "Compile retry re-executed one-shot setup work"
+    );
+    suite.Check(
+        !graph.ExecuteRecording({}, {}, true) &&
+            record_calls.load(std::memory_order_relaxed) == 0,
+        test_name,
+        "recording ran after setup/compiler failure"
+    );
+}
+
+void TestGraphDestructionTerminatesPendingValue(TestSuite& suite) {
+    constexpr std::string_view test_name =
+        "graph destruction terminates undispatched setup";
+
+    Moer::Render::RGPreparedValue<int> orphan{};
+    std::atomic<int>                   setup_calls{0};
+    {
+        RenderGraph graph("UndispatchedSetup");
+        orphan = graph.AddSetupPass(
+            "NeverDispatched",
+            1,
+            [&](const int& value) {
+                setup_calls.fetch_add(1, std::memory_order_relaxed);
+                return value;
+            }
+        );
+        AddNoOpPass(graph);
+    }
+
+    suite.Check(
+        orphan.HasFailed() && setup_calls.load(std::memory_order_relaxed) == 0 &&
+            Contains(orphan.GetError(), "destroyed before"),
+        test_name,
+        "destroying an uncompiled graph left its setup result pending"
+    );
+}
+
+void TestBatchOwnerFailureTerminalizesValues(TestSuite& suite) {
+    constexpr std::string_view test_name =
+        "setup batch owner failure is terminal and one-shot";
+
+    Moer::Render::RGPreparedValue<int> survivor{};
+    std::atomic<int>                   setup_calls{0};
+    bool                               threw = false;
+    {
+        RenderGraph graph("BatchOwnerFailure");
+        survivor = graph.AddSetupPass(
+            "NeverRuns",
+            42,
+            [&](const int& value) {
+                setup_calls.fetch_add(1, std::memory_order_relaxed);
+                return value;
+            }
+        );
+        AddNoOpPass(graph);
+        Moer::Render::RenderGraphAsyncSetupTestAccess::InjectBatchOwnerFailure(
+            graph
+        );
+
+        bool compiled = false;
+        try {
+            compiled = graph.Compile();
+        } catch (...) {
+            threw = true;
+        }
+
+        bool get_failed = false;
+        try {
+            (void)survivor.Get();
+        } catch (const std::runtime_error&) {
+            get_failed = true;
+        }
+
+        suite.Check(
+            !threw && !compiled && !graph.IsCompiled() && survivor.HasFailed() &&
+                get_failed && setup_calls.load(std::memory_order_relaxed) == 0,
+            test_name,
+            "batch owner failure escaped, compiled, ran setup, or left a value Pending"
+        );
+        suite.Check(
+            Contains(graph.GetCompileError(), "batch creation failed") &&
+                Contains(survivor.GetError(), "batch creation failed"),
+            test_name,
+            "batch owner failure did not retain a stable fallback diagnostic"
+        );
+        suite.Check(
+            !graph.Compile() && setup_calls.load(std::memory_order_relaxed) == 0 &&
+                survivor.HasFailed(),
+            test_name,
+            "Compile retry reran or revived a batch that failed before dispatch"
+        );
+    }
+
+    suite.Check(
+        survivor.HasFailed() && setup_calls.load(std::memory_order_relaxed) == 0,
+        test_name,
+        "graph destruction changed the terminal value after owner failure"
+    );
+}
+
+void TestFailureDiagnosticFaultIsTerminal(TestSuite& suite) {
+    constexpr std::string_view test_name =
+        "callback diagnostic allocation fault preserves terminal state";
+
+    std::atomic<int> failing_calls{0};
+    std::atomic<int> skipped_calls{0};
+    RenderGraph      graph("CallbackDiagnosticFailure");
+    const auto failed = graph.AddSetupPass(
+        "DiagnosticFault",
+        1,
+        [&](const int&) -> int {
+            failing_calls.fetch_add(1, std::memory_order_relaxed);
+            throw std::runtime_error("detail must be optional");
+        }
+    );
+    const auto skipped = graph.AddSetupPass(
+        "SkippedAfterDiagnosticFault",
+        2,
+        [&](const int& value) {
+            skipped_calls.fetch_add(1, std::memory_order_relaxed);
+            return value;
+        }
+    );
+    AddNoOpPass(graph);
+    Moer::Render::RenderGraphAsyncSetupTestAccess::
+        InjectFailureDiagnosticFailure(graph);
+
+    bool threw    = false;
+    bool compiled = false;
+    try {
+        compiled = graph.Compile();
+    } catch (...) {
+        threw = true;
+    }
+
+    suite.Check(
+        !threw && !compiled && failed.HasFailed() && skipped.HasFailed() &&
+            failing_calls.load(std::memory_order_relaxed) == 1 &&
+            skipped_calls.load(std::memory_order_relaxed) == 0,
+        test_name,
+        "diagnostic fault escaped, hung, or left failed/skipped values Pending"
+    );
+    suite.Check(
+        Contains(graph.GetCompileError(), "diagnostic unavailable") &&
+            Contains(failed.GetError(), "setup failed") &&
+            Contains(skipped.GetError(), "skipped"),
+        test_name,
+        "fallback diagnostics were not available after detailed storage failed"
+    );
+    suite.Check(
+        !graph.Compile() && failing_calls.load(std::memory_order_relaxed) == 1 &&
+            skipped_calls.load(std::memory_order_relaxed) == 0,
+        test_name,
+        "retry reran a callback after diagnostic allocation failure"
+    );
+}
+
+void TestTaskDispatchAndDiagnosticFaultsAreTerminal(TestSuite& suite) {
+    constexpr std::string_view test_name =
+        "task dispatch plus diagnostic fault preserves terminal state";
+
+    std::atomic<int> setup_calls{0};
+    RenderGraph      graph("TaskDispatchDiagnosticFailure");
+    const auto value = graph.AddSetupPass(
+        "NeverDispatched",
+        9,
+        [&](const int& input) {
+            setup_calls.fetch_add(1, std::memory_order_relaxed);
+            return input;
+        }
+    );
+    AddNoOpPass(graph);
+    Moer::Render::RenderGraphAsyncSetupTestAccess::InjectTaskDispatchFailure(
+        graph
+    );
+    Moer::Render::RenderGraphAsyncSetupTestAccess::
+        InjectFailureDiagnosticFailure(graph);
+
+    bool threw    = false;
+    bool compiled = false;
+    try {
+        compiled = graph.Compile();
+    } catch (...) {
+        threw = true;
+    }
+
+    suite.Check(
+        !threw && !compiled && value.HasFailed() &&
+            setup_calls.load(std::memory_order_relaxed) == 0,
+        test_name,
+        "dispatch fault escaped, ran setup, or left the prepared value Pending"
+    );
+    suite.Check(
+        Contains(graph.GetCompileError(), "diagnostic unavailable") &&
+            Contains(value.GetError(), "dispatch"),
+        test_name,
+        "dispatch failure did not publish stable fallback diagnostics"
+    );
+    suite.Check(
+        !graph.Compile() && setup_calls.load(std::memory_order_relaxed) == 0 &&
+            value.HasFailed(),
+        test_name,
+        "retry reran setup after task dispatch failure"
+    );
+}
+
+struct LifetimeProbe {
+    explicit LifetimeProbe(std::atomic<int>& destructions) :
+        destructions(destructions) {}
+
+    ~LifetimeProbe() {
+        destructions.fetch_add(1, std::memory_order_relaxed);
+    }
+
+    std::atomic<int>& destructions;
+};
+
+struct MoveOnlyPayload {
+    std::unique_ptr<LifetimeProbe> probe{};
+    int                            value = 0;
+
+    MoveOnlyPayload() = default;
+    MoveOnlyPayload(const MoveOnlyPayload&) = delete;
+    MoveOnlyPayload& operator=(const MoveOnlyPayload&) = delete;
+    MoveOnlyPayload(MoveOnlyPayload&&) = default;
+    MoveOnlyPayload& operator=(MoveOnlyPayload&&) = default;
+};
+
+struct ConsumerParameters {
+    DEFINE_RG_TOKEN_ACCESS(token, RenderGraph::AccessMode::Write);
+    Moer::Render::RGPreparedValue<MoveOnlyPayload> prepared{};
+
+    DEFINE_RG_PARAMETER_ACCESS(token);
+};
+
+void TestParallelRecordingReadsOnePreparedValue(TestSuite& suite) {
+    using namespace std::chrono_literals;
+    constexpr std::string_view test_name =
+        "parallel recording reads one immutable prepared value";
+
+    std::atomic<int>         destructions{0};
+    std::atomic<int>         record_count{0};
+    std::atomic<int>         value_sum{0};
+    std::atomic<int>         inflight{0};
+    std::atomic<int>         max_inflight{0};
+    std::atomic<const void*> observed_address{nullptr};
+    std::atomic<bool>        address_mismatch{false};
+    std::mutex               mutex{};
+    std::condition_variable  cv{};
+    int                      entered = 0;
+    bool                     timed_out = false;
+
+    {
+        RenderGraph graph("PreparedValueParallelRead");
+        const auto prepared = graph.AddSetupPass(
+            "BuildPayload",
+            42,
+            [&](const int& value) {
+                MoveOnlyPayload payload{};
+                payload.probe = std::make_unique<LifetimeProbe>(destructions);
+                payload.value = value;
+                return payload;
+            }
+        );
+        const auto first_token  = graph.CreateTransientToken("FirstToken");
+        const auto second_token = graph.CreateTransientToken("SecondToken");
+
+        auto add_consumer = [&](std::string_view name, RenderGraph::TokenHandle token) {
+            ConsumerParameters parameters{};
+            parameters.token    = token;
+            parameters.prepared = prepared;
+            graph.AddRecordPass(
+                name,
+                std::move(parameters),
+                [](RenderGraph::PassBuilder& builder) { builder.SideEffect(); },
+                [&](CommandList&, const ConsumerParameters& immutable_parameters) {
+                    const auto& payload = immutable_parameters.prepared.Get();
+                    const void* expected = nullptr;
+                    if (!observed_address.compare_exchange_strong(
+                            expected,
+                            &payload,
+                            std::memory_order_acq_rel
+                        ) && expected != &payload) {
+                        address_mismatch.store(true, std::memory_order_release);
+                    }
+                    const int current = inflight.fetch_add(1) + 1;
+                    int       observed = max_inflight.load();
+                    while (observed < current &&
+                           !max_inflight.compare_exchange_weak(observed, current)) {}
+                    {
+                        std::unique_lock lock(mutex);
+                        ++entered;
+                        cv.notify_all();
+                        if (!cv.wait_for(lock, 2s, [&] { return entered == 2; })) {
+                            timed_out = true;
+                        }
+                    }
+                    value_sum.fetch_add(payload.value, std::memory_order_relaxed);
+                    record_count.fetch_add(1, std::memory_order_relaxed);
+                    inflight.fetch_sub(1);
+                },
+                RenderGraph::PassExecutionClass::ParallelRecordEligible
+            );
+        };
+        add_consumer("FirstConsumer", first_token);
+        add_consumer("SecondConsumer", second_token);
+
+        suite.Check(graph.Compile(), test_name, graph.GetCompileError());
+        size_t published_sources = 0;
+        const bool executed = graph.ExecuteRecording(
+            {},
+            {},
+            true,
+            [&](Moer::Array<Moer::Render::RHIRecordingSource>&& sources) {
+                published_sources += sources.size();
+            }
+        );
+
+        suite.Check(executed, test_name, graph.GetCompileError());
+        suite.Check(
+            published_sources == 2 && record_count.load() == 2 &&
+                value_sum.load() == 84 && max_inflight.load() >= 2 &&
+                !timed_out && !address_mismatch.load(),
+            test_name,
+            "parallel consumers did not share one immutable setup result"
+        );
+        suite.Check(
+            destructions.load(std::memory_order_relaxed) == 0,
+            test_name,
+            "prepared payload was destroyed before graph recording completed"
+        );
+    }
+
+    suite.Check(
+        destructions.load(std::memory_order_relaxed) == 1,
+        test_name,
+        "move-only prepared payload was not destroyed exactly once"
+    );
+}
+
+void TestDeclarationFreezeAfterDispatch(TestSuite& suite) {
+    constexpr std::string_view test_name =
+        "graph declarations freeze after setup dispatch";
+
+    RenderGraph graph("SetupDeclarationFreeze");
+    const auto prepared = graph.AddSetupPass(
+        "Prepare",
+        7,
+        [](const int& value) { return value; }
+    );
+    AddNoOpPass(graph);
+    suite.Check(graph.Compile(), test_name, graph.GetCompileError());
+    const auto late_token = graph.CreateTransientToken("LateMutation");
+    suite.Check(
+        prepared.IsReady() && !late_token.IsValid() && !graph.IsCompiled() &&
+            !graph.Compile() &&
+            Contains(graph.GetCompileError(), "cannot be mutated after asynchronous setup"),
+        test_name,
+        "post-dispatch graph mutation was not rejected fail-closed"
+    );
+}
+
+} // namespace
+
+int main() {
+    TestSuite suite;
+    TestSynchronousFallbackAndOneShot(suite);
+    TestNullableSetupFailsClosed(suite);
+    TestGraphDestructionTerminatesPendingValue(suite);
+    TestBatchOwnerFailureTerminalizesValues(suite);
+
+    Moer::TaskSystem::Init();
+    TestAsyncOrderJoinAndNamedThreadIsolation(suite);
+    TestFailureJoinAndStableRetry(suite);
+    TestParallelRecordingReadsOnePreparedValue(suite);
+    TestDeclarationFreezeAfterDispatch(suite);
+    TestFailureDiagnosticFaultIsTerminal(suite);
+    TestTaskDispatchAndDiagnosticFaultsAreTerminal(suite);
+    Moer::TaskSystem::ShutDown();
+
+    if (suite.FailureCount() != 0) {
+        std::cerr << "TestRenderGraphAsyncSetup: " << suite.FailureCount()
+                  << " failure(s)\n";
+        return EXIT_FAILURE;
+    }
+    std::cout << "TestRenderGraphAsyncSetup: all checks passed\n";
+    return EXIT_SUCCESS;
+}


### PR DESCRIPTION
## Summary

- add a constrained, graph-owned `AddSetupPass` API that publishes immutable `RGPreparedValue<T>` results
- overlap ordered CPU setup work with the existing RDG compiler, then join before `Compile()` returns without pumping named-thread work
- preserve compiler-primary diagnostics and terminalize failed/skipped values across callback, dispatch, allocation, retry, and destruction paths
- migrate RT AntiAlias constant/dispatch preparation as the first production canary while keeping resource access, queue, pipeline, and history semantics unchanged
- add deterministic fault-injection and concurrency/lifetime contract tests

## Relationship to `dev_parallel_rhi`

This ports the useful async-setup/compile-overlap direction from `origin/dev_parallel_rhi@d54ad47`, but deliberately does not expose its mutable `RGSetupContext::Graph()` or setup-time `RHICommandList` overload. Setup callbacks receive only a graph-owned immutable CPU snapshot and cannot declare topology, record commands, or submit RHI work.

## Key invariants

- one worker executes setup callbacks in declaration order
- a Compile caller already running on the Normal worker pool executes setup inline, preventing bounded-pool starvation; other callers retain compile overlap
- worker captures shared batch state, never a raw `RenderGraph*`
- `Compile()` always joins setup, including compiler failure/exception paths
- `RGPreparedValue` is write-once and immutable after publication
- failure state is independent from best-effort diagnostic allocation
- setup declarations are frozen after dispatch
- setup-owned state/input/functor and the empty batch owner use standard throwing `std::make_shared`; declarations move only after owner creation succeeds

## Validation

- Debug `MoerEditor` build: passed
- Debug full CTest: 48/48 passed
- Debug related RDG contracts: 5/5 passed
- Debug async setup stress loop: 100/100 passed
- Normal-worker starvation regression: an isolated child saturates every Normal worker behind a barrier; the fixed path completes, while a deliberate fallback removal deterministically hit the bounded 5-second watchdog and was reaped
- Release `RenderGraphAsyncSetupContract`: passed
- local P0-P2 review loop: two independent final reviews found no remaining P0-P2
- Vulkan + Raytracing graph-pilot runtime: prior approximately 80-second run produced two RDG dumps containing `RT.AntiAlias.UploadConstants` and `RT.AntiAlias.Dispatch`; the exact commit candidate then ran for 88 seconds, remained responsive, submitted first present, exited gracefully, and produced no compile/setup failure, Validation Error, device lost, fatal, or stderr output
- `git diff --check`: passed (line-ending notices only)

## Known baseline issue

`ALL_BUILD` remains blocked by the unchanged third-party GKlib/MSVC `/io.h` C1083 issue. Explicit `MoerEditor`, this feature's targets, and all 48 configured CTests build and run successfully. A transient parallel WinPix DLL copy race in the first Release attempt passed on single-job retry without modifying third-party files.

## Follow-up

This PR intentionally keeps one ordered setup lane. A setup dependency DAG or broad migration of additional passes should be separate work with explicit cost and ownership analysis.

TaskGraph itself still uses the engine-wide `Memory::Malloc`/`MoerNew` policy. This PR handles ordinary C++ exceptions reported by `LambdaTask::Dispatch`, but does not claim recovery from a process-level TaskGraph allocator OOM; that allocator contract is global follow-up scope.
