### PR TITLE
feat: add timestamped session file logging

### DIFF
--- a/source/runtime/Engine.cpp
+++ b/source/runtime/Engine.cpp
@@ -4,6 +4,7 @@
 // Runtime
 #include "config/CVarSystem.h"
 #include "config/ConfigManager.h"
+#include "log/LogSystem.h"
 #include "misc/Assert.h"
 #include "misc/ScopedLogTimer.h"
 #include "remote/RemoteConfig.h"
@@ -1191,14 +1192,15 @@ void Engine::Init(
 
     report_startup("Starting engine core", "Initializing logging and configuration");
 
+    std::filesystem::path path = argv[0];
+    path = path.filename().string().find(".exe") != std::string::npos ? path.parent_path() : path;
+    const std::string log_directory = (path / "logs").generic_string();
+
     // Init LogSystem
-    LogSystem::Init(); // for LOG_DEBUG & LOG_TRACE when debug mode
+    static_cast<void>(LogSystem::Init({.directory = log_directory}));
     startup_logging_ready = true;
 
     // Init ConfigManager
-    std::filesystem::path path = argv[0];
-    path = path.filename().string().find(".exe") != std::string::npos ? path.parent_path() : path;
-
     report_startup("Reading configuration", path.string());
     LOG_INFO("Workspace Path : {}", path.string());
 
@@ -2159,6 +2161,7 @@ void Engine::ShutDown() noexcept {
     }
     m_console_control.reset();
     m_editor_config.reset();
+    LogSystem::Flush();
 }
 
 // 检测路径中是否包含非ASCII字符（包括中文）

--- a/source/runtime/core/include/log/LogSystem.h
+++ b/source/runtime/core/include/log/LogSystem.h
@@ -29,6 +29,19 @@ struct ConsoleLogPollResult {
     std::size_t   visited_count = 0;
 };
 
+enum class EFileLogInitStatus : std::uint8_t {
+    Disabled,
+    Active,
+    Failed,
+};
+
+struct FileLogInitOptions {
+    // Both views are borrowed only for Init. An empty directory disables file
+    // logging. An empty file name creates a timestamped per-process name.
+    std::string_view directory;
+    std::string_view file_name;
+};
+
 // Views are borrowed only for the visitor invocation. Init installs a
 // process-lifetime forwarding default logger: the previous logger's sink
 // storage remains untouched in its owning module, and the previous logger is
