### PR TITLE
docs: document Visual Studio CMake workflow

### DIFF
--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -63,6 +63,8 @@
   5. Configure 成功后，在 Startup Item 下拉框选择 `MoerEditor.exe`。选择 `Build -> Build All`，或在 Solution Explorer 的 CMake Targets View 中右键 `MoerEditor` 后选择 Build。
   6. 按 `F5` 构建并调试；若不附加调试器，按 `Ctrl+F5`，或选择 `Debug -> Start Without Debugging`。
 
+  构建会通过 `CopyResources` 依赖把仓库根目录的 `MoerEngine.toml` 和运行资源复制到对应的 `target/bin/<Config>` 目录；修改根配置后重新构建即可同步。
+
   Debug 产物位于 `target/bin/Debug/MoerEditor.exe`。Release 构建时在 Configuration 下拉框切换到 `x64-Release`，产物位于 `target/bin/Release/MoerEditor.exe`。
 
   Rider 2026.1 开始提供 CMake C++ 工程的 Beta 支持，但当前版本尚未提供与 CLion 完全一致的 CMake toolchain/profile 配置界面，因此本文不把未经验证的 Rider 菜单路径作为受支持构建方法。参见 [JetBrains Rider 2026.1 CMake support](https://www.jetbrains.com/rider/whatsnew/2026-1/#cmake-support-for-c-gaming-projects-beta)。

--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -52,24 +52,20 @@
   
   - 如果安装了 [just](https://github.com/casey/just)，你可以参考根目录下的 `template.justfile` 文件来编写你自己的脚本
   
-- 方法二：Rider（GUI）
+- 方法二：Visual Studio 2022（GUI）
 
-  > Rider 从 2026.1 开始提供 CMake C++ 工程支持，目前仍标记为 Beta。请使用 Rider 2026.1 或更高版本；旧版本无法直接完成这一流程。参见 [JetBrains Rider 2026.1 CMake support](https://www.jetbrains.com/rider/whatsnew/2026-1/#cmake-support-for-c-gaming-projects-beta)。
+  Visual Studio 2022 可以直接打开根目录包含 `CMakeLists.txt` 的工程，不需要生成 `.sln`。参见 [Microsoft：Visual Studio 中的 CMake 项目](https://learn.microsoft.com/zh-cn/cpp/build/cmake-projects-in-visual-studio?view=msvc-170)。
 
-  1. 在文件管理器中把 `template.MoerEngine.toml` 复制为仓库根目录下的 `MoerEngine.toml`。首次 CMake Configure 前必须存在该文件。
-  2. 在 Rider 中选择 `File -> Open` 并打开仓库根目录。Rider 会从根 `CMakeLists.txt` 加载工程。
-  3. 打开 `Settings -> Build, Execution, Deployment -> Toolchains`：
-     - 选择 Visual Studio 2022 工具链，以提供 Windows SDK、`rc.exe` 和链接器；
-     - 确认 CMake、Ninja、Clang 与 Clang++ 均能被检测到。
-  4. 打开 `Settings -> Build, Execution, Deployment -> CMake`，创建 Debug Profile：
-     - Generator：`Ninja`；
-     - Build type：`Debug`；
-     - Build directory：仓库根目录下的 `build`；
-     - CMake options：`-DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++`。
-  5. Reload CMake Project，等待 Configure 成功后，在 Rider 顶部工具栏选择 `MoerEditor` target 并执行 Build。
-  6. 打开 `Run -> Edit Configurations`，创建或选择 CMake Application：target 设为 `MoerEditor`，Working directory 设为仓库根目录。随后使用 Run 或 Debug 启动。
+  1. 在 Visual Studio Installer 中安装“使用 C++ 的桌面开发”，并勾选“用于 Windows 的 C++ CMake 工具”。
+  2. 在文件管理器中把 `template.MoerEngine.toml` 复制为仓库根目录下的 `MoerEngine.toml`。首次 Configure 前必须存在该文件。
+  3. 在 Visual Studio 中选择 `File -> Open -> Folder` 并打开仓库根目录。根目录已有 `CMakeLists.txt`，Visual Studio 会自动启用 CMake integration 并生成默认配置的 cache。
+  4. 在顶部 Configuration 下拉框选择 `x64-Debug`。如果自动 Configure 没有运行，或修改配置后需要重新生成，选择 `Project -> Configure Cache`；错误信息可在 Output 窗口的 CMake 分类中查看。
+  5. Configure 成功后，在 Startup Item 下拉框选择 `MoerEditor.exe`。选择 `Build -> Build All`，或在 Solution Explorer 的 CMake Targets View 中右键 `MoerEditor` 后选择 Build。
+  6. 按 `F5` 构建并调试；若不附加调试器，按 `Ctrl+F5`，或选择 `Debug -> Start Without Debugging`。
 
-  Debug 产物位于 `target/bin/Debug/MoerEditor.exe`。Release 构建应新建独立的 Release Profile，并把 Build type 改为 `Release`；不要只修改运行配置而继续复用 Debug Profile。
+  Debug 产物位于 `target/bin/Debug/MoerEditor.exe`。Release 构建时在 Configuration 下拉框切换到 `x64-Release`，产物位于 `target/bin/Release/MoerEditor.exe`。
+
+  Rider 2026.1 开始提供 CMake C++ 工程的 Beta 支持，但当前版本尚未提供与 CLion 完全一致的 CMake toolchain/profile 配置界面，因此本文不把未经验证的 Rider 菜单路径作为受支持构建方法。参见 [JetBrains Rider 2026.1 CMake support](https://www.jetbrains.com/rider/whatsnew/2026-1/#cmake-support-for-c-gaming-projects-beta)。
 
 - 成功启动后，可以参考 [DEVELOPMENT.md](DEVELOPMENT.md) 来了解MoerEngine的开发规范等其他内容
 

--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -52,9 +52,24 @@
   
   - 如果安装了 [just](https://github.com/casey/just)，你可以参考根目录下的 `template.justfile` 文件来编写你自己的脚本
   
-- 方法二：Rider
-  
-  - TODO
+- 方法二：Rider（GUI）
+
+  > Rider 从 2026.1 开始提供 CMake C++ 工程支持，目前仍标记为 Beta。请使用 Rider 2026.1 或更高版本；旧版本无法直接完成这一流程。参见 [JetBrains Rider 2026.1 CMake support](https://www.jetbrains.com/rider/whatsnew/2026-1/#cmake-support-for-c-gaming-projects-beta)。
+
+  1. 在文件管理器中把 `template.MoerEngine.toml` 复制为仓库根目录下的 `MoerEngine.toml`。首次 CMake Configure 前必须存在该文件。
+  2. 在 Rider 中选择 `File -> Open` 并打开仓库根目录。Rider 会从根 `CMakeLists.txt` 加载工程。
+  3. 打开 `Settings -> Build, Execution, Deployment -> Toolchains`：
+     - 选择 Visual Studio 2022 工具链，以提供 Windows SDK、`rc.exe` 和链接器；
+     - 确认 CMake、Ninja、Clang 与 Clang++ 均能被检测到。
+  4. 打开 `Settings -> Build, Execution, Deployment -> CMake`，创建 Debug Profile：
+     - Generator：`Ninja`；
+     - Build type：`Debug`；
+     - Build directory：仓库根目录下的 `build`；
+     - CMake options：`-DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++`。
+  5. Reload CMake Project，等待 Configure 成功后，在 Rider 顶部工具栏选择 `MoerEditor` target 并执行 Build。
+  6. 打开 `Run -> Edit Configurations`，创建或选择 CMake Application：target 设为 `MoerEditor`，Working directory 设为仓库根目录。随后使用 Run 或 Debug 启动。
+
+  Debug 产物位于 `target/bin/Debug/MoerEditor.exe`。Release 构建应新建独立的 Release Profile，并把 Build type 改为 `Release`；不要只修改运行配置而继续复用 Debug Profile。
 
 - 成功启动后，可以参考 [DEVELOPMENT.md](DEVELOPMENT.md) 来了解MoerEngine的开发规范等其他内容
 

--- a/docs/README.en.md
+++ b/docs/README.en.md
@@ -51,22 +51,20 @@ Engine for Realtime Rendering
     just gbr # generate build run
     ```
 
-- Method 2: Rider (GUI)
+- Method 2: Visual Studio 2022 (GUI)
 
-  > Direct CMake C++ project support is available in Rider 2026.1 and newer and is currently marked Beta. Older Rider releases cannot use this workflow. See [CMake support for C++ gaming projects](https://www.jetbrains.com/rider/whatsnew/2026-1/#cmake-support-for-c-gaming-projects-beta).
+  Visual Studio 2022 can open a folder whose root contains `CMakeLists.txt` directly; no generated `.sln` is required. See [CMake projects in Visual Studio](https://learn.microsoft.com/en-us/cpp/build/cmake-projects-in-visual-studio?view=msvc-170).
 
-  1. In File Explorer, copy `template.MoerEngine.toml` to `MoerEngine.toml` in the repository root. This file must exist before the first CMake configure.
-  2. Select `File -> Open` in Rider and open the repository root. Rider loads the project from the root `CMakeLists.txt`.
-  3. Open `Settings -> Build, Execution, Deployment -> Toolchains`. Select the Visual Studio 2022 toolchain to provide the Windows SDK, `rc.exe`, and the linker, then make sure Rider detects CMake, Ninja, Clang, and Clang++.
-  4. Open `Settings -> Build, Execution, Deployment -> CMake` and create a Debug profile with:
-     - Generator: `Ninja`;
-     - Build type: `Debug`;
-     - Build directory: `build` under the repository root;
-     - CMake options: `-DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++`.
-  5. Reload the CMake project. After configuration succeeds, select the `MoerEditor` target in the Rider toolbar and build it.
-  6. Open `Run -> Edit Configurations` and create or select a CMake Application. Set the target to `MoerEditor` and the working directory to the repository root, then choose Run or Debug.
+  1. In Visual Studio Installer, install the **Desktop development with C++** workload and the **C++ CMake tools for Windows** component.
+  2. In File Explorer, copy `template.MoerEngine.toml` to `MoerEngine.toml` in the repository root. This file must exist before the first configure.
+  3. Select `File -> Open -> Folder` in Visual Studio and open the repository root. Because the root contains `CMakeLists.txt`, Visual Studio enables CMake integration and automatically generates the cache for its default configuration.
+  4. Select `x64-Debug` in the Configuration dropdown. If automatic configuration did not run, or a setting changed, select `Project -> Configure Cache`. CMake diagnostics are available in the CMake category of the Output window.
+  5. After configuration succeeds, select `MoerEditor.exe` in the Startup Item dropdown. Choose `Build -> Build All`, or open CMake Targets View in Solution Explorer, right-click `MoerEditor`, and choose Build.
+  6. Press `F5` to build and debug. To run without the debugger, press `Ctrl+F5` or select `Debug -> Start Without Debugging`.
 
-  The Debug executable is written to `target/bin/Debug/MoerEditor.exe`. Create a separate Release CMake profile with Build type `Release`; changing only the run configuration does not reconfigure a Debug build as Release.
+  The Debug executable is written to `target/bin/Debug/MoerEditor.exe`. Select `x64-Release` in the Configuration dropdown for a Release build, which writes `target/bin/Release/MoerEditor.exe`.
+
+  Rider 2026.1 introduced Beta support for CMake C++ projects, but current Rider releases do not yet expose the same CMake toolchain/profile configuration UI as CLion. This guide therefore does not present an unverified Rider menu path as a supported build method. See [Rider 2026.1 CMake support](https://www.jetbrains.com/rider/whatsnew/2026-1/#cmake-support-for-c-gaming-projects-beta).
 
 ### CUDA, LibTorch, and TensorRT
 

--- a/docs/README.en.md
+++ b/docs/README.en.md
@@ -62,6 +62,8 @@ Engine for Realtime Rendering
   5. After configuration succeeds, select `MoerEditor.exe` in the Startup Item dropdown. Choose `Build -> Build All`, or open CMake Targets View in Solution Explorer, right-click `MoerEditor`, and choose Build.
   6. Press `F5` to build and debug. To run without the debugger, press `Ctrl+F5` or select `Debug -> Start Without Debugging`.
 
+  The `CopyResources` build dependency copies the root `MoerEngine.toml` and runtime assets into the matching `target/bin/<Config>` directory. Rebuild after editing the root configuration to refresh that copy.
+
   The Debug executable is written to `target/bin/Debug/MoerEditor.exe`. Select `x64-Release` in the Configuration dropdown for a Release build, which writes `target/bin/Release/MoerEditor.exe`.
 
   Rider 2026.1 introduced Beta support for CMake C++ projects, but current Rider releases do not yet expose the same CMake toolchain/profile configuration UI as CLion. This guide therefore does not present an unverified Rider menu path as a supported build method. See [Rider 2026.1 CMake support](https://www.jetbrains.com/rider/whatsnew/2026-1/#cmake-support-for-c-gaming-projects-beta).

--- a/docs/README.en.md
+++ b/docs/README.en.md
@@ -51,8 +51,22 @@ Engine for Realtime Rendering
     just gbr # generate build run
     ```
 
-- Method 2: Rider
-  - TODO
+- Method 2: Rider (GUI)
+
+  > Direct CMake C++ project support is available in Rider 2026.1 and newer and is currently marked Beta. Older Rider releases cannot use this workflow. See [CMake support for C++ gaming projects](https://www.jetbrains.com/rider/whatsnew/2026-1/#cmake-support-for-c-gaming-projects-beta).
+
+  1. In File Explorer, copy `template.MoerEngine.toml` to `MoerEngine.toml` in the repository root. This file must exist before the first CMake configure.
+  2. Select `File -> Open` in Rider and open the repository root. Rider loads the project from the root `CMakeLists.txt`.
+  3. Open `Settings -> Build, Execution, Deployment -> Toolchains`. Select the Visual Studio 2022 toolchain to provide the Windows SDK, `rc.exe`, and the linker, then make sure Rider detects CMake, Ninja, Clang, and Clang++.
+  4. Open `Settings -> Build, Execution, Deployment -> CMake` and create a Debug profile with:
+     - Generator: `Ninja`;
+     - Build type: `Debug`;
+     - Build directory: `build` under the repository root;
+     - CMake options: `-DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++`.
+  5. Reload the CMake project. After configuration succeeds, select the `MoerEditor` target in the Rider toolbar and build it.
+  6. Open `Run -> Edit Configurations` and create or select a CMake Application. Set the target to `MoerEditor` and the working directory to the repository root, then choose Run or Debug.
+
+  The Debug executable is written to `target/bin/Debug/MoerEditor.exe`. Create a separate Release CMake profile with Build type `Release`; changing only the run configuration does not reconfigure a Debug build as Release.
 
 ### CUDA, LibTorch, and TensorRT
 


### PR DESCRIPTION
## Summary

- replace the unfinished Rider section with a verified Visual Studio 2022 GUI CMake workflow
- document required components, Open Folder/configure/build/run steps, and Debug/Release output paths
- keep the Chinese and English guides aligned, while explicitly treating Rider CMake support as Beta

## Validation

- `git diff --check`
- independent review found no P0/P1/P2 issues
- Visual Studio Community 2022 17.14 with the Desktop C++ and CMake components is installed on the validation machine
- the repository's existing Visual Studio cache identifies `MoerEngine` with generator `Visual Studio 17 2022`
- no engine build was required because this PR changes documentation only

Closes #81