### PR TITLE
TaskGraph: add Chase-Lev work-stealing scheduler

### DIFF
--- a/source/runtime/core/include/taskgraph/TaskGraph.h
+++ b/source/runtime/core/include/taskgraph/TaskGraph.h
@@ -3,13 +3,19 @@
 #include "API_Macro.h"
 #include "Thread.h"
 #include "misc/CountableRef.h"
+#include "taskgraph/WorkStealing.h"
+
+#include <memory>
 
 enum class ESchedule {
     Max_Local_Capacity = 16
 };
 
+class AnyThreadScheduler;
+
 class TaskGraph {
 private:
+    friend class TaskThreadAnyThread;
     static TaskGraph* instance;
 
 public:
@@ -41,8 +47,17 @@ public:
     inline uint32_t        GetWorkerThreadCount() const {
         return m_worker_thread_count;
     }
+    inline uint32_t GetWorkerThreadCount(EThread::Type priority) const {
+        const int32_t priority_index = EThread::GetThreadPriority(priority);
+        assert(priority_index >= 0 && priority_index < EThread::PriorityCount);
+        return static_cast<uint32_t>(m_worker_topology.counts[priority_index]);
+    }
     /** Returns the scheduler identity of the caller, or UNKNOWN for an external thread. */
     CORE_API EThread::Type GetCurrentThread(bool localQueue = false);
+    /** True after shutdown has stopped accepting external AnyThread publications. */
+    CORE_API bool IsDraining() const noexcept;
+    /** Shutdown diagnostic used to verify that pending work is actively being drained. */
+    CORE_API bool IsWaitingForIdle() const noexcept;
 
 protected:
     void TriggerEventWhenTasksComplete(
@@ -54,18 +69,21 @@ protected:
 
 private:
     TaskThreadBase& GetThread(ThreadIndex index);
-    int32_t         GetThreadPriorityFromIndex(int32_t threadIndex) {
-        return (threadIndex - m_named_thread_count) / m_worker_per_priority;
+    int32_t         GetThreadPriorityFromIndex(int32_t threadIndex) const noexcept {
+        return m_worker_topology.PriorityForThread(threadIndex);
     }
-    void         WakeUpWorkerThread(int32_t threadIndex, QueueIndex index) noexcept;
+    void        WakeUpWorkerThread(int32_t threadIndex, QueueIndex index) noexcept;
+    static void WakeWorkerCallback(void* context, int32_t threadIndex) noexcept;
+    static void SetCurrentWorkerThread(EThread::Type thread) noexcept;
+    static void ClearCurrentWorkerThread() noexcept;
+    void        NotifyAnyThreadTaskCompleted() noexcept;
     WorkerThread m_workers[INT16_MAX];
     int32_t      m_thread_count;
     int32_t      m_named_thread_count;
-    int32_t      m_worker_per_priority;
     int32_t      m_worker_thread_count;
 
-    TaskFIFOQueue<BaseGraphTask, 1> m_task_queue[EThread::PriorityCount];
-    TaskFIFOQueue<BaseGraphTask, 1> m_global_queue; //
+    Moer::TaskGraphDetail::WorkerPoolTopology m_worker_topology{};
+    std::unique_ptr<AnyThreadScheduler>        m_any_thread_scheduler{};
 };
 
 class CORE_API TriggerEventGraphTask {

--- a/source/runtime/core/include/taskgraph/TaskSystem.h
+++ b/source/runtime/core/include/taskgraph/TaskSystem.h
@@ -9,6 +9,14 @@ public:
     TaskSystem() = default;
     ~TaskSystem() {}
     static void Init();
+    // External and named-thread producers must be quiescent before shutdown,
+    // and every named-thread owner must already be stopped and externally
+    // joined before TaskGraph releases its named queues and pooled Events.
+    // Already-running AnyThread tasks may still publish AnyThread
+    // continuations; they are drained before workers close. Named-target work
+    // must already be complete and cannot be published during drain. Any late
+    // external or named-target publication is a fatal lifecycle-contract
+    // violation because QueueTask cannot safely return task ownership.
     static void ShutDown();
 };
 } // namespace Moer

--- a/source/runtime/core/include/taskgraph/Thread.h
+++ b/source/runtime/core/include/taskgraph/Thread.h
@@ -26,6 +26,7 @@ public:
     TaskThreadBase() : m_worker{nullptr}, m_thread_type{EThread::UNKNOWN_THREAD} {
         // m_graph_tasks.reserve(128);
     }
+    virtual ~TaskThreadBase() = default;
 
     void SetAttributes(EThread::Type _threadIndex, WorkerThread* worker) {
         m_worker      = worker;
@@ -115,9 +116,7 @@ public:
         m_queue.m_close = true;
         m_queue.m_hang_event->Trigger();
     }
-    virtual uint32_t Run() override {
-        return TaskThreadBase::Run(); //process task until quit
-    }
+    uint32_t Run() override;
     uint32_t     ProcessTasks();
     virtual bool IsProcessingTask(QueueIndex queueIndex) override {
         return m_queue.call_amount > 0;
@@ -167,17 +166,18 @@ public:
         m_queue[queueIndex].m_hang_event->Trigger();
     }
     virtual void RequestQuit(QueueIndex queueIndex) override {
-        if (m_queue[queueIndex].m_hang_event == nullptr)
-            return;
         //main queue means quit
         if (queueIndex == QUIT) {
             m_queue[EThread::MAIN_QUEUE].m_close = true;
             m_queue[EThread::MAIN_QUEUE].m_hang_event->Trigger();
             m_queue[EThread::LOCAL_QUEUE >> EThread::QUEUE_MASK_SHEFT].m_close = true;
             m_queue[EThread::LOCAL_QUEUE >> EThread::QUEUE_MASK_SHEFT].m_hang_event->Trigger();
-        } else {
-            m_queue[queueIndex].m_should_return = true;
+            return;
         }
+        if (queueIndex < 0 || queueIndex >= 2 || m_queue[queueIndex].m_hang_event == nullptr) {
+            return;
+        }
+        m_queue[queueIndex].m_should_return = true;
     }
     virtual void EnqueueFromCurrentThread(QueueIndex queueIndex, BaseGraphTask* task) override {
 

--- a/source/runtime/core/include/taskgraph/ThreadManager.h
+++ b/source/runtime/core/include/taskgraph/ThreadManager.h
@@ -80,7 +80,7 @@ private:
     void Initialize();
 
 public:
-    void           AddThread(uint32_t id, RunnableThread*);
+    void           AddThread(uint32_t id, RunnableThread*) noexcept;
     void           RemoveThread(RunnableThread*);
     inline int32_t GetNum() {
         return m_threads.size();
@@ -114,12 +114,13 @@ class RunnableThread {
 
 public:
     CORE_API static RunnableThread* Create(Runnable* _runnable, ThreadAttributes _attributes);
-    virtual ~RunnableThread();
+    CORE_API virtual ~RunnableThread();
     void Tick();
     void Join() {
         if (m_thread && m_thread->joinable()) {
             m_thread->join();
-            MoerDelete(m_thread);
+            delete m_thread;
+            m_thread = nullptr;
         }
     }
     void Detach() {
@@ -128,7 +129,7 @@ public:
     bool Joinable() {
         return m_thread->joinable();
     }
-    void WaitUntilFinished();
+    CORE_API void WaitUntilFinished();
 
     inline const std::string& GetName() {
         return name;
@@ -142,12 +143,12 @@ protected:
     uint32_t Run();
 
 private:
-    Runnable*    m_runnable;
-    Event*       m_create_event;
-    Event*       m_end_event;
-    uint32_t     id;
+    Runnable*    m_runnable     = nullptr;
+    Event*       m_create_event = nullptr;
+    Event*       m_end_event    = nullptr;
+    uint32_t     id             = 0;
     std::string  name;
-    std::thread* m_thread;
+    std::thread* m_thread = nullptr;
 };
 
 class Runnable {

--- a/source/runtime/core/include/taskgraph/WorkStealing.h
+++ b/source/runtime/core/include/taskgraph/WorkStealing.h
@@ -1,0 +1,240 @@
+#ifndef MOER_TASKGRAPH_WORK_STEALING_H
+#define MOER_TASKGRAPH_WORK_STEALING_H
+
+#include "taskgraph/ThreadManager.h"
+
+#include <algorithm>
+#include <array>
+#include <atomic>
+#include <cassert>
+#include <cstdint>
+#include <exception>
+#include <limits>
+#include <memory>
+#include <type_traits>
+#include <vector>
+
+namespace Moer::TaskGraphDetail {
+
+/**
+ * Exact worker ranges for the three legacy priority pools.
+ *
+ * The old ceil(worker_count / 3) arithmetic could leave the Low pool empty
+ * for otherwise valid worker counts (for example four workers).  Keeping the
+ * ranges explicit also removes the old 32-bit waiter-bitmap indexing limit.
+ */
+struct WorkerPoolTopology {
+    int32_t named_thread_count  = 0;
+    int32_t worker_thread_count = 0;
+    std::array<int32_t, EThread::PriorityCount> starts{};
+    std::array<int32_t, EThread::PriorityCount> counts{};
+
+    [[nodiscard]] int32_t PriorityForThread(int32_t thread_index) const noexcept {
+        for (int32_t priority = 0; priority < EThread::PriorityCount; ++priority) {
+            const int32_t begin = starts[priority];
+            const int32_t end   = begin + counts[priority];
+            if (thread_index >= begin && thread_index < end) {
+                return priority;
+            }
+        }
+        return -1;
+    }
+
+    [[nodiscard]] int32_t LocalIndex(int32_t thread_index, int32_t priority) const noexcept {
+        if (priority < 0 || priority >= EThread::PriorityCount) {
+            return -1;
+        }
+        const int32_t local_index = thread_index - starts[priority];
+        return local_index >= 0 && local_index < counts[priority] ? local_index : -1;
+    }
+
+    [[nodiscard]] int32_t ThreadIndex(int32_t priority, int32_t local_index) const noexcept {
+        if (priority < 0 || priority >= EThread::PriorityCount || local_index < 0 ||
+            local_index >= counts[priority]) {
+            return -1;
+        }
+        return starts[priority] + local_index;
+    }
+};
+
+inline WorkerPoolTopology BuildWorkerPoolTopology(
+    int32_t named_thread_count,
+    int32_t worker_thread_count
+) noexcept {
+    if (named_thread_count < 0 || worker_thread_count < EThread::PriorityCount ||
+        named_thread_count + worker_thread_count > EThread::UNKNOWN_THREAD) {
+        std::terminate();
+    }
+
+    WorkerPoolTopology topology{};
+    topology.named_thread_count  = named_thread_count;
+    topology.worker_thread_count = worker_thread_count;
+
+    const int32_t workers_per_pool = worker_thread_count / EThread::PriorityCount;
+    const int32_t remainder        = worker_thread_count % EThread::PriorityCount;
+    int32_t       next_start       = named_thread_count;
+    for (int32_t priority = 0; priority < EThread::PriorityCount; ++priority) {
+        topology.starts[priority] = next_start;
+        topology.counts[priority] = workers_per_pool + (priority < remainder ? 1 : 0);
+        next_start += topology.counts[priority];
+    }
+
+    assert(next_start == named_thread_count + worker_thread_count);
+    return topology;
+}
+
+/**
+ * Single-owner, multi-thief Chase-Lev deque.
+ *
+ * Only the owning worker may call PushBottom/PopBottom. Any worker may call
+ * StealTop. Buffers grow by powers of two and every old generation remains
+ * alive until scheduler destruction, after all workers have joined. This is
+ * deliberately simple reclamation: a thief can safely finish through a stale
+ * buffer pointer without a hazard-pointer/epoch dependency in the hot path.
+ */
+template<typename T>
+class ChaseLevDeque {
+    static_assert(std::is_object_v<T>);
+
+    struct Buffer {
+        explicit Buffer(int64_t initial_capacity) : capacity(initial_capacity) {
+            assert(initial_capacity >= 2);
+            assert((initial_capacity & (initial_capacity - 1)) == 0);
+            slots = std::make_unique<std::atomic<T*>[]>(static_cast<size_t>(capacity));
+            for (int64_t index = 0; index < capacity; ++index) {
+                slots[index].store(nullptr, std::memory_order_relaxed);
+            }
+        }
+
+        [[nodiscard]] T* Load(int64_t index) const noexcept {
+            return slots[static_cast<size_t>(index & (capacity - 1))].load(
+                std::memory_order_relaxed
+            );
+        }
+
+        void Store(int64_t index, T* value) noexcept {
+            slots[static_cast<size_t>(index & (capacity - 1))].store(
+                value,
+                std::memory_order_relaxed
+            );
+        }
+
+        int64_t                            capacity = 0;
+        std::unique_ptr<std::atomic<T*>[]> slots{};
+    };
+
+public:
+    explicit ChaseLevDeque(int64_t initial_capacity = 32) : m_top(0), m_bottom(0) {
+        assert(initial_capacity >= 2);
+        assert((initial_capacity & (initial_capacity - 1)) == 0);
+        Buffer* initial = AllocateBuffer(initial_capacity);
+        m_buffer.store(initial, std::memory_order_release);
+    }
+
+    ChaseLevDeque(const ChaseLevDeque&)            = delete;
+    ChaseLevDeque& operator=(const ChaseLevDeque&) = delete;
+    ChaseLevDeque(ChaseLevDeque&&)                 = delete;
+    ChaseLevDeque& operator=(ChaseLevDeque&&)      = delete;
+
+    void PushBottom(T* value) noexcept {
+        assert(value != nullptr);
+
+        const int64_t bottom = m_bottom.load(std::memory_order_relaxed);
+        const int64_t top    = m_top.load(std::memory_order_acquire);
+        Buffer*       buffer = m_buffer.load(std::memory_order_relaxed);
+        if (bottom - top >= buffer->capacity - 1) {
+            Grow(top, bottom, buffer);
+            buffer = m_buffer.load(std::memory_order_relaxed);
+        }
+
+        buffer->Store(bottom, value);
+        std::atomic_thread_fence(std::memory_order_release);
+        m_bottom.store(bottom + 1, std::memory_order_relaxed);
+    }
+
+    [[nodiscard]] T* PopBottom() noexcept {
+        int64_t bottom = m_bottom.load(std::memory_order_relaxed) - 1;
+        Buffer* buffer = m_buffer.load(std::memory_order_relaxed);
+        m_bottom.store(bottom, std::memory_order_relaxed);
+        std::atomic_thread_fence(std::memory_order_seq_cst);
+
+        int64_t top = m_top.load(std::memory_order_relaxed);
+        if (top <= bottom) {
+            T* value = buffer->Load(bottom);
+            if (top == bottom) {
+                if (!m_top.compare_exchange_strong(
+                        top,
+                        top + 1,
+                        std::memory_order_seq_cst,
+                        std::memory_order_relaxed
+                    )) {
+                    value = nullptr;
+                }
+                m_bottom.store(bottom + 1, std::memory_order_relaxed);
+            }
+            return value;
+        }
+
+        m_bottom.store(bottom + 1, std::memory_order_relaxed);
+        return nullptr;
+    }
+
+    [[nodiscard]] T* StealTop() noexcept {
+        int64_t top = m_top.load(std::memory_order_acquire);
+        std::atomic_thread_fence(std::memory_order_seq_cst);
+        const int64_t bottom = m_bottom.load(std::memory_order_acquire);
+        if (top >= bottom) {
+            return nullptr;
+        }
+
+        Buffer* buffer = m_buffer.load(std::memory_order_acquire);
+        T*      value  = buffer->Load(top);
+        if (m_top.compare_exchange_strong(
+                top,
+                top + 1,
+                std::memory_order_seq_cst,
+                std::memory_order_relaxed
+            )) {
+            return value;
+        }
+        return nullptr;
+    }
+
+    [[nodiscard]] int64_t ApproximateSize() const noexcept {
+        const int64_t bottom = m_bottom.load(std::memory_order_acquire);
+        const int64_t top    = m_top.load(std::memory_order_acquire);
+        return std::max<int64_t>(0, bottom - top);
+    }
+
+private:
+    Buffer* AllocateBuffer(int64_t capacity) {
+        auto buffer = std::make_unique<Buffer>(capacity);
+        Buffer* raw = buffer.get();
+        m_buffers.emplace_back(std::move(buffer));
+        return raw;
+    }
+
+    void Grow(int64_t top, int64_t bottom, Buffer* current) noexcept {
+        assert(current == m_buffer.load(std::memory_order_relaxed));
+        if (current->capacity > std::numeric_limits<int64_t>::max() / 2) {
+            std::terminate();
+        }
+
+        Buffer* expanded = AllocateBuffer(current->capacity * 2);
+        for (int64_t index = top; index < bottom; ++index) {
+            expanded->Store(index, current->Load(index));
+        }
+        m_buffer.store(expanded, std::memory_order_release);
+    }
+
+    alignas(64) std::atomic<int64_t> m_top;
+    alignas(64) std::atomic<int64_t> m_bottom;
+    alignas(64) std::atomic<Buffer*> m_buffer{nullptr};
+
+    // Owner-only metadata. Thieves only dereference published Buffer objects.
+    std::vector<std::unique_ptr<Buffer>> m_buffers{};
+};
+
+} // namespace Moer::TaskGraphDetail
+
+#endif // MOER_TASKGRAPH_WORK_STEALING_H

--- a/source/runtime/core/source/taskgraph/AnyThreadScheduler.cpp
+++ b/source/runtime/core/source/taskgraph/AnyThreadScheduler.cpp
@@ -232,6 +232,15 @@ void AnyThreadScheduler::BeginDrain() noexcept {
     m_draining.store(true, std::memory_order_release);
 }
 
+AnyThreadScheduler::NamedPublicationGuard
+AnyThreadScheduler::AcquireNamedPublication() noexcept {
+    NamedPublicationGuard guard(m_admission_mutex);
+    if (m_draining.load(std::memory_order_acquire)) {
+        Platform::FailFast("TaskGraph named-target publication attempted during drain");
+    }
+    return guard;
+}
+
 bool AnyThreadScheduler::IsDraining() const noexcept {
     return m_draining.load(std::memory_order_acquire);
 }

--- a/source/runtime/core/source/taskgraph/AnyThreadScheduler.cpp
+++ b/source/runtime/core/source/taskgraph/AnyThreadScheduler.cpp
@@ -1,0 +1,250 @@
+#include "taskgraph/GraphTask.h"
+#include "misc/LockFree.h"
+#include "platform/Platform.h"
+
+#include "AnyThreadScheduler.h"
+
+#include <cassert>
+
+struct AnyThreadScheduler::PriorityPool::GlobalQueue {
+    LockFreeQueueBase<BaseGraphTask, false> queue{};
+};
+
+AnyThreadScheduler::PriorityPool::PriorityPool(int32_t in_worker_count) :
+    worker_count(in_worker_count),
+    workers(std::make_unique<WorkerState[]>(static_cast<size_t>(in_worker_count))),
+    global_queue(std::make_unique<GlobalQueue>()) {
+    assert(worker_count > 0);
+}
+
+AnyThreadScheduler::PriorityPool::~PriorityPool() = default;
+
+AnyThreadScheduler::AnyThreadScheduler(
+    Moer::TaskGraphDetail::WorkerPoolTopology topology,
+    WakeWorkerFn                              wake_worker,
+    void*                                     wake_context
+) :
+    m_topology(topology),
+    m_wake_worker(wake_worker),
+    m_wake_context(wake_context) {
+    assert(m_wake_worker != nullptr);
+    for (int32_t priority = 0; priority < EThread::PriorityCount; ++priority) {
+        assert(m_topology.counts[priority] > 0);
+        m_pools[priority] = std::make_unique<PriorityPool>(m_topology.counts[priority]);
+    }
+}
+
+AnyThreadScheduler::~AnyThreadScheduler() = default;
+
+bool AnyThreadScheduler::TryGetLocalWorker(
+    EThread::Type  actual_current_thread,
+    ThreadPriority target_priority,
+    int32_t&       local_worker_index
+) const noexcept {
+    if (EThread::IsUnKnownThread(actual_current_thread)) {
+        return false;
+    }
+
+    const int32_t thread_index = EThread::GetThreadIndex(actual_current_thread);
+    const int32_t actual_priority = m_topology.PriorityForThread(thread_index);
+    if (actual_priority != target_priority ||
+        EThread::GetThreadPriority(actual_current_thread) != target_priority) {
+        return false;
+    }
+
+    local_worker_index = m_topology.LocalIndex(thread_index, target_priority);
+    return local_worker_index >= 0;
+}
+
+bool AnyThreadScheduler::IsTaskGraphWorker(EThread::Type actual_current_thread) const noexcept {
+    if (EThread::IsUnKnownThread(actual_current_thread)) {
+        return false;
+    }
+
+    const int32_t thread_index = EThread::GetThreadIndex(actual_current_thread);
+    const int32_t priority     = m_topology.PriorityForThread(thread_index);
+    return priority >= 0 && EThread::GetThreadPriority(actual_current_thread) == priority;
+}
+
+bool AnyThreadScheduler::WakeOneIdleWorker(ThreadPriority priority) noexcept {
+    PriorityPool& pool = *m_pools[priority];
+    const uint32_t start = pool.wake_cursor.fetch_add(1, std::memory_order_relaxed) %
+                           static_cast<uint32_t>(pool.worker_count);
+
+    for (int32_t offset = 0; offset < pool.worker_count; ++offset) {
+        const int32_t local_index = static_cast<int32_t>(
+            (start + static_cast<uint32_t>(offset)) % static_cast<uint32_t>(pool.worker_count)
+        );
+        bool expected = true;
+        if (!pool.workers[local_index].idle.compare_exchange_strong(
+                expected,
+                false,
+                std::memory_order_seq_cst,
+                std::memory_order_seq_cst
+            )) {
+            continue;
+        }
+
+        const int32_t thread_index = m_topology.ThreadIndex(priority, local_index);
+        assert(thread_index >= 0);
+        m_wake_worker(m_wake_context, thread_index);
+        return true;
+    }
+    return false;
+}
+
+void AnyThreadScheduler::Enqueue(
+    BaseGraphTask* task,
+    EThread::Type  actual_current_thread,
+    bool           wake_peer
+) noexcept {
+    assert(task != nullptr);
+    (void)wake_peer;
+    const ThreadPriority priority = task->GetPriority();
+    assert(priority >= 0 && priority < EThread::PriorityCount);
+    PriorityPool& pool = *m_pools[priority];
+
+    const auto publish = [&]() noexcept {
+        m_pending_tasks.fetch_add(1, std::memory_order_relaxed);
+
+        int32_t local_worker_index = -1;
+        if (TryGetLocalWorker(actual_current_thread, priority, local_worker_index)) {
+            pool.workers[local_worker_index].deque.PushBottom(task);
+            // Always notify an actual idle peer. A single continuation can block
+            // its owner immediately after publication, so wake_peer=false is not
+            // a sufficient progress guarantee for a local deque.
+            std::atomic_thread_fence(std::memory_order_seq_cst);
+            WakeOneIdleWorker(priority);
+            return;
+        }
+
+        // External, named-thread and cross-priority producers use the MPMC ingress
+        // queue. They must always wake a real idle worker even when an upstream
+        // continuation batch passes wake_peer=false.
+        pool.global_queue->queue.Push(task);
+        std::atomic_thread_fence(std::memory_order_seq_cst);
+        WakeOneIdleWorker(priority);
+    };
+
+    if (IsTaskGraphWorker(actual_current_thread)) {
+        // The executing parent remains included in m_pending_tasks until after
+        // task->Execute() returns, so nested worker publication cannot race the
+        // pending-zero drain transition.
+        publish();
+        return;
+    }
+
+    // Serialize external/named publication with BeginDrain. Once shutdown owns
+    // this gate, accepting an untracked producer would either prolong shutdown
+    // indefinitely or publish into a scheduler that is about to be destroyed.
+    std::lock_guard admission_lock(m_admission_mutex);
+    if (m_draining.load(std::memory_order_acquire)) {
+        Platform::FailFast("external AnyThread publication attempted during TaskGraph drain");
+    }
+    publish();
+}
+
+BaseGraphTask* AnyThreadScheduler::TryFindWork(
+    PriorityPool& pool,
+    int32_t       local_worker_index
+) noexcept {
+    WorkerState& self = pool.workers[local_worker_index];
+
+    // A permanently replenished local deque must not starve external ingress.
+    if (self.local_pop_streak >= GlobalProbeInterval) {
+        self.local_pop_streak = 0;
+        if (BaseGraphTask* task = pool.global_queue->queue.Pop()) {
+            return task;
+        }
+    }
+
+    if (BaseGraphTask* task = self.deque.PopBottom()) {
+        ++self.local_pop_streak;
+        return task;
+    }
+
+    self.local_pop_streak = 0;
+    if (BaseGraphTask* task = pool.global_queue->queue.Pop()) {
+        return task;
+    }
+
+    if (pool.worker_count <= 1) {
+        return nullptr;
+    }
+
+    const uint32_t first_victim = ++self.steal_cursor % static_cast<uint32_t>(pool.worker_count);
+    for (int32_t offset = 0; offset < pool.worker_count; ++offset) {
+        const int32_t victim = static_cast<int32_t>(
+            (first_victim + static_cast<uint32_t>(offset)) %
+            static_cast<uint32_t>(pool.worker_count)
+        );
+        if (victim == local_worker_index) {
+            continue;
+        }
+        if (BaseGraphTask* task = pool.workers[victim].deque.StealTop()) {
+            return task;
+        }
+    }
+    return nullptr;
+}
+
+BaseGraphTask* AnyThreadScheduler::DequeueOrPrepareToPark(int32_t thread_index) noexcept {
+    const int32_t priority = m_topology.PriorityForThread(thread_index);
+    assert(priority >= 0 && priority < EThread::PriorityCount);
+    PriorityPool& pool = *m_pools[priority];
+    const int32_t local_worker_index = m_topology.LocalIndex(thread_index, priority);
+    assert(local_worker_index >= 0 && local_worker_index < pool.worker_count);
+
+    WorkerState& self = pool.workers[local_worker_index];
+    self.idle.store(false, std::memory_order_release);
+    if (BaseGraphTask* task = TryFindWork(pool, local_worker_index)) {
+        return task;
+    }
+
+    // Two-phase park handshake. A producer either observes this registration
+    // and sends a sticky Event signal, or its earlier publication is observed
+    // by the complete second search below.
+    self.idle.store(true, std::memory_order_relaxed);
+    // Paired with the producer-side seq_cst fence before idle claiming. This
+    // prevents the store-buffering outcome where the worker misses the newly
+    // published task while the producer still misses the idle registration.
+    std::atomic_thread_fence(std::memory_order_seq_cst);
+    if (BaseGraphTask* task = TryFindWork(pool, local_worker_index)) {
+        self.idle.store(false, std::memory_order_release);
+        return task;
+    }
+    return nullptr;
+}
+
+void AnyThreadScheduler::NotifyTaskCompleted() noexcept {
+    const uint64_t previous = m_pending_tasks.fetch_sub(1, std::memory_order_acq_rel);
+    assert(previous > 0);
+    if (previous != 1) {
+        return;
+    }
+
+    std::lock_guard lock(m_idle_mutex);
+    m_idle_condition.notify_all();
+}
+
+void AnyThreadScheduler::BeginDrain() noexcept {
+    std::lock_guard admission_lock(m_admission_mutex);
+    m_draining.store(true, std::memory_order_release);
+}
+
+bool AnyThreadScheduler::IsDraining() const noexcept {
+    return m_draining.load(std::memory_order_acquire);
+}
+
+bool AnyThreadScheduler::IsWaitingForIdle() const noexcept {
+    return m_waiting_for_idle.load(std::memory_order_acquire);
+}
+
+void AnyThreadScheduler::WaitUntilIdle() noexcept {
+    std::unique_lock lock(m_idle_mutex);
+    m_waiting_for_idle.store(true, std::memory_order_release);
+    m_idle_condition.wait(lock, [this] {
+        return m_pending_tasks.load(std::memory_order_acquire) == 0;
+    });
+    m_waiting_for_idle.store(false, std::memory_order_release);
+}

--- a/source/runtime/core/source/taskgraph/AnyThreadScheduler.h
+++ b/source/runtime/core/source/taskgraph/AnyThreadScheduler.h
@@ -1,0 +1,89 @@
+#ifndef MOER_ANY_THREAD_SCHEDULER_H
+#define MOER_ANY_THREAD_SCHEDULER_H
+
+#include "taskgraph/WorkStealing.h"
+
+#include <array>
+#include <atomic>
+#include <condition_variable>
+#include <cstdint>
+#include <memory>
+#include <mutex>
+
+class BaseGraphTask;
+
+/** Core-private AnyThread backend. GraphEvent and dependency semantics stay in TaskGraph. */
+class AnyThreadScheduler {
+public:
+    using WakeWorkerFn = void (*)(void* context, int32_t thread_index) noexcept;
+
+    AnyThreadScheduler(
+        Moer::TaskGraphDetail::WorkerPoolTopology topology,
+        WakeWorkerFn                              wake_worker,
+        void*                                     wake_context
+    );
+    ~AnyThreadScheduler();
+
+    AnyThreadScheduler(const AnyThreadScheduler&)            = delete;
+    AnyThreadScheduler& operator=(const AnyThreadScheduler&) = delete;
+
+    void Enqueue(
+        BaseGraphTask* task,
+        EThread::Type  actual_current_thread,
+        bool           wake_peer
+    ) noexcept;
+
+    /** Returns work or atomically registers the caller as safe to park. */
+    [[nodiscard]] BaseGraphTask* DequeueOrPrepareToPark(int32_t thread_index) noexcept;
+    void                         NotifyTaskCompleted() noexcept;
+    /** Stop external/named producers while allowing in-flight workers to publish continuations. */
+    void                         BeginDrain() noexcept;
+    [[nodiscard]] bool           IsDraining() const noexcept;
+    [[nodiscard]] bool           IsWaitingForIdle() const noexcept;
+    void                         WaitUntilIdle() noexcept;
+
+private:
+    struct WorkerState {
+        Moer::TaskGraphDetail::ChaseLevDeque<BaseGraphTask> deque{};
+        std::atomic_bool idle{false};
+        uint32_t         local_pop_streak = 0;
+        uint32_t         steal_cursor     = 0;
+    };
+
+    struct PriorityPool {
+        struct GlobalQueue;
+
+        explicit PriorityPool(int32_t worker_count);
+        ~PriorityPool();
+
+        int32_t                         worker_count = 0;
+        std::unique_ptr<WorkerState[]>  workers{};
+        std::unique_ptr<GlobalQueue>    global_queue{};
+        std::atomic<uint32_t>           wake_cursor{0};
+    };
+
+    [[nodiscard]] BaseGraphTask*
+    TryFindWork(PriorityPool& pool, int32_t local_worker_index) noexcept;
+    [[nodiscard]] bool TryGetLocalWorker(
+        EThread::Type  actual_current_thread,
+        ThreadPriority target_priority,
+        int32_t&       local_worker_index
+    ) const noexcept;
+    [[nodiscard]] bool IsTaskGraphWorker(EThread::Type actual_current_thread) const noexcept;
+    bool WakeOneIdleWorker(ThreadPriority priority) noexcept;
+
+    static constexpr uint32_t GlobalProbeInterval = 32;
+
+    Moer::TaskGraphDetail::WorkerPoolTopology                 m_topology{};
+    std::array<std::unique_ptr<PriorityPool>, EThread::PriorityCount> m_pools{};
+    WakeWorkerFn                                              m_wake_worker = nullptr;
+    void*                                                     m_wake_context = nullptr;
+    std::atomic<uint64_t>                                     m_pending_tasks{0};
+    std::atomic_bool                                          m_draining{false};
+    std::atomic_bool                                          m_waiting_for_idle{false};
+    std::mutex                                                m_admission_mutex{};
+    std::mutex                                                m_idle_mutex{};
+    std::condition_variable                                   m_idle_condition{};
+};
+
+#endif // MOER_ANY_THREAD_SCHEDULER_H

--- a/source/runtime/core/source/taskgraph/AnyThreadScheduler.h
+++ b/source/runtime/core/source/taskgraph/AnyThreadScheduler.h
@@ -17,6 +17,21 @@ class AnyThreadScheduler {
 public:
     using WakeWorkerFn = void (*)(void* context, int32_t thread_index) noexcept;
 
+    class NamedPublicationGuard {
+    public:
+        NamedPublicationGuard(NamedPublicationGuard&&) noexcept = default;
+        NamedPublicationGuard& operator=(NamedPublicationGuard&&) noexcept = default;
+
+        NamedPublicationGuard(const NamedPublicationGuard&)            = delete;
+        NamedPublicationGuard& operator=(const NamedPublicationGuard&) = delete;
+
+    private:
+        friend class AnyThreadScheduler;
+        explicit NamedPublicationGuard(std::mutex& admission_mutex) : m_lock(admission_mutex) {}
+
+        std::unique_lock<std::mutex> m_lock;
+    };
+
     AnyThreadScheduler(
         Moer::TaskGraphDetail::WorkerPoolTopology topology,
         WakeWorkerFn                              wake_worker,
@@ -38,6 +53,8 @@ public:
     void                         NotifyTaskCompleted() noexcept;
     /** Stop external/named producers while allowing in-flight workers to publish continuations. */
     void                         BeginDrain() noexcept;
+    /** Keep the drain decision and named-queue publication in one admission interval. */
+    [[nodiscard]] NamedPublicationGuard AcquireNamedPublication() noexcept;
     [[nodiscard]] bool           IsDraining() const noexcept;
     [[nodiscard]] bool           IsWaitingForIdle() const noexcept;
     void                         WaitUntilIdle() noexcept;

--- a/source/runtime/core/source/taskgraph/TaskGraph.cpp
+++ b/source/runtime/core/source/taskgraph/TaskGraph.cpp
@@ -1,9 +1,15 @@
 #include "taskgraph/TaskGraph.h"
+#include "AnyThreadScheduler.h"
 #include "platform/Platform.h"
 #include "taskgraph/GraphTask.h"
 #include "taskgraph/ThreadManager.h"
 //#define NOMINMAX 1
 #undef max
+
+namespace {
+thread_local EThread::Type g_task_graph_worker_thread = EThread::UNKNOWN_THREAD;
+}
+
 TaskGraph* TaskGraph::instance = nullptr;
 
 TaskGraph& TaskGraph::GetInterface() {
@@ -17,11 +23,25 @@ bool TaskGraph::IsInitialized() noexcept {
 
 void TaskGraph::Init() {
     if (instance == nullptr) {
-        instance = MoerNew(TaskGraph)();
+        void* storage = Memory::Malloc(sizeof(TaskGraph));
+        if (storage == nullptr) {
+            throw std::bad_alloc();
+        }
+        try {
+            instance = MoerPlacementNew(storage) TaskGraph();
+        } catch (...) {
+            Memory::Free(storage);
+            throw;
+        }
     }
 }
 void TaskGraph::Shutdown() {
     if (instance != nullptr) {
+        // A worker cannot wait for pending==0 while its own executing task is
+        // still part of that count. Shutdown is an external-owner operation.
+        if (!EThread::IsUnKnownThread(g_task_graph_worker_thread)) {
+            Platform::FailFast("TaskGraph shutdown requested from an AnyThread worker");
+        }
         MoerDelete(instance);
         instance = nullptr;
     }
@@ -35,8 +55,20 @@ TaskThreadBase& TaskGraph::GetThread(ThreadIndex index) {
 }
 
 void TaskGraph::WakeUpWorkerThread(int32_t threadIndex, QueueIndex index) noexcept {
-    assert(threadIndex >= 0);
+    assert(threadIndex >= m_named_thread_count && threadIndex < m_thread_count);
     m_workers[threadIndex].task_thread->Wake(index);
+}
+void TaskGraph::WakeWorkerCallback(void* context, int32_t threadIndex) noexcept {
+    static_cast<TaskGraph*>(context)->WakeUpWorkerThread(threadIndex, EThread::MAIN_QUEUE);
+}
+void TaskGraph::SetCurrentWorkerThread(EThread::Type thread) noexcept {
+    g_task_graph_worker_thread = thread;
+}
+void TaskGraph::ClearCurrentWorkerThread() noexcept {
+    g_task_graph_worker_thread = EThread::UNKNOWN_THREAD;
+}
+void TaskGraph::NotifyAnyThreadTaskCompleted() noexcept {
+    m_any_thread_scheduler->NotifyTaskCompleted();
 }
 void TaskGraph::WaitUntilTaskComplete(const GraphEventRef& task, EThread::Type currentThread) {
     WaitUntilTasksComplete({task}, currentThread);
@@ -46,49 +78,98 @@ void TaskGraph::WaitUntilTaskComplete(GraphEventRef&& task, EThread::Type curren
 };
 TaskGraph::TaskGraph() {
     assert(instance == nullptr);
-    int32_t actual_thread_num = Platform::GetProcessorCoreCount();
+    const int32_t actual_thread_num = Platform::GetProcessorCoreCount();
 
     m_named_thread_count                   = EThread::NamedThreadCount;
-    int32_t min_worker_thread_per_priority = 1;
-    int32_t min_thread_count = min_worker_thread_per_priority * EThread::PriorityCount + m_named_thread_count;
+    const int32_t min_worker_thread_per_priority = 1;
+    const int32_t min_thread_count =
+        min_worker_thread_per_priority * EThread::PriorityCount + m_named_thread_count;
 
-    m_thread_count = std::max(min_thread_count, actual_thread_num);
+    // EThread reserves the all-ones 8-bit index for UNKNOWN_THREAD, so valid
+    // worker/named indices end at 254 even on very large server topologies.
+    m_thread_count = std::min(
+        std::max(min_thread_count, actual_thread_num),
+        static_cast<int32_t>(EThread::UNKNOWN_THREAD)
+    );
 
     m_worker_thread_count = m_thread_count - m_named_thread_count;
+    m_worker_topology = Moer::TaskGraphDetail::BuildWorkerPoolTopology(
+        m_named_thread_count,
+        m_worker_thread_count
+    );
 
-    m_worker_per_priority = m_worker_thread_count / EThread::PriorityCount;
-    m_worker_per_priority =
-        m_worker_thread_count % EThread::PriorityCount ? m_worker_per_priority + 1 : m_worker_per_priority;
-    int32_t priority_set_count = m_worker_thread_count / EThread::PriorityCount;
+    // Allocate the owning scheduler before raw queue objects so a failure here
+    // cannot strand TaskThread Event resources in a partially-built TaskGraph.
+    m_any_thread_scheduler = std::make_unique<AnyThreadScheduler>(
+        m_worker_topology,
+        &TaskGraph::WakeWorkerCallback,
+        this
+    );
 
-    for (int32_t i = 0; i < m_thread_count; i++) {
-        EThread::Type  type     = EThread::SetThreadIndex(EThread::UNKNOWN_THREAD, i);
-        ThreadPriority priority = GetThreadPriorityFromIndex(i) << EThread::PRIORITY_SHEFT;
-        type                    = EThread::SetPriority(type, priority);
-        if (i >= m_named_thread_count) {
-            //any_thread
-            m_workers[i].task_thread = new TaskThreadAnyThread(type);
-        } else {
-            m_workers[i].task_thread = new NamedThread;
-            //named_thread
+    int32_t constructed_task_threads = 0;
+    try {
+        for (int32_t i = 0; i < m_thread_count; i++) {
+            EThread::Type type = EThread::SetThreadIndex(EThread::UNKNOWN_THREAD, i);
+            const int32_t priority_index =
+                i < m_named_thread_count ? 0 : GetThreadPriorityFromIndex(i);
+            assert(priority_index >= 0 && priority_index < EThread::PriorityCount);
+            const ThreadPriority priority = priority_index << EThread::PRIORITY_SHEFT;
+            type                          = EThread::SetPriority(type, priority);
+            m_workers[i].task_thread = i >= m_named_thread_count
+                                           ? static_cast<TaskThreadBase*>(new TaskThreadAnyThread(type))
+                                           : static_cast<TaskThreadBase*>(new NamedThread);
+            m_workers[i].task_thread->SetAttributes(type, &m_workers[i]);
+            ++constructed_task_threads;
         }
-        m_workers[i].task_thread->SetAttributes(type, &m_workers[i]);
-    }
-    instance = this; //set here to make sure access of worker_threads below
-    //todo no handle for thread groups
-    for (int32_t i = m_named_thread_count; i < m_thread_count; i++) {
-        int32_t     priority = GetThreadPriorityFromIndex(i);
-        std::string name     = "WorkerThread_" + GetPriorityStr(priority) + "_" +
-                           std::to_string((i - m_named_thread_count) % m_worker_per_priority);
-        m_workers[i].actual_thread = RunnableThread::Create(
-            &GetThread(i),
-            ThreadAttributes{.affinity = Affinity::AnyOf(i, std::move(Affinity::All())), .name = name}
-        );
-        m_workers[i].attached = true;
+
+        instance = this; // Worker entry resolves the graph through the singleton.
+        // TODO: no handle for thread groups.
+        for (int32_t i = m_named_thread_count; i < m_thread_count; i++) {
+            const int32_t priority = GetThreadPriorityFromIndex(i);
+            const std::string name = "WorkerThread_" + GetPriorityStr(priority) + "_" +
+                                     std::to_string(m_worker_topology.LocalIndex(i, priority));
+            m_workers[i].actual_thread = RunnableThread::Create(
+                &GetThread(i),
+                ThreadAttributes{
+                    .affinity = Affinity::AnyOf(i, std::move(Affinity::All())),
+                    .name     = name
+                }
+            );
+            m_workers[i].attached = true;
+        }
+    } catch (...) {
+        // Successfully-started workers still require the live singleton while
+        // they observe their close signal and leave the scheduler loop.
+        for (int32_t i = m_named_thread_count; i < m_thread_count; ++i) {
+            if (m_workers[i].actual_thread != nullptr) {
+                m_workers[i].task_thread->RequestQuit(QUIT);
+            }
+        }
+        for (int32_t i = m_named_thread_count; i < m_thread_count; ++i) {
+            if (m_workers[i].actual_thread != nullptr) {
+                m_workers[i].actual_thread->WaitUntilFinished();
+                MoerDelete(m_workers[i].actual_thread);
+                m_workers[i].actual_thread = nullptr;
+            }
+        }
+        if (instance == this) {
+            instance = nullptr;
+        }
+        for (int32_t i = 0; i < constructed_task_threads; ++i) {
+            delete m_workers[i].task_thread;
+            m_workers[i].task_thread = nullptr;
+        }
+        m_any_thread_scheduler.reset();
+        throw;
     }
 }
 
 TaskGraph::~TaskGraph() {
+    // TaskSystem shutdown requires external producers to be quiescent. Keep
+    // every priority pool alive until already-published work (including
+    // cross-priority continuations) has completed, then close the workers.
+    m_any_thread_scheduler->BeginDrain();
+    m_any_thread_scheduler->WaitUntilIdle();
     for (int32_t i = 0; i < m_thread_count; i++) {
         m_workers[i].task_thread->RequestQuit(QUIT);
     }
@@ -100,32 +181,43 @@ TaskGraph::~TaskGraph() {
             m_workers[i].actual_thread = nullptr;
         }
         m_workers[i].attached = false;
+        // Named owners are externally joined before TaskSystem shutdown (the
+        // render service enforces this ordering), but TaskGraph still owns the
+        // NamedThread queue objects and their pooled Events.
+        delete m_workers[i].task_thread;
+        m_workers[i].task_thread = nullptr;
     }
+    m_any_thread_scheduler.reset();
     instance = nullptr;
 }
 EThread::Type TaskGraph::GetCurrentThread(bool localQueue) {
-    ThreadIndex index = Platform::GetCurrentThreadID();
-    if (Platform::GetCurrentThreadID() == ThreadManager::g_game_thread_id)
+    if (!EThread::IsUnKnownThread(g_task_graph_worker_thread)) {
         return EThread::Type(
-            localQueue ? (EThread::EMainThread | EThread::LOCAL_QUEUE) : EThread::EMainThread
-        );
-    if (Platform::GetCurrentThreadID() == ThreadManager::g_render_thread_id)
-        return EThread::Type(
-            localQueue ? (EThread::ERenderThread | EThread::LOCAL_QUEUE) : EThread::ERenderThread
-        );
-    auto* thread = ThreadManager::Instance().GetRunnableThread(Platform::GetCurrentThreadID());
-    if (thread) {
-        ThreadIndex index = thread->m_runnable->GetIndex();
-        return EThread::Type(
-            m_workers[index].task_thread->m_thread_type |
+            g_task_graph_worker_thread |
             (localQueue ? EThread::LOCAL_QUEUE : EThread::MAIN_QUEUE)
         );
     }
+
+    const uint32_t current_thread_id = Platform::GetCurrentThreadID();
+    if (current_thread_id == ThreadManager::g_game_thread_id)
+        return EThread::Type(
+            localQueue ? (EThread::EMainThread | EThread::LOCAL_QUEUE) : EThread::EMainThread
+        );
+    if (current_thread_id == ThreadManager::g_render_thread_id)
+        return EThread::Type(
+            localQueue ? (EThread::ERenderThread | EThread::LOCAL_QUEUE) : EThread::ERenderThread
+        );
     // Dedicated runtime owners such as the RHI Executor are intentionally not
     // TaskGraph workers. Treat them as external callers so GraphEvent::Wait()
     // installs an ordinary completion event instead of indexing a named
     // worker queue. This matches the dev_parallel_rhi ownership model.
     return EThread::SetPriority(EThread::UNKNOWN_THREAD, EThread::NORMAL_PRI);
+}
+bool TaskGraph::IsDraining() const noexcept {
+    return m_any_thread_scheduler->IsDraining();
+}
+bool TaskGraph::IsWaitingForIdle() const noexcept {
+    return m_any_thread_scheduler->IsWaitingForIdle();
 }
 bool TaskGraph::IsThreadProcessingTask(EThread::Type index) {
     return m_workers[EThread::GetThreadIndex(index)].task_thread->IsProcessingTask(
@@ -219,17 +311,20 @@ void TaskGraph::QueueTask(
     bool           wake_worker
 ) noexcept {
     if (EThread::GetThreadIndex(_prefered_thread) == EThread::UNKNOWN_THREAD) { //any thread is ok
-        ThreadPriority priority                = task->GetPriority();
-        int32_t        possible_thread_to_wake = m_task_queue[priority].Push(task, 0);
-        if (possible_thread_to_wake >= 0) {
-            //start task thread
-            possible_thread_to_wake =
-                possible_thread_to_wake + priority * m_worker_per_priority + m_named_thread_count;
-            WakeUpWorkerThread(possible_thread_to_wake, 0);
-        }
+        // Scheduler ownership comes only from trusted worker TLS, never from
+        // ThreadManager's mutable registry or the caller-supplied hint.
+        const EThread::Type actual_current_thread = g_task_graph_worker_thread;
+        m_any_thread_scheduler->Enqueue(task, actual_current_thread, wake_worker);
         return;
     }
     //named thread
+    // Shutdown only owns/drains the AnyThread pools. Publishing a named-target
+    // continuation after their drain point would leave work in a queue whose
+    // owner is no longer guaranteed to pump, so reject it at the same fatal
+    // post-ownership-transfer boundary as a late external AnyThread publish.
+    if (m_any_thread_scheduler->IsDraining()) {
+        Platform::FailFast("TaskGraph named-target publication attempted during drain");
+    }
     EThread::Type temp_current_thread;
     temp_current_thread = GetCurrentThread();
 
@@ -242,11 +337,5 @@ void TaskGraph::QueueTask(
     }
 }
 BaseGraphTask* TaskGraph::DequeueTask(int32_t threadIndex) {
-    int32_t        priority          = GetThreadPriorityFromIndex(threadIndex);
-    int32_t        index_in_priority = (threadIndex - m_named_thread_count) % m_worker_per_priority;
-    BaseGraphTask* task              = m_task_queue[priority].Pop(index_in_priority);
-    //if (task != nullptr) {
-    //	task = m_global_queue.pop(index_in_priority);
-    //}
-    return task;
+    return m_any_thread_scheduler->DequeueOrPrepareToPark(threadIndex);
 }

--- a/source/runtime/core/source/taskgraph/TaskGraph.cpp
+++ b/source/runtime/core/source/taskgraph/TaskGraph.cpp
@@ -318,13 +318,11 @@ void TaskGraph::QueueTask(
         return;
     }
     //named thread
-    // Shutdown only owns/drains the AnyThread pools. Publishing a named-target
-    // continuation after their drain point would leave work in a queue whose
-    // owner is no longer guaranteed to pump, so reject it at the same fatal
-    // post-ownership-transfer boundary as a late external AnyThread publish.
-    if (m_any_thread_scheduler->IsDraining()) {
-        Platform::FailFast("TaskGraph named-target publication attempted during drain");
-    }
+    // Shutdown only owns/drains the AnyThread pools. Keep the drain check and
+    // named-queue publication under the same admission gate so BeginDrain
+    // cannot linearize between them and strand a continuation after shutdown.
+    [[maybe_unused]] auto named_admission =
+        m_any_thread_scheduler->AcquireNamedPublication();
     EThread::Type temp_current_thread;
     temp_current_thread = GetCurrentThread();
 

--- a/source/runtime/core/source/taskgraph/Thread.cpp
+++ b/source/runtime/core/source/taskgraph/Thread.cpp
@@ -2,6 +2,19 @@
 #include "platform/Platform.h"
 #include "taskgraph/GraphTask.h"
 #include "taskgraph/TaskGraph.h"
+
+uint32_t TaskThreadAnyThread::Run() {
+    TaskGraph::SetCurrentWorkerThread(m_thread_type);
+    try {
+        const uint32_t result = TaskThreadBase::Run();
+        TaskGraph::ClearCurrentWorkerThread();
+        return result;
+    } catch (...) {
+        TaskGraph::ClearCurrentWorkerThread();
+        throw;
+    }
+}
+
 BaseGraphTask* TaskThreadAnyThread::FindTaskToDo() {
 
     return TaskGraph::GetInterface().DequeueTask(EThread::GetThreadIndex(m_thread_type));
@@ -19,6 +32,7 @@ uint32_t TaskThreadAnyThread::ProcessTasks() {
             continue;
         }
         task->Execute(m_thread_type);
+        TaskGraph::GetInterface().NotifyAnyThreadTaskCompleted();
     }
     assert(--m_queue.call_amount == 0);
     return 0;

--- a/source/runtime/core/source/taskgraph/ThreadManager.cpp
+++ b/source/runtime/core/source/taskgraph/ThreadManager.cpp
@@ -40,10 +40,16 @@ std::string GetPriorityStr(int32_t priority) {
 ThreadManager::~ThreadManager() {
     ShutDown();
 }
-void ThreadManager::AddThread(uint32_t id, RunnableThread* thread) {
-    if (m_threads.find(id) == m_threads.end()) {
-        m_threads.emplace(id, thread);
-        m_thread_indexs.emplace(id, m_threads.size() - 1);
+void ThreadManager::AddThread(uint32_t id, RunnableThread* thread) noexcept {
+    try {
+        if (m_threads.find(id) == m_threads.end()) {
+            m_threads.emplace(id, thread);
+            m_thread_indexs.emplace(id, m_threads.size() - 1);
+        }
+    } catch (...) {
+        // RunnableThread registration happens only after the OS thread has
+        // started; generic Runnable::Stop is not strong enough for rollback.
+        Platform::FailFast("RunnableThread registry publication failed");
     }
 }
 
@@ -135,12 +141,30 @@ void RunnableThread::SetName(std::string_view _name) {
 RunnableThread::~RunnableThread() {
     ThreadManager::Instance().RemoveThread(this);
     Join();
+    if (m_end_event != nullptr) {
+        EventPool::Get()->ReleaseEvent(m_end_event);
+        m_end_event = nullptr;
+    }
 }
 
 RunnableThread* RunnableThread::Create(Runnable* _runnable, ThreadAttributes _attributes) {
+    // Resolve the registry before starting the OS thread. Once construction
+    // succeeds the worker is externally observable, so registration is a
+    // process-fatal publication boundary rather than a recoverable exception.
+    ThreadManager& manager = ThreadManager::Instance();
+    void* storage = Memory::Malloc(sizeof(RunnableThread));
+    if (storage == nullptr) {
+        throw std::bad_alloc();
+    }
+
     RunnableThread* created_thread = nullptr;
-    created_thread                 = MoerNew(RunnableThread)(_runnable, _attributes);
-    ThreadManager::Instance().AddThread(created_thread->id, created_thread);
+    try {
+        created_thread = MoerPlacementNew(storage) RunnableThread(_runnable, _attributes);
+    } catch (...) {
+        Memory::Free(storage);
+        throw;
+    }
+    manager.AddThread(created_thread->id, created_thread);
     return created_thread;
 }
 
@@ -148,20 +172,37 @@ void RunnableThread::Tick() {}
 
 RunnableThread::RunnableThread(Runnable* _in_runnable, ThreadAttributes _attributes) {
     assert(_in_runnable != nullptr);
-    m_runnable     = _in_runnable;
+    m_runnable = _in_runnable;
+    name       = _attributes.name;
+    std::string thread_name = name;
+    Affinity    affinity    = std::move(_attributes.affinity);
+
     m_create_event = EventPool::Get()->GetEvent(false);
-    m_end_event    = EventPool::Get()->GetEvent(false);
     EventRef create_event(m_create_event);
-    m_thread = MoerNew(std::thread)(
-        [_in_runnable, name(_attributes.name), affinity(std::move(_attributes.affinity)), this]() {
-            SetName(name);
-            auto tmp_affinity = affinity;
-            SetAffinity(std::move(tmp_affinity));
-            Run();
-        }
-    );
-    create_event.Wait();
-    this->name = _attributes.name;
+    m_end_event    = EventPool::Get()->GetEvent(false);
+
+    try {
+        m_thread = new std::thread(
+            [thread_name = std::move(thread_name), affinity = std::move(affinity), this]() mutable {
+                Platform::SetCurrentThreadName(thread_name);
+                SetAffinity(std::move(affinity));
+                Run();
+            }
+        );
+    } catch (...) {
+        EventPool::Get()->ReleaseEvent(m_end_event);
+        m_end_event = nullptr;
+        throw;
+    }
+
+    // No exception may escape after the OS thread has started: the generic
+    // Runnable contract cannot guarantee that Stop() can unwind every worker.
+    try {
+        create_event.Wait();
+    } catch (...) {
+        Platform::FailFast("RunnableThread startup handshake failed");
+    }
+    m_create_event = nullptr;
 
     // SPDLOG_DEBUG("[{}] {} thread created", name, this->id);
 }

--- a/source/test/CMakeLists.txt
+++ b/source/test/CMakeLists.txt
@@ -652,6 +652,11 @@ target_link_libraries(${test_target}
     PUBLIC Moer::Core
 )
 set_target_properties(${test_target} PROPERTIES FOLDER ${moer_test_folder})
+add_test(NAME TaskGraphContract COMMAND $<TARGET_FILE:${test_target}>)
+set_tests_properties(
+    TaskGraphContract
+    PROPERTIES TIMEOUT 120 CONFIGURATIONS Debug
+)
 
 set(pipe_test_target TestTaskPipe)
 add_executable(${pipe_test_target} "TaskPipeTest.cpp")
@@ -662,6 +667,20 @@ target_link_libraries(${pipe_test_target}
     PUBLIC Moer::Core
 )
 set_target_properties(${pipe_test_target} PROPERTIES FOLDER ${moer_test_folder})
+add_test(NAME TaskPipeContract COMMAND $<TARGET_FILE:${pipe_test_target}>)
+set_tests_properties(
+    TaskPipeContract
+    PROPERTIES TIMEOUT 60 CONFIGURATIONS Debug
+)
+
+set(test_target TestTaskGraphScheduler)
+add_executable(${test_target} "TaskGraphSchedulerTest.cpp")
+target_link_libraries(${test_target}
+    PRIVATE Moer::Core
+)
+set_target_properties(${test_target} PROPERTIES FOLDER ${moer_test_folder})
+add_test(NAME TaskGraphSchedulerContract COMMAND $<TARGET_FILE:${test_target}>)
+set_tests_properties(TaskGraphSchedulerContract PROPERTIES TIMEOUT 60)
 
 add_executable(MeshProcessTest "MeshProcessTest.cpp")
 target_link_libraries(MeshProcessTest

--- a/source/test/RenderGraphAsyncSetupTest.cpp
+++ b/source/test/RenderGraphAsyncSetupTest.cpp
@@ -451,8 +451,7 @@ int RunNormalWorkerStarvationChild() {
     Moer::TaskSystem::Init();
     TaskGraph& task_graph = TaskGraph::GetInterface();
     const uint32_t normal_worker_count =
-        (task_graph.GetWorkerThreadCount() + EThread::PriorityCount - 1) /
-        EThread::PriorityCount;
+        task_graph.GetWorkerThreadCount(EThread::AnyThread_NormalPri);
     if (normal_worker_count == 0) {
         Moer::TaskSystem::ShutDown();
         std::cerr << "normal worker starvation child: no Normal workers\n";

--- a/source/test/TaskGraphSchedulerTest.cpp
+++ b/source/test/TaskGraphSchedulerTest.cpp
@@ -1,0 +1,731 @@
+#include "taskgraph/TaskGraph.h"
+#include "taskgraph/TaskSystem.h"
+#include "taskgraph/WorkStealing.h"
+
+#include <algorithm>
+#include <atomic>
+#include <array>
+#include <barrier>
+#include <chrono>
+#include <cerrno>
+#include <cstdint>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <functional>
+#include <iostream>
+#include <memory>
+#include <mutex>
+#include <set>
+#include <string>
+#include <string_view>
+#include <thread>
+#include <vector>
+
+#if PLATFORM_WINDOWS
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+// clang-format off
+#include <Windows.h>
+// clang-format on
+#else
+#include <signal.h>
+#include <sys/wait.h>
+#include <unistd.h>
+#endif
+
+namespace {
+
+using Moer::TaskGraphDetail::BuildWorkerPoolTopology;
+using Moer::TaskGraphDetail::ChaseLevDeque;
+using namespace std::chrono_literals;
+
+struct TestSuite {
+    void Check(bool condition, const char* test, const char* detail) {
+        if (condition) {
+            return;
+        }
+        failed = true;
+        std::cerr << "[FAIL] " << test << ": " << detail << '\n';
+    }
+
+    void Skip(const char* test, const char* detail) {
+        ++skipped;
+        std::cout << "[SKIP] " << test << ": " << detail << '\n';
+    }
+
+    bool     failed  = false;
+    uint32_t skipped = 0;
+};
+
+struct Item {
+    uint32_t id = 0;
+};
+
+struct ChildProcessResult {
+    bool launched         = false;
+    bool completed        = false;
+    bool expected_failure = false;
+    int  exit_code        = 0;
+};
+
+constexpr std::string_view NamedTargetDrainMarker = "named-target-publication-reached\n";
+
+int RunNamedTargetDuringDrainChild(const std::filesystem::path& marker_path) {
+    Moer::TaskSystem::Init();
+    TaskGraph& graph = TaskGraph::GetInterface();
+
+    std::atomic_bool owner_started{false};
+    GraphEventRef owner = LambdaTask::Dispatch(
+        [&] {
+            owner_started.store(true, std::memory_order_release);
+            while (!graph.IsDraining()) {
+                std::this_thread::yield();
+            }
+            // Allocate and construct every task/event resource before the
+            // marker. Dispatch below then crosses only the admission boundary,
+            // so an allocation/setup failure cannot satisfy the death test.
+            auto late_named_task = LambdaTask::Create([] {}, EThread::EMainThread);
+            static_cast<void>(late_named_task.GetCompletionEvent());
+            {
+                std::ofstream marker(marker_path, std::ios::binary | std::ios::trunc);
+                marker.write(NamedTargetDrainMarker.data(), NamedTargetDrainMarker.size());
+                marker.flush();
+                if (!marker) {
+                    std::_Exit(EXIT_FAILURE);
+                }
+            }
+            static_cast<void>(late_named_task.Dispatch());
+        },
+        EThread::AnyThread_HighPri
+    );
+
+    const auto deadline = std::chrono::steady_clock::now() + 5s;
+    while (!owner_started.load(std::memory_order_acquire) &&
+           std::chrono::steady_clock::now() < deadline) {
+        std::this_thread::yield();
+    }
+    if (!owner_started.load(std::memory_order_acquire)) {
+        return EXIT_FAILURE;
+    }
+
+    std::jthread shutdown_thread([] { Moer::TaskSystem::ShutDown(); });
+    shutdown_thread.join();
+    return EXIT_SUCCESS;
+}
+
+ChildProcessResult RunNamedTargetDuringDrainProcess(
+    const std::filesystem::path& executable,
+    const std::filesystem::path& marker_path
+) {
+#if PLATFORM_WINDOWS
+    std::wstring command = L"\"" + executable.wstring() +
+                           L"\" --named-target-drain-child \"" + marker_path.wstring() + L"\"";
+    std::vector<wchar_t> mutable_command(command.begin(), command.end());
+    mutable_command.push_back(L'\0');
+
+    STARTUPINFOW        startup{};
+    PROCESS_INFORMATION process{};
+    startup.cb = sizeof(startup);
+    if (::CreateProcessW(
+            nullptr,
+            mutable_command.data(),
+            nullptr,
+            nullptr,
+            FALSE,
+            CREATE_NO_WINDOW,
+            nullptr,
+            nullptr,
+            &startup,
+            &process
+        ) == FALSE) {
+        return {};
+    }
+
+    const DWORD wait_result = ::WaitForSingleObject(process.hProcess, 15000);
+    if (wait_result != WAIT_OBJECT_0) {
+        static_cast<void>(::TerminateProcess(process.hProcess, 0xEE));
+        static_cast<void>(::WaitForSingleObject(process.hProcess, 2000));
+        ::CloseHandle(process.hThread);
+        ::CloseHandle(process.hProcess);
+        return {
+            .launched = true, .completed = false, .expected_failure = false, .exit_code = 0
+        };
+    }
+
+    DWORD      exit_code     = 0;
+    const BOOL got_exit_code = ::GetExitCodeProcess(process.hProcess, &exit_code);
+    ::CloseHandle(process.hThread);
+    ::CloseHandle(process.hProcess);
+    constexpr DWORD expected_fail_fast_exit_code = 0xC0000602u;
+    return {
+        .launched         = true,
+        .completed        = got_exit_code != FALSE,
+        .expected_failure = got_exit_code != FALSE &&
+                            exit_code == expected_fail_fast_exit_code,
+        .exit_code        = static_cast<int>(exit_code)
+    };
+#else
+    const std::string executable_string = executable.string();
+    const std::string marker_string     = marker_path.string();
+    const pid_t       child             = ::fork();
+    if (child < 0) {
+        return {};
+    }
+    if (child == 0) {
+        ::execl(
+            executable_string.c_str(),
+            executable_string.c_str(),
+            "--named-target-drain-child",
+            marker_string.c_str(),
+            static_cast<char*>(nullptr)
+        );
+        ::_exit(127);
+    }
+
+    int        status   = 0;
+    const auto deadline = std::chrono::steady_clock::now() + 15s;
+    for (;;) {
+        const pid_t wait_result = ::waitpid(child, &status, WNOHANG);
+        if (wait_result == child) {
+            const bool exited   = WIFEXITED(status);
+            const bool signaled = WIFSIGNALED(status);
+            return {
+                .launched         = true,
+                .completed        = exited || signaled,
+                .expected_failure = signaled && WTERMSIG(status) == SIGABRT,
+                .exit_code        = exited ? WEXITSTATUS(status) :
+                                            (signaled ? -WTERMSIG(status) : 0)
+            };
+        }
+        if (wait_result < 0 && errno != EINTR) {
+            return {.launched = true};
+        }
+        if (std::chrono::steady_clock::now() >= deadline) {
+            static_cast<void>(::kill(child, SIGKILL));
+            while (::waitpid(child, &status, 0) < 0 && errno == EINTR) {
+            }
+            return {.launched = true, .completed = false};
+        }
+        std::this_thread::sleep_for(10ms);
+    }
+#endif
+}
+
+class RegisteredExternalRunnable final : public Runnable {
+public:
+    uint32_t Run() override {
+        while (!start.load(std::memory_order_acquire)) {
+            std::this_thread::yield();
+        }
+        const EThread::Type identity = TaskGraph::GetInterface().GetCurrentThread();
+        observed_external.store(EThread::IsUnKnownThread(identity), std::memory_order_release);
+
+        GraphEventRef event = LambdaTask::Dispatch([this] {
+            dispatched_task_ran.store(true, std::memory_order_release);
+        });
+        TaskGraph::GetInterface().WaitUntilTaskComplete(event, identity);
+        return 0;
+    }
+
+    void Init() override {}
+    void Stop() override {}
+    void Exit() override {}
+    ThreadIndex GetIndex() override {
+        return EThread::UNKNOWN_THREAD;
+    }
+
+    std::atomic_bool start{false};
+    std::atomic_bool observed_external{false};
+    std::atomic_bool dispatched_task_ran{false};
+};
+
+void TestWorkerPoolTopology(TestSuite& suite) {
+    struct Case {
+        int32_t workers;
+        std::array<int32_t, EThread::PriorityCount> expected;
+    };
+    constexpr Case cases[] = {
+        {3, {1, 1, 1}},
+        {4, {2, 1, 1}},
+        {5, {2, 2, 1}},
+        {6, {2, 2, 2}},
+        {31, {11, 10, 10}},
+        {253, {85, 84, 84}},
+    };
+
+    for (const Case& test_case : cases) {
+        const auto topology = BuildWorkerPoolTopology(EThread::NamedThreadCount, test_case.workers);
+        suite.Check(
+            topology.counts == test_case.expected,
+            "worker topology",
+            "priority distribution is not balanced"
+        );
+
+        int32_t visited = 0;
+        for (int32_t priority = 0; priority < EThread::PriorityCount; ++priority) {
+            suite.Check(
+                topology.counts[priority] > 0,
+                "worker topology",
+                "a priority pool has no worker"
+            );
+            for (int32_t local = 0; local < topology.counts[priority]; ++local) {
+                const int32_t thread = topology.ThreadIndex(priority, local);
+                suite.Check(
+                    topology.PriorityForThread(thread) == priority &&
+                        topology.LocalIndex(thread, priority) == local,
+                    "worker topology",
+                    "global/local worker mapping is not reversible"
+                );
+                ++visited;
+            }
+        }
+        suite.Check(
+            visited == test_case.workers,
+            "worker topology",
+            "topology did not cover every worker exactly once"
+        );
+        suite.Check(
+            topology.ThreadIndex(
+                EThread::PriorityCount - 1,
+                topology.counts[EThread::PriorityCount - 1] - 1
+            ) < EThread::UNKNOWN_THREAD,
+            "worker topology",
+            "a valid worker aliases the reserved UNKNOWN_THREAD index"
+        );
+    }
+}
+
+void TestDequeOrderAndGrowth(TestSuite& suite) {
+    ChaseLevDeque<Item> deque(2);
+    std::vector<Item>   items(4096);
+    for (uint32_t index = 0; index < items.size(); ++index) {
+        items[index].id = index;
+        deque.PushBottom(&items[index]);
+    }
+
+    suite.Check(
+        deque.ApproximateSize() == static_cast<int64_t>(items.size()),
+        "deque growth",
+        "grown deque reported the wrong size"
+    );
+    for (uint32_t offset = 0; offset < items.size(); ++offset) {
+        Item* item = deque.PopBottom();
+        suite.Check(item != nullptr, "owner LIFO", "owner lost an item after growth");
+        if (item != nullptr) {
+            suite.Check(
+                item->id == items.size() - offset - 1,
+                "owner LIFO",
+                "owner order changed across a buffer generation"
+            );
+        }
+    }
+    suite.Check(deque.PopBottom() == nullptr, "owner LIFO", "empty deque returned an item");
+
+    for (uint32_t index = 0; index < 64; ++index) {
+        deque.PushBottom(&items[index]);
+    }
+    for (uint32_t index = 0; index < 64; ++index) {
+        Item* item = deque.StealTop();
+        suite.Check(item != nullptr, "thief FIFO", "thief lost an item");
+        if (item != nullptr) {
+            suite.Check(item->id == index, "thief FIFO", "thief order is not FIFO from top");
+        }
+    }
+    suite.Check(deque.StealTop() == nullptr, "thief FIFO", "empty deque was stealable");
+}
+
+void TestLastItemRace(TestSuite& suite) {
+    constexpr uint32_t rounds = 20000;
+    ChaseLevDeque<Item> deque(2);
+    std::vector<Item>   items(rounds);
+    std::vector<Item*>  stolen(rounds, nullptr);
+    std::barrier        start(2);
+    std::barrier        finish(2);
+
+    std::jthread thief([&] {
+        for (uint32_t round = 0; round < rounds; ++round) {
+            start.arrive_and_wait();
+            stolen[round] = deque.StealTop();
+            finish.arrive_and_wait();
+        }
+    });
+
+    for (uint32_t round = 0; round < rounds; ++round) {
+        items[round].id = round;
+        deque.PushBottom(&items[round]);
+        start.arrive_and_wait();
+        Item* popped = deque.PopBottom();
+        finish.arrive_and_wait();
+
+        const uint32_t winners = static_cast<uint32_t>(popped != nullptr) +
+                                 static_cast<uint32_t>(stolen[round] != nullptr);
+        suite.Check(
+            winners == 1,
+            "last-item race",
+            "owner and thief did not produce exactly one winner"
+        );
+        Item* winner = popped != nullptr ? popped : stolen[round];
+        suite.Check(
+            winner == &items[round],
+            "last-item race",
+            "the winner observed a stale slot"
+        );
+    }
+}
+
+void TestConcurrentExactlyOnce(TestSuite& suite) {
+    constexpr uint32_t item_count   = 50000;
+    constexpr uint32_t thief_count  = 6;
+    ChaseLevDeque<Item> deque(2);
+    std::vector<Item>   items(item_count);
+    auto seen = std::make_unique<std::atomic<uint32_t>[]>(item_count);
+    for (uint32_t index = 0; index < item_count; ++index) {
+        items[index].id = index;
+        seen[index].store(0, std::memory_order_relaxed);
+    }
+
+    std::atomic<uint32_t> consumed{0};
+    std::atomic_bool      start{false};
+    std::atomic_bool      stop{false};
+    std::atomic_bool      invalid{false};
+
+    auto record = [&](Item* item) {
+        if (item == nullptr) {
+            return;
+        }
+        const uintptr_t address = reinterpret_cast<uintptr_t>(item);
+        const uintptr_t begin   = reinterpret_cast<uintptr_t>(items.data());
+        const uintptr_t end     = begin + items.size() * sizeof(Item);
+        if (address < begin || address >= end || (address - begin) % sizeof(Item) != 0) {
+            invalid.store(true, std::memory_order_relaxed);
+            return;
+        }
+        if (seen[item->id].fetch_add(1, std::memory_order_relaxed) != 0) {
+            invalid.store(true, std::memory_order_relaxed);
+        }
+        consumed.fetch_add(1, std::memory_order_release);
+    };
+
+    std::vector<std::jthread> thieves;
+    thieves.reserve(thief_count);
+    for (uint32_t thief_index = 0; thief_index < thief_count; ++thief_index) {
+        thieves.emplace_back([&] {
+            while (!start.load(std::memory_order_acquire)) {
+                std::this_thread::yield();
+            }
+            while (!stop.load(std::memory_order_acquire)) {
+                if (Item* item = deque.StealTop()) {
+                    record(item);
+                } else {
+                    std::this_thread::yield();
+                }
+            }
+        });
+    }
+
+    start.store(true, std::memory_order_release);
+    for (uint32_t index = 0; index < item_count; ++index) {
+        deque.PushBottom(&items[index]);
+        if ((index & 7u) == 7u) {
+            record(deque.PopBottom());
+        }
+    }
+
+    const auto deadline = std::chrono::steady_clock::now() + 10s;
+    while (consumed.load(std::memory_order_acquire) < item_count &&
+           std::chrono::steady_clock::now() < deadline) {
+        if (Item* item = deque.PopBottom()) {
+            record(item);
+        } else {
+            std::this_thread::yield();
+        }
+    }
+    stop.store(true, std::memory_order_release);
+    thieves.clear();
+
+    suite.Check(
+        consumed.load(std::memory_order_acquire) == item_count,
+        "concurrent deque",
+        "items were lost or the deque stopped making progress"
+    );
+    suite.Check(
+        !invalid.load(std::memory_order_relaxed),
+        "concurrent deque",
+        "an item was duplicated or a stale pointer was observed"
+    );
+    for (uint32_t index = 0; index < item_count; ++index) {
+        if (seen[index].load(std::memory_order_relaxed) != 1) {
+            suite.Check(false, "concurrent deque", "an item was not consumed exactly once");
+            break;
+        }
+    }
+}
+
+void TestNamedTargetDrainRejection(
+    TestSuite&                   suite,
+    const std::filesystem::path& executable
+) {
+    const auto nonce = std::to_string(
+                           std::chrono::steady_clock::now().time_since_epoch().count()
+                       ) +
+#if PLATFORM_WINDOWS
+                       "_" + std::to_string(::GetCurrentProcessId());
+#else
+                       "_" + std::to_string(::getpid());
+#endif
+    const std::filesystem::path marker_path =
+        std::filesystem::temp_directory_path() / ("moer_named_target_drain_" + nonce + ".marker");
+    std::error_code filesystem_error;
+    std::filesystem::remove(marker_path, filesystem_error);
+
+    const ChildProcessResult result =
+        RunNamedTargetDuringDrainProcess(executable, marker_path);
+
+    std::ifstream marker(marker_path, std::ios::binary);
+    const std::string marker_contents(
+        (std::istreambuf_iterator<char>(marker)),
+        std::istreambuf_iterator<char>()
+    );
+    marker.close();
+    std::filesystem::remove(marker_path, filesystem_error);
+
+    suite.Check(
+        result.launched && result.completed && result.expected_failure &&
+            marker_contents == NamedTargetDrainMarker,
+        "named-target drain admission",
+        "child did not reach the late named-target publication and fail fast within the deadline"
+    );
+}
+
+void TestTaskGraphIntegration(TestSuite& suite) {
+    Moer::TaskSystem::Init();
+    TaskGraph& graph = TaskGraph::GetInterface();
+
+    std::atomic<uint32_t> wrong_priority{0};
+    GraphEventArray       priority_events;
+    constexpr EThread::Type priorities[] = {
+        EThread::AnyThread_HighPri,
+        EThread::AnyThread_NormalPri,
+        EThread::AnyThread_LowPri,
+    };
+    for (EThread::Type expected : priorities) {
+        for (uint32_t task_index = 0; task_index < 64; ++task_index) {
+            priority_events.emplace_back(LambdaTask::Dispatch(
+                [&, expected](EThread::Type current, const GraphEventRef&) {
+                    if (EThread::GetThreadPriority(current) !=
+                        EThread::GetThreadPriority(expected)) {
+                        wrong_priority.fetch_add(1, std::memory_order_relaxed);
+                    }
+                },
+                expected
+            ));
+        }
+    }
+    graph.WaitUntilTasksComplete(priority_events, EThread::EMainThread);
+    suite.Check(
+        wrong_priority.load(std::memory_order_relaxed) == 0,
+        "priority isolation",
+        "a task crossed a strict priority-pool boundary"
+    );
+
+    std::atomic<uint32_t> burst_count{0};
+    for (uint32_t round = 0; round < 100; ++round) {
+        GraphEventArray burst;
+        for (uint32_t task_index = 0; task_index < 8; ++task_index) {
+            burst.emplace_back(LambdaTask::Dispatch([&] {
+                burst_count.fetch_add(1, std::memory_order_relaxed);
+            }));
+        }
+        graph.WaitUntilTasksComplete(burst, EThread::EMainThread);
+        std::this_thread::sleep_for(1ms);
+    }
+    suite.Check(
+        burst_count.load(std::memory_order_relaxed) == 800,
+        "park/wake bursts",
+        "a publish/register/wait race stranded work"
+    );
+
+    RegisteredExternalRunnable external;
+    RunnableThread* external_thread = RunnableThread::Create(
+        &external,
+        ThreadAttributes{.affinity = Affinity::All(), .name = "TaskGraphExternalOwnerTest"}
+    );
+    external.start.store(true, std::memory_order_release);
+    external_thread->WaitUntilFinished();
+    suite.Check(
+        external.observed_external.load(std::memory_order_acquire) &&
+            external.dispatched_task_ran.load(std::memory_order_acquire),
+        "scheduler owner identity",
+        "a registered external Runnable was treated as a deque owner or could not dispatch"
+    );
+    MoerDelete(external_thread);
+
+    EThread::Type steal_priority = EThread::AnyThread_HighPri;
+    uint32_t      steal_workers  = 0;
+    for (EThread::Type priority : priorities) {
+        const uint32_t workers = graph.GetWorkerThreadCount(priority);
+        if (workers > steal_workers) {
+            steal_workers  = workers;
+            steal_priority = priority;
+        }
+    }
+
+    auto run_local_steal_case = [&](uint32_t child_count, const char* test_name) {
+        GraphEventRef  release     = GraphEvent::CreateGraphEvent();
+        GraphEventArray children;
+        children.reserve(child_count);
+        std::atomic<uint32_t> completed{0};
+        std::atomic<int32_t>  owner_thread{-1};
+        std::atomic_bool      owner_timed_out{false};
+        std::mutex            child_threads_mutex;
+        std::set<int32_t>     child_threads;
+
+        for (uint32_t child = 0; child < child_count; ++child) {
+            std::function<void()> function = [&] {
+                const int32_t current = EThread::GetThreadIndex(graph.GetCurrentThread());
+                {
+                    std::lock_guard lock(child_threads_mutex);
+                    child_threads.insert(current);
+                }
+                completed.fetch_add(1, std::memory_order_release);
+            };
+            children.emplace_back(
+                LambdaTask::Create(std::move(function), steal_priority)
+                    .Wait(release)
+                    .Dispatch()
+            );
+        }
+
+        GraphEventRef owner = LambdaTask::Dispatch(
+            [&, release](EThread::Type current, const GraphEventRef&) {
+                owner_thread.store(EThread::GetThreadIndex(current), std::memory_order_release);
+                release->TryUnlockSubsequents(current);
+
+                const auto deadline = std::chrono::steady_clock::now() + 5s;
+                while (completed.load(std::memory_order_acquire) < child_count &&
+                       std::chrono::steady_clock::now() < deadline) {
+                    std::this_thread::yield();
+                }
+                if (completed.load(std::memory_order_acquire) != child_count) {
+                    owner_timed_out.store(true, std::memory_order_release);
+                }
+            },
+            steal_priority
+        );
+
+        graph.WaitUntilTaskComplete(owner, EThread::EMainThread);
+        graph.WaitUntilTasksComplete(children, EThread::EMainThread);
+        const int32_t owner_index = owner_thread.load(std::memory_order_acquire);
+        bool          ran_on_peer = false;
+        {
+            std::lock_guard lock(child_threads_mutex);
+            ran_on_peer = !child_threads.empty() && !child_threads.contains(owner_index);
+        }
+        suite.Check(
+            !owner_timed_out.load(std::memory_order_acquire) && ran_on_peer,
+            test_name,
+            "idle peers did not steal while the deque owner was blocked"
+        );
+    };
+
+    if (steal_workers > 1) {
+        run_local_steal_case(1, "single local continuation stealing");
+        run_local_steal_case(std::max<uint32_t>(64, steal_workers * 4), "local fan-out stealing");
+    } else {
+        suite.Skip(
+            "TaskGraph local stealing integration",
+            "runtime topology has only one worker per priority; deque stealing is covered synthetically"
+        );
+    }
+
+    // Shutdown must keep every pool alive while an already-running task can
+    // still publish a continuation into a different priority pool.
+    std::atomic_bool shutdown_task_started{false};
+    std::atomic_bool release_shutdown_task{false};
+    std::atomic_bool cross_priority_child_ran{false};
+    GraphEventRef shutdown_owner = LambdaTask::Dispatch(
+        [&] {
+            shutdown_task_started.store(true, std::memory_order_release);
+            while (!release_shutdown_task.load(std::memory_order_acquire)) {
+                std::this_thread::yield();
+            }
+            LambdaTask::Dispatch(
+                [&] { cross_priority_child_ran.store(true, std::memory_order_release); },
+                EThread::AnyThread_LowPri
+            );
+        },
+        EThread::AnyThread_HighPri
+    );
+    const auto shutdown_start_deadline = std::chrono::steady_clock::now() + 5s;
+    while (!shutdown_task_started.load(std::memory_order_acquire) &&
+           std::chrono::steady_clock::now() < shutdown_start_deadline) {
+        std::this_thread::yield();
+    }
+    suite.Check(
+        shutdown_task_started.load(std::memory_order_acquire),
+        "shutdown drain",
+        "owner task did not start before the shutdown regression"
+    );
+
+    std::jthread shutdown_thread([] { Moer::TaskSystem::ShutDown(); });
+    const auto drain_deadline = std::chrono::steady_clock::now() + 5s;
+    while ((!graph.IsDraining() || !graph.IsWaitingForIdle()) &&
+           std::chrono::steady_clock::now() < drain_deadline) {
+        std::this_thread::yield();
+    }
+    const bool drain_observed = graph.IsDraining() && graph.IsWaitingForIdle();
+    suite.Check(
+        drain_observed,
+        "shutdown drain",
+        "shutdown did not enter WaitUntilIdle behind the publication drain gate"
+    );
+    release_shutdown_task.store(true, std::memory_order_release);
+    shutdown_thread.join();
+    suite.Check(
+        cross_priority_child_ran.load(std::memory_order_acquire),
+        "shutdown drain",
+        "shutdown closed a target pool before a cross-priority child completed"
+    );
+
+    // Reinitialization verifies worker Event, deque-buffer and scheduler
+    // lifetimes end only after all worker threads have joined.
+    Moer::TaskSystem::Init();
+    std::atomic_bool rerun{false};
+    GraphEventRef second_lifetime = LambdaTask::Dispatch([&] {
+        rerun.store(true, std::memory_order_release);
+    });
+    TaskGraph::GetInterface().WaitUntilTaskComplete(second_lifetime, EThread::EMainThread);
+    suite.Check(
+        rerun.load(std::memory_order_acquire),
+        "scheduler lifetime",
+        "task did not run after TaskGraph reinitialization"
+    );
+    Moer::TaskSystem::ShutDown();
+}
+
+} // namespace
+
+int main(int argc, char** argv) {
+    if (argc == 3 && std::string_view(argv[1]) == "--named-target-drain-child") {
+        return RunNamedTargetDuringDrainChild(argv[2]);
+    }
+
+    TestSuite suite;
+    TestWorkerPoolTopology(suite);
+    TestDequeOrderAndGrowth(suite);
+    TestLastItemRace(suite);
+    TestConcurrentExactlyOnce(suite);
+    TestTaskGraphIntegration(suite);
+    TestNamedTargetDrainRejection(suite, std::filesystem::absolute(argv[0]));
+
+    if (suite.failed) {
+        return EXIT_FAILURE;
+    }
+    std::cout << "TaskGraph scheduler contract passed (skipped=" << suite.skipped << ")\n";
+    return EXIT_SUCCESS;
+}

--- a/source/test/TaskGraphTest.cpp
+++ b/source/test/TaskGraphTest.cpp
@@ -190,5 +190,6 @@ int main() {
     TaskGraph::GetInterface().WaitUntilTaskComplete(finished, EThread::EMainThread);
     assert(k == 1200);
 
+    Moer::TaskSystem::ShutDown();
     return 0;
 }


### PR DESCRIPTION
## Summary
- replace AnyThread shared FIFO scheduling with per-worker Chase-Lev deques plus per-priority MPMC ingress
- add exact balanced priority-pool topology, trusted worker TLS ownership, idle-aware wakeups, global fairness probes, and bounded shutdown drain
- harden TaskGraph/RunnableThread construction, join, Event, named-queue, and reinitialization lifetimes
- add scheduler contract, stress, shutdown, death-test, and legacy TaskGraph/TaskPipe CTest coverage

## Relationship to dev_parallel_rhi
This is a semantic port of its Chase-Lev direction, adapted to current main. It deliberately tightens the old branch's blind round-robin wakeup, local-enqueue-without-wake, approximate worker indexing, caller-supplied ownership, and incomplete shutdown behavior.

## Shutdown contract
External/named producers must be quiescent and named owners must be stopped and externally joined before TaskSystem shutdown. Already-running AnyThread tasks may still publish AnyThread continuations; all priority pools drain before worker close. Late external Any or named-target publication fails fast.

## Validation
- Visual Studio 2022 Debug full build
- Debug CTest: 51/51
- Release TaskGraphSchedulerContract
- scheduler stress: 50/50, then 10/10 after final lifetime/death-test fixes
- Vulkan + Raytracing + Sponza: first present, >60 s responsive runtime, graceful close, empty stderr, Vulkan device destroyed
- two independent local P0-P2 review loops: clean
- git diff --check

`just`/Ninja/Clang are unavailable on this host, so the configured VS 2022/MSVC fallback was used.