@@ -46,6 +59,15 @@ struct ConsoleLogPollResult {
 using ConsoleLogVisitor = void (*)(const ConsoleLogEntryView& _entry, void* _context);
 
 CORE_API void Init();
+
+// File output is configured by the first successful default-logger install and
+// remains process-scoped. Repeated calls reuse the same file sink. Failure to
+// create the file degrades to the existing console and in-editor channels.
+[[nodiscard]] CORE_API EFileLogInitStatus Init(const FileLogInitOptions& _options);
+
+// Flushes the process-scoped file sink when present. Safe to call during
+// orderly shutdown after concurrent log producers have stopped.
+CORE_API void Flush() noexcept;
 
 // Sequence zero is normalized to one. Entries removed by bounded overwrite or
 // ClearConsoleLogs are reported through dropped_count. The visitor runs after

--- a/source/runtime/core/source/log/LogSystem.cpp
+++ b/source/runtime/core/source/log/LogSystem.cpp
@@ -1,12 +1,21 @@
 #include "log/LogSystem.h"
 
+#include "spdlog/details/os.h"
+#include "spdlog/sinks/basic_file_sink.h"
 #include "spdlog/sinks/sink.h"
 
 #include <algorithm>
+#include <array>
+#include <chrono>
+#include <cstdio>
+#include <ctime>
 #include <deque>
+#include <filesystem>
 #include <memory>
 #include <mutex>
+#include <stdexcept>
 #include <string>
+#include <system_error>
 #include <vector>
 
 namespace Moer::LogSystem {
@@ -17,6 +26,7 @@ namespace fmt_lib = spdlog::fmt_lib;
 
 constexpr std::size_t ConsoleLogCapacity        = 4096;
 constexpr std::size_t AbiSafeLoggerNameCapacity = 64;
+constexpr std::string_view FileLogPattern = "%Y-%m-%d %H:%M:%S.%e [%t] [%l] %v";
 
 std::string MakeCoreOwnedLoggerName(std::string_view _name) {
     std::string owned_name;
@@ -28,6 +38,93 @@ std::string MakeCoreOwnedLoggerName(std::string_view _name) {
         owned_name.append(_name.data(), _name.size());
     }
     return owned_name;
+}
+
+std::string MakeTimestampedFileName() {
+    const auto now = std::chrono::system_clock::now();
+    const auto milliseconds = std::chrono::duration_cast<std::chrono::milliseconds>(
+                                  now.time_since_epoch()
+                              ) %
+                              std::chrono::seconds(1);
+    const std::time_t time = std::chrono::system_clock::to_time_t(now);
+    const std::tm     local_time = spdlog::details::os::localtime(time);
+
+    std::array<char, 128> file_name{};
+    const int written = std::snprintf(
+        file_name.data(),
+        file_name.size(),
+        "MoerEditor_%04d%02d%02d_%02d%02d%02d_%03lld_p%d.log",
+        local_time.tm_year + 1900,
+        local_time.tm_mon + 1,
+        local_time.tm_mday,
+        local_time.tm_hour,
+        local_time.tm_min,
+        local_time.tm_sec,
+        static_cast<long long>(milliseconds.count()),
+        spdlog::details::os::pid()
+    );
+    if (written <= 0 || static_cast<std::size_t>(written) >= file_name.size()) {
+        throw std::runtime_error("timestamped log file name exceeded its fixed buffer");
+    }
+    return std::string(file_name.data(), static_cast<std::size_t>(written));
+}
+
+struct FileLogSetupResult {
+    EFileLogInitStatus                  status = EFileLogInitStatus::Disabled;
+    std::shared_ptr<spdlog::sinks::sink> sink;
+    std::string                         path;
+    std::string                         error;
+};
+
+FileLogSetupResult CreateFileLogSink(const FileLogInitOptions& _options) {
+    FileLogSetupResult result;
+    if (_options.directory.empty()) {
+        return result;
+    }
+
+    try {
+        const std::filesystem::path directory(std::string(_options.directory));
+        std::error_code             directory_error;
+        std::filesystem::create_directories(directory, directory_error);
+        if (directory_error || !std::filesystem::is_directory(directory, directory_error)) {
+            result.status = EFileLogInitStatus::Failed;
+            result.error  = "could not create log directory '" + directory.generic_string() + "'";
+            if (directory_error) {
+                result.error.append(": ").append(directory_error.message());
+            }
+            return result;
+        }
+
+        const std::filesystem::path requested_file_name = _options.file_name.empty() ?
+                                                                    MakeTimestampedFileName() :
+                                                                    std::string(_options.file_name);
+        const std::filesystem::path file_name = requested_file_name.filename();
+        if (file_name.empty() || file_name == "." || file_name == "..") {
+            result.status = EFileLogInitStatus::Failed;
+            result.error  = "log file name is empty or invalid";
+            return result;
+        }
+
+        const std::filesystem::path log_path = directory / file_name;
+        auto file_sink = std::make_shared<spdlog::sinks::basic_file_sink_mt>(
+            log_path.string(), true
+        );
+        file_sink->set_level(spdlog::level::trace);
+        file_sink->set_pattern(std::string(FileLogPattern));
+
+        result.status = EFileLogInitStatus::Active;
+        result.sink   = std::move(file_sink);
+        result.path   = log_path.generic_string();
+        return result;
+    } catch (const std::exception& error) {
+        result.status = EFileLogInitStatus::Failed;
+        result.error  = error.what();
+        return result;
+    } catch (...) {
+        result.status = EFileLogInitStatus::Failed;
+        result.error  = "unknown file logging initialization failure";
+        return result;
+    }
 }
 
 struct ConsoleLogEntryStorage {
@@ -161,12 +258,14 @@ public:
         std::string                     _name,
         std::shared_ptr<spdlog::logger> _source_logger,
         std::shared_ptr<spdlog::logger> _dispatch_logger,
-        std::shared_ptr<ConsoleLogSink> _console_sink
+        std::shared_ptr<ConsoleLogSink> _console_sink,
+        std::shared_ptr<spdlog::sinks::sink> _file_sink
     ) :
         spdlog::logger(std::move(_name)),
         source_logger(std::move(_source_logger)),
         dispatch_logger(std::move(_dispatch_logger)),
-        console_sink(std::move(_console_sink)) {
+        console_sink(std::move(_console_sink)),
+        file_sink(std::move(_file_sink)) {
         const spdlog::level::level_enum source_level       = source_logger->level();
         const spdlog::level::level_enum source_flush_level = source_logger->flush_level();
         set_level(source_level);
@@ -198,6 +297,16 @@ protected:
         }
         SPDLOG_LOGGER_CATCH(_message.source)
 
+        if (file_sink && file_sink->should_log(_message.level)) {
+            SPDLOG_TRY {
+                file_sink->log(_message);
+                if (_message.level >= spdlog::level::err) {
+                    file_sink->flush();
+                }
+            }
+            SPDLOG_LOGGER_CATCH(_message.source)
+        }
+
         // Keep the normal logger::sinks() extension point functional without
         // placing the downstream sink vector in a different module's heap.
         for (const spdlog::sink_ptr& sink : sinks_) {
@@ -214,6 +323,12 @@ protected:
                 console_sink->flush();
             }
             SPDLOG_LOGGER_CATCH(_message.source)
+            if (file_sink) {
+                SPDLOG_TRY {
+                    file_sink->flush();
+                }
+                SPDLOG_LOGGER_CATCH(_message.source)
+            }
             for (const spdlog::sink_ptr& sink : sinks_) {
                 SPDLOG_TRY {
                     sink->flush();
@@ -233,6 +348,12 @@ protected:
             console_sink->flush();
         }
         SPDLOG_LOGGER_CATCH(spdlog::source_loc())
+        if (file_sink) {
+            SPDLOG_TRY {
+                file_sink->flush();
+            }
+            SPDLOG_LOGGER_CATCH(spdlog::source_loc())
+        }
         for (const spdlog::sink_ptr& sink : sinks_) {
             SPDLOG_TRY {
                 sink->flush();
@@ -243,9 +364,9 @@ protected:
 
 public:
     std::shared_ptr<spdlog::logger> clone(std::string _logger_name) override {
-        // Clones preserve the original logger behavior. The console channel is
-        // intentionally default-logger scoped; make a clone default and call
-        // LogSystem::Init again if it also needs capture.
+        // Clones preserve the original logger behavior. The console and file
+        // channels are intentionally default-logger scoped; make a clone
+        // default and call LogSystem::Init again if it also needs capture.
         SynchronizeConfiguration();
         std::shared_ptr<spdlog::logger> cloned = source_logger->clone(std::move(_logger_name));
         if (cloned) {
@@ -266,12 +387,17 @@ private:
     std::shared_ptr<spdlog::logger> source_logger;
     std::shared_ptr<spdlog::logger> dispatch_logger;
     std::shared_ptr<ConsoleLogSink> console_sink;
+    std::shared_ptr<spdlog::sinks::sink> file_sink;
 };
 
 struct LogRuntime {
     std::mutex                                   install_mutex;
     std::shared_ptr<ConsoleLogSink>              console_sink = std::make_shared<ConsoleLogSink>();
+    std::shared_ptr<spdlog::sinks::sink>         file_sink;
     std::vector<std::shared_ptr<spdlog::logger>> installed_loggers;
+    EFileLogInitStatus                           file_status = EFileLogInitStatus::Disabled;
+    bool                                         file_configuration_locked = false;
+    std::string                                  file_path;
 };
 
 LogRuntime& GetLogRuntime() {
@@ -285,57 +411,122 @@ LogRuntime& GetLogRuntime() {
 } // namespace
 
 void Init() {
+    static_cast<void>(Init(FileLogInitOptions{}));
+}
+
+EFileLogInitStatus Init(const FileLogInitOptions& _options) {
 
 #if !defined(NDEBUG)
     spdlog::set_level(spdlog::level::trace);
 #endif
 
-    LogRuntime&     runtime = GetLogRuntime();
-    std::lock_guard install_lock(runtime.install_mutex);
+    LogRuntime& runtime = GetLogRuntime();
+    bool        report_file_active = false;
+    bool        report_file_failure = false;
+    std::string report_path;
+    std::string report_error;
 
-    const std::shared_ptr<spdlog::logger> logger = spdlog::default_logger();
-    if (!logger) {
-        return;
-    }
+    {
+        std::lock_guard install_lock(runtime.install_mutex);
 
-    const bool already_attached = std::ranges::any_of(
-        runtime.installed_loggers,
-        [&logger](const std::shared_ptr<spdlog::logger>& _installed) {
-            return _installed.get() == logger.get();
+        const std::shared_ptr<spdlog::logger> logger = spdlog::default_logger();
+        if (!logger) {
+            return _options.directory.empty() ? EFileLogInitStatus::Disabled :
+                                                EFileLogInitStatus::Failed;
         }
-    );
-    if (already_attached) {
-        return;
+
+        const bool already_attached = std::ranges::any_of(
+            runtime.installed_loggers,
+            [&logger](const std::shared_ptr<spdlog::logger>& _installed) {
+                return _installed.get() == logger.get();
+            }
+        );
+        if (already_attached) {
+            return runtime.file_status;
+        }
+
+        // logger::sinks() is an owning std::vector. Mutating or copying it into
+        // a logger owned by another DLL makes later reallocation/free depend on
+        // the wrong mimalloc heap. Leave the original logger untouched and
+        // forward to it instead. Runtime keeps every forwarding logger alive
+        // so spdlog shutdown cannot become the final release of Core-defined
+        // state.
+        const std::string& downstream_name = logger->name();
+        const std::string_view downstream_name_view(
+            downstream_name.data(), downstream_name.size()
+        );
+        // The private clone only handles below-threshold backtrace replay and
+        // is retained for process lifetime with its Core-owned, non-SSO name
+        // storage. All messages use the clone so explicit flush has exactly one
+        // downstream target and custom/async virtual dispatch remains intact.
+        std::shared_ptr<spdlog::logger> dispatch_logger =
+            logger->clone(MakeCoreOwnedLoggerName(downstream_name_view));
+        if (!dispatch_logger) {
+            return _options.directory.empty() ? runtime.file_status : EFileLogInitStatus::Failed;
+        }
+        dispatch_logger->disable_backtrace();
+        dispatch_logger->set_level(spdlog::level::trace);
+
+        if (!runtime.file_configuration_locked) {
+            FileLogSetupResult setup = CreateFileLogSink(_options);
+            runtime.file_configuration_locked = true;
+            runtime.file_status               = setup.status;
+            runtime.file_sink                 = std::move(setup.sink);
+            runtime.file_path                 = std::move(setup.path);
+            report_error                      = std::move(setup.error);
+            report_file_active                = runtime.file_status == EFileLogInitStatus::Active;
+            report_file_failure               = runtime.file_status == EFileLogInitStatus::Failed;
+            report_path                       = runtime.file_path;
+        }
+
+        auto replacement = std::make_shared<ConsoleForwardingLogger>(
+            MakeCoreOwnedLoggerName(downstream_name_view),
+            logger,
+            std::move(dispatch_logger),
+            runtime.console_sink,
+            runtime.file_sink
+        );
+
+        runtime.installed_loggers.push_back(replacement);
+        spdlog::set_default_logger(std::move(replacement));
     }
 
-    // logger::sinks() is an owning std::vector. Mutating or copying it into a
-    // logger owned by another DLL makes later reallocation/free depend on the
-    // wrong mimalloc heap. Leave the original logger untouched and forward to
-    // it instead. Runtime keeps every forwarding logger alive so spdlog
-    // shutdown cannot become the final release of Core-defined state.
-    const std::string&     downstream_name = logger->name();
-    const std::string_view downstream_name_view(downstream_name.data(), downstream_name.size());
-    // The private clone only handles below-threshold backtrace replay and is
-    // retained for process lifetime with its Core-owned, non-SSO name storage.
-    // All messages use the clone so explicit flush has exactly one downstream
-    // target and custom/async virtual dispatch remains intact.
-    std::shared_ptr<spdlog::logger> dispatch_logger =
-        logger->clone(MakeCoreOwnedLoggerName(downstream_name_view));
-    if (!dispatch_logger) {
-        return;
+    if (report_file_active) {
+        try {
+            if (const std::shared_ptr<spdlog::logger> logger = spdlog::default_logger()) {
+                logger->info("[LogSystem] Session log: {}", report_path);
+            }
+        } catch (...) {
+            std::fprintf(stderr, "[LogSystem] Session log: %s\n", report_path.c_str());
+        }
+    } else if (report_file_failure) {
+        try {
+            if (const std::shared_ptr<spdlog::logger> logger = spdlog::default_logger()) {
+                logger->warn("[LogSystem] File logging disabled: {}", report_error);
+            }
+        } catch (...) {
+            std::fprintf(
+                stderr, "[LogSystem] File logging disabled: %s\n", report_error.c_str()
+            );
+        }
     }
-    dispatch_logger->disable_backtrace();
-    dispatch_logger->set_level(spdlog::level::trace);
 
-    auto replacement = std::make_shared<ConsoleForwardingLogger>(
-        MakeCoreOwnedLoggerName(downstream_name_view),
-        logger,
-        std::move(dispatch_logger),
-        runtime.console_sink
-    );
+    return runtime.file_status;
+}
 
-    runtime.installed_loggers.push_back(replacement);
-    spdlog::set_default_logger(std::move(replacement));
+void Flush() noexcept {
+    std::shared_ptr<spdlog::sinks::sink> file_sink;
+    try {
+        LogRuntime& runtime = GetLogRuntime();
+        {
+            std::lock_guard lock(runtime.install_mutex);
+            file_sink = runtime.file_sink;
+        }
+        if (file_sink) {
+            file_sink->flush();
+        }
+    } catch (...) {
+    }
 }
 
 ConsoleLogPollResult VisitConsoleLogs(

--- a/source/test/ConsoleLogCoreTest.cpp
+++ b/source/test/ConsoleLogCoreTest.cpp
@@ -1,16 +1,22 @@
 #include "log/LogSystem.h"
+#include "platform/Platform.h"
 
 #include "spdlog/details/os.h"
 #include "spdlog/sinks/null_sink.h"
 
 #include <algorithm>
 #include <atomic>
+#include <chrono>
 #include <cstddef>
 #include <cstdint>
 #include <cstdlib>
+#include <filesystem>
+#include <fstream>
 #include <iostream>
+#include <iterator>
 #include <memory>
 #include <mutex>
+#include <regex>
 #include <stdexcept>
 #include <string>
 #include <string_view>
@@ -18,11 +24,25 @@
 #include <unordered_set>
 #include <vector>
 
+#if PLATFORM_WINDOWS
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+// clang-format off
+#include <Windows.h>
+// clang-format on
+#endif
+
 namespace {
 
 using namespace Moer;
 
 constexpr std::size_t ConsoleLogCapacity = 4096;
+constexpr std::size_t FileLogThreadCount = 4;
+constexpr std::size_t FileLogEntriesPerThread = 64;
 
 struct CapturedEntry {
     std::uint64_t             sequence = 0;
@@ -39,6 +59,69 @@ void Expect(bool _condition, std::string_view _message) {
     if (!_condition) {
         throw std::runtime_error(std::string(_message));
     }
+}
+
+class ScopedDirectory {
+public:
+    ScopedDirectory() {
+        static std::atomic<std::uint64_t> next_id{1};
+        for (std::uint32_t attempt = 0; attempt < 64; ++attempt) {
+            const auto tick = static_cast<std::uint64_t>(
+                std::chrono::steady_clock::now().time_since_epoch().count()
+            );
+            const std::filesystem::path candidate =
+                std::filesystem::temp_directory_path() /
+                ("moer-console-log-" + std::to_string(tick) + "-" +
+                 std::to_string(next_id.fetch_add(1, std::memory_order_relaxed)));
+            std::error_code error;
+            if (std::filesystem::create_directory(candidate, error)) {
+                path = candidate;
+                return;
+            }
+            if (error && error != std::errc::file_exists) {
+                break;
+            }
+        }
+        throw std::runtime_error("console log fixture directory could not be created");
+    }
+
+    ~ScopedDirectory() {
+        std::error_code ignored;
+        std::filesystem::remove_all(path, ignored);
+    }
+
+    std::filesystem::path path;
+};
+
+std::string ReadText(const std::filesystem::path& _path) {
+    std::ifstream stream(_path, std::ios::binary);
+    Expect(stream.is_open(), "session log could not be opened");
+    return std::string(std::istreambuf_iterator<char>(stream), std::istreambuf_iterator<char>());
+}
+
+std::size_t CountOccurrences(std::string_view _text, std::string_view _needle) {
+    std::size_t count  = 0;
+    std::size_t offset = 0;
+    while ((offset = _text.find(_needle, offset)) != std::string_view::npos) {
+        ++count;
+        offset += _needle.size();
+    }
+    return count;
+}
+
+std::vector<std::filesystem::path> FindLogFiles(const std::filesystem::path& _directory) {
+    std::vector<std::filesystem::path> files;
+    std::error_code                    error;
+    std::filesystem::directory_iterator iterator(_directory, error);
+    const std::filesystem::directory_iterator end;
+    while (!error && iterator != end) {
+        if (iterator->is_regular_file(error) && iterator->path().extension() == ".log") {
+            files.push_back(iterator->path());
+        }
+        iterator.increment(error);
+    }
+    std::ranges::sort(files);
+    return files;
 }
 
 CapturedBatch Poll(std::uint64_t _next_sequence, std::size_t _max_count) {
@@ -96,6 +179,187 @@ public:
     std::atomic<std::size_t> log_count{0};
     std::atomic<std::size_t> flush_count{0};
 };
+
+int RunFileLogChild(const std::filesystem::path& _directory, std::string_view _file_name) {
+    auto source_sink = std::make_shared<CountingSink>();
+    auto source_logger = std::make_shared<spdlog::logger>("file-log-contract-source", source_sink);
+    source_logger->set_level(spdlog::level::trace);
+    source_logger->flush_on(spdlog::level::err);
+    spdlog::set_default_logger(source_logger);
+
+    const std::string directory = _directory.generic_string();
+    const LogSystem::FileLogInitOptions options{
+        .directory = directory,
+        .file_name = _file_name,
+    };
+    Expect(
+        LogSystem::Init(options) == LogSystem::EFileLogInitStatus::Active,
+        "file logging did not become active"
+    );
+    const std::shared_ptr<spdlog::logger> installed_logger = spdlog::default_logger();
+    Expect(
+        installed_logger && installed_logger.get() != source_logger.get() &&
+            installed_logger->sinks().empty(),
+        "file logging changed the ABI-safe forwarding logger contract"
+    );
+
+    const std::uint64_t cursor = ClearAndGetNextSequence();
+    Expect(
+        LogSystem::Init(options) == LogSystem::EFileLogInitStatus::Active &&
+            spdlog::default_logger().get() == installed_logger.get(),
+        "repeated file logging initialization replaced the forwarding logger"
+    );
+
+    installed_logger->info("file-log-contract-info");
+    installed_logger->warn("file-log-contract-warning");
+    installed_logger->error("file-log-contract-error");
+
+    std::vector<std::thread> producers;
+    producers.reserve(FileLogThreadCount);
+    for (std::size_t thread_index = 0; thread_index < FileLogThreadCount; ++thread_index) {
+        producers.emplace_back([installed_logger, thread_index]() {
+            for (std::size_t entry_index = 0; entry_index < FileLogEntriesPerThread; ++entry_index) {
+                installed_logger->info(
+                    "file-log-thread-{}-entry-{}#", thread_index, entry_index
+                );
+            }
+        });
+    }
+    for (std::thread& producer : producers) {
+        producer.join();
+    }
+    LogSystem::Flush();
+
+    const CapturedBatch batch = Poll(cursor, 1024);
+    const std::size_t expected_message_count =
+        3 + FileLogThreadCount * FileLogEntriesPerThread;
+    Expect(
+        batch.result.dropped_count == 0 && batch.entries.size() == expected_message_count,
+        "file logging child did not retain every message in the console channel"
+    );
+    const auto has_entry = [&batch](spdlog::level::level_enum _level, std::string_view _message) {
+        return std::ranges::any_of(batch.entries, [_level, _message](const CapturedEntry& _entry) {
+            return _entry.level == _level && _entry.message == _message;
+        });
+    };
+    Expect(
+        has_entry(spdlog::level::info, "file-log-contract-info") &&
+            has_entry(spdlog::level::warn, "file-log-contract-warning") &&
+            has_entry(spdlog::level::err, "file-log-contract-error"),
+        "file logging child changed message severity or payload"
+    );
+    Expect(
+        source_sink->log_count.load() == expected_message_count + 1,
+        "file logging duplicated or bypassed the downstream logger"
+    );
+    return EXIT_SUCCESS;
+}
+
+int RunFileLogFailureChild(const std::filesystem::path& _directory) {
+    std::error_code directory_error;
+    std::filesystem::create_directories(_directory, directory_error);
+    Expect(!directory_error, "file logging failure fixture directory could not be created");
+
+    const std::filesystem::path blocker = _directory / "blocked";
+    {
+        std::ofstream stream(blocker, std::ios::binary);
+        Expect(stream.is_open(), "file logging failure fixture blocker could not be created");
+        stream << "not-a-directory";
+    }
+
+    auto source_sink = std::make_shared<CountingSink>();
+    auto source_logger = std::make_shared<spdlog::logger>(
+        "file-log-failure-contract-source", source_sink
+    );
+    source_logger->set_level(spdlog::level::trace);
+    spdlog::set_default_logger(source_logger);
+
+    const std::string blocked_directory = blocker.generic_string();
+    Expect(
+        LogSystem::Init({.directory = blocked_directory, .file_name = "contract.log"}) ==
+            LogSystem::EFileLogInitStatus::Failed,
+        "file logging did not report an unusable directory"
+    );
+    const std::shared_ptr<spdlog::logger> installed_logger = spdlog::default_logger();
+    Expect(
+        installed_logger && installed_logger.get() != source_logger.get(),
+        "file logging failure prevented console forwarding installation"
+    );
+
+    const std::uint64_t cursor = ClearAndGetNextSequence();
+    installed_logger->info("file-log-failure-console-sentinel");
+    LogSystem::Flush();
+    const CapturedBatch batch = Poll(cursor, 4);
+    Expect(
+        batch.entries.size() == 1 &&
+            batch.entries.front().message == "file-log-failure-console-sentinel" &&
+            source_sink->log_count.load() >= 2,
+        "file logging failure disabled an existing log channel"
+    );
+    return EXIT_SUCCESS;
+}
+
+#if PLATFORM_WINDOWS
+std::filesystem::path CurrentExecutablePath() {
+    std::vector<wchar_t> path(1024);
+    for (;;) {
+        const DWORD length = ::GetModuleFileNameW(nullptr, path.data(), static_cast<DWORD>(path.size()));
+        if (length == 0) {
+            throw std::runtime_error("GetModuleFileNameW failed");
+        }
+        if (length < path.size() - 1) {
+            return std::filesystem::path(std::wstring_view(path.data(), length));
+        }
+        path.resize(path.size() * 2);
+    }
+}
+
+DWORD RunFileLogChildProcess(
+    const std::filesystem::path& _directory,
+    std::wstring_view            _mode
+) {
+    const std::filesystem::path executable = CurrentExecutablePath();
+    std::wstring command = L"\"" + executable.wstring() + L"\" " + std::wstring(_mode) +
+                           L" \"" + _directory.wstring() + L"\"";
+    std::vector<wchar_t> mutable_command(command.begin(), command.end());
+    mutable_command.push_back(L'\0');
+
+    STARTUPINFOW        startup{};
+    PROCESS_INFORMATION process{};
+    startup.cb = sizeof(startup);
+    Expect(
+        ::CreateProcessW(
+            nullptr,
+            mutable_command.data(),
+            nullptr,
+            nullptr,
+            FALSE,
+            CREATE_NO_WINDOW,
+            nullptr,
+            nullptr,
+            &startup,
+            &process
+        ) != FALSE,
+        "file logging child process could not be created"
+    );
+
+    const DWORD wait_result = ::WaitForSingleObject(process.hProcess, 15000);
+    if (wait_result != WAIT_OBJECT_0) {
+        static_cast<void>(::TerminateProcess(process.hProcess, 0xEE));
+        static_cast<void>(::WaitForSingleObject(process.hProcess, 2000));
+        ::CloseHandle(process.hThread);
+        ::CloseHandle(process.hProcess);
+        throw std::runtime_error("file logging child did not terminate within the bounded timeout");
+    }
+
+    DWORD      exit_code     = 0;
+    const BOOL got_exit_code = ::GetExitCodeProcess(process.hProcess, &exit_code);
+    ::CloseHandle(process.hThread);
+    ::CloseHandle(process.hProcess);
+    Expect(got_exit_code != FALSE, "file logging child exit code was unavailable");
+    return exit_code;
+}
+#endif
 
 class ThrowingSink final : public spdlog::sinks::sink {
 public:
@@ -560,9 +824,99 @@ void TestSpdlogTeardownAndReattach(std::shared_ptr<spdlog::logger>& _logger) {
     _logger = installed_replacement;
 }
 
+void TestFileLoggingContract() {
+#if PLATFORM_WINDOWS
+    ScopedDirectory output;
+
+    const std::filesystem::path fixed_directory = output.path / "fixed";
+    Expect(
+        RunFileLogChildProcess(fixed_directory, L"--file-log-fixed-child") == EXIT_SUCCESS,
+        "fixed-name file logging child failed"
+    );
+    const std::vector<std::filesystem::path> fixed_logs = FindLogFiles(fixed_directory);
+    Expect(
+        fixed_logs.size() == 1 && fixed_logs.front().filename() == "contract.log",
+        "fixed-name file logging did not create exactly one requested file"
+    );
+    const std::string fixed_text = ReadText(fixed_logs.front());
+    Expect(
+        std::regex_search(
+            fixed_text,
+            std::regex(
+                R"([0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}\.[0-9]{3} \[[0-9]+\] \[info\] file-log-contract-info)"
+            )
+        ),
+        "session log omitted its timestamp, thread id, level, or payload"
+    );
+    Expect(
+        CountOccurrences(fixed_text, "file-log-contract-info") == 1 &&
+            CountOccurrences(fixed_text, "file-log-contract-warning") == 1 &&
+            CountOccurrences(fixed_text, "file-log-contract-error") == 1 &&
+            fixed_text.find("[warning] file-log-contract-warning") != std::string::npos &&
+            fixed_text.find("[error] file-log-contract-error") != std::string::npos,
+        "session log duplicated or changed a severity sentinel"
+    );
+    Expect(
+        CountOccurrences(fixed_text, "file-log-thread-") ==
+            FileLogThreadCount * FileLogEntriesPerThread,
+        "session log lost or duplicated concurrent messages"
+    );
+    for (std::size_t thread_index = 0; thread_index < FileLogThreadCount; ++thread_index) {
+        for (std::size_t entry_index = 0; entry_index < FileLogEntriesPerThread; ++entry_index) {
+            const std::string message = "file-log-thread-" + std::to_string(thread_index) +
+                                        "-entry-" + std::to_string(entry_index) + "#";
+            Expect(
+                CountOccurrences(fixed_text, message) == 1,
+                "session log did not preserve each concurrent message exactly once"
+            );
+        }
+    }
+
+    const std::filesystem::path timestamp_directory = output.path / "timestamp";
+    Expect(
+        RunFileLogChildProcess(timestamp_directory, L"--file-log-timestamp-child") == EXIT_SUCCESS,
+        "timestamped file logging child failed"
+    );
+    const std::vector<std::filesystem::path> timestamp_logs = FindLogFiles(timestamp_directory);
+    Expect(timestamp_logs.size() == 1, "timestamped file logging did not create exactly one file");
+    Expect(
+        std::regex_match(
+            timestamp_logs.front().filename().string(),
+            std::regex(R"(MoerEditor_[0-9]{8}_[0-9]{6}_[0-9]{3}_p[0-9]+\.log)")
+        ),
+        "timestamped session log file name did not match its contract"
+    );
+
+    const std::filesystem::path failure_directory = output.path / "failure";
+    Expect(
+        RunFileLogChildProcess(failure_directory, L"--file-log-failure-child") == EXIT_SUCCESS,
+        "file logging failure child failed"
+    );
+    Expect(
+        FindLogFiles(failure_directory).empty(),
+        "file logging failure unexpectedly created a session log"
+    );
+#endif
+}
+
 } // namespace
 
-int main() {
+int main(int _argc, char** _argv) {
+    try {
+        if (_argc == 3 && std::string_view(_argv[1]) == "--file-log-fixed-child") {
+            return RunFileLogChild(std::filesystem::path(_argv[2]), "contract.log");
+        }
+        if (_argc == 3 && std::string_view(_argv[1]) == "--file-log-timestamp-child") {
+            return RunFileLogChild(std::filesystem::path(_argv[2]), {});
+        }
+        if (_argc == 3 && std::string_view(_argv[1]) == "--file-log-failure-child") {
+            return RunFileLogFailureChild(std::filesystem::path(_argv[2]));
+        }
+    } catch (const std::exception& error) {
+        std::cerr << "Console log file child failed: " << error.what() << '\n';
+        return EXIT_FAILURE;
+    }
+
     DefaultLoggerRestore restore_default_logger;
 
     const LogSystem::ConsoleLogPollResult initial = LogSystem::VisitConsoleLogs(0, 0, nullptr, nullptr);
@@ -598,6 +952,7 @@ int main() {
         TestVirtualLoggerBacktraceDispatch(logger);
         TestBacktraceThreadMetadata(logger);
         TestSpdlogTeardownAndReattach(logger);
+        TestFileLoggingContract();
         std::cout << "Console log core contract tests passed.\n";
         return EXIT_SUCCESS;
     } catch (const std::exception& error) {


### PR DESCRIPTION
## Summary

- create one timestamped session log under the runtime workspace `logs` directory
- forward admitted messages to the existing downstream logger, editor console, and a Core-owned thread-safe file sink
- flush error/critical messages immediately and flush again during orderly Engine shutdown
- fail open when the log directory cannot be created, preserving the existing console channels
- add isolated child-process tests for timestamp naming, fixed-name output, concurrent writes, repeated initialization, formatting, severity, and failure fallback

The Vulkan validation callback formatting requested by #86 was already structured on `main`; this PR completes the missing file-output portion.

## Validation

- `cmake --build build --config Debug --target TestConsoleLogCore moer_runtime --parallel 16`
- `ctest --test-dir build -C Debug -R '^ConsoleLogCoreContract$' --output-on-failure` — 1/1 passed
- `cmake --build build --config Debug --target MoerEditor TestConsoleLogCore --parallel 16`
- `MoerEditor.exe --threading-raster-lifecycle-validation` — Raster stable for 12 frames and exited cleanly
- generated a 47,604-byte session log containing startup, lifecycle completion, and Vulkan device shutdown; no error/critical/fatal entries
- independent concurrency/DLL-ownership review found no remaining P0/P1/P2 issues

Closes #86