### PR TITLE
ci: fix Vulkan GPU gate runner path initialization

### DIFF
--- a/.github/workflows/vulkan-gpu-gate.yml
+++ b/.github/workflows/vulkan-gpu-gate.yml
@@ -96,8 +96,6 @@ jobs:
       group: moerengine-gpu-valerie
       queue: max
     env:
-      BUILD_DIR: ${{ runner.temp }}\moerengine-gpu-${{ github.run_id }}-${{ github.run_attempt }}\build
-      OUTPUT_DIR: ${{ runner.temp }}\moerengine-gpu-${{ github.run_id }}-${{ github.run_attempt }}\output
       EVIDENCE_DIR: ${{ github.workspace }}\target\validation\gpu-ci\${{ github.run_id }}-${{ github.run_attempt }}
       MOER_GATE_SHA: ${{ needs.trust_policy.outputs.target_sha }}
       MOER_GATE_PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -112,6 +110,21 @@ jobs:
           fetch-depth: 1
           persist-credentials: false
           submodules: recursive
+
+      - name: Initialize runner-local paths
+        shell: powershell
+        run: |
+          $ErrorActionPreference = "Stop"
+          if ([string]::IsNullOrWhiteSpace($env:RUNNER_TEMP)) {
+            throw "RUNNER_TEMP is unavailable"
+          }
+          $runRoot = Join-Path $env:RUNNER_TEMP (
+            "moerengine-gpu-{0}-{1}" -f $env:GITHUB_RUN_ID, $env:GITHUB_RUN_ATTEMPT
+          )
+          "BUILD_DIR=$(Join-Path $runRoot 'build')" |
+            Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          "OUTPUT_DIR=$(Join-Path $runRoot 'output')" |
+            Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
       - name: Parser contract tests
         timeout-minutes: 5


### PR DESCRIPTION
## Summary
- move GPU build/output path initialization out of job-level `env`, where the `runner` context is unavailable
- derive the same per-run paths from `RUNNER_TEMP` inside a Windows PowerShell step
- preserve evidence paths, trust boundaries, and all downstream environment-variable contracts

## Root cause
The first post-merge dispatch of Phase 27 was rejected by GitHub before creating a run: `runner.temp` is not an allowed expression context in `jobs.gpu_validation.env`.

## Validation
- GitHub service accepted branch dispatch run https://github.com/NJUCG/MoerEngine/actions/runs/30695539710 for exact head `e78934c51ab718667c0dcf17ea0b80db84e4301a`
- branch dispatch then failed closed as designed with `manual_dispatch_requires_main`; GPU job was skipped
- Python runner contracts: 164/164 PASS
- PowerShell 5.1 AST and spaced-path probe: PASS
- YAML parse and `git diff --check`: PASS
- independent P0-P2 review: clean

After merge, the workflow will be dispatched on `main` for the real protected-environment GPU qualification.