### PR TITLE
Implement Vulkan multiview cubemap rendering

### DIFF
--- a/shaders/pipelines/raster/deferred/geometry/GeometryPassVertex.hlsl
+++ b/shaders/pipelines/raster/deferred/geometry/GeometryPassVertex.hlsl
@@ -2,6 +2,10 @@
 #define SHADOW_DEPTH_PASS 0
 #endif
 
+#ifndef POINT_SHADOW_MULTIVIEW
+#define POINT_SHADOW_MULTIVIEW 0
+#endif
+
 #include "core/common/Bindless.hlsl"
 #include "core/common/Common.hlsl"
 #include "shared/ShaderParameters.h"
@@ -14,6 +18,10 @@ BINDLESS_BINDINGS(3, 2, 4, 5)
 #include "pipelines/raster/deferred/geometry/GeometryPassCommon.hlsli"
 
 [[vk::push_constant]] ConstantBuffer<Moer::GeometryPassBindlessParam> param;
+
+#if POINT_SHADOW_MULTIVIEW
+[[vk::binding(0, 0)]] ConstantBuffer<Moer::PointShadowViewMatrices> point_shadow_view_matrices;
+#endif
 
 struct VsContext {
     // input
@@ -41,7 +49,7 @@ struct VsContext {
 
     // funcs
 
-    void Load(uint _vertex_id, uint _instance_id) {
+    void Load(uint _vertex_id, uint _instance_id, uint _view_id) {
         vertex_id   = _vertex_id;
         instance_id = _instance_id;
 
@@ -74,7 +82,11 @@ struct VsContext {
             vertex_pos               = position_buf.Load<float3>(primitive.position_start_idx + vertex_id);
         }
         float3 world_pos = mul(model2world, float4(vertex_pos, 1.0)).xyz;
-        out_clip_pos  = mul(param.world2clip, float4(world_pos, 1.0));
+        float4x4 world2clip = param.world2clip;
+#if POINT_SHADOW_MULTIVIEW
+        world2clip = point_shadow_view_matrices.world2clip[min(_view_id, 5u)];
+#endif
+        out_clip_pos = mul(world2clip, float4(world_pos, 1.0));
 
 #if !SHADOW_DEPTH_PASS
 
@@ -120,10 +132,16 @@ struct VsContext {
 VsOutput main(
     uint vertex_id : SV_VertexID,    // 顶点 ID（自动由 GPU 提供）
     uint instance_id : SV_InstanceID // 实例 ID（自动由 GPU 提供）
+#if POINT_SHADOW_MULTIVIEW
+    , uint view_id : SV_ViewID
+#endif
 ) {
 
     VsContext context;
-    context.Load(vertex_id, instance_id);
+#if !POINT_SHADOW_MULTIVIEW
+    uint view_id = 0u;
+#endif
+    context.Load(vertex_id, instance_id, view_id);
 
     VsOutput output;
 

--- a/shaders/test/MultiviewLayer.hlsl
+++ b/shaders/test/MultiviewLayer.hlsl
@@ -1,0 +1,22 @@
+struct VsOutput {
+    float4 position : SV_Position;
+    nointerpolation uint view_id : TEXCOORD0;
+};
+
+VsOutput MultiviewVS(uint vertex_id : SV_VertexID, uint view_id : SV_ViewID) {
+    float2 uv = float2((vertex_id << 1u) & 2u, vertex_id & 2u);
+    VsOutput output;
+    output.position = float4(uv * 2.0 - 1.0, 0.5, 1.0);
+    output.view_id  = view_id;
+    return output;
+}
+
+float4 MultiviewPS(VsOutput input) : SV_Target0 {
+    uint view_id = min(input.view_id, 5u);
+    float3 color = float3(
+        view_id == 0u || view_id == 3u || view_id == 4u,
+        view_id == 1u || view_id == 3u || view_id == 5u,
+        view_id == 2u || view_id == 4u || view_id == 5u
+    );
+    return float4(color, 1.0);
+}

--- a/source/editor/raster_ui/RasterUI.cpp
+++ b/source/editor/raster_ui/RasterUI.cpp
@@ -839,6 +839,10 @@ void RasterUI::ShowConfig() {
 
         if (m_config.shadow_map_mode == EShadowMapMode::POINT_CUBE) {
             ImGui::SliderInt("Shadow Map Size", &m_config.shadow_csm_sm_size, 512, 4096);
+            ImGui::Checkbox(
+                "Enable Point Shadow Multiview",
+                &m_config.shadow_point_multiview_enabled
+            );
         } else if (m_config.shadow_map_mode == EShadowMapMode::CSM) {
             draw_csm_common_settings();
             float minimum_cover_ratio = 0.0f;

--- a/source/runtime/render/renderer/raster/CullingPass.h
+++ b/source/runtime/render/renderer/raster/CullingPass.h
@@ -192,6 +192,39 @@ public:
         Process(context, gpu_scene_res, params, data, visibility_set, out_stats, profile_scope_name);
     }
 
+    // Builds one conservative visibility set for an axis-aligned world-space volume.
+    // Point-shadow multiview uses this cube as the union of its six 90-degree frusta.
+    void ProcessAabb(
+        RasterContext&                    context,
+        const float3&                     bounds_min,
+        const float3&                     bounds_max,
+        const GpuScene::Res&              gpu_scene_res,
+        GpuCullingBuffers::VisibilitySet& visibility_set,
+        CullStatistics*                   out_stats          = nullptr,
+        std::string_view                  profile_scope_name = {},
+        CullingOptions                    options            = {true, false, 1.0f, -1}
+    ) {
+        const uint draw_count = gpu_scene_res.draw_cmd_buf.buf->GetNumElement();
+
+        CullParams params{};
+        CullData   data{};
+        params.draw_count = draw_count;
+        data.frustum_planes[0] = float4(1.0f, 0.0f, 0.0f, -bounds_min.x);
+        data.frustum_planes[1] = float4(-1.0f, 0.0f, 0.0f, bounds_max.x);
+        data.frustum_planes[2] = float4(0.0f, 1.0f, 0.0f, -bounds_min.y);
+        data.frustum_planes[3] = float4(0.0f, -1.0f, 0.0f, bounds_max.y);
+        data.frustum_planes[4] = float4(0.0f, 0.0f, 1.0f, -bounds_min.z);
+        data.frustum_planes[5] = float4(0.0f, 0.0f, -1.0f, bounds_max.z);
+
+        if (options.enable_frustum_culling) {
+            params.flags |= CULL_FLAG_ENABLE_FRUSTUM;
+        }
+
+        FillHiZOcclusionParams(context, options, params, data);
+
+        Process(context, gpu_scene_res, params, data, visibility_set, out_stats, profile_scope_name);
+    }
+
 private:
     // Converts the raw GPU counters into UI-facing culling statistics.
     static CullStatistics ToStatistics(const GpuCullingCounterData& counters) {

--- a/source/runtime/render/renderer/raster/RasterConfig.h
+++ b/source/runtime/render/renderer/raster/RasterConfig.h
@@ -382,6 +382,7 @@ struct RasterConfig {
     bool           shadow_csm_blend_option               = true;
     int            shadow_csm_sm_size                    = 4096;
     bool           shadow_csm_visualize_cascade          = false;
+    bool           shadow_point_multiview_enabled        = true;
     float          shadow_csm_auto_max_cover_ratio_of_camera = 0.25f;
     bool           shadow_cache_enabled                  = true; // 开启后允许远级联复用上一帧阴影图
     int            shadow_cache_disable_first_n_cascades = 0;    // 前N层级联始终全量刷新

--- a/source/runtime/render/renderer/raster/ShadowDepthPass.cpp
+++ b/source/runtime/render/renderer/raster/ShadowDepthPass.cpp
@@ -17,6 +17,7 @@
 #include "shaderheaders/shared/raster/geometry_pass/ShaderParameters.h"
 
 #include <cmath>
+#include <cstring>
 #include <sstream>
 
 namespace {
@@ -506,6 +507,61 @@ ShadowDepthPass::ShadowDepthPass(RasterContext& context) : m_culling_pass(contex
     m_pso = ShaderManager::Get().Raster().Vertex(vtx).Pixel(frag).Build<ShadowDepthPassPipeline>(
         std::move(pso_info)
     );
+
+    m_point_shadow_multiview_supported = context.device.SupportsMultiview(k_point_shadow_view_count);
+    if (!m_point_shadow_multiview_supported) {
+        LOG_INFO(
+            "[PointShadow][Multiview] requested_views={} path=serial fallback_reason=device_capability",
+            k_point_shadow_view_count
+        );
+        return;
+    }
+
+    GfxPsoCreateInfo multiview_pso_info(
+        RHIRasterizeInfo::Preset(),
+        {},
+        {},
+        RHIDepthStencilStateInfo::Preset<DepthStencil::DEPTH_WRITE_GREATER>(),
+        context.textures.depth_linear_sampler.tex->GetFormat()
+    );
+    multiview_pso_info.SetViewMask(k_point_shadow_view_mask);
+
+    PointShadowMultiviewPipeline::MutationSet multiview_mutation_set{};
+    multiview_mutation_set.SetMutation<PointShadowMultiviewPipeline::SHADOW_DEPTH_PASS>(true);
+    multiview_mutation_set.SetMutation<PointShadowMultiviewPipeline::POINT_SHADOW_MULTIVIEW>(true);
+
+    Shader& multiview_vtx = ShaderManager::Get().CompileShader(
+        ST_VERTEX,
+        "pipelines/raster/deferred/geometry/GeometryPassVertex.hlsl",
+        multiview_mutation_set
+    );
+    Shader& multiview_frag = ShaderManager::Get().CompileShader(
+        ST_FRAGMENT,
+        "pipelines/raster/deferred/geometry/GeometryPassPixel.hlsl",
+        multiview_mutation_set
+    );
+
+    m_point_shadow_multiview_pso = ShaderManager::Get()
+                                           .Raster()
+                                           .Vertex(multiview_vtx)
+                                           .Pixel(multiview_frag)
+                                           .Build<PointShadowMultiviewPipeline>(
+                                               std::move(multiview_pso_info)
+                                           );
+    m_point_shadow_view_matrices = context.device.CreateBuffer<byte>(
+        "Raster::PointShadowMultiviewMatrices",
+        sizeof(PointShadowViewMatrices),
+        EBufferUsageFlags::CONSTANT_BUFFER
+    );
+
+    m_point_shadow_multiview_supported =
+        m_point_shadow_multiview_pso.handle.IsValid() && m_point_shadow_view_matrices != nullptr;
+    LOG_INFO(
+        "[PointShadow][Multiview] requested_views={} view_mask=0x{:x} path={}",
+        k_point_shadow_view_count,
+        k_point_shadow_view_mask,
+        m_point_shadow_multiview_supported ? "multiview" : "serial"
+    );
 }
 
 bool ShadowDepthPass::RefreshShadowCasterBounds(RasterContext& context) {
@@ -936,11 +992,46 @@ void ShadowDepthPass::RenderPointShadows(
         {{0, 0, -1}, {0, -1, 0}}  // -Z (Back)
     };
 
-    // 4. 遍历 6 个面进行渲染
+    StaticArray<float4x4, CUBE_FACE_Num> view_projections{};
+    PointShadowViewMatrices              multiview_matrices{};
     for (uint face = 0; face < CUBE_FACE_Num; ++face) {
-        float3   light_pos = cube_res.light_pos;
-        float4x4 view      = MakeLookatViewMatrixRH(light_pos, light_pos + faces[face].dir, faces[face].up);
-        float4x4 view_proj = proj * view;
+        const float3   light_pos = cube_res.light_pos;
+        const float4x4 view = MakeLookatViewMatrixRH(light_pos, light_pos + faces[face].dir, faces[face].up);
+        view_projections[face]            = proj * view;
+        multiview_matrices.world2clip[face] = Transpose(view_projections[face]);
+    }
+
+    if (m_point_shadow_multiview_supported && config.shadow_point_multiview_enabled) {
+        ScopedGpuMarker multiview_marker(
+            context.cmd_list,
+            "PointShadow Multiview",
+            GpuMarkerPalette::Subpass()
+        );
+
+        m_culling_pass.Process(
+            context,
+            view_projections[0],
+            context.GetGpuSceneRes(),
+            context.gpu_culling_buffers.shadow,
+            nullptr,
+            "PointShadow Multiview Culling",
+            CullingPass::CullingOptions{false, false, 1.0f, -1}
+        );
+
+        RenderPointShadowMultiview(
+            context,
+            config,
+            multiview_matrices,
+            Rect2D(0, 0, config.shadow_csm_sm_size, config.shadow_csm_sm_size),
+            TextureView(cube_res.tex.Get()).Slice(0, k_point_shadow_view_count),
+            std::format("PointShadow L{} Multiview", light_idx)
+        );
+        return;
+    }
+
+    // Compatibility path: cull and render each cube face independently.
+    for (uint face = 0; face < CUBE_FACE_Num; ++face) {
+        const float4x4& view_proj = view_projections[face];
 
         TextureView face_view = TextureView(cube_res.tex.Get()).Slice(face, 1);
 
@@ -971,6 +1062,64 @@ void ShadowDepthPass::RenderPointShadows(
     }
 }
 
+void ShadowDepthPass::RenderPointShadowMultiview(
+    RasterContext&                 context,
+    const RasterConfig&            config,
+    const PointShadowViewMatrices& view_matrices,
+    const Rect2D&                  rect,
+    TextureView                    depth_view,
+    std::string_view               pass_name
+) {
+    Array<byte> matrix_upload(sizeof(PointShadowViewMatrices));
+    std::memcpy(matrix_upload.data(), &view_matrices, sizeof(PointShadowViewMatrices));
+    context.cmd_list.CopyFrom(
+        std::move(matrix_upload),
+        m_point_shadow_view_matrices->GetView(),
+        "Raster::PointShadowMultiviewMatrices"
+    );
+
+    GeometryPassBindlessParam param{};
+    param.world2clip = view_matrices.world2clip[0];
+
+    const auto& gpu_scene_res           = context.GetGpuSceneRes();
+    param.instance_buf_hdl              = gpu_scene_res.instance_buf.hdl;
+    param.visible_instance_id_buf_hdl   = context.gpu_culling_buffers.shadow.visible_instance_id_buf.hdl;
+    param.use_visible_instance_id_remap = 1;
+    param.primitive_buf_hdl             = gpu_scene_res.primitive_buf.hdl;
+    param.position_buf_hdl              = gpu_scene_res.position_buf.hdl;
+    param.packed_normal_buf_hdl         = gpu_scene_res.packed_normal_buf.hdl;
+    param.packed_tangent_buf_hdl        = gpu_scene_res.packed_tangent_buf.hdl;
+    param.texcoord0_buf_hdl             = gpu_scene_res.texcoord0_buf.hdl;
+    param.material_buf_hdl              = gpu_scene_res.material_buf.hdl;
+    param.enable_alpha_test             = config.geometry_enable_alpha_test ? 1 : 0;
+    param.alpha_test_blend_pixel_cutoff = config.geometry_alpha_test_blend_pixel_cutoff;
+
+    context.cmd_list.PushScopeWithTimeScope("PointShadow Multiview Draw");
+
+    auto draw = context.cmd_list.Gfx(
+        m_point_shadow_multiview_pso,
+        m_point_shadow_view_matrices,
+        context.bdls,
+        param
+    );
+    draw.SetViewMask(k_point_shadow_view_mask);
+
+    const auto& visibility = context.gpu_culling_buffers.shadow;
+    draw.DrawIndirect(
+        pass_name,
+        rect,
+        {},
+        IndexBuffer{gpu_scene_res.index_buf.buf->GetView(), EIndexElementType::IET_UINT32},
+        visibility.draw_cmd_buf->GetView(),
+        visibility.GetDrawCountView(),
+        visibility.draw_cmd_buf->GetStride(),
+        visibility.max_draw_count,
+        DepthAttachment(depth_view)
+    );
+
+    context.cmd_list.PopScopeWithTimeScope();
+}
+
 void ShadowDepthPass::RenderShadow(
     RasterContext&      context,
     const RasterConfig& config,
@@ -980,7 +1129,7 @@ void ShadowDepthPass::RenderShadow(
     std::string_view                pass_name,
     std::optional<std::string_view> profile_scope_name
 ) {
-    GeometryPassBindlessParam param;
+    GeometryPassBindlessParam param{};
     param.world2clip = Transpose(view_proj);
 
     const auto& gpu_scene_res           = context.GetGpuSceneRes();
@@ -1013,7 +1162,7 @@ void ShadowDepthPass::RenderShadow(
         visibility.GetDrawCountView(),
         visibility.draw_cmd_buf->GetStride(),
         visibility.max_draw_count,
-        DepthAttachment(depth_view.GetTexture())
+        DepthAttachment(depth_view)
     );
 
     if (profile_scope_name.has_value()) {

--- a/source/runtime/render/renderer/raster/ShadowDepthPass.cpp
+++ b/source/runtime/render/renderer/raster/ShadowDepthPass.cpp
@@ -1008,14 +1008,16 @@ void ShadowDepthPass::RenderPointShadows(
             GpuMarkerPalette::Subpass()
         );
 
-        m_culling_pass.Process(
+        const float3 point_shadow_extent(far_plane, far_plane, far_plane);
+        m_culling_pass.ProcessAabb(
             context,
-            view_projections[0],
+            cube_res.light_pos - point_shadow_extent,
+            cube_res.light_pos + point_shadow_extent,
             context.GetGpuSceneRes(),
             context.gpu_culling_buffers.shadow,
             nullptr,
             "PointShadow Multiview Culling",
-            CullingPass::CullingOptions{false, false, 1.0f, -1}
+            CullingPass::CullingOptions{true, false, 1.0f, -1}
         );
 
         RenderPointShadowMultiview(

--- a/source/runtime/render/renderer/raster/ShadowDepthPass.h
+++ b/source/runtime/render/renderer/raster/ShadowDepthPass.h
@@ -27,6 +27,19 @@ public:
     MUTATION_SET(MutationSet, SHADOW_DEPTH_PASS);
 };
 
+class PointShadowMultiviewPipeline : public RasterPipeline {
+public:
+    DEFINE_RASTER_PIPELINE_CLASS(PointShadowMultiviewPipeline);
+    DEFINE_SHADER_BUFFER(point_shadow_view_matrices);
+    DEFINE_SHADER_BINDLESS_ARRAY(bdls);
+    DEFINE_SHADER_CONSTANT_STRUCT(GeometryPassBindlessParam, param);
+    DEFINE_SHADER_ARGS(point_shadow_view_matrices, bdls, param);
+
+    MUTATION_BOOL(SHADOW_DEPTH_PASS);
+    MUTATION_BOOL(POINT_SHADOW_MULTIVIEW);
+    MUTATION_SET(MutationSet, SHADOW_DEPTH_PASS, POINT_SHADOW_MULTIVIEW);
+};
+
 class ShadowDepthPass {
 public:
     ShadowDepthPass(RasterContext& context);
@@ -59,9 +72,24 @@ private:
         std::optional<std::string_view> profile_scope_name = std::nullopt
     );
 
+    void RenderPointShadowMultiview(
+        RasterContext&                  context,
+        const RasterConfig&             config,
+        const PointShadowViewMatrices&  view_matrices,
+        const Rect2D&                   rect,
+        TextureView                     depth_view,
+        std::string_view                pass_name
+    );
+
 private:
+    static constexpr uint32_t k_point_shadow_view_count = 6u;
+    static constexpr uint32_t k_point_shadow_view_mask  = (1u << k_point_shadow_view_count) - 1u;
+
     uint                    enabled_cascade_layers;
     ShadowDepthPassPipeline m_pso;
+    PointShadowMultiviewPipeline m_point_shadow_multiview_pso;
+    BufferRef                    m_point_shadow_view_matrices;
+    bool                         m_point_shadow_multiview_supported = false;
     CullingPass             m_culling_pass;
     Array<Box3D>            m_shadow_caster_bounds;
     uint64_t                m_shadow_caster_bounds_generation = 0u;

--- a/source/runtime/render/rhi/RHI.h
+++ b/source/runtime/render/rhi/RHI.h
@@ -202,6 +202,7 @@ public:
 
     RENDER_API bool SupportsTessellation() const;
     RENDER_API uint32_t GetMaxTessellationFactor() const;
+    RENDER_API bool SupportsMultiview(uint32_t view_count) const;
 
     RENDER_API PipelineHandle
     CreatePipeline(GfxPsoCreateInfo&& _pso_info, PipelineShaderInfo&& _shaders); //gfx

--- a/source/runtime/render/rhi/RHICommand.h
+++ b/source/runtime/render/rhi/RHICommand.h
@@ -1004,6 +1004,11 @@ public:
 
         DrawDispatcher(RasterPipeline& _pso, CommandList& _cmd_list, ArrayArguments&& _args);
 
+        DrawDispatcher& SetViewMask(uint32_t mask) {
+            view_mask = mask;
+            return *this;
+        }
+
         // Unnamed Draw with mesh data list and depth attachment
         template<typename... TRenderTarget>
         void Draw(
@@ -1013,6 +1018,7 @@ public:
             TRenderTarget&&... _render_targets
         ) {
             RenderPassInfo pass_info({std::forward<TRenderTarget>(_render_targets)...}, _depth, _rect);
+            pass_info.view_mask = view_mask;
             cmd_list.SetRenderCmds(pso.handle, std::move(args), std::move(pass_info), std::move(_mesh_data));
         };
 
@@ -1062,6 +1068,7 @@ public:
             TRenderTarget&&... _render_targets
         ) {
             RenderPassInfo      pass_info({std::forward<TRenderTarget>(_render_targets)...}, _depth, _rect);
+            pass_info.view_mask = view_mask;
             Array<MeshDrawData> mesh_data;
             mesh_data.emplace_back(_vtx, _vtx_cnt);
             mesh_data.back().draw_params = std::move(_mesh_data);
@@ -1090,6 +1097,7 @@ public:
             TRenderTarget&&... _render_targets
         ) {
             RenderPassInfo pass_info({std::forward<TRenderTarget>(_render_targets)...}, _depth, _rect);
+            pass_info.view_mask = view_mask;
             cmd_list.SetRenderCmds(
                 pso.handle, std::move(args), std::move(pass_info), std::move(_mesh_data), _name
             );
@@ -1142,6 +1150,7 @@ public:
             TRenderTarget&&... _render_targets
         ) {
             RenderPassInfo      pass_info({std::forward<TRenderTarget>(_render_targets)...}, _depth, _rect);
+            pass_info.view_mask = view_mask;
             Array<MeshDrawData> mesh_data;
             mesh_data.emplace_back();
             mesh_data.back().draw_params = std::move(_mesh_data);
@@ -1162,6 +1171,7 @@ public:
             RenderPassInfo pass_info(
                 {std::forward<TRenderTarget>(_render_targets)...}, DepthAttachment{}, _rect
             );
+            pass_info.view_mask = view_mask;
             Array<MeshDrawData> mesh_data;
             mesh_data.emplace_back();
             mesh_data.back().draw_params = std::move(_mesh_data);
@@ -1183,6 +1193,7 @@ public:
             TRenderTarget&&... _render_targets
         ) {
             RenderPassInfo      pass_info({std::forward<TRenderTarget>(_render_targets)...}, _depth, _rect);
+            pass_info.view_mask = view_mask;
             Array<MeshDrawData> mesh_data;
             mesh_data.emplace_back(_vtx, _vtx_cnt);
             mesh_data.back().draw_params = std::move(_mesh_data);
@@ -1205,6 +1216,7 @@ public:
             RenderPassInfo pass_info(
                 {std::forward<TRenderTarget>(_render_targets)...}, DepthAttachment{}, _rect
             );
+            pass_info.view_mask = view_mask;
             Array<MeshDrawData> mesh_data;
             mesh_data.emplace_back(_vtx, _vtx_cnt);
             mesh_data.back().draw_params = std::move(_mesh_data);
@@ -1246,6 +1258,7 @@ public:
             RenderPassInfo pass_info(
                 {std::forward<TRenderTarget>(_render_targets)...}, DepthAttachment{}, _rect
             );
+            pass_info.view_mask = view_mask;
             Array<MeshDrawData> mesh_data;
             mesh_data.emplace_back(_vtx, _idx);
             mesh_data.back().DrawIndirect(_indirect_buffer, _count, _stride);
@@ -1269,6 +1282,7 @@ public:
             TRenderTarget&&... _render_targets
         ) {
             RenderPassInfo      pass_info({std::forward<TRenderTarget>(_render_targets)...}, _depth, _rect);
+            pass_info.view_mask = view_mask;
             Array<MeshDrawData> mesh_data;
             mesh_data.emplace_back(_vtx, _idx);
             mesh_data.back().DrawIndirect(_indirect_buffer, _count, _stride);
@@ -1293,6 +1307,7 @@ public:
             TRenderTarget&&... _render_targets
         ) {
             RenderPassInfo      pass_info({std::forward<TRenderTarget>(_render_targets)...}, _depth, _rect);
+            pass_info.view_mask = view_mask;
             Array<MeshDrawData> mesh_data;
             mesh_data.emplace_back(_vtx, _idx);
             mesh_data.back().DrawIndirect(_indirect_buffer, _count_buffer, _max_cnt, _stride);
@@ -1318,6 +1333,7 @@ public:
             RenderPassInfo pass_info(
                 {std::forward<TRenderTarget>(_render_targets)...}, DepthAttachment{}, _rect
             );
+            pass_info.view_mask = view_mask;
             Array<MeshDrawData> mesh_data;
             mesh_data.emplace_back(_vtx, _idx);
             mesh_data.back().DrawIndirect(_indirect_buffer, _count_buffer, _max_cnt, _stride);
@@ -1341,6 +1357,7 @@ public:
             TRenderTarget&&... _render_targets
         ) {
             RenderPassInfo      pass_info({std::forward<TRenderTarget>(_render_targets)...}, _depth, _rect);
+            pass_info.view_mask = view_mask;
             Array<MeshDrawData> mesh_data;
             mesh_data.emplace_back(_vtx, _vtx_cnt);
             mesh_data.back().DrawIndirect(_indirect_buffer, _count_buffer, _max_cnt, _stride);
@@ -1365,6 +1382,7 @@ public:
             RenderPassInfo pass_info(
                 {std::forward<TRenderTarget>(_render_targets)...}, DepthAttachment{}, _rect
             );
+            pass_info.view_mask = view_mask;
             Array<MeshDrawData> mesh_data;
             mesh_data.emplace_back(_vtx, _vtx_cnt);
             mesh_data.back().DrawIndirect(_indirect_buffer, _count_buffer, _max_cnt, _stride);
@@ -1388,6 +1406,7 @@ public:
             RenderPassInfo pass_info(
                 {std::forward<TRenderTarget>(_render_targets)...}, DepthAttachment{}, _rect
             );
+            pass_info.view_mask = view_mask;
             Array<MeshDrawData> mesh_data;
             mesh_data.emplace_back(_vtx, _vtx_cnt);
             mesh_data.back().DrawIndirect(_indirect_buffer, _count, _stride);
@@ -1410,6 +1429,7 @@ public:
             TRenderTarget&&... _render_targets
         ) {
             RenderPassInfo      pass_info({std::forward<TRenderTarget>(_render_targets)...}, _depth, _rect);
+            pass_info.view_mask = view_mask;
             Array<MeshDrawData> mesh_data;
             mesh_data.emplace_back(_vtx, _vtx_cnt);
             mesh_data.back().DrawIndirect(_indirect_buffer, _count, _stride);
@@ -1424,6 +1444,7 @@ public:
         ArrayArguments  args;
 
     private:
+        uint32_t        view_mask = 0;
         TCachedArgArray args_cache;
     };
 
@@ -1448,6 +1469,10 @@ public:
 
         MutiDrawDispatcher& AcceptDrawBatch(DrawBatch&& _draw_batch) {
             draw_batch = std::move(_draw_batch);
+            return *this;
+        }
+        MutiDrawDispatcher& SetViewMask(uint32_t mask) {
+            pass_info.view_mask = mask;
             return *this;
         }
         void Dispatch() {

--- a/source/runtime/render/rhi/RHIImpl.cpp
+++ b/source/runtime/render/rhi/RHIImpl.cpp
@@ -148,6 +148,10 @@ uint32_t RenderDevice::GetMaxTessellationFactor() const {
     return impl ? impl->GetMaxTessellationFactor() : 0;
 }
 
+bool RenderDevice::SupportsMultiview(uint32_t view_count) const {
+    return impl && impl->SupportsMultiview(view_count);
+}
+
 RaytracingGeometryRef RenderDevice::CreateRaytracingGeometry(const RaytracingGeometryInfo& _init) {
     return impl->CreateRaytracingGeometry(_init);
 }

--- a/source/runtime/render/rhi/RHIImpl.h
+++ b/source/runtime/render/rhi/RHIImpl.h
@@ -1965,8 +1965,10 @@ public:
         uint32_t           _array_size = 1,
         ETextureUsageFlags _usage      = ETextureUsageFlags::DEPTH_STENCIL_ATTACHMENT
     ) {
+        const ETextureDimension dimension =
+            _array_size > 1 ? ETextureDimension::TEX_2D_ARRAY : ETextureDimension::TEX_2D;
         return DepthBufferRef(MoerNew(DepthBuffer)(
-            CreateTexture(_name, ETextureDimension::TEX_2D, _size, _format, _usage, 1, _array_size)
+            CreateTexture(_name, dimension, _size, _format, _usage, 1, _array_size)
         ));
     }
 

--- a/source/runtime/render/rhi/RHIImpl.h
+++ b/source/runtime/render/rhi/RHIImpl.h
@@ -2018,6 +2018,10 @@ public:
         return 0;
     }
 
+    virtual bool SupportsMultiview(uint32_t) const {
+        return false;
+    }
+
     virtual bool IsExtensionCooperativeEnabled() const {
         return false;
     }

--- a/source/runtime/render/rhi/RHIMultiview.h
+++ b/source/runtime/render/rhi/RHIMultiview.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include <bit>
+#include <cstdint>
+
+namespace Moer::Render::Multiview {
+
+[[nodiscard]] constexpr uint32_t RequiredViewCount(uint32_t view_mask) noexcept {
+    return std::bit_width(view_mask);
+}
+
+[[nodiscard]] constexpr bool SupportsViewCount(
+    bool     feature_enabled,
+    uint32_t max_view_count,
+    uint32_t requested_view_count
+) noexcept {
+    return requested_view_count != 0u && feature_enabled &&
+           max_view_count >= requested_view_count;
+}
+
+[[nodiscard]] constexpr bool IsAttachmentRangeValid(
+    uint32_t base_layer,
+    uint32_t layer_count,
+    uint32_t texture_layer_count
+) noexcept {
+    return layer_count != 0u && base_layer <= texture_layer_count &&
+           layer_count <= texture_layer_count - base_layer;
+}
+
+[[nodiscard]] constexpr bool AttachmentCoversViewMask(
+    uint32_t layer_count,
+    uint32_t view_mask
+) noexcept {
+    return layer_count >= RequiredViewCount(view_mask);
+}
+
+[[nodiscard]] constexpr bool PipelineMatchesRenderPass(
+    uint32_t pipeline_view_mask,
+    uint32_t render_pass_view_mask
+) noexcept {
+    return pipeline_view_mask == render_pass_view_mask;
+}
+
+} // namespace Moer::Render::Multiview

--- a/source/runtime/render/rhi/RHIResource.h
+++ b/source/runtime/render/rhi/RHIResource.h
@@ -1271,6 +1271,11 @@ struct GfxPsoCreateInfo {
         return *this;
     }
 
+    GfxPsoCreateInfo& SetViewMask(uint32_t mask) {
+        view_mask = mask;
+        return *this;
+    }
+
     RHIRasterizeInfo         rasterizer_info;
     VertexStream             vertex_stream;
     RHIMultisampleStateInfo  multisample_info;
@@ -1287,6 +1292,10 @@ struct GfxPsoCreateInfo {
     uint32_t color_attachment_count;
 
     uint8_t multi_view_count = 1;
+
+    // Vulkan multiview view mask. This is intentionally independent from
+    // multi_view_count, which controls the number of dynamic viewports/scissors.
+    uint32_t view_mask = 0;
 
     //for VSR
     bool                b_has_fragment_density_attachments;
@@ -1356,12 +1365,14 @@ struct ColorAttachment {
     float4            clear_color = {0, 0, 0, 0};
     uint              mip_level   = 0;
     uint              array_layer = 0;
+    uint              array_count = 1;
 };
 
 // 聚合初始化会触发零初始化，但构造函数不会，所以必须设置默认值
 struct DepthAttachment {
     Texture*          target{nullptr};
     uint              array_layer   = 0;
+    uint              array_count   = 1;
     uint              mip_level     = 0;
     EAttachmentAction action        = AC_DS_CLEAR_STORE;
     float             clear_depth   = 0.f;
@@ -1374,6 +1385,7 @@ struct DepthAttachment {
     DepthAttachment(const TextureView& _view) :
         target(_view.GetTexture()),
         array_layer(_view.array_layer),
+        array_count(_view.num_array),
         mip_level(_view.mip_level) {}
 };
 
@@ -1382,6 +1394,7 @@ struct RenderPassInfo {
     DepthAttachment        depth_attachment;
     Rect2D                 render_area;
     uint                   viewport_cnt = 1;
+    uint32_t               view_mask    = 0;
 };
 
 struct SwapchainCreateInfo {

--- a/source/runtime/render/rhi/vulkan/RHICmdReorderer.h
+++ b/source/runtime/render/rhi/vulkan/RHICmdReorderer.h
@@ -1273,7 +1273,7 @@ public:
                 EmplaceArg(
                     (uint64)(depth.target),
                     ResourceType::Texture_Buffer,
-                    Range(depth.mip_level, 1, depth.array_layer, 1),
+                    Range(depth.mip_level, 1, depth.array_layer, depth.array_count),
                     false
                 );
             }
@@ -1281,7 +1281,7 @@ public:
                 EmplaceArg(
                     (uint64)(depth.target),
                     ResourceType::Texture_Buffer,
-                    Range(depth.mip_level, 1, depth.array_layer, 1),
+                    Range(depth.mip_level, 1, depth.array_layer, depth.array_count),
                     true
                 );
             }
@@ -1292,7 +1292,7 @@ public:
                 EmplaceArg(
                     (uint64)(target.target),
                     ResourceType::Texture_Buffer,
-                    Range(target.mip_level, 1, target.array_layer, 1),
+                    Range(target.mip_level, 1, target.array_layer, target.array_count),
                     false
                 );
             }
@@ -1300,7 +1300,7 @@ public:
                 EmplaceArg(
                     (uint64)(target.target),
                     ResourceType::Texture_Buffer,
-                    Range(target.mip_level, 1, target.array_layer, 1),
+                    Range(target.mip_level, 1, target.array_layer, target.array_count),
                     true
                 );
             }
@@ -1388,7 +1388,7 @@ public:
                 EmplaceArg(
                     (uint64)(depth.target),
                     ResourceType::Texture_Buffer,
-                    Range(depth.mip_level, 1, depth.array_layer, 1),
+                    Range(depth.mip_level, 1, depth.array_layer, depth.array_count),
                     false
                 );
             }
@@ -1396,7 +1396,7 @@ public:
                 EmplaceArg(
                     (uint64)(depth.target),
                     ResourceType::Texture_Buffer,
-                    Range(depth.mip_level, 1, depth.array_layer, 1),
+                    Range(depth.mip_level, 1, depth.array_layer, depth.array_count),
                     true
                 );
             }
@@ -1407,7 +1407,7 @@ public:
                 EmplaceArg(
                     (uint64)(target.target),
                     ResourceType::Texture_Buffer,
-                    Range(target.mip_level, 1, target.array_layer, 1),
+                    Range(target.mip_level, 1, target.array_layer, target.array_count),
                     false
                 );
             }
@@ -1415,7 +1415,7 @@ public:
                 EmplaceArg(
                     (uint64)(target.target),
                     ResourceType::Texture_Buffer,
-                    Range(target.mip_level, 1, target.array_layer, 1),
+                    Range(target.mip_level, 1, target.array_layer, target.array_count),
                     true
                 );
             }

--- a/source/runtime/render/rhi/vulkan/VulkanDevice.cpp
+++ b/source/runtime/render/rhi/vulkan/VulkanDevice.cpp
@@ -22,6 +22,7 @@
 #include "misc/STL.h"
 #include "rhi/RHICommand.h"
 #include "rhi/RHICommon.h"
+#include "rhi/RHIMultiview.h"
 #include "rhi/RHIThreadHeartbeat.h"
 #include "rhi/RHIResource.h"
 #include "rhi/RHIResourceInitilizer.h"
@@ -1930,6 +1931,19 @@ static void MergeReflectInfo(
 
 PipelineHandle
 VulkanDevice::CreatePipeline(GfxPsoCreateInfo&& _create_info, PipelineShaderInfo&& _shader_info) {
+    const uint32_t required_view_count = Multiview::RequiredViewCount(_create_info.view_mask);
+    if (_create_info.view_mask != 0 && !SupportsMultiview(required_view_count)) {
+        LOG_ERROR(
+            "Cannot create multiview graphics pipeline: view_mask=0x{:x} requires {} views, "
+            "but the selected device supports at most {} (feature enabled={}).",
+            _create_info.view_mask,
+            required_view_count,
+            m_device_info.core_properties.core_1_1.maxMultiviewViewCount,
+            m_device_info.core_features.core_1_1.multiview == VK_TRUE
+        );
+        return {};
+    }
+
     const bool uses_tessellation = std::holds_alternative<ShaderVsHsDsPs>(_shader_info.shader_group);
     if (uses_tessellation) {
         const uint32_t patch_control_points = _create_info.patch_control_points;
@@ -1966,7 +1980,7 @@ VulkanDevice::CreatePipeline(GfxPsoCreateInfo&& _create_info, PipelineShaderInfo
     }
     VkPipelineRenderingCreateInfo rendering_create_info{VK_STRUCTURE_TYPE_PIPELINE_RENDERING_CREATE_INFO};
     rendering_create_info.pNext                   = nullptr;
-    rendering_create_info.viewMask                = 0;
+    rendering_create_info.viewMask                = _create_info.view_mask;
     rendering_create_info.colorAttachmentCount    = attachment_count;
     rendering_create_info.pColorAttachmentFormats = color_attachment_formats.data();
     rendering_create_info.depthAttachmentFormat =
@@ -1981,6 +1995,7 @@ VulkanDevice::CreatePipeline(GfxPsoCreateInfo&& _create_info, PipelineShaderInfo
     bool stencil_enabled = _create_info.depth_stencil_info.b_enable_front_face_stencil ||
                            _create_info.depth_stencil_info.b_enable_back_face_stencil;
     vk_pso->b_uses_stencil_attachment = depth_has_stencil && stencil_enabled;
+    vk_pso->view_mask                 = _create_info.view_mask;
     rendering_create_info.stencilAttachmentFormat =
         vk_pso->b_uses_stencil_attachment ?
             VulkanEnumTranslator::METoVKFormat(_create_info.depth_stencil_format) :

--- a/source/runtime/render/rhi/vulkan/VulkanDevice.h
+++ b/source/runtime/render/rhi/vulkan/VulkanDevice.h
@@ -9,6 +9,7 @@
 #include "rhi/RHI.h"
 #include "rhi/RHICommand.h"
 #include "rhi/RHICommon.h"
+#include "rhi/RHIMultiview.h"
 #include "rhi/RHIResource.h"
 
 #include "VulkanCommand.h"
@@ -132,6 +133,14 @@ public:
         return SupportsTessellation() ?
                    m_device_info.core_properties.core_1_0.limits.maxTessellationGenerationLevel :
                    0;
+    }
+
+    bool SupportsMultiview(uint32_t view_count) const override {
+        return Multiview::SupportsViewCount(
+            m_device_info.core_features.core_1_1.multiview == VK_TRUE,
+            m_device_info.core_properties.core_1_1.maxMultiviewViewCount,
+            view_count
+        );
     }
 
     // Cooperative support related

--- a/source/runtime/render/rhi/vulkan/VulkanQueue.cpp
+++ b/source/runtime/render/rhi/vulkan/VulkanQueue.cpp
@@ -20,6 +20,7 @@
 #include "rhi/RHICommon.h"
 #include "rhi/RHIExecutorBackend.h"
 #include "rhi/RHIIO.h"
+#include "rhi/RHIMultiview.h"
 #include "rhi/RHIResource.h"
 #include "rhi/RHIThreadHeartbeat.h"
 
@@ -638,8 +639,11 @@ VkRenderingAttachmentInfo FromColorAttachmentInfo(const ColorAttachment& _attach
     attachment_info.pNext = nullptr;
 
     VulkanTexture* vk_texture = reinterpret_cast<VulkanTexture*>(_attachment.target);
-    attachment_info.imageView = vk_texture->GetView(
-        static_cast<uint8>(_attachment.mip_level), 1, static_cast<uint8>(_attachment.array_layer), 1
+    attachment_info.imageView = vk_texture->GetAttachmentView(
+        static_cast<uint8>(_attachment.mip_level),
+        1,
+        static_cast<uint8>(_attachment.array_layer),
+        static_cast<uint8>(_attachment.array_count)
     );
 
     attachment_info.imageLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
@@ -671,6 +675,86 @@ static bool PipelineUsesStencilAttachment(const PipelineHandle& pipeline) {
     return vk_pso->UsesStencilAttachment();
 }
 
+static uint32_t PipelineViewMask(const PipelineHandle& pipeline) {
+    if (!pipeline.IsValid()) {
+        return 0;
+    }
+
+    auto* vk_pso = reinterpret_cast<VulkanPipelineState*>(pipeline.handle);
+    return vk_pso->GetViewMask();
+}
+
+static void ValidateRenderPassMultiview(const RenderPassInfo& pass_info) {
+    const uint32_t required_view_count = Multiview::RequiredViewCount(pass_info.view_mask);
+    auto validate_attachment = [required_view_count, view_mask = pass_info.view_mask](
+                                   Texture* texture,
+                                   uint32_t mip_level,
+                                   uint32_t base_layer,
+                                   uint32_t layer_count,
+                                   std::string_view attachment_name
+                               ) {
+        if (texture == nullptr || mip_level >= texture->GetNumMips() ||
+            !Multiview::IsAttachmentRangeValid(
+                base_layer,
+                layer_count,
+                texture->GetNumArray()
+            )) {
+            LOG_ERROR(
+                "Invalid {} attachment subresource range: mip={}, base_layer={}, "
+                "layer_count={}, texture_mips={}, texture_layers={}.",
+                attachment_name,
+                mip_level,
+                base_layer,
+                layer_count,
+                texture ? texture->GetNumMips() : 0,
+                texture ? texture->GetNumArray() : 0
+            );
+            throw std::invalid_argument("render attachment subresource range is invalid");
+        }
+        if (!Multiview::AttachmentCoversViewMask(layer_count, view_mask)) {
+            LOG_ERROR(
+                "Multiview {} attachment exposes {} layers, but view_mask=0x{:x} requires at least {}.",
+                attachment_name,
+                layer_count,
+                view_mask,
+                required_view_count
+            );
+            throw std::invalid_argument("multiview attachment does not cover the view mask");
+        }
+    };
+
+    for (const ColorAttachment& attachment : pass_info.color_attachments) {
+        validate_attachment(
+            attachment.target,
+            attachment.mip_level,
+            attachment.array_layer,
+            attachment.array_count,
+            "color"
+        );
+    }
+    if (pass_info.depth_attachment.Valid()) {
+        validate_attachment(
+            pass_info.depth_attachment.target,
+            pass_info.depth_attachment.mip_level,
+            pass_info.depth_attachment.array_layer,
+            pass_info.depth_attachment.array_count,
+            "depth"
+        );
+    }
+}
+
+static void ValidatePipelineViewMask(const PipelineHandle& pipeline, const RenderPassInfo& pass_info) {
+    const uint32_t pipeline_view_mask = PipelineViewMask(pipeline);
+    if (!Multiview::PipelineMatchesRenderPass(pipeline_view_mask, pass_info.view_mask)) {
+        LOG_ERROR(
+            "Graphics pipeline view mask 0x{:x} does not match rendering view mask 0x{:x}.",
+            pipeline_view_mask,
+            pass_info.view_mask
+        );
+        throw std::logic_error("graphics pipeline and rendering view masks do not match");
+    }
+}
+
 static bool DrawBatchUsesStencilAttachment(const DrawBatch& draw_batch) {
     for (const DrawBatchElement& draw_cmd : draw_batch.draw_cmds) {
         if (PipelineUsesStencilAttachment(draw_cmd.handle)) {
@@ -687,8 +771,11 @@ VkRenderingAttachmentInfo FromDepthAttachmentInfo(const DepthAttachment& _attach
     attachment_info.pNext = nullptr;
 
     VulkanTexture* vk_texture = reinterpret_cast<VulkanTexture*>(_attachment.target);
-    attachment_info.imageView = vk_texture->GetView(
-        static_cast<uint8>(_attachment.mip_level), 1, static_cast<uint8>(_attachment.array_layer), 1
+    attachment_info.imageView = vk_texture->GetAttachmentView(
+        static_cast<uint8>(_attachment.mip_level),
+        1,
+        static_cast<uint8>(_attachment.array_layer),
+        static_cast<uint8>(_attachment.array_count)
     );
 
     bool has_stencil            = FormatHasStencil(_attachment.target->GetFormat());
@@ -1067,6 +1154,32 @@ struct VkCmdPreprocessor {
                 );
             }
         );
+    }
+
+    void RecordAttachmentState(
+        VulkanTexture*            _texture,
+        VkAccessFlagBits2         _access,
+        VkImageLayout             _layout,
+        VkPipelineStageFlagBits2  _stage,
+        uint32_t                  _mip_level,
+        uint32_t                  _base_layer,
+        uint32_t                  _layer_count
+    ) {
+        // Keep inferred attachment state mip/layer atomic. A layered multiview
+        // attachment may be consumed one face at a time later in the same
+        // submit; aggregate tracker keys cannot join that transition exactly.
+        for (uint32_t layer = 0; layer < _layer_count; ++layer) {
+            tracker.RecordState(
+                _texture,
+                _access,
+                _layout,
+                _stage,
+                static_cast<uint8>(_mip_level),
+                1,
+                static_cast<uint8>(_base_layer + layer),
+                1
+            );
+        }
     }
 
     void HandleBindless(BindlessArrayRef _bindless_array, VkPipelineStageFlagBits2 _pipeline_stages) {
@@ -1949,6 +2062,8 @@ struct VkCmdPreprocessor {
         }
     }
     void Visit(const SetDrawStateCmd* _cmd) {
+        ValidateRenderPassMultiview(_cmd->RenderPassInfo());
+        ValidatePipelineViewMask(_cmd->Pipeline(), _cmd->RenderPassInfo());
 
         const auto& vbs = _cmd->VertexBuffers();
         for (const auto& vb : vbs) {
@@ -2008,16 +2123,15 @@ struct VkCmdPreprocessor {
             auto  action     = rt.action;
             bool  b_load     = GetLoadOp(action) == EAttachmentLoadOp::LOAD;
             bool  b_store    = GetStoreOp(action) == EAttachmentStoreOp::STORE;
-            tracker.RecordState(
+            RecordAttachmentState(
                 vk_texture,
                 (b_load ? VK_ACCESS_2_COLOR_ATTACHMENT_READ_BIT : VK_ACCESS_2_NONE) |
                     (b_store ? VK_ACCESS_2_COLOR_ATTACHMENT_WRITE_BIT : VK_ACCESS_2_NONE),
                 VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
                 VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT,
-                static_cast<uint8>(rt.mip_level),
-                1,
-                static_cast<uint8>(rt.array_layer),
-                1
+                rt.mip_level,
+                rt.array_layer,
+                rt.array_count
             );
         }
         if (_cmd->RenderPassInfo().depth_attachment.Valid()) {
@@ -2029,21 +2143,25 @@ struct VkCmdPreprocessor {
             bool  b_stencil_store = GetStoreOp(GetStencilAction(action)) == EAttachmentStoreOp::STORE;
             bool  b_read          = b_depth_load || b_stencil_load;
             bool  b_write         = b_depth_store || b_stencil_store;
-            tracker.RecordState(
+            RecordAttachmentState(
                 vk_texture,
                 (b_read ? VK_ACCESS_2_DEPTH_STENCIL_ATTACHMENT_READ_BIT : VK_ACCESS_2_NONE) |
                     (b_write ? VK_ACCESS_2_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT : VK_ACCESS_2_NONE),
                 VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL,
                 VK_PIPELINE_STAGE_2_EARLY_FRAGMENT_TESTS_BIT | VK_PIPELINE_STAGE_2_LATE_FRAGMENT_TESTS_BIT,
-                static_cast<uint8>(_cmd->RenderPassInfo().depth_attachment.mip_level),
-                1,
-                static_cast<uint8>(_cmd->RenderPassInfo().depth_attachment.array_layer),
-                1
+                _cmd->RenderPassInfo().depth_attachment.mip_level,
+                _cmd->RenderPassInfo().depth_attachment.array_layer,
+                _cmd->RenderPassInfo().depth_attachment.array_count
             );
         }
     }
 
     void Visit(const MultiDrawCmd* _cmd) {
+        ValidateRenderPassMultiview(_cmd->RenderPassInfo());
+        for (const DrawBatchElement& draw_cmd : _cmd->draw_batch.draw_cmds) {
+            ValidatePipelineViewMask(draw_cmd.handle, _cmd->RenderPassInfo());
+        }
+
         const auto& vbs = _cmd->VertexBuffers();
         for (const auto& vb : vbs) {
             auto* vk_buffer = ResourceCast(vb.first);
@@ -2104,16 +2222,15 @@ struct VkCmdPreprocessor {
             auto  action     = rt.action;
             bool  b_load     = GetLoadOp(action) == EAttachmentLoadOp::LOAD;
             bool  b_store    = GetStoreOp(action) == EAttachmentStoreOp::STORE;
-            tracker.RecordState(
+            RecordAttachmentState(
                 vk_texture,
                 (b_load ? VK_ACCESS_2_COLOR_ATTACHMENT_READ_BIT : VK_ACCESS_2_NONE) |
                     (b_store ? VK_ACCESS_2_COLOR_ATTACHMENT_WRITE_BIT : VK_ACCESS_2_NONE),
                 VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
                 VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT,
-                static_cast<uint8>(rt.mip_level),
-                1,
-                static_cast<uint8>(rt.array_layer),
-                1
+                rt.mip_level,
+                rt.array_layer,
+                rt.array_count
             );
         }
         if (_cmd->RenderPassInfo().depth_attachment.Valid()) {
@@ -2125,16 +2242,15 @@ struct VkCmdPreprocessor {
             bool  b_stencil_store = GetStoreOp(GetStencilAction(action)) == EAttachmentStoreOp::STORE;
             bool  b_read          = b_depth_load || b_stencil_load;
             bool  b_write         = b_depth_store || b_stencil_store;
-            tracker.RecordState(
+            RecordAttachmentState(
                 vk_texture,
                 (b_read ? VK_ACCESS_2_DEPTH_STENCIL_ATTACHMENT_READ_BIT : VK_ACCESS_2_NONE) |
                     (b_write ? VK_ACCESS_2_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT : VK_ACCESS_2_NONE),
                 VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL,
                 VK_PIPELINE_STAGE_2_EARLY_FRAGMENT_TESTS_BIT | VK_PIPELINE_STAGE_2_LATE_FRAGMENT_TESTS_BIT,
-                static_cast<uint8>(_cmd->RenderPassInfo().depth_attachment.mip_level),
-                1,
-                static_cast<uint8>(_cmd->RenderPassInfo().depth_attachment.array_layer),
-                1
+                _cmd->RenderPassInfo().depth_attachment.mip_level,
+                _cmd->RenderPassInfo().depth_attachment.array_layer,
+                _cmd->RenderPassInfo().depth_attachment.array_count
             );
         }
     }
@@ -2700,6 +2816,9 @@ public:
 
     void Visit(const SetDrawStateCmd& _cmd) {
 
+        ValidateRenderPassMultiview(_cmd.RenderPassInfo());
+        ValidatePipelineViewMask(_cmd.Pipeline(), _cmd.RenderPassInfo());
+
         static float4 draw_color = {0.0f, 1.0f, 0.0f, 1.0f};
         cmd_list.BeginLabel(_cmd.name, draw_color);
         state = EState::Draw;
@@ -2746,6 +2865,7 @@ public:
                 {.offset = {pass_info.render_area.offset.x, pass_info.render_area.offset.y},
                  .extent = {pass_info.render_area.extent.width, pass_info.render_area.extent.height}},
             .layerCount           = 1,
+            .viewMask             = pass_info.view_mask,
             .colorAttachmentCount = uint(pass_info.color_attachments.size()),
             .pColorAttachments    = color_attachments.data(),
             .pDepthAttachment =
@@ -2902,6 +3022,11 @@ public:
     }
 
     void Visit(const MultiDrawCmd& _cmd) {
+        ValidateRenderPassMultiview(_cmd.RenderPassInfo());
+        for (const DrawBatchElement& draw_cmd : _cmd.draw_batch.draw_cmds) {
+            ValidatePipelineViewMask(draw_cmd.handle, _cmd.RenderPassInfo());
+        }
+
         static float4 draw_color = {0.0f, 1.0f, 0.0f, 1.0f};
         cmd_list.BeginLabel(_cmd.name, draw_color);
         state = EState::Draw;
@@ -2927,6 +3052,7 @@ public:
                 {.offset = {pass_info.render_area.offset.x, pass_info.render_area.offset.y},
                  .extent = {pass_info.render_area.extent.width, pass_info.render_area.extent.height}},
             .layerCount           = 1,
+            .viewMask             = pass_info.view_mask,
             .colorAttachmentCount = uint(pass_info.color_attachments.size()),
             .pColorAttachments    = color_attachments.data(),
             .pDepthAttachment =

--- a/source/runtime/render/rhi/vulkan/VulkanRHIResource.cpp
+++ b/source/runtime/render/rhi/vulkan/VulkanRHIResource.cpp
@@ -1722,6 +1722,48 @@ VkAccessFlags2 VulkanEnumTranslator::METoVkAccessFlags2(ERHIAccessFlags _flags) 
         return view;
     }
 
+    VkImageView VulkanTexture::GetAttachmentView(
+        uint _mip_level,
+        uint _mip_cnt,
+        uint _base_layer,
+        uint _layer_cnt
+    ) {
+        if (GetDimension() != ETextureDimension::TEX_CUBE &&
+            GetDimension() != ETextureDimension::TEX_CUBE_ARRAY) {
+            return GetView(_mip_level, _mip_cnt, _base_layer, _layer_cnt);
+        }
+
+        std::lock_guard<std::mutex> lock(m_views_mutex);
+        const uint64 key = EncodeViewKey(_mip_level, _mip_cnt, _base_layer, _layer_cnt);
+        const auto   it  = m_attachment_views.find(key);
+        if (it != m_attachment_views.end()) {
+            return it->second;
+        }
+
+        VkImageViewCreateInfo view_create_info{VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO};
+        view_create_info.image = m_alloc.image;
+        view_create_info.viewType =
+            _layer_cnt == 1 ? VK_IMAGE_VIEW_TYPE_2D : VK_IMAGE_VIEW_TYPE_2D_ARRAY;
+        view_create_info.format = VulkanEnumTranslator::METoVKFormat(GetFormat());
+        view_create_info.components = {
+            VK_COMPONENT_SWIZZLE_IDENTITY,
+            VK_COMPONENT_SWIZZLE_IDENTITY,
+            VK_COMPONENT_SWIZZLE_IDENTITY,
+            VK_COMPONENT_SWIZZLE_IDENTITY
+        };
+        view_create_info.subresourceRange.aspectMask =
+            VulkanEnumTranslator::METoVKImageAspectFlags(GetAspectFlags());
+        view_create_info.subresourceRange.baseMipLevel   = _mip_level;
+        view_create_info.subresourceRange.levelCount     = _mip_cnt;
+        view_create_info.subresourceRange.baseArrayLayer = _base_layer;
+        view_create_info.subresourceRange.layerCount     = _layer_cnt;
+
+        VkImageView view = VK_NULL_HANDLE;
+        VK_CHECK_RESULT(vkCreateImageView(m_device->GetDevice(), &view_create_info, nullptr, &view));
+        m_attachment_views.emplace(key, view);
+        return view;
+    }
+
     uint VulkanTexture::GetMipByteSize(uint _mip_level) const {
         uint mip_width  = std::max(1u, GetWidth() >> _mip_level);
         uint mip_height = std::max(1u, GetHeight() >> _mip_level);
@@ -4258,6 +4300,10 @@ VkAccessFlags2 VulkanEnumTranslator::METoVkAccessFlags2(ERHIAccessFlags _flags) 
                 vkDestroyImageView(m_device->GetDevice(), view, VK_NULL_HANDLE);
             }
             m_views.clear();
+            for (auto& [key, view] : m_attachment_views) {
+                vkDestroyImageView(m_device->GetDevice(), view, VK_NULL_HANDLE);
+            }
+            m_attachment_views.clear();
         }
         if (m_alloc.image != VK_NULL_HANDLE && m_alloc.alloc != VK_NULL_HANDLE) { vmaDestroyImage(m_device->GetVmaAllocator(), m_alloc.image, m_alloc.alloc); }
         //free descriptors

--- a/source/runtime/render/rhi/vulkan/VulkanRHIResource.cpp
+++ b/source/runtime/render/rhi/vulkan/VulkanRHIResource.cpp
@@ -1728,8 +1728,10 @@ VkAccessFlags2 VulkanEnumTranslator::METoVkAccessFlags2(ERHIAccessFlags _flags) 
         uint _base_layer,
         uint _layer_cnt
     ) {
-        if (GetDimension() != ETextureDimension::TEX_CUBE &&
-            GetDimension() != ETextureDimension::TEX_CUBE_ARRAY) {
+        const bool requires_attachment_view =
+            _layer_cnt > 1 || GetDimension() == ETextureDimension::TEX_CUBE ||
+            GetDimension() == ETextureDimension::TEX_CUBE_ARRAY;
+        if (!requires_attachment_view) {
             return GetView(_mip_level, _mip_cnt, _base_layer, _layer_cnt);
         }
 

--- a/source/runtime/render/rhi/vulkan/VulkanRHIResource.h
+++ b/source/runtime/render/rhi/vulkan/VulkanRHIResource.h
@@ -532,6 +532,10 @@ public:
         return b_uses_stencil_attachment;
     }
 
+    uint32_t GetViewMask() const {
+        return view_mask;
+    }
+
     void InitDescriptorSetLayouts(
         Moer::Array<Moer::Render::TDescriptorSetLayoutBindingArray>& _descriptor_bindings
     );
@@ -565,6 +569,7 @@ protected:
     Moer::Render::VulkanDescriptorSetsLayout* m_descriptor_sets_layout = nullptr;
     EType                                     m_type;
     bool                                      b_uses_stencil_attachment = false;
+    uint32_t                                  view_mask                 = 0;
 };
 
 #pragma endregion
@@ -721,6 +726,12 @@ public:
         uint _base_layer = 0,
         uint _layer_cnt  = VK_REMAINING_ARRAY_LAYERS
     );
+    VkImageView GetAttachmentView(
+        uint _mip_level  = 0,
+        uint _mip_cnt    = 1,
+        uint _base_layer = 0,
+        uint _layer_cnt  = 1
+    );
 
     void          SetName(const std::string_view _name) override;
     bool          b_has_preferred_state : 1 = false;
@@ -786,6 +797,7 @@ private:
         VmaAllocation alloc;
     } m_alloc;
     UnorderedMap<uint64, VkImageView> m_views;
+    UnorderedMap<uint64, VkImageView> m_attachment_views;
     mutable std::mutex                m_views_mutex;
     VkImageLayout                     m_preferred_layout = VK_IMAGE_LAYOUT_GENERAL;
     std::atomic_bool                  presentation_source_ready{false};

--- a/source/runtime/render/rhi/vulkan/VulkanSerialGolden.cpp
+++ b/source/runtime/render/rhi/vulkan/VulkanSerialGolden.cpp
@@ -347,12 +347,14 @@ struct VulkanSerialGoldenTrace::Impl {
             AddFloat(_hash, attachment.clear_color.w);
             _hash.Add(attachment.mip_level);
             _hash.Add(attachment.array_layer);
+            _hash.Add(attachment.array_count);
         }
         const DepthAttachment& depth = _pass.depth_attachment;
         _hash.Add(depth.Valid() ? 1u : 0u);
         if (depth.Valid()) {
             _resources.push_back(RegisterTexture(depth.target));
             _hash.Add(depth.array_layer);
+            _hash.Add(depth.array_count);
             _hash.Add(depth.mip_level);
             _hash.Add(static_cast<uint64_t>(depth.action));
             AddFloat(_hash, depth.clear_depth);
@@ -363,6 +365,7 @@ struct VulkanSerialGoldenTrace::Impl {
         _hash.Add(_pass.render_area.extent.width);
         _hash.Add(_pass.render_area.extent.height);
         _hash.Add(_pass.viewport_cnt);
+        _hash.Add(_pass.view_mask);
     }
 
     void HashIndirect(

--- a/source/runtime/render/shaderheaders/shared/raster/geometry_pass/ShaderParameters.h
+++ b/source/runtime/render/shaderheaders/shared/raster/geometry_pass/ShaderParameters.h
@@ -45,6 +45,16 @@ struct GeometryPassBindlessParam {
     uint  debug_visualization_mode;
 };
 
+// Six transposed world-to-clip matrices used by Vulkan point-shadow multiview.
+// Matrices have a 64-byte stride in both C++ and HLSL constant-buffer layouts.
+struct PointShadowViewMatrices {
+    float4x4 world2clip[6];
+};
+
+#ifdef __cplusplus
+static_assert(sizeof(PointShadowViewMatrices) == sizeof(float4x4) * 6);
+#endif
+
 // MARK: Main Content End
 
 #ifdef __cplusplus

--- a/source/test/CMakeLists.txt
+++ b/source/test/CMakeLists.txt
@@ -320,6 +320,17 @@ target_link_libraries(${test_target}
 set_target_properties(${test_target} PROPERTIES FOLDER ${moer_test_folder})
 add_test(NAME RHIExplicitBarrierContract COMMAND $<TARGET_FILE:${test_target}>)
 
+# CPU-only contract for Vulkan-style multiview masks and attachment layer
+# coverage. The Vulkan integration test below owns the real GPU draw/readback.
+set(test_target TestRHIMultiviewContract)
+add_executable(${test_target} "RHIMultiviewContractTest.cpp")
+target_link_libraries(${test_target}
+    PRIVATE Moer::Render
+)
+set_target_properties(${test_target} PROPERTIES FOLDER ${moer_test_folder})
+add_test(NAME RHIMultiviewContract COMMAND $<TARGET_FILE:${test_target}>)
+set_tests_properties(RHIMultiviewContract PROPERTIES TIMEOUT 60)
+
 set(test_target TestRHICommandMarker)
 add_executable(${test_target} "RHICommandMarkerTest.cpp")
 target_link_libraries(${test_target}

--- a/source/test/RHICmdReordererTest.cpp
+++ b/source/test/RHICmdReordererTest.cpp
@@ -1111,6 +1111,67 @@ void ResourceImportExactHistorySurvivesReadWriteAndTwoDimensionalCompression() {
     );
 }
 
+void MultiviewAttachmentsPublishEveryLayerWrite() {
+    TCachedArgArray cached_args;
+    CmdReorderer   reorderer(MakeFunctionTable(), cached_args);
+
+    TestTexture draw_color(8);
+    RenderPassInfo draw_pass{};
+    draw_pass.color_attachments.emplace_back(ColorAttachment{
+        .target      = &draw_color,
+        .action      = AC_CLEAR_STORE,
+        .mip_level   = 0,
+        .array_layer = 1,
+        .array_count = 6,
+    });
+
+    PipelineHandle      pipeline{};
+    ArrayArguments      args{};
+    Array<MeshDrawData> meshes{};
+    SetDrawStateCmd     draw(
+        pipeline, std::move(args), std::move(draw_pass), std::move(meshes), "MultiviewSetDraw"
+    );
+    reorderer.AcceptCmd(&draw);
+
+    auto* draw_color_handle = reorderer.GetHandle(
+        uint64(&draw_color), CmdReorderer::ResourceType::Texture_Buffer
+    );
+    Expect(
+        reorderer.SetRead(draw_color_handle, CmdReorderer::Range(0, 1, 6, 1)) == 1,
+        "set-draw attachment did not publish the last multiview layer write"
+    );
+    Expect(
+        reorderer.SetRead(draw_color_handle, CmdReorderer::Range(0, 1, 7, 1)) == 0,
+        "set-draw attachment published a write outside its layer range"
+    );
+
+    TestTexture multi_draw_depth(8);
+    RenderPassInfo multi_draw_pass{};
+    multi_draw_pass.depth_attachment.target       = &multi_draw_depth;
+    multi_draw_pass.depth_attachment.action       = AC_DS_CLEAR_STORE;
+    multi_draw_pass.depth_attachment.mip_level    = 0;
+    multi_draw_pass.depth_attachment.array_layer  = 1;
+    multi_draw_pass.depth_attachment.array_count  = 6;
+
+    DrawBatch    batch{};
+    MultiDrawCmd multi_draw(
+        std::move(batch), std::move(multi_draw_pass), "MultiviewMultiDraw"
+    );
+    reorderer.AcceptCmd(&multi_draw);
+
+    auto* multi_draw_depth_handle = reorderer.GetHandle(
+        uint64(&multi_draw_depth), CmdReorderer::ResourceType::Texture_Buffer
+    );
+    Expect(
+        reorderer.SetRead(multi_draw_depth_handle, CmdReorderer::Range(0, 1, 6, 1)) == 1,
+        "multi-draw attachment did not publish the last multiview layer write"
+    );
+    Expect(
+        reorderer.SetRead(multi_draw_depth_handle, CmdReorderer::Range(0, 1, 7, 1)) == 0,
+        "multi-draw attachment published a write outside its layer range"
+    );
+}
+
 void CommandResourcePreprocessingIsTaskGraphIndependent() {
     std::exception_ptr worker_error;
     std::jthread worker([&] {
@@ -1260,6 +1321,7 @@ int main() {
         QueueTransferWritesFeedBindlessAliasOrderingWithoutExactPollution();
         ExactImportHistoryIsBoundedAndMergesDuplicateRanges();
         ResourceImportExactHistorySurvivesReadWriteAndTwoDimensionalCompression();
+        MultiviewAttachmentsPublishEveryLayerWrite();
         CommandResourcePreprocessingIsTaskGraphIndependent();
         std::cout << "RHI command reorderer tests passed\n";
         return 0;

--- a/source/test/RHIMultiviewContractTest.cpp
+++ b/source/test/RHIMultiviewContractTest.cpp
@@ -1,0 +1,88 @@
+#include "rhi/RHIMultiview.h"
+#include "rhi/RHIResource.h"
+
+#include <iostream>
+#include <stdexcept>
+
+using namespace Moer::Render;
+
+namespace {
+
+void Expect(bool condition, const char* message) {
+    if (!condition) {
+        throw std::runtime_error(message);
+    }
+}
+
+void ViewMaskShapeIsExplicit() {
+    Expect(Multiview::RequiredViewCount(0u) == 0u, "zero mask requires a view");
+    Expect(Multiview::RequiredViewCount(0x3fu) == 6u, "cube mask does not require six views");
+    Expect(Multiview::RequiredViewCount(0x40u) == 7u, "highest set bit was not preserved");
+    Expect(Multiview::RequiredViewCount(0x21u) == 6u, "sparse view mask was treated as popcount");
+}
+
+void CapabilityFailsClosed() {
+    Expect(!Multiview::SupportsViewCount(false, 32u, 6u), "disabled feature was accepted");
+    Expect(!Multiview::SupportsViewCount(true, 5u, 6u), "undersized view limit was accepted");
+    Expect(Multiview::SupportsViewCount(true, 6u, 6u), "six-view capability was rejected");
+    Expect(!Multiview::SupportsViewCount(true, 6u, 0u), "zero-view request was accepted");
+}
+
+void AttachmentCoverageUsesViewRelativeLayers() {
+    Expect(Multiview::IsAttachmentRangeValid(0u, 6u, 6u), "whole cube range was rejected");
+    Expect(Multiview::IsAttachmentRangeValid(1u, 6u, 7u), "nonzero base range was rejected");
+    Expect(!Multiview::IsAttachmentRangeValid(2u, 6u, 7u), "out-of-bounds range was accepted");
+    Expect(!Multiview::IsAttachmentRangeValid(0u, 0u, 6u), "empty range was accepted");
+
+    Expect(Multiview::AttachmentCoversViewMask(6u, 0x3fu), "six layers do not cover cube mask");
+    Expect(!Multiview::AttachmentCoversViewMask(5u, 0x3fu), "five layers cover cube mask");
+    Expect(Multiview::AttachmentCoversViewMask(6u, 0x21u), "sparse mask coverage is incorrect");
+    Expect(!Multiview::AttachmentCoversViewMask(5u, 0x21u), "sparse mask ignored its highest view");
+}
+
+void RhiPayloadCarriesIndependentMasksAndRanges() {
+    GfxPsoCreateInfo pipeline_info(RHIRasterizeInfo::Preset(), {}, {});
+    pipeline_info.SetViewMask(0x3fu);
+    Expect(pipeline_info.view_mask == 0x3fu, "pipeline view mask was not stored");
+    Expect(pipeline_info.multi_view_count == 1u, "view mask changed viewport count");
+
+    TextureView depth_view{};
+    depth_view.texture     = nullptr;
+    depth_view.mip_level   = 2u;
+    depth_view.array_layer = 1u;
+    depth_view.num_array   = 6u;
+    const DepthAttachment depth_attachment(depth_view);
+    Expect(
+        depth_attachment.mip_level == 2u && depth_attachment.array_layer == 1u &&
+            depth_attachment.array_count == 6u,
+        "depth attachment dropped its texture-view range"
+    );
+
+    RenderPassInfo pass_info{};
+    pass_info.view_mask = 0x3fu;
+    Expect(
+        Multiview::PipelineMatchesRenderPass(pipeline_info.view_mask, pass_info.view_mask),
+        "matching pipeline and render-pass masks were rejected"
+    );
+    pass_info.view_mask = 0x1u;
+    Expect(
+        !Multiview::PipelineMatchesRenderPass(pipeline_info.view_mask, pass_info.view_mask),
+        "pipeline/render-pass mismatch was accepted"
+    );
+}
+
+} // namespace
+
+int main() {
+    try {
+        ViewMaskShapeIsExplicit();
+        CapabilityFailsClosed();
+        AttachmentCoverageUsesViewRelativeLayers();
+        RhiPayloadCarriesIndependentMasksAndRanges();
+        std::cout << "RHIMultiviewContract: all checks passed\n";
+        return 0;
+    } catch (const std::exception& error) {
+        std::cerr << "RHIMultiviewContract: " << error.what() << '\n';
+        return 1;
+    }
+}

--- a/source/test/RHIParallelRecordVulkanTest.cpp
+++ b/source/test/RHIParallelRecordVulkanTest.cpp
@@ -15895,14 +15895,16 @@ void RunMultiviewCubeAttachmentDraw(ShaderManager& shader_manager) {
     if (!cube.IsValid() || cube->GetNumArray() != view_count) {
         throw std::runtime_error("multiview cube attachment creation failed");
     }
-    TextureRef depth_cube = device.CreateCubeMap(
-        "multiview_depth_cube_attachment",
+    DepthBufferRef depth_array = device.CreateDepthBuffer(
+        "multiview_depth_array_attachment",
         Extent2D(width, height),
         PF_D32_SFLOAT,
+        view_count,
         ETextureUsageFlags::DEPTH_STENCIL_ATTACHMENT
     );
-    if (!depth_cube.IsValid() || depth_cube->GetNumArray() != view_count) {
-        throw std::runtime_error("multiview depth cube attachment creation failed");
+    if (!depth_array.IsValid() || depth_array->GetNumArray() != view_count ||
+        depth_array->GetDimension() != ETextureDimension::TEX_2D_ARRAY) {
+        throw std::runtime_error("multiview depth array attachment creation failed");
     }
 
     CommandList draw_commands(EQueueType::Graphics);
@@ -15912,7 +15914,7 @@ void RunMultiviewCubeAttachmentDraw(ShaderManager& shader_manager) {
         "MultiviewCubeAttachmentDraw",
         Rect2D(0, 0, width, height),
         Array<SingleDrawParam>{SingleDrawParam{3, 1, 0, 0, 0}},
-        DepthAttachment(depth_cube->GetView(0, 1).Slice(0, view_count)),
+        DepthAttachment(depth_array->GetView().Slice(0, view_count)),
         ColorAttachment{
             .target      = cube.Get(),
             .action      = AC_CLEAR_STORE,

--- a/source/test/RHIParallelRecordVulkanTest.cpp
+++ b/source/test/RHIParallelRecordVulkanTest.cpp
@@ -17,6 +17,7 @@
 #include "rhi/vulkan/VulkanRHIResource.h"
 #include "rhi/vulkan/VulkanSubmissionDiagnostics.h"
 #include "renderer/raytracing/RaytracingExportSubmission.h"
+#include "shader/ShaderResourceManager.h"
 #include "taskgraph/TaskSystem.h"
 
 #include <algorithm>
@@ -51,6 +52,12 @@ constexpr size_t kElementCount = 64;
 constexpr uint32 kIterations   = 24;
 constexpr uint32 kHeavyCopiesPerWave = 48;
 constexpr uint32 kHeavyCopyCount = kHeavyCopiesPerWave * 2;
+
+class MultiviewLayerPipeline final : public RasterPipeline {
+public:
+    DEFINE_RASTER_PIPELINE_CLASS(MultiviewLayerPipeline);
+    DEFINE_SHADER_ARGS();
+};
 
 bool IsExpectedZeroOcclusionResult(
     const OcclusionQueryResult* _result,
@@ -1556,7 +1563,8 @@ void ValidateArguments(int _argc, const char** _argv) {
             argument != "--timestamp-query-success-batch" &&
             argument != "--timestamp-query-mid-failure" &&
             argument != "--timestamp-query-record-failure" &&
-            argument != "--gpu-scope-stream") {
+            argument != "--gpu-scope-stream" &&
+            argument != "--multiview") {
             throw std::invalid_argument("unsupported argument: " + std::string(argument));
         }
     }
@@ -15846,6 +15854,126 @@ void RunTimestampQuerySerialRecordFailure() {
     );
 }
 
+void RunMultiviewCubeAttachmentDraw(ShaderManager& shader_manager) {
+    auto& device = RenderDevice::Get();
+    constexpr uint32 view_count = 6u;
+    constexpr uint32 view_mask  = 0x3fu;
+    constexpr uint32 width      = 8u;
+    constexpr uint32 height     = 8u;
+
+    GfxPsoCreateInfo pipeline_info(
+        RHIRasterizeInfo::Preset(),
+        {},
+        {RHIColorAttachmentInfo::Preset(PF_R8G8B8A8_UNORM)},
+        RHIDepthStencilStateInfo::Preset<DepthStencil::DEPTH_WRITE_GREATER>(),
+        PF_D32_SFLOAT
+    );
+    pipeline_info.SetViewMask(view_mask);
+    MultiviewLayerPipeline pipeline = shader_manager.Raster()
+                                              .Vertex(
+                                                  "test/MultiviewLayer.hlsl",
+                                                  "MultiviewVS"
+                                              )
+                                              .Pixel(
+                                                  "test/MultiviewLayer.hlsl",
+                                                  "MultiviewPS"
+                                              )
+                                              .Build<MultiviewLayerPipeline>(
+                                                  std::move(pipeline_info)
+                                              );
+    if (!pipeline.handle.IsValid()) {
+        throw std::runtime_error("multiview test pipeline creation failed");
+    }
+
+    TextureRef cube = device.CreateCubeMap(
+        "multiview_cube_attachment",
+        Extent2D(width, height),
+        PF_R8G8B8A8_UNORM,
+        ETextureUsageFlags::COLOR_ATTACHMENT |
+            ETextureUsageFlags::TRANSFER_SRC
+    );
+    if (!cube.IsValid() || cube->GetNumArray() != view_count) {
+        throw std::runtime_error("multiview cube attachment creation failed");
+    }
+    TextureRef depth_cube = device.CreateCubeMap(
+        "multiview_depth_cube_attachment",
+        Extent2D(width, height),
+        PF_D32_SFLOAT,
+        ETextureUsageFlags::DEPTH_STENCIL_ATTACHMENT
+    );
+    if (!depth_cube.IsValid() || depth_cube->GetNumArray() != view_count) {
+        throw std::runtime_error("multiview depth cube attachment creation failed");
+    }
+
+    CommandList draw_commands(EQueueType::Graphics);
+    auto        draw = draw_commands.Gfx(pipeline);
+    draw.SetViewMask(view_mask);
+    draw.Draw(
+        "MultiviewCubeAttachmentDraw",
+        Rect2D(0, 0, width, height),
+        Array<SingleDrawParam>{SingleDrawParam{3, 1, 0, 0, 0}},
+        DepthAttachment(depth_cube->GetView(0, 1).Slice(0, view_count)),
+        ColorAttachment{
+            .target      = cube.Get(),
+            .action      = AC_CLEAR_STORE,
+            .clear_color = float4(0.0f, 0.0f, 0.0f, 1.0f),
+            .mip_level   = 0u,
+            .array_layer = 0u,
+            .array_count = view_count,
+        }
+    );
+    Array<ReadbackFuture> readbacks;
+    readbacks.reserve(view_count);
+    for (uint32 layer = 0; layer < view_count; ++layer) {
+        readbacks.emplace_back(draw_commands.Readback(
+            cube->GetView(0, 1).Slice(layer, 1),
+            std::format("MultiviewCubeLayer{}", layer)
+        ));
+        if (!readbacks.back().Valid()) {
+            throw std::runtime_error("multiview layer readback was rejected");
+        }
+    }
+    RHIExecutor::Get().Submit(
+        EQueueType::Graphics,
+        draw_commands.Submit(),
+        ERHIExecSubmitFlags::FlushGPU
+    );
+
+    constexpr std::array<uint32, view_count> expected_colors{
+        0xff0000ffu,
+        0xff00ff00u,
+        0xffff0000u,
+        0xff00ffffu,
+        0xffff00ffu,
+        0xffffff00u,
+    };
+    for (uint32 layer = 0; layer < view_count; ++layer) {
+        const ReadbackResult result = readbacks[layer].Get();
+        const auto            pixels = result.CopyAs<uint32>();
+        if (result.status != ReadbackStatus::Ready || !pixels.has_value() ||
+            pixels->size() != width * height ||
+            !std::all_of(
+                pixels->begin(),
+                pixels->end(),
+                [expected = expected_colors[layer]](uint32 pixel) {
+                    return pixel == expected;
+                }
+            )) {
+            throw std::runtime_error(
+                std::format("multiview cube layer {} readback mismatch", layer)
+            );
+        }
+    }
+
+    LOG_INFO(
+        "[TESTCASE][PASS] name=MultiviewCubeAttachment "
+        "views={} view_mask=0x{:x} color_view=2d_array depth_view=2d_array "
+        "draws=1 layers=readback_verified",
+        view_count,
+        view_mask
+    );
+}
+
 void RunOwningReadbackFuture() {
     auto& device = RenderDevice::Get();
     constexpr size_t buffer_element_count = 16;
@@ -16234,8 +16362,9 @@ void RunOwningReadbackFuture() {
 } // namespace
 
 int main(int argc, const char** argv) {
-    bool task_system_initialized = false;
+    bool task_system_initialized    = false;
     bool render_device_initialized = false;
+    bool shader_manager_initialized = false;
     try {
         ValidateArguments(argc, argv);
         const bool parallel = HasArgument(argc, argv, "--parallel");
@@ -16296,6 +16425,8 @@ int main(int argc, const char** argv) {
             );
         const bool gpu_scope_stream_mode =
             HasArgument(argc, argv, "--gpu-scope-stream");
+        const bool multiview_mode =
+            HasArgument(argc, argv, "--multiview");
         const uint32 submission_batch_window =
             pipeline_window1 ? 1u : 2u;
 
@@ -16336,6 +16467,26 @@ int main(int argc, const char** argv) {
             .parallel_record_worker_throw_trigger = inject_worker_failure ? 1u : 0u,
         });
         render_device_initialized = true;
+
+        if (multiview_mode) {
+            if (RenderDevice::Get().SupportsMultiview(6u)) {
+                ShaderManager& shader_manager = ShaderManager::Get();
+                shader_manager_initialized = true;
+                RunMultiviewCubeAttachmentDraw(shader_manager);
+                ShaderManager::ShutDown();
+                shader_manager_initialized = false;
+            } else {
+                LOG_INFO(
+                    "[TESTCASE][SKIP] name=MultiviewCubeAttachment "
+                    "reason=device_does_not_support_six_views"
+                );
+            }
+            RenderDevice::Dispose();
+            render_device_initialized = false;
+            TaskSystem::ShutDown();
+            task_system_initialized = false;
+            return 0;
+        }
 
         if (present_legacy_owner) {
             RunLegacyDirectPresentOwnerBoundary();
@@ -16545,6 +16696,9 @@ int main(int argc, const char** argv) {
     } catch (const std::exception& error) {
         std::cerr << "[TESTCASE][EXCEPTION] " << error.what() << std::endl;
         LOG_ERROR("[TESTCASE][FAIL] name=ParallelRecordOrderedReadback error={}", error.what());
+        if (shader_manager_initialized) {
+            ShaderManager::ShutDown();
+        }
         if (render_device_initialized) {
             RenderDevice::Dispose();
         }
@@ -16555,6 +16709,9 @@ int main(int argc, const char** argv) {
     } catch (...) {
         std::cerr << "[TESTCASE][EXCEPTION] unknown" << std::endl;
         LOG_ERROR("[TESTCASE][FAIL] name=ParallelRecordOrderedReadback error=unknown");
+        if (shader_manager_initialized) {
+            ShaderManager::ShutDown();
+        }
         if (render_device_initialized) {
             RenderDevice::Dispose();
         }


### PR DESCRIPTION
## What changed

- add a backend-neutral RHI multiview contract for pipeline/pass view masks and attachment layer ranges
- implement Vulkan capability queries, dynamic-rendering view masks, layered attachment views, validation, and per-layer resource-state tracking
- render point-light cubemap shadows with one six-view draw using `SV_ViewID`, with a capability/config-gated six-pass fallback
- conservatively cull the multiview draw against the union AABB of all six cubemap frusta
- preserve cubemap face slices in the existing serial shadow path
- add CPU contracts and serial/parallel Vulkan six-layer readback coverage

## Why

The existing point-shadow path records and submits one draw per cubemap face, and its depth attachment construction discarded the selected face slice. This change establishes a correct serial baseline and adds the modern multiview path requested by #116.

## Review fixes

- represent multi-layer `DepthBuffer` resources as `TEX_2D_ARRAY`
- force `VK_IMAGE_VIEW_TYPE_2D_ARRAY` for every multi-layer attachment view, including non-cubemap depth arrays
- change the Vulkan probe to exercise a real six-layer `DepthBuffer`, closing the generic depth-array coverage gap
- replace the initial all-scene multiview visibility set with conservative point-shadow volume culling

## Impact

Supported Vulkan devices use one conservative cull and one draw to populate all six cubemap layers. Unsupported devices, disabled configuration, and non-Vulkan backends keep the existing six-pass behavior.

## Validation

- Debug build: `TestRHIMultiviewContract`, `TestRHIParallelRecordVulkan`, `MoerEditor`
- CTest: `RHICmdReordererContract`, `RHIExplicitBarrierContract`, `RHIMultiviewContract`, `RHIRecordDiagnosticsContract`, `VulkanHeaderContract` — 5/5 passed
- `TestRHIParallelRecordVulkan.exe --multiview` — ordinary six-layer depth array plus cubemap color, six layers read back correctly, Vulkan validation 0 VUID
- `TestRHIParallelRecordVulkan.exe --multiview --parallel` — ordinary six-layer depth array plus cubemap color, six layers read back correctly, Vulkan validation 0 VUID
- Raster editor smoke after review fixes — multiview path selected, first present completed, 0 VUID/error/critical

No external CI runner or workflow is added.

Closes #116